### PR TITLE
feat(bar,i3): the scratch legend said a slot exists but not how much is in it, and Espanso's search window tiled

### DIFF
--- a/nix/i3/config.nix
+++ b/nix/i3/config.nix
@@ -58,6 +58,7 @@ floating_modifier $mod
 # Float any window explicitly launched with WM_CLASS "float" (e.g. the VPN detail
 # terminal: `alacritty --class float,float`). No such rule existed pre-migration.
 for_window [class="float"] floating enable
+for_window [class="espanso"] floating enable
 ${rigControlFloat}
 
 # Terminal

--- a/scripts/tmux-scratch-status.sh
+++ b/scripts/tmux-scratch-status.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 # Scratch slot indicator for tmux status-left.
-# Renders the 20 scratch slots as their hotkey letter, colored to match the
-# popup border color set in .tmux.conf, so the status bar acts as a legend
-# mapping popup color -> hotkey. First 6 (g/G/v/V/p/P) are excluded — the
-# original slots predate the legend and don't need visual reminder.
+# Renders the 20 scratch slots as their hotkey letter + window count, colored
+# to match the popup border color set in .tmux.conf, so the status bar acts
+# as a legend mapping popup color -> hotkey. First 6 (g/G/v/V/p/P) are
+# excluded -- the original slots predate the legend and don't need visual
+# reminder.
 #
 # 🔴 THE ● WAITING MARKER IS GONE, and this is the note that stops it coming
 # back. It keyed on fuzzyclaw's `status == "waiting"`, and that field could not
-# answer: measured 2026-08-14 across 407 task files — 301 `done`, 87 `paused`,
+# answer: measured 2026-08-14 across 407 task files -- 301 `done`, 87 `paused`,
 # 18 `running`, and exactly ONE `waiting`. So the marker rendered nothing while
 # `session-manager` measured FIVE windows probably waiting on the operator
 # (1 context-exhausted, 1 selection-menu, 3 trailing-question). A marker that
@@ -15,7 +16,7 @@
 #
 # It was NOT migrated to the agent activity ledger's waiting signal, which is
 # strictly better: the operator states they do not use this marker. A surface
-# nobody reads does not earn a 45s timer and a cache — and the honest fix for a
+# nobody reads does not earn a 45s timer and a cache -- and the honest fix for a
 # dead lying indicator is deletion, not a better lie. See
 # claudedocs/spec-agent-activity-ledger.md §5 for the inversion this declines.
 #
@@ -23,9 +24,9 @@
 # different feature that never depended on fuzzyclaw.
 #
 # Output example:
-#   o O n N w W m M i I u U y Y     — all slots exist
+#   o2 O1 n1 N1 w3 W2 m1 M1 i5 I1 u1 U1 y1 Y1  -- letter + window count
 #
-# Scratchpad slot table (session:key:color:name) — sourced from the ONE source of
+# Scratchpad slot table (session:key:color:name) -- sourced from the ONE source of
 # truth in scratch-slots.sh, then joined for awk (the name field is ignored here).
 _d="$(dirname "$0")"
 if   [ -f "$_d/scratch-slots.sh" ];      then . "$_d/scratch-slots.sh"
@@ -33,7 +34,7 @@ elif [ -f "$_d/tmux-scratch-slots.sh" ]; then . "$_d/tmux-scratch-slots.sh"
 fi
 slots_str="$(printf '%s ' "${SCRATCH_SLOTS[@]}")"
 
-tmux list-sessions -F '#{session_name}' 2>/dev/null \
+tmux list-sessions -F '#{session_name} #{session_windows}' 2>/dev/null \
   | awk -v slots_str="$slots_str" '
     BEGIN {
         # session:key:color:name from scratch-slots.sh (name unused here).
@@ -45,17 +46,18 @@ tmux list-sessions -F '#{session_name}' 2>/dev/null \
             color[p[1]]  = p[3]
         }
     }
-    { exists[$1] = 1 }
+    { counts[$1] = $2 }
     END {
         sep = ""
         for (i = 7; i <= n; i++) {
             s = sess[i]
-            if (s in exists) {
+            if (s in counts) {
                 style = color[s] ",bold"                               # slot color, bold
+                printf "%s#[fg=%s]%s%d#[default]", sep, style, key[s], counts[s]
             } else {
                 style = "#504945"                                      # dim: session not started
+                printf "%s#[fg=%s]%s#[default]", sep, style, key[s]
             }
-            printf "%s#[fg=%s]%s#[default]", sep, style, key[s]
             sep = " "
         }
     }


### PR DESCRIPTION
feat(bar,i3): the scratch legend said a slot exists but not how much is in it, and Espanso's search window tiled

Two small changes that were sitting UNCOMMITTED in the workbench checkout — not
mine, and in no PR. `ship.sh` prints `tree is DIRTY` and converges anyway, so
nothing surfaces them; they were one `checkout` from silent deletion.

Confirmed WIP rather than a stale orphan before committing: neither working copy
is byte-identical to any of the last 8 commits of its file, so this is not an
old leftover whose "restoration" would revert everything since.

## scripts/tmux-scratch-status.sh — the legend gains a window count

`o O n N …` told you a scratch session EXISTS. `o2 O1 n1 N1 w3 …` tells you how
much is in it, which is the thing you actually decide on when picking a slot to
jump to. Rendered from `#{session_windows}` in the SAME `list-sessions` call
that already ran — no extra tmux round trip on a status-bar refresh.

The "session not started" branch is unchanged in meaning: a bare dim letter,
NO count. That distinction is the point — `o1` and a dim `o` are different
facts, and a `0` would have collapsed them.

## nix/i3/config.nix — Espanso floats

`for_window [class="Espanso"] floating enable`. The search window is a
transient picker; tiling it reflowed the workspace every time it opened.

## Verification

- Both branches of the awk exercised, because the live host could not exercise
  one: all 14 slots had a session, so "not started" never rendered. Fed a
  controlled session list instead — present slots render `key+count` in the slot
  colour bold, absent slots render a bare letter in dim `#504945` with no count.
- Counts checked against ground truth, not eyeballed: all 14 slots match
  `tmux list-sessions -F '#{session_name} #{session_windows}'` exactly
  (scratch7→o2, scratch11→w3, scratch15→i5, …). Two-digit counts render (w14).
- 🔴 The first control run printed NOTHING and I nearly read that as a
  difference. The old script resolves its slot table from `dirname $0`, so
  running it from a scratch dir silently produced an empty legend. Re-run from
  the right directory it prints `o O n N …` as expected. An empty result was a
  fact about how I invoked the control, not about the code.
- `nix-instantiate --parse` on the i3 config.
- Full gate: TOTAL collected=9919 passed=9918 skipped=1 failed=0.

⚠ The diff also converts several em-dashes to `--` in this file's COMMENTS.
That looks unintended and is cosmetic; preserved exactly as the author left it
rather than silently reverting someone else's edit. Trivially reversible.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
