### PR TITLE
feat(hooks): a Stop nudge for turns that name no next step — via additionalContext, not a blocked turn

### DIFF
--- a/githooks/audit-on-push.sh
+++ b/githooks/audit-on-push.sh
@@ -144,7 +144,10 @@ Output format — STRICT, machine-read by the hook:
   VERDICT:SAFE
   CLEAN"
 
-AUDIT_OUT="$(cd "$REPO_ROOT" && timeout "$AUDIT_TIMEOUT" claude -p "$PROMPT" \
+# NEXT_STEP_NUDGE_OFF: this is a headless run whose "operator" is the parser below, which
+# keeps the verdict line and drops the rest. The Stop next-step nudge would spend an extra
+# turn against AUDIT_TIMEOUT writing a line nothing here reads.
+AUDIT_OUT="$(cd "$REPO_ROOT" && NEXT_STEP_NUDGE_OFF=1 timeout "$AUDIT_TIMEOUT" claude -p "$PROMPT" \
   --permission-mode plan 2>>"$AUDIT_LOG_FILE")"
 RC=$?
 if [ $RC -ne 0 ]; then

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1020,13 +1020,17 @@ in
   # without saying what it would do. Concentrated in datapacket-talos (152) and cli (33),
   # not devrc, which is why this is a hook rather than devrc prose.
   #
-  # 🔴 It BLOCKS: exit 2 is the only documented way a Stop hook can reach the model
-  # (additionalContext is not supported on Stop, and `continue:false` halts instead of
-  # continuing). So the suppression predicate is the product, not the message. Bounded to
-  # at most ONE block per session by an atomic claim, never twice in a row
-  # (stop_hook_active), and every error path exits 0. Measured on 11,215 real turn-final
-  # messages: fires on 1.0% of turns the operator answered with a bare approval and 14.6%
-  # of the turns where they had to ask for a recommendation.
+  # 🔴 It does NOT block. It emits `hookSpecificOutput.additionalContext` on stdout and
+  # exits 0 — the model gets the line as non-error feedback and the conversation
+  # continues. An earlier revision asserted that additionalContext is unsupported on Stop
+  # and used exit 2 instead; that premise was false (checked against the installed CLI's
+  # own schema, claude-code 2.1.220), and exit 2 both blocked the turn and raised a "Stop
+  # hook error occurred" notification on every fire. Still bounded to at most ONE fire per
+  # session by an atomic claim, never twice in a row (stop_hook_active), off for subagents
+  # and for headless callers (NEXT_STEP_NUDGE_OFF), with every error path exiting 0.
+  # Measured on 11,789 real turn-final messages: fires on 0.8% of turns the operator
+  # answered with a bare approval and 10.6% of the turns where they had to ask for a
+  # recommendation.
   #
   # Registered on Stop (NOT SubagentStop) per-host by register-nudge-hook.py, appended
   # alongside the three pre-existing Stop hooks it must never clobber.

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1013,6 +1013,26 @@ in
   home.file.".claude/hooks/claude-notify.py" = {
     source = ../scripts/claude-hooks/claude-notify.py;
   };
+  # next-step-nudge fires on Stop when the turn that just ended named no next step, and
+  # asks for one line saying what happens next. Measured over 14 days of operator
+  # prompts: `recommend*` is 216 occurrences against 542 `proceed` + 134 `yes` — roughly
+  # 1 in 3.5 approvals is a round trip that exists only because the assistant stopped
+  # without saying what it would do. Concentrated in datapacket-talos (152) and cli (33),
+  # not devrc, which is why this is a hook rather than devrc prose.
+  #
+  # 🔴 It BLOCKS: exit 2 is the only documented way a Stop hook can reach the model
+  # (additionalContext is not supported on Stop, and `continue:false` halts instead of
+  # continuing). So the suppression predicate is the product, not the message. Bounded to
+  # at most ONE block per session by an atomic claim, never twice in a row
+  # (stop_hook_active), and every error path exits 0. Measured on 11,215 real turn-final
+  # messages: fires on 1.0% of turns the operator answered with a bare approval and 14.6%
+  # of the turns where they had to ask for a recommendation.
+  #
+  # Registered on Stop (NOT SubagentStop) per-host by register-nudge-hook.py, appended
+  # alongside the three pre-existing Stop hooks it must never clobber.
+  home.file.".claude/hooks/next-step-nudge.py" = {
+    source = ../scripts/claude-hooks/next-step-nudge.py;
+  };
 
   # ------------------------------------------------------------------------- #
   # opencode — global config, instruction file, env plugin and subagents.

