### PR TITLE
docs(proposal): the header said "nothing built" after phase 1 shipped

### DIFF
--- a/claudedocs/proposal-subsystem-store-homelab.md
+++ b/claudedocs/proposal-subsystem-store-homelab.md
@@ -1,7 +1,15 @@
 # Proposal: move the subsystem store into homelab, behind an auth'd ingress
 
-**Status:** proposal, nothing built. Every number about the *current* store below was measured
-2026-08-16; every number about the *proposed* system is an estimate and is labelled as one.
+**Status: PHASE 1 SHIPPED 2026-08-16** — cluster-internal, no ingress. devrc #512 (the API over
+the existing reader) and homelab-infra #326 (manifests, Flux-adopted with no rollout) are merged;
+the pod runs on homelab in ns `subsystem-store`. **Phases 1.5–4 are still proposals.** The header
+formerly read *"proposal, nothing built"*, which stopped being true the day phase 1 shipped —
+the same deployed-state category as the port corrected in §2b.
+
+Every number about the *current* store below was measured 2026-08-16. Every number about the
+*unbuilt* phases is an estimate and is labelled as one. 🔴 **Nothing in §5's verification plan is
+satisfied by phase 1 for the phases that follow** — in particular no off-mesh control has ever
+run, and token rotation has never been exercised. Read §4 for what each phase still owes.
 
 **Goal (as stated):** make the store simple to reach from anywhere.
 


### PR DESCRIPTION
The proposal's line 3 still read **`Status: proposal, nothing built`** after #512 and #326 merged and the pod started running on homelab.

Same category as the `8110 → 8102` port correction that landed in the same document one PR earlier: *a historical record never stops being true; a deployed-state claim stops the day you ship.* This one stopped being true at merge.

## What changed
The header now says plainly what **is** built — phase 1, cluster-internal, no ingress, pod running in ns `subsystem-store`, Flux-adopted with no rollout — and what is **still a proposal** (phases 1.5–4).

It also carries the caveat forward rather than quietly dropping it: **no off-mesh control has ever run, and token rotation has never been exercised.** Phase 1 being green says nothing about the phases that face the internet, and a reader skimming a header that says "shipped" should not infer otherwise.

## Verification
`nix build .#checks.x86_64-linux.pytests`: `TOTAL collected=10771 passed=10770 skipped=1 failed=0`, `RESULT: PASS (exit=0)` — read from log content, not an exit code.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFzGbEBjxitrSknRovngvX