### PR TITLE
fix(handoff): "worktree" was read as "use --commit", and a dead end never named the window it had not read

### DIFF
--- a/claude/skills/handoff/SKILL.md
+++ b/claude/skills/handoff/SKILL.md
@@ -109,7 +109,9 @@ Topic argument (optional): `$ARGUMENTS`. If empty, infer a short kebab-case topi
 
    Closed-unmerged PRs are refused by name — their files exist in no tree. `OPEN` and `MERGED` are both accepted, so a PR still in review counts. The `gh` call can fail in ways nothing local can (`gh` missing, not authenticated, network down, rate-limited, a truncated file list); every one exits non-zero with its own named line, and **none of them ever returns an empty path set**, so an empty result from this source always means the PRs genuinely listed no files.
 
-   🔴 **If the work did not land through a PR — a direct push, or a repo whose own rules force every edit into a throwaway worktree — run it over the SHAS YOU CREATED:**
+   🔴 **The discriminator is whether the work LANDED AS A PR — never whether a worktree was involved.** A throwaway worktree goes both ways and the clause below is one *example* of "no PR", not an independent trigger: in the repo holding most of this store, 144 of its last 200 mainline commits carry no `(#N)`, so `--commit` is right there; elsewhere the same worktree rule lands PRs and `--pr` is the only source that sees them. MEASURED 2026-08-14: a session read "worktree" as "use `--commit`", ran it over five of its own shas, got `no-match` on one `claudedocs/` path — the base-clone shas were just the handoff doc — and reported "a real zero, index unchanged, correctly". Real for the window read; the window was wrong. **Ask which way yours landed.** 📖 `reference/index-write.md` §3.
+
+   🔴 **If the work became a commit but NO PR — a direct push, or a branch not opened yet — run it over the SHAS YOU CREATED:**
 
    ```
    python3 /home/zach/workspace/devrc/scripts/lib/subsystem_touch.py --repo <repo> --commit <sha>[,<sha>...]
@@ -133,6 +135,8 @@ Topic argument (optional): `$ARGUMENTS`. If empty, infer a short kebab-case topi
    - **`ambiguous` listed** — report the candidates and **write nothing** for that ref. The resolver refuses to pick; so do you.
    - **`no-match` / `scope-absent`** — no existing entry was touched. `scope-absent` means this repo has no scope directory yet: the **first-entry case, not a failure**, and the reason this step exists. Nothing to append either way; go to the NO ENTRY clause below.
    - **`looked-at-nothing`** — say so plainly and write nothing. This is *not* "nothing touched an entry": no path was examined at all. Never report the two as the same result.
+
+   🔴 **On either dead end the tool now prints a `ROUTE OUT` block naming the windows it did NOT read** — read it before concluding "a real zero". A zero is a fact about the window, and the four windows are blind in different directions; the block excludes the source that just failed, so every line in it is a move you have not made. It appears on `looked-at-nothing` and `no-match` only, never on a resolved run.
 
    **Separately, and independently of `status=`: if a `NO ENTRY` block is printed, consider a new entry.** It appears alongside `resolved` too — a session normally touches a known subsystem *and* an unrecorded one, and treating nominations as a `no-match`-only concern is what would stop entries ever accruing in a repo that already has one. Pick **at most one** nomination that is a real durable subsystem, or none — they are candidates, not answers, and rejecting all of them is a normal outcome. `--template <slug>` prints the entry to write — identity front matter (`scope`, `sensitivity: client-confidential`, `created_by: handoff`) plus `## What it is` and `## Pointers`. **Do not demand the full schema** — a thin entry that exists beats a rich one that doesn't. Uncomment the template's `aliases:` line if the subsystem is spelled more than one way, in particular the `test_<slug>` stem: matching is exact, so without it a module and its own test count as one path and stay under the threshold forever.
 

--- a/claude/skills/handoff/reference/index-write.md
+++ b/claude/skills/handoff/reference/index-write.md
@@ -51,7 +51,7 @@ This is the shape worth seeing at a glance, because each case has arrived separa
 
 1. **Subagent turns** — a separate transcript. 196 of 733 file-tool calls (above). Answer: `--pr`.
 2. **Files written by a `Bash` command** rather than a file tool — never recorded as an edit. Answer: `--pr`/`--commit`.
