### PR TITLE
chore(gitignore): .envrc and .opencode/ were unignored in a PUBLIC repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,19 @@ __pycache__/
 # NodePort and the Brave profile name. `claudedocs/` is otherwise committable,
 # so this one file is excluded by name.
 /claudedocs/dl-router-design-*.md
+
+# Per-host direnv entrypoint. It is `use opencode` today and holds nothing
+# secret, but an .envrc is exactly where a credential export lands, and this
+# repo is PUBLIC — so it must not be stageable even by accident. Deliberately
+# NOT shipped with a worktree either (see RULES.md "Git Workflow": copy it in
+# and `direnv allow`, or the worktree gets the wrong toolchain). Unanchored on
+# purpose: the hazard is the FILE NAME, not the depth, and nothing named .envrc
+# is tracked at any depth today. `.envrc-example` is a different name and stays
+# committable.
+.envrc
+
+# opencode's per-repo runtime dir: node_modules, a generated package.json, and
+# a `commands` symlink into the gitignored .claude/. Its own inner .gitignore
+# covers the generated files but not the directory itself, so without this line
+# the dir shows up untracked forever and is one `git add .` from being staged.
+/.opencode/


### PR DESCRIPTION
`git check-ignore -v` returned **rc=1** for both on the workbench — neither was covered by any rule in `.gitignore`. They have therefore shown as untracked indefinitely, and were one `git add .` from being staged into a public repository.

## `.envrc`
Holds nothing secret today — it is `use opencode`, one line. But an `.envrc` is exactly where a credential export lands, which is why RULES.md already treats it as a file you copy into a worktree by hand rather than one that travels with a checkout.

Ignored **unanchored** on purpose: the hazard is the file name, not the depth. `git ls-files -i -c --exclude-standard` confirms no tracked file at any depth becomes ignored by this. `.envrc-example` is a different name and stays committable.

## `.opencode/`
opencode's per-repo runtime dir — `node_modules`, a generated `package.json`/`package-lock.json`, and a `commands` symlink into the already-ignored `.claude/`. Its own inner `.gitignore` covers the generated files but not the directory itself, which is why the dir kept surfacing as untracked. Root-anchored, since that is the only place opencode creates it.

## Verification — controls watched in both directions
Positive (must be ignored, all rc=0): `.envrc`, `scripts/.envrc`, `nix/sub/.envrc`, `.opencode/`, `.opencode/commands`.
Negative (must NOT be ignored, all rc=1): `claude/RULES.md`, `scripts/ship.sh`, `scripts/.envrc-example`, `docs/envrc.md`.

`nix build .#checks.x86_64-linux.pytests` on this branch: `TOTAL collected=10380 passed=10379 skipped=1 failed=0`, `RESULT: PASS (exit=0)` — read from log content, not an exit code. No build-input change: the flake already sourced tracked files only, and neither path was ever tracked.

Split out from #507 deliberately — that one preserves stranded prose, this one is repo hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFzGbEBjxitrSknRovngvX