### PR TITLE
feat(clawgate skill): a pickup ritual that can end in `complete` — gated on who wrote the acceptance criteria

### DIFF
--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -95,37 +95,75 @@ version-from-the-live-pin, the ONE commit path (worktree off `origin/trunk`; nev
 test gate, build/push, pin bump, the CSS-cwd trap that fakes ~25 e2e failures, chart sync.
 
 ## task pickup — "read and evaluate clawgate task N", then "local dispatch"
-🔴 **The status/comment steps are NOT optional and NOT a thing to be asked for.** They were skipped
-for months because reading a task was one command while writing to it was a curl preamble; that
-asymmetry is gone (`task status` / `task comment` since 2026-08-14), so there is no longer an excuse
-to leave a task's state stale. Run the ritual unprompted.
+🔴 **The comment/status ritual is NOT optional and NOT a thing to be asked for.** It was skipped for
+months because reading a task was one command while writing to it was a curl preamble; that
+asymmetry is gone (`task status` / `task comment` since 2026-08-14). Run it unprompted.
+
+🔴 **A COMMENT is the only write that notifies a watcher.** A status flip pushes **only** on
+*entering* `ready_for_review` (`notifyTaskDone`), so going `in_progress` notifies **nobody**. That is
+*why* the pre-start comment exists — it is Zach's only chance to object **before** the work happens,
+not after. Route-level cites: `task-api.md` → "Notifications".
 
 ```bash
 clawgatectl task get <id>            # 1. READ — body + comments are BOTH already here
                                      #    (no /comments GET exists; it is 405)
 #  2. EVALUATE and report to Zach. Do NOT flip status yet — see the ordering trap below.
-clawgatectl task status <id> in_progress          # 3. on "local dispatch", THEN work
-#     …implement per repo defaults: tests that have been watched to FAIL, worktree, PR…
+#  3a. On "local dispatch": settle the acceptance criteria (detector below).
 clawgatectl task comment <id> --body "$(cat <<'EOF'
-Shipped in <PR link>. Tests: <matrix, incl. red-at-base evidence>.
-Verified: <the actual symptom reproduced>. NOT verified: <state it plainly>.
+**Starting** — host <host>, session <id>.
+Acceptance criteria (AUTHOR-SPECIFIED | DERIVED — not author-specified):
+1. … 2. …
+Plan: <2–3 lines>.
+Not doing: <explicit non-goals>.
+Assumptions: <the ones that would change the work if wrong>.
+<if DERIVED> These criteria are mine, not yours — object now if they are wrong.
 EOF
-)"                                                # 4. ONE comment, at the end
-clawgatectl task status <id> ready_for_review     # 5. hand back
+)"                                                # 3b. PRE-START comment, BEFORE the flip
+clawgatectl task status <id> in_progress          # 3c. THEN flip, and work
+#     …4. implement per repo defaults: tests watched to FAIL at base, worktree, PR…
+clawgatectl task comment <id> --body "…"          # 5. ONE completion comment (shape below)
+clawgatectl task status <id> ready_for_review     # 6. …or `complete` — see the gate
 ```
 
-- 🔴 **Ordering trap — flip to `in_progress` LAST, after any edit to the task itself.** The
+**Acceptance-criteria detector — deterministic, not a judgement call.** The body contains a heading
+matching `## Acceptance criteria` (case-insensitive) → **AUTHOR-SPECIFIED**. Anything else — including
+a body that merely *reads* like criteria — means you **DERIVE** them, and you must label them
+`DERIVED — not author-specified` in the comment.
+
+**The completion comment (5)** carries evidence **per criterion** — one line each, naming what proves
+it — plus an explicit **NOT verified** list. "All green" with no per-criterion mapping is not a
+completion report.
+
+🔴 **Status gate (6) — the only place `complete` is ever yours to set:**
+
+| criteria | every criterion validated with evidence? | final status |
+|---|---|---|
+| AUTHOR-SPECIFIED | yes | **`complete`** |
+| DERIVED | yes | **`ready_for_review`** — you must not grade an exam you wrote |
+| either | **no** | **`ready_for_review`**, naming WHICH criterion and WHY it was not validatable |
+
+🔴 **That gate is LOCAL-pickup only, structurally.** The in-devpod agent route
+`PATCH /agent/task/status` **forbids `complete`** (`notes.StatusAllowedForAgent`), so a dispatched
+devpod agent ends at `ready_for_review` regardless of what this skill says. Only the machine route
+this ritual uses can set `complete` at all — the gate governs that permission, nothing else.
+
+📌 **For the task AUTHOR (Zach): a `## Acceptance criteria` section in the body is what unlocks agent
+self-completion.** Without one, every pickup comes back `ready_for_review` for a human read. That is
+the one lever you have.
+
+- 🔴 **Ordering trap — flip to `in_progress` LAST, after any edit to the task ITSELF.** The
   `in_progress` 409 is refined but real: once in progress, a `PATCH /api/tasks/{id}` carrying any
   non-tag field (or any routing tag) is refused. Descriptive-tag-only edits still succeed.
-- 🔴 **NEVER set `complete` — that is Zach's call, always.** The machine route permits it (the
-  in-devpod agent route structurally forbids it), so nothing stops you but this line.
-  `ready_for_review` is where your work ends.
+  **Comments are exempt** — different route, no in-progress guard. So derived criteria go in the
+  **comment, never PATCHed into the body**: it dodges the 409, leaves Zach's task text untouched, and
+  makes provenance unambiguous (body = the author's words, comments = the agent's).
+- **Exactly TWO comments per pickup — start and finish, never per turn.** Per-turn self-reporting was
+  measured as noise and removed once already (memory `clawgate-loop-validation`); do not reintroduce
+  it in a new costume.
 - **Comments author as `claude-code`** by default via `X-Clawgate-Source`. There is no `--author`
   flag: the header IS the impersonation guard, and `user`/`operator` are unreachable by design. An
   unknown `--source` is silently downgraded to `api`, so the CLI warns on stderr when the author it
   gets back differs from the one it asked for.
-- **One comment, at the end — not per turn.** Per-turn self-reporting was measured as noise and
-  removed once already (memory `clawgate-loop-validation`); do not reintroduce it here.
 - ⚠ **A comment/status write also refreshes the task's idle clock**, which matters: the reaper
   dismisses anything untouched for 7d, and dismissing **tears down the linked agent pod**.
 

--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -130,6 +130,13 @@ matching `## Acceptance criteria` (case-insensitive) → **AUTHOR-SPECIFIED**. A
 a body that merely *reads* like criteria — means you **DERIVE** them, and you must label them
 `DERIVED — not author-specified` in the comment.
 
+🔴 **The verdict is frozen at your FIRST read (step 1).** Body edits are legal before the
+`in_progress` flip, so without this an agent could PATCH the heading in, re-read it as
+AUTHOR-SPECIFIED and self-complete — the exact self-grading the gate exists to stop. **Writing the
+criteria and grading them is one act, in either order.** Touch or reword the author's criteria and
+they become yours: DERIVED. **Quote them VERBATIM in the pre-start comment** (author-specified ones
+too) — that timestamped copy is what makes this auditable rather than honour-system.
+
 **The completion comment (5)** carries evidence **per criterion** — one line each, naming what proves
 it — plus an explicit **NOT verified** list. "All green" with no per-criterion mapping is not a
 completion report.

--- a/claude/skills/clawgate/reference/task-api.md
+++ b/claude/skills/clawgate/reference/task-api.md
@@ -31,6 +31,40 @@ read-back `GET` is usually redundant:
 - `POST /api/tasks/{id}/comments` → the **created comment** `{id,noteId,author,body,createdAt}`.
 - `DELETE /api/tasks/{id}` → `{"id":N,"deleted":true}`.
 
+## 🔴 Notifications: a COMMENT is the only write that notifies a watcher
+Read in source on `trunk`, 2026-08-14 — not inferred from behaviour:
+
+| write | pushes? | site |
+|---|---|---|
+| `POST /api/tasks/{id}/comments` | **always**, coalesced, **machine path only** | `notifyTaskCommented`, `internal/api/notes.go:1414` (handler `handleAPITaskComment`, `:1354`) |
+| `PATCH /api/tasks/{id}/status` | **only on ENTERING `ready_for_review`**, deduped | `notifyTaskDone` from `applyTaskStatus`, `notes.go:1065`; impl `internal/api/push_task.go:214` |
+| `PATCH /api/tasks/{id}` (edit) | no | — |
+| `POST /api/tasks` (create) | no task push — the card paths are `/api/send` and `/api/notify` | — |
+
+What a producer (and any agent picking up a task) must design around:
+- 🔴 **Flipping a task to `in_progress` notifies NOBODY.** Any "I have started" signal has to be a
+  COMMENT. This is exactly why the skill's pickup ritual posts a **pre-start comment before** the
+  `in_progress` flip: it is the watcher's only chance to object before the work happens.
+- The **session** (human) comment route deliberately does not push — that is Zach typing, and his own
+  phone must not buzz; the per-agent route keeps its existing no-push behaviour. Only the machine
+  `/api/tasks/{id}/comments` path buzzes.
+- `notifyTaskDone` is deduped per task, and the mark is CLEARED whenever the task leaves
+  `ready_for_review` — so `ready → in_progress → ready` notifies again, while a no-op re-save does not.
+
+**Comments are exempt from the `in_progress` 409.** `POST /api/tasks/{id}/comments` is a different
+route with no in-progress guard, while `PATCH /api/tasks/{id}` 409s once in progress on any non-tag
+field or any routing tag. So an agent recording derived acceptance criteria, a plan or an assumption
+against an in-progress task **comments them — it never PATCHes the body.** Three reasons, all
+load-bearing: it dodges the 409, it leaves the author's text untouched, and it keeps provenance
+unambiguous (body = the author's words, comments = the agent's).
+
+🔴 **`complete` is structurally out of reach for a dispatched devpod agent.**
+`PATCH /agent/task/status` gates on `notes.StatusAllowedForAgent` → `taskstatus.AllowedForAgent` =
+`Valid(s) && s != Complete` (`internal/taskstatus/taskstatus.go:79`), so a devpod agent's terminal
+state is always `ready_for_review`. Only the machine `PATCH /api/tasks/{id}/status` — the LOCAL
+pickup path — can set `complete`, so the skill's author-specified-criteria gate governs that
+permission and has no bearing whatsoever on the devpod route.
+
 ## ⚠ Request keys ≠ response keys (the `sourceSessionId` trap, twice more)
 `POST`/`PATCH` take **`branch`** and **`privileges`**; the task reads back as **`repoBranch`**
 and **`grantProfiles`** (`notes.go`). Round-tripping a GET body into a PATCH silently drops both.


