### PR TITLE
fix(opencode): the lock moved the binary to 1.18.18 — re-derive the claims, then re-key the pin

### DIFF
--- a/claude/opencode-addendum.md
+++ b/claude/opencode-addendum.md
@@ -32,7 +32,7 @@ bash guard.
 | search file contents | `grep` | `rg` / `grep` via bash |
 | see what is in a dir | `glob` on `<dir>/*` | `ls` |
 
-There is **no `list` tool** on opencode 1.18.16 — verified against the resolved
+There is **no `list` tool** on opencode 1.18.18 — verified against the resolved
 tool map, which contains exactly `bash, edit, glob, grep, invalid, question,
 read, skill, task, todowrite, webfetch, write`. Use `glob` to enumerate a
 directory.

--- a/flake.nix
+++ b/flake.nix
@@ -217,11 +217,11 @@
             # 🔴 This ALSO makes the sandbox the tier that pins the VERSION.
             # `pkgs.opencode` here and in nix/pkgs/tools/default.nix resolve from
             # the same flake.lock, so CI tests the exact binary the hosts deploy
-            # (1.18.16 at rev 044bfe75bfe4). Cost, stated as deliberately as the
+            # (1.18.18 at rev 5c680dac9f02). Cost, stated as deliberately as the
             # nodejs and nix entries above: this check's closure grows by
             # opencode, and a nixpkgs bump that moves it invalidates the cache
             # AND turns the version assertion red. That red is the point — the
-            # config header's "measured on v1.18.16 — do not re-derive" claims are
+            # config header's "measured on v1.18.18 — do not re-derive" claims are
             # otherwise pinned to nothing.
             #
             # logrotate: scripts/tests/test_claude_log_rotate.py drives the REAL

--- a/nix/pkgs/tools/default.nix
+++ b/nix/pkgs/tools/default.nix
@@ -12,17 +12,20 @@ with pkgs; [
   # hosts, which drifted: MEASURED 2026-08-02, laptop 1.18.4 / workbench 1.18.9,
   # each movable independently by a `nix profile upgrade` that nothing records.
   # scripts/opencode/opencode.jsonc documents a large set of load-bearing
-  # behaviours annotated "measured on v1.18.16 — do not re-derive" (last-match-
+  # behaviours annotated "measured on v1.18.18 — do not re-derive" (last-match-
   # wins permission ordering, the hidden title/summary/compaction agents
-  # inheriting the global permission block, the exact tool set, `ask` semantics
-  # under `opencode run`). Those claims were pinned to a version nothing pinned.
+  # inheriting the global permission block, the exact tool set). A few bullets
+  # there — `ask` semantics under `opencode run` among them — are explicitly
+  # CARRIED FORWARD at an older version instead, each saying so on its own line.
+  # Those claims were pinned to a version nothing pinned.
   #
-  # This entry pins them: MEASURED at flake.lock's nixpkgs rev 044bfe75bfe4,
-  # `pkgs.opencode` is 1.18.16 — store path
-  # /nix/store/rcrzfd71k96f1r55533lzc16p7ix3v22-opencode-1.18.16. (It was
-  # 1.18.4 at rev 9bc02893134c when this pin was introduced; the 2026-08-13
-  # bump re-derived the claims against the new binary rather than re-spelling
-  # them — see PINNED_VERSION in scripts/tests/test_opencode_engine.py.) A nixpkgs bump
+  # This entry pins them: MEASURED at flake.lock's nixpkgs rev 5c680dac9f02,
+  # `pkgs.opencode` is 1.18.18 — store path
+  # /nix/store/3y4zcklfn3hfk9gn08csfzd3vwfjhkl0-opencode-1.18.18. (It was
+  # 1.18.4 at rev 9bc02893134c when this pin was introduced, and 1.18.16 at rev
+  # 044bfe75bfe4; the 2026-08-13 and 2026-08-19 bumps each re-derived the claims
+  # against the new binary rather than re-spelling them — see PINNED_VERSION in
+  # scripts/tests/test_opencode_engine.py.) A nixpkgs bump
   # that moves it now shows up as a flake.lock diff AND fails
   # scripts/tests/test_opencode_engine.py's version assertion, which is the
   # prompt to re-derive the header's measurements rather than let them rot.

--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -1864,13 +1864,15 @@ field** (the CDP ops are bounded typed ops only; see the CDP security model abov
   Because the gate runs **before** the tab is opened, a gate failure leaks no tab.
 
   *Prerequisite:* an opencode whose `debug agent` reports a browser-only tool set.
-  **Both hosts run 1.18.16 and both resolve browser-only** (verified: the dump
-  parses to exactly one enabled tool, `browser`). There is no version-skew caveat
-  here any more. The hosts CONVERGED on 2026-08-15 — `ship.sh` verified at the
-  consumer, both `readlink -f $(command -v opencode)` resolving to the same
-  `…-opencode-1.18.16` store path — so the pin and the deploy now agree. The
-  browser-only resolution was measured identical on 1.18.4 and 1.18.16, so the
-  bump did not change it. 🔴 The RAW dump is NOT byte-stable, on either binary: the
+  **Both hosts run 1.18.18 and both resolve browser-only** (verified 2026-08-19:
+  the gate replicated ON EACH HOST parses to exactly one enabled tool, `browser`,
+  with every host tool present and `false`). There is no version-skew caveat
+  here any more. The hosts CONVERGED on 2026-08-15 and the pin's move to 1.18.18
+  had reached both before it was re-keyed — verified at the consumer, both
+  `readlink -f $(command -v opencode)` resolving to the same
+  `…-opencode-1.18.18` store path — so the pin and the deploy agree. The
+  browser-only resolution was measured identical on 1.18.4 and 1.18.16, and again
+  on the 1.18.18 binary, so no bump has changed it. 🔴 The RAW dump is NOT byte-stable, on either binary: the
   `permission` array's order follows a directory walk and varies run to run, so
   `cmp` on two dumps differs for reasons that have nothing to do with the version.
   Compare the resolved tool set, or canonicalise first. So the deploy gap does not
@@ -1963,7 +1965,7 @@ ln -sf ~/workspace/devrc/scripts/browser-bridge/opencode/tools/browser_tool_impl
 the wrapper substitutes them per run.)
 
 **opencode version.** The custom-tool mechanism (`.opencode/tools/*.js`,
-`permission: {"*": deny, …}`) is **verified on 1.18.16, which is what BOTH hosts
+`permission: {"*": deny, …}`) is **verified on 1.18.18, which is what BOTH hosts
 run and what `flake.lock` pins** (measured identical on 1.18.4 before the bump) — `opencode debug agent
 browser-agent` resolves to `bash:false … browser:true`
 (exactly one enabled tool) on each, plus an end-to-end `opencode debug agent …

--- a/scripts/browser-bridge/reference/agent.md
+++ b/scripts/browser-bridge/reference/agent.md
@@ -26,9 +26,9 @@ command unrunnable, which is why fixing the first didn't appear to help:
    be reached. Fixed by probing without injecting.
 
 🔴 **Every doc misattributed both symptoms to an opencode *version* problem for the
-entire arc.** They are not version-related — both hosts run 1.18.16 and both
-resolve browser-only, and the same resolution was measured on 1.18.4 before the
-bump. Do not re-open that hypothesis.
+entire arc.** They are not version-related — both hosts run 1.18.18 and both
+resolve browser-only, and the same resolution was measured on 1.18.4 and 1.18.16
+before the bumps. Do not re-open that hypothesis.
 
 ✅ **The `browser agent`-first default IS shipped** (SKILL.md → `## FIRST DECISION`).
 It was held back until capability was measured rather than argued from token
