### PR TITLE
skills-mapping: the anti-regrowth ceiling was prose, and a caller passing TEXT got 160 KB of home.nix back

### DIFF
--- a/scripts/testlib/skills_mapping.py
+++ b/scripts/testlib/skills_mapping.py
@@ -3,11 +3,21 @@
 SCOPE — HALF THE PROPERTY, ON PURPOSE
 -------------------------------------
 Four test modules pin SKILL.md files under `claude/skills/` so the pins are
-claims about files that SHIP. This answers only the cheap half:
+claims about files that SHIP. This answers only the cheap half, and only
+**as `nix/home.nix` itself declares it**:
 
-  * `home.file.".claude/skills"` exists and names a `source`;
-  * it is not neutered by `enable = false` or a redirected `target` — the two
-    smallest edits that stop the deploy while the mapping still reads fine.
+  * `home.file.".claude/skills"` exists there and names a `source`;
+  * that declaration is not neutered by `enable = false` or a redirected
+    `target` — the two smallest edits that stop the deploy while the mapping
+    still reads fine.
+
+🔴 FILE-SCOPED, NOT CONFIG-SCOPED. The real `home.file` is a MERGE of every
+module, so a sibling can switch this mapping off and this still returns None —
+verified with `imports = [ ./off.nix ];` + `enable = lib.mkForce false;`. That
+idiom is live here (`graphical.nix` already does `lib.mkIf` on `home.file`).
+Closing it means evaluating the whole `homeConfiguration`, which is the cost
+this module was cut to escape. ship.sh does NOT backstop it either: a disabled
+mapping produces no managed link, so nothing shows up dangling.
 
 🔴 It does NOT trace what the `source` RESOLVES to, and must not grow that back.
 Following it (the source is a derivation built from `../claude/skills`) meant
