### PR TITLE
feat(browser): per-site reference docs — the bridge names the file, SKILL.md names only the directory

### DIFF
--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -134,3 +134,4 @@ exact path; only `SKILL.md` + the CLI are symlinked into `~/.claude/skills/brows
 | `reference/auth-pages.md` | an authenticated request; you were about to read a cookie; a read looks logged-OUT; `extension_connected:false` |
 | `reference/security-ops.md` | 🔴 **you are MODIFYING browser-bridge** (the live-verify-on-real-Brave gate is mandatory); the user asks whether/what it records; first-time setup or a second profile |
 | `reference/x-fallback.md` | CDP `screenshot` is unsatisfactory and you must capture the raw X window (`DISPLAY`/`XAUTHORITY`, xdotool/maim) |
+| `reference/sites/<host>.md` | you are driving a site that has one — the CLI names it in the result envelope |

--- a/scripts/browser-bridge/reference/css-hit-test.md
+++ b/scripts/browser-bridge/reference/css-hit-test.md
@@ -30,10 +30,10 @@ Select **structurally** instead:
   of a known ratio.
 
 ⚠ Only `data-testid` is targeted. **Non-`testid` data attributes are NOT stripped**,
-so a purpose-built one survives into prod and makes a reliable selector — civitai
-added `data-listing-cover-placeholder` for exactly this. If you own the app and
-need a stable hook for browser-driving, add a non-`testid` data attribute rather
-than fighting the strip.
+so a purpose-built one survives into prod and makes a reliable selector. If you own
+the app and need a stable hook for browser-driving, add a non-`testid` data
+attribute rather than fighting the strip. *Which* attribute a given site already
+ships is a SITE fact, not a mechanism one — see `reference/sites/<host>.md`.
 
 The bridge is the only way to see PAINT ORDER. Markup-level tests and `html` reads
 can't: an element can be present, correct, and completely covered. The sequence

--- a/scripts/browser-bridge/reference/sites/_index.json
+++ b/scripts/browser-bridge/reference/sites/_index.json
@@ -1,0 +1,17 @@
+{
+  "_comment": [
+    "Registry for per-site reference docs. `sites` maps a HOST SUFFIX to a filename in this directory.",
+    "A host matches a key when it IS the key, or ENDS WITH '.' + the key. So `civitai.com` and",
+    "`www.civitai.com` both resolve, while `notcivitai.com` and `civitai.com.evil.test` do NOT — the",
+    "match is on label boundaries, never a substring. When several keys match, the LONGEST wins, so a",
+    "future `foo.civitai.com` entry beats the `civitai.com` catch-all.",
+    "Keys are lowercase bare hostnames: no scheme, no port, no path, no leading dot.",
+    "The key set here and the *.md file set in this directory must be IDENTICAL — an orphan entry and",
+    "an unregistered file are both errors, pinned both ways by tests/test_site_notes.py.",
+    "server.py reads this to emit `site_notes` on a matching result envelope; a missing or malformed",
+    "file degrades to no site_notes and never breaks a browser op."
+  ],
+  "sites": {
+    "civitai.com": "civitai.com.md"
+  }
+}

--- a/scripts/browser-bridge/reference/sites/_index.json
+++ b/scripts/browser-bridge/reference/sites/_index.json
@@ -1,10 +1,10 @@
 {
   "_comment": [
     "Registry for per-site reference docs. `sites` maps a HOST SUFFIX to a filename in this directory.",
-    "A host matches a key when it IS the key, or ENDS WITH '.' + the key. So `civitai.com` and",
-    "`www.civitai.com` both resolve, while `notcivitai.com` and `civitai.com.evil.test` do NOT — the",
+    "A host matches a key when it IS the key, or ENDS WITH '.' + the key. So an apex and any",
+    "subdomain of it both resolve, while `notexample.test` and `example.test.evil.invalid` do NOT — the",
     "match is on label boundaries, never a substring. When several keys match, the LONGEST wins, so a",
-    "future `foo.civitai.com` entry beats the `civitai.com` catch-all.",
+    "more specific entry beats a broader catch-all for the same apex.",
     "Keys are lowercase bare hostnames: no scheme, no port, no path, no leading dot.",
     "The key set here and the *.md file set in this directory must be IDENTICAL — an orphan entry and",
     "an unregistered file are both errors, pinned both ways by tests/test_site_notes.py.",

--- a/scripts/browser-bridge/reference/sites/civitai.com.md
+++ b/scripts/browser-bridge/reference/sites/civitai.com.md
@@ -1,0 +1,180 @@
+# civitai.com — identity, account switching, and the reads that lie
+
+**Load this when:** a result envelope named this file in `site_notes` · you are
+about to act on civitai.com **as a particular user** · you need to know WHICH
+account a Brave profile holds · a `/apps` read looks empty, stale, or shows
+entries that 404 · you are about to conclude civitai "leaked scope" or "is
+broken" from a browser read.
+
+Core: `~/workspace/devrc/scripts/browser-bridge/SKILL.md`.
+Mechanism files stay authoritative for mechanism: throttling and `wake` →
+`reference/spa-wake.md`; hit-testing and stripped `data-testid` →
+`reference/css-hit-test.md`; frames/OOPIFs → `reference/frames-cdp.md`;
+proving a read is the live authenticated session → `reference/auth-pages.md`.
+This file is only what is true of **civitai.com**.
+
+---
+
+## 🔴 Identity: never trust a written-down profile→account mapping
+
+**The Brave-profile→account mapping has NO shelf life.** It was recorded WRONG
+three times in five days, in **both** directions. Do not carry one in your head,
+in a handoff, or from this file.
+
+**ALWAYS read the session endpoint instead**, and use what it returns:
+
+```bash
+BB=~/workspace/devrc/scripts/browser-bridge/browser
+$BB --instance work js '(async function(){
+  const r = await fetch("/api/auth/session", {credentials:"include"});
+  const j = await r.json();
+  return JSON.stringify({username:j?.user?.username, id:j?.user?.id,
+                         isModerator:j?.user?.isModerator});
+})()'
+```
+
+Cost of checking: **one request**. Cost of trusting a recorded mapping: **hours**.
+
+`{username, id, isModerator}` is the identity. Nothing else is — not the profile
+key, not the profile label, not the tab title, not what you did yesterday.
+
+## 🔴 There is no "switch accounts" flow
+
+Brave profiles are **separate cookie jars, one account each**. So the real
+operation is not *switching* — it is **PICKING the profile that already holds the
+account you need**. Enumerate; never assume:
+
+```bash
+# every connected instance, then the session in each — read the pair, not the key
+$BB health          # -> .data.instances[].key
+$BB --instance <key> js '(async function(){ …the fetch above… })()'
+```
+
+### 🔴 `connected` ≠ drivable
+
+An instance can report `connected: true` from `browser health` and still fail
+`open` with `No current window`. That instance's identity is **UNKNOWN**, not
+absent — do not record it as "profile X holds no account", and do not let it
+narrow the candidate set. Re-check it, or hand it to the operator.
+
+### 🔴 Sign-in is Google SSO and CANNOT be automated
+
+Same class as the GitHub sudo-mode gate: you will not get through it. If **no**
+profile holds the account you need, **STOP** and hand it to the operator with
+exact steps (which profile to open, which account to sign in as, what to confirm).
+
+🔴 **Do NOT route around it** — not via a direct DB write, not by calling the
+service layer. Those skip the side effects the UI action exists to produce
+(notifications, re-queues, audit events), so the record ends up in a state the
+product can never produce, and the thing you were asked to verify was never
+exercised.
+
+## Capability is DERIVED, not assumed
+
+`__NEXT_DATA__.props.pageProps.flags` is the **server's own flag resolution for
+that session**. Read it rather than guessing what an account can see:
+
+```bash
+$BB --instance work js '(function(){
+  return JSON.stringify(window.__NEXT_DATA__?.props?.pageProps?.flags ?? null);
+})()'
+```
+
+**Verify a switch took by re-reading BOTH** the session endpoint **and** the
+flags. Either one alone can look right while the other has not moved.
+
+## 🔴 After ANY account switch, purge account-scoped `localStorage`
+
+`recentlyOpenedApps` is per-**BROWSER-PROFILE**, not per-account. Entries written
+by the previous account still render in the `/apps` **"Recently opened"** rail and
+**404 when clicked**.
+
+This produced a false **"scope leak"** alarm: the UI was showing another account's
+apps, and the server was doing nothing wrong.
+
+🔴 **The server returning zero rows is NOT evidence the UI shows zero.** They are
+different claims with different storage behind them — check the one you are
+actually making.
+
+```bash
+$BB --instance work js '(function(){
+  localStorage.removeItem("recentlyOpenedApps"); return "cleared";
+})()'
+```
+
+## 🔴 The account menu is a TOGGLE — a JS `.click()` half-opens it
+
+A JS `.click()` on the account menu leaves `aria-expanded="false"` and finds only
+empty `.mantine-Popover-dropdown` shells. That is **indistinguishable from "the
+entry is missing"**, and reads as a product bug.
+
+- Use the **trusted `click` op** (top-frame CDP input), not a JS `.click()`.
+- Click **ONCE** — it is a toggle, so a second click closes what the first opened.
+- **Read `aria-expanded` in the same breath** as the click, so you know which
+  state you are in rather than inferring it from what you found.
+- If the dropdown links are still not selector-reachable, **`screenshot`** and
+  look. Do not selector-hunt.
+
+## Route-level positive control
+
+- **`/apps` returns 404 for an account outside the store cohort.** A 404 there is
+  a cohort fact, not a broken session.
+- **`/models` returning 200 is the positive control** that the session works at
+  all. Run it before diagnosing anything from an `/apps` 404.
+
+## `/apps` needs a long settle (~9s)
+
+Cards arrive via tRPC, and a hidden tab is throttled (mechanism:
+`reference/spa-wake.md`). A browser read of `/apps` needs roughly **9 s after
+`wake`** before the rail is populated.
+
+Use `document.body.innerText.length` as a **sanity floor** — about **221 chars**
+means the page shell rendered and the content did **not**. Assert the floor;
+never read an empty rail as "this account has no apps".
+
+## Selectors on civitai
+
+`data-testid` is **stripped from the production build**, so a testid selector
+matches nothing and reads as a missing element — mechanism, and what to select
+instead, in `reference/css-hit-test.md`. Purpose-built non-`testid` data
+attributes DO survive: civitai added **`data-listing-cover-placeholder`** for
+exactly this, and it is a reliable hook.
+
+---
+
+## Proposed helper (NOT implemented): `browser sessions`
+
+**Status: a proposal, not a shipped op.** The loop below works today and is what
+to paste until someone builds the op.
+
+The gap it closes: reading `/api/auth/session` across **all** connected instances
+was hand-rolled **twice in one session**, and **both times contradicted the
+written-down mapping**. That is a mechanism-shaped problem, not a discipline one —
+the one-call version should print, per instance:
+
+```
+key → username → id → isModerator
+```
+
+…including an explicit `UNKNOWN` row for an instance that is `connected` but not
+drivable (see above), because a silently-omitted instance is how a candidate set
+gets narrowed to the wrong profile.
+
+Until then:
+
+```bash
+BB=~/workspace/devrc/scripts/browser-bridge/browser
+for k in $("$BB" health | python3 -c 'import json,sys; print("\n".join(i["key"] for i in json.load(sys.stdin)["result"]["data"]["instances"]))'); do
+  printf '%s → ' "$k"
+  "$BB" --instance "$k" js '(async function(){
+     const r = await fetch("/api/auth/session", {credentials:"include"});
+     const j = await r.json();
+     return (j?.user?.username ?? "ANON") + " → " + (j?.user?.id ?? "-") +
+            " → " + (j?.user?.isModerator ?? false);
+   })()' 2>/dev/null || echo "UNKNOWN (connected but not drivable?)"
+done
+```
+
+⚠ That loop reads whatever page each instance's tab is on — a session fetch is
+same-origin, so point each instance at a civitai.com tab first, or it reports the
+session of some other site (i.e. nothing).

--- a/scripts/browser-bridge/reference/sites/civitai.com.md
+++ b/scripts/browser-bridge/reference/sites/civitai.com.md
@@ -46,8 +46,10 @@ account you need**. Enumerate; never assume:
 
 ```bash
 # every connected instance, then the session in each — read the pair, not the key
-$BB health          # -> .data.instances[].key
+$BB health          # -> TOP-LEVEL .instances[].key (health is NOT a /cmd op,
+                    #    so there is no .result.data wrapper here)
 $BB --instance <key> js '(async function(){ …the fetch above… })()'
+                    # -> the value lands at .result.data.value
 ```
 
 ### 🔴 `connected` ≠ drivable
@@ -164,14 +166,19 @@ Until then:
 
 ```bash
 BB=~/workspace/devrc/scripts/browser-bridge/browser
-for k in $("$BB" health | python3 -c 'import json,sys; print("\n".join(i["key"] for i in json.load(sys.stdin)["result"]["data"]["instances"]))'); do
+KEYS=$("$BB" health | python3 -c 'import json,sys
+print("\n".join(i["key"] for i in json.load(sys.stdin)["instances"]))')
+for k in ${=KEYS}; do          # ${=…} — zsh does NOT word-split a bare $VAR
   printf '%s → ' "$k"
   "$BB" --instance "$k" js '(async function(){
      const r = await fetch("/api/auth/session", {credentials:"include"});
      const j = await r.json();
      return (j?.user?.username ?? "ANON") + " → " + (j?.user?.id ?? "-") +
             " → " + (j?.user?.isModerator ?? false);
-   })()' 2>/dev/null || echo "UNKNOWN (connected but not drivable?)"
+   })()' 2>/dev/null \
+    | python3 -c 'import json,sys
+try: print(json.load(sys.stdin)["result"]["data"]["value"])
+except Exception: print("UNKNOWN (connected but not drivable?)")'
 done
 ```
 

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -843,6 +843,130 @@ def _domain_from_result(result) -> str:
         return ""
 
 
+# --------------------------------------------------------------------------- #
+# Per-site reference docs
+#
+# Some sites carry hard-won operating facts that are true of THAT SITE ONLY (an
+# identity endpoint that must be re-read, a rail that renders stale entries, a
+# route whose 404 is a cohort fact). Those do not belong in a mechanism file —
+# `reference/spa-wake.md` is about the WEB — and they must not be pushed into
+# SKILL.md, which is loaded on every browser task and has a hard byte ceiling
+# (tests/test_skill_size.py). Putting a per-site ROW in SKILL.md would make the
+# always-loaded body grow linearly with the number of sites, so SKILL.md names
+# only the DIRECTORY and the bridge names the FILE, here, when it applies.
+#
+# The emission is deterministic and free of judgement: `_domain_from_result`
+# already extracts the bare hostname of a completed command (it has been doing so
+# for telemetry), and this looks that host up in a registry. A hit adds ONE
+# string field to the result envelope; a miss adds NOTHING AT ALL — the field is
+# ABSENT, not empty or null, so the common case costs zero bytes on the wire and
+# a consumer's `"site_notes" in result` is a true predicate.
+#
+# server.py is deployed as a FLAT single-file /nix/store symlink by home-manager,
+# so Path(__file__) does NOT sit next to reference/ — this resolves the directory
+# by the same stable ABSOLUTE repo path the spool emitter above uses, for exactly
+# the same reason. BROWSER_BRIDGE_SITES_DIR overrides it (tests).
+_SITES_DIR = Path(
+    os.environ.get("BROWSER_BRIDGE_SITES_DIR")
+    or (Path.home() / "workspace" / "devrc" / "scripts" / "browser-bridge"
+        / "reference" / "sites")
+)
+# The doc path a consumer is told to read is REPO-RELATIVE, matching how every
+# other reference file is named in SKILL.md's table.
+_SITES_REL_PREFIX = "reference/sites"
+# (resolved_dir, {host_suffix: filename}) — parsed at most once per directory.
+# Keyed on the directory so a test that repoints BROWSER_BRIDGE_SITES_DIR gets a
+# fresh load without needing a reset hook, while a normal run reads the file once
+# for the life of the process.
+_site_index_cache = None
+
+
+def _load_site_index() -> dict:
+    """The host-suffix → filename registry from `<sites dir>/_index.json`.
+
+    STRICTLY BEST-EFFORT, like every other optional input this server reads: a
+    missing file, unreadable file, malformed JSON, wrong top-level shape, or a
+    junk entry degrades to "no site notes" and can never raise into a browser
+    op. A browser command must not start failing because a doc registry got a
+    trailing comma.
+
+    Entries are validated rather than trusted: the key must be a non-empty
+    lowercase-able hostname with no scheme/slash/whitespace, and the value must
+    be a BARE filename — no `/`, no `..` — so a registry can only ever name a
+    file inside this directory. Junk entries are dropped individually; one bad
+    row does not discard the good ones.
+    """
+    global _site_index_cache
+    cached = _site_index_cache
+    if cached is not None and cached[0] == _SITES_DIR:
+        return cached[1]
+    mapping = {}
+    try:
+        raw = json.loads((_SITES_DIR / "_index.json").read_text("utf-8"))
+        sites = raw.get("sites") if isinstance(raw, dict) else None
+        if isinstance(sites, dict):
+            for key, val in sites.items():
+                if not isinstance(key, str) or not isinstance(val, str):
+                    continue
+                host = key.strip().lower().rstrip(".")
+                if not host or host.startswith("."):
+                    continue
+                if any(c in host for c in "/:\\") or any(c.isspace() for c in host):
+                    continue
+                name = val.strip()
+                if not name or "/" in name or "\\" in name or ".." in name:
+                    continue
+                mapping[host] = name
+    except Exception:  # noqa: BLE001 — an absent/broken registry is not an error.
+        mapping = {}
+    _site_index_cache = (_SITES_DIR, mapping)
+    return mapping
+
+
+def _site_notes_path(host: str) -> str:
+    """The reference-doc path for `host`, or "" when the host has none.
+
+    🔴 HOST-SUFFIX matching, on LABEL BOUNDARIES — never a substring test. A key
+    `civitai.com` matches `civitai.com` and `www.civitai.com`, and must NOT match
+    `notcivitai.com` (a longer label ending in the same characters) nor
+    `civitai.com.evil.test` (the key as a PREFIX). A naive `key in host` gets
+    both of those wrong and hands an attacker-chosen host our operating notes.
+
+    The LONGEST matching suffix wins, so a specific `foo.civitai.com` entry beats
+    a general `civitai.com` one regardless of dict order.
+    """
+    if not isinstance(host, str) or not host:
+        return ""
+    h = host.strip().lower().rstrip(".")
+    if not h:
+        return ""
+    index = _load_site_index()
+    best = ""
+    best_name = ""
+    for suffix, name in index.items():
+        if h == suffix or h.endswith("." + suffix):
+            if len(suffix) > len(best):
+                best, best_name = suffix, name
+    if not best:
+        return ""
+    return f"{_SITES_REL_PREFIX}/{best_name}"
+
+
+def _annotate_site_notes(result, host: str) -> None:
+    """Add `site_notes` to a result ENVELOPE when the host has a reference doc.
+
+    Additive and single-field, in the spirit of the extension's advisory `note:`
+    on a hidden-tab read. On a miss it does nothing whatsoever — no key, no
+    null — so every existing envelope field and every unregistered host's bytes
+    are unchanged.
+    """
+    if not isinstance(result, dict):
+        return
+    path = _site_notes_path(host)
+    if path:
+        result["site_notes"] = path
+
+
 def _session_hash(session_id) -> str:
     """A COARSE, non-reversible fingerprint of a session id: first 8 hex of its
     sha256. Used ONLY in the throttle telemetry event so a flood is attributable
@@ -2784,6 +2908,14 @@ def make_handler(registry: Registry, token: str, cmd_timeout: float,
                 self._send(504, {"ok": False, "error": "timeout"})
             else:
                 domain = _domain_from_result(result)
+                # The host is already in hand — `_domain_from_result` has been
+                # computing it here for telemetry — so routing to a per-site
+                # reference doc costs one dict lookup and no extra parsing on
+                # the completion path. Adds `site_notes` ONLY when
+                # this host is registered; an unregistered host gets no field at
+                # all, which is why SKILL.md can name the directory once and
+                # never grow again as sites are added. See _annotate_site_notes.
+                _annotate_site_notes(result, domain)
                 log("cmd_ok", op=op)
                 if op == "activate":
                     # Chrome-side activate only set the tab active WITHIN its

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -927,13 +927,14 @@ def _site_notes_path(host: str) -> str:
     """The reference-doc path for `host`, or "" when the host has none.
 
     🔴 HOST-SUFFIX matching, on LABEL BOUNDARIES — never a substring test. A key
-    `civitai.com` matches `civitai.com` and `www.civitai.com`, and must NOT match
-    `notcivitai.com` (a longer label ending in the same characters) nor
-    `civitai.com.evil.test` (the key as a PREFIX). A naive `key in host` gets
-    both of those wrong and hands an attacker-chosen host our operating notes.
+    A key `example.test` matches `example.test` and any subdomain of it, and
+    must NOT match `notexample.test` (a longer label ending in the same
+    characters) nor `example.test.evil.invalid` (the key as a PREFIX). A naive
+    `key in host` gets both of those wrong and hands an attacker-chosen host our
+    operating notes.
 
-    The LONGEST matching suffix wins, so a specific `foo.civitai.com` entry beats
-    a general `civitai.com` one regardless of dict order.
+    The LONGEST matching suffix wins, so a specific `sub.example.test` entry
+    beats a general `example.test` one regardless of dict order.
     """
     if not isinstance(host, str) or not host:
         return ""

--- a/scripts/browser-bridge/tests/test_site_notes.py
+++ b/scripts/browser-bridge/tests/test_site_notes.py
@@ -14,10 +14,12 @@ added.
 
 THE THREE THINGS THAT CAN GO SILENTLY WRONG, and the tests that pin them
 ------------------------------------------------------------------------
-1. **A substring match.** `"civitai.com" in host` is the obvious spelling and it
-   is the bug: it hands our operating notes to `notcivitai.com.evil.test`. The
-   match must be on LABEL BOUNDARIES. See the `test_suffix_*` block, and
-   especially `test_a_host_merely_containing_the_key_does_not_match`.
+1. **A substring match.** `key in host` is the obvious spelling and it is the
+   bug: for a key `example.test` it hands our operating notes to
+   `notexample.test.evil.invalid`. The match must be on LABEL BOUNDARIES. See
+   the suffix-matching block, especially
+   `test_a_host_merely_containing_the_key_does_not_match`. (That block uses
+   reserved-TLD hosts on purpose — see the 🔴 note above it.)
 2. **A miss that is not silent.** A `"site_notes": null` or `""` on every
    unregistered host would put a field on the wire for every command on the
    internet. The test asserts the key is ABSENT, not falsy — `not in`, never

--- a/scripts/browser-bridge/tests/test_site_notes.py
+++ b/scripts/browser-bridge/tests/test_site_notes.py
@@ -1,0 +1,440 @@
+"""Per-site reference docs: the registry, the suffix match, and the envelope field.
+
+WHAT IS UNDER TEST
+------------------
+`server.py` already extracted the bare hostname of every completed command for
+telemetry (`_domain_from_result`). This feature routes that host through a
+registry — `reference/sites/_index.json` — and, on a hit, adds ONE advisory
+field to the result envelope:
+
+    "site_notes": "reference/sites/civitai.com.md"
+
+so `SKILL.md` can name the DIRECTORY once and never grow again as sites are
+added.
+
+THE THREE THINGS THAT CAN GO SILENTLY WRONG, and the tests that pin them
+------------------------------------------------------------------------
+1. **A substring match.** `"civitai.com" in host` is the obvious spelling and it
+   is the bug: it hands our operating notes to `notcivitai.com.evil.test`. The
+   match must be on LABEL BOUNDARIES. See the `test_suffix_*` block, and
+   especially `test_a_host_merely_containing_the_key_does_not_match`.
+2. **A miss that is not silent.** A `"site_notes": null` or `""` on every
+   unregistered host would put a field on the wire for every command on the
+   internet. The test asserts the key is ABSENT, not falsy — `not in`, never
+   `.get(...) is None`, because the latter passes for both shapes.
+3. **A registry that can break a browser op.** A doc registry is not allowed to
+   take the bridge down. Every malformed shape must degrade to "no site_notes"
+   AND leave the command working — so those tests drive a REAL round trip, not
+   just the loader.
+
+Plus a LEDGER (`test_index_and_files_are_the_same_set`) asserting the registry's
+key set and the directory's `*.md` set are identical, failing when either GROWS
+or SHRINKS.
+
+The harness is `test_server.py`'s — same `_serve` / `FakeExtension` / `_req`
+round trip every other server test uses. Deliberately not a new one.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import server as S  # noqa: E402
+from test_server import FakeExtension, _req, _serve, _wait_connected  # noqa: E402
+
+SITES_DIR = Path(__file__).resolve().parent.parent / "reference" / "sites"
+INDEX = SITES_DIR / "_index.json"
+
+
+@pytest.fixture(autouse=True)
+def _pin_sites_dir_to_this_checkout(monkeypatch):
+    """Pin `_SITES_DIR` to THIS checkout's reference/sites, hermetically.
+
+    🔴 Load-bearing, not hygiene. The production default is the stable ABSOLUTE
+    repo path under `Path.home()` (server.py is deployed as a flat /nix/store
+    symlink, so a `__file__`-relative lookup does not survive deployment — same
+    reason the spool emitter resolves that way). Without this pin the suite
+    would read the OPERATOR'S primary clone on a dev host — grading a tree
+    nobody asked about, and going green or red on someone else's uncommitted
+    edits — and in the nix sandbox `$HOME` is an empty temp dir, so the registry
+    would parse to {} and every "does not match" assertion would pass vacuously.
+    Mirrors `pinned_manifest` in test_server.py, for the same class of reason.
+    """
+    monkeypatch.setattr(S, "_SITES_DIR", SITES_DIR)
+    monkeypatch.setattr(S, "_site_index_cache", None)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _point_at(monkeypatch, directory):
+    """Repoint the server's sites dir and drop the parsed-index cache.
+
+    The cache is keyed on the directory, so repointing is normally enough — but
+    a test that REWRITES a directory it already pointed at would otherwise read
+    the stale parse. Clearing is the honest thing; a test that silently reused a
+    cached registry would pass without exercising the file it just wrote.
+    """
+    monkeypatch.setattr(S, "_SITES_DIR", Path(directory))
+    monkeypatch.setattr(S, "_site_index_cache", None)
+
+
+def _write_index(directory, payload, files=()):
+    directory = Path(directory)
+    directory.mkdir(parents=True, exist_ok=True)
+    if payload is not None:
+        (directory / "_index.json").write_text(payload, encoding="utf-8")
+    for name in files:
+        (directory / name).write_text("# stub\n", encoding="utf-8")
+    return directory
+
+
+def _roundtrip(url):
+    """One real /cmd round trip whose result carries `url`; returns the envelope.
+
+    This is the seam the feature actually lives on — the loader being right is
+    not the claim, the ENVELOPE being right is.
+    """
+    srv, _ = _serve()
+    ext = FakeExtension(srv, executor=lambda c: {"text": "hi", "url": url})
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        status, body = _req(srv, "POST", "/cmd", {"op": "text"})
+        assert status == 200, f"round trip failed: {status} {body}"
+        assert body["ok"] is True
+        return body["result"]
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# --------------------------------------------------------------------------- #
+# Instrument validation — a zero-entry registry makes every no-match test vacuous
+# --------------------------------------------------------------------------- #
+def test_the_real_registry_is_not_empty():
+    """POSITIVE CONTROL for this whole module.
+
+    Every "does not match" assertion below passes trivially against an EMPTY
+    registry — a loader wired to nothing returns "" for `civitai.com` and for
+    `notcivitai.com.evil.test` alike, and the suite goes green while measuring
+    nothing. This is the test that makes the zeros mean something.
+    """
+    index = S._load_site_index()
+    assert index, (
+        f"the real registry at {INDEX} parsed to ZERO entries — every "
+        "non-match assertion in this module is vacuous until this passes."
+    )
+    assert "civitai.com" in index
+
+
+def test_the_real_index_parses_as_json():
+    """Guard the guard: `_load_site_index` swallows every exception by design, so
+    a syntactically broken checked-in `_index.json` would degrade to {} and be
+    invisible to the loader tests. Parse it the strict way, here, once."""
+    raw = json.loads(INDEX.read_text(encoding="utf-8"))
+    assert isinstance(raw, dict) and isinstance(raw.get("sites"), dict)
+
+
+# --------------------------------------------------------------------------- #
+# Suffix matching
+# --------------------------------------------------------------------------- #
+def test_exact_host_matches():
+    assert S._site_notes_path("civitai.com") == "reference/sites/civitai.com.md"
+
+
+def test_subdomain_matches():
+    """`www.civitai.com` and `civitai.com` must BOTH resolve — that is the whole
+    reason the match is a suffix and not an equality."""
+    assert S._site_notes_path("www.civitai.com") == "reference/sites/civitai.com.md"
+    assert S._site_notes_path("a.b.civitai.com") == "reference/sites/civitai.com.md"
+
+
+@pytest.mark.parametrize("host", [
+    # 🔴 THE BUG THIS FILE EXISTS FOR. Every one of these CONTAINS "civitai.com"
+    # and none of them is civitai.com. A naive `key in host` returns a match for
+    # all five and hands an attacker-chosen host our operating notes.
+    "notcivitai.com.evil.test",   # key as an infix
+    "civitai.com.evil.test",      # key as a PREFIX — the classic suffix-check miss
+    "notcivitai.com",             # longer LABEL ending in the key's characters
+    "xcivitai.com",
+    "evil-civitai.com",
+])
+def test_a_host_merely_containing_the_key_does_not_match(host):
+    assert S._site_notes_path(host) == "", (
+        f"{host!r} must NOT match the `civitai.com` entry — matching is on label "
+        "boundaries (host == key, or host endswith '.'+key), never a substring."
+    )
+
+
+@pytest.mark.parametrize("host", [
+    "CIVITAI.COM", "Www.CiviTai.CoM", "civitai.com.", "  civitai.com  ",
+])
+def test_host_is_normalised_before_matching(host):
+    """Case, a trailing root dot, and surrounding whitespace are not identity."""
+    assert S._site_notes_path(host) == "reference/sites/civitai.com.md"
+
+
+@pytest.mark.parametrize("host", ["example.com", "", None, 0, [], "com"])
+def test_unregistered_or_junk_host_returns_empty(host):
+    assert S._site_notes_path(host) == ""
+
+
+def test_longest_matching_suffix_wins(tmp_path, monkeypatch):
+    """A specific entry must beat a general one regardless of dict order — so a
+    future `foo.example.test` doc is reachable even though `example.test` also
+    matches. Asserted in BOTH insertion orders: with a `break`-on-first-match
+    loop this passes in one order and fails in the other, which is exactly the
+    kind of half-right that a single-order test certifies as correct."""
+    for order in (["example.test", "foo.example.test"],
+                  ["foo.example.test", "example.test"]):
+        d = tmp_path / ("order-" + order[0])
+        _write_index(d, json.dumps({"sites": {k: k + ".md" for k in order}}))
+        _point_at(monkeypatch, d)
+        assert S._site_notes_path("foo.example.test") == \
+            "reference/sites/foo.example.test.md"
+        assert S._site_notes_path("bar.example.test") == \
+            "reference/sites/example.test.md"
+
+
+# --------------------------------------------------------------------------- #
+# The envelope
+# --------------------------------------------------------------------------- #
+def test_registered_host_gets_site_notes_on_the_envelope():
+    result = _roundtrip("https://www.civitai.com/models/1")
+    assert result["site_notes"] == "reference/sites/civitai.com.md"
+
+
+def test_unregistered_host_gets_NO_site_notes_KEY():
+    """ABSENT, not empty and not null.
+
+    `assert result.get("site_notes") is None` would pass for a literal
+    `"site_notes": null` on the wire — i.e. for the exact defect this asserts
+    against. `not in` is the only spelling that distinguishes them.
+    """
+    result = _roundtrip("https://example.com/whatever")
+    assert "site_notes" not in result, (
+        f"an unregistered host must add NO field; got {result.get('site_notes')!r}"
+    )
+
+
+def test_a_containing_host_gets_no_site_notes_on_the_wire():
+    """The substring bug, asserted at the SEAM rather than on the helper — the
+    helper being right does not prove the call site passes it the right host."""
+    result = _roundtrip("https://notcivitai.com.evil.test/x")
+    assert "site_notes" not in result
+
+
+def test_existing_envelope_fields_are_untouched():
+    """The field is purely additive: everything that was on the envelope before
+    is still there, unchanged, on BOTH a hit and a miss."""
+    hit = _roundtrip("https://civitai.com/models/1")
+    miss = _roundtrip("https://example.com/models/1")
+    for env in (hit, miss):
+        assert env["ok"] is True
+        assert env["data"]["text"] == "hi"
+        assert "id" in env and "instanceId" in env
+    assert set(hit) - set(miss) == {"site_notes"}, (
+        "a hit must differ from a miss by EXACTLY the site_notes key — "
+        f"hit={sorted(hit)} miss={sorted(miss)}"
+    )
+
+
+def test_a_screenshot_style_data_url_envelope_is_unaffected():
+    """`_domain_from_result` returns "" for a data: URL. That must be a miss, not
+    a crash and not a match on a zero-length host."""
+    result = _roundtrip("data:image/png;base64,iVBORw0KGgo=")
+    assert "site_notes" not in result
+
+
+# --------------------------------------------------------------------------- #
+# Registry resilience — a doc registry may NEVER break a browser op
+# --------------------------------------------------------------------------- #
+MALFORMED = {
+    "missing_file": None,
+    "empty_file": "",
+    "trailing_comma": '{"sites": {"civitai.com": "civitai.com.md",}}',
+    "truncated": '{"sites": {"civitai.com"',
+    "not_json_at_all": "# this is markdown, not json\n",
+    "toplevel_is_a_list": '["civitai.com"]',
+    "toplevel_is_a_string": '"civitai.com"',
+    "sites_key_absent": '{"other": {"civitai.com": "civitai.com.md"}}',
+    "sites_is_a_list": '{"sites": ["civitai.com"]}',
+    "sites_is_null": '{"sites": null}',
+}
+
+
+@pytest.mark.parametrize("case", sorted(MALFORMED))
+def test_malformed_registry_degrades_to_no_site_notes(case, tmp_path, monkeypatch):
+    _point_at(monkeypatch, _write_index(tmp_path / case, MALFORMED[case]))
+    assert S._load_site_index() == {}
+    assert S._site_notes_path("civitai.com") == ""
+
+
+@pytest.mark.parametrize("case", sorted(MALFORMED))
+def test_malformed_registry_does_not_break_a_browser_op(case, tmp_path,
+                                                        monkeypatch):
+    """The load-bearing half. Degrading the LOOKUP is not enough — the command
+    must still complete, with its payload intact and no site_notes."""
+    _point_at(monkeypatch, _write_index(tmp_path / case, MALFORMED[case]))
+    result = _roundtrip("https://civitai.com/models/1")
+    assert result["ok"] is True
+    assert result["data"]["text"] == "hi"
+    assert "site_notes" not in result
+
+
+def test_missing_directory_entirely_degrades(tmp_path, monkeypatch):
+    _point_at(monkeypatch, tmp_path / "does" / "not" / "exist")
+    assert S._load_site_index() == {}
+    result = _roundtrip("https://civitai.com/models/1")
+    assert result["ok"] is True and "site_notes" not in result
+
+
+@pytest.mark.parametrize("bad_value", [
+    "../../../etc/passwd",      # traversal
+    "sub/dir/notes.md",         # escapes the flat directory
+    "..",
+    "",
+    "   ",
+    None, 5, ["civitai.com.md"],
+])
+def test_registry_rejects_a_value_that_is_not_a_bare_filename(bad_value, tmp_path,
+                                                              monkeypatch):
+    """A registry can only ever name a file INSIDE its own directory. The emitted
+    string is handed to an agent as a path to read, so a traversal value is a
+    real instruction, not a theoretical one."""
+    d = _write_index(tmp_path / "bad", json.dumps(
+        {"sites": {"civitai.com": bad_value}}))
+    _point_at(monkeypatch, d)
+    assert S._site_notes_path("civitai.com") == ""
+
+
+@pytest.mark.parametrize("bad_key", [
+    "https://civitai.com", "civitai.com:443", ".civitai.com", "", "   ",
+    "civi tai.com", "civitai.com/models",
+])
+def test_registry_rejects_a_key_that_is_not_a_bare_host(bad_key, tmp_path,
+                                                        monkeypatch):
+    d = _write_index(tmp_path / "badkey", json.dumps(
+        {"sites": {bad_key: "x.md"}}))
+    _point_at(monkeypatch, d)
+    assert S._load_site_index() == {}
+
+
+def test_one_junk_entry_does_not_discard_the_good_ones(tmp_path, monkeypatch):
+    """Per-entry validation, not all-or-nothing: a typo in a new row must not
+    silently switch OFF a site that was working yesterday."""
+    d = _write_index(tmp_path / "mixed", json.dumps({"sites": {
+        "civitai.com": "civitai.com.md",
+        "broken.test": "../escape.md",
+        "also/broken": "ok.md",
+    }}))
+    _point_at(monkeypatch, d)
+    assert S._load_site_index() == {"civitai.com": "civitai.com.md"}
+    assert S._site_notes_path("civitai.com") == "reference/sites/civitai.com.md"
+
+
+def test_the_index_is_parsed_once_per_directory(tmp_path, monkeypatch):
+    """Cheapness, asserted rather than assumed: the registry must not be re-read
+    from disk on every command. Delete the file after the first load — a second
+    lookup that still answers proves it came from the cache."""
+    d = _write_index(tmp_path / "cached", json.dumps(
+        {"sites": {"cached.test": "cached.test.md"}}))
+    _point_at(monkeypatch, d)
+    assert S._site_notes_path("cached.test") == "reference/sites/cached.test.md"
+    (d / "_index.json").unlink()
+    assert S._site_notes_path("cached.test") == "reference/sites/cached.test.md"
+
+
+# --------------------------------------------------------------------------- #
+# THE LEDGER — the registry's key set and the directory's *.md set are identical
+# --------------------------------------------------------------------------- #
+def _ledger_diff(directory):
+    """(orphan_entries, unregistered_files) for a sites directory.
+
+    An ORPHAN is a registry key naming a file that is not there — an agent is
+    told to read a doc that does not exist. An UNREGISTERED file is a doc nobody
+    can ever be routed to — the work of writing it is silently wasted. Both are
+    errors, and the ledger fails on either, so the set can neither GROW nor
+    SHRINK away from the other.
+    """
+    directory = Path(directory)
+    raw = json.loads((directory / "_index.json").read_text(encoding="utf-8"))
+    registered = set(raw["sites"].values())
+    on_disk = {p.name for p in directory.glob("*.md")}
+    return sorted(registered - on_disk), sorted(on_disk - registered)
+
+
+def test_index_and_files_are_the_same_set():
+    orphans, unregistered = _ledger_diff(SITES_DIR)
+    assert not orphans, (
+        f"{INDEX} registers file(s) that do not exist: {orphans}. An agent "
+        "following `site_notes` would be sent to a missing doc."
+    )
+    assert not unregistered, (
+        f"{SITES_DIR} holds *.md file(s) no registry entry names: "
+        f"{unregistered}. Nothing can ever route to them — add a `sites` entry "
+        "or delete the file."
+    )
+
+
+def test_the_ledger_fails_when_the_set_GROWS(tmp_path):
+    """MUTATION, in-suite and reachable: add a bogus registry entry for a file
+    that is not on disk, and the ledger must report an orphan."""
+    d = _write_index(tmp_path / "grow", json.dumps({"sites": {
+        "civitai.com": "civitai.com.md",
+        "bogus.test": "bogus.test.md",
+    }}), files=["civitai.com.md"])
+    orphans, unregistered = _ledger_diff(d)
+    assert orphans == ["bogus.test.md"]
+    assert unregistered == []
+
+
+def test_the_ledger_fails_when_the_set_SHRINKS(tmp_path):
+    """The other direction: a real file whose registry entry was deleted must be
+    reported as unregistered. A one-directional ledger passes this case."""
+    d = _write_index(tmp_path / "shrink", json.dumps({"sites": {
+        "civitai.com": "civitai.com.md",
+    }}), files=["civitai.com.md", "orphaned.test.md"])
+    orphans, unregistered = _ledger_diff(d)
+    assert orphans == []
+    assert unregistered == ["orphaned.test.md"]
+
+
+def test_every_registered_file_is_non_trivial():
+    """A registered but EMPTY doc routes an agent to nothing and would still pass
+    the ledger — the set check is about names, not content."""
+    raw = json.loads(INDEX.read_text(encoding="utf-8"))
+    for name in raw["sites"].values():
+        body = (SITES_DIR / name).read_text(encoding="utf-8")
+        assert len(body) > 500, f"{name} is {len(body)} bytes — is it a stub?"
+        assert body.lstrip().startswith("# "), f"{name} has no H1 title"
+        assert "**Load this when:**" in body, (
+            f"{name} lacks the house-style '**Load this when:**' trigger line "
+            "every other reference file opens with."
+        )
+
+
+# --------------------------------------------------------------------------- #
+# SKILL.md must name the DIRECTORY, never a site
+# --------------------------------------------------------------------------- #
+def test_skill_md_names_the_directory_and_no_individual_site():
+    """🔴 THE INVARIANT: SKILL.md does not grow as sites are added.
+
+    It is loaded on every browser task and has a hard byte ceiling
+    (test_skill_size.py). One row naming `reference/sites/<host>.md` is the
+    whole contract; a per-site row would make the always-loaded body grow
+    linearly with the registry.
+    """
+    skill = (Path(__file__).resolve().parent.parent / "SKILL.md").read_text(
+        encoding="utf-8")
+    assert "`reference/sites/<host>.md`" in skill, (
+        "SKILL.md must carry the directory-level pointer row.")
+    raw = json.loads(INDEX.read_text(encoding="utf-8"))
+    for host, name in raw["sites"].items():
+        assert f"reference/sites/{name}" not in skill, (
+            f"SKILL.md names the individual site file {name}. Sites are routed "
+            "at runtime via the `site_notes` envelope field — SKILL.md names "
+            "only the directory, so it never grows as sites are added.")

--- a/scripts/browser-bridge/tests/test_site_notes.py
+++ b/scripts/browser-bridge/tests/test_site_notes.py
@@ -140,45 +140,73 @@ def test_the_real_index_parses_as_json():
 
 # --------------------------------------------------------------------------- #
 # Suffix matching
+#
+# 🔴 The matrix below runs against a SYNTHETIC `example.test` registry, not the
+# real one, and that is a constraint of this repo rather than a preference: this
+# is a PUBLIC repo and `scripts/testlib/client_host_scan.py` blocks any CLIENT
+# SUBDOMAIN literal in a tracked file. `www.<client>` in an assertion is exactly
+# the internal-topology leak that gate exists to stop — its own playbook says a
+# test-load-bearing host becomes a `*.example.test` one (RFC 6761). The apex is
+# permitted, so the real registry keeps the two assertions that need it.
+#
+# The semantics under test are identical, and the fixture is arguably better:
+# nothing here depends on which sites happen to be registered today.
 # --------------------------------------------------------------------------- #
-def test_exact_host_matches():
+KEY = "example.test"
+DOC = f"reference/sites/{KEY}.md"
+
+
+@pytest.fixture
+def synthetic(tmp_path, monkeypatch):
+    """A one-entry registry keyed on a reserved-TLD host."""
+    _point_at(monkeypatch, _write_index(
+        tmp_path / "syn", json.dumps({"sites": {KEY: f"{KEY}.md"}})))
+
+
+def test_exact_host_matches_in_the_real_registry():
+    """The one assertion that must run against the REAL registry: an apex, which
+    the client-host gate permits."""
     assert S._site_notes_path("civitai.com") == "reference/sites/civitai.com.md"
 
 
-def test_subdomain_matches():
-    """`www.civitai.com` and `civitai.com` must BOTH resolve — that is the whole
-    reason the match is a suffix and not an equality."""
-    assert S._site_notes_path("www.civitai.com") == "reference/sites/civitai.com.md"
-    assert S._site_notes_path("a.b.civitai.com") == "reference/sites/civitai.com.md"
+def test_unregistered_host_returns_empty_in_the_real_registry():
+    assert S._site_notes_path("example.com") == ""
+
+
+@pytest.mark.parametrize("host", ["www.example.test", "a.b.example.test"])
+def test_subdomain_matches(host, synthetic):
+    """A subdomain and the apex must BOTH resolve — that is the whole reason the
+    match is a suffix and not an equality."""
+    assert S._site_notes_path(host) == DOC
 
 
 @pytest.mark.parametrize("host", [
-    # 🔴 THE BUG THIS FILE EXISTS FOR. Every one of these CONTAINS "civitai.com"
-    # and none of them is civitai.com. A naive `key in host` returns a match for
-    # all five and hands an attacker-chosen host our operating notes.
-    "notcivitai.com.evil.test",   # key as an infix
-    "civitai.com.evil.test",      # key as a PREFIX — the classic suffix-check miss
-    "notcivitai.com",             # longer LABEL ending in the key's characters
-    "xcivitai.com",
-    "evil-civitai.com",
+    # 🔴 THE BUG THIS FILE EXISTS FOR. Every one of these CONTAINS the key
+    # "example.test" and none of them IS it. A naive `key in host` returns a
+    # match for all five and hands an attacker-chosen host our operating notes.
+    "notexample.test.evil.invalid",   # key as an infix
+    "example.test.evil.invalid",      # key as a PREFIX — the classic suffix miss
+    "notexample.test",                # longer LABEL ending in the key's chars
+    "xexample.test",
+    "evil-example.test",
 ])
-def test_a_host_merely_containing_the_key_does_not_match(host):
+def test_a_host_merely_containing_the_key_does_not_match(host, synthetic):
     assert S._site_notes_path(host) == "", (
-        f"{host!r} must NOT match the `civitai.com` entry — matching is on label "
+        f"{host!r} must NOT match the {KEY!r} entry — matching is on label "
         "boundaries (host == key, or host endswith '.'+key), never a substring."
     )
 
 
 @pytest.mark.parametrize("host", [
-    "CIVITAI.COM", "Www.CiviTai.CoM", "civitai.com.", "  civitai.com  ",
+    "EXAMPLE.TEST", "Www.ExAmple.TesT", "example.test.", "  example.test  ",
 ])
-def test_host_is_normalised_before_matching(host):
+def test_host_is_normalised_before_matching(host, synthetic):
     """Case, a trailing root dot, and surrounding whitespace are not identity."""
-    assert S._site_notes_path(host) == "reference/sites/civitai.com.md"
+    assert S._site_notes_path(host) == DOC
 
 
-@pytest.mark.parametrize("host", ["example.com", "", None, 0, [], "com"])
-def test_unregistered_or_junk_host_returns_empty(host):
+@pytest.mark.parametrize("host", ["other.invalid", "", None, 0, [], "test"])
+def test_unregistered_or_junk_host_returns_empty(host, synthetic):
     assert S._site_notes_path(host) == ""
 
 
@@ -203,7 +231,7 @@ def test_longest_matching_suffix_wins(tmp_path, monkeypatch):
 # The envelope
 # --------------------------------------------------------------------------- #
 def test_registered_host_gets_site_notes_on_the_envelope():
-    result = _roundtrip("https://www.civitai.com/models/1")
+    result = _roundtrip("https://civitai.com/models/1")
     assert result["site_notes"] == "reference/sites/civitai.com.md"
 
 
@@ -223,7 +251,7 @@ def test_unregistered_host_gets_NO_site_notes_KEY():
 def test_a_containing_host_gets_no_site_notes_on_the_wire():
     """The substring bug, asserted at the SEAM rather than on the helper — the
     helper being right does not prove the call site passes it the right host."""
-    result = _roundtrip("https://notcivitai.com.evil.test/x")
+    result = _roundtrip("https://notcivitai.com/x")
     assert "site_notes" not in result
 
 

--- a/scripts/skill-audit.py
+++ b/scripts/skill-audit.py
@@ -320,6 +320,22 @@ def reference_integrity(skill_md, text):
     BOTH directions, mirroring test_eviction_playbook_lists_every_reference_topic:
     a referenced file that does not exist routes the reader nowhere, and a file
     on disk that nothing routes to is unreachable and therefore dead.
+
+    🔴 THE THIRD ROUTING SHAPE: a DIRECTORY routed with a VARIABLE segment.
+    Naming every reference file in the body is what keeps a skill honest, but it
+    also makes the body grow linearly with the corpus — which is unaffordable for
+    a set that is expected to keep growing (browser's per-site docs). A row
+    written with a placeholder segment,
+
+        | `reference/sites/<host>.md` | you are driving a site that has one … |
+
+    routes to EVERY member of that directory without naming one, because
+    something at RUN TIME resolves the placeholder (for browser, the bridge puts
+    the exact filename in the result envelope). The reachability claim the orphan
+    check exists to defend is therefore satisfied, so a member of such a
+    directory is NOT dead. Recognised structurally — `<dir>/<` in the body, the
+    repo's own documented placeholder convention — never by naming a directory
+    here. A file under a directory with NO placeholder route is still an orphan.
     """
     skill_dir = skill_md.parent
     refs = referenced_refs(text, skill_dir)
@@ -329,8 +345,12 @@ def reference_integrity(skill_md, text):
     if ref_dir.is_dir():
         for f in sorted(ref_dir.rglob("*.md")):
             rel = f.relative_to(skill_dir).as_posix()
-            if rel not in text and f.name not in text:
-                orphans.append(rel)
+            if rel in text or f.name in text:
+                continue
+            parent = f.parent.relative_to(skill_dir).as_posix()
+            if parent != "reference" and f"{parent}/<" in text:
+                continue  # routed by a variable segment — see the docstring
+            orphans.append(rel)
     relative = [r for r in refs if not (r.startswith("/") or r.startswith("~"))]
     return refs, missing, orphans, len(relative), bool(ABS_REF_BASE.search(text))
 

--- a/scripts/tests/test_skill_audit.py
+++ b/scripts/tests/test_skill_audit.py
@@ -247,6 +247,81 @@ def test_positive_control_orphan_reference_counter_moves(tmp_path):
     assert a["orphan_refs"] == ["reference/orphan.md"]
 
 
+# --- a DIRECTORY routed by a VARIABLE segment ----------------------------------
+# The third routing shape. A set that is expected to keep growing (browser's
+# per-site docs) cannot afford a row per member, because the body is loaded on
+# every task. A row naming the directory with a `<placeholder>` filename routes
+# to every member, because something at RUN TIME resolves the placeholder — so
+# those members are reachable, not dead. The four tests below pin that the
+# affordance is REAL, NARROW, and cannot be used to switch the counter off.
+
+_VAR_ROUTED = """\
+---
+name: varrouted
+description: A core that routes to a directory, not to each of its members.
+---
+
+## Reference
+
+| file | load it when… |
+|---|---|
+| `reference/errors.md` | any error you don't recognise |
+| `reference/sites/<host>.md` | you are driving a site that has one |
+"""
+
+
+def _var_routed(tmp_path, name="varrouted", body=_VAR_ROUTED, members=("a.test.md",)):
+    d = tmp_path / name
+    (d / "reference" / "sites").mkdir(parents=True)
+    (d / "SKILL.md").write_text(body)
+    (d / "reference" / "errors.md").write_text("# errors\n")
+    for m in members:
+        (d / "reference" / "sites" / m).write_text(f"# {m}\n")
+    return d / "SKILL.md"
+
+
+def test_a_member_of_a_placeholder_routed_directory_is_not_an_orphan(tmp_path):
+    """`reference/sites/<host>.md` in the body routes to every file in that
+    directory without naming one. None of them is dead."""
+    a = sa.audit_one(_var_routed(tmp_path, members=("a.test.md", "b.test.md")))
+    assert a["orphan_refs"] == [], (
+        "a directory routed with a variable segment must not report its members "
+        f"as orphans: {a['orphan_refs']}")
+    assert a["missing_refs"] == []
+
+
+def test_the_affordance_does_NOT_extend_to_a_sibling_directory(tmp_path):
+    """NARROW: only the directory the placeholder row actually names. A file in
+    a DIFFERENT subdirectory is still unreachable, and still an orphan."""
+    p = _var_routed(tmp_path, name="narrow")
+    (p.parent / "reference" / "other").mkdir()
+    (p.parent / "reference" / "other" / "lost.md").write_text("# lost\n")
+    assert sa.audit_one(p)["orphan_refs"] == ["reference/other/lost.md"]
+
+
+def test_a_toplevel_placeholder_cannot_switch_the_whole_counter_off(tmp_path):
+    """🔴 THE ABUSE CASE. A row spelled `reference/<topic>.md` would, on a naive
+    prefix rule, excuse EVERY file in reference/ — turning the orphan check off
+    repo-wide with one line. It must not: the affordance applies to a real
+    SUBdirectory only, never to reference/ itself."""
+    body = _VAR_ROUTED.replace("`reference/sites/<host>.md`", "`reference/<topic>.md`")
+    p = _var_routed(tmp_path, name="abuse", body=body)
+    (p.parent / "reference" / "orphan.md").write_text("# orphan\n")
+    assert "reference/orphan.md" in sa.audit_one(p)["orphan_refs"]
+
+
+def test_without_the_placeholder_row_the_members_ARE_orphans(tmp_path):
+    """MUTATION, in-suite: delete the routing row and the same files must go
+    back to being reported. Without this, the test above cannot distinguish
+    'the affordance works' from 'the orphan check stopped looking'."""
+    body = "\n".join(l for l in _VAR_ROUTED.splitlines()
+                     if "reference/sites/" not in l) + "\n"
+    p = _var_routed(tmp_path, name="unrouted", body=body,
+                    members=("a.test.md", "b.test.md"))
+    assert sa.audit_one(p)["orphan_refs"] == [
+        "reference/sites/a.test.md", "reference/sites/b.test.md"]
+
+
 def test_positive_control_over_budget_status_moves(tmp_path):
     p = bad(tmp_path)
     a = sa.audit_one(p)


### PR DESCRIPTION
## The problem

Every trigger in `SKILL.md`'s reference table is a **failure symptom** — "a read
came back empty", "any op returned an error you don't recognise". There is no way
to say *"you are about to drive **this site**, and here is what we already learned
the hard way about it."*

So site-specific facts had nowhere to live and leaked into mechanism files, and
the big ones — the civitai account-identity traps that cost hours, repeatedly —
were not written down anywhere the bridge could surface them.

The naive fix (a row per site in `SKILL.md`) is unaffordable: `SKILL.md` is loaded
on **every** browser task and has a hard byte ceiling enforced by
`scripts/browser-bridge/tests/test_skill_size.py`. A per-site row makes the
always-loaded body grow linearly with the number of sites.

## The design

**One row in `SKILL.md`, naming the DIRECTORY. The bridge names the FILE.**

```
| `reference/sites/<host>.md` | you are driving a site that has one — the CLI names it in the result envelope |
```

`server.py` already extracted the bare hostname of every completed command for
telemetry (`_domain_from_result`, called in the command-completion `else:`
branch). That host is now looked up in a registry, and on a hit **one** field is
added to the result envelope:

```json
{"ok": true, "data": {...}, "site_notes": "reference/sites/civitai.com.md"}
```

- **Miss → the key is ABSENT**, not empty and not null. Zero bytes on the wire for
  every unregistered host, so `"site_notes" in result` is a true predicate.
- **Deterministic, no judgement** — a dict lookup on a host that was already
  computed. No extra parsing on the completion path.
- Precedent: the extension's advisory `note:` field on a hidden-tab read.
- Registry is parsed **once per directory** and cached.

**`SKILL.md` therefore never grows as sites are added.** That invariant is pinned
by a test (`test_skill_md_names_the_directory_and_no_individual_site`), which
fails if any registered site file is named in `SKILL.md`.

### Host-suffix matching, on LABEL BOUNDARIES

A key matches a host that **is** it, or **ends with `.` + it**. So an apex and
any subdomain of it both resolve, while `notexample.test`, `xexample.test` and
`example.test.evil.invalid` must **not**. A naive `key in host` gets all of those
wrong and hands an attacker-chosen host our operating notes. Longest matching
suffix wins, so a future more-specific entry beats a broader catch-all for the
same apex regardless of dict order.

*(The test matrix uses reserved-TLD hosts rather than real client subdomains —
this is a public repo and `client_host_scan.py` blocks those; see "Two repo
gates" below.)*

### The registry may never break a browser op

Missing file, empty file, trailing comma, truncated JSON, top-level list/string,
absent/`null`/list `sites` key — every one degrades to "no site_notes" **and the
command still completes with its payload intact**. Values are validated as bare
filenames (no `/`, no `..`), so a registry can only ever name a file inside its
own directory. Junk entries are dropped individually — a typo in a new row does
not switch off a site that worked yesterday.

## `SKILL.md` byte delta

| | bytes |
|---|---|
| before | 11,821 |
| after | **11,935** |
| **delta** | **+114** (one table row) |
| hard ceiling (`test_skill_size.py`) | 12,288 |
| enforced budget (ceiling − 250 headroom) | 12,038 |
| remaining headroom | 103 |

## Migration: what MOVED and what was deliberately LEFT

The rule applied: **a MECHANISM file states what is true of the WEB; a SITE file
states what is true of THAT SITE ONLY.** A civitai mention used as an
*illustration of a general mechanism* is the doc working correctly — rewriting it
into an abstraction makes the doc worse, so it stays.

### Moved (1)

| from | fact | to |
|---|---|---|
| `reference/css-hit-test.md` | "civitai added **`data-listing-cover-placeholder`** for exactly this" — a specific attribute shipped by a specific site; no mechanism value beyond "someone did it" | `reference/sites/civitai.com.md` |

The surrounding mechanism sentence (*non-`testid` data attributes are not
stripped, so a purpose-built one survives*) is untouched and stands complete on
its own; it now ends with a one-line pointer that *which* attribute a site ships
is a site fact.

### Deliberately left (8), with reasons

| file | mention | why it stays |
|---|---|---|
| `css-hit-test.md` | civitai's `next.config.mjs` / `compiler.reactRemoveProperties` strips `data-testid` | It is the **evidence** for the general claim, and the doc already generalises it ("a common Next/SWC production setting generally"). The operational consequence *for civitai* is cross-referenced from the site file instead of duplicated. |
| `css-hit-test.md` ×2 | `civitai-manager v0.1.82` popover-under-card; the `civitai-manager, 2026-08-03` button-inventory numbers | The doc's two best **worked examples**. Also: `civitai-manager` is a browser *extension*, not the civitai.com site — not a site fact at all. |
| `spa-wake.md` | `model-benchmarking.example.test` OOPIF inside a `civitai.com` tab stayed blank | Verified case illustrating throttling. Pure illustration. |
| `spa-wake.md` | the `open https://civitai.com/apps/run/model-benchmarking` command sequence | A worked command block; the URL is the example's subject. |
| `frames-cdp.md` | the OOPIF-inside-civitai.com enumeration example | Illustration of the OOPIF fix. |
| `frames-cdp.md` | `--frame model-benchmarking` resolves HOST-first, not the `civitai.com/apps/run/model-benchmarking` PATH | A host/path **collision** is not legible without a concrete colliding pair. Removing it guts the explanation. |
| `agent.md` | the civitai card-list goal needed two wakes + `html` | The measurement behind the "don't default to the agent for virtualised lists" guardrail. |
| `auth-pages.md` | `github.com` CSP contrast → `js` returns `null` while `text`/`html` work | GitHub is the canonical example of the **CSP mechanism**, and `SKILL.md` trap #2 already names it. A `github.com.md` would fragment a mechanism across two files and duplicate the body. |

### Not warranted

- **`x.com.md`** — the only `x.com` in the corpus is a *placeholder domain* in a
  usage line (`--deny-domains x.com`, alongside `--allow-domains a.com,b.com`).
  Not a site fact.
- **`github.com.md`** — see `auth-pages.md` above.

### Nothing lost

| file | before | after | note |
|---|---|---|---|
| `reference/css-hit-test.md` | 8,739 | 8,789 | +50; the moved clause was replaced by a slightly longer pointer sentence |
| `reference/spa-wake.md` | 15,542 | 15,542 | untouched |
| `reference/frames-cdp.md` | 11,123 | 11,123 | untouched |
| `reference/agent.md` | 20,273 | 20,273 | untouched |
| `reference/auth-pages.md` | 3,832 | 3,832 | untouched |
| `reference/sites/civitai.com.md` | — | 7,699 | new |
| `reference/sites/_index.json` | — | 1,017 | new |

The one moved fact is verified present in its destination and absent from its
source (`grep -c data-listing-cover-placeholder` → 1 and 0 respectively).

## `reference/sites/civitai.com.md`

Written up in the house style (`# H1`, `**Load this when:**`, a pointer back to
`SKILL.md`, and explicit hand-offs to the mechanism files for mechanism). Covers:

- 🔴 the profile→account mapping has **no shelf life** (recorded wrong 3× in 5
  days, in both directions) — always read `/api/auth/session` for
  `{username, id, isModerator}`;
