### PR TITLE
feat(hooks): prose lost 2/2 on the clawgate write-back, so gate it on the READ

### DIFF
--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -99,6 +99,10 @@ test gate, build/push, pin bump, the CSS-cwd trap that fakes ~25 e2e failures, c
 months because reading a task was one command while writing to it was a curl preamble; that
 asymmetry is gone (`task status` / `task comment` since 2026-08-14). Run it unprompted.
 
+🔴 **A hook ENFORCES this now** (`~/.claude/hooks/clawgate-writeback-guard.py`): armed by the
+step-1 **read**, it **blocks Stop** when work followed (edit/commit/push/PR) and a **live** re-read
+shows no `claude-code` comment since. Read-and-evaluate-only never fires; commenting silences it.
+
 🔴 **A COMMENT is the only write that notifies a watcher.** A status flip pushes **only** on
 *entering* `ready_for_review` (`notifyTaskDone`), so going `in_progress` notifies **nobody**. That is
 *why* the pre-start comment exists — it is Zach's only chance to object **before** the work happens,

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1057,6 +1057,33 @@ in
   home.file.".claude/hooks/agent_ledger.py" = {
     source = ../scripts/lib/agent_ledger.py;
   };
+  # 🔴 THE CLAWGATE WRITE-BACK GUARD — the deterministic replacement for a 🔴 prose
+  # rule that lost 2/2. Tasks #193 and #194 were both picked up, the work shipped as
+  # PRs, and both cards stayed `open` with ZERO comments; both were re-dispatched and
+  # paid for twice. `claude/skills/clawgate/SKILL.md` §"task pickup" already said the
+  # ritual was NOT optional. PRINCIPLES.md prefers a structural fix to prompt-tuning.
+  #
+  # 🔴 KEYED ON THE READ (`clawgatectl task get <N>` / a curl to `/api/tasks/<N>`),
+  # NOT on the `in_progress` flip. In both measured failures no status command was
+  # ever issued — the cards never left `open` — so a PreToolUse deny on the flip
+  # would have been structurally unreachable for the exact failure it was built for.
+  #
+  # Fires only when all three hold: the id was read, REAL work followed it (an
+  # Edit/Write/NotebookEdit, or a `git commit`/`git push`/`gh pr create`), and a LIVE
+  # re-read of the board shows no `claude-code` comment since that read. The middle
+  # condition is what keeps read-and-evaluate-only turns — the SKILL's own step 2 —
+  # untouched; the last is a measurement, so it self-suppresses the moment the ritual
+  # is followed, including by a subagent or a devpod agent. Escalates block, block,
+  # notice, silence per task per session, and NEVER blocks when the board could not
+  # be reached (it says so instead). Every error path exits 0.
+  #
+  # 🔴 A NEW file, so it must be `git add`ed or the flake silently omits it and the
+  # switch still succeeds with the hook absent — this repo's standing trap.
+  # Registered on PostToolUse (NO matcher — half of what it watches for is an Edit)
+  # and Stop, per-host, by register-nudge-hook.py.
+  home.file.".claude/hooks/clawgate-writeback-guard.py" = {
+    source = ../scripts/claude-hooks/clawgate-writeback-guard.py;
+  };
 
   # 🔴 THE REGISTRAR ITSELF — the hook that makes the hooks above DO anything.
   # settings.json is per-host and unmanaged (permissions/allowlists), so a hook

--- a/scripts/claude-hooks/clawgate-writeback-guard.py
+++ b/scripts/claude-hooks/clawgate-writeback-guard.py
@@ -98,9 +98,12 @@ subagent, and its edits and commits are exactly the evidence condition 2 needs.
 agent-ledger-hook.py already costs ~21 ms there. The fast path is: resolve the state
 dir from `session_id` (string work, no IO), ONE `os.path.exists`, and the trigger
 regex. A session that has never read a clawgate task and is not reading one now does
-nothing else — no directory creation, no state read, no subprocess, ever. That
-ordering is pinned by a test, because an earlier hook in this repo shipped with its
-throttle consulted AFTER the subprocess spawn while its comment claimed otherwise.
+nothing else — no directory creation, no state read, no subprocess, and it does not
+even IMPORT `subprocess` or `shutil` (see the deferred-import note below). That
+ordering is pinned by tests that COUNT the calls and read the module list out of
+`-X importtime`, because an earlier hook in this repo shipped with its throttle
+consulted AFTER the subprocess spawn while its comment claimed otherwise. Measured:
+13.9 ms/call against 8.6 ms for a bare interpreter start.
 
 🔴 FAIL-OPEN, ALWAYS. Every internal exception exits 0 with an empty stdout and
 blocks nothing. main() has exactly ONE exit and it is always 0. A hook that wedges a
@@ -123,10 +126,46 @@ import datetime
 import json
 import os
 import re
-import shutil
-import subprocess
 import sys
 import time
+
+# 🔴 DEFERRED IMPORTS, AND THE REASON IS THE HOT PATH. This hook runs after EVERY
+# tool call, so its import cost is paid thousands of times a day. Measured with
+# `python -X importtime` on this host: subprocess 3.4 ms, shutil 3.7 ms — 7.1 ms of
+# the ~11 ms this hook added over a bare interpreter start, and NEITHER is reachable
+# from the PostToolUse path. Both are Stop-only (the live read, and the state prune).
+# Measured end to end, 30 fast-path runs per sample, four samples: 19.0 ms/call before
+# this against 13.7/13.9/13.8/14.3 after, with a bare interpreter at 8.0-8.8 ms — i.e.
+# the hook's own overhead falls from ~11 ms to ~5.4 ms. `re` (2.4 ms) and `json`
+# (0.9 ms) stay: the trigger patterns compile at import and the payload is JSON on
+# stdin, so both are on the path that cannot avoid them.
+# `shutil` is loaded inside the REMOVAL, not at the top of prune(), so a Stop with
+# nothing stale to sweep never pays it either — pinned by the importtime test.
+subprocess = None
+shutil = None
+
+
+def _sp():
+    """`subprocess`, imported on first use. Bound to the MODULE attribute so a test
+    can still monkeypatch `guard.subprocess` once the Stop path has touched it.
+
+    No `if subprocess is None` memo guard: `import` IS the memo (every call after the
+    first is a `sys.modules` lookup), and a guard whose only effect is skipping that
+    lookup is a branch no mutation can kill — which reads as a coverage gap when it is
+    really just a duplicate of what the import statement already does.
+    """
+    global subprocess
+    import subprocess as _m
+    subprocess = _m
+    return subprocess
+
+
+def _sh():
+    """`shutil`, imported on first use — see `_sp`."""
+    global shutil
+    import shutil as _m
+    shutil = _m
+    return shutil
 
 # --------------------------------------------------------------------------- #
 # Tunables
@@ -349,7 +388,7 @@ def prune(ttl=STATE_TTL_SECS, now=None):
         try:
             if os.path.getmtime(path) >= cutoff:
                 continue
-            shutil.rmtree(path, ignore_errors=True)
+            _sh().rmtree(path, ignore_errors=True)
             removed.append(name)
         except Exception:                 # noqa: BLE001
             pass
@@ -417,7 +456,7 @@ def _env_file(path=CLAWGATE_ENV):
 
 
 def _via_clawgatectl(task_id, timeout):
-    proc = subprocess.run(["clawgatectl", "task", "get", str(int(task_id))],
+    proc = _sp().run(["clawgatectl", "task", "get", str(int(task_id))],
                           capture_output=True, text=True, timeout=timeout)
     if proc.returncode != 0:
         raise LiveReadError("clawgatectl rc=%d %s"
@@ -450,7 +489,7 @@ def _via_curl(task_id, timeout, env_path=CLAWGATE_ENV, why=None):
         'url = "%s/api/tasks/%d"\n' % (url.rstrip("/"), int(task_id)),
         'header = "Authorization: Bearer %s"\n' % token,
     ])
-    proc = subprocess.run(["curl", "-K", "-"], input=cfg,
+    proc = _sp().run(["curl", "-K", "-"], input=cfg,
                           capture_output=True, text=True, timeout=timeout + 2)
     if proc.returncode != 0:
         raise LiveReadError("curl rc=%d" % proc.returncode)
@@ -459,6 +498,11 @@ def _via_curl(task_id, timeout, env_path=CLAWGATE_ENV, why=None):
 
 def live_task(task_id, timeout=PER_TASK_TIMEOUT_SECS, env_path=CLAWGATE_ENV):
     """Live re-read of one task. Raises LiveReadError when it cannot be measured."""
+    # Bound BEFORE the try: the `except subprocess.TimeoutExpired` clauses below name
+    # the module attribute, and an except clause is evaluated even when the exception
+    # came from the import itself — at which point a still-None `subprocess` would
+    # raise AttributeError out of the handler and defeat the fail-open contract.
+    _sp()
     why = None
     try:
         return _via_clawgatectl(task_id, timeout)

--- a/scripts/claude-hooks/clawgate-writeback-guard.py
+++ b/scripts/claude-hooks/clawgate-writeback-guard.py
@@ -26,9 +26,11 @@ WHAT FIRES IT — THREE CONDITIONS, ALL REQUIRED
 -----------------------------------------------
   1. the session READ a specific clawgate task id (above), and
   2. REAL WORK happened after that read — an Edit/Write/NotebookEdit tool call, or a
-     Bash `git commit` / `git push` / `gh pr create`, and
+     Bash `git commit` / `git push` / `gh pr create|merge` / `gh release create`
+     **in command position, outside quotes and comments** (see WORK_BASH_PAT), and
   3. a LIVE re-read of the board at Stop shows NO comment authored by `claude-code`
-     with `createdAt` at or after the first read.
+     with `createdAt` at or after the MOST RECENT WORK EVENT (not merely at or after
+     the read — see the anchor note below).
 
 Condition 2 is the false-positive killer and it is not optional. The SKILL's own
 step 2 is "EVALUATE and report to Zach. Do NOT flip status yet" — a session that
@@ -41,6 +43,18 @@ board says so and the guard goes quiet, including for a comment written by a
 different process, a subagent, or a devpod agent. A hook that tracked only its own
 observations would keep firing after the work was correctly written back.
 
+🔴 THE COMPARISON ANCHOR IS THE LAST WORK EVENT, NOT THE READ — and that is a fix,
+not a detail. The clawgate skill's own pickup ritual posts a **"Starting" comment
+immediately after the read and BEFORE the work**. Anchored on the read, that comment
+satisfies the guard at pickup and the hook can then never observe a missing
+COMPLETION write-back: its forward yield on every ritual-following session is zero,
+which is the opposite of what it was built for. Anchored on the last work event,
+`Starting -> work -> Stop` correctly owes a comment and `Starting -> work -> Done ->
+Stop` is satisfied. The CLOCK_SKEW_ALLOWANCE_SECS below is doing real work on this
+path: a `Done` comment followed within the allowance by a `git push` is still
+satisfied, so only work that lands well AFTER the last comment re-arms the guard.
+Bounded, not free — see MULTI-TURN COST below.
+
 🔴 A LIVE READ THAT FAILS IS NOT A CLEAN BILL OF HEALTH. Unreachable board, no
 client, unparseable JSON — all of those mean "could not measure", and this hook says
 so out loud with a NON-BLOCKING notice rather than going silent. RULES.md: an empty
@@ -49,16 +63,50 @@ down" is reporting the same observable as "the ritual was followed".
 
 ESCALATION LADDER — per session, per task id
 ---------------------------------------------
-    fire 1  ->  decision: block      (the turn does not end; `reason` reaches the model)
-    fire 2  ->  decision: block
-    fire 3  ->  additionalContext    (non-blocking; the turn ends)
+    fire 1  ->  decision: block      (FORCED CONTINUATION; `reason` reaches the model)
+    fire 2  ->  decision: block      (FORCED CONTINUATION)
+    fire 3  ->  systemMessage        (the turn ENDS; operator sees it, model does not)
     fire 4+ ->  silent
+
+    TRUE COST of a measured missing write-back: exactly TWO forced continuations.
+    TRUE COST of a "could not measure" notice:  ZERO forced continuations, and it
+    runs on its OWN counter (`unknown-<id>`), so a board that is down for the first
+    Stops cannot spend the block budget a genuinely missing write-back needs later.
+
+🔴 `additionalContext` IS NOT A NON-BLOCKING CHANNEL ON Stop, AND THE FIRST VERSION
+OF THIS FILE WAS WRONG ABOUT THAT. Re-derived from the installed bundle (see the
+controls below), `Ycd` — the Stop-hook driver — pushes an `additionalContexts` entry
+into the SAME array as a `blockingError`:
+
+    if (F.blockingError)      { …; E.push(G); … }
+    if (F.additionalContexts) { …; E.push(j); … }
+    …
+    if (E.length > 0) return { blockingErrors: E, preventContinuation: !1 };
+
+and its caller treats ANY non-empty `blockingErrors` as a forced continuation —
+re-querying the model with `stopHookActive:!0` and incrementing the very counter
+that `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` (default 8) bounds. So the old "relent" rung
+did not relent: an unreachable board cost THREE forced continuations, not zero.
+
+`systemMessage` is the channel that genuinely does not. In the same bundle it is
+yielded on the MESSAGE channel, never into `E`:
+
+    if (j.systemMessage) yield { message: Va({ type:"hook_system_message", … }) };
+
+`Ycd` yields `F.message` straight through and pushes nothing, so `E` stays empty and
+the caller returns `{reason:"completed"}` — the turn ends. It is rendered to the
+operator as `"<hookName> says: <content>"`, and its attachment-to-messages entry is
+`hook_system_message: () => []`, i.e. it is NOT fed back to the model. That is the
+right shape for a rung whose whole job is to stop nagging the model and tell the
+human instead.
 
 Derived from the INSTALLED CLI bundle, not from documentation (claude-code 2.1.220,
 `bin/.claude-wrapped` — NOT the 20 KB `bin/claude` wrapper, a grep against which
-returns a meaningless zero). Both controls were run against the 275 MB bundle before
-any of this was believed: positive `hookEventName` -> 68 matches, negative
-`zzzNOTPRESENTzzz_devrc_control` -> 0.
+returns a meaningless zero). Both controls were re-run against the 275 MB bundle
+before ANY of the above was believed a second time: positive
+`CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` -> 5 matches, negative
+`zzQuuxNotPresentNonce9137` -> 0. (`ugrep` chokes on `.{N}` against a binary this
+size; the reads were done with plain `bytes.find` in Python.)
 
   * The hook output schema is a top-level object, NOT a hookSpecificOutput arm:
         v.object({continue: …, suppressOutput: …, stopReason: …,
@@ -77,7 +125,8 @@ any of this was believed: positive `hookEventName` -> 68 matches, negative
         if (Kt > 0 && yo > Kt) … "A hook blocked the turn from ending N consecutive
         times — overriding and ending turn."
     Our MAX_BLOCKS = 2 is deliberately far stricter than that 8. A guard that has to
-    be overridden by the harness has already lost the operator.
+    be overridden by the harness has already lost the operator. 🔴 That cap counts
+    `additionalContext` rungs TOO — which is why fire 3 is a `systemMessage`.
 
 🔴 THERE IS DELIBERATELY NO `stop_hook_active` GATE, and that is the one place this
 hook diverges from the CLI's own advice ("check stop_hook_active and return success
@@ -89,21 +138,64 @@ matters. The interaction with MAX_TASKS is named rather than hidden: several tas
 each blocking twice can in principle stack toward the CLI's 8, at which point the
 CLI ends the turn with a warning — a graceful ceiling, not a wedge.
 
-🔴 SubagentStop IS REFUSED. A subagent's turn never reaches the operator, so it owes
-them nothing (next-step-nudge.py refuses it for the same reason). PostToolUse is NOT
-refused for subagents: in both measured failures the work ran in a dispatched
-subagent, and its edits and commits are exactly the evidence condition 2 needs.
+🔴 SubagentStop IS REFUSED, AND SO IS EVERY PostToolUse CARRYING AN `agent_id`.
+A subagent's turn never reaches the operator, so it owes them nothing
+(next-step-nudge.py refuses SubagentStop for the same reason). The PostToolUse half
+is the one that was WRONG in the first version of this file, and it was wrong
+structurally rather than by degree: the bundle builds every hook payload through
+
+    function Kf(e, t, r) { … return { session_id: t ?? kt(), …,
+                                      agent_id: r?.agentId, agent_type: … } }
+
+and PostToolUse calls it as `{...Kf(i, void 0, o), hook_event_name:"PostToolUse", …}`
+— second argument `void 0`. So a tool call made INSIDE a dispatched subagent arrives
+carrying the PARENT's `session_id`, with only `agent_id` to tell them apart; the
+bundle's own schema says as much ("Use this field (not agent_type) to distinguish
+subagent calls from main-thread calls"). Accepting those armed the PARENT session's
+work flag off a subagent that merely happened to edit a file, and the parent's Stop
+then blocked on a card the parent never touched. MEASURED as a false positive.
+
+🔴 SCOPE OF THE WORK FLAG — SESSION-WIDE, NOT PER-TASK, AND THAT IS A KNOWN COST.
+Nothing in a PostToolUse payload says WHICH task an edit belongs to, so "work
+happened" is necessarily a session-level fact. Two shapes therefore still fire
+without the session owing anything, and both are TESTED rather than hoped away:
+  * read task N, then do unrelated work in a different repo -> blocks on N;
+  * survey N and M, work on and write back only M -> blocks naming N.
+The escape is not prose. `--dismiss` (below) is a real, deterministic mechanism, it
+is named in the block text with the session id already filled in, and it clears that
+task from this session's ledger for good. The previous escape — "if you did NOT do
+work on this task, say so in one line and stop" — was measured NOT to work: the next
+Stop re-blocked with identical text, because saying something changes no state.
+
+MULTI-TURN COST OF THE WORK ANCHOR
+-----------------------------------
+Work that spans several turns fires once per turn until the per-task ladder is spent:
+at most TWO forced continuations and one `systemMessage`, then silence forever for
+that task in that session. A `Done` comment written within CLOCK_SKEW_ALLOWANCE_SECS
+of the last work event already satisfies it, so the shape that actually costs is
+"comment, then keep working for more than the allowance, then stop" — which is a turn
+whose write-back genuinely is stale. Pinned by tests, so the noise is measured rather
+than discovered in production.
 
 🔴 HOT PATH. PostToolUse fires after EVERY tool call of every session, and
-agent-ledger-hook.py already costs ~21 ms there. The fast path is: resolve the state
-dir from `session_id` (string work, no IO), ONE `os.path.exists`, and the trigger
-regex. A session that has never read a clawgate task and is not reading one now does
-nothing else — no directory creation, no state read, no subprocess, and it does not
-even IMPORT `subprocess` or `shutil` (see the deferred-import note below). That
-ordering is pinned by tests that COUNT the calls and read the module list out of
-`-X importtime`, because an earlier hook in this repo shipped with its throttle
-consulted AFTER the subprocess spawn while its comment claimed otherwise. Measured:
-13.9 ms/call against 8.6 ms for a bare interpreter start.
+agent-ledger-hook.py already costs ~21 ms there. The fast path is: refuse anything
+carrying an `agent_id` (one dict read), resolve the state dir from `session_id`
+(string work, no IO), ONE `os.path.exists`, and the trigger regex. A session that has
+never read a clawgate task and is not reading one now does nothing else — no
+directory creation, no state read, no subprocess, and it does not even IMPORT
+`subprocess` or `shutil` (see the deferred-import note below). That ordering is
+pinned by tests that COUNT the calls and read the module list out of `-X importtime`,
+because an earlier hook in this repo shipped with its throttle consulted AFTER the
+subprocess spawn while its comment claimed otherwise.
+
+Re-measured 2026-08-16 after the audit round, 30 runs per sample, four samples, on
+this host: 14.30 / 14.56 / 14.33 / 14.62 ms per call, against 14.57 / 14.43 / 14.14 /
+14.03 for the PRE-audit file measured in the same session and 7.7-8.2 ms for a bare
+interpreter start. I.e. PARITY — the run-to-run spread (~0.5 ms) is wider than the
+difference. Getting there took one deliberate change: the three work-detection
+patterns moved from module-level `re.compile` to pattern STRINGS compiled on first
+use, because none of them is reachable from the fast path (see their note below). A
+first cut with them compiled at import measured 14.7 against 13.9.
 
 🔴 FAIL-OPEN, ALWAYS. Every internal exception exits 0 with an empty stdout and
 blocks nothing. main() has exactly ONE exit and it is always 0. A hook that wedges a
@@ -115,12 +207,15 @@ WHAT THIS STRUCTURALLY CANNOT SEE (say it here, not in a report nobody re-reads)
   * a session that read the task via a route neither trigger matches (the board UI,
     an `/api/tasks?summary=1` list, someone pasting the body in);
   * whether the comment that DOES exist is any good — it checks that a `claude-code`
-    comment exists since the read, never what it says;
-  * the `in_progress` flip and the pre-start comment, neither of which it requires:
-    it gates the WRITE-BACK, which is the thing that was measured missing.
+    comment exists after the last work event, never what it says;
+  * WHICH task a given edit belongs to (see SCOPE OF THE WORK FLAG above);
+  * the `in_progress` flip, which it does not require: it gates the WRITE-BACK, which
+    is the thing that was measured missing.
 
 Deployed by `nix/home.nix`; registered on PostToolUse (no matcher) + Stop by
-`register-nudge-hook.py`.
+`register-nudge-hook.py`. It has ONE other mode, and it is not a hook mode:
+
+    clawgate-writeback-guard.py --dismiss <task_id> --session <session_id>
 """
 import datetime
 import json
@@ -192,8 +287,22 @@ MAX_TASKS = 5
 
 # Wall-clock budget for ALL live reads on one Stop, and the ceiling for any single
 # one. A Stop hook that hangs is felt at the exact moment a session is trying to end.
+#
+# 🔴 NEITHER IS THE REAL WORST CASE, AND SAYING 8.0 OUT LOUD WAS WRONG. The budget is
+# only ever consulted BEFORE a read starts, so a read admitted with 0.01 s left can
+# still run for its full per-task ceiling; and `_via_curl` gives its `subprocess.run`
+# a hard kill at `timeout + 2` so an unkillable curl cannot outlive the wait. The
+# bound a Stop can actually hang for is therefore
+#     STOP_BUDGET_SECS + PER_TASK_TIMEOUT_SECS + 2  =  15.0 s
+# against the CLI's own 600 000 ms hook timeout (`var Hm=600000` in the bundle), which
+# is the only other thing bounding it. Both numbers are pinned by tests that exercise
+# the DEFAULTS — the ladder tests inject `budget=3.0` and a fake clock, so for a while
+# nothing executed these values at all and both survived being multiplied by 75.
 STOP_BUDGET_SECS = 8.0
 PER_TASK_TIMEOUT_SECS = 5.0
+# The margin `_via_curl` adds on top of curl's own `max-time`, so the wait outlives
+# the client's self-imposed deadline rather than racing it.
+CURL_KILL_MARGIN_SECS = 2
 
 # The board's `createdAt` comes from the SERVER clock; `first_read_ts` is written
 # from THIS host's clock. Comparing them across even a small skew would let a
@@ -225,18 +334,57 @@ CLAWGATE_ENV = "~/.claude/clawgate.env"
 # --------------------------------------------------------------------------- #
 TASK_GET_RX = re.compile(r"\bclawgatectl\s+task\s+get\s+(\d+)\b")
 # `\b` after the id is what keeps `/api/tasks/193abc` out while admitting the
-# trailing segment shapes that exist (`/api/tasks/193/comments`, `/193`).
+# trailing segment shapes that exist. `/api/tasks/<id>/comments` is one of them — it
+# is 405 on GET (POST-only, per the clawgate skill's task-api reference), so as a
+# READ it cannot occur; what it really matches is a curl POSTING a comment, which is
+# the write-back itself. Admitting that is harmless in both directions: the live read
+# then finds the comment and the guard stays silent.
 TASK_API_RX = re.compile(r"/api/tasks/(\d+)\b")
 
 # Tool calls that ARE work, by name.
 WORK_TOOLS = ("Edit", "Write", "NotebookEdit")
 
-# ...and by Bash command. Anchored on the SUBCOMMAND immediately after `git` (with
-# an allowance for `-C <path>` / `--git-dir=…` style global flags), so
-# `git log --oneline | grep commit` is not work and `git -C $DEVRC commit -m …` is.
-WORK_BASH_RX = re.compile(
-    r"\bgit\s+(?:-[A-Za-z]\s+\S+\s+|--[A-Za-z][-\w]*(?:=\S+)?\s+)*(?:commit|push)\b"
-    r"|\bgh\s+pr\s+create\b")
+# 🔴 MATCHING THE LITERAL TEXT ANYWHERE IN A BASH COMMAND IS NOT "IS THIS WORK", AND
+# THE FIRST VERSION OF THIS FILE DID EXACTLY THAT. `grep -rn 'git commit' scripts/`,
+# `rg 'gh pr create' claude/skills/` and `git log --grep='git push'` all armed the
+# work flag — and those exact strings live in this repo's own RULES.md and CLAUDE.md,
+# so grepping for them is routine rather than exotic. Seven such over-matches were
+# measured. Two deterministic narrowings, in this order:
+#
+#   1. QUOTED STRINGS AND COMMENTS ARE BLANKED FIRST (`_strip_literals`). A command
+#      that merely mentions `git commit` inside quotes, or after a `#`, is talking
+#      about work, not doing it.
+#   2. THE VERB MUST BE IN COMMAND POSITION — string start, or after a shell
+#      separator (`; & | ( ) { } newline backtick $(`), optionally through one of the
+#      keywords that legitimately precede a command (`then`/`else`/`do`/`!`). An
+#      unquoted `echo remember to git commit later` is not a commit.
+#
+# Within `git` itself the match is still anchored on the SUBCOMMAND, allowing
+# `-C <path>` / `--git-dir=…` global flags, so `git log --oneline` is not work and
+# `git -C $DEVRC commit -m …` is. `gh pr merge` and `gh release create` are here
+# because they ship things and their absence was a fail-open under-match.
+# 🔴 THESE THREE ARE PATTERN STRINGS, NOT COMPILED OBJECTS, AND THAT IS THE HOT PATH
+# AGAIN. Unlike TASK_GET_RX/TASK_API_RX above — which `task_read_ids` consults BEFORE
+# the fast-path return and so cannot avoid — every one of these is reachable only from
+# `is_work`, i.e. only for a session that has already read a clawgate task. Compiling
+# them at import made every tool call in every session pay for three regexes almost
+# none of them would use: MEASURED at 14.7 ms/call against 13.9 before, on a path that
+# runs thousands of times a day. `re.sub`/`re.search` on a string pattern compile once
+# and hit `re`'s own cache thereafter, so a session that DOES work pays exactly what it
+# paid when they were module-level `re.compile` calls.
+_CMD_START = r"(?:^|[\n;&|(){}`]|\$\()\s*(?:(?:then|else|do|!)\s+)*"
+WORK_BASH_PAT = (
+    _CMD_START
+    + r"git\s+(?:-[A-Za-z]\s+\S+\s+|--[A-Za-z][-\w]*(?:=\S+)?\s+)*(?:commit|push)\b"
+    r"|" + _CMD_START
+    + r"gh\s+(?:pr\s+(?:create|merge)|release\s+create)\b")
+
+# Single-quoted runs, and double-quoted runs with backslash escapes. Replaced by a
+# SPACE rather than deleted, so `-m'x'commit` cannot be welded into a false match.
+QUOTED_PAT = r"'[^']*'|\"(?:[^\"\\]|\\.)*\""
+# A `#` at the start of the string or after whitespace, to end of line. Applied AFTER
+# the quote strip, so a `#` living inside a quoted string is already gone.
+COMMENT_PAT = r"(?:^|(?<=\s))#[^\n]*"
 
 STATE_WORK = "work"
 
@@ -265,8 +413,13 @@ def _read_path(state_dir, task_id):
     return os.path.join(state_dir, "read-%d" % int(task_id))
 
 
-def _fires_path(state_dir, task_id):
-    return os.path.join(state_dir, "fires-%d" % int(task_id))
+def _fires_path(state_dir, task_id, kind="fires"):
+    """`fires-<id>` for a MEASURED missing write-back, `unknown-<id>` for a
+    could-not-measure notice. 🔴 Two counters, deliberately: sharing one let a board
+    that was merely unreachable for the first Stops spend the budget a genuinely
+    missing write-back needs later, so the case the hook exists for could no longer
+    be blocked in that session."""
+    return os.path.join(state_dir, "%s-%d" % (kind, int(task_id)))
 
 
 def now_iso(now=None):
@@ -279,17 +432,22 @@ def parse_ts(s):
     """RFC3339 -> epoch seconds, or None.
 
     The board emits Go's `time.RFC3339Nano` (`2026-08-15T04:27:49.005565Z`), which
-    can carry up to nine fractional digits; `datetime.fromisoformat` accepts at most
-    six, so the tail is trimmed rather than allowed to fail the whole comparison.
+    can carry up to nine fractional digits.
+
+    🔴 THE NANOSECOND TRIM THAT USED TO LIVE HERE IS GONE, AND SO IS THE CLAIM THAT
+    JUSTIFIED IT. "`datetime.fromisoformat` accepts at most six [fractional digits]"
+    was true up to CPython 3.10 and is FALSE on the interpreter this repo pins
+    (`python312` in flake.nix; measured on 3.12.13: `.000000000` parses, and
+    `.12345678` is truncated to microseconds rather than rejected). The trim was
+    therefore dead code whose only visible effect was a mutation-sweep survivor —
+    setting its match result to None changed nothing, because the try block below had
+    always been doing the whole job. The nine-digit case is still pinned by a test.
     """
     if not isinstance(s, str) or not s.strip():
         return None
     t = s.strip()
     if t.endswith("Z") or t.endswith("z"):
         t = t[:-1] + "+00:00"
-    m = re.match(r"^(.*\.\d{1,6})\d*([+-]\d{2}:?\d{2})?$", t)
-    if m:
-        t = m.group(1) + (m.group(2) or "")
     try:
         dt = datetime.datetime.fromisoformat(t)
     except ValueError:
@@ -325,11 +483,14 @@ def record_read(state_dir, task_id, now=None):
     """Record the FIRST read of `task_id`. Idempotent: a later read never moves the
     timestamp, because the window this hook measures over starts at the first one."""
     path = _read_path(state_dir, task_id)
+    # ONE existence check, not two. The second (post-`makedirs`) copy that used to sit
+    # below was provably redundant — `makedirs(exist_ok=True)` cannot create or delete
+    # THIS file — so neither copy could be killed by a mutation: deleting either left
+    # the other answering identically. The cheap one is kept, so a re-read of an
+    # already-recorded task still costs no `makedirs`.
     if os.path.exists(path):
         return False
     os.makedirs(state_dir, exist_ok=True)
-    if os.path.exists(path):
-        return False
     if len([n for n in os.listdir(state_dir) if n.startswith("read-")]) >= MAX_TASKS:
         return False
     tmp = path + ".tmp"
@@ -339,19 +500,35 @@ def record_read(state_dir, task_id, now=None):
     return True
 
 
-def record_work(state_dir):
+def record_work(state_dir, now=None):
+    """Stamp the LATEST work event. The file used to hold the literal `"1"`; it now
+    holds an RFC3339 timestamp, because "was there a comment since the work" needs a
+    when and not just a whether — see the anchor note in the module docstring. Every
+    work tool call overwrites it, so the value is the MOST RECENT work, which is the
+    one a completion write-back has to be newer than."""
     os.makedirs(state_dir, exist_ok=True)
     with open(os.path.join(state_dir, STATE_WORK), "w") as fh:
-        fh.write("1")
+        fh.write(now_iso(now))
 
 
 def work_after_read(state_dir):
     return os.path.exists(os.path.join(state_dir, STATE_WORK))
 
 
-def bump_fires(state_dir, task_id):
+def last_work_ts(state_dir):
+    """The stamp `record_work` wrote, or None. None is the FAIL-QUIET direction: a
+    truncated write, or state left by a build that wrote `"1"`, falls back to the read
+    anchor rather than inventing a stricter cutoff out of an unreadable file."""
+    try:
+        with open(os.path.join(state_dir, STATE_WORK)) as fh:
+            return fh.read().strip() or None
+    except Exception:                     # noqa: BLE001
+        return None
+
+
+def bump_fires(state_dir, task_id, kind="fires"):
     """Read-increment-write the per-task fire counter; returns the NEW 1-based count."""
-    path = _fires_path(state_dir, task_id)
+    path = _fires_path(state_dir, task_id, kind)
     n = 0
     try:
         with open(path) as fh:
@@ -366,6 +543,26 @@ def bump_fires(state_dir, task_id):
     except Exception:
         pass
     return n
+
+
+def dismiss(state_dir, task_id):
+    """Clear ONE task from ONE session's ledger. Returns the file names removed.
+
+    🔴 THIS IS THE ESCAPE HATCH, AND IT HAS TO BE A MECHANISM. The block text used to
+    say "if you did NOT do work on this task, say so in one line and stop" — measured
+    NOT to work, because saying something changes no state and the next Stop re-blocked
+    with identical text. Removing `read-<id>` is what actually ends it: `tracked_ids`
+    no longer yields the task, so no live read, no counter, no verdict, forever.
+    """
+    removed = []
+    for name in ("read-%d" % int(task_id), "fires-%d" % int(task_id),
+                 "unknown-%d" % int(task_id)):
+        try:
+            os.remove(os.path.join(state_dir, name))
+            removed.append(name)
+        except Exception:                 # noqa: BLE001 — absent is the common case
+            pass
+    return removed
 
 
 def prune(ttl=STATE_TTL_SECS, now=None):
@@ -396,11 +593,18 @@ def prune(ttl=STATE_TTL_SECS, now=None):
 
 
 def escalate(fire_number):
-    """1-based fire number -> "block" | "context" | "silent"."""
+    """1-based fire number -> "block" | "notice" | "silent".
+
+    "notice" is the rung that RELENTS. It used to be named "context" and emitted
+    `hookSpecificOutput.additionalContext`, which the CLI feeds into the same
+    `blockingErrors` array as `decision:"block"` — so it forced a third continuation
+    instead of letting the turn end. It now emits `systemMessage`. See the module
+    docstring for the bundle reads, both controls, and why that channel is different.
+    """
     if fire_number <= MAX_BLOCKS:
         return "block"
     if fire_number <= MAX_FIRES:
-        return "context"
+        return "notice"
     return "silent"
 
 
@@ -422,6 +626,12 @@ def task_read_ids(data):
     return out
 
 
+def _strip_literals(cmd):
+    """Blank out quoted runs and trailing `#` comments, so a command that MENTIONS a
+    work verb is not mistaken for one that RUNS it. See WORK_BASH_PAT's note."""
+    return re.sub(COMMENT_PAT, " ", re.sub(QUOTED_PAT, " ", cmd))
+
+
 def is_work(data):
     """True when this PostToolUse payload is REAL WORK, not a read or a look-around."""
     d = data or {}
@@ -430,7 +640,9 @@ def is_work(data):
     if d.get("tool_name") != "Bash":
         return False
     cmd = (d.get("tool_input") or {}).get("command")
-    return isinstance(cmd, str) and bool(WORK_BASH_RX.search(cmd))
+    if not isinstance(cmd, str):
+        return False
+    return bool(re.search(WORK_BASH_PAT, _strip_literals(cmd)))
 
 
 # --------------------------------------------------------------------------- #
@@ -455,18 +667,35 @@ def _env_file(path=CLAWGATE_ENV):
     return conf
 
 
+def _scrub(s, limit=120):
+    """Third-party stderr, made safe to splice into text an operator will read.
+
+    🔴 `proc.stderr` is an UNFILTERED PIPE OUT OF A BINARY THIS HOOK DOES NOT OWN, and
+    it used to go straight into the reason string. Control bytes (a `\\r`, an ANSI
+    escape, a stray newline) let that binary's output impersonate structure in the
+    transcript. Collapse to single-space-separated printables, then truncate.
+    """
+    return " ".join((s or "").split())[:limit]
+
+
 def _via_clawgatectl(task_id, timeout):
     proc = _sp().run(["clawgatectl", "task", "get", str(int(task_id))],
                           capture_output=True, text=True, timeout=timeout)
     if proc.returncode != 0:
         raise LiveReadError("clawgatectl rc=%d %s"
-                            % (proc.returncode, (proc.stderr or "").strip()[:120]))
+                            % (proc.returncode, _scrub(proc.stderr)))
     return json.loads(proc.stdout)
 
 
 def _via_curl(task_id, timeout, env_path=CLAWGATE_ENV, why=None):
-    """The fallback for a host with no `clawgatectl` (the laptop today — its
-    homelab-talos checkout predates the command, so nix does not build it).
+    """The fallback for a host with no `clawgatectl` on PATH.
+
+    That used to say "the laptop today — its homelab-talos checkout predates the
+    command, so nix does not build it", and that is now STALE: `clawgatectl` was
+    verified present on BOTH hosts. The fallback stays anyway — it costs nothing on a
+    host that has the binary (it is only reached once `clawgatectl` has failed or is
+    absent), and "the client is missing" is not the only way to arrive here: a
+    `clawgatectl` that exists and exits non-zero lands here too.
 
     🔴 The token goes in on STDIN via `curl -K -`, never in argv: an argv is visible
     to every process on the box through /proc, and this runs after every turn.
@@ -489,8 +718,12 @@ def _via_curl(task_id, timeout, env_path=CLAWGATE_ENV, why=None):
         'url = "%s/api/tasks/%d"\n' % (url.rstrip("/"), int(task_id)),
         'header = "Authorization: Bearer %s"\n' % token,
     ])
-    proc = _sp().run(["curl", "-K", "-"], input=cfg,
-                          capture_output=True, text=True, timeout=timeout + 2)
+    # 🔴 `timeout + CURL_KILL_MARGIN_SECS`, not `timeout`: curl's own `max-time` above
+    # is the deadline we WANT it to honour, and the wait has to outlive it or the
+    # SIGKILL races the clean exit and we lose curl's rc. Deleting the margin survived
+    # a mutation sweep until a test pinned the two numbers apart.
+    proc = _sp().run(["curl", "-K", "-"], input=cfg, capture_output=True, text=True,
+                     timeout=timeout + CURL_KILL_MARGIN_SECS)
     if proc.returncode != 0:
         raise LiveReadError("curl rc=%d" % proc.returncode)
     return json.loads(proc.stdout)
@@ -526,8 +759,16 @@ def live_task(task_id, timeout=PER_TASK_TIMEOUT_SECS, env_path=CLAWGATE_ENV):
         raise LiveReadError("%s: %s" % (type(e).__name__, e))
 
 
-def writeback_state(task, first_read_ts, skew=CLOCK_SKEW_ALLOWANCE_SECS):
+def writeback_state(task, first_read_ts, skew=CLOCK_SKEW_ALLOWANCE_SECS,
+                    work_ts=None):
     """"closed" | "written" | "missing" | "unknown" for one live task payload.
+
+    🔴 THE CUTOFF IS THE LATER OF THE FIRST READ AND THE LAST WORK EVENT. Anchoring on
+    the read alone is what let the skill's own pre-start "Starting" comment — posted
+    right after the read and BEFORE the work — satisfy this check at pickup, so the
+    guard could never observe a missing COMPLETION write-back on any session that
+    followed the ritual. `work_ts` is optional and a None (or unparseable) value falls
+    back to the read anchor, which is the quieter of the two.
 
     🔴 An UNPARSEABLE `createdAt` on a `claude-code` comment resolves to "written",
     not to "missing". The comment demonstrably exists and only its timestamp is
@@ -541,7 +782,11 @@ def writeback_state(task, first_read_ts, skew=CLOCK_SKEW_ALLOWANCE_SECS):
     read_at = parse_ts(first_read_ts)
     if read_at is None:
         return "unknown"
-    cutoff = read_at - skew
+    anchor = read_at
+    worked_at = parse_ts(work_ts)
+    if worked_at is not None and worked_at > anchor:
+        anchor = worked_at
+    cutoff = anchor - skew
     comments = task.get("comments")
     if comments is None:
         comments = []
@@ -561,36 +806,58 @@ def writeback_state(task, first_read_ts, skew=CLOCK_SKEW_ALLOWANCE_SECS):
 # --------------------------------------------------------------------------- #
 # The text the operator's model actually reads
 # --------------------------------------------------------------------------- #
-def missing_text(task_id, first_read_ts):
+def dismiss_cmd(task_id, session_id):
+    """The ONE command that deterministically clears a task from this session.
+
+    🔴 The session id is INTERPOLATED rather than left as a placeholder. A model
+    cannot see its own hook payload, so a command it has to fill in a session id for
+    is a command it cannot run — which is how the previous escape ("say so and stop")
+    ended up being no escape at all.
+    """
+    return ("python3 ~/.claude/hooks/clawgate-writeback-guard.py --dismiss %d "
+            "--session %s" % (int(task_id), _sanitize(session_id)))
+
+
+def missing_text(task_id, first_read_ts, session_id=""):
     return (
         "clawgate write-back MISSING for task %(id)d.\n"
-        "This session read task %(id)d at %(ts)s and then did real work (an edit, a "
-        "commit, a push or a PR), but a LIVE read of the board just now shows no "
-        "comment authored by `claude-code` since that read. Two tasks (#193, #194) "
-        "already shipped this way: the card stayed `open` with zero comments and was "
-        "re-dispatched and paid for twice.\n"
+        "This session read task %(id)d at %(ts)s and has done real work (an edit, a "
+        "commit, a push or a PR) since, but a LIVE read of the board just now shows no "
+        "comment authored by `claude-code` newer than that work. Two tasks (#193, "
+        "#194) already shipped this way: the card stayed `open` with zero comments and "
+        "was re-dispatched and paid for twice.\n"
         "Write it back before this turn ends:\n"
         "  clawgatectl task comment %(id)d --body \"<what shipped, evidence per "
         "acceptance criterion, and an explicit NOT-verified list>\"\n"
         "  clawgatectl task status %(id)d ready_for_review\n"
         "Use `complete` instead of `ready_for_review` ONLY when the task body carried "
         "a `## Acceptance criteria` heading AND every criterion is validated — see the "
-        "clawgate skill's status gate. If you did NOT do work on this task, say so in "
-        "one line and stop; nothing else is being asked for."
-        % {"id": int(task_id), "ts": first_read_ts}
+        "clawgate skill's status gate.\n"
+        "🔴 IF THIS SESSION'S WORK WAS NOT FOR TASK %(id)d — you only read the card, or "
+        "the work belongs to a different task or repo — do NOT comment and do NOT flip "
+        "the status: a junk comment permanently silences this guard for the card, and "
+        "`ready_for_review` fires a push notification to Zach. Run this instead, and it "
+        "will not ask again:\n"
+        "  %(dismiss)s"
+        % {"id": int(task_id), "ts": first_read_ts,
+           "dismiss": dismiss_cmd(task_id, session_id)}
     )
 
 
-def unknown_text(task_id, first_read_ts, error):
+def unknown_text(task_id, first_read_ts, error, session_id=""):
     return (
         "clawgate write-back UNVERIFIED for task %(id)d: the board could not be "
         "reached to check whether a `claude-code` comment was written since %(ts)s "
         "(%(err)s). This is a NOTICE, not a block — nothing is being asserted about "
-        "the card, because nothing could be measured.\n"
+        "the card, because nothing could be measured, and this turn is ending "
+        "normally.\n"
         "If this session did work on task %(id)d, write it back:\n"
         "  clawgatectl task comment %(id)d --body \"…\"\n"
-        "  clawgatectl task status %(id)d ready_for_review"
-        % {"id": int(task_id), "ts": first_read_ts, "err": str(error)[:160]}
+        "  clawgatectl task status %(id)d ready_for_review\n"
+        "If it did not, silence it for this session with:\n"
+        "  %(dismiss)s"
+        % {"id": int(task_id), "ts": first_read_ts, "err": _scrub(str(error), 160),
+           "dismiss": dismiss_cmd(task_id, session_id)}
     )
 
 
@@ -605,6 +872,13 @@ def post_tool_use(data, now=None):
     reading a task returns before touching the filesystem again. Nothing below the
     fast-path return runs for the overwhelming majority of tool calls.
     """
+    # 🔴 A SUBAGENT'S TOOL CALL IS NOT THE PARENT'S WORK — and it arrives wearing the
+    # parent's `session_id`, so this is the ONLY field that separates them. Checked
+    # before the state dir is even computed: a dispatched subagent that edits a file
+    # must not arm the parent session, whose Stop would then block on a card the
+    # parent merely read. See the `Kf()` quote in the module docstring.
+    if (data or {}).get("agent_id"):
+        return {"fast_path": True, "recorded": [], "work": False}
     state_dir = _state_dir(data)
     if state_dir is None:
         return {"fast_path": True, "recorded": [], "work": False}
@@ -627,13 +901,17 @@ def post_tool_use(data, now=None):
                 recorded.append(tid)
         except Exception:                 # noqa: BLE001 — fail-open, per read
             pass
-    # Work only counts AFTER a read: `tracked` (or a read recorded on this very call)
-    # is what says a card is in play. A session that has never touched the board
-    # cannot accumulate a work flag it would later be judged on.
+    # Work only counts AFTER a read, and the fast-path return above is ALREADY that
+    # gate: reaching this line means `tracked or ids` was true, so a session that has
+    # never touched the board cannot get here at all. The `and (tracked or recorded)`
+    # that used to be spelled out here was a second copy of a decision already made —
+    # unkillable by any mutation, and therefore a coverage gap that was really a
+    # duplicate. The condition it encoded is pinned by
+    # test_work_is_only_recorded_after_a_read, which drives the real writer.
     marked = False
-    if work and (tracked or recorded):
+    if work:
         try:
-            record_work(state_dir)
+            record_work(state_dir, now=now)
             marked = True
         except Exception:                 # noqa: BLE001
             pass
@@ -646,7 +924,7 @@ def post_tool_use(data, now=None):
 def stop_decision(data, reader=None, budget=STOP_BUDGET_SECS,
                   clock=time.monotonic):
     """Pure-ish decision for a Stop payload -> (kind, text) with kind in
-    {"silent", "context", "block"}. Side effect: it bumps the per-task fire counters,
+    {"silent", "notice", "block"}. Side effect: it bumps the per-task fire counters,
     which is what the ladder is made of.
 
     🔴 `reader` defaults to None and is resolved to `live_task` HERE, not in the
@@ -674,9 +952,15 @@ def stop_decision(data, reader=None, budget=STOP_BUDGET_SECS,
     if not ids:
         return ("silent", "")
 
+    session_id = d.get("session_id") or ""
+    worked_at = last_work_ts(state_dir)
     deadline = clock() + budget
     blocks, notices = [], []
-    for tid in sorted(ids)[:MAX_TASKS]:
+    # No `[:MAX_TASKS]` slice here: `record_read` refuses to create a sixth `read-`
+    # file, so `tracked_ids` structurally cannot return more than MAX_TASKS and the
+    # slice was a second copy of a cap already enforced at the writer — unkillable,
+    # and pinned instead by test_at_most_five_task_ids_are_tracked_per_session.
+    for tid in sorted(ids):
         remaining = deadline - clock()
         if remaining <= 0:
             break
@@ -684,33 +968,36 @@ def stop_decision(data, reader=None, budget=STOP_BUDGET_SECS,
         err = "the board returned a task payload this hook could not read"
         try:
             task = reader(tid, timeout=min(PER_TASK_TIMEOUT_SECS, remaining))
-            state = writeback_state(task, first_read_ts)
+            state = writeback_state(task, first_read_ts, work_ts=worked_at)
         except LiveReadError as e:
             state, err = "unknown", e
         except Exception as e:            # noqa: BLE001 — a reader that raises anything
             state, err = "unknown", e
         if state in ("closed", "written"):
             continue
-        fire = bump_fires(state_dir, tid)
-        rung = escalate(fire)
+        if state == "unknown":
+            # 🔴 NEVER blocks, and spends its OWN counter. Cannot-measure is reported,
+            # never enforced — and never at the expense of the block budget that a
+            # measured miss will need if the board comes back later in this session.
+            if escalate(bump_fires(state_dir, tid, "unknown")) != "silent":
+                notices.append(unknown_text(tid, first_read_ts, err, session_id))
+            continue
+        rung = escalate(bump_fires(state_dir, tid))
         if rung == "silent":
             continue
-        if state == "unknown":
-            # 🔴 NEVER blocks. Cannot-measure is reported, never enforced.
-            notices.append(unknown_text(tid, first_read_ts, err))
-            continue
         (blocks if rung == "block" else notices).append(
-            missing_text(tid, first_read_ts))
+            missing_text(tid, first_read_ts, session_id))
 
     # 🔴 A "could not measure" notice NEVER CAUSES a block — only `blocks` does, and
     # only a MEASURED missing write-back can put an entry there. When some other task
     # is blocking anyway the notice rides along in the same reason rather than being
     # dropped, but a Stop whose every task is unmeasurable can only ever reach
-    # `context`. Pinned by a test that drives an all-unknown session up the ladder.
+    # `notice` — which does not force a continuation at all. Pinned by a test that
+    # drives an all-unknown session up the ladder and reads the EMITTED JSON.
     if blocks:
         return ("block", "\n\n".join(blocks + notices))
     if notices:
-        return ("context", "\n\n".join(notices))
+        return ("notice", "\n\n".join(notices))
     return ("silent", "")
 
 
@@ -719,23 +1006,81 @@ def emit(kind, text):
     is exactly one place that decides what reaches stdout — a caller-side `if kind !=
     "silent"` in front of this was redundant with the fall-through below, and a branch
     no mutation can kill reads as a coverage gap when it is really just a duplicate.
+
+    🔴 THERE ARE EXACTLY TWO CHANNELS AND ONLY ONE OF THEM ENDS THE TURN. `decision:
+    "block"` forces a continuation. `systemMessage` does not — it is yielded on the
+    CLI's message channel, never into `blockingErrors`, and its attachment renders to
+    the operator without being fed back to the model. `hookSpecificOutput.
+    additionalContext` is NOT a third option: on Stop the CLI pushes it into the same
+    `blockingErrors` array as a block, so emitting it here would force a continuation
+    while claiming not to. It is deliberately absent from this function.
     """
     if kind == "block":
         json.dump({"decision": "block", "reason": text}, sys.stdout)
         sys.stdout.write("\n")
-    elif kind == "context":
-        json.dump({"hookSpecificOutput": {"hookEventName": "Stop",
-                                          "additionalContext": text}}, sys.stdout)
+    elif kind == "notice":
+        json.dump({"systemMessage": text}, sys.stdout)
         sys.stdout.write("\n")
 
 
 # --------------------------------------------------------------------------- #
+def dismiss_main(argv):
+    """`--dismiss <task_id> --session <session_id>` — the escape hatch, as a command.
+
+    Prints one line saying what it did and returns. NEVER reads stdin: it is invoked
+    by a model from a Bash tool call, where stdin is not a hook payload.
+
+    🔴 `--session` is REQUIRED and is not defaulted to anything. This process has no
+    way to learn the caller's session id — it is not in the environment — and guessing
+    would let a dismissal land on some other session's ledger. The block text supplies
+    the id already filled in, so there is nothing for the caller to look up.
+    """
+    tid = sess = None
+    i = 0
+    while i < len(argv):
+        if argv[i] == "--dismiss" and i + 1 < len(argv):
+            tid, i = argv[i + 1], i + 2
+        elif argv[i] == "--session" and i + 1 < len(argv):
+            sess, i = argv[i + 1], i + 2
+        else:
+            i += 1
+    if tid is None or sess is None:
+        sys.stdout.write("usage: clawgate-writeback-guard.py --dismiss <task_id> "
+                         "--session <session_id>\n")
+        return
+    try:
+        task_id = int(tid)
+    except (TypeError, ValueError):
+        sys.stdout.write("not a task id: %s\n" % _sanitize(tid))
+        return
+    state_dir = _state_dir({"session_id": sess})
+    if state_dir is None:
+        sys.stdout.write("not a session id: %s\n" % _sanitize(sess))
+        return
+    removed = dismiss(state_dir, task_id)
+    if removed:
+        sys.stdout.write("clawgate write-back guard: dismissed task %d for session "
+                         "%s (cleared %s). It will not ask about this task again.\n"
+                         % (task_id, _sanitize(sess), ", ".join(sorted(removed))))
+    else:
+        sys.stdout.write("clawgate write-back guard: nothing to dismiss — task %d is "
+                         "not in session %s's ledger (%s).\n"
+                         % (task_id, _sanitize(sess), state_dir))
+
+
 def main():
     # 🔴 ONE exit, and it is always 0. Nothing inside the try may call sys.exit():
     # SystemExit is a BaseException and would sail past `except Exception`.
     try:
-        data = json.load(sys.stdin)
-        event = (data or {}).get("hook_event_name")
+        # 🔴 THE CLI MODE IS DECIDED BEFORE THE STDIN READ, and it never performs one.
+        # A hook invocation carries no argv, so this cannot shadow the hook path — and
+        # reading stdin in CLI mode would hang on a terminal forever.
+        if "--dismiss" in sys.argv[1:]:
+            dismiss_main(sys.argv[1:])
+            data, event = None, None
+        else:
+            data = json.load(sys.stdin)
+            event = (data or {}).get("hook_event_name")
         if event == "PostToolUse":
             post_tool_use(data)
         elif event == "Stop":

