### PR TITLE
docs(browser): prune SKILL.md for real headroom + fix 3 correctness defects

### DIFF
--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -116,9 +116,9 @@ Result payloads land under `.result.data`.
 It's their real browser, not a scratch VM. Don't `nav` a tab that may hold unsaved
 work (a half-typed comment, a form) — `open` your own tab, or an obviously
 disposable one. 🔴 If ANYTHING takes their screen — `activate`, the X-fallback
-capture — RECORD focus AND workspace first, then restore BOTH at the end, on
-failure too. Focus alone leaves them on YOUR workspace, which is the axis that
-actually gets taken. Exact commands → `reference/spa-wake.md`.
+capture — RECORD focus AND workspace first, restore BOTH at the end, on failure
+too. Restoring focus usually carries the workspace, but not always — restore it
+explicitly. Why, and the commands → `reference/spa-wake.md`.
 
 ## Reference files — load ONE only when its trigger fires
 

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -15,7 +15,11 @@ $BB --instance <key> --tab <id> text   # cheap read of a specific tab
 🔴 **Run `whoami` first on every fresh browser task.** Both hosts are hostname
 `nixos` and this bridge could be either, with several Brave profiles — confirm the
 host and pick the right `--instance` before acting. Architecture / security model:
-`scripts/browser-bridge/README.md`.
+`~/workspace/devrc/scripts/browser-bridge/README.md`.
+
+🔴 **Every `reference/<file>.md` named below lives at
+`~/workspace/devrc/scripts/browser-bridge/reference/`** — that exact path; only
+`SKILL.md` + the CLI are symlinked into `~/.claude/skills/browser/`.
 
 ## FIRST DECISION: agent or direct?
 
@@ -33,15 +37,13 @@ order) · **secret** — agent-read pages go to
 **OpenRouter/DeepSeek**: never banking, private mail, credential managers, or
 anything you wouldn't hand a third party. Nor **virtualised/lazy-loaded lists**.
 
-KNOW something from it → agent. Ambiguous → agent first; taking over costs ~200
-tokens, so agent-first wins even at a low success rate.
+KNOW something from it → agent. Ambiguous → agent first: taking over is cheap, so
+agent-first wins even at a low success rate.
 
-`blocked` → non-zero exit, take over. `partial` → read `evidence`, drive the rest.
-Thin `evidence` is a weak smell, **NOT** protection against a wrong answer. What
-protects you: auto-`wake` on a hidden `text`/`html` read — **never `eval`/`js`, so
-ASSERT a non-zero content count in any `js` measurement** — and escalation: if the
-answer depends on rendered SPA state, ONE `text --wake`. Keep `--allow-domains`
-TIGHT, incl. frame hosts.
+🔴 Auto-`wake` covers a hidden `text`/`html` read but **never `eval`/`js`** — so
+ASSERT a non-zero content count in any `js` measurement. Result handling
+(`blocked`/`partial`), why thin `evidence` is NOT protection, and the
+`--allow-domains` guardrail → `reference/agent.md`.
 
 ## Ops
 
@@ -52,25 +54,23 @@ Result payloads land under `.result.data`.
 | command | does |
 |---|---|
 | `whoami` | **read-only identity** (global; no `--instance`/`--tab`) — host label (`laptop`/`workbench`), connected instances (active-tab **domain** only), bridge diagnostics, `extension_version_current` |
-| `health` / `instances` | connected instances + count (JSON: key, label, instanceId, tab url/title). `extension_stale` on `health` ONLY (`false` is MARKER-backed; version MISMATCH → `true`; `null` = undecidable) |
+| `health` / `instances` | connected instances + count (JSON: key, label, instanceId, tab url/title). `extension_stale` on `health` ONLY — ⚠ `null` is "undecidable", NOT "fine"; tri-state semantics → `reference/errors.md` |
 | `ping` | **which extension CODE is loaded?** → `{pong,extensionVersion,buildMarker,id,ops}`; read `buildMarker` — version+id describe the DIRECTORY. Staleness is PER PROFILE |
 | `context` | **page metadata, no DOM read** — url/domain/path/query/title/tabId, tab-scoped. Cheapest read; ⚠ NOT a render check → `reference/read-envelopes.md` |
