### PR TITLE
feat(signal): the image is where a missing dependency must fail, because at runtime it does not fail at all (#514)

### DIFF
--- a/scripts/signal/Dockerfile
+++ b/scripts/signal/Dockerfile
@@ -1,0 +1,87 @@
+# The Signal consumer pod — `consumer.py run`, the long-lived ingest daemon.
+#
+# 🔴 BUILT FROM devrc, NOT VENDORED INTO homelab-talos. Same split as
+# `scripts/subsystem-store-api/Dockerfile` (read its header for the full
+# argument) and as `clusters/homelab/apps/mailbox` uses for mail-receiver:
+# the code lives HERE, gated by this repo's own suite (387 tests under
+# `scripts/signal/tests/`), and homelab-talos holds MANIFESTS ONLY plus a
+# pinned image digest. A vendored copy would pass its own tests while drifting
+# from the CLI the workbench runs — the exact local/remote disagreement the
+# design exists to make impossible.
+#
+# Build context is the REPO ROOT (so the paths below read the same as they do
+# in a git URL), hence:
+#     docker build -f scripts/signal/Dockerfile -t <tag> .
+# `build-push.sh` next to this file does that, runs the controls, and pushes.
+#
+# 🔴 COPY BY NAME, NEVER `COPY . .`. devrc is a PUBLIC repo and a working tree
+# routinely holds an un-gitignored scratch file; a `COPY . .` bakes whatever
+# happened to be sitting there into a layer and pushes it to a registry.
+# `build-push.sh` asserts the resulting /app file set EXACTLY, both directions.
+
+FROM python:3.12-slim
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE DEPENDENCIES ARE INSTALLED FROM requirements.txt, AND THAT FILE IS THE
+# ONLY LIST. Do not add a second hand-written `pip install a b c` here: the two
+# lists drift, and this service's failure mode for a missing dependency is not a
+# crash. `run()` treats any exception out of the stream factory as a dropped
+# stream and reconnects, so an absent `websocket-client` is an INFINITE
+# "reconnecting" loop with zero rows ingested and nothing in the log that says
+# why. `scripts/signal/tests/test_image_deps.py` pins requirements.txt against
+# the modules' ACTUAL imports (derived by walking the AST, not restated), and
+# `build-push.sh` imports every one of them inside the built image before it is
+# allowed to push.
+#
+# Deliberately UNPINNED versions, like requirements.txt itself. The pin that
+# matters is the image digest homelab-talos deploys — a rebuilt `0.1.0` that
+# picked up a new psycopg2 is a DIFFERENT digest and therefore a different
+# deploy decision, which is the property we actually want.
+# --------------------------------------------------------------------------- #
+COPY scripts/signal/requirements.txt /app/scripts/signal/requirements.txt
+RUN pip install --no-cache-dir -r /app/scripts/signal/requirements.txt
+
+# Every .py under scripts/signal/ that is not a test. Named individually so a
+# stray file cannot ride along. If you add a module here, add it to this list —
+# test_image_deps.py::test_dockerfile_copies_every_runtime_module fails
+# otherwise, because "the image silently lacks the new module" is a runtime
+# ImportError in a reconnect loop, not a build error.
+COPY scripts/signal/consumer.py    /app/scripts/signal/
+COPY scripts/signal/_signal_db.py  /app/scripts/signal/
+COPY scripts/signal/_minio.py      /app/scripts/signal/
+COPY scripts/signal/clawgate.py    /app/scripts/signal/
+
+# --------------------------------------------------------------------------- #
+# 🔴 SIGNAL_PG_DIRECT=1 IS A PROPERTY OF THE IMAGE, NOT A DEPLOYMENT CHOICE.
+# `_signal_db._direct_target()` returns None unless SIGNAL_PG_HOST or
+# SIGNAL_PG_DIRECT is set, and None means "bridge with `kubectl port-forward`" —
+# the off-cluster default that the workbench CLI uses. There is no kubectl in
+# this image and there must not be one, so without this the pod would
+# `FileNotFoundError` on connect. `_minio.MinioSignal` has the identical
+# fork keyed on MINIO_ARCHIVE_ENDPOINT, which the Deployment sets (an endpoint
+# is a cluster fact, not an image fact, so that one is NOT defaulted here).
+#
+# PYTHONUNBUFFERED=1: without it a crashed pod's last words sit in a 4 KiB
+# stdio buffer that is never flushed, and `kubectl logs` shows nothing.
+# HOME=/home/nonroot: a numeric-UID container has no passwd entry, and any
+# `Path.home()` on an import path would raise before anything could say so.
+# --------------------------------------------------------------------------- #
+ENV HOME=/home/nonroot \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    SIGNAL_PG_DIRECT=1
+
+RUN mkdir -p /home/nonroot && chown -R 65532:65532 /home/nonroot
+
+# 65532 matches the subsystem-store-api and clawgate precedents. This pod holds
+# no volume, so there is no fsGroup story to get right — it only needs to not
+# be root.
+USER 65532:65532
+
+WORKDIR /app/scripts/signal
+
+# `run` is the only subcommand a Deployment should ever take. Every other
+# subcommand (draft/approve/send/reconcile) is operator-driven and runs from the
+# workbench CLI, where the approval token lives — `_signal_db.APPROVAL_TOKEN_ENV`
+# is deliberately ABSENT from this pod's environment.
+CMD ["python3", "/app/scripts/signal/consumer.py", "run"]

--- a/scripts/signal/Dockerfile.dockerignore
+++ b/scripts/signal/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+**
+!scripts/signal/requirements.txt
+!scripts/signal/consumer.py
+!scripts/signal/_signal_db.py
+!scripts/signal/_minio.py
+!scripts/signal/clawgate.py

--- a/scripts/signal/build-push.sh
+++ b/scripts/signal/build-push.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# Build + push the Signal consumer image to Harbor.
+#
+# The image is built from THIS repo (see the Dockerfile's header for why), with
+# the repo root as the build context.
+#
+# 🔴 THE TAG IS AN ARGUMENT AND HAS NO DEFAULT. A `:latest` default is how a
+# mutable tag gets clobbered by a concurrent build and a pod silently restarts
+# on somebody else's code. homelab-talos pins an immutable DIGEST.
+#
+#   build-push.sh 0.1.0            # build, run the controls, push, print the digest
+#   build-push.sh 0.1.0 --no-push  # build + controls only, push nothing
+#
+# Every control below refuses the PUSH, not the build: a broken image that was
+# never pushed is a local problem; one that reached the registry is a deploy.
+
+set -euo pipefail
+
+VERSION="${1:?usage: build-push.sh <version> [--no-push]}"
+shift || true
+PUSH=1
+[[ "${1:-}" == "--no-push" ]] && PUSH=0
+
+REGISTRY="harbor.homelab.lan"
+IMAGE="$REGISTRY/library/signal-consumer:$VERSION"
+# CDPATH= : a set CDPATH makes `cd` ECHO its destination, which would be
+# captured into ROOT alongside the real path. Measured in the subsystem-store
+# precedent, not theorised.
+ROOT="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+echo "==> building $IMAGE from $ROOT"
+docker build -f "$ROOT/scripts/signal/Dockerfile" -t "$IMAGE" "$ROOT"
+
+# --------------------------------------------------------------------------- #
+# CONTROL 1 — THE POSITIVE ONE, AND THE REASON THIS SCRIPT EXISTS.
+#
+# 🔴 A MISSING DEPENDENCY IN THIS SERVICE IS NOT A CRASH, IT IS A ZOMBIE.
+# `consumer.run()` treats any exception out of the stream factory as a dropped
+# stream and reconnects with backoff — so an image built without
+# `websocket-client` comes up healthy, logs "reconnecting" forever, ingests zero
+# rows, and reports no error anywhere. Hours were lost to exactly that. The
+# failure must therefore happen HERE, at build time, loudly.
+#
+# The list is DERIVED, never restated: the script walks the AST of the modules
+# that are actually in the image and imports every non-stdlib, non-local name it
+# finds, then imports the local modules themselves. A dependency added to a new
+# `import` line is covered without anyone remembering to update this file.
+# (requirements.txt is pinned against the same derivation, from the other
+# direction, by scripts/signal/tests/test_image_deps.py.)
+# --------------------------------------------------------------------------- #
+# 🔴 `-i` IS LOad-BEARING, NOT STYLE. Without it `docker run` does not attach
+# stdin, `python3 -` reads EOF, executes an EMPTY program, and exits 0. The
+# control then "passes" having imported nothing — measured here on the first
+# run of this script, which is exactly why it prints what it imported and why
+# the caller below asserts that the output ARRIVED.
+echo "==> control 1/3: importing every derived runtime dependency INSIDE the image"
+control_out=$(docker run --rm -i --entrypoint python3 "$IMAGE" - <<'PYCONTROL'
+import ast, importlib, pathlib, sys
+
+APP = pathlib.Path("/app/scripts/signal")
+sys.path.insert(0, str(APP))
+
+modules = sorted(p for p in APP.glob("*.py"))
+if len(modules) < 4:
+    raise SystemExit(
+        f"CONTROL BROKEN: found {len(modules)} module(s) under {APP}; the AST walk "
+        "would have nothing to derive from and this control would pass vacuously")
+
+local = {p.stem for p in modules}
+third = set()
+for path in modules:
+    for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+        if isinstance(node, ast.Import):
+            names = [a.name for a in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            names = [node.module] if (node.level == 0 and node.module) else []
+        else:
+            continue
+        for name in names:
+            root = name.split(".")[0]
+            if root not in sys.stdlib_module_names and root not in local:
+                third.add(root)
+
+if not third:
+    raise SystemExit(
+        "CONTROL BROKEN: the AST walk derived ZERO third-party imports. That is "
+        "not possible for these modules (psycopg2/minio/requests/websocket are "
+        "all imported) — the walker is broken, so a green here would mean nothing")
+
+print(f"    derived {len(third)} third-party import(s) from {len(modules)} module(s)")
+for name in sorted(third):
+    mod = importlib.import_module(name)
+    version = getattr(mod, "__version__", None) or getattr(mod, "version", "")
+    print(f"    OK  dependency  {name:<12} {version}")
+
+for name in sorted(local):
+    importlib.import_module(name)
+    print(f"    OK  own module  {name}")
+
+print(f"CONTROL-1-PASSED: {len(third)} dependencies + {len(local)} own modules imported")
+PYCONTROL
+)
+printf '%s\n' "$control_out"
+
+# The output-arrived assertion. `set -e` already catches a non-zero exit, but the
+# failure this guards is the one that exits ZERO: a control that ran no code at
+# all. Anchored on a token the script only prints after every import succeeded.
+if ! printf '%s' "$control_out" | grep -q '^CONTROL-1-PASSED:'; then
+  echo "build-push: REFUSING TO PUSH — control 1 produced no completion line." >&2
+  echo "            It exited 0 having imported NOTHING (an unattached stdin does" >&2
+  echo "            exactly this). A silent pass here is the failure mode the whole" >&2
+  echo "            control exists to catch, so it is treated as one." >&2
+  exit 1
+fi
+echo "==> control 1/3 PASSED"
+
+# --------------------------------------------------------------------------- #
+# CONTROL 2 — THE NEGATIVE ONE. devrc is a PUBLIC repo and a working tree
+# routinely holds scratch files, `.envrc`, a half-written secret. The Dockerfile
+# copies by name, but "the Dockerfile is correct" is a claim about the
+# Dockerfile; this is the measurement.
+#
+# The assertion is EXACT SET EQUALITY, not a blocklist of forbidden names: a
+# blocklist can only catch the leaks somebody imagined. Anything under /app that
+# is not one of the five files we put there fails the push.
+#
+# Note the scope this control does NOT have: it walks /app only, so it says
+# nothing about the base image's own contents. That is deliberate — the base is
+# `python:3.12-slim` by digest-of-tag and its contents are upstream's problem,
+# not a leak surface from this working tree.
+# --------------------------------------------------------------------------- #
+echo "==> control 2/3: /app must hold EXACTLY the files the Dockerfile names"
+# 🔴 THE EXPECTED LIST IS DERIVED FROM THE DOCKERFILE, NOT RETYPED HERE. A third
+# hand-written copy of the file set would be one more ledger to drift, and the
+# chain that makes this meaningful is already closed WITHOUT it:
+#
+#   scripts/signal/*.py  ==  Dockerfile COPY list  ==  Dockerfile.dockerignore
+#        pinned three ways by tests/test_image_deps.py, on every gate run
+#   Dockerfile COPY list  ==  what is actually in the built image
+#        pinned right here, on every build
+#
+# so "the directory equals the image" follows, and no statement of it is
+# written twice. The leak this catches is content that entered the image
+# WITHOUT a COPY naming it — a base-image surprise under /app, a cache artifact,
+# or a `COPY . .` added in a hurry (which names a directory, so every file it
+# drags in shows up as unexpected here).
+#
+# LC_ALL=C on BOTH sides. The host sorts under the caller's locale and the
+# container under its own; en_US folds the leading underscore of `_minio.py`
+# differently from C, so two identical file sets compared as a diff of
+# differently-sorted lists reports four spurious changes. Measured, not
+# theorised — the first run of this script did exactly that.
+EXPECTED_FILES=$(
+  awk '/^COPY[[:space:]]/ {
+         src = $2; dst = $3
+         n = split(src, parts, "/")
+         # A COPY whose destination ends in "/" drops the source basename there.
+         printf "%s%s\n", dst, (dst ~ /\/$/ ? parts[n] : "")
+       }' "$ROOT/scripts/signal/Dockerfile" | LC_ALL=C sort
+)
+if [[ $(printf '%s\n' "$EXPECTED_FILES" | grep -c .) -lt 5 ]]; then
+  echo "build-push: CONTROL BROKEN — parsed fewer than 5 COPY destinations out of" >&2
+  echo "            the Dockerfile. The expected list is derived from it, so an" >&2
+  echo "            empty or short parse would compare the image against nothing." >&2
+  exit 1
+fi
+ACTUAL_FILES=$(docker run --rm --entrypoint sh "$IMAGE" -c 'find /app -type f | LC_ALL=C sort')
+
+# 🔴 The comparator gets its own controls FIRST. A `diff` that always reports
+# "same" would make the check below pass with a leaked .envrc in the image, and
+# a `diff` that always reports "different" would fail an honest build — both are
+# a broken instrument, and neither is visible from the result alone. So: prove
+# it says SAME for identical input, and DIFFERENT for input perturbed by one
+# line, before its verdict on the real thing is worth reading.
+if ! diff <(printf '%s\n' "$EXPECTED_FILES") <(printf '%s\n' "$EXPECTED_FILES") >/dev/null; then
+  echo "build-push: CONTROL BROKEN — the comparator reports a difference between a list and itself." >&2
+  exit 1
+fi
+if diff <(printf '%s\n' "$EXPECTED_FILES") <(printf '%s\n/app/LEAKED\n' "$EXPECTED_FILES") >/dev/null; then
+  echo "build-push: CONTROL BROKEN — the comparator did NOT notice an extra file. It cannot see a leak." >&2
+  exit 1
+fi
+echo "    comparator controls OK (identical => same, one extra line => different)"
+
+if [[ -z "$ACTUAL_FILES" ]]; then
+  echo "build-push: REFUSING TO PUSH — /app is EMPTY in the image. A zero-leak" >&2
+  echo "            result from an empty tree is the vacuous pass, not the all-clear." >&2
+  exit 1
+fi
+
+if ! diff <(printf '%s\n' "$EXPECTED_FILES") <(printf '%s\n' "$ACTUAL_FILES"); then
+  echo "build-push: REFUSING TO PUSH — /app does not match the Dockerfile's COPY list." >&2
+  echo "            '<' = expected and missing, '>' = present and UNINTENDED (a leak)." >&2
+  exit 1
+fi
+echo "==> control 2/3 PASSED: /app holds exactly $(printf '%s\n' "$ACTUAL_FILES" | wc -l) expected files, nothing else"
+
+# --------------------------------------------------------------------------- #
+# CONTROL 3 — the image's CMD points at the CLI, and that CLI is the one this
+# service is supposed to carry.
+#
+# Two halves, because either alone is walkable: the CMD is read STRUCTURALLY out
+# of the image config (a `docker run` would override it, so running the CLI
+# proves nothing about what the pod will execute), and the subcommand set is
+# compared as an EXACT SET against argparse's own `{a,b,c}` choices line — not
+# by grepping for the word "run", which the help TEXT spells in a dozen places
+# and which would pass with the subcommand deleted.
+#
+# It is NOT a claim that ingest works. Nothing in this script connects to
+# Signal, Postgres or MinIO, and no message has been ingested by anything it
+# builds.
+# --------------------------------------------------------------------------- #
+echo "==> control 3/3: CMD points at the CLI, and the CLI has the expected subcommands"
+cmd=$(docker inspect --format '{{join .Config.Cmd " "}}' "$IMAGE")
+want_cmd="python3 /app/scripts/signal/consumer.py run"
+if [[ "$cmd" != "$want_cmd" ]]; then
+  echo "build-push: REFUSING TO PUSH — image CMD is '$cmd', expected '$want_cmd'." >&2
+  exit 1
+fi
+
+# argparse renders the subparser choices as a single `{a,b,c,…}` token. Pulling
+# that token out and comparing SETS means a renamed or dropped subcommand fails
+# here, and an ADDED one fails here too — which is the point: a new operator
+# subcommand is a decision about what this pod can be told to do.
+choices=$(docker run --rm --entrypoint python3 "$IMAGE" \
+            /app/scripts/signal/consumer.py --help \
+          | tr ' ' '\n' | grep -o '{[a-z,]*}' | head -1 | tr -d '{}' | tr ',' '\n' | sort | tr '\n' ' ')
+want_choices="approve conversations draft drafts reconcile run search send "
+if [[ "$choices" != "$want_choices" ]]; then
+  echo "build-push: REFUSING TO PUSH — subcommand set is '$choices'," >&2
+  echo "            expected '$want_choices'. Empty means the parse found no {…}" >&2
+  echo "            token at all, i.e. this control observed nothing." >&2
+  exit 1
+fi
+echo "==> control 3/3 PASSED: CMD='$cmd'; subcommands = $choices"
+
+if [[ $PUSH -eq 0 ]]; then
+  echo "==> --no-push: built and controlled only. NOTHING was pushed."
+  exit 0
+fi
+
+docker push "$IMAGE"
+echo "==> pushed $IMAGE"
+echo "==> DIGEST (this is what homelab-talos pins, NOT the tag):"
+docker inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "$IMAGE"

--- a/scripts/signal/tests/test_image_deps.py
+++ b/scripts/signal/tests/test_image_deps.py
@@ -1,0 +1,314 @@
+"""The IMAGE must learn about a new import — requirements.txt and the Dockerfile, DERIVED.
+
+🔴 WHY THIS FILE EXISTS. A missing runtime dependency in this service is not a
+crash, it is a ZOMBIE. `consumer.run()` treats any exception out of the stream
+factory as a dropped stream and reconnects with backoff, so an image built
+without `websocket-client` comes up healthy, logs "reconnecting" forever,
+ingests zero rows, and reports nothing anywhere that says why. Hours were lost
+to exactly that before the image existed. The failure has to happen at BUILD
+time.
+
+Two guards live in the build itself (`build-push.sh`: it imports every derived
+dependency inside the built image, and asserts /app's file set exactly). Those
+run when somebody builds. THIS file runs on every gate, and pins the two
+declarations a build would silently obey:
+
+  * `requirements.txt` — what pip installs, versus what the modules IMPORT;
+  * the Dockerfile's `COPY` list — which modules are in the image at all.
+
+🔴 EVERY LEDGER HERE IS DERIVED BY WALKING THE AST, never restated. A
+hand-written list of dependencies could not catch the thing this file exists to
+catch — an `import` added to `consumer.py` with nothing else touched — because
+the list and the omission would be written by the same person in the same
+moment. `sys.stdlib_module_names` decides what is stdlib (3.10+, so the version
+that runs the gate answers it, not a table here) and the module basenames in
+`scripts/signal/` decide what is local.
+
+The one thing that CANNOT be derived is that a PyPI distribution name is not
+always the module you import (`psycopg2-binary` -> `psycopg2`,
+`websocket-client` -> `websocket`). That mapping is written down once, below,
+and `test_every_requirement_has_a_known_import_name` asserts it is TOTAL over
+requirements.txt — so a new dependency with no mapping fails loudly here rather
+than quietly dropping out of the parity check it was added to satisfy.
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+import consumer
+
+SIGNAL_DIR = Path(consumer.__file__).resolve().parent
+REQUIREMENTS = SIGNAL_DIR / "requirements.txt"
+DOCKERFILE = SIGNAL_DIR / "Dockerfile"
+DOCKERIGNORE = SIGNAL_DIR / "Dockerfile.dockerignore"
+
+# PyPI distribution name -> the name you `import`. Asserted TOTAL over
+# requirements.txt by a test below; anything not listed here is treated as
+# importing under its own name.
+DIST_TO_IMPORT = {
+    "psycopg2-binary": "psycopg2",
+    "websocket-client": "websocket",
+}
+
+# Plausible floors. NOT the contract (the derived sets are) — they exist so a
+# broken parser fails as "the harness is broken" rather than passing vacuously.
+MIN_RUNTIME_MODULES = 4
+MIN_THIRD_PARTY_IMPORTS = 4
+
+
+# --------------------------------------------------------------------------- #
+# Derivations
+# --------------------------------------------------------------------------- #
+def runtime_modules() -> list[Path]:
+    """Every .py in scripts/signal/ — i.e. the modules the image must carry.
+
+    `tests/` is a subdirectory, so a plain glob already excludes it; that is
+    checked below rather than assumed.
+    """
+    return sorted(SIGNAL_DIR.glob("*.py"))
+
+
+def imported_names(source: str, *, local: set[str]) -> set[str]:
+    """Third-party top-level import names in `source`, by AST.
+
+    Walks the WHOLE tree, so a deferred import inside a function counts — which
+    matters here more than anywhere: `websocket` is imported inside
+    `ws_stream_factory()` and `minio` inside `_open_minio()`, precisely the two
+    that a module-level-only scan would miss and precisely the two whose absence
+    produces the silent reconnect loop.
+    """
+    found: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            names = [alias.name for alias in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            # level > 0 is an explicit relative import: local by construction.
+            names = [node.module] if (node.level == 0 and node.module) else []
+        else:
+            continue
+        for name in names:
+            root = name.split(".")[0]
+            if root not in sys.stdlib_module_names and root not in local:
+                found.add(root)
+    return found
+
+
+def third_party_imports() -> set[str]:
+    modules = runtime_modules()
+    local = {p.stem for p in modules}
+    found: set[str] = set()
+    for path in modules:
+        found |= imported_names(path.read_text(encoding="utf-8"), local=local)
+    return found
+
+
+def requirement_dists() -> list[str]:
+    """The distribution names in requirements.txt, comments and blanks stripped."""
+    dists = []
+    for raw in REQUIREMENTS.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        # No version specifiers are used today; tolerate them so adding one is
+        # not silently read as part of the name.
+        dists.append(re.split(r"[<>=!~\[]", line, maxsplit=1)[0].strip())
+    return dists
+
+
+def dockerfile_copied_files() -> set[str]:
+    """Basenames of the scripts/signal/ files the Dockerfile COPYs."""
+    copied = set()
+    for m in re.finditer(r"^COPY\s+(\S+)\s+\S+\s*$", DOCKERFILE.read_text(encoding="utf-8"),
+                         re.MULTILINE):
+        src = m.group(1)
+        if src.startswith("scripts/signal/"):
+            copied.add(Path(src).name)
+    return copied
+
+
+# --------------------------------------------------------------------------- #
+# Harness controls — run these before believing anything below them
+# --------------------------------------------------------------------------- #
+def test_the_derivations_observe_something():
+    """POSITIVE CONTROL. Every parity claim in this file is `derived == derived`,
+    and two empty sets are equal. A glob that matched nothing, a regex that lost
+    its anchor, a requirements parser that ate every line — each of those makes
+    the whole file pass while measuring nothing. So each derivation is asserted
+    non-empty and plausibly-sized FIRST.
+    """
+    modules = runtime_modules()
+    assert len(modules) >= MIN_RUNTIME_MODULES, (
+        f"HARNESS BROKEN: found {len(modules)} module(s) in {SIGNAL_DIR}; the "
+        f"import derivation would have almost nothing to walk")
+    assert len(third_party_imports()) >= MIN_THIRD_PARTY_IMPORTS, (
+        "HARNESS BROKEN: the AST walk derived fewer than "
+        f"{MIN_THIRD_PARTY_IMPORTS} third-party imports")
+    assert requirement_dists(), "HARNESS BROKEN: requirements.txt parsed to zero entries"
+    assert dockerfile_copied_files(), (
+        "HARNESS BROKEN: the Dockerfile COPY regex matched nothing — every "
+        "COPY-list assertion below would pass vacuously")
+
+
+def test_the_ast_walker_can_see_a_new_import():
+    """POSITIVE CONTROL, the one that matters. The guard's entire job is to
+    NOTICE a newly added import. A walker that reported the four names it
+    already knows — hardcoded, or crashing into a cached result — would look
+    identical on today's tree and be blind to tomorrow's change.
+
+    So feed it a source that imports something no signal module imports, in each
+    of the three syntactic shapes, and watch the set MOVE. `zoneinfo` is the
+    stdlib control on the same input: it must NOT appear, or the walker is
+    reporting everything and its parity check can never fail either.
+    """
+    src = (
+        "import brandnewdep\n"
+        "import zoneinfo\n"
+        "from otherdep.sub import thing\n"
+        "def f():\n"
+        "    import deferreddep\n"
+        "    from consumer import KIND_MESSAGE\n"
+    )
+    found = imported_names(src, local={"consumer"})
+    assert found == {"brandnewdep", "otherdep", "deferreddep"}, (
+        f"the AST walker returned {sorted(found)}. It must see plain, from-, and "
+        "function-local imports; it must not report stdlib (`zoneinfo`) or local "
+        "(`consumer`) names")
+
+
+def test_dist_to_import_map_is_only_needed_where_names_differ():
+    """A mapping entry that maps a name to ITSELF is dead weight that reads as
+    coverage. Every entry here must actually rename something.
+    """
+    for dist, mod in DIST_TO_IMPORT.items():
+        assert dist != mod, (
+            f"DIST_TO_IMPORT['{dist}'] maps to itself — the fallback already "
+            "handles that case; delete the entry")
+
+
+# --------------------------------------------------------------------------- #
+# The contract
+# --------------------------------------------------------------------------- #
+def test_every_requirement_has_a_known_import_name():
+    """A new dependency whose import name differs from its distribution name must
+    be declared in DIST_TO_IMPORT, or the parity test below would compare it
+    against an import that never appears and fail confusingly — or worse, a
+    future edit "fixes" that by dropping it from the comparison entirely.
+
+    Checked by IMPORTING it: the gate installs these (flake.nix `checks.pytests`
+    carries psycopg2, minio, requests), so a wrong mapping is observable rather
+    than assumed. `websocket-client` is NOT in the gate's closure — the hermetic
+    suite injects every transport — so that one is checked against the map only,
+    and named here so the exemption is visible instead of silent.
+    """
+    not_installed_in_the_gate = {"websocket-client"}
+    for dist in requirement_dists():
+        mod = DIST_TO_IMPORT.get(dist, dist)
+        if dist in not_installed_in_the_gate:
+            assert dist in DIST_TO_IMPORT, (
+                f"{dist} is not importable in the gate's environment, so its "
+                "import name cannot be verified here — it must be declared in "
+                "DIST_TO_IMPORT explicitly")
+            continue
+        pytest.importorskip(
+            mod,
+            reason=f"requirements.txt lists {dist}, which should import as {mod}")
+
+
+def test_requirements_matches_what_the_modules_actually_import():
+    """🔴 THE GUARD. Both directions, and neither is cosmetic.
+
+    A third-party import with no requirement -> the image builds fine and the
+    pod reconnects forever (the original defect).
+
+    A requirement no module imports -> a dependency nobody can point at, kept
+    alive because deleting it feels risky. Removing it is a decision; drifting
+    into it is not.
+    """
+    imported = third_party_imports()
+    declared = {DIST_TO_IMPORT.get(d, d) for d in requirement_dists()}
+
+    missing = imported - declared
+    assert not missing, (
+        f"scripts/signal/ imports {sorted(missing)} but requirements.txt does not "
+        "declare it. The image would build, start, and ingest NOTHING — "
+        "`run()` swallows the ImportError as a dropped stream and reconnects "
+        "forever. Add it to scripts/signal/requirements.txt (and to "
+        "DIST_TO_IMPORT if the distribution name differs from the import name).")
+
+    unused = declared - imported
+    assert not unused, (
+        f"requirements.txt declares {sorted(unused)} but no module under "
+        f"{SIGNAL_DIR.name}/ imports it. Either it is dead and should be "
+        "removed, or the code that needed it was deleted and this is the "
+        "leftover.")
+
+
+def test_dockerfile_copies_every_runtime_module():
+    """🔴 THE SEAM. requirements.txt being right says nothing about whether the
+    module that imports them is even in the image.
+
+    The Dockerfile COPYs by name on purpose (devrc is public; `COPY . .` bakes a
+    working tree into a pushed layer). The cost of that choice is exactly this:
+    a new module added to scripts/signal/ is silently absent from the image, and
+    its ImportError lands inside the same reconnect loop as a missing
+    dependency. So the COPY list is pinned to the directory listing, both ways —
+    a module added without a COPY fails, and a COPY left behind by a deleted
+    module fails too.
+    """
+    on_disk = {p.name for p in runtime_modules()} | {REQUIREMENTS.name}
+    copied = dockerfile_copied_files()
+    assert copied == on_disk, (
+        f"Dockerfile COPY list {sorted(copied)} != scripts/signal/ contents "
+        f"{sorted(on_disk)}.\n"
+        "  in on_disk but not copied: the image will NOT contain it — an "
+        "ImportError inside run()'s reconnect loop, which logs nothing.\n"
+        "  in copied but not on_disk: the build will FAIL on a missing source.")
+
+
+def test_dockerignore_allowlists_exactly_the_copied_files():
+    """The per-Dockerfile ignore file is what makes `COPY`-by-name safe: it denies
+    `**` and re-admits only the named paths, so the build context cannot carry a
+    stray working-tree file to the daemon at all. If it drifts from the COPY
+    list, the build fails on a missing source (loud) or admits more context than
+    intended (quiet) — this pins the quiet direction too.
+    """
+    text = DOCKERIGNORE.read_text(encoding="utf-8")
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    assert lines and lines[0] == "**", (
+        "Dockerfile.dockerignore must DENY everything on its first line and "
+        f"re-admit by name; it starts with {lines[0]!r}")
+    admitted = {Path(ln[1:]).name for ln in lines[1:] if ln.startswith("!")}
+    copied = dockerfile_copied_files()
+    assert admitted == copied, (
+        f"Dockerfile.dockerignore admits {sorted(admitted)} but the Dockerfile "
+        f"COPYs {sorted(copied)}")
+
+
+def test_the_dockerfile_does_not_hand_write_a_second_dependency_list():
+    """requirements.txt is the single source of truth, and the Dockerfile's header
+    says so. A `pip install <names>` alongside it is the drift this whole file
+    exists to prevent, arriving from the other side.
+    """
+    for line in DOCKERFILE.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("RUN") or "pip install" not in stripped:
+            continue
+        assert "-r " in stripped, (
+            f"Dockerfile installs packages without -r requirements.txt: {stripped!r}")
+
+
+def test_tests_are_not_part_of_the_runtime_module_set():
+    """`runtime_modules()` globs one level, so tests/ is excluded by construction.
+    Pinned because the assertion above is set EQUALITY against the Dockerfile: if
+    this ever started matching tests/, the fix would look like "add tests to the
+    image", which is the wrong direction.
+    """
+    assert not any("tests" in p.parts for p in runtime_modules())
+    assert (SIGNAL_DIR / "tests").is_dir(), (
+        "HARNESS BROKEN: there is no tests/ directory, so the exclusion above "
+        "proves nothing")


### PR DESCRIPTION
feat(signal): the image is where a missing dependency must fail, because at runtime it does not fail at all (#514)

`consumer.run()` treats any exception out of the stream factory as a dropped
stream and reconnects with backoff. So an image built without
`websocket-client` does not crash — it comes up healthy, logs "reconnecting"
forever, ingests zero rows, and reports nothing anywhere that says why. Hours
went into that failure before the image existed. This makes it a BUILD error.

Adds, following `scripts/subsystem-store-api/` exactly (built from devrc not
vendored into homelab-talos; repo root as build context; COPY by name never
`COPY . .`; the tag a required argument with no `:latest` default):

  Dockerfile               python:3.12-slim, deps installed from
                           requirements.txt and from nothing else, four
                           modules copied by name, non-root 65532.
                           SIGNAL_PG_DIRECT=1 is set HERE because it is a fact
                           about the image: `_direct_target()` returns None
                           without it and None means "shell out to kubectl
                           port-forward", which this image cannot do.
  Dockerfile.dockerignore  denies `**`, re-admits the five paths by name, so a
                           stray working-tree file never reaches the daemon.
                           devrc is public; this is not hygiene.
  build-push.sh            three controls, each of which refuses the PUSH.
  tests/test_image_deps.py the gate-time half.

The controls are DERIVED, never restated. Control 1 walks the AST of the
modules actually in the image and imports every non-stdlib non-local name it
finds — so a dependency added by a new `import` line is covered without anyone
remembering. It caught its own first defect: `docker run` without `-i` leaves
`python3 -` reading EOF, which executes an empty program and exits 0, so the
control "passed" having imported nothing. It now asserts its own completion
line arrived. Control 2 derives the expected /app file set from the
Dockerfile's own COPY lines rather than keeping a third hand-written ledger,
and controls its comparator both ways before reading its verdict. Control 3
reads CMD structurally out of the image config and compares the subcommand set
against argparse's `{a,b,c}` token, not by grepping for the word "run" that
the help text spells everywhere.

test_image_deps.py pins requirements.txt against the modules' ACTUAL imports
and the Dockerfile's COPY list against the directory contents — both derived
by AST/regex, both directions. The seam matters as much as the dependencies: a
new module added to scripts/signal/ with no COPY is the same silent
ImportError inside the same reconnect loop.

Watched to fail, each with THIS guard's own error and after a successful build
where a build error could have masked it:
  drop websocket-client from requirements  -> red (the original defect)
  declare a dependency nothing imports     -> red
  drop a COPY line                         -> red
  add a new module with a new import       -> red, twice
  hardcode the AST walker's answer         -> red
  second hand-written pip install          -> red
  content baked in by RUN, no COPY         -> red (control 2)
  `COPY . /app/everything/`                -> red (control 2)
  under-parse the Dockerfile               -> red (control 2's floor guard)
  build an image without websocket-client  -> red (control 1, rc=1)
  leak a file into the image               -> red (control 2, control 1 green)

Gate: `nix build .#checks.x86_64-linux.pytests` RESULT: PASS (exit=0).
  PASS  scripts/signal/tests  (collected=396 passed=396 skipped=0 floor=368)
396 = 387 + 9. No TARGET_FLOORS change: the floor is a minimum and 396 sits
inside the drift band, so the gate asked for nothing. Zero new skips, so
EXPECTED_SKIPS is untouched, and GUARD 7 still reports
`scripts/signal/tests intercepted=0 systemctl-reads=0`.

NOT verified: nothing here has ingested a Signal message. These controls prove
the image carries what it imports and nothing it should not — not that ingest
works.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)
