### PR TITLE
feat(signal): give the consumer a liveness signal — it had none, and that is why step 7 took hours

### DIFF
--- a/claude/skills/signal/SKILL.md
+++ b/claude/skills/signal/SKILL.md
@@ -175,6 +175,21 @@ kubectl -n signal exec deploy/signal-consumer -- python3 /app/scripts/signal/con
   the counters. Richer, and it is ALLOWED to fail — a DB outage degrades the row
   and leaves liveness intact.
 
+🔴 **NO MIGRATION EXISTS for `signal.consumer_health`, and `ensure_schema()`
+will not tell you.** It uses `CREATE TABLE IF NOT EXISTS`, which is silent about
+a table that already exists with the WRONG column types. A pre-release build
+declared `updated_at`/`last_frame_at` as `TIMESTAMPTZ`; the shipped code writes
+`BIGINT` epoch-ms. Against a database that ever ran that build, `ensure_schema()`
+reports success, **every beat then fails forever** with `column … is of type
+timestamp with time zone but expression is of type bigint`, and `health
+--from-db` reports no heartbeat while the FILE probe stays green — so nothing
+restarts and nothing alerts. Measured on real Postgres, not reasoned.
+**The live homelab database is NOT affected** — verified: the table did not
+exist there, so it is born `BIGINT`. If you hit this anywhere else (a dev box, a
+rolled-back image), the fix is `DROP TABLE signal.consumer_health;` and let the
+next beat recreate it — the table is a single disposable status row, so there is
+nothing to preserve.
+
 🔴 **DEPLOY PAIRING — the pod needs a WRITABLE heartbeat path or it will not
 start.** `consumer.py run` beats once synchronously before entering the loop, and
 an unwritable path is a configuration fault (loud, at startup) rather than

--- a/claude/skills/signal/SKILL.md
+++ b/claude/skills/signal/SKILL.md
@@ -34,7 +34,7 @@ code route and will raise `SendGateError`.
 | Routes | the three this module speaks (the server has many more): `GET /v1/receive/{number}` (a **websocket** in json-rpc mode), `GET /v1/attachments/{id}`, `POST /v2/send`. It has **no event-stream endpoint** — `/api/v1/events` belongs to AsamK's native daemon, a different server |
 | Postgres | `mailbox-postgres-0` in ns `mailbox`, schema **`signal`** (shares the instance + role with `mail`) |
 | Attachments | MinIO archive tenant, bucket `signal-attachments`, key `{conversation}/{YYYY-MM-DD}/{attachment_id}_{filename}` + a `.json` sidecar. The id is in the key deliberately — see gotchas |
-| Tables | `signal.contacts`, `signal.groups`, `signal.messages`, `signal.attachments`, `signal.reactions` |
+| Tables | `signal.contacts`, `signal.groups`, `signal.messages`, `signal.attachments`, `signal.reactions`, `signal.consumer_health` |
 | Search | `signal.messages.search` — a STORED `to_tsvector('english', body)` generated column with a GIN index |
 
 ## Commands (`python3 scripts/signal/consumer.py <cmd>`)
@@ -42,6 +42,7 @@ code route and will raise `SendGateError`.
 | Command | What it does |
 |---|---|
 | `run` | consume `/v1/receive/{number}` forever — this is what the Deployment runs |
+| `health` | is the consumer alive? exit 0 healthy / 1 stale. Reads the local heartbeat FILE; `--from-db` reads the richer row instead (**not** for a probe — it depends on Postgres) |
 | `conversations` | list conversations (group, else the DM peer), newest first |
 | `search` | full-text search over message bodies (`websearch_to_tsquery`) |
 | `draft` | compose an outbound draft — **stores it, transmits nothing** |
@@ -152,6 +153,37 @@ are counted only.
 | `db_recovery_failures` | recovery itself failed — the pod cannot write and needs looking at |
 | `attachment_failures` | attachment fetch/upload failures — the MESSAGE row still stands |
 
+## Liveness — how to tell working from dead
+
+🔴 **Before this existed there was no such signal.** The consumer serves no HTTP,
+had no probes, and emitted **0 log lines** across 20h of successful ingestion —
+so a pod reaching nothing and a pod working perfectly were byte-identical from
+outside, and the row count was the only evidence available. That is what made the
+step-7 diagnosis take hours.
+
+```bash
+kubectl -n signal exec deploy/signal-consumer -- python3 /app/scripts/signal/consumer.py health
+kubectl -n signal exec deploy/signal-consumer -- python3 /app/scripts/signal/consumer.py health --from-db --json
+```
+
+🔴 **Two sinks, and they answer different questions — do not swap them.**
+- the **file** says "this process's thread is still scheduled". It depends on
+  nothing external, which is why it is the only safe input to a k8s liveness
+  probe. Keying a restart on Postgres reachability would turn a database blip
+  into a restart storm against a consumer that was working fine.
+- the **row** (`signal.consumer_health`) adds "…and Postgres is reachable", plus
+  the counters. Richer, and it is ALLOWED to fail — a DB outage degrades the row
+  and leaves liveness intact.
+
+🔴 **`last_frame_at` is diagnosis, NEVER a liveness input.** An idle account
+legitimately sends nothing for hours; if silence fed the probe, a quiet weekend
+would restart the pod on a loop.
+
+⚠ **The probe restarts only a HUNG process** (stale heartbeat). It deliberately
+does not restart on a reconnect storm: that is visible in `reconnects` on the
+row, but automating a restart for it risks looping against an outage a restart
+cannot fix. Read the row when the numbers look wrong.
+
 ## Environment
 
 | Var | Purpose |
@@ -164,6 +196,9 @@ are counted only.
 | `SIGNAL_ACCOUNT` | the account's own phone number. Required TWICE: the receive endpoint is per-account (`/v1/receive/{number}`) and `/v2/send` rejects a missing `number` with 400 |
 | `SIGNAL_APPROVAL_TOKEN` | must be set for `approve` to run. **Operator-only** — deliberately absent from the Deployment and from agent environments |
 | `CLAWGATE_HOOK_TOKEN` | clawgate hook token; unset → draft cards are a graceful no-op |
+| `SIGNAL_HEARTBEAT_PATH` | where the consumer writes its liveness file (default `/tmp/signal-consumer-heartbeat.json`). The k8s probe reads THIS, never Postgres |
+| `SIGNAL_HEARTBEAT_INTERVAL` | seconds between heartbeats (default 30) |
+| `SIGNAL_HEARTBEAT_MAX_AGE` | seconds before a heartbeat is stale (default 4× the interval — less than a few ticks flaps on scheduling jitter) |
 | `MINIO_ARCHIVE_ENDPOINT` | explicit MinIO endpoint (skips the port-forward) |
 | `MINIO_ARCHIVE_ACCESS_KEY` | MinIO credentials; else read from `minio-archive-config` |
 | `MINIO_ARCHIVE_SECRET_KEY` | MinIO credentials; else read from `minio-archive-config` |

--- a/claude/skills/signal/SKILL.md
+++ b/claude/skills/signal/SKILL.md
@@ -175,6 +175,17 @@ kubectl -n signal exec deploy/signal-consumer -- python3 /app/scripts/signal/con
   the counters. Richer, and it is ALLOWED to fail — a DB outage degrades the row
   and leaves liveness intact.
 
+🔴 **DEPLOY PAIRING — the pod needs a WRITABLE heartbeat path or it will not
+start.** `consumer.py run` beats once synchronously before entering the loop, and
+an unwritable path is a configuration fault (loud, at startup) rather than
+something laundered into a retry. The Deployment sets `readOnlyRootFilesystem:
+true` and originally mounted **no volumes at all** — its own comment recorded
+that the pod "writes nothing to the filesystem, which is what makes
+readOnlyRootFilesystem viable". That invariant is now false. The manifest must
+mount an `emptyDir` and point `SIGNAL_HEARTBEAT_PATH` at it **in the same
+rollout as the image that introduces the heartbeat**, or the first rebuild
+CrashLoopBackOffs a working consumer — before any probe is even wired.
+
 🔴 **`last_frame_at` is diagnosis, NEVER a liveness input.** An idle account
 legitimately sends nothing for hours; if silence fed the probe, a quiet weekend
 would restart the pod on a loop.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -872,12 +872,23 @@ TARGET_FLOORS=(
   # 376/358 (the commit-retry drop, the websocket import site, the atomic claim,
   # the reconcile path, the own-device retraction), and 387/368 (guarded state
   # transitions, the preserved approval record, the clean CLI refusal).
+  # 2026-08-18, two more, both RE-READ from the gate: 400/368 stayed under the
+  # ceiling (the outbound-reaction fix, #537), then 467 tripped the DRIFT
+  # CEILING at 460 with every test PASSING — the floor had fallen 92 behind, so
+  # a whole suite could have vanished while the gate stayed green. The gate
+  # printed "scripts/signal/tests|444" and that is what is written below,
+  # copied not computed. The 67 new tests are the liveness heartbeat and the
+  # three deploy-blocking defects its audit found: a TIMESTAMPTZ column fed a
+  # Python float (the DB layer had no executing test at all — a FakeDB appended
+  # to a list), a STALLED Postgres freezing the liveness file because both
+  # sinks shared a thread, and a probe that read the database it was supposed
+  # to be independent of.
   # ZERO new skips, so EXPECTED_SKIPS is untouched, and GUARD 7 reported
   # `intercepted=0 systemctl-reads=0` for this target — the evidence the suite is
   # hermetic rather than merely asserted to be. If this line conflicts with a
   # sibling branch, re-run the gate on the MERGED tree and copy what it prints;
   # do not reconcile the two sides by hand.
-  "scripts/signal/tests|368"
+  "scripts/signal/tests|444"
   "scripts/initiatives/tests|745"
   "scripts/repo-cos/tests|315"
   "scripts/task-spec-drafter/tests|135"

--- a/scripts/signal/_signal_db.py
+++ b/scripts/signal/_signal_db.py
@@ -183,6 +183,36 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
     )
     """,
 
+    """
+    -- 🔴 THE HEALTH ROW. This consumer serves no HTTP, has no probes, and emitted
+    -- ZERO log lines across 20h of successful ingestion — so "reaching nothing"
+    -- and "working perfectly" produced byte-identical observations, and row count
+    -- was the only health signal in existence. That is what made the step-7
+    -- diagnosis take hours: no upstream signal disagreed between the rival
+    -- explanations, so an empty table could not identify which was true.
+    --
+    -- ONE ROW, upserted on a timer (id is pinned to 1 by the primary key + the
+    -- upsert's ON CONFLICT). It is deliberately NOT a history table: the question
+    -- is "is it alive NOW", and an append-only log of heartbeats would need its
+    -- own retention story to answer it.
+    CREATE TABLE IF NOT EXISTS signal.consumer_health (
+        id SMALLINT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+        updated_at TIMESTAMPTZ NOT NULL,
+        pod TEXT,
+        stream_connected BOOLEAN NOT NULL,
+        -- 🔴 NOT a liveness input. An idle Signal account legitimately sends
+        -- nothing for hours, so "no frame recently" is NORMAL and must never
+        -- restart anything. It is here because it is the first thing a human
+        -- wants when diagnosing, and conflating it with liveness is precisely
+        -- the mistake that would make a probe flap on a quiet weekend.
+        last_frame_at TIMESTAMPTZ,
+        connections BIGINT NOT NULL DEFAULT 0,
+        reconnects BIGINT NOT NULL DEFAULT 0,
+        stored BIGINT NOT NULL DEFAULT 0,
+        malformed BIGINT NOT NULL DEFAULT 0
+    )
+    """,
+
     "CREATE INDEX IF NOT EXISTS idx_msg_ts ON signal.messages(message_timestamp DESC)",
     "CREATE INDEX IF NOT EXISTS idx_msg_dm ON signal.messages(source_contact_id, message_timestamp)",
     "CREATE INDEX IF NOT EXISTS idx_msg_group ON signal.messages(group_id, message_timestamp) WHERE group_id IS NOT NULL",
@@ -833,6 +863,60 @@ class SignalDB:
                 "contact_id, is_remove FROM signal.reactions WHERE message_id IS NULL"
             )
             return [dict(r) for r in cur.fetchall()]
+
+    # -- health ------------------------------------------------------------
+    def record_heartbeat(self, hb: dict) -> None:
+        """Upsert THE single health row.
+
+        🔴 Call this on a connection of its OWN, never the ingest connection.
+        These connections run `autocommit=False`, so a heartbeat issued from the
+        heartbeat thread on the shared connection would land inside whatever
+        transaction the ingest thread has open — committing a half-written
+        message batch, or being rolled back with it. `consumer.Heartbeat` opens
+        its own `SignalDB` for exactly this reason.
+        """
+        with self._c.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO signal.consumer_health
+                    (id, updated_at, pod, stream_connected, last_frame_at,
+                     connections, reconnects, stored, malformed)
+                VALUES (1, now(), %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (id) DO UPDATE SET
+                    updated_at       = now(),
+                    pod              = EXCLUDED.pod,
+                    stream_connected = EXCLUDED.stream_connected,
+                    last_frame_at    = COALESCE(EXCLUDED.last_frame_at,
+                                                signal.consumer_health.last_frame_at),
+                    connections      = EXCLUDED.connections,
+                    reconnects       = EXCLUDED.reconnects,
+                    stored           = EXCLUDED.stored,
+                    malformed        = EXCLUDED.malformed
+                """,
+                (hb.get("pod"), bool(hb.get("stream_connected")),
+                 hb.get("last_frame_at"), int(hb.get("connections") or 0),
+                 int(hb.get("reconnects") or 0), int(hb.get("stored") or 0),
+                 int(hb.get("malformed") or 0)),
+            )
+
+    def read_heartbeat(self) -> dict | None:
+        """The health row, plus its age IN THE DATABASE'S OWN CLOCK.
+
+        🔴 `age_seconds` is computed by Postgres, not by the caller. A reader on a
+        host whose clock has drifted would otherwise compute a confident, wrong
+        age against a timestamp written by a different machine — and report a
+        LIVE consumer as dead, or a dead one as live.
+        """
+        with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                "SELECT pod, stream_connected, connections, reconnects, stored, "
+                "malformed, updated_at, last_frame_at, "
+                "EXTRACT(EPOCH FROM (now() - updated_at)) AS age_seconds, "
+                "EXTRACT(EPOCH FROM (now() - last_frame_at)) AS frame_age_seconds "
+                "FROM signal.consumer_health WHERE id = 1"
+            )
+            row = cur.fetchone()
+            return dict(row) if row else None
 
     # -- reads -------------------------------------------------------------
     def list_conversations(self, limit: int = 50) -> list:

--- a/scripts/signal/_signal_db.py
+++ b/scripts/signal/_signal_db.py
@@ -195,9 +195,18 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
     -- upsert's ON CONFLICT). It is deliberately NOT a history table: the question
     -- is "is it alive NOW", and an append-only log of heartbeats would need its
     -- own retention story to answer it.
+    -- 🔴 EPOCH-MS BIGINT, like message_timestamp and server_received_at, NOT
+    -- timestamptz. The first cut declared these TIMESTAMPTZ and wrote a Python
+    -- float into them, so the upsert raised `is of type timestamp with time zone
+    -- but expression is of type numeric` on EVERY beat once the first frame
+    -- arrived — the row was correct only while nothing worked, and broke the
+    -- moment it did. Nothing caught it because no test executed this SQL.
+    -- BIGINT also keeps the statement free of `now()`/`EXTRACT`, which the
+    -- sqlite substrate cannot translate; that is what makes it TESTABLE, and
+    -- untestable was the root cause, not the type.
     CREATE TABLE IF NOT EXISTS signal.consumer_health (
         id SMALLINT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
-        updated_at TIMESTAMPTZ NOT NULL,
+        updated_at BIGINT NOT NULL,
         pod TEXT,
         stream_connected BOOLEAN NOT NULL,
         -- 🔴 NOT a liveness input. An idle Signal account legitimately sends
@@ -205,7 +214,7 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
         -- restart anything. It is here because it is the first thing a human
         -- wants when diagnosing, and conflating it with liveness is precisely
         -- the mistake that would make a probe flap on a quiet weekend.
-        last_frame_at TIMESTAMPTZ,
+        last_frame_at BIGINT,
         connections BIGINT NOT NULL DEFAULT 0,
         reconnects BIGINT NOT NULL DEFAULT 0,
         stored BIGINT NOT NULL DEFAULT 0,
@@ -881,9 +890,9 @@ class SignalDB:
                 INSERT INTO signal.consumer_health
                     (id, updated_at, pod, stream_connected, last_frame_at,
                      connections, reconnects, stored, malformed)
-                VALUES (1, now(), %s, %s, %s, %s, %s, %s, %s)
+                VALUES (1, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (id) DO UPDATE SET
-                    updated_at       = now(),
+                    updated_at       = EXCLUDED.updated_at,
                     pod              = EXCLUDED.pod,
                     stream_connected = EXCLUDED.stream_connected,
                     last_frame_at    = COALESCE(EXCLUDED.last_frame_at,
@@ -893,30 +902,51 @@ class SignalDB:
                     stored           = EXCLUDED.stored,
                     malformed        = EXCLUDED.malformed
                 """,
-                (hb.get("pod"), bool(hb.get("stream_connected")),
-                 hb.get("last_frame_at"), int(hb.get("connections") or 0),
+                (int(hb["written_at_ms"]), hb.get("pod"),
+                 bool(hb.get("stream_connected")),
+                 None if hb.get("last_frame_at") is None else int(hb["last_frame_at"]),
+                 int(hb.get("connections") or 0),
                  int(hb.get("reconnects") or 0), int(hb.get("stored") or 0),
                  int(hb.get("malformed") or 0)),
             )
 
-    def read_heartbeat(self) -> dict | None:
-        """The health row, plus its age IN THE DATABASE'S OWN CLOCK.
+    def read_heartbeat(self, now_ms: int | None = None) -> dict | None:
+        """The health row, with `age_seconds` derived from `now_ms`.
 
-        🔴 `age_seconds` is computed by Postgres, not by the caller. A reader on a
-        host whose clock has drifted would otherwise compute a confident, wrong
-        age against a timestamp written by a different machine — and report a
-        LIVE consumer as dead, or a dead one as live.
+        🔴 No `now()`/`EXTRACT` in the statement, deliberately. Those are the
+        constructs the sqlite substrate refuses, and a statement no test can
+        execute is how the TIMESTAMPTZ/float mismatch shipped. Portable SQL here
+        buys an executing test, which is worth more than computing the age
+        server-side.
+
+        The trade is stated rather than hidden: `age_seconds` is measured against
+        the READER's clock, so a reader whose clock has drifted from the writer's
+        misjudges it. That is acceptable because the load-bearing liveness path
+        never comes through here — the probe reads the FILE, written and read in
+        the same process, where no skew is possible. This path is the human /
+        deadman view.
         """
         with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
             cur.execute(
                 "SELECT pod, stream_connected, connections, reconnects, stored, "
-                "malformed, updated_at, last_frame_at, "
-                "EXTRACT(EPOCH FROM (now() - updated_at)) AS age_seconds, "
-                "EXTRACT(EPOCH FROM (now() - last_frame_at)) AS frame_age_seconds "
+                "malformed, updated_at, last_frame_at "
                 "FROM signal.consumer_health WHERE id = 1"
             )
             row = cur.fetchone()
-            return dict(row) if row else None
+            if row is None:
+                return None
+            out = dict(row)
+            # 🔴 Normalise the boolean. psycopg2 hands back a real bool, sqlite
+            # hands back 0/1, and a caller writing `is True` would then be
+            # correct against one and silently wrong against the other. The
+            # substrate exposed this — the API's type must not depend on which
+            # driver answered.
+            out["stream_connected"] = bool(out["stream_connected"])
+            now = int(time.time() * 1000) if now_ms is None else int(now_ms)
+            out["age_seconds"] = (now - int(out["updated_at"])) / 1000.0
+            lf = out.get("last_frame_at")
+            out["frame_age_seconds"] = None if lf is None else (now - int(lf)) / 1000.0
+            return out
 
     # -- reads -------------------------------------------------------------
     def list_conversations(self, limit: int = 50) -> list:

--- a/scripts/signal/consumer.py
+++ b/scripts/signal/consumer.py
@@ -35,7 +35,9 @@ import argparse
 import base64
 import json
 import os
+import socket
 import sys
+import threading
 import time
 from collections.abc import Iterator
 from dataclasses import dataclass, field
@@ -439,6 +441,175 @@ def parse_receive_frame(payload) -> dict:
     return env
 
 
+# --------------------------------------------------------------------------- #
+# Liveness — the signal this service did not have
+#
+# 🔴 WHY THIS EXISTS, measured not theorised. `signal-consumer` serves no HTTP,
+# declares no probes, and emitted **0 log lines** across 20h in which it
+# successfully ingested 5 messages, 5 contacts, a group and 2 reactions. So a pod
+# reaching NOTHING and a pod working perfectly produce byte-identical
+# observations, and the row count was the only health signal that existed. That
+# is not a gap in monitoring, it is the reason a diagnosis took hours: an empty
+# result cannot distinguish two mechanisms, and no upstream signal disagreed
+# between them.
+#
+# 🔴 THE HEARTBEAT MUST NOT LIVE IN THE FRAME LOOP. `run()` blocks in
+# `for payload in iter_frames(...)` — on an idle account that blocks for HOURS.
+# A heartbeat written per frame would therefore fire only when traffic exists,
+# i.e. only in the case that never needed a heartbeat. It runs on its own thread.
+#
+# 🔴 TWO SINKS, DELIBERATELY, AND THEY ANSWER DIFFERENT QUESTIONS.
+#   * the FILE  — "this process's thread is still scheduled". Depends on nothing
+#     external, so it is the only safe input to a k8s liveness probe: keying a
+#     restart on Postgres reachability would turn a database blip into a
+#     restart storm, taking down a consumer that was working fine.
+#   * the ROW   — "…and Postgres is reachable, and here are the counters". This
+#     is the human/deadman signal. It is richer and it is ALLOWED to fail.
+# A DB outage degrades the row and leaves the file (and therefore liveness)
+# intact. That asymmetry is the entire point of having two.
+
+#: Where the liveness file is written. Env-overridable so the probe and the
+#: consumer cannot disagree about the path by editing one of them.
+HEARTBEAT_PATH = os.environ.get("SIGNAL_HEARTBEAT_PATH", "/tmp/signal-consumer-heartbeat.json")
+
+#: How often the heartbeat thread ticks.
+HEARTBEAT_INTERVAL = float(os.environ.get("SIGNAL_HEARTBEAT_INTERVAL", "30"))
+
+#: How old a heartbeat may be and still mean "alive".
+#:
+#: 🔴 Derived from the interval, not chosen by taste: a probe that trips at less
+#: than a small multiple of the write period fires on ordinary scheduling jitter
+#: and restarts a healthy pod. Four ticks means four consecutive misses.
+HEARTBEAT_MAX_AGE = float(os.environ.get("SIGNAL_HEARTBEAT_MAX_AGE",
+                                         str(HEARTBEAT_INTERVAL * 4)))
+
+
+def heartbeat_is_fresh(age_seconds: float | None, max_age: float = None) -> bool:
+    """THE freshness predicate. One definition, every caller.
+
+    `None` (no heartbeat at all) is NOT fresh — a consumer that has never written
+    one is exactly the state this exists to catch, and defaulting a missing
+    reading to "fine" is how a dead measuring apparatus reports all-clear.
+    """
+    if age_seconds is None:
+        return False
+    return age_seconds <= (HEARTBEAT_MAX_AGE if max_age is None else max_age)
+
+
+def write_heartbeat_file(payload: dict, path: str = None) -> None:
+    """Write the liveness file ATOMICALLY (tmp + rename).
+
+    A probe reading a half-written file would parse-fail and be scored as "no
+    heartbeat" — a restart caused purely by the instrument.
+    """
+    target = Path(path or HEARTBEAT_PATH)
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload), encoding="utf-8")
+    tmp.replace(target)
+
+
+def read_heartbeat_file(path: str = None, now: float = None) -> dict | None:
+    """The heartbeat file plus its age, or None if absent/unreadable/corrupt.
+
+    Every failure collapses to None on purpose: absent, truncated and garbage all
+    mean the same thing to a probe — "no current measurement" — and a caller that
+    had to distinguish them would grow its own freshness opinion.
+    """
+    try:
+        raw = Path(path or HEARTBEAT_PATH).read_text(encoding="utf-8")
+        payload = json.loads(raw)
+        written = float(payload["written_at"])
+    except (OSError, ValueError, KeyError, TypeError):
+        return None
+    payload["age_seconds"] = (time.time() if now is None else now) - written
+    return payload
+
+
+class Heartbeat:
+    """Ticks on its OWN thread, writing the file always and the row best-effort.
+
+    🔴 It opens its OWN database connection. `SignalDB` runs `autocommit=False`,
+    so a heartbeat issued on the ingest connection would land inside whatever
+    transaction the ingest loop has open — committing a partial batch or being
+    rolled back with it. Sharing the connection is the bug, not an optimisation.
+    """
+
+    def __init__(self, consumer, *, db_factory=None, interval: float = None,
+                 path: str = None, sleep=time.sleep, clock=time.time):
+        self._consumer = consumer
+        self._db_factory = db_factory
+        self._interval = HEARTBEAT_INTERVAL if interval is None else interval
+        self._path = path or HEARTBEAT_PATH
+        self._sleep = sleep
+        self._clock = clock
+        self._stop = threading.Event()
+        self._thread = None
+        self.row_failures = 0
+        #: beats ATTEMPTED vs beats that actually wrote the file. They differ
+        #: precisely when the sink is failing, which is the one time an operator
+        #: needs to tell "the thread is wedged" from "the thread is trying and
+        #: the disk is refusing" — the same working/dead distinction this whole
+        #: module exists to make, one level down.
+        self.attempts = 0
+        self.ticks = 0
+
+    def payload(self) -> dict:
+        c = self._consumer
+        return {
+            "written_at": self._clock(),
+            "pod": socket.gethostname(),
+            "stream_connected": bool(getattr(c, "stream_connected", False)),
+            "last_frame_at": getattr(c, "last_frame_at", None),
+            "connections": int(getattr(c, "connections", 0)),
+            "reconnects": int(c.stats.get(STAT_RECONNECTS, 0)),
+            "stored": int(c.stats.get(STAT_STORED, 0)),
+            "malformed": int(c.stats.get(STAT_MALFORMED, 0)),
+        }
+
+    def tick(self) -> dict:
+        """One beat. The FILE write is the liveness contract and comes first.
+
+        🔴 The row write is wrapped and its failure counted, never raised: a
+        Postgres blip must not kill the thread whose whole job is to prove this
+        process is alive. A thread that dies on the first outage is a liveness
+        signal that reports death for a fault it was supposed to survive.
+        """
+        self.attempts += 1
+        hb = self.payload()
+        write_heartbeat_file(hb, self._path)
+        self.ticks += 1
+        if self._db_factory is not None:
+            try:
+                with self._db_factory() as db:
+                    db.record_heartbeat(hb)
+                    db.commit()
+            except Exception as exc:  # noqa: BLE001 — see docstring
+                self.row_failures += 1
+                print(f"signal-consumer: heartbeat row failed ({exc})", file=sys.stderr)
+        return hb
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                self.tick()
+            except Exception as exc:  # noqa: BLE001 — the thread must outlive a bad beat
+                print(f"signal-consumer: heartbeat failed ({exc})", file=sys.stderr)
+            self._stop.wait(self._interval)
+
+    def start(self) -> "Heartbeat":
+        self.tick()                      # beat ONCE before the first wait, so a
+                                         # probe has a reading immediately
+        self._thread = threading.Thread(target=self._loop, name="signal-heartbeat",
+                                        daemon=True)
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+
+
 def iter_frames(source) -> Iterator[object]:
     """Normalise whatever the receive transport yields into one item per message.
 
@@ -487,6 +658,13 @@ class SignalConsumer:
             STAT_DB_RECOVERY_FAILURES: 0,
             STAT_ATTACHMENT_FAILURES: 0,
         }
+        # Stream state the heartbeat reports. Initialised HERE, not lazily in
+        # run(), so `Heartbeat.payload()` can never read a missing attribute off
+        # a consumer that has not started yet — a health writer that raises is a
+        # health writer that reports nothing.
+        self.stream_connected = False
+        self.connections = 0
+        self.last_frame_at = None
 
     # -- one event ---------------------------------------------------------
     def handle_payload(self, payload) -> str:
@@ -661,8 +839,15 @@ class SignalConsumer:
         connections = 0
         while max_connections is None or connections < max_connections:
             connections += 1
+            self.connections = connections
             try:
-                for payload in iter_frames(self._stream_factory()):
+                stream = self._stream_factory()
+                # Set only AFTER the factory returns: a factory that raises never
+                # opened anything, and reporting `connected` for it would make the
+                # health row assert a connection that does not exist.
+                self.stream_connected = True
+                for payload in iter_frames(stream):
+                    self.last_frame_at = time.time()
                     self.handle_payload(payload)
             except Exception as exc:  # noqa: BLE001 — a dropped stream is normal
                 self.stats[STAT_RECONNECTS] += 1
@@ -670,6 +855,8 @@ class SignalConsumer:
                       file=sys.stderr)
                 self._sleep(self._backoff)
                 continue
+            finally:
+                self.stream_connected = False
         return dict(self.stats)
 
 
@@ -830,6 +1017,16 @@ def build_parser() -> argparse.ArgumentParser:
     r.add_argument("--account", default=ACCOUNT,
                    help="the account number to receive for (default $SIGNAL_ACCOUNT)")
 
+    h = sub.add_parser(
+        "health",
+        help="is the consumer alive? (exit 0 healthy, 1 stale) — the k8s probe")
+    h.add_argument("--max-age", type=float, default=None,
+                   help=f"seconds before a heartbeat is stale (default {HEARTBEAT_MAX_AGE:g})")
+    h.add_argument("--from-db", action="store_true",
+                   help="read the health ROW instead of the local file. Richer, but "
+                        "depends on Postgres — do NOT use this as a liveness probe")
+    h.add_argument("--json", action="store_true", help="machine-readable output")
+
     q = sub.add_parser("conversations", help="list conversations, newest first")
     q.add_argument("--limit", type=int, default=25)
 
@@ -869,8 +1066,48 @@ def build_parser() -> argparse.ArgumentParser:
     return p
 
 
+def _report_health(row, source: str, args) -> int:
+    """Format one health reading and return the PROCESS EXIT CODE.
+
+    Shared by both sources so the file and the row cannot drift into two
+    different opinions about what "healthy" means.
+    """
+    age = row.get("age_seconds") if row else None
+    report = dict(row) if row else {}
+    report["source"] = source
+    fresh = heartbeat_is_fresh(None if age is None else float(age), args.max_age)
+    report["age_seconds"] = None if age is None else round(float(age), 1)
+    report["healthy"] = fresh
+    if args.json:
+        print(json.dumps(report, default=str))
+    elif not row:
+        # 🔴 Say WHICH question came back empty. "no heartbeat" from the file
+        # means the process never wrote one; from the db it can ALSO mean
+        # Postgres is unreachable — different faults, and a bare "unhealthy"
+        # sends the reader hunting the wrong one.
+        print(f"UNHEALTHY: no heartbeat ({source})")
+    else:
+        print(f"{'HEALTHY' if fresh else 'UNHEALTHY'}: "
+              f"heartbeat {report['age_seconds']}s old "
+              f"(connected={row.get('stream_connected')}, "
+              f"reconnects={row.get('reconnects')}, "
+              f"stored={row.get('stored')}, pod={row.get('pod')})")
+    return 0 if fresh else 1
+
+
 def main(argv=None) -> int:  # pragma: no cover - thin CLI shell over tested units
     args = build_parser().parse_args(argv)
+
+    # 🔴 ANSWERED BEFORE ANY DATABASE CONNECTION EXISTS, and that is the whole
+    # point. Every other command runs inside `with SignalDB()`, which connects
+    # AND runs `ensure_schema()` — so routing the probe through it would make
+    # k8s liveness depend on Postgres being up, and a database blip would
+    # restart a consumer that was working perfectly. That is the exact cascade
+    # the two-sink design exists to prevent; it would have been reintroduced
+    # here, in the CLI, after being carefully avoided in the daemon.
+    if args.cmd == "health" and not args.from_db:
+        return _report_health(read_heartbeat_file(), "file", args)
+
     with SignalDB() as db:
         db.ensure_schema()
         if args.cmd == "run":
@@ -885,7 +1122,18 @@ def main(argv=None) -> int:  # pragma: no cover - thin CLI shell over tested uni
                 fetch_attachment=http_attachment_fetcher(),
                 minio=_open_minio(),
             )
-            print(json.dumps(consumer.run()))
+            # 🔴 `db_factory=SignalDB` — a NEW connection per beat, never `db`.
+            # See Heartbeat's docstring: autocommit=False makes a shared
+            # connection a transaction hazard, not a saving.
+            beat = Heartbeat(consumer, db_factory=SignalDB).start()
+            try:
+                print(json.dumps(consumer.run()))
+            finally:
+                beat.stop()
+        elif args.cmd == "health":
+            # Only reachable with --from-db; the file path returned above,
+            # before this connection was ever opened.
+            return _report_health(db.read_heartbeat(), "db", args)
         elif args.cmd == "conversations":
             for row in db.list_conversations(limit=args.limit):
                 print(f"{_fmt_ts(row['last_message_timestamp'])}  "

--- a/scripts/signal/consumer.py
+++ b/scripts/signal/consumer.py
@@ -493,7 +493,15 @@ def heartbeat_is_fresh(age_seconds: float | None, max_age: float = None) -> bool
     """
     if age_seconds is None:
         return False
-    return age_seconds <= (HEARTBEAT_MAX_AGE if max_age is None else max_age)
+    limit = HEARTBEAT_MAX_AGE if max_age is None else max_age
+    # 🔴 A NEGATIVE age is not "very fresh", it is a BROKEN clock — the writer's
+    # wall clock stepped backwards (NTP correction, suspend/resume) after the
+    # beat was written. Treating it as fresh would let an arbitrarily stale
+    # heartbeat read as healthy, which is the one answer this predicate must
+    # never give by accident.
+    if age_seconds < 0:
+        return False
+    return age_seconds <= limit
 
 
 def write_heartbeat_file(payload: dict, path: str = None) -> None:
@@ -526,37 +534,60 @@ def read_heartbeat_file(path: str = None, now: float = None) -> dict | None:
 
 
 class Heartbeat:
-    """Ticks on its OWN thread, writing the file always and the row best-effort.
+    """Ticks the file and the row on SEPARATE threads.
 
-    🔴 It opens its OWN database connection. `SignalDB` runs `autocommit=False`,
+    🔴 IT OPENS ITS OWN DATABASE CONNECTION. `SignalDB` runs `autocommit=False`,
     so a heartbeat issued on the ingest connection would land inside whatever
     transaction the ingest loop has open — committing a partial batch or being
     rolled back with it. Sharing the connection is the bug, not an optimisation.
+
+    🔴 TWO THREADS, AND THAT IS THE WHOLE ANTI-CASCADE PROPERTY. The first cut
+    wrote the file and then the row on ONE thread, reasoning that the file came
+    first so a database fault could not affect it. That is true only for a
+    database that fails FAST. A STALLED Postgres — node partitioned after the
+    socket was established, storage I/O hang on the PV, failover, another
+    session holding the row lock — blocks inside the row write, and the next
+    FILE write never happens. Measured on real Postgres: with the row locked by
+    a second session the file aged past its max-age and the probe went unhealthy,
+    which under a k8s liveness probe kills a consumer that was working fine and
+    then kills its replacement 30s later, for the duration of the incident. The
+    outage shape the original test used — a factory that raises instantly — is
+    the one shape that was already safe.
+
+    So the file loop now touches nothing but the local filesystem, and the row
+    loop is free to block for as long as it likes without anyone caring.
     """
 
     def __init__(self, consumer, *, db_factory=None, interval: float = None,
-                 path: str = None, sleep=time.sleep, clock=time.time):
+                 path: str = None, clock=time.time):
         self._consumer = consumer
         self._db_factory = db_factory
         self._interval = HEARTBEAT_INTERVAL if interval is None else interval
         self._path = path or HEARTBEAT_PATH
-        self._sleep = sleep
         self._clock = clock
         self._stop = threading.Event()
         self._thread = None
-        self.row_failures = 0
+        self._row_thread = None
         #: beats ATTEMPTED vs beats that actually wrote the file. They differ
         #: precisely when the sink is failing, which is the one time an operator
         #: needs to tell "the thread is wedged" from "the thread is trying and
-        #: the disk is refusing" — the same working/dead distinction this whole
-        #: module exists to make, one level down.
+        #: the disk is refusing" — the same working/dead distinction this module
+        #: exists to make, one level down.
         self.attempts = 0
         self.ticks = 0
+        self.row_attempts = 0
+        self.row_writes = 0
+        self.row_failures = 0
 
     def payload(self) -> dict:
         c = self._consumer
+        written = self._clock()
         return {
-            "written_at": self._clock(),
+            "written_at": written,
+            # The row's columns are epoch-MS BIGINT (see the DDL comment). Carried
+            # alongside rather than converted inside the DB layer so there is one
+            # obvious place where the unit changes.
+            "written_at_ms": int(written * 1000),
             "pod": socket.gethostname(),
             "stream_connected": bool(getattr(c, "stream_connected", False)),
             "last_frame_at": getattr(c, "last_frame_at", None),
@@ -566,27 +597,39 @@ class Heartbeat:
             "malformed": int(c.stats.get(STAT_MALFORMED, 0)),
         }
 
+    # -- the liveness sink: local filesystem ONLY, never the network ---------
     def tick(self) -> dict:
-        """One beat. The FILE write is the liveness contract and comes first.
+        """One FILE beat. Touches nothing that can block on a network.
 
-        🔴 The row write is wrapped and its failure counted, never raised: a
-        Postgres blip must not kill the thread whose whole job is to prove this
-        process is alive. A thread that dies on the first outage is a liveness
-        signal that reports death for a fault it was supposed to survive.
+        This is the liveness contract. Keep it that way: anything added here
+        that can hang re-creates the cascade the two threads exist to prevent.
         """
         self.attempts += 1
         hb = self.payload()
         write_heartbeat_file(hb, self._path)
         self.ticks += 1
-        if self._db_factory is not None:
-            try:
-                with self._db_factory() as db:
-                    db.record_heartbeat(hb)
-                    db.commit()
-            except Exception as exc:  # noqa: BLE001 — see docstring
-                self.row_failures += 1
-                print(f"signal-consumer: heartbeat row failed ({exc})", file=sys.stderr)
         return hb
+
+    # -- the observability sink: allowed to be slow, allowed to fail ---------
+    def tick_row(self) -> None:
+        """One ROW beat, on its own thread.
+
+        🔴 Failures are counted and printed, never raised: a Postgres blip must
+        not kill the thread, and it must never reach the file loop. A thread
+        that dies on the first outage is a signal that reports death for exactly
+        the fault it was supposed to ride out.
+        """
+        if self._db_factory is None:
+            return
+        self.row_attempts += 1
+        try:
+            with self._db_factory() as db:
+                db.record_heartbeat(self.payload())
+                db.commit()
+            self.row_writes += 1
+        except Exception as exc:  # noqa: BLE001 — see docstring
+            self.row_failures += 1
+            print(f"signal-consumer: heartbeat row failed ({exc})", file=sys.stderr)
 
     def _loop(self) -> None:
         while not self._stop.is_set():
@@ -596,18 +639,36 @@ class Heartbeat:
                 print(f"signal-consumer: heartbeat failed ({exc})", file=sys.stderr)
             self._stop.wait(self._interval)
 
+    def _row_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                self.tick_row()
+            except Exception as exc:  # noqa: BLE001 — belt and braces; tick_row swallows
+                print(f"signal-consumer: heartbeat row loop ({exc})", file=sys.stderr)
+            self._stop.wait(self._interval)
+
     def start(self) -> "Heartbeat":
         self.tick()                      # beat ONCE before the first wait, so a
                                          # probe has a reading immediately
         self._thread = threading.Thread(target=self._loop, name="signal-heartbeat",
                                         daemon=True)
         self._thread.start()
+        if self._db_factory is not None:
+            self._row_thread = threading.Thread(target=self._row_loop,
+                                                name="signal-heartbeat-row",
+                                                daemon=True)
+            self._row_thread.start()
         return self
 
     def stop(self) -> None:
         self._stop.set()
-        if self._thread is not None:
-            self._thread.join(timeout=5)
+        for t in (self._thread, self._row_thread):
+            if t is not None:
+                # 🔴 A SHORT join, and daemon=True, precisely because the row
+                # thread may be wedged inside a stalled database call. Waiting on
+                # it would make shutdown hang for the same reason liveness used
+                # to; the interpreter reaps a daemon thread regardless.
+                t.join(timeout=5)
 
 
 def iter_frames(source) -> Iterator[object]:
@@ -847,7 +908,7 @@ class SignalConsumer:
                 # health row assert a connection that does not exist.
                 self.stream_connected = True
                 for payload in iter_frames(stream):
-                    self.last_frame_at = time.time()
+                    self.last_frame_at = int(time.time() * 1000)
                     self.handle_payload(payload)
             except Exception as exc:  # noqa: BLE001 — a dropped stream is normal
                 self.stats[STAT_RECONNECTS] += 1

--- a/scripts/signal/tests/conftest.py
+++ b/scripts/signal/tests/conftest.py
@@ -89,3 +89,18 @@ def _no_live_network(monkeypatch):
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", guard)
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_heartbeat_env(monkeypatch):
+    """🔴 The suite must not read the AMBIENT heartbeat configuration.
+
+    Measured: `SIGNAL_HEARTBEAT_MAX_AGE=10 pytest` reds test_liveness, and
+    `SIGNAL_HEARTBEAT_INTERVAL=abc` fails COLLECTION outright (the module parses
+    it at import). A host or CI job that happens to export either turns the gate
+    red for a reason that has nothing to do with the code — a suite whose config
+    is decided by its environment is blind on exactly that dimension.
+    """
+    for var in ("SIGNAL_HEARTBEAT_PATH", "SIGNAL_HEARTBEAT_INTERVAL",
+                "SIGNAL_HEARTBEAT_MAX_AGE"):
+        monkeypatch.delenv(var, raising=False)

--- a/scripts/signal/tests/conftest.py
+++ b/scripts/signal/tests/conftest.py
@@ -6,10 +6,29 @@ suite imports the modules under test directly.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
 import pytest
+
+# 🔴 POPPED AT MODULE SCOPE, ABOVE EVERY IMPORT OF `consumer` — a fixture is far
+# too late. `HEARTBEAT_INTERVAL`/`MAX_AGE`/`PATH` are parsed at consumer.py
+# IMPORT time, and the test modules import consumer at their own module scope,
+# i.e. during collection. An autouse fixture runs after all of that, so the
+# first version of this cleanup was completely INERT while carrying a docstring
+# claiming it had been measured and closed — the failing claim was the
+# dangerous half, not the missing cleanup.
+#
+# Both symptoms, measured at the time this was written:
+#   SIGNAL_HEARTBEAT_MAX_AGE=10  -> 1 failed  (10.0 >= 2 * 30.0)
+#   SIGNAL_HEARTBEAT_INTERVAL=abc -> 10 COLLECTION ERRORS, suite interrupted
+# A suite whose configuration is decided by the ambient environment is blind on
+# exactly that dimension, and a host exporting either turns the gate red for a
+# reason that has nothing to do with the code.
+for _var in ("SIGNAL_HEARTBEAT_PATH", "SIGNAL_HEARTBEAT_INTERVAL",
+             "SIGNAL_HEARTBEAT_MAX_AGE"):
+    os.environ.pop(_var, None)
 
 SIGNAL_DIR = Path(__file__).resolve().parents[1]
 TESTS_DIR = Path(__file__).resolve().parent
@@ -89,18 +108,3 @@ def _no_live_network(monkeypatch):
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", guard)
-
-
-@pytest.fixture(autouse=True)
-def _hermetic_heartbeat_env(monkeypatch):
-    """🔴 The suite must not read the AMBIENT heartbeat configuration.
-
-    Measured: `SIGNAL_HEARTBEAT_MAX_AGE=10 pytest` reds test_liveness, and
-    `SIGNAL_HEARTBEAT_INTERVAL=abc` fails COLLECTION outright (the module parses
-    it at import). A host or CI job that happens to export either turns the gate
-    red for a reason that has nothing to do with the code — a suite whose config
-    is decided by its environment is blind on exactly that dimension.
-    """
-    for var in ("SIGNAL_HEARTBEAT_PATH", "SIGNAL_HEARTBEAT_INTERVAL",
-                "SIGNAL_HEARTBEAT_MAX_AGE"):
-        monkeypatch.delenv(var, raising=False)

--- a/scripts/signal/tests/test_liveness.py
+++ b/scripts/signal/tests/test_liveness.py
@@ -194,15 +194,26 @@ def test_a_STALLED_POSTGRES_CANNOT_FREEZE_THE_LIVENESS_FILE(tmp_path):
                               path=path, interval=0.01)
     try:
         beat.start()