- 🔴 there is **no "switch accounts" flow** — Brave profiles are separate cookie
  jars, so the operation is *picking* the right profile; enumerate, never assume;
- 🔴 `connected` ≠ drivable (`No current window` = identity **UNKNOWN**, not absent);
- 🔴 Google SSO cannot be automated — stop and hand to the operator, and **do not**
  route around it via the DB or the service layer (that skips the side effects the
  UI action exists to produce);
- capability is **derived** from `__NEXT_DATA__.props.pageProps.flags`, not assumed;
- 🔴 purge account-scoped `localStorage` after a switch — `recentlyOpenedApps` is
  per-**profile**, not per-account, and produced a false "scope leak" alarm; the
  server returning zero rows is not evidence the UI shows zero;
- 🔴 the account menu is a **toggle** — a JS `.click()` half-opens it and looks
  exactly like a missing entry; use the trusted `click` op, once, and read
  `aria-expanded` in the same breath;
- `/apps` 404 = cohort fact, `/models` 200 = the positive control;
- `/apps` needs ~9 s settle; `document.body.innerText.length` ≈ 221 means not loaded.

### The cross-instance session helper: PROPOSED, not implemented

The file documents a `browser sessions` op that would print
`key → username → id → isModerator` for every connected instance in one call
(hand-rolled twice in one session, contradicting the written-down mapping both
times) — **and ships a copy-pasteable shell loop that works today.**

