### PR TITLE
feat(signal): a group MUTE LIST that hides without deleting — and the group-name bug it exposed

### DIFF
--- a/claude/skills/signal/SKILL.md
+++ b/claude/skills/signal/SKILL.md
@@ -34,7 +34,7 @@ code route and will raise `SendGateError`.
 | Routes | the three this module speaks (the server has many more): `GET /v1/receive/{number}` (a **websocket** in json-rpc mode), `GET /v1/attachments/{id}`, `POST /v2/send`. It has **no event-stream endpoint** — `/api/v1/events` belongs to AsamK's native daemon, a different server |
 | Postgres | `mailbox-postgres-0` in ns `mailbox`, schema **`signal`** (shares the instance + role with `mail`) |
 | Attachments | MinIO archive tenant, bucket `signal-attachments`, key `{conversation}/{YYYY-MM-DD}/{attachment_id}_{filename}` + a `.json` sidecar. The id is in the key deliberately — see gotchas |
-| Tables | `signal.contacts`, `signal.groups`, `signal.messages`, `signal.attachments`, `signal.reactions`, `signal.consumer_health` |
+| Tables | `signal.contacts`, `signal.groups`, `signal.messages`, `signal.attachments`, `signal.reactions`, `signal.consumer_health`, `signal.excluded_groups` |
 | Search | `signal.messages.search` — a STORED `to_tsvector('english', body)` generated column with a GIN index |
 
 ## Commands (`python3 scripts/signal/consumer.py <cmd>`)
@@ -50,6 +50,9 @@ code route and will raise `SendGateError`.
 | `approve` | record Zach's clawgate approval for one pending draft |
 | `send` | transmit an **approved** draft (refuses anything else) |
 | `reconcile` | resolve a draft stranded in `sending`, after checking Signal yourself |
+| `muted` | list muted groups and how many stored rows each one hides |
+| `mute` | hide a group from every read — **stores and deletes nothing** |
+| `unmute` | un-hide a muted group; restores it in full |
 
 ```bash
 cd ~/workspace/devrc/scripts/signal
@@ -66,14 +69,55 @@ python3 consumer.py reconcile 42 --sent --timestamp 1723000009090   # it did go 
 python3 consumer.py reconcile 42 --not-sent --note "no message in the thread"
 ```
 
+## Muted groups
+
+Some conversations are deliberately filtered out of every read. `signal.excluded_groups`
+holds the mute list; **the rows are still there** — muting hides, it never deletes, so
+`unmute` restores a conversation exactly. That is why it is the default: this pipeline is
+forward-only, so a deleted message can never be re-fetched.
+
+🔴 **It is keyed on the group's BINARY id, never the name** — `signal.groups.name` is
+empty (`''`) for every group this consumer has stored, so a name-based filter would match
+nothing while looking like it worked.
+
+```bash
+python3 consumer.py muted
+python3 consumer.py mute <internal_id> --note "why"     # base64, from the API below
+python3 consumer.py unmute <internal_id>
+```
+
+Get `internal_id` (base64) — the pipeline does not store group names, so this is the only
+way to go from a name you recognise to the id the mute list wants:
+```bash
+kubectl -n signal exec deploy/signal-consumer -- python3 -c "
+import os,json,urllib.request
+api=os.environ['SIGNAL_API_URL'].rstrip('/'); acct=os.environ['SIGNAL_ACCOUNT']
+for g in json.load(urllib.request.urlopen(api+'/v1/groups/'+acct,timeout=20)):
+    print(g['internal_id'], repr(g['name']))"
+```
+Pass `internal_id`, **not** `id` — `id` is the same value wrapped in a `group.`-prefixed
+second encoding, and `mute` refuses it rather than muting 32 bytes that match nothing.
+
+🔴 **The filter lives in `SignalDB`'s read methods, so RAW `psql` BYPASSES IT COMPLETELY** —
+an application predicate cannot bind a statement typed at a shell. So the body-printing
+one-liners below **carry the predicate inline**, as `$MUTED`; a warning above them would
+just be prose you scroll past while copying the query. Paste `$MUTED` into any new query
+that selects a body. Muting also does **not** stop ingest: the consumer keeps storing that
+group's messages, reactions and attachment bytes — it only stops READS returning them.
+
 Direct SQL (the store is authoritative):
 ```bash
 export KUBECONFIG=~/workspace/homelab-talos/homelab-kubeconfig
 PSQL='kubectl -n mailbox exec mailbox-postgres-0 -- psql -U mailbox -d mailbox -c'
-$PSQL "select count(*), max(message_timestamp) from signal.messages;"
+MUTED='not exists (select 1 from signal.excluded_groups x
+        join signal.groups gx on gx.group_id=x.group_id where gx.id=m.group_id)'
+
+$PSQL "select count(*), max(message_timestamp) from signal.messages;"   -- counts: unfiltered on purpose
 $PSQL "select m.message_timestamp, c.display_name, left(m.body,60) from signal.messages m
-       join signal.contacts c on c.id=m.source_contact_id order by m.message_timestamp desc limit 20;"
-$PSQL "select id, body from signal.messages where search @@ websearch_to_tsquery('english','permit');"
+       join signal.contacts c on c.id=m.source_contact_id
+       where ${MUTED} order by m.message_timestamp desc limit 20;"
+$PSQL "select m.id, m.body from signal.messages m
+       where m.search @@ websearch_to_tsquery('english','permit') and ${MUTED};"
 $PSQL "select count(*) from signal.reactions where message_id is null;"   -- unresolved
 ```
 

--- a/scripts/signal/_signal_db.py
+++ b/scripts/signal/_signal_db.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import re
 import socket
 import subprocess
 import time