@@ -174,9 +174,9 @@ browser agent "go to news.ycombinator.com and report the top 3 story titles" \
   fail-closed property is *verified at runtime* rather than trusted — on any
   opencode where the host-tool denial didn't take, `browser agent` refuses instead
   of running the model unconfined. The gate runs BEFORE the tab is opened, so a
-  gate failure leaks no tab. **Both hosts run 1.18.16 and both resolve
-  browser-only**, and it resolved identically on 1.18.4 before the bump — there
-  is no version-skew caveat.
+  gate failure leaks no tab. **Both hosts run 1.18.18 and both resolve
+  browser-only**, and it resolved identically on 1.18.4 and 1.18.16 before the
+  bumps — there is no version-skew caveat.
   - ⚠ **If you check the gate by hand, redirect to a FILE**
     (`opencode debug agent browser-agent > /tmp/gate.json`), never a pipe or
     `$(...)`: opencode doesn't reliably flush stdout before exiting into a pipe, so

--- a/scripts/opencode/README.md
+++ b/scripts/opencode/README.md
@@ -85,11 +85,11 @@ action is irreversible, add a check to `guard_core.py`'s `"opencode"` policy.
 ### Why `tool.execute.before` and not `permission.ask`
 
 Measured on 1.18.4, this host, 2026-08-02. 🔴 Still 1.18.4 on purpose: the
-2026-08-13 re-derivation to 1.18.16 covered the resolved permissions, tool sets
-and resolver ordering (see `PINNED_VERSION` in
-`scripts/tests/test_opencode_engine.py`), but **not** the two hook claims below —
-those need a running hook to observe and were not re-measured. Treat them as
-last confirmed on 1.18.4.
+2026-08-13 re-derivation to 1.18.16, and the 2026-08-19 one that followed it,
+covered the resolved permissions, tool sets and resolver ordering (see
+`PINNED_VERSION` in `scripts/tests/test_opencode_engine.py`), but **not** the two
+hook claims below — those need a running hook to observe and were not
+re-measured by either. Treat them as last confirmed on 1.18.4.
 
 - `permission.ask` **is** in the `Hooks` type and its `output.status` is typed
   `"ask" | "deny" | "allow"`, so an *ask* decision looks expressible. It is not:
@@ -219,7 +219,7 @@ existence guard**, and defined a `KC_PROD` that zsh did not have. Add a handle i
   (`*.env` → ask); a blanket allow is appended after it and silently defeats it
   on every agent. The default already allows every non-`.env` read, so the
   correct configuration is to say nothing.
-- **There is no `list` tool and no `websearch` tool** on 1.18.16. The resolved set
+- **There is no `list` tool and no `websearch` tool** on 1.18.18. The resolved set
   is exactly {bash, edit, glob, grep, invalid, question, read, skill, task,
   todowrite, webfetch, write}. Naming a nonexistent tool is a silent no-op that
   reads like configuration.
@@ -244,10 +244,12 @@ existence guard**, and defined a `KC_PROD` that zsh did not have. Add a handle i
   global `"task": "allow"` is appended after it and flips it, which hands `plan`
   a shell by delegation (the `general` subagent has one). It is restated at agent
   level.
-- **Deprecated on 1.18.16, deliberately absent:** agent-level `tools`, `mode` at
-  config level, `layout`, `autoshare`, `reference` (now `references`),
-  `maxSteps` (now `steps`). `theme`/`keybinds`/`tui` live in a separate
-  `~/.config/opencode/tui.json`.
+- **Deprecated, deliberately absent** — a config-SCHEMA claim about keys this
+  repo does not set, which the resolved `debug agent` dumps cannot see, so it was
+  carried forward at the bump rather than relabelled; last measured on 1.18.16:
+  agent-level `tools`, `mode` at config level, `layout`, `autoshare`,
+  `reference` (now `references`), `maxSteps` (now `steps`).
+  `theme`/`keybinds`/`tui` live in a separate `~/.config/opencode/tui.json`.
 
 ### Known limitation: in-session "always allow"
 

--- a/scripts/opencode/agent/k8s.md
+++ b/scripts/opencode/agent/k8s.md
@@ -8,7 +8,7 @@ permission:
   write: deny
   # 🔴 NO `"*": allow` HERE. Agent rules are APPENDED AFTER the global block and
   # opencode is LAST-MATCH-WINS, so an agent-level wildcard NULLIFIES every
