### PR TITLE
perf(session-manager): 34% of every --json payload was indentation for a reader who does not exist

### DIFF
--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -2831,7 +2831,7 @@ def main(argv=None):
             stays on stderr, so a JSON reader is unaffected either way.
             """
             if args.json:
-                print(json.dumps(res, indent=2))
+                print(json.dumps(res, separators=(",", ":")))
 
         if not res["reachable"]:
             # The host said nothing at all. This is the unmeasured case.
@@ -2862,7 +2862,7 @@ def main(argv=None):
             _tail_json()
             return EXIT_USAGE
         if args.json:
-            print(json.dumps(res, indent=2))
+            print(json.dumps(res, separators=(",", ":")))
         else:
             sys.stdout.write(res["text"])
             # The defaulted host is recorded in the JSON but was INVISIBLE in
@@ -2898,7 +2898,18 @@ def main(argv=None):
                                                    use_ch=not args.no_ch)
 
     if args.json:
-        print(json.dumps(report, indent=2, sort_keys=True, default=str))
+        # 🔴 COMPACT, NOT INDENTED, and the reason is measured. The ONLY
+        # consumer of this tool is an agent — 0 interactive shell invocations
+        # in 30 days against 55 agent references (spec §7), confirmed by the
+        # operator 2026-08-14 — and an agent pays for output by the TOKEN.
+        # Measured on a 75-row scan: 86,066 B indented against 60,631 B
+        # compact, so 29% of every payload was whitespace formatting for a
+        # reader who does not exist. That is ~6,400 tokens per call.
+        # `sort_keys` STAYS: it costs nothing and makes two scans diffable.
+        # A human who wants it readable can pipe it through `jq .`, which is
+        # what they would do anyway.
+        print(json.dumps(report, sort_keys=True, default=str,
+                         separators=(",", ":")))
     else:
         print(render_table(report))
         if "session_history" in report:

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -5755,3 +5755,55 @@ def test_the_table_names_the_rejections_and_the_unverified_separately():
     assert "rejected:" in text
     assert "1 window gone" in text and "1 older tmux server" in text
     assert "unverified generation" not in text
+
+
+# --------------------------------------------------------------------------- #
+# §10 — the output is priced for an AGENT, because that is the only consumer
+# --------------------------------------------------------------------------- #
+def test_the_json_is_COMPACT_because_the_only_consumer_pays_by_the_token(
+        monkeypatch, capsys, absent_blocked_cache):
+    """🔴 MEASURED, and the measurement is the whole argument. This tool has 0
+    interactive shell invocations in 30 days against 55 agent references (spec
+    §7), confirmed by the operator 2026-08-14: an AGENT is the only consumer,
+    and an agent pays for output by the token.
+
+    Indented at 2 spaces, a 75-row scan emitted 86,066 B against 60,631 B
+    compact — 29% of every payload was whitespace for a reader who does not
+    exist, about 6,400 tokens per call.
+
+    KILLS: restoring `indent=2` (or any indent) at any of the three emit sites.
+    Asserted as a PROPERTY of the bytes rather than by grepping the source for
+    `indent`, so a differently-spelled reformat is caught too.
+    """
+    monkeypatch.setattr(sm, "local_host_label", lambda *a, **k: "workbench")
+    monkeypatch.setattr(sm, "_default_runner", make_runner())
+    monkeypatch.setattr(sm, "read_fuzzyclaw_texts", lambda *a, **k: [])
+    sm.main(["scan", "--no-ch", "--no-ledger", "--host", "workbench", "--json"])
+    out = capsys.readouterr().out
+
+    # it parses...
+    parsed = json.loads(out)
+    assert parsed["local_host"] == "workbench"
+    # ...on ONE line, and with no run of spaces an indent would produce
+    assert out.count("\n") == 1, "the payload is not a single line"
+    assert '": ' not in out, "a key/value separator carries indent padding"
+    assert "  " not in out, "the payload carries multi-space padding"
+
+    # ...and the compaction is real, not cosmetic: re-encoding it indented is
+    # measurably larger, which is the cost this refuses to pay.
+    indented = json.dumps(parsed, sort_keys=True, indent=2, default=str)
+    assert len(indented) > len(out.strip()) * 1.2, (
+        "compaction saved less than 20% — the claim in the source comment "
+        "no longer holds for this payload shape")
+
+
+def test_sort_keys_SURVIVES_the_compaction():
+    """🔴 The half that must NOT be dropped while trimming bytes. `sort_keys`
+    costs nothing and is what makes two scans diffable — an agent comparing a
+    before/after would otherwise see key reordering as change."""
+    report = base_gather()
+    blob = json.dumps(report, sort_keys=True, default=str,
+                      separators=(",", ":"))
+    top = [k.strip('"') for k in
+           __import__("re").findall(r'"([a-z_]+)":', blob)[:4]]
+    assert top == sorted(top), top


### PR DESCRIPTION
perf(session-manager): 34% of every --json payload was indentation for a reader who does not exist

The operator confirmed 2026-08-14 what spec §7 measured — 0 interactive shell
invocations of this tool in 30 days against 55 agent references. An AGENT is
the only consumer, and an agent pays for output by the TOKEN, not by the pixel.

MEASURED on a live 75-row cross-host scan:

  indented (indent=2)   86,066 B   ~21,516 tokens
  compact               56,052 B   ~14,013 tokens
  saved                 30,014 B   ~7,503 tokens per call, 34%

Zero information loss — same keys, same values, same order. `sort_keys` is
deliberately KEPT: it costs nothing and is what makes two scans diffable, so an
agent comparing before/after does not read key reordering as change. A human who
wants it readable pipes it through `jq .`, which is what they would do anyway.

All three emit sites (`scan`, `detail`, `tail`) were indented; all three are
compact now.

The guard asserts a PROPERTY OF THE BYTES — single line, no key/value padding,
no multi-space run — rather than grepping the source for `indent`, so a
differently-spelled reformat is caught too. It also re-encodes the payload
indented and requires the saving to still exceed 20%, which turns the claim in
the source comment into something that fails when it stops being true.

🔴 WHAT THIS DOES **NOT** FIX, so it is not mistaken for the whole answer.
Neither output shape is right for the only consumer:

  * the TABLE is cheap (~3,280 tokens) and LOSSY — measured 73 truncated cells,
    45 of 75 rows whose task text exceeds the 25-char column, unrecoverable by
    the reader.
  * the JSON is lossless and still ~14,013 tokens after this change, which is
    a large fraction of a context window for one call.

An agent-shaped view — the fields that answer "what is being worked on, what is
waiting on me", untruncated, without the per-row `ledger`/`fuzzyclaw` sub-objects
that duplicate fields already on the row (7,039 B of 60,631 B) — would beat both.
That is a design decision about which fields an agent actually needs, so it is
deliberately not smuggled in here.

Verification: `nix build .#checks.x86_64-linux.pytests` — collected=9807
passed=9806 skipped=1 failed=0.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