-3. **A repo whose rules mandate committing from a throwaway worktree** — 25 paths outside the session cwd and 0 inside. Answer: `--commit`.
+3. **A repo whose rules mandate committing from a throwaway worktree** — 25 paths outside the session cwd and 0 inside. Answer: `--commit` **or** `--pr`, and the worktree does not decide which — **whether the work landed as a PR does.** In the repo measured above, 144 of 200 mainline commits carry no `(#N)`, so `--commit` is right there; a worktree whose branch was opened as a PR is a `--pr` case, and reading "worktree" as "use `--commit`" cost a session its index write on 2026-08-14 (five base-clone shas, one `claudedocs/` path, reported as a real zero).
 4. **A session whose cwd is one repo while its work landed in another** — *partially* answered since 2026-08-13 by the `session-absolute` window, and refused with `transcript cwd does not match` only when that window is empty. Answer when refused: `--pr`/`--commit`.
 
 🔴 **All four are CORRECT behaviour, all four are already stated in the `caveat:` line, and in none of them is the fix a change to the session source** — with case 4 the documented exception, and the way it was wrong is worth keeping.

--- a/scripts/lib/subsystem_touch.py
+++ b/scripts/lib/subsystem_touch.py
@@ -3117,6 +3117,105 @@ def new_entry_template(slug: str, scope: str, *, today: str) -> str:
 
 
 # --- Rendering -----------------------------------------------------------------
+# 🔴 THE ROUTE OUT OF A DEAD END. A window that resolved nothing is a fact about
+# THE WINDOW READ, never about the session — and the four windows are blind in
+# different directions, so the agent's next move is to read a different one. The
+# tool knows which one it just ran and the alternatives are a closed set, so it
+# can say this deterministically instead of leaving the skill to describe it in
+# prose and the agent to remember at the one moment it is being told "no".
+#
+# MEASURED, 2026-08-14, the incident this exists for: a session in a repo whose
+# rules force every edit into a throwaway worktree got `looked-at-nothing` from
+# `--session` (0 paths under the session cwd, 12 outside it — structural there,
+# not occasional), correctly fell through to `--commit` over the shas it had
+# made, and got `no-match` over ONE `claudedocs/` path from five commits. It
+# reported that as "a real zero, index unchanged, correctly". The zero was real
+# for the window read and the window was the wrong one: that session's work was
+# committed inside the worktree and landed as a PR, so the base-clone shas were
+# just the handoff doc. `--pr` — the only source that sees it — was never tried,
+# and nothing on screen named it. 🔴 The trigger was reading "worktree" as "use
+# `--commit`"; the real discriminator is whether the work LANDED AS A PR, and a
+# worktree goes both ways (in the repo holding most of this store, 144 of its
+# last 200 mainline commits carry no `(#N)`, so `--commit` IS right there).
+# Which is why this block names every unread window rather than picking one.
+#
+# The mapping is deliberately NOT a recommendation engine. It states which
+# windows exist and which was read; choosing among them stays with the agent,
+# which is why every line carries what that source uniquely sees rather than a
+# score.
+# 🔴 Keyed by SOURCE, not by matching the flag's spelling. An earlier draft
+# excluded the used source by comparing the first token of two display strings,
+# which silently failed for the git window (`(git, the default)` vs `(no flag)`
+# share no prefix) — so the git window would have suggested itself. A window maps
+# to a source; a source has one row. No string arithmetic.
+_WINDOW_SOURCE: dict[str, str] = {
+    "session": "session",
+    "session-absolute": "session",
+    "branch": "git",
+    "worktree": "git",
+    "pull-requests": "pr",
+    "commits": "commit",
+    # `supplied` is the in-process/test entry point and belongs to no flag, so
+    # it excludes nothing: all four real windows genuinely are untried.
+    "supplied": "",
+}
+
+# (source, flag, what it UNIQUELY sees). The `why` is what the source can see
+# that the others cannot — never a score, because choosing among them is the
+# agent's call and this block is a statement of fact, not a recommendation.
+_ROUTE_OUT: tuple[tuple[str, str, str], ...] = (
+    (
+        "pr",
+        "--pr <n>[,<n>...]",
+        "the only source that sees a SUBAGENT's work, and the only one that "
+        "sees work committed inside a throwaway worktree AND landed as a PR",
+    ),
+    (
+        "commit",
+        "--commit <sha>[,<sha>...]",
+        "work that became a commit but no PR — a direct push, or a branch not "
+        "opened yet",
+    ),
+    (
+        "session",
+        "--session <uuid>",
+        "what THIS session's own turns edited, independent of git — blind to a "
+        "subagent's work and to anything outside the session cwd",
+    ),
+    (
+        "git",
+        "(no flag)",
+        "the git branch/worktree window — blind to work already merged",
+    ),
+)
+
+_SOURCE_FLAG: dict[str, str] = {src: flag for src, flag, _ in _ROUTE_OUT}
+
+
+def render_route_out(window: str) -> list[str]:
+    """The untried windows, named, for a run that resolved nothing.
+
+    Excludes the source that produced THIS window: re-running the one that just
+    came back empty is the single suggestion that cannot help, and printing it
+    would make the block read as boilerplate rather than as a route.
+    """
+    used = _WINDOW_SOURCE.get(window, "")
+    read = _SOURCE_FLAG.get(used, window)
+    lines = [
+        "",
+        "ROUTE OUT — a dead end is a fact about THE WINDOW READ, not about the "
+        "session.",
+        f"  read: {read}.  The other windows were NOT read:",
+    ]
+    for src, flag, why in _ROUTE_OUT:
+        if src == used:
+            continue
+        lines.append(f"    {flag:<26} {why}")
+    lines.append(
+        "  Run at most ONE more, on its own — the windows never compose (see "
+        "the skill: run it twice, never merge the two path sets)."
+    )
+    return lines
 
 
 def render_text(report: TouchReport) -> str:
@@ -3150,6 +3249,7 @@ def render_text(report: TouchReport) -> str:
             "'nothing touched an entry'; no path was examined at all."
         )
         out.append("Propose no write. Say which window was empty and why.")
+        out.extend(render_route_out(src.window))
         return "\n".join(out)
 
     if report.status == "scope-absent":
@@ -3257,6 +3357,7 @@ def render_text(report: TouchReport) -> str:
         else:
             out.append(f"NOTHING TO PROPOSE — {examined}; see the accounting above.")
         out.append("Propose no write.")
+        out.extend(render_route_out(src.window))
 
     return "\n".join(out)
 

--- a/scripts/tests/test_subsystem_touch.py
+++ b/scripts/tests/test_subsystem_touch.py
@@ -7572,3 +7572,104 @@ class TestValidateMutationKills:
         assert mod.validate_entry_file(bad) is not None
         assert mod.validate_entry_file(store / SCOPE / "collector.md") is None
         assert mod.governing_policy(store, SCOPE)[1] == mod.POLICY_SCOPE
+
+
+# =============================================================================
+# The route out of a dead end.
+# =============================================================================
+
+
+class TestRouteOutOfADeadEnd:
+    """🔴 MEASURED 2026-08-14, and this class is that incident.
+
+    A session in a repo whose rules force every edit into a throwaway worktree
+    got `looked-at-nothing` from `--session` (0 paths under the session cwd, 12
+    outside it — structural there, not occasional), correctly fell through to
+    `--commit` over the shas it had made, and got `no-match` over ONE
+    `claudedocs/` path from five commits. It reported that as "a real zero,
+    index unchanged, correctly".
+
+    The zero was real FOR THE WINDOW READ, and the window was the wrong one:
+    worktree work is committed in the worktree and lands as a PR, so the
+    base-clone shas were just the handoff doc. `--pr` — the only source that
+    sees it — was never tried, and nothing on screen named it. The skill said so
+    in prose; the agent was being told "no" at the moment it needed to remember.
+    So the tool says it instead.
+    """
+
+    def test_a_no_match_names_the_windows_it_did_NOT_read(self, store: Path) -> None:
+        text = st.render_text(_report(["docs/a.md", "notes/b.md"], store))
+        assert "ROUTE OUT" in text
+        for flag in ("--pr", "--commit", "--session"):
+            assert flag in text, flag
+
+    def test_looked_at_nothing_names_them_too(self, store: Path) -> None:
+        """The other dead end, and the one the incident hit FIRST. It returns
+        early from the renderer, so it needs its own assertion — a block added
+        to one exit and not the other is exactly the shape that leaves the
+        commonest path uncovered."""
+        text = st.render_text(_report([], store))
+        assert "ROUTE OUT" in text and "--pr" in text
+
+    def test_a_RESOLVED_run_stays_silent(self, store: Path) -> None:
+        """🔴 The negative control, and the reason this is worth having: a block
+        printed on every run is boilerplate, and boilerplate is skipped. It
+        appears only where the agent is stuck."""
+        text = st.render_text(_report(["src/collector/a.py", "src/collector/b.py"], store))
+        assert "ROUTE OUT" not in text
+
+    def test_the_source_that_just_FAILED_is_not_suggested_back(self) -> None:
+        """Re-running the window that came back empty is the one move that
+        cannot help. Asserted per window, including both spellings that share a
+        source — `session`/`session-absolute` and `branch`/`worktree` — because
+        a mapping that covers one spelling and not its twin fails only on the
+        rarer one."""
+        cases = {
+            "commits": "--commit",
+            "pull-requests": "--pr",
+            "session": "--session",
+            "session-absolute": "--session",
+            "branch": "(no flag)",
+            "worktree": "(no flag)",
+        }
+        for window, own in cases.items():
+            body = "\n".join(st.render_route_out(window)[3:-1])
+            assert own not in body, f"{window} suggested its own source back"
+            # ...and it still offers the other three, so exclusion never empties
+            # the block
+            assert len(body.strip().splitlines()) == 3, window
+
+    def test_an_unknown_window_excludes_NOTHING_rather_than_guessing(self) -> None:
+        """🔴 The fail-safe direction. `supplied` is the in-process entry point
+        and belongs to no flag; a future window name nobody mapped lands here
+        too. Offering one source too many costs a reader a line; silently
+        dropping the one they needed costs them the lesson.
+
+        🔴 ASSERTED ON THE ROWS, NOT THE WHOLE BLOCK — and that is the fix for a
+        defect in this very test. It used to search the joined block, which
+        includes the `read:` header naming the source that was used. A mutant
+        defaulting the unknown window to `"pr"` therefore dropped the `--pr` ROW
+        while `--pr` still appeared in the header, and the assertion passed: a
+        guard satisfied by the same word somewhere else in the output. Counting
+        the rows is what makes it structural.
+        """
+        for window in ("supplied", "some-window-added-later"):
+            rows = st.render_route_out(window)[3:-1]
+            assert len(rows) == 4, (window, rows)
+            body = "\n".join(rows)
+            for flag in ("--pr", "--commit", "--session", "(no flag)"):
+                assert flag in body, (window, flag)
+
+    def test_every_window_the_tool_can_emit_is_mapped(self) -> None:
+        """🔴 A ledger, failing in both directions. An unmapped window falls back
+        to naming the raw window string in `read:`, which is honest but tells the
+        reader nothing about which flag produced it — and a mapping for a window
+        that no longer exists is a phantom."""
+        emitted = {
+            "session", "session-absolute", "branch", "worktree",
+            "pull-requests", "commits", "supplied",
+        }
+        assert set(st._WINDOW_SOURCE) == emitted
+        # every mapped source (bar the deliberate blank) has exactly one row
+        mapped = {s for s in st._WINDOW_SOURCE.values() if s}
+        assert mapped == {src for src, _, _ in st._ROUTE_OUT}


