### PR TITLE
fix(skill-audit): recognise the repo-root-relative sidecar spelling the guidance recommends

### DIFF
--- a/scripts/skill-audit.py
+++ b/scripts/skill-audit.py
@@ -250,39 +250,66 @@ def fat_lines(lines, limit=FAT_LINE):
     return [(len(ln.encode()), ln.rstrip("\n")) for ln in lines if len(ln.encode()) > limit]
 
 
-def resolve_ref(skill_dir, ref):
-    p = Path(os.path.expanduser(ref))
-    return p if p.is_absolute() else skill_dir / ref
+def _sidecar_tail(skill_dir, ref):
+    """This ref expressed RELATIVE TO the skill dir, or None if it is not a sidecar.
 
+    Three accepted spellings, because a core may legitimately use any of them:
+      1. bare              `reference/x.md`
+      2. absolute          `~/workspace/.../<name>/reference/x.md`
+      3. repo-root-relative `.claude/skills/<name>/reference/x.md`
 
-def _is_sidecar(skill_dir, ref):
-    """Is this path THIS skill's own reference sidecar?
+    🔴 (3) used to return False, so a repo-local skill written the way the
+    prune-skill guidance RECOMMENDS was scored as having no sidecars at all —
+    "no skill routes to a reference/ sidecar yet" on a freshly-split skill with
+    five routing lines, and a missing topic reported by nobody. Measured on
+    datapacket-talos image-cacher 2026-08-17, right after its 70 KB -> 8 KB split.
 
-    A bare `reference/x.md` is; an absolute path under the skill dir is. A
-    relative path rooted elsewhere (`apps/reference/manifest.md` — a page on a
+    A relative path rooted elsewhere (`apps/reference/manifest.md` — a page on a
     CLIENT's public developer-docs site, seen in two real datapacket skills) is
-    NOT, and reporting it as a broken sidecar is a false alarm about another
-    repo's docs site.
+    still NOT a sidecar: reporting it as broken is a false alarm about another
+    repo's docs site. (3) is distinguished from it by naming THIS skill's own
+    directory immediately before `reference/`.
     """
-    if ref.startswith("reference/") or ref.startswith("./reference/"):
-        return True
+    if ref.startswith("./"):
+        ref = ref[2:]
+    if ref.startswith("reference/"):
+        return ref
     p = Path(os.path.expanduser(ref))
-    if not p.is_absolute():
-        return False
-    try:
-        p.relative_to(skill_dir)
-        return True
-    except ValueError:
-        return False
+    if p.is_absolute():
+        try:
+            return p.relative_to(skill_dir).as_posix()
+        except ValueError:
+            return None
+    marker = f"{skill_dir.name}/reference/"
+    i = ref.find(marker)
+    if i != -1:
+        return ref[i + len(skill_dir.name) + 1:]
+    return None
+
+
+def resolve_ref(skill_dir, ref):
+    tail = _sidecar_tail(skill_dir, ref)
+    if tail is None:
+        p = Path(os.path.expanduser(ref))
+        return p if p.is_absolute() else skill_dir / ref
+    return skill_dir / tail
 
 
 def referenced_refs(text, skill_dir):
-    """This skill's own reference/*.md sidecars, deduped, in first-seen order."""
+    """This skill's own reference/*.md sidecars, deduped, in first-seen order.
+
+    Deduped by RESOLVED TARGET, not by the string as written: a core may name the
+    same topic twice in different accepted spellings (app-blocks routes to
+    legacy-hackathon-ops.md from its table as `reference/…` and from its Repo
+    layout as `.claude/skills/app-blocks/reference/…`). Counting the spellings
+    reported 16 "reference file(s)" for 15 files.
+    """
     seen, out = set(), []
     for m in REF_PATH.findall(text):
-        if m in seen or not _is_sidecar(skill_dir, m):
+        tail = _sidecar_tail(skill_dir, m)
+        if tail is None or tail in seen:
             continue
-        seen.add(m)
+        seen.add(tail)
         out.append(m)
     return out
 

--- a/scripts/tests/test_skill_audit.py
+++ b/scripts/tests/test_skill_audit.py
@@ -711,3 +711,73 @@ def test_a_skill_with_no_reference_dir_is_never_policed(tmp_path):
         f"{n}. **step {n}**\n\n" for n in range(1, 21)))
     a = sa.audit_one(d / "SKILL.md")
     assert a["corpus_n"] == 0
