### PR TITLE
fix(next-step-nudge): the blocked family was only covered where another guard happened to overlap

### DIFF
--- a/scripts/claude-hooks/next-step-nudge.py
+++ b/scripts/claude-hooks/next-step-nudge.py
@@ -321,11 +321,22 @@ COMMITS = re.compile(
 #          on the wording its own advice recommends is the worst version of the defect
 #          that bullet exists to fix, so the arm closes it at the source rather than
 #          leaving a test to guard the exemplar's phrasing forever.
+#          `waiting for` and `blocked by` are the same family's other two prepositions,
+#          added after the same measurement was repeated on the plainest phrasings:
+#          "Waiting for the audit agent to report." and "This is blocked by an upstream
+#          decision that isn't mine." both FIRED, and the two neighbours that did
+#          suppress did so INCIDENTALLY — via DONE ("nothing to do until it clears") and
+#          COMMITS ("before I merge") — so the family was covered only where some other
+#          guard happened to overlap. An arm that holds only for the ornamented phrasing
+#          is not an arm; these close the plain one, which is the shape the blocked
+#          bullet below actually teaches.
 #    🔴 Widening a suppressor can only make this hook QUIETER, never louder, and that is
 #    the whole argument for taking (b) broad: a false suppression costs one missed nudge,
 #    a false fire costs a wrong injection into a turn that was already correct. So yes,
-#    "the request is waiting on the cache" mid-analysis now suppresses too. That is the
-#    trade, made deliberately and in the safe direction.
+#    "the request is waiting on the cache" mid-analysis now suppresses too — and with
+#    `waiting for`, so does "the job is waiting for the lock", which is the commonest
+#    mid-analysis sentence in this family. Stated here rather than discovered later: that
+#    is the trade, made deliberately and in the safe direction.
 #    The `your <noun>` arm is an enumerated set, not `your \w+`: "your repo is dirty" is
 #    a statement about the world, not a hand-off, and the open form would suppress it.
 OFFERS = re.compile(
@@ -335,7 +346,8 @@ OFFERS = re.compile(
     r"move|turn|PR|approval|sign[- ]?off)|"
     r"(?:ready|over|up) for (?:your )?review|"
     r"if you(?:['’]d| would)? (?:like|want|prefer)|on your (?:say|word|go)|"
-    r"awaiting|standing by|waiting on|blocked on|ready when you are|whenever you)\b",
+    r"awaiting|standing by|waiting on|waiting for|blocked on|blocked by|"
+    r"ready when you are|whenever you)\b",
     re.I)
 
 # 4. MARKED — a recommendation marked as such. Covers the "explicit numbered ask with a

--- a/scripts/claude-hooks/tests/test_next_step_nudge.py
+++ b/scripts/claude-hooks/tests/test_next_step_nudge.py
@@ -280,6 +280,18 @@ def test_every_suppressor_has_a_fixture():
 #     suppressor NAME, which says nothing about the ~30 alternation ARMS inside them —
 #     a mutation sweep deleting an arm survived, because a sibling arm kept the one
 #     fixture suppressed. Each entry below is owned by exactly one arm of one suppressor.
+#
+# 🔴 IF YOU ARE BUILDING A MUTATION BATTERY FOR THIS FILE, READ THIS FIRST. Deleting an
+#    arm from one of these alternations is a one-line edit that very easily produces
+#    INVALID REGEX OR INVALID PYTHON — an unbalanced group, a dangling `|`, a raw string
+#    truncated mid-literal. pytest then reports a COLLECTION ERROR, which is non-zero, and
+#    a sweep that reads only the exit status scores it as a KILL. It is not one: the
+#    module never imported, so no guard was ever exercised and the mutant proved nothing.
+#    This has now happened THREE times in this file's history, most recently on the
+#    whole-line OFFERS mutant. Two defences, both cheap: assert the mutated module still
+#    IMPORTS before running the suite, and require the kill to be a `failed` count rather
+#    than any non-zero rc. Substituting a never-matching literal (`__zzz_never__`) instead
+#    of deleting text keeps the syntax valid by construction.
 # --------------------------------------------------------------------------- #
 SUPPRESSOR_ARMS = {
     # COMMITS — the impersonal-future arm. No first-person pronoun anywhere, which is
@@ -329,6 +341,24 @@ SUPPRESSOR_ARMS = {
                            "reset.", "offers"),
     "offers_blocked_by": ("Blocked by the cache rollout that has to land before the "
                           "counter exists.", "offers"),
+    # ...and two arms in OTHER families that had no fixture either. Found the same way
+    # the PARKED gaps were — by running the battery over the WHOLE suppressor set — but
+    # by a battery built DIFFERENTLY from the one that certified the previous round: 29
+    # mutants instead of 19, enumerated arm-by-arm from the regex source rather than
+    # inherited. That sweep reported 27/29 with these two surviving, which the earlier
+    # 19-mutant sweep had scored as a clean run. A sweep is only a claim about the
+    # mutations someone imagined, so the fix is a differently-built sweep, never a
+    # bigger one.
+    #
+    # COMMITS' BARE `'ll` — no first-person pronoun, which is exactly what separates it
+    # from the `I'll`/`we'll` arm above it in the regex. The source comment justifies the
+    # impersonal-future family by name but never spells this arm, so nothing pointed at
+    # the gap.
+    "commits_bare_ll": ("There'll be one more delta re-audit once the counter lands.",
+                        "commits"),
+    # DONE's `that's it`. Same story: an arm with no fixture is an arm a sweep cannot
+    # kill, and this one sat unkillable through three rounds of work on this file.
+    "done_thats_it": ("That's everything the three runs support.", "done"),
 }
 
 
@@ -350,7 +380,11 @@ def test_each_alternation_arm_suppresses_the_turn(key):
 def test_arm_ledger_covers_every_arm_named_in_the_source_comments():
     """A ledger that can go stale silently is not a ledger. Pins the specific arms the
     source comments justify by name — deleting one from the regex without deleting the
-    fixture fails above, and adding one here without an arm fails immediately."""
+    fixture fails above, and adding one here without an arm fails immediately.
+
+    It also pins arms the source comments do NOT name, once a sweep has found them
+    surviving. That is the more useful half: an arm nobody wrote a sentence about is
+    exactly the arm nobody wrote a fixture for."""
     for arm in ("going to", "about to", "due to run", "queued to", "set to"):
         assert nsn.COMMITS.search(f"the work is {arm} happen"), arm
     for arm in ("defaults to", "leans toward", "worth a glance", "worth folding"):
@@ -360,6 +394,14 @@ def test_arm_ledger_covers_every_arm_named_in_the_source_comments():
     for arm in ("awaiting", "standing by", "waiting on", "blocked on",
                 "waiting for", "blocked by"):
         assert nsn.OFFERS.search(f"the turn is {arm} something"), arm
+    # COMMITS' BARE `'ll` — no first-person pronoun, which is the whole reason it is a
+    # separate arm from `I'll`/`we'll`. Named by no source comment; found only when a
+    # differently-built battery mutated it and the suite stayed green.
+    for arm in ("there'll", "it'll", "there’ll", "it’ll"):
+        assert nsn.COMMITS.search(f"{arm} land with the counter"), arm
+    # DONE's `that's it` arm. Same shape of gap, unkillable through three rounds here.
+    for arm in ("that's it", "that's all", "that’s everything"):
+        assert nsn.DONE.search(f"and {arm}"), arm
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/claude-hooks/tests/test_next_step_nudge.py
+++ b/scripts/claude-hooks/tests/test_next_step_nudge.py
@@ -317,6 +317,18 @@ SUPPRESSOR_ARMS = {
                         "comparison closes.", "offers"),
     "offers_standing_by": ("Standing by for the sweep to report on the retry loop.",
                            "offers"),
+    # ...and the family's other two prepositions, which were still unknown to OFFERS.
+    # Measured before the arm existed: the plain "Waiting for the audit agent to report."
+    # and "This is blocked by an upstream decision that isn't mine." both FIRED, while
+    # their ornamented neighbours suppressed only INCIDENTALLY — one via DONE, one via
+    # COMMITS. These two fixtures are deliberately free of that ornament (no "I'll", no
+    # "will", no "nothing further") so each is owned by OFFERS alone and a mutation
+    # deleting the arm leaves it FIRING rather than rescued by the sibling that happened
+    # to overlap in the corpus.
+    "offers_waiting_for": ("Waiting for the retry-loop sweep to report on the backoff "
+                           "reset.", "offers"),
+    "offers_blocked_by": ("Blocked by the cache rollout that has to land before the "
+                          "counter exists.", "offers"),
 }
 
 
@@ -345,7 +357,8 @@ def test_arm_ledger_covers_every_arm_named_in_the_source_comments():
         assert nsn.MARKED.search(f"it {arm} something"), arm
     # OFFERS' PARKED family. It was absent from this ledger entirely, which is how
     # `awaiting` and `standing by` came to have no fixture and survive a sweep.
-    for arm in ("awaiting", "standing by", "waiting on", "blocked on"):
+    for arm in ("awaiting", "standing by", "waiting on", "blocked on",
+                "waiting for", "blocked by"):
         assert nsn.OFFERS.search(f"the turn is {arm} something"), arm
 
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -823,7 +823,22 @@ TARGET_FLOORS=(
   # 2026-08-13, MERGED with main (#465's registrar target below, #459, #463). Both sides
   # of this conflict are KEPT — they pin different targets — and the number was re-read
   # from the gate run on the MERGED tree, not carried over from the branch measurement.
-  "scripts/claude-hooks/tests/test_next_step_nudge.py|116"
+  #
+  # 2026-08-13, the OFFERS `waiting for`/`blocked by` widening — the last two arms of the
+  # blocked/parked family: 122 -> 126 collected. +4 = two new PARKED-arm fixtures x the
+  # two parametrized arm tests. The branch is off fd88780 and `git merge-base --is-ancestor
+  # origin/main HEAD` is TRUE, so the MERGED tree and the branch tree are the same tree —
+  # this number is not a branch-only reading that a merge could invalidate. Measured by
+  # the AUTHORITATIVE gate, `nix build .#checks.x86_64-linux.pytests`, read out of `nix
+  # log` (the build was uncached here, but a cached one prints an EMPTY log and would
+  # otherwise read as a green with no counts):
+  #   PASS  scripts/claude-hooks/tests/test_next_step_nudge.py  (collected=126 passed=126 skipped=0 floor=116)
+  # put through the gate's OWN function rather than arithmetic:
+  #   _suggested_floor 126 = 126 - min(50, max(1, 126/20 = 6)) = 126 - 6 = 120.
+  # ZERO new skips; no HERMETIC_TARGETS entry needed (the file is already a target).
+  # If this line conflicts with a sibling branch, re-run the gate on the MERGED tree and
+  # copy what it prints — do not reconcile the two sides by hand.
+  "scripts/claude-hooks/tests/test_next_step_nudge.py|120"
   # 2026-08-13, the registrar's DELIVERY seam arrives as a NEW target: 17 collected.
   # Gate's own count through the gate's own rule:
   #   _suggested_floor 17 = 17 - min(50, max(1, 17/20 = 0 -> 1)) = 17 - 1 = 16.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -838,7 +838,25 @@ TARGET_FLOORS=(
   # ZERO new skips; no HERMETIC_TARGETS entry needed (the file is already a target).
   # If this line conflicts with a sibling branch, re-run the gate on the MERGED tree and
   # copy what it prints — do not reconcile the two sides by hand.
-  "scripts/claude-hooks/tests/test_next_step_nudge.py|120"
+  #
+  # 2026-08-13, same branch, closing the two arms a differently-built mutation sweep
+  # found SURVIVING (COMMITS' bare `'ll`, DONE's `that's it`): 126 -> 130 collected.
+  # +4 = two more arm fixtures x the two parametrized arm tests.
+  #
+  # ⚠ RE-MEASURED, and the earlier reading on this line is VOID — which is the whole
+  # argument for re-measuring rather than reconciling. The 126 above was taken when
+  # `origin/main` was fd88780; main moved to 71c0aa2 (#467) mid-round, so that number was
+  # a claim about a tree that no longer exists. This one was taken AFTER `git merge
+  # origin/main`, on the tree the merge actually produced. (#467 touched only
+  # claudedocs/handoff-subsystem-store.md, so the merge was textually AND semantically
+  # clean here — checked, not assumed: a clean `ort` merge only means no textual
+  # conflict.) The AUTHORITATIVE gate's own line, `nix build
+  # .#checks.x86_64-linux.pytests`, read out of `nix log`:
+  #   PASS  scripts/claude-hooks/tests/test_next_step_nudge.py  (collected=130 passed=130 skipped=0 floor=120)
+  #   TOTAL collected=9666  passed=9665  skipped=1  failed=0
+  # put through the gate's OWN function rather than arithmetic:
+  #   _suggested_floor 130 = 130 - min(50, max(1, 130/20 = 6)) = 130 - 6 = 124.
+  "scripts/claude-hooks/tests/test_next_step_nudge.py|124"
   # 2026-08-13, the registrar's DELIVERY seam arrives as a NEW target: 17 collected.
   # Gate's own count through the gate's own rule:
   #   _suggested_floor 17 = 17 - min(50, max(1, 17/20 = 0 -> 1)) = 17 - 1 = 16.


### PR DESCRIPTION
Closes the last two arms of `OFFERS`' blocked/parked family — `waiting for` and `blocked by` — plus the two arms in *other* families that a differently-built mutation sweep found unkillable. Follows #464 (`fd88780`), which added `waiting on` / `blocked on` and flagged these as still unknown to the predicate.

## The gap, measured against the deployed predicate

```
WOULD FIRE  []             Waiting for the audit agent to report.
suppressed  ['done']       Blocked by the pending deploy; nothing to do until it clears.
suppressed  ['commits']    Waiting for CI to go green before I merge.
WOULD FIRE  []             This is blocked by an upstream decision that isn't mine.
```

The two that suppressed did so **incidentally** — via `DONE` ("nothing to do until it clears") and `COMMITS` ("before I merge"), not because the family was covered. The hole showed only on the plainest phrasing, which is exactly the shape NUDGE's own blocked bullet teaches. An arm that holds only for the ornamented phrasing is not an arm.

## After

```
suppressed  ['offers']              Waiting for the audit agent to report.
suppressed  ['offers', 'done']      Blocked by the pending deploy; nothing to do until it clears.
suppressed  ['commits', 'offers']   Waiting for CI to go green before I merge.
suppressed  ['offers']              This is blocked by an upstream decision that isn't mine.
```

All four now carry `offers`, including the two that previously only overlapped another guard.

## The change to the predicate

Two literals added to one alternation. No other suppressor, no gate, no constant, no prose.

The safety argument is the design's own and unchanged: suppressors are lexical, so widening one can only make the hook **quieter**. A false suppressor costs one missed nudge; a false fire costs a wrong injection on a turn that was already correct.

The cost is **recorded in the source**, not left to be discovered: `waiting for` also suppresses mid-analysis phrasings like "the job is waiting for the lock".

## Verification

**Positive control, reported as a pair** — a suppressor set that suppresses everything is indistinguishable from a fix:

| | before | after |
|---|---|---|
| the four blocked endings suppressed | 2/4, both incidentally | **4/4, all by `offers`** |
| `NO_NEXT_STEP` endings that still FIRE | 5/5 | **5/5** |

**Arm-grain fixtures**, each measured `suppressed_by(...) == [owner]` so no sibling can shadow it, and each added to the arm ledger.

**Full mutant battery** over the whole suppressor set — 29 mutants, built independently of the 19 that certified the previous round (enumerated arm-by-arm off the regex source rather than inherited), each applied to a pristine copy with its pattern asserted to occur exactly once:

```
BASELINE (unmutated copy): imports=True  failed=0 passed=130 errors=0
MUTANTS: 29  killed=29  survivors=0  vacuous=0  misapplied=0
SURVIVORS: none
```

### Two survivors, found and then closed

The first run of that battery was **27/29**. The two survivors were **pre-existing arms in families this PR does not otherwise touch**, neither of which the older 19-mutant sweep had ever mutated:

* `COMMITS`' **bare `'ll`** ("there'll be…") — a separate arm from `I'll`/`we'll` precisely because it carries no first-person pronoun, and named by no source comment.
* `DONE`'s **`that's it`**.

Neither had a fixture, so neither was killable, and both sat that way through three rounds of work on this file. Both now have arm-grain fixtures, measured uniquely owned (`['commits']` / `['done']`), and both are in the ledger. The ledger's docstring now says it also pins arms the source comments do *not* name — the more useful half, since an arm nobody wrote a sentence about is exactly the arm nobody wrote a fixture for.

### 🔴 An instrument bug, recorded where the next battery-builder will read it

The first run scored a **vacuous kill**: the whole-line `OFFERS` mutant produced invalid regex source, pytest raised a *collection error*, and that is non-zero — so a sweep branching on the exit code counts it as a kill. It is not one. The module never imported, so no guard was ever exercised. **This has now happened three times in this file's history**, so it is noted at the top of the ARMS section in `test_next_step_nudge.py` with the two cheap defences.

The re-run sweep was hardened accordingly — import the mutated module first and refuse to score it if that raises; require the kill to be a non-zero `failed=` **count**, never a non-zero rc. The previously-vacuous mutant now kills for real at `failed=13`. **The clean 29/29 is the result of a stricter sweep, not a narrower one.**

## Gate

| | before | after |
|---|---|---|
| `test_next_step_nudge.py` collected | 122 | **130** (+8 = 4 fixtures × 2 parametrized arm tests) |
| floor | 116 | **124** |

```
PASS  scripts/claude-hooks/tests/test_next_step_nudge.py  (collected=130 passed=130 skipped=0 floor=124)
TOTAL collected=9666  passed=9665  skipped=1  failed=0  (floor: 9171 = sum of 19 per-target floors)
RESULT: PASS (exit=0)
```

Counts read from `nix log`, never the build's stdout — a cached build prints an *empty* log and would read as a green carrying no counts.

**Floor arithmetic, on the merged tree.** An earlier reading of 126 on this branch is **void**: it was taken when `origin/main` was `fd88780`, and main moved to `71c0aa2` (#467) mid-round. The number below was measured *after* `git merge origin/main`, on the tree the merge produced. #467 touched only `claudedocs/handoff-subsystem-store.md`, so the merge is clean here textually **and** semantically — checked, not assumed, since a clean `ort` merge only means "no textual conflict".

```
_suggested_floor 130 = 130 - min(50, max(1, 130/20 = 6)) = 130 - 6 = 124
```

## Not verified

**Nothing is deployed.** `readlink -f ~/.claude/hooks/next-step-nudge.py` → `/nix/store/3pws9lkdwzakfdz9albqdgr4kszmg7x8-hm_nextstepnudge.py`, i.e. the live hook is still the old store copy and these edits are git-only. No `home-manager switch`, no registrar run, no `settings.json` touched (0 changes to it across the branch), no tmux touched.

Behaviour above is verified against the **source predicate**, not against a running Stop hook. The `waiting for` cost is stated from reading the regex, not measured against a real corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