### PR DESCRIPTION
A session using `/handoff` reported two "write nothing" outcomes and concluded the index was correctly left unchanged. One of the two was wrong, and the skill's own wording caused it.

## What happened

That repo's rules force every edit into a throwaway worktree. So:

| step | result | correct? |
|---|---|---|
| `--session` | `looked-at-nothing` — 0 paths under the session cwd, 12 outside | ✅ and *structural* there, not occasional |
| fell through to `--commit` over its own shas | `no-match` on **one** `claudedocs/` path from **five** commits | ❌ wrong window |
| conclusion: "a real zero. Index unchanged, correctly." | — | ❌ real for the window read |

Five commits touching exactly one doc is the signature: that session's work was committed *inside* the worktree and landed as a **PR**, so the shas it made in the base clone were just the handoff doc. `--pr` — the only source that sees a subagent's work, and the only one that could see this — was never tried, and **nothing on screen named it**.

## Cause 1: an em-dash list that reads as two independent triggers

```
If the work did not land through a PR — a direct push, OR a repo whose own
rules force every edit into a throwaway worktree — run it over the SHAS
```

The second clause fired on its own. Both are now stated as what they are — *examples* of "no PR" — with the question to ask made explicit.

🔴 **The fix is NOT "worktree ⇒ `--pr`" either**, and I nearly shipped that. `reference/index-write.md` §3 already measured the repo holding most of this store at **144 of its last 200 mainline commits carrying no `(#N)`**, so `--commit` is right *there* despite the same worktree rule. A worktree goes both ways; **whether a PR landed** is the discriminator. That section stated "Answer: `--commit`" flatly and is corrected to match.