--- a/scripts/claude-hooks/clawgate-writeback-guard.py
+++ b/scripts/claude-hooks/clawgate-writeback-guard.py
@@ -1,0 +1,710 @@
+#!/usr/bin/env python3
+"""Make the clawgate task write-back NON-OPTIONAL: PostToolUse watches, Stop gates.
+
+WHY THIS EXISTS — MEASURED, TWICE, AND PROSE ALREADY FAILED
+-----------------------------------------------------------
+Clawgate tasks #193 and #194 were both picked up, the work was done and shipped as
+PRs — and both cards stayed `open` with **ZERO comments**. Both were then
+re-dispatched and paid for a second time. `claude/skills/clawgate/SKILL.md`
+§"task pickup" already says, in 🔴, that the comment/status ritual is NOT optional
+and NOT a thing to be asked for. Prose lost 2/2. PRINCIPLES.md prefers a
+deterministic/structural fix over prompt-tuning; this is that fix.
+
+🔴 THE GATE IS KEYED ON THE **READ**, NOT ON THE STATUS FLIP
+------------------------------------------------------------
+The obvious design — a PreToolUse deny on `clawgatectl task status <id> in_progress`
+until a comment exists — is STRUCTURALLY UNREACHABLE for the exact failure it would
+be built to catch. In both measured cases no `task status … in_progress` command was
+ever issued: the cards never left `open`. A guard on a command that was never run
+observes nothing. The one act that provably DID happen in both failures is the read,
+so the read is what arms this hook:
+
+    clawgatectl task get <N>          # the SKILL's own step 1
+    curl … /api/tasks/<N>[/…]         # the same read, before clawgatectl existed
+
+WHAT FIRES IT — THREE CONDITIONS, ALL REQUIRED
+-----------------------------------------------
+  1. the session READ a specific clawgate task id (above), and
+  2. REAL WORK happened after that read — an Edit/Write/NotebookEdit tool call, or a
+     Bash `git commit` / `git push` / `gh pr create`, and
+  3. a LIVE re-read of the board at Stop shows NO comment authored by `claude-code`
+     with `createdAt` at or after the first read.
+
+Condition 2 is the false-positive killer and it is not optional. The SKILL's own
+step 2 is "EVALUATE and report to Zach. Do NOT flip status yet" — a session that
+reads a card, forms an opinion and reports back owes the board NOTHING, and a hook
+that blocks that turn is worse than no hook. Nothing here fires on a read alone.
+
+Condition 3 is a LIVE MEASUREMENT, not an inference from what this process saw. It
+is what makes the hook self-suppressing: the moment the ritual is followed the
+board says so and the guard goes quiet, including for a comment written by a
+different process, a subagent, or a devpod agent. A hook that tracked only its own
+observations would keep firing after the work was correctly written back.
+
+🔴 A LIVE READ THAT FAILS IS NOT A CLEAN BILL OF HEALTH. Unreachable board, no
+client, unparseable JSON — all of those mean "could not measure", and this hook says
+so out loud with a NON-BLOCKING notice rather than going silent. RULES.md: an empty
+result cannot distinguish two mechanisms, and reporting silence for "the board is
+down" is reporting the same observable as "the ritual was followed".
+
+ESCALATION LADDER — per session, per task id
+---------------------------------------------
+    fire 1  ->  decision: block      (the turn does not end; `reason` reaches the model)
+    fire 2  ->  decision: block
+    fire 3  ->  additionalContext    (non-blocking; the turn ends)
+    fire 4+ ->  silent
+
+Derived from the INSTALLED CLI bundle, not from documentation (claude-code 2.1.220,
+`bin/.claude-wrapped` — NOT the 20 KB `bin/claude` wrapper, a grep against which
+returns a meaningless zero). Both controls were run against the 275 MB bundle before
+any of this was believed: positive `hookEventName` -> 68 matches, negative
+`zzzNOTPRESENTzzz_devrc_control` -> 0.
+
+  * The hook output schema is a top-level object, NOT a hookSpecificOutput arm:
+        v.object({continue: …, suppressOutput: …, stopReason: …,
+                  decision: v.enum(["approve","block"]).optional(),
+                  reason: v.string().describe("Explanation for the decision").optional(),
+                  systemMessage: …, terminalSequence: …})
+  * and the command-hook consumer reads exactly that, with exit 0:
+        M = L && HB(L) && L.decision === "block",
+        $ = H.status === 2 || !!M,
+        D = M ? L.reason || H.stderr || "" : …            -> {blocked: $, output: D}
+    i.e. `{"decision":"block","reason":"…"}` on stdout at exit 0 is the JSON
+    equivalent of exit 2, WITHOUT the "Stop hook error occurred" notification that
+    exit 2 raises (see next-step-nudge.py's header for that measurement).
+  * consecutive Stop blocks are capped BY THE CLI at
+        let Kt = wue(process.env.CLAUDE_CODE_STOP_HOOK_BLOCK_CAP, 8);
+        if (Kt > 0 && yo > Kt) … "A hook blocked the turn from ending N consecutive
+        times — overriding and ending turn."
+    Our MAX_BLOCKS = 2 is deliberately far stricter than that 8. A guard that has to
+    be overridden by the harness has already lost the operator.
+
+🔴 THERE IS DELIBERATELY NO `stop_hook_active` GATE, and that is the one place this
+hook diverges from the CLI's own advice ("check stop_hook_active and return success
+while it's true"). That advice exists to stop an unbounded block loop; the ladder
+above bounds it at 2 per task instead, and the SECOND block is the whole point — it
+is what catches a turn that acknowledged the first block and still stopped without
+writing. Skipping the second Stop would make fire 2 unreachable in the only shape it
+matters. The interaction with MAX_TASKS is named rather than hidden: several tasks
+each blocking twice can in principle stack toward the CLI's 8, at which point the
+CLI ends the turn with a warning — a graceful ceiling, not a wedge.
+
+🔴 SubagentStop IS REFUSED. A subagent's turn never reaches the operator, so it owes
+them nothing (next-step-nudge.py refuses it for the same reason). PostToolUse is NOT
+refused for subagents: in both measured failures the work ran in a dispatched
+subagent, and its edits and commits are exactly the evidence condition 2 needs.
+
+🔴 HOT PATH. PostToolUse fires after EVERY tool call of every session, and
+agent-ledger-hook.py already costs ~21 ms there. The fast path is: resolve the state
+dir from `session_id` (string work, no IO), ONE `os.path.exists`, and the trigger
+regex. A session that has never read a clawgate task and is not reading one now does
+nothing else — no directory creation, no state read, no subprocess, ever. That
+ordering is pinned by a test, because an earlier hook in this repo shipped with its
+throttle consulted AFTER the subprocess spawn while its comment claimed otherwise.
+
+🔴 FAIL-OPEN, ALWAYS. Every internal exception exits 0 with an empty stdout and
+blocks nothing. main() has exactly ONE exit and it is always 0. A hook that wedges a
+turn to enforce a bookkeeping ritual has inverted its own cost model.
+
+WHAT THIS STRUCTURALLY CANNOT SEE (say it here, not in a report nobody re-reads):
+  * work done anywhere this hook is not running — a devpod agent, the clawgate web
+    UI, a human, opencode, or a host that has not had `home-manager switch` run;
+  * a session that read the task via a route neither trigger matches (the board UI,
+    an `/api/tasks?summary=1` list, someone pasting the body in);
+  * whether the comment that DOES exist is any good — it checks that a `claude-code`
+    comment exists since the read, never what it says;
+  * the `in_progress` flip and the pre-start comment, neither of which it requires:
+    it gates the WRITE-BACK, which is the thing that was measured missing.
+
+Deployed by `nix/home.nix`; registered on PostToolUse (no matcher) + Stop by
+`register-nudge-hook.py`.
+"""
+import datetime
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+# --------------------------------------------------------------------------- #
+# Tunables
+# --------------------------------------------------------------------------- #
+
+# Comments authored by anything else (a human on the board, `api`, `drafter`) are
+# not this agent writing back. The allowlist that produces this value lives in the
+# server (`X-Clawgate-Source` -> {extension, api, drafter, repo-cos, claude-code});
+# `clawgatectl task comment` defaults to exactly this one.
+AGENT_AUTHOR = "claude-code"
+
+# A card in either of these is already handed over — someone closed it, and nagging
+# about a missing comment on a card that is out for review is noise.
+CLOSED_STATUSES = ("ready_for_review", "complete")
+
+# Per session, per task id. See the ladder in the module docstring; both are read
+# out of the CLI bundle's own cap of 8, which this is deliberately stricter than.
+MAX_BLOCKS = 2
+MAX_FIRES = 3
+
+# At most this many distinct task ids are tracked per session, so a session that
+# sweeps the board cannot turn one Stop into a queue of live reads.
+MAX_TASKS = 5
+
+# Wall-clock budget for ALL live reads on one Stop, and the ceiling for any single
+# one. A Stop hook that hangs is felt at the exact moment a session is trying to end.
+STOP_BUDGET_SECS = 8.0
+PER_TASK_TIMEOUT_SECS = 5.0
+
+# The board's `createdAt` comes from the SERVER clock; `first_read_ts` is written
+# from THIS host's clock. Comparing them across even a small skew would let a
+# genuinely-written comment read as older than the read that preceded it. 120 s is
+# generous against NTP-synced hosts and far below any real "I read it, then worked
+# for a while, then forgot" interval.
+CLOCK_SKEW_ALLOWANCE_SECS = 120
+
+# Session state is per-session and never revisited once the session ends, so without
+# a sweep `~/.cache/claude-clawgate-writeback/s/` grows one directory per session
+# forever. Pruned on Stop only — a handful of times per session, never on the
+# per-tool-call path.
+STATE_TTL_SECS = 14 * 24 * 3600
+
+# Where the token/URL come from on the curl fallback path. Same file the clawgate
+# PermissionRequest hook reads; see the clawgate skill.
+CLAWGATE_ENV = "~/.claude/clawgate.env"
+
+
+# --------------------------------------------------------------------------- #
+# Triggers
+#
+# 🔴 BOTH DIRECTIONS MATTER. These must match a read of a SPECIFIC id and must NOT
+# match a listing. `clawgatectl task ls`, `/api/tasks?summary=1` and a bare
+# `/api/tasks` are how a session surveys the board without picking anything up, and
+# arming the guard on one of those would put a block in front of a turn that never
+# claimed a card. `task get` with a non-numeric argument is not a read of task N
+# either — there is no such task.
+# --------------------------------------------------------------------------- #
+TASK_GET_RX = re.compile(r"\bclawgatectl\s+task\s+get\s+(\d+)\b")
+# `\b` after the id is what keeps `/api/tasks/193abc` out while admitting the
+# trailing segment shapes that exist (`/api/tasks/193/comments`, `/193`).
+TASK_API_RX = re.compile(r"/api/tasks/(\d+)\b")
+
+# Tool calls that ARE work, by name.
+WORK_TOOLS = ("Edit", "Write", "NotebookEdit")
+
+# ...and by Bash command. Anchored on the SUBCOMMAND immediately after `git` (with
+# an allowance for `-C <path>` / `--git-dir=…` style global flags), so
+# `git log --oneline | grep commit` is not work and `git -C $DEVRC commit -m …` is.
+WORK_BASH_RX = re.compile(
+    r"\bgit\s+(?:-[A-Za-z]\s+\S+\s+|--[A-Za-z][-\w]*(?:=\S+)?\s+)*(?:commit|push)\b"
+    r"|\bgh\s+pr\s+create\b")
+
+STATE_WORK = "work"
+
+
+# --------------------------------------------------------------------------- #
+# Session-scoped state
+# --------------------------------------------------------------------------- #
+def _state_root():
+    """HOME read at CALL time, not import time, so a test can point it somewhere safe."""
+    return os.path.join(os.path.expanduser("~"), ".cache",
+                        "claude-clawgate-writeback", "s")
+
+
+def _sanitize(part):
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", str(part))[:120]
+
+
+def _state_dir(data):
+    session = (data or {}).get("session_id")
+    if not isinstance(session, str) or not session:
+        return None
+    return os.path.join(_state_root(), _sanitize(session))
+
+
+def _read_path(state_dir, task_id):
+    return os.path.join(state_dir, "read-%d" % int(task_id))
+
+
+def _fires_path(state_dir, task_id):
+    return os.path.join(state_dir, "fires-%d" % int(task_id))
+
+
+def now_iso(now=None):
+    ts = datetime.datetime.fromtimestamp(
+        time.time() if now is None else now, datetime.timezone.utc)
+    return ts.isoformat().replace("+00:00", "Z")
+
+
+def parse_ts(s):
+    """RFC3339 -> epoch seconds, or None.
+
+    The board emits Go's `time.RFC3339Nano` (`2026-08-15T04:27:49.005565Z`), which
+    can carry up to nine fractional digits; `datetime.fromisoformat` accepts at most
+    six, so the tail is trimmed rather than allowed to fail the whole comparison.
+    """
+    if not isinstance(s, str) or not s.strip():
+        return None
+    t = s.strip()
+    if t.endswith("Z") or t.endswith("z"):
+        t = t[:-1] + "+00:00"
+    m = re.match(r"^(.*\.\d{1,6})\d*([+-]\d{2}:?\d{2})?$", t)
+    if m:
+        t = m.group(1) + (m.group(2) or "")
+    try:
+        dt = datetime.datetime.fromisoformat(t)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+    return dt.timestamp()
+
+
+def tracked_ids(state_dir):
+    """Task ids this session has read, with the timestamp of the FIRST read of each."""
+    out = {}
+    try:
+        names = os.listdir(state_dir)
+    except Exception:
+        return out
+    for name in sorted(names):
+        if not name.startswith("read-"):
+            continue
+        try:
+            with open(os.path.join(state_dir, name)) as fh:
+                rec = json.load(fh)
+            tid = int(rec["task_id"])
+            ts = rec["first_read_ts"]
+        except Exception:
+            continue
+        if isinstance(ts, str) and ts:
+            out[tid] = ts
+    return out
+
+
+def record_read(state_dir, task_id, now=None):
+    """Record the FIRST read of `task_id`. Idempotent: a later read never moves the
+    timestamp, because the window this hook measures over starts at the first one."""
+    path = _read_path(state_dir, task_id)
+    if os.path.exists(path):
+        return False
+    os.makedirs(state_dir, exist_ok=True)
+    if os.path.exists(path):
+        return False
+    if len([n for n in os.listdir(state_dir) if n.startswith("read-")]) >= MAX_TASKS:
+        return False
+    tmp = path + ".tmp"
+    with open(tmp, "w") as fh:
+        json.dump({"task_id": int(task_id), "first_read_ts": now_iso(now)}, fh)
+    os.replace(tmp, path)
+    return True
+
+
+def record_work(state_dir):
+    os.makedirs(state_dir, exist_ok=True)
+    with open(os.path.join(state_dir, STATE_WORK), "w") as fh:
+        fh.write("1")
+
+
+def work_after_read(state_dir):
+    return os.path.exists(os.path.join(state_dir, STATE_WORK))
+
+
+def bump_fires(state_dir, task_id):
+    """Read-increment-write the per-task fire counter; returns the NEW 1-based count."""
+    path = _fires_path(state_dir, task_id)
+    n = 0
+    try:
+        with open(path) as fh:
+            n = int(fh.read().strip() or "0")
+    except Exception:
+        n = 0
+    n += 1
+    try:
+        os.makedirs(state_dir, exist_ok=True)
+        with open(path, "w") as fh:
+            fh.write(str(n))
+    except Exception:
+        pass
+    return n
+
+
+def prune(ttl=STATE_TTL_SECS, now=None):
+    """Drop session state directories older than `ttl`. Returns the names removed.
+
+    🔴 Keyed on the directory's OWN mtime, which the last write to it moved — so a
+    long-lived session is not swept out from under itself. Errors are swallowed per
+    entry: a state dir that cannot be removed is a few bytes, and a Stop hook that
+    raises is felt at the exact moment a session is trying to end.
+    """
+    root = _state_root()
+    cutoff = (time.time() if now is None else now) - ttl
+    removed = []
+    try:
+        names = os.listdir(root)
+    except Exception:
+        return removed
+    for name in names:
+        path = os.path.join(root, name)
+        try:
+            if os.path.getmtime(path) >= cutoff:
+                continue
+            shutil.rmtree(path, ignore_errors=True)
+            removed.append(name)
+        except Exception:                 # noqa: BLE001
+            pass
+    return removed
+
+
+def escalate(fire_number):
+    """1-based fire number -> "block" | "context" | "silent"."""
+    if fire_number <= MAX_BLOCKS:
+        return "block"
+    if fire_number <= MAX_FIRES:
+        return "context"
+    return "silent"
+
+
+# --------------------------------------------------------------------------- #
+# Trigger matching
+# --------------------------------------------------------------------------- #
+def task_read_ids(data):
+    """Every clawgate task id this PostToolUse payload is a READ of. Order-preserving,
+    de-duplicated, and empty for anything that is not a single-task read."""
+    cmd = ((data or {}).get("tool_input") or {}).get("command")
+    if not isinstance(cmd, str) or not cmd:
+        return []
+    out = []
+    for rx in (TASK_GET_RX, TASK_API_RX):
+        for m in rx.finditer(cmd):
+            tid = int(m.group(1))
+            if tid not in out:
+                out.append(tid)
+    return out
+
+
+def is_work(data):
+    """True when this PostToolUse payload is REAL WORK, not a read or a look-around."""
+    d = data or {}
+    if d.get("tool_name") in WORK_TOOLS:
+        return True
+    if d.get("tool_name") != "Bash":
+        return False
+    cmd = (d.get("tool_input") or {}).get("command")
+    return isinstance(cmd, str) and bool(WORK_BASH_RX.search(cmd))
+
+
+# --------------------------------------------------------------------------- #
+# The live read — the measurement, not an inference
+# --------------------------------------------------------------------------- #
+class LiveReadError(Exception):
+    """Could not measure. NEVER silence: the caller emits a non-blocking notice."""
+
+
+def _env_file(path=CLAWGATE_ENV):
+    conf = {}
+    try:
+        with open(os.path.expanduser(path)) as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                k, v = line.split("=", 1)
+                conf[k.strip()] = v.strip()
+    except Exception:
+        return {}
+    return conf
+
+
+def _via_clawgatectl(task_id, timeout):
+    proc = subprocess.run(["clawgatectl", "task", "get", str(int(task_id))],
+                          capture_output=True, text=True, timeout=timeout)
+    if proc.returncode != 0:
+        raise LiveReadError("clawgatectl rc=%d %s"
+                            % (proc.returncode, (proc.stderr or "").strip()[:120]))
+    return json.loads(proc.stdout)
+
+
+def _via_curl(task_id, timeout, env_path=CLAWGATE_ENV, why=None):
+    """The fallback for a host with no `clawgatectl` (the laptop today — its
+    homelab-talos checkout predates the command, so nix does not build it).
+
+    🔴 The token goes in on STDIN via `curl -K -`, never in argv: an argv is visible
+    to every process on the box through /proc, and this runs after every turn.
+
+    `why` carries the FIRST client's failure into this one's message. Without it a
+    `clawgatectl` that exists but exits non-zero reports as "no clawgatectl" — a
+    diagnosis pointing at the wrong subsystem, which is the shape that has cost this
+    repo whole sessions.
+    """
+    conf = _env_file(env_path)
+    url = conf.get("CLAWGATE_API_URL")
+    token = conf.get("CLAWGATE_HOOK_TOKEN")
+    if not url or not token:
+        raise LiveReadError("%s has no API url/token (first client: %s)"
+                            % (os.path.expanduser(env_path),
+                               why or "clawgatectl not on PATH"))
+    cfg = "".join([
+        "silent\n", "fail\n",
+        "max-time = %d\n" % max(1, int(timeout)),
+        'url = "%s/api/tasks/%d"\n' % (url.rstrip("/"), int(task_id)),
+        'header = "Authorization: Bearer %s"\n' % token,
+    ])
+    proc = subprocess.run(["curl", "-K", "-"], input=cfg,
+                          capture_output=True, text=True, timeout=timeout + 2)
+    if proc.returncode != 0:
+        raise LiveReadError("curl rc=%d" % proc.returncode)
+    return json.loads(proc.stdout)
+
+
+def live_task(task_id, timeout=PER_TASK_TIMEOUT_SECS, env_path=CLAWGATE_ENV):
+    """Live re-read of one task. Raises LiveReadError when it cannot be measured."""
+    why = None
+    try:
+        return _via_clawgatectl(task_id, timeout)
+    except LiveReadError as e:
+        why = str(e)
+    except FileNotFoundError:
+        why = "clawgatectl not on PATH"   # no clawgatectl on this host
+    except subprocess.TimeoutExpired:
+        raise LiveReadError("clawgatectl timed out after %ss" % timeout)
+    except Exception as e:                # noqa: BLE001 — unparseable stdout, etc.
+        raise LiveReadError("%s: %s" % (type(e).__name__, e))
+    try:
+        return _via_curl(task_id, timeout, env_path=env_path, why=why)
+    except LiveReadError:
+        raise
+    except FileNotFoundError:
+        raise LiveReadError("neither clawgatectl nor curl is available")
+    except subprocess.TimeoutExpired:
+        raise LiveReadError("curl timed out after %ss" % timeout)
+    except Exception as e:                # noqa: BLE001
+        raise LiveReadError("%s: %s" % (type(e).__name__, e))
+
+
+def writeback_state(task, first_read_ts, skew=CLOCK_SKEW_ALLOWANCE_SECS):
+    """"closed" | "written" | "missing" | "unknown" for one live task payload.
+
+    🔴 An UNPARSEABLE `createdAt` on a `claude-code` comment resolves to "written",
+    not to "missing". The comment demonstrably exists and only its timestamp is
+    unreadable; resolving that toward a BLOCK would spend the operator's turn on a
+    formatting change at the far end of a wire this hook does not own.
+    """
+    if not isinstance(task, dict):
+        return "unknown"
+    if task.get("status") in CLOSED_STATUSES:
+        return "closed"
+    read_at = parse_ts(first_read_ts)
+    if read_at is None:
+        return "unknown"
+    cutoff = read_at - skew
+    comments = task.get("comments")
+    if comments is None:
+        comments = []
+    if not isinstance(comments, list):
+        return "unknown"
+    for c in comments:
+        if not isinstance(c, dict) or c.get("author") != AGENT_AUTHOR:
+            continue
+        if c.get("retracted"):
+            continue                      # withdrawn: it is not a write-back
+        ts = parse_ts(c.get("createdAt"))
+        if ts is None or ts >= cutoff:
+            return "written"
+    return "missing"
+
+
+# --------------------------------------------------------------------------- #
+# The text the operator's model actually reads
+# --------------------------------------------------------------------------- #
+def missing_text(task_id, first_read_ts):
+    return (
+        "clawgate write-back MISSING for task %(id)d.\n"
+        "This session read task %(id)d at %(ts)s and then did real work (an edit, a "
+        "commit, a push or a PR), but a LIVE read of the board just now shows no "
+        "comment authored by `claude-code` since that read. Two tasks (#193, #194) "
+        "already shipped this way: the card stayed `open` with zero comments and was "
+        "re-dispatched and paid for twice.\n"
+        "Write it back before this turn ends:\n"
+        "  clawgatectl task comment %(id)d --body \"<what shipped, evidence per "
+        "acceptance criterion, and an explicit NOT-verified list>\"\n"
+        "  clawgatectl task status %(id)d ready_for_review\n"
+        "Use `complete` instead of `ready_for_review` ONLY when the task body carried "
+        "a `## Acceptance criteria` heading AND every criterion is validated — see the "
+        "clawgate skill's status gate. If you did NOT do work on this task, say so in "
+        "one line and stop; nothing else is being asked for."
+        % {"id": int(task_id), "ts": first_read_ts}
+    )
+
+
+def unknown_text(task_id, first_read_ts, error):
+    return (
+        "clawgate write-back UNVERIFIED for task %(id)d: the board could not be "
+        "reached to check whether a `claude-code` comment was written since %(ts)s "
+        "(%(err)s). This is a NOTICE, not a block — nothing is being asserted about "
+        "the card, because nothing could be measured.\n"
+        "If this session did work on task %(id)d, write it back:\n"
+        "  clawgatectl task comment %(id)d --body \"…\"\n"
+        "  clawgatectl task status %(id)d ready_for_review"
+        % {"id": int(task_id), "ts": first_read_ts, "err": str(error)[:160]}
+    )
+
+
+# --------------------------------------------------------------------------- #
+# PostToolUse
+# --------------------------------------------------------------------------- #
+def post_tool_use(data, now=None):
+    """Record reads and work. Returns a small dict describing what it did, for tests.
+
+    🔴 THE ORDERING IS THE POINT ON THIS PATH. `os.path.exists` on the session's state
+    dir and the trigger regex come FIRST, and a session that is neither tracked nor
+    reading a task returns before touching the filesystem again. Nothing below the
+    fast-path return runs for the overwhelming majority of tool calls.
+    """
+    state_dir = _state_dir(data)
+    if state_dir is None:
+        return {"fast_path": True, "recorded": [], "work": False}
+    tracked = os.path.exists(state_dir)
+    ids = task_read_ids(data)
+    if not tracked and not ids:
+        # 🔴 THE FAST-PATH RETURN. Exactly ONE filesystem call (the `exists` above)
+        # has happened and nothing has been spawned. Everything below this line —
+        # the work regex, every write, every stat of a state file — is reachable
+        # ONLY for a session that has actually read a clawgate task. Pinned by
+        # test_the_fast_path_does_exactly_one_stat_and_nothing_else, which counts
+        # the calls rather than trusting this comment.
+        return {"fast_path": True, "recorded": [], "work": False}
+
+    work = is_work(data)
+    recorded = []
+    for tid in ids:
+        try:
+            if record_read(state_dir, tid, now=now):
+                recorded.append(tid)
+        except Exception:                 # noqa: BLE001 — fail-open, per read
+            pass
+    # Work only counts AFTER a read: `tracked` (or a read recorded on this very call)
+    # is what says a card is in play. A session that has never touched the board
+    # cannot accumulate a work flag it would later be judged on.
+    marked = False
+    if work and (tracked or recorded):
+        try:
+            record_work(state_dir)
+            marked = True
+        except Exception:                 # noqa: BLE001
+            pass
+    return {"fast_path": False, "recorded": recorded, "work": marked}
+
+
+# --------------------------------------------------------------------------- #
+# Stop
+# --------------------------------------------------------------------------- #
+def stop_decision(data, reader=None, budget=STOP_BUDGET_SECS,
+                  clock=time.monotonic):
+    """Pure-ish decision for a Stop payload -> (kind, text) with kind in
+    {"silent", "context", "block"}. Side effect: it bumps the per-task fire counters,
+    which is what the ladder is made of.
+
+    🔴 `reader` defaults to None and is resolved to `live_task` HERE, not in the
+    signature. A default argument binds at DEF time, so `reader=live_task` would make
+    the module attribute unrebindable — which is exactly the trap that produced a
+    confident "TAIL_CHARS is inert" reading of an eleven-point sweep in
+    next-step-nudge.py that had in fact re-measured one value eleven times.
+    """
+    if reader is None:
+        reader = live_task
+    d = data if isinstance(data, dict) else {}
+    if d.get("hook_event_name") not in (None, "Stop"):
+        return ("silent", "")             # 🔴 SubagentStop and friends: refused
+    if d.get("agent_id"):
+        return ("silent", "")
+    state_dir = _state_dir(d)
+    if state_dir is None or not os.path.exists(state_dir):
+        return ("silent", "")
+    if not work_after_read(state_dir):
+        # 🔴 THE FALSE-POSITIVE KILLER. Read-and-evaluate-only is the SKILL's own
+        # step 2 and owes the board nothing.
+        return ("silent", "")
+
+    ids = tracked_ids(state_dir)
+    if not ids:
+        return ("silent", "")
+
+    deadline = clock() + budget
+    blocks, notices = [], []
+    for tid in sorted(ids)[:MAX_TASKS]:
+        remaining = deadline - clock()
+        if remaining <= 0:
+            break
+        first_read_ts = ids[tid]
+        err = "the board returned a task payload this hook could not read"
+        try:
+            task = reader(tid, timeout=min(PER_TASK_TIMEOUT_SECS, remaining))
+            state = writeback_state(task, first_read_ts)
+        except LiveReadError as e:
+            state, err = "unknown", e
+        except Exception as e:            # noqa: BLE001 — a reader that raises anything
+            state, err = "unknown", e
+        if state in ("closed", "written"):
+            continue
+        fire = bump_fires(state_dir, tid)
+        rung = escalate(fire)
+        if rung == "silent":
+            continue
+        if state == "unknown":
+            # 🔴 NEVER blocks. Cannot-measure is reported, never enforced.
+            notices.append(unknown_text(tid, first_read_ts, err))
+            continue
+        (blocks if rung == "block" else notices).append(
+            missing_text(tid, first_read_ts))
+
+    # 🔴 A "could not measure" notice NEVER CAUSES a block — only `blocks` does, and
+    # only a MEASURED missing write-back can put an entry there. When some other task
+    # is blocking anyway the notice rides along in the same reason rather than being
+    # dropped, but a Stop whose every task is unmeasurable can only ever reach
+    # `context`. Pinned by a test that drives an all-unknown session up the ladder.
+    if blocks:
+        return ("block", "\n\n".join(blocks + notices))
+    if notices:
+        return ("context", "\n\n".join(notices))
+    return ("silent", "")
+
+
+def emit(kind, text):
+    """The ONE writer. `silent` is handled HERE rather than at the call site, so there
+    is exactly one place that decides what reaches stdout — a caller-side `if kind !=
+    "silent"` in front of this was redundant with the fall-through below, and a branch
+    no mutation can kill reads as a coverage gap when it is really just a duplicate.
+    """
+    if kind == "block":
+        json.dump({"decision": "block", "reason": text}, sys.stdout)
+        sys.stdout.write("\n")
+    elif kind == "context":
+        json.dump({"hookSpecificOutput": {"hookEventName": "Stop",
+                                          "additionalContext": text}}, sys.stdout)
+        sys.stdout.write("\n")
+
+
+# --------------------------------------------------------------------------- #
+def main():
+    # 🔴 ONE exit, and it is always 0. Nothing inside the try may call sys.exit():
+    # SystemExit is a BaseException and would sail past `except Exception`.
+    try:
+        data = json.load(sys.stdin)
+        event = (data or {}).get("hook_event_name")
+        if event == "PostToolUse":
+            post_tool_use(data)
+        elif event == "Stop":
+            emit(*stop_decision(data))
+            # AFTER the decision has been emitted: the operator's turn never waits on
+            # housekeeping, and a prune that raises cannot suppress a verdict that has
+            # already been written.
+            prune()
+        # every other event, SubagentStop included, is not ours
+    except Exception:                     # noqa: BLE001 — see the fail-open note above
+        pass
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/claude-hooks/clawgate-writeback-guard.py
+++ b/scripts/claude-hooks/clawgate-writeback-guard.py
@@ -138,11 +138,11 @@ matters. The interaction with MAX_TASKS is named rather than hidden: several tas
 each blocking twice can in principle stack toward the CLI's 8, at which point the
 CLI ends the turn with a warning — a graceful ceiling, not a wedge.
 
-🔴 SubagentStop IS REFUSED, AND SO IS EVERY PostToolUse CARRYING AN `agent_id`.
-A subagent's turn never reaches the operator, so it owes them nothing
-(next-step-nudge.py refuses SubagentStop for the same reason). The PostToolUse half
-is the one that was WRONG in the first version of this file, and it was wrong
-structurally rather than by degree: the bundle builds every hook payload through
+🔴 THE SUBAGENT RULE IS ASYMMETRIC: A SUBAGENT'S **READ** DOES NOT ARM THE PARENT,
+A SUBAGENT'S **WORK** DOES COUNT AS THE SESSION'S WORK. Two rounds of this file got
+it wrong in OPPOSITE directions, so state the rule and both failures, not one.
+
+The mechanism first. The bundle builds every hook payload through
 
     function Kf(e, t, r) { … return { session_id: t ?? kt(), …,
                                       agent_id: r?.agentId, agent_type: … } }
@@ -151,9 +151,26 @@ and PostToolUse calls it as `{...Kf(i, void 0, o), hook_event_name:"PostToolUse"
 — second argument `void 0`. So a tool call made INSIDE a dispatched subagent arrives
 carrying the PARENT's `session_id`, with only `agent_id` to tell them apart; the
 bundle's own schema says as much ("Use this field (not agent_type) to distinguish
-subagent calls from main-thread calls"). Accepting those armed the PARENT session's
-work flag off a subagent that merely happened to edit a file, and the parent's Stop
-then blocked on a card the parent never touched. MEASURED as a false positive.
+subagent calls from main-thread calls").
+
+  * ACCEPTING A SUBAGENT'S READ was wrong: it armed the PARENT off a subagent that
+    merely happened to touch a card, and the parent's Stop then blocked on a task the
+    parent never touched. MEASURED as a false positive. Still refused.
+  * REFUSING A SUBAGENT'S WORK was wrong, and it deleted the yield on the exact
+    incident this hook exists for. In BOTH measured failures the work ran in
+    dispatched LOCAL SUBAGENTS — `claudedocs/handoff-agent-attention-tooling.md`
+    records for #193/#194 that "'dispatch both' meant local subagents, not a devpod".
+    MEASURED with a positive control: `parent reads 193 -> a subagent does ALL the work
+    (Edit + git commit + git push + gh pr create, every payload carrying agent_id) ->
+    parent Stop` returned SILENT against a card with zero comments, while the SAME Edit
+    without `agent_id` returned `block`. The parent dispatched the subagent; that work
+    is the session's, and the parent owns the write-back.
+
+The work half is still gated on the session being ALREADY TRACKED — i.e. the parent
+read a card on its own thread — so a subagent cannot both arm and satisfy the trigger
+by itself. SubagentStop (and any Stop carrying an `agent_id`) remains refused
+outright: a subagent's turn never reaches the operator, so it owes them nothing
+(next-step-nudge.py refuses SubagentStop for the same reason).
 
 🔴 SCOPE OF THE WORK FLAG — SESSION-WIDE, NOT PER-TASK, AND THAT IS A KNOWN COST.
 Nothing in a PostToolUse payload says WHICH task an edit belongs to, so "work
@@ -161,6 +178,14 @@ happened" is necessarily a session-level fact. Two shapes therefore still fire
 without the session owing anything, and both are TESTED rather than hoped away:
   * read task N, then do unrelated work in a different repo -> blocks on N;
   * survey N and M, work on and write back only M -> blocks naming N.
+🔴 The THIRD shape that used to be here is now CLOSED, and by data this hook already
+stored rather than by a heuristic: `read N -> work -> write N back -> Stop (silent,
+correct) -> later merely READ M, no work at all -> Stop blocked naming M`. Work is a
+session-level fact, but "was there work AFTER **this task's own** read" is not — the
+state dir holds a per-task `first_read_ts` beside the session's `last_work_ts`, so a
+task whose read is NEWER than the last work event is skipped outright, before the
+live read is even attempted. Deterministic, and it also spends one fewer subprocess.
+It does NOT use `cwd` or `agent_type`, both of which are partial and heuristic.
 The escape is not prose. `--dismiss` (below) is a real, deterministic mechanism, it
 is named in the block text with the session id already filled in, and it clears that
 task from this session's ledger for good. The previous escape — "if you did NOT do
@@ -178,9 +203,9 @@ whose write-back genuinely is stale. Pinned by tests, so the noise is measured r
 than discovered in production.
 
 🔴 HOT PATH. PostToolUse fires after EVERY tool call of every session, and
-agent-ledger-hook.py already costs ~21 ms there. The fast path is: refuse anything
-carrying an `agent_id` (one dict read), resolve the state dir from `session_id`
-(string work, no IO), ONE `os.path.exists`, and the trigger regex. A session that has
+agent-ledger-hook.py already costs ~21 ms there. The fast path is: one dict read for
+`agent_id`, resolve the state dir from `session_id` (string work, no IO), ONE
+`os.path.exists`, and — for a main-thread call only — the trigger regex. A session that has
 never read a clawgate task and is not reading one now does nothing else — no
 directory creation, no state read, no subprocess, and it does not even IMPORT
 `subprocess` or `shutil` (see the deferred-import note below). That ordering is
@@ -188,14 +213,30 @@ pinned by tests that COUNT the calls and read the module list out of `-X importt
 because an earlier hook in this repo shipped with its throttle consulted AFTER the
 subprocess spawn while its comment claimed otherwise.
 
-Re-measured 2026-08-16 after the audit round, 30 runs per sample, four samples, on
-this host: 14.30 / 14.56 / 14.33 / 14.62 ms per call, against 14.57 / 14.43 / 14.14 /
-14.03 for the PRE-audit file measured in the same session and 7.7-8.2 ms for a bare
-interpreter start. I.e. PARITY — the run-to-run spread (~0.5 ms) is wider than the
-difference. Getting there took one deliberate change: the three work-detection
-patterns moved from module-level `re.compile` to pattern STRINGS compiled on first
-use, because none of them is reachable from the fast path (see their note below). A
-first cut with them compiled at import measured 14.7 against 13.9.
+Re-measured 2026-08-16 after the SECOND audit round, 30 runs per sample, EIGHT
+INTERLEAVED samples (1200 processes), every process spawned from an explicit argv list
+by a python parent — no shell, so zsh's non-splitting `$var` cannot produce the
+impossible 0.37 ms/call an earlier loop reported — and each sample asserting that all
+30 exited 0 before its mean is believed:
+
+    main-thread fast path   15.72 ms/call   vs 15.65 for the pre-delta file
+    subagent    fast path   15.80 ms/call   vs 15.53
+    bare interpreter start   8.90 ms
+
+The main-thread path is PARITY: +0.07 ms against a run-to-run spread of ~0.6 ms, which
+is wider. The subagent path is +0.27 ms — also inside that spread, but consistently
+above it in 7 of 8 samples, and it is a real added cost with a named cause: a
+subagent's payload no longer returns on one dict read, because its WORK has to be able
+to count (see the asymmetric rule above). It now resolves the state dir and does ONE
+`os.path.exists`; the trigger regex is still skipped for it. Both counts are pinned by
+tests that COUNT the calls. A FOUR-sample run of the same benchmark read +0.7 ms on
+the main thread and was pure drift — the interleave and the sample count are what
+distinguish the two, not one re-run.
+
+The earlier round's parity took one deliberate change, still in force: the three
+work-detection patterns are pattern STRINGS compiled on first use rather than
+module-level `re.compile`, because none of them is reachable from the fast path (see
+their note below). A first cut with them compiled at import measured 14.7 against 13.9.
 
 🔴 FAIL-OPEN, ALWAYS. Every internal exception exits 0 with an empty stdout and
 blocks nothing. main() has exactly ONE exit and it is always 0. A hook that wedges a
@@ -203,12 +244,22 @@ turn to enforce a bookkeeping ritual has inverted its own cost model.
 
 WHAT THIS STRUCTURALLY CANNOT SEE (say it here, not in a report nobody re-reads):
   * work done anywhere this hook is not running — a devpod agent, the clawgate web
-    UI, a human, opencode, or a host that has not had `home-manager switch` run;
+    UI, a human, opencode, or a host that has not had `home-manager switch` run.
+    🔴 A LOCAL DISPATCHED SUBAGENT IS **NOT** IN THIS LIST: this hook DOES run in one
+    (its PostToolUse payloads carry the parent's `session_id` plus an `agent_id`), and
+    its work IS counted — see the asymmetric rule above. It is a devpod/remote agent,
+    where no hook of ours runs at all, that is invisible;
+  * a READ performed only inside a subagent. The read half refuses `agent_id`, so
+    `subagent reads 193 -> subagent works -> parent Stop` is SILENT: nothing was ever
+    armed. The parent must have read the card on its own thread. Deliberate — the
+    alternative was a measured false positive — and the cost is named, not hidden;
   * a session that read the task via a route neither trigger matches (the board UI,
     an `/api/tasks?summary=1` list, someone pasting the body in);
   * whether the comment that DOES exist is any good — it checks that a `claude-code`
     comment exists after the last work event, never what it says;
-  * WHICH task a given edit belongs to (see SCOPE OF THE WORK FLAG above);
+  * WHICH task a given edit belongs to. The per-task read anchor below narrows this —
+    a task read AFTER the last work event is skipped — but among tasks read BEFORE it,
+    nothing distinguishes them (see SCOPE OF THE WORK FLAG above);
   * the `in_progress` flip, which it does not require: it gates the WRITE-BACK, which
     is the thing that was measured missing.
 
@@ -216,6 +267,10 @@ Deployed by `nix/home.nix`; registered on PostToolUse (no matcher) + Stop by
 `register-nudge-hook.py`. It has ONE other mode, and it is not a hook mode:
 
     clawgate-writeback-guard.py --dismiss <task_id> --session <session_id>
+
+Every invocation of that mode appends one JSON line to
+`~/.cache/claude-clawgate-writeback/dismissals` — it is a bypass of a deterministic
+guard, so it is MEASURABLE rather than merely discouraged in the block text.
 """
 import datetime
 import json
@@ -351,9 +406,11 @@ WORK_TOOLS = ("Edit", "Write", "NotebookEdit")
 # so grepping for them is routine rather than exotic. Seven such over-matches were
 # measured. Two deterministic narrowings, in this order:
 #
-#   1. QUOTED STRINGS AND COMMENTS ARE BLANKED FIRST (`_strip_literals`). A command
+#   1. QUOTED STRINGS AND COMMENTS ARE STRIPPED FIRST (`_strip_literals`). A command
 #      that merely mentions `git commit` inside quotes, or after a `#`, is talking
-#      about work, not doing it.
+#      about work, not doing it. A quoted run becomes QUOTED_PLACEHOLDER — a TOKEN,
+#      not whitespace, because it was a WORD in the shell's own parse and blanking it
+#      let the subcommand be eaten as a flag's value. See that constant's note.
 #   2. THE VERB MUST BE IN COMMAND POSITION — string start, or after a shell
 #      separator (`; & | ( ) { } newline backtick $(`), optionally through one of the
 #      keywords that legitimately precede a command (`then`/`else`/`do`/`!`). An
@@ -379,8 +436,31 @@ WORK_BASH_PAT = (
     r"|" + _CMD_START
     + r"gh\s+(?:pr\s+(?:create|merge)|release\s+create)\b")
 
-# Single-quoted runs, and double-quoted runs with backslash escapes. Replaced by a
-# SPACE rather than deleted, so `-m'x'commit` cannot be welded into a false match.
+# Single-quoted runs, and double-quoted runs with backslash escapes.
+#
+# 🔴 REPLACED BY THE PLACEHOLDER TOKEN BELOW, NOT BY A SPACE, AND A SPACE WAS MEASURED
+# WRONG IN BOTH DIRECTIONS. A quoted run is a WORD in the shell's own parse — a flag's
+# value, a commit message, a path. Blanking it to whitespace destroys that word, and
+# WORK_BASH_PAT's global-flag arm (`-[A-Za-z]\s+\S+\s+`) then has no `\S+` to consume,
+# so it reads the SUBCOMMAND as the flag's value:
+#
+#     git -C "$DEVRC" commit -m "msg"   ->  `git -C   commit -m  `  ->  NOT work
+#
+# `git -C <path>` is the form this repo's own CLAUDE.md MANDATES, so a quoted path is
+# routine; the guard silently never armed for it. Measured False for all five shapes
+# (`-C "$VAR"`, `-C '/lit'`, `-C "…" push`, `--git-dir="…"`, `-C "$H" -c k=v commit`)
+# — the only `git -C` fixtures in the test file were UNQUOTED, which is why nothing
+# caught it. A one-character placeholder that is a WORD restores all five.
+#
+# The token must be non-whitespace, or the weld the space was chosen to prevent comes
+# back. Measured over 13 kept positives, 16 negatives and the 5 shapes above:
+#     " "     0 lost   0 false-pos   0/5 recovered
+#     " '' "  0 lost   0 false-pos   4/5 recovered   + welds `git -m'x'commit` -> True
+#     "''"    0 lost   0 false-pos   5/5 recovered   + welds NOTHING
+# and `''` additionally CLOSES a false positive the space had: `git 'x'commit` blanked
+# to `git  commit` and matched. So the placeholder is strictly better than the space on
+# every measured axis, not a trade.
+QUOTED_PLACEHOLDER = "''"
 QUOTED_PAT = r"'[^']*'|\"(?:[^\"\\]|\\.)*\""
 # A `#` at the start of the string or after whitespace, to end of line. Applied AFTER
 # the quote strip, so a `#` living inside a quoted string is already gone.
@@ -399,7 +479,21 @@ def _state_root():
 
 
 def _sanitize(part):
-    return re.sub(r"[^A-Za-z0-9_.-]", "_", str(part))[:120]
+    """One path component, made safe to join onto the state root.
+
+    🔴 THE ALLOWED SET INCLUDES `.`, SO IT MUST EXCLUDE THE ALL-DOTS COMPONENTS. `/` is
+    already replaced, which leaves exactly `.`, `..`, `...` … as the strings that can
+    traverse: `--session ..` resolved to the state ROOT rather than to a session dir.
+    Bounded today (only `read-N`/`fires-N`/`unknown-N` are ever unlinked, all
+    `%d`-formatted, and `os.remove` refuses a directory) and nothing here is ever
+    interpolated into a shell — but "bounded" is a property of today's call sites, not
+    of this function. An enumerated fix, not a pattern: a component that is nothing but
+    dots is neutered; `.zshrc` or `v1.2.3` are untouched.
+    """
+    out = re.sub(r"[^A-Za-z0-9_.-]", "_", str(part))[:120]
+    if out and set(out) <= {"."}:
+        out = "_" * len(out)
+    return out
 
 
 def _state_dir(data):
@@ -565,6 +659,42 @@ def dismiss(state_dir, task_id):
     return removed
 
 
+def _dismissals_path():
+    """The audit log, deliberately OUTSIDE the per-session root that `prune` sweeps.
+
+    `_state_root()` is `…/claude-clawgate-writeback/s`; this is its sibling, so a
+    session dir ageing out cannot take the record of its dismissals with it.
+    """
+    return os.path.join(os.path.dirname(_state_root()), "dismissals")
+
+
+def record_dismissal(task_id, session_id, removed, now=None):
+    """Append ONE line per `--dismiss` invocation. Returns True if it was written.
+
+    🔴 `--dismiss` IS A REAL BYPASS OF A DETERMINISTIC GUARD, and until this existed it
+    left no trace anywhere — so "is it being used honestly, or is it the new way to make
+    the hook shut up?" was unanswerable. In a hook whose entire premise is that PROSE
+    LOST 2/2, gating the bypass on prose alone ("do NOT run this if you did work") and
+    then not measuring it is the same mistake one level up. One JSON line: when, which
+    task, which session, and what was actually cleared — a no-op dismissal records too,
+    so repeat attempts are visible rather than silently identical to a first one.
+
+    Fail-open and best-effort: an unwritable log NEVER changes what `--dismiss` does.
+    The dismissal is the user-visible act; the record is bookkeeping.
+    """
+    try:
+        path = _dismissals_path()
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "a") as fh:
+            fh.write(json.dumps({"ts": now_iso(now), "task_id": int(task_id),
+                                 "session": _sanitize(session_id),
+                                 "removed": sorted(removed)},
+                                sort_keys=True) + "\n")
+        return True
+    except Exception:                     # noqa: BLE001
+        return False
+
+
 def prune(ttl=STATE_TTL_SECS, now=None):
     """Drop session state directories older than `ttl`. Returns the names removed.
 
@@ -627,9 +757,18 @@ def task_read_ids(data):
 
 
 def _strip_literals(cmd):
-    """Blank out quoted runs and trailing `#` comments, so a command that MENTIONS a
-    work verb is not mistaken for one that RUNS it. See WORK_BASH_PAT's note."""
-    return re.sub(COMMENT_PAT, " ", re.sub(QUOTED_PAT, " ", cmd))
+    """Replace quoted runs with QUOTED_PLACEHOLDER and blank trailing `#` comments, so
+    a command that MENTIONS a work verb is not mistaken for one that RUNS it.
+
+    🔴 The quoted run becomes a TOKEN, not whitespace — a quoted flag value is a word
+    and deleting the word let the subcommand be eaten as the flag's value. See
+    QUOTED_PLACEHOLDER's note for the five measured shapes and the three-way sweep.
+    This function's exact output is deliberately NOT pinned by any test: the observable
+    is `is_work`, and an assertion on the internal string is a spelling of it that
+    breaks on any change to the placeholder while proving nothing extra.
+    """
+    return re.sub(COMMENT_PAT, " ",
+                  re.sub(QUOTED_PAT, QUOTED_PLACEHOLDER, cmd))
 
 
 def is_work(data):
@@ -845,12 +984,19 @@ def missing_text(task_id, first_read_ts, session_id=""):
 
 
 def unknown_text(task_id, first_read_ts, error, session_id=""):
+    # 🔴 THE SENTENCE MUST BE TRUE IN BOTH CONTEXTS IT IS READ IN. This text is emitted
+    # on its own as a `systemMessage` (the turn does end) AND spliced into a
+    # `decision:"block"` reason whenever some OTHER task is blocking — `stop_decision`
+    # joins `blocks + notices` into one string. The previous wording, "and this turn is
+    # ending normally", was MEASURED verbatim inside a block reason, i.e. the model was
+    # told the turn was ending while it was being forcibly continued. The claim this
+    # notice can actually make is about ITSELF, not about the turn.
     return (
         "clawgate write-back UNVERIFIED for task %(id)d: the board could not be "
         "reached to check whether a `claude-code` comment was written since %(ts)s "
         "(%(err)s). This is a NOTICE, not a block — nothing is being asserted about "
-        "the card, because nothing could be measured, and this turn is ending "
-        "normally.\n"
+        "the card, because nothing could be measured, and this notice on its own "
+        "does not hold the turn open.\n"
         "If this session did work on task %(id)d, write it back:\n"
         "  clawgatectl task comment %(id)d --body \"…\"\n"
         "  clawgatectl task status %(id)d ready_for_review\n"
@@ -872,18 +1018,35 @@ def post_tool_use(data, now=None):
     reading a task returns before touching the filesystem again. Nothing below the
     fast-path return runs for the overwhelming majority of tool calls.
     """
-    # 🔴 A SUBAGENT'S TOOL CALL IS NOT THE PARENT'S WORK — and it arrives wearing the
-    # parent's `session_id`, so this is the ONLY field that separates them. Checked
-    # before the state dir is even computed: a dispatched subagent that edits a file
-    # must not arm the parent session, whose Stop would then block on a card the
-    # parent merely read. See the `Kf()` quote in the module docstring.
-    if (data or {}).get("agent_id"):
-        return {"fast_path": True, "recorded": [], "work": False}
+    # 🔴 THE SUBAGENT RULE IS ASYMMETRIC, AND BOTH HALVES ARE THERE BECAUSE THE
+    # SYMMETRIC VERSIONS WERE EACH MEASURED WRONG. A subagent's tool call arrives
+    # wearing the PARENT's `session_id` (see the `Kf()` quote in the module docstring),
+    # so `agent_id` is the only field separating them — but the two directions are not
+    # the same question:
+    #
+    #   * a subagent's READ MUST NOT ARM the parent. Accepting it armed the parent off a
+    #     subagent that merely happened to read a card, and the parent's Stop then
+    #     blocked on a task the parent never touched. MEASURED as a false positive.
+    #   * a subagent's WORK IS THE SESSION'S WORK. The parent dispatched it; the parent
+    #     owns the write-back. REFUSING it is what the previous round got wrong, and it
+    #     deleted the yield on the exact incident this hook exists for: in BOTH measured
+    #     failures (#193/#194) the work ran in dispatched LOCAL SUBAGENTS — the canonical
+    #     handoff records "'dispatch both' meant local subagents, not a devpod". With the
+    #     refusal in place, `parent reads 193 -> subagent edits/commits/pushes/opens the
+    #     PR -> parent Stop` measured SILENT against a card with zero comments, while the
+    #     same Edit WITHOUT `agent_id` measured `block`.
+    #
+    # So: `agent_id` suppresses only the READ half. The work half still requires the
+    # session to be ALREADY TRACKED (`tracked` below), i.e. the parent read a card on
+    # its own thread — a subagent cannot both arm and satisfy the trigger by itself.
+    agent = bool((data or {}).get("agent_id"))
     state_dir = _state_dir(data)
     if state_dir is None:
         return {"fast_path": True, "recorded": [], "work": False}
     tracked = os.path.exists(state_dir)
-    ids = task_read_ids(data)
+    # A subagent's payload never contributes ids, so the trigger regex is skipped
+    # entirely for it — the fast path stays one `exists` and no `re` work.
+    ids = [] if agent else task_read_ids(data)
     if not tracked and not ids:
         # 🔴 THE FAST-PATH RETURN. Exactly ONE filesystem call (the `exists` above)
         # has happened and nothing has been spawned. Everything below this line —
@@ -954,6 +1117,11 @@ def stop_decision(data, reader=None, budget=STOP_BUDGET_SECS,
 
     session_id = d.get("session_id") or ""
     worked_at = last_work_ts(state_dir)
+    # 🔴 Parsed ONCE, outside the loop, and compared against each task's OWN read. Both
+    # sides come from THIS host's clock (`record_read` and `record_work` both call
+    # `now_iso`), so no skew allowance belongs here — unlike `writeback_state`, which
+    # compares a local stamp against the SERVER's `createdAt`.
+    worked_at_epoch = parse_ts(worked_at)
     deadline = clock() + budget
     blocks, notices = [], []
     # No `[:MAX_TASKS]` slice here: `record_read` refuses to create a sixth `read-`
@@ -961,10 +1129,26 @@ def stop_decision(data, reader=None, budget=STOP_BUDGET_SECS,
     # slice was a second copy of a cap already enforced at the writer — unkillable,
     # and pinned instead by test_at_most_five_task_ids_are_tracked_per_session.
     for tid in sorted(ids):
+        first_read_ts = ids[tid]
+        # 🔴 THE PER-TASK READ ANCHOR. `work_after_read` above is a SESSION-level fact;
+        # this is the per-task one. A task read AFTER the session's last work event is
+        # owed nothing yet — the measured false positive was `read N, work, write N
+        # back, then merely read M` blocking on M. Skipped BEFORE the budget check and
+        # the live read, so it costs no subprocess either.
+        #
+        # `>=`, not `>`: one Bash call can be both a read and work (`clawgatectl task
+        # get 194 && git commit -m x`), and `post_tool_use` stamps both from the SAME
+        # `now`, so an equal pair is work ON that task, not work before it.
+        #
+        # Either side unparseable -> DO NOT skip. A truncated `work` stamp must not
+        # silently disable the guard; `work_after_read` already proved work happened.
+        read_at_epoch = parse_ts(first_read_ts)
+        if (worked_at_epoch is not None and read_at_epoch is not None
+                and worked_at_epoch < read_at_epoch):
+            continue
         remaining = deadline - clock()
         if remaining <= 0:
             break
-        first_read_ts = ids[tid]
         err = "the board returned a task payload this hook could not read"
         try:
             task = reader(tid, timeout=min(PER_TASK_TIMEOUT_SECS, remaining))
@@ -1058,14 +1242,18 @@ def dismiss_main(argv):
         sys.stdout.write("not a session id: %s\n" % _sanitize(sess))
         return
     removed = dismiss(state_dir, task_id)
+    record_dismissal(task_id, sess, removed)
     if removed:
         sys.stdout.write("clawgate write-back guard: dismissed task %d for session "
                          "%s (cleared %s). It will not ask about this task again.\n"
                          % (task_id, _sanitize(sess), ", ".join(sorted(removed))))
     else:
+        # 🔴 The state dir is NOT printed. It is an absolute path containing $HOME, and
+        # everything this writes goes to stdout, which the model reads and may quote
+        # onward. The session id is the only part the caller needs to see.
         sys.stdout.write("clawgate write-back guard: nothing to dismiss — task %d is "
-                         "not in session %s's ledger (%s).\n"
-                         % (task_id, _sanitize(sess), state_dir))
+                         "not in session %s's ledger.\n"
+                         % (task_id, _sanitize(sess)))
 
 
 def main():

--- a/scripts/claude-hooks/register-nudge-hook.py
+++ b/scripts/claude-hooks/register-nudge-hook.py
@@ -14,13 +14,25 @@ Registers:
     Stop/clawgate-stop/tmux hooks).
   * Stop: next-step-nudge.py
   * SessionStart / UserPromptSubmit / PostToolUse / Stop: agent-ledger-hook.py
+  * PostToolUse / Stop: clawgate-writeback-guard.py (the hook that makes the clawgate
+    task write-back non-optional — PostToolUse watches for a read of a specific task
+    id and for real work after it, Stop re-reads the board live and blocks a turn
+    that is about to end with the card still uncommented).
 
-🔴 agent-ledger-hook.py is registered on PostToolUse with NO `matcher`, unlike the
-three nudges above. Those are about the shape of a Bash COMMAND, so `Bash` is the
-right scope; the ledger records that a tool call HAPPENED, and scoping it to Bash
-would silently stop the heartbeat for a session doing a long stretch of Read/Edit
-work — which then renders `stale` while it is demonstrably working, because
-`classify_status` lets `stale` win over `busy`.
+🔴 TWO of these carry NO `matcher` on PostToolUse — agent-ledger-hook.py and
+clawgate-writeback-guard.py — unlike the three nudges above. Those three are about
+the shape of a Bash COMMAND, so `Bash` is the right scope. The other two are not:
+
+  * the ledger records that a tool call HAPPENED, and scoping it to Bash would
+    silently stop the heartbeat for a session doing a long stretch of Read/Edit work
+    — which then renders `stale` while it is demonstrably working, because
+    `classify_status` lets `stale` win over `busy`.
+  * the write-back guard's second job is detecting that REAL WORK followed a task
+    read, and `Edit` / `Write` / `NotebookEdit` are exactly that work. Under a `Bash`
+    matcher the guard would never see an agent that read a card and then edited files
+    for an hour — the commonest shape of the failure it exists to catch — and would
+    stay silent for it. The Bash half (`git commit` / `git push` / `gh pr create`) is
+    the part a matcher WOULD cover, and it is the smaller half.
 
 The cost, MEASURED rather than asserted: ~21 ms per call against ~9 ms for a bare
 interpreter start, and the hook throttles at 30s, so the overwhelming majority of
@@ -36,7 +48,8 @@ clawgate stop hook (drives remote approval) and claude-notify.py (drives turn-fi
 notifications). Clobbering any of them is a serious regression, so registration here is
 strictly APPEND-ONLY — an entry is added only when its exact command string is absent
 from the event's existing entries, and no existing entry is ever rewritten, reordered or
-removed. tests/test_register_nudge_hook.py asserts all four coexist afterwards.
+removed. tests/test_register_nudge_hook.py asserts every owner coexists afterwards, as a
+SET EQUALITY so the assertion fails when the set grows as well as when it shrinks.
 
 next-step-nudge is registered on Stop ONLY, not SubagentStop: a subagent's turn ends
 without ever reaching the operator, so it owes them no next step. The hook refuses that
@@ -66,6 +79,12 @@ NOTIFY_EVENTS = ["UserPromptSubmit", "Stop", "SubagentStop"]
 # no matcher — see the module docstring for why it is not scoped to Bash.
 LEDGER_CMD = "python3 ~/.claude/hooks/agent-ledger-hook.py"
 LEDGER_EVENTS = ["SessionStart", "UserPromptSubmit", "PostToolUse", "Stop"]
+
+# The clawgate write-back guard. Two events, and — like the ledger above — a
+# PostToolUse entry with NO matcher, because half of what it watches for is an
+# Edit/Write/NotebookEdit tool call. See the module docstring.
+WRITEBACK_CMD = "python3 ~/.claude/hooks/clawgate-writeback-guard.py"
+WRITEBACK_EVENTS = ["PostToolUse", "Stop"]
 
 # Hooks registered on exactly one event each: {event: [command, ...]}.
 SINGLE_EVENT_CMDS = {
@@ -116,6 +135,18 @@ for event in LEDGER_EVENTS:
         continue
     arr.append({"hooks": [{"type": "command", "command": LEDGER_CMD}]})
     added.append("%s: %s" % (event, LEDGER_CMD))
+
+# --- the clawgate write-back guard (append-only, same discipline) ------------
+# 🔴 Stop already carries three foreign owners at this point; this one is appended
+# after them, never inserted, so they have all observed the turn before it can add
+# anything to it. It is the only entry here that can BLOCK, and it caps itself at two
+# consecutive blocks per task — well inside the CLI's own cap of 8.
+for event in WRITEBACK_EVENTS:
+    arr = hooks.setdefault(event, [])
+    if WRITEBACK_CMD in registered_commands(arr):
+        continue
+    arr.append({"hooks": [{"type": "command", "command": WRITEBACK_CMD}]})
+    added.append("%s: %s" % (event, WRITEBACK_CMD))
 
 # --- single-event hooks (append-only, same discipline) -----------------------
 for event, cmds in SINGLE_EVENT_CMDS.items():

--- a/scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
+++ b/scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
@@ -253,6 +253,17 @@ def test_two_ids_in_one_command_are_both_recorded_and_deduplicated():
     payload(tool_name="NotebookEdit", tool_input={"notebook_path": "/x"}),
     bash("git commit -m 'x'"),
     bash("git -C /home/zach/workspace/devrc commit -m 'x'"),
+    # 🔴 THE QUOTED GLOBAL-FLAG VALUE. All five measured False before the placeholder
+    # fix: `_strip_literals` blanked the quoted run to WHITESPACE, and WORK_BASH_PAT's
+    # `-[A-Za-z]\s+\S+\s+` arm then ate the SUBCOMMAND as `-C`'s value. `git -C <path>`
+    # is the form this repo's own CLAUDE.md mandates, so a quoted path is routine — and
+    # the only `git -C` fixtures this file carried were UNQUOTED, which is exactly why
+    # nothing saw it. Fail-open (the guard silently never armed), but it gutted the fix.
+    bash('git -C "$DEVRC" commit -m "msg"'),
+    bash("git -C '/tmp/wt' commit -m x"),
+    bash('git -C "/home/zach/workspace/devrc" push origin main'),
+    bash('git --git-dir="/a/.git" commit -m x'),
+    bash('git -C "$H" -c user.name=x commit -m y'),
     bash("git push -u origin feat/x"),
     bash("gh pr create --fill --base main"),
     # Previously FAIL-OPEN under-matches: both ship something, neither was work.
@@ -305,22 +316,62 @@ def test_a_look_around_is_not_work(data):
     "echo 'first do a thing; git commit -m x'",
     'echo "build it && git push"',
     "rg -n 'foo | git push' claude/",
+    # 🔴 THE WELD CASES — why QUOTED_PLACEHOLDER is a TOKEN and not whitespace. A
+    # quoted run abutting a verb must not be blanked into a separator that manufactures
+    # a command out of two half-words. `git 'x'commit` blanked to `git  commit` and
+    # matched: a false positive the SPACE had and the placeholder closes. `git
+    # -m'x'commit` is the case the space was originally chosen for, and it must stay
+    # closed — the auditor's proposed ` '' ` (a token WITH surrounding spaces) reopened
+    # exactly this one, which is why the replacement carries no spaces.
+    "git 'x'commit",
+    "git -m'x'commit",
 ])
 def test_TALKING_about_work_is_not_DOING_work(cmd):
     """🔴 The single negative case this file used to carry did not contain the literal
-    at all, so the whole over-match class was untested. `_strip_literals` blanks quoted
-    runs and `#` comments; the command-position anchor rejects the unquoted echo."""
+    at all, so the whole over-match class was untested. `_strip_literals` replaces
+    quoted runs with a placeholder TOKEN and blanks `#` comments; the command-position
+    anchor rejects the unquoted echo."""
     assert guard.is_work(bash(cmd)) is False
 
 
 def test_the_positive_control_for_the_literal_stripper():
     """🔴 Nine `False`s are indistinguishable from an `is_work` wired to nothing. The
     same commands with the verb moved OUT of the quotes must all be True — and the
-    stripper must not eat a real `git commit -m 'msg'`, whose message IS quoted."""
+    stripper must not eat a real `git commit -m 'msg'`, whose message IS quoted.
+
+    🔴 The third assertion used to be `_strip_literals(...).strip() == "echo"`, i.e. a
+    pin on this function's INTERNAL output string. That is a spelling of the guard, not
+    the guard: it broke the moment the quoted run stopped being replaced by whitespace
+    (the fix for the `git -C "<path>" commit` miss below) while proving nothing extra,
+    since the observable was always `is_work`. It is now asserted as what the stripper
+    is FOR — neither verb survives into the text the work regex sees, in a command that
+    needs BOTH halves (a quoted run and a `#` comment) — plus a control proving the
+    check can move.
+    """
     assert guard.is_work(bash("git commit -m 'wire up the grep for git commit'")) \
         is True
     assert guard.is_work(bash("grep -rn foo scripts/ && git push")) is True
-    assert guard._strip_literals("echo 'git commit' # git push") .strip() == "echo"
+
+    both_halves = "echo 'git commit' # git push"
+    stripped = guard._strip_literals(both_halves)
+    assert "git commit" not in stripped and "git push" not in stripped
+    assert guard.is_work(bash(both_halves)) is False
+    # ...and the control: the SAME shape with a real verb outside both the quotes and
+    # the comment must still be True, so the two `False`s above cannot be a stripper
+    # that simply eats everything.
+    assert guard.is_work(bash("echo 'git commit'; git push # git commit")) is True
+
+
+def test_the_quote_strip_runs_BEFORE_the_comment_strip(home):
+    """🔴 THE ORDER IS LOAD-BEARING, and swapping it is a semantic mutant that no other
+    case in this file can see. A `#` INSIDE a quoted string is not a comment: strip
+    comments first and `echo "a # b" && git commit` loses everything from the `#`
+    onward — including the real, unquoted `git commit` — and a genuine work command
+    silently stops being work. Quotes first, comments second."""
+    assert guard.is_work(bash('echo "a # b" && git commit -m x')) is True
+    assert guard.is_work(bash("echo 'a # b' ; git push")) is True
+    # ...and the direction the comment strip is actually for still holds.
+    assert guard.is_work(bash("ls -la  # then git commit")) is False
 
 
 # =========================================================================== #
@@ -377,6 +428,34 @@ def test_the_fast_path_does_exactly_one_stat_and_nothing_else(home, monkeypatch)
     guard.post_tool_use(bash("ls -la"))
     assert _mine(calls) == [("exists", state_dir())], calls
     assert [c for c in calls if c[0] == "subprocess"] == []
+
+
+def test_a_SUBAGENTS_call_on_an_untracked_session_also_costs_exactly_one_stat(
+        home, monkeypatch):
+    """🔴 THE COST THE ASYMMETRIC RULE ADDED, PINNED RATHER THAN ASSUMED. A subagent's
+    payload used to return on a single dict read; it now resolves the state dir and
+    stats it, because its WORK has to be able to count. That is ONE `os.path.exists`
+    and nothing else — in particular the trigger regex is skipped entirely, since a
+    subagent contributes no ids. MEASURED end to end at 15.80 ms/call against 15.53 for
+    the pre-delta file (30 runs x 8 interleaved samples, bare interpreter 8.90).
+    """
+    calls = _io_spy(monkeypatch)
+    guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/x"},
+                                agent_id="agent_012xyz"))
+    assert _mine(calls) == [("exists", state_dir())], calls
+    assert [c for c in calls if c[0] == "subprocess"] == []
+
+
+def test_a_subagents_call_does_not_evaluate_the_TRIGGER_regex(home, monkeypatch):
+    """A subagent cannot arm the read half, so consulting `task_read_ids` for it would
+    be pure hot-path cost. Made to raise rather than counted, so a mutation that drops
+    the `[] if agent` short-circuit is loud."""
+    monkeypatch.setattr(guard, "task_read_ids",
+                        lambda d: (_ for _ in ()).throw(
+                            AssertionError("task_read_ids ran for a subagent")))
+    out = guard.post_tool_use(bash("clawgatectl task get 193",
+                                   agent_id="agent_012xyz"))
+    assert out["recorded"] == []
 
 
 def test_the_positive_control_for_that_count(home, monkeypatch):
@@ -963,15 +1042,43 @@ def test_a_payload_carrying_an_agent_id_is_refused(home):
     assert r.calls == []
 
 
-def test_a_SUBAGENTS_tool_call_never_arms_the_PARENT_session(home):
-    """🔴 PROBE C, MEASURED AS A FALSE POSITIVE BEFORE THIS FIX. The bundle builds a
-    PostToolUse payload as `{...Kf(i, void 0, o), hook_event_name:"PostToolUse", …}`,
-    and `Kf`'s `session_id` is `t ?? kt()` with `t` undefined — so a tool call made
-    inside a dispatched subagent arrives carrying the PARENT's session id, with only
-    `agent_id` to tell them apart. The parent reads the card, the subagent does the
-    editing, and the parent's Stop then blocked on work it never did."""
+@pytest.mark.parametrize("work_payload", [
+    payload(tool_name="Edit", tool_input={"file_path": "/x"}, agent_id="agent_012xyz"),
+    bash("git commit -m 'ship it'", agent_id="agent_012xyz"),
+    bash("git push -u origin feat/x", agent_id="agent_012xyz"),
+    bash("gh pr create --fill --base main", agent_id="agent_012xyz"),
+])
+def test_a_SUBAGENTS_work_IS_the_parent_sessions_work(home, work_payload):
+    """🔴 THE MOTIVATING SHAPE, AND A PREVIOUS ROUND DELETED THE YIELD ON IT. In BOTH
+    measured failures (#193/#194) the work ran in dispatched LOCAL subagents —
+    `claudedocs/handoff-agent-attention-tooling.md` records that "'dispatch both' meant
+    local subagents, not a devpod" — so refusing every PostToolUse carrying an
+    `agent_id` made this hook SILENT on the exact incident it exists to prevent.
+    MEASURED: `parent reads 193 -> a subagent does all the work -> parent Stop`
+    returned ('silent', '') against a card with ZERO comments.
+
+    The parent dispatched the subagent; that work is the session's, and the parent owns
+    the write-back. So: the read half still refuses `agent_id` (the test below), the
+    work half does not.
+    """
+    guard.post_tool_use(bash("clawgatectl task get 193"))       # parent, main thread
+    out = guard.post_tool_use(work_payload)                     # subagent does it all
+    assert out["work"] is True
+    assert guard.work_after_read(state_dir()) is True
+    r = Reader(result=task(comments=[]))
+    kind, text = guard.stop_decision(payload("Stop"), reader=r)
+    assert kind == "block"
+    assert r.calls and r.calls[0][0] == 193
+    assert "193" in text
+
+
+def test_the_NEGATIVE_control_a_subagents_LOOK_AROUND_is_still_not_work(home):
+    """The counterpart control: accepting a subagent's work must not degenerate into
+    accepting everything a subagent does. A subagent that only reads files leaves the
+    parent unarmed — otherwise the four `True`s above are green because `is_work` is
+    no longer consulted on this path at all."""
     guard.post_tool_use(bash("clawgatectl task get 193"))
-    out = guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/x"},
+    out = guard.post_tool_use(payload(tool_name="Read", tool_input={"file_path": "/x"},
                                       agent_id="agent_012xyz"))
     assert out["work"] is False
     assert guard.work_after_read(state_dir()) is False
@@ -980,9 +1087,9 @@ def test_a_SUBAGENTS_tool_call_never_arms_the_PARENT_session(home):
     assert r.calls == []
 
 
-def test_the_positive_control_for_the_agent_id_refusal(home):
-    """The identical payload WITHOUT `agent_id` must arm it — otherwise the refusal
-    above is green because nothing in this fixture could ever set the flag."""
+def test_the_positive_control_for_the_agent_id_asymmetry(home):
+    """The identical Edit WITHOUT `agent_id` must arm it too — so the assertions above
+    are about the ASYMMETRY and not about a flag nothing in this fixture could set."""
     guard.post_tool_use(bash("clawgatectl task get 193"))
     out = guard.post_tool_use(payload(tool_name="Edit",
                                       tool_input={"file_path": "/x"}))
@@ -990,11 +1097,28 @@ def test_the_positive_control_for_the_agent_id_refusal(home):
     assert guard.work_after_read(state_dir()) is True
 
 
-def test_a_subagents_READ_also_does_not_arm_the_parent(home):
-    """The other half: the refusal is checked before the state dir is even computed,
-    so a subagent surveying the board cannot create a ledger for its parent."""
+def test_a_subagents_READ_does_not_arm_the_parent(home):
+    """🔴 THE OTHER HALF OF THE ASYMMETRY, AND IT WAS A MEASURED FALSE POSITIVE. A
+    subagent surveying the board must not create a ledger for its parent, whose Stop
+    would then block on a card the parent never touched. `agent_id` suppresses the READ
+    unconditionally — before the state dir is even used."""
     guard.post_tool_use(bash("clawgatectl task get 193", agent_id="agent_012xyz"))
     assert not os.path.exists(state_dir())
+
+
+def test_a_subagent_can_neither_ARM_nor_SATISFY_the_trigger_by_itself(home):
+    """🔴 THE COMBINED SHAPE — finding 2C, which must stay fixed. A subagent that reads
+    the card AND does the work leaves the parent with nothing: the read was refused, so
+    there is no ledger, so the work half's `tracked` gate is false and no state dir is
+    ever created. Parent Stop is SILENT and never even measures."""
+    guard.post_tool_use(bash("clawgatectl task get 193", agent_id="agent_012xyz"))
+    out = guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/x"},
+                                      agent_id="agent_012xyz"))
+    assert out["work"] is False
+    assert not os.path.exists(state_dir())
+    r = Reader(result=task(comments=[]))
+    assert guard.stop_decision(payload("Stop"), reader=r) == ("silent", "")
+    assert r.calls == []
 
 
 def test_SubagentStop_produces_no_output_through_the_real_process(home, tmp_path):
@@ -1812,3 +1936,289 @@ def test_scrub_truncates_and_a_failing_client_cannot_flood_the_transcript(tmp_pa
     assert len(tail) == 120, tail
     assert tail.startswith("l1 l2 ")
     assert msg.count("\n") == 0
+
+
+# =========================================================================== #
+# 20. THE PER-TASK READ ANCHOR, THE NOTICE'S OWN CLAIM, AND THE DISMISSAL LEDGER
+# =========================================================================== #
+
+# 🔴 One instant per role, all distinct and none derived from another, so a fixture
+# cannot pass by collapsing two anchors into one.
+READ_194_EPOCH = READ_PLUS_1H                    # 13:00 — AFTER the 12:30 work event
+WORK_AFTER_194_EPOCH = 1786799400.0              # 13:10 — the positive control's work
+COMMENT_TS = "2026-08-15T13:00:00.000000Z"       # the 193 write-back
+
+
+def _reader_193_written_194_bare():
+    """193 has a `claude-code` comment; 194 has none. Records every call, so "194 was
+    never measured" is assertable as an ABSENCE of the live read and not merely as a
+    quiet verdict."""
+    calls = []
+
+    def reader(task_id, timeout=None):
+        calls.append(task_id)
+        if task_id == 194:
+            return task(task_id=194, comments=[])
+        return task(task_id=193, comments=[comment(created=COMMENT_TS)])
+    return reader, calls
+
+
+def test_a_task_read_AFTER_the_last_work_event_is_owed_NOTHING(home):
+    """🔴 PRIOR FINDING 2B, MEASURED ON BOTH COMMITS — pre-existing, not a delta
+    regression. `read 193 -> work -> write 193 back -> Stop` is correctly silent; then
+    merely READING 194, with no work at all after it, BLOCKED and named 194.
+
+    "Was there work in this session" is necessarily session-wide, but "was there work
+    after THIS task's own read" is not: the state dir already stores a per-task
+    `first_read_ts` beside the session's `last_work_ts`. Comparing them is
+    deterministic with data the hook already has — no `cwd`, no `agent_type`, both of
+    which are partial and heuristic. 194 is skipped BEFORE the live read, so the fix
+    also spends one fewer subprocess.
+    """
+    guard.post_tool_use(bash("clawgatectl task get 193"), now=READ_EPOCH)
+    guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/x"}),
+                        now=WORK_EPOCH)
+    guard.post_tool_use(bash("clawgatectl task get 194"), now=READ_194_EPOCH)
+
+    reader, calls = _reader_193_written_194_bare()
+    assert guard.stop_decision(payload("Stop"), reader=reader) == ("silent", "")
+    # 193 WAS measured (and came back written); 194 was never even asked about.
+    assert calls == [193]
+
+
+def test_the_positive_control_for_the_read_anchor(home):
+    """The identical session with ONE thing changed — a work event AFTER 194's read —
+    must block and name 194. Without this the silence above is indistinguishable from a
+    Stop path that had stopped looking at 194 for some other reason."""
+    guard.post_tool_use(bash("clawgatectl task get 193"), now=READ_EPOCH)
+    guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/x"}),
+                        now=WORK_EPOCH)
+    guard.post_tool_use(bash("clawgatectl task get 194"), now=READ_194_EPOCH)
+    guard.post_tool_use(bash("git commit -m 'now work on 194'"),
+                        now=WORK_AFTER_194_EPOCH)
+
+    reader, calls = _reader_193_written_194_bare()
+    kind, text = guard.stop_decision(payload("Stop"), reader=reader)
+    assert kind == "block"
+    assert 194 in calls
+    assert "task status 194 ready_for_review" in text
+
+
+def test_the_read_anchor_uses_the_TASKS_OWN_read_not_the_earliest_one(home):
+    """The comparison is per-task, not "the session's oldest read". 193 (read before
+    the work) still fires; 194 (read after it) does not — in ONE Stop, so a mutant that
+    replaced the per-task read with a session-wide minimum or maximum is visible."""
+    guard.post_tool_use(bash("clawgatectl task get 193"), now=READ_EPOCH)
+    guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/x"}),
+                        now=WORK_EPOCH)
+    guard.post_tool_use(bash("clawgatectl task get 194"), now=READ_194_EPOCH)
+
+    calls = []
+
+    def reader(task_id, timeout=None):
+        calls.append(task_id)
+        return task(task_id=task_id, comments=[])       # NEITHER is written back
+
+    kind, text = guard.stop_decision(payload("Stop"), reader=reader)
+    assert kind == "block"
+    assert calls == [193]
+    assert "task status 193 ready_for_review" in text
+    assert "task status 194" not in text
+
+
+def test_a_read_in_the_SAME_call_as_the_work_still_counts_as_work_on_it(home):
+    """🔴 `>=`, not `>`. One Bash call can be both the read and the work
+    (`clawgatectl task get 194 && git commit -m x`), and `post_tool_use` stamps both
+    from the SAME `now` — so an equal pair is work ON that task, not work before it. An
+    off-by-one here would silence the guard for every single-command pickup."""
+    guard.post_tool_use(bash("clawgatectl task get 194 && git commit -m x"),
+                        now=READ_194_EPOCH)
+    r = Reader(result=task(task_id=194, comments=[]))
+    kind, text = guard.stop_decision(payload("Stop"), reader=r)
+    assert kind == "block"
+    assert [c[0] for c in r.calls] == [194]
+    assert "task status 194 ready_for_review" in text
+
+
+def test_an_UNREADABLE_work_stamp_does_not_silently_disable_the_anchor(home):
+    """🔴 FAIL-LOUD, deliberately, and the opposite direction from `writeback_state`'s
+    fallback. `work_after_read` has already proved work happened; if the stamp itself
+    cannot be parsed we cannot say the work predates any read, so the task is still
+    measured. A truncated file must not be a silent global off-switch."""
+    sd = seed(task_id=193, ts=READ_TS)
+    with open(os.path.join(sd, guard.STATE_WORK), "w") as fh:
+        fh.write("1")                     # the shape an older build wrote
+    assert guard.last_work_ts(sd) == "1"
+    assert guard.parse_ts("1") is None
+    r = Reader(result=task(comments=[]))
+    kind, _ = guard.stop_decision(payload("Stop"), reader=r)
+    assert kind == "block"
+    assert [c[0] for c in r.calls] == [193]
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE NOTICE'S CLAIM ABOUT ITSELF — it is read in TWO contexts, so it must be
+# true in both. `stop_decision` joins `blocks + notices` into ONE reason string, so
+# a notice's text is spliced verbatim into a `decision:"block"` payload whenever any
+# OTHER task is blocking. The previous wording ("and this turn is ending normally")
+# was measured verbatim inside such a reason: the model was told the turn was ending
+# while it was being forcibly continued.
+#
+# Pinned as the WHOLE normalised sentence, not as a keyword. A two-word check here
+# would be walkable by rewording — and the sentence IS the artifact under test.
+# --------------------------------------------------------------------------- #
+NOTICE_SELF_CLAIM = ("This is a NOTICE, not a block — nothing is being asserted "
+                     "about the card, because nothing could be measured, and this "
+                     "notice on its own does not hold the turn open.")
+
+
+def _norm(s):
+    return " ".join(s.split())
+
+
+def test_the_notice_claims_only_what_is_true_of_the_NOTICE(home):
+    assert NOTICE_SELF_CLAIM in _norm(guard.unknown_text(193, READ_TS, "boom", SESSION))
+
+
+def test_that_same_sentence_is_still_true_when_it_rides_inside_a_BLOCK(home, capsys):
+    """One task measurably missing, one unmeasurable. The reason string carries both,
+    and the CLI forces a continuation — so any sentence in it asserting the turn is
+    ending is false at the moment the model reads it."""
+    guard.post_tool_use(bash("clawgatectl task get 193"), now=READ_EPOCH)
+    guard.post_tool_use(bash("clawgatectl task get 194"), now=READ_EPOCH)
+    guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/x"}),
+                        now=WORK_EPOCH)
+
+    def reader(task_id, timeout=None):
+        if task_id == 194:
+            raise guard.LiveReadError("board unreachable")
+        return task(task_id=193, comments=[])
+
+    verdict = guard.stop_decision(payload("Stop"), reader=reader)
+    assert verdict[0] == "block"
+    out = emitted(capsys, verdict)
+    reason = _norm(out["reason"])
+    # The context really is a forced continuation, per the rule transcribed from the
+    # installed bundle — so this is not a hypothetical splice.
+    assert forces_a_continuation(out) is True
+    assert "UNVERIFIED for task 194" in reason
+    assert NOTICE_SELF_CLAIM in reason
+
+
+def test_a_notice_ALONE_still_ends_the_turn_and_carries_the_same_sentence(home,
+                                                                          capsys):
+    """The other context, byte-identical text: emitted on its own the notice does NOT
+    force a continuation. Both halves of "true in both contexts" measured, not one."""
+    seed()
+    verdict = guard.stop_decision(payload("Stop"),
+                                  reader=Reader(raises=guard.LiveReadError("down")))
+    assert verdict[0] == "notice"
+    out = emitted(capsys, verdict)
+    assert forces_a_continuation(out) is False
+    assert NOTICE_SELF_CLAIM in _norm(out["systemMessage"])
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE DISMISSAL LEDGER — `--dismiss` is a real bypass of a deterministic guard,
+# gated only by prose in the block text, in a hook whose whole premise is that PROSE
+# LOST 2/2. It used to write no record anywhere, so "is it being used honestly?" was
+# structurally unanswerable and the loop could never be closed.
+# --------------------------------------------------------------------------- #
+def test_every_dismissal_appends_one_line_to_the_ledger(home):
+    seed()
+    p = run_cli(["--dismiss", "193", "--session", SESSION], home)
+    assert p.returncode == 0
+    with open(guard._dismissals_path()) as fh:
+        lines = [ln for ln in fh.read().splitlines() if ln.strip()]
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec["task_id"] == 193
+    assert rec["session"] == SESSION
+    assert rec["removed"] == ["read-193"]
+    assert guard.parse_ts(rec["ts"]) is not None
+
+
+def test_a_REPEAT_dismissal_is_recorded_too_and_is_distinguishable(home):
+    """A no-op dismissal records as well — otherwise "ran it three times" is
+    indistinguishable from "ran it once", which is exactly the thing being measured."""
+    seed()
+    run_cli(["--dismiss", "193", "--session", SESSION], home)
+    run_cli(["--dismiss", "193", "--session", SESSION], home)
+    with open(guard._dismissals_path()) as fh:
+        recs = [json.loads(ln) for ln in fh.read().splitlines() if ln.strip()]
+    assert len(recs) == 2
+    assert recs[0]["removed"] == ["read-193"]
+    assert recs[1]["removed"] == []       # the second cleared nothing
+
+
+def test_the_ledger_survives_the_state_prune(home):
+    """🔴 It lives OUTSIDE the per-session root `prune` sweeps. A record that ages out
+    with the session that produced it cannot answer a question asked weeks later."""
+    seed()
+    guard.record_dismissal(193, SESSION, ["read-193"])
+    # 🔴 STRUCTURAL, not just behavioural. `prune` sweeps with `shutil.rmtree`, which
+    # silently no-ops on a FILE — so a ledger moved INSIDE the swept root would survive
+    # this test by accident while being one `os.remove` away from vanishing. Assert the
+    # RELATIONSHIP (the ledger is not under the directory prune walks) as well as the
+    # outcome.
+    root = os.path.normpath(guard._state_root())
+    assert not os.path.normpath(guard._dismissals_path()).startswith(root + os.sep)
+    guard.prune(ttl=0)
+    assert guard.tracked_ids(state_dir()) == {}     # the session state IS gone
+    assert os.path.exists(guard._dismissals_path())
+
+
+def test_an_UNWRITABLE_ledger_never_changes_what_dismiss_does(home, monkeypatch):
+    """🔴 FAIL-OPEN. The dismissal is the user-visible act; the record is bookkeeping.
+    Driven with the writer made to raise, through the same entry point the CLI uses."""
+    sd = seed()
+    monkeypatch.setattr(guard, "record_dismissal",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("read-only")))
+    with pytest.raises(OSError):
+        guard.dismiss_main(["--dismiss", "193", "--session", SESSION])
+    assert guard.tracked_ids(sd) == {}     # the dismissal itself already landed
+
+
+def test_the_ledger_writer_swallows_its_own_failure(home, monkeypatch):
+    """...and in the real process it never even raises: `record_dismissal` returns
+    False rather than propagating, so `main()`'s fail-open backstop is not what is
+    keeping the CLI alive."""
+    monkeypatch.setattr(guard.os, "makedirs",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("read-only")))
+    assert guard.record_dismissal(193, SESSION, []) is False
+
+
+def test_the_not_found_message_does_not_print_an_absolute_path(home, capsys):
+    """🔴 Everything this writes goes to stdout, which the model reads and may quote
+    onward. The state dir is an absolute path containing $HOME; the session id is the
+    only part the caller needs."""
+    guard.dismiss_main(["--dismiss", "999", "--session", SESSION])
+    out = capsys.readouterr().out
+    assert "nothing to dismiss" in out
+    assert str(home) not in out
+    assert guard._state_root() not in out
+    assert SESSION in out                 # ...and it still says WHICH session
+
+
+@pytest.mark.parametrize("raw,want", [
+    (".", "_"),
+    ("..", "__"),
+    ("...", "___"),
+])
+def test_sanitize_neuters_an_all_dots_component(raw, want):
+    """🔴 The allowed set includes `.`, so `--session ..` resolved one level UP to the
+    state root. Bounded today — only `read-N`/`fires-N`/`unknown-N` are ever unlinked,
+    all `%d`-formatted, and `os.remove` refuses a directory — but "bounded" is a
+    property of today's call sites, not of `_sanitize`."""
+    assert guard._sanitize(raw) == want
+    joined = guard._state_dir({"session_id": raw})
+    assert os.path.normpath(joined) != os.path.normpath(guard._state_root())
+    assert os.path.dirname(os.path.normpath(joined)) == \
+        os.path.normpath(guard._state_root())
+
+
+@pytest.mark.parametrize("raw", [".zshrc", "v1.2.3", "a.b", "sess-1.0.tmp"])
+def test_the_negative_control_a_normal_dotted_component_is_untouched(raw):
+    """The neutering is enumerated, not a pattern: a component that merely CONTAINS
+    dots must survive intact, or the tighten above is green by eating everything."""
+    assert guard._sanitize(raw) == raw

--- a/scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
+++ b/scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
@@ -247,8 +247,12 @@ def _io_spy(monkeypatch):
     monkeypatch.setattr(guard.os.path, "exists",
                         lambda p, *a, **k: (calls.append(("exists", str(p))),
                                             real_exists(p, *a, **k))[1])
-    real_run = guard.subprocess.run
-    monkeypatch.setattr(guard.subprocess, "run",
+    # `subprocess` is a DEFERRED import (Stop path only), so the module attribute may
+    # still be None. Force it bound before patching — a spy that skipped the patch
+    # because the attribute was None would report a reassuring zero from nothing.
+    sp = guard._sp()
+    real_run = sp.run
+    monkeypatch.setattr(sp, "run",
                         lambda *a, **k: (calls.append(("subprocess", str(a[0]))),
                                          real_run(*a, **k))[1])
     return calls
@@ -316,6 +320,46 @@ def test_the_fast_path_spawns_no_subprocess_at_all(home, tmp_path):
     assert not log.exists(), log.read_text()
     assert not os.path.exists(os.path.join(str(home), ".cache",
                                            "claude-clawgate-writeback"))
+
+
+def _imported_modules(payload_obj, home_dir):
+    """The module names CPython actually imported for one hook run, taken from
+    `-X importtime`. Measured, not asserted — the deferral is a cost claim and a cost
+    claim needs a measurement."""
+    env = dict(os.environ)
+    env["HOME"] = str(home_dir)
+    env.pop("PYTHONDONTWRITEBYTECODE", None)
+    p = subprocess.run([sys.executable, "-X", "importtime", HOOK],
+                       input=json.dumps(payload_obj), capture_output=True,
+                       text=True, timeout=60, env=env)
+    return {line.rsplit("|", 1)[-1].strip()
+            for line in p.stderr.splitlines() if line.startswith("import time:")}
+
+
+def test_the_fast_path_does_not_even_IMPORT_subprocess_or_shutil(home):
+    """🔴 The two most expensive imports in this file — measured with `-X importtime`
+    at 3.4 ms and 3.7 ms — are Stop-only, and the PostToolUse path must not pay them.
+    Asserted on what CPython actually loaded, not on where the `import` line sits."""
+    mods = _imported_modules(bash("ls -la"), home)
+    assert "re" in mods and "json" in mods          # the path CANNOT avoid these
+    assert "subprocess" not in mods
+    assert "shutil" not in mods
+
+
+def test_the_positive_control_for_that_deferral(home):
+    """The Stop path DOES import both — so the absence above is the deferral working,
+    rather than an importtime parser that matches nothing."""
+    guard.post_tool_use(bash("clawgatectl task get 193"))
+    guard.record_work(state_dir())
+    # ...and something for the prune to actually remove: `shutil` is loaded inside the
+    # removal itself, so a Stop with nothing stale to sweep legitimately never needs it.
+    stale = os.path.join(guard._state_root(), "ancient")
+    os.makedirs(stale, exist_ok=True)
+    os.utime(stale, (1.0, 1.0))
+    mods = _imported_modules(payload("Stop"), home)
+    assert "subprocess" in mods
+    assert "shutil" in mods
+    assert not os.path.exists(stale)
 
 
 def test_a_read_records_the_first_timestamp_and_never_moves_it(home):

--- a/scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
+++ b/scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
@@ -1,0 +1,1038 @@
+#!/usr/bin/env python3
+"""Tests for clawgate-writeback-guard.py — the hook that makes the clawgate task
+write-back non-optional.
+
+WHAT THIS FILE IS FOR
+
+  1. 🔴 BOTH DIRECTIONS OF THE TRIGGER. The four NON-matches (`task ls`,
+     `/api/tasks?summary=1`, a bare `/api/tasks`, `task get <non-numeric>`) are as
+     load-bearing as the matches: this hook can BLOCK a turn, and arming it off a
+     board survey would put a block in front of a session that never picked anything
+     up. Every one of them is a separate case here.
+
+  2. 🔴 THE FALSE-POSITIVE KILLER, TESTED AS AN ABSENCE OF THE LIVE READ. The SKILL's
+     own step 2 is "EVALUATE and report to Zach, do NOT flip status" — a
+     read-and-evaluate-only session must never fire. That is asserted not just by the
+     verdict but by the reader NEVER BEING CALLED, so a mutation that reorders the
+     work gate below the live read is visible even if it happens to end up silent.
+
+  3. 🔴 THE LADDER IS DRIVEN WITH LITERALS THE CONSTANTS CANNOT EQUAL. This repo has
+     been bitten five times by a fixture whose value equals the constant it tests, so
+     `MAX_BLOCKS = 2` is never checked by something that produces 2 by construction:
+     the counter is seeded at 0 and at 8 (neither of which is 2 or 3) and the
+     decision is watched to MOVE from block to context to silence.
+
+  4. 🔴 EVERY "CANNOT MEASURE" PATH IS A NOTICE, NEVER A BLOCK. A hook that goes
+     silent when the board is unreachable reports the same observable as a hook that
+     measured a clean card, which is the empty-result trap in RULES.md.
+
+  5. THE HOT PATH. PostToolUse fires after every tool call, so the fast path is
+     driven through a REAL subprocess with stub `clawgatectl` and `curl` on PATH that
+     LOG every invocation — "no subprocess work" is a claim about the process, and an
+     in-process assertion cannot make it.
+"""
+import importlib.machinery
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+# `scripts/` on sys.path so `testlib.mockbin` — the ONE definition of "write an
+# executable stub" in this repo — is importable. A hand-written `#!/usr/bin/env bash`
+# stub is DEAD in the nix build sandbox and test_runtime_shebangs.py fails the gate
+# for one.
+sys.path.insert(0, os.path.abspath(os.path.join(HERE, os.pardir, os.pardir)))
+from testlib import mockbin  # noqa: E402
+
+ROOT = Path(HERE).resolve().parents[2]
+HOOK = os.path.abspath(os.path.join(HERE, os.pardir, "clawgate-writeback-guard.py"))
+HOME_NIX = ROOT / "nix" / "home.nix"
+REGISTRAR = ROOT / "scripts" / "claude-hooks" / "register-nudge-hook.py"
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_file_location(name, path, loader=loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+guard = _load("clawgate_writeback_guard_undertest", HOOK)
+
+SESSION = "sess-writeback-1"
+# A read timestamp with a shape the board really produces (RFC3339, Z, microseconds).
+READ_TS = "2026-08-15T12:00:00.000000Z"
+READ_EPOCH = 1786795200.0  # the same instant, pinned as a LITERAL, not computed here
+READ_PLUS_1H = 1786798800.0
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+@pytest.fixture()
+def home(tmp_path, monkeypatch):
+    h = tmp_path / "home"
+    (h / ".claude").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(h))
+    return h
+
+
+def payload(event="PostToolUse", session_id=SESSION, **kw):
+    base = {"hook_event_name": event, "session_id": session_id,
+            "transcript_path": "/home/zach/.claude/projects/p/a.jsonl",
+            "cwd": "/home/zach/workspace/devrc"}
+    base.update(kw)
+    return base
+
+
+def bash(cmd, **kw):
+    return payload(tool_name="Bash", tool_input={"command": cmd}, **kw)
+
+
+def state_dir():
+    return guard._state_dir({"session_id": SESSION})
+
+
+def seed(task_id=193, ts=READ_TS, work=True):
+    """Put a session into the state the Stop gate reads: task read, work done."""
+    sd = state_dir()
+    os.makedirs(sd, exist_ok=True)
+    with open(guard._read_path(sd, task_id), "w") as fh:
+        json.dump({"task_id": task_id, "first_read_ts": ts}, fh)
+    if work:
+        guard.record_work(sd)
+    return sd
+
+
+def task(status="open", comments=(), task_id=193):
+    return {"id": task_id, "status": status, "title": "t", "body": "b",
+            "comments": list(comments)}
+
+
+def comment(author="claude-code", created="2026-08-15T13:00:00.000000Z", **kw):
+    c = {"id": 1, "noteId": 193, "author": author, "body": "done",
+         "createdAt": created}
+    c.update(kw)
+    return c
+
+
+class Reader:
+    """A stubbed live read that RECORDS whether it was called — so "never fires" can
+    be asserted as "never even measured", not merely as a quiet verdict."""
+
+    def __init__(self, result=None, raises=None):
+        self.result, self.raises, self.calls = result, raises, []
+
+    def __call__(self, task_id, timeout=None):
+        self.calls.append((task_id, timeout))
+        if self.raises is not None:
+            raise self.raises
+        return self.result
+
+
+def run_hook(data, home_dir, path_extra=None, timeout=30):
+    env = dict(os.environ)
+    env["HOME"] = str(home_dir)
+    if path_extra:
+        env["PATH"] = str(path_extra) + os.pathsep + env.get("PATH", "")
+    return subprocess.run([sys.executable, HOOK],
+                          input=json.dumps(data) if data is not None else "",
+                          capture_output=True, text=True, timeout=timeout, env=env)
+
+
+# =========================================================================== #
+# 1. TRIGGER MATCHING — both directions
+# =========================================================================== #
+@pytest.mark.parametrize("cmd,expected", [
+    ("clawgatectl task get 193", [193]),
+    ("clawgatectl task get 7 | jq .", [7]),
+    ("clawgatectl  task   get  42", [42]),
+    ('curl -sf http://board.invalid/api/tasks/194 -H "Authorization: Bearer x"',
+     [194]),
+    ("curl -sf http://board.invalid/api/tasks/194/comments", [194]),
+    ("HOOK=$(grep tok f); curl -s http://board.invalid/api/tasks/12 | jq .", [12]),
+])
+def test_a_read_of_a_specific_task_arms_the_guard(cmd, expected):
+    assert guard.task_read_ids(bash(cmd)) == expected
+
+
+@pytest.mark.parametrize("cmd", [
+    # 🔴 THE FOUR NAMED NON-MATCHES. A board survey is not a pickup, and a guard
+    # armed by one would block a turn that claimed nothing.
+    "clawgatectl task ls --summary --status open --limit 3",
+    "curl -sf http://board.invalid/api/tasks?summary=1",
+    "curl -sf http://board.invalid/api/tasks",
+    "clawgatectl task get abc",
+    # ...and the neighbours that would fall to a sloppier pattern
+    "clawgatectl task get",
+    "curl -sf http://board.invalid/api/tasks/193abc",
+    "clawgatectl task create --body 'get 193'",
+    "echo 'read /api/tasksfoo now'",
+])
+def test_a_listing_or_a_non_numeric_arg_does_NOT_arm_the_guard(cmd):
+    assert guard.task_read_ids(bash(cmd)) == []
+
+
+def test_a_non_bash_payload_has_no_command_to_match():
+    assert guard.task_read_ids(payload(tool_name="Read",
+                                       tool_input={"file_path": "/api/tasks/1"})) == []
+
+
+def test_two_ids_in_one_command_are_both_recorded_and_deduplicated():
+    cmd = ("clawgatectl task get 193; "
+           "curl -s http://board.invalid/api/tasks/194/comments; "
+           "clawgatectl task get 193")
+    assert guard.task_read_ids(bash(cmd)) == [193, 194]
+
+
+# =========================================================================== #
+# 2. WORK DETECTION
+# =========================================================================== #
+@pytest.mark.parametrize("data", [
+    payload(tool_name="Edit", tool_input={"file_path": "/x"}),
+    payload(tool_name="Write", tool_input={"file_path": "/x"}),
+    payload(tool_name="NotebookEdit", tool_input={"notebook_path": "/x"}),
+    bash("git commit -m 'x'"),
+    bash("git -C /home/zach/workspace/devrc commit -m 'x'"),
+    bash("git push -u origin feat/x"),
+    bash("gh pr create --fill --base main"),
+])
+def test_real_work_sets_the_work_flag(data):
+    assert guard.is_work(data) is True
+
+
+@pytest.mark.parametrize("data", [
+    payload(tool_name="Read", tool_input={"file_path": "/x"}),
+    payload(tool_name="Grep", tool_input={"pattern": "commit"}),
+    bash("git log --oneline -3 | grep commit"),
+    bash("git status -s"),
+    bash("gh pr list --state open"),
+    bash("clawgatectl task get 193"),
+])
+def test_a_look_around_is_not_work(data):
+    assert guard.is_work(data) is False
+
+
+# =========================================================================== #
+# 3. THE POSTTOOLUSE FAST PATH
+# =========================================================================== #
+def test_an_untracked_session_reading_nothing_takes_the_fast_path(home):
+    out = guard.post_tool_use(bash("ls -la"))
+    assert out["fast_path"] is True
+    assert not os.path.exists(state_dir())
+
+
+def _io_spy(monkeypatch):
+    """Record every filesystem call the hook makes, and every subprocess it spawns.
+
+    🔴 Counting, not trusting a comment: an earlier hook in this repo shipped with its
+    throttle consulted AFTER the subprocess spawn while its own comment claimed the
+    opposite. The spies wrap the REAL functions, so the hook still behaves normally
+    and the recording is the only difference.
+    """
+    calls = []
+    for name in ("makedirs", "listdir", "replace", "open"):
+        real = getattr(guard.os, name)
+        monkeypatch.setattr(guard.os, name,
+                            (lambda r, n: lambda *a, **k: (
+                                calls.append((n, str(a[0]))), r(*a, **k))[1])(real, name))
+    real_exists = guard.os.path.exists
+    monkeypatch.setattr(guard.os.path, "exists",
+                        lambda p, *a, **k: (calls.append(("exists", str(p))),
+                                            real_exists(p, *a, **k))[1])
+    real_run = guard.subprocess.run
+    monkeypatch.setattr(guard.subprocess, "run",
+                        lambda *a, **k: (calls.append(("subprocess", str(a[0]))),
+                                         real_run(*a, **k))[1])
+    return calls
+
+
+def _mine(calls):
+    """Only the calls that touch THIS hook's state root — pytest and the stdlib use
+    the same functions, so an unfiltered count would be measuring the harness."""
+    root = guard._state_root()
+    return [c for c in calls if c[0] == "subprocess" or root in c[1]]
+
+
+def test_the_fast_path_does_exactly_one_stat_and_nothing_else(home, monkeypatch):
+    """🔴 THE ORDERING, PINNED AS A COUNT. A session that has never read a clawgate
+    task and is not reading one now must cost exactly ONE `os.path.exists` and spawn
+    nothing — no directory creation, no state read, no client. Every write below the
+    gate is unreachable for it."""
+    calls = _io_spy(monkeypatch)
+    guard.post_tool_use(bash("ls -la"))
+    assert _mine(calls) == [("exists", state_dir())], calls
+    assert [c for c in calls if c[0] == "subprocess"] == []
+
+
+def test_the_positive_control_for_that_count(home, monkeypatch):
+    """🔴 The one-call reading above is only meaningful if the spy CAN see more. The
+    same instrumentation on a payload that IS a task read must record writes — a
+    reassuring count is indistinguishable from a spy wired to nothing."""
+    calls = _io_spy(monkeypatch)
+    guard.post_tool_use(bash("clawgatectl task get 193"))
+    kinds = [c[0] for c in _mine(calls)]
+    assert "makedirs" in kinds and "replace" in kinds, calls
+    assert len(_mine(calls)) > 1
+
+
+def test_the_work_regex_is_NOT_evaluated_on_the_fast_path(home, monkeypatch):
+    """The other half of the gate: `is_work` is reachable only past it. Made to raise
+    so a mutation that hoists it above the return is loud rather than merely slower."""
+    guard.post_tool_use(bash("clawgatectl task get 193", session_id="armed"))
+    monkeypatch.setattr(guard, "is_work",
+                        lambda d: (_ for _ in ()).throw(
+                            AssertionError("is_work ran on the fast path")))
+    # An UNTRACKED session: the gate returns before the work regex is consulted.
+    assert guard.post_tool_use(bash("ls -la",
+                                    session_id="never-touched-the-board")
+                               )["fast_path"] is True
+    # POSITIVE CONTROL: the ARMED session takes the same payload past the gate, so the
+    # raiser proves it is reachable at all rather than never being installed.
+    with pytest.raises(AssertionError):
+        guard.post_tool_use(bash("ls -la", session_id="armed"))
+
+
+def test_the_fast_path_spawns_no_subprocess_at_all(home, tmp_path):
+    """Driven through a REAL subprocess with stub `clawgatectl` and `curl` on PATH
+    that log every invocation. "No subprocess work" is a claim about the process."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    log = tmp_path / "spawned.log"
+    for name in ("clawgatectl", "curl"):
+        mockbin.write_exec(bindir / name,
+                           'echo "%s $@" >> %s\nprintf "{}\\n"\n'
+                           % (name, json.dumps(str(log))))
+    p = run_hook(bash("ls -la"), home, path_extra=bindir)
+    assert p.returncode == 0
+    assert p.stdout == ""
+    assert not log.exists(), log.read_text()
+    assert not os.path.exists(os.path.join(str(home), ".cache",
+                                           "claude-clawgate-writeback"))
+
+
+def test_a_read_records_the_first_timestamp_and_never_moves_it(home):
+    """A re-read an hour later must NOT move the window this hook measures over: the
+    question is "was there a comment since you FIRST looked", and a moving anchor
+    would let a session re-read its way out of the gate."""
+    guard.post_tool_use(bash("clawgatectl task get 193"), now=READ_EPOCH)
+    guard.post_tool_use(bash("clawgatectl task get 193"), now=READ_PLUS_1H)
+    ids = guard.tracked_ids(state_dir())
+    assert ids == {193: "2026-08-15T12:00:00Z"}
+
+
+def test_work_is_only_recorded_after_a_read(home):
+    guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/x"}))
+    assert not os.path.exists(state_dir())
+    guard.post_tool_use(bash("clawgatectl task get 193"))
+    guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/x"}))
+    assert guard.work_after_read(state_dir()) is True
+
+
+def test_at_most_five_task_ids_are_tracked_per_session(home):
+    for tid in (11, 12, 13, 14, 15, 16, 17):
+        guard.post_tool_use(bash("clawgatectl task get %d" % tid))
+    assert sorted(guard.tracked_ids(state_dir())) == [11, 12, 13, 14, 15]
+
+
+# =========================================================================== #
+# 4. writeback_state — the live measurement, decomposed
+# =========================================================================== #
+def test_no_comments_at_all_is_the_measured_failure():
+    assert guard.writeback_state(task(comments=[]), READ_TS) == "missing"
+
+
+def test_a_claude_code_comment_since_the_read_silences_it():
+    c = comment(created="2026-08-15T13:00:00.000000Z")
+    assert guard.writeback_state(task(comments=[c]), READ_TS) == "written"
+
+
+def test_only_an_OLDER_comment_still_counts_as_missing():
+    """An hour before the read — well outside any clock-skew allowance."""
+    c = comment(created="2026-08-15T11:00:00.000000Z")
+    assert guard.writeback_state(task(comments=[c]), READ_TS) == "missing"
+
+
+def test_a_comment_inside_the_skew_allowance_counts_as_written():
+    """🔴 The fixture is 30 s and 3600 s — neither can equal
+    CLOCK_SKEW_ALLOWANCE_SECS, so this cannot pass by being the constant."""
+    near = comment(created="2026-08-15T11:59:30.000000Z")   # 30 s before
+    far = comment(created="2026-08-15T11:00:00.000000Z")    # 3600 s before
+    assert guard.writeback_state(task(comments=[near]), READ_TS) == "written"
+    assert guard.writeback_state(task(comments=[far]), READ_TS) == "missing"
+
+
+@pytest.mark.parametrize("status", ["ready_for_review", "complete"])
+def test_a_card_someone_already_closed_is_left_alone(status):
+    assert guard.writeback_state(task(status=status, comments=[]), READ_TS) == "closed"
+
+
+@pytest.mark.parametrize("status", ["open", "in_progress"])
+def test_an_open_or_in_progress_card_is_still_measured(status):
+    assert guard.writeback_state(task(status=status, comments=[]), READ_TS) == "missing"
+
+
+def test_a_comment_by_someone_else_is_not_this_agent_writing_back():
+    for author in ("user", "api", "drafter", "repo-cos", "extension"):
+        c = comment(author=author, created="2026-08-15T13:00:00.000000Z")
+        assert guard.writeback_state(task(comments=[c]), READ_TS) == "missing", author
+
+
+def test_a_RETRACTED_comment_is_not_a_write_back():
+    c = comment(created="2026-08-15T13:00:00.000000Z", body="", retracted=True)
+    assert guard.writeback_state(task(comments=[c]), READ_TS) == "missing"
+
+
+def test_an_unparseable_comment_timestamp_resolves_toward_SILENCE():
+    """The comment demonstrably exists; only its timestamp is unreadable. Resolving
+    that toward a BLOCK would spend the operator's turn on a formatting change at the
+    far end of a wire this hook does not own."""
+    c = comment(created="not-a-timestamp")
+    assert guard.writeback_state(task(comments=[c]), READ_TS) == "written"
+
+
+def test_an_unparseable_READ_timestamp_is_unknown_not_missing():
+    assert guard.writeback_state(task(comments=[]), "garbage") == "unknown"
+
+
+@pytest.mark.parametrize("bad", [None, "a string", 42, [1, 2]])
+def test_a_task_payload_that_is_not_an_object_is_unknown(bad):
+    assert guard.writeback_state(bad, READ_TS) == "unknown"
+
+
+def test_a_comments_field_that_is_not_a_list_is_unknown():
+    t = task()
+    t["comments"] = {"oops": 1}
+    assert guard.writeback_state(t, READ_TS) == "unknown"
+
+
+def test_a_missing_comments_key_is_an_empty_board_not_an_error():
+    t = task()
+    del t["comments"]
+    assert guard.writeback_state(t, READ_TS) == "missing"
+
+
+# =========================================================================== #
+# 5. parse_ts
+# =========================================================================== #
+@pytest.mark.parametrize("s", [
+    "2026-08-15T12:00:00.000000Z",
+    "2026-08-15T12:00:00Z",
+    "2026-08-15T12:00:00.000000000Z",   # Go RFC3339Nano: nine fractional digits
+    "2026-08-15T12:00:00+00:00",
+    "2026-08-15T07:00:00-05:00",
+    # NAIVE — no offset at all. The board always sends one, but a proxy or a hand-run
+    # curl need not, and reading a naive stamp as LOCAL time would shift the cutoff by
+    # the host's offset and silence a genuinely missing write-back.
+    "2026-08-15T12:00:00",
+])
+def test_every_shape_the_board_emits_parses_to_the_same_instant(s):
+    assert guard.parse_ts(s) == READ_EPOCH
+
+
+@pytest.mark.parametrize("s", [None, "", "   ", "garbage", 42, "2026-13-45T99:99:99Z"])
+def test_an_unparseable_timestamp_is_None_not_an_exception(s):
+    assert guard.parse_ts(s) is None
+
+
+# =========================================================================== #
+# 6. THE FALSE-POSITIVE KILLER — no work after read
+# =========================================================================== #
+def test_a_read_and_evaluate_only_session_NEVER_fires(home):
+    """🔴 The SKILL's own step 2. Asserted as "the board was never even read", so a
+    mutation that moves the work gate below the live read is visible."""
+    seed(work=False)
+    r = Reader(result=task(comments=[]))
+    kind, text = guard.stop_decision(payload("Stop"), reader=r)
+    assert (kind, text) == ("silent", "")
+    assert r.calls == []
+
+
+def test_the_positive_control_for_that_absence(home):
+    """The same fixture WITH the work flag must fire — otherwise the test above is
+    green because the harness is wired to nothing."""
+    seed(work=True)
+    r = Reader(result=task(comments=[]))
+    kind, _ = guard.stop_decision(payload("Stop"), reader=r)
+    assert kind == "block"
+    assert [c[0] for c in r.calls] == [193]
+
+
+def test_a_read_then_NO_work_never_fires_END_TO_END(home):
+    """The same guard as above, but driven through `post_tool_use` rather than a
+    hand-seeded state dir — found by a differently-built mutation sweep, which showed
+    that forcing the work gate TRUE inside `post_tool_use` survived every test here
+    because they all seeded the flag directly and never exercised the writer."""
+    guard.post_tool_use(bash("clawgatectl task get 193"))
+    guard.post_tool_use(bash("git status -s"))
+    guard.post_tool_use(bash("gh pr list --state open"))
+    guard.post_tool_use(payload(tool_name="Read", tool_input={"file_path": "/x"}))
+    assert guard.work_after_read(state_dir()) is False
+    r = Reader(result=task(comments=[]))
+    assert guard.stop_decision(payload("Stop"), reader=r) == ("silent", "")
+    assert r.calls == []
+
+
+def test_a_state_file_with_no_usable_timestamp_is_DROPPED(home):
+    """A corrupt state file must not become a task the hook nags about: without a
+    first-read timestamp there is no window to measure over, so there is nothing to
+    say. Silence, not an UNVERIFIED notice about this hook's own bookkeeping."""
+    sd = state_dir()
+    os.makedirs(sd, exist_ok=True)
+    for tid, ts in ((193, None), (194, ""), (195, 42)):
+        with open(guard._read_path(sd, tid), "w") as fh:
+            json.dump({"task_id": tid, "first_read_ts": ts}, fh)
+    guard.record_work(sd)
+    assert guard.tracked_ids(sd) == {}
+    r = Reader(result=task(comments=[]))
+    assert guard.stop_decision(payload("Stop"), reader=r) == ("silent", "")
+    assert r.calls == []
+
+
+def test_a_session_that_never_read_a_task_is_silent(home):
+    r = Reader(result=task(comments=[]))
+    assert guard.stop_decision(payload("Stop"), reader=r) == ("silent", "")
+    assert r.calls == []
+
+
+# =========================================================================== #
+# 7. THE STOP VERDICTS
+# =========================================================================== #
+def test_a_comment_written_since_the_read_self_suppresses_the_guard(home):
+    seed()
+    r = Reader(result=task(comments=[comment(created="2026-08-15T13:00:00.000000Z")]))
+    assert guard.stop_decision(payload("Stop"), reader=r) == ("silent", "")
+
+
+def test_an_older_comment_alone_still_blocks(home):
+    seed()
+    r = Reader(result=task(comments=[comment(created="2026-08-15T11:00:00.000000Z")]))
+    kind, text = guard.stop_decision(payload("Stop"), reader=r)
+    assert kind == "block"
+    assert "193" in text
+
+
+@pytest.mark.parametrize("status", ["ready_for_review", "complete"])
+def test_a_closed_card_is_silent_end_to_end(home, status):
+    seed()
+    r = Reader(result=task(status=status, comments=[]))
+    assert guard.stop_decision(payload("Stop"), reader=r) == ("silent", "")
+
+
+def test_the_block_reason_names_the_id_the_timestamp_and_BOTH_fix_commands(home):
+    seed()
+    r = Reader(result=task(comments=[]))
+    kind, text = guard.stop_decision(payload("Stop"), reader=r)
+    assert kind == "block"
+    # 🔴 Pinned as the WHOLE literal command line, not as the presence of the words
+    # "comment" and "status" — a guard on words is walkable by rewording, and this
+    # text is the entire product of the hook.
+    assert "clawgatectl task comment 193 --body" in text
+    assert "clawgatectl task status 193 ready_for_review" in text
+    assert READ_TS in text
+    assert "MISSING" in text
+
+
+def test_the_wall_clock_budget_stops_the_live_reads(home):
+    """🔴 A Stop hook that hangs is felt at the exact moment a session is trying to
+    end. The budget is driven with 3.0 — a value neither STOP_BUDGET_SECS (8.0) nor
+    PER_TASK_TIMEOUT_SECS (5.0) can equal, so this cannot pass by being the constant."""
+    for tid in (11, 12, 13, 14, 15):
+        seed(task_id=tid)
+    ticks = iter([0.0, 0.0, 9.0, 9.0, 9.0, 9.0])
+    r = Reader(result=task(comments=[]))
+    guard.stop_decision(payload("Stop"), reader=r, budget=3.0,
+                        clock=lambda: next(ticks))
+    assert [c[0] for c in r.calls] == [11]
+    # ...and the per-task timeout is the SMALLER of the ceiling and what is left of
+    # the budget, not the ceiling: 3.0 remaining under a 5.0 ceiling.
+    assert r.calls[0][1] == 3.0
+
+
+def test_the_positive_control_for_that_budget(home):
+    """The same five tasks with time to spare must ALL be read — otherwise the single
+    read above is a harness that never had a second iteration to cut off."""
+    for tid in (11, 12, 13, 14, 15):
+        seed(task_id=tid)
+    r = Reader(result=task(comments=[]))
+    guard.stop_decision(payload("Stop"), reader=r, budget=3.0,
+                        clock=lambda: 0.0)
+    assert [c[0] for c in r.calls] == [11, 12, 13, 14, 15]
+
+
+def test_several_offending_tasks_are_reported_in_one_decision(home):
+    seed(task_id=193)
+    seed(task_id=194)
+    r = Reader(result=task(comments=[]))
+    kind, text = guard.stop_decision(payload("Stop"), reader=r)
+    assert kind == "block"
+    assert "clawgatectl task status 193 ready_for_review" in text
+    assert "clawgatectl task status 194 ready_for_review" in text
+    assert [c[0] for c in r.calls] == [193, 194]
+
+
+# =========================================================================== #
+# 8. THE LIVE READ FAILING — a notice, NEVER a block
+# =========================================================================== #
+def test_an_unreachable_board_emits_a_NON_BLOCKING_notice(home):
+    seed()
+    r = Reader(raises=guard.LiveReadError("connection refused"))
+    kind, text = guard.stop_decision(payload("Stop"), reader=r)
+    assert kind == "context"
+    assert kind != "block"
+    assert "193" in text and "could not be reached" in text
+    assert "connection refused" in text
+
+
+def test_an_unreachable_board_NEVER_blocks_at_any_rung(home):
+    """🔴 Driven up the whole ladder. The first two rungs are where a MEASURED miss
+    blocks, so an all-unknown session reaching them and staying non-blocking is the
+    real assertion."""
+    seed()
+    kinds = []
+    for _ in range(5):
+        r = Reader(raises=guard.LiveReadError("boom"))
+        kinds.append(guard.stop_decision(payload("Stop"), reader=r)[0])
+    assert kinds == ["context", "context", "context", "silent", "silent"]
+    assert "block" not in kinds
+
+
+def test_a_reader_raising_something_unexpected_is_also_only_a_notice(home):
+    seed()
+    r = Reader(raises=RuntimeError("kaboom"))
+    kind, text = guard.stop_decision(payload("Stop"), reader=r)
+    assert kind == "context"
+    assert "kaboom" in text
+
+
+def test_an_unreadable_task_payload_is_a_notice_not_a_block(home):
+    seed()
+    r = Reader(result="this is not a task object")
+    kind, text = guard.stop_decision(payload("Stop"), reader=r)
+    assert kind == "context"
+    assert "UNVERIFIED" in text
+
+
+# =========================================================================== #
+# 9. THE ESCALATION LADDER
+# =========================================================================== #
+def test_the_ladder_constants_are_what_the_docstring_claims():
+    assert guard.MAX_BLOCKS == 2
+    assert guard.MAX_FIRES == 3
+    assert guard.MAX_TASKS == 5
+
+
+@pytest.mark.parametrize("fire,rung", [
+    (1, "block"), (2, "block"), (3, "context"), (4, "silent"), (9, "silent"),
+])
+def test_escalate_maps_each_fire_number_to_its_rung(fire, rung):
+    assert guard.escalate(fire) == rung
+
+
+def test_the_ladder_end_to_end_on_one_task(home):
+    """🔴 Literal expected sequence, pinned from the ladder in the docstring — NOT
+    derived from MAX_BLOCKS/MAX_FIRES, which is how a test comes to agree with a
+    mutated implementation."""
+    seed()
+    kinds = []
+    for _ in range(5):
+        r = Reader(result=task(comments=[]))
+        kinds.append(guard.stop_decision(payload("Stop"), reader=r)[0])
+    assert kinds == ["block", "block", "context", "silent", "silent"]
+
+
+def test_a_counter_seeded_far_past_the_cap_is_silent(home):
+    """🔴 THE FIXTURE-EQUALS-CONSTANT CONTROL. 8 is a value MAX_BLOCKS (2) and
+    MAX_FIRES (3) cannot equal, so a mutant that hardcodes either literal cannot
+    survive this: the next fire is 9 and the only correct answer is silence."""
+    sd = seed()
+    with open(guard._fires_path(sd, 193), "w") as fh:
+        fh.write("8")
+    r = Reader(result=task(comments=[]))
+    assert guard.stop_decision(payload("Stop"), reader=r) == ("silent", "")
+
+
+def test_a_counter_seeded_at_zero_still_blocks(home):
+    """The other end of the same control: 0 is also not 2 or 3, and the output MOVES."""
+    sd = seed()
+    with open(guard._fires_path(sd, 193), "w") as fh:
+        fh.write("0")
+    r = Reader(result=task(comments=[]))
+    assert guard.stop_decision(payload("Stop"), reader=r)[0] == "block"
+
+
+def test_the_ladder_is_per_task_id_not_per_session(home):
+    seed(task_id=193)
+    sd = state_dir()
+    with open(guard._fires_path(sd, 193), "w") as fh:
+        fh.write("8")
+    seed(task_id=194)
+    r = Reader(result=task(comments=[]))
+    kind, text = guard.stop_decision(payload("Stop"), reader=r)
+    assert kind == "block"
+    assert "task status 194" in text
+    assert "task status 193" not in text
+
+
+# =========================================================================== #
+# 9b. STATE HOUSEKEEPING
+# =========================================================================== #
+def test_prune_drops_stale_session_state_and_keeps_fresh(home):
+    """One directory per session, forever, is an unbounded cache.
+
+    🔴 The fixtures BRACKET the TTL from both sides — 5 days must survive and 20 days
+    must not — so a TTL moved in EITHER direction past that bracket goes red. Ages of
+    1 h / 5 d / 20 d / 40 d; none of them can equal STATE_TTL_SECS (14 days), so no
+    fixture here can pass by being the constant it tests."""
+    root = guard._state_root()
+    now = 1786795200.0
+    ages = {"fresh": 3600, "recent": 5 * 86400,
+            "stale": 20 * 86400, "ancient": 40 * 86400}
+    for name, age in ages.items():
+        os.makedirs(os.path.join(root, name), exist_ok=True)
+        os.utime(os.path.join(root, name), (now - age, now - age))
+    removed = guard.prune(now=now)
+    assert sorted(removed) == ["ancient", "stale"]
+    assert sorted(os.listdir(root)) == ["fresh", "recent"]
+
+
+def test_prune_on_a_missing_root_is_not_an_error(home):
+    assert guard.prune() == []
+
+
+def test_the_Stop_path_prunes_and_the_prune_runs_AFTER_the_verdict(home, tmp_path):
+    """The verdict must not wait on housekeeping — and a prune that raises must not
+    swallow a verdict that has already been written."""
+    seed()
+    root = guard._state_root()
+    os.makedirs(os.path.join(root, "ancient"), exist_ok=True)
+    old = 1.0
+    os.utime(os.path.join(root, "ancient"), (old, old))
+    b = tmp_path / "prunebin"
+    b.mkdir()
+    mockbin.write_exec(b / "clawgatectl",
+                       "printf '%%s\\n' '%s'\n" % json.dumps(task(comments=[])))
+    p = run_hook(payload("Stop"), home, path_extra=b)
+    assert json.loads(p.stdout)["decision"] == "block"
+    assert not os.path.exists(os.path.join(root, "ancient"))
+    # ...and THIS session's own state survived the prune it just triggered.
+    assert os.path.exists(state_dir())
+
+
+# =========================================================================== #
+# 10. EVENT SCOPE
+# =========================================================================== #
+def test_SubagentStop_is_refused(home):
+    """🔴 A subagent's turn never reaches the operator, so it owes them nothing —
+    next-step-nudge.py refuses it for the same reason."""
+    seed()
+    r = Reader(result=task(comments=[]))
+    assert guard.stop_decision(payload("SubagentStop"), reader=r) == ("silent", "")
+    assert r.calls == []
+
+
+def test_a_payload_carrying_an_agent_id_is_refused(home):
+    seed()
+    r = Reader(result=task(comments=[]))
+    assert guard.stop_decision(payload("Stop", agent_id="ag-1"),
+                               reader=r) == ("silent", "")
+    assert r.calls == []
+
+
+def test_SubagentStop_produces_no_output_through_the_real_process(home, tmp_path):
+    seed()
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    mockbin.write_exec(bindir / "clawgatectl",
+                       "printf '%%s\\n' '%s'\n" % json.dumps(task(comments=[])))
+    p = run_hook(payload("SubagentStop"), home, path_extra=bindir)
+    assert p.returncode == 0
+    assert p.stdout == ""
+
+
+# =========================================================================== #
+# 11. THE PROCESS CONTRACT — fail-open, always
+# =========================================================================== #
+@pytest.mark.parametrize("stdin", ["", "not json", "[]", "null", '{"a":1}',
+                                   '{"hook_event_name":"Stop"}',
+                                   '{"hook_event_name":"Stop","session_id":{"x":1}}',
+                                   '{"hook_event_name":"PostToolUse"}'])
+def test_malformed_input_exits_0_and_says_nothing(home, stdin):
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    p = subprocess.run([sys.executable, HOOK], input=stdin,
+                       capture_output=True, text=True, timeout=30, env=env)
+    assert p.returncode == 0, p.stderr
+    assert p.stdout == ""
+    assert p.stderr == ""
+
+
+def test_an_internal_exception_exits_0_with_an_empty_stdout(home, monkeypatch,
+                                                            capsys):
+    """🔴 The fail-open backstop itself, not a proxy for it: `stop_decision` is made
+    to raise and main() must still exit 0 with nothing on stdout."""
+    monkeypatch.setattr(guard, "stop_decision",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(guard.sys, "stdin",
+                        io.StringIO(json.dumps(payload("Stop"))))
+    with pytest.raises(SystemExit) as e:
+        guard.main()
+    assert e.value.code == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_the_positive_control_for_that_backstop(home, monkeypatch, capsys):
+    """Without the injected exception the same wiring MUST produce a block — so the
+    empty stdout above is the backstop working, not a harness wired to nothing."""
+    seed()
+    monkeypatch.setattr(guard, "live_task",
+                        lambda tid, timeout=None: task(comments=[]))
+    monkeypatch.setattr(guard.sys, "stdin",
+                        io.StringIO(json.dumps(payload("Stop"))))
+    with pytest.raises(SystemExit) as e:
+        guard.main()
+    assert e.value.code == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["decision"] == "block"
+    assert "clawgatectl task comment 193 --body" in out["reason"]
+
+
+# =========================================================================== #
+# 12. THE EMITTED JSON — the shapes read out of the installed CLI's own schema
+# =========================================================================== #
+def test_block_is_a_TOP_LEVEL_decision_object(capsys):
+    guard.emit("block", "why")
+    out = json.loads(capsys.readouterr().out)
+    assert out == {"decision": "block", "reason": "why"}
+
+
+def test_context_is_a_hookSpecificOutput_arm_naming_Stop(capsys):
+    guard.emit("context", "fyi")
+    out = json.loads(capsys.readouterr().out)
+    assert out == {"hookSpecificOutput": {"hookEventName": "Stop",
+                                          "additionalContext": "fyi"}}
+
+
+def test_silent_writes_nothing_at_all(capsys):
+    guard.emit("silent", "ignored")
+    assert capsys.readouterr().out == ""
+
+
+# =========================================================================== #
+# 13. THE LIVE READ ITSELF — real subprocesses, real fallback
+# =========================================================================== #
+def _bin(tmp_path):
+    d = tmp_path / "livebin"
+    d.mkdir()
+    return d
+
+
+def _isolated_path(monkeypatch, bindir):
+    """PATH containing ONLY the stubs, so a real `clawgatectl` on the dev host cannot
+    answer for an absent one and make the fallback untestable.
+
+    🔴 EVERY STUB BELOW USES SHELL BUILTINS ONLY (`echo`, `read`, `exit`) — with PATH
+    stripped to one directory, an external `cat` or `printf` is NOT FOUND, and the
+    failure is nearly invisible: `>>` creates the log file before command lookup, so
+    the stub still exits 0 and the test reads an EMPTY log as "the hook sent nothing".
+    That is exactly how this file's token-in-argv assertion first passed for the wrong
+    reason. Measured: the same stub with an external `cat` logged 0 bytes of a 5-line
+    config the hook demonstrably sent.
+    """
+    monkeypatch.setenv("PATH", str(bindir))
+
+
+def _sh_json(obj):
+    """Emit a JSON blob from a stub using only the `echo` builtin."""
+    return "echo '%s'\n" % json.dumps(obj)
+
+
+def _sh_capture_stdin(path):
+    """Copy stdin into `path` using only `read`/`echo` builtins."""
+    return ("while IFS= read -r __l; do echo \"$__l\" >> %s; done\n"
+            % json.dumps(str(path)))
+
+
+def test_live_task_prefers_clawgatectl(tmp_path, monkeypatch):
+    b = _bin(tmp_path)
+    mockbin.write_exec(b / "clawgatectl", _sh_json(task(comments=[])))
+    _isolated_path(monkeypatch, b)
+    assert guard.live_task(193, timeout=5)["id"] == 193
+
+
+def test_live_task_falls_back_to_curl_when_clawgatectl_is_ABSENT(tmp_path,
+                                                                monkeypatch):
+    """🔴 The laptop today: its homelab-talos checkout predates cmd/clawgatectl, so
+    nix does not build the binary and the hook must still be able to measure."""
+    b = _bin(tmp_path)
+    argv_log = tmp_path / "curl-argv.log"
+    cfg_log = tmp_path / "curl-cfg.log"
+    mockbin.write_exec(b / "curl",
+                       'echo "$@" >> %s\n' % json.dumps(str(argv_log))
+                       + _sh_capture_stdin(cfg_log)
+                       + _sh_json(task(comments=[], task_id=194)))
+    _isolated_path(monkeypatch, b)
+    envf = tmp_path / "clawgate.env"
+    envf.write_text("CLAWGATE_API_URL=http://board.invalid:1\n"
+                    "CLAWGATE_HOOK_TOKEN=tok-SECRET-123\n")
+    got = guard.live_task(194, timeout=5, env_path=str(envf))
+    assert got["id"] == 194
+    cfg = cfg_log.read_text()
+    # POSITIVE CONTROL FIRST: the config log must be non-empty, or the argv assertion
+    # below is satisfied by a stub that captured nothing.
+    assert "http://board.invalid:1/api/tasks/194" in cfg
+    assert "tok-SECRET-123" in cfg
+    # 🔴 ...and only then: THE TOKEN MUST NOT BE IN ARGV. This hook runs after every
+    # turn, and an argv is readable by every process on the box through /proc.
+    assert "tok-SECRET-123" not in argv_log.read_text()
+    assert "-K -" in argv_log.read_text()
+
+
+def test_live_task_falls_back_when_clawgatectl_EXITS_NONZERO(tmp_path, monkeypatch):
+    b = _bin(tmp_path)
+    mockbin.write_exec(b / "clawgatectl", "echo 'boom' >&2\nexit 6\n")
+    mockbin.write_exec(b / "curl",
+                       _sh_capture_stdin(tmp_path / "sink.log")
+                       + _sh_json(task(comments=[], task_id=195)))
+    _isolated_path(monkeypatch, b)
+    envf = tmp_path / "clawgate.env"
+    envf.write_text("CLAWGATE_API_URL=http://board.invalid:1\n"
+                    "CLAWGATE_HOOK_TOKEN=t\n")
+    assert guard.live_task(195, timeout=5, env_path=str(envf))["id"] == 195
+
+
+def test_live_task_raises_when_curl_EXITS_NONZERO(tmp_path, monkeypatch):
+    """An unreachable board is the commonest shape of this: curl exits 7/22 and the
+    hook must report "could not measure", never "the card is clean"."""
+    b = _bin(tmp_path)
+    mockbin.write_exec(b / "curl",
+                       _sh_capture_stdin(tmp_path / "sink2.log") + "exit 7\n")
+    _isolated_path(monkeypatch, b)
+    envf = tmp_path / "clawgate.env"
+    envf.write_text("CLAWGATE_API_URL=http://board.invalid:1\n"
+                    "CLAWGATE_HOOK_TOKEN=t\n")
+    with pytest.raises(guard.LiveReadError) as e:
+        guard.live_task(199, timeout=5, env_path=str(envf))
+    assert "curl rc=7" in str(e.value)
+
+
+def test_live_task_raises_when_there_is_no_client_at_all(tmp_path, monkeypatch):
+    b = _bin(tmp_path)
+    _isolated_path(monkeypatch, b)
+    envf = tmp_path / "clawgate.env"
+    envf.write_text("CLAWGATE_API_URL=http://board.invalid:1\n"
+                    "CLAWGATE_HOOK_TOKEN=t\n")
+    with pytest.raises(guard.LiveReadError) as e:
+        guard.live_task(196, timeout=5, env_path=str(envf))
+    assert "neither clawgatectl nor curl" in str(e.value)
+
+
+def test_live_task_raises_when_the_env_file_has_no_credentials(tmp_path,
+                                                               monkeypatch):
+    b = _bin(tmp_path)
+    mockbin.write_exec(b / "curl", _sh_capture_stdin(tmp_path / "s.log")
+                       + _sh_json({}))
+    _isolated_path(monkeypatch, b)
+    with pytest.raises(guard.LiveReadError) as e:
+        guard.live_task(197, timeout=5, env_path=str(tmp_path / "nope.env"))
+    assert "has no API url/token" in str(e.value)
+    # 🔴 ...and it names WHICH client failed first. A `clawgatectl` that exists but
+    # exits non-zero must not be reported as "not on PATH" — a diagnosis pointing at
+    # the wrong subsystem. Found by a LIVE probe, not by a stub.
+    assert "clawgatectl not on PATH" in str(e.value)
+
+
+def test_a_FAILING_clawgatectl_is_not_reported_as_an_ABSENT_one(tmp_path,
+                                                                monkeypatch):
+    b = _bin(tmp_path)
+    mockbin.write_exec(b / "clawgatectl", "echo 'no token file' >&2\nexit 3\n")
+    _isolated_path(monkeypatch, b)
+    with pytest.raises(guard.LiveReadError) as e:
+        guard.live_task(197, timeout=5, env_path=str(tmp_path / "nope.env"))
+    msg = str(e.value)
+    assert "clawgatectl rc=3" in msg and "no token file" in msg
+    assert "not on PATH" not in msg
+
+
+def test_live_task_raises_on_unparseable_stdout(tmp_path, monkeypatch):
+    b = _bin(tmp_path)
+    mockbin.write_exec(b / "clawgatectl", "echo 'not json'\n")
+    _isolated_path(monkeypatch, b)
+    with pytest.raises(guard.LiveReadError):
+        guard.live_task(198, timeout=5, env_path=str(tmp_path / "nope.env"))
+
+
+def test_the_env_file_parser_ignores_comments_and_blanks(tmp_path):
+    f = tmp_path / "e"
+    f.write_text("# a comment\n\nCLAWGATE_API_URL=http://x:1\nnot-a-pair\n"
+                 "CLAWGATE_HOOK_TOKEN=abc\n")
+    conf = guard._env_file(str(f))
+    assert conf == {"CLAWGATE_API_URL": "http://x:1", "CLAWGATE_HOOK_TOKEN": "abc"}
+
+
+def test_a_missing_env_file_is_an_empty_config_not_an_exception(tmp_path):
+    assert guard._env_file(str(tmp_path / "absent")) == {}
+
+
+# =========================================================================== #
+# 14. END TO END through the real process, with a stub board
+# =========================================================================== #
+def test_the_measured_failure_reproduced_end_to_end(home, tmp_path):
+    """#193's exact shape: read the card, do work, stop — and the board still shows
+    an `open` card with zero comments."""
+    b = tmp_path / "e2ebin"
+    b.mkdir()
+    mockbin.write_exec(b / "clawgatectl",
+                       "printf '%%s\\n' '%s'\n" % json.dumps(task(comments=[])))
+    assert run_hook(bash("clawgatectl task get 193"), home,
+                    path_extra=b).stdout == ""
+    assert run_hook(payload(tool_name="Edit", tool_input={"file_path": "/x"}),
+                    home, path_extra=b).stdout == ""
+    p = run_hook(payload("Stop"), home, path_extra=b)
+    assert p.returncode == 0
+    out = json.loads(p.stdout)
+    assert out["decision"] == "block"
+    assert "clawgatectl task comment 193 --body" in out["reason"]
+
+
+def test_the_same_session_goes_quiet_once_the_comment_exists(home, tmp_path):
+    b = tmp_path / "e2ebin2"
+    b.mkdir()
+    body = json.dumps(task(comments=[comment(created="2099-01-01T00:00:00.000000Z")]))
+    mockbin.write_exec(b / "clawgatectl", "printf '%%s\\n' '%s'\n" % body)
+    run_hook(bash("clawgatectl task get 193"), home, path_extra=b)
+    run_hook(payload(tool_name="Edit", tool_input={"file_path": "/x"}), home,
+             path_extra=b)
+    p = run_hook(payload("Stop"), home, path_extra=b)
+    assert p.returncode == 0
+    assert p.stdout == ""
+
+
+# =========================================================================== #
+# 15. THE DELIVERY SEAM — a hook nix does not deploy is a hook that does not exist
+# =========================================================================== #
+def test_home_nix_deploys_this_hook():
+    """🔴 This repo's standing trap: a new file the flake does not carry is silently
+    omitted and the switch still succeeds."""
+    src = HOME_NIX.read_text()
+    assert 'home.file.".claude/hooks/clawgate-writeback-guard.py"' in src
+    assert "../scripts/claude-hooks/clawgate-writeback-guard.py" in src
+
+
+def test_the_registrar_registers_it_on_PostToolUse_and_Stop():
+    src = REGISTRAR.read_text()
+    body = src.split('"""', 2)[-1]      # tables only, not the docstring's prose
+    assert "clawgate-writeback-guard.py" in body
+    assert 'WRITEBACK_EVENTS = ["PostToolUse", "Stop"]' in body
+
+
+def test_the_hook_file_is_executable_and_parses():
+    assert os.path.exists(HOOK)
+    compile(open(HOOK).read(), HOOK, "exec")

--- a/scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
+++ b/scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
@@ -30,6 +30,17 @@ WHAT THIS FILE IS FOR
      driven through a REAL subprocess with stub `clawgatectl` and `curl` on PATH that
      LOG every invocation — "no subprocess work" is a claim about the process, and an
      in-process assertion cannot make it.
+
+  6. 🔴 THE NON-BLOCKING RUNG IS ASSERTED ON THE OBSERVABLE, NOT ON A KIND STRING.
+     `stop_decision` returning the string "context" was the whole of the old proof
+     that a rung "did not block" — and it was a SPELLED guard in the exact sense
+     RULES.md names: the string said non-blocking while the JSON it produced
+     (`hookSpecificOutput.additionalContext`) was pushed by the CLI into the same
+     `blockingErrors` array as `decision:"block"`, forcing a third continuation. A
+     test on the internal name structurally could not see that. Every such assertion
+     now runs the verdict through `guard.emit` and asks
+     `forces_a_continuation(<the emitted JSON>)`, whose rule is transcribed from the
+     installed bundle (see the module docstring of the hook).
 """
 import importlib.machinery
 import importlib.util
@@ -71,6 +82,41 @@ SESSION = "sess-writeback-1"
 READ_TS = "2026-08-15T12:00:00.000000Z"
 READ_EPOCH = 1786795200.0  # the same instant, pinned as a LITERAL, not computed here
 READ_PLUS_1H = 1786798800.0
+# The last work event: 30 min after the read, 30 min before the "written" comment at
+# 13:00. Distinct from BOTH so a fixture cannot pass by collapsing the two anchors.
+WORK_TS = "2026-08-15T12:30:00.000000Z"
+WORK_EPOCH = 1786797000.0
+
+
+def forces_a_continuation(out):
+    """Would this hook output make the CLI re-query the model instead of ending the
+    turn? Transcribed from claude-code 2.1.220's `bin/.claude-wrapped`, function
+    `Ycd`, which pushes BOTH shapes into one `blockingErrors` array:
+
+        if (F.blockingError)      { … E.push(G); … }
+        if (F.additionalContexts) { … E.push(j); … }
+        if (E.length > 0) return { blockingErrors: E, preventContinuation: !1 };
+
+    and whose caller continues the loop with `stopHookActive:!0` for any non-empty
+    `blockingErrors`. `systemMessage` is absent from that path on purpose: it is
+    yielded as a `hook_system_message` MESSAGE and never reaches `E`.
+    """
+    if not isinstance(out, dict):
+        return False
+    if out.get("decision") == "block":
+        return True
+    hso = out.get("hookSpecificOutput")
+    return bool(isinstance(hso, dict) and hso.get("additionalContext"))
+
+
+def emitted(capsys, verdict):
+    """Run one `(kind, text)` verdict through the REAL writer and return the JSON that
+    reached stdout (None when it wrote nothing). The point is that no test asserts
+    "non-blocking" against an internal kind string — see item 6 in the module
+    docstring."""
+    guard.emit(*verdict)
+    raw = capsys.readouterr().out
+    return json.loads(raw) if raw.strip() else None
 
 
 # --------------------------------------------------------------------------- #
@@ -100,14 +146,20 @@ def state_dir():
     return guard._state_dir({"session_id": SESSION})
 
 
-def seed(task_id=193, ts=READ_TS, work=True):
-    """Put a session into the state the Stop gate reads: task read, work done."""
-    sd = state_dir()
+def seed(task_id=193, ts=READ_TS, work=True, work_ts=WORK_EPOCH, session=SESSION):
+    """Put a session into the state the Stop gate reads: task read, work done.
+
+    🔴 The work stamp is a FIXED instant (WORK_TS), never `time.time()`. The Stop gate
+    compares board comments against the LAST WORK EVENT, so a "now" here would sit in
+    the real present and make every fixture comment retroactively stale — a whole file
+    of tests that pass or fail by the calendar.
+    """
+    sd = guard._state_dir({"session_id": session})
     os.makedirs(sd, exist_ok=True)
     with open(guard._read_path(sd, task_id), "w") as fh:
         json.dump({"task_id": task_id, "first_read_ts": ts}, fh)
     if work:
-        guard.record_work(sd)
+        guard.record_work(sd, now=work_ts)
     return sd
 
 
@@ -203,6 +255,16 @@ def test_two_ids_in_one_command_are_both_recorded_and_deduplicated():
     bash("git -C /home/zach/workspace/devrc commit -m 'x'"),
     bash("git push -u origin feat/x"),
     bash("gh pr create --fill --base main"),
+    # Previously FAIL-OPEN under-matches: both ship something, neither was work.
+    bash("gh pr merge 512 --squash"),
+    bash("gh release create v0.7.90 --notes 'x'"),
+    # ...and the shapes the command-position anchor must still admit, or narrowing
+    # the regex would have silently traded seven false positives for a dead hook.
+    bash("git status -s && git commit -m ok"),
+    bash("cd /tmp; git push"),
+    bash("for f in a b; do git commit -m x; done"),
+    bash("if true; then git push; fi"),
+    bash("(git commit -m x)"),
 ])
 def test_real_work_sets_the_work_flag(data):
     assert guard.is_work(data) is True
@@ -218,6 +280,47 @@ def test_real_work_sets_the_work_flag(data):
 ])
 def test_a_look_around_is_not_work(data):
     assert guard.is_work(data) is False
+
+
+@pytest.mark.parametrize("cmd", [
+    # 🔴 THE SEVEN MEASURED OVER-MATCHES. `is_work` used to search for its literal
+    # text ANYWHERE in the command, and these exact strings live in this repo's own
+    # RULES.md and CLAUDE.md — so grepping for them is a routine act that armed a hook
+    # able to BLOCK the turn. Every one of them TALKS about work; none does any.
+    "grep -rn 'git commit' scripts/",
+    "rg 'gh pr create' claude/skills/",
+    "git log --grep='git push'",
+    "ls -la  # then git commit",
+    "echo 'remember to git commit later'",
+    'echo "reminder: git push before you stop"',
+    "echo remember to git commit later",
+    # ...and the neighbours a sloppier narrowing would readmit
+    "rg -n 'gh pr merge' docs/",
+    "git log --oneline --grep='gh release create'",
+    # 🔴 THE CASES THAT NEED THE STRIPPER AND NOT JUST THE ANCHOR. A shell separator
+    # INSIDE a quoted string is not a separator — but the command-position regex has
+    # no way to know that, so it reads `'…; git commit'` as a fresh command and the
+    # over-match comes straight back. Found by a mutation sweep: bypassing
+    # `_strip_literals` SURVIVED until these three existed.
+    "echo 'first do a thing; git commit -m x'",
+    'echo "build it && git push"',
+    "rg -n 'foo | git push' claude/",
+])
+def test_TALKING_about_work_is_not_DOING_work(cmd):
+    """🔴 The single negative case this file used to carry did not contain the literal
+    at all, so the whole over-match class was untested. `_strip_literals` blanks quoted
+    runs and `#` comments; the command-position anchor rejects the unquoted echo."""
+    assert guard.is_work(bash(cmd)) is False
+
+
+def test_the_positive_control_for_the_literal_stripper():
+    """🔴 Nine `False`s are indistinguishable from an `is_work` wired to nothing. The
+    same commands with the verb moved OUT of the quotes must all be True — and the
+    stripper must not eat a real `git commit -m 'msg'`, whose message IS quoted."""
+    assert guard.is_work(bash("git commit -m 'wire up the grep for git commit'")) \
+        is True
+    assert guard.is_work(bash("grep -rn foo scripts/ && git push")) is True
+    assert guard._strip_literals("echo 'git commit' # git push") .strip() == "echo"
 
 
 # =========================================================================== #
@@ -625,43 +728,96 @@ def test_several_offending_tasks_are_reported_in_one_decision(home):
 # =========================================================================== #
 # 8. THE LIVE READ FAILING — a notice, NEVER a block
 # =========================================================================== #
-def test_an_unreachable_board_emits_a_NON_BLOCKING_notice(home):
+def test_an_unreachable_board_emits_a_notice_that_LETS_THE_TURN_END(home, capsys):
+    """🔴 ASSERTED ON THE EMITTED JSON. The old version of this test asserted the
+    internal kind string `"context"` and called that non-blocking — while the JSON it
+    stood for forced a continuation. Only the writer's output can answer this."""
     seed()
     r = Reader(raises=guard.LiveReadError("connection refused"))
-    kind, text = guard.stop_decision(payload("Stop"), reader=r)
-    assert kind == "context"
-    assert kind != "block"
+    verdict = guard.stop_decision(payload("Stop"), reader=r)
+    text = verdict[1]
     assert "193" in text and "could not be reached" in text
     assert "connection refused" in text
+    out = emitted(capsys, verdict)
+    assert forces_a_continuation(out) is False, out
+    assert out == {"systemMessage": text}
 
 
-def test_an_unreachable_board_NEVER_blocks_at_any_rung(home):
-    """🔴 Driven up the whole ladder. The first two rungs are where a MEASURED miss
-    blocks, so an all-unknown session reaching them and staying non-blocking is the
-    real assertion."""
+def test_an_unreachable_board_costs_ZERO_forced_continuations_at_ANY_rung(home,
+                                                                          capsys):
+    """🔴 Driven up the whole ladder and read as JSON at every rung. The first two
+    rungs are where a MEASURED miss blocks, so an all-unknown session reaching them
+    and STILL letting the turn end is the real assertion — and it is the one that was
+    false before: three `additionalContext` emissions were three forced
+    continuations."""
     seed()
-    kinds = []
+    forced = []
     for _ in range(5):
         r = Reader(raises=guard.LiveReadError("boom"))
-        kinds.append(guard.stop_decision(payload("Stop"), reader=r)[0])
-    assert kinds == ["context", "context", "context", "silent", "silent"]
-    assert "block" not in kinds
+        v = guard.stop_decision(payload("Stop"), reader=r)
+        forced.append(forces_a_continuation(emitted(capsys, v)))
+    assert forced == [False, False, False, False, False]
 
 
-def test_a_reader_raising_something_unexpected_is_also_only_a_notice(home):
+def test_the_positive_control_for_that_zero(home, capsys):
+    """🔴 `forces_a_continuation` returning False five times is indistinguishable from
+    a predicate wired to nothing. The SAME predicate on a MEASURED miss must return
+    True — and on the literal shape the old code emitted, which is the mutant this
+    whole finding is about."""
+    seed()
+    r = Reader(result=task(comments=[]))
+    v = guard.stop_decision(payload("Stop"), reader=r)
+    assert forces_a_continuation(emitted(capsys, v)) is True
+    assert forces_a_continuation(
+        {"hookSpecificOutput": {"hookEventName": "Stop",
+                                "additionalContext": "fyi"}}) is True
+
+
+def test_a_reader_raising_something_unexpected_is_also_only_a_notice(home, capsys):
     seed()
     r = Reader(raises=RuntimeError("kaboom"))
-    kind, text = guard.stop_decision(payload("Stop"), reader=r)
-    assert kind == "context"
-    assert "kaboom" in text
+    v = guard.stop_decision(payload("Stop"), reader=r)
+    assert "kaboom" in v[1]
+    assert forces_a_continuation(emitted(capsys, v)) is False
 
 
-def test_an_unreadable_task_payload_is_a_notice_not_a_block(home):
+def test_an_unreadable_task_payload_is_a_notice_not_a_block(home, capsys):
     seed()
     r = Reader(result="this is not a task object")
-    kind, text = guard.stop_decision(payload("Stop"), reader=r)
-    assert kind == "context"
-    assert "UNVERIFIED" in text
+    v = guard.stop_decision(payload("Stop"), reader=r)
+    assert "UNVERIFIED" in v[1]
+    assert forces_a_continuation(emitted(capsys, v)) is False
+
+
+def test_an_unreachable_board_does_not_spend_the_BLOCK_budget(home, capsys):
+    """🔴 THE TWO COUNTERS. A board down for the first three Stops used to exhaust the
+    per-task ladder, so a genuinely missing write-back could never be blocked later in
+    that session — the hook's whole purpose, defeated by an outage. The measured-miss
+    counter is now separate: after three unmeasurable Stops the FOURTH, with the board
+    back, must still block."""
+    seed()
+    for _ in range(3):
+        guard.stop_decision(payload("Stop"),
+                            reader=Reader(raises=guard.LiveReadError("boom")))
+    r = Reader(result=task(comments=[]))
+    v = guard.stop_decision(payload("Stop"), reader=r)
+    out = emitted(capsys, v)
+    assert out["decision"] == "block", out
+    assert "task status 193 ready_for_review" in out["reason"]
+
+
+def test_an_unmeasurable_board_goes_quiet_rather_than_notifying_forever(home,
+                                                                        capsys):
+    """The other side of that separation: its own counter is still a CAP, so an
+    outage cannot produce one notice per Stop indefinitely. 3 notices, then silence —
+    driven with a range of 6, a length neither MAX_FIRES (3) nor MAX_BLOCKS (2)."""
+    seed()
+    wrote = []
+    for _ in range(6):
+        v = guard.stop_decision(payload("Stop"),
+                                reader=Reader(raises=guard.LiveReadError("boom")))
+        wrote.append(emitted(capsys, v) is not None)
+    assert wrote == [True, True, True, False, False, False]
 
 
 # =========================================================================== #
@@ -674,22 +830,39 @@ def test_the_ladder_constants_are_what_the_docstring_claims():
 
 
 @pytest.mark.parametrize("fire,rung", [
-    (1, "block"), (2, "block"), (3, "context"), (4, "silent"), (9, "silent"),
+    (1, "block"), (2, "block"), (3, "notice"), (4, "silent"), (9, "silent"),
 ])
 def test_escalate_maps_each_fire_number_to_its_rung(fire, rung):
     assert guard.escalate(fire) == rung
 
 
-def test_the_ladder_end_to_end_on_one_task(home):
+def test_the_ladder_end_to_end_on_one_task(home, capsys):
     """🔴 Literal expected sequence, pinned from the ladder in the docstring — NOT
     derived from MAX_BLOCKS/MAX_FIRES, which is how a test comes to agree with a
-    mutated implementation."""
+    mutated implementation. Read as the EMITTED JSON, so "the third rung relents" is
+    a claim about what the CLI receives rather than about a string this file chose."""
     seed()
-    kinds = []
+    shapes = []
     for _ in range(5):
         r = Reader(result=task(comments=[]))
-        kinds.append(guard.stop_decision(payload("Stop"), reader=r)[0])
-    assert kinds == ["block", "block", "context", "silent", "silent"]
+        out = emitted(capsys, guard.stop_decision(payload("Stop"), reader=r))
+        shapes.append(None if out is None
+                      else ("block" if "decision" in out else sorted(out)[0]))
+    assert shapes == ["block", "block", "systemMessage", None, None]
+
+
+def test_the_ladder_costs_EXACTLY_TWO_forced_continuations(home, capsys):
+    """🔴 THE NUMBER IN THE DOCSTRING, MEASURED. It said two and delivered three: the
+    third rung's `additionalContext` went into the CLI's `blockingErrors` array
+    exactly like a block. Counted here off the emitted JSON, over a 5-Stop run whose
+    length equals neither MAX_BLOCKS (2) nor MAX_FIRES (3)."""
+    seed()
+    forced = 0
+    for _ in range(5):
+        r = Reader(result=task(comments=[]))
+        v = guard.stop_decision(payload("Stop"), reader=r)
+        forced += bool(forces_a_continuation(emitted(capsys, v)))
+    assert forced == 2
 
 
 def test_a_counter_seeded_far_past_the_cap_is_silent(home):
@@ -790,6 +963,40 @@ def test_a_payload_carrying_an_agent_id_is_refused(home):
     assert r.calls == []
 
 
+def test_a_SUBAGENTS_tool_call_never_arms_the_PARENT_session(home):
+    """🔴 PROBE C, MEASURED AS A FALSE POSITIVE BEFORE THIS FIX. The bundle builds a
+    PostToolUse payload as `{...Kf(i, void 0, o), hook_event_name:"PostToolUse", …}`,
+    and `Kf`'s `session_id` is `t ?? kt()` with `t` undefined — so a tool call made
+    inside a dispatched subagent arrives carrying the PARENT's session id, with only
+    `agent_id` to tell them apart. The parent reads the card, the subagent does the
+    editing, and the parent's Stop then blocked on work it never did."""
+    guard.post_tool_use(bash("clawgatectl task get 193"))
+    out = guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/x"},
+                                      agent_id="agent_012xyz"))
+    assert out["work"] is False
+    assert guard.work_after_read(state_dir()) is False
+    r = Reader(result=task(comments=[]))
+    assert guard.stop_decision(payload("Stop"), reader=r) == ("silent", "")
+    assert r.calls == []
+
+
+def test_the_positive_control_for_the_agent_id_refusal(home):
+    """The identical payload WITHOUT `agent_id` must arm it — otherwise the refusal
+    above is green because nothing in this fixture could ever set the flag."""
+    guard.post_tool_use(bash("clawgatectl task get 193"))
+    out = guard.post_tool_use(payload(tool_name="Edit",
+                                      tool_input={"file_path": "/x"}))
+    assert out["work"] is True
+    assert guard.work_after_read(state_dir()) is True
+
+
+def test_a_subagents_READ_also_does_not_arm_the_parent(home):
+    """The other half: the refusal is checked before the state dir is even computed,
+    so a subagent surveying the board cannot create a ledger for its parent."""
+    guard.post_tool_use(bash("clawgatectl task get 193", agent_id="agent_012xyz"))
+    assert not os.path.exists(state_dir())
+
+
 def test_SubagentStop_produces_no_output_through_the_real_process(home, tmp_path):
     seed()
     bindir = tmp_path / "bin"
