### PR TITLE
feat(session-manager): a third of the live windows had no name the tooling could say

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -160,6 +160,14 @@ set-hook -g session-created 'run-shell -b "~/.config/tmux/pipe-activity.sh init"
 set-hook -ga after-select-window 'run-shell -b "~/.config/tmux/activity-emit.sh window-focus"'
 set-hook -ga client-session-changed 'run-shell -b "~/.config/tmux/activity-emit.sh session"'
 
+# Auto-name a session tmux named with a bare counter, after the cwd it opened
+# in. -ga APPENDS: a plain -g here would clobber the pipe-activity `init` bound
+# to session-created above and silently kill activity telemetry for every new
+# session. #{q:...} escapes the name for sh(1), which is what run-shell feeds
+# the command to. The script itself renames ONLY `^[0-9]+$` and is a no-op on
+# everything else — see scripts/tmux-autoname-session.sh.
+set-hook -ga session-created 'run-shell -b "~/.config/tmux/autoname-session.sh #{q:hook_session_name}"'
+
 # Status bar refresh rate (2s - balance between responsiveness and CPU)
 set -g status-interval 2
 

--- a/claude/skills/session-manager/SKILL.md
+++ b/claude/skills/session-manager/SKILL.md
@@ -86,6 +86,24 @@ credential-exposure or cross-user-data-leak.**
   API rather than off the cache, plus open PRs and a `/proc` walk that finds a `claude`
   buried under a wrapper shell. Complements, not substitutes.
 
+## `label` + `hotkey` — a name for the sessions the slot table never named
+
+`codename` is null for anything outside `tmux-scratch-slots.sh`; on the workbench that was
+9 of ~30 windows. Every row now also carries `label` (+ `label_source`, the tier that
+answered, + `hotkey`): **`codename`** if the session is a scratch slot → else the **leaf of
+the pane's cwd** (`path`) → else **`main`** (`fallback`, i.e. cwd was `$HOME`/`/`/empty).
+The table's old CODENAME column is now LABEL and renders `Grove (S)`.
+
+🔴 **`hotkey` is the actionable half** — it is the `$mod+Shift+<k>` that gets you to the
+window, read from the slot table's own `key` field. It is **`null` (never `""`) on tiers 2
+and 3**: no binding exists for a session outside the table, so quoting a key there would
+send the operator to press something and land nowhere.
+
+🔴 **`label` is NOT an address — `session:window` still is.** Two sessions sitting in one
+repo resolve to the SAME label, so quote both. New non-scratch sessions get a real tmux name
+at creation from `scripts/tmux-autoname-session.sh`; `label` is what covers the ones that
+predate it.
+
 ## The caveats are in the OUTPUT, not just in this file
 
 `report["caveats"]` (structured) + three footer lines in the table, printed

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -734,6 +734,13 @@ in
     source = ../scripts/tmux-task-resume.sh;
     executable = true;
   };
