### PR TITLE
fix(clickup): one emoji in a comment desynced the scanner both structural guards are built on, and its controls could never see it

### DIFF
--- a/claude/skills/clickup/test/js-source.mjs
+++ b/claude/skills/clickup/test/js-source.mjs
@@ -39,14 +39,49 @@ const REGEX_PREFIX = new Set([
 ]);
 
 /**
- * Replace every comment with spaces, preserving byte offsets and line
- * structure so an index into the result still points at the same place.
+ * 🔴 EVERY INDEX IN THIS MODULE IS A UTF-16 CODE UNIT, because that is what
+ * `s[i]`, `s.length`, `s.slice()`, `indexOf` and a regex `m.index` all speak.
+ *
+ * `Array.from(s)` / `[...s]` split by CODE POINT, so an astral character (any
+ * emoji, `𝄞`, …) becomes ONE element where the string has TWO units. Both
+ * blanking functions used to do exactly that and then index the array with a
+ * code-unit offset, so every character after the first emoji was written to the
+ * wrong slot and the result came back one unit SHORT per emoji:
+ *
+ *     blankComments("// 🔴 a note\nconst x = 1;")   25 in -> 24 out
+ *
+ * That is not a cosmetic length bug. `🔴` opens nearly every source header in
+ * this repo, so the offsets the seam scanner reads drifted a unit per emoji: the
+ * literal scan then reported spans that started at a CLOSING quote and ran on
+ * through live code, and a genuine `writeFileSync(join(__dirname, 'x.json'), d)`
+ * inside such a span was invisible to the guard. The desync is silent — nothing
+ * throws, the text still looks like source.
+ *
+ * So: `splitUnits`, never `Array.from`. js-source.test.mjs feeds every function
+ * non-ASCII fixtures and asserts `after.length === before.length`, which is the
+ * assertion that turns this red the moment it comes back.
+ */
+const splitUnits = (s) => s.split('');
+
+/**
+ * Does the character starting at `k` occupy TWO code units — i.e. would a bound
+ * of `k + 1` cut a surrogate pair in half? `codePointAt` answers exactly that:
+ * it returns the combined code point only when `k` holds a high surrogate that
+ * is actually followed by a low one.
+ */
+const spansTwoUnits = (s, k) => s.codePointAt(k) > 0xffff;
+
+/**
+ * Replace every comment with spaces, preserving CODE-UNIT offsets and line
+ * structure so an index into the result still points at the same place. An
+ * astral character inside a comment becomes TWO spaces — one per code unit —
+ * which is what keeps the offsets lined up.
  *
  * String and template contents are left ALONE — `'https://x'` is not a comment,
  * and a guard that thinks it is reports defects that are not there.
  */
 export function blankComments(src) {
-  const out = Array.from(src);
+  const out = splitUnits(src);
   let i = 0;
   let prev = '\n'; // last significant code character
   const n = src.length;
@@ -136,8 +171,14 @@ export function stringLiterals(code) {
  * The `${ … }` substitutions inside ONE template literal, as [start, end)
  * offsets into `code` covering the delimiters as well.
  *
- * Brace-matched, so `${join(a, {b: 1})}` is one range. Not quote-aware inside
- * the substitution — see the module header's known limits.
+ * Brace-matched, so `${join(a, {b: 1})}` is one range.
+ *
+ * 🔴 The brace match SKIPS a string nested inside the substitution, because a
+ * brace in there is TEXT. Without that, `` `${f('}')}` `` matched the `}` inside
+ * the quotes and the range ended one character into the string — the real
+ * closing brace was then blanked as literal text while a text brace was kept,
+ * so the braces stayed balanced only by luck and every offset in between was
+ * attributed to the wrong side.
  */
 export function substitutionRanges(code, lit) {
   if (code[lit.start] !== '`') return [];
@@ -148,8 +189,15 @@ export function substitutionRanges(code, lit) {
     let depth = 0;
     let j = i + 1;
     for (; j < lit.end - 1; j++) {
-      if (code[j] === '{') depth++;
-      else if (code[j] === '}') { depth--; if (depth === 0) break; }
+      const d = code[j];
+      if (d === '\\') { j += 1; continue; }
+      if (d === "'" || d === '"' || d === '`') {
+        j += 1;
+        while (j < lit.end - 1 && code[j] !== d) j += code[j] === '\\' ? 2 : 1;
+        continue;
+      }
+      if (d === '{') depth++;
+      else if (d === '}') { depth--; if (depth === 0) break; }
     }
     const end = Math.min(j + 1, lit.end - 1);
     out.push([i, end]);
@@ -167,25 +215,82 @@ export function substitutionRanges(code, lit) {
  * The default blanks it, and that is a hole for any guard that looks for an
  * identifier: `` writeFileSync(`${__dirname}/accounts.json`, d) `` — a real
  * write idiom in this skill — became a token-free string and the state-path
- * scanner was silent on it. A substitution's braces are balanced by
- * construction, so keeping them does not disturb the depth counting this
- * function exists to protect; the literal TEXT around them is still blanked, so
- * a `{` or a comma in the text cannot skew it either.
+ * scanner was silent on it. The literal TEXT around a substitution is still
+ * blanked, so a `{` or a comma in the text cannot skew anything.
+ *
+ * 🔴 A substitution's braces are NOT "balanced by construction" — that claim
+ * shipped here and was false in two shapes, each with brace delta +1:
+ *
+ *   * `` `${f('{')}` `` — a brace that is TEXT inside a nested string. The
+ *     literal scan does not recurse, so keeping the substitution raw carried
+ *     that brace into the depth count.
+ *   * `` `${`inner`}` `` — a nested BACKTICK ends the outer literal early (the
+ *     module header's first known limit), so the range stops before its `}`.
+ *
+ * Both are handled where they arise rather than by asserting them away: the
+ * contents of a string nested inside a kept substitution are blanked too (same
+ * rule, one level deeper — the identifiers around it survive), and a range whose
+ * braces still do not balance is blanked like ordinary text. Unbalanced braces
+ * would move every span computed downstream from this text, which is the one
+ * thing this function exists to prevent.
  *
  * @param {string} code
  * @param {{keepSubstitutions?: boolean}} [opts]
  */
 export function blankStrings(code, { keepSubstitutions = false } = {}) {
-  const out = Array.from(code);
+  const out = splitUnits(code);
   for (const lit of stringLiterals(code)) {
-    const keep = keepSubstitutions ? substitutionRanges(code, lit) : [];
-    for (let k = lit.start + 1; k < lit.end - 1; k++) {
+    const { ranges, blankInner } = keepSubstitutions
+      ? keepableSubstitutions(code, lit)
+      : { ranges: [], blankInner: new Set() };
+    // An UNTERMINATED literal is clamped at the end of the input, so this stop
+    // can land BETWEEN the halves of a surrogate pair. Blanking only the high
+    // half leaves a lone surrogate in the output; blank the pair as a unit.
+    let stop = lit.end - 1;
+    if (stop > lit.start && stop < code.length && spansTwoUnits(code, stop - 1)) stop++;
+    for (let k = lit.start + 1; k < stop; k++) {
       if (out[k] === '\n') continue;
-      if (keep.some(([s, e]) => k >= s && k < e)) continue;
+      if (!blankInner.has(k) && ranges.some(([s, e]) => k >= s && k < e)) continue;
       out[k] = ' ';
     }
   }
   return out.join('');
+}
+
+/**
+ * The substitutions of `lit` that are SAFE to keep, and the offsets INSIDE them
+ * that must be blanked anyway.
+ *
+ * "Safe" means brace-balanced once the contents of any nested string literal are
+ * discounted — see the 🔴 block on `blankStrings`. A range that does not balance
+ * is dropped, so the caller blanks it like the surrounding text.
+ *
+ * @returns {{ranges: [number, number][], blankInner: Set<number>}}
+ */
+function keepableSubstitutions(code, lit) {
+  const ranges = [];
+  const blankInner = new Set();
+  for (const [s, e] of substitutionRanges(code, lit)) {
+    const inner = new Set();
+    for (const nested of stringLiterals(code.slice(s, e))) {
+      for (let k = s + nested.start + 1; k < s + nested.end - 1; k++) inner.add(k);
+    }
+    // Only the NET delta is checked. A "did it dip below zero" early exit was
+    // written here first and no mutation could kill it: the range comes from
+    // substitutionRanges, which starts it at the `$` of a `${` and stops at that
+    // brace's own match, so a prefix with more closers than openers cannot be
+    // constructed. An unkillable guard is not protection, it is noise.
+    let depth = 0;
+    for (let k = s; k < e; k++) {
+      if (inner.has(k)) continue;
+      if (code[k] === '{') depth++;
+      else if (code[k] === '}') depth--;
+    }
+    if (depth !== 0) continue;
+    ranges.push([s, e]);
+    for (const k of inner) blankInner.add(k);
+  }
+  return { ranges, blankInner };
 }
 
 /**

--- a/claude/skills/clickup/test/js-source.test.mjs
+++ b/claude/skills/clickup/test/js-source.test.mjs
@@ -35,11 +35,33 @@ import {
   topLevelCaseLabels,
 } from './js-source.mjs';
 
+/** Code units that are half of a surrogate pair with no partner. */
+function loneSurrogates(s) {
+  let n = 0;
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      const d = s.charCodeAt(i + 1);
+      if (d >= 0xdc00 && d <= 0xdfff) { i++; continue; }
+      n++;
+    } else if (c >= 0xdc00 && c <= 0xdfff) n++;
+  }
+  return n;
+}
+
 /**
  * Every one of these functions promises OFFSET PRESERVATION — an index into the
  * result points at the same character it did in the input. Both guards rely on
  * it (they scan `bare` and then read `literals` computed from another copy), and
  * nothing else in the suite would notice it breaking.
+ *
+ * 🔴 LENGTH IS IN UTF-16 CODE UNITS, and that is the whole point. This assertion
+ * was correct and shipped for the whole life of the module while the module was
+ * broken, because it was never fed a single non-ASCII character: `Array.from`
+ * splits by CODE POINT, so one emoji made the output one unit short and every
+ * offset after it wrong. Every fixture below that carries an astral character is
+ * here to keep that from being possible again — do not "simplify" them back to
+ * ASCII.
  */
 function assertSameShape(before, after, what) {
   assert.equal(after.length, before.length, `${what}: length changed — offsets no longer line up`);
@@ -50,6 +72,10 @@ function assertSameShape(before, after, what) {
       assert.equal(after[i], '\n', `${what}: newline at ${i} was overwritten`);
     }
   }
+  // Blanking must take a surrogate PAIR or neither half: half of one leaves a
+  // lone surrogate, which is a different character from anything in the input.
+  assert.equal(loneSurrogates(after), loneSurrogates(before),
+    `${what}: a surrogate pair was half-blanked, leaving a lone surrogate`);
 }
 
 // ── blankComments ─────────────────────────────────────────────────────────
@@ -107,6 +133,164 @@ describe('blankComments', () => {
   });
 });
 
+// ── astral characters: the code-point / code-unit desync ──────────────────
+//
+// 🔴 THE FIXTURES BELOW ARE THE ONES THAT WERE MISSING, AND THAT IS THE FINDING.
+// Every assertion this file already made was the right assertion; none of them
+// was ever handed a character outside the BMP, so `Array.from(src)` — a split by
+// CODE POINT, indexed with UTF-16 CODE-UNIT offsets — sat here green:
+//
+//     blankComments("// 🔴 a note\nconst x = 1;")   25 in -> 24 out
+//
+// `🔴` opens nearly every source header in this repo. Measured over the tree as
+// it stood when the webhook listener still existed, 4 of the 26 walked modules
+// desynced, and a genuine `writeFileSync(join(__dirname,'accounts.json'), d)`
+// planted inside `listen.mjs` was INVISIBLE to the seam scanner. Two markers in
+// one file is enough — see the seam-level regression in state-paths.test.mjs.
+
+const RED = '\u{1F534}'; // U+1F534, astral: TWO code units, ONE code point
+const CLEF = '\u{1D11E}'; // U+1D11E, astral and NOT an emoji
+
+describe('astral characters', () => {
+  test('🔴 an emoji in a LINE comment does not shift every later offset', () => {
+    const src = `// ${RED} a note\nwriteFileSync(join(__dirname, 'accounts.json'), d);`;
+    const out = blankComments(src);
+    assertSameShape(src, out, 'blankComments');
+    assert.ok(!/a note/.test(out), 'the comment was not blanked');
+    assert.equal(out.indexOf('writeFileSync'), src.indexOf('writeFileSync'),
+      'the code after the comment moved. Every guard downstream indexes this text with ' +
+        'offsets taken from the ORIGINAL source, so a shift here silently points them at ' +
+        'the wrong characters — that is how a real write became invisible to the seam scanner');
+  });
+
+  test('🔴 an emoji in a BLOCK comment does not shift every later offset', () => {
+    const src = `/* ${RED} prose\n   ${RED} more */\nwriteFileSync(p, d);`;
+    const out = blankComments(src);
+    assertSameShape(src, out, 'blankComments');
+    assert.ok(!/prose/.test(out) && !/more/.test(out), 'the block comment was not blanked');
+    assert.equal(out.indexOf('writeFileSync'), src.indexOf('writeFileSync'));
+  });
+
+  test('🔴 an emoji in a STRING leaves the code right after it intact', () => {
+    // The shape the seam scanner meets in real modules: a label with a marker in
+    // it, and a genuine state write on the very next statement.
+    const src = `const label = '${RED} blocked'; writeFileSync(join(__dirname, 'accounts.json'), d);`;
+    const noComments = blankComments(src);
+    assertSameShape(src, noComments, 'blankComments');
+    const bare = blankStrings(noComments, { keepSubstitutions: true });
+    assertSameShape(src, bare, 'blankStrings');
+    assert.ok(bare.includes("writeFileSync(join(__dirname, '"),
+      'the write following an emoji-bearing string was mangled, so the call the guard ' +
+        'exists to find is no longer spelled like a call');
+    assert.equal(bare.indexOf('__dirname'), src.indexOf('__dirname'),
+      'the location token moved — the argument-span arithmetic reads the wrong characters');
+  });
+
+  test('an emoji in a DOUBLE-quoted string is blanked, offsets kept', () => {
+    const src = `const s = "${RED}"; writeFileSync(p, d);`;
+    const out = blankStrings(src);
+    assertSameShape(src, out, 'blankStrings');
+    assert.ok(!out.includes(RED), 'the emoji survived inside a blanked string');
+    assert.equal(out.indexOf('writeFileSync'), src.indexOf('writeFileSync'));
+  });
+
+  test('an emoji in a TEMPLATE literal is blanked, offsets kept, both keepSubstitutions ways', () => {
+    const src = `const p = \`${RED}/\${__dirname}/accounts.json\`; writeFileSync(p, d);`;
+    for (const keep of [false, true]) {
+      const out = blankStrings(src, { keepSubstitutions: keep });
+      assertSameShape(src, out, `blankStrings(keepSubstitutions:${keep})`);
+      assert.ok(!out.includes(RED), `the emoji survived (keepSubstitutions:${keep})`);
+      assert.equal(out.indexOf('writeFileSync'), src.indexOf('writeFileSync'),
+        `the code after the template moved (keepSubstitutions:${keep})`);
+    }
+    assert.equal(blankStrings(src, { keepSubstitutions: true }).indexOf('__dirname'),
+      src.indexOf('__dirname'),
+      'the substitution was kept but at the wrong offset, which is worse than dropping it');
+  });
+
+  test('an emoji ADJACENT to a comment or string delimiter', () => {
+    // No separating space: the delimiter and the astral pair touch, which is
+    // where an off-by-one in the blanking bounds shows up.
+    for (const src of [`//${RED}\nwriteFileSync(p, d);`, `const s = '${RED}';writeFileSync(p, d);`]) {
+      const out = blankStrings(blankComments(src));
+      assertSameShape(src, out, 'blankComments+blankStrings');
+      assert.equal(out.indexOf('writeFileSync'), src.indexOf('writeFileSync'), src);
+    }
+  });
+
+  test('a non-BMP character that is NOT an emoji desyncs identically', () => {
+    // The hazard is the astral PLANE, not emoji. `𝄞` is the control that keeps
+    // a future "strip emoji" workaround from reading as a fix.
+    const src = `// ${CLEF} a clef\nwriteFileSync(join(__dirname, 'accounts.json'), d);`;
+    const out = blankComments(src);
+    assertSameShape(src, out, 'blankComments');
+    assert.equal(out.indexOf('writeFileSync'), src.indexOf('writeFileSync'));
+  });
+
+  test('🔴 TWO markers and an apostrophe — the shape that STRANDED A QUOTE', () => {
+    // The compound case, and the one with a live consequence. With the offsets
+    // shifted two units, the blanking of the middle comment stopped short of its
+    // apostrophe; the stray quote then opened a "string literal" that swallowed
+    // everything up to the next quote — the write's own filename — so the write
+    // was gone. Pinned end-to-end in state-paths.test.mjs's MUST_FIRE too.
+    const src = [
+      `// ${RED} first marker`,
+      "// the receiver doesn't care",
+      `// ${RED} second marker`,
+      "writeFileSync(join(__dirname, 'accounts.json'), d);",
+    ].join('\n');
+    const noComments = blankComments(src);
+    assertSameShape(src, noComments, 'blankComments');
+    assert.ok(!/receiver/.test(noComments), 'the middle comment was not blanked');
+    const lits = stringLiterals(noComments);
+    assert.deepEqual(lits.map((l) => l.value), ['accounts.json'],
+      `the literal scan reported ${JSON.stringify(lits.map((l) => l.value))}. A quote left ` +
+        'behind by shifted comment-blanking opens a literal that runs on through live code, ' +
+        'and every call inside it is invisible to both structural guards');
+  });
+
+  test('an UNTERMINATED literal ending in an astral character keeps the pair whole', () => {
+    // The one place a blanking bound can land BETWEEN two surrogates: the stop
+    // is clamped to the end of the input rather than sitting on a closing quote.
+    const src = `const s = 'never closed ${RED}`;
+    const out = blankStrings(src);
+    assertSameShape(src, out, 'blankStrings');
+    assert.equal(loneSurrogates(out), 0,
+      'half of the surrogate pair was blanked and half was not, so the output holds a ' +
+        'character that appears nowhere in the input');
+  });
+
+  test('a BMP character at the end of a literal does not pull in the closing quote', () => {
+    // The threshold is exactly "does this character occupy TWO code units".
+    // U+FFFF is the largest BMP code point — one unit — so a `>=` in that test
+    // blanks the closing quote, and every literal after it is bracketed wrong.
+    const src = "const s = 'x￿'; writeFileSync(p, d);";
+    const out = blankStrings(src);
+    assertSameShape(src, out, 'blankStrings');
+    const q = src.lastIndexOf("'");
+    assert.equal(out[q], "'",
+      `the closing quote at ${q} was blanked: ${JSON.stringify(out)}`);
+  });
+
+  test('an emoji does not move a switch block or its case labels', () => {
+    const src = [
+      `// ${RED} dispatch`,
+      'switch (cmd) {',
+      `  case 'one': log('${RED}'); break;`,
+      "  case 'two': break;",
+      '}',
+    ].join('\n');
+    const code = blankComments(src);
+    assertSameShape(src, code, 'blankComments');
+    const b = balancedBlockAfter(code, 'switch (cmd)');
+    assert.equal(code[b.start], '{');
+    assert.equal(code[b.end - 1], '}');
+    assert.deepEqual([...topLevelCaseLabels(code, b)].sort(), ['one', 'two'],
+      'a case label was lost once an emoji was present — the help-coverage guard then ' +
+        'stops asking for docs on a dispatchable command');
+  });
+});
+
 // ── stringLiterals ────────────────────────────────────────────────────────
 
 describe('stringLiterals', () => {
@@ -125,6 +309,20 @@ describe('stringLiterals', () => {
     const got = stringLiterals("const s = 'a\\'b';");
     assert.equal(got.length, 1);
     assert.equal(got[0].value, "a\\'b");
+  });
+
+  test('start/end still bracket the value when an emoji precedes the literal', () => {
+    // INVARIANT GUARD, not regression coverage: this was already green before the
+    // code-point fix, because stringLiterals never left code-unit space. It is
+    // here because the fix hands it non-ASCII input for the first time, and every
+    // offset-based filter downstream slices with these numbers.
+    const src = `const s = '${RED} blocked'; const t = 'accounts.json';`;
+    const got = stringLiterals(src);
+    assert.deepEqual(got.map((l) => l.value), [`${RED} blocked`, 'accounts.json']);
+    for (const lit of got) {
+      assert.equal(src.slice(lit.start + 1, lit.end - 1), lit.value,
+        'start/end stopped bracketing the reported value once a non-BMP character was present');
+    }
   });
 
   test('an unterminated literal does not run past the end of the input', () => {
@@ -173,18 +371,82 @@ describe('blankStrings', () => {
       'the literal TEXT around the substitution must still be blanked — it is not code');
   });
 
-  test('keepSubstitutions leaves braces BALANCED', () => {
-    const src = 'writeFileSync(`${join(a, {x: 1})}/f.json`, d);';
-    const out = blankStrings(src, { keepSubstitutions: true });
+  // 🔴 THIS GUARD USED TO BE CALIBRATED AROUND THE BUG. It ran ONE fixture,
+  // `${join(a, {x: 1})}` — a nested OBJECT, whose braces really are balanced by
+  // construction and therefore the one shape that cannot expose the defect. The
+  // module's comment claimed "a substitution's braces are balanced by
+  // construction"; two shapes made that false, each with delta +1, and both were
+  // silent here. A control chosen to avoid the hazard measures nothing.
+  const braceDelta = (out) => {
     let depth = 0;
+    let negative = false;
     for (const c of out) {
       if (c === '{') depth++;
-      else if (c === '}') depth--;
-      assert.ok(depth >= 0, 'brace depth went negative — argument spans would be truncated');
+      else if (c === '}') { depth--; if (depth < 0) negative = true; }
     }
-    assert.equal(depth, 0,
-      'keeping substitutions unbalanced the braces, which moves every span computed from ' +
-        'this text');
+    return { depth, negative };
+  };
+
+  for (const [label, src] of [
+    ['a nested OBJECT — balanced by construction, the shape that could never fail',
+      'writeFileSync(`${join(a, {x: 1})}/f.json`, d);'],
+    ["a brace that is TEXT in a nested string: `${f('{')}`",
+      "writeFileSync(`${f('{')}/f.json`, d);"],
+    // INVARIANT GUARD: this one's delta was 0 before the fix too — but only by
+    // luck. The range stopped at the TEXT brace, so a text `}` was kept and the
+    // real one blanked; the count balanced while every offset between them was
+    // attributed to the wrong side. The range itself is pinned under
+    // substitutionRanges, where it WAS red.
+    ["a CLOSING brace that is TEXT in a nested string: `${f('}')}`",
+      "writeFileSync(`${f('}')}/f.json`, d);"],
+    ['a nested BACKTICK, which ends the outer literal early: `${`inner`}`',
+      'writeFileSync(`${`inner`}/f.json`, d);'],
+    ['a double-quoted brace inside the substitution',
+      'writeFileSync(`${f("{")}/f.json`, d);'],
+  ]) {
+    test(`keepSubstitutions leaves braces BALANCED — ${label}`, () => {
+      const out = blankStrings(src, { keepSubstitutions: true });
+      assertSameShape(src, out, 'blankStrings(keepSubstitutions)');
+      const { depth, negative } = braceDelta(out);
+      assert.ok(!negative,
+        `brace depth went NEGATIVE on ${JSON.stringify(src)} -> ${JSON.stringify(out)}; ` +
+          'argument spans computed from this text are truncated at the wrong character');
+      assert.equal(depth, 0,
+        `keeping substitutions left brace delta ${depth} on ${JSON.stringify(src)} -> ` +
+          `${JSON.stringify(out)}. Unbalanced braces move every span computed downstream, ` +
+          'which is the one thing blanking exists to prevent');
+    });
+  }
+
+  test('🔴 an unbalanceable substitution is BLANKED rather than kept skewed', () => {
+    // The safe direction when the brace match cannot be trusted: lose the
+    // identifier (a false negative the seam scanner already tolerates for this
+    // known limit) rather than carry a stray brace into everyone's depth count.
+    const out = blankStrings('const p = `${`inner`}`;', { keepSubstitutions: true });
+    assert.ok(!out.includes('${'),
+      `a substitution whose braces do not balance was kept anyway: ${JSON.stringify(out)}`);
+  });
+
+  test('🔴 a brace in the template TEXT right after a substitution is not counted into it', () => {
+    // The range's END bound: reading one character past `}` pulls a brace that
+    // belongs to the literal TEXT into the substitution's own balance check, and
+    // the substitution is then dropped as "unbalanced" — silently reinstating the
+    // `${__dirname}` blindness this option exists to remove.
+    const src = 'writeFileSync(`${__dirname}{brace}/accounts.json`, d);';
+    const out = blankStrings(src, { keepSubstitutions: true });
+    assertSameShape(src, out, 'blankStrings(keepSubstitutions)');
+    assert.ok(/\$\{__dirname\}/.test(out),
+      `the substitution was dropped: ${JSON.stringify(out)}`);
+    assert.ok(!out.includes('{brace}'), 'the braces in the template TEXT were not blanked');
+  });
+
+  test('🔴 a brace inside a nested string is blanked, the identifier around it is NOT', () => {
+    // Both halves of the point: the depth count must not see the text brace, and
+    // the seam scanner must still see the call it is looking for.
+    const out = blankStrings("writeFileSync(`${join(__dirname, '{')}/f.json`, d);",
+      { keepSubstitutions: true });
+    assert.ok(/\$\{join\(__dirname, '\s*'\)\}/.test(out),
+      `expected the brace TEXT blanked and the call kept, got ${JSON.stringify(out)}`);
   });
 
   test('keepSubstitutions does not un-blank a comma in the literal TEXT', () => {
@@ -214,6 +476,24 @@ describe('substitutionRanges', () => {
 
   test('brace-matches a nested object literal', () => {
     assert.deepEqual(rangesOf('const p = `${f({x: 1})}`;'), ['${f({x: 1})}']);
+  });
+
+  test('🔴 the brace match SKIPS a string nested in the substitution', () => {
+    // A brace inside quotes is TEXT. Matching on it ended the range one character
+    // into the string, so the REAL closing brace was blanked as literal text
+    // while a text brace was kept — balanced only by luck, and every offset in
+    // between attributed to the wrong side.
+    assert.deepEqual(rangesOf("const p = `${f('}')}`;"), ["${f('}')}"]);
+    assert.deepEqual(rangesOf("const p = `${f('{')}`;"), ["${f('{')}"]);
+    assert.deepEqual(rangesOf('const p = `${f("}")}`;'), ['${f("}")}']);
+  });
+
+  test('ADJACENT substitutions are two ranges, not one', () => {
+    // INVARIANT GUARD, not regression coverage: green before this change too.
+    // The only fixture separating substitutions used to be `/x/`, so the
+    // end-of-range arithmetic was never exercised with nothing between them —
+    // untested, not broken.
+    assert.deepEqual(rangesOf('const p = `${a}${b}`;'), ['${a}', '${b}']);
   });
 
   test('a plain string has no substitutions', () => {

--- a/claude/skills/clickup/test/state-paths.test.mjs
+++ b/claude/skills/clickup/test/state-paths.test.mjs
@@ -911,6 +911,25 @@ const MUST_FIRE = [
     "const out = createWriteStream(join(__dirname, 'webhooks.jsonl'));"],
   ['🔴 deletion is a write too',
     "rmSync(join(__dirname, '.cache'), { recursive: true, force: true });"],
+  // ── the emoji desync, pinned where it had its consequence ──
+  //
+  // 🔴 js-source.mjs split by CODE POINT and indexed by CODE UNIT, so every
+  // astral character shifted the offsets after it by one. Two markers — fewer
+  // than a normal header in this repo carries — moved the blanking of the middle
+  // comment far enough to leave its apostrophe behind; the stray quote opened a
+  // "string literal" that ran on through the write and swallowed it. Measured
+  // against the tree that still had the webhook listener: 4 of 26 walked modules
+  // desynced, and a genuine write planted in listen.mjs was invisible here.
+  //
+  // This entry FIRED red before the fix. Keep the apostrophe and both markers —
+  // one marker alone shifts uniformly and strands nothing.
+  ['🔴 TWO emoji markers and an apostrophe — the shape that swallowed a real write',
+    "// \u{1F534} a marker, the idiom every header in this repo opens with\n" +
+    "// the receiver doesn't care which host it runs on\n" +
+    '// \u{1F534} a second marker\n' +
+    "writeFileSync(join(__dirname, 'accounts.json'), data);"],
+  ['🔴 an emoji inside the WRITTEN template path itself',
+    'writeFileSync(`${__dirname}/\u{1F534}-accounts.json`, data);'],
 ];
 
 // 🔴 CALIBRATED TO THE CLASS, NOT TO AN EXEMPTION LIST — and not to the bug
@@ -972,6 +991,11 @@ const MUST_NOT_FIRE = [
     "/* writeFileSync(join(__dirname, 'accounts.json'), d); */\nconst p = accountsPath();"],
   ['an import specifier that merely ends in .js',
     "import x from './helper.js';\nconst d = dirname(fileURLToPath(import.meta.url));"],
+  // The other direction of the emoji fix: blanking that is correct must not
+  // start UNDER-blanking either, or the prose above becomes a reported defect.
+  ['the hazard described in a comment that also carries emoji markers',
+    "// \u{1F534} never write writeFileSync(join(__dirname, 'accounts.json'), d)\n" +
+    "// \u{1F534} — use the accessor; the receiver doesn't care\nconst p = accountsPath();"],
 ];
 
 test('POSITIVE CONTROL: the seam scanner fires on every shape of the hazard', () => {

--- a/scripts/run-node-tests.sh
+++ b/scripts/run-node-tests.sh
@@ -134,6 +134,11 @@ cd "$ROOT" || { echo "run-node-tests: cannot cd to ROOT=$ROOT" >&2; exit 2; }
 #
 # MEASURED 2026-08-13, same way:
 #   claude/skills/clickup/test           3 files    71 tests
+#   -> 92 tests on 2026-08-14: js-source.mjs split by CODE POINT and indexed by
+#      CODE UNIT, so every emoji desynced the offsets both structural guards are
+#      built on. Its controls asserted the right property and had simply never
+#      been handed a non-ASCII character; 21 of the 21 new tests are those
+#      fixtures plus the substitution brace accounting they exposed.
 #   (it peaked at 6 files / 154 tests earlier the same day. Most of that was
 #   coverage OF the webhook listener, and the listener was then deleted — it
 #   had never run on either host: no token configured, no watcher ever
@@ -164,7 +169,9 @@ SUITES=(
   # run on either host): that removed webhook-server, listen-integration and
   # catchup along with the feature. 71 tests measured 2026-08-13,
   # floor 68 = 71 - min(50, max(1, 71/20)).
-  "claude/skills/clickup/test|3|68"
+  # 92 tests measured 2026-08-14 (the astral-character controls js-source.mjs
+  # never had), floor 88 = 92 - min(50, max(1, 92/20)) = 92 - 4.
+  "claude/skills/clickup/test|3|88"
 )
 
 # --- discovery roots -----------------------------------------------------------

--- a/scripts/tests/test_run_node_tests_suites.py
+++ b/scripts/tests/test_run_node_tests_suites.py
@@ -85,7 +85,12 @@ FORMERLY_UNGATED = {
     # the assertion below reads it as one (a floor is only meaningfully "not
     # drifted" against what the suite actually collects) — it is NOT a
     # high-water mark, and it moves DOWN when a feature is removed.
-    "claude/skills/clickup/test": 71,
+    #
+    # 92 on 2026-08-14: js-source.mjs, the scanner both structural guards rest
+    # on, split by CODE POINT while indexing by CODE UNIT, so one emoji shifted
+    # every later offset. Its own controls asserted exactly the right property
+    # and had never been handed a non-ASCII character.
+    "claude/skills/clickup/test": 92,
 }
 
 


### PR DESCRIPTION
Closes #456 (🟡2 and 🟡4).

`test/js-source.mjs` — the scanner BOTH structural guards in the clickup skill are
built on — split by CODE POINT (`Array.from`) and then indexed the result by UTF-16
CODE UNIT. Every astral character shifted every offset after it by one.

## Reproduction

```
blankComments("// 🔴 a note\nconst x = 1;")   input 25 -> output 24
```

Verified against the on-disk module both ways: `buggy: 25 -> 24`, `fixed: 25 -> 25`.

## Why it mattered — the planted-write proof

The length is the symptom, not the finding. Comment blanking shifted far enough to
leave an apostrophe behind; the stray quote opened a "string literal" that ran on
through live code, and every call inside it was invisible to both guards.

A genuine state-path write planted at `listen.mjs:394` (inside a 936-char span the
blanker mistook for a literal, lines 384–398), run through the REAL seam scanner
(`findOpenCodedStatePaths`):

| tree | scanner result |
|---|---|
| pre-change `js-source.mjs` | **0 hits — the write is invisible** |
| this branch | 1 hit — `__dirname + 'accounts.json'  ->  writeFileSync()` |
| positive control: same write, emoji-free header, pre-change scanner | 1 hit |

The control is the point: the "before" scanner is wired to something and fires on the
identical write. It goes silent only once an emoji is present.

## Affected-module counts

Measured as "the offset contract `assertSameShape` asserts is broken on the module's
real source", plus the literal spans that swallow live code:

| tree | before | after |
|---|---|---|
| pre-deletion (26 modules — the tree #456 measured) | **4 of 26** | **0 of 26** |
| current `main` (21 modules) | 0 of 21 | 0 of 21 |

```
lib/catchup.mjs         14 bogus literals    179 chars (1.7%)
lib/webhook-server.mjs  43 bogus literals    540 chars (5.5%)
lib/webhook-site.mjs    18 bogus literals    580 chars (11.4%)
listen.mjs             115 bogus literals  5,785 chars (27.3%)
```

Two honest corrections to the issue's numbers:

* **4 of 26, not 7.** Exactly 4 of the 26 walked modules contain an astral character
  at all, so 7 is not reachable by any offset-desync metric. `lib/markdown.mjs` is not
  among them — it has had zero astral characters at every commit that ever touched it,
  so its "743 chars (6.8%)" does not reproduce.
* **The current tree measures 0 of 21, and that is dormancy, not safety.** The four
  affected modules were the webhook listener, deleted in #474. Adding *two* `🔴`
  markers — fewer than a normal header here carries — re-blinds **21 of 21** modules
  at 154 plant positions; at seven markers, 740 positions. One marker alone shifts
  uniformly and strands nothing, which is why this survived so long.

## 🟡4 — done, not dropped

`keepSubstitutions` claimed "a substitution's braces are balanced by construction".
False, delta +1 each, and the guard used `${join(a, {x: 1})}` — a nested object, the
one shape that cannot fail:

* `` `${f('{')}` `` — a brace that is TEXT inside a nested string.
* `` `${`inner`}` `` — a nested backtick ends the outer literal early.

Fixed where each arises, not by asserting it away: `substitutionRanges` now skips a
string nested in the substitution (its brace match used to stop at a `}` inside
quotes — balanced only by luck, with every offset between attributed to the wrong
side), a nested string's contents are blanked inside a kept range, and a range whose
braces still do not balance is blanked like text. The guard fixture is replaced by a
5-shape table.

## Test matrix — red at the base ref

`d1c35d2` + this branch's tests, pre-change `js-source.mjs`: **17 red, 75 pass** —
16 subtests plus the seam scanner's POSITIVE CONTROL, which the new MUST_FIRE entry
(two markers + an apostrophe) turns red. Green at HEAD: 92/92.

Two additions are labelled in-source as INVARIANT GUARDS, not regression coverage —
they were green pre-change: `stringLiterals` offsets with an emoji, and adjacent
substitutions.

## Mutant matrix — 16 mutants, 0 survivors

Instrument controls, both watched: CLEAN → `fail=0` (it can report pass), OBVIOUS
(revert the core fix) → `fail=10` (it can report fail). Explicit `*.test.mjs` paths
with `--test-reporter=tap`, counted from `# fail N`.

| mutant | fail | assertion that fired |
|---|---|---|
| OBVIOUS `splitUnits` → `Array.from` | 10 | all astral fixtures + seam POSITIVE CONTROL |
| M1 `blankComments` → `Array.from` | 7 | line/block comment offsets, stranded quote |
| M2 `blankStrings` → `Array.from` | 5 | string/template offsets |
| M3 surrogate-pair stop DELETED | 1 | unterminated literal keeps the pair whole |
| M4 same clause made DEAD (text kept) | 1 | same |
| M5 `> 0xffff` → `>= 0xffff` | 1 | BMP char must not pull in the closing quote |
| M5b `spansTwoUnits(code, stop)` (stale operand) | 1 | unterminated literal keeps the pair whole |
| M6 substitution quote-skip made DEAD | 1 | brace match SKIPS a nested string |
| M7 quote-skip: single quotes only | 1 | same |
| M8 never DROP an unbalanced range | 2 | unbalanceable substitution is blanked |
| M10 nested-string contents not blanked | 4 | brace balance table (3 shapes) |
| M11 `blankInner` clause dead | 4 | same |
| M12 off-by-one: stop one char early | 8 | astral fixtures + brace-in-string (also trips help-coverage first) |
| M13 off-by-one: inner-set includes the quote | 1 | brace blanked, identifier kept |
| M14 balance test inverted | 7 | `${…}` preservation + seam POSITIVE CONTROL |
| M15 brace count reads one past the range | 1 | brace in template TEXT after a substitution |

Two guards were removed rather than kept unkillable: a "did depth dip below zero"
early exit that no mutation could kill (the range starts at the `$` of a `${` and
stops at that brace's own match, so a closer-heavy prefix cannot be constructed), and
`HIGH`/`LOW` helpers replaced by one `codePointAt(k) > 0xffff` test.

## Gates

* `bash scripts/run-node-tests.sh .` → `RESULT: PASS (exit=0)`, 1116 tests.
* clickup suite 71 → 92 tests. Floor `92 - min(50, max(1, 92//20)) = 92 - min(50, 4) = 88`.
  Runner reports `tests=92 pass=92 floor=88`. `FORMERLY_UNGATED` updated 71 → 92
  (its assertion is `min_tests > measured * 0.9`; 88 > 82.8).
* `nix build .#checks.x86_64-linux.nodetests` and `.pytests` — both PASS, and the
  sandbox log confirms it ran the new tests (`tests=92 … floor=88`), not a cached tree.
* **Merged-tree gate**: integration branch off `origin/main` `5fa1ddb` + this branch →
  node `RESULT: PASS` (1116), pytests `RESULT: PASS` (9826 collected, 0 failed). No
  file overlap with what main moved since `d1c35d2` (session-manager only), so no
  semantic-conflict surface.

## Not addressed

🟡1 (watchers.json), 🟡3 (PERMANENT_REJECTIONS ledger) and the 🟢 minors are untouched —
🟡1 and 🟡3 name files the webhook-listener deletion removed. The `flake.nix:300`
HERMETIC comment is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