-  # global deny/ask at a stroke. Measured on 1.18.16: with `"*": allow` present
+  # global deny/ask at a stroke. Measured on 1.18.18: with `"*": allow` present
   # it landed at index 74, after all 30 global rules, and only the 4 rules below
   # it survived — `git stash`, `git reset --hard`, `git add -A`, `rm -rf ~…`,
   # `sops -d`, `nixos-rebuild` and `home-manager switch` were all plain ALLOW on

--- a/scripts/opencode/agent/review.md
+++ b/scripts/opencode/agent/review.md
@@ -6,7 +6,7 @@ temperature: 0.1
 permission:
   edit: deny
   write: deny
-  # MEASURED on 1.18.16 (`opencode debug agent review`): the agent's bash rules
+  # MEASURED on 1.18.18 (`opencode debug agent review`): the agent's bash rules
   # are APPENDED AFTER the global block, so the resolved list is
   #   [0] allow *   … global asks/denies …   [N] deny *   [N+1…] these allows
   # Last-match-wins therefore makes [N] the effective default: any command that

--- a/scripts/opencode/opencode.jsonc
+++ b/scripts/opencode/opencode.jsonc
@@ -44,7 +44,7 @@
 // patterns has known bypasses, which is the whole reason layer 2 exists.
 //
 // ==========================================================================
-// Mechanics of layer 1 (measured on v1.18.16 — do not re-derive)
+// Mechanics of layer 1 (measured on v1.18.18 — do not re-derive)
 // ==========================================================================
 //
 // 🔴 PERMISSION ORDERING IS LOAD-BEARING AND IS THE INVERSE OF CLAUDE CODE.
@@ -70,24 +70,33 @@
 // that fires too often on a mutation family is a far better failure than an
 // `ask` that never fires on the spelling an operator actually types.
 //
-// Other measured facts baked into this file (v1.18.16):
-//   * `opencode run` AUTO-REJECTS an `ask` (it prints "auto-rejecting"); only
-//     the interactive TUI turns one into a prompt. `opencode debug agent
+// Other measured facts baked into this file (v1.18.18, EXCEPT where a bullet
+// says otherwise — the 2026-08-19 re-derivation could not reach three of them,
+// and a claim relabelled to a version nothing measured it on is worse than a
+// stale one, because it looks fresh):
+//   * `ask` SEMANTICS (NOT re-derived at the pin — last measured on v1.18.16;
+//     observing it needs a run that EXECUTES, which the engine tests refuse to
+//     do): `opencode run` AUTO-REJECTS an `ask` (it prints "auto-rejecting");
+//     only the interactive TUI turns one into a prompt. `opencode debug agent
 //     --tool` AUTO-APPROVES it. So `ask` means "friction for a human", never
 //     "a control on an unattended agent".
 //   * only a `"*": "deny"` removes a tool from the request schema; a narrow
 //     deny does not, and `"ask"` costs exactly what `"allow"` costs.
-//   * `small_model` drives TITLE GENERATION ONLY — not compaction. The real
-//     cheap-model lever is pinning the hidden title/summary/compaction agents
-//     in the `agent` block below.
+//   * `small_model` SCOPE (NOT re-derived at the pin, v1.18.16): it drives
+//     TITLE GENERATION ONLY — not compaction. The real cheap-model lever is
+//     pinning the hidden title/summary/compaction agents in the `agent` block
+//     below.
 //   * a tool listed in this global `permission` block is re-enabled on the
 //     HIDDEN title/summary/compaction agents too, whose stock tool set is
 //     EMPTY. Hence the explicit `"*": "deny"` on each of them below.
