### PR TITLE
feat(clawgate skill): a task-pickup ritual, because the write half was curl and got skipped

### DIFF
--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -50,7 +50,7 @@ Memories: `clawgate-phase2` · `clawgate-phase3` · `clawgate-runbooks` ·
 | LAN URL (hook + UI) | `http://192.168.50.250:30302` (NodePort) — **OPEN, no auth**; machine endpoints still need the token |
 | Public / nebula URL | `https://clawgate.zacx.dev` behind **Authelia passkey** (portal `login.zacx.dev`); laptop `http://10.42.0.10:8109` (homelab gateway) |
 | Hook events | `PermissionRequest` (`CLAWGATE_REMOTE_APPROVAL=off`) + `Stop` (async, `CLAWGATE_SUGGEST=off`), both in `~/.claude/settings.json`, ON by default. 🔴 The `Stop` array also carries **two** unrelated hooks (`tmux/task-hook.sh`, `claude-notify.py`) — **preserve both** |
-| 🔴 Machine client | **`clawgatectl`** (devrc `nix/pkgs/tools/clawgatectl.nix`; on PATH after a switch, but **absent on a host whose homelab-talos checkout predates it — the laptop today**). **Exactly six commands**: `health` · `agent ls` · `agent resolve <name> [--id]` · `task ls/get/create`. Reads `clawgate.env` itself (no token in argv); JSON on stdout only; rc 0–8. **Every other route is still curl.** `task-api.md` |
+| 🔴 Machine client | **`clawgatectl`** (devrc `nix/pkgs/tools/clawgatectl.nix`; on PATH after a switch, but **absent on a host whose homelab-talos checkout predates it — the laptop today**). **Exactly eight commands**: `health` · `agent ls` · `agent resolve <name> [--id]` · `task ls/get/create` · **`task status <id> <status>`** · **`task comment <id> --body …`** (both added 2026-08-14; they hit routes that already existed, so they need NO server release). Reads `clawgate.env` itself (no token in argv); JSON on stdout only; rc 0–8. **Every other route is still curl.** `task-api.md` |
 
 🔴 **clawgate has NO human auth of its own** (since 0.7.37): `requireSession` is a pass-through no-op,
 so **the LAN NodePort is fully unauthenticated** — including `DELETE /tasks/{id}` and 🔴 **`POST
@@ -94,11 +94,47 @@ evidence the code is live; the live pin and `clawgatectl health` are. **Load `de
 version-from-the-live-pin, the ONE commit path (worktree off `origin/trunk`; never `git add -A`),
 test gate, build/push, pin bump, the CSS-cwd trap that fakes ~25 e2e failures, chart sync.
 