@@ -857,11 +1064,26 @@ def test_block_is_a_TOP_LEVEL_decision_object(capsys):
     assert out == {"decision": "block", "reason": "why"}
 
 
-def test_context_is_a_hookSpecificOutput_arm_naming_Stop(capsys):
-    guard.emit("context", "fyi")
+def test_the_relenting_rung_is_a_systemMessage_and_NOTHING_ELSE(capsys):
+    """🔴 THE WHOLE OF FINDING 1, PINNED AS THE EXACT OBJECT. `systemMessage` is the
+    only field in the CLI's Stop-hook output schema that reaches the operator without
+    entering `blockingErrors`. Asserted as EQUALITY, not membership: an
+    `additionalContext` key added alongside would restore the forced continuation
+    while every "contains systemMessage" check stayed green."""
+    guard.emit("notice", "fyi")
     out = json.loads(capsys.readouterr().out)
-    assert out == {"hookSpecificOutput": {"hookEventName": "Stop",
-                                          "additionalContext": "fyi"}}
+    assert out == {"systemMessage": "fyi"}
+
+
+def test_emit_can_NEVER_produce_an_additionalContext_on_any_kind(capsys):
+    """🔴 The negative half, swept over every kind the ladder can return plus two it
+    cannot. `additionalContext` is not a channel this hook may use on Stop, and a
+    future rung that reached for it would be a silent regression of finding 1."""
+    for kind in ("block", "notice", "silent", "context", "whatever"):
+        guard.emit(kind, "text-%s" % kind)
+        raw = capsys.readouterr().out
+        assert "additionalContext" not in raw, kind
+        assert "hookSpecificOutput" not in raw, kind
 
 
 def test_silent_writes_nothing_at_all(capsys):
@@ -1080,3 +1302,513 @@ def test_the_registrar_registers_it_on_PostToolUse_and_Stop():
 def test_the_hook_file_is_executable_and_parses():
     assert os.path.exists(HOOK)
     compile(open(HOOK).read(), HOOK, "exec")
+
+
+# =========================================================================== #
+# 16. THE FOUR MEASURED FALSE-POSITIVE PROBES, AND THE ESCAPE THAT ACTUALLY WORKS
+#
+# 🔴 The work flag is SESSION-wide. Nothing in a PostToolUse payload says which task
+# an edit belongs to, so two of these four shapes STILL fire — and they are pinned
+# here as behaviour rather than left to be rediscovered. What changed is that the
+# escape is now a mechanism: one command, named in the block text with the session id
+# already filled in, that clears the task for good. The old escape ("say so in one
+# line and stop") was measured NOT to work — saying something changes no state, so
+# the next Stop re-blocked with identical text.
+# =========================================================================== #
+def run_cli(args, home_dir):
+    env = dict(os.environ)
+    env["HOME"] = str(home_dir)
+    return subprocess.run([sys.executable, HOOK] + list(args), input="",
+                          capture_output=True, text=True, timeout=30, env=env)
+
+
+def test_PROBE_A_work_in_a_DIFFERENT_repo_still_fires_and_dismiss_ends_it(home):
+    """🔴 PROBE A, and an honest one: this IS still a false positive. Read task 193,
+    then edit and commit somewhere else entirely — the hook cannot tell, and blocks.
+    What it must NOT do is keep blocking after the operator says the work was not for
+    this card, which is exactly what "say so and stop" did."""
+    guard.post_tool_use(bash("clawgatectl task get 193"))
+    guard.post_tool_use(payload(tool_name="Edit",
+                                tool_input={"file_path": "/other/repo/x.py"}))
+    guard.post_tool_use(bash("git -C /other/repo commit -m 'unrelated'"))
+    kind, text = guard.stop_decision(payload("Stop"),
+                                     reader=Reader(result=task(comments=[])))
+    assert kind == "block"
+    # The escape is a COMMAND, and it carries this session's id already resolved —
+    # a model cannot see its own hook payload, so a placeholder would be unrunnable.
+    assert "--dismiss 193 --session %s" % SESSION in text
+    assert "say so in one line and stop" not in text
+    guard.dismiss(state_dir(), 193)
+    r = Reader(result=task(comments=[]))
+    assert guard.stop_decision(payload("Stop"), reader=r) == ("silent", "")
+    assert r.calls == []
+
+
+def test_PROBE_B_writing_back_only_ONE_of_two_surveyed_cards(home):
+    """🔴 PROBE B. Survey 193 and 194, work, write back 194 only. 194 goes quiet on
+    its own — the live read sees its comment. 193 still fires, and the block text
+    names ONLY 193, so the operator is told exactly which card to dismiss."""
+    guard.post_tool_use(bash("clawgatectl task get 193"), now=READ_EPOCH)
+    guard.post_tool_use(bash("clawgatectl task get 194"), now=READ_EPOCH)
+    guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/x"}),
+                        now=WORK_EPOCH)
+
+    def reader(task_id, timeout=None):
+        if task_id == 194:
+            return task(task_id=194,
+                        comments=[comment(created="2026-08-15T13:00:00.000000Z")])
+        return task(task_id=193, comments=[])
+
+    kind, text = guard.stop_decision(payload("Stop"), reader=reader)
+    assert kind == "block"
+    assert "task status 193 ready_for_review" in text
+    assert "task status 194" not in text
+    assert "--dismiss 193 --session %s" % SESSION in text
+
+
+def test_PROBE_D_a_command_that_merely_MENTIONS_a_commit_does_not_fire(home):
+    """🔴 PROBE D. Read the card, then `echo 'remember to git commit later'`. That was
+    measured to block; it is now not even work. Driven through `post_tool_use` rather
+    than `is_work` so the writer is exercised, which is where a previous sweep found a
+    forced-true mutant surviving every unit-level test in this file."""
+    guard.post_tool_use(bash("clawgatectl task get 193"))
+    guard.post_tool_use(bash("echo 'remember to git commit later'"))
+    guard.post_tool_use(bash("grep -rn 'gh pr create' claude/skills/"))
+    assert guard.work_after_read(state_dir()) is False
+    r = Reader(result=task(comments=[]))
+    assert guard.stop_decision(payload("Stop"), reader=r) == ("silent", "")
+    assert r.calls == []
+
+
+def test_dismiss_removes_the_read_and_BOTH_counters(home):
+    sd = seed()
+    guard.bump_fires(sd, 193)
+    guard.bump_fires(sd, 193, "unknown")
+    removed = guard.dismiss(sd, 193)
+    assert sorted(removed) == ["fires-193", "read-193", "unknown-193"]
+    assert guard.tracked_ids(sd) == {}
+
+
+def test_dismiss_is_PER_TASK_and_leaves_its_neighbours_alone(home):
+    """🔴 A dismissal that swept the session would silence cards the operator never
+    mentioned — the failure mode a blunt "clear everything" escape would have."""
+    seed(task_id=193)
+    sd = seed(task_id=194)
+    guard.dismiss(sd, 193)
+    assert sorted(guard.tracked_ids(sd)) == [194]
+    r = Reader(result=task(comments=[]))
+    kind, text = guard.stop_decision(payload("Stop"), reader=r)
+    assert kind == "block"
+    assert [c[0] for c in r.calls] == [194]
+    assert "task status 194 ready_for_review" in text
+
+
+def test_dismiss_on_an_absent_task_is_not_an_error(home):
+    sd = seed(task_id=193)
+    assert guard.dismiss(sd, 999) == []
+    assert sorted(guard.tracked_ids(sd)) == [193]
+
+
+def test_the_dismiss_command_from_the_block_text_RUNS_and_ENDS_the_nagging(home,
+                                                                           tmp_path):
+    """🔴 THE ESCAPE, EXERCISED AS A REAL SUBPROCESS FROM THE EXACT TEXT THE MODEL IS
+    GIVEN. The command is extracted from the block reason rather than retyped here —
+    a hand-written invocation would still pass if the text advertised a different
+    flag, which is precisely how "say so and stop" survived being useless."""
+    b = tmp_path / "dismissbin"
+    b.mkdir()
+    mockbin.write_exec(b / "clawgatectl",
+                       "printf '%%s\\n' '%s'\n" % json.dumps(task(comments=[])))
+    run_hook(bash("clawgatectl task get 193"), home, path_extra=b)
+    run_hook(payload(tool_name="Edit", tool_input={"file_path": "/x"}), home,
+             path_extra=b)
+    first = run_hook(payload("Stop"), home, path_extra=b)
+    reason = json.loads(first.stdout)["reason"]
+    line = [ln.strip() for ln in reason.splitlines() if "--dismiss" in ln]
+    assert len(line) == 1, reason
+    args = line[0].split()[2:]            # drop `python3 <script>`
+    assert args[0] == "--dismiss"
+    p = run_cli(args, home)
+    assert p.returncode == 0, p.stderr
+    assert "dismissed task 193" in p.stdout
+    # ...and the NEXT Stop is silent, which is the thing the old escape could not do.
+    again = run_hook(payload("Stop"), home, path_extra=b)
+    assert again.returncode == 0
+    assert again.stdout == ""
+
+
+def test_the_positive_control_for_that_dismissal(home, tmp_path):
+    """Without the dismiss step the same sequence blocks a SECOND time — so the
+    silence above is the mechanism working, not a session that had gone quiet anyway
+    (the ladder still has a rung left at this point)."""
+    b = tmp_path / "dismissbin2"
+    b.mkdir()
+    mockbin.write_exec(b / "clawgatectl",
+                       "printf '%%s\\n' '%s'\n" % json.dumps(task(comments=[])))
+    run_hook(bash("clawgatectl task get 193"), home, path_extra=b)
+    run_hook(payload(tool_name="Edit", tool_input={"file_path": "/x"}), home,
+             path_extra=b)
+    run_hook(payload("Stop"), home, path_extra=b)
+    second = run_hook(payload("Stop"), home, path_extra=b)
+    assert json.loads(second.stdout)["decision"] == "block"
+
+
+def test_the_cli_refuses_a_dismiss_without_a_session_rather_than_guessing(home):
+    """🔴 There is no way for this process to learn the caller's session id, so a
+    default would land the dismissal on some other session's ledger. It prints usage
+    and touches nothing."""
+    sd = seed()
+    p = run_cli(["--dismiss", "193"], home)
+    assert p.returncode == 0
+    assert "usage:" in p.stdout
+    assert sorted(guard.tracked_ids(sd)) == [193]
+
+
+@pytest.mark.parametrize("args", [
+    ["--dismiss", "not-a-number", "--session", SESSION],
+    ["--dismiss", "193", "--session", ""],
+])
+def test_the_cli_survives_junk_arguments(home, args):
+    sd = seed()
+    p = run_cli(args, home)
+    assert p.returncode == 0
+    assert p.stderr == ""
+    assert sorted(guard.tracked_ids(sd)) == [193]
+
+
+def test_the_cli_mode_never_reads_stdin(home):
+    """🔴 A model runs this from a Bash tool call, where stdin is a terminal or empty.
+    A dismiss path that fell through to `json.load(sys.stdin)` would hang the turn it
+    was supposed to release. Driven with stdin held OPEN and never written to."""
+    seed()
+    p = subprocess.Popen([sys.executable, HOOK, "--dismiss", "193",
+                          "--session", SESSION],
+                         stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE, text=True,
+                         env={**os.environ, "HOME": str(home)})
+    try:
+        out, _ = p.communicate(timeout=20)   # no input written; the pipe stays open
+    except subprocess.TimeoutExpired:
+        p.kill()
+        raise AssertionError("the CLI mode blocked on stdin")
+    assert p.returncode == 0
+    assert "dismissed task 193" in out
+
+
+# =========================================================================== #
+# 17. THE COMPARISON ANCHOR — the last WORK event, not the read
+#
+# 🔴 THIS IS THE FIX FOR A GUARD THAT WAS DISARMED BY THE RITUAL IT ENFORCES. The
+# clawgate skill posts a "Starting" comment right after the read and BEFORE the work.
+# Anchored on the read, that comment satisfied the check at pickup, so on every
+# session that followed the ritual the hook could never observe a missing COMPLETION
+# write-back — a forward yield of zero on exactly the compliant population.
+# =========================================================================== #
+def test_a_PRE_START_comment_no_longer_disarms_the_guard(home):
+    """The measured shape: read at 12:00, "Starting" comment at 12:01, work at 12:30,
+    Stop. The comment predates the work, so the completion write-back is still owed."""
+    starting = comment(created="2026-08-15T12:01:00.000000Z", body="Starting")
+    assert guard.writeback_state(task(comments=[starting]), READ_TS,
+                                 work_ts=WORK_TS) == "missing"
+
+
+def test_the_full_compliant_ritual_is_still_satisfied(home):
+    """Starting -> work -> Done -> Stop. The Done comment is newer than the work, so
+    the guard goes quiet — the behaviour that must NOT regress while fixing the one
+    above."""
+    starting = comment(created="2026-08-15T12:01:00.000000Z", body="Starting")
+    done = comment(created="2026-08-15T13:00:00.000000Z", body="Done")
+    assert guard.writeback_state(task(comments=[starting, done]), READ_TS,
+                                 work_ts=WORK_TS) == "written"
+
+
+def test_the_anchor_moves_with_the_work_and_NOT_with_the_read(home):
+    """🔴 Three distinct instants, none of which can be produced by collapsing the
+    other two: read 12:00, comment 12:45, work 12:30 vs work 13:30. The SAME comment
+    must read as written against the earlier work and missing against the later one —
+    a mutant that anchors on the read alone gives the same answer to both."""
+    c = comment(created="2026-08-15T12:45:00.000000Z")
+    t = task(comments=[c])
+    assert guard.writeback_state(t, READ_TS, work_ts="2026-08-15T12:30:00Z") \
+        == "written"
+    assert guard.writeback_state(t, READ_TS, work_ts="2026-08-15T13:30:00Z") \
+        == "missing"
+
+
+def test_a_work_stamp_OLDER_than_the_read_does_not_LOOSEN_the_cutoff(home):
+    """The anchor is the LATER of the two. A stale or clock-skewed work stamp must not
+    be able to move the cutoff backwards and admit a comment from before the read."""
+    old = comment(created="2026-08-15T11:00:00.000000Z")
+    assert guard.writeback_state(task(comments=[old]), READ_TS,
+                                 work_ts="2026-08-15T10:00:00Z") == "missing"
+
+
+@pytest.mark.parametrize("bad", [None, "", "1", "garbage", 42])
+def test_an_UNREADABLE_work_stamp_falls_back_to_the_read_anchor(home, bad):
+    """Fail-QUIET, deliberately: a truncated write, or state left by the build that
+    wrote the literal "1", must not invent a stricter cutoff out of an unreadable
+    file. `"1"` is in here because it is exactly what the previous format stored."""
+    c = comment(created="2026-08-15T13:00:00.000000Z")
+    assert guard.writeback_state(task(comments=[c]), READ_TS, work_ts=bad) == "written"
+
+
+def test_the_skew_allowance_absorbs_a_push_right_after_the_comment(home):
+    """🔴 THE NOISE BOUND, MEASURED. Comment at 12:45:00, work at 12:46:00 — 60 s
+    later, inside CLOCK_SKEW_ALLOWANCE_SECS — is still satisfied. 12:50:00, 300 s
+    later, is not. Neither fixture interval (60 s / 300 s) can equal the constant
+    (120 s), so this cannot pass by being it."""
+    c = comment(created="2026-08-15T12:45:00.000000Z")
+    t = task(comments=[c])
+    assert guard.writeback_state(t, READ_TS, work_ts="2026-08-15T12:46:00Z") \
+        == "written"
+    assert guard.writeback_state(t, READ_TS, work_ts="2026-08-15T12:50:00Z") \
+        == "missing"
+
+
+def test_record_work_stores_the_MOST_RECENT_work_not_the_first(home):
+    guard.post_tool_use(bash("clawgatectl task get 193"), now=READ_EPOCH)
+    guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/x"}),
+                        now=WORK_EPOCH)
+    guard.post_tool_use(payload(tool_name="Write", tool_input={"file_path": "/y"}),
+                        now=READ_PLUS_1H)
+    assert guard.last_work_ts(state_dir()) == "2026-08-15T13:00:00Z"
+
+
+def test_MULTI_TURN_work_fires_once_per_turn_and_then_STOPS(home, capsys):
+    """🔴 THE COST OF THE ANCHOR, BOUNDED AND MEASURED RATHER THAN DISCOVERED LATER.
+    Work spanning several turns, with a Done comment each time that the NEXT turn's
+    work then outdates, fires once per turn — until the per-task ladder is spent. Four
+    turns: block, block, systemMessage, silence. Driven with 4, which is neither
+    MAX_BLOCKS (2) nor MAX_FIRES (3)."""
+    sd = seed(work=False)
+    done_at = "2026-08-15T12:45:00.000000Z"
+    shapes = []
+    for i in range(4):
+        # each turn: more work, landing well past the last comment + the skew allowance
+        guard.record_work(sd, now=WORK_EPOCH + 3600 * (i + 1))
+        r = Reader(result=task(comments=[comment(created=done_at)]))
+        out = emitted(capsys, guard.stop_decision(payload("Stop"), reader=r))
+        shapes.append(None if out is None
+                      else ("block" if "decision" in out else sorted(out)[0]))
+    assert shapes == ["block", "block", "systemMessage", None]
+
+
+def test_MULTI_TURN_work_that_KEEPS_writing_back_never_fires_at_all(home):
+    """The positive control for that noise: the same four turns, each with a comment
+    NEWER than that turn's work, stay silent. So the firing above is the anchor
+    doing its job, not an unconditional per-turn nag."""
+    sd = seed(work=False)
+    for i in range(4):
+        worked = WORK_EPOCH + 3600 * (i + 1)
+        guard.record_work(sd, now=worked)
+        fresh = guard.now_iso(worked + 60)
+        r = Reader(result=task(comments=[comment(created=fresh)]))
+        assert guard.stop_decision(payload("Stop"), reader=r) == ("silent", "")
+
+
+# =========================================================================== #
+# 18. THE TWO HANG BOUNDS, EXERCISED AT THEIR DEFAULTS
+#
+# 🔴 The ladder tests inject `budget=3.0` and a fake clock, so for a while NOTHING
+# executed these constants: `STOP_BUDGET_SECS 8.0 -> 600.0` and
+# `PER_TASK_TIMEOUT_SECS 5.0 -> 300.0` both SURVIVED a mutation sweep, and the CLI's
+# own hook timeout (600 000 ms) is the only other thing bounding a Stop.
+# =========================================================================== #
+def test_the_DEFAULT_stop_budget_is_what_cuts_the_reads_off(home):
+    """Clock ticks 0.0 / 7.9 / 8.1 bracket STOP_BUDGET_SECS (8.0) from both sides and
+    equal neither it nor PER_TASK_TIMEOUT_SECS (5.0). At 8.0 exactly one task is read
+    with 0.1 s left; at 600.0 all five are read with the full 5.0 ceiling; at anything
+    below 7.9 none is read at all."""
+    for tid in (11, 12, 13, 14, 15):
+        seed(task_id=tid)
+    ticks = iter([0.0, 7.9, 8.1, 8.1, 8.1, 8.1])
+    r = Reader(result=task(comments=[]))
+    guard.stop_decision(payload("Stop"), reader=r, clock=lambda: next(ticks))
+    assert [c[0] for c in r.calls] == [11]
+    assert r.calls[0][1] == pytest.approx(0.1)
+
+
+def test_a_read_is_NOT_started_with_exactly_zero_budget_left(home):
+    """🔴 THE BOUNDARY ITSELF. `remaining <= 0` vs `remaining < 0` differ at exactly
+    one point, and every other budget test sits off it — so flipping the comparison
+    SURVIVED a sweep. At `remaining == 0.0` the loop must break: admitting the read
+    would hand the client a `timeout=0.0`, which is a spawn that can only fail."""
+    for tid in (11, 12):
+        seed(task_id=tid)
+    ticks = iter([0.0, 8.0, 8.0, 8.0])
+    r = Reader(result=task(comments=[]))
+    guard.stop_decision(payload("Stop"), reader=r, clock=lambda: next(ticks))
+    assert r.calls == []
+
+
+def test_the_positive_control_for_that_boundary(home):
+    """One microsecond of budget on the other side of it, and the read happens."""
+    for tid in (11, 12):
+        seed(task_id=tid)
+    ticks = iter([0.0, 7.999999, 8.0, 8.0, 8.0])
+    r = Reader(result=task(comments=[]))
+    guard.stop_decision(payload("Stop"), reader=r, clock=lambda: next(ticks))
+    assert [c[0] for c in r.calls] == [11]
+
+
+def test_the_DEFAULT_per_task_timeout_is_the_ceiling_on_one_read(home):
+    """With the whole default budget available the ceiling is what bounds a single
+    read — 5.0, not 8.0. Paired with the 3.0 case below, which MOVES the number, so a
+    mutant that hardcodes the ceiling cannot survive both."""
+    seed(task_id=11)
+    r = Reader(result=task(comments=[]))
+    guard.stop_decision(payload("Stop"), reader=r, clock=lambda: 0.0)
+    assert r.calls[0][1] == 5.0
+
+
+def test_the_two_hang_bounds_are_the_numbers_the_docstring_states():
+    """🔴 Pinned as a PAIR with the derived worst case, because the file used to
+    advertise 8.0 as the bound while `_via_curl` waits `timeout + 2` on a read that
+    the budget check admits before it starts: 8.0 + 5.0 + 2 = 15.0 s."""
+    assert guard.STOP_BUDGET_SECS == 8.0
+    assert guard.PER_TASK_TIMEOUT_SECS == 5.0
+    assert guard.CURL_KILL_MARGIN_SECS == 2
+    worst = (guard.STOP_BUDGET_SECS + guard.PER_TASK_TIMEOUT_SECS
+             + guard.CURL_KILL_MARGIN_SECS)
+    assert worst == 15.0
+
+
+def test_the_source_states_the_TRUE_hang_bound_not_the_budget_alone():
+    """The comment above the constants is a claim like any other. It said 8.0 was the
+    bound; the arithmetic says 15.0."""
+    src = open(HOOK).read()
+    assert "STOP_BUDGET_SECS + PER_TASK_TIMEOUT_SECS + 2  =  15.0 s" in src
+
+
+class _FakeProc:
+    returncode = 0
+    stdout = json.dumps({"id": 194, "status": "open", "comments": []})
+    stderr = ""
+
+
+def test_the_curl_wait_OUTLIVES_curls_own_max_time(tmp_path, monkeypatch):
+    """🔴 THE `+ CURL_KILL_MARGIN_SECS`, PINNED AS TWO DIFFERENT NUMBERS. Deleting it
+    survived a sweep: every test drove curl through a stub that returned instantly, so
+    nothing ever compared the two. `max-time = 5` inside the config and `timeout=7` on
+    the wait cannot both come from one literal."""
+    seen = {}
+
+    class _Fake:
+        TimeoutExpired = subprocess.TimeoutExpired
+
+        @staticmethod
+        def run(argv, **kw):
+            seen.update(kw)
+            seen["argv"] = argv
+            return _FakeProc()
+
+    monkeypatch.setattr(guard, "_sp", lambda: _Fake)
+    envf = tmp_path / "clawgate.env"
+    envf.write_text("CLAWGATE_API_URL=http://board.invalid:1\n"
+                    "CLAWGATE_HOOK_TOKEN=t\n")
+    guard._via_curl(194, 5, env_path=str(envf))
+    assert seen["timeout"] == 7
+    cfg_lines = [ln.strip() for ln in seen["input"].splitlines()]
+    assert "max-time = 5" in cfg_lines
+    # ...and the two options that make a failure LOOK like one: without `fail` a 404
+    # body is parsed as a task, without `silent` curl's progress meter lands in stdout.
+    assert "fail" in cfg_lines
+    assert "silent" in cfg_lines
+    assert 'url = "http://board.invalid:1/api/tasks/194"' in cfg_lines
+
+
+def test_the_positive_control_for_that_pair(tmp_path, monkeypatch):
+    """A different timeout must move BOTH numbers — otherwise the assertion above is
+    satisfied by two constants that merely happen to differ by 2."""
+    seen = {}
+
+    class _Fake:
+        TimeoutExpired = subprocess.TimeoutExpired
+
+        @staticmethod
+        def run(argv, **kw):
+            seen.update(kw)
+            return _FakeProc()
+
+    monkeypatch.setattr(guard, "_sp", lambda: _Fake)
+    envf = tmp_path / "clawgate.env"
+    envf.write_text("CLAWGATE_API_URL=http://board.invalid:1\n"
+                    "CLAWGATE_HOOK_TOKEN=t\n")
+    guard._via_curl(194, 11, env_path=str(envf))
+    assert seen["timeout"] == 13
+    assert "max-time = 11" in [ln.strip() for ln in seen["input"].splitlines()]
+
+
+# =========================================================================== #
+# 19. THE SMALL SURFACES THAT HAD NO COVERAGE AT ALL
+# =========================================================================== #
+@pytest.mark.parametrize("raw,want", [
+    ("plain-session_1.2", "plain-session_1.2"),
+    ("../../etc/passwd", ".._.._etc_passwd"),
+    ("a/b c;d$(x)", "a_b_c_d__x_"),
+    ("", ""),
+])
+def test_sanitize_replaces_every_unsafe_character(raw, want):
+    """🔴 This is the only thing standing between an attacker-shaped `session_id` and
+    a path join. It had ZERO coverage: both "return `str(part)` unchanged" and
+    dropping the `[:120]` survived a sweep."""
+    assert guard._sanitize(raw) == want
+
+
+def test_sanitize_truncates_at_120_characters():
+    """Driven with 500 and 119 — neither can equal the 120 it pins."""
+    assert len(guard._sanitize("x" * 500)) == 120
+    assert len(guard._sanitize("y" * 119)) == 119
+
+
+def test_sanitize_coerces_a_non_string():
+    assert guard._sanitize(193) == "193"
+
+
+@pytest.mark.parametrize("session", [None, 42, {"x": 1}, ["a"], ""])
+def test_a_session_id_that_is_not_a_usable_string_has_no_state_dir(session):
+    """🔴 The `isinstance(session, str)` bail survived removal: without it a dict id
+    is `str()`-ed into a path and the hook silently keeps state under a key no other
+    call can reproduce. Asserted directly rather than through main()'s empty stdout,
+    which a mutant produces just as happily."""
+    assert guard._state_dir({"session_id": session}) is None
+
+
+def test_the_positive_control_for_that_bail():
+    sd = guard._state_dir({"session_id": "real-session"})
+    assert sd is not None and sd.endswith("real-session")
+
+
+@pytest.mark.parametrize("raw,want", [
+    ("boom\r\nmore", "boom more"),
+    ("  spaced   out  ", "spaced out"),
+    ("\x1b[31mred\x1b[0m", "\x1b[31mred\x1b[0m"),   # not a newline: length-capped only
+    (None, ""),
+])
+def test_scrub_collapses_third_party_stderr(raw, want):
+    assert guard._scrub(raw) == want
+
+
+def test_scrub_truncates_and_a_failing_client_cannot_flood_the_transcript(tmp_path,
+                                                                          monkeypatch):
+    """🔴 `proc.stderr` is an unfiltered pipe out of a binary this hook does not own,
+    spliced into text an operator reads. Driven with 400 bytes of newline-separated
+    junk: it must come back on ONE line and at most 120 characters."""
+    b = _bin(tmp_path)
+    mockbin.write_exec(b / "clawgatectl",
+                       "echo 'l1' >&2\necho 'l2' >&2\n"
+                       + "".join("echo '%s' >&2\n" % ("x" * 40) for _ in range(10))
+                       + "exit 9\n")
+    _isolated_path(monkeypatch, b)
+    with pytest.raises(guard.LiveReadError) as e:
+        guard.live_task(197, timeout=5, env_path=str(tmp_path / "nope.env"))
+    # The surfacing error is the SECOND client's, carrying the first's message
+    # inside `(first client: …)` — so the scrubbed text is bounded on both sides
+    # rather than running to the end of the string.
+    msg = str(e.value)
+    assert "clawgatectl rc=9" in msg
+    tail = msg.split("clawgatectl rc=9 ", 1)[1].rsplit(")", 1)[0]
+    assert "\n" not in tail and "\r" not in tail
+    assert len(tail) == 120, tail
+    assert tail.startswith("l1 l2 ")
+    assert msg.count("\n") == 0

