### PR TITLE
fix(browser-bridge): `i3: applied` was reachable with ZERO windows raised

### DIFF
--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -144,7 +144,12 @@
 #                               load unless --no-wait; --wait MS overrides. On i3
 #                               the SERVER also runs `i3-msg` host-side to actually
 #                               raise the Brave window + switch workspace; the
-#                               result's `i3` field reports applied/skipped/failed.
+#                               result's `i3` field reports applied/skipped/failed
+#                               and `i3_detail` says WHY (focused / no_match /
+#                               not_focused / unavailable / no_title / …).
+#                               🔴 `applied` means a window was FOUND and CONFIRMED
+#                               focused — i3-msg exits 0 even matching nothing, so
+#                               it is not inferred from an exit code.
 #   browser html              — outerHTML of the owned/active tab (+ url, title);
 #                               --max-bytes N caps it (default 32768, 0 = uncapped,
 #                               truncation appends a "…[truncated N bytes]" note).
@@ -1561,7 +1566,11 @@ sys.stdout.write(json.dumps(fields)[1:-1])
     # --wait MS overrides; --no-wait skips (waitMs:0). On i3, the SERVER then runs
     # `i3-msg` host-side to actually raise the Brave window + switch workspace
     # (Chrome-side focus alone is a no-op under i3); the result's `i3` field is
-    # applied/skipped/failed. Off a graphical/i3 host it is skipped (best-effort).
+    # applied/skipped/failed and `i3_detail` says why. Off a graphical/i3 host it
+    # is skipped (best-effort). 🔴 `applied` is only reported when the server SAW
+    # the window in `i3-msg -t get_tree` and confirmed it focused afterwards —
+    # `i3-msg … focus` exits 0 even when its criteria matched ZERO windows, so a
+    # zero-match now reports i3:"failed" / i3_detail:"no_match" instead of lying.
     wait=""
     while [ $# -gt 0 ]; do
       case "$1" in

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -97,6 +97,12 @@ Config (env):
                                  (default 900; 0 → disabled). See
                                  HEARTBEAT_INTERVAL_S for why the source needs a
                                  cadence at all.
+    BROWSER_BRIDGE_I3_TIMEOUT    seconds each host-side `i3-msg` call may take
+                                 (default 1.5). See I3_MSG_TIMEOUT.
+    BROWSER_BRIDGE_I3_MATCH_WAIT seconds `activate` keeps re-reading the i3 tree
+                                 waiting for the Brave window's WM_NAME to catch
+                                 up with the activated tab's title (default 1.5;
+                                 0 → one read, no wait). See I3_MATCH_WAIT.
 """
 from __future__ import annotations
 
@@ -371,9 +377,26 @@ HEARTBEAT_INTERVAL_S = float(os.environ.get("BROWSER_BRIDGE_HEARTBEAT_S", "900")
 # raises it + switches workspace, un-throttling the tab. Bounded by this timeout;
 # any failure is non-fatal (the Chrome-side activate result still returns).
 I3_MSG_TIMEOUT = float(os.environ.get("BROWSER_BRIDGE_I3_TIMEOUT", "1.5"))
-# Cap on the UNTRUSTED (page-controlled) tab-title fragment used in the i3
-# criteria — bounds a pathological title before it is re.escape'd.
+# Cap on the UNTRUSTED (page-controlled) tab-title fragment matched against the
+# i3 tree — bounds a pathological title before it is re.escape'd.
 I3_TITLE_MAX = 80
+# How long to keep re-reading the i3 tree waiting for the Brave window's X11
+# WM_NAME to catch up with the tab title Chrome just activated.
+#
+# 🔴 THE RACE THIS EXISTS FOR. `activate` returns the tab's title from Chrome the
+# instant the tab goes active, but the X11 window's WM_NAME is updated by the
+# browser process AFTERWARDS. Immediately after an `open` the window therefore
+# still advertises the OLD title, so a title-keyed match finds nothing. Measured
+# live 2026-08-19: activate #1 (issued right after `open`) matched no window and
+# the tab stayed `hidden`; activate #2, once the title had settled, raised it.
+# A bounded re-read turns that "unreliable by construction" first activate into a
+# normal success — and when the window genuinely is not there, the wait expires
+# and the caller is told `no_match` instead of being lied to.
+I3_MATCH_WAIT = _env_float("BROWSER_BRIDGE_I3_MATCH_WAIT", 1.5)
+# Gap between those re-reads. Each poll is one `i3-msg -t get_tree` (a READ-ONLY
+# IPC query — it cannot focus/move/switch anything), so the whole wait costs at
+# most ~I3_MATCH_WAIT/I3_MATCH_POLL cheap queries.
+I3_MATCH_POLL = 0.2
 
 # Synthetic routing key for a legacy extension that polls without a handshake
 # (no X-Bridge-Instance-Id). All such polls collapse onto one unnamed instance.
@@ -1993,29 +2016,40 @@ def _coerce_tab(tab):
 # then focuses THAT Brave window via `i3-msg` so i3 actually raises it + switches
 # workspace — the step that turns activation from a no-op into real visibility.
 #
+# 🔴 THE SHAPE OF THIS CODE IS DICTATED BY ONE FACT: `i3-msg [criteria] focus`
+# EXITS 0 AND REPLIES `[{"success":true}]` WHEN THE CRITERIA MATCHED NOTHING.
+# There is no way to tell a real raise from a total miss by reading the exit code
+# or that reply, and the previous implementation did exactly that — reporting
+# i3:"applied" for zero windows raised. So the flow is FIND (read-only
+# `-t get_tree`) → RAISE (focus by the STABLE X11 window id found there) →
+# VERIFY (read the tree back and require i3 to agree it is focused). See
+# i3_foreground for the state/detail table.
+#
 # SECURITY — the title is UNTRUSTED (page-controlled; a hostile page the agent
 # visited can set `document.title` to ANYTHING). The bound MUST be: the worst
 # outcome is "focuses the wrong Brave window or no window", NEVER command
 # execution and NEVER focusing a non-Brave window. That is enforced by:
 #   * subprocess with an ARGV LIST + shell=False (no shell → no `;`/`|`/`$()`/
 #     redirection surface at all). NEVER os.system / shell=True.
-#   * The i3 criteria `title=` value is a REGEX delimited by double-quotes inside
-#     the criteria. re.escape() neutralises regex metacharacters but does NOT
-#     escape the `"`/`[`/`]`/`\` that STRUCTURE an i3 criteria — a `"` could close
-#     the quoted value early and let trailing text be read as an i3 command
-#     (e.g. `exec`). So we STRIP those structural chars (and control chars) BEFORE
-#     re.escape. After that the value cannot break out of `title="..."`.
+#   * 🔴 The title is no longer interpolated into an i3 command AT ALL. It is
+#     compiled to a local Python regex (re.escape → a literal, so no ReDoS) and
+#     matched against i3's `get_tree` reply in-process. The only two argvs issued
+#     are the constant `["i3-msg","-t","get_tree"]` and a focus keyed on an
+#     INTEGER window id taken from i3's own reply. The old criteria-breakout
+#     surface (a `"` closing the `title="…"` value so trailing text is read as an
+#     i3 command such as `exec`) is therefore gone by construction — the strip of
+#     the structural chars below is kept as defence in depth.
 #   * A `class="Brave-browser"` constraint so a matched window is always Brave.
 #   * A length cap + a bounded timeout; failure/timeout is swallowed (non-fatal).
 # i3-only chars that i3 uses to delimit a criteria/value. Stripped from the
-# UNTRUSTED title BEFORE re.escape so the value cannot escape its `title="..."`
-# quoting (re.escape does not touch `"`). Removing them at worst makes the title
-# match a different window or none — never a breakout.
+# UNTRUSTED title BEFORE re.escape as belt-and-braces (see above: the title never
+# reaches a criteria any more). Removing them at worst makes the title match a
+# different window or none — never a breakout.
 _I3_STRUCTURAL = str.maketrans("", "", '"[]\\')
 
 
 def _sanitize_i3_title(title) -> str:
-    """Reduce an UNTRUSTED tab title to a safe i3 criteria fragment.
+    """Reduce an UNTRUSTED tab title to a safe match fragment.
 
     Strips control chars / newlines AND the i3-criteria structural chars
     (``"[]\\``), then caps length. The remaining text is re.escape'd by the
@@ -2029,19 +2063,106 @@ def _sanitize_i3_title(title) -> str:
     return cleaned.strip()[:I3_TITLE_MAX]
 
 
-def i3_focus_argv(title):
-    """Build the argv LIST for `i3-msg` to focus the Brave window whose title
-    matches `title`, or None when there is no usable title (→ skip).
+def i3_title_pattern(title):
+    """The REGEX used to find the Brave window for an (UNTRUSTED) tab `title`,
+    or None when nothing usable remains (→ skip).
 
-    shell=False BY CONSTRUCTION (a list, never a shell string). The criteria is
-    `[class="Brave-browser" title="<re.escape'd fragment>"] focus`, so the worst
-    case is "focuses the wrong Brave window or none" — never a non-Brave window,
-    never code execution. See the module block above for the threat model."""
+    This is `re.escape(sanitized)`, matched with `re.search` — an unanchored
+    literal substring match, which is exactly what i3's own `title="…"` criteria
+    (an unanchored PCRE) used to do. The difference is WHERE it is evaluated:
+    HERE, in-process, against i3's `get_tree` reply — never interpolated into an
+    i3 command.
+
+    🔴 That is a strict security IMPROVEMENT over the criteria this replaced. The
+    page-controlled title no longer reaches ANY argv at all: the only two commands
+    issued are a constant `-t get_tree` and a focus keyed on an INTEGER X11 window
+    id taken from i3's own reply. The structural-char strip + length cap in
+    _sanitize_i3_title are kept anyway (defence in depth), and re.escape means the
+    compiled pattern is a literal — no metacharacter survives, so no ReDoS."""
     safe = _sanitize_i3_title(title)
     if not safe:
         return None
-    criteria = '[class="Brave-browser" title="%s"] focus' % re.escape(safe)
-    return ["i3-msg", criteria]
+    return re.escape(safe)
+
+
+def i3_get_tree_argv():
+    """argv LIST for `i3-msg -t get_tree` — the READ-ONLY IPC query that tells us
+    what windows EXIST.
+
+    🔴 THIS IS THE ONLY THING THAT CAN ANSWER "DID ANYTHING MATCH?". Issuing
+    `focus` and reading its exit code CANNOT: i3 answers a criteria that matched
+    ZERO windows with `[{"success":true}]` and rc 0, byte-identical to a real
+    raise. `-t get_tree` is a query — it cannot focus, move or switch anything,
+    so calling it never touches the operator's screen."""
+    return ["i3-msg", "-t", "get_tree"]
+
+
+def i3_focus_by_id_argv(window_id):
+    """argv LIST for `i3-msg [id="<x11-window-id>"] focus`.
+
+    Keyed on the X11 window id — a STABLE handle. WM_NAME changes while the title
+    settles (that is the whole bug); a window id does not, so the window we
+    matched in the tree is provably the window we focus. `window_id` comes from
+    i3's own reply and is re-validated as an int here, so this argv can never
+    carry page-controlled text."""
+    return ["i3-msg", '[id="%d"] focus' % int(window_id)]
+
+
+# The X11 WM_CLASS i3 reports for Brave windows. A match is constrained to this
+# so the worst case stays "the wrong BRAVE window, or none" — never some other
+# application's window.
+_I3_BRAVE_CLASSES = ("Brave-browser",)
+
+
+def _i3_walk(node):
+    """Yield every node of an i3 `get_tree` reply, depth-first (tiled + floating)."""
+    if not isinstance(node, dict):
+        return
+    yield node
+    for key in ("nodes", "floating_nodes"):
+        kids = node.get(key)
+        if isinstance(kids, list):
+            for kid in kids:
+                yield from _i3_walk(kid)
+
+
+def _i3_node_class(node) -> str:
+    props = node.get("window_properties")
+    if isinstance(props, dict) and isinstance(props.get("class"), str):
+        return props["class"]
+    return ""
+
+
+def i3_find_windows(tree, pattern):
+    """Every Brave window in `tree` whose title matches `pattern`.
+
+    Returns a list of (x11_window_id, focused) tuples. An EMPTY list is the state
+    `i3-msg … focus` reports as success and this function reports as itself: i3
+    has no such window."""
+    out = []
+    try:
+        rx = re.compile(pattern)
+    except re.error:
+        return out
+    for node in _i3_walk(tree):
+        wid = node.get("window")
+        if not isinstance(wid, int) or isinstance(wid, bool):
+            continue  # containers/workspaces carry window=None
+        if _i3_node_class(node) not in _I3_BRAVE_CLASSES:
+            continue
+        name = node.get("name")
+        if not isinstance(name, str) or not rx.search(name):
+            continue
+        out.append((wid, bool(node.get("focused"))))
+    return out
+
+
+def _i3_is_focused(tree, window_id) -> bool:
+    """True when the window with X11 id `window_id` is the focused one in `tree`."""
+    for node in _i3_walk(tree):
+        if node.get("window") == window_id:
+            return bool(node.get("focused"))
+    return False
 
 
 # Well-known absolute locations for `i3-msg`, tried IN ORDER when it is not on