--- a/scripts/claude-hooks/next-step-nudge.py
+++ b/scripts/claude-hooks/next-step-nudge.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""Stop nudge: when a turn ends WITHOUT naming a next step, block the stop once per
-session and ask for one line saying what happens next.
+"""Stop nudge: when a turn ends WITHOUT naming a next step, hand the model one line of
+context asking it to say what happens next. Once per session. It does not block.
 
 Why this exists — measured, not assumed. Over 14 days of operator prompts in
 `activity.events`:
@@ -23,25 +23,45 @@ instruction, and shell-env-nudge.py's own header records the precedent ("the CLA
 pointers documenting them are opt-in, and opt-in guidance has historically not stuck").
 
 --------------------------------------------------------------------------------------
-MECHANISM — exit 2, and why that is the only option
+MECHANISM — additionalContext, and it does NOT block
 
-`hookSpecificOutput.additionalContext` is documented as NOT supported on Stop. The
-documented way to reach the model from a Stop hook is exit code 2, whose row in the
-hooks reference reads: `Stop | Yes | Prevents Claude from stopping, continues the
-conversation`, with stderr fed back to the model. The JSON alternative `continue:false`
-is the OPPOSITE of what is wanted — it halts processing entirely.
+A Stop hook reaches the model through `hookSpecificOutput.additionalContext`: JSON on
+stdout, exit 0. Read out of the INSTALLED CLI's own schema rather than from documentation
+(claude-code 2.1.220) — and note that `bin/claude` is a 20 KB wrapper, so a grep against
+it returns a meaningless zero; the schema lives in the 262 MB `bin/.claude-wrapped`:
 
-So firing means BLOCKING the stop. That is expensive and disruptive if wrong, which is
-why the suppression below is the substance of this file and the firing condition is an
-ABSENCE. The blast radius is bounded three ways: at most ONE block per session ever
-(atomic claim); never a second consecutive block (`stop_hook_active`); and any error,
-missing field or unreadable transcript exits 0 and lets the turn end.
+    v.object({hookEventName: v.literal("Stop"),
+              additionalContext: v.string().optional()})
+      .describe("Hook-specific output for the Stop event. additionalContext is
+       non-error feedback delivered to the model; the conversation continues so
+       the model can act on it.")
 
-🔴 BLOCKING A STOP RE-RUNS EVERY OTHER STOP HOOK — checked against each, one by one,
-because "it only affects my hook" was not true. Stop is shared with three pre-existing
-owners on this host. When this hook blocks, the turn continues and Stop fires AGAIN when
-it really ends, so those three can see two Stop events for one turn. Bounded to at most
-one extra per session by the claim below. What each does with the second event:
+The same union arm exists for SubagentStop.
+
+🔴 AN EARLIER REVISION OF THIS FILE ASSERTED THE OPPOSITE — that additionalContext is
+unsupported on Stop and that exit 2 is therefore the only route to the model — and built
+its entire cost model on that premise. The premise was false, and everything resting on
+it was wrong in the same direction:
+
+  * exit 2 delivers through `blockingError`, which raises a "Stop hook error occurred ·
+    ctrl+o to see" notification on EVERY fire. Non-error feedback was being pushed down
+    the error channel, and the operator was being shown an error for a working hook.
+  * exit 2 PREVENTS the stop. A model that was legitimately finished was compelled to
+    continue — so a false positive did not merely waste a line, it manufactured filler
+    work. That risk is what made false positives expensive.
+  * that expense is what justified sacrificing recall as hard as this file does.
+
+Under additionalContext none of those hold. The model receives one line of context and
+the turn continues normally; a false positive costs one extra model turn and produces no
+operator-facing error at all. The suppression below is still the substance of the file —
+an unwanted turn is not free — but it is no longer defending against a wedged session,
+and the framing that firing == blocking is gone from this file because it was never true.
+
+🔴 THE TURN STILL CONTINUES, so every other Stop hook still sees a SECOND Stop event.
+This is the schema's own wording ("the conversation continues"), so it survives the move
+off exit 2 rather than being repaired by it — re-checked here, not assumed. Stop is shared
+with three pre-existing owners on this host, and the second event is bounded to at most
+one per session by the claim below. What each does with it:
 
   * claude-notify.py — SAFE, twice over: it returns immediately when `stop_hook_active`
     is set, and it also consumes its turn-start marker on the first Stop, so the second
@@ -57,13 +77,15 @@ one extra per session by the claim below. What each does with the second event:
     hidden; it does not affect approval, which is the PermissionRequest hook, not this.
 
 Registration appends this hook LAST so the other three have already observed the turn
-before it can block.
+before it can add anything to it.
 
 🔴 FAIL-OPEN HERE MEANS SILENCE, which is the opposite of this hook's PostToolUse
 siblings. shell-env-nudge/search-tool-nudge fail open by EMITTING (a duplicate nudge is
-cheap, a swallowed one is invisible). This hook fails open by NOT emitting, because its
-emission blocks the operator's turn. Every `except` below therefore exits 0, and every
-gate that cannot be evaluated is treated as "do not fire".
+cheap, a swallowed one is invisible). This hook fails open by NOT emitting: its emission
+spends one of the operator's model turns, and — more to the point — a Stop hook that
+errors or hangs is felt at the exact moment a session is trying to end. Every `except`
+below therefore exits 0, and every gate that cannot be evaluated is treated as "do not
+fire". main() has exactly ONE exit and it is always 0.
 
 --------------------------------------------------------------------------------------
 DETECTION — an absence, in a positional window, over closed grammatical classes
@@ -71,17 +93,48 @@ DETECTION — an absence, in a positional window, over closed grammatical classe
 The firing condition is: the TAIL of the final message contains no forward-looking
 construction. Both halves matter.
 
-  * POSITIONAL — and stated at the scope actually measured. The tail is the message's
-    last paragraph blocks, taken from the end until at least TAIL_CHARS characters are
-    covered, rather than the whole message. 🔴 On this corpus that narrowing changes
-    NOTHING: sweeping TAIL_CHARS from 10 to 10^9 leaves the fire count at 565/11,215,
-    unmoved, because a message that has any forward-looking construction essentially
-    always has one in its final paragraph. So the window is a bound on a shape the real
-    traffic does not contain — a next step stated up top and then buried under kilobytes
-    of findings — and NOT a tuned parameter. It is kept because it is cheap and can only
-    ever make the hook louder, never quieter; it is not evidence for anything, and
-    test_next_step_buried_far_above_the_tail_does_not_suppress is labelled there as the
-    invariant guard it is rather than counted as regression coverage.
+  * POSITIONAL, and it is the single most sensitive constant in this file. The tail is
+    the message's last paragraph blocks, taken from the end until at least TAIL_CHARS
+    characters are covered, rather than the whole message.
+
+    🔴 AN EARLIER REVISION CALLED THIS PARAMETER "MEASURABLY INERT" — fire count 565 at
+    every value from 10 to 10^9 — and demoted its test to an invariant guard on the
+    strength of that. The measurement was wired to nothing. `tail_of(text,
+    nchars=TAIL_CHARS)` binds its default at DEF time, so the sweep, which rebound the
+    module-level `TAIL_CHARS` and then called `suppressed_by()`, changed no behaviour at
+    all; it re-measured the same 800-char window eleven times and reported the flat line
+    as a property of the traffic. Re-measured by passing `nchars` explicitly, over 11,789
+    turn-final messages from this host's transcripts:
+
+        TAIL_CHARS      10    200    400    600    800   1200   3200   10^9
+        fires        1,903  1,385    968    738    577    422    265    262
+
+    A 7.3x swing, and 55% of the fires at the shipped value exist ONLY because of the
+    window. Nothing about "inert" was true.
+
+    800 is KEPT, but now because it was chosen rather than inherited. Raw fire count is
+    the wrong criterion and a precision ratio computed on single-digit false-positive
+    counts is noise, so the criterion is MARGINAL: narrowing the window one step from the
+    value above it, what does it buy in genuinely-needed nudges per false one? Labelled
+    behaviourally by what the operator typed next:
+
+        narrow to    1600    1200     800     600     400     200
+        +true           5       6      18      14      15      30
+        +false          2       2       1       7       6      14
+        ratio         2.5:1   3.0:1  18.0:1   2.0:1   2.5:1   2.1:1
+
+    The 1200 -> 800 step is a genuine knee: every other step trades at 2-3:1, that one at
+    18:1. It survives both robustness checks — 9:1 on a wider draw of the false-positive
+    population, and 12:1 on the newest 25% of sessions held out by mtime, with every
+    adjacent step still <= 3:1 in both.
+
+    This also refutes the old rationale, which claimed the window bounded "a shape the
+    corpus does not contain". The corpus contains it 18 times over: turns where the model
+    DID state something forward-looking, but far enough above the ending that the operator
+    still had to ask for a recommendation. A next step buried under kilobytes of findings
+    is not a usable ending, and the operator's own behaviour is what says so.
+    test_next_step_buried_far_above_the_tail_does_not_suppress is therefore real
+    regression coverage for the file's most sensitive constant, and is labelled as such.
 
   * ABSENCE, NOT PRESENCE. There is no "does the text contain 'next'" test anywhere;
     that is the spelled-guard failure this repo has been bitten by (a
@@ -92,36 +145,45 @@ construction. Both halves matter.
     recommendation in it.
 
   * The suppressors ARE lexical, and that is deliberate and safe in this direction.
-    A false suppressor costs one missed nudge (silent, cheap). A false FIRE costs a
-    blocked turn and trains the operator to ignore the hook. So every suppressor is
+    A false suppressor costs one missed nudge (silent, cheap). A false FIRE costs one
+    wasted model turn and trains the operator to ignore the hook. So every suppressor is
     written GENEROUSLY: when in doubt, suppress. They are closed grammatical classes
-    (pronoun + modal, sentence-final `?`, second-person hand-off) rather than topic
+    (pronoun + modal, line-final `?`, second-person hand-off) rather than topic
     vocabulary, so widening one cannot make the hook fire more.
 
-MEASURED false-positive rate. Against 11,215 turn-final assistant messages taken from
-this host's own transcripts, labelled by what the OPERATOR typed next — a behavioural
-label, not my judgement about whether the turn was any good:
+MEASURED false-positive rate. Against 11,789 turn-final assistant messages taken from
+this host's own transcripts (630 sessions), labelled by what the OPERATOR typed next — a
+behavioural label, not my judgement about whether the turn was any good:
 
-    turns answered with `recommend…`   (SHOULD fire):   39/268   = 14.6%
-    turns answered with bare approval  (MUST NOT fire): 14/1464  =  1.0%
-    all turns                                          565/11215 =  5.0%
-    sessions firing at all (once-per-session dedupe):  190/620   = 30.6%
+    turns answered with `recommend…`  (SHOULD fire):     51/483   = 10.6%
+    bare approval, NARROW draw       (MUST NOT fire):     8/1000  =  0.8%
+    bare approval, WIDE draw         (MUST NOT fire):    13/1554  =  0.8%
+    all turns                                           577/11789 =  4.9%
+    sessions firing at all (once-per-session dedupe):   191/630   = 30.3%
 
-So ~15:1 in favour of firing on a turn that genuinely lacked a next step, and an
-operator sees this at most once in roughly three sessions.
+🔴 THE HEADLINE RATIO IN AN EARLIER REVISION WAS WRONG, and the way it was wrong is the
+interesting part. It claimed ~15:1 from 14.6% recall against a 1.0% false-positive rate
+drawn over 1,464 turns. Re-labelled independently, the same predicate on the same corpus
+gave 2.3% (23/1000) — the gap is DEFINITIONAL, i.e. the 1.0% was not robust to how "bare
+approval" is drawn, which is exactly the objection. The honest number for what that
+revision shipped was 4.6:1, not 15:1.
 
-Bounding the 1.0%, honestly:
-  * It is an UPPER bound on harm. Some of those 14 are turns that did name a next step
-    somewhere the operator was happy with; none of them are turns where the nudge would
-    have been welcome.
-  * It is NOT an artefact of tuning on the same data. Split by session mtime, the newest
-    25% of sessions — which the suppressors were never sampled from — give 1.1%
-    (5/461) against 0.9% (9/1003) on the older 75%. Per project: 1.0%, 0.0%, 3.4%,
-    0.0%, 0.0% (the 3.4% is 4/118, small n).
-  * Recall is deliberately the sacrificed side. Every suppressor is written generously,
-    and each widening traded recall for precision on purpose: an earlier revision sat at
-    36.9%/4.6% and was made quieter, twice. Firing costs a blocked turn; staying silent
-    costs one round trip the operator was going to pay anyway.
+The 13.2:1 above is a different claim: it is what the predicate does AFTER the ASKS
+anchor fix (see ASKS below), which removed 15 false positives and introduced none. Both
+draws of the false-positive population are reported precisely so the ratio does not rest
+on one of them again.
+
+Bounding the 0.8%, honestly:
+  * It is an UPPER bound on harm. Some of those 8 are turns that did name a next step
+    somewhere the operator was happy with; none are turns where the nudge would have
+    been welcome.
+  * Both draws of the population agree at 0.8%, which the earlier 1.0%/2.3% pair did not.
+  * Recall is deliberately the sacrificed side, and the case for sacrificing it is WEAKER
+    now than when it was made: it was justified by a false positive costing a blocked
+    turn, and under additionalContext it costs one model turn. The suppressors have NOT
+    been loosened in this round — that would be a second change measured against the same
+    retrospective corpus that has already misled once — but the trade should be revisited
+    against live data, not re-derived here.
 
 🔴 WHAT THIS DOES NOT MEASURE, stated plainly: the real-world nudge rate cannot be known
 until this ships. The corpus is retrospective — it says how often the predicate WOULD
@@ -135,9 +197,12 @@ activity.events some weeks after deploy; nothing here establishes it.
 import sys, json, os, re
 
 # --------------------------------------------------------------------------- #
-# Tunables. Each carries its own evidence below, INCLUDING where there is none:
-# TAIL_CHARS is measurably inert on this corpus and says so rather than borrowing
-# the others' credibility.
+# Tunables. Each carries its own evidence below. 🔴 Any sweep of one of these must pass
+# the parameter EXPLICITLY into the function under test — every function here that takes
+# a tunable takes it as a default argument, and a default binds at def time, so rebinding
+# the module attribute measures nothing. That mistake produced a confident "TAIL_CHARS is
+# inert" reading of an eleven-point sweep that had in fact re-measured one value eleven
+# times. A sweep must be shown to move a number before any verdict is read from it.
 # --------------------------------------------------------------------------- #
 
 # Below this, the message is a terse answer, not a piece of work that owes a next step.
@@ -146,9 +211,13 @@ import sys, json, os, re
 MIN_MESSAGE_CHARS = 600
 
 # The positional tail: last paragraph blocks covering at least this many characters.
-# NOT a tuned number — swept 10 / 200 / 400 / 800 / 1600 / 3200 / 10^9 against the final
-# suppressor set and the fire count was 565 at EVERY point. See the "POSITIONAL" note in
-# the module docstring: this bounds a pathological shape, it does not tune anything.
+# 🔴 THE MOST SENSITIVE CONSTANT IN THIS FILE — a 7.3x swing in fire count across its
+# range (1,903 at 10 down to 262 unbounded), and 55% of the fires at this value exist
+# only because of the window. Chosen on MARGINAL gain, not on fire count: narrowing
+# 1200 -> 800 buys 18 genuinely-needed nudges per 1 false one, where every adjacent step
+# trades at 2-3:1. Holds on a wider draw of the false-positive population (9:1) and on
+# the newest 25% of sessions held out by mtime (12:1). Full tables in the "POSITIONAL"
+# note in the module docstring.
 TAIL_CHARS = 800
 
 # How much of the transcript's end to read when establishing turn shape. A turn larger
@@ -159,6 +228,22 @@ TRANSCRIPT_TAIL_BYTES = 4 * 1024 * 1024
 SHORT_QUESTION_CHARS = 160
 
 STATE_TOKEN = "fired"
+
+# 🔴 HEADLESS OPT-OUT. `claude -p` inherits this host's hooks, and two of this repo's own
+# scripts drive it under a hard timeout — githooks/audit-on-push.sh (AUDIT_TIMEOUT) and
+# scripts/task-spec-drafter/drafter.sh (DRAFTER_TIMEOUT, 240s default). Both do tool work
+# and end with a long report, so both are ELIGIBLE, and in both the "operator" is a shell
+# pipeline that parses the first line and exits. Nobody reads the nudge and the extra turn
+# is charged against a bounded budget.
+#
+# Gated on an explicit env marker set BY THE CALLERS, not inferred. The alternatives were
+# both rejected as heuristics: CLAUDE_CODE_ENTRYPOINT is "cli" for `claude -p` exactly as
+# it is for an interactive session (checked against the bundle's own enum: cli, sdk-cli,
+# mcp, serve, claude-code-github-action, local-agent), and stdin/stdout are pipes for a
+# hook in BOTH modes, so neither distinguishes the case. The two call sites are ours, so
+# the deterministic fix is for them to say so — set here, read here, and nowhere else.
+# A third-party headless caller can opt out the same way; the default stays "nudge".
+OPT_OUT_ENV = "NEXT_STEP_NUDGE_OFF"
 
 
 def _state_root():
@@ -184,11 +269,27 @@ def _state_root():
 # so none of them is decoration.
 # --------------------------------------------------------------------------- #
 
-# 1. ASKS — a sentence-final '?'. The strongest single signal in the corpus: present in
-#    the tail of 70% of turns the operator answered with a bare approval, versus 26% of
-#    the turns where they had to ask for a recommendation. Anchored to end-of-line so a
-#    rhetorical '?' mid-sentence does not count.
-ASKS = re.compile(r"\?(?=[\s\"'*`)\]]*$)", re.M)
+# 1. ASKS — a question at the END of a line. The strongest single signal in the corpus:
+#    present in the tail of 70% of turns the operator answered with a bare approval,
+#    versus 26% of the turns where they had to ask for a recommendation.
+#
+#    🔴 THE TRAILER ALLOWANCE IS THE WHOLE POINT, and an earlier revision got it wrong.
+#    The first version anchored with `[\s"'*`)\]]*$` — whitespace and closing quotes
+#    only — so a '?' followed by ANY word did not match. That silently excluded the most
+#    common shape of an already-awaiting-the-operator turn: the inline answer hint.
+#    `Append this to the index? (y/N)` scored as NO question and FIRED, while the same
+#    sentence without the hint was correctly suppressed. On this corpus 12 of the 14
+#    first-fires whose operator reply was a bare approval were that one literal prompt —
+#    a flow this repo itself ships. So the trailer is now "up to 40 characters that are
+#    not a newline and not another '?'", which admits `(y/N)`, `[1-3]`, `— your call.`
+#    and the like, while a '?' buried mid-paragraph with a sentence after it still does
+#    not match. `?` is excluded from the trailer purely for attribution: it makes the
+#    LAST question on a line the one that matches, never an earlier one reaching past it.
+#    Pinned by test_asks_allows_an_inline_answer_hint and
+#    test_asks_does_not_match_a_rhetorical_question_mid_paragraph — the anchoring was
+#    previously UNTESTED (replacing the whole regex with a bare `\?` left every test
+#    green), so the claim in this comment now has a guard behind it.
+ASKS = re.compile(r"\?(?=[^\n?]{0,40}$)", re.M)
 
 # 2. COMMITS — a forward-looking clause. Two shapes, both closed classes:
 #    (a) first person + modal/volitional head ("I'll", "I would", "we can", "I plan to")
@@ -361,8 +462,26 @@ def is_short_question(prompt):
 # Turn shape, from the transcript tail
 # --------------------------------------------------------------------------- #
 def _is_real_user(rec):
-    """A genuine operator prompt, not a tool_result the harness wrote back as `user`."""
-    if rec.get("type") != "user" or rec.get("isSidechain"):
+    """A genuine operator prompt, not a tool_result the harness wrote back as `user`.
+
+    Three ways a `type: "user"` record is NOT the operator talking, and all three are
+    excluded here:
+      * isSidechain — a subagent's prompt, written into the shared transcript.
+      * tool_result content — the harness echoing a tool's output back as `user`.
+      * 🔴 isMeta — a harness-authored record with STRING content, e.g. the
+        `<local-command-caveat>` and command-expansion notes Claude Code injects. This
+        one is the dangerous shape precisely because it looks exactly like a real prompt:
+        the content is a plain string, so the tool_result test above passes it straight
+        through and `_turn_shape` returns harness boilerplate as "the opening prompt".
+        Both prompt-shaped gates then evaluate the wrong text, and they do it in the
+        FIRING direction — a caveat string is neither terminal nor a short question, so
+        the two gates that could have stayed the hook are both answered by text the
+        operator never typed. 6.1% of turns in the corpus (722) open on such a record.
+        Measured counterfactual: honouring isMeta changes 0 of the current fires, so this
+        is latent rather than live — taken anyway, because it is one token and the day it
+        becomes live it fails silently and in the expensive direction.
+    """
+    if rec.get("type") != "user" or rec.get("isSidechain") or rec.get("isMeta"):
         return False
     content = (rec.get("message") or {}).get("content")
     if isinstance(content, str):
@@ -450,8 +569,10 @@ def _turn_shape(path):
 # --------------------------------------------------------------------------- #
 # Once-per-session claim. Same atomic O_EXCL test-and-set as search-tool-nudge.py,
 # with the fail direction REVERSED: an unwritable state dir means we cannot promise
-# once-per-session, and an unbounded Stop-blocker is the one outcome worse than a
-# missed nudge — so an unclaimable token means DO NOT FIRE.
+# once-per-session, and a nudge that repeats on EVERY turn of a session is the one
+# outcome worse than a missed nudge — so an unclaimable token means DO NOT FIRE.
+# (This held more sharply when the hook blocked; it still holds, because a per-turn
+# nudge is what trains an operator to ignore the thing.)
 # --------------------------------------------------------------------------- #
 def _sanitize(part):
     return re.sub(r"[^A-Za-z0-9_.-]", "_", part)[:120]
@@ -528,10 +649,19 @@ def should_nudge(data, transcript_reader=_turn_shape):
     if data.get("agent_id"):  # reaches the operator, so it owes them no next step.
         return False
     if data.get("stop_hook_active"):
-        return False          # never block twice in a row
-    stop_reason = data.get("stop_reason")
-    if stop_reason not in (None, "", "end_turn"):
-        return False          # max_tokens/tool_use is truncation, not a considered end
+        return False          # never nudge two Stops in a row
+    if os.environ.get(OPT_OUT_ENV):
+        return False          # headless / batch caller: nobody is here to read it
+
+    # 🔴 There is deliberately NO `stop_reason` gate. An earlier revision had one —
+    # "max_tokens/tool_use is truncation, not a considered end" — and it was DEAD: the
+    # Stop payload has no such field, so the gate could never reject anything, and its
+    # test was an invariant guard wearing a gate's label. The real payload is
+    # `session_id, transcript_path, cwd, prompt_id?, permission_mode?, agent_id?,
+    # agent_type?, effort?` + `hook_event_name, stop_hook_active, last_assistant_message?,
+    # background_tasks?, session_crons?` (read out of the installed CLI's own schema,
+    # claude-code 2.1.220). Removed rather than relabelled: a gate nobody can trip is
+    # indistinguishable from one that works, and it invited a maintainer to trust it.
 
     msg = data.get("last_assistant_message")
     if not isinstance(msg, str) or len(msg) < MIN_MESSAGE_CHARS:
@@ -557,25 +687,41 @@ def should_nudge(data, transcript_reader=_turn_shape):
     return True
 
 
+def emit(text=NUDGE):
+    """The Stop hook's non-error channel: `hookSpecificOutput.additionalContext`.
+
+    Shape taken from the installed CLI's own schema rather than from documentation:
+
+        v.object({hookEventName: v.literal("Stop"),
+                  additionalContext: v.string().optional()})
+          .describe("Hook-specific output for the Stop event. additionalContext is
+           non-error feedback delivered to the model; the conversation continues so
+           the model can act on it.")
+
+    `hookEventName` is the literal "Stop" and not the payload's own field: should_nudge()
+    has already rejected every other event, and echoing an absent field would emit a
+    union arm that validates against nothing.
+    """
+    json.dump({"hookSpecificOutput": {"hookEventName": "Stop",
+                                      "additionalContext": text}}, sys.stdout)
+    sys.stdout.write("\n")
+
+
 def main():
+    # 🔴 ONE exit, and it is always 0. Nothing inside the try may call sys.exit(): a
+    # SystemExit is a BaseException, so `except Exception` would NOT catch it and the
+    # earlier `except SystemExit: raise` arm below it was unreachable decoration. The
+    # structure is now "do the work, swallow anything, exit 0" — which is the whole
+    # fail-open claim, expressed so that there is exactly one place to read it.
     try:
         data = json.load(sys.stdin)
+        if should_nudge(data):
+            state_dir = _state_dir(data)
+            if not already_fired(state_dir) and claim(state_dir):
+                emit()
     except Exception:
-        sys.exit(0)
-    try:
-        if not should_nudge(data):
-            sys.exit(0)
-        state_dir = _state_dir(data)
-        if already_fired(state_dir):
-            sys.exit(0)
-        if not claim(state_dir):
-            sys.exit(0)
-        sys.stderr.write(NUDGE + "\n")
-        sys.exit(2)
-    except SystemExit:
-        raise
-    except Exception:
-        sys.exit(0)
+        pass      # fail-open HERE means silence — see the module docstring.
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/scripts/claude-hooks/next-step-nudge.py
+++ b/scripts/claude-hooks/next-step-nudge.py
@@ -1,0 +1,582 @@
+#!/usr/bin/env python3
+"""Stop nudge: when a turn ends WITHOUT naming a next step, block the stop once per
+session and ask for one line saying what happens next.
+
+Why this exists — measured, not assumed. Over 14 days of operator prompts in
+`activity.events`:
+
+    proceed 542 · yes 134 · recommend next actions 123 · recommend 76 ·
+    recommend and proceed 17
+
+`recommend*` = 216 occurrences, roughly 1 in every 3.5 approvals. The operator's reply
+vocabulary is otherwise almost pure authorization (`proceed`, `yes`, `merge`,
+`dispatch`), so each `recommend*` is a whole round trip that exists ONLY because the
+assistant stopped without saying what it would do next. A turn that ends with a stated
+next step converts that round trip into a one-word `proceed`. Concentration by project
+over the same window — datapacket-talos 152, cli 33, devrc 22, homelab-talos 12 — is why
+this is a global hook and not devrc guidance.
+
+Prose was considered and rejected: `claude/RULES.md` is a few hundred bytes under its
+enforced ceiling, loads every session on both hosts, and is concatenated into opencode's
+`AGENTS.md` — paid twice. PRINCIPLES.md prefers deterministic/structural fixes over prose
+instruction, and shell-env-nudge.py's own header records the precedent ("the CLAUDE.md
+pointers documenting them are opt-in, and opt-in guidance has historically not stuck").
+
+--------------------------------------------------------------------------------------
+MECHANISM — exit 2, and why that is the only option
+
+`hookSpecificOutput.additionalContext` is documented as NOT supported on Stop. The
+documented way to reach the model from a Stop hook is exit code 2, whose row in the
+hooks reference reads: `Stop | Yes | Prevents Claude from stopping, continues the
+conversation`, with stderr fed back to the model. The JSON alternative `continue:false`
+is the OPPOSITE of what is wanted — it halts processing entirely.
+
+So firing means BLOCKING the stop. That is expensive and disruptive if wrong, which is
+why the suppression below is the substance of this file and the firing condition is an
+ABSENCE. The blast radius is bounded three ways: at most ONE block per session ever
+(atomic claim); never a second consecutive block (`stop_hook_active`); and any error,
+missing field or unreadable transcript exits 0 and lets the turn end.
+
+🔴 BLOCKING A STOP RE-RUNS EVERY OTHER STOP HOOK — checked against each, one by one,
+because "it only affects my hook" was not true. Stop is shared with three pre-existing
+owners on this host. When this hook blocks, the turn continues and Stop fires AGAIN when
+it really ends, so those three can see two Stop events for one turn. Bounded to at most
+one extra per session by the claim below. What each does with the second event:
+
+  * claude-notify.py — SAFE, twice over: it returns immediately when `stop_hook_active`
+    is set, and it also consumes its turn-start marker on the first Stop, so the second
+    finds no start file. Verified by reading it (`if data.get("stop_hook_active"):
+    return`, then the `if event == "Stop"` cleanup).
+  * ~/.config/tmux/task-hook.sh — its INLINE fallback guards on `stop_hook_active` and
+    exits 0. Its primary path is `exec fuzzyclaw hook stop`, and the fuzzyclaw binary was
+    NOT inspected — out of scope (it is being deprecated) and deliberately not entangled
+    with here. Unverified, stated as such; worst case is one extra task-json write.
+  * clawgate-stop-hook.sh — does NOT guard on `stop_hook_active` (grepped: no match), so
+    it WILL POST to /api/suggest a second time on a session where this hook fires. One
+    extra suggestion generation per session, at most. A real cost, named rather than
+    hidden; it does not affect approval, which is the PermissionRequest hook, not this.
+
+Registration appends this hook LAST so the other three have already observed the turn
+before it can block.
+
+🔴 FAIL-OPEN HERE MEANS SILENCE, which is the opposite of this hook's PostToolUse
+siblings. shell-env-nudge/search-tool-nudge fail open by EMITTING (a duplicate nudge is
+cheap, a swallowed one is invisible). This hook fails open by NOT emitting, because its
+emission blocks the operator's turn. Every `except` below therefore exits 0, and every
+gate that cannot be evaluated is treated as "do not fire".
+
+--------------------------------------------------------------------------------------
+DETECTION — an absence, in a positional window, over closed grammatical classes
+
+The firing condition is: the TAIL of the final message contains no forward-looking
+construction. Both halves matter.
+
+  * POSITIONAL — and stated at the scope actually measured. The tail is the message's
+    last paragraph blocks, taken from the end until at least TAIL_CHARS characters are
+    covered, rather than the whole message. 🔴 On this corpus that narrowing changes
+    NOTHING: sweeping TAIL_CHARS from 10 to 10^9 leaves the fire count at 565/11,215,
+    unmoved, because a message that has any forward-looking construction essentially
+    always has one in its final paragraph. So the window is a bound on a shape the real
+    traffic does not contain — a next step stated up top and then buried under kilobytes
+    of findings — and NOT a tuned parameter. It is kept because it is cheap and can only
+    ever make the hook louder, never quieter; it is not evidence for anything, and
+    test_next_step_buried_far_above_the_tail_does_not_suppress is labelled there as the
+    invariant guard it is rather than counted as regression coverage.
+
+  * ABSENCE, NOT PRESENCE. There is no "does the text contain 'next'" test anywhere;
+    that is the spelled-guard failure this repo has been bitten by (a
+    `Contains(body,"disabled")` check satisfied by an unrelated attribute on a live
+    button). A firing condition that is the ABSENCE of every suppressor cannot be
+    satisfied by an unrelated feature spelling a word — the only way to make this hook
+    fire is to write a tail with no question, no commitment, no offer and no marked
+    recommendation in it.
+
+  * The suppressors ARE lexical, and that is deliberate and safe in this direction.
+    A false suppressor costs one missed nudge (silent, cheap). A false FIRE costs a
+    blocked turn and trains the operator to ignore the hook. So every suppressor is
+    written GENEROUSLY: when in doubt, suppress. They are closed grammatical classes
+    (pronoun + modal, sentence-final `?`, second-person hand-off) rather than topic
+    vocabulary, so widening one cannot make the hook fire more.
+
+MEASURED false-positive rate. Against 11,215 turn-final assistant messages taken from
+this host's own transcripts, labelled by what the OPERATOR typed next — a behavioural
+label, not my judgement about whether the turn was any good:
+
+    turns answered with `recommend…`   (SHOULD fire):   39/268   = 14.6%
+    turns answered with bare approval  (MUST NOT fire): 14/1464  =  1.0%
+    all turns                                          565/11215 =  5.0%
+    sessions firing at all (once-per-session dedupe):  190/620   = 30.6%
+
+So ~15:1 in favour of firing on a turn that genuinely lacked a next step, and an
+operator sees this at most once in roughly three sessions.
+
+Bounding the 1.0%, honestly:
+  * It is an UPPER bound on harm. Some of those 14 are turns that did name a next step
+    somewhere the operator was happy with; none of them are turns where the nudge would
+    have been welcome.
+  * It is NOT an artefact of tuning on the same data. Split by session mtime, the newest
+    25% of sessions — which the suppressors were never sampled from — give 1.1%
+    (5/461) against 0.9% (9/1003) on the older 75%. Per project: 1.0%, 0.0%, 3.4%,
+    0.0%, 0.0% (the 3.4% is 4/118, small n).
+  * Recall is deliberately the sacrificed side. Every suppressor is written generously,
+    and each widening traded recall for precision on purpose: an earlier revision sat at
+    36.9%/4.6% and was made quieter, twice. Firing costs a blocked turn; staying silent
+    costs one round trip the operator was going to pay anyway.
+
+🔴 WHAT THIS DOES NOT MEASURE, stated plainly: the real-world nudge rate cannot be known
+until this ships. The corpus is retrospective — it says how often the predicate WOULD
+have fired on turns already written, not how the model's endings change once a hook is
+nudging them, and not whether a nudged turn actually converts a `recommend` into a
+`proceed`. The verifier for that is a re-run of the same prompt counts over
+activity.events some weeks after deploy; nothing here establishes it.
+
+--------------------------------------------------------------------------------------
+"""
+import sys, json, os, re
+
+# --------------------------------------------------------------------------- #
+# Tunables. Each carries its own evidence below, INCLUDING where there is none:
+# TAIL_CHARS is measurably inert on this corpus and says so rather than borrowing
+# the others' credibility.
+# --------------------------------------------------------------------------- #
+
+# Below this, the message is a terse answer, not a piece of work that owes a next step.
+# p10 of the "operator replied with approval-or-recommend" population is ~1,530 chars, so
+# 600 sits well under the real working range and only excludes genuinely short replies.
+MIN_MESSAGE_CHARS = 600
+
+# The positional tail: last paragraph blocks covering at least this many characters.
+# NOT a tuned number — swept 10 / 200 / 400 / 800 / 1600 / 3200 / 10^9 against the final
+# suppressor set and the fire count was 565 at EVERY point. See the "POSITIONAL" note in
+# the module docstring: this bounds a pathological shape, it does not tune anything.
+TAIL_CHARS = 800
+
+# How much of the transcript's end to read when establishing turn shape. A turn larger
+# than this is, by construction, a turn that did work — see _turn_shape.
+TRANSCRIPT_TAIL_BYTES = 4 * 1024 * 1024
+
+# A short interrogative opener is a factual question; answering it owes no next step.
+SHORT_QUESTION_CHARS = 160
+
+STATE_TOKEN = "fired"
+
+
+def _state_root():
+    """Read HOME at call time, not import time, so a test can point it somewhere safe."""
+    return os.path.join(os.path.expanduser("~"), ".cache", "claude-next-step-nudge", "s")
+
+
+# --------------------------------------------------------------------------- #
+# Suppressors — a tail matching ANY of these already names a next step or asks.
+# Read them as: "this tail is already forward-looking."
+#
+# The numbering below is presentational; order does not affect the result, since
+# suppressed_by() evaluates all of them. Measured load over the 11,215-turn corpus —
+# tails matched, and in brackets the tails where that suppressor was the ONLY match, i.e.
+# what would start firing if it were deleted:
+#
+#     commits 7774 [2751] · offers 4799 [330] · marked 3867 [606] · asks 1979 [32]
+#     headed 886 [40] · done 391 [55] · labelled 38 [5]
+#
+# `labelled` is the weak one and is kept knowingly: 5 unique tails is real but thin, and
+# it is the cheapest guard here. Every suppressor including that one is confirmed to move
+# the corpus fire count in BOTH directions (neutralised -> louder, saturated -> silent),
+# so none of them is decoration.
+# --------------------------------------------------------------------------- #
+
+# 1. ASKS — a sentence-final '?'. The strongest single signal in the corpus: present in
+#    the tail of 70% of turns the operator answered with a bare approval, versus 26% of
+#    the turns where they had to ask for a recommendation. Anchored to end-of-line so a
+#    rhetorical '?' mid-sentence does not count.
+ASKS = re.compile(r"\?(?=[\s\"'*`)\]]*$)", re.M)
+
+# 2. COMMITS — a forward-looking clause. Two shapes, both closed classes:
+#    (a) first person + modal/volitional head ("I'll", "I would", "we can", "I plan to")
+#    (b) IMPERSONAL future ("will merge", "'ll deploy", "going to", "about to").
+#    (b) exists because a real corpus miss was "there'll be one more delta re-audit …
+#    #256 merges and deploys as 0.42.0" — a perfectly good next step stated with no
+#    first-person pronoun anywhere. A suppressor that only understood "I will" fired on
+#    it. Widening a suppressor can only make this hook quieter, never louder.
+COMMITS = re.compile(
+    r"\b(?:I|we)\s*['’](?:ll|d|m|ve)\b"
+    r"|\b(?:I|we)\s+(?:will|shall|can|could|would|should|may|might|am|are|"
+    r"plan|intend|propose|recommend|suggest|expect|next|start|begin|go|do|run|open|"
+    r"take|pick|move|dispatch|merge|ship|write|add|fix|land|leave|hold|keep|need|want)\b"
+    r"|\b(?:will|shall)\s+(?:not\s+|then\s+|now\s+)?[a-z]+\b"
+    r"|['’]ll\b"
+    r"|\b(?:going to|about to|due to run|queued to|set to)\b",
+    re.I)
+
+# 3. OFFERS — an explicit hand-off to the operator: second-person and possessive shapes.
+#    A tail containing one of these has already put the ball in the operator's court,
+#    which is exactly the state this hook exists to produce.
+#    The `your <noun>` arm is an enumerated set, not `your \w+`: "your repo is dirty" is
+#    a statement about the world, not a hand-off, and the open form would suppress it.
+OFFERS = re.compile(
+    r"\b(?:say the word|let me know|want me to|shall I|should I|do you want|"
+    r"tell me|yours to|up to you|for you to|left (?:it |that |the \w+ )?to you|"
+    r"your (?:call|review|go[- ]?ahead|choice|decision|say|word|go|court|shout|"
+    r"move|turn|PR|approval|sign[- ]?off)|"
+    r"(?:ready|over|up) for (?:your )?review|"
+    r"if you(?:['’]d| would)? (?:like|want|prefer)|on your (?:say|word|go)|"
+    r"awaiting|standing by|ready when you are|whenever you)\b",
+    re.I)
+
+# 4. MARKED — a recommendation marked as such. Covers the "explicit numbered ask with a
+#    recommendation marked" ending, which is a legitimate way to end a turn: the operator
+#    can answer it with one word even though it is a question, not a commitment.
+#    The `worth <gerund>` / `worth a <noun>` arm is the operator-directed suggestion
+#    shape — "worth folding into the skill", "worth a glance before merging" — which the
+#    corpus produced repeatedly and an earlier revision fired on.
+MARKED = re.compile(
+    r"\b(?:recommend(?:ed|ation|ations|ing|s)?|suggest(?:ed|ion|ions|s)?|"
+    r"I['’]?d\s+(?:go|start|pick|take|do|lean|leave|say)|"
+    r"my (?:pick|call|vote|recommendation|preference)|"
+    r"default(?:s|ing)? to|lean(?:s|ing)? toward|"
+    r"worth (?:a |an )?(?:glance|look|check|[a-z]+ing)|"
+    r"the (?:one|first) (?:I['’]?d|to do))\b",
+    re.I)
+
+# 5. HEADED — a heading or bold lead-in that opens a forward-looking section. Structural:
+#    it must be at the START of a line and carry heading markup ('#' or '**'), so a
+#    mention of the word "plan" in running prose does not match. Up to two leading
+#    modifier words are allowed inside the markup — a real corpus miss was
+#    "**Ranked next steps** put the stale-node sweep ahead of …", a perfectly good
+#    next-step section that an anchored-at-the-first-word pattern walked straight past.
+HEADED = re.compile(
+    r"(?:^|\n)\s*(?:#{1,6}\s*|\*\*|\d+[.)]\s+\*\*)\s*(?:[A-Za-z-]+ ){0,2}"
+    r"(?:next|next steps?|what['’]?s next|recommend(?:ed|ation)s?|"
+    r"plan|proposed|proposal|remaining|open items?|to ?do|follow[- ]ups?)\b",
+    re.I)
+
+# 6. LABELLED — the same forward-looking section opener as HEADED but with NO markdown
+#    markup, which is how it is written about as often: a line that BEGINS with a label
+#    word and is immediately followed by a colon or dash. Structural in both position
+#    (line-initial) and punctuation (the label separator) — "the next thing I checked
+#    was" in running prose does not match, because it is neither line-initial nor
+#    followed by a separator. Split out from HEADED rather than folded in so a mutation
+#    to either is attributable to exactly one test.
+LABELLED = re.compile(
+    r"(?:^|\n)\s*(?:next(?: steps?| up)?|then|after (?:that|this)|from here|"
+    r"remaining|to ?do|follow[- ]ups?|the (?:sequence|plan|order|next step))"
+    r"\s*[:—–-]",
+    re.I)
+
+# 7. DONE — an explicit statement that nothing follows. This is a next step: the whole
+#    point of the nudge is to remove the operator's round trip, and "nothing further,
+#    this is done" removes it just as well as naming an action.
+#
+#    🔴 SELF-CONSISTENCY, and it is load-bearing: NUDGE below tells the model that
+#    "nothing further; this is done" is a valid ending. Without this suppressor the hook
+#    would fire on a turn that had followed its own instruction — the exact shape that
+#    teaches an operator the hook is noise. Pinned by a test that feeds NUDGE's own
+#    prescribed endings back through the predicate.
+DONE = re.compile(
+    r"\bnothing (?:further|else|more|left|remaining|outstanding|to do|follows)\b"
+    r"|\bno (?:further|remaining|outstanding|other) (?:steps?|work|actions?|items?|"
+    r"follow[- ]ups?|changes?)\b"
+    r"|\b(?:all|now) done\b|\bthat['’]?s (?:it|all|everything)\b"
+    r"|\bthis (?:is|task is|work is) (?:done|complete|finished)\b"
+    r"|\b(?:work|it) is (?:complete|finished)\b",
+    re.I)
+
+SUPPRESSORS = (
+    ("asks", ASKS),
+    ("commits", COMMITS),
+    ("offers", OFFERS),
+    ("marked", MARKED),
+    ("headed", HEADED),
+    ("labelled", LABELLED),
+    ("done", DONE),
+)
+
+# A user message that ENDS the exchange. The turn that answers one of these owes no next
+# step — the operator has already said they are done. Anchored whole-message (the whole
+# prompt is the word), never a substring: "stop the timer and then …" is not terminal.
+TERMINAL_PROMPT = re.compile(
+    r"^\s*(?:/(?:clear|compact|exit|quit|resume)\b.*"
+    r"|(?:thanks?|thank you|ty|thx|stop|halt|cancel|abort|nvm|never ?mind|done|"
+    r"bye|goodnight|gn|ok|okay|k|cool|nice|great|perfect|got it|understood|"
+    r"no|nope|nothing|that['’]?s all|all good)\W*)$",
+    re.I | re.S)
+
+# A short interrogative opener — "who did the semver commit", "which pod is OOMing?".
+# Wh-initial OR question-marked, AND short. Both halves are needed: a 2 KB prompt that
+# happens to end in '?' is a task, not a lookup.
+WH_INITIAL = re.compile(
+    r"^\s*(?:who|what|which|when|where|why|how|is|are|was|were|does|do|did|can|could|"
+    r"should|would|has|have|had|any)\b",
+    re.I)
+
+
+def tail_of(text, nchars=TAIL_CHARS):
+    """The message's final paragraph blocks, taken from the end until >= nchars covered.
+
+    Positional by construction: blocks are split on blank lines and consumed backwards,
+    so the window always starts at a paragraph boundary. A single huge final paragraph
+    yields itself whole — deliberately, since truncating mid-paragraph could cut a
+    commitment in half and turn a suppressed turn into a firing one.
+    """
+    if not text:
+        return ""
+    blocks = re.split(r"\n\s*\n", text.rstrip())
+    out, total = [], 0
+    for b in reversed(blocks):
+        out.append(b)
+        total += len(b)
+        if total >= nchars:
+            break
+    return "\n\n".join(reversed(out))
+
+
+def suppressed_by(text):
+    """Names of every suppressor matching the tail of `text`. Empty => the turn named
+    no next step. Returned as a list (not a bool) so a test can pin WHICH guard fired —
+    a mutation that breaks one suppressor must not be masked by another still matching.
+    """
+    t = tail_of(text)
+    return [name for name, rx in SUPPRESSORS if rx.search(t)]
+
+
+def names_next_step(text):
+    """True if the turn already names a next step, asks, or offers a marked choice."""
+    return bool(suppressed_by(text))
+
+
+def is_terminal_prompt(prompt):
+    return bool(prompt) and bool(TERMINAL_PROMPT.match(prompt))
+
+
+def is_short_question(prompt):
+    """A brief factual lookup: short AND interrogative in shape."""
+    if not prompt:
+        return False
+    p = prompt.strip()
+    if len(p) > SHORT_QUESTION_CHARS:
+        return False
+    return bool(WH_INITIAL.match(p)) or p.endswith("?")
+
+
+# --------------------------------------------------------------------------- #
+# Turn shape, from the transcript tail
+# --------------------------------------------------------------------------- #
+def _is_real_user(rec):
+    """A genuine operator prompt, not a tool_result the harness wrote back as `user`."""
+    if rec.get("type") != "user" or rec.get("isSidechain"):
+        return False
+    content = (rec.get("message") or {}).get("content")
+    if isinstance(content, str):
+        return True
+    if isinstance(content, list):
+        return not any(isinstance(b, dict) and b.get("type") == "tool_result"
+                       for b in content)
+    return False
+
+
+def _user_text(rec):
+    content = (rec.get("message") or {}).get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return " ".join(b.get("text", "") for b in content
+                        if isinstance(b, dict) and b.get("type") == "text")
+    return ""
+
+
+def _turn_shape(path):
+    """(opening_prompt, tool_use_count) for the turn that just ended, or None.
+
+    None means "could not establish", and every caller treats that as do-not-fire.
+
+    Reads only the last TRANSCRIPT_TAIL_BYTES so cost is bounded on a multi-MB
+    transcript, and drops the first (probably partial) line. If no operator prompt
+    appears in that window the turn is larger than the window, which is itself proof it
+    did work — reported as (None, large) so the work gate passes and the prompt-shaped
+    gates are skipped rather than guessed at.
+
+    🔴 Only the transcript's OLDER records are read here. The final assistant message is
+    documented to lag the transcript, which is exactly why `last_assistant_message` from
+    the payload is used for the text instead of anything found in this file.
+    """
+    try:
+        size = os.path.getsize(path)
+        with open(path, "rb") as fh:
+            if size > TRANSCRIPT_TAIL_BYTES:
+                fh.seek(size - TRANSCRIPT_TAIL_BYTES)
+                fh.readline()  # discard the partial line
+            raw_lines = fh.readlines()
+    except Exception:
+        return None
+
+    recs = []
+    for raw in raw_lines:
+        try:
+            rec = json.loads(raw)
+        except Exception:
+            continue
+        if isinstance(rec, dict):
+            recs.append(rec)
+
+    tools = 0
+    prompt = None
+    seen_user = False
+    for rec in reversed(recs):
+        if _is_real_user(rec):
+            prompt = _user_text(rec)
+            seen_user = True
+            break
+        if rec.get("type") == "assistant" and not rec.get("isSidechain"):
+            content = (rec.get("message") or {}).get("content")
+            if isinstance(content, list):
+                tools += sum(1 for b in content
+                             if isinstance(b, dict) and b.get("type") == "tool_use")
+
+    if not seen_user:
+        # 🔴 "No operator prompt in the window" has TWO causes and the observable is the
+        # same for both: (a) the turn is larger than the window — real, and proof it did
+        # work; (b) the file is corrupt, truncated, or is not a transcript at all — from
+        # which nothing at all follows. Picking (a) because it was the case I had in mind
+        # is a coin flip, and it resolves toward FIRING, which is the expensive direction.
+        #
+        # The upstream signal the two disagree about is whether ANY tool_use record
+        # parsed: an oversized turn's window is full of them, a corrupt file yields none.
+        # So require that evidence, and return "could not establish" without it. Found by
+        # test_fail_open_on_a_binary_transcript, which fired the hook on 4 KB of
+        # /dev/urandom before this branch existed.
+        return (None, tools) if tools >= 1 else None
+    return (prompt, tools)
+
+
+# --------------------------------------------------------------------------- #
+# Once-per-session claim. Same atomic O_EXCL test-and-set as search-tool-nudge.py,
+# with the fail direction REVERSED: an unwritable state dir means we cannot promise
+# once-per-session, and an unbounded Stop-blocker is the one outcome worse than a
+# missed nudge — so an unclaimable token means DO NOT FIRE.
+# --------------------------------------------------------------------------- #
+def _sanitize(part):
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", part)[:120]
+
+
+def _state_dir(data):
+    session = data.get("session_id")
+    if not isinstance(session, str) or not session:
+        return None
+    return os.path.join(_state_root(), _sanitize(session))
+
+
+def already_fired(state_dir):
+    if not state_dir:
+        return True
+    try:
+        return STATE_TOKEN in os.listdir(state_dir)
+    except FileNotFoundError:
+        return False
+    except Exception:
+        return True
+
+
+def claim(state_dir):
+    """True iff THIS process created the session's single token. Fails CLOSED.
+
+    O_CREAT|O_EXCL is one atomic test-and-set, so of N concurrent processes exactly one
+    gets True. There is no lock, so this can never hang a Stop.
+
+    🔴 ONE handler, deliberately, and this is where it diverges from
+    search-tool-nudge.py's claim(): that one splits makedirs and open into two handlers
+    because its two failure modes have DIFFERENT answers (an unwritable state dir must
+    fail OPEN and emit; only a lost race may return False). Here both answers are False —
+    FileExistsError, an unwritable directory and a state root that is a regular file all
+    mean "this token is not provably ours", and the only safe response to that is
+    silence. Two handlers returning the same value would be decoration: a mutation sweep
+    deleted the first one and no test could tell, which is what prompted this collapse.
+    """
+    if not state_dir:
+        return False
+    try:
+        os.makedirs(state_dir, exist_ok=True)
+        os.close(os.open(os.path.join(state_dir, STATE_TOKEN),
+                         os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600))
+        return True
+    except Exception:
+        return False
+
+
+NUDGE = (
+    "next-step: this turn ended without saying what happens next, so answering it "
+    "costs the operator an extra round trip just to ask.\n"
+    "Add ONE short closing line before you stop — either:\n"
+    "  • the action you would take next, stated so the reply can be a single "
+    "\"proceed\"; or\n"
+    "  • a numbered choice with YOUR recommendation marked.\n"
+    "If the work is genuinely finished and nothing follows, say that explicitly — "
+    "\"nothing further; this is done\" is a valid next step.\n"
+    "Do not redo any work, re-run any command, or restate the summary: append the one "
+    "line and stop. (Fires at most once per session.)"
+)
+
+
+def should_nudge(data, transcript_reader=_turn_shape):
+    """Pure decision, no side effects. True => this turn should be nudged.
+
+    Split out from main() so the gates can be tested directly AND mutation-tested one at
+    a time; main() adds only the claim and the exit-2 emission.
+    """
+    if not isinstance(data, dict):
+        return False
+    if data.get("hook_event_name") not in (None, "Stop"):
+        return False          # SubagentStop and friends: a subagent's turn never
+    if data.get("agent_id"):  # reaches the operator, so it owes them no next step.
+        return False
+    if data.get("stop_hook_active"):
+        return False          # never block twice in a row
+    stop_reason = data.get("stop_reason")
+    if stop_reason not in (None, "", "end_turn"):
+        return False          # max_tokens/tool_use is truncation, not a considered end
+
+    msg = data.get("last_assistant_message")
+    if not isinstance(msg, str) or len(msg) < MIN_MESSAGE_CHARS:
+        return False
+
+    if names_next_step(msg):
+        return False
+
+    path = data.get("transcript_path")
+    if not isinstance(path, str) or not path:
+        return False
+    shape = transcript_reader(path)
+    if shape is None:
+        return False          # cannot establish the turn's shape -> stay silent
+    prompt, tools = shape
+    if tools < 1:
+        return False          # no work in this turn -> nothing to have a next step for
+    if prompt is not None:
+        if is_terminal_prompt(prompt):
+            return False
+        if is_short_question(prompt):
+            return False
+    return True
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+    try:
+        if not should_nudge(data):
+            sys.exit(0)
+        state_dir = _state_dir(data)
+        if already_fired(state_dir):
+            sys.exit(0)
+        if not claim(state_dir):
+            sys.exit(0)
+        sys.stderr.write(NUDGE + "\n")
+        sys.exit(2)
+    except SystemExit:
+        raise
+    except Exception:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/claude-hooks/register-nudge-hook.py
+++ b/scripts/claude-hooks/register-nudge-hook.py
@@ -12,6 +12,20 @@ Registers:
   * UserPromptSubmit / Stop / SubagentStop: claude-notify.py (the turn-finished
     notifier — a best-effort side-effect hook, appended alongside any existing
     Stop/clawgate-stop/tmux hooks).
+  * Stop: next-step-nudge.py
+
+🔴 Stop is a SHARED event with three pre-existing owners this script does not own and
+must never disturb: the fuzzyclaw tmux writer (~/.config/tmux/task-hook.sh), the
+clawgate stop hook (drives remote approval) and claude-notify.py (drives turn-finished
+notifications). Clobbering any of them is a serious regression, so registration here is
+strictly APPEND-ONLY — an entry is added only when its exact command string is absent
+from the event's existing entries, and no existing entry is ever rewritten, reordered or
+removed. tests/test_register_nudge_hook.py asserts all four coexist afterwards.
+
+next-step-nudge is registered on Stop ONLY, not SubagentStop: a subagent's turn ends
+without ever reaching the operator, so it owes them no next step. The hook refuses that
+event itself as well — belt and braces, because the registration is per-host mutable
+state and the hook is the thing that actually ships.
 
 Run on each host after a home-manager switch that adds a new hook:
     python3 ~/workspace/devrc/scripts/claude-hooks/register-nudge-hook.py
@@ -31,6 +45,11 @@ POST_BASH_CMDS = [
 # dispatched on the event name in its stdin payload).
 NOTIFY_CMD = "python3 ~/.claude/hooks/claude-notify.py"
 NOTIFY_EVENTS = ["UserPromptSubmit", "Stop", "SubagentStop"]
+
+# Hooks registered on exactly one event each: {event: [command, ...]}.
+SINGLE_EVENT_CMDS = {
+    "Stop": ["python3 ~/.claude/hooks/next-step-nudge.py"],
+}
 
 with open(SETTINGS) as f:
     data = json.load(f)
@@ -62,6 +81,16 @@ for event in NOTIFY_EVENTS:
         continue
     arr.append({"hooks": [{"type": "command", "command": NOTIFY_CMD}]})
     added.append("%s: %s" % (event, NOTIFY_CMD))
+
+# --- single-event hooks (append-only, same discipline) -----------------------
+for event, cmds in SINGLE_EVENT_CMDS.items():
+    arr = hooks.setdefault(event, [])
+    present = registered_commands(arr)
+    for cmd in cmds:
+        if cmd in present:
+            continue
+        arr.append({"hooks": [{"type": "command", "command": cmd}]})
+        added.append("%s: %s" % (event, cmd))
 
 if not added:
     print("all devrc-managed hooks already registered — no change")

--- a/scripts/claude-hooks/tests/test_next_step_nudge.py
+++ b/scripts/claude-hooks/tests/test_next_step_nudge.py
@@ -1,0 +1,672 @@
+#!/usr/bin/env python3
+"""Tests for next-step-nudge.py — the Stop hook that asks for a next step.
+
+WHAT THIS FILE IS FOR
+
+  1. 🔴 The SUPPRESSION predicate is the whole product. This hook fires by BLOCKING
+     the operator's Stop (exit 2 is the only documented way a Stop hook can reach the
+     model), so a false positive is not a wasted line of context — it is a turn that
+     will not end. A hook that nags is strictly worse than no hook, so the negative
+     controls below outnumber the positive ones roughly 4:1 and that ratio is
+     deliberate.
+
+  2. ATTRIBUTION. `suppressed_by()` returns the NAMES of the guards that matched, and
+     every suppressor has at least one fixture that it and ONLY it saves
+     (`test_each_suppressor_is_uniquely_reachable`). That is what makes a mutation
+     sweep meaningful: break one suppressor and a test goes red naming that suppressor,
+     rather than the fixture being rescued by a sibling guard and the mutant surviving.
+
+  3. FAIL-OPEN, which here means SILENCE. Every error path must exit 0 and write
+     nothing, because the alternative is a wedged turn on the operator's live machine.
+     Driven through a real subprocess, not by calling main().
+
+  4. The SEAM between should_nudge() and the transcript reader. The unit tests stub the
+     reader; the subprocess tests write a real JSONL transcript and let the shipped
+     reader parse it, so a defect that lives only in their interface cannot hide.
+
+    run:  python -m pytest scripts/claude-hooks/tests/test_next_step_nudge.py -q
+
+Fixtures are synthetic. This repo is public: no real paths, hostnames or task titles.
+"""
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+HOOK = Path(__file__).resolve().parents[1] / "next-step-nudge.py"
+_spec = importlib.util.spec_from_file_location("next_step_nudge", HOOK)
+nsn = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(nsn)
+
+
+# --------------------------------------------------------------------------- #
+# Fixture material
+#
+# FILLER is deliberately inert: long enough to clear MIN_MESSAGE_CHARS and to fill the
+# positional tail window, and free of every suppressor. Each fixture below is
+# FILLER + a distinct final paragraph, so the ONLY thing that varies between a firing
+# and a silent case is how the turn ends — which is the claim the hook makes.
+# --------------------------------------------------------------------------- #
+FILLER = (
+    "The sweep covered three modules. Module A had two findings, both on the error\n"
+    "path, and both traced back to the same helper rather than to the call sites.\n"
+    "Module B came back clean at every input size tried. Module C had one finding in\n"
+    "its retry loop, where the backoff resets on each attempt instead of accumulating,\n"
+    "so a burst of failures retries at a fixed interval forever.\n"
+    "\n"
+    "The measurement ran at two points, 40 and 200 concurrent requests, and the two\n"
+    "runs agreed within noise. Median latency was flat across both; the tail moved by\n"
+    "roughly a factor of four between them, which is consistent with the retry loop\n"
+    "above and not with contention on the shared cache, since cache hit rate was\n"
+    "unchanged at 94 percent in both runs. The counter that would separate those two\n"
+    "explanations is not currently exported by the service.\n"
+)
+
+
+def msg(ending):
+    return FILLER + "\n" + ending
+
+
+def payload(text, **over):
+    """A realistic Stop payload. Overridable field by field so a gate test can move
+    exactly one thing and leave everything else in its firing state."""
+    d = {
+        "hook_event_name": "Stop",
+        "session_id": "11111111-2222-3333-4444-555555555555",
+        "transcript_path": "/nonexistent/transcript.jsonl",
+        "last_assistant_message": text,
+        "stop_reason": "end_turn",
+        "cwd": "/tmp",
+    }
+    d.update(over)
+    return d
+
+
+def decide(text, prompt="Audit the retry path and report what you find.", tools=7, **over):
+    """should_nudge() with the transcript reader stubbed to a known turn shape."""
+    return nsn.should_nudge(payload(text, **over), transcript_reader=lambda p: (prompt, tools))
+
+
+# ============================================================================ #
+# 0. Harness self-validation — the negative and positive controls for the tests
+#    themselves. Until both of these hold, nothing below means anything.
+# ============================================================================ #
+def test_control_filler_alone_triggers_no_suppressor():
+    """POSITIVE CONTROL for the fixtures: the shared body is inert, so every result
+    below is attributable to the ending under test and not to the filler."""
+    assert nsn.suppressed_by(FILLER) == []
+
+
+def test_control_predicate_can_fire_and_can_stay_silent():
+    """NEGATIVE CONTROL for the predicate: it is not wired to a constant. Both verdicts
+    are reachable from the same fixture body."""
+    assert decide(msg("The counter is not exported, so that comparison stays open.")) is True
+    assert decide(msg("I'll export the counter and re-run both points.")) is False
+
+
+# ============================================================================ #
+# 1. POSITIVE CONTROL — a turn that genuinely names no next step MUST nudge.
+# ============================================================================ #
+NO_NEXT_STEP = [
+    "The counter that separates the two explanations is not exported, so the "
+    "comparison stays open.",
+    "So the retry loop is the cause, and the cache is not involved at all.",
+    "That is the whole picture from the three runs.",
+    "The generalisable finding is that a backoff which resets per attempt is "
+    "indistinguishable from no backoff under a sustained failure.",
+    "Both numbers came from the same instrument, so they cannot disagree about the "
+    "thing the instrument does not measure.",
+]
+
+
+@pytest.mark.parametrize("ending", NO_NEXT_STEP, ids=range(len(NO_NEXT_STEP)))
+def test_positive_control_turn_without_next_step_nudges(ending):
+    assert decide(msg(ending)) is True
+
+
+def test_positive_control_count_moves():
+    """Report the count, not just a boolean: a predicate wired to nothing and a
+    predicate that is merely conservative both produce 'no failures' otherwise."""
+    fired = sum(1 for e in NO_NEXT_STEP if decide(msg(e)))
+    assert fired == len(NO_NEXT_STEP), f"positive control fired {fired}/{len(NO_NEXT_STEP)}"
+
+
+# ============================================================================ #
+# 2. NEGATIVE CONTROLS — the ones that matter. Each ending already discharges the
+#    operator's round trip, so each must stay silent.
+# ============================================================================ #
+NAMES_NEXT_STEP = {
+    # (id, ending, the suppressor that must own it)
+    "commitment_first_person": ("I'll export the counter and re-run both points.", "commits"),
+    "commitment_contraction": ("Next round I'd raise the ceiling before touching the loop.", "commits"),
+    "commitment_impersonal": ("The counter will land in the next deploy and the "
+                              "comparison reruns automatically after it.", "commits"),
+    "explicit_question": ("Should the counter go in before the loop fix, or after?", "asks"),
+    "numbered_choice_marked": (
+        "Two ways forward:\n\n1. Export the counter first, then re-measure.\n"
+        "2. Fix the loop now and accept the comparison stays open.\n\n"
+        "Recommendation: option 1 — it is read-only and it settles the disagreement.",
+        "marked"),
+    "offer_handoff": ("Say the word and the counter goes in.", "offers"),
+    "offer_your_call": ("Which of the two lands first is your call.", "offers"),
+    "headed_section": ("**Next steps**\n\n- export the counter\n- re-measure at both points", "headed"),
+    "headed_with_modifier": ("**Ranked next steps** put the counter ahead of the loop fix, "
+                             "because it is the cheaper measurement.", "headed"),
+    "labelled_bare": ("Next: export the counter, then re-measure at both points.", "labelled"),
+    "explicitly_done": ("Nothing further — the sweep is complete and no follow-up is owed.", "done"),
+}
+
+
+@pytest.mark.parametrize("key", sorted(NAMES_NEXT_STEP))
+def test_negative_control_turn_naming_next_step_stays_silent(key):
+    ending, _owner = NAMES_NEXT_STEP[key]
+    assert decide(msg(ending)) is False
+
+
+def test_each_suppressor_is_uniquely_reachable():
+    """🔴 REACHABILITY + ATTRIBUTION, the guard against a shadowed mutant.
+
+    For every suppressor there is a fixture that IT ALONE saves. If a sibling also
+    matched, deleting the suppressor under test would leave the fixture suppressed
+    anyway and the mutant would survive with every test still green.
+    """
+    for key, (ending, owner) in sorted(NAMES_NEXT_STEP.items()):
+        got = nsn.suppressed_by(msg(ending))
+        assert got == [owner], f"{key}: expected only {owner!r} to match, got {got!r}"
+
+
+def test_every_suppressor_has_a_fixture():
+    """A suppressor with no fixture is one a mutation sweep cannot kill. Pinned as a
+    ledger so ADDING a suppressor without a fixture fails here, loudly."""
+    owned = {owner for _e, owner in NAMES_NEXT_STEP.values()}
+    declared = {name for name, _rx in nsn.SUPPRESSORS}
+    assert owned == declared, f"unowned: {declared - owned}; stale: {owned - declared}"
+
+
+def test_self_consistency_the_nudge_does_not_fire_on_its_own_advice():
+    """🔴 The NUDGE text prescribes three endings. A turn that follows the instruction
+    must not be nudged again — that is the shape that teaches an operator to ignore a
+    hook. Read out of NUDGE's own wording rather than restated, so a reword that drops
+    an option is visible here."""
+    assert "proceed" in nsn.NUDGE and "recommendation marked" in nsn.NUDGE
+    for ending in (
+        "I would take the counter export next, so this can be a single proceed.",
+        "1. Export the counter. 2. Fix the loop. My recommendation is 1.",
+        "Nothing further; this is done.",
+    ):
+        assert decide(msg(ending)) is False, f"nudge fires on its own prescribed ending: {ending!r}"
+
+
+# ============================================================================ #
+# 3. GATES — each moves exactly one field away from the firing payload.
+# ============================================================================ #
+FIRING = msg(NO_NEXT_STEP[0])
+
+
+def test_gate_baseline_fires():
+    """The reference point every gate test below is a one-field delta from."""
+    assert decide(FIRING) is True
+
+
+def test_gate_terminal_user_message():
+    for prompt in ("thanks", "Thanks!", "/clear", "/compact", "stop", "done", "nvm",
+                   "that's all", "ok", "no"):
+        assert decide(FIRING, prompt=prompt) is False, prompt
+
+
+def test_gate_terminal_is_whole_message_not_substring():
+    """'stop the timer and then re-run' is a task, not a goodbye. A substring test here
+    would silence the hook on any prompt containing a terminal word."""
+    assert decide(FIRING, prompt="stop the timer and then re-run the sweep") is True
+
+
+def test_gate_short_factual_question():
+    for prompt in ("who wrote the retry loop", "which module was clean?",
+                   "is the counter exported?", "how many runs were there"):
+        assert decide(FIRING, prompt=prompt) is False, prompt
+
+
+def test_gate_long_question_is_still_work():
+    """Both halves of the short-question gate are needed: a long prompt that happens to
+    end in '?' is a task, and must not be excused as a lookup."""
+    long_q = ("Can you audit the retry path across all three modules, measure it at two "
+              "concurrency points, work out whether the tail is the loop or the cache, "
+              "and tell me which counter would settle it?")
+    assert len(long_q) > nsn.SHORT_QUESTION_CHARS
+    assert decide(FIRING, prompt=long_q) is True
+
+
+def test_gate_no_work_in_turn():
+    assert decide(FIRING, tools=0) is False
+
+
+def test_gate_message_too_short():
+    assert decide("Yes — module B was clean.") is False
+    assert len("Yes — module B was clean.") < nsn.MIN_MESSAGE_CHARS
+
+
+def test_gate_stop_hook_active():
+    """Never block twice in a row. Without this the 8-block cap is the only backstop."""
+    assert decide(FIRING, stop_hook_active=True) is False
+
+
+def test_gate_subagent_turn():
+    """A subagent's Stop never reaches the operator, so it owes them no next step."""
+    assert decide(FIRING, agent_id="agent-abc123") is False
+    assert decide(FIRING, hook_event_name="SubagentStop") is False
+
+
+def test_gate_non_end_turn_stop_reason():
+    """A max_tokens stop is truncation, not a considered ending; nudging it would ask
+    the model to append a next step to a sentence cut in half."""
+    assert decide(FIRING, stop_reason="max_tokens") is False
+    assert decide(FIRING, stop_reason="tool_use") is False
+    assert decide(FIRING, stop_reason=None) is True   # absent field must not gate
+
+
+def test_gate_missing_or_nonstring_message():
+    for bad in (None, 123, [], {}):
+        assert decide(FIRING, last_assistant_message=bad) is False
+
+
+def test_gate_unreadable_transcript_stays_silent():
+    """Cannot establish the turn shape => cannot establish the gates => do not fire.
+    This is the fail-open direction for THIS hook: silence, not emission."""
+    assert nsn.should_nudge(payload(FIRING), transcript_reader=lambda p: None) is False
+
+
+def test_gate_missing_transcript_path():
+    assert decide(FIRING, transcript_path=None) is False
+    assert decide(FIRING, transcript_path="") is False
+
+
+def test_gate_non_dict_payload():
+    assert nsn.should_nudge(None) is False
+    assert nsn.should_nudge("not a dict") is False
+    assert nsn.should_nudge([1, 2, 3]) is False
+
+
+# ============================================================================ #
+# 4. Positional tail — the window is the end of the message, not the whole of it.
+# ============================================================================ #
+def test_next_step_buried_far_above_the_tail_does_not_suppress():
+    """🔴 AN INVARIANT GUARD, NOT REGRESSION COVERAGE — labelled as such deliberately.
+
+    It pins that the window is positional, but real traffic never violates it: sweeping
+    TAIL_CHARS from 10 to 10^9 over 11,215 real turns leaves the fire count unmoved at
+    565, because a message with any forward-looking construction essentially always has
+    one in its final paragraph. So this test constructs a shape the corpus does not
+    contain. It earns its place by pinning the intent cheaply; it must not be counted as
+    evidence that the window does anything on real messages.
+    """
+    buried = ("I'll export the counter first.\n\n" + FILLER * 4 + "\n" +
+              "The counter is not exported, so the comparison stays open.")
+    assert nsn.suppressed_by(buried) == []
+    assert decide(buried) is True
+
+
+def test_tail_starts_at_a_paragraph_boundary():
+    tail = nsn.tail_of(FILLER * 3)
+    assert len(tail) >= nsn.TAIL_CHARS
+    assert FILLER.rstrip().endswith(tail[-40:].rstrip()) or tail in (FILLER * 3)
+
+
+def test_tail_of_short_message_is_the_whole_message():
+    assert nsn.tail_of("one short line.") == "one short line."
+    assert nsn.tail_of("") == ""
+
+
+# ============================================================================ #
+# 5. Once per session, and the atomic claim under concurrency.
+# ============================================================================ #
+def test_claim_is_once_per_session(tmp_path, monkeypatch):
+    monkeypatch.setattr(nsn, "_state_root", lambda: str(tmp_path / "s"))
+    d = nsn._state_dir({"session_id": "sess-A"})
+    assert nsn.already_fired(d) is False
+    assert nsn.claim(d) is True
+    assert nsn.already_fired(d) is True
+    assert nsn.claim(d) is False
+
+
+def test_claim_is_per_session_not_global(tmp_path, monkeypatch):
+    monkeypatch.setattr(nsn, "_state_root", lambda: str(tmp_path / "s"))
+    assert nsn.claim(nsn._state_dir({"session_id": "sess-A"})) is True
+    assert nsn.claim(nsn._state_dir({"session_id": "sess-B"})) is True
+
+
+def test_claim_fails_closed_without_a_session_id(tmp_path, monkeypatch):
+    """No session id => no once-per-session guarantee => must not block a turn."""
+    monkeypatch.setattr(nsn, "_state_root", lambda: str(tmp_path / "s"))
+    assert nsn._state_dir({}) is None
+    assert nsn.claim(None) is False
+    assert nsn.already_fired(None) is True
+
+
+def test_claim_fails_closed_when_the_state_root_is_not_a_directory(tmp_path, monkeypatch):
+    """🔴 The fail direction is REVERSED from the PostToolUse nudges. There, an
+    unwritable cache duplicates a harmless nudge; here it would mean an unbounded
+    Stop-blocker, which is the one outcome worse than a missed nudge.
+
+    This test owns the makedirs arm ONLY — see the companion below."""
+    blocker = tmp_path / "s"
+    blocker.write_text("not a directory")          # makedirs will raise
+    monkeypatch.setattr(nsn, "_state_root", lambda: str(blocker))
+    assert nsn.claim(nsn._state_dir({"session_id": "sess-C"})) is False
+
+
+def test_claim_fails_closed_when_the_token_cannot_be_created(tmp_path, monkeypatch):
+    """🔴 REACHABILITY, and the two claim() tests are NOT interchangeable.
+
+    The test above fails at `makedirs`; this one gets past it and fails at the O_EXCL
+    `open`, with an error that is NOT FileExistsError — the session directory exists but
+    is not writable, so makedirs(exist_ok=True) succeeds and the open raises
+    PermissionError. A mutation sweep is what proved the distinction matters: flipping
+    the open's handler to `return True` survived the makedirs test entirely and was
+    caught only by the once-per-session tests, i.e. green for the wrong reason."""
+    root = tmp_path / "s"
+    monkeypatch.setattr(nsn, "_state_root", lambda: str(root))
+    d = nsn._state_dir({"session_id": "sess-D"})
+    os.makedirs(d)
+    os.chmod(d, 0o500)                              # readable, NOT writable
+    try:
+        if os.access(d, os.W_OK):                   # running as root: cannot occur
+            pytest.skip("cannot make a directory unwritable as this user")
+        assert nsn.claim(d) is False
+    finally:
+        os.chmod(d, 0o700)
+
+
+def test_already_fired_fails_closed_on_an_unexpected_error(tmp_path, monkeypatch):
+    """already_fired() reads 'not yet' only for a genuinely absent directory. Any OTHER
+    error means the state is unknown, and unknown must not become 'go ahead and block'.
+    Reached with a state path that is a regular file, so listdir raises NotADirectoryError
+    rather than FileNotFoundError."""
+    root = tmp_path / "s"
+    monkeypatch.setattr(nsn, "_state_root", lambda: str(root))
+    d = nsn._state_dir({"session_id": "sess-E"})
+    os.makedirs(os.path.dirname(d), exist_ok=True)
+    Path(d).write_text("a file where a directory should be")
+    assert nsn.already_fired(d) is True
+
+
+def test_claim_is_atomic_under_concurrency(tmp_path, monkeypatch):
+    """Exactly one winner among N racers — O_EXCL, no lock, so it can never hang."""
+    monkeypatch.setattr(nsn, "_state_root", lambda: str(tmp_path / "s"))
+    d = nsn._state_dir({"session_id": "sess-race"})
+    from concurrent.futures import ThreadPoolExecutor
+    with ThreadPoolExecutor(max_workers=16) as ex:
+        wins = sum(ex.map(lambda _: nsn.claim(d), range(64)))
+    assert wins == 1
+
+
+def test_session_id_sanitised_into_one_path_component(tmp_path, monkeypatch):
+    """A session id is used as a filename, so it must not be able to escape the root.
+    Asserted STRUCTURALLY — the resolved path stays under the root and the id occupies
+    exactly one component — not by spelling, since '.._.._etc_passwd' legitimately
+    contains '..' as text while traversing nowhere."""
+    root = tmp_path / "s"
+    monkeypatch.setattr(nsn, "_state_root", lambda: str(root))
+    d = nsn._state_dir({"session_id": "../../etc/passwd"})
+    assert os.path.dirname(d) == str(root)
+    assert os.sep not in os.path.basename(d)
+    assert os.path.realpath(d).startswith(str(root.resolve()) + os.sep)
+
+
+# ============================================================================ #
+# 6. The transcript reader, against real files (the seam).
+# ============================================================================ #
+def write_transcript(path, prompt, tool_uses, trailing_assistant_text=None):
+    recs = [{"type": "user", "message": {"role": "user", "content": prompt}}]
+    for i in range(tool_uses):
+        recs.append({"type": "assistant", "message": {"role": "assistant", "content": [
+            {"type": "tool_use", "id": f"t{i}", "name": "Bash", "input": {}}]}})
+        recs.append({"type": "user", "message": {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": f"t{i}", "content": "ok"}]}})
+    if trailing_assistant_text:
+        recs.append({"type": "assistant", "message": {"role": "assistant", "content": [
+            {"type": "text", "text": trailing_assistant_text}]}})
+    path.write_text("".join(json.dumps(r) + "\n" for r in recs))
+
+
+def test_turn_shape_reads_prompt_and_counts_tools(tmp_path):
+    t = tmp_path / "t.jsonl"
+    write_transcript(t, "Audit the retry path.", 5)
+    assert nsn._turn_shape(str(t)) == ("Audit the retry path.", 5)
+
+
+def test_turn_shape_ignores_tool_results_masquerading_as_user_records(tmp_path):
+    """The harness writes tool results back as type=user. Treating one as the operator's
+    prompt would read the turn as zero-work and silence the hook everywhere."""
+    t = tmp_path / "t.jsonl"
+    write_transcript(t, "Audit the retry path.", 4)
+    prompt, tools = nsn._turn_shape(str(t))
+    assert prompt == "Audit the retry path." and tools == 4
+
+
+def test_turn_shape_counts_only_the_current_turn(tmp_path):
+    t = tmp_path / "t.jsonl"
+    recs = [
+        {"type": "user", "message": {"content": "first task"}},
+        {"type": "assistant", "message": {"content": [{"type": "tool_use", "id": "a", "name": "Bash", "input": {}}]}},
+        {"type": "user", "message": {"content": "second task"}},
+        {"type": "assistant", "message": {"content": [{"type": "tool_use", "id": "b", "name": "Bash", "input": {}}]}},
+        {"type": "assistant", "message": {"content": [{"type": "tool_use", "id": "c", "name": "Bash", "input": {}}]}},
+    ]
+    t.write_text("".join(json.dumps(r) + "\n" for r in recs))
+    assert nsn._turn_shape(str(t)) == ("second task", 2)
+
+
+def test_turn_shape_skips_sidechain_assistant_records(tmp_path):
+    """Subagent traffic shares the file; counting it as the main turn's work would let a
+    zero-work main turn look busy."""
+    t = tmp_path / "t.jsonl"
+    recs = [
+        {"type": "user", "message": {"content": "the task"}},
+        {"type": "assistant", "isSidechain": True,
+         "message": {"content": [{"type": "tool_use", "id": "s", "name": "Bash", "input": {}}]}},
+    ]
+    t.write_text("".join(json.dumps(r) + "\n" for r in recs))
+    assert nsn._turn_shape(str(t)) == ("the task", 0)
+
+
+def test_turn_shape_skips_sidechain_user_records(tmp_path):
+    """🔴 The OTHER half of the sidechain guard, and a mutation sweep proved the test
+    above does not reach it: deleting `isSidechain` from _is_real_user killed nothing,
+    because that test only exercises the assistant-side skip.
+
+    A subagent's PROMPT is also written into the shared transcript as type=user. Reading
+    one as the operator's prompt would test the terminal/short-question gates against
+    text the operator never typed, and would truncate the tool count at the subagent
+    boundary. Walking back from the end here must skip it and reach the real prompt.
+    """
+    t = tmp_path / "t.jsonl"
+    recs = [
+        {"type": "user", "message": {"content": "the operator's real task"}},
+        {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "a", "name": "Bash", "input": {}},
+            {"type": "tool_use", "id": "b", "name": "Bash", "input": {}}]}},
+        {"type": "user", "isSidechain": True, "message": {"content": "who wrote this?"}},
+        {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "c", "name": "Bash", "input": {}}]}},
+    ]
+    t.write_text("".join(json.dumps(r) + "\n" for r in recs))
+    assert nsn._turn_shape(str(t)) == ("the operator's real task", 3)
+
+
+def test_turn_shape_survives_malformed_lines(tmp_path):
+    t = tmp_path / "t.jsonl"
+    write_transcript(t, "Audit it.", 3)
+    with open(t, "a") as fh:
+        fh.write("{ this is not json\n")
+        fh.write("\n")
+        fh.write('"a bare string"\n')
+    prompt, tools = nsn._turn_shape(str(t))
+    assert prompt == "Audit it." and tools == 3
+
+
+def test_turn_shape_returns_none_for_a_missing_file(tmp_path):
+    assert nsn._turn_shape(str(tmp_path / "nope.jsonl")) is None
+
+
+def test_turn_shape_of_an_empty_file_establishes_nothing(tmp_path):
+    """🔴 An empty result cannot distinguish 'the turn is bigger than the window' from
+    'this file is not a transcript'. Both look like 'no operator prompt found'. Only the
+    first is evidence that work happened, so without a parsed tool_use to tell them
+    apart the answer is None — could not establish — and the hook stays silent."""
+    t = tmp_path / "e.jsonl"
+    t.write_text("")
+    assert nsn._turn_shape(str(t)) is None
+
+
+def test_turn_shape_of_an_unparseable_file_establishes_nothing(tmp_path):
+    t = tmp_path / "junk.jsonl"
+    t.write_text("\n".join("not json line %d" % i for i in range(500)))
+    assert nsn._turn_shape(str(t)) is None
+
+
+def test_turn_shape_treats_an_oversized_turn_as_work(tmp_path, monkeypatch):
+    """A turn bigger than the read window cannot be re-read cheaply. It is reported as
+    work-was-done with no prompt, so the work gate passes and the prompt-shaped gates
+    are skipped rather than guessed at."""
+    monkeypatch.setattr(nsn, "TRANSCRIPT_TAIL_BYTES", 512)
+    t = tmp_path / "big.jsonl"
+    write_transcript(t, "the task", 200)
+    prompt, tools = nsn._turn_shape(str(t))
+    assert prompt is None and tools >= 1
+    assert nsn.should_nudge(payload(FIRING, transcript_path=str(t))) is True
+
+
+# ============================================================================ #
+# 7. END TO END through a real subprocess — the shipped IO contract.
+# ============================================================================ #
+def run_hook(payload_dict, home):
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    return subprocess.run([sys.executable, str(HOOK)], input=json.dumps(payload_dict),
+                          capture_output=True, text=True, env=env, timeout=60)
+
+
+@pytest.fixture
+def home(tmp_path):
+    h = tmp_path / "home"
+    h.mkdir()
+    return h
+
+
+def test_e2e_fires_with_exit_2_and_a_message_on_stderr(tmp_path, home):
+    t = tmp_path / "t.jsonl"
+    write_transcript(t, "Audit the retry path.", 6)
+    p = run_hook(payload(FIRING, transcript_path=str(t)), home)
+    assert p.returncode == 2, p
+    assert p.stdout == ""
+    assert "next-step" in p.stderr and "proceed" in p.stderr
+
+
+def test_e2e_is_silent_once_per_session(tmp_path, home):
+    """The second turn of the same session stays silent even though it is identical."""
+    t = tmp_path / "t.jsonl"
+    write_transcript(t, "Audit the retry path.", 6)
+    d = payload(FIRING, transcript_path=str(t))
+    first = run_hook(d, home)
+    second = run_hook(d, home)
+    assert (first.returncode, second.returncode) == (2, 0)
+    assert second.stderr == ""
+
+
+def test_e2e_different_session_still_fires(tmp_path, home):
+    t = tmp_path / "t.jsonl"
+    write_transcript(t, "Audit the retry path.", 6)
+    a = run_hook(payload(FIRING, transcript_path=str(t), session_id="sess-1"), home)
+    b = run_hook(payload(FIRING, transcript_path=str(t), session_id="sess-2"), home)
+    assert (a.returncode, b.returncode) == (2, 2)
+
+
+def test_e2e_silent_on_a_turn_that_names_a_next_step(tmp_path, home):
+    t = tmp_path / "t.jsonl"
+    write_transcript(t, "Audit the retry path.", 6)
+    d = payload(msg("I'll export the counter and re-run both points."), transcript_path=str(t))
+    p = run_hook(d, home)
+    assert (p.returncode, p.stdout, p.stderr) == (0, "", "")
+
+
+# ============================================================================ #
+# 8. FAIL OPEN — every degenerate input exits 0 and writes NOTHING. A Stop hook that
+#    errors into the terminal, or blocks on a bad input, wedges the operator's session.
+# ============================================================================ #
+FAIL_OPEN_INPUTS = {
+    "not_json": "not json at all",
+    "empty": "",
+    "whitespace": "   \n  ",
+    "json_null": "null",
+    "json_list": "[1,2,3]",
+    "json_string": '"a string"',
+    "truncated": '{"hook_event_name": "Stop", "last_assistant_mess',
+    "empty_object": "{}",
+    "nulls_everywhere": json.dumps({"hook_event_name": None, "session_id": None,
+                                    "transcript_path": None, "last_assistant_message": None}),
+    "wrong_types": json.dumps({"hook_event_name": 7, "session_id": [], "transcript_path": {},
+                               "last_assistant_message": 12, "stop_reason": []}),
+    "deeply_nested": json.dumps({"hook_event_name": "Stop", "last_assistant_message":
+                                 {"nested": {"deeper": "x" * 2000}},
+                                 "transcript_path": "/nope", "session_id": "s"}),
+}
+
+
+@pytest.mark.parametrize("key", sorted(FAIL_OPEN_INPUTS))
+def test_fail_open_on_degenerate_stdin(key, home):
+    p = subprocess.run([sys.executable, str(HOOK)], input=FAIL_OPEN_INPUTS[key],
+                       capture_output=True, text=True,
+                       env={**os.environ, "HOME": str(home)}, timeout=60)
+    assert p.returncode == 0, f"{key}: rc={p.returncode} stderr={p.stderr!r}"
+    assert p.stderr == "", f"{key}: wrote to the operator's terminal: {p.stderr!r}"
+    assert p.stdout == "", f"{key}: {p.stdout!r}"
+
+
+def test_fail_open_on_a_missing_transcript(home):
+    p = run_hook(payload(FIRING, transcript_path="/nonexistent/nope.jsonl"), home)
+    assert (p.returncode, p.stderr) == (0, "")
+
+
+def test_fail_open_on_a_directory_as_transcript(tmp_path, home):
+    p = run_hook(payload(FIRING, transcript_path=str(tmp_path)), home)
+    assert (p.returncode, p.stderr) == (0, "")
+
+
+def test_fail_open_on_an_unreadable_transcript(tmp_path, home):
+    t = tmp_path / "t.jsonl"
+    write_transcript(t, "Audit it.", 4)
+    os.chmod(t, 0o000)
+    try:
+        if os.access(t, os.R_OK):            # running as root: the case cannot occur
+            pytest.skip("cannot make a file unreadable as this user")
+        p = run_hook(payload(FIRING, transcript_path=str(t)), home)
+        assert (p.returncode, p.stderr) == (0, "")
+    finally:
+        os.chmod(t, 0o600)
+
+
+def test_fail_open_on_a_binary_transcript(tmp_path, home):
+    t = tmp_path / "t.jsonl"
+    t.write_bytes(os.urandom(4096))
+    p = run_hook(payload(FIRING, transcript_path=str(t)), home)
+    assert (p.returncode, p.stderr) == (0, "")
+
+
+def test_fail_open_when_the_state_dir_cannot_be_created(tmp_path, home):
+    """An unwritable cache must not error out and must not block."""
+    t = tmp_path / "t.jsonl"
+    write_transcript(t, "Audit it.", 4)
+    (home / ".cache").write_text("this is a file, not a directory")
+    p = run_hook(payload(FIRING, transcript_path=str(t)), home)
+    assert (p.returncode, p.stderr) == (0, "")
+
+
+def test_hook_is_not_executable_as_a_side_effect_of_import():
+    """Importing the module must not run main(); every test above depends on it."""
+    src = HOOK.read_text()
+    assert 'if __name__ == "__main__":' in src