### PR DESCRIPTION
## What changed

Rewrites the `## task pickup` section of the `clawgate` skill so a pickup can legitimately end in
`complete`, and so Zach hears about a pickup **before** the work happens rather than after.

### 1. A pre-start comment, posted before the `in_progress` flip

🔴 **A comment is the only write that notifies a watcher.** Verified in source on `trunk`:

| write | pushes? | site |
|---|---|---|
| `POST /api/tasks/{id}/comments` | **always** (coalesced, machine path only) | `notifyTaskCommented`, `internal/api/notes.go:1414` |
| `PATCH /api/tasks/{id}/status` | **only on ENTERING `ready_for_review`**, deduped | `notifyTaskDone` from `applyTaskStatus`, `notes.go:1065` → `push_task.go:214` |
| `PATCH /api/tasks/{id}` (edit) | no | — |

So flipping to `in_progress` notifies **nobody** — that is *why* the start comment exists, and the
skill now states that as the reason. It carries: a `**Starting**` line with host/session, the
acceptance criteria with their provenance label, a 2–3 line plan, explicit **Not doing** non-goals,
and the **Assumptions** that would change the work if wrong (plus an explicit "object now" when the
criteria are derived).

### 2. A deterministic criteria detector, and a status gate keyed on it

**Detector** — not a judgement call: the task body contains a heading matching `## Acceptance
criteria` (case-insensitive) → **AUTHOR-SPECIFIED**. Anything else → the agent **DERIVES** them and
must label them `DERIVED — not author-specified`.

**Gate:**

| criteria | every criterion validated with evidence? | final status |
|---|---|---|
| AUTHOR-SPECIFIED | yes | **`complete`** |
| DERIVED | yes | **`ready_for_review`** — an agent must not grade an exam it wrote |
| either | **no** | **`ready_for_review`**, naming which criterion and why |

The old flat "NEVER set `complete`" line is not deleted — it becomes this conditional.

### 3. Ordering, fixed by the refined 409

Any edit to the task *itself* (`PATCH /api/tasks/{id}` with a non-tag field, or any routing tag) must
precede the `in_progress` flip. **Comments are exempt** — different route, no in-progress guard.
Derived criteria therefore go in the **comment, never PATCHed into the body**: dodges the 409, leaves
Zach's task text untouched, and makes provenance unambiguous (body = author's, comment = agent's).

### 4. Local-only, structurally

`PATCH /agent/task/status` gates on `notes.StatusAllowedForAgent` → `taskstatus.AllowedForAgent` =
`Valid(s) && s != Complete` (`internal/taskstatus/taskstatus.go:79`). A dispatched **devpod** agent
therefore terminates at `ready_for_review` regardless of what this skill says. Stated explicitly so
the gate is not read as applying there.

### 5. A note for the task AUTHOR

Putting a `## Acceptance criteria` section in a task body is what unlocks agent self-completion —
the one lever Zach has. Called out in the skill body.

## Preserved

Exactly **two** comments per pickup (start + finish) — per-turn commentary was measured as noise and
removed once already (memory `clawgate-loop-validation`); the skill says so, so this doesn't become a
back door for it. The ordering trap, the `X-Clawgate-Source` author note, and the reaper/idle-clock
warning are all kept.

## Size

`SKILL.md` **15019 → 17362 bytes**, under the ~18 KB working ceiling. Route-level detail (the push
matrix with source cites, the 409 exemption, the agent-route `complete` ban) went to
`reference/task-api.md` (+34 lines) rather than the body.

## Gate

```
python -m pytest scripts/tests/test_clawgate_tasks.py \
  scripts/tests/test_clawgate_predicate_single_source.py \
  scripts/tests/test_skills_mapping_guard.py -q
→ 204 passed, 0 failed (2.86s)
```

Adjacent content guards also run clean: `test_no_public_ips.py`, `test_skill_audit.py`,
`test_no_client_hostnames.py` → **74 passed**.

⚠ These are docs; no test in this repo asserts the ritual's *content*, so the gate proves only that
nothing structural (skill mapping, IP/hostname leakage) broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