@@ -2085,41 +2206,124 @@ def i3_available() -> bool:
     return _resolve_i3_msg() is not None
 
 
-def i3_foreground(title, *, timeout: float = I3_MSG_TIMEOUT) -> str:
-    """Best-effort host-side i3 foregrounding of the Brave window matching the
-    (UNTRUSTED) `title`. Returns a small metadata state for the caller:
+def _i3_run(argv, *, timeout):
+    """Run an i3-msg argv (shell=False, timeout-bounded). Returns
+    (returncode, stdout_bytes), or None when it could not be run at all
+    (i3-msg unresolvable, timeout, any exception) — all non-fatal.
 
-      * "skipped" — no graphical/i3 session (i3-msg absent or no DISPLAY), or no
-        usable title. NOT an error — the Chrome-side activate still returns.
-      * "applied" — i3-msg ran and exited 0.
-      * "failed"  — i3-msg errored, timed out, or exited nonzero (non-fatal).
-
-    The title is sanitized + re.escape'd (see i3_focus_argv) and the call is
-    shell=False + timeout-bounded, so a hostile title can at worst focus the
-    wrong Brave window / none — never execute a command."""
-    if not i3_available():
-        return "skipped"
-    argv = i3_focus_argv(title)
-    if argv is None:
-        return "skipped"
-    # Resolve i3-msg to an ABSOLUTE path for argv[0] so the call works even when
-    # i3-msg is not on the (minimal systemd --user) PATH. i3_available() above
-    # already confirmed it resolves; re-check defensively. The criteria (argv[1])
-    # is built + sanitized + re.escape'd by i3_focus_argv — UNCHANGED here.
+    Resolves i3-msg to an ABSOLUTE path for argv[0] so the call works even under
+    the minimal systemd --user service PATH."""
     i3_msg = _resolve_i3_msg()
     if i3_msg is None:
-        return "skipped"
+        return None
+    argv = list(argv)
     argv[0] = i3_msg
     try:
         proc = subprocess.run(argv, shell=False, capture_output=True,
                               timeout=timeout)
     except Exception:  # noqa: BLE001 — best-effort; any failure is non-fatal.
