### PR TITLE
feat(subsystem-store): the token is the ONLY thing between the internet and the store — phase 1.5 hardening (3 audit rounds)

### DIFF
--- a/scripts/subsystem-store-api/README.md
+++ b/scripts/subsystem-store-api/README.md
@@ -165,9 +165,27 @@ must send the header itself; that is not a hole, since addressing the pod
 directly already bypasses the edge.
 
 Every rejection is the same 401 on the wire — body, code and header set — and is
-told apart only in the audit log's `status=` field: `unauthorized`,
-`no-client-ip`, `locked-out`, `lockout-triggered`. An error that discriminates is
-an enumeration API; a log that does not is a post-mortem with no evidence.
+told apart only in the audit log's `status=` field. The full vocabulary, which is
+what the Loki rules select on:
+
+| `status=` | meaning |
+|---|---|
+| `unauthorized` | no/!wrong token, or a path outside `/api/v1/` |
+| `no-client-ip` | absent, unparseable or duplicated `CF-Connecting-IP` — fails closed |
+| `locked-out` | this client is serving a lockout |
+| `lockout-triggered` | this request is the one that started it |
+| `malformed-target` | a request target `urlsplit` could not parse |
+| `malformed-request` | the request LINE itself was unparseable — no headers exist |
+| `method-not-allowed` | a write verb from an authenticated caller (405, not 401) |
+
+An error that discriminates is an enumeration API; a log that does not is a
+post-mortem with no evidence.
+
+⚠ **A wrong PATH is not a failed AUTH and is not counted.** Only a request that
+reaches the token check and fails it moves the lockout. Counting path probes
+measured as a client holding the *right* token locking itself out with five
+ordinary 404-ish requests. Volumetric probing is the Traefik and Cloudflare
+layers' job; this layer is the only one that can see a wrong credential.
 
 ## Deferred, and why (not oversights)
 

--- a/scripts/subsystem-store-api/README.md
+++ b/scripts/subsystem-store-api/README.md
@@ -1,4 +1,4 @@
-# subsystem-store-api — phase 1
+# subsystem-store-api — phase 1 + 1.5
 
 Read-only HTTP layer over the `/analyze-service` subsystem index, so the store is
 reachable from more than the workbench. Design: `claudedocs/proposal-subsystem-store-homelab.md`.
@@ -12,9 +12,15 @@ usable is phase 2. Add the pointer when there is something to point at.
 | in | out, until |
 |---|---|
 | the pod, seeded from the local store | — |
-| read-only `GET` API, bearer token | writes / append endpoints → **phase 3** |
-| cluster-internal `ClusterIP` | IngressRoute, DNS, Authelia → **phase 1.5** |
+| read-only `GET` API, bearer token **SET** | writes / append endpoints → **phase 3** |
+| per-client rate limit + lockout, `CF-Connecting-IP` keying | separate read/write tokens → **phase 3** |
+| cluster-internal `ClusterIP` | 🔴 IngressRoute + DNS → **an UNMERGED PR** |
 | byte-identity verified against local | the CLI wrapper + read-through cache → **phase 2** |
+
+🔴 **Phase 1.5 landed the hardening and NOT the exposure.** The store is still
+unreachable from the internet: the IngressRoute and DNS Ingress live in a
+homelab-infra PR that is deliberately open and unmerged, because merging to
+`trunk` there IS deploying and that merge is the go/no-go.
 
 The local store at `~/.claude/analyze-service-index/` stays **authoritative and
 untouched**. Rollback is `kubectl delete ns subsystem-store`.