--- a/scripts/claude-hooks/tests/test_next_step_nudge.py
+++ b/scripts/claude-hooks/tests/test_next_step_nudge.py
@@ -3,12 +3,15 @@
 
 WHAT THIS FILE IS FOR
 
-  1. 🔴 The SUPPRESSION predicate is the whole product. This hook fires by BLOCKING
-     the operator's Stop (exit 2 is the only documented way a Stop hook can reach the
-     model), so a false positive is not a wasted line of context — it is a turn that
-     will not end. A hook that nags is strictly worse than no hook, so the negative
-     controls below outnumber the positive ones roughly 4:1 and that ratio is
-     deliberate.
+  1. 🔴 The SUPPRESSION predicate is the whole product. The hook fires by emitting
+     `hookSpecificOutput.additionalContext` and exiting 0 — it does NOT block, and an
+     earlier revision of this suite asserted the opposite throughout because the hook
+     used exit 2 on a false premise. A false positive therefore costs one wasted model
+     turn rather than a turn that will not end. Still worth suppressing hard — a hook
+     that nags is worse than no hook — so the negative controls below outnumber the
+     positive ones roughly 4:1 and that ratio is deliberate. The IO contract itself
+     (stdout JSON, exit 0, nothing on stderr) is pinned in section 7, because "it does
+     not block" is the claim most likely to rot.
 
   2. ATTRIBUTION. `suppressed_by()` returns the NAMES of the guards that matched, and
      every suppressor has at least one fixture that it and ONLY it saves
