### PR TITLE
fix(skills-mapping): the source-resolution half never caught a breakage and its one firing was a false positive — cut the guard 8,846 B -> 3,996 B

### DIFF
--- a/scripts/testlib/skills_mapping.py
+++ b/scripts/testlib/skills_mapping.py
@@ -1,217 +1,97 @@
-"""One place that answers "does nix/home.nix actually deploy `claude/skills/`?".
+"""Is the `~/.claude/skills` mapping DECLARED — and not switched off?
 
-WHY THIS EXISTS
----------------
-Three test modules (test_subsystem_recall, test_subsystem_resolver,
-test_subsystem_touch) each pin a SKILL.md and then check that the file they
-pinned is the one that SHIPS -- otherwise the pin is a claim about a file
-nothing deploys. All three asked the same question with the same open-coded
-substring::
+SCOPE — HALF THE PROPERTY, ON PURPOSE
+-------------------------------------
+Four test modules pin SKILL.md files under `claude/skills/` so the pins are
+claims about files that SHIP. This answers only the cheap half:
 
-    assert 'home.file.".claude/skills"' in home_nix
-    assert "source = ../claude/skills;" in home_nix
+  * `home.file.".claude/skills"` exists and names a `source`;
+  * it is not neutered by `enable = false` or a redirected `target` — the two
+    smallest edits that stop the deploy while the mapping still reads fine.
 
-That second line is a SPELLED guard, not a structural one: it pins how the
-source is written, not what it resolves to. When the mapping's source became a
-derivation built FROM `../claude/skills` (`claudeSkills`, which injects the
-clickup skill's nix-built node_modules into the store copy -- node resolves
-modules from the REALPATH, so a node_modules symlink at the deployed path is
-invisible), the deployment property was unchanged and all three went red.
+🔴 It does NOT trace what the `source` RESOLVES to, and must not grow that back.
+Following it (the source is a derivation built from `../claude/skills`) meant
+`$out` analysis, `cp`/`rm` parsing, let-binding resolution and comment
+stripping — heuristics that still admitted constructible false ALL-CLEARs, and
+whose only firing ever was a FALSE POSITIVE. That half is checked against
+REALITY, on both hosts, at the moment it matters: `scripts/ship.sh` prints
+`✅ managed artifacts resolve — N checked, 0 dangling, 0 absent` on every deploy
+and `scripts/drift-check.sh` reports the same passively (rc 14). Those stat the
+real filesystem; a text parser re-deriving it from nix source is strictly worse
+and always will be.
 
-Three copies of one predicate is three chances to fix it differently. This is
-the predicate, once. It accepts either shape and, for the indirection, insists
-the binding is genuinely built from `../claude/skills` -- so a source pointed at
-some UNRELATED tree still fails, which is the case the original was defending
-against.
-
-WHY IT IS NOT JUST A SUBSTRING SEARCH ANY MORE
-----------------------------------------------
-The first version of the indirect check was ``"../claude/skills" not in
-_binding_body(...)`` -- weaker than the three open-coded assertions it replaced,
-in three specific ways an audit named:
-
-  * it read COMMENTS. A binding that copies ``${../claudedocs}`` and merely
-    mentions ``../claude/skills`` in a ``#`` note satisfied it.
-  * it read DEAD CODE, for the same reason.
-  * it never asked what the path was DOING there. A binding that copies the
-    skills tree, then ``rm -rf "$out"`` and copies something else over it,
-    contains the string throughout and deploys none of it.
-
-So the body is comment-stripped first, and the path has to be used as a SOURCE
-INTO ``$out`` -- with no other repo tree copied there, and no removal of
-``$out``. That is still structural (it says nothing about how the copy is
-spelled, and the real binding's ``ln -sT ${clickupNodeModules}/...`` passes
-untouched); it just stops treating "the characters appear somewhere" as proof.
+HOW
+---
+`nix-instantiate --eval` on the real file, so NIX answers the structural
+questions — dotted vs attrset form, comments, where the attribute nests. What
+nix cannot evaluate FAILS loudly as "needs updating"; nothing passes silently.
 """
 from __future__ import annotations
 
-import re
+import json
+import shutil
+import subprocess
+from pathlib import Path
 
 MAPPING = 'home.file.".claude/skills"'
 
-#: The repo path the mapping must ultimately deploy.
-SKILLS_PATH = "../claude/skills"
+#: home-manager's default `target` is the attribute name itself.
+TARGET = ".claude/skills"
 
-#: The direct form: `source = ../claude/skills;` inside the mapping.
-_DIRECT = re.compile(r"source\s*=\s*\.\./claude/skills\s*;")
+#: `config`/`pkgs`/`lib` are stubs: nix is lazy, so nothing outside this one
+#: attribute is forced, and a stub that IS forced fails closed.
+_EXPR = """
+let fs = (import @PATH@ { config = {}; pkgs = {}; lib = {}; }).home.file or {};
+    m = fs.".claude/skills" or {};
+in { declared = fs ? ".claude/skills";
+     source = m ? source;
+     enable = m.enable or true;
+     target = m.target or ".claude/skills"; }
+"""
 
-#: The indirect form: `source = <ident>;` where <ident> is a let-binding whose
-#: definition mentions `../claude/skills`.
-_INDIRECT_SOURCE = re.compile(r"source\s*=\s*([A-Za-z_][A-Za-z0-9_'-]*)\s*;")
-
-
-def _mapping_block(home_nix: str) -> str:
-    """The `home.file.".claude/skills" = { … };` block, or "" if absent."""
-    start = home_nix.find(MAPPING)
-    if start == -1:
-        return ""
-    open_brace = home_nix.find("{", start)
-    if open_brace == -1:
-        return ""
-    depth = 0
-    for i in range(open_brace, len(home_nix)):
-        if home_nix[i] == "{":
-            depth += 1
-        elif home_nix[i] == "}":
-            depth -= 1
-            if depth == 0:
-                return home_nix[open_brace : i + 1]
-    return ""
+_FIX_IT = (
+    "so this check cannot answer it. FIX THE CHECK — do NOT delete it: without "
+    "it, every SKILL.md pin under claude/skills/ silently stops being a claim "
+    "about a deployed file."
+)
 
 
-#: A `let`-binding head: `  name =` at some indentation.
-_BINDING_HEAD = re.compile(r"^(\s*)([A-Za-z_][A-Za-z0-9_'-]*)\s*=")
-
-#: A nix path interpolation into a build script: `${../claude/skills}`.
-_PATH_INTERP = re.compile(r"\$\{\s*(\.{1,2}/[^}\s]+?)\s*\}")
-
-#: Anything that writes the output tree: `"$out"`, `$out/x`, `${out}`.
-_OUT_REF = re.compile(r"\$\{?out\b")
-
-#: `rm`/`rmdir` aimed at $out. A binding that empties its own output and then
-#: fills it from somewhere else contains every string this predicate looks for.
-_RM_OUT = re.compile(r"\brm(?:dir)?\b[^\n;]*\$\{?out\b")
-
-#: How far from a path interpolation a `$out` reference still counts as "this
-#: path is being copied into the output". Wide enough for a `\`-continued
-#: command, narrow enough that two unrelated statements are not conflated.
-_NEAR = 200
-
-
-def _strip_comments(text: str) -> str:
-    """Remove nix `#` line comments and `/* … */` blocks.
-
-    Both a nix comment and a SHELL comment inside a `''…''` build script are
-    handled by the same rule, which is what we want: nix interpolates
-    `${../claude/skills}` inside a `''…''` string even on a line the shell will
-    treat as a comment, so "the path appears" and "the path is used" are
-    different questions there too.
-    """
-    text = re.sub(r"/\*.*?\*/", " ", text, flags=re.S)
-    return re.sub(r"#[^\n]*", "", text)
-
-
-def _trees_copied_into_out(body: str) -> set[str]:
-    """Repo paths interpolated near a `$out` reference — i.e. copied in."""
-    out: set[str] = set()
-    for m in _PATH_INTERP.finditer(body):
-        lo = max(0, m.start() - _NEAR)
-        hi = min(len(body), m.end() + _NEAR)
-        if _OUT_REF.search(body[lo:hi]):
-            out.add(m.group(1))
-    return out
-
-
-def _binding_body(home_nix: str, ident: str) -> str:
-    """The text of the `let` binding named `ident`.
-
-    Delimited STRUCTURALLY -- from the binding's head to the next head at the
-    same-or-shallower indentation, or to `in` -- rather than by hunting for a
-    terminating `;`, which a multi-line nix string (`''…''`) makes unreliable.
-    Returns "" when there is no such binding.
-    """
-    lines = home_nix.splitlines()
-    start = None
-    indent = ""
-    for i, line in enumerate(lines):
-        m = _BINDING_HEAD.match(line)
-        if m and m.group(2) == ident:
-            start = i
-            indent = m.group(1)
-            break
-    if start is None:
-        return ""
-    body = [lines[start]]
-    for line in lines[start + 1 :]:
-        if re.match(r"^in\b", line):
-            break
-        m = _BINDING_HEAD.match(line)
-        if m and len(m.group(1)) <= len(indent):
-            break
-        body.append(line)
-    return "\n".join(body)
-
-
-def skills_mapping_problem(home_nix: str) -> str | None:
-    """Return a failure reason, or None when the mapping deploys claude/skills.
-
-    Structural on purpose: it reads the mapping's `source` and follows one level
-    of let-binding indirection, rather than matching how the line is spelled.
-    """
-    if MAPPING not in home_nix:
+def skills_mapping_problem(home_nix: Path | str) -> str | None:
+    """A failure reason, or None when the mapping is declared and live."""
+    home_nix = Path(home_nix)
+    if not home_nix.is_file():
+        return f"{home_nix} is not a file, {_FIX_IT}"
+    if shutil.which("nix-instantiate") is None:
+        return f"nix-instantiate is not on PATH, {_FIX_IT}"
+    p = subprocess.run(
+        ["nix-instantiate", "--eval", "--strict", "--json",
+         "-E", _EXPR.replace("@PATH@", str(home_nix.resolve()))],
+        capture_output=True, text=True, timeout=180,
+    )
+    if p.returncode != 0:
+        return f"nix cannot evaluate {home_nix}, {_FIX_IT}\n{p.stderr.strip()[-600:]}"
+    m = json.loads(p.stdout)
+    if not m["declared"]:
         return (
-            "nix/home.nix no longer declares the ~/.claude/skills mapping, so a "
-            "doc pinned under claude/skills/ may not ship at all."
+            f"nix/home.nix no longer declares {MAPPING} — nothing deploys "
+            "claude/skills/, so docs pinned under it may not ship at all."
         )
-    block = _strip_comments(_mapping_block(home_nix))
-    if not block:
+    if not m["source"]:
+        return f"{MAPPING} declares no `source =`, so it deploys nothing."
+    if m["enable"] is not True:
         return (
-            f"found {MAPPING} but could not read its attribute set -- this parser "
-            "needs updating, do NOT delete the check."
+            f"{MAPPING} is switched OFF (`enable = {json.dumps(m['enable'])}`): "
+            "declared, and deployed by nothing."
         )
-    if _DIRECT.search(block):
-        return None
-    m = _INDIRECT_SOURCE.search(block)
-    if not m:
+    if m["target"] != TARGET:
         return (
-            f"the {MAPPING} mapping declares no `source =` at all:\n{block}"
-        )
-    ident = m.group(1)
-    body = _strip_comments(_binding_body(home_nix, ident))
-    if not body:
-        return (
-            f"the ~/.claude/skills mapping sources `{ident}`, but there is no such "
-            "let-binding in nix/home.nix -- nothing resolves the deployed tree."
-        )
-    # Not "the characters appear somewhere in the binding" -- the path has to be
-    # COPIED INTO the output. Comments and dead code are already gone above.
-    copied = _trees_copied_into_out(body)
-    if SKILLS_PATH not in copied:
-        return (
-            f"the ~/.claude/skills mapping sources `{ident}`, but that binding never "
-            f"copies {SKILLS_PATH} into $out (it writes: "
-            f"{sorted(copied) or 'no repo tree at all'}) -- the pinned docs are not "
-            "the deployed files."
-        )
-    others = sorted(copied - {SKILLS_PATH})
-    if others:
-        return (
-            f"the `{ident}` binding copies {others} into $out as well as "
-            f"{SKILLS_PATH}. A second tree written over the same output decides what "
-            "actually ships, and the pins under claude/skills/ stop being claims "
-            "about the deployed files."
-        )
-    rm = _RM_OUT.search(body)
-    if rm:
-        return (
-            f"the `{ident}` binding removes its own output (`{rm.group(0).strip()}`). "
-            f"A binding that copies {SKILLS_PATH} and then empties $out contains every "
-            "string this check looks for and deploys none of it."
+            f"{MAPPING} redirects `target` to {m['target']!r}: claude/skills/ "
+            f"lands at ~/{m['target']}, not ~/{TARGET}."
         )
     return None
 
 
-def assert_skills_mapping_deploys_repo_skills(home_nix: str) -> None:
-    """Raise AssertionError unless nix/home.nix deploys devrc/claude/skills."""
+def assert_skills_mapping_declared(home_nix: Path | str) -> None:
+    """Raise AssertionError unless nix/home.nix declares a live skills mapping."""
     problem = skills_mapping_problem(home_nix)
     assert problem is None, problem

--- a/scripts/tests/test_skills_mapping_guard.py
+++ b/scripts/tests/test_skills_mapping_guard.py
@@ -1,20 +1,22 @@
-"""Controls for `testlib.skills_mapping` — the shared "does nix actually deploy
-claude/skills?" predicate that three subsystem test modules rest on.
+"""Controls for `testlib.skills_mapping` — "is the ~/.claude/skills mapping
+DECLARED, and not switched off?", the whole of what that predicate now claims.
 
-WHY THIS EXISTS
----------------
-The predicate is what makes those modules' SKILL.md pins claims about the
-DEPLOYED file rather than about a path in the repo. It used to be three
-open-coded copies of ``"source = ../claude/skills;" in home_nix`` — a SPELLED
-guard: it pinned how the source is written, not what it resolves to. It went red
-for a change that did not touch the property (the source became a derivation
-built from that path, injecting the clickup skill's nix-built node_modules into
-the store copy).
+WHAT CHANGED, AND WHY THESE CONTROLS SHRANK WITH IT
+---------------------------------------------------
+The predicate used to also trace whether the mapping's `source` RESOLVED to the
+repo tree — `$out` analysis, `cp`/`rm` parsing, let-binding resolution, comment
+stripping. That half is GONE on purpose (see the module docstring): it never
+caught a real breakage, its only firing was a false positive, and the deployed
+truth is measured against the real filesystem on both hosts by `ship.sh` /
+`drift-check.sh`. So the fixtures that pinned it (wrong tree, `rm $out`, second
+tree copied over, dead shell code) are gone too — a control for a check that no
+longer exists is a claim about nothing.
 
-A predicate that is now permissive enough to accept an indirection has to be
-shown it can still REJECT. So: the real home.nix must pass, and each way of
-actually breaking the deployment must fail — including the one the loosening
-could plausibly have let through, a source bound to an unrelated tree.
+What remains must still be shown able to go RED. Each fixture below is a
+one-edit break of the deployment: the mapping deleted, its `source` deleted,
+`enable = false`, a redirected `target`. Two of them are written in DOTTED form
+on purpose — nix's own parser merges those into the same attrset, which is the
+lexical hole a regex over the raw text would have.
 """
 from __future__ import annotations
 
@@ -28,321 +30,177 @@ from testlib.skills_mapping import skills_mapping_problem  # noqa: E402
 
 HOME_NIX = ROOT / "nix" / "home.nix"
 
-DIRECT = '''
+# Every fixture is a home-manager module function, like the real file.
+REAL_SHAPE = """{ ... }:
 {
+  home.file.".claude/RULES.md" = { source = ../claude/RULES.md; force = true; };
   home.file.".claude/skills" = {
     source = ../claude/skills;
     recursive = true;
     force = true;
   };
+  home.file.".claude/skills/close-the-loop/STATE.md".source = ../x/STATE.md;
 }
-'''
+"""
 
-INDIRECT = '''
+DOTTED = """{ ... }:
 {
-let
-  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
-    cp -R ${../claude/skills} "$out"
-  \'\';
-in
-  home.file.".claude/skills" = {
-    source = claudeSkills;
-    recursive = true;
-    force = true;
-  };
+  home.file.".claude/skills".source = ../claude/skills;
+  home.file.".claude/skills".recursive = true;
 }
-'''
+"""
 
-WRONG_TREE = '''
-{
-let
-  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
-    cp -R ${../claudedocs} "$out"
-  \'\';
-in
-  home.file.".claude/skills" = {
-    source = claudeSkills;
-    recursive = true;
-    force = true;
-  };
-}
-'''
-
-NO_MAPPING = '''
+NO_MAPPING = """{ ... }:
 {
   home.file.".claude/PRINCIPLES.md".source = ../claude/PRINCIPLES.md;
 }
-'''
+"""
 
-NO_SOURCE = '''
+NO_SOURCE = """{ ... }:
 {
-  home.file.".claude/skills" = {
-    recursive = true;
-    force = true;
-  };
+  home.file.".claude/skills" = { recursive = true; force = true; };
 }
-'''
+"""
 
-# The real binding's shape: a second store path is symlinked in by IDENT, which
-# is not a repo tree and must not be mistaken for one.
-WITH_INJECTION = '''
-{
-let
-  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
-    cp -R ${../claude/skills} "$out"
-    chmod -R u+w "$out"
-    ln -sT ${clickupNodeModules}/node_modules "$out/clickup/node_modules"
-  \'\';
-in
-  home.file.".claude/skills" = {
-    source = claudeSkills;
-    recursive = true;
-    force = true;
-  };
-}
-'''
-
-# A `\`-continued copy: the path and the $out reference are on DIFFERENT lines.
-CONTINUED = '''
-{
-let
-  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
-    cp -R \\
-      ${../claude/skills} \\
-      "$out"
-  \'\';
-in
-  home.file.".claude/skills" = {
-    source = claudeSkills;
-  };
-}
-'''
-
-# --- the three ways the OLD substring check was too weak -------------------
-
-#: Mentions the path in a nix COMMENT while copying somewhere else.
-COMMENT_ONLY = '''
-{
-let
-  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
-    # was: cp -R ${../claude/skills} "$out"
-    cp -R ${../claudedocs} "$out"
-  \'\';
-in
-  home.file.".claude/skills" = {
-    source = claudeSkills;
-  };
-}
-'''
-
-#: Mentions it in a SHELL comment inside the build script -- dead code that nix
-#: still interpolates, so even a "does the path resolve" check would be fooled.
-SHELL_COMMENT_ONLY = '''
-{
-let
-  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
-    cp -R ${../claudedocs} "$out"
-    # keep for reference: ${../claude/skills}
-  \'\';
-in
-  home.file.".claude/skills" = {
-    source = claudeSkills;
-  };
-}
-'''
-
-#: Copies the right tree, then empties $out and substitutes another.
-RM_AND_SUBSTITUTE = '''
-{
-let
-  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
-    cp -R ${../claude/skills} "$out"
-    rm -rf "$out"
-    cp -R ${../claudedocs} "$out"
-  \'\';
-in
-  home.file.".claude/skills" = {
-    source = claudeSkills;
-  };
-}
-'''
-
-#: Copies a SECOND repo tree over the same output, without removing anything.
-SECOND_TREE = '''
-{
-let
-  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
-    cp -R ${../claude/skills} "$out"
-    cp -R ${../claudedocs}/. "$out"
-  \'\';
-in
-  home.file.".claude/skills" = {
-    source = claudeSkills;
-  };
-}
-'''
-
-#: Copies the right tree and then empties $out, with NO second tree involved.
-#: Needed as a distinct fixture so the `rm $out` check is REACHABLE: in
-#: RM_AND_SUBSTITUTE the second-tree check fires first, so that fixture alone
-#: would leave the removal check untested behind an earlier guard.
-RM_ONLY = '''
-{
-let
-  claudeSkills = pkgs.runCommandLocal "devrc-claude-skills" { } \'\'
-    cp -R ${../claude/skills} "$out"
-    rm -rf "$out"
-    mkdir -p "$out"
-  \'\';
-in
-  home.file.".claude/skills" = {
-    source = claudeSkills;
-  };
-}
-'''
-
-#: A source bound to an ident that has no binding at all.
-DANGLING_IDENT = '''
+DISABLED = """{ ... }:
 {
   home.file.".claude/skills" = {
-    source = somethingUndefined;
+    source = ../claude/skills;
+    enable = false;
     recursive = true;
   };
 }
