### PR TITLE
docs(slots): the hotkey comment names an i3 chord bound to nothing

### DIFF
--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -149,7 +149,8 @@ ACKNOWLEDGED_UNSTUBBED = {
     "home-manager": (
         {"bar-status-poll", "drift-check.sh", "keylog-spin-capture.sh",
          "notify-failure.sh", "playwright-nixos", "session-manager",
-         "session-resolve", "ship.sh", "tmux-post-save.sh"},
+         "session-resolve", "ship.sh", "tmux-post-save.sh",
+         "tmux-scratch-slots.sh"},
         "MEASURED unreachable: a whole-tier run under a recording interceptor "
         "logged ZERO calls. TWO of these are executed by scripts/tests and "
         "neither can reach the binary: notify-failure.sh names home-manager in "
@@ -171,7 +172,25 @@ ACKNOWLEDGED_UNSTUBBED = {
         "narrowed by an ALLOWLIST of list-panes/list-windows/list-clients "
         "that raises on anything else — test_session_resolve.py pins that "
         "allowlist in both directions, so this justification cannot rot into "
-        "a claim about a file that has grown a launcher"),
+        "a claim about a file that has grown a launcher. "
+        "tmux-scratch-slots.sh (added 2026-08-19) is the FOURTH of this shape "
+        "and carries the STRONGEST form of the justification: the other three "
+        "merely lack a call site, whereas this file has no executable "
+        "statement at all. It is the slot table that session-resolve's entry "
+        "above refers to, and its entire non-comment body is a single "
+        "`SCRATCH_SLOTS=( ... )` array literal of 20 quoted "
+        "session:key:colour:name strings — measured with "
+        "`grep -vE '^\\s*#|^\\s*$'`, which returns the array and nothing else. "
+        "There is no command substitution, pipe, exec or eval anywhere in it, "
+        "and it is SOURCED rather than executed. Its single `home-manager` "
+        "occurrence is one word of comment prose at line 4, recording that the "
+        "tmux `bind -n M-<key>` popup toggles are GENERATED from this table by "
+        "nix/programs/tmux/default.nix (`builtins.readFile`) and that the "
+        "table is therefore the source of truth rather than a mirror. That "
+        "sentence was added to correct a comment which had documented the "
+        "hotkey as a `$mod+Shift+<key>` i3 chord bound to nothing; the "
+        "correction is what put the file in this scanner's sights, and it is "
+        "re-justified here rather than reworded to dodge the scanner"),
     "nixos-rebuild": (
         {"airvpn-sudo", "ship.sh"},
         "MEASURED unreachable in the same whole-tier run; both call sites are "

--- a/scripts/tmux-scratch-slots.sh
+++ b/scripts/tmux-scratch-slots.sh
@@ -1,7 +1,23 @@
 #!/usr/bin/env bash
 # Canonical scratchpad slot table — THE single source of truth for the
-# session <-> hotkey <-> color <-> codename mapping, mirroring the tmux/i3
-# scratchpad bindings ($mod+Shift+V -> tmux session `scratch4` -> codename `Vapor`).
+# session <-> hotkey <-> color <-> codename mapping. The tmux `bind -n M-<key>`
+# popup toggles are GENERATED from this table at home-manager build time
+# (nix/programs/tmux/default.nix), so this file is the source, not a mirror.
+# Example: `Alt+Shift+V` -> tmux session `scratch4` -> codename `Vapor`.
+#
+# 🔴 The binding is tmux's ROOT key table, NOT i3. There is no i3 binding for any
+# slot — measured: `grep -rE 'mod\+Shift\+(V|G|P)' nix/i3/` -> 0, against 79 live
+# `bindsym` lines in nix/i3/config.nix, and 22 `M-<key>` entries in
+# `tmux list-keys -T root`. A previous version of this comment spelled the hotkey
+# `$mod+Shift+V` (i3 syntax); a reader following it presses a chord that is bound
+# to nothing.
+#
+# 🔴 CASE IS SIGNIFICANT and is not a shift-modifier convention: `M-v` -> scratch3
+# (`violet`) and `M-V` -> scratch4 (`Vapor`) are DIFFERENT sessions. Never
+# lowercase a key when quoting it.
+#
+# Each binding is a TOGGLE: if the client is already in that session it runs
+# `detach-client` (dismissing the popup); otherwise it opens `display-popup`.
 #
 # This file is SOURCED (not executed). Consumers — keep in sync by reading THIS,
 # never a private copy:
@@ -11,7 +27,8 @@
 #
 # Field order per entry:  session:key:color:name
 #   session — tmux session name (also the emit key)
-#   key     — hotkey letter ($mod+Shift+<key>)
+#   key     — hotkey letter; the binding is tmux `bind -n M-<key>` (Alt+<key>),
+#             case-sensitive. NOT an i3 chord.
 #   color   — hex, matches the popup border color in .tmux.conf
 #   name    — human codename shown in the HUD / ledger
 # Consumers source this by looking in their own dir for the deployed name first,


### PR DESCRIPTION
`scripts/tmux-scratch-slots.sh` documented its `key` field as `$mod+Shift+<key>` and gave `$mod+Shift+V -> scratch4 -> Vapor` as the worked example. **No such i3 binding exists.** The real binding is tmux's root key table, `bind -n M-<key>`, generated from this very file at home-manager build time.

A reader following the old comment presses a chord bound to nothing — the failure mode a *wrong* comment produces and an absent one does not.

## Measured, with controls

| probe | result |
|---|---|
| `grep -rE 'mod\+Shift\+(V\|G\|P)' nix/i3/` | **0** |
| `grep -c bindsym nix/i3/config.nix` | 79 — control: the pattern *can* match |
| `tmux list-keys -T root \| grep -cE 'M-[A-Za-z] '` | 22 — the real mechanism |

The controls matter: a bare `0` from a grep is indistinguishable from a wrong pattern.

## Two further facts the comment now records

- **Case is significant, and is not a shift-modifier convention.** `M-v` -> `scratch3` (`violet`), `M-V` -> `scratch4` (`Vapor`) — *different sessions*. Quoting a hotkey lowercased points at the wrong window.
- **Each binding is a toggle** whose "already in that session" branch is `detach-client` (dismissing the popup), confirmed in the live `tmux list-keys` output.

The generation claim in the new comment was verified rather than inherited from the `window-triage` skill: `nix/programs/tmux/default.nix:9` does `builtins.readFile ../../../scripts/tmux-scratch-slots.sh`, bindings built at `:27`.

## Scope and what is deliberately not here

Comment-only. `bash -n` clean; the table still sources to 20 slots.

**No test.** A guard on this prose would be walkable by rewording, which this repo's RULES call out as producing false confidence. The guard actually worth having is structural — every slot `key` appears as a case-sensitive `M-<key>` in the generated tmux config, which would also pin the case claim above — but it needs a new test target and therefore a `run-tests.sh` `TARGET_FLOORS` edit, and that table is a known conflict hotspot with a sibling PR currently in flight. Filed as a follow-up rather than taken now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)