### PR TITLE
skill(prune-skill): the failure mode slicing CAUSES — a warning demoted away from the instruction it guards

### DIFF
--- a/claude/skills/prune-skill/SKILL.md
+++ b/claude/skills/prune-skill/SKILL.md
@@ -84,6 +84,8 @@ The auditor checks both directions, warning on relative paths with no absolute b
 
 🔴 **The loss mode slicing does NOT cover: a block you SUMMARISE into the core and slice into no sidecar is silently gone — and it looks like good pruning.** That is what §7's gap audit is for. Happened twice.
 
+🔴 **And the loss mode slicing CAUSES: a warning demoted AWAY from the instruction it guards.** Content survives, paths resolve, gates pass — the PAIRING broke. **Ask what each moved block was PROTECTING; if its trigger stays in the core, the guard goes with it or leaves a cross-reference.** Case + the staleness amplifier: `reference/verification-protocol.md`.
+
 Write evicted history to a dated `claudedocs/` doc. **Do not delete a reference file to save bytes** — it saves 0 until opened. An **ORPHAN is usually a demoted topic that lost its routing line — adopt it by default** (one skill held 40 KB across three). Delete only after reading it, and say in the commit why it is dead.
 
 ## 6. Land the change
@@ -97,7 +99,7 @@ python3 /home/zach/workspace/devrc/scripts/skill-audit.py "$SKILL_DIR"
 ```
 **Structural**: under target, every routing path resolves, no orphans, no unclosed fences, numbered-corpus integrity intact.
 
-🔴 **A structural PASS is not content survival — this bar has already missed two real losses.** **Read `reference/verification-protocol.md` and run all six**, none of which the auditor performs: the **un-sliced gap audit**; an **enumerated-population survival check (≥5 populations, one MUST be numbers)**; **two instruments** (whole-line survival is load-bearing, token membership alone is blind); 🔴 **controls that mutate a DESTINATION, never your new text** — *a control that passes is an invalid control, not a clean result*; before/after bytes from the **pushed blob**, not the working tree; and a **report** — what moved where, §2's backup path, each control's number.
+🔴 **A structural PASS is not content survival — this bar has already missed two real losses.** **Read `reference/verification-protocol.md` and run all six (§1–§5, §7)**, none of which the auditor performs. The one most often got wrong: 🔴 **a control must mutate a DESTINATION, never your new text** — *a control that passes is an invalid control, not a clean result*.
 
 🔴 **Open one demoted file and one routing line by hand before calling it done.** `skill-audit.py` resolves routing paths against the skill directory — which always succeeds — so its ✓ is not evidence a reader following the core from a repo root finds the file. That is the §4 trap; the audit cannot see it.
 

--- a/claude/skills/prune-skill/reference/verification-protocol.md
+++ b/claude/skills/prune-skill/reference/verification-protocol.md
@@ -96,6 +96,37 @@ are both about what is present, not about whether a reader can still do the task
 alone. After a campaign of 9 prunes, not one core had been exercised end-to-end on a real task.
 If the skill matters, drive it once afterwards.
 
+### What driving one actually found (2026-08-19, n=2)
+
+Two pruned cores (`manage-postgres` 69,810→7,736 B; `image-cacher` 70,034→8,300 B) were each
+given a real read-only production diagnostic by a fresh agent. **The structure held**: routing
+was 4-for-4 and 3-of-5, neither agent listed the directory or grepped to find a file, and both
+correctly skipped sidecars they did not need. Keep the design. Two things to carry forward:
+
+🔴 **THE FAILURE MODE SLICING CAUSES — a warning demoted AWAY from the instruction it guards.**
+Content survives, the path resolves, every gate passes; the **PAIRING** broke, and nothing in
+this protocol measures pairings. `image-cacher`'s core (`SKILL.md:31`) prescribes gating on
+bucket fractions `<=5s / >10s / >25s` and states the buckets as `0,5,10,25`. The warning that
+Prometheus's labels are **`"30.0"`, not `"30"`** — and that a mistyped boundary "returns an
+empty result, which reads exactly like a passing gate" — sits in
+`reference/serve-original-transcode-and-deploys.md:37`, routed for *"serve-original,
+transcode/VFE, or deploy-time 502s"*. Nothing about a duration query sends you there. The
+agent wrote `le="5"`, got silence, and the rows vanished from a unioned table. **In one fat
+body you scroll past the warning and are immune.** Milder sibling in the same skill: the core's
+Redis hot-command prints saturation numbers with no interpretation, while the sidecar saying
+*"it is NOT a 503 lever, r = 0.029"* is a routing hop away — the agent nearly filed it as an
+availability contributor. **So: when you demote a block, ask what it was PROTECTING. If the
+trigger stays in the core, the guard goes with it or leaves a cross-reference.**
+
+🔴 **A lean core AMPLIFIES stale text.** Both agents said it independently: a wrong line in a
+7.7 KB curated core reads as deliberate in a way it never did inside 70 KB of everything. The
+prune does not cause the rot — a fat body carries it identically — but it removes the noise
+that made you doubt it. This is the argument for §0 being a **pass you EXERCISE, not one you
+read**: across the two runs, the defects that mattered (a role filter that misses the roles
+that matter, a rate 40× off, a container limit 25% low, a cluster count, a `le` label) were
+**every one of them findable only by measuring live**. Four rounds of adversarial doc audit on
+this very skill never found its own dead ceiling pointer; using it did.
+
 ## 7. The report — say it, do not leave it in the transcript
 
 The core's §7 requires a report, not just a verdict. Four things, all of which exist only in


### PR DESCRIPTION
`reference/verification-protocol.md` §6 has said, since the campaign began:

> **None of this proves the pruned core is USABLE.** … After a campaign of 9 prunes, not one core had been exercised end-to-end on a real task. If the skill matters, drive it once afterwards.

That has now been done — twice — and this PR records the result.

## Method

Two heavily-pruned cores were each handed a **real read-only production diagnostic** by a fresh agent with no context from the pruning work:

| skill | prune | task |
|---|---|---|
| `manage-postgres` | 69,810 → 7,736 B (89%) | health report for the CNPG nvme0 cluster |
| `image-cacher` | 70,034 → 8,300 B (88%) | health report for civitai-image-cacher |

Each reported separately on whether the core sufficed to start, which sidecars it opened **and what made it open them**, dead ends, gaps, routing cost, and a plain verdict. Both were told a negative result is the valuable one.

## The structure held — keep the design

Routing was **4-for-4** and **3-of-5**, counting the sidecars each correctly *skipped*. Neither agent listed the skill directory or grepped to find a file. Neither opened a sidecar that failed to deliver what its routing line implied. `image-cacher` legitimately never paid for 25.6 KB of its own sidecars. Several core notes materially improved the work — one prevented the most likely wrong diagnosis of a live 503 rate outright.

## But slicing has a failure mode of its own

Not the summarise-and-lose one §5 already covers. **A warning can be demoted away from the instruction it guards.** Content survives, the path resolves, every gate passes — the **pairing** broke, and nothing in the protocol measures pairings.

`image-cacher`'s core (`SKILL.md:31`) prescribes gating on bucket fractions `<=5s / >10s / >25s` and states the buckets as `0,5,10,25`. The warning that Prometheus's labels are **`"30.0"`, not `"30"`** — and that a mistyped boundary *"returns an empty result, which reads exactly like a passing gate"* — sits in `reference/serve-original-transcode-and-deploys.md:37`, routed for *"serve-original, transcode/VFE, or deploy-time 502s"*. Nothing about a duration query sends you there. The agent wrote `le="5"`, got silence, and the rows vanished from a unioned result table.

**In one fat body you scroll past that warning and are immune.**

Milder sibling in the same skill: the core's Redis hot-command prints saturation numbers with no interpretation, while the sidecar saying *"it is NOT a 503 lever, r = 0.029"* is a routing hop away. The agent nearly filed a cost finding as an availability contributor.

## And a lean core amplifies stale text

Both agents said this independently, unprompted: a wrong line in a 7.7 KB curated core reads as **deliberate** in a way it never did inside 70 KB of everything. The prune does not cause the rot — a fat body carries it identically — but it removes the noise that made you doubt it.

That is the argument for §0 being a pass you **exercise**, not one you read. Across both runs, every defect that mattered was findable *only by measuring live*: a role filter that misses the roles that actually run long queries, a rate 40× off, a container limit 25% low, a cluster count, a `le` label. Four rounds of adversarial doc audit on *this very skill* never found its own dead ceiling pointer — using it did.

## Budget

The core line was paid for by demoting §7's six-item verification enumeration to a pointer. The detail was **already sliced** into `verification-protocol.md` §1–§5 and §7 — verified present before cutting, per the skill's own rule against summarising into the core and slicing nowhere.

Core **12,779 → 12,841 B**, under the 12,864 B working cap. `MAX_BYTES` unchanged.

The size gate caught the first attempt at **13,035 B**. I demoted rather than raising the ceiling, which is what the module's own docstring instructs.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
