### PR TITLE
fix(gate): re-pin the browser-bridge floor — 654 tests stood against a floor of 469

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -958,6 +958,29 @@ TARGET_FLOORS=(
   "scripts/collector/browser-ext/tests|12"
   "scripts/collector/opencode/tests|162"
   "scripts/dl-router/tests|942"
+  # 2026-08-19, the DRIFT CEILING fired and #570 re-pinned this line to 622 as
+  # part of the opencode-pin fix, landing the VALUE with no accounting. This is
+  # that accounting. The gate had reported: 654 collected against a floor of
+  # only 469 — 185 above the FLOOR and 68 above the ceiling of
+  # 469 + max(60, 469/4) = 469 + 117 = 586. That is the ceiling doing its job,
+  # not a suite defect: every one of the 654 passes.
+  #
+  #   _suggested_floor 654 = 654 - min(50, max(1, 654/20)) = 654 - 32 = 622
+  #
+  # WHY IT DRIFTED: 469 was set at #397 (e1219d4), when the suite collected
+  # exactly 493. It grew 161 tests across the emulation, context/annotated-read,
+  # surface-parity, session-id and SKILL.md-size work — most recently #562's
+  # per-site `site_notes` routing and its ledger test — and was never re-pinned
+  # on the way, so the gap widened one PR at a time. At 469 a collapse of a
+  # QUARTER of this suite would have fitted under the floor and reported green.
+  # A floor that has fallen far behind is not a weak guard; it is an absent one
+  # that still prints a number.
+  #
+  # ⚠ ZERO new skips on this target (collected=654 passed=654 skipped=0).
+  # ⚠ Open PR #551 edits THIS line to 580 and is already CONFLICTING. Whoever
+  #   rebases it must re-run the gate on the MERGED tree and copy what it
+  #   prints — do NOT pick between 580 and 622, and do not reconcile the two by
+  #   arithmetic.
   "scripts/browser-bridge/tests|622"
   "scripts/validation/tests|97"
   # 2026-08-12, initiative-scan's `gh_available` honesty flag: 381 -> 386


### PR DESCRIPTION
## What fired

`scripts/browser-bridge/tests  collected=654 above drift ceiling 586, floor 469`

This is the ceiling doing its job, not a suite defect — **all 654 tests pass**. The gate is reporting that its own floor had gone stale enough to stop protecting anything.

| | drift = max(60, floor/4) | ceiling | 654 collected |
|---|---|---|---|
| floor **469** (before) | 117 | 586 | 68 over → FAIL |
| floor **622** (after) | 155 | 777 | inside → PASS |

## The number is not one I picked

`_suggested_floor` (`scripts/run-tests.sh:1184`) is the documented rule, and the failing run printed the replacement itself:

```
654 - min(50, max(1, 654/20)) = 654 - 32 = 622
```

## Why it drifted

The 469 was set at #397 (`e1219d4`), when the suite collected ~493. It has since grown ~161 tests — emulation, the context/annotated-read envelopes, surface parity, the session-id fix, the SKILL.md size gate, and most recently #562's per-site `site_notes` routing and its ledger test. Nobody re-pinned it on the way, so the gap widened one PR at a time.

That is exactly the failure the ceiling exists to catch. At 469, **a collapse of a quarter of the browser-bridge suite would have fitted underneath the floor and still reported green.** The asymmetry worth naming: a floor only catches a collapse if it sits near the real count. A floor that has fallen far behind is not a weak guard — it is an absent one that still prints a number.

## Verification

- `run-tests.sh --check-floors` (GUARD 3a — the two-way pin between the floor table and the target list): `RESULT: PASS`, floor 622 for this target.
- Arithmetic re-derived from the script's own formula in **both** directions: 469 fails above the ceiling, 622 passes, and 622 is exactly `suggested_floor(654)`.
- **Control run.** `test_run_tests_floors.py`, `test_run_tests_preconditions.py` and `test_drift_check.py` fail 11 tests when run outside the nix env — and fail the **identical 11** on unmodified `origin/main` (I diffed the failure sets). Pre-existing local-environment artifact, not introduced here. Inside the hermetic gate, `scripts/tests` has exactly one failure, the one below.

## This does not make the gate green

`scripts/tests` still fails one assertion: opencode on PATH is `1.18.18` while the repo's measurements are keyed to `1.18.16`. That is separate flake drift, and someone already has a worktree on `fix/opencode-pin-1.18.18`.

This PR removes **one of the two** reasons the gate is currently red for every contributor. Both needed fixing precisely because a permanently-red gate trains everyone to click through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
