### PR TITLE
docs(browser): rescue the stranded trap-4 popover warning, and prune to fit

### DIFF
--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -36,16 +36,12 @@ anything you wouldn't hand a third party. Nor **virtualised/lazy-loaded lists**.
 KNOW something from it → agent. Ambiguous → agent first; taking over costs ~200
 tokens, so agent-first wins even at a low success rate.
 
-**Measured** 2026-07-31 (laptop, `deepseek-v4-flash`, n=1/goal): ≈0.9 correct,
-~$0.0025/run, ~20s — read as "≈0.9", **not** a rate. Numbers, guardrails, and what
-was NOT measured → `reference/agent.md`.
-
 `blocked` → non-zero exit, take over. `partial` → read `evidence`, drive the rest.
 Thin `evidence` is a weak smell, **NOT** protection against a wrong answer. What
-protects you: the agent tool's auto-`wake` on a hidden `text`/`html` read — **never
-`eval`/`js`, so ASSERT a non-zero content count in any `js` measurement** — and
-escalation: if the answer depends on rendered SPA state, ONE `text --wake`. Ignore
-`steps_used` (undercounted); keep `--allow-domains` TIGHT, incl. frame hosts.
+protects you: auto-`wake` on a hidden `text`/`html` read — **never `eval`/`js`, so
+ASSERT a non-zero content count in any `js` measurement** — and escalation: if the
+answer depends on rendered SPA state, ONE `text --wake`. Keep `--allow-domains`
+TIGHT, incl. frame hosts.
 
 ## Ops
 
@@ -77,7 +73,7 @@ Result payloads land under `.result.data`.
 | `emulate <preset>\|--reset` | **device emulation** (mobile testing) on a tab you `open`ed; sticky, owned-tab-only. `--reset` undoes it, viewport included (#319); `--recreate` replaces the tab → `reference/emulation.md` |
 | `agent "<goal>"` | the autonomous browser-agent — see **FIRST DECISION** above, then `reference/agent.md` |
 
-## 🔴 Three traps that return a WRONG answer SILENTLY
+## 🔴 Four traps that return a WRONG answer SILENTLY
 
 1. **`js`/`eval` evaluates ONE EXPRESSION, not a script.** A multi-statement body
    (`window.scrollBy(0,1400); "ok"`) returns **`null` with no error** — it looks
@@ -92,6 +88,11 @@ Result payloads land under `.result.data`.
    `activate`, and spoofing `visibilityState` does not recover the page.
    **A reload RE-throttles: re-`wake` or clicks go silently inert.**
    → `reference/spa-wake.md`
+4. **A JS `.click()` does not open a React/Mantine popover — and the read then
+   reports a confident ABSENCE.** Use the trusted **`click`** op; click **ONCE** —
+   it is a TOGGLE, so a stale earlier click makes the next read lie — and read
+   `aria-expanded` to prove it opened. Not selector-reachable? **`screenshot`** it.
+   → `reference/css-hit-test.md`
 
 ## When things look broken — triage
 

--- a/scripts/browser-bridge/reference/css-hit-test.md
+++ b/scripts/browser-bridge/reference/css-hit-test.md
@@ -168,3 +168,21 @@ would have been wrong.
 
 ⚠ `innerText` depends on layout, so it needs a rendered tab: **`wake` first**, or a
 throttled background tab returns a shell and both numbers lie.
+
+## A JS `.click()` cannot open a React/Mantine popover — and the read reports ABSENCE
+
+`SKILL.md` trap 4 carries the instruction; this is the evidence behind it.
+
+`element.click()` inside a `js` payload left `aria-expanded="false"` and found only
+**empty `.mantine-Popover-dropdown` shells** — indistinguishable from "the menu entry
+isn't there", which is what makes it a silent wrong answer rather than an error.
+
+The trusted **`click`** op (real CDP input on the top frame) does open it. Two things
+that still bite after switching:
+
+- It is a **TOGGLE**. Two clicks open then close it, so a stale earlier click makes the
+  next read report a confident absence. Click **once**, and read `aria-expanded` in the
+  same breath so the read carries its own proof.
+- On some builds the dropdown's links are **not reachable** via
+  `.mantine-Popover-dropdown a` even once open. **`screenshot` it** rather than
+  selector-hunting — a selector that matches nothing looks exactly like missing content.


### PR DESCRIPTION
## Why

The Mantine-popover trap existed **only as an uncommitted edit in the working tree**. Because `scripts/browser-bridge/SKILL.md` is an out-of-store symlink, that working copy **is** the live file — so a real, measured warning was being served to readers while living nowhere else in the repo, one routine `pull`/`checkout`/cleanup away from silent deletion.

It also could not be committed as written. Measured:

| version | bytes | vs gate |
|---|---|---|
| `main` | 11,821 | ✅ |
| live working copy (uncommitted trap 4) | 12,409 | ❌ 121 over the 12,288 hard ceiling, 371 over the 12,038 budget |

That is the likely reason it stalled: adding it was already a gate failure.

## How it lands

The **instruction and its warning stay together in the body**; only the **evidence** moves to `reference/css-hit-test.md`. Deliberately not slicing a warning away from the instruction it guards.

Two prunes, both **pure duplication** — verified present in the target rather than assumed:

- the agent measured-numbers paragraph → already `reference/agent.md:68-76`
- `Ignore steps_used (undercounted)` → already `reference/agent.md:125`

`SKILL.md` **11,821 → 11,921 B**. Size gate passes (4 tests); browser-bridge suite **615 passed / 0 failed**.

## Merged-tree check

Gated against the tree the merge creates, not just this branch. With #562 also merged: `SKILL.md` = **12,035 B**, and `pytest scripts/browser-bridge/tests scripts/tests/test_prune_skill_size.py scripts/tests/test_skill_audit.py` → **742 passed / 0 failed**.

## 🔴 Two things for the reviewer

1. **This leaves ~3 B of margin** once #562 (+114 B) lands. The body is at capacity — the next addition needs a real prune pass, not another shave.
2. **Possible pre-existing contradiction, not touched here.** The triage section says ↻ is unreliable so *"prefer a full Brave restart"*, while `reference/errors.md:161` says *"A full Brave restart is NOT sufficient"* and names per-profile Remove + Load unpacked as the fix. Those describe different failures (mid-session drop vs stale build), but the body's advice still reads against its own reference. Flagged rather than folded into a size change.
