### PR TITLE
clickup: the catch-up path's authentication is asserted in a comment and reachable by nothing, and the seam scanner calls every bundled READ an EROFS

### DIFF
--- a/claude/skills/clickup/lib/catchup.mjs
+++ b/claude/skills/clickup/lib/catchup.mjs
@@ -27,8 +27,8 @@
 import { authenticateDelivery, headerLookup } from './webhook-server.mjs';
 
 /**
- * Rejection reasons that are PERMANENT, and therefore safe to move the cursor
- * past after recording the skip.
+ * Rejection reasons that are PERMANENT: decided from the STORED BYTES alone,
+ * and never decided differently on a later run.
  *
  * 🔴 WHY THE CURSOR MAY ADVANCE AT ALL. `date_from` is the cursor and the API
  * is paged at 10, so before this the FIRST ten consecutive unverifiable stored
@@ -39,8 +39,7 @@ import { authenticateDelivery, headerLookup } from './webhook-server.mjs';
  * stored event is `unknown-webhook` and stays that way forever: the secrets
  * needed to verify them are gone.
  *
- * Each reason here is a decision this process can make from the request alone
- * and will never make differently later:
+ * Each reason here is a property of a record that no longer changes:
  *
  *   missing-signature  ClickUp signs every delivery; a stored request with no
  *                      X-Signature was not one, and no signature will appear.
@@ -50,27 +49,66 @@ import { authenticateDelivery, headerLookup } from './webhook-server.mjs';
  *                      secret is gone. Either way it is unverifiable forever.
  *   bad-signature      the body and the secret are both fixed; the digest will
  *                      not start matching.
+ *   invalid-json       the stored body is not a JSON object, and stored bytes
+ *                      do not change: it will not start being one.
+ *   malformed-record   the API returned something that is not a request object.
  *
- * 🔴 `invalid-json` is deliberately NOT here, and neither is a stored record
- * with no usable `created_at`. Those are the cases where we cannot say WHAT we
- * would be skipping: we could not parse the body, or we have no timestamp to
- * move the cursor to. Fail closed — stop catch-up, leave the cursor where it
- * is, say so on stderr — rather than step silently over something that might
- * have been a real event. That trades the old "any ten unverifiable requests
- * wedge catch-up" for "one UNPARSEABLE request stops this run", which is both
- * far rarer (ClickUp sends JSON) and recoverable with an explicit `--since`.
+ * 🔴 `invalid-json` IS ON THIS LIST, and the first version of this file is why.
+ * It made `invalid-json` undecidable — stop the walk, leave the cursor — on the
+ * reasoning that "we could not parse it, so we cannot say what we are skipping".
+ * That reasoning does not survive contact with the input: webhook.site records
+ * an empty `content` for a bare **GET**, which is what a crawler, a link
+ * preview, or the user opening their own webhook URL in a browser produces. One
+ * such request — plus a `null` content, a JSON scalar, HTML, or a form-encoded
+ * body — parked the cursor permanently, because `SINCE` defaults to
+ * `last-seen.txt` and the same page re-blocks on every subsequent run until
+ * somebody edits state by hand. Measured: a page holding [bare GET, genuine
+ * signed event] delivered NOTHING on two consecutive runs, where the code
+ * before it delivered the genuine event on run 1. It replaced a rare
+ * ten-request wedge with a permanent ONE-request wedge that anyone who can
+ * reach the URL can trigger — and the premise of the whole file is that anyone
+ * can. It was also internally inconsistent: `bad-signature` was decidable
+ * because "the body and the secret are both fixed", and a body that is not JSON
+ * is exactly as fixed.
+ *
+ * 🔴 WHAT IS ACTUALLY UNDECIDABLE IS AN **UNDATABLE** RECORD. `decidable` means
+ * one thing — may the cursor move past this? — and the cursor is a TIMESTAMP.
+ * A record with no usable `created_at` gives nothing to move the cursor TO, so
+ * advancing would be guessing; that, and only that, stops the walk. It cannot
+ * be triggered by the body of a request: webhook.site stamps what it stores.
  *
  * The cost of advancing is stated plainly rather than hidden: `date_from` has
  * one-second granularity, so moving the cursor past a rejected request also
  * moves it past anything stored in the SAME second. The live listener is
  * unaffected — it authenticates every delivery as it arrives.
+ *
+ * This set is a LEDGER, checked both ways by the tests: a reason
+ * `authenticateDelivery()` can return that is missing here defaults to
+ * undecidable — i.e. to the wedge above — so growth has to be deliberate.
  */
