### PR TITLE
fix(session-manager): --claude-only blamed the BUILD for what the FILTER removed; feat(drift-check): encode the fuzzyclaw phase-2 gate as rc 16

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,18 @@ there. Only what's specific to this repo, where a working tree is also a **deplo
   🔴 **rc 16 is NOT drift** — it is the fuzzyclaw phase-2 gate reporting that zero rows
   still take their age from fuzzyclaw alone, i.e. the readers can now be deleted; the
   final line says `ACTIONABLE (not drift)` and it is the least severe code, so it can
-  only ever be the verdict on an otherwise-clean run. Every way that gate can fail to
-  measure prints `COULD NOT MEASURE` with a reason and sets **no** rc — a `0` there is
-  never a pass, because the answer it hands over is a deletion.
+  only ever be the verdict on an otherwise-clean run — which is also printed, since
+  "no drift" and "a cleanup is possible" are independent claims. It is a **success** to
+  systemd (`SuccessExitStatus = 16`): it stays set until the cleanup happens, so failing
+  the unit on it would fire the DND-defeating failure toast 4×/day forever. Every way
+  that gate can fail to measure prints `COULD NOT MEASURE` with a reason and sets **no**
+  rc — a `0` there is never a pass, because the answer it hands over is a deletion. That
+  last claim is **enforced, not asserted**: `test_drift_check.py::test_the_phase2_reason_
+  token_ledger_is_pinned_to_the_fields_read` pins the emitted reason-token set against
+  the report fields `lib/drift_phase2.py` reads, so consulting a new field without giving
+  its absence a token fails the suite. It exists because the prose version was false for
+  three days — `summary.age_sources` was read with no presence check, and a report
+  missing it printed a `READY` byte-identical to a real one.
 - **Recovering a diverged host** — preserve, verify, *then* move the pointer:
   `git branch <topic> HEAD && git push -u origin <topic>` on that host → confirm the shas are
   on origin **from a different host** → `git reset --keep origin/main` (`--keep` refuses

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,12 @@ there. Only what's specific to this repo, where a working tree is also a **deplo
   block prompts for what the other allows, which is a real gap. Close it with
   `scripts/sync-claude-permissions.py` (idempotent, additive, **curated** — never copy the
   other host's block wholesale; #380 exists because that file accretes junk).
+  🔴 **rc 16 is NOT drift** — it is the fuzzyclaw phase-2 gate reporting that zero rows
+  still take their age from fuzzyclaw alone, i.e. the readers can now be deleted; the
+  final line says `ACTIONABLE (not drift)` and it is the least severe code, so it can
+  only ever be the verdict on an otherwise-clean run. Every way that gate can fail to
+  measure prints `COULD NOT MEASURE` with a reason and sets **no** rc — a `0` there is
+  never a pass, because the answer it hands over is a deletion.
 - **Recovering a diverged host** — preserve, verify, *then* move the pointer:
   `git branch <topic> HEAD && git push -u origin <topic>` on that host → confirm the shas are
   on origin **from a different host** → `git reset --keep origin/main` (`--keep` refuses

--- a/claude/skills/session-manager/SKILL.md
+++ b/claude/skills/session-manager/SKILL.md
@@ -39,7 +39,7 @@ these rows. `kind` is never null; `runtime` frequently is, and means something e
 | `--json` | JSON (default is a table). Compact, not indented — 34% of the payload was whitespace for a reader that does not exist |
 | `--lean` | 🔴 **with `--json`, prefer this.** The agent-shaped view: rows trimmed to the fields that answer this tool's question, **untruncated**, with every measurement discriminator and the caveats kept |
 | `--host workbench\|laptop\|all` | default `all`; `tail` resolves `all` to LOCAL |
-| `--claude-only` | drop non-Claude rows; every count then describes the FILTERED set, and `summary.excluded_non_claude` says how many went |
+| `--claude-only` | drop the **shell** rows (`CLASS=shell`) — a `cluster` dispatch is an agent and is KEPT. Every count then describes the FILTERED set; `summary.excluded_shells` says how many went and `summary.kinds_excluded_by_filter` names any kind removed entirely |
 | `--no-ch` | skip ClickHouse — the client is never constructed |
 | `--no-capture` | skip the pane scrape; **every** `waiting_probable` becomes `null` |
 | `--fuzzyclaw` / `--no-fuzzyclaw` | the task-file join is **OFF by default** (see below) |

--- a/claude/skills/session-manager/reference/exit-codes.md
+++ b/claude/skills/session-manager/reference/exit-codes.md
@@ -57,4 +57,24 @@ Under `--claude-only`, every summary count describes the **filtered** set. That 
 direction: counting the unfiltered set would publish `total_sessions: 20` beside an empty
 table and **exit 0** — "ran, found windows" over nothing printed. Counting the filtered set
 makes the same run a real measured zero (**exit 3**), because zero *agent* windows is what
-was asked, and `summary.excluded_non_claude` keeps it from reading as an empty host.
+was asked, and `summary.excluded_shells` keeps it from reading as an empty host.
+
+🔴 **The predicate is the CLASS axis, not the `claude` flag.** `--claude-only` drops
+`CLASS=shell` (via `dropped_by_claude_only` → `row_class`), so a `cluster` dispatch — an
+agent with no pane, hence `claude: null` — is **kept**. The old `r["claude"]` spelling was
+correct only while every row was a tmux pane; with the `kind` axis it silently reclassified
+every cluster agent as a shell and deleted it.
+
+🔴 **And whatever the filter removed is attributed to the FILTER, not to the build.** The
+filter runs *before* `summarize` and `measured_caveats`, both of which derive from the rows
+that survived — so a kind it removed entirely would have shown up in `kinds_produced` as a
+kind this build never emits, and rendered *"X is ENUMERATED but NOT PRODUCED, so no such row
+appears and its absence is NOT a measured zero"*, which would be false in all three clauses.
+`caveats.kind_scope.kinds_excluded_by_filter` (mirrored at
+`summary.kinds_excluded_by_filter`) names those kinds, and the rendered caveat carries an
+explicit *"a FILTER REMOVED every kind=… row this scan produced"* clause instead. The key is
+**absent when no filter ran** and `[]` when one ran and removed no whole kind — the same
+not-measured-vs-measured-none distinction as `excluded_shells` being `null` rather than `0`.
+
+Reachable today with no cluster row anywhere: `--claude-only` over a host whose tmux rows are
+all bare shells removes the last `tmux` row.

--- a/claude/skills/session-manager/reference/exit-codes.md
+++ b/claude/skills/session-manager/reference/exit-codes.md
@@ -78,3 +78,11 @@ not-measured-vs-measured-none distinction as `excluded_shells` being `null` rath
 
 Reachable today with no cluster row anywhere: `--claude-only` over a host whose tmux rows are
 all bare shells removes the last `tmux` row.
+
+🔴 **`excluded_shells` was `excluded_non_claude` until this change, and THE SCRIPT IS THE
+AUTHORITY ON WHICH NAME IS LIVE — not this file.** These skill docs deploy as a **nix-store
+copy**, so they only change on a `home-manager switch`; `scripts/session-manager` is read from
+the checkout. Between a `git pull` and the switch the two genuinely disagree, and the doc is
+the stale one. Settle it by reading the emitter, never the prose:
+`git grep -n 'excluded_' scripts/session-manager`, or just run a scan and look at the key.
+Same rule for every field named here.

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -2290,9 +2290,14 @@ in
       # NOTHING IS HIDDEN. The script still exits 16, still prints the
       # `ACTIONABLE (not drift)` verdict plus the READY block, and a hand-run
       # (`scripts/drift-check.sh`, or `systemctl --user start drift-check` then
-      # `journalctl --user -u drift-check`) surfaces both. `systemctl show
-      # drift-check -p ExecMainStatus` reads 16 on such a run even though the
-      # unit is `success`. Pinned by
+      # `journalctl --user -u drift-check`) surfaces both. 🔴 READ THE JOURNAL,
+      # NOT THE EXIT STATUS: systemd ZEROES `ExecMainStatus` for a code it has
+      # been told is a success, so `systemctl show drift-check
+      # -p ExecMainStatus` reads **0** on such a run, not 16 — measured on
+      # systemd 258.3, with the no-`SuccessExitStatus` control reading 16. An
+      # earlier revision of this comment asserted the opposite and would have
+      # led an operator to conclude the gate never opened. `journalctl --user
+      # -u drift-check | grep ACTIONABLE` is the check that works. Pinned by
       # `test_the_unit_does_not_fail_on_the_phase2_actionable_code`.
       SuccessExitStatus = 16;
       # Two `git fetch`es plus one ssh round trip. The ConnectTimeout inside the

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -2252,6 +2252,13 @@ in
   # remote leg contributes nothing to the exit code — so a local rc 8 with the
   # laptop shut still exits 8, still fails the unit, and still toasts.
   #
+  # 🔴 THE SECOND THING THAT DOES **NOT** TOAST: rc 16, the fuzzyclaw phase-2
+  # gate. Same hazard, arrived at from the other direction — that code means a
+  # CLEANUP became possible and stays set until somebody does the cleanup, so
+  # failing the unit on it would fire the DND-bypassing toast 4× a day forever
+  # over a run where nothing is wrong. `SuccessExitStatus = 16` on the service
+  # below; the full argument is there.
+  #
   # The service is emitted UNCONDITIONALLY (any host can run it by hand); only the
   # TIMER's timers.target wiring is gated — see enableDriftDeadman above.
   systemd.user.services.drift-check = {
@@ -2263,6 +2270,31 @@ in
     };
     Service = {
       Type = "oneshot";
+      # 🔴 rc 16 IS A SUCCESS TO systemd, AND THIS LINE IS LOAD-BEARING. rc 16 is
+      # the fuzzyclaw phase-2 gate reporting that a CLEANUP became possible —
+      # ACTIONABLE, not drift, nothing broken, nothing to repair. Without this
+      # `Type = "oneshot"` fails the unit on any non-zero code, OnFailure above
+      # fires, and the toast is the ONE class deliberately wired to defeat
+      # do-not-disturb (`zz_notify_failure_bypass`, override_pause_level = 100).
+      #
+      # And it would not fire once: the gate stays open until somebody deletes
+      # the readers, and the timer runs every 6h — so the DND-bypassing alert
+      # would fire 4× a day, forever, on a run where nothing is wrong. The DND
+      # bypass is justified in this file by a MEASURED rate of ~1 firing in 9
+      # days; 4/day is three orders of magnitude past that, and it is exactly
+      # the "permanently-red gate trains you to click through the one alert that
+      # must keep its meaning" hazard the unreachable-remote note below already
+      # refuses. The script's own header refuses it for rc 13 for the same
+      # reason. Correct about a printed LINE, wrong about an EXIT CODE.
+      #
+      # NOTHING IS HIDDEN. The script still exits 16, still prints the
+      # `ACTIONABLE (not drift)` verdict plus the READY block, and a hand-run
+      # (`scripts/drift-check.sh`, or `systemctl --user start drift-check` then
+      # `journalctl --user -u drift-check`) surfaces both. `systemctl show
+      # drift-check -p ExecMainStatus` reads 16 on such a run even though the
+      # unit is `success`. Pinned by
+      # `test_the_unit_does_not_fail_on_the_phase2_actionable_code`.
+      SuccessExitStatus = 16;
       # Two `git fetch`es plus one ssh round trip. The ConnectTimeout inside the
       # script is 10s, so this ceiling only ever fires on a wedged fetch; the
       # cgroup is killed and the timer re-arms on the next OnUnitActiveSec.

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -2271,7 +2271,16 @@ in
         # iproute2 is load-bearing, not incidental: `ip -4 -o addr show` is how
         # local_ipv4s identifies WHICH host this is (both report hostname `nixos`).
         # Without it detection returns "unknown" and the script exits 6.
-        "PATH=${lib.makeBinPath [ pkgs.git pkgs.openssh pkgs.iproute2 pkgs.bash pkgs.coreutils pkgs.gawk pkgs.gnused pkgs.gnugrep ]}"
+        #
+        # 🔴 python3 AND tmux ARE FOR THE CHILD, NOT FOR drift-check.sh ITSELF.
+        # The fuzzyclaw phase-2 gate execs `scripts/session-manager`, whose
+        # shebang resolves `python3` from PATH and which shells out to `tmux
+        # list-panes`. Under systemd there is none of the login shell's PATH, so
+        # without these the gate reports COULD NOT MEASURE on every timer run
+        # forever — from a unit that looks correct, which is the exact shape the
+        # iproute2 note above records. Pinned by
+        # `test_the_phase2_child_binaries_are_on_the_unit_path`.
+        "PATH=${lib.makeBinPath [ pkgs.git pkgs.openssh pkgs.iproute2 pkgs.bash pkgs.coreutils pkgs.gawk pkgs.gnused pkgs.gnugrep pkgs.python3 pkgs.tmux ]}"
         "HOME=%h"
       ];
       ExecStart = "${pkgs.bash}/bin/bash %h/workspace/devrc/scripts/drift-check.sh";
@@ -2280,6 +2289,7 @@ in
       X-Restart-Triggers = [
         "${../scripts/drift-check.sh}"
         "${../scripts/lib/host-role.sh}"
+        "${../scripts/lib/drift_phase2.py}"
       ];
     };
   };

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -101,6 +101,38 @@
 #       installed there. A short, EXPLICITLY ENUMERATED set of settings.json keys
 #       is exempt from the key-set half — see "PER-HOST settings.json KEYS"
 #       below. Nothing else is, and an unknown key is never exempt.
+#   16  ACTIONABLE, not drift — the fuzzyclaw PHASE-2 GATE has OPENED: zero rows
+#       still take their `age_secs` from fuzzyclaw alone, so the readers can be
+#       removed. See "THE FUZZYCLAW PHASE-2 GATE" below. It is the LEAST severe
+#       code this file owns, so it can only ever be the verdict when nothing
+#       else is wrong, and the final line says ACTIONABLE rather than DRIFT.
+#
+# ── THE FUZZYCLAW PHASE-2 GATE (rc 16) ────────────────────────────────────────
+# "Is it safe to delete the fuzzyclaw readers yet?" was answered by somebody
+# remembering to run a probe, which is the same failure mode as "nothing runs
+# ship.sh on a schedule" that this whole file exists to fix. So it is a
+# measurement: `session-manager scan --json` reports `age_source` per row, and
+# `summary.age_sources.fuzzyclaw` counts the rows whose age NO OTHER WRITER
+# supplied. Those are pre-deploy sessions the agent ledger has no record of, and
+# the count decays as they restart. At 0, phase 2 is unblocked.
+#
+# 🔴 LOCAL HOST ONLY, and that is not a shortcut. fuzzyclaw task files are LOCAL
+# state — `gather()` passes its task index only for `host == local_host` — so a
+# remote row structurally CANNOT carry a fuzzyclaw age. Scanning one host gives
+# the identical numerator with no ssh. Measured 2026-08-15: 7 of 47 rows locally,
+# and the same 7 in a two-host scan of 75.
+#
+# 🔴 IT OBEYS THE EXAMINED-BESIDE-DANGLING RULE, one subsystem over. The count is
+# NEVER printed alone: `N of M row(s) EXAMINED` is the claim, and a 0 over M=0 is
+# reported as COULD NOT MEASURE, never as ready. Every way this can fail to
+# measure — no session-manager, a crash, unparseable output, a scan of the wrong
+# host, fuzzyclaw not actually read — is its own reason token from
+# lib/drift_phase2.py and lands in the same COULD-NOT-MEASURE branch. None of
+# them sets rc 16, and none of them is a zero.
+#
+# It is NON-FATAL to the rest of the run by construction: it is the last block
+# before the summary, it only ever raises rc from 0 to 16, and a failure to
+# measure raises nothing at all.
 #
 # ── UNREACHABLE IS NOT DRIFT (the alerting policy) ────────────────────────────
 # 🔴 The timer runs on the WORKBENCH ONLY (gated on the ~/.server-mode marker in
@@ -127,7 +159,7 @@
 # is reading a timer's output, so the single number it hands to systemd must be
 # the worst thing found, or an un-pushed workbench could hide behind a merely
 # behind laptop. Severity order (worst first):
-#     8  >  14  >  13  >  6  >  4  >  3  >  12  >  15  >  10
+#     8  >  14  >  13  >  6  >  4  >  3  >  12  >  15  >  10  >  16
 # (6 is unreachable through this path today — the script exits 6 directly before
 # any per-host leg runs — but the order is documented for every code it owns,
 # and severity() ranks it rather than falling through to the unknown-code slot.)
@@ -159,6 +191,14 @@
 #   DRIFT_UNREACHABLE_ESCALATE  consecutive unreachable runs before rc 13 (default 4)
 #   DRIFT_STATE_DIR  where the unreachable streak is persisted
 #                    (default ${XDG_STATE_HOME:-$HOME/.local/state}/drift-check)
+#   DRIFT_SESSION_MANAGER  path to the session-manager used by the phase-2 gate
+#                    (default: the copy beside this script). Exists so the test
+#                    suite can drive every branch of that gate against a stub —
+#                    the real one scans the operator's live tmux, which no test
+#                    may do. Deliberately NOT forwarded to the remote host: the
+#                    gate is local-only, and every value sent over ssh is one
+#                    that has to be proved safe.
+#   DRIFT_PHASE2_TIMEOUT  seconds the phase-2 scan may take (default 60, integer)
 set -uo pipefail
 
 # --- Host identity: SOURCED, never copied (see header) ------------------------
@@ -167,7 +207,9 @@ set -uo pipefail
 _drift_self="${BASH_SOURCE[0]}"
 _drift_resolved="$(readlink -f "$_drift_self" 2>/dev/null || true)"
 [ -n "$_drift_resolved" ] && _drift_self="$_drift_resolved"
-_drift_lib="$(cd "$(dirname "$_drift_self")" 2>/dev/null && pwd)/lib/host-role.sh"
+_drift_dir="$(cd "$(dirname "$_drift_self")" 2>/dev/null && pwd)"
+_drift_lib="$_drift_dir/lib/host-role.sh"
+_drift_phase2_py="$_drift_dir/lib/drift_phase2.py"
 if [ ! -r "$_drift_lib" ]; then
   echo "drift-check: cannot read $_drift_lib — host identity cannot be resolved." >&2
   exit 6
@@ -185,6 +227,8 @@ DRIFT_UNTRACKED_MAX="${DRIFT_UNTRACKED_MAX:-10}"
 DRIFT_DANGLING_MAX="${DRIFT_DANGLING_MAX:-10}"
 DRIFT_UNREACHABLE_ESCALATE="${DRIFT_UNREACHABLE_ESCALATE:-4}"
 DRIFT_STATE_DIR="${DRIFT_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/drift-check}"
+DRIFT_SESSION_MANAGER="${DRIFT_SESSION_MANAGER:-$_drift_dir/session-manager}"
+DRIFT_PHASE2_TIMEOUT="${DRIFT_PHASE2_TIMEOUT:-60}"
 
 # 🔴 Both tunables are INTERPOLATED INTO A SCRIPT THAT RUNS ON THE OTHER HOST
 # (piped to `bash -s` over ssh), so a non-integer value is remote code execution
@@ -200,6 +244,10 @@ require_int() { # require_int <name> <value>
 require_int DRIFT_UNTRACKED_MAX "$DRIFT_UNTRACKED_MAX"
 require_int DRIFT_DANGLING_MAX "$DRIFT_DANGLING_MAX"
 require_int DRIFT_UNREACHABLE_ESCALATE "$DRIFT_UNREACHABLE_ESCALATE"
+# Not interpolated into a remote payload — but it IS handed to `timeout`, where a
+# non-integer would make the phase-2 scan fail in a way that reads as "the tool
+# is broken" rather than "you passed nonsense".
+require_int DRIFT_PHASE2_TIMEOUT "$DRIFT_PHASE2_TIMEOUT"
 
 DO_LOCAL=1
 DO_REMOTE=1
@@ -263,6 +311,12 @@ severity() {
     # header for why un-pushed commits still outrank a broken deployment.
     15) echo 35 ;;
     10) echo 30 ;;
+    # 16 is the FLOOR of the owned codes, deliberately. It is not a fault at all
+    # — it says an optional cleanup became possible — so it must never outrank a
+    # host that is behind, let alone one with un-pushed commits. Being last also
+    # means it can only ever BE the verdict on an otherwise-clean run, which is
+    # the only run on which "go do this now" is useful advice.
+    16) echo 20 ;;
     *)  echo 99 ;;
   esac
 }
@@ -955,6 +1009,79 @@ else
 fi
 echo
 
+# ── FUZZYCLAW PHASE-2 GATE ────────────────────────────────────────────────────
+# See "THE FUZZYCLAW PHASE-2 GATE" in the header for what this measures and why
+# it is local-only. Here: how it refuses to produce a silent zero.
+#
+# 🔴 EVERY NON-MEASUREMENT IS A REASON, NEVER A COUNT. The gate reads ONE line
+# from lib/drift_phase2.py whose first field is `ok` or a reason token, and it
+# branches on THAT — not on the numbers beside it. Without the token every
+# failure here (no session-manager on this checkout, a crashed scan, a scan of
+# the wrong host, fuzzyclaw not actually read) arrives as `0`, and `0` is the
+# value that means "phase 2 is ready". A checker whose broken state and whose
+# all-clear are the same output is the vacuous green this whole file exists to
+# refuse, and it would be handing over a DELETION.
+#
+# 🔴 AND A REAL ZERO IS ONLY REAL OVER A NON-ZERO DENOMINATOR — the same rule
+# the managed-symlink scan applies with `examined=` beside `dangling=`. `0 of 0`
+# is a scan that walked nothing; it prints as COULD NOT MEASURE and sets no rc.
+echo "=== fuzzyclaw phase-2 readiness ($LOCAL_ROLE) ==="
+if [ "$DO_LOCAL" = 0 ]; then
+  # The remote leg cannot answer this: fuzzyclaw is local state, so a scan of
+  # the other host reports 0 for a reason that has nothing to do with readiness.
+  echo "[phase2] NOT EVALUATED — --no-local, and this gate is LOCAL-ONLY (fuzzyclaw"
+  echo "[phase2]   task files are local state). Not a zero, and not a pass."
+elif [ ! -x "$DRIFT_SESSION_MANAGER" ]; then
+  echo "[phase2] COULD NOT MEASURE — no executable session-manager at $DRIFT_SESSION_MANAGER."
+  echo "[phase2]   This is NOT a zero and NOT 'phase 2 is ready'."
+elif [ ! -r "$_drift_phase2_py" ]; then
+  echo "[phase2] COULD NOT MEASURE — cannot read $_drift_phase2_py."
+  echo "[phase2]   This is NOT a zero and NOT 'phase 2 is ready'."
+else
+  # `--no-capture` and `--no-ch`: this needs `age_source` only, and the pane
+  # capture is the expensive part of a scan. `--fuzzyclaw` is REQUIRED — the
+  # index is opt-in, and without it every age falls to the ledger and the count
+  # is a guaranteed zero. drift_phase2.py re-checks that it was actually read.
+  p2_out="$(timeout "$DRIFT_PHASE2_TIMEOUT" "$DRIFT_SESSION_MANAGER" scan --json --no-ch --no-capture --fuzzyclaw --host "$LOCAL_ROLE" 2>/dev/null | python3 "$_drift_phase2_py" "$LOCAL_ROLE" 2>/dev/null)"
+  p2_token="${p2_out%% *}"
+  p2_rest="${p2_out#* }"
+  p2_rows="${p2_rest%% *}"
+  p2_fz="${p2_rest##* }"
+  # A reader that printed nothing, or something that is not `<token> <int> <int>`,
+  # is itself a could-not-measure — not a zero. Checked before any comparison,
+  # because `[ "" -gt 0 ]` is an error, not a false.
+  case "$p2_rows" in ''|*[!0-9-]*) p2_rows=-1 ;; esac
+  case "$p2_fz" in ''|*[!0-9-]*) p2_fz=-1 ;; esac
+  if [ -z "$p2_out" ] || [ "$p2_rows" = -1 ] || [ "$p2_fz" = -1 ]; then
+    echo "[phase2] COULD NOT MEASURE — the scan produced no usable counts (reason: ${p2_token:-no-output})."
+    echo "[phase2]   This is NOT a zero and NOT 'phase 2 is ready'."
+  elif [ "$p2_token" != ok ]; then
+    # The counts EXIST but the reader says they cannot be trusted (fuzzyclaw was
+    # not actually read, or the scan hit the wrong host). Printed anyway, beside
+    # the reason, so the finding is legible without being acted on.
+    echo "[phase2] COULD NOT MEASURE — reason: $p2_token (raw: $p2_fz of $p2_rows row(s))."
+    echo "[phase2]   This is NOT a zero and NOT 'phase 2 is ready'."
+  else
+    echo "[phase2] fuzzyclaw-only ages: $p2_fz of $p2_rows row(s) EXAMINED"
+    if [ "$p2_rows" = 0 ]; then
+      echo "[phase2] COULD NOT MEASURE — 0 rows examined. A zero over zero rows is a scan"
+      echo "[phase2]   that walked nothing, not a measurement. NOT 'phase 2 is ready'."
+    elif [ "$p2_fz" -gt 0 ]; then
+      echo "[phase2] NOT READY — $p2_fz of $p2_rows row(s) still take their age ONLY from"
+      echo "[phase2]   fuzzyclaw. Removing the readers now would blank those ages. The count"
+      echo "[phase2]   decays as those pre-deploy sessions restart; nothing to do but wait."
+    else
+      echo "[phase2] 🔴 READY — 0 of $p2_rows rows depend on fuzzyclaw for an age."
+      echo "[phase2]   Phase 2 is UNBLOCKED: remove the fuzzyclaw readers from"
+      echo "[phase2]   session-manager, tmux-claude-counters.sh, verify-agent-work and"
+      echo "[phase2]   validation/reconcile.py + refsources.py. This stays reported until"
+      echo "[phase2]   they are gone — that is the gate working, not the gate stuck."
+      note_rc 16
+    fi
+  fi
+fi
+echo
+
 # 🔴 The summary states WHAT WAS CHECKED. It previously said "both hosts on
 # branch main at origin/main" regardless — including for a --no-remote run that
 # looked at one host, and for a --no-local --no-remote run that looked at none.
@@ -990,7 +1117,13 @@ if [ "$rc" = 0 ]; then
     exit 2
   fi
 else
-  echo "drift-check: DRIFT (rc=$rc) — see per-host lines above."
+  # 🔴 THE VERDICT WORD IS ITSELF A CLAIM. rc 16 is not drift — nothing is out of
+  # sync and no host needs repairing; a cleanup became possible. Printing "DRIFT"
+  # for it would send the operator hunting a divergence that does not exist, and
+  # would blunt the word for the codes that DO mean it.
+  verdict="DRIFT"
+  [ "$rc" = 16 ] && verdict="ACTIONABLE (not drift)"
+  echo "drift-check: $verdict (rc=$rc) — see per-host lines above."
   echo "  checked: ${CHECKED:-none}"
   echo "  rc3=no-repo  rc4=fetch/origin-main-unavailable  rc6=host-unidentified"
   echo "  rc8=DIVERGED/AHEAD:un-pushed-commits(ship.sh will skip this host forever)"
@@ -998,6 +1131,7 @@ else
   echo "  rc13=remote unreachable for >=$DRIFT_UNREACHABLE_ESCALATE consecutive runs"
   echo "  rc14=managed symlinks resolve to nothing (needs a home-manager switch on that host)"
   echo "  rc15=host parity: settings.json key sets / enabledPlugins differ, or enabled-but-not-installed"
+  echo "  rc16=NOT drift: the fuzzyclaw phase-2 gate OPENED (0 rows depend on fuzzyclaw for an age)"
 fi
 [ -n "$UNCHECKED" ] && echo "drift-check: NOT checked: $UNCHECKED"
 exit "$rc"

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -126,13 +126,28 @@
 # NEVER printed alone: `N of M row(s) EXAMINED` is the claim, and a 0 over M=0 is
 # reported as COULD NOT MEASURE, never as ready. Every way this can fail to
 # measure — no session-manager, a crash, unparseable output, a scan of the wrong
-# host, fuzzyclaw not actually read — is its own reason token from
+# host, fuzzyclaw not actually read, the age histogram ABSENT or in a writer
+# vocabulary this gate does not recognise — is its own reason token from
 # lib/drift_phase2.py and lands in the same COULD-NOT-MEASURE branch. None of
 # them sets rc 16, and none of them is a zero.
 #
+# 🔴 THAT LAST SENTENCE WAS FALSE ON ARRIVAL, which is why the ledger below
+# exists. `summary.age_sources` shipped with no presence or type check, so a
+# report without it — including one from a session-manager older than the field,
+# i.e. exactly the stale host this deadman is FOR — printed `READY — 0 of 47`
+# byte-identical to a real one. The claim is now MACHINE-CHECKED rather than
+# restated: `test_drift_check.py::test_the_phase2_reason_token_ledger_is_pinned_
+# to_the_fields_read` ast-extracts the emitted token set AND the set of report
+# fields the reader consults, and fails when either grows or shrinks — so a
+# newly-read field with no reason token of its own is a red test.
+#
 # It is NON-FATAL to the rest of the run by construction: it is the last block
 # before the summary, it only ever raises rc from 0 to 16, and a failure to
-# measure raises nothing at all.
+# measure raises nothing at all. 🔴 rc 16 is a SUCCESS to systemd
+# (`SuccessExitStatus = 16` on the unit in nix/home.nix): it stays set until
+# somebody does the cleanup, so failing the unit on it would fire the
+# DND-defeating failure toast 4× a day forever — the same permanently-red-gate
+# refusal this file already makes for an unreachable remote, below.
 #
 # ── UNREACHABLE IS NOT DRIFT (the alerting policy) ────────────────────────────
 # 🔴 The timer runs on the WORKBENCH ONLY (gated on the ~/.server-mode marker in
@@ -1050,6 +1065,17 @@ else
   # A reader that printed nothing, or something that is not `<token> <int> <int>`,
   # is itself a could-not-measure — not a zero. Checked before any comparison,
   # because `[ "" -gt 0 ]` is an error, not a false.
+  #
+  # 🔴 THE FIELD **COUNT** IS PART OF THAT, AND CHECKING ONLY THE FIELDS' SHAPE
+  # WAS NOT ENOUGH. These expansions read positionally, and `${x%% *}` / `${x##
+  # * }` both fall back to the WHOLE STRING when there is no space — so a
+  # two-field line `ok 47` set BOTH counts from the same field and rendered
+  # `47 of 47 row(s) EXAMINED`, a well-formed-looking measurement that is one
+  # number read twice. It is fail-safe by luck (it reads as NOT READY, never
+  # READY) and it is still a fabricated denominator. `p2_rest` must therefore
+  # contain a space (>=3 fields) and must not contain a second one (<=3).
+  case "$p2_rest" in *' '*) ;; *) p2_rows=-1 ;; esac
+  case "${p2_rest#* }" in *' '*) p2_rows=-1 ;; esac
   case "$p2_rows" in ''|*[!0-9-]*) p2_rows=-1 ;; esac
   case "$p2_fz" in ''|*[!0-9-]*) p2_fz=-1 ;; esac
   if [ -z "$p2_out" ] || [ "$p2_rows" = -1 ] || [ "$p2_fz" = -1 ]; then
@@ -1085,7 +1111,15 @@ echo
 # 🔴 The summary states WHAT WAS CHECKED. It previously said "both hosts on
 # branch main at origin/main" regardless — including for a --no-remote run that
 # looked at one host, and for a --no-local --no-remote run that looked at none.
-if [ "$rc" = 0 ]; then
+#
+# 🔴 rc 16 TAKES **BOTH** BRANCHES, and that is not a convenience. It is the one
+# owned code that is NOT a statement about host health — nothing is out of sync
+# — so suppressing the affirmative line for it withheld the very finding the run
+# DID make ("no drift on the host(s) CHECKED") and printed only the cleanup
+# notice. An operator then cannot tell an rc 16 over a clean host from an rc 16
+# over a host nobody vouched for. Both claims are true and independent, so both
+# are printed. Pinned by `test_the_phase2_ready_run_still_prints_the_no_drift_line`.
+if [ "$rc" = 0 ] || [ "$rc" = 16 ]; then
   if [ -n "$CHECKED" ]; then
     # 🔴 No phrasing here may name a host this run did not contact — the wording
     # it replaced said "both hosts" unconditionally, and read as coverage the run
@@ -1103,10 +1137,18 @@ if [ "$rc" = 0 ]; then
     # `--no-local --no-remote` refusal above is already rc 2 for, so it gets the
     # same code: a run that observed no host is a usage outcome, not a verdict.
     #
-    # 🔴 GUARDED ON rc = 0, deliberately. This can only ever turn a ZERO into a
-    # 2 — it can never rewrite a real verdict, so an rc 8 stays 8 and still
-    # reaches OnFailure. (`test_local_rc8_still_wins_when_the_remote_is_
-    # unreachable` and `test_checked_nothing_does_not_rewrite_a_real_verdict`.)
+    # 🔴 GUARDED ON rc IN {0, 16}, deliberately. This can only ever turn a
+    # "nothing is wrong" code into a 2 — it can never rewrite a DRIFT verdict,
+    # so an rc 8 stays 8 and still reaches OnFailure.
+    # (`test_local_rc8_still_wins_when_the_remote_is_unreachable` and
+    # `test_checked_nothing_does_not_rewrite_a_real_verdict`.)
+    #
+    # rc 16 reaching here is unreachable rather than handled: 16 is the LEAST
+    # severe owned code, so it survives `note_rc` only when the local leg was
+    # clean, and a clean local leg is what puts the host in $CHECKED. If that
+    # ever changes, 2 ("observed no host") is the right answer over 16 ("a
+    # cleanup is safe") — the reason this branch exists is that a run which
+    # vouched for nothing must not hand systemd a code that reads as fine.
     #
     # NOT reachable from the timer, whose ExecStart passes no flags — with both
     # legs on, an unreachable remote still leaves the local host CHECKED. This
@@ -1116,7 +1158,8 @@ if [ "$rc" = 0 ]; then
     [ -n "$UNCHECKED" ] && echo "drift-check: NOT checked: $UNCHECKED"
     exit 2
   fi
-else
+fi
+if [ "$rc" != 0 ]; then
   # 🔴 THE VERDICT WORD IS ITSELF A CLAIM. rc 16 is not drift — nothing is out of
   # sync and no host needs repairing; a cleanup became possible. Printing "DRIFT"
   # for it would send the operator hunting a divergence that does not exist, and

--- a/scripts/lib/drift_phase2.py
+++ b/scripts/lib/drift_phase2.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Reduce a `session-manager scan --json` report to the ONE fact drift-check
+needs: how many rows still take their `age_secs` from fuzzyclaw ALONE.
+
+WHY THIS IS THE FACT
+--------------------
+The fuzzyclaw readers are being removed in phases (`session-manager`,
+`tmux-claude-counters.sh`, `verify-agent-work`,
+`validation/{reconcile,refsources}.py` are what remain). Phase 2 — deleting the
+readers — is safe exactly when no row depends on fuzzyclaw for a fact the agent
+ledger cannot supply. `age_source` names the writer that actually answered, so
+`summary.age_sources["fuzzyclaw"]` IS that count: those rows are pre-deploy
+sessions the ledger has no record of, and the number decays as they restart.
+
+Measured on the workbench 2026-08-15: 7 fuzzyclaw-sourced of 47 rows examined
+(local host only). The same 7 appears in a two-host scan of 75 rows, because
+fuzzyclaw task files are LOCAL state — `gather()` passes `task_index` only for
+`host == local_host`, so a remote row structurally cannot carry a fuzzyclaw
+age. That is why drift-check scans the local host alone: same numerator, no ssh.
+
+WHY A SEPARATE FILE AND NOT A `python3 -c` STRING IN drift-check.sh
+------------------------------------------------------------------
+🔴 `scripts/tests/test_drift_check.py` walks every line of drift-check.sh with a
+shell tokenizer and demands that each word in COMMAND POSITION be accounted for
+in `UNIT_PATH_REQUIREMENTS`. Python source pasted into that file sprays dozens of
+false command words at it (`_walk` splits on `(` and `{`, so `summ = rep.get(
+"summary") or {}` presents `summ` as a command). Widening the prose ledger to
+absorb them would blunt the guard that found `dirname` and `bash`. Kept out of
+the bash file, drift-check.sh gains exactly one new command word: `python3`.
+
+READ-ONLY BY CONSTRUCTION: stdin in, one line out. It opens no file, imports
+nothing but `json`/`sys`, and cannot reach the network. Pinned by
+`test_the_phase2_reader_is_read_only`.
+
+OUTPUT CONTRACT — one line, three space-separated fields:
+
+    <token> <rows_examined> <fuzzyclaw_only>
+
+`<token>` is `ok` when the two counts are a real measurement, and otherwise a
+reason token explaining why they are not. The counts are `-1` when unknown.
+🔴 The caller must branch on the TOKEN, never on the counts alone: every failure
+mode here would otherwise present as `0 0`, which is indistinguishable from a
+clean host and would read as "phase 2 is ready".
+"""
+import json
+import sys
+
+
+def emit(token, rows=-1, fuzzy=-1):
+    print(token, rows, fuzzy)
+    raise SystemExit(0)
+
+
+def main(argv):
+    want = argv[1] if len(argv) > 1 else ""
+    try:
+        rep = json.load(sys.stdin)
+    except Exception as exc:  # noqa: BLE001 — any parse/IO failure is one fact
+        emit("no-json:%s" % type(exc).__name__)
+    if not isinstance(rep, dict):
+        emit("no-json:not-an-object")
+
+    summ = rep.get("summary") or {}
+    rows = summ.get("total_sessions")
+    fuzzy = (summ.get("age_sources") or {}).get("fuzzyclaw", 0)
+    # `bool` is an `int` in Python; a True here would print as a count.
+    if not isinstance(rows, int) or isinstance(rows, bool):
+        emit("no-counts")
+    if not isinstance(fuzzy, int) or isinstance(fuzzy, bool):
+        emit("no-counts")
+
+    # 🔴 THE HOST GUARD, and it is not paranoia. `session-manager` decides which
+    # host is LOCAL from `ACTIVITY_HOST` / the collector env file, while
+    # drift-check decides from `lib/host-role.sh` and the machine IPs. Two
+    # predicates, two sources. If they disagree, `--host <role>` names the
+    # REMOTE machine and the scan ssh's there — and a remote row can never carry
+    # a fuzzyclaw age, so the count comes back 0 and the gate declares phase 2
+    # READY off a scan of the wrong machine. Surfaced as a reason token instead.
+    #
+    # Checked AFTER the counts are extracted, deliberately: the numbers exist
+    # and are real — they are just about the wrong machine — so they ride back
+    # with the reason and the caller can print the finding in full.
+    got = rep.get("local_host")
+    if want and got != want:
+        emit("host-mismatch:%s" % (got,), rows, fuzzy)
+
+    # 🔴 THE POSITIVE-CONTROL GUARD, IN TWO PARTS, because `status == "ok"` is
+    # NOT sufficient and I proved it by accident. fuzzyclaw is OPT-IN
+    # (`--fuzzyclaw`), so with the flag off no row can have a fuzzyclaw age —
+    # a guaranteed 0 from a reader wired to nothing, which is exactly the "phase
+    # 2 is ready" answer. That is the `status` half.
+    #
+    # The second half: a scan whose `$HOME` has no `~/.tmux/tasks` at all
+    # reports `status: "ok"` with `files_seen: 0` — an empty directory is a
+    # legitimate successful read. MEASURED: the drift-check suite runs with a
+    # fixture HOME, and the first version of this gate declared "READY — 0 of 48
+    # rows" off it, on a machine where the true count was 7. Zero task files
+    # means fuzzyclaw supplied nothing to ANY row, so the zero is structural
+    # rather than a measurement of readiness.
+    #
+    # Both counts are reported ALONGSIDE the reason, so the finding stays
+    # legible without being acted on.
+    fz = rep.get("fuzzyclaw") or {}
+    status = fz.get("status")
+    if status != "ok":
+        emit("fuzzyclaw-%s" % (status,), rows, fuzzy)
+    seen = fz.get("files_seen")
+    if not isinstance(seen, int) or isinstance(seen, bool) or seen <= 0:
+        emit("fuzzyclaw-no-task-files", rows, fuzzy)
+
+    emit("ok", rows, fuzzy)
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/scripts/lib/drift_phase2.py
+++ b/scripts/lib/drift_phase2.py
@@ -38,12 +38,46 @@ OUTPUT CONTRACT — one line, three space-separated fields:
 
 `<token>` is `ok` when the two counts are a real measurement, and otherwise a
 reason token explaining why they are not. The counts are `-1` when unknown.
-🔴 The caller must branch on the TOKEN, never on the counts alone: every failure
-mode here would otherwise present as `0 0`, which is indistinguishable from a
-clean host and would read as "phase 2 is ready".
+🔴 The caller must branch on the TOKEN, never on the counts alone: a failure
+mode without a token of its own presents as a plausible count — `0`, or `N 0` —
+which is indistinguishable from a clean host and reads as "phase 2 is ready".
+
+🔴 THE TOKEN SET IS A PINNED LEDGER, NOT A CONVENTION, and it is pinned against
+the FIELDS THIS MODULE READS. `test_drift_check.py::test_the_phase2_reason_token
+_ledger_is_pinned_to_the_fields_read` extracts both sets from this source with
+`ast` and fails when either GROWS or SHRINKS, so consulting a new field without
+giving its absence a token is a red test rather than a silent zero. That guard
+exists because the prose version of it was WRONG for three days: `age_sources`
+had no check at all, so a report missing it — or one from a session-manager
+predating it (it landed 2026-08-13) — printed `ok 47 0`, byte-identical to a
+legitimate READY, on the exact staleness this deadman exists to detect.
 """
 import json
 import sys
+
+# 🔴 THE WRITER VOCABULARY, and it is what makes an ABSENT `fuzzyclaw` key a
+# real zero rather than an unmeasured one. `summary.age_sources` is
+# `_count_by(r.get("age_source") or "none" for r in rows)` — a histogram that
+# creates a key only for a value it OBSERVED — so zero fuzzyclaw-sourced rows
+# means NO `fuzzyclaw` key, not `fuzzyclaw: 0`. Reading that absence as 0 is
+# therefore correct, but only while the vocabulary is intact: rename the
+# `age_source` VALUE and the absence means "renamed", not "none", and the gate
+# would authorise a deletion off it. So an unrecognised writer is its own
+# reason token. Fail-closed is the right direction here — a new legitimate
+# writer (phase 3's ledger scope change) makes this say COULD NOT MEASURE until
+# somebody adds it, which is a morning's edit versus a wrong deletion.
+# Measured on the workbench 2026-08-16: `{fuzzyclaw: 7, ledger: 29, none: 13}`.
+AGE_WRITERS = ("fuzzyclaw", "ledger", "none")
+
+
+def _tok(value):
+    """A reason token is the FIRST SPACE-SEPARATED FIELD of the output line, so
+    anything interpolated into one must not contain a space — `${p2_out%% *}`
+    in drift-check.sh would otherwise silently truncate the reason and shift
+    both counts one field left. JSON keys and host names are free text; this
+    makes them safe to quote back."""
+    text = str(value)[:40]
+    return "".join(c if (c.isalnum() or c in "-_.") else "_" for c in text) or "empty"
 
 
 def emit(token, rows=-1, fuzzy=-1):
@@ -62,12 +96,42 @@ def main(argv):
 
     summ = rep.get("summary") or {}
     rows = summ.get("total_sessions")
-    fuzzy = (summ.get("age_sources") or {}).get("fuzzyclaw", 0)
     # `bool` is an `int` in Python; a True here would print as a count.
     if not isinstance(rows, int) or isinstance(rows, bool):
         emit("no-counts")
-    if not isinstance(fuzzy, int) or isinstance(fuzzy, bool):
-        emit("no-counts")
+
+    # 🔴 THE THIRD STRUCTURAL ZERO, AND IT SHIPPED. `age_sources` used to be read
+    # as `(summ.get("age_sources") or {}).get("fuzzyclaw", 0)` — no presence
+    # check, no type check — so ALL of: the key absent, the key renamed, the key
+    # holding a non-dict, and a report from a session-manager that predates the
+    # field entirely (it landed 2026-08-13) collapsed to `0`, and `0` is the
+    # value that authorises the deletion this gate gates. Measured: with a stub
+    # emitting only `{"summary": {"total_sessions": 47}}` the run printed
+    # `🔴 READY — 0 of 47 rows depend on fuzzyclaw`, byte-identical to a real one.
+    #
+    # 🔴 AND IT WAS REACHABLE, on the one host shape this deadman is FOR.
+    # `DRIFT_SESSION_MANAGER` defaults to the checkout's own `scripts/session-
+    # manager`, so a host more than three days behind ran a scan with no
+    # `age_sources` at all — the staleness detector disabled by staleness.
+    srcs = summ.get("age_sources")
+    if not isinstance(srcs, dict):
+        emit("no-age-sources", rows)
+    unknown = sorted(k for k in srcs if k not in AGE_WRITERS)
+    if unknown:
+        emit("unknown-age-writer:%s" % _tok(unknown[0]), rows)
+    if not all(isinstance(v, int) and not isinstance(v, bool)
+               for v in srcs.values()):
+        emit("no-counts", rows)
+    # 🔴 THE COHERENCE CHECK, between two fields derived from the SAME `rows`
+    # list one line apart in `summarize()` (`total_sessions = len(rows)`,
+    # `age_sources = _count_by(... for r in rows)`), so their disagreement is
+    # never legitimate. It is what turns "the `fuzzyclaw` key is absent" from an
+    # assumption into a measurement: over a histogram proven COMPLETE and in a
+    # known vocabulary, an absent key can only mean zero rows had that writer.
+    total = sum(srcs.values())
+    if total != rows:
+        emit("age-sources-incoherent:%d" % total, rows)
+    fuzzy = srcs.get("fuzzyclaw", 0)
 
     # 🔴 THE HOST GUARD, and it is not paranoia. `session-manager` decides which
     # host is LOCAL from `ACTIVITY_HOST` / the collector env file, while
@@ -82,7 +146,7 @@ def main(argv):
     # with the reason and the caller can print the finding in full.
     got = rep.get("local_host")
     if want and got != want:
-        emit("host-mismatch:%s" % (got,), rows, fuzzy)
+        emit("host-mismatch:%s" % _tok(got), rows, fuzzy)
 
     # 🔴 THE POSITIVE-CONTROL GUARD, IN TWO PARTS, because `status == "ok"` is
     # NOT sufficient and I proved it by accident. fuzzyclaw is OPT-IN
@@ -103,7 +167,7 @@ def main(argv):
     fz = rep.get("fuzzyclaw") or {}
     status = fz.get("status")
     if status != "ok":
-        emit("fuzzyclaw-%s" % (status,), rows, fuzzy)
+        emit("fuzzyclaw-%s" % _tok(status), rows, fuzzy)
     seen = fz.get("files_seen")
     if not isinstance(seen, int) or isinstance(seen, bool) or seen <= 0:
         emit("fuzzyclaw-no-task-files", rows, fuzzy)

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -3209,9 +3209,29 @@ def _fmt_kind_scope(kd) -> str:
     this sentence attributes to the BUILD what a filter did: `--claude-only`
     runs before the derivation, so a scan that produced cluster rows and then
     dropped them rendered "cluster is ENUMERATED but NOT PRODUCED" — false in
-    all three of its clauses. Same treatment as `kinds_produced`: a MISSING key
-    means no filter ran, an EMPTY list means one ran and removed no whole kind,
-    and the two must not collapse.
+    all three of its clauses.
+
+    🔴 AND IT IS **NOT** TREATED LIKE `kinds_produced`. That distinction is
+    load-bearing and this docstring used to get it backwards, claiming a MISSING
+    key and an EMPTY list "must not collapse" three lines above an `or []` that
+    collapses them. What differs is what the two keys are ASKED:
+
+      - `kinds_produced` is asked WHICH KINDS THE SCAN SAW, and missing vs empty
+        are different answers — "no scan happened, describe the build" vs "a
+        scan measured zero rows". Different sentences, so an `or` there is the
+        literal-masquerading-as-a-measurement bug above.
+      - `kinds_excluded_by_filter` is asked ONLY WHICH WHOLE KINDS A FILTER
+        TOOK, and every clause below is guarded on `if filtered:`. Missing ("no
+        filter ran") and `[]` ("one ran and took no whole kind") agree exactly
+        on that: no kind's absence is the filter's doing, so there is nothing
+        for the filter clause to say and the head/tails are identical. Rendering
+        them differently would mean inventing a sentence about a filter that
+        removed nothing.
+
+    The distinction survives where it is actually needed — `summary` publishes
+    `None` vs `[]` verbatim, and `test_session_manager.py` pins all three states
+    as distinguishable in every JSON surface. It is collapsed HERE, in prose
+    that only ever asks the yes/no question, deliberately.
     """
     produced = kd.get("kinds_produced")
     filtered = list(kd.get("kinds_excluded_by_filter") or [])

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -128,9 +128,14 @@ the deliberate removal of the flat `summary["idle"]` integer.
 not the same word: `kind` is `tmux`/`cluster` (WHAT the entity is), `CLASS` is
 `claude`/`shell`/`cluster` (how it is COUNTED).
 
-`--claude-only` drops the shells outright; the summary then describes the
-FILTERED set and carries `excluded_non_claude` so an empty table cannot read as
-an empty host.
+`--claude-only` drops the shells outright — the SHELL CLASS, decided by
+`row_class` through `dropped_by_claude_only`, so a `cluster` row (an agent with
+no pane, hence `claude: null`) is KEPT rather than silently reclassified as a
+shell and deleted. The summary then describes the FILTERED set and carries
+`excluded_shells` so an empty table cannot read as an empty host, plus
+`kinds_excluded_by_filter` naming any kind the flag removed ENTIRELY — without
+which `kinds_produced` would attribute to this build an absence the filter
+caused.
 
 HONEST LIMITS (stated, not implied away — AND CARRIED IN THE OUTPUT as
 `report["caveats"]` plus two footer lines; see CAVEATS)
@@ -563,6 +568,53 @@ def row_class(row) -> str:
         return kind
     return "unknown_kind"
 
+
+def row_kind(row) -> str:
+    """A row's `kind` AS COUNTED — THE ONE definition of the `None` coercion.
+
+    `"none"` rather than `None`, because a null JSON key serialises to the
+    string `"null"` and reads as a kind called null. A `kind` of `"none"`
+    appearing at all is a bug (see `KINDS`), which is exactly why it is counted
+    rather than coerced away.
+
+    🔴 IT IS A FUNCTION BECAUSE `r.get("kind") or "none"` WAS OPEN-CODED AT
+    THREE SITES — `summarize`'s histogram, `measured_caveats`' derivation, and
+    (once the filter learned to record what it removed) `gather`. Three copies
+    of one coercion is three chances to disagree about what a kind-less row is
+    called, and the disagreement would surface as a summary histogram and a
+    caveat naming different sets. One rule, one place.
+    """
+    return row.get("kind") or "none"
+
+
+def dropped_by_claude_only(row) -> bool:
+    """Whether `--claude-only` drops `row`. THE ONE definition of that flag.
+
+    🔴 IT IS `row_class(row) == "shell"`, NOT `not row.get("claude")`.
+
+    The flag's documented intent has always been "drop the shells". While every
+    row was a tmux pane, `r.get("claude")` was a correct SPELLING of that — and
+    it stopped being one the moment `kind` arrived. `row["claude"]` is
+    `pane_current_command =~ /claude/`, a fact about a PANE, so a `cluster` row
+    (a dispatch with NO pane) carries `claude: None`, which is FALSY. The old
+    predicate therefore reclassified every cluster agent as a shell and dropped
+    it — silently filing an agent under "nobody is working here" and then
+    deleting it, which is the identical defect `row_class` exists to prevent,
+    one operation further along.
+
+    So the flag is defined against the CLASS axis, through the same classifier
+    the roll-ups use. Three consequences, each deliberate:
+
+      * a `claude` tmux row is KEPT (unchanged);
+      * a `shell` tmux row is DROPPED (unchanged) — including one whose title
+        happens to contain the word "claude";
+      * a `cluster` row is KEPT, because it is an agent. So is an
+        `unknown_kind` row: a row whose kind nobody set is a BUG, and filtering
+        it out would delete the evidence rather than surface it.
+    """
+    return row_class(row) == "shell"
+
+
 # 🔴 THE TWO LIMITS THAT CHANGE WHAT THE OUTPUT MEANS, CARRIED IN THE OUTPUT.
 # Both were documented in the skill body only. An agent that runs this script
 # cold never reads the skill, and the failure mode of each is silent: a `claude`
@@ -624,10 +676,19 @@ CAVEATS = {
         # adjacent-fields-disagree failure `fuzzyclaw_scope` shipped in #471.
         # What is durable is the RELATIONSHIP: which kinds exist, that an
         # absence is not a measurement, and where clawgate actually lives.
+        # 🔴 THE NOTE NAMES `kinds_excluded_by_filter` BECAUSE `kinds_produced`
+        # ALONE IS AMBIGUOUS. Both are measured from the SURVIVING rows, so a
+        # kind a filter removed and a kind this build never emits look
+        # identical in `kinds_produced` — and the reader's whole question is
+        # which of those two happened. The relationship is durable, so it
+        # belongs here rather than in a per-scan string.
         "note": ("`kinds_produced` is MEASURED from this scan's rows — read it "
                  "rather than assuming. A kind that is enumerated but absent "
                  "from `kinds_produced` was NOT LOOKED FOR by this build, so "
-                 "its absence is NOT a measured absence of that work. For "
+                 "its absence is NOT a measured absence of that work — UNLESS "
+                 "it is named in `kinds_excluded_by_filter`, which is where a "
+                 "kind removed by a filter is reported instead of being "
+                 "silently attributed to the build. For "
                  "clawgate use report.blocked_on_me (tasks needing the "
                  "operator, and its `stuck_count` for wedged dispatches), a "
                  "different population from these rows that is never "
@@ -1750,19 +1811,33 @@ def summarize(report) -> dict:
         # 🔴 THE ENTITY AXIS, published as its own histogram and DERIVED from
         # the rows — never hardcoded — so a kind cannot exist on a row and be
         # missing from the summary. Same idiom, and same reason, as
-        # `age_sources`: `"none"` rather than `None`, because a null JSON key
-        # serialises to the string `"null"` and reads as a kind called null.
-        # A `kind` of `"none"` appearing at all is a bug (see `KINDS`), which
-        # is precisely why it is counted rather than coerced away.
-        "kind": _count_by(r.get("kind") or "none" for r in rows),
+        # `age_sources`: the `None` coercion is `row_kind`, ONE definition
+        # shared with `measured_caveats` and the `--claude-only` filter, so the
+        # histogram and the caveat cannot disagree about what a kind-less row
+        # is called.
+        "kind": _count_by(row_kind(r) for r in rows),
         # 🔴 The filter travels WITH the counts it changed. Under
         # `--claude-only` every number above describes the FILTERED set (see
         # `gather`), so a reader that does not know the filter ran would read a
         # real "0 agent windows" and a "0 because the shells were dropped"
-        # identically. `excluded_non_claude` is None — not 0 — when the filter
+        # identically. `excluded_shells` is None — not 0 — when the filter
         # never ran: nothing was excluded because nothing was ever counted.
+        #
+        # 🔴 IT IS `excluded_shells`, NOT `excluded_non_claude`. The old name
+        # was accurate only while the predicate was `r["claude"]` and every row
+        # was a tmux pane. `--claude-only` now drops the SHELL class and keeps
+        # `cluster` (see `dropped_by_claude_only`), so "non_claude" would name a
+        # set strictly larger than the one counted — a reader would take a
+        # cluster row to be inside it. Renamed rather than redefined in place:
+        # a KeyError is a better morning than an integer that quietly means
+        # something else, the same trade this summary already made for the flat
+        # per-status ints.
         "claude_only": bool(filters.get("claude_only")),
-        "excluded_non_claude": filters.get("excluded_non_claude"),
+        "excluded_shells": filters.get("excluded_shells"),
+        # WHICH kinds the filter removed ENTIRELY, so `summary["kind"]` cannot
+        # be read as a statement about what the scan produced when it is a
+        # statement about what survived. None — not [] — when no filter ran.
+        "kinds_excluded_by_filter": filters.get("kinds_excluded_by_filter"),
         "hosts_reachable": sorted(k for k, v in report["hosts"].items()
                                   if v["reachable"]),
         "hosts_unreachable": sorted(k for k, v in report["hosts"].items()
@@ -2145,8 +2220,12 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
         # The row set this report describes, and how it was narrowed. Present
         # on EVERY report, filtered or not, so a consumer branches on a field
         # rather than on whether a key exists.
+        # 🔴 Both counters are None, never 0/[]: the filter has not run yet, so
+        # nothing has been excluded BECAUSE nothing has been counted. A `[]`
+        # here would tell `measured_caveats` a filter ran and removed no kind.
         "filters": {"claude_only": bool(claude_only),
-                    "excluded_non_claude": None},
+                    "excluded_shells": None,
+                    "kinds_excluded_by_filter": None},
         # 🔴 The clawgate approval queue. Filled in below; the skeleton carries
         # a `status` from the first byte so no code path can publish a bare
         # count. See `read_blocked_on_me` for the four outcomes.
@@ -2342,14 +2421,52 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
     # table. Counting the filtered set makes that same run a real measured zero
     # (EXIT_EMPTY) — true, because zero AGENT windows is what was asked. The
     # dropped count keeps it from reading as "the host had nothing at all".
+    #
+    # 🔴 THE FILTER ALSO RECORDS WHICH *KINDS* IT REMOVED ENTIRELY, and that is
+    # not bookkeeping — it is the difference between two claims a reader cannot
+    # otherwise tell apart. This block runs BEFORE `summarize` and BEFORE
+    # `measured_caveats`, both of which derive from `report["hosts"][*]
+    # ["windows"]`, i.e. from the rows that SURVIVED. So on the day writer 3
+    # emits cluster rows, a run that filtered them out would publish
+    # `kinds_produced: ["tmux"]` and render "cluster is ENUMERATED but NOT
+    # PRODUCED, so no such row appears and its absence is NOT a measured zero".
+    # Every word of that sentence would be FALSE: cluster rows were produced,
+    # such rows did appear, and their absence is entirely the filter's doing.
+    # It attributes to THE BUILD what belongs to THE FILTER, and the reader most
+    # likely to be misled is the one reading that line to find out whether
+    # cluster rows exist yet.
+    #
+    # That is the same class as `fuzzyclaw_scope` in #471 — a machine-readable
+    # claim outliving the code it describes — and the `fuzzyclaw_scope` fix is
+    # what created this one, because it made `kinds_produced` measured from
+    # rows without asking WHICH rows.
+    #
+    # The fix keeps `kinds_produced` describing the RENDERED set, so the caveat
+    # line and the table above it still cannot disagree, and publishes the
+    # removed kinds as their OWN measured field. Deriving `kinds_produced` from
+    # the unfiltered rows instead would have swapped one disagreement for
+    # another: a line reading "rows in this scan are kind=cluster/tmux" printed
+    # over a table with no cluster row in it.
     if claude_only:
         excluded = 0
+        kinds_before, kinds_after = set(), set()
         for host in hosts:
             entry = report["hosts"][host]
-            kept = [r for r in entry["windows"] if r.get("claude")]
+            kinds_before |= {row_kind(r) for r in entry["windows"]}
+            kept = [r for r in entry["windows"]
+                    if not dropped_by_claude_only(r)]
+            kinds_after |= {row_kind(r) for r in kept}
             excluded += len(entry["windows"]) - len(kept)
             entry["windows"] = kept
-        report["filters"]["excluded_non_claude"] = excluded
+        report["filters"]["excluded_shells"] = excluded
+        # Sorted for a deterministic render, for the same reason as
+        # `kinds_produced`. `[]` — not absent — when the filter ran and removed
+        # no whole kind: the filter DID run, so "which kinds did it remove" is a
+        # measurement whose answer is none. The key is absent only when no
+        # filter ran, which is the honest shape for "never measured" and mirrors
+        # `excluded_shells` being None rather than 0 in that case.
+        report["filters"]["kinds_excluded_by_filter"] = sorted(
+            kinds_before - kinds_after)
 
     # --- 🔴 blocked-on-me: the clawgate approval queue ------------------------
     # A local file read, so it costs nothing and runs unconditionally. The
@@ -2424,8 +2541,21 @@ def measured_caveats(report) -> dict:
             for r in (h.get("windows") or [])]
     # Sorted for a deterministic render. `"none"` rather than dropping a row
     # with no `kind`: it is a bug, and the caveat is where it becomes visible.
-    cav["kind_scope"]["kinds_produced"] = sorted(
-        {r.get("kind") or "none" for r in rows})
+    cav["kind_scope"]["kinds_produced"] = sorted({row_kind(r) for r in rows})
+    # 🔴 WHAT A FILTER REMOVED, so `kinds_produced` cannot be read as a
+    # statement about the BUILD when it is a statement about the FILTER. See the
+    # `--claude-only` block in `gather`. Copied out of `report["filters"]`
+    # rather than recomputed here, because only the filter itself ever saw the
+    # unfiltered rows — by the time this function runs they are gone.
+    #
+    # 🔴 SET ONLY WHEN THE KEY IS PRESENT. A filter that never ran did not
+    # measure "no kinds were removed"; it measured nothing, and `[]` would be a
+    # fake measurement of exactly the kind this caveat exists to stop emitting.
+    # `_fmt_kind_scope` distinguishes the two the same way it already
+    # distinguishes a missing `kinds_produced` from an empty one.
+    excluded = (report.get("filters") or {}).get("kinds_excluded_by_filter")
+    if excluded is not None:
+        cav["kind_scope"]["kinds_excluded_by_filter"] = sorted(excluded)
     return cav
 
 
@@ -2797,11 +2927,26 @@ def render_table(report) -> str:
             for s in WAITING_SIGNALS))
     if summ.get("claude_only"):
         # The filter is stated where the counts are, because it changed them.
-        out.append("  FILTER --claude-only: {} non-claude window(s) excluded "
+        # `shell window(s)`, not `non-claude window(s)`: the predicate drops the
+        # SHELL class and KEEPS a cluster row, so the old wording named a set
+        # wider than the one counted (see `dropped_by_claude_only`).
+        out.append("  FILTER --claude-only: {} shell window(s) excluded "
                    "from every count above".format(
-                       summ.get("excluded_non_claude")
-                       if summ.get("excluded_non_claude") is not None
+                       summ.get("excluded_shells")
+                       if summ.get("excluded_shells") is not None
                        else "an unmeasured number of"))
+        # 🔴 AND WHICH KINDS WENT WITH THEM, printed only when a whole kind
+        # vanished. Without this the reader has `summary["kind"]` and the
+        # `kind_scope` caveat both describing the surviving rows, and no line
+        # anywhere saying an entire kind was removed by the flag rather than
+        # never produced. `[]` prints nothing: the filter ran and removed no
+        # whole kind, which needs no sentence.
+        gone = summ.get("kinds_excluded_by_filter")
+        if gone:
+            out.append("  FILTER --claude-only: it removed EVERY kind={} row "
+                       "this scan produced — their absence above is the "
+                       "FILTER's doing, not a measured absence".format(
+                           "/".join(gone)))
     if summ.get("hosts_unreachable"):
         out.append("  UNREACHABLE HOSTS: " +
                    ", ".join(summ["hosts_unreachable"]))
@@ -3059,8 +3204,17 @@ def _fmt_kind_scope(kd) -> str:
     downstream by an `or` that cannot tell "not supplied" from "measured none".
     So the two cases are separated explicitly, and only a MISSING key falls
     back.
+
+    🔴 `kinds_excluded_by_filter` IS READ IN EVERY MEASURED BRANCH. Without it
+    this sentence attributes to the BUILD what a filter did: `--claude-only`
+    runs before the derivation, so a scan that produced cluster rows and then
+    dropped them rendered "cluster is ENUMERATED but NOT PRODUCED" — false in
+    all three of its clauses. Same treatment as `kinds_produced`: a MISSING key
+    means no filter ran, an EMPTY list means one ran and removed no whole kind,
+    and the two must not collapse.
     """
     produced = kd.get("kinds_produced")
+    filtered = list(kd.get("kinds_excluded_by_filter") or [])
     if produced is None:
         # 🔴 NO MEASUREMENT SUPPLIED — reached by any caveats dict without a
         # `kinds_produced` key, which is the bare CAVEATS constant (the key is
@@ -3087,16 +3241,31 @@ def _fmt_kind_scope(kd) -> str:
         # 🔴 ZERO ROWS. Naming any kind here would be inventing one. The reader
         # most likely to hit this is the one whose hosts are unreachable, and
         # the wrong thing to tell them is which kinds were "in this scan".
+        #
+        # 🔴 THE FILTERED ZERO IS A DIFFERENT FACT AND GETS A DIFFERENT
+        # SENTENCE. "NO rows were measured in this scan" is FALSE of a
+        # `--claude-only` run over a shell-only host: rows were measured, and
+        # then removed. Saying it anyway attributes an empty table to the hosts
+        # when it belongs to the flag — the same misattribution as the
+        # NOT-PRODUCED tail below, one branch over, and reachable TODAY with no
+        # cluster row anywhere.
+        if filtered:
+            return ("every row this scan measured was REMOVED BY A FILTER "
+                    "(kind={}), so no kind survives to be reported — rows were "
+                    "measured and dropped, NOT absent, and this says nothing "
+                    "about what an unfiltered scan holds; clawgate is reported "
+                    "separately under BLOCKED ON ME".format("/".join(filtered)))
         return ("NO rows were measured in this scan, so no kind was observed — "
                 "this is NOT a claim that any kind is absent, and the enumerated "
                 "kinds ({}) say nothing about what a reachable host holds; "
                 "clawgate is reported separately under BLOCKED ON ME".format(
                     "/".join(enumerated)))
     return _kind_scope_sentence("rows in this scan are kind={}", "this scan",
-                                produced, enumerated)
+                                produced, enumerated, filtered)
 
 
-def _kind_scope_sentence(head_fmt, subject, produced, enumerated) -> str:
+def _kind_scope_sentence(head_fmt, subject, produced, enumerated,
+                         filtered=()) -> str:
     """Build the non-empty `kind_scope` sentence. ONE builder for both the
     measured and the by-construction heads, so the two cannot drift into
     saying different things about the same relationship.
@@ -3110,19 +3279,50 @@ def _kind_scope_sentence(head_fmt, subject, produced, enumerated) -> str:
     i.e. exactly when writer 3 lands, which is what this caveat is FOR.
     Consolidating two strings is only safe where they say the same thing; the
     part that differed had to become a parameter, not a coincidence.
+
+    🔴 A KIND A FILTER REMOVED IS SUBTRACTED FROM `unproduced` BEFORE ANYTHING
+    IS SAID ABOUT IT. It is missing from `produced` for a reason that has
+    nothing to do with the build, so both of the tails below would be lies
+    about it: "ENUMERATED but NOT PRODUCED" denies rows that exist, and "every
+    enumerated kind IS produced" claims a coverage the render does not have.
+    It gets its own clause naming the filter as the cause.
     """
