### PR TITLE
rules(screen): the operator's screen is not yours to take — the rule did not exist anywhere

### DIFF
--- a/claude/RULES.md
+++ b/claude/RULES.md
@@ -112,6 +112,16 @@ These rules live HERE (managed, shipped to every host), not in `~/.claude/CLAUDE
 - **`gh secret set` has NO `--body-file`** — omit `--body` entirely and it reads from **stdin** (`gh secret set NAME < file`). That is also the safe way: a secret in `--body` is exposed in argv/history.
 - **GitHub sudo-mode re-auth cannot be automated** — creating a PAT (or any sudo-mode action) always stops at a passkey/TOTP/password gate. Hand that step to the user with exact instructions instead of burning turns trying to drive it.
 
+## The Operator's Screen Is Not Yours To Take 🔴
+**Triggers**: any command that raises a window, switches a workspace, or moves focus — `i3-msg`, `xdotool windowactivate`, `wmctrl`, `browser activate`
+
+- 🔴 **Switching a workspace, raising or focusing a window changes what a human is looking at RIGHT NOW.** It is a `pkill`-class action, not a read. Never as a side effect of another task; never more than once per run; **never alternately** (ping-ponging between your window and theirs is the version that makes a machine unusable). Measured 2026-08-19: one capture subagent issued **42 `i3-msg` calls and 14 workspace switches** during a single run, restoring nothing.
+- 🔴 **If a tool already performs the raise, do NOT run `i3-msg` by hand — that is a second theft, not a fix.** `browser activate` runs the host-side raise itself; the 42 calls above were re-implementing a step the tooling already did, and the skill they were "helping" contains **zero** `i3-msg` invocations.
+- **Record before you raise; restore before you finish, including on failure.** `PREV_WIN=$(xdotool getactivewindow)` and `PREV_WS=$(i3-msg -t get_workspaces | jq -r '.[]|select(.focused).num')` BEFORE the first raise — by the time you want them back the values are gone. Restore both at the end. If you cannot restore, say so in your report.
+- 🔴 **A restore rule about FOCUS does not cover a WORKSPACE.** Every pre-existing hint in this setup said "restore focus" and none mentioned workspaces — which is the axis that actually got taken. Name both.
+- **On a single-output host, "park on its own workspace" cannot mean zero switches** — every raise pulls the visible workspace. The achievable goal is *no ping-pong*: raise once, stay there for the run, restore at the end. Say which of the two you achieved; they are different claims.
+- 🔴 **This has already happened twice, and prose alone did not stop it.** Bridge telemetry caught an earlier session grabbing the screen **1–5 times per minute** while the operator was working, diagnosed then as *"partly self-inflicted by our own docs"*. A skill whose Boundaries list has ten prohibitions and none about the operator's screen reads as permission — absence next to present siblings is not neutral.
+
 ## Files, Workspace & Safety 🟡
 **Triggers**: file creation, library use, codebase changes
 

--- a/claude/skills/i3/SKILL.md
+++ b/claude/skills/i3/SKILL.md
@@ -17,7 +17,7 @@ Action + args come from `$ARGUMENTS`.
 | `windows [ws]` | all windows, optionally filtered to a workspace |
 | `focus <target>` | focus by class, title substring, mark, or con_id |
 | `move <target> <ws>` | move a window to a workspace |
-| `workspace <n>` | switch workspace |
+| `workspace <n>` | switch workspace — 🔴 **this is the operator's screen.** Only on an explicit request naming a workspace; never as a step inside another task, and never in a loop |
 | `layout <type>` | split / tabbed / stacking on the focused container |
 | `exec <cmd>` · `mark <name>` · `goto <mark>` · `resize <dir> <px>` | |
 | `scratch [show\|hide\|toggle]` · `config` · `find <query>` | |
@@ -105,3 +105,15 @@ runtime · run a destructive window operation without saying what it will do fir
 the clipboard unasked · send keystrokes before confirming focus · chain more than 3 blind
 actions without a screenshot check · use xdotool mouse for browser work when the `browser`
 skill or Playwright is available · leave screenshots in `/tmp`.
+
+🔴 **Will not: take the operator's screen as a side effect of another task.** Switching a
+workspace, raising or focusing a window changes what a human is looking at right now — only
+on explicit request, once, never alternately. **Record the prior state first and restore it
+when done, including on failure**: `PREV_WIN=$(xdotool getactivewindow)`,
+`PREV_WS=$(i3-msg -t get_workspaces | jq -r '.[]|select(.focused).num')`, restore with
+`i3-msg "workspace number $PREV_WS"` then `i3-msg "[id=$PREV_WIN] focus"`. If a task needs a
+browser window in front, that is `browser activate`'s job — **it runs the host-side raise
+itself, so driving `i3-msg` alongside it is a second theft, not a fix.** Measured 2026-08-19:
+a capture subagent issued 42 `i3-msg` calls and 14 workspace switches in one run, restoring
+nothing, against a skill that contains no `i3-msg` invocation at all. Note this list had ten
+prohibitions and none about the operator's screen — that absence is what read as permission.


### PR DESCRIPTION
## What

Adds the missing rule that an agent must not take the operator's screen, in two places: a new 🔴 section in `claude/RULES.md`, and the corresponding entry in the `i3` skill's Boundaries list plus a caveat on its `workspace <n>` row.

## Why

A capture subagent issued **42 `i3-msg` calls and 14 i3 workspace switches** in a single run, restored nothing, and made the machine unusable while it worked.

An investigation of every file that could have taught it that behaviour found the actual cause:

🔴 **No such rule existed anywhere.** Not in `RULES.md`, `CLAUDE.md`, `PRINCIPLES.md`, `MEMORY.md`, the talos `CLAUDE.md`, or devrc's own `CLAUDE.md`. Every always-loaded file was silent. What existed instead were three conditional, load-on-read hints that say "restore **focus**" and never mention a **workspace** — which is the axis that was actually taken.

The licence was structural rather than prose: the `i3` skill's Boundaries list carried **ten** "will not" entries and none about the operator's screen. Absence next to present siblings reads as permission.

🔴 **The calls were also unnecessary.** The browser CLI performs the host-side raise itself, and `app-capture` contains no `i3-msg` invocation at all — so all 42 were re-implementing a step the tooling already did. That is a second theft, not a fix.

## Three things generic wording would have missed

- **A restore rule about FOCUS does not cover a WORKSPACE.** Both are named.
- **On a single-output host, "park on its own workspace" cannot mean zero switches** — every raise pulls the visible workspace. The achievable goal is *no ping-pong*, and those are different claims, so the rule asks you to say which one you achieved.
- **This already happened once.** Bridge telemetry caught an earlier session grabbing the screen 1–5 times per minute, diagnosed at the time as *"partly self-inflicted by our own docs"*. Prose alone did not hold.

## Mechanical backstop

Because prose has already failed here once, this ships alongside a `permissions.ask` entry (applied separately to `~/.claude/settings.json`, not in this PR) that prompts on the workspace-switching form:

```
"ask": ["Bash(i3-msg:*workspace*)", "Bash(xdotool windowactivate:*)", "Bash(wmctrl:*)"]
```

Deliberately narrowed — read-only `i3-msg -t get_*` stays silent, or the gate gets disabled out of annoyance.

## Verification

Already applied and confirmed live by **store path, not exit code**:

| file | before | after |
|---|---|---|
| `hm_RULES.md` | `3nh6dm4q9…` | `0rwi8k3zn…` |
| `devrc-claude-skills` | `wng79cczay…` | `mn7jfm7rn8…` |

Both new store paths carry the new text.

🔴 The `home-manager switch` was run from an **isolated worktree** so it could not apply the uncommitted nixpkgs bump sitting in this repo's `flake.lock`. Shipping a docs rule must not drag in someone else's half-finished dependency upgrade — that `flake.lock` change is still dirty in the working tree and still theirs.

## Related

Companion fix in `civitai/talos-infra` (`55238e701`): `app-capture`'s exit-11 remedy text used to offer *"or switch to its workspace"* as an equal-standing suggestion, printed at exactly the moment an agent is scanning for a fix. That was the proximate teacher.