@@ -76,6 +82,10 @@ scripts/subsystem-store-api/verify-byte-identity.sh \
                      -o jsonpath='{.data.token}' | base64 -d)
 ```
 
+The verifier sends `CF-Connecting-IP: 127.0.0.1` (override with `$CLIENT_IP`)
+because the server requires one — see "Rate limit, lockout and the client
+address" below.
+
 ⚠ `verify-byte-identity.sh` prints a `diff` on failure, and that diff is store
 content. Redirect it to a file on a shared terminal.
 
@@ -88,13 +98,84 @@ canonicalises exactly that line and `cmp`s the result, and prints beside the
 verdict how many lines differ **with no canonicalisation** and how many of those
 are the store-root line — `2` and `2` for pod-vs-workbench.
 
+## The token is a SET, and rotation is by overlap
+
+The token file holds **one token per line, current first**. Whitespace-separated
+is also accepted; blank lines are ignored; duplicates collapse. Up to
+`MAX_TOKENS` (4) — every line is a live credential, so an uncapped set is an
+accumulation nobody has retired, and the server refuses to start rather than
+serve one.
+
+Generate one:
+
+```bash
+python3 -c 'import secrets; print(secrets.token_urlsafe(43))'   # 58 chars
+```
+
+### Rotating, and how you know it is safe to finish
+
+🔴 **The audit line names the fingerprint of the token that MATCHED**, not the
+one the server was configured with. That is the whole safety of overlap
+rotation — without it, "nobody uses the old token any more" is a guess:
+
+```
+store-api audit ts=… ip=203.0.113.7 method=GET path=/api/v1/recall/x \
+  token=dbb22a50030d auth=ok result=200 status=recalled
+```
+
+1. `sops clusters/homelab/apps/subsystem-store/secrets.enc.yaml` — put the NEW
+   token on the first line, keep the old one below it. Commit; Flux applies.
+2. Restart the pod. Its startup line prints every fingerprint in file order:
+   `token-ids=<new>,<old>`.
+3. Roll clients onto the new token. Watch the audit stream until the OLD
+   fingerprint stops appearing:
+   `kubectl -n subsystem-store logs deploy/subsystem-store-api | grep 'token=<old>'`
+4. Only then delete the old line, commit, restart. A request presenting it is
+   now an ordinary 401.
+
+Step 3 is the step that does not exist without step 2's fingerprint, and step 4
+is the one people skip — a rotation that leaves the old credential live is not a
+rotation. The whole sequence is exercised in-band by
+`TestTokenSetAndOverlapRotation::test_a_ROTATION_end_to_end_old_still_works_then_stops`
+and against the real process by `TestTheDeployedEntrypoint`.
+
+## Rate limit, lockout and the client address
+
+| knob | default | env |
+|---|---|---|
+| failed auths before a lockout | 5 | `SUBSYSTEM_STORE_MAX_FAILURES` |
+| window they must fall inside | 60 s | `SUBSYSTEM_STORE_FAILURE_WINDOW_S` |
+| lockout duration | 900 s | `SUBSYSTEM_STORE_LOCKOUT_S` |
+
+A malformed value **exits 78** at startup rather than defaulting silently.
+
+🔴 **The client is keyed on `CF-Connecting-IP`, and nothing else.** Cloudflare
+overwrites it on every proxied request, which is the only reason it can be
+trusted — and it stops being trustworthy the moment Cloudflare is not the sole
+public ingress. `X-Forwarded-For` is never read: it is caller-supplied, so an
+attacker keyed on it gets a fresh bucket per request *and* can lock out a third
+party by forging theirs. Behind Cloudflare + Traefik the TCP peer address is the
+gateway's for everybody, so keying on that is the mirror failure — one abuser
+locks out the world.
+
+An absent, unparseable or **duplicated** header therefore **fails closed**: a
+uniform 401, and nothing counted, because there is no bucket to count into.
+Anything reaching the pod directly (a port-forward, `verify-byte-identity.sh`)
+must send the header itself; that is not a hole, since addressing the pod
+directly already bypasses the edge.
+
+Every rejection is the same 401 on the wire — body, code and header set — and is
+told apart only in the audit log's `status=` field: `unauthorized`,
+`no-client-ip`, `locked-out`, `lockout-triggered`. An error that discriminates is
+an enumeration API; a log that does not is a post-mortem with no evidence.
+
 ## Deferred, and why (not oversights)
 
-- **Rate-limit / lockout on repeated 401s**, and **separate read/write tokens** —
-  §2b `(B-required)` hardening for the moment an IngressRoute exists. Phase 1
-  creates none, and shipping an unexercised throttle is how a throttle nobody has
-  watched trip gets trusted.
+- **Separate read/write tokens** — there is no write path until phase 3, so a
+  write-scoped token today is a label on a capability that does not exist.
 - **Backup CronJob, daily-commit CronJob** — the workbench copy is authoritative
-  in phase 1, so the PVC is a second copy, not the only one.
-- **Token rotation as a one-command operation** — §2b requires it be exercised
-  once before cutover. It is not, so it is not claimed.
+  until phase 3, so the PVC is a second copy, not the only one.
+- **A `rotate-token` script** — the procedure above is four steps across a SOPS
+  file and a `kubectl` restart in another repo, and §2b's "one command" is worth
+  building only once phase 2's wrapper exists to be the thing that holds it.
+  Stated here rather than claimed as done.

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -172,16 +172,23 @@ MAX_TRACKED_LOCKOUTS = 16384
 # desynchronise a keep-alive connection (see `_drain_body`).
 MAX_DRAIN_BYTES = 1 << 20
 
-# A scope or ref name, as it may appear in a URL path. Deliberately strict: the
-# store's own directory names are lowercase-hyphenated, and anything outside this
-# set is a caller probing the filesystem rather than naming a scope.
+# A scope name, as it may appear in a URL path.
 #
-# ⚠ `.` IS IN THE CLASS, so `..` MATCHES THIS PATTERN. Dots are allowed because
-# entry refs contain them; the traversal cases are therefore excluded by name at
-# the call site, NOT by this regex. A guard that looks like it covers a case it
-# does not is worse than an obvious gap — which is exactly the shape this
-# comment exists to stop the next reader from re-introducing.
-SAFE_PATH_COMPONENT = re.compile(r"[A-Za-z0-9._-]+")
+# 🔴 NO DOT. That makes traversal impossible BY CONSTRUCTION rather than by
+# excluding `.` and `..` by name — a structural guard instead of a spelled one,
+# which is the difference between "the two spellings I thought of are blocked"
+# and "the character that enables them cannot appear".
+#
+# The first draft DID permit dots (on the reasoning that refs contain them) and
+# excluded `..` by name beside it. A mutation sweep then removed the dot from
+# this class and the ENTIRE SUITE STAYED GREEN — no test had a dotted path
+# component at all, because refs travel in the QUERY STRING, not the path. So
+# the permissive class was never justified by a real caller.
+#
+# MEASURED before tightening, since this could break a real scope: all 8 scopes
+# in the live store match `[A-Za-z0-9_-]+`, and 0 contain a dot. (Counts only —
+# the names are client-confidential and this repo is PUBLIC.)
+SAFE_PATH_COMPONENT = re.compile(r"[A-Za-z0-9_-]+")
 
 DEFAULT_STORE = "/data"
 DEFAULT_TOKEN_FILE = "/run/secrets/subsystem-store/token"
@@ -957,10 +964,7 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         rest = path[len(API_PREFIX) :]
         parts = [p for p in rest.split("/") if p]
 
-        if any(
-            part in (".", "..") or not SAFE_PATH_COMPONENT.fullmatch(part)
-            for part in parts
-        ):
+        if any(not SAFE_PATH_COMPONENT.fullmatch(part) for part in parts):
             # 🔴 A PATH COMPONENT REACHES THE FILESYSTEM. `%2e%2e` decoded to
             # `..`, and `scope_revision` then read `<store>/../.git/HEAD` and put
             # the result in `X-Store-Revision`. Harmless in the pod (the store

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -310,8 +310,13 @@ def client_ip(headers: Any) -> str | None:
       * more than one     — a caller trying to smuggle a second value past a
                             proxy that appends rather than overwrites
 
-    Returns the NORMALISED form (`ipaddress`), so `::FFFF:1.2.3.4` and
-    `::ffff:1.2.3.4` cannot be two buckets for one attacker.
+    Returns the NORMALISED form (`ipaddress`), so an IPv4-mapped address written
+    in upper and lower case cannot become two buckets for one attacker. (The
+    example that belongs here is spelled out in the test rather than in this
+    docstring: `test_no_public_ips.py` rejects an IP literal in a PUBLIC repo,
+    and it is right to — see `TestClientIpIsCloudflareOnly::
+    test_the_address_is_NORMALISED_so_one_caller_is_one_bucket`, which uses the
+    RFC 5737 documentation range.)
     """
     try:
         values = headers.get_all(CLIENT_IP_HEADER)

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -172,6 +172,10 @@ MAX_TRACKED_LOCKOUTS = 16384
 # desynchronise a keep-alive connection (see `_drain_body`).
 MAX_DRAIN_BYTES = 1 << 20
 
+# …and how long it will spend doing so. A byte limit alone is not a bound: a
+# caller dripping one byte at a time satisfies it while holding a thread forever.
+DRAIN_DEADLINE_S = 10.0
+
 # A scope name, as it may appear in a URL path.
 #
 # 🔴 NO DOT. That makes traversal impossible BY CONSTRUCTION rather than by
@@ -504,14 +508,38 @@ class RateLimiter:
             recent = [t for t in self._failures.get(key, []) if t > now - self.window_s]
             recent.append(now)
             if len(recent) >= self.max_failures:
+                # 🔴 PRUNE EXPIRED LOCKOUTS BEFORE ASKING WHETHER THERE IS ROOM.
+                # Found by a test, not by reading: `_evict` ran AFTER this check,
+                # so a table full of ALREADY-EXPIRED entries reported "no room"
+                # and refused a lockout that should have been granted. Once the
+                # cap is reached once, that would persist for as long as new
+                # failures kept arriving — the cap turning into a permanent
+                # disable of the whole lockout mechanism.
+                for stale in [k for k, v in self._locked_until.items() if v <= now]:
+                    del self._locked_until[stale]
                 if (
                     key in self._locked_until
                     or len(self._locked_until) < MAX_TRACKED_LOCKOUTS
                 ):
                     self._locked_until[key] = now + self.lockout_s
-                self._failures.pop(key, None)
+                    self._failures.pop(key, None)
+                    self._evict(now)
+                    return True
+                # 🔴 THE TABLE IS FULL, SO NO LOCKOUT WAS CREATED — SAY SO.
+                # The first version returned True here regardless, and popped
+                # the streak. Measured consequences, both bad: the audit log
+                # wrote `status=lockout-triggered` for a client that was NOT
+                # locked out (the log lying about the one event the operator
+                # alerts on), and popping the streak every `max_failures`
+                # failures meant no state accumulated at all — unlimited brute
+                # force, for an attacker who had first filled the table.
+                #
+                # Keeping the streak is what makes this degrade safely: the
+                # client stays AT the threshold, so every subsequent failure
+                # retries the lockout and takes it the moment a slot frees.
+                self._failures[key] = recent
                 self._evict(now)
-                return True
+                return False
             self._failures[key] = recent
             self._evict(now)
             return False
@@ -770,25 +798,58 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         drain the declared body here, and `_respond` sets `close_connection` on
         every non-200 so a desynchronised connection cannot be reused at all.
         """
+        headers = getattr(self, "headers", None)
+        if headers is None:
+            return
+        # 🔴 ANY FRAMING THIS FUNCTION DOES NOT FULLY UNDERSTAND ENDS THE
+        # CONNECTION. A delta audit measured the first version being walked by
+        # two framings it silently ignored — `Transfer-Encoding: chunked` (no
+        # Content-Length at all, so the body stayed queued) and a NEGATIVE
+        # Content-Length — each producing two responses on one socket with store
+        # content in the second, on a 200 where the connection legitimately
+        # stays open so the close-on-non-200 belt does not apply. No endpoint
+        # here accepts a body, so refusing to reason about exotic framing costs
+        # nothing and is the only answer that cannot be walked by a third
+        # framing nobody has thought of yet.
+        if headers.get("Transfer-Encoding"):
+            self.close_connection = True
+            return
+        raw_length = headers.get("Content-Length")
+        if raw_length is None:
+            return
         try:
-            length = int(self.headers.get("Content-Length") or 0)
+            length = int(raw_length)
         except ValueError:
             # A malformed length means the framing is already unknowable. Do not
             # guess; `_respond` will close the connection.
             self.close_connection = True
             return
-        if length <= 0:
+        if length < 0:
+            # Negative lengths are not "no body" — they are a caller telling two
+            # different stories to two different parsers.
+            self.close_connection = True
+            return
+        if length == 0:
             return
         if length > MAX_DRAIN_BYTES:
             # Too big to swallow politely. Closing is the only safe answer —
             # leaving it queued is exactly the desync above.
             self.close_connection = True
             return
+        # 🔴 BOUNDED IN TIME, NOT JUST IN BYTES. `timeout` is per-recv, so a
+        # caller dripping one byte every 10s held a thread for as long as it
+        # liked — measured at 60s for a 6-byte body, i.e. months for a 1 MiB
+        # one. The read loop this fix introduced needed its own deadline.
+        deadline = time.monotonic() + DRAIN_DEADLINE_S
         remaining = length
         while remaining > 0:
+            if time.monotonic() > deadline:
+                self.close_connection = True
+                return
             chunk = self.rfile.read(min(remaining, 65536))
             if not chunk:
-                break
+                self.close_connection = True
+                return
             remaining -= len(chunk)
 
     def _reject_write(self) -> None:
@@ -841,11 +902,39 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         distinct shape for what the docstring calls "ONE 401 response,
         byte-identical for every rejection". `OPTIONS`, `TRACE` and any invented
         verb reached it. They now look exactly like a bad token.
+
+        🔴 THE FIRST VERSION OF THIS OVERRIDE REOPENED, IN THE SAME COMMIT, THE
+        TWO DEFECTS THE REST OF THAT COMMIT CLOSED. A delta audit measured both:
+
+          * it read `self.path`, which `parse_request` assigns only AFTER five of
+            its own `send_error` calls — so `GET\r\n\r\n` (six bytes), a bad
+            HTTP version, or a four-word request line raised an unhandled
+            AttributeError: no audit record, no response, a ~25-line traceback
+            per request. That is verbatim what `_request_path` exists to prevent,
+            reintroduced one screen below it, and made cheaper.
+          * it never metered, so 30 `FROBNICATE` requests wrote 30 audit lines
+            and counted for nothing — the same free channel `_reject_write` had
+            just been reordered to close, widened to every other verb.
+
+        So: `getattr` for everything, because on this path NOTHING is guaranteed
+        to exist; meter when there are headers to identify a client from; and
+        when there are not, refuse AND close, which bounds an unidentifiable
+        caller to one request per TCP handshake.
         """
         self._client_ip = None
         self._token_fp = None
-        self._unauthorized()
-        self._audit(self._raw_path(), code, "method-not-allowed")
+        path = self._raw_path()
+        if getattr(self, "headers", None) is None:
+            # The request line itself was unparseable, so there is no header to
+            # identify anyone by. Answer, audit, and do not keep the connection.
+            self.close_connection = True
+            self._unauthorized()
+            self._audit(path, 401, "malformed-request")
+            return
+        self._drain_body()
+        if not self._identify_and_meter(path):
+            return
+        self._refuse(path, self._count_failure(self.limiter, self._client_ip))
 
     # --- the router -------------------------------------------------------------
 
@@ -870,8 +959,16 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         self._audit(path, 401, status)
 
     def _raw_path(self) -> str:
-        """The request target, never parsed. Safe to log; safe on any input."""
-        return self.path if isinstance(self.path, str) else "-"
+        """The request target, never parsed. Safe to log; safe on any input.
+
+        🔴 `getattr`, NOT `self.path`. `path` is an INSTANCE attribute assigned
+        by `parse_request`, and five of that method's own `send_error` calls
+        happen BEFORE the assignment — so on a malformed request line the
+        attribute does not exist at all and `self.path` raises AttributeError.
+        There is no class-level default to fall back on.
+        """
+        raw = getattr(self, "path", None)
+        return raw if isinstance(raw, str) else "-"
 
     def _request_path(self) -> str | None:
         """The decoded path, or `None` having already answered.
@@ -944,10 +1041,23 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         if not path.startswith(API_PREFIX):
             # Not an API path and not health. Answered with the SAME uniform 401
             # as a bad token: a 404 here would let an unauthenticated caller map
-            # the URL space, which is the enumeration surface §2b forbids. It
-            # counts toward the lockout for the same reason — URL probing from
-            # one address is the same attack as token probing from one address.
-            self._refuse(path, self._count_failure(limiter, ip))
+            # the URL space, which is the enumeration surface §2b forbids.
+            #
+            # 🔴 BUT IT IS NOT COUNTED, AND THAT IS A CORRECTION. It used to be,
+            # on the reasoning that URL probing is the same attack as token
+            # probing. Combined with a success no longer forgiving a streak,
+            # that measured as a legitimate client HOLDING THE RIGHT TOKEN
+            # locking itself out for 15 minutes by requesting `/favicon.ico`,
+            # `/`, `/robots.txt`, `/metrics` and `/api/v1` — five ordinary wrong
+            # paths, one of them a missing trailing slash away from the real
+            # prefix, with nothing able to forgive it.
+            #
+            # The specification says five failed AUTHS per minute. A request to
+            # a path that never reaches the token check is not a failed auth.
+            # Volumetric URL probing is what the Traefik middleware (10/s) and
+            # the Cloudflare WAF rule are for; this layer is the only one that
+            # can see a WRONG CREDENTIAL, and that is what it counts.
+            self._refuse(path, "unauthorized")
             return
 
         try:

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -56,9 +56,37 @@ becomes internet-reachable is an auth layer nobody has watched deny anything.
     in memory: the agent exec sandbox strips env vars from agent-run commands,
     so `$SUBSYSTEM_STORE_TOKEN` is the fallback, never the primary.
 
-NOT here, on purpose, and tracked to phase 1.5: rate-limiting / lockout on
-repeated 401s, and separate read/write tokens. Both are (B-required) hardening
-for the moment an IngressRoute exists; phase 1 creates none.
+PHASE 1.5 — THE (B-REQUIRED) HARDENING, ADDED BEFORE ANY INGRESS EXISTS
+------------------------------------------------------------------------
+Exposure **B** was decided by the operator: public `store.zacx.dev`, Cloudflare-
+proxied, and `/api/*` carries NO edge auth because Authelia's 302 is unusable
+from a CLI. So the bearer token is the ONLY thing between the public internet
+and client-confidential content, and §2b's hardening stops being optional:
+
+  * **A token SET, not a token** (`load_tokens`). Rotation is by overlap —
+    current + previous both accepted — because a single-token rotation has a
+    window in which every client is broken, which is why nobody performs it.
+  * **The audit log names WHICH fingerprint matched** (`token=<12 hex>`). This
+    is the whole safety of overlap rotation: without it, "the old token is
+    unused now" is a guess, and removing it is a coin flip. Fingerprint only —
+    the token itself in a log line is the leak the log exists to detect.
+  * **The client is keyed on `CF-Connecting-IP`** (`client_ip`), which is
+    trustworthy ONLY because Cloudflare is the sole public ingress. 🔴
+    `X-Forwarded-For` is NEVER read: it is caller-supplied, so keying on it
+    lets one attacker rotate through a million buckets AND lets them lock out
+    a third party by forging theirs. Behind CF + Traefik the TCP peer address
+    is the gateway's for everybody, so keying on THAT is the mirror failure —
+    one abuser locks out the world. An absent or unparseable `CF-Connecting-IP`
+    therefore FAILS CLOSED (uniform 401), rather than being bucketed into a
+    shared "unknown" that reproduces exactly that hazard.
+  * **Rate limit + lockout in the app** (`RateLimiter`): 5 failed auths per
+    client IP per minute, then a 15-minute lockout. Defaults live here in code;
+    all three are tunable by env. Cloudflare's WAF and the Traefik middleware
+    are the outer two layers, not the only ones.
+
+Still NOT here, and still tracked forward: separate read/write tokens (there is
+no write path until phase 3, so a write-scoped token would today be a label on
+a capability that does not exist).
 """
 
 from __future__ import annotations
@@ -66,12 +94,15 @@ from __future__ import annotations
 import argparse
 import hashlib
 import hmac
+import ipaddress
 import os
 import sys
+import threading
+import time
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 from urllib.parse import parse_qs, unquote, urlsplit
 
 _LIB = Path(__file__).resolve().parents[1] / "lib"
@@ -100,7 +131,35 @@ SERVER_BANNER = "subsystem-store"
 # 256 bits, base64url'd without padding, is 43 characters. A shorter token is
 # refused at STARTUP rather than served: a store that came up with a weak token
 # is worse than one that did not come up at all, because it looks healthy.
+# Generate one with `python3 -c 'import secrets; print(secrets.token_urlsafe(43))'`
+# — 43 BYTES of entropy renders as 58 characters, comfortably over this floor.
 MIN_TOKEN_CHARS = 43
+
+# Overlap rotation needs two (current + previous); three covers a rotation that
+# overlaps another. Beyond that a "set" is an accumulation nobody has retired,
+# and every one of them is a live credential — so the file is refused rather
+# than served, at STARTUP, for the same reason a short token is.
+MAX_TOKENS = 4
+
+# 🔴 THE ONLY HEADER THIS SERVER WILL ACCEPT AS A CLIENT IDENTITY, and it is
+# trustworthy for exactly one reason: Cloudflare is the sole public ingress and
+# overwrites it on every request it proxies. `X-Forwarded-For` is deliberately
+# absent from this file — see the module docstring.
+CLIENT_IP_HEADER = "CF-Connecting-IP"
+
+# §2b: "Rate-limit + lock out on repeated 401s". The defaults are HERE, in code,
+# so a deployment that sets no env still gets them; each is overridable.
+DEFAULT_MAX_FAILURES = 5
+DEFAULT_FAILURE_WINDOW_S = 60.0
+DEFAULT_LOCKOUT_S = 900.0
+
+ENV_MAX_FAILURES = "SUBSYSTEM_STORE_MAX_FAILURES"
+ENV_FAILURE_WINDOW = "SUBSYSTEM_STORE_FAILURE_WINDOW_S"
+ENV_LOCKOUT = "SUBSYSTEM_STORE_LOCKOUT_S"
+
+# A bound on the failure table so a flood of distinct keys cannot grow it
+# without limit. Active lockouts are NEVER evicted — evicting one is a bypass.
+MAX_TRACKED_CLIENTS = 4096
 
 DEFAULT_STORE = "/data"
 DEFAULT_TOKEN_FILE = "/run/secrets/subsystem-store/token"
@@ -123,17 +182,26 @@ def token_id(token: str) -> str:
     return hashlib.sha256(token.encode("utf-8")).hexdigest()[:12]
 
 
-def load_token(token_file: str | None, env: dict[str, str]) -> str:
-    """Resolve the bearer token. FILE FIRST, env only as a fallback.
+def load_tokens(token_file: str | None, env: dict[str, str]) -> list[str]:
+    """Resolve the bearer token SET. FILE FIRST, env only as a fallback.
+
+    🔴 A SET, NOT A TOKEN, and that is the whole of rotation (§2b: "token
+    rotation must be a one-command operation"). One token per line — the CURRENT
+    one first, the PREVIOUS one below it. Rotation is then: add the new line,
+    watch the audit log until every client's `token=` fingerprint has moved,
+    then delete the old line. There is no window in which a client is broken,
+    which is the reason single-token rotations never actually get performed.
 
     Guard order — each reachable by an input no earlier guard rejects:
       1. some source at all      -> "no token source"
       2. the file is readable    -> "token file unreadable"
-      3. non-empty after strip   -> "token is empty"
-      4. long enough             -> "token is too short"
+      3. at least one token      -> "token is empty"
+      4. not an accumulation     -> "too many tokens"
+      5. every token long enough -> "token N of M is too short"
 
-    Guard 4 is reachable with a perfectly readable, non-empty file, which is the
-    case that matters: a hand-typed token passes 1-3 and is exactly what 4 is for.
+    Guard 5 names the POSITION, never the token. A file whose second line was
+    truncated by an editor passes 1-4 and is exactly what 5 is for; saying
+    "one of them is short" would leave the operator grepping a secret by hand.
     """
     raw: str | None = None
     if token_file:
@@ -152,15 +220,29 @@ def load_token(token_file: str | None, env: dict[str, str]) -> str:
             "The API is not served without one"
         )
 
-    token = raw.strip()
-    if not token:
+    # `.split()` on any whitespace: a base64url token contains none, so this
+    # accepts one-per-line (the documented shape) and survives a trailing
+    # newline, CRLF, or an operator who used spaces.
+    tokens: list[str] = []
+    for candidate in raw.split():
+        if candidate not in tokens:  # de-duplicated, ORDER PRESERVED
+            tokens.append(candidate)
+
+    if not tokens:
         raise ValueError("token is empty: the source resolved to whitespace only")
-    if len(token) < MIN_TOKEN_CHARS:
+    if len(tokens) > MAX_TOKENS:
         raise ValueError(
-            f"token is too short: {len(token)} chars, need >= {MIN_TOKEN_CHARS} "
-            f"(256 bits base64url). A short token is a guessable one"
+            f"too many tokens: {len(tokens)}, max {MAX_TOKENS}. Every line is a "
+            f"live credential; retire the old ones instead of accumulating them"
         )
-    return token
+    for index, token in enumerate(tokens, start=1):
+        if len(token) < MIN_TOKEN_CHARS:
+            raise ValueError(
+                f"token {index} of {len(tokens)} is too short: {len(token)} chars, "
+                f"need >= {MIN_TOKEN_CHARS} (256 bits base64url). A short token is "
+                f"a guessable one"
+            )
+    return tokens
 
 
 def presented_token(header: str | None) -> str:
@@ -177,17 +259,192 @@ def presented_token(header: str | None) -> str:
     return parts[1].strip()
 
 
-def authorize(header: str | None, expected: str) -> None:
-    """Constant-time bearer check. Raises `_Rejected`; never returns a reason.
+def authorize(header: str | None, expected: Sequence[str]) -> str:
+    """Constant-time bearer check against a token SET. Returns the fingerprint
+    of the token that matched; raises `_Rejected` and never returns a reason.
 
     🔴 `hmac.compare_digest`, NOT `==`. A public endpoint makes a byte-at-a-time
     timing oracle practically exploitable, and the difference is invisible in
     every functional test — which is why the test for this asserts on the CALL,
     and there is a behavioural test either side of it.
+
+    🔴 NO EARLY EXIT. The loop runs to the end whether or not it has already
+    matched, so the response time does not encode WHICH token was presented —
+    a `break` on the first hit would make "you used the old one" measurable from
+    outside, and during an overlap window that is precisely the fact an attacker
+    wants. It is also why the match is accumulated rather than returned inline.
+
+    🔴 A BARE STRING IS REFUSED, LOUDLY. `for token in "abc…"` iterates
+    CHARACTERS, so passing one token as a `str` would authorize any caller who
+    presented a single character of it. A type annotation is not a code path;
+    this check is.
     """
-    got = presented_token(header)
-    if not hmac.compare_digest(got.encode("utf-8"), expected.encode("utf-8")):
+    if isinstance(expected, (str, bytes)):
+        raise TypeError(
+            "expected must be a SEQUENCE of tokens, not one string: iterating a "
+            "str yields characters, and a one-character token would authorize"
+        )
+    got = presented_token(header).encode("utf-8")
+    matched: str | None = None
+    for token in expected:
+        if hmac.compare_digest(got, token.encode("utf-8")):
+            matched = token
+    if matched is None:
         raise _Rejected()
+    return token_id(matched)
+
+
+def client_ip(headers: Any) -> str | None:
+    """The client's address, or `None` — and `None` means REFUSE, not "unknown".
+
+    🔴 `CF-Connecting-IP` ONLY. Cloudflare sets it on every proxied request and
+    overwrites whatever the caller sent, which is what makes it trustworthy —
+    and it is trustworthy for that reason alone, so the moment Cloudflare stops
+    being the sole ingress this function stops being sound. `X-Forwarded-For` is
+    never consulted: it is caller-supplied, so an attacker keyed on it gets a
+    fresh bucket per request AND can lock out a third party by forging theirs.
+
+    Three ways to get `None`, all of them fail-closed at the call site:
+      * absent            — not a Cloudflare-proxied request
+      * not an IP address — a forged or mangled value
+      * more than one     — a caller trying to smuggle a second value past a
+                            proxy that appends rather than overwrites
+
+    Returns the NORMALISED form (`ipaddress`), so `::FFFF:1.2.3.4` and
+    `::ffff:1.2.3.4` cannot be two buckets for one attacker.
+    """
+    try:
+        values = headers.get_all(CLIENT_IP_HEADER)
+    except AttributeError:  # a plain dict, in a unit test
+        single = headers.get(CLIENT_IP_HEADER)
+        values = None if single is None else [single]
+    if not values or len(values) != 1:
+        return None
+    try:
+        return str(ipaddress.ip_address(values[0].strip()))
+    except ValueError:
+        return None
+
+
+def limiter_settings(env: dict[str, str]) -> tuple[int, float, float]:
+    """Read the three rate-limit knobs from env, or RAISE.
+
+    🔴 It raises rather than silently defaulting, for the same reason
+    `_int_param` does: a typo'd `SUBSYSTEM_STORE_MAX_FAILURES=fve` that quietly
+    became 5 is an operator believing a setting took effect. A misconfiguration
+    at startup is `EXIT_CONFIG`, visible in a CrashLoopBackOff; a
+    misconfiguration that defaults is invisible forever.
+    """
+
+    def _num(name: str, default: float, cast: Callable[[str], Any]) -> Any:
+        raw = env.get(name)
+        if raw is None or raw == "":
+            return default
+        try:
+            value = cast(raw)
+        except ValueError:
+            raise ValueError(f"{name} must be a number, got {raw!r}") from None
+        if value <= 0:
+            raise ValueError(f"{name} must be positive, got {raw!r}")
+        return value
+
+    return (
+        _num(ENV_MAX_FAILURES, DEFAULT_MAX_FAILURES, int),
+        _num(ENV_FAILURE_WINDOW, DEFAULT_FAILURE_WINDOW_S, float),
+        _num(ENV_LOCKOUT, DEFAULT_LOCKOUT_S, float),
+    )
+
+
+class RateLimiter:
+    """N failed auths per client per window -> a lockout of `lockout_s`.
+
+    §2b (B-required): "Rate-limit + lock out on repeated 401s, at the Traefik
+    middleware layer *and* in the app. Cloudflare's WAF is the third layer, not
+    the only one." This is the innermost of the three, and the only one that
+    knows an auth actually FAILED rather than that a request arrived.
+
+    Thread-safe on purpose: the server is a `ThreadingHTTPServer`, so a
+    dict-mutating limiter without a lock would drop failures under exactly the
+    concurrency a credential-stuffing run produces.
+
+    The clock is injectable so a test can prove the window and the lockout
+    EXPIRE, rather than sleeping 15 minutes or asserting only the easy half.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_failures: int = DEFAULT_MAX_FAILURES,
+        window_s: float = DEFAULT_FAILURE_WINDOW_S,
+        lockout_s: float = DEFAULT_LOCKOUT_S,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.max_failures = max_failures
+        self.window_s = window_s
+        self.lockout_s = lockout_s
+        self.clock = clock
+        self._lock = threading.Lock()
+        self._failures: dict[str, list[float]] = {}
+        self._locked_until: dict[str, float] = {}
+
+    def locked_out(self, key: str) -> bool:
+        """True while `key` is serving a lockout. Expired lockouts are dropped."""
+        now = self.clock()
+        with self._lock:
+            until = self._locked_until.get(key)
+            if until is None:
+                return False
+            if until <= now:
+                del self._locked_until[key]
+                self._failures.pop(key, None)
+                return False
+            return True
+
+    def record_failure(self, key: str) -> bool:
+        """Count one failed auth. Returns True iff THIS one started a lockout."""
+        now = self.clock()
+        with self._lock:
+            recent = [t for t in self._failures.get(key, []) if t > now - self.window_s]
+            recent.append(now)
+            if len(recent) >= self.max_failures:
+                self._locked_until[key] = now + self.lockout_s
+                self._failures.pop(key, None)
+                self._evict(now)
+                return True
+            self._failures[key] = recent
+            self._evict(now)
+            return False
+
+    def record_success(self, key: str) -> None:
+        """A good credential clears the failure streak — but NOT a live lockout.
+
+        🔴 The asymmetry is the point. Forgiving a streak keeps a legitimate
+        client from being locked out by sporadic typos across an hour; forgiving
+        a LOCKOUT would mean an attacker who eventually guessed one token could
+        wipe the record of having guessed, and `locked_out` is checked before
+        this is ever reached anyway.
+        """
+        with self._lock:
+            self._failures.pop(key, None)
+
+    def _evict(self, now: float) -> None:
+        """Bound the failure table. Called under `self._lock`.
+
+        Only entries whose whole streak has aged out of the window are dropped,
+        and ACTIVE LOCKOUTS ARE NEVER TOUCHED — evicting a lockout is a bypass
+        dressed as memory hygiene.
+        """
+        for key in [k for k, v in self._locked_until.items() if v <= now]:
+            del self._locked_until[key]
+        if len(self._failures) <= MAX_TRACKED_CLIENTS:
+            return
+        stale = [
+            key
+            for key, times in self._failures.items()
+            if not times or max(times) <= now - self.window_s
+        ]
+        for key in stale:
+            del self._failures[key]
 
 
 def scope_revision(store_root: str | Path, scope: str) -> str:
@@ -263,10 +520,17 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
     server_version = SERVER_BANNER
     sys_version = ""
 
-    # Injected by `serve()`.
+    # Injected by `build_server`.
     store_root: str = DEFAULT_STORE
-    expected_token: str = ""
+    expected_tokens: tuple[str, ...] = ()
+    limiter: RateLimiter | None = None
     audit: Callable[[str], None] = staticmethod(lambda line: print(line, flush=True))
+
+    # Per-request identity, reset at the top of every dispatch so a keep-alive
+    # connection cannot carry the previous request's fingerprint into this
+    # request's audit line.
+    _client_ip: str | None = None
+    _token_fp: str | None = None
 
     # --- plumbing ---------------------------------------------------------------
 
@@ -307,13 +571,25 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             headers={"WWW-Authenticate": 'Bearer realm="subsystem-store"'},
         )
 
-    def _audit(self, path: str, result: int, status: str, authed: bool) -> None:
+    def _audit(self, path: str, result: int, status: str) -> None:
+        """One line per `/api/*` request. `/healthz` is deliberately not audited.
+
+        🔴 `token=` is the fingerprint of the token that ACTUALLY MATCHED, not
+        of the one the server was configured with. With a token SET those differ,
+        and the difference is the entire safety of overlap rotation: it is the
+        only evidence that every client has moved off the old credential before
+        it is deleted. Nothing here is derived from `authed` any more — the
+        fingerprint's presence IS the authentication result, so the two cannot
+        disagree.
+        """
         self.audit(
             "store-api audit "
             f"ts={datetime.now(timezone.utc).isoformat(timespec='seconds')} "
+            f"ip={self._client_ip or '-'} "
             f"method={self.command} path={path} "
-            f"token={token_id(self.expected_token) if authed else '-'} "
-            f"auth={'ok' if authed else 'fail'} result={result} status={status}"
+            f"token={self._token_fp or '-'} "
+            f"auth={'ok' if self._token_fp else 'fail'} "
+            f"result={result} status={status}"
         )
 
     # --- methods ----------------------------------------------------------------
@@ -332,41 +608,90 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         router and be served as a read — a mutation that silently succeeded as a
         no-op read is indistinguishable from one that worked.
         """
+        self._client_ip = client_ip(self.headers)
+        self._token_fp = None
         self._respond(
             405,
             b"read-only\n",
             headers={"Allow": "GET, HEAD"},
         )
-        self._audit(urlsplit(self.path).path, 405, "method-not-allowed", authed=False)
+        self._audit(urlsplit(self.path).path, 405, "method-not-allowed")
 
     do_POST = do_PUT = do_PATCH = do_DELETE = _reject_write  # noqa: N815
 
     # --- the router -------------------------------------------------------------
 
+    @staticmethod
+    def _count_failure(limiter: RateLimiter | None, ip: str) -> str:
+        """Record one failed auth and name the audit status it produced."""
+        if limiter is None:
+            return "unauthorized"
+        return "lockout-triggered" if limiter.record_failure(ip) else "unauthorized"
+
+    def _refuse(self, path: str, status: str) -> None:
+        """The uniform 401, plus the audit line that says which reason it was.
+
+        🔴 THE WIRE DOES NOT DISCRIMINATE; THE LOG DOES. Every rejection below —
+        no client IP, locked out, not an API path, bad token — is the same code,
+        the same body and the same header set, because an error that
+        discriminates is an enumeration API (§2b). The `status=` field exists so
+        the operator can still tell a credential-stuffing run from a
+        misconfigured client, in a place the attacker cannot read.
+        """
+        self._unauthorized()
+        self._audit(path, 401, status)
+
     def _handle(self) -> None:
         split = urlsplit(self.path)
         path = unquote(split.path)
+        self._client_ip = None
+        self._token_fp = None
 
-        # 🔴 BEFORE AUTH, and it is the ONLY thing before auth. Unauthenticated
-        # by design (§2b) and it says nothing but "ok".
+        # 🔴 BEFORE EVERYTHING, and it is the ONLY thing before auth.
+        # Unauthenticated by design (§2b) and it says nothing but "ok". It is
+        # also the kubelet's probe, so it must not be rate-limited or require a
+        # `CF-Connecting-IP` the kubelet has no reason to send.
         if path == HEALTH_PATH:
             self._respond(200, HEALTH_BODY)
+            return
+
+        ip = client_ip(self.headers)
+        if ip is None:
+            # 🔴 FAIL CLOSED. The alternative — bucketing every unidentified
+            # request under one shared key — is the failure the whole
+            # `CF-Connecting-IP` design exists to avoid: one abuser would then
+            # lock out everybody. Nothing is counted here, precisely because
+            # there is no bucket to count into.
+            self._refuse(path, "no-client-ip")
+            return
+        self._client_ip = ip
+
+        limiter = self.limiter
+        if limiter is not None and limiter.locked_out(ip):
+            # Checked BEFORE the token: a lockout that a valid credential could
+            # walk through would not be a lockout, and an attacker who guesses
+            # one token mid-run must not have the record wiped.
+            self._refuse(path, "locked-out")
             return
 
         if not path.startswith(API_PREFIX):
             # Not an API path and not health. Answered with the SAME uniform 401
             # as a bad token: a 404 here would let an unauthenticated caller map
-            # the URL space, which is the enumeration surface §2b forbids.
-            self._unauthorized()
-            self._audit(path, 401, "unauthorized", authed=False)
+            # the URL space, which is the enumeration surface §2b forbids. It
+            # counts toward the lockout for the same reason — URL probing from
+            # one address is the same attack as token probing from one address.
+            self._refuse(path, self._count_failure(limiter, ip))
             return
 
         try:
-            authorize(self.headers.get("Authorization"), self.expected_token)
+            self._token_fp = authorize(
+                self.headers.get("Authorization"), self.expected_tokens
+            )
         except _Rejected:
-            self._unauthorized()
-            self._audit(path, 401, "unauthorized", authed=False)
+            self._refuse(path, self._count_failure(limiter, ip))
             return
+        if limiter is not None:
+            limiter.record_success(ip)
 
         params = parse_qs(split.query, keep_blank_values=True)
         rest = path[len(API_PREFIX) :]
@@ -384,7 +709,7 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             # what it did wrong.
             body = f"bad request: {exc}\n".encode("utf-8")
             self._respond(400, body, headers={"X-Store-Status": "bad-request"})
-            self._audit(path, 400, "bad-request", authed=True)
+            self._audit(path, 400, "bad-request")
             return
         except (rc.StoreMissingError, rc.EntryUnreadableError) as exc:
             # 🔴 THE STATE THIS WHOLE DESIGN EXISTS TO KEEP SEPARATE. The store
@@ -396,11 +721,11 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
                 body,
                 headers={"X-Store-Status": "store-unreachable", "X-Store-Exit": "3"},
             )
-            self._audit(path, 503, "store-unreachable", authed=True)
+            self._audit(path, 503, "store-unreachable")
             return
 
         self._respond(404, b"no such endpoint\n", headers={"X-Store-Status": "no-route"})
-        self._audit(path, 404, "no-route", authed=True)
+        self._audit(path, 404, "no-route")
 
     # --- handlers ---------------------------------------------------------------
 
@@ -429,7 +754,7 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
                 "X-Store-Revision": scope_revision(self.store_root, scope),
             },
         )
-        self._audit(path, 200, status, authed=True)
+        self._audit(path, 200, status)
 
     def _recall(self, scope: str, params: dict[str, list[str]]) -> None:
         mode_values = params.get("mode")
@@ -487,16 +812,27 @@ def build_server(
     host: str,
     port: int,
     store_root: str,
-    token: str,
+    tokens: Sequence[str],
+    limiter: RateLimiter | None = None,
     audit: Callable[[str], None] | None = None,
 ) -> ThreadingHTTPServer:
-    """Wire a server without starting it — so a test can bind :0 and drive it."""
+    """Wire a server without starting it — so a test can bind :0 and drive it.
+
+    🔴 `tokens` is a SEQUENCE, and a bare `str` is refused here as well as in
+    `authorize`. The keyword was renamed from `token=` on purpose: a caller
+    still passing the old name now fails loudly at the call, instead of silently
+    configuring the empty default set and rejecting every request — or, worse,
+    being iterated character-by-character somewhere downstream.
+    """
+    if isinstance(tokens, (str, bytes)):
+        raise TypeError("tokens must be a SEQUENCE of tokens, not one string")
 
     class _Handler(StoreRequestHandler):
         pass
 
     _Handler.store_root = store_root
-    _Handler.expected_token = token
+    _Handler.expected_tokens = tuple(tokens)
+    _Handler.limiter = limiter if limiter is not None else RateLimiter()
     if audit is not None:
         _Handler.audit = staticmethod(audit)
     return ThreadingHTTPServer((host, port), _Handler)
@@ -518,8 +854,9 @@ def main(argv: list[str] | None = None) -> int:
         "--token-file",
         default=os.environ.get("SUBSYSTEM_STORE_TOKEN_FILE", DEFAULT_TOKEN_FILE),
         help=(
-            "file holding the bearer token (mode 0600). FILE FIRST: the agent exec "
-            "sandbox strips env vars, so $SUBSYSTEM_STORE_TOKEN is the fallback"
+            "file holding the bearer token SET, ONE PER LINE, current first "
+            "(mode 0600). FILE FIRST: the agent exec sandbox strips env vars, so "
+            "$SUBSYSTEM_STORE_TOKEN is the fallback"
         ),
     )
     args = p.parse_args(argv)
@@ -539,17 +876,30 @@ def main(argv: list[str] | None = None) -> int:
         token_file = None
 
     try:
-        token = load_token(token_file, dict(os.environ))
+        tokens = load_tokens(token_file, dict(os.environ))
+        max_failures, window_s, lockout_s = limiter_settings(dict(os.environ))
     except ValueError as exc:
         print(f"subsystem-store-api: {exc}", file=sys.stderr)
         return EXIT_CONFIG
 
-    httpd = build_server(
-        host=args.host, port=args.port, store_root=args.store, token=token
+    limiter = RateLimiter(
+        max_failures=max_failures, window_s=window_s, lockout_s=lockout_s
     )
+    httpd = build_server(
+        host=args.host,
+        port=args.port,
+        store_root=args.store,
+        tokens=tokens,
+        limiter=limiter,
+    )
+    # 🔴 The startup line prints every FINGERPRINT, in the order the file lists
+    # them, and never a token. It is what makes an overlap rotation checkable:
+    # the operator reads these ids, then greps the audit log for the one that
+    # should have stopped appearing before deleting its line from the secret.
     print(
         f"subsystem-store-api: listening on {args.host}:{args.port} "
-        f"store={args.store} token-id={token_id(token)}",
+        f"store={args.store} token-ids={','.join(token_id(t) for t in tokens)} "
+        f"lockout={max_failures}/{window_s:g}s->{lockout_s:g}s",
         flush=True,
     )
     try:

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -327,6 +327,35 @@ def authorize(header: str | None, expected: Sequence[str]) -> str:
     return token_id(matched)
 
 
+def sole_header(headers: Any, name: str) -> str | None:
+    """The value of `name` iff it appears EXACTLY ONCE. Otherwise `None`.
+
+    🔴 ONE RULE, ONE PLACE. This predicate existed twice, open-coded, and was
+    correct at one site and wrong at the other — which is the shape a duplicated
+    predicate always takes. `client_ip` rejected a duplicated `CF-Connecting-IP`
+    ("a caller trying to smuggle a second value past a proxy that appends rather
+    than overwrites"); twenty lines away `_drain_body` used a bare
+    `headers.get("Content-Length")`, which silently takes the FIRST value.
+
+    A final audit walked that with a working smuggle: `Content-Length: 0`
+    followed by `Content-Length: 154` on a request that answers 200 — so the
+    connection legitimately stays open, nothing is drained, and the body is
+    served as the next request with store content in the response. The
+    `_drain_body` comment claiming "any framing this function does not fully
+    understand ends the connection" was false while a third framing walked it.
+
+    `headers.get_all` returns None for absent, a list otherwise.
+    """
+    try:
+        values = headers.get_all(name)
+    except AttributeError:  # a plain dict, in a unit test
+        single = headers.get(name)
+        values = None if single is None else [single]
+    if not values or len(values) != 1:
+        return None
+    return values[0]
+
+
 def client_ip(headers: Any) -> str | None:
     """The client's address, or `None` — and `None` means REFUSE, not "unknown".
 
@@ -351,15 +380,11 @@ def client_ip(headers: Any) -> str | None:
     test_the_address_is_NORMALISED_so_one_caller_is_one_bucket`, which uses the
     RFC 5737 documentation range.)
     """
-    try:
-        values = headers.get_all(CLIENT_IP_HEADER)
-    except AttributeError:  # a plain dict, in a unit test
-        single = headers.get(CLIENT_IP_HEADER)
-        values = None if single is None else [single]
-    if not values or len(values) != 1:
+    raw = sole_header(headers, CLIENT_IP_HEADER)
+    if raw is None:
         return None
     try:
-        address = ipaddress.ip_address(values[0].strip())
+        address = ipaddress.ip_address(raw.strip())
     except ValueError:
         return None
     return str(rate_limit_key(address))
@@ -814,8 +839,15 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         if headers.get("Transfer-Encoding"):
             self.close_connection = True
             return
-        raw_length = headers.get("Content-Length")
+        if headers.get_all("Content-Length") is None:
+            return
+        # 🔴 EXACTLY ONE Content-Length, via the SAME predicate `client_ip` uses.
+        # A bare `.get()` takes the first value, so `Content-Length: 0` followed
+        # by `Content-Length: 154` drained nothing and smuggled the body — on a
+        # 200, where the close-on-non-200 belt does not apply. Measured.
+        raw_length = sole_header(headers, "Content-Length")
         if raw_length is None:
+            self.close_connection = True
             return
         try:
             length = int(raw_length)

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -846,7 +846,14 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             if time.monotonic() > deadline:
                 self.close_connection = True
                 return
-            chunk = self.rfile.read(min(remaining, 65536))
+            # 🔴 `read1`, NOT `read`. `rfile` is a BufferedReader and `read(n)`
+            # blocks until it has ALL n bytes (or EOF) — so the deadline check
+            # above never got control back and was decorative: a caller dripping
+            # a byte at a time inside the per-recv timeout still held the thread
+            # for the whole body. Found by the test for the deadline failing,
+            # which is the only reason it was found at all. `read1` returns after
+            # one underlying recv, which is what makes the loop a loop.
+            chunk = self.rfile.read1(min(remaining, 65536))
             if not chunk:
                 self.close_connection = True
                 return
@@ -927,6 +934,15 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         if getattr(self, "headers", None) is None:
             # The request line itself was unparseable, so there is no header to
             # identify anyone by. Answer, audit, and do not keep the connection.
+            #
+            # ⚠ PROVABLY REDUNDANT TODAY, AND KEPT ANYWAY. A mutation sweep
+            # showed deleting this line changes nothing: `_respond` sets
+            # `close_connection` for every non-200, so the 401 below already
+            # closes. It stays because it is one line of defence on a
+            # smuggling-adjacent property, and because a future edit to
+            # `_respond`'s rule must not silently turn an unidentifiable caller
+            # into a keep-alive channel. Recorded as an EQUIVALENT MUTANT rather
+            # than left as an unexplained survivor.
             self.close_connection = True
             self._unauthorized()
             self._audit(path, 401, "malformed-request")

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -95,7 +95,9 @@ import argparse
 import hashlib
 import hmac
 import ipaddress
+import math
 import os
+import re
 import sys
 import threading
 import time
@@ -157,9 +159,29 @@ ENV_MAX_FAILURES = "SUBSYSTEM_STORE_MAX_FAILURES"
 ENV_FAILURE_WINDOW = "SUBSYSTEM_STORE_FAILURE_WINDOW_S"
 ENV_LOCKOUT = "SUBSYSTEM_STORE_LOCKOUT_S"
 
-# A bound on the failure table so a flood of distinct keys cannot grow it
-# without limit. Active lockouts are NEVER evicted — evicting one is a bypass.
+# 🔴 REAL bounds on both tables, enforced in `RateLimiter._evict` — see the
+# note there for why the earlier version was a bound in name only. Active
+# lockouts are NEVER evicted for space; the lockout table is instead capped, and
+# at the cap new lockouts are refused rather than old ones released.
 MAX_TRACKED_CLIENTS = 4096
+MAX_TRACKED_LOCKOUTS = 16384
+
+# How much of an unwanted request body this server will read and throw away
+# before giving up and closing the connection instead. There is no endpoint that
+# accepts a body at all, so this exists only so that a small one does not
+# desynchronise a keep-alive connection (see `_drain_body`).
+MAX_DRAIN_BYTES = 1 << 20
+
+# A scope or ref name, as it may appear in a URL path. Deliberately strict: the
+# store's own directory names are lowercase-hyphenated, and anything outside this
+# set is a caller probing the filesystem rather than naming a scope.
+#
+# ⚠ `.` IS IN THE CLASS, so `..` MATCHES THIS PATTERN. Dots are allowed because
+# entry refs contain them; the traversal cases are therefore excluded by name at
+# the call site, NOT by this regex. A guard that looks like it covers a case it
+# does not is worse than an obvious gap — which is exactly the shape this
+# comment exists to stop the next reader from re-introducing.
+SAFE_PATH_COMPONENT = re.compile(r"[A-Za-z0-9._-]+")
 
 DEFAULT_STORE = "/data"
 DEFAULT_TOKEN_FILE = "/run/secrets/subsystem-store/token"
@@ -326,9 +348,63 @@ def client_ip(headers: Any) -> str | None:
     if not values or len(values) != 1:
         return None
     try:
-        return str(ipaddress.ip_address(values[0].strip()))
+        address = ipaddress.ip_address(values[0].strip())
     except ValueError:
         return None
+    return str(rate_limit_key(address))
+
+
+def rate_limit_key(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> Any:
+    """Collapse an address to the unit a lockout should apply to.
+
+    🔴 A FULL IPv6 ADDRESS IS NOT A CLIENT, IT IS A CHOICE. An ordinary
+    residential allocation is a /64 — 2**64 addresses the same person can pick
+    freely — so keying on the full address gives one attacker 2**64 buckets and
+    the lockout becomes decorative. Worse, it is also the cheapest way to grow
+    the failure table without bound. So IPv6 is aggregated to its **/64**.
+
+    🔴 An IPv4-MAPPED IPv6 ADDRESS IS THE SAME CLIENT AS ITS IPv4 FORM. Left
+    alone, one IPv4 caller gets a free second bucket simply by reaching the edge
+    over v6 — and the guard that claimed "one caller is one bucket" only ever
+    compared two spellings of the mapped form, so it did not see this.
+    """
+    if isinstance(address, ipaddress.IPv6Address):
+        if address.ipv4_mapped is not None:
+            return address.ipv4_mapped
+        return ipaddress.ip_network(f"{address}/64", strict=False)
+    return address
+
+
+_AUDIT_SAFE = re.compile(r"[^\x20-\x7e]")
+
+
+def audit_field(value: Any, *, limit: int = 256) -> str:
+    """Make `value` safe to put in a whitespace-delimited log record.
+
+    🔴 THE AUDIT LINE IS A LOG-INJECTION SINK, AND IT IS REACHED BEFORE AUTH.
+    The request path is `unquote()`d, so `%0a` becomes a REAL NEWLINE — and this
+    record is one f-string with no escaping. An unauthenticated caller could
+    therefore emit a second, syntactically perfect line of their choosing:
+
+        GET /api/v1/x%0astore-api%20audit%20…%20token=<any>%20auth=ok%20…
+
+    That is not a cosmetic defect. This module's whole claim is that the `token=`
+    fingerprint proves which credential a client used, and the README's rotation
+    procedure says to delete the old token once its fingerprint stops appearing.
+    A caller who can forge that line can keep any fingerprint alive forever
+    (blocking rotation), fabricate an `auth=ok` from an address of their choice,
+    and drown or forge the Loki auth-fail alert.
+
+    So every field is passed through here: non-printable characters — CR, LF, NUL,
+    tabs, escapes — become `?`, spaces become `_` so a value cannot split into
+    two fields, and the result is length-capped. Percent-encoding rather than
+    replacement would be reversible, but reversibility is not what the log needs;
+    unforgeable record boundaries are.
+    """
+    text = str(value)
+    if len(text) > limit:
+        text = text[:limit] + "...truncated"
+    return _AUDIT_SAFE.sub("?", text).replace(" ", "_")
 
 
 def limiter_settings(env: dict[str, str]) -> tuple[int, float, float]:
@@ -349,6 +425,15 @@ def limiter_settings(env: dict[str, str]) -> tuple[int, float, float]:
             value = cast(raw)
         except ValueError:
             raise ValueError(f"{name} must be a number, got {raw!r}") from None
+        # 🔴 `nan` and `inf` PARSE, and both walk straight through `<= 0`
+        # (`nan <= 0` is False). Measured consequences: a nan WINDOW silently
+        # disables the limiter entirely, because `t > now - nan` is False for
+        # every recorded failure; a nan or inf LOCKOUT makes it permanent. Both
+        # are exactly the "misconfiguration that defaults is invisible forever"
+        # this function's docstring exists to prevent, arriving through the one
+        # comparison that does not order them.
+        if not math.isfinite(value):
+            raise ValueError(f"{name} must be a finite number, got {raw!r}")
         if value <= 0:
             raise ValueError(f"{name} must be positive, got {raw!r}")
         return value
@@ -412,7 +497,11 @@ class RateLimiter:
             recent = [t for t in self._failures.get(key, []) if t > now - self.window_s]
             recent.append(now)
             if len(recent) >= self.max_failures:
-                self._locked_until[key] = now + self.lockout_s
+                if (
+                    key in self._locked_until
+                    or len(self._locked_until) < MAX_TRACKED_LOCKOUTS
+                ):
+                    self._locked_until[key] = now + self.lockout_s
                 self._failures.pop(key, None)
                 self._evict(now)
                 return True
@@ -421,34 +510,63 @@ class RateLimiter:
             return False
 
     def record_success(self, key: str) -> None:
-        """A good credential clears the failure streak — but NOT a live lockout.
+        """🔴 DELIBERATELY A NO-OP. A success does NOT forgive a failure streak.
 
-        🔴 The asymmetry is the point. Forgiving a streak keeps a legitimate
-        client from being locked out by sporadic typos across an hour; forgiving
-        a LOCKOUT would mean an attacker who eventually guessed one token could
-        wipe the record of having guessed, and `locked_out` is checked before
-        this is ever reached anyway.
+        It used to. That was my invention, not the specification — which says
+        five failed auths per client per minute — and it created two attacks,
+        both of which turn on the key being an ADDRESS rather than an identity:
+
+          * an attacker holding ANY accepted token (including the old one that
+            overlap rotation deliberately keeps live) interleaves one success
+            per four guesses and brute-forces the rest of the set forever;
+          * an attacker sharing a NAT with a legitimate client is never locked
+            out at all, because the victim's ordinary traffic keeps resetting
+            the counter on their behalf.
+
+        The sliding window already provides the forgiveness this was reaching
+        for: four typos age out after `window_s` on their own. Kept as a method
+        rather than deleted so the call site still reads as a decision.
         """