-| `open [url] [--wake[=MS]]` | open a NEW tab this session owns (default `about:blank`, **created in the BACKGROUND/hidden**), returns `tabId`. Idempotent — a re-`open` does NOT navigate (url DISCARDED). Use for multi-step work |
+| `open [url] [--wake[=MS]]` | open a NEW tab this session owns (default `about:blank`, **created in the BACKGROUND/hidden**), returns `tabId`. 🔴 A re-`open` does NOT navigate — it DISCARDS your url → `reference/tabs-instances.md` |
 | `close` / `release` | close this session's owned tab / drop ownership without closing it |
 | `tabs` | list open tabs (`.data.ownedTabId` flags yours) |
 | `nav <url> [--wake[=MS]]` | navigate the owned/active tab; it lands hidden, so `--wake` un-throttles in the SAME call |
-| `text [selector] [--max-bytes N] [--annotated]` | **cheap read** — visible `innerText` (optional CSS selector), whitespace-normalized, byte-capped (default 32768; `0`=uncapped). ~98% smaller than `html` — **prefer it**. `--annotated` swaps flat text for per-element extraction — use it when you need a SELECTOR to click/type; works with `--frame` (frame-relative CSS paths). Envelope fields + `--annotated` schema → `reference/read-envelopes.md` |
+| `text [selector] [--max-bytes N] [--annotated]` | **cheap read** — visible `innerText` (optional CSS selector), byte-capped by default. ~98% smaller than `html` — **prefer it**. `--annotated` swaps flat text for per-element extraction — use it when you need a SELECTOR to click/type; works with `--frame`. Byte cap, envelope fields, `--annotated` schema → `reference/read-envelopes.md` |
 | `html [--max-bytes N]` | `outerHTML`, same byte cap and same envelope. One uncapped `html` on a heavy SPA is ~100K tokens — the cap is ON by default |
-| `js '<expr>'` (alias: `eval`) | run JS in the tab, return its value; same op on the wire either way. **Prefer `js` in a worktree-isolated agent** — Claude Code's isolation guard refuses any command containing the literal token `eval` (it matches the WORD, not the behaviour) |
-| `screenshot [path] [--fullpage] [--data-url]` | CDP capture — **works on a BACKGROUND/occluded tab**. **Always writes a `.png`** (to `path`, else a mode-0600 temp auto-pruned after 24h) and prints `{ok,path,bytes,url,via}`; the base64 is **NEVER** printed (it cost 133K–890K tokens/call) — **`Read` the `.png`**. `--data-url` is the escape hatch |
+| `js '<expr>'` (alias: `eval`) | run JS in the tab, return its value; same op on the wire either way. **Prefer the `js` spelling** — Claude Code's isolation guard refuses any command containing the literal token `eval` |
+| `screenshot [path] [--fullpage] [--data-url]` | CDP capture — **works on a BACKGROUND/occluded tab**. **Always writes a `.png`** (to `path`, else a 0600 temp) and prints `{ok,path,bytes,url,via}`; the base64 is **NEVER** printed — **`Read` the `.png`**. `--data-url` is the escape hatch |
 | `frames` | list the tab's frames (`frameId`/`url`/`parentFrameId`) **incl. cross-origin OOPIFs** — pick a numeric `frameId` for `--frame` |
-| `click <selector>` | click the element's center — **TRUSTED** CDP on the top frame, **SYNTHETIC** inside `--frame` |
-| `type <text> [--selector S]` | text input — TRUSTED CDP top frame, SYNTHETIC in-frame |
-| `key <Enter\|Tab\|Escape\|Backspace\|Delete\|Arrow*\|Home\|End\|Page*> [--selector S]` | one bounded keypress, same trust rules |
+| `click <selector>` · `type <text> [--selector S]` · `key <Enter\|Tab\|Escape\|Backspace\|Delete\|Arrow*\|Home\|End\|Page*> [--selector S]` | the input ops — click the element's centre, type text, send one bounded keypress. All three: **TRUSTED** CDP on the top frame, **SYNTHETIC** inside `--frame` |
 | `upload <selector> <path>` | fill an `<input type=file>` via CDP — Chrome reads the file BY PATH, **no bytes cross the bridge**. AUDIT-LOGGED, **operator-only** (agent → `op_not_allowed:upload`) |