-        log("activate_i3_failed", reason="exception")
-        return "failed"
-    if getattr(proc, "returncode", 1) == 0:
-        return "applied"
-    log("activate_i3_failed", reason="nonzero", rc=getattr(proc, "returncode", None))
-    return "failed"
+        return None
+    return getattr(proc, "returncode", 1), (getattr(proc, "stdout", b"") or b"")
+
+
+def _i3_tree(*, timeout):
+    """The parsed `i3-msg -t get_tree` reply, or None when it could not be read
+    (i3-msg missing/timed out/nonzero, or the reply was not a JSON object)."""
+    got = _i3_run(i3_get_tree_argv(), timeout=timeout)
+    if got is None:
+        return None
+    rc, out = got
+    if rc != 0:
+        return None
+    try:
+        tree = json.loads(out.decode("utf-8", "replace"))
+    except Exception:  # noqa: BLE001 — a malformed reply is "unreadable".
+        return None
+    return tree if isinstance(tree, dict) else None
+
+
+def i3_foreground(title, *, timeout: float = None, match_wait: float = None):
+    """Host-side i3 foregrounding of the Brave window matching the (UNTRUSTED)
+    `title`. Returns a **(state, detail)** pair.
+
+    🔴 `state` MUST reflect WHAT HAPPENED, not whether a command was accepted.
+    The bug this replaced: it ran `i3-msg [class="Brave-browser" title="…"] focus`
+    and reported "applied" on rc 0 — but i3 exits 0 and replies
+    `[{"success":true}]` for a criteria that matched ZERO windows, so "applied"
+    was reachable with nothing raised at all. Downstream that read as "the window
+    is up", and the only failure signal anyone had said everything was fine.
+
+    So the sequence is now FIND → RAISE → VERIFY, and every step can say no:
+
+      state       detail              meaning
+      ─────────── ─────────────────── ─────────────────────────────────────────
+      "skipped"   "unavailable"       no DISPLAY / no i3-msg (headless, non-i3)
+      "skipped"   "no_title"          nothing usable left of the tab title
+      "applied"   "focused"           matched → focused → CONFIRMED focused
+      "failed"    "no_match"          i3 has NO Brave window with that title
+      "failed"    "tree_unreadable"   `-t get_tree` failed/timed out/unparseable
+      "failed"    "focus_error"       the focus command itself errored
+      "failed"    "not_focused"       focus accepted, window still not focused
+
+    "applied" is now reachable ONLY via a get_tree that listed the window AND a
+    second get_tree that confirms it is focused. `state` keeps the exact three
+    values callers already branch on ("applied"/"skipped"/"failed"), with
+    not-raised now correctly landing in "failed"; `detail` is additive.
+
+    Non-fatal throughout — the Chrome-side activate result still returns."""
+    if timeout is None:
+        timeout = I3_MSG_TIMEOUT
+    if match_wait is None:
+        match_wait = I3_MATCH_WAIT
+    if not i3_available():
+        return "skipped", "unavailable"
+    pattern = i3_title_pattern(title)
+    if pattern is None:
+        return "skipped", "no_title"
+
+    # 1. FIND. A READ-ONLY get_tree is the only thing that can distinguish
+    #    "matched one window" from "matched nothing" — see i3_get_tree_argv.
+    #    Re-read for up to match_wait while there is no match: right after an
+    #    `open` the window's WM_NAME still holds the OLD title (see I3_MATCH_WAIT).
+    #    A tree that cannot be READ is not a race — bail immediately, no retry.
+    tree = _i3_tree(timeout=timeout)
+    if tree is None:
+        log("activate_i3_failed", reason="tree_unreadable")
+        return "failed", "tree_unreadable"
+    matches = i3_find_windows(tree, pattern)
+    deadline = time.monotonic() + max(0.0, match_wait)
+    while not matches and time.monotonic() < deadline:
+        time.sleep(min(I3_MATCH_POLL, max(0.0, deadline - time.monotonic())))
+        tree = _i3_tree(timeout=timeout)
+        if tree is None:
+            log("activate_i3_failed", reason="tree_unreadable")
+            return "failed", "tree_unreadable"
+        matches = i3_find_windows(tree, pattern)
+    if not matches:
+        # The old code's silent lie. Nothing was raised; say so.
+        log("activate_i3_failed", reason="no_match")
+        return "failed", "no_match"
+
+    # 2. RAISE by STABLE X11 window id — immune to the title settling underneath
+    #    us between the tree read and the focus.
+    window_id = matches[0][0]
+    got = _i3_run(i3_focus_by_id_argv(window_id), timeout=timeout)
+    if got is None or got[0] != 0:
+        log("activate_i3_failed", reason="focus_error",
+            rc=(got[0] if got is not None else None))
+        return "failed", "focus_error"
+
+    # 3. VERIFY. rc 0 from `focus` still proves nothing (an id that vanished
+    #    between the two calls also answers success:true), so read the tree back
+    #    and require i3 to agree the window is focused.
+    tree = _i3_tree(timeout=timeout)
+    if tree is None:
+        log("activate_i3_failed", reason="tree_unreadable")
+        return "failed", "tree_unreadable"
+    if not _i3_is_focused(tree, window_id):
+        log("activate_i3_failed", reason="not_focused")
+        return "failed", "not_focused"
+    return "applied", "focused"
 
 
 def _result_title(result) -> str:
@@ -2132,12 +2336,20 @@ def _result_title(result) -> str:
     return ""
 
 
-def _annotate_i3(result, state: str) -> None:
-    """Record the i3-foregrounding outcome as a small metadata field on the
-    activate result's data ({...,"i3":"applied"|"skipped"|"failed"}) so the
-    caller knows whether the window was actually raised. Never emits the title."""
+def _annotate_i3(result, state: str, detail: str = "") -> None:
+    """Record the i3-foregrounding outcome on the activate result's data:
+
+        {..., "i3": "applied"|"skipped"|"failed", "i3_detail": "<why>"}
+
+    `i3` keeps EXACTLY the three values callers already branch on — a consumer
+    that treats "failed" as fatal keeps working, and now correctly sees a raise
+    that matched nothing (which used to report "applied"). `i3_detail` is the
+    additive field that separates "I asked and nothing matched" ("no_match")
+    from "i3 is not there" ("unavailable") from a real raise ("focused"); see
+    i3_foreground for the full table. Never emits the title."""
     if isinstance(result, dict) and isinstance(result.get("data"), dict):
         result["data"]["i3"] = state
+        result["data"]["i3_detail"] = detail
 
 
 # --------------------------------------------------------------------------- #
@@ -2579,11 +2791,14 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                     # document.hidden). Focus the matching Brave X11 WINDOW via
                     # i3-msg so i3 raises it + switches workspace → the throttled
                     # SPA un-throttles and renders. Best-effort + bounded; the
-                    # title is UNTRUSTED (page-controlled) and handled shell=False
-                    # + re.escape'd inside i3_foreground. Skipped gracefully off i3.
-                    state = i3_foreground(_result_title(result))
-                    _annotate_i3(result, state)
-                    log("activate_i3", state=state)
+                    # title is UNTRUSTED (page-controlled) and never reaches an
+                    # i3 command (see i3_title_pattern). Skipped gracefully off i3.
+                    # 🔴 `state` is EARNED, not assumed: i3-msg exits 0 even when
+                    # the criteria matched nothing, so i3_foreground confirms the
+                    # window exists and ends up focused before saying "applied".
+                    state, detail = i3_foreground(_result_title(result))
+                    _annotate_i3(result, state, detail)
+                    log("activate_i3", state=state, detail=detail)
                 self._send(200, {"ok": True, "result": result})
             # Off the critical path: the HTTP response is already sent. Metadata-
             # only + best-effort — cannot delay or break the command (the key is

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -2388,81 +2388,232 @@ def _enable_i3(monkeypatch, returncode=0, raise_exc=None):
 _FAKE_I3_MSG = "/run/current-system/sw/bin/i3-msg"
 
 
