### PR TITLE
feat(skill): window-triage — one operating surface over session-resolve + waiting-windows

### DIFF
--- a/claude/skills/window-triage/SKILL.md
+++ b/claude/skills/window-triage/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: window-triage
+description: "Point at ONE tmux window by codename, hotkey or address (Gold, Alt+Shift+G, scratch2:@81) — refusing to guess when the selector is ambiguous — and rank the windows STRANDED past a threshold, longest-waited first, banded by kind. Read-only. Use for: which window is Gold, what does Alt+p open, which window has been stranded / unanswered for hours or days, the oldest unanswered question, a codename with no hotkey, why a window shows no harness record, what the scan could not cover. The live inventory — is anything waiting on me, what's running where, tail a window, unsent prompts — is `session-manager`."
+---
+
+# window-triage — name one window, rank the stranded ones
+
+Two read-only tools, one surface. **Neither writes.** Acting on a window is a command
+you hand the operator, never something this skill does.
+
+| ask | tool |
+|---|---|
+| "which window is `Gold` / `Alt+p` / `@81`?" | `scripts/session-resolve` |
+| "what has been stranded longest?" | `scripts/waiting-windows` |
+
+```bash
+python3 $DEVRC/scripts/session-resolve show <selector> [--json]
+python3 $DEVRC/scripts/waiting-windows [--json] [--top N] [--kind selection_menu,...]
+```
+
+🔴 **Read `--help` for flags and selector kinds — they are NOT restated here.** One
+place for that, and it is the tool. This file carries only what `--help` cannot say.
+
+## Why this exists
+
+A question sat unanswered in a tmux window for **55 hours** while ~98 other prompts
+were answered in the same 22. The signal existed the whole time; nothing ranked it.
+These two tools consume it. Discovering them is the remaining half.
+
+## 🔴 The eight things that bite
+
+### 1. Two `waiting` states that disagree — never merge them
+* `waiting_probable` (session-manager) — *the pane TEXT looks like it is asking a human.*
+* `harness_status` (the `~/.claude/sessions/` registry) — *this harness process is waiting on a turn.*
+
+Measured at one instant: **3 vs 1, zero overlap**, with the same window `idle` in one
+and `waiting` in the other. **No mapping between them exists.** Do not invent one, do
+not sum them, do not translate one into the other. `waiting-windows` fires its
+threshold on `waiting_probable` **alone** and passes `harness_status` through beside it.
+
+### 2. Presence is four-valued — and the two tools SPELL it differently
+`present` · `absent` (read, no record — the **majority**, normal, not a zero) ·
+`unmeasured` (could not look; carries a reason) · **structurally excluded**.
+
+The registry is a directory in the **local** host's `$HOME` — there is no host
+dimension in the path — so a **remote** window can *never* carry a record. That is
+exclusion, not absence, and re-checking it will never help.
+
+🔴 The two tools do not agree on the token:
+
+| | fourth state spelled as |
+|---|---|
+| `session-resolve` | `harness_presence: "structurally_excluded"` |
+| `waiting-windows` | `harness_presence: "unmeasured"` + `harness_presence_reason: "remote_host"` |
+
+Both name the excluded hosts at `coverage.registry.hosts_not_covered`. **Read
+`harness_presence` (plus the reason), never the nullness of `harness_status`.**
+
+### 3. `--host` defaults to `all` — leave it there
+`session-resolve --host` takes `all` (default) / `workbench` / `laptop`. Narrowing it
+makes every window on the other host **UNMATCHED**. The report now says so loudly —
+
+```
+laptop  out-of-scope   <- contributed NOTHING
+    why: not in scope for --host workbench
+```
+
+— so **read the `hosts consulted` block before believing an UNMATCHED.** tmux and the
+registry are always read locally regardless of this flag. `waiting-windows` has no
+`--host`; it takes whatever session-manager reports.
+
+### 4. `age_secs` is not time-waited
+`age_secs` is time since the window's last **ledger heartbeat** — a different question
+in the same units. A row was measured flagged waiting while `busy` with an `age_secs`
+of **2.5 seconds**. `waiting-windows` keeps its own clock and labels every row's
+number with `waited_source`:
+
+* `registry_status_updated` — the registry's `statusUpdatedAt`. **Preferred.**
+* `ledger_age_fallback` — the ledger age observed when the stamp was taken.
+* `first_seen` — elapsed since this tool first saw the window waiting (a **lower
+  bound**; a row that first appears is not 6h old because the tool has run 6h).
+* `unmeasured` — never coerced to 0.
+
+**Quote `waited_source` whenever you quote a duration.** A `first_seen` row that reads
+`6h10m` is saying "at least this long", not "exactly this long".
+
+### 5. Visible ≠ uncovered — "open it" and "reveal it" are different acts
+A window can be the **active window of its session, displayed on the base terminal,
+and still invisible** under `display-popup` overlays.
+
+* base terminal → `TERM=alacritty` (measured live: 312x64 and 103x64)
+* popup → `TERM=tmux-256color`, smaller (measured live: 247x49)
+
+The discriminator is the **TERM name**, not the size — a resized terminal must not be
+reclassified. `visible: true, covered: true` means *it is already on screen underneath
+a popup*: the fix is to dismiss the popup, not to switch to the window. Telling the
+operator to "open it" there is the wrong instruction and looks like the right one.
+
+### 6. Codename and hotkey come from ONE table — and case matters
+`scripts/tmux-scratch-slots.sh`, entries `session:key:colour:codename`. The 20 tmux
+`bind -n M-<key>` popup toggles are **generated from that file** at home-manager build
+time (`nix/programs/tmux/default.nix`). Verified live against `tmux list-keys`:
+
+| | |
+|---|---|
+| `Alt+p` | `scratch5` — **poppy** |
+| `Alt+Shift+P` | `scratch6` — **Pool** |
+
+Same letter, different session. **Never lowercase a hotkey.** A session with **no slot
+entry** (a repo-named session such as `datapacket-talos`) has **no codename and no
+hotkey** — its label falls back to the cwd, and none is invented. Read the table, never
+a private copy; the file's own header comment mentions an `$mod+Shift` i3 binding that
+does not exist — the tmux `Alt+<key>` bindings above are the live ones.
+
+### 7. Ambiguity is refused, not guessed
+A codename names a **session**, and a session has many windows: `Gold` resolved to
+**10** targets on one live run. Exit codes:
+
+| code | meaning | what to do |
+|---|---|---|
+| `0` | resolved | act |
+| `2` | **AMBIGUOUS** | it prints every candidate — pick an address `session:@window_id` or `session:index` |
+| `3` | **UNMATCHED** | check the `hosts consulted` block (see #3) before concluding it does not exist |
+
+**Branch on the exit code.** Do not parse the human output for a verdict, and never
+pick a candidate on the operator's behalf.
+
+### 8. `idle_no_signal` cannot tell blocked from finished
+session-manager does not read PRs. A window idle because its PR is blocked looks
+**exactly** like a window idle because the work is done. Both land in
+`idle_no_signal`, which is why `waiting-windows` ranks that band **last** and prints
+the caveat rather than filtering it out. **Report the ACTIONABLE count**
+(`trailing_question` + `selection_menu` + `context_exhausted`) separately from the
+total: one live run was `ACTIONABLE: 7 of 43 over threshold`, the other 36 being
+`idle_no_signal` whose titles mostly describe finished work. Sorting on time alone
+buries the rows actually asking a human, and `--top` then truncates them away.
+
+## Reading the output
+
+* `waiting-windows` bands by kind first, then time within a band:
+  `trailing_question`/`selection_menu` (a human is being asked, **now**) →
+  `context_exhausted` (needs `/compact` or a resume — batchable) → `idle_no_signal`.
+* `--top N` and `--kind` **always print what they dropped**. Say so when you use them.
+* `COVERAGE:` and the `CAVEAT` lines are part of the answer. A count from a scan that
+  walked nothing is `null`, never `0` — `counts.counts_are_partial` says whether any
+  scope went unmeasured, and `counts.per_host[<host>].measured` says which.
+
+## Handing it over
+
+Both tools are read-only by construction (`session-resolve` cannot emit a tmux write
+verb at all). So finish with the command, don't pretend to run it:
+
+```
+scratch2:@81 — Gold (G), selection_menu, waited 1d18h [ledger_age_fallback]
+  reveal: press Alt+Shift+G      (window is covered by a popup, not hidden)
+  or:     tmux select-window -t scratch2:@81
+```


### PR DESCRIPTION
## Why

`scripts/session-resolve` (#558) and `scripts/waiting-windows` both merged, both read-only, and **nothing makes either discoverable**. The failure they were built for is therefore still live: a question sat unanswered in a tmux window for **55 hours** while ~98 other prompts were answered in the same 22. The signal existed the whole time; nothing consumed it.

This PR is the routing half — one skill, `claude/skills/window-triage/SKILL.md`, 157 lines, one new file.

## What it deliberately does NOT do

**It does not restate either tool's `--help`.** One place for that, and it is the tool. The body opens by saying so and carries only what `--help` cannot say.

## The description, and why it cannot fire session-manager's cases

607 chars (cap 1,536; the listing loads every session and silently drops descriptions on overflow).

> Point at ONE tmux window by codename, hotkey or address (Gold, Alt+Shift+G, scratch2:@81) — refusing to guess when the selector is ambiguous — and rank the windows STRANDED past a threshold, longest-waited first, banded by kind. Read-only. Use for: which window is Gold, what does Alt+p open, which window has been stranded / unanswered for hours or days, the oldest unanswered question, a codename with no hotkey, why a window shows no harness record, what the scan could not cover. The live inventory — is anything waiting on me, what's running where, tail a window, unsent prompts — is `session-manager`.

The partition is by **question shape**, not by keyword overlap:

| `session-manager` owns | `window-triage` owns |
|---|---|
| the live INVENTORY — is anything waiting on me, what's running where, which windows are stale/idle/busy/blocked, tail a window, unsent prompts | naming ONE window — which window is `Gold`, what does `Alt+p` open, `@81` — and RANKING the stranded set past a threshold |

No token in one description appears as a routing phrase in the other. `window-triage` never says "waiting on me" / "waiting on a human" / "tail" / "unsent" / "what's running where"; `session-manager` never says codename, hotkey, slot, address, threshold, stranded, oldest, longest, coverage. The last sentence names `session-manager` explicitly so an inventory-shaped ask routes away.

## What the body carries — all re-measured live, not copied from the brief

1. **Two `waiting` states that disagree.** `waiting_probable` (pane TEXT looks like a question) vs the registry's `status` (harness waiting on a turn) — 3 vs 1 at one instant, zero overlap. No mapping exists; the skill forbids inventing one.
2. **Presence is four-valued** — and 🔴 **the two tools SPELL the fourth state differently.** Measured: `session-resolve` emits `harness_presence: "structurally_excluded"`; `waiting-windows` emits `harness_presence: "unmeasured"` + `harness_presence_reason: "remote_host"`. Both name the excluded hosts at `coverage.registry.hosts_not_covered`. Documented as a disagreement rather than papered over.
3. **`--host` defaults to `all`.** Verified live: `--host workbench` on a laptop window returns UNMATCHED. The report now names the out-of-scope host loudly, so the skill says to read that block before believing an UNMATCHED. `waiting-windows` has no `--host`.
4. **`age_secs` is not time-waited** — it is time since the last ledger heartbeat. All four `waited_source` values are enumerated, with the instruction to quote the source with every duration.
5. **Visible ≠ uncovered.** Measured live: base terminal `TERM=alacritty` (312x64, 103x64) vs popup `tmux-256color` (247x49). The discriminator is the TERM name, not the size. "Open it" and "reveal it" are different acts.
6. **Codename/hotkey come from `scripts/tmux-scratch-slots.sh`**, from which `nix/programs/tmux/default.nix` generates the tmux bindings. Verified against live `tmux list-keys`: `M-p` → `scratch5` (poppy), `M-P` → `scratch6` (Pool). A session with no slot entry has no codename and no hotkey.
7. **Ambiguity is refused.** `Gold` resolved to **10** targets live (exit 2). Exit codes 0/2/3 tabled, with "branch on the exit code, do not parse the human output".
8. **`idle_no_signal` cannot tell blocked from finished** — report ACTIONABLE separately. One live run: `ACTIONABLE: 7 of 43 over threshold`.

Plus: both tools are read-only by construction, so the skill closes by handing the operator a command rather than pretending to act.

## Verification

* `scripts/gate.sh --tier pytest --set hermetic` — `scripts/tests`: **1 failed, 5,840 passed**. The single failure is the **pre-existing** `test_opencode_engine.py` version pin (`opencode` 1.18.18 on PATH vs 1.18.16 pinned). **This branch changes 0 lines in that file** — the diff is one new file.
* Re-run on the rebased tree of the four skill/doc gates plus all four content gates: `test_doc_path_rot`, `test_skills_mapping_guard`, `test_skill_audit`, `test_prune_skill_size`, `test_no_client_hostnames`, `test_no_public_ips`, `test_no_captured_text`, `test_no_captured_markup` — **397 passed**.
* No test file added → **no `TARGET_FLOORS` change**, deliberately: that line took eleven values across eight PRs in one day and this change needs none of it.
* Frontmatter round-tripped through `scripts/opencode/generate-commands.py` (`parse_skill`) so the opencode command generator picks it up.
* `git add`ed explicitly — a new file the flake would otherwise silently omit.

## Refuted / corrected against the brief

* The brief described presence as one four-valued vocabulary shared by both tools. **Measured, it is not:** `waiting-windows` has only three tokens and spells the exclusion as `unmeasured` + `harness_presence_reason: "remote_host"`. The skill documents the disagreement.
* The brief said `Gold` matches 8 windows; live it was **10**. The skill quotes the measured number and dates it to a run rather than pinning a constant.
* The brief's field name for the reason is `presence_reason`; the emitted JSON key is **`harness_presence_reason`**.
* `counts_are_partial` is at `counts.counts_are_partial`, not top level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