@@ -17,7 +20,8 @@ WHAT THIS FILE IS FOR
      rather than the fixture being rescued by a sibling guard and the mutant surviving.
 
   3. FAIL-OPEN, which here means SILENCE. Every error path must exit 0 and write
-     nothing, because the alternative is a wedged turn on the operator's live machine.
+     nothing. A Stop hook runs at the moment a session is trying to end, so anything it
+     writes to stderr surfaces as an error and anything it raises is felt immediately.
      Driven through a real subprocess, not by calling main().
 
   4. The SEAM between should_nudge() and the transcript reader. The unit tests stub the
@@ -72,19 +76,101 @@ def msg(ending):
     return FILLER + "\n" + ending
 
 
+# --------------------------------------------------------------------------- #
+# AST helpers — for the guards that make a claim about the hook's CODE.
+#
+# 🔴 Read the syntax tree, never the source text. This file's subject discusses `exit 2`
+# and `stop_reason` at length in prose, so any text-level guard about them is satisfiable
+# — and breakable — by a comment. Two such guards were written for this round and BOTH
+# tripped on the very prose that explains why the thing they check was removed.
+# --------------------------------------------------------------------------- #
+def _module_ast(path):
+    import ast
+    return ast.parse(Path(path).read_text())
+
+
+def _docstring_nodes(tree):
+    """Every Constant node that IS a docstring, so they can be excluded."""
+    import ast
+    out = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef,
+                             ast.ClassDef)):
+            body = getattr(node, "body", None)
+            if (body and isinstance(body[0], ast.Expr)
+                    and isinstance(body[0].value, ast.Constant)
+                    and isinstance(body[0].value.value, str)):
+                out.add(id(body[0].value))
+    return out
+
+
+def code_string_literals(path):
+    """Every string literal in the module that is NOT a docstring. Comments never appear
+    in an AST at all, which is the point."""
+    import ast
+    tree = _module_ast(path)
+    skip = _docstring_nodes(tree)
+    return {n.value for n in ast.walk(tree)
+            if isinstance(n, ast.Constant) and isinstance(n.value, str)
+            and id(n) not in skip}
+
+
+def sys_exit_calls(path):
+    """The literal argument of every `sys.exit(...)` / `exit(...)` call, in source order.
+    A non-literal argument is reported as the string '<non-literal>' so it cannot pass
+    unnoticed."""
+    import ast
+    out = []
+    for node in ast.walk(_module_ast(path)):
+        if not isinstance(node, ast.Call):
+            continue
+        f = node.func
+        name = (f.attr if isinstance(f, ast.Attribute)
+                else f.id if isinstance(f, ast.Name) else None)
+        if name != "exit":
+            continue
+        if not node.args:
+            out.append(0)
+        elif isinstance(node.args[0], ast.Constant):
+            out.append(node.args[0].value)
+        else:
+            out.append("<non-literal>")
+    return out
+
+
 def payload(text, **over):
     """A realistic Stop payload. Overridable field by field so a gate test can move
-    exactly one thing and leave everything else in its firing state."""
+    exactly one thing and leave everything else in its firing state.
+
+    🔴 EVERY FIELD HERE EXISTS IN THE RUNTIME PAYLOAD. An earlier revision also set
+    `stop_reason`, which the Stop event does not carry — so a fixture invented a field,
+    the hook gated on it, and a test asserted the gate worked. All three agreed with each
+    other and none of them agreed with the CLI. The real schema (claude-code 2.1.220) is
+    `session_id, transcript_path, cwd, prompt_id?, permission_mode?, agent_id?,
+    agent_type?, effort?` plus `hook_event_name, stop_hook_active,
+    last_assistant_message?, background_tasks?, session_crons?`; pinned by
+    test_payload_fixture_invents_no_fields below.
+    """
     d = {
         "hook_event_name": "Stop",
         "session_id": "11111111-2222-3333-4444-555555555555",
         "transcript_path": "/nonexistent/transcript.jsonl",
         "last_assistant_message": text,
-        "stop_reason": "end_turn",
         "cwd": "/tmp",
     }
     d.update(over)
     return d
+
+
+# The Stop payload's real field set, read out of the installed CLI's schema. A fixture
+# field outside this set is an invented one, and inventing one is how the dead
+# `stop_reason` gate came to look live.
+STOP_PAYLOAD_FIELDS = {
+    "session_id", "transcript_path", "cwd", "prompt_id", "permission_mode",
+    "agent_id", "agent_type", "effort",
+    "hook_event_name", "stop_hook_active", "last_assistant_message",
+    "background_tasks", "session_crons",
+}
 
 
 def decide(text, prompt="Audit the retry path and report what you find.", tools=7, **over):
@@ -188,6 +274,102 @@ def test_every_suppressor_has_a_fixture():
     assert owned == declared, f"unowned: {declared - owned}; stale: {owned - declared}"
 
 
+# --------------------------------------------------------------------------- #
+# 2b. ARMS, not just names. `test_every_suppressor_has_a_fixture` pins one fixture per
+#     suppressor NAME, which says nothing about the ~30 alternation ARMS inside them —
+#     a mutation sweep deleting an arm survived, because a sibling arm kept the one
+#     fixture suppressed. Each entry below is owned by exactly one arm of one suppressor.
+# --------------------------------------------------------------------------- #
+SUPPRESSOR_ARMS = {
+    # COMMITS — the impersonal-future arm. No first-person pronoun anywhere, which is
+    # why this arm exists; a real corpus miss fired on exactly this shape.
+    "commits_going_to": ("The counter is going to land with the loop fix.", "commits"),
+    "commits_about_to": ("The re-measure is about to start on both points.", "commits"),
+    "commits_due_to_run": ("The sweep is due to run against both points tonight.", "commits"),
+    "commits_queued_to": ("The counter export is queued to land after the loop fix.", "commits"),
+    "commits_set_to": ("The re-measure is set to start once the counter exists.", "commits"),
+    # MARKED — the `worth <gerund>` / `worth a <noun>` arm. Its docstring says it was
+    # added BECAUSE an earlier revision fired on it: a regression fix that shipped with
+    # no regression test until now.
+    "marked_worth_gerund": ("The retry loop is worth folding into the same change.", "marked"),
+    "marked_worth_a_noun": ("The backoff constant is worth a glance before merging.", "marked"),
+    # MARKED — the soft-preference arm.
+    "marked_defaults_to": ("On a tie like this the order defaults to the cheaper "
+                           "measurement first.", "marked"),
+    "marked_leans_toward": ("The evidence leans toward the loop rather than the cache.",
+                            "marked"),
+}
+
+
+@pytest.mark.parametrize("key", sorted(SUPPRESSOR_ARMS))
+def test_each_alternation_arm_is_uniquely_owned(key):
+    """🔴 ATTRIBUTION AT ARM GRAIN. Each fixture must be saved by exactly ONE suppressor,
+    so deleting the arm under test leaves it firing rather than rescued by a sibling."""
+    ending, owner = SUPPRESSOR_ARMS[key]
+    got = nsn.suppressed_by(msg(ending))
+    assert got == [owner], f"{key}: expected only {owner!r}, got {got!r}"
+
+
+@pytest.mark.parametrize("key", sorted(SUPPRESSOR_ARMS))
+def test_each_alternation_arm_suppresses_the_turn(key):
+    ending, _owner = SUPPRESSOR_ARMS[key]
+    assert decide(msg(ending)) is False
+
+
+def test_arm_ledger_covers_every_arm_named_in_the_source_comments():
+    """A ledger that can go stale silently is not a ledger. Pins the specific arms the
+    source comments justify by name — deleting one from the regex without deleting the
+    fixture fails above, and adding one here without an arm fails immediately."""
+    for arm in ("going to", "about to", "due to run", "queued to", "set to"):
+        assert nsn.COMMITS.search(f"the work is {arm} happen"), arm
+    for arm in ("defaults to", "leans toward", "worth a glance", "worth folding"):
+        assert nsn.MARKED.search(f"it {arm} something"), arm
+
+
+# --------------------------------------------------------------------------- #
+# 2c. ASKS anchoring. Previously UNTESTED: replacing the whole regex with a bare `\\?`
+#     left every test in this file green, so the source comment about rhetorical
+#     mid-sentence '?' was an unverified claim.
+# --------------------------------------------------------------------------- #
+def test_asks_allows_an_inline_answer_hint():
+    """🔴 THE REGRESSION. The original anchor permitted only whitespace/quotes/brackets
+    after the '?', so a question carrying its own answer hint did not match and the hook
+    FIRED on a turn that was already waiting on the operator. On the real corpus, 12 of
+    the 14 first-fires whose operator reply was a bare approval were this one shape — a
+    prompt this repo itself ships."""
+    for ending in ("Append this to the index? (y/N)",
+                   "Which one should land first? [1-3]",
+                   "Do you want the counter first? — your call.",
+                   "Ready to merge? (yes/no)"):
+        assert "asks" in nsn.suppressed_by(msg(ending)), ending
+        assert decide(msg(ending)) is False, ending
+
+
+def test_asks_does_not_match_a_rhetorical_question_mid_paragraph():
+    """The other half: a '?' with a whole sentence after it on the same line is not the
+    turn asking the operator anything. Without this, the anchor could be widened to a
+    bare `\\?` and nothing would notice."""
+    ending = ("So which is it? The evidence points at the retry loop rather than the "
+              "cache, because the hit rate was unchanged across both runs and the tail "
+              "moved by a factor of four.")
+    assert "asks" not in nsn.suppressed_by(msg(ending))
+
+
+def test_asks_anchor_is_not_a_bare_question_mark():
+    """Mutation guard: a bare `\\?` would satisfy every ASKS fixture above. Pin the
+    distinction directly, so replacing the regex with `\\?` fails HERE."""
+    assert nsn.ASKS.search("what next?") is not None
+    assert nsn.ASKS.search("is it? yes, and here is a long trailing clause that "
+                           "runs well past forty characters on this line") is None
+
+
+def test_asks_trailer_has_a_bound():
+    """The trailer is bounded at 40 chars, so a '?' does not reach across an entire
+    sentence to find a line ending. Measured at both sides of the boundary."""
+    assert nsn.ASKS.search("ok? " + "x" * 30) is not None       # inside the bound
+    assert nsn.ASKS.search("ok? " + "x" * 60) is None           # outside it
+
+
 def test_self_consistency_the_nudge_does_not_fire_on_its_own_advice():
     """🔴 The NUDGE text prescribes three endings. A turn that follows the instruction
     must not be nudged again — that is the shape that teaches an operator to ignore a