-    unproduced = [k for k in enumerated if k not in produced]
+    filtered = list(filtered)
+    unproduced = [k for k in enumerated
+                  if k not in produced and k not in filtered]
     head = head_fmt.format("/".join(produced))
-    if not unproduced:
+    clauses = []
+    if filtered:
+        clauses.append(
+            "a FILTER REMOVED every kind={} row this scan produced, so their "
+            "absence above is the FILTER's doing and NOT a measured absence of "
+            "that work".format("/".join(filtered)))
+    if unproduced:
+        clauses.append(
+            "{} is ENUMERATED but NOT PRODUCED, so no such row appears and its "
+            "absence is NOT a measured zero".format("/".join(unproduced)))
+    elif not filtered:
         # Every enumerated kind is present. Saying "NOT PRODUCED" here would be
         # false; saying nothing would drop the pointer to where clawgate lives.
-        return (head + " — every enumerated kind IS produced, so {} covers the "
-                "whole entity axis; clawgate approval state is still reported "
-                "separately under BLOCKED ON ME".format(subject))
-    return (head + " — {} is ENUMERATED but NOT PRODUCED, so no such row "
-            "appears and its absence is NOT a measured zero; clawgate is "
-            "reported separately under BLOCKED ON ME".format(
-                "/".join(unproduced)))
+        # 🔴 GUARDED ON `not filtered` TOO. A kind a filter removed is not
+        # "produced and present", so this coverage claim would be false printed
+        # beside the filter clause — and it is the claim a reader uses to decide
+        # the axis is fully covered.
+        clauses.append(
+            "every enumerated kind IS produced, so {} covers the whole entity "
+            "axis".format(subject))
+        # The one branch that says nothing is MISSING keeps the pointer's
+        # original, longer phrasing. Not consolidated with the shorter one
+        # below: both are pinned whole by the suite, and rewording either buys
+        # nothing while breaking a machine-readable claim.
+        clauses.append("clawgate approval state is still reported separately "
+                       "under BLOCKED ON ME")
+        return head + " — " + "; ".join(clauses)
+    # Every other branch names something absent, and ends with the pointer to
+    # where clawgate IS reported — or the reader concludes this tool cannot say
+    # anything about cluster work at all.
+    clauses.append("clawgate is reported separately under BLOCKED ON ME")
+    return head + " — " + "; ".join(clauses)
 
 
 def render_session_history(hist) -> str:
@@ -3299,10 +3499,12 @@ def build_parser():
                    help="tail: strip ANSI at the source (drops tmux's -e) "
                         "instead of making every caller sed it out")
     p.add_argument("--claude-only", action="store_true",
-                   help="scan/list/detail: drop non-Claude windows. Every "
-                        "summary count then describes the FILTERED set, and "
-                        "summary.excluded_non_claude says how many were "
-                        "dropped. No effect on `tail`.")
+                   help="scan/list/detail: drop the SHELL rows (CLASS=shell). "
+                        "A cluster dispatch is an agent, not a shell, so it is "
+                        "KEPT. Every summary count then describes the FILTERED "
+                        "set; summary.excluded_shells says how many were "
+                        "dropped and summary.kinds_excluded_by_filter names "
+                        "any kind removed entirely. No effect on `tail`.")
     p.add_argument("--lines", type=int, default=DEFAULT_TAIL_LINES,
                    help="tail: scrollback lines")
     return p

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -156,6 +156,20 @@ class Fleet:
         env = self.env(
             SHIP_ROLE="workbench",           # bypass IP detection (no `ip` here)
             DRIFT_REPO=str(repo or self.work),
+            # 🔴 THE FOURTH HERMETICITY SEAM, and it caught a live breach the
+            # moment it was added. The fuzzyclaw phase-2 gate EXECS
+            # `scripts/session-manager`, which scans the operator's REAL tmux —
+            # unstubbed, every test in this file did exactly that (48 live
+            # windows, measured), and one of them declared "READY — 0 of 48"
+            # because the fixture $HOME has no fuzzyclaw task files. A
+            # read-only breach is still a breach, and the verdict it produced
+            # was wrong.
+            #
+            # Defaulted to a path INSIDE tmp_path that does not exist, so the
+            # gate takes its no-session-manager branch. A test that wants the
+            # gate to answer calls `stub_session_manager()`, exactly like
+            # `stub_ssh`.
+            DRIFT_SESSION_MANAGER=str(self.bin / "session-manager"),
             # Pinned into tmp_path: the unreachable streak is PERSISTENT state,
             # and left to its default ($XDG_STATE_HOME/…) these tests would both
             # write to the operator's real state dir and inherit a streak from
@@ -182,6 +196,42 @@ class Fleet:
             body.append("echo '%s'" % stdout.replace("'", "'\\''"))
         body.append("exit %d" % exit_code)
         write_exec(self.bin / "ssh", "\n".join(body) + "\n")
+
+    def stub_session_manager(self, payload, exit_code=0):
+        """Install a stub `session-manager` that prints `payload` on stdout.
+
+        `payload` is a dict (serialised to JSON) or a raw string, so both the
+        well-formed reports and the malformed ones — a crash, an empty stream,
+        a truncated body — are drivable. The real binary is never executed by
+        this suite: it scans the operator's live tmux.
+        """
+        text = payload if isinstance(payload, str) else json.dumps(payload)
+        body = "cat <<'SM_JSON_EOF'\n%s\nSM_JSON_EOF\nexit %d\n" % (
+            text, exit_code)
+        write_exec(self.bin / "session-manager", body)
+
+    def sm_report(self, rows=47, fuzzy=7, host="workbench", files_seen=400,
+                  status="ok"):
+        """The SHAPE `session-manager scan --json` really emits, cut down to the
+        four facts the phase-2 reader consults.
+
+        Pinned against the live payload rather than invented: `age_sources` is
+        a histogram keyed by WRITER (`ledger`/`fuzzyclaw`/`none`) and
+        `total_sessions` is the row count, both under `summary`. Measured on
+        the workbench 2026-08-15 — `{fuzzyclaw: 7, ledger: 27, none: 13}` over
+        47 rows — which is the default here so the fixture is a real
+        observation and not a round number.
+        """
+        return {
+            "local_host": host,
+            "fuzzyclaw": {"status": status, "files_seen": files_seen},
+            "summary": {
+                "total_sessions": rows,
+                # the two OTHER writers carry distinct values, so an assertion
+                # cannot pass by reading the wrong key
+                "age_sources": {"fuzzyclaw": fuzzy, "ledger": 27, "none": 13},
+            },
+        }
 
 
 @pytest.fixture
@@ -1435,6 +1485,28 @@ UNIT_PATH_REQUIREMENTS = {
     # remote payload are both handed to.
     "dirname": "pkgs.coreutils",
     "bash": "pkgs.bash",
+    # The fuzzyclaw phase-2 gate: `timeout` caps the scan, `python3` runs
+    # lib/drift_phase2.py over its JSON. Both are resolved from PATH BY THIS
+    # SCRIPT, which is what puts them in this table rather than the child table
+    # below.
+    "timeout": "pkgs.coreutils",
+    "python3": "pkgs.python3",
+}
+
+# 🔴 A SECOND SEAM, AND THE TABLE ABOVE STRUCTURALLY CANNOT SEE IT. The phase-2
+# gate EXECS `scripts/session-manager`, and that child resolves binaries of its
+# own from the same unit PATH: `python3` (its `#!/usr/bin/env python3` shebang)
+# and `tmux` (`tmux list-panes -a`, its only subprocess on a local scan). Neither
+# word ever appears in drift-check.sh, so the reverse tokenizer cannot find them
+# and `test_every_command_the_checker_runs_is_on_the_unit_path` would fail if
+# they were added above (it asserts the command IS called by the scripts).
+#
+# The failure is the silent kind this file keeps meeting: nothing crashes. The
+# gate reports COULD NOT MEASURE on every timer run, forever, from a unit that
+# looks correct — a checker wired to nothing, wearing an honest error message.
+CHILD_PATH_REQUIREMENTS = {
+    "python3": "pkgs.python3",
+    "tmux": "pkgs.tmux",
 }
 
 # Shell builtins/keywords: present as command words, never resolved via PATH.
@@ -2304,3 +2376,300 @@ def test_the_parity_scan_writes_nothing_into_the_home_it_walks(fleet):
     before = snapshot()
     _parity(fleet, "--no-remote", store=store)
     assert snapshot() == before, "the parity scan modified the tree it was reading"
+
+
+# --------------------------------------------------------------------------- #
+# 11. THE FUZZYCLAW PHASE-2 GATE (rc 16)
+#
+# 🔴 WHY IT IS A GATE AND NOT A NOTE. "Is it safe to delete the fuzzyclaw
+# readers?" was answered by a human remembering to run a probe — the same shape
+# as "nothing runs ship.sh on a schedule", which is the failure this whole file
+# exists to convert into a measurement.
+#
+# 🔴 AND WHY THE ZERO IS THE DANGEROUS DIRECTION. The answer this gate hands over
+# is a DELETION, and every way it can break produces the number that authorises
+# one: no session-manager -> 0, a crashed scan -> 0, fuzzyclaw not read -> 0, a
+# scan of the wrong host -> 0, a host with no windows -> 0. So the load-bearing
+# tests here are not the READY case; they are the six ways a zero can be false.
+# Each must be visibly distinct from a real zero AND must not set rc 16.
+# --------------------------------------------------------------------------- #
+def _phase2(fleet, report=None, raw=None, exit_code=0, **env):
+    """A clean local-only run with the phase-2 gate pointed at a stubbed scan."""
+    fleet.catch_up()
+    if raw is not None:
+        fleet.stub_session_manager(raw, exit_code=exit_code)
+    elif report is not None:
+        fleet.stub_session_manager(report, exit_code=exit_code)
+    return fleet.check("--no-remote", **env)
+
+
+def test_the_phase2_stub_is_the_instrument_and_it_can_move(fleet):
+    """INSTRUMENT CHECK, before any verdict is read off this stub.
+
+    A stub whose output the gate never actually reads would make every
+    assertion below pass for the wrong reason — and the zero it would report is
+    exactly the value that means READY. So: two different stub payloads, two
+    different rendered numbers, from the same fixture.
+    """
+    rc_a, out_a = _phase2(fleet, fleet.sm_report(rows=47, fuzzy=7))
+    assert "fuzzyclaw-only ages: 7 of 47 row(s) EXAMINED" in out_a, out_a
+    rc_b, out_b = _phase2(fleet, fleet.sm_report(rows=12, fuzzy=3))
+    assert "fuzzyclaw-only ages: 3 of 12 row(s) EXAMINED" in out_b, out_b
+    # BOTH numbers moved, so neither slot is static prose
+    assert rc_a == 0 and rc_b == 0
+
+
+def test_a_nonzero_fuzzyclaw_count_is_NOT_READY_and_does_not_fail_the_unit(fleet):
+    """🔴 TODAY'S STATE, and it must stay green. 7 of 47 rows were measured on
+    the workbench 2026-08-15. A gate that went red for the NORMAL condition
+    would be permanently red, which trains the operator to click through the one
+    alert that has to keep its meaning."""
+    rc, out = _phase2(fleet, fleet.sm_report(rows=47, fuzzy=7))
+    assert rc == 0, out
+    assert "fuzzyclaw-only ages: 7 of 47 row(s) EXAMINED" in out
+    assert "NOT READY — 7 of 47 row(s) still take their age ONLY from" in out
+    assert "READY — 0 of" not in out
+    assert "rc=16" not in out
+
+
+def test_a_REAL_zero_over_real_rows_is_READY_and_is_rc16(fleet):
+    """The transition this gate exists to catch, pinned at BOTH the exit code
+    and the rendered claim."""
+    rc, out = _phase2(fleet, fleet.sm_report(rows=47, fuzzy=0))
+    assert rc == 16, out
+    assert "fuzzyclaw-only ages: 0 of 47 row(s) EXAMINED" in out
+    assert "🔴 READY — 0 of 47 rows depend on fuzzyclaw for an age." in out
+    assert "Phase 2 is UNBLOCKED" in out
+    # 🔴 rc 16 is NOT drift, and the verdict word is a claim like any other.
+    assert "drift-check: ACTIONABLE (not drift) (rc=16)" in out
+    assert "drift-check: DRIFT (rc=16)" not in out
+    assert "rc16=NOT drift: the fuzzyclaw phase-2 gate OPENED" in out
+
+
+def test_a_zero_over_ZERO_ROWS_is_not_ready_and_says_it_walked_nothing(fleet):
+    """🔴 THE SILENT ZERO, in the one form this file already has a name for:
+    "a scan that examined nothing is not a clean scan; it is no scan." A host
+    with no tmux windows reports `0 of 0`, which is byte-identical to a real
+    zero if only the numerator is printed."""
+    rc, out = _phase2(fleet, fleet.sm_report(rows=0, fuzzy=0))
+    assert rc == 0, out
+    # the pair is the claim — the denominator is what distinguishes this
+    assert "fuzzyclaw-only ages: 0 of 0 row(s) EXAMINED" in out
+    assert "COULD NOT MEASURE — 0 rows examined. A zero over zero rows is a scan" in out
+    assert "that walked nothing, not a measurement. NOT 'phase 2 is ready'." in out
+    assert "READY — 0 of" not in out
+    assert "UNBLOCKED" not in out
+
+
+def test_a_missing_session_manager_is_a_could_not_measure_not_a_zero(fleet):
+    """The default in this suite: no stub installed, so the path does not exist.
+    A tool that is not there cannot have measured 0."""
+    fleet.catch_up()
+    rc, out = fleet.check("--no-remote")
+    assert rc == 0, out
+    assert "COULD NOT MEASURE — no executable session-manager at" in out
+    assert "This is NOT a zero and NOT 'phase 2 is ready'." in out
+    assert "EXAMINED" not in out
+
+
+def test_a_CRASHED_scan_is_a_could_not_measure_not_a_zero(fleet):
+    """A non-zero exit with no JSON on stdout. The reader sees an empty stream,
+    which `json.load` rejects — and the reason token names it rather than
+    letting the run fall through to the numbers."""
+    rc, out = _phase2(fleet, raw="", exit_code=2)
+    assert rc == 0, out
+    assert "COULD NOT MEASURE — the scan produced no usable counts" in out
+    assert "reason: no-json:JSONDecodeError" in out
+    assert "UNBLOCKED" not in out
+
+
+def test_TRUNCATED_json_is_a_could_not_measure_not_a_zero(fleet):
+    """Half a payload parses as nothing, and a stream cut mid-object is what a
+    `timeout` kill actually looks like."""
+    rc, out = _phase2(fleet, raw='{"summary": {"total_sessions": 47,')
+    assert rc == 0, out
+    assert "reason: no-json:" in out
+    assert "UNBLOCKED" not in out
+
+
+def test_a_scan_of_the_WRONG_HOST_is_a_could_not_measure_not_a_zero(fleet):
+    """🔴 THE ONE THAT WOULD HAVE BEEN INVISIBLE. `session-manager` decides which
+    host is local from ACTIVITY_HOST / the collector env file; drift-check
+    decides from lib/host-role.sh and the machine's IPs. If they disagree,
+    `--host <role>` names the REMOTE machine and the scan ssh's there — and a
+    remote row can never carry a fuzzyclaw age, so the count comes back 0 and
+    the gate authorises a deletion off the wrong machine."""
+    rc, out = _phase2(fleet, fleet.sm_report(rows=47, fuzzy=0, host="laptop"))
+    assert rc == 0, out
+    assert "COULD NOT MEASURE — reason: host-mismatch:laptop" in out
+    assert "UNBLOCKED" not in out
+    # ...and the counts are still shown, so the finding is legible
+    assert "raw: 0 of 47 row(s)" in out
+
+
+def test_fuzzyclaw_NOT_READ_is_a_could_not_measure_not_a_zero(fleet):
+    """fuzzyclaw is opt-in. With the index unread, NO row can have a fuzzyclaw
+    age — so 0 is guaranteed by the reader being wired to nothing, which is the
+    same output as the answer that authorises deleting it."""
+    rc, out = _phase2(fleet, fleet.sm_report(rows=47, fuzzy=0,
+                                             status="skipped"))
+    assert rc == 0, out
+    assert "COULD NOT MEASURE — reason: fuzzyclaw-skipped" in out
+    assert "UNBLOCKED" not in out
+
+
+def test_ZERO_TASK_FILES_is_a_could_not_measure_not_a_zero(fleet):
+    """🔴 MEASURED, NOT IMAGINED — this suite produced the false READY itself.
+    An empty (or absent) `~/.tmux/tasks` reads successfully, so `status` is
+    "ok" with `files_seen: 0`, and the first version of this gate announced
+    "READY — 0 of 48 rows" off a fixture HOME while the real count on that
+    machine was 7. `status == "ok"` is necessary and NOT sufficient."""
+    rc, out = _phase2(fleet, fleet.sm_report(rows=47, fuzzy=0, files_seen=0))
+    assert rc == 0, out
+    assert "COULD NOT MEASURE — reason: fuzzyclaw-no-task-files" in out
+    assert "UNBLOCKED" not in out
+    # ...and with task files present the SAME payload IS ready — the positive
+    # control that pins this guard to `files_seen` and nothing else.
+    rc2, out2 = _phase2(fleet, fleet.sm_report(rows=47, fuzzy=0, files_seen=1))
+    assert rc2 == 16, out2
+
+
+def test_a_no_local_run_does_not_report_a_phase2_zero(fleet):
+    """The gate is LOCAL-ONLY (fuzzyclaw task files are local state), so a
+    --no-local run has not measured it. That must not read as a pass, for the
+    same reason `[parity] NOT COMPARED` exists one block up."""
+    fleet.catch_up()
+    fleet.stub_ssh(0, "[laptop] clean")
+    fleet.stub_session_manager(fleet.sm_report(rows=47, fuzzy=0))
+    rc, out = fleet.check("--no-local")
+    assert "NOT EVALUATED — --no-local, and this gate is LOCAL-ONLY" in out
+    assert "Not a zero, and not a pass." in out
+    assert "UNBLOCKED" not in out
+    assert rc != 16
+
+
+def test_rc16_never_outranks_a_real_drift(fleet):
+    """🔴 SEVERITY. rc 16 says an optional cleanup became possible; rc 8 says
+    work exists on exactly one machine. A run that is both must report 8, or the
+    codes that need a rescue procedure hide behind a housekeeping note."""
+    fleet.catch_up()
+    fleet.add_local_commit()
+    fleet.stub_session_manager(fleet.sm_report(rows=47, fuzzy=0))
+    rc, out = fleet.check("--no-remote")
+    assert rc == 8, out
+    # the phase-2 finding is still PRINTED — it just does not win
+    assert "Phase 2 is UNBLOCKED" in out
+    assert "drift-check: DRIFT (rc=8)" in out
+    # ...and the mirror image: alone, the same phase-2 state IS the verdict
+    fleet.git(fleet.work, "reset", "--soft", "HEAD~1")
+    rc2, _ = fleet.check("--no-remote")
+    assert rc2 == 16
+
+
+def test_the_phase2_gate_does_not_fail_the_run_when_it_cannot_measure(fleet):
+    """"Cheap and non-fatal": a broken phase-2 gate must never change another
+    leg's verdict. A behind-only host is rc 10 with the gate answering, silent,
+    and crashed alike.
+
+    RED/GREEN: this is GREEN at the base sha and is NOT regression coverage —
+    with no gate there is nothing to interfere, so it passes vacuously there.
+    It is a non-interference guard on the new block. Proved REACHABLE by
+    mutation: changing `note_rc 16` to `note_rc 4` in the could-not-measure
+    branch fails it with rc 4 != 10."""
+    fleet.stub_session_manager(fleet.sm_report(rows=47, fuzzy=7))
+    rc_ok, _ = fleet.check("--no-remote")          # `work` is 1 behind origin
+    fleet.stub_session_manager("not json at all")
+    rc_broken, _ = fleet.check("--no-remote")
+    fleet.stub_session_manager("", exit_code=127)
+    rc_gone, _ = fleet.check("--no-remote")
+    assert rc_ok == rc_broken == rc_gone == 10
+
+
+def test_the_phase2_gate_passes_the_flags_that_make_the_measurement_valid(fleet):
+    """🔴 THE FLAGS ARE LOAD-BEARING, and two of the four fail SILENTLY.
+
+    Without `--fuzzyclaw` the index is never read and the count is a guaranteed
+    0; without `--host <role>` the scan can ssh to the other machine; `--no-ch`
+    and `--no-capture` keep a 6-hourly timer from opening a ClickHouse
+    connection and capturing every pane. Asserted from the argv the stub
+    actually received, not from the source text.
+    """
+    fleet.catch_up()
+    argv_log = fleet.root / "sm-argv.txt"
+    write_exec(
+        fleet.bin / "session-manager",
+        'printf "%%s\\n" "$*" >> "$SM_ARGV_LOG"\n'
+        "cat <<'SM_JSON_EOF'\n%s\nSM_JSON_EOF\n" % json.dumps(fleet.sm_report()),
+    )
+    fleet.check("--no-remote", SM_ARGV_LOG=str(argv_log))
+    argv = argv_log.read_text().strip()
+    assert argv.split() == ["scan", "--json", "--no-ch", "--no-capture",
+                            "--fuzzyclaw", "--host", "workbench"], argv
+
+
+def test_the_phase2_reader_is_read_only_and_imports_nothing_else():
+    """The passivity scanner walks drift-check.sh and lib/host-role.sh only, so
+    a NEW file under lib/ is unscanned by it. This is that file's guard: it may
+    import `json` and `sys`, and nothing else — no `os`, no `subprocess`, no
+    `open`, no `pathlib`."""
+    import ast
+
+    src = (REPO_ROOT / "scripts" / "lib" / "drift_phase2.py").read_text()
+    tree = ast.parse(src)
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.add((node.module or "").split(".")[0])
+    assert imported == {"json", "sys"}, imported
+    called = {n.func.id for n in ast.walk(tree)
+              if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)}
+    assert "open" not in called, "the phase-2 reader opened a file"
+    assert "exec" not in called and "eval" not in called
+
+
+@pytest.mark.parametrize("cmd,attr", sorted(CHILD_PATH_REQUIREMENTS.items()))
+def test_the_phase2_child_binaries_are_on_the_unit_path(cmd, attr):
+    """🔴 THE SEAM NEITHER EXISTING GUARD CAN SEE. `session-manager` is exec'd
+    by drift-check but resolves ITS OWN binaries from the same unit PATH, and
+    neither `python3`-as-a-shebang nor `tmux` appears as a command word in
+    drift-check.sh — so the reverse tokenizer cannot find them and the forward
+    table would reject them. Nothing crashes when they are missing: the gate
+    just reports COULD NOT MEASURE on every timer run, forever."""
+    assert attr in _drift_service_block(), (
+        "the drift-check unit's PATH is missing %s — the phase-2 gate execs "
+        "session-manager, which needs %r and would silently never measure"
+        % (attr, cmd)
+    )
+
+
+def test_the_phase2_child_requirements_are_what_session_manager_actually_runs():
+    """The table above is only accounting if it matches the child. `tmux` is
+    session-manager's ONLY subprocess on a local scan, and `python3` is its
+    shebang — both read off session-manager itself, so a child that grows a new
+    dependency makes this fail rather than silently unmeasurable.
+
+    RED/GREEN: GREEN at the base sha — it reads facts about session-manager
+    that were already true there. It is an INVARIANT GUARD on the ledger, not
+    regression coverage: it fires when the child's dependencies change and the
+    table does not.
+
+    🔴 THE SHEBANG IS MATCHED BY ITS TAIL, NOT PINNED WHOLE, and both halves of
+    that are forced. `patchShebangs` rewrites it to an absolute store path
+    inside the nix sandbox — the tier that gates merges — so a whole-string pin
+    is red exactly where it must be green; and the repo-wide scan in
+    `test_runtime_shebangs.py` forbids this file from containing the literal
+    interpreter path at all. What both tiers agree on, and what this table is
+    actually about, is that the interpreter IS python3.
+    """
+    sm_src = (REPO_ROOT / "scripts" / "session-manager").read_text()
+    shebang = sm_src.splitlines()[0]
+    # 🔴 ASSEMBLED FROM CHARACTER CODES, the same idiom and the same reason as
+    # `testlib/shebang_scan.py`'s own needles: a quote followed by the two
+    # shebang characters is shape 1 of the hazard that scan looks for, so
+    # writing it as a literal makes this read-only assertion its own offender.
+    assert shebang.startswith(chr(35) + chr(33)), shebang
+    assert shebang.rstrip().endswith("python3"), shebang
+    assert 'TMUX_PANES_ARGV = ("tmux"' in sm_src
+    assert set(CHILD_PATH_REQUIREMENTS) == {"python3", "tmux"}

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -62,6 +62,46 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+def age_histogram(rows, fuzzy):
+    """A `summary.age_sources` histogram that is COHERENT — its values sum to
+    `rows`, which is an invariant of the producer, not a nicety: `summarize()`
+    derives `total_sessions = len(rows)` and `age_sources = _count_by(... for r
+    in rows)` from the SAME list one line apart, so every row lands in exactly
+    one bucket.
+
+    🔴 THE HAND-WRITTEN VERSION OF THIS WAS NOT COHERENT, and that is worth
+    recording. It was the literal `{"fuzzyclaw": fuzzy, "ledger": 27, "none":
+    13}`, which sums to `fuzzy + 40` regardless of `rows` — so `sm_report(rows=
+    47, fuzzy=0)`, the fixture behind the whole READY path, published a
+    histogram accounting for 40 of 47 rows. Nothing could see it until the
+    reader gained a coherence check, and then every READY test went red at once.
+    A fixture that cannot occur in production tests a payload the code will
+    never receive.
+
+    🔴 A ZERO IS SPELLED BY ABSENCE, not by `fuzzyclaw: 0` — `_count_by` creates
+    a key only for a value it OBSERVED. Reproduced here so the READY tests
+    exercise the shape a real all-clear scan actually emits.
+
+    The default `rows=47, fuzzy=7` reproduces the measured workbench payload
+    exactly (`{fuzzyclaw: 7, ledger: 27, none: 13}`), and the three buckets are
+    kept pairwise distinct so an assertion cannot pass by reading the wrong key.
+    """
+    out = {}
+    if fuzzy:
+        out["fuzzyclaw"] = fuzzy
+    rest = rows - fuzzy
+    if rest > 0:
+        none = rest // 3
+        if none == fuzzy:
+            none += 1
+        none = min(none, rest)
+        if none:
+            out["none"] = none
+        if rest - none:
+            out["ledger"] = rest - none
+    return out
+
+
 # --------------------------------------------------------------------------- #
 # fixture: a throwaway origin + working clone, origin/main one commit ahead
 # --------------------------------------------------------------------------- #
