### PR TITLE
fix(signal): outbound reactions were dropped — the sync branch handled remoteDelete but not its sibling

### DIFF
--- a/claude/skills/signal/SKILL.md
+++ b/claude/skills/signal/SKILL.md
@@ -127,7 +127,7 @@ operator token as `approve`):
 |---|---|
 | `message` | a 1:1 message (attachments, quotes, view-once and expiring messages are all this kind, with fields set) |
 | `group_message` | a message carrying `groupInfo` |
-| `reaction` | an emoji reaction (may arrive BEFORE its target — see gotchas) |
+| `reaction` | an emoji reaction (may arrive BEFORE its target — see gotchas). Covers BOTH directions: someone reacting to you, and 🔴 **your own reactions sent from the phone**, which arrive in the `syncMessage.sentMessage` wrapper and are stored with **the account itself** as `reactions.contact_id` |
 | `edit` | an edit of an earlier message (`edit_target_timestamp` points at it) |
 | `sync_outbound` | a message Zach sent from another linked device, echoed back |
 | `receipt_delivery` | a delivery receipt |
@@ -186,6 +186,16 @@ and tear it down on exit — exactly like `mail-actions`.
 - **Reactions can precede their target message** (delivery is not ordered, and history is not
   backfilled). `reactions.message_id` is NULLable, resolved later, with the partial index
   `idx_rx_unresolved`. Unresolvable reactions are RETAINED, not dropped.
+- 🔴 **Filtering reactions to "what people sent me" must exclude the account's own
+  `contact_id`** — your own reactions live in the same table. Before 2026-08-18 they were
+  being DROPPED entirely, so any analysis over reactions predating that is missing them.
+- 🔴 **When you fix an own-device branch for one message shape, enumerate the others in
+  that wrapper.** `syncMessage.sentMessage` carries `remoteDelete`, `reaction` and a plain
+  `message`. The remote-delete case was fixed first and the reaction case was still missed
+  for weeks — dropped reaction plus a bodyless ghost row in `signal.messages`. Found only by
+  real traffic, after six PRs, four audit rounds and 387 green tests. Any UNMODELLED
+  `sentMessage` variant with `message: None` (e.g. a nested `editMessage`, `sticker`,
+  `payment`) still produces such a ghost row — that is open work, not a solved problem.
 - **Redelivery duplicates attachments** without `UNIQUE (message_id,
   signal_attachment_id)`.
 - **One person must be ONE contact row, in both arrival orders.** An identity arrives

--- a/scripts/signal/consumer.py
+++ b/scripts/signal/consumer.py
@@ -362,8 +362,14 @@ def parse_envelope(envelope: dict) -> ParsedEvent:
                 raw_envelope=raw,
             )
 
+        # `is not None`, NOT truthiness — the same predicate as the sync site
+        # above, deliberately. Consolidating only the parser BODY left this
+        # dispatch divergent: an inbound `reaction: {}` was stored as an ordinary
+        # message while the identical sync shape was reported malformed. A
+        # malformed frame counted as a successful message is the failure the
+        # remoteDelete branch documents; one rule, both sites.
         reaction = data.get("reaction")
-        if reaction:
+        if reaction is not None:
             rx = _reaction_from(envelope, reaction, where="inbound")
             return ParsedEvent(kind=KIND_REACTION, reaction=rx, raw_envelope=raw)
 

--- a/scripts/signal/consumer.py
+++ b/scripts/signal/consumer.py
@@ -249,6 +249,35 @@ def parse_envelope(envelope: dict) -> ParsedEvent:
                 },
                 raw_envelope=raw,
             )
+        # 🔴 A REACTION MADE ON ZACH'S OWN PHONE arrives HERE too, in the same
+        # `syncMessage.sentMessage` wrapper and for the same reason as the
+        # retraction above: this branch runs BEFORE the inbound `dataMessage`
+        # branch. Without this case it fell through to `_base_message()` and hit
+        # BOTH defects the remote-delete case exists to prevent — the reaction
+        # dropped from signal.reactions, and a bodyless ghost row left in
+        # signal.messages (`message` is None on a reaction-only sync).
+        #
+        # Found in LIVE traffic, not by review: two OTHER members had reacted to
+        # the same message, so the reaction COUNT for that target looked right
+        # and only the reactor identity showed the account's own was missing.
+        sync_reaction = sent.get("reaction")
+        if sync_reaction is not None:
+            # The reactor is the ACCOUNT ITSELF — this envelope's source is the
+            # linked device — while targetAuthor is whoever wrote the message
+            # being reacted to. Same field mapping as the inbound branch.
+            rx = {
+                "source_uuid": envelope.get("sourceUuid"),
+                "source_number": envelope.get("sourceNumber") or envelope.get("source"),
+                "target_author_uuid": sync_reaction.get("targetAuthorUuid"),
+                "target_author_number": sync_reaction.get("targetAuthor"),
+                "target_sent_timestamp": sync_reaction.get("targetSentTimestamp"),
+                "emoji": sync_reaction.get("emoji"),
+                "is_remove": bool(sync_reaction.get("isRemove")),
+            }
+            if rx["target_sent_timestamp"] is None:
+                raise MalformedEvent("sync reaction has no targetSentTimestamp")
+            return ParsedEvent(kind=KIND_REACTION, reaction=rx, raw_envelope=raw)
+
         ts = sent.get("timestamp") or env_ts
         if ts is None:
             raise MalformedEvent("sync sentMessage has no timestamp")

--- a/scripts/signal/consumer.py
+++ b/scripts/signal/consumer.py
@@ -205,6 +205,50 @@ def _base_message(env: dict, data: dict, *, timestamp: int) -> dict:
     }
 
 
+def _reaction_from(envelope: dict, reaction, *, where: str) -> dict:
+    """Build a reaction row from `reaction`, wherever in the envelope it sat.
+
+    🔴 ONE PLACE, because there are TWO sites — inbound `dataMessage.reaction`
+    and own-device `syncMessage.sentMessage.reaction` — and the second was added
+    only after live traffic showed outbound reactions being dropped. Open-coding
+    the same dict twice is what let the sync site ship missing the guards the
+    inbound site had; keeping it open-coded would guarantee the next divergence.
+
+    🔴 EVERY guard here exists because the alternative is NOT a skipped frame but
+    a WEDGED CONSUMER. `upsert_reaction` resolves BOTH the target author and the
+    reactor through `upsert_contact`, which raises `ValueError` on an
+    unidentifiable contact — and `ValueError` is neither `MalformedEvent` nor a
+    TRANSIENT_DB_ERROR, so it escapes `store()`, escapes `handle_payload()`
+    (which wraps only the PARSE), and lands in `run()`'s reconnect handler,
+    which counts it as a dropped stream. Signal then REDELIVERS the same frame
+    on reconnect: an unbounded loop that stores nothing and takes every later
+    frame on the connection down with it. Raising `MalformedEvent` here instead
+    keeps the module's promise — skipped and counted, never fatal.
+    """
+    if not isinstance(reaction, dict):
+        raise MalformedEvent(f"{where} reaction is not an object")
+    rx = {
+        "source_uuid": envelope.get("sourceUuid"),
+        "source_number": envelope.get("sourceNumber") or envelope.get("source"),
+        "target_author_uuid": reaction.get("targetAuthorUuid"),
+        # signal-cli exposes THREE identity fields and the first version of this
+        # read only two: `targetAuthorNumber` appears in real envelopes and was
+        # silently ignored, so a reaction carrying only it looked unidentifiable.
+        "target_author_number": (reaction.get("targetAuthor")
+                                 or reaction.get("targetAuthorNumber")),
+        "target_sent_timestamp": reaction.get("targetSentTimestamp"),
+        "emoji": reaction.get("emoji"),
+        "is_remove": bool(reaction.get("isRemove")),
+    }
+    if rx["target_sent_timestamp"] is None:
+        raise MalformedEvent(f"{where} reaction has no targetSentTimestamp")
+    if not (rx["target_author_uuid"] or rx["target_author_number"]):
+        raise MalformedEvent(f"{where} reaction has no target author identity")
+    if not (rx["source_uuid"] or rx["source_number"]):
+        raise MalformedEvent(f"{where} reaction has no reactor identity")
+    return rx
+
+
 def parse_envelope(envelope: dict) -> ParsedEvent:
     """Normalise one signal-cli envelope into a `ParsedEvent`.
 
@@ -264,18 +308,8 @@ def parse_envelope(envelope: dict) -> ParsedEvent:
         if sync_reaction is not None:
             # The reactor is the ACCOUNT ITSELF — this envelope's source is the
             # linked device — while targetAuthor is whoever wrote the message
-            # being reacted to. Same field mapping as the inbound branch.
-            rx = {
-                "source_uuid": envelope.get("sourceUuid"),
-                "source_number": envelope.get("sourceNumber") or envelope.get("source"),
-                "target_author_uuid": sync_reaction.get("targetAuthorUuid"),
-                "target_author_number": sync_reaction.get("targetAuthor"),
-                "target_sent_timestamp": sync_reaction.get("targetSentTimestamp"),
-                "emoji": sync_reaction.get("emoji"),
-                "is_remove": bool(sync_reaction.get("isRemove")),
-            }
-            if rx["target_sent_timestamp"] is None:
-                raise MalformedEvent("sync reaction has no targetSentTimestamp")
+            # being reacted to.
+            rx = _reaction_from(envelope, sync_reaction, where="sync")
             return ParsedEvent(kind=KIND_REACTION, reaction=rx, raw_envelope=raw)
 
         ts = sent.get("timestamp") or env_ts
@@ -330,17 +364,7 @@ def parse_envelope(envelope: dict) -> ParsedEvent:
 
         reaction = data.get("reaction")
         if reaction:
-            rx = {
-                "source_uuid": envelope.get("sourceUuid"),
-                "source_number": envelope.get("sourceNumber") or envelope.get("source"),
-                "target_author_uuid": reaction.get("targetAuthorUuid"),
-                "target_author_number": reaction.get("targetAuthor"),
-                "target_sent_timestamp": reaction.get("targetSentTimestamp"),
-                "emoji": reaction.get("emoji"),
-                "is_remove": bool(reaction.get("isRemove")),
-            }
-            if rx["target_sent_timestamp"] is None:
-                raise MalformedEvent("reaction has no targetSentTimestamp")
+            rx = _reaction_from(envelope, reaction, where="inbound")
             return ParsedEvent(kind=KIND_REACTION, reaction=rx, raw_envelope=raw)
 
         ts = data.get("timestamp") or env_ts

--- a/scripts/signal/tests/fixtures/envelopes.json
+++ b/scripts/signal/tests/fixtures/envelopes.json
@@ -8,7 +8,6 @@
     "assertion names. A fixture that can only produce the expected constant's own",
     "value cannot catch a mutant that hardcodes that literal."
   ],
-
   "dm": {
     "envelope": {
       "source": "+15550101",
@@ -41,7 +40,6 @@
       }
     }
   },
-
   "group": {
     "envelope": {
       "source": "+15550202",
@@ -69,7 +67,6 @@
       }
     }
   },
-
   "reaction": {
     "envelope": {
       "source": "+15550303",
@@ -99,7 +96,6 @@
       }
     }
   },
-
   "reaction_remove": {
     "envelope": {
       "source": "+15550808",
@@ -126,7 +122,6 @@
       }
     }
   },
-
   "edit": {
     "envelope": {
       "source": "+15550404",
@@ -150,7 +145,6 @@
       }
     }
   },
-
   "attachment": {
     "envelope": {
       "source": "+15550505",
@@ -190,7 +184,6 @@
       ]
     }
   },
-
   "voice_note": {
     "envelope": {
       "source": "+15551212",
@@ -212,13 +205,19 @@
     },
     "expect": {
       "kind": "message",
-      "message": {"message_timestamp": 1723000001212, "body": null},
+      "message": {
+        "message_timestamp": 1723000001212,
+        "body": null
+      },
       "attachments": [
-        {"id": "attach-fixture-1212", "is_voice_note": true, "content_type": "audio/aac"}
+        {
+          "id": "attach-fixture-1212",
+          "is_voice_note": true,
+          "content_type": "audio/aac"
+        }
       ]
     }
   },
-
   "quote": {
     "envelope": {
       "source": "+15550606",
@@ -246,7 +245,6 @@
       }
     }
   },
-
   "receipt_delivery": {
     "envelope": {
       "source": "+15550707",
@@ -257,15 +255,21 @@
         "when": 1723000000717,
         "isDelivery": true,
         "isRead": false,
-        "timestamps": [1723000000101]
+        "timestamps": [
+          1723000000101
+        ]
       }
     },
     "expect": {
       "kind": "receipt_delivery",
-      "receipt": {"when": 1723000000717, "timestamps": [1723000000101]}
+      "receipt": {
+        "when": 1723000000717,
+        "timestamps": [
+          1723000000101
+        ]
+      }
     }
   },
-
   "receipt_read": {
     "envelope": {
       "source": "+15550909",
@@ -276,26 +280,41 @@
         "when": 1723000000919,
         "isDelivery": false,
         "isRead": true,
-        "timestamps": [1723000000202, 1723000000303]
+        "timestamps": [
+          1723000000202,
+          1723000000303
+        ]
       }
     },
     "expect": {
       "kind": "receipt_read",
-      "receipt": {"when": 1723000000919, "timestamps": [1723000000202, 1723000000303]}
+      "receipt": {
+        "when": 1723000000919,
+        "timestamps": [
+          1723000000202,
+          1723000000303
+        ]
+      }
     }
   },
-
   "typing": {
     "envelope": {
       "source": "+15551010",
       "sourceNumber": "+15551010",
       "sourceUuid": "10101010-1010-4101-8101-101010101010",
       "timestamp": 1723000001010,
-      "typingMessage": {"action": "STARTED", "timestamp": 1723000001010}
+      "typingMessage": {
+        "action": "STARTED",
+        "timestamp": 1723000001010
+      }
     },
-    "expect": {"kind": "typing", "receipt": {"action": "STARTED"}}
+    "expect": {
+      "kind": "typing",
+      "receipt": {
+        "action": "STARTED"
+      }
+    }
   },
-
   "sync_outbound": {
     "envelope": {
       "source": "+15559090",
@@ -324,7 +343,6 @@
       }
     }
   },
-
   "view_once": {
     "envelope": {
       "source": "+15551313",
@@ -339,11 +357,13 @@
     },
     "expect": {
       "kind": "message",
-      "message": {"message_timestamp": 1723000001313, "view_once": true,
-                  "body": "look quickly"}
+      "message": {
+        "message_timestamp": 1723000001313,
+        "view_once": true,
+        "body": "look quickly"
+      }
     }
   },
-
   "expiring": {
     "envelope": {
       "source": "+15551414",
@@ -358,11 +378,13 @@
     },
     "expect": {
       "kind": "message",
-      "message": {"message_timestamp": 1723000001414, "expires_in_seconds": 3600,
-                  "body": "this vanishes in an hour"}
+      "message": {
+        "message_timestamp": 1723000001414,
+        "expires_in_seconds": 3600,
+        "body": "this vanishes in an hour"
+      }
     }
   },
-
   "remote_delete": {
     "envelope": {
       "source": "+15551616",
@@ -372,7 +394,9 @@
       "dataMessage": {
         "timestamp": 1723000001616,
         "message": null,
-        "remoteDelete": {"targetSentTimestamp": 1723000001606}
+        "remoteDelete": {
+          "targetSentTimestamp": 1723000001606
+        }
       }
     },
     "expect": {
@@ -384,7 +408,6 @@
       }
     }
   },
-
   "sync_remote_delete": {
     "envelope": {
       "source": "+15559091",
@@ -395,7 +418,9 @@
         "sentMessage": {
           "timestamp": 1723000001717,
           "destination": "+15550101",
-          "remoteDelete": {"targetSentTimestamp": 1723000001707}
+          "remoteDelete": {
+            "targetSentTimestamp": 1723000001707
+          }
         }
       }
     },
@@ -408,15 +433,63 @@
       }
     }
   },
-
+  "sync_reaction": {
+    "envelope": {
+      "source": "+15559092",
+      "sourceNumber": "+15559092",
+      "sourceUuid": "92929292-9292-4929-8929-929292929292",
+      "sourceName": "me",
+      "timestamp": 1723000009292,
+      "syncMessage": {
+        "sentMessage": {
+          "timestamp": 1723000009292,
+          "message": null,
+          "destination": null,
+          "destinationUuid": null,
+          "groupInfo": {
+            "type": "DELIVER",
+            "groupId": "c3luY3JlYWN0Zml4dHVyZQ==",
+            "revision": 4,
+            "groupName": "corpus group"
+          },
+          "reaction": {
+            "emoji": "🤯",
+            "isRemove": false,
+            "targetAuthor": "+15550404",
+            "targetAuthorUuid": "44444444-4444-4444-8444-444444444444",
+            "targetAuthorNumber": null,
+            "targetSentTimestamp": 1723000009282
+          }
+        }
+      }
+    },
+    "expect": {
+      "kind": "reaction",
+      "reaction": {
+        "emoji": "🤯",
+        "target_author_uuid": "44444444-4444-4444-8444-444444444444",
+        "target_author_number": "+15550404",
+        "target_sent_timestamp": 1723000009282,
+        "is_remove": false,
+        "source_uuid": "92929292-9292-4929-8929-929292929292",
+        "source_number": "+15559092"
+      }
+    }
+  },
   "unknown_type": {
     "envelope": {
       "source": "+15551515",
       "sourceNumber": "+15551515",
       "sourceUuid": "15151515-1515-4151-8151-151515151515",
       "timestamp": 1723000001515,
-      "callMessage": {"offerMessage": {"id": 4242424242}}
+      "callMessage": {
+        "offerMessage": {
+          "id": 4242424242
+        }
+      }
     },
-    "expect": {"kind": "unknown"}
+    "expect": {
+      "kind": "unknown"
+    }
   }
 }

--- a/scripts/signal/tests/test_consumer_resilience.py
+++ b/scripts/signal/tests/test_consumer_resilience.py
@@ -572,3 +572,71 @@ def test_run_returns_its_counters(db):
         consumer.STAT_DB_RECOVERIES, consumer.STAT_DB_RECOVERY_FAILURES,
         consumer.STAT_ATTACHMENT_FAILURES,
     }
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE SEAM. Both halves of the reaction path were tested in isolation and both
+# were clean: the parser had its own tests, the DB layer had its own tests, and
+# neither fixture ever built the combined state. The defect lived exactly there —
+# an unidentifiable contact parses FINE and only raises inside upsert_contact,
+# and that ValueError is neither MalformedEvent nor a TRANSIENT_DB_ERROR, so it
+# escapes store(), escapes handle_payload() (which wraps only the PARSE), and is
+# counted by run() as a DROPPED STREAM. Signal redelivers unacked frames on
+# reconnect: an unbounded loop storing nothing, taking every later frame with it.
+#
+# These drive parser + DB together through run(), which is the only place that
+# distinction is observable.
+
+def _sync_reaction_frame(*, target_ts, target_uuid, target_number=None):
+    return json.dumps({"account": "+15559095", "envelope": {
+        "source": "+15559095", "sourceUuid": "95959595-9595-4959-8959-959595959595",
+        "sourceNumber": "+15559095", "timestamp": target_ts + 11,
+        "syncMessage": {"sentMessage": {
+            "message": None, "timestamp": target_ts + 11,
+            "reaction": {"emoji": "🎯", "isRemove": False,
+                         "targetAuthorUuid": target_uuid,
+                         "targetAuthor": target_number,
+                         "targetSentTimestamp": target_ts}}}}})
+
+
+def test_an_unidentifiable_sync_reaction_is_SKIPPED_not_a_reconnect_loop(db):
+    """The wedge: one bad frame must not take the connection off the air."""
+    bad = _sync_reaction_frame(target_ts=1723800000010, target_uuid=None)
+    c = _consumer(db, Streams([bad]))
+    c.run(max_connections=1)
+
+    # Counted as malformed -- skipped, never fatal, exactly as the module promises.
+    assert c.stats[consumer.STAT_MALFORMED] == 1
+    # 🔴 The discriminating assertion: a reconnect here means the frame WEDGED the
+    # stream. Malformed and reconnect are the two mechanisms an empty table cannot
+    # tell apart, so the count is what identifies which one happened.
+    assert c.stats[consumer.STAT_RECONNECTS] == 0
+    assert db.conn.count("reactions") == 0
+    assert db.conn.count("messages") == 0
+
+
+def test_a_frame_AFTER_an_unidentifiable_reaction_still_gets_stored(db):
+    """The real cost of the wedge was every LATER frame on that connection."""
+    bad = _sync_reaction_frame(target_ts=1723800000020, target_uuid=None)
+    good = _sync_reaction_frame(target_ts=1723800000030, target_uuid=ALICE)
+    c = _consumer(db, Streams([bad, good]))
+    c.run(max_connections=1)
+
+    assert c.stats[consumer.STAT_MALFORMED] == 1
+    assert c.stats[consumer.STAT_RECONNECTS] == 0
+    assert db.conn.count("reactions") == 1     # the good frame survived the bad one
+
+
+def test_POSITIVE_CONTROL_a_well_formed_sync_reaction_does_store(db):
+    """Proves the two tests above can observe a stored reaction at all.
+
+    Without this, `reactions == 0` is indistinguishable from a harness wired to
+    nothing — the assertion would hold with the whole path deleted.
+    """
+    good = _sync_reaction_frame(target_ts=1723800000040, target_uuid=ALICE)
+    c = _consumer(db, Streams([good]))
+    c.run(max_connections=1)
+
+    assert c.stats[consumer.STAT_MALFORMED] == 0
+    assert c.stats[consumer.STAT_RECONNECTS] == 0
+    assert db.conn.count("reactions") == 1

--- a/scripts/signal/tests/test_reactions.py
+++ b/scripts/signal/tests/test_reactions.py
@@ -291,8 +291,32 @@ def test_reactions_unique_constraint_is_live(db):
 # same message, so a count of reactions carrying that target timestamp said "2,
 # fine". Zach's own contact was absent from every one of them. Hence the reactor
 # identity assertion below: a count assertion here would not have caught this.
+#
+# 🔴 VALUES ARE DISTINCT FROM THE CORPUS AND FROM EVERY CONSTANT NAMED BELOW. The
+# first version of this file used 🔥 — the emoji the corpus `reaction` fixture
+# ALSO uses and the emoji the assertions name — so a mutant hardcoding
+# `"emoji": "🔥"` survived all 400 tests while corrupting every stored reaction.
+# Same for SELF_UUID/SELF_NUMBER, which were byte-identical to the corpus
+# `sync_outbound` fixture. See fixtures/envelopes.json `_README`.
 
-SELF_UUID = "90909090-9090-4909-8909-909090909090"
+SELF_UUID = "95959595-9595-4959-8959-959595959595"
+SELF_NUMBER = "+15559095"
+SYNC_EMOJI = "🎯"        # distinct from the corpus 🔥 / 😂 and from REMOVE_EMOJI
+REMOVE_EMOJI = "🧊"
+
+
+def _sync_reaction_envelope(*, target_ts, emoji=SYNC_EMOJI, remove=False, **over):
+    reaction = {"emoji": emoji, "isRemove": remove,
+                "targetAuthorUuid": ALICE, "targetAuthor": "+15550101",
+                "targetSentTimestamp": target_ts}
+    reaction.update(over.pop("reaction", {}))
+    env = {"source": SELF_NUMBER, "sourceUuid": SELF_UUID,
+           "sourceNumber": SELF_NUMBER, "timestamp": target_ts + 11,
+           "syncMessage": {"sentMessage": {
+               "message": None, "timestamp": target_ts + 11,
+               "reaction": reaction}}}
+    env.update(over)
+    return env
 
 
 def test_a_reaction_made_on_ZACHS_OWN_PHONE_is_stored_not_dropped(db):
@@ -301,20 +325,7 @@ def test_a_reaction_made_on_ZACHS_OWN_PHONE_is_stored_not_dropped(db):
     db.upsert_message(_message(uuid=ALICE, ts=target_ts))
     assert db.conn.count("messages") == 1
 
-    event = consumer.parse_envelope({
-        "source": "+15559090", "sourceUuid": SELF_UUID,
-        "sourceNumber": "+15559090", "timestamp": target_ts + 11,
-        "syncMessage": {"sentMessage": {
-            "message": None, "timestamp": target_ts + 11,
-            "destination": None, "destinationUuid": None,
-            "groupInfo": {"type": "DELIVER", "groupId": "Zm9vZ3JvdXA=",
-                          "revision": 3, "groupName": "a group"},
-            "reaction": {"emoji": "🔥", "isRemove": False,
-                         "targetAuthor": "+15550101",
-                         "targetAuthorUuid": ALICE,
-                         "targetAuthorNumber": None,
-                         "targetSentTimestamp": target_ts}}},
-    })
+    event = consumer.parse_envelope(_sync_reaction_envelope(target_ts=target_ts))
 
     # It is a REACTION, and it carries NO message -- so no ghost row can be written.
     assert event.kind == consumer.KIND_REACTION
@@ -324,9 +335,11 @@ def test_a_reaction_made_on_ZACHS_OWN_PHONE_is_stored_not_dropped(db):
     # This is the assertion the live data needed: other people's reactions on the
     # same target were present, so only the identity distinguishes stored from lost.
     assert event.reaction["source_uuid"] == SELF_UUID
+    assert event.reaction["source_number"] == SELF_NUMBER
     assert event.reaction["target_author_uuid"] == ALICE
+    assert event.reaction["target_author_number"] == "+15550101"
     assert event.reaction["target_sent_timestamp"] == target_ts
-    assert event.reaction["emoji"] == "🔥"
+    assert event.reaction["emoji"] == SYNC_EMOJI
     assert event.reaction["is_remove"] is False
 
     db.upsert_reaction(event.reaction)
@@ -336,43 +349,175 @@ def test_a_reaction_made_on_ZACHS_OWN_PHONE_is_stored_not_dropped(db):
     rows = db.conn.rows("SELECT message_id, emoji FROM signal.reactions")
     assert len(rows) == 1
     assert rows[0]["message_id"] is not None
-    assert rows[0]["emoji"] == "🔥"
+    assert rows[0]["emoji"] == SYNC_EMOJI
     assert db.unresolved_reactions() == []
 
 
 def test_an_own_phone_reaction_REMOVAL_is_stored_as_a_removal(db):
     """`isRemove` must survive the sync path, or un-reacting is invisible."""
-    target_ts = 1723260000088
-    db.upsert_message(_message(uuid=ALICE, ts=target_ts))
-    event = consumer.parse_envelope({
-        "sourceUuid": SELF_UUID, "sourceNumber": "+15559090",
-        "timestamp": target_ts + 12,
-        "syncMessage": {"sentMessage": {
-            "message": None, "timestamp": target_ts + 12,
-            "reaction": {"emoji": "🔥", "isRemove": True,
-                         "targetAuthorUuid": ALICE,
-                         "targetSentTimestamp": target_ts}}},
-    })
+    event = consumer.parse_envelope(_sync_reaction_envelope(
+        target_ts=1723260000088, emoji=REMOVE_EMOJI, remove=True))
     assert event.kind == consumer.KIND_REACTION
     assert event.message is None
+    assert event.reaction["emoji"] == REMOVE_EMOJI
     assert event.reaction["is_remove"] is True
 
 
-def test_a_sync_reaction_without_a_target_is_malformed():
-    """Mirrors the inbound guard: a targetless reaction must not be stored."""
+def test_a_TRUTHY_non_bool_isRemove_is_coerced_to_a_real_bool():
+    """`bool()` is load-bearing: the DB column is boolean, JSON is not typed."""
+    event = consumer.parse_envelope(_sync_reaction_envelope(
+        target_ts=1723260000089, reaction={"isRemove": "yes"}))
+    assert event.reaction["is_remove"] is True
+
+
+def test_an_own_phone_reaction_identified_only_by_targetAuthorNumber_is_kept():
+    """signal-cli exposes THREE identity fields; the first cut read only two.
+
+    A reaction carrying only `targetAuthorNumber` looked unidentifiable and would
+    have been rejected by the guard below — silently losing a real reaction.
+    """
+    event = consumer.parse_envelope(_sync_reaction_envelope(
+        target_ts=1723260000090,
+        reaction={"targetAuthorUuid": None, "targetAuthor": None,
+                  "targetAuthorNumber": "+15550102"}))
+    assert event.kind == consumer.KIND_REACTION
+    assert event.reaction["target_author_number"] == "+15550102"
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 The guards below are NOT about tidiness. `upsert_reaction` resolves BOTH the
+# target author and the reactor through `upsert_contact`, which raises ValueError
+# on an unidentifiable contact — and ValueError is neither MalformedEvent nor a
+# TRANSIENT_DB_ERROR, so it escapes store(), escapes handle_payload() (which
+# wraps only the PARSE) and lands in run()'s reconnect handler. Signal redelivers
+# on reconnect, so one such frame is an UNBOUNDED loop that stores nothing and
+# takes every later frame on that connection with it. See the seam test in
+# test_consumer_resilience.py, which drives that end-to-end.
+
+def test_a_sync_reaction_without_a_target_timestamp_is_malformed():
+    with pytest.raises(consumer.MalformedEvent):
+        consumer.parse_envelope(_sync_reaction_envelope(
+            target_ts=1723260000091, reaction={"targetSentTimestamp": None}))
+
+
+def test_a_sync_reaction_with_NO_TARGET_AUTHOR_IDENTITY_is_malformed():
+    """Neither uuid nor number -> upsert_contact would raise and wedge ingest."""
+    with pytest.raises(consumer.MalformedEvent):
+        consumer.parse_envelope(_sync_reaction_envelope(
+            target_ts=1723260000092,
+            reaction={"targetAuthorUuid": None, "targetAuthor": None,
+                      "targetAuthorNumber": None}))
+
+
+def test_a_sync_reaction_with_NO_REACTOR_IDENTITY_is_malformed():
+    """The reactor goes through upsert_contact too — same wedge, other side."""
+    env = _sync_reaction_envelope(target_ts=1723260000093)
+    env["sourceUuid"] = None
+    env["sourceNumber"] = None
+    env["source"] = None
+    with pytest.raises(consumer.MalformedEvent):
+        consumer.parse_envelope(env)
+
+
+def test_an_EMPTY_sync_reaction_object_is_malformed_not_silently_a_message():
+    """Pins `is not None` over truthiness — the two differ ONLY here.
+
+    With truthiness an empty `reaction: {}` is falsy, falls through, and is stored
+    as an ordinary `sync_outbound`; a malformed frame would then be invisible,
+    counted as a successful message. `is not None` reports it. Same reasoning the
+    remoteDelete branch above documents, and nothing else in the suite
+    distinguishes the two idioms — a mutant swapping them survived a green run.
+
+    The trade is deliberate: a hypothetical envelope carrying BOTH an empty
+    reaction and a real body loses the body. Signal does not emit that shape, and
+    a silently-swallowed malformed frame is the worse failure of the two.
+    """
     with pytest.raises(consumer.MalformedEvent):
         consumer.parse_envelope({
-            "sourceUuid": SELF_UUID, "timestamp": 1,
+            "sourceUuid": SELF_UUID, "sourceNumber": SELF_NUMBER, "timestamp": 1,
             "syncMessage": {"sentMessage": {
-                "message": None, "timestamp": 1,
-                "reaction": {"emoji": "🔥", "targetAuthorUuid": ALICE}}}})
+                "message": None, "timestamp": 1, "reaction": {}}}})
+
+
+def test_a_NON_DICT_sync_reaction_is_malformed_not_an_AttributeError():
+    """A non-object `reaction` took the same escape route as the identity hole."""
+    with pytest.raises(consumer.MalformedEvent):
+        consumer.parse_envelope({
+            "sourceUuid": SELF_UUID, "sourceNumber": SELF_NUMBER, "timestamp": 1,
+            "syncMessage": {"sentMessage": {
+                "message": None, "timestamp": 1, "reaction": "not-an-object"}}})
+
+
+def test_the_INBOUND_reaction_path_has_the_same_guards(db):
+    """One parser, both sites (🔴 consolidation).
+
+    The sync site shipped missing guards the inbound site had, because the dict
+    was open-coded twice. These pin that the shared helper protects BOTH — if the
+    inbound site is ever re-open-coded, this goes red.
+    """
+    for bad in (
+        {"targetAuthorUuid": None, "targetAuthor": None, "targetAuthorNumber": None},
+        {"targetSentTimestamp": None},
+    ):
+        reaction = {"emoji": SYNC_EMOJI, "targetAuthorUuid": ALICE,
+                    "targetAuthor": "+15550101",
+                    "targetSentTimestamp": 1723260000094}
+        reaction.update(bad)
+        with pytest.raises(consumer.MalformedEvent):
+            consumer.parse_envelope({
+                "sourceUuid": CARL, "sourceNumber": "+15550303",
+                "timestamp": 1723260000095,
+                "dataMessage": {"timestamp": 1723260000095, "reaction": reaction}})
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 FALLBACK ORDER. Both `or` chains below survived a fully green 416-test run
+# when their operands were SWAPPED, because every fixture set the two fields to
+# the SAME value — so the mutant could not change the output. Operand-order is a
+# mutation class that deletes nothing, and a fixture of equal values collapses
+# both implementations into identical results. These use pairwise-DISTINCT values
+# so the order is actually observable.
+
+def test_sourceNumber_WINS_over_source_for_the_reactor_phone_number():
+    """`source` is not always a phone number — newer signal-cli can put a UUID
+    there — so taking it first would write a UUID into a phone column."""
+    event = consumer.parse_envelope({
+        "source": "+15559096",            # deliberately DIFFERENT from sourceNumber
+        "sourceNumber": "+15559095",
+        "sourceUuid": SELF_UUID, "timestamp": 1723260000101,
+        "syncMessage": {"sentMessage": {
+            "message": None, "timestamp": 1723260000101,
+            "reaction": {"emoji": SYNC_EMOJI, "isRemove": False,
+                         "targetAuthorUuid": ALICE, "targetAuthor": "+15550101",
+                         "targetSentTimestamp": 1723260000100}}}})
+    assert event.reaction["source_number"] == "+15559095"
+
+
+def test_targetAuthor_WINS_over_targetAuthorNumber_for_the_target_phone_number():
+    """Pins which identity field is primary when signal-cli sends both."""
+    event = consumer.parse_envelope({
+        "sourceUuid": SELF_UUID, "sourceNumber": SELF_NUMBER,
+        "timestamp": 1723260000103,
+        "syncMessage": {"sentMessage": {
+            "message": None, "timestamp": 1723260000103,
+            "reaction": {"emoji": SYNC_EMOJI, "isRemove": False,
+                         "targetAuthorUuid": ALICE,
+                         "targetAuthor": "+15550101",
+                         "targetAuthorNumber": "+15550109",   # DISTINCT
+                         "targetSentTimestamp": 1723260000102}}}})
+    assert event.reaction["target_author_number"] == "+15550101"
 
 
 def test_an_ordinary_sync_message_is_STILL_an_outbound_message(db):
-    """Guard the narrowing: only reaction-bearing syncs change branch."""
+    """Guard the narrowing: only reaction-bearing syncs change branch.
+
+    ⚠ An INVARIANT guard, not regression coverage — it passes on the pre-fix code
+    too. It is here to catch the reaction branch growing too greedy, which is a
+    different failure from the one this file's other tests pin.
+    """
     ts = 1723260000099
     event = consumer.parse_envelope({
-        "sourceUuid": SELF_UUID, "sourceNumber": "+15559090", "timestamp": ts,
+        "sourceUuid": SELF_UUID, "sourceNumber": SELF_NUMBER, "timestamp": ts,
         "syncMessage": {"sentMessage": {
             "message": "an ordinary outbound message", "timestamp": ts,
             "destination": "+15550101", "destinationUuid": ALICE}},

--- a/scripts/signal/tests/test_reactions.py
+++ b/scripts/signal/tests/test_reactions.py
@@ -275,3 +275,108 @@ def test_reactions_unique_constraint_is_live(db):
             "INSERT INTO signal.reactions (target_author_id, target_sent_timestamp, "
             "emoji, contact_id) VALUES (?, ?, '🎉', ?)",
             (author, TARGET_TS, reactor))
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 The own-device REACTION direction — the sibling the remote-delete fix missed.
+#
+# Found by step 7, from LIVE traffic: a reaction Zach sent from his phone arrived
+# as `syncMessage.sentMessage.reaction` with `message: None`. The sync branch runs
+# BEFORE the inbound `dataMessage` branch and handled only `remoteDelete`, so the
+# reaction fell through to `_base_message()` and produced exactly the two defects
+# the remote-delete branch exists to prevent: the reaction was DROPPED from
+# signal.reactions, and a bodyless ghost row was left in signal.messages.
+#
+# The live miss nearly read as clean — two OTHER group members had reacted to the
+# same message, so a count of reactions carrying that target timestamp said "2,
+# fine". Zach's own contact was absent from every one of them. Hence the reactor
+# identity assertion below: a count assertion here would not have caught this.
+
+SELF_UUID = "90909090-9090-4909-8909-909090909090"
+
+
+def test_a_reaction_made_on_ZACHS_OWN_PHONE_is_stored_not_dropped(db):
+    """Regression: outbound reaction -> a reactions row, NOT a ghost message."""
+    target_ts = 1723260000077
+    db.upsert_message(_message(uuid=ALICE, ts=target_ts))
+    assert db.conn.count("messages") == 1
+
+    event = consumer.parse_envelope({
+        "source": "+15559090", "sourceUuid": SELF_UUID,
+        "sourceNumber": "+15559090", "timestamp": target_ts + 11,
+        "syncMessage": {"sentMessage": {
+            "message": None, "timestamp": target_ts + 11,
+            "destination": None, "destinationUuid": None,
+            "groupInfo": {"type": "DELIVER", "groupId": "Zm9vZ3JvdXA=",
+                          "revision": 3, "groupName": "a group"},
+            "reaction": {"emoji": "🔥", "isRemove": False,
+                         "targetAuthor": "+15550101",
+                         "targetAuthorUuid": ALICE,
+                         "targetAuthorNumber": None,
+                         "targetSentTimestamp": target_ts}}},
+    })
+
+    # It is a REACTION, and it carries NO message -- so no ghost row can be written.
+    assert event.kind == consumer.KIND_REACTION
+    assert event.message is None
+
+    # The reactor is the ACCOUNT ITSELF, not the author of the reacted-to message.
+    # This is the assertion the live data needed: other people's reactions on the
+    # same target were present, so only the identity distinguishes stored from lost.
+    assert event.reaction["source_uuid"] == SELF_UUID
+    assert event.reaction["target_author_uuid"] == ALICE
+    assert event.reaction["target_sent_timestamp"] == target_ts
+    assert event.reaction["emoji"] == "🔥"
+    assert event.reaction["is_remove"] is False
+
+    db.upsert_reaction(event.reaction)
+
+    # Stored, resolved to its target, and still exactly one message row.
+    assert db.conn.count("messages") == 1
+    rows = db.conn.rows("SELECT message_id, emoji FROM signal.reactions")
+    assert len(rows) == 1
+    assert rows[0]["message_id"] is not None
+    assert rows[0]["emoji"] == "🔥"
+    assert db.unresolved_reactions() == []
+
+
+def test_an_own_phone_reaction_REMOVAL_is_stored_as_a_removal(db):
+    """`isRemove` must survive the sync path, or un-reacting is invisible."""
+    target_ts = 1723260000088
+    db.upsert_message(_message(uuid=ALICE, ts=target_ts))
+    event = consumer.parse_envelope({
+        "sourceUuid": SELF_UUID, "sourceNumber": "+15559090",
+        "timestamp": target_ts + 12,
+        "syncMessage": {"sentMessage": {
+            "message": None, "timestamp": target_ts + 12,
+            "reaction": {"emoji": "🔥", "isRemove": True,
+                         "targetAuthorUuid": ALICE,
+                         "targetSentTimestamp": target_ts}}},
+    })
+    assert event.kind == consumer.KIND_REACTION
+    assert event.message is None
+    assert event.reaction["is_remove"] is True
+
+
+def test_a_sync_reaction_without_a_target_is_malformed():
+    """Mirrors the inbound guard: a targetless reaction must not be stored."""
+    with pytest.raises(consumer.MalformedEvent):
+        consumer.parse_envelope({
+            "sourceUuid": SELF_UUID, "timestamp": 1,
+            "syncMessage": {"sentMessage": {
+                "message": None, "timestamp": 1,
+                "reaction": {"emoji": "🔥", "targetAuthorUuid": ALICE}}}})
+
+
+def test_an_ordinary_sync_message_is_STILL_an_outbound_message(db):
+    """Guard the narrowing: only reaction-bearing syncs change branch."""
+    ts = 1723260000099
+    event = consumer.parse_envelope({
+        "sourceUuid": SELF_UUID, "sourceNumber": "+15559090", "timestamp": ts,
+        "syncMessage": {"sentMessage": {
+            "message": "an ordinary outbound message", "timestamp": ts,
+            "destination": "+15550101", "destinationUuid": ALICE}},
+    })
+    assert event.kind == consumer.KIND_SYNC_OUTBOUND
+    assert event.message is not None
+    assert event.message["is_outbound"] is True

--- a/scripts/signal/tests/test_reactions.py
+++ b/scripts/signal/tests/test_reactions.py
@@ -402,7 +402,10 @@ def test_a_sync_reaction_without_a_target_timestamp_is_malformed():
 
 def test_a_sync_reaction_with_NO_TARGET_AUTHOR_IDENTITY_is_malformed():
     """Neither uuid nor number -> upsert_contact would raise and wedge ingest."""
-    with pytest.raises(consumer.MalformedEvent):
+    # `match=` pins the site label: it is the ONLY forensic trail a skipped
+    # frame leaves, and it exists solely to say WHICH site rejected. A mutant
+    # swapping it to "inbound" survived an otherwise-green run.
+    with pytest.raises(consumer.MalformedEvent, match=r"^sync "):
         consumer.parse_envelope(_sync_reaction_envelope(
             target_ts=1723260000092,
             reaction={"targetAuthorUuid": None, "targetAuthor": None,
@@ -506,6 +509,41 @@ def test_targetAuthor_WINS_over_targetAuthorNumber_for_the_target_phone_number()
                          "targetAuthorNumber": "+15550109",   # DISTINCT
                          "targetSentTimestamp": 1723260000102}}}})
     assert event.reaction["target_author_number"] == "+15550101"
+
+
+def test_a_reactor_identified_ONLY_by_the_legacy_source_field_is_kept():
+    """The `or envelope.get("source")` fallback is now REJECT/ACCEPT logic.
+
+    Before the identity guard it merely nulled a stored column; now, dropping it
+    makes this envelope malformed and the reaction is lost. A mutant removing it
+    survived, because the other reactor test sets BOTH fields and so cannot see
+    which one carried the value.
+    """
+    event = consumer.parse_envelope({
+        "source": "+15559097",            # legacy field ONLY -- no sourceNumber
+        "sourceUuid": None, "timestamp": 1723260000105,
+        "syncMessage": {"sentMessage": {
+            "message": None, "timestamp": 1723260000105,
+            "reaction": {"emoji": SYNC_EMOJI, "isRemove": False,
+                         "targetAuthorUuid": ALICE, "targetAuthor": "+15550101",
+                         "targetSentTimestamp": 1723260000104}}}})
+    assert event.kind == consumer.KIND_REACTION
+    assert event.reaction["source_number"] == "+15559097"
+
+
+def test_an_EMPTY_INBOUND_reaction_object_is_malformed_too(db):
+    """One rule, BOTH sites — the dispatch predicate, not just the parser body.
+
+    Consolidating only `_reaction_from()` left inbound on truthiness, so an empty
+    `reaction: {}` was stored there as an ordinary message while the identical
+    sync shape was reported malformed. The argument for `is not None` does not
+    stop at the site that happened to get audited.
+    """
+    with pytest.raises(consumer.MalformedEvent, match=r"^inbound "):
+        consumer.parse_envelope({
+            "sourceUuid": CARL, "sourceNumber": "+15550303",
+            "timestamp": 1723260000107,
+            "dataMessage": {"timestamp": 1723260000107, "reaction": {}}})
 
 
 def test_an_ordinary_sync_message_is_STILL_an_outbound_message(db):


### PR DESCRIPTION
## What

A reaction Zach makes on his **own phone** arrives as `syncMessage.sentMessage.reaction` with `message: None`. The sync branch in `consumer.py` runs **before** the inbound `dataMessage` branch and handled only `remoteDelete`, so the reaction fell through to `_base_message()` and produced **exactly the two defects the remote-delete case exists to prevent**:

- the reaction dropped from `signal.reactions`
- a bodyless ghost row left in `signal.messages`

This adds the `reaction` case to the sync branch, mirroring the `remoteDelete` one.

## How it was found

**Step 7** — sending real messages from the phone. Not by review: six PRs, four audit rounds and 387 tests passed over it. The sync branch had *already* been patched once for this exact asymmetry (`remoteDelete`), and the sibling shape was still missed.

> When you fix an own-device branch for one message shape, enumerate the others in that wrapper.

## 🔴 Why it nearly read as clean

Two **other** group members had reacted to the same message, so `signal.reactions` held **2 rows carrying that exact `target_sent_timestamp`** — a count check says "fine". The account's own contact appears in **none** of them.

Only the reactor **identity** discriminates stored from lost here. The regression test asserts identity for that reason, and the mutation battery confirms a count assertion would not have caught it.

## Verification

| | |
|---|---|
| red at `origin/main` | 3 failed — `sync_outbound` where `reaction` belongs |
| green at HEAD | 400 passed (`scripts/signal/tests`) |
| hermetic gate | `RESULT: PASS (exit=0)` — 11,689 collected, 0 failed |

Five-mutant battery, **all KILLED**, run under `PYTHONDONTWRITEBYTECODE=1` so a same-length edit cannot score a false SURVIVED off a stale `.pyc`:

| mutant | result |
|---|---|
| M1 reactor identity → target author | KILLED — dies on its own assertion |
| M2 `is_remove` hardcoded False | KILLED |
| M3 drop the `targetSentTimestamp` guard | KILLED |
| M4 `is not None` → never taken | KILLED |
| M5 whole case removed (positive control) | KILLED |

Tree checksummed byte-identical before/after the battery.

## 🔴 Merging this does not fix the cluster

The consumer runs a Harbor image **pinned by digest**, so this needs `scripts/signal/build-push.sh <ver>` plus a homelab digest bump. Until that lands, every reaction sent from the phone is still being dropped.

The one already lost **is recoverable** — `raw_envelope` on `signal.messages` id 3 still holds it.

## Not covered here

The attachment/MinIO leg has still never carried real traffic (`attachments` = 0). That zero is attributable to input — no stored envelope contains an attachment key — not to a defect. Sending an image is the outstanding check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)