### PR TITLE
docs(gate): the #551 warning I landed an hour ago is already false — correct it

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -976,11 +976,17 @@ TARGET_FLOORS=(
   # A floor that has fallen far behind is not a weak guard; it is an absent one
   # that still prints a number.
   #
-  # ⚠ ZERO new skips on this target (collected=654 passed=654 skipped=0).
-  # ⚠ Open PR #551 edits THIS line to 580 and is already CONFLICTING. Whoever
-  #   rebases it must re-run the gate on the MERGED tree and copy what it
-  #   prints — do NOT pick between 580 and 622, and do not reconcile the two by
-  #   arithmetic.
+  # ⚠ ZERO new skips on this target (collected=654 passed=654 skipped=0 at the
+  #   time of this measurement).
+  #
+  # 2026-08-20 FOLLOW-UP: #551 has since MERGED and did NOT re-pin this line —
+  # its own 469->580 edit was dropped on rebase, which is exactly what the
+  # merged-tree rule produces once 622 is already in main. It did add tests:
+  # this target now collects 680, still inside the 622/777 band, so the gate is
+  # green and no re-pin is owed. Left at 622 deliberately — the convention here
+  # is to re-pin when the gate FIRES and to copy the number it prints, not to
+  # tighten a band that is holding. (For reference only, not applied:
+  # _suggested_floor 680 = 646.)
   "scripts/browser-bridge/tests|622"
   "scripts/validation/tests|97"
   # 2026-08-12, initiative-scan's `gh_available` honesty flag: 381 -> 386


### PR DESCRIPTION
docs(gate): the #551 warning I landed an hour ago is already false — correct it

#571 added a "⚠ Open PR #551 edits THIS line to 580 and is already CONFLICTING"
note to the browser-bridge floor entry. #551 merged shortly after, so the file now
carries a live-state claim that is wrong. A comment is a claim, and this table's
entire value is that its provenance is true — a stale warning here is worse than
no warning, because the next reader trusts it.

WHAT ACTUALLY HAPPENED, measured rather than assumed:
  - #551 merged and did NOT re-pin this line. The last three commits to
    run-tests.sh are #571, #570 and #558; #551 is not among them. Its own
    469->580 edit was dropped on rebase — which is exactly what the merged-tree
    rule produces once 622 is already in main, so the note did its job and then
    outlived its subject.
  - #551 did add tests: this target now collects 680, up from the 654 the entry
    records.
  - 680 sits inside the 622/777 band, so the gate is GREEN and no re-pin is owed.

LEFT AT 622 DELIBERATELY. _suggested_floor 680 would be 646, which would tighten
the silent band from 58 to 34 — but the convention in this table is to re-pin when
the gate FIRES and to copy the number it prints, not to pre-emptively tighten a
band that is holding. Applying the rule to a count the gate never complained about
would be exactly the "number someone computed" this file warns against. The 646 is
recorded in the comment as a reference, explicitly not applied.

Also softened the "ZERO new skips" line to say it describes the measurement at
that time, since the count has since moved.

COMMENT-ONLY: no executable line changes, the floor is still exactly 622.
Verified — diff filtered to non-comment lines is empty, `bash -n` clean,
`--check-floors` reports "all 24 floor(s) pin a known target, both ways" with
floor 622, RESULT: PASS.
