### PR TITLE
fix(workbench): /tmp never expires because atime keeps it immortal — mtime-only, scoped ageing

### DIFF
--- a/nix/system/apply-tmp-churn-retention.sh
+++ b/nix/system/apply-tmp-churn-retention.sh
@@ -61,6 +61,26 @@
 #   nix-[0-9]*             778 /  612      homelab-talos-prs-*   2554 / 2537
 # Every glob matches real entries — none is a dead rule.
 #
+# 🔴 A HYPHEN IS NOT A WILDCARD: `nix-shell-*` CANNOT MATCH `nix-shell.<mktemp>`.
+# nix-shell writes its TMPDIR in two spellings and this rule set only ever saw
+# one of them. Re-measured live on the workbench 2026-08-22, top-level /tmp:
+#
+#   nix-shell.*   3340   <- UNCOVERED until this rule
+#   nix-shell-*   1017      covered since 2026-08-15
+#
+# The dot form outnumbers the hyphen form 3.3:1, and it is the form `gate.sh`
+# produces on every agent run (its log lands in /tmp/nix-shell.<x>/devrc-gate-*/),
+# so it is the one that grows fastest on a machine driven by agents. The glob
+# below closes it. Control for the count above: an unrestricted `find /tmp
+# -maxdepth 1` returns 119,066 — the zeros here are real zeros, not a walk that
+# never ran.
+#
+# 🔴 Still UNCOVERED after this change, and deliberately not taken here — each is
+# larger than everything this file reaps put together, and none has been checked
+# against live work the way the globs above were:
+#   cgparent-*  17064    fx-excerpt-*  14012    cbf-*  5268    tmp.*  4227
+# `tmp.*` in particular is bare mktemp's default and would need its own audit.
+#
 # Dry-run of the exact rule set below: 4,255,261 entries would be removed, and
 # ZERO matches against /tmp/wt-*, /tmp/claude-1000 or the named project dirs
 # (civitai-integration, peakmaps, chunkcache, pnpmvar, audit187). Estimated
@@ -103,35 +123,77 @@ restore_on_err() {
 }
 trap restore_on_err ERR
 
-if grep -qF "$MARKER" "$CFG"; then
-  echo "[1/1] tmp churn retention rules already present — skipping edit"
-else
-  echo "[1/1] inserting tmpfiles rules into systemd.tmpfiles.rules"
-  python3 - "$CFG" <<'PY'
+# 🔴 THE SKIP IS PER-RULE, NOT PER-MARKER. This block used to return early on
+# `grep -qF "$MARKER"` alone, which meant a host that had ALREADY run the script
+# could never receive a rule added later — the run printed "already present" and
+# exited 0 over a config missing the new glob. That is how `nix-shell.*` would
+# have shipped to nobody: the workbench is unapplied today, but the laptop's
+# /etc/nixos is not readable from here, so its state is UNMEASURED, not clean.
+# The ledger below is the single source of truth; the script inserts exactly the
+# rules that are absent and then re-reads the file to prove every one landed.
+echo "[1/1] reconciling tmpfiles rules in systemd.tmpfiles.rules"
+python3 - "$CFG" <<'PY'
 import sys
+
 path = sys.argv[1]
 src = open(path).read()
-anchor = "  systemd.tmpfiles.rules = [\n"
-if anchor not in src:
-    raise SystemExit("ERROR: could not find 'systemd.tmpfiles.rules = [' in configuration.nix")
-rules = '''    # /tmp churn retention (2026-08-15). mtime-ONLY ageing (`m:`), because
+
+HEADER = '''    # /tmp churn retention (2026-08-15). mtime-ONLY ageing (`m:`), because
     # systemd-tmpfiles ages on the newest of atime/mtime/ctime and any `du`/`find`
     # over /tmp refreshes atime — which made the stock 10d rule never expire
     # anything. Scoped to machine-generated prefixes ONLY: a blanket rule would
     # delete live git worktrees parked in /tmp. See nix/system/apply-tmp-churn-retention.sh.
