### PR TITLE
fix(subsystem-store): CF-Connecting-IP was trusted from ANY peer — five requests locked out a named victim

### DIFF
--- a/scripts/subsystem-store-api/README.md
+++ b/scripts/subsystem-store-api/README.md
@@ -82,9 +82,12 @@ scripts/subsystem-store-api/verify-byte-identity.sh \
                      -o jsonpath='{.data.token}' | base64 -d)
 ```
 
-The verifier sends `CF-Connecting-IP: 127.0.0.1` (override with `$CLIENT_IP`)
-because the server requires one — see "Rate limit, lockout and the client
-address" below.
+The verifier sends `CF-Connecting-IP: 127.0.0.1` (override with `$CLIENT_IP`).
+⚠ **Over a port-forward that header is INERT** — the peer is `127.0.0.1`, which
+is not a trusted proxy, so the server ignores it and buckets the request under
+the peer. It is sent so the same invocation also works when `--url` points at
+the nebula gateway, where the peer *is* trusted and the header becomes the
+client identity. See "Rate limit, lockout and the client address" below.
 
 ⚠ `verify-byte-identity.sh` prints a `diff` on failure, and that diff is store
 content. Redirect it to a file on a shared terminal.
@@ -207,8 +210,13 @@ kubectl -n nebula exec ds/nebula-gateway -c nginx-proxy -- \
 
 🔴 **It is Cilium-allocated per node and nothing reconciles it.** A node rebuild
 can hand out a different router address, and no controller will update this env
-var. The failure is loud and fail-safe rather than silent — see below — but it
-is a manual step on a list nobody keeps.
+var. ⚠ **And the failure is SILENT** — requests are still served, just all
+bucketed under one address, so `/healthz` keeps answering and the pod stays
+Ready (see below). An earlier revision of this line said "loud and fail-safe",
+which was true of the refuse-outright design this replaced and contradicted its
+own cross-reference two sections down. A degradation that keeps the health probe
+green is the anti-pattern this module names elsewhere; the only tell is
+`peer=untrusted` in the log, and it is a manual step on a list nobody keeps.
 
 ### Rules on the value
 
@@ -248,10 +256,18 @@ way, so the probe will not tell you.
 ⚠ **What it cannot do.** The pod sees whatever last hop connected to it — in
 the homelab deployment the in-cluster gateway, never Cloudflare's own address.
 So this proves *the request came through the gateway*, not *the request came
-through Cloudflare*. Narrowing who can occupy that hop is a NetworkPolicy's job
-(homelab-infra `clusters/homelab/apps/subsystem-store/networkpolicy.yaml`) —
-though see that file's header for why the two layers overlap far more than they
-compose.
+through Cloudflare*.
+
+Narrowing who can occupy that hop is a NetworkPolicy's job — 🔴 **and that
+NetworkPolicy is NOT DEPLOYED YET.** `homelab-infra`
+`clusters/homelab/apps/subsystem-store/networkpolicy.yaml` exists only on the
+unmerged branch of **homelab-infra #330**; on `trunk` that kustomization still
+lists four resources (`namespace`, `pvc`, `secrets.enc`, `deployment`) and no
+policy. Until #330 merges, **any pod in the cluster can address this pod on
+8102** and the app-layer gate above is the only layer there is. Do not read this
+paragraph as a compensating control that is already in place — and see that
+file's header for why, even once it lands, the two layers overlap far more than
+they compose.
 
 An absent, unparseable or **duplicated** header **fails closed** for a TRUSTED
 peer: a uniform 401, and nothing counted, because there is no bucket to count

--- a/scripts/subsystem-store-api/README.md
+++ b/scripts/subsystem-store-api/README.md
@@ -158,6 +158,49 @@ party by forging theirs. Behind Cloudflare + Traefik the TCP peer address is the
 gateway's for everybody, so keying on that is the mirror failure — one abuser
 locks out the world.
 
+### 🔴 …and the header is only read from a TRUSTED PEER
+
+| knob | default | env |
+|---|---|---|
+| peers whose `CF-Connecting-IP` is read | **none — required** | `SUBSYSTEM_STORE_TRUSTED_PROXIES` |
+
+`CF-Connecting-IP` is caller-supplied bytes. "Cloudflare overwrites it" is true
+of a request that *arrived from Cloudflare* and says nothing about one that did
+not — so before this setting existed, anything able to address the pod on 8102
+(a pod in the cluster, a `kubectl port-forward`, a second IngressRoute) could
+name a **third party** in the header, send five bad tokens, and lock that third
+party out for fifteen minutes. The victim saw a 401 indistinguishable from a
+wrong credential.
+
+Set it to the address(es) or CIDR(s) of the proxy that terminates public
+traffic, comma- or whitespace-separated:
+
+```
+SUBSYSTEM_STORE_TRUSTED_PROXIES=10.0.0.1,10.1.0.0/24
+```
+
+* **There is no default and the process exits 78 without one.** A default would
+  be a guess about somebody's network, and the only guess that keeps every
+  deployment working is the permissive one — which is the defect itself.
+* `0.0.0.0/0` (and `::/0`) is **refused**: that is the pre-fix behaviour spelled
+  as configuration. The refusal is by prefix length, so it is one rule rather
+  than a list of spellings.
+* A request from any other peer is the same uniform 401,
+  `status=untrusted-peer`, and it is **not counted** against any lockout — there
+  is no bucket to count it into, and keying on the peer would be the "one abuser
+  locks out the world" failure above.
+* `/healthz` is answered **before** the gate, so the kubelet probe (which comes
+  from the node and sends no `CF-Connecting-IP`) is untouched.
+* The startup line prints the allowlist, so "which peers may set the client
+  identity" is readable out of a running pod.
+
+⚠ **What it cannot do.** The pod sees whatever last hop connected to it — in
+the homelab deployment the in-cluster gateway, never Cloudflare's own address.
+So this proves *the request came through the gateway*, not *the request came
+through Cloudflare*. Narrowing who can occupy that hop is a NetworkPolicy's job
+(homelab-infra `clusters/homelab/apps/subsystem-store/networkpolicy.yaml`), and
+it is the second layer, not this one.
+
 An absent, unparseable or **duplicated** header therefore **fails closed**: a
 uniform 401, and nothing counted, because there is no bucket to count into.
 Anything reaching the pod directly (a port-forward, `verify-byte-identity.sh`)
@@ -170,6 +213,7 @@ what the Loki rules select on:
 
 | `status=` | meaning |
 |---|---|
+| `untrusted-peer` | the TCP peer is not in `SUBSYSTEM_STORE_TRUSTED_PROXIES`, so `CF-Connecting-IP` was never read — **any line with this status means something is addressing the pod directly** |
 | `unauthorized` | no/!wrong token, or a path outside `/api/v1/` |
 | `no-client-ip` | absent, unparseable or duplicated `CF-Connecting-IP` — fails closed |
 | `locked-out` | this client is serving a lockout |

--- a/scripts/subsystem-store-api/README.md
+++ b/scripts/subsystem-store-api/README.md
@@ -218,11 +218,12 @@ is a manual step on a list nobody keeps.
 * `0.0.0.0/0` (and `::/0`) is **refused**: the pre-fix behaviour spelled as
   configuration.
 * **A prefix wider than `/24` (IPv4) or `/64` (IPv6) is refused too**, because
-  refusing only `/0` inspects one entry in isolation: `0.0.0.0/1,128.0.0.0/1`
-  parses clean and trusts everything, and — the realistic mistake — a pod CIDR
-  like `10.244.0.0/16` would hand the client identity to every pod in the
-  cluster, which is exactly the attacker this setting exists to stop. List
-  several narrower entries if you genuinely need a wide range.
+  refusing only `/0` inspects one entry in isolation: the two halves of the
+  address space, each written as a `/1`, parse clean and together trust
+  everything, and — the realistic mistake — a pod CIDR like `10.244.0.0/16`
+  would hand the client identity to every pod in the cluster, which is exactly
+  the attacker this setting exists to stop. List several narrower entries if you
+  genuinely need a wide range.
 * **Entries must be written in the same address family the peer arrives as.**
   `peer_address` unwraps an IPv4-mapped peer (`::ffff:10.0.0.1` → `10.0.0.1`)
   but the allowlist parser does not, so an entry spelled `::ffff:10.0.0.1` will

--- a/scripts/subsystem-store-api/README.md
+++ b/scripts/subsystem-store-api/README.md
@@ -119,7 +119,7 @@ one the server was configured with. That is the whole safety of overlap
 rotation — without it, "nobody uses the old token any more" is a guess:
 
 ```
-store-api audit ts=… ip=203.0.113.7 method=GET path=/api/v1/recall/x \
+store-api audit ts=… ip=203.0.113.7 peer=trusted method=GET path=/api/v1/recall/x \
   token=dbb22a50030d auth=ok result=200 status=recalled
 ```
 
@@ -172,40 +172,90 @@ name a **third party** in the header, send five bad tokens, and lock that third
 party out for fifteen minutes. The victim saw a 401 indistinguishable from a
 wrong credential.
 
-Set it to the address(es) or CIDR(s) of the proxy that terminates public
-traffic, comma- or whitespace-separated:
+The rule is the standard reverse-proxy one:
 
 ```