@@ -251,7 +433,9 @@ def test_gate_message_too_short():
 
 
 def test_gate_stop_hook_active():
-    """Never block twice in a row. Without this the 8-block cap is the only backstop."""
+    """Never nudge two Stops in a row. The hook no longer blocks, but emitting
+    additionalContext still continues the conversation, so a second Stop follows every
+    fire; without this gate that second Stop is a candidate to fire again."""
     assert decide(FIRING, stop_hook_active=True) is False
 
 
@@ -261,12 +445,37 @@ def test_gate_subagent_turn():
     assert decide(FIRING, hook_event_name="SubagentStop") is False
 
 
-def test_gate_non_end_turn_stop_reason():
-    """A max_tokens stop is truncation, not a considered ending; nudging it would ask
-    the model to append a next step to a sentence cut in half."""
-    assert decide(FIRING, stop_reason="max_tokens") is False
-    assert decide(FIRING, stop_reason="tool_use") is False
-    assert decide(FIRING, stop_reason=None) is True   # absent field must not gate
+def test_payload_fixture_invents_no_fields():
+    """🔴 A FIXTURE GUARD, and labelled as one: it constrains this file's own `payload()`,
+    so it is green against the pre-change hook and is NOT regression coverage for it. Its
+    red side is the OLD FIXTURE, which set `stop_reason` and would fail this immediately.
+
+    Kept because it closes the loop that let the dead gate look live: the hook gated on a
+    field, the fixture supplied it, and the test asserted the gate worked — three
+    artefacts agreeing with each other and none of them with the CLI.
+
+    An earlier revision gated on `stop_reason`, a field the Stop event does not send. The
+    gate could never reject, its test was an invariant guard wearing a gate's label, and
+    the fixture below hardcoded the field so everything looked consistent. Pinning the
+    fixture's keys against the CLI's real field set is what makes that class of mistake
+    fail loudly instead of silently agreeing with itself.
+    """
+    invented = set(payload("x")) - STOP_PAYLOAD_FIELDS
+    assert invented == set(), f"fixture invents field(s) the runtime never sends: {invented}"
+
+
+def test_no_gate_on_a_field_the_runtime_does_not_send():
+    """`stop_reason` must not gate: it is absent from every real Stop payload, so a hook
+    that branched on it would be reading None forever. Setting it to the values that
+    'gate' used to reject must change NOTHING."""
+    for bogus in ("max_tokens", "tool_use", "stop_sequence", ""):
+        assert decide(FIRING, stop_reason=bogus) is True, (
+            f"a gate on stop_reason={bogus!r} is back; the runtime never sends the field")
+    # Structural, not spelled: the field name must not appear as a STRING LITERAL IN CODE.
+    # Asserted over the AST so the prose explaining why the gate was removed — which of
+    # course says "stop_reason" — cannot satisfy or break this guard.
+    assert "stop_reason" not in code_string_literals(HOOK), (
+        "stop_reason is read by the hook's CODE; the runtime never sends the field")
 
 
 def test_gate_missing_or_nonstring_message():