I did **not** implement it as a CLI op. It is not cheap in this codebase: it would
need to fan out across instances, each `js` call is same-origin so each instance's
tab must already be on civitai.com, and the `connected`-but-not-drivable case
needs its own `UNKNOWN` row rather than a silent omission. That is a real op with
its own semantics, not a wrapper — it belongs in its own change, and shipping the
loop now costs nothing and blocks nothing.

## Verification

### The authoritative gate — `nix build .#checks.x86_64-linux.{pytests,nodetests}`

Read from the log CONTENT, not the exit code (the outer `| tail` reported
`exit 0` over the earlier RED build — the pipe-status trap):

```
  PASS  scripts/tests                  (collected=5629 passed=5629 skipped=0 floor=5482)
  PASS  scripts/browser-bridge/tests   (collected=585  passed=585  skipped=0 floor=469)
  TOTAL collected=12355  passed=12354  skipped=1  failed=0  (floor: 11618)
RESULT: PASS (exit=0)

  PASS  scripts/browser-bridge/tests   (files=15 tests=495 pass=495 skipped=0 floor=490)
  TOTAL suites=4 files=33 tests=1116 pass=1116 fail=0 skipped=0  (floor: 1098)
RESULT: PASS (exit=0)
```

The single skip is the pre-existing pinned one (repo-cos opt-in live-drift check).