-        with self._lock:
-            self._failures.pop(key, None)
+        return
 
     def _evict(self, now: float) -> None:
-        """Bound the failure table. Called under `self._lock`.
+        """Bound BOTH tables. Called under `self._lock`.
 
-        Only entries whose whole streak has aged out of the window are dropped,
-        and ACTIVE LOCKOUTS ARE NEVER TOUCHED — evicting a lockout is a bypass
-        dressed as memory hygiene.
+        🔴 THIS USED TO BE A BOUND IN NAME ONLY, and the comment saying otherwise
+        was false. It dropped only entries whose whole streak had already aged
+        out of the window — so INSIDE the window nothing was evictable and the
+        table grew without limit (measured: 20,000 keys held against a cap of
+        4,096). `_locked_until` had no cap at all (measured: 5,000). It also ran
+        `max(times)` over every entry on every failed auth, under the global
+        lock, which is O(n) per request once the table is large.
+
+        Now: expired lockouts go first (free), then aged-out failure streaks,
+        and only if the table is STILL over the cap are the oldest live streaks
+        dropped — oldest-first, so the client closest to being locked out is the
+        last to be forgotten.
+
+        ⚠ ACTIVE LOCKOUTS ARE STILL NEVER DROPPED FOR SPACE. Evicting one is a
+        bypass dressed as memory hygiene. `_locked_until` is instead bounded by
+        construction: an entry costs an attacker `max_failures` requests to
+        create, and each one expires on its own; at the cap, new lockouts are
+        refused rather than old ones released — a bounded, stated failure mode,
+        and the safe direction is not obvious enough to leave implicit.
         """
         for key in [k for k, v in self._locked_until.items() if v <= now]:
             del self._locked_until[key]
         if len(self._failures) <= MAX_TRACKED_CLIENTS:
             return
-        stale = [
-            key
-            for key, times in self._failures.items()
-            if not times or max(times) <= now - self.window_s
-        ]
-        for key in stale:
+        cutoff = now - self.window_s
+        for key in [
+            k for k, times in self._failures.items() if not times or times[-1] <= cutoff
+        ]:
+            del self._failures[key]
+        if len(self._failures) <= MAX_TRACKED_CLIENTS:
+            return
+        # Still over: drop the OLDEST live streaks. `times` is append-ordered, so
+        # `times[-1]` is that key's most recent failure — no scan of the list.
+        overflow = len(self._failures) - MAX_TRACKED_CLIENTS
+        for key in sorted(self._failures, key=lambda k: self._failures[k][-1])[:overflow]:
             del self._failures[key]
 
 
@@ -520,6 +638,12 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
     """One GET router. Everything else is a 405."""
 
     protocol_version = "HTTP/1.1"
+    # 🔴 WITHOUT THIS, `timeout` IS None AND A HALF-OPEN CONNECTION PINS A THREAD
+    # FOREVER. Measured: 50 slowloris connections held 50 live threads, and
+    # `ThreadingHTTPServer` caps neither threads nor memory. Cloudflare shields
+    # the public side, but nothing shields a caller that reaches the pod
+    # directly — which is the same exposure the CF-Connecting-IP trust rests on.
+    timeout = 15
     # Suppress the default `BaseHTTP/x.y Python/3.n` banner. An unauthenticated
     # request should not be able to read the interpreter version off the wire.
     server_version = SERVER_BANNER
@@ -558,10 +682,22 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         content_type: str = "text/plain; charset=utf-8",
         headers: dict[str, str] | None = None,
     ) -> None:
+        if code != 200:
+            # 🔴 A REJECTED REQUEST NEVER KEEPS ITS CONNECTION. Belt to
+            # `_drain_body`'s braces: if framing was ever mis-read, the socket
+            # is already untrustworthy and reusing it is the smuggling primitive
+            # itself. Costs one TCP handshake per 401, on a path nobody legitimate
+            # walks twice.
+            self.close_connection = True
         self.send_response(code)
         self.send_header("Content-Type", content_type)
         self.send_header("Content-Length", str(len(body)))
         self.send_header("Cache-Control", "no-store")
+        if self.close_connection:
+            # Setting the flag alone closes the socket but tells the PEER
+            # nothing, so a pooling proxy keeps the entry and discovers the
+            # close on its next use. Say it on the wire.
+            self.send_header("Connection", "close")
         for key, value in (headers or {}).items():
             self.send_header(key, value)
         self.end_headers()
@@ -590,11 +726,12 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         self.audit(
             "store-api audit "
             f"ts={datetime.now(timezone.utc).isoformat(timespec='seconds')} "
-            f"ip={self._client_ip or '-'} "
-            f"method={self.command} path={path} "
-            f"token={self._token_fp or '-'} "
+            f"ip={audit_field(self._client_ip or '-')} "
+            f"method={audit_field(self.command, limit=16)} "
+            f"path={audit_field(path)} "
+            f"token={audit_field(self._token_fp or '-', limit=16)} "
             f"auth={'ok' if self._token_fp else 'fail'} "
-            f"result={result} status={status}"
+            f"result={int(result)} status={audit_field(status, limit=32)}"
         )
 
     # --- methods ----------------------------------------------------------------
@@ -605,6 +742,48 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
     def do_HEAD(self) -> None:  # noqa: N802
         self._handle()
 
+    def _drain_body(self) -> None:
+        """🔴 READ AND DISCARD THE ENTITY BODY. THIS IS A SMUGGLING FIX.
+
+        `BaseHTTPRequestHandler` never reads a request body, and this server
+        keeps connections alive (HTTP/1.1). So an unread body stayed in the
+        socket buffer and was parsed as THE NEXT REQUEST on the same connection.
+        Measured: one `POST` whose body was a complete
+        `GET /api/v1/recall/<scope>` with a valid bearer returned TWO responses,
+        the second carrying store content — from a request the caller never
+        appeared to make.
+
+        Behind a proxy that pools upstream connections (Traefik does, by
+        default) that is CL.0 request smuggling: a POST body holding a PARTIAL
+        request line desynchronises the connection, and the NEXT victim request
+        completes the attacker's line — carrying the VICTIM's `Authorization`
+        header to a scope the attacker chose.
+
+        Belt and braces, because either alone is one mistake from failing:
+        drain the declared body here, and `_respond` sets `close_connection` on
+        every non-200 so a desynchronised connection cannot be reused at all.
+        """
+        try:
+            length = int(self.headers.get("Content-Length") or 0)
+        except ValueError:
+            # A malformed length means the framing is already unknowable. Do not
+            # guess; `_respond` will close the connection.
+            self.close_connection = True
+            return
+        if length <= 0:
+            return
+        if length > MAX_DRAIN_BYTES:
+            # Too big to swallow politely. Closing is the only safe answer —
+            # leaving it queued is exactly the desync above.
+            self.close_connection = True
+            return
+        remaining = length
+        while remaining > 0:
+            chunk = self.rfile.read(min(remaining, 65536))
+            if not chunk:
+                break
+            remaining -= len(chunk)
+
     def _reject_write(self) -> None:
         """🔴 PHASE 1 IS READ-ONLY, and that is enforced here, not documented.
 
@@ -612,17 +791,54 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         Until then a POST/PUT/PATCH/DELETE must not fall through to the GET
         router and be served as a read — a mutation that silently succeeded as a
         no-op read is indistinguishable from one that worked.
+
+        🔴 IT NO LONGER SHORT-CIRCUITS THE CLIENT-IP AND LOCKOUT CHECKS. It used
+        to answer 405 before either, which made it a free, unauthenticated,
+        UNMETERED channel: 31 anonymous POSTs with no token and no
+        `CF-Connecting-IP` produced 31 audit lines and counted for nothing —
+        enough to drown the Loki auth-fail alert this design relies on. A write
+        attempt from an unidentifiable or locked-out client is now the same
+        uniform 401 as everything else, and the 405 is reserved for a caller who
+        got that far.
         """
-        self._client_ip = client_ip(self.headers)
+        self._client_ip = None
         self._token_fp = None
-        self._respond(
-            405,
-            b"read-only\n",
-            headers={"Allow": "GET, HEAD"},
-        )
-        self._audit(urlsplit(self.path).path, 405, "method-not-allowed")
+        path = self._request_path()
+        if path is None:
+            return
+        self._drain_body()
+        if not self._identify_and_meter(path):
+            return
+        try:
+            # 🔴 AUTHENTICATE BEFORE ANSWERING 405. Otherwise an anonymous
+            # POST flood is still free: identified, not locked out, and never
+            # counted — 405 after 405 with nothing charged. A write attempt
+            # with no valid credential is not a "wrong method", it is an
+            # unauthorised request, and it is answered and charged as one.
+            self._token_fp = authorize(
+                self.headers.get("Authorization"), self.expected_tokens
+            )
+        except _Rejected:
+            self._refuse(path, self._count_failure(self.limiter, self._client_ip))
+            return
+        self._respond(405, b"read-only\n", headers={"Allow": "GET, HEAD"})
+        self._audit(path, 405, "method-not-allowed")
 
     do_POST = do_PUT = do_PATCH = do_DELETE = _reject_write  # noqa: N815
+
+    def send_error(self, code: int, message=None, explain=None) -> None:  # noqa: D102
+        """🔴 EVERY unhandled method answers the ONE uniform 401, not a 501 page.
+
+        `BaseHTTPRequestHandler.send_error` renders a ~350-byte HTML page that
+        echoes the method back — pre-auth, unmetered, unaudited, and a fourth
+        distinct shape for what the docstring calls "ONE 401 response,
+        byte-identical for every rejection". `OPTIONS`, `TRACE` and any invented
+        verb reached it. They now look exactly like a bad token.
+        """
+        self._client_ip = None
+        self._token_fp = None
+        self._unauthorized()
+        self._audit(self._raw_path(), code, "method-not-allowed")
 
     # --- the router -------------------------------------------------------------
 
@@ -646,11 +862,63 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         self._unauthorized()
         self._audit(path, 401, status)
 
+    def _raw_path(self) -> str:
+        """The request target, never parsed. Safe to log; safe on any input."""
+        return self.path if isinstance(self.path, str) else "-"
+
+    def _request_path(self) -> str | None:
+        """The decoded path, or `None` having already answered.
+
+        🔴 `urlsplit` RAISES on a malformed absolute-form target. Measured:
+        `GET http://[ HTTP/1.1` produced an unhandled `ValueError: Invalid IPv6
+        URL`, no response at all, a killed connection and a ~20-line traceback
+        in the pod log — pre-auth, unauthenticated, unmetered, and a cheaper
+        log-flood than any of the paths that ARE metered. Absolute-form targets
+        are mandatory-to-accept, so this is a request a conforming client may
+        legitimately send; it must be a uniform 401, not a crash.
+        """
+        try:
+            return unquote(urlsplit(self.path).path)
+        except ValueError:
+            self._client_ip = None
+            self._token_fp = None
+            self._unauthorized()
+            self._audit(self._raw_path(), 401, "malformed-target")
+            return None
+
+    def _identify_and_meter(self, path: str) -> bool:
+        """Establish the client and charge the lockout. False = already answered.
+
+        Shared by the read router and the write rejection, because a rule
+        enforced at one call site and not the other is the failure this whole
+        file keeps finding: writes used to skip both checks entirely.
+        """
+        ip = client_ip(self.headers)
+        if ip is None:
+            # 🔴 FAIL CLOSED. The alternative — bucketing every unidentified
+            # request under one shared key — is the failure the whole
+            # `CF-Connecting-IP` design exists to avoid: one abuser would then
+            # lock out everybody. Nothing is counted here, precisely because
+            # there is no bucket to count into.
+            self._refuse(path, "no-client-ip")
+            return False
+        self._client_ip = ip
+        limiter = self.limiter
+        if limiter is not None and limiter.locked_out(ip):
+            # Checked BEFORE the token: a lockout that a valid credential could
+            # walk through would not be a lockout, and an attacker who guesses
+            # one token mid-run must not have the record wiped.
+            self._refuse(path, "locked-out")
+            return False
+        return True
+
     def _handle(self) -> None:
-        split = urlsplit(self.path)
-        path = unquote(split.path)
         self._client_ip = None
         self._token_fp = None
+        path = self._request_path()
+        if path is None:
+            return
+        self._drain_body()
 
         # 🔴 BEFORE EVERYTHING, and it is the ONLY thing before auth.
         # Unauthenticated by design (§2b) and it says nothing but "ok". It is
@@ -660,24 +928,11 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             self._respond(200, HEALTH_BODY)
             return
 
-        ip = client_ip(self.headers)
-        if ip is None:
-            # 🔴 FAIL CLOSED. The alternative — bucketing every unidentified
-            # request under one shared key — is the failure the whole
-            # `CF-Connecting-IP` design exists to avoid: one abuser would then
-            # lock out everybody. Nothing is counted here, precisely because
-            # there is no bucket to count into.
-            self._refuse(path, "no-client-ip")
+        if not self._identify_and_meter(path):
             return
-        self._client_ip = ip
-
+        ip = self._client_ip
+        assert ip is not None  # set by `_identify_and_meter` on the True path
         limiter = self.limiter
-        if limiter is not None and limiter.locked_out(ip):
-            # Checked BEFORE the token: a lockout that a valid credential could
-            # walk through would not be a lockout, and an attacker who guesses
-            # one token mid-run must not have the record wiped.
-            self._refuse(path, "locked-out")
-            return
 
         if not path.startswith(API_PREFIX):
             # Not an API path and not health. Answered with the SAME uniform 401
@@ -698,9 +953,27 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         if limiter is not None:
             limiter.record_success(ip)
 
-        params = parse_qs(split.query, keep_blank_values=True)
+        params = parse_qs(urlsplit(self.path).query, keep_blank_values=True)
         rest = path[len(API_PREFIX) :]
         parts = [p for p in rest.split("/") if p]
+
+        if any(
+            part in (".", "..") or not SAFE_PATH_COMPONENT.fullmatch(part)
+            for part in parts
+        ):
+            # 🔴 A PATH COMPONENT REACHES THE FILESYSTEM. `%2e%2e` decoded to
+            # `..`, and `scope_revision` then read `<store>/../.git/HEAD` and put
+            # the result in `X-Store-Revision`. Harmless in the pod (the store
+            # root is `/data`, whose parent holds nothing) and authenticated-only
+            # — but "harmless because of where it happens to be mounted" is not a
+            # property this file should rely on. Authenticated, so it may be told
+            # what it did wrong.
+            self._respond(
+                400, b"bad request: invalid path component\n",
+                headers={"X-Store-Status": "bad-request"},
+            )
+            self._audit(path, 400, "bad-request")
+            return
 
         try:
             if len(parts) == 2 and parts[0] == "recall":

--- a/scripts/subsystem-store-api/verify-byte-identity.sh
+++ b/scripts/subsystem-store-api/verify-byte-identity.sh
@@ -108,8 +108,17 @@ for scope in "${SCOPES[@]}"; do
     fail=$((fail + 1)); continue
   fi
 
+  # 🔴 CF-Connecting-IP is REQUIRED by the server (phase 1.5): it keys the
+  # per-client rate limiter on the one header Cloudflare overwrites, and an
+  # absent one fails CLOSED rather than being bucketed with every other
+  # unidentified caller. This verifier reaches the pod directly (port-forward or
+  # in-cluster), so no proxy sets it and it must identify itself. That is not a
+  # hole: anything that can address the pod directly has already bypassed the
+  # edge, and the header is only ever TRUSTED because Cloudflare is the sole
+  # PUBLIC ingress.
   code=$(curl -sS -o "$remote_out" -D "$tmp/hdr" -w '%{http_code}' \
            -H "Authorization: Bearer $TOKEN" \
+           -H "CF-Connecting-IP: ${CLIENT_IP:-127.0.0.1}" \
            "$URL/api/v1/recall/$scope" || echo "000")
   if [[ "$code" != "200" ]]; then
     echo "FAIL scope=$scope remote HTTP $code (body: $(head -c 120 "$remote_out"))"

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -1979,13 +1979,40 @@ class TestLockoutOverHTTP:
         assert code == 401, "a valid token reset the guessing budget"
         assert "status=lockout-triggered" in audit[5]
 
-    def test_probing_NON_API_paths_also_counts_toward_the_lockout(self, store: Path):
-        """URL probing from one address is the same attack as token probing from
-        one address, and it hits the same uniform 401 — so it is counted too.
+    def test_a_WRONG_PATH_does_NOT_lock_out_a_client_holding_the_RIGHT_token(
+        self, store: Path
+    ):
+        """🔴 INVERTED BY A DELTA AUDIT, which measured the previous behaviour
+        locking out a legitimate client. Counting path probes AND removing
+        success-forgiveness combined into: five ordinary wrong paths — one of
+        them `/api/v1`, a missing trailing slash from the real prefix — and a
+        client holding the correct token was dead for 15 minutes with nothing
+        able to forgive it.
+
+        The specification says five failed AUTHS per minute. A request that
+        never reaches the token check is not a failed auth. Volumetric probing
+        belongs to the Traefik (10/s) and Cloudflare layers.
+        """
+        with running(store) as (base, audit):
+            for path in ("/favicon.ico", "/", "/robots.txt", "/metrics", "/api/v1"):
+                assert fetch(f"{base}{path}", token=GOOD_TOKEN)[0] == 401
+            code, _h, body = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+        assert code == 200, "a valid client locked itself out on wrong paths"
+        assert POINTER_LINE.encode() in body
+        assert not any("locked-out" in line for line in audit)
+        # …and they are still REFUSED and logged, or this would be a hole.
+        assert sum("status=unauthorized" in line for line in audit) == 5
+
+    def test_a_WRONG_TOKEN_still_counts_even_on_a_path_that_does_not_exist(
+        self, store: Path
+    ):
+        """The other half: the exemption above is for the PATH check, not for
+        auth. An `/api/v1/...` request with a bad token is a failed auth no
+        matter how nonsensical the route.
         """
         with running(store) as (base, _):