@@ -152,7 +192,7 @@ class Fleet:
         self.git(self.work, "commit", "-q", "-m", msg)
 
     # -- the subject under test --------------------------------------------- #
-    def check(self, *args, repo=None, **envextra):
+    def check(self, *args, repo=None, script=None, **envextra):
         env = self.env(
             SHIP_ROLE="workbench",           # bypass IP detection (no `ip` here)
             DRIFT_REPO=str(repo or self.work),
@@ -177,8 +217,12 @@ class Fleet:
             DRIFT_STATE_DIR=str(self.state),
         )
         env.update(envextra)   # per-test overrides win (e.g. a blocked state dir)
+        # `script` runs a COPY of the checker whose `lib/` a test controls. The
+        # reader path is derived from the script's own resolved dirname and is
+        # deliberately NOT env-overridable, so a copy is the only way to drive
+        # the shell against a reader that breaks the output contract.
         proc = subprocess.run(
-            ["bash", str(DRIFT), *args],
+            ["bash", str(script or DRIFT), *args],
             capture_output=True, text=True, env=env,
         )
         return proc.returncode, proc.stdout + proc.stderr
@@ -227,9 +271,7 @@ class Fleet:
             "fuzzyclaw": {"status": status, "files_seen": files_seen},
             "summary": {
                 "total_sessions": rows,
-                # the two OTHER writers carry distinct values, so an assertion
-                # cannot pass by reading the wrong key
-                "age_sources": {"fuzzyclaw": fuzzy, "ledger": 27, "none": 13},
+                "age_sources": age_histogram(rows, fuzzy),
             },
         }
 
@@ -2673,3 +2715,496 @@ def test_the_phase2_child_requirements_are_what_session_manager_actually_runs():
     assert shebang.rstrip().endswith("python3"), shebang
     assert 'TMUX_PANES_ARGV = ("tmux"' in sm_src
     assert set(CHILD_PATH_REQUIREMENTS) == {"python3", "tmux"}
+
+
+# --------------------------------------------------------------------------- #
+# 12. THE PHASE-2 REASON-TOKEN LEDGER, THE THIRD STRUCTURAL ZERO, AND THE
+#     ALERTING POLICY FOR rc 16
+#
+# 🔴 WHY THIS SECTION EXISTS AND SECTION 11 WAS NOT ENOUGH. Section 11 tests
+# every reason token the reader HAS. It structurally cannot see a field the
+# reader READS and gives NO token to — and that is precisely what shipped:
+# `summary.age_sources` was read as `(summ.get("age_sources") or {}).get(
+# "fuzzyclaw", 0)`, so a report without it printed `ok 47 0` and the run
+# declared `🔴 READY — 0 of 47 rows`, byte-identical to a legitimate one.
+# Section 11's own fixture (`Fleet.sm_report`) ALWAYS emits `age_sources`, so no
+# test could reach the shape, and the mutant `.get("fuzzyclaw", 0)` ->
+# `.get("fuzzyclaw", 1)` SURVIVED a fully green run of both changed suites.
+#
+# 🔴 AND IT WAS REACHABLE ON THE HOST SHAPE THIS DEADMAN IS FOR. `age_sources`
+# landed 2026-08-13 and `DRIFT_SESSION_MANAGER` defaults to the CHECKOUT's own
+# `scripts/session-manager` — so a host a few days behind ran a scan that never
+# emitted the field and got READY. The staleness detector, disabled by staleness.
+#
+# So the guard here is not another token test: it is a SEAM guard pinning the
+# RELATIONSHIP between the tokens emitted and the fields read, failing when
+# either set GROWS or SHRINKS, plus a behavioural half proving every declared
+# token is REACHABLE — a structural check alone type-checks past a dead branch.
+# --------------------------------------------------------------------------- #
+PHASE2_PY = REPO_ROOT / "scripts" / "lib" / "drift_phase2.py"
+
+# Every reason token `lib/drift_phase2.py` may emit. A token built with a `%`
+# format is written here as its literal PREFIX + `*` — the variable tail is a
+# JSON key / host name / exception class and is not part of the contract.
+PHASE2_TOKENS = {
+    "ok",
+    "no-json:*",                 # json.load raised — crash, truncation, empty stream
+    "no-json:not-an-object",     # valid JSON that is not a report
+    "no-counts",                 # total_sessions, or an age_sources value, is not an int
+    "no-age-sources",            # THE ONE THAT SHIPPED MISSING
+    "unknown-age-writer:*",      # the age_source VOCABULARY changed under us
+    "age-sources-incoherent:*",  # the histogram does not account for every row
+    "host-mismatch:*",           # the scan answered about the other machine
+    "fuzzyclaw-*",               # fuzzyclaw.status was not "ok"
+    "fuzzyclaw-no-task-files",   # status ok over an empty ~/.tmux/tasks
+}
+
+# 🔴 THE SEAM ITSELF: every field of the report the reader consults, mapped to
+# the token that fires when it is absent or unusable. This is the ledger that
+# makes "a newly-consulted field with no reason token" a RED TEST rather than a
+# silent zero — add a `.get("something_new")` to the reader and the extracted
+# field set below stops matching this dict, and the only way to green it is to
+# write down which token covers that field's absence.
+#
+# `fuzzyclaw` appears once as a KEY OF THE HISTOGRAM and once as a TOP-LEVEL
+# BLOCK. Keyed by name, so the entry names the histogram reader's token; the
+# top-level block's absence makes `fz.get("status")` None -> `fuzzyclaw-*`,
+# which `status` already accounts for.
+PHASE2_FIELD_TOKENS = {
+    "summary":        "no-counts",
+    "total_sessions": "no-counts",
+    "age_sources":    "no-age-sources",
+    "fuzzyclaw":      "unknown-age-writer:*",
+    "local_host":     "host-mismatch:*",
+    "status":         "fuzzyclaw-*",
+    "files_seen":     "fuzzyclaw-no-task-files",
+}
+
+
+def _phase2_ast():
+    import ast
+    return ast.parse(PHASE2_PY.read_text())
+
+
+def _emitted_tokens() -> set:
+    """Every first argument to `emit(...)`, normalised at the first `%`."""
+    import ast
+    out = set()
+    for node in ast.walk(_phase2_ast()):
+        if not (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "emit"
+                and node.args):
+            continue
+        arg = node.args[0]
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            out.add(arg.value)
+        elif (isinstance(arg, ast.BinOp) and isinstance(arg.op, ast.Mod)
+              and isinstance(arg.left, ast.Constant)
+              and isinstance(arg.left.value, str)):
+            out.add(arg.left.value.split("%")[0] + "*")
+        else:  # pragma: no cover - a shape the ledger cannot account for
+            raise AssertionError(
+                "emit() called with an expression this guard cannot read "
+                "statically: %r. The token set is the contract — keep it a "
+                "literal or a `<literal>%%s` format." % ast.dump(arg))
+    return out
+
+
+def _fields_read() -> set:
+    """Every string literal used as the first argument of a `.get(...)`."""
+    import ast
+    return {
+        n.args[0].value
+        for n in ast.walk(_phase2_ast())
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+        and n.func.attr == "get" and n.args
+        and isinstance(n.args[0], ast.Constant)
+        and isinstance(n.args[0].value, str)
+    }
+
+
+def _read_phase2(payload, want="workbench"):
+    """Drive the REAL reader over stdin and return (token, whole line)."""
+    text = payload if isinstance(payload, str) else json.dumps(payload)
+    proc = subprocess.run([sys.executable, str(PHASE2_PY), want],
+                          input=text, capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    line = proc.stdout.strip()
+    assert len(line.split()) == 3, f"output contract broken: {line!r}"
+    return line.split()[0], line
+
+
+def _normalise(token) -> str:
+    if token in PHASE2_TOKENS:
+        return token
+    for known in PHASE2_TOKENS:
+        if known.endswith("*") and token.startswith(known[:-1]):
+            return known
+    return token
+
+
+def _report(rows=47, sources=None, host="workbench", status="ok", files_seen=3,
+            omit_sources=False):
+    """A phase-2-shaped report, built from the SAME `age_histogram` the fleet
+    fixture uses, so the coherence guard is satisfied unless a test breaks it
+    on purpose. `rows` may be a non-int here (that IS one of the cases)."""
+    if sources is None:
+        sources = age_histogram(rows, 7) if isinstance(rows, int) else {}
+    summary = {"total_sessions": rows}
+    if not omit_sources:
+        summary["age_sources"] = sources
+    return {"local_host": host,
+            "fuzzyclaw": {"status": status, "files_seen": files_seen},
+            "summary": summary}
+
+
+# -- the ledger seam -------------------------------------------------------- #
+def test_the_phase2_reason_token_ledger_is_pinned_to_the_fields_read():
+    """🔴 THE STRUCTURAL FIX FOR THE WHOLE CLASS, not for the one instance.
+
+    Two sets, both extracted from the reader's own source, both pinned two-way:
+
+      * the tokens it EMITS must be exactly `PHASE2_TOKENS`;
+      * the report fields it READS must be exactly the keys of
+        `PHASE2_FIELD_TOKENS`, whose values name the token that fires when the
+        field is missing or unusable.
+
+    Consult a new field and the second assertion fails; the only way to green it
+    is to write down which token covers its absence — which is the step that did
+    not happen for `age_sources`. Delete a token and the first fails, so a guard
+    cannot be quietly removed either.
+
+    RED/GREEN: RED at 494d14d, which emits none of `no-age-sources`,
+    `unknown-age-writer:*`, `age-sources-incoherent:*`. Regression coverage for
+    the MECHANISM, not only for the one instance.
+    """
+    assert _emitted_tokens() == PHASE2_TOKENS, (
+        "the reader's reason-token set drifted from the ledger:\n"
+        "  only in source: %r\n  only in ledger: %r"
+        % (sorted(_emitted_tokens() - PHASE2_TOKENS),
+           sorted(PHASE2_TOKENS - _emitted_tokens())))
+    assert _fields_read() == set(PHASE2_FIELD_TOKENS), (
+        "the reader consults a report field with no entry in the reason-token "
+        "ledger — that is the shape that shipped `age_sources` as a silent "
+        "zero.\n  read but unaccounted: %r\n  accounted but unread: %r"
+        % (sorted(_fields_read() - set(PHASE2_FIELD_TOKENS)),
+           sorted(set(PHASE2_FIELD_TOKENS) - _fields_read())))
+    unknown = {f: t for f, t in PHASE2_FIELD_TOKENS.items()
+               if t not in PHASE2_TOKENS}
+    assert not unknown, f"ledger names tokens the reader cannot emit: {unknown}"
+
+
+def test_every_declared_phase2_token_is_actually_reachable():
+    """🔴 THE BEHAVIOURAL HALF. A structural ledger type-checks past a token
+    whose branch can never run — and an unreachable guard is exactly what makes
+    a mutation sweep report SURVIVED for a right-looking reason. So every token
+    in the ledger gets a payload that MUST produce it, driven through the real
+    reader, and the produced set must equal the declared set.
+    """
+    cases = {
+        "ok":                       _report(),
+        "no-json:*":                "not json at all",
+        "no-json:not-an-object":    "[1, 2, 3]",
+        "no-counts":                _report(rows="47"),
+        "no-age-sources":           _report(omit_sources=True),
+        "unknown-age-writer:*":     _report(sources={"fz": 7, "ledger": 40}),
+        "age-sources-incoherent:*": _report(sources={"ledger": 40}),
+        "host-mismatch:*":          _report(host="laptop"),
+        "fuzzyclaw-*":              _report(status="skipped"),
+        "fuzzyclaw-no-task-files":  _report(files_seen=0),
+    }
+    assert set(cases) == PHASE2_TOKENS, (
+        "a declared token has no reachability case: %r"
+        % sorted(PHASE2_TOKENS ^ set(cases)))
+    produced = {}
+    for want, payload in cases.items():
+        token, line = _read_phase2(payload)
+        produced[want] = _normalise(token)
+        assert produced[want] == want, (
+            f"payload for {want!r} produced {token!r} ({line!r})")
+    assert set(produced.values()) == PHASE2_TOKENS
+
+
+# -- the third structural zero ---------------------------------------------- #
+def test_a_report_without_age_sources_is_a_could_not_measure_not_a_zero(fleet):
+    """🔴 THE DEFECT, END TO END THROUGH THE SHELL. A session-manager older than
+    `age_sources` (it landed 2026-08-13) emits a report without it, and
+    `DRIFT_SESSION_MANAGER` defaults to the checkout's own copy — so this is the
+    STALE HOST, the one condition drift-check exists to detect.
+
+    Measured at 494d14d with this exact stub: `🔴 READY — 0 of 47 rows depend on
+    fuzzyclaw`, rc 16, indistinguishable from a real all-clear.
+    """
+    rc, out = _phase2(fleet, {"local_host": "workbench",
+                              "fuzzyclaw": {"status": "ok", "files_seen": 3},
+                              "summary": {"total_sessions": 47}})
+    assert rc == 0, out
+    # Pinned whole: the reason is NAMED, and the line says COULD NOT MEASURE
+    # rather than reporting a count. The fuzzyclaw count is genuinely unknown
+    # here (unlike host-mismatch, where the numbers are real but about the wrong
+    # machine), so this is the no-usable-counts phrasing, not the raw one.
+    assert ("[phase2] COULD NOT MEASURE — the scan produced no usable counts "
+            "(reason: no-age-sources)." in out), out
+    assert "[phase2]   This is NOT a zero and NOT 'phase 2 is ready'." in out, out
+    assert "READY" not in out, out
+    assert "UNBLOCKED" not in out, out
+    assert "EXAMINED" not in out, out
+
+
+@pytest.mark.parametrize("sources,reason", [
+    # the whole histogram renamed away — what this PR did to a sibling key
+    (None, "no-age-sources"),
+    # not a dict at all (it used to raise AttributeError)
+    ("age_sources", "no-age-sources"),
+    # the age_source VALUE renamed: the count would silently read 0
+    ({"fz": 7, "ledger": 27, "none": 13}, "unknown-age-writer:fz"),
+    # a histogram that does not account for every row is not a measurement
+    ({"ledger": 27, "none": 13}, "age-sources-incoherent:40"),
+    # a non-int count must never print as a count
+    ({"fuzzyclaw": "7", "ledger": 27, "none": 13}, "no-counts"),
+])
+def test_a_broken_age_histogram_is_a_could_not_measure_not_a_zero(
+        fleet, sources, reason):
+    """Each way `summary.age_sources` can arrive unusable, through the shell.
+    All five produce the deletion-authorising number at 494d14d."""
+    report = fleet.sm_report(rows=47, fuzzy=0)
+    if sources is None:
+        del report["summary"]["age_sources"]
+    else:
+        report["summary"]["age_sources"] = sources
+    rc, out = _phase2(fleet, report)
+    assert rc == 0, out
+    assert "[phase2] COULD NOT MEASURE" in out, out
+    assert f"(reason: {reason})." in out, out
+    assert "READY" not in out, out
+    assert "EXAMINED" not in out, out
+
+
+def test_an_absent_fuzzyclaw_KEY_in_a_sound_histogram_IS_a_real_zero(fleet):
+    """🔴 THE DECISION, WRITTEN DOWN. `summary.age_sources` is
+    `_count_by(r.get("age_source") or "none" for r in rows)` — a histogram that
+    creates a key only for a value it OBSERVED — so zero fuzzyclaw-sourced rows
+    emits NO `fuzzyclaw` key rather than `fuzzyclaw: 0`. Refusing to measure
+    that would make the gate structurally unable to ever say READY, i.e. a gate
+    that can never open.
+
+    It is a real zero only because two guards hold at the same time: the writer
+    vocabulary is recognised (so the key is not merely RENAMED) and the
+    histogram accounts for every row (so it is not merely TRUNCATED). That
+    conjunction is the measurement; neither guard alone is.
+    """
+    rc, out = _phase2(fleet, _report(rows=47,
+                                     sources={"ledger": 34, "none": 13}))
+    assert rc == 16, out
+    assert "fuzzyclaw-only ages: 0 of 47 row(s) EXAMINED" in out, out
+    assert "🔴 READY — 0 of 47 rows depend on fuzzyclaw for an age." in out, out
+
+
+@pytest.mark.parametrize("payload,reason", [
+    ({"total_sessions": True, "age_sources": {"ledger": 1}}, "no-counts"),
+    ({"total_sessions": 47,
+      "age_sources": {"fuzzyclaw": True, "ledger": 46}}, "no-counts"),
+])
+def test_a_bool_never_prints_as_a_phase2_count(payload, reason):
+    """🔴 READ AT THE READER, BECAUSE THE SHELL CANNOT SEE THIS ONE. `bool` is
+    an `int` in Python, so without the explicit bool checks `total_sessions:
+    true` reaches the output as the word `True` — which drift-check.sh's numeric
+    filter then rejects as unparseable, i.e. the right verdict via a completely
+    different mechanism. Through the shell the guard's removal mutant is
+    UNOBSERVABLE (measured: it survived a sweep). Read here instead, where the
+    two mechanisms ARE distinguishable, so the guard has a test that can go red
+    when it is deleted.
+    """
+    token, line = _read_phase2({"local_host": "workbench",
+                                "fuzzyclaw": {"status": "ok", "files_seen": 3},
+                                "summary": payload})
+    assert token == reason, line
+
+
+def test_a_reason_token_never_contains_a_space():
+    """🔴 THE OUTPUT CONTRACT IS POSITIONAL. drift-check.sh reads the token as
+    `${p2_out%% *}` and the counts as the fields after it, so a space inside an
+    interpolated JSON key or host name would truncate the reason AND shift both
+    counts, printing a prefix of the real reason over numbers belonging to the
+    wrong fields."""
+    token, line = _read_phase2(_report(sources={"a b c": 47}))
+    assert token == "unknown-age-writer:a_b_c", line
+    assert len(line.split()) == 3, line
+    token2, line2 = _read_phase2(_report(host="two words"))
+    assert token2 == "host-mismatch:two_words", line2
+    assert len(line2.split()) == 3, line2
+
+
+# -- the alerting policy for rc 16 ------------------------------------------ #
+def test_the_unit_does_not_fail_on_the_phase2_actionable_code():
+    """🔴 rc 16 MUST NOT FAIL THE UNIT. `Type = "oneshot"` fails on any non-zero
+    exit, `OnFailure` fires `notify-failure@`, and that toast is the ONE class
+    deliberately wired to DEFEAT do-not-disturb (`zz_notify_failure_bypass`,
+    `override_pause_level = 100`) — a bypass justified in home.nix by a MEASURED
+    rate of ~1 firing in 9 days.
+
+    rc 16 stays set until somebody deletes the fuzzyclaw readers, and the timer
+    runs every 6h, so without `SuccessExitStatus` the gate OPENING converts that
+    into 4 DND-defeating toasts a day, forever, on runs where nothing is wrong.
+    That is the permanently-red gate this same subsystem already refuses for an
+    unreachable remote.
+
+    Asserted TOGETHER WITH the OnFailure line, deliberately: deleting the alert
+    would also make "does not toast on 16" true, and that is the wrong fix.
+    """
+    block = _drift_service_block()
+    assert "SuccessExitStatus = 16;" in block, (
+        "drift-check.service has no SuccessExitStatus, so rc 16 — the phase-2 "
+        "gate reporting that a CLEANUP is possible — puts the unit in `failed` "
+        "and fires the DND-defeating failure toast 4x a day forever:\n" + block)
+    assert "notify-failure@%n.service" in block, (
+        "the failure alert was removed rather than the exit code excused")
+
+
+def test_only_16_is_excused_from_failing_the_unit():
+    """The excuse must name exactly one code. `SuccessExitStatus` takes a LIST,
+    so a second entry would silently mute a real drift verdict — the deadman's
+    whole point. An INVARIANT GUARD, not regression coverage: at 494d14d there
+    is no SuccessExitStatus at all, so it fails there for the OTHER reason (the
+    assertion above owns that). It fires if somebody later widens the excuse."""
+    block = _drift_service_block()
+    m = re.search(r"SuccessExitStatus\s*=\s*([^;]+);", block)
+    assert m, "no SuccessExitStatus in the drift-check service block"
+    assert re.findall(r"\d+", m.group(1)) == ["16"], (
+        "only rc 16 (ACTIONABLE, not drift) may be excused from failing the "
+        f"unit; found {m.group(1).strip()!r}")
+
+
+def test_the_phase2_ready_run_still_prints_the_no_drift_line(fleet):
+    """🔴 BOTH CLAIMS, BECAUSE THEY ARE INDEPENDENT. rc 16 is the one owned code
+    that says nothing about host health, so routing it through the DRIFT branch
+    alone withheld the finding the run actually made — "no drift on the host(s)
+    CHECKED" — and printed only the cleanup notice. An operator then cannot tell
+    an rc 16 over a clean host from an rc 16 over a host nobody vouched for.
+    """
+    rc, out = _phase2(fleet, fleet.sm_report(rows=47, fuzzy=0))
+    assert rc == 16, out
+    assert "no drift on the host(s) CHECKED" in out, out
+    assert "ACTIONABLE (not drift) (rc=16)" in out, out
+    assert "🔴 READY — 0 of 47 rows depend on fuzzyclaw for an age." in out, out
+
+
+def test_a_plain_clean_run_does_not_gain_the_verdict_block(fleet):
+    """The other half of the pair above: widening the affirmative branch to
+    `rc = 0 || rc = 16` must not give an ordinary rc-0 run a verdict line. No
+    session-manager is stubbed, so the gate takes its COULD NOT MEASURE branch
+    and the run is a plain rc 0."""
+    fleet.catch_up()
+    rc, out = fleet.check("--no-remote")
+    assert rc == 0, out
+    assert "no drift on the host(s) CHECKED" in out, out
+    assert "ACTIONABLE" not in out, out
+    assert "(rc=" not in out, out
+
+
+def test_a_real_drift_verdict_does_not_gain_the_no_drift_line(fleet):
+    """The mirror image, and the dangerous one to get wrong: rc 8 must print
+    DRIFT and must NOT print the affirmative line."""
+    fleet.catch_up()
+    fleet.add_local_commit("commit the workbench never pushed")
+    rc, out = fleet.check("--no-remote")
+    assert rc == 8, out
+    assert "no drift on the host(s) CHECKED" not in out, out
+    assert "DRIFT (rc=8)" in out, out
+
+
+# -- the shell's own robustness to a reader that breaks the contract -------- #
+def _drift_copy(fleet, reader_src):
+    """A COPY of drift-check.sh whose `lib/drift_phase2.py` a test controls.
+
+    🔴 WHY A COPY. `_drift_phase2_py` is derived from the script's own resolved
+    dirname and is deliberately not env-overridable (unlike
+    `DRIFT_SESSION_MANAGER`), so the numeric filters that defend against a
+    malformed reader line are otherwise unreachable from any test — the real
+    reader cannot produce one. Measured: removing either `case` filter SURVIVED
+    a full mutation sweep before this existed.
+
+    🔴 AND IT IS NOT A HYPOTHETICAL. `scripts/` is read from the checkout while
+    the skill docs beside it deploy as a store copy, and any future consumer of
+    this line is a second implementation of the contract. A shell that trusts
+    its reader is a shell whose COULD NOT MEASURE depends on someone else's bug.
+    """
+    d = fleet.root / "driftcopy"
+    (d / "lib").mkdir(parents=True, exist_ok=True)
+    shutil.copy(str(DRIFT), str(d / "drift-check.sh"))
+    shutil.copy(str(HOST_ROLE_LIB), str(d / "lib" / "host-role.sh"))
+    if reader_src is not None:
+        (d / "lib" / "drift_phase2.py").write_text(reader_src)
+    return d / "drift-check.sh"
+
+
+@pytest.mark.parametrize("line", [
+    "ok forty-seven 0",   # rows is not a number
+    "ok 47 zero",         # the fuzzyclaw count is not a number
+    "ok 47",              # only TWO fields — both counts came from field 2
+    "ok",                 # only one
+    "ok 47 0 9",          # FOUR — the middle two are not the pair we read
+    "",                   # nothing at all
+])
+def test_a_malformed_reader_line_is_a_could_not_measure_not_a_zero(fleet, line):
+    """🔴 THE COUNTS ARE READ POSITIONALLY, so a line that is not
+    `<token> <int> <int>` puts arbitrary text where a number belongs — and
+    `[ "$x" -gt 0 ]` over text is a shell ERROR, not a false. The `case` filters
+    turn each into -1 first, which is what makes this COULD NOT MEASURE instead
+    of a crash or, worse, a fall-through to the READY branch.
+
+    🔴 THE FIELD COUNT IS HALF OF IT, and it is the half that was missing.
+    `${x%% *}` and `${x##* }` both return the WHOLE STRING when it holds no
+    space, so `ok 47` set both counts from field 2 and printed `47 of 47 row(s)
+    EXAMINED` — a fabricated denominator that passed every numeric filter.
+    MEASURED here before the fix; it reads as NOT READY, so it was fail-safe by
+    luck rather than by construction, which is not the standard this gate holds
+    every other non-measurement to.
+    """
+    fleet.catch_up()
+    fleet.stub_session_manager(fleet.sm_report(rows=47, fuzzy=0))
+    script = _drift_copy(
+        fleet, "import sys\nsys.stdin.read()\nprint(%r)\n" % line)
+    rc, out = fleet.check("--no-remote", script=str(script))
+    assert rc == 0, out
+    assert "[phase2] COULD NOT MEASURE" in out, out
+    assert "READY" not in out, out
+    assert "UNBLOCKED" not in out, out
+
+
+def test_an_unreadable_phase2_reader_is_a_could_not_measure(fleet):
+    """The `[ ! -r "$_drift_phase2_py" ]` branch, reachable only through a copy.
+    A checkout missing the reader must not report a zero."""
+    fleet.catch_up()
+    fleet.stub_session_manager(fleet.sm_report(rows=47, fuzzy=0))
+    script = _drift_copy(fleet, None)      # lib/ has host-role.sh but no reader
+    rc, out = fleet.check("--no-remote", script=str(script))
+    assert rc == 0, out
+    assert "[phase2] COULD NOT MEASURE — cannot read" in out, out
+    assert "This is NOT a zero and NOT 'phase 2 is ready'." in out, out
+    assert "READY" not in out, out
+
+
+def test_the_drift_copy_harness_can_still_produce_a_ready(fleet):
+    """🔴 POSITIVE CONTROL FOR THE HARNESS ABOVE. Every assertion in the two
+    tests before this one is that something did NOT happen, and a copy whose
+    phase-2 gate is broken for an unrelated reason (a missing lib, a bad path)
+    would satisfy all of them while measuring nothing. So: the same copy, the
+    REAL reader, and the READY verdict must come back."""
+    fleet.catch_up()
+    fleet.stub_session_manager(fleet.sm_report(rows=47, fuzzy=0))
+    script = _drift_copy(fleet, PHASE2_PY.read_text())
+    rc, out = fleet.check("--no-remote", script=str(script))
+    assert rc == 16, out
+    assert "🔴 READY — 0 of 47 rows depend on fuzzyclaw for an age." in out, out
+
+
+def test_a_non_integer_phase2_timeout_is_rejected(fleet):
+    """`DRIFT_PHASE2_TIMEOUT` is handed to `timeout`, and `require_int` is what
+    keeps it an integer. Removing that call survived a mutation sweep because
+    nothing exercised it."""
+    rc, out = fleet.check("--no-remote", DRIFT_PHASE2_TIMEOUT="60; echo PWNED")
+    assert rc == 2, f"expected a usage error, got {rc}\n{out}"
+    assert "DRIFT_PHASE2_TIMEOUT must be a non-negative integer" in out, out
+    assert not [ln for ln in out.splitlines() if ln.strip() == "PWNED"], out

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -1803,7 +1803,9 @@ def test_json_golden_schema_and_values():
         # 🔴 LITERAL, and the whole point: this fixture's 3 windows are one busy
         # claude, one idle claude and one unknown SHELL. No bucket publishes a
         # bare number, and no flat `idle` key exists to be read as an agent
-        # count. `claude_only` false -> `excluded_non_claude` is None, not 0.
+        # count. `claude_only` false -> `excluded_shells` is None, not 0, and
+        # so is `kinds_excluded_by_filter`: no filter ran, so "which kinds did
+        # it remove" was never measured and `[]` would be a fake measurement.
         "status": {
             "busy": {"claude": 1, "shell": 0, "total": 1},
             "idle": {"claude": 1, "shell": 0, "total": 1},
@@ -1811,7 +1813,8 @@ def test_json_golden_schema_and_values():
             "unknown": {"claude": 0, "shell": 1, "total": 1},
         },
         "claude_only": False,
-        "excluded_non_claude": None,
+        "excluded_shells": None,
+        "kinds_excluded_by_filter": None,
         "hosts_reachable": ["laptop", "workbench"],
         "hosts_unreachable": [],
         "fuzzyclaw_live": 1,
@@ -3754,7 +3757,7 @@ def test_claude_only_drops_the_shells_on_EVERY_host_and_keeps_the_agents():
     assert [r["session"] for r in wb] == ["scratch7"], "misc:5 is a zsh window"
     assert [r["session"] for r in lt] == ["naida-dev"], "thistle:4 is a shell"
     assert all(r["claude"] is True for r in wb + lt)
-    assert report["summary"]["excluded_non_claude"] == 2, "one PER HOST"
+    assert report["summary"]["excluded_shells"] == 2, "one PER HOST"
     # ...and the unfiltered scan still carries both shells, so the drop is
     # caused by the flag and by nothing else (positive control on the filter).
     unfiltered = base_gather(runner=make_runner(
@@ -3779,7 +3782,7 @@ def test_claude_only_filters_on_the_claude_BOOLEAN_not_a_lookalike_field():
 
 def test_claude_only_summary_counts_the_FILTERED_set_and_says_what_it_dropped():
     """🔴 KILLS: summarizing the UNFILTERED set (the silent trap), and
-    reporting `excluded_non_claude` as 0 when the filter never ran.
+    reporting `excluded_shells` as 0 when the filter never ran.
 
     Counting the unfiltered set would publish `total_sessions: 5` beside 3
     printed rows. The dropped count is what keeps the filtered zero from
@@ -3791,11 +3794,11 @@ def test_claude_only_summary_counts_the_FILTERED_set_and_says_what_it_dropped():
     assert s["status"]["idle"] == {"claude": 2, "shell": 0, "total": 2}
     assert s["status"]["busy"]["total"] == 0, "the busy SHELL is gone"
     assert s["claude_only"] is True
-    assert s["excluded_non_claude"] == 2
+    assert s["excluded_shells"] == 2
 
     off = mix_gather()["summary"]
     assert off["claude_only"] is False
-    assert off["excluded_non_claude"] is None, (
+    assert off["excluded_shells"] is None, (
         "nothing was excluded because nothing was ever counted — not 0")
 
 
@@ -3804,7 +3807,7 @@ def test_claude_only_composes_with_host_and_counts_only_the_scanned_host():
                          local_host="workbench")
     assert [r["host"] for r in report["hosts"]["laptop"]["windows"]] \
         == ["laptop"]
-    assert report["summary"]["excluded_non_claude"] == 0, (
+    assert report["summary"]["excluded_shells"] == 0, (
         "the laptop fixture has no shell window — a MEASURED zero")
     assert report["summary"]["total_sessions"] == 1
     # the workbench's zsh window was never scanned, so it is not in the count
@@ -3825,7 +3828,7 @@ def test_claude_only_over_a_shell_only_host_is_a_MEASURED_zero_not_a_success():
     assert report["summary"]["total_sessions"] == 0
     assert sm.exit_code_for(report) == sm.EXIT_EMPTY == 3
     assert sm.exit_code_for(report) != sm.EXIT_OK
-    assert report["summary"]["excluded_non_claude"] == 1, (
+    assert report["summary"]["excluded_shells"] == 1, (
         "and the zero says the host was NOT empty — 1 shell was dropped")
     # unfiltered, the very same scan is a non-empty EXIT_OK
     unfiltered = mix_gather(
@@ -3837,8 +3840,12 @@ def test_claude_only_over_a_shell_only_host_is_a_MEASURED_zero_not_a_success():
 def test_claude_only_is_STATED_in_the_table_beside_the_counts_it_changed():
     text = sm.render_table(mix_gather(claude_only=True))
     assert "FILTER --claude-only" in text
-    assert "2 non-claude window(s) excluded" in text
+    assert "2 shell window(s) excluded" in text
     assert "FILTER --claude-only" not in sm.render_table(mix_gather())
+    # ...and on a tmux-only scan NO kind vanished, so the second FILTER line —
+    # the one that names a removed kind — must not appear. Printing it with an
+    # empty slot would assert a removal that did not happen.
+    assert "removed EVERY kind=" not in text
 
 
 def test_cli_claude_only_flag_reaches_gather_and_defaults_off(monkeypatch):
@@ -3871,8 +3878,11 @@ def test_main_json_end_to_end_carries_the_split_and_the_filter(
     assert rc == sm.EXIT_OK
     assert blob["summary"]["status"]["idle"] == {"claude": 2, "shell": 0,
                                                  "total": 2}
-    assert blob["summary"]["excluded_non_claude"] == 2
-    assert blob["filters"] == {"claude_only": True, "excluded_non_claude": 2}
+    assert blob["summary"]["excluded_shells"] == 2
+    assert blob["filters"] == {"claude_only": True, "excluded_shells": 2,
+                               # the filter RAN and removed no whole kind —
+                               # `[]`, not None, and not absent
+                               "kinds_excluded_by_filter": []}
 
 
 def test_detail_under_claude_only_explains_its_own_emptiness(monkeypatch):
@@ -3884,7 +3894,7 @@ def test_detail_under_claude_only_explains_its_own_emptiness(monkeypatch):
     rows = [r for h in narrowed["hosts"].values() for r in h["windows"]]
     assert rows == []
     assert narrowed["summary"]["claude_only"] is True
-    assert narrowed["summary"]["excluded_non_claude"] == 2
+    assert narrowed["summary"]["excluded_shells"] == 2
     assert "NOT a measured absence" in sm.no_session_reason(narrowed)
 
 
@@ -3902,6 +3912,310 @@ def test_claude_only_says_it_does_nothing_for_tail_rather_than_ignoring_it(
     # ...and it is NOT printed when the flag was not passed
     sm.main(["tail", "scratch7:3", "--host", "workbench"])
     assert "--claude-only" not in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------- #
+# §5.2b — --claude-only AGAINST THE `kind` AXIS
+#
+# Two defects, one flag. `r.get("claude")` was a correct SPELLING of "drop the
+# shells" only while every row was a tmux pane, and the filter runs BEFORE both
+# `summarize` and `measured_caveats`, so whatever it removed was then attributed
+# to the BUILD rather than to the FILTER.
+#
+# 🔴 NO REAL SCAN CAN REACH EITHER ONE. Writer 3 is still gated (measured on the
+# live board: `in_progress: 0`, `agent` non-null on 0 of 29 tasks), so every real
+# scan is 100% tmux. A test that waited for a cluster row would be green today,
+# green with the whole predicate deleted, and green on the day writer 3 lands
+# wrong. So the rows are CONSTRUCTED and injected at the `fold_windows` seam,
+# which is the last point before the filter runs.
+# --------------------------------------------------------------------------- #
+def gather_with_injected(monkeypatch, *rows, **kw):
+    """A REAL `gather` whose local `fold_windows` also emits `rows`.
+
+    🔴 THE SEAM MATTERS: appending to `report["hosts"][h]["windows"]` AFTER
+    `gather` returns — which is what `with_cluster_rows` does — is too late.
+    The `--claude-only` block, `summarize` and `measured_caveats` have all
+    already run, so such a row exercises none of them. Wrapping `fold_windows`
+    puts the constructed row in front of the filter, which is the code under
+    test.
+    """
+    real = sm.fold_windows
+
+    def folded(panes, host, **fkw):
+        out = real(panes, host, **fkw)
+        if host == "workbench":
+            out.extend(copy.deepcopy(r) for r in rows)
+        return out
+
+    monkeypatch.setattr(sm, "fold_windows", folded)
+    return mix_gather(**kw)
+
+
+def test_the_injection_seam_reaches_the_filter_and_the_baseline_is_tmux_only(
+        monkeypatch):
+    """INSTRUMENT CHECK, before any verdict is read off this seam.
+
+    Two things every test below depends on, neither of which is observable from
+    the assertions themselves: the constructed row really arrives (so a seam
+    that silently stopped applying would not leave the suite green), and the
+    UNINJECTED baseline really is tmux-only (so the deltas are measured against
+    a known starting point rather than an unknown one).
+    """
+    plain = mix_gather()
+    assert {r["kind"] for r in plain["hosts"]["workbench"]["windows"]} == {"tmux"}
+    assert plain["summary"]["kind"] == {"tmux": 5}
+
+    rep = gather_with_injected(monkeypatch, cluster_row(status="busy"))
+    kinds = [r["kind"] for r in rep["hosts"]["workbench"]["windows"]]
+    assert kinds.count("cluster") == 1, (
+        "the fold_windows seam did not deliver the constructed row: %r" % kinds)
+    # ...and it went through the REAL summarize, i.e. it was present before the
+    # roll-up ran rather than bolted on afterwards.
+    assert rep["summary"]["kind"] == {"tmux": 5, "cluster": 1}
+
+
+# --- the PREDICATE, unit --------------------------------------------------- #
+def test_the_claude_only_predicate_is_the_CLASS_axis_not_the_claude_FLAG():
+    """🔴 THE DEFECT. `row["claude"]` is `pane_current_command =~ /claude/` — a
+    fact about a PANE. A cluster dispatch has no pane, so `claude` is None,
+    which is FALSY, and `--claude-only` silently reclassified an AGENT as a
+    shell and deleted it. That is the identical conflation `row_class` exists
+    to prevent, one operation further along.
+
+    Every case is pinned, including the two that must be UNCHANGED, so a fix
+    that merely inverts something cannot pass.
+    """
+    claude_pane = {"kind": "tmux", "claude": True}
+    shell_pane = {"kind": "tmux", "claude": False}
+    # a pane whose command did not parse: genuinely "not a claude pane"
+    unparsed_pane = {"kind": "tmux", "claude": None}
+    dispatch = cluster_row()
+    kindless = {"kind": None, "claude": None}
+
+    assert sm.dropped_by_claude_only(shell_pane) is True
+    assert sm.dropped_by_claude_only(unparsed_pane) is True
+    assert sm.dropped_by_claude_only(claude_pane) is False
+    # 🔴 THE REGRESSION. `not row.get("claude")` returns True here.
+    assert sm.dropped_by_claude_only(dispatch) is False, (
+        "a cluster dispatch is an AGENT, not a shell — the flag must keep it")
+    assert dispatch["claude"] is None, (
+        "fixture no longer exercises the falsy-claude path this pins")
+    # ...and a cluster row that DOES assert claude:True is kept for the same
+    # reason, so the answer comes from `kind` and not from the flag either way.
+    assert sm.dropped_by_claude_only(cluster_row(claude=True)) is False
+    # a row whose kind nobody set is a BUG; filtering it out deletes the
+    # evidence, so it survives and stays visible in `unknown_kind`.
+    assert sm.dropped_by_claude_only(kindless) is False
+    assert sm.row_class(kindless) == "unknown_kind"
+
+
+def test_the_predicate_is_DERIVED_from_row_class_not_a_second_copy_of_it():
+    """🔴 ONE RULE, ONE PLACE — asserted BEHAVIOURALLY, because a structural
+    check would type-check past a copy that merely happens to agree today.
+
+    Move `row_class`'s answer to a value the predicate cannot coincidentally
+    equal and watch the predicate follow. A second open-coded classifier stays
+    put and fails here.
+    """
+    row = {"kind": "tmux", "claude": False}
+    assert sm.dropped_by_claude_only(row) is True    # control: it drops today
+    seen = []
+
+    def fake_class(r):
+        seen.append(r)
+        return "claude"
+
+    orig = sm.row_class
+    sm.row_class = fake_class
+    try:
+        assert sm.dropped_by_claude_only(row) is False, (
+            "the predicate ignored row_class — it holds a second copy of the "
+            "claude/shell rule, and the two will disagree")
+    finally:
+        sm.row_class = orig
+    assert seen == [row], "row_class was not consulted with the row itself"
+
+
+def test_gather_applies_the_ONE_predicate_rather_than_open_coding_it(
+        monkeypatch):
+    """The seam between the flag and its definition, pinned. `gather` used to
+    spell the rule inline (`if r.get("claude")`), which is how the definition
+    and its only caller drifted apart in the first place."""
+    calls = []
+    real = sm.dropped_by_claude_only
+
+    def spy(row):
+        calls.append(row)
+        return real(row)
+
+    monkeypatch.setattr(sm, "dropped_by_claude_only", spy)
+    rep = mix_gather(claude_only=True)
+    assert len(calls) == 5, (
+        "gather did not consult the predicate for every row: %d call(s)"
+        % len(calls))
+    assert rep["summary"]["excluded_shells"] == 2
+    # POSITIVE CONTROL on the spy: with the predicate forced to keep
+    # everything, the filter must keep everything. A spy nothing calls would
+    # leave this identical to the line above.
+    monkeypatch.setattr(sm, "dropped_by_claude_only", lambda r: False)
+    kept_all = mix_gather(claude_only=True)
+    assert kept_all["summary"]["total_sessions"] == 5
+    assert kept_all["summary"]["excluded_shells"] == 0
+
+
+# --- cluster rows SURVIVE the filter, end to end --------------------------- #
+def test_claude_only_KEEPS_a_cluster_dispatch_and_still_drops_the_shells(
+        monkeypatch):
+    """🔴 THE HEADLINE REGRESSION, through the real `gather` filter.
+
+    The mix fixture is 3 agents + 2 bare shells. Adding one cluster dispatch
+    must leave the shells dropped and the dispatch present — under the old
+    predicate the dispatch went with the shells, and `excluded_shells` counted
+    it as one of them.
+    """
+    rep = gather_with_injected(monkeypatch, cluster_row(status="busy"),
+                               claude_only=True)
+    rows = rep["hosts"]["workbench"]["windows"]
+    kinds = sorted(r["kind"] for r in rows)
+    assert kinds == ["cluster", "tmux", "tmux", "tmux"], (
+        "the cluster dispatch was filtered out with the shells")
+    assert sorted(sm.row_class(r) for r in rows) == [
+        "claude", "claude", "claude", "cluster"]
+    # exactly the two BARE SHELLS went, and the count says two — not three
+    assert rep["summary"]["excluded_shells"] == 2, (
+        "the dispatch was counted among the excluded shells")
+    assert rep["summary"]["total_sessions"] == 4
+    assert rep["summary"]["kind"] == {"tmux": 3, "cluster": 1}
+    assert rep["summary"]["status"]["busy"] == {
+        "claude": 0, "shell": 0, "cluster": 1, "total": 1}
+
+
+def test_a_cluster_only_host_under_claude_only_is_not_an_empty_scan(
+        monkeypatch):
+    """The direction that changes the EXIT CODE. A host whose only agent work
+    is a cluster dispatch used to filter down to nothing and exit EXIT_EMPTY —
+    "no agent windows" over a live dispatch."""
+    rep = gather_with_injected(
+        monkeypatch, cluster_row(status="busy"), claude_only=True,
+        runner=make_runner(local_panes=SHELLS_ONLY_PANES,
+                           local_windows=SHELLS_ONLY_WINDOWS))
+    assert rep["summary"]["total_sessions"] == 1
+    assert sm.exit_code_for(rep) == sm.EXIT_OK
+    assert sm.exit_code_for(rep) != sm.EXIT_EMPTY
+    assert rep["summary"]["excluded_shells"] == 1
+
+
+# --- ATTRIBUTION: what the filter removed, said out loud ------------------- #
+def test_a_kind_the_FILTER_removed_is_never_attributed_to_the_build(
+        monkeypatch):
+    """🔴 THE SECOND DEFECT, and it is REACHABLE TODAY with no cluster row
+    anywhere: `--claude-only` over a host whose tmux rows are all bare shells
+    removes the LAST `tmux` row, so `kinds_produced` measures `[]`.
+
+    The scan produced tmux rows. The filter removed them. Every claim the
+    caveat could make about `tmux` from `kinds_produced` alone would therefore
+    be about the wrong actor, and the reader most likely to be misled is the one
+    reading that line to find out what this build emits.
+    """
+    rep = gather_with_injected(
+        monkeypatch, cluster_row(status="busy"), claude_only=True,
+        runner=make_runner(local_panes=SHELLS_ONLY_PANES,
+                           local_windows=SHELLS_ONLY_WINDOWS))
+    kd = rep["caveats"]["kind_scope"]
+    assert kd["kinds_produced"] == ["cluster"]
+    assert kd["kinds_excluded_by_filter"] == ["tmux"]
+    assert rep["summary"]["kinds_excluded_by_filter"] == ["tmux"]
+    line = next(ln for ln in sm.render_caveats(rep) if "kind_scope" in ln)
+    # the false sentence the old code rendered, banned BY NAME
+    assert "tmux is ENUMERATED but NOT PRODUCED" not in line
+    assert "a FILTER REMOVED every kind=tmux row this scan produced" in line
+
+
+def test_the_filter_records_an_EMPTY_removal_set_distinctly_from_NO_FILTER():
+    """🔴 `[]` AND `None` ARE DIFFERENT FACTS, one level down from the rule this
+    file already applies to `excluded_shells`. `[]` says a filter ran and
+    removed no whole kind; `None` says nothing was ever measured. Collapsing
+    them lets a future reader treat an unfiltered scan as one that was checked
+    and came back clean."""
+    filtered = mix_gather(claude_only=True)
+    assert filtered["filters"]["kinds_excluded_by_filter"] == []
+    assert filtered["summary"]["kinds_excluded_by_filter"] == []
+    assert filtered["caveats"]["kind_scope"]["kinds_excluded_by_filter"] == []
+
+    off = mix_gather()
+    assert off["filters"]["kinds_excluded_by_filter"] is None
+    assert off["summary"]["kinds_excluded_by_filter"] is None
+    # 🔴 and the CAVEAT omits the key entirely rather than carrying a null —
+    # `_fmt_kind_scope` branches on its presence, so a None here would read as
+    # "a filter ran and removed nothing".
+    assert "kinds_excluded_by_filter" not in off["caveats"]["kind_scope"]
+
+
+def test_an_unfiltered_scan_still_renders_the_UNCHANGED_caveat_sentence():
+    """CONTROL. Every assertion above is about what changes under the flag; this
+    pins that nothing changes without it, so the new clause cannot leak into the
+    ordinary render."""
+    line = next(ln for ln in sm.render_caveats(mix_gather())
+                if "kind_scope" in ln)
+    assert line == (
+        "  caveat[kind_scope]: rows in this scan are kind=tmux — cluster is "
+        "ENUMERATED but NOT PRODUCED, so no such row appears and its absence "
+        "is NOT a measured zero; clawgate is reported separately under "
+        "BLOCKED ON ME")
+
+
+def test_the_FILTER_line_in_the_table_names_the_kind_it_removed():
+    """The rendered claim, pinned WHOLE. A word check on this line has been
+    walked before: "shell" and "kind" both appear in its own static prose."""
+    rep = mix_gather(
+        claude_only=True,
+        runner=make_runner(local_panes=SHELLS_ONLY_PANES,
+                           local_windows=SHELLS_ONLY_WINDOWS))
+    lines = [ln for ln in sm.render_table(rep).splitlines()
+             if "FILTER --claude-only" in ln]
+    assert lines == [
+        "  FILTER --claude-only: 1 shell window(s) excluded from every count "
+        "above",
+        "  FILTER --claude-only: it removed EVERY kind=tmux row this scan "
+        "produced — their absence above is the FILTER's doing, not a measured "
+        "absence",
+    ]
+    # ...and the second line is absent when no whole kind went (positive
+    # control on the pair: the SAME flag, one row different).
+    assert [ln for ln in sm.render_table(mix_gather(claude_only=True)).splitlines()
+            if "FILTER --claude-only" in ln] == [
+        "  FILTER --claude-only: 2 shell window(s) excluded from every count "
+        "above"]
+
+
+def test_measured_caveats_does_not_SHARE_the_excluded_kinds_with_the_report():
+    """🔴 The purity claim, extended to the field this change adds. `cav` is
+    deep-copied from CAVEATS, but the excluded-kinds list comes from
+    `report["filters"]` — a DIFFERENT object, so the deepcopy says nothing
+    about it. Handing the caller the report's own list lets a consumer writing
+    through the returned caveats mutate the report it was derived from."""
+    rep = {"hosts": {}, "filters": {"kinds_excluded_by_filter": ["cluster"]}}
+    out = sm.measured_caveats(rep)
+    got = out["kind_scope"]["kinds_excluded_by_filter"]
+    assert got == ["cluster"]
+    assert got is not rep["filters"]["kinds_excluded_by_filter"]
+    got.append("POISONED")
+    assert rep["filters"]["kinds_excluded_by_filter"] == ["cluster"]
+
+
+def test_measured_caveats_reads_the_excluded_kinds_where_they_are_RECORDED():
+    """🔴 It cannot recompute them: by the time this function runs the removed
+    rows are GONE, and only the filter ever saw them. So the derivation is a
+    lookup, and this feeds values that CANNOT coincide with anything derivable
+    from the rows — which is the trap this file has walked into five times."""
+    rep = {"hosts": {"h": {"windows": [{"kind": "tmux"}]}},
+           "filters": {"kinds_excluded_by_filter": ["zzz", "qqq"]}}
+    out = sm.measured_caveats(rep)["kind_scope"]
+    assert out["kinds_produced"] == ["tmux"]
+    assert out["kinds_excluded_by_filter"] == ["qqq", "zzz"], "sorted"
+    # ...and the render moves with it, so the field is not merely stored
+    line = sm._fmt_kind_scope(out)
+    assert "a FILTER REMOVED every kind=qqq/zzz row this scan produced" in line
 
 
 # --------------------------------------------------------------------------- #
@@ -6819,6 +7133,29 @@ KIND_SCOPE_SENTENCES = {
         "rows in this scan are kind=cluster/tmux — every enumerated kind IS "
         "produced, so this scan covers the whole entity axis; clawgate "
         "approval state is still reported separately under BLOCKED ON ME"),
+    # 🔴 A FILTER REMOVED A WHOLE KIND. Without its own clause this rendered
+    # "tmux is ENUMERATED but NOT PRODUCED" — three false claims in one
+    # sentence, about rows the scan had just measured and thrown away.
+    "filtered_out": (
+        "rows in this scan are kind=cluster — a FILTER REMOVED every kind=tmux "
+        "row this scan produced, so their absence above is the FILTER's doing "
+        "and NOT a measured absence of that work; " + _CG),
+    # a filter removed one kind AND another was never produced — both causes
+    # are named, and neither is allowed to absorb the other
+    "filtered_and_unproduced": (
+        "rows in this scan are kind=tmux — a FILTER REMOVED every kind=zzz row "
+        "this scan produced, so their absence above is the FILTER's doing and "
+        "NOT a measured absence of that work; cluster is ENUMERATED but NOT "
+        "PRODUCED, so no such row appears and its absence is NOT a measured "
+        "zero; " + _CG),
+    # 🔴 ZERO SURVIVING ROWS BECAUSE OF THE FILTER. "NO rows were measured in
+    # this scan" is FALSE here and blames the hosts for what the flag did —
+    # reachable TODAY, as `--claude-only` over a shell-only host.
+    "filtered_to_empty": (
+        "every row this scan measured was REMOVED BY A FILTER (kind=tmux), so "
+        "no kind survives to be reported — rows were measured and dropped, NOT "
+        "absent, and this says nothing about what an unfiltered scan holds; "
+        + _CG),
 }
 
 
@@ -6843,15 +7180,36 @@ def test_every_kind_scope_sentence_is_pinned_WHOLE_not_by_feature():
         # moment writer 3 lands, which is what this caveat is FOR.
         "by_construction_all_produced": sm._fmt_kind_scope(
             {"kinds_enumerated": ["tmux"]}),
+        # 🔴 THE FILTERED BRANCHES. `kinds_excluded_by_filter` is the field that
+        # separates "this build never emitted that kind" from "this run threw
+        # those rows away", and both of those render out of `kinds_produced`
+        # alone as the SAME sentence.
+        "filtered_out": sm._fmt_kind_scope(
+            {"kinds_produced": ["cluster"], "kinds_enumerated": E,
+             "kinds_excluded_by_filter": ["tmux"]}),
+        # `zzz` cannot be a member of KINDS, so the filter slot is proved LIVE
+        # rather than coincident with a constant this module already holds.
+        "filtered_and_unproduced": sm._fmt_kind_scope(
+            {"kinds_produced": ["tmux"], "kinds_enumerated": ["tmux", "cluster",
+                                                              "zzz"],
+             "kinds_excluded_by_filter": ["zzz"]}),
+        "filtered_to_empty": sm._fmt_kind_scope(
+            {"kinds_produced": [], "kinds_enumerated": E,
+             "kinds_excluded_by_filter": ["tmux"]}),
     }
     assert got == KIND_SCOPE_SENTENCES
-    # INSTRUMENT CHECK: all five are genuinely distinct, so a builder that
+    # INSTRUMENT CHECK: all eight are genuinely distinct, so a builder that
     # collapsed two branches into one could not satisfy this by accident.
-    assert len(set(got.values())) == 5
+    assert len(set(got.values())) == 8
     # the three that must never phrase themselves as a measurement of a scan
     assert "in this scan are" not in got["missing"]
     assert "kind=" not in got["empty"]
     assert "this scan" not in got["by_construction_all_produced"]
+    # 🔴 the two claims a filtered branch must NEVER make about a kind the
+    # filter removed, banned by name in the branches that could make them
+    assert "tmux is ENUMERATED but NOT PRODUCED" not in got["filtered_out"]
+    assert "every enumerated kind IS produced" not in got["filtered_out"]
+    assert "NO rows were measured" not in got["filtered_to_empty"]
 
 
 def test_the_BY_CONSTRUCTION_slot_IS_LIVE_not_a_coincident_literal(monkeypatch):
@@ -6955,9 +7313,11 @@ def test_the_kind_scope_NOTE_is_pinned_WHOLE():
         "`kinds_produced` is MEASURED from this scan's rows — read it rather "
         "than assuming. A kind that is enumerated but absent from "
         "`kinds_produced` was NOT LOOKED FOR by this build, so its absence is "
-        "NOT a measured absence of that work. For clawgate use "
-        "report.blocked_on_me (tasks needing the operator, and its "
-        "`stuck_count` for wedged dispatches), a different population from "
+        "NOT a measured absence of that work — UNLESS it is named in "
+        "`kinds_excluded_by_filter`, which is where a kind removed by a filter "
+        "is reported instead of being silently attributed to the build. For "
+        "clawgate use report.blocked_on_me (tasks needing the operator, and "
+        "its `stuck_count` for wedged dispatches), a different population from "
         "these rows that is never double-counted with them.")
 
 

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -4145,10 +4145,45 @@ def test_the_filter_records_an_EMPTY_removal_set_distinctly_from_NO_FILTER():
     off = mix_gather()
     assert off["filters"]["kinds_excluded_by_filter"] is None
     assert off["summary"]["kinds_excluded_by_filter"] is None
-    # 🔴 and the CAVEAT omits the key entirely rather than carrying a null —
-    # `_fmt_kind_scope` branches on its presence, so a None here would read as
-    # "a filter ran and removed nothing".
+    # 🔴 and the CAVEAT omits the key entirely rather than carrying a null, so
+    # the JSON reader sees the same not-measured-vs-measured-none distinction
+    # here as in the two surfaces above. A null would spell "a filter ran"
+    # inside a structure whose other two keys spell "none ran".
+    #
+    # 🔴 THE RENDERER DELIBERATELY DOES NOT DISTINGUISH THEM, and an earlier
+    # version of this comment claimed it did ("`_fmt_kind_scope` branches on its
+    # presence") — it does not; it is `kd.get(...) or []`. Pinned as behaviour
+    # by `test_the_kind_scope_RENDER_collapses_missing_and_empty_deliberately`,
+    # with the reasoning there.
     assert "kinds_excluded_by_filter" not in off["caveats"]["kind_scope"]
+
+
+def test_the_kind_scope_RENDER_collapses_missing_and_empty_deliberately():
+    """🔴 THE PROSE ASKS A NARROWER QUESTION THAN THE JSON, and that is the
+    whole reason the two surfaces differ. `_fmt_kind_scope` asks only WHICH
+    WHOLE KINDS A FILTER TOOK — every clause it can emit about the filter is
+    guarded on a non-empty list. "No filter ran" and "a filter ran and took no
+    whole kind" give the same answer to that question, so rendering them
+    differently would mean inventing a sentence about a filter that removed
+    nothing.
+
+    Contrast `kinds_produced` one field over, where missing and empty ARE
+    different sentences ("no scan happened, describe the build" vs "a scan
+    measured zero rows") and an `or` would be the literal-masquerading-as-a-
+    measurement bug that field's guard exists to prevent. The asymmetry is the
+    point; this pins it so the docstring stating it is machine-checked.
+    """
+    base = {"kinds_produced": ["tmux"], "kinds_enumerated": ["cluster", "tmux"]}
+    missing = sm._fmt_kind_scope(dict(base))
+    empty = sm._fmt_kind_scope(dict(base, kinds_excluded_by_filter=[]))
+    assert missing == empty, (missing, empty)
+    # ...and a POSITIVE CONTROL, or the equality above is satisfiable by a
+    # renderer that ignores the field entirely.
+    populated = sm._fmt_kind_scope(
+        dict(base, kinds_excluded_by_filter=["cluster"]))
+    assert populated != missing
+    assert "a FILTER REMOVED every kind=cluster row this scan produced" in populated
+    assert "a FILTER REMOVED" not in missing
 
 
 def test_an_unfiltered_scan_still_renders_the_UNCHANGED_caveat_sentence():


### PR DESCRIPTION
Two related changes, both about a measurement that could not tell "this build never emitted it" from "something removed it".

Base: `4eabdb3` — still exactly `origin/main` at time of writing, so the branch tree **is** the merged tree.

---

## Change 1 — `--claude-only` misattributed a filtered row to the build

`scripts/session-manager`

### 1a. The predicate was a spelling, not a rule

The filter was `[r for r in windows if r.get("claude")]`. `row["claude"]` is `pane_current_command =~ /claude/` — a fact about a **pane**. A `cluster` row (a dispatch with no pane) carries `claude: None`, which is falsy, so the flag silently reclassified every cluster **agent** as a shell *and deleted it*. That is the identical conflation `row_class` exists to prevent, one operation further along.

Now there is one definition:

```python
def dropped_by_claude_only(row) -> bool:
    return row_class(row) == "shell"
```

- `claude` tmux row → kept (unchanged)
- `shell` tmux row → dropped (unchanged), including one whose title contains "claude"
- `cluster` row → **kept** — it is an agent
- `unknown_kind` row → **kept** — a row whose kind nobody set is a bug, and filtering it deletes the evidence

`gather` calls that function rather than open-coding the rule (pinned behaviourally by a spy, not by a source grep).

### 1b. The attribution was wrong, and it is reachable *today*

The filter runs **before** `summarize` and `measured_caveats`, both of which derive from the rows that survived. So a kind the filter removed entirely showed up in `kinds_produced` as a kind this build never emits, and rendered:

> `cluster is ENUMERATED but NOT PRODUCED, so no such row appears and its absence is NOT a measured zero`

False in all three clauses. Same class as `fuzzyclaw_scope` in #471 — a machine-readable claim outliving the code it describes — and the #471 fix is what created it, because it made `kinds_produced` measured *from rows* without asking **which** rows.

**The fix keeps `kinds_produced` describing the RENDERED set**, so the caveat line and the table above it still cannot disagree. Deriving it from the unfiltered rows would have swapped one disagreement for another (a line reading `kind=cluster/tmux` printed over a table with no cluster row in it). What the filter took is published as its own measured field:

- `filters.kinds_excluded_by_filter` → `summary.kinds_excluded_by_filter` → `caveats.kind_scope.kinds_excluded_by_filter`
- **absent** when no filter ran; `[]` when one ran and removed no whole kind — the same not-measured-vs-measured-none distinction as `excluded_shells` being `null` rather than `0`
- the rendered caveat gains `a FILTER REMOVED every kind=… row this scan produced, so their absence above is the FILTER's doing and NOT a measured absence of that work`
- the zero-row branch gets its own filtered variant: `NO rows were measured in this scan` is **false** of a `--claude-only` run over a shell-only host

🔴 **Reachable with no cluster row anywhere**: `--claude-only` over a host whose tmux rows are all bare shells removes the last `tmux` row.

### Breaking change

`summary.excluded_non_claude` → **`summary.excluded_shells`**. Once cluster rows are kept, "non_claude" names a set strictly larger than the one counted, and a reader would take a cluster row to be inside it. A KeyError is a better morning than an integer that quietly means something else — the same trade this summary already made when the flat per-status ints were removed. Rendered line follows: `N shell window(s) excluded`.

Also: `row_kind()` consolidates the `r.get("kind") or "none"` coercion that was open-coded at three sites.

---

## Change 2 — the fuzzyclaw phase-2 gate, as `rc 16`

`scripts/drift-check.sh` + new `scripts/lib/drift_phase2.py`

"Is it safe to delete the fuzzyclaw readers?" was answered by a human remembering to run a probe — the same shape as "nothing runs `ship.sh` on a schedule", which is the failure this deadman exists to convert into a measurement.

`summary.age_sources.fuzzyclaw` counts the rows whose age **no other writer supplied**. Measured on the workbench 2026-08-15: **7 of 47** locally, and the same 7 in a two-host scan of 75 — fuzzyclaw task files are LOCAL state (`gather` passes its task index only for `host == local_host`), so a remote row structurally cannot carry a fuzzyclaw age. Hence local-only: same numerator, no ssh.

**`rc 16` is ACTIONABLE, not drift.** The final line says `ACTIONABLE (not drift) (rc=16)`, and it is the least severe code this file owns, so it can only ever be the verdict on an otherwise-clean run. A gate that went red for today's *normal* state would be permanently red, which trains the operator to click through the one alert that has to keep its meaning.

### The zero is the dangerous direction

The answer this gate hands over is a **deletion**, and every way it can break produces the number that authorises one. Each is its own reason token and lands in `COULD NOT MEASURE`, never a zero:

| failure | token |
|---|---|
| no session-manager on this checkout | (own branch) |
| crashed / empty / truncated scan | `no-json:…` |
| malformed counts | `no-counts` |
| scan of the **wrong host** — session-manager and drift-check resolve "local" by *different* predicates | `host-mismatch:<got>` |
| fuzzyclaw not actually read (it is opt-in) | `fuzzyclaw-<status>` |
| `status: ok` with `files_seen: 0` — what an absent `~/.tmux/tasks` looks like | `fuzzyclaw-no-task-files` |

That last one is **measured, not imagined**: the first version of this gate announced *"READY — 0 of 48 rows"* off the test suite's fixture `$HOME` while the real count on that machine was 7. `status == "ok"` is necessary and **not** sufficient.

And the count is never printed alone — `N of M row(s) EXAMINED`, with `0 of 0` reported as `COULD NOT MEASURE`, the same `examined=` beside `dangling=` rule the managed-symlink scan already follows.

### Fallout fixed along the way

🔴 **A live hermeticity breach.** Adding the gate revealed that every test in `test_drift_check.py` was executing the operator's **real** `session-manager` against 48 live tmux windows. `DRIFT_SESSION_MANAGER` is now stubbed by default in the fixture, exactly like `ssh`.

`pkgs.python3` + `pkgs.tmux` join the unit PATH **for the child**, pinned by a new `CHILD_PATH_REQUIREMENTS` ledger — a seam neither existing PATH guard can see (neither word appears as a command in `drift-check.sh`, so the reverse tokenizer cannot find them and the forward table would reject them). Its failure is silent: `COULD NOT MEASURE` on every timer run, forever, from a unit that looks correct.

`drift_phase2.py` is a separate file rather than a `python3 -c` string because the suite's shell tokenizer splits on `(` and `{`, so inlined Python sprays dozens of false command words at the PATH guard. Kept out, `drift-check.sh` gains exactly one new command word.

---

## Verification

**Gate (authoritative, read from `nix log`, not from a pipe):**

- `nix build .#checks.x86_64-linux.pytests` → `RESULT: PASS (exit=0)`, `TOTAL collected=10656 passed=10655 skipped=1 failed=0` (floor 9543 = sum of 22 per-target floors). `scripts/tests collected=4612 floor=3970` — no floor drifted, so no floor was touched.
- `nix build .#checks.x86_64-linux.nodetests` → `RESULT: PASS (exit=0)`, `TOTAL suites=4 files=33 tests=1116 pass=1116 fail=0` (floor 1098).

**Red-at-base / green-at-HEAD** (new tests run against `origin/main`'s `session-manager` / `drift-check.sh` / `home.nix` with `drift_phase2.py` absent):

- Change 1: **20 red at base**, all green at HEAD.
- Change 2: **18 red at base**, all green at HEAD.
- **Green at base, labelled in-source as controls, NOT counted as regression coverage** (4): the two injection-seam/instrument checks, the unfiltered-render control, the non-interference guard, and the child-PATH ledger invariant guard.

**Mutation sweep** — `PYTHONDONTWRITEBYTECODE=1`, `__pycache__` deleted before every run, each mutation proved applied by *sha change* **and** *byte-equality with the constructed mutant*:

- **38 mutants, 0 mismatches.** 35 real mutants across operand swap, branch inversion, comment-out, wrong bind, off-by-one, comparison flip, guard-unreachable and aliasing — **all KILLED**.
- **Positive control** (`PC-rendered-claim`, a reworded pinned claim) → **KILLED**.
- **Negative controls** (`NC-local-rename`, a genuine local-variable rename; `NC-setcomp-to-genexp`) → **SURVIVED**.
- The applied-proof earned its keep: on the first pass it caught two patterns that did **not** apply and reported them `NOT-APPLIED` instead of scoring them SURVIVED.

**Live, against the real host, on the committed tree** (`git status` clean at the time):

```
$ ./scripts/session-manager scan --json --no-ch --no-capture --fuzzyclaw --host workbench \
    | python3 scripts/lib/drift_phase2.py workbench
ok 49 7

$ bash scripts/drift-check.sh --no-remote
=== fuzzyclaw phase-2 readiness (workbench) ===
[phase2] fuzzyclaw-only ages: 7 of 49 row(s) EXAMINED
[phase2] NOT READY — 7 of 49 row(s) still take their age ONLY from
[phase2]   fuzzyclaw. …
```

`--claude-only` live: `excluded_shells: 10`, `kinds_excluded_by_filter: []`, caveat unchanged — as designed, since a real scan is 100% tmux.

---

## Deliberately NOT done

- **`filter_report` (the `detail` path) keeps its current behaviour.** Narrowing to one window by address also removes kinds, and that path re-derives the caveat so it can still render "cluster is ENUMERATED but NOT PRODUCED" over a one-row table. That is a deliberate existing design decision with its own pinned test, and the brief scoped this to `--claude-only`. Flagging it as an adjacent gap rather than silently widening the change.
- **The `--claude-only` flag was not renamed**, only redefined against the CLASS axis.
- **`kinds_excluded_by_filter` is not duplicated into a fourth place.** It lives on `filters`, is mirrored into `summary`, and is copied into the caveat; no separate recomputation anywhere.
- Not deployed — no `home-manager switch`, no `ship.sh`. `nix/home.nix` changed, so both hosts need a switch after merge for the unit PATH to carry `python3`/`tmux`.

## Regressions introduced

One, knowingly: **`summary.excluded_non_claude` is gone** (renamed). Every in-repo consumer was updated (`SKILL.md`, `reference/exit-codes.md`, the script, the suite); there are no others. Any out-of-repo reader gets a `KeyError` rather than a silently re-scoped integer — chosen deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rwzAkPvjXK9E2aM9zwBMa

---

## Round 2 — adversarial-audit fixes (`2cd2761`)

Two 🔴 from the audit, plus the cheap items. Both 🔴 were verified against live state before fixing, and neither was visible from the diff alone.

### 🔴 rc 16 permanently failed the unit and fired the DND-defeating toast 4×/day

`Type = "oneshot"` fails the unit on any non-zero exit, `OnFailure = notify-failure@%n.service` was already wired, and that toast is the ONE class deliberately built to defeat do-not-disturb (`zz_notify_failure_bypass`, `override_pause_level = 100`, `fullscreen = "show"`) — a bypass this file justifies with a **measured** ~1-firing-in-9-days rate. rc 16 stays set until somebody deletes the readers and the timer is `OnUnitActiveSec = 6h`, so the gate opening would have made it **4×/day, forever**, over runs where nothing is wrong.

Verified live before fixing: `systemctl --user cat drift-check.service` had no `SuccessExitStatus`, and `notify-failure@drift-check.service.service` is loaded and has run.

Fix: `SuccessExitStatus = 16` on the service. The script still exits 16, still prints the `ACTIONABLE (not drift)` verdict and the READY block, and a hand-run still surfaces both (`ExecMainStatus` reads 16 even on a `success` unit). Pinned by `test_the_unit_does_not_fail_on_the_phase2_actionable_code`, asserted **together with** the `OnFailure` line so deleting the alert cannot green it, plus `test_only_16_is_excused_from_failing_the_unit` (`SuccessExitStatus` is a list; a second entry would mute a real drift verdict).

### 🔴 A third structural zero: `summary.age_sources` was never validated

`(summ.get("age_sources") or {}).get("fuzzyclaw", 0)` had no presence or type check, so the key **absent**, the key **renamed**, the key holding a **non-dict**, and a report from a **session-manager predating the field** (`age_sources` landed 2026-08-13) all collapsed to `0` — the number that authorises the deletion. End to end with a stub emitting only `{"summary":{"total_sessions":47}}` the run printed `🔴 READY — 0 of 47 rows depend on fuzzyclaw`, byte-identical to a legitimate READY.

Reachable on the one host shape this deadman exists for: `DRIFT_SESSION_MANAGER` defaults to the checkout's own `scripts/session-manager`, so a host three days behind ran a scan with no `age_sources` and got READY — the staleness detector disabled by staleness. The suite could not see it (`Fleet.sm_report` always emitted the field), and the auditor's mutant `.get("fuzzyclaw", 0)` → `1` **SURVIVED** a fully green run.

Three guards, and the third is what makes the second safe:

| condition | token |
|---|---|
| `age_sources` absent or not a dict | `no-age-sources` |
| a key outside `{fuzzyclaw, ledger, none}` | `unknown-age-writer:<k>` |
| the histogram does not account for `total_sessions` | `age-sources-incoherent:<n>` |

An **absent `fuzzyclaw` key inside a sound histogram stays a real measured zero** — `_count_by` creates a key only for a value it observed, so a genuine all-clear scan omits it, and a gate that refused that could never open. It is a measurement precisely because the vocabulary is recognised (not renamed) and the histogram is complete (not truncated). Documented and pinned.

**The structural fix, so there is no fourth:** `test_the_phase2_reason_token_ledger_is_pinned_to_the_fields_read` ast-extracts the tokens the reader EMITS and the report fields it READS, pins both two-way, and fails when either grows or shrinks — so consulting a new field without giving its absence a token is a red test. A behavioural half drives every declared token from a payload that must produce it, because a structural ledger type-checks past an unreachable branch.

`Fleet.sm_report`'s own histogram turned out to be **incoherent** — the literal `{fuzzyclaw: fuzzy, ledger: 27, none: 13}` sums to `fuzzy + 40` regardless of `rows`, so the fixture behind the whole READY path accounted for 40 of 47 rows. It is now built by `age_histogram()`, which also spells a zero the way the producer does: by absence.

The three claims this falsified (`CLAUDE.md`, the `drift-check.sh` header, the `drift_phase2.py` docstring) are corrected rather than restated, and each now names the test that enforces it.

### Also in this round

- **rc 16 prints the affirmative line too.** "no drift on the host(s) CHECKED" and "a cleanup became possible" are independent claims; suppressing the first made an rc 16 over a clean host indistinguishable from an rc 16 over a host nobody vouched for.
- **A malformed reader line no longer fabricates a denominator.** Found by the sweep: `${x%% *}` and `${x##* }` both return the whole string when it holds no space, so a two-field line `ok 47` set both counts from field 2 and printed `47 of 47 row(s) EXAMINED`. Fail-safe by luck, not by construction. The field count is now checked. Driven by a test that runs a **copy** of the checker with a stub `lib/drift_phase2.py`, since the reader path is derived from the script's own dirname and is not env-overridable — that is why both numeric filters had surviving removal mutants.
- **`_fmt_kind_scope`'s docstring** claimed missing and `[]` "must not collapse" three lines above an `or []` that collapses them. The renderer is right (it asks only which whole kinds a filter took, and both answer "none"); the docstring now states the asymmetry with `kinds_produced`, and a test pins it. A second comment in `test_session_manager.py` asserting the same false mechanism is corrected.
- Reason tokens are sanitised — a JSON key or host name with a space would truncate the reason and shift both counts, since the shell reads the token as `${p2_out%% *}`.
- `require_int DRIFT_PHASE2_TIMEOUT` and the `isinstance(rows, bool)` guards both had surviving removal mutants; both now have tests. The bool one is read at the reader, because through the shell it is genuinely unobservable (the numeric filter reaches the right verdict by a different mechanism).
- `reference/exit-codes.md`: the **script** is the authority on a field name, not the skill doc — skills deploy as a nix-store copy, so between `git pull` and `home-manager switch` the doc is the stale one.

### Verification

- **Red/green:** 13 tests red at `494d14d`, green at `2cd2761`. The rest of the additions are labelled in-file as controls or invariant guards, not regression coverage.
- **Mutation:** 40 mutants across three **differently-constructed** batteries (guard-removal/inversion; constant-hardcode + shell-consumption + pre-existing guards; direction-corrected re-runs). Each applied under `PYTHONDONTWRITEBYTECODE=1` with `__pycache__` dropped, into a per-mutant `git archive` tree with no `.git`, proved applied by sha change **and** byte-equality. **38 killed, 2 survived**, both analysed and demonstrated **equivalent**, not gaps:
  - `severity() 16) echo 20 → 1`: `severity` is higher-is-worse and 16 is already the floor, so this is a no-op. The three directions that *do* change behaviour (16 outranking rc 8, 16 collapsing into 0, rc 8 demoted below 16) are all KILLED.
  - `[ -z "$p2_out" ]` removed: redundant with the two `case` filters below it, whose own removals are now both KILLED.
  - The auditor's three survivors (`.get("fuzzyclaw", 0)`→`1`, the `require_int` removal, the `isinstance bool` removal) are all **KILLED**.
  - Controls reported both ways: a positive control that must die (`note_rc 16` neutered → KILLED) and a negative control that must survive (a comment reworded → SURVIVED).
- **Gate, from `nix log`:** `pytests` — `TOTAL collected=10683 passed=10682 skipped=1 failed=0`, `RESULT: PASS (exit=0)`. `nodetests` — `TOTAL suites=4 files=33 tests=1116 pass=1116 fail=0`, `RESULT: PASS (exit=0)`.
- Not deployed. `nix/home.nix` changed, so both hosts still need a `home-manager switch` after merge — now for `SuccessExitStatus` as well as the unit PATH.

### Follow-up, NOT this PR

`scripts/tests/test_agent_ledger.py` (7 calls) and `scripts/tests/test_claude_runs_block.py` (2 calls) reach the operator's **live tmux**. Pre-existing, unrelated to this change, and the same class of hermeticity breach this PR already closed for `test_drift_check.py` via the `DRIFT_SESSION_MANAGER` stub. Worth its own PR.