+## task pickup — "read and evaluate clawgate task N", then "local dispatch"
+🔴 **The status/comment steps are NOT optional and NOT a thing to be asked for.** They were skipped
+for months because reading a task was one command while writing to it was a curl preamble; that
+asymmetry is gone (`task status` / `task comment` since 2026-08-14), so there is no longer an excuse
+to leave a task's state stale. Run the ritual unprompted.
+
+```bash
+clawgatectl task get <id>            # 1. READ — body + comments are BOTH already here
+                                     #    (no /comments GET exists; it is 405)
+#  2. EVALUATE and report to Zach. Do NOT flip status yet — see the ordering trap below.
+clawgatectl task status <id> in_progress          # 3. on "local dispatch", THEN work
+#     …implement per repo defaults: tests that have been watched to FAIL, worktree, PR…
+clawgatectl task comment <id> --body "$(cat <<'EOF'
+Shipped in <PR link>. Tests: <matrix, incl. red-at-base evidence>.
+Verified: <the actual symptom reproduced>. NOT verified: <state it plainly>.
+EOF
+)"                                                # 4. ONE comment, at the end
+clawgatectl task status <id> ready_for_review     # 5. hand back
+```
+
+- 🔴 **Ordering trap — flip to `in_progress` LAST, after any edit to the task itself.** The
+  `in_progress` 409 is refined but real: once in progress, a `PATCH /api/tasks/{id}` carrying any
+  non-tag field (or any routing tag) is refused. Descriptive-tag-only edits still succeed.
+- 🔴 **NEVER set `complete` — that is Zach's call, always.** The machine route permits it (the
+  in-devpod agent route structurally forbids it), so nothing stops you but this line.
+  `ready_for_review` is where your work ends.
+- **Comments author as `claude-code`** by default via `X-Clawgate-Source`. There is no `--author`
+  flag: the header IS the impersonation guard, and `user`/`operator` are unreachable by design. An
+  unknown `--source` is silently downgraded to `api`, so the CLI warns on stderr when the author it
+  gets back differs from the one it asked for.
+- **One comment, at the end — not per turn.** Per-turn self-reporting was measured as noise and
+  removed once already (memory `clawgate-loop-validation`); do not reintroduce it here.
+- ⚠ **A comment/status write also refreshes the task's idle clock**, which matters: the reaper
+  dismisses anything untouched for 7d, and dismissing **tears down the linked agent pod**.
+
 ## machine (hook-token) Task API
 Read/create with `clawgatectl task ls --summary [--status open --tag t --limit n]` · `task get <id>`
 · `task create --body …`; **`--summary`/`--status`/`--limit` filter SERVER-side** — NOT true at
-0.7.85, re-measured live 0.7.87 on 2026-08-13. Every other verb (`PATCH`, `DELETE`, comments,
-`/api/tags`, `/api/projects`, `/api/notify`) is still curl with `Authorization: Bearer
+0.7.85, re-measured live 0.7.87 on 2026-08-13. Write status + comments with `clawgatectl task
+status` / `task comment` (above). Every remaining verb (`PATCH` content/tags, `DELETE`, comment
+DELETE, `/api/tags`, `/api/projects`, `/api/notify`) is still curl with `Authorization: Bearer
 $CLAWGATE_HOOK_TOKEN` or `X-Clawgate-Token`. Statuses are exactly `open` / `in_progress` /
 `ready_for_review` / `complete` — no `dismissed`; dismissing deletes.
 

--- a/claude/skills/clawgate/reference/task-api.md
+++ b/claude/skills/clawgate/reference/task-api.md
@@ -63,6 +63,8 @@ readable) and never reaches your scrollback.
 | `clawgatectl task ls [--tag --status --limit --summary]` | `GET /api/tasks` |
 | `clawgatectl task get <id>` | `GET /api/tasks/{id}` |
 | `clawgatectl task create --body\|--body-file [--title --tag --repo --branch --model --directory --privilege]` | `POST /api/tasks` |
+| `clawgatectl task status <id> <open\|in_progress\|ready_for_review\|complete>` | `PATCH /api/tasks/{id}/status` |
+| `clawgatectl task comment <id> --body\|--body-file [--source]` | `POST /api/tasks/{id}/comments` |
 
 ```bash
 # board summary, filtered SERVER-side (MEASURED live 0.7.87, 2026-08-13: 19 tasks unfiltered, 3 with --limit 3)
@@ -238,9 +240,9 @@ two until it was corrected):
 | `GET /api/tasks/{id}` | `task get` | comments embedded |
 | `POST /api/tasks` | `task create` | returns `{"id":N}` only |
 | `PATCH /api/tasks/{id}` | — curl | content/dispatch/tags; refined `in_progress` 409 |
-| `PATCH /api/tasks/{id}/status` | — curl | any status incl. `complete`; no in-progress guard |
+| `PATCH /api/tasks/{id}/status` | `task status` | any status incl. `complete`; no in-progress guard. The CLI validates the status client-side (exit 2, nothing sent) because the server's 400 is the bare `invalid or missing status` and never names the four |
 | `DELETE /api/tasks/{id}` | — curl | ⚠ tears down a live agent pod |
-| `POST /api/tasks/{id}/comments` | — curl | author from `X-Clawgate-Source`, never the body |
+| `POST /api/tasks/{id}/comments` | `task comment` | author from `X-Clawgate-Source`, never the body — so the CLI has **no `--author` flag**. `--source` defaults to `claude-code`; an unallowlisted value is not an error, it is silently authored as `api`, so the CLI compares the returned author against the requested source and warns on **stderr** |
 | `GET /api/tags` | — curl | `[{tag,count}]` |
 | `GET /api/projects` | — curl | ⚠ an OBJECT `{"projects":[…]}`, keyed `name` |
 | `POST /api/send` | — curl | the approval card the PermissionRequest hook posts |

--- a/nix/pkgs/tools/clawgatectl.nix
+++ b/nix/pkgs/tools/clawgatectl.nix
@@ -30,7 +30,7 @@
 { pkgs, workspace }:
 
 let
-  version = "0.7.87";
+  version = "0.7.95";
 
   # The whole Go module, not just cmd/clawgatectl: go.mod/go.sum live at its
   # root and buildGoModule needs them for the vendor derivation.


### PR DESCRIPTION
## The reported symptom

> when picking up tasks locally i say 'read and evaluate clawgate task x', followed by 'local dispatch, include complete test coverage'. sometimes agents comment and manage the task status on their own and sometimes I have to specifically instruct it.

## Root cause — structural, not prompting

Reading a task was **one clean command** (`clawgatectl task get 200`). Setting its status or posting a comment was **raw curl** with a token grep and an `X-Clawgate-Source` header. And `SKILL.md` documented **no pickup workflow at all** — only the status vocabulary, in passing.

Asymmetric friction: the cheap half happened every time, the expensive half didn't. That is exactly the "sometimes it does it, sometimes I have to say it" pattern.

`ZacxDev/homelab-infra#323` removed the friction (`clawgatectl task status` / `task comment`, hitting routes that already existed — no server release). **This PR is the other half: telling the skill when to use them.**

## What changed

- **`SKILL.md` gains `## task pickup`** — maps the two phrases actually used ("read and evaluate clawgate task N" → "local dispatch") onto a 5-step ritual, marked explicitly as not-optional.
- **Two ordering traps recorded**, both load-bearing:
  - flip to `in_progress` **after** any edit to the task — the refined non-tag `409` blocks spec edits once in progress;
  - 🔴 **never set `complete`** — the machine route permits it where the in-devpod agent route structurally forbids it, so nothing but this line stops an agent closing Zach's task.
- **One comment at the end, not per turn** — per-turn self-reporting was already measured as noise and removed once (memory `clawgate-loop-validation`).
- Corrects the now-false **"Exactly six commands"** → eight, and flips the two `task-api.md` route rows still marked `— curl`.
- **`clawgatectl.nix` 0.7.87 → 0.7.95** — that string is the CLI's `buildVersion`, i.e. the source of the `note: server 0.7.95, clawgatectl built for 0.7.87` line printed on every command. `vendorHash` unchanged (no new module deps).

## Size

`SKILL.md` 12,281 → 15,019 bytes. Still well under the largest skills (`activity` 27 KB, `handoff` 25 KB), and this is the highest-frequency workflow in the skill.

## Gate

`scripts/tests/{test_clawgate_tasks,test_clawgate_predicate_single_source,test_skills_mapping_guard}.py` — **204 passed**.

## ⚠ Not done, offered as a follow-up

**Nothing pins the skill's documented verb list against the binary.** That "six" was unguarded prose and had *already* drifted; it will drift again on the next verb. The house pattern exists — `test_clawgate_predicate_single_source.py` for the structural guard, plus the tracked-fixture / absent-file-passes convention documented in `test_settings_allow_junk.py` (a `$HOME`-keyed conditional skip is forbidden by `run-tests.sh` GUARD 2). Deliberately left out of scope here rather than bolted on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)