-| `wake [--wait MS]`, or `text\|html\|js\|nav\|open --wake[=MS]` | **UN-THROTTLE a hidden/background tab with NO focus movement** — the fix for an empty or `hidden` read. ~1.5s settle, cap **6s**. **Wake once per PAGE, not per read** — the un-throttled state ends at detach, but the DOM already rendered PERSISTS. `--wake` folds un-throttle+read into one session; refused with `--frame` (`wake_with_frame_unsupported`). ISOLATED-vs-MAIN world nuance → `reference/spa-wake.md` |
+| `wake [--wait MS]`, or `text\|html\|js\|nav\|open --wake[=MS]` | **UN-THROTTLE a hidden/background tab with NO focus movement** — the fix for an empty or `hidden` read. **Wake once per PAGE, not per read.** `--wake` folds un-throttle+read into one call; refused with `--frame`. Settle/cap, the once-per-page rule, ISOLATED-vs-MAIN world → `reference/spa-wake.md` |
 | `activate` | **⚠⚠ STEALS THE OPERATOR'S SCREEN — the ONE intrusive op, a LAST RESORT.** It is **NOT** the fix for a hidden/unrendered tab — that is `wake`. Read `reference/spa-wake.md` BEFORE using it |
-| `emulate <preset>\|--reset` | **device emulation** (mobile testing) on a tab you `open`ed; sticky, owned-tab-only. `--reset` undoes it, viewport included (#319); `--recreate` replaces the tab → `reference/emulation.md` |
+| `emulate <preset>\|--reset` | **device emulation** (mobile testing) on a tab you `open`ed; sticky, owned-tab-only. Presets, `--reset`, `--recreate` → `reference/emulation.md` |
 | `agent "<goal>"` | the autonomous browser-agent — see **FIRST DECISION** above, then `reference/agent.md` |
 
 ## 🔴 Four traps that return a WRONG answer SILENTLY
@@ -98,9 +98,10 @@ Result payloads land under `.result.data`.
 
 1. **A call that WORKED now fails, errors, or returns nothing** → re-run `browser
    health` BEFORE debugging the page or the CLI; the extension drops mid-session
-   (`extension_connected:false`) with no user action and no error. ⚠ ↻ **in the
-   profile you are driving** (`brave://extensions` is per-profile) — and ↻ is
-   UNRELIABLE, so prefer a full Brave restart. → `reference/errors.md`
+   (`extension_connected:false`) with no user action and no error. Fix: ↻ **in the
+   profile you are driving** (`brave://extensions` is per-profile). A STALE BUILD is
+   a DIFFERENT failure — a Brave restart does NOT clear it; that needs per-profile
+   Remove + Load unpacked. → `reference/errors.md`
 2. **A read is empty / half-built / `data.hidden:true`** → the tab is throttled.
    `browser wake`, then re-read. → `reference/spa-wake.md`
 3. **`null` from `js`/`eval`** → trap 1, then trap 2. Fall back to `text`/`html`
@@ -114,13 +115,14 @@ Result payloads land under `.result.data`.
 
 It's their real browser, not a scratch VM. Don't `nav` a tab that may hold unsaved
 work (a half-typed comment, a form) — `open` your own tab, or an obviously
-disposable one. If anything moved their focus, **restore it**
-(`i3-msg '[id="<prev-winid>"] focus'`).
+disposable one. 🔴 `activate` takes their screen. RECORD both axes first
+(`xdotool getactivewindow`; `i3-msg -t get_workspaces`), then RESTORE both at the
+end, failure included: `i3-msg '[id="<winid>"] focus'` **and** `i3-msg workspace
+<n>`. Focus alone leaves them on YOUR workspace — the axis actually taken.
 
 ## Reference files — load ONE only when its trigger fires
 
-**Read them at `~/workspace/devrc/scripts/browser-bridge/reference/<file>`** — that
-exact path; only `SKILL.md` + the CLI are symlinked into `~/.claude/skills/browser/`.
+Paths as stated in Quick start.
 
 | file | load it when… |
 |---|---|

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -40,7 +40,7 @@ anything you wouldn't hand a third party. Nor **virtualised/lazy-loaded lists**.
 KNOW something from it → agent. Ambiguous → agent first: taking over is cheap, so
 agent-first wins even at a low success rate.
 
-🔴 Auto-`wake` covers a hidden `text`/`html` read but **never `eval`/`js`** — so
+🔴 The AGENT's auto-`wake` covers a hidden `text`/`html` read but **never `eval`/`js`** — so
 ASSERT a non-zero content count in any `js` measurement. Result handling
 (`blocked`/`partial`), why thin `evidence` is NOT protection, and the
 `--allow-domains` guardrail → `reference/agent.md`.
@@ -54,7 +54,7 @@ Result payloads land under `.result.data`.
 | command | does |
 |---|---|
 | `whoami` | **read-only identity** (global; no `--instance`/`--tab`) — host label (`laptop`/`workbench`), connected instances (active-tab **domain** only), bridge diagnostics, `extension_version_current` |
-| `health` / `instances` | connected instances + count (JSON: key, label, instanceId, tab url/title). `extension_stale` on `health` ONLY — ⚠ `null` is "undecidable", NOT "fine"; tri-state semantics → `reference/errors.md` |
+| `health` / `instances` | connected instances + count (JSON: key, label, instanceId, tab url/title). per-instance `extension_stale` (on `whoami` too) — ⚠ `null` is "undecidable", NOT "fine"; tri-state → `reference/errors.md` |
 | `ping` | **which extension CODE is loaded?** → `{pong,extensionVersion,buildMarker,id,ops}`; read `buildMarker` — version+id describe the DIRECTORY. Staleness is PER PROFILE |
 | `context` | **page metadata, no DOM read** — url/domain/path/query/title/tabId, tab-scoped. Cheapest read; ⚠ NOT a render check → `reference/read-envelopes.md` |
 | `open [url] [--wake[=MS]]` | open a NEW tab this session owns (default `about:blank`, **created in the BACKGROUND/hidden**), returns `tabId`. 🔴 A re-`open` does NOT navigate — it DISCARDS your url → `reference/tabs-instances.md` |
@@ -63,7 +63,7 @@ Result payloads land under `.result.data`.
 | `nav <url> [--wake[=MS]]` | navigate the owned/active tab; it lands hidden, so `--wake` un-throttles in the SAME call |
 | `text [selector] [--max-bytes N] [--annotated]` | **cheap read** — visible `innerText` (optional CSS selector), byte-capped by default. ~98% smaller than `html` — **prefer it**. `--annotated` swaps flat text for per-element extraction — use it when you need a SELECTOR to click/type; works with `--frame`. Byte cap, envelope fields, `--annotated` schema → `reference/read-envelopes.md` |
 | `html [--max-bytes N]` | `outerHTML`, same byte cap and same envelope. One uncapped `html` on a heavy SPA is ~100K tokens — the cap is ON by default |
-| `js '<expr>'` (alias: `eval`) | run JS in the tab, return its value; same op on the wire either way. **Prefer the `js` spelling** — Claude Code's isolation guard refuses any command containing the literal token `eval` |
+| `js '<expr>'` (alias: `eval`) | run JS in the tab, return its value; same op on the wire either way. **Prefer the `js` spelling in a worktree-isolated agent** — Claude Code's isolation guard refuses any command containing the literal token `eval` |
 | `screenshot [path] [--fullpage] [--data-url]` | CDP capture — **works on a BACKGROUND/occluded tab**. **Always writes a `.png`** (to `path`, else a 0600 temp) and prints `{ok,path,bytes,url,via}`; the base64 is **NEVER** printed — **`Read` the `.png`**. `--data-url` is the escape hatch |
 | `frames` | list the tab's frames (`frameId`/`url`/`parentFrameId`) **incl. cross-origin OOPIFs** — pick a numeric `frameId` for `--frame` |
 | `click <selector>` · `type <text> [--selector S]` · `key <Enter\|Tab\|Escape\|Backspace\|Delete\|Arrow*\|Home\|End\|Page*> [--selector S]` | the input ops — click the element's centre, type text, send one bounded keypress. All three: **TRUSTED** CDP on the top frame, **SYNTHETIC** inside `--frame` |
@@ -115,10 +115,10 @@ Result payloads land under `.result.data`.
 
 It's their real browser, not a scratch VM. Don't `nav` a tab that may hold unsaved
 work (a half-typed comment, a form) — `open` your own tab, or an obviously
-disposable one. 🔴 `activate` takes their screen. RECORD both axes first
-(`xdotool getactivewindow`; `i3-msg -t get_workspaces`), then RESTORE both at the
-end, failure included: `i3-msg '[id="<winid>"] focus'` **and** `i3-msg workspace
-<n>`. Focus alone leaves them on YOUR workspace — the axis actually taken.
+disposable one. 🔴 If ANYTHING takes their screen — `activate`, the X-fallback
+capture — RECORD focus AND workspace first, then restore BOTH at the end, on
+failure too. Focus alone leaves them on YOUR workspace, which is the axis that
+actually gets taken. Exact commands → `reference/spa-wake.md`.
 
 ## Reference files — load ONE only when its trigger fires
 

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -54,7 +54,7 @@ Result payloads land under `.result.data`.
 | command | does |
 |---|---|
 | `whoami` | **read-only identity** (global; no `--instance`/`--tab`) — host label (`laptop`/`workbench`), connected instances (active-tab **domain** only), bridge diagnostics, `extension_version_current` |
-| `health` / `instances` | connected instances + count (JSON: key, label, instanceId, tab url/title). per-instance `extension_stale` (on `whoami` too) — ⚠ `null` is "undecidable", NOT "fine"; tri-state → `reference/errors.md` |
+| `health` / `instances` | connected instances + count (JSON: key, label, instanceId, tab url/title). per-instance `extension_stale` on `health` + `whoami`, NOT `instances` — ⚠ `null` is "undecidable", NOT "fine"; tri-state → `reference/errors.md` |
 | `ping` | **which extension CODE is loaded?** → `{pong,extensionVersion,buildMarker,id,ops}`; read `buildMarker` — version+id describe the DIRECTORY. Staleness is PER PROFILE |
 | `context` | **page metadata, no DOM read** — url/domain/path/query/title/tabId, tab-scoped. Cheapest read; ⚠ NOT a render check → `reference/read-envelopes.md` |
 | `open [url] [--wake[=MS]]` | open a NEW tab this session owns (default `about:blank`, **created in the BACKGROUND/hidden**), returns `tabId`. 🔴 A re-`open` does NOT navigate — it DISCARDS your url → `reference/tabs-instances.md` |

--- a/scripts/browser-bridge/reference/spa-wake.md
+++ b/scripts/browser-bridge/reference/spa-wake.md
@@ -255,8 +255,12 @@ the wake once the URL is real. See `reference/frames-cdp.md`.
 browser permission prompt, a native file picker, or verifying with your own eyes.
 **It STEALS the operator's screen** — telemetry caught a session calling it 1–5 times
 per minute, grabbing the screen on nearly every interaction. If you must, call it
-**once per TAB, never per read**, and restore focus afterward
-(`i3-msg '[id="<prev-winid>"] focus'`). It foregrounds via host-side `i3-msg`
+**once per TAB, never per read**. 🔴 RECORD both axes BEFORE the raise
+(`xdotool getactivewindow`; `i3-msg -t get_workspaces | jq -r '.[]|select(.focused).num'`)
+— by the time you want them back the values are gone — and restore BOTH afterwards,
+on failure too: `i3-msg '[id="<prev-winid>"] focus'` **and** `i3-msg workspace <n>`.
+Restoring focus alone leaves the operator on YOUR workspace, which is the axis that
+actually gets taken. It foregrounds via host-side `i3-msg`
 (Chrome-side `tabs.update`/`windows.update` is a no-op on i3), so it is i3-gated
 (`i3:"skipped"` off a graphical i3 host) and is **not available to the autonomous
 browser-agent at all**.

--- a/scripts/browser-bridge/reference/spa-wake.md
+++ b/scripts/browser-bridge/reference/spa-wake.md
@@ -259,8 +259,11 @@ per minute, grabbing the screen on nearly every interaction. If you must, call i
 (`xdotool getactivewindow`; `i3-msg -t get_workspaces | jq -r '.[]|select(.focused).num'`)
 — by the time you want them back the values are gone — and restore BOTH afterwards,
 on failure too: `i3-msg '[id="<prev-winid>"] focus'` **and** `i3-msg workspace <n>`.
-Restoring focus alone leaves the operator on YOUR workspace, which is the axis that
-actually gets taken. It foregrounds via host-side `i3-msg`
+Focusing a window that lives on another workspace switches to it, so restoring the
+recorded window usually carries the workspace back — but a criteria command silently
+no-ops if that window has closed, and there is nothing to record if the operator was
+on an empty workspace. The workspace is the axis that gets left behind, so restore it
+explicitly rather than relying on the focus command to do it. It foregrounds via host-side `i3-msg`
 (Chrome-side `tabs.update`/`windows.update` is a no-op on i3), so it is i3-gated
 (`i3:"skipped"` off a graphical i3 host) and is **not available to the autonomous
 browser-agent at all**.

--- a/scripts/browser-bridge/reference/x-fallback.md
+++ b/scripts/browser-bridge/reference/x-fallback.md
@@ -32,9 +32,9 @@ nix-shell -p imagemagick --run 'magick out.png -crop WxH+X+Y +repage cropped.png
 `browser activate`. 🔴 RECORD both axes BEFORE step 3 (`xdotool getactivewindow`;
 `i3-msg -t get_workspaces | jq -r '.[]|select(.focused).num'`), then restore BOTH
 afterwards, on failure too: `i3-msg '[id="<prev-winid>"] focus'` **and**
-`i3-msg workspace <n>`. Focus alone leaves them on YOUR workspace — and step 3's
-own comment says focusing the workspace is what makes the window visible, so this
-path moves the workspace by construction.
+`i3-msg workspace <n>`. Focus alone leaves them on YOUR workspace — focusing a
+window that lives on ANOTHER workspace switches to that workspace, so step 3 moves
+the workspace by construction, not just the focus.
 
 Two traps that produce a confidently-wrong result:
 

--- a/scripts/browser-bridge/reference/x-fallback.md
+++ b/scripts/browser-bridge/reference/x-fallback.md
@@ -29,8 +29,12 @@ nix-shell -p imagemagick --run 'magick out.png -crop WxH+X+Y +repage cropped.png
 ```
 
 ⚠ Step 3 focuses a window — that TAKES THE OPERATOR'S SCREEN, same cost as
-`browser activate`. Restore their focus afterwards
-(`i3-msg '[id="<prev-winid>"] focus'`).
+`browser activate`. 🔴 RECORD both axes BEFORE step 3 (`xdotool getactivewindow`;
+`i3-msg -t get_workspaces | jq -r '.[]|select(.focused).num'`), then restore BOTH
+afterwards, on failure too: `i3-msg '[id="<prev-winid>"] focus'` **and**
+`i3-msg workspace <n>`. Focus alone leaves them on YOUR workspace — and step 3's
+own comment says focusing the workspace is what makes the window visible, so this
+path moves the workspace by construction.
 
 Two traps that produce a confidently-wrong result:
 

--- a/scripts/browser-bridge/reference/x-fallback.md
+++ b/scripts/browser-bridge/reference/x-fallback.md
@@ -32,9 +32,11 @@ nix-shell -p imagemagick --run 'magick out.png -crop WxH+X+Y +repage cropped.png
 `browser activate`. 🔴 RECORD both axes BEFORE step 3 (`xdotool getactivewindow`;
 `i3-msg -t get_workspaces | jq -r '.[]|select(.focused).num'`), then restore BOTH
 afterwards, on failure too: `i3-msg '[id="<prev-winid>"] focus'` **and**
-`i3-msg workspace <n>`. Focus alone leaves them on YOUR workspace — focusing a
-window that lives on ANOTHER workspace switches to that workspace, so step 3 moves
-the workspace by construction, not just the focus.
+`i3-msg workspace <n>`. Focusing a window that lives on ANOTHER workspace switches
+to that workspace, so step 3 moves the WORKSPACE by construction, not just focus.
+Restoring the recorded window usually switches back — but not if it has closed
+(a criteria command silently no-ops) or there was none to record, so restore the
+workspace explicitly.
 
 Two traps that produce a confidently-wrong result:
 


### PR DESCRIPTION
## Why

`scripts/browser-bridge/SKILL.md` sat at **12,035 B against an enforced budget of 12,038** — 3 bytes. The enforced budget is `MAX_BYTES 12,288 − MIN_HEADROOM_BYTES 250`, both owned by `scripts/browser-bridge/tests/test_skill_size.py`. The next one-line correction would have failed the gate.

**12,035 → 11,880 B · headroom 253 → 408.**

Note `scripts/skill-audit.py` reports this file as `✓ OK — no prune needed`. That verdict is measured against the raw 12,288 ceiling; it cannot see `MIN_HEADROOM_BYTES`, so it is a false all-clear for this skill.

## What was removed

663 B of verified-redundant content; every removal confirmed to exist in a destination **first**, with the line reference:

| removed from core | already lives at |
|---|---|
| agent result handling, thin-`evidence`, `--allow-domains` | `agent.md:151,132,96-105,119` |
| wake settle+cap, once-per-page, ISOLATED-vs-MAIN | `spa-wake.md:63,78-80,216,218-219` |
| `text` byte cap + `--annotated` schema | `read-envelopes.md:59,62-87` |
| `extension_stale` tri-state, staleness-is-per-profile | `errors.md:148-165,159` |
| re-`open` discards the url | `tabs-instances.md:28-29` |
| `emulate --reset/--recreate`, viewport (#319) | `emulation.md:22-23,112` |
| screenshot 133K–890K token evidence | `README.md:303` |

Plus one MERGE_DUP: `click`/`type`/`key` restated the same trust rule three times → one input-ops row.

## Three correctness defects fixed

These **added** 485 B. Correctness outranks bytes.

1. **Triage item 1 was wrong in both branches.** It said the reload arrow is unreliable so prefer a full Brave restart. `errors.md:82-99` (mid-session **drop**) says reloading *in the driven profile* IS the fix; `errors.md:150-165` (**stale build**) says a full restart is explicitly NOT sufficient and needs per-profile Remove + Load unpacked. The body recommended the one thing neither branch supports. This was flagged as an open question in `claudedocs/handoff-browser-per-site-reference.md` — resolved: they are different failures, not a contradiction, and the body was simply wrong.
2. **"Restore focus" did not cover the workspace.** `claude/RULES.md` is explicit that a restore rule about focus does not cover a workspace, and that the workspace is the axis that actually gets taken. Now names both, gives the record *and* restore command for each, and says "on failure too".
3. **A routing path that could not resolve.** The README was referenced bare; only `SKILL.md` + the CLI are symlinked into `~/.claude/skills/browser/`, so it did not resolve for a reader. Now repo-absolute. Related: the `reference/` path expansion sat *below* every inline mention — hoisted into Quick start so it precedes them.

## Staleness pass — deterministic axes clean

24/24 ops, 16/16 envelope fields/flags, 13/13 error strings, and every numeric claim (32768 cap, 0600 temp, 24h prune, 1.5s settle, 6s wake cap) verified against the CLI + server + extension.

One **false finding**, recorded so nobody re-derives it: `nav_scheme_denied` / `op_not_allowed` look absent from source. They are not — `opencode/tools/browser_tool_impl.mjs:482,516,1101,1108`. The first scan's file filter took `.py/.js/.json` and not `.mjs`. Instrument fault, not doc rot.

## Verification

- **browser-bridge suite: 654 passed, 0 failed.**
- **Negative control on the size gate**: padded a scratch copy to 12,080 B and watched `test_skill_md_keeps_working_headroom` fail with `free: 208 (minimum required: 250) / RECLAIM: 42`. Green at 11,880 is a measurement, not an assumption.
- **Survival check** over (new core + all sidecars): numbers population removed=3, **orphaned=0**. Destination controls — hide each of 6 sidecars, mutate a constant in `spa-wake.md` and `read-envelopes.md` — each went red.
  The phrases/sentences populations are **not** reported as findings: they test verbatim strings across a rewrite and their controls did not move (35 vs 35/36), so they are an invalid instrument here.
- Rollback backup: `/tmp/skill-prune-browser-140452` (14 files).

## What I deliberately did not do

No further cutting. Every section now sits at or below its own historical density (Ops 188 B/row against a measured 190 mean; Reference 175 B/row against 166). There is no archive block left to demote — **the body is dense, not bloated**, which is why the margin was tight. Cutting further would remove routing value, not fat. If more headroom is wanted later, that is a decision to raise `MAX_BYTES` or to demote one of the four 🔴 traps, not something to take silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
