### PR TITLE
fix(signal): acknowledge `health` in build-push control 3, and pin the list to the CLI

### DIFF
--- a/scripts/signal/build-push.sh
+++ b/scripts/signal/build-push.sh
@@ -225,7 +225,11 @@ fi
 choices=$(docker run --rm --entrypoint python3 "$IMAGE" \
             /app/scripts/signal/consumer.py --help \
           | tr ' ' '\n' | grep -o '{[a-z,]*}' | head -1 | tr -d '{}' | tr ',' '\n' | sort | tr '\n' ' ')
-want_choices="approve conversations draft drafts reconcile run search send "
+# `health` added 2026-08-18 with the liveness heartbeat (#540). Acknowledged
+# deliberately, as this control demands: it is READ-ONLY — it reads the local
+# heartbeat file (or, with --from-db, the health row) and exits 0/1. It
+# transmits nothing, writes nothing, and is what the k8s liveness probe runs.
+want_choices="approve conversations draft drafts health reconcile run search send "
 if [[ "$choices" != "$want_choices" ]]; then
   echo "build-push: REFUSING TO PUSH — subcommand set is '$choices'," >&2
   echo "            expected '$want_choices'. Empty means the parse found no {…}" >&2

--- a/scripts/signal/tests/test_image_deps.py
+++ b/scripts/signal/tests/test_image_deps.py
@@ -312,3 +312,59 @@ def test_tests_are_not_part_of_the_runtime_module_set():
     assert (SIGNAL_DIR / "tests").is_dir(), (
         "HARNESS BROKEN: there is no tests/ directory, so the exclusion above "
         "proves nothing")
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 The build's subcommand control and the CLI must agree — pinned BOTH ways.
+#
+# `build-push.sh` control 3 compares the image's argparse choices against a
+# hardcoded `want_choices` set, and REFUSES TO PUSH on any difference, including
+# an addition. That is the right design — a new operator subcommand is a
+# decision about what the pod can be told to do — but nothing kept the list in
+# sync with the parser, so the two could drift apart silently and the mismatch
+# only surfaced at BUILD time, after the code had merged. Adding `health` in
+# #540 hit exactly that: a green gate, then a refused push.
+#
+# This closes it at the gate instead. It fails when the CLI grows or loses a
+# subcommand without the control being updated, AND when the control lists one
+# the CLI does not have.
+
+def _build_push_want_choices() -> set[str]:
+    import re
+    text = (Path(__file__).resolve().parents[1] / "build-push.sh").read_text(
+        encoding="utf-8")
+    m = re.search(r'^want_choices="([^"]*)"', text, re.MULTILINE)
+    assert m, "build-push.sh has no want_choices line — the control was renamed"
+    return set(m.group(1).split())
+
+
+def _cli_subcommands() -> set[str]:
+    import consumer
+    parser = consumer.build_parser()
+    for action in parser._actions:
+        if getattr(action, "choices", None) and hasattr(action, "_name_parser_map"):
+            return set(action.choices)
+    raise AssertionError("no subparser action found on the CLI parser")
+
+
+def test_the_build_control_lists_EXACTLY_the_CLI_subcommands():
+    want = _build_push_want_choices()
+    have = _cli_subcommands()
+    assert want == have, (
+        f"build-push.sh control 3 and consumer.py disagree.\n"
+        f"  only in build-push.sh: {sorted(want - have)}\n"
+        f"  only in the CLI:       {sorted(have - want)}\n"
+        f"Update want_choices in build-push.sh — deliberately: that control "
+        f"exists so a new subcommand is an explicit decision about what the "
+        f"pod can be told to do.")
+
+
+def test_the_two_way_pin_is_reading_REAL_data_not_empty_sets():
+    """Positive control. Two empty sets compare equal, so the test above would
+    pass with both readers wired to nothing — the failure mode its own subject
+    (control 3) documents as 'Empty means the parse found no {…} token at all'."""
+    want = _build_push_want_choices()
+    have = _cli_subcommands()
+    assert len(want) >= 8, want
+    assert len(have) >= 8, have
+    assert "run" in have and "health" in have


### PR DESCRIPTION
## 🔴 DO NOT MERGE YET — the authoritative gate could not run

`nix build .#checks.x86_64-linux.pytests` did not complete: the workbench sat at **load 138–146** throughout (other sessions; 43 accumulated worktrees; memory fine, no OOM). Foreground hit the 600s cap; background runs were killed three times.

| | |
|---|---|
| **ran** | `scripts/signal/tests` **473/473**, plus the negative control below |
| **not run** | the full gate |

The only affected target is `scripts/signal/tests`, and the sibling-file read the new test uses is proven present in the sandbox (an earlier gate log shows patchShebangs touching `src/scripts/signal/build-push.sh`). But **"the gate could not run" is not "the gate passed"**, so this is pushed rather than merged.

**To finish it:**
```bash
git fetch origin && git checkout fix/signal-build-push-health-subcommand
nix build .#checks.x86_64-linux.pytests --no-link   # read the RESULT: line, not the exit code
```

## What this fixes

The 0.1.2 build **refused to push**. Control 3 compares the image's argparse choices against a hardcoded `want_choices` set and rejects any difference, additions included — working exactly as designed. Its own comment says a new operator subcommand is a decision about what the pod can be told to do, so `health` is acknowledged explicitly, with why it is safe: **read-only**, reads the local heartbeat file (or the health row with `--from-db`), exits 0/1, transmits nothing, and is what the k8s liveness probe runs.

## 🔴 The real gap: a pinned list only a *build* could check

Nothing kept `want_choices` in sync with the parser. The gate was green, #540 merged, and the mismatch surfaced only at **build** time — after the decision point had passed. That makes it a declaration, not an enforced invariant.

So this adds a **two-way pin** in `test_image_deps.py`: it fails when the CLI grows or loses a subcommand without the control being updated, **and** when the control names one the CLI lacks. With a positive control, because two empty sets compare equal — the test would otherwise pass with both readers wired to nothing, which is the precise failure control 3 documents for itself (*"Empty means the parse found no {…} token at all"*).

Verified it goes red on exactly the drift it pins: removing `health` from the list fails the new test.

## Blocked chain behind this

0.1.2 cannot be built until this merges, so the heartbeat is not deployed. The cluster runs **0.1.1**, which is coherent — it has the reaction fix and simply lacks the heartbeat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)