### PR TITLE
test(subsystem-store): de-flake the forged-attempt audit test — the response does NOT imply the log line

### DIFF
--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -3495,12 +3495,41 @@ class TestTrustedProxyOverTheRealProcess:
         failed auth and gets a real lockout — of ITSELF. The property is only
         ever about WHOSE bucket.
         """
+        import time
+
+        # 🔴 WAIT FOR THE AUDIT LINES; DO NOT ASSUME THE RESPONSE IMPLIES THEM.
+        # `_reject()` calls `self._unauthorized()` and only THEN `self._audit()`,
+        # and this is a ThreadingHTTPServer — so `fetch_from` returning means the
+        # response was written, NOT that the handler thread has reached its
+        # `print`. Terminating on the client's return therefore raced the 5th
+        # line and killed the process before it was emitted.
+        #
+        # Measured before this fix, on an UNMODIFIED tree: 3/20 red locally and
+        # two consecutive reds in the nix sandbox, always the same
+        # `assert 4 == 5` with four identical audit lines. It is a real race in
+        # the TEST, not in the server, and re-running it was the wrong answer:
+        # a ~15% flaky gate is the thing that teaches everyone to click through
+        # a red run.
+        #
+        # A reader thread drains stdout while the process runs, so the wait is
+        # on the OBSERVABLE condition. Draining also stops the pipe buffer from
+        # ever becoming a second timing dependency. Teardown in
+        # `running_subprocess` does the terminate/wait.
+        lines: list[str] = []
+
+        def _drain() -> None:
+            for raw in proc.stdout:                     # ends when the pipe closes
+                if raw.startswith("store-api audit "):
+                    lines.append(raw.rstrip("\n"))
+
         with running_subprocess(
             store,
             token_file,
             trusted_proxies=f"{TRUSTED_PEER}/32",
             host=TRUSTED_PEER,
         ) as (base, proc):
+            reader = threading.Thread(target=_drain, daemon=True)
+            reader.start()
             for _ in range(5):
                 fetch_from(
                     UNTRUSTED_PEER,
@@ -3509,10 +3538,10 @@ class TestTrustedProxyOverTheRealProcess:
                     token="w" * 48,
                     client_ip=SPOOF_IP,
                 )
-            proc.terminate()
-            stdout, _err = proc.communicate(timeout=15)
-        lines = [ln for ln in stdout.splitlines() if ln.startswith("store-api audit ")]
-        assert len(lines) == 5, stdout
+            deadline = time.time() + 15
+            while len(lines) < 5 and time.time() < deadline:
+                time.sleep(0.02)
+        assert len(lines) == 5, lines
         # 🔴 THE ASSERTION THAT IS THE WHOLE DEFECT: the forged address never
         # becomes an identity. A fix that recorded the spoofed value but declined
         # to COUNT it would pass every status check and fail this one.


### PR DESCRIPTION
## The measurement

`test_THE_DEFECT_the_five_forged_attempts_are_CHARGED_TO_THE_FORGER` fails ~15% of the time on `main`. Measured on an **unmodified** tree, not inferred:

- **3/20** locally
- two consecutive reds in the nix sandbox

Always the identical signature: `assert 4 == 5`, with four otherwise-correct audit lines.

## Root cause — in the test, not the server

`_reject()` calls `self._unauthorized()` and only **then** `self._audit()` (`server.py:1355-1356`), and this is a `ThreadingHTTPServer`. So `fetch_from` returning proves the **response** was written — *not* that the handler thread reached its `print`.

The test called `proc.terminate()` on the client's return, killing the process before the fifth line was emitted. Nothing is wrong with the audit logic: `audit` already flushes on every line.

## The fix

Wait for the **observable condition** rather than assuming it. A reader thread drains stdout while the process runs, and the test polls until five audit lines exist. Draining also removes the pipe buffer as a second latent timing dependency. `running_subprocess`'s teardown still does the terminate/wait, so the explicit one in the test is gone.

🔴 **The assertions are untouched** — only *when* the log is read changed.

## Both controls, because de-racing a test can silently defang it

| control | result |
|---|---|
| **stability** | **0/30** failures after (3/20 before) |
| **can it still go red?** | with `_peer_trusted = True` — trust every peer, i.e. the defect this test exists to catch — it **fails** at the `ip=SPOOF_IP` assertion, and passes again when restored |

A test that could no longer detect the defect would have been a worse outcome than the flake, so the second control is the one that matters.

## Why fix rather than re-run

This surfaced while attributing a red gate on an unrelated branch (#540). Re-running until green would have left a ~15% flaky gate on `main` for everyone — which is the failure mode where a red run stops meaning anything, and the next *real* failure gets clicked through too.

Gate: `NIX BUILD EXIT: 0` **and** `RESULT: PASS (exit=0)` — 11,758 collected, 0 failed, `scripts/tests` 5245/5245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)