### PR TITLE
feat(agent-ledger): writer 2 — opencode windows had a row with no age and no session id

### DIFF
--- a/claude/skills/session-manager/SKILL.md
+++ b/claude/skills/session-manager/SKILL.md
@@ -186,9 +186,9 @@ slot-conflict drop does and does not still catch, and the field ledger:
 Measured 2026-08-12 on the shipped default view: **0 rows with an age, 0 with a session id,
 no `stale` bucket at all** — and nothing in the output said so.
 
-A devrc-owned Claude hook now writes one record per tmux pane into `~/.cache/agent-ledger/`,
-and the script reads each host's ledger with one `sh -c` (locally and over SSH). Read
-`report["ledger"]`, never just the row:
+Two writers now record one file per tmux PANE into `~/.cache/agent-ledger/` — a devrc-owned
+Claude hook, and an opencode plugin — and the script reads each host's ledger with one `sh -c`
+(locally and over SSH). Read `report["ledger"]`, never just the row:
 
 - `status` — `ok` / `partial` (some host did not answer) / `error` / `skipped`. Only `ok`
   and `partial` publish integers; the rest are `null`, never `0`.
@@ -198,8 +198,13 @@ and the script reads each host's ledger with one `sh -c` (locally and over SSH).
 - `summary.rows_with_age` / `rows_with_session_id` / `age_sources` — the meter. A `stale=0`
   bucket means *either* nothing is stale *or* nothing has an age; only this tells them apart.
 
-Row fields: `age_secs`, `age_source` (`ledger` / `fuzzyclaw` / `null` — which writer
-answered; the ledger wins), `ledger` (the joined record), `claude_session_id`.
+Row fields: `age_secs`, `age_source` (`ledger` / `fuzzyclaw` / `null` — which SOURCE answered;
+the ledger wins), `runtime` (`claude` / `opencode` / `null` — which AGENT recorded it), `ledger`
+(the joined record), `claude_session_id`.
+
+🔴 `runtime` is not `claude`. The `claude` column is `pane_current_command =~ /claude/`, so an
+opencode window reads `shell` — an agent counted as a bare prompt in every bucket. `runtime` is
+what the row says it actually is.
 
 🔴 **A null age is not age 0** — it means no writer has recorded that window. A session that
 has not taken a turn since the hook was registered has none yet.

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1202,6 +1202,29 @@ in
   home.file.".config/opencode/plugin/activity.js".source =
     ../scripts/collector/opencode/activity-plugin.js;
 
+  # 🔴 WRITER 2 of the agent activity ledger — opencode's half of what makes a
+  # `session-manager` row carry an age, a `stale` bucket and a session id.
+  # Writer 1 is the Claude hook; without this every opencode window is a row
+  # with no age, which is the #419 shape narrowed to one runtime. Spec:
+  # claudedocs/spec-agent-activity-ledger.md §3.
+  #
+  # It holds NO schema: it shells out to `agent_ledger.py --write`, the same
+  # module session-manager reads the record shape from — so writer 2 cannot
+  # drift from writer 1. That is why the module is deployed BESIDE it here, the
+  # same arrangement guard.js has with guard_core.py. `ledger.js` looks for it
+  # at `~/.config/opencode/agent_ledger.py` first.
+  #
+  # Same deployment constraints as guard.js/env.js: directly in `plugin/`,
+  # `.js` only, non-recursive glob, and NEVER also in `plugins/` (plural) — the
+  # glob reads both and a file in each loads the plugin twice.
+  #
+  # 🔴 Both are NEW files and must be `git add`ed or the flake silently omits
+  # them: the switch succeeds and opencode simply never writes a record.
+  home.file.".config/opencode/plugin/ledger.js".source =
+    ../scripts/opencode/plugin/ledger.js;
+  home.file.".config/opencode/agent_ledger.py".source =
+    ../scripts/lib/agent_ledger.py;
+
   # `shell.env` plugin — the only supported seam for putting environment into
   # opencode's bash tool (there is no `env` config key; setting one is silently
   # ignored). NOTE the bash tool DOES source .zshenv on this host — see the

--- a/scripts/claude-hooks/agent-ledger-hook.py
+++ b/scripts/claude-hooks/agent-ledger-hook.py
@@ -72,35 +72,6 @@ WRITE_EVENTS = {"SessionStart", "UserPromptSubmit", "PostToolUse", "Stop"}
 PRUNE_EVENTS = {"SessionStart", "Stop"}
 
 
-def tmux_context(runner=None, pane=None):
-    """`(window_id, tmux_pid)` for this pane, or `(None, None)`.
-
-    ONE tmux call for both fields: they come from the same server and asking twice
-    invites a skew between them for no benefit. Outside tmux — a Claude run in a
-    bare terminal, or a subagent — there is no pane and both are None, which the
-    record carries as "does not apply".
-    """
-    pane = os.environ.get("TMUX_PANE") if pane is None else pane
-    if not pane:
-        return None, None
-    argv = ["tmux", "display-message", "-t", pane, "-p", "#{window_id}|#{pid}"]
-    try:
-        run = runner or (lambda a: subprocess.run(
-            a, capture_output=True, text=True, timeout=2.0))
-        proc = run(argv)
-        if proc.returncode != 0:
-            return None, None
-        parts = (proc.stdout or "").strip().split("|")
-    except Exception:  # noqa: BLE001 — no tmux, dead server, timeout: all "no pane"
-        return None, None
-    if len(parts) < 2:
-        return None, None
-    wid, pid = parts[0].strip(), parts[1].strip()
-    if not wid.startswith("@") or not pid.isdigit():
-        return None, None
-    return wid, pid
-
-
 def record_from_payload(AL, payload, window_id=None, pane_id=None,
                         tmux_pid=None, now=None):
     """Payload -> record, or None when this event does not write one.
@@ -196,7 +167,7 @@ def main() -> int:
                                 AL.pane_filename("claude", pane))
             if AL.is_throttled(path, payload.get("session_id"), throttle):
                 return 0
-        wid, pid = tmux_context(pane=pane if pane else "")
+        wid, pid = AL.tmux_context(pane=pane if pane else "")
         rec = record_from_payload(AL, payload, window_id=wid, pane_id=pane,
                                   tmux_pid=pid)
         if rec is None:

--- a/scripts/claude-hooks/tests/test_agent_ledger_hook.py
+++ b/scripts/claude-hooks/tests/test_agent_ledger_hook.py
@@ -183,6 +183,15 @@ class FakeProc:
         self.returncode, self.stdout = rc, out
 
 
+def test_the_hook_keeps_NO_COPY_of_the_tmux_resolver():
+    """🔴 It moved into `agent_ledger.py` when the opencode `--write` CLI became
+    its second caller. A window/pid resolver copied into each writer is the
+    duplicated predicate that ends up wrong at one of its sites — so the hook
+    must have none of its own, and this fails if one grows back."""
+    assert not hasattr(hook, "tmux_context")
+    assert callable(AL.tmux_context)
+
+
 def test_tmux_context_parses_the_window_and_the_SERVER_pid():
     """ONE tmux call for both fields — asking twice invites a skew between them
     for no benefit. KILLS: reading the pane pid instead of the server pid, and
@@ -194,7 +203,7 @@ def test_tmux_context_parses_the_window_and_the_SERVER_pid():
         seen.append(argv)
         return FakeProc(0, "@41|4025325\n")
 
-    assert hook.tmux_context(runner=runner, pane="%11") == ("@41", "4025325")
+    assert AL.tmux_context(runner=runner, pane="%11") == ("@41", "4025325")
     assert seen[0][:3] == ["tmux", "display-message", "-t"]
     assert "#{window_id}|#{pid}" in seen[0]
 