-            for path in ("/admin", "/.git/config", "/wp-login.php", "/", "/api"):
-                assert fetch(f"{base}{path}", token=GOOD_TOKEN)[0] == 401
+            for _ in range(5):
+                assert fetch(f"{base}/api/v1/nonsense/x", token="w" * 48)[0] == 401
             code, _h, _b = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
         assert code == 401
 
@@ -2717,3 +2744,279 @@ class TestSlowlorisCannotPinAThreadForever:
                 sock.close()
         assert data == b"", f"expected a close, got {data[:60]!r}"
         assert elapsed < api.StoreRequestHandler.timeout + 5
+
+
+# =============================================================================
+# 17. THE DELTA AUDIT ROUND — the fixes in section 16 introduced three
+# criticals, in the same commit that closed two.
+#
+# 🔴 THIS IS THE POINT OF RE-AUDITING THE DELTA, and it is not a formality:
+# every round in this repo's history has found a real defect in the PRECEDING
+# round's fix. Here the `send_error` override written to make unknown verbs
+# uniform reopened BOTH defects the rest of that commit closed — an unhandled
+# crash on a malformed request line, and a free unmetered channel — one screen
+# below the code that exists to prevent them.
+# =============================================================================
+
+
+def _speak(host: str, payload: bytes, *, wait: float = 3.0) -> bytes:
+    """Write raw bytes to a socket and read whatever comes back."""
+    import socket
+
+    name, port = host.split(":")
+    with socket.create_connection((name, int(port)), timeout=10) as sock:
+        sock.sendall(payload)
+        sock.settimeout(wait)
+        data = b""
+        try:
+            while True:
+                chunk = sock.recv(65536)
+                if not chunk:
+                    break
+                data += chunk
+        except (TimeoutError, OSError):
+            pass
+    return data
+
+
+class TestMalformedRequestLinesDoNotCrash:
+    """🔴 `parse_request` assigns `self.path` only AFTER five of its own
+    `send_error` calls, and `path` has no class-level default — so an override
+    that read `self.path` raised AttributeError on every malformed request LINE.
+    Measured: 6 of 7 probe shapes crashed, no audit record, ~25 lines of
+    traceback each, from a six-byte request.
+    """
+
+    # Each is a request LINE the stdlib rejects BEFORE assigning self.path.
+    SHAPES = [
+        b"GET /x HTTP/9.9.9.9\r\n\r\n",
+        b"GET /x HTTP/2.0\r\n\r\n",
+        b"GET\r\n\r\n",
+        b"POST /x\r\n\r\n",
+        b"GET /x y HTTP/1.1\r\n\r\n",
+    ]
+
+    @pytest.mark.parametrize("shape", SHAPES, ids=lambda s: s.split(b"\r\n")[0].decode())
+    def test_it_answers_instead_of_crashing(self, store: Path, shape: bytes):
+        with running(store) as (base, audit):
+            data = _speak(base.split("//", 1)[1], shape)
+        assert data, "the request got no response at all"
+        assert b"unauthorized\n" in data
+        # And it was RECORDED — a crash produces no audit line, which is what
+        # made this invisible to every wire-level assertion.
+        assert len(audit) == 1, f"{len(audit)} audit lines for one request"
+        assert "auth=fail" in audit[0]
+
+    def test_the_audit_line_survives_a_missing_request_path(self, store: Path):
+        with running(store) as (base, audit):
+            _speak(base.split("//", 1)[1], b"GET\r\n\r\n")
+        assert "path=-" in audit[0], audit[0]
+        assert "status=malformed-request" in audit[0]
+
+    def test_POSITIVE_CONTROL_a_WELL_FORMED_unknown_verb_still_works(
+        self, store: Path
+    ):
+        """The shape the previous round DID test — the one where `self.path`
+        happens to be set, which is exactly why the crash stayed invisible.
+        """
+        with running(store) as (base, audit):
+            data = _speak(
+                base.split("//", 1)[1],
+                f"FROBNICATE /api/v1/recall/{SCOPE} HTTP/1.1\r\n"
+                f"Host: h\r\nCF-Connecting-IP: {CLIENT_IP}\r\n\r\n".encode(),
+            )
+        assert b"401" in data.split(b"\r\n")[0]
+        assert len(audit) == 1
+
+
+class TestUnknownVerbsAreMeteredToo:
+    """The second half of the same regression: the override answered without
+    ever metering, so 30 `FROBNICATE`s wrote 30 audit lines and counted for
+    nothing — the free channel `_reject_write` had just been reordered to close,
+    widened to every verb that is not one of the six with a handler.
+    """
+
+    def _verb(self, base: str, verb: str, ip: str | None = CLIENT_IP) -> bytes:
+        headers = f"Host: h\r\n" + (f"CF-Connecting-IP: {ip}\r\n" if ip else "")
+        return _speak(
+            base.split("//", 1)[1],
+            f"{verb} /api/v1/recall/{SCOPE} HTTP/1.1\r\n{headers}\r\n".encode(),
+        )
+
+    def test_unknown_verb_probing_COUNTS_toward_the_lockout(self, store: Path):
+        with running(store) as (base, _):
+            for _ in range(5):
+                assert b"unauthorized" in self._verb(base, "FROBNICATE")
+            code, _h, _b = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+        assert code == 401, "unknown verbs were an unmetered channel"
+
+    def test_an_unknown_verb_with_NO_client_ip_fails_closed(self, store: Path):
+        with running(store) as (base, audit):
+            data = self._verb(base, "OPTIONS", ip=None)
+        assert b"unauthorized" in data
+        assert "status=no-client-ip" in audit[0]
+
+    def test_a_MALFORMED_request_line_cannot_be_a_keep_alive_channel(
+        self, store: Path
+    ):
+        """It cannot be metered — there are no headers to identify anyone by —
+        so it is bounded the only other way: one request per TCP handshake.
+        """
+        with running(store) as (base, _):
+            data = _speak(base.split("//", 1)[1], b"GET\r\n\r\n" + b"GET\r\n\r\n")
+        assert data.count(b"unauthorized\n") == 1, "the connection was reused"
+
+
+class TestSmugglingViaOtherFramings:
+    """🔴 The drain understood exactly ONE framing, and a delta audit walked it
+    with two others — each producing two responses on one socket with store
+    content in the second, on a 200 where the connection legitimately stays open
+    so the close-on-non-200 belt does not apply.
+    """
+
+    def _smuggled(self, host: str) -> bytes:
+        return (
+            f"GET /api/v1/recall/{SCOPE} HTTP/1.1\r\nHost: {host}\r\n"
+            f"Authorization: Bearer {GOOD_TOKEN}\r\n"
+            f"CF-Connecting-IP: {CLIENT_IP}\r\n\r\n"
+        ).encode()
+
+    def test_a_CHUNKED_body_cannot_smuggle_a_request(self, store: Path):
+        with running(store) as (base, _):
+            host = base.split("//", 1)[1]
+            body = self._smuggled(host)
+            payload = (
+                f"GET /healthz HTTP/1.1\r\nHost: {host}\r\n"
+                f"Transfer-Encoding: chunked\r\n\r\n"
+                f"{len(body):x}\r\n"
+            ).encode() + body + b"\r\n0\r\n\r\n"
+            data = _speak(host, payload)
+        assert data.count(b"HTTP/1.1 ") <= 1, "chunked framing smuggled a request"
+        assert POINTER_LINE.encode() not in data
+
+    def test_a_NEGATIVE_content_length_cannot_smuggle_a_request(self, store: Path):
+        with running(store) as (base, _):
+            host = base.split("//", 1)[1]
+            payload = (
+                f"GET /healthz HTTP/1.1\r\nHost: {host}\r\n"
+                f"Content-Length: -5\r\n\r\n"
+            ).encode() + self._smuggled(host)
+            data = _speak(host, payload)
+        assert data.count(b"HTTP/1.1 ") <= 1, "a negative length smuggled a request"
+        assert POINTER_LINE.encode() not in data
+
+    def test_POSITIVE_CONTROL_the_probe_CAN_see_a_second_response(self, store: Path):
+        with running(store) as (base, _):
+            host = base.split("//", 1)[1]
+            one = f"GET /healthz HTTP/1.1\r\nHost: {host}\r\n\r\n".encode()
+            data = _speak(host, one + one)
+        assert data.count(b"HTTP/1.1 ") == 2, "the probe cannot see two responses"
+
+    def test_a_DRIPPED_body_cannot_hold_a_thread_indefinitely(self, store: Path):
+        """`timeout` is per-recv, so a caller sending one byte every few seconds
+        satisfied it forever — measured holding a thread 60s for a SIX-byte
+        body. The read loop needed its own deadline.
+        """
+        import socket
+        import time
+
+        assert api.DRAIN_DEADLINE_S <= 30
+        with running(store) as (base, _):
+            name, port = base.split("//", 1)[1].split(":")
+            sock = socket.create_connection((name, int(port)), timeout=10)
+            try:
+                sock.sendall(
+                    f"POST /api/v1/recall/{SCOPE} HTTP/1.1\r\nHost: h\r\n"
+                    f"CF-Connecting-IP: {CLIENT_IP}\r\nContent-Length: 40\r\n\r\n".encode()
+                )
+                started = time.monotonic()
+                sock.settimeout(api.DRAIN_DEADLINE_S + 20)
+                sock.sendall(b"x")
+                data = sock.recv(65536)
+                elapsed = time.monotonic() - started
+            finally:
+                sock.close()
+        assert elapsed < api.DRAIN_DEADLINE_S + 15, f"held for {elapsed:.1f}s"
+        assert data == b"" or b"HTTP" in data
+
+
+class TestTheLockoutCapDoesNotLIE:
+    """At the cap, `record_failure` returned True regardless AND popped the
+    streak: the audit log claimed `lockout-triggered` for a client that was not
+    locked out, and no state accumulated at all — unlimited brute force for an
+    attacker who had first filled the table.
+
+    🔴 The cap is monkeypatched DOWN rather than filled. Filling the real one is
+    81,920 calls, which made the suite 45s slower and — worse — forced the
+    "a slot frees" case to advance the clock past the lockout, which also aged
+    out the attacker's own streak and tested nothing. A small cap reaches the
+    same branch with the states actually distinguishable.
+    """
+
+    CAP = 8
+
+    def _full(self, now: list[float], monkeypatch, **kwargs):
+        monkeypatch.setattr(api, "MAX_TRACKED_LOCKOUTS", self.CAP)
+        lim = api.RateLimiter(clock=lambda: now[0], **kwargs)
+        for i in range(self.CAP):
+            for _ in range(5):
+                lim.record_failure(f"filler{i}")
+            now[0] += 0.0001
+        assert len(lim._locked_until) == self.CAP
+        return lim
+
+    def test_at_the_cap_it_reports_FALSE_rather_than_a_lockout_it_did_not_make(
+        self, monkeypatch
+    ):
+        now = [1000.0]
+        lim = self._full(now, monkeypatch)
+        results = [lim.record_failure("attacker") for _ in range(5)]
+        assert results[-1] is False, "it claimed a lockout the table had no room for"
+        assert lim.locked_out("attacker") is False
+
+    def test_at_the_cap_the_streak_is_KEPT_so_state_still_accumulates(
+        self, monkeypatch
+    ):
+        """The half that matters for brute force: popping the streak meant every
+        five failures started over, so nothing ever accumulated. Keeping it holds
+        the client AT the threshold, so the lockout lands the moment a slot frees.
+
+        The lockout is deliberately SHORTER than the window here, so a filler can
+        expire while the attacker's streak is still live — the only arrangement
+        in which "a slot frees" is observable at all.
+        """
+        now = [1000.0]
+        lim = self._full(now, monkeypatch, lockout_s=5.0, window_s=600.0)
+        for _ in range(9):
+            lim.record_failure("attacker")
+        assert len(lim._failures.get("attacker", [])) >= 5, "the streak was reset"
+        now[0] += 6.0  # fillers expire; the attacker's streak is still in-window
+        assert lim.record_failure("attacker") is True
+        assert lim.locked_out("attacker") is True
+
+    def test_EXPIRED_lockouts_are_released_so_the_table_DRAINS(self, monkeypatch):
+        """🔴 The release loop had ZERO coverage — a surviving mutant in the
+        previous sweep — and it is the only thing that drains `_locked_until`,
+        i.e. the only reason the cap above is not permanent.
+        """
+        now = [1000.0]
+        lim = self._full(now, monkeypatch, lockout_s=5.0, window_s=600.0)
+        now[0] += 6.0
+        lim.record_failure("anyone")
+        assert len(lim._locked_until) < self.CAP, "the table never drained"
+
+
+class TestEveryAuditFieldIsEscaped:
+    def test_the_METHOD_is_escaped_not_just_the_path(self, store: Path):
+        """🔴 A surviving mutant with zero coverage: a verb can carry control
+        bytes, and the method field went into the record unescaped.
+        """
+        with running(store) as (base, audit):
+            _speak(
+                base.split("//", 1)[1],
+                f"FROB\x1b[31mNICATE /api/v1/recall/{SCOPE} HTTP/1.1\r\n"
+                f"Host: h\r\nCF-Connecting-IP: {CLIENT_IP}\r\n\r\n".encode(),
+            )
+        assert audit, "no audit line was written"
+        assert "\x1b" not in audit[0], "an escape sequence reached the log"
+        assert "\n" not in audit[0]

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -3060,3 +3060,173 @@ class TestEveryAuditFieldIsEscaped:
         assert audit, "no audit line was written"
         assert "\x1b" not in audit[0], "an escape sequence reached the log"
         assert "\n" not in audit[0]
+
+
+# =============================================================================
+# 18. THE FINAL AUDIT ROUND — a third framing, and the loop nothing looped.
+# =============================================================================
+
+
+class TestDuplicateContentLengthCannotSmuggle:
+    """🔴 A WORKING SMUGGLE, found by a final audit, in the function whose own
+    comment claimed no framing could walk it.
+
+    `Content-Length: 0` followed by `Content-Length: 154`: a bare `.get()` takes
+    the FIRST value, so nothing is drained and the body is served as the next
+    request — on a `/healthz` 200, where the connection legitimately stays open
+    and the close-on-non-200 belt does not apply.
+
+    The predicate that catches it already existed TWENTY LINES AWAY, in
+    `client_ip`, rejecting a duplicated `CF-Connecting-IP` for exactly this
+    reason. Open-coded twice, correct at one site and wrong at the other — which
+    is the shape a duplicated predicate always takes. It is now one function.
+    """
+
+    def _smuggled(self, host: str) -> bytes:
+        return (
+            f"GET /api/v1/recall/{SCOPE} HTTP/1.1\r\nHost: {host}\r\n"
+            f"Authorization: Bearer {GOOD_TOKEN}\r\n"
+            f"CF-Connecting-IP: {CLIENT_IP}\r\n\r\n"
+        ).encode()
+
+    def test_two_content_length_headers_cannot_smuggle_a_request(self, store: Path):
+        with running(store) as (base, _):
+            host = base.split("//", 1)[1]
+            body = self._smuggled(host)
+            payload = (
+                f"GET /healthz HTTP/1.1\r\nHost: {host}\r\n"
+                f"Content-Length: 0\r\nContent-Length: {len(body)}\r\n\r\n"
+            ).encode() + body
+            data = _speak(host, payload)
+        assert data.count(b"HTTP/1.1 ") <= 1, "a duplicated Content-Length smuggled"
+        assert POINTER_LINE.encode() not in data
+
+    def test_the_LARGER_value_first_is_refused_too(self, store: Path):
+        """Order must not matter — a guard that only looked at the first value
+        would pass the test above by accident if the smaller one came second.
+        """
+        with running(store) as (base, _):
+            host = base.split("//", 1)[1]
+            body = self._smuggled(host)
+            payload = (
+                f"GET /healthz HTTP/1.1\r\nHost: {host}\r\n"
+                f"Content-Length: {len(body)}\r\nContent-Length: 0\r\n\r\n"
+            ).encode() + body
+            data = _speak(host, payload)
+        assert data.count(b"HTTP/1.1 ") <= 1
+        assert POINTER_LINE.encode() not in data
+
+    def test_the_shared_predicate_is_used_by_BOTH_sites(self):
+        """Structural, and deliberately so: the behavioural tests above and the
+        duplicate-`CF-Connecting-IP` test elsewhere would both stay green if the
+        two sites drifted apart again into two correct-today copies. What is
+        being pinned is that there is ONE predicate.
+        """
+        code = _executable_tokens(SERVER_PATH)
+        assert code.count("get_all") <= 2, (
+            "header-multiplicity logic is open-coded again; it belongs in "
+            "sole_header()"
+        )
+        assert "sole_header" in code
+
+    def test_sole_header_directly(self):
+        assert api.sole_header({"X": "1"}, "X") == "1"
+        assert api.sole_header({}, "X") is None
+
+
+class TestTheDrainLoopActuallyLOOPS:
+    """🔴 A GAP THIS BRANCH CREATED. Under the old `read(n)` the drain consumed
+    the whole body in one call; `read1` is what made the loop bookkeeping
+    load-bearing — and every other smuggling test sends headers and body in ONE
+    `sendall`, so the body arrives in one segment, the loop runs once, and the
+    accumulator is never exercised. Two mutants survived the whole suite.
+
+    🔴 THE DELIVERY SHAPE DECIDES WHICH DIRECTION IS OBSERVABLE, and a first
+    version of these tests missed that. Under-consumption (a broken accumulator)
+    is only visible when the body arrives in SEVERAL segments; over-consumption
+    (a dropped `min(remaining, …)` clamp) is only visible when the body and the
+    NEXT request arrive in ONE segment, because `read1` can only over-read bytes
+    that are already buffered. One shape cannot see both.
+    """
+
+    def _exchange(self, store: Path, *, segmented: bool, fill: int = 4000) -> bytes:
+        import socket
+        import time
+
+        with running(store) as (base, _):
+            host = base.split("//", 1)[1]
+            name, port = host.split(":")
+            smuggled = (
+                f"GET /api/v1/recall/{SCOPE} HTTP/1.1\r\nHost: {host}\r\n"
+                f"Authorization: Bearer {GOOD_TOKEN}\r\n"
+                f"CF-Connecting-IP: {CLIENT_IP}\r\n\r\n"
+            ).encode()
+            body = b"F" * fill + smuggled
+            follow = f"GET /healthz HTTP/1.1\r\nHost: {host}\r\n\r\n".encode()
+            head = (
+                f"GET /healthz HTTP/1.1\r\nHost: {host}\r\n"
+                f"Content-Length: {len(body)}\r\n\r\n"
+            ).encode()
+            with socket.create_connection((name, int(port)), timeout=10) as sock:
+                if segmented:
+                    # Separate sends with gaps: each `read1` returns only what
+                    # has arrived, so the loop MUST iterate and accumulate.
+                    sock.sendall(head)
+                    time.sleep(0.05)
+                    for at in range(0, len(body), 512):
+                        sock.sendall(body[at : at + 512])
+                        time.sleep(0.01)
+                    time.sleep(0.05)
+                    sock.sendall(follow)
+                else:
+                    # One segment: everything is buffered at once, so a `read1`
+                    # without the clamp will swallow `follow` too.
+                    sock.sendall(head + body + follow)
+                sock.settimeout(4)
+                data = b""
+                try:
+                    while True:
+                        chunk = sock.recv(65536)
+                        if not chunk:
+                            break
+                        data += chunk
+                except (TimeoutError, OSError):
+                    pass
+        return data
+
+    def test_a_SEGMENTED_body_is_drained_WHOLE(self, store: Path):
+        """UNDER-consumption. A broken accumulator stops after the first
+        `read1`, leaving the tail to be parsed as the next request — which both
+        loses the caller's real next request and can serve the smuggled one.
+        """
+        data = self._exchange(store, segmented=True)
+        assert POINTER_LINE.encode() not in data, "a segmented body leaked store content"
+        assert data.count(b"HTTP/1.1 200") == 2, (
+            f"expected both /healthz answers, got {data.count(b'HTTP/1.1 200')}: "
+            f"{data[:140]!r}"
+        )
+
+    def test_a_SINGLE_SEGMENT_body_is_drained_NO_FURTHER(self, store: Path):
+        """OVER-consumption, the direction the segmented case structurally
+        cannot see. Without the `min(remaining, …)` clamp the drain reads the
+        following pipelined request out of the buffer and answers it never —
+        fail-safe for smuggling, but it silently breaks keep-alive, and "safe by
+        accident in one direction" is not a property to leave untested.
+        """
+        data = self._exchange(store, segmented=False)
+        assert POINTER_LINE.encode() not in data
+        assert data.count(b"HTTP/1.1 200") == 2, (
+            f"the drain ate the next request: {data.count(b'HTTP/1.1 200')} "
+            f"responses, {data[:140]!r}"
+        )
+
+    def test_POSITIVE_CONTROL_both_shapes_answer_TWICE_when_correct(
+        self, store: Path
+    ):
+        """Both assertions above are `== 2`, so a server that answered nothing
+        would fail them — but a HARNESS that could never see two would fail them
+        identically. This pins that the shapes themselves are well-formed.
+        """
+        for segmented in (True, False):
+            data = self._exchange(store, segmented=segmented, fill=16)
+            assert data.count(b"ok\n") == 2, f"segmented={segmented}: {data[:140]!r}"

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -44,7 +44,9 @@ status strings are all spelled again here by hand. Importing them would assert
 
 from __future__ import annotations
 