-//   * DEPRECATED in 1.18.16, deliberately absent: agent-level `tools`, `mode`
-//     (at config level), `layout`, `autoshare`, `reference` (now `references`),
-//     `maxSteps` (now `steps`). `theme`/`keybinds`/`tui` moved to a separate
-//     ~/.config/opencode/tui.json and are NOT set here.
-//   * there is NO `list` tool and NO `websearch` tool on 1.18.16. The real set is
+//   * DEPRECATED, deliberately absent — a config-SCHEMA claim about keys this
+//     file does NOT set, which the resolved `debug agent` dumps structurally
+//     cannot see, so it was carried forward at v1.18.16 rather than relabelled:
+//     agent-level `tools`, `mode` (at config level), `layout`, `autoshare`,
+//     `reference` (now `references`), `maxSteps` (now `steps`).
+//     `theme`/`keybinds`/`tui` moved to a separate ~/.config/opencode/tui.json
+//     and are NOT set here.
+//   * there is NO `list` tool and NO `websearch` tool on 1.18.18. The real set is
 //     exactly {bash, edit, glob, grep, invalid, question, read, skill, task,
 //     todowrite, webfetch, write}. Naming a nonexistent tool here is a no-op.
 {
@@ -178,7 +187,7 @@
     // — a blanket `"read": "allow"` here lands AFTER those and silently defeats
     // the `.env` guard on every agent. The default already allows everything
     // except `.env`, so there is nothing to add.
-    // `list` and `websearch` are absent because NO SUCH TOOLS EXIST on 1.18.16.
+    // `list` and `websearch` are absent because NO SUCH TOOLS EXIST on 1.18.18.
     "glob": "allow",
     "grep": "allow",
     "edit": "allow",

--- a/scripts/opencode/plugin/guard.js
+++ b/scripts/opencode/plugin/guard.js
@@ -20,9 +20,9 @@
 //
 // 🔴 WHY `tool.execute.before` AND NOT `permission.ask` (measured on opencode
 // 1.18.4, this host, 2026-08-02 — and STILL 1.18.4 on purpose: the 2026-08-13
-// re-derivation to 1.18.16 covered resolved permissions, tool sets and resolver
-// ordering, but NOT hook firing, which needs a running hook to observe. Last
-// confirmed on 1.18.4; see PINNED_VERSION in scripts/tests/test_opencode_engine.py):
+// re-derivation to 1.18.16, and the 2026-08-19 one after it, covered resolved
+// permissions, tool sets and resolver ordering, but NOT hook firing, which needs
+// a running hook to observe. Last confirmed on 1.18.4; see PINNED_VERSION in scripts/tests/test_opencode_engine.py):
 //   * `permission.ask` IS in the Hooks type and its `output.status` is typed
 //     `"ask" | "deny" | "allow"`, so returning an *ask* decision LOOKS
 //     expressible. It is not, for a guard: the hook never fired in any probe —

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -958,7 +958,7 @@ TARGET_FLOORS=(
   "scripts/collector/browser-ext/tests|12"
   "scripts/collector/opencode/tests|162"
   "scripts/dl-router/tests|942"
-  "scripts/browser-bridge/tests|469"
+  "scripts/browser-bridge/tests|622"
   "scripts/validation/tests|97"
   # 2026-08-12, initiative-scan's `gh_available` honesty flag: 381 -> 386
   # collected, +5 for the flag's probe/report/render cases in

--- a/scripts/tests/test_opencode_config.py
+++ b/scripts/tests/test_opencode_config.py
@@ -44,7 +44,7 @@ WHAT IS UNDER TEST (see scripts/opencode/README.md for the measurements):
      manual sweep into a standing assertion — after them, 10 of 77 survive, and
      all ten are non-bash tool rows.
 
-  3. The resolver model itself. opencode 1.18.16 resolves a permission by
+  3. The resolver model itself. opencode 1.18.18 resolves a permission by
      `findLast` over a FLAT ORDERED array (built-in defaults, then agent rules,
      then user config — later wins), matching with a hand-rolled glob→regex:
 
@@ -223,7 +223,7 @@ def agent_permission(name: str) -> dict:
 # --------------------------------------------------------------------------- #
 # 🔴 the resolver model
 #
-# Faithful port of opencode 1.18.16's `Wildcard.match` + the `findLast` resolver.
+# Faithful port of opencode 1.18.18's `Wildcard.match` + the `findLast` resolver.
 # See the module docstring for the verbatim source it was ported from and for
 # how it was validated against the real engine.
 # --------------------------------------------------------------------------- #
@@ -899,7 +899,12 @@ def test_no_agent_reopens_the_bash_wildcard_with_allow():
 
     An agent-level `bash: {"*": allow}` is appended AFTER the entire global
     block, so last-match-wins makes it nullify every global deny at a stroke.
-    Measured on 1.18.16: it landed at index 74 after all 30 global rules and left
+    Measured on 1.18.16 — a dated incident record, NOT re-derived at the pin:
+    the counts below describe a tree with 30 global bash rules and there are 65
+    today, so no fresh measurement could confirm this sentence. The STRUCTURAL
+    claim under it — an agent block is appended AFTER the whole global block —
+    IS re-derived, by test_opencode_engine.py's engine-vs-model conformance
+    tests. What was measured: it landed at index 74 after all 30 global rules and left
     only the 4 agent-local rules standing — `git stash`, `git reset --hard`,
     `rm -rf ~…`, `sops -d`, `nixos-rebuild` and `home-manager switch` were all
     plain ALLOW on the k8s agent.
@@ -1596,12 +1601,12 @@ def test_tool_level_permissions_are_pinned_exactly():
 
 @pytest.mark.parametrize("dead", ["list", "websearch"])
 def test_no_nonexistent_tools_in_permission_block(dead):
-    """There is no `list` and no `websearch` tool on 1.18.16. The resolved tool
+    """There is no `list` and no `websearch` tool on 1.18.18. The resolved tool
     map is exactly {bash, edit, glob, grep, invalid, question, read, skill,
     task, todowrite, webfetch, write}. Naming a nonexistent tool is a silent
     no-op that reads like configuration."""
     assert dead not in load_config()["permission"], (
-        f"{dead!r} is not a tool on opencode 1.18.16 — the key does nothing"
+        f"{dead!r} is not a tool on opencode 1.18.18 — the key does nothing"
     )
 
 
@@ -1649,9 +1654,17 @@ def test_plan_agent_is_genuinely_read_only():
 
 
 def test_no_deprecated_keys():
+    # 🔴 CARRIED FORWARD, not re-derived at the pin. Deprecation is a config-
+    # SCHEMA claim about keys this repo does not set, which the resolved
+    # `debug agent` dumps the engine tests compare are structurally unable to
+    # see. Relabelling it to the current pin would have made it look freshly
+    # measured; the version below is the one it was actually measured on.
     cfg = load_config()
     for dead in ("mode", "layout", "autoshare", "reference", "maxSteps", "theme", "keybinds", "tui"):
-        assert dead not in cfg, f"{dead!r} is deprecated on 1.18.16 and must not be set"
+        assert dead not in cfg, (
+            f"{dead!r} is deprecated (last measured on opencode 1.18.16, carried "
+            f"forward at the pin) and must not be set"
+        )
 
 
 def test_core_settings():
@@ -1802,7 +1815,7 @@ def test_nav_has_no_shell():
 def test_nav_is_kept_lean():
     """nav must not carry the skill catalogue or be able to recurse.
 
-    VERIFIED against `opencode debug agent nav` on 1.18.16: with these denies the
+    VERIFIED against `opencode debug agent nav` on 1.18.18: with these denies the
     resolved tool set is exactly {glob, grep, read} (+ the internal `invalid`).
     Without `skill: deny` it also carries {skill, task, todowrite, webfetch} —
     and `skill` alone injects the whole catalogue, measured at ~3,730 tokens on
@@ -1817,7 +1830,7 @@ def test_nav_is_kept_lean():
 
 
 def test_no_agent_promises_a_list_tool():
-    """There is NO `list` tool on opencode 1.18.16."""
+    """There is NO `list` tool on opencode 1.18.18."""
     targets = [AGENT_DIR / f"{n}.md" for n in EXPECTED_AGENTS] + [ADDENDUM]
     bad = []
     for p in targets:

--- a/scripts/tests/test_opencode_engine.py
+++ b/scripts/tests/test_opencode_engine.py
@@ -11,7 +11,7 @@ duplicate of it).
   That is a real gap, and it is exactly the gap the version pin exists to cover:
   a config whose keys are unchanged can have its RESOLVED MEANING changed by the
   binary underneath it. opencode.jsonc's header documents a large set of
-  behaviours annotated "measured on v1.18.16 — do not re-derive" — last-match-
+  behaviours annotated "measured on v1.18.18 — do not re-derive" — last-match-
   wins ordering, hidden agents inheriting the global permission block, the exact
   tool set. A static test cannot see any of those change. This file runs the
   real engine and checks them.
@@ -44,7 +44,8 @@ front, not a silent skip deep in the run. `_opencode_bin()` below calls
 pytest.fail(), never pytest.skip() — the same choice, for the same reason, as
 `nix_eval()` in test_opencode_config.py. This file adds 22 tests and 0 skips
 (MEASURED 2026-08-11, `pytest -q`: "22 passed", ~7 s, in BOTH tiers — the
-dev-host nix-shell and `nix build .#checks.x86_64-linux.pytests`).
+dev-host nix-shell and `nix build .#checks.x86_64-linux.pytests`). Still 0 skips;
+the count is 25 as of 2026-08-19.
 
 🔴 STDOUT IS READ FROM A FILE, NEVER A PIPE. opencode loses the tail of a large
 stdout write when stdout is a pipe, silently and with exit 0. That cost this file