-export const DECIDABLE_REJECTIONS = new Set([
+export const PERMANENT_REJECTIONS = new Set([
   'missing-signature',
   'no-webhook-id',
   'unknown-webhook',
   'bad-signature',
+  'invalid-json',
+  'malformed-record',
 ]);
+
+/**
+ * May the cursor move past a REJECTED stored request?
+ *
+ * Exported so the fail-closed default is reachable from a test: no reason the
+ * current authenticator returns is unlisted, so the `PERMANENT_REJECTIONS.has()`
+ * clause has no observable effect until one is — which is precisely when it
+ * matters. Deleting it is otherwise a mutation nothing can catch.
+ *
+ * @param {string} reason
+ * @param {string|null} createdAt  a usable timestamp, or null
+ */
+export function isDecidable(reason, createdAt) {
+  return PERMANENT_REJECTIONS.has(reason) && createdAt !== null;
+}
 
 /**
  * Authenticate ONE request webhook.site stored.
@@ -83,13 +121,30 @@ export const DECIDABLE_REJECTIONS = new Set([
  *   It is meaningless for an accepted event (the cursor moves with the event).
  */
 export function classifyStoredRequest(req, lookupSecret) {
-  if (!req || typeof req !== 'object') {
-    return { accepted: false, reason: 'malformed-record', decidable: false, createdAt: null };
-  }
+  const isRecord = !!req && typeof req === 'object';
   const createdAt =
-    typeof req.created_at === 'string' && req.created_at.trim() !== '' ? req.created_at : null;
-  const raw = typeof req.content === 'string' ? req.content : '';
+    isRecord && typeof req.created_at === 'string' && req.created_at.trim() !== ''
+      ? req.created_at
+      : null;
 
+  // ONE expression for decidability, used by every rejection path: a permanent
+  // reason AND something to move the cursor to. Written once rather than per
+  // branch so a case cannot quietly acquire different rules — the previous
+  // version's `invalid-json` wedge was exactly that kind of special case.
+  const reject = (reason) => ({
+    accepted: false,
+    reason,
+    decidable: isDecidable(reason, createdAt),
+    createdAt,
+  });
+
+  // A non-object has no `created_at` to read, so this is undecidable in
+  // practice today. It goes through the same expression anyway: if the API ever
+  // returns a datable record shape this module does not recognise, the walk
+  // should skip it, not wedge on it.
+  if (!isRecord) return reject('malformed-record');
+
+  const raw = typeof req.content === 'string' ? req.content : '';
   const result = authenticateDelivery(raw, headerLookup(req.headers, 'x-signature'), lookupSecret);
 
   if (result.accepted) {
@@ -97,14 +152,7 @@ export function classifyStoredRequest(req, lookupSecret) {
     if (createdAt) event._wh_created_at = createdAt;
     return { accepted: true, reason: result.reason, decidable: true, createdAt, event };
   }
-  return {
-    accepted: false,
-    reason: result.reason,
-    // No timestamp means nothing to advance the cursor TO, so a rejection we
-    // could otherwise decide is still undecidable in practice.
-    decidable: DECIDABLE_REJECTIONS.has(result.reason) && createdAt !== null,
-    createdAt,
-  };
+  return reject(result.reason);
 }
 
 /**
@@ -122,7 +170,7 @@ export function classifyStoredRequest(req, lookupSecret) {
  * @param {(entry: object, event: object) => void} deps.onDeliver   hand it to the agent; the walk stops
  * @param {(event: object) => void} [deps.onFiltered]     authentic, but not what we are waiting for
  * @param {(info: object) => void} [deps.onSkipped]       decidable rejection — advance the cursor
- * @param {(info: object) => void} [deps.onBlocked]       undecidable — the walk stops, cursor unchanged
+ * @param {(info: object) => void} [deps.onBlocked]       UNDATABLE — the walk stops, cursor unchanged
  * @returns {{delivered: boolean, considered: number, skipped: number, filtered: number,
  *            blocked: object|null}}
  */
@@ -157,9 +205,12 @@ export function catchUp(requests, {
     }
 
     if (!r.decidable) {
-      // 🔴 Stop, do not continue. The cursor is a TIMESTAMP: advancing past a
-      // later request advances past this one too, so "skip it and carry on"
-      // would be the silent version of the thing we are refusing to do.
+      // 🔴 Stop, do not continue. Reaching here means the record is UNDATABLE
+      // (see PERMANENT_REJECTIONS): there is no timestamp to move the cursor
+      // to. Continuing would deliver a LATER event, and because the cursor is a
+      // TIMESTAMP that advances past this record anyway — the silent version of
+      // the thing we are refusing to do. This is not reachable from the BODY of
+      // a stored request; a body we cannot parse is skipped, not blocking.
       onBlocked(r);
       return { delivered: false, considered, skipped, filtered, blocked: r };
     }

--- a/claude/skills/clickup/lib/catchup.mjs
+++ b/claude/skills/clickup/lib/catchup.mjs
@@ -1,0 +1,172 @@
+/**
+ * The webhook.site CATCH-UP path: stored requests in, deliveries out.
+ *
+ * WHY THIS IS A MODULE AND NOT A FUNCTION IN listen.mjs
+ * ----------------------------------------------------
+ * It was a function in listen.mjs, and it was CORRECT BY READING — it called
+ * the same `authenticateDelivery()` predicate as the live POST path, and said so
+ * in a comment. Nothing exercised it. The branch is gated on
+ * `SINCE && MODE === 'wait'`, the integration test runs `--mode server`, so it
+ * was structurally unreachable from the suite and two mutations that reinstate
+ * the ORIGINAL defect passed all 73 tests:
+ *
+ *   * replacing the `authenticateDelivery(...)` call with
+ *     `{ accepted: true, event: JSON.parse(raw) }` — i.e. deliver anything
+ *     webhook.site stored, which is anything anyone POSTed to a public URL;
+ *   * reading the signature from a header key that never matches, which rejects
+ *     every genuine event instead (a silent outage rather than a hole).
+ *
+ * A comment is a claim. This module is the seam that lets the claim be tested.
+ *
+ * 🔴 An event read back out of webhook.site is EXACTLY as forgeable as one
+ * POSTed to the local receiver: a webhook.site URL accepts a POST from anyone.
+ * So catch-up runs the same predicate over the STORED RAW BODY (`req.content`),
+ * which is the byte string ClickUp signed.
+ */
+
+import { authenticateDelivery, headerLookup } from './webhook-server.mjs';
+
+/**
+ * Rejection reasons that are PERMANENT, and therefore safe to move the cursor
+ * past after recording the skip.
+ *
+ * 🔴 WHY THE CURSOR MAY ADVANCE AT ALL. `date_from` is the cursor and the API
+ * is paged at 10, so before this the FIRST ten consecutive unverifiable stored
+ * requests were a permanent blind spot: catch-up re-read the same ten every
+ * run, printed ten stderr lines, and could never reach a genuine event behind
+ * them. The realistic trigger is not an attacker — it is a lost or reset
+ * `watchers.json` while the ClickUp webhooks keep firing, at which point EVERY
+ * stored event is `unknown-webhook` and stays that way forever: the secrets
+ * needed to verify them are gone.
+ *
+ * Each reason here is a decision this process can make from the request alone
+ * and will never make differently later:
+ *
+ *   missing-signature  ClickUp signs every delivery; a stored request with no
+ *                      X-Signature was not one, and no signature will appear.
+ *   no-webhook-id      nothing identifies which secret would verify it, ever.
+ *   unknown-webhook    no registered secret for that id — it is not from a
+ *                      webhook this skill owns, or the registry that held the
+ *                      secret is gone. Either way it is unverifiable forever.
+ *   bad-signature      the body and the secret are both fixed; the digest will
+ *                      not start matching.
+ *
+ * 🔴 `invalid-json` is deliberately NOT here, and neither is a stored record
+ * with no usable `created_at`. Those are the cases where we cannot say WHAT we
+ * would be skipping: we could not parse the body, or we have no timestamp to
+ * move the cursor to. Fail closed — stop catch-up, leave the cursor where it
+ * is, say so on stderr — rather than step silently over something that might
+ * have been a real event. That trades the old "any ten unverifiable requests
+ * wedge catch-up" for "one UNPARSEABLE request stops this run", which is both
+ * far rarer (ClickUp sends JSON) and recoverable with an explicit `--since`.
+ *
+ * The cost of advancing is stated plainly rather than hidden: `date_from` has
+ * one-second granularity, so moving the cursor past a rejected request also
+ * moves it past anything stored in the SAME second. The live listener is
+ * unaffected — it authenticates every delivery as it arrives.
+ */
+export const DECIDABLE_REJECTIONS = new Set([
+  'missing-signature',
+  'no-webhook-id',
+  'unknown-webhook',
+  'bad-signature',
+]);
+
+/**
+ * Authenticate ONE request webhook.site stored.
+ *
+ * @param {object} req  a webhook.site stored request ({content, headers, created_at})
+ * @param {(webhookId: string) => (string|null|undefined)} lookupSecret
+ * @returns {{accepted: boolean, reason: string, decidable: boolean,
+ *            createdAt: string|null, event?: object}}
+ *   `decidable` answers ONE question: may the cursor move past this request?
+ *   It is meaningless for an accepted event (the cursor moves with the event).
+ */
+export function classifyStoredRequest(req, lookupSecret) {
+  if (!req || typeof req !== 'object') {
+    return { accepted: false, reason: 'malformed-record', decidable: false, createdAt: null };
+  }
+  const createdAt =
+    typeof req.created_at === 'string' && req.created_at.trim() !== '' ? req.created_at : null;
+  const raw = typeof req.content === 'string' ? req.content : '';
+
+  const result = authenticateDelivery(raw, headerLookup(req.headers, 'x-signature'), lookupSecret);
+
+  if (result.accepted) {
+    const event = result.event;
+    if (createdAt) event._wh_created_at = createdAt;
+    return { accepted: true, reason: result.reason, decidable: true, createdAt, event };
+  }
+  return {
+    accepted: false,
+    reason: result.reason,
+    // No timestamp means nothing to advance the cursor TO, so a rejection we
+    // could otherwise decide is still undecidable in practice.
+    decidable: DECIDABLE_REJECTIONS.has(result.reason) && createdAt !== null,
+    createdAt,
+  };
+}
+
+/**
+ * Walk the stored requests oldest-first, delivering the first authentic event
+ * that passes the filters.
+ *
+ * Every side effect is a callback the caller owns — this module writes no
+ * files, reads no config and knows nothing about the state dir.
+ *
+ * @param {object[]} requests
+ * @param {object} deps
+ * @param {(webhookId: string) => (string|null|undefined)} deps.lookupSecret
+ * @param {(event: object) => boolean} [deps.matches]     the CLI filters
+ * @param {(event: object) => object} deps.onAccepted     record it (log + cursor); returns the entry
+ * @param {(entry: object, event: object) => void} deps.onDeliver   hand it to the agent; the walk stops
+ * @param {(event: object) => void} [deps.onFiltered]     authentic, but not what we are waiting for
+ * @param {(info: object) => void} [deps.onSkipped]       decidable rejection — advance the cursor
+ * @param {(info: object) => void} [deps.onBlocked]       undecidable — the walk stops, cursor unchanged
+ * @returns {{delivered: boolean, considered: number, skipped: number, filtered: number,
+ *            blocked: object|null}}
+ */
+export function catchUp(requests, {
+  lookupSecret,
+  matches = () => true,
+  onAccepted,
+  onDeliver,
+  onFiltered = () => {},
+  onSkipped = () => {},
+  onBlocked = () => {},
+}) {
+  let considered = 0;
+  let skipped = 0;
+  let filtered = 0;
+
+  for (const req of requests || []) {
+    considered += 1;
+    const r = classifyStoredRequest(req, lookupSecret);
+
+    if (r.accepted) {
+      // The cursor advances for EVERY authentic event, matching or not —
+      // otherwise a filtered event is re-read on every subsequent run.
+      const entry = onAccepted(r.event);
+      if (matches(r.event)) {
+        onDeliver(entry, r.event);
+        return { delivered: true, considered, skipped, filtered, blocked: null };
+      }
+      filtered += 1;
+      onFiltered(r.event);
+      continue;
+    }
+
+    if (!r.decidable) {
+      // 🔴 Stop, do not continue. The cursor is a TIMESTAMP: advancing past a
+      // later request advances past this one too, so "skip it and carry on"
+      // would be the silent version of the thing we are refusing to do.
+      onBlocked(r);
+      return { delivered: false, considered, skipped, filtered, blocked: r };
+    }
+
+    skipped += 1;
+    onSkipped(r);
+  }
+
+  return { delivered: false, considered, skipped, filtered, blocked: null };
+}

--- a/claude/skills/clickup/lib/webhook-server.mjs
+++ b/claude/skills/clickup/lib/webhook-server.mjs
@@ -71,6 +71,26 @@ export function headerValue(v) {
 }
 
 /**
+ * Read one header CASE-INSENSITIVELY, array-aware.
+ *
+ * node's http lowercases what it receives, so the live path never needed this.
+ * webhook.site's stored-request API returns whatever case the sender used, and
+ * an exact-case bracket lookup there is a silent fail-closed bug: every stored
+ * event rejects as `missing-signature` and catch-up delivers nothing, which
+ * looks exactly like "no missed events". Case-insensitivity is also what makes
+ * `headers['X-Signature']` a MUTANT rather than a spelling variant — the
+ * catch-up tests feed both spellings, so a bracket access in either case dies.
+ */
+export function headerLookup(headers, name) {
+  if (!headers || typeof headers !== 'object') return undefined;
+  const want = String(name).toLowerCase();
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === want) return headerValue(headers[key]);
+  }
+  return undefined;
+}
+
+/**
  * Decide whether a delivery may be acted on. THE one predicate — the live POST
  * path and the webhook.site catch-up path both call it, because an event read
  * back from webhook.site is exactly as forgeable as one POSTed here (anyone can
@@ -157,7 +177,10 @@ export function createRequestHandler({
     });
     req.on('end', () => {
       if (aborted) return;
-      const result = authenticateDelivery(rawBody, req.headers['x-signature'], lookupSecret);
+      // Same extraction helper as the catch-up path — one spelling of the
+      // header name, in one place, for both callers of the one predicate.
+      const result = authenticateDelivery(
+        rawBody, headerLookup(req.headers, 'x-signature'), lookupSecret);
       if (!result.accepted) {
         res.writeHead(result.status, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: result.reason }));
@@ -188,4 +211,33 @@ export function listenLoopback(server, port) {
     server.once('error', reject);
     server.listen(port, LOOPBACK_HOST, () => resolve(server.address()));
   });
+}
+
+/**
+ * The argv for `whcli forward`, targeting the address this module BINDS.
+ *
+ * 🔴 The target is `LOOPBACK_HOST` — the same constant `listenLoopback()` binds
+ * — and not `localhost`. `localhost` resolves through the host's name lookup and
+ * can yield `::1` first; the receiver binds 127.0.0.1 ONLY, so a `::1` target is
+ * ECONNREFUSED on every delivery, i.e. a listener that reports healthy and
+ * silently receives nothing. Deriving both from one constant is what makes that
+ * a relationship the tests can pin rather than two literals that agree today.
+ *
+ * @param {{token: string, port: number, apiKey?: string}} opts
+ * @returns {string[]}
+ */
+export function forwarderArgs({ token, port, apiKey }) {
+  const args = [
+    'forward',
+    `--token=${token}`,
+    `--target=${forwarderTarget(port)}`,
+    '--listen-timeout=5',
+  ];
+  if (apiKey) args.push(`--api-key=${apiKey}`);
+  return args;
+}
+
+/** The URL whcli forwards to. Loggable — it carries no token. */
+export function forwarderTarget(port) {
+  return `http://${LOOPBACK_HOST}:${port}`;
 }

--- a/claude/skills/clickup/lib/webhook-site.mjs
+++ b/claude/skills/clickup/lib/webhook-site.mjs
@@ -1,0 +1,109 @@
+/**
+ * WHERE stored requests are fetched from, and WHAT CREDENTIALS may travel there.
+ *
+ * 🔴 `CLICKUP_WEBHOOK_SITE_API_BASE` exists so the catch-up path can be
+ * exercised end-to-end against a loopback stub — it had no test at all, which is
+ * how two mutations reinstating the original defect survived the whole suite.
+ * Ungated, it is also a CREDENTIAL-EGRESS and PLAINTEXT-DOWNGRADE knob, and the
+ * comment that shipped with it cleared it of a risk it never had (delivery
+ * integrity — every fetched request is still authenticated) while saying nothing
+ * about the risk it does have:
+ *
+ *   * the webhook.site token is IN THE URL PATH (`/token/<token>/requests`), so
+ *     whatever host the variable names is handed a capability that can read this
+ *     workspace's entire event stream and POST forged events into it;
+ *   * `WEBHOOK_SITE_API_KEY` rides along as an `Api-Key` header — an account
+ *     credential, not a per-workspace one;
+ *   * the client is chosen by `url.protocol`, so `http://` sends both in
+ *     cleartext.
+ *
+ * So the override is gated to the two origins that have a reason to exist, and
+ * the API key is attached ONLY to webhook.site itself:
+ *
+ *   loopback (127.x, ::1, localhost)  allowed, http or https, and NO Api-Key —
+ *                                     a test stub has no use for one, and this
+ *                                     is what makes "the tests can point it
+ *                                     somewhere" cost nothing in credentials.
+ *   webhook.site over https           allowed, Api-Key attached. This is the
+ *                                     default and the only real destination.
+ *   anything else                     REFUSED — the default base is used
+ *                                     instead and the refusal is printed. That
+ *                                     includes http://webhook.site, which is a
+ *                                     downgrade of the real destination.
+ *
+ * Refusing by falling back (rather than exiting) keeps a mis-set variable from
+ * bricking the listener, and the fallback is the SAFE endpoint, never the named
+ * one.
+ */
+
+export const DEFAULT_API_BASE = 'https://webhook.site';
+
+/**
+ * A cap on the stored-requests response. `data += chunk` with no ceiling is an
+ * unbounded allocation driven by whatever the base host chooses to send.
+ */
+export const MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
+
+/** Hosts that are this machine, in the spellings a URL can carry them. */
+function isLoopbackHost(hostname) {
+  const h = String(hostname).toLowerCase().replace(/^\[|\]$/g, '');
+  if (h === 'localhost' || h === '::1' || h === '0:0:0:0:0:0:0:1') return true;
+  return /^127(\.\d{1,3}){3}$/.test(h);
+}
+
+/** webhook.site itself, or a subdomain of it — never a lookalike suffix. */
+function isWebhookSiteHost(hostname) {
+  const h = String(hostname).toLowerCase();
+  return h === 'webhook.site' || h.endsWith('.webhook.site');
+}
+
+/**
+ * Decide the stored-request API base and whether the API key may be sent.
+ *
+ * Pure: no env read, no IO, no process.exit — so both branches are testable and
+ * listen.mjs holds no copy of the policy.
+ *
+ * @param {string|undefined|null} raw  the value of CLICKUP_WEBHOOK_SITE_API_BASE
+ * @param {{defaultBase?: string}} [opts]
+ * @returns {{base: string, sendApiKey: boolean, warning: string|null}}
+ */
+export function resolveApiBase(raw, { defaultBase = DEFAULT_API_BASE } = {}) {
+  const fallback = (warning) => ({ base: defaultBase, sendApiKey: true, warning });
+  if (raw === undefined || raw === null || String(raw).trim() === '') {
+    return { base: defaultBase, sendApiKey: true, warning: null };
+  }
+
+  let url;
+  try {
+    url = new URL(String(raw).trim());
+  } catch {
+    // 🔴 Parsed HERE and not inside the fetch: `new URL()` throwing inside a
+    // promise executor rejects a promise nothing awaits, which on this script
+    // (main() is called, not awaited) is an unhandled rejection rather than a
+    // message.
+    return fallback(`CLICKUP_WEBHOOK_SITE_API_BASE is not a URL — ignoring it and using ${defaultBase}`);
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return fallback(
+      `CLICKUP_WEBHOOK_SITE_API_BASE uses ${url.protocol} — ignoring it and using ${defaultBase}`);
+  }
+
+  const base = url.origin + url.pathname.replace(/\/+$/, '');
+
+  if (isLoopbackHost(url.hostname)) {
+    // No Api-Key: a loopback stub has no account to authenticate against, and
+    // not sending it is what keeps this override out of the credential path.
+    return { base, sendApiKey: false, warning: null };
+  }
+
+  if (isWebhookSiteHost(url.hostname) && url.protocol === 'https:') {
+    return { base, sendApiKey: true, warning: null };
+  }
+
+  return fallback(
+    `CLICKUP_WEBHOOK_SITE_API_BASE points at ${url.protocol}//${url.host}. The webhook.site ` +
+      'token is in the request PATH and the API key rides as a header, so that host would ' +
+      `receive both. Refusing it — using ${defaultBase}. Only loopback (a test stub) or ` +
+      'https://webhook.site are accepted.');
+}

--- a/claude/skills/clickup/listen.mjs
+++ b/claude/skills/clickup/listen.mjs
@@ -15,8 +15,14 @@
  * wrongly-signed deliveries are REJECTED (401): not acked, not logged, the
  * cursor does not move, and nothing is printed for the agent to act on. The
  * predicate lives in lib/webhook-server.mjs and BOTH paths — the live POST and
- * the webhook.site catch-up — go through it, because an event read back from
- * webhook.site is exactly as forgeable as one POSTed here.
+ * the webhook.site catch-up (lib/catchup.mjs) — go through it, because an event
+ * read back from webhook.site is exactly as forgeable as one POSTed here.
+ *
+ * That used to be asserted HERE, in prose, and by nothing else: the catch-up
+ * branch was unreachable from the tests, so two mutations reinstating the
+ * original defect passed the whole suite. Both halves now have their own file
+ * and their own four-case table (test/{webhook-server,catchup}.test.mjs) plus
+ * an end-to-end run of this script against each (test/listen-integration).
  *
  * The local receiver binds 127.0.0.1 only.
  *
@@ -38,6 +44,7 @@
  */
 
 import { spawn } from 'child_process';
+import http from 'http';
 import https from 'https';
 import fs from 'fs';
 import {
@@ -50,10 +57,11 @@ import {
   ensureStateDir,
 } from './lib/paths.mjs';
 import {
-  authenticateDelivery,
   createWebhookServer,
   listenLoopback,
+  forwarderArgs,
 } from './lib/webhook-server.mjs';
+import { catchUp } from './lib/catchup.mjs';
 
 // All of these are STATE, so they resolve under $XDG_STATE_HOME/clickup
 // (fallback ~/.local/state/clickup) — the skill dir deploys read-only.
@@ -249,6 +257,19 @@ function formatEventSummary(event) {
 
 // ── Catch-up: query webhook.site for missed events ────────────────────────
 
+/**
+ * Where the stored-request API lives.
+ *
+ * 🔴 The override exists so the catch-up path can be exercised end-to-end
+ * against a loopback stub — it had NO test at all, which is why two mutations
+ * reinstating the original defect survived the whole suite. It changes WHERE
+ * stored requests come from, never WHETHER they are authenticated: every
+ * request from it still goes through `authenticateDelivery()` against a secret
+ * in watchers.json, so pointing this at a hostile server yields rejections, not
+ * forged deliveries.
+ */
+const WH_API_BASE = process.env.CLICKUP_WEBHOOK_SITE_API_BASE || 'https://webhook.site';
+
 function fetchMissedEvents(since) {
   return new Promise((resolve, reject) => {
     const sinceUtc = since.includes('Z') || since.includes('+') ? since : since.replace(' ', 'T') + 'Z';
@@ -260,7 +281,7 @@ function fetchMissedEvents(since) {
     d.setSeconds(d.getSeconds() + 1);
     const dateFrom = d.toISOString().replace('T', ' ').replace(/\.\d+Z$/, '');
 
-    const url = new URL(`https://webhook.site/token/${WH_TOKEN}/requests`);
+    const url = new URL(`${WH_API_BASE}/token/${WH_TOKEN}/requests`);
     url.searchParams.set('date_from', dateFrom);
     url.searchParams.set('sorting', 'oldest');
     url.searchParams.set('per_page', '10');
@@ -268,7 +289,8 @@ function fetchMissedEvents(since) {
     const headers = {};
     if (WH_API_KEY) headers['Api-Key'] = WH_API_KEY;
 
-    https.get(url.toString(), { headers }, (res) => {
+    const client = url.protocol === 'http:' ? http : https;
+    client.get(url.toString(), { headers }, (res) => {
       let data = '';
       res.on('data', (chunk) => (data += chunk));
       res.on('end', () => {
@@ -286,30 +308,9 @@ function fetchMissedEvents(since) {
   });
 }
 
-/**
- * Authenticate a request webhook.site stored, and return the event or null.
- *
- * 🔴 Same predicate as the live POST path, deliberately. A webhook.site URL
- * accepts a POST from anyone, so an event read back out of its API is exactly
- * as forgeable as one delivered here — verifying only the live path would move
- * the hole rather than close it. The signature is over the STORED RAW BODY
- * (`req.content`), which is what ClickUp signed.
- */
-function parseWebhookSiteRequest(req) {
-  const raw = req && typeof req.content === 'string' ? req.content : '';
-  const headers = (req && req.headers) || {};
-  const result = authenticateDelivery(raw, headers['x-signature'], lookupWatcherSecret);
-  if (!result.accepted) {
-    process.stderr.write(
-      `[catch-up:rejected:${result.reason}] a stored webhook.site request did not verify ` +
-        '— skipped, not logged\n'
-    );
-    return null;
-  }
-  const event = result.event;
-  event._wh_created_at = req.created_at;
-  return event;
-}
+// The catch-up walk — authentication, the decidable/undecidable split and the
+// cursor policy — lives in lib/catchup.mjs so it can be exercised. See its
+// header: this code was correct by reading and reachable by nothing.
 
 // ── Local HTTP server ─────────────────────────────────────────────────────
 
@@ -354,16 +355,19 @@ const server = createWebhookServer({
 // ── whcli forward process ─────────────────────────────────────────────────
 
 // `port` is the port actually BOUND, not the requested one (`--port 0` asks the
-// OS to choose). The target is 127.0.0.1 rather than `localhost` because the
-// receiver binds 127.0.0.1 only and `localhost` can resolve to ::1 first.
+// OS to choose). The target is built by lib/webhook-server.mjs from the SAME
+// constant it binds — `localhost` can resolve to ::1 first, and the receiver
+// binds 127.0.0.1 only, so a `localhost` target is a listener that reports
+// healthy and receives nothing. The target is printed (it carries no token, and
+// the args do) so the integration test reads back the value actually spawned
+// rather than a second copy of it.
 function startForwarder(port) {
-  const whArgs = [
-    'forward',
-    `--token=${WH_TOKEN}`,
-    `--target=http://127.0.0.1:${port}`,
-    '--listen-timeout=5',
-  ];
-  if (WH_API_KEY) whArgs.push(`--api-key=${WH_API_KEY}`);
+  const whArgs = forwarderArgs({ token: WH_TOKEN, port, apiKey: WH_API_KEY });
+  // Read back out of the array being spawned, not recomputed: a second call to
+  // forwarderTarget() would print 127.0.0.1 even if the arg said localhost.
+  // 🔴 This one element only — `--token=` is in there too.
+  const target = (whArgs.find((a) => a.startsWith('--target=')) || '--target=<none>').slice(9);
+  process.stderr.write(`[whcli] target ${target}\n`);
 
   const proc = spawn('whcli', whArgs, {
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -397,23 +401,45 @@ async function main() {
     const requests = result.data || [];
 
     if (requests.length > 0) {
-      // Find the first missed event that passes our filters
-      for (const req of requests) {
-        const event = parseWebhookSiteRequest(req);
-        if (!event) continue;
-
-        // Always update cursor even for filtered events
-        const entry = processEvent(event, 'catch-up');
-
-        if (matchesFilters(event)) {
-          process.stderr.write(`[catch-up] Found matching event (of ${requests.length} missed). Delivering.\n`);
+      const outcome = catchUp(requests, {
+        lookupSecret: lookupWatcherSecret,
+        matches: matchesFilters,
+        // Records it: log line + cursor. Only reached for a delivery that
+        // authenticated, exactly as on the live path.
+        onAccepted: (event) => processEvent(event, 'catch-up'),
+        onDeliver: (entry) => {
+          process.stderr.write(
+            `[catch-up] Found matching event (of ${requests.length} missed). Delivering.\n`);
           console.log(JSON.stringify(entry, null, 2));
           process.exit(0);
-        } else {
+        },
+        onFiltered: (event) => {
           process.stderr.write(`[catch-up:filtered] ${event.event || 'unknown'} — skipped\n`);
-        }
-      }
-      process.stderr.write(`[catch-up] ${requests.length} missed event(s), none matched filters. Starting live listener.\n`);
+        },
+        // A PERMANENTLY unverifiable stored request. Nothing about it is
+        // logged — the body is attacker-controlled — but the cursor moves past
+        // it, or ten of these wedge catch-up forever (see lib/catchup.mjs).
+        onSkipped: ({ reason, createdAt }) => {
+          saveLastSeen(createdAt);
+          process.stderr.write(
+            `[catch-up:rejected:${reason}] a stored webhook.site request did not verify ` +
+              `— not logged, cursor advanced past it (${createdAt})\n`
+          );
+        },
+        // We could not decide what this was. The cursor stays put.
+        onBlocked: ({ reason, createdAt }) => {
+          process.stderr.write(
+            `[catch-up:blocked:${reason}] a stored webhook.site request could not be ` +
+              `parsed or dated (${createdAt || 'no timestamp'}) — catch-up stops here and the ` +
+              'cursor is unchanged, so nothing behind it is skipped silently. Pass an ' +
+              'explicit --since to step over it.\n'
+          );
+        },
+      });
+
+      process.stderr.write(
+        `[catch-up] ${outcome.considered} of ${requests.length} stored request(s) examined, ` +
+          `${outcome.skipped} unverifiable, ${outcome.filtered} filtered. Starting live listener.\n`);
     } else {
       process.stderr.write(`[catch-up] No missed events. Starting live listener.\n`);
     }

--- a/claude/skills/clickup/listen.mjs
+++ b/claude/skills/clickup/listen.mjs
@@ -62,6 +62,7 @@ import {
   forwarderArgs,
 } from './lib/webhook-server.mjs';
 import { catchUp } from './lib/catchup.mjs';
+import { resolveApiBase, MAX_RESPONSE_BYTES } from './lib/webhook-site.mjs';
 
 // All of these are STATE, so they resolve under $XDG_STATE_HOME/clickup
 // (fallback ~/.local/state/clickup) — the skill dir deploys read-only.
@@ -258,42 +259,68 @@ function formatEventSummary(event) {
 // ── Catch-up: query webhook.site for missed events ────────────────────────
 
 /**
- * Where the stored-request API lives.
+ * Where the stored-request API lives, and whether the API key may go there.
  *
- * 🔴 The override exists so the catch-up path can be exercised end-to-end
- * against a loopback stub — it had NO test at all, which is why two mutations
- * reinstating the original defect survived the whole suite. It changes WHERE
- * stored requests come from, never WHETHER they are authenticated: every
- * request from it still goes through `authenticateDelivery()` against a secret
- * in watchers.json, so pointing this at a hostile server yields rejections, not
- * forged deliveries.
+ * The policy — and the reason the override is a credential-egress knob rather
+ * than a harmless test seam — is in lib/webhook-site.mjs. Resolved ONCE, at
+ * load, so a malformed value is a message here instead of a `new URL()` throw
+ * inside a promise executor that nothing awaits.
  */
-const WH_API_BASE = process.env.CLICKUP_WEBHOOK_SITE_API_BASE || 'https://webhook.site';
+const API = resolveApiBase(process.env.CLICKUP_WEBHOOK_SITE_API_BASE);
+if (API.warning) process.stderr.write(`[catch-up] ${API.warning}\n`);
+const WH_API_BASE = API.base;
 
 function fetchMissedEvents(since) {
-  return new Promise((resolve, reject) => {
-    const sinceUtc = since.includes('Z') || since.includes('+') ? since : since.replace(' ', 'T') + 'Z';
-    const d = new Date(sinceUtc);
-    if (d.getMilliseconds() > 0) {
+  return new Promise((resolve) => {
+    let url;
+    try {
+      const sinceUtc = since.includes('Z') || since.includes('+') ? since : since.replace(' ', 'T') + 'Z';
+      const d = new Date(sinceUtc);
+      if (d.getMilliseconds() > 0) {
+        d.setSeconds(d.getSeconds() + 1);
+        d.setMilliseconds(0);
+      }
       d.setSeconds(d.getSeconds() + 1);
-      d.setMilliseconds(0);
-    }
-    d.setSeconds(d.getSeconds() + 1);
-    const dateFrom = d.toISOString().replace('T', ' ').replace(/\.\d+Z$/, '');
+      const dateFrom = d.toISOString().replace('T', ' ').replace(/\.\d+Z$/, '');
 
-    const url = new URL(`${WH_API_BASE}/token/${WH_TOKEN}/requests`);
-    url.searchParams.set('date_from', dateFrom);
-    url.searchParams.set('sorting', 'oldest');
-    url.searchParams.set('per_page', '10');
+      url = new URL(`${WH_API_BASE}/token/${WH_TOKEN}/requests`);
+      url.searchParams.set('date_from', dateFrom);
+      url.searchParams.set('sorting', 'oldest');
+      url.searchParams.set('per_page', '10');
+    } catch (err) {
+      // An unusable --since (`new Date` → Invalid Date → toISOString throws) or
+      // a token that will not go in a URL. Both used to reject a promise with
+      // no catch anywhere: main() is called, not awaited.
+      process.stderr.write(`[catch-up] Could not build the query: ${err.message}\n`);
+      resolve({ data: [] });
+      return;
+    }
 
     const headers = {};
-    if (WH_API_KEY) headers['Api-Key'] = WH_API_KEY;
+    // 🔴 Only ever to webhook.site. A loopback stub gets no account credential.
+    if (WH_API_KEY && API.sendApiKey) headers['Api-Key'] = WH_API_KEY;
 
     const client = url.protocol === 'http:' ? http : https;
     client.get(url.toString(), { headers }, (res) => {
       let data = '';
-      res.on('data', (chunk) => (data += chunk));
+      let over = false;
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => {
+        if (over) return;
+        data += chunk;
+        // Bounded: the response comes from whatever host the base names, and
+        // `data += chunk` with no ceiling is an allocation that host controls.
+        if (data.length > MAX_RESPONSE_BYTES) {
+          over = true;
+          process.stderr.write(
+            `[catch-up] The stored-requests response exceeded ${MAX_RESPONSE_BYTES} bytes — ` +
+              'discarding it and starting the live listener.\n');
+          res.destroy();
+          resolve({ data: [] });
+        }
+      });
       res.on('end', () => {
+        if (over) return;
         try {
           const json = JSON.parse(data);
           resolve(json);
@@ -301,6 +328,7 @@ function fetchMissedEvents(since) {
           resolve({ data: [] });
         }
       });
+      res.on('error', () => { if (!over) resolve({ data: [] }); });
     }).on('error', (err) => {
       process.stderr.write(`[catch-up] Failed to query webhook.site: ${err.message}\n`);
       resolve({ data: [] });
@@ -366,7 +394,9 @@ function startForwarder(port) {
   // Read back out of the array being spawned, not recomputed: a second call to
   // forwarderTarget() would print 127.0.0.1 even if the arg said localhost.
   // 🔴 This one element only — `--token=` is in there too.
-  const target = (whArgs.find((a) => a.startsWith('--target=')) || '--target=<none>').slice(9);
+  const TARGET_FLAG = '--target=';
+  const target = (whArgs.find((a) => a.startsWith(TARGET_FLAG)) || `${TARGET_FLAG}<none>`)
+    .slice(TARGET_FLAG.length);
   process.stderr.write(`[whcli] target ${target}\n`);
 
   const proc = spawn('whcli', whArgs, {
@@ -416,30 +446,40 @@ async function main() {
         onFiltered: (event) => {
           process.stderr.write(`[catch-up:filtered] ${event.event || 'unknown'} — skipped\n`);
         },
-        // A PERMANENTLY unverifiable stored request. Nothing about it is
-        // logged — the body is attacker-controlled — but the cursor moves past
-        // it, or ten of these wedge catch-up forever (see lib/catchup.mjs).
+        // A PERMANENTLY un-deliverable stored request — unverifiable, or a body
+        // that is not a ClickUp event at all (a bare GET from a crawler stores
+        // an empty one). Nothing about it is logged, because the body is
+        // attacker-controlled, but the cursor moves past it: standing still
+        // wedges catch-up on it forever (see lib/catchup.mjs).
         onSkipped: ({ reason, createdAt }) => {
           saveLastSeen(createdAt);
           process.stderr.write(
-            `[catch-up:rejected:${reason}] a stored webhook.site request did not verify ` +
+            `[catch-up:rejected:${reason}] a stored webhook.site request was rejected ` +
               `— not logged, cursor advanced past it (${createdAt})\n`
           );
         },
-        // We could not decide what this was. The cursor stays put.
+        // No usable timestamp, so there is nothing to advance the cursor TO.
+        // This is the ONLY case that stops the walk.
         onBlocked: ({ reason, createdAt }) => {
           process.stderr.write(
-            `[catch-up:blocked:${reason}] a stored webhook.site request could not be ` +
-              `parsed or dated (${createdAt || 'no timestamp'}) — catch-up stops here and the ` +
-              'cursor is unchanged, so nothing behind it is skipped silently. Pass an ' +
-              'explicit --since to step over it.\n'
+            `[catch-up:blocked:${reason}] a stored webhook.site request carries no usable ` +
+              `timestamp (created_at=${JSON.stringify(createdAt)}) — there is nothing to move ` +
+              'the cursor to, so catch-up stops here rather than guess. The cursor is ' +
+              'unchanged; pass an explicit --since to step over it.\n'
           );
         },
       });
 
+      // 🔴 `blocked` is reported. Without it a wedged run ends on a line that
+      // reads like a clean sweep — "0 unverifiable, 0 filtered" — which is what
+      // the summary said while the cursor was frozen.
+      const blockedNote = outcome.blocked
+        ? `, BLOCKED at an undatable request (${outcome.blocked.reason}) — cursor NOT advanced`
+        : '';
       process.stderr.write(
         `[catch-up] ${outcome.considered} of ${requests.length} stored request(s) examined, ` +
-          `${outcome.skipped} unverifiable, ${outcome.filtered} filtered. Starting live listener.\n`);
+          `${outcome.skipped} rejected, ${outcome.filtered} filtered${blockedNote}. ` +
+          'Starting live listener.\n');
     } else {
       process.stderr.write(`[catch-up] No missed events. Starting live listener.\n`);
     }
@@ -488,4 +528,10 @@ async function main() {
   }
 }
 
-main();
+// 🔴 Not awaited (top-level await would change how this file loads), so it needs
+// its own catch: an unhandled rejection here exits with a stack trace and no
+// explanation of which step failed.
+main().catch((err) => {
+  process.stderr.write(`Fatal: ${err && err.stack ? err.stack : err}\n`);
+  process.exit(1);
+});

--- a/claude/skills/clickup/reference/setup.md
+++ b/claude/skills/clickup/reference/setup.md
@@ -51,19 +51,38 @@ On the catch-up (startup replay) side the cursor moves in two different ways,
 and the stderr prefix tells you which:
 
 * `[catch-up:rejected:<reason>] … cursor advanced past it` — the stored request
-  can **never** verify (no signature, no `webhook_id`, no registered secret, or
-  a wrong digest), so it is skipped and the cursor moves past it. Without this,
-  ten consecutive unverifiable stored requests were a permanent blind spot: the
-  API pages at 10 and the cursor is a timestamp, so a genuine event behind them
+  can **never** be delivered: it does not verify (no signature, no `webhook_id`,
+  no registered secret, a wrong digest) or its body is not a ClickUp event at
+  all (`invalid-json` — webhook.site stores an empty body for a bare **GET**, so
+  a crawler, a link preview or opening the URL in a browser produces one). Every
+  one of those is a property of bytes that are already stored and will not
+  change, so it is skipped and the cursor moves past it. Without this, ten
+  consecutive unverifiable stored requests were a permanent blind spot: the API
+  pages at 10 and the cursor is a timestamp, so a genuine event behind them
   could never be reached. The common trigger is a lost or reset
   `watchers.json` — the secrets that would verify those events are gone.
-* `[catch-up:blocked:<reason>] … cursor is unchanged` — the request could not be
-  **parsed or dated**, so what would be skipped is unknown. Catch-up stops there
-  rather than step over it silently, and the live listener starts as usual. Pass
-  an explicit `--since` to move past it deliberately.
+* `[catch-up:blocked:<reason>] … cursor is unchanged` — the request carries **no
+  usable `created_at`**, so there is nothing to move the cursor to and advancing
+  would be guessing. Catch-up stops there, the summary line says
+  `BLOCKED at an undatable request`, and the live listener starts as usual.
+
+  🔴 A block **persists across runs**: `--since` defaults to `last-seen.txt`, so
+  the next run re-reads the same page and stops in the same place. Clear it with
+  one explicit run past the stuck request —
+  `node listen.mjs --since '<a timestamp after it>'` — the blocked line prints
+  the neighbouring timestamps you need. (Only an undatable record can do this;
+  an unparseable body is skipped, not blocking. It used to block, and one bare
+  GET then wedged catch-up permanently.)
 
 Nothing rejected is ever written to `webhooks.jsonl` in either case — the body
 is attacker-controlled — so only the timestamp cursor moves.
+
+`CLICKUP_WEBHOOK_SITE_API_BASE` overrides where stored requests are fetched
+from. It is **gated**: loopback (a test stub, and it is never sent the
+`Api-Key`) or `https://webhook.site`. Anything else is refused with a note on
+stderr and the default is used — the webhook.site token travels in the request
+**path**, so an arbitrary base would hand a stranger this workspace's event
+stream.
 
 `webhook-url.txt` is a **credential** — `https://webhook.site/<token>` is a
 capability, and whoever reads it can read this workspace's event stream and post

--- a/claude/skills/clickup/reference/setup.md
+++ b/claude/skills/clickup/reference/setup.md
@@ -47,6 +47,24 @@ So if the listener logs `[rejected:unknown-webhook]`, the fix is to re-register
 the watcher (`node query.mjs watch …`), not to disable the check. There is no
 override flag.
 
+On the catch-up (startup replay) side the cursor moves in two different ways,
+and the stderr prefix tells you which:
+
+* `[catch-up:rejected:<reason>] … cursor advanced past it` — the stored request
+  can **never** verify (no signature, no `webhook_id`, no registered secret, or
+  a wrong digest), so it is skipped and the cursor moves past it. Without this,
+  ten consecutive unverifiable stored requests were a permanent blind spot: the
+  API pages at 10 and the cursor is a timestamp, so a genuine event behind them
+  could never be reached. The common trigger is a lost or reset
+  `watchers.json` — the secrets that would verify those events are gone.
+* `[catch-up:blocked:<reason>] … cursor is unchanged` — the request could not be
+  **parsed or dated**, so what would be skipped is unknown. Catch-up stops there
+  rather than step over it silently, and the live listener starts as usual. Pass
+  an explicit `--since` to move past it deliberately.
+
+Nothing rejected is ever written to `webhooks.jsonl` in either case — the body
+is attacker-controlled — so only the timestamp cursor moves.
+
 `webhook-url.txt` is a **credential** — `https://webhook.site/<token>` is a
 capability, and whoever reads it can read this workspace's event stream and post
 forged events into it. It is written 0600, and the unauthenticated `GET /` on

--- a/claude/skills/clickup/test/catchup.test.mjs
+++ b/claude/skills/clickup/test/catchup.test.mjs
@@ -1,0 +1,320 @@
+#!/usr/bin/env node
+
+/**
+ * The webhook.site CATCH-UP path (hermetic — no token, no network, no state dir).
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * The catch-up path claimed, in a comment, that it authenticates stored events
+ * with the same predicate as the live POST path. Nothing exercised it: the
+ * branch is gated on `SINCE && MODE === 'wait'` and the integration test runs
+ * `--mode server`, so it was structurally unreachable from the suite. Two
+ * mutations that reinstate the ORIGINAL defect passed all 73 tests:
+ *
+ *   1. `authenticateDelivery(...)` -> `{ accepted: true, event: JSON.parse(raw) }`
+ *      — deliver whatever webhook.site stored, which is whatever anyone POSTed
+ *      to a public URL. This is the whole bug #438 existed to fix, one function
+ *      over.
+ *   2. reading the signature from a header key that never matches — the
+ *      opposite failure: every genuine event rejected, silently, forever.
+ *
+ * So this runs THE SAME FOUR CASES the live path is held to
+ * (webhook-server.test.mjs "the HTTP receiver"): unsigned, wrongly-signed,
+ * unregistered-webhook, correctly-signed — through the catch-up seam, with the
+ * side effects recorded. Plus the CURSOR policy, which is the second defect in
+ * #444: ten consecutive unverifiable stored requests used to be a permanent
+ * blind spot.
+ *
+ * Usage:
+ *   node --test test/catchup.test.mjs
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { signBody, forwarderArgs, forwarderTarget, LOOPBACK_HOST } from '../lib/webhook-server.mjs';
+import { catchUp, classifyStoredRequest, DECIDABLE_REJECTIONS } from '../lib/catchup.mjs';
+
+const WEBHOOK_ID = 'wh-fixture-0001';
+const SECRET = 'fixture-secret-not-a-real-clickup-signing-key';
+const OTHER_SECRET = 'a-different-fixture-secret';
+const secrets = { [WEBHOOK_ID]: SECRET };
+const lookupSecret = (id) => secrets[id] || null;
+
+const EVENT = { event: 'taskStatusUpdated', task_id: '868fixture', webhook_id: WEBHOOK_ID };
+const BODY = JSON.stringify(EVENT);
+const GOOD_SIG = signBody(BODY, SECRET);
+
+/** A webhook.site stored request, in the shape its API returns one. */
+function stored(content, signature, created_at = '2026-08-13 10:00:00') {
+  const req = { uuid: 'fixture-uuid', content, created_at, headers: {} };
+  // webhook.site returns header VALUES AS ARRAYS, and echoes the case the
+  // sender used. Both are why the header is read through a helper.
+  if (signature !== undefined) req.headers['x-signature'] = [signature];
+  return req;
+}
+
+/** Run the whole walk, recording every side effect it asks the caller to make. */
+function run(requests, { matches = () => true, lookup = lookupSecret } = {}) {
+  const log = [];       // what would be appended to webhooks.jsonl
+  const delivered = []; // what would be printed for the agent
+  const filtered = [];
+  const cursor = [];    // every last-seen.txt write, in order
+  const blocked = [];
+  const outcome = catchUp(requests, {
+    lookupSecret: lookup,
+    matches,
+    onAccepted: (event) => {
+      log.push(event);
+      cursor.push(event._wh_created_at || null);
+      return { entry: true, ...event };
+    },
+    onDeliver: (entry, event) => delivered.push(event),
+    onFiltered: (event) => filtered.push(event),
+    onSkipped: (info) => cursor.push(info.createdAt),
+    onBlocked: (info) => blocked.push(info),
+  });
+  return { outcome, log, delivered, filtered, cursor, blocked };
+}
+
+// ── 1. THE FOUR CASES, the same ones the live path is held to ─────────────
+
+describe('the catch-up path authenticates exactly like the live path', () => {
+  test('🔴 an UNSIGNED stored request is rejected — nothing logged, nothing delivered', () => {
+    const r = run([stored(BODY, undefined)]);
+    assert.equal(r.delivered.length, 0,
+      'a stored request with NO signature was delivered to the agent. A webhook.site URL ' +
+        'accepts a POST from anyone, so this is the forged-event path in full.');
+    assert.equal(r.log.length, 0, 'a rejected stored request was written to webhooks.jsonl');
+    assert.equal(r.outcome.skipped, 1);
+  });
+
+  test('🔴 a WRONGLY-signed stored request is rejected', () => {
+    const r = run([stored(BODY, signBody(BODY, OTHER_SECRET))]);
+    assert.equal(r.delivered.length, 0, 'a forged stored request was delivered to the agent');
+    assert.equal(r.log.length, 0);
+  });
+
+  test('🔴 a stored request from an UNREGISTERED webhook is rejected', () => {
+    const body = JSON.stringify({ ...EVENT, webhook_id: 'wh-never-registered' });
+    const r = run([stored(body, signBody(body, SECRET))]);
+    assert.equal(r.delivered.length, 0,
+      'an event from a webhook with no registered secret was delivered — that is the ' +
+        'unverifiable case, and the agent acts on the payload');
+  });
+
+  test('a CORRECTLY-signed stored request IS delivered (the check is not just "reject")', () => {
+    const r = run([stored(BODY, GOOD_SIG)]);
+    assert.equal(r.delivered.length, 1,
+      'a correctly signed stored event was not delivered — hardening that rejects ' +
+        'everything is an outage, not hardening');
+    assert.equal(r.delivered[0].task_id, '868fixture');
+    assert.equal(r.log.length, 1, 'the delivered event was not recorded');
+  });
+
+  test('the signature is checked against the STORED RAW BODY, not a re-serialisation', () => {
+    // Pretty-printed on purpose: whitespace is the property a JSON round-trip
+    // does NOT preserve, so this is what tells "verified req.content" apart from
+    // "verified JSON.stringify(JSON.parse(req.content))". ClickUp signs the bytes.
+    const pretty = JSON.stringify(EVENT, null, 2);
+    assert.notEqual(pretty, JSON.stringify(JSON.parse(pretty)), 'fixture precondition');
+
+    const wrong = run([stored(pretty, signBody(JSON.stringify(JSON.parse(pretty)), SECRET))]);
+    assert.equal(wrong.delivered.length, 0,
+      'a signature over a RE-SERIALISED body was accepted — the catch-up path is verifying ' +
+        'its own reconstruction of the payload, not what the sender signed');
+
+    const right = run([stored(pretty, signBody(pretty, SECRET))]);
+    assert.equal(right.delivered.length, 1, 'a signature over the exact stored bytes was rejected');
+  });
+
+  test('a stored request whose body is not JSON is never delivered', () => {
+    const r = run([stored('not json at all', GOOD_SIG)]);
+    assert.equal(r.delivered.length, 0);
+    assert.equal(r.log.length, 0);
+  });
+
+  test('POSITIVE + NEGATIVE control in one: the same stored request flips on the secret alone', () => {
+    const good = run([stored(BODY, GOOD_SIG)]);
+    const bad = run([stored(BODY, GOOD_SIG)], { lookup: () => OTHER_SECRET });
+    assert.equal(good.delivered.length, 1);
+    assert.equal(bad.delivered.length, 0,
+      'the catch-up path delivered the same body under a DIFFERENT secret — it is not ' +
+        'verifying anything');
+  });
+
+  test('the header is read case-INSENSITIVELY (webhook.site echoes the sender\'s case)', () => {
+    // Both spellings must work. That is what makes a hard-coded bracket access —
+    // in EITHER case — a mutant that dies: one of these two goes red.
+    const lower = { uuid: 'u', content: BODY, created_at: '2026-08-13 10:00:00',
+      headers: { 'x-signature': [GOOD_SIG] } };
+    const upper = { uuid: 'u', content: BODY, created_at: '2026-08-13 10:00:00',
+      headers: { 'X-Signature': GOOD_SIG } };
+    assert.equal(run([lower]).delivered.length, 1,
+      'a lowercase x-signature header was not read — every stored event rejects and ' +
+        'catch-up silently delivers nothing');
+    assert.equal(run([upper]).delivered.length, 1,
+      'an X-Signature header was not read — same silent outage, other spelling');
+  });
+});
+
+// ── 2. The CURSOR: the permanent blind spot ───────────────────────────────
+
+describe('the cursor advances past decidable rejections and stops at undecidable ones', () => {
+  test('🔴 ten consecutive unverifiable stored requests no longer wedge catch-up', () => {
+    // The realistic trigger is a lost or reset watchers.json while the ClickUp
+    // webhooks keep firing: EVERY stored event is unknown-webhook, per_page is
+    // 10, and date_from is the cursor — so before this the first ten blocked
+    // catch-up forever and a genuine event behind them was unreachable.
+    const junk = [];
+    for (let i = 0; i < 10; i++) {
+      const body = JSON.stringify({ ...EVENT, webhook_id: `wh-gone-${i}` });
+      junk.push(stored(body, signBody(body, SECRET), `2026-08-13 10:00:${String(i).padStart(2, '0')}`));
+    }
+    const real = stored(BODY, GOOD_SIG, '2026-08-13 10:00:10');
+
+    const r = run([...junk, real]);
+    assert.equal(r.delivered.length, 1,
+      'a genuine event behind ten unverifiable stored requests was never reached — that is ' +
+        'the permanent blind spot: the cursor could not move past them, so every subsequent ' +
+        'run re-read the same ten');
+    assert.equal(r.outcome.skipped, 10);
+    assert.equal(r.log.length, 1, 'a rejected stored request reached the log');
+    assert.deepEqual(
+      r.cursor,
+      [...junk.map((q) => q.created_at), '2026-08-13 10:00:10'],
+      'the cursor did not advance once per skipped request, in order');
+  });
+
+  test('a skipped request advances the cursor to ITS timestamp and logs NOTHING', () => {
+    const r = run([stored('{"webhook_id":"wh-gone"}', 'deadbeef', '2026-08-13 11:22:33')]);
+    assert.deepEqual(r.cursor, ['2026-08-13 11:22:33'],
+      'the cursor did not advance past a permanently unverifiable request');
+    assert.equal(r.log.length, 0,
+      'a rejected body was written to the log — rejected bodies are attacker-controlled');
+  });
+
+  test('🔴 an UNPARSEABLE request STOPS the walk and does NOT move the cursor', () => {
+    const r = run([
+      stored('<html>not a webhook at all</html>', GOOD_SIG, '2026-08-13 10:00:00'),
+      stored(BODY, GOOD_SIG, '2026-08-13 10:00:05'),
+    ]);
+    assert.equal(r.blocked.length, 1, 'an unparseable stored request did not block the walk');
+    assert.equal(r.blocked[0].reason, 'invalid-json');
+    assert.deepEqual(r.cursor, [],
+      'the cursor moved past a request we could not parse — that is the silent version of ' +
+        'skipping a possibly-genuine event');
+    assert.equal(r.delivered.length, 0,
+      'the walk continued past the blocked request; because the cursor is a TIMESTAMP, ' +
+        'delivering a LATER event advances past the unparseable one anyway');
+    assert.equal(r.outcome.considered, 1, 'the walk examined requests behind the blocker');
+  });
+
+  test('a rejection with NO usable timestamp is undecidable — nothing to advance TO', () => {
+    for (const createdAt of ['', '   ', undefined]) {
+      const r = run([{ content: BODY, headers: {}, created_at: createdAt }]);
+      assert.equal(r.blocked.length, 1,
+        `created_at=${JSON.stringify(createdAt)}: a rejection with no timestamp was treated ` +
+          'as decidable, so the caller would advance the cursor to nothing');
+      assert.deepEqual(r.cursor, []);
+    }
+  });
+
+  test('a non-object stored record is undecidable, not a crash', () => {
+    for (const junk of [null, 'a string', 42]) {
+      let r;
+      assert.doesNotThrow(() => { r = run([junk]); });
+      assert.equal(r.blocked[0].reason, 'malformed-record');
+      assert.deepEqual(r.cursor, []);
+    }
+  });
+
+  test('the decidable set is exactly the PERMANENT rejections', () => {
+    // Pinned as a set, not spot-checked: adding a reason here is a decision to
+    // let the cursor skip past that case, and it should be deliberate.
+    assert.deepEqual([...DECIDABLE_REJECTIONS].sort(),
+      ['bad-signature', 'missing-signature', 'no-webhook-id', 'unknown-webhook']);
+    assert.ok(!DECIDABLE_REJECTIONS.has('invalid-json'),
+      'invalid-json was made decidable — we could not parse the body, so we cannot say what ' +
+        'the cursor would be stepping over');
+  });
+
+  test('classifyStoredRequest reports decidability per reason', () => {
+    const cases = [
+      ['missing-signature', stored(BODY, undefined), true],
+      ['bad-signature', stored(BODY, signBody(BODY, OTHER_SECRET)), true],
+      ['no-webhook-id', stored(JSON.stringify({ event: 'x' }), 'sig'), true],
+      ['unknown-webhook', (() => {
+        const b = JSON.stringify({ ...EVENT, webhook_id: 'wh-nope' });
+        return stored(b, signBody(b, SECRET));
+      })(), true],
+      ['invalid-json', stored('{{{', 'sig'), false],
+    ];
+    for (const [reason, req, decidable] of cases) {
+      const r = classifyStoredRequest(req, lookupSecret);
+      assert.equal(r.accepted, false, `${reason}: expected a rejection`);
+      assert.equal(r.reason, reason, `expected reason ${reason}, got ${r.reason}`);
+      assert.equal(r.decidable, decidable,
+        `${reason}: decidable=${r.decidable}, expected ${decidable}`);
+    }
+  });
+
+  test('an accepted event carries the stored timestamp as the cursor value', () => {
+    const r = classifyStoredRequest(stored(BODY, GOOD_SIG, '2026-08-13 09:08:07'), lookupSecret);
+    assert.equal(r.accepted, true, `expected accepted, got ${r.reason}`);
+    assert.equal(r.event._wh_created_at, '2026-08-13 09:08:07',
+      'the accepted event lost its webhook.site timestamp, so the cursor would advance to ' +
+        'the RECEIVE time instead — re-reading everything in between on the next run');
+  });
+});
+
+// ── 3. Filters do not weaken the cursor ───────────────────────────────────
+
+describe('filters', () => {
+  test('an authentic but FILTERED event still advances the cursor and is not delivered', () => {
+    const r = run([stored(BODY, GOOD_SIG, '2026-08-13 12:00:00')],
+      { matches: () => false });
+    assert.equal(r.delivered.length, 0);
+    assert.equal(r.filtered.length, 1);
+    assert.deepEqual(r.cursor, ['2026-08-13 12:00:00'],
+      'a filtered event did not advance the cursor, so every later run re-reads it');
+  });
+
+  test('the walk stops at the FIRST matching event and reports what it examined', () => {
+    const second = stored(BODY, GOOD_SIG, '2026-08-13 12:00:02');
+    const r = run([stored(BODY, GOOD_SIG, '2026-08-13 12:00:01'), second]);
+    assert.equal(r.delivered.length, 1);
+    assert.equal(r.outcome.considered, 1,
+      'the walk kept going after delivering — the process exits there, and a second ' +
+        'delivery would overwrite webhook-latest.json on the way out');
+  });
+});
+
+// ── 4. The forwarder targets what the receiver BINDS ──────────────────────
+
+describe('the whcli forwarder target', () => {
+  test('🔴 the target is the literal 127.0.0.1, never `localhost`', () => {
+    const args = forwarderArgs({ token: 'fixture-token', port: 3458 });
+    const target = args.find((a) => a.startsWith('--target='));
+    assert.equal(target, '--target=http://127.0.0.1:3458',
+      `whcli would forward to ${target}. \`localhost\` resolves through the host's name ` +
+        'lookup and can yield ::1 first; the receiver binds 127.0.0.1 ONLY, so every ' +
+        'delivery would be refused by a listener that reports healthy.');
+    assert.ok(!args.some((a) => a.includes('localhost')), `\`localhost\` in ${args.join(' ')}`);
+  });
+
+  test('the target and the bind address are the SAME constant, not two literals', () => {
+    assert.equal(forwarderTarget(1234), `http://${LOOPBACK_HOST}:1234`,
+      'the forwarder target stopped being derived from LOOPBACK_HOST — the two can now ' +
+        'drift, which is the whole failure mode');
+    assert.equal(LOOPBACK_HOST, '127.0.0.1');
+  });
+
+  test('the port is the one passed (the BOUND port, not the requested one)', () => {
+    assert.ok(forwarderArgs({ token: 't', port: 45678 }).includes('--target=http://127.0.0.1:45678'));
+  });
+
+  test('the api key is included only when there is one', () => {
+    assert.ok(!forwarderArgs({ token: 't', port: 1 }).some((a) => a.startsWith('--api-key=')));
+    assert.ok(forwarderArgs({ token: 't', port: 1, apiKey: 'k' }).includes('--api-key=k'));
+  });
+});

--- a/claude/skills/clickup/test/catchup.test.mjs
+++ b/claude/skills/clickup/test/catchup.test.mjs
@@ -25,14 +25,28 @@
  * #444: ten consecutive unverifiable stored requests used to be a permanent
  * blind spot.
  *
+ * 🔴 And the cursor policy's OWN regression, which the first fix introduced:
+ * treating `invalid-json` as undecidable made ONE non-JSON stored request a
+ * permanent wedge — worse than the ten it replaced, and triggerable by anyone
+ * who can GET the public URL. The pair of tests marked "🔴 a body that is not a
+ * JSON object" and "🔴 the same page, TWICE" are what would have caught it: the
+ * first over every non-object body webhook.site actually stores, the second by
+ * re-walking one page the way consecutive runs do.
+ *
  * Usage:
  *   node --test test/catchup.test.mjs
  */
 
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath } from 'url';
 import { signBody, forwarderArgs, forwarderTarget, LOOPBACK_HOST } from '../lib/webhook-server.mjs';
-import { catchUp, classifyStoredRequest, DECIDABLE_REJECTIONS } from '../lib/catchup.mjs';
+import { catchUp, classifyStoredRequest, isDecidable, PERMANENT_REJECTIONS } from '../lib/catchup.mjs';
+import { resolveApiBase, DEFAULT_API_BASE } from '../lib/webhook-site.mjs';
+
+const SKILL = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
 const WEBHOOK_ID = 'wh-fixture-0001';
 const SECRET = 'fixture-secret-not-a-real-clickup-signing-key';
@@ -193,20 +207,63 @@ describe('the cursor advances past decidable rejections and stops at undecidable
       'a rejected body was written to the log — rejected bodies are attacker-controlled');
   });
 
-  test('🔴 an UNPARSEABLE request STOPS the walk and does NOT move the cursor', () => {
-    const r = run([
-      stored('<html>not a webhook at all</html>', GOOD_SIG, '2026-08-13 10:00:00'),
-      stored(BODY, GOOD_SIG, '2026-08-13 10:00:05'),
-    ]);
-    assert.equal(r.blocked.length, 1, 'an unparseable stored request did not block the walk');
-    assert.equal(r.blocked[0].reason, 'invalid-json');
-    assert.deepEqual(r.cursor, [],
-      'the cursor moved past a request we could not parse — that is the silent version of ' +
-        'skipping a possibly-genuine event');
-    assert.equal(r.delivered.length, 0,
-      'the walk continued past the blocked request; because the cursor is a TIMESTAMP, ' +
-        'delivering a LATER event advances past the unparseable one anyway');
-    assert.equal(r.outcome.considered, 1, 'the walk examined requests behind the blocker');
+  // 🔴 THE REGRESSION THIS PAIR EXISTS FOR. The first version of the cursor
+  // policy made `invalid-json` UNDECIDABLE — stop the walk, leave the cursor —
+  // which turned one non-JSON stored request into a PERMANENT wedge: `SINCE`
+  // defaults to last-seen.txt, so the same page re-blocked on every subsequent
+  // run until somebody edited state by hand. The trigger is not exotic:
+  // webhook.site records an empty `content` for a bare GET, i.e. a crawler, a
+  // link preview, or the user opening their own webhook URL in a browser.
+  const NOT_A_JSON_OBJECT = [
+    ['an empty body — what webhook.site records for a bare GET', ''],
+    ['a null content field', null],
+    ['a JSON scalar', '42'],
+    ['a JSON string', '"a string"'],
+    ['HTML', '<html>not a webhook at all</html>'],
+    ['a form-encoded body', 'a=1&b=2'],
+    ['a JSON array', '[{"webhook_id":"x"}]'],
+    ['truncated JSON', '{{{'],
+  ];
+
+  test('🔴 a body that is not a JSON object is SKIPPED, and the genuine event behind it is delivered', () => {
+    for (const [label, content] of NOT_A_JSON_OBJECT) {
+      const r = run([
+        { uuid: 'u', content, created_at: '2026-08-13 10:00:00', headers: {} },
+        stored(BODY, GOOD_SIG, '2026-08-13 10:00:05'),
+      ]);
+      assert.equal(r.blocked.length, 0,
+        `${label}: it BLOCKED the walk. The cursor is a timestamp and SINCE defaults to ` +
+          'last-seen.txt, so this page re-blocks on every subsequent run — permanently, and ' +
+          'anyone who can reach the URL can put such a request there.');
+      assert.equal(r.delivered.length, 1,
+        `${label}: the genuine event behind it was never delivered`);
+      assert.deepEqual(r.cursor, ['2026-08-13 10:00:00', '2026-08-13 10:00:05'],
+        `${label}: the cursor did not advance past the unparseable request and then onto the ` +
+          'genuine event');
+      assert.equal(r.log.length, 1, `${label}: a rejected body reached the log`);
+    }
+  });
+
+  test('🔴 the same page, TWICE: a wedge would show up as run 2 behaving like run 1', () => {
+    // The shape of the audit's end-to-end reproduction, at the unit level: the
+    // walk is re-run over the SAME stored page with the cursor carried over, as
+    // it is in life. A blocked run leaves the cursor untouched, so run 2 is
+    // identical to run 1 — forever.
+    const page = [
+      { uuid: 'bare-get', content: '', created_at: '2026-08-13 09:00:01', headers: {} },
+      stored(BODY, GOOD_SIG, '2026-08-13 09:00:02'),
+    ];
+    const first = run(page);
+    assert.equal(first.delivered.length, 1, 'run 1 delivered nothing');
+    const cursorAfterFirst = first.cursor[first.cursor.length - 1];
+    assert.equal(cursorAfterFirst, '2026-08-13 09:00:02',
+      `run 1 left the cursor at ${JSON.stringify(cursorAfterFirst)}. If it did not move, the ` +
+        'next run re-reads this page and blocks identically — that is the wedge.');
+
+    // Only what is newer than the cursor comes back on run 2.
+    const second = run(page.filter((p) => p.created_at > cursorAfterFirst));
+    assert.equal(second.outcome.considered, 0,
+      'run 2 still had requests to examine, so run 1 did not make progress');
   });
 
   test('a rejection with NO usable timestamp is undecidable — nothing to advance TO', () => {
@@ -228,17 +285,58 @@ describe('the cursor advances past decidable rejections and stops at undecidable
     }
   });
 
-  test('the decidable set is exactly the PERMANENT rejections', () => {
-    // Pinned as a set, not spot-checked: adding a reason here is a decision to
-    // let the cursor skip past that case, and it should be deliberate.
-    assert.deepEqual([...DECIDABLE_REJECTIONS].sort(),
-      ['bad-signature', 'missing-signature', 'no-webhook-id', 'unknown-webhook']);
-    assert.ok(!DECIDABLE_REJECTIONS.has('invalid-json'),
-      'invalid-json was made decidable — we could not parse the body, so we cannot say what ' +
-        'the cursor would be stepping over');
+  test('the permanent set is pinned, invalid-json INCLUDED', () => {
+    // Pinned as a set, not spot-checked: a reason here is a decision to let the
+    // cursor skip past that case, and one MISSING is a decision to wedge on it.
+    assert.deepEqual([...PERMANENT_REJECTIONS].sort(),
+      ['bad-signature', 'invalid-json', 'malformed-record', 'missing-signature',
+        'no-webhook-id', 'unknown-webhook']);
+    assert.ok(PERMANENT_REJECTIONS.has('invalid-json'),
+      'invalid-json was made undecidable again. Stored bytes do not change: a body that is ' +
+        'not JSON will not start being JSON, exactly as a bad signature will not start ' +
+        'matching. Removing it turns one bare GET into a permanent wedge.');
+  });
+
+  test('🔴 LEDGER: every reason authenticateDelivery can return is classified', () => {
+    // A reason the authenticator grows that nobody adds to PERMANENT_REJECTIONS
+    // defaults to UNDECIDABLE — i.e. to the wedge. Read out of the source, so
+    // this fails when the set grows there and not here.
+    const src = readFileSync(join(SKILL, 'lib/webhook-server.mjs'), 'utf8');
+    const declared = new Set(
+      [...src.matchAll(/reason:\s*'([a-z-]+)'/g)].map((m) => m[1]).filter((r) => r !== 'verified'));
+    assert.ok(declared.size >= 5,
+      `only ${declared.size} rejection reason(s) found in lib/webhook-server.mjs — the scan ` +
+        'is wired to nothing, so "all classified" means nothing');
+    const unclassified = [...declared].filter((r) => !PERMANENT_REJECTIONS.has(r));
+    assert.deepEqual(unclassified, [],
+      `authenticateDelivery can return ${unclassified.join(', ')}, which PERMANENT_REJECTIONS ` +
+        'does not list. Unlisted means undecidable means the walk STOPS on it and the cursor ' +
+        'never moves — decide deliberately, do not inherit it.');
+    const stale = [...PERMANENT_REJECTIONS].filter(
+      (r) => r !== 'malformed-record' && !declared.has(r));
+    assert.deepEqual(stale, [],
+      `PERMANENT_REJECTIONS lists ${stale.join(', ')}, which no longer exists in ` +
+        'lib/webhook-server.mjs — the ledger has to shrink with it too');
+  });
+
+  test('🔴 an UNKNOWN reason is undecidable even when dated — the fail-closed default', () => {
+    // Reachability for the `PERMANENT_REJECTIONS.has()` clause. Every reason the
+    // authenticator returns today is listed, so nothing OBSERVABLE depends on
+    // that clause — deleting it passes every other test in this file. It exists
+    // for the reason someone adds tomorrow, and this is the case that says so.
+    assert.equal(isDecidable('transient-registry-unavailable', '2026-08-13 10:00:00'), false,
+      'a rejection reason nobody classified was treated as permanent, so the cursor would ' +
+        'skip past a case that might resolve on the next run. Unlisted must mean STOP.');
+    assert.equal(isDecidable('invalid-json', '2026-08-13 10:00:00'), true,
+      'a listed reason with a timestamp is decidable — otherwise the fail-closed default has ' +
+        'swallowed everything and the walk wedges on the first rejection');
+    assert.equal(isDecidable('invalid-json', null), false,
+      'a listed reason with NO timestamp is not decidable: there is nothing to advance to');
   });
 
   test('classifyStoredRequest reports decidability per reason', () => {
+    // Every rejection is decidable WHEN DATED — the reason is a property of
+    // bytes that are already stored and will not change.
     const cases = [
       ['missing-signature', stored(BODY, undefined), true],
       ['bad-signature', stored(BODY, signBody(BODY, OTHER_SECRET)), true],
@@ -247,7 +345,8 @@ describe('the cursor advances past decidable rejections and stops at undecidable
         const b = JSON.stringify({ ...EVENT, webhook_id: 'wh-nope' });
         return stored(b, signBody(b, SECRET));
       })(), true],
-      ['invalid-json', stored('{{{', 'sig'), false],
+      ['invalid-json', stored('{{{', 'sig'), true],
+      ['invalid-json', stored('', undefined), true],
     ];
     for (const [reason, req, decidable] of cases) {
       const r = classifyStoredRequest(req, lookupSecret);
@@ -255,6 +354,23 @@ describe('the cursor advances past decidable rejections and stops at undecidable
       assert.equal(r.reason, reason, `expected reason ${reason}, got ${r.reason}`);
       assert.equal(r.decidable, decidable,
         `${reason}: decidable=${r.decidable}, expected ${decidable}`);
+    }
+  });
+
+  test('🔴 the SAME reason is undecidable without a timestamp and decidable with one', () => {
+    // The pair that proves the rule is "datable", not "this reason". Same body,
+    // same headers, one field different.
+    for (const reason of ['invalid-json', 'missing-signature']) {
+      const content = reason === 'invalid-json' ? '' : BODY;
+      const dated = classifyStoredRequest(
+        { content, headers: {}, created_at: '2026-08-13 10:00:00' }, lookupSecret);
+      const undated = classifyStoredRequest({ content, headers: {} }, lookupSecret);
+      assert.equal(dated.reason, reason);
+      assert.equal(undated.reason, reason);
+      assert.equal(dated.decidable, true, `${reason}: a DATED rejection was undecidable`);
+      assert.equal(undated.decidable, false,
+        `${reason}: an UNDATED rejection was decidable, so the caller would advance the ` +
+          'cursor to null and lose its place entirely');
     }
   });
 
@@ -316,5 +432,97 @@ describe('the whcli forwarder target', () => {
   test('the api key is included only when there is one', () => {
     assert.ok(!forwarderArgs({ token: 't', port: 1 }).some((a) => a.startsWith('--api-key=')));
     assert.ok(forwarderArgs({ token: 't', port: 1, apiKey: 'k' }).includes('--api-key=k'));
+  });
+});
+
+// ── 5. Where stored requests may be fetched FROM ──────────────────────────
+//
+// 🔴 CLICKUP_WEBHOOK_SITE_API_BASE is a credential-egress knob, not just a test
+// seam: the webhook.site token is in the request PATH and WEBHOOK_SITE_API_KEY
+// rides as an `Api-Key` header, so an unconstrained base hands both to whatever
+// host it names — over cleartext if it says http. It shipped with a comment
+// clearing it of a risk it never had (delivery integrity: every fetched request
+// is still authenticated) and silent about the one it has.
+
+describe('the webhook.site API base is gated', () => {
+  const REFUSED = [
+    ['a third-party host', 'https://evil.example.com'],
+    ['a third-party host over http', 'http://evil.example.com'],
+    ['a lookalike suffix', 'https://notwebhook.site'],
+    ['a lookalike prefix', 'https://webhook.site.evil.example.com'],
+    ['🔴 a PLAINTEXT downgrade of the real destination', 'http://webhook.site'],
+    ['a non-http scheme', 'ftp://webhook.site'],
+    ['a file URL', 'file:///etc/passwd'],
+    ['not a URL at all', 'webhook.site'],
+    ['garbage', ':::::'],
+  ];
+
+  test('🔴 a base that is neither loopback nor webhook.site is REFUSED', () => {
+    for (const [label, raw] of REFUSED) {
+      const r = resolveApiBase(raw);
+      assert.equal(r.base, DEFAULT_API_BASE,
+        `${label} (${raw}) was accepted as the API base. The webhook.site token is in the ` +
+          'URL path, so that host receives a capability for this workspace\'s entire event ' +
+          'stream.');
+      assert.ok(r.warning, `${label}: refused SILENTLY — a refusal nobody sees is a mystery`);
+    }
+  });
+
+  test('🔴 a refused base never gets the Api-Key either', () => {
+    // Belt and braces: the fallback is webhook.site itself, so sendApiKey is
+    // true — what must be impossible is the KEY going to the named host.
+    for (const [, raw] of REFUSED) {
+      const r = resolveApiBase(raw);
+      assert.equal(r.base, DEFAULT_API_BASE, `${raw} survived as the base`);
+    }
+  });
+
+  test('🔴 a loopback base is allowed and gets NO Api-Key', () => {
+    for (const raw of ['http://127.0.0.1:8123', 'http://localhost:8123',
+      'https://127.0.0.1:8123', 'http://[::1]:8123', 'http://127.9.9.9:1']) {
+      const r = resolveApiBase(raw);
+      assert.ok(r.base.startsWith(new URL(raw).origin),
+        `${raw} was refused — the catch-up path then has no way to be exercised at all`);
+      assert.equal(r.sendApiKey, false,
+        `${raw} would be sent the webhook.site account API key. A test stub has no use for ` +
+          'one, and not sending it is what keeps this override out of the credential path.');
+      assert.equal(r.warning, null, `${raw}: warned about a legitimate loopback stub`);
+    }
+  });
+
+  test('webhook.site over https is allowed, WITH the Api-Key', () => {
+    for (const raw of ['https://webhook.site', 'https://webhook.site/', 'https://eu.webhook.site']) {
+      const r = resolveApiBase(raw);
+      assert.equal(r.sendApiKey, true, `${raw}: the real destination lost its Api-Key`);
+      assert.equal(r.warning, null);
+      assert.ok(!r.base.endsWith('/'), `${raw}: a trailing slash survived into ${r.base}`);
+    }
+  });
+
+  test('an unset or empty base is the default, with the Api-Key', () => {
+    for (const raw of [undefined, null, '', '   ']) {
+      const r = resolveApiBase(raw);
+      assert.equal(r.base, DEFAULT_API_BASE);
+      assert.equal(r.sendApiKey, true);
+      assert.equal(r.warning, null, `${JSON.stringify(raw)}: warned about the default`);
+    }
+  });
+
+  test('the default destination is https', () => {
+    assert.ok(DEFAULT_API_BASE.startsWith('https://'),
+      'the default base is cleartext — the token in the path travels in the clear');
+  });
+
+  test('listen.mjs asks this module rather than reading the env itself', () => {
+    // A second copy of the policy in the script is how a gate stops applying.
+    const src = readFileSync(join(SKILL, 'listen.mjs'), 'utf8');
+    const reads = [...src.matchAll(/CLICKUP_WEBHOOK_SITE_API_BASE/g)].length;
+    assert.equal(reads, 1,
+      `listen.mjs names CLICKUP_WEBHOOK_SITE_API_BASE ${reads} times; it must read it once, ` +
+        'and only to hand it to resolveApiBase()');
+    assert.ok(/resolveApiBase\(process\.env\.CLICKUP_WEBHOOK_SITE_API_BASE\)/.test(src),
+      'listen.mjs no longer routes the override through resolveApiBase()');
+    assert.ok(/API\.sendApiKey/.test(src),
+      "listen.mjs attaches the Api-Key without consulting the gate's sendApiKey decision");
   });
 });

--- a/claude/skills/clickup/test/js-source.mjs
+++ b/claude/skills/clickup/test/js-source.mjs
@@ -17,10 +17,20 @@
  *
  * Neither can be fixed by a longer regex over raw text, because both need to
  * know what is CODE and what is a comment or a string. So: one small scanner,
- * used by both, with its own controls in js-source.test.mjs.
+ * used by both, with its own controls in js-source.test.mjs — which for one
+ * round was a claim about a file that did not exist, while both guards rested
+ * on this module's behaviour. `blankStrings` blanking `${…}` (below) is exactly
+ * the kind of thing direct controls catch and a downstream guard does not: it
+ * showed up as a state-path scanner that was silent on a template literal.
  *
  * It is not a parser. It tracks exactly what these guards need — string,
- * template, regex and comment context — and nothing else.
+ * template, regex and comment context — and nothing else. Known limits, all
+ * exercised in js-source.test.mjs:
+ *
+ *   * a nested quote INSIDE a `${…}` substitution (`` `${x['a`b']}` ``) ends the
+ *     template early — the literal scan does not recurse;
+ *   * `blankComments` does not know about JSX or about a regex whose preceding
+ *     token is a keyword (`return /x/`), because neither occurs here.
  */
 
 const REGEX_PREFIX = new Set([
@@ -123,15 +133,56 @@ export function stringLiterals(code) {
 }
 
 /**
+ * The `${ … }` substitutions inside ONE template literal, as [start, end)
+ * offsets into `code` covering the delimiters as well.
+ *
+ * Brace-matched, so `${join(a, {b: 1})}` is one range. Not quote-aware inside
+ * the substitution — see the module header's known limits.
+ */
+export function substitutionRanges(code, lit) {
+  if (code[lit.start] !== '`') return [];
+  const out = [];
+  for (let i = lit.start + 1; i < lit.end - 1; i++) {
+    if (code[i] === '\\') { i += 1; continue; }
+    if (code[i] !== '$' || code[i + 1] !== '{') continue;
+    let depth = 0;
+    let j = i + 1;
+    for (; j < lit.end - 1; j++) {
+      if (code[j] === '{') depth++;
+      else if (code[j] === '}') { depth--; if (depth === 0) break; }
+    }
+    const end = Math.min(j + 1, lit.end - 1);
+    out.push([i, end]);
+    i = end - 1;
+  }
+  return out;
+}
+
+/**
  * Blank the CONTENTS of every string/template literal (quotes kept), preserving
  * offsets. Brace-depth counting needs this: a lone `'{'` in a string would
  * otherwise skew the depth and silently move where "top level" is.
+ *
+ * 🔴 `keepSubstitutions` leaves the CODE inside a template's `${ … }` intact.
+ * The default blanks it, and that is a hole for any guard that looks for an
+ * identifier: `` writeFileSync(`${__dirname}/accounts.json`, d) `` — the idiom
+ * listen.mjs itself writes — became a token-free string and the state-path
+ * scanner was silent on it. A substitution's braces are balanced by
+ * construction, so keeping them does not disturb the depth counting this
+ * function exists to protect; the literal TEXT around them is still blanked, so
+ * a `{` or a comma in the text cannot skew it either.
+ *
+ * @param {string} code
+ * @param {{keepSubstitutions?: boolean}} [opts]
  */
-export function blankStrings(code) {
+export function blankStrings(code, { keepSubstitutions = false } = {}) {
   const out = Array.from(code);
   for (const lit of stringLiterals(code)) {
+    const keep = keepSubstitutions ? substitutionRanges(code, lit) : [];
     for (let k = lit.start + 1; k < lit.end - 1; k++) {
-      if (out[k] !== '\n') out[k] = ' ';
+      if (out[k] === '\n') continue;
+      if (keep.some(([s, e]) => k >= s && k < e)) continue;
+      out[k] = ' ';
     }
   }
   return out.join('');
@@ -175,8 +226,17 @@ export function topLevelCaseLabels(code, block) {
   const re = /case\s*(['"])([a-z][a-z0-9-]*)\1\s*:/g;
   const marks = [];
   let m;
+  // 🔴 The label NAME has to be read from the raw text (blanking strings blanks
+  // the name too), so the "is this code?" question is asked separately: a match
+  // whose `case` keyword sits INSIDE a string literal is text, not a label.
+  // Without this, `usage("case 'restore':")` in a help string invented a
+  // dispatchable command and the coverage guard demanded docs for it.
+  const lits = stringLiterals(code);
+  const insideLiteral = (i) => lits.some((l) => i > l.start && i < l.end - 1);
   while ((m = re.exec(code.slice(block.start, block.end))) !== null) {
-    marks.push({ index: block.start + m.index, name: m[2] });
+    const index = block.start + m.index;
+    if (insideLiteral(index)) continue;
+    marks.push({ index, name: m[2] });
   }
   const bare = blankStrings(code);
   let mi = 0;

--- a/claude/skills/clickup/test/js-source.test.mjs
+++ b/claude/skills/clickup/test/js-source.test.mjs
@@ -1,0 +1,344 @@
+#!/usr/bin/env node
+
+/**
+ * DIRECT controls for test/js-source.mjs (hermetic — pure string functions).
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * js-source.mjs said, in its header, "with its own controls in
+ * js-source.test.mjs" — and that file did not exist. Meanwhile it is the
+ * SUBSTRATE under both structural guards in this directory: the state-path seam
+ * scanner (comment blanking, string blanking, brace/argument depth counting, and
+ * every literal it reads) and the help-coverage extractor (its switch-block
+ * bounds and its case labels). A defect here is a silent hole in both, attributed
+ * to neither.
+ *
+ * It was not hypothetical. `blankStrings` blanked the CONTENTS of a template
+ * literal including its `${ … }` substitutions, so
+ * `` writeFileSync(`${__dirname}/accounts.json`, d) `` — the idiom listen.mjs
+ * itself writes — reached the seam scanner as a token-free string and passed
+ * clean. A guard downstream cannot see that; a direct control can, and does
+ * below.
+ *
+ * Usage:
+ *   node --test test/js-source.test.mjs
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  blankComments,
+  blankStrings,
+  stringLiterals,
+  substitutionRanges,
+  balancedBlockAfter,
+  topLevelCaseLabels,
+} from './js-source.mjs';
+
+/**
+ * Every one of these functions promises OFFSET PRESERVATION — an index into the
+ * result points at the same character it did in the input. Both guards rely on
+ * it (they scan `bare` and then read `literals` computed from another copy), and
+ * nothing else in the suite would notice it breaking.
+ */
+function assertSameShape(before, after, what) {
+  assert.equal(after.length, before.length, `${what}: length changed — offsets no longer line up`);
+  const lines = (s) => s.split('\n').length;
+  assert.equal(lines(after), lines(before), `${what}: line count changed`);
+  for (let i = 0; i < before.length; i++) {
+    if (before[i] === '\n') {
+      assert.equal(after[i], '\n', `${what}: newline at ${i} was overwritten`);
+    }
+  }
+}
+
+// ── blankComments ─────────────────────────────────────────────────────────
+
+describe('blankComments', () => {
+  test('a line comment is blanked, the code around it is not', () => {
+    const src = "const a = 1; // writeFileSync(join(__dirname, 'x.json'), d)\nconst b = 2;";
+    const out = blankComments(src);
+    assertSameShape(src, out, 'blankComments');
+    assert.ok(out.includes('const a = 1;'), 'the code before the comment was destroyed');
+    assert.ok(out.includes('const b = 2;'), 'the code after the newline was destroyed');
+    assert.ok(!/writeFileSync/.test(out),
+      'a commented-out call survived. The seam guard would report prose as a defect — and, ' +
+        'worse, a real call could be hidden from it by commenting the lines around it.');
+  });
+
+  test('a block comment is blanked across lines, preserving the newlines', () => {
+    const src = 'const a = 1;\n/* writeFileSync(p, d);\n   more prose */\nconst b = 2;';
+    const out = blankComments(src);
+    assertSameShape(src, out, 'blankComments');
+    assert.ok(!/writeFileSync/.test(out), 'a block-commented call survived');
+    assert.ok(out.includes('const b = 2;'));
+  });
+
+  test('🔴 a comment MARKER INSIDE A STRING is not a comment', () => {
+    // The control that matters in the other direction: over-blanking silently
+    // deletes real code from every guard downstream.
+    const src = "const u = 'https://webhook.site/token';\nconst p = accountsPath();";
+    const out = blankComments(src);
+    assert.ok(out.includes('webhook.site/token'),
+      'the // inside a URL string was treated as a comment, so everything after it on the ' +
+        'line was erased — including, in a real module, the call being guarded');
+    assert.ok(out.includes('accountsPath()'));
+  });
+
+  test('a regex literal containing a quote does not open a string', () => {
+    const src = "const re = /['\"]/g;\nwriteFileSync(p, d);";
+    const out = blankComments(src);
+    assert.ok(out.includes('writeFileSync(p, d);'),
+      'a quote inside a regex literal was read as opening a string, which swallows the rest ' +
+        'of the file');
+  });
+
+  test('a division is not mistaken for a regex', () => {
+    const src = 'const half = total / 2;\nconst other = count / 4;\nwriteFileSync(p, d);';
+    const out = blankComments(src);
+    assert.ok(out.includes('writeFileSync(p, d);'),
+      'two divisions were read as one regex literal, erasing the code between them');
+  });
+
+  test('an escaped quote does not end a string early', () => {
+    const src = "const s = 'it\\'s fine'; writeFileSync(p, d);";
+    const out = blankComments(src);
+    assert.ok(out.includes('writeFileSync(p, d);'));
+  });
+});
+
+// ── stringLiterals ────────────────────────────────────────────────────────
+
+describe('stringLiterals', () => {
+  test('reports value, start and end for each quote style', () => {
+    const src = `const a = 'one'; const b = "two"; const c = \`three\`;`;
+    const got = stringLiterals(src);
+    assert.deepEqual(got.map((l) => l.value), ['one', 'two', 'three']);
+    for (const lit of got) {
+      assert.equal(src.slice(lit.start + 1, lit.end - 1), lit.value,
+        'start/end do not bracket the reported value — every offset-based filter downstream ' +
+          '(which argument a literal sits in, for one) is then reading the wrong span');
+    }
+  });
+
+  test('an escaped quote is part of the value, not its end', () => {
+    const got = stringLiterals("const s = 'a\\'b';");
+    assert.equal(got.length, 1);
+    assert.equal(got[0].value, "a\\'b");
+  });
+
+  test('an unterminated literal does not run past the end of the input', () => {
+    const src = "const s = 'never closed";
+    const got = stringLiterals(src);
+    assert.equal(got.length, 1);
+    assert.ok(got[0].end <= src.length, 'end ran past the input length');
+  });
+});
+
+// ── blankStrings, and the ${…} hole it had ────────────────────────────────
+
+describe('blankStrings', () => {
+  test('string contents are blanked, quotes and offsets kept', () => {
+    const src = "const s = 'writeFileSync';\nconst t = 2;";
+    const out = blankStrings(src);
+    assertSameShape(src, out, 'blankStrings');
+    assert.ok(!/writeFileSync/.test(out), 'a bait string survived and reads as code');
+    assert.ok(out.includes("'") && out.includes('const t = 2;'));
+  });
+
+  test('a brace inside a string cannot skew depth counting', () => {
+    const src = "const s = '{';\nconst t = '}';";
+    const out = blankStrings(src);
+    assert.ok(!out.includes('{') && !out.includes('}'),
+      'braces inside strings survived, so every depth count over this text is off — that is ' +
+        'how "top level" silently moves');
+  });
+
+  test('🔴 by DEFAULT a template substitution is blanked with the text', () => {
+    const src = 'const p = `${__dirname}/accounts.json`;';
+    assert.ok(!/__dirname/.test(blankStrings(src)),
+      'the default changed. balancedBlockAfter/topLevelCaseLabels rely on the whole literal ' +
+        'being inert; only the seam scanner asks for substitutions back');
+  });
+
+  test('🔴 keepSubstitutions preserves the CODE inside ${ … }', () => {
+    const src = 'const p = `${__dirname}/accounts.json`;';
+    const out = blankStrings(src, { keepSubstitutions: true });
+    assertSameShape(src, out, 'blankStrings(keepSubstitutions)');
+    assert.ok(/\$\{__dirname\}/.test(out),
+      'the substitution was blanked, so a location token written the way listen.mjs writes it ' +
+        'is invisible to any guard scanning this text — which is exactly how the seam scanner ' +
+        'stayed silent on `writeFileSync(`${__dirname}/accounts.json`, d)`');
+    assert.ok(!/accounts\.json/.test(out),
+      'the literal TEXT around the substitution must still be blanked — it is not code');
+  });
+
+  test('keepSubstitutions leaves braces BALANCED', () => {
+    const src = 'writeFileSync(`${join(a, {x: 1})}/f.json`, d);';
+    const out = blankStrings(src, { keepSubstitutions: true });
+    let depth = 0;
+    for (const c of out) {
+      if (c === '{') depth++;
+      else if (c === '}') depth--;
+      assert.ok(depth >= 0, 'brace depth went negative — argument spans would be truncated');
+    }
+    assert.equal(depth, 0,
+      'keeping substitutions unbalanced the braces, which moves every span computed from ' +
+        'this text');
+  });
+
+  test('keepSubstitutions does not un-blank a comma in the literal TEXT', () => {
+    // A comma in template text at argument depth 0 would split one argument in
+    // two and shift every index after it.
+    const src = 'writeFileSync(`a,b/${x}`, d);';
+    const out = blankStrings(src, { keepSubstitutions: true });
+    const inner = out.slice(out.indexOf('`'), out.lastIndexOf('`'));
+    assert.ok(!inner.includes(','), 'a comma in template TEXT survived and would split args');
+  });
+
+  test('a template with no substitution is blanked either way', () => {
+    const src = 'const p = `accounts.json`;';
+    assert.ok(!/accounts/.test(blankStrings(src, { keepSubstitutions: true })));
+  });
+});
+
+describe('substitutionRanges', () => {
+  const rangesOf = (src) => {
+    const lit = stringLiterals(src)[0];
+    return substitutionRanges(src, lit).map(([s, e]) => src.slice(s, e));
+  };
+
+  test('finds each substitution, delimiters included', () => {
+    assert.deepEqual(rangesOf('const p = `${a}/x/${b}`;'), ['${a}', '${b}']);
+  });
+
+  test('brace-matches a nested object literal', () => {
+    assert.deepEqual(rangesOf('const p = `${f({x: 1})}`;'), ['${f({x: 1})}']);
+  });
+
+  test('a plain string has no substitutions', () => {
+    assert.deepEqual(rangesOf("const p = '${a}';"), [],
+      "'${a}' is text in a single-quoted string, not a substitution");
+  });
+
+  test('a bare $ or { is not a substitution', () => {
+    assert.deepEqual(rangesOf('const p = `$ {a} cost`;'), []);
+  });
+});
+
+// ── balancedBlockAfter / topLevelCaseLabels ───────────────────────────────
+
+describe('balancedBlockAfter', () => {
+  test('returns the braces of the block following the header', () => {
+    const src = 'switch (cmd) {\n  case 1: break;\n}\nconst after = 1;';
+    const b = balancedBlockAfter(src, 'switch (cmd)');
+    assert.equal(src[b.start], '{');
+    assert.equal(src[b.end - 1], '}');
+    assert.ok(src.slice(b.start, b.end).includes('case 1'));
+    assert.ok(!src.slice(b.start, b.end).includes('const after'),
+      'the block ran past its closing brace');
+  });
+
+  test('a brace inside a nested block does not close it early', () => {
+    const src = 'switch (cmd) {\n  case 1: { const x = 1; }\n  case 2: break;\n}';
+    const b = balancedBlockAfter(src, 'switch (cmd)');
+    assert.ok(src.slice(b.start, b.end).includes('case 2'),
+      'the block closed at the nested brace, so half the switch is unread');
+  });
+
+  test('a brace inside a STRING does not close it early', () => {
+    const src = "switch (cmd) {\n  case 1: log('}'); break;\n  case 2: break;\n}";
+    const b = balancedBlockAfter(src, 'switch (cmd)');
+    assert.ok(src.slice(b.start, b.end).includes('case 2'),
+      "a '}' inside a string ended the block — the extractor then sees fewer commands than " +
+        'exist, and an undocumented one is invisible');
+  });
+
+  test('a header that is not present returns null rather than throwing', () => {
+    assert.equal(balancedBlockAfter('const a = 1;', 'switch (cmd)'), null);
+  });
+});
+
+describe('topLevelCaseLabels', () => {
+  const labels = (src) => {
+    const b = balancedBlockAfter(src, 'switch (cmd)');
+    return [...topLevelCaseLabels(src, b)].sort();
+  };
+
+  test('quote style and indentation are irrelevant', () => {
+    const src = [
+      'switch (cmd) {',
+      "  case 'one': break;",
+      '        case "two": break;',
+      "case 'three': break;",
+      '}',
+    ].join('\n');
+    assert.deepEqual(labels(src), ['one', 'three', 'two'],
+      'a case label was missed on quote style or indentation — those were the two spellings ' +
+        'that made dispatchable commands invisible to the help guard');
+  });
+
+  test('🔴 a NESTED switch\'s labels are not swept in', () => {
+    const src = [
+      'switch (cmd) {',
+      "  case 'outer':",
+      '    switch (sub) {',
+      "      case 'inner': break;",
+      '    }',
+      '    break;',
+      '}',
+    ].join('\n');
+    assert.deepEqual(labels(src), ['outer'],
+      'a nested switch\'s labels were counted as dispatchable commands, inflating the set ' +
+        'with things no command dispatch reaches');
+  });
+
+  test('a case label written inside a STRING is not a label', () => {
+    const src = "switch (cmd) {\n  case 'real': help(\"case 'fake':\"); break;\n}";
+    assert.deepEqual(labels(src), ['real']);
+  });
+
+  test('a label immediately AFTER a string literal is still a label', () => {
+    // The other side of the same check: "inside a literal" has to end at the
+    // closing quote. A window even a few characters too wide silently drops
+    // real labels, and the coverage guard then stops asking about them.
+    const src = "switch (cmd) {\n  case 'a': f('x');case 'b': break;\n}";
+    assert.deepEqual(labels(src), ['a', 'b'],
+      'a case label a few characters after a string literal was swallowed by the ' +
+        '"is this inside a string?" test — that is an undocumented command going unnoticed');
+  });
+});
+
+// ── KNOWN LIMITS, pinned so they stay known ───────────────────────────────
+//
+// These assert what the scanner does WRONG. They are here because the module
+// header names both, and a header that names a limit no test demonstrates is
+// the same kind of claim this whole round is about. If a future change fixes
+// one, this file goes red — update it, do not delete it.
+
+describe('known limits', () => {
+  test('LIMIT: a quote inside ${ … } ends the template literal early', () => {
+    const src = "const p = `${x['a`b']}`;";
+    const lits = stringLiterals(src);
+    assert.equal(lits[0].value, "${x['a",
+      'the literal scan started recursing into substitutions. That is an improvement — ' +
+        'update this test and the module header rather than removing them.');
+  });
+
+  test('LIMIT: a regex after a KEYWORD is read as division, so a later comment survives', () => {
+    // REGEX_PREFIX holds punctuation only, so `return /'/` leaves an unmatched
+    // quote open and the comment after it is never blanked. For the seam
+    // scanner that means a commented-out call would read as live code — a false
+    // positive, not a miss, which is the safe direction. No module here writes
+    // a regex directly after a keyword.
+    const src = "return /'/;\n// writeFileSync(join(__dirname, 'x.json'), d)\nconst t = 1;";
+    assert.ok(/writeFileSync/.test(blankComments(src)),
+      'the keyword-regex case now blanks correctly — good; update this test and the module ' +
+        'header, which both describe it as a limit');
+    // And the shape that DOES work, so this is a limit and not a general break:
+    assert.ok(!/writeFileSync/.test(blankComments(
+      "const re = /'/;\n// writeFileSync(join(__dirname, 'x.json'), d)\nconst t = 1;")),
+    'an ASSIGNED regex is in REGEX_PREFIX and must still be handled — if this fails the ' +
+      'limit is not a limit, it is a break');
+  });
+});

--- a/claude/skills/clickup/test/listen-integration.test.mjs
+++ b/claude/skills/clickup/test/listen-integration.test.mjs
@@ -289,12 +289,14 @@ test('🔴 the forwarder is pointed at 127.0.0.1:<the bound port>, never localho
 
 /** A webhook.site stored-requests API, on loopback, serving a canned page. */
 async function stubWebhookSite(requests) {
+  const seen = [];   // every request's headers, so the caller can assert on them
   const srv = http.createServer((req, res) => {
+    seen.push(req.headers);
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ data: requests }));
   });
   await new Promise((r) => srv.listen(0, '127.0.0.1', r));
-  return { srv, base: `http://127.0.0.1:${srv.address().port}` };
+  return { srv, seen, base: `http://127.0.0.1:${srv.address().port}` };
 }
 
 /** One stored request, in the shape webhook.site's API returns (header ARRAYS). */
@@ -304,22 +306,39 @@ function storedRequest(content, signature, created_at) {
   return r;
 }
 
-/** Run listen.mjs in WAIT mode against the stub, to completion. */
-async function runCatchUp(requests, { timeout = 8 } = {}) {
+/** A scratch state dir with one registered watcher — the host's state, reusable. */
+function catchUpState() {
   const scratch = mkdtempSync(join(tmpdir(), 'clickup-catchup-'));
   const xdg = join(scratch, 'xdg');
   const state = join(xdg, 'clickup');
   mkdirSync(state, { recursive: true });
   writeFileSync(join(state, 'watchers.json'),
     JSON.stringify([{ webhookId: WEBHOOK_ID, secret: SECRET, kind: 'fixture' }], null, 2));
+  return { scratch, xdg, state };
+}
+
+/**
+ * Run listen.mjs in WAIT mode against the stub, to completion.
+ *
+ * `ctx` lets a caller run the SAME state dir twice — the only way to observe a
+ * cursor that does not move, since `--since` defaults to last-seen.txt and a
+ * wedge is by definition something that repeats. `since: null` omits the flag so
+ * the cursor file is what decides, exactly as it does on a host.
+ */
+async function runCatchUp(requests, {
+  timeout = 8, ctx = null, since = '2026-08-13 09:00:00', apiKey = '',
+} = {}) {
+  const own = !ctx;
+  const { scratch, xdg, state } = ctx || catchUpState();
 
   const stub = await stubWebhookSite(requests);
   const proc = spawn(process.execPath, [
     LISTEN, '--mode', 'wait', '--port', '0',
-    '--since', '2026-08-13 09:00:00', '--timeout', String(timeout),
+    ...(since === null ? [] : ['--since', since]),
+    '--timeout', String(timeout),
   ], {
     env: { ...process.env, HOME: scratch, XDG_STATE_HOME: xdg,
-      CLICKUP_WEBHOOK_SITE_TOKEN: FIXTURE_TOKEN, WEBHOOK_SITE_API_KEY: '',
+      CLICKUP_WEBHOOK_SITE_TOKEN: FIXTURE_TOKEN, WEBHOOK_SITE_API_KEY: apiKey,
       CLICKUP_WEBHOOK_SITE_API_BASE: stub.base },
     stdio: ['ignore', 'pipe', 'pipe'],
   });
@@ -334,11 +353,15 @@ async function runCatchUp(requests, { timeout = 8 } = {}) {
     const kill = setTimeout(() => { try { proc.kill('SIGKILL'); } catch {} }, (timeout + 10) * 1000);
     proc.on('exit', (c) => { clearTimeout(kill); resolve(c); });
   });
+  // closeAllConnections first: close() waits for live sockets, and a child
+  // killed mid-request can leave one — which hangs the file, not the test.
+  stub.srv.closeAllConnections();
   await new Promise((r) => stub.srv.close(r));
 
   const read = (n) => (existsSync(join(state, n)) ? readFileSync(join(state, n), 'utf8') : null);
-  const result = { code, out, err, state, log: read('webhooks.jsonl'), cursor: read('last-seen.txt') };
-  rmSync(scratch, { recursive: true, force: true });
+  const result = { code, out, err, state, seen: stub.seen,
+    log: read('webhooks.jsonl'), cursor: read('last-seen.txt') };
+  if (own) rmSync(scratch, { recursive: true, force: true });
   return result;
 }
 
@@ -396,19 +419,214 @@ test('🔴 CATCH-UP: a run of unverifiable stored events advances the cursor ins
   assert.equal(r.code, 1, 'wait mode should time out with exit 1 having delivered nothing');
 });
 
-test('🔴 CATCH-UP: an UNPARSEABLE stored request stops the walk with the cursor unmoved', async () => {
+test('🔴 CATCH-UP: an UNPARSEABLE stored request is stepped over, not wedged on', async () => {
   const r = await runCatchUp([
     storedRequest('<html>not a webhook</html>', 'whatever', '2026-08-13 09:20:00'),
     storedRequest(BODY, sign(BODY, SECRET), '2026-08-13 09:20:01'),
   ], { timeout: 3 });
 
+  assert.equal(r.code, 0,
+    `catch-up did not reach the genuine event behind an unparseable one:\n${redact(r.err)}`);
+  assert.ok(r.out.includes('868integration'), `nothing was delivered:\n${redact(r.out)}`);
+  assert.equal((r.cursor || '').trim(), '2026-08-13 09:20:01',
+    `the cursor is ${JSON.stringify(r.cursor)}. A stored body that is not JSON is as fixed as ` +
+      'a bad signature — standing still on it re-reads the same page forever.');
+  assert.ok(/\[catch-up:rejected:invalid-json\]/.test(r.err),
+    `the skip was not reported on stderr:\n${redact(r.err)}`);
+  const lines = (r.log || '').trim().split('\n').filter(Boolean);
+  assert.equal(lines.length, 1, `a rejected body reached the log:\n${redact(r.log || '')}`);
+});
+
+test('🔴 CATCH-UP, TWO RUNS: a bare GET does not park the cursor forever', async () => {
+  // 🔴 THE REGRESSION, end to end and in the shape it bites. webhook.site
+  // records an EMPTY body for a bare GET — a crawler, a link preview, the user
+  // opening their own webhook URL — and `--since` is omitted here, so SINCE
+  // comes from last-seen.txt exactly as it does on a host. When that request
+  // blocked the walk, the cursor never moved and run 2 was identical to run 1:
+  // measured `exit=1 delivered=false cursor=09:00:00` on both.
+  const ctx = catchUpState();
+  try {
+    writeFileSync(join(ctx.state, 'last-seen.txt'), '2026-08-13 09:00:00');
+    const page = [
+      { uuid: 'bare-get', content: '', created_at: '2026-08-13 09:00:01', headers: {} },
+      storedRequest(BODY, sign(BODY, SECRET), '2026-08-13 09:00:02'),
+    ];
+
+    const first = await runCatchUp(page, { timeout: 3, ctx, since: null });
+    assert.equal(first.code, 0,
+      `run 1 exited ${first.code} instead of delivering. One request anybody can create — a ` +
+        `GET to the public URL — is holding up every event behind it:\n${redact(first.err)}`);
+    assert.ok(first.out.includes('868integration'),
+      `run 1 delivered no genuine event:\n${redact(first.out)}`);
+    assert.equal((first.cursor || '').trim(), '2026-08-13 09:00:02',
+      `run 1 left the cursor at ${JSON.stringify(first.cursor)}; it must sit on the delivered ` +
+        'event, or run 2 re-reads the same page and blocks identically, forever');
+
+    // Run 2 sees only what is newer than the cursor — i.e. nothing.
+    const second = await runCatchUp(
+      page.filter((p) => p.created_at > (first.cursor || '').trim()), { timeout: 3, ctx, since: null });
+    assert.ok(/No missed events/.test(second.err),
+      `run 2 still had stored requests to examine, so run 1 made no progress:\n${redact(second.err)}`);
+    assert.equal(second.code, 1, 'run 2 delivered something; there was nothing left to deliver');
+  } finally {
+    rmSync(ctx.scratch, { recursive: true, force: true });
+  }
+});
+
+test('🔴 CATCH-UP: an UNDATABLE stored request is what stops the walk', async () => {
+  // The genuinely undecidable case, and the only one: no created_at means
+  // nothing to move the cursor TO. It cannot be produced by a request BODY —
+  // webhook.site stamps what it stores — which is why it does not wedge in life.
+  const r = await runCatchUp([
+    { uuid: 'undatable', content: BODY, headers: {} },
+    storedRequest(BODY, sign(BODY, SECRET), '2026-08-13 09:30:01'),
+  ], { timeout: 3 });
+
   assert.equal(r.cursor, null,
-    `the cursor advanced to ${JSON.stringify(r.cursor)} past a request that could not be ` +
-      'parsed — we cannot say what was skipped, so nothing may be skipped');
-  assert.ok(/\[catch-up:blocked:invalid-json\]/.test(r.err),
+    `the cursor advanced to ${JSON.stringify(r.cursor)} on a record with no timestamp — there ` +
+      'is nothing to advance to, so that value was guessed');
+  assert.ok(/\[catch-up:blocked:missing-signature\]/.test(r.err),
     `the blocked request was not reported:\n${redact(r.err)}`);
+  assert.ok(/BLOCKED at an undatable request/.test(r.err),
+    `the summary line hid the block. A wedged run must not end on a line that reads like a ` +
+      `clean sweep:\n${redact(r.err)}`);
   assert.equal(r.log, null, 'something was logged despite nothing being authenticated');
   assert.equal(r.code, 1);
+});
+
+test('🔴 the webhook.site ACCOUNT API KEY is never sent to the loopback override', async () => {
+  // The override's whole purpose is that the tests can point the fetch at a
+  // stub. That must not mean handing the stub an account credential — so the
+  // key is set here, deliberately, and must not appear on the wire.
+  const r = await runCatchUp([storedRequest(BODY, sign(BODY, SECRET), '2026-08-13 09:40:00')],
+    { timeout: 3, apiKey: 'fixture-account-api-key-not-real' });
+
+  assert.ok(r.seen.length >= 1,
+    `the stub received ${r.seen.length} request(s) — a header assertion over nothing is not ` +
+      `evidence:\n${redact(r.err)}`);
+  for (const headers of r.seen) {
+    const keys = Object.keys(headers).map((k) => k.toLowerCase());
+    assert.ok(!keys.includes('api-key'),
+      `the Api-Key header was sent to the loopback base. Whatever CLICKUP_WEBHOOK_SITE_API_BASE ` +
+        'names then receives a webhook.site ACCOUNT credential, not just this workspace\'s token.');
+    for (const [k, v] of Object.entries(headers)) {
+      assert.ok(!String(v).includes('fixture-account-api-key-not-real'),
+        `the API key travelled in the ${k} header instead`);
+    }
+  }
+});
+
+test('🔴 an oversized stored-requests response is discarded, not accumulated', async () => {
+  // `data += chunk` with no ceiling is an allocation the BASE HOST controls.
+  // The cap is only a real cap if something exceeds it, so this streams past it.
+  const ctx = catchUpState();
+  const big = 'x'.repeat(64 * 1024);
+  let sent = 0;
+  const flood = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    const pump = () => {
+      while (sent < 6 * 1024 * 1024) {
+        sent += big.length;
+        if (!res.write(big)) { res.once('drain', pump); return; }
+      }
+      res.end();
+    };
+    pump();
+  });
+  flood.on('clientError', () => {});
+  await new Promise((r) => flood.listen(0, '127.0.0.1', r));
+  try {
+    const proc = spawn(process.execPath, [
+      LISTEN, '--mode', 'wait', '--port', '0', '--since', '2026-08-13 09:00:00', '--timeout', '2',
+    ], {
+      env: { ...process.env, HOME: ctx.scratch, XDG_STATE_HOME: ctx.xdg,
+        CLICKUP_WEBHOOK_SITE_TOKEN: FIXTURE_TOKEN, WEBHOOK_SITE_API_KEY: '',
+        CLICKUP_WEBHOOK_SITE_API_BASE: `http://127.0.0.1:${flood.address().port}` },
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    proc.stderr.setEncoding('utf8');
+    let err = '';
+    proc.stderr.on('data', (d) => { err += d; });
+    const code = await new Promise((resolve) => {
+      const kill = setTimeout(() => { try { proc.kill('SIGKILL'); } catch {} }, 40000);
+      proc.on('exit', (c) => { clearTimeout(kill); resolve(c); });
+    });
+
+    assert.ok(sent > 5 * 1024 * 1024,
+      `the flood server only sent ${sent} bytes — under the cap, so this measures nothing`);
+    assert.ok(/response exceeded/.test(err),
+      `an oversized response was accepted instead of discarded:\n${redact(err)}`);
+    assert.ok(/Listening on 127\.0\.0\.1:/.test(err),
+      `the listener did not fall through to the live path after discarding it:\n${redact(err)}`);
+    assert.equal(code, 1, 'wait mode should time out with exit 1 having delivered nothing');
+  } finally {
+    flood.closeAllConnections();
+    await new Promise((r) => flood.close(r));
+    rmSync(ctx.scratch, { recursive: true, force: true });
+  }
+});
+
+test('🔴 a hostile CLICKUP_WEBHOOK_SITE_API_BASE is refused by the real process', async () => {
+  // The gate, exercised through the script rather than only through
+  // resolveApiBase(): a base that is neither loopback nor webhook.site must not
+  // be contacted at all — the token is in the path and the API key is a header.
+  const ctx = catchUpState();
+  let hits = 0;
+  const hostile = http.createServer((req, res) => {
+    hits += 1;
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ data: [] }));
+  });
+  await new Promise((r) => hostile.listen(0, '127.0.0.1', r));
+  try {
+    const port = hostile.address().port;
+
+    const runWithBase = async (base) => {
+      const proc = spawn(process.execPath, [
+        LISTEN, '--mode', 'wait', '--port', '0', '--since', '2026-08-13 09:00:00', '--timeout', '2',
+      ], {
+        env: { ...process.env, HOME: ctx.scratch, XDG_STATE_HOME: ctx.xdg,
+          CLICKUP_WEBHOOK_SITE_TOKEN: FIXTURE_TOKEN, WEBHOOK_SITE_API_KEY: 'fixture-api-key',
+          CLICKUP_WEBHOOK_SITE_API_BASE: base },
+        stdio: ['ignore', 'ignore', 'pipe'],
+      });
+      proc.stderr.setEncoding('utf8');
+      let err = '';
+      proc.stderr.on('data', (d) => { err += d; });
+      await new Promise((resolve) => {
+        const kill = setTimeout(() => { try { proc.kill('SIGKILL'); } catch {} }, 30000);
+        proc.on('exit', () => { clearTimeout(kill); resolve(); });
+      });
+      return err;
+    };
+
+    // POSITIVE CONTROL first: the same server, named as loopback, IS contacted.
+    // Without this, "0 requests" is indistinguishable from a server nothing
+    // could have reached — and the refusal below would prove nothing.
+    const okErr = await runWithBase(`http://127.0.0.1:${port}`);
+    assert.equal(hits, 1,
+      `the loopback base produced ${hits} request(s) — the stub is not reachable, so a zero ` +
+        `from the refused base measures nothing:\n${redact(okErr)}`);
+
+    // The same host, spelled as a name that is neither loopback nor
+    // webhook.site: refused on the NAME, before any connection.
+    const err = await runWithBase(`http://webhook.site.localtest.me:${port}`);
+    assert.equal(hits, 1,
+      `listen.mjs sent a request to a base that is neither loopback nor webhook.site (hits ` +
+        `went 1 -> ${hits}). The webhook.site token is in the request PATH and the account ` +
+        'API key rides as a header, so that host was handed both.');
+    assert.ok(/Refusing it/.test(err),
+      `the refusal was not printed — a gate nobody can see is a mystery:\n${redact(err)}`);
+  } finally {
+    // 🔴 In the FINALLY, not after the assertions. `close()` waits for open
+    // connections and node's global agent keeps them alive, so a server left
+    // open hangs the whole test FILE after its last test — and a FAILING
+    // assertion is exactly when that happens. Found by mutating this gate: the
+    // run stopped reporting instead of reporting a failure.
+    hostile.closeAllConnections();
+    await new Promise((r) => hostile.close(r));
+    rmSync(ctx.scratch, { recursive: true, force: true });
+  }
 });
 
 test('a pre-existing 0644 webhook-url.txt is REPAIRED, not left as found', async () => {

--- a/claude/skills/clickup/test/listen-integration.test.mjs
+++ b/claude/skills/clickup/test/listen-integration.test.mjs
@@ -265,6 +265,152 @@ test('🔴 webhook-url.txt is written 0600 — the URL IS the capability', async
       'and POST forged events into it. Written with no mode argument it lands 0644.');
 });
 
+// ── 6. The forwarder targets the address the receiver actually bound ──────
+
+test('🔴 the forwarder is pointed at 127.0.0.1:<the bound port>, never localhost', () => {
+  // Read back out of the array the process SPAWNS (listen.mjs prints that
+  // element, not a recomputation), because `localhost` can resolve to ::1 and
+  // the receiver binds 127.0.0.1 only: whcli would then be refused on every
+  // delivery by a listener that reports perfectly healthy.
+  const m = /\[whcli\] target (\S+)/.exec(stderrBuf);
+  assert.ok(m, `listen.mjs never reported a forwarder target:\n${redact(stderrBuf)}`);
+  assert.equal(m[1], `http://127.0.0.1:${bound.port}`,
+    `whcli was pointed at ${m[1]} while the receiver bound 127.0.0.1:${bound.port}`);
+});
+
+// ── 7. CATCH-UP, end to end, against a loopback stub of webhook.site ──────
+//
+// The catch-up branch is gated on `SINCE && MODE === 'wait'`, so the server-mode
+// child above can never reach it — which is exactly why two mutations that
+// reinstate the pre-#438 defect (deliver whatever webhook.site stored) survived
+// the entire suite. CLICKUP_WEBHOOK_SITE_API_BASE points the fetch at a stub
+// here; it changes WHERE stored requests come from, never whether they are
+// authenticated.
+
+/** A webhook.site stored-requests API, on loopback, serving a canned page. */
+async function stubWebhookSite(requests) {
+  const srv = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ data: requests }));
+  });
+  await new Promise((r) => srv.listen(0, '127.0.0.1', r));
+  return { srv, base: `http://127.0.0.1:${srv.address().port}` };
+}
+
+/** One stored request, in the shape webhook.site's API returns (header ARRAYS). */
+function storedRequest(content, signature, created_at) {
+  const r = { uuid: `fixture-${created_at}`, content, created_at, headers: {} };
+  if (signature !== undefined) r.headers['x-signature'] = [signature];
+  return r;
+}
+
+/** Run listen.mjs in WAIT mode against the stub, to completion. */
+async function runCatchUp(requests, { timeout = 8 } = {}) {
+  const scratch = mkdtempSync(join(tmpdir(), 'clickup-catchup-'));
+  const xdg = join(scratch, 'xdg');
+  const state = join(xdg, 'clickup');
+  mkdirSync(state, { recursive: true });
+  writeFileSync(join(state, 'watchers.json'),
+    JSON.stringify([{ webhookId: WEBHOOK_ID, secret: SECRET, kind: 'fixture' }], null, 2));
+
+  const stub = await stubWebhookSite(requests);
+  const proc = spawn(process.execPath, [
+    LISTEN, '--mode', 'wait', '--port', '0',
+    '--since', '2026-08-13 09:00:00', '--timeout', String(timeout),
+  ], {
+    env: { ...process.env, HOME: scratch, XDG_STATE_HOME: xdg,
+      CLICKUP_WEBHOOK_SITE_TOKEN: FIXTURE_TOKEN, WEBHOOK_SITE_API_KEY: '',
+      CLICKUP_WEBHOOK_SITE_API_BASE: stub.base },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let out = '';
+  let err = '';
+  proc.stdout.setEncoding('utf8');
+  proc.stderr.setEncoding('utf8');
+  proc.stdout.on('data', (d) => { out += d; });
+  proc.stderr.on('data', (d) => { err += d; });
+
+  const code = await new Promise((resolve) => {
+    const kill = setTimeout(() => { try { proc.kill('SIGKILL'); } catch {} }, (timeout + 10) * 1000);
+    proc.on('exit', (c) => { clearTimeout(kill); resolve(c); });
+  });
+  await new Promise((r) => stub.srv.close(r));
+
+  const read = (n) => (existsSync(join(state, n)) ? readFileSync(join(state, n), 'utf8') : null);
+  const result = { code, out, err, state, log: read('webhooks.jsonl'), cursor: read('last-seen.txt') };
+  rmSync(scratch, { recursive: true, force: true });
+  return result;
+}
+
+test('🔴 CATCH-UP: forged and unverifiable stored events are skipped, the genuine one is delivered', async () => {
+  const forged = JSON.stringify({ ...EVENT, task_id: '868forged' });
+  const orphan = JSON.stringify({ ...EVENT, task_id: '868orphan', webhook_id: 'wh-not-in-watchers' });
+  const r = await runCatchUp([
+    // Unsigned — the shape anyone can POST to a webhook.site URL.
+    storedRequest(forged, undefined, '2026-08-13 09:00:01'),
+    // Signed with the wrong key.
+    storedRequest(forged, sign(forged, 'the-attackers-guess'), '2026-08-13 09:00:02'),
+    // Correctly signed, but by a webhook this skill does not own.
+    storedRequest(orphan, sign(orphan, SECRET), '2026-08-13 09:00:03'),
+    // The real one.
+    storedRequest(BODY, sign(BODY, SECRET), '2026-08-13 09:00:04'),
+  ]);
+
+  assert.equal(r.code, 0, `catch-up did not deliver and exit 0:\n${redact(r.err)}`);
+  assert.ok(r.out.includes('868integration'),
+    `the delivered payload was not the authentic event:\n${redact(r.out)}`);
+  assert.ok(!r.out.includes('868forged') && !r.out.includes('868orphan'),
+    `catch-up delivered a payload it never authenticated — this is the pre-#438 defect ` +
+      `in the catch-up path:\n${redact(r.out)}`);
+
+  const lines = (r.log || '').trim().split('\n').filter(Boolean);
+  assert.equal(lines.length, 1,
+    `webhooks.jsonl holds ${lines.length} line(s); exactly ONE stored request was authentic. ` +
+      `Any extra line is a rejected delivery that was logged anyway:\n${redact(r.log || '')}`);
+  assert.equal(JSON.parse(lines[0]).task_id, '868integration');
+  assert.equal((r.cursor || '').trim(), '2026-08-13 09:00:04',
+    'the cursor does not sit on the delivered event');
+});
+
+test('🔴 CATCH-UP: a run of unverifiable stored events advances the cursor instead of wedging', async () => {
+  // The lost-watchers.json case: every stored event is unknown-webhook. With a
+  // 10-per-page cursor keyed on date_from, ten of these used to be a PERMANENT
+  // blind spot — the same ten re-read on every run, forever.
+  const reqs = [];
+  for (let i = 0; i < 10; i++) {
+    const body = JSON.stringify({ ...EVENT, task_id: `868gone${i}`, webhook_id: `wh-gone-${i}` });
+    reqs.push(storedRequest(body, sign(body, SECRET), `2026-08-13 09:10:0${i}`));
+  }
+  const r = await runCatchUp(reqs, { timeout: 3 });
+
+  assert.equal((r.cursor || '').trim(), '2026-08-13 09:10:09',
+    `the cursor is ${JSON.stringify(r.cursor)} after ten permanently-unverifiable stored ` +
+      'requests. It must sit past the last of them, or catch-up re-reads the same page on ' +
+      'every run and can never reach a genuine event behind it.');
+  assert.equal(r.log, null,
+    `a rejected stored request was written to the log:\n${redact(r.log || '')}`);
+  assert.ok(/\[catch-up:rejected:unknown-webhook\]/.test(r.err),
+    `the skips were not reported on stderr:\n${redact(r.err)}`);
+  assert.ok(/Listening on 127\.0\.0\.1:/.test(r.err),
+    `catch-up did not fall through to the live listener:\n${redact(r.err)}`);
+  assert.equal(r.code, 1, 'wait mode should time out with exit 1 having delivered nothing');
+});
+
+test('🔴 CATCH-UP: an UNPARSEABLE stored request stops the walk with the cursor unmoved', async () => {
+  const r = await runCatchUp([
+    storedRequest('<html>not a webhook</html>', 'whatever', '2026-08-13 09:20:00'),
+    storedRequest(BODY, sign(BODY, SECRET), '2026-08-13 09:20:01'),
+  ], { timeout: 3 });
+
+  assert.equal(r.cursor, null,
+    `the cursor advanced to ${JSON.stringify(r.cursor)} past a request that could not be ` +
+      'parsed — we cannot say what was skipped, so nothing may be skipped');
+  assert.ok(/\[catch-up:blocked:invalid-json\]/.test(r.err),
+    `the blocked request was not reported:\n${redact(r.err)}`);
+  assert.equal(r.log, null, 'something was logged despite nothing being authenticated');
+  assert.equal(r.code, 1);
+});
+
 test('a pre-existing 0644 webhook-url.txt is REPAIRED, not left as found', async () => {
   // The mode argument to writeFileSync only applies on CREATE. A host that ran
   // the old listener already has a 0644 copy, and it must not survive.

--- a/claude/skills/clickup/test/state-paths.test.mjs
+++ b/claude/skills/clickup/test/state-paths.test.mjs
@@ -23,13 +23,20 @@
  *      asserted to be inside the constant it was copied from — and it stayed
  *      green while webhook-url.txt (the webhook.site capability token, written
  *      0644) sat outside SECRET_FILES.
- *   4. The SEAM: no module re-derives a state path from its own location. Item
- *      1-3 all pass while a consumer quietly keeps its own copy of the old path,
- *      which is exactly the bug this refactor exists to remove. The scanner is
- *      STRUCTURAL (comment-aware, multi-line, quote-agnostic, and it does not
- *      depend on the filename being one this module already knows about) and
- *      carries a control PAIR: every shape must fire, and the legitimate uses of
- *      the same tokens must not.
+ *   4. The SEAM: no module WRITES to a path it derived from its own location.
+ *      Items 1-3 all pass while a consumer quietly keeps its own copy of the old
+ *      path, which is exactly the bug this refactor exists to remove. The
+ *      scanner is STRUCTURAL (comment-aware, multi-line, quote-agnostic, blind
+ *      to filenames, and it follows a path bound to a variable and written a
+ *      statement later) and carries a control PAIR: every shape must fire, and
+ *      the legitimate uses of the same tokens must not.
+ *
+ *      🔴 It asks about a WRITE, not about a filename. The previous version
+ *      never made that distinction, so four plain `readFileSync` calls on files
+ *      SHIPPED with the skill were reported as defects under a message
+ *      ("it will EROFS once deployed read-only") that is false for a read. The
+ *      escape hatch was an exemption list of two filenames, and the negative
+ *      controls were calibrated to that list rather than to the class.
  *
  * Written in `node:test` form and named `*.test.mjs` because that is what
  * devrc's node gate DISCOVERS (`scripts/run-node-tests.sh`). It still runs
@@ -281,6 +288,39 @@ test('migration: is a no-op on a second run (so the note prints once, then never
       'the stderr note would repeat forever');
 });
 
+// INVARIANT GUARD, not regression coverage — labelled as one deliberately.
+//
+// #438 deleted a `resolve(legacyDir) === resolve(stateDir)` clause from
+// migrateLegacyState() after showing it was DEAD (with src and dest the same
+// path, the existsSync(dest) skip fires for every name that exists and the
+// !existsSync(src) skip for every name that does not), and deleted the test
+// with it. The clause was dead; the BEHAVIOUR it described is not, and it went
+// unasserted. This pins the behaviour without reinstating the clause: a future
+// rewrite that reorders those two skips would silently start copying a file
+// onto itself.
+test('migration: migrating a directory ONTO ITSELF is a no-op', () => {
+  const dir = join(SCRATCH, 'same-dir');
+  mkdirSync(join(dir, '.cache'), { recursive: true });
+  writeFileSync(join(dir, 'accounts.json'), LEGACY_CONTENT);
+  chmodSync(join(dir, 'accounts.json'), 0o600);
+  writeFileSync(join(dir, '.cache', 'jwt-cache-default.json'), '{"cu_jwt":"fixture"}\n');
+  const before = readdirSync(dir).sort();
+
+  const migrated = paths.migrateLegacyState(dir, dir, { log: false });
+
+  assert.deepEqual(migrated, [],
+    `migrateLegacyState(d, d) reported ${JSON.stringify(migrated)} as migrated — it copied ` +
+      'files onto themselves and told the user it had moved their state');
+  assert.equal(readFileSync(join(dir, 'accounts.json'), 'utf8'), LEGACY_CONTENT,
+    'accounts.json was damaged by a same-directory migration — it holds the only copy of a ' +
+      'live API token');
+  assert.equal((statSync(join(dir, 'accounts.json')).mode & 0o777).toString(8), '600');
+  assert.equal(readFileSync(join(dir, '.cache', 'jwt-cache-default.json'), 'utf8'),
+    '{"cu_jwt":"fixture"}\n', 'the .cache contents were damaged');
+  assert.deepEqual(readdirSync(dir).sort(), before,
+    'a same-directory migration changed the directory listing');
+});
+
 test('migration: carries .env, watchers.json and the .cache/ dir too', () => {
   const legacy = join(SCRATCH, 'm3-legacy');
   const state = join(SCRATCH, 'm3-state');
@@ -430,8 +470,6 @@ test('webhook-url.txt is classified secret — the URL IS the credential', () =>
 // Structural, over the real sources. Items 1-3 are all satisfied by a correct
 // lib/paths.mjs that nobody actually uses; this is the check that notices.
 
-const STATE_NAMES = new Set([...paths.STATE_FILES, ...paths.STATE_DIRS]);
-
 // Every way a module can name its own location. `import.meta.url` is in here
 // because `new URL('accounts.json', import.meta.url)` is the skill's OWN idiom
 // (lib/paths.mjs:37 uses it) — the previous guard listed the token and then
@@ -440,82 +478,211 @@ const STATE_NAMES = new Set([...paths.STATE_FILES, ...paths.STATE_DIRS]);
 const LOCATION_TOKEN =
   /(?<![\w$.])(__dirname|import\.meta\.dirname|import\.meta\.url|SKILL_DIR)(?![\w$])/g;
 
-// Bundled READ-ONLY data legitimately read from the skill dir. Enumerated with
-// reasons, not pattern-matched: an unknown name is an offender by default.
-const READONLY_BUNDLED = new Set([
-  'package.json',      // the skill's own manifest — shipped, never written
-  'package-lock.json', // ditto; nix/pkgs/clickup-node-modules.nix builds from it
-]);
+/**
+ * 🔴 THE SCANNER ASKS ABOUT A **WRITE**, NOT ABOUT A FILENAME.
+ *
+ * What was here before never distinguished a READ from a WRITE: any literal
+ * with a mutable-looking extension near a location token was an offender. Four
+ * verified false positives, each a plain `readFileSync` of a SHIPPED file that
+ * is entirely legal on a read-only deploy:
+ *
+ *     join(__dirname, '..', 'data', 'custom-fields.json')
+ *     join(__dirname, 'schema.yaml')
+ *     new URL('prompt.txt', import.meta.url)
+ *     join(__dirname, '..', '.gitignore')
+ *
+ * and the failure message it printed for them — "it will EROFS once deployed
+ * read-only" — is simply FALSE for a read. The escape hatch was an enumerated
+ * `READONLY_BUNDLED` holding exactly `package.json` and `package-lock.json`,
+ * and the negative-control table was calibrated to THAT LIST rather than to the
+ * class: its two read-only cases were the two names that happened to be exempt.
+ * A guard that cries wolf gets deleted, and the exemption list would have had
+ * to grow by one entry per bundled data file forever.
+ *
+ * So the question is now the one the message actually makes: does a path
+ * derived from the module's own location end up in the TARGET position of a
+ * call that WRITES? That needs no filename registry, no extension list and no
+ * exemptions — a write into the skill dir is an EROFS whatever the file is
+ * called, including `package.json`.
+ */
 
-// Extensions a MUTABLE file plausibly has. Deliberately not `.md` (bundled
-// reference docs are read from the skill dir on purpose) and not `.mjs`/`.js`.
-const WRITABLE_EXT = new Set([
-  '.json', '.jsonl', '.ndjson', '.txt', '.log', '.env', '.yaml', '.yml',
-  '.ini', '.toml', '.db', '.sqlite', '.sqlite3', '.csv', '.state', '.lock',
-  '.cache', '.tmp',
+/**
+ * Calls that write, and WHICH argument is the path they write TO.
+ *
+ * The index matters: `cpSync(src, dest)` and `copyFileSync(src, dest)` READ
+ * their first argument, and copying bundled data OUT of the skill dir is
+ * legitimate. Flagging the whole argument list would reintroduce the false
+ * positive one level down.
+ */
+const WRITE_TARGET_ARG = new Map([
+  ['writeFileSync', [0]], ['writeFile', [0]],
+  ['appendFileSync', [0]], ['appendFile', [0]],
+  ['mkdirSync', [0]], ['mkdir', [0]],
+  ['rmSync', [0]], ['rm', [0]],
+  ['rmdirSync', [0]], ['rmdir', [0]],
+  ['unlinkSync', [0]], ['unlink', [0]],
+  ['truncateSync', [0]], ['truncate', [0]],
+  ['chmodSync', [0]], ['chmod', [0]],
+  ['chownSync', [0]], ['chown', [0]],
+  ['utimesSync', [0]], ['utimes', [0]],
+  ['mkdtempSync', [0]], ['mkdtemp', [0]],
+  ['createWriteStream', [0]],
+  // source, DESTINATION — only the destination is written.
+  ['cpSync', [1]], ['cp', [1]],
+  ['copyFileSync', [1]], ['copyFile', [1]],
+  ['renameSync', [1]], ['rename', [1]],
+  ['linkSync', [1]], ['link', [1]],
+  ['symlinkSync', [1]], ['symlink', [1]],
 ]);
 
 /**
- * Does this string literal name a file that would be WRITTEN?
- *
- * 🔴 The old guard asked a much narrower question — "is this literal one of the
- * seven names in STATE_FILES?" — which switched the guard OFF exactly when it
- * was needed: the moment someone adds a state file and forgets to register it,
- * the guard stops looking for it. So the class is "a mutable-looking data file",
- * with the read-only exceptions enumerated.
+ * `openSync`/`open` are read-OR-write depending on the flags, so they are
+ * decided by the mode argument rather than by the name. A `'r'` open of a
+ * bundled file is a read like any other; anything with `w`, `a` or `+` is a
+ * write.
  */
-export function looksLikeStateFile(literal) {
-  if (!literal || literal.includes('${')) return false;
-  const name = literal.split('/').filter(Boolean).pop() || '';
-  if (!name || name === '.' || name === '..') return false;
-  if (READONLY_BUNDLED.has(name)) return false;
-  if (STATE_NAMES.has(name)) return true;
-  if (name.startsWith('.') && name.length > 1 && !name.slice(1).includes('.')) return true;
-  const dot = name.lastIndexOf('.');
-  if (dot <= 0) return false;
-  return WRITABLE_EXT.has(name.slice(dot).toLowerCase());
+const AMBIGUOUS_OPEN = new Set(['openSync', 'open']);
+const WRITE_FLAG = /^[wa]|\+/;
+
+const IDENTIFIER = /(?<![\w$.])([A-Za-z_$][\w$]*)/g;
+
+/** The balanced `(...)` beginning at `open` (an index pointing at the paren). */
+function argSpan(bare, open) {
+  let depth = 0;
+  for (let i = open; i < bare.length; i++) {
+    const c = bare[i];
+    if (c === '(' || c === '[' || c === '{') depth++;
+    else if (c === ')' || c === ']' || c === '}') {
+      depth--;
+      if (depth === 0) return { start: open + 1, end: i };
+    }
+  }
+  return null;
 }
 
-// How far either side of a location token a filename literal still counts as
-// "the same expression". Bounded, and additionally cut at the nearest statement
-// terminator, so a state filename three statements away is not attributed here.
-const WINDOW = 400;
+/** Split an argument list at TOP-LEVEL commas: [{start, end}, …]. */
+function splitArgs(bare, span) {
+  const out = [];
+  let depth = 0;
+  let from = span.start;
+  for (let i = span.start; i < span.end; i++) {
+    const c = bare[i];
+    if (c === '(' || c === '[' || c === '{') depth++;
+    else if (c === ')' || c === ']' || c === '}') depth--;
+    else if (c === ',' && depth === 0) {
+      out.push({ start: from, end: i });
+      from = i + 1;
+    }
+  }
+  out.push({ start: from, end: span.end });
+  return out;
+}
+
+/** Does a location token occur inside [start, end)? */
+function locationTokenIn(bare, start, end) {
+  LOCATION_TOKEN.lastIndex = 0;
+  let m;
+  while ((m = LOCATION_TOKEN.exec(bare)) !== null) {
+    if (m.index >= start && m.index < end) return m[1];
+  }
+  return null;
+}
 
 /**
- * Every place `src` derives a writable path from the module's own location.
+ * Every place `src` derives a path from the module's own location and then
+ * WRITES to it.
  *
  * Structural, not spelled:
  *   * comments are BLANKED first, so prose about the hazard is not a hit and,
  *     more importantly, code cannot be hidden from the guard by commenting the
  *     surrounding lines;
  *   * string CONTENTS are blanked for the token scan, so a bait string in a
- *     test fixture is not code;
- *   * the filename may appear BEFORE or AFTER the token, on any line, in any
- *     quote style — `new URL('x.json', import.meta.url)` and a four-line
- *     `join(\n __dirname,\n 'x.json'\n)` are the same finding.
+ *     fixture is not code;
+ *   * the shape is irrelevant — `writeFileSync(new URL('x', import.meta.url))`,
+ *     a four-line `join(\n __dirname,\n 'x'\n)`, and a `const p = …` bound one
+ *     statement earlier and written LATER are all the same finding;
+ *   * no filename is required at all: `writeFileSync(join(__dirname, name))`
+ *     with a computed `name` is the same EROFS, and the literal-based predicate
+ *     could not see it.
  */
 export function findOpenCodedStatePaths(src) {
   const noComments = blankComments(src);
   const bare = blankStrings(noComments);
   const literals = stringLiterals(noComments);
-  const hits = [];
+  const hits = new Map(); // dedup by offset
+
+  // The path a location token is BOUND to, if any: `const p = join(__dirname,
+  // 'x')` writes the hazard into `p`, and the write happens on another line.
+  // Nearest preceding declaration/assignment within the same statement.
+  //
+  // Deliberately NOT scope-aware — this is a scanner, not a parser. Binding
+  // names are file-global here, so a `p` derived from __dirname in one function
+  // and a DIFFERENT `p` written in another is reported. That over-approximates
+  // in the safe direction (a false positive is a loud question about a name
+  // collision; a false negative is the EROFS this file exists to prevent), and
+  // the negative-control table is what keeps the over-approximation honest.
+  const boundNames = new Map(); // name -> {token, literal}
   LOCATION_TOKEN.lastIndex = 0;
+  let t;
+  while ((t = LOCATION_TOKEN.exec(bare)) !== null) {
+    const cut = bare.lastIndexOf(';', t.index);
+    const stmtStart = cut === -1 ? 0 : cut + 1;
+    const decl = /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=|(?:^|\n)\s*([A-Za-z_$][\w$]*)\s*=[^=]/g;
+    const head = bare.slice(stmtStart, t.index);
+    let d;
+    let name = null;
+    while ((d = decl.exec(head)) !== null) name = d[1] || d[2];
+    if (!name) continue;
+    const stmtEnd = bare.indexOf(';', t.index);
+    const lit = literals.find(
+      (l) => l.start >= stmtStart && (stmtEnd === -1 || l.end <= stmtEnd) && l.start > t.index - 400);
+    boundNames.set(name, { token: t[1], literal: lit ? lit.value : null });
+  }
+
+  const CALL = /(?<![\w$])([A-Za-z_$][\w$]*)\s*\(/g;
   let m;
-  while ((m = LOCATION_TOKEN.exec(bare)) !== null) {
-    const at = m.index;
-    const lo = Math.max(0, at - WINDOW);
-    const hi = Math.min(bare.length, at + WINDOW);
-    const leftCut = bare.lastIndexOf(';', at);
-    const rightCut = bare.indexOf(';', at);
-    const from = leftCut >= lo ? leftCut + 1 : lo;
-    const to = rightCut !== -1 && rightCut <= hi ? rightCut : hi;
-    for (const lit of literals) {
-      if (lit.start < from || lit.end > to) continue;
-      if (!looksLikeStateFile(lit.value)) continue;
-      hits.push(`${m[1]} + '${lit.value}'`);
+  while ((m = CALL.exec(bare)) !== null) {
+    const call = m[1];
+    const isOpen = AMBIGUOUS_OPEN.has(call);
+    if (!WRITE_TARGET_ARG.has(call) && !isOpen) continue;
+    const span = argSpan(bare, m.index + m[0].length - 1);
+    if (!span) continue;
+    const args = splitArgs(bare, span);
+
+    if (isOpen) {
+      const flags = literals.filter((l) => l.start >= span.start && l.end <= span.end);
+      if (!flags.some((l) => WRITE_FLAG.test(l.value))) continue;
+    }
+    const targets = isOpen ? [0] : WRITE_TARGET_ARG.get(call);
+
+    for (const idx of targets) {
+      const arg = args[idx];
+      if (!arg) continue;
+
+      // (a) the derivation is written INLINE in the target position.
+      const token = locationTokenIn(bare, arg.start, arg.end);
+      if (token) {
+        const lit = literals
+          .filter((l) => l.start >= arg.start && l.end <= arg.end)
+          .map((l) => l.value)
+          .filter((v) => v && v !== '..' && v !== '.')
+          .pop();
+        hits.set(arg.start, `${token} + '${lit ?? '<computed>'}'  ->  ${call}()`);
+        continue;
+      }
+
+      // (b) the derivation was BOUND earlier and only the name appears here.
+      IDENTIFIER.lastIndex = 0;
+      let id;
+      while ((id = IDENTIFIER.exec(bare.slice(arg.start, arg.end))) !== null) {
+        const bound = boundNames.get(id[1]);
+        if (!bound) continue;
+        hits.set(arg.start, `${bound.token} + '${bound.literal ?? '<computed>'}' (via \`${id[1]}\`)  ->  ${call}()`);
+        break;
+      }
     }
   }
-  return hits;
+  return [...hits.values()];
 }
 
 // lib/paths.mjs is exempt BY DESIGN: it is the one place allowed to name the
@@ -553,22 +720,63 @@ const CONSUMERS = [
  * scan third-party code this guard has no authority over, and would blow the
  * "no offenders" claim on the first unrelated match.
  */
-function allModules() {
+const MODULE_EXT = /\.(mjs|cjs|js)$/;
+
+function allModules(root = SKILL) {
   const out = [];
   const walk = (dir) => {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
       if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
       const abs = join(dir, entry.name);
       if (entry.isDirectory()) { walk(abs); continue; }
-      if (!/\.(mjs|cjs|js)$/.test(entry.name)) continue;
-      const rel = abs.slice(SKILL.length + 1);
+      if (!MODULE_EXT.test(entry.name)) continue;
+      const rel = abs.slice(root.length + 1);
       if (rel.startsWith('test/') || rel === 'lib/paths.mjs') continue;
       out.push(rel);
     }
   };
-  walk(SKILL);
+  walk(root);
   return out;
 }
+
+// The `.js`/`.cjs` widening was INERT: the skill has 31 .mjs and zero .js/.cjs,
+// so narrowing the pattern back to `.mjs` cost nothing and nothing went red.
+// A fixture tree makes the extension set an asserted property rather than a
+// hope — and does it BEHAVIOURALLY, through the walk, not by matching the regex
+// against a list of names.
+test('SEAM: the module walk covers .mjs, .js AND .cjs — and only those', () => {
+  const root = mkdtempSync(join(SCRATCH, 'walk-'));
+  const put = (rel, body = '// fixture\n') => {
+    const abs = join(root, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, body);
+  };
+  put('a.mjs'); put('lib/b.js'); put('api/c.cjs');
+  put('d.md'); put('e.json'); put('f.txt'); put('g.mjs.bak');
+  put('test/should-be-skipped.mjs');
+  put('node_modules/pkg/vendored.js');
+  put('.hidden/ignored.mjs');
+
+  const got = allModules(root).sort();
+  assert.deepEqual(got, ['a.mjs', 'api/c.cjs', 'lib/b.js'],
+    `the walk collected ${JSON.stringify(got)}. It must see every extension a module can ` +
+      'arrive in — package.json has no "type" field, so a .cjs is the natural way to write ' +
+      'a CommonJS helper here and a .js is legal too — and must keep skipping test/, ' +
+      'node_modules and dot-dirs.');
+});
+
+test('SEAM: the walk finds a .cjs offender the .mjs-only walk would miss', () => {
+  // Reachability for the widening: an offender that exists ONLY in a .cjs file.
+  const root = mkdtempSync(join(SCRATCH, 'walk-cjs-'));
+  writeFileSync(join(root, 'helper.cjs'),
+    "const { writeFileSync } = require('fs');\nwriteFileSync(join(__dirname, 'sessions.json'), d);\n");
+  const offenders = allModules(root).flatMap(
+    (rel) => findOpenCodedStatePaths(readFileSync(join(root, rel), 'utf8')));
+  assert.equal(offenders.length, 1,
+    'a state write open-coded in a .cjs module was invisible to the walk, so the guard\'s ' +
+      'answer to "does any module open-code a state path?" excludes every extension the ' +
+      'answer could arrive in but one');
+});
 
 test('SEAM: no module derives a state path from the skill dir', () => {
   const modules = allModules();
@@ -585,8 +793,9 @@ test('SEAM: no module derives a state path from the skill dir', () => {
     }
   }
   assert.ok(offenders.length === 0,
-    'a module still resolves a state path from the skill dir (it will EROFS once deployed ' +
-      `read-only) — import the accessor from lib/paths.mjs instead:\n        ${offenders.join('\n        ')}`);
+    'a module WRITES to a path it derived from the skill dir. That is an EROFS once the ' +
+      'skill is deployed read-only (home-manager puts it behind /nix/store symlinks) — ' +
+      `import the accessor from lib/paths.mjs instead:\n        ${offenders.join('\n        ')}`);
 });
 
 // The walk is the guard's eyes: pin that it sees the WHOLE tree, not just the
@@ -619,47 +828,89 @@ test('SEAM: every listed consumer still exists', () => {
 // deleted, which is the real way a guard dies).
 
 const MUST_FIRE = [
-  ['the one-line join form (the only shape the old regex caught)',
-    "const p = join(__dirname, 'accounts.json');"],
+  ['the one-line join form, written',
+    "writeFileSync(join(__dirname, 'accounts.json'), data);"],
   ['new URL(name, import.meta.url) — the skill\'s OWN idiom, and the filename comes FIRST',
-    "const p = new URL('accounts.json', import.meta.url);"],
+    "writeFileSync(new URL('accounts.json', import.meta.url), data);"],
   ['fileURLToPath(new URL(...)) — same, one wrapper deeper',
-    "const p = fileURLToPath(new URL('watchers.json', import.meta.url));"],
+    "writeFileSync(fileURLToPath(new URL('watchers.json', import.meta.url)), data);"],
   ['a MULTI-LINE join — the old regex stopped at the newline',
-    "const p = join(\n  __dirname,\n  '..',\n  'webhooks.jsonl'\n);"],
-  ['a state file that is NOT in STATE_FILES — the old regex only knew the seven registered names',
-    "const p = join(__dirname, 'sessions.json');"],
+    "appendFileSync(join(\n  __dirname,\n  '..',\n  'webhooks.jsonl'\n), line);"],
+  ['a state file that is NOT in STATE_FILES — no registry is consulted any more',
+    "writeFileSync(join(__dirname, 'sessions.json'), data);"],
   ['a dotfile the registry does not know either',
-    "const p = join(__dirname, '.credentials');"],
+    "writeFileSync(join(__dirname, '.credentials'), token);"],
   ['double quotes',
-    'const p = join(__dirname, "accounts.json");'],
+    'writeFileSync(join(__dirname, "accounts.json"), data);'],
   ['SKILL_DIR as the base',
-    "const p = join(SKILL_DIR, 'last-seen.txt');"],
+    "writeFileSync(join(SKILL_DIR, 'last-seen.txt'), ts);"],
   ['import.meta.dirname',
-    "const p = join(import.meta.dirname, 'watchers.json');"],
-  ['a nested state dir',
-    "const p = join(__dirname, '.cache', 'jwt-cache-default.json');"],
+    "writeFileSync(join(import.meta.dirname, 'watchers.json'), data);"],
+  ['a nested state dir, created rather than written',
+    "mkdirSync(join(__dirname, '.cache'), { recursive: true });"],
+  // ── shapes the literal-and-extension predicate could NOT see ──
+  ['🔴 INDIRECT: bound one statement earlier, written later',
+    "const p = join(__dirname, 'watchers.json');\nappendFileSync(p, line);"],
+  ['🔴 INDIRECT through an accessor function',
+    "const logFile = () => join(__dirname, 'webhooks.jsonl');\nappendFileSync(logFile(), line);"],
+  ['🔴 a COMPUTED filename — no literal for a filename check to match',
+    'writeFileSync(join(__dirname, name), data);'],
+  ['🔴 WRITING the manifest back — the old READONLY_BUNDLED exemption made this invisible',
+    "writeFileSync(join(__dirname, '..', 'package.json'), JSON.stringify(pkg));"],
+  ['🔴 a .md file — the old WRITABLE_EXT list did not consider one writable',
+    "writeFileSync(join(__dirname, '..', 'reference', 'generated.md'), body);"],
+  ['🔴 the DESTINATION of a copy',
+    "cpSync(tmpDir, join(__dirname, '.cache'), { recursive: true });"],
+  ['🔴 chmod of a skill-dir path',
+    "chmodSync(join(__dirname, 'accounts.json'), 0o600);"],
+  ['🔴 openSync with a WRITE flag',
+    "const fd = openSync(join(__dirname, 'webhooks.jsonl'), 'a');"],
+  ['🔴 a write stream',
+    "const out = createWriteStream(join(__dirname, 'webhooks.jsonl'));"],
+  ['🔴 deletion is a write too',
+    "rmSync(join(__dirname, '.cache'), { recursive: true, force: true });"],
 ];
 
+// 🔴 CALIBRATED TO THE CLASS, NOT TO AN EXEMPTION LIST. The first four entries
+// are the verified false positives the previous scanner produced: each is a
+// plain READ of a shipped file, and the message it printed for them ("it will
+// EROFS once deployed read-only") was false. None of them is exempt by name any
+// more — they are quiet because nothing writes.
 const MUST_NOT_FIRE = [
+  ['READ: bundled data next to the module',
+    "const fields = JSON.parse(readFileSync(join(__dirname, '..', 'data', 'custom-fields.json'), 'utf8'));"],
+  ['READ: a bundled schema with a "writable" extension',
+    "const schema = readFileSync(join(__dirname, 'schema.yaml'), 'utf8');"],
+  ['READ: the skill\'s own idiom, new URL(..., import.meta.url)',
+    "const prompt = readFileSync(new URL('prompt.txt', import.meta.url), 'utf8');"],
+  ['READ: a bundled dotfile',
+    "const ignore = readFileSync(join(__dirname, '..', '.gitignore'), 'utf8');"],
+  ['READ: the manifest (no longer exempt BY NAME — exempt because it is a read)',
+    "const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));"],
+  ['READ: a bundled reference doc',
+    "const help = readFileSync(join(__dirname, '..', 'reference', 'setup.md'), 'utf8');"],
+  ['READ: listing a bundled directory',
+    "const docs = readdirSync(join(__dirname, '..', 'reference'));"],
+  ['READ: copying bundled data OUT of the skill dir — the SOURCE argument',
+    "cpSync(join(__dirname, '..', 'templates'), outDir, { recursive: true });"],
+  ['READ: openSync with a read flag',
+    "const fd = openSync(join(__dirname, 'schema.yaml'), 'r');"],
   ['the __dirname preamble every module writes',
     "const __dirname = dirname(fileURLToPath(import.meta.url));"],
   ['the run-as-main guard (this is lib/jwt.mjs:338 verbatim)',
     "const isMain = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));"],
-  ['reading a BUNDLED read-only doc out of the skill dir — legitimate',
-    "const help = readFileSync(join(__dirname, '..', 'reference', 'setup.md'), 'utf8');"],
-  ['reading the skill\'s own manifest',
-    "const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));"],
   ['deriving the skill dir itself (lib/paths.mjs:43 verbatim)',
     "export const SKILL_DIR = resolve(__dirname, '..');"],
-  ['a state filename with NO location token anywhere near it',
-    "const p = statePath('accounts.json');"],
-  ['a location token and a state name in DIFFERENT statements',
-    "const d = dirname(fileURLToPath(import.meta.url));\nconst p = statePath('accounts.json');"],
+  ['the CORRECT code: a write through the accessor, with a location token nearby',
+    "const __dirname = dirname(fileURLToPath(import.meta.url));\nwriteFileSync(accountsPath(), data);"],
+  ['a write to a path derived from the STATE dir, not the module',
+    "writeFileSync(join(stateBaseDir(), 'accounts.json'), data);"],
+  ['a scratch dir under tmpdir()',
+    "const dir = mkdtempSync(join(tmpdir(), 'clickup-'));\nwriteFileSync(join(dir, 'accounts.json'), data);"],
   ['the hazard described in a COMMENT — prose is not code',
-    "// never write join(__dirname, 'accounts.json') — use the accessor\nconst p = accountsPath();"],
+    "// never write writeFileSync(join(__dirname, 'accounts.json'), d) — use the accessor\nconst p = accountsPath();"],
   ['the hazard commented OUT — still not code',
-    "/* const p = join(__dirname, 'accounts.json'); */\nconst p = accountsPath();"],
+    "/* writeFileSync(join(__dirname, 'accounts.json'), d); */\nconst p = accountsPath();"],
   ['an import specifier that merely ends in .js',
     "import x from './helper.js';\nconst d = dirname(fileURLToPath(import.meta.url));"],
 ];
@@ -685,12 +936,72 @@ test('NEGATIVE CONTROL: the seam scanner stays quiet on legitimate uses', () => 
 test('the scanner is exercised against both halves of the control pair', () => {
   // A guard on the guard: a refactor that emptied either table would leave both
   // control tests passing vacuously.
-  assert.ok(MUST_FIRE.length >= 10,
+  assert.ok(MUST_FIRE.length >= 20,
     `only ${MUST_FIRE.length} positive control(s) — the shapes this scanner is trusted ` +
       'to catch are exactly the ones listed here');
-  assert.ok(MUST_NOT_FIRE.length >= 8,
+  assert.ok(MUST_NOT_FIRE.length >= 18,
     `only ${MUST_NOT_FIRE.length} negative control(s) — false positives are what get a ` +
       'guard deleted, so they need as much pinning as the true ones');
+});
+
+// ── READ vs WRITE, stated as its own property and proved BOTH ways ────────
+//
+// The control tables above would still be satisfied by a scanner that fired on
+// everything containing `writeFileSync` somewhere. These two say the distinction
+// itself is what is being measured: the SAME path expression, in the same
+// module, read and then written.
+
+const READ_ONLY_SHAPES = [
+  ["join(__dirname, '..', 'data', 'custom-fields.json')", 'readFileSync(EXPR, \'utf8\')'],
+  ["join(__dirname, 'schema.yaml')", 'readFileSync(EXPR, \'utf8\')'],
+  ["new URL('prompt.txt', import.meta.url)", 'readFileSync(EXPR, \'utf8\')'],
+  ["join(__dirname, '..', '.gitignore')", 'readFileSync(EXPR, \'utf8\')'],
+];
+
+test('🔴 READ vs WRITE: the four bundled-read shapes are SILENT', () => {
+  const wrong = [];
+  for (const [expr, template] of READ_ONLY_SHAPES) {
+    const src = `const x = ${template.replace('EXPR', expr)};`;
+    const hits = findOpenCodedStatePaths(src);
+    if (hits.length) wrong.push(`${expr}  ->  ${hits.join(', ')}`);
+  }
+  assert.equal(wrong.length, 0,
+    'the seam scanner flagged a plain READ of a file shipped inside the skill dir. Reading ' +
+      'bundled data off __dirname is legal on a read-only deploy, and the message the guard ' +
+      'prints ("it will EROFS once deployed read-only") is FALSE for a read. A guard that ' +
+      `cries wolf gets deleted:\n        ${wrong.join('\n        ')}`);
+});
+
+test('🔴 READ vs WRITE: the SAME expressions WRITTEN all fire', () => {
+  // The other half, over the identical expressions: this is what proves the
+  // scanner is measuring the write context and not just the four templates.
+  const missed = [];
+  for (const [expr] of READ_ONLY_SHAPES) {
+    const src = `writeFileSync(${expr}, data);`;
+    if (findOpenCodedStatePaths(src).length === 0) missed.push(expr);
+  }
+  assert.equal(missed.length, 0,
+    'a genuine open-coded state WRITE off the module\'s own location did NOT fire — the ' +
+      'read/write check was widened into a hole. These EROFS on a read-only deploy:\n        ' +
+      missed.join('\n        '));
+});
+
+test('🔴 READ vs WRITE: a genuine write via EACH location idiom fires, direct and indirect', () => {
+  const cases = [
+    ['__dirname + join, inline',
+      "writeFileSync(join(__dirname, 'sessions.json'), data);"],
+    ['__dirname + join, bound then written',
+      "const p = join(__dirname, 'sessions.json');\nwriteFileSync(p, data);"],
+    ['new URL(..., import.meta.url), inline',
+      "writeFileSync(new URL('sessions.json', import.meta.url), data);"],
+    ['new URL(..., import.meta.url), bound then written',
+      "const p = new URL('sessions.json', import.meta.url);\nwriteFileSync(p, data);"],
+  ];
+  const missed = cases.filter(([, src]) => findOpenCodedStatePaths(src).length === 0)
+    .map(([label]) => label);
+  assert.equal(missed.length, 0,
+    'the scanner missed a genuine state WRITE derived from the module\'s own location — ' +
+      `this is the property the whole file exists for:\n        ${missed.join('\n        ')}`);
 });
 
 test('SEAM: the consumer list covers every module that imports lib/paths.mjs', () => {

--- a/claude/skills/clickup/test/state-paths.test.mjs
+++ b/claude/skills/clickup/test/state-paths.test.mjs
@@ -482,24 +482,35 @@ const LOCATION_TOKEN =
  * 🔴 THE SCANNER ASKS ABOUT A **WRITE**, NOT ABOUT A FILENAME.
  *
  * What was here before never distinguished a READ from a WRITE: any literal
- * with a mutable-looking extension near a location token was an offender. Four
- * verified false positives, each a plain `readFileSync` of a SHIPPED file that
- * is entirely legal on a read-only deploy:
+ * with a mutable-looking extension near a location token was an offender, under
+ * a message ("it will EROFS once deployed read-only") that is FALSE for a read.
+ * The escape hatch was an enumerated `READONLY_BUNDLED` holding exactly
+ * `package.json` and `package-lock.json`, and the negative-control table was
+ * calibrated to THAT LIST rather than to the class: its two read-only cases
+ * were the two names that happened to be exempt. A guard that cries wolf gets
+ * deleted, and the exemption list would have had to grow by one entry per
+ * bundled data file forever.
+ *
+ * 🔴 HOW MUCH OF THAT IS OBSERVED, PRECISELY. The shapes below are CONSTRUCTED
+ * — they are what the old predicate does when a bundled read is written in one
+ * of them, not defects it reported in this repo:
  *
  *     join(__dirname, '..', 'data', 'custom-fields.json')
  *     join(__dirname, 'schema.yaml')
  *     new URL('prompt.txt', import.meta.url)
  *     join(__dirname, '..', '.gitignore')
  *
- * and the failure message it printed for them — "it will EROFS once deployed
- * read-only" — is simply FALSE for a read. The escape hatch was an enumerated
- * `READONLY_BUNDLED` holding exactly `package.json` and `package-lock.json`,
- * and the negative-control table was calibrated to THAT LIST rather than to the
- * class: its two read-only cases were the two names that happened to be exempt.
- * A guard that cries wolf gets deleted, and the exemption list would have had
- * to grow by one entry per bundled data file forever.
+ * None of those four files is read by any module in the skill; repo-wide they
+ * occur only as fixture strings in this file. Run over the CURRENT 26 modules,
+ * `origin/main`'s scanner reports **0 offenders — identical to this one**, with
+ * both firing on a planted `writeFileSync(join(__dirname, 'watchers.json'), d)`
+ * (so neither zero is a dead scanner). This rewrite therefore changes nothing
+ * observable today: it is FORWARD-LOOKING hardening against the first bundled
+ * data file somebody reads off `__dirname`, plus the indirect write shapes the
+ * literal predicate structurally cannot see. Calling constructed examples
+ * "verified false positives" is how a claim like that stops being checkable.
  *
- * So the question is now the one the message actually makes: does a path
+ * The question it asks now is the one the message actually makes: does a path
  * derived from the module's own location end up in the TARGET position of a
  * call that WRITES? That needs no filename registry, no extension list and no
  * exemptions — a write into the skill dir is an EROFS whatever the file is
@@ -540,6 +551,18 @@ const WRITE_TARGET_ARG = new Map([
  * decided by the mode argument rather than by the name. A `'r'` open of a
  * bundled file is a read like any other; anything with `w`, `a` or `+` is a
  * write.
+ *
+ * 🔴 THE FLAG IS ARGUMENT 1 ONWARD, NEVER ARGUMENT 0. `WRITE_FLAG` used to be
+ * tested against every literal in the whole call, and argument 0 is the PATH:
+ * `openSync(join(__dirname, 'accounts.json'), 'r')` fired because the FILENAME
+ * begins with an `a`, as did `webhooks.jsonl` (w) and `c++notes.txt` (+). The
+ * shipped negative control used `schema.yaml` — an `s`, the one initial that
+ * cannot trip it — so the table was calibrated AROUND the bug and stayed green.
+ * The flags now come from the argument spans after the path only.
+ *
+ * A non-literal flags argument (`openSync(p, mode)`) has no literal to test and
+ * so does not fire. That is a deliberate false negative: it is unreadable to a
+ * scanner, and firing on it would flag every read too.
  */
 const AMBIGUOUS_OPEN = new Set(['openSync', 'open']);
 const WRITE_FLAG = /^[wa]|\+/;
@@ -597,17 +620,35 @@ function locationTokenIn(bare, start, end) {
  *     more importantly, code cannot be hidden from the guard by commenting the
  *     surrounding lines;
  *   * string CONTENTS are blanked for the token scan, so a bait string in a
- *     fixture is not code;
- *   * the shape is irrelevant — `writeFileSync(new URL('x', import.meta.url))`,
- *     a four-line `join(\n __dirname,\n 'x'\n)`, and a `const p = …` bound one
- *     statement earlier and written LATER are all the same finding;
+ *     fixture is not code — but a template's `${ … }` is KEPT, because that is
+ *     code (`` `${__dirname}/accounts.json` `` is listen.mjs's own idiom);
+ *   * the WRITE SHAPE is irrelevant — `writeFileSync(new URL('x',
+ *     import.meta.url))`, a four-line `join(\n __dirname,\n 'x'\n)`, a template
+ *     literal, and a `const p = …` bound one statement earlier and written
+ *     LATER are all the same finding;
  *   * no filename is required at all: `writeFileSync(join(__dirname, name))`
  *     with a computed `name` is the same EROFS, and the literal-based predicate
  *     could not see it.
+ *
+ * 🔴 WHAT IT DOES **NOT** SEE — measured, not assumed. Each of these is silent,
+ * and none is a regression (the predicate this replaced saw none of them
+ * either); they are the honest edge of "the shape is irrelevant":
+ *
+ *   * a TWO-HOP binding — `const a = join(__dirname,'x'); const b = a;` — the
+ *     binding table is one level deep, by design;
+ *   * an ALIASED import: `import { writeFileSync as wfs }` … `wfs(p, d)`. The
+ *     call names are matched literally, so a rename escapes;
+ *   * a path handed to a FUNCTION and written inside it — that needs dataflow,
+ *     not a scanner.
+ *
+ * The guard's job is this repo's own modules, where the inline and one-hop
+ * forms are what actually get written. Widen it when one of the above appears,
+ * and add the case to MUST_FIRE in the same commit.
  */
 export function findOpenCodedStatePaths(src) {
   const noComments = blankComments(src);
-  const bare = blankStrings(noComments);
+  // keepSubstitutions: `${__dirname}` is a location token in code, not text.
+  const bare = blankStrings(noComments, { keepSubstitutions: true });
   const literals = stringLiterals(noComments);
   const hits = new Map(); // dedup by offset
 
@@ -650,7 +691,11 @@ export function findOpenCodedStatePaths(src) {
     const args = splitArgs(bare, span);
 
     if (isOpen) {
-      const flags = literals.filter((l) => l.start >= span.start && l.end <= span.end);
+      // Arguments 1+ only. Argument 0 is the path, and reading it as a flag
+      // makes the BASENAME decide — see WRITE_FLAG.
+      const flagArgs = args.slice(1);
+      const flags = literals.filter(
+        (l) => flagArgs.some((a) => l.start >= a.start && l.end <= a.end));
       if (!flags.some((l) => WRITE_FLAG.test(l.value))) continue;
     }
     const targets = isOpen ? [0] : WRITE_TARGET_ARG.get(call);
@@ -865,17 +910,34 @@ const MUST_FIRE = [
     "chmodSync(join(__dirname, 'accounts.json'), 0o600);"],
   ['🔴 openSync with a WRITE flag',
     "const fd = openSync(join(__dirname, 'webhooks.jsonl'), 'a');"],
+  ['🔴 openSync WRITE of a name that could never be mistaken for a flag',
+    "const fd = openSync(join(__dirname, 'schema.yaml'), 'w');"],
+  ['🔴 openSync r+ — read-WRITE',
+    "const fd = openSync(join(__dirname, 'schema.yaml'), 'r+');"],
+  ['🔴 a TEMPLATE LITERAL path — the idiom listen.mjs itself writes',
+    'writeFileSync(`${__dirname}/accounts.json`, data);'],
+  ['🔴 a template literal bound one statement earlier',
+    'const p = `${__dirname}/watchers.json`;\nappendFileSync(p, line);'],
   ['🔴 a write stream',
     "const out = createWriteStream(join(__dirname, 'webhooks.jsonl'));"],
   ['🔴 deletion is a write too',
     "rmSync(join(__dirname, '.cache'), { recursive: true, force: true });"],
 ];
 
-// 🔴 CALIBRATED TO THE CLASS, NOT TO AN EXEMPTION LIST. The first four entries
-// are the verified false positives the previous scanner produced: each is a
-// plain READ of a shipped file, and the message it printed for them ("it will
-// EROFS once deployed read-only") was false. None of them is exempt by name any
-// more — they are quiet because nothing writes.
+// 🔴 CALIBRATED TO THE CLASS, NOT TO AN EXEMPTION LIST — and not to the bug
+// either. The first four entries are CONSTRUCTED bundled reads, not defects
+// anything reported in this repo (none of those four files is read by any
+// module here; over the real tree both scanners find zero). They are here
+// because each is a plain READ of a shipped file, and the message the old
+// predicate printed for that shape ("it will EROFS once deployed read-only")
+// was false. None of them is exempt by name any more — they are quiet because
+// nothing writes.
+//
+// 🔴 The openSync read cases below are deliberately basenames that START with
+// `w` and `a` or CONTAIN `+`. The single shipped control was `schema.yaml`,
+// whose `s` is the one initial the flag pattern cannot match, so it passed while
+// `openSync(join(__dirname,'accounts.json'),'r')` fired on the FILENAME. A
+// control chosen to avoid the bug measures nothing.
 const MUST_NOT_FIRE = [
   ['READ: bundled data next to the module',
     "const fields = JSON.parse(readFileSync(join(__dirname, '..', 'data', 'custom-fields.json'), 'utf8'));"],
@@ -895,6 +957,14 @@ const MUST_NOT_FIRE = [
     "cpSync(join(__dirname, '..', 'templates'), outDir, { recursive: true });"],
   ['READ: openSync with a read flag',
     "const fd = openSync(join(__dirname, 'schema.yaml'), 'r');"],
+  ['READ: openSync of a file whose name STARTS WITH W (not a write flag)',
+    "const fd = openSync(join(__dirname, 'webhooks.jsonl'), 'r');"],
+  ['READ: openSync of a file whose name STARTS WITH A (not a write flag)',
+    "const fd = openSync(join(__dirname, 'accounts.json'), 'r');"],
+  ['READ: openSync of a file whose name CONTAINS + (not a write flag)',
+    "const fd = openSync(join(__dirname, 'c++notes.txt'), 'r');"],
+  ['READ: openSync with the flags omitted entirely (defaults to r)',
+    "const fd = openSync(join(__dirname, 'webhooks.jsonl'));"],
   ['the __dirname preamble every module writes',
     "const __dirname = dirname(fileURLToPath(import.meta.url));"],
   ['the run-as-main guard (this is lib/jwt.mjs:338 verbatim)',
@@ -936,12 +1006,57 @@ test('NEGATIVE CONTROL: the seam scanner stays quiet on legitimate uses', () => 
 test('the scanner is exercised against both halves of the control pair', () => {
   // A guard on the guard: a refactor that emptied either table would leave both
   // control tests passing vacuously.
-  assert.ok(MUST_FIRE.length >= 20,
+  assert.ok(MUST_FIRE.length >= 24,
     `only ${MUST_FIRE.length} positive control(s) — the shapes this scanner is trusted ` +
       'to catch are exactly the ones listed here');
-  assert.ok(MUST_NOT_FIRE.length >= 18,
+  assert.ok(MUST_NOT_FIRE.length >= 22,
     `only ${MUST_NOT_FIRE.length} negative control(s) — false positives are what get a ` +
       'guard deleted, so they need as much pinning as the true ones');
+});
+
+// ── openSync: the FLAGS decide, never the filename ────────────────────────
+//
+// Its own test rather than two more table rows, because the failure it pins is
+// specific and was invisible: the flag pattern was tested against every literal
+// in the call, so argument 0 — the PATH — voted. Both directions, over the SAME
+// basenames, is the only arrangement that can tell "reads the flags" apart from
+// "reads the name".
+
+const OPEN_FLAG_CASES = [
+  // basename,           flags,      must fire
+  ['webhooks.jsonl',     "'r'",      false],  // w-initial name, READ
+  ['accounts.json',      "'r'",      false],  // a-initial name, READ
+  ['c++notes.txt',       "'r'",      false],  // + in the name, READ
+  ['schema.yaml',        "'r'",      false],
+  ['webhooks.jsonl',     "'a'",      true],
+  ['accounts.json',      "'w'",      true],
+  ['schema.yaml',        "'w'",      true],   // innocuous name, WRITE
+  ['schema.yaml',        "'r+'",     true],   // read-write
+  ['schema.yaml',        "'wx'",     true],
+  ['webhooks.jsonl',     null,       false],  // flags omitted → defaults to 'r'
+];
+
+test('🔴 openSync is decided by its FLAGS argument, never by the filename', () => {
+  // Both directions have to be present, or this passes by having only one.
+  assert.ok(OPEN_FLAG_CASES.some(([, , fire]) => fire) && OPEN_FLAG_CASES.some(([, , fire]) => !fire),
+    'the openSync table lost one of its two directions');
+  assert.ok(OPEN_FLAG_CASES.filter(([name]) => /^[wa]|\+/.test(name)).length >= 3,
+    'the read cases no longer include basenames that the flag pattern itself would match ' +
+      '(w-initial, a-initial, +-containing) — that is the bug this test exists for');
+  const wrong = [];
+  for (const [name, flags, shouldFire] of OPEN_FLAG_CASES) {
+    const src = `const fd = openSync(join(__dirname, '${name}')${flags ? `, ${flags}` : ''});`;
+    const fired = findOpenCodedStatePaths(src).length > 0;
+    if (fired !== shouldFire) {
+      wrong.push(`openSync('${name}'${flags ? `, ${flags}` : ''}) ${fired ? 'FIRED' : 'was SILENT'}` +
+        ` — expected ${shouldFire ? 'a hit' : 'silence'}`);
+    }
+  }
+  assert.equal(wrong.length, 0,
+    'the openSync branch is not reading the flags argument. If the PATH argument votes, the ' +
+      'basename decides: a plain read of `accounts.json` reports an EROFS that will never ' +
+      'happen (and the only shipped control used an `s`-initial name, which cannot trip ' +
+      `it):\n        ${wrong.join('\n        ')}`);
 });
 
 // ── READ vs WRITE, stated as its own property and proved BOTH ways ────────
@@ -951,6 +1066,8 @@ test('the scanner is exercised against both halves of the control pair', () => {
 // itself is what is being measured: the SAME path expression, in the same
 // module, read and then written.
 
+// CONSTRUCTED shapes — no module in this skill reads any of these four files.
+// They are the bundled-read CLASS written four ways, not observed findings.
 const READ_ONLY_SHAPES = [
   ["join(__dirname, '..', 'data', 'custom-fields.json')", 'readFileSync(EXPR, \'utf8\')'],
   ["join(__dirname, 'schema.yaml')", 'readFileSync(EXPR, \'utf8\')'],

--- a/claude/skills/clickup/test/webhook-server.test.mjs
+++ b/claude/skills/clickup/test/webhook-server.test.mjs
@@ -39,6 +39,7 @@ import {
   safeEqualHex,
   signBody,
   headerValue,
+  headerLookup,
   authenticateDelivery,
   createWebhookServer,
   listenLoopback,
@@ -194,6 +195,19 @@ describe('authenticateDelivery', () => {
     assert.equal(r.accepted, true, `expected accepted, got reason=${r.reason}`);
   });
 
+  test('the header lookup is case-insensitive and array-aware', () => {
+    // node's http lowercases what it receives; webhook.site's stored-request
+    // API echoes whatever case the sender used, and returns values as ARRAYS.
+    // One helper for both callers of the one predicate — an exact-case bracket
+    // access on the catch-up side rejects every stored event, silently.
+    assert.equal(headerLookup({ 'x-signature': GOOD_SIG }, 'x-signature'), GOOD_SIG);
+    assert.equal(headerLookup({ 'X-Signature': GOOD_SIG }, 'x-signature'), GOOD_SIG);
+    assert.equal(headerLookup({ 'X-SIGNATURE': [GOOD_SIG] }, 'x-signature'), GOOD_SIG);
+    assert.equal(headerLookup({ 'content-type': 'application/json' }, 'x-signature'), undefined);
+    assert.equal(headerLookup(undefined, 'x-signature'), undefined);
+    assert.equal(headerLookup(null, 'x-signature'), undefined);
+  });
+
   test('POSITIVE + NEGATIVE control in one: the same body flips on the secret alone', () => {
     const good = authenticateDelivery(BODY, GOOD_SIG, lookupSecret);
     const bad = authenticateDelivery(BODY, GOOD_SIG, () => OTHER_SECRET);
@@ -243,10 +257,25 @@ async function withServer(fn, overrides = {}) {
 describe('the HTTP receiver', () => {
   test('🔴 binds 127.0.0.1, not every interface', async () => {
     await withServer(({ addr }) => {
-      assert.equal(addr.address, LOOPBACK_HOST,
+      // 🔴 The LITERAL, not the constant. `assert.equal(addr.address,
+      // LOOPBACK_HOST)` is SELF-REFERENTIAL: mutate LOOPBACK_HOST to '0.0.0.0'
+      // and the server binds every interface while the assertion still passes,
+      // because both sides moved together. Only listen-integration.test.mjs's
+      // literal killed that mutant, so the whole bind guard rested on one file
+      // — and would have gone vacuous, silently, the day that file was skipped.
+      assert.equal(addr.address, '127.0.0.1',
         `the receiver bound ${addr.address} — 0.0.0.0/:: makes a webhook sidecar ` +
           'reachable from the LAN and from nebula. It must bind loopback.');
     });
+  });
+
+  test('🔴 LOOPBACK_HOST is 127.0.0.1 — the constant everything else derives from', () => {
+    // Pinned separately from the bind so the two claims fail SEPARATELY: this
+    // one says what the constant is, the one above says what the server did.
+    assert.equal(LOOPBACK_HOST, '127.0.0.1',
+      `LOOPBACK_HOST is ${JSON.stringify(LOOPBACK_HOST)}. It is the bind address AND the ` +
+        'whcli forward target; anything but the loopback literal puts the receiver on the ' +
+        'LAN and the nebula address of whichever host runs it.');
   });
 
   test('🔴 GET does not disclose webhook_url', async () => {

--- a/scripts/run-node-tests.sh
+++ b/scripts/run-node-tests.sh
@@ -133,10 +133,12 @@ cd "$ROOT" || { echo "run-node-tests: cannot cd to ROOT=$ROOT" >&2; exit 2; }
 #   scripts/collector/browser-ext/tests  2 files    21 tests
 #
 # MEASURED 2026-08-13, same way:
-#   claude/skills/clickup/test           4 files    73 tests
-#   (was 2 files / 27 tests earlier the same day; the webhook listener had ZERO
-#   coverage, which is why four defects in it survived review — see
-#   claude/skills/clickup/test/{webhook-server,listen-integration}.test.mjs)
+#   claude/skills/clickup/test           5 files   107 tests
+#   (was 2 files / 27 tests earlier the same day, then 4 files / 73; the webhook
+#   listener had ZERO coverage, which is why four defects in it survived review —
+#   see claude/skills/clickup/test/{webhook-server,listen-integration}.test.mjs.
+#   The 73 -> 107 step is #444/#445: the webhook.site CATCH-UP path had no test
+#   either, and two mutations reinstating the original defect passed all 73.)
 #
 # Raise a floor when a suite grows. NEVER lower one to get green — that is the
 # move that turned the pytest global floor into less than half the real total.
@@ -153,11 +155,13 @@ SUITES=(
   # complete; state-paths: no state path resolves inside the read-only skill dir,
   # including a structural seam walk over every module in the tree;
   # webhook-server + listen-integration: the receiver rejects unsigned and forged
-  # deliveries, binds loopback, and discloses no capability URL). They lived in a
-  # standalone, UNCOMMITTED ~/.claude/skills/clickup/ and ran only when a human
-  # remembered — ungated by anything, on either host. 73 tests measured
-  # 2026-08-13, floor 70 = 73 - min(50, max(1, 73/20)).
-  "claude/skills/clickup/test|4|70"
+  # deliveries, binds loopback, and discloses no capability URL; catchup: the
+  # webhook.site catch-up path runs the SAME authentication predicate and its
+  # cursor cannot develop a permanent blind spot). They lived in a standalone,
+  # UNCOMMITTED ~/.claude/skills/clickup/ and ran only when a human remembered —
+  # ungated by anything, on either host. 107 tests measured 2026-08-13,
+  # floor 102 = 107 - min(50, max(1, 107/20)).
+  "claude/skills/clickup/test|5|102"
 )
 
 # --- discovery roots -----------------------------------------------------------

--- a/scripts/run-node-tests.sh
+++ b/scripts/run-node-tests.sh
@@ -133,12 +133,16 @@ cd "$ROOT" || { echo "run-node-tests: cannot cd to ROOT=$ROOT" >&2; exit 2; }
 #   scripts/collector/browser-ext/tests  2 files    21 tests
 #
 # MEASURED 2026-08-13, same way:
-#   claude/skills/clickup/test           5 files   107 tests
-#   (was 2 files / 27 tests earlier the same day, then 4 files / 73; the webhook
-#   listener had ZERO coverage, which is why four defects in it survived review —
-#   see claude/skills/clickup/test/{webhook-server,listen-integration}.test.mjs.
-#   The 73 -> 107 step is #444/#445: the webhook.site CATCH-UP path had no test
-#   either, and two mutations reinstating the original defect passed all 73.)
+#   claude/skills/clickup/test           6 files   154 tests
+#   (was 2 files / 27 tests earlier the same day, then 4 files / 73, then 107;
+#   the webhook listener had ZERO coverage, which is why four defects in it
+#   survived review — see claude/skills/clickup/test/{webhook-server,
+#   listen-integration}.test.mjs. The 73 -> 107 step is #444/#445: the
+#   webhook.site CATCH-UP path had no test either, and two mutations
+#   reinstating the original defect passed all 73. The 107 -> 154 step is that
+#   round's own audit: the cursor policy it shipped wedged permanently on one
+#   non-JSON stored request, and test/js-source.mjs — the substrate under both
+#   structural guards — cited controls in a file that did not exist.)
 #
 # Raise a floor when a suite grows. NEVER lower one to get green — that is the
 # move that turned the pytest global floor into less than half the real total.
@@ -151,17 +155,19 @@ SUITES=(
   # Ungated for the same reason. Small, but 21 tests reporting safety they never
   # measured is the same defect as 508 of them.
   "scripts/collector/browser-ext/tests|2|20"
-  # The clickup skill's four hermetic gates (help-coverage: showUsage() is
-  # complete; state-paths: no state path resolves inside the read-only skill dir,
+  # The clickup skill's hermetic gates (help-coverage: showUsage() is complete;
+  # state-paths: no state path resolves inside the read-only skill dir,
   # including a structural seam walk over every module in the tree;
   # webhook-server + listen-integration: the receiver rejects unsigned and forged
   # deliveries, binds loopback, and discloses no capability URL; catchup: the
   # webhook.site catch-up path runs the SAME authentication predicate and its
-  # cursor cannot develop a permanent blind spot). They lived in a standalone,
-  # UNCOMMITTED ~/.claude/skills/clickup/ and ran only when a human remembered —
-  # ungated by anything, on either host. 107 tests measured 2026-08-13,
-  # floor 102 = 107 - min(50, max(1, 107/20)).
-  "claude/skills/clickup/test|5|102"
+  # cursor neither develops a permanent blind spot nor wedges on one stored
+  # request; js-source: direct controls for the scanner both structural guards
+  # are built on). They lived in a standalone, UNCOMMITTED
+  # ~/.claude/skills/clickup/ and ran only when a human remembered — ungated by
+  # anything, on either host. 154 tests measured 2026-08-13,
+  # floor 147 = 154 - min(50, max(1, 154/20)).
+  "claude/skills/clickup/test|6|147"
 )
 
 # --- discovery roots -----------------------------------------------------------

--- a/scripts/tests/test_run_node_tests_suites.py
+++ b/scripts/tests/test_run_node_tests_suites.py
@@ -57,9 +57,7 @@ an INVARIANT GUARD -- label it as one, don't count it as regression coverage"):
 """
 from __future__ import annotations
 
-import os
 import re
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -78,10 +76,13 @@ FORMERLY_UNGATED = {
     # ~/.claude/skills/clickup/ on two hosts and ran only when a human typed it.
     # Measured 2026-08-13 once vendored into claude/skills/clickup/test: 27 at
     # first, then 73 once the webhook listener got the coverage whose absence is
-    # why four defects in it survived review. The number here is the CURRENT
-    # measurement, because the assertion below reads it as one (a floor is only
-    # meaningfully "not drifted" against what the suite actually collects).
-    "claude/skills/clickup/test": 73,
+    # why four defects in it survived review, then 107 once the webhook.site
+    # CATCH-UP path got the same treatment (#444/#445 — two mutations that
+    # reinstated the original defect passed all 73). The number here is the
+    # CURRENT measurement, because the assertion below reads it as one (a floor
+    # is only meaningfully "not drifted" against what the suite actually
+    # collects).
+    "claude/skills/clickup/test": 107,
 }
 
 
@@ -166,7 +167,7 @@ def _discovery_roots() -> list[str]:
     return roots
 
 
-def _discovered_dirs() -> set[str]:
+def _discovered_dirs(base: Path = REPO_ROOT) -> set[str]:
     """Every directory under a DISCOVERY_ROOT holding a .test.mjs file.
 
     Uses pathlib rather than shelling out to `find`: the `find` on this host's
@@ -178,11 +179,11 @@ def _discovered_dirs() -> set[str]:
     """
     out: set[str] = set()
     for root in _discovery_roots():
-        base = REPO_ROOT / root
-        if not base.is_dir():
+        start = base / root
+        if not start.is_dir():
             continue
-        for p in base.rglob("*.test.mjs"):
-            rel = p.relative_to(REPO_ROOT)
+        for p in start.rglob("*.test.mjs"):
+            rel = p.relative_to(base)
             # node_modules is excluded here for the same reason the runner
             # excludes it -- see the 🔴 block above DISCOVERED_DIRS. The two
             # implementations are independent ON PURPOSE (this one cross-checks
@@ -463,30 +464,33 @@ def test_dropping_a_discovery_root_is_loud(tmp_path):
 
 
 @pytest.fixture
-def vendored_test_file():
-    """A `*.test.mjs` inside a node_modules tree, as `npm ci` would leave it.
+def vendored_test_file(tmp_path):
+    """A synthetic ROOT holding the pinned suites plus one vendored test file.
 
-    Written under `claude/skills/clickup/node_modules/`, which is gitignored
-    (claude/skills/.gitignore), so even a failed teardown cannot make it
-    committable.
+    The runner takes a ROOT argument, so this needs no part of the developer's
+    real checkout. It used to write
+    ``claude/skills/clickup/node_modules/pytest-fixture-<pid>/test/`` INTO the
+    working tree -- gitignored and torn down in ``finally``, but a killed run
+    (^C, a timeout, an OOM) left the directory behind in whatever tree the
+    suite happened to run in, including a worktree someone was mid-commit in.
+    A test does not need write access to the repo it is testing.
+
+    The suite layout is derived from the runner's own SUITES list, so the
+    fixture cannot drift from it.
+
+    :returns: ``(root, vendored_file)``
     """
-    victim = (
-        REPO_ROOT
-        / "claude/skills/clickup/node_modules"
-        / f"pytest-fixture-{os.getpid()}"
-        / "test"
-    )
-    root = victim.parents[1]
-    created_root = not root.exists()
+    root = tmp_path / "fake-repo"
+    for suite in _pinned_suites():
+        d = root / suite
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "placeholder.test.mjs").write_text("// stands in for the real suite\n")
+
+    victim = root / "claude/skills/clickup/node_modules/some-package/test"
     victim.mkdir(parents=True, exist_ok=True)
     f = victim / "vendored.test.mjs"
     f.write_text("// a third-party package's own test file\n")
-    try:
-        yield f
-    finally:
-        shutil.rmtree(victim.parent, ignore_errors=True)
-        if created_root and root.exists() and not any(root.iterdir()):
-            root.rmdir()
+    return root, f
 
 
 def test_a_vendored_test_file_does_not_break_the_gate(vendored_test_file):
@@ -502,9 +506,10 @@ def test_a_vendored_test_file_does_not_break_the_gate(vendored_test_file):
     for a third-party file, produced by following the documented procedure.
     """
     _require_check_suites()
-    assert vendored_test_file.exists(), "fixture precondition: the vendored file exists"
+    root, vendored = vendored_test_file
+    assert vendored.exists(), "fixture precondition: the vendored file exists"
 
-    proc = _run([str(RUNNER), "--check-suites", str(REPO_ROOT)])
+    proc = _run([str(RUNNER), "--check-suites", str(root)])
     out = proc.stdout + proc.stderr
     assert proc.returncode == 0, (
         "a *.test.mjs inside node_modules made the runner FATAL:\n"
@@ -515,7 +520,7 @@ def test_a_vendored_test_file_does_not_break_the_gate(vendored_test_file):
     )
 
     # And the second, independent discovery implementation must agree.
-    assert not any("node_modules" in d for d in _discovered_dirs()), (
+    assert not any("node_modules" in d for d in _discovered_dirs(root)), (
         "this file's own discovery still walks node_modules, so it would report "
         "vendored suites the runner deliberately ignores"
     )
@@ -530,19 +535,40 @@ def test_the_vendored_fixture_is_actually_discoverable_without_the_exclusion(
     result would be true for the wrong reason and would hold with the exclusion
     removed. So: an UNFILTERED walk must find it.
     """
+    root, vendored = vendored_test_file
     unfiltered = {
-        str(p.parent.relative_to(REPO_ROOT))
-        for root in _discovery_roots()
-        if (REPO_ROOT / root).is_dir()
-        for p in (REPO_ROOT / root).rglob("*.test.mjs")
+        str(p.parent.relative_to(root))
+        for r in _discovery_roots()
+        if (root / r).is_dir()
+        for p in (root / r).rglob("*.test.mjs")
     }
-    rel = str(vendored_test_file.parent.relative_to(REPO_ROOT))
+    rel = str(vendored.parent.relative_to(root))
     assert rel in unfiltered, (
         f"the fixture at {rel} is invisible even to an unfiltered walk, so the "
         "exclusion test above proves nothing"
     )
-    assert rel not in _discovered_dirs(), (
+    assert rel not in _discovered_dirs(root), (
         f"{rel} survived the node_modules filter"
+    )
+
+
+def test_the_synthetic_root_stays_out_of_the_real_checkout(vendored_test_file):
+    """The point of the fixture change, asserted rather than assumed.
+
+    A killed run must not be able to leave anything behind in the tree the
+    developer is working in -- so the fixture must live under tmp_path and the
+    old victim path must not exist.
+    """
+    root, vendored = vendored_test_file
+    assert REPO_ROOT not in vendored.parents, (
+        f"the vendored fixture at {vendored} is inside the real checkout"
+    )
+    strays = sorted(
+        (REPO_ROOT / "claude/skills/clickup/node_modules").glob("pytest-fixture-*")
+    )
+    assert not strays, (
+        f"a previous run of this file left {strays} in the checkout -- exactly what "
+        "moving the fixture to tmp_path prevents"
     )
 
 


### PR DESCRIPTION
## The catch-up path asserted its own security property in a comment

`listen.mjs`'s webhook.site catch-up called the same `authenticateDelivery()`
predicate as the live POST path — correct by reading, and it said so in a
comment. Nothing exercised it. The branch is gated on `SINCE && MODE === 'wait'`
and `listen-integration.test.mjs` runs `--mode server`, so it was *structurally*
unreachable from the suite, and two mutations reinstating the original #438
defect passed all 73 tests:

| mutation | before | after |
|---|---|---|
| `authenticateDelivery(…)` → `{ accepted: true, event: JSON.parse(raw) }` | `tests=73 fail=0` | **dies**, 14 failures |
| the signature read from a bracket-access header key | `tests=73 fail=0` | **dies**, 11 failures |

The walk moved to `lib/catchup.mjs` — a seam with injected callbacks, no
filesystem, no config — and runs **the same four cases the live path is held
to** (unsigned / wrongly-signed / unregistered-webhook / correctly-signed), plus
the raw-body-vs-re-serialisation case. `listen.mjs` also gets an end-to-end
catch-up run against a **loopback stub** of the webhook.site API.

### The cursor: a permanent blind spot, and the wedge the first fix introduced

`date_from` is the cursor and the API pages at 10, so ten consecutive
unverifiable stored requests wedged catch-up forever: the same page re-read every
run, a genuine event behind them unreachable. The realistic trigger is a lost or
reset `watchers.json`, at which point *every* stored event is `unknown-webhook`
— permanently, because the secrets that would verify them are gone.

🔴 **The first version of this PR replaced that with a worse one, and the audit
caught it.** It made `invalid-json` *undecidable* — stop the walk, leave the
cursor — reasoning that an unparseable body means "we cannot say what we are
skipping". webhook.site records an **empty body for a bare GET**: a crawler, a
link preview, or opening your own webhook URL in a browser. One such request
parked the cursor permanently, because `--since` defaults to `last-seen.txt` and
the same page re-blocks on every run until somebody edits state by hand.
Measured end to end against a page holding `[bare GET, genuine signed event]`:

| | run 1 | run 2 |
|---|---|---|
| pre-PR (`origin/main`, reachability patched in so the branch runs) | `exit=0`, delivered, cursor → `09:00:02` | same |
| **first fix (`2c56a33`)** | `exit=1`, **nothing delivered**, cursor stuck at `09:00:00` | **identical** |
| this push | `exit=0`, delivered, cursor → `09:00:02` | nothing left to read |

Same result for every trigger the audit named: empty `content`, `null` content,
a JSON scalar, a JSON string, HTML, form-encoded, a JSON array, truncated JSON.

The rationale was also internally inconsistent: `bad-signature` counted as
decidable because "the body and the secret are both fixed" — and a body that is
not JSON will not start being JSON either. Same stored bytes, same permanence.

So decidability is now **one expression** (`isDecidable`): a permanent rejection
*and* a usable timestamp. `invalid-json` and `malformed-record` join the four
authentication rejections. The only thing that stops the walk is an **undatable**
record — no `created_at` means nothing to advance the cursor *to* — and that
cannot be produced by a request body, because webhook.site stamps what it
stores. `PERMANENT_REJECTIONS` is checked both ways against the reasons
`lib/webhook-server.mjs` can actually return, so a new reason cannot silently
inherit "wedge", and `isDecidable` is exported so that fail-closed default is
*reachable* from a test rather than inert. The summary line reports `blocked`
now: a wedged run used to end on `0 unverifiable, 0 filtered`, which reads like
a clean sweep.

### `CLICKUP_WEBHOOK_SITE_API_BASE` is a credential-egress knob, now gated

The override exists so the catch-up path can be exercised at all, and it shipped
with a comment clearing it of a risk it never had (delivery integrity — every
fetched request is still authenticated) and silent about the one it has: the
webhook.site token is in the request **path** and `WEBHOOK_SITE_API_KEY` rides
as an `Api-Key` header, so whatever host the variable names receives both, in
cleartext if it says `http`. `lib/webhook-site.mjs` gates it — **loopback** (a
stub, and it is never sent the `Api-Key`) or **`https://webhook.site`**;
anything else is refused with a note on stderr and the default is used. Asserted
on the wire: the stub records its request headers, and the hostile-base test has
a positive control proving the stub is reachable before it reads a zero. Also in
that path: the response is capped (proved by streaming past it), `new URL()` no
longer throws inside a promise executor nothing awaits, and `main()` has a
`.catch`.

## The seam scanner never distinguished a READ from a WRITE

Four plain `readFileSync` calls on files **shipped with the skill** would be
reported as defects by the old predicate, under a message ("it will EROFS once
deployed read-only") that is false for a read. The escape hatch was a two-name
`READONLY_BUNDLED` list, and the `MUST_NOT_FIRE` table's read-only cases were
exactly the two names that happened to be exempt — calibrated to the exemption
list, not to the class.

🔴 **Correcting the previous version of this PR body: those four are CONSTRUCTED
shapes, not observed false positives.** None of `custom-fields.json`,
`schema.yaml`, `prompt.txt` or `.gitignore` is read by any module in the skill;
repo-wide they appear only as fixture strings in the test file. Run over the
current 26 modules, `origin/main`'s scanner reports **0 offenders — identical to
the new one**, both firing on a planted
`writeFileSync(join(__dirname, 'watchers.json'), d)`. **This rewrite changes
nothing observable today**; it is forward-looking hardening against the first
bundled data file somebody reads off `__dirname`, plus the indirect write shapes
a literal-based predicate structurally cannot see. The comments now say exactly
that.

* 🔴 **`openSync` was deciding on the FILENAME.** `WRITE_FLAG = /^[wa]|\+/` was
  tested against *every* literal in the call, and argument 0 is the path —
  `openSync(join(__dirname,'accounts.json'),'r')` fired, as did
  `webhooks.jsonl` and `c++notes.txt`. The one negative control used
  `schema.yaml`, whose `s` is the only initial that cannot trip it: calibrated
  around the bug. Flags now come from argument 1 onward, and a ten-case table
  proves both directions over the *same* basenames.
* **Template literals are seen now.** `` writeFileSync(`${__dirname}/f.json`, d) ``
  — the idiom `listen.mjs` itself writes — was silent, because `blankStrings`
  blanked `${…}` along with the text. `blankStrings` grew a `keepSubstitutions`
  option; substitution braces are balanced, so depth counting is unaffected.
* **The "shape is irrelevant" claim is scoped, not restated.** A two-hop
  binding, an aliased import (`writeFileSync as wfs`) and a path passed as a
  function parameter are all silent — measured, listed in the source, and none
  of them a regression.

## `test/js-source.mjs` cited controls in a file that did not exist

The header said "with its own controls in js-source.test.mjs". There was no such
file — while both structural guards in the directory rest on this module's
comment blanking, string blanking, brace-depth counting and literal offsets.
`test/js-source.test.mjs` now exists: **30 tests**, both directions (a comment
marker *inside a string* is not a comment; a `}` inside a string does not close a
block), the offset-preservation contract asserted directly, the `${…}` behaviour
above, and the two known limits pinned so they stay known.

It found a second defect immediately: `topLevelCaseLabels` matched `case 'x':`
**inside a string**, so a help string mentioning a command invented a
dispatchable one for the coverage guard to demand docs for.

## Verification

`bash scripts/run-node-tests.sh .`, `nix build .#checks.x86_64-linux.nodetests`
and `.#checks.x86_64-linux.pytests` all pass, on the branch **and on an
integration tree merged with current `origin/main`**. The clickup suite goes
107 → **154** tests; its floor 102 → **147** = `154 - min(50, max(1, 154/20))`.

Every finding above is a test now, including the two-run scenario
(`CATCH-UP, TWO RUNS: a bare GET does not park the cursor forever`), the
undatable record that legitimately blocks, the oversized response, the Api-Key
never reaching the loopback base, and a hostile base refused before any
connection.

**25 mutants**, applied to everything this round touched — inverted branches,
`&&`→`||`, off-by-one on argument indices and on a delimiter range, clauses
commented out so the text remains but is dead, a rebound stale value, a ledger
made vacuous, and plain deletions. **25/25 died**, each with its own guard's
message. Two needed a new control before they would die (`isDecidable`'s
fail-closed default, and a label immediately after a string literal) — both are
in this push.

The battery also found a defect in the tests themselves: a stub server closed
only on the success path, so a *failing* assertion hung the whole file instead of
reporting. Cleanup moved into `finally`.

🔴 **Not verified against a live ClickUp delivery.** The listener is dormant —
nothing on either host starts it, and no nix unit references it — so everything
here is exercised against loopback stubs and fixtures. In particular, whether
`whcli` forwarding preserves `X-Signature` byte-for-byte is still untested; if it
does not, the fail-closed policy rejects real events *loudly*, as
`[rejected:bad-signature]`.

Closes #444
Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)