+import ast
 import hashlib
+import http.client
 import importlib.util
 import os
 import secrets
@@ -142,8 +144,16 @@ def store(tmp_path: Path) -> Path:
     return root
 
 
+# RFC 5737 TEST-NET-3, and three DISTINCT addresses: a test that used one
+# address for the client and the same one for the spoofed header could not tell
+# "keyed on CF-Connecting-IP" from "keyed on anything at all".
+CLIENT_IP = "203.0.113.7"
+OTHER_IP = "203.0.113.99"
+SPOOF_IP = "198.51.100.4"  # TEST-NET-2 — the value a forged XFF would carry
+
+
 @contextmanager
-def running(store_root, token=GOOD_TOKEN):
+def running(store_root, token=GOOD_TOKEN, *, tokens=None, limiter=None):
     """Bind a real server on :0 and drive it over a real socket.
 
     Deliberately not a handler-level unit test: the response CODE, the header
@@ -155,7 +165,8 @@ def running(store_root, token=GOOD_TOKEN):
         host="127.0.0.1",
         port=0,
         store_root=str(store_root),
-        token=token,
+        tokens=(token,) if tokens is None else tuple(tokens),
+        limiter=limiter,
         audit=audit.append,
     )
     thread = threading.Thread(target=httpd.serve_forever, daemon=True)
@@ -168,18 +179,82 @@ def running(store_root, token=GOOD_TOKEN):
         thread.join(timeout=10)
 
 
-def fetch(url: str, *, token: str | None = None, method: str = "GET", auth_header=None):
-    """Return (code, headers, body-bytes) without raising on 4xx/5xx."""
+def fetch(
+    url: str,
+    *,
+    token: str | None = None,
+    method: str = "GET",
+    auth_header=None,
+    client_ip: str | None = CLIENT_IP,
+    extra_headers: dict[str, str] | None = None,
+):
+    """Return (code, headers, body-bytes) without raising on 4xx/5xx.
+
+    🔴 `CF-Connecting-IP` is sent BY DEFAULT because the server requires it —
+    it is the rate limiter's key, and an absent one fails closed. Pass
+    `client_ip=None` to exercise exactly that.
+    """
     req = urllib.request.Request(url, method=method)
     if auth_header is not None:
         req.add_header("Authorization", auth_header)
     elif token is not None:
         req.add_header("Authorization", f"Bearer {token}")
+    if client_ip is not None:
+        req.add_header("CF-Connecting-IP", client_ip)
+    for key, value in (extra_headers or {}).items():
+        req.add_header(key, value)
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:
             return resp.status, dict(resp.headers), resp.read()
     except urllib.error.HTTPError as exc:
         return exc.code, dict(exc.headers), exc.read()
+
+
+def _raw_request(host: str, path: str, headers: list[tuple[str, str]]) -> int:
+    """GET `path` with headers put on the wire VERBATIM, duplicates included.
+
+    `urllib.request.Request.add_header` stores headers in a dict, so it silently
+    collapses a repeated header to one — which makes it structurally incapable
+    of expressing the "two `CF-Connecting-IP`s" case. `http.client.putheader`
+    can.
+    """
+    conn = http.client.HTTPConnection(host, timeout=15)
+    try:
+        conn.putrequest("GET", path, skip_host=True, skip_accept_encoding=True)
+        conn.putheader("Host", host)
+        for key, value in headers:
+            conn.putheader(key, value)
+        conn.endheaders()
+        resp = conn.getresponse()
+        resp.read()
+        return resp.status
+    finally:
+        conn.close()
+
+
+def _executable_tokens(path: Path) -> str:
+    """`path`'s source with COMMENTS and DOCSTRINGS removed, string literals kept.
+
+    A header name IS a string literal, so a scan that dropped strings could not
+    see one; a scan that kept comments would trip over the paragraphs explaining
+    why a header is refused. `ast` drops comments by construction and the walk
+    below drops docstrings, leaving exactly what executes.
+    """
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if not isinstance(
+            node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+        ):
+            continue
+        body = getattr(node, "body", None)
+        if (
+            body
+            and isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)
+        ):
+            node.body = body[1:] or [ast.Pass()]
+    return ast.unparse(tree)
 
 
 def _comparable(headers: dict) -> tuple:
@@ -206,7 +281,7 @@ def tree_hash(root: Path) -> str:
 
 
 class TestTokenLoadingGuards:
-    """`load_token` refuses to serve on a token that is absent, empty or weak.
+    """`load_tokens` refuses to serve on a token that is absent, empty or weak.
 
     🔴 Each case is built so that every EARLIER guard passes: the empty-token
     case uses a file that exists and is readable, and the too-short case uses a
@@ -216,14 +291,14 @@ class TestTokenLoadingGuards:
 
     def test_no_source_at_all_names_the_two_ways_to_supply_one(self):
         with pytest.raises(ValueError) as exc:
-            api.load_token(None, {})
+            api.load_tokens(None, {})
         assert "no token source" in str(exc.value)
         assert "--token-file" in str(exc.value)
         assert "SUBSYSTEM_STORE_TOKEN" in str(exc.value)
 
     def test_a_missing_file_is_not_confused_with_an_absent_one(self, tmp_path: Path):
         with pytest.raises(ValueError) as exc:
-            api.load_token(str(tmp_path / "nope"), {})
+            api.load_tokens(str(tmp_path / "nope"), {})
         assert "token file unreadable" in str(exc.value)
 
     def test_a_readable_file_of_whitespace_is_rejected_as_EMPTY(self, tmp_path: Path):
@@ -231,7 +306,7 @@ class TestTokenLoadingGuards:
         path = tmp_path / "tok"
         path.write_text("   \n\t\n")
         with pytest.raises(ValueError) as exc:
-            api.load_token(str(path), {})
+            api.load_tokens(str(path), {})
         assert "token is empty" in str(exc.value)
 
     def test_a_short_but_perfectly_valid_file_is_rejected_as_TOO_SHORT(
@@ -242,8 +317,11 @@ class TestTokenLoadingGuards:
         path = tmp_path / "tok"
         path.write_text("hunter2\n")
         with pytest.raises(ValueError) as exc:
-            api.load_token(str(path), {})
-        assert "token is too short" in str(exc.value)
+            api.load_tokens(str(path), {})
+        assert "is too short" in str(exc.value)
+        # The position is named even when there is only one — a message that
+        # said "the token" would have to change shape the day a second appears.
+        assert "token 1 of 1" in str(exc.value)
         # 43 chars = 256 bits base64url, pinned LITERALLY (§2b).
         assert "43" in str(exc.value)
 
@@ -254,7 +332,7 @@ class TestTokenLoadingGuards:
     def test_a_token_of_exactly_the_floor_is_accepted(self, tmp_path: Path):
         path = tmp_path / "tok"
         path.write_text("z" * 43 + "\n")
-        assert api.load_token(str(path), {}) == "z" * 43
+        assert api.load_tokens(str(path), {}) == ["z" * 43]
 
     def test_env_is_the_FALLBACK_not_the_primary(self, tmp_path: Path):
         # Both sources present: the FILE wins. The agent exec sandbox strips env
@@ -262,10 +340,12 @@ class TestTokenLoadingGuards:
         # mounted secret would make the deployed token unknowable.
         path = tmp_path / "tok"
         path.write_text("f" * 50)
-        assert api.load_token(str(path), {"SUBSYSTEM_STORE_TOKEN": "e" * 50}) == "f" * 50
+        assert api.load_tokens(str(path), {"SUBSYSTEM_STORE_TOKEN": "e" * 50}) == [
+            "f" * 50
+        ]
 
     def test_env_is_used_when_no_file_is_named(self):
-        assert api.load_token(None, {"SUBSYSTEM_STORE_TOKEN": "e" * 50}) == "e" * 50
+        assert api.load_tokens(None, {"SUBSYSTEM_STORE_TOKEN": "e" * 50}) == ["e" * 50]
 
 
 # =============================================================================
@@ -388,7 +468,7 @@ class TestConstantTimeComparison:
             return real(a, b)
 
         monkeypatch.setattr(api.hmac, "compare_digest", spy)
-        api.authorize(f"Bearer {GOOD_TOKEN}", GOOD_TOKEN)
+        api.authorize(f"Bearer {GOOD_TOKEN}", (GOOD_TOKEN,))
         assert len(seen) == 1
         # 🔴 And with the RIGHT arguments, in the right order: presented first,
         # expected second, both as bytes. A spy that only counted calls would be
@@ -396,15 +476,15 @@ class TestConstantTimeComparison:
         assert seen[0] == (GOOD_TOKEN.encode(), GOOD_TOKEN.encode())
 
     def test_BEHAVIOURAL_it_accepts_the_right_token_and_rejects_a_near_miss(self):
-        api.authorize(f"Bearer {GOOD_TOKEN}", GOOD_TOKEN)  # no raise
+        api.authorize(f"Bearer {GOOD_TOKEN}", (GOOD_TOKEN,))  # no raise
         with pytest.raises(api._Rejected):
-            api.authorize(f"Bearer {GOOD_TOKEN[:-1]}X", GOOD_TOKEN)
+            api.authorize(f"Bearer {GOOD_TOKEN[:-1]}X", (GOOD_TOKEN,))
         with pytest.raises(api._Rejected):
-            api.authorize(None, GOOD_TOKEN)
+            api.authorize(None, (GOOD_TOKEN,))
 
     def test_a_PREFIX_of_the_token_is_rejected(self):
         with pytest.raises(api._Rejected):
-            api.authorize(f"Bearer {GOOD_TOKEN[:10]}", GOOD_TOKEN)
+            api.authorize(f"Bearer {GOOD_TOKEN[:10]}", (GOOD_TOKEN,))
 
     def test_the_source_contains_no_equality_test_against_the_token(self):
         # A cheap second reading of the same property. It is NOT the guard —
@@ -1280,3 +1360,570 @@ class TestPhaseOneScope:
             text = path.read_text()
             assert "git push" not in text, f"{path.name} reaches for git push"
             assert "remote add" not in text, f"{path.name} configures a git remote"
+
+
+# =============================================================================
+# 14. PHASE 1.5 — the (B-required) hardening.
+#
+# 🔴 WHAT THESE ARE, HONESTLY. `server.py` EXISTS at the base ref, so unlike
+# every section above, some of these are real regressions: a request with no
+# `CF-Connecting-IP` and a valid token is served 200 at base and 401 here, and a
+# valid token after five failures is served 200 at base and refused here. Those
+# two are red at base for the RIGHT reason. The token-SET tests are NOT: they
+# call `build_server(tokens=…)` / `load_tokens`, which do not exist at base, so
+# their red is an API error and proves nothing. The PR body reports which is
+# which, and the mutation matrix is the evidence for the second group.
+# =============================================================================
+
+
+SECOND_TOKEN = "q" * 20 + "R" * 20 + "s" * 8  # 48 chars, disjoint from GOOD_TOKEN
+THIRD_TOKEN = "m" * 20 + "N" * 20 + "o" * 8
+
+
+class TestTokenSetAndOverlapRotation:
+    """§2b: "Token rotation must be a one-command operation and must be
+    exercised once before cutover." Overlap is what makes it one command: the
+    server accepts current AND previous, so no client is ever broken.
+    """
+
+    def _write(self, tmp_path: Path, *tokens: str) -> str:
+        path = tmp_path / "tokens"
+        path.write_text("\n".join(tokens) + "\n")
+        return str(path)
+
+    def test_two_tokens_load_as_a_set_IN_FILE_ORDER(self, tmp_path: Path):
+        path = self._write(tmp_path, GOOD_TOKEN, SECOND_TOKEN)
+        assert api.load_tokens(path, {}) == [GOOD_TOKEN, SECOND_TOKEN]
+
+    def test_a_duplicated_line_collapses_and_order_is_kept(self, tmp_path: Path):
+        path = self._write(tmp_path, SECOND_TOKEN, GOOD_TOKEN, SECOND_TOKEN)
+        assert api.load_tokens(path, {}) == [SECOND_TOKEN, GOOD_TOKEN]
+
+    def test_the_cap_is_FOUR(self):
+        # Literal, not `api.MAX_TOKENS` — importing it would assert x == x.
+        assert api.MAX_TOKENS == 4
+
+    def test_a_FIFTH_token_is_refused_at_startup(self, tmp_path: Path):
+        # Every earlier guard passes: the file exists, reads, is non-empty, and
+        # every one of the five tokens clears the length floor. Only the cap can
+        # reject this input.
+        five = [chr(ord("a") + i) * 48 for i in range(5)]
+        path = self._write(tmp_path, *five)
+        with pytest.raises(ValueError) as exc:
+            api.load_tokens(path, {})
+        assert "too many tokens" in str(exc.value)
+        assert "5" in str(exc.value)
+
+    def test_FOUR_tokens_are_accepted_the_boundary_is_not_off_by_one(
+        self, tmp_path: Path
+    ):
+        four = [chr(ord("a") + i) * 48 for i in range(4)]
+        path = self._write(tmp_path, *four)
+        assert api.load_tokens(path, {}) == four
+
+    def test_a_SHORT_SECOND_token_names_its_POSITION_and_never_the_token(
+        self, tmp_path: Path
+    ):
+        # 🔴 The reachable case that a "is the token long enough" check written
+        # against `raw.strip()` would wave straight through: the FIRST token is
+        # fine, so the file passes every earlier guard.
+        path = self._write(tmp_path, GOOD_TOKEN, "hunter2")
+        with pytest.raises(ValueError) as exc:
+            api.load_tokens(path, {})
+        message = str(exc.value)
+        assert "token 2 of 2 is too short" in message
+        assert "hunter2" not in message, "the secret was echoed into the error"
+        assert "43" in message
+
+    def test_BOTH_tokens_in_the_set_authorize_over_HTTP(self, store: Path):
+        with running(store, tokens=(GOOD_TOKEN, SECOND_TOKEN)) as (base, _):
+            for token in (GOOD_TOKEN, SECOND_TOKEN):
+                code, _h, body = fetch(f"{base}/api/v1/recall/{SCOPE}", token=token)
+                assert code == 200, f"{token[:3]}… was refused"
+                assert POINTER_LINE.encode() in body
+
+    def test_a_token_OUTSIDE_the_set_is_still_refused(self, store: Path):
+        with running(store, tokens=(GOOD_TOKEN, SECOND_TOKEN)) as (base, _):
+            code, _h, body = fetch(f"{base}/api/v1/recall/{SCOPE}", token=THIRD_TOKEN)
+        assert code == 401
+        assert body == b"unauthorized\n"
+
+    def test_the_audit_line_names_WHICH_fingerprint_matched(self, store: Path):
+        """🔴 THE ONE THING THAT MAKES OVERLAP ROTATION SAFE.
+
+        Without this, "nobody is using the old token any more" is a guess and
+        deleting it is a coin flip. A log that named the SERVER's token instead
+        of the MATCHED one would be green on a single-token deployment and
+        useless on the only deployment shape that needs it.
+        """
+        with running(store, tokens=(GOOD_TOKEN, SECOND_TOKEN)) as (base, audit):
+            fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+            fetch(f"{base}/api/v1/recall/{SCOPE}", token=SECOND_TOKEN)
+        assert len(audit) == 2
+        first, second = api.token_id(GOOD_TOKEN), api.token_id(SECOND_TOKEN)
+        assert first != second
+        assert f"token={first}" in audit[0]
+        assert f"token={second}" in audit[1]
+        assert "auth=ok" in audit[0] and "auth=ok" in audit[1]
+        # And never the credential itself, on either line.
+        joined = "\n".join(audit)
+        assert GOOD_TOKEN not in joined and SECOND_TOKEN not in joined
+
+    def test_authorize_compares_against_EVERY_token_with_no_early_exit(
+        self, monkeypatch
+    ):
+        """A `break` on the first match would make "which token did you use"
+        measurable from outside — during an overlap window that is exactly the
+        fact an attacker wants. The FIRST token matches here, so a short-circuit
+        would show up as one call instead of three.
+        """
+        seen: list[tuple] = []
+        real = api.hmac.compare_digest
+
+        def spy(a, b):
+            seen.append((a, b))
+            return real(a, b)
+
+        monkeypatch.setattr(api.hmac, "compare_digest", spy)
+        got = api.authorize(
+            f"Bearer {GOOD_TOKEN}", (GOOD_TOKEN, SECOND_TOKEN, THIRD_TOKEN)
+        )
+        assert got == api.token_id(GOOD_TOKEN)
+        assert len(seen) == 3, f"short-circuited after {len(seen)} comparisons"
+
+    def test_authorize_REFUSES_a_bare_string_rather_than_iterating_CHARACTERS(self):
+        """🔴 `for token in "abc…"` yields "a", "b", "c". Without this guard, a
+        caller who passed one token as a `str` would authorize anybody who
+        presented a SINGLE CHARACTER of it — a total auth bypass that no
+        functional test with a correct caller would ever surface.
+        """
+        with pytest.raises(TypeError) as exc:
+            api.authorize(f"Bearer {GOOD_TOKEN}", GOOD_TOKEN)
+        assert "SEQUENCE" in str(exc.value)
+        # And the hazard it describes is real: one character is not the token.
+        with pytest.raises(api._Rejected):
+            api.authorize(f"Bearer {GOOD_TOKEN[0]}", (GOOD_TOKEN,))
+
+    def test_build_server_refuses_a_bare_string_too(self, store: Path):
+        with pytest.raises(TypeError):
+            api.build_server(
+                host="127.0.0.1", port=0, store_root=str(store), tokens=GOOD_TOKEN
+            )
+
+    def test_a_ROTATION_end_to_end_old_still_works_then_stops(self, store: Path):
+        """The proposal's pre-cutover requirement, in-band: add the new token,
+        watch BOTH work and the fingerprints diverge, then remove the old one
+        and watch it be REFUSED. A rotation path never run is not a rotation
+        path — and the last step is the one that is usually skipped.
+        """
+        # Step 1: only the old token exists.
+        with running(store, tokens=(GOOD_TOKEN,)) as (base, audit):
+            assert fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)[0] == 200
+            assert fetch(f"{base}/api/v1/recall/{SCOPE}", token=SECOND_TOKEN)[0] == 401
+        # Step 2: OVERLAP — both accepted, and the log tells them apart.
+        with running(store, tokens=(SECOND_TOKEN, GOOD_TOKEN)) as (base, audit):
+            assert fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)[0] == 200
+            assert fetch(f"{base}/api/v1/recall/{SCOPE}", token=SECOND_TOKEN)[0] == 200
+        assert f"token={api.token_id(GOOD_TOKEN)}" in audit[0]
+        assert f"token={api.token_id(SECOND_TOKEN)}" in audit[1]
+        # Step 3: the old token is REMOVED. 🔴 This is the assertion that makes
+        # the whole exercise mean something.
+        with running(store, tokens=(SECOND_TOKEN,)) as (base, _):
+            assert fetch(f"{base}/api/v1/recall/{SCOPE}", token=SECOND_TOKEN)[0] == 200
+            code, _h, body = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+        assert code == 401
+        assert body == b"unauthorized\n"
+
+    def test_the_startup_banner_prints_FINGERPRINTS_never_tokens(
+        self, tmp_path: Path, store: Path, capsys, monkeypatch
+    ):
+        path = self._write(tmp_path, GOOD_TOKEN, SECOND_TOKEN)
+        started: dict = {}
+
+        class _Fake:
+            def serve_forever(self_inner):
+                raise KeyboardInterrupt
+
+            def server_close(self_inner):
+                pass
+
+        def fake_build(**kwargs):
+            started.update(kwargs)
+            return _Fake()
+
+        monkeypatch.setattr(api, "build_server", fake_build)
+        rc = api.main(["--store", str(store), "--port", "0", "--token-file", path])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert api.token_id(GOOD_TOKEN) in out
+        assert api.token_id(SECOND_TOKEN) in out
+        assert GOOD_TOKEN not in out and SECOND_TOKEN not in out
+        assert started["tokens"] == [GOOD_TOKEN, SECOND_TOKEN]
+
+
+class TestClientIpIsCloudflareOnly:
+    """§0.2: `/api/*` has no edge auth, so the app is the only place a client can
+    be identified — and it can only be identified correctly.
+    """
+
+    def test_the_audit_line_carries_the_CF_Connecting_IP(self, store: Path):
+        with running(store) as (base, audit):
+            fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, client_ip=CLIENT_IP)
+        assert f"ip={CLIENT_IP}" in audit[0]
+
+    def test_a_spoofed_X_Forwarded_For_does_NOT_win(self, store: Path):
+        """🔴 Both headers present, DIFFERENT values. The CF one must be the one
+        that is recorded and keyed on; the forged one must not appear anywhere.
+        """
+        with running(store) as (base, audit):
+            code, _h, _b = fetch(
+                f"{base}/api/v1/recall/{SCOPE}",
+                token=GOOD_TOKEN,
+                client_ip=CLIENT_IP,
+                extra_headers={"X-Forwarded-For": SPOOF_IP},
+            )
+        assert code == 200
+        assert f"ip={CLIENT_IP}" in audit[0]
+        assert SPOOF_IP not in audit[0], "a caller-supplied address was trusted"
+
+    def test_X_Forwarded_For_ALONE_fails_CLOSED(self, store: Path):
+        """The header an attacker controls cannot substitute for the one
+        Cloudflare overwrites — not even as a fallback.
+        """
+        with running(store) as (base, audit):
+            code, _h, body = fetch(
+                f"{base}/api/v1/recall/{SCOPE}",
+                token=GOOD_TOKEN,
+                client_ip=None,
+                extra_headers={"X-Forwarded-For": SPOOF_IP},
+            )
+        assert code == 401
+        assert body == b"unauthorized\n"
+        assert "status=no-client-ip" in audit[0]
+        assert SPOOF_IP not in audit[0]
+
+    def test_a_MISSING_CF_Connecting_IP_fails_closed_even_with_a_VALID_token(
+        self, store: Path
+    ):
+        with running(store) as (base, audit):
+            code, _h, body = fetch(
+                f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, client_ip=None
+            )
+        assert code == 401
+        assert body == b"unauthorized\n"
+        assert "auth=fail" in audit[0] and "ip=-" in audit[0]
+
+    def test_a_MANGLED_CF_Connecting_IP_fails_closed(self, store: Path):
+        for value in ("not-an-ip", "", "203.0.113.7, 198.51.100.4", "999.1.1.1"):
+            with running(store) as (base, _):
+                code, _h, _b = fetch(
+                    f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, client_ip=value
+                )
+            assert code == 401, f"{value!r} was accepted as a client address"
+
+    def test_TWO_CF_Connecting_IP_headers_fail_closed(self, store: Path):
+        """A proxy that APPENDS rather than overwrites would let a caller smuggle
+        a second value past it. Refuse rather than pick one.
+        """
+        # 🔴 `urllib`'s `add_header` OVERWRITES, so it cannot express this at
+        # all — a test written with it would send ONE header and pass with the
+        # guard deleted. Raw `putheader` twice is the only way to put two on the
+        # wire, and the control below proves the shape reaches the server.
+        with running(store) as (base, _):
+            host = base.split("//", 1)[1]
+            two = _raw_request(
+                host,
+                f"/api/v1/recall/{SCOPE}",
+                [
+                    ("Authorization", f"Bearer {GOOD_TOKEN}"),
+                    ("CF-Connecting-IP", CLIENT_IP),
+                    ("CF-Connecting-IP", SPOOF_IP),
+                ],
+            )
+            # POSITIVE CONTROL on the harness: the same call shape with ONE
+            # header must be served, or the 401 above would prove only that
+            # `_raw_request` is broken.
+            one = _raw_request(
+                host,
+                f"/api/v1/recall/{SCOPE}",
+                [
+                    ("Authorization", f"Bearer {GOOD_TOKEN}"),
+                    ("CF-Connecting-IP", CLIENT_IP),
+                ],
+            )
+        assert one == 200, "the raw-request harness cannot reach a 200 at all"
+        assert two == 401
+
+    def test_unidentified_requests_are_NOT_bucketed_together(self, store: Path):
+        """🔴 THE HAZARD THE FAIL-CLOSED EXISTS TO AVOID. Bucketing every
+        unidentified caller under one shared key means one abuser locks out
+        everybody. Twenty rejected no-IP requests — four times the failure
+        budget — must leave an identified client completely unaffected.
+        """
+        with running(store) as (base, _):
+            for _ in range(20):
+                assert fetch(f"{base}/api/v1/recall/{SCOPE}", client_ip=None)[0] == 401
+            code, _h, body = fetch(
+                f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, client_ip=CLIENT_IP
+            )
+        assert code == 200, "an unidentifiable caller locked out an identified one"
+        assert POINTER_LINE.encode() in body
+
+    def test_the_address_is_NORMALISED_so_one_caller_is_one_bucket(self):
+        assert api.client_ip({"CF-Connecting-IP": "::FFFF:203.0.113.7"}) == api.client_ip(
+            {"CF-Connecting-IP": "::ffff:203.0.113.7"}
+        )
+        assert api.client_ip({"CF-Connecting-IP": " 203.0.113.7 "}) == "203.0.113.7"
+        assert api.client_ip({}) is None
+        assert api.client_ip({"CF-Connecting-IP": "nope"}) is None
+
+    def test_health_needs_NO_client_ip_because_the_kubelet_sends_none(
+        self, store: Path
+    ):
+        with running(store) as (base, audit):
+            code, _h, body = fetch(f"{base}/healthz", client_ip=None)
+        assert (code, body) == (200, b"ok\n")
+        assert audit == []
+
+    def test_the_source_never_reads_X_Forwarded_For(self):
+        """Secondary, not the guard — `test_a_spoofed_X_Forwarded_For_does_NOT_win`
+        is. A behavioural test alone would stay green if XFF were consulted only
+        when `CF-Connecting-IP` is absent, which this catches directly.
+
+        🔴 It reads CODE, not text. Comments and docstrings in `server.py`
+        discuss `X-Forwarded-For` at length — that is the documentation of why
+        it is refused — so a substring scan over the file would be red for the
+        wrong reason and get "fixed" by deleting the explanation. Tokenising and
+        dropping COMMENT/STRING tokens leaves only what actually executes.
+        """
+        code = _executable_tokens(SERVER_PATH)
+        assert "X-Forwarded-For" not in code
+        assert "x-forwarded-for" not in code.lower()
+        # POSITIVE CONTROL: the tokeniser CAN see a header string in real code —
+        # otherwise the assertion above is a fact about the tokeniser.
+        assert "CF-Connecting-IP" in code
+
+
+class TestRateLimiterUnit:
+    """Injected clock, so the WINDOW and the LOCKOUT are both watched to expire.
+
+    A limiter tested only in the "locks out" direction is half a guard: one that
+    never released would take the whole store down on a typo.
+    """
+
+    def _limiter(self, now: list[float], **kwargs):
+        return api.RateLimiter(clock=lambda: now[0], **kwargs)
+
+    def test_the_defaults_are_5_per_60s_then_900s(self):
+        # Literals (§: 5 failures / minute -> 15-minute lockout), never imported.
+        assert api.DEFAULT_MAX_FAILURES == 5
+        assert api.DEFAULT_FAILURE_WINDOW_S == 60.0
+        assert api.DEFAULT_LOCKOUT_S == 900.0
+
+    def test_four_failures_do_NOT_lock_and_the_fifth_DOES(self):
+        now = [1000.0]
+        lim = self._limiter(now)
+        for i in range(4):
+            assert lim.record_failure("a") is False, f"locked after {i + 1}"
+            assert lim.locked_out("a") is False
+        assert lim.record_failure("a") is True
+        assert lim.locked_out("a") is True
+
+    def test_failures_OUTSIDE_the_window_do_not_accumulate(self):
+        now = [1000.0]
+        lim = self._limiter(now)
+        for _ in range(4):
+            assert lim.record_failure("a") is False
+        now[0] += 61.0  # the four have aged out
+        for _ in range(4):
+            assert lim.record_failure("a") is False
+        assert lim.locked_out("a") is False
+
+    def test_the_lockout_EXPIRES(self):
+        now = [1000.0]
+        lim = self._limiter(now)
+        for _ in range(5):
+            lim.record_failure("a")
+        assert lim.locked_out("a") is True
+        now[0] += 899.0
+        assert lim.locked_out("a") is True, "released early"
+        now[0] += 2.0
+        assert lim.locked_out("a") is False
+
+    def test_a_lockout_is_PER_KEY_not_global(self):
+        now = [1000.0]
+        lim = self._limiter(now)
+        for _ in range(5):
+            lim.record_failure("a")
+        assert lim.locked_out("a") is True
+        assert lim.locked_out("b") is False
+
+    def test_a_success_clears_the_STREAK(self):
+        now = [1000.0]
+        lim = self._limiter(now)
+        for _ in range(4):
+            lim.record_failure("a")
+        lim.record_success("a")
+        for _ in range(4):
+            assert lim.record_failure("a") is False
+        assert lim.locked_out("a") is False
+
+    def test_a_success_does_NOT_clear_a_LIVE_lockout(self):
+        now = [1000.0]
+        lim = self._limiter(now)
+        for _ in range(5):
+            lim.record_failure("a")
+        lim.record_success("a")
+        assert lim.locked_out("a") is True
+
+    def test_the_thresholds_are_tunable(self):
+        now = [1000.0]
+        lim = self._limiter(now, max_failures=2, window_s=10.0, lockout_s=30.0)
+        assert lim.record_failure("a") is False
+        assert lim.record_failure("a") is True
+        now[0] += 31.0
+        assert lim.locked_out("a") is False
+
+
+class TestLimiterSettings:
+    def test_an_empty_env_yields_the_code_defaults(self):
+        assert api.limiter_settings({}) == (5, 60.0, 900.0)
+
+    def test_env_overrides_all_three(self):
+        env = {
+            "SUBSYSTEM_STORE_MAX_FAILURES": "9",
+            "SUBSYSTEM_STORE_FAILURE_WINDOW_S": "30",
+            "SUBSYSTEM_STORE_LOCKOUT_S": "120",
+        }
+        assert api.limiter_settings(env) == (9, 30.0, 120.0)
+
+    def test_a_TYPO_raises_rather_than_silently_defaulting(self):
+        with pytest.raises(ValueError) as exc:
+            api.limiter_settings({"SUBSYSTEM_STORE_MAX_FAILURES": "fve"})
+        assert "SUBSYSTEM_STORE_MAX_FAILURES" in str(exc.value)
+
+    def test_a_NON_POSITIVE_value_raises(self):
+        # Reachable past the parse guard: "0" parses fine and would disable the
+        # limiter — or lock everyone out on request one, depending on the
+        # comparison. Neither is a setting anybody meant.
+        with pytest.raises(ValueError) as exc:
+            api.limiter_settings({"SUBSYSTEM_STORE_LOCKOUT_S": "0"})
+        assert "positive" in str(exc.value)
+
+    def test_main_EXITS_78_on_a_bad_limiter_setting(
+        self, store: Path, tmp_path: Path, monkeypatch, capsys
+    ):
+        path = tmp_path / "tok"
+        path.write_text(GOOD_TOKEN)
+        monkeypatch.setenv("SUBSYSTEM_STORE_MAX_FAILURES", "lots")
+        rc = api.main(["--store", str(store), "--port", "0", "--token-file", str(path)])
+        assert rc == 78
+        assert "SUBSYSTEM_STORE_MAX_FAILURES" in capsys.readouterr().err
+
+
+class TestLockoutOverHTTP:
+    """The limiter wired into the router — the layer that knows an auth FAILED.
+
+    🔴 A genuine regression against the base ref: at base, a valid token after
+    five wrong ones is served a 200.
+    """
+
+    def test_five_failures_lock_out_a_VALID_token_from_the_same_client(
+        self, store: Path
+    ):
+        with running(store) as (base, audit):
+            for _ in range(5):
+                assert fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48)[0] == 401
+            code, _h, body = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+        assert code == 401, "a locked-out client was served with a valid token"
+        assert body == b"unauthorized\n"
+        assert "status=lockout-triggered" in audit[4]
+        assert "status=locked-out" in audit[5]
+
+    def test_FOUR_failures_do_not_lock_out_the_boundary_is_not_off_by_one(
+        self, store: Path
+    ):
+        with running(store) as (base, _):
+            for _ in range(4):
+                assert fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48)[0] == 401
+            code, _h, body = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+        assert code == 200
+        assert POINTER_LINE.encode() in body
+
+    def test_the_lockout_is_PER_CLIENT_not_a_global_kill_switch(self, store: Path):
+        """🔴 The failure the `CF-Connecting-IP` keying exists to prevent: one
+        abuser must not take the store down for everyone else.
+        """
+        with running(store) as (base, _):
+            for _ in range(6):
+                fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48, client_ip=CLIENT_IP)
+            locked = fetch(
+                f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, client_ip=CLIENT_IP
+            )
+            other = fetch(
+                f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, client_ip=OTHER_IP
+            )
+        assert locked[0] == 401
+        assert other[0] == 200, "an unrelated client was caught in someone else's lockout"
+
+    def test_a_LOCKED_OUT_response_is_BYTE_IDENTICAL_to_an_ordinary_401(
+        self, store: Path
+    ):
+        """The log discriminates; the wire must not. An attacker who could see
+        the lockout land would know exactly how to pace a stuffing run.
+        """
+        with running(store) as (base, audit):
+            ordinary = fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48)
+            for _ in range(5):
+                fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48)
+            locked = fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48)
+        assert ordinary[0] == locked[0] == 401
+        assert ordinary[2] == locked[2]
+        assert _comparable(ordinary[1]) == _comparable(locked[1])
+        # …and the audit log DOES tell them apart, or the property is vacuous.
+        assert "status=unauthorized" in audit[0]
+        assert "status=locked-out" in audit[-1]
+
+    def test_a_SUCCESS_clears_the_streak_over_HTTP(self, store: Path):
+        with running(store) as (base, _):
+            for _ in range(4):
+                fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48)
+            assert fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)[0] == 200
+            for _ in range(4):
+                fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48)
+            code, _h, _b = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+        assert code == 200, "a cleared streak still locked the client out"
+
+    def test_probing_NON_API_paths_also_counts_toward_the_lockout(self, store: Path):
+        """URL probing from one address is the same attack as token probing from
+        one address, and it hits the same uniform 401 — so it is counted too.
+        """
+        with running(store) as (base, _):
+            for path in ("/admin", "/.git/config", "/wp-login.php", "/", "/api"):
+                assert fetch(f"{base}{path}", token=GOOD_TOKEN)[0] == 401
+            code, _h, _b = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+        assert code == 401
+
+    def test_the_health_probe_is_never_rate_limited(self, store: Path):
+        with running(store) as (base, _):
+            for _ in range(10):
+                fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48)
+            code, _h, body = fetch(f"{base}/healthz", client_ip=None)
+        assert (code, body) == (200, b"ok\n"), "a lockout took the readiness probe down"
+
+    def test_POST_is_STILL_405_and_not_swallowed_by_the_new_ordering(
+        self, store: Path
+    ):
+        """Phase 3 owns writes. The 405 sits ahead of the client-IP and lockout
+        checks, so none of the phase-1.5 plumbing can turn a mutation into a
+        read — pinned here because that ordering is now load-bearing.
+        """
+        with running(store) as (base, audit):
+            for method in ("POST", "PUT", "PATCH", "DELETE"):
+                code, headers, body = fetch(
+                    f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, method=method
+                )
+                assert code == 405, f"{method} answered {code}"
+                assert body == b"read-only\n"
+                assert headers["Allow"] == "GET, HEAD"
+        assert all("status=method-not-allowed" in line for line in audit)

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -1782,6 +1782,27 @@ class TestRateLimiterUnit:
         lim.record_success("a")
         assert lim.locked_out("a") is True
 
+    def test_eviction_NEVER_releases_a_live_lockout(self):
+        """🔴 The failure table is bounded, and a bound is a deletion policy —
+        so the question is what it is allowed to delete. Flooding it with more
+        distinct keys than it will hold must not buy an attacker their way out
+        of a lockout they already earned. Reachable: `MAX_TRACKED_CLIENTS` + 1
+        distinct keys, each with one failure, is exactly one eviction pass.
+        """
+        now = [1000.0]
+        lim = self._limiter(now)
+        for _ in range(5):
+            lim.record_failure("victim")
+        assert lim.locked_out("victim") is True
+        # Age every subsequent failure past the window so they are all evictable
+        # — the eviction path only ever considers stale entries.
+        for i in range(api.MAX_TRACKED_CLIENTS + 1):
+            now[0] += 0.001
+            lim.record_failure(f"flood-{i}")
+        now[0] += 61.0
+        lim.record_failure("one-more")
+        assert lim.locked_out("victim") is True, "a flood released a live lockout"
+
     def test_the_thresholds_are_tunable(self):
         now = [1000.0]
         lim = self._limiter(now, max_failures=2, window_s=10.0, lockout_s=30.0)

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -1764,12 +1764,32 @@ class TestRateLimiterUnit:
         assert lim.locked_out("a") is True
         assert lim.locked_out("b") is False
 
-    def test_a_success_clears_the_STREAK(self):
+    def test_a_success_does_NOT_forgive_the_streak(self):
+        """🔴 INVERTED BY AN AUDIT FINDING, and the old behaviour was mine, not
+        the spec's. Forgiving a streak on success created two attacks, both
+        because the key is an ADDRESS and not an identity: an attacker holding
+        ANY accepted token — including the old one overlap rotation keeps live —
+        interleaves one success per four guesses and brute-forces forever; and
+        an attacker behind the same NAT as a legitimate client is never locked
+        out, because the victim's own traffic keeps resetting them.
+        """
         now = [1000.0]
         lim = self._limiter(now)
         for _ in range(4):
             lim.record_failure("a")
         lim.record_success("a")
+        assert lim.record_failure("a") is True, "a success forgave the streak"
+        assert lim.locked_out("a") is True
+
+    def test_the_WINDOW_is_what_forgives_a_streak(self):
+        """The forgiveness the inverted test above was reaching for, done by the
+        mechanism that cannot be driven by an attacker: four typos age out.
+        """
+        now = [1000.0]
+        lim = self._limiter(now)
+        for _ in range(4):
+            assert lim.record_failure("a") is False
+        now[0] += 61.0
         for _ in range(4):
             assert lim.record_failure("a") is False
         assert lim.locked_out("a") is False
@@ -1929,15 +1949,21 @@ class TestLockoutOverHTTP:
         assert "status=unauthorized" in audit[0]
         assert "status=locked-out" in audit[-1]
 
-    def test_a_SUCCESS_clears_the_streak_over_HTTP(self, store: Path):
-        with running(store) as (base, _):
+    def test_a_SUCCESS_does_NOT_buy_more_GUESSES(self, store: Path):
+        """🔴 THE INTERLEAVE ATTACK, over HTTP. An attacker holding one accepted
+        token — the old one, during an overlap rotation — must not be able to
+        spend it to reset the budget and keep guessing the rest of the set.
+        Four wrong, one right, one wrong: the sixth request is the fifth FAILURE
+        inside the window, so it locks out.
+        """
+        with running(store, tokens=(GOOD_TOKEN, SECOND_TOKEN)) as (base, audit):
             for _ in range(4):
                 fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48)
             assert fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)[0] == 200
-            for _ in range(4):
-                fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48)
-            code, _h, _b = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
-        assert code == 200, "a cleared streak still locked the client out"
+            fetch(f"{base}/api/v1/recall/{SCOPE}", token="x" * 48)
+            code, _h, _b = fetch(f"{base}/api/v1/recall/{SCOPE}", token=SECOND_TOKEN)
+        assert code == 401, "a valid token reset the guessing budget"
+        assert "status=lockout-triggered" in audit[5]
 
     def test_probing_NON_API_paths_also_counts_toward_the_lockout(self, store: Path):
         """URL probing from one address is the same attack as token probing from
