### PR TITLE
fix(obs-read): retry port-forward on local-port bind collision

### DIFF
--- a/claude/skills/obs-read/SKILL.md
+++ b/claude/skills/obs-read/SKILL.md
@@ -85,7 +85,12 @@ validated preset; treat unvalidated ones as starting points.
 - `--since` applies to range/profile queries (Loki, Pyroscope, `--kind range`).
 - Signal-safe teardown: kubectl runs in its own session and is torn down by
   killing the process group on success/error/SIGINT/SIGTERM (no leaked tunnel).
-- Known limitations (documented, unchanged): a matched-nothing result still exits
-  0 (check the `--json` `matched_nothing`/`warning` fields to fail a pipeline);
-  `_free_port` has a sub-ms TOCTOU window (kubectl fails loudly, surfaced via its
-  captured stderr, if the port is taken).
+- Concurrency-safe local port: `_free_port` is TOCTOU by construction (the probe
+  socket closes before kubectl binds), so `PortForward.__enter__` RETRIES up to
+  `PF_ATTEMPTS` (3) times on a freshly-picked port when — and only when —
+  kubectl died with a bind collision, reaping each failed attempt's process
+  first. Concurrent obs-read runs no longer lose a race. Every other failure
+  (missing service, wrong namespace, RBAC denial, backend never ready) still
+  surfaces on the FIRST attempt with kubectl's own message unchanged.
+- Known limitation (documented, unchanged): a matched-nothing result still exits
+  0 — check the `--json` `matched_nothing`/`warning` fields to fail a pipeline.

--- a/scripts/obs-read
+++ b/scripts/obs-read
@@ -619,16 +619,47 @@ def build_url(backend: str, port: int, query: str, kind: str,
 # Transport (the only non-pure part; injectable for tests)
 # --------------------------------------------------------------------------- #
 def _free_port() -> int:
-    # KNOWN LIMITATION (TOCTOU): we pick a free port, close the socket, then hand
-    # the number to kubectl — a racing process could grab it in between. In
-    # practice the window is sub-ms and kubectl fails loudly (surfaced via the
-    # captured stderr on early-exit) if the port is taken, so this is left as a
-    # documented known limitation rather than a bind-and-hold handoff.
+    # TOCTOU by construction: we pick a free port, close the socket, then hand
+    # the number to kubectl — a racing process (another agent running obs-read
+    # concurrently) can grab it in between. We do NOT bind-and-hold (kubectl
+    # needs to bind it itself), so the race is closed one level up instead:
+    # PortForward.__enter__ RETRIES with a freshly-picked port when kubectl dies
+    # with a bind collision (see _is_port_collision / PF_ATTEMPTS). Any other
+    # kubectl failure still surfaces on the first attempt, unretried.
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.bind(("127.0.0.1", 0))
     port = s.getsockname()[1]
     s.close()
     return port
+
+
+# How many times PortForward.__enter__ will re-pick a local port and relaunch
+# kubectl when — and ONLY when — the previous attempt died on a bind collision.
+PF_ATTEMPTS = 3
+
+# Substrings of kubectl's own stderr that mean "the local port I was told to
+# bind was already taken". kubectl prints both lines on a collision:
+#   Unable to listen on port N: ... [unable to create listener: Error listen
+#     tcp4 127.0.0.1:N: bind: address already in use]
+#   error: unable to listen on any of the requested ports: [{N M}]
+# _drain_stderr keeps only the LAST non-empty line, so match either.
+_PORT_COLLISION_MARKERS = (
+    "unable to listen on any of the requested ports",
+    "address already in use",
+)
+
+
+def _is_port_collision(exc: BaseException) -> bool:
+    """True ONLY for a local-port bind collision — the one failure that a retry
+    on a different port can fix.
+
+    Everything else (service not found, wrong namespace, RBAC denial, backend
+    never became ready, SIGTERM) is a genuine failure: retrying it would mask a
+    real error and triple the time-to-error on the commonest misconfiguration,
+    so it must propagate on the FIRST attempt.
+    """
+    text = str(exc).lower()
+    return any(marker in text for marker in _PORT_COLLISION_MARKERS)
 
 
 def _http_get(url: str, timeout: float = 15.0) -> dict:
@@ -742,6 +773,12 @@ class PortForward:
     signal can never orphan the tunnel. popen/wait_ready are injectable so the
     whole lifecycle (incl. cleanup-on-error and the KUBECONFIG override) is
     unit-tested offline.
+
+    Local-port selection is racy by construction (_free_port closes its probe
+    socket before kubectl binds the number), so __enter__ retries up to
+    PF_ATTEMPTS times on a BIND COLLISION only — reaping each failed attempt's
+    kubectl first. Any other failure (missing service, RBAC denial, backend not
+    ready) propagates unchanged on the first attempt.
     """
 
     def __init__(self, kubeconfig: str, backend: Backend, *,
@@ -756,25 +793,42 @@ class PortForward:
         self.local_port = None
 
     def __enter__(self) -> int:
-        self.local_port = _free_port()
-        # The KUBECONFIG override IS the "can't hit the ambient/wrong cluster"
-        # guarantee: whatever KUBECONFIG is in the ambient env, this forces the
-        # named cluster's kubeconfig for the kubectl child. start_new_session
-        # puts kubectl in its own process group so _terminate can killpg it.
-        env = dict(os.environ, KUBECONFIG=self.kubeconfig)
-        argv = ["kubectl", "-n", self.backend.namespace, "port-forward",
-                "svc/%s" % self.backend.service,
-                "%d:%d" % (self.local_port, self.backend.remote_port)]
-        self.proc = self._popen(
-            argv, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, env=env,
-            start_new_session=True)
-        try:
-            self._wait_ready(self.local_port, self.backend.ready_path,
-                             self._startup_timeout, self.proc)
-        except BaseException:
-            self._terminate()
-            raise
-        return self.local_port
+        # Bounded retry that closes the _free_port() TOCTOU race: a port picked
+        # here can be stolen before kubectl binds it (concurrent obs-read runs).
+        # ONLY a bind collision is retried, on a freshly-picked port; every other
+        # failure is re-raised unchanged on the first attempt.
+        for attempt in range(1, PF_ATTEMPTS + 1):
+            self.local_port = _free_port()
+            # The KUBECONFIG override IS the "can't hit the ambient/wrong
+            # cluster" guarantee: whatever KUBECONFIG is in the ambient env,
+            # this forces the named cluster's kubeconfig for the kubectl child.
+            # start_new_session puts kubectl in its own process group so
+            # _terminate can killpg it.
+            env = dict(os.environ, KUBECONFIG=self.kubeconfig)
+            argv = ["kubectl", "-n", self.backend.namespace, "port-forward",
+                    "svc/%s" % self.backend.service,
+                    "%d:%d" % (self.local_port, self.backend.remote_port)]
+            self.proc = self._popen(
+                argv, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+                env=env, start_new_session=True)
+            try:
+                self._wait_ready(self.local_port, self.backend.ready_path,
+                                 self._startup_timeout, self.proc)
+            except BaseException as exc:
+                # Reap THIS attempt's kubectl before doing anything else — a
+                # retry must never leave a port-forward process behind.
+                self._terminate()
+                if not _is_port_collision(exc):
+                    raise
+                if attempt >= PF_ATTEMPTS:
+                    raise RuntimeError(
+                        "kubectl port-forward: local port collision on all %d "
+                        "attempts — a freshly-picked free local port was taken "
+                        "before kubectl could bind it every time (last error: "
+                        "%s)" % (PF_ATTEMPTS, exc)) from exc
+                continue
+            return self.local_port
+        raise AssertionError("unreachable")  # pragma: no cover
 
     def __exit__(self, *exc):
         self._terminate()

--- a/scripts/tests/test_obs_read.py
+++ b/scripts/tests/test_obs_read.py
@@ -511,6 +511,165 @@ def test_kill_process_group_noop_without_pid():
 
 
 # =========================================================================== #
+# Local-port TOCTOU — bounded retry on a BIND COLLISION only
+#
+# _free_port() closes its probe socket before kubectl binds the number, so a
+# concurrent obs-read can steal it. __enter__ re-picks and relaunches, but ONLY
+# for a collision: a genuine failure (RBAC, missing svc, backend never ready)
+# must surface on the FIRST attempt, unretried and unrewritten.
+# =========================================================================== #
+# Verbatim kubectl stderr for a local-port collision (it prints BOTH lines;
+# _drain_stderr keeps only the LAST non-empty one).
+KUBECTL_COLLISION_STDERR = (
+    "Unable to listen on port 45011: Listeners failed to create with the "
+    "following errors: [unable to create listener: Error listen tcp4 "
+    "127.0.0.1:45011: bind: address already in use]\n"
+    "error: unable to listen on any of the requested ports: [{45011 9090}]\n"
+)
+# A genuine, NON-retryable failure.
+KUBECTL_RBAC_STDERR = (
+    'error: services "kube-prometheus-stack-prometheus" is forbidden: User '
+    '"system:serviceaccount:default:default" cannot get resource "services" '
+    'in API group "" in the namespace "monitoring"\n'
+)
+
+
+class _PFAttempts:
+    """popen stub recording one FakeProc per attempt.
+
+    `stderrs[i]` scripts attempt i to die early with that kubectl stderr; any
+    attempt past the end of the list gets a LIVE proc (i.e. succeeds).
+    """
+
+    def __init__(self, stderrs):
+        self.stderrs = list(stderrs)
+        self.ports = []          # local port used by each attempt, in order
+        self.procs = []          # the FakeProc handed to each attempt
+
+    def popen(self, argv, **kw):
+        # argv's last element is the "<local>:<remote>" port mapping
+        self.ports.append(int(argv[-1].split(":")[0]))
+        i = len(self.procs)
+        if i < len(self.stderrs):
+            proc = FakeProc(alive=False, stderr_text=self.stderrs[i])
+        else:
+            proc = FakeProc()    # alive -> ready
+        self.procs.append(proc)
+        return proc
+
+
+def _wait_ready_faithful(port, ready_path, timeout, proc=None):
+    """Stand-in for _wait_ready that routes an early-exited proc through the
+    REAL _wait_ready — so the error TEXT the retry discriminates on is produced
+    by production code, not by the test. A live proc is treated as ready."""
+    if proc is not None and proc.poll() is not None:
+        obs._wait_ready(port, ready_path, 0.5, proc)   # raises RuntimeError
+    return None
+
+
+def _pf_with(handler, ports, monkeypatch, backend="prometheus"):
+    it = iter(ports)
+    monkeypatch.setattr(obs, "_free_port", lambda: next(it))
+    return obs.PortForward("/kc", obs.BACKENDS[backend],
+                           popen=handler.popen,
+                           wait_ready=_wait_ready_faithful)
+
+
+def test_is_port_collision_discriminates(monkeypatch):
+    # both shapes kubectl can leave as the last stderr line
+    assert obs._is_port_collision(RuntimeError(
+        "kubectl port-forward exited early: error: unable to listen on any of "
+        "the requested ports: [{45011 9090}]")) is True
+    assert obs._is_port_collision(RuntimeError(
+        "kubectl port-forward exited early: Unable to listen on port 45011: "
+        "... bind: address already in use]")) is True
+    # everything that a different port cannot fix
+    for other in (
+        'kubectl port-forward exited early: Error from server (NotFound): '
+        'services "pyroscope" not found',
+        "kubectl port-forward exited early: " + KUBECTL_RBAC_STDERR.strip(),
+        "backend not ready on 127.0.0.1:45011/ready in 10s (timed out)",
+        "kubectl port-forward exited early",
+    ):
+        assert obs._is_port_collision(RuntimeError(other)) is False
+    assert obs._is_port_collision(TimeoutError("never became ready")) is False
+
+
+def test_port_forward_retries_collision_on_a_different_port(monkeypatch):
+    # attempt 1 loses the race; attempt 2 must use a DIFFERENT port and win.
+    h = _PFAttempts([KUBECTL_COLLISION_STDERR])
+    pf = _pf_with(h, [45011, 45013, 45017], monkeypatch)
+    with pf as port:
+        assert port == 45013
+    assert h.ports == [45011, 45013]              # re-picked, not reused
+    assert len(set(h.ports)) == len(h.ports)      # pairwise distinct
+    assert h.procs[0].terminated is True          # failed attempt reaped
+    assert h.procs[1].terminated is True          # success torn down on exit
+
+
+def test_port_forward_does_not_retry_a_non_collision_failure(monkeypatch):
+    # An RBAC denial must fail on attempt 1 with kubectl's own message intact —
+    # retrying would mask a real error and triple the time-to-error.
+    h = _PFAttempts([KUBECTL_RBAC_STDERR] * 5)
+    pf = _pf_with(h, [45011, 45013, 45017, 45021], monkeypatch)
+    with pytest.raises(RuntimeError) as ei:
+        pf.__enter__()
+    assert len(h.procs) == 1                      # EXACTLY one attempt
+    assert h.ports == [45011]
+    # original error preserved verbatim — not rewritten into a retry message
+    assert str(ei.value) == ("kubectl port-forward exited early: "
+                             + KUBECTL_RBAC_STDERR.strip())
+    assert h.procs[0].terminated is True
+
+
+def test_port_forward_does_not_retry_a_readiness_timeout(monkeypatch):
+    # The backend never answering is not a port problem either.
+    calls = []
+    it = iter([45011, 45013, 45017])
+    monkeypatch.setattr(obs, "_free_port", lambda: next(it))
+
+    def never_ready(*a, **k):
+        calls.append(1)
+        raise TimeoutError("backend not ready on 127.0.0.1:45011/ready in 10s")
+
+    proc = FakeProc()
+    pf = obs.PortForward("/kc", obs.BACKENDS["loki"],
+                         popen=lambda *a, **k: proc, wait_ready=never_ready)
+    with pytest.raises(TimeoutError) as ei:
+        pf.__enter__()
+    assert len(calls) == 1
+    assert "backend not ready" in str(ei.value)
+    assert proc.terminated is True
+
+
+def test_port_forward_gives_up_after_exhausting_collision_retries(monkeypatch):
+    h = _PFAttempts([KUBECTL_COLLISION_STDERR] * 6)
+    pf = _pf_with(h, [45011, 45013, 45017, 45021], monkeypatch)
+    with pytest.raises(RuntimeError) as ei:
+        pf.__enter__()
+    msg = str(ei.value)
+    assert obs.PF_ATTEMPTS == 3
+    assert h.ports == [45011, 45013, 45017]       # bounded: exactly PF_ATTEMPTS
+    assert len(h.procs) == obs.PF_ATTEMPTS
+    # actionable: names the exhausted budget AND carries kubectl's last error
+    assert ("local port collision on all %d attempts" % obs.PF_ATTEMPTS) in msg
+    assert "unable to listen on any of the requested ports" in msg
+
+
+def test_port_forward_leaks_no_process_across_retries(monkeypatch):
+    # every failed attempt's kubectl is terminated AND reaped before the next
+    h = _PFAttempts([KUBECTL_COLLISION_STDERR] * 6)
+    pf = _pf_with(h, [45011, 45013, 45017, 45021], monkeypatch)
+    with pytest.raises(RuntimeError):
+        pf.__enter__()
+    assert len(h.procs) == obs.PF_ATTEMPTS
+    assert all(p.terminated for p in h.procs)
+    assert all(p.waited for p in h.procs)
+    assert pf.proc is None                        # no handle left dangling
+
+
+
+# =========================================================================== #
 # kubectl stderr surfaced on early exit (#4)
 # =========================================================================== #
 def test_wait_ready_surfaces_kubectl_stderr():


### PR DESCRIPTION
## Why

`_free_port()` picks an ephemeral port, closes its probe socket, then hands the number to `kubectl` — so a concurrent `obs-read` run can steal the port before kubectl binds it. The source already carried this as a documented `KNOWN LIMITATION`. The window is sub-millisecond, but it becomes reachable once several agents query Prometheus/Loki at once, and it surfaced as a bare `kubectl port-forward exited early`.

Bind-and-hold isn't available: kubectl must bind the port itself.

## What

`PortForward.__enter__` retries up to `PF_ATTEMPTS` (3) with a freshly-picked port — **only** when the failed attempt died on a bind collision, matched via `_is_port_collision` against kubectl's own stderr.

Every other failure (service not found, wrong namespace, RBAC denial, backend never ready) still propagates on the **first** attempt. That discrimination is the crux: retrying those would mask real errors and triple time-to-error on the commonest misconfiguration. Each failed attempt's kubectl is terminated and reaped before the next, so a retry cannot leak a tunnel.

The stale `KNOWN LIMITATION` comment is rewritten to describe what the code now does.

## Verification

**Red/green** — new tests against pre-change code at base `d5a0fe5`: **4 failed, 66 passed**. At HEAD: **70 passed**.

The 4 genuinely red at base are the regression coverage. Two others — `test_port_forward_does_not_retry_a_non_collision_failure` and `..._a_readiness_timeout` — **pass at base vacuously** (nothing retries there), so they are *invariant guards*, not regression tests. They earn their place by killing the retry-everything mutant below.

**Mutation** (narrowest expression only — just the `return` in `_is_port_collision`; run under `PYTHONDONTWRITEBYTECODE=1` with `__pycache__` cleared, so no mutant can be scored on stale bytecode):

| Mutant | Killed by |
|---|---|
| `-> always True` (retry everything) | `does_not_retry_a_non_collision_failure`, `does_not_retry_a_readiness_timeout`, `is_port_collision_discriminates`, `terminates_on_wait_ready_error` |
| `-> always False` (retry nothing) | `retries_collision_on_a_different_port`, `gives_up_after_exhausting_collision_retries`, `leaks_no_process_across_retries`, `is_port_collision_discriminates` |

Both directions die to disjoint, semantically correct test sets — the discriminator is pinned in both directions, not just "a test failed".

## Known limitation

`_is_port_collision` matches on the stringified exception, so a backend error body literally containing `address already in use` would trigger one spurious retry. Judged acceptable — the retry is bounded and idempotent — but stated rather than left silent.