-'''
+"""
+
+# The dotted-form hole: the `enable = false` is nowhere near the block it kills.
+DISABLED_ELSEWHERE = """{ ... }:
+{
+  home.file.".claude/skills" = { source = ../claude/skills; recursive = true; };
+  home.file.".claude/PRINCIPLES.md".source = ../claude/PRINCIPLES.md;
+  home.file.".claude/skills".enable = false;
+}
+"""
+
+REDIRECTED = """{ ... }:
+{
+  home.file.".claude/skills" = {
+    source = ../claude/skills;
+    target = ".claude/skills-off";
+    recursive = true;
+  };
+}
+"""
+
+#: Not valid nix. Stands in for every shape this check cannot decide.
+UNPARSEABLE = """{ ... }:
+{
+  home.file.".claude/skills" = { source = ;
+}
+"""
+
+
+def write(tmp_path: Path, body: str) -> Path:
+    """A fixture module on disk. The `source` paths need not exist: nix is lazy
+    and this predicate asks whether `source` is DECLARED, never what it is."""
+    p = tmp_path / "home.nix"
+    p.write_text(body, encoding="utf-8")
+    return p
 
 
 # --------------------------------------------------------------------------
-# POSITIVE: the shipped file, and both accepted shapes.
+# POSITIVE: the shipped file, and the two spellings of a live mapping.
 # --------------------------------------------------------------------------
 
 def test_the_real_home_nix_passes():
     """The load-bearing case: whatever nix/home.nix says today must satisfy it.
 
     If this goes red, either the mapping stopped deploying claude/skills (fix
-    nix) or the parser stopped understanding it (fix the parser) — do NOT relax
-    the predicate to make it green, or the three modules that call it go back to
+    nix) or this check stopped understanding the file (fix the check) — do NOT
+    relax it, and do NOT delete it, or the four modules that call it go back to
     pinning docs nothing ships.
     """
-    assert skills_mapping_problem(HOME_NIX.read_text(encoding="utf-8")) is None
+    assert skills_mapping_problem(HOME_NIX) is None
 
 
-def test_the_direct_form_passes():
-    assert skills_mapping_problem(DIRECT) is None
+def test_the_attrset_form_with_unrelated_attributes_passes(tmp_path):
+    """`force`/`recursive` and sibling `home.file` entries are not a problem."""
+    assert skills_mapping_problem(write(tmp_path, REAL_SHAPE)) is None
 
 
-def test_the_indirect_form_passes():
-    """A source bound to a derivation BUILT from ../claude/skills."""
-    assert skills_mapping_problem(INDIRECT) is None
+def test_the_dotted_form_passes(tmp_path):
+    """`home.file."…".source = …;` is the same mapping, differently spelled."""
+    assert skills_mapping_problem(write(tmp_path, DOTTED)) is None
 
 
 # --------------------------------------------------------------------------
-# NEGATIVE CONTROLS: it must still be able to go red, for each real breakage.
+# NEGATIVE CONTROLS: one edit each, and each must go red for its OWN reason.
 # --------------------------------------------------------------------------
 
-def test_a_source_built_from_an_unrelated_tree_fails():
-    """The case the loosening could have let through.
+def test_a_missing_mapping_fails(tmp_path):
+    problem = skills_mapping_problem(write(tmp_path, NO_MAPPING))
+    assert problem is not None, (
+        "home.nix with NO ~/.claude/skills mapping was accepted — the predicate "
+        "is wired to nothing and its passes mean nothing"
+    )
+    assert "no longer declares" in problem, problem
 
-    Accepting `source = <ident>;` is only safe while the binding is checked. A
-    mapping sourcing a derivation built from somewhere else deploys a different
-    tree, and every SKILL.md pin under claude/skills/ becomes vacuous.
+
+def test_a_mapping_without_a_source_fails(tmp_path):
+    problem = skills_mapping_problem(write(tmp_path, NO_SOURCE))
+    assert problem is not None, "a mapping with no `source` deploys nothing"
+    assert "no `source =`" in problem, problem
+
+
+def test_a_disabled_mapping_fails(tmp_path):
+    """`enable = false` — declared, deployed by nothing, reads fine."""
+    problem = skills_mapping_problem(write(tmp_path, DISABLED))
+    assert problem is not None, (
+        "`enable = false;` was accepted — one line silently stops the deploy "
+        "while every SKILL.md pin stays green"
+    )
+    assert "switched OFF" in problem, problem
+
+
+def test_a_mapping_disabled_from_a_DOTTED_line_elsewhere_fails(tmp_path):
+    """The lexical hole: a regex reading the block would never see this line.
+
+    nix merges `home.file."…".enable = false;` into the same attrset, so asking
+    nix is what makes the distance between the two lines irrelevant.
     """
-    problem = skills_mapping_problem(WRONG_TREE)
+    problem = skills_mapping_problem(write(tmp_path, DISABLED_ELSEWHERE))
     assert problem is not None, (
-        "a ~/.claude/skills mapping sourced from an UNRELATED tree was accepted — "
-        "the predicate is wired to nothing and its passes mean nothing"
+        "a dotted `enable = false;` outside the mapping block was accepted — "
+        "this check is reading text, not structure"
     )
-    assert "claudeSkills" in problem
+    assert "switched OFF" in problem, problem
 
 
-def test_a_missing_mapping_fails():
-    problem = skills_mapping_problem(NO_MAPPING)
-    assert problem is not None
-    assert "no longer declares" in problem
-
-
-def test_a_mapping_without_a_source_fails():
-    problem = skills_mapping_problem(NO_SOURCE)
-    assert problem is not None
-    assert "no `source =`" in problem
+def test_a_redirected_target_fails(tmp_path):
+    problem = skills_mapping_problem(write(tmp_path, REDIRECTED))
+    assert problem is not None, (
+        "`target = \".claude/skills-off\";` was accepted — the tree ships, just "
+        "not where anything reads it"
+    )
+    assert "redirects `target`" in problem, problem
 
 
 # --------------------------------------------------------------------------
-# POSITIVE, continued: shapes the TIGHTENED predicate must still accept.
-# A guard that rejects the legitimate case gets loosened back, so these matter
-# as much as the negatives below.
+# UNDECIDABLE INPUT MUST FAIL LOUDLY, never pass. This is the whole safety
+# story of a checker this small: it has no fallback heuristics, so anything it
+# cannot answer has to arrive as "fix the check", not as a green.
 # --------------------------------------------------------------------------
 
-def test_a_symlinked_store_path_is_not_mistaken_for_a_second_tree():
-    """`ln -sT ${clickupNodeModules}/… "$out/…"` is the real binding's shape."""
-    assert skills_mapping_problem(WITH_INJECTION) is None
+def test_a_file_nix_cannot_evaluate_fails_and_says_do_not_delete(tmp_path):
+    problem = skills_mapping_problem(write(tmp_path, UNPARSEABLE))
+    assert problem is not None, "an unevaluatable home.nix passed silently"
+    assert "cannot evaluate" in problem, problem
+    assert "do NOT delete it" in problem, problem
 
 
-def test_a_line_continued_copy_passes():
-    """The path and `$out` on different lines is still one copy."""
-    assert skills_mapping_problem(CONTINUED) is None
-
-
-# --------------------------------------------------------------------------
-# NEGATIVE CONTROLS for the three weaknesses of the substring version.
-# Each was ACCEPTED before the tightening: the predicate asked whether the
-# characters `../claude/skills` occurred in the binding, not what they did.
-# --------------------------------------------------------------------------
-
-def test_a_path_named_only_in_a_nix_comment_fails():
-    problem = skills_mapping_problem(COMMENT_ONLY)
-    assert problem is not None, (
-        "a binding that copies ../claudedocs and only MENTIONS ../claude/skills in a "
-        "comment was accepted — the predicate is reading prose as if it were code"
-    )
-    assert "never copies" in problem, problem
-
-
-def test_a_path_named_only_in_dead_shell_code_fails():
-    problem = skills_mapping_problem(SHELL_COMMENT_ONLY)
-    assert problem is not None, (
-        "a binding whose only use of ../claude/skills is a commented-out shell line "
-        "was accepted"
-    )
-    assert "never copies" in problem, problem
-
-
-def test_copying_the_tree_and_then_emptying_out_fails():
-    problem = skills_mapping_problem(RM_AND_SUBSTITUTE)
-    assert problem is not None, (
-        "a binding that copies claude/skills, then `rm -rf \"$out\"` and copies another "
-        "tree over it was accepted — it contains every string the check looks for and "
-        "deploys none of them"
-    )
-    # It must fail for one of the two REAL reasons, not incidentally.
-    assert ("removes its own output" in problem) or ("as well as" in problem), problem
-
-
-def test_copying_a_second_repo_tree_over_the_output_fails():
-    problem = skills_mapping_problem(SECOND_TREE)
-    assert problem is not None, (
-        "a binding that copies a SECOND repo tree over $out was accepted — whichever "
-        "copy runs last decides what ships"
-    )
-    assert "as well as" in problem, problem
-
-
-def test_emptying_out_after_copying_fails_on_its_own():
-    """REACHABILITY for the `rm $out` check.
-
-    RM_AND_SUBSTITUTE trips the second-tree check first, so it would pass with
-    the removal check deleted — a guard sitting behind an earlier one that
-    always wins. This fixture reaches it: one tree, copied, then removed.
-    """
-    problem = skills_mapping_problem(RM_ONLY)
-    assert problem is not None, (
-        "a binding that copies claude/skills and then `rm -rf \"$out\"` was accepted — "
-        "it deploys an EMPTY tree"
-    )
-    assert "removes its own output" in problem, problem
-
-
-def test_a_source_bound_to_a_nonexistent_ident_fails():
-    problem = skills_mapping_problem(DANGLING_IDENT)
-    assert problem is not None
-    assert "no such let-binding" in problem, problem
+def test_a_path_that_is_not_a_file_fails(tmp_path):
+    """Named as its own failure, not left to nix's "file not found" — a caller
+    passing the wrong thing (the file's TEXT, say) must read as a broken check."""
+    problem = skills_mapping_problem(tmp_path / "absent.nix")
+    assert problem is not None, "a nonexistent home.nix passed silently"
+    assert "is not a file" in problem, problem
+    assert "do NOT delete it" in problem, problem

--- a/scripts/tests/test_subsystem_recall.py
+++ b/scripts/tests/test_subsystem_recall.py
@@ -64,7 +64,7 @@ sys.path.insert(0, str(ROOT / "scripts" / "lib"))
 sys.path.insert(0, str(ROOT / "scripts"))
 
 from testlib.skills_mapping import (  # noqa: E402
-    assert_skills_mapping_deploys_repo_skills,
+    assert_skills_mapping_declared,
 )
 
 import subsystem_recall as rc  # noqa: E402
@@ -3111,12 +3111,11 @@ class TestSkillDocsArePinned:
         assert RESUME_DOC.exists()
         assert RESUME_DOC.name == "SKILL.md"
         assert RESUME_DOC.parent.parent.name == "skills"
-        home_nix = (ROOT / "nix" / "home.nix").read_text(encoding="utf-8")
-        # Structural, and shared with test_subsystem_resolver/_touch — the three
-        # copies of this predicate used to match the LITERAL
-        # `source = ../claude/skills;`, and all three went red together when the
-        # mapping's source became a derivation built from that path.
-        assert_skills_mapping_deploys_repo_skills(home_nix)
+        # Shared with test_subsystem_resolver/_touch. It checks only that the
+        # mapping is DECLARED and not switched off (`enable = false`, redirected
+        # `target`) — whether the source RESOLVES to this tree is measured
+        # against the real filesystem at deploy time by ship.sh/drift-check.sh.
+        assert_skills_mapping_declared(ROOT / "nix" / "home.nix")
 
     # 🔴 THE CONCURRENCY FINDING WAS SPLIT ACROSS TWO FILES, so this pin table is
     # split the same way. Step 4 keeps every IMPERATIVE; the measured evidence
@@ -3260,14 +3259,10 @@ class TestSkillDocsArePinned:
         An untracking mutation is caught in BOTH: the sandbox loses the file,
         the host loses the `ls-files` hit.
         """
-        home_nix = (ROOT / "nix" / "home.nix").read_text(encoding="utf-8")
-        # Same predicate as the three sites consolidated above, NOT a fourth
-        # open-coded `"source = ../claude/skills;" in home_nix`. That literal is
-        # a SPELLED guard: it pins how the source is written, not what it
-        # resolves to, so it goes red for a change that leaves the deployment
-        # property intact — which is exactly what happened when the mapping's
-        # source became a derivation built FROM ../claude/skills.
-        assert_skills_mapping_deploys_repo_skills(home_nix)
+        # Same predicate as the three sites consolidated above. DECLARED-only:
+        # see testlib/skills_mapping.py for what it deliberately no longer
+        # traces, and which deploy-time check covers that instead.
+        assert_skills_mapping_declared(ROOT / "nix" / "home.nix")
         assert HANDOFF_REFERENCE.exists(), (
             f"{HANDOFF_REFERENCE} is absent from the tree under test. In the nix "
             f"sandbox that means it was never git-added, so the deploy omits it."

--- a/scripts/tests/test_subsystem_resolver.py
+++ b/scripts/tests/test_subsystem_resolver.py
@@ -85,7 +85,7 @@ sys.path.insert(0, str(ROOT / "scripts" / "lib"))
 sys.path.insert(0, str(ROOT / "scripts"))
 
 from testlib.skills_mapping import (  # noqa: E402
-    assert_skills_mapping_deploys_repo_skills,
+    assert_skills_mapping_declared,
 )
 
 import subsystem_resolver as sr  # noqa: E402
@@ -1756,12 +1756,10 @@ class TestCommandDocIsPinned:
         # The non-tautological half: nix must actually deploy the directory this
         # pin lives under. A pin under a directory home-manager does not ship is
         # precisely the vacuous green this test exists to prevent.
-        # One shared, STRUCTURAL predicate (testlib/skills_mapping.py) instead of
-        # the literal `source = ../claude/skills;` this used to grep for: the
-        # mapping's source is now a derivation BUILT from that path, which the
-        # spelled version could not tell apart from a source pointed elsewhere.
-        home_nix = (ROOT / "nix" / "home.nix").read_text(encoding="utf-8")
-        assert_skills_mapping_deploys_repo_skills(home_nix)
+        # One shared predicate (testlib/skills_mapping.py), and a deliberately
+        # narrow one: the mapping is declared and not switched off. Whether its
+        # source resolves to this tree is ship.sh/drift-check.sh's job.
+        assert_skills_mapping_declared(ROOT / "nix" / "home.nix")
 
     # --- the behavioural half: what each sentence ASSERTS ---------------------
 

--- a/scripts/tests/test_subsystem_touch.py
+++ b/scripts/tests/test_subsystem_touch.py
@@ -66,7 +66,7 @@ sys.path.insert(0, str(ROOT / "scripts" / "lib"))
 sys.path.insert(0, str(ROOT / "scripts"))
 
 from testlib.skills_mapping import (  # noqa: E402
-    assert_skills_mapping_deploys_repo_skills,
+    assert_skills_mapping_declared,
 )
 
 import subsystem_resolver as sr  # noqa: E402
@@ -1429,10 +1429,9 @@ class TestSkillDocsArePinned:
             assert d.exists(), f"the pinned doc is gone: {d}"
             assert d.name == "SKILL.md"
             assert d.parent.parent.name == "skills"
-        home_nix = (ROOT / "nix" / "home.nix").read_text(encoding="utf-8")
-        # Shared, structural predicate — see testlib/skills_mapping.py for why
-        # the literal-substring version of this had to go.
-        assert_skills_mapping_deploys_repo_skills(home_nix)
+        # Shared predicate — declared-and-not-switched-off only; see
+        # testlib/skills_mapping.py for what it does NOT check, and why.
+        assert_skills_mapping_declared(ROOT / "nix" / "home.nix")
 
 
 class TestEntrySchemaAgreement:


### PR DESCRIPTION
## This REDUCES pre-merge coverage, deliberately

`scripts/testlib/skills_mapping.py` answers "does `nix/home.nix` actually deploy
`claude/skills/`?", so four modules' SKILL.md pins are claims about files that
really ship. This PR keeps the cheap half of that property and **drops the
expensive half** — it is a reduction in ambition, not a bug fix.

**Kept** — the `home.file.".claude/skills"` mapping is declared and names a
`source`, and is not neutered by `enable = false` or a redirected `target` (the
two smallest edits that stop the deploy while the block still reads fine).

**Dropped, not reimplemented in any form** — tracing what the source *resolves
to*: `$out` analysis, `cp`/`rm` statement parsing, opaque-identifier tracking,
`src`/`srcs`/`paths` handling, let-binding resolution, brace matching, comment
stripping. A comment in the module names what covers it instead and says plainly
that this module does not.

## Why cut rather than fix

* **It never caught a real breakage.** Its only firing was a **false positive**
  on #438 — a change that left deployment intact.
* **The attempt to make it correct (#455, now closed) grew it to 29,920 B** and
  still admitted six constructible false ALL-CLEARs, two of them one-line edits
  to the real block, plus a regression against base. The heuristic surface grew
  faster than the coverage.
* **The holes are latent.** The real mapping is the attrset form, so the
  dotted-form and `enable` holes need a future edit to bite.
* 🔴 **The traded-away half is already covered at deploy time, correctly, against
  reality.** `scripts/ship.sh` prints per host on every deploy
  `✅ managed artifacts resolve — 429 checked, 0 dangling, 0 absent`, and
  `scripts/drift-check.sh` reports the same passively (rc 14). Those stat the
  real filesystem on both hosts. A text parser re-deriving that from nix source
  is strictly worse and always will be.

**The 4,000 B ceiling stated in the module header is the point** — it is what
stops the heuristic surface growing back. Final: **3,996 B**.

## Implementation: nix, not regex

`nix-instantiate --eval --strict --json` on the real file with stub
`config`/`pkgs`/`lib` (nix is lazy, so nothing outside that one attribute is
ever forced, and a stub that *is* forced fails closed), reading a small JSON
projection: `declared` / `source` / `enable` / `target`. Nix answers
dotted-vs-attrset form, comments, string escapes and where the attribute nests,
so the lexical failure class behind most of #455's holes cannot arise —
`home.file.".claude/skills".enable = false;` written 40 lines away from the
block is merged by nix's own parser and caught (pinned as a test).

Precedent: `pkgs.nix` is already in the pytests check's `nativeBuildInputs`
(`flake.nix:115`) for `test_opencode_config.py`'s `nix_eval()`, which *fails*
rather than skips when nix is absent. Same here. Anything nix cannot evaluate
returns `FIX THE CHECK — do NOT delete it`; nothing passes silently.

## Rename

`assert_skills_mapping_deploys_repo_skills` overclaims once the resolution half
is gone → **`assert_skills_mapping_declared`**, updated at all four consumers
(`test_subsystem_recall`, `_resolver`, `_touch`, `test_skills_mapping_guard`),
along with the call-site comments that described the old rationale. A guard's
name is a claim too.

## Verification

* Guard passes against the **real** `nix/home.nix`, in both tiers.
* **Mutation sweep: 20 mutants, 0 survivors.** 15 module mutants — deleted
  checks, inverted branches, swapped operands, a spelled-but-dead `return`,
  stale rebind of the nix expression (`enable` reading `force`) and of `TARGET`
  — each red on the expected test. 5 mutants of the **real** `home.nix` (mapping
  removed / `source` removed / `enable = false;` added / `target` redirected)
  each fired with that check's own message; the unchanged file stayed silent, as
  did the attrset form with unrelated attributes.
* **Instrument validated both ways** before believing any of it: a no-op module
  mutation stayed green, a syntax-error mutant went red, `__pycache__` cleared
  between runs with `PYTHONDONTWRITEBYTECODE=1` (a same-size rewrite has voided
  a sweep in this repo before).
* **Merged-tree gate**, integration branch off `origin/main` @ `0ee9c21`:
  `gate.sh --tier both` → `PASS pytest exit=0` / `PASS node exit=0`
  (`TOTAL collected=9538 passed=9537 skipped=1 failed=0`, node `1178 pass`).
  `nix build .#checks.x86_64-linux.pytests` and `.nodetests` both exit 0 on that
  same merged tree.
* `scripts/tests` goes 3865 → 3863 collected against a floor of 3725 — no floor
  change needed.

Closes #443. Supersedes #455.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