-def test_i3_focus_argv_hostile_title_is_safe():
-    """KEY SECURITY TEST: a hostile, page-controlled title (i3-criteria breakout
-    attempt, regex metachars, quotes, `;`, newlines, `$()`, backticks, very long)
-    can NEVER break out of the `title="..."` value into an i3 command. The argv is
-    a 2-element LIST (→ shell=False), constrained to class="Brave-browser", and
-    the criteria has EXACTLY the 4 structural `"`, one `[`, one `]` — a hostile
-    `"`/`]` would add more. Worst case is "wrong Brave window or none"."""
-    hostile = (
-        'evil"] exec xterm [title="pwn'      # try to close value → i3 `exec`
-        + '; rm -rf ~ | cat `id` $(whoami)'  # shell metachars (irrelevant, no shell)
-        + '\n\r\tmore .*+?[]{}^$\\ '          # control chars + regex metachars
-        + "A" * 500                             # length bomb
-    )
-    argv = S.i3_focus_argv(hostile)
-    assert isinstance(argv, list) and len(argv) == 2
-    assert argv[0] == "i3-msg"
-    crit = argv[1]
-    # Structural integrity: exactly one criteria bracket pair + the 2 quoted
-    # attribute values (class + title) → 4 double-quotes, and NO breakout.
-    assert crit.startswith('[class="Brave-browser" title="')
-    assert crit.endswith('"] focus')
-    assert crit.count('"') == 4, crit
-    assert crit.count("[") == 1 and crit.count("]") == 1, crit
-    assert "\n" not in crit and "\r" not in crit and "\t" not in crit
-    # `exec` cannot be a standalone i3 command — it only survives as inert text
-    # INSIDE the quoted title value (still between title=" and "]).
-    title_frag = crit[len('[class="Brave-browser" title="'):-len('"] focus')]
-    assert '"' not in title_frag and "]" not in title_frag and "[" not in title_frag
-    # Length is capped (the 500-char bomb cannot bloat the criteria unbounded).
-    assert len(title_frag) <= len(re.escape("A" * S.I3_TITLE_MAX)) + 40
+# --- a FAKE of the `i3-msg` boundary --------------------------------------- #
+# 🔴 NEVER a real i3. Every test below stubs subprocess.run, so the suite cannot
+# switch a workspace, raise a window or otherwise take the operator's screen.
+#
+# 🔴 THE FAKE'S ONE LOAD-BEARING FIDELITY REQUIREMENT: real `i3-msg` exits 0 and
+# replies `[{"success":true}]` for a command whose criteria matched ZERO windows —
+# byte-identical to a real raise. That is the entire defect. A fake that returned
+# nonzero on a miss would make the buggy implementation look correct and every
+# test here would be vacuous, so the fake reproduces the lie faithfully and
+# test_fake_i3_mirrors_real_i3_success_on_zero_match pins that it does.
+_I3_SUCCESS_REPLY = b'[{"success":true}]'
+_TITLE_CRITERIA_RE = re.compile(r'^\[class="([^"]*)" title="(.*)"\] focus$')
+_ID_CRITERIA_RE = re.compile(r'^\[id="(\d+)"\] focus$')
 
 
-def test_i3_focus_argv_escapes_regex_metacharacters():
-    """A plain title with regex metacharacters is re.escape'd so it matches
-    literally (never alters i3's regex matching)."""
-    argv = S.i3_focus_argv("Model Benchmarking")
-    assert argv == ["i3-msg",
-                    '[class="Brave-browser" title="%s"] focus'
-                    % re.escape("Model Benchmarking")]
+class _FakeI3:
+    """An in-memory i3 that answers `-t get_tree` and `… focus`.
+
+    windows: list of (x11_window_id, wm_class, wm_name). `focused` is the id of
+    the currently focused window (None = none). Understands BOTH command shapes
+    so one test file can be run against the pre-fix implementation (which focuses
+    by a `title="…"` criteria) and the fixed one (which focuses by `id="…"`)."""
+
+    def __init__(self, windows=(), focused=None):
+        self.windows = [list(w) for w in windows]
+        self.focused = focused
+        self.calls = []            # every argv, in order
+        self.tree_rc = 0
+        self.tree_stdout = None    # not None → return this instead of a tree
+        self.focus_rc = 0
+        # False → focus is ACCEPTED (rc 0, success:true) but changes nothing.
+        # This is not hypothetical: an id that vanished between the tree read and
+        # the focus answers exactly this way.
+        self.focus_effective = True
+        self.on_call = None        # hook(fake, call_index) run BEFORE each reply
+
+    # -- test-facing helpers ------------------------------------------------ #
+    def set_title(self, window_id, name):
+        for w in self.windows:
+            if w[0] == window_id:
+                w[2] = name
+
+    def _is_tree(self, argv):
+        return argv[1:] == ["-t", "get_tree"]
+
+    @property
+    def tree_calls(self):
+        return [a for a in self.calls if self._is_tree(a)]
+
+    @property
+    def focus_calls(self):
+        return [a for a in self.calls if not self._is_tree(a)]
+
+    # -- the i3 model ------------------------------------------------------- #
+    def tree(self):
+        nodes = [{"type": "con", "window": wid, "name": name,
+                  "window_properties": {"class": cls, "instance": "brave-browser"},
+                  "focused": wid == self.focused,
+                  "nodes": [], "floating_nodes": []}
+                 for wid, cls, name in self.windows]
+        return {"type": "root", "name": "root", "window": None, "focused": False,
+                "floating_nodes": [],
+                "nodes": [{"type": "workspace", "name": "1", "window": None,
+                           "focused": False, "floating_nodes": [],
+                           "nodes": nodes}]}
+
+    def _focus(self, window_id):
+        if not self.focus_effective:
+            return
+        if any(w[0] == window_id for w in self.windows):
+            self.focused = window_id
+
+    def run(self, argv, **kw):
+        argv = list(argv)
+        self.calls.append(argv)
+        if self.on_call is not None:
+            self.on_call(self, len(self.calls) - 1)
+        if self._is_tree(argv):
+            if self.tree_stdout is not None:
+                return _FakeProcOut(self.tree_rc, self.tree_stdout)
+            return _FakeProcOut(self.tree_rc,
+                                json.dumps(self.tree()).encode("utf-8"))
+        cmd = argv[1] if len(argv) > 1 else ""
+        m = _ID_CRITERIA_RE.match(cmd)
+        if m:
+            self._focus(int(m.group(1)))
+        else:
+            m = _TITLE_CRITERIA_RE.match(cmd)
+            if m:
+                cls, pat = m.group(1), m.group(2)
+                try:
+                    rx = re.compile(pat)
+                except re.error:
+                    rx = None
+                if rx is not None:
+                    for wid, wcls, name in self.windows:
+                        if wcls == cls and rx.search(name):
+                            self._focus(wid)
+                            break
+        # 🔴 UNCONDITIONAL success — matched or not. This is what real i3 does.
+        return _FakeProcOut(self.focus_rc, _I3_SUCCESS_REPLY)
 
 
-def test_i3_focus_argv_empty_title_returns_none():
-    """No usable title (empty / only structural+control chars) → None → skip."""
-    assert S.i3_focus_argv("") is None
-    assert S.i3_focus_argv(None) is None
-    assert S.i3_focus_argv('"[]\\\n\t ') is None
+class _FakeProcOut:
+    def __init__(self, returncode, stdout):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = b""
 
 
-def test_activate_invokes_i3_msg_on_success(monkeypatch):
-    """On a successful activate the server runs i3-msg with the ARGV LIST
-    (shell=False), a class="Brave-browser" + re.escape'd-title criteria, and
-    `focus`; the result reports i3:"applied"."""
-    calls = _enable_i3(monkeypatch, returncode=0)
+def _enable_fake_i3(monkeypatch, windows=(), focused=None, match_wait=0.0):
+    """Turn the i3 path ON, routed at a _FakeI3. `match_wait` 0 = one tree read
+    (keeps the suite fast); the settle-race tests raise it deliberately."""
+    fake = _FakeI3(windows=windows, focused=focused)
+    monkeypatch.setattr(S, "i3_available", lambda: True)
+    monkeypatch.setattr(S, "_resolve_i3_msg", lambda: _FAKE_I3_MSG)
+    monkeypatch.setattr(S, "I3_MATCH_WAIT", match_wait, raising=False)
+    monkeypatch.setattr(S, "I3_MATCH_POLL", 0.01, raising=False)
+    monkeypatch.setattr(S.subprocess, "run",
+                        lambda argv, **kw: fake.run(argv, **kw))
+    return fake
+
+
+# The live pair measured 2026-08-19, reproduced as a fixture: `activate` is
+# answered by Chrome with the NEW tab title while the Brave X11 window's WM_NAME
+# still advertises the OLD one.
+_NEW_TITLE = "Model Benchmarking"
+_OLD_TITLE = "New Tab"
+_BRAVE = "Brave-browser"
+
+
+def _activate_with_fake_i3(fake_windows, focused=None, match_wait=0.0,
+                           title=_NEW_TITLE, monkeypatch=None, mutate=None):
+    """Drive ONE real `activate` through the HTTP surface against a fake i3.
+    Returns (response_body, fake)."""
+    fake = _enable_fake_i3(monkeypatch, windows=fake_windows, focused=focused,
+                           match_wait=match_wait)
+    if mutate is not None:
+        mutate(fake)
     srv, _ = _serve()
     ext = FakeExtension(srv, executor=lambda c: {
         "tabId": 5, "windowId": 1, "active": True, "status": "complete",
-        "url": "https://model-benchmarking.example.test/run",
-        "title": "Model Benchmarking"})
+        "url": "https://model-benchmarking.example.test/run", "title": title})
     ext.start()
     try:
         assert _wait_connected(srv, want=True)
         st, body = _req(srv, "POST", "/cmd", {"op": "activate"})
         assert st == 200