-    "e /tmp/nix-shell-* - - - m:7d"
-    "e /tmp/nix-develop-* - - - m:7d"
-    "e /tmp/nix-[0-9]* - - - m:7d"
-    "e /tmp/go-build* - - - m:7d"
-    "e /tmp/chromedp-runner* - - - m:7d"
-    "e /tmp/homelab-talos-prs-* - - - m:7d"
 '''
-open(path, "w").write(src.replace(anchor, anchor + rules, 1))
+
+# 🔴 A hyphen is a LITERAL. `nix-shell-*` and `nix-shell.*` are two globs, and
+# nix-shell writes both spellings — see the header for the 3340-vs-1017 count.
+RULES = [
+    '    "e /tmp/nix-shell-* - - - m:7d"',
+    '    "e /tmp/nix-shell.* - - - m:7d"',
+    '    "e /tmp/nix-develop-* - - - m:7d"',
+    '    "e /tmp/nix-[0-9]* - - - m:7d"',
+    '    "e /tmp/go-build* - - - m:7d"',
+    '    "e /tmp/chromedp-runner* - - - m:7d"',
+    '    "e /tmp/homelab-talos-prs-* - - - m:7d"',
+]
+
+missing = [r for r in RULES if r.strip() not in src]
+if not missing:
+    print("      all %d rules already present — nothing to insert" % len(RULES))
+    raise SystemExit(0)
+
+anchor = "  systemd.tmpfiles.rules = [\n"
+if anchor not in src:
+    raise SystemExit("ERROR: could not find 'systemd.tmpfiles.rules = [' in configuration.nix")
+
+# Re-applying onto a config that already carries the block must not duplicate the
+# comment header; a first application must not omit it.
+block = "".join(r + "\n" for r in missing)
+if HEADER.splitlines()[0] not in src:
+    block = HEADER + block
+
+open(path, "w").write(src.replace(anchor, anchor + block, 1))
+print("      inserted %d of %d rules (%d already present)"
+      % (len(missing), len(RULES), len(RULES) - len(missing)))
+for r in missing:
+    print("        + " + r.strip())
 PY
-  grep -qF "$MARKER" "$CFG" || { echo "ERROR: tmpfiles edit did not apply"; false; }
-  grep -qF 'e /tmp/nix-shell-* - - - m:7d' "$CFG" || { echo "ERROR: rule text missing after edit"; false; }
-  echo "      rules inserted and verified present"
-fi
+
+# Verify by RE-READING the file, every rule individually — the insert reporting
+# success is a claim about the writer, not about what is now on disk.
+for _rule in \
+  'e /tmp/nix-shell-* - - - m:7d' \
+  'e /tmp/nix-shell.* - - - m:7d' \
+  'e /tmp/nix-develop-* - - - m:7d' \
+  'e /tmp/nix-[0-9]* - - - m:7d' \
+  'e /tmp/go-build* - - - m:7d' \
+  'e /tmp/chromedp-runner* - - - m:7d' \
+  'e /tmp/homelab-talos-prs-* - - - m:7d'
+do
+  grep -qF "$_rule" "$CFG" || { echo "ERROR: rule missing after edit: $_rule" >&2; false; }
+done
+grep -qF "$MARKER" "$CFG" || { echo "ERROR: comment header missing after edit" >&2; false; }
+echo "      all rules verified present on disk"
 
 trap - ERR
 

--- a/nix/system/apply-tmp-churn-retention.sh
+++ b/nix/system/apply-tmp-churn-retention.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# /tmp churn retention — workbench, 2026-08-15.
+#
+# Claude cannot run `sudo nixos-rebuild`, so the /etc/nixos edit is staged here.
+# Idempotent: safe to re-run.
+#
+#   sudo bash nix/system/apply-tmp-churn-retention.sh
+#
+# Safe on a non-TTY (pipe, ssh without -t, agent shell): the prompt is skipped
+# rather than aborting mid-edit, and any error restores the backup via an ERR
+# trap — same shape as apply-perf-tuning-2026-07-30.sh next door.
+#
+# ── THE PROBLEM, AND WHY THE OBVIOUS FIX IS NOT IT ───────────────────────────
+#
+# workbench went DiskPressure=True on 2026-08-13 and evicted node-wide (clawgate,
+# supabase, remix-worker, auditloop, orchestrator-devpod). The disk genuinely
+# filled: 1.7 TB of 1.8 TB, down to 101 GiB free against a ~92 GiB eviction line.
+#
+# 🔴 Do NOT reach for the two fixes the incident handoff proposed — both are
+# no-ops, measured 2026-08-15:
+#   - "relax eviction-hard to 5%": it is ALREADY 5%. That is a k3s BUILT-IN
+#     default, present in no config file, surviving every rebuild. (And writing
+#     the flag by hand is hazardous: eviction-hard REPLACES the whole default
+#     set, so spelling only the two disk signals silently drops memory.available
+#     and both inodesFree guards.)
+#   - "add systemd-tmpfiles ageing on /tmp": it ALREADY exists. systemd ships
+#     `q /tmp 1777 root root 10d` and systemd-tmpfiles-clean.timer runs daily and
+#     succeeds. `systemd-tmpfiles --clean --dry-run` reclaims 0.55 GiB.
+#
+# ── ROOT CAUSE: atime keeps stale dirs immortal ──────────────────────────────
+#
+# systemd-tmpfiles ages on the MOST RECENT of atime/mtime/ctime. Measured on
+# real /tmp entries:
+#
+#   /tmp/nix-shell-3304470-3498967483   m=2026-08-02  a=2026-08-14  c=2026-08-02
+#   /tmp/nix-shell-2760455-2726689738   m=2026-07-30  a=2026-08-14  c=2026-07-30
+#
+# mtime/ctime are weeks old; atime is yesterday. So the 10d rule sees "1 day old"
+# and never expires them.
+#
+# 🔴 And what refreshes atime is SCANNING /tmp with du or find — precisely what
+# investigating a full disk requires. Every investigation resets the clock on
+# everything it looks at. That is why /tmp sat at 362 GB with a working cleaner.
+#
+# ── THE FIX: mtime-only ageing, SCOPED to machine-generated churn ────────────
+#
+# systemd >= 253 accepts an age-by prefix (`m:7d` = consider mtime only). Verified
+# on this host's systemd 258 by control pair: `z:7d` -> "Invalid age-by 'z'",
+# `m:7d` -> parses and matches.
+#
+# 🔴 It is scoped by GLOB, not applied to /tmp as a whole, because /tmp holds
+# real work that a blanket rule would destroy. Measured: a blanket mtime-only
+# 7d rule would have deleted TWO LIVE GIT WORKTREES —
+#   /tmp/wt-apps-ui-3497  (14d)  gitdir: ~/workspace/civit/civitai/.git/worktrees/...
+#   /tmp/wt-waitunit      (10d)  gitdir: ~/workspace/civit/civitai/.git/worktrees/...
+# possibly carrying uncommitted work. Hence: machine-generated prefixes only.
+#
+# Coverage, measured 2026-08-15 (dirs / of those with mtime >7d):
+#   nix-shell-*           1003 /  988      go-build*              114 /  98
+#   nix-develop-*         1196 /  392      chromedp-runner*       158 / 158
+#   nix-[0-9]*             778 /  612      homelab-talos-prs-*   2554 / 2537
+# Every glob matches real entries — none is a dead rule.
+#
+# Dry-run of the exact rule set below: 4,255,261 entries would be removed, and
+# ZERO matches against /tmp/wt-*, /tmp/claude-1000 or the named project dirs
+# (civitai-integration, peakmaps, chunkcache, pnpmvar, audit187). Estimated
+# reclaim ~47 GB, a LOWER BOUND — the dry-run ran unprivileged and cannot see
+# root-owned paths.
+#
+# NOT covered on purpose:
+#   - /tmp/claude-1000 (52 GB): Claude session scratchpads. The stock 10d /tmp
+#     rule already covers them and they are the user's own working state; a
+#     mid-session sweep is not worth 52 GB.
+#   - /tmp/wt-*: real git worktrees. Never age these automatically.
+#
+# Rollback: cp -a the backup this script prints, then nixos-rebuild switch. The
+# rules are additive and delete nothing at rebuild time — cleanup happens on the
+# next systemd-tmpfiles-clean.timer firing.
+
+set -euo pipefail
+
+CFG=/etc/nixos/configuration.nix
+BAK="${CFG}.bak-tmp-churn-$(date +%Y%m%d-%H%M%S)"
+MARKER='/tmp churn retention'
+
+if [[ $EUID -ne 0 ]]; then
+  echo "This script edits ${CFG} and must run as root:" >&2
+  echo "    sudo bash $0" >&2
+  exit 1
+fi
+
+if [[ ! -f "$CFG" ]]; then
+  echo "ERROR: ${CFG} not found — is this workbench?" >&2
+  exit 1
+fi
+
+cp -a "$CFG" "$BAK"
+echo "Backup: ${BAK}"
+
+restore_on_err() {
+  echo "ERROR — restoring ${CFG} from ${BAK}" >&2
+  cp -a "$BAK" "$CFG"
+}
+trap restore_on_err ERR
+
+if grep -qF "$MARKER" "$CFG"; then
+  echo "[1/1] tmp churn retention rules already present — skipping edit"
+else
+  echo "[1/1] inserting tmpfiles rules into systemd.tmpfiles.rules"
+  python3 - "$CFG" <<'PY'
+import sys
+path = sys.argv[1]
+src = open(path).read()
+anchor = "  systemd.tmpfiles.rules = [\n"
+if anchor not in src:
+    raise SystemExit("ERROR: could not find 'systemd.tmpfiles.rules = [' in configuration.nix")
+rules = '''    # /tmp churn retention (2026-08-15). mtime-ONLY ageing (`m:`), because
+    # systemd-tmpfiles ages on the newest of atime/mtime/ctime and any `du`/`find`
+    # over /tmp refreshes atime — which made the stock 10d rule never expire
+    # anything. Scoped to machine-generated prefixes ONLY: a blanket rule would
+    # delete live git worktrees parked in /tmp. See nix/system/apply-tmp-churn-retention.sh.
+    "e /tmp/nix-shell-* - - - m:7d"
+    "e /tmp/nix-develop-* - - - m:7d"
+    "e /tmp/nix-[0-9]* - - - m:7d"
+    "e /tmp/go-build* - - - m:7d"
+    "e /tmp/chromedp-runner* - - - m:7d"
+    "e /tmp/homelab-talos-prs-* - - - m:7d"
+'''
+open(path, "w").write(src.replace(anchor, anchor + rules, 1))
+PY
+  grep -qF "$MARKER" "$CFG" || { echo "ERROR: tmpfiles edit did not apply"; false; }
+  grep -qF 'e /tmp/nix-shell-* - - - m:7d' "$CFG" || { echo "ERROR: rule text missing after edit"; false; }
+  echo "      rules inserted and verified present"
+fi
+
+trap - ERR
+
+echo
+echo "Config edited. Validate the rule syntax BEFORE rebuilding:"
+echo "    systemd-tmpfiles --clean --dry-run 2>&1 | head"
+echo "  (a bad age-by prefix reports 'Invalid age-by' and names the file:line)"
+echo
+
+if [[ -t 0 ]]; then
+  read -r -p "Run 'nixos-rebuild switch' now? [y/N] " ans || ans=n
+else
+  echo "Non-interactive shell — skipping the rebuild prompt."
+  ans=n
+fi
+
+if [[ "$ans" == "y" || "$ans" == "Y" ]]; then
+  if ! nixos-rebuild switch; then
+    echo >&2
+    echo "nixos-rebuild FAILED. The config edits are still in place." >&2
+    echo "Rollback: cp -a ${BAK} ${CFG} && nixos-rebuild switch" >&2
+    exit 1
+  fi
+  echo
+  echo "Switched. Cleanup runs on the next systemd-tmpfiles-clean.timer firing;"
+  echo "to trigger it now:  systemctl start systemd-tmpfiles-clean.service"
+else
+  echo "Config edited and validated; nixos-rebuild NOT run. Run it when ready:"
+  echo "    sudo nixos-rebuild switch"
+fi
+
+echo
+echo "Rollback: cp -a ${BAK} ${CFG} && nixos-rebuild switch"

--- a/scripts/tests/test_tmp_churn_retention.py
+++ b/scripts/tests/test_tmp_churn_retention.py
@@ -1,0 +1,232 @@
+"""`nix/system/apply-tmp-churn-retention.sh` — the tmpfiles rule ledger.
+
+The script itself cannot be executed here: it refuses a non-root EUID and writes a
+hardcoded `/etc/nixos/configuration.nix`. What CAN be exercised, and is the part
+that decides what lands on disk, is the `python3 … <<'PY'` heredoc it runs. These
+tests extract that heredoc verbatim from the shipped file and run it against
+fixture configs, so a change to the script changes what is under test — there is
+no second copy of the rules here to drift out of sync.
+
+Two properties are pinned that prose alone got wrong once already:
+
+  1. **A re-run on an ALREADY-APPLIED host still receives a newly-added rule.**
+     The original script gated the whole edit on `grep -qF "$MARKER"`, i.e. on the
+     presence of a *comment*. Any rule added later was therefore unreachable on
+     every host that had already run it: the run printed "already present" and
+     exited 0 over a config missing the new glob. That is the shape of a guard
+     that reads as coverage while providing none.
+
+  2. **`nix-shell-*` cannot match `nix-shell.<mktemp>`.** A hyphen is a literal.
+     The two spellings are two globs and nix-shell emits both.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2] / "nix" / "system" / "apply-tmp-churn-retention.sh"
+)
+
+ANCHOR = "  systemd.tmpfiles.rules = [\n"
+
+# A config shaped like the real one, reduced to what the inserter reads.
+FRESH_CONFIG = f"""{{ config, pkgs, ... }}:
+{{
+  networking.hostName = "workbench";
+
+{ANCHOR}    "d /run/example 0755 root root -"
+  ];
+}}
+"""
+
+# The glob added after the script had already shipped. Case 1 above is the reason
+# this constant is spelled out separately rather than read from the ledger: the
+# test must know which rule is the LATE one.
+LATE_RULE = '"e /tmp/nix-shell.* - - - m:7d"'
+
+
+def _script_text() -> str:
+    return SCRIPT.read_text()
+
+
+def _extract_inserter() -> str:
+    """The body of the `python3 - "$CFG" <<'PY' … PY` heredoc, verbatim."""
+    text = _script_text()
+    m = re.search(r"^python3 - \"\$CFG\" <<'PY'\n(.*?)^PY$", text, re.M | re.S)
+    assert m, "could not find the python heredoc — has the script's shape changed?"
+    body = m.group(1)
+    assert "systemd.tmpfiles.rules" in body, "extracted the wrong block"
+    return body
+
+
+def _python_rules() -> list[str]:
+    """The RULES ledger as the inserter itself defines it."""
+    body = _extract_inserter()
+    m = re.search(r"^RULES = \[\n(.*?)^\]$", body, re.M | re.S)
+    assert m, "could not find the RULES ledger in the inserter"
+    return re.findall(r"'\s*(\"e /tmp/.*?\")\s*'", m.group(1))
+
+
+def _shell_verified_rules() -> list[str]:
+    """The rules the script re-reads off disk after writing, in its `for` loop."""
+    text = _script_text()
+    m = re.search(r"^for _rule in \\\n(.*?)^do$", text, re.M | re.S)
+    assert m, "could not find the post-write verification loop"
+    return re.findall(r"'(e /tmp/.*?)'", m.group(1))
+
+
+def _run_inserter(tmp_path: Path, config_text: str) -> tuple[int, str, str, str]:
+    """Run the extracted inserter against a fixture config. Returns rc/out/err/text."""
+    cfg = tmp_path / "configuration.nix"
+    cfg.write_text(config_text)
+    src = tmp_path / "inserter.py"
+    src.write_text(_extract_inserter())
+    proc = subprocess.run(
+        [sys.executable, str(src), str(cfg)],
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode, proc.stdout, proc.stderr, cfg.read_text()
+
+
+# ---------------------------------------------------------------- the ledger --
+
+
+def test_the_shell_verification_ledger_equals_the_python_rule_ledger():
+    """A rule written but never re-read off disk is unverified; a rule verified but
+    never written is a permanently-failing check. The two lists must be the SAME
+    set — this fails when either grows or shrinks, not merely when one is empty."""
+    written = {r.strip('"') for r in _python_rules()}
+    verified = set(_shell_verified_rules())
+
+    assert written, "the python RULES ledger parsed empty — the extractor is broken"
+    assert verified, "the shell verification loop parsed empty — the extractor is broken"
+    assert written == verified, (
+        "the rules the script WRITES and the rules it VERIFIES have diverged.\n"
+        f"  written but not verified: {sorted(written - verified)}\n"
+        f"  verified but not written: {sorted(verified - written)}"
+    )
+
+
+def test_the_late_rule_is_actually_in_the_ledger():
+    """Positive control for the two tests below: they are only meaningful if the
+    rule they are about is present at all."""
+    assert LATE_RULE in _python_rules()
+
+
+# ------------------------------------------------------- hyphen is a literal --
+
+
+def test_the_hyphen_glob_cannot_match_the_dot_form():
+    """Why a second nix-shell rule has to exist. `fnmatch` here stands in for
+    systemd-tmpfiles' own glob(3) matching, which shares the semantics that
+    matter: `-` is a literal, `*` does not cross the boundary backwards."""
+    dot_form = "/tmp/nix-shell.QcVn1oNwEG"
+    hyphen_form = "/tmp/nix-shell-3304470-3498967483"
+
+    assert not fnmatch.fnmatchcase(dot_form, "/tmp/nix-shell-*"), (
+        "if this ever passes, the hyphen rule covers the dot form and the second "
+        "rule is dead — delete it rather than leaving two rules for one case"
+    )
+    assert fnmatch.fnmatchcase(dot_form, "/tmp/nix-shell.*")
+    assert fnmatch.fnmatchcase(hyphen_form, "/tmp/nix-shell-*")
+
+
+def test_both_nix_shell_spellings_are_covered_by_the_shipped_ledger():
+    """The behavioural form of the test above, against the real ledger rather than
+    against two literals: every spelling nix-shell emits must be matched by SOME
+    shipped rule. Deleting either rule fails this."""
+    globs = [r.strip('"').split()[1] for r in _python_rules()]
+    for path in ("/tmp/nix-shell.QcVn1oNwEG", "/tmp/nix-shell-3304470-3498967483"):
+        assert any(fnmatch.fnmatchcase(path, g) for g in globs), (
+            f"{path} is matched by no shipped rule; globs = {globs}"
+        )
+
+
+# ------------------------------------------------------------- the inserter --
+
+
+def test_a_fresh_config_receives_every_rule_and_the_comment_header(tmp_path):
+    rc, out, err, text = _run_inserter(tmp_path, FRESH_CONFIG)
+
+    assert rc == 0, f"inserter failed: {err}"
+    for rule in _python_rules():
+        assert rule in text, f"{rule} missing from the written config"
+    assert "/tmp churn retention" in text, "comment header not written"
+    assert f"inserted {len(_python_rules())} of {len(_python_rules())}" in out
+
+
+def test_a_second_run_changes_nothing(tmp_path):
+    """Idempotence, asserted on the BYTES rather than on the message."""
+    rc, _, err, once = _run_inserter(tmp_path, FRESH_CONFIG)
+    assert rc == 0, err
+
+    rc2, out2, err2, twice = _run_inserter(tmp_path, once)
+    assert rc2 == 0, err2
+    assert twice == once, "a second run modified the config"
+    assert "nothing to insert" in out2
+
+
+def test_an_already_applied_host_still_receives_a_newly_added_rule(tmp_path):
+    """🔴 THE REGRESSION TEST for defect 1 in this module's docstring.
+
+    Fixture = a config that already carries the comment header and every rule
+    EXCEPT the late one, i.e. exactly the state of a host that ran the script
+    before that rule existed. The marker-gated version of this script skipped the
+    edit entirely on such a host and reported success.
+    """
+    seeded = FRESH_CONFIG.replace(
+        ANCHOR,
+        ANCHOR
+        + "    # /tmp churn retention (2026-08-15). mtime-ONLY ageing (`m:`), because\n"
+        + "".join(
+            f"    {r}\n" for r in _python_rules() if r != LATE_RULE
+        ),
+        1,
+    )
+    assert LATE_RULE not in seeded, "fixture built wrong — the late rule is present"
+    assert "/tmp churn retention" in seeded, "fixture built wrong — no marker"
+
+    rc, out, err, text = _run_inserter(tmp_path, seeded)
+
+    assert rc == 0, f"inserter failed: {err}"
+    assert LATE_RULE in text, (
+        "an already-applied host did NOT receive the newly-added rule — the skip "
+        "is keyed on the comment header again"
+    )
+    assert f"inserted 1 of {len(_python_rules())}" in out, out
+    assert text.count("/tmp churn retention (2026-08-15)") == 1, (
+        "the comment header was duplicated onto a config that already had it"
+    )
+
+
+def test_a_config_without_the_anchor_is_refused_not_silently_skipped(tmp_path):
+    rc, _out, err, text = _run_inserter(tmp_path, FRESH_CONFIG.replace(ANCHOR, ""))
+
+    assert rc != 0, "a config with no rules list was accepted"
+    assert "systemd.tmpfiles.rules" in err
+    assert "e /tmp/nix-shell" not in text, "the config was mutated on the error path"
+
+
+@pytest.mark.parametrize(
+    "protected",
+    [
+        "/tmp/wt-apps-ui-3497",
+        "/tmp/claude-1000",
+        "/tmp/nix-shellish-not-really",
+    ],
+)
+def test_no_shipped_rule_matches_a_path_that_must_never_be_reaped(protected):
+    """The script's own header promises live worktrees and Claude scratchpads are
+    out of scope. That promise is only as good as the globs — a rule broadened by
+    one character could take them, and nothing else would notice."""
+    globs = [r.strip('"').split()[1] for r in _python_rules()]
+    hits = [g for g in globs if fnmatch.fnmatchcase(protected, g)]
+    assert not hits, f"{protected} would be reaped by {hits}"


### PR DESCRIPTION
Staged for root (`sudo bash nix/system/apply-tmp-churn-retention.sh`), same shape as `apply-perf-tuning-2026-07-30.sh`.

## Root cause

`systemd-tmpfiles` ages on the **most recent** of atime/mtime/ctime. Measured on real entries:

```
/tmp/nix-shell-3304470-3498967483   m=2026-08-02  a=2026-08-14  c=2026-08-02
/tmp/nix-shell-2760455-2726689738   m=2026-07-30  a=2026-08-14  c=2026-07-30
```

mtime/ctime weeks old, **atime yesterday** — so the stock `q /tmp 1777 root root 10d` rule sees "1 day old" and never expires them.

🔴 **And what refreshes atime is scanning `/tmp` with `du` or `find`** — exactly what investigating a full disk requires. Every investigation resets the clock on everything it looks at. That is how `/tmp` reached 362 GB with a cleaner that runs daily and succeeds.

## What this replaces

Both fixes the incident handoff proposed are **no-ops**, measured:

| proposed fix | reality |
|---|---|
| relax `eviction-hard` to 5% | **already 5%** — a k3s built-in default, in no config file, surviving every rebuild |
| add tmpfiles ageing on `/tmp` | **already exists** and runs daily; `--clean --dry-run` reclaims 0.55 GiB |

`ZacxDev/homelab-infra@23b5fb22` retracts both in the handoff doc.

## The fix

mtime-only age (`m:7d`), verified supported on this host's systemd 258 by control pair — `z:7d` → `Invalid age-by 'z'`, `m:7d` → parses and matches.

🔴 **Scoped by glob, NOT applied to `/tmp` as a whole.** A blanket mtime-only 7d rule would have deleted **two live git worktrees**:

```
/tmp/wt-apps-ui-3497  (14d)   gitdir: ~/workspace/civit/civitai/.git/worktrees/…
/tmp/wt-waitunit      (10d)   gitdir: ~/workspace/civit/civitai/.git/worktrees/…
```

possibly carrying uncommitted work. So: machine-generated prefixes only.

Coverage (dirs / with mtime >7d) — every glob matches something, none is a dead rule:

| glob | dirs | stale |
|---|---|---|
| `nix-shell-*` | 1003 | 988 |
| `nix-develop-*` | 1196 | 392 |
| `nix-[0-9]*` | 778 | 612 |
| `go-build*` | 114 | 98 |
| `chromedp-runner*` | 158 | 158 |
| `homelab-talos-prs-*` | 2554 | 2537 |

**Dry-run of the exact rule set: 4,255,261 entries removed, and ZERO matches** against `/tmp/wt-*`, `/tmp/claude-1000`, or the named project dirs (`civitai-integration`, `peakmaps`, `chunkcache`, `pnpmvar`, `audit187`). Estimated reclaim **~47 GB — a lower bound**, since the dry-run ran unprivileged and cannot see root-owned paths.

**Deliberately not covered:** `/tmp/claude-1000` (52 GB — the user's own session state, already covered by the stock 10d rule) and `/tmp/wt-*` (real worktrees; never age these automatically).

## Validated before staging

- Edit applied to a **copy of the live `configuration.nix`** → 777 → 788 lines, `nix-instantiate --parse` **OK**
- **Negative control:** anchor absent → exits 1 with a named error, file untouched
- **Idempotence:** marker present → second run skips
- `shellcheck` clean

## ⚠ Not run

The rebuild itself, so **no live reclaim has been measured** — the ~47 GB is a dry-run estimate. The rules are additive and delete nothing at switch time; cleanup happens on the next `systemd-tmpfiles-clean.timer` firing (or `systemctl start systemd-tmpfiles-clean.service`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)