### PR TITLE
fix(prune-skill): the reformat could emit unopenable routing lines and certify them green

### DIFF
--- a/claude/skills/prune-skill/SKILL.md
+++ b/claude/skills/prune-skill/SKILL.md
@@ -22,7 +22,9 @@ Why this recurs: a `SKILL.md` costs **0 tokens until its trigger fires, then ALL
 python3 /home/zach/workspace/devrc/scripts/skill-audit.py            # $PWD/.claude/skills
 python3 /home/zach/workspace/devrc/scripts/skill-audit.py path/to/SKILL.md
 ```
-Prints: size vs budget per skill (worst first), per-section byte weights (H2, then H3 in the fattest H2), **dated-history blocks + projected saving**, fat lines (>500 B), **reference-file integrity both directions**, unclosed fences, and a one-line verdict. If it says "no prune needed", **stop** — report it, don't churn the file.
+Prints: size vs budget per skill (worst first), per-section byte weights (H2, then H3 in the fattest H2), **dated-history blocks + projected saving**, fat lines (>500 B), **reference-file integrity both directions**, **numbered-corpus integrity**, unclosed fences, and a one-line verdict. If it says "no prune needed", **stop** — report it, don't churn the file.
+
+🔴 **But a SMALL over-budget number does not mean a small defect — the auditor measures bytes, only a read finds rot.** app-blocks audited at 144 B over (1.2%), which reads as "trim a line"; the actual finding was a 1,931 B section titled *"direct mutations to ephemeral state… if the DB is rebuilt, they vanish"* in which **two of the four entries were retired**, one struck through and one marked `NO LONGER LOAD-BEARING`. Half a section headed *re-apply these* described state that must **not** be re-applied, and both entries were already stated in a reference file whose own banners pointed back at it. Read the fattest sections whatever the byte verdict says.
 
 ## 2. Back up first (the cut deletes/rewrites)
 ```bash
@@ -34,6 +36,8 @@ For a big pass, dispatch read-only classifier subagents (one per fat H2) checkin
 - **EVICT_HISTORY** — **work-status** narrative (`### Session …`, `Changelog`, "what we shipped") → a `claudedocs/` doc, leaving at most **one ≤200-char durable tell**. This is the `prune-memory` skill's "work-STATUS doesn't belong in the index", one level down.
   🔴 **A date in a heading is NOT this verdict.** `## Common silent-failure modes (from the 2026-05-22 audit)` is durable guidance citing a date; evicting it guts the skill. The auditor reports the two separately for that reason — across the 67-skill datapacket corpus **app-blocks holds 45 work-status headings and every other skill ZERO**, while carrying 8–17 dated-but-topical ones. Read its "dated lessons" as DEMOTE, never eviction, candidates.
 - **DEMOTE_TO_REFERENCE** — long-but-real procedures, tables, gotcha-depth → `reference/<topic>.md` beside the skill, with **ONE routing line** left in the core ("load it when…").
+  🔴 **If the block is NUMBERED and cited by number, the numbers are an API — FREEZE them.** Items cited as "gotcha #178" are referenced from the core, from sibling reference files and from OTHER skills, so a split that renumbers each file 1..n breaks every citation while leaving all PATHS valid — no path gate can see it. Keep the original global numbers (they will be non-contiguous inside each file, which is correct), say so in a banner at the top of every shard, and never renumber. app-blocks survives a 9-file split this way: 200 items, numbered 1–200 with zero gaps, 150 citations, zero dangling. Renumbering its shards strands **53** citations instantly.
+  🔴 **Do not put a COUNT in a routing line.** "(18 gotchas)" is a number no gate checks and every append invalidates — app-blocks' table labelled a 20-item file `(18)` and its headline said `198` for 200. Describe what the file is *for*, not how much is in it.
 - **DROP_REDUNDANT** — already in an always-loaded file or another skill; **cite where**, then delete.
 - **MERGE_DUP** — the same gotcha restated across N appended sections → one statement.
 - **KEEP_HOT** — the core: orientation, the hot commands, the 🔴 safety gotchas.
@@ -54,7 +58,16 @@ Reference files are reached **BY PATH from the core**; how you write it depends 
   `reference/` subtree — so those cores MUST use repo-absolute paths
   (`~/workspace/devrc/scripts/<subsystem>/reference/<topic>.md`), as browser's core does.
 - **Repo-local skills** (a project's own `.claude/skills/<name>/`) ship the whole
-  directory — relative `reference/<topic>.md` is fine.
+  directory, so the file is always THERE — but 🔴 **a bare `reference/<topic>.md`
+  is still resolved by the reader against the CWD, not against the skill's own
+  directory, and is simply not found** (measured on datapacket-talos app-blocks
+  2026-08-04). Write the repo-root-relative form
+  `.claude/skills/<name>/reference/<topic>.md`, **or** keep short table entries
+  and state the expansion once in a preamble above the table — which is what
+  app-blocks does. All three repo-local skills that have a `reference/` dir use
+  one of those two forms; **none** relies on a bare relative path. Shipping and
+  resolving are separate failures: the nix question below is about whether the
+  file exists at all, this one bites when it does.
 
 The auditor checks both directions, warning on relative paths with no absolute base.
 Independently of the auditor: every backticked repo path in a skill should EXIST. Write a
@@ -73,6 +86,8 @@ Rewrite `SKILL.md` as KEEP_HOT plus routing lines; create the `reference/*.md` f
 ```bash
 python3 /home/zach/workspace/devrc/scripts/skill-audit.py <SKILL_DIR>
 ```
-Confirm: under target (at least under the hard cap), **every routing path resolves**, no orphans, no unclosed fences. Report before/after bytes, what moved where, and the backup path.
+Confirm: under target (at least under the hard cap), **every routing path resolves**, no orphans, no unclosed fences, and — if you split a numbered corpus — **`numbered-corpus integrity` reports every citation resolving with no duplicates**. Duplicate numbers across shards are the signature of a per-file renumber; dangling citations are what that costs. Report before/after bytes, what moved where, and the backup path.
+
+🔴 **Open one demoted file and one routing line by hand before calling it done.** `skill-audit.py` resolves routing paths against the skill directory — which always succeeds — so its ✓ is not evidence that a reader following the core from a repo root will find the file. That is the §4 trap, and the audit cannot see it.
 
 Pair: the `prune-memory` skill (the same cut on the per-session `MEMORY.md` index); `test_skill_size.py` above is the precedent — once a skill is lean, a byte-cap test keeps it lean.

--- a/scripts/skill-audit.py
+++ b/scripts/skill-audit.py
@@ -100,6 +100,37 @@ REF_PATH = re.compile(r"[\w./~$@-]*reference/[\w.-]+\.md")
 # the deployment caveat below does not apply.
 ABS_REF_BASE = re.compile(r"(?:~|/)[\w./-]*/reference/")
 
+# --- numbered-corpus integrity --------------------------------------------------
+# A corpus of numbered items ("11. **ModelMetric is declared...**") that has been
+# DEMOTED across several reference files is cited BY NUMBER — from the core, from
+# sibling reference files, and from OTHER skills ("gotcha #178"). The numbers are
+# therefore an API, and a demote that renumbers per-file silently breaks every
+# citation: nothing in a repo-relative path gate can see it, because the paths are
+# all still fine. Measured on datapacket-talos app-blocks 2026-08-17: 200 items
+# spread over 9 files, numbered 1-200 with ZERO gaps, 150 distinct citations, zero
+# dangling — i.e. the scheme survives a split only because whoever split it froze
+# the numbers and said so in a banner on every file.
+CORPUS_ITEM = re.compile(r"^(\d+)\. ", re.M)
+# Only the EXPLICIT form. A bare `#N` is unusable here: across app-blocks it
+# matches 313 distinct numbers of which 189 exceed the corpus entirely (civitai
+# PRs, issues, line numbers), whereas `gotcha #N` matches 61, max 188 — every one
+# a real index. Bounding bare `#N` by the highest defined index was tried first
+# and is WORSE THAN USELESS: a demote that renumbers every shard to 1..n drops the
+# ceiling with it, so the citations that just broke fall below the bound and the
+# check goes silent at exactly the moment it should fire.
+CORPUS_CITE = re.compile(r"gotchas?\s+#(\d+)")
+# A SHARD of a split corpus vs an ordinary numbered list, decided by DENSITY: a
+# shard holds a scattered slice of one global sequence, a procedure holds 1..n.
+# Measured over app-blocks' 13 numbered files — the 9 shards score span/n 4.90 to
+# 12.00, and all 4 non-shards (a W-table, two step lists, the core) score exactly
+# 1.00. A 1.5 cut sits in a 3.4x-wide empty gap, so this is not a tuned constant.
+CORPUS_SPARSE = 1.5
+# Guards the degenerate end: 2 items numbered 1 and 9 are sparse by ratio and are
+# still just a list.
+CORPUS_FILE_MIN = 5
+# Below this many items across all shards, there is no corpus worth policing.
+CORPUS_MIN = 10
+
 
 def _bytes(lines):
     return sum(len(ln.encode()) for ln in lines)
@@ -277,6 +308,75 @@ def reference_integrity(skill_md, text):
     return refs, missing, orphans, len(relative), bool(ABS_REF_BASE.search(text))
 
 
+def _corpus_items(body):
+    """Top-level numbered items in one file, nested/restarting lists dropped.
+
+    Real corpus items ascend monotonically within a file (they are a slice of one
+    global sequence). A nested "1./2." list inside an item's body restarts, so
+    keeping only the strictly-ascending run is what separates the two — verified
+    against app-blocks, where it reproduced the core's own per-file counts on 8 of
+    9 files and exposed the 9th as genuinely stale (labelled 18, holds 20).
+    """
+    out, last = [], 0
+    for n in (int(m) for m in CORPUS_ITEM.findall(body)):
+        if n > last:
+            out.append(n)
+            last = n
+    return out
+
+
+def corpus_integrity(skill_md):
+    """(n_defined, dangling, dupes) over the skill's whole directory.
+
+    Reports ONLY on a corpus that is actually cited: a skill whose numbered lists
+    are procedures produces no citations, hence no findings, hence no noise.
+    """
+    skill_dir = skill_md.parent
+    ref_dir = skill_dir / "reference"
+    if not ref_dir.is_dir():
+        return 0, [], []  # nothing has been split, so nothing can have desynced
+    files = [skill_md] + sorted(ref_dir.rglob("*.md"))
+    bodies = {f: f.read_text(errors="replace") for f in files}
+
+    # DEFINED is every top-level numbered item, density irrelevant. Keeping the
+    # dense files in is what makes a total renumber detectable: after one, every
+    # shard reads 1..n, so a density-filtered view would hold nothing at all.
+    per_file = {f: _corpus_items(b) for f, b in bodies.items()}
+    defined = {}
+    for f, items in per_file.items():
+        for n in items:
+            defined.setdefault(n, f.name)
+    if len(defined) < CORPUS_MIN or sum(1 for i in per_file.values() if i) < 2:
+        return 0, [], []
+
+    cited = {int(n) for b in bodies.values() for n in CORPUS_CITE.findall(b)}
+    if not cited:
+        return 0, [], []
+    # Several skills cite ANOTHER skill's corpus ("gotchas #137" from
+    # manage-design-system, one in gitops-gate). Requiring a citation to land in
+    # this skill's own numbers was tried as the guard against policing those, and
+    # it REINTRODUCED the silent-renumber hole: when every shard is rewritten,
+    # nothing overlaps and the check disappears. The size gate above already
+    # excludes every borrowed case in the real corpus — measured across all 67
+    # datapacket skills, dropping this guard adds zero findings.
+
+    # DUPES are scored over sparse shards only: a dense 1..n list legitimately
+    # reuses low numbers that a shard also holds, and pairing those reported 15
+    # bogus collisions on a corpus that is provably intact.
+    seen, dupes = {}, []
+    for f, items in per_file.items():
+        if len(items) < CORPUS_FILE_MIN:
+            continue
+        if (max(items) - min(items) + 1) / len(items) <= CORPUS_SPARSE:
+            continue
+        for n in items:
+            if n in seen:
+                dupes.append((n, seen[n], f.name))
+            else:
+                seen[n] = f.name
+    return len(defined), sorted(cited - set(defined)), dupes
+
+
 def audit_one(skill_md):
     text = skill_md.read_text(errors="replace")
     lines = text.splitlines(keepends=True)
@@ -287,6 +387,7 @@ def audit_one(skill_md):
     lessons = dated_blocks(lines, heads, "dated_lesson")
     fat = fat_lines(lines)
     refs, missing, orphans, n_rel, abs_base = reference_integrity(skill_md, text)
+    corpus_n, corpus_dangling, corpus_dupes = corpus_integrity(skill_md)
     first_h2 = h2[0][1] if h2 else len(lines)
     fattest = max(h2, key=lambda s: s[3]) if h2 else None
     return {
@@ -313,6 +414,9 @@ def audit_one(skill_md):
         "orphan_refs": orphans,
         "relative_refs": n_rel,
         "abs_ref_base": abs_base,
+        "corpus_n": corpus_n,
+        "corpus_dangling": corpus_dangling,
+        "corpus_dupes": corpus_dupes,
         "fence_ok": fence_balanced(lines),
     }
 
@@ -446,7 +550,18 @@ def render(audits, show_all, n_sections, n_detail, out=sys.stdout):
               "exceptions — `browser` (scripts/browser-bridge/) and `dl-router` "
               "(scripts/dl-router/) link only SKILL.md plus their CLI — so THOSE "
               "cores must use repo-absolute paths. State the absolute source next "
-              "to the deployed path either way, so a reader can find it to edit.")
+              "to the deployed path either way, so a reader can find it to edit.\n"
+              "    🔴 That paragraph is about whether the file SHIPS. A REPO-LOCAL "
+              "skill (a project's own .claude/skills/<name>/) always ships its "
+              "reference/ dir, and still breaks here for a different reason: a "
+              "bare `reference/<topic>.md` is resolved by the reader against the "
+              "CWD, not against the skill's directory, so it is simply not found "
+              "(measured on datapacket-talos app-blocks 2026-08-04). Write the "
+              "repo-root-relative form `.claude/skills/<name>/reference/<topic>.md`, "
+              "or keep short table entries and state the expansion once in a "
+              "preamble — which is what app-blocks does, and why it does not warn "
+              "here. All 3 repo-local skills with a reference/ dir use one of "
+              "those two forms; none relies on a bare relative path.")
     if not any_ref_issue:
         n_refd = sum(len(a["refs"]) for a in audits)
         if n_refd:
@@ -454,6 +569,21 @@ def render(audits, show_all, n_sections, n_detail, out=sys.stdout):
         else:
             p("  no skill routes to a reference/ sidecar yet — DEMOTE_TO_REFERENCE is "
               "unused here, which is why the cores carry everything")
+
+    corpora = [a for a in audits if a["corpus_n"]]
+    if corpora:
+        p("\n## numbered-corpus integrity (the numbers are an API — never renumber)")
+        for a in corpora:
+            if a["corpus_dangling"]:
+                p(f"  🔴 {a['name']}: {len(a['corpus_dangling'])} CITED BUT UNDEFINED "
+                  f"— {', '.join('#' + str(n) for n in a['corpus_dangling'][:12])}")
+            if a["corpus_dupes"]:
+                p(f"  🔴 {a['name']}: {len(a['corpus_dupes'])} DUPLICATE number(s) "
+                  "— the hallmark of a demote that renumbered per file: "
+                  + ", ".join(f"#{n} in {x} and {y}" for n, x, y in a["corpus_dupes"][:6]))
+            if not a["corpus_dangling"] and not a["corpus_dupes"]:
+                p(f"  {a['name']}: {a['corpus_n']} numbered items, every citation "
+                  "resolves, no duplicates ✓")
 
     broken_fence = [a["name"] for a in audits if not a["fence_ok"]]
     if broken_fence:

--- a/scripts/tests/test_skill_audit.py
+++ b/scripts/tests/test_skill_audit.py
@@ -624,3 +624,90 @@ def _run(root, *extra):
                        capture_output=True, text=True)
     assert r.returncode == 0, r.stderr
     return r.stdout
+
+
+# --- numbered-corpus integrity --------------------------------------------------
+# The numbers in a split corpus are an API: they are cited from the core, from
+# sibling reference files and from OTHER skills, so a demote that renumbers
+# per-file silently breaks every citation while leaving all PATHS valid — no path
+# gate can see it. Measured on datapacket-talos app-blocks 2026-08-17: intact at
+# 200 items / 0 dangling; renumbering its 9 shards to 1..n each produced 53
+# dangling citations, which is the mutation the reporter below must catch.
+
+def _corpus_skill(tmp_path, name, core, shards):
+    d = tmp_path / name
+    (d / "reference").mkdir(parents=True)
+    (d / "SKILL.md").write_text(core)
+    for fn, nums in shards.items():
+        body = "# shard\n\n" + "".join(f"{n}. **item {n}** body\n\n" for n in nums)
+        (d / "reference" / fn).write_text(body)
+    return d / "SKILL.md"
+
+
+# Two sparse shards of one 1..200-style sequence, as a real split corpus looks.
+# 12 apiece, so a total renumber still leaves >= CORPUS_MIN defined numbers —
+# otherwise the size gate, not the logic, is what the mutation test measures.
+SHARDS = {"a.md": [3, 17, 45, 92, 140, 155, 161, 170, 175, 182, 190, 196],
+          "b.md": [8, 23, 60, 111, 150, 158, 166, 172, 178, 185, 193, 199]}
+CORE_CITES = "# core\n\nSee gotcha #45 and gotcha #111 for detail.\n"
+
+
+def test_a_split_corpus_with_frozen_numbers_is_clean(tmp_path):
+    a = sa.audit_one(_corpus_skill(tmp_path, "ok", CORE_CITES, SHARDS))
+    assert a["corpus_n"] == 24
+    assert a["corpus_dangling"] == []
+    assert a["corpus_dupes"] == []
+
+
+def test_positive_control_renumbering_shards_breaks_citations(tmp_path):
+    """THE mutation this check exists for — and the one a ceiling-bounded
+    citation regex could not see, because renumbering drops the ceiling too."""
+    renumbered = {"a.md": list(range(1, 13)), "b.md": list(range(1, 13))}
+    a = sa.audit_one(_corpus_skill(tmp_path, "renum", CORE_CITES, renumbered))
+    assert a["corpus_dangling"] == [45, 111], (
+        "renumbering every shard to 1..n must strand both citations; got "
+        f"{a['corpus_dangling']}")
+
+
+def test_positive_control_a_duplicate_number_across_shards_is_reported(tmp_path):
+    """A PARTIAL renumber — one shard rewritten, the other left alone."""
+    clashing = {"a.md": SHARDS["a.md"], "b.md": SHARDS["a.md"][:-1] + [141]}
+    a = sa.audit_one(_corpus_skill(tmp_path, "dupe", CORE_CITES, clashing))
+    assert [n for n, *_ in a["corpus_dupes"]] == SHARDS["a.md"][:-1]
+
+
+def test_a_dense_procedure_list_is_not_a_corpus(tmp_path):
+    """1..n is a procedure. Scoring these as shards reported 15 bogus
+    collisions against app-blocks' provably-intact corpus."""
+    dense = {"a.md": [1, 2, 3, 4, 5, 6], "b.md": [1, 2, 3, 4, 5, 6]}
+    a = sa.audit_one(_corpus_skill(tmp_path, "dense", "# core\n\ngotcha #3\n", dense))
+    assert a["corpus_dupes"] == []
+
+
+def test_a_skill_citing_another_skills_corpus_is_not_policed(tmp_path):
+    """Several datapacket skills cite app-blocks' numbers ("gotchas #137" in
+    manage-design-system, one in gitops-gate). None of those is theirs to
+    resolve. The SIZE gate is what keeps them silent — they have no corpus of
+    their own — so this pins the real shape: a reference/ dir, a borrowed
+    citation, and too few numbers to be a corpus."""
+    tiny = {"a.md": [1, 2, 3]}
+    a = sa.audit_one(_corpus_skill(tmp_path, "borrow",
+                                   "# core\n\nsee gotcha #137 elsewhere\n", tiny))
+    assert a["corpus_n"] == 0 and a["corpus_dangling"] == []
+
+
+def test_a_bare_hash_number_is_not_read_as_a_citation(tmp_path):
+    """`#2319` is a PR. Across app-blocks the bare form matches 313 distinct
+    numbers, 189 of them outside the corpus entirely."""
+    a = sa.audit_one(_corpus_skill(tmp_path, "prs",
+                                   CORE_CITES + "\nShipped in #2319 and #201.\n", SHARDS))
+    assert a["corpus_dangling"] == []
+
+
+def test_a_skill_with_no_reference_dir_is_never_policed(tmp_path):
+    d = tmp_path / "flat"
+    d.mkdir()
+    (d / "SKILL.md").write_text(CORE_CITES + "".join(
+        f"{n}. **step {n}**\n\n" for n in range(1, 21)))
+    a = sa.audit_one(d / "SKILL.md")
+    assert a["corpus_n"] == 0