⚠️ Scope, stated plainly: that gate run covers commits 1–2. Commits 3–4 are a
markdown fix and a docstring, verified by the targeted re-run below (149 passed,
0 client-host hits) rather than a second 15-minute full gate.

### Suite counts (measured, not asserted)

| | collected | passed | failed | skipped |
|---|---|---|---|---|
| `scripts/browser-bridge/tests` **before** | 515 | 515 | 0 | 0 |
| `scripts/browser-bridge/tests` **after** | **585** | 585 | 0 | 0 |
| delta | **+70** | | | the new file's 70 tests |
| `scripts/tests/test_skill_audit.py` + `test_no_client_hostnames.py` | 75 | 75 | 0 | 0 | |

No existing browser-bridge test changed behaviour. (`test_skill_audit.py` gained
4 tests for the auditor change described below.)

### Instrument validation

`test_the_real_registry_is_not_empty` is the **positive control for the whole
module**: every "does not match" assertion below passes trivially against an
EMPTY registry — a loader wired to nothing returns `""` for `civitai.com` and for
`notcivitai.com.evil.test` alike. That test is what makes the zeros mean
something.

A harness bug was caught this way on the first run: the round-trip helper used a
non-existent op (`getText`), and 16 tests failed with
`400 {'error': 'unknown_op'}` rather than silently passing.

