### PR TITLE
fix(i3): the espanso float rule matches case-sensitively, so it fires only if espanso happens to report a lowercase class

### DIFF
--- a/nix/i3/config.nix
+++ b/nix/i3/config.nix
@@ -58,7 +58,16 @@ floating_modifier $mod
 # Float any window explicitly launched with WM_CLASS "float" (e.g. the VPN detail
 # terminal: `alacritty --class float,float`). No such rule existed pre-migration.
 for_window [class="float"] floating enable
-for_window [class="espanso"] floating enable
+# 🔴 `(?i)` IS LOAD-BEARING, not decoration. i3 criteria are PCRE and
+# CASE-SENSITIVE by default (the userguide's "case-insensitive" examples are
+# showing you how to opt IN with `(?i)`), and `class` matches the SECOND field
+# of WM_CLASS — the one toolkits conventionally capitalise. So a bare
+# `class="espanso"` fires only if espanso reports a lowercase class, and if it
+# reports `Espanso` the rule silently never matches: no error, no warning, just
+# a window that keeps tiling. Which one espanso 2.4.0 actually sets could not be
+# determined without popping its search window on a live desktop, so the rule is
+# written to match either.
+for_window [class="(?i)espanso"] floating enable
 ${rigControlFloat}
 
 # Terminal


### PR DESCRIPTION
fix(i3): the espanso float rule matches case-sensitively, so it fires only if espanso happens to report a lowercase class

`for_window [class="espanso"] floating enable` landed in #486. It may never
match, and if it does not there is no error to notice — the search window just
keeps tiling, which is the symptom the rule was added to fix.

Two facts, measured:

- **i3 criteria are PCRE and CASE-SENSITIVE by default.** The i3 4.25.1
  userguide's "case-insensitive" mentions are examples showing how to opt IN
  (`[class="(?i)firefox"]`), not a description of the default. My first grep for
  "case-insensitive" in that doc hit exactly those examples and read as the
  opposite of what they mean — an instrument returning a confident wrong answer.
- **`class` matches the SECOND field of WM_CLASS**, the one GUI toolkits
  conventionally capitalise. So the rule turns on whether espanso reports
  `espanso` or `Espanso`.

Which one espanso 2.4.0 actually sets could NOT be determined without triggering
its search window on a live desktop. The binary carries a lowercase `espanso`
string and no capitalised `Espanso` — suggestive, not conclusive, since the
class is set by the toolkit (espanso-modulo, wxWidgets) rather than by a literal
in the binary. Rather than steal focus on a working desktop to find out, the
rule is written to match either: `(?i)`.

## Verification

- `nix-instantiate --parse` on the module.
- `i3 -C` accepts the criterion (rc=0, no output).
- 🔴 **Positive control on that validator**, because "accepted silently" and
  "not checked at all" are the same observation: fed `class="(?i)espanso[") ]`,
  `i3 -C` fails with `PCRE regular expression compilation failed at 12: missing
  terminating ] for character class`. So i3 genuinely compiles the pattern and
  `(?i)` is being parsed as PCRE, not swallowed as a literal.

Not verified: that a real espanso window now floats. That needs the search
window open after a switch, and it is the one check worth doing by hand.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