@@ -2151,3 +2177,483 @@ class TestTheDeployedEntrypoint:
         # And never a credential, on any line.
         assert GOOD_TOKEN not in stdout and SECOND_TOKEN not in stdout
         assert "w" * 48 not in stdout
+
+
+# =============================================================================
+# 16. THE AUDIT ROUND — one test per finding, each red before its fix.
+#
+# 🔴 EVERY TEST BELOW EXISTS BECAUSE A REVIEW FOUND A REAL DEFECT IN SECTIONS
+# 14-15, NOT BECAUSE OF A STYLE NOTE. Two were critical: an unauthenticated
+# caller could FORGE audit lines (defeating the exact property the token-set
+# design rests on), and an unread request body could be re-parsed as the next
+# request on a keep-alive connection (CL.0 smuggling). A fix made in response to
+# a review is a code change like any other, so each one is pinned here.
+# =============================================================================
+
+
+class TestAuditLogCannotBeForged:
+    """🔴 CRITICAL. `unquote()` turns `%0a` into a REAL newline and the audit
+    record is one f-string. An unauthenticated caller could emit a second,
+    syntactically perfect `auth=ok` line naming any fingerprint and any address.
+
+    Why that is not cosmetic: the README's rotation procedure says to delete the
+    old token once its fingerprint stops appearing in the log. A caller who can
+    keep any fingerprint appearing forever can block rotation indefinitely, and
+    one who can forge `auth=fail` at will can drown or fabricate the Loki alert.
+    """
+
+    FORGED = (
+        "store-api%20audit%20ts=2026-01-01T00:00:00+00:00%20ip=198.51.100.4"
+        "%20method=GET%20path=/api/v1/recall/x%20token=deadbeef1234%20auth=ok"
+        "%20result=200%20status=recalled"
+    )
+
+    def test_a_NEWLINE_in_the_path_cannot_open_a_second_record(self, store: Path):
+        with running(store) as (base, audit):
+            code, _h, _b = fetch(f"{base}/api/v1/x%0a{self.FORGED}")
+        assert code == 401
+        # ONE request, ONE record — the property nothing asserted before.
+        assert len(audit) == 1, f"the request produced {len(audit)} audit entries"
+        assert "\n" not in audit[0], "a newline survived into the audit record"
+        assert "\r" not in audit[0]
+        # 🔴 ASSERT THE PARSED FIELDS, NOT THE SPELLING. The escaped text still
+        # CONTAINS the characters `auth=ok` inside the path value — a substring
+        # check would be red for a record that is perfectly safe, and would then
+        # be "fixed" by scrubbing the path into uselessness. What matters is
+        # that a splitter sees one `auth` field and it says `fail`.
+        fields = [part for part in audit[0].split() if "=" in part]
+        keys = [part.split("=", 1)[0] for part in fields]
+        assert keys.count("auth") == 1, f"more than one auth field: {audit[0]}"
+        assert keys.count("token") == 1
+        parsed = dict(part.split("=", 1) for part in fields)
+        assert parsed["auth"] == "fail"
+        assert parsed["token"] == "-"
+
+    def test_the_forged_text_cannot_reach_the_log_as_SEPARATE_FIELDS(
+        self, store: Path
+    ):
+        """Escaping newlines alone is not enough — a SPACE also opens a new
+        field, so `path=/x auth=ok` would parse as two fields to any splitter.
+        """
+        with running(store) as (base, audit):
+            fetch(f"{base}/api/v1/x%20auth=ok%20token=deadbeef1234")
+        line = audit[0]
+        fields = dict(
+            part.split("=", 1) for part in line.split()[2:] if "=" in part
+        )
+        assert fields["auth"] == "fail", f"auth was forged to {fields['auth']!r}"
+        assert fields["token"] == "-"
+
+    def test_control_characters_are_neutralised_but_the_path_is_still_LEGIBLE(
+        self, store: Path
+    ):
+        with running(store) as (base, audit):
+            fetch(f"{base}/api/v1/recall/{SCOPE}%00%09%1b[31m", token=GOOD_TOKEN)
+        line = audit[0]
+        assert "\x00" not in line and "\x1b" not in line and "\t" not in line
+        # A log that scrubbed everything would be safe and useless.
+        assert SCOPE in line
+
+    def test_an_ABSURDLY_long_path_cannot_flood_one_record(self, store: Path):
+        with running(store) as (base, audit):
+            fetch(f"{base}/api/v1/{'z' * 4000}")
+        assert len(audit[0]) < 1000, "one request wrote an unbounded log record"
+        assert "truncated" in audit[0]
+
+    def test_POSITIVE_CONTROL_an_ordinary_path_is_logged_verbatim(self, store: Path):
+        """Without this, every assertion above is satisfied by a `_audit` that
+        logs nothing at all.
+        """
+        with running(store) as (base, audit):
+            fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+        assert f"path=/api/v1/recall/{SCOPE}" in audit[0]
+        assert f"token={api.token_id(GOOD_TOKEN)}" in audit[0]
+
+
+class TestNoRequestSmuggling:
+    """🔴 CRITICAL. The server keeps connections alive and never read request
+    bodies, so a body was parsed as the NEXT request on the same socket.
+
+    Behind a proxy that pools upstream connections — Traefik does by default —
+    that is CL.0 smuggling: a POST body holding a partial request line
+    desynchronises the connection and the next VICTIM request completes the
+    attacker's line, carrying the victim's `Authorization` header to a scope the
+    attacker chose.
+    """
+
+    def _raw(self, host: str, payload: bytes, expect: int = 2) -> list[bytes]:
+        """Write raw bytes on ONE socket and read every response that comes back."""
+        import socket
+
+        host_name, port = host.split(":")
+        with socket.create_connection((host_name, int(port)), timeout=10) as sock:
+            sock.sendall(payload)
+            sock.settimeout(5)
+            chunks = []
+            try:
+                while True:
+                    chunk = sock.recv(65536)
+                    if not chunk:
+                        break
+                    chunks.append(chunk)
+            except (TimeoutError, OSError):
+                pass
+        return b"".join(chunks).split(b"HTTP/1.1 ")[1:]
+
+    def test_a_POST_BODY_is_not_served_as_the_next_request(self, store: Path):
+        with running(store) as (base, _):
+            host = base.split("//", 1)[1]
+            smuggled = (
+                f"GET /api/v1/recall/{SCOPE} HTTP/1.1\r\n"
+                f"Host: {host}\r\n"
+                f"Authorization: Bearer {GOOD_TOKEN}\r\n"
+                f"CF-Connecting-IP: {CLIENT_IP}\r\n\r\n"
+            ).encode()
+            payload = (
+                f"POST /api/v1/recall/{SCOPE} HTTP/1.1\r\n"
+                f"Host: {host}\r\n"
+                f"CF-Connecting-IP: {CLIENT_IP}\r\n"
+                f"Content-Length: {len(smuggled)}\r\n\r\n"
+            ).encode() + smuggled
+            responses = self._raw(host, payload)
+        assert len(responses) == 1, (
+            f"the body was re-parsed as a request: {len(responses)} responses"
+        )
+        assert POINTER_LINE.encode() not in b"".join(responses)
+
+    def test_a_GET_with_a_body_does_not_desynchronise_the_connection(
+        self, store: Path
+    ):
+        with running(store) as (base, _):
+            host = base.split("//", 1)[1]
+            smuggled = (
+                f"GET /api/v1/recall/{SCOPE} HTTP/1.1\r\n"
+                f"Host: {host}\r\n"
+                f"Authorization: Bearer {GOOD_TOKEN}\r\n"
+                f"CF-Connecting-IP: {CLIENT_IP}\r\n\r\n"
+            ).encode()
+            payload = (
+                f"GET /healthz HTTP/1.1\r\nHost: {host}\r\n"
+                f"Content-Length: {len(smuggled)}\r\n\r\n"
+            ).encode() + smuggled
+            responses = self._raw(host, payload)
+        assert len(responses) == 1, "a GET body was re-parsed as a request"
+        assert POINTER_LINE.encode() not in b"".join(responses)
+
+    def test_POSITIVE_CONTROL_the_raw_harness_CAN_see_two_responses(
+        self, store: Path
+    ):
+        """🔴 Otherwise "1 response" is a fact about the socket reader. Two
+        genuinely pipelined requests must come back as two.
+        """
+        with running(store) as (base, _):
+            host = base.split("//", 1)[1]
+            one = (
+                f"GET /healthz HTTP/1.1\r\nHost: {host}\r\n\r\n"
+            ).encode()
+            responses = self._raw(host, one + one)
+        assert len(responses) == 2, f"the harness cannot see two: {len(responses)}"
+
+    def test_a_rejected_request_does_not_keep_its_connection(self, store: Path):
+        with running(store) as (base, _):
+            host = base.split("//", 1)[1]
+            bad = (
+                f"GET /api/v1/recall/{SCOPE} HTTP/1.1\r\nHost: {host}\r\n"
+                f"CF-Connecting-IP: {CLIENT_IP}\r\n\r\n"
+            ).encode()
+            responses = self._raw(host, bad + bad)
+        assert len(responses) == 1, "a 401 left the connection open for reuse"
+        assert b"Connection: close" in responses[0]
+
+
+class TestWritesAreMeteredLikeEverythingElse:
+    """A write attempt used to answer 405 BEFORE the client-IP and lockout
+    checks: 31 anonymous POSTs with no token and no `CF-Connecting-IP` produced
+    31 audit lines and counted for nothing. That is a free, unauthenticated,
+    unbounded channel for drowning the Loki alert this design depends on.
+    """
+
+    def test_a_POST_with_NO_client_ip_is_a_401_not_a_405(self, store: Path):
+        with running(store) as (base, audit):
+            code, _h, body = fetch(
+                f"{base}/api/v1/recall/{SCOPE}", method="POST", client_ip=None
+            )
+        assert code == 401
+        assert body == b"unauthorized\n"
+        assert "status=no-client-ip" in audit[0]
+
+    def test_POST_probing_COUNTS_toward_the_lockout(self, store: Path):
+        with running(store) as (base, _):
+            for _ in range(5):
+                fetch(f"{base}/api/v1/recall/{SCOPE}", method="POST")
+            code, _h, _b = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+        assert code == 401, "unauthenticated POSTs were an unmetered channel"
+
+    def test_a_LOCKED_OUT_client_cannot_even_learn_that_writes_are_405(
+        self, store: Path
+    ):
+        with running(store) as (base, _):
+            for _ in range(5):
+                fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48)
+            code, _h, body = fetch(
+                f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, method="POST"
+            )
+        assert (code, body) == (401, b"unauthorized\n")
+
+    def test_an_IDENTIFIED_caller_still_gets_the_405(self, store: Path):
+        """The read-only guarantee is unchanged for anyone who gets that far —
+        this is the positive control on the reordering.
+        """
+        with running(store) as (base, _):
+            for method in ("POST", "PUT", "PATCH", "DELETE"):
+                code, headers, body = fetch(
+                    f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, method=method
+                )
+                assert code == 405, f"{method} answered {code}"
+                assert body == b"read-only\n"
+                assert headers["Allow"] == "GET, HEAD"
+
+
+class TestMalformedTargetsAndUnknownMethods:
+    def test_an_absolute_form_target_that_breaks_urlsplit_is_a_401_not_a_CRASH(
+        self, store: Path
+    ):
+        """`GET http://[ HTTP/1.1` raised an unhandled ValueError: no response,
+        a killed connection, and a ~20-line traceback per request in the pod log
+        — cheaper than any metered path. Absolute-form is mandatory-to-accept.
+        """
+        import socket
+
+        with running(store) as (base, audit):
+            host = base.split("//", 1)[1]
+            with socket.create_connection(tuple(host.split(":")[:1]) + (int(host.split(":")[1]),), timeout=10) as sock:
+                sock.sendall(
+                    f"GET http://[ HTTP/1.1\r\nHost: {host}\r\n"
+                    f"CF-Connecting-IP: {CLIENT_IP}\r\n\r\n".encode()
+                )
+                sock.settimeout(5)
+                data = b""
+                try:
+                    while True:
+                        chunk = sock.recv(65536)
+                        if not chunk:
+                            break
+                        data += chunk
+                except (TimeoutError, OSError):
+                    pass
+        assert data, "the request got no response at all"
+        assert b"401" in data.split(b"\r\n")[0], data.split(b"\r\n")[0]
+        assert b"unauthorized" in data
+        assert any("status=malformed-target" in line for line in audit)
+
+    def test_an_UNKNOWN_method_is_the_same_uniform_401_not_a_501_page(
+        self, store: Path
+    ):
+        import socket
+
+        for verb in ("OPTIONS", "TRACE", "FROBNICATE"):
+            with running(store) as (base, _):
+                host = base.split("//", 1)[1]
+                name, port = host.split(":")
+                with socket.create_connection((name, int(port)), timeout=10) as sock:
+                    sock.sendall(
+                        f"{verb} /api/v1/recall/{SCOPE} HTTP/1.1\r\nHost: {host}\r\n"
+                        f"CF-Connecting-IP: {CLIENT_IP}\r\n\r\n".encode()
+                    )
+                    sock.settimeout(5)
+                    data = b""
+                    try:
+                        while True:
+                            chunk = sock.recv(65536)
+                            if not chunk:
+                                break
+                            data += chunk
+                    except (TimeoutError, OSError):
+                        pass
+            assert b"401" in data.split(b"\r\n")[0], f"{verb}: {data[:80]!r}"
+            assert b"unauthorized\n" in data
+            assert verb.encode() not in data, f"{verb} was echoed back to the caller"
+
+    def test_a_traversal_component_is_refused_before_it_reaches_the_disk(
+        self, store: Path
+    ):
+        with running(store) as (base, _):
+            code, headers, _b = fetch(
+                f"{base}/api/v1/recall/%2e%2e", token=GOOD_TOKEN
+            )
+        assert code == 400
+        assert headers["X-Store-Status"] == "bad-request"
+
+    def test_a_NORMAL_scope_name_is_still_accepted(self, store: Path):
+        """The positive control on that guard: dots are legal in refs, so the
+        pattern permits them and `..` is excluded BY NAME. A guard that rejected
+        every dot would pass the test above and break real callers.
+        """
+        with running(store) as (base, _):
+            assert fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)[0] == 200
+            code, _h, _b = fetch(
+                f"{base}/api/v1/recall/{SCOPE}?ref=thing-alpha", token=GOOD_TOKEN
+            )
+        assert code == 200
+
+
+class TestRateLimitKeyIsAClientNotAnAddress:
+    """An IPv6 /64 is one client's free choice of 2**64 addresses. Keying on the
+    full address makes the lockout decorative and is the cheapest way to grow the
+    failure table without bound.
+    """
+
+    def test_two_addresses_in_ONE_v6_slash_64_are_ONE_bucket(self, store: Path):
+        a = "2001:db8:1:2::1"
+        b = "2001:db8:1:2:ffff:ffff:ffff:ffff"
+        with running(store) as (base, _):
+            for _ in range(3):
+                fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48, client_ip=a)
+            for _ in range(2):
+                fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48, client_ip=b)
+            code, _h, _b = fetch(
+                f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, client_ip=a
+            )
+        assert code == 401, "an attacker got a fresh bucket by changing host bits"
+
+    def test_a_DIFFERENT_slash_64_is_a_DIFFERENT_bucket(self, store: Path):
+        """The negative half: aggregating to /64 must not aggregate the world.
+        Without this, `return 0` would pass the test above.
+        """
+        with running(store) as (base, _):
+            for _ in range(6):
+                fetch(
+                    f"{base}/api/v1/recall/{SCOPE}",
+                    token="w" * 48,
+                    client_ip="2001:db8:1:2::1",
+                )
+            code, _h, _b = fetch(
+                f"{base}/api/v1/recall/{SCOPE}",
+                token=GOOD_TOKEN,
+                client_ip="2001:db8:9:9::1",
+            )
+        assert code == 200, "an unrelated /64 was caught in someone else's lockout"
+
+    def test_a_v4_MAPPED_address_is_the_SAME_bucket_as_its_v4_form(self):
+        assert api.client_ip({"CF-Connecting-IP": "::ffff:203.0.113.7"}) == api.client_ip(
+            {"CF-Connecting-IP": "203.0.113.7"}
+        )
+
+    def test_v4_is_NOT_aggregated(self):
+        """A /64 rule misapplied to v4 would collapse whole ISPs into one
+        bucket. Two adjacent v4 addresses stay two clients.
+        """
+        first = api.client_ip({"CF-Connecting-IP": "203.0.113.7"})
+        second = api.client_ip({"CF-Connecting-IP": "203.0.113.8"})
+        assert first != second
+
+
+class TestTheTablesAreActuallyBounded:
+    """`MAX_TRACKED_CLIENTS` was a bound in name only: it dropped just the
+    entries that had already aged out, so INSIDE the window nothing was
+    evictable. Measured before the fix: 20,000 tracked against a cap of 4,096.
+    """
+
+    def _limiter(self, now: list[float]):
+        return api.RateLimiter(clock=lambda: now[0])
+
+    def test_the_failure_table_stays_under_the_cap_with_NON_stale_entries(self):
+        now = [1000.0]
+        lim = self._limiter(now)
+        for i in range(api.MAX_TRACKED_CLIENTS * 2):
+            now[0] += 0.0001  # every entry stays well inside the window
+            lim.record_failure(f"k{i}")
+        assert len(lim._failures) <= api.MAX_TRACKED_CLIENTS, len(lim._failures)
+
+    def test_a_LIVE_lockout_survives_that_flood(self):
+        """Bounding must never be a release valve — the whole reason the first
+        version only dropped stale entries.
+        """
+        now = [1000.0]
+        lim = self._limiter(now)
+        for _ in range(5):
+            lim.record_failure("victim")
+        assert lim.locked_out("victim") is True
+        for i in range(api.MAX_TRACKED_CLIENTS * 2):
+            now[0] += 0.0001
+            lim.record_failure(f"k{i}")
+        assert lim.locked_out("victim") is True
+
+    def test_the_lockout_table_is_bounded_too(self):
+        now = [1000.0]
+        lim = self._limiter(now)
+        for i in range(api.MAX_TRACKED_LOCKOUTS + 500):
+            for _ in range(5):
+                lim.record_failure(f"lk{i}")
+            now[0] += 0.0001
+        assert len(lim._locked_until) <= api.MAX_TRACKED_LOCKOUTS
+
+    def test_the_client_CLOSEST_to_a_lockout_is_the_LAST_forgotten(self):
+        """Oldest-first eviction, so the flood does not launder the attacker's
+        own streak out of the table.
+        """
+        now = [1000.0]
+        lim = self._limiter(now)
+        lim.record_failure("early")
+        for i in range(api.MAX_TRACKED_CLIENTS * 2):
+            now[0] += 0.0001
+            lim.record_failure(f"k{i}")
+        assert "early" not in lim._failures
+        assert f"k{api.MAX_TRACKED_CLIENTS * 2 - 1}" in lim._failures
+
+
+class TestNonFiniteLimiterSettings:
+    """`nan <= 0` is False, so both walked through the "must be positive" guard —
+    the exact "misconfiguration that defaults is invisible forever" the function
+    exists to prevent, arriving through the one comparison that does not order
+    them. Measured before the fix: a nan WINDOW silently disabled the limiter
+    entirely; a nan or inf LOCKOUT made it permanent.
+    """
+
+    @pytest.mark.parametrize("value", ["nan", "inf", "-inf", "NaN", "Infinity"])
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "SUBSYSTEM_STORE_FAILURE_WINDOW_S",
+            "SUBSYSTEM_STORE_LOCKOUT_S",
+        ],
+    )
+    def test_a_non_finite_value_is_REFUSED(self, name: str, value: str):
+        with pytest.raises(ValueError) as exc:
+            api.limiter_settings({name: value})
+        assert name in str(exc.value)
+
+    def test_a_FINITE_value_is_still_accepted(self):
+        assert api.limiter_settings(
+            {"SUBSYSTEM_STORE_LOCKOUT_S": "42.5"}
+        ) == (5, 60.0, 42.5)
+
+
+class TestSlowlorisCannotPinAThreadForever:
+    def test_the_handler_declares_a_socket_TIMEOUT(self):
+        # `timeout = None` is the stdlib default and means "wait forever".
+        # Measured before the fix: 50 half-open connections held 50 threads.
+        assert api.StoreRequestHandler.timeout is not None
+        assert 0 < api.StoreRequestHandler.timeout <= 60
+
+    def test_a_HALF_OPEN_connection_is_dropped_rather_than_held(self, store: Path):
+        """Behavioural, not a constant check: send headers with no terminating
+        blank line and watch the server give up on its own.
+        """
+        import socket
+        import time
+
+        with running(store) as (base, _):
+            host = base.split("//", 1)[1]
+            name, port = host.split(":")
+            sock = socket.create_connection((name, int(port)), timeout=10)
+            try:
+                sock.sendall(b"GET /healthz HTTP/1.1\r\n")  # never finished
+                sock.settimeout(api.StoreRequestHandler.timeout + 10)
+                started = time.monotonic()
+                data = sock.recv(65536)  # returns b"" when the server closes
+                elapsed = time.monotonic() - started
+            finally:
+                sock.close()
+        assert data == b"", f"expected a close, got {data[:60]!r}"
+        assert elapsed < api.StoreRequestHandler.timeout + 5

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -2789,7 +2789,14 @@ class TestMalformedRequestLinesDoNotCrash:
 
     # Each is a request LINE the stdlib rejects BEFORE assigning self.path.
     SHAPES = [
-        b"GET /x HTTP/9.9.9.9\r\n\r\n",
+        # A three-component version: `parse_request` raises on the split.
+        # ⚠ THREE components, deliberately not four. A four-component
+        # version string is indistinguishable from an IPv4 literal, and
+        # `test_no_public_ips` reads it as one — correctly, in a PUBLIC
+        # repo. This comment names the shape rather than quoting it, for
+        # the same reason: an explanation that quotes the banned value is
+        # the banned value.
+        b"GET /x HTTP/1.1.1\r\n\r\n",
         b"GET /x HTTP/2.0\r\n\r\n",
         b"GET\r\n\r\n",
         b"POST /x\r\n\r\n",

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -1666,7 +1666,7 @@ class TestClientIpIsCloudflareOnly:
         everybody. Twenty rejected no-IP requests — four times the failure
         budget — must leave an identified client completely unaffected.
         """
-        with running(store) as (base, _):
+        with running(store) as (base, audit):
             for _ in range(20):
                 assert fetch(f"{base}/api/v1/recall/{SCOPE}", client_ip=None)[0] == 401
             code, _h, body = fetch(
@@ -1674,6 +1674,20 @@ class TestClientIpIsCloudflareOnly:
             )
         assert code == 200, "an unidentifiable caller locked out an identified one"
         assert POINTER_LINE.encode() in body
+        # 🔴 THE ASSERTION THAT MAKES THIS TEST MEAN ANYTHING, and it was missing.
+        # An audit found this test VACUOUS against the very hazard it names:
+        # under the mutant `ip = "unknown"` (bucket every unidentified caller
+        # under one shared key) the flood locks out `"unknown"` while the final
+        # request above uses a DIFFERENT key — so it stayed green. What actually
+        # distinguishes fail-closed from a shared bucket is that the twentieth
+        # unidentified request is STILL `no-client-ip` and never `locked-out`:
+        # nothing was counted, because there was no bucket to count into.
+        statuses = {
+            line.split("status=")[1].split()[0] for line in audit[:20]
+        }
+        assert statuses == {"no-client-ip"}, statuses
+        assert not any("locked-out" in line for line in audit)
+        assert not any("lockout-triggered" in line for line in audit)
 
     def test_the_address_is_NORMALISED_so_one_caller_is_one_bucket(self):
         assert api.client_ip({"CF-Connecting-IP": "::FFFF:203.0.113.7"}) == api.client_ip(
@@ -2238,11 +2252,18 @@ class TestAuditLogCannotBeForged:
         with running(store) as (base, audit):
             fetch(f"{base}/api/v1/x%20auth=ok%20token=deadbeef1234")
         line = audit[0]
-        fields = dict(
-            part.split("=", 1) for part in line.split()[2:] if "=" in part
-        )
-        assert fields["auth"] == "fail", f"auth was forged to {fields['auth']!r}"
-        assert fields["token"] == "-"
+        # 🔴 COUNT THE FIELDS; DO NOT `dict()` THEM. A round-2 mutation sweep
+        # caught this test being vacuous: `dict()` lets the LAST occurrence win,
+        # and the genuine `auth=fail` the server appends is always last — so
+        # under the mutant that stops escaping spaces (leaving the forged
+        # `auth=ok` in the line as its own field) the assertions still passed.
+        # What a log consumer sees is a DUPLICATE key, so that is what to assert.
+        keys = [part.split("=", 1)[0] for part in line.split() if "=" in part]
+        assert keys.count("auth") == 1, f"the record has {keys.count('auth')} auth fields"
+        assert keys.count("token") == 1, f"the record has {keys.count('token')} token fields"
+        parsed = dict(part.split("=", 1) for part in line.split() if "=" in part)
+        assert parsed["auth"] == "fail"
+        assert parsed["token"] == "-"
 
     def test_control_characters_are_neutralised_but_the_path_is_still_LEGIBLE(
         self, store: Path
@@ -2301,6 +2322,13 @@ class TestNoRequestSmuggling:
         return b"".join(chunks).split(b"HTTP/1.1 ")[1:]
 
     def test_a_POST_BODY_is_not_served_as_the_next_request(self, store: Path):
+        """The end-to-end property. ⚠ It is defended by BOTH layers, so a sweep
+        shows it killed by the connection-close mutant and NOT by the
+        no-drain one — the 405 closes the socket either way. The drain's own
+        guard is the GET case below, where the response is a 200 and the
+        connection legitimately stays open. Recorded because a reader who
+        assumed this test covers the drain would delete the other one.
+        """
         with running(store) as (base, _):
             host = base.split("//", 1)[1]
             smuggled = (
@@ -2324,6 +2352,11 @@ class TestNoRequestSmuggling:
     def test_a_GET_with_a_body_does_not_desynchronise_the_connection(
         self, store: Path
     ):
+        """🔴 THIS is the drain's guard, not the POST case above. `/healthz`
+        answers 200, so the connection is deliberately kept alive and the ONLY
+        thing standing between the body and the next request is `_drain_body`.
+        Confirmed by mutation: removing the drain kills exactly this test.
+        """
         with running(store) as (base, _):
             host = base.split("//", 1)[1]
             smuggled = (
@@ -2485,14 +2518,41 @@ class TestMalformedTargetsAndUnknownMethods:
         assert headers["X-Store-Status"] == "bad-request"
 
     def test_a_NORMAL_scope_name_is_still_accepted(self, store: Path):
-        """The positive control on that guard: dots are legal in refs, so the
-        pattern permits them and `..` is excluded BY NAME. A guard that rejected
-        every dot would pass the test above and break real callers.
+        """The positive control on that guard — a guard that refused everything
+        would pass the traversal test above and break every real caller.
         """
         with running(store) as (base, _):
             assert fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)[0] == 200
             code, _h, _b = fetch(
                 f"{base}/api/v1/recall/{SCOPE}?ref=thing-alpha", token=GOOD_TOKEN
+            )
+        assert code == 200
+
+    def test_a_DOT_in_a_path_component_is_refused_at_all(self, store: Path):
+        """🔴 ADDED BECAUSE A MUTANT SURVIVED. Removing `.` from the character
+        class left the whole suite green: nothing had a dotted PATH component,
+        because refs travel in the query string. So the permissive class was
+        never justified by a caller, and the guard is now structural — no dot at
+        all, which makes `..` impossible to spell rather than excluded by name.
+
+        Measured before tightening: all 8 scopes in the live store match
+        `[A-Za-z0-9_-]+` and 0 contain a dot (counts only — the names are
+        client-confidential and this repo is public).
+        """
+        with running(store) as (base, _):
+            for probe in ("with.dot", "..", ".", "a.b.c", "%2e%2e%2f"):
+                code, _h, _b = fetch(
+                    f"{base}/api/v1/recall/{probe}", token=GOOD_TOKEN
+                )
+                assert code == 400, f"{probe!r} was accepted as a path component"
+
+    def test_the_ref_QUERY_parameter_may_still_contain_a_dot(self, store: Path):
+        """The path is strict; the query string is not, and must not become so —
+        that is the distinction the surviving mutant exposed.
+        """
+        with running(store) as (base, _):
+            code, _h, _b = fetch(
+                f"{base}/api/v1/recall/{SCOPE}?ref=thing.alpha.v2", token=GOOD_TOKEN
             )
         assert code == 200
 

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -2920,31 +2920,64 @@ class TestSmugglingViaOtherFramings:
         assert data.count(b"HTTP/1.1 ") == 2, "the probe cannot see two responses"
 
     def test_a_DRIPPED_body_cannot_hold_a_thread_indefinitely(self, store: Path):