@@ -90,10 +91,55 @@ ROOT = Path(__file__).resolve().parents[2]
 OC_DIR = ROOT / "scripts" / "opencode"
 TOOLS_NIX = ROOT / "nix" / "pkgs" / "tools" / "default.nix"
 
-# 🔴 THE PIN. Every "measured on v1.18.16" claim in opencode.jsonc's header, in
+# 🔴 THE PIN. Every "measured on v1.18.18" claim in opencode.jsonc's header, in
 # scripts/opencode/README.md and in test_opencode_config.py's docstrings is keyed
 # to this exact version. It is pinned declaratively by nix/pkgs/tools/default.nix
 # resolving `pkgs.opencode` out of flake.lock's nixpkgs.
+#
+# 🔴 RE-DERIVED AGAIN 1.18.16 -> 1.18.18 (2026-08-19), by the SAME method as the
+# 2026-08-13 pass below, after `chore(flake): bump nixpkgs and home-manager`
+# moved the lock underneath the pin. What was measured:
+#
+#   * `debug agent <a> --pure` dumped for ALL SEVEN agents under BOTH the
+#     outgoing and the incoming binary, from a config dir seeded out of this
+#     repo, canonicalised, with the harness's OWN per-run TMPDIR normalised out
+#     of the generated `external_directory` rules. IDENTICAL on every agent
+#     except `compaction`, whose `prompt` — opencode's own built-in text, which
+#     nothing in this repo sets — moved upstream. Permissions (as a set AND in
+#     ORDER), the resolved tool map INCLUDING its key set, and the model:
+#     identical on all seven.
+#   * The four primaries' ORDERED bash rule arrays, compared position by
+#     position: equal, at 65 / 66 / 67 / 92 rules. Last-match-wins ordering is
+#     exactly what that comparison pins, and it did not move.
+#   * CONTROLS, reported as a PAIR rather than as a bare "identical":
+#       - same-binary control — two runs of the incoming binary collapse to
+#         identical for all seven agents. Before the TMPDIR normalisation they
+#         did NOT, and that is what proved the only cross-version "difference"
+#         was harness noise rather than a resolver change.
+#       - comparator negative control — flipping one boolean in one dump makes
+#         the comparator report a difference, so "identical" is not a comparator
+#         wired to nothing.
+#   * The browser-only tool-set gate (scripts/browser-bridge/browser-agent's
+#     fail-closed `debug agent browser-agent` check) replicated against BOTH
+#     binaries and on BOTH hosts: exactly one enabled tool, `browser`, with
+#     every host tool present and false.
+#   * Both hosts verified AT THE CONSUMER on 2026-08-19: `readlink -f $(command
+#     -v opencode)` resolves to the same incoming store path on each.
+#
+# NOT covered by the 2026-08-19 pass, and deliberately still keyed to the
+# OUTGOING version. Each carries its own in-place marker and a
+# HISTORICAL_VERSION_CLAIMS entry, so none of them was silently relabelled:
+#   * `ask` semantics under `opencode run` / `debug agent --tool` — observing
+#     them needs a run that EXECUTES, which this file refuses to do (see the
+#     `--tool` note in the module docstring).
+#   * `small_model` drives title generation only.
+#   * the DEPRECATED-key list — a config-SCHEMA claim about keys this repo does
+#     not set, which the resolved dumps cannot see.
+#   * the k8s "index 74 after all 30 global rules" incident record, whose counts
+#     describe a tree that no longer exists (65 global bash rules today), so no
+#     fresh measurement could confirm that sentence. The STRUCTURAL claim under
+#     it — agent rules are appended AFTER the whole global block — IS re-derived,
+#     by the engine-vs-model conformance tests below.
 #
 # 🔴 RE-DERIVED 1.18.4 -> 1.18.16 (2026-08-13), not merely re-spelled. What was
 # actually measured, and how, so a future bump can repeat it rather than trust it:
@@ -121,9 +167,9 @@ TOOLS_NIX = ROOT / "nix" / "pkgs" / "tools" / "default.nix"
 # hook-behaviour claims (`permission.ask` never fires, `tool.execute.before` does)
 # in scripts/opencode/README.md and scripts/opencode/plugin/guard.js. Those need
 # a running hook to observe and were not re-measured here.
-PINNED_VERSION = "1.18.16"
+PINNED_VERSION = "1.18.18"
 
-# MEASURED via `opencode debug agent nav --pure` at 1.18.16. This is the cost AND
+# MEASURED via `opencode debug agent nav --pure` at 1.18.18. This is the cost AND
 # blast-radius pin that test_opencode_config.py's `test_nav_is_kept_lean` only
 # asserts about the CONFIG KEYS; here it is read off the engine's resolved tool
 # map. `skill` alone injects the ~3,730-token catalogue on every request.
@@ -708,8 +754,19 @@ assert PINNED_VERSION.rsplit(".", 1)[0] in OPENCODE_SERIES, (
     "surviving claim in the previous series invisible on the same day the pin stops "
     "matching it."
 )
+# 🔴 THE TRAILING-DOT BLIND SPOT, found by the 2026-08-19 bump. The lookahead
+# used to be `(?![\d.])`, which rejects a version at the END OF A SENTENCE,
+# because the full stop is itself a `.`. That is not a corner case: it hid FIVE
+# stale claims in the pin's own surface across four files, including the store
+# path in nix/pkgs/tools/default.nix — i.e. exactly the class this test exists to
+# catch, in exactly the file that implements the pin. `(?!\d|\.\d)` keeps both
+# jobs the old form was doing — it still refuses to match a version that is only
+# a PREFIX of a longer number — while admitting terminal punctuation. Both
+# directions are pinned by
+# test_the_version_scanner_sees_a_version_at_the_end_of_a_sentence below, whose
+# fixtures are BUILT rather than spelled for exactly the reason this comment is.
 _VERSION_RE = re.compile(
-    r"(?<![\d.])(?:" + "|".join(re.escape(s) + r"\.\d+" for s in OPENCODE_SERIES) + r")(?![\d.])"
+    r"(?<![\d.])(?:" + "|".join(re.escape(s) + r"\.\d+" for s in OPENCODE_SERIES) + r")(?!\d|\.\d)"
 )
 
 # (path, snippet on the SAME LINE as the version, why it does not track the pin)
@@ -741,8 +798,20 @@ HISTORICAL_VERSION_CLAIMS = (
      "heads the hook-behaviour block; deliberately not re-derived"),
     ("scripts/opencode/README.md", 'startup files" is **FALSE on this host**',
      "zsh-startup-files claim — not re-derived"),
