### PR TITLE
docs(browser-bridge): the hosts converged, so five deployed-state lines went false

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -1650,12 +1650,13 @@ field** (the CDP ops are bounded typed ops only; see the CDP security model abov
   Because the gate runs **before** the tab is opened, a gate failure leaks no tab.
 
   *Prerequisite:* an opencode whose `debug agent` reports a browser-only tool set.
-  **Both hosts run 1.18.4 and both resolve browser-only** (verified: the dump
+  **Both hosts run 1.18.16 and both resolve browser-only** (verified: the dump
   parses to exactly one enabled tool, `browser`). There is no version-skew caveat
-  here any more. 🔴 1.18.4 is what the hosts RUN; `flake.lock` pins **1.18.16**
-  and they converge on the next `ship.sh` — merged is not deployed. The
-  browser-only resolution was re-derived on 1.18.16 too — identical resolved tool
-  set, on both binaries. 🔴 The RAW dump is NOT byte-stable, on either binary: the
+  here any more. The hosts CONVERGED on 2026-08-15 — `ship.sh` verified at the
+  consumer, both `readlink -f $(command -v opencode)` resolving to the same
+  `…-opencode-1.18.16` store path — so the pin and the deploy now agree. The
+  browser-only resolution was measured identical on 1.18.4 and 1.18.16, so the
+  bump did not change it. 🔴 The RAW dump is NOT byte-stable, on either binary: the
   `permission` array's order follows a directory walk and varies run to run, so
   `cmp` on two dumps differs for reasons that have nothing to do with the version.
   Compare the resolved tool set, or canonicalise first. So the deploy gap does not
@@ -1748,8 +1749,8 @@ ln -sf ~/workspace/devrc/scripts/browser-bridge/opencode/tools/browser_tool_impl
 the wrapper substitutes them per run.)
 
 **opencode version.** The custom-tool mechanism (`.opencode/tools/*.js`,
-`permission: {"*": deny, …}`) is **verified on 1.18.4, which is what BOTH hosts
-run today, and re-derived on the pinned 1.18.16** — `opencode debug agent
+`permission: {"*": deny, …}`) is **verified on 1.18.16, which is what BOTH hosts
+run and what `flake.lock` pins** (measured identical on 1.18.4 before the bump) — `opencode debug agent
 browser-agent` resolves to `bash:false … browser:true`
 (exactly one enabled tool) on each, plus an end-to-end `opencode debug agent …
 --tool browser` run against a fake bridge. The wrapper still writes the tool to

--- a/scripts/browser-bridge/reference/agent.md
+++ b/scripts/browser-bridge/reference/agent.md
@@ -26,9 +26,9 @@ command unrunnable, which is why fixing the first didn't appear to help:
    be reached. Fixed by probing without injecting.
 
 🔴 **Every doc misattributed both symptoms to an opencode *version* problem for the
-entire arc.** They are not version-related — both hosts run 1.18.4 and both
-resolve browser-only, and the same resolution was re-derived on the pinned
-1.18.16. Do not re-open that hypothesis.
+entire arc.** They are not version-related — both hosts run 1.18.16 and both
+resolve browser-only, and the same resolution was measured on 1.18.4 before the
+bump. Do not re-open that hypothesis.
 
 ✅ **The `browser agent`-first default IS shipped** (SKILL.md → `## FIRST DECISION`).
 It was held back until capability was measured rather than argued from token
@@ -174,9 +174,9 @@ browser agent "go to news.ycombinator.com and report the top 3 story titles" \
   fail-closed property is *verified at runtime* rather than trusted — on any
   opencode where the host-tool denial didn't take, `browser agent` refuses instead
   of running the model unconfined. The gate runs BEFORE the tab is opened, so a
-  gate failure leaks no tab. **Both hosts run 1.18.4 and both resolve
-  browser-only**, and it re-derives identically on the pinned 1.18.16 — there is
-  no version-skew caveat.
+  gate failure leaks no tab. **Both hosts run 1.18.16 and both resolve
+  browser-only**, and it resolved identically on 1.18.4 before the bump — there
+  is no version-skew caveat.
   - ⚠ **If you check the gate by hand, redirect to a FILE**
     (`opencode debug agent browser-agent > /tmp/gate.json`), never a pipe or
     `$(...)`: opencode doesn't reliably flush stdout before exiting into a pipe, so

--- a/scripts/tests/test_opencode_engine.py
+++ b/scripts/tests/test_opencode_engine.py
@@ -755,8 +755,20 @@ HISTORICAL_VERSION_CLAIMS = (
      "this test's own docstring, naming the bump it was written for"),
     ("scripts/tests/test_opencode_engine.py", "true at the merge-base",
      "the scope note's account of the claims this PR touched"),
-    ("scripts/tests/test_opencode_engine.py", "while the lock pins",
-     "this ledger's own record of the measured deploy gap"),
+    # The CONVERGENCE record. These lines now state the pinned version and cite
+    # the pre-bump one as evidence that the bump changed nothing — history, not a
+    # claim about what runs. Distinct from the deployed-state category above,
+    # which is gone: these do not stop being true on the next ship.
+    ("scripts/browser-bridge/README.md", "resolution was measured identical on",
+     "cites the pre-bump measurement as evidence the bump was a no-op"),
+    ("scripts/browser-bridge/README.md", "pins** (measured identical on",
+     "same, for the custom-tool claim"),
+    ("scripts/browser-bridge/reference/agent.md", "the same resolution was measured on",
+     "same, for the misattribution warning"),
+    ("scripts/browser-bridge/reference/agent.md", "and it resolved identically on",
+     "same, for the gate claim"),
+    ("scripts/tests/test_opencode_engine.py", 'Five lines said "both hosts run',
+     "this ledger's own record of the exemptions it used to carry"),
     ("scripts/browser-bridge/README.md", "opencode JSON envelope (verified live, opencode",
      "dated envelope-shape observation; not re-derived"),
     ("scripts/browser-bridge/reference/agent.md", "extension 0.2.0, `opencode`",
@@ -774,25 +786,19 @@ HISTORICAL_VERSION_CLAIMS = (
      "@-import claim, third copy"),
     ("scripts/tests/test_opencode_config.py", "NOT re-derived since — needs a live model call",
      "@-import claim, fourth copy"),
-    # 🔴 DEPLOYED-STATE claims — a category of their own, and the one this PR got
-    # wrong twice. A `flake.lock` bump changes what the lock PINS; it changes
-    # nothing about what a host RUNS until `home-manager switch` (this repo's
-    # CLAUDE.md: "Merged ≠ deployed"). MEASURED 2026-08-13: both hosts resolve
-    # /nix/store/64n428…-opencode-1.18.4 while the lock pins 1.18.16.
-    # An audit round called these "falsified by this PR" and they were not — they
-    # were TRUE. Rewriting them to "the pinned version" made them FALSE and, worse,
-    # UNCHECKABLE: with no literal left, nothing above can ever see them go stale.
-    # They track the DEPLOY, so they change on the next ship.sh, not on this merge.
-    ("scripts/browser-bridge/README.md", "and both resolve browser-only** (verified: the dump",
-     "deployed-state: what the hosts RUN, not what the lock pins"),
-    ("scripts/browser-bridge/README.md", "is what the hosts RUN",
-     "deployed-state: names the deploy gap explicitly"),
-    ("scripts/browser-bridge/README.md", "which is what BOTH hosts",
-     "deployed-state: what the hosts RUN"),
-    ("scripts/browser-bridge/reference/agent.md", "They are not version-related — both hosts run",
-     "deployed-state: what the hosts RUN"),
-    ("scripts/browser-bridge/reference/agent.md", "gate failure leaks no tab.",
-     "deployed-state: what the hosts RUN"),
+    # 🔴 THE DEPLOYED-STATE EXEMPTIONS ARE GONE, and their absence is the record.
+    # Five lines said "both hosts run 1.18.4" — TRUE while the lock pinned 1.18.16
+    # and the hosts had not converged, which is exactly why they were exempt
+    # rather than wrong. `ship.sh` converged both on 2026-08-15, verified at the
+    # CONSUMER (both `readlink -f $(command -v opencode)` resolve to the same
+    # …-opencode-1.18.16 store path), so those lines now carry the pinned version
+    # and need no exemption.
+    #
+    # The ledger caught its own obsolescence: the moment the lines were updated,
+    # all five entries orphaned and the suite went red. That is the SHRINK
+    # direction working, and the reason this category was named separately
+    # instead of filed under "historical" — a historical record never stops being
+    # true, a deployed-state claim stops the day you ship.
 )
 
 


### PR DESCRIPTION
`ship.sh` converged both hosts on 2026-08-15 and **verified at the consumer**, not at the deploy: `readlink -f $(command -v opencode)` on workbench *and* laptop both resolve to the same `…-opencode-1.18.16` store path, and the pin test that was red on the workbench (`assert '1.18.4' == '1.18.16'`) now passes. Managed artifacts 432 / 393, 0 dangling, 0 absent — per-host lines read individually, not the final verdict.

## What changed and why

Five lines in `scripts/browser-bridge/` said *"both hosts run 1.18.4"*. That was **true** while the lock pinned 1.18.16 and the hosts had not converged — which is exactly why they were *exempt* from the version guard rather than wrong — and it became **false** the moment `ship.sh` finished. They now state 1.18.16 and cite the pre-bump measurement as evidence the bump changed nothing, which is history and does not expire.

## 🔴 The ledger caught its own obsolescence

Updating the lines orphaned all five `DEPLOYED-STATE` exemptions and the suite went red immediately. That is the **shrink** direction working, and the reason the category was named separately instead of filed under "historical":

> a historical record never stops being true; a deployed-state claim stops the day you ship.

The exemptions are gone and their absence is the record. Five new entries cover the pre-bump citations that remain.

This consequence was written into the handoff *before* the convergence ran — "five DEPLOYED-STATE lines go false the moment it converges, and the ledger exempts them, so nothing will catch it." The ledger did catch it, because the exemptions themselves are asserted.

## Gate

`TOTAL collected=10302 passed=10301 skipped=1 failed=0` · `RESULT: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)