@@ -295,19 +504,55 @@ def test_gate_non_dict_payload():
 # 4. Positional tail — the window is the end of the message, not the whole of it.
 # ============================================================================ #
 def test_next_step_buried_far_above_the_tail_does_not_suppress():
-    """🔴 AN INVARIANT GUARD, NOT REGRESSION COVERAGE — labelled as such deliberately.
+    """🔴 REGRESSION COVERAGE for the most sensitive constant in the hook — and it was
+    demoted to "an invariant guard, not regression coverage" on the strength of a
+    measurement that was wired to nothing.
 
-    It pins that the window is positional, but real traffic never violates it: sweeping
-    TAIL_CHARS from 10 to 10^9 over 11,215 real turns leaves the fire count unmoved at
-    565, because a message with any forward-looking construction essentially always has
-    one in its final paragraph. So this test constructs a shape the corpus does not
-    contain. It earns its place by pinning the intent cheaply; it must not be counted as
-    evidence that the window does anything on real messages.
+    That measurement rebound the module-level `TAIL_CHARS` and called `suppressed_by()`.
+    `tail_of(text, nchars=TAIL_CHARS)` binds its default at DEF time, so the rebind
+    reached nothing: an eleven-point sweep re-measured the same 800-char window eleven
+    times and its flat line was read as "the parameter is inert on real traffic".
+
+    Measured properly, by passing `nchars`, the fire count runs 1,903 (at 10) -> 577 (at
+    800) -> 262 (unbounded) over 11,789 real turns: a 7.3x swing, with 55% of the fires
+    at the shipped value existing only because of this window. The shape below is not
+    hypothetical either — the corpus contains 18 turns where the model stated something
+    forward-looking well above the ending and the operator STILL had to ask for a
+    recommendation.
+
+    So this pins real behaviour on real traffic. See test_tail_window_is_load_bearing for
+    the companion that pins the parameter is actually read.
     """
     buried = ("I'll export the counter first.\n\n" + FILLER * 4 + "\n" +
               "The counter is not exported, so the comparison stays open.")
     assert nsn.suppressed_by(buried) == []
     assert decide(buried) is True
+
+
+def test_tail_window_is_load_bearing():
+    """🔴 THE GUARD AGAINST THE SWEEP THAT MEASURED NOTHING.
+
+    Pins that `tail_of` genuinely honours its `nchars` argument, by requiring the SAME
+    text to be suppressed at a wide window and unsuppressed at a narrow one. A default
+    bound at def time (the original defect) cannot satisfy both halves.
+    """
+    buried = ("I'll export the counter first.\n\n" + FILLER * 4 + "\n" +
+              "The counter is not exported, so the comparison stays open.")
+
+    def supp(nchars):
+        t = nsn.tail_of(buried, nchars=nchars)
+        return [n for n, rx in nsn.SUPPRESSORS if rx.search(t)]
+
+    assert supp(10) == [], "a tiny window must see only the (inert) last paragraph"
+    assert "commits" in supp(10 ** 9), "an unbounded window must reach the commitment"
+    assert len(nsn.tail_of(buried, nchars=10)) < len(nsn.tail_of(buried, nchars=10 ** 9))
+
+
+def test_tail_chars_default_matches_the_module_constant():
+    """The shipped default must be the constant a maintainer reads, not a stale literal."""
+    import inspect
+    assert (inspect.signature(nsn.tail_of).parameters["nchars"].default
+            == nsn.TAIL_CHARS == 800)
 
 
 def test_tail_starts_at_a_paragraph_boundary():
@@ -349,8 +594,9 @@ def test_claim_fails_closed_without_a_session_id(tmp_path, monkeypatch):
 
 def test_claim_fails_closed_when_the_state_root_is_not_a_directory(tmp_path, monkeypatch):
     """🔴 The fail direction is REVERSED from the PostToolUse nudges. There, an