@@ -210,7 +219,7 @@ def test_tmux_context_returns_a_PAIR_OF_NULLS_rather_than_half_an_answer(rc, out
     """🔴 KILLS: returning a window id with no generation. A record carrying a
     window and no pid is KEPT by the reader as `generation_unchecked` — so half
     an answer here is silently promoted to a trusted join downstream."""
-    assert hook.tmux_context(runner=lambda a: FakeProc(rc, out),
+    assert AL.tmux_context(runner=lambda a: FakeProc(rc, out),
                              pane="%11") == (None, None)
 
 
@@ -218,7 +227,7 @@ def test_no_TMUX_PANE_means_no_tmux_call_at_all():
     """A Claude run in a bare terminal has no pane. KILLS: shelling out to tmux
     anyway, which costs a subprocess on every tool call of every non-tmux run."""
     called = []
-    assert hook.tmux_context(runner=lambda a: called.append(a),
+    assert AL.tmux_context(runner=lambda a: called.append(a),
                             pane="") == (None, None)
     assert called == []
 

--- a/scripts/lib/agent_ledger.py
+++ b/scripts/lib/agent_ledger.py
@@ -70,11 +70,25 @@ same pid (4025325) on every window. Records that cannot be checked (writer preda
 the field, or a host whose pid was not measured) are KEPT and COUNTED separately —
 `generation_unchecked` — never silently treated as verified.
 
-WHAT THIS MODULE DOES NOT DO
-----------------------------
-It does not read tmux and it does not read the network. `write_record` and `prune`
-touch the filesystem; everything else is pure, so the reader's join is exercised
-end-to-end from fixtures with no host state at all.
+WHAT THIS MODULE DOES AND DOES NOT DO
+-------------------------------------
+It does not read the network. `write_record`/`prune` touch the filesystem and
+`tmux_context` shells out to tmux; everything else is pure, so the reader's join
+is exercised end-to-end from fixtures with no host state at all.
+
+🔴 `tmux_context` LIVES HERE rather than in the Claude hook, because it now has
+TWO callers — that hook and the `--write` CLI the opencode plugin spawns. A
+window/pid resolver copied into each writer is the duplicated predicate that ends
+up wrong at one of its sites; there is one, and both writers reach it.
+
+THE `--write` CLI, and why the opencode writer is a SPAWN
+---------------------------------------------------------
+`scripts/opencode/plugin/ledger.js` shells out to `python3 agent_ledger.py
+--write …` rather than re-implementing the record in JavaScript. That is the
+same shape `guard.js` uses for `guard_core.py` and `activity-plugin.js` uses for
+its emit script: the JS holds no schema, so writer 2 cannot drift from writer 1
+or from the reader. It costs one interpreter start per opencode tool call
+(~9 ms measured), which is the price of there being one definition.
 
 `parse_iso_epoch` lives HERE and `session-manager` aliases it, so the timestamp both
 sides of the ledger agree on has ONE definition. The hook cannot import
@@ -85,6 +99,8 @@ one of its two sites.
 import json
 import os
 import re
+import subprocess
+import sys
 import tempfile
 from datetime import datetime, timezone
 
@@ -596,6 +612,103 @@ def index_by_window(records) -> dict:
         "conflicts": [{"window_id": w,
                        "claimants": len(v),
                        "session_ids": sorted({str(r.get("session_id"))
-                                              for r in v})}
+                                              for r in v}),
+                       # 🔴 The RUNTIMES too, because the commonest real
+                       # conflict is cross-runtime and two opaque session ids
+                       # do not say so. A pane that ran Claude and later
+                       # opencode holds one record per runtime — both live,
+                       # both naming the same window — and `claude, opencode`
+                       # is the difference between "which agent owns this
+                       # window" and two UUIDs a reader cannot act on.
+                       "runtimes": sorted({str(r.get("runtime")) for r in v})}
                       for w, v in sorted(conflicts.items())],
     }
+
+
+# =========================================================================== #
+# TMUX + the CLI — the two IMPURE edges, both shared by every writer
+# =========================================================================== #
+def tmux_context(runner=None, pane=None):
+    """`(window_id, tmux_pid)` for this pane, or `(None, None)`.
+
+    ONE tmux call for both fields: they come from the same server and asking twice
+    invites a skew between them for no benefit. Outside tmux — a Claude run in a
+    bare terminal, an opencode run outside tmux, or a subagent — there is no
+    pane and both are None, which the record carries as "does not apply".
+
+    TWO callers: the Claude hook and the `--write` CLI. It is here so there is
+    one resolver rather than one per writer.
+    """
+    pane = os.environ.get("TMUX_PANE") if pane is None else pane
+    if not pane:
+        return None, None
+    argv = ["tmux", "display-message", "-t", pane, "-p", "#{window_id}|#{pid}"]
+    try:
+        run = runner or (lambda a: subprocess.run(
+            a, capture_output=True, text=True, timeout=2.0))
+        proc = run(argv)
+        if proc.returncode != 0:
+            return None, None
+        parts = (proc.stdout or "").strip().split("|")
+    except Exception:  # noqa: BLE001 — no tmux, dead server, timeout: all "no pane"
+        return None, None
+    if len(parts) < 2:
+        return None, None
+    wid, pid = parts[0].strip(), parts[1].strip()
+    if not wid.startswith("@") or not pid.isdigit():
+        return None, None
+    return wid, pid
+
+
+def main(argv=None) -> int:
+    """`--write` a record for a runtime that cannot import this module.
+
+    Used by `scripts/opencode/plugin/ledger.js`. The pane comes from
+    `$TMUX_PANE` (free); the window id and server pid cost one tmux call, and
+    only when a write is actually going to happen — the same ordering the Claude
+    hook uses, for the same reason: most calls are inside the throttle.
+
+    🔴 Exit codes are HONEST (0 wrote-or-throttled, 1 could not) even though the
+    only caller ignores them. A CLI that always exits 0 is untestable, and its
+    tests would then be asserting nothing.
+    """
+    import argparse
+    p = argparse.ArgumentParser(prog="agent_ledger", description=__doc__)
+    p.add_argument("--write", action="store_true", required=True)
+    p.add_argument("--runtime", required=True)
+    p.add_argument("--session", required=True)
+    p.add_argument("--transcript-path", default=None)
+    p.add_argument("--throttle", type=float, default=DEFAULT_THROTTLE)
+    p.add_argument("--prune", action="store_true",
+                   help="also reap records past the retention window; the "
+                        "caller does this on a session boundary, not per call")
+    p.add_argument("--directory", default=LEDGER_DIR)
+    args = p.parse_args(sys.argv[1:] if argv is None else list(argv))
+
+    try:
+        pane = os.environ.get("TMUX_PANE") or None
+        # Same early-out as the hook: the pane names the file, so the throttle
+        # is answerable without asking tmux anything.
+        if args.throttle and pane:
+            path = os.path.join(args.directory,
+                                pane_filename(args.runtime, pane))
+            if is_throttled(path, args.session, args.throttle):
+                return 0
+        wid, pid = tmux_context(pane=pane or "")
+        rec = build_record(
+            runtime=args.runtime, session_id=args.session,
+            last_activity_ts=now_iso(), window_id=wid, pane_id=pane,
+            tmux_pid=pid, transcript_path=args.transcript_path)
+        out = write_record(rec, directory=args.directory,
+                           throttle_secs=args.throttle)
+        if args.prune:
+            prune(directory=args.directory)
+        return 0 if out["written"] or out["reason"] == "throttled" else 1
+    except Exception as e:  # noqa: BLE001
+        print("agent_ledger --write: %s: %s" % (type(e).__name__, e),
+              file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/agent_ledger.py
+++ b/scripts/lib/agent_ledger.py
@@ -698,7 +698,13 @@ def main(argv=None) -> int:
         rec = build_record(
             runtime=args.runtime, session_id=args.session,
             last_activity_ts=now_iso(), window_id=wid, pane_id=pane,
-            tmux_pid=pid, transcript_path=args.transcript_path)
+            tmux_pid=pid, transcript_path=args.transcript_path,
+            # Same source the Claude hook uses. Without it writer 2's records
+            # carried `host: null` while writer 1's did not — an asymmetry no
+            # consumer reads today (the READER attributes a host by which
+            # machine it read from, which is strictly more reliable), but one
+            # that made the record shape differ by writer for no reason.
+            host=(os.environ.get("ACTIVITY_HOST") or "").strip() or None)
         out = write_record(rec, directory=args.directory,
                            throttle_secs=args.throttle)
         if args.prune:

--- a/scripts/opencode/plugin/ledger.js
+++ b/scripts/opencode/plugin/ledger.js
@@ -12,8 +12,23 @@
 // and from the reader while all three look correct — the failure the module's own
 // docstring calls out. Same shape `guard.js` uses for `guard_core.py` and
 // `activity-plugin.js` for its emit script: the JS carries arguments, never
-// structure. It costs one interpreter start (~9 ms measured) per tool call that
-// is not throttled, and that is the price of there being one definition.
+// structure.
+//
+// 🔴 THE COST, MEASURED RATHER THAN ASSUMED, and an earlier version of this
+// comment was wrong twice. It said "~9 ms per tool call that is not throttled":
+// 9 ms is a BARE interpreter start, and the throttle lives INSIDE the Python
+// process — so every `tool.execute.after` paid a full spawn, measured at
+// **24.5 ms** of synchronously blocked node event loop, on top of
+// `activity-plugin.js`'s own `execFileSync` on the same event.
+//
+// So the throttle is memoised HERE, in front of the spawn. This is the only
+// change that actually removes it: `lastWrite` holds one timestamp per session,
+// and a repeat inside the interval returns without touching the process table.
+// It is a CACHE, not logic — the Python throttle stays authoritative and is
+// still consulted on every call that gets through, so the worst a wrong memo
+// can do is skip a write the writer would have skipped anyway. Keyed on the
+// session, never on the pane, for the same reason the Python rule is: a
+// different session taking the pane over must claim it immediately.
 //
 // 🔴 `tool.execute.AFTER`, never `.before`. `.before` is where `guard.js` THROWS
 // to block a command; a second handler on that event that can fail is a way to
