### PR TITLE
fix(browser-bridge): 6,937 telemetry rows in 14d had an EMPTY session column — the value was already on the wire

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -1411,7 +1411,7 @@ as `X-Session-Id`. Right for routing and the audit trail; **wrong** for the
 `session` column, which means *the agent session that issued this command*. Left
 alone, one `browser agent "<goal>"` call would become N browser calls credited to
 the operator's own session — a fabricated usage number in the exact column
-`adoption-scan.py` reads (~581 nested rows in 14d, ~11% of bridge commands).
+`session` JOIN column (~581 nested rows in 14d, ~11% of bridge commands).
 
 So the nested tool declares `X-Session-Origin: browser-agent`. When that header is
 present the server writes **no** `session`; the forwarded id is recorded as
@@ -1435,7 +1435,7 @@ assignment is therefore not specific to whichever of the two you land on.
 So inside opencode that variable names an **ancestor**, not the session issuing
 the command. A plain `opencode run …` whose bash tool shells out to `browser`
 would otherwise have the bridge credit the **outer** Claude session with browser
-usage it never performed — in the column `adoption-scan` and the deadman read.
+usage it never performed.
 
 **🔴 The id is indistinguishable from a direct call.** There is nothing in it to
 branch on: it *is* the outer session's id, correctly tagged `claude:`. So the
@@ -1490,8 +1490,25 @@ source.
   zero rows, which reads as a valid "no sessions matched" answer.
 - An id over 200 chars or carrying a control character is **dropped whole**, never
   truncated — a truncated join key is a *wrong* join key.
-- Server-originated events (the heartbeat, `/whoami`, `/health`) carry **none** of
-  these fields: they have no caller session to attribute.
+- **Only the heartbeat** is server-originated and carries none of these fields.
+  `/whoami` and `/health` are **operator** calls — `browser whoami` / `browser
+  health` are subcommands a person runs, and the CLI sends its ordinary session
+  headers on them because `_curl` is one code path — so they are attributed like
+  any other command. They were previously excluded on the stated grounds of
+  having "no caller session", which was false for these two and made ONE
+  operation have TWO outcomes: `whoami` via POST `/cmd` was attributed, the same
+  `whoami` via GET was not (125 rows, 2.0% of `kind='cmd'` over 14d).
+- Both header vocabularies are **validated closed sets**, not documentation. A
+  `sess_src` tag outside the tier list becomes `unknown` and carries no id; an
+  `origin` outside the two tokens is recorded as `invalid`. Both arrive on
+  caller-supplied headers, so without this each is an unbounded-cardinality
+  column.
+- **Origin suppression keys off header PRESENCE, never the value.** Any present
+  value — including empty, oversized or control-char — suppresses `session`.
+  Losing attribution beats fabricating it.
+- `origin_session` passes the **same tier gate** as `session`: a non-joinable
+  parent id (`tmux:`/`sid:`/`ppid:`) is not recorded, because a reader grouping by
+  it would merge unrelated sessions exactly as they would on `session`.
 - `kind='cmd'` is unchanged — it is the usage signal `adoption-scan.py` reads.
 - Best-effort is unchanged: every field above is written inside `emit_cmd_event`'s
   swallowing `try`, off the critical path.
@@ -1501,14 +1518,57 @@ one: the agent session's own opaque handle is not page content, is not derived
 from anything the browser saw, and is minted by the local agent harness before
 any browser command exists. It says *who asked*, never *what was browsed*.
 
-**Example — sessions that used both opencode and the browser skill:**
+### What this makes answerable — and what it does not
+
+**Answerable now — which Claude sessions used the browser skill, and how much:**
 
 ```sql
-SELECT session, count() AS browser_calls
+SELECT session, count() AS browser_calls,
+       min(ts) AS first_call, max(ts) AS last_call
 FROM activity.events
 WHERE source = 'browser-bridge' AND kind = 'cmd' AND session != ''
-  AND session IN (SELECT DISTINCT session FROM activity.events WHERE source = 'opencode')
-GROUP BY session ORDER BY browser_calls DESC
+GROUP BY session
+ORDER BY browser_calls DESC
+```
+
+`session` holds the bare Claude session uuid, so it joins straight against
+`source='claude'` rows — same column, same values, no transform:
+
+```sql
+SELECT count(DISTINCT session) AS joinable_browser_sessions
+FROM activity.events
+WHERE source = 'browser-bridge' AND kind = 'cmd' AND session != ''
+  AND session IN (SELECT DISTINCT session FROM activity.events WHERE source = 'claude')
+```
+
+🔴 **NOT answerable yet — "which sessions used opencode AND the browser skill".**
+That was this change's motivating question and it is still open, for two
+independent reasons, either of which alone is fatal:
+
+1. **The id spaces are disjoint.** `source='opencode'` sessions are `ses_`-prefixed
+   opencode ids; `source='claude'` sessions are uuids. Measured over 14 days: 406
+   distinct claude sessions, 183 distinct opencode sessions, **overlap 0**. A query
+   joining `browser-bridge.session` against opencode's `session` cannot match — and
+   it fails as a **silent empty result**, which reads exactly like a truthful
+   "no sessions matched".
+2. **Those calls deliberately carry no `session`.** A browser call issued from
+   inside opencode is the leak case above: it is marked with
+   `origin='opencode-inherited'` and attributed to nobody.
+
+An earlier draft of this README shipped exactly that broken join as its flagship
+example. It is replaced rather than annotated, because a wrong query that returns
+zero rows is worse than no query.
+
+**What would make it answerable:** the follow-up `shell.env` hook exporting
+`OPENCODE_SESSION_ID`, which gives nested runs a joinable `opencode:` tier of
+their own. Until then, use `origin='opencode-inherited'` to *count* opencode-driven
+browser usage — you can see how much there is, just not whose:
+
+```sql
+SELECT JSONExtractString(toString(payload), 'origin') AS origin, count()
+FROM activity.events
+WHERE source = 'browser-bridge' AND kind = 'cmd'
+GROUP BY origin ORDER BY count() DESC
 ```
 
 ## Session isolation (concurrent-session tab clobbering)

--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -1397,6 +1397,7 @@ would be, and is forbidden.
 | `sid:<sid>:<start>` | `sid` | no | no other source records it |
 | `ppid:<pid>:<rand>` | `ppid` | no | last-resort random token |
 | `synthetic:…` | `synthetic` | no | an id the CLI made up on purpose (the `emulate --recreate` close) |
+| `oc-inherited:<uuid>` | `oc-inherited` | no | a `CLAUDE_CODE_SESSION_ID` that **leaked into an opencode tool shell** — it names an ancestor, not the caller (see below) |
 | anything untagged, absent, or empty | `unknown` | no | fail closed |
 
 Only the **first** colon splits (a `sid:`/`ppid:` id contains more). An id with no
@@ -1417,6 +1418,49 @@ So the nested tool declares `X-Session-Origin: browser-agent`. When that header 
 present the server writes **no** `session`; the forwarded id is recorded as
 `payload.origin_session` (the causal **parent**) beside `payload.origin`. Giving
 the nested session an id of its own is a later change.
+
+### Hazard 3 — `CLAUDE_CODE_SESSION_ID` leaks into opencode
+
+opencode 1.18.18 sets `process.env.OPENCODE="1"` in a yargs **top-level
+`.middleware()`** — registered before every `.command(...)`, so it runs for every
+subcommand — and hands its tool shells `{...process.env}`. Launch opencode from a
+Claude Code bash call and the outer session's `CLAUDE_CODE_SESSION_ID` rides all
+the way down: a live env dump from inside an opencode bash tool still had it.
+
+So inside opencode that variable names an **ancestor**, not the session issuing
+the command. A plain `opencode run …` whose bash tool shells out to `browser`
+would otherwise hit the joinable tier on the leaked value, and the server would
+write the outer Claude session's uuid into `session` — where those rows are
+**indistinguishable from that session's own direct browser use**. There is no
+`X-Session-Origin` on that path; that header is only sent by
+`browser_tool_impl.mjs` on the browser-agent path.
+
+`derive_session_id` therefore **re-tags** a leaked id `oc-inherited:` whenever
+`OPENCODE` is set. Re-tagging, not re-deriving, is the point:
+
+- the underlying value is unchanged, so the id stays **stable** across the many
+  `browser` calls one opencode session makes and per-session tab ownership still
+  works (asserted through the same `$( … )` subshell probe as the joinable path);
+- the tier is not joinable, so `session` stays **empty** — exactly as it is today
+  for these rows. Empty is recoverable; plausible-but-wrong is not;
+- `payload.sess_src = "oc-inherited"` still records that it happened, so the
+  population is **measurable** rather than invisible.
+
+Two consequences, stated rather than buried:
+
+- **Unchanged degradation.** Two concurrent opencode sessions launched from one
+  Claude session still resolve to the same id and share a tab. That is today's
+  behaviour, not a new one; `--tab` is the escape hatch.
+- **Routing does change in one place.** An opencode-inner call no longer shares
+  tab ownership with its *outer* Claude session (different id ⇒ different owner),
+  so it falls back to the active tab rather than the outer session's owned tab.
+  That separation is inherent to any re-tagging fix, and is the intended
+  isolation.
+
+**This guard is temporary.** A follow-up adds an opencode `shell.env` plugin hook
+exporting `OPENCODE_SESSION_ID`; once nested runs have a key of their own,
+`derive_session_id` gains a joinable `opencode:` tier above the guard and the
+guard retires. The slot is marked in the source.
 
 ### Contract
 

--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -1397,7 +1397,6 @@ would be, and is forbidden.
 | `sid:<sid>:<start>` | `sid` | no | no other source records it |
 | `ppid:<pid>:<rand>` | `ppid` | no | last-resort random token |
 | `synthetic:…` | `synthetic` | no | an id the CLI made up on purpose (the `emulate --recreate` close) |
-| `oc-inherited:<uuid>` | `oc-inherited` | no | a `CLAUDE_CODE_SESSION_ID` that **leaked into an opencode tool shell** — it names an ancestor, not the caller (see below) |
 | anything untagged, absent, or empty | `unknown` | no | fail closed |
 
 Only the **first** colon splits (a `sid:`/`ppid:` id contains more). An id with no
@@ -1421,46 +1420,64 @@ the nested session an id of its own is a later change.
 
 ### Hazard 3 — `CLAUDE_CODE_SESSION_ID` leaks into opencode
 
-opencode 1.18.18 sets `process.env.OPENCODE="1"` in a yargs **top-level
-`.middleware()`** — registered before every `.command(...)`, so it runs for every
-subcommand — and hands its tool shells `{...process.env}`. Launch opencode from a
-Claude Code bash call and the outer session's `CLAUDE_CODE_SESSION_ID` rides all
-the way down: a live env dump from inside an opencode bash tool still had it.
+opencode sets `process.env.OPENCODE="1"` in a yargs **top-level `.middleware()`**
+— registered before every `.command(...)`, so it runs for every subcommand — and
+hands its tool shells `{...process.env}`. Launch opencode from a Claude Code bash
+call and the outer session's `CLAUDE_CODE_SESSION_ID` rides all the way down: a
+live env dump from inside an opencode bash tool still had it.
+
+Derived against the **pinned** build (`PINNED_VERSION` in
+`scripts/tests/test_opencode_engine.py`) — named rather than copied so it cannot
+go stale — and confirmed byte-identical in the newer build on this host's own
+profile, which is the one a real `opencode run` here actually executes. The
+assignment is therefore not specific to whichever of the two you land on.
 
 So inside opencode that variable names an **ancestor**, not the session issuing
 the command. A plain `opencode run …` whose bash tool shells out to `browser`
-would otherwise hit the joinable tier on the leaked value, and the server would
-write the outer Claude session's uuid into `session` — where those rows are
-**indistinguishable from that session's own direct browser use**. There is no
-`X-Session-Origin` on that path; that header is only sent by
-`browser_tool_impl.mjs` on the browser-agent path.
+would otherwise have the bridge credit the **outer** Claude session with browser
+usage it never performed — in the column `adoption-scan` and the deadman read.
 
-`derive_session_id` therefore **re-tags** a leaked id `oc-inherited:` whenever
-`OPENCODE` is set. Re-tagging, not re-deriving, is the point:
+**🔴 The id is indistinguishable from a direct call.** There is nothing in it to
+branch on: it *is* the outer session's id, correctly tagged `claude:`. So the
+server cannot tell the two apart by inspection — the caller has to say so.
 
-- the underlying value is unchanged, so the id stays **stable** across the many
-  `browser` calls one opencode session makes and per-session tab ownership still
-  works (asserted through the same `$( … )` subshell probe as the joinable path);
-- the tier is not joinable, so `session` stays **empty** — exactly as it is today
-  for these rows. Empty is recoverable; plausible-but-wrong is not;
-- `payload.sess_src = "oc-inherited"` still records that it happened, so the
-  population is **measurable** rather than invisible.
+That is the **same question** `browser agent` already answers (hazard 2), so it
+gets the **same mechanism**: `X-Session-Id` is left completely alone and the
+nested-run fact travels beside it.
 
-Two consequences, stated rather than buried:
+```
+X-Session-Id:     claude:<uuid>        # unchanged — routing, ownership, not_owned_tab
+X-Session-Origin: opencode-inherited   # this command was issued by something nested
+```
 
-- **Unchanged degradation.** Two concurrent opencode sessions launched from one
-  Claude session still resolve to the same id and share a tab. That is today's
-  behaviour, not a new one; `--tab` is the escape hatch.
-- **Routing does change in one place.** An opencode-inner call no longer shares
-  tab ownership with its *outer* Claude session (different id ⇒ different owner),
-  so it falls back to the active tab rather than the outer session's owned tab.
-  That separation is inherent to any re-tagging fix, and is the intended
-  isolation.
+`origin` is a two-value enum — `browser-agent` | `opencode-inherited` — both
+meaning "issued by something nested under `origin_session`", which is precisely
+true of both cases. The server needed **no change**: the origin path already
+suppresses `session` and records `payload.origin` + `payload.origin_session`.
 
-**This guard is temporary.** A follow-up adds an opencode `shell.env` plugin hook
-exporting `OPENCODE_SESSION_ID`; once nested runs have a key of their own,
-`derive_session_id` gains a joinable `opencode:` tier above the guard and the
-guard retires. The slot is marked in the source.
+Why this beats re-tagging the id, which was tried first and rejected:
+
+- **Routing is byte-identical.** Tab ownership, `--tab`, `not_owned_tab` and the
+  `$( … )` stability property are untouched, because the id is untouched. A
+  re-tagged id would have silently stopped an opencode-inner call from sharing
+  ownership with its outer session. The equivalence is now machine-checked: the
+  id is derived with and without `OPENCODE` and both must equal the same pinned
+  literal.
+- **One question, one mechanism.** Two ways to say "this is nested" inside one
+  system is a defect regardless of which is better in isolation.
+- It reuses a path that is already tested, rather than adding a parallel one.
+
+The origin is declared only when a Claude id was **actually inherited** — the
+condition reads the *derived* id (`claude:*`) rather than re-testing the env
+vars, so it cannot drift out of step with the precedence chain. An opencode
+session run interactively with no Claude ancestor derives `tmux:`/`sid:`/`ppid:`,
+declares nothing, and behaves exactly as it does today.
+
+**This is temporary.** A follow-up adds an opencode `shell.env` hook exporting
+`OPENCODE_SESSION_ID`; `derive_session_id` then gains a **joinable** `opencode:`
+tier, nested runs get a key of their own, the `claude:*` case stops matching on
+its own, and the token becomes dead code to delete. The slot is marked in the
+source.
 
 ### Contract
 

--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -1364,9 +1364,91 @@ unchanged.
 distinct `{"event":"throttled","key":…,"reason":…,"sess":…}` line AND emits a
 telemetry event (`outcome="throttled"`, `payload.reason`) into `activity.events`.
 `payload.sess` is a **coarse, non-reversible** fingerprint (first 8 hex of
-sha256 of the `X-Session-Id`) — enough to attribute a flood to a session without
-storing the raw id, kept metadata-only (no page content). This is the ONLY event
-that carries the session hash.
+sha256 of the `X-Session-Id`), kept metadata-only (no page content). This is the
+ONLY event that carries the session hash.
+
+`sess` was **kept** when the `session` join key landed (below) rather than
+replaced by it: the column is filled for the `claude:` tier and non-nested calls
+only, so a flood driven from a `tmux:`/`sid:`/`ppid:`/untagged id — or from a
+nested `browser agent` run — is exactly the case where you still need *some*
+stable handle to tell one flooder from two.
+
+## Session as a telemetry join key
+
+**The bug (measured 2026-08-18).** Every `source='browser-bridge'` row in
+`activity.events` had an **empty `session` column** — 0 of 6,937 over 14 days —
+while `claude`, `opencode`, `keys`, `tmux` and `zsh` filled it 100%. The value
+already reached the server (`X-Session-Id`, used for tab-ownership routing); it
+was simply never passed to `emit_cmd_event`. So a browser-skill call could not be
+joined to the agent session that made it, and "which sessions used the browser
+skill" had to be answered by scanning 1.5M transcript records.
+
+### Hazard 1 — only one tier is a join key
+
+The id is **tagged** with the tier that produced it (everything before the first
+`:`), and the server reads that tag. Reading a tag the CLI emits on purpose is not
+shape inference; deciding from the value's *form* ("looks like a uuid → claude")
+would be, and is forbidden.
+
+| `X-Session-Id` | `payload.sess_src` | fills `session`? | why |
+|---|---|---|---|
+| `claude:<uuid>` | `claude` | **yes** — the bare `<uuid>` | it IS Claude Code's session uuid, the same value `source='claude'` rows store |
+| `tmux:%3` | `tmux` | no | a pane id is stable across **many unrelated sessions**; storing it would silently merge them — worse than empty |
+| `sid:<sid>:<start>` | `sid` | no | no other source records it |
+| `ppid:<pid>:<rand>` | `ppid` | no | last-resort random token |
+| `synthetic:…` | `synthetic` | no | an id the CLI made up on purpose (the `emulate --recreate` close) |
+| anything untagged, absent, or empty | `unknown` | no | fail closed |
+
+Only the **first** colon splits (a `sid:`/`ppid:` id contains more). An id with no
+tag is **never** promoted — a bare uuid is exactly the value it would be tempting
+to accept, and the opencode tool's own default is the literal `browser-agent`.
+
+### Hazard 2 — a nested `browser agent` run is not its invoker
+
+`browser agent` captures the id of the session that **invoked** it
+(`--print-session-id`) and forwards it to the nested opencode tool, which sends it
+as `X-Session-Id`. Right for routing and the audit trail; **wrong** for the
+`session` column, which means *the agent session that issued this command*. Left
+alone, one `browser agent "<goal>"` call would become N browser calls credited to
+the operator's own session — a fabricated usage number in the exact column
+`adoption-scan.py` reads (~581 nested rows in 14d, ~11% of bridge commands).
+
+So the nested tool declares `X-Session-Origin: browser-agent`. When that header is
+present the server writes **no** `session`; the forwarded id is recorded as
+`payload.origin_session` (the causal **parent**) beside `payload.origin`. Giving
+the nested session an id of its own is a later change.
+
+### Contract
+
+- `payload.sess_src` is **always** set on a `/cmd` event, so every row is
+  self-describing about why it does or does not carry a key.
+- `session` holds the **bare** id (the tag stripped) so it compares `=` against
+  `source='claude'` rows with no `replaceOne()` at the join site.
+- Stored **raw, not hashed** — deliberately. A hash would make browser-bridge the
+  one source needing `hex(SHA256())` at query time, and a forgotten join returns
+  zero rows, which reads as a valid "no sessions matched" answer.
+- An id over 200 chars or carrying a control character is **dropped whole**, never
+  truncated — a truncated join key is a *wrong* join key.
+- Server-originated events (the heartbeat, `/whoami`, `/health`) carry **none** of
+  these fields: they have no caller session to attribute.
+- `kind='cmd'` is unchanged — it is the usage signal `adoption-scan.py` reads.
+- Best-effort is unchanged: every field above is written inside `emit_cmd_event`'s
+  swallowing `try`, off the critical path.
+
+**Privacy.** A deliberate widening of the metadata-only contract, and a narrow
+one: the agent session's own opaque handle is not page content, is not derived
+from anything the browser saw, and is minted by the local agent harness before
+any browser command exists. It says *who asked*, never *what was browsed*.
+
+**Example — sessions that used both opencode and the browser skill:**
+
+```sql
+SELECT session, count() AS browser_calls
+FROM activity.events
+WHERE source = 'browser-bridge' AND kind = 'cmd' AND session != ''
+  AND session IN (SELECT DISTINCT session FROM activity.events WHERE source = 'opencode')
+GROUP BY session ORDER BY browser_calls DESC
+```
 
 ## Session isolation (concurrent-session tab clobbering)
 
@@ -1389,6 +1471,10 @@ per-session (multi-step **workflow**) isolation did not.
   **routing only** and is **never** trusted for auth — bearer + Host still gate
   every request. If two sessions ever resolve the same id they share a tab
   (documented degradation — no worse than before).
+- 🔴 **The tier tag before the first `:` is load-bearing for telemetry too.**
+  `server.py` parses it to decide whether the id is a joinable session key — see
+  "Session as a telemetry join key" above. Adding a tier means deciding which it
+  is; never emit an id whose tag misdescribes it.
 - **⚠ Why the POSIX session id, and not `$PPID` (fixed 2026-08-01).** The
   PPID-keyed token was **not stable across a command substitution**: a `$( … )`
   that forks gives `browser` a different parent pid, so

--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -1410,8 +1410,8 @@ to accept, and the opencode tool's own default is the literal `browser-agent`.
 as `X-Session-Id`. Right for routing and the audit trail; **wrong** for the
 `session` column, which means *the agent session that issued this command*. Left
 alone, one `browser agent "<goal>"` call would become N browser calls credited to
-the operator's own session — a fabricated usage number in the exact column
-`session` JOIN column (~581 nested rows in 14d, ~11% of bridge commands).
+the operator's own session — fabricated rows in the `session` JOIN column
+(~581 nested rows in 14d, ~11% of bridge commands).
 
 So the nested tool declares `X-Session-Origin: browser-agent`. When that header is
 present the server writes **no** `session`; the forwarded id is recorded as
@@ -1520,7 +1520,14 @@ any browser command exists. It says *who asked*, never *what was browsed*.
 
 ### What this makes answerable — and what it does not
 
-**Answerable now — which Claude sessions used the browser skill, and how much:**
+**Answerable once this ships — which Claude sessions used the browser skill, and
+how much:**
+
+🔴 *"Once this ships", not "now": `session` is filled by code that is not
+deployed yet, so this returns **0 of 6,166** browser-bridge `kind='cmd'` rows
+today (measured over 14d). Merged is not deployed — every `home.file` target here
+changes only on a `home-manager switch`, and reading these queries as live before
+that is the same silent-empty-result trap the replaced query fell into.*
 
 ```sql
 SELECT session, count() AS browser_calls,

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -356,6 +356,46 @@ _session_from_proc() {
 }
 
 derive_session_id() {
+  # ---- FOLLOW-UP SLOT: a REAL opencode session id ------------------------- #
+  # An opencode `shell.env` plugin hook will export OPENCODE_SESSION_ID. When it
+  # lands, check it HERE — above the leak guard — and emit `opencode:$…` as a
+  # JOINABLE tier (opencode rows in activity.events carry that id already). That
+  # gives nested runs a key of their OWN and RETIRES the guard below, which only
+  # exists because there is nothing better to attribute them to today.
+  #
+  # ---- LEAK GUARD: CLAUDE_CODE_SESSION_ID is INHERITED, not ours ---------- #
+  # 🔴 opencode's CLI sets `process.env.OPENCODE="1"` in a yargs top-level
+  # `.middleware()` registered before every `.command(...)`, so it is set for
+  # EVERY subcommand, and its tool shells get `{...process.env}` — VERIFIED in
+  # the 1.18.18 bundle, and separately by a live env dump from inside an
+  # opencode bash tool. That dump also carried the OUTER Claude session's
+  # CLAUDE_CODE_SESSION_ID: launching opencode from a Claude Code bash call
+  # leaks the variable down, and it is STILL SET several processes deep.
+  #
+  # So inside opencode, `CLAUDE_CODE_SESSION_ID` names an ANCESTOR, not the
+  # session issuing the command. Claiming the `claude:` tier on it would make
+  # the server write the outer session's uuid into the telemetry `session`
+  # column, and those rows would be indistinguishable from that session's own
+  # direct browser use — in the column adoption-scan and the deadman read. The
+  # column is EMPTY today; empty is recoverable, plausible-but-wrong is not.
+  #
+  # Re-TAG rather than re-derive: the underlying value is unchanged, so the id
+  # stays stable across the many `browser` calls one opencode session makes and
+  # per-session tab ownership still works. `oc-inherited:` is not a joinable
+  # tier, so the server writes no session key while `payload.sess_src` still
+  # records that this happened — the population stays MEASURABLE instead of
+  # silently reverting to invisible.
+  # KNOWN, UNCHANGED DEGRADATION: two concurrent opencode sessions launched from
+  # ONE Claude session still resolve to the same id and so share a tab. That is
+  # exactly today's behaviour, not a new one; `--tab` is the escape hatch.
+  # ROUTING CONSEQUENCE, stated plainly: an opencode-inner call no longer shares
+  # ownership with its OUTER Claude session (different id ⇒ different owner), so
+  # it falls back to the active tab instead of the outer session's owned tab.
+  # That separation is inherent to re-tagging and is the intended isolation.
+  if [ -n "${OPENCODE:-}" ]; then
+    local leaked="${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
+    if [ -n "$leaked" ]; then printf 'oc-inherited:%s' "$leaked"; return; fi
+  fi
   if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then printf 'claude:%s' "$CLAUDE_CODE_SESSION_ID"; return; fi
   if [ -n "${CLAUDE_SESSION_ID:-}" ];      then printf 'claude:%s' "$CLAUDE_SESSION_ID"; return; fi
   if [ -n "${TMUX_PANE:-}" ];              then printf 'tmux:%s' "$TMUX_PANE"; return; fi

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -268,7 +268,15 @@ die() { echo "browser: $*" >&2; exit 1; }
 # `bash` process, so it must come from the environment / process tree, not shell
 # state). Sent as X-Session-Id on every /cmd so the server can route this session
 # to its OWN owned tab. Namespaced by source so ids from different sources can't
-# collide. Fallback chain (most→least reliable), documented in README/SKILL:
+# collide.
+# 🔴 THAT NAMESPACE TAG — everything before the FIRST `:` — IS LOAD-BEARING
+# BEYOND COLLISION AVOIDANCE. server.py parses it to decide whether the id is a
+# joinable key for activity telemetry: `claude:` is Claude Code's own session
+# uuid (the same value `source='claude'` rows store, so it JOINS), while
+# `tmux:`/`sid:`/`ppid:` are not — a pane id like %3 is stable across many
+# UNRELATED sessions and recording it as a session key would silently merge
+# them. Do not add a tier without deciding which of those it is, and never emit
+# an id whose tag misdescribes it (see the recreate-close re-tag below). Fallback chain (most→least reliable), documented in README/SKILL:
 #   1. CLAUDE_CODE_SESSION_ID — Claude Code's own session UUID (present since the
 #      2.1.x CLI; verified stable across every Bash-tool call in a session). Best.
 #   2. CLAUDE_SESSION_ID — defensive alternate spelling, in case a CLI build
@@ -1194,8 +1202,17 @@ print(t)
   # both empty, the new tab id lost). The `$( … )` confines the exit to a
   # subshell, so `close_ok="false"` / `closeError` / `closedOldTab:false` are live
   # code paths rather than the dead ones they used to be.
+  #
+  # 🔴 THE THROWAWAY ID IS RE-TAGGED, not just suffixed. The id carries an
+  # explicit TIER TAG before its first `:` (claude:/tmux:/sid:/ppid: — see
+  # derive_session_id), and server.py reads that tag to decide whether the id is
+  # a joinable session key for activity telemetry. Appending alone would leave a
+  # fabricated value still wearing the live session's `claude:` tag, and the
+  # bridge would store it in the `session` column as a near-duplicate of the real
+  # key. `synthetic:` is not a joinable tier, so nothing is attributed. Routing is
+  # unaffected: all this id has to be is DIFFERENT from ours, which it still is.
   local close_ok="true" close_err="" saved_sid="$SESSION_ID" close_rc close_stderr
-  SESSION_ID="${SESSION_ID}+recreate-close"
+  SESSION_ID="synthetic:${SESSION_ID}+recreate-close"
   TAB="$old_tab"
   close_stderr="$( cmd_op close 2>&1 >/dev/null )"; close_rc=$?
   if [ "$close_rc" -ne 0 ]; then

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -356,46 +356,6 @@ _session_from_proc() {
 }
 
 derive_session_id() {
-  # ---- FOLLOW-UP SLOT: a REAL opencode session id ------------------------- #
-  # An opencode `shell.env` plugin hook will export OPENCODE_SESSION_ID. When it
-  # lands, check it HERE — above the leak guard — and emit `opencode:$…` as a
-  # JOINABLE tier (opencode rows in activity.events carry that id already). That
-  # gives nested runs a key of their OWN and RETIRES the guard below, which only
-  # exists because there is nothing better to attribute them to today.
-  #
-  # ---- LEAK GUARD: CLAUDE_CODE_SESSION_ID is INHERITED, not ours ---------- #
-  # 🔴 opencode's CLI sets `process.env.OPENCODE="1"` in a yargs top-level
-  # `.middleware()` registered before every `.command(...)`, so it is set for
-  # EVERY subcommand, and its tool shells get `{...process.env}` — VERIFIED in
-  # the 1.18.18 bundle, and separately by a live env dump from inside an
-  # opencode bash tool. That dump also carried the OUTER Claude session's
-  # CLAUDE_CODE_SESSION_ID: launching opencode from a Claude Code bash call
-  # leaks the variable down, and it is STILL SET several processes deep.
-  #
-  # So inside opencode, `CLAUDE_CODE_SESSION_ID` names an ANCESTOR, not the
-  # session issuing the command. Claiming the `claude:` tier on it would make
-  # the server write the outer session's uuid into the telemetry `session`
-  # column, and those rows would be indistinguishable from that session's own
-  # direct browser use — in the column adoption-scan and the deadman read. The
-  # column is EMPTY today; empty is recoverable, plausible-but-wrong is not.
-  #
-  # Re-TAG rather than re-derive: the underlying value is unchanged, so the id
-  # stays stable across the many `browser` calls one opencode session makes and
-  # per-session tab ownership still works. `oc-inherited:` is not a joinable
-  # tier, so the server writes no session key while `payload.sess_src` still
-  # records that this happened — the population stays MEASURABLE instead of
-  # silently reverting to invisible.
-  # KNOWN, UNCHANGED DEGRADATION: two concurrent opencode sessions launched from
-  # ONE Claude session still resolve to the same id and so share a tab. That is
-  # exactly today's behaviour, not a new one; `--tab` is the escape hatch.
-  # ROUTING CONSEQUENCE, stated plainly: an opencode-inner call no longer shares
-  # ownership with its OUTER Claude session (different id ⇒ different owner), so
-  # it falls back to the active tab instead of the outer session's owned tab.
-  # That separation is inherent to re-tagging and is the intended isolation.
-  if [ -n "${OPENCODE:-}" ]; then
-    local leaked="${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
-    if [ -n "$leaked" ]; then printf 'oc-inherited:%s' "$leaked"; return; fi
-  fi
   if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then printf 'claude:%s' "$CLAUDE_CODE_SESSION_ID"; return; fi
   if [ -n "${CLAUDE_SESSION_ID:-}" ];      then printf 'claude:%s' "$CLAUDE_SESSION_ID"; return; fi
   if [ -n "${TMUX_PANE:-}" ];              then printf 'tmux:%s' "$TMUX_PANE"; return; fi
@@ -461,6 +421,56 @@ done
 [ "$_sub_known" -eq 1 ] || die "unknown subcommand: ${1:-} (try: $SUBCOMMANDS)"
 
 SESSION_ID="$(derive_session_id)"
+
+# SESSION_ORIGIN — non-empty when THIS command was issued by something NESTED
+# under the session whose id we just derived. Sent as X-Session-Origin; the
+# bridge then records the id as `payload.origin_session` (the causal parent)
+# instead of as the issuing `session`. See server.py's HDR_SESSION_ORIGIN.
+#
+# ---- FOLLOW-UP SLOT: a REAL opencode session id ------------------------- #
+# An opencode `shell.env` plugin hook will export OPENCODE_SESSION_ID. When it
+# lands, `derive_session_id` gains a JOINABLE `opencode:` tier above its claude
+# branches (opencode rows in activity.events already carry that id), nested runs
+# get a key of their OWN, and the token below RETIRES — the `claude:*` case stops
+# matching on its own, so this becomes dead code to delete rather than logic to
+# unpick.
+#
+# ---- WHY: CLAUDE_CODE_SESSION_ID is INHERITED inside opencode ----------- #
+# 🔴 opencode's CLI sets `process.env.OPENCODE="1"` in a yargs TOP-LEVEL
+# `.middleware()` — registered before every `.command(...)`, so it runs for every
+# subcommand — and hands its tool shells `{...process.env}`. VERIFIED in the
+# PINNED bundle (named, not copied: PINNED_VERSION in
+# scripts/tests/test_opencode_engine.py) AND in the newer build on this host's
+# profile — the assignment is identical in both, so it is not pin-specific. And
+# separately by a live env dump from inside an opencode bash tool which still
+# carried the OUTER Claude session's CLAUDE_CODE_SESSION_ID:
+# launch opencode from a Claude Code bash call and the variable rides down, still
+# set several processes deep.
+#
+# So inside opencode that variable names an ANCESTOR, not the session issuing the
+# command. Left unmarked, a plain `opencode run …` whose bash tool shells out to
+# `browser` would have the bridge write the OUTER session's uuid into the
+# telemetry `session` column, where those rows are indistinguishable from that
+# session's own direct browser use. The column is EMPTY today: empty is
+# recoverable, plausible-but-wrong is not.
+#
+# 🔴 THE ID ITSELF IS NOT TOUCHED — that is the whole point of using the origin
+# header rather than a new tier. X-Session-Id stays byte-identical to what this
+# environment produced before any of this existed, so routing, per-session tab
+# ownership and the `not_owned_tab` semantics are unchanged. The nested-run fact
+# travels beside the id, exactly as it does for `browser agent`
+# (X-Session-Origin: browser-agent, sent by opencode/tools/browser_tool_impl.mjs)
+# — ONE mechanism for one question.
+#
+# The `claude:*` case is what keeps this honest, and it is read off the DERIVED
+# id rather than re-testing the env vars, so it cannot drift out of step with the
+# precedence chain above. An opencode session with NO Claude ancestor (run
+# interactively) derives `tmux:`/`sid:`/`ppid:` — nothing was inherited, so no
+# origin is declared and the row behaves exactly as it does today.
+SESSION_ORIGIN=""
+case "$SESSION_ID" in
+  claude:*) if [ -n "${OPENCODE:-}" ]; then SESSION_ORIGIN="opencode-inherited"; fi ;;
+esac
 
 [ -r "$TOKEN_FILE" ] || die "token file not found/readable: $TOKEN_FILE (is the browser-bridge service running?)"
 TOKEN="$(tr -d '[:space:]' < "$TOKEN_FILE")"
@@ -631,11 +641,21 @@ _curl() {
   local method="$1" path="$2" body="${3:-}"
   # X-Session-Id routes this session to its owned tab. It is ROUTING-ONLY — the
   # server never trusts it for auth (bearer + Host still gate every request).
+  # X-Session-Origin, when present, says the command was issued by something
+  # NESTED under that id (see SESSION_ORIGIN); it changes telemetry attribution
+  # only, never routing.
   local args=(-sS -m 60 -X "$method"
     -H "Authorization: Bearer ${TOKEN}"
     -H "Host: 127.0.0.1"
     -H "X-Session-Id: ${SESSION_ID}"
     -w '\n%{http_code}')
+  # Declared ONLY when set — an empty `-H "X-Session-Origin: "` is not a
+  # no-origin request, and curl treats a header with no content on the right of
+  # the colon as an instruction to REMOVE that header, so an unconditional flag
+  # would be both wrong and confusing to read on the wire.
+  if [ -n "${SESSION_ORIGIN:-}" ]; then
+    args+=(-H "X-Session-Origin: ${SESSION_ORIGIN}")
+  fi
   if [ -n "$body" ]; then
     args+=(-H "Content-Type: application/json" --data "$body")
   fi

--- a/scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs
+++ b/scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs
@@ -595,6 +595,16 @@ export function buildRequest(args, env, token) {
       Authorization: `Bearer ${token}`,
       Host: "127.0.0.1", // loopback Host-allowlist invariant (#168)
       "X-Session-Id": sessionId, // routing-only; forced `tab` overrides ownership
+      // 🔴 X-Session-Origin: this request was NOT issued by the session whose id
+      // X-Session-Id carries. browser-agent captures its INVOKER's id (its
+      // `--print-session-id` call) and forwards it here purely so routing and the
+      // audit trail stay consistent with the `open` that created our tab. The
+      // telemetry `session` column means "the agent session that ISSUED this
+      // command"; for a nested run the issuer is this opencode agent, whose own id
+      // we do not have. Declaring the origin makes the server record the forwarded
+      // id as `origin_session` (the causal PARENT) instead of attributing N nested
+      // calls to the operator's own session — ~11% of bridge commands in 14d.
+      "X-Session-Origin": "browser-agent",
       "Content-Type": "application/json",
     },
     body,

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -358,6 +358,17 @@ HDR_SESSION_ID = "X-Session-Id"
 # version-skewed caller can send anything.
 SESSION_SRC_JOINABLE = "claude"
 SESSION_SRC_UNKNOWN = "unknown"
+# The CLOSED vocabulary of tier tags `derive_session_id` can emit. Pinned two-way
+# against the CLI by tests/test_browser_session_id.py, so a new tier fails there
+# until someone classifies it as joinable-or-not.
+#
+# 🔴 IT IS A VALIDATION SET, not documentation. The tag arrives on a
+# caller-supplied header: without this, `sess_src` is an unbounded-cardinality
+# column filled from a string a raw token-holder chooses ("['claude", " claude",
+# "CLAUDE", "claud" were all measured landing verbatim). Anything not in here is
+# reported as SESSION_SRC_UNKNOWN and carries no id — a new tier needs a CLI
+# change, which the two-way pin already forces you to declare.
+SESSION_TIER_TAGS = ("claude", "tmux", "sid", "ppid", "synthetic")
 
 # ---- Nested runs: the forwarded id is the PARENT, not the actor ------------ #
 # `browser agent "<goal>"` shells out to an opencode agent, and browser-agent
@@ -367,7 +378,7 @@ SESSION_SRC_UNKNOWN = "unknown"
 # It is WRONG for the `session` column, which means "the agent session that
 # ISSUED this command": for a nested run the issuer is the opencode agent, whose
 # own id we do not have yet. Attributing those calls to the operator's session
-# would fabricate usage in the exact column adoption-scan reads (measured: ~581
+# would fabricate usage in the `session` JOIN column (measured: ~581
 # nested tool-call rows in 14d, ~11% of bridge commands).
 #
 # So the nested tool declares itself. When this header is present we record the
@@ -375,6 +386,20 @@ SESSION_SRC_UNKNOWN = "unknown"
 # can mistake it for the actor — and leave `session` EMPTY. Giving the nested
 # session an id of its own is a later change.
 HDR_SESSION_ORIGIN = "X-Session-Origin"
+# The CLOSED ledger of origin tokens, and the marker for a declaration that is
+# present but not one of them.
+#
+# 🔴 PRESENCE IS THE SIGNAL, NOT THE VALUE. Attribution is suppressed whenever the
+# header is THERE, whatever it says. An oversized, control-char, empty or unknown
+# value means a caller tried to disclaim authorship and we could not read it —
+# losing attribution beats fabricating it, so it fails CLOSED and is marked so the
+# case is visible in the data rather than silent. Validating the value only after
+# deciding to suppress is what keeps this from turning into the id-sanitiser bug
+# it mirrors: that one returned "" for a malformed value and fell through to
+# writing `session` with the PARENT's id — the exact fabrication this mechanism
+# exists to prevent.
+ORIGIN_TOKENS = ("browser-agent", "opencode-inherited")
+SESSION_ORIGIN_INVALID = "invalid"
 
 # Bound what a caller-supplied header can put on a telemetry row. A value that
 # fails this is dropped entirely, never truncated: a truncated join key is a
@@ -829,6 +854,19 @@ def log(event: str, **fields) -> None:
 # The tier gate and the origin gate are what keep this honest — see
 # SESSION_SRC_JOINABLE and HDR_SESSION_ORIGIN.
 #
+# 🔴 WHO ACTUALLY READS `session`, STATED CORRECTLY. An earlier draft of these
+# comments said "the column adoption-scan and the deadman read". That is FALSE
+# and was checked: adoption-scan's browser-bridge entry is `via="source"`, whose
+# query selects text/payload/exit_code/duration_ms/ts/host and never `session`;
+# the deadman consumes only a row's EXISTENCE. Every shipped `GROUP BY session`
+# filters `source='claude'` (or claude+opencode). So NO shipped consumer reads
+# this column for `source='browser-bridge'` today — precisely because it has
+# always been empty.
+# That makes the harm LATENT, not live, and it is still the reason for every
+# gate here: a wrong value corrupts the FIRST consumer that reads it, silently,
+# and a fabricated session key is indistinguishable from a real one after the
+# fact. Absent data is recoverable; wrong-and-plausible data is not.
+#
 # BEST-EFFORT CONTRACT (do not weaken): emitting must never affect command
 # handling. The emitter is discovered lazily by absolute path and every failure
 # mode (missing module, unwritable spool, any exception) is swallowed — the
@@ -956,6 +994,12 @@ def _split_session_id(session_id):
     tier, sep, bare = s.partition(":")
     if not sep or not tier or not bare:
         return SESSION_SRC_UNKNOWN, ""
+    # A tag we do not know is not reported verbatim: `sess_src` would otherwise be
+    # an unbounded column filled from a caller-supplied header. Both halves are
+    # dropped together — an unrecognised tier tells us nothing about what the
+    # remainder means, so it must not reach `session` OR `origin_session`.
+    if tier not in SESSION_TIER_TAGS:
+        return SESSION_SRC_UNKNOWN, ""
     return tier, bare
 
 
@@ -1052,12 +1096,26 @@ def emit_cmd_event(op: str, key: str, outcome: str, duration_ms: int,
                 payload.pop(reserved, None)
             tier, bare = _split_session_id(session_id)
             payload["sess_src"] = tier
-            origin = _clean_session_field(session_origin)
-            if origin:
-                # A NESTED run: the forwarded id is the causal PARENT, not the
-                # actor. Recorded where nothing can mistake it for one.
-                payload["origin"] = origin
-                if bare:
+            # 🔴 BRANCH ON PRESENCE, NEVER ON THE CLEANED VALUE'S TRUTHINESS.
+            # `session_origin is None` means the header was absent; ANY present
+            # value — including "" — is a caller disclaiming authorship, and must
+            # suppress `session` even when we cannot make sense of it. Keying this
+            # off `if origin:` instead let a 201-char or control-char origin fall
+            # through to the `elif` and write `session` with the PARENT's id.
+            if session_origin is not None:
+                declared = _clean_session_field(session_origin)
+                # The value decides only what we RECORD, never whether to suppress.
+                payload["origin"] = (declared if declared in ORIGIN_TOKENS
+                                     else SESSION_ORIGIN_INVALID)
+                # 🔴 THE SAME TIER GATE AS `session`, and for the same reason: a
+                # pane id is stable across many unrelated sessions, so a reader who
+                # groups by `origin_session` would merge them exactly as they would
+                # on `session`. REACHABLE, not theoretical — browser-agent forwards
+                # whatever --print-session-id produced and the opencode tool
+                # declares its origin unconditionally, so a `tmux:`/`sid:` parent
+                # id genuinely arrives here. The tier is on the row either way, so
+                # the suppressed population stays measurable.
+                if tier == SESSION_SRC_JOINABLE and bare:
                     payload["origin_session"] = bare
             elif tier == SESSION_SRC_JOINABLE and bare:
                 # 🔴 THE TIER GATE. Only the joinable tier may fill the `session`
@@ -1072,7 +1130,8 @@ def emit_cmd_event(op: str, key: str, outcome: str, duration_ms: int,
         pass
 
 
-def _emit_diag_event(op: str, t0: float) -> None:
+def _emit_diag_event(op: str, t0: float, session_id=None,
+                     session_origin=None) -> None:
     """One metadata-only event for a read-only DIAGNOSTIC GET (/whoami, /health).
 
     A thin, deliberately narrow wrapper over emit_cmd_event: op + outcome + latency
@@ -1080,10 +1139,20 @@ def _emit_diag_event(op: str, t0: float) -> None:
     they are global, describing every connected profile at once, so there is no
     single active domain to attribute and emitting per-profile domains would widen
     the privacy contract. Best-effort like every other emit: it cannot raise.
-    """
+
+    🔴 THESE ARE OPERATOR CALLS AND ARE ATTRIBUTED. `browser whoami` / `browser
+    health` are subcommands a person runs — the skill documents them as the FIRST
+    thing to run — and the CLI sends its ordinary session headers on them, because
+    `_curl` is one code path. They are NOT server-originated; only the heartbeat
+    is. Leaving them unattributed made ONE operation have TWO outcomes: `whoami`
+    reached via POST /cmd got a session, the same `whoami` via GET did not, for
+    125 rows / 2.0% of `kind='cmd'` over 14 days. That is a smaller copy of the
+    very bug this file's session work exists to fix, so they are attributed the
+    same way as any other operator command."""
     emit_cmd_event(op=op, key="", outcome="ok",
                    duration_ms=int((time.monotonic() - t0) * 1000),
-                   domain="", exit_code=0)
+                   domain="", exit_code=0, session_id=session_id,
+                   session_origin=session_origin, attribute_session=True)
 
 
 # --------------------------------------------------------------------------- #
@@ -2560,7 +2629,14 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                 # emitting one per profile would widen the contract to "which sites
                 # are open in each of your browsers". `key` is likewise empty:
                 # these endpoints take no --instance.
-                _emit_diag_event("health", t0)
+                #
+                # The SESSION HEADERS are passed through, though: these are
+                # operator subcommands (`browser whoami` / `browser health`), not
+                # server-originated rows, so they attribute like any other command
+                # — see _emit_diag_event for why excluding them was wrong.
+                _emit_diag_event("health", t0,
+                                 self.headers.get(HDR_SESSION_ID),
+                                 self.headers.get(HDR_SESSION_ORIGIN))
                 return
             if path == "/instances":
                 insts = registry.snapshot()
@@ -2569,7 +2645,9 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                 return
             if path == "/whoami":
                 self._send(200, self._whoami())
-                _emit_diag_event("whoami", t0)   # see the /health emit above
+                _emit_diag_event("whoami", t0,
+                                 self.headers.get(HDR_SESSION_ID),
+                                 self.headers.get(HDR_SESSION_ORIGIN))   # see the /health emit above
                 return
             if path == "/poll":
                 (instance_id, label, active, ext_version,
@@ -2642,7 +2720,11 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
             # A nested `browser agent` run declares itself here so its forwarded
             # invoker id is never attributed to the invoker as usage. Absent for
             # every ordinary caller. See HDR_SESSION_ORIGIN.
-            session_origin = self.headers.get(HDR_SESSION_ORIGIN) or None
+            # 🔴 NO `or None` — that would collapse a PRESENT-but-empty header
+            # into "absent" and attribute a call whose caller explicitly
+            # disclaimed it. `.get()` returns None only when the header is really
+            # missing, which is the distinction the emitter branches on.
+            session_origin = self.headers.get(HDR_SESSION_ORIGIN)
             # The upload file PATH is captured for the AUDIT log/event (see the
             # ALLOWED_OPS note). It is local metadata (never file content); logging
             # it is acceptable and required for traceability of this exfil-capable

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -324,6 +324,64 @@ KNOWN_FORGET_S = 86400.0
 # yank a visible tab out from under the user); explicit `browser close` closes it.
 HDR_SESSION_ID = "X-Session-Id"
 
+# ---- The session id as a TELEMETRY JOIN KEY (distinct from routing) -------- #
+# X-Session-Id is a ROUTING key: any string that is stable per caller works, and
+# every tier of the CLI's fallback chain produces one. That is NOT enough to
+# record it as an activity.events `session` value, which is a JOIN key — a row
+# claiming session X asserts "this is the same session other sources call X".
+#
+# The id already carries its provenance: `derive_session_id` deliberately tags it
+# with the tier that produced it, before the FIRST colon.
+#
+#   claude:<uuid>          CLAUDE_CODE_SESSION_ID / CLAUDE_SESSION_ID — Claude
+#                          Code's own session uuid, which is EXACTLY what
+#                          `source='claude'` rows already store. JOINABLE.
+#   tmux:%<n>              $TMUX_PANE. A pane id is stable across MANY unrelated
+#                          sessions, so writing it into `session` would silently
+#                          merge them into one apparent session — strictly worse
+#                          than an empty column.
+#   sid:<sid>:<starttime>  the POSIX session id. No other source records it.
+#   ppid:<pid>:<rand>      the last-resort cached random token.
+#   synthetic:<...>        an id the CLI deliberately made up (its recreate-close
+#                          presents a throwaway so the close cannot evict the
+#                          mapping it just created).
+#
+# Reading that tag is NOT shape inference: it is a tag the CLI author emits on
+# purpose, not a guess from what the value happens to look like. 🔴 What WOULD be
+# shape inference — and is forbidden — is deciding from the id's FORM ("looks
+# like a uuid → claude"). The tag, or nothing.
+#
+# FAIL CLOSED. An id with no tag at all (no colon), an empty one, or a tag we do
+# not know is reported as SESSION_SRC_UNKNOWN and writes NO session key. In
+# particular an UNPREFIXED value is never treated as a bare claude id — the
+# opencode browser tool's own default is the literal "browser-agent", and a
+# version-skewed caller can send anything.
+SESSION_SRC_JOINABLE = "claude"
+SESSION_SRC_UNKNOWN = "unknown"
+
+# ---- Nested runs: the forwarded id is the PARENT, not the actor ------------ #
+# `browser agent "<goal>"` shells out to an opencode agent, and browser-agent
+# captures the id of the session that INVOKED it (`--print-session-id`) and
+# forwards it as this nested run's X-Session-Id. That is right for ROUTING and
+# for the audit trail — the nested tool drives the tab that invoker `open`ed.
+# It is WRONG for the `session` column, which means "the agent session that
+# ISSUED this command": for a nested run the issuer is the opencode agent, whose
+# own id we do not have yet. Attributing those calls to the operator's session
+# would fabricate usage in the exact column adoption-scan reads (measured: ~581
+# nested tool-call rows in 14d, ~11% of bridge commands).
+#
+# So the nested tool declares itself. When this header is present we record the
+# forwarded id as `payload.origin_session` — the causal PARENT, somewhere nothing
+# can mistake it for the actor — and leave `session` EMPTY. Giving the nested
+# session an id of its own is a later change.
+HDR_SESSION_ORIGIN = "X-Session-Origin"
+
+# Bound what a caller-supplied header can put on a telemetry row. A value that
+# fails this is dropped entirely, never truncated: a truncated join key is a
+# WRONG join key, which is the failure this whole change exists to avoid. 200 is
+# ~5x a uuid plus its tag.
+MAX_SESSION_FIELD = 200
+
 # Idle seconds after which a session's tab ownership is reclaimed (released, NOT
 # closed). Refreshed on every op the session routes through its owned tab.
 OWNER_TTL_S = float(os.environ.get("BROWSER_BRIDGE_OWNER_TTL", "900"))
@@ -747,10 +805,29 @@ def log(event: str, **fields) -> None:
 # source from the collector's `browser` (nav/scroll) source; keep them separate.
 #
 # PRIVACY CONTRACT (do not weaken): we emit ONLY metadata — the op name, the
-# instance routing key, the outcome, the server-side latency, and (best-effort)
-# the active tab's BARE DOMAIN. We NEVER emit the eval source, page HTML,
-# screenshot bytes/data-URLs, a full URL with path/query, or any page content.
-# The payload stays tiny.
+# instance routing key, the outcome, the server-side latency, (best-effort) the
+# active tab's BARE DOMAIN, the caller's SESSION TIER, and — for the joinable
+# tier only — the caller's own agent SESSION ID. We NEVER emit the eval source,
+# page HTML, screenshot bytes/data-URLs, a full URL with path/query, or any page
+# content. The payload stays tiny.
+#
+# 🔴 THE SESSION ID IS A DELIBERATE WIDENING (2026-08-18) — read this before
+# calling it a leak. Until now the `session` column was EMPTY on every
+# browser-bridge row (measured: 0 of 6,937 over 14 days) while claude/opencode/
+# keys/tmux/zsh filled it 100%, so a browser-skill call could not be joined to
+# the agent session that made it; answering "which sessions used the browser
+# skill" meant scanning 1.5M transcript records instead of reading one column.
+# What is now emitted is the AGENT SESSION'S OWN OPAQUE HANDLE — the same
+# `CLAUDE_CODE_SESSION_ID` that `source='claude'` rows in this very table already
+# store, raw. It is NOT page content, is not derived from any page, and is not
+# derived from anything the browser saw: it is an identifier the local agent
+# harness minted for itself before any browser command existed. Storing it adds
+# no information about WHAT was browsed — only about WHO asked. It is stored RAW
+# and unhashed on purpose: a hash would make this the ONE source needing
+# hex(SHA256()) at query time, and a forgotten join silently returns zero rows,
+# which reads as a valid "no sessions matched" answer.
+# The tier gate and the origin gate are what keep this honest — see
+# SESSION_SRC_JOINABLE and HDR_SESSION_ORIGIN.
 #
 # BEST-EFFORT CONTRACT (do not weaken): emitting must never affect command
 # handling. The emitter is discovered lazily by absolute path and every failure
@@ -831,6 +908,57 @@ def _session_hash(session_id) -> str:
     return hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:8]
 
 
+def _clean_session_field(value) -> str:
+    """A caller-supplied header value, made safe to put on a telemetry row.
+
+    Returns "" for anything empty, over MAX_SESSION_FIELD, or carrying a control
+    character. DROPS rather than truncates — a truncated join key is a wrong join
+    key, and a control character would be an unreadable handle in a column other
+    tools compare with `=`. (The spool line is base64'd, so this is not an
+    injection guard; it is a data-quality one.)
+    """
+    if not value:
+        return ""
+    try:
+        s = str(value)
+    except Exception:  # noqa: BLE001 — telemetry is strictly best-effort.
+        return ""
+    if len(s) > MAX_SESSION_FIELD:
+        return ""
+    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in s):
+        return ""
+    return s
+
+
+def _split_session_id(session_id):
+    """`X-Session-Id` -> (tier, bare id), reading the tag the CLI put there.
+
+    The tag is everything before the FIRST colon; the rest is the id as the
+    producing source knows it (`sid:` and `ppid:` ids contain further colons, so
+    only the first one may split). Both halves must be non-empty.
+
+    Anything that carries no tag at all — including a bare uuid, which is exactly
+    the value that would be most tempting to accept — returns
+    (SESSION_SRC_UNKNOWN, ""). That is the fail-closed direction: an id whose
+    provenance is unstated must never be promoted to a join key on the strength
+    of looking like one.
+
+    The BARE half is what reaches the `session` column, because
+    `source='claude'` rows store the bare uuid (the transcript filename stem ==
+    CLAUDE_CODE_SESSION_ID). Keeping the tag would force a
+    replaceOne(session,'claude:','') at every join site, and a forgotten one
+    returns zero rows — which reads as a valid "no sessions matched" answer, the
+    same failure the raw-not-hashed decision above exists to avoid.
+    """
+    s = _clean_session_field(session_id)
+    if not s:
+        return SESSION_SRC_UNKNOWN, ""
+    tier, sep, bare = s.partition(":")
+    if not sep or not tier or not bare:
+        return SESSION_SRC_UNKNOWN, ""
+    return tier, bare
+
+
 def _emulate_extra(body) -> dict:
     """METADATA-ONLY telemetry fields for an `emulate` command.
 
@@ -864,7 +992,8 @@ def _emulate_extra(body) -> dict:
 
 def emit_cmd_event(op: str, key: str, outcome: str, duration_ms: int,
                    domain: str = "", exit_code: int = 0, extra: dict = None,
-                   kind: str = "cmd") -> None:
+                   kind: str = "cmd", session_id=None, session_origin=None,
+                   attribute_session: bool = False) -> None:
     """Append ONE metadata-only activity event for a handled command.
 
     Best-effort + fire-and-forget: any failure is swallowed so telemetry can
@@ -872,6 +1001,21 @@ def emit_cmd_event(op: str, key: str, outcome: str, duration_ms: int,
     `extra` merges additional METADATA-ONLY keys into the payload (used by the
     throttle path for {reason, sess} — a fixed reason string + a coarse session
     hash, never page content).
+
+    SESSION ATTRIBUTION (see SESSION_SRC_JOINABLE / HDR_SESSION_ORIGIN):
+      * `attribute_session=False` (the default) — this call site has no caller
+        session at all: the heartbeat, and the /whoami+/health diagnostics.
+        NOTHING is added; their records are byte-identical to before.
+      * `attribute_session=True` — `payload.sess_src` ALWAYS records the tier
+        parsed off `session_id`, so every row is self-describing about why it
+        does or does not carry a key. The `session` COLUMN is filled with the
+        BARE id only when that tier is SESSION_SRC_JOINABLE **and** no
+        `session_origin` was declared.
+      * `session_origin` set — a NESTED run forwarding its invoker's id. `session`
+        stays empty; the bare id is recorded as `payload.origin_session` (the
+        causal parent) beside `payload.origin`.
+      * every field this adds is written AFTER `extra` merges, so no call site can
+        overwrite an attribution with a value that did not come from a header.
 
     🔴 `kind` defaults to "cmd" and MUST stay that way for operator-driven
     commands: `kind='cmd'` is the USAGE signal downstream — session-analysis/
@@ -884,21 +1028,46 @@ def emit_cmd_event(op: str, key: str, outcome: str, duration_ms: int,
         se = _load_spool_emit()
         if se is None:
             return
-        # METADATA ONLY — op/key/outcome/(bare)domain. Never page content.
+        # METADATA ONLY — op/key/outcome/(bare)domain, plus the caller's session
+        # TIER and (joinable tier, non-nested only) its agent session id. Never
+        # page content.
         payload = {"op": op, "key": key, "outcome": outcome}
         if domain:
             payload["domain"] = domain
         if extra:
             payload.update(extra)
-        se.emit({
+        rec = {
             "source": "browser-bridge",
             "kind": kind,
             "text": domain or op,
             "duration_ms": int(duration_ms),
             "exit_code": int(exit_code),
-            "payload": json.dumps(payload, ensure_ascii=False,
-                                  separators=(",", ":")),
-        })
+        }
+        if attribute_session:
+            # These keys belong to the headers alone. Clear them first so a stale
+            # or smuggled `extra` cannot leave a claim standing that the headers
+            # did not make — "written after extra" only wins for keys we WRITE,
+            # and the origin keys are conditional.
+            for reserved in ("sess_src", "origin", "origin_session"):
+                payload.pop(reserved, None)
+            tier, bare = _split_session_id(session_id)
+            payload["sess_src"] = tier
+            origin = _clean_session_field(session_origin)
+            if origin:
+                # A NESTED run: the forwarded id is the causal PARENT, not the
+                # actor. Recorded where nothing can mistake it for one.
+                payload["origin"] = origin
+                if bare:
+                    payload["origin_session"] = bare
+            elif tier == SESSION_SRC_JOINABLE and bare:
+                # 🔴 THE TIER GATE. Only the joinable tier may fill the `session`
+                # JOIN column; any other tier would merge unrelated sessions
+                # under one apparent key. Never widen this to a test on the id's
+                # form, and never let an origin-declaring caller reach it.
+                rec["session"] = bare
+        rec["payload"] = json.dumps(payload, ensure_ascii=False,
+                                    separators=(",", ":"))
+        se.emit(rec)
     except Exception:  # noqa: BLE001 — strictly best-effort.
         pass
 
@@ -2470,6 +2639,10 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                     self._send(400, {"ok": False, "error": terr})
                     return
             session_id = self.headers.get(HDR_SESSION_ID) or None
+            # A nested `browser agent` run declares itself here so its forwarded
+            # invoker id is never attributed to the invoker as usage. Absent for
+            # every ordinary caller. See HDR_SESSION_ORIGIN.
+            session_origin = self.headers.get(HDR_SESSION_ORIGIN) or None
             # The upload file PATH is captured for the AUDIT log/event (see the
             # ALLOWED_OPS note). It is local metadata (never file content); logging
             # it is acceptable and required for traceability of this exfil-capable
@@ -2491,7 +2664,8 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                 emit_cmd_event(
                     op=op, key=(target or ""), outcome="ok",
                     duration_ms=int((time.monotonic() - t0) * 1000),
-                    domain="", exit_code=0)
+                    domain="", exit_code=0, session_id=session_id,
+                    session_origin=session_origin, attribute_session=True)
                 return
             try:
                 # `ping` alone asks for the fast-fail-when-idle deadline. Named
@@ -2506,8 +2680,14 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
             except RateLimited as e:
                 # Per-instance concurrency backstop tripped. Distinct structured
                 # log + a telemetry event carrying a COARSE session hash so the
-                # NEXT storm is attributable in activity.events without storing
-                # the raw session id (the audit couldn't attribute the 44K flood).
+                # NEXT storm is attributable in activity.events (the audit
+                # couldn't attribute the 44K flood).
+                # `sess` is KEPT alongside the new `session` column, deliberately.
+                # The column is filled for the `claude` tier and non-nested calls
+                # ONLY — and a flood driven from a tmux/sid/ppid/unknown tier, or
+                # from a nested browser-agent run, is exactly the case where you
+                # still need SOME stable handle to tell one flooder from two. It
+                # is 8 hex, on the throttle path only.
                 # Returns immediately (no turnstile impact) — caller-visible 429
                 # backpressure with a Retry-After-style hint in the body.
                 sess = _session_hash(session_id)
@@ -2526,7 +2706,8 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                 emit_cmd_event(
                     op=op, key=(target or ""), outcome="throttled",
                     duration_ms=int((time.monotonic() - t0) * 1000),
-                    domain="", exit_code=1, extra=extra)
+                    domain="", exit_code=1, extra=extra, session_id=session_id,
+                    session_origin=session_origin, attribute_session=True)
                 return
             except NoOwnedTab:
                 outcome, exit_code = "no_owned_tab", 1
@@ -2598,7 +2779,9 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                     key=(target or ""))
             emit_cmd_event(op=op, key=(target or ""), outcome=outcome,
                            duration_ms=int((time.monotonic() - t0) * 1000),
-                           domain=domain, exit_code=exit_code, extra=extra)
+                           domain=domain, exit_code=exit_code, extra=extra,
+                           session_id=session_id, session_origin=session_origin,
+                           attribute_session=True)
 
         def _handle_result(self):
             body, err = self._read_body(MAX_RESULT_BODY)

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -358,9 +358,16 @@ HDR_SESSION_ID = "X-Session-Id"
 # version-skewed caller can send anything.
 SESSION_SRC_JOINABLE = "claude"
 SESSION_SRC_UNKNOWN = "unknown"
-# The CLOSED vocabulary of tier tags `derive_session_id` can emit. Pinned two-way
-# against the CLI by tests/test_browser_session_id.py, so a new tier fails there
-# until someone classifies it as joinable-or-not.
+# The CLOSED vocabulary of tier tags `derive_session_id` can emit. Pinned against
+# the tags PARSED OUT OF THE CLI SOURCE by test_browser_session_id.py::
+# test_the_server_validation_set_equals_the_tags_parsed_from_the_cli, so a new
+# tier fails there until it is added here too.
+# 🔴 Against the PARSE, not against a retyped literal. This comment previously
+# claimed a two-way pin that did not exist — each side was checked against its own
+# copy of the list, so a change touching both real files passed (measured: grow
+# the CLI by an `opencode:` tier and update its ledger, leave this alone → the
+# whole suite green). The failure that hides is silent and fail-closed: the new
+# tier normalises to SESSION_SRC_UNKNOWN, loses its id, and the column empties.
 #
 # 🔴 IT IS A VALIDATION SET, not documentation. The tag arrives on a
 # caller-supplied header: without this, `sess_src` is an unbounded-cardinality
@@ -1048,8 +1055,13 @@ def emit_cmd_event(op: str, key: str, outcome: str, duration_ms: int,
 
     SESSION ATTRIBUTION (see SESSION_SRC_JOINABLE / HDR_SESSION_ORIGIN):
       * `attribute_session=False` (the default) — this call site has no caller
-        session at all: the heartbeat, and the /whoami+/health diagnostics.
-        NOTHING is added; their records are byte-identical to before.
+        session at all. Exactly ONE emit is in that category: the heartbeat,
+        which a timer produces with no request behind it. NOTHING is added.
+        🔴 /whoami and /health are NOT in this category, though this docstring
+        said they were until the audit round that moved them: they are operator
+        subcommands (`browser whoami` / `browser health`) whose requests carry
+        the ordinary session headers, so they pass attribute_session=True like
+        any other command — see _emit_diag_event.
       * `attribute_session=True` — `payload.sess_src` ALWAYS records the tier
         parsed off `session_id`, so every row is self-describing about why it
         does or does not carry a key. The `session` COLUMN is filled with the

--- a/scripts/browser-bridge/tests/browser_tool.test.mjs
+++ b/scripts/browser-bridge/tests/browser_tool.test.mjs
@@ -105,6 +105,32 @@ test("buildRequest: forces the env tab + maps op names; headers carry the invari
   assert.equal(body.tab, 4242);                        // FORCED from env
 });
 
+// --- X-Session-Origin: a NESTED run must not be credited as the operator ---- //
+// browser-agent captures the id of the session that INVOKED it and forwards it
+// here, so every nested command arrives wearing the operator's own `claude:` tag.
+// The bridge fills activity.events' `session` column from that tag -- so without
+// this header one `browser agent "<goal>"` call would become N browser calls
+// attributed to the operator's own session, indistinguishable from direct use
+// (~11% of bridge commands over 14d). Declaring the origin makes the server
+// record the forwarded id as the causal PARENT (`origin_session`) instead.
+test("buildRequest: declares X-Session-Origin so the forwarded id is not credited as usage", () => {
+  const { headers } = buildRequest({ op: "html" }, baseEnv(), TOK);
+  assert.equal(headers["X-Session-Origin"], "browser-agent");
+  // Routing is untouched: the forwarded id still rides along, verbatim.
+  assert.equal(headers["X-Session-Id"], "claude:sess");
+});
+
+test("buildRequest: the origin is UNCONDITIONAL -- it does not depend on the env id", () => {
+  // Every request from this tool is nested, whatever id it was handed (including
+  // the "browser-agent" literal it falls back to). A header that appeared only
+  // when some env var happened to be set would silently mis-credit the rest.
+  for (const env of [baseEnv({ BROWSER_AGENT_SESSION_ID: "tmux:%41" }),
+    baseEnv({ BROWSER_AGENT_SESSION_ID: undefined })]) {
+    const { headers } = buildRequest({ op: "text" }, env, TOK);
+    assert.equal(headers["X-Session-Origin"], "browser-agent");
+  }
+});
+
 test("buildRequest: the model CANNOT override the forced tab (no tab arg exists)", () => {
   // Even if a hostile arg tried to smuggle a tab/target, buildRequest ignores it.
   const { body } = buildRequest({ op: "text", tab: 999, target: "other" },

--- a/scripts/browser-bridge/tests/test_browser_session_id.py
+++ b/scripts/browser-bridge/tests/test_browser_session_id.py
@@ -432,7 +432,7 @@ import server as S  # noqa: E402
 # Every tag `derive_session_id` (and the recreate-close re-tag) can put on the
 # wire. Pinned two-way: the parse below must find exactly this set, so a NEW tier
 # fails here until someone decides whether it is joinable.
-CLI_TIER_TAGS = {"claude", "tmux", "sid", "ppid", "synthetic", "oc-inherited"}
+CLI_TIER_TAGS = {"claude", "tmux", "sid", "ppid", "synthetic"}
 
 
 def _emitted_tags():
@@ -443,12 +443,9 @@ def _emitted_tags():
     matched nothing would make every claim below pass vacuously.
     """
     src = CLI.read_text()
-    # `[a-z][a-z-]*` — a tag may contain a hyphen (`oc-inherited`). Widened WITH
-    # the ledger assertion above as its control: if this over-matched, the set
-    # comparison would fail rather than quietly absorb the extra.
-    tags = set(re.findall(r"printf '([a-z][a-z-]*):%s", src))
-    tags |= set(re.findall(r'SESSION_ID="([a-z][a-z-]*):', src))
-    tags |= set(re.findall(r'tok="([a-z][a-z-]*):', src))
+    tags = set(re.findall(r"printf '([a-z]+):%s", src))
+    tags |= set(re.findall(r'SESSION_ID="([a-z]+):', src))
+    tags |= set(re.findall(r'tok="([a-z]+):', src))
     return tags
 
 
@@ -578,81 +575,167 @@ def test_an_ordinary_cli_call_declares_no_nested_origin(capture):
 
 
 # --------------------------------------------------------------------------- #
-# 8. THE OPENCODE LEAK. `CLAUDE_CODE_SESSION_ID` survives into opencode's tool
-#    shells, so inside opencode it names an ANCESTOR, not the caller.
+# 8. THE OPENCODE LEAK, and why it is an ORIGIN HEADER rather than a new tier.
 #
-# MEASURED TWO WAYS: (a) a live env dump from inside an opencode bash tool
-# carried the outer Claude session's CLAUDE_CODE_SESSION_ID; (b) opencode 1.18.18
-# sets `process.env.OPENCODE="1"` in a yargs TOP-LEVEL `.middleware()`, i.e. for
-# every subcommand, and hands its tool shells `{...process.env}`.
+# `CLAUDE_CODE_SESSION_ID` survives into opencode's tool shells. MEASURED TWO
+# WAYS: (a) a live env dump from inside an opencode bash tool carried the outer
+# Claude session's value; (b) opencode sets `process.env.OPENCODE="1"` in a yargs
+# TOP-LEVEL `.middleware()` -- i.e. for every subcommand -- and hands its tool
+# shells `{...process.env}`. Confirmed in the PINNED build (PINNED_VERSION in
+# scripts/tests/test_opencode_engine.py) and in the newer build on this host's
+# profile; identical in both, so it is not pin-specific.
 #
-# Claiming the joinable `claude:` tier on that value would write the OUTER
-# session's uuid into the telemetry `session` column, where it is
-# indistinguishable from that session's own direct browser use. The column is
-# EMPTY today: empty is recoverable, plausible-but-wrong is not. So the id is
-# RE-TAGGED (not re-derived) — non-joinable, but the same underlying value, so
-# it stays stable and per-session tab ownership survives.
+# So inside opencode that variable names an ANCESTOR, not the caller, and a plain
+# `opencode run …` shelling out to `browser` would have the bridge credit the
+# OUTER session with browser usage it never did.
+#
+# 🔴 THE ID IS NOT TOUCHED. `browser agent` already answers the identical
+# question -- "this command was issued by something nested under the id on the
+# wire" -- with a separate `X-Session-Origin` header, leaving `X-Session-Id`
+# alone. This case gets the SAME mechanism: one question, one mechanism. The
+# payoff is that routing, tab ownership and `not_owned_tab` semantics are
+# byte-identical to before any of this existed, which the first test below makes
+# machine-checked rather than asserted in a comment.
 # --------------------------------------------------------------------------- #
-@pytest.mark.parametrize("var", ["CLAUDE_CODE_SESSION_ID", "CLAUDE_SESSION_ID"])
-def test_a_leaked_claude_id_inside_opencode_is_not_claimed_as_joinable(tmp_path, var):
-    """Both spellings, because both feed the same joinable tier — a guard placed
-    on only the primary one would leave the alternate wide open."""
-    env = _env(tmp_path, OPENCODE="1", **{var: "uuid-leaked"})
-    assert _print_id(env) == "oc-inherited:uuid-leaked"
+# (env overrides, the id that env must still produce). Pairwise distinct, and
+# distinct from every literal the assertions name, so a mutant hardcoding one
+# cannot satisfy the row next to it.
+ROUTING_CASES = [
+    ({"CLAUDE_CODE_SESSION_ID": "uuid-primary"}, "claude:uuid-primary"),
+    ({"CLAUDE_SESSION_ID": "uuid-alternate"}, "claude:uuid-alternate"),
+    ({"TMUX_PANE": "%41"}, "tmux:%41"),
+]
 
 
-def test_the_discriminating_pair_opencode_set_versus_unset(tmp_path):
-    """🔴 THE PAIR. The SAME uuid, derived twice, differing only in OPENCODE.
+@pytest.mark.parametrize("over,want_id", ROUTING_CASES)
+def test_routing_equivalence_opencode_does_not_change_the_id(tmp_path, over, want_id):
+    """🔴 ROUTING MUST NOT CHANGE -- machine-checked, not asserted in prose.
 
-    Asserted together on purpose: a guard that tagged EVERYTHING `oc-inherited`
-    would satisfy the leak test above on its own and silently empty the column
-    for ordinary Claude sessions — the very bug this PR fixes, restored. Only the
-    unset side may claim the joinable tier, and the two ids must differ so the
-    server can tell them apart at all.
+    For each environment the id is derived TWICE, differing only in whether
+    OPENCODE is set, and both must equal the SAME PINNED LITERAL. That literal is
+    what this environment produced before any of this PR existed, so the pair is
+    exactly the claim "the wire id is byte-identical to before".
+
+    Two assertions, and both are load-bearing:
+      * the two arms equal EACH OTHER -- OPENCODE changes nothing;
+      * they equal a literal taken from the contract rather than from the
+        implementation, so a change that moved BOTH arms together still fails.
+    An earlier draft of this fix re-tagged the id (`oc-inherited:<uuid>`); it
+    would die on both halves here, which is why this test exists.
+
+    BASELINES DIFFER PER ROW, so read them per row: the two `claude:` rows are
+    RED at 84bf324 (that draft perturbed exactly those); the `tmux:` row is an
+    INVARIANT GUARD there, because the draft never fired on a non-claude id. All
+    three are red at da33356 only in the sense that OPENCODE was ignored
+    entirely — the ids matched, so they pass there too. Mutant N6 is what proves
+    the whole table reachable.
     """
-    same_uuid = "uuid-shared-by-both-arms"
-    inside = _print_id(_env(tmp_path, OPENCODE="1",
-                            CLAUDE_CODE_SESSION_ID=same_uuid))
-    outside = _print_id(_env(tmp_path, CLAUDE_CODE_SESSION_ID=same_uuid))
-    assert outside == "claude:" + same_uuid
-    assert inside == "oc-inherited:" + same_uuid
-    assert inside != outside
-    # The tier tags, specifically — that is what the server branches on.
-    assert outside.split(":", 1)[0] == S.SESSION_SRC_JOINABLE
-    assert inside.split(":", 1)[0] != S.SESSION_SRC_JOINABLE
+    inside = _print_id(_env(tmp_path, OPENCODE="1", **over))
+    outside = _print_id(_env(tmp_path, **over))
+    assert outside == want_id, "the pre-PR id changed"
+    assert inside == outside, "OPENCODE must not perturb the routing id"
 
 
-def test_an_empty_opencode_is_not_opencode(tmp_path):
-    """`OPENCODE=` (exported empty) is not an opencode session.
+def test_routing_equivalence_holds_for_the_derived_posix_tier(tmp_path):
+    """The `sid:` tier has no literal to pin (it reads live procfs), so it gets
+    the equality half only -- still enough to catch an id perturbed by OPENCODE.
+    Kept separate rather than bent into the table above so the table's literals
+    stay literal.
 
-    INVARIANT GUARD — green at f47be59 too, where no guard exists at all, so it
-    is not regression coverage. It pins the guard's BOUNDARY: `-n` vs `-z` is a
-    one-character difference that would turn every ordinary session into a
-    non-joinable one and silently re-empty the column. Proved reachable by
-    mutant M9 (condition inverted), which this test kills."""
-    env = _env(tmp_path, OPENCODE="", CLAUDE_CODE_SESSION_ID="uuid-A")
-    assert _print_id(env) == "claude:uuid-A"
-
-
-def test_the_re_tagged_id_is_still_stable_across_subshells(tmp_path):
-    """ROUTING MUST NOT BREAK. Per-session tab ownership needs one id across the
-    many `browser` calls a session makes, including through `$( ... )` — the exact
-    property the ppid fallback lost. Re-tagging preserves it because the
-    underlying value is untouched; minting a fresh id would not.
-
-    This runs the SAME probe as the joinable path's stability test, so the guard
-    is held to the same bar rather than a weaker one."""
-    r = _probe(tmp_path, _env(tmp_path, OPENCODE="1",
-                              CLAUDE_CODE_SESSION_ID="uuid-A"))
-    assert r["direct"] == r["subst"] == r["pipe"] == "oc-inherited:uuid-A", r
+    INVARIANT GUARD — green at 84bf324, whose re-tagging only ever fired on a
+    claude-tagged id, and at da33356. Proved reachable by mutant N6."""
+    inside = _print_id(_env(tmp_path, OPENCODE="1"))
+    outside = _print_id(_env(tmp_path))
+    assert SID_RE.match(outside), outside
+    assert inside == outside
 
 
-def test_opencode_does_not_disturb_the_lower_tiers(tmp_path):
-    """With no Claude var to inherit there is nothing leaked to re-tag, so the
-    chain must fall through unchanged.
+@pytest.mark.parametrize("var", ["CLAUDE_CODE_SESSION_ID", "CLAUDE_SESSION_ID"])
+@pytest.mark.skipif(shutil.which("curl") is None, reason="the CLI uses curl")
+def test_an_inherited_claude_id_declares_the_opencode_origin(capture, var):
+    """THE WIRE. Both Claude spellings feed the joinable tier, so a guard placed
+    on only the primary one would leave the alternate wide open.
 
-    INVARIANT GUARD — green at f47be59 too. It pins that the guard cannot swallow
-    the tmux/posix tiers whenever it fires. Proved reachable by mutant M10 (the
-    inner non-empty check dropped), which this test kills."""
-    assert _print_id(_env(tmp_path, OPENCODE="1", TMUX_PANE="%9")) == "tmux:%9"
-    assert SID_RE.match(_print_id(_env(tmp_path, OPENCODE="1")))
+    Asserted on the request the stub actually received: the id rides through
+    unchanged AND the origin header names this mechanism.
+    """
+    capture.run("emulate", "iphone-15", OPENCODE="1", **{var: "uuid-inherited"})
+    assert capture.headers, "the stub recorded no request at all"
+    h = capture.headers[0]
+    assert h.get("X-Session-Id") == "claude:uuid-inherited", h
+    assert h.get("X-Session-Origin") == "opencode-inherited", h
+
+
+@pytest.mark.skipif(shutil.which("curl") is None, reason="the CLI uses curl")
+def test_the_discriminating_pair_on_the_wire(capture):
+    """🔴 THE PAIR, at the transport. Same id both times; the header is the
+    ONLY difference, and it must be absent without OPENCODE.
+
+    Both directions in one test on purpose: a guard that declared the origin
+    unconditionally would suppress the session key for every ordinary Claude
+    session -- silently re-emptying the column this PR exists to fill -- and
+    would pass the leak test above on its own.
+    """
+    capture.run("emulate", "iphone-15", OPENCODE="1",
+                CLAUDE_CODE_SESSION_ID="uuid-pair")
+    inside = capture.headers[0]
+    capture.headers.clear()
+    capture.run("emulate", "iphone-15", CLAUDE_CODE_SESSION_ID="uuid-pair")
+    outside = capture.headers[0]
+
+    assert inside.get("X-Session-Id") == outside.get("X-Session-Id") == "claude:uuid-pair"
+    assert inside.get("X-Session-Origin") == "opencode-inherited", inside
+    assert "X-Session-Origin" not in outside, outside
+
+
+@pytest.mark.skipif(shutil.which("curl") is None, reason="the CLI uses curl")
+def test_an_opencode_session_with_no_claude_ancestor_declares_nothing(capture):
+    """opencode run INTERACTIVELY, with no Claude ancestor: nothing was inherited,
+    so there is nothing to disclaim. The id falls through to the `tmux:` tier and
+    NO origin header is sent -- the row behaves exactly as it does today.
+
+    This is the case a guard keyed on `OPENCODE` alone (rather than on having
+    actually inherited a claude-tagged id) would get wrong.
+
+    INVARIANT GUARD — green at 84bf324 and at da33356, where no origin header
+    exists at all, so it is not regression coverage. Proved reachable by mutant
+    N3 (the `claude:*` case widened to `*`), which this test alone kills.
+    """
+    capture.run("emulate", "iphone-15", OPENCODE="1", TMUX_PANE="%41")
+    assert capture.headers, "the stub recorded no request at all"
+    h = capture.headers[0]
+    assert h.get("X-Session-Id") == "tmux:%41", h
+    assert "X-Session-Origin" not in h, h
+
+
+@pytest.mark.skipif(shutil.which("curl") is None, reason="the CLI uses curl")
+def test_an_empty_opencode_is_not_opencode(capture):
+    """`OPENCODE=` (exported empty) is not an opencode session, so no origin is
+    declared.
+
+    INVARIANT GUARD — green at 84bf324 and at da33356. It pins the guard's
+    BOUNDARY: `-n` vs `-z` is a one-character difference that would disclaim
+    every ordinary session and re-empty the column. Proved reachable by mutants
+    N1 and N2."""
+    capture.run("emulate", "iphone-15", OPENCODE="",
+                CLAUDE_CODE_SESSION_ID="uuid-A")
+    h = capture.headers[0]
+    assert h.get("X-Session-Id") == "claude:uuid-A", h
+    assert "X-Session-Origin" not in h, h
+
+
+def test_the_cli_declares_the_token_the_server_tests_pin(tmp_path):
+    """SEAM. The token is a string the CLI writes and the server records; nothing
+    in either file fails if they drift. Read the literal out of the CLI source and
+    hold it against the ledger the server suite pins, so a rename on one side
+    cannot pass alone.
+
+    The parser is asserted non-empty first -- a regex that matched nothing would
+    make the comparison pass vacuously."""
+    src = CLI.read_text()
+    declared = set(re.findall(r'SESSION_ORIGIN="([a-z-]+)"', src))
+    assert declared, "the origin-token parser matched nothing -- it tests nothing"
+    assert declared == {"opencode-inherited"}, declared
+    # The other producer of an origin token is the opencode tool, not this CLI;
+    # the two must stay distinct or the populations merge in the column.
+    assert "browser-agent" not in declared

--- a/scripts/browser-bridge/tests/test_browser_session_id.py
+++ b/scripts/browser-bridge/tests/test_browser_session_id.py
@@ -59,7 +59,15 @@ pytestmark = pytest.mark.skipif(
 
 # Env vars that would short-circuit the derivation before the fallback we are
 # testing. Cleared for every fallback test.
-HIGHER_PRECEDENCE = ("CLAUDE_CODE_SESSION_ID", "CLAUDE_SESSION_ID", "TMUX_PANE")
+#
+# OPENCODE is in this list for a different reason than the rest, and it is the
+# harness-blindness one: opencode's CLI exports OPENCODE=1 for every subcommand,
+# so running THIS SUITE from inside an opencode session would silently change
+# what every `claude:`-expecting test below derives. Clearing it makes the
+# dimension explicit — the leak-guard tests set it themselves — instead of
+# letting the answer depend on which agent happened to launch pytest.
+HIGHER_PRECEDENCE = ("CLAUDE_CODE_SESSION_ID", "CLAUDE_SESSION_ID", "TMUX_PANE",
+                     "OPENCODE")
 
 SID_RE = re.compile(r"^sid:([1-9][0-9]*):([0-9]+|x)$")
 
@@ -424,7 +432,7 @@ import server as S  # noqa: E402
 # Every tag `derive_session_id` (and the recreate-close re-tag) can put on the
 # wire. Pinned two-way: the parse below must find exactly this set, so a NEW tier
 # fails here until someone decides whether it is joinable.
-CLI_TIER_TAGS = {"claude", "tmux", "sid", "ppid", "synthetic"}
+CLI_TIER_TAGS = {"claude", "tmux", "sid", "ppid", "synthetic", "oc-inherited"}
 
 
 def _emitted_tags():
@@ -435,9 +443,12 @@ def _emitted_tags():
     matched nothing would make every claim below pass vacuously.
     """
     src = CLI.read_text()
-    tags = set(re.findall(r"printf '([a-z]+):%s", src))
-    tags |= set(re.findall(r'SESSION_ID="([a-z]+):', src))
-    tags |= set(re.findall(r'tok="([a-z]+):', src))
+    # `[a-z][a-z-]*` — a tag may contain a hyphen (`oc-inherited`). Widened WITH
+    # the ledger assertion above as its control: if this over-matched, the set
+    # comparison would fail rather than quietly absorb the extra.
+    tags = set(re.findall(r"printf '([a-z][a-z-]*):%s", src))
+    tags |= set(re.findall(r'SESSION_ID="([a-z][a-z-]*):', src))
+    tags |= set(re.findall(r'tok="([a-z][a-z-]*):', src))
     return tags
 
 
@@ -564,3 +575,84 @@ def test_an_ordinary_cli_call_declares_no_nested_origin(capture):
     h = capture.headers[0]
     assert h.get("X-Session-Id") == "claude:uuid-direct", h
     assert "X-Session-Origin" not in h, h
+
+
+# --------------------------------------------------------------------------- #
+# 8. THE OPENCODE LEAK. `CLAUDE_CODE_SESSION_ID` survives into opencode's tool
+#    shells, so inside opencode it names an ANCESTOR, not the caller.
+#
+# MEASURED TWO WAYS: (a) a live env dump from inside an opencode bash tool
+# carried the outer Claude session's CLAUDE_CODE_SESSION_ID; (b) opencode 1.18.18
+# sets `process.env.OPENCODE="1"` in a yargs TOP-LEVEL `.middleware()`, i.e. for
+# every subcommand, and hands its tool shells `{...process.env}`.
+#
+# Claiming the joinable `claude:` tier on that value would write the OUTER
+# session's uuid into the telemetry `session` column, where it is
+# indistinguishable from that session's own direct browser use. The column is
+# EMPTY today: empty is recoverable, plausible-but-wrong is not. So the id is
+# RE-TAGGED (not re-derived) — non-joinable, but the same underlying value, so
+# it stays stable and per-session tab ownership survives.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("var", ["CLAUDE_CODE_SESSION_ID", "CLAUDE_SESSION_ID"])
+def test_a_leaked_claude_id_inside_opencode_is_not_claimed_as_joinable(tmp_path, var):
+    """Both spellings, because both feed the same joinable tier — a guard placed
+    on only the primary one would leave the alternate wide open."""
+    env = _env(tmp_path, OPENCODE="1", **{var: "uuid-leaked"})
+    assert _print_id(env) == "oc-inherited:uuid-leaked"
+
+
+def test_the_discriminating_pair_opencode_set_versus_unset(tmp_path):
+    """🔴 THE PAIR. The SAME uuid, derived twice, differing only in OPENCODE.
+
+    Asserted together on purpose: a guard that tagged EVERYTHING `oc-inherited`
+    would satisfy the leak test above on its own and silently empty the column
+    for ordinary Claude sessions — the very bug this PR fixes, restored. Only the
+    unset side may claim the joinable tier, and the two ids must differ so the
+    server can tell them apart at all.
+    """
+    same_uuid = "uuid-shared-by-both-arms"
+    inside = _print_id(_env(tmp_path, OPENCODE="1",
+                            CLAUDE_CODE_SESSION_ID=same_uuid))
+    outside = _print_id(_env(tmp_path, CLAUDE_CODE_SESSION_ID=same_uuid))
+    assert outside == "claude:" + same_uuid
+    assert inside == "oc-inherited:" + same_uuid
+    assert inside != outside
+    # The tier tags, specifically — that is what the server branches on.
+    assert outside.split(":", 1)[0] == S.SESSION_SRC_JOINABLE
+    assert inside.split(":", 1)[0] != S.SESSION_SRC_JOINABLE
+
+
+def test_an_empty_opencode_is_not_opencode(tmp_path):
+    """`OPENCODE=` (exported empty) is not an opencode session.
+
+    INVARIANT GUARD — green at f47be59 too, where no guard exists at all, so it
+    is not regression coverage. It pins the guard's BOUNDARY: `-n` vs `-z` is a
+    one-character difference that would turn every ordinary session into a
+    non-joinable one and silently re-empty the column. Proved reachable by
+    mutant M9 (condition inverted), which this test kills."""
+    env = _env(tmp_path, OPENCODE="", CLAUDE_CODE_SESSION_ID="uuid-A")
+    assert _print_id(env) == "claude:uuid-A"
+
+
+def test_the_re_tagged_id_is_still_stable_across_subshells(tmp_path):
+    """ROUTING MUST NOT BREAK. Per-session tab ownership needs one id across the
+    many `browser` calls a session makes, including through `$( ... )` — the exact
+    property the ppid fallback lost. Re-tagging preserves it because the
+    underlying value is untouched; minting a fresh id would not.
+
+    This runs the SAME probe as the joinable path's stability test, so the guard
+    is held to the same bar rather than a weaker one."""
+    r = _probe(tmp_path, _env(tmp_path, OPENCODE="1",
+                              CLAUDE_CODE_SESSION_ID="uuid-A"))
+    assert r["direct"] == r["subst"] == r["pipe"] == "oc-inherited:uuid-A", r
+
+
+def test_opencode_does_not_disturb_the_lower_tiers(tmp_path):
+    """With no Claude var to inherit there is nothing leaked to re-tag, so the
+    chain must fall through unchanged.
+
+    INVARIANT GUARD — green at f47be59 too. It pins that the guard cannot swallow
+    the tmux/posix tiers whenever it fires. Proved reachable by mutant M10 (the
+    inner non-empty check dropped), which this test kills."""
+    assert _print_id(_env(tmp_path, OPENCODE="1", TMUX_PANE="%9")) == "tmux:%9"
+    assert SID_RE.match(_print_id(_env(tmp_path, OPENCODE="1")))

--- a/scripts/browser-bridge/tests/test_browser_session_id.py
+++ b/scripts/browser-bridge/tests/test_browser_session_id.py
@@ -44,6 +44,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -400,3 +401,166 @@ def test_not_owned_tab_without_a_tab_flag_says_open_first(refuser):
     assert "claude:uuid-under-test" in err, err
     # No --tab was passed, so nothing may accuse a tab id.
     assert "is not owned by THIS session" not in err, err
+
+
+# --------------------------------------------------------------------------- #
+# 6. The tier TAG is now load-bearing for TELEMETRY, not just for collision
+#    avoidance.
+#
+# server.py reads the tag before the FIRST `:` to decide whether the id is a
+# joinable key for the activity.events `session` column: `claude:` is Claude
+# Code's own session uuid (the same value `source='claude'` rows store, so it
+# JOINS), while `tmux:`/`sid:`/`ppid:` are not — a pane id like %3 is stable
+# across many UNRELATED sessions and recording it would silently merge them.
+#
+# That makes the tag a SEAM: the CLI writes it, a different file reads it, and
+# nothing in either file fails if they drift. A rename here would not break a
+# single existing test and would silently empty the column again.
+# --------------------------------------------------------------------------- #
+sys.path.insert(0, str(BB))
+import server as S  # noqa: E402
+
+
+# Every tag `derive_session_id` (and the recreate-close re-tag) can put on the
+# wire. Pinned two-way: the parse below must find exactly this set, so a NEW tier
+# fails here until someone decides whether it is joinable.
+CLI_TIER_TAGS = {"claude", "tmux", "sid", "ppid", "synthetic"}
+
+
+def _emitted_tags():
+    """Parse the tags the CLI can emit out of its own source.
+
+    Each is a literal at the START of a printf format or an assignment, followed
+    by `:`. The parser is asserted non-empty by its caller — a regex that silently
+    matched nothing would make every claim below pass vacuously.
+    """
+    src = CLI.read_text()
+    tags = set(re.findall(r"printf '([a-z]+):%s", src))
+    tags |= set(re.findall(r'SESSION_ID="([a-z]+):', src))
+    tags |= set(re.findall(r'tok="([a-z]+):', src))
+    return tags
+
+
+def test_the_cli_tier_tag_vocabulary_is_pinned():
+    """SEAM LEDGER. Fails when the set GROWS (a new tier nobody classified as
+    joinable-or-not) or SHRINKS (a tag renamed or dropped) — neither of which any
+    behavioural test in this file would notice, because they all assert the tag
+    they were written with."""
+    found = _emitted_tags()
+    assert found, "the tag parser matched nothing — it is testing nothing"
+    assert found == CLI_TIER_TAGS, f"CLI tier tags drifted: {found}"
+
+
+def test_the_servers_joinable_tag_is_one_the_cli_actually_emits():
+    """The other half of the seam: server.py's allowlist must name a tag this CLI
+    can produce. If either side renames alone, the `session` column silently goes
+    back to empty — the exact bug this whole change fixes, restored with a green
+    suite on both sides."""
+    assert S.SESSION_SRC_JOINABLE in CLI_TIER_TAGS
+    assert S.SESSION_SRC_JOINABLE in _emitted_tags()
+    # And the fail-closed token is NOT a tag anything can legitimately emit.
+    assert S.SESSION_SRC_UNKNOWN not in CLI_TIER_TAGS
+
+
+def test_the_throwaway_recreate_close_id_is_re_tagged_not_just_suffixed():
+    """🔴 REGRESSION. `emulate --recreate` sends its close under a THROWAWAY id so
+    the close cannot evict the ownership mapping it just created. That id was
+    built by APPENDING to the real one — which left the live session's `claude:`
+    tag on a value that is not that session's key, so the bridge would have
+    stored `<uuid>+recreate-close` in the `session` column as a near-duplicate of
+    the real key, inflating distinct-session counts with fabricated rows.
+
+    Structural because the behaviour needs a full recreate round-trip against a
+    real extension; what is pinned is the property that actually matters — the
+    throwaway is re-TAGGED with a tier the server does not join on."""
+    src = CLI.read_text()
+    m = re.search(r'SESSION_ID="([^"]*\+recreate-close)"', src)
+    assert m, "the recreate-close throwaway id assignment is gone or renamed"
+    throwaway = m.group(1)
+    tag = throwaway.split(":", 1)[0]
+    assert tag == "synthetic", f"throwaway id wears tier tag {tag!r}"
+    assert tag != S.SESSION_SRC_JOINABLE
+    assert throwaway.startswith("synthetic:${SESSION_ID}"), throwaway
+
+
+# --------------------------------------------------------------------------- #
+# 7. The WIRE. A stub bridge that RECORDS the request headers, so what is
+#    asserted is what the CLI actually sends — not what a reader of the source
+#    believes it sends.
+#
+# INVARIANT GUARDS: these pass at base too. They exist because server.py now
+# DEPENDS on the tagged form reaching it, and nothing else asserts that the tag
+# survives the transport rather than only the deriver.
+# --------------------------------------------------------------------------- #
+_CAPTURED = []
+
+
+class _Capture(BaseHTTPRequestHandler):
+    def _record(self):
+        self.rfile.read(int(self.headers.get("Content-Length") or 0))
+        _CAPTURED.append({k: v for k, v in self.headers.items()})
+        raw = json.dumps({"ok": False, "error": "not_owned_tab"}).encode()
+        self.send_response(409)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    do_POST = _record
+    do_GET = _record
+
+    def log_message(self, *a):
+        pass
+
+
+@pytest.fixture
+def capture(tmp_path):
+    _CAPTURED.clear()
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), _Capture)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    tok = tmp_path / "token"
+    tok.write_text("test-token-abc123\n")
+    base = dict(BROWSER_BRIDGE_HOST="127.0.0.1",
+                BROWSER_BRIDGE_PORT=str(srv.server_address[1]),
+                BROWSER_BRIDGE_TOKEN_FILE=str(tok))
+
+    class _C:
+        headers = _CAPTURED
+
+        @staticmethod
+        def run(*args, **over):
+            env = _env(tmp_path, **{**base, **over})
+            return subprocess.run(["bash", str(CLI), *args], env=env,
+                                  capture_output=True, text=True, timeout=60)
+    try:
+        yield _C
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+@pytest.mark.skipif(shutil.which("curl") is None, reason="the CLI uses curl")
+@pytest.mark.parametrize("envvars,want_id", [
+    ({"CLAUDE_CODE_SESSION_ID": "uuid-onwire"}, "claude:uuid-onwire"),
+    ({"TMUX_PANE": "%41"}, "tmux:%41"),
+])
+def test_the_tagged_id_survives_the_transport(capture, envvars, want_id):
+    """PIN THE WIRE FORMAT: the tag is on the header value the server receives.
+    Two tiers with pairwise-distinct ids, so a stub that hardcoded either literal
+    could not satisfy both rows."""
+    capture.run("emulate", "iphone-15", **envvars)
+    assert capture.headers, "the stub recorded no request at all"
+    h = capture.headers[0]
+    assert h.get("X-Session-Id") == want_id, h
+
+
+@pytest.mark.skipif(shutil.which("curl") is None, reason="the CLI uses curl")
+def test_an_ordinary_cli_call_declares_no_nested_origin(capture):
+    """X-Session-Origin marks a NESTED browser-agent run, whose forwarded id must
+    not be credited as usage. The direct CLI must never send it — if it did,
+    every ordinary command would stop filling the session column."""
+    capture.run("health", CLAUDE_CODE_SESSION_ID="uuid-direct")
+    assert capture.headers, "the stub recorded no request at all"
+    h = capture.headers[0]
+    assert h.get("X-Session-Id") == "claude:uuid-direct", h
+    assert "X-Session-Origin" not in h, h

--- a/scripts/browser-bridge/tests/test_browser_session_id.py
+++ b/scripts/browser-bridge/tests/test_browser_session_id.py
@@ -470,6 +470,36 @@ def test_the_servers_joinable_tag_is_one_the_cli_actually_emits():
     assert S.SESSION_SRC_UNKNOWN not in CLI_TIER_TAGS
 
 
+def test_the_server_validation_set_equals_the_tags_parsed_from_the_cli():
+    """🔴 THE ACTUAL TWO-WAY PIN. server.py's SESSION_TIER_TAGS is compared against
+    the tags PARSED OUT OF THE CLI, not against a literal retyped beside it.
+
+    THIS TEST EXISTS BECAUSE THE PIN IT REPLACES WAS FICTIONAL. server.py said
+    SESSION_TIER_TAGS was "pinned two-way against the CLI by
+    test_browser_session_id.py" and the symbol appeared nowhere in this file: the
+    server set was checked against a literal in test_server.py, the CLI against a
+    separate literal here, and NOTHING compared the two. A delta audit measured
+    the consequence — grow the CLI by an `opencode:` tier and update
+    CLI_TIER_TAGS, leave server.py alone: 400 passed, 0 failed, SURVIVED.
+
+    That is not hypothetical. `browser`'s own FOLLOW-UP SLOT says an `opencode:`
+    tier is the next planned change, and the failure is silent and fail-closed:
+    the server normalises the unknown tag to `unknown`, drops the id, and the
+    column this PR exists to fill just re-empties.
+
+    Comparing against the PARSE is what makes it real — a literal can be updated
+    in lockstep with the thing it is supposed to be checking, which is precisely
+    how the fictional version passed.
+    """
+    parsed = _emitted_tags()
+    assert parsed, "the tag parser matched nothing — it is testing nothing"
+    assert set(S.SESSION_TIER_TAGS) == parsed, (
+        f"server.py SESSION_TIER_TAGS={sorted(S.SESSION_TIER_TAGS)} does not match "
+        f"the tags the CLI can actually emit {sorted(parsed)}. A tier present in "
+        f"one and not the other is silently normalised to "
+        f"{S.SESSION_SRC_UNKNOWN!r} and loses its id.")
+
+
 def test_the_throwaway_recreate_close_id_is_re_tagged_not_just_suffixed():
     """🔴 REGRESSION. `emulate --recreate` sends its close under a THROWAWAY id so
     the close cannot evict the ownership mapping it just created. That id was

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -1234,8 +1234,14 @@ def test_cmd_ok_emits_one_metadata_event(telemetry):
         assert int(e["duration_ms"]) >= 0        # latency present
         assert e["text"] == "mail.google.com"    # text = bare domain
         p = json.loads(e["payload"])
+        # Exact equality on purpose: metadata-only is asserted POSITIVELY and
+        # NEGATIVELY — nothing may creep into this payload unnoticed. `sess_src`
+        # is here because every /cmd row now states which tier its session id
+        # came from; this request sends NO X-Session-Id, so the honest answer is
+        # `unknown` and no `session` key is written (asserted below).
         assert p == {"op": "getHtml", "key": "", "outcome": "ok",
-                     "domain": "mail.google.com"}
+                     "domain": "mail.google.com", "sess_src": "unknown"}
+        assert "session" not in e, e
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
 
@@ -2150,6 +2156,430 @@ def test_load_spool_emit_missing_path_returns_none(monkeypatch, tmp_path):
     monkeypatch.setattr(S, "_spool_emit_mod", None)
     monkeypatch.setattr(S, "_spool_emit_tried", False)
     assert S._load_spool_emit() is None
+
+
+# --------------------------------------------------------------------------- #
+# The session JOIN KEY on browser-bridge telemetry rows.
+#
+# THE BUG (measured 2026-08-18): every `source='browser-bridge'` row had an EMPTY
+# `session` column — 0 of 6,937 over 14 days — while claude/opencode/keys/tmux/
+# zsh filled it 100%. The value already reached the server (X-Session-Id, used
+# for tab-ownership routing) and was simply never handed to emit_cmd_event, so
+# "which agent session made this browser call" was unanswerable from the one
+# structured source and had to be answered by scanning 1.5M transcript records.
+#
+# THE TWO HAZARDS THE FIX MUST NOT CREATE:
+#   1. TIER. The id is TAGGED with the fallback tier that produced it, and only
+#      `claude:` is a join key. `tmux:%3` is stable across many unrelated
+#      sessions in one pane, so recording it would silently merge them into one
+#      apparent session — worse than the empty column.
+#   2. NESTING. `browser agent` forwards its INVOKER's id, so a nested run's
+#      commands arrive wearing the operator's own `claude:` tag. Attributed
+#      naively, one `browser agent` call becomes N calls credited to the
+#      operator's session — a fabricated usage number in the exact column
+#      adoption-scan reads. The nested tool declares X-Session-Origin, and the
+#      forwarded id is then recorded as the causal PARENT, not the actor.
+#
+# FIXTURE DISCIPLINE: every id below is pairwise distinct AND distinct from every
+# constant the assertions name ("claude", "tmux", "unknown", "browser-agent", …),
+# so a mutant that hardcodes any of those literals cannot survive.
+# --------------------------------------------------------------------------- #
+JOINABLE_UUID = "6f1c9a20-1111-4bbb-8ccc-000000000001"
+JOINABLE_ID = "claude:" + JOINABLE_UUID
+NESTED_UUID = "8ab3d704-2222-4eee-9fff-000000000002"
+NESTED_ID = "claude:" + NESTED_UUID
+# tier tag -> (wire id, the bare id behind it). Mirrors derive_session_id's tags.
+TIER_IDS = {
+    "claude": (JOINABLE_ID, JOINABLE_UUID),
+    "tmux": ("tmux:%77", "%77"),
+    "sid": ("sid:424242:99887766", "424242:99887766"),
+    "ppid": ("ppid:31337:deadbeefcafef00d", "31337:deadbeefcafef00d"),
+    "synthetic": ("synthetic:" + JOINABLE_ID + "+recreate-close",
+                  JOINABLE_ID + "+recreate-close"),
+}
+
+
+def _cmd_sess(srv, body, sid=None, origin=None):
+    """POST /cmd with explicit session headers; None omits the header entirely."""
+    hdrs = {}
+    if sid is not None:
+        hdrs[S.HDR_SESSION_ID] = sid
+    if origin is not None:
+        hdrs[S.HDR_SESSION_ORIGIN] = origin
+    return _req(srv, "POST", "/cmd", body, headers=hdrs or None)
+
+
+@pytest.mark.parametrize("tier", sorted(TIER_IDS))
+def test_session_column_is_filled_for_the_joinable_tier_only(telemetry, tier):
+    """Each tier reports its own `sess_src`; ONLY `claude` fills `session`.
+
+    Both halves matter and are asserted together per tier:
+      * `sess_src` is always present, so a row is self-describing about WHY it
+        does or does not carry a key;
+      * `session` is the BARE id for the joinable tier and ABSENT for every other
+        — asserted as "the key is not in the record", not "it is empty", because
+        an empty column and a merged-sessions column are the two outcomes this
+        test exists to keep apart.
+    """
+    spool_dir = telemetry
+    wire_id, bare = TIER_IDS[tier]
+    srv, _ = _serve()
+    ext = FakeExtension(srv, instance_id="solo", label="only")
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _read_events(spool_dir) == [], "the negative control: 0 before"
+        st, body = _cmd_sess(srv, {"op": "tabs"}, sid=wire_id)
+        assert st == 200 and body["ok"] is True
+
+        evs = _wait_events(spool_dir, 1)
+        assert len(evs) == 1, evs
+        e = evs[0]
+        assert e["source"] == "browser-bridge"
+        # The USAGE signal (adoption-scan.py) is untouched by this change.
+        assert e["kind"] == "cmd"
+        p = json.loads(e["payload"])
+        assert p["sess_src"] == tier, p
+        if tier == "claude":
+            assert e.get("session") == bare, e
+        else:
+            assert "session" not in e, (
+                f"tier {tier!r} must NOT produce a join key; got {e.get('session')!r}")
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_the_session_column_carries_the_bare_id_not_the_wire_tag(telemetry):
+    """`session` must equal what `source='claude'` rows store — the BARE uuid.
+
+    The CLI tags its routing id `claude:<uuid>` so tiers cannot collide on the
+    wire. Storing that tag in the COLUMN would make browser-bridge the one source
+    needing a replaceOne() at every join site, and a forgotten one returns zero
+    rows — which reads as a valid "no sessions matched" answer.
+    """
+    spool_dir = telemetry
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=JOINABLE_ID)[0] == 200
+        e = _wait_events(spool_dir, 1)[0]
+        assert e["session"] == JOINABLE_UUID
+        assert ":" not in e["session"], e["session"]
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_only_the_first_colon_splits_a_multi_colon_id(telemetry):
+    """`sid:` and `ppid:` ids contain further colons. Splitting on the LAST one
+    (or on every one) would report a tier of `424242` and mangle the id — this
+    pins that the tag is the FIRST field and the remainder is kept whole."""
+    spool_dir = telemetry
+    wire_id, bare = TIER_IDS["sid"]
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=wire_id)[0] == 200
+        p = json.loads(_wait_events(spool_dir, 1)[0]["payload"])
+        assert p["sess_src"] == "sid"
+        assert S._split_session_id(wire_id) == ("sid", bare)
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+@pytest.mark.parametrize("untagged", ["", None])
+def test_an_absent_or_empty_id_fails_closed(telemetry, untagged):
+    """No id at all: the event still lands (usage is still usage), reports the
+    unknown tier, and carries no join key."""
+    spool_dir = telemetry
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=untagged)[0] == 200
+        e = _wait_events(spool_dir, 1)[0]
+        assert e["kind"] == "cmd"
+        assert json.loads(e["payload"])["sess_src"] == "unknown"
+        assert "session" not in e, e
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_an_untagged_id_is_never_promoted_to_a_join_key(telemetry):
+    """🔴 THE FAIL-CLOSED CASE THAT LOOKS MOST LIKE A JOIN KEY. A bare uuid with
+    no tier tag is exactly the value it would be tempting to accept — and a
+    version-skewed or hand-rolled caller can send anything (the opencode tool's
+    own default is the literal "browser-agent"). Provenance is stated or it is
+    unknown; it is never inferred from the value's FORM."""
+    spool_dir = telemetry
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=JOINABLE_UUID)[0] == 200
+        e = _wait_events(spool_dir, 1)[0]
+        p = json.loads(e["payload"])
+        assert p["sess_src"] == "unknown", p
+        assert p["sess_src"] not in TIER_IDS, "must not spell a real tier"
+        assert "session" not in e, e
+        # And the id itself is nowhere on the row, in any field.
+        assert JOINABLE_UUID not in _log_file(spool_dir).read_text()
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_a_tag_the_server_does_not_know_is_recorded_but_not_joined(telemetry):
+    """A FUTURE tier: record it verbatim for diagnosis, join on nothing. Only the
+    ONE known-joinable tag opens the gate — an allowlist, not a denylist."""
+    spool_dir = telemetry
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _cmd_sess(srv, {"op": "tabs"},
+                         sid="futuretier:" + JOINABLE_UUID)[0] == 200
+        e = _wait_events(spool_dir, 1)[0]
+        assert json.loads(e["payload"])["sess_src"] == "futuretier"
+        assert "session" not in e, e
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# --- nesting: the forwarded id is the causal PARENT, not the actor --------- #
+def test_a_nested_run_records_the_forwarded_id_as_origin_not_as_session(telemetry):
+    """`browser agent` forwards its INVOKER's `claude:` id. Attributed naively,
+    one agent call becomes N calls credited to the operator's own session —
+    fabricated usage in the column adoption-scan reads (~11% of bridge commands
+    over 14d). The origin declaration moves it to `origin_session`, where nothing
+    can mistake the parent for the actor.
+
+    The id is DISTINCT from the ordinary-request fixture below, so a mutant that
+    wrote whichever id it had lying around cannot satisfy both.
+    """
+    spool_dir = telemetry
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=NESTED_ID,
+                         origin="browser-agent")[0] == 200
+        e = _wait_events(spool_dir, 1)[0]
+        p = json.loads(e["payload"])
+        assert "session" not in e, f"a nested run must not claim the session: {e}"
+        assert p["origin"] == "browser-agent", p
+        assert p["origin_session"] == NESTED_UUID, p
+        assert p["sess_src"] == "claude", p   # the tier of the forwarded id
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_an_ordinary_request_sets_session_and_declares_no_origin(telemetry):
+    """The other side of the nesting fork, on the SAME request shape: a direct
+    call fills `session` and adds NO origin fields. Without this pair, a change
+    that dropped attribution entirely would still satisfy the nested test."""
+    spool_dir = telemetry
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=JOINABLE_ID)[0] == 200
+        e = _wait_events(spool_dir, 1)[0]
+        p = json.loads(e["payload"])
+        assert e["session"] == JOINABLE_UUID, e
+        assert "origin" not in p, p
+        assert "origin_session" not in p, p
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_an_origin_wins_over_the_joinable_tier_on_every_emit_site(telemetry):
+    """The three /cmd emit call sites are three places to forget the fork. All
+    three are exercised with a joinable tier PLUS an origin; none may write a
+    session key."""
+    spool_dir = telemetry
+    # 1. the `release` short-circuit (returns before submit).
+    srv, _ = _serve()
+    try:
+        assert _cmd_sess(srv, {"op": "release"}, sid=NESTED_ID,
+                         origin="browser-agent")[0] == 200
+        e = _wait_events(spool_dir, 1)[0]
+        assert "session" not in e, e
+        assert json.loads(e["payload"])["origin_session"] == NESTED_UUID
+    finally:
+        srv.shutdown(); srv.server_close()
+
+    # 2. the throttle path, and 3. the terminal emit.
+    reg = S.Registry(rate_per_sec=0.001, burst=1, max_queue=1000)
+    srv, _ = _serve(registry=reg)
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=NESTED_ID,
+                         origin="browser-agent")[0] == 200          # terminal
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=NESTED_ID,
+                         origin="browser-agent")[0] == 429          # throttled
+        evs = _wait_events(spool_dir, 3)[1:]
+        assert len(evs) == 2, evs
+        for e in evs:
+            assert "session" not in e, e
+            assert json.loads(e["payload"])["origin"] == "browser-agent"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_the_release_short_circuit_attributes_an_ordinary_session(telemetry):
+    """`release` returns BEFORE the submit path, from its own emit call site. A
+    second call site is a second place to forget the attribution — pin it."""
+    spool_dir = telemetry
+    srv, _ = _serve()
+    try:
+        st, body = _cmd_sess(srv, {"op": "release"}, sid=JOINABLE_ID)
+        assert st == 200 and body["ok"] is True
+        e = _wait_events(spool_dir, 1)[0]
+        assert json.loads(e["payload"])["sess_src"] == "claude"
+        assert e["session"] == JOINABLE_UUID
+    finally:
+        srv.shutdown(); srv.server_close()
+
+
+def test_the_throttle_path_carries_both_the_hash_and_the_join_key(telemetry):
+    """The throttle emit is the THIRD call site. `sess` (the coarse hash) is KEPT
+    on purpose beside the new `session` column: the column is filled for the
+    joinable tier and non-nested calls only, and a flood from a tmux/sid/unknown
+    tier or a nested agent run is exactly the case where you still need some
+    stable handle to tell one flooder from two."""
+    spool_dir = telemetry
+    reg = S.Registry(rate_per_sec=0.001, burst=1, max_queue=1000)
+    srv, _ = _serve(registry=reg)
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=JOINABLE_ID)[0] == 200
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=JOINABLE_ID)[0] == 429
+        evs = _wait_events(spool_dir, 2)
+        thr = [e for e in evs
+               if json.loads(e["payload"]).get("outcome") == "throttled"]
+        assert len(thr) == 1, evs
+        p = json.loads(thr[0]["payload"])
+        assert p["sess"] == hashlib.sha256(JOINABLE_ID.encode()).hexdigest()[:8]
+        assert p["sess_src"] == "claude"
+        assert thr[0]["session"] == JOINABLE_UUID
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_a_raising_emitter_still_lets_the_command_succeed(telemetry, monkeypatch):
+    """BEST-EFFORT CONTRACT, re-proved through the NEW code path: the attribution
+    branch runs inside emit_cmd_event's swallowing try, so an emitter that
+    explodes while attributing must still leave /cmd at 200.
+
+    Four header shapes are exercised — joinable, non-joinable, nested, and none
+    at all — because a guard that only holds on the path you thought about is not
+    a guard."""
+    class _Boom:
+        @staticmethod
+        def emit(_rec):
+            raise RuntimeError("spool exploded")
+
+    monkeypatch.setattr(S, "_load_spool_emit", lambda: _Boom)
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        for sid, origin in ((JOINABLE_ID, None), (TIER_IDS["tmux"][0], None),
+                            (NESTED_ID, "browser-agent"), (None, None)):
+            st, body = _cmd_sess(srv, {"op": "tabs"}, sid=sid, origin=origin)
+            assert st == 200 and body["ok"] is True, (sid, origin)
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_an_oversized_id_is_dropped_whole_never_truncated(telemetry):
+    """A truncated join key is a WRONG join key — it silently attributes a call to
+    a different session. So an id past the sanity bound is dropped ENTIRELY.
+
+    The paired control is the point: the SAME request shape with a well-formed id
+    DOES produce a key, so this cannot pass by the emitter being wired to nothing.
+    """
+    spool_dir = telemetry
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        # Positive control first: a good id on this exact path yields a key.
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=JOINABLE_ID)[0] == 200
+        good = _wait_events(spool_dir, 1)[0]
+        assert good["session"] == JOINABLE_UUID, "positive control: no key emitted"
+
+        over = "claude:" + ("x" * (S.MAX_SESSION_FIELD + 1))
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=over)[0] == 200
+        evs = _wait_events(spool_dir, 2)
+        assert "session" not in evs[1], evs[1]
+        assert json.loads(evs[1]["payload"])["sess_src"] == "unknown", evs[1]
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+@pytest.mark.parametrize("bad", ["has\ttab", "has\nnewline", "has\x00nul",
+                                 "has\x7fdel"])
+def test_a_control_character_id_is_dropped_at_the_unit(bad):
+    """Unit-level because these cannot travel: http.client refuses a header value
+    containing a newline, so the wire cannot deliver one. The sanitiser is still
+    what decides, and a control character in a column other tools compare with
+    `=` is an unreadable handle — drop it whole.
+
+    Paired with its own control, so a sanitiser that rejected EVERYTHING would be
+    caught rather than looking correct."""
+    assert S._clean_session_field(bad) == ""
+    assert S._split_session_id("claude:" + bad) == ("unknown", "")
+    assert S._split_session_id(JOINABLE_ID) == ("claude", JOINABLE_UUID)  # control
+
+
+def test_extra_cannot_overwrite_the_attribution(telemetry):
+    """The attribution fields are written AFTER the `extra` merge, so an internal
+    call site cannot smuggle a tier or an origin the headers did not send.
+    Unit-level: `extra` is not caller-reachable today, and this pins that it stays
+    uncontestable if it ever becomes so."""
+    spool_dir = telemetry
+    S.emit_cmd_event(op="tabs", key="", outcome="ok", duration_ms=1,
+                     extra={"sess_src": "claude", "origin": "spoofed"},
+                     session_id=TIER_IDS["tmux"][0], attribute_session=True)
+    e = _read_events(spool_dir)[0]
+    p = json.loads(e["payload"])
+    assert p["sess_src"] == "tmux", p
+    assert "origin" not in p, p
+    assert "session" not in e, e
+
+
+def test_server_originated_events_carry_no_session_fields(telemetry):
+    """INVARIANT GUARD (green before this change too — it pins what must NOT move).
+
+    The heartbeat and the /whoami+/health diagnostics have no caller session at
+    all, so they must gain neither `session` nor `sess_src`. A `sess_src` on a
+    machine-generated row would be a claim about a caller that does not exist,
+    and the diagnostics' payload equality is asserted elsewhere as exactly
+    {op,key,outcome}."""
+    spool_dir = telemetry
+    S.emit_heartbeat_event(S.Registry())
+    S._emit_diag_event("whoami", time.monotonic())
+    evs = _wait_events(spool_dir, 2)
+    assert len(evs) == 2, evs
+    for e in evs:
+        assert "session" not in e, e
+        p = json.loads(e["payload"])
+        assert "sess_src" not in p and "origin" not in p, e
 
 
 # --------------------------------------------------------------------------- #
@@ -3433,7 +3863,13 @@ def test_cmd_rate_limited_returns_429_and_emits_throttle(telemetry):
         # Attribution is a COARSE, non-reversible hash of X-Session-Id — NOT raw.
         assert p["sess"] == hashlib.sha256(b"floodsession").hexdigest()[:8]
         raw = _log_file(spool_dir).read_text()
-        assert "floodsession" not in raw          # raw session id NEVER stored
+        # This id carries no tier TAG, so it is `unknown` and no join key may be
+        # written — the raw id appears nowhere. (Since the session-key fix a
+        # `claude:`-tagged id DOES reach the `session` column, deliberately; see
+        # the join-key section below. The invariant here is the fail-closed one,
+        # not "never".)
+        assert "floodsession" not in raw
+        assert p["sess_src"] == "unknown"
         # No deadlock: the server still answers after shedding load.
         assert _req(srv, "GET", "/health")[0] == 200
     finally:

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -2188,12 +2188,18 @@ JOINABLE_UUID = "6f1c9a20-1111-4bbb-8ccc-000000000001"
 JOINABLE_ID = "claude:" + JOINABLE_UUID
 NESTED_UUID = "8ab3d704-2222-4eee-9fff-000000000002"
 NESTED_ID = "claude:" + NESTED_UUID
-# A Claude session uuid that LEAKED into an opencode tool shell. The CLI re-tags
-# it `oc-inherited:` because inside opencode the variable names an ANCESTOR, not
-# the caller -- see the leak section at the bottom of this file. Distinct from
-# both uuids above so a mutant reusing either cannot satisfy its tests.
+# A Claude session uuid that LEAKED into an opencode tool shell. It arrives
+# `claude:`-tagged and is INDISTINGUISHABLE from a direct call by inspection --
+# the id is genuinely the outer session's. Only the origin header separates them,
+# which is exactly why the fix is a header and not a tier. Distinct from both
+# uuids above so a mutant reusing either cannot satisfy its tests.
 LEAKED_UUID = "c05e17b6-3333-4aaa-8ddd-000000000003"
-LEAKED_ID = "oc-inherited:" + LEAKED_UUID
+LEAKED_ID = "claude:" + LEAKED_UUID
+# The complete set of origin tokens any caller may declare. Pinned as a LEDGER:
+# both mean "issued by something nested under origin_session", and both must
+# suppress the session key identically. A third one added without a test here
+# fails the ledger rather than silently getting a different behaviour.
+ORIGIN_TOKENS = ("browser-agent", "opencode-inherited")
 # tier tag -> (wire id, the bare id behind it). Mirrors derive_session_id's tags.
 TIER_IDS = {
     "claude": (JOINABLE_ID, JOINABLE_UUID),
@@ -2202,7 +2208,6 @@ TIER_IDS = {
     "ppid": ("ppid:31337:deadbeefcafef00d", "31337:deadbeefcafef00d"),
     "synthetic": ("synthetic:" + JOINABLE_ID + "+recreate-close",
                   JOINABLE_ID + "+recreate-close"),
-    "oc-inherited": (LEAKED_ID, LEAKED_UUID),
 }
 
 
@@ -2573,39 +2578,43 @@ def test_extra_cannot_overwrite_the_attribution(telemetry):
 # --------------------------------------------------------------------------- #
 # The opencode leak, server side.
 #
-# `CLAUDE_CODE_SESSION_ID` survives into opencode's tool shells (opencode 1.18.18
-# sets OPENCODE=1 in a yargs top-level `.middleware()` and hands its tools
-# `{...process.env}`; a live env dump confirmed the outer Claude id was still
-# there). So the CLI re-tags the leaked value `oc-inherited:` and the server must
-# treat that tag as NON-joinable — otherwise a plain `opencode run …` whose bash
-# tool shells out to `browser` writes the OUTER Claude session's uuid into
-# `session`, indistinguishable from that session's own direct browser use.
+# `CLAUDE_CODE_SESSION_ID` survives into opencode's tool shells (opencode sets
+# OPENCODE=1 in a yargs top-level `.middleware()` and hands its tools
+# `{...process.env}` -- confirmed in the PINNED build, see PINNED_VERSION in
+# scripts/tests/test_opencode_engine.py; a live env dump showed the outer Claude
+# id still present). So a plain `opencode run …` whose bash tool shells out to
+# `browser` sends a genuinely `claude:`-tagged id that names an ANCESTOR.
 #
-# The tier itself is covered by the parametrized table above. What is left is the
-# interaction nobody owns: browser-agent invoked from INSIDE an opencode session,
-# where the leak guard and the nesting guard both apply at once.
+# 🔴 THE ID IS INDISTINGUISHABLE FROM A DIRECT CALL. There is nothing in it to
+# branch on -- it IS the outer session's id, correctly tagged. That is precisely
+# why the fix is the ORIGIN HEADER and not a new tier: the server cannot tell
+# these apart by inspection, so the caller has to say so. It is the same question
+# `browser agent` already answers the same way, and one question gets one
+# mechanism.
 #
-# 🔴 HONEST LABEL: every test in this section is an INVARIANT GUARD relative to
-# f47be59 (this PR's first commit), and green there. The whole leak fix lives in
-# the CLI — the server needed NO change, because its tier gate is an allowlist of
-# exactly one tag, so a tag it has never heard of was already non-joinable. These
-# tests are not regression coverage for a server bug; they pin that the generic
-# gate really does cover the new tag, and that the leak and nesting guards
-# compose. They ARE red against origin/main (da33356), where `sess_src` and the
-# origin header do not exist at all. Reachability is proved by mutant M11, which
-# widens the gate to admit `oc-inherited` and is killed here.
+# 🔴 HONEST LABEL: everything in this section is an INVARIANT GUARD, green at
+# BOTH f47be59 (which introduced the origin path) and 84bf324. The server needed
+# NO change for the opencode leak -- the origin path already did the right thing,
+# and reusing it rather than adding a parallel one is the entire point of this
+# round. These tests pin that BOTH origin tokens behave identically and that a
+# leaked-but-genuinely-claude-tagged id composes with the tier gate; they are not
+# regression coverage for a server bug. They ARE red against origin/main
+# (da33356), where the origin header does not exist. Reachability is proved by
+# mutants N7 (origin never detected) and N8 (the token collapsed to a constant).
 # --------------------------------------------------------------------------- #
-def test_a_nested_agent_run_inside_opencode_keeps_both_guards(telemetry):
-    """SEAM. `browser agent` normally derives its id BEFORE opencode starts, so
-    the id is `claude:`-tagged and only the ORIGIN guard stops the invoker being
-    credited. But when browser-agent is itself launched from inside an opencode
-    session, OPENCODE is already set at `--print-session-id` time, so the
-    forwarded id arrives `oc-inherited:`-tagged AND carries the origin header.
+@pytest.mark.parametrize("token", ORIGIN_TOKENS)
+def test_every_origin_token_suppresses_the_session_key(telemetry, token):
+    """LEDGER + BEHAVIOUR. Both declared origins mean the same thing -- "issued by
+    something nested under this id" -- so both must suppress `session` and record
+    the id as the causal parent instead.
 
-    Both guards must hold together, and the origin must still win: no `session`,
-    the tier reported honestly, and the bare id recorded as the causal parent —
-    a bare uuid, exactly as on the non-leaked nested path, so the two are
-    queryable the same way.
+    Parametrized over the ledger rather than written once per token: a third
+    token added to ORIGIN_TOKENS without server support fails here, and a token
+    that got special-cased into filling `session` fails here too.
+
+    The id is `claude:`-tagged on purpose. A non-joinable tier would suppress
+    `session` on its own, so the test would pass with the origin logic deleted --
+    the joinable tier is the only fixture that can distinguish the two.
     """
     spool_dir = telemetry
     srv, _ = _serve()
@@ -2613,41 +2622,63 @@ def test_a_nested_agent_run_inside_opencode_keeps_both_guards(telemetry):
     ext.start()
     try:
         assert _wait_connected(srv, want=True)
-        assert _cmd_sess(srv, {"op": "tabs"}, sid=LEAKED_ID,
-                         origin="browser-agent")[0] == 200
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=LEAKED_ID, origin=token)[0] == 200
         e = _wait_events(spool_dir, 1)[0]
         p = json.loads(e["payload"])
-        assert "session" not in e, f"a leaked+nested id must claim nothing: {e}"
-        assert p["sess_src"] == "oc-inherited", p
-        assert p["origin"] == "browser-agent", p
+        assert "session" not in e, f"origin {token!r} must claim no session: {e}"
+        assert p["origin"] == token, p
         assert p["origin_session"] == LEAKED_UUID, p
         assert ":" not in p["origin_session"], p
+        # The tier is still reported honestly -- the id really is claude-tagged.
+        assert p["sess_src"] == "claude", p
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
 
 
-def test_the_leaked_tier_is_not_the_joinable_one(telemetry):
-    """The blunt statement of the fix, asserted against the CONSTANT rather than
-    the spelling: whatever `SESSION_SRC_JOINABLE` is, the leak tier is not it, and
-    a leaked id on the ordinary (non-nested) path writes no key.
+def test_the_same_id_fills_the_session_when_no_origin_is_declared(telemetry):
+    """🔴 THE CONTROL FOR THE WHOLE MECHANISM, and the reason the fixture above is
+    `claude:`-tagged. The EXACT SAME id on the EXACT SAME path, differing only in
+    whether the origin header is present, must fill `session`.
 
-    Its control is the joinable id on the SAME path in the same test — so a
-    server that had simply stopped writing `session` at all could not pass."""
+    Without this pair, a server that had simply stopped writing `session`
+    altogether would satisfy every origin test in this file.
+    """
     spool_dir = telemetry
-    assert S.SESSION_SRC_JOINABLE != "oc-inherited"
     srv, _ = _serve()
     ext = FakeExtension(srv)
     ext.start()
     try:
         assert _wait_connected(srv, want=True)
         assert _cmd_sess(srv, {"op": "tabs"}, sid=LEAKED_ID)[0] == 200
-        assert _cmd_sess(srv, {"op": "tabs"}, sid=JOINABLE_ID)[0] == 200
-        leaked, direct = _wait_events(spool_dir, 2)
-        assert "session" not in leaked, leaked
-        assert json.loads(leaked["payload"])["sess_src"] == "oc-inherited"
-        assert direct["session"] == JOINABLE_UUID, "control: direct use still joins"
-        # The two uuids are different values, so this cannot pass by coincidence.
-        assert LEAKED_UUID not in _log_file(spool_dir).read_text()
+        e = _wait_events(spool_dir, 1)[0]
+        assert e["session"] == LEAKED_UUID, e
+        assert "origin" not in json.loads(e["payload"])
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_the_two_origin_tokens_are_distinct_and_recorded_verbatim(telemetry):
+    """`origin` is a two-value enum and its VALUE carries the diagnosis: which
+    nesting mechanism produced the row. Recording one token under the other's
+    name would make the two populations unseparable in the column -- the same
+    class of harm as the session key itself.
+
+    Asserted as distinctness plus verbatim round-trip, so a mutant that collapsed
+    them to a single constant dies here rather than in a test that only checks
+    `origin` is truthy."""
+    spool_dir = telemetry
+    assert len(set(ORIGIN_TOKENS)) == len(ORIGIN_TOKENS), ORIGIN_TOKENS
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        for token in ORIGIN_TOKENS:
+            assert _cmd_sess(srv, {"op": "tabs"}, sid=LEAKED_ID,
+                             origin=token)[0] == 200
+        evs = _wait_events(spool_dir, len(ORIGIN_TOKENS))
+        seen = [json.loads(e["payload"])["origin"] for e in evs]
+        assert seen == list(ORIGIN_TOKENS), seen
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
 

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -2403,18 +2403,22 @@ def test_a_whitespace_padded_tag_is_rejected_at_the_unit(padded):
     assert S._split_session_id(JOINABLE_ID) == ("claude", JOINABLE_UUID)
 
 
-def test_the_server_tier_vocabulary_matches_what_the_cli_can_emit():
-    """SEAM LEDGER, server side. The validation set must equal the tags the CLI
-    actually produces, or a legitimate tier gets silently normalised to `unknown`
-    and its rows lose their id. The CLI half of this pin lives in
-    test_browser_session_id.py; this is the half that fails if the SERVER list
-    drifts."""
+def test_the_tier_vocabulary_holds_its_internal_invariants():
+    """The SELF-CONSISTENCY half only. Whether the set matches the CLI is pinned
+    in test_browser_session_id.py::
+    test_the_server_validation_set_equals_the_tags_parsed_from_the_cli, which
+    compares it against tags PARSED from the CLI source.
+
+    🔴 The literal that used to live here has been DELETED, deliberately. It read
+    as a cross-file pin and was not one: retyping the CLI's tags beside the
+    server's meant a change touching both real files sailed through, and a delta
+    audit measured exactly that (grow the CLI + its own ledger, leave the server
+    alone -> 400 passed, SURVIVED). A literal that can be updated in lockstep
+    with the thing it checks is worse than no check, because it reads as one."""
     assert S.SESSION_SRC_JOINABLE in S.SESSION_TIER_TAGS
     assert S.SESSION_SRC_UNKNOWN not in S.SESSION_TIER_TAGS, (
         "the fallback marker must not also be a real tier -- an unparseable id "
         "and a genuine tier would become indistinguishable")
-    assert set(S.SESSION_TIER_TAGS) == {"claude", "tmux", "sid", "ppid",
-                                        "synthetic"}, S.SESSION_TIER_TAGS
 
 
 # --- nesting: the forwarded id is the causal PARENT, not the actor --------- #

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -2118,7 +2118,12 @@ def test_orientation_ops_emit_exactly_one_metadata_only_event(telemetry, path, o
         assert e["exit_code"] == "0"
         assert e["text"] == op                      # no domain → text is the op
         p = json.loads(e["payload"])
-        assert p == {"op": op, "key": "", "outcome": "ok"}, p
+        # Exact equality still, so nothing can creep in unnoticed. `sess_src` is
+        # here because these are OPERATOR calls and are now attributed like any
+        # other command (see test_only_the_heartbeat_is_server_originated); this
+        # request sends no X-Session-Id, so the honest tier is `unknown`.
+        assert p == {"op": op, "key": "", "outcome": "ok",
+                     "sess_src": "unknown"}, p
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
 
@@ -2176,8 +2181,11 @@ def test_load_spool_emit_missing_path_returns_none(monkeypatch, tmp_path):
 #   2. NESTING. `browser agent` forwards its INVOKER's id, so a nested run's
 #      commands arrive wearing the operator's own `claude:` tag. Attributed
 #      naively, one `browser agent` call becomes N calls credited to the
-#      operator's session — a fabricated usage number in the exact column
-#      adoption-scan reads. The nested tool declares X-Session-Origin, and the
+#      operator's session — fabricated rows in the `session` JOIN column. (NOT,
+#      as an earlier draft said, "the column adoption-scan reads": adoption-scan
+#      never selects `session` for this source, and the deadman reads only row
+#      existence. The harm is latent — it corrupts the first consumer that does
+#      read it.) The nested tool declares X-Session-Origin, and the
 #      forwarded id is then recorded as the causal PARENT, not the actor.
 #
 # FIXTURE DISCIPLINE: every id below is pairwise distinct AND distinct from every
@@ -2345,9 +2353,23 @@ def test_an_untagged_id_is_never_promoted_to_a_join_key(telemetry):
         ext.stop(); srv.shutdown(); srv.server_close()
 
 
-def test_a_tag_the_server_does_not_know_is_recorded_but_not_joined(telemetry):
-    """A FUTURE tier: record it verbatim for diagnosis, join on nothing. Only the
-    ONE known-joinable tag opens the gate — an allowlist, not a denylist."""
+@pytest.mark.parametrize("bogus_tag", [
+    "futuretier",      # a tier that does not exist yet
+    "CLAUDE",          # the joinable tag, wrong case
+    "claud",           # a near-miss
+    "['claude",        # the shape a mangled caller actually produced
+])
+def test_a_tag_outside_the_vocabulary_is_normalised_not_recorded(telemetry, bogus_tag):
+    """🔴 `sess_src` IS A CLOSED SET, NOT FREE TEXT. It arrives on a
+    caller-supplied header, so recording it verbatim makes it an
+    unbounded-cardinality column: every string below was measured landing in it
+    unchanged, and four of the five are near-misses of the joinable tag that a
+    reader skimming a GROUP BY would misread as the real thing.
+
+    Anything outside SESSION_TIER_TAGS collapses to `unknown` and carries NO id.
+    A genuinely new tier needs a CLI change, which the two-way vocabulary pin in
+    test_browser_session_id.py already forces someone to declare.
+    """
     spool_dir = telemetry
     srv, _ = _serve()
     ext = FakeExtension(srv)
@@ -2355,20 +2377,53 @@ def test_a_tag_the_server_does_not_know_is_recorded_but_not_joined(telemetry):
     try:
         assert _wait_connected(srv, want=True)
         assert _cmd_sess(srv, {"op": "tabs"},
-                         sid="futuretier:" + JOINABLE_UUID)[0] == 200
+                         sid=bogus_tag + ":" + JOINABLE_UUID)[0] == 200
         e = _wait_events(spool_dir, 1)[0]
-        assert json.loads(e["payload"])["sess_src"] == "futuretier"
+        p = json.loads(e["payload"])
+        assert p["sess_src"] == "unknown", p
         assert "session" not in e, e
+        # Neither half of an unrecognised id may survive anywhere on the row.
+        assert JOINABLE_UUID not in _log_file(spool_dir).read_text()
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
+
+
+@pytest.mark.parametrize("padded", [" claude", "claude ", "\tclaude"])
+def test_a_whitespace_padded_tag_is_rejected_at_the_unit(padded):
+    """Unit-level because these CANNOT travel: an HTTP header value is delimited
+    by the colon-space, so `X-Session-Id:  claude:<uuid>` arrives as
+    `claude:<uuid>` with the padding already gone -- measured, and it is why this
+    case is not in the HTTP table above. The validator is still what decides, and
+    a padded tag must not slip through if a future caller reaches the emitter by
+    another route.
+
+    Paired with its own control so a validator that rejected EVERYTHING would be
+    caught rather than looking correct."""
+    assert S._split_session_id(padded + ":" + JOINABLE_UUID) == ("unknown", "")
+    assert S._split_session_id(JOINABLE_ID) == ("claude", JOINABLE_UUID)
+
+
+def test_the_server_tier_vocabulary_matches_what_the_cli_can_emit():
+    """SEAM LEDGER, server side. The validation set must equal the tags the CLI
+    actually produces, or a legitimate tier gets silently normalised to `unknown`
+    and its rows lose their id. The CLI half of this pin lives in
+    test_browser_session_id.py; this is the half that fails if the SERVER list
+    drifts."""
+    assert S.SESSION_SRC_JOINABLE in S.SESSION_TIER_TAGS
+    assert S.SESSION_SRC_UNKNOWN not in S.SESSION_TIER_TAGS, (
+        "the fallback marker must not also be a real tier -- an unparseable id "
+        "and a genuine tier would become indistinguishable")
+    assert set(S.SESSION_TIER_TAGS) == {"claude", "tmux", "sid", "ppid",
+                                        "synthetic"}, S.SESSION_TIER_TAGS
 
 
 # --- nesting: the forwarded id is the causal PARENT, not the actor --------- #
 def test_a_nested_run_records_the_forwarded_id_as_origin_not_as_session(telemetry):
     """`browser agent` forwards its INVOKER's `claude:` id. Attributed naively,
     one agent call becomes N calls credited to the operator's own session —
-    fabricated usage in the column adoption-scan reads (~11% of bridge commands
-    over 14d). The origin declaration moves it to `origin_session`, where nothing
+    fabricated rows in the `session` JOIN column (~11% of bridge commands over
+    14d). Not "the column adoption-scan reads" -- it does not read this one; the
+    harm is latent, landing on the first consumer that does. The origin declaration moves it to `origin_session`, where nothing
     can mistake the parent for the actor.
 
     The id is DISTINCT from the ordinary-request fixture below, so a mutant that
@@ -2683,23 +2738,245 @@ def test_the_two_origin_tokens_are_distinct_and_recorded_verbatim(telemetry):
         ext.stop(); srv.shutdown(); srv.server_close()
 
 
-def test_server_originated_events_carry_no_session_fields(telemetry):
-    """INVARIANT GUARD (green before this change too — it pins what must NOT move).
+# --------------------------------------------------------------------------- #
+# The ORIGIN path, hardened. Three findings from the blind audit of #549, all one
+# shape: the origin path was more permissive than the id path beside it.
+#
+#   A1. The origin sanitiser failed OPEN. `if origin:` on the CLEANED value meant
+#       an oversized or control-char origin cleaned to "" and fell through to the
+#       `elif`, writing `session` WITH THE PARENT'S ID -- the exact fabrication
+#       the mechanism exists to prevent. Measured: a 201-char origin produced
+#       session='uuid-w'.
+#   A2. `origin` accepted anything. `totally-made-up`, `false`, `   ` were all
+#       recorded verbatim and all suppressed `session`. The "two-value enum" was
+#       documentation, not a contract.
+#   A3. `origin_session` bypassed the tier gate, and is REACHABLE: browser-agent
+#       forwards whatever --print-session-id produced and the opencode tool
+#       declares its origin unconditionally, so `tmux:%3` genuinely arrived and
+#       was recorded as `origin_session='%3'`.
+#
+# The fix is one rule: branch on header PRESENCE, validate the value against the
+# ledger, and put `origin_session` behind the SAME tier gate as `session`.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("bad_origin,label", [
+    ("x" * (S.MAX_SESSION_FIELD + 1), "oversized"),
+    ("", "empty"),
+    ("   ", "whitespace"),
+    ("totally-made-up", "unknown token"),
+    ("false", "a word that looks like a negative"),
+    ("unknown", "collides with the tier fallback marker"),
+    ("BROWSER-AGENT", "a real token, wrong case"),
+])
+def test_an_unreadable_origin_still_suppresses_the_session(telemetry, bad_origin,
+                                                           label):
+    """🔴 THE A1/A2 REGRESSION. A present-but-unreadable origin must STILL
+    suppress.
 
-    The heartbeat and the /whoami+/health diagnostics have no caller session at
-    all, so they must gain neither `session` nor `sess_src`. A `sess_src` on a
-    machine-generated row would be a claim about a caller that does not exist,
-    and the diagnostics' payload equality is asserted elsewhere as exactly
-    {op,key,outcome}."""
+    The id is `claude:`-tagged, so if suppression were keyed off the cleaned
+    value's truthiness -- as it was -- every row here would carry the PARENT's
+    uuid in `session`. Fail closed: a caller that tried to disclaim authorship and
+    could not be understood loses attribution rather than fabricating it.
+
+    `unknown` and `BROWSER-AGENT` are in the table on purpose: the first collides
+    with the tier fallback marker, the second is a real token in the wrong case --
+    both are near-misses a `value in LEDGER` check must still reject.
+
+    HONEST NOTE ON THE TABLE: over HTTP the `whitespace` row is NOT a distinct
+    case from `empty`. A header value is delimited by the colon-space and trailing
+    whitespace is stripped, so `X-Session-Origin:    ` arrives as `""`. Measured
+    via mutant P6, which kills both rows identically. The row is kept because it
+    documents what a caller writing whitespace actually gets, not because it
+    exercises a separate branch.
+    """
+    spool_dir = telemetry
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=LEAKED_ID,
+                         origin=bad_origin)[0] == 200
+        e = _wait_events(spool_dir, 1)[0]
+        p = json.loads(e["payload"])
+        assert "session" not in e, (
+            f"{label}: a present origin must suppress the key; "
+            f"got {e.get('session')!r}")
+        assert p["origin"] == "invalid", p
+        assert p["origin"] not in ORIGIN_TOKENS, p
+        # The parent id is still recorded -- suppression is not amnesia.
+        assert p["origin_session"] == LEAKED_UUID, p
+        # And no session field reached the line at all, under any name.
+        assert "b64:session=" not in _log_file(spool_dir).read_text()
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_the_invalid_marker_is_distinguishable_from_every_real_token():
+    """The marker exists so the failure is VISIBLE in the data rather than silent.
+    It must not collide with a real token, or a malformed declaration would be
+    indistinguishable from a working one when someone groups by `origin`."""
+    assert S.SESSION_ORIGIN_INVALID == "invalid"
+    assert S.SESSION_ORIGIN_INVALID not in S.ORIGIN_TOKENS
+
+
+def test_the_origin_ledger_is_the_same_set_the_tests_pin():
+    """SEAM. The server's ledger and this suite's expectation are two lists that
+    nothing forces to agree; pin them, or a token added to one alone changes
+    behaviour with a green suite."""
+    assert tuple(S.ORIGIN_TOKENS) == ORIGIN_TOKENS, S.ORIGIN_TOKENS
+
+
+@pytest.mark.parametrize("tier", ["tmux", "sid", "ppid", "synthetic"])
+def test_origin_session_passes_the_same_tier_gate_as_session(telemetry, tier):
+    """🔴 THE A3 REGRESSION, and it is REACHABLE rather than theoretical.
+
+    browser-agent forwards whatever `--print-session-id` produced -- its own
+    opencode-tool test exercises `BROWSER_AGENT_SESSION_ID: "tmux:%41"` -- and the
+    tool declares the origin unconditionally. So a non-joinable parent id really
+    does arrive here. The tier gate's own rationale applies verbatim: a pane id is
+    stable across many unrelated sessions, so a reader grouping by
+    `origin_session` would merge them exactly as they would on `session`.
+
+    The tier is still recorded, so the suppressed population stays measurable --
+    that is the difference between a gate and a silent drop.
+    """
+    spool_dir = telemetry
+    wire_id, bare = TIER_IDS[tier]
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=wire_id,
+                         origin="browser-agent")[0] == 200
+        e = _wait_events(spool_dir, 1)[0]
+        p = json.loads(e["payload"])
+        assert "session" not in e, e
+        assert "origin_session" not in p, (
+            f"tier {tier!r} is not joinable and must not be recorded as a parent "
+            f"key; got {p.get('origin_session')!r}")
+        assert p["origin"] == "browser-agent", p
+        assert p["sess_src"] == tier, p        # measurable, not silent
+        # The bare id must not have leaked onto the row under any other name.
+        assert bare not in _log_file(spool_dir).read_text()
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_a_joinable_parent_is_still_recorded(telemetry):
+    """The control for the gate above: the joinable tier still yields a parent
+    key. Without this, deleting `origin_session` entirely would pass every test
+    in this section."""
+    spool_dir = telemetry
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=LEAKED_ID,
+                         origin="browser-agent")[0] == 200
+        p = json.loads(_wait_events(spool_dir, 1)[0]["payload"])
+        assert p["origin_session"] == LEAKED_UUID, p
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_an_absent_origin_header_is_not_the_same_as_an_empty_one(telemetry):
+    """PRESENCE vs VALUE, asserted as the pair that defines the rule.
+
+    Absent -> attribute normally (the ordinary case; regressing it would re-empty
+    the column this PR exists to fill). Present but empty -> suppress. They differ
+    ONLY in whether the header is on the request, which is exactly what
+    `session_origin is None` tests and what `or None` in the handler destroyed.
+    """
+    spool_dir = telemetry
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=LEAKED_ID)[0] == 200
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=LEAKED_ID, origin="")[0] == 200
+        absent, empty = _wait_events(spool_dir, 2)
+        assert absent["session"] == LEAKED_UUID, absent
+        assert "origin" not in json.loads(absent["payload"])
+        assert "session" not in empty, empty
+        assert json.loads(empty["payload"])["origin"] == "invalid"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_only_the_heartbeat_is_server_originated(telemetry):
+    """🔴 CATEGORY CORRECTION. This test used to assert that the heartbeat AND the
+    /whoami+/health diagnostics "have no caller session to attribute". That was
+    true of the heartbeat and FALSE of the other two, and the wrong half was
+    load-bearing: `browser whoami` / `browser health` are subcommands a person
+    runs, and the CLI sends its ordinary session headers on them because `_curl`
+    is one code path. 125 rows / 2.0% of `kind='cmd'` over 14d were being
+    de-attributed on a false premise, while the SAME `whoami` reached via POST
+    /cmd was attributed -- one operation, two outcomes.
+
+    So the category now contains exactly one member. The heartbeat is emitted by a
+    timer with no request behind it; a `sess_src` on it would be a claim about a
+    caller that does not exist.
+    """
     spool_dir = telemetry
     S.emit_heartbeat_event(S.Registry())
-    S._emit_diag_event("whoami", time.monotonic())
-    evs = _wait_events(spool_dir, 2)
-    assert len(evs) == 2, evs
-    for e in evs:
-        assert "session" not in e, e
+    e = _wait_events(spool_dir, 1)[0]
+    assert e["kind"] == "heartbeat"
+    assert "session" not in e, e
+    p = json.loads(e["payload"])
+    assert "sess_src" not in p and "origin" not in p, e
+
+
+def test_the_diagnostic_gets_are_attributed_like_any_operator_command(telemetry):
+    """The other side of that correction: /whoami and /health are operator calls,
+    so they attribute exactly like a POST /cmd.
+
+    Asserted through the REAL HTTP path with real headers rather than by calling
+    the emitter directly -- the bug was that the handler never passed the headers
+    it already had, which a direct-call test cannot see.
+    """
+    spool_dir = telemetry
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        for path in ("/whoami", "/health"):
+            st, _b = _req(srv, "GET", path,
+                          headers={S.HDR_SESSION_ID: JOINABLE_ID})
+            assert st == 200, path
+        evs = _wait_events(spool_dir, 2)
+        assert len(evs) == 2, evs
+        for e in evs:
+            assert e["session"] == JOINABLE_UUID, e
+            assert json.loads(e["payload"])["sess_src"] == "claude", e
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_a_diagnostic_get_from_a_nested_run_is_not_credited(telemetry):
+    """And they honour the origin header too -- otherwise `browser health` from
+    inside an opencode session would be the one command that still credited the
+    inherited id, which is the whole class this PR closes."""
+    spool_dir = telemetry
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, _b = _req(srv, "GET", "/whoami",
+                      headers={S.HDR_SESSION_ID: LEAKED_ID,
+                               S.HDR_SESSION_ORIGIN: "opencode-inherited"})
+        assert st == 200
+        e = _wait_events(spool_dir, 1)[0]
         p = json.loads(e["payload"])
-        assert "sess_src" not in p and "origin" not in p, e
+        assert "session" not in e, e
+        assert p["origin"] == "opencode-inherited", p
+        assert p["origin_session"] == LEAKED_UUID, p
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -2188,6 +2188,12 @@ JOINABLE_UUID = "6f1c9a20-1111-4bbb-8ccc-000000000001"
 JOINABLE_ID = "claude:" + JOINABLE_UUID
 NESTED_UUID = "8ab3d704-2222-4eee-9fff-000000000002"
 NESTED_ID = "claude:" + NESTED_UUID
+# A Claude session uuid that LEAKED into an opencode tool shell. The CLI re-tags
+# it `oc-inherited:` because inside opencode the variable names an ANCESTOR, not
+# the caller -- see the leak section at the bottom of this file. Distinct from
+# both uuids above so a mutant reusing either cannot satisfy its tests.
+LEAKED_UUID = "c05e17b6-3333-4aaa-8ddd-000000000003"
+LEAKED_ID = "oc-inherited:" + LEAKED_UUID
 # tier tag -> (wire id, the bare id behind it). Mirrors derive_session_id's tags.
 TIER_IDS = {
     "claude": (JOINABLE_ID, JOINABLE_UUID),
@@ -2196,6 +2202,7 @@ TIER_IDS = {
     "ppid": ("ppid:31337:deadbeefcafef00d", "31337:deadbeefcafef00d"),
     "synthetic": ("synthetic:" + JOINABLE_ID + "+recreate-close",
                   JOINABLE_ID + "+recreate-close"),
+    "oc-inherited": (LEAKED_ID, LEAKED_UUID),
 }
 
 
@@ -2561,6 +2568,88 @@ def test_extra_cannot_overwrite_the_attribution(telemetry):
     assert p["sess_src"] == "tmux", p
     assert "origin" not in p, p
     assert "session" not in e, e
+
+
+# --------------------------------------------------------------------------- #
+# The opencode leak, server side.
+#
+# `CLAUDE_CODE_SESSION_ID` survives into opencode's tool shells (opencode 1.18.18
+# sets OPENCODE=1 in a yargs top-level `.middleware()` and hands its tools
+# `{...process.env}`; a live env dump confirmed the outer Claude id was still
+# there). So the CLI re-tags the leaked value `oc-inherited:` and the server must
+# treat that tag as NON-joinable — otherwise a plain `opencode run …` whose bash
+# tool shells out to `browser` writes the OUTER Claude session's uuid into
+# `session`, indistinguishable from that session's own direct browser use.
+#
+# The tier itself is covered by the parametrized table above. What is left is the
+# interaction nobody owns: browser-agent invoked from INSIDE an opencode session,
+# where the leak guard and the nesting guard both apply at once.
+#
+# 🔴 HONEST LABEL: every test in this section is an INVARIANT GUARD relative to
+# f47be59 (this PR's first commit), and green there. The whole leak fix lives in
+# the CLI — the server needed NO change, because its tier gate is an allowlist of
+# exactly one tag, so a tag it has never heard of was already non-joinable. These
+# tests are not regression coverage for a server bug; they pin that the generic
+# gate really does cover the new tag, and that the leak and nesting guards
+# compose. They ARE red against origin/main (da33356), where `sess_src` and the
+# origin header do not exist at all. Reachability is proved by mutant M11, which
+# widens the gate to admit `oc-inherited` and is killed here.
+# --------------------------------------------------------------------------- #
+def test_a_nested_agent_run_inside_opencode_keeps_both_guards(telemetry):
+    """SEAM. `browser agent` normally derives its id BEFORE opencode starts, so
+    the id is `claude:`-tagged and only the ORIGIN guard stops the invoker being
+    credited. But when browser-agent is itself launched from inside an opencode
+    session, OPENCODE is already set at `--print-session-id` time, so the
+    forwarded id arrives `oc-inherited:`-tagged AND carries the origin header.
+
+    Both guards must hold together, and the origin must still win: no `session`,
+    the tier reported honestly, and the bare id recorded as the causal parent —
+    a bare uuid, exactly as on the non-leaked nested path, so the two are
+    queryable the same way.
+    """
+    spool_dir = telemetry
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=LEAKED_ID,
+                         origin="browser-agent")[0] == 200
+        e = _wait_events(spool_dir, 1)[0]
+        p = json.loads(e["payload"])
+        assert "session" not in e, f"a leaked+nested id must claim nothing: {e}"
+        assert p["sess_src"] == "oc-inherited", p
+        assert p["origin"] == "browser-agent", p
+        assert p["origin_session"] == LEAKED_UUID, p
+        assert ":" not in p["origin_session"], p
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_the_leaked_tier_is_not_the_joinable_one(telemetry):
+    """The blunt statement of the fix, asserted against the CONSTANT rather than
+    the spelling: whatever `SESSION_SRC_JOINABLE` is, the leak tier is not it, and
+    a leaked id on the ordinary (non-nested) path writes no key.
+
+    Its control is the joinable id on the SAME path in the same test — so a
+    server that had simply stopped writing `session` at all could not pass."""
+    spool_dir = telemetry
+    assert S.SESSION_SRC_JOINABLE != "oc-inherited"
+    srv, _ = _serve()
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=LEAKED_ID)[0] == 200
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=JOINABLE_ID)[0] == 200
+        leaked, direct = _wait_events(spool_dir, 2)
+        assert "session" not in leaked, leaked
+        assert json.loads(leaked["payload"])["sess_src"] == "oc-inherited"
+        assert direct["session"] == JOINABLE_UUID, "control: direct use still joins"
+        # The two uuids are different values, so this cannot pass by coincidence.
+        assert LEAKED_UUID not in _log_file(spool_dir).read_text()
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
 
 
 def test_server_originated_events_carry_no_session_fields(telemetry):

--- a/scripts/tests/test_opencode_engine.py
+++ b/scripts/tests/test_opencode_engine.py
@@ -664,6 +664,14 @@ def test_engine_is_the_version_every_measurement_is_keyed_to():
 # behaviour means adding it here — nothing can detect that omission for you.
 PIN_SURFACE = (
     "scripts/browser-bridge/README.md",
+    # The CLI carries a LIVE structural claim about opencode's env (its
+    # X-Session-Origin guard turns on `OPENCODE`, and the comment says why).
+    # Added per the "surface only rots downward" rule above: it is not a dated
+    # "measured on <version>" record like browser-agent* and opencode/tools/,
+    # so it tracks the pin. It names PINNED_VERSION instead of copying it —
+    # nothing here to go stale, and the gate now covers it if anyone writes a
+    # literal later.
+    "scripts/browser-bridge/browser",
     "scripts/browser-bridge/reference/agent.md",
     "scripts/opencode/README.md",
     "scripts/opencode/opencode.jsonc",


### PR DESCRIPTION
## The bug

`activity.events` rows with `source='browser-bridge'` had an **empty `session` column — 0 of 6,937 over 14 days**, while `claude`/`opencode`/`keys`/`tmux`/`zsh` filled it 100%. The value already reached the server as `X-Session-Id` (it drives tab-ownership routing); it was simply never passed to `emit_cmd_event`. So a browser-skill call could not be joined to the agent session that made it, and *"which sessions used opencode **and** the browser skill"* had to be answered by scanning 1.5M transcript records.

## What changed

Passing the id through naively would have produced two **wrong** joins instead of no join. Both are closed here.

### 1. Tier — only `claude:` is a join key

`derive_session_id` already tags the id with the tier that produced it, before the first `:`. The server now reads **that tag** (a tag the CLI emits on purpose — never the id's *shape*) and:

| `X-Session-Id` | `payload.sess_src` | `session` column |
|---|---|---|
| `claude:<uuid>` | `claude` | **the bare `<uuid>`** |
| `tmux:%3` | `tmux` | empty |
| `sid:<sid>:<start>` | `sid` | empty |
| `ppid:<pid>:<rand>` | `ppid` | empty |
| `synthetic:…` | `synthetic` | empty |
| untagged / absent / oversized / control-char | `unknown` | empty |

- Only the **first** colon splits (`sid:`/`ppid:` ids contain more).
- The tag is **stripped** from the column value so it compares `=` against `source='claude'` rows with no `replaceOne()` at the join site.
- An **untagged** id — including a bare uuid, the value most tempting to accept — is never promoted. Fail closed.
- An id over 200 chars or carrying a control character is **dropped whole, never truncated**: a truncated join key is a *wrong* join key.
- Stored **raw, not hashed**, as briefed.

### 2. Nesting — `browser agent` forwards its *invoker's* id

`browser-agent:675` captures `--print-session-id` from the session that invoked it and hands it to the nested opencode tool, which sends it verbatim as `X-Session-Id`. Left alone, one `browser agent "<goal>"` call would have become N browser calls credited to the operator's own session (~581 nested rows in 14d, ~11% of bridge commands) — fabricated usage in the `session` JOIN column (**not** "the column adoption-scan reads" — corrected in B2 below).

`browser_tool_impl.mjs` now sends `X-Session-Origin: browser-agent`. When present the server writes **no** `session`; the forwarded id lands in `payload.origin_session` (the causal **parent**) beside `payload.origin`. `X-Session-Id` is untouched, so routing is unchanged. Giving the nested session an id of its own is a later change.

### 3. One forced CLI change

`emulate --recreate` sent its close under a throwaway id built by **appending** to the real one — leaving the live session's `claude:` tag on a value that is *not* that session's key. Under prefix-parsing the bridge would have stored `<uuid>+recreate-close` in `session` as a near-duplicate of the real key, inflating distinct-session counts with fabricated rows. It is now re-tagged `synthetic:` (routing only requires that the id be *different*, which it still is). This is the only behavioural change to `browser`; the rest of the CLI diff is comments.

### Contracts

- **Best-effort intact.** Everything added is inside `emit_cmd_event`'s swallowing `try`, off the critical path. Proved by a test that runs all four header shapes against a raising emitter and asserts 200.
- **`kind='cmd'` untouched.**
- **Privacy comment rewritten.** The module block said "METADATA ONLY … never page content", which is now false as written. It states what is emitted and why an agent-minted session handle is not page content: it is not derived from any page, it says *who asked*, never *what was browsed* — and it is the same value `source='claude'` rows already store raw.
- **Server-originated events** (heartbeat, `/whoami`, `/health`) gain nothing: `attribute_session` defaults to `False`, so their records are byte-identical.

### Throttle-path `sess` hash — decision: **KEPT**

`_session_hash` stays. The `session` column is filled only for the `claude` tier and only for non-nested calls, so a flood driven from a `tmux`/`sid`/`ppid`/untagged id, or from a nested `browser agent` run, is exactly the case where you still need *some* stable handle to tell one flooder from two. It is 8 hex, on the throttle path only. Both now appear on a joinable-tier throttle event and a test pins that.

The pre-existing test asserting *"raw session id NEVER stored"* was **narrowed, not deleted**: it sends an untagged id, so its invariant is the fail-closed one. The comment now says so, and the joinable case is asserted separately.

## Verification

Base = `da33356` (`origin/main`; `scripts/browser-bridge/` is byte-identical between it and the `85cf466` I branched from). Base runs used a `git archive` of `origin/main` with only the three test files copied in, under `PYTHONDONTWRITEBYTECODE=1`.

### Red at base → green at HEAD

`tests/test_server.py` — **25 red at base, all green at HEAD**:

| test | base failure |
|---|---|
| `test_session_column_is_filled_for_the_joinable_tier_only[claude\|tmux\|sid\|ppid\|synthetic]` (5) | `KeyError: 'sess_src'` |
| `test_the_session_column_carries_the_bare_id_not_the_wire_tag` | `KeyError: 'session'` |
| `test_only_the_first_colon_splits_a_multi_colon_id` | `KeyError: 'sess_src'` |
| `test_an_absent_or_empty_id_fails_closed[None\|""]` (2) | `KeyError: 'sess_src'` |
| `test_an_untagged_id_is_never_promoted_to_a_join_key` | `KeyError: 'sess_src'` |
| `test_a_tag_the_server_does_not_know_is_recorded_but_not_joined` | `KeyError: 'sess_src'` |
| `test_an_ordinary_request_sets_session_and_declares_no_origin` | `KeyError: 'session'` |
| `test_the_release_short_circuit_attributes_an_ordinary_session` | `KeyError: 'session'` |
| `test_the_throttle_path_carries_both_the_hash_and_the_join_key` | `KeyError: 'sess_src'` |
| `test_an_oversized_id_is_dropped_whole_never_truncated` | positive control finds no key |
| `test_extra_cannot_overwrite_the_attribution` | `TypeError` (no such kwarg) |
| `test_a_nested_run_records_the_forwarded_id_as_origin_not_as_session` | `AttributeError: HDR_SESSION_ORIGIN` |
| `test_an_origin_wins_over_the_joinable_tier_on_every_emit_site` | `AttributeError: HDR_SESSION_ORIGIN` |
| `test_a_raising_emitter_still_lets_the_command_succeed` | `AttributeError: HDR_SESSION_ORIGIN` |
| `test_a_control_character_id_is_dropped_at_the_unit[tab\|nl\|nul\|del]` (4) | `AttributeError: _clean_session_field` |
| `test_cmd_ok_emits_one_metadata_event` *(existing, expectation updated)* | payload gained `sess_src` |
| `test_cmd_rate_limited_returns_429_and_emits_throttle` *(existing, narrowed)* | `KeyError: 'sess_src'` |

`tests/test_browser_session_id.py` — **3 red at base**: `test_the_cli_tier_tag_vocabulary_is_pinned`, `test_the_servers_joinable_tag_is_one_the_cli_actually_emits` (`AttributeError: SESSION_SRC_JOINABLE`), `test_the_throwaway_recreate_close_id_is_re_tagged_not_just_suffixed` (`throwaway id wears tier tag '${SESSION_ID}+recreate-close'`).

`tests/browser_tool.test.mjs` — **2 red at base** (`85 pass / 2 fail` at base, `87 pass / 0 fail` at HEAD).

**Honest note on three of those reds.** The three `AttributeError: HDR_SESSION_ORIGIN` rows are red at base because the constant does not exist there, not because base *behaves* differently on a path the test could otherwise reach — the header is new. Counted as coverage of new behaviour, not as evidence base was buggy on an existing path.

### Green at base — labelled INVARIANT GUARDS, not counted as regression coverage

- `test_server_originated_events_carry_no_session_fields` — pins that the heartbeat/diagnostics gain nothing. Proved **reachable** by mutant M7 below, not just green.
- `test_the_tagged_id_survives_the_transport[claude|tmux]` and `test_an_ordinary_cli_call_declares_no_nested_origin` — the wire pins. `server.py` now *depends* on the tag reaching it and on the direct CLI never declaring an origin; nothing else asserted that the tag survives the transport rather than only the deriver. Labelled as invariant guards in the file.

### Mutation results

Sandbox copy of the tree, `PYTHONDONTWRITEBYTECODE=1` plus an explicit `__pycache__` purge before every run (a same-length edit in the same second is invisible to CPython's mtime+size cache and would score SURVIVED without executing — M5 is exactly that shape, length delta **0**, and it was killed). **Positive control first: pristine → 26/26 green**, so no "killed" verdict comes from an already-red suite. Each mutation is the narrowest expression that can be wrong; no guard was deleted together with its enclosing condition.

| # | mutation | killed by | with its own assertion |
|---|---|---|---|
| M1 | `tier == SESSION_SRC_JOINABLE` → `tier in (SESSION_SRC_JOINABLE, "tmux")` | `..._joinable_tier_only[tmux]` | `tier 'tmux' must NOT produce a join key; got '%77'` |
| M2 | `origin = _clean_session_field(session_origin)` → `origin = ""` | `test_a_nested_run_records_the_forwarded_id_as_origin...` | `a nested run must not claim the session: {…'session': '8ab3d704-…'}` |
| M3 | `rec["session"] = bare` → `= _clean_session_field(session_id)` | `..._carries_the_bare_id_not_the_wire_tag` | `assert 'claude:6f1c9…' == '6f1c9a20-…'` |
| M4 | `s.partition(":")` → `s.rpartition(":")` | `test_only_the_first_colon_splits_a_multi_colon_id` | `assert 'sid:424242' == 'sid'` |
| M5 | untagged returns `(SESSION_SRC_JOINABLE, s)` | `test_an_untagged_id_is_never_promoted_to_a_join_key` | `sess_src: 'claude'` on an untagged id |
| M6 | oversized returns `s[:MAX]` instead of `""` | `test_an_oversized_id_is_dropped_whole_never_truncated` | truncated key present on the row |
| M7 | `attribute_session: bool = False` → `True` | `test_server_originated_events_carry_no_session_fields` | attribution on a `kind=heartbeat` row |

M1 also killed `test_extra_cannot_overwrite_the_attribution`; M3 killed six; M4 killed four. Every mutant's *primary* killer is the guard's own assertion, quoted above.

Fixture ids are pairwise distinct and distinct from every constant the assertions name (`claude`, `tmux`, `unknown`, `browser-agent`), so a mutant hardcoding any of those literals cannot survive. Two different `claude:` uuids are used for the direct and nested cases so a mutant writing "whichever id it had" fails one of them.

### Gate (commit 1, `f47be59`)

Historical — the authoritative run for the
current head is at the bottom of this description. Both hermetic CI checks,
on this branch rebased onto `da33356`:

```
nix build .#checks.x86_64-linux.pytests   -> exit 0
  RESULT: all good
  TOTAL collected=11863  passed=11862  skipped=1  failed=0  (floor: 11039)
  scripts/browser-bridge/tests: 532 passed in 188.30s
  RESULT: PASS (exit=0)