-    unwritable cache duplicates a harmless nudge; here it would mean an unbounded
-    Stop-blocker, which is the one outcome worse than a missed nudge.
+    unwritable cache duplicates a harmless nudge; here it would mean a nudge with no
+    once-per-session bound at all, repeating on every turn of the session — which is the
+    one outcome worse than a missed nudge.
 
     This test owns the makedirs arm ONLY — see the companion below."""
     blocker = tmp_path / "s"
@@ -498,6 +744,70 @@ def test_turn_shape_skips_sidechain_user_records(tmp_path):
     assert nsn._turn_shape(str(t)) == ("the operator's real task", 3)
 
 
+def test_turn_shape_skips_meta_user_records(tmp_path):
+    """🔴 THE THIRD WAY a type=user record is not the operator, and the dangerous one.
+
+    Claude Code writes `isMeta` records — `<local-command-caveat>…`, command expansion
+    notes — with STRING content. String content is exactly what the tool_result test
+    passes through, so without an isMeta check the harness's own boilerplate is returned
+    as "the opening prompt" and both prompt-shaped gates evaluate text the operator never
+    typed. 6.1% of real turns (724 of 11,789) open on such a record.
+
+    Reading back from the end here must walk past it to the operator's real prompt, and
+    must keep counting tool_use across it rather than truncating the turn there.
+    """
+    t = tmp_path / "t.jsonl"
+    recs = [
+        {"type": "user", "message": {"content": "the operator's real task"}},
+        {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "a", "name": "Bash", "input": {}}]}},
+        {"type": "user", "isMeta": True,
+         "message": {"content": "<local-command-caveat>caveat text</local-command-caveat>"}},
+        {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "b", "name": "Bash", "input": {}}]}},
+    ]
+    t.write_text("".join(json.dumps(r) + "\n" for r in recs))
+    assert nsn._turn_shape(str(t)) == ("the operator's real task", 2)
+
+
+def test_meta_record_does_not_defeat_the_terminal_prompt_gate(tmp_path):
+    """🔴 WHY isMeta MATTERS, asserted where the HARM lands — end to end, in the FIRING
+    direction.
+
+    A meta record is neither terminal nor a short question. So if one is read as the
+    opening prompt, BOTH gates that could have stayed the hook answer "no" against text
+    the operator never wrote. This fixture is that exact shape: the operator's real prompt
+    is `/clear` (terminal — the hook must stay silent), and a harness caveat record sits
+    after it. Without the isMeta check the caveat is returned as the prompt, the terminal
+    gate never sees `/clear`, and the hook FIRES on a session the operator just ended.
+
+    Asserted on should_nudge with the SHIPPED reader, not on the predicate helpers, so it
+    covers the seam rather than one side of it.
+    """
+    t = tmp_path / "t.jsonl"
+    recs = [
+        {"type": "user", "message": {"content": "/clear"}},
+        {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "a", "name": "Bash", "input": {}}]}},
+        {"type": "user", "isMeta": True, "message": {
+            "content": "<local-command-caveat>caveat text the operator never typed"
+                       "</local-command-caveat>"}},
+    ]
+    t.write_text("".join(json.dumps(r) + "\n" for r in recs))
+
+    prompt, tools = nsn._turn_shape(str(t))
+    assert prompt == "/clear", f"the harness record was read as the prompt: {prompt!r}"
+    assert tools == 1
+    assert nsn.should_nudge(payload(FIRING, transcript_path=str(t))) is False, (
+        "fired on a turn whose operator prompt was terminal")
+
+    # Control: the same transcript WITHOUT the terminal prompt does fire, so the silence
+    # above is the terminal gate doing its job and not some unrelated gate.
+    recs[0] = {"type": "user", "message": {"content": "Audit the retry path and report."}}
+    t.write_text("".join(json.dumps(r) + "\n" for r in recs))
+    assert nsn.should_nudge(payload(FIRING, transcript_path=str(t))) is True
+
+
 def test_turn_shape_survives_malformed_lines(tmp_path):
     t = tmp_path / "t.jsonl"
     write_transcript(t, "Audit it.", 3)
@@ -529,6 +839,35 @@ def test_turn_shape_of_an_unparseable_file_establishes_nothing(tmp_path):
     assert nsn._turn_shape(str(t)) is None
 
 
+def test_turn_shape_reads_only_the_tail_of_a_large_transcript(tmp_path, monkeypatch):
+    """🔴 FOUND BY THE MUTATION SWEEP: deleting the `seek` to the last
+    TRANSCRIPT_TAIL_BYTES survived the whole suite.
+
+    The oversized-turn test below could not catch it. Its fixture writes the operator
+    prompt as line ONE, and the reader discards the first (possibly partial) line after
+    seeking — so with the seek deleted, the very first `readline()` ate the prompt and the
+    result was the same (None, tools) either way. Green for the wrong reason.
+
+    Distinguishing fixture: a junk record FIRST, then the prompt. With the seek, neither
+    is reachable. Without it, the discard eats the junk and the prompt becomes visible —
+    which is exactly the unbounded read the cap exists to prevent.
+    """
+    monkeypatch.setattr(nsn, "TRANSCRIPT_TAIL_BYTES", 2048)
+    t = tmp_path / "big.jsonl"
+    recs = [{"type": "system", "message": {"content": "junk header"}},
+            {"type": "user", "message": {"content": "the prompt that must stay out of reach"}}]
+    for i in range(400):
+        recs.append({"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": f"t{i}", "name": "Bash", "input": {"pad": "x" * 40}}]}})
+    t.write_text("".join(json.dumps(r) + "\n" for r in recs))
+    assert t.stat().st_size > nsn.TRANSCRIPT_TAIL_BYTES
+
+    prompt, tools = nsn._turn_shape(str(t))
+    assert prompt is None, (
+        "the reader reached a prompt outside the tail window: it is reading the whole file")
+    assert tools >= 1
+
+
 def test_turn_shape_treats_an_oversized_turn_as_work(tmp_path, monkeypatch):
     """A turn bigger than the read window cannot be re-read cheaply. It is reported as
     work-was-done with no prompt, so the work gate passes and the prompt-shaped gates
@@ -558,13 +897,39 @@ def home(tmp_path):
     return h
 
 
-def test_e2e_fires_with_exit_2_and_a_message_on_stderr(tmp_path, home):
+def test_e2e_fires_as_additional_context_and_does_not_block(tmp_path, home):
+    """🔴 THE IO CONTRACT, and the whole point of the mechanism.
+
+    Non-error feedback goes out as `hookSpecificOutput.additionalContext` on STDOUT with
+    exit 0. The three assertions are independent and each pins a different past defect:
+
+      * rc == 0 — exit 2 would PREVENT the stop, compelling a model that was legitimately
+        finished to keep going. Asserted as `!= 2` too, explicitly, because that is the
+        specific regression.
+      * stderr empty — exit 2 delivered through `blockingError`, which put a "Stop hook
+        error occurred · ctrl+o to see" notification in front of the operator on EVERY
+        fire. Anything on stderr from a Stop hook is operator-visible noise.
+      * the stdout JSON parses and is shaped to the CLI's union arm — a payload the
+        runtime cannot validate is silently ignored, which looks exactly like a hook
+        that never fired.
+    """
     t = tmp_path / "t.jsonl"
     write_transcript(t, "Audit the retry path.", 6)
     p = run_hook(payload(FIRING, transcript_path=str(t)), home)
-    assert p.returncode == 2, p
-    assert p.stdout == ""
-    assert "next-step" in p.stderr and "proceed" in p.stderr
+
+    assert p.returncode == 0, p
+    assert p.returncode != 2, "the hook is blocking the stop again"
+    assert p.stderr == "", f"operator-visible stderr from a Stop hook: {p.stderr!r}"
+
+    out = json.loads(p.stdout)
+    assert set(out) == {"hookSpecificOutput"}, out
+    hso = out["hookSpecificOutput"]
+    assert hso["hookEventName"] == "Stop", hso
+    assert isinstance(hso["additionalContext"], str)
+    assert set(hso) == {"hookEventName", "additionalContext"}, hso
+    assert "next-step" in hso["additionalContext"]
+    assert "proceed" in hso["additionalContext"]
+    assert hso["additionalContext"] == nsn.NUDGE
 
 
 def test_e2e_is_silent_once_per_session(tmp_path, home):
@@ -574,7 +939,8 @@ def test_e2e_is_silent_once_per_session(tmp_path, home):
     d = payload(FIRING, transcript_path=str(t))
     first = run_hook(d, home)
     second = run_hook(d, home)
-    assert (first.returncode, second.returncode) == (2, 0)
+    assert (first.returncode, second.returncode) == (0, 0)
+    assert first.stdout != "" and second.stdout == ""
     assert second.stderr == ""
 
 
@@ -583,7 +949,51 @@ def test_e2e_different_session_still_fires(tmp_path, home):
     write_transcript(t, "Audit the retry path.", 6)
     a = run_hook(payload(FIRING, transcript_path=str(t), session_id="sess-1"), home)
     b = run_hook(payload(FIRING, transcript_path=str(t), session_id="sess-2"), home)
-    assert (a.returncode, b.returncode) == (2, 2)
+    assert (a.returncode, b.returncode) == (0, 0)
+    assert a.stdout != "" and b.stdout != ""
+
+
+def test_e2e_headless_caller_opts_out(tmp_path, home):
+    """🔴 `claude -p` inherits this host's hooks. Two of this repo's own scripts drive it
+    under a hard timeout and parse the first line of the result, so the nudge would spend
+    a turn of a bounded budget on a line nothing reads. Gated on an explicit marker the
+    CALLERS set — pinned here together with the call sites that set it, so deleting either
+    half is visible."""
+    t = tmp_path / "t.jsonl"
+    write_transcript(t, "Audit the retry path.", 6)
+    d = payload(FIRING, transcript_path=str(t))
+
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    env[nsn.OPT_OUT_ENV] = "1"
+    p = subprocess.run([sys.executable, str(HOOK)], input=json.dumps(d),
+                       capture_output=True, text=True, env=env, timeout=60)
+    assert (p.returncode, p.stdout, p.stderr) == (0, "", "")
+
+    # ...and the same payload without the marker DOES fire, so this is the marker's doing
+    # and not some other gate. (A gate test that only shows silence proves nothing.)
+    assert run_hook(d, home).stdout != ""
+
+
+def test_headless_call_sites_set_the_opt_out():
+    """🔴 The other half of the seam: a hook reading a marker nobody sets is inert, and
+    NOTHING else in this suite would notice — the hook's own gate test passes whether or
+    not any caller cooperates. This is the "verified in isolation" failure mode, so the
+    guard has to pin the RELATIONSHIP, across both files.
+
+    🔴 It also has to be STRUCTURAL. The first version of this test asserted the variable
+    NAME appeared in the file, and a mutation that deleted the actual assignment left it
+    green — because the comment ABOVE the call site explains why the variable is there,
+    and that comment spelled the name. Both call-site mutants survived on that. So:
+    strip comment lines, then require the ASSIGNMENT form on an executable line.
+    """
+    repo = HOOK.resolve().parents[2]
+    for rel in ("githooks/audit-on-push.sh", "scripts/task-spec-drafter/drafter.sh"):
+        src = (repo / rel).read_text()
+        code = "\n".join(l for l in src.splitlines() if not l.lstrip().startswith("#"))
+        assert "claude -p" in code, f"{rel}: no headless claude call; update this test"
+        assert f"{nsn.OPT_OUT_ENV}=1" in code, (
+            f"{rel}: headless `claude -p` call does not set {nsn.OPT_OUT_ENV}")
 
 
 def test_e2e_silent_on_a_turn_that_names_a_next_step(tmp_path, home):
@@ -596,7 +1006,8 @@ def test_e2e_silent_on_a_turn_that_names_a_next_step(tmp_path, home):
 
 # ============================================================================ #
 # 8. FAIL OPEN — every degenerate input exits 0 and writes NOTHING. A Stop hook that
-#    errors into the terminal, or blocks on a bad input, wedges the operator's session.
+#    errors into the terminal, or exits non-zero on a bad input, surfaces as a failure at
+#    the exact moment the operator's session is trying to end.
 # ============================================================================ #
 FAIL_OPEN_INPUTS = {
     "not_json": "not json at all",
@@ -664,6 +1075,55 @@ def test_fail_open_when_the_state_dir_cannot_be_created(tmp_path, home):
     (home / ".cache").write_text("this is a file, not a directory")
     p = run_hook(payload(FIRING, transcript_path=str(t)), home)
     assert (p.returncode, p.stderr) == (0, "")
+
+
+def test_main_backstop_swallows_an_unexpected_error(monkeypatch, capsys):
+    """🔴 THE WHOLE-HOOK FAIL-OPEN BACKSTOP, and it survived every mutation until now:
+    flipping main()'s `except Exception` to exit(2) left all tests green, even though
+    that line IS the central safety claim.
+
+    It was unkillable because nothing in a realistic payload can make the guarded block
+    raise — every helper already fails closed on its own. So reach it directly: make
+    should_nudge() raise, and require main() to still exit 0 having written nothing.
+    """
+    import io
+
+    def boom(_data):
+        raise RuntimeError("simulated defect inside the decision path")
+
+    monkeypatch.setattr(nsn, "should_nudge", boom)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload(FIRING))))
+    with pytest.raises(SystemExit) as exc:
+        nsn.main()
+    assert exc.value.code == 0, "the fail-open backstop no longer exits 0"
+    out = capsys.readouterr()
+    assert out.out == "" and out.err == ""
+
+
+def test_main_exits_zero_even_when_it_fires(monkeypatch, capsys, tmp_path):
+    """The success path is exit 0 too — there is exactly ONE exit in main() and it is
+    always 0. A non-zero exit from a Stop hook is how the old blocking behaviour looked."""
+    import io
+    monkeypatch.setattr(nsn, "_state_root", lambda: str(tmp_path / "s"))
+    monkeypatch.setattr(nsn, "should_nudge", lambda _d: True)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload(FIRING))))
+    with pytest.raises(SystemExit) as exc:
+        nsn.main()
+    assert exc.value.code == 0
+    out = capsys.readouterr()
+    assert out.err == ""
+    assert json.loads(out.out)["hookSpecificOutput"]["hookEventName"] == "Stop"
+
+
+def test_main_has_no_nonzero_exit_anywhere():
+    """Structural companion to the two above: the hook must not be ABLE to exit non-zero.
+
+    Pins the "it does not block" claim against the whole file rather than against the one
+    path a test happened to drive. Read off the AST, not the text — the source discusses
+    exit 2 at length in prose, and a guard a comment can satisfy is not a guard.
+    """
+    exits = sys_exit_calls(HOOK)
+    assert exits == [0], f"the hook's exit codes are {exits}; every one must be 0"
 
 
 def test_hook_is_not_executable_as_a_side_effect_of_import():

--- a/scripts/claude-hooks/tests/test_register_nudge_hook.py
+++ b/scripts/claude-hooks/tests/test_register_nudge_hook.py
@@ -21,6 +21,8 @@ SCRIPT = os.path.join(HERE, "..", "register-nudge-hook.py")
 NOTIFY = "python3 ~/.claude/hooks/claude-notify.py"
 CLAWGATE_STOP = "/home/zach/.claude/clawgate-stop-hook.sh"
 SEARCH_NUDGE = "python3 ~/.claude/hooks/search-tool-nudge.py"
+NEXT_STEP = "python3 ~/.claude/hooks/next-step-nudge.py"
+TMUX_STOP = "~/.config/tmux/task-hook.sh"
 
 failures = []
 
@@ -43,8 +45,13 @@ BASE_SETTINGS = {
             {"matcher": "Bash", "hooks": [{"type": "command", "command": "python3 ~/.claude/hooks/audit-pr-nudge.py"}]},
             {"matcher": "Bash", "hooks": [{"type": "command", "command": "python3 ~/.claude/hooks/shell-env-nudge.py"}]},
         ],
+        # 🔴 Stop already has TWO foreign owners before this script ever runs: the
+        # fuzzyclaw tmux writer and the clawgate stop hook (remote approval). Both are
+        # in the fixture so "append-only" is tested against a populated event, not an
+        # empty one — an append-only bug is invisible on an empty array.
         "Stop": [
-            {"hooks": [{"type": "command", "command": CLAWGATE_STOP}]}
+            {"hooks": [{"type": "command", "command": TMUX_STOP}]},
+            {"hooks": [{"type": "command", "command": CLAWGATE_STOP}]},
         ],
     }
 }
@@ -77,6 +84,26 @@ with tempfile.TemporaryDirectory() as tmp:
     for ev in ("UserPromptSubmit", "Stop", "SubagentStop"):
         check("1: claude-notify registered on " + ev, NOTIFY in cmds(d, ev))
     check("2: pre-existing clawgate Stop hook preserved", CLAWGATE_STOP in cmds(d, "Stop"))