-        """`timeout` is per-recv, so a caller sending one byte every few seconds
-        satisfied it forever — measured holding a thread 60s for a SIX-byte
-        body. The read loop needed its own deadline.
+        """`timeout` is per-RECV, so a caller that sends a byte before each
+        timeout expires satisfies it forever — measured holding a thread 60s for
+        a SIX-byte body. The read loop needed its own total deadline.
+
+        🔴 THE FIRST VERSION OF THIS TEST WAS VACUOUS, and a mutation sweep said
+        so: it sent ONE byte and then waited, so the per-recv timeout ended the
+        connection at ~15s either way and the assertion (`< deadline + 15`) was
+        satisfied with the deadline deleted. A drip test has to actually DRIP —
+        fast enough that the per-recv timeout never fires — or it measures the
+        socket timeout and calls it the deadline.
         """
         import socket
+        import threading
         import time
 
         assert api.DRAIN_DEADLINE_S <= 30
+        interval = api.DRAIN_DEADLINE_S / 4
+        assert interval < api.StoreRequestHandler.timeout, (
+            "the drip must outpace the per-recv timeout, or this measures that"
+        )
         with running(store) as (base, _):
             name, port = base.split("//", 1)[1].split(":")
             sock = socket.create_connection((name, int(port)), timeout=10)
+            stop = threading.Event()
+
+            def drip():
+                # 200 bytes at `interval` apart would take 50 * DEADLINE if the
+                # deadline did not exist.
+                for _ in range(200):
+                    if stop.wait(interval):
+                        return
+                    try:
+                        sock.sendall(b"x")
+                    except OSError:
+                        return
+
             try:
                 sock.sendall(
                     f"POST /api/v1/recall/{SCOPE} HTTP/1.1\r\nHost: h\r\n"
-                    f"CF-Connecting-IP: {CLIENT_IP}\r\nContent-Length: 40\r\n\r\n".encode()
+                    f"CF-Connecting-IP: {CLIENT_IP}\r\n"
+                    f"Content-Length: 200\r\n\r\n".encode()
                 )
                 started = time.monotonic()
-                sock.settimeout(api.DRAIN_DEADLINE_S + 20)
-                sock.sendall(b"x")
-                data = sock.recv(65536)
+                dripper = threading.Thread(target=drip, daemon=True)
+                dripper.start()
+                sock.settimeout(api.DRAIN_DEADLINE_S * 6)
+                try:
+                    sock.recv(65536)
+                except (TimeoutError, OSError):
+                    pass
                 elapsed = time.monotonic() - started
             finally:
+                stop.set()
                 sock.close()
-        assert elapsed < api.DRAIN_DEADLINE_S + 15, f"held for {elapsed:.1f}s"
-        assert data == b"" or b"HTTP" in data
+        # Without the deadline the drip keeps the connection alive far past this.
+        assert elapsed < api.DRAIN_DEADLINE_S * 3, (
+            f"a dripped body held the thread for {elapsed:.1f}s"
+        )
 
 
 class TestTheLockoutCapDoesNotLIE:

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -1505,10 +1505,16 @@ class TestTokenSetAndOverlapRotation:
             api.authorize(f"Bearer {GOOD_TOKEN[0]}", (GOOD_TOKEN,))
 
     def test_build_server_refuses_a_bare_string_too(self, store: Path):
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError) as exc:
             api.build_server(
                 host="127.0.0.1", port=0, store_root=str(store), tokens=GOOD_TOKEN
             )
+        # 🔴 The MESSAGE, not just the type. At the base ref this call raises
+        # `TypeError: unexpected keyword argument 'tokens'` — so a bare
+        # `pytest.raises(TypeError)` is GREEN AT BASE for a completely different
+        # reason, which is a vacuous guard. Pinning the sentence makes the test
+        # a statement about the guard rather than about the signature.
+        assert "SEQUENCE" in str(exc.value)
 
     def test_a_ROTATION_end_to_end_old_still_works_then_stops(self, store: Path):
         """The proposal's pre-cutover requirement, in-band: add the new token,
