### PR TITLE
fix(clawgate-guard): --dismiss now writes a tombstone — verifying a dismissal re-armed it, twice, in production

### DIFF
--- a/scripts/claude-hooks/clawgate-writeback-guard.py
+++ b/scripts/claude-hooks/clawgate-writeback-guard.py
@@ -265,19 +265,48 @@ file with 130 lines of REAL CODE cost `+0.40 ms` (6/8) and 1300 lines cost `+4.2
 here and the first attempt at one was wrong: 1200 comment lines moved the number
 `+0.50 ms` with a stdev of 1.00, because a comment produces no AST node.
 
-The mechanism is compile time and nothing else. The tombstone check lives INSIDE
-`record_read`, which the fast path never reaches, so a session that has not read a
-clawgate task executes not one new statement — but `python3 <script>` never caches
-bytecode for `__main__`, so every invocation re-compiles the whole file and 158 more
-source lines are not free. Timed directly (200 `compile()` calls per sample, 10 paired
-samples), which has ~1000x the resolution of spawning processes:
+The dominant mechanism is compile time. The tombstone check lives INSIDE `record_read`,
+which the fast path never reaches, so a session that has not read a clawgate task
+executes not one new statement on that path — but `python3 <script>` never caches
+bytecode for `__main__`, so every invocation re-compiles the whole file and the added
+source is not free. Timed directly (200 `compile()` calls per sample, 10 paired
+samples), which has ~1000x the resolution of spawning processes. RE-MEASURED after the
+audit round that followed, against the same base (`4eabdb3`), at +290 source lines:
 
-    compile BASE  2.140 ms      compile NEW  2.324 ms
-    paired delta  +0.184 ms, stdev 0.038, higher in 10/10 samples
+    compile BASE  2.361 ms      compile NEW  2.696 ms
+    paired delta  +0.334 ms, stdev 0.057, higher in 10/10 samples
 
-i.e. ~1.1% of a ~16 ms call, paid by every tool call in every session, in exchange for
-`--dismiss` meaning what it says. Named rather than hidden — and it is the reason not to
-answer the next audit round with another page of prose in this docstring.
+🔴 AND IT IS THE CODE, NOT THE PROSE — SO TRIMMING THIS DOCSTRING WOULD NOT RECOVER IT.
+The control: strip every comment and every docstring from BOTH files and re-run. That
+removes 256 of the 290 added lines and leaves +0.252 ms of the +0.334 ms standing
+(10/10 samples) on 34 added lines of real code. Consistent with the padding calibration
+above, where comment lines moved nothing an AST node could account for. Anyone reading
+this docstring as the thing to cut has the wrong lever; the lever is the code, and the
+code is the fix.
+
+🔴 THE SECOND COST IS A STATE CHANGE, NOT A STATEMENT, AND THE "not one new statement"
+SENTENCE ABOVE DOES NOT COVER IT. `--dismiss` calls `makedirs` (see
+`write_dismissal_tombstone`), so a bare dismissal for a session that never read a card
+CREATES the session dir — and `post_tool_use`'s fast path keys on
+`os.path.exists(state_dir)`. That session is therefore off the one-stat fast path for
+the rest of its life, on every subsequent tool call. Measured directly on
+`post_tool_use` (2000 calls per sample, 8 interleaved paired samples, dir absent vs dir
+present-and-empty):
+
+    fast path 0.0038 ms/call   slow path 0.0288 ms/call
+    paired delta +0.025 ms/call, stdev 0.014, higher in 8/8 samples
+
+It never blocks: `tracked_ids` on that dir is empty, so the slow path reaches no verdict
+(pinned by `test_a_bare_dismiss_CREATES_the_session_dir_...`). Accepted rather than
+removed, because making the dir conditional would silently drop the PRE-EMPTIVE
+dismissal — "this session's work is not for card N", said before the first read — which
+is a case `dismiss` deliberately supports. Named here rather than hidden, which is the
+whole point of this section; and note that a process-level benchmark of the same effect
+read +0.43 ms, i.e. sat exactly on the ~0.4 ms floor that calibration above established
+for that instrument, and should not be believed over the direct measurement.
+
+Total: ~2.1% of a ~16 ms call for the compile, plus 0.025 ms per tool call for any
+session that dismissed something, in exchange for `--dismiss` meaning what it says.
 
 The earlier round's parity took one deliberate change, still in force: the three
 work-detection patterns are pattern STRINGS compiled on first use rather than
@@ -698,12 +727,21 @@ def record_read(state_dir, task_id, now=None):
     # missed it: every test drove `--dismiss` and then asserted silence, and none of
     # them read the card again afterwards.
     #
-    # One consultation point, deliberately. `tracked_ids` cannot return a dismissed
-    # task anyway (its `read-` file is gone and this line stops it coming back), so a
-    # second check in `stop_decision` would be a duplicate of a decision already made
-    # here — the shape this file has removed twice before, unkillable by any mutation
-    # and reading as a coverage gap when it is really a copy. Same reasoning as
-    # MAX_TASKS, which is enforced only at this writer.
+    # One consultation point, deliberately — but on a PRECONDITION, not on a structural
+    # impossibility, and the earlier wording here ("`tracked_ids` structurally cannot
+    # return a dismissed task") overstated it. What holds is: WHEN THE REMOVAL SUCCEEDED,
+    # `tracked_ids` cannot return a dismissed task — its `read-` file is gone and this
+    # line stops it coming back. When `os.remove` FAILED, `read-<id>` survives the
+    # dismissal and `tracked_ids` does still yield it, so the guard stays armed.
+    #
+    # That case is reported rather than papered over: `dismiss_report` re-measures the
+    # ledger off disk (`_ledger_residue`) and says the clear did not happen, instead of
+    # promising a silence the state cannot deliver. A second check in `stop_decision`
+    # would not rescue it either — it would silence a card whose ledger entry is still
+    # on disk, i.e. HIDE the failed removal rather than name it — and it would be the
+    # shape this file has removed twice before: unkillable by any mutation and reading
+    # as a coverage gap when it is really a copy. Same reasoning as MAX_TASKS, which is
+    # enforced only at this writer.
     #
     # AFTER the `exists` above, so a re-read of an already-tracked task still costs one
     # stat: this branch is reachable only on the FIRST read of a given task in a
@@ -796,7 +834,34 @@ def dismiss(state_dir, task_id, now=None):
     Tombstoning is unconditional, including for a task that was never read: a dismissal
     is the operator asserting this session's work is not for this card, and that is as
     true said before the first read as after it.
+
+    🔴 THE TOMBSTONE IS WRITTEN FIRST, AND THAT ORDER IS LOAD-BEARING — an earlier
+    revision of this function wrote it LAST and called the two orders equivalent. They
+    are not. See the comment on the call below for the state the other order can leave
+    behind.
     """
+    # 🔴 FIRST, NOT LAST. Between an `os.remove` and a later tombstone write the session
+    # sits in EXACTLY its pre-dismissal state — `read-<id>` gone, nothing on disk saying
+    # a dismissal is in flight — so a `record_read` landing in that window re-creates
+    # `read-<id>` and the tombstone then lands on TOP of it. The result is
+    # `dismissed-<id>` and `read-<id>` both present: `is_dismissed` True while
+    # `tracked_ids` still yields the task, so `stop_decision` returns `block` and the CLI
+    # prints the whole "It will not ask about task N again" promise over a guard that is
+    # armed. That is the precise false-promise shape this function exists to delete,
+    # reintroduced one statement later. Writing the tombstone first closes the window:
+    # `record_read` consults it and returns without writing.
+    #
+    # Reachability is narrow and is not the point — both files live in one directory, so
+    # nearly every permission failure hits both, and a session's hooks are sequential.
+    # The point is that the ORDER is a claim, and "equivalent" was the wrong one. Pinned
+    # two ways: `test_the_tombstone_is_written_BEFORE_the_removals_...` drives a read
+    # into the window and goes RED if these statements are swapped back, and
+    # `test_the_tombstone_WRITE_precedes_every_REMOVAL_...` pins the call sequence whole.
+    #
+    # Still best-effort in the failing direction: a tombstone that cannot be written
+    # NEVER changes what the removals below do. What it changes is what the caller is
+    # allowed to PROMISE — see `dismiss_report`.
+    write_dismissal_tombstone(state_dir, task_id, now=now)
     removed = []
     for name in ("read-%d" % int(task_id), "fires-%d" % int(task_id),
                  "unknown-%d" % int(task_id)):
@@ -805,11 +870,31 @@ def dismiss(state_dir, task_id, now=None):
             removed.append(name)
         except Exception:                 # noqa: BLE001 — absent is the common case
             pass
-    # Best-effort and last: a tombstone that cannot be written NEVER changes what the
-    # removals above already did. What it does change is what the caller is allowed to
-    # PROMISE — see `dismiss_report`.
-    write_dismissal_tombstone(state_dir, task_id, now=now)
     return removed
+
+
+def _ledger_residue(state_dir, task_id):
+    """Which of this task's ledger entries are STILL on disk. Sorted; usually empty.
+
+    🔴 THIS EXISTS BECAUSE `dismiss`'s `removed` LIST CANNOT ANSWER THE QUESTION THE
+    REPORT ASKS. `removed` is "which `os.remove` calls did not raise", so an unwritable
+    session dir makes it EMPTY — byte-identical to "there was nothing here to remove".
+    Reporting off that printed `nothing to dismiss — task N is not in session S's
+    ledger` while `read-N` was sitting in that ledger, measured against a `0o500` dir.
+    Only the disk distinguishes the two, so the head asks the disk.
+
+    Symmetry with the other half of the sentence is the point: the tombstone clause has
+    been re-measured off disk since it landed (`is_dismissed`, not the writer's return
+    value), and the ledger clause was still trusting a return value. Both now measure.
+
+    No try/except, for the same reason as `is_dismissed`: `os.path.exists` swallows
+    every OSError itself, the id is `%d`-formatted, and the only caller runs inside
+    `main()`'s backstop — a handler here could not be reached by any test.
+    """
+    return sorted(name for name in ("read-%d" % int(task_id),
+                                    "fires-%d" % int(task_id),
+                                    "unknown-%d" % int(task_id))
+                  if os.path.exists(os.path.join(state_dir, name)))
 
 
 def _dismissals_path():
@@ -1361,7 +1446,7 @@ def emit(kind, text):
         sys.stdout.write("\n")
 
 
-def dismiss_report(task_id, session_id, removed, tombstoned):
+def dismiss_report(task_id, session_id, removed, tombstoned, residue=()):
     """The ONE sentence `--dismiss` prints. A pure function of what actually happened,
     so the claim can be pinned as a whole string by a test rather than sampled for
     keywords — this repo has had four prose guards walked by rewording, and a
@@ -1375,9 +1460,26 @@ def dismiss_report(task_id, session_id, removed, tombstoned):
     🔴 The state dir is NOT printed. It is an absolute path containing $HOME, and
     everything this writes goes to stdout, which the model reads and may quote onward.
     The session id is the only part the caller needs to see.
+
+    🔴 BOTH HALVES ARE NOW MEASURED OFF DISK. `tombstoned` already was; `residue` is the
+    ledger half, and it was added because `removed` alone could not tell "there was
+    nothing to remove" apart from "the removal FAILED" — see `_ledger_residue`.
     """
     sess = _sanitize(session_id)
     tid = int(task_id)
+    # 🔴 THE RESIDUE BRANCH OWNS BOTH HALVES OF THE SENTENCE, AND COMES FIRST. A ledger
+    # entry that survived the dismissal falsifies both of the other halves at once: the
+    # head would report `nothing to dismiss` about a task that is demonstrably still in
+    # the ledger, and the promise would claim a silence `tracked_ids` will not honour —
+    # it still yields the task, so the very next Stop blocks. Emitting it as one branch
+    # is what makes it impossible for the two clauses to contradict each other, which is
+    # the defect being fixed: the previous text paired a head saying nothing happened
+    # with a tail warning that something had.
+    if residue:
+        return ("clawgate write-back guard: could NOT clear task %d from session %s's "
+                "ledger — %s still present. WARNING: nothing was dismissed and this "
+                "guard will still ask about task %d in session %s."
+                % (tid, sess, ", ".join(sorted(residue)), tid, sess))
     if removed:
         head = ("clawgate write-back guard: dismissed task %d for session %s "
                 "(cleared %s)." % (tid, sess, ", ".join(sorted(removed))))
@@ -1429,14 +1531,19 @@ def dismiss_main(argv):
         return
     removed = dismiss(state_dir, task_id)
     record_dismissal(task_id, sess, removed)
-    # 🔴 THE PROMISE IS RE-MEASURED OFF DISK, NOT TAKEN FROM THE WRITER'S RETURN VALUE.
-    # Two reasons, and the second is the one a `tombstoned = write_...()` would get
-    # wrong: a write that failed while an EARLIER dismissal's tombstone is still present
-    # leaves the promise TRUE, and only asking the filesystem sees that. The first is
-    # plainer — this sentence is a claim about the state of the world, so it should be
-    # read out of the world.
+    # 🔴 BOTH CLAIMS ARE RE-MEASURED OFF DISK, NOT TAKEN FROM A RETURN VALUE. For the
+    # tombstone, two reasons, and the second is the one a `tombstoned = write_...()`
+    # would get wrong: a write that failed while an EARLIER dismissal's tombstone is
+    # still present leaves the promise TRUE, and only asking the filesystem sees that.
+    # For the ledger, `removed` is empty both when there was nothing to remove and when
+    # the removal FAILED, which is how the head came to say `nothing to dismiss` over a
+    # `read-<id>` that was still on disk. The first reason is plainer and covers both —
+    # this sentence is a claim about the state of the world, so it is read out of the
+    # world. The `dismissals` ledger above deliberately keeps recording `removed`: that
+    # log is a record of what this invocation DELETED, not of what survived it.
     sys.stdout.write(dismiss_report(task_id, sess, removed,
-                                    is_dismissed(state_dir, task_id)) + "\n")
+                                    is_dismissed(state_dir, task_id),
+                                    _ledger_residue(state_dir, task_id)) + "\n")
 
 
 def main():

--- a/scripts/claude-hooks/clawgate-writeback-guard.py
+++ b/scripts/claude-hooks/clawgate-writeback-guard.py
@@ -192,6 +192,27 @@ task from this session's ledger for good. The previous escape — "if you did NO
 work on this task, say so in one line and stop" — was measured NOT to work: the next
 Stop re-blocked with identical text, because saying something changes no state.
 
+🔴 AND `--dismiss` ITSELF WAS MEASURED NOT TO WORK, IN PRODUCTION, TWICE — IT NOW
+WRITES A TOMBSTONE. Clearing `read-<id>`/`fires-<id>` restored the session to its
+pre-read state, so the NEXT read of the card re-armed the guard and it blocked again,
+while the message promised "It will not ask about this task again." The footgun is
+worse than the bug: the natural way to confirm a dismissal landed is to look at the
+card, which IS a read. From the dismissals ledger and the block text's own timestamps:
+
+    22:32:13.912419Z  dismissed 200, removed [fires-200, read-200]
+    22:32:14.002017Z  new read of 200 recorded   <- 90 ms later, SAME tool call
+    22:46:57.515257Z  dismissed 200 again (identical entry)
+
+— the second dismissal was needed ONLY because verifying the first one re-armed it.
+Three audit rounds missed this because every test drove `--dismiss` and then asserted
+silence; none of them read the card again afterwards. `dismiss` now also writes
+`dismissed-<id>` into the session state dir and `record_read` refuses to re-create
+`read-<id>` while it is there. The tombstone is ABSOLUTE for the session and scoped to
+it: same directory, so it inherits `prune`'s existing TTL rather than becoming a new
+unbounded artifact, and a NEW session starts fresh. Deliberately the opposite placement
+from the `dismissals` ledger, which lives OUTSIDE the swept root because it answers a
+question asked weeks later.
+
 MULTI-TURN COST OF THE WORK ANCHOR
 -----------------------------------
 Work that spans several turns fires once per turn until the per-task ladder is spent:
@@ -233,6 +254,31 @@ tests that COUNT the calls. A FOUR-sample run of the same benchmark read +0.7 ms
 the main thread and was pure drift — the interleave and the sample count are what
 distinguish the two, not one re-run.
 
+🔴 RE-MEASURED AGAIN 2026-08-16 FOR THE DISMISSAL TOMBSTONE, AND THE PROCESS-LEVEL
+BENCHMARK COULD NOT RESOLVE IT — SO THE MECHANISM WAS MEASURED DIRECTLY INSTEAD. Two
+interleaved 8-sample runs of the benchmark above disagreed with each other (main-thread
+NEW-BASE `+0.39 ms`, higher in 7/8 samples; then `+0.06 ms`, higher in 3/8), which is
+the signature of an effect below the instrument's floor rather than of a regression.
+Calibrating that instrument against the only mechanism available settled it: padding the
+file with 130 lines of REAL CODE cost `+0.40 ms` (6/8) and 1300 lines cost `+4.21 ms`
+(8/8) — linear, so it resolves ~0.4 ms at best. Comment padding is NOT a valid control
+here and the first attempt at one was wrong: 1200 comment lines moved the number
+`+0.50 ms` with a stdev of 1.00, because a comment produces no AST node.
+
+The mechanism is compile time and nothing else. The tombstone check lives INSIDE
+`record_read`, which the fast path never reaches, so a session that has not read a
+clawgate task executes not one new statement — but `python3 <script>` never caches
+bytecode for `__main__`, so every invocation re-compiles the whole file and 158 more
+source lines are not free. Timed directly (200 `compile()` calls per sample, 10 paired
+samples), which has ~1000x the resolution of spawning processes:
+
+    compile BASE  2.140 ms      compile NEW  2.324 ms
+    paired delta  +0.184 ms, stdev 0.038, higher in 10/10 samples
+
+i.e. ~1.1% of a ~16 ms call, paid by every tool call in every session, in exchange for
+`--dismiss` meaning what it says. Named rather than hidden — and it is the reason not to
+answer the next audit round with another page of prose in this docstring.
+
 The earlier round's parity took one deliberate change, still in force: the three
 work-detection patterns are pattern STRINGS compiled on first use rather than
 module-level `re.compile`, because none of them is reachable from the fast path (see
@@ -261,7 +307,17 @@ WHAT THIS STRUCTURALLY CANNOT SEE (say it here, not in a report nobody re-reads)
     a task read AFTER the last work event is skipped — but among tasks read BEFORE it,
     nothing distinguishes them (see SCOPE OF THE WORK FLAG above);
   * the `in_progress` flip, which it does not require: it gates the WRITE-BACK, which
-    is the thing that was measured missing.
+    is the thing that was measured missing;
+  * 🔴 ANY LATER WORK ON A TASK THIS SESSION HAS DISMISSED. The tombstone is ABSOLUTE
+    for the session: dismiss task N, then genuinely pick N up and work on it in the
+    SAME session, and this guard stays silent for N until the session ends. That is a
+    real FALSE NEGATIVE and it is the price of the message being true — the operator
+    explicitly asserted the work was not for that card, and the alternative (some
+    re-arm signal that decides the assertion has expired) is speculative complexity
+    inventing an intention nobody stated. There is deliberately NO `--rearm` flag: the
+    escape from a dismissal is a new session, which costs nothing and is unambiguous.
+    Everything else about the card is unaffected — a dismissal is not a status change,
+    writes nothing to the board, and silences only THIS session's guard.
 
 Deployed by `nix/home.nix`; registered on PostToolUse (no matcher) + Stop by
 `register-nudge-hook.py`. It has ONE other mode, and it is not a hook mode:
@@ -468,6 +524,12 @@ COMMENT_PAT = r"(?:^|(?<=\s))#[^\n]*"
 
 STATE_WORK = "work"
 
+# 🔴 THE DISMISSAL TOMBSTONE. Its own prefix, and that is load-bearing in BOTH
+# directions: `tracked_ids` takes only names starting `read-`, and `record_read`'s
+# MAX_TASKS census counts only those too — so a tombstone can neither be mistaken for
+# a tracked task nor consume a tracking slot. See `dismiss` for the incident.
+DISMISSED_PREFIX = "dismissed-"
+
 
 # --------------------------------------------------------------------------- #
 # Session-scoped state
@@ -505,6 +567,49 @@ def _state_dir(data):
 
 def _read_path(state_dir, task_id):
     return os.path.join(state_dir, "read-%d" % int(task_id))
+
+
+def _dismissed_path(state_dir, task_id):
+    return os.path.join(state_dir, "%s%d" % (DISMISSED_PREFIX, int(task_id)))
+
+
+def is_dismissed(state_dir, task_id):
+    """Has `--dismiss` been run for THIS task in THIS session?
+
+    EXISTENCE is the entire signal; the file's contents are documentation for a human
+    reading the cache by hand. A truncated or empty tombstone therefore still silences
+    — the fail-QUIET direction, and the right one here: the operator has already
+    asserted out loud that this session's work was not for this card, so a half-written
+    file must not resurrect the nagging.
+
+    NO try/except here, deliberately. `os.path.exists` swallows every OSError itself and
+    the id is `%d`-formatted, so the only handler that could fire would be one no test
+    can reach — the unkillable-branch shape this file has already deleted twice (see
+    `record_read` and `post_tool_use`). Fail-open is preserved STRUCTURALLY instead:
+    both call sites are already inside one — `post_tool_use` wraps each `record_read` in
+    a per-read `except Exception`, and `dismiss_main` runs inside `main()`'s single
+    backstop — and a raise there fails toward NOT arming the guard, which is the quiet
+    direction.
+    """
+    return os.path.exists(_dismissed_path(state_dir, task_id))
+
+
+def write_dismissal_tombstone(state_dir, task_id, now=None):
+    """Record that this session dismissed this task. Best-effort; returns whether the
+    write itself succeeded — but see `dismiss_main`, which does NOT trust this value and
+    re-measures the disk instead.
+
+    `makedirs` matches every other writer here (`record_work`, `bump_fires`): a
+    dismissal that arrives before the session dir exists — a pre-emptive one, or one
+    that lands after `prune` swept the session — still has to mean something.
+    """
+    try:
+        os.makedirs(state_dir, exist_ok=True)
+        with open(_dismissed_path(state_dir, task_id), "w") as fh:
+            json.dump({"task_id": int(task_id), "dismissed_ts": now_iso(now)}, fh)
+        return True
+    except Exception:                     # noqa: BLE001
+        return False
 
 
 def _fires_path(state_dir, task_id, kind="fires"):
@@ -584,6 +689,27 @@ def record_read(state_dir, task_id, now=None):
     # already-recorded task still costs no `makedirs`.
     if os.path.exists(path):
         return False
+    # 🔴 THE DISMISSAL TOMBSTONE IS CONSULTED HERE, AT THE WRITER, AND NOWHERE ELSE.
+    # Measured in production, twice: `--dismiss 200` cleared `read-200`/`fires-200` and
+    # wrote nothing, so the very next read of the card re-created `read-200` and the
+    # guard blocked again. The dismissals ledger and the block text's own timestamps
+    # caught it 90 ms apart, in the SAME tool call — because the natural way to confirm
+    # a dismissal worked is to look at the card, which is a read. Three audit rounds
+    # missed it: every test drove `--dismiss` and then asserted silence, and none of
+    # them read the card again afterwards.
+    #
+    # One consultation point, deliberately. `tracked_ids` cannot return a dismissed
+    # task anyway (its `read-` file is gone and this line stops it coming back), so a
+    # second check in `stop_decision` would be a duplicate of a decision already made
+    # here — the shape this file has removed twice before, unkillable by any mutation
+    # and reading as a coverage gap when it is really a copy. Same reasoning as
+    # MAX_TASKS, which is enforced only at this writer.
+    #
+    # AFTER the `exists` above, so a re-read of an already-tracked task still costs one
+    # stat: this branch is reachable only on the FIRST read of a given task in a
+    # session, which is the rarest event on a path that is itself off the fast path.
+    if is_dismissed(state_dir, task_id):
+        return False
     os.makedirs(state_dir, exist_ok=True)
     if len([n for n in os.listdir(state_dir) if n.startswith("read-")]) >= MAX_TASKS:
         return False
@@ -639,14 +765,37 @@ def bump_fires(state_dir, task_id, kind="fires"):
     return n
 
 
-def dismiss(state_dir, task_id):
-    """Clear ONE task from ONE session's ledger. Returns the file names removed.
+def dismiss(state_dir, task_id, now=None):
+    """Clear ONE task from ONE session's ledger AND tombstone it. Returns the file
+    names removed (the tombstone is a write, not a removal, and is not in that list).
 
     🔴 THIS IS THE ESCAPE HATCH, AND IT HAS TO BE A MECHANISM. The block text used to
     say "if you did NOT do work on this task, say so in one line and stop" — measured
     NOT to work, because saying something changes no state and the next Stop re-blocked
     with identical text. Removing `read-<id>` is what actually ends it: `tracked_ids`
-    no longer yields the task, so no live read, no counter, no verdict, forever.
+    no longer yields the task, so no live read, no counter, no verdict.
+
+    🔴 REMOVAL ALONE WAS NOT ENOUGH, AND THAT WAS MEASURED IN PRODUCTION TWICE. Clearing
+    the entries leaves the session in the state it was in before the card was ever read,
+    so the NEXT read re-arms the guard and it blocks again — while the message claimed
+    "It will not ask about this task again." The footgun is worse than the bug: the
+    natural way to check a dismissal took is to look at the card, which IS a read. The
+    ledger and the block text's own timestamps recorded the whole loop:
+
+        22:32:13.912419Z  dismissed 200, removed [fires-200, read-200]
+        22:32:14.002017Z  new read of 200 recorded   <- 90 ms later, SAME tool call
+        22:46:57.515257Z  dismissed 200 again (identical entry)
+
+    So the removal is now paired with a tombstone that `record_read` consults. The
+    tombstone lives INSIDE the session dir on purpose — it is a statement about THIS
+    session's work, it inherits `prune`'s existing TTL with no new artifact and no new
+    sweep, and a new session correctly starts fresh. That is the opposite placement from
+    the `dismissals` ledger, which sits OUTSIDE the swept root because it answers a
+    question asked weeks later; the two are not the same kind of record.
+
+    Tombstoning is unconditional, including for a task that was never read: a dismissal
+    is the operator asserting this session's work is not for this card, and that is as
+    true said before the first read as after it.
     """
     removed = []
     for name in ("read-%d" % int(task_id), "fires-%d" % int(task_id),
@@ -656,6 +805,10 @@ def dismiss(state_dir, task_id):
             removed.append(name)
         except Exception:                 # noqa: BLE001 — absent is the common case
             pass
+    # Best-effort and last: a tombstone that cannot be written NEVER changes what the
+    # removals above already did. What it does change is what the caller is allowed to
+    # PROMISE — see `dismiss_report`.
+    write_dismissal_tombstone(state_dir, task_id, now=now)
     return removed
 
 
@@ -975,8 +1128,9 @@ def missing_text(task_id, first_read_ts, session_id=""):
         "🔴 IF THIS SESSION'S WORK WAS NOT FOR TASK %(id)d — you only read the card, or "
         "the work belongs to a different task or repo — do NOT comment and do NOT flip "
         "the status: a junk comment permanently silences this guard for the card, and "
-        "`ready_for_review` fires a push notification to Zach. Run this instead, and it "
-        "will not ask again:\n"
+        "`ready_for_review` fires a push notification to Zach. Run this instead — it "
+        "will not ask about task %(id)d again in THIS session, even if you read the "
+        "card again, and a new session starts fresh:\n"
         "  %(dismiss)s"
         % {"id": int(task_id), "ts": first_read_ts,
            "dismiss": dismiss_cmd(task_id, session_id)}
@@ -1207,6 +1361,38 @@ def emit(kind, text):
         sys.stdout.write("\n")
 
 
+def dismiss_report(task_id, session_id, removed, tombstoned):
+    """The ONE sentence `--dismiss` prints. A pure function of what actually happened,
+    so the claim can be pinned as a whole string by a test rather than sampled for
+    keywords — this repo has had four prose guards walked by rewording, and a
+    two-word check on this text would be satisfied by its own static prefix.
+
+    🔴 THE PROMISE IS SCOPED TO THE SESSION, AND THAT IS THE FIX, NOT A HEDGE. The old
+    text said "It will not ask about this task again", which was false in two separate
+    ways: the next read re-armed the guard (the bug), and even with the tombstone it
+    says nothing about the NEXT session, which correctly starts fresh. Both are stated.
+
+    🔴 The state dir is NOT printed. It is an absolute path containing $HOME, and
+    everything this writes goes to stdout, which the model reads and may quote onward.
+    The session id is the only part the caller needs to see.
+    """
+    sess = _sanitize(session_id)
+    tid = int(task_id)
+    if removed:
+        head = ("clawgate write-back guard: dismissed task %d for session %s "
+                "(cleared %s)." % (tid, sess, ", ".join(sorted(removed))))
+    else:
+        head = ("clawgate write-back guard: nothing to dismiss — task %d is not in "
+                "session %s's ledger." % (tid, sess))
+    if tombstoned:
+        tail = ("It will not ask about task %d again in session %s, even if the card "
+                "is read again — a NEW session starts fresh." % (tid, sess))
+    else:
+        tail = ("WARNING: the tombstone could NOT be written, so a later read of task "
+                "%d in session %s will arm this guard again." % (tid, sess))
+    return head + " " + tail
+
+
 # --------------------------------------------------------------------------- #
 def dismiss_main(argv):
     """`--dismiss <task_id> --session <session_id>` — the escape hatch, as a command.
@@ -1243,17 +1429,14 @@ def dismiss_main(argv):
         return
     removed = dismiss(state_dir, task_id)
     record_dismissal(task_id, sess, removed)
-    if removed:
-        sys.stdout.write("clawgate write-back guard: dismissed task %d for session "
-                         "%s (cleared %s). It will not ask about this task again.\n"
-                         % (task_id, _sanitize(sess), ", ".join(sorted(removed))))
-    else:
-        # 🔴 The state dir is NOT printed. It is an absolute path containing $HOME, and
-        # everything this writes goes to stdout, which the model reads and may quote
-        # onward. The session id is the only part the caller needs to see.
-        sys.stdout.write("clawgate write-back guard: nothing to dismiss — task %d is "
-                         "not in session %s's ledger.\n"
-                         % (task_id, _sanitize(sess)))
+    # 🔴 THE PROMISE IS RE-MEASURED OFF DISK, NOT TAKEN FROM THE WRITER'S RETURN VALUE.
+    # Two reasons, and the second is the one a `tombstoned = write_...()` would get
+    # wrong: a write that failed while an EARLIER dismissal's tombstone is still present
+    # leaves the promise TRUE, and only asking the filesystem sees that. The first is
+    # plainer — this sentence is a claim about the state of the world, so it should be
+    # read out of the world.
+    sys.stdout.write(dismiss_report(task_id, sess, removed,
+                                    is_dismissed(state_dir, task_id)) + "\n")
 
 
 def main():

--- a/scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
+++ b/scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
@@ -2350,11 +2350,100 @@ def test_the_tombstone_is_PER_TASK_a_neighbour_read_LATER_still_blocks(home):
     assert sorted(guard.tracked_ids(state_dir())) == [NEIGHBOUR_TASK]
 
 
+def test_the_tombstone_is_written_BEFORE_the_removals_so_a_racing_read_cannot_re_arm(
+        home, monkeypatch):
+    """🔴 THE WRITE ORDER IS NOT AN EQUIVALENT ORDER, AND THIS IS THE TEST THAT SAYS SO.
+
+    An earlier revision of `dismiss` wrote the tombstone AFTER the removals and labelled
+    the reverse an "equivalent order" negative control. No test distinguished them,
+    which is exactly why that label survived. This one does, behaviourally: it drives a
+    `record_read` into the window between the `os.remove` of `read-200` and the
+    tombstone write — the same 90 ms interleaving the production ledger recorded, here
+    made deterministic by a patched `os.remove` rather than by timing.
+
+    With the tombstone written FIRST the read is refused and the dismissal holds. With
+    the two statements swapped, `read-200` is re-created and the tombstone lands on top
+    of it, leaving `dismissed-200` and `read-200` BOTH present: `is_dismissed` True
+    while `stop_decision` returns `block`. The final assertion pins that as a
+    RELATIONSHIP between the two, not as two separate facts, because it is the pair
+    that is the false promise — the CLI prints the whole "It will not ask about task 200
+    again" sentence over a guard that is armed.
+
+    RED at base (`is_dismissed` does not exist at `4eabdb3`) and RED under the swapped
+    order, which is the mutation this test was written for.
+    """
+    sd = seed(task_id=DISMISSED_TASK, ts=READ_TS)     # read at 12:00, work at 12:30
+    assert os.path.exists(guard._read_path(sd, DISMISSED_TASK))
+    real_remove = guard.os.remove
+    landed = []
+
+    def remove_then_a_read_lands(path):
+        """Unlink as normal, then let the operator confirm the card — which is a read.
+
+        Stamped BEFORE the session's last work event (12:01 against 12:30) on purpose:
+        a read after the last work event is skipped by the per-task read anchor that
+        already shipped, so it could not re-arm anything and the test would pass under
+        both orders. Same reasoning as
+        `test_REGRESSION_the_re_read_alone_does_not_re_arm_it_either`.
+        """
+        real_remove(path)
+        if os.path.basename(path) == "read-%d" % DISMISSED_TASK:
+            landed.append(guard.record_read(sd, DISMISSED_TASK, now=READ_EPOCH + 60))
+
+    monkeypatch.setattr(guard.os, "remove", remove_then_a_read_lands)
+    guard.dismiss(sd, DISMISSED_TASK)
+    monkeypatch.undo()
+
+    # The instrument first: a test that never reached the window would pass vacuously
+    # under BOTH orders, which is the failure mode this whole test exists to end.
+    assert landed == [False], "the read never landed in the window, or was not refused"
+    assert not os.path.exists(guard._read_path(sd, DISMISSED_TASK))
+    assert guard.tracked_ids(sd) == {}
+    r = Reader(result=task(task_id=DISMISSED_TASK, comments=[]))
+    kind, _ = guard.stop_decision(payload("Stop"), reader=r)
+    assert (guard.is_dismissed(sd, DISMISSED_TASK), kind) == (True, "silent")
+    assert r.calls == []
+
+
+def test_the_tombstone_WRITE_precedes_every_REMOVAL_in_the_call_sequence(home,
+                                                                        monkeypatch):
+    """🔴 The structural companion to the test above, and it pins the ORDER ITSELF as a
+    whole sequence rather than leaving a reader to reconstruct it from a race.
+
+    Every removal is listed, including the one that raises (`unknown-200` is absent, and
+    the loop swallows that) — so this is a ledger of what `dismiss` touches and in which
+    order, and it fails if the set GROWS or SHRINKS as well as if it is reordered. A
+    check that the tombstone merely appears somewhere in the list would be satisfied by
+    the order this PR removed."""
+    sd = seed(task_id=DISMISSED_TASK, ts=READ_TS)
+    guard.bump_fires(sd, DISMISSED_TASK)
+    order = []
+    real_wdt, real_remove = guard.write_dismissal_tombstone, guard.os.remove
+
+    def spy_tombstone(*a, **kw):
+        order.append("tombstone")
+        return real_wdt(*a, **kw)
+
+    def spy_remove(path):
+        order.append("remove:" + os.path.basename(path))
+        return real_remove(path)
+
+    monkeypatch.setattr(guard, "write_dismissal_tombstone", spy_tombstone)
+    monkeypatch.setattr(guard.os, "remove", spy_remove)
+    guard.dismiss(sd, DISMISSED_TASK)
+    monkeypatch.undo()
+    assert order == ["tombstone", "remove:read-200", "remove:fires-200",
+                     "remove:unknown-200"]
+
+
 def test_the_tombstone_is_PER_SESSION_a_DIFFERENT_session_still_blocks(home):
-    """🔴 An INVARIANT GUARD on the scope decision — green at base, because at base the
-    tombstone did not exist at all. It exists to kill the implementation that would put
-    the tombstone in the shared state ROOT: a dismissal in session A must say nothing
-    about session B, which is what makes "a NEW session starts fresh" true."""
+    """🔴 A SCOPE GUARD, and RED at base — not because base scoped it differently but
+    because `guard.is_dismissed` does not exist at `4eabdb3` at all, so this test cannot
+    even be collected there. (An earlier docstring here claimed "green at base", which
+    was false; the PR body's table always had it right.) What it earns is not regression
+    coverage but the kill on the implementation that would put the tombstone in the
+    shared state ROOT: a dismissal in session A must say nothing about session B, which
+    is what makes "a NEW session starts fresh" true."""
     guard.dismiss(state_dir(), DISMISSED_TASK)
     assert guard.is_dismissed(state_dir(), DISMISSED_TASK) is True
     # ...and B, which never dismissed anything, is untouched.
@@ -2510,6 +2599,15 @@ DISMISS_MSG_NOTHING_NOT_TOMBSTONED = (
     "clawgate write-back guard: nothing to dismiss — task 200 is not in session "
     "sess-writeback-1's ledger. WARNING: the tombstone could NOT be written, so a "
     "later read of task 200 in session sess-writeback-1 will arm this guard again.")
+# 🔴 THE FIFTH SHAPE, AND THE ONE THE OLD MESSAGE COULD NOT SAY. A removal that FAILED
+# and a ledger that was already empty both leave `removed` empty, so the head used to
+# report "nothing to dismiss" over a `read-200` that was still sitting on disk. It is
+# one branch owning the WHOLE sentence, because the alternative — an honest head paired
+# with the tombstone tail — is a sentence that contradicts itself.
+DISMISS_MSG_RESIDUE = (
+    "clawgate write-back guard: could NOT clear task 200 from session "
+    "sess-writeback-1's ledger — read-200 still present. WARNING: nothing was dismissed "
+    "and this guard will still ask about task 200 in session sess-writeback-1.")
 
 # The block text's own version of the promise. Same reasoning, and it is read by the
 # MODEL rather than by a human, which is the reason it has to be true.
@@ -2518,15 +2616,20 @@ BLOCK_DISMISS_PROMISE = (
     "you read the card again, and a new session starts fresh:")
 
 
-@pytest.mark.parametrize("removed,tombstoned,want", [
-    (["read-200", "fires-200"], True, DISMISS_MSG_CLEARED_AND_TOMBSTONED),
-    ([], True, DISMISS_MSG_NOTHING_BUT_TOMBSTONED),
-    (["read-200", "fires-200"], False, DISMISS_MSG_CLEARED_NOT_TOMBSTONED),
-    ([], False, DISMISS_MSG_NOTHING_NOT_TOMBSTONED),
+@pytest.mark.parametrize("removed,tombstoned,residue,want", [
+    (["read-200", "fires-200"], True, [], DISMISS_MSG_CLEARED_AND_TOMBSTONED),
+    ([], True, [], DISMISS_MSG_NOTHING_BUT_TOMBSTONED),
+    (["read-200", "fires-200"], False, [], DISMISS_MSG_CLEARED_NOT_TOMBSTONED),
+    ([], False, [], DISMISS_MSG_NOTHING_NOT_TOMBSTONED),
+    # Residue wins over BOTH other axes, and the two rows say so independently: the
+    # tombstone flag moves and the sentence does not, so a mutant that let the tail
+    # through would have to walk two rows, not one.
+    ([], False, ["read-200"], DISMISS_MSG_RESIDUE),
+    ([], True, ["read-200"], DISMISS_MSG_RESIDUE),
 ])
-def test_every_dismiss_message_is_pinned_WHOLE(removed, tombstoned, want):
+def test_every_dismiss_message_is_pinned_WHOLE(removed, tombstoned, residue, want):
     assert _norm(guard.dismiss_report(DISMISSED_TASK, SESSION, removed,
-                                      tombstoned)) == want
+                                      tombstoned, residue)) == want
 
 
 def test_the_block_texts_promise_is_pinned_WHOLE_and_scoped_to_the_SESSION(home):
@@ -2611,6 +2714,81 @@ def test_an_UNWRITABLE_STATE_DIR_is_the_same_answer_by_the_other_route(home):
         assert _norm(p.stdout) == DISMISS_MSG_NOTHING_NOT_TOMBSTONED
     finally:
         os.chmod(sd, 0o700)
+
+
+def test_a_FAILED_REMOVAL_says_the_ledger_entry_SURVIVED_instead_of_nothing_to_dismiss(
+        home):
+    """🔴 THE HEAD IS RE-MEASURED OFF DISK, AND THIS IS THE CASE THAT FORCED IT. A
+    `0o500` session dir makes `os.remove` raise, so `dismiss` returns an EMPTY `removed`
+    list — byte-identical to the list it returns when there was genuinely nothing to
+    remove. Reporting off that printed "nothing to dismiss — task 200 is not in session
+    …'s ledger" while `read-200` was still in that ledger, and the tail then warned that
+    something had gone wrong: one sentence making two contradictory claims.
+
+    Asymmetric with the tombstone half until now — that half has been re-measured off
+    disk (`is_dismissed`) since the change landed. Both halves ask the disk now.
+
+    The ledger entry surviving is also the load-bearing part of the message: `read-200`
+    is still on disk, so `tracked_ids` still yields 200 and the very next Stop blocks.
+    The sentence has to say that, and the assertion below proves it rather than trusting
+    the wording."""
+    sd = seed(task_id=DISMISSED_TASK, ts=READ_TS, work=False)
+    os.chmod(sd, 0o500)                   # readable and listable, NOT writable
+    try:
+        if os.access(sd, os.W_OK):        # running as root: cannot occur
+            pytest.skip("cannot make a directory unwritable as this user")
+        assert guard._ledger_residue(sd, DISMISSED_TASK) == ["read-200"]
+        p = run_cli(["--dismiss", str(DISMISSED_TASK), "--session", SESSION], home)
+        assert p.returncode == 0
+        assert p.stderr == ""
+        assert "Traceback" not in p.stdout
+        assert _norm(p.stdout) == DISMISS_MSG_RESIDUE
+        # ...and the warning is TRUE, not defensive wording: the entry really is still
+        # tracked, which is precisely why "nothing to dismiss" was the wrong sentence.
+        assert sorted(guard.tracked_ids(sd)) == [DISMISSED_TASK]
+    finally:
+        os.chmod(sd, 0o700)
+
+
+def test_a_CLEAN_dismissal_reports_NO_residue_the_positive_control_for_that_branch(home):
+    """The negative half of the test above: the same code path with a WRITABLE dir must
+    take neither the residue branch nor the warning, or the branch would be firing on
+    every dismissal and the test above would prove nothing about permissions."""
+    sd = seed(task_id=DISMISSED_TASK, ts=READ_TS, work=False)
+    guard.bump_fires(sd, DISMISSED_TASK)
+    assert sorted(guard._ledger_residue(sd, DISMISSED_TASK)) == ["fires-200",
+                                                                 "read-200"]
+    p = run_cli(["--dismiss", str(DISMISSED_TASK), "--session", SESSION], home)
+    assert p.returncode == 0
+    assert _norm(p.stdout) == DISMISS_MSG_CLEARED_AND_TOMBSTONED
+    assert guard._ledger_residue(sd, DISMISSED_TASK) == []
+
+
+def test_a_bare_dismiss_CREATES_the_session_dir_and_that_costs_the_fast_path(home):
+    """🔴 A MEASURED SIDE EFFECT, PINNED RATHER THAN LEFT IMPLICIT. `--dismiss` for a
+    session that never read a card calls `makedirs` (deliberately — a pre-emptive
+    dismissal has to mean something), and `post_tool_use`'s fast path keys on
+    `os.path.exists(state_dir)`. So a bare dismissal permanently flips that session off
+    the one-stat fast path for the rest of its life.
+
+    It is a COST, not a defect: `tracked_ids` is empty, so the slow path reaches no
+    verdict and blocks nothing — which is the half this test proves, because the flip is
+    only acceptable if it stays silent. The timing half is named in the module docstring
+    beside the hot-path claim, where the "not one new statement" wording was true of the
+    code and false of the state it creates."""
+    sd = state_dir()
+    assert not os.path.exists(sd)
+    p = run_cli(["--dismiss", str(DISMISSED_TASK), "--session", SESSION], home)
+    assert p.returncode == 0
+    assert os.path.isdir(sd), "the dismissal did not create the session dir"
+    # The flip is real: `tracked` is now True where it was False...
+    assert guard.tracked_ids(sd) == {}
+    # ...and it still cannot block, on either the tool path or the Stop path.
+    guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/x"}),
+                        now=WORK_EPOCH)
+    r = Reader(result=task(task_id=DISMISSED_TASK, comments=[]))
+    assert guard.stop_decision(payload("Stop"), reader=r) == ("silent", "")
+    assert r.calls == []
 
 
 def test_a_tombstone_path_that_is_a_DIRECTORY_still_silences_the_guard(home):

--- a/scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
+++ b/scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
@@ -2222,3 +2222,499 @@ def test_the_negative_control_a_normal_dotted_component_is_untouched(raw):
     """The neutering is enumerated, not a pattern: a component that merely CONTAINS
     dots must survive intact, or the tighten above is green by eating everything."""
     assert guard._sanitize(raw) == raw
+
+
+# =========================================================================== #
+# 21. THE DISMISSAL TOMBSTONE
+#
+# 🔴 MEASURED IN PRODUCTION, TWICE. `--dismiss <id> --session <sid>` cleared
+# `read-<id>`/`fires-<id>` and wrote nothing, so the session was returned to its
+# pre-read state and the NEXT read of the card re-armed the guard — while the message
+# promised "It will not ask about this task again." The footgun is worse than the bug:
+# the natural way to confirm a dismissal landed is to look at the card, which IS a read.
+#
+#     22:32:13.912419Z  dismissed 200, removed [fires-200, read-200]
+#     22:32:14.002017Z  new read of 200 recorded   <- 90 ms later, SAME tool call
+#     22:46:57.515257Z  dismissed 200 again (identical entry)
+#
+# 🔴 AND THE REASON THREE AUDIT ROUNDS MISSED IT IS THE SHAPE OF THE OLD TESTS: every
+# one of them drove `--dismiss` and then asserted silence. NONE of them read the card
+# again afterwards. So the tests below are written the other way round — the read comes
+# AFTER the dismissal, always.
+# =========================================================================== #
+SESSION_B = "sess-writeback-2"
+# 200/201 are the production ids. Neither can be produced by MAX_TASKS (5), MAX_BLOCKS
+# (2) or MAX_FIRES (3), and neither equals the 193/194 the rest of this file uses — so
+# no fixture here can pass by being a constant it is testing.
+DISMISSED_TASK = 200
+NEIGHBOUR_TASK = 201
+
+
+def read_card(task_id, **kw):
+    """The exact act that re-armed the guard in production: a read of the card."""
+    return bash("clawgatectl task get %d" % task_id, **kw)
+
+
+def test_REGRESSION_dismiss_then_READ_then_WORK_stays_silent(home):
+    """🔴 THE TEST NOBODY WROTE. Read 200, work, get blocked, dismiss it — and then do
+    the thing the operator actually did: look at the card again, and carry on working.
+
+    RED at the base commit: the re-read re-created `read-200` (the tombstone did not
+    exist), the fresh work event cleared the per-task read anchor, `fires-200` had been
+    removed by the dismissal so the ladder restarted at rung 1, and the guard blocked
+    with the same text a second time.
+    """
+    guard.post_tool_use(read_card(DISMISSED_TASK), now=READ_EPOCH)
+    guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/x"}),
+                        now=WORK_EPOCH)
+    first = guard.stop_decision(payload("Stop"),
+                                reader=Reader(result=task(task_id=DISMISSED_TASK,
+                                                          comments=[])))
+    assert first[0] == "block"             # the state the operator was actually in
+
+    guard.dismiss(state_dir(), DISMISSED_TASK)
+
+    # ...and now the 90 ms that mattered: confirm the card, then keep working.
+    guard.post_tool_use(read_card(DISMISSED_TASK), now=READ_PLUS_1H)
+    guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/y"}),
+                        now=READ_PLUS_1H + 60)
+    r = Reader(result=task(task_id=DISMISSED_TASK, comments=[]))
+    assert guard.stop_decision(payload("Stop"), reader=r) == ("silent", "")
+    # Never even MEASURED, so this is silence by mechanism rather than a quiet verdict.
+    assert r.calls == []
+
+
+def test_REGRESSION_the_re_read_alone_does_not_re_arm_it_either(home):
+    """The same defect reached without the second work event, by stamping the re-read
+    BEFORE the session's recorded last work — which is what the per-task read anchor
+    keys on. RED at base for the same reason and by a different route, so a fix that
+    only special-cased "a read after the last work event" cannot pass this.
+    """
+    seed(task_id=DISMISSED_TASK, ts=READ_TS)     # read at 12:00, work at 12:30
+    guard.dismiss(state_dir(), DISMISSED_TASK)
+    guard.post_tool_use(read_card(DISMISSED_TASK), now=READ_EPOCH + 60)
+    r = Reader(result=task(task_id=DISMISSED_TASK, comments=[]))
+    assert guard.stop_decision(payload("Stop"), reader=r) == ("silent", "")
+    assert r.calls == []
+
+
+def test_the_INVARIANT_GUARD_a_re_read_with_no_further_work_was_already_silent(home):
+    """🔴 LABELLED HONESTLY: this one is GREEN AT BASE and is NOT regression coverage.
+    A re-read stamped after the last work event is skipped by the per-task read anchor
+    that already shipped, so the naive "dismiss -> read -> Stop" never blocked in the
+    first place. It is pinned so a tombstone implementation cannot break it, not as
+    evidence the tombstone works."""
+    seed(task_id=DISMISSED_TASK, ts=READ_TS)
+    guard.dismiss(state_dir(), DISMISSED_TASK)
+    guard.post_tool_use(read_card(DISMISSED_TASK), now=WORK_EPOCH + 3600)
+    r = Reader(result=task(task_id=DISMISSED_TASK, comments=[]))
+    assert guard.stop_decision(payload("Stop"), reader=r) == ("silent", "")
+
+
+def test_the_POSITIVE_CONTROL_without_the_dismissal_the_same_sequence_blocks(home):
+    """The silence above is the tombstone, not a session that had gone quiet anyway.
+    Identical to the regression test with the `dismiss` line removed."""
+    guard.post_tool_use(read_card(DISMISSED_TASK), now=READ_EPOCH)
+    guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/x"}),
+                        now=WORK_EPOCH)
+    guard.post_tool_use(read_card(DISMISSED_TASK), now=READ_PLUS_1H)
+    guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/y"}),
+                        now=READ_PLUS_1H + 60)
+    r = Reader(result=task(task_id=DISMISSED_TASK, comments=[]))
+    kind, text = guard.stop_decision(payload("Stop"), reader=r)
+    assert kind == "block"
+    assert [c[0] for c in r.calls] == [DISMISSED_TASK]
+    assert "task status %d ready_for_review" % DISMISSED_TASK in text
+
+
+def test_the_tombstone_is_PER_TASK_a_neighbour_read_LATER_still_blocks(home):
+    """🔴 Dismiss 200, then read 201 and work. 201 must still block, and the block must
+    name ONLY 201. RED at base: at base the re-read of 200 re-armed it too, so the
+    reason named both cards and the operator was told to dismiss one they already had."""
+    guard.post_tool_use(read_card(DISMISSED_TASK), now=READ_EPOCH)
+    guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/x"}),
+                        now=WORK_EPOCH)
+    guard.dismiss(state_dir(), DISMISSED_TASK)
+    guard.post_tool_use(read_card(DISMISSED_TASK), now=READ_PLUS_1H)
+    guard.post_tool_use(read_card(NEIGHBOUR_TASK), now=READ_PLUS_1H)
+    guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/z"}),
+                        now=READ_PLUS_1H + 60)
+
+    def reader(task_id, timeout=None):
+        return task(task_id=task_id, comments=[])
+
+    kind, text = guard.stop_decision(payload("Stop"), reader=reader)
+    assert kind == "block"
+    assert "task status %d ready_for_review" % NEIGHBOUR_TASK in text
+    assert "task %d" % DISMISSED_TASK not in text
+    assert sorted(guard.tracked_ids(state_dir())) == [NEIGHBOUR_TASK]
+
+
+def test_the_tombstone_is_PER_SESSION_a_DIFFERENT_session_still_blocks(home):
+    """🔴 An INVARIANT GUARD on the scope decision — green at base, because at base the
+    tombstone did not exist at all. It exists to kill the implementation that would put
+    the tombstone in the shared state ROOT: a dismissal in session A must say nothing
+    about session B, which is what makes "a NEW session starts fresh" true."""
+    guard.dismiss(state_dir(), DISMISSED_TASK)
+    assert guard.is_dismissed(state_dir(), DISMISSED_TASK) is True
+    # ...and B, which never dismissed anything, is untouched.
+    sd_b = guard._state_dir({"session_id": SESSION_B})
+    assert guard.is_dismissed(sd_b, DISMISSED_TASK) is False
+    b = payload("Stop", session_id=SESSION_B)
+    guard.post_tool_use(read_card(DISMISSED_TASK, session_id=SESSION_B),
+                        now=READ_EPOCH)
+    guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/x"},
+                                session_id=SESSION_B), now=WORK_EPOCH)
+    r = Reader(result=task(task_id=DISMISSED_TASK, comments=[]))
+    kind, text = guard.stop_decision(b, reader=r)
+    assert kind == "block"
+    assert [c[0] for c in r.calls] == [DISMISSED_TASK]
+    assert "--dismiss %d --session %s" % (DISMISSED_TASK, SESSION_B) in text
+
+
+def test_the_tombstone_lives_INSIDE_the_swept_session_dir(home):
+    """🔴 STRUCTURAL, and the mirror image of the ledger's placement assertion. The
+    ledger is deliberately OUTSIDE the root `prune` walks because it answers a question
+    asked weeks later; the tombstone is deliberately INSIDE the session's own directory,
+    so it shares that directory's existing TTL instead of becoming a second unbounded
+    artifact with a sweep of its own. Assert the RELATIONSHIP, not just the outcome."""
+    sd = os.path.normpath(state_dir())
+    p = os.path.normpath(guard._dismissed_path(sd, DISMISSED_TASK))
+    assert os.path.dirname(p) == sd
+    assert p.startswith(os.path.normpath(guard._state_root()) + os.sep)
+    # ...and it is NOT where the ledger went.
+    assert os.path.dirname(p) != os.path.dirname(guard._dismissals_path())
+    # 🔴 THE NAME CARRIES THE TASK ID, pinned as a LITERAL against TWO distinct ids.
+    # Found by a mutation sweep: `int(task_id) + 1` SURVIVED everything above, because
+    # the writer and the reader share this one function and an off-by-one is
+    # self-consistent — dismiss 200 wrote `dismissed-201` and `is_dismissed(200)` looked
+    # for `dismissed-201`, so no behaviour moved. What moved was the artifact a human
+    # debugging the cache reads, which would have said 201 was dismissed when it was
+    # not. Two ids, because one could be satisfied by a mutant hardcoding the literal.
+    assert os.path.basename(p) == "dismissed-200"
+    assert os.path.basename(guard._dismissed_path(sd, NEIGHBOUR_TASK)) \
+        == "dismissed-201"
+
+
+def test_the_tombstone_shares_the_session_dirs_TTL_and_does_not_RESURRECT(home):
+    """🔴 THE PRUNE BOUNDARY, bracketed from BOTH sides with literal ages that no
+    constant in the module can equal: 5 days must survive and 20 days must not, against
+    a 14-day TTL. A TTL moved in either direction past that bracket goes red.
+
+    "Does not resurrect" is the second half and it is a separate claim: once the session
+    dir is swept, a read of the same card in the same session id arms the guard again —
+    which is correct, because a session idle for a fortnight is not the session that
+    made the assertion."""
+    now = 1786795200.0
+    fresh = guard._state_dir({"session_id": "sess-tomb-fresh"})
+    stale = guard._state_dir({"session_id": "sess-tomb-stale"})
+    for sd, age in ((fresh, 5 * 86400), (stale, 20 * 86400)):
+        guard.dismiss(sd, DISMISSED_TASK)
+        assert guard.is_dismissed(sd, DISMISSED_TASK) is True
+        os.utime(sd, (now - age, now - age))
+    removed = guard.prune(now=now)
+    assert "sess-tomb-stale" in removed
+    assert "sess-tomb-fresh" not in removed
+    # The fresh session's promise still holds...
+    assert guard.is_dismissed(fresh, DISMISSED_TASK) is True
+    assert guard.record_read(fresh, DISMISSED_TASK) is False
+    # ...and the swept one's does not, so the card can arm the guard again there.
+    assert guard.is_dismissed(stale, DISMISSED_TASK) is False
+    assert guard.record_read(stale, DISMISSED_TASK) is True
+
+
+def test_record_read_REFUSES_a_dismissed_task_but_still_takes_its_NEIGHBOURS(home):
+    """The writer-level statement of the fix, plus its negative control in the same
+    test: the refusal must be keyed on the id, not on "this session has dismissed
+    something"."""
+    sd = state_dir()
+    os.makedirs(sd, exist_ok=True)
+    guard.dismiss(sd, DISMISSED_TASK)
+    assert guard.record_read(sd, DISMISSED_TASK) is False
+    assert guard.record_read(sd, NEIGHBOUR_TASK) is True
+    assert sorted(guard.tracked_ids(sd)) == [NEIGHBOUR_TASK]
+
+
+def test_the_tombstone_is_invisible_to_tracked_ids_and_to_the_MAX_TASKS_census(home):
+    """🔴 BOTH readers of this directory scan it BY NAME, and a tombstone that started
+    with `read-` would have broken both at once: `tracked_ids` would have yielded a
+    dismissed card, and `record_read`'s census would have burned a tracking slot per
+    dismissal. Driven at the cap — five tombstones, then five reads that must ALL land,
+    against MAX_TASKS = 5 (a number none of the ids used here can equal)."""
+    sd = state_dir()
+    os.makedirs(sd, exist_ok=True)
+    for tid in (300, 301, 302, 303, 304):
+        guard.dismiss(sd, tid)
+    assert guard.tracked_ids(sd) == {}
+    landed = [tid for tid in (400, 401, 402, 403, 404)
+              if guard.record_read(sd, tid)]
+    assert landed == [400, 401, 402, 403, 404]
+    assert sorted(guard.tracked_ids(sd)) == [400, 401, 402, 403, 404]
+    # ...and the sixth is still refused, so the cap itself did not move.
+    assert guard.record_read(sd, 405) is False
+
+
+def test_the_tombstone_is_consulted_only_on_a_FIRST_read_of_a_task(home):
+    """Ordering, and it is the hot-path claim in the source: the `read-<id>` existence
+    check comes FIRST, so a re-read of an already-tracked task still costs exactly one
+    stat and never touches the tombstone at all."""
+    sd = seed(task_id=193)
+    seen = []
+    real = guard.is_dismissed
+    guard.is_dismissed = lambda d, t: (seen.append(t), real(d, t))[1]
+    try:
+        assert guard.record_read(sd, 193) is False   # already tracked
+        assert seen == []                            # ...and not consulted
+        assert guard.record_read(sd, NEIGHBOUR_TASK) is True
+        assert seen == [NEIGHBOUR_TASK]              # the positive control
+    finally:
+        guard.is_dismissed = real
+
+
+def test_is_dismissed_is_EXISTENCE_only_even_for_an_empty_tombstone(home):
+    """A truncated write must still silence — the fail-QUIET direction, and the right
+    one: the operator has already asserted the work was not for this card."""
+    sd = state_dir()
+    os.makedirs(sd, exist_ok=True)
+    with open(guard._dismissed_path(sd, DISMISSED_TASK), "w"):
+        pass
+    assert guard.is_dismissed(sd, DISMISSED_TASK) is True
+    assert guard.record_read(sd, DISMISSED_TASK) is False
+
+
+def test_is_dismissed_on_a_state_dir_that_does_not_exist_is_False_not_an_error(home):
+    assert guard.is_dismissed(state_dir(), DISMISSED_TASK) is False
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE MESSAGE IS THE ARTIFACT UNDER TEST, so it is pinned as a WHOLE normalised
+# string. A two-word check would be satisfied by this sentence's own STATIC prefix —
+# which is exactly how four prose guards in this repo were walked by rewording. The
+# trade is accepted: a cosmetic reword fails these tests, and that is the price of a
+# machine-readable claim. The old text — "It will not ask about this task again." —
+# was FALSE, and no keyword check could have said so.
+# --------------------------------------------------------------------------- #
+DISMISS_MSG_CLEARED_AND_TOMBSTONED = (
+    "clawgate write-back guard: dismissed task 200 for session sess-writeback-1 "
+    "(cleared fires-200, read-200). It will not ask about task 200 again in session "
+    "sess-writeback-1, even if the card is read again — a NEW session starts fresh.")
+DISMISS_MSG_NOTHING_BUT_TOMBSTONED = (
+    "clawgate write-back guard: nothing to dismiss — task 200 is not in session "
+    "sess-writeback-1's ledger. It will not ask about task 200 again in session "
+    "sess-writeback-1, even if the card is read again — a NEW session starts fresh.")
+DISMISS_MSG_CLEARED_NOT_TOMBSTONED = (
+    "clawgate write-back guard: dismissed task 200 for session sess-writeback-1 "
+    "(cleared fires-200, read-200). WARNING: the tombstone could NOT be written, so a "
+    "later read of task 200 in session sess-writeback-1 will arm this guard again.")
+DISMISS_MSG_NOTHING_NOT_TOMBSTONED = (
+    "clawgate write-back guard: nothing to dismiss — task 200 is not in session "
+    "sess-writeback-1's ledger. WARNING: the tombstone could NOT be written, so a "
+    "later read of task 200 in session sess-writeback-1 will arm this guard again.")
+
+# The block text's own version of the promise. Same reasoning, and it is read by the
+# MODEL rather than by a human, which is the reason it has to be true.
+BLOCK_DISMISS_PROMISE = (
+    "Run this instead — it will not ask about task 200 again in THIS session, even if "
+    "you read the card again, and a new session starts fresh:")
+
+
+@pytest.mark.parametrize("removed,tombstoned,want", [
+    (["read-200", "fires-200"], True, DISMISS_MSG_CLEARED_AND_TOMBSTONED),
+    ([], True, DISMISS_MSG_NOTHING_BUT_TOMBSTONED),
+    (["read-200", "fires-200"], False, DISMISS_MSG_CLEARED_NOT_TOMBSTONED),
+    ([], False, DISMISS_MSG_NOTHING_NOT_TOMBSTONED),
+])
+def test_every_dismiss_message_is_pinned_WHOLE(removed, tombstoned, want):
+    assert _norm(guard.dismiss_report(DISMISSED_TASK, SESSION, removed,
+                                      tombstoned)) == want
+
+
+def test_the_block_texts_promise_is_pinned_WHOLE_and_scoped_to_the_SESSION(home):
+    """🔴 The old wording, "Run this instead, and it will not ask again", was a claim
+    about ALL FUTURE TIME made by a mechanism that did not hold past the next read. The
+    replacement says what is actually enforced, and says the limit out loud."""
+    text = guard.missing_text(DISMISSED_TASK, READ_TS, SESSION)
+    assert BLOCK_DISMISS_PROMISE in _norm(text)
+    assert "and it will not ask again" not in _norm(text)
+
+
+def test_the_CLI_prints_the_cleared_and_tombstoned_message_END_TO_END(home):
+    seed(task_id=DISMISSED_TASK, ts=READ_TS)
+    guard.bump_fires(state_dir(), DISMISSED_TASK)
+    p = run_cli(["--dismiss", str(DISMISSED_TASK), "--session", SESSION], home)
+    assert p.returncode == 0
+    assert p.stderr == ""
+    assert _norm(p.stdout) == DISMISS_MSG_CLEARED_AND_TOMBSTONED
+
+
+def test_a_dismiss_for_a_task_that_was_NEVER_READ_still_tombstones_it(home):
+    """A pre-emptive dismissal is a coherent thing to say — "this session's work is not
+    for card 200" is as true before the first read as after it — and the message must
+    not promise something the state does not support. RED at base twice over: at base
+    there was no tombstone at all, and the message stopped at the ledger sentence."""
+    p = run_cli(["--dismiss", str(DISMISSED_TASK), "--session", SESSION], home)
+    assert p.returncode == 0
+    assert _norm(p.stdout) == DISMISS_MSG_NOTHING_BUT_TOMBSTONED
+    # ...and the promise is real: reading the card afterwards does not arm it.
+    guard.post_tool_use(read_card(DISMISSED_TASK), now=READ_EPOCH)
+    guard.post_tool_use(payload(tool_name="Edit", tool_input={"file_path": "/x"}),
+                        now=WORK_EPOCH)
+    r = Reader(result=task(task_id=DISMISSED_TASK, comments=[]))
+    assert guard.stop_decision(payload("Stop"), reader=r) == ("silent", "")
+    assert r.calls == []
+
+
+def test_a_MISSING_state_root_is_created_rather_than_losing_the_dismissal(home):
+    """The "parent missing" case resolves toward the promise being TRUE, not toward a
+    warning: every other writer here (`record_work`, `bump_fires`) makedirs, and a
+    dismissal that silently meant nothing because a directory was absent is the defect
+    this whole change exists to remove."""
+    assert not os.path.exists(guard._state_root())
+    assert guard.write_dismissal_tombstone(state_dir(), DISMISSED_TASK) is True
+    assert guard.is_dismissed(state_dir(), DISMISSED_TASK) is True
+
+
+def test_an_UNWRITABLE_tombstone_says_so_instead_of_promising_it(home):
+    """🔴 FAIL-OPEN AND HONEST. The session state path is a regular FILE, so `makedirs`
+    raises, the removals raise, and nothing can be written — reached without any
+    dependence on the uid, unlike a chmod. The CLI must still exit 0 with an empty
+    stderr and no traceback, and the sentence must NOT contain the promise."""
+    root = guard._state_root()
+    os.makedirs(root, exist_ok=True)
+    with open(state_dir(), "w") as fh:    # the session "dir" is a file
+        fh.write("not a directory")
+    p = run_cli(["--dismiss", str(DISMISSED_TASK), "--session", SESSION], home)
+    assert p.returncode == 0
+    assert p.stderr == ""
+    assert "Traceback" not in p.stdout
+    assert _norm(p.stdout) == DISMISS_MSG_NOTHING_NOT_TOMBSTONED
+    # ...and it emitted no hook verdict of any kind: `--dismiss` can never block.
+    assert "decision" not in p.stdout
+
+
+def test_an_UNWRITABLE_STATE_DIR_is_the_same_answer_by_the_other_route(home):
+    """The second fail-open route, and NOT interchangeable with the one above: here the
+    session dir exists and is readable, so `makedirs(exist_ok=True)` SUCCEEDS and the
+    failure lands on the `open`. A fix that only handled a raising `makedirs` would
+    survive that test and die here."""
+    sd = state_dir()
+    os.makedirs(sd, exist_ok=True)
+    os.chmod(sd, 0o500)                   # readable, NOT writable
+    try:
+        if os.access(sd, os.W_OK):        # running as root: cannot occur
+            pytest.skip("cannot make a directory unwritable as this user")
+        assert guard.write_dismissal_tombstone(sd, DISMISSED_TASK) is False
+        assert guard.is_dismissed(sd, DISMISSED_TASK) is False
+        p = run_cli(["--dismiss", str(DISMISSED_TASK), "--session", SESSION], home)
+        assert p.returncode == 0
+        assert p.stderr == ""
+        assert _norm(p.stdout) == DISMISS_MSG_NOTHING_NOT_TOMBSTONED
+    finally:
+        os.chmod(sd, 0o700)
+
+
+def test_a_tombstone_path_that_is_a_DIRECTORY_still_silences_the_guard(home):
+    """The third shape, and the answer is deliberately the opposite of the two above:
+    the write fails, but EXISTENCE is the signal, so the promise genuinely holds and
+    the message says so. Documented rather than hidden — a warning here would be the
+    message lying in the other direction."""
+    sd = state_dir()
+    os.makedirs(guard._dismissed_path(sd, DISMISSED_TASK))
+    assert guard.write_dismissal_tombstone(sd, DISMISSED_TASK) is False
+    assert guard.is_dismissed(sd, DISMISSED_TASK) is True
+    p = run_cli(["--dismiss", str(DISMISSED_TASK), "--session", SESSION], home)
+    assert p.returncode == 0
+    assert _norm(p.stdout) == DISMISS_MSG_NOTHING_BUT_TOMBSTONED
+    assert guard.record_read(sd, DISMISSED_TASK) is False
+
+
+def test_a_FAILED_write_over_an_EARLIER_tombstone_still_reports_the_promise(home,
+                                                                            capsys):
+    """🔴 WHY THE MESSAGE IS RE-MEASURED OFF DISK RATHER THAN TAKEN FROM THE WRITER'S
+    RETURN VALUE. A second `--dismiss` whose write fails, against a session that was
+    already tombstoned, leaves the promise TRUE — and only asking the filesystem sees
+    that. Trusting `write_dismissal_tombstone`'s return here would print a warning that
+    is false."""
+    sd = state_dir()
+    os.makedirs(sd, exist_ok=True)
+    guard.dismiss(sd, DISMISSED_TASK)
+    capsys.readouterr()
+    calls = []
+    real = guard.write_dismissal_tombstone
+    guard.write_dismissal_tombstone = lambda *a, **k: calls.append(a) or False
+    try:
+        guard.dismiss_main(["--dismiss", str(DISMISSED_TASK), "--session", SESSION])
+    finally:
+        guard.write_dismissal_tombstone = real
+    assert calls, "the seam was never exercised"
+    assert _norm(capsys.readouterr().out) == DISMISS_MSG_NOTHING_BUT_TOMBSTONED
+
+
+def test_a_dismiss_with_a_NON_NUMERIC_id_writes_no_tombstone_anywhere(home):
+    sd = seed(task_id=DISMISSED_TASK)
+    before = sorted(os.listdir(sd))
+    p = run_cli(["--dismiss", "two-hundred", "--session", SESSION], home)
+    assert p.returncode == 0
+    assert p.stderr == ""
+    assert "not a task id" in p.stdout
+    assert sorted(os.listdir(sd)) == before
+    assert not any(n.startswith(guard.DISMISSED_PREFIX) for n in os.listdir(sd))
+
+
+def test_a_dismiss_with_NO_id_at_all_writes_no_tombstone_anywhere(home):
+    sd = seed(task_id=DISMISSED_TASK)
+    before = sorted(os.listdir(sd))
+    p = run_cli(["--session", SESSION], home)
+    assert p.returncode == 0
+    assert sorted(os.listdir(sd)) == before
+
+
+def test_the_LEDGER_still_records_every_dismissal_including_a_REPEAT(home):
+    """🔴 The ledger is what made this diagnosable at all — without it there would have
+    been no evidence the FIRST dismissal ever happened, and the 90 ms gap that named the
+    mechanism could not have been read. It is unchanged by the tombstone: still one line
+    per invocation, still recording a no-op, still outside the swept root."""
+    seed(task_id=DISMISSED_TASK)
+    run_cli(["--dismiss", str(DISMISSED_TASK), "--session", SESSION], home)
+    run_cli(["--dismiss", str(DISMISSED_TASK), "--session", SESSION], home)
+    with open(guard._dismissals_path()) as fh:
+        recs = [json.loads(ln) for ln in fh.read().splitlines() if ln.strip()]
+    assert len(recs) == 2
+    assert recs[0]["removed"] == ["read-%d" % DISMISSED_TASK]
+    assert recs[1]["removed"] == []       # the repeat cleared nothing...
+    assert recs[1]["task_id"] == DISMISSED_TASK
+    assert recs[1]["session"] == SESSION
+    # ...and the tombstone is NOT smuggled into the removal list, which is a record of
+    # what was deleted, not of what was written.
+    assert all(guard.DISMISSED_PREFIX not in n
+               for rec in recs for n in rec["removed"])
+
+
+def test_the_WHOLE_LOOP_THROUGH_THE_REAL_PROCESS(home, tmp_path):
+    """🔴 END TO END, as separate processes, with the dismiss command taken from the
+    block text the model is actually given — then the card read AGAIN, then more work,
+    then Stop. This is the production sequence, and at base the final Stop blocked."""
+    b = tmp_path / "tombbin"
+    b.mkdir()
+    mockbin.write_exec(b / "clawgatectl",
+                       "printf '%%s\\n' '%s'\n"
+                       % json.dumps(task(task_id=DISMISSED_TASK, comments=[])))
+    run_hook(read_card(DISMISSED_TASK), home, path_extra=b)
+    run_hook(payload(tool_name="Edit", tool_input={"file_path": "/x"}), home,
+             path_extra=b)
+    first = run_hook(payload("Stop"), home, path_extra=b)
+    reason = json.loads(first.stdout)["reason"]
+    line = [ln.strip() for ln in reason.splitlines() if "--dismiss" in ln]
+    assert len(line) == 1, reason
+    p = run_cli(line[0].split()[2:], home)
+    assert p.returncode == 0
+    assert _norm(p.stdout).endswith("a NEW session starts fresh.")
+
+    # 🔴 THE STEP EVERY EARLIER TEST OMITTED: look at the card again.
+    run_hook(read_card(DISMISSED_TASK), home, path_extra=b)
+    run_hook(payload(tool_name="Edit", tool_input={"file_path": "/y"}), home,
+             path_extra=b)
+    again = run_hook(payload("Stop"), home, path_extra=b)
+    assert again.returncode == 0
+    assert again.stdout == ""
+    assert again.stderr == ""

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -972,7 +972,22 @@ TARGET_FLOORS=(
   #   _suggested_floor 273 = 273 - min(50, max(1, 273/20 = 13)) = 273 - 13 = 260.
   # ZERO new skips, so EXPECTED_SKIPS is untouched. If this line conflicts with a
   # sibling branch, re-run the gate on the MERGED tree and copy what it prints.
-  "scripts/claude-hooks/tests/test_clawgate_writeback_guard.py|260"
+  #
+  # 2026-08-16, THE AUDIT-FIX ROUND ON THAT SAME PR: 273 -> 280. The audit found the
+  # write order inside `dismiss` was NOT the "equivalent order" the PR called it — the
+  # tombstone was written AFTER the removals, leaving a window in which a `record_read`
+  # re-creates `read-<id>` and the tombstone then lands on top of it, so `is_dismissed`
+  # is True while `stop_decision` still returns `block`. No test distinguished the two
+  # orders, which is how the label survived; +2 here do, one behavioural (a read driven
+  # into the window by a patched `os.remove`) and one structural (the call sequence
+  # pinned whole). +3 more cover `dismiss_report`'s head, which derived "nothing to
+  # dismiss" from `removed` rather than from disk and so said it over a `read-<id>` a
+  # failed `os.remove` had left behind, plus the state-dir side effect of a bare
+  # `--dismiss`. +2 are new rows on the whole-string message parametrize. ALL SEVEN are
+  # RED at the base sha. Read from the AUTHORITATIVE gate's own per-target line:
+  #   PASS  scripts/claude-hooks/tests/test_clawgate_writeback_guard.py  (collected=280 passed=280 skipped=0 floor=260)
+  #   _suggested_floor 280 = 280 - min(50, max(1, 280/20 = 14)) = 280 - 14 = 266.
+  "scripts/claude-hooks/tests/test_clawgate_writeback_guard.py|266"
   # 2026-08-14, writer 2 (opencode) arrives as a NEW target: 15 collected.
   #   _suggested_floor 15 = 15 - min(50, max(1, 15/20 = 0 -> 1)) = 14.
   "scripts/opencode/tests|14"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -953,7 +953,26 @@ TARGET_FLOORS=(
   # alone and spliced into a block reason, and the `--dismiss` audit ledger. Read from
   # the gate's per-target line, then through the gate's OWN function:
   #   _suggested_floor 244 = 244 - min(50, max(1, 244/20 = 12)) = 244 - 12 = 232.
-  "scripts/claude-hooks/tests/test_clawgate_writeback_guard.py|232"
+  #
+  # 2026-08-16, THE `--dismiss` TOMBSTONE: 244 -> 273. `--dismiss` cleared the ledger
+  # entries and wrote nothing, so the NEXT read of the card re-armed the guard and it
+  # blocked again — measured in production twice, 90 ms apart in the SAME tool call,
+  # because the natural way to confirm a dismissal is to look at the card. Three audit
+  # rounds missed it: every existing test drove `--dismiss` and then asserted silence,
+  # and NONE of them read the card again afterwards. So +29 here are written the other
+  # way round — the read comes after the dismissal. Two are regression tests measured
+  # RED at the base sha (dismiss -> re-read -> work -> Stop, by two different routes),
+  # four are labelled invariant guards/controls that were already green at base, and
+  # one (the tombstone's file NAME) exists only because a mutation sweep found
+  # `int(task_id) + 1` SURVIVING everything else — writer and reader share one
+  # function, so an off-by-one is self-consistent. Read from the AUTHORITATIVE gate's
+  # own per-target line out of `nix log`, not from a local pytest run:
+  #   PASS  scripts/claude-hooks/tests/test_clawgate_writeback_guard.py  (collected=273 passed=273 skipped=0 floor=232)
+  # then through the gate's OWN function rather than arithmetic:
+  #   _suggested_floor 273 = 273 - min(50, max(1, 273/20 = 13)) = 273 - 13 = 260.
+  # ZERO new skips, so EXPECTED_SKIPS is untouched. If this line conflicts with a
+  # sibling branch, re-run the gate on the MERGED tree and copy what it prints.
+  "scripts/claude-hooks/tests/test_clawgate_writeback_guard.py|260"
   # 2026-08-14, writer 2 (opencode) arrives as a NEW target: 15 collected.
   #   _suggested_floor 15 = 15 - min(50, max(1, 15/20 = 0 -> 1)) = 14.
   "scripts/opencode/tests|14"


### PR DESCRIPTION
## The defect — measured, twice, in production

`--dismiss <id> --session <sid>` cleared `read-<id>`/`fires-<id>` from the session state dir and **wrote no tombstone**. That restores the session to exactly its pre-read state, so the **next read of the card re-arms the guard and it blocks again** — while the message said *"It will not ask about this task again."*

The footgun is worse than the bug: the natural thing to do after dismissing is confirm the card was not touched, which means reading it, which re-arms it. From the dismissals ledger and the block text's own timestamps:

```
22:32:13.912419Z   dismissed 200, removed [fires-200, read-200]
22:32:14.002017Z   new read of 200 recorded   <- 90 ms later, SAME tool call
22:46:57.515257Z   dismissed 200 again (identical entry)
```

The second dismissal was needed **only** because the verification command for the first one re-armed it.

Three audit rounds missed this because every test drove `--dismiss` and then asserted silence — **none of them read the card again after dismissing.**

## The fix

`dismiss()` now also writes `dismissed-<id>` into the session state dir, and `record_read` refuses to re-create `read-<id>` while it is there.

**Where it lives / how it is pruned.** Inside the session state dir, so it inherits `prune`'s existing 14-day TTL with no new artifact and no new sweep. That is deliberately the **opposite** placement from the `dismissals` ledger, which sits outside the swept root because it answers a question asked weeks later. The ledger is unchanged — it is what made this diagnosable at all.

**One consultation point, at the writer.** `tracked_ids` structurally cannot return a dismissed task once `record_read` stops re-creating its file, so a second check in `stop_decision` would be a duplicate of a decision already made — the unkillable-branch shape this file has deleted twice. Same reasoning as `MAX_TASKS`, enforced only at its writer. The check sits **after** the existing `read-<id>` stat, so a re-read of an already-tracked task still costs exactly one stat.

**Absolute for the session.** A new session starts fresh. There is deliberately **no `--rearm`** — no evidence it is needed, and the escape from a dismissal is a new session.

**The messages are now true, and pinned WHOLE.** Four CLI variants (cleared/nothing x tombstoned/not) plus the block text's promise, each asserted as a whole normalised string rather than sampled for keywords — this repo has had four prose guards walked by rewording. A cosmetic reword now fails a test; that is the trade. The CLI's promise is also **re-measured off disk** rather than taken from the writer's return value: a failed write over an *earlier* tombstone leaves the promise true, and only asking the filesystem sees that.

## The regression this introduces — stated in the file

Added to `WHAT THIS STRUCTURALLY CANNOT SEE`:

> **ANY LATER WORK ON A TASK THIS SESSION HAS DISMISSED.** Dismiss task N, then genuinely pick N up and work on it in the SAME session, and the guard stays silent for N until the session ends.

Acceptable because the operator explicitly asserted the work was not for that card; the alternative — a re-arm signal that decides the assertion has expired — is speculative complexity inventing an intention nobody stated. A dismissal is not a status change, writes nothing to the board, and silences only this session's guard.

## Red-at-base / green-at-HEAD matrix

Base sha `4eabdb3` (= `origin/main`). 244 -> 273 tests.

| | count |
|---|---|
| **RED at base, green at HEAD** (regression coverage) | **25** |
| Green at base AND at HEAD (invariant guards / controls) | 4 |

The 4 green-at-base ones are **labelled as such in their docstrings** and are *not* counted as regression coverage:
- `test_the_INVARIANT_GUARD_a_re_read_with_no_further_work_was_already_silent` — the per-task read anchor already covered this shape
- `test_the_POSITIVE_CONTROL_without_the_dismissal_the_same_sequence_blocks`
- `test_the_tombstone_is_invisible_to_tracked_ids_and_to_the_MAX_TASKS_census`
- `test_a_dismiss_with_NO_id_at_all_writes_no_tombstone_anywhere`

The headline regression test is `test_REGRESSION_dismiss_then_READ_then_WORK_stays_silent` — dismiss, **read the card again**, keep working, Stop. A second route (`..._the_re_read_alone_does_not_re_arm_it_either`) stamps the re-read before the last work event, so a fix that only special-cased "a read after the last work event" cannot pass.

Also covered: per-task, per-session, prune boundary + no resurrection, the ledger still recording every dismissal including a repeat, three fail-open shapes (parent-is-a-file, read-only dir, tombstone-path-is-a-dir), a never-read task, non-numeric and absent ids, and the whole loop through real subprocesses with the dismiss command extracted from the block text it advertises.

## Mutation sweep — 28 mutants, 28 as expected

`PYTHONDONTWRITEBYTECODE=1`, `__pycache__` deleted between mutants, every mutant proved applied by **sha change AND byte-equality** (a substring probe has silently passed on insertion/deletion mutants here before).

- **24 KILLED** — enumerated from semantic failure modes, not deletions: branch inversion (x3), wrong bind (x3), off-by-one (x2), operand/sentinel swap, comparison swap (`exists` -> `isdir`), namespace collision (x2), comment-out, no-op-that-reports-success, report-success-on-failure, report-failure-on-success, drop-the-sort, trust-the-writer-instead-of-the-disk, revert-the-prose.
- **2 POSITIVE CONTROLS killed** — `MAX_BLOCKS 2->7` and `MAX_TASKS 5->9`, both outside this delta, so the harness demonstrably runs the whole file. Both are **same-length** edits, which is also the control against the stale-`.pyc` failure mode (a same-length edit in the same second scores SURVIVED without executing; these did not).
- ~~**2 NEGATIVE CONTROLS survived** — renaming the tombstone's JSON key (existence is the signal, content is never read) and moving the tombstone write before the removals (equivalent order).~~ **The second one was WRONG and is retracted — see "Audit-fix round" below.** The orders are not equivalent, and the reason it "survived" is that no test distinguished them. One negative control stands (the JSON key).

**The sweep found a real gap.** `_dismissed_path` with `int(task_id) + 1` **SURVIVED** the first run: writer and reader share that one function, so an off-by-one is self-consistent and no behaviour moves — but the artifact a human debugging the cache reads would have said 201 was dismissed when it was not. The file NAME is now pinned against **two distinct literal ids** (a mutant hardcoding one literal cannot pass).

## Hot path

The process-level benchmark **could not resolve this delta**, and saying so is the finding. Two interleaved 8-sample runs (30 runs/sample, explicit argv from a python parent, every child asserted `rc=0`) disagreed: `+0.39 ms` higher in 7/8 samples, then `+0.06 ms` higher in 3/8. Calibrating that instrument against the only available mechanism settled it — padding the file with **130 lines of real code** cost `+0.40 ms` (6/8) and **1300 lines** cost `+4.21 ms` (8/8), i.e. linear, resolving ~0.4 ms at best. (Comment padding is *not* a valid control and the first attempt at one was wrong: 1200 comment lines read `+0.50 ± 1.00` because a comment produces no AST node.)

So the mechanism was measured directly. The fast path executes **no new statement** — the tombstone check is inside `record_read`, which a session that never read a clawgate task never reaches — so the only cost is that `python3 <script>` never caches bytecode for `__main__` and the file is longer. **Corrected below:** the delta is **+290** source lines, not 158, and the fast-path claim is incomplete — a bare `--dismiss` creates the session dir, which flips `post_tool_use`'s fast-path check for the rest of that session. Numbers re-measured in "Audit-fix round".

```
compile BASE  2.140 ms      compile NEW  2.324 ms
paired delta  +0.184 ms, stdev 0.038, higher in 10/10 samples
```

~1.1% of a ~16 ms call. Bare interpreter start measured 9.05-10.4 ms across runs, well below the hook — which is what proves the interpreters actually started rather than the harness measuring nothing.

## Gate

Read out of `nix log`, not from an exit code:

```
PASS  scripts/claude-hooks/tests/test_clawgate_writeback_guard.py  (collected=273 passed=273 skipped=0 floor=260)
TOTAL collected=10653  passed=10652  skipped=1  failed=0  (floor: 9571 = sum of 22 per-target floors)
RESULT: PASS (exit=0)
```

Zero new skips (the one pinned skip is the pre-existing opt-in repo-cos live-store check). The per-target floor moved `232 -> 260` via the runner's own `_suggested_floor`, not by arithmetic.

## Not done

Not merged, no `home-manager switch`, no `ship.sh` — the hook is deployed and live on both hosts and still runs the old code until a switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rwzAkPvjXK9E2aM9zwBMa

---

# Audit-fix round (2026-08-16, `5dbb644`)

An adversarial audit of this PR returned **safe to merge**, and then found four things
worth tightening. All four are addressed here; the fix round re-ran the full gate and
the whole mutation battery, because an audit fix is a code change like any other.

## 1 🟡 The write order is NOT equivalent, and this PR called it a negative control

The claim above — "moving the tombstone write before the removals (equivalent order)" —
is **retracted**. `dismiss` wrote the tombstone AFTER the removals, which leaves a window
between the `os.remove` of `read-<id>` and the tombstone write in which the session sits
in its exact pre-dismissal state. A `record_read` landing there re-creates `read-<id>`
and the tombstone lands on top of it, leaving `dismissed-<id>` and `read-<id>` **both**
present: `is_dismissed` True while `tracked_ids` still yields the task, so `stop_decision`
returns `block` and the CLI prints the whole *"It will not ask about task 200 again"*
sentence over an armed guard. That is the exact false-promise shape this PR exists to
delete, reintroduced one statement later.

The mutant "survived" because **no test distinguished the two orders** — which is
precisely how the "equivalent" label got through review.

Fixed: the tombstone write moves ahead of the removal loop, and two tests now
distinguish the orders.

- `test_the_tombstone_is_written_BEFORE_the_removals_so_a_racing_read_cannot_re_arm`
  drives a `record_read` into the window via a patched `os.remove` — the production
  90 ms interleaving, made deterministic — and asserts `is_dismissed` and the Stop
  verdict as a **pair**, because it is the pair that is the false promise.
- `test_the_tombstone_WRITE_precedes_every_REMOVAL_in_the_call_sequence` pins the call
  sequence whole (`tombstone`, `remove:read-200`, `remove:fires-200`,
  `remove:unknown-200`), so the ledger fails if it grows, shrinks **or** reorders.

Reachability is narrow — both files share one directory, so nearly every permission
failure hits both, and a session's hooks are sequential — so this is correctness of the
**claim**, not a live emergency.

Also fixed: `record_read`'s comment asserted `tracked_ids` *"structurally cannot return a
dismissed task"*. That holds only **when the removal succeeded**; the precondition is now
stated, together with what happens when it did not.

## 2 🟢 A test docstring made a false claim about itself

`test_the_tombstone_is_PER_SESSION_a_DIFFERENT_session_still_blocks` said *"An INVARIANT
GUARD … green at base"*. It is **red at base** — it calls `guard.is_dismissed`, which
does not exist at `4eabdb3`. The table in this PR body was right; the test's own comment
was wrong. Corrected, and it now says what the test actually earns (a kill on the
shared-state-root implementation, not regression coverage).

## 3 🟢 `dismiss_report`'s head is now re-measured off disk

The head derived from `removed`, which is *"which `os.remove` calls did not raise"* — so
an unwritable session dir made it empty, **byte-identical** to "there was nothing to
remove". It printed *"nothing to dismiss — task N is not in session S's ledger"* while
`read-N` was still sitting in that ledger, and the tail then warned that something had
gone wrong: one sentence, two contradictory claims. Asymmetric with the tombstone half,
which already measured the disk.

New `_ledger_residue()` asks the filesystem. The residue branch owns **both halves** of
the sentence so they cannot disagree, and it is pinned as a whole normalised string like
the other four. Reached end-to-end through the real CLI with a `0o500` state dir, plus a
writable-dir positive control so the branch cannot be firing on every dismissal.

## 4 🟢 `--dismiss` creates the session dir — stated where the hot-path claim is

`write_dismissal_tombstone`'s `makedirs` means a bare `--dismiss` for a session that
never read a card **creates** the state dir, permanently flipping `post_tool_use`'s
`tracked = os.path.exists(state_dir)` fast-path check for the rest of that session. The
*"executes not one new statement"* wording was true of the code and false of the state
the change creates.

Kept rather than made conditional — a conditional `makedirs` would silently drop the
**pre-emptive** dismissal ("this session's work is not for card N", said before the first
read), which `dismiss` deliberately supports. The cost is named instead, and measured
**directly on `post_tool_use`** rather than by spawning processes (2000 calls/sample, 8
interleaved paired samples, dir absent vs dir present-and-empty):

```
fast path 0.0038 ms/call   slow path 0.0288 ms/call
paired delta +0.025 ms/call, stdev 0.014, higher in 8/8 samples
```

Note this is **~17x smaller** than the `+0.43 ms` a process-level benchmark read for the
same effect — which sits exactly on the ~0.4 ms floor this PR already established for
that instrument, so it should not be believed over the direct measurement. It never
blocks (`tracked_ids` is empty, so the slow path reaches no verdict), pinned by
`test_a_bare_dismiss_CREATES_the_session_dir_and_that_costs_the_fast_path`.

## Corrected numbers

**Source lines: +290, not +158** (1287 -> 1577 against `4eabdb3`). Conclusion unaffected.
Re-measured compile delta:

```
compile BASE  2.361 ms      compile NEW  2.696 ms
paired delta  +0.334 ms, stdev 0.057, higher in 10/10 samples
```

**And the cost is the CODE, not the prose — trimming the docstring would not recover it.**
Control: strip every comment and docstring from both files and re-run. That removes 256
of the 290 added lines and leaves **+0.252 ms of the +0.334 ms** standing, 10/10 samples,
on 34 added lines of real code. Consistent with this PR's own padding calibration, where
comment lines moved nothing an AST node could account for. Stated so nobody tries.

## Verification

**Red/green:** 273 -> **280 passed**. All **7** new/changed tests measured **RED at
`4eabdb3`**; 32 red at base overall (was 25). The new order tests are additionally red
under the reversed order, which is the mutation they were written for — base-redness
alone would only prove the tombstone is new.

**Mutation battery re-run** (a fix round resets the gate), `PYTHONDONTWRITEBYTECODE=1`,
`__pycache__` deleted between mutants, each mutant proved applied by **sha change AND
byte-equality** against the intended text:

| mutant | want | got |
|---|---|---|
| `write-order-REVERSED` | KILL | **KILLED** |
| `write-order-TOMBSTONE-MID-LOOP` | KILL | **KILLED** |
| `residue-always-empty` | KILL | **KILLED** |
| `residue-drops-read-file` | KILL | **KILLED** |
| `residue-branch-never-taken` | KILL | **KILLED** |
| `dismiss_main-passes-no-residue` | KILL | **KILLED** |
| `record_read-ignores-tombstone` | KILL | **KILLED** |
| POSITIVE CONTROL `_dismissed_path +1` | KILL | **KILLED** |
| NEGATIVE CONTROL (comment-only edit) | SURVIVE | **SURVIVED** |

Unexpected: **0**. 🔴 The reversed write order is now **KILLED**, which is the
whole point of the round.

**One mutant first read SURVIVED and that was the HARNESS being wrong, not the suite:**
`residue-always-empty` was written as `return [] or sorted(...)`, which evaluates to
`sorted(...)` and is a no-op. Corrected to `return []`, it kills. This is why every
mutant is read back for byte-equality against the text it was meant to be — and why a
single green sweep is a claim about the mutations you imagined.

**Gate — the MERGED tree**, `main` (`6bc6518`) merged into this branch. `main` has moved
past this PR's base; its `run-tests.sh` edit is `REQUIRED_TOOLS` (`+rsync`) and does not
touch `TARGET_FLOORS`, and the merged region was read rather than assumed clean. Read out
of `nix log`, not from an exit code:

```
PASS  scripts/claude-hooks/tests/test_clawgate_writeback_guard.py  (collected=280 passed=280 skipped=0 floor=266)
TOTAL collected=10807  passed=10806  skipped=1  failed=0  (floor: 9577 = sum of 22 per-target floors)
RESULT: PASS (exit=0)
```

No `panic: test timed out`. Zero new skips. Per-target floor `260 -> 266` via the
runner's own `_suggested_floor`, not by arithmetic.

**Nothing the audit measured good was regressed:** fail-open across all 7 write-path
shapes, per-session and per-task scoping, prune reaching the tombstone but not the
`dismissals` ledger, no resurrection of a stale `read-<id>`, id normalisation, the
whole-normalised-string message pins, the `_dismissed_path` off-by-one. Fail-open stays
absolute: any internal error -> exit 0, print nothing, never block.

## Follow-up, deliberately NOT in this PR

🟢 **The self-consistent-shared-function blind spot is a CLASS, and four more
instances survive** — all pre-existing and outside this delta: `_state_root()`'s two path
components, `STATE_WORK`'s file name, and `_dismissals_path()`'s file name. Each renames a
live on-disk artifact with **zero test movement**, because writer and reader share one
function. Renaming the state root on a deploy would silently orphan every in-flight
session's read anchors. `_dismissed_path` is now pinned, but the fix was applied to the
instance the sweep found, not to the class. **Worth its own PR pinning every on-disk name
against a literal.**