-    ("scripts/tests/test_opencode_engine.py", "RE-DERIVED",
-     "names the transition itself"),
+    # 🔴 Newly VISIBLE, not newly stale: this line ends its sentence with the
+    # version, and the scanner's old lookahead could not see a version followed
+    # by a full stop. It was always a historical claim; it just never reached the
+    # ledger. See the TRAILING-DOT BLIND SPOT note on _VERSION_RE.
+    ("scripts/opencode/README.md", "Treat them as last confirmed on",
+     "hook-behaviour claims — need a running hook to observe, not re-derived"),
+    # 🔴 This snippet used to be the bare word "RE-DERIVED", which stopped being
+    # unique the moment a SECOND re-derivation record was added above it — and
+    # `test_every_historical_version_claim_still_exists` requires exactly one
+    # match. Both entries are now keyed on text only their own line carries.
+    ("scripts/tests/test_opencode_engine.py", "not merely re-spelled",
+     "names the 2026-08-13 transition itself"),
+    ("scripts/tests/test_opencode_engine.py", "RE-DERIVED AGAIN",
+     "names the 2026-08-19 transition itself"),
     ("scripts/tests/test_opencode_engine.py", "deliberately still keyed to",
      "the pin's own note naming the not-re-derived subset"),
     ("scripts/tests/test_opencode_engine.py", "MEASURED 2026-08-11 on the workbench, opencode",
@@ -786,6 +855,8 @@ HISTORICAL_VERSION_CLAIMS = (
     # nothing re-derived it, because it needs an all-tools-denied agent making a
     # real model call. Reverted to the version it was actually measured on. Fixing
     # a consistency complaint by making a claim FALSE is the worse trade.
+    ("scripts/tests/test_opencode_engine.py", "on the first audit's consistency advice",
+     "this ledger's own account of the version that claim was wrongly re-spelled to"),
     ("claude/opencode-addendum.md", "NOT re-derived",
      "@-import claim — needs a live model call, never re-measured"),
     ("nix/home.nix", "NOT re-derived since — it needs a live model call",
@@ -794,13 +865,35 @@ HISTORICAL_VERSION_CLAIMS = (
      "@-import claim, third copy"),
     ("scripts/tests/test_opencode_config.py", "NOT re-derived since — needs a live model call",
      "@-import claim, fourth copy"),
+    # 🔴 CARRIED FORWARD AT THE 2026-08-19 BUMP, not re-derived. Each of these
+    # was left at the OUTGOING version on purpose, with an in-place marker on the
+    # same line saying so. An unverifiable claim relabelled to a new version is
+    # WORSE than a stale one, because it looks fresh — that is the trade the
+    # @-import entries above already record, and these are the same trade.
+    ("scripts/opencode/opencode.jsonc", "`ask` SEMANTICS (NOT re-derived at the pin",
+     "`ask` semantics under `opencode run` — needs a run that EXECUTES"),
+    ("scripts/opencode/opencode.jsonc", "`small_model` SCOPE (NOT re-derived at the pin",
+     "which code path `small_model` drives — not observable in a resolved dump"),
+    ("scripts/opencode/opencode.jsonc", "cannot see, so it was carried forward at v",
+     "the DEPRECATED-key list — a config-SCHEMA claim the dumps cannot see"),
+    ("scripts/opencode/README.md", "carried forward at the bump rather than relabelled; last measured on",
+     "the DEPRECATED-key list, second copy"),
+    ("scripts/opencode/README.md", "and the 2026-08-19 one that followed it,",
+     "names the transitions whose hook claims were NOT re-derived"),
+    ("scripts/opencode/plugin/guard.js", "and the 2026-08-19 one after it, covered resolved",
+     "same, in the plugin's own copy of that note"),
+    ("scripts/tests/test_opencode_config.py", "a dated incident record, NOT re-derived at the pin",
+     "the k8s index-74 record; its counts describe a tree that no longer exists"),
+    ("scripts/tests/test_opencode_config.py", "is deprecated (last measured on opencode",
+     "the DEPRECATED-key list, third copy — in the assertion message"),
     # 🔴 THE DEPLOYED-STATE EXEMPTIONS ARE GONE, and their absence is the record.
     # Five lines said "both hosts run 1.18.4" — TRUE while the lock pinned 1.18.16
     # and the hosts had not converged, which is exactly why they were exempt
-    # rather than wrong. `ship.sh` converged both on 2026-08-15, verified at the
-    # CONSUMER (both `readlink -f $(command -v opencode)` resolve to the same
-    # …-opencode-1.18.16 store path), so those lines now carry the pinned version
-    # and need no exemption.
+    # rather than wrong. `ship.sh` converged both on 2026-08-15, and the lock's
+    # move to the CURRENT pin had reached both before this PR — re-verified at the
+    # CONSUMER on 2026-08-19 (both `readlink -f $(command -v opencode)` resolve to
+    # the same …-opencode-1.18.18 store path), so those lines now carry the pinned
+    # version and need no exemption.
     #
     # The ledger caught its own obsolescence: the moment the lines were updated,
     # all five entries orphaned and the suite went red. That is the SHRINK
@@ -866,6 +959,44 @@ def test_every_historical_version_claim_still_exists():
         "HISTORICAL_VERSION_CLAIMS is a LEDGER and it no longer matches the tree "
         "one-for-one:\n" + "\n".join(orphans)
     )
+
+
+def test_the_version_scanner_sees_a_version_at_the_end_of_a_sentence():
+    """🔴 REGRESSION. `_VERSION_RE` is the INSTRUMENT the two ledger tests above
+    read their verdict from, so it gets validated before either verdict is
+    believed — a scanner that cannot see a whole shape reports a confident clean.
+
+    Its lookahead used to be `(?![\\d.])`, which silently REFUSED to match a
+    version followed by a full stop. Measured at the bump this test was written
+    for: FIVE stale claims inside the pin's own surface were invisible to it,
+    across four files, including the store path in nix/pkgs/tools/default.nix.
+
+    Both directions are asserted together, so this cannot be satisfied by
+    widening the pattern until everything matches: terminal punctuation must be
+    seen, and a version that is a PREFIX of a longer number must not be.
+
+    🔴 The fixtures are BUILT from PINNED_VERSION and the series constant, never
+    spelled. A literal here would be scanned as a stale claim by the very test
+    above, and an allowlist exemption for a test fixture is a hole nobody should
+    have to reason about later.
+    """
+    v = PINNED_VERSION
+    old = OPENCODE_SERIES[0] + ".0"      # in-series, and never the pin
+    assert old != v
+    for text, expected in ((f"measured on {old}.", old),        # end of sentence
+                           (f"…-opencode-{old}. (It was", old),  # the store-path line
+                           (f"on v{v} with", v),                 # leading `v`
+                           (f"({old})", old),                    # closing paren
+                           (f"{v},", v)):                        # comma
+        assert _VERSION_RE.findall(text) == [expected], (
+            f"the scanner does not see {expected!r} in {text!r} — while that is "
+            f"true, every claim it reports clean is unproven"
+        )
+    for text in (f"{v}6", f"{v}.2", f"1{v}"):
+        assert v not in _VERSION_RE.findall(text), (
+            f"the scanner matched {v!r} as a PREFIX inside {text!r}; widening "
+            f"the lookahead must not cost the prefix rejection"
+        )
 
 
 def test_opencode_is_declared_in_the_nix_package_set():
@@ -940,7 +1071,7 @@ def test_engine_and_model_agree_on_every_pinned_command(engine_name, model_agent
 # --------------------------------------------------------------------------- #
 def test_engine_resolves_navs_tool_set_to_exactly_the_pinned_four():
     """test_opencode_config.py's `test_nav_is_kept_lean` docstring says "VERIFIED
-    against `opencode debug agent nav` on 1.18.16: the resolved tool set is
+    against `opencode debug agent nav` on 1.18.18: the resolved tool set is
     exactly {glob, grep, read} (+ the internal `invalid`)" — but that file
     asserts only the CONFIG KEYS, so the verification was a one-off nobody
     re-ran. This re-runs it every gate.


### PR DESCRIPTION
## What was red

`scripts/tests/test_opencode_engine.py::test_engine_is_the_version_every_measurement_is_keyed_to`, on `main`, since `8f2958f chore(flake): bump nixpkgs and home-manager` moved opencode **1.18.16 → 1.18.18** without re-keying the measurements it pins.

The test's own message forbids the one-line fix, and it is right to: bumping `PINNED_VERSION` alone would relabel a set of unverified claims as *"measured on 1.18.18"*.

## Red → green matrix

| tree | result |
|---|---|
| `origin/main` (clean worktree, `nix develop .#checks.x86_64-linux.pytests`) | **1 failed, 23 passed** — the failure is exactly the version assertion at line 605 |
| HEAD | **25 passed** (24 existing + 1 new regression test) |

Whole-file runs at HEAD, no `-x`:

- `scripts/tests/test_opencode_config.py` + `scripts/browser-bridge/tests/test_browser_session_id.py` — **666 passed**
- `scripts/browser-bridge/tests` (full suite) — **654 passed**
- `scripts/tests` (full directory) — **5842 passed**

The full hermetic gate was deliberately **not** run — the box is contended and the merged tree is gated separately.

## What was re-derived, and with which controls

All against the binary the flake now provides, resolved **from the flake** (`nix develop .#checks…` → `/nix/store/3y4zcklfn3hfk9gn08csfzd3vwfjhkl0-opencode-1.18.18`), not from `$PATH`. The outgoing `…-opencode-1.18.16` store path was still present, so every comparison is genuinely two-sided.

**1. The resolved engine state — the claim the pin exists for.**
`opencode debug agent <a> --pure` dumped for **all seven agents** (4 primaries + 3 hidden) under **both** binaries, from a config dir seeded out of this repo, canonicalised (every array sorted).

- **IDENTICAL on every agent** except `compaction`'s `prompt` — opencode's own built-in text, which nothing in this repo sets.
- Permissions **as a set and in ORDER**, the resolved tool map **including its key set**, and the model: identical on all seven.
- The four primaries' **ordered** bash rule arrays compared position by position: equal, at 65 / 66 / 67 / 92 rules. Last-match-wins ordering is exactly what that pins.
- No `list` tool, no `websearch` tool, on either binary — with a **positive control** (`read` present on both) so a uniform "absent" is not a map read as empty.

Controls, reported as pairs rather than as a bare "identical":

- **same-binary control** — two runs of 1.18.18 collapse to identical for all seven agents. Before the TMPDIR normalisation they did **not**, which is precisely what proved the only cross-version "difference" (paths inside the generated `external_directory` rules) was harness noise rather than a resolver change.
- **comparator negative control** — flipping one boolean in one dump makes the comparator report a difference, so "identical" is not a comparator wired to nothing.

**2. 🔴 The `OPENCODE="1"` middleware claim — the one PR #549 depends on. IT STILL HOLDS.**

Verified against the real payload, `<store>/bin/.opencode-wrapped` (191 MB), not the 16 KB launcher.

```
POS control  grep -c 'OPENCODE_CONFIG_DIR'              = 6
NEG control  grep -c 'OPENCODE_NOT_A_REAL_VAR_XYZZY'    = 0
middleware   grep -c -F 'process.env.AGENT="1",process.env.OPENCODE="1",
                         process.env.OPENCODE_PID=String(process.pid)' = 1
```

Same three numbers on 1.18.16 (6 / 0 / 1), so the method is shown to be version-comparable. And the *structure* is what matters, not the presence of a string — the surrounding context confirms it is still a **top-level `.middleware()` registered before the `.command(...)` chain**:

```
.option("pure",…).middleware(async(D)=>{…E3.start(),process.env.AGENT="1",
process.env.OPENCODE="1",process.env.OPENCODE_PID=String(process.pid)})
.usage("").completion(…).command(m1).command(q1).command(c1)…
```

The consumer side is unchanged too: `ShellTool.shellEnv` still returns `{...process.env, ...b.env}` on 1.18.18, byte-identical to 1.18.16. **The deployed guard is not inert.** No edit was needed at `scripts/browser-bridge/browser:447`, `tests/test_browser_session_id.py:614` or `README.md:1429` — those name `PINNED_VERSION` rather than copying it, so they tracked the bump on their own.

**3. The browser-only fail-closed gate.**
`browser-agent`'s runtime tool-set gate replicated against **both binaries** and on **both hosts**: `rc=0`, exactly one enabled tool `browser`, every host tool (`bash`/`read`/`edit`/`write`/`webfetch`) present and `false`.

**4. Deployed state.**
Both hosts already resolve the new binary — verified at the consumer, not inferred: `readlink -f $(command -v opencode)` → the same `…-opencode-1.18.18` path on workbench and laptop. So the "both hosts run X" claims are re-keyed on measurement, not on the lock.

## What could NOT be re-derived — carried forward, not relabelled

Four claims are left at **1.18.16** on purpose. Each now carries an in-place marker saying so on its own line, plus a `HISTORICAL_VERSION_CLAIMS` ledger entry with the reason. An unverifiable claim relabelled to a new version is worse than a stale one, because it looks fresh.

| claim | where | why not re-derived |
|---|---|---|
| `ask` semantics: `opencode run` auto-rejects, `debug agent --tool` auto-approves | `opencode.jsonc` | observing it needs a run that **executes**, which the engine tests refuse to do by design |
| `small_model` drives title generation only | `opencode.jsonc` | which code path consumes it is not visible in a resolved dump |
| the DEPRECATED-key list | `opencode.jsonc`, `opencode/README.md`, `test_opencode_config.py` | a config-**schema** claim about keys this repo does not set; the dumps are structurally blind to it |
| the k8s "index 74 after all 30 global rules" record | `test_opencode_config.py:902` | its counts describe a tree with 30 global bash rules and there are **65** today, so no fresh measurement could confirm that sentence. The structural claim under it — an agent block is appended AFTER the whole global block — **is** re-derived, by the engine-vs-model conformance tests |

The hook-behaviour claims (`permission.ask` never fires, `tool.execute.before` does) stay keyed to **1.18.4** as before; the notes naming them now say neither the 08-13 nor the 08-19 pass re-measured them.

## Bonus: a blind spot this bump exposed

`_VERSION_RE`'s lookahead was `(?![\d.])`, which **rejects a version at the end of a sentence** — the full stop is itself a `.`. That is not cosmetic: it hid **five** stale claims inside the pin's own surface across four files, including the store path in `nix/pkgs/tools/default.nix`, i.e. exactly the class the test exists to catch, in exactly the file that implements the pin.

`(?!\d|\.\d)` admits terminal punctuation while still refusing a version that is only a prefix of a longer number. A new test, `test_the_version_scanner_sees_a_version_at_the_end_of_a_sentence`, pins both directions — its fixtures are **built** from `PINNED_VERSION` and the series constant rather than spelled, because a literal there would be scanned as a stale claim by the very test above it.

**Mutation-tested, not asserted.** Reverting the lookahead to `(?![\d.])` (under `PYTHONDONTWRITEBYTECODE=1`) makes that test fail with **its own** error — `the scanner does not see '1.18.0' in 'measured on 1.18.0.'` — on its **first** assertion, so it is reachable and not dying for another guard's reason. The `-k` filter was positive-controlled first: `1/25 tests collected (24 deselected)`.

## Scope

Twelve files, comments and docstrings plus one constant, one regex and one new test. `wip/opencode-kubectl-exec-allow` was not merged, absorbed or reconciled. No new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