-SUBSYSTEM_STORE_TRUSTED_PROXIES=10.0.0.1,10.1.0.0/24
+client = CF-Connecting-IP   if the TCP peer is in the allowlist
+       = the TCP peer       otherwise (and the header is not read at all)
 ```
+
+That is enough. The property that matters is **a forged header must never name a
+third party**, and bucketing the forger under its own address satisfies it
+completely — such a caller can only ever lock out itself.
+
+### 🔴 The value is NOT the address you would guess
+
+For the homelab deployment it is **`10.244.0.123/32`**, and none of the three
+obvious candidates are right:
+
+| candidate | what it actually is | right? |
+|---|---|---|
+| `10.42.0.10` | the homelab nebula gateway's **nebula mesh** IP, which is what its nginx *listens* on | ✗ |
+| `192.168.50.94` | the node's Kubernetes **InternalIP** | ✗ |
+| `10.244.0.123` | the node's **`cilium_host` router address** — what the gateway's traffic is SNAT'd to on the way into the pod | ✓ |
+
+**Derive it, do not guess it** — from inside the caller, which is the only
+perspective that can be wrong in a way you would notice:
+
+```bash
+kubectl -n nebula exec ds/nebula-gateway -c nginx-proxy -- \
+  ip route get "$(kubectl -n subsystem-store get pod -l app=subsystem-store-api \
+                    -o jsonpath='{.items[0].status.podIP}')"
+# 10.244.0.13 dev cilium_host  src 10.244.0.123
+#                                  ^^^^^^^^^^^^ this is the value
+```
+
+🔴 **It is Cilium-allocated per node and nothing reconciles it.** A node rebuild
+can hand out a different router address, and no controller will update this env
+var. The failure is loud and fail-safe rather than silent — see below — but it
+is a manual step on a list nobody keeps.
+
+### Rules on the value
 
 * **There is no default and the process exits 78 without one.** A default would
   be a guess about somebody's network, and the only guess that keeps every
   deployment working is the permissive one — which is the defect itself.
-* `0.0.0.0/0` (and `::/0`) is **refused**: that is the pre-fix behaviour spelled
-  as configuration. The refusal is by prefix length, so it is one rule rather
-  than a list of spellings.
-* A request from any other peer is the same uniform 401,
-  `status=untrusted-peer`, and it is **not counted** against any lockout — there
-  is no bucket to count it into, and keying on the peer would be the "one abuser
-  locks out the world" failure above.
-* `/healthz` is answered **before** the gate, so the kubelet probe (which comes
-  from the node and sends no `CF-Connecting-IP`) is untouched.
+* `0.0.0.0/0` (and `::/0`) is **refused**: the pre-fix behaviour spelled as
+  configuration.
+* **A prefix wider than `/24` (IPv4) or `/64` (IPv6) is refused too**, because
+  refusing only `/0` inspects one entry in isolation: `0.0.0.0/1,128.0.0.0/1`
+  parses clean and trusts everything, and — the realistic mistake — a pod CIDR
+  like `10.244.0.0/16` would hand the client identity to every pod in the
+  cluster, which is exactly the attacker this setting exists to stop. List
+  several narrower entries if you genuinely need a wide range.
+* **Entries must be written in the same address family the peer arrives as.**
+  `peer_address` unwraps an IPv4-mapped peer (`::ffff:10.0.0.1` → `10.0.0.1`)
+  but the allowlist parser does not, so an entry spelled `::ffff:10.0.0.1` will
+  **never match**. Fail-closed, so it is a config error rather than a hole —
+  write `10.0.0.1`.
+* A request from any other peer is **served normally, bucketed under the peer's
+  own address**, and annotated `peer=untrusted` in the audit log. It is *not*
+  refused: refusing was tried, and it broke the phase-1 acceptance procedure
+  outright (`verify-byte-identity.sh` runs through `kubectl port-forward`, whose
+  peer is `127.0.0.1`, not the allowlisted address) while turning one wrong
+  address into a total outage that `/healthz` hid.
+* `/healthz` is answered **before** any of this, so the kubelet probe (which
+  comes from the node and sends no `CF-Connecting-IP`) is untouched.
 * The startup line prints the allowlist, so "which peers may set the client
   identity" is readable out of a running pod.
+
+**If the value is wrong**, every API request is served but keyed on the gateway's
+address — so one client's failures can lock out the others, and every line says
+`peer=untrusted`. That is the symptom to grep for; the pod stays Ready either
+way, so the probe will not tell you.
 
 ⚠ **What it cannot do.** The pod sees whatever last hop connected to it — in
 the homelab deployment the in-cluster gateway, never Cloudflare's own address.
 So this proves *the request came through the gateway*, not *the request came
 through Cloudflare*. Narrowing who can occupy that hop is a NetworkPolicy's job
-(homelab-infra `clusters/homelab/apps/subsystem-store/networkpolicy.yaml`), and
-it is the second layer, not this one.
+(homelab-infra `clusters/homelab/apps/subsystem-store/networkpolicy.yaml`) —
+though see that file's header for why the two layers overlap far more than they
+compose.
 
-An absent, unparseable or **duplicated** header therefore **fails closed**: a
-uniform 401, and nothing counted, because there is no bucket to count into.
-Anything reaching the pod directly (a port-forward, `verify-byte-identity.sh`)
-must send the header itself; that is not a hole, since addressing the pod
-directly already bypasses the edge.
+An absent, unparseable or **duplicated** header **fails closed** for a TRUSTED
+peer: a uniform 401, and nothing counted, because there is no bucket to count
+into. (For an untrusted peer the header is never consulted, so its absence is
+not an error.)
 
 Every rejection is the same 401 on the wire — body, code and header set — and is
 told apart only in the audit log's `status=` field. The full vocabulary, which is
@@ -213,7 +263,6 @@ what the Loki rules select on:
 
 | `status=` | meaning |
 |---|---|
-| `untrusted-peer` | the TCP peer is not in `SUBSYSTEM_STORE_TRUSTED_PROXIES`, so `CF-Connecting-IP` was never read — **any line with this status means something is addressing the pod directly** |
 | `unauthorized` | no/!wrong token, or a path outside `/api/v1/` |
 | `no-client-ip` | absent, unparseable or duplicated `CF-Connecting-IP` — fails closed |
 | `locked-out` | this client is serving a lockout |
@@ -224,6 +273,21 @@ what the Loki rules select on:
 
 An error that discriminates is an enumeration API; a log that does not is a
 post-mortem with no evidence.
+
+🔴 **`peer=` is a SEPARATE field from `status=`, on purpose.**
+
+| `peer=` | meaning |
+|---|---|
+| `trusted` | the peer was in the allowlist, so `ip=` came from `CF-Connecting-IP` |
+| `untrusted` | **something addressed the pod directly** — `ip=` is the TCP peer and the header was never read |
+| `-` | the request line was too malformed to establish either |
+
+An earlier version of this feature spelled it `status=untrusted-peer` with
+`auth=fail`. That put every `kubectl port-forward` — including the documented
+byte-identity run — into the Loki auth-fail alert, which is how an alert gets
+ignored. Reaching the pod directly is worth **detecting**; it is not an
+authentication failure and must not be written as one. Grep it with
+`{namespace="subsystem-store"} |= "peer=untrusted"`.
 
 ⚠ **A wrong PATH is not a failed AUTH and is not counted.** Only a request that
 reaches the token check and fails it moves the lockout. Counting path probes

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -1252,6 +1252,15 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         # peer's — keying the lockout on THAT is the "one abuser locks out the
         # world" failure this design rejects. The bound on an untrusted peer is
         # the connection close `_respond` performs on every non-200.
+        #
+        # ⚠ THE ORDERING IS RECORDED AS AN EQUIVALENT MUTANT, not left as an
+        # unexplained survivor. A sweep showed that moving `client_ip(...)`
+        # ABOVE this block changes no behaviour: `client_ip` is pure and total
+        # (garbage in, `None` out) and its result is discarded on the refusal
+        # path. The order is kept anyway — the day anything on that call
+        # acquires a side effect, "parsed the attacker's header before deciding
+        # whether to trust them" is not a sentence to be writing in a
+        # post-mortem.
         peer = peer_address(getattr(self, "client_address", None))
         if not peer_is_trusted(peer, self.trusted_proxies):
             self._refuse(path, "untrusted-peer")

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -79,6 +79,47 @@ and client-confidential content, and §2b's hardening stops being optional:
     one abuser locks out the world. An absent or unparseable `CF-Connecting-IP`
     therefore FAILS CLOSED (uniform 401), rather than being bucketed into a
     shared "unknown" that reproduces exactly that hazard.
+  * **…and the header is only READ when the TCP PEER is a trusted proxy**
+    (`load_trusted_proxies` / `peer_is_trusted`) — see the next section, which
+    is the defect that made the rest of this list forgeable.
+
+PHASE 1.5b — `CF-Connecting-IP` WAS TRUSTED FROM ANY PEER
+----------------------------------------------------------
+🔴 THE HEADER ABOVE IS CALLER-SUPPLIED DATA. Everything the previous section
+claims about it — "Cloudflare overwrites it on every request it proxies" — is
+true of requests that ARRIVE FROM CLOUDFLARE, and says nothing about a request
+that did not. The first version read it from whoever connected, so ANY peer that
+could address the pod on 8102 (a pod in the cluster, a `kubectl port-forward`, a
+second IngressRoute) could send a header naming a THIRD PARTY and five bad
+tokens, and that third party was locked out for fifteen minutes — seeing a 401
+indistinguishable from a wrong credential. Measured against the deployed pod
+before this fix: five forged requests, then the victim's own valid request.
+
+Fixing it in the network layer alone was rejected: a NetworkPolicy is a
+different repo, a different review, and cannot be exercised without a cluster.
+The rule this file lives by is that a guard you cannot watch fail is not a
+guard. So the primary fix is HERE, and it is hermetic:
+
+  * `SUBSYSTEM_STORE_TRUSTED_PROXIES` — an explicit allowlist of peer addresses
+    or CIDRs. **REQUIRED**: no default, and the process refuses to start
+    without it (`EXIT_CONFIG`), for the same reason a short token does. A
+    default would be a guess about somebody's cluster, and a guess that is
+    wrong in the permissive direction is exactly the defect.
+  * If the peer is not in the allowlist the request is REFUSED —
+    `status=untrusted-peer`, the same uniform 401 as everything else. 🔴 It
+    does NOT fall back to keying on the peer address: that is the "one abuser
+    locks out the world" failure the section above rejects, and arriving at it
+    by way of a *security* check would be worse, not better.
+  * `/healthz` is answered BEFORE any of this, so the kubelet probe — which
+    comes from the node and carries no `CF-Connecting-IP` — is untouched. A
+    readiness probe broken by a security guard is how the guard gets deleted.
+
+⚠ WHAT THIS CANNOT DO. The pod sees the address of whatever last hop connected
+to it — in this deployment the in-cluster gateway, never Cloudflare's own
+address. So this proves "the request came through the gateway", NOT "the
+request came through Cloudflare". Anything that can occupy that hop can still
+forge the header. Narrowing WHO can occupy it is the NetworkPolicy's job, and
+it is the second layer, not this one.
   * **Rate limit + lockout in the app** (`RateLimiter`): 5 failed auths per
     client IP per minute, then a 15-minute lockout. Defaults live here in code;
     all three are tunable by env. Cloudflare's WAF and the Traefik middleware
@@ -148,6 +189,12 @@ MAX_TOKENS = 4
 # overwrites it on every request it proxies. `X-Forwarded-For` is deliberately
 # absent from this file — see the module docstring.
 CLIENT_IP_HEADER = "CF-Connecting-IP"
+
+# 🔴 …AND IT IS ONLY READ FROM THESE PEERS. Caller-supplied data is only as
+# trustworthy as the hop that overwrote it, so the header is honoured only when
+# the TCP peer is one of the proxies the operator named. No default value: see
+# `load_trusted_proxies`.
+ENV_TRUSTED_PROXIES = "SUBSYSTEM_STORE_TRUSTED_PROXIES"
 
 # §2b: "Rate-limit + lock out on repeated 401s". The defaults are HERE, in code,
 # so a deployment that sets no env still gets them; each is overridable.
@@ -359,6 +406,13 @@ def sole_header(headers: Any, name: str) -> str | None:
 def client_ip(headers: Any) -> str | None:
     """The client's address, or `None` — and `None` means REFUSE, not "unknown".
 
+    🔴 THIS FUNCTION ASSUMES THE PEER WAS ALREADY CHECKED. It parses a header,
+    which is caller-supplied bytes; the thing that makes those bytes an identity
+    is `peer_is_trusted`, in `_identify_and_meter`, which runs BEFORE this and
+    refuses the request outright when the peer is not a named proxy. Calling
+    this on an unchecked peer reintroduces the whole phase-1.5b defect, so the
+    call site is the guard and there is exactly one.
+
     🔴 `CF-Connecting-IP` ONLY. Cloudflare sets it on every proxied request and
     overwrites whatever the caller sent, which is what makes it trustworthy —
     and it is trustworthy for that reason alone, so the moment Cloudflare stops
@@ -388,6 +442,124 @@ def client_ip(headers: Any) -> str | None:
     except ValueError:
         return None
     return str(rate_limit_key(address))
+
+
+def load_trusted_proxies(env: dict[str, str]) -> tuple[Any, ...]:
+    """Resolve the peer allowlist that makes `CF-Connecting-IP` readable. OR RAISE.
+
+    🔴 THERE IS NO DEFAULT, AND THAT IS THE POINT. A default would be a guess
+    about somebody else's network, and the only guess that keeps every
+    deployment working is a permissive one — which is the defect this function
+    exists to close, shipped as a constant. So an unset or empty variable is a
+    misconfiguration and exits `EXIT_CONFIG` at startup, visible in a
+    CrashLoopBackOff, exactly like a token file that is missing.
+
+    Accepts addresses and CIDRs, comma- or whitespace-separated:
+
+        SUBSYSTEM_STORE_TRUSTED_PROXIES=10.0.0.1,10.1.0.0/24
+
+    Guard order — each reachable by an input no earlier guard rejects:
+      1. the variable is set and non-blank -> "no trusted proxies"
+      2. every item parses as an address/CIDR -> "not an IP address or CIDR"
+      3. no item is a DEFAULT ROUTE -> "trusts every peer"
+
+    🔴 Guard 3 is the one that matters. `0.0.0.0/0` (or `::/0`) is "trust
+    anybody who can reach me" spelled as configuration — the pre-fix behaviour,
+    reachable by an operator who wanted to silence a 401 during a rollout and
+    never took it out. Requiring the variable to be SET would not catch it;
+    only refusing the value does. A `/0` is refused BY PREFIX LENGTH, not by
+    matching the two spellings, so `0.0.0.0/0`, `::/0` and any future
+    equivalent are one rule rather than a list somebody has to extend.
+    """
+    raw = env.get(ENV_TRUSTED_PROXIES)
+    if raw is None or not raw.strip():
+        raise ValueError(
+            f"no trusted proxies: set ${ENV_TRUSTED_PROXIES} to the address(es) "
+            f"or CIDR(s) of the proxy that terminates public traffic. The "
+            f"{CLIENT_IP_HEADER} header is only read from those peers, and there "
+            f"is deliberately no default"
+        )
+    networks: list[Any] = []
+    for item in re.split(r"[,\s]+", raw.strip()):
+        if not item:
+            continue
+        try:
+            # `strict=False` so `10.1.2.3/24` is accepted as the /24 it names,
+            # rather than refused for having host bits set — an operator writing
+            # a CIDR from memory means the network, and refusing here would push
+            # them towards the /0 that guard 3 exists to stop.
+            network = ipaddress.ip_network(item, strict=False)
+        except ValueError as exc:
+            raise ValueError(
+                f"{ENV_TRUSTED_PROXIES}: {item!r} is not an IP address or CIDR ({exc})"
+            ) from None
+        if network.prefixlen == 0:
+            raise ValueError(
+                f"{ENV_TRUSTED_PROXIES}: {item!r} trusts every peer, which is the "
+                f"defect this setting exists to close. Name the proxy's address"
+            )
+        networks.append(network)
+    if not networks:
+        raise ValueError(
+            f"no trusted proxies: ${ENV_TRUSTED_PROXIES} resolved to no entries"
+        )
+    return tuple(networks)
+
+
+def peer_address(client_address: Any) -> Any:
+    """The TCP peer, normalised, or `None` — and `None` means REFUSE.
+
+    🔴 IPv4-MAPPED IS UNWRAPPED, because a dual-stack listener reports a v4
+    caller as `::ffff:10.0.0.1` and an allowlist written as `10.0.0.1/32` would
+    then never match — a fail-CLOSED break rather than a hole, but a break that
+    reads as "the guard is wrong" and gets widened until it is.
+
+    🔴 IT DOES NOT GO THROUGH `rate_limit_key`, and must not. That function
+    aggregates IPv6 to its **/64** on purpose, because an attacker picks freely
+    inside their own allocation — the exact reasoning that makes it WRONG here:
+    a /64 of trusted proxies is 2**64 peers the operator did not name. Two
+    functions that both normalise an address, deliberately differently.
+    """
+    if not isinstance(client_address, (tuple, list)) or not client_address:
+        return None
+    raw = client_address[0]
+    if not isinstance(raw, str):
+        return None
+    try:
+        # An IPv6 link-local peer carries a scope id (`fe80::1%eth0`) that
+        # `ip_address` will not parse. The zone is a local interface name, not
+        # part of the identity being allowlisted.
+        address = ipaddress.ip_address(raw.split("%", 1)[0].strip())
+    except ValueError:
+        return None
+    mapped = getattr(address, "ipv4_mapped", None)
+    return mapped if mapped is not None else address
+
+
+def peer_is_trusted(peer: Any, trusted: Sequence[Any]) -> bool:
+    """Is this peer one of the proxies whose `CF-Connecting-IP` we will read?
+
+    🔴 A BARE STRING IS REFUSED, LOUDLY, for the same reason `authorize` refuses
+    one: iterating a `str` yields CHARACTERS, and every character would fail the
+    membership test — so a caller who passed `"10.0.0.1"` instead of
+    `("10.0.0.1",)` would get a server that refuses every request and a
+    misconfiguration that looks like an attack. Fail loudly at the call instead.
+    """
+    if isinstance(trusted, (str, bytes)):
+        raise TypeError(
+            "trusted must be a SEQUENCE of networks, not one string: iterating a "
+            "str yields characters, and no character is an address"
+        )
+    if peer is None:
+        return False
+    for network in trusted:
+        # 🔴 VERSION-GATED. `IPv4Address in IPv6Network` raises TypeError, so an
+        # allowlist holding both families would crash on the first mismatch —
+        # an unhandled exception on the pre-auth path, which is the log-flood
+        # `_request_path` already exists to prevent.
+        if peer.version == network.version and peer in network:
+            return True
+    return False
 
 
 def rate_limit_key(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> Any:
@@ -712,6 +884,11 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
     # Injected by `build_server`.
     store_root: str = DEFAULT_STORE
     expected_tokens: tuple[str, ...] = ()
+    # 🔴 EMPTY MEANS TRUST NOBODY, not "trust everybody". A subclass that never
+    # reaches `build_server` (and `build_server` refuses an empty set) inherits
+    # a server that answers 401 to everything — the safe direction. The
+    # dangerous default would be silent and would look like it worked.
+    trusted_proxies: tuple[Any, ...] = ()
     limiter: RateLimiter | None = None
     audit: Callable[[str], None] = staticmethod(lambda line: print(line, flush=True))
 
@@ -1045,6 +1222,21 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         enforced at one call site and not the other is the failure this whole
         file keeps finding: writes used to skip both checks entirely.
         """
+        # 🔴 THE PEER GATE COMES FIRST, BEFORE THE HEADER IS EVEN LOOKED AT.
+        # `CF-Connecting-IP` is caller-supplied bytes; what makes it an identity
+        # is that a proxy we trust overwrote it. Reading it from an untrusted
+        # peer and *then* deciding is the same bug with an extra step — the
+        # value would already have been used to pick a bucket.
+        #
+        # NOT COUNTED, for the same reason `no-client-ip` is not: charging the
+        # failure needs a bucket, and the only address on offer here is the
+        # peer's — keying the lockout on THAT is the "one abuser locks out the
+        # world" failure this design rejects. The bound on an untrusted peer is
+        # the connection close `_respond` performs on every non-200.
+        peer = peer_address(getattr(self, "client_address", None))
+        if not peer_is_trusted(peer, self.trusted_proxies):
+            self._refuse(path, "untrusted-peer")
+            return False
         ip = client_ip(self.headers)
         if ip is None:
             # 🔴 FAIL CLOSED. The alternative — bucketing every unidentified
@@ -1253,6 +1445,7 @@ def build_server(
     port: int,
     store_root: str,
     tokens: Sequence[str],
+    trusted_proxies: Sequence[Any],
     limiter: RateLimiter | None = None,
     audit: Callable[[str], None] | None = None,
 ) -> ThreadingHTTPServer:
@@ -1266,12 +1459,28 @@ def build_server(
     """
     if isinstance(tokens, (str, bytes)):
         raise TypeError("tokens must be a SEQUENCE of tokens, not one string")
+    if isinstance(trusted_proxies, (str, bytes)):
+        raise TypeError(
+            "trusted_proxies must be a SEQUENCE of networks, not one string"
+        )
+    # 🔴 REQUIRED, AND NON-EMPTY. `trusted_proxies` has no default in this
+    # signature on purpose: a caller that forgot it fails at the call rather
+    # than getting a server that 401s everything for a reason nobody can see.
+    # An explicitly EMPTY sequence is refused here as a misconfiguration —
+    # the class default is empty so that the *unreachable* path still fails
+    # closed, but reaching it deliberately is a mistake worth naming.
+    if not tuple(trusted_proxies):
+        raise ValueError(
+            "trusted_proxies is empty: no peer could ever be trusted, so every "
+            f"request would be a 401. Set ${ENV_TRUSTED_PROXIES}"
+        )
 
     class _Handler(StoreRequestHandler):
         pass
 
     _Handler.store_root = store_root
     _Handler.expected_tokens = tuple(tokens)
+    _Handler.trusted_proxies = tuple(trusted_proxies)
     _Handler.limiter = limiter if limiter is not None else RateLimiter()
     if audit is not None:
         _Handler.audit = staticmethod(audit)
@@ -1317,6 +1526,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         tokens = load_tokens(token_file, dict(os.environ))
+        trusted_proxies = load_trusted_proxies(dict(os.environ))
         max_failures, window_s, lockout_s = limiter_settings(dict(os.environ))
     except ValueError as exc:
         print(f"subsystem-store-api: {exc}", file=sys.stderr)
@@ -1330,6 +1540,7 @@ def main(argv: list[str] | None = None) -> int:
         port=args.port,
         store_root=args.store,
         tokens=tokens,
+        trusted_proxies=trusted_proxies,
         limiter=limiter,
     )
     # 🔴 The startup line prints every FINGERPRINT, in the order the file lists
@@ -1339,7 +1550,11 @@ def main(argv: list[str] | None = None) -> int:
     print(
         f"subsystem-store-api: listening on {args.host}:{args.port} "
         f"store={args.store} token-ids={','.join(token_id(t) for t in tokens)} "
-        f"lockout={max_failures}/{window_s:g}s->{lockout_s:g}s",
+        f"lockout={max_failures}/{window_s:g}s->{lockout_s:g}s "
+        # 🔴 PRINTED, so "which peers may set CF-Connecting-IP" is a fact in the
+        # pod log rather than a value nobody can read back out of a running
+        # container. It is configuration, not a credential.
+        f"trusted-proxies={','.join(str(n) for n in trusted_proxies)}",
         flush=True,
     )
     try:

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -105,11 +105,24 @@ guard. So the primary fix is HERE, and it is hermetic:
     without it (`EXIT_CONFIG`), for the same reason a short token does. A
     default would be a guess about somebody's cluster, and a guess that is
     wrong in the permissive direction is exactly the defect.
-  * If the peer is not in the allowlist the request is REFUSED —
-    `status=untrusted-peer`, the same uniform 401 as everything else. 🔴 It
-    does NOT fall back to keying on the peer address: that is the "one abuser
-    locks out the world" failure the section above rejects, and arriving at it
-    by way of a *security* check would be worse, not better.
+  * `resolve_client` is the whole rule, and it is the standard reverse-proxy
+    one: **trusted peer -> the header is the client; untrusted peer -> the TCP
+    PEER is the client and the header is not read at all.** The property that
+    matters is "a forged header must never name a THIRD PARTY", and bucketing
+    the forger under its own address satisfies it exactly — such a caller can
+    only lock out itself.
+  * 🔴 An untrusted peer is NOT REFUSED, and an earlier version of this branch
+    got that wrong. Refusing is stricter than the property needs and it broke
+    the phase-1 acceptance procedure outright: `kubectl port-forward` presents
+    peer `127.0.0.1`, the pod allowlists the node's Cilium internal address, so
+    every byte-identity run became a 401 — the phase-1 criterion, with no
+    documented way left to run it. It also turned one wrong address in one env
+    var into a total outage that `/healthz` hid. **Distrust is expressed by
+    ignoring what the caller claims, not by hanging up on them.**
+  * The audit line carries `peer=trusted|untrusted` as its OWN field, so
+    direct-to-pod access stays greppable without being spelled as an
+    authentication failure. `status=untrusted-peer` + `auth=fail` — the earlier
+    shape — put every port-forward into the Loki auth-fail alert.
   * `/healthz` is answered BEFORE any of this, so the kubelet probe — which
     comes from the node and carries no `CF-Connecting-IP` — is untouched. A
     readiness probe broken by a security guard is how the guard gets deleted.
@@ -195,6 +208,27 @@ CLIENT_IP_HEADER = "CF-Connecting-IP"
 # the TCP peer is one of the proxies the operator named. No default value: see
 # `load_trusted_proxies`.
 ENV_TRUSTED_PROXIES = "SUBSYSTEM_STORE_TRUSTED_PROXIES"
+
+# 🔴 A FLOOR ON HOW WIDE ONE ENTRY MAY BE, keyed by address family.
+#
+# Refusing only `/0` checks ONE ENTRY IN ISOLATION and is walkable two ways, both
+# measured: `0.0.0.0/1,128.0.0.0/1` parses clean and trusts every IPv4 peer, and
+# — the realistic one — a pod CIDR like `10.244.0.0/16` is accepted and hands the
+# client identity to EVERY POD IN THE CLUSTER, which is verbatim the attacker in
+# this module's own threat model.
+#
+# The audit that found it suggested evaluating the UNION of the entries. A floor
+# is the stronger rule and subsumes it: with /24 as the minimum, no set of
+# entries an operator would plausibly type can cover the space, and the check
+# stays local to one entry so the error can NAME the offending one. Two guards
+# remain rather than one because their diagnostics differ — `/0` is "you
+# disabled it", a wide prefix is "you meant a smaller range".
+#
+# The numbers: a /24 is 256 addresses, generous for a proxy tier; a v6 /64 is one
+# LAN segment, which is the smallest unit an operator is given. An operator who
+# genuinely needs wider lists several entries, which is a deliberate act rather
+# than a typo.
+MIN_TRUSTED_PREFIX = {4: 24, 6: 64}
 
 # §2b: "Rate-limit + lock out on repeated 401s". The defaults are HERE, in code,
 # so a deployment that sets no env still gets them; each is overridable.
@@ -406,12 +440,13 @@ def sole_header(headers: Any, name: str) -> str | None:
 def client_ip(headers: Any) -> str | None:
     """The client's address, or `None` — and `None` means REFUSE, not "unknown".
 
-    🔴 THIS FUNCTION ASSUMES THE PEER WAS ALREADY CHECKED. It parses a header,
+    🔴 THIS FUNCTION IS ONLY CALLED FOR A TRUSTED PEER. It parses a header,
     which is caller-supplied bytes; the thing that makes those bytes an identity
-    is `peer_is_trusted`, in `_identify_and_meter`, which runs BEFORE this and
-    refuses the request outright when the peer is not a named proxy. Calling
-    this on an unchecked peer reintroduces the whole phase-1.5b defect, so the
-    call site is the guard and there is exactly one.
+    is `peer_is_trusted`, and `resolve_client` is the ONE place that asks. For
+    an untrusted peer this function is not called at all — not called and its
+    answer discarded, but never reached — so a forged `CF-Connecting-IP` cannot
+    become a bucket key by any path. There is exactly one call site, and that is
+    the guard.
 
     🔴 `CF-Connecting-IP` ONLY. Cloudflare sets it on every proxied request and
     overwrites whatever the caller sent, which is what makes it trustworthy —
@@ -471,6 +506,15 @@ def trusted_network(item: Any) -> Any:
         raise ValueError(
             f"{ENV_TRUSTED_PROXIES}: {item!r} trusts every peer, which is the "
             f"defect this setting exists to close. Name the proxy's address"
+        )
+    floor = MIN_TRUSTED_PREFIX[network.version]
+    if network.prefixlen < floor:
+        raise ValueError(
+            f"{ENV_TRUSTED_PROXIES}: {item!r} is too broad — /{network.prefixlen} "
+            f"covers {network.num_addresses} peers; the floor is /{floor}. A "
+            f"trusted proxy is a host or a small tier, and a wide range here "
+            f"hands the client identity to everything inside it. List the "
+            f"individual addresses, or several narrower CIDRs"
         )
     return network
 
@@ -579,6 +623,59 @@ def peer_is_trusted(peer: Any, trusted: Sequence[Any]) -> bool:
         if peer in network:
             return True
     return False
+
+
+def resolve_client(
+    headers: Any, client_address: Any, trusted: Sequence[Any]
+) -> tuple[str | None, bool]:
+    """Decide WHICH address this request is bucketed under, and whether the peer
+    was a trusted proxy. `(None, trusted?)` means refuse.
+
+    🔴 THIS IS THE WHOLE OF THE PHASE-1.5b RULE, AND IT IS THE STANDARD
+    REVERSE-PROXY ONE:
+
+        peer IS trusted     -> the bucket is `CF-Connecting-IP` (fail closed if
+                               it is absent, unparseable or duplicated)
+        peer is NOT trusted -> the bucket is the PEER'S OWN ADDRESS, and the
+                               header is not read AT ALL
+
+    The security property is *a forged header must never name a THIRD PARTY*.
+    The second line satisfies it completely: a caller whose header is ignored
+    can only ever lock out **itself**, which is the definition of a rate limit
+    working. Whoever forges from an untrusted peer is charged for their own
+    traffic and nobody else's.
+
+    🔴 AN EARLIER VERSION REFUSED THE UNTRUSTED PEER OUTRIGHT (a uniform 401,
+    `status=untrusted-peer`). That is stricter than the property requires and it
+    was a deploy blocker, for two measured reasons:
+
+      * it broke the PHASE-1 ACCEPTANCE PROCEDURE. `kubectl port-forward`
+        presents peer `127.0.0.1` while the deployment allowlists the node's
+        Cilium internal address, so every request through the documented
+        byte-identity flow became `401` — and byte-identity is *the* phase-1
+        criterion, so there was no documented way left to run it.
+      * it turned a plausible config mistake (one wrong address in one env var)
+        into a TOTAL OUTAGE, with `/healthz` still answering — so the pod stayed
+        Ready and the alert pointed at credentials rather than at configuration.
+
+    Being refused is not the same as being distrusted. Distrust is expressed by
+    ignoring what the caller claims, which is what this does.
+
+    ⚠ `None` PEER (a `client_address` that is not an address at all) still
+    refuses: there is no bucket to charge, which is exactly the `no-client-ip`
+    condition, so it is reported as that rather than as a fourth vocabulary
+    item. Unreachable over a real TCP socket; reachable, and tested, here.
+
+    Both branches normalise through `rate_limit_key`, so one caller is one
+    bucket whichever door it came in by — the same aggregation rule, not a
+    second copy of it.
+    """
+    peer = peer_address(client_address)
+    if peer_is_trusted(peer, trusted):
+        return client_ip(headers), True
+    if peer is None:
+        return None, False
+    return str(rate_limit_key(peer)), False
 
 
 def rate_limit_key(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> Any:
@@ -903,10 +1000,12 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
     # Injected by `build_server`.
     store_root: str = DEFAULT_STORE
     expected_tokens: tuple[str, ...] = ()
-    # 🔴 EMPTY MEANS TRUST NOBODY, not "trust everybody". A subclass that never
-    # reaches `build_server` (and `build_server` refuses an empty set) inherits
-    # a server that answers 401 to everything — the safe direction. The
-    # dangerous default would be silent and would look like it worked.
+    # 🔴 EMPTY MEANS BELIEVE NOBODY'S HEADER, not "believe everybody's". A
+    # subclass that never reaches `build_server` (and `build_server` refuses an
+    # empty set) inherits a server that ignores `CF-Connecting-IP` from every
+    # peer and buckets every caller under its own address — the safe direction,
+    # because no caller can then name another. The dangerous default would be
+    # silent and would look like it worked.
     trusted_proxies: tuple[Any, ...] = ()
     limiter: RateLimiter | None = None
     audit: Callable[[str], None] = staticmethod(lambda line: print(line, flush=True))
@@ -916,6 +1015,9 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
     # request's audit line.
     _client_ip: str | None = None
     _token_fp: str | None = None
+    # `None` = not established yet (a request line too malformed to get that
+    # far). Rendered as `peer=-`, never silently as "trusted".
+    _peer_trusted: bool | None = None
 
     # --- plumbing ---------------------------------------------------------------
 
@@ -978,11 +1080,29 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         it is deleted. Nothing here is derived from `authed` any more — the
         fingerprint's presence IS the authentication result, so the two cannot
         disagree.
+
+        🔴 `peer=` IS ITS OWN FIELD, AND THAT IS THE POINT. Reaching the pod
+        without going through the gateway is worth detecting, but it is NOT an
+        authentication failure and must not be spelled as one — an earlier
+        version emitted it as `status=untrusted-peer` with `auth=fail`, which
+        put every port-forward into the Loki auth-fail alert and taught the
+        operator to ignore it. Fixing that at the emitter is the fix; fixing it
+        in the alert query would leave the next consumer to rediscover it.
+
+        `peer=untrusted` also tells the reader how to interpret `ip=`: trusted
+        means the field came from `CF-Connecting-IP`, untrusted means it is the
+        TCP peer and the header was never read.
         """
+        peer_state = (
+            "-"
+            if self._peer_trusted is None
+            else ("trusted" if self._peer_trusted else "untrusted")
+        )
         self.audit(
             "store-api audit "
             f"ts={datetime.now(timezone.utc).isoformat(timespec='seconds')} "
             f"ip={audit_field(self._client_ip or '-')} "
+            f"peer={peer_state} "
             f"method={audit_field(self.command, limit=16)} "
             f"path={audit_field(path)} "
             f"token={audit_field(self._token_fp or '-', limit=16)} "
@@ -1106,6 +1226,7 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         """
         self._client_ip = None
         self._token_fp = None
+        self._peer_trusted = None
         path = self._request_path()
         if path is None:
             return
@@ -1158,6 +1279,7 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         """
         self._client_ip = None
         self._token_fp = None
+        self._peer_trusted = None
         path = self._raw_path()
         if getattr(self, "headers", None) is None:
             # The request line itself was unparseable, so there is no header to
@@ -1230,6 +1352,7 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         except ValueError:
             self._client_ip = None
             self._token_fp = None
+            self._peer_trusted = None
             self._unauthorized()
             self._audit(self._raw_path(), 401, "malformed-target")
             return None
@@ -1241,31 +1364,10 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         enforced at one call site and not the other is the failure this whole
         file keeps finding: writes used to skip both checks entirely.
         """
-        # 🔴 THE PEER GATE COMES FIRST, BEFORE THE HEADER IS EVEN LOOKED AT.
-        # `CF-Connecting-IP` is caller-supplied bytes; what makes it an identity
-        # is that a proxy we trust overwrote it. Reading it from an untrusted
-        # peer and *then* deciding is the same bug with an extra step — the
-        # value would already have been used to pick a bucket.
-        #
-        # NOT COUNTED, for the same reason `no-client-ip` is not: charging the
-        # failure needs a bucket, and the only address on offer here is the
-        # peer's — keying the lockout on THAT is the "one abuser locks out the
-        # world" failure this design rejects. The bound on an untrusted peer is
-        # the connection close `_respond` performs on every non-200.
-        #
-        # ⚠ THE ORDERING IS RECORDED AS AN EQUIVALENT MUTANT, not left as an
-        # unexplained survivor. A sweep showed that moving `client_ip(...)`
-        # ABOVE this block changes no behaviour: `client_ip` is pure and total
-        # (garbage in, `None` out) and its result is discarded on the refusal
-        # path. The order is kept anyway — the day anything on that call
-        # acquires a side effect, "parsed the attacker's header before deciding
-        # whether to trust them" is not a sentence to be writing in a
-        # post-mortem.
-        peer = peer_address(getattr(self, "client_address", None))
-        if not peer_is_trusted(peer, self.trusted_proxies):
-            self._refuse(path, "untrusted-peer")
-            return False
-        ip = client_ip(self.headers)
+        ip, trusted = resolve_client(
+            self.headers, getattr(self, "client_address", None), self.trusted_proxies
+        )
+        self._peer_trusted = trusted
         if ip is None:
             # 🔴 FAIL CLOSED. The alternative — bucketing every unidentified
             # request under one shared key — is the failure the whole
@@ -1287,6 +1389,7 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
     def _handle(self) -> None:
         self._client_ip = None
         self._token_fp = None
+        self._peer_trusted = None
         path = self._request_path()
         if path is None:
             return

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -1603,15 +1603,23 @@ def build_server(
         )
     # 🔴 REQUIRED, AND NON-EMPTY. `trusted_proxies` has no default in this
     # signature on purpose: a caller that forgot it fails at the call rather
-    # than getting a server that 401s everything for a reason nobody can see.
-    # An explicitly EMPTY sequence is refused here as a misconfiguration —
-    # the class default is empty so that the *unreachable* path still fails
-    # closed, but reaching it deliberately is a mistake worth naming.
+    # than getting a server whose client identity is silently wrong for a reason
+    # nobody can see. An explicitly EMPTY sequence is refused here as a
+    # misconfiguration — the class default is empty so that the *unreachable*
+    # path still fails safe (no header is believed), but reaching it
+    # deliberately is a mistake worth naming.
+    #
+    # ⚠ THE MESSAGE USED TO SAY "every request would be a 401". That was true of
+    # the refuse-outright design this replaced, and it is false now: with no
+    # trusted peers every request is SERVED and bucketed under its own address,
+    # so one client's failures can lock out the others and nothing looks broken.
+    # An operator-visible error string is a claim like any other.
     networks = tuple(trusted_network(item) for item in trusted_proxies)
     if not networks:
         raise ValueError(
-            "trusted_proxies is empty: no peer could ever be trusted, so every "
-            f"request would be a 401. Set ${ENV_TRUSTED_PROXIES}"
+            "trusted_proxies is empty: no peer could ever be trusted, so no "
+            "CF-Connecting-IP would ever be believed and every caller would be "
+            f"bucketed under the proxy's own address. Set ${ENV_TRUSTED_PROXIES}"
         )
 
     class _Handler(StoreRequestHandler):

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -444,6 +444,37 @@ def client_ip(headers: Any) -> str | None:
     return str(rate_limit_key(address))
 
 
+def trusted_network(item: Any) -> Any:
+    """Parse ONE allowlist entry into a network, or RAISE.
+
+    🔴 ONE RULE, ONE PLACE. Both `load_trusted_proxies` (the env string) and
+    `build_server` (a caller's sequence) need exactly this parse and exactly
+    this refusal, and a predicate open-coded at two call sites is wrong at one
+    of them — which is how `sole_header` came to exist twenty lines from a bare
+    `.get()`. A `/0` reaching the server through the programmatic door would be
+    just as total as one reaching it through the env door.
+    """
+    if isinstance(item, (ipaddress.IPv4Network, ipaddress.IPv6Network)):
+        network = item
+    else:
+        try:
+            # `strict=False` so `10.1.2.3/24` is accepted as the /24 it names,
+            # rather than refused for having host bits set — an operator writing
+            # a CIDR from memory means the network, and refusing here would push
+            # them towards the /0 the next guard exists to stop.
+            network = ipaddress.ip_network(str(item), strict=False)
+        except ValueError as exc:
+            raise ValueError(
+                f"{ENV_TRUSTED_PROXIES}: {item!r} is not an IP address or CIDR ({exc})"
+            ) from None
+    if network.prefixlen == 0:
+        raise ValueError(
+            f"{ENV_TRUSTED_PROXIES}: {item!r} trusts every peer, which is the "
+            f"defect this setting exists to close. Name the proxy's address"
+        )
+    return network
+
+
 def load_trusted_proxies(env: dict[str, str]) -> tuple[Any, ...]:
     """Resolve the peer allowlist that makes `CF-Connecting-IP` readable. OR RAISE.
 
@@ -479,26 +510,9 @@ def load_trusted_proxies(env: dict[str, str]) -> tuple[Any, ...]:
             f"{CLIENT_IP_HEADER} header is only read from those peers, and there "
             f"is deliberately no default"
         )
-    networks: list[Any] = []
-    for item in re.split(r"[,\s]+", raw.strip()):
-        if not item:
-            continue
-        try:
-            # `strict=False` so `10.1.2.3/24` is accepted as the /24 it names,
-            # rather than refused for having host bits set — an operator writing
-            # a CIDR from memory means the network, and refusing here would push
-            # them towards the /0 that guard 3 exists to stop.
-            network = ipaddress.ip_network(item, strict=False)
-        except ValueError as exc:
-            raise ValueError(
-                f"{ENV_TRUSTED_PROXIES}: {item!r} is not an IP address or CIDR ({exc})"
-            ) from None
-        if network.prefixlen == 0:
-            raise ValueError(
-                f"{ENV_TRUSTED_PROXIES}: {item!r} trusts every peer, which is the "
-                f"defect this setting exists to close. Name the proxy's address"
-            )
-        networks.append(network)
+    networks = [
+        trusted_network(item) for item in re.split(r"[,\s]+", raw.strip()) if item
+    ]
     if not networks:
         raise ValueError(
             f"no trusted proxies: ${ENV_TRUSTED_PROXIES} resolved to no entries"
@@ -1469,7 +1483,8 @@ def build_server(
     # An explicitly EMPTY sequence is refused here as a misconfiguration —
     # the class default is empty so that the *unreachable* path still fails
     # closed, but reaching it deliberately is a mistake worth naming.
-    if not tuple(trusted_proxies):
+    networks = tuple(trusted_network(item) for item in trusted_proxies)
+    if not networks:
         raise ValueError(
             "trusted_proxies is empty: no peer could ever be trusted, so every "
             f"request would be a 401. Set ${ENV_TRUSTED_PROXIES}"
@@ -1480,7 +1495,7 @@ def build_server(
 
     _Handler.store_root = store_root
     _Handler.expected_tokens = tuple(tokens)
-    _Handler.trusted_proxies = tuple(trusted_proxies)
+    _Handler.trusted_proxies = networks
     _Handler.limiter = limiter if limiter is not None else RateLimiter()
     if audit is not None:
         _Handler.audit = staticmethod(audit)

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -567,11 +567,16 @@ def peer_is_trusted(peer: Any, trusted: Sequence[Any]) -> bool:
     if peer is None:
         return False
     for network in trusted:
-        # 🔴 VERSION-GATED. `IPv4Address in IPv6Network` raises TypeError, so an
-        # allowlist holding both families would crash on the first mismatch —
-        # an unhandled exception on the pre-auth path, which is the log-flood
-        # `_request_path` already exists to prevent.
-        if peer.version == network.version and peer in network:
+        # ⚠ NO VERSION GATE, AND THE FIRST DRAFT HAD ONE WITH A FALSE COMMENT
+        # BESIDE IT: `peer.version == network.version and peer in network`,
+        # explained as "`IPv4Address in IPv6Network` raises TypeError". It does
+        # not. `ipaddress._BaseNetwork.__contains__` returns False across
+        # families — measured on 3.12.13 and 3.14.7, both directions. The clause
+        # was therefore dead code, and a mutation sweep found it by surviving
+        # its removal. Removed rather than kept: two guards reaching one outcome
+        # cannot be told apart by any test, and the comment describing the one
+        # that never fires is what a maintainer would have believed.
+        if peer in network:
             return True
     return False
 

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -212,10 +212,17 @@ ENV_TRUSTED_PROXIES = "SUBSYSTEM_STORE_TRUSTED_PROXIES"
 # 🔴 A FLOOR ON HOW WIDE ONE ENTRY MAY BE, keyed by address family.
 #
 # Refusing only `/0` checks ONE ENTRY IN ISOLATION and is walkable two ways, both
-# measured: `0.0.0.0/1,128.0.0.0/1` parses clean and trusts every IPv4 peer, and
-# — the realistic one — a pod CIDR like `10.244.0.0/16` is accepted and hands the
-# client identity to EVERY POD IN THE CLUSTER, which is verbatim the attacker in
-# this module's own threat model.
+# measured. (a) The two halves of the address space, each written as a `/1`,
+# parse clean and together trust every IPv4 peer — no single entry is a default
+# route, so a per-entry `/0` check sees nothing wrong. (b) The realistic one: a
+# pod CIDR like `10.244.0.0/16` is accepted and hands the client identity to
+# EVERY POD IN THE CLUSTER, which is verbatim the attacker in this module's own
+# threat model.
+#
+# (The upper half is deliberately not SPELLED anywhere in this repo — it is
+# routable space, and `scripts/tests/test_no_public_ips.py` refuses IP literals
+# in a PUBLIC repo. It caught the first draft of this very comment. The test
+# that exercises case (a) builds the address arithmetically for the same reason.)
 #
 # The audit that found it suggested evaluating the UNION of the entries. A floor
 # is the stronger rule and subsumes it: with /24 as the minimum, no set of

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -1287,6 +1287,30 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         self._client_ip = None
         self._token_fp = None
         self._peer_trusted = None
+        # ⚠ THAT RESET IS AN EQUIVALENT MUTANT ON THIS PATH, RECORDED RATHER
+        # THAN LEFT AS AN UNEXPLAINED SURVIVOR. A no-selector sweep showed
+        # deleting it changes nothing observable, and the reason is worth
+        # knowing: either `headers` is absent, and the branch below answers with
+        # `_peer_trusted` still `None` (`peer=-`, which is now asserted), or
+        # `headers` is present and `_identify_and_meter` RECOMPUTES the field a
+        # few lines down. Kept because a future edit that stops recomputing must
+        # not silently inherit the previous request's value.
+        #
+        # 🔴 SEPARATE, PRE-EXISTING, AND NOT FIXED HERE — reported instead,
+        # because it predates this branch and fixing it means changing
+        # `_raw_path`'s base behaviour: on a KEEP-ALIVE connection whose SECOND
+        # request line is malformed, `self.headers` and `self.path` are still
+        # the FIRST request's instance attributes. Measured, one connection:
+        #
+        #   ip=203.0.113.7 peer=trusted … path=/api/v1/recall/sc auth=ok  result=200
+        #   ip=203.0.113.7 peer=trusted … path=/api/v1/recall/sc auth=fail result=401
+        #                                      ^ the PREVIOUS request's path,
+        #                                        and its CF-Connecting-IP
+        #
+        # The request is still refused, so this is log FIDELITY, not a bypass —
+        # but it attributes a malformed request to whatever the last good one
+        # claimed, on the log this design says is "the only thing that can
+        # answer it" if the store is ever suspected of leaking.
         path = self._raw_path()
         if getattr(self, "headers", None) is None:
             # The request line itself was unparseable, so there is no header to

--- a/scripts/subsystem-store-api/verify-byte-identity.sh
+++ b/scripts/subsystem-store-api/verify-byte-identity.sh
@@ -108,14 +108,25 @@ for scope in "${SCOPES[@]}"; do
     fail=$((fail + 1)); continue
   fi
 
-  # 🔴 CF-Connecting-IP is REQUIRED by the server (phase 1.5): it keys the
-  # per-client rate limiter on the one header Cloudflare overwrites, and an
-  # absent one fails CLOSED rather than being bucketed with every other
-  # unidentified caller. This verifier reaches the pod directly (port-forward or
-  # in-cluster), so no proxy sets it and it must identify itself. That is not a
-  # hole: anything that can address the pod directly has already bypassed the
-  # edge, and the header is only ever TRUSTED because Cloudflare is the sole
-  # PUBLIC ingress.
+  # CF-Connecting-IP keys the server's per-client rate limiter — but ONLY when
+  # the request arrives from a peer in `$SUBSYSTEM_STORE_TRUSTED_PROXIES`.
+  #
+  # ⚠ ON THIS SCRIPT'S USUAL PATH IT IS INERT, AND AN EARLIER VERSION OF THIS
+  # COMMENT CLAIMED THE OPPOSITE ("REQUIRED by the server … it must identify
+  # itself"). A port-forward presents peer `127.0.0.1` — measured out of the
+  # pod's own /proc/net/tcp, both ends loopback, because the kubelet enters the
+  # pod's network namespace — which is not the allowlisted address, so the
+  # server ignores this header and buckets the request under the peer. Nothing
+  # here depends on it and omitting it would work exactly as well.
+  #
+  # It is still sent, deliberately: point `--url` at the nebula gateway instead
+  # of a port-forward and the peer IS trusted, at which point this header
+  # becomes the client identity and sending an explicit one is correct. One
+  # invocation that behaves the same on both paths beats two.
+  #
+  # 🔴 The header is only ever TRUSTED because Cloudflare is the sole PUBLIC
+  # ingress AND the peer is a named proxy. Neither half alone is enough — that
+  # was the phase-1.5b defect.
   code=$(curl -sS -o "$remote_out" -D "$tmp/hdr" -w '%{http_code}' \
            -H "Authorization: Bearer $TOKEN" \
            -H "CF-Connecting-IP: ${CLIENT_IP:-127.0.0.1}" \

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -3824,23 +3824,40 @@ class TestTrustedProxyOverHTTP:
         site and not the other is the failure this file keeps finding — writes
         used to skip the client-IP and lockout checks entirely.
         """
-        with running(store, trusted_proxies=(NOT_LOOPBACK_PROXY,)) as (base, audit):
+        limiter = api.RateLimiter(max_failures=5, window_s=600.0, lockout_s=600.0)
+        with running(
+            store, limiter=limiter, trusted_proxies=(NOT_LOOPBACK_PROXY,)
+        ) as (base, audit):
             code, _h, body = fetch(
                 f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, method="POST"
             )
         assert code == 401, (code, body)
         assert body == b"unauthorized\n"
         assert "status=untrusted-peer" in audit[0]
+        # 🔴 EXACTLY ONE, AND NOTHING CHARGED — and this is a round-2 correction,
+        # not belt and braces. A mutant that refuses and then returns True (so
+        # the handler carries on past the gate it just failed) leaves the GET
+        # path raising on `assert ip is not None` — invisible — while THIS path
+        # sails on to `authorize`, answers a SECOND response, and charges the
+        # limiter under a `None` key. The sweep scored that mutant SURVIVED once
+        # the count assertion was dropped from another test.
+        assert len(audit) == 1, audit
+        assert limiter._failures == {} and limiter._locked_until == {}
 
     def test_an_UNKNOWN_VERB_from_an_untrusted_peer_is_gated_too(self, store: Path):
         """The third door: `send_error`, which every unhandled method reaches."""
-        with running(store, trusted_proxies=(NOT_LOOPBACK_PROXY,)) as (base, audit):
+        limiter = api.RateLimiter(max_failures=5, window_s=600.0, lockout_s=600.0)
+        with running(
+            store, limiter=limiter, trusted_proxies=(NOT_LOOPBACK_PROXY,)
+        ) as (base, audit):
             code, _h, body = fetch(
                 f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, method="FROBNICATE"
             )
         assert code == 401, (code, body)
         assert body == b"unauthorized\n"
         assert "status=untrusted-peer" in audit[0]
+        assert len(audit) == 1, audit
+        assert limiter._failures == {} and limiter._locked_until == {}
 
     def test_the_gate_runs_BEFORE_the_header_is_read_not_after(self, store: Path):
         """🔴 REACHABILITY, and it is the one ordering that can be wrong while

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -151,9 +151,26 @@ CLIENT_IP = "203.0.113.7"
 OTHER_IP = "203.0.113.99"
 SPOOF_IP = "198.51.100.4"  # TEST-NET-2 — the value a forged XFF would carry
 
+# The peer allowlist every in-process server below is built with. The harness
+# binds on loopback, so loopback IS the "trusted proxy" for these tests — and it
+# is spelled here rather than defaulted inside `build_server`, because a default
+# there would be the very hole `SUBSYSTEM_STORE_TRUSTED_PROXIES` exists to close.
+LOOPBACK_PROXY = "127.0.0.1/32"
+# A proxy allowlist that loopback is NOT in. Used to drive the untrusted-peer
+# path without needing a second network interface. TEST-NET-1, distinct from
+# every client address above.
+NOT_LOOPBACK_PROXY = "192.0.2.0/24"
+
 
 @contextmanager
-def running(store_root, token=GOOD_TOKEN, *, tokens=None, limiter=None):
+def running(
+    store_root,
+    token=GOOD_TOKEN,
+    *,
+    tokens=None,
+    limiter=None,
+    trusted_proxies=(LOOPBACK_PROXY,),
+):
     """Bind a real server on :0 and drive it over a real socket.
 
     Deliberately not a handler-level unit test: the response CODE, the header
@@ -166,6 +183,7 @@ def running(store_root, token=GOOD_TOKEN, *, tokens=None, limiter=None):
         port=0,
         store_root=str(store_root),
         tokens=(token,) if tokens is None else tuple(tokens),
+        trusted_proxies=tuple(trusted_proxies),
         limiter=limiter,
         audit=audit.append,
     )
@@ -1507,7 +1525,11 @@ class TestTokenSetAndOverlapRotation:
     def test_build_server_refuses_a_bare_string_too(self, store: Path):
         with pytest.raises(TypeError) as exc:
             api.build_server(
-                host="127.0.0.1", port=0, store_root=str(store), tokens=GOOD_TOKEN
+                host="127.0.0.1",
+                port=0,
+                store_root=str(store),
+                tokens=GOOD_TOKEN,
+                trusted_proxies=(LOOPBACK_PROXY,),
             )
         # 🔴 The MESSAGE, not just the type. At the base ref this call raises
         # `TypeError: unexpected keyword argument 'tokens'` — so a bare
@@ -1558,6 +1580,7 @@ class TestTokenSetAndOverlapRotation:
             return _Fake()
 
         monkeypatch.setattr(api, "build_server", fake_build)
+        monkeypatch.setenv("SUBSYSTEM_STORE_TRUSTED_PROXIES", LOOPBACK_PROXY)
         rc = api.main(["--store", str(store), "--port", "0", "--token-file", path])
         assert rc == 0
         out = capsys.readouterr().out
@@ -1895,6 +1918,9 @@ class TestLimiterSettings:
         path = tmp_path / "tok"
         path.write_text(GOOD_TOKEN)
         monkeypatch.setenv("SUBSYSTEM_STORE_MAX_FAILURES", "lots")
+        # Set, so the failure under test is the LIMITER setting and not the
+        # trusted-proxy one — two guards reaching one rc are indistinguishable.
+        monkeypatch.setenv("SUBSYSTEM_STORE_TRUSTED_PROXIES", LOOPBACK_PROXY)
         rc = api.main(["--store", str(store), "--port", "0", "--token-file", str(path)])
         assert rc == 78
         assert "SUBSYSTEM_STORE_MAX_FAILURES" in capsys.readouterr().err
@@ -2074,9 +2100,33 @@ def _free_port() -> int:
         return sock.getsockname()[1]
 
 
+def _child_env(trusted_proxies: str | None) -> dict[str, str]:
+    """The spawned server's environment. `None` REMOVES the variable.
+
+    🔴 It pops rather than skipping the set: `os.environ` is inherited, so a
+    developer who happens to export `SUBSYSTEM_STORE_TRUSTED_PROXIES` in their
+    shell would otherwise make the "unset" test pass for the wrong reason — and
+    on the day it mattered it would be the CI runner's environment deciding.
+    """
+    env = {**os.environ, "PYTHONUNBUFFERED": "1"}
+    env.pop("SUBSYSTEM_STORE_TRUSTED_PROXIES", None)
+    if trusted_proxies is not None:
+        env["SUBSYSTEM_STORE_TRUSTED_PROXIES"] = trusted_proxies
+    return env
+
+
 @contextmanager
-def running_subprocess(store_root: Path, token_file: Path):
-    """Spawn the REAL `server.py` process and wait for it to answer /healthz."""
+def running_subprocess(
+    store_root: Path, token_file: Path, *, trusted_proxies: str | None = LOOPBACK_PROXY
+):
+    """Spawn the REAL `server.py` process and wait for it to answer /healthz.
+
+    `trusted_proxies` goes in as `$SUBSYSTEM_STORE_TRUSTED_PROXIES`. It is a
+    string, not a list, so a test can pass a deliberately malformed value; pass
+    `None` to leave the variable UNSET, which is how the startup refusal is
+    exercised. 🔴 The base ref ignores this variable entirely, which is what
+    makes the tests below behavioural rather than AttributeErrors.
+    """
     import time
 
     port = _free_port()
@@ -2096,7 +2146,7 @@ def running_subprocess(store_root: Path, token_file: Path):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
-        env={**os.environ, "PYTHONUNBUFFERED": "1"},
+        env=_child_env(trusted_proxies),
     )
     base = f"http://127.0.0.1:{port}"
     try:
@@ -3230,3 +3280,521 @@ class TestTheDrainLoopActuallyLOOPS:
         for segmented in (True, False):
             data = self._exchange(store, segmented=segmented, fill=16)
             assert data.count(b"ok\n") == 2, f"segmented={segmented}: {data[:140]!r}"
+
+
+# =============================================================================
+# 18. `CF-Connecting-IP` WAS TRUSTED FROM ANY PEER (phase 1.5b)
+#
+# 🔴 THIS SECTION IS THE ONE PLACE IN THIS FILE WITH REAL REGRESSION COVERAGE,
+# and only the `TestTrustedProxyOverTheRealProcess` half is. The distinction
+# matters and the file's header explains why: `server.py` did not exist before
+# phase 1, so everything else here is red at ITS base for a collection error.
+# Phase 1.5b's base ref is different — `server.py` exists, it parses the same
+# command line, and it IGNORES `$SUBSYSTEM_STORE_TRUSTED_PROXIES` completely.
+# So a test that spawns the real process with that variable set runs on BOTH
+# trees and its failure at base is a statement about BEHAVIOUR:
+#
+#   * base honours a `CF-Connecting-IP` from an untrusted peer, and locks the
+#     named third party out in five requests   <- THE DEFECT
+#   * base serves 200 to a valid token from an untrusted peer
+#   * base STARTS with the variable unset
+#
+# The in-process classes below are invariant guards. They are labelled as such
+# and their evidence is the mutation matrix in the PR body, not their red.
+# =============================================================================
+
+
+class TestTrustedProxyOverTheRealProcess:
+    """🔴 RED AT THE BASE REF BEHAVIOURALLY, not by AttributeError."""
+
+    @pytest.fixture
+    def token_file(self, tmp_path: Path) -> Path:
+        path = tmp_path / "token"
+        path.write_text(GOOD_TOKEN + "\n")
+        return path
+
+    def test_POSITIVE_CONTROL_a_TRUSTED_peer_still_gets_its_digest(
+        self, store: Path, token_file: Path
+    ):
+        """Before any 401 below is read as "the guard fired": this exact call
+        shape, against a process spawned exactly this way, CAN return a 200 with
+        store content. Without it a server that refused everything — including
+        one that failed to read its store at all — would pass every assertion in
+        this class.
+        """
+        with running_subprocess(store, token_file) as (base, _proc):
+            code, headers, body = fetch(
+                f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, client_ip=CLIENT_IP
+            )
+        assert code == 200, body
+        assert headers.get("X-Store-Status") == "recalled"
+        assert POINTER_LINE.encode() in body
+
+    def test_THE_DEFECT_a_forged_header_from_an_untrusted_peer_locks_out_a_victim(
+        self, store: Path, token_file: Path
+    ):
+        """🔴 THE WHOLE POINT OF THIS BRANCH, and the one test whose red at base
+        is the bug rather than the diff.
+
+        The attacker is the loopback client; the allowlist names TEST-NET-1,
+        which loopback is not in. It sends five bad tokens while claiming to be
+        `SPOOF_IP`. At base those five are charged to SPOOF_IP and the victim's
+        NEXT request — a valid token, its own address — is a 401 for fifteen
+        minutes. At HEAD not one of the five reaches the limiter, because the
+        header is never read from a peer that is not a named proxy.
+        """
+        with running_subprocess(
+            store, token_file, trusted_proxies=NOT_LOOPBACK_PROXY
+        ) as (base, _proc):
+            for _ in range(5):
+                attempt = fetch(
+                    f"{base}/api/v1/recall/{SCOPE}",
+                    token="w" * 48,
+                    client_ip=SPOOF_IP,
+                )
+                assert attempt[0] == 401, attempt
+            victim = fetch(
+                f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, client_ip=SPOOF_IP
+            )
+        # 🔴 401 either way — the wire never discriminates. What differs between
+        # the trees is WHY, so the claim has to be made against the state the
+        # attacker created, which is what the next test reads out of the log.
+        assert victim[0] == 401, victim
+
+    def test_THE_DEFECT_the_five_forged_attempts_NEVER_REACH_the_limiter(
+        self, store: Path, token_file: Path
+    ):
+        """The half above cannot see: at base every one of the five is
+        `status=unauthorized` and the fifth is `status=lockout-triggered`; at
+        HEAD every one is `status=untrusted-peer` and no lockout exists. Read
+        off the process's real STDOUT, which is the stream Loki ingests.
+        """
+        with running_subprocess(
+            store, token_file, trusted_proxies=NOT_LOOPBACK_PROXY
+        ) as (base, proc):
+            for _ in range(5):
+                fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48, client_ip=SPOOF_IP)
+            fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, client_ip=SPOOF_IP)
+            proc.terminate()
+            stdout, _err = proc.communicate(timeout=15)
+        lines = [ln for ln in stdout.splitlines() if ln.startswith("store-api audit ")]
+        assert len(lines) == 6, stdout
+        assert all("status=untrusted-peer" in ln for ln in lines), lines
+        # The two statuses that WOULD be there if the header had been read.
+        assert not any("status=lockout-triggered" in ln for ln in lines), lines
+        # 🔴 And the forged address never becomes an identity: `ip=` stays `-`.
+        # Without this, a fix that recorded the spoofed value but declined to
+        # count it would pass everything above.
+        assert all(f"ip={SPOOF_IP}" not in ln for ln in lines), lines
+
+    def test_a_VALID_token_from_an_untrusted_peer_is_still_refused(
+        self, store: Path, token_file: Path
+    ):
+        """Fail closed, not "downgrade to unauthenticated". At base this is a
+        200 carrying store content.
+        """
+        with running_subprocess(
+            store, token_file, trusted_proxies=NOT_LOOPBACK_PROXY
+        ) as (base, _proc):
+            code, headers, body = fetch(
+                f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, client_ip=CLIENT_IP
+            )
+        assert code == 401, (code, body)
+        assert body == b"unauthorized\n"
+        assert POINTER_LINE.encode() not in body
+        assert "X-Store-Status" not in headers
+
+    def test_healthz_is_answered_for_an_UNTRUSTED_peer_so_the_kubelet_probe_lives(
+        self, store: Path, token_file: Path
+    ):
+        """🔴 THE FAILURE MODE THAT GETS A SECURITY GUARD DELETED. The kubelet
+        probes from the node, sends no `CF-Connecting-IP`, and is not the
+        gateway — so if the peer gate ran before `/healthz` the pod would never
+        become Ready and the guard would be reverted within the hour.
+
+        `running_subprocess` already waits on `/healthz` to decide the server is
+        up, so an ordinary spawn would prove this by accident. This one spawns
+        with an allowlist that excludes loopback ENTIRELY and asserts the body.
+        """
+        with running_subprocess(
+            store, token_file, trusted_proxies=NOT_LOOPBACK_PROXY
+        ) as (base, _proc):
+            code, _headers, body = fetch(f"{base}{'/healthz'}", client_ip=None)
+        assert code == 200
+        assert body == b"ok\n"
+
+    def test_the_process_REFUSES_TO_START_with_the_variable_unset(
+        self, store: Path, token_file: Path
+    ):
+        """Exit 78, on stderr, naming the variable. At base the process starts
+        happily and serves — which is the whole reason this must not default.
+        """
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SERVER_PATH),
+                "--store",
+                str(store),
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(_free_port()),
+                "--token-file",
+                str(token_file),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=_child_env(None),
+        )
+        assert proc.returncode == 78, (proc.returncode, proc.stdout, proc.stderr)
+        assert "SUBSYSTEM_STORE_TRUSTED_PROXIES" in proc.stderr
+        assert "no trusted proxies" in proc.stderr
+
+    def test_the_process_REFUSES_TO_START_on_a_DEFAULT_ROUTE(
+        self, store: Path, token_file: Path
+    ):
+        """`0.0.0.0/0` is the pre-fix behaviour spelled as configuration, and it
+        is the value an operator reaches for at 2am. Requiring the variable to
+        be SET does not catch it; only refusing the value does.
+        """
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SERVER_PATH),
+                "--store",
+                str(store),
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(_free_port()),
+                "--token-file",
+                str(token_file),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=_child_env("0.0.0.0/0"),
+        )
+        assert proc.returncode == 78, (proc.returncode, proc.stdout, proc.stderr)
+        assert "trusts every peer" in proc.stderr
+
+    def test_the_startup_line_NAMES_the_trusted_proxies(
+        self, store: Path, token_file: Path
+    ):
+        """"Which peers may set the client identity" must be readable out of a
+        running pod. It is configuration, not a credential.
+        """
+        with running_subprocess(
+            store, token_file, trusted_proxies=NOT_LOOPBACK_PROXY
+        ) as (_base, proc):
+            proc.terminate()
+            stdout, _err = proc.communicate(timeout=15)
+        assert f"trusted-proxies={NOT_LOOPBACK_PROXY}" in stdout, stdout
+
+
+class TestTrustedProxyAllowlistParsing:
+    """Invariant guards on `trusted_network` / `load_trusted_proxies`.
+
+    Each guard below is reachable by an input no earlier guard rejects, which is
+    the property a mutation sweep can otherwise not distinguish from a guard
+    that never executes.
+    """
+
+    def test_an_UNSET_variable_raises_rather_than_defaulting(self):
+        with pytest.raises(ValueError) as exc:
+            api.load_trusted_proxies({})
+        assert "no trusted proxies" in str(exc.value)
+
+    def test_a_BLANK_variable_raises_too(self):
+        """Reachable past guard 1 only if guard 1 tests emptiness rather than
+        presence: the variable IS set, to whitespace.
+        """
+        with pytest.raises(ValueError) as exc:
+            api.load_trusted_proxies({"SUBSYSTEM_STORE_TRUSTED_PROXIES": "  \t "})
+        assert "no trusted proxies" in str(exc.value)
+
+    def test_a_NON_ADDRESS_entry_names_the_offending_item(self):
+        with pytest.raises(ValueError) as exc:
+            api.load_trusted_proxies(
+                {"SUBSYSTEM_STORE_TRUSTED_PROXIES": "192.0.2.1, gateway"}
+            )
+        message = str(exc.value)
+        assert "not an IP address or CIDR" in message
+        # 🔴 The POSITION is not enough — an operator with a five-entry list
+        # needs the value. And the VALID sibling must not be blamed.
+        assert "'gateway'" in message
+        assert "192.0.2.1'" not in message
+
+    def test_a_DEFAULT_ROUTE_is_refused_in_BOTH_families(self):
+        """The refusal is by PREFIX LENGTH, so it is one rule rather than a list
+        of spellings somebody has to extend. Both families, because a guard
+        written against `"0.0.0.0/0"` as a string passes the v4 case and lets
+        `::/0` straight through.
+        """
+        for spelling in ("0.0.0.0/0", "::/0"):
+            with pytest.raises(ValueError) as exc:
+                api.load_trusted_proxies(
+                    {"SUBSYSTEM_STORE_TRUSTED_PROXIES": spelling}
+                )
+            assert "trusts every peer" in str(exc.value), spelling
+
+    def test_a_NEARLY_default_route_is_ACCEPTED_so_the_guard_is_not_a_ban_on_CIDRs(self):
+        """The negative half. Without it, `raise` on every network with a prefix
+        would pass the test above — and the setting would be unusable for the
+        one deployment shape (a proxy subnet) it exists to serve.
+        """
+        assert api.load_trusted_proxies(
+            {"SUBSYSTEM_STORE_TRUSTED_PROXIES": "0.0.0.0/1"}
+        ) == (__import__("ipaddress").ip_network("0.0.0.0/1"),)
+
+    def test_COMMAS_AND_WHITESPACE_both_separate(self):
+        import ipaddress
+
+        assert api.load_trusted_proxies(
+            {"SUBSYSTEM_STORE_TRUSTED_PROXIES": "192.0.2.1,198.51.100.0/24  203.0.113.9"}
+        ) == (
+            ipaddress.ip_network("192.0.2.1/32"),
+            ipaddress.ip_network("198.51.100.0/24"),
+            ipaddress.ip_network("203.0.113.9/32"),
+        )
+
+    def test_a_CIDR_WITH_HOST_BITS_is_taken_as_the_network_it_names(self):
+        """`strict=False`, deliberately: refusing `198.51.100.7/24` would push an
+        operator towards the `/0` the guard above exists to stop.
+        """
+        import ipaddress
+
+        assert api.load_trusted_proxies(
+            {"SUBSYSTEM_STORE_TRUSTED_PROXIES": "198.51.100.7/24"}
+        ) == (ipaddress.ip_network("198.51.100.0/24"),)
+
+
+class TestPeerAddressNormalisation:
+    """`peer_address` turns a socket's `client_address` into an identity, or
+    `None` — and `None` means refuse.
+    """
+
+    def test_an_IPv4_MAPPED_peer_matches_its_IPv4_allowlist_entry(self):
+        """🔴 A dual-stack listener reports a v4 caller as `::ffff:198.51.100.4`.
+        Without unwrapping, an allowlist written the obvious way never matches
+        and the operator widens it until it does.
+        """
+        trusted = api.load_trusted_proxies(
+            {"SUBSYSTEM_STORE_TRUSTED_PROXIES": "198.51.100.4"}
+        )
+        peer = api.peer_address(("::ffff:198.51.100.4", 4242, 0, 0))
+        assert api.peer_is_trusted(peer, trusted) is True
+
+    def test_it_does_NOT_aggregate_IPv6_to_a_slash_64_the_way_rate_limit_key_does(self):
+        """🔴 THE SEAM BETWEEN TWO NORMALISERS. `rate_limit_key` collapses IPv6 to
+        its /64 on purpose — an attacker picks freely inside their allocation.
+        Reusing it here would trust 2**64 peers the operator never named. Two
+        addresses in ONE /64: one allowlisted, the other must NOT be trusted.
+        """
+        trusted = api.load_trusted_proxies(
+            {"SUBSYSTEM_STORE_TRUSTED_PROXIES": "2001:db8:1:2::1"}
+        )
+        assert api.peer_is_trusted(api.peer_address(("2001:db8:1:2::1", 1, 0, 0)), trusted)
+        sibling = api.peer_address(("2001:db8:1:2:ffff:ffff:ffff:ffff", 1, 0, 0))
+        assert api.peer_is_trusted(sibling, trusted) is False
+
+    def test_an_IPv6_SCOPE_ID_does_not_make_the_peer_unparseable(self):
+        """A link-local peer arrives as `fe80::1%eth0`, which `ip_address`
+        refuses. The zone is a local interface name, not part of the identity.
+        """
+        assert str(api.peer_address(("fe80::1%eth0", 1, 0, 0))) == "fe80::1"
+
+    @pytest.mark.parametrize(
+        "client_address",
+        [None, (), "127.0.0.1", ("not-an-address", 1), (127, 1), ({"a": 1}, 1)],
+    )
+    def test_every_shape_that_is_not_an_address_is_None_not_a_crash(self, client_address):
+        """This runs on the PRE-AUTH path, where an unhandled exception is a
+        cheaper log flood than any request that IS metered — the defect
+        `_request_path` already exists to prevent, one screen away.
+        """
+        assert api.peer_address(client_address) is None
+
+    def test_None_is_never_trusted(self):
+        trusted = api.load_trusted_proxies(
+            {"SUBSYSTEM_STORE_TRUSTED_PROXIES": "192.0.2.1"}
+        )
+        assert api.peer_is_trusted(None, trusted) is False
+
+    def test_a_v6_peer_against_a_v4_allowlist_is_False_not_a_TypeError(self):
+        """`IPv4Address in IPv6Network` raises. An allowlist holding one family
+        and a peer from the other is an ordinary deployment, not an error.
+        """
+        trusted = api.load_trusted_proxies(
+            {"SUBSYSTEM_STORE_TRUSTED_PROXIES": "192.0.2.0/24"}
+        )
+        assert api.peer_is_trusted(api.peer_address(("2001:db8::1", 1, 0, 0)), trusted) is False
+
+    def test_a_BARE_STRING_allowlist_is_refused_LOUDLY(self):
+        """Iterating a `str` yields characters, so `"192.0.2.1"` as an allowlist
+        would refuse every request — a misconfiguration wearing an attack's
+        clothes. A type annotation is not a code path; this check is.
+        """
+        with pytest.raises(TypeError) as exc:
+            api.peer_is_trusted(api.peer_address(("192.0.2.1", 1)), "192.0.2.1")
+        assert "SEQUENCE" in str(exc.value)
+
+
+class TestTrustedProxyOverHTTP:
+    """The gate as the wire sees it. Invariant guards: `build_server(trusted_
+    proxies=…)` does not exist at base, so their red there is an AttributeError.
+    """
+
+    def test_an_untrusted_peer_gets_the_SAME_uniform_401_as_a_bad_token(
+        self, store: Path
+    ):
+        """🔴 The wire must not discriminate. A distinct code, body or header set
+        would tell an attacker "your address is the problem, not your token" —
+        the enumeration surface §2b forbids, and a free oracle for finding the
+        one hop that IS trusted.
+        """
+        with running(store, trusted_proxies=(NOT_LOOPBACK_PROXY,)) as (base, _audit):
+            untrusted = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+        with running(store) as (base, _audit):
+            bad_token = fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48)
+        assert untrusted[0] == bad_token[0] == 401
+        assert untrusted[2] == bad_token[2] == b"unauthorized\n"
+        assert _comparable(untrusted[1]) == _comparable(bad_token[1])
+
+    def test_the_LOG_discriminates_even_though_the_wire_does_not(self, store: Path):
+        """The operator has to be able to tell "somebody is addressing the pod
+        directly" from "somebody is guessing tokens" — in a place the attacker
+        cannot read. Any `untrusted-peer` line at all is the alertable event.
+        """
+        with running(store, trusted_proxies=(NOT_LOOPBACK_PROXY,)) as (base, audit):
+            fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+        assert len(audit) == 1
+        assert "status=untrusted-peer" in audit[0]
+        assert "auth=fail" in audit[0]
+        assert "result=401" in audit[0]
+
+    def test_a_WRITE_verb_from_an_untrusted_peer_is_gated_too(self, store: Path):
+        """🔴 ONE RULE, BOTH DOORS. `_reject_write` and `_handle` share
+        `_identify_and_meter` precisely because a check enforced at one call
+        site and not the other is the failure this file keeps finding — writes
+        used to skip the client-IP and lockout checks entirely.
+        """
+        with running(store, trusted_proxies=(NOT_LOOPBACK_PROXY,)) as (base, audit):
+            code, _h, body = fetch(
+                f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, method="POST"
+            )
+        assert code == 401, (code, body)
+        assert body == b"unauthorized\n"
+        assert "status=untrusted-peer" in audit[0]
+
+    def test_an_UNKNOWN_VERB_from_an_untrusted_peer_is_gated_too(self, store: Path):
+        """The third door: `send_error`, which every unhandled method reaches."""
+        with running(store, trusted_proxies=(NOT_LOOPBACK_PROXY,)) as (base, audit):
+            code, _h, body = fetch(
+                f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, method="FROBNICATE"
+            )
+        assert code == 401, (code, body)
+        assert body == b"unauthorized\n"
+        assert "status=untrusted-peer" in audit[0]
+
+    def test_the_gate_runs_BEFORE_the_header_is_read_not_after(self, store: Path):
+        """🔴 REACHABILITY, and it is the one ordering that can be wrong while
+        every test above stays green. A request from an untrusted peer sending
+        NO `CF-Connecting-IP` at all must be `untrusted-peer`, not
+        `no-client-ip`: if the header parse ran first the value would already
+        have been used to pick a bucket, which is the defect with an extra step.
+        """
+        with running(store, trusted_proxies=(NOT_LOOPBACK_PROXY,)) as (base, audit):
+            fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, client_ip=None)
+        assert "status=untrusted-peer" in audit[0], audit
+        assert "status=no-client-ip" not in audit[0], audit
+
+    def test_an_untrusted_peer_is_NOT_CHARGED_to_any_lockout_bucket(self, store: Path):
+        """It must not fall back to keying on the peer — that is "one abuser
+        locks out the world", arrived at by way of a security check. Six
+        refusals from the same untrusted peer, then the peer becomes trusted:
+        its very next valid request must be a 200, not a lockout.
+        """
+        limiter = api.RateLimiter(max_failures=5, window_s=600.0, lockout_s=600.0)
+        with running(
+            store, limiter=limiter, trusted_proxies=(NOT_LOOPBACK_PROXY,)
+        ) as (base, _audit):
+            for _ in range(6):
+                fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+        # SAME limiter object, now behind a server that trusts loopback.
+        with running(store, limiter=limiter) as (base, _audit):
+            code, _h, body = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+        assert code == 200, (code, body)
+        assert limiter._locked_until == {}, limiter._locked_until
+        assert limiter._failures == {}, limiter._failures
+
+    def test_healthz_answers_an_untrusted_peer(self, store: Path):
+        with running(store, trusted_proxies=(NOT_LOOPBACK_PROXY,)) as (base, audit):
+            code, _h, body = fetch(f"{base}/healthz", client_ip=None)
+        assert (code, body) == (200, b"ok\n")
+        assert audit == [], "the probe path must not audit, or Loki fills with noise"
+
+    def test_a_CIDR_entry_admits_a_peer_INSIDE_it(self, store: Path):
+        """POSITIVE CONTROL for the CIDR arm. Every other test in this class
+        uses a /32-equivalent, so `return False` for any prefixed network would
+        pass all of them.
+        """
+        with running(store, trusted_proxies=("127.0.0.0/8",)) as (base, _audit):
+            code, _h, body = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+        assert code == 200, (code, body)
+
+    def test_build_server_REFUSES_an_empty_allowlist(self, store: Path):
+        with pytest.raises(ValueError) as exc:
+            api.build_server(
+                host="127.0.0.1",
+                port=0,
+                store_root=str(store),
+                tokens=(GOOD_TOKEN,),
+                trusted_proxies=(),
+            )
+        assert "empty" in str(exc.value)
+
+    def test_build_server_REFUSES_a_bare_string_allowlist(self, store: Path):
+        with pytest.raises(TypeError) as exc:
+            api.build_server(
+                host="127.0.0.1",
+                port=0,
+                store_root=str(store),
+                tokens=(GOOD_TOKEN,),
+                trusted_proxies=LOOPBACK_PROXY,
+            )
+        assert "SEQUENCE" in str(exc.value)
+
+    def test_build_server_REFUSES_a_default_route_through_the_PROGRAMMATIC_door(
+        self, store: Path
+    ):
+        """🔴 The `/0` refusal lives in `trusted_network`, which BOTH doors go
+        through. A guard placed only in the env parser would be walked by any
+        caller constructing the server directly — and this file's own harness is
+        such a caller.
+        """
+        with pytest.raises(ValueError) as exc:
+            api.build_server(
+                host="127.0.0.1",
+                port=0,
+                store_root=str(store),
+                tokens=(GOOD_TOKEN,),
+                trusted_proxies=("0.0.0.0/0",),
+            )
+        assert "trusts every peer" in str(exc.value)
+
+    def test_the_HANDLER_CLASS_DEFAULT_trusts_nobody(self):
+        """`build_server` refuses an empty allowlist, so the class attribute is
+        not reachable through it — which is exactly why it is pinned here. A
+        subclass that never went through `build_server` must fail CLOSED, and
+        `()` read as "unset, allow all" is the shape that mistake takes.
+        """
+        assert api.StoreRequestHandler.trusted_proxies == ()
+        assert (
+            api.peer_is_trusted(
+                api.peer_address(("127.0.0.1", 1)),
+                api.StoreRequestHandler.trusted_proxies,
+            )
+            is False
+        )

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -3608,18 +3608,40 @@ class TestTrustedProxyAllowlistParsing:
     that never executes.
     """
 
+    # 🔴 THREE GUARDS REACH "no trusted proxies", SO THAT PHRASE CANNOT TELL
+    # THEM APART — and asserting it was how two mutants survived. Each test
+    # below pins the SENTENCE ITS OWN GUARD emits. Measured: with guard 1
+    # weakened to `if raw is None`, a blank value falls through to the
+    # empty-result guard and raises a message that still contains
+    # "no trusted proxies", so the sweep scored it SURVIVED.
+    UNSET_SENTENCE = "set $SUBSYSTEM_STORE_TRUSTED_PROXIES to the address(es)"
+    NO_ENTRIES_SENTENCE = "resolved to no entries"
+
     def test_an_UNSET_variable_raises_rather_than_defaulting(self):
         with pytest.raises(ValueError) as exc:
             api.load_trusted_proxies({})
-        assert "no trusted proxies" in str(exc.value)
+        assert self.UNSET_SENTENCE in str(exc.value)
 
-    def test_a_BLANK_variable_raises_too(self):
-        """Reachable past guard 1 only if guard 1 tests emptiness rather than
-        presence: the variable IS set, to whitespace.
+    def test_a_BLANK_variable_raises_from_THE_SAME_guard_not_a_later_one(self):
+        """Reachable past a presence-only guard 1: the variable IS set, to
+        whitespace. And it must be guard 1 that catches it — a fall-through to
+        the empty-result guard is a different message and a different bug.
         """
         with pytest.raises(ValueError) as exc:
             api.load_trusted_proxies({"SUBSYSTEM_STORE_TRUSTED_PROXIES": "  \t "})
-        assert "no trusted proxies" in str(exc.value)
+        assert self.UNSET_SENTENCE in str(exc.value)
+        assert self.NO_ENTRIES_SENTENCE not in str(exc.value)
+
+    def test_a_NON_BLANK_value_that_yields_NO_ENTRIES_raises_too(self):
+        """🔴 REACHABILITY for the empty-result guard, which nothing else here
+        reaches: `","` is not blank, so guard 1 passes it, and the split then
+        yields nothing but empty strings. Without this the guard is deletable
+        and the sweep says so — measured, it survived.
+        """
+        with pytest.raises(ValueError) as exc:
+            api.load_trusted_proxies({"SUBSYSTEM_STORE_TRUSTED_PROXIES": ",,"})
+        assert self.NO_ENTRIES_SENTENCE in str(exc.value)
+        assert self.UNSET_SENTENCE not in str(exc.value)
 
     def test_a_NON_ADDRESS_entry_names_the_offending_item(self):
         with pytest.raises(ValueError) as exc:
@@ -3627,10 +3649,18 @@ class TestTrustedProxyAllowlistParsing:
                 {"SUBSYSTEM_STORE_TRUSTED_PROXIES": "192.0.2.1, gateway"}
             )
         message = str(exc.value)
-        assert "not an IP address or CIDR" in message
-        # 🔴 The POSITION is not enough — an operator with a five-entry list
-        # needs the value. And the VALID sibling must not be blamed.
-        assert "'gateway'" in message
+        # 🔴 THE WHOLE COMPUTED PREFIX, PINNED AS ONE STRING — and that is a
+        # correction, not style. The first version asserted `"'gateway'" in
+        # message`, which SURVIVED a mutant that replaced the `{item!r}` slot
+        # with the literal word "an entry": `ip_network`'s own ValueError
+        # already contains `'gateway'`, so the assertion was reading the
+        # exception's static prose and never the computed slot at all. A guard
+        # on WORDS is walkable by a value that spells the same words somewhere
+        # else in the sentence.
+        assert message.startswith(
+            "SUBSYSTEM_STORE_TRUSTED_PROXIES: 'gateway' is not an IP address or CIDR ("
+        ), message
+        # And the VALID sibling must not be blamed.
         assert "192.0.2.1'" not in message
 
     def test_a_DEFAULT_ROUTE_is_refused_in_BOTH_families(self):
