### PR TITLE
feat(hooks): deploy the registrar and RUN it on switch — a hook that no one registers is inert (#460)

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1037,6 +1037,56 @@ in
   home.file.".claude/hooks/next-step-nudge.py" = {
     source = ../scripts/claude-hooks/next-step-nudge.py;
   };
+  # 🔴 THE REGISTRAR ITSELF — the hook that makes the hooks above DO anything.
+  # settings.json is per-host and unmanaged (permissions/allowlists), so a hook
+  # script landing in ~/.claude/hooks/ registers nothing by itself; this script
+  # appends the missing entries. Until 2026-08-13 it had NO home.file entry at
+  # all — only the two comments above mentioning it — and nothing ever invoked
+  # it. Measured consequence: next-step-nudge.py (#452) deployed to both hosts
+  # and sat INERT, because the switch reported success about the LAYER BELOW
+  # (the file landed) and nothing checked the layer above (it was registered).
+  # Same shape as this repo's `git add`-or-the-flake-omits-it trap.
+  #
+  # No `force = true` and no `dropStaleClaudeHooks` entry, unlike bash-guard.py:
+  # that treatment exists to displace a PRE-EXISTING hand-placed regular file,
+  # and this path has never been hand-placed. MEASURED 2026-08-13 on both hosts
+  # before the first switch that deploys it: `ls -la ~/.claude/hooks/` shows
+  # eight entries on the workbench and eight on the laptop, all store symlinks,
+  # and register-nudge-hook.py among none of them. If a foreign file ever does
+  # appear here the switch fails LOUDLY ("would be clobbered") rather than
+  # silently leaving it unmanaged — add it to dropStaleClaudeHooks then.
+  home.file.".claude/hooks/register-nudge-hook.py" = {
+    source = ../scripts/claude-hooks/register-nudge-hook.py;
+  };
+
+  # ...and RUN it, every switch. Delivering the registrar without invoking it
+  # would only move the manual step, not remove it.
+  #
+  # 🔴 SLOT: after "linkGeneration", NOT merely after "writeBoundary".
+  # linkGeneration is the step that creates the home-file symlinks, and it is
+  # itself `entryAfter ["writeBoundary"]` — so two entries that both declare
+  # only writeBoundary have NO order between them. MEASURED in this host's
+  # current generated `activate`: activityCollectorEnv and
+  # browserBridgeExtension (both writeBoundary-only) are emitted at lines 290
+  # and 300, linkGeneration at 502 — i.e. the topo sort put them BEFORE the
+  # files land. Copying that precedent here would have run the registrar
+  # before ~/.claude/hooks/register-nudge-hook.py existed on the one switch
+  # where it matters (the first one on each host), and worked on every switch
+  # after — a bug visible only on a fresh host.
+  #
+  # VERIFIED on the built artifact rather than argued: `nix build` of this
+  # config's activation-script derivation emits "registerClaudeHooks" at line
+  # 546, after "linkGeneration" at 502. (Building that derivation activates
+  # nothing — it only writes the script.)
+  #
+  # The wrapper never returns non-zero, so this cannot abort a switch under
+  # activation's `set -eu -o pipefail`; see the contract in its header.
+  # $DRY_RUN_CMD keeps `home-manager build`/dry-run read-only.
+  home.activation.registerClaudeHooks =
+    lib.hm.dag.entryAfter [ "writeBoundary" "linkGeneration" ] ''
+      $DRY_RUN_CMD ${pkgs.bash}/bin/bash ${../scripts/claude-hooks/register-hooks-activation.sh} \
+        "$HOME/.claude/hooks/register-nudge-hook.py" ${pkgs.python312}/bin/python3
+    '';
 
   # ------------------------------------------------------------------------- #
   # opencode — global config, instruction file, env plugin and subagents.

--- a/scripts/claude-hooks/register-hooks-activation.sh
+++ b/scripts/claude-hooks/register-hooks-activation.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# The home-manager ACTIVATION wrapper around register-nudge-hook.py.
+#
+#   usage: bash register-hooks-activation.sh [registrar-path] [python]
+#          defaults: ~/.claude/hooks/register-nudge-hook.py, python3 on PATH
+#
+# WHY THIS FILE EXISTS AT ALL, rather than four lines inlined in home.nix:
+# the bug it closes (#452 shipped a Stop hook that sat INERT on both hosts
+# because nothing ever registered it) was invisible precisely because the
+# DELIVERY seam had no test. An inline nix string is testable only by scraping
+# home.nix; a real script is driven by tests/test_registrar_activation.py with
+# the exact bytes that ship.
+#
+# CONTRACT — all three are pinned by that suite:
+#
+#   1. 🔴 IT ALWAYS EXITS 0. home-manager activation runs under `set -eu -o
+#      pipefail`, so ANY non-zero status here aborts the whole switch. An
+#      unregistered hook is an inconvenience; a switch that will not complete
+#      blocks every other change on that host, and this repo already has a
+#      "failed switch" incident class (CLAUDE.md → Git discipline). Every
+#      failure path therefore warns on stderr and returns 0.
+#   2. IT SAYS WHAT IT DID. The registrar's own report ("registered hooks: …"
+#      / "… no change") is echoed line by line, prefixed. A silent activation
+#      step is how the original failure went unnoticed for a full deploy cycle.
+#   3. IT DECIDES NOTHING ABOUT settings.json. Every read/merge/write belongs
+#      to the registrar, which is strictly APPEND-ONLY and never clobbers a
+#      hook it does not own (the clawgate Stop hook drives remote approval;
+#      losing it would silently break that). This wrapper adds no second
+#      writer — it must never grow one.
+#
+# The registrar path defaults to the DEPLOYED copy rather than the store
+# source deliberately: if the `home.file` entry for it ever stops landing,
+# activation says so out loud instead of quietly working from the store, which
+# is the same "delivery succeeded, feature absent" shape as the original bug.
+set -u
+
+PREFIX="claude-hooks:"
+reg="${1:-$HOME/.claude/hooks/register-nudge-hook.py}"
+py="${2:-python3}"
+
+emit() { # $1 = stream marker (1|2), $2… = text
+  if [ "$1" = "2" ]; then
+    shift
+    printf '%s %s\n' "$PREFIX" "$*" >&2
+  else
+    shift
+    printf '%s %s\n' "$PREFIX" "$*"
+  fi
+}
+
+# Echo a captured block line by line so multi-line registrar output stays
+# attributable to this step in the switch log.
+relay() { # $1 = stream marker, $2 = text block
+  [ -n "$2" ] || return 0
+  printf '%s\n' "$2" | while IFS= read -r line; do
+    emit "$1" "  $line"
+  done
+}
+
+if [ ! -f "$reg" ]; then
+  emit 2 "WARNING registrar not found at $reg — Claude Code hooks were NOT registered in ~/.claude/settings.json. Check its home.file entry in nix/home.nix, then re-switch."
+  exit 0
+fi
+
+out="$("$py" "$reg" 2>&1)"
+rc=$?
+
+if [ "$rc" -ne 0 ]; then
+  emit 2 "WARNING registrar exited $rc — ~/.claude/settings.json was left as it was, so some hooks may be unregistered. The switch continues; fix and re-run: $py $reg"
+  relay 2 "$out"
+  exit 0
+fi
+
+relay 1 "$out"
+exit 0

--- a/scripts/claude-hooks/tests/test_registrar_activation.py
+++ b/scripts/claude-hooks/tests/test_registrar_activation.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Tests for the DELIVERY seam: register-hooks-activation.sh + its home.nix wiring.
+
+WHAT THIS FILE IS FOR
+
+  🔴 The bug this closes was invisible because the DEPLOY SUCCEEDED. next-step-nudge.py
+  (#452) landed on both hosts, `home-manager switch` reported success, the file was
+  present — and the hook did nothing, because `~/.claude/settings.json` never named it
+  and nothing was ever going to make it. A test asserting "the activation step ran"
+  would have passed throughout that bug's entire life. So every test here asserts the
+  END STATE IN settings.json, or the wiring that produces it.
+
+  The seam has three parts and each is owned by a section below:
+
+    1. END STATE — drive the shipped wrapper against a throwaway HOME and read the
+       resulting settings.json. Both directions: a file without the nudge gets it, a
+       file that already has it comes back BYTE-IDENTICAL.
+    2. NEVER FAIL THE SWITCH — activation runs under `set -eu -o pipefail`, so a
+       non-zero status here aborts the whole switch and blocks every other change on
+       that host. Four distinct broken environments, each asserted to exit 0, warn on
+       stderr, and leave settings.json exactly as found.
+    3. WIRING — home.nix must deploy the registrar AND every hook the registrar
+       registers, and must run the wrapper AFTER the files land. Section 1 passes
+       perfectly with home.nix untouched; that combination is precisely the shipped
+       bug, which is why section 3 exists.
+
+  🔴 NEVER touches the operator's real ~/.claude/settings.json: every test runs the
+  wrapper with HOME pointed at a tmp_path, and the registrar resolves the file from
+  HOME. Both hosts are registered correctly right now and must stay that way.
+
+  Not tested here, deliberately: a chmod-000 settings.json. Whether it is readable
+  depends on the euid of whoever runs the gate (root ignores the mode), so it would
+  assert one thing on a dev host and another in a build sandbox. The
+  directory-at-the-settings-path fixture is the uid-independent "cannot be read".
+
+    run:  python -m pytest scripts/claude-hooks/tests/test_registrar_activation.py -q
+
+Fixtures are synthetic. This repo is public: no real paths, hostnames or task titles.
+"""
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts" / "claude-hooks" / "register-hooks-activation.sh"
+REGISTRAR = ROOT / "scripts" / "claude-hooks" / "register-nudge-hook.py"
+HOME_NIX = ROOT / "nix" / "home.nix"
+
+BASH = shutil.which("bash") or "/bin/bash"
+
+NEXT_STEP = "python3 ~/.claude/hooks/next-step-nudge.py"
+NOTIFY = "python3 ~/.claude/hooks/claude-notify.py"
+CLAWGATE_STOP = "/home/zach/.claude/clawgate-stop-hook.sh"
+TMUX_STOP = "~/.config/tmux/task-hook.sh"
+
+# The workbench's real shape before the manual fix: THREE foreign owners of Stop, one
+# of which (the clawgate hook) drives remote approval. An append-only bug is invisible
+# on an empty array, so the preservation fixtures are all populated.
+THREE_FOREIGN_STOP_HOOKS = [TMUX_STOP, CLAWGATE_STOP, NOTIFY]
+
+
+def settings_with(stop_commands, extra=None):
+    data = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": "python3 ~/.claude/hooks/bash-guard.py"}
+                    ],
+                }
+            ],
+            "Stop": [
+                {"hooks": [{"type": "command", "command": c}]} for c in stop_commands
+            ],
+        },
+        "permissions": {"allow": ["Bash(git status)"]},
+    }
+    if extra:
+        data.update(extra)
+    return data
+
+
+def make_home(tmp_path, settings, name="home"):
+    """A throwaway HOME with ~/.claude/settings.json holding `settings`.
+
+    `settings` may be a dict (written as JSON) or raw text (for the malformed case);
+    None means "no settings.json at all".
+    """
+    home = tmp_path / name
+    (home / ".claude").mkdir(parents=True)
+    path = home / ".claude" / "settings.json"
+    if isinstance(settings, dict):
+        path.write_text(json.dumps(settings, indent=2) + "\n")
+    elif settings is not None:
+        path.write_text(settings)
+    return home
+
+
+def run_activation(home, registrar=REGISTRAR, python=None, args=None):
+    """Drive the SHIPPED wrapper exactly as home.nix drives it."""
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    if args is None:
+        args = [str(registrar), python or sys.executable]
+    return subprocess.run(
+        [BASH, str(SCRIPT)] + args, env=env, capture_output=True, text=True
+    )
+
+
+def stop_commands(home):
+    data = json.loads((home / ".claude" / "settings.json").read_text())
+    return [
+        h.get("command")
+        for entry in data.get("hooks", {}).get("Stop", [])
+        for h in entry.get("hooks", [])
+    ]
+
+
+def settings_bytes(home):
+    return (home / ".claude" / "settings.json").read_bytes()
+
+
+# --------------------------------------------------------------------------- #
+# 1. END STATE in settings.json — the assertion the shipped bug would have failed
+# --------------------------------------------------------------------------- #
+
+
+def test_a_settings_file_without_the_nudge_comes_back_with_it_registered(tmp_path):
+    home = make_home(tmp_path, settings_with([TMUX_STOP]))
+    assert NEXT_STEP not in stop_commands(home), "fixture must start WITHOUT the nudge"
+
+    p = run_activation(home)
+
+    assert p.returncode == 0, p.stderr
+    assert NEXT_STEP in stop_commands(home), (
+        "activation ran but settings.json does not name the nudge — this is the exact "
+        "shipped bug: the step succeeded and the feature stayed inert.\n" + p.stdout + p.stderr
+    )
+
+
+def test_it_says_what_it_did_on_stdout(tmp_path):
+    """A silent activation step is how the original failure went unnoticed."""
+    home = make_home(tmp_path, settings_with([TMUX_STOP]))
+
+    p = run_activation(home)
+
+    assert p.returncode == 0
+    assert "claude-hooks:" in p.stdout, p.stdout + p.stderr
+    assert "registered hooks" in p.stdout, p.stdout
+    assert NEXT_STEP in p.stdout, p.stdout
+
+
+def test_three_foreign_stop_hooks_come_back_as_four_originals_intact_and_in_order(tmp_path):
+    """🔴 Losing the clawgate Stop hook would silently break remote approval."""
+    home = make_home(tmp_path, settings_with(THREE_FOREIGN_STOP_HOOKS))
+
+    p = run_activation(home)
+    after = stop_commands(home)
+
+    assert p.returncode == 0, p.stderr
+    # SET equality, not membership: it fails when the set SHRINKS (one clobbered) and
+    # when it GROWS (something registered by accident), which membership cannot see.
+    assert set(after) == set(THREE_FOREIGN_STOP_HOOKS) | {NEXT_STEP}, after
+    assert len(after) == 4, after
+    # The three originals keep their identity AND their relative order, and stay ahead
+    # of the appended one — append-only, never a rewrite.
+    assert after[:3] == THREE_FOREIGN_STOP_HOOKS, after
+    assert after[3] == NEXT_STEP, after
+
+
+def test_unrelated_settings_content_is_untouched(tmp_path):
+    home = make_home(tmp_path, settings_with(THREE_FOREIGN_STOP_HOOKS))
+
+    p = run_activation(home)
+
+    # 🔴 Assert the run WORKED first. Without this line the test passes vacuously on a
+    # tree where the wrapper does not exist at all — nothing is written, so nothing is
+    # disturbed — which is exactly the tree this whole PR exists to leave behind.
+    assert p.returncode == 0 and NEXT_STEP in stop_commands(home), p.stderr
+    data = json.loads(settings_bytes(home))
+    assert data["permissions"] == {"allow": ["Bash(git status)"]}
+    pre = [
+        h.get("command")
+        for e in data["hooks"]["PreToolUse"]
+        for h in e.get("hooks", [])
+    ]
+    assert pre == ["python3 ~/.claude/hooks/bash-guard.py"], pre
+
+
+def test_a_settings_file_that_already_has_the_nudge_is_left_byte_identical(tmp_path):
+    """The other direction: re-running must register nothing and rewrite nothing."""
+    home = make_home(tmp_path, settings_with(THREE_FOREIGN_STOP_HOOKS))
+
+    first = run_activation(home)
+    assert first.returncode == 0, first.stderr
+    registered = settings_bytes(home)
+
+    second = run_activation(home)
+
+    assert second.returncode == 0, second.stderr
+    assert settings_bytes(home) == registered, "second run rewrote settings.json"
+    assert "no change" in second.stdout, second.stdout
+    assert stop_commands(home).count(NEXT_STEP) == 1, stop_commands(home)
+
+
+def test_no_temp_files_are_left_beside_settings_json(tmp_path):
+    home = make_home(tmp_path, settings_with([TMUX_STOP]))
+
+    p = run_activation(home)
+
+    # Same anti-vacuity line as above: a run that wrote nothing leaves no litter.
+    assert p.returncode == 0 and NEXT_STEP in stop_commands(home), p.stderr
+    leftovers = [n for n in os.listdir(home / ".claude") if n != "settings.json"]
+    assert leftovers == [], leftovers
+
+
+# --------------------------------------------------------------------------- #
+# 2. NEVER FAIL THE SWITCH — activation runs under `set -eu -o pipefail`
+# --------------------------------------------------------------------------- #
+
+
+def assert_warned_and_survived(p, message):
+    assert p.returncode == 0, (
+        message + " — a non-zero status here ABORTS home-manager switch.\n"
+        "stdout: " + p.stdout + "\nstderr: " + p.stderr
+    )
+    assert "WARNING" in p.stderr, (
+        message + " — it exited 0 but said nothing; a silent failure is the shape of "
+        "the original bug.\nstdout: " + p.stdout + "\nstderr: " + p.stderr
+    )
+
+
+def test_malformed_settings_json_warns_and_lets_the_switch_finish(tmp_path):
+    home = make_home(tmp_path, '{"hooks": {"Stop": [ this is not json')
+    before = settings_bytes(home)
+
+    p = run_activation(home)
+
+    assert_warned_and_survived(p, "malformed settings.json")
+    assert settings_bytes(home) == before, "a malformed file must not be rewritten"
+
+
+def test_an_unreadable_settings_json_warns_and_lets_the_switch_finish(tmp_path):
+    """Unreadable in a uid-independent way: a DIRECTORY where the file should be."""
+    home = tmp_path / "home"
+    (home / ".claude" / "settings.json").mkdir(parents=True)
+
+    p = run_activation(home)
+
+    assert_warned_and_survived(p, "unreadable settings.json")
+    assert (home / ".claude" / "settings.json").is_dir()
+
+
+def test_a_missing_settings_json_warns_and_lets_the_switch_finish(tmp_path):
+    home = make_home(tmp_path, None)
+
+    p = run_activation(home)
+
+    assert_warned_and_survived(p, "missing settings.json")
+    assert not (home / ".claude" / "settings.json").exists(), (
+        "the wrapper must not conjure a settings.json — that file is per-host, "
+        "unmanaged, and holds the permission allowlist"
+    )
+
+
+def test_a_missing_registrar_warns_naming_the_path_and_lets_the_switch_finish(tmp_path):
+    """The residual failure mode: the registrar's own delivery breaks."""
+    home = make_home(tmp_path, settings_with(THREE_FOREIGN_STOP_HOOKS))
+    before = settings_bytes(home)
+
+    p = run_activation(home, registrar=tmp_path / "nowhere" / "register-nudge-hook.py")
+
+    assert_warned_and_survived(p, "missing registrar")
+    assert "register-nudge-hook.py" in p.stderr, p.stderr
+    assert settings_bytes(home) == before
+
+
+def test_a_broken_interpreter_warns_and_lets_the_switch_finish(tmp_path):
+    home = make_home(tmp_path, settings_with(THREE_FOREIGN_STOP_HOOKS))
+    before = settings_bytes(home)
+
+    p = run_activation(home, python=str(tmp_path / "no-such-python"))
+
+    assert_warned_and_survived(p, "broken interpreter")
+    assert settings_bytes(home) == before
+
+
+def test_with_no_arguments_it_looks_for_the_registrar_under_home(tmp_path):
+    """Pins the DEFAULT home.nix relies on, without depending on a python3 on PATH."""
+    home = make_home(tmp_path, settings_with([TMUX_STOP]))
+
+    p = run_activation(home, args=[])
+
+    assert_warned_and_survived(p, "no arguments, no deployed registrar")
+    assert str(home / ".claude" / "hooks" / "register-nudge-hook.py") in p.stderr, p.stderr
+
+
+# --------------------------------------------------------------------------- #
+# 3. WIRING — section 1 passes with home.nix untouched; that IS the shipped bug
+# --------------------------------------------------------------------------- #
+
+HOOK_CMD_RE = re.compile(r"~/\.claude/hooks/([A-Za-z0-9_.-]+\.py)")
+HOME_FILE_RE = re.compile(r'home\.file\."\.claude/hooks/([^"]+)"')
+
+
+def registrar_registers():
+    """Hook filenames the registrar writes into settings.json (parsed, never imported —
+    importing it would read the REAL ~/.claude/settings.json)."""
+    src = REGISTRAR.read_text()
+    # Only the command tables at the top, not the docstring's prose.
+    body = src.split('"""', 2)[-1]
+    return set(HOOK_CMD_RE.findall(body))
+
+
+def home_nix_deploys():
+    return set(HOME_FILE_RE.findall(HOME_NIX.read_text()))
+
+
+def test_the_parsers_find_something_positive_control():
+    """A zero from either parser would make the two tests below vacuously green."""
+    registers = registrar_registers()
+    deploys = home_nix_deploys()
+    assert len(registers) >= 4, registers
+    assert "next-step-nudge.py" in registers, registers
+    assert len(deploys) >= 5, deploys
+    assert "bash-guard.py" in deploys, deploys
+
+
+def test_home_nix_deploys_every_hook_the_registrar_registers():
+    """The bug class, pinned as a RELATIONSHIP: registering a hook that no home.file
+    delivers produces a settings.json entry pointing at a file that does not exist.
+
+    ⚠ Labelled honestly: this is an INVARIANT GUARD, not regression coverage. It is
+    GREEN at the base commit — the shipped bug was the registrar's own delivery, and
+    the registrar does not appear in its own command tables. It is here because the
+    NEXT hook lands the same way, and it was mutation-checked reachable (adding a
+    command for an undeployed hook turns it red naming that file)."""
+    missing = registrar_registers() - home_nix_deploys()
+    assert missing == set(), (
+        "these hooks are registered in ~/.claude/settings.json by "
+        "register-nudge-hook.py but have no home.file entry in nix/home.nix, so they "
+        "are named but never delivered: " + ", ".join(sorted(missing))
+    )
+
+
+def test_home_nix_deploys_the_registrar_itself():
+    assert "register-nudge-hook.py" in home_nix_deploys(), (
+        "register-nudge-hook.py has no home.file entry — it was mentioned only in "
+        "comments for weeks, which is why nothing ever registered the hooks"
+    )
+    assert REGISTRAR.exists()
+
+
+def activation_block():
+    src = HOME_NIX.read_text()
+    m = re.search(
+        r"home\.activation\.registerClaudeHooks\s*=(.*?)'';", src, re.S
+    )
+    return m.group(1) if m else None
+
+
+def test_home_nix_runs_the_wrapper_on_switch():
+    block = activation_block()
+    assert block is not None, (
+        "no home.activation.registerClaudeHooks entry — the registrar would be "
+        "delivered and never invoked, which is the state that shipped"
+    )
+    assert "register-hooks-activation.sh" in block, block
+    assert SCRIPT.exists(), SCRIPT
+    assert "register-nudge-hook.py" in block, block
+
+
+def test_the_activation_entry_runs_after_the_hook_files_land():
+    """🔴 linkGeneration is the step that creates the home-file symlinks, and it is
+    itself entryAfter ["writeBoundary"] — so writeBoundary alone orders this entry
+    BEFORE the files it depends on (measured in the generated activate: two
+    writeBoundary-only entries at lines 290/300, linkGeneration at 502)."""
+    block = activation_block()
+    assert block is not None
+    m = re.search(r"entryAfter\s*\[([^\]]*)\]", block)
+    assert m is not None, block
+    deps = set(re.findall(r'"([^"]+)"', m.group(1)))
+    assert "linkGeneration" in deps, (
+        "the registrar would run before ~/.claude/hooks/ is populated on a fresh "
+        "host; declared dependencies: " + ", ".join(sorted(deps))
+    )

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -325,6 +325,13 @@ HERMETIC_TARGETS=(
   # suppression predicate is gated here rather than left to the ungated hand-rolled
   # scripts beside it.
   scripts/claude-hooks/tests/test_next_step_nudge.py
+  # Same reason again — a FILE, not the directory. This one gates the DELIVERY seam
+  # rather than a hook's own logic: that register-nudge-hook.py is deployed, that a
+  # switch actually RUNS it, and that the run leaves the right end state in a
+  # throwaway settings.json without ever clobbering a foreign Stop hook. It exists
+  # because #452's hook shipped to both hosts and sat inert — every component was
+  # tested, the seam between them was owned by nobody.
+  scripts/claude-hooks/tests/test_registrar_activation.py
 )
 
 # --- DEV-HOST-ONLY set ---------------------------------------------------------
@@ -746,6 +753,10 @@ TARGET_FLOORS=(
   # local pytest run — then put through the gate's own function:
   #   _suggested_floor 112 = 112 - min(50, max(1, 112/20 = 5)) = 112 - 5 = 107.
   "scripts/claude-hooks/tests/test_next_step_nudge.py|107"
+  # 2026-08-13, the registrar's DELIVERY seam arrives as a NEW target: 17 collected.
+  # Gate's own count through the gate's own rule:
+  #   _suggested_floor 17 = 17 - min(50, max(1, 17/20 = 0 -> 1)) = 17 - 1 = 16.
+  "scripts/claude-hooks/tests/test_registrar_activation.py|16"
 )
 
 # The allowance rule, in one place, used by BOTH the drift message and anyone


### PR DESCRIPTION
Implements `claudedocs/kickoff-registrar-activation.md` (#460).

`next-step-nudge.py` (#452) shipped to both hosts and sat **inert**: the file landed, the
switch reported success, and `~/.claude/settings.json` never named it — because
`register-nudge-hook.py` had no `home.file` entry (only two comments mentioning it) and
nothing ever invoked it. A success report about one layer, read as a success report about
the layer above.

## What this adds

**a. The registrar is deployed** — `home.file.".claude/hooks/register-nudge-hook.py"`,
alongside its five siblings.

**It did NOT need the `dropStaleClaudeHooks` treatment.** That entry exists to displace a
*pre-existing hand-placed regular file*, and this path has never been one — measured on
both hosts before the first switch that deploys it: `ls -la ~/.claude/hooks/` shows eight
entries on the workbench and eight on the laptop, every one a `/nix/store` symlink, and
`register-nudge-hook.py` among neither. Should a foreign file ever appear there, the switch
fails loudly ("would be clobbered") rather than silently leaving it unmanaged; the comment
says to add it then.

**b. It runs on switch** — `home.activation.registerClaudeHooks`.

🔴 Ordered `entryAfter [ "writeBoundary" "linkGeneration" ]`, **not** `writeBoundary` alone.
`linkGeneration` is the step that creates the home-file symlinks and is itself
writeBoundary-only, so two writeBoundary-only entries have no order between them: in this
host's current generated `activate`, `activityCollectorEnv` (290) and
`browserBridgeExtension` (300) both land *before* `linkGeneration` (502). The obvious
precedent would have run the registrar before the file existed on the one switch where it
matters — the first on each host — and worked on every switch after.

Verified on the built artifact, not argued: `nix build` of this config's
`activation-script` derivation emits `registerClaudeHooks` at line **546**, after
`linkGeneration` at **502**. (Building that derivation activates nothing.)

**c. `scripts/claude-hooks/register-hooks-activation.sh`** — the wrapper, whose whole
contract is:

1. **It always exits 0.** Activation runs under `set -eu -o pipefail`; a failed switch
   blocks every other change on that host.
2. **It always says what it did** — the registrar's own `registered hooks: …` / `… no
   change` line, prefixed `claude-hooks:`. A silent step is how this went unnoticed for a
   full deploy cycle.
3. **It decides nothing about `settings.json`.** The registrar stays the single
   append-only writer, so the three foreign `Stop` hooks — clawgate's included — keep
   working. No second writer, ever.

It is a file rather than four inlined lines because the bug *was* an untested delivery
seam: an inline nix string is testable only by scraping `home.nix`; a script is driven by
the gate with the exact bytes that ship.

`settings.json` stays per-host and unmanaged, deliberately — out of scope, unchanged.

## Verification

`scripts/claude-hooks/tests/test_registrar_activation.py` (17 tests, new gate target)
asserts the **end state in `settings.json`**, never that activation ran, always under a
temp `HOME` — the operator's real file is never touched.

* both directions: absent → registered; present → **byte-identical**, `no change` on stdout
* preservation: a `Stop` array holding three foreign hooks comes back with **four**, all
  three originals intact and in their original order, ahead of the appended one (set
  equality, so it fails if the set shrinks *or* grows)
* failure paths, each exiting 0 **and** warning: malformed JSON, an unreadable
  `settings.json`, a missing one, a missing registrar, a broken interpreter
* wiring: the registrar is deployed, every hook the registrar registers has a `home.file`
  entry, the activation entry runs the wrapper, and it declares `linkGeneration`

**Red→green: 15 of 17 fail at the base commit**, each on its own assertion. The two that do
not are labelled in the file as what they are — a parser positive control, and an invariant
guard (the register/deploy ledger, green at base because the registrar does not appear in
its own command tables; kept because the next hook lands the same way, and mutation-checked
reachable).

**Mutation sweep: 10 mutants, 0 survivors**, each killed by the test that owns it, dying
with that test's own message — clobber-protection (registrar rewrites the `Stop` array
instead of appending), never-fail-the-switch (wrapper propagates the exit status; wrapper
exits 1 on a missing registrar), silent-failure (warning removed; report removed), the
registrar's own table, the register/deploy ledger, and all three wiring mutants including
"ordered on `writeBoundary` alone".

**Gate** (`nix build .#checks.x86_64-linux.pytests`, counts read from `nix log`):
`TOTAL collected=9555 passed=9554 skipped=1 failed=0`, `RESULT: PASS (exit=0)`; this
target `collected=17 passed=17 floor=16`, GUARD 7 `plugin=1 intercepted=0`.
Floor arithmetic, the gate's own count through the gate's own rule:
`_suggested_floor 17 = 17 - min(50, max(1, 17/20 = 0 → 1)) = 16`.
`nix-instantiate --parse nix/home.nix` — OK, and the whole config **evaluates**
(`nix build --impure --dry-run .#homeConfigurations.zach.activationPackage`), which is what
actually proves the `linkGeneration` DAG dependency resolves.

Additionally, the **exact command line the generated activation script will run** —
store-path wrapper, store-path python — was executed by hand against a throwaway `HOME`
seeded from a copy of the live `settings.json` with the nudge removed: 3 → 4 `Stop` hooks,
originals in order, second run byte-identical, `rc=0`. The real file's md5 and mtime were
identical before and after.

**Not verified:** a real `home-manager switch` — not run, by instruction. Everything above
is the built artifact and its exact invocation, not the switch itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
