### PR TITLE
fix(skills-mapping): the dotted `home.file."…".source =` form returned a clean bill of health while the wrong tree deployed

### DIFF
--- a/scripts/testlib/skills_mapping.py
+++ b/scripts/testlib/skills_mapping.py
@@ -42,6 +42,50 @@ INTO ``$out`` -- with no other repo tree copied there, and no removal of
 ``$out``. That is still structural (it says nothing about how the copy is
 spelled, and the real binding's ``ln -sT ${clickupNodeModules}/...`` passes
 untouched); it just stops treating "the characters appear somewhere" as proof.
+
+WHAT ISSUE #443 FOUND, AND HOW THE PARSER CHANGED
+--------------------------------------------------
+The first structural version was both too loose and too strict, in one file.
+
+*Too loose.* It located the mapping's attribute set with
+``home_nix.find("{", start)`` -- the next ``{`` ANYWHERE in the file. nix's
+DOTTED form has no attribute set of its own::
+
+    home.file.".claude/skills".source = ../claudedocs;
+    home.file.".config/opencode/skills" = { source = ../claude/skills; ... };
+
+so the scan walked past the real (wrong) source into an unrelated block and
+returned a clean bill of health while ``~/.claude/skills`` deployed
+``../claudedocs``. The dotted form is not hypothetical -- home.nix already uses
+it about twenty times. The mapping's source is now read from the mapping's OWN
+syntax: either ``."…".source = <expr>;`` or ``."…" = { source = <expr>; };``,
+and nothing else is guessed at.
+
+*Too strict.* Copy-detection saw only ``${…}`` interpolations sitting within
+200 characters of a ``$out`` reference, and any ``rm`` naming ``$out`` counted
+as emptying the output. Five legitimate shapes were therefore rejected with a
+confident, wrong "the deploy is broken" -- which is how a guard gets deleted
+rather than fixed. Now:
+
+  * the root-producing derivation attributes (``src``/``srcs``/``paths``) count
+    as writing the output, so ``mkDerivation { src = ../claude/skills; }`` and
+    ``symlinkJoin { paths = [ ../claude/skills … ]; }`` are understood;
+  * one further hop of let-indirection is followed, so ``skillsSrc =
+    ../claude/skills;`` used as ``${skillsSrc}`` is understood;
+  * proximity is gone. The build script is split into STATEMENTS, and a repo
+    path counts as written to the output only in a statement that also names
+    ``$out``. That also makes the destination legible: writing ``$out`` itself
+    replaces the tree, writing ``$out/sub`` adds to it. So ``rm -rf
+    "$out/clickup/node_modules"`` and ``cp ${../claude/PRINCIPLES.md}
+    "$out/PRINCIPLES.md"`` are additions, while ``rm -rf "$out"`` and ``cp -R
+    ${../claudedocs} "$out"`` still fail.
+
+The property being defended is unchanged and deliberately NOT softened: the
+deployed tree must be built from ``../claude/skills``, and no other repo tree
+may be written over the output root. Where the parser cannot decide -- an
+unrecognised source expression, or an unresolvable identifier written over the
+output root -- it FAILS, saying it needs updating and must not be deleted.
+Silence is the one answer it must never give.
 """
 from __future__ import annotations
 
@@ -52,50 +96,47 @@ MAPPING = 'home.file.".claude/skills"'
 #: The repo path the mapping must ultimately deploy.
 SKILLS_PATH = "../claude/skills"
 
-#: The direct form: `source = ../claude/skills;` inside the mapping.
-_DIRECT = re.compile(r"source\s*=\s*\.\./claude/skills\s*;")
+#: The tail of the message every undecidable case carries. A wrong-but-confident
+#: verdict gets a guard deleted; this one asks for the parser instead.
+_NEEDS_UPDATING = "this parser needs updating, do NOT delete the check."
 
-#: The indirect form: `source = <ident>;` where <ident> is a let-binding whose
-#: definition mentions `../claude/skills`.
-_INDIRECT_SOURCE = re.compile(r"source\s*=\s*([A-Za-z_][A-Za-z0-9_'-]*)\s*;")
+#: A nix path literal: `../claude/skills`, `./pkgs/foo.nix`.
+_PATH_LITERAL = re.compile(r"\.{1,2}/[^\s;,\]\)\}\"']+")
 
+#: An expression that is EXACTLY a path literal.
+_ONLY_PATH = re.compile(r"^\.{1,2}/[^\s;,\]\)\}\"']+$")
 
-def _mapping_block(home_nix: str) -> str:
-    """The `home.file.".claude/skills" = { … };` block, or "" if absent."""
-    start = home_nix.find(MAPPING)
-    if start == -1:
-        return ""
-    open_brace = home_nix.find("{", start)
-    if open_brace == -1:
-        return ""
-    depth = 0
-    for i in range(open_brace, len(home_nix)):
-        if home_nix[i] == "{":
-            depth += 1
-        elif home_nix[i] == "}":
-            depth -= 1
-            if depth == 0:
-                return home_nix[open_brace : i + 1]
-    return ""
-
+#: An expression that is exactly a nix identifier.
+_ONLY_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_'-]*$")
 
 #: A `let`-binding head: `  name =` at some indentation.
 _BINDING_HEAD = re.compile(r"^(\s*)([A-Za-z_][A-Za-z0-9_'-]*)\s*=")
 
-#: A nix path interpolation into a build script: `${../claude/skills}`.
-_PATH_INTERP = re.compile(r"\$\{\s*(\.{1,2}/[^}\s]+?)\s*\}")
+#: A binding whose whole value is a path literal: `skillsSrc = ../claude/skills;`.
+_BARE_PATH_BINDING = re.compile(
+    r"^\s*[A-Za-z_][A-Za-z0-9_'-]*\s*=\s*(\.{1,2}/[^\s;]+)\s*;\s*$"
+)
 
-#: Anything that writes the output tree: `"$out"`, `$out/x`, `${out}`.
-_OUT_REF = re.compile(r"\$\{?out\b")
+#: A nix interpolation, `${…}`. The braces bound the expression: in
+#: `${clickupNodeModules}/node_modules` only the identifier is interpolated.
+_INTERP = re.compile(r"\$\{\s*([^{}]*?)\s*\}")
 
-#: `rm`/`rmdir` aimed at $out. A binding that empties its own output and then
-#: fills it from somewhere else contains every string this predicate looks for.
-_RM_OUT = re.compile(r"\brm(?:dir)?\b[^\n;]*\$\{?out\b")
+#: Derivation attributes whose value BECOMES the output tree. `src`/`srcs` for a
+#: stdenv build, `paths` for symlinkJoin/buildEnv. A path in `buildInputs` is an
+#: input, not the output, which is why this is an enumeration and not "any path".
+_ROOT_ATTR = re.compile(r"(?<![\w.'-])(src|srcs|paths)\s*=\s*")
 
-#: How far from a path interpolation a `$out` reference still counts as "this
-#: path is being copied into the output". Wide enough for a `\`-continued
-#: command, narrow enough that two unrelated statements are not conflated.
-_NEAR = 200
+#: A `$out` reference, with whatever path follows it. Group 1 empty/absent means
+#: the reference is to the output ROOT (`"$out"`, `$out/.`); a non-trivial group
+#: 1 means a path UNDER the output (`"$out/clickup/node_modules"`).
+_OUT_REF = re.compile(r"\$\{?out\}?(/[^\s\"';|&)]*)?")
+
+#: Shell statement separators. Line continuations are folded first, so a
+#: `\`-continued `cp` is one statement.
+_STATEMENT_SPLIT = re.compile(r"[\n;|&]")
+
+#: `rm`/`rmdir`, in a statement that may or may not aim at the output ROOT.
+_RM = re.compile(r"\brm(?:dir)?\b")
 
 
 def _strip_comments(text: str) -> str:
@@ -106,20 +147,102 @@ def _strip_comments(text: str) -> str:
     `${../claude/skills}` inside a `''…''` string even on a line the shell will
     treat as a comment, so "the path appears" and "the path is used" are
     different questions there too.
+
+    Applied to the WHOLE file before anything is located, so a commented-out
+    mapping cannot be mistaken for a live one. Line structure is preserved (a
+    `#` comment is replaced to end-of-line only), which `_binding_body`'s
+    indentation scan depends on.
     """
     text = re.sub(r"/\*.*?\*/", " ", text, flags=re.S)
     return re.sub(r"#[^\n]*", "", text)
 
 
-def _trees_copied_into_out(body: str) -> set[str]:
-    """Repo paths interpolated near a `$out` reference — i.e. copied in."""
-    out: set[str] = set()
-    for m in _PATH_INTERP.finditer(body):
-        lo = max(0, m.start() - _NEAR)
-        hi = min(len(body), m.end() + _NEAR)
-        if _OUT_REF.search(body[lo:hi]):
-            out.add(m.group(1))
-    return out
+def _brace_block(text: str, open_brace: int) -> str:
+    """The `{ … }` starting at `open_brace`, or "" if it never closes."""
+    depth = 0
+    for i in range(open_brace, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[open_brace : i + 1]
+    return ""
+
+
+def _expr_until_semicolon(text: str, start: int) -> str:
+    """The expression from `start` to the next `;`, or "" if there is none."""
+    end = text.find(";", start)
+    if end == -1:
+        return ""
+    return text[start:end].strip()
+
+
+def _source_expr(text: str) -> tuple[str | None, str | None]:
+    """The expression the ~/.claude/skills mapping's `source` is bound to.
+
+    Returns `(expr, None)` or `(None, problem)`. Read from the mapping's OWN
+    syntax -- both spellings nix allows for one `home.file` entry::
+
+        home.file.".claude/skills".source = <expr>;      # dotted
+        home.file.".claude/skills" = { source = <expr>; };  # attribute set
+
+    and NOTHING else. The predecessor took "the next `{` anywhere in the file",
+    which for the dotted form walked into an unrelated block and read a source
+    that was not the mapping's (issue #443).
+
+    `text` must already be comment-stripped.
+    """
+    problem: str | None = None
+    seen = False
+    for m in re.finditer(re.escape(MAPPING), text):
+        seen = True
+        rest = text[m.end() :]
+        dotted = re.match(r"\s*\.\s*source\s*=\s*", rest)
+        if dotted:
+            expr = _expr_until_semicolon(rest, dotted.end())
+            if expr:
+                return expr, None
+            problem = problem or (
+                f"the {MAPPING} mapping's dotted `.source =` has no terminating "
+                f"`;` -- {_NEEDS_UPDATING}"
+            )
+            continue
+        attrset = re.match(r"\s*=\s*\{", rest)
+        if attrset:
+            block = _brace_block(rest, attrset.end() - 1)
+            if not block:
+                problem = problem or (
+                    f"found {MAPPING} but its attribute set never closes -- "
+                    f"{_NEEDS_UPDATING}"
+                )
+                continue
+            src = re.search(r"(?<![\w.'-])source\s*=\s*", block)
+            if not src:
+                problem = problem or (
+                    f"the {MAPPING} mapping declares no `source =` at all:\n{block}"
+                )
+                continue
+            expr = _expr_until_semicolon(block, src.end())
+            if expr:
+                return expr, None
+            problem = problem or (
+                f"the {MAPPING} mapping's `source =` has no terminating `;` -- "
+                f"{_NEEDS_UPDATING}\n{block}"
+            )
+            continue
+        # Neither spelling: `= mkIf …`, `.text =`, `.recursive = true;` on its
+        # own. Keep looking -- another occurrence may carry the source.
+        problem = problem or (
+            f"found {MAPPING} but it is neither `.source = <expr>;` nor "
+            f"`= {{ source = <expr>; … }}` -- {_NEEDS_UPDATING}"
+        )
+    if not seen:
+        return None, (
+            "nix/home.nix no longer declares the ~/.claude/skills mapping, so a "
+            "doc pinned under claude/skills/ may not ship at all."
+        )
+    return None, problem
 
 
 def _binding_body(home_nix: str, ident: str) -> str:
@@ -152,48 +275,179 @@ def _binding_body(home_nix: str, ident: str) -> str:
     return "\n".join(body)
 
 
+def _resolve_path_ident(text: str, ident: str) -> str | None:
+    """`ident`'s value when it is a bare path literal, else None.
+
+    ONE hop, deliberately: `skillsSrc = ../claude/skills;` used as
+    `${skillsSrc}` is the indirection real nix code uses. An identifier bound to
+    a derivation (`clickupNodeModules = pkgs.callPackage …`) is not a repo tree
+    and must not be reported as one.
+    """
+    body = _binding_body(text, ident)
+    if not body:
+        return None
+    m = _BARE_PATH_BINDING.match(body.strip())
+    return m.group(1) if m else None
+
+
+def _normalise(path: str) -> str:
+    """`../claudedocs/.` and `../claudedocs/` both name `../claudedocs`."""
+    path = path.rstrip("/")
+    if path.endswith("/."):
+        path = path[:-2]
+    return path.rstrip("/")
+
+
+def _statements(body: str) -> list[str]:
+    """The build script's statements, with `\\`-continuations folded in.
+
+    Replaces the predecessor's 200-character proximity window, which conflated
+    neighbouring lines: a `cp ${../claude/PRINCIPLES.md} "$out/PRINCIPLES.md"`
+    two lines below a `cp -R ${../claude/skills} "$out"` looked like a second
+    tree written over the output root.
+    """
+    folded = re.sub(r"\\\n\s*", " ", body)
+    return [s for s in _STATEMENT_SPLIT.split(folded) if s.strip()]
+
+
+def _writes_output_root(statement: str) -> bool:
+    """True when the statement writes `$out` ITSELF, not a path under it.
+
+    `"$out"`, `$out/` and `"$out/."` all name the output tree; `"$out/clickup/
+    node_modules"` names one entry inside it. That distinction IS #443's `rm -rf
+    "$out/clickup/node_modules"` false positive, and it is what makes a file
+    copied to a name under $out an addition rather than a second tree.
+    """
+    for m in _OUT_REF.finditer(statement):
+        tail = (m.group(1) or "").rstrip("\"'")
+        if tail in ("", "/", "/."):
+            return True
+    return False
+
+
+def _paths_in(statement: str, text: str) -> tuple[set[str], set[str]]:
+    """`(repo paths, unresolvable identifiers)` interpolated in `statement`."""
+    paths: set[str] = set()
+    idents: set[str] = set()
+    for m in _INTERP.finditer(statement):
+        expr = m.group(1).strip()
+        if _ONLY_PATH.match(expr):
+            paths.add(_normalise(expr))
+        elif _ONLY_IDENT.match(expr):
+            resolved = _resolve_path_ident(text, expr)
+            if resolved is not None:
+                paths.add(_normalise(resolved))
+            else:
+                idents.add(expr)
+    return paths, idents
+
+
+#: An identifier in a derivation-attribute value. `/` is in the lookbehind so
+#: the components of a path literal (`../claude/skills` -> `claude`, `skills`)
+#: are not read as identifiers to resolve.
+_ATTR_WORD = re.compile(r"(?<![\w.'/-])[A-Za-z_][A-Za-z0-9_'-]*")
+
+
+def _root_attr_paths(body: str, text: str) -> set[str]:
+    """Repo paths bound to `src`/`srcs`/`paths` -- which BECOME the output.
+
+    `mkDerivation { src = ../claude/skills; }` and `symlinkJoin { paths = [
+    ../claude/skills … ]; }` write the output root without ever naming `$out`,
+    which is why the predecessor called both "never copies ../claude/skills into
+    $out". A path in `buildInputs` is an INPUT, not the output, which is why
+    this is an enumeration of attributes and not "any path in the binding".
+    """
+    paths: set[str] = set()
+    for m in _ROOT_ATTR.finditer(body):
+        value = _expr_until_semicolon(body, m.end())
+        if not value:
+            continue
+        for lit in _PATH_LITERAL.findall(value):
+            paths.add(_normalise(lit))
+        for word in _ATTR_WORD.findall(value):
+            resolved = _resolve_path_ident(text, word)
+            if resolved is not None:
+                paths.add(_normalise(resolved))
+    return paths
+
+
+def _analyse_binding(body: str, text: str) -> tuple[set[str], set[str], str]:
+    """What `body` writes over its output ROOT: repo paths, opaque identifiers,
+    and the first statement that REMOVES the root, if any.
+
+    Only root writes are collected. A statement that writes a path UNDER $out
+    adds to the tree and cannot replace it, so it is not a hazard and not
+    tracked -- see `_writes_output_root`.
+    """
+    roots = _root_attr_paths(body, text)
+    root_idents: set[str] = set()
+    removes_root = ""
+    for statement in _statements(body):
+        if not _writes_output_root(statement):
+            continue
+        if _RM.search(statement) and not removes_root:
+            removes_root = statement.strip()
+        paths, idents = _paths_in(statement, text)
+        roots |= paths
+        root_idents |= idents
+    return roots, root_idents, removes_root
+
+
 def skills_mapping_problem(home_nix: str) -> str | None:
     """Return a failure reason, or None when the mapping deploys claude/skills.
 
-    Structural on purpose: it reads the mapping's `source` and follows one level
-    of let-binding indirection, rather than matching how the line is spelled.
+    Structural on purpose: it reads the mapping's own `source` -- in either of
+    the two spellings nix allows -- and follows let-binding indirection, rather
+    than matching how the line is spelled.
     """
-    if MAPPING not in home_nix:
+    text = _strip_comments(home_nix)
+    expr, problem = _source_expr(text)
+    if expr is None:
+        return problem
+
+    if _ONLY_PATH.match(expr):
+        if _normalise(expr) == SKILLS_PATH:
+            return None
         return (
-            "nix/home.nix no longer declares the ~/.claude/skills mapping, so a "
-            "doc pinned under claude/skills/ may not ship at all."
+            f"the ~/.claude/skills mapping sources `{expr}`, not {SKILLS_PATH} -- "
+            "the pinned docs under claude/skills/ are not the deployed files."
         )
-    block = _strip_comments(_mapping_block(home_nix))
-    if not block:
+
+    if not _ONLY_IDENT.match(expr):
         return (
-            f"found {MAPPING} but could not read its attribute set -- this parser "
-            "needs updating, do NOT delete the check."
+            f"the ~/.claude/skills mapping's source is `{expr}`, which this check "
+            f"cannot resolve to a repo tree -- {_NEEDS_UPDATING}"
         )
-    if _DIRECT.search(block):
-        return None
-    m = _INDIRECT_SOURCE.search(block)
-    if not m:
+
+    ident = expr
+    direct = _resolve_path_ident(text, ident)
+    if direct is not None:
+        if _normalise(direct) == SKILLS_PATH:
+            return None
         return (
-            f"the {MAPPING} mapping declares no `source =` at all:\n{block}"
+            f"the ~/.claude/skills mapping sources `{ident}`, which is bound to "
+            f"`{direct}`, not {SKILLS_PATH} -- the pinned docs are not the "
+            "deployed files."
         )
-    ident = m.group(1)
-    body = _strip_comments(_binding_body(home_nix, ident))
+
+    body = _binding_body(text, ident)
     if not body:
         return (
             f"the ~/.claude/skills mapping sources `{ident}`, but there is no such "
             "let-binding in nix/home.nix -- nothing resolves the deployed tree."
         )
-    # Not "the characters appear somewhere in the binding" -- the path has to be
-    # COPIED INTO the output. Comments and dead code are already gone above.
-    copied = _trees_copied_into_out(body)
-    if SKILLS_PATH not in copied:
+
+    # Not "the characters appear somewhere in the binding" -- the path has to
+    # BECOME the output. Comments and dead code are already gone above.
+    roots, opaque, removes_root = _analyse_binding(body, text)
+    if SKILLS_PATH not in roots:
         return (
             f"the ~/.claude/skills mapping sources `{ident}`, but that binding never "
             f"copies {SKILLS_PATH} into $out (it writes: "
-            f"{sorted(copied) or 'no repo tree at all'}) -- the pinned docs are not "
+            f"{sorted(roots) or 'no repo tree at all'}) -- the pinned docs are not "
             "the deployed files."
         )
-    others = sorted(copied - {SKILLS_PATH})
+    others = sorted(roots - {SKILLS_PATH})
     if others:
         return (
             f"the `{ident}` binding copies {others} into $out as well as "
@@ -201,10 +455,15 @@ def skills_mapping_problem(home_nix: str) -> str | None:
             "actually ships, and the pins under claude/skills/ stop being claims "
             "about the deployed files."
         )
-    rm = _RM_OUT.search(body)
-    if rm:
+    if opaque:
         return (
-            f"the `{ident}` binding removes its own output (`{rm.group(0).strip()}`). "
+            f"the `{ident}` binding writes {sorted(opaque)} over the output ROOT, and "
+            f"this check cannot tell what those resolve to -- whichever write runs "
+            f"last decides what ships. {_NEEDS_UPDATING}"
+        )
+    if removes_root:
+        return (
+            f"the `{ident}` binding removes its own output (`{removes_root}`). "
             f"A binding that copies {SKILLS_PATH} and then empties $out contains every "
             "string this check looks for and deploys none of it."
         )

--- a/scripts/testlib/skills_mapping.py
+++ b/scripts/testlib/skills_mapping.py
@@ -82,16 +82,60 @@ rather than fixed. Now:
 
 The property being defended is unchanged and deliberately NOT softened: the
 deployed tree must be built from ``../claude/skills``, and no other repo tree
-may be written over the output root. Where the parser cannot decide -- an
-unrecognised source expression, or an unresolvable identifier written over the
-output root -- it FAILS, saying it needs updating and must not be deleted.
-Silence is the one answer it must never give.
+may be written over the output root. Where the parser cannot decide it FAILS,
+saying it needs updating and must not be deleted, rather than returning None --
+because None is the answer that silently stops checking anything.
+
+WHAT AN ADVERSARIAL AUDIT OF THAT FIX THEN FOUND
+------------------------------------------------
+Eight constructible shapes still returned a clean bill of health, two of them
+using idioms already in this file. Each is now a loud failure, and each has a
+fixture:
+
+  * ``#`` is only a comment at line start or after WHITESPACE. Blanking every
+    ``#`` to end-of-line ate the ``}`` out of ``"''${bbOld##*.}"`` -- which is
+    `nix/home.nix:548`, today -- unbalancing the braces the attrset scan counts
+    and letting it run into the NEXT mapping's ``source``. Comments are blanked
+    in place now (offsets preserved), never deleted.
+  * The mapping literal occurring MORE THAN ONCE (in a ``''…''`` script, in
+    prose) took the first match and never noticed the disagreement.
+  * ``cd "$out"`` then ``cp -R ${../claudedocs}/. .``, a ``tar | tar`` pipe, and
+    ``dst="$out"`` all write the root in a statement that does not name ``$out``.
+    Statement-scoping cannot see those, so every repo path in the binding must
+    now be ACCOUNTED FOR -- as a root write or as a write under the root -- and
+    one that is neither is undecidable, not ignorable.
+  * ``{ … } // lib.optionalAttrs cond { source = <other>; }``: the override was
+    invisible because only the first attribute set was read.
+  * A ``let`` binding whose name is declared more than once (shadowing).
+  * ``${pkgs.other}`` over the root fell through both the path branch and the
+    identifier branch and was dropped in silence.
+
+And the headline false positive of #443 was still alive one character to the
+left: ``rm -rf "$out"/clickup/node_modules`` (quote before the slash, not after)
+read as a removal of the root.
+
+KNOWN LIMITS -- read before trusting a PASS
+-------------------------------------------
+  * ``src``/``srcs``/``paths`` are matched by NAME, not by POSITION, so a
+    ``src`` sitting in a ``runCommandLocal`` ENV attribute set is credited as
+    the output tree even though it is only an environment variable there.
+  * A repo path this cannot classify is reported as undecidable rather than
+    ignored, which makes some legitimate-but-unusual builds (a ``tar`` pipe out
+    of the right tree) fail asking for the parser. That direction is deliberate:
+    the alternative is `cd "$out"` aliasing passing in silence.
+  * It reads text, not nix. `nix eval` is the only thing that actually knows
+    what a `home.file` source resolves to.
 """
 from __future__ import annotations
 
 import re
+from typing import NamedTuple
 
 MAPPING = 'home.file.".claude/skills"'
+
+#: The attribute on its own, for telling "the entry is gone" apart from "the
+#: entry is spelled some way this cannot read" (`home.file = { … }`, `mkMerge`).
+ATTR_NAME = '".claude/skills"'
 
 #: The repo path the mapping must ultimately deploy.
 SKILLS_PATH = "../claude/skills"
@@ -102,6 +146,11 @@ _NEEDS_UPDATING = "this parser needs updating, do NOT delete the check."
 
 #: A nix path literal: `../claude/skills`, `./pkgs/foo.nix`.
 _PATH_LITERAL = re.compile(r"\.{1,2}/[^\s;,\]\)\}\"']+")
+
+#: A path OUT of the nix/ directory -- i.e. some other tree in this repo. `./x`
+#: is excluded: inside a build script `./.` is the builder's cwd, not a repo
+#: tree, and crediting it as one would reject every `installPhase`.
+_REPO_PATH = re.compile(r"\.\./[^\s;,\]\)\}\"']+")
 
 #: An expression that is EXACTLY a path literal.
 _ONLY_PATH = re.compile(r"^\.{1,2}/[^\s;,\]\)\}\"']+$")
@@ -129,32 +178,60 @@ _ROOT_ATTR = re.compile(r"(?<![\w.'-])(src|srcs|paths)\s*=\s*")
 #: A `$out` reference, with whatever path follows it. Group 1 empty/absent means
 #: the reference is to the output ROOT (`"$out"`, `$out/.`); a non-trivial group
 #: 1 means a path UNDER the output (`"$out/clickup/node_modules"`).
-_OUT_REF = re.compile(r"\$\{?out\}?(/[^\s\"';|&)]*)?")
+#:
+#: 🔴 The optional quote before group 1 is load-bearing: `"$out"/clickup/x` and
+#: `"$out/clickup/x"` are the same destination, and without it the first read as
+#: the ROOT -- resurrecting #443's headline false positive one character to the
+#: left of where it was fixed.
+_OUT_REF = re.compile(r"\$\{?out\}?[\"']?(/[^\s\"';|&)]*)?")
 
-#: Shell statement separators. Line continuations are folded first, so a
-#: `\`-continued `cp` is one statement.
-_STATEMENT_SPLIT = re.compile(r"[\n;|&]")
+#: Shell statement separators: newline and `;` only. `|`, `&&` and `||` are
+#: deliberately NOT separators -- `tar -C ${…} -cf - . | tar -C "$out" -xf -` is
+#: ONE write, and splitting it put the source and the destination in different
+#: statements where nothing could relate them.
+_STATEMENT_SPLIT = re.compile(r"[\n;]")
 
 #: `rm`/`rmdir`, in a statement that may or may not aim at the output ROOT.
 _RM = re.compile(r"\brm(?:dir)?\b")
 
 
-def _strip_comments(text: str) -> str:
-    """Remove nix `#` line comments and `/* … */` blocks.
+#: A comment `#` -- at the start of the text or after WHITESPACE, and nowhere
+#: else. 🔴 The lookbehind is the whole point. `#` mid-token is not a comment in
+#: any of the languages in this file, and blanking from one to end-of-line ate
+#: the closing brace out of `bbPid="''${bbOld##*.}"` -- `nix/home.nix:548`,
+#: present today -- which unbalanced the braces the attrset scan counts and let
+#: it run past the mapping into the NEXT one's `source`. It also ate the rest of
+#: `echo "theme=#282828"`, taking any statement that followed on that line.
+_COMMENT = re.compile(r"(?<![^\s])#[^\n]*")
 
-    Both a nix comment and a SHELL comment inside a `''…''` build script are
-    handled by the same rule, which is what we want: nix interpolates
-    `${../claude/skills}` inside a `''…''` string even on a line the shell will
-    treat as a comment, so "the path appears" and "the path is used" are
-    different questions there too.
+#: `/* … */`, which nix allows anywhere.
+_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.S)
+
+
+def _blank(m: re.Match[str]) -> str:
+    """The match, with every character but `\\n` replaced by a space.
+
+    Comments are BLANKED, not deleted: every offset and every line number in the
+    text stays exactly where it was, so a scan can be run on the stripped text
+    and its results quoted against the original.
+    """
+    return re.sub(r"[^\n]", " ", m.group(0))
+
+
+def _strip_comments(text: str) -> str:
+    """Blank nix `#` line comments and `/* … */` blocks, in place.
+
+    A SHELL comment inside a `''…''` build script is blanked by the same rule,
+    which is what we want: nix interpolates `${../claude/skills}` inside a
+    `''…''` string even on a line the shell will treat as a comment, so "the
+    path appears" and "the path is used" are different questions there too.
 
     Applied to the WHOLE file before anything is located, so a commented-out
-    mapping cannot be mistaken for a live one. Line structure is preserved (a
-    `#` comment is replaced to end-of-line only), which `_binding_body`'s
-    indentation scan depends on.
+    mapping cannot be mistaken for a live one -- and, because it blanks rather
+    than deletes, without moving anything the brace and indentation scans read.
     """
-    text = re.sub(r"/\*.*?\*/", " ", text, flags=re.S)
-    return re.sub(r"#[^\n]*", "", text)
+    text = _BLOCK_COMMENT.sub(_blank, text)
+    return _COMMENT.sub(_blank, text)
 
 
 def _brace_block(text: str, open_brace: int) -> str:
@@ -193,16 +270,29 @@ def _source_expr(text: str) -> tuple[str | None, str | None]:
 
     `text` must already be comment-stripped.
     """
+    hits = list(re.finditer(re.escape(MAPPING), text))
+    if not hits:
+        if ATTR_NAME in text:
+            return None, (
+                f"{ATTR_NAME} appears in nix/home.nix but not as `{MAPPING}` -- it "
+                f"may be declared through `home.file = {{ … }}`, `mkMerge` or a "
+                f"loop, which this cannot read. {_NEEDS_UPDATING}"
+            )
+        return None, (
+            "nix/home.nix no longer declares the ~/.claude/skills mapping, so a "
+            "doc pinned under claude/skills/ may not ship at all."
+        )
     problem: str | None = None
-    seen = False
-    for m in re.finditer(re.escape(MAPPING), text):
-        seen = True
+    found: list[tuple[str, int]] = []
+    for m in hits:
         rest = text[m.end() :]
+        line_no = text[: m.start()].count("\n") + 1
         dotted = re.match(r"\s*\.\s*source\s*=\s*", rest)
         if dotted:
             expr = _expr_until_semicolon(rest, dotted.end())
             if expr:
-                return expr, None
+                found.append((expr, line_no))
+                continue
             problem = problem or (
                 f"the {MAPPING} mapping's dotted `.source =` has no terminating "
                 f"`;` -- {_NEEDS_UPDATING}"
@@ -217,6 +307,15 @@ def _source_expr(text: str) -> tuple[str | None, str | None]:
                     f"{_NEEDS_UPDATING}"
                 )
                 continue
+            after = rest[attrset.end() - 1 + len(block) :]
+            if re.match(r"\s*//", after):
+                # `{ source = A; } // lib.optionalAttrs cond { source = B; }`:
+                # nix's effective source is B, and only A is in `block`.
+                return None, (
+                    f"the {MAPPING} mapping's attribute set is merged with `//`, so "
+                    f"its effective `source` is not the one written here. "
+                    f"{_NEEDS_UPDATING}"
+                )
             src = re.search(r"(?<![\w.'-])source\s*=\s*", block)
             if not src:
                 problem = problem or (
@@ -225,7 +324,8 @@ def _source_expr(text: str) -> tuple[str | None, str | None]:
                 continue
             expr = _expr_until_semicolon(block, src.end())
             if expr:
-                return expr, None
+                found.append((expr, line_no))
+                continue
             problem = problem or (
                 f"the {MAPPING} mapping's `source =` has no terminating `;` -- "
                 f"{_NEEDS_UPDATING}\n{block}"
@@ -237,11 +337,26 @@ def _source_expr(text: str) -> tuple[str | None, str | None]:
             f"found {MAPPING} but it is neither `.source = <expr>;` nor "
             f"`= {{ source = <expr>; … }}` -- {_NEEDS_UPDATING}"
         )
-    if not seen:
+
+    # 🔴 Reading the FIRST occurrence is how a mapping quoted inside a `''…''`
+    # script or an activation-script heredoc answered for the real declaration.
+    # Several `.source` spellings are only safe when they AGREE; disagreement is
+    # a question about which one nix takes, which this cannot answer.
+    #
+    # Several occurrences that do NOT each carry a source are fine and normal --
+    # `home.file."…".source = X;` beside `home.file."…".recursive = true;` is one
+    # entry written as two dotted attributes.
+    distinct = {expr for expr, _ in found}
+    if len(distinct) > 1:
+        where = ", ".join(f"line {n}: `{e}`" for e, n in found)
         return None, (
-            "nix/home.nix no longer declares the ~/.claude/skills mapping, so a "
-            "doc pinned under claude/skills/ may not ship at all."
+            f"`{MAPPING}` is given {len(distinct)} DIFFERENT sources in "
+            f"nix/home.nix ({where}); which one nix takes is not something this can "
+            f"read, and taking the first is how a copy inside a string answers for "
+            f"the real one. {_NEEDS_UPDATING}"
         )
+    if found:
+        return found[0][0], None
     return None, problem
 
 
@@ -252,18 +367,19 @@ def _binding_body(home_nix: str, ident: str) -> str:
     same-or-shallower indentation, or to `in` -- rather than by hunting for a
     terminating `;`, which a multi-line nix string (`''…''`) makes unreliable.
     Returns "" when there is no such binding.
+
+    This is a TEXT scan and knows nothing about nix scope, so a name declared
+    more than once (a nested attribute set using it as a key, a shadowing
+    binding) is not resolvable here -- see `_binding_head_count`, which makes
+    that case fail loudly rather than silently taking the first one.
     """
     lines = home_nix.splitlines()
-    start = None
-    indent = ""
-    for i, line in enumerate(lines):
-        m = _BINDING_HEAD.match(line)
-        if m and m.group(2) == ident:
-            start = i
-            indent = m.group(1)
-            break
-    if start is None:
+    heads = [i for i, line in enumerate(lines)
+             if (m := _BINDING_HEAD.match(line)) and m.group(2) == ident]
+    if not heads:
         return ""
+    start = heads[0]
+    indent = _BINDING_HEAD.match(lines[start]).group(1)  # type: ignore[union-attr]
     body = [lines[start]]
     for line in lines[start + 1 :]:
         if re.match(r"^in\b", line):
@@ -275,6 +391,15 @@ def _binding_body(home_nix: str, ident: str) -> str:
     return "\n".join(body)
 
 
+def _binding_head_count(home_nix: str, ident: str) -> int:
+    """How many `<ident> =` heads exist. More than one means this cannot say
+    which one a reference resolves to -- nix scope is not a text property."""
+    return sum(
+        1 for line in home_nix.splitlines()
+        if (m := _BINDING_HEAD.match(line)) and m.group(2) == ident
+    )
+
+
 def _resolve_path_ident(text: str, ident: str) -> str | None:
     """`ident`'s value when it is a bare path literal, else None.
 
@@ -282,7 +407,14 @@ def _resolve_path_ident(text: str, ident: str) -> str | None:
     `${skillsSrc}` is the indirection real nix code uses. An identifier bound to
     a derivation (`clickupNodeModules = pkgs.callPackage …`) is not a repo tree
     and must not be reported as one.
+
+    A name declared MORE THAN ONCE resolves to nothing here, in ONE place rather
+    than at each call site: which declaration a reference sees is a question
+    about nix scope, and this is a text scan. Callers get None and report it in
+    their own terms.
     """
+    if _binding_head_count(text, ident) != 1:
+        return None
     body = _binding_body(text, ident)
     if not body:
         return None
@@ -310,36 +442,49 @@ def _statements(body: str) -> list[str]:
     return [s for s in _STATEMENT_SPLIT.split(folded) if s.strip()]
 
 
-def _writes_output_root(statement: str) -> bool:
-    """True when the statement writes `$out` ITSELF, not a path under it.
+def _out_scope(statement: str) -> str | None:
+    """`"root"`, `"under"`, or None -- what part of the output this writes.
 
     `"$out"`, `$out/` and `"$out/."` all name the output tree; `"$out/clickup/
     node_modules"` names one entry inside it. That distinction IS #443's `rm -rf
     "$out/clickup/node_modules"` false positive, and it is what makes a file
-    copied to a name under $out an addition rather than a second tree.
+    copied to a name under $out an addition rather than a second tree. A root
+    reference wins: a statement naming both replaces the tree.
     """
+    scope: str | None = None
     for m in _OUT_REF.finditer(statement):
         tail = (m.group(1) or "").rstrip("\"'")
         if tail in ("", "/", "/."):
-            return True
-    return False
+            return "root"
+        scope = "under"
+    return scope
 
 
 def _paths_in(statement: str, text: str) -> tuple[set[str], set[str]]:
-    """`(repo paths, unresolvable identifiers)` interpolated in `statement`."""
+    """`(repo paths, expressions this cannot resolve)` interpolated here.
+
+    Every `${…}` lands in one bucket or the other. An earlier version had a
+    third, silent outcome -- an expression matching neither the path shape nor
+    the identifier shape (`${pkgs.otherTree}`, `${inputs.x}`) fell off the end
+    of the `elif` and was dropped -- so a whole derivation copied over the
+    output root was invisible.
+    """
     paths: set[str] = set()
-    idents: set[str] = set()
+    opaque: set[str] = set()
     for m in _INTERP.finditer(statement):
         expr = m.group(1).strip()
+        if expr == "out":
+            continue  # the output itself, not something being copied into it
         if _ONLY_PATH.match(expr):
             paths.add(_normalise(expr))
-        elif _ONLY_IDENT.match(expr):
+            continue
+        if _ONLY_IDENT.match(expr):
             resolved = _resolve_path_ident(text, expr)
             if resolved is not None:
                 paths.add(_normalise(resolved))
-            else:
-                idents.add(expr)
-    return paths, idents
+                continue
+        opaque.add(expr)
+    return paths, opaque
 
 
 #: An identifier in a derivation-attribute value. `/` is in the lookbehind so
@@ -371,26 +516,55 @@ def _root_attr_paths(body: str, text: str) -> set[str]:
     return paths
 
 
-def _analyse_binding(body: str, text: str) -> tuple[set[str], set[str], str]:
-    """What `body` writes over its output ROOT: repo paths, opaque identifiers,
-    and the first statement that REMOVES the root, if any.
+class _Writes(NamedTuple):
+    """What a binding does to its output."""
 
-    Only root writes are collected. A statement that writes a path UNDER $out
-    adds to the tree and cannot replace it, so it is not a hazard and not
-    tracked -- see `_writes_output_root`.
+    #: Repo paths written over the output ROOT -- these decide what ships.
+    roots: set[str]
+    #: Expressions written over the root that cannot be resolved to a tree.
+    opaque: set[str]
+    #: The first statement that removes the root, verbatim, or "".
+    removes_root: str
+    #: Repo paths in the binding that are neither of the above -- not written
+    #: to the output as far as this can tell, which is not the same as harmless.
+    unaccounted: set[str]
+
+
+def _analyse_binding(body: str, text: str) -> _Writes:
+    """What `body` writes into its output.
+
+    🔴 Every repo path in the binding must come out CLASSIFIED -- as a root
+    write or as a write under the root. A path that is neither is reported, not
+    dropped, because statement-scoping cannot see a write whose statement does
+    not name `$out`:
+
+        cp -R ${../claude/skills} "$out"
+        cd "$out"
+        cp -R ${../claudedocs}/. .
+
+    Nothing here relates that third line to the output; `../claudedocs` simply
+    goes unaccounted for. Ignoring it made the above a clean PASS while the
+    deployed tree was ../claudedocs.
     """
     roots = _root_attr_paths(body, text)
-    root_idents: set[str] = set()
+    opaque: set[str] = set()
+    additions: set[str] = set()
     removes_root = ""
     for statement in _statements(body):
-        if not _writes_output_root(statement):
+        scope = _out_scope(statement)
+        if scope is None:
             continue
-        if _RM.search(statement) and not removes_root:
-            removes_root = statement.strip()
-        paths, idents = _paths_in(statement, text)
-        roots |= paths
-        root_idents |= idents
-    return roots, root_idents, removes_root
+        paths, unresolved = _paths_in(statement, text)
+        if scope == "root":
+            if _RM.search(statement) and not removes_root:
+                removes_root = statement.strip()
+            roots |= paths
+            opaque |= unresolved
+        else:
+            additions |= paths
+    mentioned = {_normalise(p) for p in _REPO_PATH.findall(body)}
+    return _Writes(roots, opaque, removes_root,
+                   mentioned - roots - additions)
 
 
 def skills_mapping_problem(home_nix: str) -> str | None:
@@ -420,6 +594,15 @@ def skills_mapping_problem(home_nix: str) -> str | None:
         )
 
     ident = expr
+    declared = _binding_head_count(text, ident)
+    if declared > 1:
+        return (
+            f"the ~/.claude/skills mapping sources `{ident}`, and `{ident} =` is "
+            f"declared {declared} times in nix/home.nix -- which one a reference "
+            f"resolves to is a question about nix SCOPE, and this reads text. "
+            f"{_NEEDS_UPDATING}"
+        )
+
     direct = _resolve_path_ident(text, ident)
     if direct is not None:
         if _normalise(direct) == SKILLS_PATH:
@@ -439,15 +622,15 @@ def skills_mapping_problem(home_nix: str) -> str | None:
 
     # Not "the characters appear somewhere in the binding" -- the path has to
     # BECOME the output. Comments and dead code are already gone above.
-    roots, opaque, removes_root = _analyse_binding(body, text)
-    if SKILLS_PATH not in roots:
+    writes = _analyse_binding(body, text)
+    if SKILLS_PATH not in writes.roots:
         return (
             f"the ~/.claude/skills mapping sources `{ident}`, but that binding never "
             f"copies {SKILLS_PATH} into $out (it writes: "
-            f"{sorted(roots) or 'no repo tree at all'}) -- the pinned docs are not "
-            "the deployed files."
+            f"{sorted(writes.roots) or 'no repo tree at all'}) -- the pinned docs are "
+            "not the deployed files."
         )
-    others = sorted(roots - {SKILLS_PATH})
+    others = sorted(writes.roots - {SKILLS_PATH})
     if others:
         return (
             f"the `{ident}` binding copies {others} into $out as well as "
@@ -455,17 +638,26 @@ def skills_mapping_problem(home_nix: str) -> str | None:
             "actually ships, and the pins under claude/skills/ stop being claims "
             "about the deployed files."
         )
-    if opaque:
+    if writes.unaccounted:
         return (
-            f"the `{ident}` binding writes {sorted(opaque)} over the output ROOT, and "
-            f"this check cannot tell what those resolve to -- whichever write runs "
-            f"last decides what ships. {_NEEDS_UPDATING}"
+            f"the `{ident}` binding names {sorted(writes.unaccounted)} in statements "
+            f"this cannot relate to $out -- so it cannot say whether they land in the "
+            f"deployed tree. A `cd \"$out\"` or a `dst=\"$out\"` reads exactly like "
+            f"this, and it replaces everything. {_NEEDS_UPDATING}"
         )
