### PR TITLE
test(browser-agent): the stall constant was measured on one host in one tier, and it decides every hung-vs-stalled verdict (#194)

### DIFF
--- a/scripts/browser-bridge/tests/test_browser_agent.py
+++ b/scripts/browser-bridge/tests/test_browser_agent.py
@@ -320,6 +320,20 @@ _SPAWN_PROBE_N = 10
 # 10 trivial spawns cost 0.085-0.105 s on this idle 24-core box (n=5, 2026-08-13).
 # 8x that is comfortably outside the idle spread and far below what a real stall
 # produces, so it does not read a busy-but-healthy box as stalled.
+#
+# 🔴 That was ONE host in ONE tier, and this constant decides every hung-vs-
+# stalled verdict in the file — so the scope it carries matters. Set it too low
+# and a healthy-but-busy box extends forever up to RUN_HARD_CAP instead of
+# reporting a real hang. Re-measured 2026-08-15 at the two points the first
+# measurement could not see (same probe, n=3-5 each):
+#   * inside a NIX BUILD SANDBOX — the tier the authoritative gate runs in, and
+#     the one the 2026-08-13 flake actually happened in: 0.099-0.113 s, taken
+#     while a devrc-pytests build was in flight (loadavg 15.5).
+#   * the LAPTOP host (8-core i7-1165G7, idle): 0.113-0.117 s.
+# So 0.10 holds across both hosts and both tiers, with ~7x headroom to the
+# 0.80 s threshold. For reference at the other end: 6 concurrent full runs of
+# this file plus 12 CPU hogs on the 24-core box only reached 0.14-0.22 s — a
+# busy box is nowhere near the threshold, which is the point.
 _SPAWN_IDLE_REF = 0.10
 _SPAWN_STALL_FACTOR = 8.0
 


### PR DESCRIPTION
## TL;DR — clawgate task #194 was already fixed. This PR is not that fix.

Task #194 asked to fix the 60s-timeout flake in `test_agent_def_denies_bash_allows_only_custom_tool`. **That was already done and merged**: `8291785` / PR #461, merged 2026-08-14T00:10:29Z, ~4h after the card was filed. `git merge-base --is-ancestor 8291785 origin/main` → true. The card was simply never written back to, so it sat `open` with zero comments and got re-dispatched.

I did **not** re-implement it. I re-verified it, and the one thing verification turned up is the comment-only change here.

## What this PR changes

Nothing that executes. `_SPAWN_IDLE_REF` keeps the value `0.10`. Only its comment grows, to carry the scope of the measurement behind it.

That constant decides *every* hung-vs-stalled verdict in the file (`base > _SPAWN_IDLE_REF * 8`) — it is the linchpin of #461's determinism argument. Its comment scoped itself to "this idle 24-core box": one host, in the dev-host tier. Neither is the tier that mattered — the 2026-08-13 flake happened inside the authoritative gate's **nix build sandbox**, and devrc also ships to the **laptop**. Wrong there and the hang-net silently degrades to the 900s hard cap in the one place the dev host cannot observe.

Measured at both, same probe:

| point | measurement |
|---|---|
| nix build **sandbox** (the gate's tier), taken during a live `devrc-pytests` build, loadavg 15.5 | **0.099–0.113 s** (n=5) |
| **laptop** host, 8-core i7-1165G7, idle | **0.113–0.117 s** (n=3) |
| busy 24-core box: 6 concurrent full runs of this file + 12 CPU hogs | 0.14–0.22 s |

`0.10` holds at both, ~7x below the 0.80 s threshold, and a busy box does not read as a stalled one.

## Verification of #461 (the actual fix), done independently

**The guard can still go red.** Injected `bash: allow` into `opencode/browser-agent.md` on a scratch copy → the test fails on **its own** assertion, not an earlier error:

```
>       assert "bash:" not in md, "the old bash permission block must be gone"
E       AssertionError: the old bash permission block must be gone
1 failed, 59 deselected in 0.25s
```

**Deterministic repro of the pre-fix mechanism, no load required.** Drove the OLD (pre-#461) and NEW wrappers under one identical hostile condition — a stray regular file at the warm-lock path — with the OLD rig's `subprocess.run(timeout=60)` semantics:

```
 old: subprocess.TimeoutExpired after  60.06s (deadline 60.0s)  <-- the #194 symptom
 new: EXITED rc=0 in   0.19s
new-: EXITED rc=0 in   0.19s   browser-agent: warm-lock-refused:unwaitable — …
```

`new-` is the new wrapper *without* the pre-warm, which isolates fix (1) from fix (2): even when the bootstrap does run, the lock now refuses instead of sleeping 120s. This reproduces the reported symptom exactly (`TimeoutExpired`, 60s) from a deterministic cause.

**Mutation controls re-run rather than trusted.** #461 self-reported a 12-mutant battery; the two guarding the mechanism that removes the wall-clock dependency were re-verified here, each red on the intended test:

- W10 (delete the run-wait stall extension) → `test_a_stalled_machine_extends_the_wait_instead_of_failing` red
- W12 (delete the poll stall extension) → `test_the_condition_poll_also_extends_on_a_stalled_machine` red

**Stability.** 30/30 consecutive runs of the target test (0.24–0.30 s each). 10/10 under contention. 6 concurrent full runs of the file, 60/60 each.

**Gate.** `nix build .#checks.x86_64-linux.pytests --rebuild`:

```
RESULT: all good
  TOTAL collected=10285  passed=10284  skipped=1  failed=0  (floor: 9311 = sum of 21 per-target floors)
RESULT: PASS (exit=0)
```

browser-bridge target: **502 passed in 171.58s** (card's pre-fix baseline 165.02s/493 idle; #461 reported 168.33s/498). No `panic: test timed out`. File re-run after this edit: 60 passed in 19.56s.

## NOT established

The contention reproduction **did not reach stall territory** — 6 concurrent suites + 12 hogs on 24 cores only moved the spawn probe to 0.14–0.22 s against a 0.80 s threshold, so it exercised concurrency, not a stall. It is evidence the suite survives contention, not evidence about the stall branch. That branch is covered instead by the two mutation-verified positive controls above, which force the probe rather than hoping the box cooperates. #461's own loadavg-65 reproduction (a measured 125.4 s wrapper invocation) remains the only observation of a real stall.

Also unchanged from #461: which of the two mechanisms produced that specific 60s on 2026-08-13 is still not established. One occurrence cannot distinguish them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)