@@ -222,6 +223,31 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
     )
     """,
 
+    """
+    -- 🔴 THE MUTE LIST. Rows named here are HIDDEN FROM READS, never dropped
+    -- from ingest and never deleted — see `not_excluded()` for the one predicate
+    -- that enforces it. Hiding rather than dropping is what makes the decision
+    -- REVERSIBLE: delete a row here and the whole conversation reappears, which
+    -- is impossible if the consumer had refused to store it (the pipeline is
+    -- forward-only, so nothing can re-fetch history it declined).
+    --
+    -- 🔴 KEYED ON THE SIGNAL BINARY GROUP ID, not on `signal.groups.id` and NOT
+    -- on the name. Two measured reasons, either one fatal on its own:
+    --   * `signal.groups.name` is EMPTY ('') for every group this consumer has
+    --     stored — it never captured names — so a name predicate matches nothing
+    --     and would read as a working filter that silently hides zero rows.
+    --   * the exclusion must be settable BEFORE the group has ever been seen;
+    --     a FK to `signal.groups(id)` cannot express "mute this from now on"
+    --     for a group with no row yet.
+    -- The binary id is the stable Signal identity and is what `signal.groups`
+    -- itself is UNIQUE on, so the join in `not_excluded()` is exact.
+    CREATE TABLE IF NOT EXISTS signal.excluded_groups (
+        group_id BYTEA PRIMARY KEY,
+        note TEXT,
+        created_at TIMESTAMPTZ DEFAULT now()
+    )
+    """,
+
     "CREATE INDEX IF NOT EXISTS idx_msg_ts ON signal.messages(message_timestamp DESC)",
     "CREATE INDEX IF NOT EXISTS idx_msg_dm ON signal.messages(source_contact_id, message_timestamp)",
     "CREATE INDEX IF NOT EXISTS idx_msg_group ON signal.messages(group_id, message_timestamp) WHERE group_id IS NOT NULL",
@@ -230,6 +256,46 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
     # The partial index that makes the unresolved-reaction sweep cheap (🔧 #3).
     "CREATE INDEX IF NOT EXISTS idx_rx_unresolved ON signal.reactions(target_author_id, target_sent_timestamp) WHERE message_id IS NULL",
 )
+
+
+# --------------------------------------------------------------------------- #
+# The mute predicate — ONE PLACE
+# --------------------------------------------------------------------------- #
+# 🔴 EVERY read that can surface message CONTENT must apply this, and it exists
+# exactly once so it cannot diverge between call sites. This pipeline has already
+# paid for the alternative: the reaction dict was open-coded at two sites and
+# that is WHY the sync site shipped without the guards the inbound site had.
+# A filter open-coded at three read sites would be wrong at two of them, in the
+# same direction, and the failure is SILENT — a leaked conversation looks
+# exactly like a conversation you meant to keep.
+#
+# `test_group_exclusions.py` pins the ledger of read methods against this
+# predicate and fails when that set GROWS or SHRINKS, so a new read surface
+# added without the filter is a red test rather than a quiet leak.
+_SAFE_ALIAS = re.compile(r"^[a-z][a-z0-9_]{0,15}$")
+
+
+def not_excluded(alias: str = "m") -> str:
+    """SQL predicate: `alias` is a `signal.messages` row NOT in a muted group.
+
+    Written as `NOT EXISTS` and never as `alias.group_id IS NULL OR ...` — the
+    OR form needs parenthesising at every call site to survive being ANDed onto
+    an existing WHERE clause, and forgetting those brackets at ONE site silently
+    widens that query to every row in the database. `NOT EXISTS` composes with
+    `AND` unconditionally and is already correct for a DM (`group_id IS NULL`
+    matches no exclusion row, so the predicate is true).
+
+    `alias` is interpolated, so it is validated against a strict whitelist — it
+    is always a literal from this module, and the whitelist keeps it that way.
+    Every VALUE in these queries is still a bound parameter.
+    """
+    if not _SAFE_ALIAS.match(alias):
+        raise ValueError(f"unsafe SQL alias: {alias!r}")
+    return (
+        "NOT EXISTS (SELECT 1 FROM signal.excluded_groups x "
+        "JOIN signal.groups gx ON gx.group_id = x.group_id "
+        f"WHERE gx.id = {alias}.group_id)"
+    )
 
 
 class SendGateError(RuntimeError):
@@ -685,7 +751,18 @@ class SignalDB:
                 INSERT INTO signal.groups (group_id, name, revision)
                 VALUES (%s, %s, %s)
                 ON CONFLICT (group_id) DO UPDATE SET
-                    name = COALESCE(EXCLUDED.name, groups.name),
+                    -- 🔴 NULLIF, not a bare COALESCE. The bind below is
+                    -- `name or ""` because the column is NOT NULL, so
+                    -- `EXCLUDED.name` is NEVER NULL — it is `''` — and the
+                    -- COALESCE that was here could therefore never fire. It was
+                    -- dead code that READ as protection: a later envelope for a
+                    -- known group carrying no name (a sync echo, an edit, a
+                    -- plain DELIVER frame with only `groupId`) overwrote the
+                    -- stored name with `''`, so a name would appear and then
+                    -- silently revert. Measured: a mutant deleting the whole
+                    -- COALESCE survived all 508 tests, because nothing could
+                    -- tell the two apart.
+                    name = COALESCE(NULLIF(EXCLUDED.name, ''), groups.name),
                     revision = GREATEST(EXCLUDED.revision, groups.revision)
                 RETURNING id
                 """,
@@ -948,6 +1025,58 @@ class SignalDB:
             out["frame_age_seconds"] = None if lf is None else (now - int(lf)) / 1000.0
             return out
 
+    # -- the mute list -----------------------------------------------------
+    def exclude_group(self, group_id: bytes, *, note: str | None = None) -> None:
+        """Mute a group by its Signal binary id. Idempotent; stores nothing else.
+
+        Accepts a group that has never been seen — the row is the intent, and
+        `not_excluded()` joins it to `signal.groups` only when one exists.
+        """
+        if not isinstance(group_id, (bytes, bytearray, memoryview)):
+            raise TypeError("group_id must be the raw Signal group id as bytes")
+        if not bytes(group_id):
+            raise ValueError("group_id is empty — that would mute nothing, silently")
+        with self._c.cursor() as cur:
+            cur.execute(
+                "INSERT INTO signal.excluded_groups (group_id, note) VALUES (%s, %s) "
+                # COALESCE, not a bare assignment: `mute <id>` with no --note is
+                # the natural way to re-issue a mute, and a bare assignment made
+                # that WIPE the recorded reason — destroying the only record of
+                # why, as a side effect of a command that changes nothing else.
+                # Pass a new --note to replace it; omit it to keep what is there.
+                "ON CONFLICT (group_id) DO UPDATE SET "
+                "note = COALESCE(EXCLUDED.note, excluded_groups.note)",
+                (bytes(group_id), note),   # raw bytes, exactly like upsert_group
+            )
+
+    def unexclude_group(self, group_id: bytes) -> int:
+        """Un-mute. Returns rows removed (0 when it was not muted).
+
+        This is the whole rollback story: the messages were never deleted, so
+        removing the row restores the conversation exactly.
+        """
+        with self._c.cursor() as cur:
+            cur.execute("DELETE FROM signal.excluded_groups WHERE group_id = %s",
+                        (bytes(group_id),))
+            return cur.rowcount
+
+    def list_excluded_groups(self) -> list:
+        """Muted groups, joined to `signal.groups` when the group is known.
+
+        `group_row_id` is None for a group muted before it was ever seen — an
+        ordinary state, not a dangling reference.
+        """
+        with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                "SELECT x.group_id, x.note, gx.id AS group_row_id, gx.name AS group_name, "
+                "(SELECT count(*) FROM signal.messages m WHERE m.group_id = gx.id) "
+                "AS hidden_message_count "
+                "FROM signal.excluded_groups x "
+                "LEFT JOIN signal.groups gx ON gx.group_id = x.group_id "
+                "ORDER BY gx.id"
+            )
+            return [dict(r) for r in cur.fetchall()]
+
     # -- reads -------------------------------------------------------------
     def list_conversations(self, limit: int = 50) -> list:
         """One row per CONVERSATION — a group, else the PEER of a DM.
@@ -958,10 +1087,15 @@ class SignalDB:
         row. The conversation key is therefore the group when there is one, and
         otherwise the OTHER PARTY — the destination for an outbound message, the
         sender for an inbound one.
+
+        Muted groups are filtered INSIDE the inner aggregate, so their rows never
+        reach `count(*)`/`max(timestamp)` at all. Filtering the outer query would
+        give the same visible answer today and would quietly stop doing so the
+        first time the grouping key widens.
         """
         with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
             cur.execute(
-                """
+                f"""
                 SELECT
                     conv.group_row_id,
                     g.name AS group_name,
@@ -980,6 +1114,7 @@ class SignalDB:
                         max(m.message_timestamp) AS last_message_timestamp,
                         count(*) AS message_count
                     FROM signal.messages m
+                    WHERE {not_excluded('m')}
                     GROUP BY 1, 2
                 ) conv
                 LEFT JOIN signal.groups g ON g.id = conv.group_row_id