nix build .#checks.x86_64-linux.nodetests -> exit 0
  PASS  scripts/browser-bridge/tests  (files=15 tests=497 pass=497 skipped=0 floor=490)
  TOTAL suites=4 files=33 tests=1118 pass=1118 fail=0 skipped=0  (floor: 1098)
  RESULT: PASS (exit=0)
```

`scripts/gate.sh --tier both --set all` run **outside** a flake shell returned node PASS but pytest FAIL — every one of those failures was a missing host tool or python dep in the ad-hoc shell (`logrotate` absent; `psycopg2` absent, so `mail-actions`/`signal`/`initiatives`/`scripts/tests` failed to collect). The same targets are green in the hermetic runs above (e.g. `initiatives` 784 passed there vs 9 failed in the ad-hoc shell), which is what makes that an environment verdict and not a code one. Nothing was skipped, disabled, or bypassed.

## Not verified

- **No live probe, by instruction.** Nothing here was exercised against the running bridge: the deployed CLI is an `mkOutOfStoreSymlink` onto the base clone and `server.py` is a `home.file` copy needing a `home-manager switch`, so a live observation would measure other code. **Deployed ≠ verified, and this is neither.**
- **No ClickHouse round-trip.** Tests assert the spool line; that `session` survives `collector.parse_line` into the column is inferred from `STRING_COLS` containing `session`, not measured.
- The `~11%` nested-call figure and the `0/6,937` count are taken from the brief; I did not re-measure them.
- The `synthetic:` retag is pinned **structurally** (the throwaway id's tag), not by driving a full `emulate --recreate` round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Follow-up commit `38a12b5` — hazard 3, redone as an origin header

## The leak

opencode sets `process.env.OPENCODE="1"` in a yargs **top-level `.middleware()`** — registered before every `.command(...)`, so it runs for every subcommand — and hands its tool shells `{...process.env}`:

```
.middleware(async(D)=>{ … E3.start(),process.env.AGENT="1",
  process.env.OPENCODE="1",process.env.OPENCODE_PID=String(process.pid)})
  .usage("").completion(…).command(m1).command(q1)…