@@ -37,6 +52,16 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const PYTHON = process.env.DEVRC_LEDGER_PYTHON || "python3";
+
+// Must match `agent_ledger.DEFAULT_THROTTLE`. It is a memo in front of the real
+// rule rather than a second copy of it: too LOW only costs a spawn the Python
+// side then skips, and too HIGH is bounded by the same interval the writer uses.
+const THROTTLE_MS = 30 * 1000;
+
+// sessionID -> Date.now() of the last spawn. Module scope, so it lives as long
+// as the opencode process — which is exactly the window in which repeat tool
+// calls happen.
+const lastWrite = new Map();
 
 function moduleRelativeModule() {
   try {
@@ -73,6 +98,12 @@ export const LedgerPlugin = async () => ({
       // would be the hollow one `build_record` refuses. Skip rather than write it.
       if (typeof session !== "string" || session === "") return;
 
+      // 🔴 BEFORE `resolveModule()` and before the spawn — the whole point.
+      // A `stat` and a Map lookup instead of a 24.5 ms subprocess.
+      const now = Date.now();
+      const previous = lastWrite.get(session);
+      if (previous !== undefined && now - previous < THROTTLE_MS) return;
+
       const mod = resolveModule();
       // 🔴 Absent module => SILENTLY skip. Unlike the guard, which refuses the
       // command rather than run it unchecked, a missing ledger writer is not a
@@ -87,9 +118,19 @@ export const LedgerPlugin = async () => ({
           "--write",
           "--runtime", "opencode",
           "--session", session,
+          // Reaping is bounded here BECAUSE of the memo above: this runs at
+          // most once per session per interval, not once per tool call. Writer
+          // 1 prunes on its session boundaries; without this a host running
+          // opencode and NOT Claude Code would grow the ledger without bound —
+          // the fuzzyclaw rot (401 files, ~90% stale) the module cites.
+          "--prune",
         ],
         { stdio: "ignore", timeout: 5000, shell: false },
       );
+      // Recorded only on a spawn that RETURNED. A throw leaves the map
+      // untouched, so a transient failure retries on the next call rather than
+      // being memoised into a 30 s hole.
+      lastWrite.set(session, now);
     } catch {
       // swallow — a ledger write must never fail a tool call
     }

--- a/scripts/opencode/plugin/ledger.js
+++ b/scripts/opencode/plugin/ledger.js
@@ -1,0 +1,97 @@
+// Writer 2 of the agent activity ledger — opencode, local, in tmux.
+//
+// WHY: `session-manager` puts an AGE, a `stale` bucket and a session id on a
+// row from a ledger record. Writer 1 (`scripts/claude-hooks/agent-ledger-hook.py`)
+// covers Claude Code; without this, every opencode window is a row with no age
+// and no session id — the #419 shape, just narrowed to one runtime.
+// Spec: claudedocs/spec-agent-activity-ledger.md §3, "Writer 2 — opencode".
+//
+// 🔴 THIS FILE HOLDS NO SCHEMA. It shells out to `agent_ledger.py --write`,
+// which is the same module `session-manager` reads the record shape from. A
+// JavaScript re-implementation of the record is how writer 2 drifts from writer 1
+// and from the reader while all three look correct — the failure the module's own
+// docstring calls out. Same shape `guard.js` uses for `guard_core.py` and
+// `activity-plugin.js` for its emit script: the JS carries arguments, never
+// structure. It costs one interpreter start (~9 ms measured) per tool call that
+// is not throttled, and that is the price of there being one definition.
+//
+// 🔴 `tool.execute.AFTER`, never `.before`. `.before` is where `guard.js` THROWS
+// to block a command; a second handler on that event that can fail is a way to
+// break the guard's gate. `.after` fires on a completed call and gates nothing.
+//
+// 🔴 IT MUST NEVER THROW. opencode carries a plugin's exception up; a ledger
+// write is not worth a failed tool call, and the worst case of losing one is a
+// row rendering `unknown` instead of `idle` for up to one throttle interval.
+// Every path here is inside a try/catch that swallows, exactly like
+// `activity-plugin.js`.
+//
+// 🔴 NOT MERGED INTO activity-plugin.js, though it has the same hook and the
+// same identity. That plugin spools telemetry to ClickHouse; this one writes
+// local state `session-manager` joins on. Different consumer, different
+// retention, different failure mode — and a bug in either would otherwise take
+// out the other.
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PYTHON = process.env.DEVRC_LEDGER_PYTHON || "python3";
+
+function moduleRelativeModule() {
+  try {
+    return fileURLToPath(new URL("../agent_ledger.py", import.meta.url));
+  } catch {
+    return null;
+  }
+}
+
+// Resolved PER CALL, not once at module load — same reasoning as `guard.js`:
+// resolving at load time freezes a path taken before a `home-manager switch`
+// mid-session, and the cost is a couple of stat()s.
+function resolveModule() {
+  const override = process.env.DEVRC_LEDGER_MODULE;
+  if (override) return existsSync(override) ? override : null;
+  const candidates = [
+    join(homedir(), ".config", "opencode", "agent_ledger.py"),
+    join(homedir(), ".claude", "hooks", "agent_ledger.py"),
+    join(homedir(), "workspace", "devrc", "scripts", "lib", "agent_ledger.py"),
+    moduleRelativeModule(),
+  ].filter(Boolean);
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  return null;
+}
+
+export const LedgerPlugin = async () => ({
+  "tool.execute.after": async (input, _output) => {
+    try {
+      if (process.env.DEVRC_LEDGER_DISABLE === "1") return;
+      const session = input?.sessionID;
+      // No session id means no ClickHouse join and no row identity — the record
+      // would be the hollow one `build_record` refuses. Skip rather than write it.
+      if (typeof session !== "string" || session === "") return;
+
+      const mod = resolveModule();
+      // 🔴 Absent module => SILENTLY skip. Unlike the guard, which refuses the
+      // command rather than run it unchecked, a missing ledger writer is not a
+      // safety question: the honest outcome is a row with no age, which the
+      // reader already renders as "no writer has recorded this window".
+      if (!mod) return;
+
+      execFileSync(
+        PYTHON,
+        [
+          mod,
+          "--write",
+          "--runtime", "opencode",
+          "--session", session,
+        ],
+        { stdio: "ignore", timeout: 5000, shell: false },
+      );
+    } catch {
+      // swallow — a ledger write must never fail a tool call
+    }
+  },
+});

--- a/scripts/opencode/tests/test_ledger_plugin.py
+++ b/scripts/opencode/tests/test_ledger_plugin.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Tests for the OpenCode ledger plugin — writer 2 of the agent activity ledger.
+
+Mirrors `scripts/collector/opencode/tests/test_plugin.py`, which is the repo's
+established way to test an opencode plugin: a Python test driving real `node`.
+There is no node suite for `scripts/opencode/plugin/` and this does not add one.
+
+WHAT THIS FILE IS FOR
+
+  1. 🔴 THE SEAM, which is the whole risk here. The record shape lives in Python
+     and the writer is JavaScript, so "the plugin works" and "the record is one
+     `session-manager` can read" are different claims. The round-trip test makes
+     both: node drives the hook, the CLI writes, and the record is read back
+     through `agent_ledger.parse_ledger` — the same function the reader uses.
+
+  2. 🔴 IT MUST NEVER THROW. opencode carries a plugin exception up, and a
+     ledger write is not worth a failed tool call. Every failure mode — no
+     module, no session id, a python that exits non-zero, a missing interpreter
+     — is driven through real node and asserted silent.
+
+  3. THE HOOK CHOICE. `tool.execute.after`, never `.before`: `.before` is where
+     `guard.js` THROWS to block a command, and a second handler there that can
+     fail is a way to break the guard's gate.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# parents[3]: tests/ -> opencode/ -> scripts/ -> the repo root.
+ROOT = Path(__file__).resolve().parents[3]
+PLUGIN_JS = ROOT / "scripts" / "opencode" / "plugin" / "ledger.js"
+MODULE_PY = ROOT / "scripts" / "lib" / "agent_ledger.py"
+HOME_NIX = ROOT / "nix" / "home.nix"
+
+sys.path.insert(0, str(ROOT / "scripts"))
+from testlib import mockbin as M  # noqa: E402
+
+
+def run_node(code: str, env: dict | None = None) -> subprocess.CompletedProcess:
+    base = dict(os.environ)
+    base.pop("TMUX_PANE", None)
+    base.update(env or {})
+    return subprocess.run(["node", "--input-type=module", "-e", code],
+                          capture_output=True, text=True, env=base, timeout=30)
+
+
+def fire(session="oc-sess", env=None, tool="bash"):
+    """Drive `tool.execute.after` exactly as opencode does."""
+    code = (
+        'import { LedgerPlugin } from %s;\n'
+        'const p = await LedgerPlugin();\n'
+        'await p["tool.execute.after"]('
+        '  { tool: %s, sessionID: %s, callID: "c1" }, {});\n'
+        'console.log("OK");\n'
+    ) % (json.dumps(str(PLUGIN_JS)), json.dumps(tool), json.dumps(session))
+    return run_node(code, env=env)
+
+
+def ledger_env(tmp_path, **extra):
+    e = {"DEVRC_LEDGER_MODULE": str(MODULE_PY),
+         "HOME": str(tmp_path)}
+    e.update(extra)
+    return e
+
+
+def read_back(tmp_path):
+    """Read what the plugin wrote through the SHIPPING read path."""
+    import importlib.machinery
+    import importlib.util
+    loader = importlib.machinery.SourceFileLoader("_al_probe", str(MODULE_PY))
+    spec = importlib.util.spec_from_file_location("_al_probe", str(MODULE_PY),
+                                                  loader=loader)
+    al = importlib.util.module_from_spec(spec)
+    loader.exec_module(al)
+    d = Path(tmp_path) / ".cache" / "agent-ledger"
+    proc = subprocess.run(list(al.read_argv(abs_dir=str(d))),
+                          capture_output=True, text=True, timeout=10)
+    return al.parse_ledger(proc.stdout)
+
+
+# =========================================================================== #
+# the loader contract — opencode rejects a module that breaks it
+# =========================================================================== #
+def test_exactly_one_named_export_and_it_is_a_function():
+    """opencode rejects the whole module if a named export is not a function,
+    and a rejected module is a writer that silently never runs."""
+    code = (
+        'const m = await import(%s);\n'
+        'const names = Object.keys(m);\n'
+        'console.log(JSON.stringify({names, kinds: names.map(n => typeof m[n])}));\n'
+    ) % json.dumps(str(PLUGIN_JS))
+    proc = run_node(code)
+    assert proc.returncode == 0, proc.stderr
+    out = json.loads(proc.stdout)
+    assert out["names"] == ["LedgerPlugin"]
+    assert out["kinds"] == ["function"]
+
+
+def test_it_registers_ONLY_tool_execute_after():
+    """🔴 `.before` is where `guard.js` throws to BLOCK a command. A second
+    handler on that event that can fail is a way to break the guard's gate, so
+    this writer must not be on it. Both directions: `.after` present,
+    `.before` absent."""
+    code = (
+        'import { LedgerPlugin } from %s;\n'
+        'const p = await LedgerPlugin();\n'
+        'console.log(JSON.stringify(Object.keys(p)));\n'
+    ) % json.dumps(str(PLUGIN_JS))
+    proc = run_node(code)
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout) == ["tool.execute.after"]
+
+
+# =========================================================================== #
+# the round trip — node writes, the READER reads
+# =========================================================================== #
+def test_the_plugin_writes_a_record_the_READER_can_parse(tmp_path):
+    """🔴 THE SEAM. The record shape is Python and the writer is JavaScript, so
+    "the plugin ran" and "the record is one session-manager can read" are
+    different claims. This makes both, through the shipping read path."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    M.write_exec(bindir / "tmux", "printf '@41|4025325\\n'\n")
+    env = ledger_env(tmp_path, TMUX_PANE="%77",
+                     PATH="%s:%s" % (bindir, os.environ["PATH"]))
+    proc = fire(session="oc-roundtrip", env=env)
+    assert proc.returncode == 0 and "OK" in proc.stdout, proc.stderr
+
+    parsed = read_back(tmp_path)
+    assert parsed["measured"] is True
+    assert len(parsed["records"]) == 1
+    rec = parsed["records"][0]
+    assert rec["runtime"] == "opencode"
+    assert rec["session_id"] == "oc-roundtrip"
+    assert rec["window_id"] == "@41" and rec["pane_id"] == "%77"
+    assert rec["tmux_pid"] == "4025325"
+
+
+def test_the_record_is_namespaced_so_it_cannot_clobber_writer_1(tmp_path):
+    """🔴 The guard built before this writer existed: a pane that ran Claude and
+    later opencode holds ONE record each, not one overwriting the other."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    M.write_exec(bindir / "tmux", "printf '@41|4025325\\n'\n")
+    env = ledger_env(tmp_path, TMUX_PANE="%77",
+                     PATH="%s:%s" % (bindir, os.environ["PATH"]))
+    fire(session="oc-ns", env=env)
+    names = sorted(p.name for p in
+                   (tmp_path / ".cache" / "agent-ledger").iterdir())
+    assert names == ["opencode-p77.json"], names
+
+
+# =========================================================================== #
+# 🔴 fail-open — every path, through real node
+# =========================================================================== #
+@pytest.mark.parametrize("session", ["", None, 42])
+def test_a_missing_or_non_string_session_writes_NOTHING_and_is_silent(
+        session, tmp_path):
+    """No session id means no ClickHouse join and no row identity — the hollow
+    record `build_record` refuses. Skip, silently."""
+    proc = fire(session=session, env=ledger_env(tmp_path))
+    assert proc.returncode == 0 and proc.stderr == ""
+    assert not (tmp_path / ".cache" / "agent-ledger").exists()
+
+
+def test_an_ABSENT_module_is_survived_silently(tmp_path):
+    """🔴 Unlike the guard — which refuses the command rather than run it
+    unchecked — a missing ledger writer is not a safety question. The honest
+    outcome is a row with no age, which the reader already renders as "no writer
+    has recorded this window"."""
+    env = ledger_env(tmp_path, DEVRC_LEDGER_MODULE=str(tmp_path / "nope.py"))
+    proc = fire(env=env)
+    assert proc.returncode == 0 and proc.stderr == ""
+
+
+def test_a_FAILING_python_does_not_fail_the_tool_call(tmp_path):
+    """The CLI exits non-zero on a bad record. opencode carries a plugin
+    exception up, so that must not become a failed tool call."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    M.write_exec(bindir / "python3", "exit 9\n")
+    env = ledger_env(tmp_path,
+                     DEVRC_LEDGER_PYTHON=str(bindir / "python3"))
+    proc = fire(env=env)
+    assert proc.returncode == 0 and proc.stderr == ""
+
+
+def test_a_MISSING_interpreter_does_not_fail_the_tool_call(tmp_path):
+    env = ledger_env(tmp_path,
+                     DEVRC_LEDGER_PYTHON="/nonexistent/python-that-is-not-here")
+    proc = fire(env=env)
+    assert proc.returncode == 0 and proc.stderr == ""
+
+
+def test_the_kill_switch_writes_nothing(tmp_path):
+    env = ledger_env(tmp_path, DEVRC_LEDGER_DISABLE="1", TMUX_PANE="%77")
+    proc = fire(env=env)
+    assert proc.returncode == 0
+    assert not (tmp_path / ".cache" / "agent-ledger").exists()
+
+
+# =========================================================================== #
+# deployment — a writer that is not deployed writes nothing
+# =========================================================================== #
+def test_home_nix_deploys_it_to_the_SINGULAR_plugin_dir():
+    """🔴 opencode's glob is `{plugin,plugins}/*.{ts,js}` and reads BOTH, so a
+    file in each loads the plugin twice and writes twice. Singular only."""
+    nix = HOME_NIX.read_text()
+    assert '".config/opencode/plugin/ledger.js"' in nix
+    assert '".config/opencode/plugins/ledger.js"' not in nix
+
+
+def test_home_nix_deploys_the_MODULE_beside_it():
+    """The plugin holds no schema — it shells out to `agent_ledger.py`, which
+    must therefore be deployed where it looks first. Same arrangement guard.js
+    has with guard_core.py."""
+    nix = HOME_NIX.read_text()
+    assert '".config/opencode/agent_ledger.py"' in nix
+    assert "../scripts/lib/agent_ledger.py" in nix
+
+
+def test_the_plugin_is_tracked_by_git():
+    """🔴 A new file that is not `git add`ed is silently omitted from the flake:
+    the switch succeeds and opencode simply never writes a record.
+
+    🔴 ASSERTED IN BOTH TIERS AND NEVER SKIPPED, following the shape
+    `test_handoff_doc.py::test_the_tool_is_tracked_by_git` already established.
+    In the nix sandbox there is no `.git` at all, so the file's PRESENCE in the
+    flake source is the evidence; on the dev host `git ls-files` is asked
+    directly. The first draft ran `git` unconditionally and passed on the host
+    while failing in the sandbox with `not a git repository` — a two-tier split
+    this suite would have carried into CI had the target not been registered in
+    the same change.
+    """
+    rel = "scripts/opencode/plugin/ledger.js"
+    assert PLUGIN_JS.exists(), f"{PLUGIN_JS} is missing from this tree"
+    if not (ROOT / ".git").exists():
+        return
+    out = subprocess.run(["git", "-C", str(ROOT), "ls-files", "--", rel],
+                         capture_output=True, text=True, timeout=30)
+    assert out.stdout.strip() == rel, (
+        f"{rel} is not tracked by git, so the flake will omit it and "
+        "`home-manager switch` will succeed with opencode never writing a "
+        "record.")
+
+
+def test_the_plugin_carries_NO_record_schema_of_its_own():
+    """🔴 The reason it spawns Python. A JavaScript re-implementation of the
+    record is how writer 2 drifts from writer 1 and from the reader while all
+    three look correct. Asserted structurally: the field names that make up a
+    record must not appear in the JS."""
+    js = PLUGIN_JS.read_text()
+    for field in ("last_activity_ts", "tmux_pid", "window_id", "schema"):
+        assert field not in js, field

--- a/scripts/opencode/tests/test_ledger_plugin.py
+++ b/scripts/opencode/tests/test_ledger_plugin.py
@@ -62,6 +62,23 @@ def fire(session="oc-sess", env=None, tool="bash"):
     return run_node(code, env=env)
 
 
+def _no_plugin_error(stderr: str) -> bool:
+    """🔴 ASSERTS THE ABSENCE OF A THROW, not an empty stderr.
+
+    `stderr == ""` is a property of the ENVIRONMENT: node picks ESM-vs-CJS by
+    walking up from the module's ABSOLUTE path looking for a `package.json`, so
+    a checkout placed under any directory with a typeless one emits
+    `MODULE_TYPELESS_PACKAGE_JSON` and every such assertion fails — an audit hit
+    exactly that. devrc has none above `scripts/` and CI runs from
+    `/nix/store/...-source`, so it passes today for a reason that has nothing to
+    do with this plugin. What the tests actually mean is "the hook did not
+    throw", which is what this checks.
+    """
+    lowered = stderr.lower()
+    return not any(marker in lowered for marker in
+                   ("error", "throw", "traceback", "unhandled"))
+
+
 def ledger_env(tmp_path, **extra):
     e = {"DEVRC_LEDGER_MODULE": str(MODULE_PY),
          "HOME": str(tmp_path)}
@@ -165,7 +182,8 @@ def test_a_missing_or_non_string_session_writes_NOTHING_and_is_silent(
     """No session id means no ClickHouse join and no row identity — the hollow
     record `build_record` refuses. Skip, silently."""
     proc = fire(session=session, env=ledger_env(tmp_path))
-    assert proc.returncode == 0 and proc.stderr == ""
+    assert proc.returncode == 0
+    assert _no_plugin_error(proc.stderr), proc.stderr
     assert not (tmp_path / ".cache" / "agent-ledger").exists()
 
 
@@ -176,7 +194,8 @@ def test_an_ABSENT_module_is_survived_silently(tmp_path):
     has recorded this window"."""
     env = ledger_env(tmp_path, DEVRC_LEDGER_MODULE=str(tmp_path / "nope.py"))
     proc = fire(env=env)
-    assert proc.returncode == 0 and proc.stderr == ""
+    assert proc.returncode == 0
+    assert _no_plugin_error(proc.stderr), proc.stderr
 
 
 def test_a_FAILING_python_does_not_fail_the_tool_call(tmp_path):
@@ -188,14 +207,16 @@ def test_a_FAILING_python_does_not_fail_the_tool_call(tmp_path):
     env = ledger_env(tmp_path,
                      DEVRC_LEDGER_PYTHON=str(bindir / "python3"))
     proc = fire(env=env)
-    assert proc.returncode == 0 and proc.stderr == ""
+    assert proc.returncode == 0
+    assert _no_plugin_error(proc.stderr), proc.stderr
 
 
 def test_a_MISSING_interpreter_does_not_fail_the_tool_call(tmp_path):
     env = ledger_env(tmp_path,
                      DEVRC_LEDGER_PYTHON="/nonexistent/python-that-is-not-here")
     proc = fire(env=env)
-    assert proc.returncode == 0 and proc.stderr == ""
+    assert proc.returncode == 0
+    assert _no_plugin_error(proc.stderr), proc.stderr
 
 
 def test_the_kill_switch_writes_nothing(tmp_path):
@@ -258,3 +279,103 @@ def test_the_plugin_carries_NO_record_schema_of_its_own():
     js = PLUGIN_JS.read_text()
     for field in ("last_activity_ts", "tmux_pid", "window_id", "schema"):
         assert field not in js, field
+
+
+# =========================================================================== #
+# the spawn memo — the throttle in front of the subprocess
+# =========================================================================== #
+def _counting_python(bindir, log):
+    """A stub `python3` that records each invocation."""
+    return str(M.write_exec(bindir / "python3",
+                            'echo "$@" >> %s\n' % json.dumps(str(log))))
+
+
+def test_a_REPEAT_call_inside_the_interval_never_SPAWNS(tmp_path):
+    """🔴 THE FIX FOR THE COST, and it must be observed as a MISSING PROCESS
+    rather than a missing record. The throttle lives inside Python, so before
+    this every `tool.execute.after` paid a full interpreter start — measured
+    24.5 ms of synchronously blocked node event loop per opencode tool call, on
+    top of activity-plugin.js's own. The memo in front of the spawn is the only
+    change that removes it.
+
+    KILLS: deleting the memo, or keying it on anything that repeats.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    log = tmp_path / "spawns.log"
+    env = ledger_env(tmp_path, DEVRC_LEDGER_PYTHON=_counting_python(bindir, log))
+
+    code = (
+        'import { LedgerPlugin } from %s;\n'
+        'const p = await LedgerPlugin();\n'
+        'const ev = { tool: "bash", sessionID: "memo-1", callID: "c" };\n'
+        'for (let i = 0; i < 5; i++) await p["tool.execute.after"](ev, {});\n'
+        'console.log("OK");\n'
+    ) % json.dumps(str(PLUGIN_JS))
+    proc = run_node(code, env=env)
+    assert proc.returncode == 0, proc.stderr
+    assert log.read_text().count("\n") == 1, (
+        "five tool calls spawned python more than once: " + log.read_text())
+
+
+def test_a_DIFFERENT_session_is_never_memoised_away(tmp_path):
+    """🔴 The asymmetry the Python rule already has, mirrored: a different
+    session taking the pane over must claim it IMMEDIATELY, or the departed
+    session's id keeps winning the join for a full interval. KILLS: keying the
+    memo on the pane, or on nothing."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    log = tmp_path / "spawns.log"
+    env = ledger_env(tmp_path, DEVRC_LEDGER_PYTHON=_counting_python(bindir, log))
+
+    code = (
+        'import { LedgerPlugin } from %s;\n'
+        'const p = await LedgerPlugin();\n'
+        'for (const s of ["a", "b", "c"]) {\n'
+        '  await p["tool.execute.after"]({ tool: "bash", sessionID: s }, {});\n'
+        '}\n'
+        'console.log("OK");\n'
+    ) % json.dumps(str(PLUGIN_JS))
+    proc = run_node(code, env=env)
+    assert proc.returncode == 0, proc.stderr
+    assert log.read_text().count("\n") == 3, log.read_text()
+
+
+def test_a_FAILED_spawn_is_not_memoised_into_a_hole(tmp_path):
+    """The memo is set only after a spawn that RETURNED. A throw must leave it
+    untouched, so a transient failure retries on the next call rather than
+    suppressing writes for a full interval."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    log = tmp_path / "spawns.log"
+    M.write_exec(bindir / "python3", 'echo "$@" >> %s\nexit 9\n'
+                 % json.dumps(str(log)))
+    env = ledger_env(tmp_path,
+                     DEVRC_LEDGER_PYTHON=str(bindir / "python3"))
+    code = (
+        'import { LedgerPlugin } from %s;\n'
+        'const p = await LedgerPlugin();\n'
+        'const ev = { tool: "bash", sessionID: "fail-1", callID: "c" };\n'
+        'await p["tool.execute.after"](ev, {});\n'
+        'await p["tool.execute.after"](ev, {});\n'
+        'console.log("OK");\n'
+    ) % json.dumps(str(PLUGIN_JS))
+    proc = run_node(code, env=env)
+    assert proc.returncode == 0, proc.stderr
+    assert log.read_text().count("\n") == 2, (
+        "a failed spawn was memoised: " + log.read_text())
+
+
+def test_the_plugin_asks_the_writer_to_PRUNE(tmp_path):
+    """🔴 Writer 1 prunes on its session boundaries; writer 2 passed no
+    `--prune`, so a host running opencode and NOT Claude Code would grow the
+    ledger without bound — the fuzzyclaw rot (401 files, ~90% stale) the module
+    cites as its own motivation. Bounded by the memo: once per session per
+    interval, not once per tool call."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    log = tmp_path / "spawns.log"
+    env = ledger_env(tmp_path, DEVRC_LEDGER_PYTHON=_counting_python(bindir, log))
+    proc = fire(session="prune-1", env=env)
+    assert proc.returncode == 0, proc.stderr
+    assert "--prune" in log.read_text()

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -338,6 +338,14 @@ HERMETIC_TARGETS=(
   # stderr, on every malformed input) is felt on every turn and is gated here
   # rather than left to the ungated hand-rolled scripts beside it.
   scripts/claude-hooks/tests/test_agent_ledger_hook.py
+  # Writer 2 of the agent activity ledger — the OPENCODE half. A Python suite
+  # driving real `node`, mirroring scripts/collector/opencode/tests/test_plugin.py
+  # (this repo's established way to test an opencode plugin; there is no node
+  # suite for scripts/opencode/plugin/ and this does not add one). It gates the
+  # SEAM that matters: the record shape is Python and the writer is JavaScript,
+  # so "the plugin ran" and "the record is one session-manager can read" are
+  # different claims.
+  scripts/opencode/tests
 )
 
 # --- DEV-HOST-ONLY set ---------------------------------------------------------
@@ -901,6 +909,9 @@ TARGET_FLOORS=(
   # failed-tmux-lookup regression. Gate's own count through the gate's own rule:
   #   _suggested_floor 39 = 39 - min(50, max(1, 39/20 = 1)) = 39 - 1 = 38.
   "scripts/claude-hooks/tests/test_agent_ledger_hook.py|38"
+  # 2026-08-14, writer 2 (opencode) arrives as a NEW target: 15 collected.
+  #   _suggested_floor 15 = 15 - min(50, max(1, 15/20 = 0 -> 1)) = 14.
+  "scripts/opencode/tests|14"
 )
 
 # The allowance rule, in one place, used by BOTH the drift message and anyone

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -169,7 +169,7 @@ and the roll-ups a caller usually wants are:
 Each row carries: host, session, window_index, window_id, window_name,
 codename, label, label_source, hotkey, pane_id, path, command, task, claude,
 busy, age_secs, age_source, status, waiting_probable, waiting_signals,
-waiting_status, claude_session_id, ledger, fuzzyclaw, panes. The row ledger is
+waiting_status, claude_session_id, runtime, ledger, fuzzyclaw, panes. The row ledger is
 pinned by a test.
 
 🔴 `label` IS NOT AN ADDRESS — `session:window` still is.
@@ -1451,6 +1451,14 @@ def fold_windows(panes, host, slots=None, task_index=None,
             # window's history to a session that ended days ago.
             "claude_session_id": ((led or {}).get("session_id")
                                   or (task or {}).get("claude_session")),
+            # 🔴 WHICH AGENT wrote the record, and it is not cosmetic. `claude`
+            # on a row is `pane_current_command =~ /claude/`, so an OPENCODE
+            # window is classified `shell` — an agent counted as a bare prompt
+            # in every bucket. That was invisible while opencode wrote no
+            # records; writer 2 makes it a row with an age, a session id and
+            # `claude: false`, which is worse than invisible unless the row can
+            # say what it is. `null` means no writer has recorded this window.
+            "runtime": (led or {}).get("runtime"),
             "ledger": led,
             "fuzzyclaw": task,
             "panes": len(members),
@@ -2604,8 +2612,8 @@ LEAN_ROW_FIELDS = (
     # label" — dropping it made exactly that pair unreadable. An audit caught
     # the inconsistency between the rule and the field list; the rule won.
     "host", "session", "window_index", "label", "label_source", "hotkey",
-    # what it is working on
-    "path", "task",
+    # what it is working on, and WHICH agent is doing it
+    "path", "task", "runtime",
     # what state it is in
     "claude", "busy", "status", "age_secs", "age_source",
     # whether it needs the operator — `waiting_status` is NOT optional, it is

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -2561,9 +2561,17 @@ def render_ledger(led) -> list:
             ("  [%d unverified generation]" % h["generation_unchecked"]
              if h.get("generation_unchecked") else "")))
     for c in (led.get("conflicts") or []):
+        # 🔴 THE RUNTIMES, not just the session ids. An audit found this line
+        # printing `[7f3a-uuid-claude, ses_9911]` — "two UUIDs a reader cannot
+        # act on", which is the exact phrase the change adding `runtimes` used
+        # to justify itself while the renderer still ignored the field. The
+        # commonest real conflict is cross-runtime (a pane that ran Claude and
+        # later opencode holds one record each, both live, both naming that
+        # window), and naming them is what turns an alarming ⚠ into a fact.
         out.append("  ⚠ LEDGER CONFLICT {} {} claimed by {} record(s) "
-                   "[{}] — NEWEST wins".format(
+                   "[{}] — sessions [{}] — NEWEST wins".format(
                        c.get("host"), c.get("window_id"), c.get("claimants"),
+                       ", ".join(c.get("runtimes") or ["unknown runtime"]),
                        ", ".join(c.get("session_ids") or [])))
     return out
 

--- a/scripts/tests/test_agent_ledger.py
+++ b/scripts/tests/test_agent_ledger.py
@@ -729,12 +729,24 @@ def test_the_CLI_throttles_on_a_repeat_from_the_SAME_session(tmp_path):
     first = _cli("--runtime", "opencode", "--session", "oc-3", env=env,
                  directory=tmp_path)
     assert first.returncode == 0
-    before = open(os.path.join(str(tmp_path), "opencode-p77.json")).read()
+    path = os.path.join(str(tmp_path), "opencode-p77.json")
+    before = os.stat(path)
+
     second = _cli("--runtime", "opencode", "--session", "oc-3", env=env,
                   directory=tmp_path)
     assert second.returncode == 0
-    assert open(os.path.join(str(tmp_path),
-                             "opencode-p77.json")).read() == before
+    after = os.stat(path)
+
+    # 🔴 INODE AND mtime, NOT CONTENT — and an audit is why. This compared the
+    # file's BYTES, and `now_iso()` has one-second resolution, so two
+    # back-to-back spawns write byte-identical records whether or not the
+    # throttle fires. Proof it was vacuous: setting DEFAULT_THROTTLE to 0 —
+    # throttling fully disabled — left the old assertion passing. `write_record`
+    # replaces via `os.replace`, so a write that DID happen shows a new inode
+    # even when the bytes match.
+    assert (after.st_ino, after.st_mtime_ns) == (before.st_ino,
+                                                 before.st_mtime_ns), (
+        "the record was rewritten — the throttle did not fire")
 
 
 def test_TWO_RUNTIMES_in_one_pane_do_not_overwrite_each_other(tmp_path):
@@ -782,3 +794,39 @@ def test_tmux_context_lives_HERE_so_both_writers_share_one_resolver():
     assert AL.tmux_context(runner=lambda a: called.append(a),
                            pane="") == (None, None)
     assert called == []
+
+
+
+def test_the_CLI_exit_code_distinguishes_a_FAILED_write(tmp_path):
+    """🔴 The `return 0` mutant survived: the only test reaching a non-zero exit
+    went through the EXCEPTION path, so the write-failure branch was unpinned.
+    A directory that cannot be created is the reachable case."""
+    blocker = tmp_path / "blocked"
+    blocker.write_text("a FILE where the ledger directory should be\n")
+    proc = _cli("--runtime", "opencode", "--session", "oc-x",
+                directory=blocker)
+    # 🔴 Exit 1 with EMPTY stderr, which is the discriminant: `write_record`
+    # catches the OSError itself and returns `reason: "error"`, so this is the
+    # write-failure branch and NOT the exception branch the other test covers.
+    # That distinction is the whole point — `return 0` survived precisely
+    # because only the exception path was ever reached.
+    assert proc.returncode == 1
+    assert proc.stderr == ""
+    assert blocker.read_text().startswith("a FILE")
+
+
+def test_the_CLI_sets_the_host_like_writer_1_does(tmp_path):
+    """Writer 2's records carried `host: null` while writer 1's did not — an
+    asymmetry with no consumer, but no reason either. Both directions: set and
+    unset."""
+    proc = _cli("--runtime", "opencode", "--session", "oc-h",
+                env={"ACTIVITY_HOST": "laptop"}, directory=tmp_path)
+    assert proc.returncode == 0
+    rec = json.loads(open(os.path.join(str(tmp_path),
+                                       "opencode-s-oc-h.json")).read())
+    assert rec["host"] == "laptop"
+
+    _cli("--runtime", "opencode", "--session", "oc-h2", directory=tmp_path)
+    rec2 = json.loads(open(os.path.join(str(tmp_path),
+                                        "opencode-s-oc-h2.json")).read())
+    assert rec2["host"] is None

--- a/scripts/tests/test_agent_ledger.py
+++ b/scripts/tests/test_agent_ledger.py
@@ -16,10 +16,14 @@ import importlib.util
 import json
 import os
 import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.abspath(os.path.join(_HERE, os.pardir)))
+from testlib import mockbin  # noqa: E402
 _MODULE = os.path.join(_HERE, os.pardir, "lib", "agent_ledger.py")
 
 
@@ -479,7 +483,8 @@ def test_two_records_claiming_one_window_resolve_to_the_NEWEST_and_are_reported(
     out = AL.index_by_window([older, newer])
     assert out["index"]["@41"]["session_id"] == "new"
     assert out["conflicts"] == [{"window_id": "@41", "claimants": 2,
-                                 "session_ids": ["new", "old"]}]
+                                 "session_ids": ["new", "old"],
+                                 "runtimes": ["claude"]}]
     # order-independent: the newest wins whichever way round they arrive
     assert AL.index_by_window([newer, older])["index"]["@41"]["session_id"] \
         == "new"
@@ -641,3 +646,139 @@ def test_the_tie_break_resolves_on_the_record_read_FIRST():
     assert AL.index_by_window([b, a])["index"]["@41"]["session_id"] == "second"
     # ...and it is still reported as contested either way round
     assert AL.index_by_window([a, b])["conflicts"][0]["claimants"] == 2
+
+
+# =========================================================================== #
+# the --write CLI, and writer 2 (opencode)
+# =========================================================================== #
+def _stub_tmux(bindir, answer="@41|4025325"):
+    """A stub `tmux` on PATH so the CLI can resolve a window hermetically.
+
+    🔴 Without one the CLI takes the DEGRADED path — `$TMUX_PANE` set, tmux
+    unable to answer — and correctly writes a session-keyed file instead of a
+    pane-keyed one. That is the regression guard from `filename_for` doing its
+    job, and it is why a fixture that fakes only the pane tests the wrong path.
+    Via `testlib.mockbin`, which owns the shebang (`#!/usr/bin/env bash` is dead
+    in the nix sandbox).
+    """
+    return str(mockbin.write_exec(Path(str(bindir)) / "tmux",
+                                  "printf '%s\\n'\n" % answer))
+
+
+def _cli(*args, env=None, directory=None):
+    """Drive the REAL CLI as `ledger.js` does — argv, no shell."""
+    e = dict(os.environ)
+    e.pop("TMUX_PANE", None)
+    e.update(env or {})
+    argv = [sys.executable, _MODULE, "--write", *args]
+    if directory:
+        argv += ["--directory", str(directory)]
+    return subprocess.run(argv, capture_output=True, text=True, timeout=30,
+                          env=e)
+
+
+def test_the_CLI_writes_a_record_a_runtime_that_cannot_IMPORT_us_can_reach(
+        tmp_path):
+    """🔴 THE WHOLE POINT OF THE CLI. `scripts/opencode/plugin/ledger.js` is
+    JavaScript and cannot import this module, so it spawns it. If it
+    re-implemented the record instead, writer 2 would drift from writer 1 and
+    from the reader while all three looked correct — the failure this module's
+    docstring names. The JS carries arguments; this carries the structure.
+    """
+    proc = _cli("--runtime", "opencode", "--session", "oc-1",
+                directory=tmp_path)
+    assert proc.returncode == 0, proc.stderr
+    written = json.loads(open(os.path.join(str(tmp_path),
+                                           "opencode-s-oc-1.json")).read())
+    assert written["runtime"] == "opencode"
+    assert written["session_id"] == "oc-1"
+    assert written["schema"] == AL.SCHEMA
+    # ...and it is a record the READER accepts, not merely valid JSON
+    assert AL.valid_record(written)
+
+
+def test_the_CLI_record_is_readable_through_the_SHIPPING_read_path(tmp_path):
+    """End-to-end: what the opencode plugin writes is what session-manager
+    reads. A writer test that stops at the file proves the file."""
+    _cli("--runtime", "opencode", "--session", "oc-2", directory=tmp_path)
+    proc = subprocess.run(list(AL.read_argv(abs_dir=str(tmp_path))),
+                          capture_output=True, text=True, timeout=10)
+    parsed = AL.parse_ledger(proc.stdout)
+    assert parsed["measured"] is True and len(parsed["records"]) == 1
+    assert parsed["records"][0]["runtime"] == "opencode"
+
+
+def test_the_CLI_refuses_a_record_with_no_session_rather_than_writing_a_hollow_one(
+        tmp_path):
+    """Same rule as `build_record`: no session id means nothing can resolve the
+    ClickHouse join, and a hollow record is worse than none. Exit code is
+    HONEST even though the only caller ignores it — a CLI that always exits 0
+    is untestable."""
+    proc = _cli("--runtime", "opencode", "--session", "", directory=tmp_path)
+    assert proc.returncode == 1
+    assert os.listdir(tmp_path) == []
+
+
+def test_the_CLI_throttles_on_a_repeat_from_the_SAME_session(tmp_path):
+    """The hot path: `tool.execute.after` fires on every opencode tool call."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    _stub_tmux(bindir)
+    env = {"TMUX_PANE": "%77",
+           "PATH": "%s:%s" % (bindir, os.environ["PATH"])}
+    first = _cli("--runtime", "opencode", "--session", "oc-3", env=env,
+                 directory=tmp_path)
+    assert first.returncode == 0
+    before = open(os.path.join(str(tmp_path), "opencode-p77.json")).read()
+    second = _cli("--runtime", "opencode", "--session", "oc-3", env=env,
+                  directory=tmp_path)
+    assert second.returncode == 0
+    assert open(os.path.join(str(tmp_path),
+                             "opencode-p77.json")).read() == before
+
+
+def test_TWO_RUNTIMES_in_one_pane_do_not_overwrite_each_other(tmp_path):
+    """🔴 THE GUARD THAT WAS BUILT BEFORE ITS WRITER EXISTED. `pane_filename` is
+    namespaced by runtime, so a pane that ran Claude and later opencode holds
+    ONE record each rather than the second silently replacing the first. This
+    became reachable the moment writer 2 landed; it was pinned in advance.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    _stub_tmux(bindir)
+    env = {"TMUX_PANE": "%77",
+           "PATH": "%s:%s" % (bindir, os.environ["PATH"])}
+    _cli("--runtime", "opencode", "--session", "oc-4", env=env,
+         directory=tmp_path)
+    AL.write_record(rec(runtime="claude", pane_id="%77", session_id="cl-4"),
+                    directory=str(tmp_path))
+    assert sorted(n for n in os.listdir(tmp_path) if n.endswith(".json")) == [
+        "claude-p77.json", "opencode-p77.json"]
+
+
+def test_a_cross_runtime_conflict_NAMES_THE_RUNTIMES():
+    """🔴 The commonest real conflict is cross-runtime, and two opaque session
+    ids do not say so. `claude, opencode` is the difference between "which agent
+    owns this window" and two UUIDs a reader cannot act on."""
+    a = rec(runtime="claude", pane_id="%77", session_id="cl-5",
+            last_activity_ts=AL.now_iso(NOW - 600))
+    b = rec(runtime="opencode", pane_id="%78", session_id="oc-5",
+            last_activity_ts=AL.now_iso(NOW))
+    out = AL.index_by_window([a, b])
+    assert out["index"]["@41"]["runtime"] == "opencode"   # newest wins
+    conflict = out["conflicts"][0]
+    assert conflict["runtimes"] == ["claude", "opencode"]
+    assert conflict["claimants"] == 2
+
+
+def test_tmux_context_lives_HERE_so_both_writers_share_one_resolver():
+    """🔴 It moved out of the Claude hook when the CLI became its second caller.
+    A window/pid resolver copied into each writer is the duplicated predicate
+    that ends up wrong at one of its sites."""
+    assert callable(AL.tmux_context)
+    # no pane => no tmux call at all, and a PAIR of nulls rather than half an
+    # answer (a window with no generation is silently trusted downstream)
+    called = []
+    assert AL.tmux_context(runner=lambda a: called.append(a),
+                           pane="") == (None, None)
+    assert called == []

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -1752,6 +1752,12 @@ def test_json_golden_schema_and_values():
         "waiting_signals": None,
         "waiting_status": "uncaptured",
         "claude_session_id": "11111111-2222-4333-8444-555555555555",
+        # 🔴 `runtime` names WHICH agent recorded the window. Null here because
+        # this fixture runs `use_ledger=False`, so no writer answered — and
+        # `claude: true` above is the pane's COMMAND matching /claude/, which is
+        # a different fact. An opencode window is `claude: false` with
+        # `runtime: "opencode"`, which is why the row needs both.
+        "runtime": None,
         "ledger": None,
         "fuzzyclaw": {
             "task": "task-alpha-text",
@@ -5269,7 +5275,7 @@ def test_the_row_FIELD_LEDGER_fails_when_it_grows_or_shrinks():
         "command",
         "task", "claude", "busy", "age_secs", "age_source", "status",
         "waiting_probable", "waiting_signals", "waiting_status",
-        "claude_session_id", "ledger", "fuzzyclaw",
+        "claude_session_id", "runtime", "ledger", "fuzzyclaw",
         "panes",
     }
     assert set(row) == expected
@@ -5828,7 +5834,8 @@ def test_the_LEAN_row_field_ledger_fails_when_it_grows_or_shrinks():
     assert set(row) == set(sm.LEAN_ROW_FIELDS)
     assert set(sm.LEAN_ROW_FIELDS) == {
         "host", "session", "window_index", "label", "label_source", "hotkey",
-        "path", "task", "claude", "busy", "status", "age_secs", "age_source",
+        "path", "task", "runtime", "claude", "busy", "status", "age_secs",
+        "age_source",
         "waiting_probable", "waiting_signals", "waiting_status",
         "claude_session_id",
     }

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -6214,3 +6214,56 @@ def test_a_PLAIN_tail_also_says_lean_has_no_effect(
     monkeypatch.setattr(sm, "_default_runner", make_runner())
     sm.main(["tail", "scratch7:3", "--lean"])
     assert "--lean has no effect on `tail`" in capsys.readouterr().err
+
+
+def test_the_row_RUNTIME_carries_the_VALUE_not_just_the_key(monkeypatch):
+    """🔴 THE PR'S HEADLINE FIELD, and an audit found it pinned by NAME in three
+    places and by VALUE in none. Two mutants survived the whole 9,849-test gate:
+    `"runtime": None` (the feature ships completely inert) and
+    `.get("session_id")` (a WRONG value on every row). The three tests naming
+    `runtime` were the two field ledgers — which assert key names — and a golden
+    that asserts `None` on a `use_ledger=False` fixture, which every mutant also
+    produces. "A type declaration is not a code path."
+
+    So: a row joined to a record must carry that record's RUNTIME, and it must
+    be distinguishable from the session id — the fixture's two values are
+    deliberately different strings.
+    """
+    rep = ledger_gather(
+        workbench=[led_rec(window_id="@41", session_id="ses_9911",
+                           runtime="opencode")],
+        use_fuzzyclaw=False)
+    row = next(r for r in rows_of(rep) if r["window_id"] == "@41")
+    assert row["runtime"] == "opencode"
+    assert row["claude_session_id"] == "ses_9911"
+    assert row["runtime"] != row["claude_session_id"]
+    # ...and it survives the lean projection, which is the view agents read
+    lean = lean_of(rep)
+    lrow = next(r for r in rows_of(lean) if r["session"] == row["session"])
+    assert lrow["runtime"] == "opencode"
+
+
+def test_a_row_no_writer_recorded_has_a_NULL_runtime_not_a_guess():
+    """The other direction: `runtime` is null when nothing recorded the window,
+    never inferred from the pane command. `claude` (the command matching
+    /claude/) and `runtime` (which writer answered) are different facts."""
+    rep = ledger_gather(workbench=[], use_fuzzyclaw=False)
+    for row in rows_of(rep):
+        assert row["runtime"] is None
+
+
+def test_a_CROSS_RUNTIME_conflict_names_the_runtimes_in_the_TABLE():
+    """🔴 `runtimes` was computed and never rendered — the line printed two
+    UUIDs, which is the exact thing the change adding the field said it fixed.
+    The commonest real conflict is cross-runtime, and `claude, opencode` is what
+    makes the ⚠ actionable rather than alarming."""
+    text = sm.render_table(ledger_gather(
+        workbench=[led_rec(pane_id="%11", session_id="7f3a-claude",
+                           runtime="claude", ago=900),
+                   led_rec(pane_id="%12", session_id="ses_9911",
+                           runtime="opencode", ago=60)],
+        use_fuzzyclaw=False))
+    assert "⚠ LEDGER CONFLICT" in text
+    assert "claude, opencode" in text
+    # the session ids stay too — they are how you find the actual sessions
+    assert "7f3a-claude" in text and "ses_9911" in text


### PR DESCRIPTION
feat(agent-ledger): writer 2 — opencode windows had a row with no age and no session id

Spec §3, "Writer 2 — opencode". Writer 1 (the Claude hook) shipped in #471, so
until now every opencode window was a `session-manager` row with no age, no
`stale` bucket and no session id — the #419 shape, narrowed to one runtime.

  * `scripts/opencode/plugin/ledger.js` — a fourth opencode plugin, on
    `tool.execute.after`.
  * `agent_ledger.py` gains a `--write` CLI and absorbs `tmux_context`.
  * a `runtime` field on every session-manager row, and in the lean view.

🔴 THE PLUGIN HOLDS NO SCHEMA. It shells out to `agent_ledger.py --write`, the
same module `session-manager` reads the record shape from. A JavaScript
re-implementation of the record is how writer 2 drifts from writer 1 and from
the reader while all three look correct — the exact failure the module's
docstring names. This is the shape `guard.js` already uses for `guard_core.py`
and `activity-plugin.js` for its emit script: the JS carries arguments, never
structure. It costs one interpreter start (~9 ms) per non-throttled tool call,
and that is the price of there being one definition. A test asserts the record's
field names appear NOWHERE in the JS.

🔴 `tool.execute.AFTER`, never `.before`. `.before` is where `guard.js` THROWS
to block a command; a second handler there that can fail is a way to break the
guard's gate. Pinned in both directions.

🔴 IT MUST NEVER THROW — opencode carries a plugin exception up, and a ledger
write is not worth a failed tool call. Every failure mode (absent module, no
session id, python exiting non-zero, a missing interpreter, the kill switch) is
driven through REAL node and asserted silent.

`tmux_context` MOVED into the shared module because the CLI became its second
caller. A window/pid resolver copied into each writer is the duplicated
predicate that ends up wrong at one of its sites; the hook now has none of its
own and a test fails if one grows back.

THE ROW LEARNS ITS RUNTIME, and this is not cosmetic. `claude` on a row is
`pane_current_command =~ /claude/`, so an opencode window is classified `shell`
— an agent counted as a bare prompt in every bucket. That was invisible while
opencode wrote no records; writer 2 makes it a row with an age, a session id and
`claude: false`, which is worse than invisible unless the row can say what it
is. `runtime` is null when no writer has recorded the window.

Cross-runtime conflicts now name the RUNTIMES as well as the session ids: a pane
that ran Claude and later opencode holds one record each (the runtime-namespaced
key added in #471, before its second writer existed), both live and both naming
one window. `claude, opencode` is the difference between "which agent owns this
window" and two UUIDs a reader cannot act on. Newest still wins.

Verification:
  * `nix build .#checks.x86_64-linux.pytests` — collected=9849 passed=9848
    skipped=1 failed=0, across TWENTY-ONE per-target floors.
  * 🔴 THE GATE ALMOST DIDN'T RUN THIS SUITE. The edit registering
    `scripts/opencode/tests` was inside a Bash call the `git add -A` guard
    blocked, so it never applied — and the gate then passed with "sum of 20
    per-target floors" while the new tests ran nowhere. Caught by reading the
    per-target line rather than the verdict, which is this repo's own rule.
  * 🔴 AND REGISTERING IT IMMEDIATELY FOUND A TWO-TIER SPLIT: the
    tracked-by-git test ran `git` unconditionally, passing on the dev host and
    failing in the nix sandbox with `not a git repository`. It now follows the
    shape `test_handoff_doc.py` established — presence is the evidence where
    there is no `.git`, `git ls-files` where there is — and is skipped in
    neither tier.
  * Live: the plugin's hook driven for real wrote
    `opencode-p101.json` with the true window `@101` and server pid, read back
    through the shipping `parse_ledger`.

Not in scope: writer 3 (clawgate agents) and the §4 `kind` field.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
