### PR TITLE
fix: a stale SOURCE repo shipped a silent no-op wearing a current version — derive clawgatectl's version from the code, and give drift-check rc 17

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,10 +56,18 @@ there. Only what's specific to this repo, where a working tree is also a **deplo
   help and **exited 0**, and drift-check was green throughout. Both halves are now
   closed: `clawgatectl.nix` **reads its version out of the Go source it compiles**
   (never a literal — an unparseable source means no binary, not a wrong label), and
-  drift-check reports each source repo's currency per host. The covered set is
+  drift-check reports each package's source currency per host. The covered set is
   **derived from `nix/pkgs/` at scan time and pinned two-way by a test**, so a third
   such package is covered automatically. `absent` / `fetch failed` / `detached` are
   reported as **UNMEASURED**, never folded into a clean count.
+  🔴 **The unit is the package's own `srcDir` SUBTREE, not the repo** — escalating
+  on the repo made rc 17 a permanently-red gate. Measured: the workbench sat 18
+  commits behind `origin/trunk` with **0** of them touching `containers/clawgate`,
+  and over 14 days that repo took 98 commits of which only 32 could reach any
+  built artefact. So the verdict is a pathspec-limited count against the branch's
+  **own** upstream (never a hardcoded `main`/`trunk`), the repo-wide numbers are
+  printed beside it as information, and the cross-host comparison diffs **subtree
+  tree OIDs** rather than repo HEADs.
   🔴 **rc 16 is NOT drift** — it is the fuzzyclaw phase-2 gate reporting that zero rows
   still take their age from fuzzyclaw alone, i.e. the readers can now be deleted; the
   final line says `ACTIONABLE (not drift)` and it is the least severe code, so it can

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,19 @@ there. Only what's specific to this repo, where a working tree is also a **deplo
   block prompts for what the other allows, which is a real gap. Close it with
   `scripts/sync-claude-permissions.py` (idempotent, additive, **curated** — never copy the
   other host's block wholesale; #380 exists because that file accretes junk).
+  🔴 **Git parity is not SOURCE parity either — rc 17.** Some `nix/pkgs/**`
+  derivations build from a **local working tree of another repo** (`${workspace}/…`:
+  today `homelab-talos` and `tmux-fuzzyclaw`), and **nothing converges those** —
+  `ship.sh` is scoped to `~/workspace/devrc`. On 2026-08-14 the laptop's
+  homelab-talos was 24 commits behind, so it shipped a `clawgatectl` with no
+  `task status`, labelled `0.7.95` by devrc's version literal; the command printed
+  help and **exited 0**, and drift-check was green throughout. Both halves are now
+  closed: `clawgatectl.nix` **reads its version out of the Go source it compiles**
+  (never a literal — an unparseable source means no binary, not a wrong label), and
+  drift-check reports each source repo's currency per host. The covered set is
+  **derived from `nix/pkgs/` at scan time and pinned two-way by a test**, so a third
+  such package is covered automatically. `absent` / `fetch failed` / `detached` are
+  reported as **UNMEASURED**, never folded into a clean count.
   🔴 **rc 16 is NOT drift** — it is the fuzzyclaw phase-2 gate reporting that zero rows
   still take their age from fuzzyclaw alone, i.e. the readers can now be deleted; the
   final line says `ACTIONABLE (not drift)` and it is the least severe code, so it can

--- a/claude/skills/clawgate/reference/task-api.md
+++ b/claude/skills/clawgate/reference/task-api.md
@@ -109,6 +109,18 @@ is answered structurally, not by promising to keep it fresh: response bodies are
 prints a one-line `note: server X, clawgatectl built for Y` skew warning **to stderr** when the two
 disagree. What is NOT answered: a route the CLI has never heard of is still a route you must curl.
 
+🔴 **That skew note was MUTE for 19 hours on the laptop, and the argument above was wrong until
+2026-08-18.** `clawgatectl.nix` used to carry a hand-written `version` literal and stamp it with
+`-ldflags -X main.buildVersion=`, so on 2026-08-14 the laptop — whose `~/workspace/homelab-talos`
+was 24 commits behind — built a CLI with **no `task status` and no `task comment`** and the nix
+literal labelled it `0.7.95` anyway. `h.Version == buildVersion` compared equal, the note stayed
+silent, and `clawgatectl task status <id> in_progress` printed help and **exited 0**. The fix is
+in devrc: the version is now **read out of `cmd/clawgatectl/client.go`'s own `var buildVersion`**,
+so a stale checkout reports its real version and the skew note fires correctly. Two consequences
+worth knowing: **the note is only as good as the checkout's freshness** — `drift-check.sh` rc 17
+now reports a stale `homelab-talos` per host — and an **unparseable** `var buildVersion` line means
+the package is not installed at all (`clawgatectl: command not found`), never a guessed label.
+
 It reads `CLAWGATE_API_URL` + `CLAWGATE_HOOK_TOKEN` out of `~/.claude/clawgate.env` itself, so the
 `H="Authorization: Bearer $(grep '^CLAWGATE_HOOK_TOKEN=' … | cut -d= -f2)"` preamble that used to
 head every recipe in this skill **is gone** — the token never reaches argv (`/proc` is world

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -2259,6 +2259,18 @@ in
   # over a run where nothing is wrong. `SuccessExitStatus = 16` on the service
   # below; the full argument is there.
   #
+  # 🔴 rc 17 DOES TOAST, and that is the point. It means a repo devrc BUILDS A
+  # PACKAGE FROM (`nix/pkgs/**` derivations with a `${workspace}/…` src) is not
+  # current on that host — so the binary it installs is old code under a
+  # current-looking version. Measured 2026-08-14: the laptop's homelab-talos was
+  # 24 commits behind, so its clawgatectl had no `task status`/`task comment`
+  # while devrc's version literal stamped 0.7.95 onto it; the command printed
+  # help and exited 0. This deadman was green on that host throughout. Unlike
+  # rc 13 and rc 16 this is a real divergence with a real fix (a pull plus a
+  # switch), so it must reach OnFailure like rc 8 does — it is NOT on
+  # SuccessExitStatus. It cannot become permanently red: `fetch failed`,
+  # `absent` and `detached` are all reported as UNMEASURED and set no code.
+  #
   # The service is emitted UNCONDITIONALLY (any host can run it by hand); only the
   # TIMER's timers.target wiring is gated — see enableDriftDeadman above.
   systemd.user.services.drift-check = {
@@ -2300,10 +2312,28 @@ in
       # -u drift-check | grep ACTIONABLE` is the check that works. Pinned by
       # `test_the_unit_does_not_fail_on_the_phase2_actionable_code`.
       SuccessExitStatus = 16;
-      # Two `git fetch`es plus one ssh round trip. The ConnectTimeout inside the
-      # script is 10s, so this ceiling only ever fires on a wedged fetch; the
-      # cgroup is killed and the timer re-arms on the next OnUnitActiveSec.
-      TimeoutStartSec = 180;
+      # 🔴 THE BUDGET IS A FUNCTION OF WHAT THE SCRIPT FETCHES, and that grew.
+      # It was 180 for "two `git fetch`es plus one ssh round trip" — the two
+      # devrc checkouts. The source-repo leg (rc 17) fetches EVERY repo nix/pkgs
+      # builds a package from, on BOTH hosts, so the worst case is now
+      #   2 hosts x N source repos x DRIFT_SRC_FETCH_TIMEOUT (30s)
+      # on top of the devrc fetches, the ssh round trip and the 60s phase-2 cap.
+      # At today's N=2 that is 120s of new worst case, which 180 could not
+      # absorb: the cgroup would be killed mid-run and the deadman would report
+      # NOTHING, on a schedule, looking like a unit that merely takes a while.
+      # 420 leaves headroom for one more source repo without another edit.
+      #
+      # This is a SEAM — the tunable lives in the script, the ceiling lives here,
+      # and neither file's tests owned their product. Pinned by
+      # `test_drift_check.py::test_the_unit_start_timeout_can_absorb_every_source
+      # _repo_fetch`, which recomputes it from both files and fails if either
+      # moves out from under the other.
+      #
+      # The ConnectTimeout inside the script is 10s and each source fetch is
+      # capped individually, so this ceiling only ever fires on several wedges at
+      # once; the cgroup is killed and the timer re-arms on the next
+      # OnUnitActiveSec.
+      TimeoutStartSec = 420;
       Environment = [
         # iproute2 is load-bearing, not incidental: `ip -4 -o addr show` is how
         # local_ipv4s identifies WHICH host this is (both report hostname `nixos`).

--- a/nix/pkgs/tools/clawgatectl.nix
+++ b/nix/pkgs/tools/clawgatectl.nix
@@ -24,33 +24,109 @@
 #   • An uncommitted edit in that tree changes the src hash, so the next switch
 #     rebuilds. That is a cost, not a bug.
 #
+# 🔴 THE VERSION IS READ OUT OF THE SOURCE. IT IS NOT WRITTEN HERE. Two repos,
+# two delivery mechanisms, and only one of them is automatic — a hand-maintained
+# `version = "x.y.z"` literal in THIS file is a claim about code that lives in
+# the OTHER one, and nothing keeps the two together. Measured 2026-08-14:
+#
+#   17:44  homelab-infra 978c549c (#323) added `task status` + `task comment` to
+#          clawgatectl and set the Go default buildVersion to "0.7.95".
+#   17:48  devrc 1b790b3 (#483) bumped THIS FILE's literal 0.7.87 -> 0.7.95 and
+#          shipped to both hosts. The changed ldflag forced a rebuild on both.
+#
+# The workbench's homelab-talos was current, so it got a genuine 0.7.95. The
+# laptop's was frozen 24 commits back at 6e9055f7; its client.go correctly said
+# "0.7.87", and the ldflag OVERWROTE that truth with "0.7.95". The laptop then
+# carried a binary with no `task status` and no `task comment` wearing the label
+# of one that had both: `clawgatectl task status <id> in_progress` printed help
+# and exited 0 — a silent no-op, against a CLI whose write ritual the `clawgate`
+# skill makes mandatory. No check anywhere could see it (drift-check.sh was
+# green on that host throughout; it only knew about devrc).
+#
+# So `version` is now DERIVED from the very file being compiled — the Go default
+# at cmd/clawgatectl/client.go — and the ldflag stamps that same derived value.
+# Both the store path and the stamped buildVersion therefore describe the code
+# that is actually in the tree. A stale checkout now reports its own real
+# version, which is the point: client.go compares the server's /health version
+# against buildVersion by EXACT EQUALITY and prints a one-line skew note when
+# they differ, so a 0.7.87 binary talking to a 0.7.95 server says so. Had this
+# been in place on 08-14 the laptop would have printed exactly that.
+#
+# 🔴 NO FINGERPRINT, SUFFIX OR "-dirty" MARKER MAY BE APPENDED TO buildVersion.
+# That equality check is what makes the skew note meaningful; any suffix makes
+# it fire on every command on every host forever, and a permanently-noisy
+# warning is worse than none — it teaches the operator to ignore the one line
+# that has to keep its meaning. Let the existing mechanism work.
+#
+# 🔴 AN UNPARSEABLE SOURCE MUST NOT FALL BACK TO A LITERAL — that is the lie
+# again, in a new shape. It sets available = false instead, so the binary is
+# simply not installed and the failure is LOUD at use time (`clawgatectl:
+# command not found`) rather than silent at build time. Failing the switch is
+# the worse outcome and is deliberately not what happens: ship.sh reports a
+# failed switch as a SKIPPED host, which this repo's CLAUDE.md documents as the
+# failure mode that silently stops all future delivery to that machine.
+#
 # If clawgatectl ever needs to build on a host without the checkout, the fix is
-# to move it to its own public repo and swap this for fetchFromGitHub — the rest
-# of this derivation is unchanged by that.
+# to move it to its own public repo and swap this for fetchFromGitHub — the
+# version extraction below is unchanged by that, since it reads the source tree
+# whatever produced it.
 { pkgs, workspace }:
 
 let
-  version = "0.7.95";
-
   # The whole Go module, not just cmd/clawgatectl: go.mod/go.sum live at its
   # root and buildGoModule needs them for the vendor derivation.
   srcDir = "${workspace}/homelab-talos/containers/clawgate";
 
-  # 🔴 Guard on THIS COMMAND'S OWN SOURCE FILE, not on the repo and not on the
+  # 🔴 Guard on THIS COMMAND'S OWN SOURCE FILES, not on the repo and not on the
   # module. "Does the checkout exist" is the wrong question and was MEASURED
   # wrong on 2026-08-13: the laptop has ~/workspace/homelab-talos (so a
   # directory check passes) and it has go.mod (so a module check passes), but
-  # its checkout sits at c417af30 — well behind the commit that added
+  # its checkout sat at c417af30 — well behind the commit that added
   # cmd/clawgatectl. Under either weaker guard the derivation would be built and
   # `subPackages` would fail deep in the Go build, taking down that host's whole
   # home-manager switch — which ship.sh reports as a SKIPPED host, the failure
   # mode this repo's CLAUDE.md warns silently stops all future delivery.
   # Guarding on main.go also covers the empty-placeholder-directory case.
-  available = builtins.pathExists "${srcDir}/cmd/clawgatectl/main.go";
+  mainFile = "${srcDir}/cmd/clawgatectl/main.go";
+
+  # The single source of truth for the version, and the file whose `var
+  # buildVersion = "…"` line is BOTH the Go default and what this derivation
+  # stamps back in. Guarded by the same pathExists rule as main.go: a checkout
+  # too old to have it is a host that does not get the binary, not a host whose
+  # switch fails.
+  versionFile = "${srcDir}/cmd/clawgatectl/client.go";
+
+  # 🔴 EXACTLY ONE MATCHING LINE, OR NOTHING. Zero matches means the declaration
+  # was renamed or reformatted; two or more means the pattern has become
+  # ambiguous and picking either one would be a guess presented as a fact. Both
+  # land on `null`, which switches the package off — see the header on why that
+  # is preferable to both a literal fallback and a failed switch.
+  versionPattern = "var buildVersion = \"([^\"]+)\".*";
+
+  versionLines =
+    if builtins.pathExists versionFile
+    then
+      builtins.filter
+        (l: builtins.isString l && builtins.match versionPattern l != null)
+        # builtins.split yields the separators as LISTS between the string
+        # pieces, hence the isString filter above.
+        (builtins.split "\n" (builtins.readFile versionFile))
+    else [ ];
+
+  parsedVersion =
+    if builtins.length versionLines == 1
+    then builtins.head (builtins.match versionPattern (builtins.head versionLines))
+    else null;
+
+  # Both halves are required. main.go answers "is this checkout new enough to
+  # build at all"; parsedVersion answers "can this derivation state truthfully
+  # what it is building". A package that cannot answer the second is not
+  # installed — it is never labelled with a guess.
+  available = builtins.pathExists mainFile && parsedVersion != null;
 
   clawgatectl = pkgs.buildGoModule {
     pname = "clawgatectl";
-    inherit version;
+    version = parsedVersion;
 
     src = pkgs.lib.cleanSource (/. + srcDir);
 
@@ -64,9 +140,16 @@ let
     subPackages = [ "cmd/clawgatectl" ];
 
     # buildVersion is what the CLI compares the live server's /health version
-    # against to print its one-line skew note, and what exit 7 quotes. Stamping
-    # it from `version` keeps the two from drifting apart silently.
-    ldflags = [ "-s" "-w" "-X main.buildVersion=${version}" ];
+    # against to print its one-line skew note, and what exit 7 quotes.
+    #
+    # 🔴 This stamp is now an IDENTITY — parsedVersion was read out of the very
+    # `var buildVersion` line this overwrites — and that is exactly the property
+    # that was missing. It is kept rather than deleted because it is what makes
+    # the store path and the compiled-in string provably the same value, and
+    # because the link-time override is the documented mechanism (client.go says
+    # so). It must never be given anything but parsedVersion: the moment it can
+    # differ, the binary can lie about itself again.
+    ldflags = [ "-s" "-w" "-X main.buildVersion=${parsedVersion}" ];
 
     meta = with pkgs.lib; {
       description = "Machine client for the clawgate JSON API";

--- a/nix/pkgs/tools/tmux-fuzzyclaw.nix
+++ b/nix/pkgs/tools/tmux-fuzzyclaw.nix
@@ -1,3 +1,24 @@
+# tmux-fuzzyclaw — built, like clawgatectl next door, from a LOCAL working tree
+# of another repo (`${workspace}/tmux-fuzzyclaw`), with a hand-written `version`
+# literal stamped into the binary at link time.
+#
+# 🔴 THAT SHAPE IS THE ONE THAT FAILED FOR clawgatectl ON 2026-08-14 — the nix
+# literal overwrote a stale checkout's own, correct, version and produced a
+# binary that lied about itself. clawgatectl.nix now reads its version out of
+# the Go source it compiles. THIS PACKAGE CANNOT DO THE SAME, and the reason is
+# a measurement, not an oversight (2026-08-18):
+#
+#   * cmd/version.go declares `var Version = "dev"` — a link-time placeholder,
+#     not a version;
+#   * the string "2.0.0" appears NOWHERE in that repo, only here;
+#   * the repo carries no git tags to derive one from.
+#
+# There is no source of truth to read, and inventing one would be the same lie
+# in a new place. So the literal stays, deliberately, and
+# `scripts/tests/test_clawgatectl_version.py` pins that finding: it fails the
+# day cmd/version.go grows a real version, which is the trigger to apply the
+# same fix here. The STALENESS half is covered regardless — drift-check.sh
+# reports whether this source repo is current on each host (rc 17).
 { pkgs, workspace }:
 
 let

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -101,12 +101,15 @@
 #       installed there. A short, EXPLICITLY ENUMERATED set of settings.json keys
 #       is exempt from the key-set half — see "PER-HOST settings.json KEYS"
 #       below. Nothing else is, and an unknown key is never exempt.
-#   17  DRIFT — a SOURCE REPO devrc BUILDS A PACKAGE FROM is not current on that
-#       host: behind or ahead of its own upstream. 🔴 The SECOND thing git parity
-#       on devrc structurally cannot see. See "SOURCE-REPO PARITY" below. The
-#       number is high because 5/7/9/11 are reserved to ship.sh meanings this
-#       script does not take; its SEVERITY is set by the table, not by the digit,
-#       and it ranks between 8 and 14 — see severity() for why.
+#   17  DRIFT — the SOURCE SUBTREE a devrc package is BUILT FROM is not current
+#       on that host: behind or ahead of its branch's own upstream, counted with
+#       a PATHSPEC limited to that package's `srcDir`. 🔴 The SECOND thing git
+#       parity on devrc structurally cannot see — and 🔴 NOT the same thing as
+#       "the repo is behind", which is reported but never escalates. See
+#       "SOURCE-REPO PARITY" below. The number is high because 5/7/9/11 are
+#       reserved to ship.sh meanings this script does not take; its SEVERITY is
+#       set by the table, not by the digit, and it ranks between 8 and 14 — see
+#       severity() for why.
 #   16  ACTIONABLE, not drift — the fuzzyclaw PHASE-2 GATE has OPENED: zero rows
 #       still take their `age_secs` from fuzzyclaw alone, so the readers can be
 #       removed. See "THE FUZZYCLAW PHASE-2 GATE" below. It is the LEAST severe
@@ -137,22 +140,41 @@
 # fixed in nix/pkgs/tools/clawgatectl.nix (the version is now read out of the
 # compiled source); THIS is the other half — noticing the stale tree at all.
 #
+# 🔴 THE UNIT IS THE srcDir SUBTREE, NOT THE REPO — and getting that wrong makes
+# this a PERMANENTLY-RED GATE, which is worse than no gate because it trains
+# click-through on the one alert that has to keep its meaning. MEASURED
+# 2026-08-18 on the workbench: it was 1 commit behind `origin/trunk`, and that
+# commit was `2ce7cbdc fix(naida-ai-demo): raise memory limit 128Mi -> 512Mi` —
+# `git diff --name-only HEAD..origin/trunk -- containers/clawgate` is EMPTY, so it
+# cannot reach the built binary. Over the preceding 14 days that repo took 98
+# commits of which only 32 touched `containers/clawgate`; at ~7 commits/day the
+# host is behind almost continuously and roughly two thirds of those reds could
+# not affect any package devrc builds. So the verdict is computed with a PATHSPEC
+# limited to each package's own srcDir (`HEAD..@{u} -- <subtree>`, and the reverse
+# for ahead), and the repo-wide numbers are printed beside it as INFORMATION.
+#
 # 🔴 THE COVERED SET IS DERIVED, NEVER LISTED. The payload reads `nix/pkgs/**.nix`
-# out of the checkout it is examining and collects every `${workspace}/<name>` it
-# finds outside a comment, so a THIRD such package is covered the day it is
-# added. A hardcoded pair would have been correct on the day it was written and
-# silently incomplete afterwards, which is the same shape as the bug. The
-# derivation is pinned TWO-WAY by `test_drift_check.py::test_the_source_repo_set_
-# is_pinned_two_way_against_nix_pkgs` — it fails when the set GROWS or SHRINKS.
+# out of the checkout it is examining and collects every `${workspace}/<path>` it
+# finds outside a comment — the WHOLE path, so the repo and the subtree both fall
+# out of the same scan — and one repo may yield SEVERAL scopes. A THIRD such
+# package is covered the day it is added; a hardcoded pair would have been
+# correct on the day it was written and silently incomplete afterwards, which is
+# the same shape as the bug. The derivation is pinned TWO-WAY by
+# `test_drift_check.py::test_the_source_repo_set_is_pinned_two_way_against_nix_
+# pkgs` — it fails when the set GROWS or SHRINKS.
 #
 # 🔴 EXAMINED BESIDE STALE, again. `examined=N stale=M unmeasured=K` is the
-# claim; none of the three numbers means anything alone. A repo whose fetch
-# failed, whose branch has no upstream, or which is absent from this host is
-# UNMEASURED — never folded into "0 stale", because a checker wired to nothing
-# reports exactly that zero.
+# claim; none of the three numbers means anything alone, and the unit counted is
+# the BUILT-SOURCE SCOPE (repo count printed beside it). A scope whose repo is
+# absent, whose fetch failed, whose branch has no upstream, or whose pathspec
+# count will not parse is UNMEASURED — never folded into "0 stale", because a
+# checker wired to nothing reports exactly that zero.
 #
-# WHAT IS DRIFT HERE AND WHAT IS NOT — the line is "did we MEASURE a divergence":
-#   * behind / ahead of the branch's own upstream ................. rc 17
+# WHAT IS DRIFT HERE AND WHAT IS NOT — the line is "did we MEASURE a divergence
+# IN THE CODE THAT GETS COMPILED":
+#   * the package's own srcDir SUBTREE is behind / ahead of the branch's own
+#     upstream ..................................................... rc 17
+#   * the REPO is behind / ahead but the subtree is not .... reported, NOT drift.
 #   * repo ABSENT on this host ......... reported, NOT drift. The derivations
 #     guard on pathExists and simply omit the binary; a host without the checkout
 #     is a documented, tolerated state (see clawgatectl.nix's header).
@@ -169,13 +191,16 @@
 #     would be a permanently-red gate.
 #
 # 🔴 THE CROSS-HOST HALF IS INFORMATION ONLY, deliberately. The driver diffs the
-# two hosts' `FACT src-repos` lines and reports repos whose HEAD differs — the
-# most direct statement of "these two machines build different code" — but sets
-# NO rc, because whether a given HEAD is WRONG is already answered per host by
-# the upstream comparison, which has a defined correct answer. Two hosts sitting
-# on different branches of a shared development repo is normal, and a code that
-# fires on it would be a permanently-red gate. Like every cross-host claim here
-# it prints NOT COMPARED unless facts arrived from BOTH machines.
+# two hosts' `FACT src-repos` lines — 🔴 whose values are the srcDir SUBTREE's
+# TREE OID, not the repo HEAD, for the same reason the verdict is scoped: a repo
+# HEAD differs whenever the two hosts disagree about ANY commit, including cluster
+# manifests no package is built from. It reports scopes whose built tree differs —
+# the most direct statement of "these two machines compile different code" — but
+# sets NO rc, because whether a given tree is WRONG is already answered per host
+# by the upstream comparison, which has a defined correct answer. Two hosts
+# sitting on different branches of a shared development repo is normal, and a code
+# that fires on it would be a permanently-red gate. Like every cross-host claim
+# here it prints NOT COMPARED unless facts arrived from BOTH machines.
 #
 # READ-ONLY, like everything else in this file: `fetch`, `rev-parse`, `rev-list`,
 # `symbolic-ref`, `status`. It never pulls, never switches, never repairs.
@@ -792,6 +817,21 @@ echo "[$label] PARITY-RC=$p_rc"
 # nothing derived has to be interpolated into a payload that executes on the
 # other machine.
 #
+# 🔴 TWO UNITS, AND CONFLATING THEM MAKES THIS GATE PERMANENTLY RED.
+#   * a REPO is what gets FETCHED — one fetch, however many packages sit in it;
+#   * a SCOPE (`<repo>:<srcDir-subtree>`) is what gets JUDGED.
+# The scan therefore keeps the WHOLE `${workspace}/…` path, not just its first
+# component: `${workspace}/homelab-talos/containers/clawgate` is repo
+# `homelab-talos` with subtree `containers/clawgate`, while
+# `${workspace}/tmux-fuzzyclaw` is a repo whose srcDir IS its root — an empty
+# subtree, for which scope and repo coincide and behaviour is unchanged. One repo
+# may carry SEVERAL scopes and each is judged on its own.
+#
+# 🔴 NO `find`, for the same reason the parity walk avoids it: the laptop resolves
+# `find` to BUSYBOX, which does not implement `-xtype`, rejects it by printing
+# usage to stderr and EXITS 0 — a confident zero from a scan wired to nothing.
+# `shopt -s globstar` plus a glob is bash's own, and behaves identically on both.
+#
 # 🔴 COMMENTS ARE EXCLUDED BY TRUNCATION — each line is cut at its first `#`
 # before anything is read out of it, which covers a whole-line comment and a
 # trailing one with the same rule. clawgatectl.nix's own header discusses
@@ -802,11 +842,6 @@ echo "[$label] PARITY-RC=$p_rc"
 # stated rather than engineered away: a `#` inside a nix STRING would truncate
 # early. That direction UNDER-reports, and under-reporting is what the two-way
 # pin against the real nix/pkgs exists to catch.
-#
-# 🔴 NO `find`, for the same reason the parity walk avoids it: the laptop resolves
-# `find` to BUSYBOX, which does not implement `-xtype`, rejects it by printing
-# usage to stderr and EXITS 0 — a confident zero from a scan wired to nothing.
-# `shopt -s globstar` plus a glob is bash's own, and behaves identically on both.
 #
 # Loop and local variable names are UPPERCASE for the same reason they are in the
 # parity payload: the suite's reverse-PATH tokenizer reads a lowercase word in
@@ -823,23 +858,42 @@ repo="${DRIFT_REPO:-$HOME/workspace/devrc}"
 sfto="${DRIFT_SRC_FETCH_TIMEOUT:-30}"
 ssay() { echo "[$label] $*"; }
 
+# S_NAMES — deduped REPO roots, the unit that gets FETCHED.
+# S_SUBS  — deduped "<repo>:<subtree>" SCOPES, the unit that gets JUDGED. An
+#           empty subtree means that package srcDir IS the repo root.
 S_NAMES=""
-s_add() { # s_add <repo-name> — dedupe, as two derivations can share one repo
+S_SUBS=""
+
+s_add() { # s_add <repo> <subtree-or-empty>
   case " $S_NAMES " in
-    *" $1 "*) return 0 ;;
+    *" $1 "*) ;;
+    *) S_NAMES="$S_NAMES $1" ;;
   esac
-  S_NAMES="$S_NAMES $1"
+  case " $S_SUBS " in
+    *" $1:$2 "*) return 0 ;;
+  esac
+  S_SUBS="$S_SUBS $1:$2"
 }
 
-s_scan() { # s_scan <nix-file> — collect the workspace-relative repo names it uses
-  local LN REST NAME
+s_key() { # s_key <repo> <subtree-or-empty> — the scope name used in every message
+  if [ -z "$2" ]; then printf "%s" "$1"; else printf "%s/%s" "$1" "$2"; fi
+}
+
+s_scan() { # s_scan <nix-file> — collect the workspace-relative srcDir paths it names
+  local LN REST PP NAME SUB
   while IFS= read -r LN || [ -n "$LN" ]; do
     LN="${LN%%#*}"
     while : ; do
       case "$LN" in *\$\{workspace\}/*) ;; *) break ;; esac
       REST="${LN#*\$\{workspace\}/}"
-      NAME="${REST%%[!A-Za-z0-9._-]*}"
-      [ -n "$NAME" ] && s_add "$NAME"
+      PP="${REST%%[!A-Za-z0-9._/-]*}"
+      PP="${PP%/}"
+      NAME="${PP%%/*}"
+      case "$PP" in
+        */*) SUB="${PP#*/}" ;;
+        *)   SUB="" ;;
+      esac
+      [ -n "$NAME" ] && s_add "$NAME" "$SUB"
       LN="$REST"
     done
   done < "$1"
@@ -853,29 +907,47 @@ for F in "$repo"/nix/pkgs/**/*.nix; do
   s_scan "$F"
 done
 
+S_REPOS=0
 S_EXAMINED=0
 S_STALE=0
 S_UNMEASURED=0
 S_FACTS=""
 s_rc=0
 
+# 🔴 A repo we could not evaluate makes EVERY scope under it UNMEASURED — never
+# one silent pass hiding behind a repo whose fetch failed. The reason token also
+# becomes that scope FACT value, so the cross-host comparison cannot mistake
+# "we could not look" for agreement.
+s_unmeasured_scopes() { # s_unmeasured_scopes <repo> <reason-token>
+  local X SUBP K
+  for X in $S_SUBS; do
+    case "$X" in
+      "$1:"*) ;;
+      *) continue ;;
+    esac
+    SUBP="${X#*:}"
+    K="$(s_key "$1" "$SUBP")"
+    S_EXAMINED=$(( S_EXAMINED + 1 ))
+    S_UNMEASURED=$(( S_UNMEASURED + 1 ))
+    S_FACTS="$S_FACTS $K=$2"
+  done
+}
+
 for N in $S_NAMES; do
   SR="$HOME/workspace/$N"
-  S_EXAMINED=$(( S_EXAMINED + 1 ))
+  S_REPOS=$(( S_REPOS + 1 ))
 
   # A worktree checkout has .git as a FILE, a normal clone as a directory.
   if [ ! -e "$SR/.git" ]; then
     ssay "source repo $N: ABSENT at $SR — currency NOT evaluated."
     ssay "  nix/pkgs builds from it; this host cannot. Reported, NOT drift: the"
     ssay "  derivations guard on pathExists and simply omit the binary."
-    S_FACTS="$S_FACTS $N=ABSENT"
-    S_UNMEASURED=$(( S_UNMEASURED + 1 ))
+    s_unmeasured_scopes "$N" ABSENT
     continue
   fi
 
   SHA="$(git -C "$SR" rev-parse --short=12 HEAD 2>/dev/null)"
   [ -n "$SHA" ] || SHA=UNBORN
-  S_FACTS="$S_FACTS $N=$SHA"
   BR="$(git -C "$SR" symbolic-ref --quiet --short HEAD 2>/dev/null || echo DETACHED)"
 
   # DIRTY is reported for every present repo, INCLUDING a current one: these
@@ -897,7 +969,7 @@ for N in $S_NAMES; do
     printf "%s\n" "$FERR" | head -n 3 | sed "s|^|[$label]   git: |"
     ssay "  these repos are private and reached over ssh, and a systemd --user"
     ssay "  unit has no ssh-agent. NOT drift — and NOT a pass either."
-    S_UNMEASURED=$(( S_UNMEASURED + 1 ))
+    s_unmeasured_scopes "$N" FETCHFAILED
     continue
   fi
 
@@ -912,47 +984,82 @@ for N in $S_NAMES; do
   if [ -z "$UP" ]; then
     ssay "source repo $N: on branch $BR at $SHA — no upstream to compare against, currency NOT evaluated."
     ssay "  a detached HEAD or an untracked branch has no defined right answer."
-    S_UNMEASURED=$(( S_UNMEASURED + 1 ))
+    s_unmeasured_scopes "$N" NOUPSTREAM
     continue
   fi
 
+  # 🔴 REPO-WIDE COUNTS ARE INFORMATION, NEVER THE VERDICT. They are true and
+  # worth printing — but escalating on them made rc 17 fire on commits that
+  # cannot reach any built artefact, which is a permanently-red gate.
   CNT="$(git -C "$SR" rev-list --left-right --count "$UP...HEAD" 2>/dev/null)"
-  S_BEHIND="$(printf "%s" "$CNT" | awk "{print \$1}")"
-  S_AHEAD="$(printf "%s" "$CNT" | awk "{print \$2}")"
-  case "$S_BEHIND" in ""|*[!0-9]*) S_BEHIND=-1 ;; esac
-  case "$S_AHEAD" in ""|*[!0-9]*) S_AHEAD=-1 ;; esac
-  if [ "$S_BEHIND" = -1 ] || [ "$S_AHEAD" = -1 ]; then
-    ssay "source repo $N: could not compare $BR to $UP — currency NOT evaluated."
-    S_UNMEASURED=$(( S_UNMEASURED + 1 ))
-    continue
-  fi
+  R_BEHIND="$(printf "%s" "$CNT" | awk "{print \$1}")"
+  R_AHEAD="$(printf "%s" "$CNT" | awk "{print \$2}")"
+  case "$R_BEHIND" in ""|*[!0-9]*) R_BEHIND=-1 ;; esac
+  case "$R_AHEAD" in ""|*[!0-9]*) R_AHEAD=-1 ;; esac
+  ssay "source repo $N: on branch $BR at $SHA — repo-wide $R_BEHIND behind / $R_AHEAD ahead of $UP."
+  ssay "  repo-wide is INFORMATION ONLY. Only the built-source scope(s) below set the verdict."
 
-  if [ "$S_BEHIND" -gt 0 ] || [ "$S_AHEAD" -gt 0 ]; then
-    S_STALE=$(( S_STALE + 1 ))
-    ssay "🔴 DRIFT — source repo $N is NOT current: $S_BEHIND behind / $S_AHEAD ahead of $UP (on $BR at $SHA)."
-    ssay "  nix/pkgs builds a package from THIS TREE. Whatever version string that"
-    ssay "  package carries, the code in the binary is the code sitting here."
-    ssay "  fix (on that host): git -C $SR pull --ff-only   then a home-manager switch"
-    s_rc=17
-  else
-    ssay "source repo $N: current — $BR == $UP at $SHA."
-  fi
+  for X in $S_SUBS; do
+    case "$X" in
+      "$N:"*) ;;
+      *) continue ;;
+    esac
+    SUBP="${X#*:}"
+    K="$(s_key "$N" "$SUBP")"
+    S_EXAMINED=$(( S_EXAMINED + 1 ))
+
+    # The subtree TREE OID — what the two hosts are compared on, because it is
+    # what the derivation actually copies. A repo HEAD would report a difference
+    # for any commit anywhere in the repo.
+    TREE="$(git -C "$SR" rev-parse --short=12 "HEAD:$SUBP" 2>/dev/null)"
+    [ -n "$TREE" ] || TREE=NOSUBTREE
+    S_FACTS="$S_FACTS $K=$TREE"
+
+    if [ -z "$SUBP" ]; then
+      SB="$R_BEHIND"
+      SA="$R_AHEAD"
+    else
+      SB="$(git -C "$SR" rev-list --count "HEAD..$UP" -- "$SUBP" 2>/dev/null)"
+      SA="$(git -C "$SR" rev-list --count "$UP..HEAD" -- "$SUBP" 2>/dev/null)"
+    fi
+    case "$SB" in ""|*[!0-9]*) SB=-1 ;; esac
+    case "$SA" in ""|*[!0-9]*) SA=-1 ;; esac
+    if [ "$SB" = -1 ] || [ "$SA" = -1 ]; then
+      ssay "  BUILT SOURCE $K: could not compare $BR to $UP over that path — currency NOT evaluated."
+      S_UNMEASURED=$(( S_UNMEASURED + 1 ))
+      continue
+    fi
+
+    if [ "$SB" -gt 0 ] || [ "$SA" -gt 0 ]; then
+      S_STALE=$(( S_STALE + 1 ))
+      ssay "🔴 DRIFT — BUILT SOURCE $K is NOT current: $SB behind / $SA ahead of $UP (repo-wide $R_BEHIND behind / $R_AHEAD ahead)."
+      ssay "  nix/pkgs builds a package from THIS SUBTREE. Whatever version string"
+      ssay "  that package carries, the code in the binary is the code sitting here."
+      ssay "  fix (on that host): git -C $SR pull --ff-only   then a home-manager switch"
+      s_rc=17
+    elif [ "$R_BEHIND" -gt 0 ] || [ "$R_AHEAD" -gt 0 ]; then
+      ssay "  BUILT SOURCE $K is CURRENT ($SB behind / $SA ahead) — the repo-wide $R_BEHIND behind /"
+      ssay "  $R_AHEAD ahead touch nothing this package is built from. Information, NOT drift."
+    else
+      ssay "  BUILT SOURCE $K is CURRENT — $BR == $UP at $SHA."
+    fi
+  done
 done
 
 # 🔴 EXAMINED BESIDE STALE, and UNMEASURED beside both. A bare "0 stale" from a
-# scan that walked no repos, or one whose every fetch failed, is exactly what a
-# checker wired to nothing prints.
+# scan that walked no scopes, or one whose every fetch failed, is exactly what a
+# checker wired to nothing prints. The unit counted here is the BUILT-SOURCE
+# SCOPE, not the repo — the repo count is printed beside it.
 if [ "$S_EXAMINED" = 0 ]; then
   ssay "source repos: NOT EVALUATED — nix/pkgs under $repo names no \${workspace}/ source ($S_FILES nix file(s) scanned)."
   ssay "  a scan that examined nothing is not a clean scan; it is no scan."
 else
-  ssay "source repos: examined=$S_EXAMINED stale=$S_STALE unmeasured=$S_UNMEASURED ($S_FILES nix file(s) scanned)"
+  ssay "source repos: examined=$S_EXAMINED stale=$S_STALE unmeasured=$S_UNMEASURED built-source scope(s) over $S_REPOS repo(s) ($S_FILES nix file(s) scanned)"
 fi
 
 echo "[$label] FACT src-repos$S_FACTS"
 echo "[$label] SRC-RC=$s_rc"
 '
-
 # The payload actually shipped to each host: the git CHECK in a SUBSHELL (so its
 # many `exit`s end the subshell and not the run) followed by the parity scan and
 # the source-repo scan.
@@ -1362,7 +1469,8 @@ else
       echo "[srcrepo]   $N — named by nix/pkgs on only one host's checkout; not compared."
       S_DISAGREE=$(( S_DISAGREE + 1 ))
     elif [ "$LV" != "$RV" ]; then
-      echo "[srcrepo]   $N — $LOCAL_ROLE at $LV, $REMOTE_ROLE at $RV: the two hosts build DIFFERENT source."
+      echo "[srcrepo]   $N — $LOCAL_ROLE tree $LV, $REMOTE_ROLE tree $RV: the two hosts build DIFFERENT source."
+      echo "[srcrepo]     (srcDir subtree trees, not repo HEADs — a commit outside this path does not appear here.)"
       S_DISAGREE=$(( S_DISAGREE + 1 ))
     else
       S_AGREE=$(( S_AGREE + 1 ))
@@ -1527,7 +1635,8 @@ if [ "$rc" != 0 ]; then
   echo "  rc14=managed symlinks resolve to nothing (needs a home-manager switch on that host)"
   echo "  rc15=host parity: settings.json key sets / enabledPlugins differ, or enabled-but-not-installed"
   echo "  rc16=NOT drift: the fuzzyclaw phase-2 gate OPENED (0 rows depend on fuzzyclaw for an age)"
-  echo "  rc17=a SOURCE REPO nix/pkgs builds a package from is behind/ahead its upstream on that host"
+  echo "  rc17=the srcDir SUBTREE a nix/pkgs package is BUILT FROM is behind/ahead its own upstream"
+  echo "       on that host. A repo that is behind OUTSIDE every srcDir is reported, never rc 17."
   echo "       (ranks between rc8 and rc14 — the digit is not the severity; see severity() )"
 fi
 [ -n "$UNCHECKED" ] && echo "drift-check: NOT checked: $UNCHECKED"

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -902,9 +902,9 @@ for N in $S_NAMES; do
   fi
 
   # 🔴 The comparison is against the OWN upstream of whatever branch is checked
-  # out, never a hardcoded
-  # `main`. These repos do not agree on a default branch — homelab-talos works on
-  # `trunk` — and assuming one would be a guess printed as a measurement.
+  # out, never a hardcoded `main`. These repos do not agree on a default branch
+  # — homelab-talos works on `trunk` — and assuming one would be a guess printed
+  # as a measurement.
   UP=""
   if [ "$BR" != DETACHED ]; then
     UP="$(git -C "$SR" rev-parse -q --verify --symbolic-full-name "$BR@{upstream}" 2>/dev/null)"
@@ -954,14 +954,16 @@ echo "[$label] SRC-RC=$s_rc"
 '
 
 # The payload actually shipped to each host: the git CHECK in a SUBSHELL (so its
-# many `exit`s end the subshell and not the run) followed by the parity scan.
+# many `exit`s end the subshell and not the run) followed by the parity scan and
+# the source-repo scan.
 # Composed rather than run as two ssh legs so an unreachable host is still ONE
 # missed connection and ONE bump of the streak counter.
 #
 # The exit status is the GIT verdict, byte-for-byte what it always was — every
-# pinned rc in the suite is a statement about that number. The parity verdict
-# rides back on the PARITY-RC= line and is folded in by the driver through the
-# same severity() table, so there is exactly one severity ranking in this file.
+# pinned rc in the suite is a statement about that number. The parity and
+# source-repo verdicts ride back on the PARITY-RC= and SRC-RC= lines and are
+# folded in by the driver through the same severity() table, so there is exactly
+# one severity ranking in this file.
 PAYLOAD="(
 $CHECK
 )

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -101,11 +101,84 @@
 #       installed there. A short, EXPLICITLY ENUMERATED set of settings.json keys
 #       is exempt from the key-set half — see "PER-HOST settings.json KEYS"
 #       below. Nothing else is, and an unknown key is never exempt.
+#   17  DRIFT — a SOURCE REPO devrc BUILDS A PACKAGE FROM is not current on that
+#       host: behind or ahead of its own upstream. 🔴 The SECOND thing git parity
+#       on devrc structurally cannot see. See "SOURCE-REPO PARITY" below. The
+#       number is high because 5/7/9/11 are reserved to ship.sh meanings this
+#       script does not take; its SEVERITY is set by the table, not by the digit,
+#       and it ranks between 8 and 14 — see severity() for why.
 #   16  ACTIONABLE, not drift — the fuzzyclaw PHASE-2 GATE has OPENED: zero rows
 #       still take their `age_secs` from fuzzyclaw alone, so the readers can be
 #       removed. See "THE FUZZYCLAW PHASE-2 GATE" below. It is the LEAST severe
 #       code this file owns, so it can only ever be the verdict when nothing
 #       else is wrong, and the final line says ACTIONABLE rather than DRIFT.
+#
+# ── SOURCE-REPO PARITY (rc 17) ────────────────────────────────────────────────
+# 🔴 A THIRD KIND OF PARITY, AND THE FIRST TWO ARE BLIND TO IT. devrc builds some
+# packages from a LOCAL WORKING TREE OF ANOTHER REPO — `nix/pkgs/**` derivations
+# whose `src` is `${workspace}/<repo>/…`. The devrc checkout can be byte-identical
+# to origin/main, every managed symlink can resolve, and the binary that gets
+# installed is still built from a source tree that is months old, because NOTHING
+# CONVERGES THOSE REPOS: ship.sh is scoped to $HOME/workspace/devrc and this file
+# used to have no idea they existed.
+#
+# MEASURED 2026-08-14, on clawgatectl:
+#   17:44  homelab-infra #323 added `task status`/`task comment` and set the Go
+#          source's own default buildVersion to "0.7.95".
+#   17:48  devrc #483 bumped clawgatectl.nix's hand-written version literal
+#          0.7.87 -> 0.7.95 and shipped to BOTH hosts.
+# The workbench's ~/workspace/homelab-talos was current, so it got a real 0.7.95.
+# The laptop's was frozen 24 commits back; its client.go correctly said "0.7.87"
+# and the nix ldflag OVERWROTE that with "0.7.95". The laptop then carried a
+# binary with neither subcommand, wearing the label of one that had both:
+# `clawgatectl task status <id> in_progress` printed help and exited 0 — a silent
+# no-op against a CLI whose write ritual the `clawgate` skill makes mandatory.
+# This deadman was FULLY GREEN on that laptop throughout. The version half is
+# fixed in nix/pkgs/tools/clawgatectl.nix (the version is now read out of the
+# compiled source); THIS is the other half — noticing the stale tree at all.
+#
+# 🔴 THE COVERED SET IS DERIVED, NEVER LISTED. The payload reads `nix/pkgs/**.nix`
+# out of the checkout it is examining and collects every `${workspace}/<name>` it
+# finds outside a comment, so a THIRD such package is covered the day it is
+# added. A hardcoded pair would have been correct on the day it was written and
+# silently incomplete afterwards, which is the same shape as the bug. The
+# derivation is pinned TWO-WAY by `test_drift_check.py::test_the_source_repo_set_
+# is_pinned_two_way_against_nix_pkgs` — it fails when the set GROWS or SHRINKS.
+#
+# 🔴 EXAMINED BESIDE STALE, again. `examined=N stale=M unmeasured=K` is the
+# claim; none of the three numbers means anything alone. A repo whose fetch
+# failed, whose branch has no upstream, or which is absent from this host is
+# UNMEASURED — never folded into "0 stale", because a checker wired to nothing
+# reports exactly that zero.
+#
+# WHAT IS DRIFT HERE AND WHAT IS NOT — the line is "did we MEASURE a divergence":
+#   * behind / ahead of the branch's own upstream ................. rc 17
+#   * repo ABSENT on this host ......... reported, NOT drift. The derivations
+#     guard on pathExists and simply omit the binary; a host without the checkout
+#     is a documented, tolerated state (see clawgatectl.nix's header).
+#   * `git fetch` FAILED ............... reported, NOT drift. These repos are
+#     private and reached over ssh, and a systemd --user unit has no ssh-agent.
+#     "We could not look" must never read as either a pass or a divergence.
+#   * DETACHED HEAD / branch with no upstream ... reported, NOT drift. There is
+#     no defined answer to compare against; inventing one (assume `main`) would
+#     be a guess presented as a measurement.
+#   * DIRTY TREE ....................... reported, NOT drift, and reported even
+#     when the repo is otherwise current: these derivations build the TREE, not
+#     the commit, so an uncommitted or untracked file IS in the binary. The
+#     workbench's homelab-talos is routinely dirty; making that fail the unit
+#     would be a permanently-red gate.
+#
+# 🔴 THE CROSS-HOST HALF IS INFORMATION ONLY, deliberately. The driver diffs the
+# two hosts' `FACT src-repos` lines and reports repos whose HEAD differs — the
+# most direct statement of "these two machines build different code" — but sets
+# NO rc, because whether a given HEAD is WRONG is already answered per host by
+# the upstream comparison, which has a defined correct answer. Two hosts sitting
+# on different branches of a shared development repo is normal, and a code that
+# fires on it would be a permanently-red gate. Like every cross-host claim here
+# it prints NOT COMPARED unless facts arrived from BOTH machines.
+#
+# READ-ONLY, like everything else in this file: `fetch`, `rev-parse`, `rev-list`,
+# `symbolic-ref`, `status`. It never pulls, never switches, never repairs.
 #
 # ── THE FUZZYCLAW PHASE-2 GATE (rc 16) ────────────────────────────────────────
 # "Is it safe to delete the fuzzyclaw readers yet?" was answered by somebody
@@ -174,7 +247,12 @@
 # is reading a timer's output, so the single number it hands to systemd must be
 # the worst thing found, or an un-pushed workbench could hide behind a merely
 # behind laptop. Severity order (worst first):
-#     8  >  14  >  13  >  6  >  4  >  3  >  12  >  15  >  10  >  16
+#     8  >  17  >  14  >  13  >  6  >  4  >  3  >  12  >  15  >  10  >  16
+# 🔴 THAT ORDER IS THE severity() TABLE, NOT THE DIGITS — it never was monotonic
+# (14 outranks 13 outranks 6 outranks 4), and 17 is not "less severe than 16"
+# because it is larger. Every code below 16 that is still free (5, 7, 9, 11) is
+# reserved to a ship.sh meaning this script does not take, so a new DRIFT code
+# has nowhere to go but upward; its rank is stated in severity() and here.
 # (6 is unreachable through this path today — the script exits 6 directly before
 # any per-host leg runs — but the order is documented for every code it owns,
 # and severity() ranks it rather than falling through to the unknown-code slot.)
@@ -203,6 +281,13 @@
 #                        "/nix/store/"). Exists so the test suite can build a
 #                        fixture tree; the default is the only correct value on
 #                        a real host, and is NOT forwarded over ssh.
+#   DRIFT_SRC_FETCH_TIMEOUT  seconds each SOURCE REPO's `git fetch` may take
+#                        (default 30, integer). These are private repos over ssh
+#                        and a user unit has no agent, so the failure mode to
+#                        avoid is a HANG, not an error — an error is reported.
+#                        Deliberately NOT forwarded over ssh: the remote host
+#                        uses the default, and every value sent across that hop
+#                        is one that has to be proved safe.
 #   DRIFT_UNREACHABLE_ESCALATE  consecutive unreachable runs before rc 13 (default 4)
 #   DRIFT_STATE_DIR  where the unreachable streak is persisted
 #                    (default ${XDG_STATE_HOME:-$HOME/.local/state}/drift-check)
@@ -244,6 +329,7 @@ DRIFT_UNREACHABLE_ESCALATE="${DRIFT_UNREACHABLE_ESCALATE:-4}"
 DRIFT_STATE_DIR="${DRIFT_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/drift-check}"
 DRIFT_SESSION_MANAGER="${DRIFT_SESSION_MANAGER:-$_drift_dir/session-manager}"
 DRIFT_PHASE2_TIMEOUT="${DRIFT_PHASE2_TIMEOUT:-60}"
+DRIFT_SRC_FETCH_TIMEOUT="${DRIFT_SRC_FETCH_TIMEOUT:-30}"
 
 # 🔴 Both tunables are INTERPOLATED INTO A SCRIPT THAT RUNS ON THE OTHER HOST
 # (piped to `bash -s` over ssh), so a non-integer value is remote code execution
@@ -263,6 +349,9 @@ require_int DRIFT_UNREACHABLE_ESCALATE "$DRIFT_UNREACHABLE_ESCALATE"
 # non-integer would make the phase-2 scan fail in a way that reads as "the tool
 # is broken" rather than "you passed nonsense".
 require_int DRIFT_PHASE2_TIMEOUT "$DRIFT_PHASE2_TIMEOUT"
+# Same reasoning as DRIFT_PHASE2_TIMEOUT: not interpolated into a remote payload,
+# but handed to `timeout`, where a non-integer reads as "the tool is broken".
+require_int DRIFT_SRC_FETCH_TIMEOUT "$DRIFT_SRC_FETCH_TIMEOUT"
 
 DO_LOCAL=1
 DO_REMOTE=1
@@ -305,6 +394,17 @@ severity() {
   case "${1:-0}" in
     0)  echo 0 ;;
     8)  echo 70 ;;
+    # 17 (a source repo devrc BUILDS FROM is not current here) sits between 8
+    # and 14, and the digit says nothing about that — see the header.
+    #   BELOW 8, because a diverged devrc stops every future change to this host,
+    #   of which a stale source repo is one instance; and rc 8's rescue can
+    #   destroy work if done carelessly, while this one is a pull.
+    #   ABOVE 14, because a dangling managed symlink is LOUD at the moment of use
+    #   ("command not found") whereas this is SILENT: the measured failure shipped
+    #   a binary that ran, exited 0, and did nothing, wearing a version string
+    #   that said otherwise. It also carries the AHEAD case — un-pushed commits in
+    #   a repo whose code this host compiles — which is rc 8's loss class.
+    17) echo 67 ;;
     # 14 (a host's managed symlinks resolve to nothing) sits between 8 and 13.
     # It is BELOW 8 because rc 8 means work exists on exactly one machine and a
     # careless fix destroys it, whereas a broken deployment is repaired by a
@@ -678,6 +778,181 @@ echo "[$label] FACT installed-plugins $iplug"
 echo "[$label] PARITY-RC=$p_rc"
 '
 
+# ── The per-host SOURCE-REPO routine ──────────────────────────────────────────
+# 🔴 See "SOURCE-REPO PARITY (rc 17)" in the header for what this measures, what
+# counts as drift and what deliberately does not. Here: how it is derived, and
+# why it cannot be a list.
+#
+# devrc builds packages from LOCAL WORKING TREES of other repos — a `src` of
+# `${workspace}/<repo>/…` in nix/pkgs. Nothing converges those repos, so a host
+# with a perfect devrc checkout can still compile months-old code. The covered
+# set is read out of nix/pkgs ON THE HOST BEING EXAMINED rather than passed in
+# from here, for two reasons: a hardcoded pair goes stale the moment a third
+# package is added (the same shape as the bug), and deriving it locally means
+# nothing derived has to be interpolated into a payload that executes on the
+# other machine.
+#
+# 🔴 COMMENTS ARE EXCLUDED BY TRUNCATION — each line is cut at its first `#`
+# before anything is read out of it, which covers a whole-line comment and a
+# trailing one with the same rule. clawgatectl.nix's own header discusses
+# `~/workspace/homelab-talos` in prose repeatedly and this very file documents the
+# `${workspace}/` pattern it is looking for, so a whole-file grep would "find"
+# sources in the documentation. What survives is scanned for EVERY occurrence, not
+# just the first: one line may legitimately name two sources. The known bound,
+# stated rather than engineered away: a `#` inside a nix STRING would truncate
+# early. That direction UNDER-reports, and under-reporting is what the two-way
+# pin against the real nix/pkgs exists to catch.
+#
+# 🔴 NO `find`, for the same reason the parity walk avoids it: the laptop resolves
+# `find` to BUSYBOX, which does not implement `-xtype`, rejects it by printing
+# usage to stderr and EXITS 0 — a confident zero from a scan wired to nothing.
+# `shopt -s globstar` plus a glob is bash's own, and behaves identically on both.
+#
+# Loop and local variable names are UPPERCASE for the same reason they are in the
+# parity payload: the suite's reverse-PATH tokenizer reads a lowercase word in
+# command position (including inside `$(( … ))`) as a command, and an uppercase
+# one is dropped by its filter instead of needing a "this is prose" ledger entry.
+#
+# READ-ONLY BY CONSTRUCTION: git fetch / rev-parse / symbolic-ref / rev-list /
+# status, plus printf, wc, tr, sed, head, awk and shell builtins. It writes
+# nothing and creates nothing.
+SRCREPO='
+set -uo pipefail
+label="${DRIFT_LABEL:-host}"
+repo="${DRIFT_REPO:-$HOME/workspace/devrc}"
+sfto="${DRIFT_SRC_FETCH_TIMEOUT:-30}"
+ssay() { echo "[$label] $*"; }
+
+S_NAMES=""
+s_add() { # s_add <repo-name> — dedupe, as two derivations can share one repo
+  case " $S_NAMES " in
+    *" $1 "*) return 0 ;;
+  esac
+  S_NAMES="$S_NAMES $1"
+}
+
+s_scan() { # s_scan <nix-file> — collect the workspace-relative repo names it uses
+  local LN REST NAME
+  while IFS= read -r LN || [ -n "$LN" ]; do
+    LN="${LN%%#*}"
+    while : ; do
+      case "$LN" in *\$\{workspace\}/*) ;; *) break ;; esac
+      REST="${LN#*\$\{workspace\}/}"
+      NAME="${REST%%[!A-Za-z0-9._-]*}"
+      [ -n "$NAME" ] && s_add "$NAME"
+      LN="$REST"
+    done
+  done < "$1"
+}
+
+shopt -s nullglob globstar
+S_FILES=0
+for F in "$repo"/nix/pkgs/**/*.nix; do
+  [ -f "$F" ] || continue
+  S_FILES=$(( S_FILES + 1 ))
+  s_scan "$F"
+done
+
+S_EXAMINED=0
+S_STALE=0
+S_UNMEASURED=0
+S_FACTS=""
+s_rc=0
+
+for N in $S_NAMES; do
+  SR="$HOME/workspace/$N"
+  S_EXAMINED=$(( S_EXAMINED + 1 ))
+
+  # A worktree checkout has .git as a FILE, a normal clone as a directory.
+  if [ ! -e "$SR/.git" ]; then
+    ssay "source repo $N: ABSENT at $SR — currency NOT evaluated."
+    ssay "  nix/pkgs builds from it; this host cannot. Reported, NOT drift: the"
+    ssay "  derivations guard on pathExists and simply omit the binary."
+    S_FACTS="$S_FACTS $N=ABSENT"
+    S_UNMEASURED=$(( S_UNMEASURED + 1 ))
+    continue
+  fi
+
+  SHA="$(git -C "$SR" rev-parse --short=12 HEAD 2>/dev/null)"
+  [ -n "$SHA" ] || SHA=UNBORN
+  S_FACTS="$S_FACTS $N=$SHA"
+  BR="$(git -C "$SR" symbolic-ref --quiet --short HEAD 2>/dev/null || echo DETACHED)"
+
+  # DIRTY is reported for every present repo, INCLUDING a current one: these
+  # derivations copy the working TREE, so an uncommitted edit or an untracked
+  # .go file is in the binary while `git log` says nothing happened.
+  ST="$(git -C "$SR" status --porcelain 2>/dev/null)"
+  S_DIRTY=0
+  [ -n "$ST" ] && S_DIRTY="$(printf "%s\n" "$ST" | wc -l | tr -d " ")"
+  if [ "$S_DIRTY" != 0 ]; then
+    ssay "source repo $N: DIRTY — $S_DIRTY path(s) modified or untracked."
+    ssay "  the build reads this TREE, not the commit, so those paths are IN the"
+    ssay "  binary. Reported, never drift on its own."
+  fi
+
+  FERR="$(timeout "$sfto" git -C "$SR" fetch --quiet origin 2>&1)"
+  frc=$?
+  if [ "$frc" != 0 ]; then
+    ssay "source repo $N: on branch $BR at $SHA — git fetch FAILED (rc=$frc), currency NOT evaluated."
+    printf "%s\n" "$FERR" | head -n 3 | sed "s|^|[$label]   git: |"
+    ssay "  these repos are private and reached over ssh, and a systemd --user"
+    ssay "  unit has no ssh-agent. NOT drift — and NOT a pass either."
+    S_UNMEASURED=$(( S_UNMEASURED + 1 ))
+    continue
+  fi
+
+  # 🔴 The comparison is against the OWN upstream of whatever branch is checked
+  # out, never a hardcoded
+  # `main`. These repos do not agree on a default branch — homelab-talos works on
+  # `trunk` — and assuming one would be a guess printed as a measurement.
+  UP=""
+  if [ "$BR" != DETACHED ]; then
+    UP="$(git -C "$SR" rev-parse -q --verify --symbolic-full-name "$BR@{upstream}" 2>/dev/null)"
+  fi
+  if [ -z "$UP" ]; then
+    ssay "source repo $N: on branch $BR at $SHA — no upstream to compare against, currency NOT evaluated."
+    ssay "  a detached HEAD or an untracked branch has no defined right answer."
+    S_UNMEASURED=$(( S_UNMEASURED + 1 ))
+    continue
+  fi
+
+  CNT="$(git -C "$SR" rev-list --left-right --count "$UP...HEAD" 2>/dev/null)"
+  S_BEHIND="$(printf "%s" "$CNT" | awk "{print \$1}")"
+  S_AHEAD="$(printf "%s" "$CNT" | awk "{print \$2}")"
+  case "$S_BEHIND" in ""|*[!0-9]*) S_BEHIND=-1 ;; esac
+  case "$S_AHEAD" in ""|*[!0-9]*) S_AHEAD=-1 ;; esac
+  if [ "$S_BEHIND" = -1 ] || [ "$S_AHEAD" = -1 ]; then
+    ssay "source repo $N: could not compare $BR to $UP — currency NOT evaluated."
+    S_UNMEASURED=$(( S_UNMEASURED + 1 ))
+    continue
+  fi
+
+  if [ "$S_BEHIND" -gt 0 ] || [ "$S_AHEAD" -gt 0 ]; then
+    S_STALE=$(( S_STALE + 1 ))
+    ssay "🔴 DRIFT — source repo $N is NOT current: $S_BEHIND behind / $S_AHEAD ahead of $UP (on $BR at $SHA)."
+    ssay "  nix/pkgs builds a package from THIS TREE. Whatever version string that"
+    ssay "  package carries, the code in the binary is the code sitting here."
+    ssay "  fix (on that host): git -C $SR pull --ff-only   then a home-manager switch"
+    s_rc=17
+  else
+    ssay "source repo $N: current — $BR == $UP at $SHA."
+  fi
+done
+
+# 🔴 EXAMINED BESIDE STALE, and UNMEASURED beside both. A bare "0 stale" from a
+# scan that walked no repos, or one whose every fetch failed, is exactly what a
+# checker wired to nothing prints.
+if [ "$S_EXAMINED" = 0 ]; then
+  ssay "source repos: NOT EVALUATED — nix/pkgs under $repo names no \${workspace}/ source ($S_FILES nix file(s) scanned)."
+  ssay "  a scan that examined nothing is not a clean scan; it is no scan."
+else
+  ssay "source repos: examined=$S_EXAMINED stale=$S_STALE unmeasured=$S_UNMEASURED ($S_FILES nix file(s) scanned)"
+fi
+
+echo "[$label] FACT src-repos$S_FACTS"
+echo "[$label] SRC-RC=$s_rc"
+'
+
 # The payload actually shipped to each host: the git CHECK in a SUBSHELL (so its
 # many `exit`s end the subshell and not the run) followed by the parity scan.
 # Composed rather than run as two ssh legs so an unreachable host is still ONE
@@ -692,6 +967,7 @@ $CHECK
 )
 _drift_git_rc=\$?
 $PARITY
+$SRCREPO
 exit \$_drift_git_rc"
 
 rc=0
@@ -730,6 +1006,32 @@ parity_rc_of() { # parity_rc_of <host-output> -> that host's parity rc (0 if non
   local V
   V="$(printf '%s\n' "$1" | sed -n 's/^\[[^]]*\] PARITY-RC=//p' | head -n 1)"
   case "$V" in ''|*[!0-9]*) echo 0 ;; *) echo "$V" ;; esac
+}
+
+src_rc_of() { # src_rc_of <host-output> -> that host's source-repo rc (0 if none)
+  # Same contract as parity_rc_of, for the same reason: an ABSENT verdict (an
+  # older drift-check.sh on the far side, a truncated stream) must not invent a
+  # failure. The absence stays visible because the FACT line is missing too, and
+  # the cross-host block then reports NOT COMPARED.
+  local V
+  V="$(printf '%s\n' "$1" | sed -n 's/^\[[^]]*\] SRC-RC=//p' | head -n 1)"
+  case "$V" in ''|*[!0-9]*) echo 0 ;; *) echo "$V" ;; esac
+}
+
+src_names_of() { # src_names_of <name=head list> -> just the names
+  local X OUT=""
+  for X in $1; do OUT="$OUT ${X%%=*}"; done
+  printf '%s' "$OUT"
+}
+
+src_head_of() { # src_head_of <name=head list> <name> -> that repo's HEAD token
+  local X
+  for X in $1; do
+    case "$X" in
+      "$2="*) printf '%s' "${X#*=}"; return 0 ;;
+    esac
+  done
+  printf ''
 }
 
 only_in() { # only_in <set-a> <set-b> -> members of a absent from b
@@ -890,6 +1192,7 @@ if [ "$DO_LOCAL" = 1 ]; then
   note_rc "$?"
   [ -n "$LOCAL_OUT" ] && printf '%s\n' "$LOCAL_OUT"
   note_rc "$(parity_rc_of "$LOCAL_OUT")"
+  note_rc "$(src_rc_of "$LOCAL_OUT")"
   mark_checked "$LOCAL_ROLE (local)"
   echo
 else
@@ -939,6 +1242,7 @@ if [ "$DO_REMOTE" = 1 ]; then
     streak_reset "$REMOTE_ROLE"
     note_rc "$remrc"
     note_rc "$(parity_rc_of "$REMOTE_OUT")"
+    note_rc "$(src_rc_of "$REMOTE_OUT")"
     mark_checked "$REMOTE_ROLE (remote)"
   fi
   echo
@@ -1021,6 +1325,52 @@ else
       echo "[parity] enabledPlugins AGREE."
     fi
   fi
+fi
+echo
+
+# ── CROSS-HOST SOURCE-REPO COMPARISON ─────────────────────────────────────────
+# 🔴 INFORMATION ONLY — it sets no exit code, and that is a decision, not an
+# omission. Whether a given source-repo HEAD is WRONG has a defined answer and it
+# is measured PER HOST above, against that branch's own upstream. "The two hosts
+# are on different commits" has no such answer: these are shared development
+# repos and one machine sitting on a feature branch is normal. A code that fired
+# on it would be red most of the time, and a permanently-red gate is worse than
+# no gate — the same refusal this file already makes for an unreachable laptop.
+#
+# What it IS worth printing is the most direct statement available of "these two
+# machines compile different code", which no per-host line can make.
+#
+# 🔴 AND IT IS ONLY VISIBLE WITH BOTH. One host's facts is not "the hosts agree",
+# it is "agreement not looked for", and the two must never print the same way.
+echo "=== source-repo parity ($LOCAL_ROLE vs $REMOTE_ROLE) ==="
+L_SRC="$(fact_of "$LOCAL_OUT" src-repos)"
+R_SRC="$(fact_of "$REMOTE_OUT" src-repos)"
+if [ -z "$L_SRC" ] || [ -z "$R_SRC" ]; then
+  echo "[srcrepo] NOT COMPARED — needs a fact set from EACH host; obtained from: ${CHECKED:-none}."
+  echo "[srcrepo]   this is not 'the two machines build the same source'. Nothing was compared."
+else
+  L_SN="$(src_names_of "$L_SRC")"
+  R_SN="$(src_names_of "$R_SRC")"
+  S_AGREE=0
+  S_DISAGREE=0
+  for N in $L_SN $(only_in "$R_SN" "$L_SN"); do
+    LV="$(src_head_of "$L_SRC" "$N")"
+    RV="$(src_head_of "$R_SRC" "$N")"
+    if [ -z "$LV" ] || [ -z "$RV" ]; then
+      echo "[srcrepo]   $N — named by nix/pkgs on only one host's checkout; not compared."
+      S_DISAGREE=$(( S_DISAGREE + 1 ))
+    elif [ "$LV" != "$RV" ]; then
+      echo "[srcrepo]   $N — $LOCAL_ROLE at $LV, $REMOTE_ROLE at $RV: the two hosts build DIFFERENT source."
+      S_DISAGREE=$(( S_DISAGREE + 1 ))
+    else
+      S_AGREE=$(( S_AGREE + 1 ))
+    fi
+  done
+  # Counted into a variable first, never interpolated as `$(( … ))` inside the
+  # message: a command substitution ENDS the printer segment, leaving the rest of
+  # the sentence looking like a command line to the suite's tokenizer.
+  S_COMPARED=$(( S_AGREE + S_DISAGREE ))
+  echo "[srcrepo] compared=$S_COMPARED same=$S_AGREE differing=$S_DISAGREE — information only; the per-host lines above carry the verdict."
 fi
 echo
 
@@ -1175,6 +1525,8 @@ if [ "$rc" != 0 ]; then
   echo "  rc14=managed symlinks resolve to nothing (needs a home-manager switch on that host)"
   echo "  rc15=host parity: settings.json key sets / enabledPlugins differ, or enabled-but-not-installed"
   echo "  rc16=NOT drift: the fuzzyclaw phase-2 gate OPENED (0 rows depend on fuzzyclaw for an age)"
+  echo "  rc17=a SOURCE REPO nix/pkgs builds a package from is behind/ahead its upstream on that host"
+  echo "       (ranks between rc8 and rc14 — the digit is not the severity; see severity() )"
 fi
 [ -n "$UNCHECKED" ] && echo "drift-check: NOT checked: $UNCHECKED"
 exit "$rc"

--- a/scripts/tests/test_clawgatectl_version.py
+++ b/scripts/tests/test_clawgatectl_version.py
@@ -1,0 +1,313 @@
+"""The clawgatectl derivation must not be able to LABEL a binary with a version
+its source does not carry.
+
+WHAT THIS IS FOR
+----------------
+`nix/pkgs/tools/clawgatectl.nix` builds a Go CLI from a LOCAL working tree of a
+DIFFERENT repo (`~/workspace/homelab-talos/containers/clawgate`). Two repos, two
+delivery mechanisms, and only one of them is automatic:
+
+  * the CODE is read live off disk — nothing in devrc converges that repo
+    (`scripts/ship.sh` is scoped to `$HOME/workspace/devrc`);
+  * the VERSION used to be a hand-maintained literal in the devrc file, stamped
+    into the binary with `-X main.buildVersion=`.
+
+Measured 2026-08-14: homelab-infra #323 added `task status`/`task comment` and
+set the Go default to "0.7.95"; four minutes later devrc #483 bumped the nix
+literal 0.7.87 -> 0.7.95 and shipped to both hosts. The laptop's homelab-talos
+was 24 commits behind — its client.go correctly said "0.7.87" — and the ldflag
+OVERWROTE that truth. The laptop then carried a binary with neither subcommand,
+labelled 0.7.95; `clawgatectl task status <id> in_progress` printed help and
+exited 0. A silent no-op wearing a correct-looking version string.
+
+So the invariant asserted here is: the version in the store path and the version
+compiled into the binary both come from the file being compiled, and there is no
+literal anywhere that can disagree with it.
+
+TWO LAYERS, ON PURPOSE
+----------------------
+1. STRUCTURAL (always runs): no hardcoded version literal survives in the nix
+   file, the extraction reads the Go source, and the ldflag is fed the SAME
+   derived value rather than a second literal.
+2. BEHAVIOURAL (needs `nix-instantiate`): the file is actually EVALUATED against
+   throwaway fixture source trees, with `pkgs` stubbed down to the four
+   attributes it touches. That is the layer that can see a regex which parses
+   but extracts the wrong thing — a structural check type-checks past that.
+
+The behavioural layer FAILS rather than skips when `nix-instantiate` is missing
+— the policy `test_opencode_config.py::nix_eval` already sets in this repo, and
+`nix-instantiate` is both a run-tests.sh REQUIRED_TOOL and on the flake gate's
+sandbox PATH. A skip there would be a green that measured nothing.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+NIX_FILE = REPO_ROOT / "nix" / "pkgs" / "tools" / "clawgatectl.nix"
+FUZZYCLAW_NIX = REPO_ROOT / "nix" / "pkgs" / "tools" / "tmux-fuzzyclaw.nix"
+
+SRC_SUBDIR = "homelab-talos/containers/clawgate/cmd/clawgatectl"
+
+# A `pkgs` cut down to exactly what clawgatectl.nix touches. `buildGoModule` is
+# the identity function, so evaluating the file produces the ARGUMENT ATTRSET
+# rather than a derivation — no store write, no build, no network, and every
+# field this test cares about is readable straight off it.
+STUB_NIX = """{ file, workspace }:
+let
+  lib = {
+    cleanSource = x: x;
+    optionals = c: l: if c then l else [ ];
+    platforms = { linux = [ "x86_64-linux" ]; };
+  };
+  pkgs = { inherit lib; buildGoModule = a: a; };
+  out = import file { inherit pkgs workspace; };
+in
+if out == [ ] then "UNAVAILABLE"
+else {
+  version = (builtins.head out).version;
+  ldflags = (builtins.head out).ldflags;
+  pname = (builtins.head out).pname;
+}
+"""
+
+def _tree(tmp_path, *, client_go=None, main_go='package main\n\nfunc main() {}\n'):
+    """Build a throwaway `workspace` containing the clawgatectl source files."""
+    ws = tmp_path / "ws"
+    d = ws / SRC_SUBDIR
+    d.mkdir(parents=True, exist_ok=True)
+    if main_go is not None:
+        (d / "main.go").write_text(main_go)
+    if client_go is not None:
+        (d / "client.go").write_text(client_go)
+    return ws
+
+
+def _eval(tmp_path, ws):
+    # 🔴 FAIL, NOT SKIP — the same policy scripts/tests/test_opencode_config.py's
+    # `nix_eval()` already sets, and for the same reason: this is the only layer
+    # that can see a regex which parses but extracts the wrong thing, so a skip
+    # here is a green that measured nothing. `nix-instantiate` is a REQUIRED_TOOL
+    # in run-tests.sh and is on the flake gate's sandbox PATH, so an absence is a
+    # broken environment, not an expected condition.
+    if shutil.which("nix-instantiate") is None:
+        pytest.fail(
+            "nix-instantiate not on PATH. These tests EVALUATE clawgatectl.nix "
+            "against fixture source trees and must not be skipped — a skip is "
+            "how a binary mislabelled with a hardcoded version ships. Run under "
+            "`nix develop` / scripts/gate.sh."
+        )
+    stub = tmp_path / "stub.nix"
+    stub.write_text(STUB_NIX)
+    proc = subprocess.run(
+        ["nix-instantiate", "--eval", "--strict", "--json", str(stub),
+         "--argstr", "file", str(NIX_FILE),
+         "--argstr", "workspace", str(ws)],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, (
+        "evaluating clawgatectl.nix failed:\n" + proc.stdout + proc.stderr
+    )
+    return json.loads(proc.stdout)
+
+
+CLIENT_GO = '''package main
+
+import "fmt"
+
+// buildVersion is the clawgate server version this CLI was built against. It is
+// overridable at link time (-ldflags "-X main.buildVersion=0.8.0").
+var buildVersion = "%s"
+
+const emptyPathParamMsg = "refusing to build a request path"
+
+func show() { fmt.Println(buildVersion) }
+'''
+
+
+# --------------------------------------------------------------------------- #
+# 1. BEHAVIOURAL — the derivation reports what the SOURCE says, and only that
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("declared", ["0.7.87", "9.9.9", "1.2.3-rc4"])
+def test_the_version_comes_from_the_go_source(tmp_path, declared):
+    """🔴 THE REGRESSION. Three DISTINCT values, none of them the version the
+    file used to hardcode, so an assertion cannot pass by reading a literal that
+    happens to agree — the mutation that reintroduces `version = "0.7.95"` has
+    no fixture it can satisfy.
+    """
+    ws = _tree(tmp_path, client_go=CLIENT_GO % declared)
+    got = _eval(tmp_path, ws)
+    assert got != "UNAVAILABLE", got
+    assert got["version"] == declared, got
+    assert "-X main.buildVersion=%s" % declared in got["ldflags"], got
+
+
+
+def test_the_stamped_ldflag_and_the_store_version_are_the_same_string(tmp_path):
+    """The two halves of the 08-14 failure are one value now.
+
+    `version` decides the store path; the ldflag decides what the binary says
+    about itself. They disagreed for ~19 hours on the laptop and nothing could
+    see it. Asserted as an EQUALITY between the two evaluated fields, not as the
+    presence of a substring in the nix file.
+    """
+    ws = _tree(tmp_path, client_go=CLIENT_GO % "4.5.6")
+    got = _eval(tmp_path, ws)
+    stamps = [f for f in got["ldflags"] if f.startswith("-X main.buildVersion=")]
+    assert stamps == ["-X main.buildVersion=" + got["version"]], got
+
+
+
+@pytest.mark.parametrize("client_go,why", [
+    ('package main\n\nvar buildVersionX = "9.9.9"\n', "declaration renamed"),
+    ('package main\n\nvar buildVersion string\n', "no literal to read"),
+    ("package main\n\nconst buildVersion = \"9.9.9\"\n", "const, not var"),
+    ('var buildVersion = "1.1.1"\nvar buildVersion = "2.2.2"\n', "ambiguous: two matches"),
+    (None, "client.go absent entirely"),
+])
+def test_an_unparseable_source_yields_NO_PACKAGE_not_a_fallback(tmp_path, client_go, why):
+    """🔴 A fallback literal would recreate the exact lie this change removes.
+
+    The chosen failure mode is `available = false` — no binary, so `clawgatectl:
+    command not found` at use time. Loud, and specifically NOT a failed
+    home-manager switch: ship.sh reports a failed switch as a SKIPPED host, the
+    documented failure mode that silently stops all future delivery.
+
+    The two-match case is here because "extract the first match" is the obvious
+    implementation and it is a guess presented as a fact.
+    """
+    ws = _tree(tmp_path, client_go=client_go)
+    assert _eval(tmp_path, ws) == "UNAVAILABLE", why
+
+
+
+def test_a_checkout_too_old_to_have_main_go_still_yields_no_package(tmp_path):
+    """The pre-existing guard must survive the new one — a checkout predating
+    cmd/clawgatectl would otherwise fail deep in the Go build and take the whole
+    switch down with it (measured on the laptop 2026-08-13, c417af30)."""
+    ws = _tree(tmp_path, client_go=CLIENT_GO % "9.9.9", main_go=None)
+    assert _eval(tmp_path, ws) == "UNAVAILABLE"
+
+
+
+def test_the_evaluator_can_tell_available_from_unavailable(tmp_path):
+    """🔴 POSITIVE CONTROL for the harness itself. Every UNAVAILABLE assertion
+    above is worthless if the stub returns "UNAVAILABLE" for everything — a
+    scanner wired to nothing. So: one tree that MUST evaluate to a package, and
+    one that must not, through the identical code path.
+    """
+    good = _eval(tmp_path / "a", _tree(tmp_path / "a", client_go=CLIENT_GO % "7.7.7"))
+    bad = _eval(tmp_path / "b", _tree(tmp_path / "b", client_go=None))
+    assert good != "UNAVAILABLE" and good["pname"] == "clawgatectl", good
+    assert bad == "UNAVAILABLE", bad
+
+
+# --------------------------------------------------------------------------- #
+# 2. STRUCTURAL — always runs, including where nix does not exist
+# --------------------------------------------------------------------------- #
+def _code_lines():
+    """Non-comment lines of clawgatectl.nix. The header DOCUMENTS the old
+    literal (`0.7.87 -> 0.7.95`) as the incident record, so a whole-file grep
+    would flag the file's own post-mortem."""
+    return [ln for ln in NIX_FILE.read_text().splitlines()
+            if not ln.strip().startswith("#")]
+
+
+def test_no_hardcoded_version_literal_survives_in_the_nix_file():
+    """The literal IS the bug. Not "is out of date" — a version written in devrc
+    is a claim about code in homelab-talos, and nothing holds the two together.
+    """
+    import re
+    offenders = [ln for ln in _code_lines()
+                 if re.search(r'version\s*=\s*"[0-9]', ln, re.I)]
+    assert offenders == [], (
+        "clawgatectl.nix hardcodes a version — it must be READ from "
+        "cmd/clawgatectl/client.go instead: %r" % offenders
+    )
+
+
+def test_the_version_is_read_from_the_compiled_source_file():
+    code = "\n".join(_code_lines())
+    assert "builtins.readFile" in code
+    assert "cmd/clawgatectl/client.go" in code, (
+        "the version must be derived from the file that is actually compiled"
+    )
+    assert "builtins.match" in code
+
+
+def test_the_ldflag_is_fed_the_derived_value_and_not_a_second_literal():
+    code = "\n".join(_code_lines())
+    stamps = [ln for ln in _code_lines() if "main.buildVersion=" in ln]
+    assert len(stamps) == 1, stamps
+    assert "-X main.buildVersion=${parsedVersion}" in stamps[0], stamps
+    assert "parsedVersion" in code
+
+
+def test_no_fingerprint_or_suffix_is_appended_to_the_stamped_version():
+    """🔴 client.go compares `h.Version == buildVersion` by EXACT equality, so
+    any suffix ("-dirty", a tree hash) fires the skew note on every command on
+    every host forever. A permanently-noisy warning is worse than none.
+
+    Asserted on the STAMP LINE's shape: the interpolation must be the whole tail
+    of the flag, with nothing concatenated after it.
+    """
+    stamps = [ln.strip() for ln in _code_lines() if "main.buildVersion=" in ln]
+    assert len(stamps) == 1, stamps
+    assert stamps[0] == '''ldflags = [ "-s" "-w" "-X main.buildVersion=${parsedVersion}" ];''', (
+        "the stamped version is not exactly the derived value: %r" % stamps
+    )
+
+
+def test_an_unparseable_source_switches_the_package_OFF_rather_than_failing():
+    """Structural counterpart to the behavioural test above, so the claim is
+    still made where nix is unavailable: availability is a conjunction of the
+    path guard and a successful parse, and the whole package rides on it."""
+    code = "\n".join(_code_lines())
+    assert "available = builtins.pathExists mainFile && parsedVersion != null;" in code
+    assert "pkgs.lib.optionals available" in code
+    assert "throw" not in code and "assert " not in code, (
+        "an unparseable source must not fail the switch — ship.sh reports that "
+        "as a SKIPPED host, which stops all future delivery to it"
+    )
+
+
+def test_the_header_no_longer_describes_a_hand_maintained_version():
+    """A comment is a claim too. The old header explained the version/source
+    relationship in terms this change makes false."""
+    header = NIX_FILE.read_text().split("{ pkgs, workspace }:")[0]
+    assert "Stamping" not in header
+    assert "READ OUT OF THE SOURCE" in header, (
+        "the header must state where the version now comes from"
+    )
+    assert "buildVersion" in header
+
+
+# --------------------------------------------------------------------------- #
+# 3. THE SIBLING — tmux-fuzzyclaw has the same SHAPE and could not take the fix
+# --------------------------------------------------------------------------- #
+def test_tmux_fuzzyclaw_is_documented_as_having_no_version_source_of_truth():
+    """🔴 An ASSERTED FINDING, not an omission.
+
+    tmux-fuzzyclaw.nix has the identical pattern — a hardcoded `version` plus a
+    matching hardcoded ldflag, built from `${workspace}/tmux-fuzzyclaw` — so the
+    obvious question is why it did not get the same treatment. Measured
+    2026-08-18: its `cmd/version.go` says `var Version = "dev"`, the string
+    "2.0.0" appears NOWHERE in that repo outside the devrc nix file, and the
+    repo carries no git tags. There is no source of truth to read; inventing one
+    would be the same lie in a new place.
+
+    This test fails if that ever stops being true, which is the trigger to apply
+    Change A there too.
+    """
+    src = FUZZYCLAW_NIX.read_text()
+    assert "workspace}/tmux-fuzzyclaw" in src, "the sibling no longer builds from a local tree"
+    note = [ln for ln in src.splitlines() if "cmd/version.go" in ln]
+    assert note, (
+        "tmux-fuzzyclaw.nix keeps a hand-maintained version literal and must SAY "
+        "why it cannot be derived (its cmd/version.go declares Version = \"dev\")"
+    )

--- a/scripts/tests/test_clawgatectl_version.py
+++ b/scripts/tests/test_clawgatectl_version.py
@@ -149,12 +149,16 @@ def test_the_version_comes_from_the_go_source(tmp_path, declared):
 
 
 def test_the_stamped_ldflag_and_the_store_version_are_the_same_string(tmp_path):
-    """The two halves of the 08-14 failure are one value now.
+    """⚠ INVARIANT GUARD, not regression coverage — MEASURED GREEN AT a2707be.
+
+    The old file already stamped its own `version` literal, so these two agreed
+    before this change too; what they never did was describe the SOURCE. So this
+    pins the half of the contract that was already true and must stay true, and
+    the regression coverage is `test_the_version_comes_from_the_go_source`.
 
     `version` decides the store path; the ldflag decides what the binary says
-    about itself. They disagreed for ~19 hours on the laptop and nothing could
-    see it. Asserted as an EQUALITY between the two evaluated fields, not as the
-    presence of a substring in the nix file.
+    about itself. Asserted as an EQUALITY between the two evaluated fields, not
+    as the presence of a substring in the nix file.
     """
     ws = _tree(tmp_path, client_go=CLIENT_GO % "4.5.6")
     got = _eval(tmp_path, ws)
@@ -187,7 +191,10 @@ def test_an_unparseable_source_yields_NO_PACKAGE_not_a_fallback(tmp_path, client
 
 
 def test_a_checkout_too_old_to_have_main_go_still_yields_no_package(tmp_path):
-    """The pre-existing guard must survive the new one — a checkout predating
+    """⚠ INVARIANT GUARD, not regression coverage — MEASURED GREEN AT a2707be.
+
+    The main.go pathExists guard predates this change; this pins that the new
+    `&& parsedVersion != null` conjunct did not weaken it. A checkout predating
     cmd/clawgatectl would otherwise fail deep in the Go build and take the whole
     switch down with it (measured on the laptop 2026-08-13, c417af30)."""
     ws = _tree(tmp_path, client_go=CLIENT_GO % "9.9.9", main_go=None)

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -3235,7 +3235,13 @@ def test_a_non_integer_phase2_timeout_is_rejected(fleet):
 #     makes "a third package is covered automatically" a fact instead of a hope.
 # --------------------------------------------------------------------------- #
 
-# 🔴 THE LEDGER. The set of repos devrc builds packages from, as of this commit.
+# 🔴 THE LEDGER. The BUILT-SOURCE SCOPES devrc compiles, as of this commit — the
+# full `${workspace}/…` path of each package's `srcDir`, NOT merely its repo. That
+# distinction is the whole point of the pathspec scoping: `homelab-talos` takes
+# ~7 commits a day of which only about a third touch `containers/clawgate`, so
+# escalating on the REPO made rc 17 a permanently-red gate (measured — see the
+# SOURCE-REPO PARITY block in drift-check.sh).
+#
 # Pinned as a LITERAL and cross-checked BOTH ways below — against an independent
 # Python extraction and against what the shell payload itself reports — so the
 # set fails the suite when it GROWS (a new source package nobody told the
@@ -3243,7 +3249,11 @@ def test_a_non_integer_phase2_timeout_is_rejected(fleet):
 # checker is now fetching a repo for no reason). Same discipline as
 # run-tests.sh's TARGET_FLOORS: a derived value, pinned two-way against the
 # thing it is derived from.
-EXPECTED_SOURCE_REPOS = {"homelab-talos", "tmux-fuzzyclaw"}
+EXPECTED_BUILT_SOURCE_SCOPES = {"homelab-talos/containers/clawgate", "tmux-fuzzyclaw"}
+
+# The repos those scopes live in — the unit that gets FETCHED (one fetch however
+# many packages sit in it), which is what the unit's time budget is a function of.
+EXPECTED_SOURCE_REPOS = {q.split("/", 1)[0] for q in EXPECTED_BUILT_SOURCE_SCOPES}
 
 NIX_PKGS = REPO_ROOT / "nix" / "pkgs"
 
@@ -3254,12 +3264,16 @@ def _oracle_source_repos():
     The payload walks with a bash glob and bash parameter expansion; this walks
     with pathlib.rglob and a regex. Two constructions that agree are evidence;
     one construction compared to itself is not (a shared blind spot survives).
+
+    Returns the FULL srcDir paths, because that — not the repo — is the unit the
+    verdict is computed over.
     """
     out = set()
     for p in sorted(NIX_PKGS.rglob("*.nix")):
         for ln in p.read_text().splitlines():
-            out.update(re.findall(r"\$\{workspace\}/([A-Za-z0-9._-]+)",
-                                  ln.split("#", 1)[0]))
+            for hit in re.findall(r"\$\{workspace\}/([A-Za-z0-9._/-]+)",
+                                  ln.split("#", 1)[0]):
+                out.add(hit.rstrip("/"))
     return out
 
 
@@ -3300,6 +3314,14 @@ def _nixpkg(fleet, filename, *names, repo=None):
     (d / filename).write_text("\n".join(body) + "\n")
 
 
+# The paths every fixture source repo carries. Two of them sit UNDER a srcDir a
+# package would be built from and one deliberately does not — that third path is
+# what makes "behind, but not in anything we compile" constructible, which is the
+# case the whole pathspec scoping exists for and which no single-file fixture can
+# express.
+SRC_FILES = ("f", "containers/clawgate/main.go", "clusters/naida/deploy.yaml")
+
+
 def _src_repo(fleet, name, *, branch="main", home=None):
     """A bare origin plus a clone at <home>/workspace/<name>, both on `branch`.
 
@@ -3311,9 +3333,13 @@ def _src_repo(fleet, name, *, branch="main", home=None):
     fleet._run(["git", "init", "-q", "--bare", "-b", branch, str(origin)])
     builder = fleet.root / ("srcbuild-%s-%s" % (home.name, name))
     fleet._run(["git", "clone", "-q", str(origin), str(builder)])
-    (builder / "f").write_text("base\n")
+    for rel in SRC_FILES:
+        f = builder / rel
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text("base\n")
     fleet.git(builder, "checkout", "-q", "-B", branch)
-    fleet.git(builder, "add", "f")
+    for rel in SRC_FILES:
+        fleet.git(builder, "add", rel)
     fleet.git(builder, "commit", "-q", "-m", "base")
     fleet.git(builder, "push", "-q", "-u", "origin", branch)
     clone = home / "workspace" / name
@@ -3323,10 +3349,21 @@ def _src_repo(fleet, name, *, branch="main", home=None):
     return clone, builder
 
 
-def _push_upstream(fleet, builder, branch="main", n=1):
+def _push_upstream(fleet, builder, branch="main", n=1, path="f"):
+    """Advance the upstream by `n` commits, each touching exactly `path`.
+
+    🔴 `path` is the load-bearing parameter. The verdict is computed with a
+    pathspec limited to the package's own srcDir, so "behind by N" is only
+    meaningful once you say WHERE — and a fixture that always writes the same
+    file cannot tell a commit that changes the built source from one that
+    cannot.
+    """
     for i in range(n):
-        (builder / "f").write_text("base\nupstream-%d\n" % i)
-        fleet.git(builder, "commit", "-q", "-am", "upstream %d" % i)
+        f = builder / path
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text("base\nupstream-%d\n" % i)
+        fleet.git(builder, "add", path)
+        fleet.git(builder, "commit", "-q", "-m", "upstream %d (%s)" % (i, path))
     fleet.git(builder, "push", "-q", "origin", branch)
 
 
@@ -3341,7 +3378,7 @@ def test_a_source_repo_behind_its_upstream_is_rc17(fleet):
 
     rc, out = fleet.check("--no-remote")
     assert rc == 17, f"a stale source repo must be rc 17, got {rc}\n{out}"
-    assert "source repo homelab-talos is NOT current: 3 behind / 0 ahead" in out, out
+    assert "BUILT SOURCE homelab-talos is NOT current: 3 behind / 0 ahead" in out, out
     assert _src_counts(out) == (1, 1, 0), out
 
 
@@ -3373,7 +3410,7 @@ def test_a_current_source_repo_is_green(fleet):
 
     rc, out = fleet.check("--no-remote")
     assert rc == 0, f"a current source repo must not be drift, got {rc}\n{out}"
-    assert "source repo homelab-talos: current — trunk ==" in out, out
+    assert "BUILT SOURCE homelab-talos is CURRENT — trunk ==" in out, out
     assert _src_counts(out) == (1, 0, 0), out
 
 
@@ -3393,7 +3430,7 @@ def test_the_examined_count_is_reported_beside_the_stale_count(fleet):
     rc, out = fleet.check("--no-remote")
     assert rc == 17, out
     assert _src_counts(out) == (2, 1, 0), out
-    assert "source repo tmux-fuzzyclaw: current" in out, out
+    assert "BUILT SOURCE tmux-fuzzyclaw is CURRENT" in out, out
 
 
 def test_a_scan_that_found_no_source_packages_says_so_instead_of_reporting_zero(fleet):
@@ -3476,7 +3513,7 @@ def test_a_dirty_source_repo_is_reported_even_when_it_is_current(fleet):
     rc, out = fleet.check("--no-remote")
     assert rc == 0, f"a dirty source repo is not drift on its own, got {rc}\n{out}"
     assert "source repo homelab-talos: DIRTY — 2 path(s)" in out, out
-    assert "source repo homelab-talos: current" in out, out
+    assert "BUILT SOURCE homelab-talos is CURRENT" in out, out
     assert _src_counts(out) == (1, 0, 0), out
 
 
@@ -3514,14 +3551,21 @@ def test_the_source_repo_set_is_pinned_two_way_against_nix_pkgs(tmp_path):
     out = _run_srcrepo_payload(tmp_path, REPO_ROOT, home)
     reported = set(_src_facts(out))
 
-    assert _oracle_source_repos() == EXPECTED_SOURCE_REPOS, (
-        "nix/pkgs' `${workspace}/`-sourced repo set has CHANGED. Update "
-        "EXPECTED_SOURCE_REPOS — and check that the new repo is one the deadman "
-        "should be fetching on both hosts: %r" % (_oracle_source_repos(),)
+    assert _oracle_source_repos() == EXPECTED_BUILT_SOURCE_SCOPES, (
+        "nix/pkgs' `${workspace}/`-sourced SCOPE set has CHANGED. Update "
+        "EXPECTED_BUILT_SOURCE_SCOPES — and check that the new srcDir is one the "
+        "deadman should be judging on both hosts: %r" % (_oracle_source_repos(),)
     )
-    assert reported == EXPECTED_SOURCE_REPOS, (
+    assert reported == EXPECTED_BUILT_SOURCE_SCOPES, (
         "drift-check.sh's own scan disagrees with nix/pkgs: it reported %r\n%s"
         % (sorted(reported), out)
+    )
+    # 🔴 AND THE SUBTREE MUST SURVIVE THE ROUND TRIP. `homelab-talos` alone would
+    # satisfy a repo-level pin while silently restoring the whole-repo verdict
+    # that made this gate permanently red, so assert the path is still there.
+    assert any("/" in k for k in reported), (
+        "no scope carries a srcDir SUBTREE — the scan has collapsed back to repo "
+        "roots, which is the permanently-red-gate defect: %r" % sorted(reported)
     )
     # ...and it must have walked real files to get there. `0 scanned` producing
     # the right answer would mean the answer came from somewhere else.
@@ -3547,23 +3591,35 @@ def test_a_third_source_package_is_covered_with_no_change_to_the_checker(fleet):
 
     rc, out = fleet.check("--no-remote")
     assert rc == 17, f"the third package was not covered, got {rc}\n{out}"
-    assert "source repo some-new-repo is NOT current: 2 behind" in out, out
+    assert "BUILT SOURCE some-new-repo is NOT current: 2 behind" in out, out
     assert _src_counts(out) == (3, 1, 0), out
 
 
-def test_two_derivations_sharing_one_source_repo_are_fetched_once(fleet):
-    """clawgatectl's src is `${workspace}/homelab-talos/containers/clawgate` —
-    a SUBDIRECTORY. The repo root is what has a `.git`, and two derivations under
-    one repo must not be counted (or fetched) twice."""
+def test_two_subtrees_of_ONE_repo_are_judged_separately(fleet):
+    """clawgatectl's src is `${workspace}/homelab-talos/containers/clawgate` — a
+    SUBDIRECTORY. The repo root is what has a `.git` and gets fetched ONCE, but
+    each srcDir under it is its own verdict.
+
+    Here the upstream moves inside ONE of the two subtrees. A repo-level check
+    would call both stale (or, worse, one repo "stale" with no way to say which
+    package is affected); the scoped check must report exactly one.
+    """
     fleet.catch_up()
     _nixpkg(fleet, "a.nix", "homelab-talos/containers/clawgate")
-    _nixpkg(fleet, "b.nix", "homelab-talos/containers/other")
-    _src_repo(fleet, "homelab-talos", branch="trunk")
+    _nixpkg(fleet, "b.nix", "homelab-talos/clusters/naida")
+    _, b = _src_repo(fleet, "homelab-talos", branch="trunk")
+    _push_upstream(fleet, b, branch="trunk", n=2,
+                   path="containers/clawgate/main.go")
 
     rc, out = fleet.check("--no-remote")
-    assert rc == 0, out
-    assert _src_counts(out) == (1, 0, 0), out
-    assert set(_src_facts(out)) == {"homelab-talos"}, out
+    assert rc == 17, out
+    # ONE repo, TWO scopes, exactly ONE of them stale.
+    assert _src_counts(out) == (2, 1, 0), out
+    assert "over 1 repo(s)" in out, "the repo was walked more than once\n" + out
+    assert set(_src_facts(out)) == {
+        "homelab-talos/containers/clawgate", "homelab-talos/clusters/naida"}, out
+    assert "BUILT SOURCE homelab-talos/containers/clawgate is NOT current: 2 behind" in out, out
+    assert "BUILT SOURCE homelab-talos/clusters/naida is CURRENT" in out, out
 
 
 def test_two_source_repos_named_on_ONE_line_are_both_found(fleet):
@@ -3592,7 +3648,7 @@ def test_two_source_repos_named_on_ONE_line_are_both_found(fleet):
     rc, out = fleet.check("--no-remote")
     assert set(_src_facts(out)) == {"first-repo", "second-repo"}, out
     assert rc == 17, f"the SECOND repo on the line went unwatched, got {rc}\n{out}"
-    assert "source repo second-repo is NOT current: 4 behind" in out, out
+    assert "BUILT SOURCE second-repo is NOT current: 4 behind" in out, out
     assert _src_counts(out) == (2, 1, 0), out
 
 
@@ -3630,7 +3686,7 @@ def test_unpushed_devrc_commits_still_outrank_a_stale_source_repo(fleet):
 
     rc, out = fleet.check("--no-remote")
     assert rc == 8, f"rc 8 must outrank rc 17, got {rc}\n{out}"
-    assert "source repo homelab-talos is NOT current" in out, (
+    assert "BUILT SOURCE homelab-talos is NOT current" in out, (
         "the source-repo finding must still be PRINTED even when outranked\n" + out
     )
 
@@ -3665,7 +3721,7 @@ def test_the_rc17_legend_is_printed_with_the_verdict(fleet):
     rc, out = fleet.check("--no-remote")
     assert rc == 17, out
     assert "drift-check: DRIFT (rc=17)" in out, out
-    assert "rc17=a SOURCE REPO" in out, out
+    assert "rc17=the srcDir SUBTREE" in out, out
 
 
 # --- the cross-host half ----------------------------------------------------- #
@@ -3848,3 +3904,197 @@ def test_a_run_against_a_stale_source_repo_mutates_nothing(fleet):
     assert snapshot() == before, (
         "🔴 the deadman MUTATED a source repo — it may only fetch\n" + out
     )
+
+
+# --------------------------------------------------------------------------- #
+# 11b. THE VERDICT IS SCOPED TO THE srcDir SUBTREE, NOT THE REPO
+#
+# 🔴 rc 17 shipped escalating on WHOLE-REPO staleness, and that is a
+# permanently-red gate — the failure mode RULES.md names explicitly, because it
+# trains click-through on the one alert that has to keep its meaning. MEASURED on
+# the workbench 2026-08-18: it was 1 commit behind `origin/trunk`, and that commit
+# was `2ce7cbdc fix(naida-ai-demo): raise memory limit 128Mi -> 512Mi` —
+# `git diff --name-only HEAD..origin/trunk -- containers/clawgate` EMPTY, so it
+# cannot reach the built binary. Over the preceding 14 days that repo took 98
+# commits of which only 32 touched `containers/clawgate`; at ~7 commits/day the
+# host is behind nearly continuously and about two thirds of those reds could not
+# affect any package devrc builds.
+#
+# The two tests that matter are a PAIR, and neither is worth anything alone:
+#   * a commit OUTSIDE every srcDir must NOT escalate — the regression;
+#   * a commit INSIDE one still MUST — or the noise was "fixed" by breaking the
+#     detector, and every mutation would pass.
+# --------------------------------------------------------------------------- #
+def test_a_commit_OUTSIDE_every_srcDir_is_reported_but_is_NOT_rc17(fleet):
+    """🔴 THE REGRESSION, in the measured shape: the repo is behind, and not by
+    anything the package is compiled from.
+
+    The fixture mirrors the real one — a `containers/clawgate` srcDir and an
+    unrelated `clusters/naida` path — and the upstream commit lands only in the
+    latter. rc must stay 0, and the finding must still be legible: the repo-wide
+    count is printed, and the built source is stated to be CURRENT.
+    """
+    fleet.catch_up()
+    _nixpkg(fleet, "clawgatectl.nix", "homelab-talos/containers/clawgate")
+    _, b = _src_repo(fleet, "homelab-talos", branch="trunk")
+    _push_upstream(fleet, b, branch="trunk", n=1,
+                   path="clusters/naida/deploy.yaml")
+
+    rc, out = fleet.check("--no-remote")
+    assert rc == 0, (
+        "a commit that cannot reach the built binary escalated to rc %d — that is "
+        "the permanently-red gate\\n%s" % (rc, out))
+    # 🔴 Reported, not dropped: the repo-wide number is true and useful.
+    assert "repo-wide 1 behind / 0 ahead" in out, (
+        "the whole-repo count was silently dropped\\n" + out)
+    assert "repo-wide is INFORMATION ONLY" in out, out
+    assert "BUILT SOURCE homelab-talos/containers/clawgate is CURRENT (0 behind / 0 ahead)" in out, out
+    assert "touch nothing this package is built from" in out, out
+    assert _src_counts(out) == (1, 0, 0), out
+
+
+def test_a_commit_INSIDE_a_srcDir_is_still_rc17(fleet):
+    """🔴 THE OTHER HALF OF THE PAIR — and the guard against "fixing" the noise
+    by breaking the detector.
+
+    Byte-for-byte the fixture above except for WHICH path the upstream commit
+    touches. That is the only variable, so a green here plus a green above is a
+    statement about the pathspec and nothing else.
+    """
+    fleet.catch_up()
+    _nixpkg(fleet, "clawgatectl.nix", "homelab-talos/containers/clawgate")
+    _, b = _src_repo(fleet, "homelab-talos", branch="trunk")
+    _push_upstream(fleet, b, branch="trunk", n=1,
+                   path="containers/clawgate/main.go")
+
+    rc, out = fleet.check("--no-remote")
+    assert rc == 17, (
+        "a commit INSIDE the srcDir did not escalate — the detector is broken, "
+        "not merely quiet\\n%s" % out)
+    assert "BUILT SOURCE homelab-talos/containers/clawgate is NOT current: 1 behind / 0 ahead" in out, out
+    assert "repo-wide 1 behind / 0 ahead" in out, out
+    assert _src_counts(out) == (1, 1, 0), out
+
+
+def test_UNPUSHED_commits_inside_a_srcDir_still_escalate_and_outside_do_not(fleet):
+    """The AHEAD direction gets the same pathspec, in both directions.
+
+    Scoping only the behind half would leave un-pushed cluster manifests firing
+    rc 17 forever while un-pushed clawgate code was the case that mattered.
+    """
+    fleet.catch_up()
+    _nixpkg(fleet, "clawgatectl.nix", "homelab-talos/containers/clawgate")
+    clone, _ = _src_repo(fleet, "homelab-talos", branch="trunk")
+
+    # (a) un-pushed work OUTSIDE the srcDir — reported, not drift.
+    (clone / "clusters" / "naida" / "deploy.yaml").write_text("local edit\\n")
+    fleet.git(clone, "add", "clusters/naida/deploy.yaml")
+    fleet.git(clone, "commit", "-q", "-m", "local manifest tweak")
+    rc, out = fleet.check("--no-remote")
+    assert rc == 0, "un-pushed work outside every srcDir escalated\\n" + out
+    assert "repo-wide 0 behind / 1 ahead" in out, out
+    assert "BUILT SOURCE homelab-talos/containers/clawgate is CURRENT (0 behind / 0 ahead)" in out, out
+
+    # (b) now un-pushed work INSIDE it — same repo, same run shape, must fire.
+    (clone / "containers" / "clawgate" / "main.go").write_text("local code\\n")
+    fleet.git(clone, "add", "containers/clawgate/main.go")
+    fleet.git(clone, "commit", "-q", "-m", "un-pushed clawgate change")
+    rc, out = fleet.check("--no-remote")
+    assert rc == 17, "un-pushed work INSIDE the srcDir did not escalate\\n" + out
+    assert "BUILT SOURCE homelab-talos/containers/clawgate is NOT current: 0 behind / 1 ahead" in out, out
+
+
+def test_a_root_srcDir_package_is_unchanged_by_the_scoping(fleet):
+    """⚠ MOSTLY AN INVARIANT GUARD, and the distinction is worth stating.
+
+    MEASURED at b10c4ae: RED — but only on the message wording, which this commit
+    renamed. Its BEHAVIOURAL claim (rc 17 for a root-srcDir package that is one
+    commit behind) already held there, so this is not regression coverage for the
+    scoping defect. What it does hold is the boundary the fix could have broken:
+    tmux-fuzzyclaw's srcDir IS its repo root, its scope and its repo coincide, and
+    every commit anywhere in it genuinely does change what is built. A pathspec
+    accidentally applied to the root case would silence it, and that mutation is
+    in the battery.
+    """
+    fleet.catch_up()
+    _nixpkg(fleet, "tmux-fuzzyclaw.nix", "tmux-fuzzyclaw")
+    _, b = _src_repo(fleet, "tmux-fuzzyclaw")
+    _push_upstream(fleet, b, n=1, path="clusters/naida/deploy.yaml")
+
+    rc, out = fleet.check("--no-remote")
+    assert rc == 17, (
+        "a root-srcDir package stopped escalating — for it, EVERY commit is in "
+        "the built source\\n%s" % out)
+    assert "BUILT SOURCE tmux-fuzzyclaw is NOT current: 1 behind / 0 ahead" in out, out
+    assert set(_src_facts(out)) == {"tmux-fuzzyclaw"}, out
+
+
+def test_an_unmeasurable_repo_makes_EVERY_scope_under_it_unmeasured(fleet):
+    """🔴 One repo, several packages: a repo we could not evaluate must not let
+    any of its scopes read as a silent pass.
+
+    Without this, `examined` counted repos and a two-package repo whose fetch
+    failed contributed ONE unmeasured — leaving the second package accounted for
+    nowhere at all.
+    """
+    fleet.catch_up()
+    _nixpkg(fleet, "a.nix", "homelab-talos/containers/clawgate")
+    _nixpkg(fleet, "b.nix", "homelab-talos/clusters/naida")
+    clone, _ = _src_repo(fleet, "homelab-talos", branch="trunk")
+    fleet.git(clone, "remote", "set-url", "origin",
+              str(fleet.root / "definitely-not-a-repo"))
+
+    rc, out = fleet.check("--no-remote")
+    assert rc == 0, "an unreachable source remote is not drift\\n" + out
+    assert _src_counts(out) == (2, 0, 2), out
+    facts = _src_facts(out)
+    assert facts == {"homelab-talos/containers/clawgate": "FETCHFAILED",
+                     "homelab-talos/clusters/naida": "FETCHFAILED"}, out
+
+
+# --- the cross-host half, scoped the same way -------------------------------- #
+def _two_host_scoped(fleet, *, remote_path):
+    """Both hosts current with their own upstreams; the REMOTE carries one extra
+    pushed commit touching `remote_path`. The only variable is where it lands."""
+    fleet.catch_up()
+    _nixpkg(fleet, "clawgatectl.nix", "homelab-talos/containers/clawgate")
+    lstore = _mkhome(fleet.home, healthy=1)
+    _src_repo(fleet, "homelab-talos", branch="trunk")
+
+    rhome = fleet.root / "remote-home"
+    rhome.mkdir()
+    rstore = _mkhome(rhome, healthy=1, store=fleet.root / "remote-store")
+    rclone, _ = _src_repo(fleet, "homelab-talos", branch="trunk", home=rhome)
+    f = rclone / remote_path
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("remote-only\\n")
+    fleet.git(rclone, "add", remote_path)
+    fleet.git(rclone, "commit", "-q", "-m", "remote work")
+    fleet.git(rclone, "push", "-q", "origin", "trunk")
+    _remote_running_the_real_payload(fleet, rhome, rstore)
+    return _parity(fleet, store=lstore, REMOTE_SSH="stub@example.invalid")
+
+
+def test_the_cross_host_comparison_ignores_divergence_OUTSIDE_every_srcDir(fleet):
+    """🔴 "The two hosts build DIFFERENT source" must mean DIFFERENT BUILT
+    SOURCE. Compared on repo HEADs it fired whenever the machines disagreed about
+    any commit at all — cluster manifests included — which is the same
+    permanently-noisy shape one level over.
+    """
+    rc, out = _two_host_scoped(fleet, remote_path="clusters/naida/deploy.yaml")
+    assert rc == 0, out
+    block = out.split("=== source-repo parity")[1]
+    assert "the two hosts build DIFFERENT source" not in block, (
+        "a divergence outside every srcDir was reported as different built "
+        "source\\n" + block)
+    assert "compared=1 same=1 differing=0" in block, block
+
+
+def test_the_cross_host_comparison_still_reports_a_differing_built_subtree(fleet):
+    """POSITIVE CONTROL for the test above — without it, `differing=0` is
+    indistinguishable from a comparator wired to nothing."""
+    rc, out = _two_host_scoped(fleet, remote_path="containers/clawgate/main.go")
+    block = out.split("=== source-repo parity")[1]
+    assert "the two hosts build DIFFERENT source" in block, block
+    assert "srcDir subtree trees, not repo HEADs" in block, block
+    assert "compared=1 same=0 differing=1" in block, block

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -3208,3 +3208,643 @@ def test_a_non_integer_phase2_timeout_is_rejected(fleet):
     assert rc == 2, f"expected a usage error, got {rc}\n{out}"
     assert "DRIFT_PHASE2_TIMEOUT must be a non-negative integer" in out, out
     assert not [ln for ln in out.splitlines() if ln.strip() == "PWNED"], out
+
+
+# --------------------------------------------------------------------------- #
+# 11. SOURCE-REPO PARITY (rc 17) — the repos devrc BUILDS PACKAGES FROM
+#
+# 🔴 A THIRD KIND OF PARITY. devrc has `nix/pkgs/**` derivations whose `src` is
+# `${workspace}/<repo>/…` — a LOCAL working tree of a DIFFERENT repo. Nothing
+# converges those: ship.sh is scoped to $HOME/workspace/devrc. So a host can have
+# a perfect devrc checkout, every managed symlink resolving, and still compile
+# months-old code, and both existing halves of this deadman report clean.
+#
+# MEASURED 2026-08-14 on clawgatectl: the laptop's ~/workspace/homelab-talos was
+# 24 commits behind, so it built a CLI without `task status`/`task comment` —
+# and devrc's hand-written version literal stamped "0.7.95" onto it anyway, so
+# `clawgatectl task status <id> in_progress` printed help and exited 0. Silent.
+# This file was green on that host the whole time.
+#
+# The load-bearing tests here are, in order:
+#   * the NEGATIVE CONTROLS — behind, and ahead — watched red with rc 17;
+#   * the POSITIVE CONTROL — a current repo is green, so the reds mean something;
+#   * the four NOT-DRIFT-BUT-NOT-A-PASS shapes (absent, fetch failed, no
+#     upstream, dirty), each of which must be counted as UNMEASURED rather than
+#     folded into a reassuring "0 stale";
+#   * the TWO-WAY PIN of the covered set against the real nix/pkgs, which is what
+#     makes "a third package is covered automatically" a fact instead of a hope.
+# --------------------------------------------------------------------------- #
+
+# 🔴 THE LEDGER. The set of repos devrc builds packages from, as of this commit.
+# Pinned as a LITERAL and cross-checked BOTH ways below — against an independent
+# Python extraction and against what the shell payload itself reports — so the
+# set fails the suite when it GROWS (a new source package nobody told the
+# deadman about) and when it SHRINKS (a package moved to fetchFromGitHub and the
+# checker is now fetching a repo for no reason). Same discipline as
+# run-tests.sh's TARGET_FLOORS: a derived value, pinned two-way against the
+# thing it is derived from.
+EXPECTED_SOURCE_REPOS = {"homelab-talos", "tmux-fuzzyclaw"}
+
+NIX_PKGS = REPO_ROOT / "nix" / "pkgs"
+
+
+def _oracle_source_repos():
+    """An INDEPENDENT extraction of the same set, built differently on purpose.
+
+    The payload walks with a bash glob and bash parameter expansion; this walks
+    with pathlib.rglob and a regex. Two constructions that agree are evidence;
+    one construction compared to itself is not (a shared blind spot survives).
+    """
+    out = set()
+    for p in sorted(NIX_PKGS.rglob("*.nix")):
+        for ln in p.read_text().splitlines():
+            out.update(re.findall(r"\$\{workspace\}/([A-Za-z0-9._-]+)",
+                                  ln.split("#", 1)[0]))
+    return out
+
+
+def _src_facts(out):
+    """The `FACT src-repos …` line as a {name: head} dict.
+
+    Raises rather than returning {} when the line is missing: an absent fact set
+    and an empty one are the same value to a comparison, and only one of them is
+    good news."""
+    m = re.search(r"FACT src-repos(.*)", out)
+    assert m, "no `FACT src-repos` line in the output:\n" + out
+    d = {}
+    for tok in m.group(1).split():
+        k, _, v = tok.partition("=")
+        d[k] = v
+    return d
+
+
+def _src_counts(out):
+    """(examined, stale, unmeasured) — 🔴 THE TRIPLE IS THE CLAIM, never one of
+    them. A bare `stale=0` from a scan that walked no repos, or one whose every
+    fetch failed, is indistinguishable from a clean host."""
+    m = re.search(r"source repos: examined=(\d+) stale=(\d+) unmeasured=(\d+)", out)
+    assert m, ("no examined/stale/unmeasured TRIPLE in the output — the triple "
+               "IS the claim:\n" + out)
+    return int(m.group(1)), int(m.group(2)), int(m.group(3))
+
+
+def _nixpkg(fleet, filename, *names, repo=None):
+    """Write a nix/pkgs file into the devrc checkout naming `${workspace}/<name>`
+    sources, in the shape the real derivations use."""
+    d = (repo or fleet.work) / "nix" / "pkgs" / "tools"
+    d.mkdir(parents=True, exist_ok=True)
+    body = ["{ pkgs, workspace }:", "let"]
+    for n in names:
+        body.append('  src%s = pkgs.lib.cleanSource (/. + "${workspace}/%s");' % (len(body), n))
+    body.append("in [ ]")
+    (d / filename).write_text("\n".join(body) + "\n")
+
+
+def _src_repo(fleet, name, *, branch="main", home=None):
+    """A bare origin plus a clone at <home>/workspace/<name>, both on `branch`.
+
+    Returns (clone, builder). The builder is a second clone used to advance the
+    upstream, so `behind` is produced the way it happens in life — someone else
+    pushed — rather than by rewriting the clone's refs."""
+    home = home or fleet.home
+    origin = fleet.root / ("srcorigin-%s-%s.git" % (home.name, name))
+    fleet._run(["git", "init", "-q", "--bare", "-b", branch, str(origin)])
+    builder = fleet.root / ("srcbuild-%s-%s" % (home.name, name))
+    fleet._run(["git", "clone", "-q", str(origin), str(builder)])
+    (builder / "f").write_text("base\n")
+    fleet.git(builder, "checkout", "-q", "-B", branch)
+    fleet.git(builder, "add", "f")
+    fleet.git(builder, "commit", "-q", "-m", "base")
+    fleet.git(builder, "push", "-q", "-u", "origin", branch)
+    clone = home / "workspace" / name
+    clone.parent.mkdir(parents=True, exist_ok=True)
+    fleet._run(["git", "clone", "-q", str(origin), str(clone)])
+    fleet.git(clone, "checkout", "-q", branch)
+    return clone, builder
+
+
+def _push_upstream(fleet, builder, branch="main", n=1):
+    for i in range(n):
+        (builder / "f").write_text("base\nupstream-%d\n" % i)
+        fleet.git(builder, "commit", "-q", "-am", "upstream %d" % i)
+    fleet.git(builder, "push", "-q", "origin", branch)
+
+
+# --- the negative controls, in the real failure shape ----------------------- #
+def test_a_source_repo_behind_its_upstream_is_rc17(fleet):
+    """🔴 THE MEASURED FAILURE, reproduced: the checkout devrc compiles is behind
+    what its own upstream says, and no other check in this file can see it."""
+    fleet.catch_up()
+    _nixpkg(fleet, "clawgatectl.nix", "homelab-talos")
+    _, builder = _src_repo(fleet, "homelab-talos", branch="trunk")
+    _push_upstream(fleet, builder, branch="trunk", n=3)
+
+    rc, out = fleet.check("--no-remote")
+    assert rc == 17, f"a stale source repo must be rc 17, got {rc}\n{out}"
+    assert "source repo homelab-talos is NOT current: 3 behind / 0 ahead" in out, out
+    assert _src_counts(out) == (1, 1, 0), out
+
+
+def test_a_source_repo_with_UNPUSHED_commits_is_rc17(fleet):
+    """The other direction, and it is the same loss class as rc 8 one repo over:
+    a commit that exists on exactly one machine, in code the other machine
+    compiles."""
+    fleet.catch_up()
+    _nixpkg(fleet, "clawgatectl.nix", "homelab-talos")
+    clone, _ = _src_repo(fleet, "homelab-talos", branch="trunk")
+    (clone / "new.go").write_text("package main\n")
+    fleet.git(clone, "add", "new.go")
+    fleet.git(clone, "commit", "-q", "-m", "un-pushed")
+
+    rc, out = fleet.check("--no-remote")
+    assert rc == 17, f"un-pushed source commits must be rc 17, got {rc}\n{out}"
+    assert "0 behind / 1 ahead" in out, out
+    assert _src_counts(out) == (1, 1, 0), out
+
+
+# --- the positive control --------------------------------------------------- #
+def test_a_current_source_repo_is_green(fleet):
+    """🔴 REPORT THIS ALONGSIDE THE REDS, never alone: a zero from a checker
+    wired to nothing looks exactly like this. Here the checker must both find the
+    repo (examined=1) and pronounce it current."""
+    fleet.catch_up()
+    _nixpkg(fleet, "clawgatectl.nix", "homelab-talos")
+    _src_repo(fleet, "homelab-talos", branch="trunk")
+
+    rc, out = fleet.check("--no-remote")
+    assert rc == 0, f"a current source repo must not be drift, got {rc}\n{out}"
+    assert "source repo homelab-talos: current — trunk ==" in out, out
+    assert _src_counts(out) == (1, 0, 0), out
+
+
+def test_the_examined_count_is_reported_beside_the_stale_count(fleet):
+    """One stale repo among two must print BOTH numbers.
+
+    `stale=1` alone says nothing about coverage, and `examined=2` alone says
+    nothing about health. The pair is the claim — the same rule the managed
+    symlink scan follows one subsystem over."""
+    fleet.catch_up()
+    _nixpkg(fleet, "clawgatectl.nix", "homelab-talos")
+    _nixpkg(fleet, "tmux-fuzzyclaw.nix", "tmux-fuzzyclaw")
+    _, b1 = _src_repo(fleet, "homelab-talos", branch="trunk")
+    _src_repo(fleet, "tmux-fuzzyclaw")
+    _push_upstream(fleet, b1, branch="trunk")
+
+    rc, out = fleet.check("--no-remote")
+    assert rc == 17, out
+    assert _src_counts(out) == (2, 1, 0), out
+    assert "source repo tmux-fuzzyclaw: current" in out, out
+
+
+def test_a_scan_that_found_no_source_packages_says_so_instead_of_reporting_zero(fleet):
+    """🔴 A checkout with no `${workspace}/` derivations must print NOT EVALUATED.
+
+    `examined=0 stale=0` would be a scan that walked nothing wearing the exact
+    output of a clean host — the failure mode this whole file exists to refuse."""
+    fleet.catch_up()
+    rc, out = fleet.check("--no-remote")
+    assert rc == 0, out
+    assert "source repos: NOT EVALUATED" in out, out
+    assert "a scan that examined nothing is not a clean scan" in out, out
+    assert "source repos: examined=" not in out, (
+        "a scan that walked nothing printed a count triple:\n" + out
+    )
+
+
+# --- reported, but NOT drift (and never folded into a zero) ------------------ #
+def test_an_absent_source_repo_is_reported_as_unmeasured_not_as_clean(fleet):
+    """A host without the checkout is a documented, tolerated state — the
+    derivations guard on pathExists and simply omit the binary. It must still
+    never be counted as a repo that was found current."""
+    fleet.catch_up()
+    _nixpkg(fleet, "clawgatectl.nix", "homelab-talos")
+
+    rc, out = fleet.check("--no-remote")
+    assert rc == 0, f"an absent source repo is not drift, got {rc}\n{out}"
+    assert "source repo homelab-talos: ABSENT" in out, out
+    assert _src_counts(out) == (1, 0, 1), out
+    assert _src_facts(out)["homelab-talos"] == "ABSENT", out
+
+
+def test_a_failed_fetch_is_reported_as_unmeasured_not_as_clean(fleet):
+    """These repos are private and reached over ssh, and a systemd --user unit
+    has no ssh-agent. "We could not look" must read as neither a pass nor a
+    divergence — and git's own stderr must survive, because for a unit whose only
+    output is the journal that message is the entire diagnosis."""
+    fleet.catch_up()
+    _nixpkg(fleet, "clawgatectl.nix", "homelab-talos")
+    clone, _ = _src_repo(fleet, "homelab-talos", branch="trunk")
+    fleet.git(clone, "remote", "set-url", "origin",
+              str(fleet.root / "definitely-not-a-repo"))
+
+    rc, out = fleet.check("--no-remote")
+    assert rc == 0, f"an unreachable source remote is not drift, got {rc}\n{out}"
+    assert "git fetch FAILED" in out, out
+    assert "git:" in out, "git's own stderr was swallowed\n" + out
+    assert _src_counts(out) == (1, 0, 1), out
+
+
+def test_a_detached_source_repo_is_reported_as_unmeasured_not_as_clean(fleet):
+    """A detached HEAD has no upstream, so there is no defined answer to compare
+    against. Assuming `main` would be a guess printed as a measurement — and
+    these repos do not even agree on a default branch (homelab-talos uses
+    `trunk`)."""
+    fleet.catch_up()
+    _nixpkg(fleet, "clawgatectl.nix", "homelab-talos")
+    clone, _ = _src_repo(fleet, "homelab-talos", branch="trunk")
+    fleet.git(clone, "checkout", "-q", "--detach", "HEAD")
+
+    rc, out = fleet.check("--no-remote")
+    assert rc == 0, f"a detached source checkout is not drift, got {rc}\n{out}"
+    assert "no upstream to compare against" in out, out
+    assert _src_counts(out) == (1, 0, 1), out
+
+
+def test_a_dirty_source_repo_is_reported_even_when_it_is_current(fleet):
+    """🔴 REPORTED, NEVER DRIFT — and reported even on a repo that is otherwise
+    perfectly current, which is the case a "report the problems" check would
+    drop. These derivations copy the working TREE, so an untracked .go file is IN
+    the binary while `git log` says nothing happened. The workbench's
+    homelab-talos is routinely dirty; failing the unit on it would be a
+    permanently-red gate."""
+    fleet.catch_up()
+    _nixpkg(fleet, "clawgatectl.nix", "homelab-talos")
+    clone, _ = _src_repo(fleet, "homelab-talos", branch="trunk")
+    (clone / "scratch.go").write_text("package main\n")
+    (clone / "f").write_text("edited\n")
+
+    rc, out = fleet.check("--no-remote")
+    assert rc == 0, f"a dirty source repo is not drift on its own, got {rc}\n{out}"
+    assert "source repo homelab-talos: DIRTY — 2 path(s)" in out, out
+    assert "source repo homelab-talos: current" in out, out
+    assert _src_counts(out) == (1, 0, 0), out
+
+
+# --- the covered set is DERIVED, and pinned two-way -------------------------- #
+def _run_srcrepo_payload(tmp_path, repo, home, label="pin"):
+    """Run ONLY the SRCREPO payload, against a chosen repo and a chosen $HOME.
+
+    Used to point the REAL extraction at the REAL nix/pkgs without running the
+    git leg over the operator's own checkout: the fixture $HOME contains no
+    `workspace/` at all, so every repo it names comes back ABSENT and not one
+    git command touches anything real."""
+    payload = _payload_literal("SRCREPO")
+    env = dict(os.environ)
+    env.update(HOME=str(home), DRIFT_REPO=str(repo), DRIFT_LABEL=label)
+    proc = subprocess.run(["bash", "-c", payload],
+                          capture_output=True, text=True, env=env)
+    return proc.stdout + proc.stderr
+
+
+def test_the_source_repo_set_is_pinned_two_way_against_nix_pkgs(tmp_path):
+    """🔴 THE LEDGER, in three independent spellings that must all agree.
+
+      1. `EXPECTED_SOURCE_REPOS` — the literal a human has reviewed;
+      2. `_oracle_source_repos()` — pathlib + regex over nix/pkgs;
+      3. what the SHELL PAYLOAD itself reports, run against the real nix/pkgs.
+
+    Fails when the set GROWS — a new `${workspace}/`-sourced package that nobody
+    told the deadman about, which is the exact shape of the bug this whole
+    section exists for — and when it SHRINKS. (3) is what makes (1) and (2) more
+    than bookkeeping: a checker that agrees with a regex but does not actually
+    walk the tree is the thing being ruled out.
+    """
+    home = tmp_path / "empty-home"
+    home.mkdir()
+    out = _run_srcrepo_payload(tmp_path, REPO_ROOT, home)
+    reported = set(_src_facts(out))
+
+    assert _oracle_source_repos() == EXPECTED_SOURCE_REPOS, (
+        "nix/pkgs' `${workspace}/`-sourced repo set has CHANGED. Update "
+        "EXPECTED_SOURCE_REPOS — and check that the new repo is one the deadman "
+        "should be fetching on both hosts: %r" % (_oracle_source_repos(),)
+    )
+    assert reported == EXPECTED_SOURCE_REPOS, (
+        "drift-check.sh's own scan disagrees with nix/pkgs: it reported %r\n%s"
+        % (sorted(reported), out)
+    )
+    # ...and it must have walked real files to get there. `0 scanned` producing
+    # the right answer would mean the answer came from somewhere else.
+    m = re.search(r"\((\d+) nix file\(s\) scanned\)", out)
+    assert m and int(m.group(1)) >= len(list(NIX_PKGS.rglob("*.nix"))), out
+
+
+def test_a_third_source_package_is_covered_with_no_change_to_the_checker(fleet):
+    """🔴 THE GENERALISATION CLAIM, asserted rather than hoped.
+
+    The set is derived from nix/pkgs at scan time, so a package added later is
+    covered the day it lands. A hardcoded pair would have been correct when it
+    was written and silently incomplete afterwards — the same shape as the bug.
+    """
+    fleet.catch_up()
+    _nixpkg(fleet, "clawgatectl.nix", "homelab-talos")
+    _nixpkg(fleet, "tmux-fuzzyclaw.nix", "tmux-fuzzyclaw")
+    _nixpkg(fleet, "brand-new.nix", "some-new-repo")
+    _src_repo(fleet, "homelab-talos", branch="trunk")
+    _src_repo(fleet, "tmux-fuzzyclaw")
+    _, b3 = _src_repo(fleet, "some-new-repo")
+    _push_upstream(fleet, b3, n=2)
+
+    rc, out = fleet.check("--no-remote")
+    assert rc == 17, f"the third package was not covered, got {rc}\n{out}"
+    assert "source repo some-new-repo is NOT current: 2 behind" in out, out
+    assert _src_counts(out) == (3, 1, 0), out
+
+
+def test_two_derivations_sharing_one_source_repo_are_fetched_once(fleet):
+    """clawgatectl's src is `${workspace}/homelab-talos/containers/clawgate` —
+    a SUBDIRECTORY. The repo root is what has a `.git`, and two derivations under
+    one repo must not be counted (or fetched) twice."""
+    fleet.catch_up()
+    _nixpkg(fleet, "a.nix", "homelab-talos/containers/clawgate")
+    _nixpkg(fleet, "b.nix", "homelab-talos/containers/other")
+    _src_repo(fleet, "homelab-talos", branch="trunk")
+
+    rc, out = fleet.check("--no-remote")
+    assert rc == 0, out
+    assert _src_counts(out) == (1, 0, 0), out
+    assert set(_src_facts(out)) == {"homelab-talos"}, out
+
+
+def test_two_source_repos_named_on_ONE_line_are_both_found(fleet):
+    """🔴 FOUND BY A SURVIVING MUTANT, not by review.
+
+    Mutating `LN="$REST"` (advance past the occurrence just consumed) to
+    `LN=""` (stop after the first) SURVIVED the whole suite including the
+    two-way pin — because every line in the real nix/pkgs happens to name at
+    most one source, so the pin compared two extractions that shared the blind
+    spot. A `let a = "${workspace}/x"; b = "${workspace}/y";` line is entirely
+    legal nix, and under that mutant the second repo silently stops being
+    watched. This is the fixture the pin cannot build for itself.
+    """
+    fleet.catch_up()
+    d = fleet.work / "nix" / "pkgs" / "tools"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "pair.nix").write_text(
+        '{ pkgs, workspace }:\n'
+        'let a = "${workspace}/first-repo"; b = "${workspace}/second-repo";\n'
+        'in [ ]\n'
+    )
+    _src_repo(fleet, "first-repo")
+    _, b2 = _src_repo(fleet, "second-repo")
+    _push_upstream(fleet, b2, n=4)
+
+    rc, out = fleet.check("--no-remote")
+    assert set(_src_facts(out)) == {"first-repo", "second-repo"}, out
+    assert rc == 17, f"the SECOND repo on the line went unwatched, got {rc}\n{out}"
+    assert "source repo second-repo is NOT current: 4 behind" in out, out
+    assert _src_counts(out) == (2, 1, 0), out
+
+
+def test_a_workspace_path_inside_a_comment_is_not_a_source_repo(fleet):
+    """clawgatectl.nix's header discusses its own source path in prose, and this
+    checker's own header documents the `${workspace}/` pattern it looks for. A
+    whole-file grep would "find" repos in the documentation and then report them
+    ABSENT forever."""
+    fleet.catch_up()
+    d = fleet.work / "nix" / "pkgs" / "tools"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "commented.nix").write_text(
+        "# the source lives at ${workspace}/ghost-repo, historically\n"
+        '{ pkgs, workspace }:\n'
+        '  src = pkgs.lib.cleanSource (/. + "${workspace}/real-repo");'
+        '   # was ${workspace}/old-ghost\n'
+    )
+    _src_repo(fleet, "real-repo")
+
+    rc, out = fleet.check("--no-remote")
+    assert rc == 0, out
+    assert set(_src_facts(out)) == {"real-repo"}, out
+    assert "ghost" not in out, out
+
+
+# --- severity: where rc 17 sorts -------------------------------------------- #
+def test_unpushed_devrc_commits_still_outrank_a_stale_source_repo(fleet):
+    """rc 8 > rc 17. A diverged devrc stops EVERY future change to the host, of
+    which a stale source repo is one instance, and its rescue can destroy work."""
+    fleet.catch_up()
+    fleet.add_local_commit()
+    _nixpkg(fleet, "clawgatectl.nix", "homelab-talos")
+    _, b = _src_repo(fleet, "homelab-talos", branch="trunk")
+    _push_upstream(fleet, b, branch="trunk")
+
+    rc, out = fleet.check("--no-remote")
+    assert rc == 8, f"rc 8 must outrank rc 17, got {rc}\n{out}"
+    assert "source repo homelab-talos is NOT current" in out, (
+        "the source-repo finding must still be PRINTED even when outranked\n" + out
+    )
+
+
+def test_a_stale_source_repo_outranks_dangling_symlinks_and_a_behind_checkout(fleet):
+    """rc 17 > rc 14 and rc 17 > rc 10.
+
+    A dangling managed symlink is LOUD at the moment of use (`command not
+    found`); a stale source repo is SILENT — the measured failure ran, exited 0
+    and did nothing. `behind` is merely a ship away."""
+    lstore = _mkhome(fleet.home, healthy=1, dangling=2)
+    _nixpkg(fleet, "clawgatectl.nix", "homelab-talos")
+    _, b = _src_repo(fleet, "homelab-talos", branch="trunk")
+    _push_upstream(fleet, b, branch="trunk")
+
+    # `work` is left one commit BEHIND origin/main (the fixture's default), so
+    # rc 10 is live too and all three conditions are present at once.
+    rc, out = _parity(fleet, "--no-remote", store=lstore)
+    assert rc == 17, f"rc 17 must outrank rc 14 and rc 10, got {rc}\n{out}"
+    assert "managed symlink(s) point at a path that does not exist" in out, out
+    assert "local main is BEHIND origin/main" in out, out
+
+
+def test_the_rc17_legend_is_printed_with_the_verdict(fleet):
+    """The journal is the only place this output is ever read, so the code it
+    hands systemd has to be legible there without opening the source."""
+    fleet.catch_up()
+    _nixpkg(fleet, "clawgatectl.nix", "homelab-talos")
+    _, b = _src_repo(fleet, "homelab-talos", branch="trunk")
+    _push_upstream(fleet, b, branch="trunk")
+
+    rc, out = fleet.check("--no-remote")
+    assert rc == 17, out
+    assert "drift-check: DRIFT (rc=17)" in out, out
+    assert "rc17=a SOURCE REPO" in out, out
+
+
+# --- the cross-host half ----------------------------------------------------- #
+def test_the_cross_host_source_comparison_is_NOT_COMPARED_with_one_host(fleet):
+    """One host's facts is not "the machines agree", it is "agreement not looked
+    for", and the two must never print the same way."""
+    fleet.catch_up()
+    _nixpkg(fleet, "clawgatectl.nix", "homelab-talos")
+    _src_repo(fleet, "homelab-talos", branch="trunk")
+
+    rc, out = fleet.check("--no-remote")
+    assert rc == 0, out
+    assert "[srcrepo] NOT COMPARED" in out, out
+    assert "Nothing was compared" in out, out
+
+
+def _two_host_src(fleet, *, remote_extra=0):
+    """Both hosts run the REAL payload against the SAME nix/pkgs but their OWN
+    $HOME/workspace, which is exactly how the two machines differ in life.
+
+    `remote_extra` commits are made AND PUSHED on the remote side, so that host
+    ends up CURRENT with its own upstream at a sha the local host does not have.
+    That is the shape the cross-host claim is about, and it is deliberately not
+    reachable through "behind": with identical fixture content and one clock
+    second, two independently built base commits hash the SAME, so a test that
+    tried to make the heads differ by advancing an upstream compared a sha to
+    itself and passed for the wrong reason (measured).
+    """
+    fleet.catch_up()
+    _nixpkg(fleet, "clawgatectl.nix", "homelab-talos")
+    lstore = _mkhome(fleet.home, healthy=1)
+    _src_repo(fleet, "homelab-talos", branch="trunk")
+
+    rhome = fleet.root / "remote-home"
+    rhome.mkdir()
+    rstore = _mkhome(rhome, healthy=1, store=fleet.root / "remote-store")
+    rclone, _ = _src_repo(fleet, "homelab-talos", branch="trunk", home=rhome)
+    for i in range(remote_extra):
+        (rclone / "f").write_text("remote-only-%d\n" % i)
+        fleet.git(rclone, "commit", "-q", "-am", "remote work %d" % i)
+    if remote_extra:
+        fleet.git(rclone, "push", "-q", "origin", "trunk")
+    _remote_running_the_real_payload(fleet, rhome, rstore)
+    return _parity(fleet, store=lstore, REMOTE_SSH="stub@example.invalid")
+
+
+def test_the_cross_host_comparison_reports_differing_heads_without_setting_an_rc(fleet):
+    """🔴 INFORMATION, NOT A VERDICT — and that is a decision, not an omission.
+
+    Whether a given HEAD is WRONG has a defined answer and is measured per host
+    against that branch's own upstream. "The two hosts are on different commits"
+    has no such answer: these are shared development repos and one machine on a
+    feature branch is normal. A code that fired on it would be red most of the
+    time, and a permanently-red gate is worse than no gate.
+
+    So this is the load-bearing case: BOTH hosts are current with their own
+    upstreams — nothing is stale anywhere — and their source HEADs still differ.
+    The difference is printed and the exit code stays 0.
+    """
+    rc, out = _two_host_src(fleet, remote_extra=1)
+    assert rc == 0, (
+        "a cross-host source difference must not set an exit code, got %d\n%s"
+        % (rc, out))
+    assert "the two hosts build DIFFERENT source" in out, out
+    assert "information only" in out, out
+    assert "compared=1 same=0 differing=1" in out, out
+
+
+def test_the_cross_host_comparison_reports_agreement_when_the_heads_match(fleet):
+    """🔴 POSITIVE CONTROL for the comparison. Without it, `differing=0` is
+    indistinguishable from a comparator wired to nothing — an empty union minus
+    anything is still empty."""
+    rc, out = _two_host_src(fleet)
+    assert rc == 0, out
+    assert "[srcrepo] compared=1 same=1 differing=0" in out, out
+    assert "NOT COMPARED" not in out.split("=== source-repo parity")[1], out
+
+
+def test_a_non_integer_source_fetch_timeout_is_rejected(fleet):
+    """`DRIFT_SRC_FETCH_TIMEOUT` is handed to `timeout`, so `require_int` is what
+    keeps it an integer — and what keeps a shell metacharacter out of a command
+    line. Its sibling for DRIFT_PHASE2_TIMEOUT survived a mutation sweep because
+    nothing exercised it; this is the same guard, exercised."""
+    rc, out = fleet.check("--no-remote", DRIFT_SRC_FETCH_TIMEOUT="30; echo PWNED")
+    assert rc == 2, f"expected a usage error, got {rc}\n{out}"
+    assert "DRIFT_SRC_FETCH_TIMEOUT must be a non-negative integer" in out, out
+    assert not [ln for ln in out.splitlines() if ln.strip() == "PWNED"], out
+
+
+def test_the_source_fetch_timeout_is_not_forwarded_over_ssh(fleet):
+    """⚠ INVARIANT GUARD, not regression coverage — trivially GREEN AT a2707be,
+    where the variable did not exist. It pins a property of the new code that
+    nothing else asserts.
+
+    🔴 Every value this script sends across the ssh hop is a value that has to be
+    proved safe on the FAR side, where the static passivity scanner cannot see
+    it. The remote host uses the default — asserted on the payload the driver
+    actually builds, not on a comment claiming it.
+    """
+    src = DRIFT.read_text()
+    i = src.index("| ssh -o ConnectTimeout=10")
+    forwarded = src[src.rindex("printf 'DRIFT_LABEL", 0, i):i]
+    # Positive control: the slice must contain the values that ARE forwarded, or
+    # "the timeout is not in it" is a claim about an empty string.
+    for expected in ("DRIFT_LABEL", "DRIFT_UNTRACKED_MAX", "DRIFT_DANGLING_MAX"):
+        assert expected in forwarded, (
+            "the forwarded-env slice is not the one the driver builds: %r"
+            % forwarded)
+    assert "DRIFT_SRC_FETCH_TIMEOUT" not in forwarded, (
+        "the source-fetch timeout is interpolated into the REMOTE payload:\n"
+        + forwarded
+    )
+
+
+# --- the SEAM: the script's fetch budget vs the unit's start timeout ---------- #
+def test_the_unit_start_timeout_can_absorb_every_source_repo_fetch():
+    """🔴 A SEAM NEITHER FILE'S TESTS OWN.
+
+    The per-fetch cap is a tunable in drift-check.sh; the ceiling on the whole
+    run is `TimeoutStartSec` in nix/home.nix. Their PRODUCT is what decides
+    whether the unit finishes, and nothing computed it: the ceiling was 180,
+    sized for "two `git fetch`es plus one ssh round trip", while the source-repo
+    leg adds `2 hosts x N repos x cap` on top.
+
+    The failure it guards is the silent kind. systemd kills the cgroup at the
+    ceiling, the deadman reports NOTHING — no verdict about either host — and
+    the unit merely looks slow. So this recomputes the budget from BOTH files
+    and fails when either moves out from under the other, whether the cap grows,
+    a third source repo lands, or the ceiling shrinks.
+    """
+    m = re.search(r'DRIFT_SRC_FETCH_TIMEOUT="\$\{DRIFT_SRC_FETCH_TIMEOUT:-(\d+)\}"',
+                  DRIFT.read_text())
+    assert m, "no DRIFT_SRC_FETCH_TIMEOUT default in drift-check.sh"
+    cap = int(m.group(1))
+    m2 = re.search(r'DRIFT_PHASE2_TIMEOUT="\$\{DRIFT_PHASE2_TIMEOUT:-(\d+)\}"',
+                   DRIFT.read_text())
+    assert m2, "no DRIFT_PHASE2_TIMEOUT default in drift-check.sh"
+    phase2 = int(m2.group(1))
+
+    block = _drift_service_block()
+    m3 = re.search(r"TimeoutStartSec = (\d+);", block)
+    assert m3, "the drift-check unit declares no TimeoutStartSec:\n" + block
+    ceiling = int(m3.group(1))
+
+    # 2 hosts x every source repo, plus the phase-2 scan, plus the 60s this
+    # already needed for the two devrc fetches and the ssh round trip.
+    needed = 2 * len(EXPECTED_SOURCE_REPOS) * cap + phase2 + 60
+    assert ceiling >= needed, (
+        "TimeoutStartSec=%d cannot absorb the worst case: %d source fetches at "
+        "%ds + a %ds phase-2 scan + 60s of devrc fetch/ssh = %ds. systemd would "
+        "kill the run and the deadman would report nothing, on a schedule."
+        % (ceiling, 2 * len(EXPECTED_SOURCE_REPOS), cap, phase2, needed)
+    )
+
+
+# --- passivity, behaviourally ------------------------------------------------ #
+def test_a_run_against_a_stale_source_repo_mutates_nothing(fleet):
+    """🔴 THE CONTRACT. This leg FETCHES — a write to remote-tracking refs and
+    nothing else. Branch, HEAD, worktree and stash stack of the source repo must
+    all be byte-identical afterwards, for shapes nobody enumerated.
+    """
+    fleet.catch_up()
+    _nixpkg(fleet, "clawgatectl.nix", "homelab-talos")
+    clone, b = _src_repo(fleet, "homelab-talos", branch="trunk")
+    _push_upstream(fleet, b, branch="trunk", n=2)
+    (clone / "wip.go").write_text("package main // uncommitted\n")
+
+    def snapshot():
+        return (
+            fleet.git(clone, "symbolic-ref", "--quiet", "--short", "HEAD"),
+            fleet.git(clone, "rev-parse", "HEAD"),
+            fleet.git(clone, "status", "--porcelain"),
+            fleet.git(clone, "stash", "list"),
+            (clone / "wip.go").read_text(),
+        )
+
+    before = snapshot()
+    rc, out = fleet.check("--no-remote")
+    assert rc == 17, out
+    assert snapshot() == before, (
+        "🔴 the deadman MUTATED a source repo — it may only fetch\n" + out
+    )


### PR DESCRIPTION
## The failure

Two repos, two delivery mechanisms, and only one of them is automatic.

`clawgatectl` is built by devrc from a **local working tree of a different repo** —
`nix/pkgs/tools/clawgatectl.nix` sets `srcDir = "${workspace}/homelab-talos/containers/clawgate"`.
The **version literal** lived in devrc and was stamped in with `-X main.buildVersion=`.
The **code** lives in homelab-talos and is read live off disk. **Nothing converges
homelab-talos on either host**: `ship.sh` is scoped to `$HOME/workspace/devrc`, and
`drift-check.sh` had never heard of it.

Measured 2026-08-14:

| time | what |
|---|---|
| 17:44 | homelab-infra `978c549c` (#323) adds `task status` + `task comment`, sets the Go default `buildVersion` to `"0.7.95"` |
| 17:48 | devrc `1b790b3` (#483) bumps the nix literal `0.7.87 → 0.7.95`, ships to both hosts |

The workbench's homelab-talos was current → a genuine 0.7.95. The laptop's was frozen
24 commits back at `6e9055f7`; its `client.go` **correctly said `0.7.87`**, and the nix
ldflag **overwrote that truth**. The laptop shipped a binary with neither subcommand,
labelled `0.7.95`. `clawgatectl task status <id> in_progress` printed help and **exited 0**
— a silent no-op against a CLI whose write ritual the `clawgate` skill makes mandatory.

`drift-check.sh` was fully green on that laptop the entire time: devrc git parity fine,
symlinks resolved, `settings.json` keys matched. The condition was structurally outside
its scope.

`task-api.md` argued a stale binary is harmless because every command prints a
server-vs-build skew note. That argument was **false**: `h.Version == buildVersion`
compared *equal*, so the note stayed silent. Corrected here.

---

## Change A — nix stops overwriting the source's own version

`nix/pkgs/tools/clawgatectl.nix` no longer carries a `version` literal. It reads
`cmd/clawgatectl/client.go` and extracts **exactly one** `var buildVersion = "…"` line;
`version` (hence the store path) and the stamped `buildVersion` are then the same derived
value, both describing the code actually being compiled.

* **No suffix, no fingerprint.** `client.go:277` compares `h.Version == buildVersion` by
  exact equality; any suffix fires the skew note on every command on every host forever.
  Had this been in place on 08-14 the laptop would have reported `0.7.87` and the skew
  note would have fired **correctly** against the 0.7.95 server. Letting the existing
  mechanism work *is* the design.
* **Unparseable source → `available = false`, never a fallback literal.** Zero matches
  (renamed/reformatted) and two-or-more (ambiguous) both yield `null`. The binary is
  simply not installed — loud at use time as `command not found` — rather than failing
  the switch, which `ship.sh` reports as a SKIPPED host and this repo's `CLAUDE.md`
  documents as the failure mode that silently stops all future delivery. The existing
  `pathExists` guard is extended, not replaced.
* Header comment block rewritten; the old one explained the version/source relationship
  in terms this change makes false.

**`tmux-fuzzyclaw` could NOT take Change A**, and that is a measurement, not an omission
(2026-08-18): its `cmd/version.go` declares `var Version = "dev"`, the string `2.0.0`
appears **nowhere** in that repo outside the devrc nix file, and the repo carries **no git
tags**. There is no source of truth to read and inventing one would be the same lie in a
new place. The finding is documented in `tmux-fuzzyclaw.nix` and **pinned by a test that
fails the day `cmd/version.go` grows a real version** — which is the trigger to apply
Change A there too. Change B covers it regardless.

---

## Change B — a source-repo parity deadman, `drift-check.sh` rc 17

A third kind of parity, one level past "git parity is not host parity": **for every
package devrc builds from a local working tree, is that source repo current on each host?**

* **The covered set is DERIVED, never listed.** The payload reads `nix/pkgs/**.nix` out of
  the checkout it is examining (bash `globstar`, no `find` — busybox on the laptop
  silently exits 0 on `-xtype`) and collects every `${workspace}/<name>` outside a
  comment. A third such package is covered the day it lands.
* **Pinned two-way, three independent spellings that must agree**: a reviewed literal, a
  pathlib+regex oracle, and *what the shell payload itself reports against the real
  `nix/pkgs`*. Fails when the set GROWS or SHRINKS.
* **Per host**: behind/ahead of the branch's **own upstream** (never a hardcoded `main` —
  homelab-talos works on `trunk`), plus dirty trees, which matter because these
  derivations copy the **tree**, not the commit.
* **`examined=N stale=M unmeasured=K` is printed as a triple.** `absent`, `fetch failed`,
  `detached`/`no upstream` and `could not compare` are **UNMEASURED** — reported, never
  folded into a reassuring `stale=0`, never drift. A scan finding no source packages
  prints `NOT EVALUATED`, not `examined=0 stale=0`.
* **Cross-host half is INFORMATION ONLY** and says `NOT COMPARED` without facts from both
  machines. Differing HEADs are reported with **no rc**: whether a HEAD is *wrong* is
  already answered per host against its own upstream, whereas two hosts on different
  branches of a shared dev repo is normal — a code for it would be permanently red.
* **READ-ONLY**: `fetch`, `rev-parse`, `symbolic-ref`, `rev-list`, `status`. Passes the
  suite's static passivity allowlist and a new behavioural test asserting a source repo's
  branch/HEAD/worktree/stash are byte-identical after a run.

### Why rc 17, and where it sorts

`severity()` is a **lookup table**, and the published order was never monotonic in the
digits (14 > 13 > 6 > 4 > 3 > 12). Every free code **below** 16 (5, 7, 9, 11) is
explicitly reserved to a ship.sh meaning this script does not take, so a new DRIFT code
has nowhere to go but upward. 17 is ranked **67**:

```
8  >  17  >  14  >  13  >  6  >  4  >  3  >  12  >  15  >  10  >  16
```

* **below 8** — a diverged devrc stops *every* future change to the host, of which a stale
  source repo is one instance, and rc 8's rescue can destroy work.
* **above 14** — a dangling managed symlink is **loud** at the moment of use
  (`command not found`); this is **silent**: the measured failure ran, exited 0 and did
  nothing while wearing a current-looking version.

rc 17 is **not** on `SuccessExitStatus` — unlike 13 and 16 it is a real divergence with a
real fix, so it reaches `OnFailure` and toasts, like rc 8.

### `nix/home.nix`: `TimeoutStartSec` 180 → 420

180 was sized for "two `git fetch`es plus one ssh round trip". The source-repo leg adds
`2 hosts × N repos × DRIFT_SRC_FETCH_TIMEOUT (30s)` = 120s of new worst case. At 180 the
cgroup would be killed mid-run and the deadman would report **nothing**, on a schedule,
looking merely slow. That product is now a **pinned seam test** recomputed from both files.

---

## Testing

**42 new tests** — 24 in `test_drift_check.py` (213 → 237 collected) and 18 in a new
`test_clawgatectl_version.py`. Full per-test matrix vs base **`a2707be`** is in the PR
conversation: **39 of 42 are RED at base**, and the 3 that are green are labelled
**⚠ INVARIANT GUARD** in their own docstrings rather than counted as regression coverage.

`test_clawgatectl_version.py` has two layers: structural assertions that always run, and a
behavioural layer that **actually evaluates** `clawgatectl.nix` against throwaway fixture
source trees with `pkgs` stubbed to the four attributes it touches. It **fails rather than
skips** when `nix-instantiate` is missing — the policy `test_opencode_config.py::nix_eval`
already sets here.

### Mutation sweep — 19 mutants, run under `PYTHONDONTWRITEBYTECODE=1`

18 killed on the first pass, **one SURVIVED**: mutating `LN="$REST"` (advance past the
occurrence just consumed) to `LN=""` (stop after the first) survived the entire suite
**including the two-way pin** — because every line in the real `nix/pkgs` happens to name
at most one source, so both extractions shared the blind spot. That is a mutant silently
reintroducing an under-reporting bug through a fully green suite.
`test_two_source_repos_named_on_ONE_line_are_both_found` closes it; the battery is **19/19
after**. Each mutant is the narrowest expression that can be wrong (the guard is never
deleted together with its enclosing condition), and the positive control is included.

### Live probe

Read-only with respect to both real checkouts: each was `git clone`d (hardlinked, source
untouched) into a scratch `$HOME`, its origin repointed at the **real private GitHub URL**,
and only the clone fetched. The private-repo fetch over ssh **succeeded** from this
environment, and the leg reported:

```
🔴 DRIFT — source repo homelab-talos is NOT current: 1 behind / 0 ahead of refs/remotes/origin/trunk
source repo tmux-fuzzyclaw: on branch docs/tui-rendering-footguns — no upstream to compare against, currency NOT evaluated.
source repos: examined=2 stale=1 unmeasured=1 (7 nix file(s) scanned)
SRC-RC=17
```

That is **real, live drift on the workbench right now** — the exact class this exists for.
It also validates the "no upstream is NOT drift" decision: `tmux-fuzzyclaw` is genuinely
sitting on an untracked local branch, and had that been ruled drift the deadman would have
been permanently red on the workbench from day one.

**Not verified**: whether the fetch succeeds from a **systemd `--user`** context, which has
no ssh-agent. If the GitHub key needs an agent it will report `FETCH FAILED` → UNMEASURED
→ no rc, which is honest but measures nothing there. Worth one `systemctl --user start
drift-check` after the deploy. Neither host was touched.

## Gate

See the PR conversation for the `scripts/gate.sh` exit status and the authoritative
`nix build .#checks.x86_64-linux.pytests` result. `TARGET_FLOORS` needed **no re-pin**:
`scripts/tests` collected 5228 against floor 4976 and a drift ceiling of 6220, and the
gate printed no replacement number.
