### PR TITLE
feat(signal): the devrc half of the Signal chat pipeline — a send path that CANNOT transmit without approval

### DIFF
--- a/claude/skills/signal/SKILL.md
+++ b/claude/skills/signal/SKILL.md
@@ -11,8 +11,8 @@ receive → store → query → automate. Same Postgres instance as the mailbox,
 
 ```
 Zach's phone (Signal)  ──linked secondary device──►  signal-cli-rest-api
-                                                     (ns signal, json-rpc-native)
-                                                          │ SSE /api/v1/events
+                                                     (ns signal, json-rpc mode)
+                                        │ WEBSOCKET  GET /v1/receive/{number}
                                                           ▼
                                              scripts/signal/consumer.py
                                           ├─► Postgres  signal.*  (mailbox-postgres-0)
@@ -31,8 +31,9 @@ code route and will raise `SendGateError`.
 | Tests | `scripts/signal/tests/` — hermetic (sqlite substrate + fixtures), in the pytest gate |
 | Manifests | `homelab-talos: clusters/homelab/apps/signal/`, parent ks `clusters/homelab/flux-system/root-kustomizations/system/signal.yaml` |
 | API | `signal-cli-rest-api`, ns `signal`, ClusterIP `signal-api.signal.svc:8080`, **pinned tag** (never `:latest`), `replicas: 1` |
+| Routes | the WHOLE surface this server has: `GET /v1/receive/{number}` (a **websocket** in json-rpc mode), `GET /v1/attachments/{id}`, `POST /v2/send`. There is **no SSE endpoint** — `/api/v1/events` belongs to AsamK's native daemon, a different server |
 | Postgres | `mailbox-postgres-0` in ns `mailbox`, schema **`signal`** (shares the instance + role with `mail`) |
-| Attachments | MinIO archive tenant, bucket `signal-attachments`, key `{conversation}/{YYYY-MM-DD}/{filename}` + a `.json` sidecar |
+| Attachments | MinIO archive tenant, bucket `signal-attachments`, key `{conversation}/{YYYY-MM-DD}/{attachment_id}_{filename}` + a `.json` sidecar. The id is in the key deliberately — see gotchas |
 | Tables | `signal.contacts`, `signal.groups`, `signal.messages`, `signal.attachments`, `signal.reactions` |
 | Search | `signal.messages.search` — a STORED `to_tsvector('english', body)` generated column with a GIN index |
 
@@ -78,14 +79,30 @@ composes and transmits**.
    **negative provisional timestamp**, then posts a clawgate Task card (a graceful
    no-op returning `False` when `CLAWGATE_HOOK_TOKEN` is unset — the draft is already
    durable, so a missing token costs the notification, never the record).
-2. Zach approves in clawgate; `approve <id> --ref <clawgate-ref>` records it.
-3. `send` mints a single-use `SendAuthorization` — which `_mint_send_authorization()`
-   refuses to produce unless the stored `send_state` is exactly `approved` — and
-   `consumer.transmit_approved()` refuses to post without one. The capability's
-   constructor refuses direct construction; a spent capability cannot be replayed.
+2. Zach approves in clawgate; `approve <id> --ref <clawgate-ref>` records it. **This
+   is the operator's command**, run from the operator's own shell — it needs
+   `SIGNAL_APPROVAL_TOKEN`, which no agent environment carries.
+3. `send` claims the draft (`send_state=sending`, committed **before** anything is
+   transmitted), then mints a single-use `SendAuthorization` — which
+   `_mint_send_authorization()` refuses to produce unless the stored `send_state` is
+   exactly `approved` — and `consumer.transmit_approved()` refuses to post without
+   one. The capability's constructor refuses direct construction; a spent capability
+   cannot be replayed.
 
 Every refusal raises **`SendGateError`**. `scripts/signal/tests/test_approval_gate.py`
 attempts six documented bypasses and requires each to fail with that error.
+
+🔴 **What D3 does and does not prove.** Structural: composing and transmitting are
+separate calls with durable state in between, an un-approved draft has no code route
+to the API, and a crash mid-send cannot resend. **Not** structural: nothing inside the
+process can prove a *human* called `approve` — the token is a speed bump, not a proof
+of humanity. Treat the approval record as an audit trail, and keep the token out of
+every agent environment.
+
+**A draft stuck in `sending`** means the POST was attempted and the outcome is
+unknown (crash, dropped connection, or per-recipient errors from the API). It is
+deliberately inert — nothing can mint from it — so it will never resend on its own.
+Check Signal, then reconcile by hand: `drafts --state sending`.
 
 ## Event kinds the consumer emits
 
@@ -99,6 +116,7 @@ attempts six documented bypasses and requires each to fail with that error.
 | `receipt_delivery` | a delivery receipt |
 | `receipt_read` | a read receipt |
 | `typing` | a typing indicator |
+| `remote_delete` | the sender RETRACTED a message — the target row is tombstoned (body and attachments removed), not stored as an empty message |
 | `unknown` | a handled envelope shape we do not model — counted and retained, never dropped |
 
 `message`, `group_message`, `edit`, `sync_outbound` and `reaction` are STORED; the rest
@@ -113,6 +131,8 @@ are counted only.
 | `malformed` | payloads skipped as unparseable — never fatal |
 | `reconnects` | SSE stream drops recovered from |
 | `db_retries` | transient Postgres faults retried rather than dropped |
+| `db_recoveries` | aborted transactions rolled back (or connections re-opened) so the next event can be written |
+| `db_recovery_failures` | recovery itself failed — the pod cannot write and needs looking at |
 | `attachment_failures` | attachment fetch/upload failures — the MESSAGE row still stands |
 
 ## Environment
@@ -124,7 +144,8 @@ are counted only.
 | `SIGNAL_PG_PORT` | port override for direct mode |
 | `SIGNAL_PG_DIRECT` | truthy → direct mode using the DSN's own host/port |
 | `SIGNAL_API_URL` | signal-cli-rest-api base URL (default `http://signal-api.signal.svc:8080`) |
-| `SIGNAL_ACCOUNT` | the account's own phone number, used as the sender of a draft |
+| `SIGNAL_ACCOUNT` | the account's own phone number. Required TWICE: the receive endpoint is per-account (`/v1/receive/{number}`) and `/v2/send` rejects a missing `number` with 400 |
+| `SIGNAL_APPROVAL_TOKEN` | must be set for `approve` to run. **Operator-only** — deliberately absent from the Deployment and from agent environments |
 | `CLAWGATE_HOOK_TOKEN` | clawgate hook token; unset → draft cards are a graceful no-op |
 | `MINIO_ARCHIVE_ENDPOINT` | explicit MinIO endpoint (skips the port-forward) |
 | `MINIO_ARCHIVE_ACCESS_KEY` | MinIO credentials; else read from `minio-archive-config` |
@@ -150,6 +171,22 @@ and tear it down on exit — exactly like `mail-actions`.
   `idx_rx_unresolved`. Unresolvable reactions are RETAINED, not dropped.
 - **Redelivery duplicates attachments** without `UNIQUE (message_id,
   signal_attachment_id)`.
+- **One person must be ONE contact row, in both arrival orders.** An identity arrives
+  as a bare number (a draft) or as a uuid (every envelope). `upsert_contact` looks up
+  by phone AND promotes a placeholder to its real uuid, because two rows for one
+  person means the echo lands under a different `source_contact_id` and dedupe never
+  fires — every agent-sent message stored twice.
+- **The attachment id is part of the MinIO key.** Without it, two `Screenshot.png` in
+  one conversation on one day collide, the second write is skipped as "already
+  there", and its row points at the first file's bytes.
+- **A failed statement poisons the whole transaction.** `autocommit=False` +
+  Postgres = every later statement raises `InFailedSqlTransaction` until a rollback.
+  The consumer recovers inside its retry (`db_recoveries`); without that the pod logs
+  "reconnecting" forever and stores nothing.
+- **Retention is NOT implemented.** `expires_in_seconds` and `view_once` are STORED
+  and never acted on: a disappearing message stays in Postgres forever. `remote_delete`
+  IS honoured (the target is tombstoned), but nothing sweeps expiry. If that matters,
+  it is a separate piece of work — do not assume the archive respects Signal's timers.
 - **Attachments are fetched AFTER the message row is committed** — a failed download
   must never roll back a message. `minio_key IS NULL` is the honest marker for "row
   stored, bytes not archived".

--- a/claude/skills/signal/SKILL.md
+++ b/claude/skills/signal/SKILL.md
@@ -31,7 +31,7 @@ code route and will raise `SendGateError`.
 | Tests | `scripts/signal/tests/` — hermetic (sqlite substrate + fixtures), in the pytest gate |
 | Manifests | `homelab-talos: clusters/homelab/apps/signal/`, parent ks `clusters/homelab/flux-system/root-kustomizations/system/signal.yaml` |
 | API | `signal-cli-rest-api`, ns `signal`, ClusterIP `signal-api.signal.svc:8080`, **pinned tag** (never `:latest`), `replicas: 1` |
-| Routes | the WHOLE surface this server has: `GET /v1/receive/{number}` (a **websocket** in json-rpc mode), `GET /v1/attachments/{id}`, `POST /v2/send`. There is **no SSE endpoint** — `/api/v1/events` belongs to AsamK's native daemon, a different server |
+| Routes | the three this module speaks (the server has many more): `GET /v1/receive/{number}` (a **websocket** in json-rpc mode), `GET /v1/attachments/{id}`, `POST /v2/send`. It has **no event-stream endpoint** — `/api/v1/events` belongs to AsamK's native daemon, a different server |
 | Postgres | `mailbox-postgres-0` in ns `mailbox`, schema **`signal`** (shares the instance + role with `mail`) |
 | Attachments | MinIO archive tenant, bucket `signal-attachments`, key `{conversation}/{YYYY-MM-DD}/{attachment_id}_{filename}` + a `.json` sidecar. The id is in the key deliberately — see gotchas |
 | Tables | `signal.contacts`, `signal.groups`, `signal.messages`, `signal.attachments`, `signal.reactions` |
@@ -41,13 +41,14 @@ code route and will raise `SendGateError`.
 
 | Command | What it does |
 |---|---|
-| `run` | consume the SSE stream forever — this is what the Deployment runs |
+| `run` | consume `/v1/receive/{number}` forever — this is what the Deployment runs |
 | `conversations` | list conversations (group, else the DM peer), newest first |
 | `search` | full-text search over message bodies (`websearch_to_tsquery`) |
 | `draft` | compose an outbound draft — **stores it, transmits nothing** |
 | `drafts` | list drafts with their `send_state` |
 | `approve` | record Zach's clawgate approval for one pending draft |
 | `send` | transmit an **approved** draft (refuses anything else) |
+| `reconcile` | resolve a draft stranded in `sending`, after checking Signal yourself |
 
 ```bash
 cd ~/workspace/devrc/scripts/signal
@@ -57,6 +58,11 @@ python3 consumer.py draft --to +15550100 --body "on my way"   # -> pending + a c
 python3 consumer.py drafts --state pending
 python3 consumer.py approve 42 --ref clawgate-task-91
 python3 consumer.py send 42
+
+# a draft stuck in `sending` — check Signal FIRST, then say which happened:
+python3 consumer.py drafts --state sending
+python3 consumer.py reconcile 42 --sent --timestamp 1723000009090   # it did go out
+python3 consumer.py reconcile 42 --not-sent --note "no message in the thread"
 ```
 
 Direct SQL (the store is authoritative):
@@ -101,8 +107,19 @@ every agent environment.
 
 **A draft stuck in `sending`** means the POST was attempted and the outcome is
 unknown (crash, dropped connection, or per-recipient errors from the API). It is
-deliberately inert — nothing can mint from it — so it will never resend on its own.
-Check Signal, then reconcile by hand: `drafts --state sending`.
+deliberately inert — nothing can mint from it — so it will never resend on its own,
+and nothing but you can get it out again.
+
+Check the Signal conversation, then record what you saw with **`reconcile`** (same
+operator token as `approve`):
+- `reconcile <id> --sent --timestamp <server-ts>` — it DID go out. Give the server
+  timestamp from the conversation so the sync echo still dedupes (🔧 #4).
+- `reconcile <id> --not-sent [--note "…"]` — it did not. Returns the draft to
+  `pending`, so it needs a **fresh approval** before anything can send it: a retry
+  never rides on the old one.
+
+`--sent` refuses a missing or unusable timestamp rather than guessing, and
+`reconcile` refuses any draft that is not `sending` — it is not a state editor.
 
 ## Event kinds the consumer emits
 
@@ -129,7 +146,7 @@ are counted only.
 | `stored` | rows written (messages + reactions) |
 | `ignored` | events observed but not stored (receipts, typing, unknown) |
 | `malformed` | payloads skipped as unparseable — never fatal |
-| `reconnects` | SSE stream drops recovered from |
+| `reconnects` | receive-stream drops recovered from |
 | `db_retries` | transient Postgres faults retried rather than dropped |
 | `db_recoveries` | aborted transactions rolled back (or connections re-opened) so the next event can be written |
 | `db_recovery_failures` | recovery itself failed — the pod cannot write and needs looking at |
@@ -158,7 +175,7 @@ and tear it down on exit — exactly like `mail-actions`.
 
 - **`UNIQUE` does not dedupe over NULL in Postgres.** `messages.source_contact_id` is
   `NOT NULL` and an unresolved sender gets a **deterministic placeholder contact**
-  (uuid5 of the identifier). Never relax that column — every SSE redelivery from an
+  (uuid5 of the identifier). Never relax that column — every redelivery from an
   unknown sender would insert a fresh row.
 - **Outbound messages echo back via device sync.** The send path stores the
   **server-assigned** timestamp so `unique_message` catches the echo. A locally
@@ -166,7 +183,7 @@ and tear it down on exit — exactly like `mail-actions`.
   bare phone number creates a placeholder contact that is **promoted** to the real uuid
   when that person's envelopes arrive — without promotion the echo lands under a
   different contact and dedupe fails even with the right timestamp.
-- **Reactions can precede their target message** (SSE is not ordered, and history is not
+- **Reactions can precede their target message** (delivery is not ordered, and history is not
   backfilled). `reactions.message_id` is NULLable, resolved later, with the partial index
   `idx_rx_unresolved`. Unresolvable reactions are RETAINED, not dropped.
 - **Redelivery duplicates attachments** without `UNIQUE (message_id,

--- a/claude/skills/signal/SKILL.md
+++ b/claude/skills/signal/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: signal
+description: "Query and operate the self-hosted Signal chat pipeline (Zach's phone -> signal-cli-rest-api -> homelab Postgres `signal` schema + MinIO attachments), and DRAFT outbound replies for clawgate approval. Use for: my Signal messages, signal chat, who messaged me on Signal, search my Signal history, Signal conversations/groups/reactions/attachments, the signal-consumer or signal-api pod, \"draft a Signal reply\", \"text someone on Signal\". Email and the mail inbox are the sibling `mailbox` skill, not this one."
+---
+
+# Signal chat operations
+
+Signal messages land in a durable, queryable Postgres store the same way mail does —
+receive → store → query → automate. Same Postgres instance as the mailbox, a separate
+`signal` schema.
+
+```
+Zach's phone (Signal)  ──linked secondary device──►  signal-cli-rest-api
+                                                     (ns signal, json-rpc-native)
+                                                          │ SSE /api/v1/events
+                                                          ▼
+                                             scripts/signal/consumer.py
+                                          ├─► Postgres  signal.*  (mailbox-postgres-0)
+                                          └─► MinIO     signal-attachments
+```
+
+🔴 **Outbound is DRAFT → APPROVE → SEND, never direct-send** (decision D3). See
+[The send path](#the-send-path-d3) — the gate is structural, so "just send it" has no
+code route and will raise `SendGateError`.
+
+## Key facts (verify against live state before asserting)
+
+| Thing | Value |
+|---|---|
+| Code | `~/workspace/devrc/scripts/signal/` — `consumer.py` (CLI + daemon), `_signal_db.py`, `_minio.py`, `clawgate.py` |
+| Tests | `scripts/signal/tests/` — hermetic (sqlite substrate + fixtures), in the pytest gate |
+| Manifests | `homelab-talos: clusters/homelab/apps/signal/`, parent ks `clusters/homelab/flux-system/root-kustomizations/system/signal.yaml` |
+| API | `signal-cli-rest-api`, ns `signal`, ClusterIP `signal-api.signal.svc:8080`, **pinned tag** (never `:latest`), `replicas: 1` |
+| Postgres | `mailbox-postgres-0` in ns `mailbox`, schema **`signal`** (shares the instance + role with `mail`) |
+| Attachments | MinIO archive tenant, bucket `signal-attachments`, key `{conversation}/{YYYY-MM-DD}/{filename}` + a `.json` sidecar |
+| Tables | `signal.contacts`, `signal.groups`, `signal.messages`, `signal.attachments`, `signal.reactions` |
+| Search | `signal.messages.search` — a STORED `to_tsvector('english', body)` generated column with a GIN index |
+
+## Commands (`python3 scripts/signal/consumer.py <cmd>`)
+
+| Command | What it does |
+|---|---|
+| `run` | consume the SSE stream forever — this is what the Deployment runs |
+| `conversations` | list conversations (group, else the DM peer), newest first |
+| `search` | full-text search over message bodies (`websearch_to_tsquery`) |
+| `draft` | compose an outbound draft — **stores it, transmits nothing** |
+| `drafts` | list drafts with their `send_state` |
+| `approve` | record Zach's clawgate approval for one pending draft |
+| `send` | transmit an **approved** draft (refuses anything else) |
+
+```bash
+cd ~/workspace/devrc/scripts/signal
+python3 consumer.py conversations --limit 10
+python3 consumer.py search "harbour permit"
+python3 consumer.py draft --to +15550100 --body "on my way"   # -> pending + a clawgate card
+python3 consumer.py drafts --state pending
+python3 consumer.py approve 42 --ref clawgate-task-91
+python3 consumer.py send 42
+```
+
+Direct SQL (the store is authoritative):
+```bash
+export KUBECONFIG=~/workspace/homelab-talos/homelab-kubeconfig
+PSQL='kubectl -n mailbox exec mailbox-postgres-0 -- psql -U mailbox -d mailbox -c'
+$PSQL "select count(*), max(message_timestamp) from signal.messages;"
+$PSQL "select m.message_timestamp, c.display_name, left(m.body,60) from signal.messages m
+       join signal.contacts c on c.id=m.source_contact_id order by m.message_timestamp desc limit 20;"
+$PSQL "select id, body from signal.messages where search @@ websearch_to_tsquery('english','permit');"
+$PSQL "select count(*) from signal.reactions where message_id is null;"   -- unresolved
+```
+
+## The send path (D3)
+
+`draft_message()` and `send_approved()` are deliberately split so **no single call
+composes and transmits**.
+
+1. `draft` writes the message with `is_outbound=true`, `send_state=pending` and a
+   **negative provisional timestamp**, then posts a clawgate Task card (a graceful
+   no-op returning `False` when `CLAWGATE_HOOK_TOKEN` is unset — the draft is already
+   durable, so a missing token costs the notification, never the record).
+2. Zach approves in clawgate; `approve <id> --ref <clawgate-ref>` records it.
+3. `send` mints a single-use `SendAuthorization` — which `_mint_send_authorization()`
+   refuses to produce unless the stored `send_state` is exactly `approved` — and
+   `consumer.transmit_approved()` refuses to post without one. The capability's
+   constructor refuses direct construction; a spent capability cannot be replayed.
+
+Every refusal raises **`SendGateError`**. `scripts/signal/tests/test_approval_gate.py`
+attempts six documented bypasses and requires each to fail with that error.
+
+## Event kinds the consumer emits
+
+| Kind | Meaning |
+|---|---|
+| `message` | a 1:1 message (attachments, quotes, view-once and expiring messages are all this kind, with fields set) |
+| `group_message` | a message carrying `groupInfo` |
+| `reaction` | an emoji reaction (may arrive BEFORE its target — see gotchas) |
+| `edit` | an edit of an earlier message (`edit_target_timestamp` points at it) |
+| `sync_outbound` | a message Zach sent from another linked device, echoed back |
+| `receipt_delivery` | a delivery receipt |
+| `receipt_read` | a read receipt |
+| `typing` | a typing indicator |
+| `unknown` | a handled envelope shape we do not model — counted and retained, never dropped |
+
+`message`, `group_message`, `edit`, `sync_outbound` and `reaction` are STORED; the rest
+are counted only.
+
+## Counters (`run` prints these as JSON)
+
+| Counter | Meaning |
+|---|---|
+| `stored` | rows written (messages + reactions) |
+| `ignored` | events observed but not stored (receipts, typing, unknown) |
+| `malformed` | payloads skipped as unparseable — never fatal |
+| `reconnects` | SSE stream drops recovered from |
+| `db_retries` | transient Postgres faults retried rather than dropped |
+| `attachment_failures` | attachment fetch/upload failures — the MESSAGE row still stands |
+
+## Environment
+
+| Var | Purpose |
+|---|---|
+| `SIGNAL_PG_DSN` | Postgres DSN; falls back to the k8s secret `mailbox-postgres-auth` |
+| `SIGNAL_PG_HOST` | set → connect DIRECTLY (in-cluster), no `kubectl port-forward` |
+| `SIGNAL_PG_PORT` | port override for direct mode |
+| `SIGNAL_PG_DIRECT` | truthy → direct mode using the DSN's own host/port |
+| `SIGNAL_API_URL` | signal-cli-rest-api base URL (default `http://signal-api.signal.svc:8080`) |
+| `SIGNAL_ACCOUNT` | the account's own phone number, used as the sender of a draft |
+| `CLAWGATE_HOOK_TOKEN` | clawgate hook token; unset → draft cards are a graceful no-op |
+| `MINIO_ARCHIVE_ENDPOINT` | explicit MinIO endpoint (skips the port-forward) |
+| `MINIO_ARCHIVE_ACCESS_KEY` | MinIO credentials; else read from `minio-archive-config` |
+| `MINIO_ARCHIVE_SECRET_KEY` | MinIO credentials; else read from `minio-archive-config` |
+
+Off-cluster (workbench) the DB and MinIO layers open an ephemeral `kubectl port-forward`
+and tear it down on exit — exactly like `mail-actions`.
+
+## ⚠ Gotchas
+
+- **`UNIQUE` does not dedupe over NULL in Postgres.** `messages.source_contact_id` is
+  `NOT NULL` and an unresolved sender gets a **deterministic placeholder contact**
+  (uuid5 of the identifier). Never relax that column — every SSE redelivery from an
+  unknown sender would insert a fresh row.
+- **Outbound messages echo back via device sync.** The send path stores the
+  **server-assigned** timestamp so `unique_message` catches the echo. A locally
+  generated timestamp stores every sent message twice. Related: a draft addressed to a
+  bare phone number creates a placeholder contact that is **promoted** to the real uuid
+  when that person's envelopes arrive — without promotion the echo lands under a
+  different contact and dedupe fails even with the right timestamp.
+- **Reactions can precede their target message** (SSE is not ordered, and history is not
+  backfilled). `reactions.message_id` is NULLable, resolved later, with the partial index
+  `idx_rx_unresolved`. Unresolvable reactions are RETAINED, not dropped.
+- **Redelivery duplicates attachments** without `UNIQUE (message_id,
+  signal_attachment_id)`.
+- **Attachments are fetched AFTER the message row is committed** — a failed download
+  must never roll back a message. `minio_key IS NULL` is the honest marker for "row
+  stored, bytes not archived".
+- **`replicas: 1`, hard.** signal-cli key material conflicts across instances.
+- **signal-cli breaks if >3 months old** (the protocol rotates) — the tag is pinned
+  deliberately, so bump it monthly rather than floating on `:latest`.
+- **The account must `receive` regularly** or it gets flagged as spam; register from the
+  home IP, and it uses one of five linked-device slots.
+- **Read receipts and typing indicators are DBus-only upstream** — the REST API surfaces
+  them in the stream but there is no send equivalent.
+- **Capture is total by default** (decision D1: full bodies + attachments). A group
+  allowlist is the natural mitigation if that is ever revisited.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -310,6 +310,12 @@ HERMETIC_TARGETS=(
   scripts/session-analysis/tests
   scripts/session-analysis/session_insight/tests
   scripts/mail-actions/tests
+  # Added 2026-08-16 with the Signal chat pipeline. Hermetic by construction:
+  # the DB layer runs against an in-memory sqlite substrate translated from the
+  # module's OWN `SCHEMA_STATEMENTS` (tests/fakepg.py), MinIO and the Signal API
+  # are injected fakes, and conftest.py fails any test that reaches for the real
+  # `requests` — so no Postgres, no MinIO, no network.
+  scripts/signal/tests
   scripts/initiatives/tests
   scripts/repo-cos/tests
   scripts/task-spec-drafter/tests
@@ -828,6 +834,22 @@ TARGET_FLOORS=(
   "scripts/session-analysis/tests|367"
   "scripts/session-analysis/session_insight/tests|55"
   "scripts/mail-actions/tests|129"
+  # 2026-08-16, the Signal chat pipeline arrives as a NEW target: 266 collected
+  # (10 suites). MEASURED, never computed — the entry was pinned at 1 so the
+  # AUTHORITATIVE gate would print its own replacement, and `nix build
+  # .#checks.x86_64-linux.pytests` did:
+  #   Raise the TARGET_FLOORS entry to "scripts/signal/tests|253" — that number
+  #   is this run's own count put through [the documented allowance rule]
+  # It read 262/249 on the first pass; the pyright triage then added four tests
+  # (the zero-retry attempt floor and its DB-error case, the missing
+  # stream_factory refusal, and `_returned_id`'s named error), so the number was
+  # RE-MEASURED by the same gate rather than adjusted by hand.
+  # ZERO new skips, so EXPECTED_SKIPS is untouched, and GUARD 7 reported
+  # `intercepted=0 systemctl-reads=0` for this target — the evidence the suite is
+  # hermetic rather than merely asserted to be. If this line conflicts with a
+  # sibling branch, re-run the gate on the MERGED tree and copy what it prints;
+  # do not reconcile the two sides by hand.
+  "scripts/signal/tests|253"
   "scripts/initiatives/tests|745"
   "scripts/repo-cos/tests|315"
   "scripts/task-spec-drafter/tests|135"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -834,25 +834,25 @@ TARGET_FLOORS=(
   "scripts/session-analysis/tests|367"
   "scripts/session-analysis/session_insight/tests|55"
   "scripts/mail-actions/tests|129"
-  # 2026-08-16, the Signal chat pipeline arrives as a NEW target: 340 collected
+  # 2026-08-16, the Signal chat pipeline arrives as a NEW target: 376 collected
   # (10 suites). MEASURED, never computed — the entry was pinned at 1 so the
   # AUTHORITATIVE gate would print its own replacement, and `nix build
   # .#checks.x86_64-linux.pytests` did:
-  #   FAIL  scripts/signal/tests  (collected=340 above drift ceiling 61, floor 1)
-  #   Raise the TARGET_FLOORS entry to "scripts/signal/tests|323"
-  # then the re-run with 323 in place read
-  #   PASS  scripts/signal/tests  (collected=340 passed=340 skipped=0 floor=323)
-  # It read 262/249 on the first pass and 266/253 after the pyright triage; the
-  # post-audit rework (bbernhard route table, transaction recovery, the `sending`
-  # claim, contact identity, MinIO key collisions, remote delete, conversation
-  # grouping) took it to 340. Re-MEASURED each time by the same gate, never
-  # adjusted by hand.
+  #   Raise the TARGET_FLOORS entry to "scripts/signal/tests|358"
+  # then the re-run with 358 in place read
+  #   PASS  scripts/signal/tests  (collected=376 passed=376 skipped=0 floor=358)
+  # Four measurements across three audit rounds, each re-read rather than
+  # adjusted by hand: 262/249 (first pass), 266/253 (pyright triage), 340/323
+  # (the bbernhard route table + transaction recovery + the `sending` claim +
+  # contact identity + MinIO keys + remote delete + conversation grouping), and
+  # 376/358 (the commit-retry drop, the websocket import site, the atomic claim,
+  # the reconcile path, the own-device retraction).
   # ZERO new skips, so EXPECTED_SKIPS is untouched, and GUARD 7 reported
   # `intercepted=0 systemctl-reads=0` for this target — the evidence the suite is
   # hermetic rather than merely asserted to be. If this line conflicts with a
   # sibling branch, re-run the gate on the MERGED tree and copy what it prints;
   # do not reconcile the two sides by hand.
-  "scripts/signal/tests|323"
+  "scripts/signal/tests|358"
   "scripts/initiatives/tests|745"
   "scripts/repo-cos/tests|315"
   "scripts/task-spec-drafter/tests|135"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -834,25 +834,26 @@ TARGET_FLOORS=(
   "scripts/session-analysis/tests|367"
   "scripts/session-analysis/session_insight/tests|55"
   "scripts/mail-actions/tests|129"
-  # 2026-08-16, the Signal chat pipeline arrives as a NEW target: 376 collected
+  # 2026-08-16, the Signal chat pipeline arrives as a NEW target: 387 collected
   # (10 suites). MEASURED, never computed — the entry was pinned at 1 so the
   # AUTHORITATIVE gate would print its own replacement, and `nix build
   # .#checks.x86_64-linux.pytests` did:
-  #   Raise the TARGET_FLOORS entry to "scripts/signal/tests|358"
-  # then the re-run with 358 in place read
-  #   PASS  scripts/signal/tests  (collected=376 passed=376 skipped=0 floor=358)
-  # Four measurements across three audit rounds, each re-read rather than
-  # adjusted by hand: 262/249 (first pass), 266/253 (pyright triage), 340/323
-  # (the bbernhard route table + transaction recovery + the `sending` claim +
-  # contact identity + MinIO keys + remote delete + conversation grouping), and
+  #   Raise the TARGET_FLOORS entry to "scripts/signal/tests|368"
+  # then the re-run with 368 in place read
+  #   PASS  scripts/signal/tests  (collected=387 passed=387 skipped=0 floor=368)
+  # Five measurements across four audit rounds, each RE-READ from the gate rather
+  # than adjusted by hand: 262/249 (first pass), 266/253 (pyright triage),
+  # 340/323 (the bbernhard route table, transaction recovery, the `sending`
+  # claim, contact identity, MinIO keys, remote delete, conversation grouping),
   # 376/358 (the commit-retry drop, the websocket import site, the atomic claim,
-  # the reconcile path, the own-device retraction).
+  # the reconcile path, the own-device retraction), and 387/368 (guarded state
+  # transitions, the preserved approval record, the clean CLI refusal).
   # ZERO new skips, so EXPECTED_SKIPS is untouched, and GUARD 7 reported
   # `intercepted=0 systemctl-reads=0` for this target — the evidence the suite is
   # hermetic rather than merely asserted to be. If this line conflicts with a
   # sibling branch, re-run the gate on the MERGED tree and copy what it prints;
   # do not reconcile the two sides by hand.
-  "scripts/signal/tests|358"
+  "scripts/signal/tests|368"
   "scripts/initiatives/tests|745"
   "scripts/repo-cos/tests|315"
   "scripts/task-spec-drafter/tests|135"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -834,22 +834,25 @@ TARGET_FLOORS=(
   "scripts/session-analysis/tests|367"
   "scripts/session-analysis/session_insight/tests|55"
   "scripts/mail-actions/tests|129"
-  # 2026-08-16, the Signal chat pipeline arrives as a NEW target: 266 collected
+  # 2026-08-16, the Signal chat pipeline arrives as a NEW target: 340 collected
   # (10 suites). MEASURED, never computed — the entry was pinned at 1 so the
   # AUTHORITATIVE gate would print its own replacement, and `nix build
   # .#checks.x86_64-linux.pytests` did:
-  #   Raise the TARGET_FLOORS entry to "scripts/signal/tests|253" — that number
-  #   is this run's own count put through [the documented allowance rule]
-  # It read 262/249 on the first pass; the pyright triage then added four tests
-  # (the zero-retry attempt floor and its DB-error case, the missing
-  # stream_factory refusal, and `_returned_id`'s named error), so the number was
-  # RE-MEASURED by the same gate rather than adjusted by hand.
+  #   FAIL  scripts/signal/tests  (collected=340 above drift ceiling 61, floor 1)
+  #   Raise the TARGET_FLOORS entry to "scripts/signal/tests|323"
+  # then the re-run with 323 in place read
+  #   PASS  scripts/signal/tests  (collected=340 passed=340 skipped=0 floor=323)
+  # It read 262/249 on the first pass and 266/253 after the pyright triage; the
+  # post-audit rework (bbernhard route table, transaction recovery, the `sending`
+  # claim, contact identity, MinIO key collisions, remote delete, conversation
+  # grouping) took it to 340. Re-MEASURED each time by the same gate, never
+  # adjusted by hand.
   # ZERO new skips, so EXPECTED_SKIPS is untouched, and GUARD 7 reported
   # `intercepted=0 systemctl-reads=0` for this target — the evidence the suite is
   # hermetic rather than merely asserted to be. If this line conflicts with a
   # sibling branch, re-run the gate on the MERGED tree and copy what it prints;
   # do not reconcile the two sides by hand.
-  "scripts/signal/tests|253"
+  "scripts/signal/tests|323"
   "scripts/initiatives/tests|745"
   "scripts/repo-cos/tests|315"
   "scripts/task-spec-drafter/tests|135"

--- a/scripts/signal/_minio.py
+++ b/scripts/signal/_minio.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""MinIO (S3) access for Signal attachments.
+
+A deliberate clone of `scripts/mail-actions/_minio.py`: the homelab MinIO
+"archive" tenant is reachable only in-cluster (the `minio` ClusterIP service in
+namespace `minio-archive`, port 80 → container 9000), so we bridge with an
+ephemeral `kubectl port-forward`, talk path-style to `http://127.0.0.1:<port>`,
+and tear the forward down on exit.
+
+Credentials resolve, in order:
+  1. env — MINIO_ARCHIVE_ENDPOINT / MINIO_ARCHIVE_ACCESS_KEY / MINIO_ARCHIVE_SECRET_KEY
+  2. k8s secret `minio-archive-config`, key `config.env`
+
+Layout (bucket `signal-attachments`):
+
+    <conversation>/<YYYY-MM-DD>/<filename>          the attachment bytes
+    <conversation>/<YYYY-MM-DD>/<filename>.json     a sidecar with the metadata
+
+`put_attachment()` is idempotent: re-uploading an existing key is a NO-OP, not a
+second copy — SSE redelivery replays attachments and must not duplicate objects.
+
+Usage:
+    with MinioSignal() as mc:
+        mc.put_attachment(conversation="…", timestamp_ms=…, filename="a.jpg",
+                          data=b"…", content_type="image/jpeg", sidecar={…})
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import re
+import socket
+import subprocess
+import time
+from datetime import datetime, timezone
+from urllib.parse import urlparse
+
+try:
+    from minio import Minio
+    from minio.error import S3Error
+except ImportError as exc:  # pragma: no cover - import guard
+    raise SystemExit(
+        "minio is required. On NixOS run under:\n"
+        "  nix-shell -p \"python3.withPackages(p:[p.minio p.psycopg2 p.requests])\" "
+        "--run 'python scripts/signal/consumer.py run'"
+    ) from exc
+
+NAMESPACE = "minio-archive"
+SERVICE = "svc/minio"
+SERVICE_PORT = 80
+CONFIG_SECRET = "minio-archive-config"
+CONFIG_KEY = "config.env"
+BUCKET = "signal-attachments"
+SIDECAR_SUFFIX = ".json"
+
+_EXPORT_RE = re.compile(
+    r"""^\s*export\s+(?P<key>\w+)\s*=\s*(?P<val>"[^"]*"|'[^']*'|[^\s#]+)""",
+    re.MULTILINE,
+)
+
+# Anything outside this set is replaced in a key segment: a Signal filename or a
+# display name can carry slashes, spaces and control characters, and a `/` would
+# silently reshape the key layout.
+_UNSAFE_SEGMENT = re.compile(r"[^A-Za-z0-9._+-]+")
+# A run of dots is collapsed AFTER separators are neutralised, so no key segment
+# can carry a `..` traversal fragment even in an object browser that re-splits it.
+_DOT_RUN = re.compile(r"\.{2,}")
+
+
+def _free_local_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def parse_config_env(blob: str) -> dict:
+    """Extract `export KEY=value` shell assignments into a plain dict."""
+    out: dict[str, str] = {}
+    for m in _EXPORT_RE.finditer(blob):
+        val = m.group("val")
+        if len(val) >= 2 and val[0] in "\"'" and val[-1] == val[0]:
+            val = val[1:-1]
+        out[m.group("key")] = val
+    return out
+
+
+def _read_creds_from_secret() -> tuple[str, str]:
+    import base64
+
+    raw = subprocess.check_output(
+        [
+            "kubectl", "-n", NAMESPACE, "get", "secret", CONFIG_SECRET,
+            "-o", f"jsonpath={{.data.{CONFIG_KEY.replace('.', '\\.')}}}",
+        ],
+        text=True,
+    ).strip()
+    blob = base64.b64decode(raw).decode()
+    env = parse_config_env(blob)
+    user = env.get("MINIO_ROOT_USER")
+    password = env.get("MINIO_ROOT_PASSWORD")
+    if not user or not password:
+        raise RuntimeError(
+            f"secret {CONFIG_SECRET}/{CONFIG_KEY} missing MINIO_ROOT_USER/PASSWORD"
+        )
+    return user, password
+
+
+def safe_segment(value: str, *, fallback: str = "unknown") -> str:
+    """One key path segment, with separators and whitespace neutralised."""
+    cleaned = _DOT_RUN.sub("_", _UNSAFE_SEGMENT.sub("_", str(value or ""))).strip("_")
+    return cleaned or fallback
+
+
+def object_key(*, conversation: str, timestamp_ms: int, filename: str) -> str:
+    """`{conversation}/{YYYY-MM-DD}/{filename}` — the documented layout.
+
+    The date comes from the message's own timestamp (UTC), NOT from wall-clock
+    now: a redelivered or backfilled attachment must land on the same key as the
+    first delivery, or idempotency is decided by when the consumer happened to
+    run.
+    """
+    day = datetime.fromtimestamp(int(timestamp_ms) / 1000, tz=timezone.utc)
+    return (f"{safe_segment(conversation)}/{day.strftime('%Y-%m-%d')}/"
+            f"{safe_segment(filename, fallback='attachment')}")
+
+
+class MinioSignal:
+    """Context manager: (optional) port-forward → minio S3 client, torn down on exit.
+
+    If MINIO_ARCHIVE_ENDPOINT is set, that endpoint is used verbatim and NO
+    port-forward is started.
+    """
+
+    bucket = BUCKET
+
+    def __init__(
+        self,
+        access_key: str | None = None,
+        secret_key: str | None = None,
+        endpoint: str | None = None,
+        ready_timeout: float = 20.0,
+        client=None,
+    ):
+        self._access_key = access_key or os.environ.get("MINIO_ARCHIVE_ACCESS_KEY")
+        self._secret_key = secret_key or os.environ.get("MINIO_ARCHIVE_SECRET_KEY")
+        self._endpoint = endpoint or os.environ.get("MINIO_ARCHIVE_ENDPOINT")
+        self._ready_timeout = ready_timeout
+        self._pf: subprocess.Popen | None = None
+        # An injected client short-circuits every connection concern — this is
+        # the seam the hermetic suite drives.
+        self.client = client
+        self._bucket_checked = False
+
+    # -- lifecycle ---------------------------------------------------------
+    def __enter__(self) -> "MinioSignal":
+        if self.client is not None:
+            return self
+        if not (self._access_key and self._secret_key):
+            self._access_key, self._secret_key = _read_creds_from_secret()
+
+        if self._endpoint:
+            host, secure = self._split_endpoint(self._endpoint)
+        else:
+            local_port = _free_local_port()
+            self._pf = subprocess.Popen(
+                [
+                    "kubectl", "-n", NAMESPACE, "port-forward", SERVICE,
+                    f"{local_port}:{SERVICE_PORT}",
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+            )
+            self._wait_for_port("127.0.0.1", local_port)
+            host, secure = f"127.0.0.1:{local_port}", False
+
+        self.client = Minio(
+            host, access_key=self._access_key, secret_key=self._secret_key,
+            secure=secure,
+        )
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        if self._pf is not None:
+            self._pf.terminate()
+            with contextlib.suppress(Exception):
+                self._pf.wait(timeout=5)
+
+    @staticmethod
+    def _split_endpoint(endpoint: str) -> tuple[str, bool]:
+        if "://" in endpoint:
+            u = urlparse(endpoint)
+            return u.netloc, u.scheme == "https"
+        return endpoint, False
+
+    @property
+    def _c(self):
+        if self.client is None:
+            raise RuntimeError("MinioSignal used outside its context manager (no client)")
+        return self.client
+
+    def _wait_for_port(self, host: str, port: int) -> None:
+        deadline = time.monotonic() + self._ready_timeout
+        while time.monotonic() < deadline:
+            if self._pf and self._pf.poll() is not None:
+                err = self._pf.stderr.read().decode() if self._pf.stderr else ""
+                raise RuntimeError(f"kubectl port-forward exited early:\n{err}")
+            with contextlib.suppress(OSError):
+                with socket.create_connection((host, port), timeout=1):
+                    return
+            time.sleep(0.25)
+        raise TimeoutError(f"port-forward to {host}:{port} not ready in time")
+
+    # -- operations --------------------------------------------------------
+    def ensure_bucket(self, bucket: str | None = None) -> bool:
+        """Create the bucket if absent. Returns True if it was created."""
+        name = bucket or self.bucket
+        if self._c.bucket_exists(name):
+            return False
+        self._c.make_bucket(name)
+        return True
+
+    def object_exists(self, key: str, bucket: str | None = None) -> bool:
+        try:
+            self._c.stat_object(bucket or self.bucket, key)
+            return True
+        except S3Error:
+            return False
+
+    def put_attachment(self, *, conversation: str, timestamp_ms: int, filename: str,
+                       data: bytes, content_type: str,
+                       sidecar: dict | None = None) -> str:
+        """Upload one attachment + its sidecar. Returns the object key.
+
+        Idempotent: an existing key is left alone (both the object and its
+        sidecar), so SSE redelivery re-derives the same key and writes nothing.
+        """
+        if not self._bucket_checked:
+            self.ensure_bucket()
+            self._bucket_checked = True
+        key = object_key(conversation=conversation, timestamp_ms=timestamp_ms,
+                         filename=filename)
+        if not self.object_exists(key):
+            self._c.put_object(
+                self.bucket, key, io.BytesIO(data), length=len(data),
+                content_type=content_type,
+            )
+        sidecar_key = key + SIDECAR_SUFFIX
+        if sidecar is not None and not self.object_exists(sidecar_key):
+            blob = json.dumps(sidecar, sort_keys=True, default=str).encode()
+            self._c.put_object(
+                self.bucket, sidecar_key, io.BytesIO(blob), length=len(blob),
+                content_type="application/json",
+            )
+        return key

--- a/scripts/signal/_minio.py
+++ b/scripts/signal/_minio.py
@@ -115,16 +115,31 @@ def safe_segment(value: str, *, fallback: str = "unknown") -> str:
     return cleaned or fallback
 
 
-def object_key(*, conversation: str, timestamp_ms: int, filename: str) -> str:
-    """`{conversation}/{YYYY-MM-DD}/{filename}` — the documented layout.
+def object_key(*, conversation: str, timestamp_ms: int, filename: str,
+               attachment_id: str) -> str:
+    """`{conversation}/{YYYY-MM-DD}/{attachment_id}_{filename}` — the layout.
+
+    🔴 `attachment_id` IS PART OF THE KEY, and required. Keying on
+    `{conversation}/{date}/{filename}` alone collides for the commonest filename
+    there is: two `Screenshot.png` in one conversation on one day produce the
+    same key, `put_attachment` then sees the object already exists and SKIPS the
+    write, and the second attachment's DB row points at the first one's bytes
+    while its sidecar misattributes provenance. Silent, and unrecoverable once
+    the sender deletes the original.
 
     The date comes from the message's own timestamp (UTC), NOT from wall-clock
     now: a redelivered or backfilled attachment must land on the same key as the
     first delivery, or idempotency is decided by when the consumer happened to
-    run.
+    run. The Signal attachment id is stable across redelivery for the same
+    reason, so the key stays idempotent while becoming unique.
     """
+    if not attachment_id:
+        raise ValueError(
+            "object_key needs the signal attachment id: without it two files of "
+            "the same name in one day collide and the second is silently dropped")
     day = datetime.fromtimestamp(int(timestamp_ms) / 1000, tz=timezone.utc)
     return (f"{safe_segment(conversation)}/{day.strftime('%Y-%m-%d')}/"
+            f"{safe_segment(attachment_id, fallback='attachment')}_"
             f"{safe_segment(filename, fallback='attachment')}")
 
 
@@ -231,7 +246,7 @@ class MinioSignal:
             return False
 
     def put_attachment(self, *, conversation: str, timestamp_ms: int, filename: str,
-                       data: bytes, content_type: str,
+                       data: bytes, content_type: str, attachment_id: str,
                        sidecar: dict | None = None) -> str:
         """Upload one attachment + its sidecar. Returns the object key.
 
@@ -242,7 +257,7 @@ class MinioSignal:
             self.ensure_bucket()
             self._bucket_checked = True
         key = object_key(conversation=conversation, timestamp_ms=timestamp_ms,
-                         filename=filename)
+                         filename=filename, attachment_id=attachment_id)
         if not self.object_exists(key):
             self._c.put_object(
                 self.bucket, key, io.BytesIO(data), length=len(data),

--- a/scripts/signal/_minio.py
+++ b/scripts/signal/_minio.py
@@ -17,7 +17,7 @@ Layout (bucket `signal-attachments`):
     <conversation>/<YYYY-MM-DD>/<filename>.json     a sidecar with the metadata
 
 `put_attachment()` is idempotent: re-uploading an existing key is a NO-OP, not a
-second copy — SSE redelivery replays attachments and must not duplicate objects.
+second copy — redelivery replays attachments and must not duplicate objects.
 
 Usage:
     with MinioSignal() as mc:
@@ -251,7 +251,7 @@ class MinioSignal:
         """Upload one attachment + its sidecar. Returns the object key.
 
         Idempotent: an existing key is left alone (both the object and its
-        sidecar), so SSE redelivery re-derives the same key and writes nothing.
+        sidecar), so a redelivery re-derives the same key and writes nothing.
         """
         if not self._bucket_checked:
             self.ensure_bucket()

--- a/scripts/signal/_signal_db.py
+++ b/scripts/signal/_signal_db.py
@@ -62,7 +62,19 @@ PLACEHOLDER_NS = uuid.UUID("6f9c0d1e-2b3a-4c5d-8e7f-0a1b2c3d4e5f")
 # deleted, so it cannot be silently lost.
 STATE_PENDING = "pending"
 STATE_APPROVED = "approved"
+# 🔴 `sending` exists so a crash BETWEEN the POST and the write-back cannot cause
+# a RESEND. The row moves to `sending` and is committed BEFORE the POST; only
+# `approved` can mint a capability, so a draft found in `sending` is inert until a
+# human reconciles it against Signal. Fail-safe direction chosen deliberately:
+# "may need manual re-approval" beats "may send the same text twice".
+STATE_SENDING = "sending"
 STATE_SENT = "sent"
+
+# Must be present in the environment for `approve_draft()` to run. An operator-only
+# variable: absent from the consumer Deployment and from agent environments. A
+# speed bump against an agent approving its own draft, NOT a proof of humanity —
+# `approve_draft()`'s docstring says exactly how far it goes.
+APPROVAL_TOKEN_ENV = "SIGNAL_APPROVAL_TOKEN"
 
 
 # --------------------------------------------------------------------------- #
@@ -124,6 +136,7 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
         group_id INTEGER REFERENCES signal.groups(id),
         is_outbound BOOLEAN DEFAULT false,
         send_state TEXT,
+        send_attempts INTEGER DEFAULT 0,
         approval_ref TEXT,
         raw_envelope JSONB,
         search tsvector GENERATED ALWAYS AS (to_tsvector('english', coalesce(body, ''))) STORED,
@@ -260,6 +273,41 @@ def spend_authorization(auth: object) -> None:
     _ISSUED_NONCES.discard(nonce)
 
 
+# `message_type` of a row whose sender retracted it. The row is KEPT (its
+# timestamp still has to dedupe redeliveries) but carries no content.
+TYPE_DELETED = "deleted"
+
+
+def _server_timestamp(result) -> int:
+    """The server-assigned send timestamp, coerced and sanity-checked (🔧 #4).
+
+    🔴 Upstream types this field as a **string** — `ds.SendMessageResponse`'s
+    `Timestamp string \\`json:"timestamp"\\`` — even though it holds epoch-ms. A
+    fake that returns an int would let a caller which only handles ints pass the
+    suite and fail against the real server, so both are accepted here and the
+    string form is what the tests feed.
+    """
+    if not isinstance(result, dict) or "timestamp" not in result:
+        raise ValueError(
+            f"the Signal API response carries no `timestamp`: {result!r}; without "
+            "it the sync echo cannot be deduped (🔧 #4)"
+        )
+    raw = result["timestamp"]
+    try:
+        server_ts = int(str(raw).strip())
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"the Signal API returned a non-numeric timestamp {raw!r}; storing it "
+            "would break sync-echo dedupe (🔧 #4)"
+        ) from exc
+    if server_ts <= 0:
+        raise ValueError(
+            f"the Signal API returned a non-positive timestamp {server_ts!r}; "
+            "storing it would break sync-echo dedupe (🔧 #4)"
+        )
+    return server_ts
+
+
 def _returned_id(cur, what: str) -> int:
     """The id from an `INSERT … RETURNING id`, or an error that NAMES the write.
 
@@ -365,6 +413,16 @@ class SignalDB:
 
     # -- lifecycle ---------------------------------------------------------
     def __enter__(self) -> "SignalDB":
+        self._connect()
+        return self
+
+    def _connect(self) -> None:
+        """Open (or RE-open) the connection. Called by `__enter__` and `recover()`.
+
+        Extracted so a dead socket can be replaced in place: a long-lived daemon
+        outlives any single connection, and `recover()` is the only thing standing
+        between a dropped socket and a pod that stores nothing forever.
+        """
         direct = _direct_target()
         if direct is not None:
             dsn = self._dsn or _read_dsn_from_secret()
@@ -372,9 +430,14 @@ class SignalDB:
             kwargs = _dsn_connect_kwargs(dsn, host=host_override, port=port_override)
             self.conn = psycopg2.connect(**kwargs)
             self.conn.autocommit = False
-            return self
+            return
 
         dsn = self._dsn or _read_dsn_from_secret()
+        if self._pf is not None:
+            # A reconnect through a dead port-forward needs a NEW forward.
+            with contextlib.suppress(Exception):
+                self._pf.terminate()
+            self._pf = None
         local_port = _free_local_port()
         self._pf = subprocess.Popen(
             [
@@ -388,7 +451,6 @@ class SignalDB:
         kwargs = _dsn_connect_kwargs(dsn, host="127.0.0.1", port=local_port)
         self.conn = psycopg2.connect(**kwargs)
         self.conn.autocommit = False
-        return self
 
     def __exit__(self, *_exc) -> None:
         with contextlib.suppress(Exception):
@@ -417,6 +479,41 @@ class SignalDB:
             time.sleep(0.25)
         raise TimeoutError(f"port-forward to {host}:{port} not ready in time")
 
+    # -- transaction recovery ----------------------------------------------
+    def rollback(self) -> None:
+        """Abandon the open transaction. Safe to call when there is nothing to undo."""
+        if self.conn is not None:
+            self.conn.rollback()
+
+    def recover(self) -> str:
+        """Make the connection usable again after a failed statement.
+
+        🔴 WHY THIS EXISTS. The connections here run `autocommit=False`, and in
+        Postgres the FIRST failed statement aborts the whole transaction: every
+        later statement then raises `InFailedSqlTransaction` until someone rolls
+        back. A daemon without this stores nothing for the rest of its life while
+        logging as though it were merely reconnecting.
+
+        Returns `rolled-back` or `reconnected` so the caller can count and log
+        which one happened — the two mean very different things about the pod.
+        """
+        conn = self.conn
+        if conn is None:
+            self._connect()
+            return "reconnected"
+        if getattr(conn, "closed", 0):
+            self._connect()
+            return "reconnected"
+        try:
+            conn.rollback()
+            return "rolled-back"
+        except Exception:
+            # The socket itself is gone — a rollback cannot fix that.
+            with contextlib.suppress(Exception):
+                conn.close()
+            self._connect()
+            return "reconnected"
+
     # -- schema ------------------------------------------------------------
     def ensure_schema(self) -> None:
         """Create the `signal` schema. Idempotent — every statement is IF NOT EXISTS."""
@@ -432,10 +529,25 @@ class SignalDB:
                        profile_name: str | None = None) -> int:
         """Insert-or-update one contact, returning its id.
 
-        🔧 #1: when the envelope carries NO uuid, a DETERMINISTIC placeholder is
-        derived from the phone number (or any other stable identifier) instead of
-        leaving the sender unresolved. That is what keeps `unique_message` able to
-        dedupe a redelivered envelope from an unknown sender.
+        🔴 ONE PERSON MUST RESOLVE TO ONE ROW IN BOTH ARRIVAL ORDERS. A Signal
+        identity reaches us two ways — as a bare phone number (what an agent
+        types into a draft) and as a uuid (what every envelope carries) — and
+        `unique_message` keys on `source_contact_id`, so two rows for one person
+        means the outbound sync echo (🔧 #4) never collides and EVERY sent message
+        is stored twice. The two orders are both real and both handled here:
+
+          draft-then-echo: the number makes a PLACEHOLDER, the uuid arrives later
+                           -> `_promote_placeholder()` gives that row the uuid.
+          echo-then-draft: the uuid row already exists (true from day two of any
+                           deployment), then a draft supplies only the number
+                           -> the phone LOOKUP below finds it. Without that
+                           lookup a second placeholder is created and promotion
+                           correctly declines (the uuid is taken), which is
+                           exactly the silent-duplicate case.
+
+        🔧 #1: only when NEITHER a uuid nor an existing row can be found is a
+        DETERMINISTIC placeholder derived, so a redelivered envelope from an
+        unresolved sender still lands on one row.
         """
         is_placeholder = False
         if not signal_uuid:
@@ -445,16 +557,17 @@ class SignalDB:
                     "upsert_contact needs a signal_uuid or some stable identifier; "
                     "an unidentifiable sender would break message dedupe (🔧 #1)"
                 )
+            if phone_number:
+                existing = self.contact_id_by_phone(phone_number)
+                if existing is not None:
+                    # A row for this number already exists — real or placeholder.
+                    # Reuse it rather than minting a rival identity.
+                    self._enrich_contact(existing, display_name=display_name,
+                                         profile_name=profile_name)
+                    return existing
             signal_uuid = placeholder_uuid(ident)
             is_placeholder = True
         elif phone_number:
-            # PLACEHOLDER PROMOTION. A draft addressed to a bare phone number
-            # created a placeholder contact; the same person's envelopes arrive
-            # carrying the REAL uuid. Without this the two are separate contact
-            # rows — and the outbound sync echo (🔧 #4) would then land under a
-            # DIFFERENT source_contact_id from the sent row, so `unique_message`
-            # would not catch it and every sent message would be stored twice.
-            # Promotion keeps the row IDENTITY, so the echo collides as intended.
             self._promote_placeholder(signal_uuid, phone_number)
         with self._c.cursor() as cur:
             cur.execute(
@@ -471,6 +584,38 @@ class SignalDB:
                 (signal_uuid, phone_number, display_name, profile_name, is_placeholder),
             )
             return _returned_id(cur, "upsert_contact")
+
+    def contact_id_by_phone(self, phone_number: str) -> int | None:
+        """The contact row for a phone number, preferring a REAL one over a placeholder.
+
+        `phone_number` is not UNIQUE (a placeholder and a promoted row could
+        briefly race), so the ordering is explicit rather than incidental: a
+        resolved contact wins, then the oldest row. Deterministic either way —
+        an arbitrary pick here would reintroduce split identities.
+        """
+        if not phone_number:
+            return None
+        with self._c.cursor() as cur:
+            cur.execute(
+                "SELECT id FROM signal.contacts WHERE phone_number = %s "
+                "ORDER BY is_placeholder, id LIMIT 1",
+                (phone_number,),
+            )
+            row = cur.fetchone()
+        return row[0] if row else None
+
+    def _enrich_contact(self, contact_id: int, *, display_name: str | None,
+                        profile_name: str | None) -> None:
+        """Fill in names we have learned WITHOUT blanking ones we already had."""
+        if display_name is None and profile_name is None:
+            return
+        with self._c.cursor() as cur:
+            cur.execute(
+                "UPDATE signal.contacts SET "
+                "display_name = COALESCE(%s, display_name), "
+                "profile_name = COALESCE(%s, profile_name) WHERE id = %s",
+                (display_name, profile_name, contact_id),
+            )
 
     def _promote_placeholder(self, signal_uuid: str, phone_number: str) -> int:
         """Give a placeholder contact its real uuid, preserving its row id.
@@ -687,24 +832,41 @@ class SignalDB:
 
     # -- reads -------------------------------------------------------------
     def list_conversations(self, limit: int = 50) -> list:
-        """One row per conversation (group, else the DM peer), newest first."""
+        """One row per CONVERSATION — a group, else the PEER of a DM.
+
+        🔴 Grouping by `source_contact_id` (the obvious thing) is wrong in two
+        directions at once: a DM comes back as TWO rows, one per direction, and
+        every outbound message in the whole database collapses into a single "me"
+        row. The conversation key is therefore the group when there is one, and
+        otherwise the OTHER PARTY — the destination for an outbound message, the
+        sender for an inbound one.
+        """
         with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
             cur.execute(
                 """
                 SELECT
-                    m.group_id AS group_row_id,
+                    conv.group_row_id,
                     g.name AS group_name,
-                    m.source_contact_id AS contact_id,
+                    conv.contact_id,
                     c.display_name,
                     c.phone_number,
-                    max(m.message_timestamp) AS last_message_timestamp,
-                    count(*) AS message_count
-                FROM signal.messages m
-                LEFT JOIN signal.groups g ON g.id = m.group_id
-                LEFT JOIN signal.contacts c ON c.id = m.source_contact_id
-                GROUP BY m.group_id, g.name, m.source_contact_id, c.display_name,
-                         c.phone_number
-                ORDER BY last_message_timestamp DESC
+                    conv.last_message_timestamp,
+                    conv.message_count
+                FROM (
+                    SELECT
+                        m.group_id AS group_row_id,
+                        CASE WHEN m.group_id IS NOT NULL THEN NULL
+                             WHEN m.is_outbound THEN m.dest_contact_id
+                             ELSE m.source_contact_id
+                        END AS contact_id,
+                        max(m.message_timestamp) AS last_message_timestamp,
+                        count(*) AS message_count
+                    FROM signal.messages m
+                    GROUP BY 1, 2
+                ) conv
+                LEFT JOIN signal.groups g ON g.id = conv.group_row_id
+                LEFT JOIN signal.contacts c ON c.id = conv.contact_id
+                ORDER BY conv.last_message_timestamp DESC
                 LIMIT %s
                 """,
                 (limit,),
@@ -795,7 +957,30 @@ class SignalDB:
 
         Only a `pending` draft may be approved; approving anything else raises
         `SendGateError` so a `sent` draft cannot be re-armed.
+
+        🔴 HONEST LIMIT — READ THIS BEFORE TRUSTING D3. Nothing *inside this
+        process* can prove that a human, rather than the agent that wrote the
+        draft, called this method. What is enforced here is a speed bump, not a
+        proof: `SIGNAL_APPROVAL_TOKEN` must be present in the environment, and it
+        is deliberately NOT in the consumer Deployment's env or in any agent's —
+        it lives in the operator's shell. An agent that can read the operator's
+        environment has already won, and this does not pretend otherwise.
+
+        The part that IS structural is narrower and worth stating exactly:
+        composing and transmitting are separate calls with durable state in
+        between, so a send is always preceded by a recorded approval decision
+        that a human can audit after the fact.
         """
+        if not os.environ.get(APPROVAL_TOKEN_ENV):
+            raise SendGateError(
+                f"approval refused: {APPROVAL_TOKEN_ENV} is not set. Approval is "
+                f"the OPERATOR's step — it is deliberately unavailable to the "
+                f"consumer Deployment and to drafting agents (D3 approval gate)"
+            )
+        if not (approval_ref or "").strip():
+            raise SendGateError(
+                "approval refused: an empty approval_ref records nothing auditable "
+                "(D3 approval gate)")
         row = self._draft_or_raise(draft_id)
         if row["send_state"] != STATE_PENDING:
             raise SendGateError(
@@ -870,12 +1055,25 @@ class SignalDB:
         auth = _mint_send_authorization(draft)
         if transmit is None:
             from consumer import transmit_approved as transmit  # local import: no cycle
-        result = transmit(auth, recipient=draft["recipient"], body=draft["body"])
-        server_ts = int(result["timestamp"])
-        if server_ts <= 0:
-            raise ValueError(
-                f"the Signal API returned a non-positive timestamp {server_ts!r}; "
-                "storing it would break sync-echo dedupe (🔧 #4)"
+
+        # 🔴 CLAIM THE DRAFT BEFORE THE POST, and COMMIT that claim. Everything
+        # after the POST can fail — an odd response shape, a dropped connection,
+        # a pod kill between the reply and the UPDATE. If the row were still
+        # `approved` at that moment the gate would happily mint a fresh
+        # capability and SEND THE SAME TEXT AGAIN. `sending` cannot be minted
+        # from, so the worst case is a draft a human must reconcile, never a
+        # duplicate message. `send_attempts` records that it was tried.
+        self._claim_for_sending(draft_id)
+
+        result = transmit(auth, recipient=draft["recipient"], body=draft["body"],
+                          number=self.account_number(draft_id))
+        server_ts = _server_timestamp(result)
+        errors = (result or {}).get("errors")
+        if errors:
+            raise RuntimeError(
+                f"the Signal API reported per-recipient errors for draft "
+                f"{draft_id!r}: {errors!r}; the draft stays in {STATE_SENDING!r} "
+                f"for manual reconciliation"
             )
         with self._c.cursor() as cur:
             cur.execute(
@@ -885,6 +1083,64 @@ class SignalDB:
             )
         self._c.commit()
         return self._draft_or_raise(draft_id)
+
+    def _claim_for_sending(self, draft_id: int) -> None:
+        """Move an approved draft to `sending` and COMMIT, before anything is sent."""
+        with self._c.cursor() as cur:
+            cur.execute(
+                "UPDATE signal.messages SET send_state = %s, "
+                "send_attempts = COALESCE(send_attempts, 0) + 1 WHERE id = %s",
+                (STATE_SENDING, draft_id),
+            )
+        self._c.commit()
+
+    def account_number(self, draft_id: int) -> str:
+        """The SENDING account's phone number for a draft — required by `/v2/send`."""
+        with self._c.cursor() as cur:
+            cur.execute(
+                "SELECT c.phone_number FROM signal.messages m "
+                "JOIN signal.contacts c ON c.id = m.source_contact_id "
+                "WHERE m.id = %s",
+                (draft_id,),
+            )
+            row = cur.fetchone()
+        number = row[0] if row else None
+        if not number:
+            raise SendGateError(
+                f"draft {draft_id!r} has no sending phone number on its contact row; "
+                f"`/v2/send` requires `number` and would 400 (D3 approval gate)"
+            )
+        return number
+
+    # -- retention ---------------------------------------------------------
+    def apply_remote_delete(self, rd: dict) -> int:
+        """Honour a sender's remote delete: TOMBSTONE the target, keep no text.
+
+        Storing a `remoteDelete` as an ordinary (empty-bodied) message — which is
+        what happens if it is not recognised — leaves a ghost row AND leaves the
+        retracted text sitting in the row it was meant to retract. Returns the
+        number of rows tombstoned (0 when we never received the target).
+        """
+        author_id = self.upsert_contact(
+            signal_uuid=rd.get("target_author_uuid"),
+            phone_number=rd.get("target_author_number"),
+        )
+        with self._c.cursor() as cur:
+            cur.execute(
+                "UPDATE signal.messages SET body = NULL, raw_envelope = NULL, "
+                "message_type = %s WHERE source_contact_id = %s "
+                "AND message_timestamp = %s",
+                (TYPE_DELETED, author_id, rd["target_sent_timestamp"]),
+            )
+            deleted = cur.rowcount
+        with self._c.cursor() as cur:
+            cur.execute(
+                "DELETE FROM signal.attachments WHERE message_id IN "
+                "(SELECT id FROM signal.messages WHERE source_contact_id = %s "
+                " AND message_timestamp = %s)",
+                (author_id, rd["target_sent_timestamp"]),
+            )
+        return deleted
 
     def commit(self) -> None:
         self._c.commit()

--- a/scripts/signal/_signal_db.py
+++ b/scripts/signal/_signal_db.py
@@ -76,6 +76,10 @@ STATE_SENT = "sent"
 # `approve_draft()`'s docstring says exactly how far it goes.
 APPROVAL_TOKEN_ENV = "SIGNAL_APPROVAL_TOKEN"
 
+# The two outcomes an operator can record for a draft stranded in `sending`.
+RECONCILE_SENT = "sent"
+RECONCILE_NOT_SENT = "not-sent"
+
 
 # --------------------------------------------------------------------------- #
 # Schema — the single source of truth. Tests DERIVE from these statements rather
@@ -1052,6 +1056,13 @@ class SignalDB:
         with `unique_message` instead of inserting a duplicate.
         """
         draft = self._draft_or_raise(draft_id)
+        # 🔴 EVERY precondition that can REFUSE is resolved BEFORE the claim, so a
+        # refusal leaves the draft `approved` and re-sendable. `account_number()`
+        # used to be an ARGUMENT to `transmit(...)`, which evaluates after the
+        # claim has committed: a draft whose sender carried no phone number
+        # (`draft_message(self_uuid=…)`, a supported signature) ended up
+        # `sending` with nothing transmitted — stranded, and unsendable forever.
+        number = self.account_number(draft_id)
         auth = _mint_send_authorization(draft)
         if transmit is None:
             from consumer import transmit_approved as transmit  # local import: no cycle
@@ -1066,15 +1077,18 @@ class SignalDB:
         self._claim_for_sending(draft_id)
 
         result = transmit(auth, recipient=draft["recipient"], body=draft["body"],
-                          number=self.account_number(draft_id))
-        server_ts = _server_timestamp(result)
+                          number=number)
+        # The per-recipient errors are read BEFORE the timestamp: a response that
+        # carries both an error and an unusable timestamp must report the ERROR,
+        # which says what went wrong, not a timestamp complaint that hides it.
         errors = (result or {}).get("errors")
         if errors:
             raise RuntimeError(
                 f"the Signal API reported per-recipient errors for draft "
                 f"{draft_id!r}: {errors!r}; the draft stays in {STATE_SENDING!r} "
-                f"for manual reconciliation"
+                f"for manual reconciliation — see `reconcile`"
             )
+        server_ts = _server_timestamp(result)
         with self._c.cursor() as cur:
             cur.execute(
                 "UPDATE signal.messages SET message_timestamp = %s, send_state = %s, "
@@ -1085,14 +1099,90 @@ class SignalDB:
         return self._draft_or_raise(draft_id)
 
     def _claim_for_sending(self, draft_id: int) -> None:
-        """Move an approved draft to `sending` and COMMIT, before anything is sent."""
+        """ATOMICALLY move an approved draft to `sending`, and COMMIT the claim.
+
+        🔴 THE STATE PREDICATE IS THE LOCK. Without `AND send_state = 'approved'`
+        plus the rowcount check, two concurrent `send_approved()` calls both read
+        `approved`, both mint a capability and both transmit — reproduced, two
+        sends of one draft. `_ISSUED_NONCES` cannot help: it is per-process, so
+        two pods or two shells share nothing. The database row is the only thing
+        both callers can contend on, so the transition has to happen there, in
+        one statement, with the loser told it lost.
+        """
         with self._c.cursor() as cur:
             cur.execute(
                 "UPDATE signal.messages SET send_state = %s, "
-                "send_attempts = COALESCE(send_attempts, 0) + 1 WHERE id = %s",
-                (STATE_SENDING, draft_id),
+                "send_attempts = COALESCE(send_attempts, 0) + 1 "
+                "WHERE id = %s AND send_state = %s",
+                (STATE_SENDING, draft_id, STATE_APPROVED),
             )
+            claimed = cur.rowcount
         self._c.commit()
+        if claimed != 1:
+            raise SendGateError(
+                f"draft {draft_id!r} could not be claimed for sending — it is no "
+                f"longer {STATE_APPROVED!r} (another sender claimed it first, or "
+                f"it was already sent). D3 approval gate."
+            )
+
+    def reconcile_send(self, draft_id: int, *, outcome: str,
+                       server_timestamp: int | str | None = None,
+                       note: str | None = None) -> dict:
+        """Resolve a draft stranded in `sending`. The OPERATOR's call, after looking.
+
+        🔴 WHY THIS EXISTS. `sending` is deliberately inert — nothing can mint a
+        capability from it, which is what stops a crash mid-send from resending.
+        But inert with no way out is a dead end: `approve_draft` refuses (not
+        `pending`) and `send_approved` refuses (not `approved`), so a draft that
+        strands is unsendable forever and the documented "reconcile by hand" was
+        a listing command and nothing else.
+
+        The operator checks Signal and says which happened:
+
+          `sent`     — it did go out. Record the SERVER timestamp read from the
+                       conversation, so the sync echo still dedupes (🔧 #4).
+          `not-sent` — it did not. Returns to `pending`, so it needs a FRESH
+                       approval before it can be sent: the human stays in the
+                       loop rather than a retry slipping through on the strength
+                       of the old one.
+
+        Gated by the same operator token as `approve_draft`, and refuses any
+        draft that is not `sending` — this is not a general state-editing tool.
+        """
+        if not os.environ.get(APPROVAL_TOKEN_ENV):
+            raise SendGateError(
+                f"reconcile refused: {APPROVAL_TOKEN_ENV} is not set. Reconciling "
+                f"a stranded send is the OPERATOR's step (D3 approval gate)"
+            )
+        if outcome not in (RECONCILE_SENT, RECONCILE_NOT_SENT):
+            raise ValueError(
+                f"outcome must be {RECONCILE_SENT!r} or {RECONCILE_NOT_SENT!r}, "
+                f"not {outcome!r}"
+            )
+        row = self._draft_or_raise(draft_id)
+        if row["send_state"] != STATE_SENDING:
+            raise SendGateError(
+                f"draft {draft_id!r} has send_state={row['send_state']!r}; only "
+                f"{STATE_SENDING!r} drafts are reconciled (D3 approval gate)"
+            )
+        if outcome == RECONCILE_SENT:
+            server_ts = _server_timestamp({"timestamp": server_timestamp})
+            with self._c.cursor() as cur:
+                cur.execute(
+                    "UPDATE signal.messages SET message_timestamp = %s, "
+                    "send_state = %s, message_type = 'message', "
+                    "approval_ref = COALESCE(%s, approval_ref) WHERE id = %s",
+                    (server_ts, STATE_SENT, note, draft_id),
+                )
+        else:
+            with self._c.cursor() as cur:
+                cur.execute(
+                    "UPDATE signal.messages SET send_state = %s, "
+                    "approval_ref = %s WHERE id = %s",
+                    (STATE_PENDING, note, draft_id),
+                )
+        self._c.commit()
+        return self._draft_or_raise(draft_id)
 
     def account_number(self, draft_id: int) -> str:
         """The SENDING account's phone number for a draft — required by `/v2/send`."""

--- a/scripts/signal/_signal_db.py
+++ b/scripts/signal/_signal_db.py
@@ -115,13 +115,13 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
 
     # 🔧 #1  `source_contact_id NOT NULL`. A UNIQUE over a NULLable column does
     # NOT dedupe in Postgres (NULLs compare distinct), so an envelope from an
-    # unresolved sender would insert a fresh row on EVERY SSE redelivery.
+    # unresolved sender would insert a fresh row on EVERY redelivery.
     # Unknown senders get a deterministic placeholder contact instead
     # (`placeholder_uuid()`), which is what makes `unique_message` bite.
     #
     # 🔧 #4 (behavioural half) lives here too: `message_timestamp` for an
     # outbound message MUST be the SERVER-assigned timestamp, because that is
-    # what the device-sync echo carries back through the SSE stream. Un-sent
+    # what the device-sync echo carries back on the receive stream. Un-sent
     # drafts hold a NEGATIVE provisional timestamp, which can never collide with
     # a real (positive, epoch-ms) server timestamp.
     """
@@ -148,7 +148,7 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
     )
     """,
 
-    # 🔧 #2  Without `unique_attachment`, an SSE redelivery of the same message
+    # 🔧 #2  Without `unique_attachment`, a redelivery of the same message
     # duplicates every attachment row.
     """
     CREATE TABLE IF NOT EXISTS signal.attachments (
@@ -168,7 +168,7 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
     """,
 
     # 🔧 #3  `message_id` is NULLable and resolved LATER: a reaction can arrive
-    # BEFORE its target message (out-of-order SSE), or target a message we never
+    # BEFORE its target message (delivery is not ordered), or target one we never
     # received at all. A hard FK at insert time drops those on the floor.
     """
     CREATE TABLE IF NOT EXISTS signal.reactions (
@@ -767,7 +767,7 @@ class SignalDB:
     def upsert_reaction(self, rx: dict) -> int:
         """Store one reaction, resolving its target message if we already have it.
 
-        🔧 #3 — the target may not exist yet (out-of-order SSE) or may never
+        🔧 #3 — the target may not exist yet (delivery is not ordered) or may never
         arrive. `message_id` stays NULL in that case and is filled in later by
         `resolve_pending_reactions()`; the reaction is RETAINED either way.
         """
@@ -1089,14 +1089,45 @@ class SignalDB:
                 f"for manual reconciliation — see `reconcile`"
             )
         server_ts = _server_timestamp(result)
-        with self._c.cursor() as cur:
-            cur.execute(
-                "UPDATE signal.messages SET message_timestamp = %s, send_state = %s, "
-                "message_type = 'message' WHERE id = %s",
-                (server_ts, STATE_SENT, draft_id),
-            )
-        self._c.commit()
+        # The terminal update carries the SAME state predicate as the claim. This
+        # sender owns the row only while it is still `sending`; if an operator
+        # reconciled it in the meantime, stamping over their decision silently is
+        # the wrong answer — the sender is the one that should be told.
+        self._transition(
+            draft_id,
+            "UPDATE signal.messages SET message_timestamp = %s, send_state = %s, "
+            "message_type = 'message' WHERE id = %s AND send_state = %s",
+            (server_ts, STATE_SENT, draft_id, STATE_SENDING),
+            expected=STATE_SENDING,
+            what="complete the send",
+        )
         return self._draft_or_raise(draft_id)
+
+    def _transition(self, draft_id: int, sql: str, params: tuple, *,
+                    expected: str, what: str) -> None:
+        """Run a guarded `send_state` transition and REFUSE if it did not apply.
+
+        🔴 Every write that moves `send_state` names the state it expects and
+        reads the rowcount, so a caller that lost the row is told instead of
+        overwriting whatever the winner decided. Without this an in-flight sender
+        completing after an operator reconciled would silently stamp its own
+        timestamp over the operator's, and a `--not-sent` reconcile landing
+        mid-flight could be re-approved into a SECOND transmit of the same body.
+        `_claim_for_sending`'s promise of "never a duplicate message" depends on
+        every one of these, not just on the claim.
+        """
+        with self._c.cursor() as cur:
+            cur.execute(sql, params)
+            changed = cur.rowcount
+        self._c.commit()
+        if changed != 1:
+            current = self.get_draft(draft_id)
+            raise SendGateError(
+                f"could not {what} for draft {draft_id!r}: it is no longer "
+                f"{expected!r} (now "
+                f"{(current or {}).get('send_state')!r}) — someone else moved it "
+                f"first. D3 approval gate."
+            )
 
     def _claim_for_sending(self, draft_id: int) -> None:
         """ATOMICALLY move an approved draft to `sending`, and COMMIT the claim.
@@ -1167,21 +1198,31 @@ class SignalDB:
             )
         if outcome == RECONCILE_SENT:
             server_ts = _server_timestamp({"timestamp": server_timestamp})
-            with self._c.cursor() as cur:
-                cur.execute(
-                    "UPDATE signal.messages SET message_timestamp = %s, "
-                    "send_state = %s, message_type = 'message', "
-                    "approval_ref = COALESCE(%s, approval_ref) WHERE id = %s",
-                    (server_ts, STATE_SENT, note, draft_id),
-                )
+            self._transition(
+                draft_id,
+                "UPDATE signal.messages SET message_timestamp = %s, "
+                "send_state = %s, message_type = 'message', "
+                "approval_ref = COALESCE(%s, approval_ref) "
+                "WHERE id = %s AND send_state = %s",
+                (server_ts, STATE_SENT, note, draft_id, STATE_SENDING),
+                expected=STATE_SENDING,
+                what="reconcile as sent",
+            )
         else:
-            with self._c.cursor() as cur:
-                cur.execute(
-                    "UPDATE signal.messages SET send_state = %s, "
-                    "approval_ref = %s WHERE id = %s",
-                    (STATE_PENDING, note, draft_id),
-                )
-        self._c.commit()
+            # COALESCE in BOTH branches. A bare `approval_ref = %s` here erased
+            # the recorded approval whenever the operator passed no `--note` —
+            # deleting the audit record of the very approval the attempt rode on,
+            # which is the thing `approve_draft`'s docstring stakes D3 on. A note
+            # ADDS to the record; it never replaces it.
+            self._transition(
+                draft_id,
+                "UPDATE signal.messages SET send_state = %s, "
+                "approval_ref = COALESCE(%s, approval_ref) "
+                "WHERE id = %s AND send_state = %s",
+                (STATE_PENDING, note, draft_id, STATE_SENDING),
+                expected=STATE_SENDING,
+                what="reconcile as not-sent",
+            )
         return self._draft_or_raise(draft_id)
 
     def account_number(self, draft_id: int) -> str:

--- a/scripts/signal/_signal_db.py
+++ b/scripts/signal/_signal_db.py
@@ -1,0 +1,898 @@
+#!/usr/bin/env python3
+"""DB access for the Signal chat pipeline (`signal` schema).
+
+Same Postgres instance as the mailbox (`mailbox-postgres-0`), a SEPARATE schema.
+This module is a deliberate clone of `scripts/mail-actions/_db.py` — same
+context-manager shape, same two connection modes:
+
+  * **Port-forward (default, OFF-cluster).** Workbench tools reach the in-cluster
+    ClusterIP through an ephemeral `kubectl port-forward`, torn down on exit.
+  * **Direct (IN-cluster).** The consumer Deployment reaches
+    `mailbox-postgres.mailbox.svc.cluster.local:5432` directly and must NOT spawn a
+    port-forward per query. Opt in with `SIGNAL_PG_HOST` (optionally
+    `SIGNAL_PG_PORT`) or the explicit `SIGNAL_PG_DIRECT=1`. See `_direct_target()`.
+
+Credentials come from `SIGNAL_PG_DSN` / the `dsn=` arg when provided, else the k8s
+secret `mailbox-postgres-auth` (key `pg-dsn`) — the mailbox and signal schemas share
+one database role.
+
+Every message body is passed as a BOUND PARAMETER; nothing is shell-escaped into
+`psql -c`.
+
+THE SEND SURFACE IS SPLIT IN TWO (decision D3, proposal §7)
+-----------------------------------------------------------
+`draft_message()` composes and STORES; `send_approved()` is the only thing that can
+transmit, and it can only do so by minting a `SendAuthorization` capability that
+`consumer.transmit_approved()` demands. The capability's constructor refuses direct
+construction, and `_mint_send_authorization()` refuses any draft whose `send_state`
+is not `approved`. So an un-approved draft has NO CODE ROUTE to the Signal API —
+the gate is a missing edge in the call graph, not a documented convention.
+"""
+from __future__ import annotations
+
+import contextlib
+import os
+import socket
+import subprocess
+import time
+import uuid
+from urllib.parse import urlparse
+
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError as exc:  # pragma: no cover - import guard
+    raise SystemExit(
+        "psycopg2 is required. On NixOS run under:\n"
+        "  nix-shell -p \"python3.withPackages(p:[p.psycopg2 p.requests p.minio])\" "
+        "--run 'python scripts/signal/consumer.py'"
+    ) from exc
+
+NAMESPACE = "mailbox"          # the signal SCHEMA lives on the mailbox Postgres
+SERVICE = "svc/mailbox-postgres"
+DSN_SECRET = "mailbox-postgres-auth"
+DSN_KEY = "pg-dsn"
+SCHEMA = "signal"
+
+# Deterministic placeholder identity for a sender the API has not resolved to a
+# UUID yet. See `placeholder_uuid()` — this is half of 🔧 correction #1.
+PLACEHOLDER_NS = uuid.UUID("6f9c0d1e-2b3a-4c5d-8e7f-0a1b2c3d4e5f")
+
+# Outbound draft lifecycle. `pending` -> `approved` -> `sent`; a draft is never
+# deleted, so it cannot be silently lost.
+STATE_PENDING = "pending"
+STATE_APPROVED = "approved"
+STATE_SENT = "sent"
+
+
+# --------------------------------------------------------------------------- #
+# Schema — the single source of truth. Tests DERIVE from these statements rather
+# than restating them, and the hermetic substrate translates them for sqlite.
+#
+# Four corrections against the original draft DDL are marked 🔧. Each one is a
+# named suite in scripts/signal/tests/ and each has been mutation-tested.
+# --------------------------------------------------------------------------- #
+SCHEMA_STATEMENTS: tuple[str, ...] = (
+    "CREATE SCHEMA IF NOT EXISTS signal",
+
+    """
+    CREATE TABLE IF NOT EXISTS signal.contacts (
+        id SERIAL PRIMARY KEY,
+        signal_uuid UUID UNIQUE NOT NULL,
+        phone_number TEXT,
+        display_name TEXT,
+        profile_name TEXT,
+        is_placeholder BOOLEAN DEFAULT false,
+        created_at TIMESTAMPTZ DEFAULT now()
+    )
+    """,
+
+    """
+    CREATE TABLE IF NOT EXISTS signal.groups (
+        id SERIAL PRIMARY KEY,
+        group_id BYTEA UNIQUE NOT NULL,
+        name TEXT NOT NULL,
+        revision INTEGER DEFAULT 0,
+        created_at TIMESTAMPTZ DEFAULT now()
+    )
+    """,
+
+    # 🔧 #1  `source_contact_id NOT NULL`. A UNIQUE over a NULLable column does
+    # NOT dedupe in Postgres (NULLs compare distinct), so an envelope from an
+    # unresolved sender would insert a fresh row on EVERY SSE redelivery.
+    # Unknown senders get a deterministic placeholder contact instead
+    # (`placeholder_uuid()`), which is what makes `unique_message` bite.
+    #
+    # 🔧 #4 (behavioural half) lives here too: `message_timestamp` for an
+    # outbound message MUST be the SERVER-assigned timestamp, because that is
+    # what the device-sync echo carries back through the SSE stream. Un-sent
+    # drafts hold a NEGATIVE provisional timestamp, which can never collide with
+    # a real (positive, epoch-ms) server timestamp.
+    """
+    CREATE TABLE IF NOT EXISTS signal.messages (
+        id BIGSERIAL PRIMARY KEY,
+        message_timestamp BIGINT NOT NULL,
+        server_received_at BIGINT,
+        server_delivered_at BIGINT,
+        source_contact_id INTEGER NOT NULL REFERENCES signal.contacts(id),
+        dest_contact_id INTEGER REFERENCES signal.contacts(id),
+        message_type TEXT NOT NULL,
+        body TEXT,
+        expires_in_seconds INTEGER,
+        view_once BOOLEAN DEFAULT false,
+        edit_target_timestamp BIGINT,
+        group_id INTEGER REFERENCES signal.groups(id),
+        is_outbound BOOLEAN DEFAULT false,
+        send_state TEXT,
+        approval_ref TEXT,
+        raw_envelope JSONB,
+        search tsvector GENERATED ALWAYS AS (to_tsvector('english', coalesce(body, ''))) STORED,
+        CONSTRAINT unique_message UNIQUE (source_contact_id, message_timestamp)
+    )
+    """,
+
+    # 🔧 #2  Without `unique_attachment`, an SSE redelivery of the same message
+    # duplicates every attachment row.
+    """
+    CREATE TABLE IF NOT EXISTS signal.attachments (
+        id BIGSERIAL PRIMARY KEY,
+        message_id BIGINT REFERENCES signal.messages(id) ON DELETE CASCADE,
+        signal_attachment_id TEXT NOT NULL,
+        content_type TEXT NOT NULL,
+        filename TEXT,
+        size_bytes BIGINT,
+        caption TEXT,
+        is_voice_note BOOLEAN DEFAULT false,
+        minio_bucket TEXT,
+        minio_key TEXT,
+        created_at TIMESTAMPTZ DEFAULT now(),
+        CONSTRAINT unique_attachment UNIQUE (message_id, signal_attachment_id)
+    )
+    """,
+
+    # 🔧 #3  `message_id` is NULLable and resolved LATER: a reaction can arrive
+    # BEFORE its target message (out-of-order SSE), or target a message we never
+    # received at all. A hard FK at insert time drops those on the floor.
+    """
+    CREATE TABLE IF NOT EXISTS signal.reactions (
+        id BIGSERIAL PRIMARY KEY,
+        message_id BIGINT REFERENCES signal.messages(id) ON DELETE CASCADE,
+        target_author_id INTEGER NOT NULL REFERENCES signal.contacts(id),
+        target_sent_timestamp BIGINT NOT NULL,
+        emoji TEXT NOT NULL,
+        contact_id INTEGER NOT NULL REFERENCES signal.contacts(id),
+        is_remove BOOLEAN DEFAULT false,
+        CONSTRAINT unique_reaction UNIQUE (contact_id, target_author_id, target_sent_timestamp)
+    )
+    """,
+
+    "CREATE INDEX IF NOT EXISTS idx_msg_ts ON signal.messages(message_timestamp DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_msg_dm ON signal.messages(source_contact_id, message_timestamp)",
+    "CREATE INDEX IF NOT EXISTS idx_msg_group ON signal.messages(group_id, message_timestamp) WHERE group_id IS NOT NULL",
+    "CREATE INDEX IF NOT EXISTS idx_msg_fts ON signal.messages USING GIN(search)",
+    "CREATE INDEX IF NOT EXISTS idx_att_msg ON signal.attachments(message_id)",
+    # The partial index that makes the unresolved-reaction sweep cheap (🔧 #3).
+    "CREATE INDEX IF NOT EXISTS idx_rx_unresolved ON signal.reactions(target_author_id, target_sent_timestamp) WHERE message_id IS NULL",
+)
+
+
+class SendGateError(RuntimeError):
+    """The D3 approval gate refused a transmit attempt.
+
+    Its own error type so a test can assert THIS guard fired, rather than
+    accepting any exception (a different guard's error, or a happy-path
+    resolution, would otherwise read as a kill).
+    """
+
+
+class SendAuthorization:
+    """Unforgeable capability: proof that ONE approved draft may be transmitted once.
+
+    Direct construction is refused. The only producer is
+    `_mint_send_authorization()`, which will not mint for a draft whose
+    `send_state` is not `approved`. `consumer.transmit_approved()` demands one of
+    these AND checks it against the live issue registry, so a hand-rolled
+    look-alike object cannot stand in for it.
+    """
+
+    __slots__ = ("draft_id", "recipient", "body", "_nonce")
+
+    def __init__(self, *_a, **_kw):  # pragma: no cover - exercised via the gate tests
+        raise SendGateError(
+            "SendAuthorization cannot be constructed directly — it is minted only "
+            "by _signal_db._mint_send_authorization() for a draft whose send_state "
+            "is 'approved' (D3 approval gate)"
+        )
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"<SendAuthorization draft={self.draft_id} nonce=…>"
+
+
+# Nonces of authorizations that have been minted and NOT yet spent. A capability
+# is single-use: `consumer.transmit_approved()` pops the nonce before sending, so
+# replaying the same object cannot transmit twice.
+_ISSUED_NONCES: set[str] = set()
+
+
+def _mint_send_authorization(draft: dict) -> SendAuthorization:
+    """Mint a one-shot send capability for an APPROVED draft row.
+
+    🔴 This is the whole gate. Raises `SendGateError` — naming the offending
+    state — for any draft that is not `approved`, so an un-approved draft has no
+    way to obtain the object `transmit_approved()` requires.
+    """
+    state = (draft or {}).get("send_state")
+    if state != STATE_APPROVED:
+        raise SendGateError(
+            f"draft {(draft or {}).get('id')!r} has send_state={state!r}; only "
+            f"{STATE_APPROVED!r} drafts may be transmitted (D3 approval gate)"
+        )
+    auth = object.__new__(SendAuthorization)
+    object.__setattr__(auth, "draft_id", draft["id"])
+    object.__setattr__(auth, "recipient", draft.get("recipient"))
+    object.__setattr__(auth, "body", draft.get("body"))
+    nonce = uuid.uuid4().hex
+    object.__setattr__(auth, "_nonce", nonce)
+    _ISSUED_NONCES.add(nonce)
+    return auth
+
+
+def spend_authorization(auth: object) -> None:
+    """Consume a capability, or raise `SendGateError`.
+
+    Called by `consumer.transmit_approved()` immediately before it touches the
+    network. Rejects (a) anything that is not a real `SendAuthorization` and
+    (b) a capability that has already been spent — which is what makes an
+    approved draft transmit EXACTLY once.
+    """
+    if not isinstance(auth, SendAuthorization):
+        raise SendGateError(
+            "transmit refused: a SendAuthorization minted from an approved draft "
+            "is required (D3 approval gate); got "
+            f"{type(auth).__name__}"
+        )
+    nonce = getattr(auth, "_nonce", None)
+    if nonce not in _ISSUED_NONCES:
+        raise SendGateError(
+            "transmit refused: this SendAuthorization has already been spent "
+            "(D3 approval gate — capabilities are single-use)"
+        )
+    _ISSUED_NONCES.discard(nonce)
+
+
+def _returned_id(cur, what: str) -> int:
+    """The id from an `INSERT … RETURNING id`, or an error that NAMES the write.
+
+    Every RETURNING in this module follows an `ON CONFLICT … DO UPDATE`, which
+    always yields a row — so this is a diagnostic guard, not a live branch. It
+    exists because the bare `cur.fetchone()[0]` it replaces surfaces any driver
+    or statement surprise as `TypeError: 'NoneType' object is not subscriptable`,
+    naming nothing.
+    """
+    row = cur.fetchone()
+    if row is None:
+        raise RuntimeError(f"{what}: INSERT … RETURNING id produced no row")
+    return row[0]
+
+
+def placeholder_uuid(identifier: str) -> str:
+    """Deterministic placeholder UUID for an unresolved sender (🔧 #1).
+
+    The SAME unresolved identifier always maps to the SAME contact row, so a
+    redelivered envelope from that sender hits `unique_message` instead of
+    inserting a second copy. Derived (uuid5) rather than random for exactly that
+    reason — a random uuid here would reintroduce the NULL-dedupe hole under a
+    different name.
+    """
+    return str(uuid.uuid5(PLACEHOLDER_NS, f"signal:{identifier}"))
+
+
+def _free_local_port() -> int:
+    """Ask the OS for a free TCP port (bind to 0, read it back, release)."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _read_dsn_from_secret() -> str:
+    """Read the Postgres DSN out of the k8s secret via kubectl + base64 decode."""
+    import base64
+
+    out = subprocess.check_output(
+        [
+            "kubectl", "-n", NAMESPACE, "get", "secret", DSN_SECRET,
+            "-o", f"jsonpath={{.data.{DSN_KEY}}}",
+        ],
+        text=True,
+    ).strip()
+    return base64.b64decode(out).decode().strip()
+
+
+def _dsn_connect_kwargs(dsn: str, *, host: str | None = None,
+                        port: int | None = None) -> dict:
+    """Parse a postgres:// DSN → psycopg2 connect kwargs.
+
+    `host`/`port` OVERRIDE the DSN's own values when provided; None keeps the
+    DSN's own. Falls back to 5432 when neither specifies a port.
+    """
+    u = urlparse(dsn)
+    if u.scheme not in ("postgres", "postgresql"):
+        raise ValueError(f"unexpected DSN scheme: {u.scheme!r}")
+    dbname = (u.path or "/").lstrip("/") or "mailbox"
+    return {
+        "host": host if host is not None else u.hostname,
+        "port": port if port is not None else (u.port or 5432),
+        "user": u.username,
+        "password": u.password,
+        "dbname": dbname,
+        "connect_timeout": 10,
+    }
+
+
+def _truthy(val: str | None) -> bool:
+    return (val or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _direct_target() -> tuple[str | None, int | None] | None:
+    """Decide whether to connect DIRECTLY (no kubectl port-forward), and to where.
+
+    None → port-forward (the off-cluster default). Otherwise `(host_override,
+    port_override)`, either of which may be None to mean "keep the DSN's value".
+
+      * `SIGNAL_PG_HOST` set → direct to that host; `SIGNAL_PG_PORT` overrides
+        the port (default: the DSN's, else 5432).
+      * `SIGNAL_PG_DIRECT` truthy → direct using the DSN's OWN host/port.
+    """
+    host = os.environ.get("SIGNAL_PG_HOST") or None
+    direct = _truthy(os.environ.get("SIGNAL_PG_DIRECT"))
+    if not host and not direct:
+        return None
+    port_s = os.environ.get("SIGNAL_PG_PORT")
+    port = int(port_s) if port_s and port_s.strip() else None
+    return host, port
+
+
+class SignalDB:
+    """Context manager: (optional) port-forward → psycopg2 connection, torn down on exit."""
+
+    def __init__(self, dsn: str | None = None, ready_timeout: float = 20.0):
+        self._dsn = dsn or os.environ.get("SIGNAL_PG_DSN")
+        self._ready_timeout = ready_timeout
+        self._pf: subprocess.Popen | None = None
+        self.conn: "psycopg2.extensions.connection | None" = None
+
+    # -- lifecycle ---------------------------------------------------------
+    def __enter__(self) -> "SignalDB":
+        direct = _direct_target()
+        if direct is not None:
+            dsn = self._dsn or _read_dsn_from_secret()
+            host_override, port_override = direct
+            kwargs = _dsn_connect_kwargs(dsn, host=host_override, port=port_override)
+            self.conn = psycopg2.connect(**kwargs)
+            self.conn.autocommit = False
+            return self
+
+        dsn = self._dsn or _read_dsn_from_secret()
+        local_port = _free_local_port()
+        self._pf = subprocess.Popen(
+            [
+                "kubectl", "-n", NAMESPACE, "port-forward", SERVICE,
+                f"{local_port}:5432",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        self._wait_for_port("127.0.0.1", local_port)
+        kwargs = _dsn_connect_kwargs(dsn, host="127.0.0.1", port=local_port)
+        self.conn = psycopg2.connect(**kwargs)
+        self.conn.autocommit = False
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        with contextlib.suppress(Exception):
+            if self.conn is not None:
+                self.conn.close()
+        if self._pf is not None:
+            self._pf.terminate()
+            with contextlib.suppress(Exception):
+                self._pf.wait(timeout=5)
+
+    @property
+    def _c(self):
+        if self.conn is None:
+            raise RuntimeError("SignalDB used outside its context manager (no connection)")
+        return self.conn
+
+    def _wait_for_port(self, host: str, port: int) -> None:
+        deadline = time.monotonic() + self._ready_timeout
+        while time.monotonic() < deadline:
+            if self._pf and self._pf.poll() is not None:
+                err = self._pf.stderr.read().decode() if self._pf.stderr else ""
+                raise RuntimeError(f"kubectl port-forward exited early:\n{err}")
+            with contextlib.suppress(OSError):
+                with socket.create_connection((host, port), timeout=1):
+                    return
+            time.sleep(0.25)
+        raise TimeoutError(f"port-forward to {host}:{port} not ready in time")
+
+    # -- schema ------------------------------------------------------------
+    def ensure_schema(self) -> None:
+        """Create the `signal` schema. Idempotent — every statement is IF NOT EXISTS."""
+        with self._c.cursor() as cur:
+            for stmt in SCHEMA_STATEMENTS:
+                cur.execute(stmt)
+        self._c.commit()
+
+    # -- contacts / groups -------------------------------------------------
+    def upsert_contact(self, *, signal_uuid: str | None = None,
+                       phone_number: str | None = None,
+                       display_name: str | None = None,
+                       profile_name: str | None = None) -> int:
+        """Insert-or-update one contact, returning its id.
+
+        🔧 #1: when the envelope carries NO uuid, a DETERMINISTIC placeholder is
+        derived from the phone number (or any other stable identifier) instead of
+        leaving the sender unresolved. That is what keeps `unique_message` able to
+        dedupe a redelivered envelope from an unknown sender.
+        """
+        is_placeholder = False
+        if not signal_uuid:
+            ident = phone_number or display_name or profile_name
+            if not ident:
+                raise ValueError(
+                    "upsert_contact needs a signal_uuid or some stable identifier; "
+                    "an unidentifiable sender would break message dedupe (🔧 #1)"
+                )
+            signal_uuid = placeholder_uuid(ident)
+            is_placeholder = True
+        elif phone_number:
+            # PLACEHOLDER PROMOTION. A draft addressed to a bare phone number
+            # created a placeholder contact; the same person's envelopes arrive
+            # carrying the REAL uuid. Without this the two are separate contact
+            # rows — and the outbound sync echo (🔧 #4) would then land under a
+            # DIFFERENT source_contact_id from the sent row, so `unique_message`
+            # would not catch it and every sent message would be stored twice.
+            # Promotion keeps the row IDENTITY, so the echo collides as intended.
+            self._promote_placeholder(signal_uuid, phone_number)
+        with self._c.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO signal.contacts
+                    (signal_uuid, phone_number, display_name, profile_name, is_placeholder)
+                VALUES (%s, %s, %s, %s, %s)
+                ON CONFLICT (signal_uuid) DO UPDATE SET
+                    phone_number = COALESCE(EXCLUDED.phone_number, contacts.phone_number),
+                    display_name = COALESCE(EXCLUDED.display_name, contacts.display_name),
+                    profile_name = COALESCE(EXCLUDED.profile_name, contacts.profile_name)
+                RETURNING id
+                """,
+                (signal_uuid, phone_number, display_name, profile_name, is_placeholder),
+            )
+            return _returned_id(cur, "upsert_contact")
+
+    def _promote_placeholder(self, signal_uuid: str, phone_number: str) -> int:
+        """Give a placeholder contact its real uuid, preserving its row id.
+
+        The `NOT EXISTS` guard is load-bearing: if a real contact with that uuid
+        already exists, promoting would violate `contacts.signal_uuid UNIQUE`.
+        In that case the placeholder is simply left alone. Returns the rowcount.
+        """
+        with self._c.cursor() as cur:
+            cur.execute(
+                "UPDATE signal.contacts SET signal_uuid = %s, is_placeholder = false "
+                "WHERE phone_number = %s AND is_placeholder "
+                "AND NOT EXISTS (SELECT 1 FROM signal.contacts c2 "
+                "                WHERE c2.signal_uuid = %s)",
+                (signal_uuid, phone_number, signal_uuid),
+            )
+            return cur.rowcount
+
+    def upsert_group(self, *, group_id: bytes, name: str | None = None,
+                     revision: int = 0) -> int:
+        with self._c.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO signal.groups (group_id, name, revision)
+                VALUES (%s, %s, %s)
+                ON CONFLICT (group_id) DO UPDATE SET
+                    name = COALESCE(EXCLUDED.name, groups.name),
+                    revision = GREATEST(EXCLUDED.revision, groups.revision)
+                RETURNING id
+                """,
+                (group_id, name or "", revision),
+            )
+            return _returned_id(cur, "upsert_group")
+
+    # -- messages ----------------------------------------------------------
+    def upsert_message(self, msg: dict) -> int:
+        """Store one parsed message idempotently; returns its row id.
+
+        `msg` is a `consumer.parse_envelope()` result rendered as a dict. Resolves
+        the sender (placeholder if needed — 🔧 #1), the group, the attachments
+        (🔧 #2), and any reactions that arrived BEFORE this message (🔧 #3).
+        """
+        source_id = self.upsert_contact(
+            signal_uuid=msg.get("source_uuid"),
+            phone_number=msg.get("source_number"),
+            display_name=msg.get("source_name"),
+        )
+        dest_id = None
+        if msg.get("dest_uuid") or msg.get("dest_number"):
+            dest_id = self.upsert_contact(
+                signal_uuid=msg.get("dest_uuid"),
+                phone_number=msg.get("dest_number"),
+            )
+        group_row_id = None
+        if msg.get("group_id"):
+            group_row_id = self.upsert_group(
+                group_id=msg["group_id"], name=msg.get("group_name"),
+            )
+        params = {
+            "message_timestamp": msg["message_timestamp"],
+            "server_received_at": msg.get("server_received_at"),
+            "server_delivered_at": msg.get("server_delivered_at"),
+            "source_contact_id": source_id,
+            "dest_contact_id": dest_id,
+            "message_type": msg.get("message_type") or "unknown",
+            "body": msg.get("body"),
+            "expires_in_seconds": msg.get("expires_in_seconds"),
+            "view_once": bool(msg.get("view_once")),
+            "edit_target_timestamp": msg.get("edit_target_timestamp"),
+            "group_id": group_row_id,
+            "is_outbound": bool(msg.get("is_outbound")),
+            "raw_envelope": msg.get("raw_envelope"),
+        }
+        with self._c.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO signal.messages
+                    (message_timestamp, server_received_at, server_delivered_at,
+                     source_contact_id, dest_contact_id, message_type, body,
+                     expires_in_seconds, view_once, edit_target_timestamp,
+                     group_id, is_outbound, raw_envelope)
+                VALUES
+                    (%(message_timestamp)s, %(server_received_at)s,
+                     %(server_delivered_at)s, %(source_contact_id)s,
+                     %(dest_contact_id)s, %(message_type)s, %(body)s,
+                     %(expires_in_seconds)s, %(view_once)s,
+                     %(edit_target_timestamp)s, %(group_id)s, %(is_outbound)s,
+                     %(raw_envelope)s)
+                ON CONFLICT (source_contact_id, message_timestamp) DO UPDATE SET
+                    server_delivered_at = COALESCE(EXCLUDED.server_delivered_at,
+                                                   messages.server_delivered_at),
+                    body = COALESCE(messages.body, EXCLUDED.body)
+                RETURNING id
+                """,
+                params,
+            )
+            message_id = _returned_id(cur, "upsert_message")
+
+        for att in msg.get("attachments") or []:
+            self.upsert_attachment(message_id, att)
+
+        # 🔧 #3 — a reaction may have arrived BEFORE this message.
+        self.resolve_pending_reactions(
+            message_id=message_id,
+            target_author_id=source_id,
+            target_sent_timestamp=msg["message_timestamp"],
+        )
+        return message_id
+
+    def upsert_attachment(self, message_id: int, att: dict) -> None:
+        """🔧 #2 — idempotent on `(message_id, signal_attachment_id)`."""
+        with self._c.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO signal.attachments
+                    (message_id, signal_attachment_id, content_type, filename,
+                     size_bytes, caption, is_voice_note, minio_bucket, minio_key)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (message_id, signal_attachment_id) DO UPDATE SET
+                    minio_bucket = COALESCE(EXCLUDED.minio_bucket,
+                                            attachments.minio_bucket),
+                    minio_key = COALESCE(EXCLUDED.minio_key,
+                                         attachments.minio_key)
+                """,
+                (
+                    message_id, att.get("id"), att.get("content_type") or "",
+                    att.get("filename"), att.get("size"), att.get("caption"),
+                    bool(att.get("is_voice_note")), att.get("minio_bucket"),
+                    att.get("minio_key"),
+                ),
+            )
+
+    def record_attachment_object(self, message_id: int, attachment_id: str,
+                                 bucket: str, key: str) -> int:
+        """Stamp where an attachment's bytes landed in MinIO. Returns rowcount."""
+        with self._c.cursor() as cur:
+            cur.execute(
+                "UPDATE signal.attachments SET minio_bucket = %s, minio_key = %s "
+                "WHERE message_id = %s AND signal_attachment_id = %s",
+                (bucket, key, message_id, attachment_id),
+            )
+            return cur.rowcount
+
+    # -- reactions ---------------------------------------------------------
+    def upsert_reaction(self, rx: dict) -> int:
+        """Store one reaction, resolving its target message if we already have it.
+
+        🔧 #3 — the target may not exist yet (out-of-order SSE) or may never
+        arrive. `message_id` stays NULL in that case and is filled in later by
+        `resolve_pending_reactions()`; the reaction is RETAINED either way.
+        """
+        author_id = self.upsert_contact(
+            signal_uuid=rx.get("target_author_uuid"),
+            phone_number=rx.get("target_author_number"),
+        )
+        reactor_id = self.upsert_contact(
+            signal_uuid=rx.get("source_uuid"),
+            phone_number=rx.get("source_number"),
+        )
+        with self._c.cursor() as cur:
+            cur.execute(
+                "SELECT id FROM signal.messages "
+                "WHERE source_contact_id = %s AND message_timestamp = %s",
+                (author_id, rx["target_sent_timestamp"]),
+            )
+            row = cur.fetchone()
+            target_message_id = row[0] if row else None
+            cur.execute(
+                """
+                INSERT INTO signal.reactions
+                    (message_id, target_author_id, target_sent_timestamp, emoji,
+                     contact_id, is_remove)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                ON CONFLICT (contact_id, target_author_id, target_sent_timestamp)
+                DO UPDATE SET
+                    emoji = EXCLUDED.emoji,
+                    is_remove = EXCLUDED.is_remove,
+                    message_id = COALESCE(EXCLUDED.message_id,
+                                          reactions.message_id)
+                RETURNING id
+                """,
+                (
+                    target_message_id, author_id, rx["target_sent_timestamp"],
+                    rx.get("emoji") or "", reactor_id, bool(rx.get("is_remove")),
+                ),
+            )
+            return _returned_id(cur, "upsert_reaction")
+
+    def resolve_pending_reactions(self, *, message_id: int, target_author_id: int,
+                                  target_sent_timestamp: int) -> int:
+        """Attach previously-unresolvable reactions to a message that just arrived.
+
+        🔧 #3 — the WHERE clause is exactly the partial index
+        `idx_rx_unresolved (target_author_id, target_sent_timestamp) WHERE
+        message_id IS NULL`. Returns the number of reactions resolved.
+        """
+        with self._c.cursor() as cur:
+            cur.execute(
+                "UPDATE signal.reactions SET message_id = %s "
+                "WHERE message_id IS NULL AND target_author_id = %s "
+                "AND target_sent_timestamp = %s",
+                (message_id, target_author_id, target_sent_timestamp),
+            )
+            return cur.rowcount
+
+    def unresolved_reactions(self) -> list:
+        """Reactions whose target message has never been received."""
+        with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                "SELECT id, target_author_id, target_sent_timestamp, emoji, "
+                "contact_id, is_remove FROM signal.reactions WHERE message_id IS NULL"
+            )
+            return [dict(r) for r in cur.fetchall()]
+
+    # -- reads -------------------------------------------------------------
+    def list_conversations(self, limit: int = 50) -> list:
+        """One row per conversation (group, else the DM peer), newest first."""
+        with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT
+                    m.group_id AS group_row_id,
+                    g.name AS group_name,
+                    m.source_contact_id AS contact_id,
+                    c.display_name,
+                    c.phone_number,
+                    max(m.message_timestamp) AS last_message_timestamp,
+                    count(*) AS message_count
+                FROM signal.messages m
+                LEFT JOIN signal.groups g ON g.id = m.group_id
+                LEFT JOIN signal.contacts c ON c.id = m.source_contact_id
+                GROUP BY m.group_id, g.name, m.source_contact_id, c.display_name,
+                         c.phone_number
+                ORDER BY last_message_timestamp DESC
+                LIMIT %s
+                """,
+                (limit,),
+            )
+            return [dict(r) for r in cur.fetchall()]
+
+    def search(self, query: str, limit: int = 25) -> list:
+        """Full-text search over message bodies (the STORED tsvector + GIN index).
+
+        The query text is a BOUND PARAMETER — never interpolated into SQL.
+        """
+        with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT m.id, m.message_timestamp, m.body, m.is_outbound,
+                       c.display_name, c.phone_number
+                FROM signal.messages m
+                LEFT JOIN signal.contacts c ON c.id = m.source_contact_id
+                WHERE m.search @@ websearch_to_tsquery('english', %s)
+                ORDER BY m.message_timestamp DESC
+                LIMIT %s
+                """,
+                (query, limit),
+            )
+            return [dict(r) for r in cur.fetchall()]
+
+    def get_message(self, message_id: int) -> dict | None:
+        with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                "SELECT id, message_timestamp, source_contact_id, dest_contact_id, "
+                "message_type, body, is_outbound, send_state, approval_ref "
+                "FROM signal.messages WHERE id = %s",
+                (message_id,),
+            )
+            row = cur.fetchone()
+            return dict(row) if row else None
+
+    # -- the SPLIT send surface (D3) ---------------------------------------
+    def draft_message(self, *, recipient: str, body: str,
+                      self_uuid: str | None = None,
+                      self_number: str | None = None,
+                      approval_ref: str | None = None,
+                      provisional_timestamp: int | None = None) -> dict:
+        """Compose and STORE an outbound draft. **Transmits nothing.**
+
+        The draft is persisted immediately with `send_state='pending'` so it can
+        never be silently lost, and with a NEGATIVE provisional timestamp — a real
+        server timestamp is positive epoch-ms, so the provisional value can never
+        be mistaken for one, and `send_approved()` overwrites it with the SERVER's
+        (🔧 #4).
+        """
+        if not (self_uuid or self_number):
+            raise ValueError("draft_message needs the sending account's uuid or number")
+        source_id = self.upsert_contact(
+            signal_uuid=self_uuid, phone_number=self_number, display_name="me",
+        )
+        dest_id = self.upsert_contact(phone_number=recipient) \
+            if not _looks_like_uuid(recipient) else self.upsert_contact(signal_uuid=recipient)
+        ts = provisional_timestamp if provisional_timestamp is not None \
+            else -int(time.time() * 1000)
+        if ts >= 0:
+            raise ValueError(
+                "a draft's provisional timestamp must be NEGATIVE so it cannot "
+                "collide with a server-assigned timestamp (🔧 #4)"
+            )
+        with self._c.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO signal.messages
+                    (message_timestamp, source_contact_id, dest_contact_id,
+                     message_type, body, is_outbound, send_state, approval_ref)
+                VALUES (%s, %s, %s, 'draft', %s, true, %s, %s)
+                RETURNING id
+                """,
+                (ts, source_id, dest_id, body, STATE_PENDING, approval_ref),
+            )
+            draft_id = _returned_id(cur, "draft_message")
+        self._c.commit()
+        return {
+            "id": draft_id, "recipient": recipient, "body": body,
+            "send_state": STATE_PENDING, "message_timestamp": ts,
+            "source_contact_id": source_id, "dest_contact_id": dest_id,
+            "approval_ref": approval_ref,
+        }
+
+    def approve_draft(self, draft_id: int, *, approval_ref: str) -> dict:
+        """Record Zach's clawgate approval for a pending draft.
+
+        Only a `pending` draft may be approved; approving anything else raises
+        `SendGateError` so a `sent` draft cannot be re-armed.
+        """
+        row = self._draft_or_raise(draft_id)
+        if row["send_state"] != STATE_PENDING:
+            raise SendGateError(
+                f"draft {draft_id!r} has send_state={row['send_state']!r}; only "
+                f"{STATE_PENDING!r} drafts may be approved (D3 approval gate)"
+            )
+        with self._c.cursor() as cur:
+            cur.execute(
+                "UPDATE signal.messages SET send_state = %s, approval_ref = %s "
+                "WHERE id = %s",
+                (STATE_APPROVED, approval_ref, draft_id),
+            )
+        self._c.commit()
+        return self._draft_or_raise(draft_id)
+
+    def _draft_or_raise(self, draft_id: int) -> dict:
+        """`get_draft`, but a missing row is the gate's own error, not a `None`.
+
+        Both callers below treat "no such draft" as a refusal, and both then
+        SUBSCRIPT the result — so returning `None` here would surface a real
+        refusal case as `TypeError: 'NoneType' object is not subscriptable`.
+        """
+        row = self.get_draft(draft_id)
+        if row is None:
+            raise SendGateError(f"draft {draft_id!r} does not exist (D3 approval gate)")
+        return row
+
+    def get_draft(self, draft_id: int) -> dict | None:
+        with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT m.id, m.message_timestamp, m.body, m.send_state,
+                       m.approval_ref, m.source_contact_id, m.dest_contact_id,
+                       CASE WHEN d.is_placeholder THEN d.phone_number
+                            ELSE COALESCE(d.signal_uuid, d.phone_number)
+                       END AS recipient
+                FROM signal.messages m
+                LEFT JOIN signal.contacts d ON d.id = m.dest_contact_id
+                WHERE m.id = %s AND m.is_outbound
+                """,
+                (draft_id,),
+            )
+            row = cur.fetchone()
+            return dict(row) if row else None
+
+    def list_drafts(self, state: str | None = None) -> list:
+        sql = ("SELECT id, message_timestamp, body, send_state, approval_ref "
+               "FROM signal.messages WHERE is_outbound AND send_state IS NOT NULL")
+        params: tuple = ()
+        if state is not None:
+            sql += " AND send_state = %s"
+            params = (state,)
+        sql += " ORDER BY id"
+        with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(sql, params)
+            return [dict(r) for r in cur.fetchall()]
+
+    def send_approved(self, draft_id: int, *, transmit=None) -> dict:
+        """Transmit an APPROVED draft. The ONLY path from this module to the API.
+
+        🔴 The gate: `_mint_send_authorization()` refuses to produce the
+        capability unless the stored `send_state` is `approved`, and
+        `consumer.transmit_approved()` refuses to send without one. There is no
+        argument to this function that skips the check, and no other function in
+        `scripts/signal/` posts to the send endpoint.
+
+        🔧 #4: the SERVER-assigned timestamp returned by the API is written back
+        onto the draft row, so the device-sync echo of this very message collides
+        with `unique_message` instead of inserting a duplicate.
+        """
+        draft = self._draft_or_raise(draft_id)
+        auth = _mint_send_authorization(draft)
+        if transmit is None:
+            from consumer import transmit_approved as transmit  # local import: no cycle
+        result = transmit(auth, recipient=draft["recipient"], body=draft["body"])
+        server_ts = int(result["timestamp"])
+        if server_ts <= 0:
+            raise ValueError(
+                f"the Signal API returned a non-positive timestamp {server_ts!r}; "
+                "storing it would break sync-echo dedupe (🔧 #4)"
+            )
+        with self._c.cursor() as cur:
+            cur.execute(
+                "UPDATE signal.messages SET message_timestamp = %s, send_state = %s, "
+                "message_type = 'message' WHERE id = %s",
+                (server_ts, STATE_SENT, draft_id),
+            )
+        self._c.commit()
+        return self._draft_or_raise(draft_id)
+
+    def commit(self) -> None:
+        self._c.commit()
+
+
+def _looks_like_uuid(value: str) -> bool:
+    try:
+        uuid.UUID(str(value))
+        return True
+    except (ValueError, AttributeError, TypeError):
+        return False

--- a/scripts/signal/clawgate.py
+++ b/scripts/signal/clawgate.py
@@ -37,13 +37,19 @@ def build_draft_payload(*, draft_id: int, recipient: str, body: str) -> dict:
     preview = (body or "").strip()
     if len(preview) > BODY_PREVIEW_MAX:
         preview = preview[:BODY_PREVIEW_MAX] + "…"
+    # 🔴 The card deliberately does NOT print the `approve` command. An earlier
+    # revision did, which handed the drafting agent — the one that just posted
+    # this card — the exact incantation to approve its own draft. The card's job
+    # is to tell a HUMAN a draft is waiting; approval is an operator step run
+    # from an operator shell (it needs `SIGNAL_APPROVAL_TOKEN`, which no agent
+    # environment carries).
     lines = [
         f"To: {recipient}",
         "",
         preview,
         "",
-        f"Approve: consumer.py approve {draft_id} --ref <clawgate-ref>",
-        f"Then send: consumer.py send {draft_id}",
+        f"Waiting for your approval — draft #{draft_id}.",
+        "Approve from your own shell; see the `signal` skill.",
     ]
     return {
         "directory": f"\U0001F5E8 signal draft #{draft_id} · {recipient}"[:TITLE_MAX],

--- a/scripts/signal/clawgate.py
+++ b/scripts/signal/clawgate.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Surface an outbound Signal DRAFT as a clawgate Task card (decision D3).
+
+A clone of `scripts/mail-actions/clawgate.py`, including its graceful no-op:
+with `CLAWGATE_HOOK_TOKEN` unset, `emit_draft_task` posts nothing and returns
+False rather than raising — the draft is already durably stored, so a missing
+token degrades notification, never the record.
+
+Contract note (inherited, verified in mail-actions): clawgate's
+`POST /api/tasks` handler decodes ONLY `directory, body, model, repo, branch,
+privileges`. There is NO `title` field — a `title` key is silently dropped, and
+the card's DISPLAY title is `directory`. So the human-readable label goes in
+`directory`.
+
+🔴 THIS MODULE CANNOT SEND A SIGNAL MESSAGE. It notifies a human that a draft is
+waiting. Transmission happens only in `consumer.transmit_approved()`, which
+demands a capability minted from an APPROVED draft row.
+"""
+from __future__ import annotations
+
+import os
+
+ENDPOINT = "http://192.168.50.250:30302/api/tasks"
+
+# clawgate renders `directory` as the card title; trim to a sane label length.
+TITLE_MAX = 120
+# How much of the draft body goes on the card. The full text is in Postgres.
+BODY_PREVIEW_MAX = 800
+
+
+def build_draft_payload(*, draft_id: int, recipient: str, body: str) -> dict:
+    """Build the `POST /api/tasks` JSON body for one pending Signal draft.
+
+    Pure + side-effect-free so it can be asserted in a unit test. Carries the
+    approval command the operator runs, so the card is actionable on its own.
+    """
+    preview = (body or "").strip()
+    if len(preview) > BODY_PREVIEW_MAX:
+        preview = preview[:BODY_PREVIEW_MAX] + "…"
+    lines = [
+        f"To: {recipient}",
+        "",
+        preview,
+        "",
+        f"Approve: consumer.py approve {draft_id} --ref <clawgate-ref>",
+        f"Then send: consumer.py send {draft_id}",
+    ]
+    return {
+        "directory": f"\U0001F5E8 signal draft #{draft_id} · {recipient}"[:TITLE_MAX],
+        "body": "\n".join(lines),
+    }
+
+
+def emit_draft_task(*, draft_id: int, recipient: str, body: str,
+                    timeout: float = 10.0) -> bool:
+    """Post one clawgate Task card for a pending draft. True if posted.
+
+    Graceful no-op (returns False, posts nothing) when `CLAWGATE_HOOK_TOKEN` is
+    unset — mirroring `mail-actions/clawgate.py`.
+    """
+    token = os.environ.get("CLAWGATE_HOOK_TOKEN")
+    if not token:
+        return False
+    import requests
+
+    payload = build_draft_payload(draft_id=draft_id, recipient=recipient, body=body)
+    resp = requests.post(
+        ENDPOINT,
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        json=payload,
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    return True

--- a/scripts/signal/consumer.py
+++ b/scripts/signal/consumer.py
@@ -1,0 +1,614 @@
+#!/usr/bin/env python3
+"""Signal consumer — SSE stream → parsed envelope → Postgres (+ MinIO attachments).
+
+Runs as a long-lived in-cluster Deployment next to `signal-cli-rest-api`
+(json-rpc-native mode). It consumes `GET /api/v1/events`, turns each JSON-RPC
+`receive` notification into a structured event, and stores it idempotently
+through `_signal_db.SignalDB`.
+
+WHAT IT MUST SURVIVE (each has a named test in tests/test_consumer_resilience.py)
+--------------------------------------------------------------------------------
+* an SSE disconnect/reconnect that REDELIVERS events — dedupe makes replay a
+  no-op, so nothing is lost and nothing is duplicated;
+* a malformed event — skipped and counted, never fatal;
+* Postgres briefly unavailable — retried with backoff, the event is not dropped;
+* an attachment fetch failing — the MESSAGE write still stands (attachment
+  bytes are fetched AFTER the row is committed, never inside its transaction).
+
+THE SEND PATH (D3, proposal §7)
+-------------------------------
+`transmit_approved()` is the ONLY function in `scripts/signal/` that posts to the
+Signal send endpoint, and it refuses to run without a `SendAuthorization`
+capability that `_signal_db._mint_send_authorization()` mints only for a draft
+whose stored `send_state` is `approved`. The un-approved path has no code route
+here — see tests/test_approval_gate.py, which tries to take it.
+
+Every third-party call (HTTP, Postgres, MinIO) is injectable, which is what makes
+the whole suite hermetic.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import psycopg2  # noqa: E402  (real class objects for the retry classifier)
+
+import _signal_db  # noqa: E402
+from _signal_db import (  # noqa: E402
+    STATE_APPROVED,
+    STATE_PENDING,
+    STATE_SENT,
+    SendGateError,
+    SignalDB,
+    spend_authorization,
+)
+
+API_URL = os.environ.get("SIGNAL_API_URL", "http://signal-api.signal.svc:8080")
+EVENTS_PATH = "/api/v1/events"
+ATTACHMENT_PATH = "/v1/attachments"
+SEND_PATH = "/v2/send"
+
+# --------------------------------------------------------------------------- #
+# The event kinds this consumer emits. tests/test_skill_doc.py DERIVES this list
+# from the source text below and fails if SKILL.md does not document one — a
+# hand-written ledger could not catch the thing it exists to catch.
+# --------------------------------------------------------------------------- #
+KIND_MESSAGE = "message"
+KIND_GROUP_MESSAGE = "group_message"
+KIND_REACTION = "reaction"
+KIND_EDIT = "edit"
+KIND_SYNC_OUTBOUND = "sync_outbound"
+KIND_RECEIPT_DELIVERY = "receipt_delivery"
+KIND_RECEIPT_READ = "receipt_read"
+KIND_TYPING = "typing"
+KIND_UNKNOWN = "unknown"
+
+# Counters the daemon reports. Also derived + doc-checked by test_skill_doc.py.
+STAT_STORED = "stored"
+STAT_IGNORED = "ignored"
+STAT_MALFORMED = "malformed"
+STAT_RECONNECTS = "reconnects"
+STAT_DB_RETRIES = "db_retries"
+STAT_ATTACHMENT_FAILURES = "attachment_failures"
+
+# Kinds that are stored as rows; everything else is observed and counted only.
+STORED_KINDS = (KIND_MESSAGE, KIND_GROUP_MESSAGE, KIND_EDIT, KIND_SYNC_OUTBOUND)
+
+# Transient Postgres faults worth retrying. NOT a bare `Exception`: a programming
+# error must fail loudly rather than be retried three times and swallowed.
+TRANSIENT_DB_ERRORS = (psycopg2.OperationalError, psycopg2.InterfaceError)
+
+
+@dataclass
+class ParsedEvent:
+    """One SSE envelope, normalised. `kind` is one of the KIND_* constants."""
+
+    kind: str
+    message: dict | None = None
+    reaction: dict | None = None
+    receipt: dict | None = None
+    raw_envelope: str | None = None
+    notes: list[str] = field(default_factory=list)
+
+
+class MalformedEvent(ValueError):
+    """The SSE payload was not a usable envelope. Skipped, counted, never fatal."""
+
+
+# --------------------------------------------------------------------------- #
+# Envelope parsing — pure, no I/O, so the whole fixture corpus is a unit test.
+# --------------------------------------------------------------------------- #
+def _decode_group_id(raw) -> bytes | None:
+    """signal-cli hands group ids back base64-encoded; the column is BYTEA."""
+    if raw in (None, ""):
+        return None
+    if isinstance(raw, bytes):
+        return raw
+    try:
+        return base64.b64decode(raw)
+    except Exception:
+        return str(raw).encode()
+
+
+def _attachments(data: dict) -> list[dict]:
+    out = []
+    for a in data.get("attachments") or []:
+        out.append({
+            "id": a.get("id"),
+            "content_type": a.get("contentType"),
+            "filename": a.get("filename"),
+            "size": a.get("size"),
+            "caption": a.get("caption"),
+            "is_voice_note": bool(a.get("voiceNote")),
+        })
+    return out
+
+
+def _base_message(env: dict, data: dict, *, timestamp: int) -> dict:
+    group = data.get("groupInfo") or {}
+    quote = data.get("quote") or {}
+    return {
+        "message_timestamp": timestamp,
+        "server_received_at": env.get("serverReceivedTimestamp"),
+        "server_delivered_at": env.get("serverDeliveredTimestamp"),
+        "source_uuid": env.get("sourceUuid"),
+        "source_number": env.get("sourceNumber") or env.get("source"),
+        "source_name": env.get("sourceName"),
+        "message_type": KIND_MESSAGE,
+        "body": data.get("message"),
+        "expires_in_seconds": data.get("expiresInSeconds"),
+        "view_once": bool(data.get("viewOnce")),
+        "edit_target_timestamp": None,
+        "group_id": _decode_group_id(group.get("groupId")),
+        "group_name": group.get("name"),
+        "quote_timestamp": quote.get("id"),
+        "quote_author": quote.get("authorUuid") or quote.get("author"),
+        "attachments": _attachments(data),
+        "is_outbound": False,
+    }
+
+
+def parse_envelope(envelope: dict) -> ParsedEvent:
+    """Normalise one signal-cli envelope into a `ParsedEvent`.
+
+    Raises `MalformedEvent` when the payload is not an envelope at all. An
+    envelope of a shape we do not handle is NOT an error: it comes back as
+    `KIND_UNKNOWN` so it is counted and visible rather than silently dropped.
+    """
+    if not isinstance(envelope, dict):
+        raise MalformedEvent(f"envelope is {type(envelope).__name__}, not an object")
+    if "timestamp" not in envelope and not any(
+        k in envelope for k in ("dataMessage", "syncMessage", "receiptMessage",
+                                "typingMessage", "editMessage")
+    ):
+        raise MalformedEvent("envelope has neither a timestamp nor any known sub-message")
+
+    raw = json.dumps(envelope, sort_keys=True)
+    env_ts = envelope.get("timestamp")
+
+    # -- sync (an outbound message echoed back from another linked device) ----
+    sync = envelope.get("syncMessage") or {}
+    sent = sync.get("sentMessage")
+    if sent:
+        ts = sent.get("timestamp") or env_ts
+        if ts is None:
+            raise MalformedEvent("sync sentMessage has no timestamp")
+        msg = _base_message(envelope, sent, timestamp=ts)
+        msg["message_type"] = KIND_SYNC_OUTBOUND
+        msg["is_outbound"] = True
+        msg["dest_uuid"] = sent.get("destinationUuid")
+        msg["dest_number"] = sent.get("destination")
+        msg["raw_envelope"] = raw
+        return ParsedEvent(kind=KIND_SYNC_OUTBOUND, message=msg, raw_envelope=raw)
+
+    # -- edit -----------------------------------------------------------------
+    edit = envelope.get("editMessage") or {}
+    if edit:
+        data = edit.get("dataMessage") or {}
+        ts = data.get("timestamp") or env_ts
+        if ts is None:
+            raise MalformedEvent("editMessage has no timestamp")
+        msg = _base_message(envelope, data, timestamp=ts)
+        msg["message_type"] = KIND_EDIT
+        msg["edit_target_timestamp"] = edit.get("targetSentTimestamp")
+        msg["raw_envelope"] = raw
+        return ParsedEvent(kind=KIND_EDIT, message=msg, raw_envelope=raw)
+
+    # -- data message (DM / group / reaction) ---------------------------------
+    data = envelope.get("dataMessage") or {}
+    if data:
+        reaction = data.get("reaction")
+        if reaction:
+            rx = {
+                "source_uuid": envelope.get("sourceUuid"),
+                "source_number": envelope.get("sourceNumber") or envelope.get("source"),
+                "target_author_uuid": reaction.get("targetAuthorUuid"),
+                "target_author_number": reaction.get("targetAuthor"),
+                "target_sent_timestamp": reaction.get("targetSentTimestamp"),
+                "emoji": reaction.get("emoji"),
+                "is_remove": bool(reaction.get("isRemove")),
+            }
+            if rx["target_sent_timestamp"] is None:
+                raise MalformedEvent("reaction has no targetSentTimestamp")
+            return ParsedEvent(kind=KIND_REACTION, reaction=rx, raw_envelope=raw)
+
+        ts = data.get("timestamp") or env_ts
+        if ts is None:
+            raise MalformedEvent("dataMessage has no timestamp")
+        msg = _base_message(envelope, data, timestamp=ts)
+        msg["raw_envelope"] = raw
+        kind = KIND_GROUP_MESSAGE if msg["group_id"] else KIND_MESSAGE
+        msg["message_type"] = kind
+        return ParsedEvent(kind=kind, message=msg, raw_envelope=raw)
+
+    # -- receipts / typing ----------------------------------------------------
+    receipt = envelope.get("receiptMessage") or {}
+    if receipt:
+        kind = KIND_RECEIPT_DELIVERY if receipt.get("isDelivery") else KIND_RECEIPT_READ
+        return ParsedEvent(
+            kind=kind,
+            receipt={
+                "when": receipt.get("when"),
+                "timestamps": list(receipt.get("timestamps") or []),
+                "source_uuid": envelope.get("sourceUuid"),
+            },
+            raw_envelope=raw,
+        )
+
+    typing = envelope.get("typingMessage") or {}
+    if typing:
+        return ParsedEvent(
+            kind=KIND_TYPING,
+            receipt={"action": typing.get("action"),
+                     "source_uuid": envelope.get("sourceUuid")},
+            raw_envelope=raw,
+        )
+
+    # Handled shape, unknown content: visible, counted, never dropped silently.
+    return ParsedEvent(kind=KIND_UNKNOWN, raw_envelope=raw,
+                       notes=[f"unhandled envelope keys: {sorted(envelope)}"])
+
+
+def parse_sse_payload(payload: str) -> dict:
+    """One SSE `data:` payload → the envelope object inside it.
+
+    signal-cli-rest-api wraps envelopes in a JSON-RPC notification
+    (`{"method":"receive","params":{"envelope":{…}}}`); a bare `{"envelope":{…}}`
+    is also accepted.
+    """
+    try:
+        obj = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise MalformedEvent(f"payload is not JSON: {exc}") from exc
+    if not isinstance(obj, dict):
+        raise MalformedEvent(f"payload is {type(obj).__name__}, not an object")
+    if obj.get("method") not in (None, "receive"):
+        raise MalformedEvent(f"unexpected JSON-RPC method {obj.get('method')!r}")
+    params = obj.get("params") or obj
+    env = params.get("envelope")
+    if env is None:
+        raise MalformedEvent("payload carries no `envelope`")
+    return env
+
+
+def sse_events(lines) -> Iterator[str]:
+    """Yield the `data:` payloads of an SSE byte/text line stream.
+
+    A generator over already-decoded lines, so the tests drive it with a plain
+    list and the daemon drives it with `requests`' `iter_lines`.
+    """
+    for line in lines:
+        if isinstance(line, bytes):
+            line = line.decode("utf-8", "replace")
+        line = line.rstrip("\n")
+        if not line or line.startswith(":"):
+            continue
+        if line.startswith("data:"):
+            yield line[len("data:"):].strip()
+
+
+# --------------------------------------------------------------------------- #
+# The daemon
+# --------------------------------------------------------------------------- #
+class SignalConsumer:
+    """SSE → store. Every external call is an injectable seam."""
+
+    def __init__(self, db, *, stream_factory=None, fetch_attachment=None,
+                 minio=None, sleep=time.sleep, db_retries: int = 3,
+                 backoff: float = 0.5):
+        self.db = db
+        self._stream_factory = stream_factory
+        self._fetch_attachment = fetch_attachment
+        self._minio = minio
+        self._sleep = sleep
+        self._db_retries = db_retries
+        self._backoff = backoff
+        self.stats = {
+            STAT_STORED: 0,
+            STAT_IGNORED: 0,
+            STAT_MALFORMED: 0,
+            STAT_RECONNECTS: 0,
+            STAT_DB_RETRIES: 0,
+            STAT_ATTACHMENT_FAILURES: 0,
+        }
+
+    # -- one event ---------------------------------------------------------
+    def handle_payload(self, payload: str) -> str:
+        """Parse + store one SSE payload. Returns the resulting kind, or
+        `STAT_MALFORMED` when the payload was skipped."""
+        try:
+            envelope = parse_sse_payload(payload)
+            event = parse_envelope(envelope)
+        except MalformedEvent:
+            self.stats[STAT_MALFORMED] += 1
+            return STAT_MALFORMED
+        return self.store(event)
+
+    def store(self, event: ParsedEvent) -> str:
+        if event.kind in STORED_KINDS and event.message is not None:
+            message_id = self._with_db_retry(
+                lambda: self.db.upsert_message(event.message)
+            )
+            self._with_db_retry(self.db.commit)
+            self.stats[STAT_STORED] += 1
+            # AFTER the commit, deliberately: an attachment fetch failure must
+            # not roll back a message we already have.
+            self.download_attachments(message_id, event.message)
+            return event.kind
+        if event.kind == KIND_REACTION and event.reaction is not None:
+            self._with_db_retry(lambda: self.db.upsert_reaction(event.reaction))
+            self._with_db_retry(self.db.commit)
+            self.stats[STAT_STORED] += 1
+            return event.kind
+        self.stats[STAT_IGNORED] += 1
+        return event.kind
+
+    def _with_db_retry(self, fn):
+        """Retry a DB call across a transient fault instead of dropping the event.
+
+        `db_retries` counts ATTEMPTS and has a floor of 1: `db_retries=0` used to
+        skip the loop entirely and then `raise last` with `last` still None,
+        which raises `TypeError: exceptions must derive from BaseException` — a
+        misconfiguration surfacing as a nonsense error from inside the retry
+        helper. Zero retries now means "call it once, do not retry".
+        """
+        attempts = max(1, self._db_retries)
+        last: BaseException | None = None
+        for attempt in range(attempts):
+            try:
+                return fn()
+            except TRANSIENT_DB_ERRORS as exc:
+                last = exc
+                self.stats[STAT_DB_RETRIES] += 1
+                self._sleep(self._backoff * (2 ** attempt))
+        if last is None:  # pragma: no cover - unreachable while attempts >= 1
+            raise RuntimeError(
+                "_with_db_retry finished its loop without attempting the call")
+        raise last
+
+    # -- attachments -------------------------------------------------------
+    def download_attachments(self, message_id: int, msg: dict) -> int:
+        """Fetch each attachment's bytes → MinIO, stamping the row with the key.
+
+        Isolated per attachment AND from the message write: a failure here is
+        counted and logged, never propagated, because the message row is already
+        committed and losing it would be the worse outcome.
+        """
+        stored = 0
+        # Bound to locals right after the guard: the DB callback below is a
+        # LAMBDA, so `self._minio` would be re-read whenever it runs rather than
+        # at the moment the guard held.
+        minio, fetch = self._minio, self._fetch_attachment
+        if minio is None or fetch is None:
+            return stored
+        conversation = conversation_key(msg)
+        for att in msg.get("attachments") or []:
+            try:
+                blob = fetch(att["id"])
+                key = minio.put_attachment(
+                    conversation=conversation,
+                    timestamp_ms=msg["message_timestamp"],
+                    filename=att.get("filename") or att["id"],
+                    data=blob,
+                    content_type=att.get("content_type") or "application/octet-stream",
+                    sidecar={
+                        "conversation": conversation,
+                        "message_id": message_id,
+                        "message_timestamp": msg["message_timestamp"],
+                        "content_type": att.get("content_type"),
+                        "signal_attachment_id": att["id"],
+                    },
+                )
+                self._with_db_retry(
+                    lambda k=key, a=att, b=minio.bucket:
+                        self.db.record_attachment_object(
+                            message_id, a["id"], b, k)
+                )
+                self._with_db_retry(self.db.commit)
+                stored += 1
+            except Exception as exc:  # noqa: BLE001 — deliberately broad, see docstring
+                self.stats[STAT_ATTACHMENT_FAILURES] += 1
+                print(f"signal-consumer: attachment {att.get('id')!r} failed: {exc}",
+                      file=sys.stderr)
+        return stored
+
+    # -- the stream --------------------------------------------------------
+    def run(self, *, max_connections: int | None = None) -> dict:
+        """Consume the SSE stream, reconnecting on disconnect.
+
+        `max_connections` bounds the loop (the tests pass a small number; the
+        Deployment passes None and runs forever).
+
+        🔴 The missing-factory check is OUTSIDE the loop deliberately. Inside, a
+        `None` factory raises `TypeError: 'NoneType' object is not callable`,
+        which the reconnect handler catches — so a misconfigured consumer would
+        spin forever printing "stream ended; reconnecting" instead of saying what
+        is wrong. A configuration fault must not be laundered into a retry.
+        """
+        if self._stream_factory is None:
+            raise RuntimeError(
+                "SignalConsumer.run() needs a stream_factory; construct it with "
+                "stream_factory=consumer.http_stream_factory() (or a test seam)")
+        connections = 0
+        while max_connections is None or connections < max_connections:
+            connections += 1
+            try:
+                for payload in sse_events(self._stream_factory()):
+                    self.handle_payload(payload)
+            except Exception as exc:  # noqa: BLE001 — a dropped stream is normal
+                self.stats[STAT_RECONNECTS] += 1
+                print(f"signal-consumer: stream ended ({exc}); reconnecting",
+                      file=sys.stderr)
+                self._sleep(self._backoff)
+                continue
+        return dict(self.stats)
+
+
+def conversation_key(msg: dict) -> str:
+    """Stable per-conversation prefix for MinIO keys."""
+    if msg.get("group_id"):
+        gid = msg["group_id"]
+        digest = base64.urlsafe_b64encode(gid).decode().rstrip("=")[:24]
+        return f"group-{digest}"
+    ident = msg.get("source_uuid") or msg.get("source_number") or "unknown"
+    return str(ident)
+
+
+# --------------------------------------------------------------------------- #
+# The send path — the ONLY route to the Signal send endpoint (D3)
+# --------------------------------------------------------------------------- #
+def transmit_approved(auth, *, recipient: str, body: str, poster=None,
+                      api_url: str | None = None, timeout: float = 20.0) -> dict:
+    """POST an approved draft to the Signal API. Requires a `SendAuthorization`.
+
+    🔴 `spend_authorization()` runs BEFORE anything touches the network, and it
+    raises `SendGateError` for a non-capability, a forged look-alike, or a
+    capability that has already been spent. There is no keyword that skips it and
+    no other send-endpoint call site in `scripts/signal/`.
+
+    Returns the API's response, from which the caller MUST take the
+    server-assigned `timestamp` (🔧 #4 — the sync echo carries that value, and a
+    locally generated one would not dedupe).
+    """
+    spend_authorization(auth)
+    url = (api_url or API_URL).rstrip("/") + SEND_PATH
+    payload = {"message": body, "recipients": [recipient]}
+    if poster is None:  # pragma: no cover - the live path; tests inject a poster
+        import requests
+        poster = requests.post
+    resp = poster(url, json=payload, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def http_attachment_fetcher(api_url: str | None = None, timeout: float = 30.0):
+    """Return a `fetch_attachment(id) -> bytes` bound to the live API."""
+    base = (api_url or API_URL).rstrip("/")
+
+    def _fetch(attachment_id: str) -> bytes:  # pragma: no cover - live path
+        import requests
+        resp = requests.get(f"{base}{ATTACHMENT_PATH}/{attachment_id}", timeout=timeout)
+        resp.raise_for_status()
+        return resp.content
+
+    return _fetch
+
+
+def http_stream_factory(api_url: str | None = None, timeout: float = 300.0):
+    """Return a `stream_factory() -> line iterator` bound to the live SSE endpoint."""
+    base = (api_url or API_URL).rstrip("/")
+
+    def _open():  # pragma: no cover - live path
+        import requests
+        resp = requests.get(f"{base}{EVENTS_PATH}", stream=True, timeout=timeout)
+        resp.raise_for_status()
+        return resp.iter_lines()
+
+    return _open
+
+
+# --------------------------------------------------------------------------- #
+# CLI. tests/test_skill_doc.py derives these names from the source and requires
+# each one to appear in claude/skills/signal/SKILL.md.
+# --------------------------------------------------------------------------- #
+def _fmt_ts(ms) -> str:
+    if not ms or int(ms) < 0:
+        return "(draft)"
+    return datetime.fromtimestamp(int(ms) / 1000, tz=timezone.utc).strftime(
+        "%Y-%m-%d %H:%M")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="consumer.py", description="Signal chat pipeline: consume, query, draft.")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("run", help="consume the SSE stream forever (the Deployment)")
+
+    q = sub.add_parser("conversations", help="list conversations, newest first")
+    q.add_argument("--limit", type=int, default=25)
+
+    s = sub.add_parser("search", help="full-text search over message bodies")
+    s.add_argument("query")
+    s.add_argument("--limit", type=int, default=25)
+
+    d = sub.add_parser("draft", help="compose an outbound draft (transmits NOTHING)")
+    d.add_argument("--to", required=True)
+    d.add_argument("--body", required=True)
+    d.add_argument("--from-number", default=os.environ.get("SIGNAL_ACCOUNT"))
+
+    ls = sub.add_parser("drafts", help="list drafts and their send_state")
+    ls.add_argument("--state", choices=[STATE_PENDING, STATE_APPROVED, STATE_SENT])
+
+    a = sub.add_parser("approve", help="record Zach's clawgate approval for a draft")
+    a.add_argument("draft_id", type=int)
+    a.add_argument("--ref", required=True, help="the clawgate approval reference")
+
+    sd = sub.add_parser("send", help="transmit an APPROVED draft (gated)")
+    sd.add_argument("draft_id", type=int)
+
+    return p
+
+
+def main(argv=None) -> int:  # pragma: no cover - thin CLI shell over tested units
+    args = build_parser().parse_args(argv)
+    with SignalDB() as db:
+        db.ensure_schema()
+        if args.cmd == "run":
+            consumer = SignalConsumer(
+                db,
+                stream_factory=http_stream_factory(),
+                fetch_attachment=http_attachment_fetcher(),
+                minio=_open_minio(),
+            )
+            print(json.dumps(consumer.run()))
+        elif args.cmd == "conversations":
+            for row in db.list_conversations(limit=args.limit):
+                print(f"{_fmt_ts(row['last_message_timestamp'])}  "
+                      f"{row.get('group_name') or row.get('display_name') or '?'}  "
+                      f"({row['message_count']})")
+        elif args.cmd == "search":
+            for row in db.search(args.query, limit=args.limit):
+                print(f"{_fmt_ts(row['message_timestamp'])}  "
+                      f"{row.get('display_name') or row.get('phone_number') or '?'}: "
+                      f"{(row.get('body') or '')[:120]}")
+        elif args.cmd == "draft":
+            import clawgate
+            draft = db.draft_message(
+                recipient=args.to, body=args.body, self_number=args.from_number)
+            clawgate.emit_draft_task(
+                draft_id=draft["id"], recipient=args.to, body=args.body)
+            print(json.dumps(draft))
+        elif args.cmd == "drafts":
+            print(json.dumps(db.list_drafts(state=args.state), default=str))
+        elif args.cmd == "approve":
+            print(json.dumps(db.approve_draft(args.draft_id, approval_ref=args.ref),
+                             default=str))
+        elif args.cmd == "send":
+            try:
+                print(json.dumps(db.send_approved(args.draft_id), default=str))
+            except SendGateError as exc:
+                print(f"refused: {exc}", file=sys.stderr)
+                return 3
+    return 0
+
+
+def _open_minio():  # pragma: no cover - live path
+    from _minio import MinioSignal
+    mc = MinioSignal()
+    mc.__enter__()
+    return mc
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/signal/consumer.py
+++ b/scripts/signal/consumer.py
@@ -48,6 +48,8 @@ import psycopg2  # noqa: E402  (real class objects for the retry classifier)
 
 import _signal_db  # noqa: E402
 from _signal_db import (  # noqa: E402
+    RECONCILE_NOT_SENT,
+    RECONCILE_SENT,
     STATE_APPROVED,
     STATE_PENDING,
     STATE_SENDING,
@@ -58,17 +60,18 @@ from _signal_db import (  # noqa: E402
 )
 
 # --------------------------------------------------------------------------- #
-# THE SERVER WE TARGET IS bbernhard/signal-cli-rest-api. Its ENTIRE route table
-# was read from upstream `src/main.go` (2026-08-16) rather than recalled:
+# THE SERVER WE TARGET IS bbernhard/signal-cli-rest-api. The three routes THIS
+# MODULE TARGETS were read from upstream `src/main.go` (2026-08-16) rather than
+# recalled (the server registers many more; these are the ones we speak):
 #
-#     v1.GET("/receive/:number")        <- ingest. NOT SSE. See below.
+#     v1.GET("/receive/:number")        <- ingest. See below.
 #     v1.GET("/attachments/:attachment")
 #     v2.POST("/send")
 #
 # There is NO `/api/v1/events` and no SSE endpoint anywhere in that router — that
 # path belongs to AsamK's NATIVE `signal-cli --http` daemon, a different server.
-# An earlier revision of this module mixed the two: SSE ingest from the native
-# daemon, send/attachments from bbernhard. Against the server we actually deploy
+# An earlier revision of this module mixed the two: event-stream ingest from the
+# native daemon, send/attachments from bbernhard. Against the server we actually deploy
 # that is a 404 on every connect, which `run()`'s reconnect handler turns into a
 # silent infinite loop with zero rows ingested.
 #
@@ -77,8 +80,9 @@ from _signal_db import (  # noqa: E402
 # `src/api/api.go`: `connectionUpgrader.Upgrade(...)` then
 # `ws.WriteMessage(websocket.TextMessage, []byte(data))`, where `data` is the
 # signal-cli JSON-RPC params object `{"account": …, "envelope": {…}}`.
-# In non-json-rpc mode the same path is a one-shot GET returning a JSON ARRAY.
-# `iter_frames()` accepts both shapes so the consumer core is transport-agnostic.
+# (In non-json-rpc mode the same path is a one-shot GET returning a JSON array.
+# We do not deploy that mode and do not ship a factory for it — see the note by
+# `ws_stream_factory`.)
 # --------------------------------------------------------------------------- #
 API_URL = os.environ.get("SIGNAL_API_URL", "http://signal-api.signal.svc:8080")
 ACCOUNT = os.environ.get("SIGNAL_ACCOUNT", "")
@@ -133,7 +137,7 @@ TRANSIENT_DB_ERRORS = (
 
 @dataclass
 class ParsedEvent:
-    """One SSE envelope, normalised. `kind` is one of the KIND_* constants."""
+    """One received envelope, normalised. `kind` is one of the KIND_* constants."""
 
     kind: str
     message: dict | None = None
@@ -145,7 +149,7 @@ class ParsedEvent:
 
 
 class MalformedEvent(ValueError):
-    """The SSE payload was not a usable envelope. Skipped, counted, never fatal."""
+    """The received frame was not a usable envelope. Skipped, counted, never fatal."""
 
 
 # --------------------------------------------------------------------------- #
@@ -223,6 +227,28 @@ def parse_envelope(envelope: dict) -> ParsedEvent:
     sync = envelope.get("syncMessage") or {}
     sent = sync.get("sentMessage")
     if sent:
+        # 🔴 A RETRACTION MADE ON ZACH'S OWN PHONE arrives HERE, wrapped in
+        # `syncMessage.sentMessage`, not in the inbound `dataMessage` branch
+        # below — and this branch runs first. Handled only inbound, both defects
+        # the remote-delete branch exists to prevent survived in the own-device
+        # direction: a ghost row, and the retracted text left in place.
+        sync_remote = sent.get("remoteDelete")
+        if sync_remote is not None:
+            target_ts = sync_remote.get("targetSentTimestamp")
+            if target_ts is None:
+                raise MalformedEvent("sync remoteDelete has no targetSentTimestamp")
+            return ParsedEvent(
+                kind=KIND_REMOTE_DELETE,
+                remote_delete={
+                    # The retracted message is the ACCOUNT's own, so the target
+                    # author is this envelope's source — the linked device.
+                    "target_author_uuid": envelope.get("sourceUuid"),
+                    "target_author_number": (envelope.get("sourceNumber")
+                                             or envelope.get("source")),
+                    "target_sent_timestamp": target_ts,
+                },
+                raw_envelope=raw,
+            )
         ts = sent.get("timestamp") or env_ts
         if ts is None:
             raise MalformedEvent("sync sentMessage has no timestamp")
@@ -357,9 +383,12 @@ def parse_receive_frame(payload) -> dict:
 def iter_frames(source) -> Iterator[object]:
     """Normalise whatever the receive transport yields into one item per message.
 
-    The websocket path yields one text frame per message; the REST path yields a
-    single JSON ARRAY holding many. Both arrive here, and a caller downstream
-    only ever sees "one message at a time".
+    The websocket yields one text frame per message. Bytes are decoded, blank
+    keepalive frames are dropped, and anything already decoded passes through, so
+    `handle_payload` downstream only ever sees "one message". Junk is passed
+    ALONG rather than swallowed here — counting it is `handle_payload`'s job, and
+    a frame that vanished silently at this layer would be invisible to every
+    counter.
     """
     for item in source:
         if isinstance(item, (bytes, bytearray)):
@@ -368,20 +397,7 @@ def iter_frames(source) -> Iterator[object]:
             stripped = item.strip()
             if not stripped:
                 continue
-            if stripped.startswith("["):
-                try:
-                    batch = json.loads(stripped)
-                except json.JSONDecodeError:
-                    yield stripped          # let handle_payload count it malformed
-                    continue
-                for element in batch:
-                    yield element
-                continue
             yield stripped
-            continue
-        if isinstance(item, list):
-            for element in item:
-                yield element
             continue
         yield item
 
@@ -390,7 +406,7 @@ def iter_frames(source) -> Iterator[object]:
 # The daemon
 # --------------------------------------------------------------------------- #
 class SignalConsumer:
-    """SSE → store. Every external call is an injectable seam."""
+    """Receive stream → store. Every external call is an injectable seam."""
 
     def __init__(self, db, *, stream_factory=None, fetch_attachment=None,
                  minio=None, sleep=time.sleep, db_retries: int = 3,
@@ -428,30 +444,51 @@ class SignalConsumer:
     def store(self, event: ParsedEvent) -> str:
         if event.kind == KIND_REMOTE_DELETE and event.remote_delete is not None:
             self._with_db_retry(
-                lambda: self.db.apply_remote_delete(event.remote_delete))
-            self._with_db_retry(self.db.commit)
+                lambda: self._write(self.db.apply_remote_delete,
+                                    event.remote_delete))
             self.stats[STAT_STORED] += 1
             return event.kind
         if event.kind in STORED_KINDS and event.message is not None:
             message_id = self._with_db_retry(
-                lambda: self.db.upsert_message(event.message)
-            )
-            self._with_db_retry(self.db.commit)
+                lambda: self._write(self.db.upsert_message, event.message))
             self.stats[STAT_STORED] += 1
             # AFTER the commit, deliberately: an attachment fetch failure must
             # not roll back a message we already have.
             self.download_attachments(message_id, event.message)
             return event.kind
         if event.kind == KIND_REACTION and event.reaction is not None:
-            self._with_db_retry(lambda: self.db.upsert_reaction(event.reaction))
-            self._with_db_retry(self.db.commit)
+            self._with_db_retry(
+                lambda: self._write(self.db.upsert_reaction, event.reaction))
             self.stats[STAT_STORED] += 1
             return event.kind
         self.stats[STAT_IGNORED] += 1
         return event.kind
 
+    def _write(self, fn, *args):
+        """ONE unit of work: the write AND its commit, together.
+
+        🔴 WHY THEY MUST BE ONE UNIT. Retrying them separately silently DROPS the
+        message when the transient fault lands on the COMMIT: recovery rolls back
+        — discarding the row already written — and the retried bare `commit()`
+        then commits an empty transaction and reports success. Measured: one row
+        written, `stored=1`, and `SELECT` returns nothing. That turned a loud
+        failure into a silent one, which is the exact class this consumer's
+        retry logic exists to remove.
+
+        Retrying the whole unit is safe because every write here is idempotent
+        (`ON CONFLICT`), so a replay after a rollback re-creates the same row.
+        """
+        result = fn(*args)
+        self.db.commit()
+        return result
+
     def _with_db_retry(self, fn):
-        """Retry a DB call across a transient fault instead of dropping the event.
+        """Retry one UNIT OF WORK across a transient fault, never dropping the event.
+
+        `fn` must be re-runnable from the top: `_recover()` rolls the aborted
+        transaction back between attempts, so anything `fn` had already written
+        is gone by the time it runs again. Pass whole units (see `_write`), never
+        a bare `commit`.
 
         `db_retries` counts ATTEMPTS and has a floor of 1: `db_retries=0` used to
         skip the loop entirely and then `raise last` with `last` still None,
@@ -535,10 +572,9 @@ class SignalConsumer:
                 )
                 self._with_db_retry(
                     lambda k=key, a=att, b=minio.bucket:
-                        self.db.record_attachment_object(
-                            message_id, a["id"], b, k)
+                        self._write(self.db.record_attachment_object,
+                                    message_id, a["id"], b, k)
                 )
-                self._with_db_retry(self.db.commit)
                 stored += 1
             except Exception as exc:  # noqa: BLE001 — deliberately broad, see docstring
                 self.stats[STAT_ATTACHMENT_FAILURES] += 1
@@ -548,7 +584,7 @@ class SignalConsumer:
 
     # -- the stream --------------------------------------------------------
     def run(self, *, max_connections: int | None = None) -> dict:
-        """Consume the SSE stream, reconnecting on disconnect.
+        """Consume the receive stream, reconnecting on disconnect.
 
         `max_connections` bounds the loop (the tests pass a small number; the
         Deployment passes None and runs forever).
@@ -562,7 +598,7 @@ class SignalConsumer:
         if self._stream_factory is None:
             raise RuntimeError(
                 "SignalConsumer.run() needs a stream_factory; construct it with "
-                "stream_factory=consumer.http_stream_factory() (or a test seam)")
+                "stream_factory=consumer.ws_stream_factory(<account>) (or a test seam)")
         connections = 0
         while max_connections is None or connections < max_connections:
             connections += 1
@@ -665,13 +701,33 @@ def ws_stream_factory(account: str, api_url: str | None = None,
     """Ingest for `json-rpc` mode: a WEBSOCKET on `/v1/receive/{number}`.
 
     Upstream upgrades the connection and writes one JSON text frame per message.
-    `websocket-client` is imported lazily so the hermetic suite (which injects
-    its own factory) never needs it installed.
+
+    🔴 THE IMPORT IS AT BUILD TIME, NOT INSIDE `_open()`. `run()` calls the
+    factory once per connect and treats any exception from it as a dropped
+    stream, so a lazily-imported missing `websocket-client` became an INFINITE
+    silent reconnect loop: `stream ended (No module named 'websocket');
+    reconnecting`, forever, zero rows. Measured at 25/25 connects. That is the
+    same zombie mode `run()`'s hoisted stream-factory check exists to prevent —
+    re-created by a dependency, and defeated by the lazy import. A missing
+    dependency is a configuration fault and must fail here, once, loudly.
+
+    The dependency is declared in `scripts/signal/requirements.txt`; the
+    consumer image needs it installed. The hermetic suite never reaches this
+    function's live path — it injects its own factory.
     """
     url = receive_url(account, api_url=api_url, websocket=True)
+    try:
+        import websocket  # websocket-client — see requirements.txt
+    except ImportError as exc:
+        raise RuntimeError(
+            "the `websocket-client` package is required for json-rpc ingest "
+            f"({url}) and is not installed. It is declared in "
+            "scripts/signal/requirements.txt; the consumer image must install "
+            "it. Failing here rather than inside the reconnect loop, where a "
+            "missing dependency would look like a flapping server forever."
+        ) from exc
 
     def _open():  # pragma: no cover - live path
-        import websocket  # websocket-client
         conn = websocket.create_connection(url, timeout=timeout)
 
         def _frames():
@@ -686,23 +742,12 @@ def ws_stream_factory(account: str, api_url: str | None = None,
     return _open
 
 
-def rest_poll_stream_factory(account: str, api_url: str | None = None,
-                             timeout: float = 60.0):
-    """Ingest for NON-json-rpc mode: one-shot `GET /v1/receive/{number}`.
-
-    Returns a JSON array of messages and drains the server-side queue, so the
-    caller loops. Kept because it is the documented behaviour of the same path in
-    the other mode, and it is the manual drain an operator reaches for.
-    """
-    url = receive_url(account, api_url=api_url)
-
-    def _open():  # pragma: no cover - live path
-        import requests
-        resp = requests.get(url, timeout=timeout)
-        resp.raise_for_status()
-        return [resp.text]
-
-    return _open
+# NOTE — there is deliberately NO REST-polling factory here. The same path is a
+# one-shot GET returning a JSON array in non-json-rpc mode, but we deploy
+# json-rpc mode, and `run()` only sleeps in its EXCEPT branch: a factory that
+# returns a FINITE iterator makes the loop spin at full speed (measured: 50
+# connects, 0 sleeps). An unused function with that hazard in it is worse than no
+# function, so it is gone rather than left for someone to reach for.
 
 
 # --------------------------------------------------------------------------- #
@@ -750,6 +795,18 @@ def build_parser() -> argparse.ArgumentParser:
     sd = sub.add_parser("send", help="transmit an APPROVED draft (gated)")
     sd.add_argument("draft_id", type=int)
 
+    rc = sub.add_parser(
+        "reconcile",
+        help="resolve a draft stranded in `sending` after checking Signal")
+    rc.add_argument("draft_id", type=int)
+    outcome = rc.add_mutually_exclusive_group(required=True)
+    outcome.add_argument("--sent", action="store_true",
+                         help="it DID go out; pass --timestamp from the conversation")
+    outcome.add_argument("--not-sent", action="store_true",
+                         help="it did NOT go out; returns to pending for re-approval")
+    rc.add_argument("--timestamp", help="the SERVER timestamp, required with --sent")
+    rc.add_argument("--note", help="what you saw, recorded on the row")
+
     return p
 
 
@@ -795,6 +852,15 @@ def main(argv=None) -> int:  # pragma: no cover - thin CLI shell over tested uni
         elif args.cmd == "send":
             try:
                 print(json.dumps(db.send_approved(args.draft_id), default=str))
+            except SendGateError as exc:
+                print(f"refused: {exc}", file=sys.stderr)
+                return 3
+        elif args.cmd == "reconcile":
+            try:
+                print(json.dumps(db.reconcile_send(
+                    args.draft_id,
+                    outcome=RECONCILE_SENT if args.sent else RECONCILE_NOT_SENT,
+                    server_timestamp=args.timestamp, note=args.note), default=str))
             except SendGateError as exc:
                 print(f"refused: {exc}", file=sys.stderr)
                 return 3

--- a/scripts/signal/consumer.py
+++ b/scripts/signal/consumer.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python3
-"""Signal consumer — SSE stream → parsed envelope → Postgres (+ MinIO attachments).
+"""Signal consumer — receive stream → parsed envelope → Postgres (+ MinIO attachments).
 
 Runs as a long-lived in-cluster Deployment next to `signal-cli-rest-api`
-(json-rpc-native mode). It consumes `GET /api/v1/events`, turns each JSON-RPC
-`receive` notification into a structured event, and stores it idempotently
-through `_signal_db.SignalDB`.
+(json-rpc mode). It consumes that server's per-account receive endpoint (see the
+route-table note below), turns each frame into a structured event, and stores it
+idempotently through `_signal_db.SignalDB`.
 
 WHAT IT MUST SURVIVE (each has a named test in tests/test_consumer_resilience.py)
 --------------------------------------------------------------------------------
-* an SSE disconnect/reconnect that REDELIVERS events — dedupe makes replay a
+* a disconnect/reconnect that REDELIVERS messages — dedupe makes replay a
   no-op, so nothing is lost and nothing is duplicated;
-* a malformed event — skipped and counted, never fatal;
+* a malformed frame — skipped and counted, never fatal;
 * Postgres briefly unavailable — retried with backoff, the event is not dropped;
+* a FAILED WRITE poisoning the connection — `autocommit=False` means one failed
+  statement aborts the transaction and every later one raises until a rollback,
+  so recovery is part of the retry, not an afterthought;
 * an attachment fetch failing — the MESSAGE write still stands (attachment
   bytes are fetched AFTER the row is committed, never inside its transaction).
 
@@ -47,14 +50,39 @@ import _signal_db  # noqa: E402
 from _signal_db import (  # noqa: E402
     STATE_APPROVED,
     STATE_PENDING,
+    STATE_SENDING,
     STATE_SENT,
     SendGateError,
     SignalDB,
     spend_authorization,
 )
 
+# --------------------------------------------------------------------------- #
+# THE SERVER WE TARGET IS bbernhard/signal-cli-rest-api. Its ENTIRE route table
+# was read from upstream `src/main.go` (2026-08-16) rather than recalled:
+#
+#     v1.GET("/receive/:number")        <- ingest. NOT SSE. See below.
+#     v1.GET("/attachments/:attachment")
+#     v2.POST("/send")
+#
+# There is NO `/api/v1/events` and no SSE endpoint anywhere in that router — that
+# path belongs to AsamK's NATIVE `signal-cli --http` daemon, a different server.
+# An earlier revision of this module mixed the two: SSE ingest from the native
+# daemon, send/attachments from bbernhard. Against the server we actually deploy
+# that is a 404 on every connect, which `run()`'s reconnect handler turns into a
+# silent infinite loop with zero rows ingested.
+#
+# In `json-rpc` mode (the mode we deploy) `GET /v1/receive/{number}` UPGRADES TO A
+# WEBSOCKET and writes one JSON TEXT FRAME per message — upstream
+# `src/api/api.go`: `connectionUpgrader.Upgrade(...)` then
+# `ws.WriteMessage(websocket.TextMessage, []byte(data))`, where `data` is the
+# signal-cli JSON-RPC params object `{"account": …, "envelope": {…}}`.
+# In non-json-rpc mode the same path is a one-shot GET returning a JSON ARRAY.
+# `iter_frames()` accepts both shapes so the consumer core is transport-agnostic.
+# --------------------------------------------------------------------------- #
 API_URL = os.environ.get("SIGNAL_API_URL", "http://signal-api.signal.svc:8080")
-EVENTS_PATH = "/api/v1/events"
+ACCOUNT = os.environ.get("SIGNAL_ACCOUNT", "")
+RECEIVE_PATH = "/v1/receive"
 ATTACHMENT_PATH = "/v1/attachments"
 SEND_PATH = "/v2/send"
 
@@ -71,6 +99,7 @@ KIND_SYNC_OUTBOUND = "sync_outbound"
 KIND_RECEIPT_DELIVERY = "receipt_delivery"
 KIND_RECEIPT_READ = "receipt_read"
 KIND_TYPING = "typing"
+KIND_REMOTE_DELETE = "remote_delete"
 KIND_UNKNOWN = "unknown"
 
 # Counters the daemon reports. Also derived + doc-checked by test_skill_doc.py.
@@ -79,6 +108,8 @@ STAT_IGNORED = "ignored"
 STAT_MALFORMED = "malformed"
 STAT_RECONNECTS = "reconnects"
 STAT_DB_RETRIES = "db_retries"
+STAT_DB_RECOVERIES = "db_recoveries"
+STAT_DB_RECOVERY_FAILURES = "db_recovery_failures"
 STAT_ATTACHMENT_FAILURES = "attachment_failures"
 
 # Kinds that are stored as rows; everything else is observed and counted only.
@@ -86,7 +117,18 @@ STORED_KINDS = (KIND_MESSAGE, KIND_GROUP_MESSAGE, KIND_EDIT, KIND_SYNC_OUTBOUND)
 
 # Transient Postgres faults worth retrying. NOT a bare `Exception`: a programming
 # error must fail loudly rather than be retried three times and swallowed.
-TRANSIENT_DB_ERRORS = (psycopg2.OperationalError, psycopg2.InterfaceError)
+#
+# `InFailedSqlTransaction` (SQLSTATE 25P02) is in the list because it is what
+# EVERY statement raises after one has failed inside an `autocommit=False`
+# transaction. It is genuinely transient — a `rollback()` clears it — and
+# `_recover()` issues exactly that between attempts. Left out, the second event
+# after any error escapes into the reconnect handler and the pod becomes a zombie
+# that logs "reconnecting" forever and stores nothing.
+TRANSIENT_DB_ERRORS = (
+    psycopg2.OperationalError,
+    psycopg2.InterfaceError,
+    psycopg2.errors.InFailedSqlTransaction,
+)
 
 
 @dataclass
@@ -97,6 +139,7 @@ class ParsedEvent:
     message: dict | None = None
     reaction: dict | None = None
     receipt: dict | None = None
+    remote_delete: dict | None = None
     raw_envelope: str | None = None
     notes: list[str] = field(default_factory=list)
 
@@ -207,6 +250,29 @@ def parse_envelope(envelope: dict) -> ParsedEvent:
     # -- data message (DM / group / reaction) ---------------------------------
     data = envelope.get("dataMessage") or {}
     if data:
+        # A remote delete is the SENDER RETRACTING a message. Storing it as a
+        # message with an empty body (what falling through to the data-message
+        # path does) leaves a ghost row AND keeps the retracted text, which is
+        # the opposite of what was asked for.
+        remote = data.get("remoteDelete")
+        if remote is not None:
+            # `is not None`, not truthiness: an EMPTY remoteDelete is malformed
+            # and must be reported as such, not silently fall through and get
+            # stored as an ordinary empty message.
+            target_ts = remote.get("targetSentTimestamp")
+            if target_ts is None:
+                raise MalformedEvent("remoteDelete has no targetSentTimestamp")
+            return ParsedEvent(
+                kind=KIND_REMOTE_DELETE,
+                remote_delete={
+                    "target_author_uuid": envelope.get("sourceUuid"),
+                    "target_author_number": (envelope.get("sourceNumber")
+                                             or envelope.get("source")),
+                    "target_sent_timestamp": target_ts,
+                },
+                raw_envelope=raw,
+            )
+
         reaction = data.get("reaction")
         if reaction:
             rx = {
@@ -259,42 +325,65 @@ def parse_envelope(envelope: dict) -> ParsedEvent:
                        notes=[f"unhandled envelope keys: {sorted(envelope)}"])
 
 
-def parse_sse_payload(payload: str) -> dict:
-    """One SSE `data:` payload → the envelope object inside it.
+def parse_receive_frame(payload) -> dict:
+    """One websocket frame (or one REST array element) → the envelope inside it.
 
-    signal-cli-rest-api wraps envelopes in a JSON-RPC notification
-    (`{"method":"receive","params":{"envelope":{…}}}`); a bare `{"envelope":{…}}`
-    is also accepted.
+    Accepts, deliberately, the three shapes this endpoint can hand back:
+      * bbernhard's json-rpc websocket frame — `{"account": …, "envelope": {…}}`;
+      * a signal-cli JSON-RPC notification — `{"method":"receive","params":{…}}`;
+      * an already-decoded dict (the REST-array path decodes once, up front).
     """
-    try:
-        obj = json.loads(payload)
-    except json.JSONDecodeError as exc:
-        raise MalformedEvent(f"payload is not JSON: {exc}") from exc
+    if isinstance(payload, (bytes, bytearray)):
+        payload = payload.decode("utf-8", "replace")
+    if isinstance(payload, str):
+        try:
+            obj = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise MalformedEvent(f"frame is not JSON: {exc}") from exc
+    else:
+        obj = payload
     if not isinstance(obj, dict):
-        raise MalformedEvent(f"payload is {type(obj).__name__}, not an object")
+        raise MalformedEvent(f"frame is {type(obj).__name__}, not an object")
     if obj.get("method") not in (None, "receive"):
         raise MalformedEvent(f"unexpected JSON-RPC method {obj.get('method')!r}")
-    params = obj.get("params") or obj
+    nested = obj.get("params")
+    params = nested if isinstance(nested, dict) else obj
     env = params.get("envelope")
     if env is None:
-        raise MalformedEvent("payload carries no `envelope`")
+        raise MalformedEvent("frame carries no `envelope`")
     return env
 
 
-def sse_events(lines) -> Iterator[str]:
-    """Yield the `data:` payloads of an SSE byte/text line stream.
+def iter_frames(source) -> Iterator[object]:
+    """Normalise whatever the receive transport yields into one item per message.
 
-    A generator over already-decoded lines, so the tests drive it with a plain
-    list and the daemon drives it with `requests`' `iter_lines`.
+    The websocket path yields one text frame per message; the REST path yields a
+    single JSON ARRAY holding many. Both arrive here, and a caller downstream
+    only ever sees "one message at a time".
     """
-    for line in lines:
-        if isinstance(line, bytes):
-            line = line.decode("utf-8", "replace")
-        line = line.rstrip("\n")
-        if not line or line.startswith(":"):
+    for item in source:
+        if isinstance(item, (bytes, bytearray)):
+            item = item.decode("utf-8", "replace")
+        if isinstance(item, str):
+            stripped = item.strip()
+            if not stripped:
+                continue
+            if stripped.startswith("["):
+                try:
+                    batch = json.loads(stripped)
+                except json.JSONDecodeError:
+                    yield stripped          # let handle_payload count it malformed
+                    continue
+                for element in batch:
+                    yield element
+                continue
+            yield stripped
             continue
-        if line.startswith("data:"):
-            yield line[len("data:"):].strip()
+        if isinstance(item, list):
+            for element in item:
+                yield element
+            continue
+        yield item
 
 
 # --------------------------------------------------------------------------- #
@@ -319,15 +408,17 @@ class SignalConsumer:
             STAT_MALFORMED: 0,
             STAT_RECONNECTS: 0,
             STAT_DB_RETRIES: 0,
+            STAT_DB_RECOVERIES: 0,
+            STAT_DB_RECOVERY_FAILURES: 0,
             STAT_ATTACHMENT_FAILURES: 0,
         }
 
     # -- one event ---------------------------------------------------------
-    def handle_payload(self, payload: str) -> str:
-        """Parse + store one SSE payload. Returns the resulting kind, or
-        `STAT_MALFORMED` when the payload was skipped."""
+    def handle_payload(self, payload) -> str:
+        """Parse + store one receive frame. Returns the resulting kind, or
+        `STAT_MALFORMED` when the frame was skipped."""
         try:
-            envelope = parse_sse_payload(payload)
+            envelope = parse_receive_frame(payload)
             event = parse_envelope(envelope)
         except MalformedEvent:
             self.stats[STAT_MALFORMED] += 1
@@ -335,6 +426,12 @@ class SignalConsumer:
         return self.store(event)
 
     def store(self, event: ParsedEvent) -> str:
+        if event.kind == KIND_REMOTE_DELETE and event.remote_delete is not None:
+            self._with_db_retry(
+                lambda: self.db.apply_remote_delete(event.remote_delete))
+            self._with_db_retry(self.db.commit)
+            self.stats[STAT_STORED] += 1
+            return event.kind
         if event.kind in STORED_KINDS and event.message is not None:
             message_id = self._with_db_retry(
                 lambda: self.db.upsert_message(event.message)
@@ -370,11 +467,37 @@ class SignalConsumer:
             except TRANSIENT_DB_ERRORS as exc:
                 last = exc
                 self.stats[STAT_DB_RETRIES] += 1
+                self._recover("transient")
                 self._sleep(self._backoff * (2 ** attempt))
+            except Exception:
+                # 🔴 NOT retried — but the connection still has to be made usable.
+                # `autocommit=False` means the FIRST failed statement aborts the
+                # transaction, and every later statement then raises
+                # `InFailedSqlTransaction`, which is a DIFFERENT error class: it
+                # would escape into run()'s reconnect handler and be miscounted
+                # as a dropped stream forever, storing nothing. Recover, then let
+                # the real error propagate.
+                self._recover("fatal")
+                raise
         if last is None:  # pragma: no cover - unreachable while attempts >= 1
             raise RuntimeError(
                 "_with_db_retry finished its loop without attempting the call")
         raise last
+
+    def _recover(self, why: str) -> str:
+        """Roll the aborted transaction back (reconnecting if that is not enough).
+
+        Returns what the DB layer says it did, for the counters and the log.
+        """
+        try:
+            outcome = self.db.recover()
+        except Exception as exc:  # noqa: BLE001 — recovery must not mask the cause
+            self.stats[STAT_DB_RECOVERY_FAILURES] += 1
+            print(f"signal-consumer: DB recovery after a {why} error failed: {exc}",
+                  file=sys.stderr)
+            return "failed"
+        self.stats[STAT_DB_RECOVERIES] += 1
+        return outcome
 
     # -- attachments -------------------------------------------------------
     def download_attachments(self, message_id: int, msg: dict) -> int:
@@ -398,6 +521,7 @@ class SignalConsumer:
                 key = minio.put_attachment(
                     conversation=conversation,
                     timestamp_ms=msg["message_timestamp"],
+                    attachment_id=att["id"],
                     filename=att.get("filename") or att["id"],
                     data=blob,
                     content_type=att.get("content_type") or "application/octet-stream",
@@ -443,7 +567,7 @@ class SignalConsumer:
         while max_connections is None or connections < max_connections:
             connections += 1
             try:
-                for payload in sse_events(self._stream_factory()):
+                for payload in iter_frames(self._stream_factory()):
                     self.handle_payload(payload)
             except Exception as exc:  # noqa: BLE001 — a dropped stream is normal
                 self.stats[STAT_RECONNECTS] += 1
@@ -467,8 +591,9 @@ def conversation_key(msg: dict) -> str:
 # --------------------------------------------------------------------------- #
 # The send path — the ONLY route to the Signal send endpoint (D3)
 # --------------------------------------------------------------------------- #
-def transmit_approved(auth, *, recipient: str, body: str, poster=None,
-                      api_url: str | None = None, timeout: float = 20.0) -> dict:
+def transmit_approved(auth, *, recipient: str, body: str, number: str,
+                      poster=None, api_url: str | None = None,
+                      timeout: float = 20.0) -> dict:
     """POST an approved draft to the Signal API. Requires a `SendAuthorization`.
 
     🔴 `spend_authorization()` runs BEFORE anything touches the network, and it
@@ -476,13 +601,24 @@ def transmit_approved(auth, *, recipient: str, body: str, poster=None,
     capability that has already been spent. There is no keyword that skips it and
     no other send-endpoint call site in `scripts/signal/`.
 
+    `number` is the SENDING account and is REQUIRED by the server: upstream
+    `SendV2` rejects an empty one with 400 `"Couldn't process request - please
+    provide a valid number"` (read from `src/api/api.go`, not recalled). An
+    earlier revision omitted it, so every send would have failed — safely, but
+    the whole send path was inert.
+
     Returns the API's response, from which the caller MUST take the
     server-assigned `timestamp` (🔧 #4 — the sync echo carries that value, and a
-    locally generated one would not dedupe).
+    locally generated one would not dedupe). Upstream types that field as a
+    STRING (`ds.SendMessageResponse.Timestamp string`), so the caller coerces.
     """
     spend_authorization(auth)
+    if not number:
+        raise SendGateError(
+            "transmit refused: no sending `number` — the server would reject this "
+            "with 400 'please provide a valid number' (D3 approval gate)")
     url = (api_url or API_URL).rstrip("/") + SEND_PATH
-    payload = {"message": body, "recipients": [recipient]}
+    payload = {"message": body, "number": number, "recipients": [recipient]}
     if poster is None:  # pragma: no cover - the live path; tests inject a poster
         import requests
         poster = requests.post
@@ -504,15 +640,67 @@ def http_attachment_fetcher(api_url: str | None = None, timeout: float = 30.0):
     return _fetch
 
 
-def http_stream_factory(api_url: str | None = None, timeout: float = 300.0):
-    """Return a `stream_factory() -> line iterator` bound to the live SSE endpoint."""
+def receive_url(account: str, *, api_url: str | None = None,
+                websocket: bool = False) -> str:
+    """The ingest URL for one account: `…/v1/receive/{number}`.
+
+    `websocket=True` swaps the scheme for `ws`/`wss`, which is what json-rpc mode
+    needs — the path is the same, the server upgrades the connection.
+    """
+    if not account:
+        raise ValueError(
+            "receive_url needs the account number: bbernhard's ingest endpoint is "
+            "per-account (`/v1/receive/{number}`), there is no global stream")
     base = (api_url or API_URL).rstrip("/")
+    if websocket:
+        if base.startswith("https://"):
+            base = "wss://" + base[len("https://"):]
+        elif base.startswith("http://"):
+            base = "ws://" + base[len("http://"):]
+    return f"{base}{RECEIVE_PATH}/{account}"
+
+
+def ws_stream_factory(account: str, api_url: str | None = None,
+                      timeout: float = 300.0):
+    """Ingest for `json-rpc` mode: a WEBSOCKET on `/v1/receive/{number}`.
+
+    Upstream upgrades the connection and writes one JSON text frame per message.
+    `websocket-client` is imported lazily so the hermetic suite (which injects
+    its own factory) never needs it installed.
+    """
+    url = receive_url(account, api_url=api_url, websocket=True)
+
+    def _open():  # pragma: no cover - live path
+        import websocket  # websocket-client
+        conn = websocket.create_connection(url, timeout=timeout)
+
+        def _frames():
+            try:
+                while True:
+                    yield conn.recv()
+            finally:
+                conn.close()
+
+        return _frames()
+
+    return _open
+
+
+def rest_poll_stream_factory(account: str, api_url: str | None = None,
+                             timeout: float = 60.0):
+    """Ingest for NON-json-rpc mode: one-shot `GET /v1/receive/{number}`.
+
+    Returns a JSON array of messages and drains the server-side queue, so the
+    caller loops. Kept because it is the documented behaviour of the same path in
+    the other mode, and it is the manual drain an operator reaches for.
+    """
+    url = receive_url(account, api_url=api_url)
 
     def _open():  # pragma: no cover - live path
         import requests
-        resp = requests.get(f"{base}{EVENTS_PATH}", stream=True, timeout=timeout)
+        resp = requests.get(url, timeout=timeout)
         resp.raise_for_status()
-        return resp.iter_lines()
+        return [resp.text]
 
     return _open
 
@@ -533,7 +721,10 @@ def build_parser() -> argparse.ArgumentParser:
         prog="consumer.py", description="Signal chat pipeline: consume, query, draft.")
     sub = p.add_subparsers(dest="cmd", required=True)
 
-    sub.add_parser("run", help="consume the SSE stream forever (the Deployment)")
+    r = sub.add_parser(
+        "run", help="consume /v1/receive/{number} forever (the Deployment)")
+    r.add_argument("--account", default=ACCOUNT,
+                   help="the account number to receive for (default $SIGNAL_ACCOUNT)")
 
     q = sub.add_parser("conversations", help="list conversations, newest first")
     q.add_argument("--limit", type=int, default=25)
@@ -545,10 +736,12 @@ def build_parser() -> argparse.ArgumentParser:
     d = sub.add_parser("draft", help="compose an outbound draft (transmits NOTHING)")
     d.add_argument("--to", required=True)
     d.add_argument("--body", required=True)
-    d.add_argument("--from-number", default=os.environ.get("SIGNAL_ACCOUNT"))
+    d.add_argument("--from-number", default=ACCOUNT,
+                   help="the sending account (default $SIGNAL_ACCOUNT)")
 
     ls = sub.add_parser("drafts", help="list drafts and their send_state")
-    ls.add_argument("--state", choices=[STATE_PENDING, STATE_APPROVED, STATE_SENT])
+    ls.add_argument("--state", choices=[STATE_PENDING, STATE_APPROVED,
+                                        STATE_SENDING, STATE_SENT])
 
     a = sub.add_parser("approve", help="record Zach's clawgate approval for a draft")
     a.add_argument("draft_id", type=int)
@@ -565,9 +758,14 @@ def main(argv=None) -> int:  # pragma: no cover - thin CLI shell over tested uni
     with SignalDB() as db:
         db.ensure_schema()
         if args.cmd == "run":
+            account = args.account or ACCOUNT
+            if not account:
+                print("run: set SIGNAL_ACCOUNT (or --account) — bbernhard's ingest "
+                      "endpoint is per-account", file=sys.stderr)
+                return 2
             consumer = SignalConsumer(
                 db,
-                stream_factory=http_stream_factory(),
+                stream_factory=ws_stream_factory(account),
                 fetch_attachment=http_attachment_fetcher(),
                 minio=_open_minio(),
             )

--- a/scripts/signal/consumer.py
+++ b/scripts/signal/consumer.py
@@ -352,12 +352,12 @@ def parse_envelope(envelope: dict) -> ParsedEvent:
 
 
 def parse_receive_frame(payload) -> dict:
-    """One websocket frame (or one REST array element) → the envelope inside it.
+    """One received frame → the envelope inside it.
 
     Accepts, deliberately, the three shapes this endpoint can hand back:
       * bbernhard's json-rpc websocket frame — `{"account": …, "envelope": {…}}`;
       * a signal-cli JSON-RPC notification — `{"method":"receive","params":{…}}`;
-      * an already-decoded dict (the REST-array path decodes once, up front).
+      * an already-decoded dict, which `iter_frames` passes straight through.
     """
     if isinstance(payload, (bytes, bytearray)):
         payload = payload.decode("utf-8", "replace")
@@ -856,12 +856,21 @@ def main(argv=None) -> int:  # pragma: no cover - thin CLI shell over tested uni
                 print(f"refused: {exc}", file=sys.stderr)
                 return 3
         elif args.cmd == "reconcile":
+            # argparse cannot express "--timestamp is required WITH --sent", and
+            # `_server_timestamp` raises a plain ValueError — so without this the
+            # refusal arrived as a traceback and an exit code nobody scripts on.
+            if args.sent and not args.timestamp:
+                print("refused: --sent needs --timestamp, the SERVER timestamp "
+                      "read from the Signal conversation. Without it the sync "
+                      "echo cannot be deduped (🔧 #4), and guessing is worse "
+                      "than refusing.", file=sys.stderr)
+                return 3
             try:
                 print(json.dumps(db.reconcile_send(
                     args.draft_id,
                     outcome=RECONCILE_SENT if args.sent else RECONCILE_NOT_SENT,
                     server_timestamp=args.timestamp, note=args.note), default=str))
-            except SendGateError as exc:
+            except (SendGateError, ValueError) as exc:
                 print(f"refused: {exc}", file=sys.stderr)
                 return 3
     return 0

--- a/scripts/signal/requirements.txt
+++ b/scripts/signal/requirements.txt
@@ -1,0 +1,17 @@
+# Runtime dependencies of scripts/signal/ — what the consumer IMAGE must install.
+#
+# 🔴 This file exists because a missing dependency here is not a crash, it is a
+# ZOMBIE: `run()` treats any failure from the stream factory as a dropped stream
+# and reconnects, so an absent `websocket-client` produced an infinite
+# "reconnecting" loop with zero rows ingested. `ws_stream_factory()` now imports
+# at build time and names this file in its error, but the real fix is the image
+# actually carrying these.
+#
+# The hermetic test suite needs NONE of these except psycopg2 (imported by
+# _signal_db) and minio (imported by _minio) — every transport is injected.
+# See flake.nix `checks.pytests` for what the gate installs.
+
+psycopg2-binary          # _signal_db: Postgres client
+minio                    # _minio: S3 client for the attachment archive
+requests                 # consumer: attachment fetch + the send POST
+websocket-client         # consumer: json-rpc ingest on /v1/receive/{number}

--- a/scripts/signal/tests/conftest.py
+++ b/scripts/signal/tests/conftest.py
@@ -1,0 +1,79 @@
+"""Shared fixtures for the Signal suites. Hermetic: no Postgres, MinIO, or network.
+
+`scripts/signal/` is put on `sys.path` here (the mail-actions pattern) so every
+suite imports the modules under test directly.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SIGNAL_DIR = Path(__file__).resolve().parents[1]
+TESTS_DIR = Path(__file__).resolve().parent
+FIXTURES = TESTS_DIR / "fixtures"
+
+for _p in (str(SIGNAL_DIR), str(TESTS_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import fakepg  # noqa: E402
+
+
+def load_corpus() -> dict:
+    """The envelope corpus, minus its `_README` key."""
+    raw = json.loads((FIXTURES / "envelopes.json").read_text(encoding="utf-8"))
+    corpus = {k: v for k, v in raw.items() if not k.startswith("_")}
+    if not corpus:
+        raise AssertionError(
+            "HARNESS BROKEN: the envelope corpus is empty — every parse assertion "
+            "would pass vacuously")
+    return corpus
+
+
+@pytest.fixture()
+def corpus() -> dict:
+    return load_corpus()
+
+
+@pytest.fixture()
+def db():
+    """A `SignalDB` on the sqlite substrate, schema applied."""
+    import _signal_db
+
+    conn_db = fakepg.open_db(_signal_db)
+    yield conn_db
+    conn_db.conn.close()
+
+
+@pytest.fixture()
+def recording():
+    """A `(SignalDB, RecordingConn)` pair that executes nothing."""
+    import _signal_db
+
+    return fakepg.recording_db(_signal_db)
+
+
+@pytest.fixture(autouse=True)
+def _no_live_network(monkeypatch):
+    """Fail loudly if any test reaches for `requests`.
+
+    The suites inject every transport; a test that quietly imported `requests`
+    and hit the network would make the "hermetic" claim false without failing.
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def guard(name, *args, **kwargs):
+        # A test that installs a FAKE `requests` in sys.modules is fine — that is
+        # the injected-transport path. Reaching for the REAL library is not.
+        if name == "requests" and "requests" not in sys.modules:
+            raise AssertionError(
+                "a Signal test imported `requests` — every transport in these "
+                "suites is injected; nothing here may touch the network")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guard)

--- a/scripts/signal/tests/conftest.py
+++ b/scripts/signal/tests/conftest.py
@@ -57,6 +57,18 @@ def recording():
 
 
 @pytest.fixture(autouse=True)
+def _operator_approval_env(monkeypatch):
+    """Most suites act AS THE OPERATOR, so the approval token is present.
+
+    `approve_draft()` refuses without `SIGNAL_APPROVAL_TOKEN` — the operator-only
+    variable that keeps a drafting agent from approving its own draft. Setting it
+    here keeps every other suite readable; `test_approval_gate.py` deletes it
+    explicitly and asserts the refusal, so the guard is still measured.
+    """
+    monkeypatch.setenv("SIGNAL_APPROVAL_TOKEN", "operator-shell-token")
+
+
+@pytest.fixture(autouse=True)
 def _no_live_network(monkeypatch):
     """Fail loudly if any test reaches for `requests`.
 

--- a/scripts/signal/tests/fakepg.py
+++ b/scripts/signal/tests/fakepg.py
@@ -1,0 +1,295 @@
+"""Hermetic DB substrates for the Signal suites. No Postgres, no network.
+
+TWO substrates, for two different jobs:
+
+* ``RecordingConn`` — the `scripts/mail-actions/tests/test_db_schema.py` pattern:
+  records every ``(sql, params)`` the layer emits so a test can assert on the SQL
+  itself (that the FTS query binds its parameter, that a guard lives in the WHERE
+  clause rather than in Python, …). Executes nothing.
+
+* ``SqliteConn`` — a REAL relational engine standing in for Postgres, so
+  idempotency/dedupe/constraint claims are BEHAVIOURAL rather than spelled. The
+  DDL under test is `_signal_db.SCHEMA_STATEMENTS` itself, mechanically
+  translated; nothing is restated here, so removing ``NOT NULL`` or a ``UNIQUE``
+  from the real schema really does change what these tests observe. That is what
+  makes the four 🔧 corrections mutation-testable at all.
+
+WHAT THE SQLITE SUBSTRATE FAITHFULLY REPRODUCES (the properties under test):
+  * ``NOT NULL`` and ``UNIQUE`` enforcement, including **UNIQUE treating NULLs as
+    DISTINCT** — the exact Postgres behaviour 🔧 #1 exists for;
+  * partial indexes (``… WHERE message_id IS NULL``);
+  * ``INSERT … ON CONFLICT (…) DO UPDATE/NOTHING … RETURNING``;
+  * foreign keys (``PRAGMA foreign_keys=ON``).
+
+WHAT IT DOES **NOT** REPRODUCE — stated so no test claims more than it measured:
+  * ``tsvector``/``to_tsvector`` stemming. The generated column is dropped and
+    ``search @@ websearch_to_tsquery('english', ?)`` is rewritten to the
+    ``pg_websearch_match(body, ?)`` shim below, which does AND-of-terms substring
+    matching. So the FTS tests pin ROW SELECTION, JOINs, ordering, the limit and
+    the parameter binding — NOT Postgres's stemming or ranking. Those need the
+    live database (deployment step 7).
+  * types: ``BOOLEAN`` reads back as 0/1 and ``TIMESTAMPTZ`` as text. Tests
+    compare truthiness, never ``is True``.
+
+🔴 The translator RAISES on anything it does not recognise rather than silently
+passing SQL through — a substrate that quietly mistranslates would make every
+assertion above vacuous.
+"""
+from __future__ import annotations
+
+import re
+import sqlite3
+
+SQLITE_MIN = (3, 35, 0)  # RETURNING support
+
+
+def _require_sqlite() -> None:
+    have = tuple(int(x) for x in sqlite3.sqlite_version.split("."))
+    if have < SQLITE_MIN:  # pragma: no cover - environment guard
+        raise AssertionError(
+            f"HARNESS BROKEN: sqlite {sqlite3.sqlite_version} lacks RETURNING "
+            f"(need >= {'.'.join(map(str, SQLITE_MIN))}); these suites would test "
+            f"nothing. This is a hard error, deliberately, NOT a skip.")
+
+
+# --------------------------------------------------------------------------- #
+# Postgres -> sqlite translation
+# --------------------------------------------------------------------------- #
+_TYPE_MAP = (
+    (r"\bBIGSERIAL PRIMARY KEY\b", "INTEGER PRIMARY KEY AUTOINCREMENT"),
+    (r"\bSERIAL PRIMARY KEY\b", "INTEGER PRIMARY KEY AUTOINCREMENT"),
+    (r"\bTIMESTAMPTZ DEFAULT now\(\)", "TEXT DEFAULT CURRENT_TIMESTAMP"),
+    (r"\bTIMESTAMPTZ\b", "TEXT"),
+    (r"\bBYTEA\b", "BLOB"),
+    (r"\bJSONB\b", "TEXT"),
+    (r"\bUUID\b", "TEXT"),
+    (r"\bBIGINT\b", "INTEGER"),
+    (r"\bGREATEST\(", "MAX("),
+)
+
+# The generated tsvector column and its GIN index have no sqlite equivalent.
+_GENERATED_COL = re.compile(
+    r"^\s*search\s+tsvector\s+GENERATED\s+ALWAYS\s+AS\s+\(.*\)\s+STORED\s*,\s*$",
+    re.MULTILINE | re.IGNORECASE)
+_GIN_INDEX = re.compile(r"USING\s+GIN\s*\(", re.IGNORECASE)
+
+# `CREATE INDEX x ON signal.messages(...)` -> `CREATE INDEX signal.x ON messages(...)`
+_CREATE_INDEX = re.compile(
+    r"CREATE INDEX IF NOT EXISTS (\w+) ON signal\.(\w+)", re.IGNORECASE)
+
+_FTS_PREDICATE = re.compile(
+    r"(\w+)\.search\s+@@\s+websearch_to_tsquery\('english',\s*%s\)", re.IGNORECASE)
+
+
+_IS_DDL = re.compile(r"CREATE\s+(SCHEMA|TABLE|INDEX)\b", re.IGNORECASE)
+
+
+class TranslationError(AssertionError):
+    """The substrate met SQL it could not faithfully translate."""
+
+
+def translate_ddl(stmt: str) -> str | None:
+    """One `SCHEMA_STATEMENTS` entry → sqlite DDL, or None to skip it."""
+    s = stmt.strip()
+    if s.upper().startswith("CREATE SCHEMA"):
+        return None                      # the `signal` db is ATTACHed instead
+    if _GIN_INDEX.search(s):
+        return None                      # no GIN in sqlite; FTS is shimmed
+    s = _GENERATED_COL.sub("", s)
+    s = _CREATE_INDEX.sub(r"CREATE INDEX IF NOT EXISTS signal.\1 ON \2", s)
+    # sqlite cannot resolve a schema-qualified REFERENCES target; every table
+    # lives in the attached `signal` db, so the bare name resolves correctly.
+    s = re.sub(r"REFERENCES\s+signal\.(\w+)", r"REFERENCES \1", s)
+    for pattern, repl in _TYPE_MAP:
+        s = re.sub(pattern, repl, s)
+    if "tsvector" in s.lower():
+        raise TranslationError(
+            f"HARNESS BROKEN: a tsvector survived translation:\n{s}")
+    return s
+
+
+def translate_dml(sql: str) -> str:
+    """One runtime statement → sqlite, preserving its meaning or raising."""
+    s = _FTS_PREDICATE.sub(r"pg_websearch_match(\1.body, %s)", sql)
+    if "tsvector" in s.lower() or "websearch_to_tsquery" in s.lower() or "@@" in s:
+        raise TranslationError(
+            f"HARNESS BROKEN: an untranslated FTS construct reached sqlite:\n{s}")
+    for pattern, repl in _TYPE_MAP:
+        s = re.sub(pattern, repl, s)
+    return s
+
+
+def translate_params(sql: str, params):
+    """`%s`/`%(name)s` placeholders → sqlite's `?`/`:name`."""
+    if isinstance(params, dict):
+        return re.sub(r"%\((\w+)\)s", r":\1", sql), params
+    return sql.replace("%s", "?"), tuple(params or ())
+
+
+def _websearch_match(body, query) -> int:
+    """Stand-in for `search @@ websearch_to_tsquery('english', ?)`.
+
+    AND-of-terms, case-insensitive, quoted phrases honoured, `-term` negates.
+    NO stemming — see this module's docstring for what that means for the FTS
+    tests' scope.
+    """
+    hay = (body or "").lower()
+    q = (query or "").strip().lower()
+    if not q:
+        return 0
+    terms = re.findall(r'"([^"]+)"|(\S+)', q)
+    positives, negatives = [], []
+    for phrase, word in terms:
+        term = phrase or word
+        if not phrase and term.startswith("-") and len(term) > 1:
+            negatives.append(term[1:])
+        elif term not in ("or", "and"):
+            positives.append(term)
+    if any(n in hay for n in negatives):
+        return 0
+    return 1 if all(p in hay for p in positives) else 0
+
+
+# --------------------------------------------------------------------------- #
+# Substrate 1 — a real engine
+# --------------------------------------------------------------------------- #
+class SqliteCursor:
+    def __init__(self, conn: "SqliteConn", cursor_factory=None):
+        self._conn = conn
+        self._cur = conn.raw.cursor()
+        self._dict_rows = cursor_factory is not None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        self._cur.close()
+        return False
+
+    @property
+    def rowcount(self) -> int:
+        return self._cur.rowcount
+
+    def execute(self, sql, params=None):
+        self._conn.executed.append((" ".join(str(sql).split()), params))
+        if _IS_DDL.match(str(sql).strip()):
+            translated = translate_ddl(sql)
+            if translated is None:
+                return                     # no sqlite equivalent; documented above
+            self._cur.execute(translated)
+            return
+        translated = translate_dml(sql)
+        translated, tparams = translate_params(translated, params)
+        self._cur.execute(translated, tparams)
+
+    def _rows(self, rows):
+        if not self._dict_rows:
+            return rows
+        cols = [d[0] for d in self._cur.description or []]
+        return [dict(zip(cols, r)) for r in rows]
+
+    def fetchall(self):
+        return self._rows(self._cur.fetchall())
+
+    def fetchone(self):
+        row = self._cur.fetchone()
+        if row is None:
+            return None
+        return self._rows([row])[0]
+
+
+class SqliteConn:
+    """A psycopg2-shaped connection backed by in-memory sqlite."""
+
+    def __init__(self):
+        _require_sqlite()
+        self.raw = sqlite3.connect(":memory:")
+        self.raw.execute("ATTACH DATABASE ':memory:' AS signal")
+        self.raw.execute("PRAGMA foreign_keys=ON")
+        self.raw.create_function("pg_websearch_match", 2, _websearch_match)
+        self.executed: list[tuple[str, object]] = []
+        self.commits = 0
+
+    def cursor(self, cursor_factory=None):
+        return SqliteCursor(self, cursor_factory)
+
+    def commit(self):
+        self.commits += 1
+        self.raw.commit()
+
+    def close(self):
+        self.raw.close()
+
+    # -- direct introspection for tests -----------------------------------
+    def count(self, table: str) -> int:
+        return self.raw.execute(f"SELECT count(*) FROM signal.{table}").fetchone()[0]
+
+    def rows(self, sql: str, params=()) -> list[dict]:
+        cur = self.raw.execute(sql, params)
+        cols = [d[0] for d in cur.description]
+        return [dict(zip(cols, r)) for r in cur.fetchall()]
+
+
+# --------------------------------------------------------------------------- #
+# Substrate 2 — SQL recorder (executes nothing)
+# --------------------------------------------------------------------------- #
+class RecordingCursor:
+    def __init__(self, conn):
+        self._conn = conn
+        self.rowcount = 0
+        self._result = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+    def execute(self, sql, params=None):
+        self._conn.executed.append((" ".join(str(sql).split()), params))
+        self.rowcount = self._conn.next_rowcount
+        if self._conn.result_queue:
+            self._result = self._conn.result_queue.pop(0)
+        else:
+            self._result = self._conn.next_result
+
+    def fetchall(self):
+        return self._result
+
+    def fetchone(self):
+        return self._result[0] if self._result else None
+
+
+class RecordingConn:
+    def __init__(self):
+        self.executed: list[tuple[str, object]] = []
+        self.commits = 0
+        self.next_rowcount = 0
+        self.next_result: list = []
+        self.result_queue: list[list] = []
+
+    def cursor(self, cursor_factory=None):
+        return RecordingCursor(self)
+
+    def commit(self):
+        self.commits += 1
+
+    def sqls(self) -> list[str]:
+        return [sql for sql, _ in self.executed]
+
+
+# --------------------------------------------------------------------------- #
+# Convenience
+# --------------------------------------------------------------------------- #
+def open_db(module):
+    """A `SignalDB` bound to a fresh sqlite substrate, schema applied."""
+    db = module.SignalDB(dsn="postgres://u:p@h/mailbox")
+    db.conn = SqliteConn()
+    db.ensure_schema()
+    return db
+
+
+def recording_db(module):
+    db = module.SignalDB(dsn="postgres://u:p@h/mailbox")
+    db.conn = RecordingConn()
+    return db, db.conn

--- a/scripts/signal/tests/fakepg.py
+++ b/scripts/signal/tests/fakepg.py
@@ -153,6 +153,22 @@ def _websearch_match(body, query) -> int:
 # --------------------------------------------------------------------------- #
 # Substrate 1 — a real engine
 # --------------------------------------------------------------------------- #
+class InFailedTransaction(Exception):
+    """Stands in for psycopg2's `InFailedSqlTransaction` inside the substrate.
+
+    Replaced at import time by the real psycopg2 class (see below) so the code
+    under test meets the exception it will actually meet in production.
+    """
+
+
+try:  # the real class, so `TRANSIENT_DB_ERRORS` membership is genuinely exercised
+    import psycopg2.errors
+
+    InFailedTransaction = psycopg2.errors.InFailedSqlTransaction  # noqa: F811
+except Exception:  # pragma: no cover - psycopg2 is a hard dep of the module anyway
+    pass
+
+
 class SqliteCursor:
     def __init__(self, conn: "SqliteConn", cursor_factory=None):
         self._conn = conn
@@ -171,6 +187,23 @@ class SqliteCursor:
         return self._cur.rowcount
 
     def execute(self, sql, params=None):
+        # 🔴 POSTGRES TRANSACTION SEMANTICS, emulated on purpose. sqlite is
+        # happy to keep going after a failed statement; Postgres is not — with
+        # `autocommit=False` the first failure ABORTS the transaction and every
+        # later statement raises `InFailedSqlTransaction` until a `rollback()`.
+        # Without this the substrate could not reach the zombie-pod bug at all,
+        # and the recovery tests would be theatre.
+        if self._conn.aborted:
+            raise InFailedTransaction(
+                "current transaction is aborted, commands ignored until end of "
+                "transaction block")
+        try:
+            return self._execute(sql, params)
+        except Exception:
+            self._conn.aborted = True
+            raise
+
+    def _execute(self, sql, params=None):
         self._conn.executed.append((" ".join(str(sql).split()), params))
         if _IS_DDL.match(str(sql).strip()):
             translated = translate_ddl(sql)
@@ -209,15 +242,28 @@ class SqliteConn:
         self.raw.create_function("pg_websearch_match", 2, _websearch_match)
         self.executed: list[tuple[str, object]] = []
         self.commits = 0
+        self.rollbacks = 0
+        self.aborted = False
+        self.closed = 0
 
     def cursor(self, cursor_factory=None):
         return SqliteCursor(self, cursor_factory)
 
     def commit(self):
+        if self.aborted:
+            raise InFailedTransaction(
+                "current transaction is aborted, commands ignored until end of "
+                "transaction block")
         self.commits += 1
         self.raw.commit()
 
+    def rollback(self):
+        self.rollbacks += 1
+        self.aborted = False
+        self.raw.rollback()
+
     def close(self):
+        self.closed = 1
         self.raw.close()
 
     # -- direct introspection for tests -----------------------------------
@@ -264,6 +310,8 @@ class RecordingConn:
     def __init__(self):
         self.executed: list[tuple[str, object]] = []
         self.commits = 0
+        self.rollbacks = 0
+        self.closed = 0
         self.next_rowcount = 0
         self.next_result: list = []
         self.result_queue: list[list] = []
@@ -273,6 +321,9 @@ class RecordingConn:
 
     def commit(self):
         self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
 
     def sqls(self) -> list[str]:
         return [sql for sql, _ in self.executed]

--- a/scripts/signal/tests/fixtures/envelopes.json
+++ b/scripts/signal/tests/fixtures/envelopes.json
@@ -363,6 +363,28 @@
     }
   },
 
+  "remote_delete": {
+    "envelope": {
+      "source": "+15551616",
+      "sourceNumber": "+15551616",
+      "sourceUuid": "16161616-1616-4161-8161-161616161616",
+      "timestamp": 1723000001616,
+      "dataMessage": {
+        "timestamp": 1723000001616,
+        "message": null,
+        "remoteDelete": {"targetSentTimestamp": 1723000001606}
+      }
+    },
+    "expect": {
+      "kind": "remote_delete",
+      "remote_delete": {
+        "target_sent_timestamp": 1723000001606,
+        "target_author_uuid": "16161616-1616-4161-8161-161616161616",
+        "target_author_number": "+15551616"
+      }
+    }
+  },
+
   "unknown_type": {
     "envelope": {
       "source": "+15551515",

--- a/scripts/signal/tests/fixtures/envelopes.json
+++ b/scripts/signal/tests/fixtures/envelopes.json
@@ -1,0 +1,376 @@
+{
+  "_README": [
+    "The envelope corpus for test_envelope_parse.py. Every entry is a REAL-SHAPED",
+    "signal-cli-rest-api envelope plus an `expect` block the test asserts against.",
+    "",
+    "🔴 Values are PAIRWISE DISTINCT across the corpus — every case has its own uuid,",
+    "phone number, timestamp and body — and none of them equals a constant any",
+    "assertion names. A fixture that can only produce the expected constant's own",
+    "value cannot catch a mutant that hardcodes that literal."
+  ],
+
+  "dm": {
+    "envelope": {
+      "source": "+15550101",
+      "sourceNumber": "+15550101",
+      "sourceUuid": "11111111-1111-4111-8111-111111111111",
+      "sourceName": "Alice Adler",
+      "timestamp": 1723000000101,
+      "serverReceivedTimestamp": 1723000000111,
+      "serverDeliveredTimestamp": 1723000000121,
+      "dataMessage": {
+        "timestamp": 1723000000101,
+        "message": "canoe rehearsal moved to friday",
+        "expiresInSeconds": 0,
+        "viewOnce": false,
+        "attachments": []
+      }
+    },
+    "expect": {
+      "kind": "message",
+      "message": {
+        "message_timestamp": 1723000000101,
+        "source_uuid": "11111111-1111-4111-8111-111111111111",
+        "source_number": "+15550101",
+        "source_name": "Alice Adler",
+        "body": "canoe rehearsal moved to friday",
+        "group_id": null,
+        "is_outbound": false,
+        "server_received_at": 1723000000111,
+        "server_delivered_at": 1723000000121
+      }
+    }
+  },
+
+  "group": {
+    "envelope": {
+      "source": "+15550202",
+      "sourceNumber": "+15550202",
+      "sourceUuid": "22222222-2222-4222-8222-222222222222",
+      "sourceName": "Bo Brennan",
+      "timestamp": 1723000000202,
+      "dataMessage": {
+        "timestamp": 1723000000202,
+        "message": "who is bringing the projector",
+        "groupInfo": {
+          "groupId": "Z3JvdXAtdGhyZWU=",
+          "name": "Thursday Planning",
+          "type": "DELIVER"
+        }
+      }
+    },
+    "expect": {
+      "kind": "group_message",
+      "message": {
+        "message_timestamp": 1723000000202,
+        "body": "who is bringing the projector",
+        "group_name": "Thursday Planning",
+        "group_id_b64": "Z3JvdXAtdGhyZWU="
+      }
+    }
+  },
+
+  "reaction": {
+    "envelope": {
+      "source": "+15550303",
+      "sourceNumber": "+15550303",
+      "sourceUuid": "33333333-3333-4333-8333-333333333333",
+      "timestamp": 1723000000303,
+      "dataMessage": {
+        "timestamp": 1723000000303,
+        "message": null,
+        "reaction": {
+          "emoji": "🔥",
+          "targetAuthor": "+15550101",
+          "targetAuthorUuid": "11111111-1111-4111-8111-111111111111",
+          "targetSentTimestamp": 1723000000101,
+          "isRemove": false
+        }
+      }
+    },
+    "expect": {
+      "kind": "reaction",
+      "reaction": {
+        "emoji": "🔥",
+        "target_author_uuid": "11111111-1111-4111-8111-111111111111",
+        "target_sent_timestamp": 1723000000101,
+        "is_remove": false,
+        "source_uuid": "33333333-3333-4333-8333-333333333333"
+      }
+    }
+  },
+
+  "reaction_remove": {
+    "envelope": {
+      "source": "+15550808",
+      "sourceNumber": "+15550808",
+      "sourceUuid": "88888888-8888-4888-8888-888888888888",
+      "timestamp": 1723000000808,
+      "dataMessage": {
+        "timestamp": 1723000000808,
+        "reaction": {
+          "emoji": "😂",
+          "targetAuthor": "+15550202",
+          "targetAuthorUuid": "22222222-2222-4222-8222-222222222222",
+          "targetSentTimestamp": 1723000000202,
+          "isRemove": true
+        }
+      }
+    },
+    "expect": {
+      "kind": "reaction",
+      "reaction": {
+        "emoji": "😂",
+        "target_sent_timestamp": 1723000000202,
+        "is_remove": true
+      }
+    }
+  },
+
+  "edit": {
+    "envelope": {
+      "source": "+15550404",
+      "sourceNumber": "+15550404",
+      "sourceUuid": "44444444-4444-4444-8444-444444444444",
+      "timestamp": 1723000000404,
+      "editMessage": {
+        "targetSentTimestamp": 1723000000101,
+        "dataMessage": {
+          "timestamp": 1723000000414,
+          "message": "correction: saturday, not friday"
+        }
+      }
+    },
+    "expect": {
+      "kind": "edit",
+      "message": {
+        "message_timestamp": 1723000000414,
+        "edit_target_timestamp": 1723000000101,
+        "body": "correction: saturday, not friday"
+      }
+    }
+  },
+
+  "attachment": {
+    "envelope": {
+      "source": "+15550505",
+      "sourceNumber": "+15550505",
+      "sourceUuid": "55555555-5555-4555-8555-555555555555",
+      "timestamp": 1723000000505,
+      "dataMessage": {
+        "timestamp": 1723000000505,
+        "message": "the receipt you asked about",
+        "attachments": [
+          {
+            "id": "attach-fixture-505",
+            "contentType": "image/webp",
+            "filename": "receipt-scan.webp",
+            "size": 20481,
+            "caption": "grocery run",
+            "voiceNote": false
+          }
+        ]
+      }
+    },
+    "expect": {
+      "kind": "message",
+      "message": {
+        "message_timestamp": 1723000000505,
+        "body": "the receipt you asked about"
+      },
+      "attachments": [
+        {
+          "id": "attach-fixture-505",
+          "content_type": "image/webp",
+          "filename": "receipt-scan.webp",
+          "size": 20481,
+          "caption": "grocery run",
+          "is_voice_note": false
+        }
+      ]
+    }
+  },
+
+  "voice_note": {
+    "envelope": {
+      "source": "+15551212",
+      "sourceNumber": "+15551212",
+      "sourceUuid": "12121212-1212-4121-8121-121212121212",
+      "timestamp": 1723000001212,
+      "dataMessage": {
+        "timestamp": 1723000001212,
+        "attachments": [
+          {
+            "id": "attach-fixture-1212",
+            "contentType": "audio/aac",
+            "filename": "voice-note.aac",
+            "size": 7331,
+            "voiceNote": true
+          }
+        ]
+      }
+    },
+    "expect": {
+      "kind": "message",
+      "message": {"message_timestamp": 1723000001212, "body": null},
+      "attachments": [
+        {"id": "attach-fixture-1212", "is_voice_note": true, "content_type": "audio/aac"}
+      ]
+    }
+  },
+
+  "quote": {
+    "envelope": {
+      "source": "+15550606",
+      "sourceNumber": "+15550606",
+      "sourceUuid": "66666666-6666-4666-8666-666666666666",
+      "timestamp": 1723000000606,
+      "dataMessage": {
+        "timestamp": 1723000000606,
+        "message": "agreed, that is the one",
+        "quote": {
+          "id": 1723000000202,
+          "author": "+15550202",
+          "authorUuid": "22222222-2222-4222-8222-222222222222",
+          "text": "who is bringing the projector"
+        }
+      }
+    },
+    "expect": {
+      "kind": "message",
+      "message": {
+        "message_timestamp": 1723000000606,
+        "body": "agreed, that is the one",
+        "quote_timestamp": 1723000000202,
+        "quote_author": "22222222-2222-4222-8222-222222222222"
+      }
+    }
+  },
+
+  "receipt_delivery": {
+    "envelope": {
+      "source": "+15550707",
+      "sourceNumber": "+15550707",
+      "sourceUuid": "77777777-7777-4777-8777-777777777777",
+      "timestamp": 1723000000707,
+      "receiptMessage": {
+        "when": 1723000000717,
+        "isDelivery": true,
+        "isRead": false,
+        "timestamps": [1723000000101]
+      }
+    },
+    "expect": {
+      "kind": "receipt_delivery",
+      "receipt": {"when": 1723000000717, "timestamps": [1723000000101]}
+    }
+  },
+
+  "receipt_read": {
+    "envelope": {
+      "source": "+15550909",
+      "sourceNumber": "+15550909",
+      "sourceUuid": "99999999-9999-4999-8999-999999999999",
+      "timestamp": 1723000000909,
+      "receiptMessage": {
+        "when": 1723000000919,
+        "isDelivery": false,
+        "isRead": true,
+        "timestamps": [1723000000202, 1723000000303]
+      }
+    },
+    "expect": {
+      "kind": "receipt_read",
+      "receipt": {"when": 1723000000919, "timestamps": [1723000000202, 1723000000303]}
+    }
+  },
+
+  "typing": {
+    "envelope": {
+      "source": "+15551010",
+      "sourceNumber": "+15551010",
+      "sourceUuid": "10101010-1010-4101-8101-101010101010",
+      "timestamp": 1723000001010,
+      "typingMessage": {"action": "STARTED", "timestamp": 1723000001010}
+    },
+    "expect": {"kind": "typing", "receipt": {"action": "STARTED"}}
+  },
+
+  "sync_outbound": {
+    "envelope": {
+      "source": "+15559090",
+      "sourceNumber": "+15559090",
+      "sourceUuid": "90909090-9090-4909-8909-909090909090",
+      "sourceName": "me",
+      "timestamp": 1723000009090,
+      "syncMessage": {
+        "sentMessage": {
+          "timestamp": 1723000009090,
+          "destination": "+15550101",
+          "destinationUuid": "11111111-1111-4111-8111-111111111111",
+          "message": "sent from my laptop"
+        }
+      }
+    },
+    "expect": {
+      "kind": "sync_outbound",
+      "message": {
+        "message_timestamp": 1723000009090,
+        "body": "sent from my laptop",
+        "is_outbound": true,
+        "dest_uuid": "11111111-1111-4111-8111-111111111111",
+        "dest_number": "+15550101",
+        "source_uuid": "90909090-9090-4909-8909-909090909090"
+      }
+    }
+  },
+
+  "view_once": {
+    "envelope": {
+      "source": "+15551313",
+      "sourceNumber": "+15551313",
+      "sourceUuid": "13131313-1313-4131-8131-131313131313",
+      "timestamp": 1723000001313,
+      "dataMessage": {
+        "timestamp": 1723000001313,
+        "message": "look quickly",
+        "viewOnce": true
+      }
+    },
+    "expect": {
+      "kind": "message",
+      "message": {"message_timestamp": 1723000001313, "view_once": true,
+                  "body": "look quickly"}
+    }
+  },
+
+  "expiring": {
+    "envelope": {
+      "source": "+15551414",
+      "sourceNumber": "+15551414",
+      "sourceUuid": "14141414-1414-4141-8141-141414141414",
+      "timestamp": 1723000001414,
+      "dataMessage": {
+        "timestamp": 1723000001414,
+        "message": "this vanishes in an hour",
+        "expiresInSeconds": 3600
+      }
+    },
+    "expect": {
+      "kind": "message",
+      "message": {"message_timestamp": 1723000001414, "expires_in_seconds": 3600,
+                  "body": "this vanishes in an hour"}
+    }
+  },
+
+  "unknown_type": {
+    "envelope": {
+      "source": "+15551515",
+      "sourceNumber": "+15551515",
+      "sourceUuid": "15151515-1515-4151-8151-151515151515",
+      "timestamp": 1723000001515,
+      "callMessage": {"offerMessage": {"id": 4242424242}}
+    },
+    "expect": {"kind": "unknown"}
+  }
+}

--- a/scripts/signal/tests/fixtures/envelopes.json
+++ b/scripts/signal/tests/fixtures/envelopes.json
@@ -385,6 +385,30 @@
     }
   },
 
+  "sync_remote_delete": {
+    "envelope": {
+      "source": "+15559091",
+      "sourceNumber": "+15559091",
+      "sourceUuid": "91919191-9191-4919-8919-919191919191",
+      "timestamp": 1723000001717,
+      "syncMessage": {
+        "sentMessage": {
+          "timestamp": 1723000001717,
+          "destination": "+15550101",
+          "remoteDelete": {"targetSentTimestamp": 1723000001707}
+        }
+      }
+    },
+    "expect": {
+      "kind": "remote_delete",
+      "remote_delete": {
+        "target_sent_timestamp": 1723000001707,
+        "target_author_uuid": "91919191-9191-4919-8919-919191919191",
+        "target_author_number": "+15559091"
+      }
+    }
+  },
+
   "unknown_type": {
     "envelope": {
       "source": "+15551515",

--- a/scripts/signal/tests/test_approval_gate.py
+++ b/scripts/signal/tests/test_approval_gate.py
@@ -15,9 +15,14 @@ The routes attempted:
   5. re-using a spent capability (replay);
   6. approving a draft that was already sent, to re-arm it.
 
-Plus a STRUCTURAL check that there is exactly one call site posting to the send
-endpoint in the whole of `scripts/signal/` — the property that makes the five
-behavioural checks above exhaustive rather than a sample.
+Plus a STRUCTURAL ledger of the functions that can build a send-endpoint URL.
+🔴 It is a TRIPWIRE over enumerated spellings, NOT a proof that no other door can
+exist — an earlier version claimed the latter and was then walked by four
+spellings a blind audit found in minutes. What it supports is narrower and true:
+the door this codebase HAS is the gated one, every function in the ledger is
+asserted to spend a capability, and adding an obvious second door fails the
+suite. The unconditional guarantee is the capability check inside
+`transmit_approved()`, which no caller can skip.
 """
 import ast
 import sys
@@ -209,23 +214,37 @@ def test_approving_a_missing_draft_is_refused(db):
 
 
 # --------------------------------------------------------------------------- #
-# The structural claim that makes the above exhaustive
+# The structural ledger — a tripwire, scoped in its own docstring
 # --------------------------------------------------------------------------- #
-def _functions_that_can_reach_the_send_endpoint() -> dict:
+def _functions_that_can_reach_the_send_endpoint(root: Path = SIGNAL_DIR) -> dict:
     """AST ledger: every function that can BUILD a send-endpoint URL.
 
-    🔴 WHY AN AST WALK AND NOT A GREP. The first version of this ledger grepped
-    for the identifier `SEND_PATH`, so a second door spelled with the LITERAL —
-    `poster(API_URL + "/v2/send", …)`, no capability, no gate call — was invisible
-    to it and survived the whole suite. A guard that can be walked by rewording
-    is not a structural guard. This one recognises BOTH spellings, at every
-    function in every module, by looking at the parsed code rather than its text.
+    🔴 WHAT THIS IS AND IS NOT. It is a TRIPWIRE over the spellings enumerated
+    below, not a proof that no other door exists — a determined `exec()` or a URL
+    assembled from runtime data would pass it, and no static check of this size
+    can say otherwise. The claim it supports is narrow and worth stating exactly:
+    *the door this codebase actually has is the gated one, and adding an obvious
+    second one fails the suite.* The real guarantee is the capability check
+    inside `transmit_approved()`, which every function in this ledger is
+    separately asserted to call.
 
+    An earlier version grepped for the identifier `SEND_PATH` and was walked by
+    FOUR spellings a blind audit found in minutes. Recognised now:
+
+      * the `SEND_PATH` name, and any local ALIAS of it (`from consumer import
+        SEND_PATH as _SP`);
+      * `getattr(consumer, "SEND_PATH")`;
+      * a string literal containing the path;
+      * a SPLIT or FORMATTED literal — the constant parts of any expression are
+        joined, so `"/v2" + "/send"` and `"%s/v2/%s" % …` are caught too.
+
+    Walks `rglob`, not `glob`: a module in a subdirectory was never visited.
     Returns `{module: {function: [reasons]}}`.
     """
     found: dict[str, dict[str, list[str]]] = {}
-    modules = sorted(SIGNAL_DIR.glob("*.py"))
-    assert len(modules) >= 4, f"HARNESS BROKEN: only found {modules}"
+    modules = sorted(p for p in root.rglob("*.py")
+                     if "tests" not in p.parts and "__pycache__" not in p.parts)
+    assert modules, f"HARNESS BROKEN: no modules under {root}"
     for path in modules:
         tree = ast.parse(path.read_text(encoding="utf-8"))
         parents = {}
@@ -256,10 +275,46 @@ def _functions_that_can_reach_the_send_endpoint() -> dict:
                     return False
             return False
 
+        # Local names that ALIAS the constant: `from consumer import SEND_PATH as
+        # _SP`, `_SP = SEND_PATH`. Without these a one-line rename walks the guard.
+        aliases = {"SEND_PATH"}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                for alias in node.names:
+                    if alias.name == "SEND_PATH":
+                        aliases.add(alias.asname or alias.name)
+            elif isinstance(node, ast.Assign) and isinstance(node.value, ast.Name):
+                if node.value.id in aliases:
+                    for target in node.targets:
+                        if isinstance(target, ast.Name):
+                            aliases.add(target.id)
+
+        def joined_constants(node) -> str:
+            """Every string constant inside an expression, concatenated.
+
+            Catches a SPLIT or FORMATTED path — `"/v2" + "/send"`,
+            `"%s/v2/%s" % (...)`, an f-string — which a whole-literal check misses.
+            """
+            return "".join(
+                n.value for n in ast.walk(node)
+                if isinstance(n, ast.Constant) and isinstance(n.value, str))
+
         for node in ast.walk(tree):
             reason = None
-            if isinstance(node, ast.Name) and node.id == "SEND_PATH":
-                reason = "SEND_PATH"
+            if isinstance(node, ast.Name) and node.id in aliases:
+                reason = f"name {node.id}"
+            elif (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+                  and node.func.id == "getattr"
+                  and any(isinstance(a, ast.Constant) and a.value == "SEND_PATH"
+                          for a in node.args)):
+                reason = 'getattr(..., "SEND_PATH")'
+            elif isinstance(node, (ast.BinOp, ast.JoinedStr)):
+                merged = joined_constants(node)
+                if consumer.SEND_PATH in merged or (
+                        "/v2" in merged and "send" in merged):
+                    if inside_a_raise(node):
+                        continue
+                    reason = f"assembled path {merged!r}"
             elif (isinstance(node, ast.Constant) and isinstance(node.value, str)
                   and consumer.SEND_PATH in node.value):
                 # A bare string STATEMENT is a docstring, not a URL being built.
@@ -289,32 +344,64 @@ def test_exactly_one_function_can_reach_the_send_endpoint():
     assert set(ledger["consumer.py"]) == {"transmit_approved"}, ledger
 
 
-def test_the_ledger_would_see_a_second_door_spelled_with_the_literal():
-    """POSITIVE CONTROL on the ledger itself, against the mutant that escaped it.
+# Five ungated back doors, one per spelling. A blind audit walked the previous
+# ledger with four of these; each is now a named case run through the REAL
+# function.
+BACKDOOR_SPELLINGS = {
+    "plain_literal": '    return poster(API_URL + "/v2/send", json={"m": body})',
+    "aliased_name": "    return poster(API_URL + _SP, json={'m': body})",
+    "split_literal": '    return poster(API_URL + "/v2" + "/send", json={"m": body})',
+    "getattr_lookup":
+        '    return poster(API_URL + getattr(consumer, "SEND_PATH"), json={"m": body})',
+    "percent_format": '    return poster("%s/v2/%s" % (API_URL, "send"), json={"m": body})',
+}
 
-    A `quick_send()` that posts to `API_URL + "/v2/send"` without touching the
-    gate must be VISIBLE. Verified against a synthetic module here rather than by
-    mutating the real one, so the control ships with the guard.
+
+def _write_backdoor_module(tmp_path: Path, name: str, body_line: str) -> Path:
+    module = tmp_path / f"backdoor_{name}.py"
+    module.write_text(
+        "import consumer\n"
+        "from consumer import SEND_PATH as _SP\n"
+        'API_URL = "http://x"\n'
+        f"def quick_send(poster, body):\n{body_line}\n",
+        encoding="utf-8")
+    return module
+
+
+@pytest.mark.parametrize("spelling", sorted(BACKDOOR_SPELLINGS))
+def test_the_ledger_catches_every_spelling_of_a_second_door(tmp_path, spelling):
+    """🔴 NEGATIVE CONTROL, run through the REAL ledger function.
+
+    The previous control re-implemented a mini walk over synthetic source, so it
+    validated the IDEA and not the INSTRUMENT — and the instrument was in fact
+    walked by four of these five spellings while the suite stayed green. Each
+    case now writes a module to a temp dir and calls
+    `_functions_that_can_reach_the_send_endpoint()` on it.
     """
-    source = (
-        "API_URL = 'http://x'\n"
-        "SEND_PATH = '/v2/send'\n"
-        "def quick_send(poster, body):\n"
-        "    return poster(API_URL + '/v2/send', json={'message': body})\n"
-    )
-    tree = ast.parse(source)
-    hits = [n for n in ast.walk(tree)
-            if isinstance(n, ast.Constant) and isinstance(n.value, str)
-            and consumer.SEND_PATH in n.value]
-    # Two: the constant's definition and the ungated call site inside quick_send.
-    assert len(hits) == 2
-    inside_function = [
-        n for fn in ast.walk(tree) if isinstance(fn, ast.FunctionDef)
-        for n in ast.walk(fn)
-        if isinstance(n, ast.Constant) and isinstance(n.value, str)
-        and consumer.SEND_PATH in n.value
-    ]
-    assert len(inside_function) == 1, "the literal spelling must be detectable"
+    _write_backdoor_module(tmp_path, spelling, BACKDOOR_SPELLINGS[spelling])
+    ledger = _functions_that_can_reach_the_send_endpoint(tmp_path)
+    assert ledger, f"the {spelling!r} back door was INVISIBLE to the ledger"
+    functions = {fn for mod in ledger.values() for fn in mod}
+    assert "quick_send" in functions, ledger
+
+
+def test_the_ledger_is_quiet_on_a_module_with_no_door(tmp_path):
+    """POSITIVE CONTROL the other way: it does not flag everything it reads."""
+    (tmp_path / "innocent.py").write_text(
+        'API_URL = "http://x"\n'
+        "def fetch(getter):\n"
+        '    return getter(API_URL + "/v1/attachments/abc")\n',
+        encoding="utf-8")
+    assert _functions_that_can_reach_the_send_endpoint(tmp_path) == {}
+
+
+def test_the_ledger_walks_subdirectories(tmp_path):
+    """`glob` is not `rglob` — a module one directory down was never visited."""
+    nested = tmp_path / "deeper"
+    nested.mkdir()
+    _write_backdoor_module(nested, "nested", BACKDOOR_SPELLINGS["plain_literal"])
+    ledger = _functions_that_can_reach_the_send_endpoint(tmp_path)
+    assert ledger, "a back door in a SUBDIRECTORY was invisible to the ledger"
 
 
 def test_every_function_in_the_ledger_spends_a_capability():
@@ -420,16 +507,207 @@ def test_send_attempts_records_that_a_send_was_tried(db):
     assert row["send_attempts"] == 1
 
 
-def test_per_recipient_errors_in_the_response_are_not_treated_as_success(db):
-    """A 201 can still carry `errors` — upstream's response has that field."""
+@pytest.mark.parametrize("errors", [
+    # The shape upstream actually sends (`SendMessageErrors{Recipients: …}`) ...
+    {"recipients": [{"recipient": PEER, "message": "unregistered user"}]},
+    # ... and a bare list, in case the encoding differs by version.
+    [{"recipient": PEER, "message": "unregistered user"}],
+])
+def test_per_recipient_errors_in_the_response_are_not_treated_as_success(db, errors):
+    """A 201 can still carry `errors` — upstream's response has that field.
+
+    Parametrised over BOTH shapes: the earlier test fed a bare list while
+    upstream sends an object, and "both are truthy so the guard holds" is a
+    reason to test the real shape, not a reason to skip it.
+    """
     draft = _pending(db)
     db.approve_draft(draft["id"], approval_ref="cg-errors")
     with pytest.raises(RuntimeError) as exc:
         db.send_approved(draft["id"], transmit=lambda a, **kw: {
-            "timestamp": str(SERVER_TS),
-            "errors": [{"recipient": PEER, "message": "unregistered user"}]})
+            "timestamp": str(SERVER_TS), "errors": errors})
     assert "per-recipient errors" in str(exc.value)
     assert db.get_draft(draft["id"])["send_state"] == _signal_db.STATE_SENDING
+
+
+def test_an_error_response_reports_the_ERROR_not_a_timestamp_complaint(db):
+    """Ordering: the reason must survive, not be masked by a parsing gripe.
+
+    A response carrying both an error and an unusable timestamp used to raise the
+    timestamp `ValueError`, hiding the per-recipient reason — the one piece of
+    information the operator needs to reconcile.
+    """
+    draft = _pending(db)
+    db.approve_draft(draft["id"], approval_ref="cg-error-order")
+    with pytest.raises(RuntimeError) as exc:
+        db.send_approved(draft["id"], transmit=lambda a, **kw: {
+            "timestamp": "", "errors": {"recipients": [{"message": "rate limited"}]}})
+    assert "rate limited" in str(exc.value)
+    assert "sync-echo dedupe" not in str(exc.value)
+
+
+def test_a_sender_without_a_number_is_refused_BEFORE_the_claim(db):
+    """🔴 A refusal must not strand the draft.
+
+    `account_number()` used to be an ARGUMENT to `transmit(...)`, which evaluates
+    AFTER the claim has committed — so a draft whose sender had no phone number
+    (`draft_message(self_uuid=…)`, a supported signature) ended `sending` with
+    nothing transmitted: stranded, and unsendable forever.
+    """
+    draft = db.draft_message(recipient=PEER, body="no sender number",
+                             self_uuid="90909090-9090-4909-8909-909090909090")
+    db.approve_draft(draft["id"], approval_ref="cg-no-number")
+    poster = Poster()
+
+    with pytest.raises(SendGateError) as exc:
+        db.send_approved(draft["id"],
+                         transmit=lambda a, **kw: consumer.transmit_approved(
+                             a, poster=poster, **kw))
+    assert "no sending phone number" in str(exc.value)
+    assert poster.calls == []
+    # Still APPROVED — a refusal is recoverable, a strand is not.
+    assert db.get_draft(draft["id"])["send_state"] == _signal_db.STATE_APPROVED
+    row = db.conn.rows("SELECT send_attempts FROM signal.messages WHERE id = ?",
+                       (draft["id"],))[0]
+    assert row["send_attempts"] == 0            # the claim never ran
+
+
+def test_two_senders_that_BOTH_minted_still_transmit_once(db):
+    """🔴 The claim is the lock, and it has to be atomic.
+
+    This is the real race, and the one `_ISSUED_NONCES` cannot cover: both
+    senders read `approved` and BOTH mint a valid capability before either
+    claims. (The nonce registry is per-process — two pods or two shells share
+    nothing.) The database row is the only thing both can contend on, so the
+    transition has to be a single conditional statement with the loser told.
+    """
+    draft = _pending(db, body="exactly once, please")
+    db.approve_draft(draft["id"], approval_ref="cg-race")
+
+    auth_a = _signal_db._mint_send_authorization(db.get_draft(draft["id"]))
+    auth_b = _signal_db._mint_send_authorization(db.get_draft(draft["id"]))
+    assert auth_a is not auth_b          # both are genuine, both would transmit
+
+    db._claim_for_sending(draft["id"])   # sender A wins the row
+    with pytest.raises(SendGateError) as exc:
+        db._claim_for_sending(draft["id"])   # sender B loses AT THE DATABASE
+    assert "could not be claimed" in str(exc.value)
+
+    poster = Poster()
+    consumer.transmit_approved(auth_a, recipient=PEER, body="exactly once, please",
+                               number=SELF_NUMBER, poster=poster)
+    assert len(poster.calls) == 1
+
+
+def test_a_re_entrant_send_of_the_same_draft_is_refused(db):
+    """End to end: whichever guard gets there first, only ONE send happens."""
+    draft = _pending(db, body="exactly once, end to end")
+    db.approve_draft(draft["id"], approval_ref="cg-reentrant")
+    sends = []
+    second = {}
+
+    def transmit(auth, *, recipient, body, number):
+        sends.append(body)
+        if "attempted" not in second:
+            second["attempted"] = True
+            try:
+                db.send_approved(draft["id"], transmit=transmit)
+            except SendGateError as exc:
+                second["refused"] = str(exc)
+        return {"timestamp": str(SERVER_TS)}
+
+    db.send_approved(draft["id"], transmit=transmit)
+    assert sends == ["exactly once, end to end"]
+    assert "D3 approval gate" in second["refused"]
+
+
+def test_the_claim_refuses_a_draft_that_is_no_longer_approved(db):
+    draft = _pending(db)
+    db.approve_draft(draft["id"], approval_ref="cg-claim")
+    db._claim_for_sending(draft["id"])
+    with pytest.raises(SendGateError) as exc:
+        db._claim_for_sending(draft["id"])
+    assert "could not be claimed" in str(exc.value)
+
+
+# --------------------------------------------------------------------------- #
+# Reconciling a stranded send — the operator's way out of `sending`
+# --------------------------------------------------------------------------- #
+def _stranded(db, body="stranded draft"):
+    draft = _pending(db, body=body)
+    db.approve_draft(draft["id"], approval_ref="cg-strand")
+
+    def die(auth, **kw):
+        raise ConnectionResetError("pod killed mid-send")
+
+    with pytest.raises(ConnectionResetError):
+        db.send_approved(draft["id"], transmit=die)
+    assert db.get_draft(draft["id"])["send_state"] == _signal_db.STATE_SENDING
+    return draft
+
+
+def test_reconcile_sent_records_the_server_timestamp(db):
+    """It DID go out — so the row must carry the timestamp the echo will bring."""
+    draft = _stranded(db)
+    row = db.reconcile_send(draft["id"], outcome=_signal_db.RECONCILE_SENT,
+                            server_timestamp="1723800000001")
+    assert row["send_state"] == _signal_db.STATE_SENT
+    assert row["message_timestamp"] == 1723800000001
+
+
+def test_reconcile_sent_refuses_an_unusable_timestamp(db):
+    """Guessing here would break sync-echo dedupe silently."""
+    draft = _stranded(db)
+    for bad in (None, "", "not-a-number", "0"):
+        with pytest.raises(ValueError):
+            db.reconcile_send(draft["id"], outcome=_signal_db.RECONCILE_SENT,
+                              server_timestamp=bad)
+    assert db.get_draft(draft["id"])["send_state"] == _signal_db.STATE_SENDING
+
+
+def test_reconcile_not_sent_returns_the_draft_to_pending_for_RE_APPROVAL(db):
+    """It did not go out — and a retry must not ride on the old approval."""
+    draft = _stranded(db)
+    row = db.reconcile_send(draft["id"], outcome=_signal_db.RECONCILE_NOT_SENT,
+                            note="nothing in the thread")
+    assert row["send_state"] == _signal_db.STATE_PENDING
+    # It cannot be sent until a human approves again ...
+    with pytest.raises(SendGateError):
+        db.send_approved(draft["id"], transmit=lambda a, **kw: {"timestamp": "1"})
+    # ... and once they do, it sends normally.
+    db.approve_draft(draft["id"], approval_ref="cg-second-look")
+    poster = Poster()
+    db.send_approved(draft["id"],
+                     transmit=lambda a, **kw: consumer.transmit_approved(
+                         a, poster=poster, **kw))
+    assert len(poster.calls) == 1
+
+
+def test_reconcile_refuses_a_draft_that_is_not_sending(db):
+    draft = _pending(db)
+    with pytest.raises(SendGateError) as exc:
+        db.reconcile_send(draft["id"], outcome=_signal_db.RECONCILE_NOT_SENT)
+    assert "are reconciled" in str(exc.value)
+
+
+def test_reconcile_needs_the_operator_token(db, monkeypatch):
+    draft = _stranded(db)
+    monkeypatch.delenv(_signal_db.APPROVAL_TOKEN_ENV, raising=False)
+    with pytest.raises(SendGateError) as exc:
+        db.reconcile_send(draft["id"], outcome=_signal_db.RECONCILE_NOT_SENT)
+    assert _signal_db.APPROVAL_TOKEN_ENV in str(exc.value)
+
+
+def test_reconcile_rejects_an_unknown_outcome(db):
+    draft = _stranded(db)
+    with pytest.raises(ValueError):
+        db.reconcile_send(draft["id"], outcome="probably-sent")
+
+
+def test_a_stranded_draft_is_reachable_from_the_drafts_listing(db):
+    """The operator has to be able to FIND it before reconciling it."""
+    draft = _stranded(db)
+    listed = db.list_drafts(state=_signal_db.STATE_SENDING)
+    assert [d["id"] for d in listed] == [draft["id"]]
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/signal/tests/test_approval_gate.py
+++ b/scripts/signal/tests/test_approval_gate.py
@@ -1,0 +1,339 @@
+"""🔴 D3 — an un-approved draft must have NO CODE ROUTE to the Signal API.
+
+The proposal is explicit that a documented convention ("call approve first") is
+not good enough, and that a green-but-bypassable gate is worse than no gate. So
+this suite does not check that the happy path works; it TRIES TO GET AROUND the
+gate, six ways, and requires each attempt to fail with the gate's OWN error type
+(`SendGateError`) — not "some exception", which a typo or a different guard would
+also produce.
+
+The routes attempted:
+  1. `send_approved()` on a pending draft;
+  2. `transmit_approved()` with no capability at all;
+  3. `transmit_approved()` with a hand-rolled look-alike object;
+  4. constructing a `SendAuthorization` directly;
+  5. re-using a spent capability (replay);
+  6. approving a draft that was already sent, to re-arm it.
+
+Plus a STRUCTURAL check that there is exactly one call site posting to the send
+endpoint in the whole of `scripts/signal/` — the property that makes the five
+behavioural checks above exhaustive rather than a sample.
+"""
+import re
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+import clawgate
+import consumer
+import _signal_db
+from _signal_db import SendGateError
+
+SIGNAL_DIR = Path(consumer.__file__).resolve().parent
+PEER = "+15550101"
+SELF_NUMBER = "+15559090"
+SERVER_TS = 1723500000001
+
+
+class Poster:
+    """Records every HTTP post it is asked to make. It must stay EMPTY on refusal."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, url, json=None, timeout=None):
+        self.calls.append({"url": url, "json": json, "timeout": timeout})
+        return types.SimpleNamespace(
+            raise_for_status=lambda: None,
+            json=lambda: {"timestamp": SERVER_TS},
+        )
+
+
+def _pending(db, body="an unapproved message"):
+    return db.draft_message(recipient=PEER, body=body, self_number=SELF_NUMBER)
+
+
+# --------------------------------------------------------------------------- #
+# Route 1 — the obvious one
+# --------------------------------------------------------------------------- #
+def test_send_approved_refuses_a_pending_draft(db):
+    draft = _pending(db)
+    poster = Poster()
+    with pytest.raises(SendGateError) as exc:
+        db.send_approved(draft["id"],
+                         transmit=lambda a, **kw: consumer.transmit_approved(
+                             a, poster=poster, **kw))
+    assert "send_state='pending'" in str(exc.value)
+    assert "D3 approval gate" in str(exc.value)
+    assert poster.calls == []                     # nothing reached the wire
+
+
+def test_send_approved_refuses_a_draft_that_does_not_exist(db):
+    with pytest.raises(SendGateError):
+        db.send_approved(4242)
+
+
+def test_send_approved_refuses_an_already_sent_draft(db):
+    draft = _pending(db)
+    db.approve_draft(draft["id"], approval_ref="cg-once")
+    db.send_approved(draft["id"], transmit=lambda a, **kw: {"timestamp": SERVER_TS})
+    with pytest.raises(SendGateError) as exc:
+        db.send_approved(draft["id"], transmit=lambda a, **kw: {"timestamp": 9})
+    assert "send_state='sent'" in str(exc.value)
+
+
+# --------------------------------------------------------------------------- #
+# Routes 2 + 3 — go around the DB layer entirely
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("forged", [
+    None,
+    "approved",
+    {"draft_id": 1, "recipient": PEER, "body": "x", "_nonce": "deadbeef"},
+    types.SimpleNamespace(draft_id=1, recipient=PEER, body="x", _nonce="deadbeef"),
+])
+def test_transmit_refuses_anything_that_is_not_a_real_capability(forged):
+    """🔴 The refusal must come from the TYPE guard, named explicitly.
+
+    A mutation sweep caught this test passing for the wrong reason: with the
+    `isinstance` check disabled, the single-use NONCE check refused these
+    forgeries instead — a different guard's error, so the mutant survived a green
+    suite. Asserting the type guard's own wording (and that it is NOT the
+    spent-nonce wording) is what makes the kill real.
+    """
+    poster = Poster()
+    with pytest.raises(SendGateError) as exc:
+        consumer.transmit_approved(forged, recipient=PEER, body="bypass attempt",
+                                   poster=poster)
+    message = str(exc.value)
+    assert "D3 approval gate" in message
+    assert "a SendAuthorization minted from an approved draft is required" in message
+    assert f"got {type(forged).__name__}" in message
+    assert "already been spent" not in message      # ... not the OTHER guard
+    assert poster.calls == []
+
+
+def test_transmit_refuses_a_subclass_forged_with_a_guessed_nonce():
+    """Even the right TYPE is not enough — the nonce must have been issued."""
+    auth = object.__new__(_signal_db.SendAuthorization)
+    object.__setattr__(auth, "draft_id", 1)
+    object.__setattr__(auth, "recipient", PEER)
+    object.__setattr__(auth, "body", "x")
+    object.__setattr__(auth, "_nonce", "0" * 32)
+    poster = Poster()
+    with pytest.raises(SendGateError) as exc:
+        consumer.transmit_approved(auth, recipient=PEER, body="x", poster=poster)
+    assert "already been spent" in str(exc.value)
+    assert poster.calls == []
+
+
+# --------------------------------------------------------------------------- #
+# Route 4 — mint one yourself
+# --------------------------------------------------------------------------- #
+def test_send_authorization_cannot_be_constructed_directly():
+    with pytest.raises(SendGateError) as exc:
+        _signal_db.SendAuthorization(draft_id=1, recipient=PEER, body="x")
+    assert "cannot be constructed directly" in str(exc.value)
+
+
+def test_minting_refuses_every_non_approved_state():
+    for state in (None, "pending", "sent", "", "APPROVED", "approved ",):
+        with pytest.raises(SendGateError):
+            _signal_db._mint_send_authorization({"id": 7, "send_state": state})
+
+
+def test_minting_positive_control_an_approved_draft_yields_a_capability():
+    """The refusals above are about the STATE, not a minter that never mints."""
+    auth = _signal_db._mint_send_authorization(
+        {"id": 8, "send_state": _signal_db.STATE_APPROVED, "recipient": PEER,
+         "body": "ok"})
+    assert isinstance(auth, _signal_db.SendAuthorization)
+    assert auth.draft_id == 8
+
+
+# --------------------------------------------------------------------------- #
+# Route 5 — replay
+# --------------------------------------------------------------------------- #
+def test_an_approved_draft_transmits_exactly_once(db):
+    draft = _pending(db, body="approved and sent once")
+    db.approve_draft(draft["id"], approval_ref="cg-exactly-once")
+    poster = Poster()
+
+    sent = db.send_approved(
+        draft["id"],
+        transmit=lambda a, **kw: consumer.transmit_approved(a, poster=poster, **kw))
+    assert len(poster.calls) == 1
+    assert sent["message_timestamp"] == SERVER_TS
+
+    # The state moved to `sent`, so a second send is refused ...
+    with pytest.raises(SendGateError):
+        db.send_approved(draft["id"],
+                         transmit=lambda a, **kw: consumer.transmit_approved(
+                             a, poster=poster, **kw))
+    assert len(poster.calls) == 1                 # ... and still one call
+
+
+def test_a_spent_capability_cannot_be_replayed():
+    auth = _signal_db._mint_send_authorization(
+        {"id": 9, "send_state": _signal_db.STATE_APPROVED, "recipient": PEER,
+         "body": "replay me"})
+    poster = Poster()
+    consumer.transmit_approved(auth, recipient=PEER, body="replay me", poster=poster)
+    assert len(poster.calls) == 1
+    with pytest.raises(SendGateError) as exc:
+        consumer.transmit_approved(auth, recipient=PEER, body="replay me",
+                                   poster=poster)
+    assert "single-use" in str(exc.value)
+    assert len(poster.calls) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Route 6 — re-arm an already-sent draft
+# --------------------------------------------------------------------------- #
+def test_approving_a_sent_draft_is_refused(db):
+    draft = _pending(db)
+    db.approve_draft(draft["id"], approval_ref="cg-rearm")
+    db.send_approved(draft["id"], transmit=lambda a, **kw: {"timestamp": SERVER_TS})
+    with pytest.raises(SendGateError) as exc:
+        db.approve_draft(draft["id"], approval_ref="cg-rearm-again")
+    assert "may be approved" in str(exc.value)
+
+
+def test_approving_a_missing_draft_is_refused(db):
+    with pytest.raises(SendGateError):
+        db.approve_draft(9999, approval_ref="cg-nope")
+
+
+# --------------------------------------------------------------------------- #
+# The structural claim that makes the above exhaustive
+# --------------------------------------------------------------------------- #
+def test_exactly_one_call_site_posts_to_the_send_endpoint():
+    """A ledger of send-endpoint call sites, derived by reading every module.
+
+    Fails when the set GROWS (a second, ungated send path) or SHRINKS (the gated
+    one moved or was deleted). Both directions matter: the whole gate rests on
+    there being ONE door.
+    """
+    modules = sorted(p for p in SIGNAL_DIR.glob("*.py"))
+    assert len(modules) >= 4, f"HARNESS BROKEN: only found {modules}"
+    senders = {}
+    for path in modules:
+        src = path.read_text(encoding="utf-8")
+        for match in re.finditer(r"SEND_PATH", src):
+            line = src[:match.start()].count("\n") + 1
+            senders.setdefault(path.name, []).append(line)
+    assert set(senders) == {"consumer.py"}, senders
+    # Two mentions in consumer.py: the constant's definition and its one use.
+    assert len(senders["consumer.py"]) == 2, senders
+
+
+def test_the_only_send_call_site_is_inside_transmit_approved():
+    src = Path(consumer.__file__).read_text(encoding="utf-8")
+    body = src.split("def transmit_approved(")[1].split("\ndef ")[0]
+    assert "SEND_PATH" in body
+    assert "spend_authorization(auth)" in body
+    # The gate runs BEFORE the URL is even built.
+    assert body.index("spend_authorization(auth)") < body.index("SEND_PATH")
+
+
+def test_clawgate_module_cannot_transmit():
+    """The notifier must be exactly that — it must not become a second door."""
+    src = Path(clawgate.__file__).read_text(encoding="utf-8")
+    assert "SEND_PATH" not in src
+    assert "/v2/send" not in src
+    assert clawgate.ENDPOINT.endswith("/api/tasks")
+
+
+# --------------------------------------------------------------------------- #
+# The draft is never lost, and the clawgate notification degrades gracefully
+# --------------------------------------------------------------------------- #
+def test_a_refused_send_leaves_the_draft_intact_and_pending(db):
+    draft = _pending(db, body="still here afterwards")
+    with pytest.raises(SendGateError):
+        db.send_approved(draft["id"], transmit=lambda a, **kw: {"timestamp": 1})
+    stored = db.get_draft(draft["id"])
+    assert stored["send_state"] == _signal_db.STATE_PENDING
+    assert stored["body"] == "still here afterwards"
+    assert db.list_drafts(state=_signal_db.STATE_PENDING)
+
+
+def test_a_draft_is_persisted_before_any_approval_exists(db):
+    draft = _pending(db, body="durable from the first moment")
+    assert db.conn.count("messages") == 1
+    row = db.conn.rows("SELECT is_outbound, send_state, body FROM signal.messages")[0]
+    assert row["is_outbound"]
+    assert row["send_state"] == _signal_db.STATE_PENDING
+    assert row["body"] == "durable from the first moment"
+    assert draft["message_timestamp"] < 0
+
+
+def test_draft_to_a_phone_number_transmits_to_that_number_not_a_placeholder(db):
+    """A draft addressed to a bare number must not be sent to a synthetic uuid."""
+    draft = _pending(db)
+    db.approve_draft(draft["id"], approval_ref="cg-recipient")
+    poster = Poster()
+    db.send_approved(draft["id"],
+                     transmit=lambda a, **kw: consumer.transmit_approved(
+                         a, poster=poster, **kw))
+    assert poster.calls[0]["json"]["recipients"] == [PEER]
+
+
+def test_emit_draft_task_is_a_graceful_noop_without_a_token(monkeypatch):
+    monkeypatch.delenv("CLAWGATE_HOOK_TOKEN", raising=False)
+    posted = []
+    module = types.ModuleType("requests")
+    module.post = lambda *a, **k: posted.append(a)
+    monkeypatch.setitem(sys.modules, "requests", module)
+    assert clawgate.emit_draft_task(draft_id=1, recipient=PEER, body="x") is False
+    assert posted == []
+
+
+def test_emit_draft_task_posts_the_card_when_a_token_is_set(monkeypatch):
+    monkeypatch.setenv("CLAWGATE_HOOK_TOKEN", "tok-signal-1")
+    calls = []
+
+    class Resp:
+        def raise_for_status(self):
+            calls.append("raised")
+
+    module = types.ModuleType("requests")
+
+    def post(url, headers=None, json=None, timeout=None):
+        calls.append({"url": url, "headers": headers, "json": json})
+        return Resp()
+
+    module.post = post
+    monkeypatch.setitem(sys.modules, "requests", module)
+
+    assert clawgate.emit_draft_task(draft_id=17, recipient=PEER,
+                                    body="please approve") is True
+    call = calls[0]
+    assert call["url"] == clawgate.ENDPOINT
+    assert call["headers"]["Authorization"] == "Bearer tok-signal-1"
+    assert "title" not in call["json"]              # clawgate ignores `title`
+    assert "17" in call["json"]["directory"]
+    assert "raised" in calls
+
+
+def test_clawgate_card_carries_the_recipient_and_the_approval_command():
+    payload = clawgate.build_draft_payload(draft_id=23, recipient=PEER,
+                                           body="the drafted text")
+    assert set(payload) == {"directory", "body"}
+    assert PEER in payload["body"]
+    assert "the drafted text" in payload["body"]
+    assert "approve 23" in payload["body"]
+    assert "send 23" in payload["body"]
+
+
+def test_clawgate_card_title_is_length_capped():
+    payload = clawgate.build_draft_payload(draft_id=1, recipient="+1" + "5" * 400,
+                                           body="x")
+    assert len(payload["directory"]) <= clawgate.TITLE_MAX
+
+
+def test_clawgate_card_truncates_a_huge_body():
+    payload = clawgate.build_draft_payload(draft_id=2, recipient=PEER,
+                                           body="z" * 5000)
+    assert len(payload["body"]) < 2000
+    assert payload["body"].count("z") == clawgate.BODY_PREVIEW_MAX

--- a/scripts/signal/tests/test_approval_gate.py
+++ b/scripts/signal/tests/test_approval_gate.py
@@ -19,7 +19,7 @@ Plus a STRUCTURAL check that there is exactly one call site posting to the send
 endpoint in the whole of `scripts/signal/` — the property that makes the five
 behavioural checks above exhaustive rather than a sample.
 """
-import re
+import ast
 import sys
 import types
 from pathlib import Path
@@ -45,9 +45,10 @@ class Poster:
 
     def __call__(self, url, json=None, timeout=None):
         self.calls.append({"url": url, "json": json, "timeout": timeout})
+        # STRING timestamp: upstream types it `Timestamp string`.
         return types.SimpleNamespace(
             raise_for_status=lambda: None,
-            json=lambda: {"timestamp": SERVER_TS},
+            json=lambda: {"timestamp": str(SERVER_TS)},
         )
 
 
@@ -78,9 +79,9 @@ def test_send_approved_refuses_a_draft_that_does_not_exist(db):
 def test_send_approved_refuses_an_already_sent_draft(db):
     draft = _pending(db)
     db.approve_draft(draft["id"], approval_ref="cg-once")
-    db.send_approved(draft["id"], transmit=lambda a, **kw: {"timestamp": SERVER_TS})
+    db.send_approved(draft["id"], transmit=lambda a, **kw: {"timestamp": str(SERVER_TS)})
     with pytest.raises(SendGateError) as exc:
-        db.send_approved(draft["id"], transmit=lambda a, **kw: {"timestamp": 9})
+        db.send_approved(draft["id"], transmit=lambda a, **kw: {"timestamp": "9"})
     assert "send_state='sent'" in str(exc.value)
 
 
@@ -105,7 +106,7 @@ def test_transmit_refuses_anything_that_is_not_a_real_capability(forged):
     poster = Poster()
     with pytest.raises(SendGateError) as exc:
         consumer.transmit_approved(forged, recipient=PEER, body="bypass attempt",
-                                   poster=poster)
+                                   number=SELF_NUMBER, poster=poster)
     message = str(exc.value)
     assert "D3 approval gate" in message
     assert "a SendAuthorization minted from an approved draft is required" in message
@@ -123,7 +124,8 @@ def test_transmit_refuses_a_subclass_forged_with_a_guessed_nonce():
     object.__setattr__(auth, "_nonce", "0" * 32)
     poster = Poster()
     with pytest.raises(SendGateError) as exc:
-        consumer.transmit_approved(auth, recipient=PEER, body="x", poster=poster)
+        consumer.transmit_approved(auth, recipient=PEER, body="x",
+                                   number=SELF_NUMBER, poster=poster)
     assert "already been spent" in str(exc.value)
     assert poster.calls == []
 
@@ -179,11 +181,12 @@ def test_a_spent_capability_cannot_be_replayed():
         {"id": 9, "send_state": _signal_db.STATE_APPROVED, "recipient": PEER,
          "body": "replay me"})
     poster = Poster()
-    consumer.transmit_approved(auth, recipient=PEER, body="replay me", poster=poster)
+    consumer.transmit_approved(auth, recipient=PEER, body="replay me",
+                               number=SELF_NUMBER, poster=poster)
     assert len(poster.calls) == 1
     with pytest.raises(SendGateError) as exc:
         consumer.transmit_approved(auth, recipient=PEER, body="replay me",
-                                   poster=poster)
+                                   number=SELF_NUMBER, poster=poster)
     assert "single-use" in str(exc.value)
     assert len(poster.calls) == 1
 
@@ -194,7 +197,7 @@ def test_a_spent_capability_cannot_be_replayed():
 def test_approving_a_sent_draft_is_refused(db):
     draft = _pending(db)
     db.approve_draft(draft["id"], approval_ref="cg-rearm")
-    db.send_approved(draft["id"], transmit=lambda a, **kw: {"timestamp": SERVER_TS})
+    db.send_approved(draft["id"], transmit=lambda a, **kw: {"timestamp": str(SERVER_TS)})
     with pytest.raises(SendGateError) as exc:
         db.approve_draft(draft["id"], approval_ref="cg-rearm-again")
     assert "may be approved" in str(exc.value)
@@ -208,24 +211,125 @@ def test_approving_a_missing_draft_is_refused(db):
 # --------------------------------------------------------------------------- #
 # The structural claim that makes the above exhaustive
 # --------------------------------------------------------------------------- #
-def test_exactly_one_call_site_posts_to_the_send_endpoint():
-    """A ledger of send-endpoint call sites, derived by reading every module.
+def _functions_that_can_reach_the_send_endpoint() -> dict:
+    """AST ledger: every function that can BUILD a send-endpoint URL.
 
-    Fails when the set GROWS (a second, ungated send path) or SHRINKS (the gated
-    one moved or was deleted). Both directions matter: the whole gate rests on
-    there being ONE door.
+    🔴 WHY AN AST WALK AND NOT A GREP. The first version of this ledger grepped
+    for the identifier `SEND_PATH`, so a second door spelled with the LITERAL —
+    `poster(API_URL + "/v2/send", …)`, no capability, no gate call — was invisible
+    to it and survived the whole suite. A guard that can be walked by rewording
+    is not a structural guard. This one recognises BOTH spellings, at every
+    function in every module, by looking at the parsed code rather than its text.
+
+    Returns `{module: {function: [reasons]}}`.
     """
-    modules = sorted(p for p in SIGNAL_DIR.glob("*.py"))
+    found: dict[str, dict[str, list[str]]] = {}
+    modules = sorted(SIGNAL_DIR.glob("*.py"))
     assert len(modules) >= 4, f"HARNESS BROKEN: only found {modules}"
-    senders = {}
     for path in modules:
-        src = path.read_text(encoding="utf-8")
-        for match in re.finditer(r"SEND_PATH", src):
-            line = src[:match.start()].count("\n") + 1
-            senders.setdefault(path.name, []).append(line)
-    assert set(senders) == {"consumer.py"}, senders
-    # Two mentions in consumer.py: the constant's definition and its one use.
-    assert len(senders["consumer.py"]) == 2, senders
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        parents = {}
+        for parent in ast.walk(tree):
+            for child in ast.iter_child_nodes(parent):
+                parents[child] = parent
+
+        def enclosing_function(node):
+            while node in parents:
+                node = parents[node]
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    return node.name
+            return "<module>"
+
+        def inside_a_raise(node) -> bool:
+            """Is this constant part of an exception MESSAGE rather than a URL?
+
+            You cannot POST from inside a `raise`, and several guards name the
+            endpoint in the error they raise about it. Excluding those keeps the
+            ledger about doors instead of about prose — without weakening it: the
+            positive control below shows a literal in a CALL is still caught.
+            """
+            while node in parents:
+                node = parents[node]
+                if isinstance(node, ast.Raise):
+                    return True
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    return False
+            return False
+
+        for node in ast.walk(tree):
+            reason = None
+            if isinstance(node, ast.Name) and node.id == "SEND_PATH":
+                reason = "SEND_PATH"
+            elif (isinstance(node, ast.Constant) and isinstance(node.value, str)
+                  and consumer.SEND_PATH in node.value):
+                # A bare string STATEMENT is a docstring, not a URL being built.
+                # Prose that mentions the endpoint (and this codebase's prose
+                # mentions it a lot, deliberately) is not a door.
+                if isinstance(parents.get(node), ast.Expr):
+                    continue
+                if inside_a_raise(node):
+                    continue
+                reason = f"literal {node.value!r}"
+            if reason is None:
+                continue
+            fn = enclosing_function(node)
+            if fn == "<module>":
+                continue                    # the constant's own definition
+            found.setdefault(path.name, {}).setdefault(fn, []).append(reason)
+    return found
+
+
+def test_exactly_one_function_can_reach_the_send_endpoint():
+    """The ledger. Fails when the set GROWS (a second door) or SHRINKS (it moved).
+
+    Both directions matter: the whole gate rests on there being ONE door.
+    """
+    ledger = _functions_that_can_reach_the_send_endpoint()
+    assert set(ledger) == {"consumer.py"}, ledger
+    assert set(ledger["consumer.py"]) == {"transmit_approved"}, ledger
+
+
+def test_the_ledger_would_see_a_second_door_spelled_with_the_literal():
+    """POSITIVE CONTROL on the ledger itself, against the mutant that escaped it.
+
+    A `quick_send()` that posts to `API_URL + "/v2/send"` without touching the
+    gate must be VISIBLE. Verified against a synthetic module here rather than by
+    mutating the real one, so the control ships with the guard.
+    """
+    source = (
+        "API_URL = 'http://x'\n"
+        "SEND_PATH = '/v2/send'\n"
+        "def quick_send(poster, body):\n"
+        "    return poster(API_URL + '/v2/send', json={'message': body})\n"
+    )
+    tree = ast.parse(source)
+    hits = [n for n in ast.walk(tree)
+            if isinstance(n, ast.Constant) and isinstance(n.value, str)
+            and consumer.SEND_PATH in n.value]
+    # Two: the constant's definition and the ungated call site inside quick_send.
+    assert len(hits) == 2
+    inside_function = [
+        n for fn in ast.walk(tree) if isinstance(fn, ast.FunctionDef)
+        for n in ast.walk(fn)
+        if isinstance(n, ast.Constant) and isinstance(n.value, str)
+        and consumer.SEND_PATH in n.value
+    ]
+    assert len(inside_function) == 1, "the literal spelling must be detectable"
+
+
+def test_every_function_in_the_ledger_spends_a_capability():
+    """The invariant behind the ledger: reaching the endpoint REQUIRES the gate."""
+    ledger = _functions_that_can_reach_the_send_endpoint()
+    src = Path(consumer.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    by_name = {n.name: n for n in ast.walk(tree)
+               if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}
+    for fn_name in ledger["consumer.py"]:
+        fn = by_name[fn_name]
+        calls = {c.func.id for c in ast.walk(fn)
+                 if isinstance(c, ast.Call) and isinstance(c.func, ast.Name)}
+        assert "spend_authorization" in calls, (
+            f"{fn_name} can reach the send endpoint without spending a capability")
 
 
 def test_the_only_send_call_site_is_inside_transmit_approved():
@@ -246,12 +350,176 @@ def test_clawgate_module_cannot_transmit():
 
 
 # --------------------------------------------------------------------------- #
+# 🔴 Crash-between-POST-and-write-back must not RESEND
+# --------------------------------------------------------------------------- #
+def test_a_failure_after_the_post_leaves_the_draft_inert(db):
+    """The resend hazard, reproduced.
+
+    Everything after the POST can fail — an odd response, a dropped connection, a
+    pod kill. If the row were still `approved` at that moment, the gate would
+    mint a fresh capability and send the SAME TEXT again. It is `sending`
+    instead, which nothing can mint from.
+    """
+    draft = _pending(db, body="must not be sent twice")
+    db.approve_draft(draft["id"], approval_ref="cg-crash")
+    poster = Poster()
+
+    def transmit_then_die(auth, *, recipient, body, number):
+        poster(f"http://x{consumer.SEND_PATH}", json={"message": body})
+        raise ConnectionResetError("pod killed between the POST and the write-back")
+
+    with pytest.raises(ConnectionResetError):
+        db.send_approved(draft["id"], transmit=transmit_then_die)
+    assert len(poster.calls) == 1
+
+    stored = db.get_draft(draft["id"])
+    assert stored["send_state"] == _signal_db.STATE_SENDING
+    with pytest.raises(SendGateError) as exc:
+        db.send_approved(draft["id"], transmit=transmit_then_die)
+    assert "send_state='sending'" in str(exc.value)
+    assert len(poster.calls) == 1                 # NOT sent a second time
+
+
+def test_the_sending_claim_is_committed_before_anything_is_transmitted(db):
+    """Ordering is the mechanism, so it is observed directly, not inferred.
+
+    🔴 The COMMIT is asserted, not just the in-memory state. A mutation sweep
+    found that dropping the commit survived: on one connection the uncommitted
+    write is still visible, so "state == sending" alone passes while the claim
+    would not have survived the pod kill it exists for. The commit COUNT is the
+    observable that distinguishes them.
+    """
+    draft = _pending(db)
+    db.approve_draft(draft["id"], approval_ref="cg-order")
+    commits_before = db.conn.commits
+    seen = {}
+
+    def transmit(auth, *, recipient, body, number):
+        seen["state_at_post"] = db.get_draft(draft["id"])["send_state"]
+        seen["commits_at_post"] = db.conn.commits
+        return {"timestamp": str(SERVER_TS)}
+
+    db.send_approved(draft["id"], transmit=transmit)
+    assert seen["state_at_post"] == _signal_db.STATE_SENDING
+    assert seen["commits_at_post"] > commits_before, (
+        "the `sending` claim was written but never committed — it would not "
+        "survive the crash it exists to protect against")
+
+
+def test_send_attempts_records_that_a_send_was_tried(db):
+    draft = _pending(db)
+    db.approve_draft(draft["id"], approval_ref="cg-attempts")
+
+    def boom(auth, **kw):
+        raise TimeoutError("no answer")
+
+    with pytest.raises(TimeoutError):
+        db.send_approved(draft["id"], transmit=boom)
+    row = db.conn.rows("SELECT send_attempts FROM signal.messages WHERE id = ?",
+                       (draft["id"],))[0]
+    assert row["send_attempts"] == 1
+
+
+def test_per_recipient_errors_in_the_response_are_not_treated_as_success(db):
+    """A 201 can still carry `errors` — upstream's response has that field."""
+    draft = _pending(db)
+    db.approve_draft(draft["id"], approval_ref="cg-errors")
+    with pytest.raises(RuntimeError) as exc:
+        db.send_approved(draft["id"], transmit=lambda a, **kw: {
+            "timestamp": str(SERVER_TS),
+            "errors": [{"recipient": PEER, "message": "unregistered user"}]})
+    assert "per-recipient errors" in str(exc.value)
+    assert db.get_draft(draft["id"])["send_state"] == _signal_db.STATE_SENDING
+
+
+# --------------------------------------------------------------------------- #
+# The server's actual request contract
+# --------------------------------------------------------------------------- #
+def test_the_send_body_carries_number_recipients_and_message(db):
+    """🔴 `number` is REQUIRED — upstream 400s with 'please provide a valid number'.
+
+    An earlier revision omitted it, so every send failed and the whole D3 path
+    was inert. The fake asserted only `recipients`, which is exactly why the
+    suite could not see it.
+    """
+    draft = _pending(db, body="the body that goes on the wire")
+    db.approve_draft(draft["id"], approval_ref="cg-body")
+    poster = Poster()
+    db.send_approved(draft["id"],
+                     transmit=lambda a, **kw: consumer.transmit_approved(
+                         a, poster=poster, **kw))
+    body = poster.calls[0]["json"]
+    assert body == {"message": "the body that goes on the wire",
+                    "number": SELF_NUMBER, "recipients": [PEER]}
+    assert poster.calls[0]["url"].endswith("/v2/send")
+
+
+def test_transmit_refuses_an_empty_number_rather_than_earning_a_400():
+    auth = _signal_db._mint_send_authorization(
+        {"id": 11, "send_state": _signal_db.STATE_APPROVED, "recipient": PEER,
+         "body": "x"})
+    poster = Poster()
+    with pytest.raises(SendGateError) as exc:
+        consumer.transmit_approved(auth, recipient=PEER, body="x", number="",
+                                   poster=poster)
+    assert "valid number" in str(exc.value)
+    assert poster.calls == []
+
+
+def test_the_server_timestamp_is_read_from_a_STRING(db):
+    """Upstream types it `Timestamp string`; an int-only reader would break live."""
+    draft = _pending(db)
+    db.approve_draft(draft["id"], approval_ref="cg-string-ts")
+    sent = db.send_approved(
+        draft["id"], transmit=lambda a, **kw: {"timestamp": " 1723500000123 "})
+    assert sent["message_timestamp"] == 1723500000123
+
+
+@pytest.mark.parametrize("bad", [{}, {"timestamp": None}, {"timestamp": "abc"},
+                                 {"timestamp": "0"}, {"timestamp": "-5"}])
+def test_an_unusable_timestamp_is_refused_and_the_draft_stays_sending(db, bad):
+    draft = _pending(db)
+    db.approve_draft(draft["id"], approval_ref="cg-bad-ts")
+    with pytest.raises(ValueError):
+        db.send_approved(draft["id"], transmit=lambda a, **kw: bad)
+    assert db.get_draft(draft["id"])["send_state"] == _signal_db.STATE_SENDING
+
+
+# --------------------------------------------------------------------------- #
+# Approval is the OPERATOR's step
+# --------------------------------------------------------------------------- #
+def test_approval_is_refused_without_the_operator_token(db, monkeypatch):
+    """The drafting agent's environment does not carry it — by design."""
+    draft = _pending(db)
+    monkeypatch.delenv(_signal_db.APPROVAL_TOKEN_ENV, raising=False)
+    with pytest.raises(SendGateError) as exc:
+        db.approve_draft(draft["id"], approval_ref="agent-self-approval")
+    assert _signal_db.APPROVAL_TOKEN_ENV in str(exc.value)
+    assert db.get_draft(draft["id"])["send_state"] == _signal_db.STATE_PENDING
+
+
+def test_approval_positive_control_with_the_token_present(db, monkeypatch):
+    """The refusal above is about the TOKEN, not an approver that never approves."""
+    draft = _pending(db)
+    monkeypatch.setenv(_signal_db.APPROVAL_TOKEN_ENV, "operator-shell-token")
+    approved = db.approve_draft(draft["id"], approval_ref="cg-real")
+    assert approved["send_state"] == _signal_db.STATE_APPROVED
+
+
+def test_an_empty_approval_ref_records_nothing_and_is_refused(db):
+    draft = _pending(db)
+    with pytest.raises(SendGateError) as exc:
+        db.approve_draft(draft["id"], approval_ref="   ")
+    assert "auditable" in str(exc.value)
+
+
+# --------------------------------------------------------------------------- #
 # The draft is never lost, and the clawgate notification degrades gracefully
 # --------------------------------------------------------------------------- #
 def test_a_refused_send_leaves_the_draft_intact_and_pending(db):
     draft = _pending(db, body="still here afterwards")
     with pytest.raises(SendGateError):
-        db.send_approved(draft["id"], transmit=lambda a, **kw: {"timestamp": 1})
+        db.send_approved(draft["id"], transmit=lambda a, **kw: {"timestamp": "1"})
     stored = db.get_draft(draft["id"])
     assert stored["send_state"] == _signal_db.STATE_PENDING
     assert stored["body"] == "still here afterwards"
@@ -316,14 +584,24 @@ def test_emit_draft_task_posts_the_card_when_a_token_is_set(monkeypatch):
     assert "raised" in calls
 
 
-def test_clawgate_card_carries_the_recipient_and_the_approval_command():
+def test_clawgate_card_identifies_the_draft_without_handing_over_the_command():
+    """🔴 The card must not contain a RUNNABLE approval command.
+
+    It is posted BY the drafting agent, so any command it prints is a command
+    that agent can read back and run against its own draft. Naming the draft is
+    fine — and necessary; printing `consumer.py approve <id> --ref …` is the
+    self-approval path D3 exists to prevent. Asserted on the runnable pieces, not
+    on the word "approve", which the card legitimately uses in prose.
+    """
     payload = clawgate.build_draft_payload(draft_id=23, recipient=PEER,
                                            body="the drafted text")
     assert set(payload) == {"directory", "body"}
     assert PEER in payload["body"]
     assert "the drafted text" in payload["body"]
-    assert "approve 23" in payload["body"]
-    assert "send 23" in payload["body"]
+    assert "#23" in payload["body"]
+    body = payload["body"]
+    for runnable in ("consumer.py", "--ref", "approve 23", "send 23"):
+        assert runnable not in body, f"the card hands over {runnable!r}"
 
 
 def test_clawgate_card_title_is_length_capped():

--- a/scripts/signal/tests/test_approval_gate.py
+++ b/scripts/signal/tests/test_approval_gate.py
@@ -697,6 +697,151 @@ def test_reconcile_needs_the_operator_token(db, monkeypatch):
     assert _signal_db.APPROVAL_TOKEN_ENV in str(exc.value)
 
 
+def test_an_in_flight_sender_cannot_stamp_over_an_OPERATORS_reconcile(db):
+    """🔴 F1 — the terminal update needs the same predicate as the claim.
+
+    The operator reconciles a draft they believe was lost; the original sender
+    then completes. With an unconditional `WHERE id = %s` the sender silently
+    overwrote the operator's decision with its own timestamp and nobody read the
+    rowcount. Now the sender is TOLD it lost.
+    """
+    draft = _pending(db, body="whose timestamp wins")
+    db.approve_draft(draft["id"], approval_ref="cg-inflight")
+    operator_ts = 1723900000111
+    api_ts = 1723900000999
+
+    def transmit(auth, *, recipient, body, number):
+        # While this send is in flight, the operator reconciles it as sent.
+        db.reconcile_send(draft["id"], outcome=_signal_db.RECONCILE_SENT,
+                          server_timestamp=str(operator_ts))
+        return {"timestamp": str(api_ts)}
+
+    with pytest.raises(SendGateError) as exc:
+        db.send_approved(draft["id"], transmit=transmit)
+    assert "complete the send" in str(exc.value)
+
+    row = db.get_draft(draft["id"])
+    assert row["send_state"] == _signal_db.STATE_SENT
+    assert row["message_timestamp"] == operator_ts       # the operator's, not the API's
+
+
+def test_a_not_sent_reconcile_mid_flight_cannot_become_a_SECOND_transmit(db):
+    """🔴 F1 — the resend this round's own escape hatch would otherwise open.
+
+    `_claim_for_sending` promises "never a duplicate message". This round added
+    the supported path OUT of `sending`; without a predicate on the terminal
+    update, a `--not-sent` reconcile landing mid-flight could be re-approved and
+    the same body transmitted twice.
+    """
+    draft = _pending(db, body="exactly one on the wire")
+    db.approve_draft(draft["id"], approval_ref="cg-midflight")
+    poster = Poster()
+
+    def transmit(auth, *, recipient, body, number):
+        poster(f"http://x{consumer.SEND_PATH}", json={"message": body})
+        db.reconcile_send(draft["id"], outcome=_signal_db.RECONCILE_NOT_SENT,
+                          note="looked empty at the time")
+        return {"timestamp": str(SERVER_TS)}
+
+    with pytest.raises(SendGateError):
+        db.send_approved(draft["id"], transmit=transmit)
+
+    # Re-approved and sent again — the SECOND transmit is the hazard, so count it.
+    db.approve_draft(draft["id"], approval_ref="cg-midflight-2")
+    db.send_approved(draft["id"],
+                     transmit=lambda a, **kw: consumer.transmit_approved(
+                         a, poster=poster, **kw))
+    assert len(poster.calls) == 2, (
+        "one deliberate re-send after an explicit human decision is expected; "
+        "what must never happen is the FIRST attempt landing twice")
+    assert db.get_draft(draft["id"])["send_state"] == _signal_db.STATE_SENT
+
+
+def test_reconcile_refuses_when_the_row_moved_under_it(db):
+    """A second reconcile is refused — by the PYTHON precondition, note.
+
+    Labelled honestly: this exercises the read-then-check, not the SQL predicate.
+    A mutation sweep proved the difference — stripping `AND send_state = …` from
+    both reconcile writes left this test green, because the Python check
+    short-circuits first. The test below is the one that reaches the predicate.
+    """
+    draft = _stranded(db)
+    db.reconcile_send(draft["id"], outcome=_signal_db.RECONCILE_NOT_SENT)
+    with pytest.raises(SendGateError):
+        db.reconcile_send(draft["id"], outcome=_signal_db.RECONCILE_NOT_SENT)
+
+
+@pytest.mark.parametrize("outcome", [_signal_db.RECONCILE_SENT,
+                                     _signal_db.RECONCILE_NOT_SENT])
+def test_reconcile_refuses_when_the_row_MOVES_between_the_read_and_the_write(
+        db, monkeypatch, outcome):
+    """🔴 The TOCTOU window the SQL predicate exists for, made reachable.
+
+    `reconcile_send` reads the row, checks it in Python, then writes. Everything
+    interesting happens in the gap: another actor moving the row there is exactly
+    what the predicate catches and what the Python check cannot. Simulated by
+    making the READ report `sending` while the real row has already moved on —
+    with the predicate the write matches nothing and the caller is told; without
+    it the write lands and the loser silently overwrites the winner.
+    """
+    draft = _pending(db)                       # the REAL row is `pending`
+    stale = dict(draft, send_state=_signal_db.STATE_SENDING)
+    monkeypatch.setattr(type(db), "_draft_or_raise", lambda self, i: stale)
+
+    with pytest.raises(SendGateError) as exc:
+        db.reconcile_send(draft["id"], outcome=outcome,
+                          server_timestamp="1723900000333")
+    assert "no longer 'sending'" in str(exc.value)
+    # The row is untouched: the loser wrote nothing at all.
+    assert db.get_draft(draft["id"])["send_state"] == _signal_db.STATE_PENDING
+
+
+def test_reconcile_without_a_note_PRESERVES_the_approval_record(db):
+    """🔴 F2 — the audit record D3 stakes its claim on.
+
+    `--not-sent` used a bare `approval_ref = %s` while `--sent` nine lines up
+    used `COALESCE`, so reconciling without `--note` NULLed the reference to the
+    approval the attempt actually rode on — and the test only ever exercised the
+    with-`--note` case. `approve_draft`'s docstring stakes D3 on "a recorded
+    approval decision that a human can audit after the fact".
+    """
+    draft = _pending(db)
+    db.approve_draft(draft["id"], approval_ref="clawgate-task-4242")
+
+    def die(auth, **kw):
+        raise ConnectionResetError("dropped")
+
+    with pytest.raises(ConnectionResetError):
+        db.send_approved(draft["id"], transmit=die)
+
+    row = db.reconcile_send(draft["id"], outcome=_signal_db.RECONCILE_NOT_SENT)
+    assert row["approval_ref"] == "clawgate-task-4242"
+
+
+def test_reconcile_sent_without_a_note_also_preserves_it(db):
+    """Both branches, so the two cannot drift apart again."""
+    draft = _pending(db)
+    db.approve_draft(draft["id"], approval_ref="clawgate-task-5150")
+
+    def die(auth, **kw):
+        raise ConnectionResetError("dropped")
+
+    with pytest.raises(ConnectionResetError):
+        db.send_approved(draft["id"], transmit=die)
+
+    row = db.reconcile_send(draft["id"], outcome=_signal_db.RECONCILE_SENT,
+                            server_timestamp="1723900000222")
+    assert row["approval_ref"] == "clawgate-task-5150"
+
+
+def test_a_note_ADDS_to_the_record_rather_than_replacing_it(db):
+    """POSITIVE CONTROL: the preservation above is not "the note is ignored"."""
+    draft = _stranded(db)
+    row = db.reconcile_send(draft["id"], outcome=_signal_db.RECONCILE_NOT_SENT,
+                            note="checked the thread, nothing there")
+    assert row["approval_ref"] == "checked the thread, nothing there"
+
+
 def test_reconcile_rejects_an_unknown_outcome(db):
     draft = _stranded(db)
     with pytest.raises(ValueError):

--- a/scripts/signal/tests/test_consumer_resilience.py
+++ b/scripts/signal/tests/test_consumer_resilience.py
@@ -150,6 +150,69 @@ def test_transient_postgres_failure_is_retried_and_the_event_survives(db):
     assert db.conn.count("messages") == 1
 
 
+class FailOnCommit:
+    """A transient fault landing on the COMMIT rather than on the write."""
+
+    def __init__(self, inner, failures):
+        self._inner = inner
+        self.remaining = failures
+        self.commits_attempted = 0
+
+    def commit(self):
+        self.commits_attempted += 1
+        if self.remaining > 0:
+            self.remaining -= 1
+            raise psycopg2.OperationalError("server closed the connection")
+        return self._inner.commit()
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+def test_a_transient_fault_ON_THE_COMMIT_does_not_drop_the_message(db):
+    """🔴 The retry must not turn a loud failure into a silent one.
+
+    The write and its commit used to be retried SEPARATELY. When the fault landed
+    on the commit, recovery rolled back — discarding the row already written —
+    and the retried bare `commit()` then committed an empty transaction and
+    reported success. MEASURED before the fix: `rows=[]`, `stored=1`. The message
+    was gone, the counter said otherwise, and the module docstring promised "the
+    event is not dropped".
+    """
+    flaky = FailOnCommit(db, failures=1)
+    c = _consumer(flaky, Streams([_payload(1723700000001, "must survive")]))
+    c.run(max_connections=1)
+
+    rows = db.conn.rows("SELECT body FROM signal.messages")
+    assert [r["body"] for r in rows] == ["must survive"]
+    assert c.stats[consumer.STAT_STORED] == 1
+    assert c.stats[consumer.STAT_DB_RETRIES] == 1
+    assert flaky.commits_attempted == 2       # failed once, then succeeded
+
+
+def test_positive_control_the_commit_path_can_still_fail_for_real(db):
+    """The rescue above is a retry, not a swallow: an endless fault still raises."""
+    flaky = FailOnCommit(db, failures=99)
+    c = _consumer(flaky, Streams([]), db_retries=2)
+    with pytest.raises(psycopg2.OperationalError):
+        c.handle_payload(_payload(1723700000011))
+    assert db.conn.count("messages") == 0
+
+
+def test_a_reaction_write_is_also_one_unit_with_its_commit(db):
+    """The same hazard on the OTHER write paths, not just messages."""
+    flaky = FailOnCommit(db, failures=1)
+    reaction = json.dumps({"account": "+15559090", "envelope": {
+        "sourceUuid": "33333333-3333-4333-8333-333333333333",
+        "timestamp": 1723700000021,
+        "dataMessage": {"timestamp": 1723700000021, "reaction": {
+            "emoji": "🔥", "targetAuthorUuid": ALICE,
+            "targetSentTimestamp": 1723700000020, "isRemove": False}}}})
+    c = _consumer(flaky, Streams([reaction]))
+    c.run(max_connections=1)
+    assert db.conn.count("reactions") == 1
+
+
 def test_a_persistent_postgres_failure_is_not_swallowed(db):
     """Retry must have a floor: an endless outage has to surface, not vanish."""
     flaky = FlakyDB(db, failures=99)

--- a/scripts/signal/tests/test_consumer_resilience.py
+++ b/scripts/signal/tests/test_consumer_resilience.py
@@ -13,6 +13,7 @@ import psycopg2
 import pytest
 
 import consumer
+import fakepg
 
 ALICE = "11111111-1111-4111-8111-111111111111"
 
@@ -24,7 +25,7 @@ def _payload(ts, body="stream fixture", *, uuid=ALICE, attachments=()):
         "dataMessage": {"timestamp": ts, "message": body,
                         "attachments": list(attachments)},
     }
-    return "data: " + json.dumps({"method": "receive", "params": {"envelope": env}})
+    return json.dumps({"account": "+15559090", "envelope": env})
 
 
 class Streams:
@@ -96,7 +97,7 @@ def test_a_clean_stream_end_is_not_counted_as_a_reconnect(db):
 # --------------------------------------------------------------------------- #
 def test_malformed_event_is_skipped_and_the_stream_continues(db):
     streams = Streams([
-        "data: {this is not json",
+        "{this is not json",
         _payload(1723400000031, "after the bad one"),
     ])
     c = _consumer(db, streams)
@@ -107,10 +108,10 @@ def test_malformed_event_is_skipped_and_the_stream_continues(db):
 
 
 def test_unknown_kinds_are_counted_as_ignored_not_stored(db):
-    typing = json.dumps({"method": "receive", "params": {"envelope": {
+    typing = json.dumps({"account": "+15559090", "envelope": {
         "sourceUuid": ALICE, "timestamp": 1723400000041,
-        "typingMessage": {"action": "STARTED"}}}})
-    c = _consumer(db, Streams(["data: " + typing]))
+        "typingMessage": {"action": "STARTED"}}})
+    c = _consumer(db, Streams([typing]))
     c.run(max_connections=1)
     assert c.stats[consumer.STAT_IGNORED] == 1
     assert c.stats[consumer.STAT_STORED] == 0
@@ -154,7 +155,7 @@ def test_a_persistent_postgres_failure_is_not_swallowed(db):
     flaky = FlakyDB(db, failures=99)
     c = _consumer(flaky, Streams([_payload(1723400000061)]), db_retries=2)
     with pytest.raises(psycopg2.OperationalError):
-        c.handle_payload(_payload(1723400000061)[len("data: "):])
+        c.handle_payload(_payload(1723400000061))
     assert c.stats[consumer.STAT_DB_RETRIES] == 2
 
 
@@ -168,7 +169,7 @@ def test_a_programming_error_is_not_retried(db):
     broken = Broken(db, failures=0)
     c = _consumer(broken, Streams([]), db_retries=5)
     with pytest.raises(psycopg2.ProgrammingError):
-        c.handle_payload(_payload(1723400000071)[len("data: "):])
+        c.handle_payload(_payload(1723400000071))
     assert broken.upserts == 1
     assert c.stats[consumer.STAT_DB_RETRIES] == 0
 
@@ -184,7 +185,10 @@ class FakeMinio:
 
     def put_attachment(self, **kw):
         self.calls.append(kw)
-        return f"{kw['conversation']}/2026-01-01/{kw['filename']}"
+        # Mirrors the real key layout, INCLUDING the attachment id — a fake that
+        # dropped it would hide the collision the real one exists to prevent.
+        return (f"{kw['conversation']}/2026-01-01/"
+                f"{kw['attachment_id']}_{kw['filename']}")
 
 
 def _attachment_payload(ts, att_id="att-resilience"):
@@ -299,7 +303,7 @@ def test_zero_retries_propagates_the_real_database_error(db):
     flaky = FlakyDB(db, failures=1)
     c = _consumer(flaky, Streams([]), db_retries=0)
     with pytest.raises(psycopg2.OperationalError):
-        c.handle_payload(_payload(1723400000151)[len("data: "):])
+        c.handle_payload(_payload(1723400000151))
     assert flaky.upserts == 1
 
 
@@ -317,11 +321,191 @@ def test_run_without_a_stream_factory_fails_loudly_instead_of_spinning(db):
     assert c.stats[consumer.STAT_RECONNECTS] == 0      # not swallowed into a retry
 
 
+# --------------------------------------------------------------------------- #
+# 🔴 The aborted-transaction zombie. `autocommit=False` + one failed statement =
+# every later statement raises InFailedSqlTransaction until someone rolls back.
+# --------------------------------------------------------------------------- #
+def test_substrate_reproduces_postgres_transaction_abort(db):
+    """INSTRUMENT VALIDATION — without this the recovery tests are theatre.
+
+    sqlite alone happily continues after a failed statement. The substrate
+    emulates the Postgres rule, so the tests below can actually reach the bug.
+    """
+    import sqlite3
+
+    with pytest.raises(sqlite3.IntegrityError):
+        db.conn.cursor().execute(
+            "INSERT INTO signal.messages (message_timestamp, source_contact_id, "
+            "message_type) VALUES (1723500000001, NULL, 'message')")
+    # Every LATER statement now fails, on a connection that is otherwise fine.
+    with pytest.raises(psycopg2.errors.InFailedSqlTransaction):
+        db.conn.cursor().execute("SELECT 1 FROM signal.messages")
+    db.rollback()                                     # ... and recovery clears it
+    db.conn.cursor().execute("SELECT 1 FROM signal.messages")
+
+
+def test_in_failed_sql_transaction_is_classified_transient():
+    """It must be RETRIED, not escape into the reconnect handler.
+
+    Left out of `TRANSIENT_DB_ERRORS`, the event after any failure escapes into
+    `run()`'s broad `except`, is miscounted as a dropped stream, and the pod logs
+    "reconnecting" forever while storing nothing.
+    """
+    assert issubclass(psycopg2.errors.InFailedSqlTransaction, Exception)
+    assert any(issubclass(psycopg2.errors.InFailedSqlTransaction, cls)
+               for cls in consumer.TRANSIENT_DB_ERRORS)
+
+
+def test_a_failed_write_does_not_poison_the_next_event(db):
+    """END TO END: a bad frame, then a good one, on ONE connection.
+
+    This is the zombie-pod scenario. Before `recover()` existed, the good frame
+    raised `InFailedSqlTransaction`, escaped into the reconnect handler and was
+    counted as a dropped stream — for the life of the process.
+    """
+    import sqlite3
+
+    # A statement fails on this connection — exactly as a real write can.
+    with pytest.raises(sqlite3.IntegrityError):
+        db.conn.cursor().execute(
+            "INSERT INTO signal.messages (message_timestamp, source_contact_id, "
+            "message_type) VALUES (1723500000011, NULL, 'message')")
+
+    good = _payload(1723500000012, "stored after the failure")
+    c = _consumer(db, Streams([good]))
+    c.run(max_connections=1)
+
+    assert db.conn.count("messages") == 1
+    rows = db.conn.rows("SELECT body FROM signal.messages")
+    assert rows[0]["body"] == "stored after the failure"
+    assert c.stats[consumer.STAT_DB_RECOVERIES] >= 1
+    assert c.stats[consumer.STAT_RECONNECTS] == 0      # NOT miscounted as a drop
+
+
+def test_recover_rolls_back_rather_than_reconnecting_when_it_can(db):
+    db.conn.aborted = True
+    assert db.recover() == "rolled-back"
+    assert db.conn.rollbacks == 1
+    assert db.conn.aborted is False
+
+
+def test_recover_reconnects_when_the_socket_is_gone(monkeypatch):
+    """A rollback cannot fix a closed connection — recovery must re-open it."""
+    import _signal_db
+
+    fresh = fakepg.SqliteConn()
+    opened = []
+
+    class Dead:
+        closed = 1
+        rollbacks = 0
+
+        def rollback(self):  # pragma: no cover - must not be reached
+            raise AssertionError("rollback on a closed connection")
+
+    target = _signal_db.SignalDB(dsn="postgres://u:p@h/mailbox")
+    target.conn = Dead()
+
+    def fake_connect():
+        opened.append(True)
+        target.conn = fresh
+
+    monkeypatch.setattr(target, "_connect", fake_connect)
+    assert target.recover() == "reconnected"
+    assert opened == [True]
+    assert target.conn is fresh
+
+
+def test_recover_failure_is_counted_and_does_not_mask_the_cause(db):
+    """If recovery itself fails, the ORIGINAL error still surfaces."""
+    class Unrecoverable:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def recover(self):
+            raise RuntimeError("kubectl port-forward is gone")
+
+        def upsert_message(self, msg):
+            raise psycopg2.OperationalError("server closed the connection")
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+    c = _consumer(Unrecoverable(db), Streams([]), db_retries=2)
+    with pytest.raises(psycopg2.OperationalError):
+        c.handle_payload(_payload(1723500000021))
+    assert c.stats[consumer.STAT_DB_RECOVERY_FAILURES] == 2
+    assert c.stats[consumer.STAT_DB_RECOVERIES] == 0
+
+
+def test_a_non_transient_error_still_recovers_the_connection(db):
+    """A programming error is NOT retried — but the transaction must still clear."""
+    class Broken:
+        def __init__(self, inner):
+            self._inner = inner
+            self.recoveries = 0
+
+        def recover(self):
+            self.recoveries += 1
+            return "rolled-back"
+
+        def upsert_message(self, msg):
+            raise psycopg2.ProgrammingError("column does not exist")
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+    broken = Broken(db)
+    c = _consumer(broken, Streams([]), db_retries=3)
+    with pytest.raises(psycopg2.ProgrammingError):
+        c.handle_payload(_payload(1723500000031))
+    assert broken.recoveries == 1
+    assert c.stats[consumer.STAT_DB_RETRIES] == 0     # not retried ...
+    assert c.stats[consumer.STAT_DB_RECOVERIES] == 1  # ... but recovered
+
+
+def test_a_remote_delete_frame_tombstones_its_target_END_TO_END(db):
+    """🔴 Through the CONSUMER, not by calling the DB method directly.
+
+    A mutation sweep disabled the `remote_delete` branch in `store()` and nothing
+    failed: every retraction test called `apply_remote_delete()` itself, so the
+    dispatch — the part that decides whether a retraction is honoured at all —
+    was never exercised. Disabled, the frame falls through and is stored as an
+    ordinary empty message beside the text it was meant to retract.
+    """
+    target_ts = 1723600000001
+    original = _payload(target_ts, "please forget this")
+    retraction = json.dumps({"account": "+15559090", "envelope": {
+        "source": "+15550101", "sourceNumber": "+15550101", "sourceUuid": ALICE,
+        "timestamp": target_ts + 10,
+        "dataMessage": {"timestamp": target_ts + 10,
+                        "remoteDelete": {"targetSentTimestamp": target_ts}},
+    }})
+
+    c = _consumer(db, Streams([original, retraction]))
+    c.run(max_connections=1)
+
+    rows = db.conn.rows("SELECT body, message_type FROM signal.messages")
+    assert len(rows) == 1, "the retraction was stored as a message of its own"
+    assert rows[0]["body"] is None
+    assert rows[0]["message_type"] == "deleted"
+    assert c.stats[consumer.STAT_STORED] == 2      # the message and the retraction
+
+
+def test_positive_control_without_the_retraction_the_text_stays(db):
+    """The `None` above only means something because this leaves the body intact."""
+    c = _consumer(db, Streams([_payload(1723600000002, "kept on purpose")]))
+    c.run(max_connections=1)
+    assert db.conn.rows("SELECT body FROM signal.messages")[0]["body"] == \
+        "kept on purpose"
+
+
 def test_run_returns_its_counters(db):
     c = _consumer(db, Streams([_payload(1723400000131)]))
     stats = c.run(max_connections=1)
     assert set(stats) == {
         consumer.STAT_STORED, consumer.STAT_IGNORED, consumer.STAT_MALFORMED,
         consumer.STAT_RECONNECTS, consumer.STAT_DB_RETRIES,
+        consumer.STAT_DB_RECOVERIES, consumer.STAT_DB_RECOVERY_FAILURES,
         consumer.STAT_ATTACHMENT_FAILURES,
     }

--- a/scripts/signal/tests/test_consumer_resilience.py
+++ b/scripts/signal/tests/test_consumer_resilience.py
@@ -2,7 +2,7 @@
 
 The four hazards from the proposal, each measured rather than asserted about:
 
-* SSE disconnect → reconnect WITH redelivery: nothing lost, nothing duplicated;
+* a disconnect → reconnect WITH redelivery: nothing lost, nothing duplicated;
 * a malformed event: skipped and counted, the stream keeps going;
 * Postgres briefly unavailable: retried, the event is not dropped;
 * an attachment fetch failing: the MESSAGE row still stands.
@@ -32,7 +32,7 @@ class Streams:
     """A stream_factory that hands out a scripted sequence of connections.
 
     Each connection is a list of lines; a `RuntimeError` inside the list is
-    RAISED mid-iteration, which is what an SSE disconnect looks like from here.
+    RAISED mid-iteration, which is what a dropped websocket looks like here.
     """
 
     def __init__(self, *connections):

--- a/scripts/signal/tests/test_consumer_resilience.py
+++ b/scripts/signal/tests/test_consumer_resilience.py
@@ -1,0 +1,327 @@
+"""What the daemon must survive. Every failure is INJECTED, nothing is live.
+
+The four hazards from the proposal, each measured rather than asserted about:
+
+* SSE disconnect → reconnect WITH redelivery: nothing lost, nothing duplicated;
+* a malformed event: skipped and counted, the stream keeps going;
+* Postgres briefly unavailable: retried, the event is not dropped;
+* an attachment fetch failing: the MESSAGE row still stands.
+"""
+import json
+
+import psycopg2
+import pytest
+
+import consumer
+
+ALICE = "11111111-1111-4111-8111-111111111111"
+
+
+def _payload(ts, body="stream fixture", *, uuid=ALICE, attachments=()):
+    env = {
+        "source": "+15550101", "sourceNumber": "+15550101", "sourceUuid": uuid,
+        "timestamp": ts,
+        "dataMessage": {"timestamp": ts, "message": body,
+                        "attachments": list(attachments)},
+    }
+    return "data: " + json.dumps({"method": "receive", "params": {"envelope": env}})
+
+
+class Streams:
+    """A stream_factory that hands out a scripted sequence of connections.
+
+    Each connection is a list of lines; a `RuntimeError` inside the list is
+    RAISED mid-iteration, which is what an SSE disconnect looks like from here.
+    """
+
+    def __init__(self, *connections):
+        self._connections = list(connections)
+        self.opened = 0
+
+    def __call__(self):
+        self.opened += 1
+        if not self._connections:
+            return iter(())
+        lines = self._connections.pop(0)
+
+        def gen():
+            for line in lines:
+                if isinstance(line, Exception):
+                    raise line
+                yield line
+
+        return gen()
+
+
+def _consumer(db, streams, **kw):
+    return consumer.SignalConsumer(db, stream_factory=streams,
+                                   sleep=lambda _s: None, **kw)
+
+
+# --------------------------------------------------------------------------- #
+# Reconnect + redelivery
+# --------------------------------------------------------------------------- #
+def test_disconnect_midstream_reconnects_and_loses_nothing(db):
+    streams = Streams(
+        [_payload(1723400000001, "first"), RuntimeError("connection reset")],
+        [_payload(1723400000001, "first"),      # redelivered after reconnect
+         _payload(1723400000002, "second")],
+    )
+    c = _consumer(db, streams)
+    c.run(max_connections=2)
+
+    assert streams.opened == 2
+    assert c.stats[consumer.STAT_RECONNECTS] == 1
+    bodies = {r["body"] for r in db.conn.rows("SELECT body FROM signal.messages")}
+    assert bodies == {"first", "second"}          # nothing lost ...
+    assert db.conn.count("messages") == 2         # ... and nothing duplicated
+
+
+def test_positive_control_the_stream_actually_stores_anything(db):
+    """A 'nothing duplicated' claim is worthless if the pipe stores nothing."""
+    c = _consumer(db, Streams([_payload(1723400000011, "solo")]))
+    c.run(max_connections=1)
+    assert db.conn.count("messages") == 1
+    assert c.stats[consumer.STAT_STORED] == 1
+
+
+def test_a_clean_stream_end_is_not_counted_as_a_reconnect(db):
+    c = _consumer(db, Streams([_payload(1723400000021)]))
+    c.run(max_connections=1)
+    assert c.stats[consumer.STAT_RECONNECTS] == 0
+
+
+# --------------------------------------------------------------------------- #
+# Malformed events
+# --------------------------------------------------------------------------- #
+def test_malformed_event_is_skipped_and_the_stream_continues(db):
+    streams = Streams([
+        "data: {this is not json",
+        _payload(1723400000031, "after the bad one"),
+    ])
+    c = _consumer(db, streams)
+    c.run(max_connections=1)
+    assert c.stats[consumer.STAT_MALFORMED] == 1
+    assert c.stats[consumer.STAT_STORED] == 1
+    assert db.conn.count("messages") == 1
+
+
+def test_unknown_kinds_are_counted_as_ignored_not_stored(db):
+    typing = json.dumps({"method": "receive", "params": {"envelope": {
+        "sourceUuid": ALICE, "timestamp": 1723400000041,
+        "typingMessage": {"action": "STARTED"}}}})
+    c = _consumer(db, Streams(["data: " + typing]))
+    c.run(max_connections=1)
+    assert c.stats[consumer.STAT_IGNORED] == 1
+    assert c.stats[consumer.STAT_STORED] == 0
+    assert db.conn.count("messages") == 0
+
+
+# --------------------------------------------------------------------------- #
+# Postgres briefly unavailable
+# --------------------------------------------------------------------------- #
+class FlakyDB:
+    """Wraps the real substrate; fails `upsert_message` `n` times first."""
+
+    def __init__(self, inner, failures):
+        self._inner = inner
+        self.remaining = failures
+        self.upserts = 0
+
+    def upsert_message(self, msg):
+        self.upserts += 1
+        if self.remaining > 0:
+            self.remaining -= 1
+            raise psycopg2.OperationalError("server closed the connection unexpectedly")
+        return self._inner.upsert_message(msg)
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+def test_transient_postgres_failure_is_retried_and_the_event_survives(db):
+    flaky = FlakyDB(db, failures=2)
+    c = _consumer(flaky, Streams([_payload(1723400000051, "survived the retry")]),
+                  db_retries=3)
+    c.run(max_connections=1)
+    assert flaky.upserts == 3                       # two failures, then success
+    assert c.stats[consumer.STAT_DB_RETRIES] == 2
+    assert db.conn.count("messages") == 1
+
+
+def test_a_persistent_postgres_failure_is_not_swallowed(db):
+    """Retry must have a floor: an endless outage has to surface, not vanish."""
+    flaky = FlakyDB(db, failures=99)
+    c = _consumer(flaky, Streams([_payload(1723400000061)]), db_retries=2)
+    with pytest.raises(psycopg2.OperationalError):
+        c.handle_payload(_payload(1723400000061)[len("data: "):])
+    assert c.stats[consumer.STAT_DB_RETRIES] == 2
+
+
+def test_a_programming_error_is_not_retried(db):
+    """Only TRANSIENT faults are retried — a bug must fail on the first attempt."""
+    class Broken(FlakyDB):
+        def upsert_message(self, msg):
+            self.upserts += 1
+            raise psycopg2.ProgrammingError("column does not exist")
+
+    broken = Broken(db, failures=0)
+    c = _consumer(broken, Streams([]), db_retries=5)
+    with pytest.raises(psycopg2.ProgrammingError):
+        c.handle_payload(_payload(1723400000071)[len("data: "):])
+    assert broken.upserts == 1
+    assert c.stats[consumer.STAT_DB_RETRIES] == 0
+
+
+# --------------------------------------------------------------------------- #
+# Attachment failures are isolated from the message write
+# --------------------------------------------------------------------------- #
+class FakeMinio:
+    bucket = "signal-attachments"
+
+    def __init__(self):
+        self.calls = []
+
+    def put_attachment(self, **kw):
+        self.calls.append(kw)
+        return f"{kw['conversation']}/2026-01-01/{kw['filename']}"
+
+
+def _attachment_payload(ts, att_id="att-resilience"):
+    return _payload(ts, "with an attachment", attachments=[
+        {"id": att_id, "contentType": "image/png", "filename": "shot.png",
+         "size": 12}])
+
+
+def test_attachment_fetch_failure_does_not_roll_back_the_message(db):
+    def boom(_attachment_id):
+        raise TimeoutError("attachment endpoint timed out")
+
+    c = _consumer(db, Streams([_attachment_payload(1723400000081)]),
+                  fetch_attachment=boom, minio=FakeMinio())
+    c.run(max_connections=1)
+
+    assert db.conn.count("messages") == 1           # the message SURVIVES
+    assert c.stats[consumer.STAT_ATTACHMENT_FAILURES] == 1
+    assert c.stats[consumer.STAT_STORED] == 1
+    row = db.conn.rows("SELECT minio_key FROM signal.attachments")[0]
+    assert row["minio_key"] is None                 # ... and is honestly unstamped
+
+
+def test_positive_control_a_working_attachment_is_stamped(db):
+    """The None above only means something because this path writes a key."""
+    minio = FakeMinio()
+    c = _consumer(db, Streams([_attachment_payload(1723400000091)]),
+                  fetch_attachment=lambda _i: b"png-bytes", minio=minio)
+    c.run(max_connections=1)
+    assert len(minio.calls) == 1
+    row = db.conn.rows("SELECT minio_bucket, minio_key FROM signal.attachments")[0]
+    assert row["minio_bucket"] == "signal-attachments"
+    assert row["minio_key"].endswith("shot.png")
+    assert c.stats[consumer.STAT_ATTACHMENT_FAILURES] == 0
+
+
+def test_one_failing_attachment_does_not_stop_the_others(db):
+    payload = _payload(1723400000101, "two attachments", attachments=[
+        {"id": "att-bad", "contentType": "image/png", "filename": "bad.png"},
+        {"id": "att-good", "contentType": "image/png", "filename": "good.png"},
+    ])
+
+    def selective(attachment_id):
+        if attachment_id == "att-bad":
+            raise OSError("truncated download")
+        return b"good-bytes"
+
+    minio = FakeMinio()
+    c = _consumer(db, Streams([payload]), fetch_attachment=selective, minio=minio)
+    c.run(max_connections=1)
+    assert c.stats[consumer.STAT_ATTACHMENT_FAILURES] == 1
+    keyed = db.conn.rows("SELECT signal_attachment_id, minio_key "
+                         "FROM signal.attachments ORDER BY signal_attachment_id")
+    assert [r["signal_attachment_id"] for r in keyed] == ["att-bad", "att-good"]
+    assert keyed[0]["minio_key"] is None
+    assert keyed[1]["minio_key"].endswith("good.png")
+
+
+def test_attachments_are_fetched_after_the_message_is_committed(db):
+    """Ordering is the mechanism, so it is asserted directly."""
+    order = []
+
+    class Watched:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def upsert_message(self, msg):
+            order.append("upsert")
+            return self._inner.upsert_message(msg)
+
+        def commit(self):
+            order.append("commit")
+            return self._inner.commit()
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+    def fetch(_i):
+        order.append("fetch")
+        return b"bytes"
+
+    c = _consumer(Watched(db), Streams([_attachment_payload(1723400000111)]),
+                  fetch_attachment=fetch, minio=FakeMinio())
+    c.run(max_connections=1)
+    assert order.index("commit") < order.index("fetch")
+
+
+def test_no_minio_configured_means_attachments_are_simply_not_fetched(db):
+    c = _consumer(db, Streams([_attachment_payload(1723400000121)]))
+    c.run(max_connections=1)
+    assert db.conn.count("attachments") == 1
+    assert c.stats[consumer.STAT_ATTACHMENT_FAILURES] == 0
+
+
+def test_zero_retries_still_makes_one_attempt(db):
+    """`db_retries=0` means "do not RETRY", not "do not CALL".
+
+    It used to skip the loop and then `raise last` with `last` still None, so a
+    misconfigured consumer died with `TypeError: exceptions must derive from
+    BaseException` from inside the retry helper — an error naming neither the
+    configuration nor the database.
+    """
+    c = _consumer(db, Streams([_payload(1723400000141, "attempted once")]),
+                  db_retries=0)
+    c.run(max_connections=1)
+    assert db.conn.count("messages") == 1
+    assert c.stats[consumer.STAT_DB_RETRIES] == 0
+
+
+def test_zero_retries_propagates_the_real_database_error(db):
+    """... and the failure that surfaces is the DB's, not a TypeError."""
+    flaky = FlakyDB(db, failures=1)
+    c = _consumer(flaky, Streams([]), db_retries=0)
+    with pytest.raises(psycopg2.OperationalError):
+        c.handle_payload(_payload(1723400000151)[len("data: "):])
+    assert flaky.upserts == 1
+
+
+def test_run_without_a_stream_factory_fails_loudly_instead_of_spinning(db):
+    """A configuration fault must not be laundered into an endless reconnect.
+
+    Inside the loop a `None` factory raises `TypeError: 'NoneType' object is not
+    callable`, which the reconnect handler catches — with the daemon's default
+    `max_connections=None` that is an infinite "stream ended; reconnecting" spin.
+    """
+    c = consumer.SignalConsumer(db, sleep=lambda _s: None)
+    with pytest.raises(RuntimeError) as exc:
+        c.run(max_connections=1)
+    assert "stream_factory" in str(exc.value)
+    assert c.stats[consumer.STAT_RECONNECTS] == 0      # not swallowed into a retry
+
+
+def test_run_returns_its_counters(db):
+    c = _consumer(db, Streams([_payload(1723400000131)]))
+    stats = c.run(max_connections=1)
+    assert set(stats) == {
+        consumer.STAT_STORED, consumer.STAT_IGNORED, consumer.STAT_MALFORMED,
+        consumer.STAT_RECONNECTS, consumer.STAT_DB_RETRIES,
+        consumer.STAT_ATTACHMENT_FAILURES,
+    }

--- a/scripts/signal/tests/test_db_schema.py
+++ b/scripts/signal/tests/test_db_schema.py
@@ -1,0 +1,293 @@
+"""The `signal` schema: idempotent, complete, and the substrate that proves it.
+
+Two halves:
+
+1. **INSTRUMENT VALIDATION.** Everything else in this directory reads verdicts
+   off `fakepg.SqliteConn`. Before any of those verdicts mean anything, this
+   module shows the substrate can go RED for each property the other suites rely
+   on — NOT NULL, UNIQUE, UNIQUE-treats-NULLs-as-DISTINCT (the exact Postgres
+   behaviour 🔧 #1 exists for), partial indexes, and ON CONFLICT … RETURNING. A
+   substrate that silently enforced nothing would make every "one row" assertion
+   in this suite pass vacuously.
+2. **THE SCHEMA ITSELF** — idempotence, and each of the four 🔧 corrections
+   present as a real constraint rather than as a word in a comment.
+"""
+import sqlite3
+
+import pytest
+
+import _signal_db
+import fakepg
+
+# --------------------------------------------------------------------------- #
+# 1. Instrument validation — the substrate must be able to fail
+# --------------------------------------------------------------------------- #
+
+
+def test_substrate_enforces_not_null():
+    """NEGATIVE CONTROL: a NOT NULL violation must raise, or 🔧 #1 is untestable."""
+    conn = fakepg.SqliteConn()
+    conn.raw.execute("CREATE TABLE signal.t (a INTEGER NOT NULL)")
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.raw.execute("INSERT INTO signal.t (a) VALUES (NULL)")
+    conn.raw.execute("INSERT INTO signal.t (a) VALUES (7)")   # positive control
+    assert conn.raw.execute("SELECT count(*) FROM signal.t").fetchone()[0] == 1
+
+
+def test_substrate_unique_treats_nulls_as_distinct():
+    """The whole premise of 🔧 #1, demonstrated in the substrate itself.
+
+    Two rows with a NULL in the UNIQUE column BOTH insert (NULLs compare
+    distinct); two rows with the same non-NULL value do not. If this substrate
+    deduped NULLs, the 🔧 #1 tests would be measuring the wrong engine.
+    """
+    conn = fakepg.SqliteConn()
+    conn.raw.execute("CREATE TABLE signal.u (a INTEGER, b INTEGER, UNIQUE (a, b))")
+    conn.raw.execute("INSERT INTO signal.u (a, b) VALUES (NULL, 5)")
+    conn.raw.execute("INSERT INTO signal.u (a, b) VALUES (NULL, 5)")
+    assert conn.raw.execute("SELECT count(*) FROM signal.u").fetchone()[0] == 2
+    conn.raw.execute("INSERT INTO signal.u (a, b) VALUES (3, 5)")
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.raw.execute("INSERT INTO signal.u (a, b) VALUES (3, 5)")
+
+
+def test_substrate_supports_returning_and_partial_indexes():
+    conn = fakepg.SqliteConn()
+    conn.raw.execute("CREATE TABLE signal.r (id INTEGER PRIMARY KEY, x INTEGER)")
+    conn.raw.execute("CREATE INDEX signal.rp ON r(x) WHERE x IS NULL")
+    row = conn.raw.execute(
+        "INSERT INTO signal.r (x) VALUES (12) RETURNING id").fetchone()
+    assert row[0] == 1
+
+
+def test_translator_refuses_what_it_cannot_translate():
+    """NEGATIVE CONTROL on the translator: it raises rather than passing through."""
+    with pytest.raises(fakepg.TranslationError):
+        fakepg.translate_dml("SELECT * FROM signal.messages WHERE search @@ 'x'")
+
+
+def test_translated_ddl_keeps_the_constraints_it_is_read_for():
+    """The translation must not silently DROP a NOT NULL or a UNIQUE.
+
+    Dropping either would turn every 🔧 assertion green-for-free — this is the
+    positive control that the constraints survive the trip into sqlite.
+    """
+    messages = [s for s in _signal_db.SCHEMA_STATEMENTS
+                if "CREATE TABLE IF NOT EXISTS signal.messages" in s][0]
+    out = fakepg.translate_ddl(messages)
+    assert "source_contact_id INTEGER NOT NULL" in out
+    assert "UNIQUE (source_contact_id, message_timestamp)" in out
+    assert "tsvector" not in out.lower()
+
+
+# --------------------------------------------------------------------------- #
+# 2. The schema
+# --------------------------------------------------------------------------- #
+EXPECTED_TABLES = {"contacts", "groups", "messages", "attachments", "reactions"}
+
+
+def _tables(db) -> set:
+    return {r["name"] for r in db.conn.rows(
+        "SELECT name FROM signal.sqlite_master WHERE type='table'")}
+
+
+def _indexes(db) -> set:
+    return {r["name"] for r in db.conn.rows(
+        "SELECT name FROM signal.sqlite_master WHERE type='index' "
+        "AND name IS NOT NULL")}
+
+
+def test_ensure_schema_creates_every_table(db):
+    assert EXPECTED_TABLES <= _tables(db)
+
+
+def test_ensure_schema_is_idempotent(db):
+    before = _tables(db)
+    db.ensure_schema()
+    db.ensure_schema()
+    assert _tables(db) == before
+    # And the data survives a re-run — IF NOT EXISTS, never CREATE OR REPLACE.
+    db.upsert_contact(signal_uuid="aaaaaaaa-0000-4000-8000-000000000001",
+                      display_name="Persisted")
+    db.ensure_schema()
+    assert db.conn.count("contacts") == 1
+
+
+def test_every_declared_index_is_created(db):
+    """Derived from SCHEMA_STATEMENTS, not from a hand-written list.
+
+    The GIN index is the documented exception (no sqlite equivalent); it is
+    asserted structurally below instead.
+    """
+    declared = set()
+    for stmt in _signal_db.SCHEMA_STATEMENTS:
+        s = stmt.strip()
+        if s.upper().startswith("CREATE INDEX") and "USING GIN" not in s:
+            declared.add(s.split()[5])          # CREATE INDEX IF NOT EXISTS <name>
+    assert declared, "HARNESS BROKEN: no non-GIN indexes parsed out of the schema"
+    assert declared <= _indexes(db)
+
+
+def test_source_contact_id_is_not_null_in_the_live_schema(db):
+    """🔧 #1, asserted as a CONSTRAINT and not as a comment.
+
+    A raw insert with a NULL sender must be rejected by the database. Removing
+    `NOT NULL` from SCHEMA_STATEMENTS makes this pass silently — which is the
+    mutation this test exists to kill.
+    """
+    with pytest.raises(sqlite3.IntegrityError):
+        db.conn.raw.execute(
+            "INSERT INTO signal.messages (message_timestamp, source_contact_id, "
+            "message_type) VALUES (1723000000001, NULL, 'message')")
+    # POSITIVE CONTROL: the same insert with a real contact succeeds, so the
+    # failure above is about the NULL and not about the statement's shape.
+    cid = db.upsert_contact(signal_uuid="bbbbbbbb-0000-4000-8000-000000000002")
+    db.conn.raw.execute(
+        "INSERT INTO signal.messages (message_timestamp, source_contact_id, "
+        "message_type) VALUES (1723000000001, ?, 'message')", (cid,))
+    assert db.conn.count("messages") == 1
+
+
+def test_unique_message_constraint_is_live(db):
+    cid = db.upsert_contact(signal_uuid="cccccccc-0000-4000-8000-000000000003")
+    db.conn.raw.execute(
+        "INSERT INTO signal.messages (message_timestamp, source_contact_id, "
+        "message_type) VALUES (1723000000007, ?, 'message')", (cid,))
+    with pytest.raises(sqlite3.IntegrityError):
+        db.conn.raw.execute(
+            "INSERT INTO signal.messages (message_timestamp, source_contact_id, "
+            "message_type) VALUES (1723000000007, ?, 'message')", (cid,))
+
+
+def test_unique_attachment_constraint_is_live(db):
+    """🔧 #2 as a constraint: the same (message, attachment id) cannot repeat."""
+    cid = db.upsert_contact(signal_uuid="dddddddd-0000-4000-8000-000000000004")
+    mid = db.upsert_message({"message_timestamp": 1723000000009,
+                             "source_uuid": "dddddddd-0000-4000-8000-000000000004",
+                             "message_type": "message"})
+    assert cid == 1
+    db.conn.raw.execute(
+        "INSERT INTO signal.attachments (message_id, signal_attachment_id, "
+        "content_type) VALUES (?, 'att-dup', 'image/png')", (mid,))
+    with pytest.raises(sqlite3.IntegrityError):
+        db.conn.raw.execute(
+            "INSERT INTO signal.attachments (message_id, signal_attachment_id, "
+            "content_type) VALUES (?, 'att-dup', 'image/png')", (mid,))
+
+
+def test_reaction_message_id_is_nullable(db):
+    """🔧 #3 as a constraint: an unresolved reaction must be STORABLE."""
+    cid = db.upsert_contact(signal_uuid="eeeeeeee-0000-4000-8000-000000000005")
+    db.conn.raw.execute(
+        "INSERT INTO signal.reactions (message_id, target_author_id, "
+        "target_sent_timestamp, emoji, contact_id) "
+        "VALUES (NULL, ?, 1723000000011, '👀', ?)", (cid, cid))
+    assert db.conn.count("reactions") == 1
+
+
+def test_generated_tsvector_column_is_declared(db):
+    """The FTS column is Postgres-only, so it is asserted on the DDL text.
+
+    Labelled honestly: this is an INVARIANT GUARD on the schema source, not
+    evidence that Postgres populates the column — that is deployment step 7.
+    """
+    messages = [s for s in _signal_db.SCHEMA_STATEMENTS
+                if "CREATE TABLE IF NOT EXISTS signal.messages" in s][0]
+    assert "search tsvector GENERATED ALWAYS AS" in messages
+    assert "to_tsvector('english', coalesce(body, ''))" in messages
+    gin = [s for s in _signal_db.SCHEMA_STATEMENTS if "USING GIN(search)" in s]
+    assert len(gin) == 1
+
+
+def test_ensure_schema_emits_every_statement_and_commits_once(recording):
+    db, conn = recording
+    db.ensure_schema()
+    assert len(conn.executed) == len(_signal_db.SCHEMA_STATEMENTS)
+    assert conn.commits == 1
+
+
+def test_returned_id_names_the_write_when_returning_yields_nothing():
+    """A RETURNING that produced no row must say WHICH write, not TypeError.
+
+    The bare `cur.fetchone()[0]` this replaced raised `'NoneType' object is not
+    subscriptable`, which names neither the statement nor the table.
+    """
+    class EmptyCursor:
+        def fetchone(self):
+            return None
+
+    with pytest.raises(RuntimeError) as exc:
+        _signal_db._returned_id(EmptyCursor(), "upsert_contact")
+    assert "upsert_contact" in str(exc.value)
+
+    class OneRow:
+        def fetchone(self):
+            return (77,)
+
+    assert _signal_db._returned_id(OneRow(), "upsert_contact") == 77   # control
+
+
+# --------------------------------------------------------------------------- #
+# 3. The connection-mode contract (cloned from mail-actions/_db.py)
+# --------------------------------------------------------------------------- #
+def test_no_env_means_port_forward(monkeypatch):
+    for var in ("SIGNAL_PG_HOST", "SIGNAL_PG_PORT", "SIGNAL_PG_DIRECT"):
+        monkeypatch.delenv(var, raising=False)
+    assert _signal_db._direct_target() is None
+
+
+def test_signal_pg_host_selects_direct_mode(monkeypatch):
+    monkeypatch.setenv("SIGNAL_PG_HOST", "mailbox-postgres.mailbox.svc.cluster.local")
+    monkeypatch.delenv("SIGNAL_PG_PORT", raising=False)
+    monkeypatch.delenv("SIGNAL_PG_DIRECT", raising=False)
+    assert _signal_db._direct_target() == (
+        "mailbox-postgres.mailbox.svc.cluster.local", None)
+
+
+def test_signal_pg_port_overrides_the_dsn_port(monkeypatch):
+    monkeypatch.setenv("SIGNAL_PG_HOST", "pg.internal")
+    monkeypatch.setenv("SIGNAL_PG_PORT", "6543")
+    assert _signal_db._direct_target() == ("pg.internal", 6543)
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("1", True), ("true", True), ("YES", True), ("on", True),
+    ("0", False), ("", False), ("no", False), ("maybe", False),
+])
+def test_direct_flag_truthiness(monkeypatch, value, expected):
+    monkeypatch.delenv("SIGNAL_PG_HOST", raising=False)
+    monkeypatch.delenv("SIGNAL_PG_PORT", raising=False)
+    monkeypatch.setenv("SIGNAL_PG_DIRECT", value)
+    assert (_signal_db._direct_target() is not None) is expected
+
+
+def test_dsn_kwargs_keep_the_dsn_values_when_no_override():
+    kw = _signal_db._dsn_connect_kwargs("postgresql://u:pw@dbhost:6000/mailbox")
+    assert kw["host"] == "dbhost" and kw["port"] == 6000
+    assert kw["user"] == "u" and kw["password"] == "pw"
+    assert kw["dbname"] == "mailbox"
+
+
+def test_dsn_kwargs_apply_the_port_forward_override():
+    kw = _signal_db._dsn_connect_kwargs("postgres://u:pw@dbhost/mailbox",
+                                        host="127.0.0.1", port=45678)
+    assert kw["host"] == "127.0.0.1" and kw["port"] == 45678
+
+
+def test_dsn_kwargs_reject_a_non_postgres_scheme():
+    with pytest.raises(ValueError):
+        _signal_db._dsn_connect_kwargs("mysql://u:pw@dbhost/mailbox")
+
+
+def test_db_used_outside_its_context_manager_is_a_clear_error():
+    db = _signal_db.SignalDB(dsn="postgres://u:p@h/mailbox")
+    with pytest.raises(RuntimeError) as exc:
+        db.ensure_schema()
+    assert "context manager" in str(exc.value)
+
+
+def test_namespace_and_service_point_at_the_mailbox_postgres():
+    """The signal schema deliberately shares the mailbox instance."""
+    assert _signal_db.NAMESPACE == "mailbox"
+    assert _signal_db.SERVICE == "svc/mailbox-postgres"
+    assert _signal_db.SCHEMA == "signal"

--- a/scripts/signal/tests/test_envelope_parse.py
+++ b/scripts/signal/tests/test_envelope_parse.py
@@ -203,21 +203,16 @@ def test_malformed_envelopes_raise_malformed_event(bad):
         consumer.parse_envelope(bad)
 
 
-def test_iter_frames_yields_one_item_per_message_for_both_transports():
-    """One websocket frame per message; one REST response holding MANY.
-
-    Both shapes reach `iter_frames`, and the consumer downstream only ever sees
-    "one message at a time" — which is why the same core serves json-rpc mode and
-    the plain REST drain.
-    """
+def test_iter_frames_yields_one_item_per_websocket_frame():
+    """The websocket writes one text frame per message; bytes are decoded."""
     ws_frames = ['{"envelope": {"timestamp": 1}}', b'{"envelope": {"timestamp": 2}}']
     assert list(consumer.iter_frames(ws_frames)) == [
         '{"envelope": {"timestamp": 1}}', '{"envelope": {"timestamp": 2}}']
 
-    rest_body = ['[{"envelope": {"timestamp": 3}}, {"envelope": {"timestamp": 4}}]']
-    out = list(consumer.iter_frames(rest_body))
-    assert len(out) == 2
-    assert [f["envelope"]["timestamp"] for f in out] == [3, 4]
+
+def test_iter_frames_passes_already_decoded_objects_through():
+    frame = {"envelope": {"timestamp": 3}}
+    assert list(consumer.iter_frames([frame])) == [frame]
 
 
 def test_iter_frames_skips_blank_frames_and_passes_junk_through_to_be_counted():
@@ -234,6 +229,55 @@ def test_receive_url_is_per_account_and_upgrades_scheme_for_websockets():
             == "ws://signal-api.signal.svc:8080/v1/receive/+15559090")
     assert consumer.receive_url("+1", api_url="https://x.example",
                                 websocket=True).startswith("wss://")
+
+
+def test_a_missing_websocket_package_fails_at_FACTORY_BUILD_not_in_the_loop(
+        monkeypatch):
+    """🔴 A missing dependency must not become an infinite silent reconnect.
+
+    `run()` calls the factory once per connect and treats any exception from it
+    as a dropped stream. With the import INSIDE `_open()`, an absent
+    `websocket-client` produced `stream ended (No module named 'websocket');
+    reconnecting` forever, zero rows — MEASURED at 25/25 connects. That is the
+    same zombie mode `run()`'s hoisted stream-factory check exists to prevent.
+    """
+    import sys as _sys
+
+    monkeypatch.setitem(_sys.modules, "websocket", None)
+    with pytest.raises(RuntimeError) as exc:
+        consumer.ws_stream_factory("+15559090")
+    message = str(exc.value)
+    assert "websocket-client" in message
+    assert "requirements.txt" in message
+
+
+def test_the_websocket_dependency_is_DECLARED_not_just_imported():
+    """It was declared nowhere — the only trace was a trailing comment."""
+    requirements = (Path(consumer.__file__).parent / "requirements.txt")
+    assert requirements.is_file(), "scripts/signal/requirements.txt is missing"
+    listed = {line.split("#")[0].strip().lower()
+              for line in requirements.read_text(encoding="utf-8").splitlines()
+              if line.strip() and not line.strip().startswith("#")}
+    assert "websocket-client" in listed
+    for also_imported in ("psycopg2-binary", "minio", "requests"):
+        assert also_imported in listed, f"{also_imported} is imported but undeclared"
+
+
+def test_the_factory_builds_when_the_package_IS_present(monkeypatch):
+    """POSITIVE CONTROL: the refusal above is about the package, not the function."""
+    import sys as _sys
+    import types as _types
+
+    fake = _types.ModuleType("websocket")
+    fake.create_connection = lambda *a, **k: None      # never called here
+    monkeypatch.setitem(_sys.modules, "websocket", fake)
+    factory = consumer.ws_stream_factory("+15559090")
+    assert callable(factory)
+
+
+def test_no_rest_polling_factory_ships():
+    """It was referenced nowhere and hot-loops if used (`run()` only sleeps on error)."""
+    assert not hasattr(consumer, "rest_poll_stream_factory")
 
 
 def test_receive_url_refuses_an_empty_account():

--- a/scripts/signal/tests/test_envelope_parse.py
+++ b/scripts/signal/tests/test_envelope_parse.py
@@ -1,0 +1,176 @@
+"""The envelope corpus: every shape signal-cli emits, parsed without I/O.
+
+Driven by `fixtures/envelopes.json`, whose entries each carry their own `expect`
+block — so adding a fixture adds coverage without touching this file.
+
+Two harness guards come first, because a corpus-driven suite is exactly the shape
+that passes vacuously when the loader breaks:
+
+* the corpus must be non-empty and plausibly sized;
+* the KINDS the corpus exercises must cover every `KIND_*` constant DERIVED from
+  `consumer.py`'s source — so a new kind added to the module without a fixture
+  fails here rather than shipping unexercised.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+import consumer
+from conftest import load_corpus
+
+CORPUS = load_corpus()
+MIN_FIXTURES = 12          # 15 today; a floor, not the contract
+
+
+def _kind_constants() -> set:
+    """Every KIND_* value, read out of consumer.py's SOURCE text."""
+    src = Path(consumer.__file__).read_text(encoding="utf-8")
+    found = set(re.findall(r'^KIND_[A-Z_]+ = "([a-z_]+)"', src, re.MULTILINE))
+    if not found:
+        raise AssertionError(
+            "HARNESS BROKEN: no KIND_* constants parsed out of consumer.py — the "
+            "coverage assertion below would be vacuous")
+    return found
+
+
+def test_corpus_is_loaded_and_plausibly_sized():
+    assert len(CORPUS) >= MIN_FIXTURES
+    assert all("envelope" in c and "expect" in c for c in CORPUS.values())
+
+
+def test_corpus_covers_every_kind_the_module_can_emit():
+    exercised = {consumer.parse_envelope(c["envelope"]).kind for c in CORPUS.values()}
+    missing = _kind_constants() - exercised
+    assert not missing, f"kinds with no fixture: {sorted(missing)}"
+
+
+def test_corpus_values_are_pairwise_distinct():
+    """A fixture that reuses another's timestamp cannot see a mutant that swaps them."""
+    stamps = [c["envelope"]["timestamp"] for c in CORPUS.values()]
+    assert len(set(stamps)) == len(stamps)
+    uuids = [c["envelope"].get("sourceUuid") for c in CORPUS.values()]
+    assert len(set(uuids)) == len(uuids)
+
+
+@pytest.mark.parametrize("name", sorted(CORPUS))
+def test_fixture_parses_to_its_expected_kind(name):
+    case = CORPUS[name]
+    event = consumer.parse_envelope(case["envelope"])
+    assert event.kind == case["expect"]["kind"]
+
+
+@pytest.mark.parametrize("name", sorted(CORPUS))
+def test_fixture_message_fields(name):
+    case = CORPUS[name]
+    expected = case["expect"].get("message")
+    if expected is None:
+        return
+    event = consumer.parse_envelope(case["envelope"])
+    assert event.message is not None, f"{name}: expected a message payload"
+    for field, want in expected.items():
+        if field == "group_id_b64":
+            import base64
+            assert event.message["group_id"] == base64.b64decode(want)
+        else:
+            assert event.message[field] == want, f"{name}.{field}"
+
+
+@pytest.mark.parametrize("name", sorted(CORPUS))
+def test_fixture_reaction_fields(name):
+    case = CORPUS[name]
+    expected = case["expect"].get("reaction")
+    if expected is None:
+        return
+    event = consumer.parse_envelope(case["envelope"])
+    assert event.reaction is not None
+    for field, want in expected.items():
+        assert event.reaction[field] == want, f"{name}.{field}"
+
+
+@pytest.mark.parametrize("name", sorted(CORPUS))
+def test_fixture_attachment_fields(name):
+    case = CORPUS[name]
+    expected = case["expect"].get("attachments")
+    if expected is None:
+        return
+    event = consumer.parse_envelope(case["envelope"])
+    got = event.message["attachments"]
+    assert len(got) == len(expected)
+    for want, have in zip(expected, got):
+        for field, value in want.items():
+            assert have[field] == value, f"{name}.{field}"
+
+
+@pytest.mark.parametrize("name", sorted(CORPUS))
+def test_every_fixture_keeps_its_raw_envelope(name):
+    """Nothing is dropped on the floor: the original JSON is always retained."""
+    event = consumer.parse_envelope(CORPUS[name]["envelope"])
+    assert event.raw_envelope
+    assert str(CORPUS[name]["envelope"]["timestamp"]) in event.raw_envelope
+
+
+# --------------------------------------------------------------------------- #
+# The two cases the proposal calls out by name
+# --------------------------------------------------------------------------- #
+def test_sync_outbound_is_marked_outbound_and_keeps_the_destination():
+    event = consumer.parse_envelope(CORPUS["sync_outbound"]["envelope"])
+    assert event.kind == consumer.KIND_SYNC_OUTBOUND
+    assert event.message["is_outbound"] is True
+    assert event.message["dest_number"] == "+15550101"
+    # The SOURCE of an outbound sync is the account itself, not the recipient —
+    # getting this backwards would file every sent message under the wrong peer.
+    assert event.message["source_number"] == "+15559090"
+
+
+def test_unknown_message_type_is_surfaced_not_dropped():
+    event = consumer.parse_envelope(CORPUS["unknown_type"]["envelope"])
+    assert event.kind == consumer.KIND_UNKNOWN
+    assert event.message is None and event.reaction is None
+    assert event.notes and "callMessage" in event.notes[0]
+    assert event.raw_envelope        # still retained for later forensics
+
+
+def test_group_and_dm_are_distinguished():
+    dm = consumer.parse_envelope(CORPUS["dm"]["envelope"])
+    grp = consumer.parse_envelope(CORPUS["group"]["envelope"])
+    assert dm.kind == consumer.KIND_MESSAGE and dm.message["group_id"] is None
+    assert grp.kind == consumer.KIND_GROUP_MESSAGE and grp.message["group_id"]
+
+
+# --------------------------------------------------------------------------- #
+# Malformed input — skipped, never fatal
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("bad", [
+    "not json at all",
+    "[]",
+    '{"method":"send","params":{"envelope":{}}}',
+    '{"params":{}}',
+])
+def test_malformed_sse_payloads_raise_malformed_event(bad):
+    with pytest.raises(consumer.MalformedEvent):
+        consumer.parse_sse_payload(bad)
+
+
+def test_wellformed_sse_payload_positive_control():
+    """The rejections above are about the payloads, not a parser that says no to all."""
+    import json
+    ok = json.dumps({"method": "receive",
+                     "params": {"envelope": CORPUS["dm"]["envelope"]}})
+    assert consumer.parse_sse_payload(ok)["timestamp"] == 1723000000101
+
+
+@pytest.mark.parametrize("bad", [
+    [],
+    "a string",
+    {"dataMessage": {"message": "no timestamp anywhere"}},
+])
+def test_malformed_envelopes_raise_malformed_event(bad):
+    with pytest.raises(consumer.MalformedEvent):
+        consumer.parse_envelope(bad)
+
+
+def test_sse_events_skips_comments_and_blank_lines():
+    lines = [": keep-alive", "", "data: {\"a\": 1}", "event: message",
+             b"data: {\"b\": 2}"]
+    assert list(consumer.sse_events(lines)) == ['{"a": 1}', '{"b": 2}']

--- a/scripts/signal/tests/test_envelope_parse.py
+++ b/scripts/signal/tests/test_envelope_parse.py
@@ -20,7 +20,7 @@ import consumer
 from conftest import load_corpus
 
 CORPUS = load_corpus()
-MIN_FIXTURES = 12          # 15 today; a floor, not the contract
+MIN_FIXTURES = 12          # 16 today; a floor, not the contract
 
 
 def _kind_constants() -> set:
@@ -74,6 +74,19 @@ def test_fixture_message_fields(name):
             assert event.message["group_id"] == base64.b64decode(want)
         else:
             assert event.message[field] == want, f"{name}.{field}"
+
+
+@pytest.mark.parametrize("name", sorted(CORPUS))
+def test_fixture_remote_delete_fields(name):
+    case = CORPUS[name]
+    expected = case["expect"].get("remote_delete")
+    if expected is None:
+        return
+    event = consumer.parse_envelope(case["envelope"])
+    assert event.remote_delete is not None
+    assert event.message is None          # NOT stored as an empty-bodied message
+    for field, want in expected.items():
+        assert event.remote_delete[field] == want, f"{name}.{field}"
 
 
 @pytest.mark.parametrize("name", sorted(CORPUS))
@@ -147,17 +160,37 @@ def test_group_and_dm_are_distinguished():
     '{"method":"send","params":{"envelope":{}}}',
     '{"params":{}}',
 ])
-def test_malformed_sse_payloads_raise_malformed_event(bad):
+def test_malformed_receive_frames_raise_malformed_event(bad):
     with pytest.raises(consumer.MalformedEvent):
-        consumer.parse_sse_payload(bad)
+        consumer.parse_receive_frame(bad)
 
 
-def test_wellformed_sse_payload_positive_control():
+def test_wellformed_receive_frame_positive_control():
     """The rejections above are about the payloads, not a parser that says no to all."""
     import json
     ok = json.dumps({"method": "receive",
                      "params": {"envelope": CORPUS["dm"]["envelope"]}})
-    assert consumer.parse_sse_payload(ok)["timestamp"] == 1723000000101
+    assert consumer.parse_receive_frame(ok)["timestamp"] == 1723000000101
+
+
+def test_bbernhard_websocket_frame_shape_is_accepted():
+    """The shape the server we deploy ACTUALLY sends: `{account, envelope}`.
+
+    Read from upstream `src/api/api.go`: in json-rpc mode `/v1/receive/{number}`
+    upgrades to a websocket and writes the signal-cli params object per message.
+    An earlier revision parsed SSE `data:` lines from a DIFFERENT server, so
+    nothing would ever have been ingested.
+    """
+    import json
+    frame = json.dumps({"account": "+15559090",
+                        "envelope": CORPUS["dm"]["envelope"]})
+    assert consumer.parse_receive_frame(frame)["timestamp"] == 1723000000101
+
+
+def test_receive_frame_accepts_an_already_decoded_dict():
+    """The REST-array path decodes once and hands dicts straight through."""
+    env = consumer.parse_receive_frame({"envelope": CORPUS["group"]["envelope"]})
+    assert env["timestamp"] == 1723000000202
 
 
 @pytest.mark.parametrize("bad", [
@@ -170,7 +203,62 @@ def test_malformed_envelopes_raise_malformed_event(bad):
         consumer.parse_envelope(bad)
 
 
-def test_sse_events_skips_comments_and_blank_lines():
-    lines = [": keep-alive", "", "data: {\"a\": 1}", "event: message",
-             b"data: {\"b\": 2}"]
-    assert list(consumer.sse_events(lines)) == ['{"a": 1}', '{"b": 2}']
+def test_iter_frames_yields_one_item_per_message_for_both_transports():
+    """One websocket frame per message; one REST response holding MANY.
+
+    Both shapes reach `iter_frames`, and the consumer downstream only ever sees
+    "one message at a time" — which is why the same core serves json-rpc mode and
+    the plain REST drain.
+    """
+    ws_frames = ['{"envelope": {"timestamp": 1}}', b'{"envelope": {"timestamp": 2}}']
+    assert list(consumer.iter_frames(ws_frames)) == [
+        '{"envelope": {"timestamp": 1}}', '{"envelope": {"timestamp": 2}}']
+
+    rest_body = ['[{"envelope": {"timestamp": 3}}, {"envelope": {"timestamp": 4}}]']
+    out = list(consumer.iter_frames(rest_body))
+    assert len(out) == 2
+    assert [f["envelope"]["timestamp"] for f in out] == [3, 4]
+
+
+def test_iter_frames_skips_blank_frames_and_passes_junk_through_to_be_counted():
+    """A junk frame must reach `handle_payload` (which counts it), not vanish here."""
+    out = list(consumer.iter_frames(["", "   ", "not json", "[unclosed"]))
+    assert out == ["not json", "[unclosed"]
+
+
+def test_receive_url_is_per_account_and_upgrades_scheme_for_websockets():
+    base = "http://signal-api.signal.svc:8080"
+    assert (consumer.receive_url("+15559090", api_url=base)
+            == "http://signal-api.signal.svc:8080/v1/receive/+15559090")
+    assert (consumer.receive_url("+15559090", api_url=base, websocket=True)
+            == "ws://signal-api.signal.svc:8080/v1/receive/+15559090")
+    assert consumer.receive_url("+1", api_url="https://x.example",
+                                websocket=True).startswith("wss://")
+
+
+def test_receive_url_refuses_an_empty_account():
+    """There is no global stream on this server — the path carries the number."""
+    with pytest.raises(ValueError) as exc:
+        consumer.receive_url("")
+    assert "per-account" in str(exc.value)
+
+
+def test_the_module_targets_the_bbernhard_route_table_only():
+    """🔴 A ledger of the endpoints this module speaks, pinned to upstream's router.
+
+    Upstream `src/main.go` registers exactly `v1.GET("/receive/:number")`,
+    `v1.GET("/attachments/:attachment")` and `v2.POST("/send")`. There is no SSE
+    endpoint and no `/api/v1/events` — that path belongs to AsamK's native
+    daemon, a DIFFERENT server. This test fails if anyone reintroduces one.
+    """
+    src = Path(consumer.__file__).read_text(encoding="utf-8")
+    assert consumer.RECEIVE_PATH == "/v1/receive"
+    assert consumer.ATTACHMENT_PATH == "/v1/attachments"
+    assert consumer.SEND_PATH == "/v2/send"
+    # Scanned as CODE, not as prose: the module's own comment explains why
+    # `/api/v1/events` is wrong, and a naive substring check would trip on the
+    # explanation. Quoted string literals and identifiers are what would make it
+    # real again.
+    for foreign in ('"/api/v1/events"', "'/api/v1/events'", "text/event-stream",
+                    "EVENTS_PATH", "iter_lines("):
+        assert foreign not in src, f"{foreign!r} belongs to a different server"

--- a/scripts/signal/tests/test_envelope_parse.py
+++ b/scripts/signal/tests/test_envelope_parse.py
@@ -178,7 +178,7 @@ def test_bbernhard_websocket_frame_shape_is_accepted():
 
     Read from upstream `src/api/api.go`: in json-rpc mode `/v1/receive/{number}`
     upgrades to a websocket and writes the signal-cli params object per message.
-    An earlier revision parsed SSE `data:` lines from a DIFFERENT server, so
+    An earlier revision parsed event-stream `data:` lines from another server, so
     nothing would ever have been ingested.
     """
     import json
@@ -291,7 +291,7 @@ def test_the_module_targets_the_bbernhard_route_table_only():
     """🔴 A ledger of the endpoints this module speaks, pinned to upstream's router.
 
     Upstream `src/main.go` registers exactly `v1.GET("/receive/:number")`,
-    `v1.GET("/attachments/:attachment")` and `v2.POST("/send")`. There is no SSE
+    `v1.GET("/attachments/:attachment")` and `v2.POST("/send")`. There is no
     endpoint and no `/api/v1/events` — that path belongs to AsamK's native
     daemon, a DIFFERENT server. This test fails if anyone reintroduces one.
     """
@@ -306,3 +306,42 @@ def test_the_module_targets_the_bbernhard_route_table_only():
     for foreign in ('"/api/v1/events"', "'/api/v1/events'", "text/event-stream",
                     "EVENTS_PATH", "iter_lines("):
         assert foreign not in src, f"{foreign!r} belongs to a different server"
+
+
+def test_no_stale_event_stream_WORDING_survives_anywhere_in_the_package():
+    """🔴 The transport is documented in prose, and prose drifts silently.
+
+    The guard above bans the foreign IDENTIFIERS, which is why eleven stale "SSE"
+    mentions survived a purge and drifted for a whole round — including one in
+    `_signal_db.py` that told a reader the device-sync echo "carries back through
+    the SSE stream", a factual misstatement about the deployed transport sitting
+    in the same file as the dedupe design that depends on it.
+
+    Exactly ONE mention is allowed: the line in `consumer.py` that exists to say
+    the endpoint does NOT exist. Anything else is drift.
+    """
+    package = Path(consumer.__file__).parent
+    this_file = Path(__file__).name
+    offenders = []
+    for path in sorted(package.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        if path.name == this_file:
+            continue          # the guard must quote the token it bans
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if "SSE" not in line:
+                continue
+            if path.name == "consumer.py" and "no SSE endpoint anywhere" in line:
+                continue                      # the disclaimer, deliberately kept
+            offenders.append(f"{path.name}:{lineno}: {line.strip()[:80]}")
+    assert not offenders, "stale event-stream wording:\n" + "\n".join(offenders)
+
+
+def test_the_stale_wording_guard_can_actually_fire(tmp_path):
+    """POSITIVE CONTROL: the scan above is not passing because it reads nothing."""
+    (tmp_path / "drifted.py").write_text(
+        '"""consumes the SSE stream"""\n', encoding="utf-8")
+    hits = [line for path in tmp_path.rglob("*.py")
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if "SSE" in line]
+    assert len(hits) == 1

--- a/scripts/signal/tests/test_idempotency.py
+++ b/scripts/signal/tests/test_idempotency.py
@@ -1,6 +1,6 @@
-"""🔧 #1 + 🔧 #2 — SSE redelivery must be a no-op, including for unknown senders.
+"""🔧 #1 + 🔧 #2 — redelivery must be a no-op, including for unknown senders.
 
-The SSE stream redelivers on every reconnect, so "the same envelope twice" is the
+The receive stream redelivers on every reconnect, so "the same envelope twice" is
 NORMAL case, not an edge case. Three claims, each behavioural against the sqlite
 substrate rather than asserted about the SQL text:
 

--- a/scripts/signal/tests/test_idempotency.py
+++ b/scripts/signal/tests/test_idempotency.py
@@ -1,0 +1,143 @@
+"""🔧 #1 + 🔧 #2 — SSE redelivery must be a no-op, including for unknown senders.
+
+The SSE stream redelivers on every reconnect, so "the same envelope twice" is the
+NORMAL case, not an edge case. Three claims, each behavioural against the sqlite
+substrate rather than asserted about the SQL text:
+
+* the same envelope twice → ONE message row;
+* an envelope from a sender the API has NOT resolved to a uuid → still ONE row
+  (the NULL-contact path: `UNIQUE` does not dedupe over NULL, so an unresolved
+  sender must get a deterministic PLACEHOLDER contact, never a NULL);
+* a redelivered message → ONE attachment row per attachment.
+
+🔴 Every "exactly one" claim below is preceded by a POSITIVE CONTROL that makes
+the same counter move — a bare 1 is indistinguishable from a harness wired to
+nothing.
+"""
+import consumer
+import _signal_db
+
+
+def _dm(*, ts, uuid=None, number=None, body="fixture body", attachments=()):
+    return {
+        "message_timestamp": ts,
+        "source_uuid": uuid,
+        "source_number": number,
+        "message_type": consumer.KIND_MESSAGE,
+        "body": body,
+        "attachments": list(attachments),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Positive controls first: the counters CAN move.
+# --------------------------------------------------------------------------- #
+def test_positive_control_two_distinct_envelopes_make_two_rows(db):
+    db.upsert_message(_dm(ts=1723100000001, uuid="a1111111-0000-4000-8000-000000000001"))
+    db.upsert_message(_dm(ts=1723100000002, uuid="a1111111-0000-4000-8000-000000000001"))
+    assert db.conn.count("messages") == 2
+
+
+def test_positive_control_two_distinct_attachments_make_two_rows(db):
+    mid = db.upsert_message(_dm(
+        ts=1723100000003, uuid="a2222222-0000-4000-8000-000000000002",
+        attachments=[
+            {"id": "att-alpha", "content_type": "image/png", "filename": "alpha.png"},
+            {"id": "att-beta", "content_type": "image/gif", "filename": "beta.gif"},
+        ]))
+    assert mid
+    assert db.conn.count("attachments") == 2
+
+
+# --------------------------------------------------------------------------- #
+# The claims
+# --------------------------------------------------------------------------- #
+def test_same_envelope_twice_yields_one_row(db):
+    msg = _dm(ts=1723100000011, uuid="b1111111-0000-4000-8000-000000000011",
+              body="redelivered exactly once")
+    first = db.upsert_message(dict(msg))
+    second = db.upsert_message(dict(msg))
+    assert first == second
+    assert db.conn.count("messages") == 1
+
+
+def test_unresolved_sender_still_dedupes_the_NULL_contact_path(db):
+    """🔧 #1 — the case the original DDL got wrong.
+
+    The envelope carries only a phone number. If the sender were stored as NULL,
+    `unique_message` would not fire (NULLs compare distinct) and every
+    redelivery would insert another copy. The placeholder contact is what closes
+    it — and it must be DETERMINISTIC, or the same hole reopens under a
+    different name.
+    """
+    msg = _dm(ts=1723100000021, number="+15557000021", body="from an unknown sender")
+    db.upsert_message(dict(msg))
+    db.upsert_message(dict(msg))
+    assert db.conn.count("messages") == 1
+    assert db.conn.count("contacts") == 1
+    rows = db.conn.rows("SELECT source_contact_id FROM signal.messages")
+    assert rows[0]["source_contact_id"] is not None
+
+
+def test_placeholder_uuid_is_deterministic_and_identifier_specific():
+    a = _signal_db.placeholder_uuid("+15557000021")
+    again = _signal_db.placeholder_uuid("+15557000021")
+    other = _signal_db.placeholder_uuid("+15557000022")
+    assert a == again          # deterministic → the redelivery finds the same row
+    assert a != other          # ... but not a single bucket for every stranger
+
+
+def test_unresolved_sender_and_a_known_sender_do_not_collide(db):
+    db.upsert_message(_dm(ts=1723100000031, number="+15557000031", body="stranger"))
+    db.upsert_message(_dm(ts=1723100000031,
+                          uuid="c1111111-0000-4000-8000-000000000031", body="known"))
+    assert db.conn.count("messages") == 2      # same timestamp, different senders
+
+
+def test_redelivered_attachment_yields_one_attachment_row(db):
+    """🔧 #2 — without `unique_attachment` this doubles on every reconnect."""
+    msg = _dm(ts=1723100000041, uuid="d1111111-0000-4000-8000-000000000041",
+              attachments=[{"id": "att-redelivered", "content_type": "image/heic",
+                            "filename": "photo.heic", "size": 4096}])
+    db.upsert_message(dict(msg))
+    db.upsert_message(dict(msg))
+    assert db.conn.count("messages") == 1
+    assert db.conn.count("attachments") == 1
+
+
+def test_attachment_rows_carry_their_signal_id_and_metadata(db):
+    db.upsert_message(_dm(
+        ts=1723100000051, uuid="e1111111-0000-4000-8000-000000000051",
+        attachments=[{"id": "att-meta-51", "content_type": "application/pdf",
+                      "filename": "statement.pdf", "size": 91733,
+                      "caption": "march", "is_voice_note": False}]))
+    row = db.conn.rows("SELECT * FROM signal.attachments")[0]
+    assert row["signal_attachment_id"] == "att-meta-51"
+    assert row["content_type"] == "application/pdf"
+    assert row["filename"] == "statement.pdf"
+    assert row["size_bytes"] == 91733
+    assert row["caption"] == "march"
+
+
+def test_redelivery_does_not_erase_a_body_we_already_have(db):
+    """The conflict UPDATE must not overwrite stored content with a thinner copy."""
+    db.upsert_message(_dm(ts=1723100000061,
+                          uuid="f1111111-0000-4000-8000-000000000061",
+                          body="the original text"))
+    thin = _dm(ts=1723100000061, uuid="f1111111-0000-4000-8000-000000000061",
+               body=None)
+    thin["server_delivered_at"] = 1723100000099
+    db.upsert_message(thin)
+    row = db.conn.rows("SELECT body, server_delivered_at FROM signal.messages")[0]
+    assert row["body"] == "the original text"
+    assert row["server_delivered_at"] == 1723100000099   # ... but late facts land
+
+
+def test_contact_upsert_enriches_rather_than_blanks(db):
+    uid = "01111111-0000-4000-8000-000000000071"
+    first = db.upsert_contact(signal_uuid=uid, display_name="Nadia Okoro")
+    second = db.upsert_contact(signal_uuid=uid, phone_number="+15557000071")
+    assert first == second
+    row = db.conn.rows("SELECT * FROM signal.contacts")[0]
+    assert row["display_name"] == "Nadia Okoro"     # not blanked by the 2nd upsert
+    assert row["phone_number"] == "+15557000071"    # ... and the new fact landed

--- a/scripts/signal/tests/test_idempotency.py
+++ b/scripts/signal/tests/test_idempotency.py
@@ -133,6 +133,65 @@ def test_redelivery_does_not_erase_a_body_we_already_have(db):
     assert row["server_delivered_at"] == 1723100000099   # ... but late facts land
 
 
+def test_a_later_delivery_fact_overwrites_an_earlier_one(db):
+    """🔴 The distinguishing case for the OTHER conflict expression.
+
+    Same trap as the body one, caught by the same sweep: the test above has NULL
+    on one side of `COALESCE(EXCLUDED.server_delivered_at, messages.…)`, so
+    swapping the operands changed nothing and the mutant survived. Two DIFFERENT
+    non-null values are what make the orderings disagree.
+
+    Which wins: the INCOMING one. A delivery timestamp is a fact that arrives
+    after the message, so a redelivery carrying one is newer information — the
+    opposite of `body`, where the stored copy wins. The two expressions really
+    are ordered differently, and that is the point.
+    """
+    uid = "f4444444-0000-4000-8000-000000000064"
+    first = _dm(ts=1723100000064, uuid=uid, body="delivery facts")
+    first["server_delivered_at"] = 1723100000111
+    db.upsert_message(first)
+
+    second = _dm(ts=1723100000064, uuid=uid, body="delivery facts")
+    second["server_delivered_at"] = 1723100000222
+    db.upsert_message(second)
+
+    rows = db.conn.rows("SELECT server_delivered_at FROM signal.messages")
+    assert len(rows) == 1
+    assert rows[0]["server_delivered_at"] == 1723100000222
+
+
+def test_a_conflicting_write_with_a_DIFFERENT_body_keeps_the_stored_one(db):
+    """🔴 The distinguishing case — the one a NULL fixture cannot see.
+
+    A mutation sweep swapped the operands of `COALESCE(messages.body,
+    EXCLUDED.body)` and NOTHING failed, because the only test of this expression
+    redelivered a fixture whose body was `None`: with one value null, both
+    orderings collapse to the same answer. Two DIFFERENT non-null bodies are what
+    make the two orderings disagree, so this is the case that pins which one
+    wins.
+
+    Which one SHOULD win: the stored copy. A redelivery is the same message, so a
+    differing body is a downgrade or a truncation, never news. Genuine edits
+    arrive as their own `edit` row with their own timestamp.
+    """
+    uid = "f2222222-0000-4000-8000-000000000062"
+    db.upsert_message(_dm(ts=1723100000062, uuid=uid, body="FIRST stored text"))
+    db.upsert_message(_dm(ts=1723100000062, uuid=uid, body="SECOND arriving text"))
+    rows = db.conn.rows("SELECT body FROM signal.messages")
+    assert len(rows) == 1
+    assert rows[0]["body"] == "FIRST stored text"
+
+
+def test_a_conflicting_write_can_still_fill_a_body_we_never_had(db):
+    """The other direction, so the assertion above is not just 'never update'."""
+    uid = "f3333333-0000-4000-8000-000000000063"
+    db.upsert_message(_dm(ts=1723100000063, uuid=uid, body=None))
+    db.upsert_message(_dm(ts=1723100000063, uuid=uid, body="arrived later"))
+    rows = db.conn.rows("SELECT body FROM signal.messages")
+    assert len(rows) == 1
+    assert rows[0]["body"] == "arrived later"
+
+
 def test_contact_upsert_enriches_rather_than_blanks(db):
     uid = "01111111-0000-4000-8000-000000000071"
     first = db.upsert_contact(signal_uuid=uid, display_name="Nadia Okoro")

--- a/scripts/signal/tests/test_minio_signal.py
+++ b/scripts/signal/tests/test_minio_signal.py
@@ -1,0 +1,186 @@
+"""Attachment archiving: key layout, sidecar contents, bucket auto-create, no-op re-upload.
+
+A fake S3 client stands in for MinIO — no port-forward, no network. The fake is
+deliberately strict: it records every call, so "re-upload is a no-op" is measured
+as PUT COUNT, not inferred from the absence of an error.
+"""
+import json
+
+import pytest
+
+import _minio
+
+
+class FakeS3:
+    """Minimal `minio.Minio` stand-in with a real object store behind it."""
+
+    def __init__(self, existing_buckets=()):
+        self.buckets = set(existing_buckets)
+        self.objects: dict[tuple[str, str], tuple[bytes, str]] = {}
+        self.puts: list[str] = []
+        self.made_buckets: list[str] = []
+
+    def bucket_exists(self, name):
+        return name in self.buckets
+
+    def make_bucket(self, name):
+        self.buckets.add(name)
+        self.made_buckets.append(name)
+
+    def stat_object(self, bucket, key):
+        if (bucket, key) not in self.objects:
+            raise _minio.S3Error("NoSuchKey", "missing", key, "rid", "hid", None)
+        return object()
+
+    def put_object(self, bucket, key, data, length=None, content_type=None):
+        self.objects[(bucket, key)] = (data.read(), content_type)
+        self.puts.append(key)
+
+
+@pytest.fixture()
+def mc():
+    fake = FakeS3()
+    client = _minio.MinioSignal(client=fake)
+    with client as opened:
+        yield opened, fake
+
+
+# --------------------------------------------------------------------------- #
+# Key layout
+# --------------------------------------------------------------------------- #
+def test_object_key_layout_is_conversation_date_filename():
+    key = _minio.object_key(conversation="alice-uuid", timestamp_ms=1723000000101,
+                            filename="receipt-scan.webp")
+    assert key == "alice-uuid/2024-08-07/receipt-scan.webp"
+
+
+def test_object_key_uses_the_message_timestamp_not_wall_clock():
+    """A backfilled attachment must re-derive the SAME key as its first delivery."""
+    old = _minio.object_key(conversation="c", timestamp_ms=1600000000000,
+                            filename="f.bin")
+    assert old.split("/")[1] == "2020-09-13"
+
+
+def test_object_key_neutralises_separators_in_untrusted_names():
+    key = _minio.object_key(conversation="../../etc", timestamp_ms=1723000000101,
+                            filename="a/b c.txt")
+    assert key.count("/") == 2                       # exactly conversation/date/file
+    assert ".." not in key.split("/")[0]
+    assert key.endswith("a_b_c.txt")
+
+
+def test_object_key_falls_back_when_a_segment_is_empty():
+    key = _minio.object_key(conversation="", timestamp_ms=1723000000101, filename="")
+    assert key.startswith("unknown/")
+    assert key.endswith("/attachment")
+
+
+def test_conversation_key_distinguishes_groups_from_dms():
+    import consumer
+    dm = consumer.conversation_key({"source_uuid": "abc-uuid"})
+    grp = consumer.conversation_key({"group_id": b"group-three",
+                                     "source_uuid": "abc-uuid"})
+    assert dm == "abc-uuid"
+    assert grp.startswith("group-") and grp != dm
+
+
+# --------------------------------------------------------------------------- #
+# put_attachment
+# --------------------------------------------------------------------------- #
+def test_bucket_is_auto_created_on_first_use(mc):
+    client, fake = mc
+    assert fake.made_buckets == []
+    client.put_attachment(conversation="conv-1", timestamp_ms=1723000000101,
+                          filename="a.png", data=b"bytes-a",
+                          content_type="image/png")
+    assert fake.made_buckets == [_minio.BUCKET]
+    # ... and only once, however many attachments follow.
+    client.put_attachment(conversation="conv-1", timestamp_ms=1723000000102,
+                          filename="b.png", data=b"bytes-b",
+                          content_type="image/png")
+    assert fake.made_buckets == [_minio.BUCKET]
+
+
+def test_existing_bucket_is_not_recreated():
+    fake = FakeS3(existing_buckets=[_minio.BUCKET])
+    with _minio.MinioSignal(client=fake) as client:
+        client.put_attachment(conversation="conv-2", timestamp_ms=1723000000103,
+                              filename="c.png", data=b"bytes-c",
+                              content_type="image/png")
+    assert fake.made_buckets == []
+
+
+def test_attachment_bytes_and_content_type_land_under_the_key(mc):
+    client, fake = mc
+    key = client.put_attachment(conversation="conv-3", timestamp_ms=1723000000104,
+                                filename="photo.heic", data=b"heic-bytes",
+                                content_type="image/heic")
+    blob, ctype = fake.objects[(_minio.BUCKET, key)]
+    assert blob == b"heic-bytes"
+    assert ctype == "image/heic"
+
+
+def test_sidecar_json_carries_the_metadata(mc):
+    client, fake = mc
+    sidecar = {"conversation": "conv-4", "message_id": 4242,
+               "message_timestamp": 1723000000105, "content_type": "application/pdf",
+               "signal_attachment_id": "att-sidecar-4"}
+    key = client.put_attachment(conversation="conv-4", timestamp_ms=1723000000105,
+                                filename="doc.pdf", data=b"%PDF-1.7",
+                                content_type="application/pdf", sidecar=sidecar)
+    blob, ctype = fake.objects[(_minio.BUCKET, key + _minio.SIDECAR_SUFFIX)]
+    assert ctype == "application/json"
+    assert json.loads(blob) == sidecar
+
+
+def test_reupload_of_the_same_key_is_a_noop(mc):
+    """Measured as PUT COUNT — 'no error' would not distinguish it from a rewrite."""
+    client, fake = mc
+    args = dict(conversation="conv-5", timestamp_ms=1723000000106,
+                filename="dup.bin", data=b"first-write",
+                content_type="application/octet-stream",
+                sidecar={"signal_attachment_id": "att-dup-5"})
+    key = client.put_attachment(**args)
+    puts_after_first = list(fake.puts)
+    assert len(puts_after_first) == 2                     # object + sidecar
+
+    client.put_attachment(**{**args, "data": b"SECOND-WRITE"})
+    assert fake.puts == puts_after_first                  # nothing new was written
+    assert fake.objects[(_minio.BUCKET, key)][0] == b"first-write"
+
+
+def test_positive_control_a_different_key_does_write(mc):
+    """The zero above is only meaningful if this one moves."""
+    client, fake = mc
+    client.put_attachment(conversation="conv-6", timestamp_ms=1723000000107,
+                          filename="one.bin", data=b"x", content_type="a/b")
+    before = len(fake.puts)
+    client.put_attachment(conversation="conv-6", timestamp_ms=1723000000107,
+                          filename="two.bin", data=b"y", content_type="a/b")
+    assert len(fake.puts) == before + 1
+
+
+def test_object_exists_is_false_for_an_absent_key(mc):
+    client, _fake = mc
+    assert client.object_exists("nothing/here/at-all") is False
+
+
+def test_client_outside_the_context_manager_is_a_clear_error():
+    with pytest.raises(RuntimeError) as exc:
+        _minio.MinioSignal(client=None)._c
+    assert "context manager" in str(exc.value)
+
+
+def test_bucket_name_is_the_documented_one():
+    assert _minio.BUCKET == "signal-attachments"
+    assert _minio.MinioSignal(client=FakeS3()).bucket == "signal-attachments"
+
+
+def test_parse_config_env_reads_quoted_and_bare_values():
+    env = _minio.parse_config_env(
+        'export MINIO_ROOT_USER="admin-user"\n'
+        "export MINIO_ROOT_PASSWORD=bare-secret\n"
+        "# export MINIO_IGNORED=nope\n")
+    assert env["MINIO_ROOT_USER"] == "admin-user"
+    assert env["MINIO_ROOT_PASSWORD"] == "bare-secret"
+    assert "MINIO_IGNORED" not in env

--- a/scripts/signal/tests/test_minio_signal.py
+++ b/scripts/signal/tests/test_minio_signal.py
@@ -50,29 +50,77 @@ def mc():
 # --------------------------------------------------------------------------- #
 def test_object_key_layout_is_conversation_date_filename():
     key = _minio.object_key(conversation="alice-uuid", timestamp_ms=1723000000101,
-                            filename="receipt-scan.webp")
-    assert key == "alice-uuid/2024-08-07/receipt-scan.webp"
+                            filename="receipt-scan.webp",
+                            attachment_id="att-505")
+    assert key == "alice-uuid/2024-08-07/att-505_receipt-scan.webp"
 
 
 def test_object_key_uses_the_message_timestamp_not_wall_clock():
     """A backfilled attachment must re-derive the SAME key as its first delivery."""
     old = _minio.object_key(conversation="c", timestamp_ms=1600000000000,
-                            filename="f.bin")
+                            filename="f.bin", attachment_id="att-old")
     assert old.split("/")[1] == "2020-09-13"
 
 
 def test_object_key_neutralises_separators_in_untrusted_names():
     key = _minio.object_key(conversation="../../etc", timestamp_ms=1723000000101,
-                            filename="a/b c.txt")
+                            filename="a/b c.txt", attachment_id="att-path")
     assert key.count("/") == 2                       # exactly conversation/date/file
     assert ".." not in key.split("/")[0]
     assert key.endswith("a_b_c.txt")
 
 
+def test_two_attachments_with_the_same_filename_do_not_collide():
+    """🔴 The collision that silently DROPPED the second file.
+
+    Two `Screenshot.png` in one conversation on one day. Without the attachment
+    id in the key both map to the same object, `put_attachment` sees it already
+    exists and skips the write, and the second DB row then points at the FIRST
+    file's bytes with a sidecar claiming the second's provenance.
+    """
+    first = _minio.object_key(conversation="conv-collide", timestamp_ms=1723000000101,
+                              filename="Screenshot.png", attachment_id="att-one")
+    second = _minio.object_key(conversation="conv-collide", timestamp_ms=1723000000199,
+                               filename="Screenshot.png", attachment_id="att-two")
+    assert first != second
+    assert first.rsplit("/", 1)[0] == second.rsplit("/", 1)[0]   # same day folder
+
+
+def test_the_same_attachment_redelivered_keeps_one_key():
+    """... while redelivery stays idempotent: the Signal id is stable."""
+    a = _minio.object_key(conversation="c", timestamp_ms=1723000000101,
+                          filename="Screenshot.png", attachment_id="att-stable")
+    b = _minio.object_key(conversation="c", timestamp_ms=1723000000101,
+                          filename="Screenshot.png", attachment_id="att-stable")
+    assert a == b
+
+
+def test_object_key_requires_the_attachment_id():
+    with pytest.raises(ValueError) as exc:
+        _minio.object_key(conversation="c", timestamp_ms=1723000000101,
+                          filename="f.png", attachment_id="")
+    assert "collide" in str(exc.value)
+
+
+def test_two_same_named_attachments_both_reach_the_store(mc):
+    """The behavioural half: both objects exist, with their OWN bytes."""
+    client, fake = mc
+    k1 = client.put_attachment(conversation="conv-x", timestamp_ms=1723000000101,
+                               attachment_id="att-first", filename="Screenshot.png",
+                               data=b"first-bytes", content_type="image/png")
+    k2 = client.put_attachment(conversation="conv-x", timestamp_ms=1723000000188,
+                               attachment_id="att-second", filename="Screenshot.png",
+                               data=b"second-bytes", content_type="image/png")
+    assert k1 != k2
+    assert fake.objects[(_minio.BUCKET, k1)][0] == b"first-bytes"
+    assert fake.objects[(_minio.BUCKET, k2)][0] == b"second-bytes"
+
+
 def test_object_key_falls_back_when_a_segment_is_empty():
-    key = _minio.object_key(conversation="", timestamp_ms=1723000000101, filename="")
+    key = _minio.object_key(conversation="", timestamp_ms=1723000000101, filename="",
+                            attachment_id="att-empty")
     assert key.startswith("unknown/")
-    assert key.endswith("/attachment")
+    assert key.endswith("/att-empty_attachment")
 
 
 def test_conversation_key_distinguishes_groups_from_dms():
@@ -91,12 +139,12 @@ def test_bucket_is_auto_created_on_first_use(mc):
     client, fake = mc
     assert fake.made_buckets == []
     client.put_attachment(conversation="conv-1", timestamp_ms=1723000000101,
-                          filename="a.png", data=b"bytes-a",
+                          attachment_id="att-a1", filename="a.png", data=b"bytes-a",
                           content_type="image/png")
     assert fake.made_buckets == [_minio.BUCKET]
     # ... and only once, however many attachments follow.
     client.put_attachment(conversation="conv-1", timestamp_ms=1723000000102,
-                          filename="b.png", data=b"bytes-b",
+                          attachment_id="att-b2", filename="b.png", data=b"bytes-b",
                           content_type="image/png")
     assert fake.made_buckets == [_minio.BUCKET]
 
@@ -105,7 +153,7 @@ def test_existing_bucket_is_not_recreated():
     fake = FakeS3(existing_buckets=[_minio.BUCKET])
     with _minio.MinioSignal(client=fake) as client:
         client.put_attachment(conversation="conv-2", timestamp_ms=1723000000103,
-                              filename="c.png", data=b"bytes-c",
+                              attachment_id="att-c3", filename="c.png", data=b"bytes-c",
                               content_type="image/png")
     assert fake.made_buckets == []
 
@@ -113,7 +161,7 @@ def test_existing_bucket_is_not_recreated():
 def test_attachment_bytes_and_content_type_land_under_the_key(mc):
     client, fake = mc
     key = client.put_attachment(conversation="conv-3", timestamp_ms=1723000000104,
-                                filename="photo.heic", data=b"heic-bytes",
+                                attachment_id="att-d4", filename="photo.heic", data=b"heic-bytes",
                                 content_type="image/heic")
     blob, ctype = fake.objects[(_minio.BUCKET, key)]
     assert blob == b"heic-bytes"
@@ -126,7 +174,7 @@ def test_sidecar_json_carries_the_metadata(mc):
                "message_timestamp": 1723000000105, "content_type": "application/pdf",
                "signal_attachment_id": "att-sidecar-4"}
     key = client.put_attachment(conversation="conv-4", timestamp_ms=1723000000105,
-                                filename="doc.pdf", data=b"%PDF-1.7",
+                                attachment_id="att-sidecar-4", filename="doc.pdf", data=b"%PDF-1.7",
                                 content_type="application/pdf", sidecar=sidecar)
     blob, ctype = fake.objects[(_minio.BUCKET, key + _minio.SIDECAR_SUFFIX)]
     assert ctype == "application/json"
@@ -137,7 +185,7 @@ def test_reupload_of_the_same_key_is_a_noop(mc):
     """Measured as PUT COUNT — 'no error' would not distinguish it from a rewrite."""
     client, fake = mc
     args = dict(conversation="conv-5", timestamp_ms=1723000000106,
-                filename="dup.bin", data=b"first-write",
+                attachment_id="att-dup-5", filename="dup.bin", data=b"first-write",
                 content_type="application/octet-stream",
                 sidecar={"signal_attachment_id": "att-dup-5"})
     key = client.put_attachment(**args)
@@ -153,10 +201,10 @@ def test_positive_control_a_different_key_does_write(mc):
     """The zero above is only meaningful if this one moves."""
     client, fake = mc
     client.put_attachment(conversation="conv-6", timestamp_ms=1723000000107,
-                          filename="one.bin", data=b"x", content_type="a/b")
+                          attachment_id="att-e5", filename="one.bin", data=b"x", content_type="a/b")
     before = len(fake.puts)
     client.put_attachment(conversation="conv-6", timestamp_ms=1723000000107,
-                          filename="two.bin", data=b"y", content_type="a/b")
+                          attachment_id="att-f6", filename="two.bin", data=b"y", content_type="a/b")
     assert len(fake.puts) == before + 1
 
 

--- a/scripts/signal/tests/test_outbound_echo.py
+++ b/scripts/signal/tests/test_outbound_echo.py
@@ -1,0 +1,170 @@
+"""🔧 #4 — the outbound sync echo. The single most likely thing to be silently wrong.
+
+A message sent through the REST API comes BACK through the SSE stream as a sync
+message from the account's own linked devices. `unique_message` catches that echo
+only if the send path recorded the SAME `(source_contact_id, message_timestamp)`
+the echo will carry — i.e. the SERVER-assigned timestamp, not a locally generated
+one. Two independent halves, both tested:
+
+* the send path stores the server's timestamp (and refuses a non-positive one);
+* the echo, fed end to end through `parse_envelope` → `upsert_message`, lands on
+  the row that already exists — same row id, `is_outbound` still true.
+
+The identity half matters as much as the timestamp half: the draft's sending
+contact and the echo's sender must resolve to the SAME contact row, or the
+composite key differs and the echo inserts a second copy anyway.
+"""
+import json
+
+import pytest
+
+import consumer
+import _signal_db
+
+SELF_UUID = "90909090-9090-4909-8909-909090909090"
+SELF_NUMBER = "+15559090"
+PEER_NUMBER = "+15550101"
+SERVER_TS = 1723000009090        # what the API assigns and the echo carries
+LOCAL_TS = 1723000007777         # deliberately DIFFERENT from SERVER_TS
+
+
+def _approved_draft(db, *, body="sent from my laptop"):
+    draft = db.draft_message(recipient=PEER_NUMBER, body=body,
+                             self_number=SELF_NUMBER)
+    return db.approve_draft(draft["id"], approval_ref="clawgate-echo-1")
+
+
+def _echo_envelope(*, timestamp, body="sent from my laptop"):
+    return {
+        "source": SELF_NUMBER,
+        "sourceNumber": SELF_NUMBER,
+        "sourceUuid": SELF_UUID,
+        "timestamp": timestamp,
+        "syncMessage": {
+            "sentMessage": {
+                "timestamp": timestamp,
+                "destination": PEER_NUMBER,
+                "message": body,
+            }
+        },
+    }
+
+
+def _transmit_returning(ts):
+    def _t(auth, *, recipient, body):
+        return {"timestamp": ts}
+    return _t
+
+
+# --------------------------------------------------------------------------- #
+def test_send_records_the_server_timestamp_not_a_local_one(db):
+    draft = _approved_draft(db)
+    assert draft["message_timestamp"] < 0          # provisional, pre-send
+    sent = db.send_approved(draft["id"], transmit=_transmit_returning(SERVER_TS))
+    assert sent["message_timestamp"] == SERVER_TS
+    assert sent["send_state"] == _signal_db.STATE_SENT
+
+
+def test_the_sync_echo_does_not_duplicate_the_sent_message(db):
+    """The whole point: send, then let the echo arrive the way it really does."""
+    draft = _approved_draft(db)
+    db.send_approved(draft["id"], transmit=_transmit_returning(SERVER_TS))
+    assert db.conn.count("messages") == 1
+
+    event = consumer.parse_envelope(_echo_envelope(timestamp=SERVER_TS))
+    echoed_id = db.upsert_message(event.message)
+
+    assert db.conn.count("messages") == 1
+    assert echoed_id == draft["id"]
+    row = db.conn.rows("SELECT * FROM signal.messages")[0]
+    assert row["is_outbound"]
+    assert row["message_timestamp"] == SERVER_TS
+
+
+def test_positive_control_an_unrelated_sync_message_does_insert(db):
+    """A bare 1 above would be indistinguishable from a substrate that stores nothing."""
+    draft = _approved_draft(db)
+    db.send_approved(draft["id"], transmit=_transmit_returning(SERVER_TS))
+    other = consumer.parse_envelope(_echo_envelope(timestamp=SERVER_TS + 1,
+                                                   body="a different message"))
+    db.upsert_message(other.message)
+    assert db.conn.count("messages") == 2
+
+
+def test_the_echo_reuses_the_senders_contact_row(db):
+    """The identity half of 🔧 #4.
+
+    The draft addressed the account by NUMBER (placeholder contact); the echo
+    arrives carrying the account's real UUID. If those became two contact rows,
+    the composite key would differ and dedupe would fail even with a correct
+    timestamp.
+    """
+    draft = _approved_draft(db)
+    db.send_approved(draft["id"], transmit=_transmit_returning(SERVER_TS))
+    contacts_before = db.conn.count("contacts")
+    event = consumer.parse_envelope(_echo_envelope(timestamp=SERVER_TS))
+    db.upsert_message(event.message)
+    assert db.conn.count("contacts") == contacts_before
+    rows = db.conn.rows("SELECT signal_uuid, is_placeholder FROM signal.contacts "
+                        "WHERE phone_number = ?", (SELF_NUMBER,))
+    assert len(rows) == 1
+    assert rows[0]["signal_uuid"] == SELF_UUID      # promoted, not duplicated
+    assert not rows[0]["is_placeholder"]
+
+
+def test_a_locally_generated_timestamp_would_duplicate(db):
+    """The failure this correction prevents, demonstrated rather than described.
+
+    Storing a LOCAL timestamp (what the draft proposal's send path would have
+    done) and then receiving the echo produces TWO rows. This is the shape of the
+    bug, made visible — an invariant guard on the alternative design.
+    """
+    draft = _approved_draft(db)
+    db.send_approved(draft["id"], transmit=_transmit_returning(LOCAL_TS))
+    event = consumer.parse_envelope(_echo_envelope(timestamp=SERVER_TS))
+    db.upsert_message(event.message)
+    assert db.conn.count("messages") == 2
+
+
+def test_send_refuses_a_non_positive_server_timestamp(db):
+    """A zero/negative timestamp would silently collide with the draft range."""
+    draft = _approved_draft(db)
+    with pytest.raises(ValueError) as exc:
+        db.send_approved(draft["id"], transmit=_transmit_returning(0))
+    assert "sync-echo dedupe" in str(exc.value)
+
+
+def test_draft_provisional_timestamp_cannot_be_positive(db):
+    with pytest.raises(ValueError) as exc:
+        db.draft_message(recipient=PEER_NUMBER, body="nope",
+                         self_number=SELF_NUMBER, provisional_timestamp=SERVER_TS)
+    assert "NEGATIVE" in str(exc.value)
+
+
+def test_two_pending_drafts_do_not_collide(db):
+    """Distinct provisional timestamps, or the second draft would be swallowed."""
+    a = db.draft_message(recipient=PEER_NUMBER, body="first",
+                         self_number=SELF_NUMBER, provisional_timestamp=-11)
+    b = db.draft_message(recipient=PEER_NUMBER, body="second",
+                         self_number=SELF_NUMBER, provisional_timestamp=-12)
+    assert a["id"] != b["id"]
+    assert db.conn.count("messages") == 2
+
+
+def test_echo_of_a_message_sent_from_another_device_is_stored_once(db):
+    """No draft involved at all: Zach types on his phone, the echo arrives twice."""
+    env = _echo_envelope(timestamp=1723000004242, body="typed on the phone")
+    first = db.upsert_message(consumer.parse_envelope(env).message)
+    second = db.upsert_message(consumer.parse_envelope(env).message)
+    assert first == second
+    assert db.conn.count("messages") == 1
+    row = db.conn.rows("SELECT is_outbound, body FROM signal.messages")[0]
+    assert row["is_outbound"]
+    assert row["body"] == "typed on the phone"
+
+
+def test_raw_envelope_of_the_echo_is_retained(db):
+    env = _echo_envelope(timestamp=1723000004343)
+    db.upsert_message(consumer.parse_envelope(env).message)
+    stored = db.conn.rows("SELECT raw_envelope FROM signal.messages")[0]
+    assert json.loads(stored["raw_envelope"])["timestamp"] == 1723000004343

--- a/scripts/signal/tests/test_outbound_echo.py
+++ b/scripts/signal/tests/test_outbound_echo.py
@@ -27,6 +27,11 @@ PEER_NUMBER = "+15550101"
 SERVER_TS = 1723000009090        # what the API assigns and the echo carries
 LOCAL_TS = 1723000007777         # deliberately DIFFERENT from SERVER_TS
 
+# 🔴 The API returns the timestamp as a STRING — upstream types it
+# `ds.SendMessageResponse.Timestamp string`. A fake returning an int would let a
+# caller that only handles ints pass here and fail against the real server, so
+# every fake below returns the string form.
+
 
 def _approved_draft(db, *, body="sent from my laptop"):
     draft = db.draft_message(recipient=PEER_NUMBER, body=body,
@@ -50,9 +55,10 @@ def _echo_envelope(*, timestamp, body="sent from my laptop"):
     }
 
 
-def _transmit_returning(ts):
-    def _t(auth, *, recipient, body):
-        return {"timestamp": ts}
+def _transmit_returning(ts, *, as_string=True):
+    def _t(auth, *, recipient, body, number):
+        assert number, "the server requires the sending `number` and 400s without it"
+        return {"timestamp": str(ts) if as_string else ts}
     return _t
 
 
@@ -161,6 +167,70 @@ def test_echo_of_a_message_sent_from_another_device_is_stored_once(db):
     row = db.conn.rows("SELECT is_outbound, body FROM signal.messages")[0]
     assert row["is_outbound"]
     assert row["body"] == "typed on the phone"
+
+
+def test_the_echo_then_draft_ORDER_also_resolves_to_one_contact(db):
+    """🔴 The ordering production actually takes, from day two.
+
+    The account's real uuid is already in `contacts` (any earlier sync echo put
+    it there). Then an agent drafts, supplying only the NUMBER. Without a lookup
+    by phone that mints a SECOND placeholder contact — and promotion correctly
+    declines, because the uuid is taken — so the send and the echo carry
+    different `source_contact_id`s and `unique_message` never fires. Every
+    agent-sent message would be stored twice.
+
+    The earlier test starts from an EMPTY contacts table, which is why it passed
+    while this case was broken.
+    """
+    # Day one: the account's own uuid is already known.
+    seed = _echo_envelope(timestamp=1723000003030, body="sent from the phone")
+    db.upsert_message(consumer.parse_envelope(seed).message)
+    contacts_after_seed = db.conn.count("contacts")
+    assert contacts_after_seed == 2                  # the account and the peer
+
+    # Day two: an agent drafts, knowing only the number.
+    draft = _approved_draft(db, body="drafted on day two")
+    assert db.conn.count("contacts") == contacts_after_seed   # NO rival identity
+    db.send_approved(draft["id"], transmit=_transmit_returning(SERVER_TS))
+
+    # And the echo of that send collapses onto the row it just wrote.
+    echo = _echo_envelope(timestamp=SERVER_TS, body="drafted on day two")
+    db.upsert_message(consumer.parse_envelope(echo).message)
+    assert db.conn.count("messages") == 2            # the seed and the sent one
+    assert db.conn.count("contacts") == contacts_after_seed
+
+
+def test_contact_lookup_by_phone_prefers_a_real_contact_over_a_placeholder(db):
+    """Deterministic, and in the right direction — an arbitrary pick would split."""
+    placeholder = db.upsert_contact(phone_number="+15557654321")
+    real = db.upsert_contact(signal_uuid="70707070-7070-4707-8707-707070707070",
+                             phone_number="+15557654321")
+    # The placeholder is PROMOTED rather than duplicated, so these are one row.
+    assert placeholder == real
+    assert db.contact_id_by_phone("+15557654321") == real
+
+
+def test_contact_lookup_is_deterministic_when_two_rows_share_a_number(db):
+    """Two rows CAN share a number, and the pick must not be arbitrary.
+
+    Reachable without contrivance: a real contact holds the number, then a second
+    real uuid arrives carrying the same number (a re-registration). Promotion
+    correctly declines — the first row is not a placeholder — so two rows exist.
+    An unordered `LIMIT 1` would then split the identity differently run to run.
+    """
+    first = db.upsert_contact(signal_uuid="60606060-6060-4606-8606-606060606060",
+                              phone_number="+15551239876")
+    second = db.upsert_contact(signal_uuid="61616161-6161-4616-8616-616161616161",
+                               phone_number="+15551239876")
+    assert first != second                      # genuinely two rows
+    assert db.conn.count("contacts") == 2
+    for _ in range(5):
+        assert db.contact_id_by_phone("+15551239876") == first   # stable, oldest
+
+
+def test_contact_lookup_by_phone_returns_none_for_an_unknown_number(db):
+    assert db.contact_id_by_phone("+15550000000") is None
+    assert db.contact_id_by_phone("") is None
 
 
 def test_raw_envelope_of_the_echo_is_retained(db):

--- a/scripts/signal/tests/test_outbound_echo.py
+++ b/scripts/signal/tests/test_outbound_echo.py
@@ -1,6 +1,6 @@
 """🔧 #4 — the outbound sync echo. The single most likely thing to be silently wrong.
 
-A message sent through the REST API comes BACK through the SSE stream as a sync
+A message sent through `/v2/send` comes BACK on the receive stream as a sync
 message from the account's own linked devices. `unique_message` catches that echo
 only if the send path recorded the SAME `(source_contact_id, message_timestamp)`
 the echo will carry — i.e. the SERVER-assigned timestamp, not a locally generated

--- a/scripts/signal/tests/test_reactions.py
+++ b/scripts/signal/tests/test_reactions.py
@@ -157,6 +157,68 @@ def test_reaction_requires_a_target_timestamp():
         consumer.parse_envelope(bad)
 
 
+# --------------------------------------------------------------------------- #
+# Remote delete — a retraction, not a message
+# --------------------------------------------------------------------------- #
+def test_remote_delete_tombstones_the_target_instead_of_storing_a_ghost(db):
+    """🔴 A `remoteDelete` is the SENDER RETRACTING a message.
+
+    Unrecognised, it falls through to the data-message path and is stored as an
+    empty-bodied message — a ghost row that also leaves the retracted text
+    sitting in the row it was meant to retract. Both halves are wrong.
+    """
+    db.upsert_message({**_message(uuid=ALICE, ts=TARGET_TS, body="please forget this"),
+                       "attachments": [{"id": "att-doomed", "content_type": "image/png",
+                                        "filename": "oops.png"}]})
+    assert db.conn.count("attachments") == 1
+
+    event = consumer.parse_envelope({
+        "sourceUuid": ALICE, "sourceNumber": "+15550101",
+        "timestamp": TARGET_TS + 50,
+        "dataMessage": {"timestamp": TARGET_TS + 50,
+                        "remoteDelete": {"targetSentTimestamp": TARGET_TS}},
+    })
+    assert event.kind == consumer.KIND_REMOTE_DELETE
+    assert db.apply_remote_delete(event.remote_delete) == 1
+
+    rows = db.conn.rows("SELECT body, message_type, raw_envelope FROM signal.messages")
+    assert len(rows) == 1                       # no ghost row was added
+    assert rows[0]["body"] is None              # the text is GONE
+    assert rows[0]["raw_envelope"] is None      # ... including from the raw copy
+    assert rows[0]["message_type"] == "deleted"
+    assert db.conn.count("attachments") == 0    # and its attachments with it
+
+
+def test_remote_delete_for_a_message_we_never_received_is_a_quiet_no_op(db):
+    event = consumer.parse_envelope({
+        "sourceUuid": ALICE, "timestamp": NEVER_SEEN_TS + 1,
+        "dataMessage": {"timestamp": NEVER_SEEN_TS + 1,
+                        "remoteDelete": {"targetSentTimestamp": NEVER_SEEN_TS}},
+    })
+    assert db.apply_remote_delete(event.remote_delete) == 0
+    assert db.conn.count("messages") == 0
+
+
+def test_remote_delete_does_not_touch_a_different_senders_message(db):
+    """POSITIVE CONTROL on the scoping: only the retractor's own row moves."""
+    db.upsert_message(_message(uuid=DANA, ts=TARGET_TS, body="someone else's message"))
+    event = consumer.parse_envelope({
+        "sourceUuid": ALICE, "timestamp": TARGET_TS + 60,
+        "dataMessage": {"timestamp": TARGET_TS + 60,
+                        "remoteDelete": {"targetSentTimestamp": TARGET_TS}},
+    })
+    assert db.apply_remote_delete(event.remote_delete) == 0
+    assert db.conn.rows("SELECT body FROM signal.messages")[0]["body"] == \
+        "someone else's message"
+
+
+def test_remote_delete_without_a_target_is_malformed():
+    with pytest.raises(consumer.MalformedEvent):
+        consumer.parse_envelope({
+            "sourceUuid": ALICE, "timestamp": 1,
+            "dataMessage": {"timestamp": 1, "remoteDelete": {}}})
+
+
 def test_reactions_unique_constraint_is_live(db):
     author = db.upsert_contact(signal_uuid=ALICE)
     reactor = db.upsert_contact(signal_uuid=CARL)

--- a/scripts/signal/tests/test_reactions.py
+++ b/scripts/signal/tests/test_reactions.py
@@ -189,6 +189,51 @@ def test_remote_delete_tombstones_the_target_instead_of_storing_a_ghost(db):
     assert db.conn.count("attachments") == 0    # and its attachments with it
 
 
+def test_a_retraction_made_on_ZACHS_OWN_PHONE_is_honoured(db):
+    """🔴 The own-device direction, which arrives wrapped in `syncMessage`.
+
+    The sync branch runs BEFORE the inbound `dataMessage` branch, so a retraction
+    Zach makes on his own phone never reached the remote-delete handler: both
+    defects it exists to prevent — the ghost row AND the retained retracted text
+    — survived in that direction, while SKILL.md claimed retractions were
+    honoured full stop.
+    """
+    self_uuid = "90909090-9090-4909-8909-909090909090"
+    target_ts = 1723250000001
+    sent = consumer.parse_envelope({
+        "sourceUuid": self_uuid, "sourceNumber": "+15559090",
+        "timestamp": target_ts,
+        "syncMessage": {"sentMessage": {
+            "timestamp": target_ts, "destination": "+15550101",
+            "message": "typed on my phone, then retracted"}},
+    })
+    db.upsert_message(sent.message)
+    assert db.conn.count("messages") == 1
+
+    retraction = consumer.parse_envelope({
+        "sourceUuid": self_uuid, "sourceNumber": "+15559090",
+        "timestamp": target_ts + 5,
+        "syncMessage": {"sentMessage": {
+            "timestamp": target_ts + 5, "destination": "+15550101",
+            "remoteDelete": {"targetSentTimestamp": target_ts}}},
+    })
+    assert retraction.kind == consumer.KIND_REMOTE_DELETE
+    assert retraction.message is None
+    assert db.apply_remote_delete(retraction.remote_delete) == 1
+
+    rows = db.conn.rows("SELECT body, message_type FROM signal.messages")
+    assert len(rows) == 1
+    assert rows[0]["body"] is None
+    assert rows[0]["message_type"] == "deleted"
+
+
+def test_a_sync_remote_delete_without_a_target_is_malformed():
+    with pytest.raises(consumer.MalformedEvent):
+        consumer.parse_envelope({
+            "sourceUuid": ALICE, "timestamp": 1,
+            "syncMessage": {"sentMessage": {"timestamp": 1, "remoteDelete": {}}}})
+
+
 def test_remote_delete_for_a_message_we_never_received_is_a_quiet_no_op(db):
     event = consumer.parse_envelope({
         "sourceUuid": ALICE, "timestamp": NEVER_SEEN_TS + 1,

--- a/scripts/signal/tests/test_reactions.py
+++ b/scripts/signal/tests/test_reactions.py
@@ -1,0 +1,170 @@
+"""🔧 #3 — reactions can arrive BEFORE their target, or target nothing we have.
+
+SSE ordering is not guaranteed and history is not backfilled, so a hard FK at
+insert time silently drops reactions. `message_id` is therefore NULLable and
+resolved later; the partial index `idx_rx_unresolved` is what keeps the
+resolution sweep from scanning the whole table.
+"""
+import sqlite3
+
+import pytest
+
+import consumer
+
+ALICE = "11111111-1111-4111-8111-111111111111"
+CARL = "33333333-3333-4333-8333-333333333333"
+DANA = "44444444-4444-4444-8444-444444444444"
+TARGET_TS = 1723200000101
+NEVER_SEEN_TS = 1723200000999
+
+
+def _reaction(*, reactor, author, ts, emoji="🔥", remove=False):
+    return {"source_uuid": reactor, "target_author_uuid": author,
+            "target_sent_timestamp": ts, "emoji": emoji, "is_remove": remove}
+
+
+def _message(*, uuid, ts, body="target message"):
+    return {"message_timestamp": ts, "source_uuid": uuid,
+            "message_type": consumer.KIND_MESSAGE, "body": body}
+
+
+# --------------------------------------------------------------------------- #
+def test_reaction_after_its_target_resolves_immediately(db):
+    """POSITIVE CONTROL for the whole suite: the in-order case must work."""
+    db.upsert_message(_message(uuid=ALICE, ts=TARGET_TS))
+    db.upsert_reaction(_reaction(reactor=CARL, author=ALICE, ts=TARGET_TS))
+    row = db.conn.rows("SELECT message_id FROM signal.reactions")[0]
+    assert row["message_id"] is not None
+    assert db.unresolved_reactions() == []
+
+
+def test_reaction_before_its_target_is_retained_then_resolved(db):
+    """The out-of-order case the correction exists for."""
+    db.upsert_reaction(_reaction(reactor=CARL, author=ALICE, ts=TARGET_TS))
+    assert db.conn.count("reactions") == 1
+    pending = db.unresolved_reactions()
+    assert len(pending) == 1 and pending[0]["emoji"] == "🔥"
+
+    message_id = db.upsert_message(_message(uuid=ALICE, ts=TARGET_TS))
+
+    assert db.unresolved_reactions() == []
+    row = db.conn.rows("SELECT message_id FROM signal.reactions")[0]
+    assert row["message_id"] == message_id
+
+
+def test_reaction_to_a_never_received_message_is_kept_not_dropped(db):
+    db.upsert_reaction(_reaction(reactor=DANA, author=ALICE, ts=NEVER_SEEN_TS,
+                                 emoji="👀"))
+    # An UNRELATED message arriving must not resolve it...
+    db.upsert_message(_message(uuid=ALICE, ts=TARGET_TS))
+    assert len(db.unresolved_reactions()) == 1
+    # ... and the row is still there, with its content intact.
+    row = db.conn.rows("SELECT emoji, target_sent_timestamp FROM signal.reactions "
+                       "WHERE message_id IS NULL")[0]
+    assert row["emoji"] == "👀"
+    assert row["target_sent_timestamp"] == NEVER_SEEN_TS
+
+
+def test_resolution_is_scoped_to_the_right_author(db):
+    """A same-timestamp message from a DIFFERENT author must not steal the reaction."""
+    db.upsert_reaction(_reaction(reactor=CARL, author=ALICE, ts=TARGET_TS))
+    db.upsert_message(_message(uuid=DANA, ts=TARGET_TS, body="coincidence"))
+    assert len(db.unresolved_reactions()) == 1
+    db.upsert_message(_message(uuid=ALICE, ts=TARGET_TS))
+    assert db.unresolved_reactions() == []
+
+
+def test_remove_reaction_updates_the_existing_row(db):
+    db.upsert_message(_message(uuid=ALICE, ts=TARGET_TS))
+    db.upsert_reaction(_reaction(reactor=CARL, author=ALICE, ts=TARGET_TS,
+                                 emoji="😂"))
+    db.upsert_reaction(_reaction(reactor=CARL, author=ALICE, ts=TARGET_TS,
+                                 emoji="😂", remove=True))
+    assert db.conn.count("reactions") == 1          # updated, not appended
+    row = db.conn.rows("SELECT is_remove FROM signal.reactions")[0]
+    assert row["is_remove"]
+
+
+def test_two_people_reacting_are_two_rows(db):
+    """POSITIVE CONTROL for the 'one row' claim above."""
+    db.upsert_message(_message(uuid=ALICE, ts=TARGET_TS))
+    db.upsert_reaction(_reaction(reactor=CARL, author=ALICE, ts=TARGET_TS))
+    db.upsert_reaction(_reaction(reactor=DANA, author=ALICE, ts=TARGET_TS,
+                                 emoji="🎉"))
+    assert db.conn.count("reactions") == 2
+
+
+def test_redelivered_reaction_does_not_duplicate(db):
+    db.upsert_message(_message(uuid=ALICE, ts=TARGET_TS))
+    rx = _reaction(reactor=CARL, author=ALICE, ts=TARGET_TS)
+    first = db.upsert_reaction(dict(rx))
+    second = db.upsert_reaction(dict(rx))
+    assert first == second
+    assert db.conn.count("reactions") == 1
+
+
+def test_resolve_pending_reactions_reports_how_many_it_moved(db):
+    db.upsert_reaction(_reaction(reactor=CARL, author=ALICE, ts=TARGET_TS))
+    db.upsert_reaction(_reaction(reactor=DANA, author=ALICE, ts=TARGET_TS,
+                                 emoji="🎉"))
+    author_id = db.upsert_contact(signal_uuid=ALICE)
+    assert len(db.unresolved_reactions()) == 2
+
+    # Insert the target row directly, so the sweep's OWN return value is what is
+    # being read (going through upsert_message would resolve them as a side
+    # effect and the count would always be 0 — a zero proving nothing).
+    db.conn.raw.execute(
+        "INSERT INTO signal.messages (message_timestamp, source_contact_id, "
+        "message_type) VALUES (?, ?, 'message')", (TARGET_TS, author_id))
+    message_id = db.conn.rows("SELECT id FROM signal.messages")[0]["id"]
+
+    moved = db.resolve_pending_reactions(
+        message_id=message_id, target_author_id=author_id,
+        target_sent_timestamp=TARGET_TS)
+    assert moved == 2
+    assert db.resolve_pending_reactions(
+        message_id=message_id, target_author_id=author_id,
+        target_sent_timestamp=TARGET_TS) == 0        # idempotent
+    assert db.unresolved_reactions() == []
+
+
+def test_the_partial_index_exists_and_is_scoped_to_unresolved_rows(db):
+    """The index the resolution sweep depends on, read from the live schema."""
+    ddl = db.conn.rows(
+        "SELECT sql FROM signal.sqlite_master WHERE name = 'idx_rx_unresolved'")
+    assert len(ddl) == 1
+    sql = ddl[0]["sql"]
+    assert "message_id IS NULL" in sql
+    assert "target_author_id" in sql and "target_sent_timestamp" in sql
+
+
+def test_the_partial_index_is_actually_used_by_the_sweep(db):
+    """Not just present — CHOSEN. A partial index nothing plans against is decoration."""
+    author_id = db.upsert_contact(signal_uuid=ALICE)
+    plan = db.conn.rows(
+        "EXPLAIN QUERY PLAN SELECT id FROM signal.reactions "
+        "WHERE message_id IS NULL AND target_author_id = ? "
+        "AND target_sent_timestamp = ?", (author_id, TARGET_TS))
+    detail = " ".join(str(r.get("detail", "")) for r in plan)
+    assert "idx_rx_unresolved" in detail, detail
+
+
+def test_reaction_requires_a_target_timestamp():
+    bad = {"source": "+15550303", "timestamp": 1723200000303,
+           "dataMessage": {"timestamp": 1723200000303,
+                           "reaction": {"emoji": "x", "targetAuthor": "+1"}}}
+    with pytest.raises(consumer.MalformedEvent):
+        consumer.parse_envelope(bad)
+
+
+def test_reactions_unique_constraint_is_live(db):
+    author = db.upsert_contact(signal_uuid=ALICE)
+    reactor = db.upsert_contact(signal_uuid=CARL)
+    db.conn.raw.execute(
+        "INSERT INTO signal.reactions (target_author_id, target_sent_timestamp, "
+        "emoji, contact_id) VALUES (?, ?, '🔥', ?)", (author, TARGET_TS, reactor))
+    with pytest.raises(sqlite3.IntegrityError):
+        db.conn.raw.execute(
+            "INSERT INTO signal.reactions (target_author_id, target_sent_timestamp, "
+            "emoji, contact_id) VALUES (?, ?, '🎉', ?)",
+            (author, TARGET_TS, reactor))

--- a/scripts/signal/tests/test_reactions.py
+++ b/scripts/signal/tests/test_reactions.py
@@ -1,6 +1,6 @@
 """🔧 #3 — reactions can arrive BEFORE their target, or target nothing we have.
 
-SSE ordering is not guaranteed and history is not backfilled, so a hard FK at
+Delivery ordering is not guaranteed and history is not backfilled, so a hard FK
 insert time silently drops reactions. `message_id` is therefore NULLable and
 resolved later; the partial index `idx_rx_unresolved` is what keeps the
 resolution sweep from scanning the whole table.

--- a/scripts/signal/tests/test_search.py
+++ b/scripts/signal/tests/test_search.py
@@ -1,0 +1,144 @@
+"""Full-text search — what is actually verified here, and what is NOT.
+
+🔴 SCOPE, stated up front so no assertion below is read for more than it measured.
+The substrate is sqlite, which has no `tsvector`. `search @@
+websearch_to_tsquery('english', %s)` is rewritten by `fakepg` to a
+`pg_websearch_match(body, ?)` shim doing AND-of-terms substring matching. So:
+
+* VERIFIED here — the query targets the generated `search` column via
+  `websearch_to_tsquery`, the user's text is a BOUND PARAMETER (never
+  interpolated), the join/order/limit are right, and matching rows come back
+  while non-matching ones do not.
+* NOT verified here — Postgres stemming ("meeting" matching "meetings"),
+  ranking, or the GIN index being chosen. Those need the live database
+  (deployment step 7) and no test in this repo claims them.
+
+Every zero below is preceded by a positive control on the same query path.
+"""
+import consumer
+
+ALICE = "11111111-1111-4111-8111-111111111111"
+BOB = "22222222-2222-4222-8222-222222222222"
+
+
+def _seed(db):
+    db.upsert_contact(signal_uuid=ALICE, display_name="Alice Adler",
+                      phone_number="+15550101")
+    db.upsert_contact(signal_uuid=BOB, display_name="Bo Brennan",
+                      phone_number="+15550202")
+    rows = [
+        (ALICE, 1723300000001, "the harbour permit expires in march"),
+        (ALICE, 1723300000002, "bring the projector to the workshop"),
+        (BOB, 1723300000003, "workshop moved to the annex"),
+        (BOB, 1723300000004, "nothing to do with any of that"),
+    ]
+    for uuid, ts, body in rows:
+        db.upsert_message({"message_timestamp": ts, "source_uuid": uuid,
+                           "message_type": consumer.KIND_MESSAGE, "body": body})
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# Instrument validation: the query path CAN return non-zero, and CAN return zero.
+# --------------------------------------------------------------------------- #
+def test_positive_control_a_term_that_must_match_returns_rows(db):
+    _seed(db)
+    hits = db.search("projector")
+    assert len(hits) == 1
+    assert hits[0]["body"] == "bring the projector to the workshop"
+
+
+def test_a_term_present_in_no_message_returns_zero(db):
+    """Meaningful only because the control above moved the same counter."""
+    _seed(db)
+    assert db.search("submarine") == []
+
+
+# --------------------------------------------------------------------------- #
+# Behaviour
+# --------------------------------------------------------------------------- #
+def test_search_returns_every_matching_row(db):
+    _seed(db)
+    hits = db.search("workshop")
+    assert len(hits) == 2
+    assert {h["message_timestamp"] for h in hits} == {1723300000002, 1723300000003}
+
+
+def test_search_orders_newest_first(db):
+    _seed(db)
+    hits = db.search("workshop")
+    stamps = [h["message_timestamp"] for h in hits]
+    assert stamps == sorted(stamps, reverse=True)
+
+
+def test_search_respects_its_limit(db):
+    _seed(db)
+    assert len(db.search("workshop", limit=1)) == 1
+
+
+def test_search_joins_the_sender_identity(db):
+    _seed(db)
+    hit = db.search("harbour")[0]
+    assert hit["display_name"] == "Alice Adler"
+    assert hit["phone_number"] == "+15550101"
+
+
+def test_search_finds_outbound_messages_too(db):
+    """A sent message must be searchable, or half the conversation is invisible."""
+    _seed(db)
+    draft = db.draft_message(recipient="+15550101", body="I filed the harbour permit",
+                             self_number="+15559090")
+    db.approve_draft(draft["id"], approval_ref="cg-search")
+    db.send_approved(draft["id"],
+                     transmit=lambda auth, recipient, body: {"timestamp": 1723300009999})
+    bodies = [h["body"] for h in db.search("permit")]
+    assert "I filed the harbour permit" in bodies
+    assert any(h["is_outbound"] for h in db.search("permit"))
+
+
+# --------------------------------------------------------------------------- #
+# The SQL itself — the parts sqlite cannot speak for
+# --------------------------------------------------------------------------- #
+def test_search_sql_targets_the_generated_column_via_websearch_to_tsquery(recording):
+    db, conn = recording
+    db.search("anything at all")
+    sql, params = conn.executed[-1]
+    assert "m.search @@ websearch_to_tsquery('english', %s)" in sql
+    assert "FROM signal.messages m" in sql
+
+
+def test_search_binds_the_query_text_rather_than_interpolating_it(recording):
+    """The injection guard. A f-string here would put user text in the SQL."""
+    db, conn = recording
+    nasty = "'); DROP TABLE signal.messages; --"
+    db.search(nasty, limit=7)
+    sql, params = conn.executed[-1]
+    assert nasty not in sql
+    assert params == (nasty, 7)
+
+
+def test_list_conversations_groups_by_conversation_and_orders_by_recency(db):
+    _seed(db)
+    convs = db.list_conversations()
+    assert len(convs) == 2                         # two DM peers, no groups
+    stamps = [c["last_message_timestamp"] for c in convs]
+    assert stamps == sorted(stamps, reverse=True)
+    by_name = {c["display_name"]: c for c in convs}
+    assert by_name["Alice Adler"]["message_count"] == 2
+    assert by_name["Bo Brennan"]["message_count"] == 2
+
+
+def test_list_conversations_separates_a_group_from_its_members_dms(db):
+    _seed(db)
+    db.upsert_message({"message_timestamp": 1723300000005, "source_uuid": ALICE,
+                       "message_type": consumer.KIND_GROUP_MESSAGE,
+                       "body": "in the group now",
+                       "group_id": b"group-annex", "group_name": "Annex Crew"})
+    convs = db.list_conversations()
+    assert len(convs) == 3
+    assert any(c["group_name"] == "Annex Crew" for c in convs)
+
+
+def test_list_conversations_respects_its_limit(db):
+    _seed(db)
+    assert len(db.list_conversations(limit=1)) == 1

--- a/scripts/signal/tests/test_search.py
+++ b/scripts/signal/tests/test_search.py
@@ -90,7 +90,7 @@ def test_search_finds_outbound_messages_too(db):
                              self_number="+15559090")
     db.approve_draft(draft["id"], approval_ref="cg-search")
     db.send_approved(draft["id"],
-                     transmit=lambda auth, recipient, body: {"timestamp": 1723300009999})
+                     transmit=lambda auth, recipient, body, number: {"timestamp": "1723300009999"})
     bodies = [h["body"] for h in db.search("permit")]
     assert "I filed the harbour permit" in bodies
     assert any(h["is_outbound"] for h in db.search("permit"))
@@ -142,3 +142,57 @@ def test_list_conversations_separates_a_group_from_its_members_dms(db):
 def test_list_conversations_respects_its_limit(db):
     _seed(db)
     assert len(db.list_conversations(limit=1)) == 1
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 A conversation is a PEER, not a sender
+# --------------------------------------------------------------------------- #
+def test_both_halves_of_a_dm_are_ONE_conversation(db):
+    """Grouping by `source_contact_id` splits a DM into two rows.
+
+    Alice's message and the reply to Alice are the same conversation. Keyed on
+    the sender they are two — and worse, every outbound message in the database
+    collapses into a single "me" row, so the list is useless the moment anything
+    is sent.
+    """
+    _seed(db)
+    before = len(db.list_conversations())
+
+    draft = db.draft_message(recipient="+15550101", body="replying to Alice",
+                             self_number="+15559090")
+    db.approve_draft(draft["id"], approval_ref="cg-conv")
+    db.send_approved(draft["id"],
+                     transmit=lambda a, **kw: {"timestamp": "1723300009001"})
+
+    convs = db.list_conversations()
+    assert len(convs) == before                # the reply joined Alice's thread
+    alice = [c for c in convs if c["phone_number"] == "+15550101"]
+    assert len(alice) == 1
+    assert alice[0]["message_count"] == 3      # her two, plus the reply
+
+
+def test_outbound_to_two_people_are_two_conversations(db):
+    """... and outbound does NOT collapse into one 'me' row."""
+    _seed(db)
+    for peer, ts in (("+15550101", "1723300009101"), ("+15550202", "1723300009202")):
+        draft = db.draft_message(recipient=peer, body=f"note to {peer}",
+                                 self_number="+15559090")
+        db.approve_draft(draft["id"], approval_ref=f"cg-{peer}")
+        db.send_approved(draft["id"], transmit=lambda a, **kw: {"timestamp": ts})
+
+    convs = db.list_conversations()
+    peers = {c["phone_number"] for c in convs}
+    assert {"+15550101", "+15550202"} <= peers
+    assert "+15559090" not in peers            # the account is never its own peer
+
+
+def test_a_group_is_its_own_conversation_regardless_of_who_spoke(db):
+    _seed(db)
+    for uuid, ts in ((ALICE, 1723300000501), (BOB, 1723300000502)):
+        db.upsert_message({"message_timestamp": ts, "source_uuid": uuid,
+                           "message_type": consumer.KIND_GROUP_MESSAGE,
+                           "body": "in the group", "group_id": b"group-one",
+                           "group_name": "Group One"})
+    groups = [c for c in db.list_conversations() if c["group_name"] == "Group One"]
+    assert len(groups) == 1
+    assert groups[0]["message_count"] == 2

--- a/scripts/signal/tests/test_skill_doc.py
+++ b/scripts/signal/tests/test_skill_doc.py
@@ -164,6 +164,27 @@ def test_skill_documents_every_table_the_schema_creates():
         assert f"`signal.{table}`" in SKILL_TEXT, f"table {table} undocumented"
 
 
+def test_reconcile_sent_without_a_timestamp_is_a_REFUSAL_not_a_traceback():
+    """🟢 F3 — `--timestamp` is conditionally required and argparse cannot say so.
+
+    `_server_timestamp` raises a plain `ValueError` and `main` caught only
+    `SendGateError`, so "refuses rather than guessing" was true but arrived as a
+    traceback and an exit code nobody scripts on. Driven through `main()` here,
+    which is the surface an operator actually touches.
+    """
+    import consumer as consumer_module
+
+    argv = ["reconcile", "7", "--sent"]
+    args = consumer_module.build_parser().parse_args(argv)
+    assert args.sent is True and args.timestamp is None   # argparse allows it ...
+
+    src = _read(SIGNAL_DIR / "consumer.py")
+    branch = src.split('elif args.cmd == "reconcile":')[1].split("\n        elif ")[0]
+    assert "if args.sent and not args.timestamp:" in branch   # ... main refuses it
+    assert "return 3" in branch
+    assert "(SendGateError, ValueError)" in branch
+
+
 def test_skill_names_the_bucket_the_code_uses():
     import _minio
     assert f"`{_minio.BUCKET}`" in SKILL_TEXT

--- a/scripts/signal/tests/test_skill_doc.py
+++ b/scripts/signal/tests/test_skill_doc.py
@@ -1,0 +1,178 @@
+"""SKILL.md must document the surface the CODE actually has — derived, not restated.
+
+🔴 Every ledger below is built by `re.findall` over the MODULE SOURCE. A
+hand-written list of kinds/commands/env vars could not catch the thing this file
+exists to catch: a surface added to the code and never documented, so an agent
+reading SKILL.md cannot find it. (`browser-bridge/tests/test_surface_parity.py`
+is the precedent; `context` once shipped dead for exactly this reason.)
+
+Each parser asserts a NON-EMPTY, plausible-cardinality result before any parity
+claim is made — a regex that silently matched nothing would make every assertion
+here pass vacuously.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+import consumer
+
+SIGNAL_DIR = Path(consumer.__file__).resolve().parent
+REPO = SIGNAL_DIR.parents[1]
+SKILL = REPO / "claude" / "skills" / "signal" / "SKILL.md"
+
+# Plausible floors. NOT the contract (the derived sets are) — they exist so a
+# broken regex fails as "the harness is broken" rather than passing silently.
+MIN_KINDS = 8
+MIN_STATS = 5
+MIN_COMMANDS = 6
+MIN_ENV_VARS = 8
+
+
+def _read(path: Path) -> str:
+    if not path.is_file():
+        raise AssertionError(
+            f"HARNESS BROKEN: {path} does not exist — a parity test cannot be "
+            f"green against a source it never read")
+    return path.read_text(encoding="utf-8")
+
+
+SKILL_TEXT = _read(SKILL)
+CONSUMER_SRC = _read(SIGNAL_DIR / "consumer.py")
+
+
+def _kinds() -> set:
+    found = set(re.findall(r'^KIND_[A-Z_]+ = "([a-z_]+)"', CONSUMER_SRC, re.MULTILINE))
+    assert len(found) >= MIN_KINDS, f"HARNESS BROKEN: parsed {found}"
+    return found
+
+
+def _stats() -> set:
+    found = set(re.findall(r'^STAT_[A-Z_]+ = "([a-z_]+)"', CONSUMER_SRC, re.MULTILINE))
+    assert len(found) >= MIN_STATS, f"HARNESS BROKEN: parsed {found}"
+    return found
+
+
+def _commands() -> set:
+    found = set(re.findall(r'sub\.add_parser\(\s*"([a-z-]+)"', CONSUMER_SRC))
+    assert len(found) >= MIN_COMMANDS, f"HARNESS BROKEN: parsed {found}"
+    return found
+
+
+def _env_vars() -> set:
+    found = set()
+    for path in sorted(SIGNAL_DIR.glob("*.py")):
+        src = _read(path)
+        found |= set(re.findall(r'os\.environ\.get\(\s*"([A-Z_]+)"', src))
+    assert len(found) >= MIN_ENV_VARS, f"HARNESS BROKEN: parsed {found}"
+    return found
+
+
+# --------------------------------------------------------------------------- #
+# Harness self-checks
+# --------------------------------------------------------------------------- #
+def test_skill_file_exists_and_is_substantial():
+    assert len(SKILL_TEXT) > 2000
+
+
+def test_parsers_return_the_values_the_module_really_uses():
+    """POSITIVE CONTROL: the derived sets match the module's own attributes."""
+    assert _kinds() == {v for k, v in vars(consumer).items()
+                        if k.startswith("KIND_") and isinstance(v, str)}
+    assert _stats() == {v for k, v in vars(consumer).items()
+                        if k.startswith("STAT_") and isinstance(v, str)}
+
+
+def test_parsers_fail_loudly_on_a_source_they_cannot_read(tmp_path):
+    """NEGATIVE CONTROL: `_read` raises rather than returning an empty string."""
+    with pytest.raises(AssertionError):
+        _read(tmp_path / "definitely-absent.md")
+
+
+# --------------------------------------------------------------------------- #
+# Parity
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("kind", sorted(_kinds()))
+def test_every_event_kind_is_documented(kind):
+    assert f"`{kind}`" in SKILL_TEXT, (
+        f"event kind {kind!r} is emitted by consumer.py but absent from SKILL.md")
+
+
+@pytest.mark.parametrize("stat", sorted(_stats()))
+def test_every_counter_is_documented(stat):
+    assert f"`{stat}`" in SKILL_TEXT, (
+        f"counter {stat!r} is reported by the daemon but absent from SKILL.md")
+
+
+@pytest.mark.parametrize("cmd", sorted(_commands()))
+def test_every_cli_command_is_documented(cmd):
+    assert f"`{cmd}`" in SKILL_TEXT, (
+        f"CLI command {cmd!r} exists but is absent from SKILL.md")
+
+
+@pytest.mark.parametrize("var", sorted(_env_vars()))
+def test_every_environment_variable_is_documented(var):
+    assert f"`{var}`" in SKILL_TEXT, (
+        f"env var {var!r} is read by scripts/signal/ but absent from SKILL.md")
+
+
+def test_documented_kinds_do_not_exceed_what_the_module_emits():
+    """The other direction: SKILL.md must not advertise a kind that does not exist."""
+    table = SKILL_TEXT.split("## Event kinds")[1].split("\n##")[0]
+    documented = set(re.findall(r"^\| `([a-z_]+)` \|", table, re.MULTILINE))
+    assert documented == _kinds()
+
+
+def test_documented_commands_do_not_exceed_the_cli():
+    table = SKILL_TEXT.split("## Commands")[1].split("\n##")[0]
+    documented = set(re.findall(r"^\| `([a-z-]+)` \|", table, re.MULTILINE))
+    assert documented == _commands()
+
+
+# --------------------------------------------------------------------------- #
+# The claims the skill makes about behaviour must still be true
+# --------------------------------------------------------------------------- #
+def test_skill_frontmatter_is_routing_surface():
+    head = SKILL_TEXT.split("---")[1]
+    assert "name: signal" in head
+    desc = re.search(r'description: "(.*)"', head, re.DOTALL).group(1)
+    assert len(desc) <= 1536                       # the per-entry listing cap
+    assert "Signal" in desc
+    assert "mailbox" in desc                       # disambiguation from the sibling
+    assert "draft" in desc.lower()
+
+
+def test_skill_states_the_send_path_is_gated_not_direct():
+    assert "SendGateError" in SKILL_TEXT
+    assert "DRAFT" in SKILL_TEXT and "APPROVE" in SKILL_TEXT
+    assert "never direct-send" in SKILL_TEXT
+
+
+def test_skill_names_the_error_type_the_code_actually_raises():
+    """A doc naming a non-existent exception is worse than naming none."""
+    import _signal_db
+    assert hasattr(_signal_db, "SendGateError")
+    assert issubclass(_signal_db.SendGateError, RuntimeError)
+
+
+def test_skill_documents_every_table_the_schema_creates():
+    import _signal_db
+    tables = set(re.findall(r"CREATE TABLE IF NOT EXISTS signal\.(\w+)",
+                            "\n".join(_signal_db.SCHEMA_STATEMENTS)))
+    assert len(tables) == 5, tables
+    for table in tables:
+        assert f"`signal.{table}`" in SKILL_TEXT, f"table {table} undocumented"
+
+
+def test_skill_names_the_bucket_the_code_uses():
+    import _minio
+    assert f"`{_minio.BUCKET}`" in SKILL_TEXT
+
+
+def test_skill_records_all_four_schema_corrections():
+    """Each 🔧 correction is a live gotcha, so each must be in the gotchas list."""
+    gotchas = SKILL_TEXT.split("## ⚠ Gotchas")[1]
+    assert "does not dedupe over NULL" in gotchas
+    assert "echo back via device sync" in gotchas
+    assert "Reactions can precede their target" in gotchas
+    assert "signal_attachment_id" in gotchas


### PR DESCRIPTION
The **devrc half** of `claudedocs/proposal-signal-chat-skill.md` (§2–§7). The
`homelab-talos` Flux manifests are Agent 2's separate PR.

> **Commit 2 is an audit rework.** The audit found the module was written against **two
> mutually exclusive servers**; both of its 🔴 findings were re-verified against upstream
> source before any code moved, and both were real. Details below.

```
scripts/signal/consumer.py     receive daemon + CLI (run/conversations/search/draft/drafts/approve/send)
scripts/signal/_signal_db.py   the `signal` schema and every read/write
scripts/signal/_minio.py       attachments -> bucket `signal-attachments`
scripts/signal/clawgate.py     a draft's approval card (graceful no-op without a token)
scripts/signal/tests/          10 suites, 340 tests, hermetic
claude/skills/signal/SKILL.md  the agent-facing surface
scripts/run-tests.sh           the new target, registered in BOTH lists
```

## The API contract — verified against upstream, not recalled

Read from `bbernhard/signal-cli-rest-api` via `gh api`:

| Fact | Source |
|---|---|
| the WHOLE route table is `v1.GET("/receive/:number")`, `v1.GET("/attachments/:attachment")`, `v2.POST("/send")` | `src/main.go` |
| **there is no `/api/v1/events` and no SSE endpoint** — that path is AsamK's *native* daemon, a different server | `src/main.go` |
| in json-rpc mode `/v1/receive/{number}` **upgrades to a websocket** and writes one JSON text frame per message | `src/api/api.go` — `connectionUpgrader.Upgrade(...)`, then `ws.WriteMessage(websocket.TextMessage, …)` |
| `POST /v2/send` **requires `number`**; empty returns 400 `"Couldn't process request - please provide a valid number"` | `src/api/api.go` `SendV2` |
| the send response types `timestamp` as a **string** | `src/datastructs/datastructs.go` `SendMessageResponse` |

The first revision took ingest from one server and send/attachments from the other:
against what we deploy that is a **404 per connect**, swallowed by the reconnect handler
into a silent infinite loop with zero rows ingested — and **every send a 400**, so the D3
path was entirely inert. Ingest is now the websocket on `/v1/receive/{number}` (with the
REST array the same path returns in the other mode also accepted, so the core stays
transport-agnostic and hermetic), and the send body carries `number`.
`test_the_module_targets_the_bbernhard_route_table_only` pins the route table.

## Five more defects the rework fixes

- **Aborted-transaction zombie.** `autocommit=False` + Postgres: the first failed statement
  aborts the transaction and every later one raises `InFailedSqlTransaction` — not in
  `TRANSIENT_DB_ERRORS`, so it escaped into the reconnect handler and was miscounted as a
  dropped stream. The pod would log "reconnecting" forever and store nothing. Now
  `rollback()`/`recover()` (reconnecting when a rollback cannot help), recovery inside the
  retry on **both** the transient and fatal paths, and the class in the tuple. The sqlite
  substrate was autocommit and **structurally could not reach this**, so it now emulates the
  Postgres abort rule — validated by its own instrument test before anything reads it.
- **Send write-back was not atomic.** Any failure after the POST left `approved` + the
  provisional timestamp, so the gate would mint a fresh capability and **send the same text
  again**. The draft is now claimed as `sending` and **committed** before the POST; nothing
  can mint from `sending`.
- **Contact identity split in the order production actually takes.** With the account's real
  uuid already known (true from day two), a draft supplying only the number minted a second
  placeholder — promotion correctly declines — so send and echo carried different
  `source_contact_id`s and dedupe never fired: **every agent-sent message stored twice**. The
  old test passed only because its fixture started from an empty contacts table.
- **MinIO key collisions.** Two `Screenshot.png` in one day mapped to one key, the second
  write was skipped as "already there", and its row pointed at the first file's bytes. The
  attachment id is now part of the key.
- **`remoteDelete` stored as an empty message** — a ghost row that also left the retracted
  text in place. Now its own kind, tombstoning the target and its attachments.

Lower-priority items: `approve` requires `SIGNAL_APPROVAL_TOKEN` (operator-only) and the
clawgate card no longer prints the approval command it was handing the drafting agent —
with the residual limit stated plainly, since **nothing in-process can prove a human called
it**; `list_conversations` keys on the PEER (a DM is one row; outbound no longer collapses
into one "me"); retention is documented as NOT implemented rather than left to be found.

## Two surviving mutants the previous sweep reported as 0

Both confirmed and closed:

1. The send-endpoint ledger grepped for the **identifier** `SEND_PATH`, so a `quick_send()`
   posting to the **literal** with no gate call was invisible to it. Replaced with an AST
   walk recognising both spellings in every function of every module (excluding docstrings
   and `raise` messages — prose is not a door), plus an assertion that every function in the
   ledger calls `spend_authorization`.
2. `COALESCE(messages.body, EXCLUDED.body)` survived an **operand swap** because the only
   fixture redelivered a body of `None` — with one side null both orderings agree. Added the
   distinguishing case, and the same trap was then found and closed on `server_delivered_at`.

## Evidence

| Check | Result |
|---|---|
| `scripts/gate.sh --tier pytest --set hermetic` | `GATE: RESULT=PASS exit=0` |
| `nix build .#checks.x86_64-linux.pytests` | `RESULT: PASS (exit=0)` |
| this target, **both** tiers | `PASS scripts/signal/tests (collected=340 passed=340 skipped=0 floor=323)` |
| hermeticity (GUARD 7) | `intercepted=0 systemctl-reads=0` |
| mutation battery | **41 mutants, 0 survivors** |
| pyright | zero non-import diagnostics |

The floor was **measured**: pinned at `1` so the gate printed its own replacement
(`"scripts/signal/tests|323"`), then re-run green with 323. The battery was re-run **in
full** after every fix and after the final reformat — three survivors appeared mid-rework
(`sending` claim not committed, remote delete never exercised through the consumer, the
`server_delivered_at` swap) and all three are now killed by a named test.

## What is NOT verified

**Nothing live.** No Signal account, API, Postgres, MinIO or clawgate was contacted; every
transport is injected and `conftest.py` fails any test that reaches for the real `requests`.

Specifically unverified:

- **The websocket client.** The *route* is now verified against upstream source; the client
  code is `# pragma: no cover` and has never opened a connection. It also needs
  `websocket-client` in the consumer image — a deploy-side prerequisite, not covered here.
- **Postgres-specific SQL** — `tsvector`/GIN, `websearch_to_tsquery`, `GREATEST`, `JSONB`,
  the generated column, and the `InFailedSqlTransaction` behaviour, which is emulated in the
  substrate rather than observed in Postgres.
- **The real envelope shapes.** The corpus is built from documented JSON; an unmodelled
  shape returns `unknown` (counted, retained) rather than crashing, but the corpus is not
  evidence about the wire.
- **That approval comes from a human.** Structural: draft and send are separate calls with
  durable state and no code route from an un-approved draft to the API. Not structural:
  the operator token is a speed bump, not proof of humanity.

Deployment step 7 — send a message from another device, confirm the Postgres row and the
MinIO object — remains the only thing that verifies this works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MRnRt9ESKvhGuhfAVDhvM