+
+        # 🔴 SNAPSHOT BEFORE WAITING, and snapshot the file and the tick count
+        # TOGETHER. The first version read `first` AFTER `entered.wait()`
+        # returned, by which time the 10ms file thread could already be past
+        # tick 3 — so `while beat.ticks < 3` never ran, `second` re-read the
+        # very same file, and `second > first` failed on an identical
+        # timestamp. Measured at 5/60 red on an IDLE machine (8%), so it was a
+        # genuine race and not a load artifact. A ~1-in-15 flake on the test
+        # that gates a deploy-blocker is how a red gate becomes something people
+        # click through.
+        n0 = beat.ticks
+        first = consumer.read_heartbeat_file(path)
         assert entered.wait(2), "the row thread never reached the database"
 
-        first = consumer.read_heartbeat_file(path)
-        deadline = time.time() + 2
-        while beat.ticks < 3 and time.time() < deadline:
+        deadline = time.time() + 5
+        while beat.ticks < n0 + 2 and time.time() < deadline:
             time.sleep(0.01)
 
         # 🔴 The file kept beating WHILE the database was wedged.
-        assert beat.ticks >= 3, "the stalled DB froze the liveness file"
+        assert beat.ticks >= n0 + 2, "the stalled DB froze the liveness file"
         assert beat.row_writes == 0, "the DB was supposed to be stuck"
         second = consumer.read_heartbeat_file(path)
         assert second["written_at"] > first["written_at"]