@@ -59,17 +69,32 @@ _FIX_IT = (
 def skills_mapping_problem(home_nix: Path | str) -> str | None:
     """A failure reason, or None when the mapping is declared and live."""
     home_nix = Path(home_nix)
-    if not home_nix.is_file():
-        return f"{home_nix} is not a file, {_FIX_IT}"
+    # NEVER interpolate the raw argument: a caller passing the file's TEXT
+    # instead of its path makes every message below ~160 KB of nix source.
+    # Depending on the filesystem that argument either raises ENAMETOOLONG out
+    # of is_file() or simply reads as a missing file, so truncating is the fix
+    # that holds in both cases — catching the errno alone does not.
+    shown = (lambda t: t if len(t) <= 120 else t[:117] + "...")(str(home_nix))
+    try:
+        is_file = home_nix.is_file()
+    except OSError as exc:
+        return f"cannot stat {shown!r} ({exc.strerror}), {_FIX_IT}"
+    if not is_file:
+        return f"{shown} is not a file, {_FIX_IT}"
     if shutil.which("nix-instantiate") is None:
         return f"nix-instantiate is not on PATH, {_FIX_IT}"
-    p = subprocess.run(
-        ["nix-instantiate", "--eval", "--strict", "--json",
-         "-E", _EXPR.replace("@PATH@", str(home_nix.resolve()))],
-        capture_output=True, text=True, timeout=180,
-    )
+    try:
+        p = subprocess.run(
+            ["nix-instantiate", "--eval", "--strict", "--json",
+             "-E", _EXPR.replace("@PATH@", str(home_nix.resolve()))],
+            capture_output=True, text=True, timeout=60,
+        )
+    except subprocess.TimeoutExpired:
+        # Measured runtime is ~0.02 s; a hang means the environment is wrong,
+        # which is a broken check, not a broken home.nix.
+        return f"nix-instantiate did not finish within 60s, {_FIX_IT}"
     if p.returncode != 0:
-        return f"nix cannot evaluate {home_nix}, {_FIX_IT}\n{p.stderr.strip()[-600:]}"
+        return f"nix cannot evaluate {shown}, {_FIX_IT}\n{p.stderr.strip()[-600:]}"
     m = json.loads(p.stdout)
     if not m["declared"]:
         return (

--- a/scripts/tests/test_skills_mapping_guard.py
+++ b/scripts/tests/test_skills_mapping_guard.py
@@ -197,6 +197,42 @@ def test_a_file_nix_cannot_evaluate_fails_and_says_do_not_delete(tmp_path):
     assert "do NOT delete it" in problem, problem
 
 
+def test_passing_the_files_TEXT_reads_as_a_broken_check(tmp_path):
+    """The docstring below claims this case is covered; a short bogus path does
+    not exercise it. Real nix source is ~160 KB, which makes `is_file()` raise
+    ENAMETOOLONG rather than return False — pathlib does not swallow that errno.
+    Must be a named failure, and must NOT echo the argument back."""
+    text = HOME_NIX.read_text(encoding="utf-8")
+    problem = skills_mapping_problem(text)
+    assert problem is not None, "the file's TEXT passed silently"
+    assert "do NOT delete it" in problem, problem
+    assert len(problem) < 2_000, (
+        f"the failure message is {len(problem):,} bytes — it is echoing the "
+        "argument, which here is the whole of home.nix"
+    )
+
+
+#: The module is deliberately SMALL. Its predecessor reached 29,920 B chasing a
+#: property it still got wrong, and was cut to ~4 KB by dropping that ambition.
+#: Without a gate that ceiling is a prose intention, and this file's own history
+#: shows prose intentions do not hold. Precedent: test_rules_size.py.
+MAX_MODULE_BYTES = 5_600
+
+
+def test_the_module_stays_under_its_ceiling():
+    size = (ROOT / "scripts" / "testlib" / "skills_mapping.py").stat().st_size
+    assert size <= MAX_MODULE_BYTES, (
+        f"scripts/testlib/skills_mapping.py is {size:,} bytes\n"
+        f"  ceiling: {MAX_MODULE_BYTES:,} bytes\n"
+        "This module was cut from 8,846 B (and an abandoned 29,920 B rewrite) by\n"
+        "DROPPING source-resolution tracing, not by golfing it. If you are over,\n"
+        "the question is which ambition crept back -- $out analysis, cp/rm\n"
+        "parsing, let-binding resolution, comment stripping -- not how to raise\n"
+        "the number. That half is verified against reality by ship.sh and\n"
+        "drift-check.sh; re-deriving it from nix source is strictly worse."
+    )
+
+
 def test_a_path_that_is_not_a_file_fails(tmp_path):
     """Named as its own failure, not left to nix's "file not found" — a caller
     passing the wrong thing (the file's TEXT, say) must read as a broken check."""


### PR DESCRIPTION
Audit follow-ups on the guard cut that landed as **#462**.

This PR originally carried the cut itself. While it was open, a concurrent session merged the same commit as #462, so the base is now on `main` and this is rebased down to only the three fixes the audit of that work turned up. All three are **honesty defects** in a change whose entire argument is that a *small* guard can be trusted where a large one could not.

## 1. The scope claim was unqualified

The module said "not neutered by `enable = false` or a redirected `target`" full stop. That is true of `nix/home.nix` **only** — the real `home.file` is a merge of every module, so `imports = [ ./off.nix ];` with `enable = lib.mkForce false;` still reads CLEAN. Verified. That idiom is live in this repo: `graphical.nix` already does `lib.mkIf` on `home.file`.

Now documented as a FILE-SCOPED limit, including the part that is easy to assume away: **`ship.sh` does not backstop it.** A disabled mapping produces no managed link, so there is nothing for the dangling-link scan to find. Closing it properly means evaluating the whole `homeConfiguration`, which is the cost this module was cut to escape.

## 2. Passing the file's TEXT dumped 160 KB into the traceback

`skills_mapping_problem(home_nix_text)` produced a **160,234-byte** failure message containing all of `home.nix`.

The audit diagnosed this as `ENAMETOOLONG` raising out of `Path.is_file()`. I wrote the `try/except OSError` accordingly — **and the new test still failed**, because on this filesystem `is_file()` returns `False` instead of raising and the echo happens anyway. Catching the errno fixed the diagnosis, not the defect.

Every message now interpolates a truncated form, which holds under both behaviours. The pre-existing test asserted this case but only exercised a short bogus path; the new one passes real source and bounds the message length — and it is what caught the errno-only fix as insufficient.

## 3. The ceiling was prose, not a gate

The commit message for the cut asserted that a 4,000 B ceiling "is what stops the heuristic surface growing back". **No such ceiling existed and no test enforced one.** The anti-regrowth argument is the main defence against re-litigating #455, and it was an intention.

Now enforced, following the `test_rules_size.py` precedent, and verified red at a lowered bound. The number is **5,600, not 4,000** — scoping the docstring honestly for finding 1 cost bytes. Raised deliberately and recorded rather than adjusted quietly; documentation is not the ambition the ceiling exists to stop. Headroom: 139 B. The failure message asks *which ambition crept back*, not how to raise the number.

Also: `subprocess.TimeoutExpired` was uncaught and would surface as a test error rather than the module's own "FIX THE CHECK" string. Timeout cut 180 s → 60 s against a measured 0.02 s runtime.

## Verified

Mutation battery re-run after the fixes (a fix round resets the gate), each firing with its own message:

| mutation | result |
|---|---|
| unmutated control | CLEAN |
| `enable = false;` | FIRES — "switched OFF" |
| `target = ".claude/skills-off";` | FIRES — "redirects `target`" |
| `enable = null;` | FIRES — the non-bool falsy case the audit found unfixtured |
| `source` removed | FIRES — "declares no `source =`" |
| unparseable file | FIRES — "nix cannot evaluate", not a silent pass |

Ceiling test verified red at a lowered bound. Guard suite 12/12. `nix build .#checks.x86_64-linux.{pytests,nodetests}` green, rebased onto current `origin/main` (`d01cf23`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)