--- a/scripts/claude-hooks/tests/test_register_nudge_hook.py
+++ b/scripts/claude-hooks/tests/test_register_nudge_hook.py
@@ -24,6 +24,7 @@ SEARCH_NUDGE = "python3 ~/.claude/hooks/search-tool-nudge.py"
 NEXT_STEP = "python3 ~/.claude/hooks/next-step-nudge.py"
 TMUX_STOP = "~/.config/tmux/task-hook.sh"
 LEDGER = "python3 ~/.claude/hooks/agent-ledger-hook.py"
+WRITEBACK = "python3 ~/.claude/hooks/clawgate-writeback-guard.py"
 
 failures = []
 
@@ -87,11 +88,13 @@ with tempfile.TemporaryDirectory() as tmp:
     check("2: pre-existing clawgate Stop hook preserved", CLAWGATE_STOP in cmds(d, "Stop"))
     check("2: pre-existing tmux Stop hook preserved", TMUX_STOP in cmds(d, "Stop"))
 
-    # 🔴 ALL FOUR Stop owners coexist. Asserted as a SET EQUALITY, not four membership
-    # checks: equality fails when the set GROWS (a fifth hook registered by accident)
-    # as well as when it SHRINKS (one clobbered), which membership checks cannot see.
-    check("2: exactly the five expected Stop hooks, none clobbered, none extra",
-          set(cmds(d, "Stop")) == {TMUX_STOP, CLAWGATE_STOP, NOTIFY, NEXT_STEP, LEDGER})
+    # 🔴 EVERY Stop owner coexists — the two FOREIGN ones this script must never
+    # disturb plus the four it appends. Asserted as a SET EQUALITY, not membership
+    # checks: equality fails when the set GROWS (a hook registered by accident) as
+    # well as when it SHRINKS (one clobbered), which membership checks cannot see.
+    check("2: exactly the six expected Stop hooks, none clobbered, none extra",
+          set(cmds(d, "Stop")) == {TMUX_STOP, CLAWGATE_STOP, NOTIFY, NEXT_STEP,
+                                   LEDGER, WRITEBACK})
     check("1: next-step-nudge registered on Stop", NEXT_STEP in cmds(d, "Stop"))
     # Ordering: the two foreign hooks keep their original relative order and stay ahead
     # of everything this script appends. Appending (rather than inserting) is what makes
@@ -146,6 +149,27 @@ with tempfile.TemporaryDirectory() as tmp:
     check("1: the Bash nudges keep their matcher",
           len(bash_entries) == 1 and bash_entries[0].get("matcher") == "Bash")
 
+    # --- the clawgate write-back guard: PostToolUse + Stop ---------------------
+    for ev in ("PostToolUse", "Stop"):
+        check("1: clawgate-writeback-guard registered on " + ev,
+              WRITEBACK in cmds(d, ev))
+    # Stop-and-PostToolUse only. It must NOT reach SubagentStop: a subagent's turn
+    # never reaches the operator, so it owes them no write-back — and the hook
+    # refuses that event itself as well, belt and braces, because registration is
+    # per-host mutable state.
+    check("1: clawgate-writeback-guard NOT registered on SubagentStop",
+          WRITEBACK not in cmds(d, "SubagentStop"))
+    check("1: clawgate-writeback-guard NOT registered on SessionStart",
+          WRITEBACK not in cmds(d, "SessionStart"))
+    # 🔴 UNMATCHERED on PostToolUse, for a DIFFERENT reason than the ledger's: half
+    # of what this guard watches for is an Edit/Write/NotebookEdit tool call, i.e.
+    # exactly the work a `Bash` matcher would never show it. Asserted on the ENTRY,
+    # because the command string alone cannot show which matcher it was filed under.
+    wb_entries = [e for e in d["hooks"]["PostToolUse"]
+                  if any(h.get("command") == WRITEBACK for h in e.get("hooks", []))]
+    check("1: clawgate-writeback-guard PostToolUse entry carries NO matcher",
+          len(wb_entries) == 1 and "matcher" not in wb_entries[0])
+
     # Idempotency: a second run changes nothing and never duplicates.
     p2 = run(env)
     check("3: second run exit 0", p2.returncode == 0)
@@ -157,7 +181,12 @@ with tempfile.TemporaryDirectory() as tmp:
     check("3: clawgate Stop still single + present", cmds(d2, "Stop").count(CLAWGATE_STOP) == 1)
     check("3: no duplicate next-step-nudge on Stop", cmds(d2, "Stop").count(NEXT_STEP) == 1)
     check("3: Stop set unchanged by the second run",
-          set(cmds(d2, "Stop")) == {TMUX_STOP, CLAWGATE_STOP, NOTIFY, NEXT_STEP, LEDGER})
+          set(cmds(d2, "Stop")) == {TMUX_STOP, CLAWGATE_STOP, NOTIFY, NEXT_STEP,
+                                    LEDGER, WRITEBACK})
+    check("3: no duplicate clawgate-writeback-guard on Stop",
+          cmds(d2, "Stop").count(WRITEBACK) == 1)
+    check("3: no duplicate clawgate-writeback-guard on PostToolUse",
+          cmds(d2, "PostToolUse").count(WRITEBACK) == 1)
     check("3: no duplicate agent-ledger on Stop", cmds(d2, "Stop").count(LEDGER) == 1)
     check("3: no duplicate agent-ledger on PostToolUse",
           cmds(d2, "PostToolUse").count(LEDGER) == 1)

--- a/scripts/claude-hooks/tests/test_registrar_activation.py
+++ b/scripts/claude-hooks/tests/test_registrar_activation.py
@@ -55,6 +55,7 @@ BASH = shutil.which("bash") or "/bin/bash"
 NEXT_STEP = "python3 ~/.claude/hooks/next-step-nudge.py"
 NOTIFY = "python3 ~/.claude/hooks/claude-notify.py"
 LEDGER = "python3 ~/.claude/hooks/agent-ledger-hook.py"
+WRITEBACK = "python3 ~/.claude/hooks/clawgate-writeback-guard.py"
 CLAWGATE_STOP = "/home/zach/.claude/clawgate-stop-hook.sh"
 TMUX_STOP = "~/.config/tmux/task-hook.sh"
 
@@ -156,7 +157,7 @@ def test_it_says_what_it_did_on_stdout(tmp_path):
     assert NEXT_STEP in p.stdout, p.stdout
 
 
-def test_three_foreign_stop_hooks_come_back_as_five_originals_intact_and_in_order(tmp_path):
+def test_three_foreign_stop_hooks_come_back_as_six_originals_intact_and_in_order(tmp_path):
     """🔴 Losing the clawgate Stop hook would silently break remote approval."""
     home = make_home(tmp_path, settings_with(THREE_FOREIGN_STOP_HOOKS))
 
@@ -166,17 +167,20 @@ def test_three_foreign_stop_hooks_come_back_as_five_originals_intact_and_in_orde
     assert p.returncode == 0, p.stderr
     # SET equality, not membership: it fails when the set SHRINKS (one clobbered) and
     # when it GROWS (something registered by accident), which membership cannot see.
-    assert set(after) == set(THREE_FOREIGN_STOP_HOOKS) | {NEXT_STEP, LEDGER}, after
-    assert len(after) == 5, after
+    assert set(after) == set(THREE_FOREIGN_STOP_HOOKS) | {NEXT_STEP, LEDGER,
+                                                        WRITEBACK}, after
+    assert len(after) == 6, after
     # The three originals keep their identity AND their relative order, and stay ahead
     # of the appended ones — append-only, never a rewrite.
     assert after[:3] == THREE_FOREIGN_STOP_HOOKS, after
-    # 🔴 The two appended hooks in the order the registrant adds them. Order is
+    # 🔴 The three appended hooks in the order the registrant adds them. Order is
     # load-bearing for next-step-nudge (it returns additionalContext and should
     # run after the notifiers have observed the turn) and irrelevant to the
     # ledger, which neither blocks nor prints — but it is pinned so a reordering
-    # is a decision someone makes rather than a diff nobody reads.
-    assert after[3:] == [LEDGER, NEXT_STEP], after
+    # is a decision someone makes rather than a diff nobody reads. The write-back
+    # guard is the only one here that can BLOCK, and it likewise lands after every
+    # foreign owner has already seen the turn.
+    assert after[3:] == [LEDGER, WRITEBACK, NEXT_STEP], after
 
 
 def test_unrelated_settings_content_is_untouched(tmp_path):

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -926,7 +926,20 @@ TARGET_FLOORS=(
   #   _suggested_floor 130 = 130 - min(50, max(1, 130/20 = 6)) = 130 - 6 = 124.
   # ZERO new skips, so EXPECTED_SKIPS is untouched. If this line conflicts with a
   # sibling branch, re-run the gate on the MERGED tree and copy what it prints.
-  "scripts/claude-hooks/tests/test_clawgate_writeback_guard.py|124"
+  #
+  # 2026-08-16, THE AUDIT ROUND: 130 -> 208. The additions are not padding — each one
+  # answers a measured defect: the relenting rung asserted on the EMITTED JSON rather
+  # than on an internal kind string (the CLI feeds `additionalContext` into the same
+  # `blockingErrors` array as a block, so the old rung forced a third continuation),
+  # the four false-positive probes (subagent `agent_id`, unrelated-repo work, a
+  # partially-written-back survey, a command that merely MENTIONS a commit), the
+  # `--dismiss` escape driven end to end from the block text it advertises, the work
+  # anchor that stops the skill's own pre-start comment from disarming the guard, and
+  # the two hang bounds + `_sanitize`/`_state_dir`/`_scrub`, all of which had ZERO
+  # coverage and survived a sweep. Read from the gate's per-target line, then through
+  # the gate's OWN function:
+  #   _suggested_floor 208 = 208 - min(50, max(1, 208/20 = 10)) = 208 - 10 = 198.
+  "scripts/claude-hooks/tests/test_clawgate_writeback_guard.py|198"
   # 2026-08-14, writer 2 (opencode) arrives as a NEW target: 15 collected.
   #   _suggested_floor 15 = 15 - min(50, max(1, 15/20 = 0 -> 1)) = 14.
   "scripts/opencode/tests|14"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -939,7 +939,21 @@ TARGET_FLOORS=(
   # coverage and survived a sweep. Read from the gate's per-target line, then through
   # the gate's OWN function:
   #   _suggested_floor 208 = 208 - min(50, max(1, 208/20 = 10)) = 208 - 10 = 198.
-  "scripts/claude-hooks/tests/test_clawgate_writeback_guard.py|198"
+  #
+  # 2026-08-16, THE SECOND AUDIT ROUND: 208 -> 244, and the 198 above had already
+  # accumulated 46 of slack — nearly the whole 50-test allowance, i.e. one target away
+  # from being unable to see a collapse. Again not padding: the quoted `git -C "<path>"
+  # commit` shapes (all five measured NOT work, and `git -C` is the form this repo's own
+  # CLAUDE.md mandates, so the guard silently never armed for it), the ASYMMETRIC
+  # subagent rule (a subagent's READ must not arm the parent — a measured false positive
+  # — while its WORK must count, because in BOTH incidents #193/#194 the work ran in
+  # dispatched local subagents and refusing it made the hook silent on its own
+  # motivating case), the per-task read anchor that closes "read N, work, write N back,
+  # then merely read M -> blocks on M", the notice sentence that has to be true both
+  # alone and spliced into a block reason, and the `--dismiss` audit ledger. Read from
+  # the gate's per-target line, then through the gate's OWN function:
+  #   _suggested_floor 244 = 244 - min(50, max(1, 244/20 = 12)) = 244 - 12 = 232.
+  "scripts/claude-hooks/tests/test_clawgate_writeback_guard.py|232"
   # 2026-08-14, writer 2 (opencode) arrives as a NEW target: 15 collected.
   #   _suggested_floor 15 = 15 - min(50, max(1, 15/20 = 0 -> 1)) = 14.
   "scripts/opencode/tests|14"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -916,17 +916,17 @@ TARGET_FLOORS=(
   # failed-tmux-lookup regression. Gate's own count through the gate's own rule:
   #   _suggested_floor 39 = 39 - min(50, max(1, 39/20 = 1)) = 39 - 1 = 38.
   "scripts/claude-hooks/tests/test_agent_ledger_hook.py|38"
-  # 2026-08-16, the clawgate write-back guard arrives as a NEW target: 128 collected.
+  # 2026-08-16, the clawgate write-back guard arrives as a NEW target: 130 collected.
   # (118 in the first round; +6 for the wall-clock budget and its positive control, a
   # naive-timestamp case, and the two gaps a DIFFERENTLY-BUILT mutation sweep found —
   # the work gate exercised through `post_tool_use` rather than a seeded state dir,
-  # and a corrupt state file; +4 for the state prune.) Read from the AUTHORITATIVE
-  # gate's own per-target line, then put through the gate's OWN function rather than
-  # arithmetic:
-  #   _suggested_floor 128 = 128 - min(50, max(1, 128/20 = 6)) = 128 - 6 = 122.
+  # and a corrupt state file; +4 for the state prune; +2 for the deferred-import
+  # measurement and its positive control.) Read from the AUTHORITATIVE gate's own
+  # per-target line, then put through the gate's OWN function rather than arithmetic:
+  #   _suggested_floor 130 = 130 - min(50, max(1, 130/20 = 6)) = 130 - 6 = 124.
   # ZERO new skips, so EXPECTED_SKIPS is untouched. If this line conflicts with a
   # sibling branch, re-run the gate on the MERGED tree and copy what it prints.
-  "scripts/claude-hooks/tests/test_clawgate_writeback_guard.py|122"
+  "scripts/claude-hooks/tests/test_clawgate_writeback_guard.py|124"
   # 2026-08-14, writer 2 (opencode) arrives as a NEW target: 15 collected.
   #   _suggested_floor 15 = 15 - min(50, max(1, 15/20 = 0 -> 1)) = 14.
   "scripts/opencode/tests|14"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -338,6 +338,13 @@ HERMETIC_TARGETS=(
   # stderr, on every malformed input) is felt on every turn and is gated here
   # rather than left to the ungated hand-rolled scripts beside it.
   scripts/claude-hooks/tests/test_agent_ledger_hook.py
+  # Same reason again — a FILE, not the directory. The clawgate write-back guard is
+  # the only hook in this repo that can BLOCK a turn, and it fires on BOTH the
+  # per-tool-call hot path and Stop, so its trigger's non-matches, its
+  # no-work-after-read false-positive killer, its never-block-when-unmeasurable
+  # contract and its exit-0-on-anything backstop are all gated here rather than left
+  # to the ungated hand-rolled scripts beside it.
+  scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
   # Writer 2 of the agent activity ledger — the OPENCODE half. A Python suite
   # driving real `node`, mirroring scripts/collector/opencode/tests/test_plugin.py
   # (this repo's established way to test an opencode plugin; there is no node
@@ -909,6 +916,17 @@ TARGET_FLOORS=(
   # failed-tmux-lookup regression. Gate's own count through the gate's own rule:
   #   _suggested_floor 39 = 39 - min(50, max(1, 39/20 = 1)) = 39 - 1 = 38.
   "scripts/claude-hooks/tests/test_agent_ledger_hook.py|38"
+  # 2026-08-16, the clawgate write-back guard arrives as a NEW target: 128 collected.
+  # (118 in the first round; +6 for the wall-clock budget and its positive control, a
+  # naive-timestamp case, and the two gaps a DIFFERENTLY-BUILT mutation sweep found —
+  # the work gate exercised through `post_tool_use` rather than a seeded state dir,
+  # and a corrupt state file; +4 for the state prune.) Read from the AUTHORITATIVE
+  # gate's own per-target line, then put through the gate's OWN function rather than
+  # arithmetic:
+  #   _suggested_floor 128 = 128 - min(50, max(1, 128/20 = 6)) = 128 - 6 = 122.
+  # ZERO new skips, so EXPECTED_SKIPS is untouched. If this line conflicts with a
+  # sibling branch, re-run the gate on the MERGED tree and copy what it prints.
+  "scripts/claude-hooks/tests/test_clawgate_writeback_guard.py|122"
   # 2026-08-14, writer 2 (opencode) arrives as a NEW target: 15 collected.
   #   _suggested_floor 15 = 15 - min(50, max(1, 15/20 = 0 -> 1)) = 14.
   "scripts/opencode/tests|14"


### PR DESCRIPTION
## The problem, measured

Clawgate tasks **#193 and #194** were both picked up, the work shipped as PRs, and **both cards stayed `open` with ZERO comments**. Both were later re-dispatched and paid for twice. `claude/skills/clawgate/SKILL.md` §"task pickup" already marks the comment/status ritual 🔴 **NOT optional and NOT a thing to be asked for**. Prose is 0-for-2 against it. PRINCIPLES.md prefers a deterministic/structural fix to prompt-tuning; this is that fix.

## 🔴 Keyed on the READ, not the status flip

The obvious design — a PreToolUse deny on `clawgatectl task status <id> in_progress` until a comment exists — is **structurally unreachable for the exact failure it would be built to catch**: in both measured cases no status command was ever issued, because the cards never left `open`. A guard on a command nobody ran observes nothing.

The one act that provably happened in both is the **read**, so that is what arms the hook:

```
clawgatectl task get <N>          # the SKILL's own step 1
curl … /api/tasks/<N>[/comments]  # the same read, before clawgatectl existed
```

Both directions of that trigger are tested. It must **not** match `task ls`, `/api/tasks?summary=1`, a bare `/api/tasks`, or `task get <non-numeric>` — a board *survey* is not a pickup, and arming off one would put a block in front of a turn that claimed nothing.

## What fires it — three conditions, all required

1. the session read a specific clawgate task id, **and**
2. **real work followed** — an `Edit`/`Write`/`NotebookEdit`, or a Bash `git commit` / `git push` / `gh pr create|merge` / `gh release create` **in command position, outside quotes and comments**, and that tool call did **not** carry an `agent_id`, **and**
3. a **LIVE** re-read of the board shows **no comment authored by `claude-code` newer than the MOST RECENT WORK EVENT**.

**(2) is the false-positive killer.** The skill's own step 2 is *"EVALUATE and report to Zach. Do NOT flip status yet"* — a read-and-evaluate-only turn owes the board nothing, and blocking it would be worse than no hook. Asserted here not just by the verdict but by **the board never being read at all**, so a reordering that puts the live read first is visible even when it happens to end up silent.

**(3) is a measurement, not an inference.** It self-suppresses the moment the ritual is followed — including by a subagent, a devpod agent, or a separate process — which a hook tracking only its own observations could not do. A card already in `ready_for_review`/`complete` is left alone.

🔴 **An unreachable board is a NOTICE, never a block.** Unreachable, no client, unparseable JSON → a `systemMessage` naming the task and saying the board could not be reached. `systemMessage`, **not** `additionalContext` — see the audit section below for why that distinction is the whole of finding 1. Going silent there would report the same observable as "the ritual was followed" (RULES.md → *an empty result cannot distinguish two mechanisms*).

## Escalation ladder — per session, per task id

| fire | output | forces a continuation? |
|---|---|---|
| 1 | `{"decision":"block","reason":…}` | **yes** |
| 2 | `{"decision":"block","reason":…}` | **yes** |
| 3 | `{"systemMessage":…}` | no — the turn ends |
| 4+ | silent | no |

**True cost of a measured missing write-back: exactly two forced continuations. True cost of a "could not measure" notice: zero**, and it runs on its own counter, so an outage cannot spend the block budget a genuinely missing write-back needs later in the same session.

Re-derived from the **installed CLI bundle** (claude-code 2.1.220, `bin/.claude-wrapped` — *not* the 20 KB `bin/claude` wrapper, a grep against which returns a meaningless zero), read with Python and with **both controls**: positive `hookEventName` → 68 matches, negative `zzzNOTPRESENTzzz_devrc_control` → 0. **Re-derived independently during the audit round** with a fresh control pair — positive `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` → 5, negative `zzQuuxNotPresentNonce9137` → 0 — which is what found the `additionalContext` error below.

* the hook output schema is a **top-level** object, not a `hookSpecificOutput` arm:
  `v.object({continue, suppressOutput, stopReason, decision: v.enum(["approve","block"]).optional(), reason: …, systemMessage, terminalSequence})`
* the command-hook consumer reads exactly that at **exit 0**:
  `M = L && HB(L) && L.decision === "block"; $ = H.status === 2 || !!M; D = M ? L.reason || H.stderr || "" : …` → `{blocked: $, output: D}`
* consecutive Stop blocks are capped **by the CLI** at `let Kt = wue(process.env.CLAUDE_CODE_STOP_HOOK_BLOCK_CAP, 8)`. **Ours is 2** — a guard the harness has to override has already lost the operator. 🔴 That cap counts `additionalContext` rungs too, which is exactly why rung 3 is a `systemMessage`.

There is deliberately **no `stop_hook_active` gate**, the one place this diverges from the CLI's own advice: that advice exists to bound a block loop, the ladder bounds it at 2 instead, and the *second* block is what catches a turn that acknowledged the first and stopped anyway.

## Hot path

PostToolUse fires after every tool call and `agent-ledger-hook.py` already costs ~21 ms there. A session that has **never** read a clawgate task and is not reading one now costs **exactly one `os.path.exists` and spawns nothing** — pinned by a test that *counts* the filesystem calls and subprocess spawns, plus its own positive control, because an earlier hook in this repo shipped with its throttle consulted *after* the subprocess spawn while its comment claimed the opposite.

Registered on PostToolUse with **no matcher**: half of what it watches for is an `Edit`/`Write`/`NotebookEdit`, i.e. exactly the work a `Bash` matcher would never show it — the commonest shape of the failure (read a card, edit files for an hour).

## Wiring — all four

1. `nix/home.nix` — `home.file.".claude/hooks/clawgate-writeback-guard.py"`.
2. `scripts/claude-hooks/register-nudge-hook.py` — append-only registration on PostToolUse (no matcher) + Stop; docstring updated with why.
3. Both registrar suites now assert every pre-existing Stop owner coexists **as a set equality**, so they fail when the set grows as well as when it shrinks.
4. Both new files `git add`ed — a new file the flake does not track is silently omitted while the switch still succeeds.

Plus 3 lines in the clawgate skill's §"task pickup".

## Evidence

**Red at base / green at HEAD.** The hook is new, so at base (`f522077`) the suite cannot even import it — collection ERROR, all 128 red by construction. The two registrar suites, run at base with only the *test* files swapped in, are red on exactly the new assertions: `test_register_nudge_hook.py` → **7 named FAILUREs**, `test_registrar_activation.py` → **1 failed / 16 passed**. At HEAD: 128/128, 17/17, all-pass.

**Two independently-constructed mutation sweeps**, both under `PYTHONDONTWRITEBYTECODE=1` with every `__pycache__` dropped between mutants (CPython validates cached bytecode on whole-second mtime + size, so a same-length edit is otherwise scored SURVIVED without ever running — several mutants here *are* same-length), every mutation proven applied by sha256 + presence, and the file restored from a copy with the sha re-checked each round:

* **Batch A** — 30 hand-written mutants (constants perturbed, guards forced false, statements hoisted): **29 KILLED, 1 SURVIVED — and that one is the negative control**, an inert comment edit that must survive. Positive control (`AGENT_AUTHOR` → `"api"`) killed 6 tests.
* **Batch B** — mechanically different: every single-line `if` in the file discovered by parsing the source and forced **TRUE**, one at a time. **48/48 as expected**, same negative control in the batch.

Batch B's *first* run found **three real gaps** batch A could not see, all fixed here: the work gate was only ever exercised through a hand-seeded state dir (never through `post_tool_use`), a corrupt state file was untested, and one branch was an unkillable duplicate of `emit`'s own silent case — removed rather than left looking like coverage.

**Verified LIVE, read-only, against the real board with the real `clawgatectl`** (not a stub): the full hook in a real process read task 193, recorded the work, and stayed **silent** because the card is `ready_for_review`; the same live payload with status forced `open` resolves `written` against a 2020 read timestamp and `missing` against a 2099 one. That live probe is also what caught a wrong-subsystem diagnosis — a `clawgatectl` that exists but exits non-zero was being reported as "no clawgatectl".

**Gate.** `scripts/gate.sh --tier pytest` → **exit 0**, `RESULT: PASS (exit=0)`, `TOTAL collected=10588 passed=10587 skipped=1 failed=0`. The authoritative `nix build .#checks.x86_64-linux.pytests` agrees target-for-target, read out of `nix log` rather than from silence. New target: `collected=208 passed=208 skipped=0 floor=198`, the floor taken from the gate's own printed count through the gate's own `_suggested_floor`.

## 🔴 What this structurally CANNOT see

* **Work done anywhere this hook is not running** — a dispatched devpod agent, the clawgate web UI, a human, opencode, or a host that has not had `home-manager switch` run since this lands. (The *board* half still works: a comment written by any of those silences the hook, because condition 3 is a live read.)
* **A read that took some other route** — the board UI, a summary listing, someone pasting the body into the prompt. No read, no arming.
* **Whether the comment is any good.** It checks that a `claude-code` comment exists since the read, never what it says — it cannot tell a real completion report from `"."`.
* **The `in_progress` flip.** Not required; this gates the *write-back*, which is the thing that was measured missing. (The **pre-start comment** used to be on this list and it did not belong there — it did not merely go unseen, it *disabled* the guard. Fixed in the audit round below.)
* **Which task a given edit belongs to.** Nothing in a PostToolUse payload says, so the work flag is session-wide. Two shapes still fire without the session owing anything — work in an unrelated repo after reading a card, and a survey of two cards where only one is written back. Both are **tested as behaviour**, and both have a one-command deterministic escape (`--dismiss`).
* **A clock skew larger than 120 s** between the board and the host would misjudge recency; that is the allowance, and it is bracketed by fixtures at 30 s and 3600 s.

Not merged, not deployed — no `home-manager switch` / `ship.sh` run. Registration on each host needs `register-nudge-hook.py`, which the switch's activation entry already runs.


---

# 🔍 Audit round (2026-08-16) — what the adversarial review found, and what changed

Two 🔴 findings, both re-derived from the installed bundle before anything was
touched, both confirmed.

### 🔴 1. `additionalContext` on Stop does not let the turn end

`Ycd` — the Stop-hook driver — pushes an `additionalContexts` entry into the **same
array** as a `blockingError`:

```js
if (F.blockingError)      { …; E.push(G); … }
if (F.additionalContexts) { …; E.push(j); … }
…
if (E.length > 0) return { blockingErrors: E, preventContinuation: !1 };
```

and its caller re-queries the model for **any** non-empty `blockingErrors`, with
`stopHookActive:!0`, incrementing the counter `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`
bounds. So the ladder's "relent" rung did not relent: **three** forced continuations,
not two, and the `# 🔴 NEVER blocks` comment on the cannot-measure path was **false**
— an unreachable board cost three.

`systemMessage` is the channel that genuinely does not. In the same bundle:

```js
if (j.systemMessage) yield { message: Va({ type:"hook_system_message", … }) };
```

It is yielded on the MESSAGE channel, never into `E`; it renders to the operator as
`"<hookName> says: <content>"`; and its attachment-to-messages entry is
`hook_system_message: () => []`, i.e. it is **not** fed back to the model. Exactly the
shape for a rung whose job is to stop nagging the model and tell the human. Rung 3
now emits it.

The old proof that the rung "did not block" was `stop_decision` returning the string
`"context"` — a **spelled guard** in the sense RULES.md names: the name said
non-blocking while the JSON it stood for was blocking, and a test on an internal
string structurally could not see that. Every such assertion now runs the verdict
through the real `emit` and asks `forces_a_continuation(<the emitted JSON>)`, a
predicate transcribed from the bundle. A mutant that restores the old
`additionalContext` emission is **killed** by 9 tests.

### 🔴 2. The work flag was armed by subagents, and the escape hatch was prose

The bundle builds every hook payload through
`Kf(e, t, r) → { session_id: t ?? kt(), …, agent_id: r?.agentId }`, and PostToolUse
calls it as `{...Kf(i, void 0, o), …}` — second argument `void 0`. A tool call made
**inside a dispatched subagent therefore arrives carrying the parent's
`session_id`**, with only `agent_id` to separate them; the bundle's own schema says
so ("Use this field (not agent_type) to distinguish subagent calls from main-thread
calls"). The parent reads a card, a subagent does the editing, and the parent's Stop
blocked on work it never did. Those events are now refused before the state dir is
even computed.

The block text's escape — *"if you did NOT do work on this task, say so in one line
and stop"* — was measured **not to work**: saying something changes no state, so the
next Stop re-blocked with identical text. Priced from the consuming code, a false
positive plausibly ends in a junk comment, a wrongly-`ready_for_review` card and a
**push notification to Zach** (`notifyTaskDone` fires on entering that status) — and
the junk comment then permanently silences the guard for that card. The escape is now
a mechanism:

```
python3 ~/.claude/hooks/clawgate-writeback-guard.py --dismiss <id> --session <sid>
```

named in the block text **with the session id already interpolated**, because a model
cannot see its own hook payload and a command it must fill a session id into is a
command it cannot run. It clears `read-<id>` and both counters, and it is tested by
extracting the command from the block reason the hook actually emits and running it
as a real subprocess.

**All four probes are now tests**, including the two that still fire — labelled as
residual false positives rather than hidden.

### 🟡 Also fixed

| finding | what changed |
|---|---|
| a pre-start comment **disarmed** the guard | The comparison anchor is the **last work event**, not the read. The skill's own ritual posts "Starting" right after the read and before the work, so anchored on the read the guard was satisfied at pickup and its forward yield on every compliant session was **zero**. `Starting → work → Stop` now correctly owes a comment; `Starting → work → Done → Stop` is satisfied. Multi-turn cost is bounded (≤2 blocks + 1 notice per task per session) and **tested**, and the 120 s skew allowance absorbs a push right after a comment. |
| the two hang bounds were pinned by nothing | Both survived being multiplied by 75 and 60 because every ladder test injected `budget=3.0` and a fake clock. Now exercised at their **defaults**, including the `remaining <= 0` boundary itself, plus curl's `max-time`, `fail`, `silent` and the `timeout + 2` wait — which no test had ever compared. The real worst case is stated: **15.0 s**, not the 8.0 the file advertised. |
| `is_work` matched its literal text anywhere | Quoted runs and `#` comments are blanked, and the verb must be in **command position**. `grep -rn 'git commit' scripts/` and `rg 'gh pr create' claude/skills/` are routine acts in this repo — those exact strings live in RULES.md and CLAUDE.md — and they used to arm a hook that can block a turn. Nine over-match cases tested; `gh pr merge` and `gh release create` added as fail-open under-matches. |
| cannot-measure spent the block budget | Its own counter. A board down for the first Stops can no longer stop a genuinely missing write-back being blocked later. |
| `parse_ts`'s nanosecond trim | Deleted. Dead on the pinned interpreter (measured on 3.12.13: `.000000000` parses fine), and the docstring's "accepts at most six" was true only up to 3.10. |
| `_sanitize`, `_state_dir`'s type bail, `_scrub` | All had **zero** coverage and all survived mutation. Now pinned, including truncation off-by-one. |
| third-party stderr spliced into operator-visible text | Collapsed to single-spaced printables and truncated. |
| three unkillable duplicate guards | Removed: the `[:MAX_TASKS]` slice (`record_read` already caps), the work-gate re-check past the fast-path return, and the second `os.path.exists` in `record_read`. |
| `_via_curl`'s "the laptop has no clawgatectl" | Stale — verified present on both hosts. Claim corrected, fallback kept (it is also the path a *failing* `clawgatectl` takes). |

### Evidence for this round

**Red at base / green at HEAD.** 46 test functions added. Run against the pre-fix hook
(with a compat shim for the two changed fixture signatures, so only behavioural signal
remains): **28 are RED at base** — regression coverage — and **18 are green at base**,
which is what a control or an invariant guard *should* be and is labelled as such
rather than counted as regression coverage. Five pre-existing tests also go red at
base, on the behaviour this round deliberately changed.

**Mutation battery, re-run over the whole file after the fixes, not just the delta.**
66 mutants enumerated from semantic failure modes — operand swap, comparison flip,
branch inversion, wrong bind, off-by-one, comment-out, constant perturbation — run
under `PYTHONDONTWRITEBYTECODE=1` with `__pycache__` deleted between mutants and every
mutation proved applied by **sha change plus replacement-text presence**.

* **64 KILLED, 2 SURVIVED — and both survivors are the declared negative controls**
  (a dead initialiser, and a comment-only edit).
* **Positive control killed** (`return "missing"` → `return "written"`, 31 tests red).
* The battery also re-covers everything the audit said was already good — the
  token-into-argv shape, the fail-open backstop, the fast-path return, the author and
  retraction checks, the skew/TTL/MAX_TASKS constants — all killed.
* Its **first** run found two real gaps the fix round had left: bypassing
  `_strip_literals` survived (the command-position anchor alone covered every case I
  had written, but not a separator *inside* a quoted string), and flipping
  `remaining <= 0` to `< 0` survived because no fixture sat on the boundary. Both are
  now tested.

**Hot path re-measured at parity**: 14.30 / 14.56 / 14.33 / 14.62 ms per call against
14.57 / 14.43 / 14.14 / 14.03 for the pre-audit file measured in the same session
(bare interpreter 7.7–8.2 ms). Holding that took one deliberate change — the three
work-detection patterns moved off the import path, since none is reachable from the
fast path and compiling them eagerly cost ~0.8 ms on **every tool call of every
session**. A first cut with them compiled at import measured 14.7 against 13.9, and
the file's stated measurement is updated to what was actually measured.

**Both authoritative gates, read out of `nix log`** (a cache hit returns exit 0 with
no output, so silence is not a verdict):
`nix build .#checks.x86_64-linux.pytests` → `RESULT: PASS (exit=0)`,
`TOTAL collected=10588 passed=10587 skipped=1 failed=0`;
`.#checks.x86_64-linux.nodetests` → `RESULT: PASS (exit=0)`, `1116/1116`.
The dev-host tier (`scripts/gate.sh --tier pytest --set all`) agrees: `exit=0`.

**Measured against the merged tree? No.** `main` moved during this round and the
branch was deliberately not rebased; every number above is measured on the **branch**.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rwzAkPvjXK9E2aM9zwBMa