+  # session-created hook: names an auto-numbered session after its cwd. It
+  # SOURCES scratch-slots.sh from its own directory, so it must land beside it
+  # under ~/.config/tmux/ — the same reason that file is deployed there.
+  home.file.".config/tmux/autoname-session.sh" = {
+    source = ../scripts/tmux-autoname-session.sh;
+    executable = true;
+  };
   # Canonical scratchpad slot table (session<->hotkey<->color<->codename), sourced by
   # scratch-monitor/initiatives/status; must sit beside them under ~/.config/tmux/.
   home.file.".config/tmux/scratch-slots.sh" = {

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -660,7 +660,38 @@ TARGET_FLOORS=(
   # ⚠ ZERO new skips — `skipped=0` on this target, and the suite's single skip is
   # still the pinned one in repo-cos. No new FILES: every change is to a file the
   # flake already tracks.
-  "scripts/tests|3428"
+  #
+  # 2026-08-13, the session LABEL/HOTKEY resolver + the tmux session-created
+  # autoname hook: 3704 -> 3774 collected on the merged tree.
+  #
+  # 🔴 THE DELTA IS DECOMPOSED, and the CONTROL was measured first — the entry
+  # above implies main should have been 3478, and it was 3704, i.e. main was
+  # carrying 226 tests this table had never seen. Subtracting from the RECORDED
+  # number would have claimed +296 for this branch and a floor ~226 too high, a
+  # FALSE RED for whoever lands next.
+  #     3704  origin/main at a8f8426, measured FIRST by the authoritative gate
+  #           as the control
+  #     + 27  scripts/tests/test_session_manager.py, 391 -> 418 (the three label
+  #           tiers, the hotkey seam against the slot table, render_label, the
+  #           column trade, and the two-sessions-one-label tie)
+  #     + 44  scripts/tests/test_tmux_autoname_session.py (NEW FILE)
+  #     ----
+  #     3775  the merged tree, which is what the gate printed
+  #   _suggested_floor 3775 = 3775 - min(50, max(1, 3775/20 = 188)) = 3775 - 50
+  #                         = 3725.
+  # Two independent attributions agree: the same delta was measured against the
+  # branch's ORIGINAL base (6eaeb61) too, where the gate printed 3774 at 43
+  # cases in the new file — #446/#448 landed in between and added no tests,
+  # which is what makes the two readings agree rather than a coincidence to
+  # explain away. The 44th case (a MISSING slot table, `set -u` + unset array)
+  # was added after that reading and re-measured here.
+  #
+  # ⚠ ZERO new skips (`skipped=0` on this target; the suite's single skip is
+  # still the pinned one in repo-cos). A NEW FILE was added in BOTH senses —
+  # `scripts/tmux-autoname-session.sh` and its test — and both are `git add`ed;
+  # `test_the_script_is_tracked_by_git` fails if the script ever is not, in the
+  # sandbox by its ABSENCE and on the host via `git ls-files`.
+  "scripts/tests|3725"
   # 2026-08-11, the session-summary changed-paths work: 230 -> 273 collected,
   # +43 for scripts/collector/tests/test_changed_paths.py (the shared
   # `changed_paths*` module). The gate printed this replacement itself —

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -167,9 +167,30 @@ and the roll-ups a caller usually wants are:
     report["blocked_on_me"]             {"status", "count", ...}
 
 Each row carries: host, session, window_index, window_id, window_name,
-codename, pane_id, path, command, task, claude, busy, age_secs, status,
-waiting_probable, waiting_signals, waiting_status, claude_session_id,
-fuzzyclaw, panes. The row ledger is pinned by a test.
+codename, label, label_source, hotkey, pane_id, path, command, task, claude,
+busy, age_secs, status, waiting_probable, waiting_signals, waiting_status,
+claude_session_id, fuzzyclaw, panes. The row ledger is pinned by a test.
+
+🔴 `label` IS NOT AN ADDRESS — `session:window` still is.
+--------------------------------------------------------------------------
+`label` exists because `codename` is null for every session outside the
+scratch slot table, and on the workbench that was 9 of ~30 windows: two
+unnamed sessions (`0`, `8`) that the codename/colour/hotkey machinery could
+not name at all. It resolves in three tiers (`resolve_label`), and
+`label_source` says WHICH tier answered, because "the cwd is a repo called
+main" and "the cwd told us nothing" must not read the same.
+
+`hotkey` rides with it and is the ACTIONABLE half: a slot session is reported
+as `Gold (G)`, because the operator's question is "which key gets me there",
+which `Gold` alone does not answer. It comes from the slot table's own `key`
+field (`scratch2:G:#d79921:Gold`) — never a second copy of that mapping. It is
+`null`, never `""`, for tiers 2 and 3: no `$mod+Shift+<k>` binding EXISTS for
+a session outside the table, and a fabricated key sends the operator to press
+something and land nowhere.
+
+It is ADDITIVE. Two sessions can resolve to the SAME label — `0` and `8` are
+both sitting in one repo today — so a label alone identifies nothing. Every
+surface that renders a row shows `session` and `window_index` beside it.
 """
 from __future__ import annotations
 
@@ -603,12 +624,19 @@ def slots_to_window_ids(live_windows) -> dict:
     return {slot: wid for wid, slot in (live_windows or {}).items()}
 
 
-def load_scratch_codenames(paths=None, reader=None) -> dict:
-    """`{session: codename}` from the SCRATCH_SLOTS table.
+def load_scratch_slots(paths=None, reader=None) -> dict:
+    """`{session: {"codename":…, "key":…, "color":…}}` from the SCRATCH_SLOTS
+    table — THE parse, which everything else here projects out of.
+
+    🔴 THE HOTKEY IS THE POINT, not a bonus field. An entry is
+    `scratch4:V:#83a598:Vapor`, and the operator's question is not "what is this
+    session called" but "which key gets me to it" — `Vapor` alone does not
+    answer that, `Vapor (V)` does. The key was parsed and thrown away into a
+    `_key` for as long as this file has existed.
 
     Tries each path in order (deployed first, then in-repo) and returns the
-    first non-empty mapping. {} on any failure — codenames are a display nicety,
-    never a hard dependency.
+    first non-empty mapping. {} on any failure — the slot table is a display
+    nicety, never a hard dependency.
     """
     reader = reader or _read_text
     for p in (paths if paths is not None
@@ -616,11 +644,108 @@ def load_scratch_codenames(paths=None, reader=None) -> dict:
         text = reader(p)
         if text is None:
             continue
-        mapping = {session: name
-                   for session, _key, _color, name in _SLOT_RE.findall(text)}
+        mapping = {session: {"codename": name, "key": key, "color": color}
+                   for session, key, color, name in _SLOT_RE.findall(text)}
         if mapping:
             return mapping
     return {}
+
+
+def load_scratch_codenames(paths=None, reader=None) -> dict:
+    """`{session: codename}` — a PROJECTION of `load_scratch_slots`, not a
+    second parse. Kept because `codename` is its own row field and several
+    consumers only want the name."""
+    return {s: v["codename"]
+            for s, v in load_scratch_slots(paths, reader).items()}
+
+
+# --------------------------------------------------------------------------- #
+# LABEL RESOLUTION — three tiers, and the tier is carried in the output
+# --------------------------------------------------------------------------- #
+# The tier names, enumerated here rather than spelled at each return, so a
+# consumer can branch on the set and a test can assert it is exactly this.
+LABEL_SOURCES = ("codename", "path", "fallback")
+LABEL_FALLBACK = "main"
+
+
+def label_from_path(path, home=None):
+    """The leaf directory name of a pane's cwd, or None when the cwd says
+    nothing useful (`$HOME`, `/`, `~`, empty).
+
+    🔴 STATED LIMIT: this is the LEAF, not the git repo root. It equals the
+    repo name when the pane sits at the repo root, which is the common case and
+    the case that motivated the feature (a session called nothing but `8`,
+    sitting in a checkout whose name says exactly what it is). A pane parked
+    three directories deep gets
+    that directory's name instead. It is NOT resolved to a repo root here on
+    purpose: `path` is a STRING FROM ANOTHER MACHINE — half of these rows come
+    off the laptop over ssh — so a local `git rev-parse` would silently answer
+    about whatever happens to sit at that path on THIS host, or about nothing.
+    `scripts/tmux-autoname-session.sh` does resolve the repo root, because it
+    runs on the machine that owns the directory.
+
+    `home` is injectable so the test suite does not depend on the operator's
+    real `$HOME`.
+    """
+    home = HOME if home is None else home
+    p = (path or "").strip()
+    if not p:
+        return None
+    if p == "~" or p.startswith("~/"):
+        p = home + p[1:]
+    # `/w/repo/` and `/w/repo` are the same directory; basename disagrees.
+    # 🔴 There is deliberately NO `if not p: return None` here for the `/` case:
+    # a mutation sweep showed it SURVIVED removal, because `basename("")` is
+    # `""` and the final `or None` already covers it. An unreachable guard reads
+    # as a defence and is not one. `test_tier3_…[/]` is what actually pins it.
+    p = p.rstrip("/")
+    if os.path.normpath(p) == os.path.normpath(home):
+        return None
+    return os.path.basename(p) or None
+
+
+def resolve_label(session, path, slots=None, home=None) -> dict:
+    """`{"label": str, "label_source": one of LABEL_SOURCES, "hotkey": str|None}`.
+
+    Precedence, highest first:
+      1. `codename`  — the scratch slot table already names this session, and
+         that name is the one the hotkeys, colours and HUD use. Never overruled
+         by the cwd. THIS is the tier that carries a `hotkey`.
+      2. `path`      — the leaf of the pane's cwd (see `label_from_path`).
+      3. `fallback`  — `main`, and ONLY when the cwd yielded nothing. A row
+         labelled `main` from a cwd of `$HOME` and a row labelled `main`
+         because the operator really is in a directory called `main` are
+         distinguishable by `label_source`, not by the label.
+
+    🔴 `hotkey` IS `None` ON TIERS 2 AND 3, AND THAT IS LOAD-BEARING. A label
+    only answers "where is it"; the key answers "how do I get there", which is
+    the question actually being asked. But no key EXISTS for a session outside
+    the slot table — `$mod+Shift+<k>` is bound per slot in the tmux/i3 config —
+    so inventing one, or rendering it as `""`, would send the operator to press
+    something and land nowhere. `None`, never an empty string, so a consumer
+    cannot read a missing key as a real one.
+
+    Never returns a None label: a row always has something to render.
+    """
+    slot = (slots or {}).get(session) or {}
+    name = slot.get("codename")
+    if name:
+        return {"label": name, "label_source": "codename",
+                "hotkey": slot.get("key") or None}
+    base = label_from_path(path, home=home)
+    if base:
+        return {"label": base, "label_source": "path", "hotkey": None}
+    return {"label": LABEL_FALLBACK, "label_source": "fallback", "hotkey": None}
+
+
+def render_label(row) -> str:
+    """The label as an OPERATOR reads it: `Gold (G)` when a hotkey exists,
+    the bare label when none does. One writer, so the table and any other
+    surface cannot spell the parenthesis differently — or, worse, print an
+    empty `()` for a session that has no key."""
+    label = (row or {}).get("label") or "—"
+    key = (row or {}).get("hotkey")
+    return f"{label} ({key})" if key else label
 
 
 def _is_braille(ch: str) -> bool:
@@ -1119,7 +1244,7 @@ def index_tasks_by_window(tasks) -> dict:
 # =========================================================================== #
 # PURE — folding panes into window rows
 # =========================================================================== #
-def fold_windows(panes, host, codenames=None, task_index=None,
+def fold_windows(panes, host, slots=None, task_index=None,
                  threshold=DEFAULT_STALE_THRESHOLD, now=None,
                  slot_window_ids=None, captures=None,
                  capture_status="skipped") -> list:
@@ -1164,7 +1289,7 @@ def fold_windows(panes, host, codenames=None, task_index=None,
     about a pane nobody looked at.
     """
     now = time.time() if now is None else now
-    codenames = codenames or {}
+    slots = slots or {}
     task_index = task_index or {}
     slot_window_ids = slot_window_ids or {}
     order, groups = [], {}
@@ -1188,6 +1313,7 @@ def fold_windows(panes, host, codenames=None, task_index=None,
                 age = max(0.0, now - last)
         busy = busy_from_title(lead.get("title", ""))
         is_claude = any(pane_is_claude(p) for p in members)
+        lab = resolve_label(session, lead.get("path", ""), slots)
         # 🔴 The waiting fields, resolved through the None-vs-{} distinction
         # above. `probable` is None on every path where nothing was scraped.
         if not is_claude:
@@ -1207,7 +1333,15 @@ def fold_windows(panes, host, codenames=None, task_index=None,
             "window_index": widx,
             "window_id": slot_window_ids.get((str(session), str(widx))),
             "window_name": lead.get("window_name", ""),
-            "codename": codenames.get(session),
+            "codename": (slots.get(session) or {}).get("codename"),
+            # 🔴 ADDITIVE to `session`/`window_index`, never a replacement:
+            # two sessions in one repo resolve to the SAME label. See the
+            # module docstring.
+            "label": lab["label"],
+            "label_source": lab["label_source"],
+            # 🔴 `null` for every non-slot session, because no hotkey EXISTS
+            # for one. Never "".
+            "hotkey": lab["hotkey"],
             "pane_id": lead.get("pane_id"),
             "path": lead.get("path", ""),
             "command": lead.get("command", ""),
@@ -1535,7 +1669,7 @@ def ch_query(client, sql) -> dict:
 def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
            use_fuzzyclaw=False, threshold=DEFAULT_STALE_THRESHOLD, now=None,
            ch_client_factory=None, fuzzyclaw_texts=None,
-           codenames=None, ch_sql=SQL_RECENT_SESSIONS,
+           slots=None, ch_sql=SQL_RECENT_SESSIONS,
            claude_only=False, use_capture=True, capture_nonce=None,
            blocked_reader=None, blocked_path=None) -> dict:
     """Build the whole report. Every source is injectable, so this is the
@@ -1560,7 +1694,7 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
     now = time.time() if now is None else now
     local_host = local_host or local_host_label()
     hosts = [h for h in hosts if h in HOST_NAMES]
-    codenames = load_scratch_codenames() if codenames is None else codenames
+    slots = load_scratch_slots() if slots is None else slots
     # A fresh hex nonce per run: a pane cannot print a marker built from a
     # string that did not exist when it was drawn. Injectable so the suite is
     # deterministic.
@@ -1701,7 +1835,7 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
         if not entry["reachable"]:
             continue
         entry["windows"] = fold_windows(
-            parse_panes(raw_panes.get(host, "")), host, codenames=codenames,
+            parse_panes(raw_panes.get(host, "")), host, slots=slots,
             # fuzzyclaw is LOCAL-only: a remote row gets no task, no session id
             # and no age. Stated, not implied away.
             task_index=(task_index if host == local_host else {}),
@@ -1771,6 +1905,12 @@ def _fmt_age(secs):
 
 _STATUS_GLYPH = {"busy": "▶ busy", "idle": "● idle",
                  "stale": "· stale", "unknown": "? unk"}
+
+# 🔴 ONE format string for the header AND every row, so the header cannot drift
+# out of alignment with the data under it — the previous version carried the
+# column widths twice (a hand-spaced header literal and a `.format` spec) and
+# any width change had to be made in both places or the frame skewed silently.
+_ROW_FMT = ("  {:<9}  {:<12}  {:<3}  {:<14}  {:<25}  {:<6}  {:<8}  {:<4}  {}")
 
 
 def _trunc(s, n):
@@ -1920,17 +2060,27 @@ def render_table(report) -> str:
         # `claude` and `shell` states which one the row IS. `● idle` on an
         # agent and `● idle` on a bare zsh prompt were the same six characters
         # before this.
-        out.append("  HOST       SESSION       WIN  CODENAME   TASK"
-                   "                          KIND    STATUS    AGE   WAIT")
+        # 🔴 THE COLUMN TRADE, stated because the table did not get wider.
+        # CODENAME (9) became LABEL (14) and TASK gave up the 5 characters, so
+        # the frame is byte-for-byte the same width as before. Nothing was lost
+        # by dropping CODENAME: for a scratch session `label` IS the codename
+        # (tier 1) and the cell additionally carries the HOTKEY — `Gold (G)`,
+        # which is what the operator actually needs to reach the window — so
+        # the column says strictly more than CODENAME did, and the rows it used
+        # to render as `—` now say where they are. 14 fits the longest slot
+        # cell (`Yarrow (Y)` = 10) uncut.
+        # The cost is real and it is TASK: 30 -> 25 characters before the
+        # ellipsis. `--json` carries every field untruncated and unjoined.
+        out.append(_ROW_FMT.format("HOST", "SESSION", "WIN", "LABEL", "TASK",
+                                   "KIND", "STATUS", "AGE", "WAIT"))
         out.append("  " + "─" * 112)
         for r in rows:
             out.append(
-                "  {:<9}  {:<12}  {:<3}  {:<9}  {:<30}  {:<6}  {:<8}  "
-                "{:<4}  {}".format(
+                _ROW_FMT.format(
                     _trunc(r.get("host"), 9), _trunc(r.get("session"), 12),
                     _trunc(r.get("window_index"), 3),
-                    _trunc(r.get("codename") or "—", 9),
-                    _trunc(r.get("task") or "—", 30),
+                    _trunc(render_label(r), 14),
+                    _trunc(r.get("task") or "—", 25),
                     "claude" if r.get("claude") else "shell",
                     _STATUS_GLYPH.get(r.get("status"), "?"),
                     _fmt_age(r.get("age_secs")),

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -28,6 +28,7 @@ import importlib.machinery
 import importlib.util
 import json
 import os
+import re
 
 import pytest
 
@@ -228,6 +229,14 @@ SLOT_TABLE = '\n'.join([
     '  "scratch2:T:#83a598:Vapor"',
     ')',
 ])
+# The PARSED form of exactly the table above. Deliberately derived by hand
+# rather than by calling the parser, so a broken parser cannot define its own
+# expectation. Keys, colours and codenames are pairwise distinct — a fixture
+# whose fields coincide cannot show WHICH field a value came from.
+SLOTS_FIXTURE = {
+    "scratch7": {"codename": "Grove", "key": "S", "color": "#b8bb26"},
+    "scratch2": {"codename": "Vapor", "key": "T", "color": "#83a598"},
+}
 
 
 def make_runner(local_panes=WORKBENCH_PANES, local_windows=WORKBENCH_WINDOWS,
@@ -326,7 +335,7 @@ def base_gather(**kw):
         use_fuzzyclaw=True,
         now=NOW,
         fuzzyclaw_texts=[json.dumps(TASK_LIVE), json.dumps(TASK_STALE)],
-        codenames={"scratch7": "Grove", "scratch2": "Vapor"},
+        slots=SLOTS_FIXTURE,
         # The clawgate cache: absent by default, so no test inherits a value
         # that depends on the operator's real queue. Override per test.
         blocked_reader=lambda p: None,
@@ -501,6 +510,191 @@ def test_codename_lookup_falls_through_to_the_next_path():
     got = sm.load_scratch_codenames(paths=["/deployed", "/repo"], reader=reader)
     assert seen == ["/deployed", "/repo"]
     assert got == {"scratch7": "Grove", "scratch2": "Vapor"}
+
+
+# =========================================================================== #
+# §3.2b — LABEL RESOLUTION (the three tiers, and the tie they cannot break)
+# =========================================================================== #
+# `codename` is null for every session outside the slot table; measured on the
+# workbench 2026-08-13 that was 9 of ~30 windows, all of them rendering `—`.
+# `resolve_label` fills that in from the cwd, and `label_source` says which tier
+# answered — because "labelled `main` because the cwd is a repo called main" and
+# "labelled `main` because the cwd said nothing" are different facts.
+SYNTH_HOME = "/home/synthuser"
+
+
+def test_tier1_a_slot_table_session_is_labelled_by_its_CODENAME_AND_HOTKEY():
+    """🔴 The hotkey is the ACTIONABLE half. `Grove` says which session it is;
+    `S` is what the operator presses to get there."""
+    got = sm.resolve_label("scratch7", "/w/synth-alpha", SLOTS_FIXTURE,
+                           home=SYNTH_HOME)
+    assert got == {"label": "Grove", "label_source": "codename", "hotkey": "S"}
+
+
+def test_tier1_BEATS_the_cwd_rather_than_merging_with_it():
+    """PRECEDENCE, stated as its own case. The codename is what the hotkeys, the
+    colours and the ledger already call this session; a cwd-derived name for the
+    same window would be a second vocabulary for one thing."""
+    with_cwd = sm.resolve_label("scratch7", "/w/synth-bravo", SLOTS_FIXTURE,
+                                home=SYNTH_HOME)
+    without = sm.resolve_label("scratch7", "", SLOTS_FIXTURE, home=SYNTH_HOME)
+    assert with_cwd == without == {"label": "Grove", "label_source": "codename",
+                                   "hotkey": "S"}
+
+
+def test_tier2_a_session_with_no_codename_is_labelled_by_its_CWD():
+    got = sm.resolve_label("8", "/w/synth-charlie", {}, home=SYNTH_HOME)
+    assert got == {"label": "synth-charlie", "label_source": "path",
+                   "hotkey": None}
+
+
+def test_tier2_a_trailing_slash_is_the_same_directory():
+    """`basename("/w/x/")` is `""`. Without the rstrip this row would fall all
+    the way to `main` — pinned because a mutation sweep can otherwise delete the
+    rstrip and nothing goes red."""
+    assert sm.resolve_label("8", "/w/synth-india/", {}, home=SYNTH_HOME) == {
+        "label": "synth-india", "label_source": "path", "hotkey": None}
+
+
+def test_tier2_an_EMPTY_codename_does_not_win():
+    """A slot entry with a falsy codename is not a name, and returning it would
+    render a blank cell that looks like a bug in the table rather than a missing
+    slot entry. Its key must not leak out either — a hotkey with no label is
+    exactly as useless as a label with no hotkey."""
+    got = sm.resolve_label("8", "/w/synth-delta",
+                           {"8": {"codename": "", "key": "Q"}}, home=SYNTH_HOME)
+    assert got == {"label": "synth-delta", "label_source": "path",
+                   "hotkey": None}
+
+
+@pytest.mark.parametrize("path", [
+    SYNTH_HOME, SYNTH_HOME + "/", "~", "/", "//", "", "   ", None,
+])
+def test_tier3_a_cwd_that_yields_nothing_falls_back_to_main(path):
+    got = sm.resolve_label("8", path, {}, home=SYNTH_HOME)
+    assert got == {"label": "main", "label_source": "fallback", "hotkey": None}
+
+
+def test_tier3_is_DISTINGUISHABLE_from_a_directory_actually_called_main():
+    """SILENT-ZERO, label edition. Both rows read `main`; only `label_source`
+    says which one was measured and which one is a shrug."""
+    real = sm.resolve_label("8", "/w/main", {}, home=SYNTH_HOME)
+    shrug = sm.resolve_label("9", SYNTH_HOME, {}, home=SYNTH_HOME)
+    assert real["label"] == shrug["label"] == "main"
+    assert real["label_source"] == "path"
+    assert shrug["label_source"] == "fallback"
+    assert real != shrug
+
+
+def test_a_tilde_path_resolves_against_the_given_home():
+    assert sm.resolve_label("8", "~/workspace/synth-echo", {},
+                            home=SYNTH_HOME) == {
+        "label": "synth-echo", "label_source": "path", "hotkey": None}
+
+
+def test_label_source_is_always_one_of_the_declared_set():
+    for path in ("/w/synth-fox", SYNTH_HOME, "", "/"):
+        for names in ({}, {"8": {"codename": "Grove", "key": "S"}}):
+            got = sm.resolve_label("8", path, names, home=SYNTH_HOME)
+            assert got["label_source"] in sm.LABEL_SOURCES
+            assert got["label"]          # never None, never empty
+            # 🔴 A key only ever accompanies tier 1, and is None (not "")
+            # otherwise — the shape a consumer branches on.
+            assert (got["hotkey"] is not None) is (
+                got["label_source"] == "codename")
+            assert got["hotkey"] != ""
+    assert set(sm.LABEL_SOURCES) == {"codename", "path", "fallback"}
+
+
+# --------------------------------------------------------------------------- #
+# THE HOTKEY, and where it comes from
+# --------------------------------------------------------------------------- #
+def test_the_hotkey_comes_from_the_SLOT_TABLE_not_a_second_map():
+    """🔴 A SEAM guard, not a spelling one. The slot table is hand-edited and is
+    the single source of truth for session <-> hotkey <-> colour <-> codename;
+    a hardcoded map here — or in the script — would agree today and drift the
+    first time a slot is rekeyed. So the expectation is READ OUT OF the table
+    text, and the answer must track an edit to it.
+    """
+    slots = sm.load_scratch_slots(paths=["/x"], reader=lambda p: SLOT_TABLE)
+    assert slots == SLOTS_FIXTURE
+    for session, entry in slots.items():
+        got = sm.resolve_label(session, "/w/synth-whatever", slots,
+                               home=SYNTH_HOME)
+        assert got["hotkey"] == entry["key"]
+        assert got["label"] == entry["codename"]
+
+    # ...and REKEYING the table moves the answer. A hardcoded map passes every
+    # assertion above and fails this one.
+    rekeyed = SLOT_TABLE.replace('"scratch7:S:', '"scratch7:X:')
+    assert rekeyed != SLOT_TABLE
+    moved = sm.load_scratch_slots(paths=["/x"], reader=lambda p: rekeyed)
+    assert sm.resolve_label("scratch7", "/w/x", moved,
+                            home=SYNTH_HOME)["hotkey"] == "X"
+
+
+def test_load_scratch_codenames_is_a_PROJECTION_of_one_parse():
+    """One rule, one place: the codename map must be derived from the slot
+    parse, not from a second regex pass that can disagree with it."""
+    slots = sm.load_scratch_slots(paths=["/x"], reader=lambda p: SLOT_TABLE)
+    names = sm.load_scratch_codenames(paths=["/x"], reader=lambda p: SLOT_TABLE)
+    assert names == {s: v["codename"] for s, v in slots.items()}
+
+
+def test_the_colour_rides_along_too_but_is_not_rendered():
+    slots = sm.load_scratch_slots(paths=["/x"], reader=lambda p: SLOT_TABLE)
+    assert slots["scratch2"]["color"] == "#83a598"
+
+
+@pytest.mark.parametrize("row,expect", [
+    ({"label": "Gold", "hotkey": "G"}, "Gold (G)"),
+    ({"label": "synth-longer-repo", "hotkey": None}, "synth-longer-repo"),
+    ({"label": "main", "hotkey": None}, "main"),
+    ({"label": "x", "hotkey": ""}, "x"),        # never an empty `()`
+    ({}, "—"),
+])
+def test_render_label_never_fabricates_or_empties_the_parens(row, expect):
+    assert sm.render_label(row) == expect
+
+
+def test_the_label_is_the_LEAF_not_the_repo_root_and_that_is_documented():
+    """🔴 A STATED LIMIT, pinned so the docstring cannot drift away from it.
+    `session-manager` sees a path STRING from another machine, so it does not
+    resolve a repo root — a local `git rev-parse` would answer about whatever
+    happens to sit at that path on THIS host. `tmux-autoname-session.sh` does
+    resolve it, because it runs where the directory lives."""
+    got = sm.resolve_label("8", "/w/synth-golf/nix/system", {}, home=SYNTH_HOME)
+    assert got == {"label": "system", "label_source": "path", "hotkey": None}
+    assert "LEAF, not the git repo root" in sm.label_from_path.__doc__
+
+
+def test_TWO_SESSIONS_IN_ONE_REPO_share_a_label_and_stay_addressable():
+    """🔴 THE TIE, which is the whole reason `label` is additive.
+
+    On the workbench today `0` and `8` are both sitting in one repo, so they
+    resolve to the SAME label. A consumer that switched from `session:window` to
+    `label` would silently address the wrong window; the rows must still be
+    told apart by the identifier, and every renderer must carry it.
+    """
+    panes = sm.parse_panes("\n".join([
+        "%1|1|0|1|w-one|/w/synth-hotel|zsh|first",
+        "%2|2|8|1|w-two|/w/synth-hotel|zsh|second",
+    ]))
+    rows = sm.fold_windows(panes, "workbench", slots={}, now=NOW)
+    assert [r["label"] for r in rows] == ["synth-hotel", "synth-hotel"]
+    assert [r["label_source"] for r in rows] == ["path", "path"]
+    # ...and the identifier still separates them, in the data AND on screen.
+    ids = {(r["session"], r["window_index"]) for r in rows}
+    assert ids == {("0", "1"), ("8", "1")}
+    report = base_gather()
+    report["hosts"]["workbench"]["windows"] = rows
+    report["hosts"]["laptop"]["windows"] = []
+    text = sm.render_table(report)
+    body = [ln for ln in text.splitlines() if "synth-hotel" in ln]
+    assert len(body) == 2
+    assert any(re.search(r"\b0\b.*\b1\b", ln) for ln in body)
+    assert any(re.search(r"\b8\b.*\b1\b", ln) for ln in body)
+    assert body[0] != body[1], "two rows rendered identically — unaddressable"
 
 
 # =========================================================================== #
@@ -1521,6 +1715,15 @@ def test_json_golden_schema_and_values():
         "window_id": "@41",
         "window_name": "win-alpha",
         "codename": "Grove",
+        # tier 1: the slot table names this session, so the cwd never gets a
+        # vote — `repo-alpha` would be a DIFFERENT name for a window the
+        # hotkeys, the HUD and the ledger all already call `Grove`.
+        "label": "Grove",
+        "label_source": "codename",
+        # ...and the key that actually gets the operator there. `S` is this
+        # fixture's, not the real table's — pinned so a hardcoded map cannot
+        # satisfy it.
+        "hotkey": "S",
         "pane_id": "%11",
         "path": "/home/zach/workspace/repo-alpha",
         "command": "claude",
@@ -1559,6 +1762,9 @@ def test_json_golden_schema_and_values():
     assert second["window_id"] == "@52"
     assert second["claude"] is False
     assert second["codename"] is None
+    # ...and this is the row the whole feature exists for: no codename, and a
+    # cwd (`/home/zach/tmp`) that names it anyway.
+    assert (second["label"], second["label_source"]) == ("tmp", "path")
     assert second["status"] == "unknown"
     assert second["age_secs"] is None
     assert second["fuzzyclaw"] is None
@@ -1796,10 +2002,49 @@ def test_table_renders_ch_rows():
     assert "devrc" in text and "Add session-manager" in text
 
 
+def test_table_shows_the_LABEL_column_and_the_frame_did_not_get_wider():
+    """🔴 The trade is the assertion. CODENAME (9 wide) became LABEL (14) and
+    TASK gave up exactly those 5 characters, so the frame is byte-for-byte the
+    width it was — checked against the rule line the renderer prints, not
+    against a number restated here.
+    """
+    text = sm.render_table(base_gather())
+    header = next(ln for ln in text.splitlines() if ln.strip().startswith("HOST"))
+    rule = next(ln for ln in text.splitlines() if "─" in ln)
+    assert "LABEL" in header and "CODENAME" not in header
+    assert len(rule.strip()) == 112
+
+    # 🔴 The width claim, read off the FORMAT STRING rather than off one
+    # rendered line — a line's width depends on the data in it, so a row that
+    # happens to be short would satisfy a length check while the frame grew.
+    widths = [int(w) for w in re.findall(r"\{:<(\d+)\}", sm._ROW_FMT)]
+    assert widths == [9, 12, 3, 14, 25, 6, 8, 4]     # host ses win LABEL task …
+    assert sum(widths) == 9 + 12 + 3 + 9 + 30 + 6 + 8 + 4, (
+        "the table got wider. The pre-change columns were "
+        "host9 session12 win3 CODENAME9 task30 kind6 status8 age4; LABEL may "
+        "only grow by what another column gives up")
+
+    # Nothing was LOST by dropping the column: for a slot session the label IS
+    # the codename — and it now carries the HOTKEY too, which CODENAME never
+    # did and which is the half that gets the operator to the window.
+    assert "Grove (S)" in text
+    # ...and a row that used to render `—` now says where it is — with NO
+    # fabricated key, because none exists for a non-slot session.
+    assert "tmp" in text
+    assert "tmp (" not in text
+    # The longest possible slot cell still fits the column uncut.
+    assert len(sm.render_label({"label": "Yarrow", "hotkey": "Y"})) <= 14
+    # The header and the rows come from ONE format string, so they cannot skew.
+    assert sm._ROW_FMT.count("{") == 9
+    assert header == sm._ROW_FMT.format("HOST", "SESSION", "WIN", "LABEL",
+                                        "TASK", "KIND", "STATUS", "AGE", "WAIT")
+
+
 def test_table_does_not_crash_on_none_valued_fields():
     report = base_gather()
     row = report["hosts"]["workbench"]["windows"][0]
-    for key in ("task", "codename", "status", "age_secs", "session"):
+    for key in ("task", "codename", "label", "label_source", "status",
+                "age_secs", "session"):
         mutated = copy.deepcopy(report)
         mutated["hosts"]["workbench"]["windows"][0][key] = None
         assert isinstance(sm.render_table(mutated), str)
@@ -2921,7 +3166,7 @@ def test_a_detail_json_never_claims_a_measured_absence_it_did_not_measure(
                                     local_windows_err="list-windows died"))
     monkeypatch.setattr(sm, "read_fuzzyclaw_texts",
                         lambda *a, **k: [json.dumps(TASK_LIVE)])
-    monkeypatch.setattr(sm, "load_scratch_codenames", lambda *a, **k: {})
+    monkeypatch.setattr(sm, "load_scratch_slots", lambda *a, **k: {})
     # 🔴 `--fuzzyclaw` is now REQUIRED to reach this code path at all: the join
     # is opt-in, so without it the status would be `skipped` and this test
     # would pass vacuously against a source that was never read.
@@ -3300,7 +3545,7 @@ def mix_gather(**kw):
     defaults = dict(hosts=("workbench",), local_host="workbench",
                     runner=make_runner(local_panes=IDLE_MIX_PANES,
                                        local_windows=IDLE_MIX_WINDOWS),
-                    fuzzyclaw_texts=[], codenames={})
+                    fuzzyclaw_texts=[], slots={})
     defaults.update(kw)
     return base_gather(**defaults)
 
@@ -4867,7 +5112,7 @@ def test_fuzzyclaw_is_OFF_by_default_and_publishes_None_not_zero():
         is False
     rep = _REAL_GATHER(hosts=("workbench",), local_host="workbench",
                        runner=make_runner(), use_ch=False, now=NOW,
-                       codenames={}, blocked_reader=lambda p: None)
+                       slots={}, blocked_reader=lambda p: None)
     assert rep["fuzzyclaw"]["status"] == "skipped"
     assert rep["fuzzyclaw"]["files_seen"] is None
     assert rep["summary"]["fuzzyclaw_live"] is None
@@ -4892,7 +5137,7 @@ def test_the_fuzzyclaw_flags_compose_with_explicit_OFF_winning(
     def fake_gather(**kw):
         seen.update(kw)
         return _REAL_GATHER(**dict(kw, runner=make_runner(),
-                                   fuzzyclaw_texts=[], codenames={},
+                                   fuzzyclaw_texts=[], slots={},
                                    blocked_reader=lambda p: None, now=NOW))
     monkeypatch.setattr(sm, "gather", fake_gather)
     sm.main(["scan", "--host", "workbench", "--no-ch", *argv])
@@ -4908,7 +5153,7 @@ def test_no_capture_flag_reaches_gather(monkeypatch, absent_blocked_cache):
 
     def fake_gather(**kw):
         seen.update(kw)
-        return _REAL_GATHER(**dict(kw, runner=make_runner(), codenames={},
+        return _REAL_GATHER(**dict(kw, runner=make_runner(), slots={},
                                    blocked_reader=lambda p: None, now=NOW))
     monkeypatch.setattr(sm, "gather", fake_gather)
     sm.main(["scan", "--host", "workbench", "--no-ch", "--no-capture"])
@@ -4940,9 +5185,11 @@ def test_the_row_FIELD_LEDGER_fails_when_it_grows_or_shrinks():
     row = base_gather()["hosts"]["workbench"]["windows"][0]
     expected = {
         "host", "session", "window_index", "window_id", "window_name",
-        "codename", "pane_id", "path", "command", "task", "claude", "busy",
-        "age_secs", "status", "waiting_probable", "waiting_signals",
-        "waiting_status", "claude_session_id", "fuzzyclaw", "panes",
+        "codename", "label", "label_source", "hotkey", "pane_id", "path",
+        "command",
+        "task", "claude", "busy", "age_secs", "status", "waiting_probable",
+        "waiting_signals", "waiting_status", "claude_session_id", "fuzzyclaw",
+        "panes",
     }
     assert set(row) == expected
     for field in expected:

--- a/scripts/tests/test_tmux_autoname_session.py
+++ b/scripts/tests/test_tmux_autoname_session.py
@@ -1,0 +1,527 @@
+"""Behavioural tests for scripts/tmux-autoname-session.sh — the `session-created`
+hook that names an auto-numbered tmux session after the directory it opened in.
+
+🔴 NOTHING HERE MAY REACH THE REAL TMUX SERVER
+----------------------------------------------
+This suite runs on a live workbench holding ~30 real tmux windows of the
+operator's in-flight work, and the script under test calls `rename-session`.
+A rename changes a session's ADDRESS mid-flight, so a leak is not a cosmetic
+failure — every `session:window` anyone wrote down stops resolving.
+
+`TMUX_TMPDIR` is NOT sufficient isolation: `$TMUX` overrides it, so a child that
+inherits the operator's `$TMUX` reaches the live server regardless. So the
+mechanism here is a STUB `tmux` first on PATH, and the child's `$TMUX` is
+removed as well. `test_the_stub_is_what_the_script_actually_reaches` is the
+POSITIVE CONTROL on that: a guard nobody watched work is not a guard, and a
+suite of green "0 renames" assertions is indistinguishable from a harness wired
+to nothing unless something proves a rename CAN be observed.
+
+WHAT THE LOAD-BEARING TESTS ARE
+-------------------------------
+Not the happy path. The gate — `^[0-9]+$` — is the only thing standing between
+this hook and `scratch7`'s name, which is a hotkey target, a colour and a
+codename rather than just a string. So it gets a MUTATION test that widens the
+pattern and watches the owning assertion go red, proving the gate is REACHED
+rather than shadowed by an earlier check.
+
+The fixtures are synthetic and pairwise distinct. The one place the REAL
+`tmux-scratch-slots.sh` is used is the seam test, which reads a codename out of
+that file at runtime rather than restating one — the point there is that the
+script and the canonical table agree, which a copied constant cannot show.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "scripts"))
+
+from testlib.mockbin import write_exec  # noqa: E402
+
+SCRIPT = REPO / "scripts" / "tmux-autoname-session.sh"
+REAL_SLOTS = REPO / "scripts" / "tmux-scratch-slots.sh"
+TMUX_CONF = REPO / ".tmux.conf"
+HOME_NIX = REPO / "nix" / "home.nix"
+
+pytestmark = pytest.mark.skipif(shutil.which("bash") is None,
+                                reason="needs bash on PATH")
+
+# Synthetic slot table: pairwise-distinct session names AND codenames, none of
+# which collide with anything else in this file. Deliberately NOT the real
+# table — a fixture that borrows production values cannot show which of the two
+# a behaviour came from.
+SYNTH_SLOTS = "\n".join([
+    "SCRATCH_SLOTS=(",
+    '    "scratch:q:#111111:quartz"',
+    '    "scratch2:Z:#222222:Zephyr"',
+    '    "scratch3:k:#333333:kelp"',
+    ")",
+    "",
+])
+
+# The gate, verbatim. Quoted here so the mutation test can rewrite THAT LINE and
+# nothing else — see its docstring.
+GATE_LINE = '[[ "$SESSION" =~ ^[0-9]+$ ]] || exit 0'
+
+TMUX_STUB = """
+printf '%s\\n' "$*" >> "$SM_LOG"
+case "${1:-}" in
+  display-message)
+    if [ -n "${SM_DISPLAY_FAILS:-}" ]; then exit 1; fi
+    printf '%s\\n' "${SM_CWD:-}"
+    ;;
+  list-sessions)
+    if [ -n "${SM_LIST_FAILS:-}" ]; then exit 1; fi
+    printf '%s' "${SM_SESSIONS:-}"
+    ;;
+  rename-session)
+    :
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+exit 0
+"""
+
+GIT_STUB = """
+printf 'git %s\\n' "$*" >> "$SM_LOG"
+if [ -z "${SM_GIT_ROOT:-}" ]; then exit 128; fi
+printf '%s\\n' "$SM_GIT_ROOT"
+exit 0
+"""
+
+
+class Run:
+    """One invocation's result: the process, plus the parsed stub log."""
+
+    def __init__(self, proc, log_text):
+        self.proc = proc
+        self.log = [ln for ln in log_text.splitlines() if ln.strip()]
+
+    @property
+    def renames(self):
+        """`[(target, new_name), ...]` — every rename-session the script asked
+        for. The COUNT is the measurement; a bare `not r.renames` would be
+        satisfied by a harness that never recorded anything."""
+        out = []
+        for line in self.log:
+            m = re.match(r"^rename-session -t (\S+) (.*)$", line)
+            if m:
+                out.append((m.group(1), m.group(2)))
+        return out
+
+
+def make_tree(tmp_path, slots=SYNTH_SLOTS, script_text=None):
+    """A copy of the script with a slot table beside it, mirroring the deployed
+    layout (~/.config/tmux/{autoname-session.sh,scratch-slots.sh})."""
+    d = tmp_path / "tmuxdir"
+    d.mkdir(exist_ok=True)
+    target = d / "autoname-session.sh"
+    target.write_text(SCRIPT.read_text() if script_text is None else script_text)
+    target.chmod(0o755)
+    (d / "scratch-slots.sh").write_text(slots)
+    return target
+
+
+def invoke(tmp_path, session, *, script=None, cwd="/w/synth-alpha",
+           sessions=(), git_root=None, home="/home/synthuser",
+           display_fails=False, list_fails=False, slots=SYNTH_SLOTS,
+           script_text=None):
+    """Run the script with a stub `tmux` + `git` first on PATH."""
+    script = make_tree(tmp_path, slots=slots,
+                       script_text=script_text) if script is None else script
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    log = tmp_path / "calls.log"
+    log.write_text("")
+    write_exec(bindir / "tmux", TMUX_STUB)
+    write_exec(bindir / "git", GIT_STUB)
+
+    env = dict(os.environ)
+    env.pop("TMUX", None)          # $TMUX overrides TMUX_TMPDIR; remove it
+    env["TMUX_TMPDIR"] = str(tmp_path / "tmuxsock")
+    env["PATH"] = f"{bindir}{os.pathsep}{os.environ['PATH']}"
+    env["SM_LOG"] = str(log)
+    env["SM_CWD"] = cwd
+    env["SM_SESSIONS"] = "".join(f"{s}\n" for s in sessions)
+    env["HOME"] = home
+    if git_root:
+        env["SM_GIT_ROOT"] = git_root
+    else:
+        env.pop("SM_GIT_ROOT", None)
+    if display_fails:
+        env["SM_DISPLAY_FAILS"] = "1"
+    if list_fails:
+        env["SM_LIST_FAILS"] = "1"
+
+    proc = subprocess.run([str(script), session], env=env,
+                          capture_output=True, text=True, timeout=30)
+    return Run(proc, log.read_text())
+
+
+# --------------------------------------------------------------------------- #
+# THE HARNESS, before any verdict read off it
+# --------------------------------------------------------------------------- #
+def test_the_stub_is_what_the_script_actually_reaches(tmp_path):
+    """POSITIVE CONTROL, both halves.
+
+    (a) `tmux` resolves to the stub on the child's PATH, so nothing in this file
+        can touch the operator's live server; and
+    (b) a rename IS observable through the log — otherwise every `renames == []`
+        below is a fact about the recorder, not about the script.
+    """
+    r = invoke(tmp_path, "3", cwd="/w/synth-alpha")
+    bindir = tmp_path / "bin"
+    resolved = shutil.which("tmux", path=f"{bindir}{os.pathsep}"
+                                         f"{os.environ['PATH']}")
+    assert resolved == str(bindir / "tmux"), (
+        "the stub is not first on PATH — this suite would be driving the real "
+        "tmux server")
+    assert len(r.renames) == 1, "the recorder never observed a rename at all"
+
+
+# --------------------------------------------------------------------------- #
+# TIER 1 — the auto-number gate
+# --------------------------------------------------------------------------- #
+def test_an_auto_numbered_session_is_renamed_after_its_directory(tmp_path):
+    r = invoke(tmp_path, "8", cwd="/w/synth-alpha")
+    assert r.renames == [("=8", "synth-alpha")]
+    assert r.proc.returncode == 0
+
+
+def test_a_scratch_session_is_NEVER_touched(tmp_path):
+    """🔴 The one that matters. `scratch7` ends in a digit and sits in a
+    perfectly good repo directory — everything except the gate would let this
+    through, which is why the mutation test below points at exactly this case.
+    """
+    r = invoke(tmp_path, "scratch7", cwd="/w/synth-alpha")
+    assert r.renames == [], (
+        "the hook renamed a SCRATCH session — that name is a hotkey target, a "
+        "colour and a codename, not just a string")
+    assert r.proc.returncode == 0
+
+
+def test_a_deliberately_named_session_is_NEVER_touched(tmp_path):
+    r = invoke(tmp_path, "reviews", cwd="/w/synth-alpha")
+    assert r.renames == []
+
+
+@pytest.mark.parametrize("session", ["", "12a", "a12", "8:1", "-8", "8.2", " 8"])
+def test_only_a_purely_numeric_name_is_eligible(tmp_path, session):
+    r = invoke(tmp_path, session, cwd="/w/synth-alpha")
+    assert r.renames == []
+
+
+def test_MUTATION_widening_the_gate_is_what_eats_a_scratch_name(tmp_path):
+    """🔴 MUTATION + REACHABILITY, on the guard that owns the hazard.
+
+    Widening `^[0-9]+$` to also admit letters is the single edit that turns this
+    hook into something that renames `scratch7`. Two things are proven here, and
+    the second is the one that is usually skipped:
+
+      * the mutant DIES on the assertion that owns it — the mutant renames
+        `scratch7`, so `test_a_scratch_session_is_NEVER_touched` goes red for
+        THIS reason and not because some other guard's error killed the run; and
+      * the gate is REACHED, not shadowed. The mutant's rename proves every
+        later check (cwd, sanitiser, slot table, live sessions) ACCEPTS
+        `scratch7` in exactly this fixture — so the unmutated `[]` is the gate's
+        doing, not an accident of some earlier rejection.
+    """
+    # 🔴 The mutation targets the GATE LINE, not the pattern text. The header
+    # comment quotes `^[0-9]+$` too, so a bare `.replace` on the pattern
+    # rewrites the comment as well — and would then read as "mutation applied"
+    # even against a tree where the gate had already been deleted. Measured:
+    # that is exactly what happened on the first run of this sweep.
+    src = SCRIPT.read_text()
+    assert src.count(GATE_LINE) == 1, (
+        f"expected exactly one gate line, found {src.count(GATE_LINE)} — the "
+        "guard was renamed, duplicated or deleted, and this test can no longer "
+        "say which")
+    mutant = src.replace(GATE_LINE, GATE_LINE.replace("[0-9]", "[A-Za-z0-9]"))
+    assert mutant != src
+
+    r = invoke(tmp_path, "scratch7", cwd="/w/synth-alpha", script_text=mutant)
+    assert r.renames == [("=scratch7", "synth-alpha")], (
+        "the mutant did NOT rename scratch7 — the gate is shadowed by an "
+        "earlier check and this suite is not testing what it claims to")
+
+
+# --------------------------------------------------------------------------- #
+# TIER 2 — where the name comes from
+# --------------------------------------------------------------------------- #
+def test_the_git_repo_root_beats_the_raw_directory(tmp_path):
+    r = invoke(tmp_path, "8", cwd="/w/synth-bravo/nix/system",
+               git_root="/w/synth-bravo")
+    assert r.renames == [("=8", "synth-bravo")]
+
+
+def test_a_cwd_outside_a_work_tree_falls_back_to_the_leaf(tmp_path):
+    r = invoke(tmp_path, "8", cwd="/w/synth-charlie/deep/leafdir", git_root=None)
+    assert r.renames == [("=8", "leafdir")]
+
+
+@pytest.mark.parametrize("raw,expect", [
+    ("/w/my repo.v2", "my-repo-v2"),
+    ("/w/--edges--", "edges"),
+    ("/w/Keep_Me-1", "Keep_Me-1"),
+])
+def test_the_name_is_reduced_to_a_tmux_safe_alphabet(tmp_path, raw, expect):
+    """tmux forbids `.` and `:` in a session name, and the name is interpolated
+    back into shell command lines by the other hooks."""
+    r = invoke(tmp_path, "8", cwd=raw)
+    assert r.renames == [("=8", expect)]
+    assert "." not in expect and ":" not in expect
+
+
+@pytest.mark.parametrize("kw", [
+    {"cwd": "/home/synthuser"},          # $HOME — `synthuser` is not information
+    {"cwd": "/"},
+    {"cwd": ""},
+    {"cwd": "/w/..."},                   # sanitises to nothing
+    {"display_fails": True},             # tmux could not answer
+])
+def test_a_cwd_that_says_nothing_leaves_the_session_ALONE(tmp_path, kw):
+    r = invoke(tmp_path, "8", **kw)
+    assert r.renames == []
+    assert r.proc.returncode == 0
+
+
+def test_the_git_root_is_checked_against_HOME_too(tmp_path):
+    """The HOME guard must survive the git-root path, not only the raw cwd —
+    otherwise `git -C ~ rev-parse` in a dotfiles work tree renames a session to
+    the operator's username."""
+    r = invoke(tmp_path, "8", cwd="/home/synthuser/notes",
+               git_root="/home/synthuser")
+    assert r.renames == []
+
+
+# --------------------------------------------------------------------------- #
+# TIER 3 — collisions
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("name", ["scratch2", "Zephyr"])
+def test_a_name_the_SLOT_TABLE_owns_is_deduped(tmp_path, name):
+    """BOTH halves of a slot entry are reserved: the session name (renaming onto
+    it would point a hotkey at the wrong window) and the codename (that is the
+    word the HUD and the ledger use)."""
+    r = invoke(tmp_path, "8", cwd=f"/w/{name}")
+    assert r.renames == [("=8", f"{name}-2")]
+
+
+def test_a_name_a_LIVE_session_holds_is_deduped(tmp_path):
+    r = invoke(tmp_path, "8", cwd="/w/synth-delta",
+               sessions=("synth-delta", "8"))
+    assert r.renames == [("=8", "synth-delta-2")]
+
+
+def test_dedupe_walks_past_consecutive_collisions(tmp_path):
+    r = invoke(tmp_path, "8", cwd="/w/synth-echo",
+               sessions=("synth-echo", "synth-echo-2", "synth-echo-3", "8"))
+    assert r.renames == [("=8", "synth-echo-4")]
+
+
+def test_ten_collisions_leaves_the_session_alone(tmp_path):
+    taken = ["synth-fox"] + [f"synth-fox-{n}" for n in range(2, 11)]
+    r = invoke(tmp_path, "8", cwd="/w/synth-fox", sessions=(*taken, "8"))
+    assert r.renames == []
+
+
+def test_the_session_being_renamed_does_not_collide_with_itself(tmp_path):
+    """`8` is in `list-sessions` output while the hook runs. A dedupe that
+    counted it would be a no-op on every real invocation."""
+    r = invoke(tmp_path, "8", cwd="/w/synth-golf", sessions=("8", "scratch"))
+    assert r.renames == [("=8", "synth-golf")]
+
+
+def test_a_MISSING_slot_table_degrades_instead_of_crashing(tmp_path):
+    """🔴 `set -u` + an UNSET array is a crash, not a no-op — and this is
+    reachable: a host that has not switched yet, or any future edit that moves
+    the deployed `scratch-slots.sh`. The mutant that empties the table
+    (`SCRATCH_SLOTS=()`) does NOT cover it; that array is defined.
+
+    Correct degradation is: rename anyway, having lost only the reservation.
+    Refusing to name anything because a display nicety is missing would be the
+    worse failure, and crashing would put a bash error in the terminal.
+    """
+    d = tmp_path / "noslots"
+    d.mkdir()
+    script = d / "autoname-session.sh"
+    script.write_text(SCRIPT.read_text())
+    script.chmod(0o755)
+    assert not (d / "scratch-slots.sh").exists()
+    assert not (d / "tmux-scratch-slots.sh").exists()
+
+    r = invoke(tmp_path, "8", cwd="/w/synth-juliet", script=script)
+    assert r.proc.returncode == 0
+    assert r.proc.stderr == "", f"a bash error reached the terminal: {r.proc.stderr!r}"
+    assert r.renames == [("=8", "synth-juliet")]
+
+
+def test_a_failed_list_sessions_does_not_abort_the_rename(tmp_path):
+    """Degrade, do not crash: tmux would refuse a duplicate rename anyway, so
+    losing the live-session list costs a suffix, not the feature."""
+    r = invoke(tmp_path, "8", cwd="/w/synth-hotel", list_fails=True)
+    assert r.renames == [("=8", "synth-hotel")]
+
+
+# --------------------------------------------------------------------------- #
+# THE SEAM — the script and the CANONICAL slot table, not a copy of it
+# --------------------------------------------------------------------------- #
+def test_reserved_names_come_from_the_real_slot_table(tmp_path):
+    """Read a codename OUT of `scripts/tmux-scratch-slots.sh` at runtime and
+    check the script refuses it. Restating a codename here would pass against a
+    private copy of the table — which is exactly the drift the table's own
+    header forbids."""
+    entries = re.findall(r'"([^":]+):([^":]+):(#[0-9a-fA-F]{6}):([^":]+)"',
+                         REAL_SLOTS.read_text())
+    assert entries, "the canonical slot table did not parse"
+    codename = entries[0][3]
+
+    tree = tmp_path / "repolike"
+    tree.mkdir()
+    script = tree / "autoname-session.sh"
+    script.write_text(SCRIPT.read_text())
+    script.chmod(0o755)
+    # the in-repo NAME, which is the second of the two the script looks for
+    (tree / "tmux-scratch-slots.sh").write_text(REAL_SLOTS.read_text())
+
+    r = invoke(tmp_path, "8", cwd=f"/w/{codename}", script=script)
+    assert r.renames == [("=8", f"{codename}-2")]
+
+
+# --------------------------------------------------------------------------- #
+# IDEMPOTENCE + THE HOOK CONTRACT (silence, exit 0)
+# --------------------------------------------------------------------------- #
+def test_running_it_again_on_the_renamed_session_is_a_no_op(tmp_path):
+    first = invoke(tmp_path, "8", cwd="/w/synth-india")
+    assert first.renames == [("=8", "synth-india")]
+    second = invoke(tmp_path, "synth-india", cwd="/w/synth-india")
+    assert second.renames == []
+
+
+@pytest.mark.parametrize("session,kw", [
+    ("8", {}),
+    ("scratch7", {}),
+    ("8", {"cwd": "/"}),
+    ("8", {"display_fails": True}),
+    ("", {}),
+])
+def test_it_exits_zero_and_says_nothing_on_every_path(tmp_path, session, kw):
+    """It runs from a `session-created` hook. A non-zero exit or a stray line of
+    output lands in the operator's terminal — or a view-mode popup — at the
+    moment they open a new session."""
+    r = invoke(tmp_path, session, **kw)
+    assert r.proc.returncode == 0
+    assert r.proc.stdout == ""
+    assert r.proc.stderr == ""
+
+
+# --------------------------------------------------------------------------- #
+# THE HOOK WIRING — appended, not clobbered; and deployed at all
+# --------------------------------------------------------------------------- #
+_SET_HOOK_RE = re.compile(r"^\s*set-hook\s+(-[a-zA-Z]+)\s+(\S+)", re.M)
+
+
+def _hooks_in_order():
+    return _SET_HOOK_RE.findall(TMUX_CONF.read_text())
+
+
+def test_only_the_FIRST_binding_of_a_hook_may_be_non_append():
+    """🔴 A RELATIONSHIP guard over every hook in `.tmux.conf`, not a spelling
+    check on the line this branch added.
+
+    `set-hook -g <name>` REPLACES the hook; `-ga` appends. So a plain `-g` that
+    appears after any other binding of the same hook silently deletes it. That
+    is the exact way this branch could have killed activity telemetry: the
+    `session-created` hook already carried `pipe-activity.sh init`, and a `-g`
+    autoname line would have removed it with no error anywhere.
+    """
+    seen: dict[str, int] = {}
+    for flags, hook in _hooks_in_order():
+        seen[hook] = seen.get(hook, 0) + 1
+        if seen[hook] > 1:
+            assert "a" in flags.lstrip("-"), (
+                f"`set-hook {flags} {hook}` is binding #{seen[hook]} for that "
+                f"hook and does NOT append — it deletes every binding above it")
+
+
+def test_the_pre_existing_session_created_binding_is_still_there():
+    """The specific one this branch had to not break, pinned by its target."""
+    hooks = [(f, h) for f, h in _hooks_in_order() if h == "session-created"]
+    assert len(hooks) == 2, f"expected exactly two session-created bindings: {hooks}"
+    assert hooks[0][0] == "-g" and hooks[1][0] == "-ga"
+    text = TMUX_CONF.read_text()
+    assert 'set-hook -g session-created' in text
+    assert 'pipe-activity.sh init' in text
+
+
+def test_the_hook_escapes_the_session_name_for_sh():
+    """`run-shell` feeds its command to /bin/sh, so an unescaped
+    `#{hook_session_name}` is shell syntax. `#{q:...}` is tmux's sh(1) escape."""
+    line = [ln for ln in TMUX_CONF.read_text().splitlines()
+            if "autoname-session.sh" in ln and ln.lstrip().startswith("set-hook")]
+    assert len(line) == 1, line
+    assert "#{q:hook_session_name}" in line[0]
+    assert "-ga session-created" in line[0]
+
+
+def test_the_script_is_EXECUTABLE():
+    """🔴 MEASURED, not defensive. The first live run of this hook against an
+    isolated tmux server did nothing at all: the file had landed mode 644, so
+    `run-shell` got `Permission denied` — and `run-shell -b` swallows it, so the
+    only symptom was a session that stayed called `0`. The `home.file` entry
+    carries `executable = true`, which fixes the DEPLOYED copy and hides the
+    repo mode; this pins the repo mode, which is what every other consumer
+    (and this suite, which execs the file directly) actually sees.
+    """
+    assert os.access(SCRIPT, os.X_OK), (
+        "scripts/tmux-autoname-session.sh is not executable — the hook will "
+        "fail silently and the session will keep its auto-number")
+    assert 'executable = true' in re.sub(
+        r"\s+", " ",
+        HOME_NIX.read_text().split('.config/tmux/autoname-session.sh')[1][:200])
+
+
+def test_the_script_is_DEPLOYED_beside_the_slot_table_it_sources():
+    """It resolves the slot table from its OWN directory, so a `home.file`
+    entry that put it anywhere else would deploy a script that silently
+    reserves no names at all. Both paths are asserted, not just the entry."""
+    nix = HOME_NIX.read_text()
+    assert '.config/tmux/autoname-session.sh' in nix
+    assert '../scripts/tmux-autoname-session.sh' in nix
+    assert '.config/tmux/scratch-slots.sh' in nix
+
+    hook_path = re.search(r'run-shell -b "([^ "]*autoname-session\.sh)',
+                          TMUX_CONF.read_text()).group(1)
+    assert hook_path == "~/.config/tmux/autoname-session.sh"
+    assert hook_path.split("/", 1)[1] in nix
+
+
+def test_the_script_is_tracked_by_git():
+    """🔴 CLAUDE.md: a new file that is not `git add`ed is silently omitted from
+    the flake, the switch succeeds, and the file simply is not there.
+
+    Deliberately NOT a skip in the sandbox — the two tiers check it two ways and
+    both are assertions. In the nix build the flake source only carries TRACKED
+    files, so the script EXISTING there is itself the proof; on the dev host,
+    where an untracked file would still be sitting in the tree, `git ls-files`
+    is the one that can tell the difference.
+    """
+    assert SCRIPT.exists(), (
+        "scripts/tmux-autoname-session.sh is absent — in the nix sandbox that "
+        "means it was never git added, so the flake omitted it")
+    if shutil.which("git") and (REPO / ".git").exists():
+        out = subprocess.run(
+            ["git", "-C", str(REPO), "ls-files", "--error-unmatch",
+             "scripts/tmux-autoname-session.sh"],
+            capture_output=True, text=True)
+        assert out.returncode == 0, (
+            "scripts/tmux-autoname-session.sh is UNTRACKED — `home-manager "
+            "switch` will succeed and the hook will point at nothing")

--- a/scripts/tmux-autoname-session.sh
+++ b/scripts/tmux-autoname-session.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# tmux-autoname-session.sh — give a session tmux named with a bare counter a
+# name that says WHERE IT IS, once, at creation.
+#
+# Called from the `session-created` hook in .tmux.conf, APPENDED with `-ga` so
+# it does not clobber the pipe-activity hook already bound there:
+#
+#   set-hook -ga session-created \
+#     'run-shell -b "~/.config/tmux/autoname-session.sh #{q:hook_session_name}"'
+#
+# `#{q:...}` is tmux's sh(1)-escaping format modifier: the session name is
+# interpolated into a /bin/sh command line, and a name containing a space or a
+# `;` would otherwise be parsed as shell syntax.
+#
+# 🔴 WHAT THIS IS FOR. `session-manager` renders `codename: —` for every session
+# outside the scratch slot table, because that table IS the codename vocabulary.
+# Measured on the workbench 2026-08-13: two auto-numbered sessions (`0`, `8`)
+# held 9 of ~30 windows, so a third of the operator's live work was invisible to
+# every surface that keys on a codename. `workbench 8:1` says nothing; the cwd
+# says plenty. This closes it going FORWARD; `session-manager`'s `label` field
+# covers the sessions that already exist.
+#
+# 🔴 IT IS DELIBERATELY TIMID. Five things stop it, and the FIRST is the one
+# that matters: it renames ONLY a name matching `^[0-9]+$`, which is exactly
+# what tmux auto-assigns and nothing a human would type. Widening that pattern
+# is how this eats `scratch7`'s name — and `scratch7` is a hotkey target, a
+# colour and a codename, not just a string. Every other guard below is a
+# fallback; this one is the guard.
+#
+# Exits 0 on EVERY path, prints nothing on success. It runs from a tmux hook: a
+# non-zero exit or a stray line of output lands in the operator's terminal (or a
+# view-mode popup) at the moment they open a new session.
+set -uo pipefail
+
+# The session name tmux is asking about. Absent -> nothing to do.
+SESSION="${1:-}"
+[ -n "$SESSION" ] || exit 0
+
+# --------------------------------------------------------------------------- #
+# GUARD 1 — the auto-number gate. THE load-bearing one; see the header.
+# --------------------------------------------------------------------------- #
+[[ "$SESSION" =~ ^[0-9]+$ ]] || exit 0
+
+# --------------------------------------------------------------------------- #
+# Where is it? `=` prefixes an EXACT session-name match, so a session called `1`
+# cannot be resolved to `12` by tmux's prefix matching.
+# --------------------------------------------------------------------------- #
+cwd=$(tmux display-message -p -t "=${SESSION}:" '#{pane_current_path}' 2>/dev/null) || exit 0
+[ -n "$cwd" ] || exit 0
+
+# Prefer the git repo ROOT's basename over the raw directory: a session opened
+# in `<repo>/nix/system` is about the repo, not about `system`. Falls through to
+# the raw directory when the cwd is not in a work tree (or `git` is absent).
+root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null) || root=""
+dir="${root:-$cwd}"
+dir="${dir%/}"
+
+# --------------------------------------------------------------------------- #
+# GUARD 2 — a cwd that yields nothing useful leaves the session ALONE. Renaming
+# `0` to `zach` (the basename of $HOME) is worse than leaving it as `0`: it
+# looks like information and is not.
+# --------------------------------------------------------------------------- #
+[ -n "$dir" ] || exit 0
+[ "$dir" != "${HOME:-}" ] || exit 0
+base=$(basename -- "$dir" 2>/dev/null) || exit 0
+[ -n "$base" ] && [ "$base" != "/" ] && [ "$base" != "." ] || exit 0
+
+# --------------------------------------------------------------------------- #
+# GUARD 3 — sanitise. tmux forbids `.` and `:` in a session name, and the name
+# is interpolated back into shell command lines by other hooks, so reduce to a
+# conservative alphabet rather than escaping per consumer.
+# --------------------------------------------------------------------------- #
+cand=$(printf '%s' "$base" | tr -c 'A-Za-z0-9_-' '-' | tr -s '-')
+cand="${cand#-}"
+cand="${cand%-}"
+[ -n "$cand" ] || exit 0
+
+# --------------------------------------------------------------------------- #
+# GUARD 4 — never take a name the scratch slot table owns.
+#
+# Sourced from the canonical table (deployed copy first, then the in-repo one),
+# the same resolution every other consumer uses — a private copy of these names
+# would go stale the first time a slot is renamed. BOTH halves of each entry are
+# reserved: the session name (`scratch7`) because renaming onto it would make
+# `$mod+Shift+O` resolve to the wrong window, and the codename (`orange`)
+# because that is the word the HUD, the ledger and the operator use for it.
+# --------------------------------------------------------------------------- #
+_d="$(dirname "$0")"
+if   [ -f "$_d/scratch-slots.sh" ];      then . "$_d/scratch-slots.sh"
+elif [ -f "$_d/tmux-scratch-slots.sh" ]; then . "$_d/tmux-scratch-slots.sh"; fi
+
+taken=()
+for _entry in "${SCRATCH_SLOTS[@]:-}"; do
+    [ -n "$_entry" ] || continue
+    taken+=("${_entry%%:*}")   # session name
+    taken+=("${_entry##*:}")   # codename
+done
+
+# --------------------------------------------------------------------------- #
+# GUARD 5 — and never take a name a LIVE session already holds. tmux would
+# refuse the rename anyway ("duplicate session"), but refusing silently leaves
+# the session as `0` forever; a suffix keeps the name useful.
+# --------------------------------------------------------------------------- #
+while IFS= read -r _live; do
+    [ -n "$_live" ] && taken+=("$_live")
+done < <(tmux list-sessions -F '#{session_name}' 2>/dev/null || true)
+
+_is_taken() {
+    local want="$1" t
+    for t in "${taken[@]:-}"; do
+        [ "$t" = "$want" ] && return 0
+    done
+    return 1
+}
+
+pick="$cand"
+if _is_taken "$pick"; then
+    pick=""
+    for n in 2 3 4 5 6 7 8 9 10; do
+        if ! _is_taken "${cand}-${n}"; then pick="${cand}-${n}"; break; fi
+    done
+fi
+# Ten collisions on one name is not a case worth guessing at — leave it alone.
+[ -n "$pick" ] || exit 0
+
+# Nothing to do if it is somehow already there (belt-and-braces: GUARD 1 already
+# means `pick` cannot equal a purely-numeric `$SESSION`).
+[ "$pick" != "$SESSION" ] || exit 0
+
+tmux rename-session -t "=${SESSION}" "$pick" >/dev/null 2>&1 || exit 0
+exit 0


### PR DESCRIPTION
## The problem, measured

`session-manager` renders `codename: —` for any session outside the scratch slot table,
because that table **is** the codename vocabulary. On the workbench, 2026-08-13:

```
slot table (scripts/tmux-scratch-slots.sh): scratch..scratch20, 20 codenames
unnamed sessions: "0" (5 windows) and "8" (4 windows)  ->  9 windows with no codename
```

9 of ~30 live windows invisible to every surface that keys on a codename. `workbench 8:1`
tells you nothing; the cwd tells you plenty. Both of those sessions are sitting in the
**same** checkout, which is why the label alone can never be an address.

---

## Part 1 — `label` + `hotkey` in `session-manager`

Every row now carries `label`, `label_source` and `hotkey`, resolved in three tiers:

| tier | `label_source` | `label` | `hotkey` |
|---|---|---|---|
| 1 | `codename` | the slot codename | the slot's **key** |
| 2 | `path` | leaf of the pane's `pane_current_path` | `null` |
| 3 | `fallback` | `main` | `null` |

🔴 **The hotkey is the actionable half.** A codename says which session it is; the key is
what you press to get there. It was already being parsed out of the slot table
(`scratch2:G:#d79921:Gold`) and thrown away into a `_key`. The table renders `Gold (G)`.

🔴 **`hotkey` is `null`, never `""`, on tiers 2 and 3.** No `$mod+Shift+<k>` binding
*exists* for a non-slot session, so a fabricated or empty key would send you to press
something and land nowhere. Pinned in both directions.

🔴 **`session:window` is still THE identifier.** Two sessions in one repo resolve to the
same label — the state on the workbench right now — so a label alone addresses nothing.
Every renderer carries both, and a test builds that exact tie and asserts the two rows stay
distinguishable in the data *and* on screen.

`label_source` exists because "labelled `main` because the cwd is a repo called main" and
"labelled `main` because the cwd said nothing" must not read the same.

**The table did not get wider.** CODENAME (9) became LABEL (14); TASK gave up exactly those
5 characters (30 → 25 before the ellipsis). Nothing was lost — for a slot session the label
IS the codename, plus the key CODENAME never carried. `--json` is untruncated. The header
and the rows now come from one format string, so they cannot skew.

**Stated limit:** tier 2 is the *leaf* directory, not the git repo root. `path` is a string
from another machine (half these rows come off the laptop over ssh), so a local
`git rev-parse` would answer about whatever happens to sit at that path on *this* host. The
autoname script below *does* resolve the root, because it runs where the directory lives.

## Part 2 — `session-created` auto-naming

`scripts/tmux-autoname-session.sh`, bound with **`-ga`** so it appends to the
`session-created` hook rather than clobbering `pipe-activity.sh init` — a plain `-g` there
would have silently killed activity telemetry for every new session, with no error anywhere.

Five guards, and the first is the one that matters:

1. **`^[0-9]+$` only.** Exactly what tmux auto-assigns, and nothing a human types. Widening
   it is how this eats `scratch7`'s name — a hotkey target, a colour and a codename.
2. a cwd that says nothing (`$HOME`, `/`, unresolvable) leaves the session alone
3. reduced to a tmux-safe alphabet (tmux forbids `.` and `:`)
4. never a name the slot table owns — **both** halves of each entry, session name and
   codename, sourced from the canonical table rather than copied
5. never a name a live session holds; dedupe with `-2`, `-3`, …, giving up after ten

Exits 0 and prints nothing on every path: it runs from a hook, where a stray line lands in
your terminal. Idempotent — after the rename the name is no longer numeric, so it no-ops.

Deployed via `home.file` **beside** `scratch-slots.sh`, which it sources from its own
directory.

---

## The two live sessions are NOT renamed by this PR

Renaming them changes their address mid-flight. Run this when convenient — it is the
deployed script itself, so it applies the same guards and the same dedupe, and running it
twice is a no-op:

```sh
# after `scripts/ship.sh` (or a home-manager switch on this host)
for s in 0 8; do ~/.config/tmux/autoname-session.sh "$s"; done
tmux list-sessions -F '#{session_name}'   # confirm
```

Both sessions are in one checkout, so the second gets a `-2` suffix — that is the dedupe
working, not a bug.

**To arm the hook in the ALREADY-RUNNING server** (it otherwise binds on the next tmux
server start), append just this one hook by hand. Do **not** `source-file` the whole config:
every `-ga` line in it would append a *second* copy, and pipe-activity/activity-emit would
then fire twice per event.

```sh
tmux set-hook -ga session-created 'run-shell -b "~/.config/tmux/autoname-session.sh #{q:hook_session_name}"'
tmux show-hooks -g | grep session-created   # expect [0] pipe-activity, [1] autoname
```

---

## Verification

**Gate** — `nix build .#checks.x86_64-linux.pytests`, read from `nix log`, counts not exit
codes:

| tree | `scripts/tests` | total |
|---|---|---|
| `origin/main` @ `a8f8426` (control, measured first) | `collected=3704 passed=3704 skipped=0` | 9267 |
| this branch, merged | `collected=3775 passed=3775 skipped=0` | 9338 |

Floor re-pinned `3428 → 3725`, decomposed in `run-tests.sh` beside the line:
`3704 (control) + 27 (test_session_manager.py 391→418) + 44 (new test file) = 3775`, then
`_suggested_floor 3775 = 3775 - min(50, max(1, 188)) = 3725`. Zero new skips.

`nix build .#checks.x86_64-linux.nodetests` also green: `TOTAL suites=4 files=34 tests=1097
pass=1097 fail=0 skipped=0 (floor: 1080)` — no `.mjs` was touched, run to confirm that.

⚠ The previous floor entry implied main should have been 3478; it measured **3704**. Main
was carrying 226 tests the table had never seen — subtracting from the recorded number would
have claimed +296 for this branch and a floor ~226 too high.

**Red → green** — the label/hotkey tests run against `origin/main`'s `session-manager`:
**166 red / 252 passed**, versus **418 green** at HEAD. Honest decomposition: 140 of those
reds are `TypeError: gather() got an unexpected keyword argument 'slots'` cascading through
the shared fixture (the `codenames → slots` rename), and 26 are `AttributeError` for the new
API. So the baseline run shows the tests *cannot* pass on old code, but it is the mutation
sweep below that shows each guard fails for its **own** reason.

**Mutation — 28 mutants, 0 survivors**, each dying on the assertion that owns it.

Resolver (16): precedence inverted · empty codename wins · `$HOME` guard dropped · `~` not
expanded · `label_source` always `path` · `rstrip("/")` removed · LABEL column widened ·
`label_source` dropped from the row · table back to `codename` · `hotkey` dropped from the
row · **hotkey hardcoded as a map instead of read from the slot table** · `hotkey` as `""`
instead of `null` · `render_label` always emits parens · table drops the hotkey ·
`load_scratch_codenames` as a second parse · key/colour fields swapped.

Script (12): gate widened · gate deleted · `$HOME` guard dropped · sanitiser dropped · slot
table not sourced · codename half unreserved · session half unreserved · live sessions
ignored · dedupe cap widened · git root ignored · noisy failure · inexact `-t` target.

The `^[0-9]+$` gate has its **own in-suite mutation test**, which proves both that the
mutant renames `scratch7` (so the owning assertion catches it) and that the gate is
**reached rather than shadowed** — every later check accepts `scratch7` in that fixture, so
the unmutated `[]` is the gate's doing.

One survivor was found and fixed rather than papered over: a `if not p: return None` in
`label_from_path` survived deletion because `basename("") or None` already covered it. It
was dead, so it was removed — an unreachable guard reads as a defence and is not one — and
a trailing-slash test now pins the `rstrip` that *is* load-bearing.

One reachable case was found by probing rather than by the sweep and now has its own test:
a **missing** `scratch-slots.sh` beside the script leaves `SCRATCH_SLOTS` unset, which under
`set -u` is a crash rather than a no-op — and the `SCRATCH_SLOTS=()` mutant does not cover
it, because that array is defined. Measured: it degrades correctly (renames anyway, having
lost only the reservation, nothing on stderr).

**The existing `session-created` hook still fires — verified LIVE**, on a separate tmux
server (`-L <unique>`, `$TMUX` unset, throwaway `TMUX_TMPDIR`), driven by a config derived
from *this* `.tmux.conf`'s own two hook lines:

```
session-created[0] run-shell -b ".../recorder.sh init"       <- the pipe-activity stand-in
session-created[1] run-shell -b ".../tmux-autoname-session.sh #{q:hook_session_name}"
recorder log: FIRED init, FIRED init                          <- once per session created
sessions: [synth-live-repo]                    <- the auto-numbered session WAS renamed
after creating scratch-live-probe: [scratch-live-probe synth-live-repo]  <- left alone
```

That run is also what caught the script shipping **mode 644**: `run-shell` swallowed the
`Permission denied` and the only symptom was a session that stayed `0`. Now `100755` and
pinned by `test_the_script_is_EXECUTABLE`.

**Never touched the live tmux server.** The unit tests drive a stub `tmux` first on PATH
(with a positive control asserting `shutil.which("tmux")` resolves to the stub and that a
rename *is* observable through the recorder); the live check ran only against `-L`-isolated
servers, which were killed and their sockets removed.

## Not verified

- The deployed path (`~/.config/tmux/autoname-session.sh`) and the hook in the running
  server — both need a `home-manager switch`, which this PR does not do.
- Behaviour on the laptop: not exercised. The script is host-agnostic and reads nothing
  host-specific beyond `$HOME` and the slot table.
- `session-manager`'s `label` against real cross-host output: the suite is hermetic by
  construction, so every reading here is from fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