-        assert body["result"]["data"]["i3"] == "applied"
-        assert len(calls) == 1
-        argv, kw = calls[0]
-        # argv[0] is the RESOLVED ABSOLUTE i3-msg path (not the bare name) so the
-        # call works even under the minimal systemd --user service PATH.
-        assert argv[0] == _FAKE_I3_MSG
-        assert argv[1] == ('[class="Brave-browser" title="%s"] focus'
-                           % re.escape("Model Benchmarking"))
-        assert kw.get("shell", False) is False  # NEVER a shell string
-        assert kw.get("timeout")  # bounded
+        return body, fake
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
+
+
+_HOSTILE_TITLE = (
+    'evil"] exec xterm [title="pwn'      # try to close value → i3 `exec`
+    + '; rm -rf ~ | cat `id` $(whoami)'  # shell metachars (irrelevant, no shell)
+    + '\n\r\tmore .*+?[]{}^$\\ '          # control chars + regex metachars
+    + "A" * 500                             # length bomb
+)
+
+
+def test_i3_title_pattern_hostile_title_is_inert():
+    """KEY SECURITY TEST (was: the criteria-breakout test). A hostile,
+    page-controlled title is reduced to a LITERAL regex — every metacharacter
+    re.escape'd, every i3-structural char stripped, length capped. It is matched
+    in-process against i3's get_tree reply, so a `"`/`]` has nothing to break out
+    of; the escaping also means the compiled pattern is a literal (no ReDoS)."""
+    pat = S.i3_title_pattern(_HOSTILE_TITLE)
+    assert isinstance(pat, str) and pat
+    assert '"' not in pat and "\n" not in pat and "\r" not in pat and "\t" not in pat
+    # A LITERAL: the compiled pattern matches its own unescaped text and nothing
+    # a metacharacter would have let through.
+    lit = S._sanitize_i3_title(_HOSTILE_TITLE)
+    assert re.compile(pat).search(lit)
+    assert not re.compile(pat).search("totally unrelated window title")
+    # Length is capped (the 500-char bomb cannot bloat the pattern unbounded).
+    assert len(lit) <= S.I3_TITLE_MAX
+
+
+def test_i3_title_pattern_escapes_regex_metacharacters():
+    """A plain title with regex metacharacters is re.escape'd so it matches
+    literally (never alters the match)."""
+    assert S.i3_title_pattern("Model Benchmarking") == re.escape("Model Benchmarking")
+
+
+def test_i3_title_pattern_empty_title_returns_none():
+    """No usable title (empty / only structural+control chars) → None → skip."""
+    assert S.i3_title_pattern("") is None
+    assert S.i3_title_pattern(None) is None
+    assert S.i3_title_pattern('"[]\\\n\t ') is None
+
+
+def test_activate_invokes_i3_msg_on_success(monkeypatch):
+    """On a successful activate the server talks to i3 with ARGV LISTS
+    (shell=False), reads the tree, focuses the matched window, and reports
+    i3:"applied" / i3_detail:"focused"."""
+    body, fake = _activate_with_fake_i3(
+        [(4242, _BRAVE, _NEW_TITLE)], focused=None, monkeypatch=monkeypatch)
+    assert body["result"]["data"]["i3"] == "applied"
+    assert body["result"]["data"]["i3_detail"] == "focused"
+    # argv[0] is the RESOLVED ABSOLUTE i3-msg path (not the bare name) so the
+    # call works even under the minimal systemd --user service PATH.
+    assert all(a[0] == _FAKE_I3_MSG for a in fake.calls), fake.calls
+    assert fake.tree_calls, "the raise must be decided from a get_tree read"
+    assert fake.focus_calls == [[_FAKE_I3_MSG, '[id="4242"] focus']]
+    assert fake.focused == 4242
+
+
+def test_activate_i3_calls_are_shell_false_and_bounded(monkeypatch):
+    """Every i3-msg invocation is an argv LIST with shell=False and a timeout."""
+    seen = []
+    fake = _FakeI3(windows=[(7, _BRAVE, _NEW_TITLE)])
+    monkeypatch.setattr(S, "i3_available", lambda: True)
+    monkeypatch.setattr(S, "_resolve_i3_msg", lambda: _FAKE_I3_MSG)
+
+    def _run(argv, **kw):
+        seen.append((argv, kw))
+        return fake.run(argv, **kw)
+
+    monkeypatch.setattr(S.subprocess, "run", _run)
+    assert S.i3_foreground(_NEW_TITLE, match_wait=0) == ("applied", "focused")
+    assert seen, "positive control: at least one i3-msg call was made"
+    for argv, kw in seen:
+        assert isinstance(argv, list)          # NEVER a shell string
+        assert kw.get("shell", False) is False
+        assert kw.get("timeout")               # bounded
 
 
 def test_activate_i3_skipped_when_unavailable(monkeypatch):
@@ -2483,6 +2634,7 @@ def test_activate_i3_skipped_when_unavailable(monkeypatch):
         st, body = _req(srv, "POST", "/cmd", {"op": "activate"})
         assert st == 200
         assert body["result"]["data"]["i3"] == "skipped"
+        assert body["result"]["data"]["i3_detail"] == "unavailable"
         assert body["result"]["data"]["tabId"] == 5  # Chrome-side result intact
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
@@ -2501,6 +2653,7 @@ def test_activate_i3_skipped_when_no_title(monkeypatch):
         st, body = _req(srv, "POST", "/cmd", {"op": "activate"})
         assert st == 200
         assert body["result"]["data"]["i3"] == "skipped"