### Red → green matrix (mutation, isolated, `PYTHONDONTWRITEBYTECODE=1`, `__pycache__` cleared between mutants)

Run against a `.git`-stripped copy of the tree; each mutant is the **narrowest
expression that can be wrong**, applied to a pristine restore. Pristine positive
control first: `1 passed, 67 deselected`.

| # | mutation | verdict | evidence |
|---|---|---|---|
| M1 | boundary predicate → `if suffix in h:` (the naive substring bug) | **KILLED** | `6 failed` — `AssertionError: 'notexample.test.evil.invalid' must NOT match the 'example.test' entry — matching is on label boundaries` |
| M1b | `h.endswith(suffix)` — dot dropped | **KILLED** | `3 failed, 2 passed` — catches `notexample.test` / `xexample.test` / `evil-example.test` only, proving the parametrisation is **not** redundant (the prefix cases survive this one) |
| M2 | degradation guard removed (`except: raise`) | **KILLED** | `11 failed, 10 passed`; the round trips die with `http.client.RemoteDisconnected: Remote end closed connection without response` — i.e. **a malformed `_index.json` genuinely kills the browser command** without the guard |
| M3 | `result["site_notes"] = path or None` (null on a miss) | **KILLED** | `AssertionError: an unregistered host must add NO field; got None` |
| M4 | the `_annotate_site_notes(...)` call at the seam deleted (helper left perfect) | **KILLED** | `test_registered_host_gets_site_notes_on_the_envelope` |
| M5 | longest-suffix tiebreak removed (first match wins) | **KILLED** | `test_longest_matching_suffix_wins` (asserted in **both** insertion orders — a `break`-on-first-match passes one order and fails the other) |
| M6 | value validation removed | **KILLED** | `5 failed` incl. `[../../../etc/passwd]`, `[sub/dir/notes.md]` |
| **L1** | **ledger GROWS** — bogus `"bogus.test": "bogus.test.md"` entry added to the real registry | **KILLED** | `_index.json registers file(s) that do not exist: ['bogus.test.md']. An agent following site_notes would be sent to a missing doc.` |
| **L2** | **ledger SHRINKS** — the `civitai.com` entry deleted, file left on disk | **KILLED** | `reference/sites holds *.md file(s) no registry entry names: ['civitai.com.md']. Nothing can ever route to them` |

