### PR TITLE
docs(signal): the activity-emission half was impossible as designed, and four schema defects would have shipped

### DIFF
--- a/claudedocs/dispatch-signal-chat-skill.md
+++ b/claudedocs/dispatch-signal-chat-skill.md
@@ -1,0 +1,149 @@
+# Dispatch brief: Signal chat skill
+
+Companion to `claudedocs/proposal-signal-chat-skill.md` (revised 2026-08-16). Two agents, two
+repos, one hard ordering dependency.
+
+## Gate — CLEARED 2026-08-16
+
+| Decision | Answer | Effect on dispatch |
+|---|---|---|
+| **D1** durability/privacy | **full bodies + attachments** | DDL unchanged; Agent 1 unblocked |
+| **D2** phone number | **existing personal number** | Operator step 1 unblocked; register from the home IP |
+| **D3** send workflow | **draft → clawgate approval** | Agent 1 scope **grows**: split send surface (`draft_message()` / `send_approved()`), clawgate integration cloned from `scripts/mail-actions/clawgate.py`, and a 10th suite `test_approval_gate.py` |
+
+**Agent 1 is dispatchable now.** Agent 2 still waits on operator step 1 (link the phone via QR
+— manual, cannot be delegated) and, for the consumer Deployment only, on Agent 1's PR merging.
+
+---
+
+## Agent 1 — devrc: consumer, DB layer, MinIO, tests, skill
+
+**Blocked on:** nothing — D1/D3 answered. **Not blocked on:** the phone, the cluster, D2 —
+everything here is hermetic and runs against fakes.
+
+**Isolation:** `isolation: "worktree"` — this agent modifies files and devrc is a shared
+checkout.
+
+⚠ **The worktree does not carry `.envrc`** (gitignored), so the flake toolchain is absent and
+the agent will reinvent workarounds. First action inside the worktree:
+`cp $DEVRC/.envrc <worktree>/ && direnv allow <worktree>`. Both or neither — an `.envrc` that
+exists but was never allowed errors on every `cd`.
+
+### Brief
+
+> Implement the devrc half of `claudedocs/proposal-signal-chat-skill.md` on a feature branch
+> ending in a PR. Read the proposal in full first; it is the spec, including the four 🔧 schema
+> corrections and the nine-suite test plan, both of which are load-bearing.
+>
+> Build: `scripts/signal/{consumer.py,_signal_db.py,_minio.py,clawgate.py}` +
+> `scripts/signal/tests/` (10 suites + `fixtures/`) + `claude/skills/signal/SKILL.md`.
+> Clone the patterns from `scripts/mail-actions/{_db.py,_minio.py,clawgate.py}` and
+> `scripts/mail-actions/tests/` — same context-manager shape, same port-forward-vs-direct
+> split, same fixture style, same graceful-no-op-without-token behaviour.
+>
+> **D3 = draft → clawgate approval, not direct-send** (proposal §7). The send surface is split
+> in two — `draft_message()` and `send_approved()` — so no single call composes and transmits.
+> 🔴 The gate must be **structural**: an un-approved draft must have no code route to the
+> Signal API, not merely a documented convention to call approve first. This is the one guard
+> where a green-but-bypassable test is worse than no test.
+>
+> **Hermetic only.** No live Postgres, MinIO, Signal API, or network in any test.
+>
+> **Register the new target in BOTH places or the gate fails naming it:**
+> `scripts/signal/tests` into `HERMETIC_TARGETS` (`scripts/run-tests.sh:288`) *and* into
+> `TARGET_FLOORS` (`:431`). They pin each other two-way (`--check-floors`).
+> 🔴 The floor is MEASURED, never computed: `git add` the new files FIRST (an untracked test is
+> silently absent from the flake source, so the gate reports the old count), run the
+> authoritative gate, read that target's `collected=`, write what the gate prints
+> (`collected - min(50, max(1, collected/20))`). Never do arithmetic across a conflict.
+>
+> **Verification bar — report the evidence, not the claim:**
+> - every regression test shown **RED at base, GREEN at HEAD**; report the matrix. Label any
+>   invariant guard as such rather than counting it as regression coverage.
+> - **mutation-test all four 🔧 corrections plus the D3 approval gate** (five): break each on
+>   purpose, confirm a test fails with *that guard's specific* error, and confirm the case is
+>   reachable (no earlier check short-circuits it). Report survivors — a survivor is the
+>   finding, and a surviving mutant on the approval gate blocks the PR.
+> - fixture values pairwise distinct, and distinct from any constant an assertion names.
+> - any "0 duplicates"/"0 matches" assertion gets a positive control first: feed a case that
+>   MUST be non-zero, watch it move, report the pair.
+> - `test_skill_doc.py` derives its list from the module source, never a hand-written literal.
+> - run the gate via `scripts/gate.sh`; its exit status is authoritative; **90 = could-not-vouch**,
+>   read the log. Never read a status through a pipe or a trailing `echo`.
+>
+> **Git:** feature branch, never `main`. Never `git stash` (repo-global). Never `git add -A` —
+> stage explicit paths. Every new file must be `git add`ed or the flake silently omits it from
+> the deploy. Re-check `git branch --show-current` immediately before each commit.
+>
+> Deliver a PR. In the description, state plainly what you verified live vs. what you did not.
+
+### Definition of done
+- 10 test suites green in the authoritative gate, with the red-at-base matrix reported.
+- Mutation results reported for all four 🔧 corrections **and the approval gate**, survivors
+  named. A surviving mutant on the approval gate blocks the PR.
+- `--check-floors` passes; the floor is the gate's own printed number.
+- `SKILL.md` description written as routing surface (key use case → Zach's literal phrases →
+  disambiguation from `mailbox`).
+- PR open, nothing committed to `main`.
+
+---
+
+## Agent 2 — homelab-talos: Flux manifests
+
+**Blocked on:** D2, operator step 1 (phone linked), **and Agent 1's PR merging** — the consumer
+image is built from devrc source.
+
+🔴 **Do NOT pass `isolation: "worktree"`.** A worktree is built from the *current* cwd's repo,
+not the one the brief names — dispatching from devrc would hand this agent a devrc worktree it
+cannot do the work in. Instead the agent runs the recipe itself:
+`git -C $HOMELAB worktree add ../homelab-talos-signal -b feat/signal origin/trunk`.
+That still satisfies the isolation mandate.
+
+🔴 **`homelab-talos` is GitOps-reconciled — committing to trunk IS deploying.** Its own
+`CLAUDE.md` declares this, which is what makes it the standing exception to the
+feature-branch rule. Work on a branch, and land deliberately.
+
+### Brief
+
+> Implement §1 of `claudedocs/proposal-signal-chat-skill.md` (read it first) in
+> `homelab-talos`: `clusters/homelab/apps/signal/` mirroring
+> `clusters/homelab/apps/mailbox/`, plus the parent Flux Kustomization at
+> `clusters/homelab/flux-system/root-kustomizations/system/signal.yaml` (mirror `mailbox.yaml`
+> there — note this path, the draft proposal had it wrong).
+>
+> Constraints that are not negotiable: **pinned image tag, not `:latest`**; `replicas: 1`
+> (signal-cli key material conflicts across instances); `openebs-nvme-1tb` for the state PVC;
+> SOPS-encrypted `secrets.enc.yaml` for the Postgres DSN.
+>
+> Check `homelab-talos/tests/` for existing manifest-validation precedent and follow it; if
+> there is none, at minimum confirm `kustomize build` succeeds for the new app and for the
+> parent kustomization.
+>
+> Do not deploy the consumer Deployment until Agent 1's PR has merged and its image exists.
+
+### Definition of done
+- `kustomize build` clean for the new app and the parent.
+- No `:latest`, `replicas: 1` present, secrets SOPS-encrypted.
+- Branch pushed; landing on trunk is a deliberate, separately-confirmed step.
+
+---
+
+## Sequencing
+
+```
+Agent 1 (devrc PR) ────────────┐
+                               ├──▶ Agent 2 deploys consumer ──▶ step 7 verify
+operator links phone ──────────┤
+                               └──▶ Agent 2 deploys signal-cli-rest-api + schema
+```
+
+Agent 2's first two objects (API + schema) need only the linked phone; the consumer Deployment
+needs Agent 1 merged. Agent 1 needs neither the phone nor the cluster — it can start now, in
+parallel with the phone linking.
+
+## Verification is the operator's, at the end
+
+Step 7 — send a test message from another device, confirm the Postgres row and the MinIO
+object — is the **only** thing that verifies this works. Nothing an agent reports about a
+hermetic suite is evidence about the live pipeline; a green gate and a successful `kustomize
+build` are prerequisites, not verification.