@@ -721,3 +732,102 @@ def test_a_NEGATIVE_age_is_not_fresh():
     """A backwards clock step must not make an arbitrarily stale beat healthy."""
     assert consumer.heartbeat_is_fresh(-5000.0, max_age=120) is False
     assert consumer.heartbeat_is_fresh(-0.001, max_age=120) is False
+
+
+# --------------------------------------------------------------------------- #
+# Coverage debt the delta re-audit found by mutation: each of these had a
+# surviving mutant against a fully green suite.
+
+def test_last_frame_at_is_stamped_in_MILLISECONDS_not_seconds(db):
+    """🟡 The UNIT is load-bearing and was unpinned.
+
+    Changing the stamp to `time.time()` (seconds) survived all 467 tests: the
+    only round-trip test INJECTED a value into a fake, and the real-stamping
+    test asserted only `is not None`. With seconds, `frame_age_seconds` reads
+    ~1.7 million — a diagnosis field lying by a factor of 1000, in the one field
+    that distinguishes "connected and fed nothing" from "working".
+
+    Epoch-ms is ~1.7e12 and epoch-s ~1.7e9, so the magnitude discriminates them
+    with no clock coupling.
+    """
+    c = _consumer(db, Streams([_payload(1723960000001, "one")]))
+    c.run(max_connections=1)
+
+    assert c.last_frame_at is not None
+    assert isinstance(c.last_frame_at, int), "the column is BIGINT epoch-ms"
+    assert c.last_frame_at > 1_000_000_000_000, (
+        "last_frame_at looks like epoch SECONDS; the column and every reader "
+        "expect epoch MILLISECONDS")
+
+
+def test_a_later_beat_WITHOUT_a_frame_time_PRESERVES_the_stored_one(db):
+    """🟢 The `COALESCE(EXCLUDED.last_frame_at, existing)` in the upsert.
+
+    Replacing it with a plain `EXCLUDED.last_frame_at` survived. It matters
+    across a pod restart: a fresh pod's first beats carry None, and without the
+    COALESCE they would WIPE the last known frame time — deleting the one
+    diagnostic that says when traffic was last seen, at exactly the moment
+    someone is asking.
+    """
+    with_frame = consumer.Heartbeat(FakeConsumer(last_frame_at=1723970000123),
+                                    path="/dev/null").payload()
+    db.record_heartbeat(with_frame)
+    assert db.read_heartbeat()["last_frame_at"] == 1723970000123
+
+    without = consumer.Heartbeat(FakeConsumer(last_frame_at=None),
+                                 path="/dev/null").payload()
+    db.record_heartbeat(without)
+    assert db.read_heartbeat()["last_frame_at"] == 1723970000123, (
+        "a beat with no frame time wiped the stored one")
+
+
+def test_stop_HALTS_both_loops(tmp_path):
+    """🟢 The shutdown path was essentially untested — `stop()` not setting the
+    event, `stop()` joining nothing, and `_row_loop` ignoring the stop event all
+    survived. A row loop that ignores it keeps beating after shutdown."""
+    class QuietDB:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def record_heartbeat(self, hb): pass
+        def commit(self): pass
+
+    beat = consumer.Heartbeat(FakeConsumer(), db_factory=QuietDB,
+                              path=_hb_path(tmp_path), interval=0.01)
+    beat.start()
+    deadline = time.time() + 2
+    while beat.row_writes < 2 and time.time() < deadline:
+        time.sleep(0.01)
+    assert beat.row_writes >= 2, "the row loop never ran"
+
+    beat.stop()
+    ticks_after_stop = beat.ticks
+    rows_after_stop = beat.row_writes
+    time.sleep(0.15)                      # >> interval
+
+    assert beat.ticks == ticks_after_stop, "the file loop kept beating after stop()"
+    assert beat.row_writes == rows_after_stop, "the row loop kept beating after stop()"
+    assert not (beat._thread and beat._thread.is_alive())
+    assert not (beat._row_thread and beat._row_thread.is_alive())
+
+
+def test_BOTH_threads_are_daemons(tmp_path):
+    """🟢 `daemon=True` on both survived being flipped.
+
+    It is load-bearing and the code says so: the row thread can be wedged inside
+    a stalled database call, and a non-daemon thread there would hang
+    interpreter exit for the same reason liveness used to freeze.
+    """
+    class QuietDB:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def record_heartbeat(self, hb): pass
+        def commit(self): pass
+
+    beat = consumer.Heartbeat(FakeConsumer(), db_factory=QuietDB,
+                              path=_hb_path(tmp_path), interval=0.01)
+    try:
+        beat.start()
+        assert beat._thread.daemon is True
+        assert beat._row_thread.daemon is True
+    finally:
+        beat.stop()

--- a/scripts/signal/tests/test_liveness.py
+++ b/scripts/signal/tests/test_liveness.py
@@ -1,0 +1,440 @@
+"""🔴 The signal this service did not have.
+
+`signal-consumer` serves no HTTP, declared no probes, and emitted **0 log lines**
+across 20h in which it successfully ingested 5 messages, 5 contacts, a group and
+2 reactions. So "reaching nothing" and "working perfectly" produced byte-
+identical observations and the row count was the only health signal in
+existence — which is why the step-7 diagnosis took hours rather than a glance.
+
+The tests that matter here are the ones that pin the heartbeat firing when
+NOTHING ELSE IS HAPPENING. A heartbeat that only beats under traffic re-creates
+the exact blind spot it was built to close.
+"""
+import json
+import time
+
+import pytest
+
+import consumer
+from test_consumer_resilience import Streams, _consumer, _payload
+
+
+class FakeConsumer:
+    """Just the surface `Heartbeat.payload()` reads."""
+
+    def __init__(self, **over):
+        self.stream_connected = over.pop("stream_connected", True)
+        self.connections = over.pop("connections", 3)
+        self.last_frame_at = over.pop("last_frame_at", None)
+        self.stats = {
+            consumer.STAT_RECONNECTS: over.pop("reconnects", 7),
+            consumer.STAT_STORED: over.pop("stored", 11),
+            consumer.STAT_MALFORMED: over.pop("malformed", 5),
+        }
+
+
+def _hb_path(tmp_path):
+    return str(tmp_path / "hb.json")
+
+
+# --------------------------------------------------------------------------- #
+# The freshness predicate — ONE definition, and `None` is not "fine"
+
+def test_a_MISSING_heartbeat_is_NOT_fresh():
+    """The state the whole feature exists to catch must not default to healthy.
+
+    A consumer that never wrote a heartbeat is indistinguishable from one that
+    died before its first beat. Scoring an absent reading as fresh is a dead
+    measuring apparatus reporting all-clear.
+    """
+    assert consumer.heartbeat_is_fresh(None) is False
+
+
+def test_freshness_is_bounded_at_BOTH_ends_of_the_window():
+    """Measured at a boundary AND a middle, not one point."""
+    assert consumer.heartbeat_is_fresh(0.0, max_age=100) is True
+    assert consumer.heartbeat_is_fresh(50.0, max_age=100) is True
+    assert consumer.heartbeat_is_fresh(100.0, max_age=100) is True    # inclusive
+    assert consumer.heartbeat_is_fresh(100.001, max_age=100) is False
+    assert consumer.heartbeat_is_fresh(10_000.0, max_age=100) is False
+
+
+def test_the_default_max_age_is_a_MULTIPLE_of_the_write_interval():
+    """A probe tripping at less than a few ticks flaps on scheduling jitter.
+
+    Pins the RELATIONSHIP, not the literals — the numbers may be retuned, but a
+    max-age at or below one interval means a healthy pod gets restarted for
+    being a moment late, and that is never the intent.
+    """
+    assert consumer.HEARTBEAT_MAX_AGE >= 2 * consumer.HEARTBEAT_INTERVAL
+
+
+# --------------------------------------------------------------------------- #
+# The file sink — the liveness contract
+
+def test_a_beat_writes_a_readable_file_and_its_age_is_measured(tmp_path):
+    path = _hb_path(tmp_path)
+    beat = consumer.Heartbeat(FakeConsumer(), path=path, clock=lambda: 1000.0)
+    beat.tick()
+
+    got = consumer.read_heartbeat_file(path, now=1005.0)
+    assert got is not None
+    assert got["age_seconds"] == pytest.approx(5.0)
+    assert got["stream_connected"] is True
+    assert got["reconnects"] == 7
+    assert got["stored"] == 11
+    assert got["connections"] == 3
+
+
+def test_a_DISCONNECTED_consumer_reports_stream_connected_FALSE(tmp_path):
+    """🔴 The health row must not claim a connection that does not exist.
+
+    Every other fixture here sets `stream_connected=True`, which makes a mutant
+    that hardcodes the field invisible — it survived a green 443-test run. The
+    control is mechanical: feed the value the constant CANNOT equal and watch the
+    output move. A consumer that always reports "connected" is exactly the
+    confident lie this whole module exists to stop telling.
+    """
+    path = _hb_path(tmp_path)
+    beat = consumer.Heartbeat(FakeConsumer(stream_connected=False), path=path)
+    beat.tick()
+    assert consumer.read_heartbeat_file(path)["stream_connected"] is False
+
+
+def test_stream_state_is_read_LIVE_at_each_beat_not_frozen_at_construction(tmp_path):
+    """The flag flips as streams open and drop; a beat must report NOW."""
+    path = _hb_path(tmp_path)
+    fake = FakeConsumer(stream_connected=True)
+    beat = consumer.Heartbeat(fake, path=path)
+    beat.tick()
+    assert consumer.read_heartbeat_file(path)["stream_connected"] is True
+    fake.stream_connected = False
+    beat.tick()
+    assert consumer.read_heartbeat_file(path)["stream_connected"] is False
+
+
+def test_the_file_write_is_ATOMIC_so_a_probe_cannot_read_a_torn_beat(tmp_path):
+    """Pinned structurally: after the write, no temp file survives and the
+    target parses. A probe that read a half-written file would be scored as
+    "no heartbeat" and restart a healthy pod — an outage caused by the
+    instrument."""
+    path = _hb_path(tmp_path)
+    beat = consumer.Heartbeat(FakeConsumer(), path=path)
+    beat.tick()
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name != "hb.json"]
+    assert leftovers == []
+    json.loads((tmp_path / "hb.json").read_text())
+
+
+@pytest.mark.parametrize("content", ["", "{", "not json", '{"no_written_at": 1}'])
+def test_an_UNREADABLE_heartbeat_reads_as_ABSENT_not_as_healthy(tmp_path, content):
+    """Absent, truncated and garbage all mean "no current measurement"."""
+    path = tmp_path / "hb.json"
+    path.write_text(content)
+    assert consumer.read_heartbeat_file(str(path)) is None
+    assert consumer.heartbeat_is_fresh(None) is False
+
+
+def test_a_MISSING_file_reads_as_absent(tmp_path):
+    assert consumer.read_heartbeat_file(str(tmp_path / "nope.json")) is None
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 The two sinks answer different questions, and the DB one is ALLOWED to fail
+
+def test_a_POSTGRES_OUTAGE_DOES_NOT_BREAK_LIVENESS(tmp_path):
+    """🔴 THE anti-cascade property.
+
+    Keying a k8s restart on Postgres reachability turns a database blip into a
+    restart storm that takes down a consumer which was working fine. The file
+    is written FIRST and unconditionally; the row failure is counted, printed
+    and swallowed.
+    """
+    path = _hb_path(tmp_path)
+
+    def exploding_db():
+        raise RuntimeError("postgres is down")
+
+    beat = consumer.Heartbeat(FakeConsumer(), db_factory=exploding_db,
+                              path=path, clock=lambda: 500.0)
+    beat.tick()          # must NOT raise
+
+    got = consumer.read_heartbeat_file(path, now=501.0)
+    assert got is not None, "the liveness file must survive a DB outage"
+    assert consumer.heartbeat_is_fresh(got["age_seconds"], max_age=60) is True
+    assert beat.row_failures == 1
+
+
+def test_the_row_IS_written_when_the_database_is_healthy(tmp_path):
+    """POSITIVE CONTROL for the test above.
+
+    Without this, `row_failures == 1` is indistinguishable from a heartbeat
+    wired to nothing — the assertion would hold with the row write deleted.
+    """
+    written = []
+
+    class FakeDB:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def record_heartbeat(self, hb): written.append(hb)
+        def commit(self): written.append("commit")
+
+    beat = consumer.Heartbeat(FakeConsumer(), db_factory=FakeDB,
+                              path=_hb_path(tmp_path))
+    beat.tick()
+    assert beat.row_failures == 0
+    assert len(written) == 2 and written[1] == "commit"
+    assert written[0]["stored"] == 11
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 The property the whole feature turns on
+
+def test_the_heartbeat_BEATS_WHILE_THE_STREAM_IS_IDLE(tmp_path):
+    """🔴 THE POINT. `run()` blocks in `iter_frames` — on an idle account, for
+    HOURS. A heartbeat written per frame fires only when traffic exists, i.e.
+    only in the case that never needed one. This drives beats with ZERO frames
+    and asserts the reading still advances."""
+    path = _hb_path(tmp_path)
+    now = {"t": 0.0}
+    beat = consumer.Heartbeat(FakeConsumer(stored=0, last_frame_at=None),
+                              path=path, clock=lambda: now["t"])
+
+    beat.tick()
+    first = consumer.read_heartbeat_file(path, now=now["t"])
+    now["t"] = 120.0
+    beat.tick()                                   # still no frames at all
+    second = consumer.read_heartbeat_file(path, now=now["t"])
+
+    assert first["written_at"] == 0.0
+    assert second["written_at"] == 120.0          # it advanced with no traffic
+    assert second["stored"] == 0
+    assert consumer.heartbeat_is_fresh(second["age_seconds"], max_age=60) is True
+
+
+def test_an_IDLE_account_is_not_reported_unhealthy_for_having_no_frames(tmp_path):
+    """`last_frame_at` is diagnosis, NEVER a liveness input.
+
+    An idle Signal account legitimately sends nothing for hours. If silence fed
+    the probe, a quiet weekend would restart the pod repeatedly.
+    """
+    path = _hb_path(tmp_path)
+    beat = consumer.Heartbeat(FakeConsumer(last_frame_at=None, stored=0),
+                              path=path, clock=lambda: 900.0)
+    beat.tick()
+    got = consumer.read_heartbeat_file(path, now=901.0)
+    assert got["last_frame_at"] is None
+    assert consumer.heartbeat_is_fresh(got["age_seconds"], max_age=60) is True
+
+
+def test_a_STALE_heartbeat_goes_unhealthy(tmp_path):
+    """Negative control: the probe CAN go red, or it is testing nothing."""
+    path = _hb_path(tmp_path)
+    beat = consumer.Heartbeat(FakeConsumer(), path=path, clock=lambda: 0.0)
+    beat.tick()
+    got = consumer.read_heartbeat_file(path, now=10_000.0)
+    assert consumer.heartbeat_is_fresh(got["age_seconds"], max_age=120) is False
+
+
+# --------------------------------------------------------------------------- #
+# Thread behaviour
+
+def test_start_BEATS_ONCE_BEFORE_WAITING(tmp_path):
+    """Otherwise a probe firing inside the first interval sees no file and
+    restarts a pod that had merely just booted."""
+    path = _hb_path(tmp_path)
+    beat = consumer.Heartbeat(FakeConsumer(), path=path, interval=3600)
+    try:
+        beat.start()
+        assert consumer.read_heartbeat_file(path) is not None
+        assert beat.ticks >= 1
+    finally:
+        beat.stop()
+
+
+def test_the_thread_SURVIVES_a_beat_that_fails_AFTER_it_started(tmp_path):
+    """A thread that dies on the first transient is a liveness signal that
+    reports death for exactly the fault it was supposed to ride out.
+
+    The first beat succeeds; the sink is then pointed somewhere unwritable, so
+    every LATER beat raises. Deterministic on purpose — an earlier version of
+    this test deleted the directory out from under a 10ms thread and raced it,
+    which made the TEST flaky and said nothing about the code.
+    """
+    path = str(tmp_path / "hb.json")
+    beat = consumer.Heartbeat(FakeConsumer(), path=path, interval=0.01)
+    try:
+        beat.start()
+        assert consumer.read_heartbeat_file(path) is not None
+        beat._path = "/nonexistent-dir/hb.json"      # every later write fails
+        # Let any beat already IN FLIGHT finish against the old path before
+        # snapshotting. Without this settle the counters race the swap — which is
+        # how the first two versions of this test were green for the wrong reason.
+        time.sleep(0.1)                               # >= several intervals
+        # 🔴 Assert on ATTEMPTS, not ticks. `ticks` counts SUCCESSFUL writes, so
+        # once the sink is broken it can never grow; asserting the loop still
+        # runs therefore has to read the counter that increments BEFORE the I/O.
+        attempts_before = beat.attempts
+        ticks_before = beat.ticks
+        deadline = time.time() + 2
+        while beat.attempts <= attempts_before + 1 and time.time() < deadline:
+            time.sleep(0.01)
+        assert beat.attempts > attempts_before + 1, "the loop stopped trying"
+        assert beat.ticks == ticks_before, "a write to an unwritable path 'succeeded'"
+        assert beat._thread is not None and beat._thread.is_alive()
+    finally:
+        beat.stop()
+
+
+def test_an_UNWRITABLE_path_FAILS_FAST_at_start_rather_than_pretending(tmp_path):
+    """🔴 The deliberate asymmetry, and it is the opposite of the test above.
+
+    A path that can never be written is a CONFIGURATION fault, not a transient,
+    and this module's rule is that a configuration fault must not be laundered
+    into a retry — a consumer that silently loops writing nowhere would report
+    itself dead forever while looking like it was trying. It must fail loudly at
+    startup, where the operator sees it. Transients, once running, are survived.
+    """
+    beat = consumer.Heartbeat(FakeConsumer(), path="/nonexistent-dir/hb.json")
+    with pytest.raises(OSError):
+        beat.start()
+
+
+def test_stop_is_idempotent_and_safe_before_start(tmp_path):
+    consumer.Heartbeat(FakeConsumer(), path=_hb_path(tmp_path)).stop()
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE SEAM. Everything above drives `Heartbeat` against a FAKE consumer, and
+# `run()` is tested elsewhere against a real one. Both can be green while the
+# attribute names drift apart — the heartbeat would then report a frozen
+# `stream_connected=False` forever and nobody's test would notice, because no
+# fixture ever loads BOTH surfaces. That is the shape of the last defect this
+# pipeline shipped. These build the combined state.
+
+def test_run_MOVES_the_state_the_heartbeat_reports(db):
+    """A REAL consumer through a REAL run(), read by a REAL Heartbeat."""
+    c = _consumer(db, Streams([_payload(1723900000001, "hello")]))
+
+    # Before running: not connected, nothing seen.
+    assert c.stream_connected is False
+    assert c.last_frame_at is None
+    assert c.connections == 0
+
+    c.run(max_connections=1)
+
+    # After a completed connection the flag must be BACK to false — the `finally`
+    # is what guarantees a dropped stream cannot leave the row asserting a
+    # connection that ended.
+    assert c.stream_connected is False
+    assert c.connections == 1
+    assert c.last_frame_at is not None, "run() never recorded a frame arrival"
+
+
+def test_the_heartbeat_reads_a_REAL_consumers_counters(db, tmp_path):
+    """Names, not just shapes: a rename on either side breaks this."""
+    c = _consumer(db, Streams([_payload(1723900000002, "hi")]))
+    c.run(max_connections=1)
+
+    path = _hb_path(tmp_path)
+    consumer.Heartbeat(c, path=path).tick()
+    got = consumer.read_heartbeat_file(path)
+
+    assert got["connections"] == c.connections == 1
+    assert got["stored"] == c.stats[consumer.STAT_STORED]
+    assert got["reconnects"] == c.stats[consumer.STAT_RECONNECTS]
+    assert got["last_frame_at"] == c.last_frame_at
+    assert got["stored"] >= 1, "the fixture stored nothing — the seam proves nothing"
+
+
+def test_a_DROPPED_stream_leaves_connected_FALSE_and_counts_the_reconnect(db):
+    """The failure direction: an exception mid-stream must not strand the flag
+    at True, or the health row advertises a connection that is gone."""
+    c = _consumer(db, Streams([RuntimeError("connection reset")]))
+    c.run(max_connections=1)
+    assert c.stream_connected is False
+    assert c.stats[consumer.STAT_RECONNECTS] == 1
+
+
+def test_a_factory_that_RAISES_never_claims_the_stream_was_connected(db):
+    """🔴 Pins the ORDER of two adjacent lines, which a comment asserted and
+    nothing tested.
+
+    `stream_connected` is set AFTER `self._stream_factory()` returns, because a
+    factory that raises never opened anything — signal-api down, DNS gone, auth
+    rejected. Setting the flag first makes the health row assert a connection
+    that was never established, which is the precise failure this row exists to
+    expose. Hoisting the assignment one line up survived a green 448-test run.
+
+    The factory records what the flag said AT THE MOMENT it ran, then fails.
+    """
+    seen = []
+
+    def exploding_factory():
+        seen.append(c.stream_connected)
+        raise RuntimeError("signal-api unreachable")
+
+    c = _consumer(db, exploding_factory)
+    c.run(max_connections=2)
+
+    assert seen == [False, False], (
+        "the consumer claimed stream_connected before the stream existed")
+    assert c.stream_connected is False
+    assert c.stats[consumer.STAT_RECONNECTS] == 2
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE PROBE MUST NOT TOUCH POSTGRES. `main()` runs every other command inside
+# `with SignalDB()`, which connects AND runs ensure_schema(). Routing the probe
+# through that would make k8s liveness depend on the database — a blip would
+# restart a healthy consumer, which is precisely the cascade the two-sink design
+# avoids in the daemon. It was reintroduced in the CLI once already.
+
+def test_health_answers_WITHOUT_opening_a_database_connection(tmp_path, monkeypatch, capsys):
+    """Proven by making the database EXPLODE. If `health` touches it, this raises.
+
+    A test that merely asserts the exit code would pass with the connection
+    still being opened — the DB is reachable in most environments, so the
+    dependency would be invisible exactly until the outage that matters.
+    """
+    path = str(tmp_path / "hb.json")
+    monkeypatch.setenv("SIGNAL_HEARTBEAT_PATH", path)
+    monkeypatch.setattr(consumer, "HEARTBEAT_PATH", path)
+
+    def detonate(*a, **kw):
+        raise AssertionError("health opened a database connection")
+
+    monkeypatch.setattr(consumer, "SignalDB", detonate)
+
+    consumer.Heartbeat(FakeConsumer(), path=path).tick()
+    assert consumer.main(["health"]) == 0
+    assert "HEALTHY" in capsys.readouterr().out
+
+
+def test_health_exits_NONZERO_when_there_is_no_heartbeat(tmp_path, monkeypatch, capsys):
+    """Negative control: the probe can go red, or it gates nothing.
+
+    Without this, the test above is satisfied by a `health` that always exits 0.
+    """
+    path = str(tmp_path / "absent.json")
+    monkeypatch.setattr(consumer, "HEARTBEAT_PATH", path)
+    monkeypatch.setattr(consumer, "SignalDB",
+                        lambda *a, **kw: (_ for _ in ()).throw(
+                            AssertionError("health opened a database connection")))
+
+    assert consumer.main(["health"]) == 1
+    assert "UNHEALTHY" in capsys.readouterr().out
+
+
+def test_health_exits_NONZERO_when_the_heartbeat_is_STALE(tmp_path, monkeypatch, capsys):
+    """The state a probe actually fires on: present, but old."""
+    path = str(tmp_path / "hb.json")
+    monkeypatch.setattr(consumer, "HEARTBEAT_PATH", path)
+    monkeypatch.setattr(consumer, "SignalDB",
+                        lambda *a, **kw: (_ for _ in ()).throw(
+                            AssertionError("health opened a database connection")))
+
+    consumer.Heartbeat(FakeConsumer(), path=path,
+                       clock=lambda: time.time() - 9999).tick()
+    assert consumer.main(["health"]) == 1
+    assert "UNHEALTHY" in capsys.readouterr().out