+    check("2: pre-existing tmux Stop hook preserved", TMUX_STOP in cmds(d, "Stop"))
+
+    # 🔴 ALL FOUR Stop owners coexist. Asserted as a SET EQUALITY, not four membership
+    # checks: equality fails when the set GROWS (a fifth hook registered by accident)
+    # as well as when it SHRINKS (one clobbered), which membership checks cannot see.
+    check("2: exactly the four expected Stop hooks, none clobbered, none extra",
+          set(cmds(d, "Stop")) == {TMUX_STOP, CLAWGATE_STOP, NOTIFY, NEXT_STEP})
+    check("1: next-step-nudge registered on Stop", NEXT_STEP in cmds(d, "Stop"))
+    # Ordering: the two foreign hooks keep their original relative order and stay ahead
+    # of everything this script appends. Appending (rather than inserting) is what makes
+    # the blocking hook run last, after the notifiers have already observed the turn.
+    stop = cmds(d, "Stop")
+    check("2: foreign Stop hooks keep their original relative order",
+          stop.index(TMUX_STOP) < stop.index(CLAWGATE_STOP))
+    check("2: appended hooks come after the pre-existing ones",
+          max(stop.index(TMUX_STOP), stop.index(CLAWGATE_STOP))
+          < min(stop.index(NOTIFY), stop.index(NEXT_STEP)))
+    # next-step-nudge is Stop-only: it must NOT have been added to SubagentStop.
+    check("1: next-step-nudge NOT registered on SubagentStop",
+          NEXT_STEP not in cmds(d, "SubagentStop"))
     check("2: bash-guard preserved", "python3 ~/.claude/hooks/bash-guard.py" in cmds(d, "PreToolUse"))
     check("2: both PostToolUse nudges preserved",
           "python3 ~/.claude/hooks/audit-pr-nudge.py" in cmds(d, "PostToolUse")
@@ -95,6 +122,9 @@ with tempfile.TemporaryDirectory() as tmp:
     check("3: no duplicate claude-notify on Stop", cmds(d2, "Stop").count(NOTIFY) == 1)
     check("3: no duplicate search-tool-nudge", cmds(d2, "PostToolUse").count(SEARCH_NUDGE) == 1)
     check("3: clawgate Stop still single + present", cmds(d2, "Stop").count(CLAWGATE_STOP) == 1)
+    check("3: no duplicate next-step-nudge on Stop", cmds(d2, "Stop").count(NEXT_STEP) == 1)
+    check("3: Stop set unchanged by the second run",
+          set(cmds(d2, "Stop")) == {TMUX_STOP, CLAWGATE_STOP, NOTIFY, NEXT_STEP})
 
     # Atomicity: no temp litter left in the dir, and the source uses os.replace.
     leftovers = [n for n in os.listdir(os.path.dirname(settings)) if n.startswith(".settings.")]

--- a/scripts/claude-hooks/tests/test_register_nudge_hook.py
+++ b/scripts/claude-hooks/tests/test_register_nudge_hook.py
@@ -94,7 +94,9 @@ with tempfile.TemporaryDirectory() as tmp:
     check("1: next-step-nudge registered on Stop", NEXT_STEP in cmds(d, "Stop"))
     # Ordering: the two foreign hooks keep their original relative order and stay ahead
     # of everything this script appends. Appending (rather than inserting) is what makes
-    # the blocking hook run last, after the notifiers have already observed the turn.
+    # the nudge run last, after the notifiers have already observed the turn. (It no
+    # longer BLOCKS — it returns additionalContext and exits 0 — but the turn still
+    # continues, so the ordering argument is unchanged.)
     stop = cmds(d, "Stop")
     check("2: foreign Stop hooks keep their original relative order",
           stop.index(TMUX_STOP) < stop.index(CLAWGATE_STOP))

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -319,6 +319,12 @@ HERMETIC_TARGETS=(
   # apart. (test_guard_core.py covers the shared guard core behind BOTH
   # bash-guard.py and opencode's plugin/guard.js.)
   scripts/claude-hooks/tests/test_guard_core.py
+  # Same reason as the line above: a FILE, because its directory neighbours are
+  # hand-rolled scripts pytest cannot collect. next-step-nudge is the Stop hook that
+  # asks for a next step; it BLOCKS the operator's turn when it fires, so its
+  # suppression predicate is gated here rather than left to the ungated hand-rolled
+  # scripts beside it.
+  scripts/claude-hooks/tests/test_next_step_nudge.py
 )
 
 # --- DEV-HOST-ONLY set ---------------------------------------------------------
@@ -728,6 +734,10 @@ TARGET_FLOORS=(
   "scripts/repo-cos/tests|315"
   "scripts/task-spec-drafter/tests|135"
   "scripts/claude-hooks/tests/test_guard_core.py|1260"
+  # 2026-08-13, next-step-nudge.py's suite arrives as a NEW target: 78 collected on the
+  # branch. Gate's own count through the gate's own rule:
+  #   _suggested_floor 78 = 78 - min(50, max(1, 78/20 = 3)) = 78 - 3 = 75.
+  "scripts/claude-hooks/tests/test_next_step_nudge.py|75"
 )
 
 # The allowance rule, in one place, used by BOTH the drift message and anyone

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -737,7 +737,15 @@ TARGET_FLOORS=(
   # 2026-08-13, next-step-nudge.py's suite arrives as a NEW target: 78 collected on the
   # branch. Gate's own count through the gate's own rule:
   #   _suggested_floor 78 = 78 - min(50, max(1, 78/20 = 3)) = 78 - 3 = 75.
-  "scripts/claude-hooks/tests/test_next_step_nudge.py|75"
+  #
+  # 2026-08-13, the audit-fix round: 78 -> 112 collected. +34 for the switch to
+  # additionalContext (IO-contract tests), the ASKS anchor fix, per-ARM fixtures for the
+  # alternation mutants that were surviving, the isMeta guard, the headless opt-out seam,
+  # and main()'s fail-open backstop. Re-measured by the AUTHORITATIVE gate — `nix build
+  # .#checks.x86_64-linux.pytests` -> `collected=112`, read out of `nix log`, not from a
+  # local pytest run — then put through the gate's own function:
+  #   _suggested_floor 112 = 112 - min(50, max(1, 112/20 = 5)) = 112 - 5 = 107.
+  "scripts/claude-hooks/tests/test_next_step_nudge.py|107"
 )
 
 # The allowance rule, in one place, used by BOTH the drift message and anyone

--- a/scripts/task-spec-drafter/drafter.sh
+++ b/scripts/task-spec-drafter/drafter.sh
@@ -1043,8 +1043,10 @@ Run the five-step pipeline on ticket $TID now and output ONLY the json block."
   # deny layer with the suite still green. The value is validated by the
   # DENY-LAYER INTEGRITY GUARD above, which aborts the run if it is empty or
   # short, so there is nothing left for a conditional to guard against.
+  # NEXT_STEP_NUDGE_OFF: headless run on a bounded budget; the consumer is the JSON
+  # parser below, not a person, so a Stop next-step nudge would only burn DRAFTER_TIMEOUT.
   RAW="$(timeout "$DRAFTER_TIMEOUT" \
-    env KUBECONFIG="$PROD_KUBECONFIG" \
+    env KUBECONFIG="$PROD_KUBECONFIG" NEXT_STEP_NUDGE_OFF=1 \
     claude -p "$PROMPT" \
       --model "$DRAFTER_MODEL" \
       --allowedTools "$DRAFTER_ALLOWED_TOOLS" \


### PR DESCRIPTION
## Why

Operator prompts over 14 days, from `activity.events`:

```
proceed 542 · yes 134 · recommend next actions 123 · recommend 76 · recommend and proceed 17
```

`recommend*` = **216 occurrences, ~1 in every 3.5 approvals**. The rest of the reply vocabulary is almost pure authorization, so each `recommend*` is a round trip that exists only because the turn stopped without saying what came next. Concentration by project: `datapacket-talos 152, cli 33, devrc 22, homelab-talos 12` — so this is a global hook, not devrc prose.

Prose was rejected per `PRINCIPLES.md` (deterministic > prose) and because `claude/RULES.md` is near its enforced ceiling and is paid twice (session load + opencode's `AGENTS.md`).

## Mechanism — `additionalContext`, and it does NOT block

🔴 **An earlier revision of this PR asserted the opposite and was wrong.** It claimed `hookSpecificOutput.additionalContext` is unsupported on `Stop` and that `exit 2` is the only route to the model, and built its entire cost model on that. Read out of the **installed CLI's own schema** (claude-code 2.1.220 — note `bin/claude` is a 20K wrapper, so a grep against it returns a meaningless zero; the schema is in the 262M `bin/.claude-wrapped`):

```
hookEventName: v.literal("Stop"), additionalContext: v.string().optional()
  .describe("Hook-specific output for the Stop event. additionalContext is
   non-error feedback delivered to the model; the conversation continues so
   the model can act on it.")
```

Everything resting on the false premise was wrong in the same direction:

- `exit 2` delivers through `blockingError`, which raised a **"Stop hook error occurred · ctrl+o to see"** notification on *every* fire — non-error feedback on the error channel.
- `exit 2` **prevents the stop**, compelling a model that was legitimately finished to keep going. That is the filler-work risk, and it is what made a false positive expensive.
- that expense is what justified sacrificing recall as hard as this hook does.

Now: JSON on stdout, exit 0. `main()` has exactly **one** exit and it is always 0 (the old `except SystemExit: raise` arm was unreachable — `SystemExit` is a `BaseException`, so `except Exception` never caught it).

The turn still **continues**, which is the schema's own wording, so the second-Stop-event analysis survives the switch rather than being repaired by it and was re-checked, not assumed. Bounded three ways: at most one fire per session (atomic `O_EXCL` claim), never twice in a row (`stop_hook_active`), off for subagents. 🔴 Fail-open here means **silence** — every error path exits 0.

## What else this round fixed

**`ASKS` fired on turns already awaiting the operator.** The anchor `\?(?=[\s"'*`)\]]*$)` permitted only whitespace/quotes after the `?`, so `Append this to the index? (y/N)` scored as *no question* and fired, while the same sentence without the hint was suppressed. **12 of the 14 first-fires whose operator reply was a bare approval were that one literal prompt** — a flow this repo ships. Widened to a bounded 40-char trailer:

| anchor | all fires | FP (narrow) | FP (wide) | recall |
|---|---:|---:|---:|---:|
| old | 594 | 23/1000 = 2.3% | 28/1554 = 1.8% | 51/483 = 10.6% |
| new | 577 | **8/1000 = 0.8%** | **13/1554 = 0.8%** | 51/483 = 10.6% |

15 false positives removed, **0 introduced, 0 genuine nudges lost.** The anchoring was previously **untested** — replacing the whole regex with a bare `\?` left all 78 tests green — and is now pinned from both sides.

**`TAIL_CHARS` was called "measurably inert". The sweep was wired to nothing.** `tail_of(text, nchars=TAIL_CHARS)` binds its default at *def* time, so a sweep that rebinds `nsn.TAIL_CHARS` changes no behaviour — it re-measured one value eleven times and its flat line was read as a property of the traffic. Both wirings, same corpus, same process:

| TAIL_CHARS | 10 | 200 | 400 | 600 | 800 | 1200 | 3200 | 10⁹ |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| broken (rebind) | 577 | 577 | 577 | 577 | 577 | 577 | 577 | 577 |
| correct (`nchars=`) | 1,903 | 1,385 | 968 | 738 | **577** | 422 | 265 | 262 |

A **7.3× swing**, and **55% of the fires at the shipped value exist only because of the window.**

**800 is kept, but now chosen rather than inherited.** Raw fire count is the wrong criterion and a ratio on single-digit FP counts is noise, so the criterion is *marginal*: narrowing one step, what does it buy in genuinely-needed nudges per false one?

| narrow to | 1600 | 1200 | **800** | 600 | 400 | 200 |
|---|---:|---:|---:|---:|---:|---:|
| +true | 5 | 6 | **18** | 14 | 15 | 30 |
| +false | 2 | 2 | **1** | 7 | 6 | 14 |
| ratio | 2.5:1 | 3.0:1 | **18.0:1** | 2.0:1 | 2.5:1 | 2.1:1 |

The `1200 → 800` step is a genuine knee. It holds on a wider draw of the FP population (**9:1**) and on the newest 25% of sessions held out by mtime (**12:1**), with every adjacent step ≤ 3:1 in both. This also **refutes** the old rationale that the window bounded "a shape the corpus does not contain" — the corpus contains it 18 times, and its test is restored to real regression coverage.

**Removed the dead `stop_reason` gate.** The Stop payload has no such field, so the gate could never reject. The fixture invented the field, the hook read it, and a test asserted the gate worked — three artefacts agreeing with each other and none with the CLI. Replaced by a guard pinning the fixture's keys to the real schema.

**`_is_real_user` now excludes `isMeta`.** Claude Code writes `isMeta` records with *string* content, so they pass the `tool_result` test and get returned as "the opening prompt"; both prompt gates then evaluate text the operator never typed, in the **firing** direction. **724 turns (6.1%)**. Counterfactual: **0 of the current outcomes change**, so this is latent, not live — taken anyway, because it is one token and it fails silently when it does become live.

**Headless callers opt out.** `githooks/audit-on-push.sh` and `scripts/task-spec-drafter/drafter.sh` run `claude -p` under hard timeouts and parse the first line of the result. Gated on `NEXT_STEP_NUDGE_OFF`, set **by the callers** — not inferred: `CLAUDE_CODE_ENTRYPOINT` is `cli` for `claude -p` exactly as for an interactive session, and a hook's stdio is a pipe in both modes, so neither distinguishes the case. Both halves of that seam are pinned, so deleting either is visible.

**Pinned the ~30 alternation ARMS** the per-suppressor-*name* ledger did not cover (`going to|about to|due to run|queued to|set to`; `worth …ing`; `default(s|ing)? to|lean(s|ing)? toward`), plus **`main()`'s fail-open backstop**, which survived every mutation until now.

## Correcting the record

The headline was **~15:1**, from 14.6% recall against a 1.0% FP rate drawn over 1,464 turns. Re-labelled independently, the same predicate on the same corpus gives **2.3% (23/1000)**. The gap is **definitional** — the 1.0% was not robust to how "bare approval" is drawn, which is the whole objection. **The honest number for what the earlier revision shipped was 4.6:1, not 15:1.**

The 13.2:1 below is a *different* claim: it is what the predicate does **after** the ASKS fix. Both draws are reported so the ratio does not rest on one of them again.

| population | fires |
|---|---|
| answered with `recommend…` (**should** fire) | 51/483 = **10.6%** |
| bare approval, NARROW draw (**must not** fire) | 8/1000 = **0.8%** |
| bare approval, WIDE draw (**must not** fire) | 13/1554 = **0.8%** |
| all turns | 577/11,789 = 4.9% |
| sessions firing at all (once-per-session) | 191/630 = **30.3%** |

Recall is still the sacrificed side, and the case for sacrificing it is **weaker** than when it was made — it was justified by a false positive costing a blocked turn, and it now costs one model turn. The suppressors were deliberately **not** loosened in this round: that would be a second change measured against the same retrospective corpus that has already misled once.

## Red → green

12 of the new guards **watched RED** at `origin/feat/next-step-nudge` (the pre-fix hook + call sites, same test file) and green at HEAD:

```
test_asks_allows_an_inline_answer_hint          test_e2e_headless_caller_opts_out
test_asks_trailer_has_a_bound                   test_headless_call_sites_set_the_opt_out
test_no_gate_on_a_field_the_runtime_does_not_send   test_main_exits_zero_even_when_it_fires
test_turn_shape_skips_meta_user_records         test_main_has_no_nonzero_exit_anywhere
test_meta_record_does_not_defeat_the_terminal_prompt_gate
test_e2e_fires_as_additional_context_and_does_not_block
test_e2e_is_silent_once_per_session             test_e2e_different_session_still_fires

12 failed, 100 passed   (base)  ->  112 passed  (HEAD)
```

The remaining new guards are **green at base by construction** and are labelled as such in-source rather than counted as regression coverage — they are mutation-coverage for arms/parameters that already existed, and their watched-to-fail evidence is the battery below.

## Mutation testing — full battery re-run, not just the delta

Both controls watched first: unmutated copy **green** (111→112 passed), gutted predicate **red** (34 failed). Then **51/51 mutants killed, 0 survived, 0 invalid.**

The battery found three things:

1. 🔴 **A real coverage gap**: deleting the transcript **tail-seek** survived the whole suite. The oversized-turn fixture put the operator prompt on line 1, and the reader discards the first (possibly partial) line after seeking — so with the seek deleted the discard ate the prompt and the result was identical. Green for the wrong reason. Fixed with a junk-record-first fixture.
2. 🔴 **Two spelled guards of my own.** `test_headless_call_sites_set_the_opt_out` asserted the variable *name* appeared in the file — and the explanatory **comment** above each call site spells that name, so both call-site mutants survived. Now strips comment lines and requires the assignment form.
3. 🔴 **The harness itself could not tell a syntax error from a survivor.** It counted only `N failed`, so a mutant producing invalid Python collected 0 tests, reported 0 failures, and was recorded as SURVIVED — the instrument inventing a coverage gap. Errors are now a separate category.

`main()`'s backstop is now genuinely killable and **dies with its own assertion in isolation** (`assert exc.value.code == 0` → `assert 2 == 0`).

**Proof the new sweep observes what it tests**: the broken and correct wirings are run side by side on the same corpus in the same process; the broken column must be flat and the correct one must move. It does — 577 flat vs 262 → 1,903.

## Gate

`nix build .#checks.x86_64-linux.pytests` → **PASS**, run against the **committed** tree (not a dirty one), counts read from `nix log`:

```
PASS  scripts/claude-hooks/tests/test_next_step_nudge.py  (collected=112 passed=112 skipped=0 floor=107)
all register-nudge-hook tests passed
TOTAL collected=9541  passed=9540  skipped=1  failed=0  (floor: 8981 = sum of 18 per-target floors)
RESULT: PASS (exit=0)
```

Before this round: `collected=78 floor=75`, global floor 8949. After: **112 / 107**, global **8981** (= 8949 + 32, and 107 − 75 = 32). Floor arithmetic from the gate's own `_suggested_floor`:

`112 - min(50, max(1, 112/20 = 5)) = 112 - 5 = 107`

`--check-floors` passes the two-way pin. `.#checks.x86_64-linux.nodetests` also passes (untouched by this round). Rebased onto `origin/main` (`b2fb680`); merge state CLEAN.

## Unverified, plainly

- Whether a nudged turn converts a `recommend` into a `proceed` — **cannot** be known until it ships. Verifier = re-run the prompt counts over `activity.events` some weeks after deploy.
- Whether `stop_hook_active` is set on the second Stop event that `additionalContext` causes. The guard is kept and is correct either way, but the flag's value on that path was not observed.
- `fuzzyclaw hook stop`'s behaviour on a second Stop event (deprecated, deliberately not entangled with).
- `clawgate-stop-hook.sh` does **not** guard `stop_hook_active`, so it will re-POST to `/api/suggest` once per session where this fires. A real cost, named rather than hidden.
- Recall is low by design (10.6%).
- **Not deployed**: PR only, no `home-manager switch`, and `register-nudge-hook.py` has not been run on either host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