-    if removes_root:
+    if writes.opaque:
         return (
-            f"the `{ident}` binding removes its own output (`{removes_root}`). "
-            f"A binding that copies {SKILLS_PATH} and then empties $out contains every "
-            "string this check looks for and deploys none of it."
+            f"the `{ident}` binding writes {sorted(writes.opaque)} over the output "
+            f"ROOT, and this check cannot tell what those resolve to -- whichever "
+            f"write runs last decides what ships. {_NEEDS_UPDATING}"
+        )
+    if writes.removes_root:
+        return (
+            f"the `{ident}` binding both copies {SKILLS_PATH} into $out and REMOVES "
+            f"$out (`{writes.removes_root}`). Which one wins is a question about "
+            "order that this does not answer, and if the removal runs last the "
+            "binding contains every string this check looks for and deploys none of "
+            "it."
         )
     return None
 

--- a/scripts/tests/test_skills_mapping_guard.py
+++ b/scripts/tests/test_skills_mapping_guard.py
@@ -613,6 +613,289 @@ MAPPING_BEHIND_MKIF = '''
 }
 '''
 
+# --------------------------------------------------------------------------
+# Found by an adversarial audit OF the #443 fix. Each of these returned a clean
+# bill of health against the first version of the new parser; two use idioms
+# that are in nix/home.nix today. They are the reason the fix took two rounds.
+# --------------------------------------------------------------------------
+
+#: 🔴 `''${bbOld##*.}` — a shell parameter expansion inside an indented string,
+#: verbatim from `nix/home.nix:548`. Blanking every `#` to end-of-line ate the
+#: `}`, unbalanced the braces the attrset scan counts, and let it run out of
+#: this mapping and into the NEXT one's `source`. Verdict was None.
+HASH_IN_A_SHELL_EXPANSION = '''
+{
+  home.file.".claude/skills" = {
+    recursive = true;
+    onChange = \'\'
+      ext="\'\'${f##*.}"
+    \'\';
+  };
+  home.file.".config/opencode/skills" = {
+    source = ../claude/skills;
+  };
+}
+'''
+
+#: A `#` inside a quoted shell string, followed on the SAME line by the
+#: statement that overwrites the output. Blanking from the `#` deleted it.
+HASH_INSIDE_A_STRING_HIDES_A_STATEMENT = '''
+{
+let
+  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
+    cp -R ${../claude/skills} "$out"
+    echo "theme=#282828" > /dev/null ; cp -R ${../claudedocs}/. "$out"
+  \'\';
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: The mapping quoted inside a `\'\'…\'\'` string, ABOVE the real declaration.
+#: First-match-wins let the quoted copy answer for the live one.
+MAPPING_QUOTED_IN_A_STRING = '''
+{
+let
+  readme = \'\'
+    home.file.".claude/skills" = { source = ../claude/skills; };
+  \'\';
+in
+  home.file.".claude/skills" = { source = ../claudedocs; };
+}
+'''
+
+#: `cd "$out"` then a copy whose statement never names $out. Statement-scoping
+#: cannot relate the two, so `../claudedocs` must come out UNACCOUNTED FOR
+#: rather than ignored — ignoring it was a clean PASS on a replaced tree.
+CD_INTO_OUT_THEN_OVERWRITE = '''
+{
+let
+  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
+    cp -R ${../claude/skills} "$out"
+    cd "$out"
+    cp -R ${../claudedocs}/. .
+  \'\';
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: The same evasion through a shell variable alias.
+OUT_ALIASED_TO_A_VARIABLE = '''
+{
+let
+  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
+    cp -R ${../claude/skills} "$out"
+    dst="$out"
+    cp -R ${../claudedocs}/. "$dst"
+  \'\';
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: A `tar | tar` pipe from the RIGHT tree. `|` used to split the statement, so
+#: the source and the destination ended up in different ones and nothing could
+#: relate them: "never copies ../claude/skills into $out" — wrong.
+TAR_PIPE_FROM_THE_SKILLS_TREE = '''
+{
+let
+  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
+    mkdir -p "$out"
+    tar -C ${../claude/skills} -cf - . | tar -C "$out" -xf -
+  \'\';
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: …and the same pipe from the WRONG tree, which must still fail.
+TAR_PIPE_FROM_ANOTHER_TREE = '''
+{
+let
+  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
+    cp -R ${../claude/skills} "$out"
+    tar -C ${../claudedocs} -cf - . | tar -C "$out" -xf -
+  \'\';
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: `//` merge: nix's effective `source` is the RIGHT operand, and only the left
+#: attribute set was ever read.
+ATTRSET_OVERRIDDEN_BY_MERGE = '''
+{
+  home.file.".claude/skills" = { source = ../claude/skills; recursive = true; }
+    // lib.optionalAttrs isLaptop { source = ../claudedocs; };
+}
+'''
+
+#: The same identifier declared twice — as an attribute key inside an unrelated
+#: attribute set, and as the real binding. Which one a reference resolves to is
+#: a question about nix SCOPE, and this reads text.
+SHADOWED_BINDING = '''
+{
+let
+  opencodeDefaults = {
+      claudeSkills = ../claude/skills;
+      recursive = true;
+  };
+  claudeSkills = ../claudedocs;
+in
+  home.file.".claude/skills".source = claudeSkills;
+}
+'''
+
+#: A whole other derivation copied over the output root, written as a DOTTED
+#: expression. It matched neither the path shape nor the identifier shape and
+#: was dropped by both branches, in silence.
+DOTTED_EXPR_OVER_ROOT = '''
+{
+let
+  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
+    cp -R ${../claude/skills} "$out"
+    cp -R ${pkgs.someOtherSkillsTree}/. "$out"
+  \'\';
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: 🔴 #443's headline false positive, one character to the LEFT: the quote
+#: before the slash rather than after it. Same destination, and it read as the
+#: output ROOT — "the binding removes its own output".
+RM_UNDER_OUT_QUOTE_FIRST = '''
+{
+let
+  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
+    cp -R ${../claude/skills} "$out"
+    chmod -R u+w "$out"
+    rm -rf "$out"/clickup/node_modules
+    ln -sT ${clickupNodeModules}/node_modules "$out"/clickup/node_modules
+    cp ${../claude/PRINCIPLES.md} "$out"/PRINCIPLES.md
+  \'\';
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: `${out}` — a spelling `_OUT_REF`'s own comment claims to support, which the
+#: interpolation scan then reported as an unresolvable tree written over $out.
+OUT_SPELLED_AS_AN_INTERPOLATION = '''
+{
+let
+  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
+    cp -R ${../claude/skills} "${out}"
+  \'\';
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: The entry declared through an attribute set rather than a dotted path. The
+#: literal `home.file.".claude/skills"` never appears, so this read as "the
+#: mapping was deleted" and sent the reader hunting for a removal.
+MAPPING_AS_A_NESTED_ATTRSET = '''
+{
+  home.file = {
+    ".claude/skills" = {
+      source = ../claude/skills;
+      recursive = true;
+    };
+  };
+}
+'''
+
+#: `src = <ident>;` where the ident is a bare path. Without this, the identifier
+#: resolution inside a root attribute never executes on any fixture — the
+#: feature is unexercised and its guard vacuous.
+ROOT_ATTR_THROUGH_AN_IDENT = '''
+{
+let
+  skillsSrc = ../claude/skills;
+  claudeSkills = pkgs.stdenv.mkDerivation {
+    name = "devrc-claude-skills";
+    src = skillsSrc;
+    installPhase = "cp -R ./. $out";
+  };
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: …and the same, where the identifier is declared TWICE. One declaration is
+#: the right tree and the other is not; which one `src` sees is nix scope, so
+#: the resolution must decline rather than pick.
+ROOT_ATTR_THROUGH_A_SHADOWED_IDENT = '''
+{
+let
+  opencodeDefaults = {
+      skillsSrc = ../claude/skills;
+  };
+  skillsSrc = ../claudedocs;
+  claudeSkills = pkgs.stdenv.mkDerivation {
+    name = "devrc-claude-skills";
+    src = skillsSrc;
+    installPhase = "cp -R ./. $out";
+  };
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+ROOT_ATTR_THROUGH_AN_IDENT_WRONG_TREE = '''
+{
+let
+  skillsSrc = ../claudedocs;
+  claudeSkills = pkgs.stdenv.mkDerivation {
+    name = "devrc-claude-skills";
+    src = skillsSrc;
+    installPhase = "cp -R ./. $out";
+  };
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: A defensive `rm -rf "$out"` BEFORE the copy. Genuinely harmless — and this
+#: cannot tell it from the harmful order, so the message must not claim one.
+RM_BEFORE_THE_COPY = '''
+{
+let
+  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
+    rm -rf "$out"
+    cp -R ${../claude/skills} "$out"
+  \'\';
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
 #: An UNRESOLVABLE identifier written over the output root. Not a repo path, so
 #: nothing here can say what ships — the parser must say so, not stay silent.
 OPAQUE_IDENT_OVER_ROOT = '''
@@ -733,7 +1016,7 @@ def test_copying_the_tree_and_then_emptying_out_fails():
         "deploys none of them"
     )
     # It must fail for one of the two REAL reasons, not incidentally.
-    assert ("removes its own output" in problem) or ("as well as" in problem), problem
+    assert ("REMOVES $out" in problem) or ("as well as" in problem), problem
 
 
 def test_copying_a_second_repo_tree_over_the_output_fails():
@@ -757,7 +1040,11 @@ def test_emptying_out_after_copying_fails_on_its_own():
         "a binding that copies claude/skills and then `rm -rf \"$out\"` was accepted — "
         "it deploys an EMPTY tree"
     )
-    assert "removes its own output" in problem, problem
+    assert "REMOVES $out" in problem, problem
+    # The message must NOT assert an order it did not establish: a defensive
+    # `rm -rf "$out"` BEFORE the copy is harmless, and this cannot tell the two
+    # apart, so it has to say which question is open rather than invent an answer.
+    assert "question about order" in problem, problem
 
 
 def test_a_source_bound_to_a_nonexistent_ident_fails():
@@ -1013,6 +1300,168 @@ def test_malformed_nix_is_reported_as_a_parser_problem_not_a_pass():
         problem = skills_mapping_problem(fixture)
         assert problem is not None, f"{name} was accepted as a valid deploy"
         assert "do NOT delete the check" in problem, f"{name}: {problem}"
+
+
+# --------------------------------------------------------------------------
+# Found by an adversarial audit OF the #443 fix. Every one of these was a clean
+# PASS (or, for the last group, a confident wrong FAIL) against the first
+# version of the new parser.
+# --------------------------------------------------------------------------
+
+def test_a_hash_inside_a_shell_expansion_is_not_a_comment():
+    """🔴 `''${bbOld##*.}` is `nix/home.nix:548`, today.
+
+    Blanking every `#` to end-of-line removed the closing `}` of the expansion,
+    which unbalanced the braces the attrset scan counts, which let it run out of
+    this mapping and into the NEXT one's `source`. Verdict: None — the same
+    false all-clear #443 is about, reintroduced by the fix for it.
+    """
+    problem = skills_mapping_problem(HASH_IN_A_SHELL_EXPANSION)
+    assert problem is not None, (
+        "a sourceless mapping containing `${x##*.}` was accepted because comment "
+        "stripping ate a brace and the scan read the next mapping's source"
+    )
+    assert "no `source =`" in problem, problem
+
+
+def test_a_hash_inside_a_string_does_not_swallow_the_rest_of_the_line():
+    problem = skills_mapping_problem(HASH_INSIDE_A_STRING_HIDES_A_STATEMENT)
+    assert problem is not None, (
+        "a `#` inside a quoted string blanked the statement after it on the same "
+        "line — the one that copied another tree over $out"
+    )
+    assert "as well as" in problem, problem
+
+
+def test_the_mapping_quoted_in_a_string_cannot_answer_for_the_real_one():
+    """Two DIFFERENT sources for one path is not a question this can settle."""
+    problem = skills_mapping_problem(MAPPING_QUOTED_IN_A_STRING)
+    assert problem is not None, (
+        "a copy of the mapping inside a `''…''` string answered for the real "
+        "declaration below it, which sourced ../claudedocs"
+    )
+    assert "do NOT delete the check" in problem, problem
+
+
+def test_a_write_this_cannot_relate_to_out_is_reported_not_ignored():
+    """`cd "$out"` and `dst="$out"` both replace the tree from a statement that
+    never names `$out`. Statement-scoping is blind to them by construction, so
+    an unclassified repo path has to be an ANSWER, not a shrug."""
+    for name, fixture in (
+        ("cd into $out", CD_INTO_OUT_THEN_OVERWRITE),
+        ("$out aliased to a variable", OUT_ALIASED_TO_A_VARIABLE),
+    ):
+        problem = skills_mapping_problem(fixture)
+        assert problem is not None, (
+            f"{name}: ../claudedocs was copied over the deployed tree and accepted"
+        )
+        assert "../claudedocs" in problem, f"{name}: {problem}"
+        assert "do NOT delete the check" in problem, f"{name}: {problem}"
+
+
+def test_a_pipeline_is_one_statement():
+    """`tar -C ${src} -cf - . | tar -C "$out" -xf -` is a single write.
+
+    Splitting on `|` put the source and the destination in different statements,
+    so the legitimate form was rejected ("never copies …") and the hostile form
+    was accepted. Both directions are pinned.
+    """
+    assert skills_mapping_problem(TAR_PIPE_FROM_THE_SKILLS_TREE) is None
+    problem = skills_mapping_problem(TAR_PIPE_FROM_ANOTHER_TREE)
+    assert problem is not None, "a second tree untarred over $out was accepted"
+    assert "as well as" in problem, problem
+
+
+def test_an_attribute_set_merged_with_an_override_is_not_readable():
+    """`{ source = A; } // lib.optionalAttrs cond { source = B; }` deploys B."""
+    problem = skills_mapping_problem(ATTRSET_OVERRIDDEN_BY_MERGE)
+    assert problem is not None, (
+        "only the left operand of `//` was read, so an override to ../claudedocs "
+        "was invisible"
+    )
+    assert "do NOT delete the check" in problem, problem
+
+
+def test_a_shadowed_binding_is_a_question_about_scope_not_text():
+    problem = skills_mapping_problem(SHADOWED_BINDING)
+    assert problem is not None, (
+        "the first `claudeSkills =` head in the file won — but it was an attribute "
+        "inside an unrelated set, not the binding the source refers to"
+    )
+    assert "do NOT delete the check" in problem, problem
+
+
+def test_a_dotted_expression_over_the_root_is_not_dropped():
+    """`${pkgs.someOtherSkillsTree}` matches neither the path shape nor the
+    identifier shape. It used to fall off the end of the `elif` — the one
+    outcome the module docstring says must never happen."""
+    problem = skills_mapping_problem(DOTTED_EXPR_OVER_ROOT)
+    assert problem is not None, (
+        "a whole other derivation copied over the output root was silently dropped"
+    )
+    assert "do NOT delete the check" in problem, problem
+
+
+def test_the_quote_may_come_before_the_slash():
+    """🔴 `"$out"/clickup/node_modules` — #443's headline false positive, one
+    character to the left of where it was fixed. Same destination, and the
+    root-vs-under split has to read the DESTINATION, not the spelling."""
+    assert skills_mapping_problem(RM_UNDER_OUT_QUOTE_FIRST) is None
+
+
+def test_out_spelled_as_an_interpolation_is_the_output_not_a_tree():
+    """`${out}` is the output. `_OUT_REF`'s comment already said so; the
+    interpolation scan then reported it as an unresolvable tree written there."""
+    assert skills_mapping_problem(OUT_SPELLED_AS_AN_INTERPOLATION) is None
+
+
+def test_the_mapping_declared_as_a_nested_attribute_set_asks_for_the_parser():
+    """`home.file = { ".claude/skills" = …; }` never spells the literal this
+    searches for. That is not "the mapping was deleted" — it is a spelling this
+    cannot read, and the two send a reader to completely different places."""
+    problem = skills_mapping_problem(MAPPING_AS_A_NESTED_ATTRSET)
+    assert problem is not None
+    assert "do NOT delete the check" in problem, problem
+    assert "no longer declares" not in problem, problem
+
+
+def test_a_root_attribute_bound_to_an_identifier_resolves():
+    """`src = skillsSrc;` with `skillsSrc = ../claude/skills;`.
+
+    Without this fixture the identifier resolution inside `src`/`paths` never
+    executes on anything, and the guard that keeps it from eating path
+    components is vacuous — it asserts a loop does not do something, while
+    nothing shows the loop does anything.
+    """
+    assert skills_mapping_problem(ROOT_ATTR_THROUGH_AN_IDENT) is None
+    problem = skills_mapping_problem(ROOT_ATTR_THROUGH_AN_IDENT_WRONG_TREE)
+    assert problem is not None, "`src = skillsSrc;` bound to ../claudedocs passed"
+    assert "never copies" in problem, problem
+
+
+def test_a_root_attribute_bound_to_a_SHADOWED_identifier_does_not_resolve():
+    """`src = skillsSrc;` where `skillsSrc =` is declared twice.
+
+    Declining is the only honest answer — picking the first declaration is a
+    guess about nix scope. Pinned because the shadow check sits at a second call
+    site, and until this fixture existed a mutation of it changed no verdict.
+    """
+    problem = skills_mapping_problem(ROOT_ATTR_THROUGH_A_SHADOWED_IDENT)
+    assert problem is not None, (
+        "a `src` bound to a name declared twice — once to ../claude/skills and "
+        "once to ../claudedocs — was resolved to whichever came first in the file"
+    )
+    assert "never copies" in problem, problem
+
+
+def test_a_removal_before_the_copy_is_not_claimed_to_come_after():
+    """A defensive `rm -rf "$out"` first is harmless, and this cannot tell it
+    from the harmful order — so it must report the open question, not assert an
+    answer. It still fails: order is exactly what is undetermined."""
+    problem = skills_mapping_problem(RM_BEFORE_THE_COPY)
+    assert problem is not None
+    assert "question about order" in problem, problem
+    assert "and then empties" not in problem, problem
 
 
 def test_an_opaque_identifier_written_over_the_output_root_is_not_silently_ok():

--- a/scripts/tests/test_skills_mapping_guard.py
+++ b/scripts/tests/test_skills_mapping_guard.py
@@ -15,6 +15,26 @@ A predicate that is now permissive enough to accept an indirection has to be
 shown it can still REJECT. So: the real home.nix must pass, and each way of
 actually breaking the deployment must fail — including the one the loosening
 could plausibly have let through, a source bound to an unrelated tree.
+
+WHAT ISSUE #443 ADDED
+---------------------
+Two groups of fixtures, one per direction the parser was wrong.
+
+*The dotted form.* nix spells one `home.file` entry two ways, and this file only
+ever fixtured the attribute-set one. The predicate located the mapping's attrs
+with "the next `{` ANYWHERE in the file", so for `home.file.".claude/skills"
+.source = ../claudedocs;` it walked past the real source into an unrelated block
+and returned CLEAN. Its absence here is precisely why that shipped, so the
+dotted form is now fixtured in both directions — correct and wrong-tree — and
+the wrong-tree case asserts on WHICH path the message names, because the failure
+mode was a confident verdict about a block that was not the mapping's.
+
+*Five legitimate shapes it rejected.* `src =`, `paths = [ … ]`, one more hop of
+let-indirection, `rm -rf "$out/sub"`, and a file copied to `"$out/name"`. These
+are MUST-NOT-FIRE controls: a guard that cries wolf on the real thing gets
+deleted, so they are load-bearing in the same way the negatives are. Each is
+paired with a wrong-tree twin below, so widening the parser to accept the shape
+is shown not to have accepted the HAZARD in that shape.
 """
 from __future__ import annotations
 
@@ -211,6 +231,404 @@ DANGLING_IDENT = '''
 }
 '''
 
+# --------------------------------------------------------------------------
+# ISSUE #443, DIRECTION 1 — the DOTTED form. `home.file."…".source = <expr>;`
+# has no attribute set of its own, and home.nix already uses it ~20 times.
+# --------------------------------------------------------------------------
+
+#: The dotted form, deploying the right tree.
+DOTTED = '''
+{
+  home.file.".claude/skills".source = ../claude/skills;
+  home.file.".claude/skills".recursive = true;
+}
+'''
+
+#: The verified false ALL-CLEAR: dotted source pointing at an unrelated tree,
+#: with an attrset mapping BELOW it that does name ../claude/skills. The old
+#: `find("{", start)` scan skipped over the real source and read this one.
+DOTTED_WRONG_TREE = '''
+{
+  home.file.".claude/skills".source = ../claudedocs;
+  home.file.".config/opencode/skills" = { source = ../claude/skills; recursive = true; };
+}
+'''
+
+#: The other verified variant: the next `{` in the file belongs to something
+#: else entirely, and the predicate reported "declares no `source =` at all"
+#: while quoting an unrelated block — confidently wrong about the wrong text.
+DOTTED_WRONG_TREE_DECOY = '''
+{
+  home.file.".claude/skills".source = ../claudedocs;
+  services.dunst = { enable = true; };
+}
+'''
+
+#: The dotted form reaching the deployed tree through the let-binding, i.e. the
+#: real home.nix's source expression written in the other spelling.
+DOTTED_INDIRECT = '''
+{
+let
+  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
+    cp -R ${../claude/skills} "$out"
+  \'\';
+in
+  home.file.".claude/skills".source = claudeSkills;
+}
+'''
+
+#: Dotted, wrong tree, through the binding — the indirection must not launder it.
+DOTTED_INDIRECT_WRONG_TREE = '''
+{
+let
+  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
+    cp -R ${../claudedocs} "$out"
+  \'\';
+in
+  home.file.".claude/skills".source = claudeSkills;
+}
+'''
+
+#: The mapping named ONLY in a comment. Deleting the entry and leaving the note
+#: must read as "no longer declares", not as a live mapping.
+MAPPING_ONLY_IN_A_COMMENT = '''
+{
+  # was: home.file.".claude/skills".source = ../claude/skills;
+  home.file.".claude/PRINCIPLES.md".source = ../claude/PRINCIPLES.md;
+}
+'''
+
+#: A source expression that is neither a path nor an identifier. Undecidable —
+#: and undecidable must be LOUD, or the mapping stops being checked at all.
+UNREADABLE_SOURCE = '''
+{
+  home.file.".claude/skills".source =
+    config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/claude/skills";
+}
+'''
+
+# --------------------------------------------------------------------------
+# ISSUE #443, DIRECTION 2 — five legitimate shapes rejected with a confident,
+# wrong "the deploy is broken". Each is followed by its wrong-tree twin.
+# --------------------------------------------------------------------------
+
+#: `mkDerivation { src = …; }` — the output tree comes from `src`, and the
+#: builder never names `$out` in nix at all.
+MKDERIVATION_SRC = '''
+{
+let
+  claudeSkills = pkgs.stdenv.mkDerivation {
+    name = "devrc-claude-skills";
+    src = ../claude/skills;
+    installPhase = "cp -R ./. $out";
+  };
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+MKDERIVATION_SRC_WRONG_TREE = '''
+{
+let
+  claudeSkills = pkgs.stdenv.mkDerivation {
+    name = "devrc-claude-skills";
+    src = ../claudedocs;
+    installPhase = "cp -R ./. $out";
+  };
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: `symlinkJoin { paths = [ … ]; }` — same, via a list. The second entry is a
+#: derivation, not a repo tree, and must not be reported as one.
+SYMLINKJOIN_PATHS = '''
+{
+let
+  claudeSkills = pkgs.symlinkJoin {
+    name = "devrc-claude-skills";
+    paths = [ ../claude/skills clickupNodeModules ];
+  };
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: Two REPO trees merged into one output root is the hazard the widening must
+#: not have accepted: whichever wins the join decides what ships.
+SYMLINKJOIN_SECOND_TREE = '''
+{
+let
+  claudeSkills = pkgs.symlinkJoin {
+    name = "devrc-claude-skills";
+    paths = [ ../claude/skills ../claudedocs ];
+  };
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: One more hop: the path is a let-binding of its own, interpolated by name.
+EXTRA_LET_INDIRECTION = '''
+{
+let
+  skillsSrc = ../claude/skills;
+  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
+    cp -R ${skillsSrc} "$out"
+  \'\';
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+EXTRA_LET_INDIRECTION_WRONG_TREE = '''
+{
+let
+  skillsSrc = ../claudedocs;
+  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
+    cp -R ${skillsSrc} "$out"
+  \'\';
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: The source itself bound straight to a path by name — no derivation at all.
+SOURCE_IDENT_IS_A_PATH = '''
+{
+let
+  skillsSrc = ../claude/skills;
+in
+  home.file.".claude/skills".source = skillsSrc;
+}
+'''
+
+SOURCE_IDENT_IS_THE_WRONG_PATH = '''
+{
+let
+  skillsSrc = ../claudedocs;
+in
+  home.file.".claude/skills".source = skillsSrc;
+}
+'''
+
+#: `rm -rf "$out/clickup/node_modules"` as a cleanup step — a removal UNDER the
+#: output, one line from the code it guards. The most likely near-term trip.
+RM_UNDER_OUT = '''
+{
+let
+  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
+    cp -R ${../claude/skills} "$out"
+    chmod -R u+w "$out"
+    rm -rf "$out/clickup/node_modules"
+    ln -sT ${clickupNodeModules}/node_modules "$out/clickup/node_modules"
+  \'\';
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: A single FILE added at a named path under $out. Additive — it cannot be the
+#: "second tree written over the same output" the guard is about.
+EXTRA_FILE_COPIED_IN = '''
+{
+let
+  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
+    cp -R ${../claude/skills} "$out"
+    chmod -R u+w "$out"
+    cp ${../claude/PRINCIPLES.md} "$out/PRINCIPLES.md"
+  \'\';
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: …and the twin: the same second tree written over the output ROOT instead of
+#: to a name under it. Scoping the destination must not have cost the check.
+EXTRA_TREE_OVER_ROOT = '''
+{
+let
+  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
+    cp -R ${../claude/skills} "$out"
+    chmod -R u+w "$out"
+    cp -R ${../claudedocs}/. "$out"
+  \'\';
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: The output root spelled `"$out/"` rather than `"$out"`, and the source with
+#: the `cp -R src/. dst` idiom. Same write; the guard must read it as the root,
+#: or a legitimate binding is rejected.
+ROOT_SPELLED_WITH_A_SLASH = '''
+{
+let
+  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
+    mkdir -p "$out"
+    cp -R ${../claude/skills}/. "$out/"
+  \'\';
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: …and its twin: a second tree over `"$out/."`, which is still the root. If
+#: only the bare `"$out"` spelling counts, this shape walks straight through.
+SECOND_TREE_OVER_ROOT_DOT = '''
+{
+let
+  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
+    cp -R ${../claude/skills} "$out"
+    cp -R ${../claudedocs}/. "$out/."
+  \'\';
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: A path literal written `../claude/skills/.` — VALID nix naming the same tree
+#: (verified with `nix-instantiate --parse`; note `../claude/skills/` is a
+#: syntax error, so the trailing `/.` is the only spelling to handle).
+PATHS_WITH_A_TRAILING_DOT = '''
+{
+let
+  claudeSkills = pkgs.symlinkJoin {
+    name = "devrc-claude-skills";
+    paths = [ ../claude/skills/. clickupNodeModules ];
+  };
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: A let-binding whose NAME collides with a component of the path. Resolving
+#: identifiers inside a `src =` value must not read `../claude/skills` as a
+#: reference to a binding called `skills`.
+PATH_COMPONENT_SHADOWED_BY_A_BINDING = '''
+{
+let
+  skills = ../claudedocs;
+  claudeSkills = pkgs.stdenv.mkDerivation {
+    name = "devrc-claude-skills";
+    src = ../claude/skills;
+    installPhase = "cp -R ./. $out";
+  };
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+#: An attrset mapping with NO source, followed by a sibling that HAS one. The
+#: attribute-set twin of the dotted defect: if the brace scan runs past the
+#: mapping's own `}`, the sibling's source is read as the mapping's.
+#: (Found by mutating `if depth == 0` in the brace scan — the fixtures above
+#: could not tell the difference.)
+NO_SOURCE_WITH_A_SIBLING_THAT_HAS_ONE = '''
+{
+  home.file.".claude/skills" = {
+    recursive = true;
+    force = true;
+  };
+  home.file.".config/opencode/skills" = {
+    source = ../claude/skills;
+    recursive = true;
+  };
+}
+'''
+
+#: A binding that MENTIONS the tree but never writes the output at all — the
+#: derivation ships an empty $out. Distinct from "copies the wrong tree": the
+#: message has to say there is no repo tree in it, not name one.
+NOTHING_WRITTEN_TO_OUT = '''
+{
+let
+  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
+    echo ${../claude/skills} > /dev/null
+  \'\';
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
+# --- malformed nix. It cannot be the real home.nix (it would not build), but
+# "the parser fell off the end of the file" must never come out as a PASS. ---
+
+#: A dotted source with no terminating `;`.
+DOTTED_NO_SEMICOLON = '''
+{
+  home.file.".claude/skills".source = ../claude/skills
+}
+'''
+
+#: An attribute set that never closes.
+ATTRSET_NEVER_CLOSES = '''
+{
+  home.file.".claude/skills" = {
+    source = ../claude/skills;
+'''
+
+#: An attribute set whose `source =` has no terminating `;`.
+ATTRSET_SOURCE_NO_SEMICOLON = '''
+{
+  home.file.".claude/skills" = { source = ../claude/skills }
+}
+'''
+
+#: A mapping wrapped in something this does not parse. Not a pass, and not a
+#: claim that the deploy is broken either.
+MAPPING_BEHIND_MKIF = '''
+{
+  home.file.".claude/skills" = lib.mkIf config.programs.claude.enable {
+    source = ../claude/skills;
+  };
+}
+'''
+
+#: An UNRESOLVABLE identifier written over the output root. Not a repo path, so
+#: nothing here can say what ships — the parser must say so, not stay silent.
+OPAQUE_IDENT_OVER_ROOT = '''
+{
+let
+  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
+    cp -R ${../claude/skills} "$out"
+    cp -R ${someOtherDerivation}/. "$out"
+  \'\';
+in
+  home.file.".claude/skills" = {
+    source = claudeSkills;
+  };
+}
+'''
+
 
 # --------------------------------------------------------------------------
 # POSITIVE: the shipped file, and both accepted shapes.
@@ -346,3 +764,263 @@ def test_a_source_bound_to_a_nonexistent_ident_fails():
     problem = skills_mapping_problem(DANGLING_IDENT)
     assert problem is not None
     assert "no such let-binding" in problem, problem
+
+
+# --------------------------------------------------------------------------
+# ISSUE #443, DIRECTION 1 — the dotted form, which had NO fixture at all.
+# --------------------------------------------------------------------------
+
+def test_the_dotted_form_passes():
+    """`home.file."…".source = ../claude/skills;` — the other legal spelling."""
+    assert skills_mapping_problem(DOTTED) is None
+
+
+def test_a_dotted_source_pointing_at_another_tree_fails():
+    """The verified false ALL-CLEAR of #443.
+
+    `find("{", start)` took the next `{` anywhere in the file, so with the
+    dotted form it read the source of a LATER, unrelated mapping — one that does
+    name ../claude/skills — and returned clean while ~/.claude/skills deployed
+    ../claudedocs. Asserting on the named path, not merely on non-None: the
+    defect was a confident verdict about text that was not the mapping's.
+    """
+    problem = skills_mapping_problem(DOTTED_WRONG_TREE)
+    assert problem is not None, (
+        "a DOTTED ~/.claude/skills mapping sourced from ../claudedocs was accepted "
+        "because a LATER mapping in the file mentions ../claude/skills — the "
+        "predicate is reading someone else's attribute set"
+    )
+    assert "../claudedocs" in problem, problem
+
+
+def test_a_dotted_source_is_not_diagnosed_from_an_unrelated_block():
+    """The second verified variant: right verdict, wrong reason, is not enough.
+
+    Here the next `{` belonged to `services.dunst`, and the predicate reported
+    "declares no `source =` at all" while quoting `{ enable = true; }`. It DID
+    go red, so a non-None assertion passes on the broken parser — the message is
+    what distinguishes reading the mapping from reading whatever came next.
+    """
+    problem = skills_mapping_problem(DOTTED_WRONG_TREE_DECOY)
+    assert problem is not None, problem
+    assert "../claudedocs" in problem, problem
+    assert "no `source =`" not in problem, (
+        "the dotted mapping HAS a source; reporting that it has none means the "
+        f"parser is quoting an unrelated block: {problem}"
+    )
+    assert "enable = true" not in problem, problem
+
+
+def test_the_dotted_form_follows_the_let_binding():
+    assert skills_mapping_problem(DOTTED_INDIRECT) is None
+
+
+def test_a_dotted_source_built_from_an_unrelated_tree_fails():
+    problem = skills_mapping_problem(DOTTED_INDIRECT_WRONG_TREE)
+    assert problem is not None, (
+        "the dotted spelling laundered a binding built from ../claudedocs"
+    )
+    assert "never copies" in problem, problem
+
+
+def test_a_mapping_named_only_in_a_comment_does_not_count():
+    problem = skills_mapping_problem(MAPPING_ONLY_IN_A_COMMENT)
+    assert problem is not None, (
+        "a commented-out mapping was read as a live one — deleting the entry and "
+        "leaving the note would then look healthy"
+    )
+    assert "no longer declares" in problem, problem
+
+
+def test_an_unreadable_source_expression_says_the_parser_needs_updating():
+    """Undecidable must be LOUD.
+
+    A source this cannot resolve is not a pass. It is also not "the deploy is
+    broken" — the message has to send the reader to the parser, because the one
+    answer that silently stops checking anything is None.
+    """
+    problem = skills_mapping_problem(UNREADABLE_SOURCE)
+    assert problem is not None, (
+        "a source expression the parser cannot resolve was accepted — the check "
+        "would then be wired to nothing"
+    )
+    assert "do NOT delete the check" in problem, problem
+
+
+# --------------------------------------------------------------------------
+# ISSUE #443, DIRECTION 2 — the five legitimate shapes it rejected.
+# MUST-NOT-FIRE controls, each paired with its wrong-tree twin so the widening
+# is shown to have kept the property.
+# --------------------------------------------------------------------------
+
+def test_a_derivation_whose_src_is_the_skills_tree_passes():
+    """`src = ../claude/skills;` — a plain path attribute, no `${…}` anywhere."""
+    assert skills_mapping_problem(MKDERIVATION_SRC) is None
+
+
+def test_a_derivation_whose_src_is_another_tree_fails():
+    problem = skills_mapping_problem(MKDERIVATION_SRC_WRONG_TREE)
+    assert problem is not None, (
+        "reading `src =` as a copy accepted a derivation built from ../claudedocs"
+    )
+    assert "never copies" in problem, problem
+
+
+def test_a_symlinkjoin_over_the_skills_tree_passes():
+    """`paths = [ ../claude/skills clickupNodeModules ]` — a path in a list."""
+    assert skills_mapping_problem(SYMLINKJOIN_PATHS) is None
+
+
+def test_a_symlinkjoin_that_merges_a_second_repo_tree_fails():
+    problem = skills_mapping_problem(SYMLINKJOIN_SECOND_TREE)
+    assert problem is not None, (
+        "two repo trees merged into one output root were accepted — whichever wins "
+        "the join decides what ships"
+    )
+    assert "as well as" in problem, problem
+
+
+def test_one_more_hop_of_let_indirection_passes():
+    """`skillsSrc = ../claude/skills;` then `${skillsSrc}`."""
+    assert skills_mapping_problem(EXTRA_LET_INDIRECTION) is None
+
+
+def test_one_more_hop_of_let_indirection_to_another_tree_fails():
+    problem = skills_mapping_problem(EXTRA_LET_INDIRECTION_WRONG_TREE)
+    assert problem is not None, (
+        "following an identifier to a path accepted ../claudedocs — the extra hop "
+        "laundered the wrong tree"
+    )
+    assert "never copies" in problem, problem
+
+
+def test_a_source_bound_directly_to_the_skills_path_by_name_passes():
+    assert skills_mapping_problem(SOURCE_IDENT_IS_A_PATH) is None
+
+
+def test_a_source_bound_directly_to_another_path_by_name_fails():
+    problem = skills_mapping_problem(SOURCE_IDENT_IS_THE_WRONG_PATH)
+    assert problem is not None, (
+        "`source = skillsSrc;` with `skillsSrc = ../claudedocs;` was accepted"
+    )
+    assert "../claudedocs" in problem, problem
+
+
+def test_removing_a_path_UNDER_out_is_not_removing_out():
+    """`rm -rf "$out/clickup/node_modules"` is a cleanup step, not a wipe.
+
+    The old check matched any `rm` naming `$out`. This shape sits one line from
+    the injection it guards, so it was the likeliest trip — and it arrives as
+    "the binding removes its own output", which reads as a broken deploy.
+    """
+    assert skills_mapping_problem(RM_UNDER_OUT) is None
+
+
+def test_a_file_copied_to_a_name_under_out_is_not_a_second_tree():
+    """`cp ${../claude/PRINCIPLES.md} "$out/PRINCIPLES.md"` ADDS; it cannot
+    replace the skills tree."""
+    assert skills_mapping_problem(EXTRA_FILE_COPIED_IN) is None
+
+
+def test_a_second_tree_written_over_the_output_ROOT_still_fails():
+    """The twin of the fixture above — scoping the destination is the whole
+    difference, so both directions have to be pinned."""
+    problem = skills_mapping_problem(EXTRA_TREE_OVER_ROOT)
+    assert problem is not None, (
+        "distinguishing `$out/name` from `$out` cost the second-tree check: a tree "
+        "copied over the output root was accepted"
+    )
+    assert "as well as" in problem, problem
+
+
+def test_the_output_root_spelled_with_a_trailing_slash_is_still_the_root():
+    """`"$out/"` and `cp -R src/. dst` — the same write, spelled the other way."""
+    assert skills_mapping_problem(ROOT_SPELLED_WITH_A_SLASH) is None
+
+
+def test_a_second_tree_over_out_dot_still_fails():
+    """`"$out/."` is the output root too. Recognising only the bare `"$out"`
+    spelling would let this shape through as an addition."""
+    problem = skills_mapping_problem(SECOND_TREE_OVER_ROOT_DOT)
+    assert problem is not None, (
+        "a second repo tree copied over `\"$out/.\"` was read as an addition — the "
+        "root-vs-under split is matching a spelling, not a destination"
+    )
+    assert "as well as" in problem, problem
+
+
+def test_a_path_literal_with_a_trailing_dot_names_the_same_tree():
+    """`../claude/skills/.` parses (nix-instantiate) and resolves to the skills
+    tree; `../claude/skills/` does not parse at all, so this is the one variant
+    spelling that can legitimately reach the guard."""
+    assert skills_mapping_problem(PATHS_WITH_A_TRAILING_DOT) is None
+
+
+def test_a_binding_named_like_a_path_component_is_not_a_reference_to_it():
+    """`src = ../claude/skills;` names a PATH, not the binding `skills`.
+
+    Identifiers in a derivation attribute are resolved one hop, so the scan has
+    to stop at `/`. Without that, the `skills` component resolves to whatever a
+    binding of that name holds and the guard reports a second tree that is not
+    there — a confident, wrong "the deploy is broken".
+    """
+    assert skills_mapping_problem(PATH_COMPONENT_SHADOWED_BY_A_BINDING) is None
+
+
+def test_a_sourceless_mapping_does_not_borrow_a_siblings_source():
+    """The attribute-set twin of the dotted defect.
+
+    The mapping has no `source` of its own; the NEXT one does, and names the
+    right tree. A brace scan that runs past the mapping's own `}` reads the
+    sibling's and reports a clean deploy — the same class of false all-clear as
+    #443, in the shape the existing fixtures could not distinguish.
+    """
+    problem = skills_mapping_problem(NO_SOURCE_WITH_A_SIBLING_THAT_HAS_ONE)
+    assert problem is not None, (
+        "a ~/.claude/skills mapping with NO source was accepted because a LATER "
+        "mapping has one — the brace scan is reading past the mapping's own block"
+    )
+    assert "no `source =`" in problem, problem
+
+
+def test_a_binding_that_writes_nothing_to_out_fails():
+    """A derivation that mentions the tree and ships an EMPTY output.
+
+    Different failure from "copies the wrong tree", and it has to read that way:
+    the message must say no repo tree reaches $out, not name one that does.
+    """
+    problem = skills_mapping_problem(NOTHING_WRITTEN_TO_OUT)
+    assert problem is not None, (
+        "a binding whose $out is never written was accepted — it deploys nothing"
+    )
+    assert "no repo tree at all" in problem, problem
+
+
+def test_malformed_nix_is_reported_as_a_parser_problem_not_a_pass():
+    """Truncated/unterminated input must not fall through to None.
+
+    None is the one answer that silently stops checking anything, so every way
+    the scans can run off the end is pinned — each of these branches was
+    unreached until an automated sweep turned it into `return None` and no test
+    noticed.
+    """
+    for name, fixture in (
+        ("dotted source with no `;`", DOTTED_NO_SEMICOLON),
+        ("attribute set that never closes", ATTRSET_NEVER_CLOSES),
+        ("attrset `source =` with no `;`", ATTRSET_SOURCE_NO_SEMICOLON),
+        ("mapping behind an unparsed wrapper", MAPPING_BEHIND_MKIF),
+    ):
+        problem = skills_mapping_problem(fixture)
+        assert problem is not None, f"{name} was accepted as a valid deploy"
+        assert "do NOT delete the check" in problem, f"{name}: {problem}"
+
+
+def test_an_opaque_identifier_written_over_the_output_root_is_not_silently_ok():
+    """`cp -R ${someOtherDerivation}/. "$out"` — not a repo path, so nothing here
+    can say what ships. That is a case for the parser, not a pass."""
+    problem = skills_mapping_problem(OPAQUE_IDENT_OVER_ROOT)
+    assert problem is not None, (
+        "an unresolvable derivation copied over the output ROOT was accepted — "
+        "whichever write runs last decides what ships and this check cannot tell"
+    )
+    assert "do NOT delete the check" in problem, problem


### PR DESCRIPTION
`scripts/testlib/skills_mapping.py` is the one predicate answering "does `nix/home.nix` actually deploy `claude/skills/`?", and four test modules rest on it. It was wrong in both directions at once, and an adversarial audit of the first fix found the loose direction was wrong in eight more shapes — two of them idioms already in `home.nix`.

Closes #443.

## What was wrong

**Too loose — a false ALL-CLEAR.** `_mapping_block()` located the mapping's attribute set with `home_nix.find("{", start)`: the next `{` **anywhere in the file**. nix's dotted form has no attribute set of its own, so the scan walked past the real source into a sibling's block and returned `None` — clean — while `~/.claude/skills` deployed the wrong tree. The dotted form is not hypothetical: `home.nix` already uses it ~20 times against 34 attrset-form mappings, and it had **no fixture at all**, which is why this shipped.

**Too strict — five confident, wrong rejections.** Copy-detection saw only `${…}` interpolations within 200 characters of a `$out` reference, and any `rm` naming `$out` counted as emptying the output. Unlike the loose case these carried no "parser may need updating" hedge, so they read as "the deploy is broken" — which is how a guard gets deleted rather than fixed. The `rm -rf "$out/clickup/node_modules"` one sits one line from the code it guards.

## Verified reproductions

All run against the real predicate, not inferred. `[base]` = `6eaeb61`, `[HEAD]` = this branch.

| shape | must | base | HEAD |
|---|---|---|---|
| `home.file.".claude/skills".source = ../claudedocs;` + a sibling naming `../claude/skills` | FAIL | **PASS** (false all-clear) | FAIL, naming `../claudedocs` |
| same, sibling is `services.dunst = { enable = true; }` | FAIL | FAIL — quoting `{ enable = true; }`, "declares no `source =`" | FAIL, naming `../claudedocs` |
| `home.file.".claude/skills".source = ../claude/skills;` | PASS | FAIL "could not read its attribute set" | PASS |
| `mkDerivation { src = ../claude/skills; … }` | PASS | FAIL "never copies … into $out" | PASS |
| `symlinkJoin { paths = [ ../claude/skills … ]; }` | PASS | FAIL "never copies" | PASS |
| `skillsSrc = ../claude/skills;` then `${skillsSrc}` | PASS | FAIL "never copies" | PASS |
| `rm -rf "$out/clickup/node_modules"` | PASS | FAIL "removes its own output" | PASS |
| `cp ${../claude/PRINCIPLES.md} "$out/PRINCIPLES.md"` | PASS | FAIL "copies a second tree" | PASS |

### And what the audit of that fix then found

Eight further shapes returned `None` while the deployed tree was not `claude/skills`, plus the headline false positive one character to the left. Each verified by running the predicate, each now a fixture:

| shape | after round 1 | now |
|---|---|---|
| `''${bbOld##*.}` in the mapping — **`nix/home.nix:548`, today** | PASS | FAIL "no `source =`" |
| `echo "theme=#282828" ; cp -R ${../claudedocs}/. "$out"` | PASS | FAIL "as well as" |
| the mapping quoted inside a `''…''` string above the real one | PASS | FAIL, parser |
| `cd "$out"` then `cp -R ${../claudedocs}/. .` | PASS | FAIL, parser |
| `dst="$out"` then `cp -R ${../claudedocs}/. "$dst"` | PASS | FAIL, parser |
| `tar -C ${../claudedocs} -cf - . \| tar -C "$out" -xf -` | PASS | FAIL "as well as" |
| `{ … } // lib.optionalAttrs cond { source = ../claudedocs; }` | PASS | FAIL, parser |
| a `let` name declared twice (shadowing) | PASS | FAIL, parser |
| `cp -R ${pkgs.someOtherTree}/. "$out"` | PASS | FAIL, parser |
| `rm -rf "$out"/clickup/node_modules` (quote before the slash) | **FAIL** | PASS |
| `cp -R ${../claude/skills} "${out}"` | **FAIL** | PASS |
| `tar -C ${../claude/skills} -cf - . \| tar -C "$out" -xf -` | **FAIL** | PASS |

`#` is a comment at line start or after whitespace and nowhere else — blanking every one to end-of-line ate the `}` out of `"''${bbOld##*.}"` and unbalanced the braces the attrset scan counts. Measured on the real file: **345/345 braces raw, 333/332 after stripping.**

## What changed

- The source is read from the mapping's **own** syntax — `."…".source = <expr>;` or `."…" = { source = <expr>; }` — and nothing else is guessed at. Sources that **disagree** are undecidable; several occurrences that agree (one entry written as two dotted attributes) are fine.
- `src`/`srcs`/`paths` count as writing the output root; one further hop of let-indirection is followed.
- The 200-character proximity window is replaced by **statement** scoping, which also makes the destination legible: `$out` itself replaces the tree, `$out/sub` adds to it. `|` and `&&` are **not** separators — a pipeline is one write.
- Because statement scoping cannot see `cd "$out"`, every repo path in a binding must come out **accounted for**; one that is neither a root write nor a write under the root is reported, not dropped.
- Where it cannot decide — an unreadable source expression, an opaque expression over the root, a shadowed name, malformed nix — it **fails saying the parser needs updating and must not be deleted**. `None` is the answer it must never give by accident.

The property is not softened: every widened shape has a wrong-tree twin fixture that must still fail.

## Mutant matrix

Two sweeps, built differently, because a hand-built sweep only covers the mutants I imagined. Fixtures: **14 → 54**.

**Sweep A — 24 hand-written mutants, no deletions.** Each asserts the *expected* test goes red, so a mutant killed only by some other guard is reported as such.

| mutant | kind | result |
|---|---|---|
| M0 control (no-op) | — | **0 failures** (harness can be quiet) |
| M1 root/under inverted | invert a branch | KILLED, expected test red |
| M2 paths/opaque unpacked backwards | swap operands | KILLED, expected |
| M3 dotted branch `if False:` | clause dead, text present | KILLED, expected |
| M4 per-statement → whole-body paths | stale rebind | KILLED, expected |
| M5 binding indent `<=` → `<` | off-by-one | KILLED, expected |
| M6 brace scan starts +1 | off-by-one | KILLED, expected |
| M7 `"$out/."` dropped from the root set | clause commented out | KILLED, expected |
| M8 path normalisation dead | clause commented out | KILLED, expected |
| M9 `_OUT_REF` quote dropped | operand narrowed | KILLED, expected |
| M10 `paths` → `path` | operand swap | KILLED, expected |
| M11 root scope inverted | invert a branch | KILLED, expected |
| M12 undecidable → `return None` | invert the verdict | KILLED, expected |
| M13 no comment strip | rebind | KILLED, expected |
| M14 `depth == 0` → `!= 0` | invert a comparison | KILLED, expected |
| M15 comment lookbehind dropped | widen a lookbehind | KILLED, expected |
| M16 `_ATTR_WORD` eats path parts | widen a lookbehind | KILLED, expected |
| M17 additions stop explaining a path | swap operands | KILLED, expected |
| M18 first source wins again | clause commented out | KILLED, expected |
| M19 shadow count `> 1` → `> 2` | off-by-one | KILLED, expected |
| M20 `//` → `///` | operand swap | KILLED, expected |
| M21 `${out}` not skipped | rebind | KILLED, expected |
| M22 opaque dropped again | clause commented out | KILLED, expected |
| M23 split on `\|`/`&` again | operand widened | KILLED, expected |
| M24 attr-name probe inverted | invert a branch | KILLED, expected |

**24/24 killed with the expected assertion red.**

**Sweep B — 54 mutants enumerated mechanically** (every `in`/`not in`, `and`/`or`, `<=`/`<`, `==`/`!=`, `\|=`/`&=`, True/False token via `tokenize`, so no docstring is touched; plus every problem-returning `return` turned into `return None`): **39 killed, 0 survived, 15 unrunnable** (all `for x in` → `for x not in`, i.e. `SyntaxError`).

Sweep B earned its keep three times: it found the brace-scan mutant that no fixture could tell apart (now `test_a_sourceless_mapping_does_not_borrow_a_siblings_source`), a dead `additions` accumulator and an unreachable identifier channel (both removed), and four unfixtured malformed-nix branches. It also caught **itself** lying first: a same-size mutation rewritten inside the same second left a cached `.pyc` valid, so mutants never executed and reported as survivors — one "survivor" was hand-checked and actually killed 25 tests. Both sweeps now sweep `__pycache__` and set `PYTHONDONTWRITEBYTECODE`.

Three of the wrong-tree twin fixtures also pass on the pre-fix parser. They are **invariant guards on the widening**, not regression coverage for the shipped defect, and are labelled as such.

## Gate

- Real `nix/home.nix` still passes the guard (its mapping is correct and verified live).
- `nix build .#checks.x86_64-linux.pytests` — **rc 0**, `TOTAL collected=9398 passed=9397 skipped=1 failed=0`, `RESULT: PASS (exit=0)`.
- `nix build .#checks.x86_64-linux.nodetests` — **rc 0**, `tests=1097 pass=1097 fail=0`.
- `scripts/gate.sh --tier both --set all` — **rc 0**, both tiers `RESULT: PASS (exit=0)`.
- **Merged-tree gate.** `origin/main` moved three times during this work (`6eaeb61` → `a8f8426` → `23bc6f4`). A fresh worktree off `23bc6f4` with this branch merged in: full gate **rc 0** both tiers, both nix checks **rc 0**. Nothing main gained touches `skills_mapping.py`, `home.nix` or `testlib/`, so there is no overlapping region to read for a semantic conflict.

## What I did NOT verify

- **No `home-manager switch` and no `ship.sh`** — out of scope and explicitly excluded. This changes a test-only predicate; nothing under `nix/` moved, so no deployed artifact changes.
- **`claude/skills/clickup/test/smoke-test.mjs` was not run** (live writes to a real ClickUp workspace). The node tier runs `*.test.mjs` only, so it never reaches it.
- **Two known limits are documented in the module, not fixed.** `src`/`srcs`/`paths` are matched by NAME, not by POSITION, so a `src` sitting in a `runCommandLocal` **env** attribute set is still credited as the output tree — a constructible false all-clear. And a repo path the parser cannot classify fails asking for the parser, which rejects some legitimate-but-unusual builds; that direction is deliberate, since the alternative is `cd "$out"` aliasing passing in silence.
- **This reads text, not nix.** `nix eval` is the only thing that actually knows what a `home.file` source resolves to; every guarantee here is about the shapes fixtured above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