+        assert body["result"]["data"]["i3_detail"] == "no_title"
         assert calls == []
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
@@ -2520,6 +2673,7 @@ def test_activate_i3_failed_on_nonzero(monkeypatch):
         st, body = _req(srv, "POST", "/cmd", {"op": "activate"})
         assert st == 200
         assert body["result"]["data"]["i3"] == "failed"
+        assert body["result"]["data"]["i3_detail"] == "tree_unreadable"
         assert body["result"]["data"]["tabId"] == 5
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
@@ -2539,8 +2693,255 @@ def test_activate_i3_failed_on_timeout(monkeypatch):
         st, body = _req(srv, "POST", "/cmd", {"op": "activate"})
         assert st == 200
         assert body["result"]["data"]["i3"] == "failed"
+        assert body["result"]["data"]["i3_detail"] == "tree_unreadable"
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# ======================================================================== #
+# 🔴 `i3: applied` MUST MEAN A WINDOW WAS RAISED
+#
+# Live pair, 2026-08-19: `activate` #1 (right after `open`) reported
+# i3:"applied" while raising NOTHING — the tab stayed `hidden` — because the
+# Brave window's WM_NAME still held the OLD title, the `title="…"` criteria
+# matched zero windows, and `i3-msg` exits 0 with `[{"success":true}]` anyway.
+# `activate` #2, once the title had settled, reported the SAME "applied" and
+# really did raise it. One signal, two opposite realities.
+#
+# Downstream that is the dominant live cause of a capture tool exiting 11 "the
+# app never booted": it never booted because nothing was ever raised, and the
+# only status said everything was fine.
+# ======================================================================== #
+
+def test_fake_i3_mirrors_real_i3_success_on_zero_match():
+    """INSTRUMENT VALIDATION — pin the fake's fidelity to the ONE real i3
+    behaviour every test below depends on: a `focus` whose criteria matched ZERO
+    windows still exits 0 with `[{"success":true}]`.
+
+    If this ever stops holding, the fake has become kinder than i3 and every
+    zero-match test below would pass against the BUGGY implementation."""
+    fake = _FakeI3(windows=[(1, _BRAVE, _OLD_TITLE)])
+    miss = fake.run([_FAKE_I3_MSG,
+                     '[class="%s" title="%s"] focus' % (_BRAVE, re.escape(_NEW_TITLE))])
+    assert miss.returncode == 0                     # ← the trap, faithfully
+    assert miss.stdout == b'[{"success":true}]'
+    assert fake.focused is None                     # …and nothing was raised
+    # POSITIVE CONTROL: the same reply shape for a criteria that DOES match, so
+    # the assertion above is about the MATCH, not about the fake refusing to work.
+    hit = fake.run([_FAKE_I3_MSG,
+                    '[class="%s" title="%s"] focus' % (_BRAVE, re.escape(_OLD_TITLE))])
+    assert hit.returncode == 0 and hit.stdout == b'[{"success":true}]'
+    assert fake.focused == 1                        # this one really raised
+
+
+def test_activate_i3_zero_match_is_never_reported_as_applied(monkeypatch):
+    """🔴 THE REGRESSION TEST. RED on the pre-fix implementation.
+
+    The exact live race: Chrome answers `activate` with the NEW title while the
+    only Brave window still advertises the OLD one. i3 matches nothing and exits
+    0 — so the pre-fix code reported i3:"applied" with the tab still hidden.
+    `applied` must be unreachable here."""
+    body, fake = _activate_with_fake_i3(
+        [(4242, _BRAVE, _OLD_TITLE)], monkeypatch=monkeypatch)
+    data = body["result"]["data"]
+    assert data["i3"] != "applied", (
+        "zero windows matched — `applied` is a lie the caller acts on")
+    assert data["i3"] == "failed"
+    assert data["i3_detail"] == "no_match"
+    # Ground truth from the fake: nothing was ever focused.
+    assert fake.focused is None
+    # The Chrome-side result is untouched (the i3 step is non-fatal metadata).
+    assert data["tabId"] == 5
+
+
+def test_activate_i3_real_match_is_reported_as_applied(monkeypatch):
+    """POSITIVE CONTROL for the test above — the SAME fixture with the SAME code
+    path, differing only in the window's title. Reported pair:
+      window title OLD (no match) → i3="failed"  / detail="no_match"
+      window title NEW (a match)  → i3="applied" / detail="focused"
+    Without this, "never applied" could be satisfied by a check wired to nothing."""
+    body, fake = _activate_with_fake_i3(
+        [(4242, _BRAVE, _NEW_TITLE)], monkeypatch=monkeypatch)
+    data = body["result"]["data"]
+    assert data["i3"] == "applied"
+    assert data["i3_detail"] == "focused"
+    assert fake.focused == 4242          # ground truth: it really was raised
+
+
+def test_activate_i3_zero_match_issues_no_focus_command(monkeypatch):
+    """A raise that cannot match must not fire a focus at all — and the ZERO is
+    reported WITH its positive control (0 focus calls on a miss, 1 on a hit), so
+    a harness wired to nothing cannot masquerade as the finding."""
+    miss_body, miss = _activate_with_fake_i3(
+        [(1, _BRAVE, _OLD_TITLE)], monkeypatch=monkeypatch)
+    hit_body, hit = _activate_with_fake_i3(
+        [(1, _BRAVE, _NEW_TITLE)], monkeypatch=monkeypatch)
+    assert len(miss.focus_calls) == 0, miss.focus_calls
+    assert len(hit.focus_calls) == 1, hit.focus_calls   # ← the positive control
+    assert miss_body["result"]["data"]["i3"] == "failed"
+    assert hit_body["result"]["data"]["i3"] == "applied"
+    # Both arms DID talk to i3 — the miss is a real read, not a skipped step.
+    assert miss.tree_calls and hit.tree_calls
+
+
+def test_activate_i3_focus_is_keyed_on_stable_window_id(monkeypatch):
+    """The focus is keyed on the X11 window ID from i3's own reply, not on the
+    racy title — the id cannot change underneath us while WM_NAME settles."""
+    body, fake = _activate_with_fake_i3(
+        [(9, _BRAVE, "Some Other Tab"), (77, _BRAVE, _NEW_TITLE)],
+        monkeypatch=monkeypatch)
+    assert body["result"]["data"]["i3"] == "applied"
+    assert fake.focus_calls == [[_FAKE_I3_MSG, '[id="77"] focus']]
+    assert fake.focused == 77            # the RIGHT window, not the first one
+
+
+def test_activate_i3_untrusted_title_never_reaches_any_argv(monkeypatch):
+    """SECURITY: with the title out of the criteria entirely, no fragment of the
+    page-controlled title appears in ANY i3-msg argv. The window is named with
+    the sanitized title so the match SUCCEEDS — the positive control that proves
+    this assertion is made over a run that really did find and focus a window."""
+    lit = S._sanitize_i3_title(_HOSTILE_TITLE)
+    body, fake = _activate_with_fake_i3(
+        [(31337, _BRAVE, "prefix " + lit + " suffix")],
+        title=_HOSTILE_TITLE, monkeypatch=monkeypatch)
+    assert body["result"]["data"]["i3"] == "applied"      # ← positive control
+    assert fake.focused == 31337
+    flat = " ".join(" ".join(a) for a in fake.calls)
+    for probe in ("exec", "xterm", "rm -rf", "whoami", "pwn", "AAAA"):
+        assert probe not in flat, (probe, flat)
+    assert fake.focus_calls == [[_FAKE_I3_MSG, '[id="31337"] focus']]
+
+
+def test_activate_i3_focus_accepted_but_not_focused_is_failed(monkeypatch):
+    """VERIFY step: i3 accepting the focus (rc 0, success:true) is not proof. A
+    window that does not end up focused → failed/not_focused, never applied.
+
+    Reported pair — same window, same command, only the effect differs:
+      focus takes effect     → applied / focused
+      focus is a no-op       → failed  / not_focused"""
+    eff_body, eff = _activate_with_fake_i3(
+        [(5, _BRAVE, _NEW_TITLE)], monkeypatch=monkeypatch)
+    noop_body, noop = _activate_with_fake_i3(
+        [(5, _BRAVE, _NEW_TITLE)], monkeypatch=monkeypatch,
+        mutate=lambda f: setattr(f, "focus_effective", False))
+    assert eff_body["result"]["data"]["i3"] == "applied"          # control
+    assert noop_body["result"]["data"]["i3"] == "failed"
+    assert noop_body["result"]["data"]["i3_detail"] == "not_focused"
+    # Both arms issued the focus and got rc 0 — the difference is only the EFFECT.
+    assert len(eff.focus_calls) == 1 and len(noop.focus_calls) == 1
+    assert eff.focused == 5 and noop.focused is None
+
+
+def test_activate_i3_focus_nonzero_is_failed(monkeypatch):
+    """The focus command itself erroring → failed/focus_error (not applied)."""
+    body, fake = _activate_with_fake_i3(
+        [(5, _BRAVE, _NEW_TITLE)], monkeypatch=monkeypatch,
+        mutate=lambda f: setattr(f, "focus_rc", 2))
+    assert body["result"]["data"]["i3"] == "failed"
+    assert body["result"]["data"]["i3_detail"] == "focus_error"
+    assert len(fake.focus_calls) == 1     # positive control: it WAS attempted
+
+
+def test_activate_i3_unparseable_tree_is_failed(monkeypatch):
+    """A get_tree reply that is not JSON → failed/tree_unreadable, and NO focus
+    is attempted (we cannot know what would match). Positive control: the same
+    fixture with a parseable tree focuses exactly once."""
+    bad_body, bad = _activate_with_fake_i3(
+        [(5, _BRAVE, _NEW_TITLE)], monkeypatch=monkeypatch,
+        mutate=lambda f: setattr(f, "tree_stdout", b"not json at all"))
+    good_body, good = _activate_with_fake_i3(
+        [(5, _BRAVE, _NEW_TITLE)], monkeypatch=monkeypatch)
+    assert bad_body["result"]["data"]["i3"] == "failed"
+    assert bad_body["result"]["data"]["i3_detail"] == "tree_unreadable"
+    assert len(bad.focus_calls) == 0
+    assert good_body["result"]["data"]["i3"] == "applied"     # ← control
+    assert len(good.focus_calls) == 1
+
+
+def test_activate_i3_ignores_non_brave_windows(monkeypatch):
+    """A same-titled window of ANOTHER application must not be raised or counted
+    as a match — the class constraint survived the move out of the criteria."""
+    body, fake = _activate_with_fake_i3(
+        [(8, "Alacritty", _NEW_TITLE)], monkeypatch=monkeypatch)
+    assert body["result"]["data"]["i3"] == "failed"
+    assert body["result"]["data"]["i3_detail"] == "no_match"
+    assert fake.focused is None
+    assert len(fake.focus_calls) == 0
+    # POSITIVE CONTROL: identical title, class Brave → matched and raised.
+    body2, fake2 = _activate_with_fake_i3(
+        [(8, _BRAVE, _NEW_TITLE)], monkeypatch=monkeypatch)
+    assert body2["result"]["data"]["i3"] == "applied" and fake2.focused == 8
+
+
+def test_i3_foreground_waits_out_the_title_settling_race(monkeypatch):
+    """THE OTHER HALF OF THE LIVE PAIR: a bounded re-read of the tree turns the
+    first post-`open` activate — the one that used to match nothing — into a real
+    raise once WM_NAME catches up.
+
+    Reported pair:
+      title settles on the 3rd tree read → applied / focused, >1 tree read
+      title never settles                → failed  / no_match, >1 tree read
+    (the second arm is the control proving the loop actually re-read and did not
+    simply succeed on its first look)."""
+    monkeypatch.setattr(S, "i3_available", lambda: True)
+    monkeypatch.setattr(S, "_resolve_i3_msg", lambda: _FAKE_I3_MSG)
+    monkeypatch.setattr(S, "I3_MATCH_POLL", 0.001)
+
+    settling = _FakeI3(windows=[(4242, _BRAVE, _OLD_TITLE)])
+
+    def _settle(fake, idx):
+        if len(fake.tree_calls) >= 2:      # this call is the 3rd tree read
+            fake.set_title(4242, _NEW_TITLE)
+
+    settling.on_call = _settle
+    monkeypatch.setattr(S.subprocess, "run",
+                        lambda argv, **kw: settling.run(argv, **kw))
+    assert S.i3_foreground(_NEW_TITLE, match_wait=1.0) == ("applied", "focused")
+    assert len(settling.tree_calls) > 1, "it must have re-read the tree"
+    assert settling.focused == 4242
+
+    stuck = _FakeI3(windows=[(4242, _BRAVE, _OLD_TITLE)])
+    monkeypatch.setattr(S.subprocess, "run",
+                        lambda argv, **kw: stuck.run(argv, **kw))
+    assert S.i3_foreground(_NEW_TITLE, match_wait=0.05) == ("failed", "no_match")
+    assert len(stuck.tree_calls) > 1, "the wait must have polled, not given up"
+    assert stuck.focused is None
+
+
+def test_i3_foreground_state_vocabulary_is_closed(monkeypatch):
+    """LEDGER: `result.data.i3` keeps EXACTLY the three values consumers branch
+    on, and "applied" pairs with exactly one detail. A new state added without
+    updating the consumer contract fails here."""
+    monkeypatch.setattr(S, "i3_available", lambda: True)
+    monkeypatch.setattr(S, "_resolve_i3_msg", lambda: _FAKE_I3_MSG)
+    monkeypatch.setattr(S, "I3_MATCH_POLL", 0.001)
+
+    def _outcome(windows, **attrs):
+        fake = _FakeI3(windows=windows)
+        for k, v in attrs.items():
+            setattr(fake, k, v)
+        monkeypatch.setattr(S.subprocess, "run",
+                            lambda argv, **kw: fake.run(argv, **kw))
+        return S.i3_foreground(_NEW_TITLE, match_wait=0)
+
+    seen = {
+        _outcome([(1, _BRAVE, _NEW_TITLE)]),
+        _outcome([(1, _BRAVE, _OLD_TITLE)]),
+        _outcome([(1, _BRAVE, _NEW_TITLE)], focus_effective=False),
+        _outcome([(1, _BRAVE, _NEW_TITLE)], focus_rc=3),
+        _outcome([(1, _BRAVE, _NEW_TITLE)], tree_rc=1),
+        _outcome([(1, _BRAVE, _NEW_TITLE)], tree_stdout=b"{"),
+    }
+    monkeypatch.setattr(S, "i3_available", lambda: False)
+    seen.add(S.i3_foreground(_NEW_TITLE, match_wait=0))
+    monkeypatch.setattr(S, "i3_available", lambda: True)
+    seen.add(S.i3_foreground("", match_wait=0))
+
+    # Positive control: the enumeration really did exercise every branch.
+    assert len(seen) >= 7, seen
+    assert {s for s, _ in seen} == {"applied", "skipped", "failed"}, seen
+    assert {d for s, d in seen if s == "applied"} == {"focused"}, seen
+    assert all(d for _, d in seen), "every outcome carries a reason"
 
 
 def test_activate_i3_telemetry_stays_metadata_only(telemetry, monkeypatch):