### PR DESCRIPTION
fix(prune-skill): the reformat could emit unopenable routing lines and certify them green

Running the pruner's DEMOTE_TO_REFERENCE path against a monolithic skill produces
a router core plus reference/*.md — that part already worked, and is how app-blocks
got its 15 topics. Two things could then go wrong without anything saying so.

1. Sec 4 told repo-local skills that a bare `reference/<topic>.md` is fine because
   the directory ships. Shipping is not resolving: a reader expands it against the
   CWD, not the skill dir, so it is simply not found (app-blocks measured this
   2026-08-04 and carries a preamble to work around it). All 3 repo-local skills
   with a reference/ dir use the repo-root-relative form or an explicit expansion
   preamble; NONE relies on a bare relative path. Corrected, and the audit's
   relative-path note now separates "does it ship" from "does it resolve".

2. Splitting a corpus that is CITED BY NUMBER silently breaks every citation if the
   shards get renumbered 1..n, and no path gate can see it because the paths stay
   valid. app-blocks is 200 items over 9 files, numbered 1-200 with zero gaps, 150
   citations, zero dangling — intact only because whoever split it froze the
   numbers. New `numbered-corpus integrity` check reports dangling citations and
   duplicate numbers across shards.

Also: sec 3 gains "no counts in routing lines" (app-blocks labels a 20-item file
(18) and says 198 for 200 — numbers no gate checks), sec 1 gains a note that a
small over-budget figure is not a small defect, and sec 7 now says to open one
routing line by hand, since skill-audit resolves paths against the skill dir and
therefore always succeeds.

Design notes on the checker, both of which cost a rewrite:
- Citations match only the explicit `gotcha #N`. The bare `#N` form matches 313
  distinct numbers in app-blocks, 189 of them PRs/issues. Bounding bare `#N` by the
  highest defined index is worse than useless: a total renumber drops the ceiling
  with it, so the check goes silent exactly when it should fire.
- Shard-vs-procedure is decided by density (span/n). app-blocks' 9 shards score
  4.90-12.00; all 4 non-shards score exactly 1.00, so the 1.5 cut sits in a wide
  empty gap rather than being tuned. Dupes are scored over sparse shards only —
  pairing dense lists reported 15 bogus collisions on a provably-intact corpus.

Verified: clean on the real app-blocks corpus (200 items, 0 dangling, 0 dupes) and
SILENT on the other 66 datapacket skills. Negative control: renumbering its 9
shards to 1..n each strands 53 citations and the check goes red for its own reason.
48 skill-audit tests pass, including that mutation as a permanent regression test.
Full devrc suite 4909 passed / 24 failed — the same 24 test IDs fail at clean
origin/main, byte-identical set, so none is introduced here.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)