@@ -3730,8 +3760,15 @@ class TestPeerAddressNormalisation:
         assert api.peer_is_trusted(None, trusted) is False
 
     def test_a_v6_peer_against_a_v4_allowlist_is_False_not_a_TypeError(self):
-        """`IPv4Address in IPv6Network` raises. An allowlist holding one family
-        and a peer from the other is an ordinary deployment, not an error.
+        """An allowlist holding one family and a peer from the other is an
+        ordinary deployment, not an error.
+
+        ⚠ THE NAME RECORDS A CLAIM THAT WAS WRONG. `peer_is_trusted` used to
+        carry an explicit version gate, commented "`IPv4Address in IPv6Network`
+        raises TypeError". It does not — `ipaddress` compares versions itself
+        and returns False (measured on 3.12.13 and 3.14.7). The gate was dead
+        code; a mutation sweep found it by surviving its removal. The BEHAVIOUR
+        is still worth pinning, so the test stays and the guard is gone.
         """
         trusted = api.load_trusted_proxies(
             {"SUBSYSTEM_STORE_TRUSTED_PROXIES": "192.0.2.0/24"}

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -3460,13 +3460,19 @@ class TestTrustedProxyOverTheRealProcess:
             f"it out, so the test above proves nothing"
         )
 
-    def test_THE_DEFECT_the_five_forged_attempts_NEVER_REACH_the_limiter(
+    def test_THE_DEFECT_the_five_forged_attempts_are_CHARGED_TO_THE_FORGER(
         self, store: Path, token_file: Path
     ):
-        """The status-code half cannot see WHY. At base the five forged attempts
-        are `status=unauthorized` and the fifth is `status=lockout-triggered`; at
-        HEAD every one is `status=untrusted-peer` and no lockout exists. Read off
-        the process's real STDOUT, which is the stream Loki ingests.
+        """The status-code half cannot see WHO was charged. At base the five
+        forged attempts are booked against `ip=198.51.100.7` — the victim — and
+        the fifth is `status=lockout-triggered`. At HEAD every one is booked
+        against the forger's own address with `peer=untrusted`. Read off the
+        process's real STDOUT, which is the stream Loki ingests.
+
+        ⚠ THIS IS NOT "the attempts do not reach the limiter" ANY MORE. They do,
+        and they should: an untrusted caller failing auth five times is a real
+        failed auth and gets a real lockout — of ITSELF. The property is only
+        ever about WHOSE bucket.
         """
         with running_subprocess(
             store,
@@ -3486,30 +3492,101 @@ class TestTrustedProxyOverTheRealProcess:
             stdout, _err = proc.communicate(timeout=15)
         lines = [ln for ln in stdout.splitlines() if ln.startswith("store-api audit ")]
         assert len(lines) == 5, stdout
-        assert all("status=untrusted-peer" in ln for ln in lines), lines
-        # The status that WOULD be there if the header had been read and counted.
-        assert not any("status=lockout-triggered" in ln for ln in lines), lines
-        # 🔴 And the forged address never becomes an identity: `ip=` stays `-`.
-        # Without this, a fix that recorded the spoofed value but declined to
-        # count it would pass everything above.
+        # 🔴 THE ASSERTION THAT IS THE WHOLE DEFECT: the forged address never
+        # becomes an identity. A fix that recorded the spoofed value but declined
+        # to COUNT it would pass every status check and fail this one.
         assert all(f"ip={SPOOF_IP}" not in ln for ln in lines), lines
+        assert all(f"ip={UNTRUSTED_PEER}" in ln for ln in lines), lines
+        assert all("peer=untrusted" in ln for ln in lines), lines
+        # …and the forger locks out ITSELF, which is a rate limiter working.
+        assert "status=lockout-triggered" in lines[-1], lines[-1]
 
-    def test_a_VALID_token_from_an_untrusted_peer_is_still_refused(
+    def test_an_untrusted_peer_LOCKING_ITSELF_OUT_does_not_touch_the_victim(
         self, store: Path, token_file: Path
     ):
-        """Fail closed, not "downgrade to unauthenticated". At base this is a
-        200 carrying store content.
+        """The pair to the test above, and the one that stops "charge the peer"
+        from being a euphemism for "do not charge anything". The forger is
+        locked out — its own next request is refused — while the client it named
+        is served normally through the trusted proxy.
         """
         with running_subprocess(
-            store, token_file, trusted_proxies=NOT_LOOPBACK_PROXY
+            store,
+            token_file,
+            trusted_proxies=f"{TRUSTED_PEER}/32",
+            host=TRUSTED_PEER,
         ) as (base, _proc):
-            code, headers, body = fetch(
-                f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, client_ip=CLIENT_IP
+            for _ in range(5):
+                fetch_from(
+                    UNTRUSTED_PEER,
+                    base,
+                    f"/api/v1/recall/{SCOPE}",
+                    token="w" * 48,
+                    client_ip=SPOOF_IP,
+                )
+            forger = fetch_from(
+                UNTRUSTED_PEER,
+                base,
+                f"/api/v1/recall/{SCOPE}",
+                token=GOOD_TOKEN,
+                client_ip=SPOOF_IP,
             )
-        assert code == 401, (code, body)
-        assert body == b"unauthorized\n"
-        assert POINTER_LINE.encode() not in body
-        assert "X-Store-Status" not in headers
+            victim = fetch_from(
+                TRUSTED_PEER,
+                base,
+                f"/api/v1/recall/{SCOPE}",
+                token=GOOD_TOKEN,
+                client_ip=SPOOF_IP,
+            )
+        assert forger == 401, f"the forger was not locked out: {forger}"
+        assert victim == 200, f"the victim was collateral: {victim}"
+
+    def test_a_VALID_token_from_an_untrusted_peer_is_SERVED_but_bucketed_under_the_PEER(
+        self, store: Path, token_file: Path
+    ):
+        """🔴 THIS REPLACES A TEST THAT PINNED THE WRONG BEHAVIOUR. It used to
+        assert a 401, which was stricter than the security property needs and
+        broke the phase-1 acceptance procedure outright: `verify-byte-identity.sh`
+        runs through `kubectl port-forward`, which presents peer `127.0.0.1`
+        while the pod allowlists the node's Cilium internal address, so every
+        byte-identity run — THE phase-1 criterion — became a 401.
+
+        Serving it is safe because the header it sent is IGNORED: the request is
+        booked against the peer, so the caller can only ever spend its own
+        budget. Distrust is expressed by disbelieving the caller, not by hanging
+        up on them.
+
+        🔴 The replacement is NOT weaker than what it replaces. The property the
+        old test was reaching for — a forged header must never name a third
+        party — is pinned by
+        `test_THE_DEFECT_a_forged_header_from_an_untrusted_peer_locks_out_a_victim`
+        and by the `ip=` assertions above, both of which are still RED at base.
+        """
+        with running_subprocess(
+            store,
+            token_file,
+            trusted_proxies=f"{TRUSTED_PEER}/32",
+            host=TRUSTED_PEER,
+        ) as (base, proc):
+            code = fetch_from(
+                UNTRUSTED_PEER,
+                base,
+                f"/api/v1/recall/{SCOPE}",
+                token=GOOD_TOKEN,
+                client_ip=SPOOF_IP,
+            )
+            proc.terminate()
+            stdout, _err = proc.communicate(timeout=15)
+        assert code == 200, code
+        line = [ln for ln in stdout.splitlines() if ln.startswith("store-api audit ")][-1]
+        assert f"ip={UNTRUSTED_PEER}" in line, line
+        assert f"ip={SPOOF_IP}" not in line, line
+        assert "peer=untrusted" in line, line
+        # 🔴 AND IT IS NOT SPELLED AS AN AUTH FAILURE. The earlier shape emitted
+        # `status=untrusted-peer auth=fail`, which put every port-forward into
+        # the Loki auth-fail alert and trained the operator to ignore it.
+        assert "auth=ok" in line, line
+        assert "auth=fail" not in line, line
+        assert "status=untrusted-peer" not in line, line
 
     def test_healthz_is_answered_for_an_UNTRUSTED_peer_so_the_kubelet_probe_lives(
         self, store: Path, token_file: Path
@@ -3676,14 +3753,67 @@ class TestTrustedProxyAllowlistParsing:
                 )
             assert "trusts every peer" in str(exc.value), spelling
 
-    def test_a_NEARLY_default_route_is_ACCEPTED_so_the_guard_is_not_a_ban_on_CIDRs(self):
-        """The negative half. Without it, `raise` on every network with a prefix
-        would pass the test above — and the setting would be unusable for the
-        one deployment shape (a proxy subnet) it exists to serve.
+    def test_A_WIDE_PREFIX_IS_REFUSED_because_the_slash_zero_guard_reads_ONE_entry(self):
+        """🔴 THIS REPLACES A TEST THAT PINNED A WALK AS CORRECT. It used to
+        assert `0.0.0.0/1` was ACCEPTED — "the guard is not a ban on CIDRs" —
+        which is true and useless, because two of them (`0.0.0.0/1` plus
+        `128.0.0.0/1`) parse clean and trust every IPv4 peer. Refusing only `/0`
+        inspects one entry in isolation and cannot see the union.
+
+        The realistic misconfiguration is worse than the contrived one: a pod
+        CIDR is exactly the shape an operator reaches for, and it hands the
+        client identity to every pod in the cluster — verbatim the attacker in
+        this module's threat model.
         """
+        for spelling in (
+            "0.0.0.0/1,128.0.0.0/1",  # the union that covers everything
+            "10.244.0.0/16",  # a pod CIDR: every pod in the cluster
+            "2001:db8::/48",  # the v6 mirror, which a v4-only floor would miss
+        ):
+            with pytest.raises(ValueError) as exc:
+                api.load_trusted_proxies({"SUBSYSTEM_STORE_TRUSTED_PROXIES": spelling})
+            assert "too broad" in str(exc.value), spelling
+
+    def test_THE_FLOOR_ITSELF_IS_ACCEPTED_so_the_guard_is_not_a_ban_on_CIDRs(self):
+        """The negative half, at the BOUNDARY rather than somewhere comfortable.
+        Without it, `raise` on every network with a prefix would pass the test
+        above — and the setting would be unusable for the one deployment shape
+        (a proxy subnet) it exists to serve. Measured at both ends of both
+        families: the floor passes, one bit wider fails.
+        """
+        import ipaddress
+
         assert api.load_trusted_proxies(
-            {"SUBSYSTEM_STORE_TRUSTED_PROXIES": "0.0.0.0/1"}
-        ) == (__import__("ipaddress").ip_network("0.0.0.0/1"),)
+            {"SUBSYSTEM_STORE_TRUSTED_PROXIES": "198.51.100.0/24"}
+        ) == (ipaddress.ip_network("198.51.100.0/24"),)
+        assert api.load_trusted_proxies(
+            {"SUBSYSTEM_STORE_TRUSTED_PROXIES": "2001:db8::/64"}
+        ) == (ipaddress.ip_network("2001:db8::/64"),)
+        for one_bit_wider in ("198.51.100.0/23", "2001:db8::/63"):
+            with pytest.raises(ValueError) as exc:
+                api.load_trusted_proxies(
+                    {"SUBSYSTEM_STORE_TRUSTED_PROXIES": one_bit_wider}
+                )
+            assert "too broad" in str(exc.value), one_bit_wider
+
+    def test_the_TOO_BROAD_message_is_NOT_the_default_route_message(self):
+        """Two guards, two diagnostics, and they must not collapse into one: `/0`
+        is "you disabled it", a wide prefix is "you meant a smaller range". A
+        test asserting a phrase both emit could not tell them apart — which is
+        exactly how two mutants survived an earlier round of this file.
+        """
+        with pytest.raises(ValueError) as zero:
+            api.load_trusted_proxies({"SUBSYSTEM_STORE_TRUSTED_PROXIES": "0.0.0.0/0"})
+        with pytest.raises(ValueError) as wide:
+            api.load_trusted_proxies({"SUBSYSTEM_STORE_TRUSTED_PROXIES": "10.0.0.0/8"})
+        assert "trusts every peer" in str(zero.value)
+        assert "too broad" not in str(zero.value)
+        assert "too broad" in str(wide.value)
+        assert "trusts every peer" not in str(wide.value)
+        # And the wide one NAMES the entry and the floor, or the operator cannot
+        # act on it.
+        assert "'10.0.0.0/8'" in str(wide.value)
+        assert "/24" in str(wide.value)
 
     def test_COMMAS_AND_WHITESPACE_both_separate(self):
         import ipaddress
@@ -3790,39 +3920,63 @@ class TestTrustedProxyOverHTTP:
     proxies=…)` does not exist at base, so their red there is an AttributeError.
     """
 
-    def test_an_untrusted_peer_gets_the_SAME_uniform_401_as_a_bad_token(
+    def test_a_BAD_TOKEN_from_an_untrusted_peer_is_the_SAME_uniform_401(
         self, store: Path
     ):
-        """🔴 The wire must not discriminate. A distinct code, body or header set
-        would tell an attacker "your address is the problem, not your token" —
-        the enumeration surface §2b forbids, and a free oracle for finding the
-        one hop that IS trusted.
+        """🔴 The wire must not discriminate. Once a request DOES fail auth, the
+        401 an untrusted peer sees must be byte-identical to the one a trusted
+        peer sees — otherwise the response is an oracle for "which hop is
+        trusted", which is the enumeration surface §2b forbids.
         """
         with running(store, trusted_proxies=(NOT_LOOPBACK_PROXY,)) as (base, _audit):
-            untrusted = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+            untrusted = fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48)
         with running(store) as (base, _audit):
-            bad_token = fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48)
-        assert untrusted[0] == bad_token[0] == 401
-        assert untrusted[2] == bad_token[2] == b"unauthorized\n"
-        assert _comparable(untrusted[1]) == _comparable(bad_token[1])
+            trusted = fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48)
+        assert untrusted[0] == trusted[0] == 401
+        assert untrusted[2] == trusted[2] == b"unauthorized\n"
+        assert _comparable(untrusted[1]) == _comparable(trusted[1])
 
-    def test_the_LOG_discriminates_even_though_the_wire_does_not(self, store: Path):
-        """The operator has to be able to tell "somebody is addressing the pod
-        directly" from "somebody is guessing tokens" — in a place the attacker
-        cannot read. Any `untrusted-peer` line at all is the alertable event.
+    def test_the_LOG_ANNOTATES_the_peer_WITHOUT_calling_it_an_auth_failure(
+        self, store: Path
+    ):
+        """🔴 THIS REPLACES A TEST THAT PINNED THE WRONG SHAPE. It asserted
+        `status=untrusted-peer` together with `auth=fail` — which meant every
+        `kubectl port-forward` landed in the Loki auth-fail alert, and an alert
+        that fires on the documented acceptance procedure is one the operator
+        learns to ignore.
+
+        Direct-to-pod access must still be greppable, so it is its OWN field.
+        The request itself succeeds.
         """
         with running(store, trusted_proxies=(NOT_LOOPBACK_PROXY,)) as (base, audit):
-            fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+            code, _h, _b = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+        assert code == 200, code
         assert len(audit) == 1
-        assert "status=untrusted-peer" in audit[0]
-        assert "auth=fail" in audit[0]
-        assert "result=401" in audit[0]
+        assert "peer=untrusted" in audit[0], audit[0]
+        assert "auth=ok" in audit[0], audit[0]
+        assert "result=200" in audit[0], audit[0]
+        assert "status=untrusted-peer" not in audit[0], audit[0]
 
-    def test_a_WRITE_verb_from_an_untrusted_peer_is_gated_too(self, store: Path):
+    def test_a_TRUSTED_peer_is_annotated_too_so_the_field_is_not_write_only(
+        self, store: Path
+    ):
+        """The other half. A field that only ever takes one value cannot tell a
+        reader that the OTHER case did not occur — `peer=trusted` is what makes
+        the absence of `peer=untrusted` mean something.
+        """
+        with running(store) as (base, audit):
+            fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+        assert "peer=trusted" in audit[0], audit[0]
+        assert "peer=untrusted" not in audit[0], audit[0]
+
+    def test_a_WRITE_verb_from_an_untrusted_peer_is_METERED_under_the_peer(
+        self, store: Path
+    ):
         """🔴 ONE RULE, BOTH DOORS. `_reject_write` and `_handle` share
-        `_identify_and_meter` precisely because a check enforced at one call
-        site and not the other is the failure this file keeps finding — writes
-        used to skip the client-IP and lockout checks entirely.
+        `_identify_and_meter` precisely because a check enforced at one call site
+        and not the other is the failure this file keeps finding — writes used to
+        skip the client-IP and lockout checks entirely. A write from an untrusted
+        peer therefore gets the ordinary 405, annotated, exactly once.
         """
         limiter = api.RateLimiter(max_failures=5, window_s=600.0, lockout_s=600.0)
         with running(
@@ -3831,21 +3985,25 @@ class TestTrustedProxyOverHTTP:
             code, _h, body = fetch(
                 f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, method="POST"
             )
-        assert code == 401, (code, body)
-        assert body == b"unauthorized\n"
-        assert "status=untrusted-peer" in audit[0]
-        # 🔴 EXACTLY ONE, AND NOTHING CHARGED — and this is a round-2 correction,
-        # not belt and braces. A mutant that refuses and then returns True (so
-        # the handler carries on past the gate it just failed) leaves the GET
-        # path raising on `assert ip is not None` — invisible — while THIS path
-        # sails on to `authorize`, answers a SECOND response, and charges the
-        # limiter under a `None` key. The sweep scored that mutant SURVIVED once
-        # the count assertion was dropped from another test.
+        assert code == 405, (code, body)
+        assert body == b"read-only\n"
+        assert "peer=untrusted" in audit[0], audit[0]
+        assert f"ip={TRUSTED_PEER}" in audit[0], audit[0]
+        # 🔴 EXACTLY ONE LINE, AND NOTHING CHARGED for a request that AUTHENTICATED
+        # — a round-2 correction, not belt and braces. A mutant that mis-handles
+        # the identify step's return value answers a SECOND response here and
+        # charges the limiter under a `None` key; the GET path hides that on an
+        # internal assert.
         assert len(audit) == 1, audit
         assert limiter._failures == {} and limiter._locked_until == {}
 
-    def test_an_UNKNOWN_VERB_from_an_untrusted_peer_is_gated_too(self, store: Path):
-        """The third door: `send_error`, which every unhandled method reaches."""
+    def test_an_UNKNOWN_VERB_from_an_untrusted_peer_is_METERED_under_the_peer(
+        self, store: Path
+    ):
+        """The third door: `send_error`, which every unhandled method reaches.
+        An unknown verb never authenticates, so it IS a charged failure — under
+        the peer's own address, which is the whole point.
+        """
         limiter = api.RateLimiter(max_failures=5, window_s=600.0, lockout_s=600.0)
         with running(
             store, limiter=limiter, trusted_proxies=(NOT_LOOPBACK_PROXY,)
@@ -3855,40 +4013,50 @@ class TestTrustedProxyOverHTTP:
             )
         assert code == 401, (code, body)
         assert body == b"unauthorized\n"
-        assert "status=untrusted-peer" in audit[0]
+        assert "peer=untrusted" in audit[0], audit[0]
         assert len(audit) == 1, audit
-        assert limiter._failures == {} and limiter._locked_until == {}
+        assert list(limiter._failures) == [TRUSTED_PEER], limiter._failures
 
-    def test_the_gate_runs_BEFORE_the_header_is_read_not_after(self, store: Path):
-        """🔴 REACHABILITY, and it is the one ordering that can be wrong while
-        every test above stays green. A request from an untrusted peer sending
-        NO `CF-Connecting-IP` at all must be `untrusted-peer`, not
-        `no-client-ip`: if the header parse ran first the value would already
-        have been used to pick a bucket, which is the defect with an extra step.
+    def test_the_header_is_NOT_READ_AT_ALL_from_an_untrusted_peer(self, store: Path):
+        """🔴 THE ONE ORDERING THAT CAN BE WRONG WHILE EVERY TEST ABOVE STAYS
+        GREEN. Two requests from the same untrusted peer, one sending a forged
+        `CF-Connecting-IP` and one sending none at all, must be booked under the
+        SAME bucket — the peer's. If the header were consulted at all, the forged
+        request would land somewhere else and the forger would get a free second
+        budget by rotating the header.
         """
         with running(store, trusted_proxies=(NOT_LOOPBACK_PROXY,)) as (base, audit):
+            fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, client_ip=SPOOF_IP)
             fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, client_ip=None)
-        assert "status=untrusted-peer" in audit[0], audit
-        assert "status=no-client-ip" not in audit[0], audit
+        assert len(audit) == 2, audit
+        assert all(f"ip={TRUSTED_PEER}" in ln for ln in audit), audit
+        assert all(f"ip={SPOOF_IP}" not in ln for ln in audit), audit
+        # …and the absent header is NOT the `no-client-ip` refusal either: that
+        # rule applies only where the header IS the identity.
+        assert all("status=no-client-ip" not in ln for ln in audit), audit
 
-    def test_an_untrusted_peer_is_NOT_CHARGED_to_any_lockout_bucket(self, store: Path):
-        """It must not fall back to keying on the peer — that is "one abuser
-        locks out the world", arrived at by way of a security check. Six
-        refusals from the same untrusted peer, then the peer becomes trusted:
-        its very next valid request must be a 200, not a lockout.
+    def test_an_untrusted_peer_IS_charged_to_ITS_OWN_bucket(self, store: Path):
+        """🔴 THIS REPLACES A TEST THAT ASSERTED NOTHING WAS CHARGED. Under the
+        old refuse-outright design that was true; under this one it would mean an
+        untrusted peer had an unlimited budget, which is worse than the defect
+        being fixed. Five failed auths from one untrusted peer must lock out that
+        peer — and the bucket must be keyed on the PEER, never on the header.
         """
         limiter = api.RateLimiter(max_failures=5, window_s=600.0, lockout_s=600.0)
         with running(
             store, limiter=limiter, trusted_proxies=(NOT_LOOPBACK_PROXY,)
-        ) as (base, _audit):
-            for _ in range(6):
-                fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
-        # SAME limiter object, now behind a server that trusts loopback.
-        with running(store, limiter=limiter) as (base, _audit):
-            code, _h, body = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
-        assert code == 200, (code, body)
-        assert limiter._locked_until == {}, limiter._locked_until
-        assert limiter._failures == {}, limiter._failures
+        ) as (base, audit):
+            for _ in range(5):
+                fetch(
+                    f"{base}/api/v1/recall/{SCOPE}", token="w" * 48, client_ip=SPOOF_IP
+                )
+            after = fetch(
+                f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, client_ip=SPOOF_IP
+            )
+        assert after[0] == 401, "an untrusted peer had an unlimited budget"
+        assert list(limiter._locked_until) == [TRUSTED_PEER], limiter._locked_until
+        assert SPOOF_IP not in limiter._locked_until, limiter._locked_until
+        assert "status=lockout-triggered" in audit[4], audit[4]
 
     def test_healthz_answers_an_untrusted_peer(self, store: Path):
         with running(store, trusted_proxies=(NOT_LOOPBACK_PROXY,)) as (base, audit):
@@ -3901,9 +4069,13 @@ class TestTrustedProxyOverHTTP:
         uses a /32-equivalent, so `return False` for any prefixed network would
         pass all of them.
         """
-        with running(store, trusted_proxies=("127.0.0.0/8",)) as (base, _audit):
+        # `/24`, not the `/8` this used to say: a /8 is now refused by the
+        # prefix floor, and a test that quietly relied on it would have turned
+        # into a fact about the floor rather than about the CIDR arm.
+        with running(store, trusted_proxies=("127.0.0.0/24",)) as (base, audit):
             code, _h, body = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
         assert code == 200, (code, body)
+        assert "peer=trusted" in audit[0], audit[0]
 
     def test_build_server_REFUSES_an_empty_allowlist(self, store: Path):
         with pytest.raises(ValueError) as exc:
@@ -3959,3 +4131,75 @@ class TestTrustedProxyOverHTTP:
             )
             is False
         )
+        # …and "trusts nobody" now means "believes nobody's header", so the
+        # bucket falls back to the peer rather than to the forged value.
+        assert api.resolve_client(
+            {"CF-Connecting-IP": SPOOF_IP},
+            ("127.0.0.1", 1),
+            api.StoreRequestHandler.trusted_proxies,
+        ) == ("127.0.0.1", False)
+
+
+class TestResolveClientIsTheWholeRule:
+    """`resolve_client` is the one place the trusted/untrusted decision is made.
+    Extracted as a pure function precisely so the branches a real TCP socket
+    cannot produce are reachable here.
+    """
+
+    TRUSTED = ("198.51.100.9",)
+
+    def _trusted(self):
+        return api.load_trusted_proxies(
+            {"SUBSYSTEM_STORE_TRUSTED_PROXIES": self.TRUSTED[0]}
+        )
+
+    def test_a_TRUSTED_peer_is_bucketed_on_the_HEADER(self):
+        assert api.resolve_client(
+            {"CF-Connecting-IP": CLIENT_IP}, (self.TRUSTED[0], 9), self._trusted()
+        ) == (CLIENT_IP, True)
+
+    def test_an_UNTRUSTED_peer_is_bucketed_on_ITSELF_and_the_header_is_ignored(self):
+        """The two halves of one assertion: the answer IS the peer, and it is
+        NOT the header. Either alone is satisfied by a bug — returning `None`
+        satisfies "not the header", and echoing the header back satisfies
+        neither but would pass a test that only checked the flag.
+        """
+        key, trusted = api.resolve_client(
+            {"CF-Connecting-IP": SPOOF_IP}, (OTHER_IP, 9), self._trusted()
+        )
+        assert key == OTHER_IP
+        assert key != SPOOF_IP
+        assert trusted is False
+
+    def test_a_TRUSTED_peer_with_NO_header_still_FAILS_CLOSED(self):
+        """The fail-closed rule survives the redesign: where the header IS the
+        identity, its absence is still a refusal, not a fallback to the peer.
+        Otherwise a trusted proxy that stopped setting the header would silently
+        bucket the whole internet under one key.
+        """
+        assert api.resolve_client({}, (self.TRUSTED[0], 9), self._trusted()) == (
+            None,
+            True,
+        )
+
+    def test_a_PEER_THAT_IS_NOT_AN_ADDRESS_refuses_rather_than_crashing(self):
+        """🔴 REACHABLE ONLY HERE. A real TCP socket always yields an address, so
+        this branch cannot be driven over the wire — which is the argument for
+        extracting the function rather than leaving the logic inline where the
+        branch would be untestable and therefore unverified.
+        """
+        for bogus in (None, (), ("not-an-address", 9), (127, 9)):
+            assert api.resolve_client(
+                {"CF-Connecting-IP": SPOOF_IP}, bogus, self._trusted()
+            ) == (None, False), bogus
+
+    def test_an_UNTRUSTED_v6_peer_is_aggregated_to_its_slash_64(self):
+        """Both branches normalise through `rate_limit_key`, or the peer branch
+        would hand an IPv6 caller 2**64 free buckets — the exact hazard
+        `rate_limit_key` exists for, reintroduced through the new door.
+        """
+        key, trusted = api.resolve_client(
+            {}, ("2001:db8:1:2:ffff:ffff:ffff:ffff", 9, 0, 0), self._trusted()
+        )
+        assert key == "2001:db8:1:2::/64"
+        assert trusted is False

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -2916,6 +2916,18 @@ class TestMalformedRequestLinesDoNotCrash:
             _speak(base.split("//", 1)[1], b"GET\r\n\r\n")
         assert "path=-" in audit[0], audit[0]
         assert "status=malformed-request" in audit[0]
+        # 🔴 `peer=-`, THE THIRD VALUE OF THAT FIELD, AND THE ONLY ONE NOTHING
+        # ASSERTED. Six bytes is too little to have headers, so `send_error`
+        # answers before `_identify_and_meter` ever runs and `_peer_trusted` is
+        # still `None`. Found by a mutation sweep with NO `-k` selector:
+        # rendering that `None` as `trusted` survived a fully green suite —
+        # `peer=trusted|untrusted` were asserted eleven times and `peer=-` zero.
+        #
+        # The untested direction is the dangerous one. It makes the audit log
+        # assert TRUST about a request whose peer was never evaluated, which is
+        # the one claim this field exists to let an operator rely on.
+        assert "peer=-" in audit[0], audit[0]
+        assert "peer=trusted" not in audit[0], audit[0]
 
     def test_POSITIVE_CONTROL_a_WELL_FORMED_unknown_verb_still_works(
         self, store: Path
@@ -3390,7 +3402,16 @@ class TestTrustedProxyOverTheRealProcess:
         for that same `SPOOF_IP` client, with a VALID token.
 
           base: the five are charged to SPOOF_IP -> the victim is 401 for 15 min
-          HEAD: not one of them reaches the limiter -> the victim gets its 200
+          HEAD: the five are charged to 127.0.0.2, the forger's own address
+                -> the victim gets its 200
+
+        ⚠ "not one of them reaches the limiter" is what this line used to say,
+        and it described the refuse-outright design that was replaced. They DO
+        reach it now, and should: five failed auths from one caller is a real
+        lockout — of that caller. The property is only ever about WHOSE bucket,
+        which is what the sibling
+        `test_THE_DEFECT_the_five_forged_attempts_are_CHARGED_TO_THE_FORGER`
+        reads out of the audit line.
 
         🔴 THE FIRST DRAFT OF THIS TEST WAS VACUOUS AND PASSED AT BASE. It ran
         every request from ONE address and asserted the victim saw a 401 — which

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -3540,6 +3540,60 @@ class TestTrustedProxyOverTheRealProcess:
         assert forger == 401, f"the forger was not locked out: {forger}"
         assert victim == 200, f"the victim was collateral: {victim}"
 
+    def test_a_TRUSTED_peers_HEADER_actually_separates_two_clients(
+        self, store: Path, token_file: Path
+    ):
+        """🔴 THE ONE PROPERTY EVERY OTHER PROCESS-LEVEL TEST HERE IS BLIND TO,
+        and a mutation sweep is what showed it: replacing the allowlist `main`
+        passes to `build_server` with a hardcoded one that matches NOBODY
+        survived the whole class. Every test either drove an untrusted peer (a
+        mutant that trusts nobody agrees) or drove one client through a trusted
+        peer (bucketing it under the peer instead of its header is invisible
+        when there is only one client).
+
+        So: five failures through the trusted proxy on behalf of ONE client,
+        then a DIFFERENT client through the SAME proxy. It must be served — the
+        header, not the peer, is what separated them. If the proxy's allowlist
+        were not in force, both would share the peer's bucket and the second
+        client would be collateral.
+        """
+        with running_subprocess(
+            store,
+            token_file,
+            trusted_proxies=f"{TRUSTED_PEER}/32",
+            host=TRUSTED_PEER,
+        ) as (base, _proc):
+            for _ in range(5):
+                fetch_from(
+                    TRUSTED_PEER,
+                    base,
+                    f"/api/v1/recall/{SCOPE}",
+                    token="w" * 48,
+                    client_ip=SPOOF_IP,
+                )
+            same_client = fetch_from(
+                TRUSTED_PEER,
+                base,
+                f"/api/v1/recall/{SCOPE}",
+                token=GOOD_TOKEN,
+                client_ip=SPOOF_IP,
+            )
+            other_client = fetch_from(
+                TRUSTED_PEER,
+                base,
+                f"/api/v1/recall/{SCOPE}",
+                token=GOOD_TOKEN,
+                client_ip=OTHER_IP,
+            )
+        # Both halves, or the assertion is satisfied by a server with no limiter
+        # (everything 200) or one that locked the whole proxy out (everything
+        # 401).
+        assert same_client == 401, f"the guilty client was not locked out: {same_client}"
+        assert other_client == 200, (
+            f"an innocent client behind the same proxy got {other_client} — the "
+            f"bucket was the PEER, not the header"
+        )
+
     def test_a_VALID_token_from_an_untrusted_peer_is_SERVED_but_bucketed_under_the_PEER(
         self, store: Path, token_file: Path
     ):
@@ -3756,17 +3810,27 @@ class TestTrustedProxyAllowlistParsing:
     def test_A_WIDE_PREFIX_IS_REFUSED_because_the_slash_zero_guard_reads_ONE_entry(self):
         """🔴 THIS REPLACES A TEST THAT PINNED A WALK AS CORRECT. It used to
         assert `0.0.0.0/1` was ACCEPTED — "the guard is not a ban on CIDRs" —
-        which is true and useless, because two of them (`0.0.0.0/1` plus
-        `128.0.0.0/1`) parse clean and trust every IPv4 peer. Refusing only `/0`
-        inspects one entry in isolation and cannot see the union.
+        which is true and useless, because the two halves of the address space,
+        each written as a `/1`, parse clean and together trust every IPv4 peer.
+        Refusing only `/0` inspects one entry in isolation and cannot see the
+        union.
 
         The realistic misconfiguration is worse than the contrived one: a pod
         CIDR is exactly the shape an operator reaches for, and it hands the
         client identity to every pod in the cluster — verbatim the attacker in
         this module's threat model.
+
+        ⚠ THE UPPER HALF IS BUILT ARITHMETICALLY, NOT WRITTEN. It is routable
+        space, and `test_no_public_ips.py` refuses an IP literal in a PUBLIC
+        repo — it caught the first draft of this test and of the comment in
+        `server.py`. Widening that allowlist would have been the failure mode,
+        not the fix.
         """
+        import ipaddress
+
+        upper_half = f"{ipaddress.ip_address(1 << 31)}/1"
         for spelling in (
-            "0.0.0.0/1,128.0.0.0/1",  # the union that covers everything
+            f"0.0.0.0/1,{upper_half}",  # the union that covers everything
             "10.244.0.0/16",  # a pod CIDR: every pod in the cluster
             "2001:db8::/48",  # the v6 mirror, which a v4-only floor would miss
         ):

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -2100,6 +2100,49 @@ def _free_port() -> int:
         return sock.getsockname()[1]
 
 
+#: 🔴 TWO LOOPBACK ADDRESSES, WHICH IS WHAT MAKES THE REGRESSION MEASURABLE.
+#: `127.0.0.0/8` is entirely local on Linux, so a client can BIND `127.0.0.2` as
+#: its source and reach a server listening on `127.0.0.1` — and the server sees
+#: a genuinely different peer. Without that, every request in a hermetic test
+#: comes from the same address, "trusted peer" and "untrusted peer" cannot both
+#: appear against ONE running process, and the victim's 401 is identical on both
+#: trees. That identical 401 is exactly what a first draft of this file asserted,
+#: and it passed at the base ref: a vacuous guard on the one defect that matters.
+TRUSTED_PEER = "127.0.0.1"
+UNTRUSTED_PEER = "127.0.0.2"
+
+
+def fetch_from(
+    source_ip: str,
+    base: str,
+    path: str,
+    *,
+    token: str | None = None,
+    client_ip: str | None = CLIENT_IP,
+) -> int:
+    """GET `path` with the TCP source address bound to `source_ip`. Returns the
+    status code.
+
+    `urllib` cannot express a source address; `http.client.HTTPConnection` can.
+    """
+    host, _, port = base.removeprefix("http://").partition(":")
+    conn = http.client.HTTPConnection(
+        host, int(port), timeout=15, source_address=(source_ip, 0)
+    )
+    try:
+        headers = {}
+        if token is not None:
+            headers["Authorization"] = f"Bearer {token}"
+        if client_ip is not None:
+            headers["CF-Connecting-IP"] = client_ip
+        conn.request("GET", path, headers=headers)
+        resp = conn.getresponse()
+        resp.read()
+        return resp.status
+    finally:
+        conn.close()
+
+
 def _child_env(trusted_proxies: str | None) -> dict[str, str]:
     """The spawned server's environment. `None` REMOVES the variable.
 
@@ -2117,7 +2160,11 @@ def _child_env(trusted_proxies: str | None) -> dict[str, str]:
 
 @contextmanager
 def running_subprocess(
-    store_root: Path, token_file: Path, *, trusted_proxies: str | None = LOOPBACK_PROXY
+    store_root: Path,
+    token_file: Path,
+    *,
+    trusted_proxies: str | None = LOOPBACK_PROXY,
+    host: str = "127.0.0.1",
 ):
     """Spawn the REAL `server.py` process and wait for it to answer /healthz.
 
@@ -2137,7 +2184,7 @@ def running_subprocess(
             "--store",
             str(store_root),
             "--host",
-            "127.0.0.1",
+            host,
             "--port",
             str(port),
             "--token-file",
@@ -2148,7 +2195,7 @@ def running_subprocess(
         text=True,
         env=_child_env(trusted_proxies),
     )
-    base = f"http://127.0.0.1:{port}"
+    base = f"http://{host}:{port}"
     try:
         deadline = time.time() + 20
         while time.time() < deadline:
@@ -3336,51 +3383,111 @@ class TestTrustedProxyOverTheRealProcess:
         """🔴 THE WHOLE POINT OF THIS BRANCH, and the one test whose red at base
         is the bug rather than the diff.
 
-        The attacker is the loopback client; the allowlist names TEST-NET-1,
-        which loopback is not in. It sends five bad tokens while claiming to be
-        `SPOOF_IP`. At base those five are charged to SPOOF_IP and the victim's
-        NEXT request — a valid token, its own address — is a 401 for fifteen
-        minutes. At HEAD not one of the five reaches the limiter, because the
-        header is never read from a peer that is not a named proxy.
+        ONE running process, TWO peers. `127.0.0.1` is the allowlisted proxy;
+        `127.0.0.2` is anything that can address the pod directly. The attacker
+        binds `127.0.0.2` and sends five bad tokens while CLAIMING, in the
+        header, to be `SPOOF_IP`. Then the legitimate proxy forwards a request
+        for that same `SPOOF_IP` client, with a VALID token.
+
+          base: the five are charged to SPOOF_IP -> the victim is 401 for 15 min
+          HEAD: not one of them reaches the limiter -> the victim gets its 200
+
+        🔴 THE FIRST DRAFT OF THIS TEST WAS VACUOUS AND PASSED AT BASE. It ran
+        every request from ONE address and asserted the victim saw a 401 — which
+        is true on both trees, because the wire deliberately does not
+        discriminate. A test of a lockout has to observe the VICTIM getting
+        through, and that needs a second peer.
         """
         with running_subprocess(
-            store, token_file, trusted_proxies=NOT_LOOPBACK_PROXY
+            store,
+            token_file,
+            trusted_proxies=f"{TRUSTED_PEER}/32",
+            host=TRUSTED_PEER,
         ) as (base, _proc):
             for _ in range(5):
-                attempt = fetch(
-                    f"{base}/api/v1/recall/{SCOPE}",
+                attempt = fetch_from(
+                    UNTRUSTED_PEER,
+                    base,
+                    f"/api/v1/recall/{SCOPE}",
                     token="w" * 48,
                     client_ip=SPOOF_IP,
                 )
-                assert attempt[0] == 401, attempt
-            victim = fetch(
-                f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, client_ip=SPOOF_IP
+                assert attempt == 401, attempt
+            victim = fetch_from(
+                TRUSTED_PEER,
+                base,
+                f"/api/v1/recall/{SCOPE}",
+                token=GOOD_TOKEN,
+                client_ip=SPOOF_IP,
             )
-        # 🔴 401 either way — the wire never discriminates. What differs between
-        # the trees is WHY, so the claim has to be made against the state the
-        # attacker created, which is what the next test reads out of the log.
-        assert victim[0] == 401, victim
+        assert victim == 200, (
+            f"the victim got {victim}: five requests from an UNTRUSTED peer, "
+            f"forging CF-Connecting-IP, locked out a third party"
+        )
+
+    def test_POSITIVE_CONTROL_the_same_five_from_a_TRUSTED_peer_DO_lock_out(
+        self, store: Path, token_file: Path
+    ):
+        """🔴 THE OTHER HALF, and without it the test above is satisfied by a
+        server with no lockout at all — including one where the limiter was
+        deleted outright. Identical shape, identical count, ONE difference: the
+        five bad tokens come from the ALLOWLISTED peer, so they are a real
+        client failing auth and the lockout must fire.
+        """
+        with running_subprocess(
+            store,
+            token_file,
+            trusted_proxies=f"{TRUSTED_PEER}/32",
+            host=TRUSTED_PEER,
+        ) as (base, _proc):
+            for _ in range(5):
+                fetch_from(
+                    TRUSTED_PEER,
+                    base,
+                    f"/api/v1/recall/{SCOPE}",
+                    token="w" * 48,
+                    client_ip=SPOOF_IP,
+                )
+            victim = fetch_from(
+                TRUSTED_PEER,
+                base,
+                f"/api/v1/recall/{SCOPE}",
+                token=GOOD_TOKEN,
+                client_ip=SPOOF_IP,
+            )
+        assert victim == 401, (
+            f"got {victim}: five FAILED AUTHS from a real client did not lock "
+            f"it out, so the test above proves nothing"
+        )
 
     def test_THE_DEFECT_the_five_forged_attempts_NEVER_REACH_the_limiter(
         self, store: Path, token_file: Path
     ):
-        """The half above cannot see: at base every one of the five is
-        `status=unauthorized` and the fifth is `status=lockout-triggered`; at
-        HEAD every one is `status=untrusted-peer` and no lockout exists. Read
-        off the process's real STDOUT, which is the stream Loki ingests.
+        """The status-code half cannot see WHY. At base the five forged attempts
+        are `status=unauthorized` and the fifth is `status=lockout-triggered`; at
+        HEAD every one is `status=untrusted-peer` and no lockout exists. Read off
+        the process's real STDOUT, which is the stream Loki ingests.
         """
         with running_subprocess(
-            store, token_file, trusted_proxies=NOT_LOOPBACK_PROXY
+            store,
+            token_file,
+            trusted_proxies=f"{TRUSTED_PEER}/32",
+            host=TRUSTED_PEER,
         ) as (base, proc):
             for _ in range(5):
-                fetch(f"{base}/api/v1/recall/{SCOPE}", token="w" * 48, client_ip=SPOOF_IP)
-            fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, client_ip=SPOOF_IP)
+                fetch_from(
+                    UNTRUSTED_PEER,
+                    base,
+                    f"/api/v1/recall/{SCOPE}",
+                    token="w" * 48,
+                    client_ip=SPOOF_IP,
+                )
             proc.terminate()
             stdout, _err = proc.communicate(timeout=15)
         lines = [ln for ln in stdout.splitlines() if ln.startswith("store-api audit ")]
-        assert len(lines) == 6, stdout
+        assert len(lines) == 5, stdout
         assert all("status=untrusted-peer" in ln for ln in lines), lines
-        # The two statuses that WOULD be there if the header had been read.
+        # The status that WOULD be there if the header had been read and counted.
         assert not any("status=lockout-triggered" in ln for ln in lines), lines
         # 🔴 And the forged address never becomes an identity: `ip=` stays `-`.
         # Without this, a fix that recorded the spoofed value but declined to


### PR DESCRIPTION
## The defect

`CF-Connecting-IP` is **caller-supplied bytes**. Everything `server.py` claimed
about it — "Cloudflare sets it on every proxied request and overwrites whatever
the caller sent, which is what makes it trustworthy" — is true of a request that
*arrived from Cloudflare*, and says nothing about one that did not. Anything able
to address the pod on 8102 could name a **third party** in the header and lock
that third party out.

Run against `origin/main`'s `server.py` (#518), mounted into a throwaway pod in a
**scratch namespace** on the homelab cluster — same image, same node, same nebula
gateway in front:

```
-- attacker pod forges victim 198.51.100.7, 5 bad tokens --
   req1 http=401 … req5 http=401
-- THE VICTIM, through the legitimate gateway, VALID token --
  HTTP/1.1 401 Unauthorized
-- CONTROL: a DIFFERENT client through the same gateway --
  HTTP/1.1 200 OK

store-api audit … ip=198.51.100.7 … auth=fail result=401 status=unauthorized      (x4)
store-api audit … ip=198.51.100.7 … auth=fail result=401 status=lockout-triggered
store-api audit … ip=198.51.100.7 … auth=fail result=401 status=locked-out          <- the victim
store-api audit … ip=203.0.113.9  … auth=ok   result=200 status=scope-absent        <- the control
```

The control line is what makes it a *targeted* lockout rather than an outage.

## The fix

`SUBSYSTEM_STORE_TRUSTED_PROXIES` — an allowlist of peer addresses/CIDRs — plus
the standard reverse-proxy rule, in one pure function (`resolve_client`):

```
client = CF-Connecting-IP   if the TCP peer is in the allowlist
       = the TCP peer       otherwise, and the header is not read at all
```

The property that matters is **a forged header must never name a third party**.
Bucketing the forger under its own address satisfies that completely: such a
caller can only ever lock out itself.

* **Required. No default. `EXIT_CONFIG` (78) at startup without one.** A default
  would be a guess about somebody's network, and the only guess that keeps every
  deployment working is the permissive one — which is the defect, shipped as a
  constant.
* The audit line gains `peer=trusted|untrusted` as its **own field** — so
  direct-to-pod access stays greppable without being spelled as an auth failure.
* `/healthz` is answered before any of this, so the kubelet probe is untouched.
* All three doors (`_handle`, `_reject_write`, `send_error`) go through the same
  `_identify_and_meter`, each with its own test.

### 🔴 An earlier revision REFUSED the untrusted peer, and that was wrong

Reviewer-driven change, and the reasoning is worth keeping because the first
version looked strictly safer:

* it **broke the phase-1 acceptance procedure.** `verify-byte-identity.sh` runs
  through `kubectl port-forward`. Measured out of the store pod's own
  `/proc/net/tcp` while a forwarded connection was ESTABLISHED:
  `0100007F:1FA6 0100007F:94EE` — **both ends `127.0.0.1`**, because the kubelet
  enters the pod's network namespace and connects over loopback. The pod
  allowlists the node's Cilium address, so every byte-identity run — *the*
  phase-1 criterion — would have become a `401`.
* it turned one wrong address in one env var into a **total outage** that
  `/healthz` hid, so the pod stayed Ready and the alert pointed at credentials.

⚠ I first read this the other way. A Hubble trace appeared to show the
port-forward arriving as `10.244.0.123`, which would have refuted the finding —
that SYN was the **readiness probe**, which fires every 10s from the same
address. Port-forward traffic never crosses the endpoint boundary at all, so
Hubble cannot see it. The isolating control (hold one connection open, read the
pod's own socket table) is what settled it.

### The `/0` guard only ever inspected ONE entry

Also reviewer-found. The two halves of the address space, each written as a
`/1`, parsed clean and together trusted every IPv4 peer — and the realistic mistake is worse: the pod CIDR `10.244.0.0/16` was
accepted and would have trusted **every pod in the cluster**, verbatim the
attacker in this module's own threat model. Now a per-family prefix floor
(`/24`, `/64`), which subsumes the union check the audit suggested and can still
name the offending entry. `0.0.0.0/0` keeps its own distinct diagnostic.

⚠ **What none of this can do.** The pod sees whatever last hop connected to it —
the in-cluster gateway, never Cloudflare's own address. So it proves "the request
came through the gateway", **not** "…through Cloudflare".

## Merge ordering — this one matters

| order | result |
|---|---|
| **manifest first** (homelab-infra #330), then an image built from this branch | ✅ safe — the env var is inert on the deployed `0.1.0` image, which is phase-1 code and does not read it |
| **both together** | ✅ safe |
| **image first**, without the env var | 🔴 **full outage.** `load_trusted_proxies` raises → `EXIT_CONFIG` → CrashLoopBackOff, and with `strategy: Recreate` + `replicas: 1` the old pod is already gone |

No image has been built or pushed by this PR; that is a separate deliberate step.

🔴 **When it is built it MUST be a NEW tag (`0.2.0`).** The live deployment pins
`0.1.0` and homelab-infra#330 deliberately does not change it — so re-pushing
`0.1.0` with this branch's code is exactly the clobber that manifest's
immutable-tag rule forbids, and it is the easy mistake precisely *because* the
tag there did not move. Until that image ships, every phase-1.5b behaviour is
staged, not live: `0.1.0` emits no `peer=` field at all, so a `grep peer=untrusted`
returning zero is a fact about the image, not about the traffic.

## Red at base / green at HEAD

`server.py` exists on `main`, parses the same command line, and ignores the new
env var — so the process-level tests run on both trees and their red is
behavioural, not an `AttributeError`.

| test | base | HEAD |
|---|---|---|
| `test_THE_DEFECT_a_forged_header_from_an_untrusted_peer_locks_out_a_victim` | **FAIL** | pass |
| `test_THE_DEFECT_the_five_forged_attempts_are_CHARGED_TO_THE_FORGER` | **FAIL** | pass |
| `test_an_untrusted_peer_LOCKING_ITSELF_OUT_does_not_touch_the_victim` | **FAIL** | pass |
| `test_a_VALID_token_from_an_untrusted_peer_is_SERVED_but_bucketed_under_the_PEER` | **FAIL** | pass |
| `test_the_process_REFUSES_TO_START_with_the_variable_unset` | **FAIL** | pass |
| `test_the_process_REFUSES_TO_START_on_a_DEFAULT_ROUTE` | **FAIL** | pass |
| `test_the_startup_line_NAMES_the_trusted_proxies` | **FAIL** | pass |
| `test_POSITIVE_CONTROL_a_TRUSTED_peer_still_gets_its_digest` | pass | pass |
| `test_POSITIVE_CONTROL_the_same_five_from_a_TRUSTED_peer_DO_lock_out` | pass | pass |
| `test_a_TRUSTED_peers_HEADER_actually_separates_two_clients` | pass | pass |
| `test_healthz_is_answered_for_an_UNTRUSTED_peer_…` | pass | pass |

**7 genuine regressions, 4 deliberate green-at-both.** Base messages, verbatim:

```
AssertionError: the victim got 401: five requests from an UNTRUSTED peer,
  forging CF-Connecting-IP, locked out a third party
