### PR TITLE
feat(nix/system): stage the Logitech USB autosuspend fix — applied on the laptop 2026-08-13, never committed

### DIFF
--- a/nix/system/apply-logitech-no-autosuspend.sh
+++ b/nix/system/apply-logitech-no-autosuspend.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Disable USB autosuspend for Logitech wireless receivers
+# =============================================================================
+# Prevents the mouse from going to sleep after short idle periods.
+# Applies the NixOS module logitech-no-autosuspend.nix, which adds a udev rule
+# via services.udev.extraRules. Idempotent. Run from the repo root:
+#
+#     sudo bash nix/system/apply-logitech-no-autosuspend.sh
+# =============================================================================
+set -euo pipefail
+
+if [[ ${EUID} -ne 0 ]]; then
+  echo "This must run as root:  sudo bash nix/system/apply-logitech-no-autosuspend.sh" >&2
+  exit 1
+fi
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+NIXOS_DIR="/etc/nixos"
+CONFIG="${NIXOS_DIR}/configuration.nix"
+MODULE="${NIXOS_DIR}/logitech-no-autosuspend.nix"
+
+echo "=== Disable Logitech USB autosuspend ==="
+
+# ---------------------------------------------------------------------------- #
+# 1. Install the module.
+# ---------------------------------------------------------------------------- #
+echo "[1/3] Installing ${MODULE}..."
+install -m 0644 -o root -g root "${REPO}/nix/system/logitech-no-autosuspend.nix" "${MODULE}"
+
+# ---------------------------------------------------------------------------- #
+# 2. Ensure configuration.nix imports it.
+# ---------------------------------------------------------------------------- #
+if grep -q 'logitech-no-autosuspend.nix' "${CONFIG}"; then
+  echo "[2/3] Import already present — skipping."
+else
+  echo "[2/3] Wiring import into ${CONFIG}..."
+  cp "${CONFIG}" "${CONFIG}.bak-logitech"
+  n_imports="$(grep -cE '^[[:space:]]*imports[[:space:]]*=' "${CONFIG}" || true)"
+  if [[ "${n_imports}" != "1" ]]; then
+    echo "  -> ERROR: found ${n_imports} 'imports =' assignment(s) in ${CONFIG}." >&2
+    echo "     Add ./logitech-no-autosuspend.nix to imports manually, then re-run." >&2
+    exit 1
+  fi
+  awk '
+    !ins && /^[[:space:]]*imports[[:space:]]*=/ { arm = 1 }
+    arm && !ins && index($0, "[") > 0 {
+      p = index($0, "[")
+      print substr($0, 1, p) "\n      ./logitech-no-autosuspend.nix" substr($0, p + 1)
+      ins = 1; arm = 0; next
+    }
+    { print }
+  ' "${CONFIG}" > "${CONFIG}.tmp.logitech"
+  cat "${CONFIG}.tmp.logitech" > "${CONFIG}"
+  rm -f "${CONFIG}.tmp.logitech"
+  if ! grep -q 'logitech-no-autosuspend.nix' "${CONFIG}"; then
+    echo "  -> ERROR: could not wire import automatically." >&2
+    cp "${CONFIG}.bak-logitech" "${CONFIG}"
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------------------- #
+# 3. Rebuild.
+# ---------------------------------------------------------------------------- #
+echo "[3/3] nixos-rebuild switch..."
+nixos-rebuild switch
+
+# Immediately apply to the current receiver (no replug needed)
+if [[ -d /sys/bus/usb/devices/3-1 ]]; then
+  echo "on" > /sys/bus/usb/devices/3-1/power/control 2>/dev/null || true
+fi
+
+echo "Done. Logitech receivers will no longer autosuspend."

--- a/nix/system/logitech-no-autosuspend.nix
+++ b/nix/system/logitech-no-autosuspend.nix
@@ -1,0 +1,9 @@
+# Disable USB autosuspend for Logitech wireless receivers
+# Prevents mouse from sleeping after short idle periods (2s default)
+{ ... }: {
+  services.udev.extraRules = ''
+    # Disable autosuspend for all Logitech USB receivers
+    ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="046d", TEST=="power/control", ATTR{power/control}="on"
+    ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="046d", TEST=="power/autosuspend", ATTR{power/autosuspend}="-1"
+  '';
+}


### PR DESCRIPTION
The mouse slept after ~2s idle. A udev rule pins Logitech receivers (vendor `046d`) to `power/control=on`, and the usual `nix/system/apply-<change>.sh` installs the module, wires the `/etc/nixos/configuration.nix` import, and rebuilds.

Both files existed **only in the laptop's working tree** — untracked, in no commit and no backup — since 2026-08-13. Surfaced by `drift-check.sh`. Same stranded-work class as #503 and #507; this is the last of the four the handoff listed.

## Preserved as found
- Transferred from the laptop and **sha256-compared after transfer** — byte-identical, both files.
- Modes preserved `755` / `644`, matching the existing `airvpn-host` and `file-manager-backend` pairs. Staged blobs confirm `100755` / `100644`.
- `nix-instantiate --parse` and `bash -n` both clean.

## Already live on the laptop — verified at the consumer, not assumed
| check | result |
|---|---|
| module installed | `/etc/nixos/logitech-no-autosuspend.nix`, 461 B, Aug 13 17:24 |
| step 2 ran | `configuration.nix.bak-logitech` present — **this script writes it and nothing else does** |
| rule rendered | both lines verbatim in `/etc/udev/rules.d/99-local.rules` |
| effect | receiver at `3-1` reads `control=on`, against a default of `auto` |

The obvious check — grepping `configuration.nix` for the import — was **not** usable: that file is mode `0600 root`, so `grep` exited **2 (permission denied)**, not 0-matches. An instrument error, not a zero. The `.bak-logitech` artifact is what actually settles it.

## ⚠ One rule line does not work, left in deliberately
`ATTR{power/autosuspend}="-1"` did **not** take — that receiver still reads `autosuspend=2`. The fix works entirely via `control=on` on the preceding line. Left verbatim: this PR preserves stranded work as found, and removing the dead line is a follow-up rather than a drive-by edit inside a rescue.

Also note `/sys/bus/usb/devices/3-1` is hardcoded in the script's immediate-apply step. It is laptop-specific but `[[ -d ]]`-guarded, so it is a no-op elsewhere.

## Workbench
**Staged, not applied.** An agent cannot `sudo nixos-rebuild`, so the script is committed for the operator to run there if the same fix is wanted:
```
sudo bash nix/system/apply-logitech-no-autosuspend.sh
```

## Gate
`nix build .#checks.x86_64-linux.pytests`: `TOTAL collected=10624 passed=10623 skipped=1 failed=0`, `RESULT: PASS (exit=0)` — read from log content. Branched off current `origin/main` (`9592060`, includes #506), so this is gated on the merged tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFzGbEBjxitrSknRovngvX