### PR TITLE
fix(handoff): the /resume prefix did not survive a dispatched agent, so the index read moves into the doc

### DIFF
--- a/claude/skills/handoff/SKILL.md
+++ b/claude/skills/handoff/SKILL.md
@@ -24,6 +24,16 @@ Topic argument (optional): `$ARGUMENTS`. If empty, infer a short kebab-case topi
    ```markdown
    # Handoff: <topic> — <YYYY-MM-DD>
 
+   ## Run this first — the index, one read-only command
+   ```bash
+   python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py --repo <repo>
+   ```
+   Terse pointers this doc does not carry, curated by past sessions and outliving it.
+   🔴 RECALL, NOT LIVE OBSERVATION — every line is a pointer to VERIFY, never a current
+   reading, and it may describe a gotcha already fixed. `scope-absent`/`scope-empty` means
+   nothing is recorded yet: ordinary, not an error, and not a clean bill of health.
+   Non-blocking: if it exits non-zero, print the stderr line and carry on.
+
    ## Goal
    What we're trying to achieve and why (1–3 lines).
 
@@ -59,7 +69,11 @@ Topic argument (optional): `$ARGUMENTS`. If empty, infer a short kebab-case topi
    <one-line of the single most important next action>
    ```
 
-   🔴 **The block MUST begin with a literal `/resume`, and that is not decoration.** MEASURED 2026-08-13: a kickoff emitted as plain prose (`Continue the <topic> work. Canonical handoff (read first): …`) was pasted into the next session, and that session made **zero** calls to `subsystem_recall.py` / `subsystem_touch.py` — `/resume` was never invoked and the skill did **not** auto-fire, despite "pick up where we left off" matching its description almost verbatim. So `/resume` step 4 — the index READ — never ran, and the entry written by *this* step an hour earlier, describing the very subsystem that session was working on, was never seen. A kickoff that only *points at* a doc gets the doc read and the index skipped. Typing the command is what makes the read deterministic instead of luck.
+   🔴 **The block MUST begin with a literal `/resume`, and that is not decoration.** MEASURED 2026-08-13: a kickoff emitted as plain prose (`Continue the <topic> work. Canonical handoff (read first): …`) was pasted into the next session, and that session made **zero** calls to `subsystem_recall.py` / `subsystem_touch.py` — `/resume` was never invoked and the skill did **not** auto-fire, despite "pick up where we left off" matching its description almost verbatim. So `/resume` step 4 — the index READ — never ran, and the entry written by *this* step an hour earlier, describing the very subsystem that session was working on, was never seen. A kickoff that only *points at* a doc gets the doc read and the index skipped.
+
+   🔴 **CORRECTED 2026-08-13, same day: the `/resume` prefix is NOT sufficient, and the claim that "typing the command makes the read deterministic" was wrong.** Re-measured against a DISPATCHED agent given the new `/resume`-prefixed kickoff verbatim and nothing else: **zero `Skill` tool calls, zero `subsystem_recall.py` executions** — behaviourally identical to the prose kickoff it replaced. It read the doc, oriented, and went straight to the named next step. A subagent receives the kickoff as prompt TEXT — there is no CLI slash-command parsing on that path — so a leading `/resume —` reads as a topic label, and the clause after it is a perfectly actionable instruction on its own. This is not a corner case: dispatching implementation to a subagent is the standing default here.
+
+   **So the deterministic hook is step 2's doc, not this block.** Both measured sessions read the handoff doc first, immediately, before anything else — that is the reliable behaviour, so the index command lives at the TOP OF THE DOC where reading it leads into running it. Keep the `/resume` prefix: it costs nothing and does work in an interactive session, where the CLI parses it before the model sees it. Just do not rely on it alone.
 
    🔴 **Emit this BEFORE step 4's confirm gate, unconditionally.** The kickoff block is the deliverable; step 4 blocks on a y/N, and a user who walks away from that prompt must still have got it.
 