+
+
+# --- repo-root-relative sidecar spelling -----------------------------------------
+# A repo-local skill may route as `.claude/skills/<name>/reference/<topic>.md` — the
+# form prune-skill's sec 4 recommends, because a BARE relative path is resolved by the
+# reader against the CWD and not found. That spelling used to score as "not a sidecar",
+# so a freshly-split skill reported "no skill routes to a reference/ sidecar yet" with
+# five live routing lines, and a missing topic was reported by nobody. Measured on
+# datapacket-talos image-cacher 2026-08-17.
+
+REPO_ROOT_CORE = """# core
+
+| File | Load it when… |
+|---|---|
+| `.claude/skills/rr/reference/alpha.md` | alpha things |
+| `.claude/skills/rr/reference/beta.md` | beta things |
+"""
+
+
+def _rr_skill(tmp_path, core, refs):
+    d = tmp_path / "rr"
+    (d / "reference").mkdir(parents=True)
+    (d / "SKILL.md").write_text(core)
+    for r in refs:
+        (d / "reference" / r).write_text(f"# {r}\n")
+    return d / "SKILL.md"
+
+
+def test_a_repo_root_relative_routing_line_is_recognised(tmp_path):
+    a = sa.audit_one(_rr_skill(tmp_path, REPO_ROOT_CORE, ("alpha.md", "beta.md")))
+    assert len(a["refs"]) == 2, f"routing lines not seen as sidecars: {a['refs']}"
+    assert a["missing_refs"] == []
+    assert a["orphan_refs"] == []
+
+
+def test_positive_control_a_missing_repo_root_relative_topic_is_reported(tmp_path):
+    """THE control: before the fix this returned [] — a dead routing line, silently."""
+    a = sa.audit_one(_rr_skill(tmp_path, REPO_ROOT_CORE, ("alpha.md",)))
+    assert a["missing_refs"] == [".claude/skills/rr/reference/beta.md"], (
+        f"a dead repo-root-relative routing line went unreported: {a['missing_refs']}")
+
+
+def test_a_repo_root_relative_orphan_is_still_reported(tmp_path):
+    core = "# core\n\n| `.claude/skills/rr/reference/alpha.md` | alpha |\n"
+    a = sa.audit_one(_rr_skill(tmp_path, core, ("alpha.md", "nobody-routes-here.md")))
+    assert a["orphan_refs"] == ["reference/nobody-routes-here.md"]
+
+
+def test_another_repos_reference_path_is_still_not_a_sidecar(tmp_path):
+    """Regression guard: `apps/reference/manifest.md` is a page on a CLIENT's public
+    docs site, seen in two real datapacket skills. It names a directory that is not
+    this skill, so it must stay out — reporting it broken is a false alarm."""
+    core = "# core\n\nsee `apps/reference/manifest.md` on the docs site\n"
+    a = sa.audit_one(_rr_skill(tmp_path, core, ()))
+    assert a["refs"] == [] and a["missing_refs"] == []
+
+
+def test_two_spellings_of_one_topic_count_once(tmp_path):
+    """app-blocks names legacy-hackathon-ops.md both ways; counting spellings
+    reported 16 "reference file(s)" for 15 files.
+
+    🔴 INVARIANT GUARD, not a regression test — it passes at the pre-fix base too,
+    for the wrong reason: there the second spelling was not recognised at all, so
+    the count was 1 by blindness rather than by deduping. Nothing expressible as a
+    baseline test separates those, so do not read this as covering the dedupe.
+    """
+    core = ("# core\n\n`reference/alpha.md` in the table, and "
+            "`.claude/skills/rr/reference/alpha.md` in the repo-layout section\n")
+    a = sa.audit_one(_rr_skill(tmp_path, core, ("alpha.md",)))
+    assert len(a["refs"]) == 1, f"same file counted {len(a['refs'])}x: {a['refs']}"


### PR DESCRIPTION
fix(skill-audit): recognise the repo-root-relative sidecar spelling the guidance recommends

#523 corrected prune-skill sec 4 to tell repo-local skills to route as
`.claude/skills/<name>/reference/<topic>.md`, because a BARE relative path is
resolved by the reader against the CWD and not found. It did not teach the auditor
to see that spelling — so the checker was blind to the exact form the guidance now
recommends.

Caught by running the pruner for real against datapacket-talos image-cacher
(70,034 -> 8,280 B, five new reference topics). The audit of the freshly-split
skill said:

    no skill routes to a reference/ sidecar yet — DEMOTE_TO_REFERENCE is unused
    here, which is why the cores carry everything

with five live routing lines on screen. Worse than the wrong banner: `missing_refs`
was empty by construction, so a dead routing line in that spelling was reported by
NOBODY. (The orphan direction still fired, but only by substring accident.)

`_is_sidecar` becomes `_sidecar_tail`, returning the path relative to the skill dir
for all three accepted spellings — bare, absolute-under-the-skill-dir, and
repo-root-relative — or None. `resolve_ref` resolves through it, which also fixes
the resolution bug the old code would have had (`skill_dir / ".claude/skills/x/..."`
doubles the prefix). A path rooted elsewhere (`apps/reference/manifest.md`, a page
on a CLIENT's public docs site in two real skills) is still not a sidecar: the new
form is distinguished by naming THIS skill's own directory right before `reference/`.

Also dedupes by RESOLVED TARGET rather than by the string as written. app-blocks
routes to legacy-hackathon-ops.md from its table as `reference/…` and from its repo
layout as `.claude/skills/app-blocks/reference/…`; once both spellings are seen,
counting strings reported 16 "reference file(s)" for 15 files. Corpus-wide the
honest count is 104, not 110.

Verified: image-cacher 0 -> 5 refs resolving, app-blocks unchanged at 15, all 67
datapacket skills clean with no new false alarms. 53 skill-audit tests pass (74
across the size/skill gates). BASELINE CONTROL: the two tests pinning the new
behaviour were run against origin/main's script and FAIL there — red at base, green
at HEAD. The dedupe test is labelled in-file as an invariant guard, not a
regression test: it passes at base for the wrong reason (the second spelling was
invisible there) and nothing expressible as a baseline test separates the two.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)
