### PR TITLE
feat(session-manager): a clawgate dispatch has no pane, so `claude: None` would have counted every one of them as a bare shell

### DIFF
--- a/claude/skills/session-manager/SKILL.md
+++ b/claude/skills/session-manager/SKILL.md
@@ -19,8 +19,10 @@ level. Roll-ups: `summary.waiting`, `summary.status[bucket]`, `summary.kind`,
 `blocked_on_me`.
 
 🔴 **`summary.status[bucket]` is one key per CLASS plus `total`** — `{claude, shell, total}`
-on every scan today. A class key is added **on demand**, never pre-seeded, so the absence of
-`cluster` is not a zero. Same rule at the top level (`summary.claude`, `summary.shell`).
+on every scan today. `claude` and `shell` are **always present** (pre-seeded, so a zero there
+is a real zero); every class **beyond** those two — `cluster`, `unknown_kind` — appears only
+when such a row exists, so the *absence* of a `cluster` key is not a measured zero. Same at
+the top level (`summary.claude`/`summary.shell` always; others on demand).
 
 🔴 **`kind` (row field) and `CLASS` (table column) are DIFFERENT axes — do not conflate.**
 `kind` is `tmux` | `cluster`: **what the entity is**. `CLASS` is `claude` | `shell` |

--- a/claude/skills/session-manager/SKILL.md
+++ b/claude/skills/session-manager/SKILL.md
@@ -15,8 +15,22 @@ python3 $DEVRC/scripts/session-manager tail scratch7:3 --plain     # scrollback,
 ```
 
 🔴 **Rows are at `report["hosts"][<"workbench"|"laptop">]["windows"]`** — not at the top
-level. Roll-ups: `summary.waiting`, `summary.status[bucket]` (`{claude, shell, total}`),
+level. Roll-ups: `summary.waiting`, `summary.status[bucket]`, `summary.kind`,
 `blocked_on_me`.
+
+🔴 **`summary.status[bucket]` is one key per CLASS plus `total`** — `{claude, shell, total}`
+on every scan today. A class key is added **on demand**, never pre-seeded, so the absence of
+`cluster` is not a zero. Same rule at the top level (`summary.claude`, `summary.shell`).
+
+🔴 **`kind` (row field) and `CLASS` (table column) are DIFFERENT axes — do not conflate.**
+`kind` is `tmux` | `cluster`: **what the entity is**. `CLASS` is `claude` | `shell` |
+`cluster`: **how it is counted**. Every row today is `kind: tmux`; `cluster` is enumerated
+for a clawgate dispatch with no pane and is **not produced yet**, which
+`caveats.kind_scope` states in the payload (`kinds_produced` is **measured from the rows**,
+not asserted). So an absence of cluster rows is **not** a measured absence of cluster work —
+clawgate lives in `blocked_on_me`, a different population that is never double-counted with
+these rows. `kind` is never null; `runtime` frequently is, and means something else
+(**which agent software**, from the ledger).
 
 | flag | effect |
 |---|---|

--- a/claudedocs/design-ledger-writer3-and-kind-2026-08-14.md
+++ b/claudedocs/design-ledger-writer3-and-kind-2026-08-14.md
@@ -1,0 +1,232 @@
+# Design pass: ledger writer 3 (clawgate) + the spec §4 `kind` field
+
+**Date:** 2026-08-14 · **Status:** design, no code written · **Decides:** spec §4, and
+whether writer 3 is built at all · **Spec:** `claudedocs/spec-agent-activity-ledger.md`
+
+Everything below marked *measured* was read live today. Everything else is a claim to check.
+
+---
+
+## 0. What changed since the handoff
+
+`claudedocs/handoff-agent-attention-tooling.md` is stale in three ways — writer 2 shipped
+(#478), and #475/#476/#477 landed after it was written. Two of its open investigations
+moved today, both from one live read.
+
+---
+
+## 1. 🔴 The stuck detector fired on a real wedge — first time
+
+Measured 2026-08-14 against the live board (`GET /api/tasks?summary=1`, 29 tasks):
+
+```
+stuck_count: 2   (previously 0 on every check — a measured zero, never a firing)
+  #194 devrc: fix the 60s-timeout flake …   reasons: ["no_agent"]  dispatch_age 86,119s (23.9h)
+  #193 devrc: consolidate the five worktree bullets …  reasons: ["no_agent"]  dispatch_age 86,119s
+board: open 11 · in_progress 2 · ready_for_review 8 · complete 8
+```
+
+The detector works on real data, not only on its 5 fixtures and 37 mutants. Both tasks have
+sat in `in_progress` for 23.9h with **no `updatedAt` movement**, and `GET /api/agents`
+contains no agent for either.
+
+### 🔴 But the handoff's discriminator does NOT hold, and this is the correction
+
+The handoff said: *"on the next genuinely wedged dispatch, read the reported `reasons`. If it
+is `no_agent` rather than `not_kicked_off`, that confirms the link theory."*
+
+It is `no_agent` — and **that confirms nothing.** `no_agent` fires when `task.agent` is null,
+and two mechanisms produce a null there:
+
+| mechanism | would this board look different? |
+|---|---|
+| **(a)** the task↔agent link is broken upstream (#316) — an agent exists, unlinked | no |
+| **(b)** no agent was ever created — the task was moved to `in_progress` without a dispatch | no |
+
+`no_agent` is an **absence**, and an absence cannot separate two causes that both produce it —
+the same trap that made me file and retract the "never populated" claim on #316.
+
+**The evidence available today favours (b), the rival mechanism**, and therefore *weakens* the
+link theory rather than confirming it:
+- `/api/agents` returns **2 agents total**, ids 10 and 40, created 2026-06-06 and 2026-07-30 —
+  both **predate** tasks 193/194 (created 2026-08-13T20:08). There is no unlinked candidate for
+  these tasks to be linked *to*.
+- Both tasks flipped to `in_progress` at `20:12:22.03` and `20:12:22.04` — **10 ms apart**,
+  4 minutes after creation. That is the shape of a batch status write, not two dispatches.
+
+⚠ Stated at the scope measured: this is one board at one instant. It does not prove the link is
+healthy, and it does not prove no dispatch was attempted (an agent record could have been torn
+down — the `clawgate` skill notes two task-deletion paths tear down the agent pod, though the
+tasks still exist here).
+
+**The upstream signal that WOULD separate them** — and the only thing worth spending a probe on:
+the agent-pod logs for ns `devpod-<name>`, or clawgate's dispatch-side log for the
+`20:08–20:12` window. If no `POST /agents` was issued for 193/194, it is (b) and the stuck
+detector is correctly reporting *"claims to be in progress, nothing is working on it"* — which
+is the operator-relevant fact either way.
+
+**Actionable now, independent of the diagnosis:** two devrc tasks have been falsely `in_progress`
+for a day. They need re-dispatching or closing.
+
+---
+
+## 2. 🔴 The spec §4 premise does not survive the live data
+
+§4 opens: *"its primary entity **stops being a tmux window and becomes an agent run**."*
+
+Measured, clawgate has **no agent-run entity**:
+
+| | |
+|---|---|
+| `/api/agents` population | **2**, both `status: "error"`, both `noteId: null` |
+| id 10 `operator` | created **2026-06-06**, still present — a long-lived worker, not a run |
+| id 40 `brave-heron` | created 2026-07-30, `kickedOff: false`, dead since |
+| `lastActivityAt` | present on both (the field §3 relies on) — but on a *pod*, not a run |
+
+A clawgate **agent** is a persistent devpod namespace. The thing that is ephemeral, that starts
+and finishes, that maps to "an agent run" — is the **task in `in_progress`**, i.e. the dispatch.
+`scripts/lib/clawgate_tasks.py` already models exactly that: `dispatch_age_secs`,
+`agent_idle_secs(task, …)`, `stuck_reasons(task, …)` all take a **task**.
+
+**So §3's "Writer 3 — clawgate agents … `session-manager` fetches `/api/agents`" is aimed at the
+wrong entity.** Building it would put 2 permanently-errored pods in the table and leave the 2
+actual in-flight dispatches out.
+
+### The correction
+
+If cluster rows are built at all, their source is **`/api/tasks` filtered to `in_progress`**,
+enriched by the embedded `agent` object for liveness — which is the read `clawgate_tasks.py`
+already performs and which just fired correctly. Writer 3 collapses from *"a new fetch and a new
+entity"* into *"promote the existing clawgate dispatch read into rows"*.
+
+**Non-overlap with `blocked_on_me`, stated so it cannot drift:** `blocked_on_me` counts tasks
+**waiting on the operator** (`open` + `ready_for_review`); cluster rows would carry tasks
+**in flight** (`in_progress`). Disjoint by status, no double count. Without that line written
+down, clawgate lands in the report three times.
+
+---
+
+## 3. 🔴 What §4's "one table, add a `kind` field" leaves undecided
+
+The decision is right in spirit and **under-specified**: it names a row field but not the
+container. Rows do not live in a table. They live at:
+
+```
+report["hosts"][<host>]["windows"][]        # summarize(): rows = [r for h in hosts.values() for r in h["windows"]]
+```
+
+A clawgate dispatch has no host, no session, no window index. Three ways to place it:
+
+| option | cost |
+|---|---|
+| **A. synthetic host** `hosts["clawgate"]` | free pickup by every consumer — and it poisons `hosts_reachable`/`hosts_unreachable`/`windows_unmeasured`/`local_host`, all of which mean *"an SSH target answered"* |
+| **B. sibling collection** `report["agents"]` | §4 rejects it, correctly: two shapes every consumer must merge by hand |
+| **C. `kind` on rows + every roll-up split by `kind`** | **recommended** — the precedent is already in this file |
+
+**C is what `summarize` already does for `claude`/`shell`.** That split exists because a mixed
+integer was published and read as an agent count (measured: `idle: 17` = 12 agents + 5 shells).
+A mixed tmux+cluster integer is the identical defect one axis over. The container stays
+`hosts`, gaining one **explicitly non-SSH** entry whose provenance keys say so.
+
+### Three concrete defects a naive `kind` would ship
+
+1. 🔴 **`claude` silently buckets cluster rows as `shell`.**
+   `summarize` does `bucket["claude" if r.get("claude") else "shell"] += 1`. `claude` is defined
+   as `pane_current_command =~ /claude/`; a cluster row has no pane, so it is null, so **every
+   cluster agent is counted as a bare shell.** This is the conflation the split was built to
+   kill, reintroduced through the back door. The claude/shell split must become
+   `kind`-scoped — or `claude` becomes tri-state with the roll-up reading it as such.
+
+2. 🔴 **`classify_status` erases the state that matters.** It returns busy/idle/stale/unknown from
+   `(busy, age)`, and `stale` wins over everything. Both live agents are `status: "error"` —
+   mapping that through a glyph-and-age classifier renders a permanently-broken dispatch as
+   `stale`, i.e. as "an agent that went quiet". `error` must survive as its own bucket or ride
+   in a dedicated field.
+
+3. 🟡 **`waiting_probable` needs a fourth `waiting_status`.** There is no pane to capture, so the
+   value is `None` with a reason — `not_tmux`, enumerated alongside
+   `not_claude`/`uncaptured`/`skipped`. Absent that, `_waiting_rollup`'s measured-vs-unmeasured
+   accounting quietly counts cluster rows as *looked at and found fine*.
+
+### `kind` vs the existing `runtime` — different axes, and say so
+
+Rows already carry `runtime` (`claude` | `opencode` | null, from the ledger record). They are
+**not** derivable from each other and both are needed:
+
+- `kind` — where the row came from (a tmux pane scan vs the clawgate API). Known with certainty
+  at row construction. **Never null.**
+- `runtime` — which agent software, from the ledger record. **Null when no writer has recorded
+  that window** — the common, meaningful case.
+
+Two discriminants that agree ~90% of the time is how one gets derived from the other six months
+later, and the null semantics is where that breaks.
+
+---
+
+## 4. 🔴 Does writer 3 earn its cost? — the gate before the code
+
+Per the standing "do we need it" check, before a second round of building on this surface:
+
+**What it buys, measured:** rows for **2** long-lived pods, both errored, neither doing work —
+or, under the §2 correction, rows for **2** in-flight dispatches.
+
+**What it costs:** a new network read in a tool that must work with the homelab down; a `kind`
+axis through `fold_windows`, `summarize`, `_waiting_rollup`, `classify_status`, the table, the
+lean view and `LEAN_ROW_FIELDS`; and re-deciding the claude/shell split that 18 tests assert.
+
+**What already covers the same ground:** `blocked_on_me` (tasks needing the operator, with the
+count/discriminant contract) **plus** the stuck detector, which today reported the 2 wedged
+dispatches by id, title, reason and age — the exact rows writer 3 would add, in a surface that
+already exists and just proved itself on live data.
+
+**Recommendation: split the work, and do not build writer 3 now.**
+
+1. **Land `kind` now, on tmux rows only** (`kind: "tmux"` on every row, never null; roll-ups
+   split by it). This settles the entity model, is testable with no network, and makes the three
+   defects above impossible to ship later by accident. It is the part agent-ops retirement and
+   the §5 bar inversion actually need.
+2. **Promote the stuck rows into the report** as the cheap 80% — `summary.blocked_on_me` already
+   carries `stuck_count`; surfacing the stuck *rows* costs no new fetch.
+3. **Gate writer 3** on a stated trigger: the `in_progress` population being routinely non-zero
+   **and** `task.agent` non-null (i.e. #316 resolved). Both are false today. Re-check by reading
+   `stuck_count` and `agent non-null` off one `/api/tasks` call.
+
+### On agent-ops retirement — it does **not** gate on this
+
+Re-read of §7 against the code: every disposition routes to `session-manager` / `standup` /
+`/initiative-scan`, and none of them needs cluster rows. The one 🔴 KEEP is the **`/proc`
+detector** (`scripts/i3status-agent-ops` depends on it; it is strictly more accurate than
+`pane_current_command =~ /claude/`, which is why 15 windows render `? unk`). **That** is the
+real gate, and it is independent of writer 3 and of `kind`. Retirement was blocked on a decision
+it never needed.
+
+---
+
+## 5. If `kind` is built — the shape
+
+```python
+# On every row, never null. The claude/shell split becomes kind-scoped.
+"kind": "tmux" | "cluster"
+```
+
+- `KINDS` a module constant, and the roll-up derived from it, so a new kind cannot exist in
+  `fold_windows` and be missing from `summarize` — the rule `WAITING_SIGNALS` and
+  `STUCK_REASONS` already follow here.
+- `LEAN_ROW_FIELDS` gains `kind`. It is a discriminant, not duplication: the lean view's own
+  rule keeps provenance and drops human-facing identity.
+- `CAVEATS` gains an entry, or `ledger_scope` is amended. 🔴 A caveat is a machine-readable
+  claim — `fuzzyclaw_scope` went stale the moment the ledger shipped, and the guard that should
+  have caught it was blinded by a fixture default (`base_gather` is `use_ledger=False`). Any
+  `kind` fixture default must not blind that test the same way.
+- Verification: `kind` is 100% `tmux` until cluster rows exist, so a test asserting the split is
+  **vacuous by construction** — it must be driven from a constructed `cluster` row, and watched
+  to fail. A positive control reporting the pair ("N cluster rows on the control, 0 live") is
+  the only honest way to publish a zero here.
+
+## 6. Open / to verify
+
+- Which mechanism wedged 193/194 — see §1. Needs a dispatch-side log, not another board read.
+- Whether a clawgate agent record is ever deleted while its task survives. If yes, `no_agent`
+  gains a third mechanism and the reason string is doing more work than its name admits.
+- `/api/tasks?summary=1` carries `agent` on 0/29 today, including 0/2 `in_progress`. The
+  handoff records another observer seeing 1/3 populated. Unresolved; #316 stays *intermittent*.

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -598,15 +598,26 @@ CAVEATS = {
     # conclude the tool simply cannot say.
     "kind_scope": {
         "kinds_enumerated": list(KINDS),
+        # 🔴 OVERWRITTEN PER SCAN by `measured_caveats`. This literal is only
+        # what a caller rendering the bare constant sees; the shipped value is
+        # measured from the rows.
         "kinds_produced": ["tmux"],
-        "note": ("every row is a tmux pane on a scanned host. `cluster` is "
-                 "ENUMERATED but NOT PRODUCED — no clawgate dispatch is read "
-                 "into rows by this build, so an absence of cluster rows is "
-                 "NOT a measured absence of cluster work. For clawgate use "
-                 "report.blocked_on_me (tasks needing the operator, and its "
-                 "`stuck_count` for wedged dispatches), which is a different "
-                 "population from these rows and is never double-counted "
-                 "with them."),
+        # 🔴 THE NOTE STATES ONLY WHAT IS DURABLY TRUE, because it sits beside
+        # a MEASURED field and ships in the same `--json` payload. It used to
+        # assert "every row is a tmux pane … cluster is ENUMERATED but NOT
+        # PRODUCED" — a standing claim that would contradict its own
+        # `kinds_produced` the day writer 3 lands, which is precisely the
+        # adjacent-fields-disagree failure `fuzzyclaw_scope` shipped in #471.
+        # What is durable is the RELATIONSHIP: which kinds exist, that an
+        # absence is not a measurement, and where clawgate actually lives.
+        "note": ("`kinds_produced` is MEASURED from this scan's rows — read it "
+                 "rather than assuming. A kind that is enumerated but absent "
+                 "from `kinds_produced` was NOT LOOKED FOR by this build, so "
+                 "its absence is NOT a measured absence of that work. For "
+                 "clawgate use report.blocked_on_me (tasks needing the "
+                 "operator, and its `stuck_count` for wedged dispatches), a "
+                 "different population from these rows that is never "
+                 "double-counted with them."),
     },
     "ledger_scope": {
         "scope": "per_host",
@@ -1641,10 +1652,10 @@ def _summary_classes(summ) -> list:
     seen = set()
     for cell in (summ.get("status") or {}).values():
         seen |= {k for k in cell if k != "total"}
-    # `claude`/`shell` unconditionally: every bucket is pre-seeded with both, so
-    # they are always present, and a scan that happened to contain neither must
+    # `claude`/`shell` unconditionally: `summarize` PRE-SEEDS both in every
+    # bucket, so they are always present, and a scan containing neither must
     # still render `claude=0 shell=0` rather than quietly dropping the columns
-    # a reader is scanning for.
+    # a reader is scanning for. Only classes BEYOND these two are on-demand.
     lead = ["claude", "shell"]
     return lead + sorted(seen - set(lead))
 
@@ -1674,9 +1685,11 @@ def summarize(report) -> dict:
     🔴 BACKWARD COMPATIBILITY, chosen deliberately in the LOUD direction. The
     flat `summary["busy"|"idle"|"stale"|"unknown"]` integers are GONE, replaced
     by `summary["status"][bucket]` -> one key per CLASS plus `"total"`. On a
-    tmux-only scan the classes are exactly `{"claude", "shell"}`; a class key is
-    added on demand (see `row_class`), never pre-seeded, so no bucket publishes
-    a zero for a class the build cannot produce. Keeping
+    tmux-only scan the classes are exactly `{"claude", "shell"}`. Those TWO are
+    pre-seeded and always present (a reader scans for them, and dropping the
+    column would be its own confusion); every class BEYOND them — `cluster`,
+    `unknown_kind` — is added on demand, so no bucket publishes a zero for a
+    class this build cannot produce. Keeping
     the flat ints would have left every existing reader silently reading the
     mixed number as an agent count — the exact defect — while the fix sat in
     keys they never learned about. A KeyError is a worse morning and a better
@@ -2366,7 +2379,7 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
     return report
 
 
-def measured_caveats(report, caveats=None) -> dict:
+def measured_caveats(report) -> dict:
     """CAVEATS with `kind_scope.kinds_produced` MEASURED from `report`'s rows.
     PURE — returns a new dict, mutates nothing.
 
@@ -2378,9 +2391,16 @@ def measured_caveats(report, caveats=None) -> dict:
     collapses "derived" and "hardcoded" into the same observation; the fix is
     an input where they differ, which means a seam that accepts one.
     """
-    cav = dict(caveats if caveats is not None else report.get("caveats")
-               or CAVEATS)
-    cav["kind_scope"] = dict(cav["kind_scope"])
+    # 🔴 EVERY SUB-DICT IS COPIED, not just the one being written. Copying only
+    # `kind_scope` left `claude_detection`/`fuzzyclaw_scope`/`ledger_scope`/
+    # `waiting_signal` as the SAME objects as the module constant, so a
+    # consumer writing through `report["caveats"]["waiting_signal"]` — which
+    # this function's own "returns a new dict, mutates nothing" docstring
+    # invites — would poison CAVEATS for every later caller in the process. A
+    # purity claim that holds for one key and not its siblings is worse than no
+    # claim: it is exactly specific enough to be trusted.
+    cav = {k: (dict(v) if isinstance(v, dict) else v)
+           for k, v in (report.get("caveats") or CAVEATS).items()}
     rows = [r for h in (report.get("hosts") or {}).values()
             for r in (h.get("windows") or [])]
     # Sorted for a deterministic render. `"none"` rather than dropping a row
@@ -2704,8 +2724,16 @@ def render_table(report) -> str:
     classes = _summary_classes(summ)
     out.append("  summary: {total} windows  {parts}".format(
         total=summ.get("total_sessions", 0),
-        parts="  ".join("{}={}".format(c, summ.get(c, 0))
-                        for c in classes if c in summ)))
+        # 🔴 `.get(c, 0)`, and NO `if c in summ` filter. An audit called that
+        # filter dead because `classes` derives from the rows `summarize`
+        # counted — true of the `gather` path, and FALSE of `render_table`,
+        # which is also called on a bare/empty report whose summary carries
+        # neither key. Removing the guard raised `KeyError: 'claude'` in two
+        # existing tests: unreachable through one entry point is not
+        # unreachable. But the filter was still the wrong shape — it SKIPPED
+        # the class, dropping it from this line while the legend one line below
+        # still named it. `.get` renders every class, missing ones as 0.
+        parts="  ".join("{}={}".format(c, summ.get(c, 0)) for c in classes)))
     # 🔴 Every bucket prints per class, never as one number. The legend is on
     # the same line, so no reader has to remember which part is which — and
     # there is no rendering of `idle` that a reader can mistake for a count of
@@ -2998,12 +3026,39 @@ def render_caveats(report) -> list:
 
 
 def _fmt_kind_scope(kd) -> str:
-    """The `kind_scope` caveat's sentence, split out so both branches are
-    reachable from a test without building a whole report."""
-    produced = list(kd.get("kinds_produced") or ["tmux"])
+    """The `kind_scope` caveat's sentence, split out so every branch is
+    reachable from a test without building a whole report.
+
+    🔴 `[]` IS A MEASUREMENT AND MUST NOT FALL BACK TO A LITERAL. The first
+    version read `kd.get("kinds_produced") or ["tmux"]`, and an empty list is
+    FALSY — so a scan that measured zero rows rendered `rows in this scan are
+    kind=tmux` over `summary: 0 windows`. Reachable today, with no cluster row
+    anywhere: both hosts unreachable, or `--claude-only` on a host with no
+    claude windows. That is a literal masquerading as a measurement — the exact
+    defect this caveat was made measured to kill — reintroduced one function
+    downstream by an `or` that cannot tell "not supplied" from "measured none".
+    So the two cases are separated explicitly, and only a MISSING key falls
+    back.
+    """
+    produced = kd.get("kinds_produced")
+    if produced is None:
+        # No measurement supplied at all — a caller rendering the bare CAVEATS
+        # constant. Say what the tool produces by construction, not what this
+        # scan saw, because this scan was never measured.
+        produced = ["tmux"]
+    produced = list(produced)
     enumerated = list(kd.get("kinds_enumerated") or KINDS)
+    if not produced:
+        # 🔴 ZERO ROWS. Naming any kind here would be inventing one. The reader
+        # most likely to hit this is the one whose hosts are unreachable, and
+        # the wrong thing to tell them is which kinds were "in this scan".
+        return ("NO rows were measured in this scan, so no kind was observed — "
+                "this is NOT a claim that any kind is absent, and the enumerated "
+                "kinds ({}) say nothing about what a reachable host holds; "
+                "clawgate is reported separately under BLOCKED ON ME".format(
+                    "/".join(enumerated)))
     unproduced = [k for k in enumerated if k not in produced]
-    head = "rows in this scan are kind={}".format("/".join(produced) or "none")
+    head = "rows in this scan are kind={}".format("/".join(produced))
     if not unproduced:
         # Every enumerated kind is present. Saying "NOT PRODUCED" here would be
         # false; saying nothing would drop the pointer to where clawgate lives.
@@ -3504,6 +3559,14 @@ def filter_report(report, session, window_index) -> dict:
                          and str(r.get("window_index")) == str(window_index)]
         out["hosts"][name] = h2
     out["summary"] = summarize(out)
+    # 🔴 THE CAVEATS ARE RE-DERIVED HERE TOO. This path re-runs `summarize` and
+    # then renders through `render_caveats`, so leaving the inherited caveats
+    # alone made `kind_scope` a claim about the FULL scan printed under a
+    # ONE-ROW table — the disagreement between the line and the table above it
+    # that measuring it was supposed to make impossible. `gather` was fixed and
+    # this second summarize call was not; a rule enforced at one of its two
+    # sites is the failure this whole change keeps re-finding.
+    out["caveats"] = measured_caveats(out)
     return out
 
 

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -163,14 +163,33 @@ and the roll-ups a caller usually wants are:
 
     report["summary"]["waiting"]        {"probable", "measured", "unmeasured",
                                          "per_signal", "unmeasured_reasons"}
-    report["summary"]["status"][b]      {"claude", "shell", "total"} per bucket
+    report["summary"]["status"][b]      class counts + "total" per bucket
+    report["summary"]["kind"]           {"tmux": N} — the entity axis
     report["blocked_on_me"]             {"status", "count", ...}
 
-Each row carries: host, session, window_index, window_id, window_name,
+Each row carries: kind, host, session, window_index, window_id, window_name,
 codename, label, label_source, hotkey, pane_id, path, command, task, claude,
 busy, age_secs, age_source, status, waiting_probable, waiting_signals,
 waiting_status, claude_session_id, runtime, ledger, fuzzyclaw, panes. The row ledger is
 pinned by a test.
+
+🔴 `kind` IS THE ENTITY AXIS, AND IT IS WHY THE STATUS BUCKETS ARE NOT
+SIMPLY {claude, shell}.
+--------------------------------------------------------------------------
+`kind` is `tmux` on every row this build produces: a pane on a host it ssh'd
+to. `cluster` is enumerated for a dispatch with NO pane (spec §4, writer 3)
+and is NOT produced yet — `caveats.kind_scope` says so in the payload, so an
+absence of cluster rows is never readable as a measured absence of cluster
+work. Clawgate is reported instead under `blocked_on_me`, a different
+population that is never double-counted with these rows.
+
+The buckets count by `row_class`, not by `claude`-or-`shell`, because
+`row["claude"]` is `pane_current_command =~ /claude/` — a fact about a PANE.
+A row with no pane has `claude: None`, which is FALSY, so an inline
+`"claude" if row["claude"] else "shell"` would file every cluster agent as a
+BARE SHELL. That is the claude/shell conflation this summary already exists
+to prevent, one axis over. A class key is created on demand, so no `cluster: 0`
+is published while no cluster row can exist.
 
 🔴 `label` IS NOT AN ADDRESS — `session:window` still is.
 --------------------------------------------------------------------------
@@ -457,6 +476,78 @@ CAPTURE_MARK_PREFIX = "SMCAP"
 # bucket cannot exist in `classify_status` and be missing from the summary.
 STATUS_BUCKETS = ("busy", "idle", "stale", "unknown")
 
+# 🔴 WHAT KIND OF THING A ROW IS — the entity axis, enumerated and CLOSED.
+#
+# Every row today is `tmux`: a pane on a host this tool ssh'd to. `cluster` is
+# the name reserved for a row with NO pane — a clawgate dispatch running in the
+# workbench cluster (spec §4). It is enumerated here BEFORE such a row exists,
+# and that is the point: the decision this constant records is that clawgate
+# rows join the SAME collection with the tmux-only fields null, rather than
+# living in a second section every consumer has to merge by hand.
+# `claudedocs/design-ledger-writer3-and-kind-2026-08-14.md` has the reasoning
+# and the measurement that says `cluster` rows are NOT built yet.
+#
+# 🔴 NO `cluster` COUNT IS PUBLISHED UNTIL A `cluster` ROW EXISTS. `summarize`
+# creates a class key on demand, never pre-seeded, because a `cluster: 0` in a
+# build that cannot produce cluster rows is indistinguishable from a reader
+# wired to nothing — the exact zero this tool exists to stop emitting. So the
+# summary of a tmux-only scan is byte-identical to what it was before `kind`.
+KINDS = ("tmux", "cluster")
+
+# 🔴 `kind` VS `runtime` — TWO AXES, AND NEITHER IS DERIVABLE FROM THE OTHER.
+# They will agree on almost every row, which is exactly how someone collapses
+# them later and finds out the hard way that the null semantics differ:
+#
+#   kind     WHERE the row came from — a tmux pane scan, or the clawgate API.
+#            Known with certainty when the row is built. NEVER null.
+#   runtime  WHICH agent software — from the ledger record (`claude`/`opencode`).
+#            NULL whenever no writer has recorded that window, which is the
+#            common case for a session that has not taken a turn yet.
+#
+# So `runtime is None` is a real, frequent measurement about a tmux row, and
+# `kind is None` is a bug. Do not infer one from the other.
+
+
+def row_class(row) -> str:
+    """Which class a row is counted as in the roll-ups: `claude` | `shell` |
+    `cluster`. THE ONE definition — `summarize` uses it for both the per-status
+    buckets and the top-level totals, so the two cannot disagree.
+
+    🔴 `claude`/`shell` IS A TMUX-ONLY DISTINCTION, and that is the whole reason
+    this function exists rather than an inline conditional. The old roll-up read
+    `"claude" if row.get("claude") else "shell"`, and `row["claude"]` is
+    `pane_current_command =~ /claude/` — a fact about a PANE. A row with no pane
+    has `claude: None`, which is falsy, so every cluster agent would have been
+    counted as a BARE SHELL: an agent silently added to the bucket that means
+    "nobody is working here".
+
+    That is not a hypothetical restatement of the rule — it is the identical
+    defect the claude/shell split was built to kill one axis over. Measured on
+    this host 2026-08-11, `idle: 17` was 12 agent windows + 5 bare shells
+    rendered identically, and the fix was to stop publishing the mixed integer.
+    Publishing a cluster agent inside `shell` re-opens it in a form the existing
+    tests cannot see, because every fixture in the suite is tmux-only.
+
+    Keyed on `kind`, NOT on `claude is None`. A tmux row can also carry a null
+    `claude` (a pane whose command did not parse), and that row genuinely is
+    "not a claude pane" — it belongs in `shell`. The two nulls mean different
+    things and only `kind` separates them.
+
+    🔴 A MISSING OR UNKNOWN `kind` GETS ITS OWN CLASS, and does not fall through
+    to `cluster`. Folding it into `cluster` would be the same mistake one level
+    down: "a row whose kind nobody set" and "a row measured as a cluster
+    dispatch" are different findings, and the first is a bug in whatever built
+    the row. `unknown_kind` is never pre-seeded, so it publishes a count only
+    when such a row actually exists — at which point it is loud rather than
+    absorbed into a plausible neighbour.
+    """
+    kind = row.get("kind")
+    if kind == "tmux":
+        return "claude" if row.get("claude") else "shell"
+    if kind in KINDS:
+        return kind
+    return "unknown_kind"
+
 # 🔴 THE TWO LIMITS THAT CHANGE WHAT THE OUTPUT MEANS, CARRIED IN THE OUTPUT.
 # Both were documented in the skill body only. An agent that runs this script
 # cold never reads the skill, and the failure mode of each is silent: a `claude`
@@ -493,6 +584,24 @@ CAVEATS = {
                  "NOTHING about `age_secs`/`claude_session_id`/`stale` — those "
                  "come from the agent ledger, which IS read per host; see "
                  "caveats.ledger_scope."),
+    },
+    # 🔴 THE SCOPE OF THE ENTITY AXIS. Without this a `--json` consumer reads a
+    # scan containing only `kind: tmux` rows as "there are no cluster
+    # dispatches", when the truth is that this build never looks for one — the
+    # zero-vs-wired-to-nothing confusion, in the one field newly added to every
+    # row. It names the source that DOES answer, so the reader is not left to
+    # conclude the tool simply cannot say.
+    "kind_scope": {
+        "kinds_enumerated": list(KINDS),
+        "kinds_produced": ["tmux"],
+        "note": ("every row is a tmux pane on a scanned host. `cluster` is "
+                 "ENUMERATED but NOT PRODUCED — no clawgate dispatch is read "
+                 "into rows by this build, so an absence of cluster rows is "
+                 "NOT a measured absence of cluster work. For clawgate use "
+                 "report.blocked_on_me (tasks needing the operator, and its "
+                 "`stuck_count` for wedged dispatches), which is a different "
+                 "population from these rows and is never double-counted "
+                 "with them."),
     },
     "ledger_scope": {
         "scope": "per_host",
@@ -1411,6 +1520,15 @@ def fold_windows(panes, host, slots=None, task_index=None,
             w_probable = det["probable"]
             w_signals = det["signals"]
         rows.append({
+            # 🔴 WHAT KIND OF ENTITY THIS ROW IS. Always `tmux` here — this
+            # function folds PANES, so by construction every row it builds has
+            # one. It is written explicitly rather than left to a default
+            # because the field's contract is that it is NEVER null (see
+            # `KINDS`). A row built somewhere else that forgets to set it does
+            # NOT quietly become a cluster row: `row_class` gives it
+            # `unknown_kind` and `summary["kind"]` counts it as `"none"`, both
+            # of which a test asserts against `KINDS`.
+            "kind": "tmux",
             "host": host,
             "session": session,
             "window_index": widx,
@@ -1540,15 +1658,39 @@ def summarize(report) -> dict:
     counts = {b: {"claude": 0, "shell": 0} for b in STATUS_BUCKETS}
     for r in rows:
         bucket = counts.setdefault(r["status"], {"claude": 0, "shell": 0})
-        bucket["claude" if r.get("claude") else "shell"] += 1
+        # 🔴 `row_class`, not an inline `claude`-or-`shell`: a row with no pane
+        # must NOT land in `shell`. See `row_class` for why that is the same
+        # defect this split was built to kill. The class key is created ON
+        # DEMAND — `cluster` appears only once a cluster row does, so a
+        # tmux-only scan never publishes a `cluster: 0` that would read as a
+        # measured absence of something this build cannot produce.
+        cls = row_class(r)
+        bucket[cls] = bucket.get(cls, 0) + 1
     for b in counts.values():
-        b["total"] = b["claude"] + b["shell"]
+        # Every class key accounts for the bucket's own total, whatever class
+        # keys the rows produced. Summing `claude + shell` by name would have
+        # silently dropped any third class from the total instead of failing.
+        b["total"] = sum(v for k, v in b.items() if k != "total")
     filters = report.get("filters") or {}
     return {
         "total_sessions": len(rows),
-        "claude": sum(1 for r in rows if r["claude"]),
-        "shell": sum(1 for r in rows if not r["claude"]),
+        # 🔴 THE SAME `row_class`, so the top-level totals and the per-status
+        # buckets cannot disagree. These read `row_class`, not `r["claude"]`
+        # directly: `shell` used to be `not r["claude"]`, which absorbs every
+        # row with a null `claude` — including a cluster row that has no pane
+        # to have a command. One predicate, one place; the version of this that
+        # is open-coded at two sites is wrong at exactly one of them.
+        "claude": sum(1 for r in rows if row_class(r) == "claude"),
+        "shell": sum(1 for r in rows if row_class(r) == "shell"),
         "status": counts,
+        # 🔴 THE ENTITY AXIS, published as its own histogram and DERIVED from
+        # the rows — never hardcoded — so a kind cannot exist on a row and be
+        # missing from the summary. Same idiom, and same reason, as
+        # `age_sources`: `"none"` rather than `None`, because a null JSON key
+        # serialises to the string `"null"` and reads as a kind called null.
+        # A `kind` of `"none"` appearing at all is a bug (see `KINDS`), which
+        # is precisely why it is counted rather than coerced away.
+        "kind": _count_by(r.get("kind") or "none" for r in rows),
         # 🔴 The filter travels WITH the counts it changed. Under
         # `--claude-only` every number above describes the FILTERED set (see
         # `gather`), so a reader that does not know the filter ran would read a
@@ -2619,6 +2761,12 @@ LEAN_ROW_FIELDS = (
     # yielded nothing "are distinguishable by `label_source`, not by the
     # label" — dropping it made exactly that pair unreadable. An audit caught
     # the inconsistency between the rule and the field list; the rule won.
+    # 🔴 `kind` is a DISCRIMINANT, not duplication — it is what tells a reader
+    # whether the null `session`/`window_index` on a row is "not measured" or
+    # "this entity has no such thing". Dropping it would leave a cluster row
+    # indistinguishable from a tmux row whose host went unreachable, which is
+    # the ambiguity this whole view exists to remove.
+    "kind",
     "host", "session", "window_index", "label", "label_source", "hotkey",
     # what it is working on, and WHICH agent is doing it
     "path", "task", "runtime",
@@ -2695,6 +2843,7 @@ def render_caveats(report) -> list:
     fz = cav.get("fuzzyclaw_scope") or {}
     led = cav.get("ledger_scope") or {}
     wt = cav.get("waiting_signal") or {}
+    kd = cav.get("kind_scope") or {}
     return [
         # 🔴 The signal set is ENUMERATED in the footer, because `WAIT: no` is
         # the cell a reader will over-trust. Naming the three things that were
@@ -2721,6 +2870,16 @@ def render_caveats(report) -> list:
         "agent ledger, read {} — a REMOTE row has both and CAN be `stale`. A "
         "null age means NO WRITER HAS RECORDED that window, not age 0; "
         "`age_source` names the writer".format(led.get("scope", "per_host")),
+        # 🔴 The entity axis, printed for the same reason as the three above:
+        # `kind` is now on every row, and "only tmux rows here" must not be
+        # read as "no cluster work exists".
+        "  caveat[kind_scope]: every row is kind={} — {} is ENUMERATED but NOT "
+        "PRODUCED, so no cluster/clawgate dispatch appears as a row and their "
+        "absence is NOT a measured zero; clawgate is reported separately under "
+        "BLOCKED ON ME".format(
+            "/".join(kd.get("kinds_produced") or ["tmux"]),
+            "/".join(k for k in (kd.get("kinds_enumerated") or list(KINDS))
+                     if k not in (kd.get("kinds_produced") or ["tmux"]))),
     ]
 
 

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -220,6 +220,7 @@ surface that renders a row shows `session` and `window_index` beside it.
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import os
 import re
@@ -2391,16 +2392,20 @@ def measured_caveats(report) -> dict:
     collapses "derived" and "hardcoded" into the same observation; the fix is
     an input where they differ, which means a seam that accepts one.
     """
-    # 🔴 EVERY SUB-DICT IS COPIED, not just the one being written. Copying only
-    # `kind_scope` left `claude_detection`/`fuzzyclaw_scope`/`ledger_scope`/
-    # `waiting_signal` as the SAME objects as the module constant, so a
-    # consumer writing through `report["caveats"]["waiting_signal"]` — which
-    # this function's own "returns a new dict, mutates nothing" docstring
-    # invites — would poison CAVEATS for every later caller in the process. A
-    # purity claim that holds for one key and not its siblings is worse than no
-    # claim: it is exactly specific enough to be trusted.
-    cav = {k: (dict(v) if isinstance(v, dict) else v)
-           for k, v in (report.get("caveats") or CAVEATS).items()}
+    # 🔴 DEEP-COPIED, because a purity claim is only as true as its DEEPEST
+    # shared object. This was fixed once at depth 1 — `{k: dict(v)}` — and an
+    # audit walked straight past it into depth 2: `waiting_signal["excluded"]`
+    # is itself a dict, and `signals` / `kinds_enumerated` /
+    # `null_fields_on_remote_rows` are lists, all still the SAME objects as the
+    # module constant. Writing into any of them poisoned CAVEATS for every
+    # later caller in the process, and the contamination surfaced in a
+    # DIFFERENT scan's rendered caveat line.
+    #
+    # "One level deeper than the fix" is the shape this whole change keeps
+    # producing, so the copy is made total rather than incrementally deepened
+    # again. CAVEATS is a handful of small literals; `deepcopy` is not a cost
+    # worth trading for a claim that has now been wrong twice.
+    cav = copy.deepcopy(report.get("caveats") or CAVEATS)
     rows = [r for h in (report.get("hosts") or {}).values()
             for r in (h.get("windows") or [])]
     # Sorted for a deterministic render. `"none"` rather than dropping a row
@@ -3042,10 +3047,16 @@ def _fmt_kind_scope(kd) -> str:
     """
     produced = kd.get("kinds_produced")
     if produced is None:
-        # No measurement supplied at all — a caller rendering the bare CAVEATS
-        # constant. Say what the tool produces by construction, not what this
-        # scan saw, because this scan was never measured.
-        produced = ["tmux"]
+        # 🔴 NO MEASUREMENT SUPPLIED AT ALL — a caller rendering the bare
+        # CAVEATS constant rather than a scanned report. The sentence must then
+        # describe what this tool produces BY CONSTRUCTION and must NOT say
+        # "in this scan", because no scan happened. The first version said
+        # exactly that while its own comment claimed otherwise: a comment is a
+        # claim too, and it disagreed with the string three lines below it.
+        return _kind_scope_sentence(
+            "this tool produces kind={} rows by construction (no scan "
+            "measured here)", ["tmux"],
+            list(kd.get("kinds_enumerated") or KINDS))
     produced = list(produced)
     enumerated = list(kd.get("kinds_enumerated") or KINDS)
     if not produced:
@@ -3057,8 +3068,16 @@ def _fmt_kind_scope(kd) -> str:
                 "kinds ({}) say nothing about what a reachable host holds; "
                 "clawgate is reported separately under BLOCKED ON ME".format(
                     "/".join(enumerated)))
+    return _kind_scope_sentence("rows in this scan are kind={}", produced,
+                                enumerated)
+
+
+def _kind_scope_sentence(head_fmt, produced, enumerated) -> str:
+    """Build the non-empty `kind_scope` sentence. ONE builder for both the
+    measured and the by-construction heads, so the two cannot drift into
+    saying different things about the same relationship."""
     unproduced = [k for k in enumerated if k not in produced]
-    head = "rows in this scan are kind={}".format("/".join(produced))
+    head = head_fmt.format("/".join(produced))
     if not unproduced:
         # Every enumerated kind is present. Saying "NOT PRODUCED" here would be
         # false; saying nothing would drop the pointer to where clawgate lives.

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -119,10 +119,15 @@ The headline question is "is anything waiting on me", and `idle` answered it
 with 12 agent windows and 5 bare shells added together — rendered identically
 as `● idle`, with nothing on the row saying which was which. The row data was
 already right (every row carries `claude`); only the roll-up and the table
-conflated. So every status bucket now splits `{claude, shell, total}` in the
-summary, and the table carries a KIND column. See `summarize` for why all four
-buckets split rather than just `idle`, and for the deliberate removal of the
-flat `summary["idle"]` integer.
+conflated. So every status bucket now splits per CLASS plus `total` in the
+summary, and the table carries a CLASS column. The classes are `claude` and
+`shell` for a tmux row and `cluster` for a row with no pane — see `row_class`,
+and `summarize` for why all four buckets split rather than just `idle` and for
+the deliberate removal of the flat `summary["idle"]` integer.
+
+⚠ The CLASS column and the `kind` FIELD are different axes and are deliberately
+not the same word: `kind` is `tmux`/`cluster` (WHAT the entity is), `CLASS` is
+`claude`/`shell`/`cluster` (how it is COUNTED).
 
 `--claude-only` drops the shells outright; the summary then describes the
 FILTERED set and carries `excluded_non_claude` so an empty table cannot read as
@@ -1623,6 +1628,27 @@ def _count_by(values) -> dict:
     return out
 
 
+def _summary_classes(summ) -> list:
+    """The class names this summary actually contains, in render order.
+
+    DERIVED from the status buckets, so a class cannot exist in `row_class` and
+    be missing from the human-facing lines — the same rule `age_sources` and
+    `waiting.per_signal` follow. `claude`/`shell` lead because they are the two
+    a reader has been reading for months and their order carries meaning in the
+    `claude+shell` legend; anything else is appended in sorted order so the
+    render is deterministic rather than dict-insertion dependent.
+    """
+    seen = set()
+    for cell in (summ.get("status") or {}).values():
+        seen |= {k for k in cell if k != "total"}
+    # `claude`/`shell` unconditionally: every bucket is pre-seeded with both, so
+    # they are always present, and a scan that happened to contain neither must
+    # still render `claude=0 shell=0` rather than quietly dropping the columns
+    # a reader is scanning for.
+    lead = ["claude", "shell"]
+    return lead + sorted(seen - set(lead))
+
+
 def summarize(report) -> dict:
     """🔴 EVERY status bucket is split claude/shell. A MIXED count is never
     published as a bare integer.
@@ -1647,7 +1673,10 @@ def summarize(report) -> dict:
 
     🔴 BACKWARD COMPATIBILITY, chosen deliberately in the LOUD direction. The
     flat `summary["busy"|"idle"|"stale"|"unknown"]` integers are GONE, replaced
-    by `summary["status"][bucket]` -> `{"claude", "shell", "total"}`. Keeping
+    by `summary["status"][bucket]` -> one key per CLASS plus `"total"`. On a
+    tmux-only scan the classes are exactly `{"claude", "shell"}`; a class key is
+    added on demand (see `row_class`), never pre-seeded, so no bucket publishes
+    a zero for a class the build cannot produce. Keeping
     the flat ints would have left every existing reader silently reading the
     mixed number as an agent count — the exact defect — while the fix sat in
     keys they never learned about. A KeyError is a worse morning and a better
@@ -1670,9 +1699,16 @@ def summarize(report) -> dict:
         # Every class key accounts for the bucket's own total, whatever class
         # keys the rows produced. Summing `claude + shell` by name would have
         # silently dropped any third class from the total instead of failing.
-        b["total"] = sum(v for k, v in b.items() if k != "total")
+        #
+        # No `if k != "total"` filter: `total` is assigned HERE and `counts` is
+        # rebuilt per call, so the key cannot already be present and the filter
+        # could never fire. A mutation sweep proved it — deleting the clause
+        # changed nothing and no test could tell. An unreachable guard reads as
+        # protection while providing none, so it is stated as a precondition
+        # instead of pantomimed as a check.
+        b["total"] = sum(b.values())
     filters = report.get("filters") or {}
-    return {
+    out = {
         "total_sessions": len(rows),
         # 🔴 THE SAME `row_class`, so the top-level totals and the per-status
         # buckets cannot disagree. These read `row_class`, not `r["claude"]`
@@ -1744,6 +1780,18 @@ def summarize(report) -> dict:
         "rows_with_session_id": sum(1 for r in rows
                                     if r.get("claude_session_id")),
     }
+    # 🔴 A TOP-LEVEL COUNT FOR EVERY CLASS, ON DEMAND. `claude` and `shell`
+    # are above; any further class gets its own key here rather than being
+    # left out of the whole-set totals. Without this the human summary line
+    # renders `N windows claude=3 shell=2` while N is 7 — a complete-looking
+    # accounting with rows missing and nothing saying so.
+    #
+    # On demand, for the same reason the buckets are: a `cluster: 0` at the top
+    # level of a build that cannot produce cluster rows is a measurement of
+    # nothing. So a tmux-only summary keeps exactly the integer keys it had.
+    for cls, n in _count_by(row_class(r) for r in rows).items():
+        out.setdefault(cls, n)
+    return out
 
 
 def exit_code_for(report) -> int:
@@ -2299,7 +2347,47 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
             report["clickhouse"] = res
 
     report["summary"] = summarize(report)
+    # 🔴 THE `kind_scope` CAVEAT IS A MEASUREMENT, NOT A STANDING CLAIM.
+    #
+    # `kinds_produced` used to be a literal in the CAVEATS constant, so the
+    # rendered line asserted "every row is kind=tmux" no matter what the rows
+    # actually were — it would keep saying that on the day writer 3 starts
+    # emitting cluster rows, and the reader most likely to be misled is the one
+    # reading the line to find out. That is exactly how `fuzzyclaw_scope` went
+    # stale in #471: a machine-readable claim that outlived the code it
+    # described.
+    #
+    # Derived from THIS report's rows instead, so the line cannot disagree with
+    # the table above it. Sorted for a deterministic render, and copied rather
+    # than mutated in place — `report["caveats"]` is the module-level CAVEATS
+    # dict by reference, and writing through it would leak one scan's
+    # measurement into every later caller in the process.
+    report["caveats"] = measured_caveats(report)
     return report
+
+
+def measured_caveats(report, caveats=None) -> dict:
+    """CAVEATS with `kind_scope.kinds_produced` MEASURED from `report`'s rows.
+    PURE — returns a new dict, mutates nothing.
+
+    🔴 THIS IS A SEPARATE FUNCTION SO THE DERIVATION IS REACHABLE FROM A TEST
+    WITH NON-TMUX INPUT. Inlined in `gather`, the only way to exercise it was a
+    real scan — and every real scan is tmux-only, so a mutant that replaced the
+    derivation with the literal `["tmux"]` produced byte-identical output and
+    SURVIVED a green suite. A fixture whose values coincide with the constant
+    collapses "derived" and "hardcoded" into the same observation; the fix is
+    an input where they differ, which means a seam that accepts one.
+    """
+    cav = dict(caveats if caveats is not None else report.get("caveats")
+               or CAVEATS)
+    cav["kind_scope"] = dict(cav["kind_scope"])
+    rows = [r for h in (report.get("hosts") or {}).values()
+            for r in (h.get("windows") or [])]
+    # Sorted for a deterministic render. `"none"` rather than dropping a row
+    # with no `kind`: it is a bug, and the caveat is where it becomes visible.
+    cav["kind_scope"]["kinds_produced"] = sorted(
+        {r.get("kind") or "none" for r in rows})
+    return cav
 
 
 # =========================================================================== #
@@ -2468,13 +2556,25 @@ def render_table(report) -> str:
         out.append("  (none)" if reach
                    else "  (no host answered — nothing was measured)")
     else:
-        # 🔴 KIND is its own column, read straight off the row's `claude`
-        # boolean. It is deliberately NOT spelled into the STATUS word: a
-        # status cell of "idle·sh" can be satisfied by anything that happens to
-        # contain those characters, while a column whose only two values are
-        # `claude` and `shell` states which one the row IS. `● idle` on an
-        # agent and `● idle` on a bare zsh prompt were the same six characters
-        # before this.
+        # 🔴 CLASS is its own column. It is deliberately NOT spelled into the
+        # STATUS word: a status cell of "idle·sh" can be satisfied by anything
+        # that happens to contain those characters, while a column stating
+        # which class the row IS cannot. `● idle` on an agent and `● idle` on a
+        # bare zsh prompt were the same six characters before this.
+        #
+        # 🔴 IT WAS HEADED `KIND` AND IT IS NOT THE `kind` FIELD. The row now
+        # carries a real `kind` (`tmux`/`cluster`, the ENTITY axis), and this
+        # column renders `claude`/`shell`/`cluster` — the CLASS axis. Two
+        # vocabularies under one word, on the two surfaces a reader compares
+        # side by side (`--json` and the table), is a misread waiting to
+        # happen, so the column is `CLASS` and the field is `kind`.
+        #
+        # It also renders `row_class(r)` rather than a third open-coded
+        # `"claude" if r["claude"] else "shell"`. That inline conditional is
+        # the exact predicate `row_class` exists to consolidate, and leaving a
+        # copy here would have made the TABLE say `shell` for a cluster row
+        # while the SUMMARY it sits under said `cluster` — the one-rule-one-
+        # place failure, visible on one screen.
         # 🔴 THE COLUMN TRADE, stated because the table did not get wider.
         # CODENAME (9) became LABEL (14) and TASK gave up the 5 characters, so
         # the frame is byte-for-byte the same width as before. Nothing was lost
@@ -2487,7 +2587,7 @@ def render_table(report) -> str:
         # The cost is real and it is TASK: 30 -> 25 characters before the
         # ellipsis. `--json` carries every field untruncated and unjoined.
         out.append(_ROW_FMT.format("HOST", "SESSION", "WIN", "LABEL", "TASK",
-                                   "KIND", "STATUS", "AGE", "WAIT"))
+                                   "CLASS", "STATUS", "AGE", "WAIT"))
         out.append("  " + "─" * 112)
         for r in rows:
             out.append(
@@ -2496,7 +2596,7 @@ def render_table(report) -> str:
                     _trunc(r.get("window_index"), 3),
                     _trunc(render_label(r), 14),
                     _trunc(r.get("task") or "—", 25),
-                    "claude" if r.get("claude") else "shell",
+                    row_class(r),
                     _STATUS_GLYPH.get(r.get("status"), "?"),
                     _fmt_age(r.get("age_secs")),
                     _fmt_waiting(r)))
@@ -2592,18 +2692,28 @@ def render_table(report) -> str:
     out.append("")
     out.extend(render_ledger(report.get("ledger")))
     out.append("")
-    out.append("  summary: {total} windows  claude={claude}  shell={shell}"
-               .format(total=summ.get("total_sessions", 0),
-                       claude=summ.get("claude", 0),
-                       shell=summ.get("shell", 0)))
-    # 🔴 Every bucket prints as `claude+shell`, never as one number. The legend
-    # is on the same line, so no reader has to remember which half is which —
-    # and there is no rendering of `idle` that a reader can mistake for a count
-    # of waiting AGENTS.
+    # 🔴 THE HUMAN LINE IS CLASS-GENERIC TOO. `summarize` was made to total over
+    # whatever class keys exist; this render was left summing `claude`/`shell`
+    # BY NAME, so a row in any third class was silently absent from a line that
+    # still looked like a complete accounting — `7 windows claude=3 shell=2`,
+    # with two rows unmentioned and no discriminant saying so. The JSON was
+    # right and the screen was wrong, which is the harder version to notice.
+    #
+    # `_kind_classes` derives the class names from the summary itself, so a
+    # class cannot exist in `row_class` and be missing from either line.
+    classes = _summary_classes(summ)
+    out.append("  summary: {total} windows  {parts}".format(
+        total=summ.get("total_sessions", 0),
+        parts="  ".join("{}={}".format(c, summ.get(c, 0))
+                        for c in classes if c in summ)))
+    # 🔴 Every bucket prints per class, never as one number. The legend is on
+    # the same line, so no reader has to remember which part is which — and
+    # there is no rendering of `idle` that a reader can mistake for a count of
+    # waiting AGENTS.
     st = summ.get("status") or {}
-    out.append("  by status (claude+shell): " + "  ".join(
-        "{}={}+{}".format(b, (st.get(b) or {}).get("claude", 0),
-                          (st.get(b) or {}).get("shell", 0))
+    out.append("  by status ({}): ".format("+".join(classes)) + "  ".join(
+        "{}={}".format(b, "+".join(str((st.get(b) or {}).get(c, 0))
+                                   for c in classes))
         for b in STATUS_BUCKETS))
     # 🔴 The line that would have made #419 visible on the day it shipped.
     # `stale` is derived from an age, so a `stale=0+0` bucket means one of two
@@ -2855,7 +2965,9 @@ def render_caveats(report) -> list:
         "deliberately EXCLUDED, so a window one Enter away reads `no` "
         "(reference/waiting-signal.md)".format(
             "/".join(wt.get("signals") or WAITING_SIGNALS)),
-        "  caveat[claude_detection]: KIND is `pane_current_command =~ /{}/` — "
+        # `CLASS`, matching the column header. It said `KIND`, which now names
+        # a different field with a different vocabulary.
+        "  caveat[claude_detection]: CLASS is `pane_current_command =~ /{}/` — "
         "shallower than agent-ops' /proc walk; a claude under a wrapper shell "
         "reads as `shell`".format(det.get("pattern", "claude")),
         "  caveat[fuzzyclaw_scope]: fuzzyclaw is {} — REMOTE rows carry null "
@@ -2873,14 +2985,35 @@ def render_caveats(report) -> list:
         # 🔴 The entity axis, printed for the same reason as the three above:
         # `kind` is now on every row, and "only tmux rows here" must not be
         # read as "no cluster work exists".
-        "  caveat[kind_scope]: every row is kind={} — {} is ENUMERATED but NOT "
-        "PRODUCED, so no cluster/clawgate dispatch appears as a row and their "
-        "absence is NOT a measured zero; clawgate is reported separately under "
-        "BLOCKED ON ME".format(
-            "/".join(kd.get("kinds_produced") or ["tmux"]),
-            "/".join(k for k in (kd.get("kinds_enumerated") or list(KINDS))
-                     if k not in (kd.get("kinds_produced") or ["tmux"]))),
+        #
+        # 🔴 BOTH BRANCHES EXIST BECAUSE THE EMPTY SET IS REACHABLE. `gather`
+        # derives `kinds_produced` from the rows, so once every enumerated kind
+        # IS produced the set difference is empty and the single-sentence
+        # version rendered "—  is ENUMERATED but NOT PRODUCED": a blank subject
+        # in a sentence whose whole job is naming what is missing. A caveat
+        # that degrades into a grammatically-broken half-claim is worse than
+        # one that says nothing, because it still reads as a claim.
+        "  caveat[kind_scope]: " + _fmt_kind_scope(kd),
     ]
+
+
+def _fmt_kind_scope(kd) -> str:
+    """The `kind_scope` caveat's sentence, split out so both branches are
+    reachable from a test without building a whole report."""
+    produced = list(kd.get("kinds_produced") or ["tmux"])
+    enumerated = list(kd.get("kinds_enumerated") or KINDS)
+    unproduced = [k for k in enumerated if k not in produced]
+    head = "rows in this scan are kind={}".format("/".join(produced) or "none")
+    if not unproduced:
+        # Every enumerated kind is present. Saying "NOT PRODUCED" here would be
+        # false; saying nothing would drop the pointer to where clawgate lives.
+        return (head + " — every enumerated kind IS produced, so this scan "
+                "covers the whole entity axis; clawgate approval state is "
+                "still reported separately under BLOCKED ON ME")
+    return (head + " — {} is ENUMERATED but NOT PRODUCED, so no such row "
+            "appears and its absence is NOT a measured zero; clawgate is "
+            "reported separately under BLOCKED ON ME".format(
+                "/".join(unproduced)))
 
 
 def render_session_history(hist) -> str:

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -500,6 +500,14 @@ STATUS_BUCKETS = ("busy", "idle", "stale", "unknown")
 # summary of a tmux-only scan is byte-identical to what it was before `kind`.
 KINDS = ("tmux", "cluster")
 
+#: 🔴 What this build produces WITHOUT measuring — the honest answer for a
+#: caller that has no scan. Separate from `KINDS` (what exists) and from a
+#: report's measured `kinds_produced` (what a scan saw). Writer 3 updates THIS
+#: tuple, and the moment it gains `cluster` the all-produced branch of
+#: `_kind_scope_sentence` goes live under the by-construction head — which is
+#: why that branch's wording is parameterised rather than hardcoded to a scan.
+KINDS_PRODUCED_BY_CONSTRUCTION = ("tmux",)
+
 # 🔴 `kind` VS `runtime` — TWO AXES, AND NEITHER IS DERIVABLE FROM THE OTHER.
 # They will agree on almost every row, which is exactly how someone collapses
 # them later and finds out the hard way that the null semantics differ:
@@ -599,10 +607,14 @@ CAVEATS = {
     # conclude the tool simply cannot say.
     "kind_scope": {
         "kinds_enumerated": list(KINDS),
-        # 🔴 OVERWRITTEN PER SCAN by `measured_caveats`. This literal is only
-        # what a caller rendering the bare constant sees; the shipped value is
-        # measured from the rows.
-        "kinds_produced": ["tmux"],
+        # 🔴 DELIBERATELY ABSENT. `kinds_produced` is a MEASUREMENT, supplied
+        # per scan by `measured_caveats`, and a literal here is a fake one: it
+        # made the bare constant render "rows in this scan are kind=tmux" when
+        # no scan had happened, and it made the honest by-construction branch
+        # in `_fmt_kind_scope` UNREACHABLE — so the fix for that sentence sat
+        # in code nothing could execute while the false sentence stayed live.
+        # A missing key is the honest representation of "not measured", which
+        # is exactly what this constant knows.
         # 🔴 THE NOTE STATES ONLY WHAT IS DURABLY TRUE, because it sits beside
         # a MEASURED field and ships in the same `--json` payload. It used to
         # assert "every row is a tmux pane … cluster is ENUMERATED but NOT
@@ -3047,15 +3059,24 @@ def _fmt_kind_scope(kd) -> str:
     """
     produced = kd.get("kinds_produced")
     if produced is None:
-        # 🔴 NO MEASUREMENT SUPPLIED AT ALL — a caller rendering the bare
-        # CAVEATS constant rather than a scanned report. The sentence must then
-        # describe what this tool produces BY CONSTRUCTION and must NOT say
-        # "in this scan", because no scan happened. The first version said
-        # exactly that while its own comment claimed otherwise: a comment is a
-        # claim too, and it disagreed with the string three lines below it.
+        # 🔴 NO MEASUREMENT SUPPLIED — reached by any caveats dict without a
+        # `kinds_produced` key, which is the bare CAVEATS constant (the key is
+        # deliberately absent there) and any report that never went through
+        # `measured_caveats`. The sentence must then describe what this tool
+        # produces BY CONSTRUCTION and must NOT say "in this scan", because no
+        # scan happened.
+        #
+        # An earlier comment here named the bare-constant caller while the
+        # constant still carried a literal `kinds_produced`, so that caller
+        # took the MEASURED branch and this one was unreachable: the comment
+        # described a path its own code could not take, and the false sentence
+        # it claimed to have fixed was still being rendered. A comment is a
+        # claim, and this one was wrong about reachability, which is the
+        # hardest kind to notice.
         return _kind_scope_sentence(
             "this tool produces kind={} rows by construction (no scan "
-            "measured here)", ["tmux"],
+            "measured here)", "this build",
+            list(KINDS_PRODUCED_BY_CONSTRUCTION),
             list(kd.get("kinds_enumerated") or KINDS))
     produced = list(produced)
     enumerated = list(kd.get("kinds_enumerated") or KINDS)
@@ -3068,22 +3089,33 @@ def _fmt_kind_scope(kd) -> str:
                 "kinds ({}) say nothing about what a reachable host holds; "
                 "clawgate is reported separately under BLOCKED ON ME".format(
                     "/".join(enumerated)))
-    return _kind_scope_sentence("rows in this scan are kind={}", produced,
-                                enumerated)
+    return _kind_scope_sentence("rows in this scan are kind={}", "this scan",
+                                produced, enumerated)
 
 
-def _kind_scope_sentence(head_fmt, produced, enumerated) -> str:
+def _kind_scope_sentence(head_fmt, subject, produced, enumerated) -> str:
     """Build the non-empty `kind_scope` sentence. ONE builder for both the
     measured and the by-construction heads, so the two cannot drift into
-    saying different things about the same relationship."""
+    saying different things about the same relationship.
+
+    🔴 `subject` EXISTS BECAUSE SHARING THE BUILDER CREATED A FALSE SENTENCE.
+    The all-produced tail hardcoded "so THIS SCAN covers the whole entity
+    axis". Under the by-construction head — which explicitly says "no scan
+    measured here" — that produced a sentence contradicting itself eight words
+    later. It was unreachable the moment the builder was shared and becomes
+    reachable the moment `KINDS_PRODUCED_BY_CONSTRUCTION` gains `cluster`,
+    i.e. exactly when writer 3 lands, which is what this caveat is FOR.
+    Consolidating two strings is only safe where they say the same thing; the
+    part that differed had to become a parameter, not a coincidence.
+    """
     unproduced = [k for k in enumerated if k not in produced]
     head = head_fmt.format("/".join(produced))
     if not unproduced:
         # Every enumerated kind is present. Saying "NOT PRODUCED" here would be
         # false; saying nothing would drop the pointer to where clawgate lives.
-        return (head + " — every enumerated kind IS produced, so this scan "
-                "covers the whole entity axis; clawgate approval state is "
-                "still reported separately under BLOCKED ON ME")
+        return (head + " — every enumerated kind IS produced, so {} covers the "
+                "whole entity axis; clawgate approval state is still reported "
+                "separately under BLOCKED ON ME".format(subject))
     return (head + " — {} is ENUMERATED but NOT PRODUCED, so no such row "
             "appears and its absence is NOT a measured zero; clawgate is "
             "reported separately under BLOCKED ON ME".format(

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -6418,8 +6418,15 @@ def test_NO_cluster_key_is_published_while_no_cluster_row_exists():
     for b in sm.STATUS_BUCKETS:
         assert set(s["status"][b]) == {"claude", "shell", "total"}, (
             "a tmux-only scan must not publish a cluster count")
-    # the caveat is what tells the reader why, instead of the absent key
-    assert sm.CAVEATS["kind_scope"]["kinds_produced"] == ["tmux"]
+    # the caveat is what tells the reader why, instead of the absent key.
+    # 🔴 The CONSTANT carries no `kinds_produced` at all — that key is a
+    # MEASUREMENT and a literal there was a fake one. What the build produces
+    # without measuring lives in its own named constant.
+    assert "kinds_produced" not in sm.CAVEATS["kind_scope"]
+    assert sm.KINDS_PRODUCED_BY_CONSTRUCTION == ("tmux",)
+    # a real scan supplies it
+    assert sm.summarize(mix_gather())  # (fixture sanity)
+    assert mix_gather()["caveats"]["kind_scope"]["kinds_produced"] == ["tmux"]
 
 
 def test_a_row_with_NO_kind_gets_its_OWN_class_and_never_becomes_cluster():
@@ -6761,6 +6768,14 @@ KIND_SCOPE_SENTENCES = {
         "rows in this scan are kind=tmux — cluster is ENUMERATED but NOT "
         "PRODUCED, so no such row appears and its absence is NOT a measured "
         "zero; " + _CG),
+    # 🔴 by-construction head with NOTHING unproduced — the combination the
+    # shared builder rendered self-contradicting ("no scan measured here …
+    # so this scan covers"). Its tail must speak of the BUILD.
+    "by_construction_all_produced": (
+        "this tool produces kind=tmux rows by construction (no scan measured "
+        "here) — every enumerated kind IS produced, so this build covers the "
+        "whole entity axis; clawgate approval state is still reported "
+        "separately under BLOCKED ON ME"),
     # after writer 3
     "both": (
         "rows in this scan are kind=cluster/tmux — every enumerated kind IS "
@@ -6782,14 +6797,50 @@ def test_every_kind_scope_sentence_is_pinned_WHOLE_not_by_feature():
                                     "kinds_enumerated": E}),
         "both": sm._fmt_kind_scope({"kinds_produced": ["cluster", "tmux"],
                                     "kinds_enumerated": E}),
+        # 🔴 THE COMBINATION THE SHARED BUILDER MADE FALSE. The by-construction
+        # head with NOTHING unproduced took a tail hardcoded to "so THIS SCAN
+        # covers the whole entity axis" — contradicting the head's own "no scan
+        # measured here" eight words earlier. Unreachable until
+        # KINDS_PRODUCED_BY_CONSTRUCTION covers the enumerated set, i.e. the
+        # moment writer 3 lands, which is what this caveat is FOR.
+        "by_construction_all_produced": sm._fmt_kind_scope(
+            {"kinds_enumerated": ["tmux"]}),
     }
     assert got == KIND_SCOPE_SENTENCES
-    # INSTRUMENT CHECK: the four are genuinely distinct, so a builder that
+    # INSTRUMENT CHECK: all five are genuinely distinct, so a builder that
     # collapsed two branches into one could not satisfy this by accident.
-    assert len(set(got.values())) == 4
-    # the two that must never phrase themselves as a measurement of a scan
+    assert len(set(got.values())) == 5
+    # the three that must never phrase themselves as a measurement of a scan
     assert "in this scan are" not in got["missing"]
     assert "kind=" not in got["empty"]
+    assert "this scan" not in got["by_construction_all_produced"]
+
+
+def test_the_kinds_enumerated_SLOT_IS_LIVE_not_defaulted_to_KINDS():
+    """🔴 THE FIXTURE-COINCIDES-WITH-THE-CONSTANT TRAP, which this file names
+    in its own comments and which I then walked into.
+
+    Every pin above uses `["tmux", "cluster"]` — which IS `KINDS`. So
+    `kd.get("kinds_enumerated") or KINDS` and a hardcoded `KINDS` produce
+    byte-identical output, and two mutants replacing the lookup with the
+    constant SURVIVED the whole suite. A fixture whose value equals the
+    constant cannot distinguish "read the argument" from "ignored it".
+
+    So this passes an enumerated set that CANNOT be KINDS.
+    """
+    line = sm._fmt_kind_scope({"kinds_produced": ["tmux"],
+                              "kinds_enumerated": ["tmux", "zzz"]})
+    assert "zzz is ENUMERATED but NOT PRODUCED" in line
+    assert "cluster" not in line, "the argument was ignored in favour of KINDS"
+    # the zero-row branch interpolates it too, and had the same blind spot
+    zero = sm._fmt_kind_scope({"kinds_produced": [],
+                               "kinds_enumerated": ["zzz", "qqq"]})
+    assert "(zzz/qqq)" in zero
+    assert "tmux" not in zero and "cluster" not in zero
+    # ...and so does the by-construction branch
+    bc = sm._fmt_kind_scope({"kinds_enumerated": ["tmux", "zzz"]})
+    assert "zzz is ENUMERATED but NOT PRODUCED" in bc
+    assert "cluster" not in bc
 
 
 def test_the_kind_scope_NOTE_names_NO_kind_at_all():
@@ -6797,11 +6848,22 @@ def test_the_kind_scope_NOTE_names_NO_kind_at_all():
 
     The old assertion banned the literal string "every row is a tmux pane", and
     a mutant saying "every row here is a tmux pane and the cluster kind never
-    appears" passed. Any ban-list of phrasings is walkable; the invariant that
-    is not is that the NOTE must name NO member of KINDS. `kinds_produced` is
-    the measured field and the note's job is to point at it — the moment the
-    note itself names a kind, it is making the standing claim that field
-    exists to replace, in whatever words.
+    appears" passed. Any ban-list of phrasings is walkable, so this bans
+    naming a KIND at all: `kinds_produced` is the measured field and the note's
+    job is to point AT it, so the moment the note names a kind it is making the
+    standing claim that field exists to replace.
+
+    🔴 THIS GUARD IS NOT SUFFICIENT ON ITS OWN, and saying so is the point of
+    this paragraph. An audit walked it with a SYNONYM: "every row here is a
+    terminal pane and the second enumerated entity never appears" names no
+    member of KINDS, keeps every required token, and clears the length floor.
+    The WHOLE-STRING pin in `test_the_kind_scope_NOTE_is_pinned_WHOLE` is what
+    actually kills that; deleting the pin lets it through and deleting this
+    guard does not. So this one adds no kill power TODAY — it exists to
+    constrain a future edit that legitimately updates the pin, where "the new
+    text must still name no kind" is the invariant a human re-pinning the
+    string would otherwise drop. Documented rather than deleted, and
+    documented as redundant rather than as protection.
     """
     note = sm.CAVEATS["kind_scope"]["note"]
     for k in sm.KINDS:
@@ -6942,8 +7004,8 @@ def test_measured_caveats_is_PURE_and_does_not_touch_its_input():
     rep = {"hosts": {"h": {"windows": [{"kind": "cluster"}]}}}
     out = sm.measured_caveats(rep)
     assert out["kind_scope"]["kinds_produced"] == ["cluster"]
-    assert sm.CAVEATS["kind_scope"]["kinds_produced"] == \
-        before["kind_scope"]["kinds_produced"]
+    # the constant never GAINS the measured key
+    assert "kinds_produced" not in sm.CAVEATS["kind_scope"]
     assert out["kind_scope"] is not sm.CAVEATS["kind_scope"]
 
 
@@ -6952,10 +7014,11 @@ def test_deriving_the_caveat_does_not_MUTATE_the_module_constant():
     Writing the derived value through it would leak one scan's measurement into
     every later caller in the process — and the tests would still pass, because
     each one gathers its own report."""
-    before = list(sm.CAVEATS["kind_scope"]["kinds_produced"])
+    assert "kinds_produced" not in sm.CAVEATS["kind_scope"]
     rep = base_gather()
     rep["caveats"]["kind_scope"]["kinds_produced"] = ["MUTATED"]
-    assert sm.CAVEATS["kind_scope"]["kinds_produced"] == before
+    # the constant never gains the key by being written through a report
+    assert "kinds_produced" not in sm.CAVEATS["kind_scope"]
     assert base_gather()["caveats"]["kind_scope"]["kinds_produced"] == ["tmux"]
 
 
@@ -7031,7 +7094,15 @@ def test_the_kind_scope_caveat_MATCHES_what_the_code_actually_produces():
         produced |= {r["kind"] for h in rep["hosts"].values()
                      for r in h["windows"]}
     assert produced, "no rows measured — this guard would pass vacuously"
-    assert produced == set(sm.CAVEATS["kind_scope"]["kinds_produced"])
+    # 🔴 Compared against each report's OWN measured caveat, not against a
+    # constant. The constant carries no `kinds_produced` at all now — a
+    # literal there was a fake measurement, and comparing to it was comparing
+    # the code to a copy of itself.
+    for rep in (base_gather(), mix_gather()):
+        assert set(rep["caveats"]["kind_scope"]["kinds_produced"]) == {
+            r["kind"] for h in rep["hosts"].values() for r in h["windows"]}
     assert set(sm.CAVEATS["kind_scope"]["kinds_enumerated"]) == set(sm.KINDS)
     assert produced < set(sm.KINDS), (
         "cluster is enumerated but must not be produced yet")
+    # what the build produces WITHOUT measuring agrees with what it measured
+    assert set(sm.KINDS_PRODUCED_BY_CONSTRUCTION) == produced

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -6668,10 +6668,13 @@ def test_a_ZERO_ROW_scan_does_not_CLAIM_a_kind_it_never_measured():
     assert "kind=tmux" not in line
     assert "NO rows were measured" in line
     assert "NOT a claim that any kind is absent" in line
-    # a MISSING key is different from a measured empty one, and still falls
-    # back — that is the bare-constant render, not a scan
+    # A MISSING key is different from a measured empty one, and still falls
+    # back — that is the bare-constant render, not a scan. It must say so:
+    # phrasing it as "in this scan" was the very contradiction between this
+    # branch's comment and its own output.
     missing = sm._fmt_kind_scope({"kinds_enumerated": ["tmux", "cluster"]})
-    assert "kind=tmux —" in missing
+    assert "kind=tmux rows by construction" in missing
+    assert "in this scan are" not in missing
 
 
 def test_the_zero_row_scan_reaches_that_branch_through_the_REAL_render():
@@ -6727,6 +6730,134 @@ def test_measured_caveats_detaches_EVERY_caveat_from_the_module_constant():
     before = list(sm.CAVEATS["waiting_signal"]["signals"])
     out["waiting_signal"]["signals"] = ["POISONED"]
     assert sm.CAVEATS["waiting_signal"]["signals"] == before
+
+
+# 🔴 THE WHOLE SENTENCE, PINNED — because a PARTIAL assertion on prose is
+# satisfied by prose that says something else. Two mutants walked the earlier
+# feature-based guards by REWORDING the banned claim: one put
+# "every row here is a tmux pane and the cluster kind never appears" into the
+# note (the banned substring was "every row is a tmux pane"), the other slipped
+# a false parenthetical into the zero-row sentence while keeping all three
+# asserted phrases. Both passed the full suite.
+#
+# So each branch's exact output is pinned. The trade is explicit and accepted:
+# a cosmetic reword fails this test. That is the price of a guard a reword
+# cannot walk, and these four sentences are the tool's machine-readable claims
+# about what it did and did not measure.
+_CG = ("clawgate is reported separately under BLOCKED ON ME")
+KIND_SCOPE_SENTENCES = {
+    # no measurement supplied — the bare-constant render. MUST NOT say "scan".
+    "missing": (
+        "this tool produces kind=tmux rows by construction (no scan measured "
+        "here) — cluster is ENUMERATED but NOT PRODUCED, so no such row "
+        "appears and its absence is NOT a measured zero; " + _CG),
+    # measured ZERO rows — must name no kind as observed
+    "empty": (
+        "NO rows were measured in this scan, so no kind was observed — this "
+        "is NOT a claim that any kind is absent, and the enumerated kinds "
+        "(tmux/cluster) say nothing about what a reachable host holds; " + _CG),
+    # today's ordinary scan
+    "tmux": (
+        "rows in this scan are kind=tmux — cluster is ENUMERATED but NOT "
+        "PRODUCED, so no such row appears and its absence is NOT a measured "
+        "zero; " + _CG),
+    # after writer 3
+    "both": (
+        "rows in this scan are kind=cluster/tmux — every enumerated kind IS "
+        "produced, so this scan covers the whole entity axis; clawgate "
+        "approval state is still reported separately under BLOCKED ON ME"),
+}
+
+
+def test_every_kind_scope_sentence_is_pinned_WHOLE_not_by_feature():
+    """🔴 Feature-based assertions on this sentence have been walked TWICE by
+    mutants that reworded the claim while keeping the asserted fragments. The
+    whole string is the only thing a reword cannot satisfy."""
+    E = ["tmux", "cluster"]
+    got = {
+        "missing": sm._fmt_kind_scope({"kinds_enumerated": E}),
+        "empty": sm._fmt_kind_scope({"kinds_produced": [],
+                                     "kinds_enumerated": E}),
+        "tmux": sm._fmt_kind_scope({"kinds_produced": ["tmux"],
+                                    "kinds_enumerated": E}),
+        "both": sm._fmt_kind_scope({"kinds_produced": ["cluster", "tmux"],
+                                    "kinds_enumerated": E}),
+    }
+    assert got == KIND_SCOPE_SENTENCES
+    # INSTRUMENT CHECK: the four are genuinely distinct, so a builder that
+    # collapsed two branches into one could not satisfy this by accident.
+    assert len(set(got.values())) == 4
+    # the two that must never phrase themselves as a measurement of a scan
+    assert "in this scan are" not in got["missing"]
+    assert "kind=" not in got["empty"]
+
+
+def test_the_kind_scope_NOTE_names_NO_kind_at_all():
+    """🔴 STRUCTURAL, replacing a spelled guard an auditor walked.
+
+    The old assertion banned the literal string "every row is a tmux pane", and
+    a mutant saying "every row here is a tmux pane and the cluster kind never
+    appears" passed. Any ban-list of phrasings is walkable; the invariant that
+    is not is that the NOTE must name NO member of KINDS. `kinds_produced` is
+    the measured field and the note's job is to point at it — the moment the
+    note itself names a kind, it is making the standing claim that field
+    exists to replace, in whatever words.
+    """
+    note = sm.CAVEATS["kind_scope"]["note"]
+    for k in sm.KINDS:
+        assert k not in note, (
+            f"the note names the kind {k!r}; that is a standing claim which "
+            f"will contradict the measured `kinds_produced` after writer 3")
+    # ...and it must still do its job, or "names no kind" is satisfied by ""
+    assert "MEASURED" in note and "kinds_produced" in note
+    assert "blocked_on_me" in note
+    assert len(note) > 200
+
+
+def test_the_kind_scope_NOTE_is_pinned_WHOLE():
+    """The structural guard above bans naming a kind; this pins everything
+    else, so a reword that keeps the kinds out but drops the pointer to
+    `blocked_on_me` — or reintroduces a scope claim in other words — fails."""
+    assert sm.CAVEATS["kind_scope"]["note"] == (
+        "`kinds_produced` is MEASURED from this scan's rows — read it rather "
+        "than assuming. A kind that is enumerated but absent from "
+        "`kinds_produced` was NOT LOOKED FOR by this build, so its absence is "
+        "NOT a measured absence of that work. For clawgate use "
+        "report.blocked_on_me (tasks needing the operator, and its "
+        "`stuck_count` for wedged dispatches), a different population from "
+        "these rows that is never double-counted with them.")
+
+
+def test_measured_caveats_detaches_at_EVERY_DEPTH_not_just_the_first():
+    """🔴 FIXED ONCE AT DEPTH 1, WALKED AT DEPTH 2. `{k: dict(v)}` copies each
+    caveat but leaves every nested dict and list SHARED with the module
+    constant: `waiting_signal["excluded"]` is a dict, and `signals` /
+    `kinds_enumerated` / `null_fields_on_remote_rows` are lists. Writing into
+    any of them in place poisoned CAVEATS process-wide, and the contamination
+    surfaced in a LATER scan's rendered line.
+
+    The earlier purity test asserted a top-level REBIND, which a shallow copy
+    survives — precisely one level too shallow to see this.
+    """
+    out = sm.measured_caveats({"hosts": {}})
+    # nested dict, mutated IN PLACE (not rebound)
+    before_excl = dict(sm.CAVEATS["waiting_signal"]["excluded"])
+    out["waiting_signal"]["excluded"]["prompt_buffer_text"] = "POISONED"
+    assert sm.CAVEATS["waiting_signal"]["excluded"] == before_excl
+    # nested list, mutated IN PLACE
+    before_sig = list(sm.CAVEATS["waiting_signal"]["signals"])
+    out["waiting_signal"]["signals"].append("POISONED")
+    assert sm.CAVEATS["waiting_signal"]["signals"] == before_sig
+    before_enum = list(sm.CAVEATS["kind_scope"]["kinds_enumerated"])
+    out["kind_scope"]["kinds_enumerated"].append("POISONED")
+    assert sm.CAVEATS["kind_scope"]["kinds_enumerated"] == before_enum
+    before_null = list(sm.CAVEATS["fuzzyclaw_scope"]["null_fields_on_remote_rows"])
+    out["fuzzyclaw_scope"]["null_fields_on_remote_rows"].append("POISONED")
+    assert sm.CAVEATS["fuzzyclaw_scope"]["null_fields_on_remote_rows"] \
+        == before_null
+    # and a SECOND caller still sees the clean constant
+    assert sm.measured_caveats({"hosts": {}})["waiting_signal"]["excluded"] \
+        == before_excl
 
 
 def test_the_kind_scope_NOTE_does_not_restate_the_measured_field():

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -29,6 +29,8 @@ import importlib.util
 import json
 import os
 import re
+import subprocess
+import sys
 
 import pytest
 
@@ -2073,7 +2075,7 @@ def test_table_shows_the_LABEL_column_and_the_frame_did_not_get_wider():
     # The header and the rows come from ONE format string, so they cannot skew.
     assert sm._ROW_FMT.count("{") == 9
     assert header == sm._ROW_FMT.format("HOST", "SESSION", "WIN", "LABEL",
-                                        "TASK", "KIND", "STATUS", "AGE", "WAIT")
+                                        "TASK", "CLASS", "STATUS", "AGE", "WAIT")
 
 
 def test_table_does_not_crash_on_none_valued_fields():
@@ -3698,7 +3700,7 @@ def test_the_bucket_tuple_and_the_classifier_cannot_drift_apart():
 
 
 def test_the_table_distinguishes_an_idle_AGENT_from_an_idle_SHELL():
-    """🔴 KILLS: dropping the KIND column, or deriving it from the wrong field.
+    """🔴 KILLS: dropping the CLASS column, or deriving it from the wrong field.
 
     Both rows render `● idle`; the row must still say which one it is, and the
     footer must never print a bare `idle=3`.
@@ -3710,7 +3712,11 @@ def test_the_table_distinguishes_an_idle_AGENT_from_an_idle_SHELL():
     assert "● idle" in agent and "● idle" in shell, "both are idle rows"
     assert "claude" in agent.split("● idle")[0]
     assert "shell" in shell.split("● idle")[0]
-    assert "KIND" in text
+    # 🔴 `CLASS`, not `KIND`: the row now carries a real `kind` field with a
+    # DIFFERENT vocabulary (tmux/cluster), and one word for two axes on the
+    # two surfaces a reader compares is a misread waiting to happen.
+    assert "CLASS" in text
+    assert "KIND" not in text, "the old header collides with the kind field"
     # the footer carries both halves, labelled, and never the mixed integer
     assert "by status (claude+shell):" in text
     assert "idle=2+1" in text
@@ -6494,13 +6500,236 @@ def test_the_lean_view_carries_kind():
 # the caveat — a machine-readable CLAIM, and claims go stale
 # --------------------------------------------------------------------------- #
 def test_the_kind_scope_caveat_is_rendered_and_names_the_unproduced_kind():
+    """🔴 THIS TEST USED TO BE SPELLED RATHER THAN STRUCTURAL, and an audit
+    found two mutants surviving a fully green suite because of it.
+
+    It asserted `"tmux" in line and "cluster" in line` — and BOTH words also
+    appear in the sentence's STATIC prose, so neither computed slot was ever
+    read. Swapping `kinds_produced` for `kinds_enumerated` (rendering the false
+    claim "every row is kind=tmux/cluster"), or inverting the set difference
+    (rendering the self-contradictory "tmux is ENUMERATED but NOT PRODUCED"),
+    both passed. A guard is spelled when it can pass while the hazard exists in
+    a different shape; the fix is to assert the COMPUTED substrings, with the
+    surrounding punctuation that pins which slot they came from.
+    """
     lines = sm.render_caveats(base_gather())
     line = next(ln for ln in lines if "caveat[kind_scope]" in ln)
-    assert "tmux" in line and "cluster" in line
-    assert "NOT " in line and "PRODUCED" in line
+    # the two computed slots, each anchored so a swap cannot satisfy the other
+    assert "kind=tmux —" in line, "the produced-kinds slot"
+    assert "— cluster is ENUMERATED" in line, "the unproduced-kinds slot"
+    # ...and the inversions the old spelling allowed are now excluded by name
+    assert "kind=tmux/cluster" not in line
+    assert "tmux is ENUMERATED" not in line
+    assert "NOT PRODUCED" in line
     # it must point at where clawgate IS reported, or the reader concludes the
     # tool cannot say anything about cluster work at all
     assert "BLOCKED ON ME" in line
+
+
+def test_the_kind_scope_caveat_SLOTS_ARE_LIVE_not_static_prose():
+    """The positive control the spelled version never had: change the inputs
+    and watch BOTH slots move. If either is hardcoded in the sentence, one of
+    these renders identically to the default and this fails."""
+    default = sm._fmt_kind_scope({"kinds_produced": ["tmux"],
+                                  "kinds_enumerated": ["tmux", "cluster"]})
+    swapped = sm._fmt_kind_scope({"kinds_produced": ["cluster"],
+                                  "kinds_enumerated": ["tmux", "cluster"]})
+    assert "kind=cluster —" in swapped and "— tmux is ENUMERATED" in swapped
+    assert swapped != default
+
+
+def test_the_caveat_does_not_degrade_when_EVERY_kind_is_produced():
+    """🔴 THE EMPTY SET IS REACHABLE — `gather` derives `kinds_produced` from
+    the rows, so once writer 3 lands, the unproduced set is empty. The
+    single-sentence version then rendered `—  is ENUMERATED but NOT PRODUCED`:
+    a blank subject in the sentence whose only job is naming what is missing.
+
+    A caveat that degrades into a grammatically-broken half-claim is worse than
+    one that says nothing, because it still reads as a claim.
+    """
+    line = sm._fmt_kind_scope({"kinds_produced": ["cluster", "tmux"],
+                               "kinds_enumerated": ["tmux", "cluster"]})
+    assert "NOT PRODUCED" not in line
+    assert "  is ENUMERATED" not in line, "blank subject"
+    assert "every enumerated kind IS produced" in line
+    # the pointer to where clawgate lives survives BOTH branches
+    assert "BLOCKED ON ME" in line
+
+
+def test_the_caveat_is_MEASURED_from_the_rows_not_asserted_from_the_constant():
+    """🔴 A caveat is a machine-readable claim, and this one used to be a
+    literal in CAVEATS — so it said "every row is kind=tmux" no matter what the
+    rows were, and would have kept saying it on the day writer 3 shipped. That
+    is precisely how `fuzzyclaw_scope` went stale in #471.
+
+    Derived from the report's own rows, so the line cannot disagree with the
+    table printed above it.
+    """
+    rep = with_cluster_rows(mix_gather(), cluster_row())
+    rep["summary"] = sm.summarize(rep)
+    rep["caveats"] = dict(rep["caveats"])
+    rep["caveats"]["kind_scope"] = dict(rep["caveats"]["kind_scope"])
+    rep["caveats"]["kind_scope"]["kinds_produced"] = sorted(
+        rep["summary"]["kind"])
+    line = next(ln for ln in sm.render_caveats(rep) if "kind_scope" in ln)
+    assert "cluster/tmux" in line, "the caveat ignored the cluster row"
+    assert "every enumerated kind IS produced" in line
+    # and the REAL gather path does the same derivation, not just this test
+    live = base_gather()
+    assert live["caveats"]["kind_scope"]["kinds_produced"] == ["tmux"]
+
+
+def test_measured_caveats_DERIVES_from_rows_where_derived_differs_from_the_constant():
+    """🔴 THE CONTROL THAT THE PREVIOUS TEST CANNOT PROVIDE.
+
+    Asserting `kinds_produced == ["tmux"]` off a real gather is satisfied
+    equally by the derivation and by a hardcoded `["tmux"]` — every real scan
+    is tmux-only, so the two are byte-identical and a mutant replacing one with
+    the other SURVIVED a green suite. A fixture whose values coincide with the
+    constant collapses distinct implementations into one observation.
+
+    So this feeds rows whose kinds CANNOT be the constant, and watches the
+    output move.
+    """
+    def rep_of(*kinds):
+        return {"hosts": {"h": {"windows": [{"kind": k} for k in kinds]}}}
+
+    assert sm.measured_caveats(
+        rep_of("cluster"))["kind_scope"]["kinds_produced"] == ["cluster"]
+    assert sm.measured_caveats(
+        rep_of("cluster", "tmux"))["kind_scope"]["kinds_produced"] \
+        == ["cluster", "tmux"]
+    # deduplicated and sorted, so the render is deterministic
+    assert sm.measured_caveats(
+        rep_of("tmux", "cluster", "tmux"))["kind_scope"]["kinds_produced"] \
+        == ["cluster", "tmux"]
+    # a row with NO kind is a bug, and the caveat is where it surfaces —
+    # dropping it would let the line claim a scope it did not measure
+    assert sm.measured_caveats(
+        rep_of("tmux", None))["kind_scope"]["kinds_produced"] \
+        == ["none", "tmux"]
+    # empty report: no rows measured, so no kinds claimed
+    assert sm.measured_caveats(
+        {"hosts": {}})["kind_scope"]["kinds_produced"] == []
+
+
+def test_the_derived_kinds_are_SORTED_deterministically():
+    """🔴 A DETERMINISTIC KILL FOR A NONDETERMINISM MUTANT.
+
+    Dropping `sorted()` leaves `list({...})`, whose order depends on
+    PYTHONHASHSEED — which is RANDOM per process by default. The literal
+    assertion above catches that only on the seeds that happen to order the set
+    wrongly, so it is a coin-flip kill, not a kill: a mutation sweep scored it
+    SURVIVED on one run purely because that run's seed put `cluster` first.
+
+    A flaky guard is fixable rather than re-runnable, so the seed dependency is
+    removed instead of tolerated: seed 2 is one under which
+    `list({"cluster", "tmux"})` yields `tmux` FIRST (measured), so with
+    `sorted()` this returns `["cluster", "tmux"]` and without it `["tmux",
+    "cluster"]` — every run, not most runs.
+    """
+    prog = (
+        "import importlib.machinery as m, importlib.util as u, json;"
+        "l=m.SourceFileLoader('sm', %r);"
+        "sp=u.spec_from_file_location('sm', %r, loader=l);"
+        "mod=u.module_from_spec(sp); sp.loader.exec_module(mod);"
+        "rep={'hosts':{'h':{'windows':[{'kind':'tmux'},{'kind':'cluster'}]}}};"
+        "print(json.dumps("
+        "mod.measured_caveats(rep)['kind_scope']['kinds_produced']))"
+    ) % (_SCRIPT, _SCRIPT)
+    env = dict(os.environ, PYTHONHASHSEED="2", PYTHONDONTWRITEBYTECODE="1")
+    out = subprocess.run([sys.executable, "-c", prog], capture_output=True,
+                         text=True, env=env, timeout=60)
+    assert out.returncode == 0, out.stderr
+    # POSITIVE CONTROL: under this seed the RAW set order really is tmux-first,
+    # so a passing assertion below proves `sorted()` ran — not that the seed
+    # happened to agree with it.
+    raw = subprocess.run(
+        [sys.executable, "-c", "print(list({'cluster','tmux'}))"],
+        capture_output=True, text=True, env=env, timeout=60)
+    assert raw.stdout.strip() == "['tmux', 'cluster']", (
+        "seed 2 no longer orders this set tmux-first; pick another seed or "
+        "this test proves nothing")
+    assert json.loads(out.stdout) == ["cluster", "tmux"]
+
+
+def test_measured_caveats_is_PURE_and_does_not_touch_its_input():
+    before = {k: dict(v) for k, v in sm.CAVEATS.items()}
+    rep = {"hosts": {"h": {"windows": [{"kind": "cluster"}]}}}
+    out = sm.measured_caveats(rep)
+    assert out["kind_scope"]["kinds_produced"] == ["cluster"]
+    assert sm.CAVEATS["kind_scope"]["kinds_produced"] == \
+        before["kind_scope"]["kinds_produced"]
+    assert out["kind_scope"] is not sm.CAVEATS["kind_scope"]
+
+
+def test_deriving_the_caveat_does_not_MUTATE_the_module_constant():
+    """`report["caveats"]` is the module-level CAVEATS dict by reference.
+    Writing the derived value through it would leak one scan's measurement into
+    every later caller in the process — and the tests would still pass, because
+    each one gathers its own report."""
+    before = list(sm.CAVEATS["kind_scope"]["kinds_produced"])
+    rep = base_gather()
+    rep["caveats"]["kind_scope"]["kinds_produced"] = ["MUTATED"]
+    assert sm.CAVEATS["kind_scope"]["kinds_produced"] == before
+    assert base_gather()["caveats"]["kind_scope"]["kinds_produced"] == ["tmux"]
+
+
+# --------------------------------------------------------------------------- #
+# the TABLE — the JSON was made class-generic and the screen was not
+# --------------------------------------------------------------------------- #
+def test_the_table_summary_line_ACCOUNTS_for_every_row():
+    """🔴 `summarize` totals over whatever class keys exist; `render_table`
+    summed `claude`/`shell` BY NAME, so a row in any third class vanished from
+    a line that still looked like a complete accounting —
+    `7 windows claude=3 shell=2`, two rows unmentioned, no discriminant."""
+    rep = with_cluster_rows(mix_gather(), cluster_row(status="busy"),
+                            cluster_row(status="idle"))
+    rep["summary"] = sm.summarize(rep)
+    text = sm.render_table(rep)
+    line = next(ln for ln in text.splitlines() if "summary:" in ln)
+    assert "7 windows" in line
+    # every class named, and the parts account for the whole
+    assert "claude=3" in line and "shell=2" in line and "cluster=2" in line
+    parts = [int(p.split("=")[1]) for p in line.split() if "=" in p]
+    assert sum(parts) == 7
+
+
+def test_the_by_status_line_carries_the_cluster_class_and_its_legend():
+    rep = with_cluster_rows(mix_gather(), cluster_row(status="idle"))
+    rep["summary"] = sm.summarize(rep)
+    text = sm.render_table(rep)
+    line = next(ln for ln in text.splitlines() if "by status" in ln)
+    assert "(claude+shell+cluster)" in line, "the legend must name every part"
+    assert "idle=2+1+1" in line
+    assert "idle=4" not in line, "never the mixed integer"
+
+
+def test_the_table_CLASS_column_renders_cluster_not_shell():
+    """The one-rule-one-place failure made visible on one screen: the table
+    said `shell` for a row the summary underneath counted as `cluster`."""
+    rep = with_cluster_rows(mix_gather(), cluster_row(status="idle",
+                                                      task="wedged dispatch"))
+    rep["summary"] = sm.summarize(rep)
+    text = sm.render_table(rep)
+    row = next(ln for ln in text.splitlines() if "wedged dispatch" in ln)
+    assert "cluster" in row
+    assert "shell" not in row
+
+
+def test_the_table_totals_stay_IDENTICAL_for_a_tmux_only_scan():
+    """The class-generic render must not change today's output. Pinned against
+    the literal strings a reader has been reading for months."""
+    text = sm.render_table(mix_gather())
+    assert "summary: 5 windows  claude=3  shell=2" in text
+    assert "by status (claude+shell): " in text
+    assert "idle=2+1" in text
+    # scoped to the two TOTAL lines — the kind_scope caveat legitimately says
+    # "cluster" further down, and asserting over the whole tail would have made
+    # this fail for a reason that is not the one it is testing
+    totals = "\n".join(ln for ln in text.splitlines()
+                       if "summary:" in ln or "by status" in ln)
+    assert "cluster" not in totals
 
 
 def test_the_kind_scope_caveat_MATCHES_what_the_code_actually_produces():

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -6653,6 +6653,159 @@ def test_the_derived_kinds_are_SORTED_deterministically():
     assert json.loads(out.stdout) == ["cluster", "tmux"]
 
 
+def test_a_ZERO_ROW_scan_does_not_CLAIM_a_kind_it_never_measured():
+    """🔴 REACHABLE TODAY, with no cluster row anywhere. `kinds_produced` is
+    measured, so a scan with no rows measures `[]` — and `[] or ["tmux"]` is
+    `["tmux"]`, because an empty list is FALSY. The line then read `rows in
+    this scan are kind=tmux` over `summary: 0 windows`: a literal wearing a
+    measurement's clothes, which is the defect measuring it was meant to kill.
+
+    The reader who hits this is the one whose hosts are unreachable — exactly
+    the reader who must not be told what "this scan" contained.
+    """
+    line = sm._fmt_kind_scope({"kinds_produced": [],
+                               "kinds_enumerated": ["tmux", "cluster"]})
+    assert "kind=tmux" not in line
+    assert "NO rows were measured" in line
+    assert "NOT a claim that any kind is absent" in line
+    # a MISSING key is different from a measured empty one, and still falls
+    # back — that is the bare-constant render, not a scan
+    missing = sm._fmt_kind_scope({"kinds_enumerated": ["tmux", "cluster"]})
+    assert "kind=tmux —" in missing
+
+
+def test_the_zero_row_scan_reaches_that_branch_through_the_REAL_render():
+    """The unit test above proves the branch; this proves it is REACHED. A
+    scan where no host answers produces zero rows through the ordinary path."""
+    rep = base_gather(runner=make_runner(local_rc=1, remote_rc=1))
+    assert rep["summary"]["total_sessions"] == 0, "fixture did not go empty"
+    assert rep["caveats"]["kind_scope"]["kinds_produced"] == []
+    line = next(ln for ln in sm.render_caveats(rep) if "kind_scope" in ln)
+    assert "NO rows were measured" in line
+    assert "kind=tmux" not in line
+
+
+def test_the_DETAIL_path_re_derives_the_caveats_it_re_summarizes():
+    """🔴 `filter_report` re-runs `summarize` and renders through
+    `render_caveats`. Inheriting the full scan's caveats made `kind_scope` a
+    claim about every row, printed under a ONE-ROW table — the disagreement
+    between line and table that measuring it was supposed to make impossible.
+    One rule enforced at one of its two call sites."""
+    rep = with_cluster_rows(mix_gather(), cluster_row())
+    rep["summary"] = sm.summarize(rep)
+    rep["caveats"] = sm.measured_caveats(rep)
+    assert rep["caveats"]["kind_scope"]["kinds_produced"] == ["cluster", "tmux"]
+    # narrow to one TMUX window — the cluster row is filtered out, so the
+    # caveat must stop claiming cluster was produced
+    one = sm.filter_report(rep, "hollow", "2")
+    assert one["summary"]["total_sessions"] == 1
+    assert one["caveats"]["kind_scope"]["kinds_produced"] == ["tmux"]
+    line = next(ln for ln in sm.render_caveats(one) if "kind_scope" in ln)
+    assert "cluster is ENUMERATED but NOT PRODUCED" in line
+
+
+def test_measured_caveats_reads_EVERY_host_not_just_the_first():
+    """A cluster row on the second host would otherwise vanish from
+    `kinds_produced`, and the caveat would deny rows that ARE in the payload."""
+    rep = {"hosts": {"a": {"windows": [{"kind": "tmux"}]},
+                     "b": {"windows": [{"kind": "cluster"}]}}}
+    assert sm.measured_caveats(rep)["kind_scope"]["kinds_produced"] \
+        == ["cluster", "tmux"]
+
+
+def test_measured_caveats_detaches_EVERY_caveat_from_the_module_constant():
+    """🔴 Copying only `kind_scope` left the other four as the SAME objects as
+    CAVEATS, so a consumer writing through the returned dict — which the
+    "returns a new dict, mutates nothing" docstring invites — poisoned the
+    process-global constant. A purity claim true of one key and false of its
+    siblings is worse than none: it is specific enough to be trusted."""
+    rep = {"hosts": {}}
+    out = sm.measured_caveats(rep)
+    assert set(out) == set(sm.CAVEATS)
+    for key in sm.CAVEATS:
+        assert out[key] is not sm.CAVEATS[key], f"{key} is still shared"
+    before = list(sm.CAVEATS["waiting_signal"]["signals"])
+    out["waiting_signal"]["signals"] = ["POISONED"]
+    assert sm.CAVEATS["waiting_signal"]["signals"] == before
+
+
+def test_the_kind_scope_NOTE_does_not_restate_the_measured_field():
+    """🔴 The note ships in the same `--json` payload as `kinds_produced`. It
+    used to assert "every row is a tmux pane … cluster is ENUMERATED but NOT
+    PRODUCED" — a standing claim that would contradict its own measured
+    neighbour the day writer 3 lands. That adjacent-fields-disagree failure is
+    what `fuzzyclaw_scope` shipped in #471."""
+    note = sm.CAVEATS["kind_scope"]["note"]
+    assert "MEASURED" in note
+    assert "every row is a tmux pane" not in note
+    assert "cluster is ENUMERATED but NOT PRODUCED" not in note
+    # it still has to say the durable part, or the field loses its meaning
+    assert "NOT a measured absence" in note
+    assert "blocked_on_me" in note
+
+
+def _under_seed(seed, expr):
+    """Evaluate `expr` against a freshly-imported session-manager in a
+    subprocess with PYTHONHASHSEED pinned. Set iteration order is seed-derived,
+    so this is the only way to kill a dropped-`sorted()` mutant DETERMINISTICALLY
+    rather than on the runs whose seed happens to disagree."""
+    prog = (
+        "import importlib.machinery as m, importlib.util as u, json;"
+        "l=m.SourceFileLoader('sm', %r);"
+        "sp=u.spec_from_file_location('sm', %r, loader=l);"
+        "sm=u.module_from_spec(sp); sp.loader.exec_module(sm);"
+        "print(json.dumps(%s))" % (_SCRIPT, _SCRIPT, expr))
+    env = dict(os.environ, PYTHONHASHSEED=str(seed),
+               PYTHONDONTWRITEBYTECODE="1")
+    out = subprocess.run([sys.executable, "-c", prog], capture_output=True,
+                         text=True, env=env, timeout=60)
+    assert out.returncode == 0, out.stderr
+    return json.loads(out.stdout)
+
+
+def test_summary_classes_sorts_the_non_lead_classes_DETERMINISTICALLY():
+    """🔴 SAME NONDETERMINISM TRAP AS THE OTHER SORT, and it was left unguarded
+    while the sibling got a seed-pinned harness — rigor applied to one of two
+    identical hazards, which is how the unguarded one ships.
+
+    Two non-lead classes are needed to observe order at all, and no other test
+    produces two. Under seed 3 the RAW set yields `unknown_kind` first
+    (measured), so a `sorted()` that ran returns `cluster` first and a dropped
+    one returns `unknown_kind` first — every run, not most.
+    """
+    summ = {"status": {"busy": {"unknown_kind": 1, "cluster": 1, "claude": 0,
+                                "shell": 0, "total": 2}}}
+    # POSITIVE CONTROL: seed 3 really does order this set the other way, so a
+    # pass below means `sorted()` ran — not that the seed agreed with it.
+    raw = subprocess.run(
+        [sys.executable, "-c", "print(list({'cluster','unknown_kind'}))"],
+        capture_output=True, text=True, timeout=60,
+        env=dict(os.environ, PYTHONHASHSEED="3"))
+    assert raw.stdout.strip() == "['unknown_kind', 'cluster']", (
+        "seed 3 no longer orders this set unknown_kind-first; pick another "
+        "seed or this test proves nothing")
+    assert _under_seed(3, "sm._summary_classes(%r)" % (summ,)) == [
+        "claude", "shell", "cluster", "unknown_kind"]
+    # in-process too, so the ordinary path is covered as well
+    assert sm._summary_classes(summ) == ["claude", "shell", "cluster",
+                                         "unknown_kind"]
+    # ...and it is robust to a summary with no status at all
+    assert sm._summary_classes({}) == ["claude", "shell"]
+
+
+def test_the_summary_line_NAMES_every_class_even_when_the_count_is_missing():
+    """🔴 The difference between `.get(c, 0)` and the `if c in summ` filter is
+    invisible unless a class is ABSENT from the summary — which `render_table`
+    reaches on a bare report, the same path that made removing the filter
+    outright raise `KeyError`. Filtering SKIPS the class, so the summary line
+    silently loses a column the by-status legend one line below still names."""
+    text = sm.render_table({"hosts": {}, "summary": {"total_sessions": 0},
+                            "fuzzyclaw": {}, "ledger": {}})
+    line = next(ln for ln in text.splitlines() if "summary:" in ln)
+    assert "claude=0" in line and "shell=0" in line, (
+        "a missing count must render as 0, not vanish from the line")
+
+
 def test_measured_caveats_is_PURE_and_does_not_touch_its_input():
     before = {k: dict(v) for k, v in sm.CAVEATS.items()}
     rep = {"hosts": {"h": {"windows": [{"kind": "cluster"}]}}}

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -6425,7 +6425,6 @@ def test_NO_cluster_key_is_published_while_no_cluster_row_exists():
     assert "kinds_produced" not in sm.CAVEATS["kind_scope"]
     assert sm.KINDS_PRODUCED_BY_CONSTRUCTION == ("tmux",)
     # a real scan supplies it
-    assert sm.summarize(mix_gather())  # (fixture sanity)
     assert mix_gather()["caveats"]["kind_scope"]["kinds_produced"] == ["tmux"]
 
 
@@ -6816,6 +6815,39 @@ def test_every_kind_scope_sentence_is_pinned_WHOLE_not_by_feature():
     assert "this scan" not in got["by_construction_all_produced"]
 
 
+def test_the_BY_CONSTRUCTION_slot_IS_LIVE_not_a_coincident_literal(monkeypatch):
+    """🔴 THE SAME TRAP, ONE SLOT OVER — and it survived the commit that fixed
+    the neighbouring one.
+
+    `_fmt_kind_scope` renders `list(KINDS_PRODUCED_BY_CONSTRUCTION)`, and that
+    constant is `("tmux",)`. So the lookup and a hardcoded `["tmux"]` produce
+    byte-identical output, and a mutant replacing one with the other SURVIVES
+    the whole suite. Every pin asserts `kind=tmux` — the value both spellings
+    give.
+
+    That matters precisely at writer 3: someone updating the constant to
+    `("tmux", "cluster")` would update the two tests that pin it, see the
+    `missing` whole-string pin still green, and ship a sentence that still says
+    `kind=tmux`. The constant's own comment promises "writer 3 updates THIS
+    tuple"; nothing proved the render reads it.
+
+    So: move the constant to a value it cannot coincidentally equal, and watch
+    the sentence move.
+    """
+    monkeypatch.setattr(sm, "KINDS_PRODUCED_BY_CONSTRUCTION", ("zzz",))
+    line = sm._fmt_kind_scope({"kinds_enumerated": ["zzz", "qqq"]})
+    assert "produces kind=zzz rows by construction" in line
+    assert "tmux" not in line, "the render ignored the constant"
+    assert "qqq is ENUMERATED but NOT PRODUCED" in line
+    # and the writer-3 shape: the constant covering the whole enumerated set
+    # must reach the all-produced tail, with the BUILD subject
+    monkeypatch.setattr(sm, "KINDS_PRODUCED_BY_CONSTRUCTION", ("tmux", "cluster"))
+    w3 = sm._fmt_kind_scope({"kinds_enumerated": ["tmux", "cluster"]})
+    assert "produces kind=tmux/cluster rows by construction" in w3
+    assert "so this build covers the whole entity axis" in w3
+    assert "this scan covers" not in w3
+
+
 def test_the_kinds_enumerated_SLOT_IS_LIVE_not_defaulted_to_KINDS():
     """🔴 THE FIXTURE-COINCIDES-WITH-THE-CONSTANT TRAP, which this file names
     in its own comments and which I then walked into.
@@ -7000,7 +7032,6 @@ def test_the_summary_line_NAMES_every_class_even_when_the_count_is_missing():
 
 
 def test_measured_caveats_is_PURE_and_does_not_touch_its_input():
-    before = {k: dict(v) for k, v in sm.CAVEATS.items()}
     rep = {"hosts": {"h": {"windows": [{"kind": "cluster"}]}}}
     out = sm.measured_caveats(rep)
     assert out["kind_scope"]["kinds_produced"] == ["cluster"]

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -1717,6 +1717,8 @@ def test_json_golden_schema_and_values():
 
     row = wb["windows"][0]
     assert row == {
+        # the entity axis — `tmux` here because `fold_windows` folds panes
+        "kind": "tmux",
         "host": "workbench",
         "session": "scratch7",
         "window_index": "3",
@@ -1838,6 +1840,11 @@ def test_json_golden_schema_and_values():
         # it. Pinned literally so a regression that re-zeroes the ages cannot
         # pass by leaving some unrelated total unchanged.
         "age_sources": {"fuzzyclaw": 1, "none": 2},
+        # The entity axis, DERIVED from the rows. All three are tmux. Pinned
+        # literally for the same reason as `age_sources`: it is the number that
+        # moves when a row is built without a `kind`, and `total_sessions`
+        # alone would not.
+        "kind": {"tmux": 3},
         "rows_with_age": 1,
         "rows_with_session_id": 1,
     }
@@ -2749,12 +2756,23 @@ def test_summarize_counts_every_status_bucket():
     s = sm.summarize(report)
     assert sum(s["status"][b]["total"] for b in sm.STATUS_BUCKETS) \
         == s["total_sessions"]
-    # ...and each bucket's halves account for its own total, so a row cannot be
-    # counted in a bucket without also being counted as claude or as shell.
+    # ...and each bucket's CLASS KEYS account for its own total, so a row cannot
+    # be counted in a bucket without also being counted in some class.
+    #
+    # 🔴 Summed over whatever class keys the bucket actually has, NOT over
+    # `claude + shell` by name. Naming the two would have quietly stopped being
+    # an accounting check the moment a third class appeared: the sum would still
+    # be computed, still be compared, and simply omit the new class from both
+    # sides of nothing. This fixture is tmux-only, so the classes here ARE
+    # claude/shell — the generality is what stops the guard rotting when they
+    # are not (see the cluster tests in §kind).
     for b in sm.STATUS_BUCKETS:
         cell = s["status"][b]
-        assert cell["claude"] + cell["shell"] == cell["total"]
+        assert sum(v for k, v in cell.items() if k != "total") == cell["total"]
     assert s["claude"] + s["shell"] == s["total_sessions"]
+    # This fixture really is tmux-only — stated, so the line above is read as
+    # "no cluster rows here", not as a claim that the two always sum.
+    assert s["kind"] == {"tmux": s["total_sessions"]}
 
 
 # =========================================================================== #
@@ -3888,7 +3906,7 @@ def test_the_caveats_are_in_the_json_as_structured_fields_not_prose():
     string a consumer would have to parse."""
     cav = mix_gather()["caveats"]
     assert set(cav) == {"claude_detection", "fuzzyclaw_scope", "ledger_scope",
-                        "waiting_signal"}
+                        "waiting_signal", "kind_scope"}
     det = cav["claude_detection"]
     assert det["method"] == "pane_current_command_regex"
     assert det["pattern"] == sm.CLAUDE_RE.pattern == "claude"
@@ -5270,6 +5288,7 @@ def test_the_row_FIELD_LEDGER_fails_when_it_grows_or_shrinks():
     checked."""
     row = base_gather()["hosts"]["workbench"]["windows"][0]
     expected = {
+        "kind",
         "host", "session", "window_index", "window_id", "window_name",
         "codename", "label", "label_source", "hotkey", "pane_id", "path",
         "command",
@@ -5833,6 +5852,7 @@ def test_the_LEAN_row_field_ledger_fails_when_it_grows_or_shrinks():
     row = rep["hosts"]["workbench"]["windows"][0]
     assert set(row) == set(sm.LEAN_ROW_FIELDS)
     assert set(sm.LEAN_ROW_FIELDS) == {
+        "kind",
         "host", "session", "window_index", "label", "label_source", "hotkey",
         "path", "task", "runtime", "claude", "busy", "status", "age_secs",
         "age_source",
@@ -6267,3 +6287,238 @@ def test_a_CROSS_RUNTIME_conflict_names_the_runtimes_in_the_TABLE():
     assert "claude, opencode" in text
     # the session ids stay too — they are how you find the actual sessions
     assert "7f3a-claude" in text and "ses_9911" in text
+
+
+# =========================================================================== #
+# §kind — THE ENTITY AXIS
+#
+# `kind` says WHAT a row is: a tmux pane (`tmux`) or a dispatch with no pane
+# (`cluster`). Only `tmux` rows are produced today; `cluster` is enumerated
+# ahead of writer 3 so the roll-ups are decided BEFORE such a row can appear,
+# not patched after one silently miscounts.
+#
+# 🔴 EVERY CLUSTER TEST BELOW CONSTRUCTS ITS OWN ROW, because no fixture and no
+# code path in this build produces one. A test that waited for a real cluster
+# row would be VACUOUS — green today, green with the whole classifier deleted,
+# and still green on the day writer 3 lands wrong. Constructing the row is what
+# makes these fail on pre-`kind` code.
+# =========================================================================== #
+def cluster_row(status="busy", **kw):
+    """A row shaped the way spec §4 says a clawgate dispatch will be shaped:
+    the tmux-only fields null, `claude` null because there is no pane whose
+    command could be read, `kind` the discriminant that says so."""
+    row = dict(kind="cluster", host=None, session=None, window_index=None,
+               window_id=None, claude=None, busy=None, status=status,
+               age_secs=42.0, age_source="clawgate", runtime="clawgate",
+               claude_session_id=None, task="a wedged dispatch",
+               waiting_probable=None, waiting_status="not_tmux",
+               waiting_signals=None, path="", command="", panes=0,
+               label="cg", label_source="none", hotkey=None, codename=None,
+               window_name="", pane_id=None, ledger=None, fuzzyclaw=None)
+    row.update(kw)
+    return row
+
+
+def with_cluster_rows(rep, *rows):
+    """Append constructed cluster rows to a real gathered report, in place."""
+    rep["hosts"]["workbench"]["windows"].extend(rows)
+    return rep
+
+
+def test_the_mix_fixture_really_produces_only_tmux_rows():
+    """INSTRUMENT CHECK, before any cluster claim is read off this fixture.
+
+    Every test below asserts what changes when a cluster row is ADDED. That is
+    only meaningful if the baseline has none — otherwise the deltas are
+    measured against an unknown starting point.
+    """
+    rows = mix_gather()["hosts"]["workbench"]["windows"]
+    assert rows, "empty fixture would make every assertion below vacuous"
+    assert {r["kind"] for r in rows} == {"tmux"}
+
+
+def test_every_row_carries_a_kind_and_it_is_never_null():
+    """🔴 `kind` is the one field on a row whose null IS a bug. `runtime` is
+    null all the time and means something; `kind` is known at construction."""
+    for rep in (base_gather(), mix_gather()):
+        rows = [r for h in rep["hosts"].values() for r in h["windows"]]
+        assert rows
+        for r in rows:
+            assert "kind" in r, "a row was built without the discriminant"
+            assert r["kind"] is not None
+            assert r["kind"] in sm.KINDS
+
+
+def test_KINDS_is_a_closed_vocabulary_that_fails_if_it_GROWS_or_SHRINKS():
+    """The same ledger idiom as FUZZYCLAW_FIELDS/WAITING_SIGNALS/STUCK_REASONS.
+    Both directions are silent breakage: a kind removed here while rows still
+    carry it turns `row_class` into `unknown_kind`, and a kind added without
+    the roll-up being taught about it is the miscount this axis exists to stop.
+    """
+    assert sm.KINDS == ("tmux", "cluster")
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE DEFECT THIS AXIS EXISTS TO PREVENT
+# --------------------------------------------------------------------------- #
+def test_a_CLUSTER_row_is_NOT_counted_as_a_SHELL():
+    """🔴 THE ONE THAT MATTERS. `claude` on a row is
+    `pane_current_command =~ /claude/` — a fact about a PANE. A dispatch with no
+    pane has `claude: None`, which is FALSY, so the old
+    `"claude" if row["claude"] else "shell"` counted an agent as a bare shell:
+    an agent filed under the bucket that means "nobody is working here".
+
+    That is the claude/shell conflation one axis over — the same defect that
+    published `idle: 17` for 12 agents + 5 shells. Every fixture in this suite
+    is tmux-only, so nothing else here can see it.
+    """
+    rep = with_cluster_rows(mix_gather(), cluster_row(status="busy"))
+    s = sm.summarize(rep)
+    busy = s["status"]["busy"]
+    # the bare shell that was already busy in the fixture is still the ONLY one
+    assert busy["shell"] == 1, "the cluster dispatch leaked into `shell`"
+    assert busy["cluster"] == 1
+    assert busy["claude"] == 0
+    # ...and it is not absorbed at the top level either. The fixture has TWO
+    # bare shells (ridge idle, thicket busy) and three agents; adding a cluster
+    # dispatch must move neither number.
+    assert s["shell"] == 2
+    assert s["claude"] == 3
+
+
+def test_a_CLUSTER_row_is_not_quietly_counted_as_CLAUDE_either():
+    """The mirror image. Overcounting agents is the friendlier direction and
+    still wrong: `claude` is what the operator reads as "my Claude windows"."""
+    rep = with_cluster_rows(mix_gather(),
+                            cluster_row(status="busy", claude=True))
+    s = sm.summarize(rep)
+    # `kind` decides, NOT the `claude` flag — a cluster row asserting claude:True
+    # must still not land in the claude count.
+    assert s["status"]["busy"]["cluster"] == 1
+    assert s["status"]["busy"]["claude"] == 0
+    assert s["claude"] == 3
+
+
+def test_NO_cluster_key_is_published_while_no_cluster_row_exists():
+    """🔴 THE FAKE ZERO. Pre-seeding `cluster: 0` in every bucket would publish
+    a measurement of a population this build structurally cannot produce, and a
+    reader cannot tell that zero from "wired to nothing" — which is the exact
+    failure this tool spends most of its output guarding against.
+
+    So the class key is created ON DEMAND, and a tmux-only summary is
+    byte-identical to what it was before `kind` existed.
+    """
+    s = sm.summarize(mix_gather())
+    for b in sm.STATUS_BUCKETS:
+        assert set(s["status"][b]) == {"claude", "shell", "total"}, (
+            "a tmux-only scan must not publish a cluster count")
+    # the caveat is what tells the reader why, instead of the absent key
+    assert sm.CAVEATS["kind_scope"]["kinds_produced"] == ["tmux"]
+
+
+def test_a_row_with_NO_kind_gets_its_OWN_class_and_never_becomes_cluster():
+    """A row built by code that forgot the field is a BUG in that code. Folding
+    it into `cluster` would dress it as a real measurement — the same mistake
+    one level down from counting a cluster row as a shell."""
+    assert sm.row_class({"claude": True}) == "unknown_kind"
+    assert sm.row_class({"kind": None, "claude": False}) == "unknown_kind"
+    assert sm.row_class({"kind": "wat"}) == "unknown_kind"
+    rep = with_cluster_rows(mix_gather(), cluster_row(status="busy", kind=None))
+    s = sm.summarize(rep)
+    assert s["status"]["busy"].get("cluster") is None
+    assert s["status"]["busy"]["unknown_kind"] == 1
+    # and it is visible in the histogram rather than absorbed
+    assert s["kind"]["none"] == 1
+
+
+def test_row_class_keys_on_KIND_not_on_a_null_claude():
+    """A tmux pane whose command did not parse also has `claude: None`, and
+    that row genuinely IS "not a claude pane" — it belongs in `shell`. Two
+    different nulls, and only `kind` separates them. Keying on `claude is None`
+    would have collapsed both into one class and looked correct."""
+    assert sm.row_class({"kind": "tmux", "claude": None}) == "shell"
+    assert sm.row_class({"kind": "tmux", "claude": False}) == "shell"
+    assert sm.row_class({"kind": "tmux", "claude": True}) == "claude"
+    assert sm.row_class({"kind": "cluster", "claude": None}) == "cluster"
+
+
+def test_the_bucket_TOTAL_accounts_for_the_cluster_class_too():
+    """🔴 The total is summed over whatever class keys exist, never over
+    `claude + shell` by name. Named summation would have kept returning a
+    plausible number that silently omitted the new class."""
+    rep = with_cluster_rows(mix_gather(), cluster_row(status="idle"),
+                            cluster_row(status="idle"))
+    s = sm.summarize(rep)
+    idle = s["status"]["idle"]
+    assert idle["cluster"] == 2
+    assert idle["total"] == idle["claude"] + idle["shell"] + idle["cluster"]
+    assert sum(s["status"][b]["total"] for b in s["status"]) \
+        == s["total_sessions"]
+
+
+def test_the_top_level_totals_use_the_SAME_predicate_as_the_buckets():
+    """One rule, one place. `claude`/`shell` were open-coded at two sites with
+    different expressions (`r["claude"]` and `not r["claude"]`), which is the
+    shape that ends up wrong at exactly one site."""
+    rep = with_cluster_rows(mix_gather(), cluster_row(status="busy"),
+                            cluster_row(status="idle"))
+    s = sm.summarize(rep)
+    rows = [r for h in rep["hosts"].values() for r in h["windows"]]
+    assert s["claude"] == sum(1 for r in rows if sm.row_class(r) == "claude")
+    assert s["shell"] == sum(1 for r in rows if sm.row_class(r) == "shell")
+    # the two no longer sum to the whole set — the cluster rows are neither
+    assert s["claude"] + s["shell"] == s["total_sessions"] - 2
+
+
+def test_the_kind_histogram_is_DERIVED_from_the_rows():
+    """Derived, not hardcoded, so a kind cannot exist on a row and be missing
+    from the summary — the rule `age_sources` and `waiting.per_signal` follow."""
+    rep = with_cluster_rows(mix_gather(), cluster_row(), cluster_row())
+    s = sm.summarize(rep)
+    assert s["kind"] == {"tmux": 5, "cluster": 2}
+    assert sum(s["kind"].values()) == s["total_sessions"]
+
+
+def test_the_lean_view_carries_kind():
+    """`kind` is what tells a lean reader whether a null `session` is "not
+    measured" or "this entity has no session". Dropping it would recreate the
+    ambiguity the lean field lists exist to remove."""
+    assert "kind" in sm.LEAN_ROW_FIELDS
+    lean = sm.lean_report(mix_gather())
+    assert "kind" in lean["lean_row_fields"]
+    for r in lean["hosts"]["workbench"]["windows"]:
+        assert r["kind"] == "tmux"
+
+
+# --------------------------------------------------------------------------- #
+# the caveat — a machine-readable CLAIM, and claims go stale
+# --------------------------------------------------------------------------- #
+def test_the_kind_scope_caveat_is_rendered_and_names_the_unproduced_kind():
+    lines = sm.render_caveats(base_gather())
+    line = next(ln for ln in lines if "caveat[kind_scope]" in ln)
+    assert "tmux" in line and "cluster" in line
+    assert "NOT " in line and "PRODUCED" in line
+    # it must point at where clawgate IS reported, or the reader concludes the
+    # tool cannot say anything about cluster work at all
+    assert "BLOCKED ON ME" in line
+
+
+def test_the_kind_scope_caveat_MATCHES_what_the_code_actually_produces():
+    """🔴 A caveat is a machine-readable claim, and `fuzzyclaw_scope` proved it
+    goes stale the moment the code changes — while the guard that should have
+    caught it was blinded by a fixture default.
+
+    So this reads the kinds from a REAL gather rather than from a constant, and
+    from BOTH shared fixtures, so no single fixture's defaults can make it
+    agree by accident. The day writer 3 produces cluster rows, this fails and
+    `kinds_produced` must be updated in the same commit.
+    """
+    produced = set()
+    for rep in (base_gather(), mix_gather()):
+        produced |= {r["kind"] for h in rep["hosts"].values()
+                     for r in h["windows"]}
+    assert produced, "no rows measured — this guard would pass vacuously"
+    assert produced == set(sm.CAVEATS["kind_scope"]["kinds_produced"])
+    assert set(sm.CAVEATS["kind_scope"]["kinds_enumerated"]) == set(sm.KINDS)
+    assert produced < set(sm.KINDS), (
+        "cluster is enumerated but must not be produced yet")


### PR DESCRIPTION
Adds `kind` — the entity axis — to every row and makes the roll-ups count by it.

**No scan changes today.** Every row is `kind: tmux`, and a tmux-only summary is byte-identical to before. What changes is what becomes impossible later. Verified live: 78 rows, `summary.kind = {"tmux": 78}`, and **no `cluster` key in any bucket**.

## Why now, before writer 3

spec §4 decided clawgate dispatches join the **same** collection as tmux rows with the tmux-only fields null. That decision is right and was under-specified: it named a row field but never said what the roll-ups do with a row that has no pane. Deciding that *after* such a row exists means deciding it against a miscount already in the output.

`summarize` read `"claude" if row["claude"] else "shell"`. `row["claude"]` is `pane_current_command =~ /claude/` — a fact about a **pane**. A dispatch with no pane has `claude: None`, which is **falsy**, so every cluster agent would have been filed under `shell`: an agent counted in the bucket that means *"nobody is working here"*.

That is the claude/shell conflation this summary already exists to prevent, one axis over — the same defect that once published `idle: 17` for 12 agent windows + 5 bare shells. Every fixture in the suite is tmux-only, so nothing already here could see it.

## What landed

- **`KINDS = ("tmux", "cluster")`** — closed vocabulary; `cluster` enumerated but **not produced**.
- **`row_class()` is the one classifier**, used by both the per-status buckets and the top-level totals so they cannot disagree. `shell` was open-coded as `not r["claude"]` at the top level and `else "shell"` in the buckets — the shape that ends up wrong at exactly one site.
- **Keyed on `kind`, not on `claude is None`.** A tmux pane whose command did not parse *also* has a null `claude`, and that row genuinely belongs in `shell`. Two different nulls; only `kind` separates them.
- **A missing/unknown `kind` gets `unknown_kind`, never `cluster`** — dressing a bug as a real measurement is the same mistake one level down.
- 🔴 **No fake zero.** The class key is created on demand, so nothing publishes `cluster: 0` while no cluster row can exist — that zero is indistinguishable from a reader wired to nothing. `caveats.kind_scope` states the scope instead and points at `blocked_on_me` as where clawgate *is* reported (a different population, never double-counted).
- The bucket total sums whatever class keys exist rather than `claude + shell` by name, which would have silently omitted a new class from the total.

## Verification

- **14 new tests + 5 updated ledger pins: red at `origin/main` (1797d42), green at HEAD.** The load-bearing one fails at base with the defect itself — `assert 2 == 1`, *"the cluster dispatch leaked into `shell`"* — not with an AttributeError.
- **Every cluster test constructs its row**, because no code path in this build produces one. Waiting for a real cluster row would be vacuous: green today, green with the classifier deleted, and green on the day writer 3 lands wrong.
- **Mutation sweep: 7/7 killed by the specific named test**, each mutant confirmed to import first (the syntax-error-scored-as-a-kill trap): drop `kind` from the row · pre-seed `cluster: 0` · sum the total by name · fold `unknown_kind` into `cluster` · revert the top-level `shell` predicate · collapse the cluster class to `shell` · drop `kind` from the lean view.
- **Both CI tiers green:** pytests `RESULT: PASS (exit=0)`, `TOTAL collected=9872 failed=0`; nodetests `RESULT: PASS (exit=0)`, `tests=1116 fail=0`.
- Control pair for the honest zero: **cluster counts non-zero on the constructed fixtures, 0 live** — reported together, never the zero alone.

## Not in this PR — deliberately

Writer 3 is **not** built. Design and the measurements behind that: `claudedocs/design-ledger-writer3-and-kind-2026-08-14.md`. In short, `/api/agents` live is 2 long-lived devpods, both `status: error` — clawgate has no "agent run" entity; the ephemeral thing is the **task in `in_progress`**, which `clawgate_tasks.py` already models and which reported 2 wedged dispatches correctly today. Writer 3 is gated on that population being routinely non-zero **and** `task.agent` non-null (ZacxDev/homelab-infra#316).

🤖 Generated with [Claude Code](https://claude.com/claude-code)