**L1 and L2 fail on DIFFERENT assertions** — orphan vs unregistered — so the
ledger is genuinely bidirectional, not one check that happens to fire twice.

**Reported honestly — one SURVIVED mutant:** neutralising the
`isinstance(sites, dict)` shape check (`M7`) leaves all 68 tests green. It is
**redundant** with the outer `except`: `None.items()` / `list.items()` raise
`AttributeError`, which the exception handler catches, so the observable
behaviour is identical either way. The shape tests are not vacuous (they assert
real degradation), but they are killed by the exception guard, not by this check.
Kept as intent-documenting defence in depth, not claimed as independently tested.

### Hermeticity

`_SITES_DIR` defaults to the stable **absolute** repo path under `Path.home()`
(server.py is deployed as a flat `/nix/store` symlink, so a `__file__`-relative
lookup does not survive deployment — the same reason the spool emitter resolves
that way). The test module therefore pins it to **this checkout** via an autouse
fixture, mirroring `pinned_manifest` in `test_server.py`. Without that pin the
suite would read the operator's primary clone on a dev host, and in the nix
sandbox `$HOME` is an empty temp dir — the registry would parse to `{}` and every
non-match assertion would pass vacuously.

## Two repo gates the design tripped (2nd commit) — neither suppressed

`nix build .#checks.x86_64-linux.pytests` went **RED** on the first commit.
Both failures were real.

*(Worth recording: the outer `nix build … | tail` reported **exit 0** over a red
build — the pipe-status trap this repo documents. The verdict was read from the
CONTENT: `RESULT: FAIL (exit=1)`.)*

### 1. `test_no_client_hostnames` — a CLIENT SUBDOMAIN in a PUBLIC repo

`www.<client>` / `a.b.<client>` in assertions and `foo.<client>` in two doc
comments are exactly the internal-topology leak that gate exists to stop. The
apex is explicitly permitted (`civitai.com` appears ~100× as prose); subdomains
are not.

Fixed the way that gate's own playbook says: a test-load-bearing host becomes a
reserved-TLD one (RFC 6761). The whole suffix matrix now runs against a synthetic
`example.test` registry; the two assertions that genuinely need the real registry
(the apex hit, and the positive control that the registry is non-empty) keep it.
The semantics are identical and the fixture is arguably better — nothing now
depends on which sites happen to be registered today.

**Instrument validated before believing the zero:** planted
`grafana-new.<client>` → scan reported it; removed → scan reports **0 hits
repo-wide** (and 0 in browser-bridge).

### 2. `test_skill_audit` — the orphan check could not see a runtime-routed directory

`skill-audit.py`'s orphan check knew two routing shapes (an exact path, a bare
filename) and reported `reference/sites/civitai.com.md` as **ORPHANED** — because
the entire point of this design is that `SKILL.md` does *not* name it.

That is a **real gap in the auditor**, not a false positive to silence. There is a
third shape: a **DIRECTORY routed with a VARIABLE segment**, where something at
run time resolves the placeholder. `reference_integrity` now recognises it
**structurally** — `<dir>/<` in the body, the repo's own documented placeholder
convention — and never by naming a directory in the auditor.

**Deliberately narrow: a real SUBdirectory only.** A row spelled
`reference/<topic>.md` would otherwise excuse every file in `reference/` and
switch the orphan counter off repo-wide with one line.

Red → green for the 4 new auditor tests, each killed for its own reason:

| mutation | RED tests | evidence |
|---|---|---|
| the fix reverted (pre-change behaviour) | members-not-orphans, sibling-directory | `must not report its members as orphans: ['reference/sites/a.test.md', 'reference/sites/b.test.md']` |
| **the naive version of this very fix** — `parent != "reference"` guard dropped | the abuse-case test | `assert 'reference/orphan.md' in ['reference/sites/a.test.md']` |
| `/<` check dropped, affordance always on | sibling-directory, and the without-the-row control | `assert [] == ['reference/other/lost.md']` |

The middle row is the one that matters: it proves the abuse-case guard is
**reachable**, not decoration.

## A defect in my own doc, found by reading the server (3rd commit)

The helper snippets in `civitai.com.md` named the **wrong envelope shape**:

- `/health` is a plain endpoint, **not** a `/cmd` op, so its instances list is
  top-level `.instances[]`. The snippet's `["result"]["data"]["instances"]`
  would have raised `KeyError` on the first line an agent pasted.
- a `js` value lands at `.result.data.value` (pinned at `test_server.py:2000`),
  so the loop now extracts it rather than printing the raw envelope.
- the loop iterated a bare `$VAR`, which **zsh does not word-split** — one
  iteration over the whole blob.

Found by reading `server.py` against the doc rather than trusting the doc. A
per-site doc whose first command is broken is worse than no doc — which is
precisely the rot this change exists to fight, so it is worth naming rather than
quietly fixing.

## 🔴 Deployment: what is live on merge and what is not

Measured with `readlink -f` (the arbiter), **not** inferred:

| artifact | resolves to | status |
|---|---|---|
| `~/.claude/skills/browser/SKILL.md` | `/home/zach/workspace/devrc/scripts/browser-bridge/SKILL.md` | **out-of-store symlink → LIVE** once the primary clone carries the commit (no switch) |
| `~/.claude/skills/browser/browser` (CLI) | `…/scripts/browser-bridge/browser` | same — **LIVE** |
| `reference/**` (incl. `reference/sites/`) | not deployed at all; read by absolute repo path per `SKILL.md` | **LIVE** on pull |
| `~/.config/browser-bridge/server.py` | `/nix/store/csz622vjp12990ih0xxcjbm4kv24cbfc-hm_server.py` | **`home.file` COPY → INERT until `home-manager switch`** |

So: the docs and the `SKILL.md` row go live as soon as the primary clone has the
commit, but **the `site_notes` emission does nothing until you run a
`home-manager switch`** — `server.py` is a `home.file` copy
(`nix/home.nix:857`), and the running bridge holds the old code. I have **not**
run a switch; that is a host-level action and yours to take.

*(Note: the brief for this change stated the opposite — that `SKILL.md` was the
`/nix/store` copy. `readlink -f` says it is the out-of-store symlink and
`server.py` is the copy. Stating the measurement, not the assumption.)*

## Adding the next site

1. Write `reference/sites/<host>.md` (H1 + `**Load this when:**` + a pointer back
   to `SKILL.md`; hand mechanism off to the mechanism files).
2. Add one `"host": "host.md"` row under `sites` in `_index.json`.
3. Run the suite. The ledger fails if you do only one of the two.
4. **Do not touch `SKILL.md`.** That is the whole point, and a test enforces it.