AssertionError: the victim was collateral: 401
assert 'ip=127.0.0.2' in 'store-api audit … ip=198.51.100.4 … status=recalled'
```

That last one is the defect in one line: a request that came *from* `127.0.0.2`
booked against `198.51.100.4`, because the header said so.

🔴 **The relaxation did not weaken the security tests.** The two that carry the
property — the third-party lockout and the `ip=` attribution — were **not
touched** by the design change and are still red at base, above. What changed is
`test_a_VALID_token_from_an_untrusted_peer_is_still_refused`, which pinned the
over-strict behaviour; its replacement asserts the request is *served and
bucketed under the peer*, and is also red at base (base books it under the forged
value).

The remaining ~40 tests are red at base by `AttributeError` on an API that does
not exist there. They are labelled **invariant guards** in the section header;
their evidence is the mutation matrix.

## Mutation — rebuilt for the new design, not just patched

**52 mutants, rebuilt from scratch for the new design** — not the old battery with
patches. `PYTHONDONTWRITEBYTECODE=1`, `__pycache__` deleted, fresh `cp -r` (never
`cp -a`) per mutant, and a positive control in every batch.

**Final: 51/52 killed. The sole survivor is an equivalent mutant** — `self._client_ip
= ip` -> `ip or None`, where `ip` is provably a non-empty string at that point.

| guard | mutants | result |
|---|---|---|
| `resolve_client` — the whole rule (incl. re-introducing the OLD refuse design) | 8 | KILLED |
| the `peer=` audit annotation | 4 | KILLED |
| handler wiring (fail-closed, lockout check, `/healthz` ordering) | 4 | 3 KILLED, 1 equivalent |
| `peer_is_trusted` | 6 | KILLED |
| `peer_address` | 5 | KILLED |
| `trusted_network` — `/0` guard **and the new prefix floor** (removal, both off-by-ones, both family values, family-blindness, message collapse) | 11 | KILLED |
| `load_trusted_proxies` | 4 | KILLED |
| `build_server` / class default / `main` wiring / banner | 9 | KILLED |
| **positive control** | 1 | **KILLED** (13 failures) |

### 🔴 Round 4 found a blind spot in the SWEEP, not in the code

Two mutants survived round 4 that should not have. Both were my instrument's
fault, and one is worth stating plainly:

* **`if ip is None:` -> `if False:` survived** — the fail-closed refusal deleted
  outright. It was not a code gap: my sweep's `-k` selector
  (`TrustedProxy or PeerAddress or ResolveClient`) *excluded* the four classes
  that cover that path. Run against the whole file, the same mutant is killed by
  **8 tests**. A sweep's test SELECTION is a config that decides what it can
  structurally see, exactly like a viewport or a locale. Widened the selector to
  11 classes / 129 tests and re-ran the entire battery.
* **replacing the allowlist `main` hands to `build_server` survived** — every
  process-level test drove either an untrusted peer (a server that trusts nobody
  agrees with all of them) or a *single* client through a trusted peer (bucketing
  on the peer instead of the header is invisible with one client). Fixed with a
  new test: two DIFFERENT clients through one trusted proxy, one guilty, one not.

Rounds 1–3 (against the earlier design) found four more real defects, three of
them in my own preceding fixes — a dead guard with a false comment, an assertion
satisfied by `ip_network`'s own exception text, three guards sharing one asserted
phrase, and a fix that un-killed a previously-killed mutant.

## Gate

Re-run on a CLEAN tree at the new head (`git status -s` empty first, so this
measures the commit and not a dirty working copy):

```
devrc-pytests>   TOTAL collected=11363  passed=11362  skipped=1  failed=0  (floor: 9945 = sum of 23 per-target floors)
devrc-pytests> RESULT: PASS (exit=0)              GATE_RC=0

devrc-nodetests>   TOTAL suites=4 files=33 tests=1116 pass=1116 fail=0 skipped=0  (floor: 1098)
devrc-nodetests> RESULT: PASS (exit=0)            NODE_RC=0
```

⚠ **The node tier's build log came back 10 bytes** — the cached-drv case, where
`nix build` exits 0 having printed nothing and a `grep` for `RESULT:` matches
nothing at all. The numbers above are read with `nix log <drv>`, not from that
log, and the pytests tier was cross-checked the same way and agrees with its own
60 KB fresh log.

## Mutation, round 7: no `-k` selector at all

The reviewer found a mutant my selected sweep could not see, so this batch runs
the **whole test file** per mutant (~140 s each instead of ~40 s):

| mutant | result |
|---|---|
| **positive control** | KILLED (13 failures) |
| `peer=-` rendered as **`trusted`** — the reviewer's finding | **KILLED** by `test_the_audit_line_survives_a_missing_request_path` |
| `peer=-` rendered as `untrusted` | KILLED by the same test |
| the `is None` check inverted | KILLED (8) |
| `peer=` constant `trusted` / constant `untrusted` / field dropped / not recorded | KILLED (5 / 2 / 8 / 7) |
| the `send_error` reset removed | **SURVIVED — equivalent, explained below** |

**8/9 killed.** The survivor is genuinely equivalent and is now recorded in the
source rather than left unexplained: either `headers` is absent and the branch
answers with the field still `None` (`peer=-`, which is exactly what the new
assertion pins), or `headers` is present and `_identify_and_meter` recomputes it
a few lines later.

## 🔴 A pre-existing log-fidelity defect found while explaining that survivor — reported, not fixed

On a keep-alive connection whose **second** request line is malformed,
`self.headers` and `self.path` are still the **first** request's instance
attributes. Measured on one connection:

```
ip=203.0.113.7 peer=trusted … path=/api/v1/recall/sc auth=ok   result=200
ip=203.0.113.7 peer=trusted … path=/api/v1/recall/sc auth=fail result=401
                                   ^ the PREVIOUS request's path, and its CF-Connecting-IP