## Cause 2, and the actual fix: the tool never named the window it hadn't read

Prose in a skill is read *before* the work. The agent needed this at the moment the tool was telling it "no" — which is exactly where a prose instruction is weakest and a deterministic one is strongest.

`subsystem_touch.py` now prints a `ROUTE OUT` block on both dead-end statuses:

```
ROUTE OUT — a dead end is a fact about THE WINDOW READ, not about the session.
  read: --commit <sha>[,<sha>...].  The other windows were NOT read:
    --pr <n>[,<n>...]          the only source that sees a SUBAGENT's work, and the only one
                               that sees work committed inside a throwaway worktree AND landed as a PR
    --session <uuid>           what THIS session's own turns edited, independent of git — …
    (no flag)                  the git branch/worktree window — blind to work already merged
  Run at most ONE more, on its own — the windows never compose.
```

Three properties worth stating:

- **It excludes the source that just failed.** Re-running the window that came back empty is the one suggestion that cannot help, and printing it would make the block read as boilerplate.
- **It is silent on a resolved run.** A block printed every time is boilerplate, and boilerplate is skipped.
- **It is not a recommendation engine.** It states which windows exist and which was read; every row carries what that source *uniquely* sees rather than a score. Choosing stays with the agent — deliberately, because as the §3 measurement shows, the right choice is repo-dependent.

## Verification

- `nix build .#checks.x86_64-linux.pytests` — `collected=9793 passed=9792 skipped=1 failed=0`.
- **Mutation sweep, 9 mutants: 8 killed, 0 survived**, comment-only control survived.

Three things about the sweep itself are worth recording, because each one is a case of the instrument being wrong before the code was:

1. 🔴 **It found a defect in one of my own new tests**, and it is the *spelled-not-structural* shape. The test searched the joined block — which includes the `read:` header naming the used source — so a mutant that dropped the `--pr` **row** while leaving `--pr` in the **header** passed. It counts the rows now.
2. **The sweep runs in place.** Two rounds of growing a per-mutant copy list left the CONTROL red (the suite is coupled to the real tree: git operations, deployed skill docs, the session-tailer extractor), and a sweep on a red baseline kills nothing. So: `cp -a` backup, restore in a `finally`, and a sha256 reported **before and after** — byte-identical.
3. **Its import probe had to be fixed before it measured anything.** A module exec'd but never registered in `sys.modules` makes `dataclasses` raise, which is indistinguishable from a mutant that will not import — every mutant scored `BAD-MUTANT` until then. Validate the instrument before reading its verdict.

## Not addressed

The reported session's index write is still outstanding — if it landed a PR, re-running `--pr <n>` over it may turn up a subsystem whose lesson is currently lost. That is a re-run of the step, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
