### PR TITLE
fix(session-manager): `blocked_on_me` held the CLAWGATE queue — the caveat warning against that misread was read past, so rename the field

### DIFF
--- a/claude/skills/session-manager/SKILL.md
+++ b/claude/skills/session-manager/SKILL.md
@@ -16,7 +16,7 @@ python3 $DEVRC/scripts/session-manager tail scratch7:3 --plain     # scrollback,
 
 🔴 **Rows are at `report["hosts"][<"workbench"|"laptop">]["windows"]`** — not at the top
 level. Roll-ups: `summary.waiting`, `summary.unsent_prompt`, `summary.status[bucket]`,
-`summary.kind`, `blocked_on_me`. And `report["not_measured"]` for what this tool does **not**
+`summary.kind`, `clawgate_queue`. And `report["not_measured"]` for what this tool does **not**
 see at all.
 
 🔴 **`summary.status[bucket]` is one key per CLASS plus `total`** — `{claude, shell, total}`
@@ -31,7 +31,7 @@ the top level (`summary.claude`/`summary.shell` always; others on demand).
 for a clawgate dispatch with no pane and is **not produced yet**, which
 `caveats.kind_scope` states in the payload (`kinds_produced` is **measured from the rows**,
 not asserted). So an absence of cluster rows is **not** a measured absence of cluster work —
-clawgate lives in `blocked_on_me`, a different population that is never double-counted with
+clawgate lives in `clawgate_queue`, a different population that is never double-counted with
 these rows. `kind` is never null; `runtime` frequently is, and means something else
 (**which agent software**, from the ledger).
 
@@ -67,7 +67,7 @@ table is for and that is unchanged; do not quote the absolute numbers as current
 **Ask for `--json --lean` unless you need a dropped field.** It is cheaper than the full payload
 AND more faithful than the cheap one. `lean_row_fields` and `lean_host_fields` travel in the payload
 naming exactly what this view CARRIES — so a key absent from a row was omitted by the view, never
-measured as null. `caveats`, `summary.waiting`'s tri-state, `blocked_on_me` and every per-host
+measured as null. `caveats`, `summary.waiting`'s tri-state, `clawgate_queue` and every per-host
 measurement status are kept in full, because a cheap payload that can lie is worse than an
 expensive one.
 
@@ -160,16 +160,27 @@ the **skill that answers it**: `pull_requests` → `standup`, `mail_queue` → `
 only while the report carries no key for that population, so the day PR querying lands the
 claim stops being made with no edit anywhere. This file has shipped a constant masquerading
 as a measurement five times; a static list of "things we do not measure" is the same defect
-with a longer fuse. `blocked_on_me` (clawgate) is **not** listed — that one *is* measured.
+with a longer fuse. `clawgate_queue` (clawgate) is **not** listed — that one *is* measured.
 
-## 🔴 `blocked_on_me` — the clawgate approval queue
+## 🔴 `clawgate_queue` — the clawgate approval queue
+
+🔴 **Renamed from `blocked_on_me` (2026-08-18).** The old name read as "everything waiting on
+you" and was measured doing exactly that damage: a caveat in this tool's own payload already
+said *"reading it as one is the misread this entry exists to prevent"*, and a reader made that
+misread anyway and shipped it into a brief for three subagents. A field name is read a hundred
+times for every once its caveat is, so the name changed rather than the wording.
+**For panes that look like they are waiting on a human, the field is `summary.waiting.probable`
+— a different population, never summed with this one.** No alias is kept: the old key is gone,
+and a test bans it at any depth in the payload, because a key that silently means something
+else is worse than a key that is absent.
 
 Read from the bar poller's cache. It is here because an accurate cross-reference once cost
 real signal: a dogfooding agent read that the (now retired) `agent-ops` TUI had no JSON API,
 correctly preferred this script, never opened agent-ops, and **missed 11 pending approvals —
 four of them credential-exposure or cross-user-data-leak.** 🔴 With that TUI gone this
 section is the ONLY place the queue surfaces outside the bar pill, so the lesson binds
-harder, not less: never answer a `blocked_on_me` question by pointing somewhere else.
+harder, not less: never answer an "is anything waiting for my approval" question by pointing
+somewhere else.
 
 - **`count` = pending + STUCK.** `pending_count` is the `{open, ready_for_review}` half;
   `stuck_count` is `in_progress` tasks whose agent looks dead. The two always travel with

--- a/claudedocs/design-ledger-writer3-and-kind-2026-08-14.md
+++ b/claudedocs/design-ledger-writer3-and-kind-2026-08-14.md
@@ -99,7 +99,7 @@ enriched by the embedded `agent` object for liveness — which is the read `claw
 already performs and which just fired correctly. Writer 3 collapses from *"a new fetch and a new
 entity"* into *"promote the existing clawgate dispatch read into rows"*.
 
-**Non-overlap with `blocked_on_me`, stated so it cannot drift:** `blocked_on_me` counts tasks
+**Non-overlap with `clawgate_queue`, stated so it cannot drift:** `clawgate_queue` counts tasks
 **waiting on the operator** (`open` + `ready_for_review`); cluster rows would carry tasks
 **in flight** (`in_progress`). Disjoint by status, no double count. Without that line written
 down, clawgate lands in the report three times.
@@ -174,7 +174,7 @@ or, under the §2 correction, rows for **2** in-flight dispatches.
 axis through `fold_windows`, `summarize`, `_waiting_rollup`, `classify_status`, the table, the
 lean view and `LEAN_ROW_FIELDS`; and re-deciding the claude/shell split that 18 tests assert.
 
-**What already covers the same ground:** `blocked_on_me` (tasks needing the operator, with the
+**What already covers the same ground:** `clawgate_queue` (tasks needing the operator, with the
 count/discriminant contract) **plus** the stuck detector, which today reported the 2 wedged
 dispatches by id, title, reason and age — the exact rows writer 3 would add, in a surface that
 already exists and just proved itself on live data.
@@ -185,7 +185,7 @@ already exists and just proved itself on live data.
    split by it). This settles the entity model, is testable with no network, and makes the three
    defects above impossible to ship later by accident. It is the part agent-ops retirement and
    the §5 bar inversion actually need.
-2. **Promote the stuck rows into the report** as the cheap 80% — `summary.blocked_on_me` already
+2. **Promote the stuck rows into the report** as the cheap 80% — `summary.clawgate_queue` already
    carries `stuck_count`; surfacing the stuck *rows* costs no new fetch.
 3. **Gate writer 3** on a stated trigger: the `in_progress` population being routinely non-zero
    **and** `task.agent` non-null (i.e. #316 resolved). Both are false today. Re-check by reading

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -21,7 +21,7 @@ agent-ops showed, four of them credential-exposure or cross-user-data-leak. An
 accurate cross-reference steered a reader away from the highest-stakes signal on
 the machine. The fix that survived the retirement is the one that mattered:
 
-  * the pending count is read HERE (`report["blocked_on_me"]`, and a
+  * the pending count is read HERE (`report["clawgate_queue"]`, and a
     `▸ BLOCKED ON ME` section printed in every state including unmeasured), so
     the headline question does not depend on remembering another tool.
 
@@ -187,7 +187,7 @@ and the roll-ups a caller usually wants are:
                                         `waiting`, never summed into it
     report["summary"]["status"][b]      class counts + "total" per bucket
     report["summary"]["kind"]           {"tmux": N} — the entity axis
-    report["blocked_on_me"]             {"status", "count", ...}
+    report["clawgate_queue"]             {"status", "count", ...}
     report["not_measured"]              [{population, owner_skill, ...}] — the
                                         populations this tool CANNOT see, and
                                         which skill owns each
@@ -226,7 +226,7 @@ SIMPLY {claude, shell}.
 to. `cluster` is enumerated for a dispatch with NO pane (spec §4, writer 3)
 and is NOT produced yet — `caveats.kind_scope` says so in the payload, so an
 absence of cluster rows is never readable as a measured absence of cluster
-work. Clawgate is reported instead under `blocked_on_me`, a different
+work. Clawgate is reported instead under `clawgate_queue`, a different
 population that is never double-counted with these rows.
 
 The buckets count by `row_class`, not by `claude`-or-`shell`, because
@@ -776,7 +776,7 @@ CAVEATS = {
                  "it is named in `kinds_excluded_by_filter`, which is where a "
                  "kind removed by a filter is reported instead of being "
                  "silently attributed to the build. For "
-                 "clawgate use report.blocked_on_me (tasks needing the "
+                 "clawgate use report.clawgate_queue (tasks needing the "
                  "operator, and its `stuck_count` for wedged dispatches), a "
                  "different population from these rows that is never "
                  "double-counted with them."),
@@ -915,10 +915,10 @@ NOT_MEASURED_POPULATIONS = {
         "report_key": "mail_queue",
         "owner_skill": "mailbox",
         "note": ("Inbound mail and the extracted action-items queue are a "
-                 "separate store this tool never opens. `blocked_on_me` is the "
-                 "CLAWGATE approval queue only — it is not a general "
-                 "'everything waiting on you' number, and reading it as one is "
-                 "the misread this entry exists to prevent."),
+                 "separate store this tool never opens. For anything that is "
+                 "waiting on a human see `clawgate_queue` (approvals) and "
+                 "`summary.waiting.probable` (tmux panes) — two separate "
+                 "populations, never summed. Neither covers mail."),
     },
     "cluster_alerts": {
         "report_key": "cluster_alerts",
@@ -1539,7 +1539,7 @@ def detect_waiting(text) -> dict:
     return {"probable": bool(signals), "signals": signals}
 
 
-def read_blocked_on_me(path=None, reader=None, now=None,
+def read_clawgate_queue(path=None, reader=None, now=None,
                        max_age=BLOCKED_CACHE_MAX_AGE) -> dict:
     """The clawgate approval queue's pending COUNT, status-discriminated.
 
@@ -2296,11 +2296,11 @@ def summarize(report) -> dict:
         # the predicate — a roll-up reader must be able to tell "no wedged
         # dispatches" from "wedged dispatches were never looked for", which is
         # the distinction that made a four-hour-dead agent invisible here.
-        "blocked_on_me": {
-            "count": (report.get("blocked_on_me") or {}).get("count"),
-            "status": (report.get("blocked_on_me") or {}).get("status"),
-            "stuck_count": (report.get("blocked_on_me") or {}).get("stuck_count"),
-            "schema_ok": (report.get("blocked_on_me") or {}).get("schema_ok"),
+        "clawgate_queue": {
+            "count": (report.get("clawgate_queue") or {}).get("count"),
+            "status": (report.get("clawgate_queue") or {}).get("status"),
+            "stuck_count": (report.get("clawgate_queue") or {}).get("stuck_count"),
+            "schema_ok": (report.get("clawgate_queue") or {}).get("schema_ok"),
         },
         # Hosts whose `list-windows` did not answer even though `list-panes`
         # did. Their rows carry no window_id and, if local, no fuzzyclaw join.
@@ -2577,7 +2577,7 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
            ch_client_factory=None, fuzzyclaw_texts=None,
            slots=None, ch_sql=SQL_RECENT_SESSIONS,
            claude_only=False, use_capture=True, capture_nonce=None,
-           blocked_reader=None, blocked_path=None,
+           clawgate_reader=None, clawgate_path=None,
            use_ledger=True, ledger_outputs=None) -> dict:
     """Build the whole report. Every source is injectable, so this is the
     function the hermetic suite exercises end-to-end.
@@ -2665,8 +2665,8 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
                     "kinds_excluded_by_filter": None},
         # 🔴 The clawgate approval queue. Filled in below; the skeleton carries
         # a `status` from the first byte so no code path can publish a bare
-        # count. See `read_blocked_on_me` for the four outcomes.
-        "blocked_on_me": {"status": "skipped", "count": None,
+        # count. See `read_clawgate_queue` for the four outcomes.
+        "clawgate_queue": {"status": "skipped", "count": None,
                           "stuck_count": None, "schema_ok": False},
         # 🔴 The two limits that change what these rows MEAN, carried in the
         # payload rather than left in the skill body. See CAVEATS.
@@ -2910,8 +2910,8 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
     # reader is resolved AT CALL TIME (same reason as `ch_client_factory`
     # above): binding `_read_text` as a default would make the seam unpatchable
     # on the one path — `main()` -> `gather()` — with no injection point.
-    report["blocked_on_me"] = read_blocked_on_me(
-        path=blocked_path, reader=blocked_reader, now=now)
+    report["clawgate_queue"] = read_clawgate_queue(
+        path=clawgate_path, reader=clawgate_reader, now=now)
 
     # --- ClickHouse ----------------------------------------------------------
     if use_ch:
@@ -3099,7 +3099,7 @@ def _render_blocked_rows(b) -> list:
     return out
 
 
-def render_blocked_on_me(blocked) -> list:
+def render_clawgate_queue(queue) -> list:
     """🔴 The clawgate queue, with the count and its discriminant on one line.
 
     Printed unconditionally and in every state, because the failure this closes
@@ -3108,7 +3108,7 @@ def render_blocked_on_me(blocked) -> list:
     is blocked on you" is the exact substitution this script refuses everywhere
     else.
     """
-    b = blocked or {}
+    b = queue or {}
     st = b.get("status")
     count, out = b.get("count"), []
     if st == "ok":
@@ -3251,7 +3251,7 @@ def render_table(report) -> str:
     # This section exists because a dogfood agent, correctly reading that
     # `agent-ops` has no JSON API, never opened it and so missed 11 pending
     # approvals — four of them credential-exposure or cross-user-data-leak.
-    out.extend(render_blocked_on_me(report.get("blocked_on_me")))
+    out.extend(render_clawgate_queue(report.get("clawgate_queue")))
     out.append("")
 
     ch = report.get("clickhouse") or {}
@@ -3534,7 +3534,7 @@ def render_ledger(led) -> list:
 # should: a cheap payload that can LIE is worse than an expensive one. Every
 # null-vs-zero discriminator survives verbatim — `summary` (whose `waiting`
 # block carries the tri-state and `unmeasured_reasons`), `caveats` IN FULL,
-# `blocked_on_me`, `ledger`/`fuzzyclaw` section status, and per host
+# `clawgate_queue`, `ledger`/`fuzzyclaw` section status, and per host
 # `reachable`/`windows_measured`/`captures_status`. `caveats` costs ~586 tokens
 # and is the one thing standing between a cold agent and a fabricated zero; it
 # is the LAST thing to trim, not the first. What goes is duplication and
@@ -3623,7 +3623,7 @@ def render_not_measured(report) -> list:
     skill that owns it.
 
     🔴 PRINTED UNCONDITIONALLY, in every state, for the same reason
-    `render_blocked_on_me` is: the reader this exists for is the one who does
+    `render_clawgate_queue` is: the reader this exists for is the one who does
     not know the population exists. A section that appears only sometimes is one
     a reader learns not to expect, and the run where it would have mattered is
     exactly the run where everything else looked clean.

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -116,7 +116,7 @@ def test_hermeticity_fixture_is_actually_installed():
 def test_the_blocked_cache_seam_is_separate_from_the_general_file_reader():
     """🔴 The guard above is only real if the two seams are actually distinct.
 
-    If `read_blocked_on_me` were changed to call `_read_text` directly, the
+    If `read_clawgate_queue` were changed to call `_read_text` directly, the
     autouse raiser would stop covering it and every later test would be free to
     read the live machine again — with the suite still green, because the
     positive control above only proves the raiser is INSTALLED, not that the
@@ -124,10 +124,10 @@ def test_the_blocked_cache_seam_is_separate_from_the_general_file_reader():
     reader injected, the read must raise.
     """
     with pytest.raises(_Forbidden):
-        sm.read_blocked_on_me()
+        sm.read_clawgate_queue()
     # ...and an INJECTED reader must bypass the seam entirely, or every test
     # below is testing the raiser rather than the parser.
-    got = sm.read_blocked_on_me(path="/nope", reader=lambda p: None)
+    got = sm.read_clawgate_queue(path="/nope", reader=lambda p: None)
     assert got["status"] == "absent"
 
 
@@ -350,7 +350,7 @@ def base_gather(**kw):
         slots=SLOTS_FIXTURE,
         # The clawgate cache: absent by default, so no test inherits a value
         # that depends on the operator's real queue. Override per test.
-        blocked_reader=lambda p: None,
+        clawgate_reader=lambda p: None,
     )
     defaults.update(kw)
     return _REAL_GATHER(**defaults)
@@ -1707,7 +1707,7 @@ def test_json_golden_schema_and_values():
     assert blob["stale_threshold_secs"] == 3600
     assert set(blob) == {"ts", "local_host", "stale_threshold_secs", "hosts",
                          "clickhouse", "fuzzyclaw", "ledger", "filters",
-                         "caveats", "summary", "blocked_on_me",
+                         "caveats", "summary", "clawgate_queue",
                          # what this report contains NOTHING about, derived from
                          # the keys above rather than written down
                          "not_measured"}
@@ -1856,7 +1856,7 @@ def test_json_golden_schema_and_values():
         # fixture's environment), so the count is None with its discriminant —
         # and so is `stuck_count`, which is the same rule applied to the
         # stuck-dispatch half rather than a second, weaker one.
-        "blocked_on_me": {"count": None, "status": "absent",
+        "clawgate_queue": {"count": None, "status": "absent",
                           "stuck_count": None, "schema_ok": False},
         # 🔴 THE #419 METER, in the golden. One of these three windows has an
         # age and it came from fuzzyclaw — because this fixture runs
@@ -2026,6 +2026,168 @@ def test_stale_threshold_flows_from_the_argument_into_the_rows():
     # the row that moved is a CLAUDE row, so it moved on the claude half
     assert stale["summary"]["status"]["stale"] == {"claude": 1, "shell": 0,
                                                   "total": 1}
+
+
+# =========================================================================== #
+# §3.16b — the misnomer, banned structurally
+# =========================================================================== #
+def _all_keys(obj, out=None):
+    """Every dict key anywhere in a nested payload."""
+    if out is None:
+        out = set()
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            out.add(k)
+            _all_keys(v, out)
+    elif isinstance(obj, list):
+        for v in obj:
+            _all_keys(v, out)
+    return out
+
+
+def test_no_key_named_blocked_on_me_survives_at_ANY_depth():
+    """\U0001f534 THE MISNOMER, BANNED STRUCTURALLY, BECAUSE THE PROSE MITIGATION FAILED.
+
+    `report["blocked_on_me"]` held the CLAWGATE APPROVAL QUEUE, not "everything
+    waiting on you". This tool already carried a caveat saying exactly that,
+    whose own text called the wrong reading "the misread this entry exists to
+    prevent" — and a reader made that misread anyway, in a brief that then
+    shipped to three subagents. A field NAME is read a hundred times for every
+    once its caveat is. RULES.md: prefer the deterministic/structural fix over
+    the prose one. The name is now `clawgate_queue`; this is what stops the old
+    one coming back.
+
+    Walked over the WHOLE payload rather than the top level, because the
+    top-level key set is already pinned by the golden test while `lean_report`
+    is a SEPARATE builder — a key resurrected inside `summary` or inside the
+    lean projection would be invisible to that pin. Both surfaces here.
+
+    \U0001f534 POSITIVE CONTROL, and not decoration: a walker wired to nothing
+    returns an empty set, and `"blocked_on_me" not in set()` passes happily. The
+    control asserts the walker really finds the key that REPLACED the misnomer,
+    so an empty result cannot be read as a clean one.
+    """
+    report = base_gather()
+    for label, payload in (("full", report), ("lean", lean_of(report))):
+        keys = _all_keys(json.loads(json.dumps(payload, default=str)))
+        assert keys, "%s: the walker found NO keys — it is wired to nothing" % label
+        assert "clawgate_queue" in keys, (
+            "%s: POSITIVE CONTROL FAILED — the walker cannot see the key that "
+            "replaced the misnomer, so its verdict on the misnomer is worthless"
+            % label)
+        assert "blocked_on_me" not in keys, label
+
+
+def test_the_clawgate_queue_and_the_tmux_WAITING_count_stay_SEPARATE_populations():
+    """\U0001f534 A RELATIONSHIP, not a value. The rename fixes what the field is
+    CALLED; this pins what it must not BECOME.
+
+    The two answer different questions from different stores: `clawgate_queue`
+    is the approval queue read out of the bar-status cache, and
+    `summary.waiting.probable` is panes whose own tail looks like it is asking a
+    human something. Summing them, or sourcing either from the other, rebuilds
+    the exact conflation the rename removed.
+
+    🔴 DRIVEN OFF A POPULATED CACHE, and that is the whole point. The default
+    fixture leaves BOTH counts `None` — an earlier version of this test ran
+    against it and asserted a "separation" that a mutant aliasing one to the
+    other would have satisfied trivially, because `None == None`. `_cache()`
+    supplies 12 / stuck 1, values `waiting.probable` cannot produce here, so the
+    numbers have to disagree for this to pass.
+
+    🔴 `summary.clawgate_queue` IS a deliberate projection of the top-level
+    field, not a duplicate to be removed — the summary carries count WITH its
+    discriminant so a roll-up reader can tell "none pending" from "never
+    measured". So the invariant is that the projection MIRRORS, on every field
+    it republishes; a hardcoded value in either place breaks it.
+    """
+    report = base_gather(clawgate_reader=_cache())
+    top = report["clawgate_queue"]
+    proj = report["summary"]["clawgate_queue"]
+    waiting = report["summary"]["waiting"]
+
+    # The cache really did land — without this the mirror assertions below could
+    # be comparing None to None and pass with the reader unwired.
+    assert top["count"] == 12 and top["stuck_count"] == 1, top
+
+    # The projection mirrors, field for field.
+    for field in ("count", "status", "stuck_count", "schema_ok"):
+        assert proj[field] == top[field], (field, proj[field], top[field])
+
+    # ...and the tmux waiting population is untouched by any of it: a separate
+    # key, a separate shape, and a count that did NOT become 12.
+    assert set(waiting) >= {"probable", "measured", "unmeasured"}
+    assert waiting["probable"] != top["count"]
+    assert "waiting" not in top and "probable" not in proj
+
+
+def _payload_paths_in(text):
+    """Backticked tokens in a note that CLAIM to be payload paths.
+
+    Structural, not lexical: a token qualifies only if it is a dotted path or a
+    bare `snake_case` word, so prose like `list-panes` (hyphen) and
+    `--claude-only` (dashes) are not mistaken for keys. What comes back is a
+    list of things the note tells a JSON reader to go and look at.
+    """
+    import re as _re
+    out = []
+    for tok in _re.findall(r"`([^`]+)`", text):
+        if _re.fullmatch(r"[a-z_]+(?:\.[a-z_]+)+", tok):
+            out.append(tok)
+        elif _re.fullmatch(r"[a-z_]{3,}", tok):
+            out.append(tok)
+    return out
+
+
+def _resolves(report, path):
+    node = report
+    for part in path.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return False
+        node = node[part]
+    return True
+
+
+def test_every_payload_path_a_not_measured_NOTE_points_at_actually_EXISTS():
+    """\U0001f534 A CAVEAT IS A MACHINE-READABLE CLAIM, so its POINTERS are claims too.
+
+    These notes are what a `--json` consumer reads to find out what this tool did
+    not measure and where to look instead. This repo has already been bitten by a
+    caveat that went stale the moment the code changed
+    (`CAVEATS["fuzzyclaw_scope"]` told every consumer that remote rows carry null
+    `age_secs` — exactly the field the ledger had just started filling). A note
+    that says "see `summary.waiting.probable`" is worthless the day that key is
+    renamed, and nothing until now checked it.
+
+    Resolves each path against a REAL report rather than against a list of
+    expected names, so this cannot be satisfied by keeping a stale allowlist in
+    step with a stale note.
+
+    \U0001f534 BOTH CONTROLS. Positive: the extractor must find paths at all, and
+    they must be MORE than one, or a regex that quietly stopped matching would
+    read as "every pointer is valid". Negative: a note containing a path that
+    does NOT exist must be reported — otherwise `_resolves` returning True for
+    everything would look identical to a clean run.
+    """
+    report = base_gather()
+    notes = [p.get("note", "") for p in report["not_measured"]]
+    assert notes, "no not_measured entries — nothing was checked"
+
+    found = [pth for n in notes for pth in _payload_paths_in(n)]
+    assert len(found) > 1, (
+        "POSITIVE CONTROL FAILED — the extractor found %d payload paths across "
+        "%d notes; a pointer guard that finds nothing passes vacuously"
+        % (len(found), len(notes)))
+
+    broken = [pth for pth in found if not _resolves(report, pth)]
+    assert broken == [], (
+        "a not_measured note points at payload path(s) that do not exist: %s"
+        % broken)
+
+    # NEGATIVE CONTROL: a planted bad pointer must be caught by the same code.
+    planted = _payload_paths_in("see `summary.waiting.probable` and `no_such_key`")
+    assert "no_such_key" in planted, planted
+    assert [p for p in planted if not _resolves(report, p)] == ["no_such_key"]
 
 
 # =========================================================================== #
@@ -5217,7 +5379,7 @@ def _legacy_cache(**kw):
 
 
 def test_a_fresh_cache_is_ok_and_carries_the_count():
-    got = sm.read_blocked_on_me(reader=_cache(), now=NOW)
+    got = sm.read_clawgate_queue(reader=_cache(), now=NOW)
     assert got["status"] == "ok"
     assert got["count"] == 12
     assert got["cache_age_secs"] == 30
@@ -5230,7 +5392,7 @@ def test_a_fresh_cache_is_ok_and_carries_the_count():
 # one, plus the twin that must not.
 # --------------------------------------------------------------------------- #
 def test_a_schema2_cache_surfaces_the_stuck_dispatch_with_its_idle_time():
-    got = sm.read_blocked_on_me(reader=_cache(), now=NOW)
+    got = sm.read_clawgate_queue(reader=_cache(), now=NOW)
     assert got["schema_ok"] is True and got["schema_note"] is None
     assert got["stuck_count"] == 1
     assert got["stuck"] == [{"id": 173, "title": "wedged dispatch",
@@ -5244,7 +5406,7 @@ def test_a_schema2_cache_surfaces_the_stuck_dispatch_with_its_idle_time():
 def test_a_LEGACY_cache_reports_stuck_as_UNMEASURED_never_as_zero():
     """🔴 The exact substitution this whole script refuses, on the newest field.
     A poller that never looked for stuck dispatches did not find zero of them."""
-    got = sm.read_blocked_on_me(reader=_legacy_cache(), now=NOW)
+    got = sm.read_clawgate_queue(reader=_legacy_cache(), now=NOW)
     assert got["status"] == "ok", "the COUNT it does carry is still usable"
     assert got["count"] == 11
     assert got["schema"] is None and got["schema_ok"] is False
@@ -5260,7 +5422,7 @@ def test_a_LEGACY_cache_reports_stuck_as_UNMEASURED_never_as_zero():
 ])
 def test_the_schema_gate_is_measured_either_side_of_the_boundary(schema, ok):
     body = {} if schema is None else {"schema": schema}
-    got = sm.read_blocked_on_me(reader=_cache(**body) if schema is not None
+    got = sm.read_clawgate_queue(reader=_cache(**body) if schema is not None
                                 else _legacy_cache(), now=NOW)
     assert got["schema_ok"] is ok, schema
 
@@ -5268,9 +5430,9 @@ def test_the_schema_gate_is_measured_either_side_of_the_boundary(schema, ok):
 def test_a_schema2_cache_enumerates_ready_for_review_rather_than_folding_it_in():
     """🔴 Three finished tasks once appeared in NO list on any surface: the
     count moved and nothing said what had finished."""
-    got = sm.read_blocked_on_me(reader=_cache(), now=NOW)
+    got = sm.read_clawgate_queue(reader=_cache(), now=NOW)
     assert got["ready_for_review"] == [{"id": 172, "title": "finished item"}]
-    text = "\n".join(sm.render_blocked_on_me(got))
+    text = "\n".join(sm.render_clawgate_queue(got))
     assert "#172 REVIEW finished item" in text
     # and every open row is named too — not just the six the detail string caps
     for i in range(10):
@@ -5278,8 +5440,8 @@ def test_a_schema2_cache_enumerates_ready_for_review_rather_than_folding_it_in()
 
 
 def test_the_rendered_stuck_row_carries_the_idle_time_beside_the_flag():
-    text = "\n".join(sm.render_blocked_on_me(
-        sm.read_blocked_on_me(reader=_cache(), now=NOW)))
+    text = "\n".join(sm.render_clawgate_queue(
+        sm.read_clawgate_queue(reader=_cache(), now=NOW)))
     assert "1 STUCK dispatch(es)" in text
     assert "#173 idle 4h [agent_idle]" in text
     # 🔴 and it says what the measure cannot see, in the output itself
@@ -5292,8 +5454,8 @@ def test_a_stuck_row_at_sixteen_minutes_reads_differently_from_one_at_four_hours
     near = _cache(stuck=[{"id": 173, "title": "wedged dispatch",
                           "reasons": ["agent_idle"], "agent_idle_secs": 960}])
     far = _cache()
-    a = "\n".join(sm.render_blocked_on_me(sm.read_blocked_on_me(reader=near, now=NOW)))
-    b = "\n".join(sm.render_blocked_on_me(sm.read_blocked_on_me(reader=far, now=NOW)))
+    a = "\n".join(sm.render_clawgate_queue(sm.read_clawgate_queue(reader=near, now=NOW)))
+    b = "\n".join(sm.render_clawgate_queue(sm.read_clawgate_queue(reader=far, now=NOW)))
     assert "idle 16m" in a and "idle 4h" in b
     assert a != b
 
@@ -5306,7 +5468,7 @@ def test_a_schema2_cache_MISSING_the_stuck_key_is_still_None_not_empty():
     nothing was read."""
     body = {"schema": 2, "count": 3, "ts": NOW - 30, "state": "Warning",
             "detail": "3 need you"}
-    got = sm.read_blocked_on_me(reader=lambda p: json.dumps(body), now=NOW)
+    got = sm.read_clawgate_queue(reader=lambda p: json.dumps(body), now=NOW)
     assert got["status"] == "ok" and got["count"] == 3
     assert got["stuck"] is None and got["stuck_count"] is None
     assert got["ready_for_review"] is None and got["open"] is None
@@ -5314,7 +5476,7 @@ def test_a_schema2_cache_MISSING_the_stuck_key_is_still_None_not_empty():
 
 def test_the_RENDERER_also_says_UNMEASURED_for_a_schema2_cache_with_no_lists():
     """🔴 THE SAME BUG ONE LAYER DOWN, and the reason a reader test was not
-    enough. `read_blocked_on_me` preserves the None correctly (test above) — and
+    enough. `read_clawgate_queue` preserves the None correctly (test above) — and
     then `_render_blocked_rows` did `b.get("stuck") or []`, collapsing exactly
     the distinction the reader had just protected. Measured: this cache rendered
     a clean "3 clawgate task(s) needing you" with NO warning anywhere, while the
@@ -5325,8 +5487,8 @@ def test_the_RENDERER_also_says_UNMEASURED_for_a_schema2_cache_with_no_lists():
     """
     body = {"schema": 2, "count": 3, "ts": NOW - 30, "state": "Warning",
             "detail": "3 need you"}
-    got = sm.read_blocked_on_me(reader=lambda p: json.dumps(body), now=NOW)
-    text = "\n".join(sm.render_blocked_on_me(got))
+    got = sm.read_clawgate_queue(reader=lambda p: json.dumps(body), now=NOW)
+    text = "\n".join(sm.render_clawgate_queue(got))
     assert "NOT measured" in text or "NOT enumerated" in text, text
     assert "stuck" in text.lower()
     # …and it must not read as a measured all-clear.
@@ -5337,15 +5499,15 @@ def test_the_renderer_distinguishes_a_MEASURED_empty_queue_from_an_ABSENT_one():
     """🔴 THE DISCRIMINATING PAIR for the renderer. A measured-empty board and a
     cache that carries no lists at all must not produce the same text — that
     equality IS the bug."""
-    measured = sm.read_blocked_on_me(
+    measured = sm.read_clawgate_queue(
         reader=_cache(stuck=[], stuck_count=0, open=[], ready_for_review=[],
                       count=0), now=NOW)
-    absent_lists = sm.read_blocked_on_me(
+    absent_lists = sm.read_clawgate_queue(
         reader=lambda p: json.dumps({"schema": 2, "count": 3, "ts": NOW - 30,
                                      "state": "Warning", "detail": "3 need you"}),
         now=NOW)
-    a = "\n".join(sm.render_blocked_on_me(measured))
-    b = "\n".join(sm.render_blocked_on_me(absent_lists))
+    a = "\n".join(sm.render_clawgate_queue(measured))
+    b = "\n".join(sm.render_clawgate_queue(absent_lists))
     assert a != b
     assert "NOT measured" not in a and "NOT enumerated" not in a
     assert "NOT measured" in b or "NOT enumerated" in b
@@ -5370,8 +5532,8 @@ def test_EACH_absent_list_announces_itself_separately(missing):
         ready_for_review=[{"id": 192, "title": "queued beta"}],
         count=2, pending_count=2)("p"))
     del full[missing]
-    got = sm.read_blocked_on_me(reader=lambda p: json.dumps(full), now=NOW)
-    text = "\n".join(sm.render_blocked_on_me(got))
+    got = sm.read_clawgate_queue(reader=lambda p: json.dumps(full), now=NOW)
+    text = "\n".join(sm.render_clawgate_queue(got))
     assert missing in text, text
     assert "NOT measured" in text or "NOT enumerated" in text
 
@@ -5379,10 +5541,10 @@ def test_EACH_absent_list_announces_itself_separately(missing):
 def test_a_schema2_cache_with_zero_stuck_is_a_MEASURED_zero():
     """The other half of the discriminating control: `0` and `None` must not
     render the same, or the field is worthless."""
-    got = sm.read_blocked_on_me(
+    got = sm.read_clawgate_queue(
         reader=_cache(stuck=[], stuck_count=0, count=11), now=NOW)
     assert got["stuck_count"] == 0 and got["schema_ok"] is True
-    text = "\n".join(sm.render_blocked_on_me(got))
+    text = "\n".join(sm.render_clawgate_queue(got))
     assert "STUCK" not in text
     assert "UNMEASURED" not in text
 
@@ -5391,7 +5553,7 @@ def test_an_ABSENT_cache_is_None_and_NEVER_zero():
     """🔴 THE TOOL'S ENTIRE THESIS, applied to its newest source. A missing file
     rendering as "nothing is blocked on you" is the exact substitution every
     other section of this script exists to refuse."""
-    got = sm.read_blocked_on_me(reader=lambda p: None, now=NOW)
+    got = sm.read_clawgate_queue(reader=lambda p: None, now=NOW)
     assert got["status"] == "absent"
     assert got["count"] is None, "an unread queue is not an empty queue"
     assert got["error"] and "not measured" in got["error"].lower()
@@ -5400,7 +5562,7 @@ def test_an_ABSENT_cache_is_None_and_NEVER_zero():
 def test_an_UNPARSEABLE_cache_is_None_and_says_so():
     for body in ("{not json", "", "null", "[]", '{"state":"Warning"}',
                  '{"count":"12"}', '{"count":true}'):
-        got = sm.read_blocked_on_me(reader=lambda p, b=body: b, now=NOW)
+        got = sm.read_clawgate_queue(reader=lambda p, b=body: b, now=NOW)
         assert got["status"] == "unparseable", body
         assert got["count"] is None, body
 
@@ -5416,7 +5578,7 @@ def test_the_staleness_boundary_is_measured_at_more_than_one_point(age, status):
     """🔴 One measurement is not a claim about a threshold. Measured AT the
     boundary, one second either side, and well outside it — a comparison that
     is off by one is invisible from a single point."""
-    got = sm.read_blocked_on_me(reader=_cache(ts=NOW - age), now=NOW)
+    got = sm.read_clawgate_queue(reader=_cache(ts=NOW - age), now=NOW)
     assert got["status"] == status
     assert got["cache_age_secs"] == age
 
@@ -5424,7 +5586,7 @@ def test_the_staleness_boundary_is_measured_at_more_than_one_point(age, status):
 def test_a_STALE_cache_still_carries_its_number_but_never_calls_it_current():
     """The count is real, just possibly old — dropping it would lose signal,
     and publishing it as `ok` would fabricate freshness. Both, labelled."""
-    got = sm.read_blocked_on_me(reader=_cache(ts=NOW - 9999), now=NOW)
+    got = sm.read_clawgate_queue(reader=_cache(ts=NOW - 9999), now=NOW)
     assert got["status"] == "stale"
     assert got["count"] == 12
     assert "out of date" in got["error"]
@@ -5434,7 +5596,7 @@ def test_a_STALE_cache_still_carries_its_number_but_never_calls_it_current():
 def test_a_cache_whose_AGE_cannot_be_established_is_stale_not_ok(ts):
     """🔴 The conservative direction. A count whose freshness is unknowable is
     not a fresh count; calling it `ok` is a guess about the writer."""
-    got = sm.read_blocked_on_me(reader=_cache(ts=ts), now=NOW)
+    got = sm.read_clawgate_queue(reader=_cache(ts=ts), now=NOW)
     assert got["status"] == "stale"
     assert got["cache_age_secs"] is None
     assert "freshness" in got["error"]
@@ -5447,7 +5609,7 @@ def test_the_detail_string_is_NEVER_parsed_for_a_count():
     DISAGREES with itself: 11 pending, 6 named. Anything deriving the number
     from the string reports 6 and loses five tasks silently.
     """
-    got = sm.read_blocked_on_me(reader=_legacy_cache(), now=NOW)
+    got = sm.read_clawgate_queue(reader=_legacy_cache(), now=NOW)
     assert got["count"] == 11, "the count is the measurement, not the string"
     assert got["detail"].count("#") == 6, "fixture must actually be truncated"
     assert got["detail_truncated"] is True
@@ -5458,7 +5620,7 @@ def test_a_schema2_detail_string_STATES_its_own_truncation():
     """🔴 Item 5. The old string named six of eleven with no hint any were
     missing, and the dropped tail has included `ready_for_review` work. The new
     one says `(+N more)` AND the full sets travel structurally beside it."""
-    got = sm.read_blocked_on_me(reader=_cache(), now=NOW)
+    got = sm.read_clawgate_queue(reader=_cache(), now=NOW)
     assert "(+6 more)" in got["detail"]
     assert got["detail_shown"] == 6 and got["detail_total"] == 12
     # the note is gone precisely because the lists are present
@@ -5471,14 +5633,14 @@ def test_a_real_measured_zero_is_distinguishable_from_an_absent_cache():
     """🔴 THE DISCRIMINATING CONTROL. Both are "no pending approvals" to a
     careless reader; only one of them is a measurement, and the renderer must
     not spell them the same."""
-    zero = sm.read_blocked_on_me(
+    zero = sm.read_clawgate_queue(
         reader=_cache(count=0, pending_count=0, stuck_count=0, open=[],
                       ready_for_review=[], stuck=[], detail=None), now=NOW)
-    absent = sm.read_blocked_on_me(reader=lambda p: None, now=NOW)
+    absent = sm.read_clawgate_queue(reader=lambda p: None, now=NOW)
     assert zero["status"] == "ok" and zero["count"] == 0
     assert absent["status"] == "absent" and absent["count"] is None
-    a = "\n".join(sm.render_blocked_on_me(zero))
-    b = "\n".join(sm.render_blocked_on_me(absent))
+    a = "\n".join(sm.render_clawgate_queue(zero))
+    b = "\n".join(sm.render_clawgate_queue(absent))
     assert a != b
     assert "a measured zero" in a and "UNMEASURED" not in a
     assert "UNMEASURED" in b and "NOT zero pending" in b
@@ -5490,7 +5652,7 @@ def test_the_blocked_section_is_rendered_in_EVERY_state():
     is one nobody learns to look for."""
     for reader in (_cache(), _cache(count=0), _cache(ts=NOW - 9999),
                    lambda p: None, lambda p: "{broken"):
-        rep = base_gather(blocked_reader=reader, now=NOW)
+        rep = base_gather(clawgate_reader=reader, now=NOW)
         text = sm.render_table(rep)
         assert "▸ BLOCKED ON ME" in text
 
@@ -5527,7 +5689,7 @@ def test_the_rendered_queue_points_the_reader_AT_A_LIVE_SURFACE_for_the_full_lis
       * unmeasured -> a live surface MUST be named; that is the whole render.
     """
     live = ("clawgate API", "clawgate pill")
-    text = sm.render_table(base_gather(blocked_reader=_cache(), now=NOW))
+    text = sm.render_table(base_gather(clawgate_reader=_cache(), now=NOW))
     assert "12 clawgate task(s) needing you" in text
     assert "agent-ops" not in text, "the render points at a retired tool"
     # what this render owes instead of a pointer: the queue itself, enumerated
@@ -5535,56 +5697,56 @@ def test_the_rendered_queue_points_the_reader_AT_A_LIVE_SURFACE_for_the_full_lis
     assert "#173 idle 4h" in text, text
 
     # 🔴 the branch the mutant survived in: a real count whose detail truncates
-    legacy = sm.render_table(base_gather(blocked_reader=_legacy_cache(), now=NOW))
+    legacy = sm.render_table(base_gather(clawgate_reader=_legacy_cache(), now=NOW))
     assert "11 clawgate task(s) needing you" in legacy
     assert "agent-ops" not in legacy
     assert any(s in legacy for s in live), legacy
 
     # and the same when the count could NOT be read — that is exactly when a
     # reader most needs somewhere else to look
-    absent = sm.render_table(base_gather(blocked_reader=lambda p: None))
+    absent = sm.render_table(base_gather(clawgate_reader=lambda p: None))
     assert "agent-ops" not in absent
     assert any(s in absent for s in live), absent
 
 
 def test_the_summary_carries_the_count_WITH_its_discriminant():
     """The count never travels alone, in the roll-up any consumer reads first."""
-    ok = base_gather(blocked_reader=_cache(), now=NOW)
-    assert ok["summary"]["blocked_on_me"] == {"count": 12, "status": "ok",
+    ok = base_gather(clawgate_reader=_cache(), now=NOW)
+    assert ok["summary"]["clawgate_queue"] == {"count": 12, "status": "ok",
                                               "stuck_count": 1,
                                               "schema_ok": True}
-    gone = base_gather(blocked_reader=lambda p: None, now=NOW)
-    assert gone["summary"]["blocked_on_me"] == {"count": None,
+    gone = base_gather(clawgate_reader=lambda p: None, now=NOW)
+    assert gone["summary"]["clawgate_queue"] == {"count": None,
                                                 "status": "absent",
                                                 "stuck_count": None,
                                                 "schema_ok": False}
     # 🔴 And a legacy cache: a real count, but `stuck_count` None — a roll-up
     # reader must be able to tell "no wedged dispatches" from "never looked".
-    old = base_gather(blocked_reader=_legacy_cache(), now=NOW)
-    assert old["summary"]["blocked_on_me"] == {"count": 11, "status": "ok",
+    old = base_gather(clawgate_reader=_legacy_cache(), now=NOW)
+    assert old["summary"]["clawgate_queue"] == {"count": 11, "status": "ok",
                                                "stuck_count": None,
                                                "schema_ok": False}
 
 
 def test_the_blocked_reader_is_resolved_at_CALL_time_not_bound_as_a_default():
     """🔴 The same hole `ch_client_factory` had, on a new seam. A default of
-    `blocked_reader=_read_blocked_text` would capture the ORIGINAL function at
+    `clawgate_reader=_read_blocked_text` would capture the ORIGINAL function at
     def time, so the autouse hermeticity raiser would NOT be honoured on the
     one path with no injection point — `main()` -> `gather()` — and the suite
     would quietly read the operator's live queue while staying green."""
     import inspect
     params = inspect.signature(sm.gather).parameters
-    assert params["blocked_reader"].default is None
-    assert params["blocked_path"].default is None
+    assert params["clawgate_reader"].default is None
+    assert params["clawgate_path"].default is None
     with pytest.raises(_Forbidden):
-        base_gather(blocked_reader=None)
+        base_gather(clawgate_reader=None)
 
 
 def test_the_cache_path_is_the_bar_pollers_and_is_not_hardcoded_elsewhere():
     """One constant, so the poller and the reader cannot drift apart."""
     assert sm.BLOCKED_CACHE.endswith("/.cache/bar-status/clawgate.json")
     seen = {}
-    sm.read_blocked_on_me(reader=lambda p: seen.setdefault("path", p) and None,
+    sm.read_clawgate_queue(reader=lambda p: seen.setdefault("path", p) and None,
                           now=NOW)
     assert seen["path"] == sm.BLOCKED_CACHE
 
@@ -5640,7 +5802,7 @@ def test_fuzzyclaw_is_OFF_by_default_and_publishes_None_not_zero():
         is False
     rep = _REAL_GATHER(hosts=("workbench",), local_host="workbench",
                        runner=make_runner(), use_ch=False, now=NOW,
-                       slots={}, blocked_reader=lambda p: None)
+                       slots={}, clawgate_reader=lambda p: None)
     assert rep["fuzzyclaw"]["status"] == "skipped"
     assert rep["fuzzyclaw"]["files_seen"] is None
     assert rep["summary"]["fuzzyclaw_live"] is None
@@ -5666,7 +5828,7 @@ def test_the_fuzzyclaw_flags_compose_with_explicit_OFF_winning(
         seen.update(kw)
         return _REAL_GATHER(**dict(kw, runner=make_runner(),
                                    fuzzyclaw_texts=[], slots={},
-                                   blocked_reader=lambda p: None, now=NOW))
+                                   clawgate_reader=lambda p: None, now=NOW))
     monkeypatch.setattr(sm, "gather", fake_gather)
     sm.main(["scan", "--host", "workbench", "--no-ch", *argv])
     assert seen["use_fuzzyclaw"] is expect_on
@@ -5682,7 +5844,7 @@ def test_no_capture_flag_reaches_gather(monkeypatch, absent_blocked_cache):
     def fake_gather(**kw):
         seen.update(kw)
         return _REAL_GATHER(**dict(kw, runner=make_runner(), slots={},
-                                   blocked_reader=lambda p: None, now=NOW))
+                                   clawgate_reader=lambda p: None, now=NOW))
     monkeypatch.setattr(sm, "gather", fake_gather)
     sm.main(["scan", "--host", "workbench", "--no-ch", "--no-capture"])
     assert seen["use_capture"] is False
@@ -6318,7 +6480,7 @@ def test_the_lean_view_keeps_EVERY_null_vs_zero_discriminator():
                          ledger_outputs={"workbench": None})
     lean = lean_of(full)
 
-    for key in ("summary", "caveats", "blocked_on_me", "ledger", "fuzzyclaw",
+    for key in ("summary", "caveats", "clawgate_queue", "ledger", "fuzzyclaw",
                 "filters", "local_host", "ts"):
         assert key in lean, key
     # the caveats survive IN FULL, not as a pointer to somewhere else
@@ -6404,7 +6566,7 @@ def test_the_lean_view_shrinks_the_ROWS_which_is_where_the_payload_lives():
     """🔴 ASSERTED ON THE ROWS, not on the whole payload, and the first draft of
     this test got that wrong. Rows are 86% of a real payload (52,564 B of
     60,631 B on a 75-row scan) and are the only part lean trims — the fixed
-    sections (`caveats`, `blocked_on_me`, `summary`) are kept ON PURPOSE.
+    sections (`caveats`, `clawgate_queue`, `summary`) are kept ON PURPOSE.
 
     So whole-payload saving SCALES WITH ROW COUNT: 36% measured live at 75
     rows, but only ~12% on this 3-row fixture, where the retained fixed cost
@@ -6429,7 +6591,7 @@ def test_the_lean_view_shrinks_the_ROWS_which_is_where_the_payload_lives():
                                                    rowbytes(full))
     # ...and the retained fixed sections really are byte-identical, so the
     # saving above came from trimming rows and nothing else.
-    for key in ("caveats", "summary", "blocked_on_me"):
+    for key in ("caveats", "summary", "clawgate_queue"):
         assert enc(lean[key]) == enc(full[key]), key
 
 
@@ -6506,7 +6668,7 @@ def test_the_retained_TOP_LEVEL_set_is_pinned_in_both_directions():
         # dropped it would be a smaller payload that reads as more complete —
         # the exact trade this view's own rule forbids.
         "not_measured",
-        "blocked_on_me", "view", "lean_row_fields", "lean_host_fields",
+        "clawgate_queue", "view", "lean_row_fields", "lean_host_fields",
     }
 
 
@@ -7392,14 +7554,14 @@ def test_the_kind_scope_NOTE_names_NO_kind_at_all():
             f"will contradict the measured `kinds_produced` after writer 3")
     # ...and it must still do its job, or "names no kind" is satisfied by ""
     assert "MEASURED" in note and "kinds_produced" in note
-    assert "blocked_on_me" in note
+    assert "clawgate_queue" in note
     assert len(note) > 200
 
 
 def test_the_kind_scope_NOTE_is_pinned_WHOLE():
     """The structural guard above bans naming a kind; this pins everything
     else, so a reword that keeps the kinds out but drops the pointer to
-    `blocked_on_me` — or reintroduces a scope claim in other words — fails."""
+    `clawgate_queue` — or reintroduces a scope claim in other words — fails."""
     assert sm.CAVEATS["kind_scope"]["note"] == (
         "`kinds_produced` is MEASURED from this scan's rows — read it rather "
         "than assuming. A kind that is enumerated but absent from "
@@ -7407,7 +7569,7 @@ def test_the_kind_scope_NOTE_is_pinned_WHOLE():
         "NOT a measured absence of that work — UNLESS it is named in "
         "`kinds_excluded_by_filter`, which is where a kind removed by a filter "
         "is reported instead of being silently attributed to the build. For "
-        "clawgate use report.blocked_on_me (tasks needing the operator, and "
+        "clawgate use report.clawgate_queue (tasks needing the operator, and "
         "its `stuck_count` for wedged dispatches), a different population from "
         "these rows that is never double-counted with them.")
 
@@ -7456,7 +7618,7 @@ def test_the_kind_scope_NOTE_does_not_restate_the_measured_field():
     assert "cluster is ENUMERATED but NOT PRODUCED" not in note
     # it still has to say the durable part, or the field loses its meaning
     assert "NOT a measured absence" in note
-    assert "blocked_on_me" in note
+    assert "clawgate_queue" in note
 
 
 def _under_seed(seed, expr):
@@ -9082,7 +9244,7 @@ def test_the_docstring_documents_the_shell_pane_DECISION_not_just_the_behaviour(
 # =========================================================================== #
 _GATHER_REPORT_KEYS = {
     "ts", "local_host", "stale_threshold_secs", "hosts", "clickhouse",
-    "fuzzyclaw", "ledger", "filters", "blocked_on_me", "caveats", "summary",
+    "fuzzyclaw", "ledger", "filters", "clawgate_queue", "caveats", "summary",
     "not_measured",
 }
 
@@ -9321,7 +9483,7 @@ def test_the_not_measured_key_is_in_the_report_and_names_the_two_required_ones()
     # 🔴 the note carries the EVIDENCE, not just the label — a reader deciding
     # whether to spend a hop needs to know what is at stake behind the name
     assert "conflicting" in pops["pull_requests"]["note"].lower()
-    # and clawgate is NOT re-listed: `blocked_on_me` measures it
+    # and clawgate is NOT re-listed: `clawgate_queue` measures it
     assert "clawgate" not in pops
     # nor is the opencode misclassification, which is a measured population
     # reported under the wrong class, not an unmeasured one


### PR DESCRIPTION
## The defect, and the measurement that it is real

`report["blocked_on_me"]` was the **clawgate approval queue**, read from the bar-status cache. It was never "everything waiting on you".

The tool already said so. A note in its own `not_measured` payload read:

> *"`blocked_on_me` is the CLAWGATE approval queue only — it is not a general 'everything waiting on you' number, and reading it as one is the misread this entry exists to prevent."*

**That prose mitigation failed under test.** While answering "which of my ClickUp tickets are being worked on", a reader took `blocked_on_me` as the count of tmux windows waiting on a human, wrote it into a brief, and shipped that brief to three subagents. One of them refuted it by quoting the tool's own caveat back. The signal actually wanted is `summary.waiting.probable` — a different population, never summed with this one.

A field **name** is read a hundred times for every once its caveat is. RULES.md says prefer the deterministic/structural fix over the prose one, so the name changed rather than the wording.

## What changed

- `report["blocked_on_me"]` → `report["clawgate_queue"]`, and its `summary` projection with it.
- `read_blocked_on_me` → `read_clawgate_queue`, `render_blocked_on_me` → `render_clawgate_queue`, `gather(blocked_reader=, blocked_path=)` → `gather(clawgate_reader=, clawgate_path=)`. **The kwargs too, deliberately** — leaving `blocked_*` in the signature is how the next reader re-derives the same confusion.
- **No alias.** The old key is gone rather than deprecated: an absent key raises at the consumer, a wrong one gets published.
- The `not_measured` note no longer argues against its own field name — it points at **both** populations (`clawgate_queue` for approvals, `summary.waiting.probable` for panes) and says neither covers mail.
- `SKILL.md` documents the rename *and* where to look for the thing people actually meant. `claudedocs/design-ledger-writer3-and-kind-2026-08-14.md`'s non-overlap statements updated so they don't go stale.

### What I proposed and did NOT build

I originally suggested promoting a top-level `waiting_on_human` count. I dropped it: `summary.waiting` already carries the count **with** its tri-state (`probable`/`measured`/`unmeasured`), and a second home for the same number invites reading it without its discriminant — the exact defect class this file's own comments say it has shipped five times. The rename plus the corrected note gets there without a duplicate.

## Three new guards, each watched to fail

1. **`test_no_key_named_blocked_on_me_survives_at_ANY_depth`** — walks the whole payload, full view *and* `lean_report` (a separate builder the top-level golden pin cannot see). 🔴 With a positive control, because a walker wired to nothing returns an empty set and `"blocked_on_me" not in set()` passes happily; the control asserts it really finds the key that *replaced* the misnomer.
2. **`test_the_clawgate_queue_and_the_tmux_WAITING_count_stay_SEPARATE_populations`** — `summary.clawgate_queue` is a deliberate projection (count *with* its discriminant, so a roll-up reader can tell "none pending" from "never measured"), so the pin is that it mirrors field-for-field and the tmux count is untouched. 🔴 Driven off `_cache()` (count 12, stuck 1), **not** the default fixture: in `base_gather()` both counts are `None`, and my first version asserted a "separation" that `None == None` satisfied trivially — an aliasing mutant would have survived it.
3. **`test_every_payload_path_a_not_measured_NOTE_points_at_actually_EXISTS`** — a caveat is a machine-readable claim, so its *pointers* are claims too. Every backticked payload path in a note is resolved against a real report. Both controls: more than one path must be found (a regex that quietly stopped matching would read as "every pointer is valid"), and a planted `no_such_key` must be reported unresolvable.

## A separate finding this surfaced

**`not_measured[*].note` was entirely unguarded.** Rewording that note to *"waiting on a human see NOTHING AT ALL"* passed all 569 tests. `test_the_NOT_MEASURED_section_is_pinned_as_a_WHOLE_normalised_string` is **not** at fault — it pins the *rendered* `population -> /skill` block, completely, and the note text is never rendered in the table; it lives only in the JSON. I misread its scope before checking. Guard 3 closes the hole.

## Mutation matrix

Green baseline 570, mutation proven to land, module imported first so a syntax error can't score as a kill, `__pycache__` purged before every scored run.

| mutant | verdict |
|---|---|
| M1 `blocked_on_me` back at top level | **KILLED** (8, incl. guard 1) |
| M2 `blocked_on_me` back *inside* `summary` | **KILLED** (4, incl. guard 1) |
| M3 summary projection hardcodes `count` | **KILLED** (3, incl. guard 2) |
| M4 `summary.waiting` renamed → note pointer rots | **KILLED** (17) |
| M5 note reworded so its pointers vanish | **KILLED** (1, guard 3) |

M4's 17 failures are mostly pre-existing waiting tests, and "something went red" is not evidence *this* guard did — so I re-ran M4 with `-k` selecting only guard 3 and confirmed it fails on its own.

**Honest limit on guard 3:** it pins *pointers*, not prose. A reword that keeps valid pointers still passes, and M5 was caught by the `found > 1` positive control rather than by any prose pin. A note that becomes misleading while still naming real keys is not covered.

## Verification

```
scripts/gate.sh --tier both --set hermetic
  TOTAL collected=11675  passed=11673  skipped=1  failed=1   (was 11672 — +3, the new guards)
  NODE: suites=4 files=33 tests=1116 pass=1116 fail=0        RESULT: PASS
```

**The one failure is pre-existing and unrelated**: `test_opencode_engine.py` asserts `opencode` on PATH matches `PINNED_VERSION = "1.18.16"`; this host has 1.18.18. `git diff origin/main -- scripts/tests/test_opencode_engine.py` is **0 lines** on this branch. Same failure as #530.

## Process notes

Two self-inflicted errors, both caught, both worth recording since they are repo-documented classes:

- **An insertion anchored mid-function.** My first attempt to add the guards anchored on a line inside `test_json_golden_schema_and_values`, which **compiled fine** while silently moving half that test's assertions into a new function where `blob` was undefined. `py_compile` passing is not a correctness check. Fixed by anchoring on a section header and asserting the anchor is unique.
- **A param rename that broke its own body.** Renaming `render_blocked_on_me(blocked)` → `(queue)` left `b = blocked or {}` further down; I had grepped only 8 lines past the `def` and concluded the body used another name. 73 tests went red and named it immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