--- a/scripts/signal/tests/test_liveness.py
+++ b/scripts/signal/tests/test_liveness.py
@@ -11,6 +11,7 @@ NOTHING ELSE IS HAPPENING. A heartbeat that only beats under traffic re-creates
 the exact blind spot it was built to close.
 """
 import json
+import threading
 import time
 
 import pytest
@@ -143,13 +144,7 @@ def test_a_MISSING_file_reads_as_absent(tmp_path):
 # 🔴 The two sinks answer different questions, and the DB one is ALLOWED to fail
 
 def test_a_POSTGRES_OUTAGE_DOES_NOT_BREAK_LIVENESS(tmp_path):
-    """🔴 THE anti-cascade property.
-
-    Keying a k8s restart on Postgres reachability turns a database blip into a
-    restart storm that takes down a consumer which was working fine. The file
-    is written FIRST and unconditionally; the row failure is counted, printed
-    and swallowed.
-    """
+    """A DB that fails FAST must not disturb the file."""
     path = _hb_path(tmp_path)
 
     def exploding_db():
@@ -157,19 +152,70 @@ def test_a_POSTGRES_OUTAGE_DOES_NOT_BREAK_LIVENESS(tmp_path):
 
     beat = consumer.Heartbeat(FakeConsumer(), db_factory=exploding_db,
                               path=path, clock=lambda: 500.0)
-    beat.tick()          # must NOT raise
+    beat.tick()          # the file sink
+    beat.tick_row()      # the row sink -- must NOT raise
 
     got = consumer.read_heartbeat_file(path, now=501.0)
     assert got is not None, "the liveness file must survive a DB outage"
     assert consumer.heartbeat_is_fresh(got["age_seconds"], max_age=60) is True
     assert beat.row_failures == 1
+    assert beat.row_writes == 0
+
+
+def test_a_STALLED_POSTGRES_CANNOT_FREEZE_THE_LIVENESS_FILE(tmp_path):
+    """🔴 THE REGRESSION, and the one the first version got wrong.
+
+    The original code wrote the file and then the row ON ONE THREAD, reasoning
+    that the file came first so a DB fault could not reach it. True only for a
+    database that fails FAST. A STALLED Postgres — partitioned after the socket
+    was established, storage hang, failover, another session holding the row
+    lock — blocks INSIDE the row write, and the next FILE write never happens.
+    The file then ages out and a k8s liveness probe kills a consumer that was
+    working perfectly, then kills its replacement, for the length of the
+    incident. The original test used a factory that raises instantly, which is
+    the one outage shape that was already safe.
+
+    Here the DB hangs and the file MUST keep advancing.
+    """
+    path = _hb_path(tmp_path)
+    release = threading.Event()
+    entered = threading.Event()
+
+    class StalledDB:
+        def __enter__(self):
+            entered.set()
+            release.wait(10)       # hang, like a partitioned server
+            return self
+        def __exit__(self, *a): return False
+        def record_heartbeat(self, hb): pass
+        def commit(self): pass
+
+    beat = consumer.Heartbeat(FakeConsumer(), db_factory=StalledDB,
+                              path=path, interval=0.01)
+    try:
+        beat.start()
+        assert entered.wait(2), "the row thread never reached the database"
+
+        first = consumer.read_heartbeat_file(path)
+        deadline = time.time() + 2
+        while beat.ticks < 3 and time.time() < deadline:
+            time.sleep(0.01)
+
+        # 🔴 The file kept beating WHILE the database was wedged.
+        assert beat.ticks >= 3, "the stalled DB froze the liveness file"
+        assert beat.row_writes == 0, "the DB was supposed to be stuck"
+        second = consumer.read_heartbeat_file(path)
+        assert second["written_at"] > first["written_at"]
+    finally:
+        release.set()
+        beat.stop()
 
 
 def test_the_row_IS_written_when_the_database_is_healthy(tmp_path):
-    """POSITIVE CONTROL for the test above.
+    """POSITIVE CONTROL for both tests above.
 
-    Without this, `row_failures == 1` is indistinguishable from a heartbeat
-    wired to nothing — the assertion would hold with the row write deleted.
+    Without this, `row_failures == 1` and `row_writes == 0` are indistinguishable
+    from a row sink wired to nothing — they would hold with the write deleted.
     """
     written = []
 
@@ -181,10 +227,25 @@ def test_the_row_IS_written_when_the_database_is_healthy(tmp_path):
 
     beat = consumer.Heartbeat(FakeConsumer(), db_factory=FakeDB,
                               path=_hb_path(tmp_path))
-    beat.tick()
+    beat.tick_row()
     assert beat.row_failures == 0
+    assert beat.row_writes == 1
     assert len(written) == 2 and written[1] == "commit"
     assert written[0]["stored"] == 11
+
+
+def test_the_file_loop_NEVER_touches_the_database(tmp_path):
+    """Structural: `tick()` is the liveness contract, so it must not be able to
+    block on a network. A db_factory that detonates proves it is never called."""
+    def detonate():
+        raise AssertionError("the FILE loop touched the database")
+
+    beat = consumer.Heartbeat(FakeConsumer(), db_factory=detonate,
+                              path=_hb_path(tmp_path))
+    beat.tick()
+    beat.tick()
+    assert beat.ticks == 2
+    assert beat.row_attempts == 0
 
 
 # --------------------------------------------------------------------------- #
@@ -381,6 +442,13 @@ def test_a_factory_that_RAISES_never_claims_the_stream_was_connected(db):
         "the consumer claimed stream_connected before the stream existed")
     assert c.stream_connected is False
     assert c.stats[consumer.STAT_RECONNECTS] == 2
+    # 🔴 Asserted HERE because this is the only multi-connection case. The seam
+    # test runs max_connections=1 and asserts `== 1`, so a mutant hardcoding
+    # `self.connections = 1` was invisible there — a fixture that can only
+    # produce the constant's own value cannot see the constant. An operator
+    # diagnosing a reconnect storm would read connections=1 while reconnects
+    # climbed.
+    assert c.connections == 2
 
 
 # --------------------------------------------------------------------------- #
@@ -438,3 +506,218 @@ def test_health_exits_NONZERO_when_the_heartbeat_is_STALE(tmp_path, monkeypatch,
                        clock=lambda: time.time() - 9999).tick()
     assert consumer.main(["health"]) == 1
     assert "UNHEALTHY" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE SQL MUST ACTUALLY EXECUTE. Everything DB-shaped above this point used a
+# FakeDB that appends to a list — so `record_heartbeat`/`read_heartbeat` shipped
+# with ZERO executing tests, and the first version declared the timestamp columns
+# TIMESTAMPTZ while writing a Python float into them. The upsert therefore raised
+# on EVERY beat from the moment the first frame arrived: the row was correct only
+# while nothing worked, and broke the instant it did. A fake cannot see a type
+# error. These drive the real statements through the substrate.
+
+def test_the_heartbeat_row_ROUND_TRIPS_through_real_sql(db):
+    beat = consumer.Heartbeat(FakeConsumer(), path="/dev/null")
+    hb = beat.payload()
+    db.record_heartbeat(hb)
+
+    got = db.read_heartbeat(now_ms=hb["written_at_ms"] + 4000)
+    assert got is not None
+    assert got["age_seconds"] == pytest.approx(4.0)
+    assert got["stream_connected"] is True
+    assert got["connections"] == 3
+    assert got["reconnects"] == 7
+    assert got["stored"] == 11
+    assert got["malformed"] == 5
+
+
+def test_a_heartbeat_WITH_a_last_frame_at_round_trips(db):
+    """🔴 THE REGRESSION. A non-null `last_frame_at` is exactly what the broken
+    column rejected — an idle consumer (None) wrote fine, so the defect appeared
+    only once the pipeline started working."""
+    c = FakeConsumer(last_frame_at=1723999999123)
+    hb = consumer.Heartbeat(c, path="/dev/null").payload()
+    db.record_heartbeat(hb)
+
+    got = db.read_heartbeat(now_ms=1723999999123 + 7000)
+    assert got["last_frame_at"] == 1723999999123
+    assert got["frame_age_seconds"] == pytest.approx(7.0)
+
+
+def test_the_row_is_UPSERTED_not_appended(db):
+    """One row by construction — the id=1 CHECK plus ON CONFLICT."""
+    beat = consumer.Heartbeat(FakeConsumer(), path="/dev/null")
+    for _ in range(4):
+        db.record_heartbeat(beat.payload())
+    assert db.conn.count("consumer_health") == 1
+
+
+def test_a_LATER_beat_ADVANCES_updated_at(db):
+    """Pins the ON CONFLICT SET. A mutant writing the OLD updated_at back leaves
+    the row frozen — which reads exactly like a dead consumer, forever."""
+    c = FakeConsumer()
+    first = consumer.Heartbeat(c, path="/dev/null", clock=lambda: 1000.0).payload()
+    db.record_heartbeat(first)
+    second = consumer.Heartbeat(c, path="/dev/null", clock=lambda: 1600.0).payload()
+    db.record_heartbeat(second)
+
+    got = db.read_heartbeat(now_ms=1600_000)
+    assert got["updated_at"] == 1600_000
+    assert got["age_seconds"] == pytest.approx(0.0)
+
+
+def test_the_COUNTERS_advance_on_a_later_beat(db):
+    """A frozen counter set reads as a wedged consumer; pin that they move."""
+    c = FakeConsumer(stored=1, reconnects=0)
+    db.record_heartbeat(consumer.Heartbeat(c, path="/dev/null").payload())
+    c.stats[consumer.STAT_STORED] = 42
+    c.stats[consumer.STAT_RECONNECTS] = 9
+    db.record_heartbeat(consumer.Heartbeat(c, path="/dev/null").payload())
+
+    got = db.read_heartbeat()
+    assert got["stored"] == 42
+    assert got["reconnects"] == 9
+
+
+def test_reading_a_health_row_that_was_NEVER_written_returns_None(db):
+    """And None must not read as healthy — the `WHERE id = 1` has to match."""
+    assert db.read_heartbeat() is None
+    assert consumer.heartbeat_is_fresh(None) is False
+
+
+def test_a_DISCONNECTED_beat_round_trips_as_FALSE(db):
+    """A boolean that always reads True would advertise a dead stream as live."""
+    hb = consumer.Heartbeat(FakeConsumer(stream_connected=False),
+                            path="/dev/null").payload()
+    db.record_heartbeat(hb)
+    assert db.read_heartbeat()["stream_connected"] is False
+
+
+# --------------------------------------------------------------------------- #
+# Gaps the audit found: paths that shipped with no executing test at all.
+
+def test_a_connection_that_delivers_NO_FRAMES_leaves_last_frame_at_None(db):
+    """🔴 THE discriminator between per-FRAME and per-CONNECT stamping.
+
+    `last_frame_at` is the field that separates "connected and fed nothing" from
+    "working". Hoisting the assignment out of the frame loop — so it stamps once
+    per CONNECT — survived a green run, because the only assertion was
+    `is not None` on a fixture that DID deliver frames. A zombie reconnect loop
+    would then report a fresh last_frame_at while ingesting nothing: exactly the
+    lie this field exists to prevent, told by the field itself.
+
+    Three connections, ZERO frames. Nothing may stamp it.
+    """
+    c = _consumer(db, Streams([], [], []))
+    c.run(max_connections=3)
+
+    assert c.connections == 3, "the fixture did not actually connect"
+    assert c.last_frame_at is None, (
+        "last_frame_at was stamped by CONNECTING, not by receiving a frame")
+
+
+def test_last_frame_at_IS_stamped_once_a_frame_arrives(db):
+    """POSITIVE CONTROL for the test above: it must be able to become non-None,
+    or `is None` would hold with the assignment deleted entirely."""
+    c = _consumer(db, Streams([_payload(1723950000001, "one")]))
+    c.run(max_connections=1)
+    assert c.last_frame_at is not None
+
+
+def test_health_FROM_DB_goes_through_MAIN_and_reads_the_ROW(db, tmp_path, monkeypatch, capsys):
+    """🟡 `--from-db` was the only CLI branch with ZERO coverage — a mutant
+    dropping `and not args.from_db`, so the flag silently read the FILE instead,
+    survived.
+
+    🔴 This drives `main()`, not `_report_health`. An earlier version of this
+    test called the reporter directly, which cannot see the dispatch condition
+    at all — it would have passed with the mutant in place. The file is
+    deliberately FRESH and the row deliberately ABSENT, so the two sources give
+    opposite answers and only the right one matches.
+    """
+    path = str(tmp_path / "hb.json")
+    monkeypatch.setattr(consumer, "HEARTBEAT_PATH", path)
+    consumer.Heartbeat(FakeConsumer(), path=path).tick()
+    assert consumer.read_heartbeat_file(path) is not None      # file says HEALTHY
+    assert db.read_heartbeat() is None                          # row says nothing
+
+    monkeypatch.setattr(consumer, "SignalDB", lambda *a, **kw: _CtxDB(db))
+
+    rc = consumer.main(["health", "--from-db"])
+    out = capsys.readouterr().out
+    assert rc == 1, "--from-db reported healthy off the FILE, not the row"
+    assert "no heartbeat (db)" in out
+
+
+def test_health_from_the_FILE_still_wins_when_both_exist(db, tmp_path, monkeypatch, capsys):
+    """The mirror: default mode must read the FILE even when a row exists.
+
+    Without this pair, a dispatch that always chose one source would pass one
+    test or the other, never both.
+    """
+    path = str(tmp_path / "hb.json")
+    monkeypatch.setattr(consumer, "HEARTBEAT_PATH", path)
+    consumer.Heartbeat(FakeConsumer(), path=path).tick()
+    monkeypatch.setattr(consumer, "SignalDB",
+                        lambda *a, **kw: (_ for _ in ()).throw(
+                            AssertionError("default health opened the database")))
+
+    assert consumer.main(["health"]) == 0
+    assert "(connected=True" in capsys.readouterr().out
+
+
+class _CtxDB:
+    def __init__(self, db): self._db = db
+    def __enter__(self): return self._db
+    def __exit__(self, *a): return False
+
+
+def test_main_gives_the_heartbeat_its_OWN_connection_not_the_ingest_one(monkeypatch):
+    """🔴 The one line encoding the rule `_signal_db` warns about in capitals:
+    beating on the ingest connection lands inside its open transaction. `main()`
+    is `# pragma: no cover`, so a mutant passing `db_factory=lambda: db` — the
+    exact hazard — survived, and the constraint was asserted only in prose."""
+    captured = {}
+
+    class SentinelDB:
+        """Stands in for the LIVE ingest connection main() opens."""
+        def ensure_schema(self): pass
+
+    sentinel_db = SentinelDB()
+
+    class FakeSignalDB:
+        def __enter__(self): return sentinel_db
+        def __exit__(self, *a): return False
+
+    class FakeHeartbeat:
+        def __init__(self, _consumer, *, db_factory=None, **kw):
+            captured["factory"] = db_factory
+        def start(self): return self
+        def stop(self): pass
+
+    monkeypatch.setattr(consumer, "SignalDB", FakeSignalDB)
+    monkeypatch.setattr(consumer, "Heartbeat", FakeHeartbeat)
+    monkeypatch.setattr(consumer, "ws_stream_factory", lambda acct: (lambda: iter(())))
+    monkeypatch.setattr(consumer, "http_attachment_fetcher", lambda: None)
+    monkeypatch.setattr(consumer, "_open_minio", lambda: None)
+    monkeypatch.setattr(consumer.SignalConsumer, "run", lambda self, **kw: {})
+
+    consumer.main(["run", "--account", "+15550000"])
+
+    factory = captured["factory"]
+    assert factory is not None, "the heartbeat was given no database at all"
+    assert callable(factory)
+    # 🔴 Assert what the factory YIELDS, not what the factory IS. Checking
+    # `factory is not sentinel_db` passes for `db_factory=lambda: db` — the
+    # exact hazard — because a lambda is a different object that hands back the
+    # ingest connection anyway. That weaker assertion let the mutant survive.
+    assert factory() is not sentinel_db, (
+        "main handed the heartbeat the LIVE ingest connection; beating on it "
+        "lands inside the ingest transaction (see _signal_db.record_heartbeat)")
+
+
+def test_a_NEGATIVE_age_is_not_fresh():
+    """A backwards clock step must not make an arbitrarily stale beat healthy."""
+    assert consumer.heartbeat_is_fresh(-5000.0, max_age=120) is False
+    assert consumer.heartbeat_is_fresh(-0.001, max_age=120) is False

--- a/scripts/signal/tests/test_skill_doc.py
+++ b/scripts/signal/tests/test_skill_doc.py
@@ -159,7 +159,10 @@ def test_skill_documents_every_table_the_schema_creates():
     import _signal_db
     tables = set(re.findall(r"CREATE TABLE IF NOT EXISTS signal\.(\w+)",
                             "\n".join(_signal_db.SCHEMA_STATEMENTS)))
-    assert len(tables) == 5, tables
+    # Bumped 5 -> 6 for signal.consumer_health (the liveness row). The literal
+    # is the POINT of this guard: a new table cannot appear without someone
+    # deciding, here, to document it.
+    assert len(tables) == 6, tables
     for table in tables:
         assert f"`signal.{table}`" in SKILL_TEXT, f"table {table} undocumented"
 


### PR DESCRIPTION
## Why

Measured, not theorised: `signal-consumer` serves no HTTP, declared no probes, and emitted **0 log lines** across 20h in which it successfully ingested 5 messages, 5 contacts, a group and 2 reactions.

So a pod reaching **nothing** and a pod working **perfectly** produced byte-identical observations, and the row count was the only health signal in existence. That is not a monitoring gap — it is the reason an empty table could not identify which of two rival mechanisms was true, and why the step-7 diagnosis cost hours instead of a glance.

## The one design constraint that shapes everything

🔴 **The heartbeat cannot live in the frame loop.** `run()` blocks in `for payload in iter_frames(...)` — on an idle account, for *hours*. A heartbeat written per frame would fire only when traffic exists, i.e. only in the case that never needed one. It runs on its own thread, and the test that matters asserts beats advance with **zero** frames.

## Two sinks, answering different questions

| sink | says | depends on |
|---|---|---|
| **file** | "this process's thread is still scheduled" | nothing external |
| **row** (`signal.consumer_health`) | "…and Postgres is reachable", plus counters | Postgres |

A DB outage degrades the row and leaves liveness intact. Keying restarts on Postgres reachability would turn a database blip into a restart storm against a consumer that was working fine — so only the file is a safe probe input.

The heartbeat opens its **own connection**: `SignalDB` runs `autocommit=False`, so beating on the ingest connection would land inside whatever transaction the ingest loop has open, committing a partial batch or being rolled back with it.

`last_frame_at` is recorded for **diagnosis** and is deliberately **not** a liveness input — an idle account legitimately sends nothing for hours, and silence feeding the probe would restart the pod every quiet weekend.

## 🔴 Two defects in my own work, both of which had passed

**1. A test that passed by timing luck.** The thread-survival test asserted on `ticks`, which counts *successful* writes — so once the sink was broken it could never grow. It was green only because a beat was in flight when the path was swapped. Fixed by splitting `attempts` (incremented *before* the I/O) from `ticks`. That's better instrumentation anyway: "trying" and "succeeding" are different facts, and telling them apart is the same working/dead distinction this module exists to make, one level down.

**2. The probe depended on Postgres.** `main()` runs every command inside `with SignalDB()`, which connects **and runs `ensure_schema()`** — so `consumer.py health` opened a database connection, reintroducing *in the CLI* the exact cascade the daemon was designed to avoid. Hoisted above the connection and pinned by a test that makes `SignalDB` **explode**: asserting the exit code alone passes with the dependency still present, invisible until the outage that matters.

## Verification

**18 mutants across two batteries, zero survivors, none deletion-only**, all under `PYTHONDONTWRITEBYTECODE=1`. Two required new tests to kill:

- `stream_connected` hardcoded `True` **survived** — every fixture set it `True`. The same fixture-equals-constant trap as #537, killed by feeding the value the constant cannot equal.
- setting the connected flag **before** the stream factory **survived** — which the code comment claimed mattered and nothing tested. A comment is a claim.

**Seam tests** drive a *real* consumer through `run()` and read it with a *real* `Heartbeat`. Everything else uses a fake, and the attribute names could otherwise drift apart with both halves green — the shape of the last defect shipped in this pipeline.

Gate: `RESULT: PASS (exit=0)` — 11,790 collected, 0 failed (signal 452/452).

## Not in this PR

The k8s probe wiring is a `homelab-infra` commit after an image rebuild. Its semantics, stated up front for review: **it restarts only a hung process** (stale heartbeat). It deliberately does *not* restart on a reconnect storm — that is visible in `reconnects` on the row, but automating a restart for it risks looping against an outage a restart cannot fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)