--- a/claudedocs/proposal-signal-chat-skill.md
+++ b/claudedocs/proposal-signal-chat-skill.md
@@ -1,7 +1,8 @@
 # Proposal: Signal Chat Skill
 
 **Date:** 2026-08-15 (draft, opencode session) · **Revised:** 2026-08-16 after evaluation against the tree
-**Status:** Ready to dispatch — all three blocking decisions resolved 2026-08-16 (§Decisions)
+**Status:** Implemented (devrc half) in **PR #514** — see §Corrections from implementation, which
+records where this spec turned out to be wrong. Decisions resolved 2026-08-16 (§Decisions).
 
 ---
 
@@ -61,6 +62,38 @@ verified in-tree; the file:line evidence is in the bullets.
 Additionally, four **schema defects** found while reviewing the DDL — all now fixed in §4 and
 each one is a named test in §Test Plan: the `UNIQUE`/NULL idempotency hole, the reaction FK
 ordering trap, unconstrained attachment re-delivery, and the outbound sync echo.
+
+## Corrections from implementation (PR #514)
+
+🔴 **This spec was written from a review, not from having built the thing. Building it found
+four places where it was wrong.** Recorded here rather than silently fixed, because the point
+of the document is to be re-readable later — and because two of the four are the same class of
+error the review itself was correcting for: a claim stated slightly beyond what was checked.
+
+1. 🔴 **🔧#4 has an IDENTITY half this spec missed, and the timestamp fix alone does not
+   close it.** §4 says the outbound sync echo dedupes if the send path records the *server*
+   timestamp. That is necessary and **not sufficient**. The draft's sender is a synthetic
+   placeholder contact (minted from the account's own phone number); the echo's sender is the
+   real uuid. Those are two different rows in `signal.contacts`, so the composite key
+   `(source_contact_id, message_timestamp)` **differs**, and the echo dedupes against nothing
+   even with the timestamp handled perfectly. Closed in the implementation by
+   `_promote_placeholder()`. The review caught the timestamp half and stopped there.
+2. 🔴 **§7's send path had a latent bug**: a draft addressed to a **bare phone number** would
+   have transmitted to the synthetic placeholder uuid rather than the real recipient.
+3. 🔴 **The §4 DDL cannot express D3 at all.** It has no `send_state`, no `approval_ref`, no
+   `dest_contact_id` — so the approve-then-send lifecycle has nowhere to live. The
+   implementation adds them, and gives a pending draft a **negative provisional timestamp** so
+   it can never collide with a real message's. The DDL above is therefore the *pre-D3* shape;
+   read the migration in PR #514 for the real one.
+4. **"Sync/outbound" is not a fixture case, it is a full code path.** §Test Plan lists it as
+   one row in the `test_envelope_parse.py` corpus. `syncMessage.sentMessage` carries its own
+   timestamp and destination and needs its own handling, not a variant fixture.
+
+Also worth recording, because it is a result about the *method* rather than the code: the one
+mutant that survived the sweep (the D3 type check) survived because **the test asserted a
+string both guards' messages contain** — it passed for the wrong reason. The gate itself was
+never bypassable and no security hole was closed; what was defective was the evidence. That is
+the spelled-guard trap, and it is worth expecting again anywhere a test asserts on a message.
 
 ## Verified sound (checked, not assumed)
 

--- a/claudedocs/proposal-signal-chat-skill.md
+++ b/claudedocs/proposal-signal-chat-skill.md
@@ -1,32 +1,88 @@
 # Proposal: Signal Chat Skill
 
-**Date:** 2026-08-15
-**Status:** Draft
-**Author:** opencode session
+**Date:** 2026-08-15 (draft, opencode session) · **Revised:** 2026-08-16 after evaluation against the tree
+**Status:** Ready to dispatch — all three blocking decisions resolved 2026-08-16 (§Decisions)
 
 ---
 
 ## Problem
 
-We have a self-hosted mail pipeline (`mailbox` skill) that receives, stores, queries, and automates over email. There is no equivalent for Signal — Zach's primary messaging app. Agent-driven Signal workflows (reading messages, replying, searching conversations, tracking reactions) currently require manual browser/phone interaction.
+We have a self-hosted mail pipeline (`mailbox` skill) that receives, stores, queries, and
+automates over email. There is no equivalent for Signal — Zach's primary messaging app.
+Agent-driven Signal workflows (reading messages, replying, searching conversations, tracking
+reactions) currently require manual browser/phone interaction.
 
 ## Goal
 
-Build a Signal chat skill that mirrors the mailbox skill pattern: **receive → store → query → automate → emit to activity pipeline**. Agents can query Signal conversations, search message history, send replies, and track attachments — all from the CLI.
+Build a Signal chat skill that mirrors the mailbox skill pattern: **receive → store → query →
+automate**. Agents can query Signal conversations, search message history, send replies, and
+track attachments — all from the CLI.
 
-## Architecture
+🔴 **The original draft's fifth stage, "emit to activity pipeline", is CUT from v1.** See
+§Cut from v1 for why, and what it would take to revisit.
+
+## What changed in this revision
+
+Six findings from checking the draft against `devrc` and `homelab-talos`. Every one is
+verified in-tree; the file:line evidence is in the bullets.
+
+1. 🔴 **§6 (activity emission) was architecturally impossible as written — CUT.** The spool is
+   `~/.local/state/activity/spool` (`scripts/collector/collector.py:18,36`), a **per-host local
+   directory** drained by a per-host collector. Every existing emitter runs host-side (keylog,
+   i3, browser-ext receiver, claude session-tailer, browser-bridge server, `invocation.py`).
+   The draft deployed the consumer as a K8s Deployment *and* had it call `emit_activity(msg)`.
+   Both cannot be true. Downstream, `EXPECTED_HOSTS = {"workbench","laptop"}` is **enforced**
+   (`scripts/validation/invariants.py:61,340` via `eval_unexpected_set`), so an in-cluster
+   emitter either trips the host invariant or has to lie about its host.
+2. 🔴 **The draft's Email→Signal mapping row for activity was fabricated symmetry.** The left
+   column is "Email Pattern", and that row claimed one existed. **Mailbox emits nothing to the
+   activity pipeline** — grepping `scripts/mail-actions/*.py` for activity/spool/emit returns
+   only `emit_task` to *clawgate*. (The pattern matches those clawgate lines, so this is a real
+   zero, not a broken grep.) So §6 had no analogue to clone, and its "Trivial (~30 lines)"
+   estimate described code with no working precedent in the repo.
+3. 🔴 **"Add `signal` to `EXPECTED_SOURCES`" was never a one-liner — it enrolls the source in
+   the deadman.** `scripts/collector/deadman.py` evaluates per `(source, host)` pairs against a
+   2-active-hour floor / 48-active-hour cap, and `deadman.py:268` carries an explicit 🔴: a
+   source a human drives directly must also go in `PRESENCE_SOURCES` (`deadman.py:276`).
+   Outbound Signal is human-driven; inbound is not — and the draft emitted both under one
+   source name. Un-navigated that goes one of two bad ways: a quiet day reads as "signal is
+   DEAD", or an inbound message at 03:00 marks Zach present and corrupts active-time
+   accounting for **every other source**.
+4. **The Flux parent-kustomization path did not exist.** Real path is
+   `clusters/homelab/flux-system/root-kustomizations/system/mailbox.yaml`; the draft wrote
+   `root-kustomizations/system/signal.yaml`. Corrected in §1.
+5. **The work spans two repos and the draft did not say so.** §1 lands in `homelab-talos`,
+   where committing to trunk **is** deploying (its own `CLAUDE.md` declares it). Everything
+   else is `devrc`, which is feature-branch-and-PR. Two PRs, two repos, an ordering
+   dependency, different git rules. Now stated in §Deployment Sequence.
+6. **The one irreversible decision was missing from the decisions table.** Now §Decisions
+   Required.
+
+Additionally, four **schema defects** found while reviewing the DDL — all now fixed in §4 and
+each one is a named test in §Test Plan: the `UNIQUE`/NULL idempotency hole, the reaction FK
+ordering trap, unconstrained attachment re-delivery, and the outbound sync echo.
+
+## Verified sound (checked, not assumed)
+
+- `scripts/mail-actions/_db.py` (20.8 KB) and `_minio.py` (7.7 KB) exist — the clone targets
+  are real.
+- `mailbox-postgres` StatefulSet → pod **`mailbox-postgres-0`** ✓ (`postgres.yaml:22,24`).
+- `openebs-nvme-1tb` is a real storage class and the most-used one in the cluster (13 uses) ✓.
+- `clusters/homelab/apps/mailbox/` has almost exactly the file shape §1 copies.
+- No `scripts/signal/` or `claude/skills/signal/` — clean greenfield.
+
+## Architecture (v1)
 
 ```
 Signal App (Zach's phone, linked as secondary device)
        │
        ▼
-signal-cli-rest-api (Docker, json-rpc-native mode, K8s Deployment)
+signal-cli-rest-api (Docker, json-rpc-native mode, K8s Deployment, replicas: 1)
   │ SSE stream + REST API
   ▼
 signal-consumer.py (Python, K8s Deployment)
   ├── Postgres (signal schema on mailbox-postgres-0)
-  ├── MinIO (archive tenant, signal-attachments bucket)
-  └── activity spool (source=signal)
+  └── MinIO (archive tenant, signal-attachments bucket)
 ```
 
 ### Component Mapping (Email → Signal)
@@ -41,27 +97,34 @@ signal-consumer.py (Python, K8s Deployment)
 | `_db.py` (shared DB layer) | `_signal_db.py` (same pattern, same Postgres instance) |
 | `MinioArchive` (invoice archiver) | `MinioSignal` (attachment archiver) |
 | Sent-mail poller (IMAP) | `signal-cli send` + store outbound in same table |
-| `emit` (activity spool) | `activity_emit.py` → v1 lines to spool |
+
+*(The draft's eighth row, `emit` → activity spool, is removed: it had no left-hand side.)*
 
 ## Components
 
-### 1. Flux Manifests — `clusters/homelab/apps/signal/`
+### 1. Flux Manifests — `homelab-talos: clusters/homelab/apps/signal/`
 
 | File | Purpose |
 |---|---|
 | `kustomization.yaml` | Flux Kustomization |
 | `namespace.yaml` | `signal` namespace |
-| `deployment.yaml` | `bbernhard/signal-cli-rest-api:latest`, `json-rpc-native` mode, 1 replica |
+| `deployment.yaml` | `bbernhard/signal-cli-rest-api`, **pinned tag** (not `:latest`), `json-rpc-native`, `replicas: 1` |
 | `service.yaml` | ClusterIP `signal-api.signal.svc:8080` |
 | `pvc.yaml` | 1Gi `openebs-nvme-1tb` for signal-cli state |
-| `configmap-schema.yaml` | `signal` schema SQL for init job |
+| `configmap-schema.yaml` | `signal` schema SQL for the init job |
 | `secrets.enc.yaml` | SOPS-encrypted Postgres DSN |
+| `consumer.yaml` | the consumer Deployment (image built from `devrc: scripts/signal/`) |
 
-Parent Flux Kustomization added to `root-kustomizations/system/signal.yaml`.
+Parent Flux Kustomization at **`clusters/homelab/flux-system/root-kustomizations/system/signal.yaml`**
+(corrected path — mirror `mailbox.yaml` there).
 
-### 2. Consumer — `scripts/signal/consumer.py`
+⚠ `:latest` is replaced with a pinned tag deliberately: the draft's own gotcha table says
+signal-cli breaks if >3 months old, which is an argument for a *deliberate* monthly bump, not
+for floating.
 
-SSE-driven daemon. Pseudocode:
+### 2. Consumer — `devrc: scripts/signal/consumer.py`
+
+SSE-driven daemon.
 
 ```python
 class SignalConsumer:
@@ -71,29 +134,27 @@ class SignalConsumer:
             for event in sse_stream(f"{API_URL}/api/v1/events"):
                 if event.method == "receive":
                     msg = parse_envelope(event.params.envelope)
-                    db.insert_message(msg)
-                    download_attachments(msg)  # → MinIO
-                    emit_activity(msg)          # → spool
+                    db.upsert_message(msg)       # idempotent — see §4
+                    download_attachments(msg)    # → MinIO, idempotent
 ```
 
-Responsibilities:
-- Consume SSE stream from signal-cli-rest-api
-- Parse Signal envelope JSON → structured message
-- Download attachments via `GET /api/v1/attachments/{id}` → upload to MinIO
-- Store message in Postgres via `_signal_db.py`
-- Emit activity event to spool for every message
+Responsibilities: consume the SSE stream · parse envelope JSON → structured message · download
+attachments via `GET /api/v1/attachments/{id}` → MinIO · store via `_signal_db.py`.
 
-### 3. DB Layer — `scripts/signal/_signal_db.py`
+**Must survive:** SSE disconnect/reconnect with redelivery, a malformed event, Postgres
+briefly unavailable, and an attachment fetch failing independently of the message write.
 
-Clone of `scripts/mail-actions/_db.py`:
-- Same `SignalDB` context manager pattern
-- Port-forward vs direct connection (`SIGNAL_PG_HOST` / `SIGNAL_PG_DIRECT`)
-- Namespace `signal`, same Postgres instance (`mailbox-postgres-0`)
-- Methods: `ensure_schema()`, `insert_message()`, `insert_contact()`, `insert_reaction()`, `list_conversations()`, `search()`, `send_message()`
+### 3. DB Layer — `devrc: scripts/signal/_signal_db.py`
+
+Clone of `scripts/mail-actions/_db.py`: same context-manager pattern, port-forward vs direct
+(`SIGNAL_PG_HOST` / `SIGNAL_PG_DIRECT`), namespace `signal`, same Postgres instance.
+Methods: `ensure_schema()`, `upsert_message()`, `upsert_contact()`, `upsert_reaction()`,
+`list_conversations()`, `search()`, `draft_message()`, `send_approved()` — the send surface is
+split in two by D3 (§7), so that no single call composes *and* transmits.
 
 ### 4. Postgres Schema — `signal` Schema
 
-Separate schema on `mailbox-postgres-0` (same instance as `mail`):
+Separate schema on `mailbox-postgres-0`. **Four corrections against the draft DDL, marked 🔧.**
 
 ```sql
 CREATE SCHEMA IF NOT EXISTS signal;
@@ -120,7 +181,11 @@ CREATE TABLE signal.messages (
     message_timestamp BIGINT NOT NULL,
     server_received_at BIGINT,
     server_delivered_at BIGINT,
-    source_contact_id INTEGER REFERENCES signal.contacts(id),
+    -- 🔧 NOT NULL: a UNIQUE over a NULLable column does NOT dedupe in Postgres
+    -- (NULLs compare distinct), so an envelope from an unresolved contact would
+    -- insert a fresh row on every SSE redelivery. Unknown senders get a
+    -- placeholder contact row instead.
+    source_contact_id INTEGER NOT NULL REFERENCES signal.contacts(id),
     message_type TEXT NOT NULL,
     body TEXT,
     expires_in_seconds INTEGER,
@@ -136,6 +201,7 @@ CREATE TABLE signal.messages (
 CREATE TABLE signal.attachments (
     id BIGSERIAL PRIMARY KEY,
     message_id BIGINT REFERENCES signal.messages(id) ON DELETE CASCADE,
+    signal_attachment_id TEXT NOT NULL,   -- 🔧 the API's own id
     content_type TEXT NOT NULL,
     filename TEXT,
     size_bytes BIGINT,
@@ -143,125 +209,209 @@ CREATE TABLE signal.attachments (
     is_voice_note BOOLEAN DEFAULT false,
     minio_bucket TEXT,
     minio_key TEXT,
-    created_at TIMESTAMPTZ DEFAULT now()
+    created_at TIMESTAMPTZ DEFAULT now(),
+    -- 🔧 without this, a redelivered message duplicates every attachment row
+    CONSTRAINT unique_attachment UNIQUE (message_id, signal_attachment_id)
 );
 
 CREATE TABLE signal.reactions (
     id BIGSERIAL PRIMARY KEY,
+    -- 🔧 NULLable + resolved later: a reaction can arrive BEFORE its target
+    -- message (out-of-order SSE) or target a message we never received. A hard
+    -- FK at insert time drops those on the floor.
     message_id BIGINT REFERENCES signal.messages(id) ON DELETE CASCADE,
-    emoji TEXT NOT NULL,
-    contact_id INTEGER REFERENCES signal.contacts(id),
+    target_author_id INTEGER NOT NULL REFERENCES signal.contacts(id),
     target_sent_timestamp BIGINT NOT NULL,
-    is_remove BOOLEAN DEFAULT false
+    emoji TEXT NOT NULL,
+    contact_id INTEGER NOT NULL REFERENCES signal.contacts(id),
+    is_remove BOOLEAN DEFAULT false,
+    CONSTRAINT unique_reaction UNIQUE (contact_id, target_author_id, target_sent_timestamp)
 );
 
--- Indexes
-CREATE INDEX idx_msg_ts ON signal.messages(message_timestamp DESC);
-CREATE INDEX idx_msg_dm ON signal.messages(source_contact_id, message_timestamp);
-CREATE INDEX idx_msg_group ON signal.messages(group_id, message_timestamp) WHERE group_id IS NOT NULL;
-CREATE INDEX idx_msg_fts ON signal.messages USING GIN(search);
-CREATE INDEX idx_att_msg ON signal.attachments(message_id);
+CREATE INDEX idx_msg_ts        ON signal.messages(message_timestamp DESC);
+CREATE INDEX idx_msg_dm        ON signal.messages(source_contact_id, message_timestamp);
+CREATE INDEX idx_msg_group     ON signal.messages(group_id, message_timestamp) WHERE group_id IS NOT NULL;
+CREATE INDEX idx_msg_fts       ON signal.messages USING GIN(search);
+CREATE INDEX idx_att_msg       ON signal.attachments(message_id);
+CREATE INDEX idx_rx_unresolved ON signal.reactions(target_author_id, target_sent_timestamp) WHERE message_id IS NULL;
 ```
 
-### 5. Attachment Storage — `scripts/signal/_minio.py`
+🔧 **The fourth correction is behavioural, not DDL — the outbound sync echo.** A message sent
+via the REST API comes *back* through the SSE stream as a sync message from Zach's own linked
+devices. Without dedupe that stores every sent message twice. `unique_message` covers it only
+if the send path writes the same `(source_contact_id, message_timestamp)` the sync echo will
+carry — so the send path must record the server-assigned timestamp, not a locally generated
+one. This is the single most likely thing to be silently wrong in v1; it has its own test.
 
-Clone of `scripts/mail-actions/_minio.py` targeting archive tenant:
-- Bucket: `signal-attachments` (auto-created on first use)
-- Key: `{contact_or_group}/{YYYY-MM-DD}/{filename}`
-- Sidecar JSON: `{filename}.json` with contact, timestamp, message_id, content_type
+### 5. Attachment Storage — `devrc: scripts/signal/_minio.py`
 
-### 6. Activity Pipeline — `scripts/signal/activity_emit.py`
+Clone of `scripts/mail-actions/_minio.py` targeting the archive tenant. Bucket
+`signal-attachments` (auto-created on first use). Key `{contact_or_group}/{YYYY-MM-DD}/{filename}`.
+Sidecar JSON `{filename}.json` with contact, timestamp, message_id, content_type. Re-upload of
+the same key is a no-op, not a duplicate.
 
-Appends v1-format lines to the activity spool:
+### 6. Skill File — `devrc: claude/skills/signal/SKILL.md`
 
-```python
-emit(
-    source="signal",
-    kind="message",
-    text=f"{'in' if not is_outbound else 'out'} {contact_name}: {body_preview}",
-    project=group_name or contact_name,
-    payload=json.dumps({
-        "contact": contact_name,
-        "group": group_name,
-        "has_attachments": bool(attachments),
-        "message_type": message_type,
-    })
-)
-```
+Same structure as `claude/skills/mailbox/SKILL.md`: key-facts table, query examples (FTS,
+conversation listing, recent messages), send example, gotchas.
 
-Add `"signal"` to `EXPECTED_SOURCES` in `scripts/validation/invariants.py`.
+🔴 Its description line is **routing surface, not documentation** — key use case first, then
+the literal phrases Zach says, then disambiguation from `mailbox`. The listing is budgeted at
+1% of the context window and silently drops descriptions on overflow.
 
-### 7. Skill File — `claude/skills/signal/SKILL.md`
+## Cut from v1: activity-pipeline emission
 
-Same structure as `claude/skills/mailbox/SKILL.md`:
-- Key facts table
-- Query examples (FTS, conversation listing, recent messages)
-- Send example (via signal-cli REST API)
-- Gotchas section
+Removed for three independent reasons, any one of which is sufficient:
 
-## Key Design Decisions
+- **Architecturally blocked** as designed (finding 1) — needs a host-side emitter, which is a
+  different component in a different place from the K8s consumer.
+- **No precedent to clone** (finding 2) — mailbox does not do this.
+- **Requires renegotiating a live invariant** (finding 3) — the inbound/outbound presence
+  split is a real design question about what "active time" means, not a config edit.
 
-| Decision | Rationale |
-|---|---|
-| `signal-cli-rest-api` over raw `signal-cli` | Docker-ready, REST+SSE, MIT, 2.8k stars, `json-rpc-native` mode avoids JVM startup per request |
-| Same Postgres instance as mailbox | Single DB to manage, port-forward already works, `_db.py` pattern is proven |
-| Separate `signal` schema | Isolation from `mail` schema, independent migrations, shared instance |
-| MinIO archive tenant for attachments | Same pattern as invoice archiver, already deployed and operational |
-| `json-rpc-native` mode over `json-rpc` | Persistent daemon, lower memory, no subprocess per request |
-| 1 replica (always) | Signal key material conflicts on multi-instance — non-negotiable |
-| Link as secondary device | Keeps Zach's phone as primary, bot occupies 1 of 5 linked device slots |
+Nothing else in v1 depends on it. **If revisited**, the shape is: a host-side emitter (not the
+cluster consumer), **outbound only**, added to `EXPECTED_SOURCES` but deliberately *not* to
+`PRESENCE_SOURCES`, with the reasoning written at the constant the way the existing ones are.
+That is its own proposal.
+
+## Decisions (RESOLVED 2026-08-16, operator)
+
+| # | Decision | Answer | Consequence |
+|---|---|---|---|
+| D1 | Durability/privacy of message content | **(a) full bodies + attachments** | §4 DDL stands as written — no schema change. Accepted knowingly: this is the irreversible one. |
+| D2 | Phone number | **(a) existing personal number** | Uses 1 of 5 linked-device slots. Register from the home IP (see Gotchas). The bot sees everything the phone sees, which interacts with D1 — capture is total by default. |
+| D3 | Send workflow | **(b) draft → clawgate approval** | The write surface **exists but is gated**. See §7. Adds a component the draft did not have; `test_outbound_echo.py` stays in scope, and a new approval-gate suite joins it. |
+
+**Deferred, not blocking:** group capture allowlist (a filter, addable later — note it is also
+the natural mitigation if D1 is ever revisited), activity depth (downstream of a cut feature).
+
+### 7. Send path — draft → clawgate approval (D3)
+
+Not direct-send. The skill composes a draft; the message reaches Signal only after Zach
+approves it in the existing clawgate UI.
+
+**Precedent to clone:** `scripts/mail-actions/clawgate.py` — `emit_task(...)`, which posts a
+Task card and is a **graceful no-op returning `False`** when `CLAWGATE_HOOK_TOKEN` is unset.
+Mirror that shape, including the no-op.
+
+🔴 **The gate must be structural, not procedural.** `send_message()` must be unable to reach
+the Signal API without an approval token — not merely documented as "call approve first". The
+failure mode this guards against is an agent calling the send helper directly and bypassing a
+convention. Design it so the un-approved path has no code route to the API, and pin that with
+a test that tries to take it.
+
+Un-approved drafts are stored with `is_outbound=true` and a pending state so a draft is never
+silently lost; the sync-echo dedupe (§4 🔧) applies once the approved message actually sends.
 
 ## Deployment Sequence
 
-1. Register phone — link as secondary device via QR code scan
-2. Deploy `signal-cli-rest-api` — PVC + Deployment + Service via Flux
-3. Create Postgres schema — `CREATE SCHEMA signal` + tables init
-4. Build + deploy consumer — SSE consumer as K8s Deployment
-5. Wire activity pipeline — emit events, add to `EXPECTED_SOURCES`
-6. Write skill — `SKILL.md` with query/send examples
-7. Verify — send test message from another device, check Postgres + MinIO + spool
+🔴 **Two repos, different rules.** `homelab-talos` is GitOps-reconciled — committing to trunk
+**is** deploying. `devrc` is feature-branch → PR → `scripts/ship.sh`.
 
-## Gotchas
+| # | Step | Repo |
+|---|---|---|
+| 1 | Register phone — link as secondary device via QR (**operator, manual**) | — |
+| 2 | Deploy `signal-cli-rest-api` — PVC + Deployment + Service via Flux | homelab-talos |
+| 3 | Create `signal` schema — init job from `configmap-schema.yaml` | homelab-talos |
+| 4 | Build consumer + `_signal_db.py` + `_minio.py` + tests | devrc (PR) |
+| 5 | Deploy consumer Deployment | homelab-talos |
+| 6 | Write `claude/skills/signal/SKILL.md` | devrc (same PR as 4) |
+| 7 | Verify — send a test message from another device, confirm Postgres row + MinIO object | — |
+
+Steps 4+6 are one devrc PR. Steps 2/3/5 are homelab-talos commits, and **5 depends on 4
+merging first** (the image is built from devrc source).
+
+## Test Plan
+
+🔴 **Hermetic.** The new target runs in the nix sandbox — no live Postgres, no live MinIO, no
+Signal API, no network. Fakes/fixtures only, on the `scripts/mail-actions/tests/` model
+(`test_db_schema.py`, `test_db_direct_mode.py`, `test_idempotency.py`, `fixtures/`).
+
+### Registering the target — both edits or the gate fails naming it
+
+`scripts/signal/tests` must be added to **`HERMETIC_TARGETS`** (`scripts/run-tests.sh:288`)
+**and** to **`TARGET_FLOORS`** (`:431`) — they pin each other two-way, validated by
+`--check-floors`.
+
+🔴 **The floor is MEASURED, never computed.** `git add` the new files first (an untracked test
+is silently absent from the flake source, so the gate reports the old count), run the
+authoritative gate, read that target's `collected=`, and write what the gate prints:
+`collected - min(50, max(1, collected/20))`. Do not do arithmetic across a conflict.
+
+### Suites
+
+| File | Covers |
+|---|---|
+| `test_db_schema.py` | `ensure_schema()` is idempotent; every table/index/constraint present; the generated `search` tsvector actually populates |
+| `test_idempotency.py` | 🔧 the same envelope twice → **one** row; **the NULL-contact path specifically** (an unresolved sender must not bypass `unique_message`); attachment redelivery → one attachment row |
+| `test_envelope_parse.py` | fixture corpus: DM · group · reaction · edit · attachment · quote · delivery receipt · read receipt · typing · **sync (outbound from another linked device)** · view-once · expiring · **unknown/unhandled type** |
+| `test_outbound_echo.py` | 🔧 send → the sync echo arrives → **one** row, `is_outbound=true`; and the send path records the *server* timestamp, not a local one |
+| `test_reactions.py` | 🔧 reaction arriving **before** its target message resolves later; reaction to a never-received message is retained, not dropped; remove-reaction; the partial index is used |
+| `test_minio_signal.py` | key layout; sidecar JSON contents; bucket auto-create; re-upload of the same key is a no-op |
+| `test_search.py` | FTS returns the right rows — **and a positive control**: a query that MUST match something, so a zero is distinguishable from a miswired query |
+| `test_consumer_resilience.py` | SSE disconnect→reconnect with redelivery loses and duplicates nothing; malformed event is skipped, not fatal; Postgres unavailable → retry without dropping; attachment fetch failure does not roll back the message write |
+| `test_approval_gate.py` | 🔴 **D3**: an un-approved draft has **no code route to the Signal API** — assert the attempt fails with the gate's own specific error, not merely that a convention was skipped; approval token absent → graceful no-op (`False`), mirroring `mail-actions/clawgate.py`; an approved draft transmits exactly once; a draft is never lost |
+| `test_skill_doc.py` | every status/command the module emits is documented in `SKILL.md`, **derived from the source** (`re.findall` over the module), never from a hand-written literal |
+
+### Discipline the implementer must follow (repo-standard, non-negotiable)
+
+- 🔴 **Every regression test shown RED at base, GREEN at HEAD** — report the matrix. A test
+  that only ever passed proves nothing. A guard pinning an invariant the bug never violated is
+  an *invariant guard*: label it, don't count it as regression coverage.
+- 🔴 **Mutation-test each of the four 🔧 corrections *and* the D3 approval gate** (five in
+  total): break it on purpose, confirm a test fails **with that guard's specific error**, and
+  confirm the case is *reachable* (no earlier check short-circuits it). A mutant that survives
+  a green suite is the finding. The approval gate is the one where a survivor matters most —
+  a bypassable gate that tests green is worse than no gate.
+- 🔴 **Fixture values pairwise distinct, and distinct from any constant an assertion names** —
+  a fixture that can only produce the constant's own value cannot catch a hardcoded literal.
+- 🔴 **Validate the instrument before reading its verdict**: for any "0 duplicates" / "0
+  matches" assertion, first feed a case that MUST produce a non-zero count and watch the number
+  move. Report the pair, never the zero alone.
+- 🔴 **`test_skill_doc.py` must DERIVE its list from the module.** A ledger that restates a
+  hand-written literal cannot catch the thing it was written for.
+- Read the gate's verdict with **`scripts/gate.sh`** — its exit status is authoritative, exit
+  **90 = could-not-vouch** (read the log), and never read a status through a pipe or a trailing
+  `echo`.
+
+## Gotchas (carried forward, plus the new ones)
 
 | Gotcha | Mitigation |
 |---|---|
-| signal-cli breaks if >3 months old (protocol rotates) | Pin version in Deployment, monthly update cadence |
-| 1 replica max — key conflicts on multi-instance | `replicas: 1` hard constraint |
-| Must `receive` regularly or account flagged spam | CronJob calling `/api/v1/receive` every 6h |
-| Cloud IPs may be pre-flagged | Use home IP for initial registration |
-| Max 5 linked devices per phone | Uses 1 slot — dedicated number if scaling needed |
+| signal-cli breaks if >3 months old (protocol rotates) | **Pinned tag** + monthly bump cadence |
+| 1 replica max — key conflicts on multi-instance | `replicas: 1`, hard constraint |
+| Must `receive` regularly or the account is flagged spam | CronJob calling `/api/v1/receive` every 6h |
+| Cloud IPs may be pre-flagged | Register from the home IP |
+| Max 5 linked devices per phone | Uses 1 slot — see D2 |
 | Rate limits undocumented (~100 msgs/day to new contacts) | Exponential backoff, respect `Retry-After` |
-| Read receipts / typing indicators DBus-only | Accept limitation, no REST equivalent |
-| Postgres shared with mailbox | Separate schema, distinct namespace, no collision |
-
-## Open Questions
-
-| Question | Options |
-|---|---|
-| Consumer runtime | K8s Deployment (always-on) vs CronJob (poll every N min)? |
-| Send workflow | Agent direct-send, or Zach-reviewed only? |
-| Group capture | All groups, or configurable allowlist? |
-| Activity pipeline depth | Just message events, or also reactions/edits/group-changes? |
-| Phone number | Existing personal, or dedicated bot number? |
+| Read receipts / typing indicators DBus-only | Accept; no REST equivalent |
+| Postgres shared with mailbox | Separate schema, distinct namespace |
+| 🔧 **`UNIQUE` does not dedupe over NULL in Postgres** | `source_contact_id NOT NULL` + placeholder contacts |
+| 🔧 **Outbound messages echo back via device sync** | Store the server timestamp so `unique_message` catches the echo |
+| 🔧 **Reactions can precede their target message** | Nullable `message_id`, resolved later, partial index |
+| 🔧 **Redelivery duplicates attachments** | `UNIQUE (message_id, signal_attachment_id)` |
+| ⚠ Every gotcha above except the 🔧 ones is **recall from upstream docs**, unverified here | Confirm against the live deployment at step 7 |
 
 ## Estimated Effort
 
 | Component | Size |
 |---|---|
-| Flux manifests | Small (copy + adapt mailbox pattern) |
+| Flux manifests | Small (copy + adapt mailbox) |
 | Consumer (SSE → parse → store) | Medium (~300-400 lines) |
-| `_signal_db.py` | Small (clone `_db.py`, adapt methods) |
-| Postgres schema | Small (SQL above, run once) |
-| `_minio.py` | Small (clone `_minio.py`, change bucket) |
-| Activity emit | Trivial (~30 lines) |
-| Skill file | Small (clone mailbox skill, rewrite for Signal) |
-| Testing + iteration | Medium (SSE edge cases, attachment paths, group messages) |
+| `_signal_db.py` | Small (clone `_db.py`) |
+| Postgres schema | Small (SQL above) |
+| `_minio.py` | Small (clone `_minio.py`) |
+| Skill file | Small (clone mailbox skill) |
+| Send path + clawgate approval gate (D3) | Small-medium (clone `mail-actions/clawgate.py`) |
+| **Tests (10 suites + fixture corpus)** | **Medium-large — the largest single item** |
+| Testing + iteration (SSE edge cases, attachments, groups) | Medium |
 
-**Total: ~1-2 days of focused work** after the phone is linked.
+**~2-3 days of focused work** after the phone is linked. The draft's 1-2 days predated the
+test plan and the four schema corrections; the storage half alone is still ~1-2.
 
 ## References
 
-- [signal-cli](https://github.com/AsamK/signal-cli) — 4.9k stars, GPLv3, v0.14.7
-- [signal-cli-rest-api](https://github.com/bbernhard/signal-cli-rest-api) — 2.8k stars, MIT
-- [signal-cli-rest-api docs](https://bbernhard.github.io/signal-cli-rest-api/) — Swagger, config, Docker usage
-- [signalbot](https://github.com/sergdort/signalbot) — Python framework (decorator-based handlers)
+- [signal-cli](https://github.com/AsamK/signal-cli) — GPLv3
+- [signal-cli-rest-api](https://github.com/bbernhard/signal-cli-rest-api) — MIT
+- [signal-cli-rest-api docs](https://bbernhard.github.io/signal-cli-rest-api/) — Swagger, config, Docker
+- [signalbot](https://github.com/sergdort/signalbot) — Python framework, decorator handlers


### PR DESCRIPTION
Evaluation of `claudedocs/proposal-signal-chat-skill.md` (drafted by an opencode session) against the actual tree, plus the dispatch brief for implementation.

## The cut

The draft's fifth stage — emit to the activity pipeline — cannot work as written. Three independent reasons, any one sufficient:

- **Architecturally blocked.** The spool is `~/.local/state/activity/spool` (`collector.py:18,36`), a per-host local directory drained by a per-host collector; every existing emitter runs host-side. The draft deployed the consumer as a K8s Deployment *and* had it call `emit_activity()`. Downstream, `EXPECTED_HOSTS = {"workbench","laptop"}` is enforced (`invariants.py:61,340`), so an in-cluster emitter either trips the host invariant or lies about its host.
- **No precedent to clone.** The Email→Signal mapping row for activity had no left-hand side — mailbox emits nothing to activity (only `emit_task` to clawgate). Its "trivial ~30 lines" estimate described code with no working analogue in the repo.
- **Requires renegotiating a live invariant.** `EXPECTED_SOURCES` enrolls the source in the deadman's per-`(source,host)` evaluation, and `deadman.py:268` requires a human-driven source to also enter `PRESENCE_SOURCES`. The draft emitted inbound and outbound under one name — precisely the split that allowlist exists to make. Un-navigated: a quiet day reads as "signal is DEAD", or an inbound message at 03:00 marks the operator present and corrupts active-time for every other source.

Nothing else in v1 depended on it. The revisit shape is recorded rather than discarded.

## Four schema defects found reviewing the DDL

Each corrected, each now a named test:

| Defect | Why it would have shipped silently |
|---|---|
| `UNIQUE` does not dedupe over `NULL` in Postgres | an unresolved sender inserted a fresh row on every SSE redelivery |
| reactions can arrive **before** their target message | a hard FK dropped them on the floor |
| attachments had no unique constraint | redelivery duplicated every attachment row |
| outbound messages echo back via device sync | only dedupes if the send path records the **server** timestamp, not a local one |

The last is the one most likely to be silently wrong in v1.

## Also fixed

The Flux parent path did not exist (real path is under `clusters/homelab/flux-system/root-kustomizations/system/`); `:latest` replaced with a pinned tag, since the draft's own gotcha table argues for a deliberate monthly bump rather than floating; and the unstated two-repo split — `homelab-talos` is GitOps-reconciled, where committing to trunk *is* deploying.

## Decisions resolved

Full bodies + attachments · existing personal number · **draft → clawgate approval** rather than direct-send. The last splits the send surface (`draft_message()` / `send_approved()`) so no single call composes and transmits, and requires the gate to be structural — an un-approved draft must have no code route to the Signal API, not merely a convention to call approve first.

## Dispatch brief

Two agents, ten hermetic test suites, five mutation targets (four 🔧 corrections + the approval gate, where a survivor blocks the PR), and the `HERMETIC_TARGETS`/`TARGET_FLOORS` two-way registration with the measure-don't-compute floor procedure. Agent 2 is explicitly told **not** to use worktree isolation — a worktree is built from the current cwd's repo, so dispatching from devrc would hand it the wrong tree.

## Verification

Docs only — no code paths touched, nothing to run. Every claim above is cited to a file:line that was read in this session, not inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MRnRt9ESKvhGuhfAVDhvM