@@ -2548,7 +2949,8 @@ def test_activate_i3_telemetry_stays_metadata_only(telemetry, monkeypatch):
     page title — only op / outcome / bare domain (the title can hold page
     content; the i3 step must not leak it into activity.events)."""
     spool_dir = telemetry
-    _enable_i3(monkeypatch, returncode=0)
+    _enable_fake_i3(monkeypatch,
+                    windows=[(5, _BRAVE, "SECRET PAGE CONTENT IN TITLE")])
     srv, _ = _serve()
     ext = FakeExtension(srv, executor=lambda c: {
         "tabId": 5, "active": True, "status": "complete",
@@ -2557,8 +2959,12 @@ def test_activate_i3_telemetry_stays_metadata_only(telemetry, monkeypatch):
     ext.start()
     try:
         assert _wait_connected(srv, want=True)
-        st, _ = _req(srv, "POST", "/cmd", {"op": "activate"})
+        st, body = _req(srv, "POST", "/cmd", {"op": "activate"})
         assert st == 200
+        # POSITIVE CONTROL: the i3 step really RAN and raised the window, so the
+        # "no title in telemetry" assertion below is made over a live i3 path —
+        # a skipped/failed i3 step would leak nothing for trivial reasons.
+        assert body["result"]["data"]["i3"] == "applied"
         e = _wait_events(spool_dir, 1)[0]
         p = json.loads(e["payload"])
         assert p["op"] == "activate" and p["outcome"] == "ok"


### PR DESCRIPTION
## The defect

`browser activate` ran `i3-msg [class="Brave-browser" title="<tab title>"] focus`
and reported `i3:"applied"` on rc 0. **i3 exits 0 and replies `[{"success":true}]`
for a criteria that matched ZERO windows** — byte-identical to a real raise. So
`applied` was a claim about the exit code, never about any window.

Measured live 2026-08-19, a discriminating pair:

| | reported | reality |
|---|---|---|
| `activate` #1, right after `open` | `applied` | X11 `WM_NAME` still held the **old** title → matched nothing → **nothing raised**, tab stayed `hidden` |
| `activate` #2, once the title settled | `applied` | window raised, `hasFocus: true` |

One signal, two opposite realities. Downstream this is the dominant live cause of
a capture tool exiting 11 *"the app never booted"* — it never booted because
nothing was ever raised, and the only status said everything was fine.

## The fix — FIND → RAISE → VERIFY

1. **FIND** — a **read-only** `i3-msg -t get_tree` (a *query*; it cannot focus,
   move or switch anything) is the only thing that can tell one match from none.
   Re-read for up to `BROWSER_BRIDGE_I3_MATCH_WAIT` (default 1.5 s) while there
   is no match. That also fixes the settling race: the first post-`open`
   activate now waits `WM_NAME` out instead of missing by construction.
2. **RAISE** — focus by the **stable X11 window id** from that reply, not the
   racy title, so the window matched is provably the window focused.
3. **VERIFY** — read the tree back and require i3 to agree it is focused. rc 0
   from `focus` still proves nothing (an id that vanished between the two calls
   answers `success:true` too).

`applied` is now reachable **only** via a `get_tree` that listed the window *and*
a second `get_tree` confirming it is focused.

## 🔴 Consumer contract

`result.data.i3` keeps **exactly** its three values — `applied` / `skipped` /
`failed`. A consumer that treats `failed` as fatal needs **no change** and now
correctly sees a raise that matched nothing (which used to report `applied`).

**New additive field `result.data.i3_detail`** says *which* state it is:

| `i3` | `i3_detail` | meaning |
|---|---|---|
| `skipped` | `unavailable` | no `DISPLAY` / no `i3-msg` (headless, non-i3) |
| `skipped` | `no_title` | nothing usable left of the tab title |
| `applied` | `focused` | matched → focused → **confirmed** focused |
| `failed` | `no_match` | i3 has **no** Brave window with that title |
| `failed` | `tree_unreadable` | `-t get_tree` failed / timed out / unparseable |
| `failed` | `focus_error` | the focus command itself errored |
| `failed` | `not_focused` | focus accepted, window still not focused |

A consumer wanting *"I asked and nothing matched"* apart from *"i3 is broken"*
reads `i3_detail`. Nothing has to be updated to benefit.

## Security (improved as a side effect)

The untrusted, page-controlled title is **no longer interpolated into an i3
command at all**. It becomes a local `re.escape`d pattern (a literal → no ReDoS)
matched in-process against the tree. The only two argvs issued are the constant
`-t get_tree` and a focus keyed on an **integer** window id from i3's own reply,
so the old criteria-breakout surface is gone by construction. The
`class="Brave-browser"` constraint and the structural-char strip are kept as
defence in depth, and both are still pinned by tests.

## Test matrix

Hermetic, stubbed at the `i3-msg` boundary. **The suite never runs a real i3 and
cannot take the operator's screen.** A `_FakeI3` answers `-t get_tree` and *both*
focus shapes (`title="…"` and `id="…"`), so the same test file runs against the
pre-fix implementation.

**RED at `origin/main`, GREEN at HEAD:**

| test | verdict at base | at HEAD |
|---|---|---|
| `test_activate_i3_zero_match_is_never_reported_as_applied` | ❌ `AssertionError: assert 'applied' != 'applied'` | ✅ `failed` / `no_match` |
| `test_activate_i3_zero_match_issues_no_focus_command` | ❌ 1 focus call issued on a zero match (`assert 1 == 0`) | ✅ 0 on miss / 1 on hit |
| + 9 more new i3 tests | ❌ | ✅ |

**Instrument validation** — `test_fake_i3_mirrors_real_i3_success_on_zero_match`
pins the fake's fidelity to the one real i3 behaviour everything depends on
(zero-match `focus` → rc 0 + `[{"success":true}]`). **It passes at base too**: a
fake that returned nonzero on a miss would make the buggy code look correct and
every test here vacuous.

**Positive-control pairs** — every zero / "no match" is reported with a control
proving the check can observe a real match:

| assertion | control arm |
|---|---|
| no match → `failed`/`no_match` | match → `applied`/`focused` — *at base **both** arms report `applied`; that is the indistinguishability* |
| 0 focus calls on a miss | 1 focus call on a hit |
| non-Brave same-titled window → `no_match` | Brave window, same title → `applied` |
| unparseable tree → 0 focus calls | parseable tree → 1 focus call |
| focus is a no-op → `not_focused` | focus takes effect → `applied` |
| title never settles → `no_match`, >1 tree read | title settles on the 3rd read → `applied`, >1 tree read |
| no title in telemetry | asserted over a run where `i3 == "applied"` |

**Mutation-tested**, each mutant the narrowest expression that can be wrong, each
dying for its **own** reason on a reachable input:

| mutant | killed by | message |
|---|---|---|
| `no_match` → return `"applied"` | `zero_match_is_never_reported_as_applied` | `assert 'applied' != 'applied'` |
| VERIFY step deleted | `focus_accepted_but_not_focused_is_failed` | `assert 'applied' == 'failed'` |
| class constraint deleted | `ignores_non_brave_windows` (sole killer) | — |
| focus `id=` → `con_id=` | 12 tests | — |
| **unmutated control** | — | **28 passed** |

Full suite: **515 passed** (`scripts/browser-bridge/tests`, floor 469). Runner
guards `--check-targets` / `--check-floors`: PASS.

## Not verified

Nothing was checked against a live i3 — **no `i3-msg` focus, raise or workspace
switch was issued during this work**. The live confirmation that remains is the
original discriminating pair re-run against this build: an `activate` issued
immediately after `open` should now either wait the title out and report
`applied` with the window really raised, or report `failed`/`no_match` — and
never `applied` with the tab still `hidden`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