```

Instrument controls on that grep: the exact string matched once at a known byte offset, and a deliberately bogus control string (`OPENCODE_THIS_SHOULD_NOT_EXIST_XYZ`) correctly returned no match — so "found" is not an artifact of a grep that matches anything. Re-derived against the **pinned** build after the gate caught me using the wrong artifact (see below); identical there.

Combined with the reported live env dump — an opencode bash tool still carrying the outer Claude session's `CLAUDE_CODE_SESSION_ID` — that variable inside opencode names an **ancestor**, not the caller. I also hit the leak by accident while smoke-testing: a run with only `CLAUDE_SESSION_ID` set returned **my own agent shell's** `CLAUDE_CODE_SESSION_ID`. The variable really is ambient.

**Consequence:** a plain `opencode run …` whose bash tool shells out to `browser` sends a genuinely `claude:`-tagged id, and the server would credit the **outer** Claude session with browser usage it never performed — in the `session` JOIN column. (An earlier version of this description said "the column adoption-scan and the deadman read" — that was **false**; see the B2 correction below.) **There is nothing in the id to branch on:** it *is* the outer session's id, correctly tagged. The server cannot tell it from a direct call by inspection, so the caller has to say so.

## The fix

`84bf324` gave the opencode leak its own non-joinable tier (`oc-inherited:`). That is **superseded**: it answered a question this PR had already answered a different way. `browser agent` declares `X-Session-Origin` and leaves `X-Session-Id` alone; the opencode leak is the same question — *"this command was issued by something nested under the id on the wire"* — so it now gets the same answer.

```
X-Session-Id:     claude:<uuid>        # unchanged
X-Session-Origin: opencode-inherited   # declared beside it
```

**This closes the constraint I flagged and could not meet before: routing is byte-identical.** Tab ownership, `--tab`, `not_owned_tab` and the `$( … )` stability property are untouched because the id is untouched. `derive_session_id` is now byte-identical to `f47be59`.

`origin` becomes a two-value enum — `browser-agent` | `opencode-inherited` — both meaning "issued by something nested under `origin_session`", which is precisely true of both. **The server needed no change.** The tier, its vocabulary-ledger entry, and the hyphen widening its parser needed are all deleted.

Net against `84bf324`: **355 insertions, 196 deletions** — smaller, and reusing an already-tested path.

The origin is declared only when a Claude id was *actually inherited*: the condition reads the **derived id** (`claude:*`) rather than re-testing env vars, so it cannot drift out of step with the precedence chain. Your interactive-opencode case (`OPENCODE=1`, no Claude ancestor → `tmux:` tier, no header at all) is covered by its own test.

## A real gate failure the previous round's hermetic run caught

`84bf324`'s hermetic pytest run came back **FAIL (1 test)** — `scripts/tests/test_opencode_engine.py`. Worth noting how: the background wrapper reported `exit code 0` while nix printed `Cannot build …devrc-pytests.drv`. Reading the content rather than the status is what surfaced it.

The cause was substantive, not cosmetic. That file pins opencode's version across an enumerated surface, and my README cited **1.18.18** — which is **not the pinned build**. The pin is **1.18.16**; 1.18.18 is what this host's imperative nix profile has on `PATH`.

So my evidence had been gathered from the wrong artifact. I re-derived it against the pinned bundle: the `AGENT=1, OPENCODE=1, OPENCODE_PID` middleware sequence is present and **byte-identical** there. The claim holds at both points — the gate turned a single-point measurement into a two-point one.

Both the README and the CLI comment now **name `PINNED_VERSION` instead of copying its value** (the idiom that file already uses), so neither can go stale.

I also added `scripts/browser-bridge/browser` to `PIN_SURFACE`. It now carries a live structural claim about opencode's environment, and that file's own rule is explicit: *"the surface only rots downward — a NEW file carrying a live claim is simply invisible… nothing can detect that omission for you."* Flagging it as a deliberate, gate-instructed edit to a file outside this PR's core.

**Separately, and NOT fixed here:** `opencode --version` on this host is **1.18.18** while the flake pins **1.18.16**, so `test_engine_is_the_version_every_measurement_is_keyed_to` fails *in an interactive shell* — it passes hermetically, which is why CI never saw it. Both operands (`PINNED_VERSION`, the host binary) are identical at `84bf324` and at `origin/main`, so this is **pre-existing host drift, not from this PR**. The test's own message prescribes the fix (`nix profile remove opencode`, then `home-manager switch`) — a host mutation, so yours to make, not mine.

## Verification — the gate was reset, not carried over

Baseline for this round is **`84bf324`** (the PR's third; `da33356` = `origin/main`, `f47be59` = commit 1).

### Red at `84bf324` → green at HEAD — 6 tests

| test | failure at `84bf324` |
|---|---|
| `test_routing_equivalence_opencode_does_not_change_the_id[claude:uuid-primary]` | `OPENCODE must not perturb the routing id` |
| `…[claude:uuid-alternate]` | same |
| `test_an_inherited_claude_id_declares_the_opencode_origin[CLAUDE_CODE_SESSION_ID]` | no `X-Session-Origin` on the wire |
| `…[CLAUDE_SESSION_ID]` | same |
| `test_the_discriminating_pair_on_the_wire` | `assert 'oc-inherited:uuid-pair' == 'claude:uuid-pair'` |
| `test_the_cli_declares_the_token_the_server_tests_pin` | `the origin-token parser matched nothing` |

Note the routing-equivalence table's **`tmux:` row is green at `84bf324`** — the old re-tagging only ever fired on a claude id. Baselines are labelled **per row** in the test's docstring rather than per test.

### Green at `84bf324` — INVARIANT GUARDS

Labelled in-file with the mutant that proves each reachable. All **five server-side tests** are here: the server needed no change, so they pin that the origin path covers the new token and composes with the tier gate — not regression coverage. Plus `…declares_nothing` (N3), `…empty_opencode…` (N1/N2/N9), `…derived_posix_tier` (N6).

### The routing-equivalence test — your requested assertion

`test_routing_equivalence_opencode_does_not_change_the_id` derives each id **twice**, differing only in `OPENCODE`, and requires both to equal the **same pinned literal**. Two load-bearing halves: the arms must equal *each other* (OPENCODE changes nothing) **and** equal a literal taken from the contract, so a change moving both arms together still fails. `84bf324`'s design dies on both halves — that is mutant N6.

### Mutation results — carrying forward the M10 standard

Fresh sandbox, `PYTHONDONTWRITEBYTECODE=1` + `__pycache__` purge per run.

**Positive control, stated with its numbers:** pristine → **37 passed** (CLI file) and **14 passed** (server slice), zero failures. My first battery run printed *nothing* for the control because the grep missed the summary line — a silent zero indistinguishable from a harness wired to nothing. I fixed the filter and re-ran rather than reporting the kills off it.

| # | mutation (narrowest expression) | killed | by |
|---|---|---|---|
| N1 | `[ -n "${OPENCODE:-}" ]` → `true` | 3 | the "no OPENCODE ⇒ no origin" claim at 3 layers |
| N2 | `-n` → `-z` | 5 | both directions |
| **N3** | case `claude:*` → `*` | **exactly 1** | `…no_claude_ancestor_declares_nothing`, its own assertion |
| N4 | token → `browser-agent` | 4 | incl. the seam ledger |
| N5 | the `args+=` header line → `:` | 3 | wire tests only |
| N6 | **re-tag the id instead** (the rejected design) | 3 | incl. **routing equivalence** |
| **N9** | `${OPENCODE:-}` → `${OPENCODE+set}` (empty-string boundary only) | **exactly 1** | `…empty_opencode_is_not_opencode`, its own assertion |
| N7 | server: `origin = ""` | 5 | every origin test |
| N8 | server: `payload["origin"] = "browser-agent"` | 2 | incl. its own distinctness test |

You asked me to carry forward the standard that M8 missed and M10 met. **N3 and N9 are exact-1 killers** — I added N9 specifically to give the empty-string boundary its own surgical mutant. N1/N2/N4/N5/N7 kill several, but every kill is the *same claim* observed at a different layer (id / wire / both spellings), not an unrelated neighbour; I am not claiming isolation I did not get.

### Gate

Both hermetic CI checks, on commit `38a12b5`. Superseded by `5cc0731` below,
whose verification is targeted (the branch is deliberately not rebased, so the
full hermetic gate is the coordinator's to run on the merged tree). Read from the
log CONTENT, not an exit code — the background wrapper reported `exit code 0` for the
`84bf324` run that had actually failed, which is exactly why these are quoted:

```
nix build .#checks.x86_64-linux.pytests
  RESULT: all good
  TOTAL collected=11877  passed=11876  skipped=1  failed=0  (floor: 11039)
  RESULT: PASS (exit=0)

nix build .#checks.x86_64-linux.nodetests
  TOTAL suites=4 files=33 tests=1118 pass=1118 fail=0 skipped=0  (floor: 1098)
  RESULT: PASS (exit=0)
```

Nothing was skipped, disabled, or bypassed. The single `skipped=1` is pre-existing
and pinned in the suite's own `EXPECTED_SKIPS`.

## Still not verified

Everything previously listed still stands. Unchanged and explicitly not addressed per your instruction: no live `opencode run` exercise, and the guard silently not firing if `OPENCODE` were ever unset on some real path.

---

# Follow-up commit `5cc0731` — six blind-audit findings

The audit came back safe-to-merge, and independently measured the join premise I could only infer: this shell's `CLAUDE_CODE_SESSION_ID` matches **34 live `source='claude'` rows**, and all 406 claude sessions in 14d are uuid-shaped. Storing the bare id is measured-correct, not assumed-correct.

Six findings, all closed.

## A — the origin path was more permissive than the id path beside it

All four are one shape: the guard against fabricated attribution had holes the *id* guard did not.

**A1 + A2 — one fix.** Suppression branched on `if origin:` — the **cleaned** value — so an oversized or control-char origin cleaned to `""`, fell through to the `elif`, and wrote **`session` with the parent's id**. That is the exact fabrication this mechanism exists to prevent, arriving *through the mechanism itself*. And any string was accepted: `totally-made-up`, `false`, `   ` were all recorded verbatim and all suppressed, so the "two-value enum" was documentation, not a contract.

Now: **branch on header presence** (`session_origin is None`), validate the value against `ORIGIN_TOKENS`, and record `invalid` for anything else so the case is visible in the data rather than silent. Presence decides suppression; the value decides only what gets recorded. The handler's `or None` is gone too — it collapsed a *present-but-empty* header into "absent" and re-attributed the call.

**A3 — reachable, not theoretical.** `origin_session` bypassed the tier gate. `browser-agent` forwards whatever `--print-session-id` produced and the opencode tool declares its origin unconditionally, so `tmux:%3` genuinely arrived and was recorded as `origin_session='%3'`. Same gate now, same rationale as `session`: a pane id is stable across many unrelated sessions, and `origin_session` is a column a reader can `GROUP BY`. The tier is still recorded, so the suppressed population stays measurable.

**A4 — `sess_src` was unbounded-cardinality.** `['claude`, `CLAUDE`, `claud` all landed verbatim; four of the measured values are near-misses of the joinable tag that a reader skimming a `GROUP BY` would misread. Validated against `SESSION_TIER_TAGS`, pinned two-way against the CLI's vocabulary.

## B — three claims the code contradicted

**B1 and B2 are also posted as a [PR comment](https://github.com/innovation-upstream/devrc/pull/549#issuecomment-5338877940)**, because anyone who read this description earlier read the wrong version.

**B1.** The flagship example query returned **zero rows forever** — disjoint id spaces (406 claude uuids vs 183 `ses_` opencode ids, overlap 0) *and* the opencode guard suppresses `session` for exactly the calls it was about. It failed as a silent empty result. **Replaced, not annotated**, with queries answerable today plus an explicit "not answerable yet" section naming the follow-up work.

**B2.** "adoption-scan and the deadman read this column" was **false**, in four places, in the present tense. Verified independently: adoption-scan's browser-bridge entry is `via="source"` and never selects `session`; the deadman reads row existence. **No shipped consumer reads `session` for this source today** — because it has always been empty. The harm is **latent**: it lands on the first consumer that does. Still the reason for every gate, but a weaker claim than the one I made. (`kind='cmd'` *is* read by adoption-scan — that part was true and is untouched.)

**B3.** `/whoami` and `/health` were mislabelled server-originated. They are operator subcommands and the CLI sends its session headers on them because `_curl` is one code path. **Made consistent rather than relabelled:** they now attribute like any other command. The old exclusion gave one operation two outcomes — `whoami` via POST `/cmd` attributed, the same `whoami` via GET not — for 125 rows / 2.0% of `kind='cmd'` over 14d, a smaller copy of the bug this PR fixes. Only the heartbeat is server-originated now, and the test's category has exactly one member.

## Verification

Baseline **`38a12b5`** (the PR's fourth commit).

### Red at `38a12b5` → green at HEAD — 25 tests

All 25 selected tests failed at base, and the failure text reproduces the audit's measurements exactly:

| finding | representative base failure |
|---|---|
| A1 | `oversized: a present origin must suppress the key; got 'c05e17b6-…'` (also `empty`, `whitespace`) |
| A2 | unknown/`false`/`BROWSER-AGENT` tokens recorded verbatim |
| A3 | `tier 'sid' is not joinable and must not be recorded as a parent key; got '424242:99887766'` (also `tmux`, `ppid`, `synthetic`) |
| A4 | `sess_src` = `futuretier` / `CLAUDE` / `claud` / `['claude` |
| B3 | the diagnostic GETs carried no session; the orientation payload lacked `sess_src` |

**Green at `38a12b5` — 1 test, labelled INVARIANT GUARD:** `test_only_the_heartbeat_is_server_originated`. Proved reachable by mutant P5.

### Mutation results — 7 mutants, all killed

Fresh sandbox, `PYTHONDONTWRITEBYTECODE=1`, `__pycache__` purged between mutants. **Positive control: 47 passed / 0 failed**, and the number is asserted against a *measured* `EXPECT_SELECTED`, not a guess.

| # | mutation (narrowest expression) | killed | notes |
|---|---|---|---|
| P1 | `if session_origin is not None:` → `if _clean_session_field(...)` | 4 | the A1 bug itself |
| P2 | ledger check dropped — record `declared` raw | 8 | distinguishes A2 from A1: `session` stays suppressed, only `origin` is wrong |
| P3 | **one conjunct** removed: `tier == JOINABLE and bare` → `bare` | 4 | exactly `…origin_session_passes_the_same_tier_gate…`. Deleting the whole condition would also drop the `bare` test and prove nothing about the tier half — mutating a conjunct instead, per your note |
| P4 | tier vocabulary check deleted | 6 | exactly the A4 tests |
| P5 | `attribute_session=True` → `False` in the diag emitter | 4 | exactly the B3 tests |
| P6 | handler `or None` restored | 3 | a **different site** from P1, reachable only over the wire |
| P7 | `origin_session` never recorded | 13 | added *because* the filter control found its killer unselectable — see below |

🔴 **The filter guard fired, and it caught a real gap.** My battery asserts the control's selected count and, separately, that every new/changed test is selectable. The second check failed: `test_a_joinable_parent_is_still_recorded` — the control for the A3 gate — was **not** selected by my `-k` filter, so a mutant deleting `origin_session` outright could have reported SURVIVED. Exactly the false-SURVIVED shape you warned about, in my own harness. I widened the filter, re-measured `EXPECT_SELECTED` (47, not the 57 I had guessed), and added **P7** to confirm that test does the killing. It does.

### Honest note on one test row

Over HTTP, the `whitespace` origin row is **not** a distinct case from `empty` — a header value is delimited by the colon-space and trailing whitespace is stripped, so `X-Session-Origin:    ` arrives as `""`. Measured via P6, which kills both rows identically. The row is kept because it documents what a caller writing whitespace actually gets, not because it exercises a separate branch. Likewise `" claude"` as a tier tag cannot travel, so it is tested at the unit level with that stated.

### Targeted runs (no full hermetic gate, per instruction)

```
scripts/browser-bridge/tests/{test_server,test_browser_session_id,test_surface_parity,test_skill_size}.py
  419 passed
scripts/tests/{test_opencode_engine,test_no_captured_text,test_no_captured_markup}.py
  217 passed, 1 deselected
node --test scripts/browser-bridge/tests/browser_tool.test.mjs
  tests 87  pass 87  fail 0
```

The one deselected test is `test_engine_is_the_version_every_measurement_is_keyed_to` — the **pre-existing host drift** (`opencode` on PATH is 1.18.18, flake pins 1.18.16) documented in the previous round. Both its operands are identical at `38a12b5` and `origin/main`, so it is not from this PR; it passes hermetically.

## Still not verified

- No live probe, no live `opencode run`, no ClickHouse round-trip — unchanged, and yours after `ship.sh`.
- `origin='invalid'` rows are a **new** population in the data. Nothing has ever emitted one, so I cannot say what fraction of real traffic will land there; if a shipped caller is malformed in a way I have not imagined, it shows up as `invalid` rather than as a wrong join, which is the intended direction but is not the same as "measured zero".

---

# Follow-up commit `b17790f` — delta-audit items N1–N4

Delta re-audit of `38a12b5..5cc0731` came back safe-to-merge with all six earlier findings confirmed fixed. Four items remained; none change runtime behaviour.

## 🔴 N2 — the "two-way pin" was fictional, and the next planned change is what it fails to catch

`server.py` claimed `SESSION_TIER_TAGS` was *"pinned two-way against the CLI by `tests/test_browser_session_id.py`"*. **That symbol appeared nowhere in that file.** The server set was checked against a literal retyped in `test_server.py`; the CLI against a *separate* literal in `test_browser_session_id.py`; nothing compared the two.

Measured: grow the CLI by an `opencode:` tier **and** update `CLI_TIER_TAGS`, leave `server.py` alone → **400 passed, 0 failed. SURVIVED.**

The harm lands on the **next** change, not this one. `browser`'s own FOLLOW-UP SLOT says an `opencode:` tier is coming — the very follow-up this PR exists to enable. Without a real pin the server normalises the new tag to `unknown`, drops the id, and the column silently re-empties. A fail-closed silent regression is exactly what every gate here targets, reintroduced *in the gate itself*.

**Fixed where the parser already lives.** `test_browser_session_id.py` now compares `set(S.SESSION_TIER_TAGS)` against `_emitted_tags()` — tags **parsed out of the CLI source**, not a literal beside them.

The retyped literal in `test_server.py` is **deleted**, not kept alongside. It read as a cross-file pin and was not one, and *a literal that can be updated in lockstep with the thing it checks is worse than no check, because it reads as one*. What remains there is the self-consistency half (the joinable tag is in the set; the fallback marker is not), pointing at the real pin by name.

**Verification — the auditor's exact mutant shape, re-run:**

| | before | after |
|---|---|---|
| grow CLI + `CLI_TIER_TAGS`, leave `server.py` | **SURVIVED** — 400 passed, 0 failed | **KILLED** — 1 failed, 400 passed |

Killed by **exactly one test**, `test_the_server_validation_set_equals_the_tags_parsed_from_the_cli`:

```
server.py SESSION_TIER_TAGS=['claude','ppid','sid','synthetic','tmux'] does not
match the tags the CLI can actually emit ['claude','opencode','ppid','sid',
'synthetic','tmux']. A tier present in one and not the other is silently
normalised to 'unknown' and loses its id.
```

## 🟡 N1 — `emit_cmd_event`'s docstring still described pre-B3 behaviour

It said `attribute_session=False` covers *"the heartbeat, and the /whoami+/health diagnostics"* and that their records are *"byte-identical to before"*. B3 moved those two to `True` in the previous commit, so both sentences were false while `_emit_diag_event` 90 lines below, `README:1493` and the test all said the opposite.

Worth naming plainly: this is **the same shape as B2 — a false comment about who writes what — reintroduced by the round that fixed B2.** Nothing gates it; #553's doc-rot corpus is `CORPUS_DIRS = ("claude", "CLAUDE.md")` and excludes every file this PR touches.

## 🟡 N3 — "Answerable **now**" returned zero rows

Measured **0 of 6,166** browser-bridge `kind='cmd'` rows in 14d, because `session` is filled by code that is not deployed. B1's entire finding was a flagship query returning nothing; a replacement that also returns nothing — under a heading contrasting "now" with "NOT answerable yet" — repeats it in miniature. Reworded to **"Answerable once this ships"**, with *merged ≠ deployed* stated inline. That is this repo's standing hazard and it belongs in its own docs.

## 🟢 N4 — doubled phrase

The B2 reword left *"in the exact column `session` JOIN column"*. Fixed.

## Verification

Whole-file runs, **no `-x`** (the auditor's first pass used it and first-failure-wins mis-attributed two mutants to the flaky test below, producing a false KILL that would have hidden N2 entirely — not repeated):

```
test_server.py + test_browser_session_id.py + test_surface_parity.py + test_skill_size.py
  420 passed
test_no_captured_text.py + test_no_captured_markup.py + test_rules_size.py + test_opencode_engine.py
  222 passed, 1 deselected
```

The deselected test is the pre-existing 1.18.18-vs-1.18.16 host drift documented earlier. No hermetic gate run on this branch, per instruction.

## Recorded, deliberately not fixed here

- **C1 control characters.** `_clean_session_field` rejects C0 and DEL but not C1 (0x80–0x9F), so `claude:a\x9db` is accepted and a C1 char can reach the `session` column. Pre-existing, outside this delta.
- **A load-flaky test.** `test_the_throttle_path_carries_both_the_hash_and_the_join_key` failed 2 of 12 whole-file runs on an identical tree — same code, two outcomes. Its `_wait_events(..., 2, timeout=3.0)` budget is too tight for two off-critical-path spool writes under load. Present at `38a12b5`. It passed in every run of mine this round, including in isolation, which is consistent with load-dependence rather than a defect in the change. **This one is a genuine "fix it rather than re-run it" candidate** — the timing dependency is removable — and I have left it alone only because it was scoped out; say the word and it is a one-line follow-up.
- **N8.** `test_only_the_heartbeat_is_server_originated` asserts the heartbeat's own fields; the universal "only" rests on a sibling test rather than a grows-or-shrinks ledger.