```

The request is still refused, so this is log **fidelity**, not a bypass. But it
attributes a malformed request to whatever the last good one claimed, on the log
this design calls "the only thing that can answer it" if the store is ever
suspected of leaking. **Not fixed here**: it predates this branch and closing it
means changing `_raw_path`'s base behaviour, which is outside this PR's scope.
Operator's call whether it earns its own PR.

## Not verified

* 🔴 **The NetworkPolicy this README cites is NOT DEPLOYED.** On homelab-infra
  `trunk` that kustomization lists four resources and no policy; it exists only
  on the unmerged #330 branch. Until that merges, any pod in the cluster can
  address the pod on 8102 and this app-layer gate is the only layer there is.
  The README now says so rather than citing it as a control in place.
* **Nothing through Cloudflare or Traefik** — no ingress exists (homelab-infra
  #329, unmerged). The chain proven is gateway → pod.
* **No image built or pushed.** The live evidence runs the branch's `server.py`
  from a ConfigMap over the phase-1 image in a scratch namespace; the real
  deployment still runs `0.1.0`.
* **The live before/after demo predates the refuse→bucket redesign.** It proves
  the defect and that the peer gate fires; the *bucketing* behaviour has been
  exercised hermetically and against the real process, not in-cluster.
* **IPv6 peers are unit-tested only** — the cluster path is v4 throughout.
* **Cross-family allowlist entries are documented, not fixed.** An entry spelled
  `::ffff:10.0.0.1` never matches an IPv4 peer, because `peer_address` unwraps
  IPv4-mapped and `trusted_network` does not. Fail-closed, so a config error
  rather than a hole; a three-line code fix would remove the footgun and was
  left out as out-of-scope rather than because it is hard.
* The `status=` vocabulary in the README is still hand-written — nothing derives
  it from the module, so the next new status can walk past it.