--- a/claudedocs/handoff-subsystem-store.md
+++ b/claudedocs/handoff-subsystem-store.md
@@ -1,5 +1,16 @@
 # Handoff: subsystem-store — 2026-08-13
 
+## Run this first — the index, one read-only command
+```bash
+python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py --repo ~/workspace/devrc
+```
+Terse pointers this doc does not carry, curated by past sessions and outliving it — the
+`devrc/subsystem-index` entry describes the very tooling below. 🔴 RECALL, NOT LIVE
+OBSERVATION: every line is a pointer to VERIFY, never a current reading, and it may describe
+a gotcha already fixed. Non-blocking — if it exits non-zero, print the stderr line and carry
+on. **Two measured sessions skipped this because it was only reachable via `/resume`; it is
+here because reading this doc is the one thing both of them did first.**
+
 ## Goal
 A durable store for subsystem data + history with clean Claude Code integration.
 **Built, deployed, verified end to end.** The read half is now cheap enough to run every


### PR DESCRIPTION
## Correcting my own fix from earlier today

#446 made the kickoff block begin with a literal `/resume`, and recorded the claim that *"typing the command is what makes the read deterministic instead of luck."*

**That claim is false**, re-measured the same day against a **dispatched agent** handed the new `/resume`-prefixed kickoff verbatim and nothing else:

```
Skill tool calls:             NONE
subsystem_recall executions:  0
first action:                 Read the handoff doc, then straight to git recon
```

Behaviourally identical to the prose kickoff it replaced. A subagent receives the kickoff as prompt **text** — there is no CLI slash-command parsing on that path — so a leading `/resume —` reads as a topic label, and the clause after it (*"continue the … work. Canonical handoff (read first): …"*) is a perfectly actionable instruction on its own.

The measurement is the same one that caught the original failure: parse the transcript for `Skill` tool calls and for Bash commands that actually *execute* the index tools. Counting string mentions is not the measurement — the failing session had 7 incidental `subsystem_recall` mentions and 0 executions.

## Why this is not a corner case

Dispatching implementation to a subagent is the standing default in this repo; this arc alone ran five. So a whole class of continuations would never pull index context regardless of how the kickoff is worded.

## The fix: put the hook where the reliable behaviour already is

**Both** measured sessions read the handoff doc first, immediately, before anything else. That is the dependable step. So the index command now sits at the **top of the doc** — in step 2's template and in this arc's live doc — where reading leads into running:

```markdown
## Run this first — the index, one read-only command
```bash
python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py --repo <repo>
```
```

carrying the 🔴 RECALL-not-live-observation framing, the `scope-absent`/`scope-empty` "ordinary, not an error" note, and the non-blocking rule.

**The `/resume` prefix stays.** It costs nothing and does work interactively, where the CLI parses it before the model sees it. It is simply no longer relied on alone. The retraction sits beside the original claim rather than replacing it, so the reasoning survives.

## Verification

Markdown only; no behaviour change to any tool.

Positive control — the command as written in the doc runs clean: `rc=0`, `status=recalled`, `ALL 2 entries`.

Pins checked (with `grep -F`; `**` is a regex quantifier and my first check errored rather than returning a count):
- `**Output a kickoff block**`
- `The kickoff block is the deliverable`
- `A bullet that adds nothing to what is on screen ⇒ propose nothing`
- `Decline on CONTENT, never on cost`
- ordering `kickoff < index-step < confirm-gate`

Gate on the pushed commit:

```
TOTAL collected=9429  passed=9428  skipped=1  failed=0
PASS  scripts/tests  (collected=3866 passed=3866 skipped=0 floor=3725)
RESULT: PASS (exit=0)
```

No floor change from this branch (3725 came in with #453).

## Still unverified, stated plainly

This is untested in the way the last fix was: it has not survived contact with a real continuation. The difference is that the hook now rests on **measured** behaviour — doc-read-first, observed in both sessions — rather than on a routing mechanism I assumed. The next kickoff-driven session should be measured the same way before this is called closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)