@@ -1927,3 +1933,182 @@ class TestLockoutOverHTTP:
                 assert body == b"read-only\n"
                 assert headers["Allow"] == "GET, HEAD"
         assert all("status=method-not-allowed" in line for line in audit)
+
+
+# =============================================================================
+# 15. The REAL entrypoint, driven as a SUBPROCESS.
+#
+# 🔴 THIS SECTION EXISTS TO BE RED AT THE BASE REF FOR THE RIGHT REASON.
+# Everything in section 14 that touches the server calls `build_server(tokens=…)`
+# or `load_tokens`, neither of which exists at base — so its red is an
+# AttributeError, which is a collection error wearing a failure's clothes and
+# proves nothing (the same trap phase 1's header calls out).
+#
+# The COMMAND LINE, by contrast, is unchanged between the two refs:
+# `server.py --store --host --port --token-file` parses identically at base. So
+# a test that spawns the real process and drives it over a real socket runs on
+# BOTH trees, and its failure at base is a statement about BEHAVIOUR:
+#
+#   * base serves 200 to a valid token with no `CF-Connecting-IP` at all
+#   * base serves 200 to a valid token after five wrong ones from one address
+#   * base treats a TWO-LINE token file as ONE 97-character token, so neither
+#     line authorises anything — an overlap rotation is impossible
+#
+# It is also the only test here that reads the audit line off the process's
+# STDOUT, which is the stream Loki actually ingests. The in-process `audit`
+# callback used everywhere above is a different code path.
+# =============================================================================
+
+
+def _free_port() -> int:
+    import socket
+
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@contextmanager
+def running_subprocess(store_root: Path, token_file: Path):
+    """Spawn the REAL `server.py` process and wait for it to answer /healthz."""
+    import time
+
+    port = _free_port()
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            str(SERVER_PATH),
+            "--store",
+            str(store_root),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--token-file",
+            str(token_file),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env={**os.environ, "PYTHONUNBUFFERED": "1"},
+    )
+    base = f"http://127.0.0.1:{port}"
+    try:
+        deadline = time.time() + 20
+        while time.time() < deadline:
+            if proc.poll() is not None:
+                out, err = proc.communicate()
+                raise AssertionError(f"server exited {proc.returncode}: {err or out}")
+            try:
+                if fetch(f"{base}/healthz", client_ip=None)[0] == 200:
+                    break
+            except Exception:
+                time.sleep(0.1)
+        else:
+            raise AssertionError("server never became healthy")
+        yield base, proc
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:  # pragma: no cover
+            proc.kill()
+            proc.wait(timeout=10)
+
+
+class TestTheDeployedEntrypoint:
+    """🔴 RED AT THE BASE REF BEHAVIOURALLY, not by AttributeError."""
+
+    @pytest.fixture
+    def token_file(self, tmp_path: Path) -> Path:
+        path = tmp_path / "token"
+        path.write_text(GOOD_TOKEN + "\n")
+        return path
+
+    @pytest.fixture
+    def rotating_token_file(self, tmp_path: Path) -> Path:
+        """Two tokens, one per line — the overlap-rotation shape."""
+        path = tmp_path / "tokens"
+        path.write_text(f"{SECOND_TOKEN}\n{GOOD_TOKEN}\n")
+        return path
+
+    def test_POSITIVE_CONTROL_the_spawned_process_serves_a_real_digest(
+        self, store: Path, token_file: Path
+    ):
+        """Before any zero or any 401 below is believed: this call shape CAN
+        return a 200 with content from a process spawned exactly this way.
+        """
+        with running_subprocess(store, token_file) as (base, _proc):
+            code, headers, body = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+        assert code == 200
+        assert headers["X-Store-Status"] == "recalled"
+        assert POINTER_LINE.encode() in body
+
+    def test_a_valid_token_with_NO_client_ip_is_REFUSED(
+        self, store: Path, token_file: Path
+    ):
+        """Base serves this 200. The store would be reachable by anything that
+        held the token, from anywhere, with no address recorded against it.
+        """
+        with running_subprocess(store, token_file) as (base, _proc):
+            code, _h, body = fetch(
+                f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, client_ip=None
+            )
+        assert code == 401
+        assert body == b"unauthorized\n"
+
+    def test_five_wrong_tokens_LOCK_OUT_the_right_one(
+        self, store: Path, token_file: Path
+    ):
+        """Base serves the sixth request 200 — an unlimited online guessing
+        budget against the one credential protecting the whole store.
+        """
+        with running_subprocess(store, token_file) as (base, _proc):
+            for _ in range(5):
+                assert fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48)[0] == 401
+            code, _h, _b = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+        assert code == 401, "an unlimited guessing budget survived"
+
+    def test_a_TWO_LINE_token_file_authorises_BOTH_lines(
+        self, store: Path, rotating_token_file: Path
+    ):
+        """Base reads the whole file as ONE 97-character token, so NEITHER line
+        works and an overlap rotation cannot be performed at all.
+        """
+        with running_subprocess(store, rotating_token_file) as (base, _proc):
+            for token in (GOOD_TOKEN, SECOND_TOKEN):
+                code, _h, _b = fetch(f"{base}/api/v1/recall/{SCOPE}", token=token)
+                assert code == 200, f"{token[:3]}… was refused during overlap"
+            outside = fetch(f"{base}/api/v1/recall/{SCOPE}", token=THIRD_TOKEN)[0]
+        assert outside == 401, "the set accepted a token that is not in it"
+
+    def test_the_STDOUT_audit_stream_names_the_matched_fingerprint(
+        self, store: Path, rotating_token_file: Path
+    ):
+        """🔴 The stream Loki ingests, not the in-process callback — and the
+        field the `SubsystemStoreAuthFailSpike` rule keys on.
+
+        Base prints the CONFIGURED token's id on every line, so during an
+        overlap it cannot tell you which credential a client actually used,
+        which is the one fact that makes retiring the old one safe.
+        """
+        with running_subprocess(store, rotating_token_file) as (base, proc):
+            fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+            fetch(f"{base}/api/v1/recall/{SCOPE}", token=SECOND_TOKEN)
+            fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48)
+            proc.terminate()
+            stdout, _stderr = proc.communicate(timeout=15)
+
+        lines = [ln for ln in stdout.splitlines() if ln.startswith("store-api audit ")]
+        assert len(lines) == 3, f"expected 3 audit lines, got {len(lines)}: {stdout}"
+        assert f"token={api.token_id(GOOD_TOKEN)}" in lines[0]
+        assert f"token={api.token_id(SECOND_TOKEN)}" in lines[1]
+        assert api.token_id(GOOD_TOKEN) != api.token_id(SECOND_TOKEN)
+        # The failure line: no fingerprint, `auth=fail`, and the client address —
+        # the three fields the Loki alert selects on.
+        assert "auth=fail" in lines[2] and "token=-" in lines[2]
+        assert f"ip={CLIENT_IP}" in lines[2]
+        assert "result=401" in lines[2]
+        # And never a credential, on any line.
+        assert GOOD_TOKEN not in stdout and SECOND_TOKEN not in stdout
+        assert "w" * 48 not in stdout

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -1840,6 +1840,24 @@ class TestLimiterSettings:
     def test_main_EXITS_78_on_a_bad_limiter_setting(
         self, store: Path, tmp_path: Path, monkeypatch, capsys
     ):
+        """🔴 `build_server` IS STUBBED TO RAISE, AND THAT IS THE POINT, NOT
+        TIDINESS. Found by the mutation sweep: with the parse guard broken to
+        `return default`, `main` sails past the check and reaches
+        `serve_forever()` — so this test does not FAIL, it HANGS, forever, and
+        every test after it in the run is silently truncated (claude/RULES.md:
+        "a known-red slow test eats the suite budget"). A guard whose mutant
+        hangs the suite is worse than one with no test at all, because the
+        symptom reads as infrastructure. The stub turns that hang into an
+        immediate, named failure.
+        """
+
+        def _must_not_be_reached(**kwargs):
+            raise AssertionError(
+                "main() reached build_server on a bad SUBSYSTEM_STORE_MAX_FAILURES "
+                "— the limiter setting was accepted instead of exiting 78"
+            )
+
+        monkeypatch.setattr(api, "build_server", _must_not_be_reached)
         path = tmp_path / "tok"
         path.write_text(GOOD_TOKEN)
         monkeypatch.setenv("SUBSYSTEM_STORE_MAX_FAILURES", "lots")


### PR DESCRIPTION
Phase 1.5 of `claudedocs/proposal-subsystem-store-homelab.md`: the `(B-required)` hardening from §2b. **This PR creates no route** — the IngressRoute and DNS Ingress are a separate, deliberately unmerged homelab-infra PR.

Exposure **B** is decided: public `store.zacx.dev`, Cloudflare-proxied, and `/api/*` carries **no edge auth** because Authelia's 302 is unusable from a CLI. So the bearer token is the only thing between the public internet and client-confidential content, and every item below stops being optional.

## What lands

| | |
|---|---|
| **A token SET, not a token** | `load_tokens` reads one per line, current first. Overlap rotation: both accepted, so no client is ever broken. Capped at 4 — every line is a live credential. |
| **The audit log names WHICH fingerprint matched** | Not the configured one. On a single-token deployment those are the same value, which is exactly how a log that named the wrong one stays green — and on the only shape that needs it, an overlap window, it is useless. |
| **Client keyed on `CF-Connecting-IP`** | Trustworthy for one reason: Cloudflare overwrites it and is the sole public ingress. `X-Forwarded-For` is never read. Absent / unparseable / **duplicated** → fails closed. |
| **Rate limit + lockout in the app** | 5 failed auths per client IP per minute → 15 minutes out. Defaults in code, all three tunable by env; a typo'd env var **exits 78** rather than defaulting. |
| **`POST` stays 405** | Writes are phase 3, and the 405 now sits *ahead* of the client-IP and lockout checks — pinned by a test, because that ordering became load-bearing. |

**The wire does not discriminate; the log does.** `unauthorized`, `no-client-ip`, `locked-out` and `lockout-triggered` are one byte-identical 401 with four `status=` values. An error that discriminates is an enumeration API; a log that does not is a post-mortem with no evidence.

### Why `X-Forwarded-For` is refused rather than used as a fallback
It is caller-supplied: keying on it hands an attacker a fresh bucket per request **and** lets them lock out a third party by forging theirs. Behind Cloudflare + Traefik the TCP peer address is the gateway's for everybody, so keying on *that* is the mirror failure — one abuser locks out the world. Bucketing unidentified requests under a shared "unknown" reproduces that hazard exactly, so an unidentifiable request is refused and **counted against nobody**.

### `authorize` refuses a bare `str`, loudly
`for token in "abc…"` iterates **characters**. Passing one token as a string would authorize anyone presenting a single character of it — a total bypass that no functional test with a correct caller would surface. A type annotation is not a code path.

---

## Verification

### Red at base / green at HEAD

Measured at `fe8eabd` (current `origin/main`) with the HEAD test file copied into a detached worktree.

🔴 **Honest split.** Most phase-1.5 tests call `build_server(tokens=…)` or `load_tokens`, which do not exist at base — their red is an AttributeError, i.e. a collection error wearing a failure's clothes, and proves nothing. Phase 1's own header says this about its 88 guards. So a class was added that drives the **real process** over its **unchanged command line**, which runs on both trees:

| test | base | HEAD |
|---|---|---|
| `test_a_valid_token_with_NO_client_ip_is_REFUSED` | **200** | 401 |
| `test_five_wrong_tokens_LOCK_OUT_the_right_one` | **200** ("unlimited guessing budget survived") | 401 |
| `test_a_TWO_LINE_token_file_authorises_BOTH_lines` | **401 for both lines** | 200 for both |
| `test_the_STDOUT_audit_stream_names_the_matched_fingerprint` | `token=-` on every line | both fingerprints, distinct |
| `test_build_server_refuses_a_bare_string_too` | `TypeError: unexpected keyword` | `…must be a SEQUENCE…` |
| `test_POSITIVE_CONTROL_the_spawned_process_serves_a_real_digest` | **PASS** | PASS |

The last row is what makes the four above statements about behaviour rather than about a broken harness. The third is worth stating plainly: base `strip()`s the whole file, so a two-line token file is **one 97-character token** and neither line authorises anything — overlap rotation was not merely unexercised, it was impossible.

The other **43** new tests are red at base by API-absence. They are labelled invariant guards in the file, exactly as phase 1's are, and the mutation matrix is their evidence.

### Mutation matrix — 24/24 killed by their NAMED test

Swept under `PYTHONDONTWRITEBYTECODE=1` with `__pycache__` deleted between mutants (the 198/200-stale-bytecode trap), every mutation asserting its replacement **count** before running, and each scored on whether **its own named test** went red — not on "something failed".

`positive-control-405` (writes fall through to the GET router) rode in **both** batches and was killed in both.

| mutant | killed by |
|---|---|
| `positive-control-405` | `test_every_write_method_is_405_even_with_a_VALID_token` |
| `authorize-early-exit` (`break` on first match) | `test_authorize_compares_against_EVERY_token_with_no_early_exit` |
| `authorize-str-guard-deleted` | `test_authorize_REFUSES_a_bare_string_rather_than_iterating_CHARACTERS` |
| `authorize-always-yes` | `test_NEGATIVE_a_wrong_token` (22 tests red) |
| `max-tokens-off-by-one` (`>` → `>=`) | `test_FOUR_tokens_are_accepted_the_boundary_is_not_off_by_one` |
| `length-floor-first-only` | `test_a_SHORT_SECOND_token_names_its_POSITION_and_never_the_token` |
| `token-order-reversed` | `test_two_tokens_load_as_a_set_IN_FILE_ORDER` |
| `client-ip-accepts-duplicates` | `test_TWO_CF_Connecting_IP_headers_fail_closed` |
| `client-ip-unvalidated` | `test_a_MANGLED_CF_Connecting_IP_fails_closed` |
| `client-ip-xff-fallback` | `test_X_Forwarded_For_ALONE_fails_CLOSED` |
| `unidentified-shared-bucket` | `test_a_MISSING_CF_Connecting_IP_fails_closed_even_with_a_VALID_token` |
| `lockout-checked-after-auth` | `test_five_failures_lock_out_a_VALID_token_from_the_same_client` |
| `failures-not-counted` | same |
| `non-api-probe-free` | `test_probing_NON_API_paths_also_counts_toward_the_lockout` |
| `threshold-off-by-one` (`>=` → `>`) | `test_four_failures_do_NOT_lock_and_the_fifth_DOES` |
| `lockout-never-expires` | `test_the_lockout_EXPIRES` |
| `success-clears-lockout` | `test_a_success_does_NOT_clear_a_LIVE_lockout` |
| `eviction-drops-lockouts` | `test_eviction_NEVER_releases_a_live_lockout` |
| `env-zero-accepted` (`<= 0` → `< 0`) | `test_a_NON_POSITIVE_value_raises` |
| `env-typo-defaults` | `test_main_EXITS_78_on_a_bad_limiter_setting` |
| `audit-logs-configured-token` | `test_the_audit_line_names_WHICH_fingerprint_matched` |
| `audit-drops-client-ip` | `test_the_audit_line_carries_the_CF_Connecting_IP` |
| `health-behind-the-ip-gate` | `test_health_needs_NO_client_ip_because_the_kubelet_sends_none` |
| `wire-discriminates-lockout` (401 → 429) | `test_a_LOCKED_OUT_response_is_BYTE_IDENTICAL_to_an_ordinary_401` |

#### 🔴 The sweep found a defect in one of my own tests
`env-typo-defaults` did not fail — it **hung**, for the full 900s timeout, and every mutant after it went unmeasured. With the parse guard broken to `return default`, `main()` sails past the check and reaches `serve_forever()`. That is the RULES hazard about a slow red test eating the suite budget and truncating everything after it, arriving from a direction I did not anticipate: not a slow test, a guard whose *failure mode* is a hang, whose symptom reads as infrastructure and would have been re-run rather than diagnosed. `build_server` is now stubbed to raise in that test; the mutant is killed in ~2s.

### Rotation, exercised end to end
`test_a_ROTATION_end_to_end_old_still_works_then_stops`, plus the subprocess class against the real process:

1. only the old token exists → old **200**, new **401**
2. overlap (both in the file) → **both 200**, and the audit lines carry *different* fingerprints
3. old token removed → new **200**, **old token 401, body `unauthorized\n`**

Step 3 is the one that gets skipped; a rotation that leaves the old credential live is not a rotation.

### Leak check
`scripts/tests/test_store_content_not_copied.py` live half: **841 tracked text files examined** (all 8 of this PR's files confirmed in that set) against **37 store entry files** → no shared phrases. Both denominators non-zero, so the zero is informative. Every fixture here is synthetic, under `tmp_path`, with invented names.

### What is NOT verified
- **No off-mesh test of this code path.** There is no route; the probe (in the ingress PR) confirms `store.zacx.dev` does not resolve.
- **Cloudflare's WAF layer** is not automated and does not exist yet — see the ingress PR.
- **Separate read/write tokens** are not built. There is no write path until phase 3.
- **Rotation against the live pod** has not been run — only in-band and against the real process locally.

---

# 🔴 THREE ADVERSARIAL AUDIT ROUNDS, AND EVERY ONE FOUND REAL DEFECTS

The sections above describe the branch as first written. **They were wrong**, and
the record of how is more useful than the tidy version:

## Round 1 — the hardening did not survive its own audit
Round 1's mutation sweep was **24/24 green** while two criticals sat in the same
file. A sweep is only a claim about the mutations you imagined.

- 🔴 **The audit log was forgeable, pre-auth, by anyone.** `unquote()` turns
  `%0a` into a real newline and the record was one f-string, so an
  unauthenticated caller could emit a second, perfect `auth=ok` line naming any
  fingerprint and any address. This defeats the exact property the token-set
  design rests on: the README says to delete the old token once its fingerprint
  stops appearing. A forger could keep any fingerprint alive forever.
- 🔴 **Request bodies were never read on a keep-alive server** — one `POST`
  whose body was a complete `GET …/recall/<scope>` returned **two responses on
  one socket**, the second carrying store content. Behind a pooling proxy that
  is CL.0 smuggling with the *victim's* `Authorization` header.
- writes bypassed the client-IP and lockout checks (31 anonymous POSTs, 31 audit
  lines, nothing counted); a success **forgave** the failure streak, enabling an
  interleave brute force; `MAX_TRACKED_CLIENTS` was a bound in name only
  (20,000 tracked against a cap of 4,096) *and its comment said otherwise*; the
  key was a full IPv6 address (2^64 buckets per client); `nan`/`inf` walked
  through the "must be positive" check and silently disabled the limiter;
  `GET http://[` crashed the handler.

## Round 2 — the sweep of the fixes found a SURVIVOR and two vacuous tests
- 🔴 **SURVIVED:** removing `.` from the path-component class left the whole
  suite green — nothing had a dotted path component, because refs travel in the
  query string. The permissive class was never justified by a caller. Guard is
  now structural (no dot at all, so `..` cannot be spelled) after measuring that
  all 8 live scopes match `[A-Za-z0-9_-]+`.
- one test parsed the audit record with `dict()`, which lets the last occurrence
  win, so it passed under the mutant it named.

## Round 3 — the delta audit: the fix for the criticals introduced three more
**In the same commit, one screen below the code that prevents them.**
- 🔴 the `send_error` override read `self.path`, which `parse_request` assigns
  only *after* five of its own `send_error` calls — **6 of 7 malformed
  request-line shapes crashed**, no audit record, ~25 lines of traceback, from a
  six-byte request. Verbatim the defect `_request_path` exists to prevent.
- 🔴 the same override never metered: 30 unknown-verb requests, 30 audit lines,
  nothing counted — the free channel `_reject_write` had just been reordered to
  close, widened to every verb.
- 🔴 the drain understood exactly one framing: `Transfer-Encoding: chunked` and
  a **negative** `Content-Length` each still smuggled a request on a 200.
- 🔴 at the lockout cap, `record_failure` returned `True` regardless and popped
  the streak — the log lying about the one event the operator alerts on, and
  unlimited brute force behind it. Writing that test found a **fourth**: the
  capacity check ran before the expiry sweep, so a table of already-expired
  lockouts reported "no room" — the cap becoming a permanent disable.
- 🔴 a client holding the **right token** could lock itself out with five
  ordinary wrong paths (`/favicon.ico`, `/`, …, `/api/v1`). A wrong path is not
  a failed auth; only requests that reach the token check are counted now.

## Round 4 — the sweep of *those* fixes found the deadline was decorative
- 🔴 `rfile.read(n)` **blocks until it has all n bytes**, so the drain loop never
  got control back and `DRAIN_DEADLINE_S` was unreachable: a dripping caller
  still held a thread for the whole body. `read1` fixed it. Found only because
  the test for the deadline failed — and that test's first version had itself
  been vacuous (it sent one byte and measured the *socket* timeout).
- one survivor verified **equivalent** rather than assumed: `_respond` already
  closes on every non-200. Annotated in place so it is not an unexplained zero.

## Round 5 — the final audit: a third framing, and two guards nothing could reach
- 🔴 **duplicate `Content-Length` smuggled a request** (`Content-Length: 0`
  then `Content-Length: 154`) — a bare `.get()` takes the first value, so
  nothing drained and store content came back in a second response on a 200.
  🔴 **The predicate that stops it already existed twenty lines away**, in
  `client_ip`, rejecting a duplicated `CF-Connecting-IP` for exactly this
  reason — open-coded twice, correct at one site and wrong at the other. Now one
  `sole_header()`, with a structural test that fails if it is open-coded again.
  The `_drain_body` comment claiming no third framing could walk it was false
  when written.
- ⚠ **two mutants survived the whole 199-test suite**, both created by this
  branch: `read1` is what made the drain loop's bookkeeping load-bearing, and
  every smuggling test sent headers and body in ONE `sendall`, so the loop ran
  exactly once. And the first fix for *that* was wrong too — **the delivery
  shape decides which direction is observable**: under-consumption needs several
  segments, over-consumption needs the body and the next request in one, because
  `read1` can only over-read bytes already buffered. Two tests now, one per
  direction, plus a control that both shapes can produce two responses.

## Final numbers

| | |
|---|---|
| tests in this file | **206** (89 at phase 1) |
| adversarial audit rounds | 3, each found real defects |
| mutation rounds | 6, each built differently; **every survivor resolved or proven equivalent** |
| round 1 | 24/24 killed by their named test — *while two criticals sat in the file* |
| round 2 | 25 mutants, 22 killed → 3 real findings → re-swept 4/4 |
| round 4 | 15 mutants, 13 killed → 2 real findings → re-swept 3/3 |
| round 6 | 5 mutants, 3 killed → 2 unreachable guards → re-swept 5/5 |
| positive control | `positive-control-405` in **every** batch, killed in every batch |

```
devrc-pytests>   TOTAL collected=10925  passed=10924  skipped=1  failed=0  (floor: 9577)
devrc-pytests> RESULT: PASS (exit=0)

devrc-nodetests>   TOTAL suites=4 files=33 tests=1116 pass=1116 fail=0 skipped=0  (floor: 1098)
devrc-nodetests> RESULT: PASS (exit=0)
```

Leak scan: **841 tracked text files examined** (all 8 of this PR's files in that
set) against **37 store entries** → 0 shared phrases.

## 🔴 ONE AUDIT FINDING IS DELIBERATELY NOT FIXED

**`CF-Connecting-IP` is trusted from any peer.** The assumption "Cloudflare is
the sole ingress" is documented in three places and enforced nowhere. Anything
that can address the pod directly — a cluster pod, a port-forward, a second
IngressRoute — can lock out a *named victim* in five requests, and the victim
sees a 401 indistinguishable from a bad token.

It is not fixed here because the fix is not in this file: the pod cannot see
Cloudflare's address (it sees Traefik's), so an app-level origin check would be
theatre. The structural answer is a **NetworkPolicy** on the `subsystem-store`
namespace restricting ingress to the nebula gateway — which I could not write
and *test* against the live cluster, and an untested NetworkPolicy can silently
break the readiness probe. **Operator's call, and it belongs in homelab-infra
before the ingress PR merges.**

Also not fixed, and stated rather than smoothed over: every holder of the single
token can enumerate all scopes (there is no per-scope authz — a design
consequence, not a bug), and NAT64-translated clients share one rate-limit
bucket (low: such a value should never appear in `CF-Connecting-IP`).