@@ -995,15 +1130,17 @@ class SignalDB:
         """Full-text search over message bodies (the STORED tsvector + GIN index).
 
         The query text is a BOUND PARAMETER — never interpolated into SQL.
+        Muted groups (`signal.excluded_groups`) never appear in results.
         """
         with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
             cur.execute(
-                """
+                f"""
                 SELECT m.id, m.message_timestamp, m.body, m.is_outbound,
                        c.display_name, c.phone_number
                 FROM signal.messages m
                 LEFT JOIN signal.contacts c ON c.id = m.source_contact_id
                 WHERE m.search @@ websearch_to_tsquery('english', %s)
+                  AND {not_excluded('m')}
                 ORDER BY m.message_timestamp DESC
                 LIMIT %s
                 """,
@@ -1012,11 +1149,21 @@ class SignalDB:
             return [dict(r) for r in cur.fetchall()]
 
     def get_message(self, message_id: int) -> dict | None:
+        """One message by id, or None — including when it is MUTED.
+
+        🔴 A muted message is indistinguishable from a nonexistent one here, and
+        that is deliberate: "filter it out entirely" has to mean the id route
+        too, or `search` hiding a row while `get_message` serves it in full is a
+        filter with a hole in the shape of anyone who knows an id. The cost is
+        that a muted id reads as "no such message"; the mute list is the place
+        to look when that is surprising.
+        """
         with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
             cur.execute(
-                "SELECT id, message_timestamp, source_contact_id, dest_contact_id, "
-                "message_type, body, is_outbound, send_state, approval_ref "
-                "FROM signal.messages WHERE id = %s",
+                "SELECT m.id, m.message_timestamp, m.source_contact_id, "
+                "m.dest_contact_id, m.message_type, m.body, m.is_outbound, "
+                "m.send_state, m.approval_ref "
+                f"FROM signal.messages m WHERE m.id = %s AND {not_excluded('m')}",
                 (message_id,),
             )
             row = cur.fetchone()
@@ -1127,6 +1274,19 @@ class SignalDB:
         return row
 
     def get_draft(self, draft_id: int) -> dict | None:
+        """One DRAFT by id — and `is_outbound` alone does not mean "draft".
+
+        🔴 `send_state IS NOT NULL` is what makes this a draft surface. Without
+        it the predicate was `m.is_outbound` alone, which also matches every
+        device-sync ECHO of a message sent from the phone — and those DO carry a
+        `group_id`, so this method returned a muted group's body in full while
+        `get_message` correctly returned None for the same row. Nothing exploited
+        it (every caller goes through `_draft_or_raise`, and the D3 gate rejects
+        `send_state=None` before printing), but the mute ledger EXEMPTS this
+        method on the stated grounds that drafts carry no group — and that reason
+        was false until this line existed. A guard whose justification the code
+        contradicts is one refactor away from being a real leak.
+        """
         with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
             cur.execute(
                 """
@@ -1137,7 +1297,7 @@ class SignalDB:
                        END AS recipient
                 FROM signal.messages m
                 LEFT JOIN signal.contacts d ON d.id = m.dest_contact_id
-                WHERE m.id = %s AND m.is_outbound
+                WHERE m.id = %s AND m.is_outbound AND m.send_state IS NOT NULL
                 """,
                 (draft_id,),
             )

--- a/scripts/signal/build-push.sh
+++ b/scripts/signal/build-push.sh
@@ -229,7 +229,14 @@ choices=$(docker run --rm --entrypoint python3 "$IMAGE" \
 # deliberately, as this control demands: it is READ-ONLY — it reads the local
 # heartbeat file (or, with --from-db, the health row) and exits 0/1. It
 # transmits nothing, writes nothing, and is what the k8s liveness probe runs.
-want_choices="approve conversations draft drafts health reconcile run search send "
+#
+# `mute`/`unmute`/`muted` added 2026-08-19 with the group mute list. Acknowledged
+# deliberately, as this control demands. They write to ONE table
+# (`signal.excluded_groups`) that nothing else reads except the read predicate,
+# transmit nothing, and — the property that made this the chosen design — DELETE
+# nothing: `unmute` restores the conversation in full, because the messages were
+# never removed. `muted` is read-only.
+want_choices="approve conversations draft drafts health mute muted reconcile run search send unmute "
 if [[ "$choices" != "$want_choices" ]]; then
   echo "build-push: REFUSING TO PUSH — subcommand set is '$choices'," >&2
   echo "            expected '$want_choices'. Empty means the parse found no {…}" >&2

--- a/scripts/signal/consumer.py
+++ b/scripts/signal/consumer.py
@@ -169,6 +169,48 @@ def _decode_group_id(raw) -> bytes | None:
         return str(raw).encode()
 
 
+def _decode_internal_id(text: str) -> bytes:
+    """An OPERATOR-typed base64 group id → bytes, refusing anything ambiguous.
+
+    Deliberately stricter than `_decode_group_id`, which serves a different
+    requirement: on the ingest path a group id that will not decode must never
+    kill the frame, so it falls back to the raw bytes. Applied to operator input
+    that same fallback turns a typo into a mute of some other 32 bytes that
+    matches nothing — a filter that reports success and hides no rows.
+
+    So: decode through the ONE decoder, then require that re-encoding reproduces
+    the input exactly. The round-trip is what rejects the fallback path and any
+    non-canonical spelling, without this function owning a second base64 reader.
+    """
+    if not isinstance(text, str) or not text.strip():
+        raise ValueError("group id is empty")
+    s = text.strip().replace("-", "+").replace("_", "/")   # tolerate urlsafe
+    raw = _decode_group_id(s)
+    if not raw or base64.b64encode(raw).decode() != s:
+        raise ValueError(
+            f"{text!r} is not a canonical base64 group id. Copy `internal_id` "
+            "verbatim from GET /v1/groups/<account> — not `id` (which is the "
+            "`group.`-prefixed double encoding) and not the display name.")
+    # 🔴 LENGTH IS THE ONLY THING THAT REJECTS A SHORT WORD. The round-trip above
+    # is satisfied by any string that is valid base64, and plenty of display
+    # names are: `Team` decodes to 3 bytes and `deadbeef` to 6, both round-trip
+    # perfectly, and both were ACCEPTED — muting nothing while printing success.
+    # GroupV2 ids are 32 bytes and legacy GroupV1 ids 16; nothing else is a
+    # group id, so anything else is a typo caught here instead of at 3am.
+    if len(raw) not in (16, 32):
+        raise ValueError(
+            f"{text!r} decodes to {len(raw)} bytes; a Signal group id is 32 "
+            "(GroupV2) or 16 (legacy GroupV1). This is almost certainly a "
+            "display name or a truncated paste — muting it would hide nothing "
+            "and report success.")
+    return raw
+
+
+def _fmt_group_id(raw) -> str:
+    """A BYTEA group id back to the base64 an operator can paste."""
+    return base64.b64encode(bytes(raw)).decode()
+
+
 def _attachments(data: dict) -> list[dict]:
     out = []
     for a in data.get("attachments") or []:
@@ -199,7 +241,17 @@ def _base_message(env: dict, data: dict, *, timestamp: int) -> dict:
         "view_once": bool(data.get("viewOnce")),
         "edit_target_timestamp": None,
         "group_id": _decode_group_id(group.get("groupId")),
-        "group_name": group.get("name"),
+        # 🔴 `groupName`, not `name`. Measured on the live store 2026-08-19: 34
+        # of 34 stored group envelopes carry a NON-EMPTY `groupInfo.groupName`
+        # and NONE carries `groupInfo.name`, so this read `None` every time and
+        # `upsert_group` stored `''` for every group that has ever arrived. The
+        # consequence was invisible because nothing asserted on a group name —
+        # `conversations` just printed the DM peer or `?`, and it took wanting
+        # to filter a group BY NAME to notice that no name had ever been stored.
+        # Both spellings are read (the field was renamed upstream at some point
+        # and an older server may still send `name`); `groupName` wins because
+        # that is the one real envelopes carry.
+        "group_name": group.get("groupName") or group.get("name"),
         "quote_timestamp": quote.get("id"),
         "quote_author": quote.get("authorUuid") or quote.get("author"),
         "attachments": _attachments(data),
@@ -1095,6 +1147,25 @@ def build_parser() -> argparse.ArgumentParser:
     s.add_argument("query")
     s.add_argument("--limit", type=int, default=25)
 
+    sub.add_parser("muted", help="list muted groups and how many rows each hides")
+
+    mu = sub.add_parser(
+        "mute",
+        help="hide a group from every read (stores and deletes NOTHING)")
+    mu.add_argument("internal_id",
+                    help="the group's base64 `internal_id` from "
+                         "GET /v1/groups/<account> — NOT the display name, which "
+                         "this pipeline does not capture")
+    mu.add_argument("--note", help="why, recorded on the row")
+    mu.add_argument("--allow-unseen", action="store_true",
+                    help="accept a group id that matches nothing stored yet. "
+                         "Without this, muting an unknown id EXITS 4 — a typo "
+                         "and a deliberate mute-before-first-message look "
+                         "identical otherwise, and one of them hides nothing")
+
+    um = sub.add_parser("unmute", help="un-hide a muted group; restores it entirely")
+    um.add_argument("internal_id")
+
     d = sub.add_parser("draft", help="compose an outbound draft (transmits NOTHING)")
     d.add_argument("--to", required=True)
     d.add_argument("--body", required=True)
@@ -1205,6 +1276,56 @@ def main(argv=None) -> int:  # pragma: no cover - thin CLI shell over tested uni
                 print(f"{_fmt_ts(row['message_timestamp'])}  "
                       f"{row.get('display_name') or row.get('phone_number') or '?'}: "
                       f"{(row.get('body') or '')[:120]}")
+        elif args.cmd == "muted":
+            rows = db.list_excluded_groups()
+            if not rows:
+                print("no groups are muted")
+            for row in rows:
+                print(f"{_fmt_group_id(row['group_id'])}  "
+                      f"row={row['group_row_id'] if row['group_row_id'] is not None else '-'}  "
+                      f"hides={row['hidden_message_count'] or 0}  "
+                      f"{row.get('note') or ''}")
+        elif args.cmd in ("mute", "unmute"):
+            try:
+                gid = _decode_internal_id(args.internal_id)
+            except ValueError as exc:
+                print(f"refused: {exc}", file=sys.stderr)
+                return 3
+            if args.cmd == "mute":
+                db.exclude_group(gid, note=args.note)
+                db.commit()
+                # 🔴 REPORT WHAT WAS MATCHED, never a bare "muted". A mistyped
+                # base64 id still decodes to a perfectly valid 32 bytes, so no
+                # length or alphabet check can catch it — the only thing that
+                # discriminates a real id from a plausible one is whether it
+                # joins to a stored group, and how many rows it now hides.
+                hit = next((r for r in db.list_excluded_groups()
+                            if bytes(r["group_id"]) == gid), None)
+                if hit and hit["group_row_id"] is not None:
+                    print(f"muted group row {hit['group_row_id']} — now hiding "
+                          f"{hit['hidden_message_count'] or 0} stored message(s)")
+                elif args.allow_unseen:
+                    print("muted an as-yet-unseen group; it applies from the "
+                          "first message that arrives.")
+                else:
+                    # 🔴 NON-ZERO. The prose above used to say all this and exit
+                    # 0 — the same code as a mute that hid 18 messages — so no
+                    # script, hook or agent could tell a working mute from one
+                    # that matched nothing. The report has to carry in the exit
+                    # status, not only in the text a human might read.
+                    print("REFUSING to report success: no stored group has this "
+                          "id, so this mute hides NOTHING. Either the id is "
+                          "wrong (check `internal_id` from GET /v1/groups/"
+                          "<account>), or you meant to mute a group not yet "
+                          "seen — in which case pass --allow-unseen. The row "
+                          "HAS been written either way; `unmute` removes it.",
+                          file=sys.stderr)
+                    return 4
+            else:
+                removed = db.unexclude_group(gid)
+                db.commit()
+                print(f"unmuted ({removed} row(s) removed)" if removed
+                      else "that group was not muted — nothing changed")
         elif args.cmd == "draft":
             import clawgate
             draft = db.draft_message(

--- a/scripts/signal/tests/test_group_exclusions.py
+++ b/scripts/signal/tests/test_group_exclusions.py
@@ -1,0 +1,645 @@
+"""The group MUTE list — `signal.excluded_groups` and the one read predicate.
+
+Scope of the claim these tests make, stated up front because it is narrower than
+"the group is filtered out":
+
+  * They cover the three PYTHON read surfaces on `SignalDB`. Raw `psql` against
+    the schema bypasses every one of them, by construction — a predicate in an
+    application query cannot bind a hand-typed statement. `SKILL.md` says so
+    where it prints those one-liners.
+  * They assert HIDING, never deleting. The rows stay; that is the whole design,
+    and `test_muting_deletes_nothing...` is what keeps it true.
+
+The seam these tests exist for: a filter open-coded at three call sites is wrong
+at two of them, in the same direction, and the failure is silent. So there is a
+behavioural case per surface AND a ledger that fails when the set of read
+surfaces grows or shrinks — a structural check alone type-checks past a wrong
+argument, and a behavioural check alone cannot see a NEW method that skipped it.
+"""
+from __future__ import annotations
+
+import base64
+import inspect
+import re
+
+import pytest
+
+import _signal_db
+from _signal_db import SignalDB, not_excluded
+
+import consumer
+
+
+GROUP_KEEP = b"\x11" * 32       # 32 bytes, like every real Signal group id
+GROUP_MUTE = b"\x22" * 32
+GROUP_UNSEEN = b"\x33" * 32     # muted before it was ever stored
+
+# The shape of the API's `id` field: `group.` + base64(base64(raw)). GENERATED
+# from a repeated byte, never copied from a live response.
+#
+# 🔴 THIS REPO IS PUBLIC AND NOTHING WOULD CATCH A REAL ONE. A Signal group id
+# identifies a real group of real people; the four content gates
+# (`test_no_captured_text.py`, `test_no_captured_markup.py`, and the IP and
+# hostname ones) scan JSON/JSONL/HTML/TXT and **not** `.py`, so a real id pasted
+# into a test file lands in history permanently with no gate between it and
+# `main`. An earlier revision of this very file carried one, copied straight out
+# of `GET /v1/groups/<account>` while checking what the field looked like.
+# Generate fixtures; never paste a response.
+GROUP_ID_FIELD_SHAPE = "group." + base64.b64encode(
+    base64.b64encode(b"\x44" * 32)).decode()
+
+
+def _seed(db):
+    """Two groups and a DM, each with a distinctive body. Returns row ids.
+
+    🔴 Every body, group id and contact is PAIRWISE DISTINCT, and distinct from
+    any constant an assertion names. A fixture whose values collapse into each
+    other cannot see a mutant that hardcodes one of them — this pipeline has
+    already shipped three such fixtures (two operand-order mutants survived
+    because `source` and `sourceNumber` were the same string, and a hardcoding
+    mutant survived 400 tests because the fixture emoji equalled the asserted
+    constant).
+    """
+    keep_row = db.upsert_group(group_id=GROUP_KEEP, name="")
+    mute_row = db.upsert_group(group_id=GROUP_MUTE, name="")
+    ids = {}
+    ids["keep"] = db.upsert_message({
+        "message_timestamp": 1000,
+        "source_uuid": "11111111-1111-4111-8111-111111111111",
+        "source_number": "+15550001", "source_name": "Alice",
+        "message_type": "group_message", "body": "quarterly kestrel report",
+        "group_id": GROUP_KEEP, "is_outbound": False,
+    })
+    ids["mute"] = db.upsert_message({
+        "message_timestamp": 2000,
+        "source_uuid": "22222222-2222-4222-8222-222222222222",
+        "source_number": "+15550002", "source_name": "Bob",
+        "message_type": "group_message", "body": "quarterly kestrel potluck",
+        "group_id": GROUP_MUTE, "is_outbound": False,
+    })
+    ids["dm"] = db.upsert_message({
+        "message_timestamp": 3000,
+        "source_uuid": "33333333-3333-4333-8333-333333333333",
+        "source_number": "+15550003", "source_name": "Carol",
+        "message_type": "direct_message", "body": "quarterly kestrel invoice",
+        "group_id": None, "is_outbound": False,
+    })
+    ids["_rows"] = {"keep": keep_row, "mute": mute_row}
+    return ids
+
+
+def _conv_group_rows(db):
+    return {r["group_row_id"] for r in db.list_conversations()}
+
+
+# --------------------------------------------------------------------------- #
+# Behaviour, one case per read surface — each with its own positive control
+# --------------------------------------------------------------------------- #
+def test_conversations_hides_a_muted_group_and_shows_it_again_after_unmute(db):
+    ids = _seed(db)
+    mute_row = ids["_rows"]["mute"]
+    keep_row = ids["_rows"]["keep"]
+
+    # POSITIVE CONTROL: it is visible BEFORE the mute. Without this the "hidden"
+    # assertion below is indistinguishable from a query wired to nothing.
+    assert mute_row in _conv_group_rows(db)
+    assert keep_row in _conv_group_rows(db)
+
+    db.exclude_group(GROUP_MUTE, note="filtered by operator")
+    after = _conv_group_rows(db)
+    assert mute_row not in after
+    assert keep_row in after
+    assert None in after, "the DM conversation must survive a group mute"
+
+    # And the rollback story is real, not asserted.
+    assert db.unexclude_group(GROUP_MUTE) == 1
+    assert _conv_group_rows(db) == {mute_row, keep_row, None}
+
+
+def test_search_hides_a_muted_group(db):
+    _seed(db)
+    # All three bodies match this query — that is deliberate. A query matching
+    # only the muted row could not tell "filtered correctly" from "matched
+    # nothing", which is the empty-result trap.
+    before = {r["body"] for r in db.search("quarterly kestrel")}
+    assert before == {"quarterly kestrel report", "quarterly kestrel potluck",
+                      "quarterly kestrel invoice"}
+
+    db.exclude_group(GROUP_MUTE)
+    after = {r["body"] for r in db.search("quarterly kestrel")}
+    assert after == {"quarterly kestrel report", "quarterly kestrel invoice"}
+
+
+def test_get_message_hides_a_muted_message_by_id(db):
+    ids = _seed(db)
+    assert db.get_message(ids["mute"])["body"] == "quarterly kestrel potluck"
+
+    db.exclude_group(GROUP_MUTE)
+    assert db.get_message(ids["mute"]) is None, (
+        "the id route must be filtered too — otherwise the mute has a hole in "
+        "the shape of anyone who knows a message id")
+    # The unmuted neighbours are untouched: this is a filter, not an outage.
+    assert db.get_message(ids["keep"])["body"] == "quarterly kestrel report"
+    assert db.get_message(ids["dm"])["body"] == "quarterly kestrel invoice"
+
+
+def test_muting_deletes_nothing_and_unmute_restores_exactly(db):
+    ids = _seed(db)
+    before_rows = db.conn.count("messages")
+    before_search = [dict(r) for r in db.search("quarterly kestrel")]
+
+    db.exclude_group(GROUP_MUTE)
+    assert db.conn.count("messages") == before_rows, (
+        "muting must not delete — the pipeline is forward-only, so a deleted "
+        "message can never be re-fetched and the decision would be irreversible")
+    assert db.conn.count("attachments") == 0  # nothing cascaded either
+
+    db.unexclude_group(GROUP_MUTE)
+    assert [dict(r) for r in db.search("quarterly kestrel")] == before_search
+    assert db.get_message(ids["mute"])["body"] == "quarterly kestrel potluck"
+
+
+# --------------------------------------------------------------------------- #
+# The mute list itself
+# --------------------------------------------------------------------------- #
+def test_muting_is_idempotent_and_the_note_is_updated_not_duplicated(db):
+    _seed(db)
+    db.exclude_group(GROUP_MUTE, note="first reason")
+    db.exclude_group(GROUP_MUTE, note="second reason")
+    rows = db.list_excluded_groups()
+    assert len(rows) == 1
+    assert rows[0]["note"] == "second reason"
+
+
+def test_re_muting_WITHOUT_a_note_keeps_the_recorded_reason(db):
+    """The note→note case above cannot see this; note→None is the common one.
+
+    `mute <id>` with no --note is the natural way to re-issue a mute, and a bare
+    `note = EXCLUDED.note` made that destroy the only record of WHY the group is
+    muted — as a side effect of a command that otherwise changes nothing.
+    """
+    _seed(db)
+    db.exclude_group(GROUP_MUTE, note="spam group, muted 2026-08-19")
+    db.exclude_group(GROUP_MUTE)
+    assert db.list_excluded_groups()[0]["note"] == "spam group, muted 2026-08-19"
+
+
+def test_a_group_can_be_muted_before_it_has_ever_been_seen(db):
+    _seed(db)
+    db.exclude_group(GROUP_UNSEEN, note="not stored yet")
+    listed = {bytes(r["group_id"]): r for r in db.list_excluded_groups()}
+    assert listed[GROUP_UNSEEN]["group_row_id"] is None, (
+        "an unseen group is an ordinary state — the mute is the INTENT, and a "
+        "FK to signal.groups could not express it")
+
+    # …and it takes effect the moment the group does appear.
+    db.upsert_message({
+        "message_timestamp": 4000,
+        "source_uuid": "44444444-4444-4444-8444-444444444444",
+        "source_number": "+15550004", "source_name": "Dave",
+        "message_type": "group_message", "body": "quarterly kestrel latecomer",
+        "group_id": GROUP_UNSEEN, "is_outbound": False,
+    })
+    row = db.upsert_group(group_id=GROUP_UNSEEN, name="")
+    assert row not in _conv_group_rows(db)
+    assert not [r for r in db.search("quarterly kestrel")
+                if r["body"] == "quarterly kestrel latecomer"]
+
+
+def test_hidden_message_count_reports_what_the_mute_is_actually_hiding(db):
+    ids = _seed(db)
+    db.exclude_group(GROUP_MUTE)
+    row = next(r for r in db.list_excluded_groups()
+               if bytes(r["group_id"]) == GROUP_MUTE)
+    assert row["hidden_message_count"] == 1
+    assert row["group_row_id"] == ids["_rows"]["mute"]
+
+
+def test_unmuting_something_that_was_not_muted_reports_zero(db):
+    _seed(db)
+    assert db.unexclude_group(GROUP_KEEP) == 0
+
+
+@pytest.mark.parametrize("bad", [b"", bytearray()])
+def test_an_empty_group_id_is_refused(db, bad):
+    with pytest.raises(ValueError):
+        db.exclude_group(bad)
+
+
+def test_a_str_group_id_is_refused(db):
+    """A base64 STRING silently stored as bytes would mute nothing, forever.
+
+    🔴 `match=` is load-bearing. Without it this passed on the `TypeError` that
+    `bytes("…")` raises further down — green for the wrong reason, and still
+    green with the isinstance guard deleted. Pin THIS guard's own message.
+    """
+    with pytest.raises(TypeError, match="raw Signal group id"):
+        db.exclude_group("IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=")
+
+
+# --------------------------------------------------------------------------- #
+# The predicate
+# --------------------------------------------------------------------------- #
+def test_the_predicate_refuses_an_unsafe_alias():
+    """The alias is interpolated, so the whitelist is load-bearing."""
+    for bad in ("m; DROP TABLE signal.messages --", "M", "1m", "m m", ""):
+        with pytest.raises(ValueError):
+            not_excluded(bad)
+
+
+def test_the_predicate_actually_USES_the_alias_it_is_given():
+    """🔴 Validating the alias is not the same as using it.
+
+    A mutant that validated `alias` and then hardcoded `m` SURVIVED the whole
+    suite: every call site passes `m`, so nothing could tell the two apart. The
+    parameter would have silently become decorative, and the first read method
+    to use a different alias would get a predicate pointing at the wrong table.
+    """
+    assert "q.group_id" in not_excluded("q")
+    assert "m.group_id" not in not_excluded("q")
+
+
+def test_the_predicate_is_composable_with_AND():
+    """`NOT EXISTS`, never `... IS NULL OR ...`.
+
+    An OR-form predicate ANDed onto a WHERE clause without brackets widens the
+    query to every row — silently, and only at the call site that forgot them.
+    This pins the shape rather than the wording, so a rewrite that reintroduces
+    a top-level OR fails here.
+    """
+    sql = not_excluded("m")
+    assert sql.startswith("NOT EXISTS ("), sql
+    # No OR outside the subquery's parens.
+    depth, top_level = 0, []
+    for tok in re.findall(r"\(|\)|\bOR\b", sql):
+        if tok == "(":
+            depth += 1
+        elif tok == ")":
+            depth -= 1
+        elif depth == 0:
+            top_level.append(tok)
+    assert not top_level, f"top-level OR in the predicate: {sql}"
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE LEDGER — fails when the set of message-reading surfaces GROWS or SHRINKS
+# --------------------------------------------------------------------------- #
+# Every method here reads `signal.messages` and returns rows to a caller. Each
+# must either apply `not_excluded()` or be listed as EXEMPT with a reason. This
+# is the seam guard: the behavioural cases above can only see the surfaces that
+# existed when they were written, and a new read method that skipped the filter
+# is exactly the failure this pipeline has already shipped once (the sync
+# reaction branch, added without the guards its inbound twin already had).
+FILTERED_READS = {"list_conversations", "search", "get_message"}
+
+EXEMPT_READS = {
+    # Counts what a mute is hiding — it must see muted rows, that is its job.
+    "list_excluded_groups":
+        "reports the hidden count; filtering it would always print 0",
+    # --- WRITES that name signal.messages in a subquery, not read surfaces.
+    "upsert_reaction":
+        "write: resolves a reaction's target message id",
+    "apply_remote_delete":
+        "write: blanks a deleted message's body",
+    # --- The DRAFT surface (D3). Drafts live in signal.messages with a NEGATIVE
+    # provisional timestamp and are addressed to a RECIPIENT, never a group, so
+    # `group_id` is NULL on every one of them and the predicate could only ever
+    # be a no-op. Filtering the compose/approve/send path by a mute list would
+    # also be wrong in principle: muting is about what you READ, and a draft is
+    # something you WROTE. 🔴 If drafting to a group is ever added, these move
+    # into FILTERED_READS — this test fails when that day comes only because the
+    # method set is pinned, so re-read this note then rather than trusting it.
+    "get_draft": "draft surface: drafts have no group_id",
+    "list_drafts": "draft surface: drafts have no group_id",
+    "account_number": "draft surface: reads the sending account off a draft",
+}
+
+
+def _read_methods_touching_messages() -> set[str]:
+    """Methods whose body SELECTs from `signal.messages`.
+
+    🔴 SCOPE, stated because this guard is SPELLED rather than structural and
+    the difference matters. It greps the method's own source text, so it detects
+    exactly one shape: SQL written inline, naming `signal.messages`, in a method
+    defined directly on `SignalDB`. Measured evasions — all four confirmed to
+    slip past it: SQL held in a module-level constant; `SET search_path` plus an
+    unqualified `FROM messages`; delegation to a module-level helper; a method
+    inherited from a mixin (absent from `vars(SignalDB)`). It also FALSE-positives
+    on a method whose comment merely names both tokens.
+
+    So this catches the copy-paste shape — which is how every read method here
+    was actually written, and how the next one will be — and it is not a proof
+    of completeness. Claim it as the former.
+    """
+    found = set()
+    for name, fn in vars(SignalDB).items():
+        if not callable(fn) or name.startswith("__"):
+            continue
+        try:
+            src = inspect.getsource(fn)
+        except (OSError, TypeError):        # pragma: no cover - defensive
+            continue
+        if re.search(r"\bSELECT\b", src, re.IGNORECASE) and "signal.messages" in src:
+            found.add(name)
+    return found
+
+
+def test_the_ledger_of_message_reads_is_pinned_both_ways():
+    found = _read_methods_touching_messages()
+    assert found, (
+        "HARNESS BROKEN: the scan found no message-reading methods at all, so "
+        "every assertion below would pass vacuously")
+    declared = FILTERED_READS | set(EXEMPT_READS)
+    assert found == declared, (
+        f"the set of methods that SELECT from signal.messages changed.\n"
+        f"  new (add to FILTERED_READS and apply not_excluded(), or to "
+        f"EXEMPT_READS with a reason): {sorted(found - declared)}\n"
+        f"  gone (drop from the ledger): {sorted(declared - found)}")
+
+
+@pytest.mark.parametrize("name", sorted(FILTERED_READS))
+def test_every_filtered_read_actually_calls_the_predicate(name):
+    src = inspect.getsource(getattr(SignalDB, name))
+    assert "not_excluded(" in src, (
+        f"SignalDB.{name} SELECTs from signal.messages without the mute "
+        f"predicate — muted rows leak through it")
+
+
+def test_get_draft_refuses_a_device_sync_ECHO_not_just_a_draft(db):
+    """🔴 The exemption's REASON, measured on the population it actually returns.
+
+    `test_a_draft_really_has_no_group_id` only inspects a row that
+    `draft_message()` created, so it can never see this: `is_outbound` alone
+    also matches every device-sync echo of a message sent from the phone, and
+    those DO carry a `group_id`. Before `send_state IS NOT NULL`, `get_draft`
+    returned a muted group's body in full while `get_message` returned None for
+    the very same row.
+    """
+    ids = _seed(db)
+    db.exclude_group(GROUP_MUTE)
+    # The seeded muted-group row is inbound; make an OUTBOUND one in that group,
+    # exactly as a sync echo arrives — no send_state, because nothing drafted it.
+    echo_id = db.upsert_message({
+        "message_timestamp": 5000,
+        "source_uuid": "66666666-6666-4666-8666-666666666666",
+        "source_number": "+15550006", "source_name": "me",
+        "message_type": "group_message", "body": "SECRET body in a muted group",
+        "group_id": GROUP_MUTE, "is_outbound": True,
+    })
+    assert db.get_message(echo_id) is None, "positive control: get_message hides it"
+    assert db.get_draft(echo_id) is None, (
+        "get_draft returned a device-sync echo — so `is_outbound` alone is not "
+        "'a draft', and the ledger's exemption reason is false")
+    assert ids["mute"] is not None
+
+
+def test_a_draft_really_has_no_group_id(db):
+    """The draft surface's EXEMPTION, measured instead of asserted in prose.
+
+    `EXEMPT_READS` claims drafts carry no `group_id`, so the mute predicate on
+    them could only ever be a no-op. A comment is a claim like any other; this
+    reads the column. If drafting to a group is ever added, this goes red and
+    the exemption has to be revisited rather than inherited.
+    """
+    draft = db.draft_message(recipient="+15550009", body="drafted, never sent",
+                             self_number="+15550000")
+    rows = db.conn.rows("SELECT group_id FROM signal.messages WHERE id = ?",
+                        (draft["id"],))
+    assert rows and rows[0]["group_id"] is None
+
+
+def test_the_ledger_would_notice_an_unfiltered_read():
+    """Negative control on the ledger itself: can it go red?
+
+    Without this, `test_the_ledger_...` passing proves only that the CURRENT
+    code matches the CURRENT list — not that the check can ever fail.
+    """
+    found = _read_methods_touching_messages()
+    pretend_new = found | {"list_archived_messages"}
+    assert pretend_new != (FILTERED_READS | set(EXEMPT_READS))
+
+
+# --------------------------------------------------------------------------- #
+# Operator input decoding
+# --------------------------------------------------------------------------- #
+def test_decode_internal_id_round_trips_a_canonical_id():
+    text = base64.b64encode(GROUP_MUTE).decode()
+    assert consumer._decode_internal_id(text) == GROUP_MUTE
+    assert consumer._fmt_group_id(GROUP_MUTE) == text
+
+
+def test_fmt_group_id_emits_the_STANDARD_alphabet_not_urlsafe():
+    """🔴 `GROUP_MUTE` cannot see this — its encoding contains no `+` or `/`.
+
+    A mutant switching `_fmt_group_id` to `urlsafe_b64encode` SURVIVED, because
+    every fixture that reached it was a repeated byte whose base64 has neither
+    character. The output is what an operator pastes back into `mute`, so a
+    urlsafe rendering round-trips through our own tolerant decoder and diverges
+    from what the Signal API prints. Use bytes that CAN tell the two apart.
+    """
+    raw = b"\xfb\xff" * 16
+    std = base64.b64encode(raw).decode()
+    assert "+" in std and "/" in std, (
+        "HARNESS BROKEN: this fixture cannot distinguish the two alphabets")
+    assert consumer._fmt_group_id(raw) == std
+
+
+def test_decode_internal_id_tolerates_the_urlsafe_alphabet():
+    raw = b"\xfb\xff" * 16                      # encodes to '+/' repeated
+    std = base64.b64encode(raw).decode()
+    urlsafe = base64.urlsafe_b64encode(raw).decode()
+    assert "+" in std or "/" in std, (
+        "HARNESS BROKEN: this fixture does not exercise the +/ characters, so "
+        "the urlsafe branch is never reached and this test proves nothing")
+    assert consumer._decode_internal_id(urlsafe) == raw
+
+
+@pytest.mark.parametrize("bad", [
+    "",
+    "   ",
+    "not base64 at all!",
+    GROUP_ID_FIELD_SHAPE,          # the `id` field, not `internal_id`
+    "Team",                        # a display name that IS valid base64
+    "deadbeef",                    # 6 bytes — decodes cleanly, is not a group id
+])
+def test_decode_internal_id_refuses_anything_non_canonical(bad):
+    """🔴 The ingest decoder falls back to `str.encode()` rather than failing.
+
+    That is right for a frame (never kill ingest over one field) and wrong for
+    operator input, where it turns a typo into a mute of 32 bytes that match
+    nothing — a filter that reports success and hides nothing. This pins the
+    strict half; `_decode_group_id` keeps the lenient half.
+    """
+    with pytest.raises(ValueError):
+        consumer._decode_internal_id(bad)
+
+
+def test_a_NON_CANONICAL_32_byte_encoding_is_refused():
+    """🔴 The only case that reaches the round-trip check — found by a mutant.
+
+    Adding the 16/32 length check made every other bad input die on LENGTH, so
+    disabling the round-trip check entirely left the suite GREEN: a guard with
+    no case that reaches it. (Round 1's battery killed that mutant; round 2's
+    did not, because round 2's own fix had made it unreachable. A fix round
+    resets the gate.)
+
+    Base64's last data character carries only 4 significant bits for a 2-byte
+    tail, so the low 2 bits are ignored on decode: `v` and `v+1` decode to the
+    SAME 32 bytes while only `v` re-encodes to itself. That is a string of the
+    right length, decoding to the right size, which is still not what the API
+    emitted — exactly what the round-trip check is for and nothing else catches.
+    """
+    alphabet = ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+                "0123456789+/")
+    canonical = base64.b64encode(GROUP_MUTE).decode()
+    assert canonical.endswith("=") and canonical[-2] in alphabet
+    v = alphabet.index(canonical[-2])
+    assert v % 4 == 0, "HARNESS BROKEN: canonical tail already has low bits set"
+    variant = canonical[:-2] + alphabet[v + 1] + "="
+
+    # Positive control: it really is the same 32 bytes, so this is NOT caught by
+    # the length check — it can only be caught by the round trip.
+    assert base64.b64decode(variant) == GROUP_MUTE
+    assert len(base64.b64decode(variant)) == 32
+    assert variant != canonical
+
+    with pytest.raises(ValueError, match="canonical"):
+        consumer._decode_internal_id(variant)
+
+
+def test_the_two_decoders_genuinely_disagree_on_the_same_input():
+    """Positive control for the paragraph above: the leniency is real."""
+    bad = "not base64 at all!"
+    assert consumer._decode_group_id(bad) == bad.encode()
+    with pytest.raises(ValueError):
+        consumer._decode_internal_id(bad)
+
+
+# --------------------------------------------------------------------------- #
+# The group NAME — found while checking the claim that names are never stored
+# --------------------------------------------------------------------------- #
+def _group_envelope(*, group_info: dict) -> dict:
+    return {
+        "timestamp": 9000,
+        "sourceUuid": "55555555-5555-4555-8555-555555555555",
+        "sourceNumber": "+15550005",
+        "sourceName": "Erin",
+        "dataMessage": {"message": "hello", "timestamp": 9000,
+                        "groupInfo": group_info},
+    }
+
+
+def test_the_parser_reads_groupName_which_is_what_real_envelopes_carry():
+    """🔴 Regression: `groupInfo.name` was read and is never present.
+
+    Measured on the live store before this fix: 34 of 34 stored group envelopes
+    carried a non-empty `groupInfo.groupName`, and NONE carried `groupInfo.name`
+    — so every group was stored with an empty name. Nothing caught it because no
+    test and no output ever asserted on a group name.
+    """
+    parsed = consumer.parse_envelope(_group_envelope(group_info={
+        "type": "DELIVER", "groupId": "IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=",
+        "revision": 3, "groupName": "Widget Testers",
+    }))
+    assert parsed.message["group_name"] == "Widget Testers"
+
+
+def test_groupName_WINS_over_the_legacy_spelling():
+    """The two keys hold DISTINCT values here, deliberately.
+
+    A fixture setting both to the same string collapses the two operand orders
+    into identical output, and an order-swap mutant then survives a fully green
+    suite — which is exactly how two such mutants survived 416 tests in this
+    same module's history.
+    """
+    parsed = consumer.parse_envelope(_group_envelope(group_info={
+        "type": "DELIVER", "groupId": "IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=",
+        "revision": 3, "groupName": "Widget Testers", "name": "Sprocket Fans",
+    }))
+    assert parsed.message["group_name"] == "Widget Testers"
+
+
+def test_the_legacy_spelling_is_still_honoured_when_it_is_the_only_one():
+    parsed = consumer.parse_envelope(_group_envelope(group_info={
+        "type": "DELIVER", "groupId": "IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=",
+        "revision": 3, "name": "Sprocket Fans",
+    }))
+    assert parsed.message["group_name"] == "Sprocket Fans"
+
+
+def test_a_LATER_nameless_envelope_does_not_WIPE_a_stored_group_name(db):
+    """🔴 Two envelopes, because one cannot see this.
+
+    `upsert_group` binds `name or ""` (the column is NOT NULL), so `EXCLUDED.name`
+    is never NULL — it is `''` — and the original `COALESCE(EXCLUDED.name, …)`
+    could therefore never fire. It was dead code that READ as protection: a later
+    frame for a known group carrying no name (a sync echo, an edit, a plain
+    DELIVER with only `groupId`) overwrote the stored name with `''`. The name
+    would appear and then silently revert, and nothing asserted on group names
+    over time, so a mutant DELETING the whole COALESCE survived all 508 tests.
+    """
+    gid = "IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI="
+    db.upsert_message(consumer.parse_envelope(_group_envelope(group_info={
+        "type": "DELIVER", "groupId": gid, "revision": 3,
+        "groupName": "Widget Testers"})).message)
+    assert "Widget Testers" in {r["group_name"] for r in db.list_conversations()}
+
+    # A second frame for the SAME group, carrying no name at all.
+    second = _group_envelope(group_info={"type": "DELIVER", "groupId": gid,
+                                         "revision": 4})
+    second["timestamp"] = 9100
+    second["dataMessage"]["timestamp"] = 9100
+    db.upsert_message(consumer.parse_envelope(second).message)
+
+    assert "Widget Testers" in {r["group_name"] for r in db.list_conversations()}, (
+        "a nameless envelope wiped the stored group name back to ''")
+
+
+def test_a_stored_group_keeps_the_name_the_envelope_carried(db):
+    """End-to-end through `upsert_message` -> `upsert_group`, not just the parser.
+
+    The parser and the DB layer were each clean on their own the last time this
+    module shipped a defect; the bug lived in the seam. One fixture builds both.
+    """
+    parsed = consumer.parse_envelope(_group_envelope(group_info={
+        "type": "DELIVER", "groupId": "IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=",
+        "revision": 3, "groupName": "Widget Testers",
+    }))
+    db.upsert_message(parsed.message)
+    names = {r["group_name"] for r in db.list_conversations()}
+    assert "Widget Testers" in names
+
+
+# --------------------------------------------------------------------------- #
+# Schema
+# --------------------------------------------------------------------------- #
+def test_the_mute_table_is_in_the_schema_and_survives_translation():
+    ddl = [s for s in _signal_db.SCHEMA_STATEMENTS
+           if "excluded_groups" in s and "CREATE TABLE" in s]
+    assert len(ddl) == 1, "the mute table must be declared exactly once"
+    import fakepg
+    translated = fakepg.translate_ddl(ddl[0])
+    assert translated and "BLOB" in translated, (
+        "BYTEA must translate to BLOB or the hermetic suite is testing a "
+        "different column type than production")
+
+
+def test_the_mute_table_is_keyed_on_the_binary_id_not_the_name():
+    """`signal.groups.name` is EMPTY for every group this consumer has stored.
+
+    A name-keyed mute would match nothing while looking like a working filter,
+    which is the exact shape of a silent zero.
+    """
+    ddl = next(s for s in _signal_db.SCHEMA_STATEMENTS
+               if "excluded_groups" in s and "CREATE TABLE" in s)
+    assert re.search(r"group_id\s+BYTEA\s+PRIMARY KEY", ddl), ddl
+    # 🔴 Read the COLUMN LIST, not the statement. The previous version did
+    # `ddl.split("(", 1)[1]`, which split on a `(` inside the COMMENT block
+    # above the DDL, so `body` was prose; and its assertion was
+    # `X or "group_id" in body` whose right side is unconditionally true. Two
+    # independent ways of asserting nothing, in one line, both invisible.
+    cols = ddl[ddl.index("CREATE TABLE"):]
+    cols = cols[cols.index("(") + 1:cols.rindex(")")]
+    assert "group_id" in cols
+    assert "name" not in cols, (
+        f"the mute list must not key on a group NAME — column list was: {cols}")

--- a/scripts/signal/tests/test_skill_doc.py
+++ b/scripts/signal/tests/test_skill_doc.py
@@ -159,10 +159,11 @@ def test_skill_documents_every_table_the_schema_creates():
     import _signal_db
     tables = set(re.findall(r"CREATE TABLE IF NOT EXISTS signal\.(\w+)",
                             "\n".join(_signal_db.SCHEMA_STATEMENTS)))
-    # Bumped 5 -> 6 for signal.consumer_health (the liveness row). The literal
-    # is the POINT of this guard: a new table cannot appear without someone
-    # deciding, here, to document it.
-    assert len(tables) == 6, tables
+    # Bumped 5 -> 6 for signal.consumer_health (the liveness row), 6 -> 7 for
+    # signal.excluded_groups (the group mute list). The literal is the POINT of
+    # this guard: a new table cannot appear without someone deciding, here, to
+    # document it.
+    assert len(tables) == 7, tables
     for table in tables:
         assert f"`signal.{table}`" in SKILL_TEXT, f"table {table} undocumented"
 


### PR DESCRIPTION
Asked to "filter out a group entirely". Implemented as a **query-time filter, not an ingest-time drop**, and as **hiding, not deleting** — both for reversibility: this pipeline is forward-only, so a message the consumer declines can never be re-fetched. `unmute` restores a conversation exactly.

## One predicate, one place

`not_excluded()` is the single mute predicate, applied to `list_conversations`, `search` and `get_message`. This module has already paid for the alternative — the reaction dict was open-coded at two sites, and that is *why* the sync site shipped without guards its inbound twin already had.

`test_group_exclusions.py` pins the **ledger** of methods that `SELECT` from `signal.messages` and fails when that set **grows or shrinks**. Its docstring states its **scope honestly**: it greps method source, so it catches the copy-paste shape and *not* SQL held in a constant, hidden behind `search_path`, delegated to a helper, or inherited from a mixin — all four evasions measured. A useful guard, not a proof of completeness.

Keyed on the Signal **binary group id**: a mute must be settable before a group has ever been seen, and no group name had ever been stored — see below.

## 🔴 The bug this found

Writing the comment "names are empty" required checking *why*. Not that signal-cli omits them: `parse_envelope` read `groupInfo.name`, and real envelopes carry **`groupInfo.groupName`**. Measured live: **34 of 34** stored group envelopes have a non-empty `groupName`, **none** has `name`. Every group has been stored with an empty name since day one — which is why `conversations` prints `?` where a group name belongs.

## Audit round 1 — five real defects, three of them mine

An independent adversarial pass plus a differently-built mutation battery found things my own battery could not:

| | |
|---|---|
| 🔴 | A **real Signal group id**, copied out of the live API while checking the field's shape, committed to this **public** repo. Fixtures are now generated. All four content gates scan JSON/JSONL/HTML/TXT and **not `.py`** — nothing here would ever have caught it. **Branch history rewritten**; the literal is in no reachable commit. |
| 🟡 | `upsert_group`'s `COALESCE(EXCLUDED.name, …)` was **dead code that read as protection** — the bind is `name or ""`, so `EXCLUDED.name` is never NULL. A later nameless envelope wiped a stored name back to `''`. A mutant deleting the entire COALESCE **survived all 508 tests**. Now `NULLIF`. |
| 🟡 | `get_draft` matched `is_outbound` alone, which also matches every **device-sync echo** — and those carry a `group_id`, so it returned a muted group's body while `get_message` correctly returned `None` for the same row. Now `send_state IS NOT NULL`, which makes the ledger's exemption reason **true** rather than merely stated. |
| 🟡 | `_decode_internal_id` accepted any valid base64: `Team` (3 bytes) and `deadbeef` (6) were **accepted**, muting nothing while printing success. Now length-checked to 16/32. |
| 🟡 | A note-less re-mute **wiped the recorded reason**. Now COALESCE. |
| 🟡 | `mute` exited **0** whether it matched a real group or nothing. Now exits 4 unless `--allow-unseen`, so the report carries in the exit status and not only in prose. |
| 🟡 | SKILL.md's psql one-liners now **carry the predicate inline** as `$MUTED`, instead of a prose warning one scroll above the query you copy. |

## Verification — re-run from scratch, because a review fix resets the gate

| | |
|---|---|
| `nix build .#checks.x86_64-linux.pytests` | **`RESULT: PASS (exit=0)`** — `TOTAL collected=12747 passed=12746 skipped=1 failed=0` |
| `scripts/signal/tests` | **516 collected, 516 passed**, floor 444 |
| mutation battery, `PYTHONDONTWRITEBYTECODE=1` | **20/20 killed by their NAMED test**, no anchor misses, tree restored byte-identical |
| the group-name fix at pre-change code | **RED (3 tests)** — regression coverage, not an invariant guard |

The battery folds in the four mutants the auditor found **surviving** my original one — which is the evidence that a green first battery was a claim about my imagination, not about the code. Re-running it then exposed a mutant **my own fix had made unreachable**: the new length check swallowed every input that previously reached the canonicality check, so disabling that check left the suite green. Closed with a non-canonical 32-byte case.

The earlier revision of this PR reported the gate as red on `main` for two causes not from this branch. #570 has since fixed the opencode pin and the browser-bridge ceiling has moved; rebased onto current `main`, **the full gate is green**.

## Scope of the claim

Raw `psql` still bypasses the filter — an application predicate cannot bind a statement typed at a shell — which is why the documented queries now embed it rather than warn about it. Muting also does **not** stop ingest: the consumer keeps storing that group's messages, reactions and attachment bytes; it only stops reads returning them. `SKILL.md` says both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
