### PR TITLE
docs(opencode): the AGENTS.md "7.7k uncached tokens per request" is HALF true — the tokens are real, the "uncached" is not

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1162,9 +1162,22 @@ in
   # wins), so this is the file opencode really reads.
   #
   # Concatenating at switch time means it can never drift from the sources
-  # Claude Code reads. Measured result: 38,363 B / 37.5 KB ≈ 8.9k tokens (at the
-  # 4.31 B/token measured on this exact content) — safe. (For scale: a 331 KB
-  # AGENTS.md causes a permanent compaction loop.)
+  # Claude Code reads.
+  #
+  # COST — re-measured 2026-08-19 on engine 1.18.18 / openrouter/xiaomi/mimo-v2.5.
+  # The file is 43,676 B = 8,329 input tokens (A/B pair: one trivial prompt in an
+  # empty scratch project, under two config dirs identical in every byte except
+  # this file — 22,019 input tok with it, 13,690 without).
+  # 🔴 That is NOT a per-request tax, and the note that used to stand here
+  # implied it was. The file sits at the HEAD of the prompt prefix, which is
+  # exactly what a provider prefix-cache retains: of the 2,218 billed requests
+  # this box logged on 1.18.16+1.18.18, only 60 (2.7%) were cold, and a cached
+  # token bills ~50x under an input token. Attributed cost of this file over that
+  # window: ~$0.12 of $1.77 total spend (~7%). A COLD first request does pay the
+  # full 8,329 — that, not the steady state, is what browser-agent's isolated
+  # config dir sheds (every one of its runs is single-shot).
+  # Full working: scripts/opencode/README.md → "Size, and what it actually costs".
+  # (For scale: a 331 KB AGENTS.md causes a permanent compaction loop.)
   # scripts/tests/test_opencode_config.py pins the content and a 100 KB ceiling.
   home.file.".config/opencode/AGENTS.md".text =
     builtins.readFile ../claude/PRINCIPLES.md

--- a/scripts/browser-bridge/browser-agent
+++ b/scripts/browser-bridge/browser-agent
@@ -80,17 +80,28 @@ die() { echo "browser-agent: $*" >&2; exit 2; }
 command -v "$OPENCODE_BIN" >/dev/null 2>&1 || die "opencode not found on PATH ('$OPENCODE_BIN') — install it or set BROWSER_AGENT_OPENCODE"
 
 # --- isolated opencode CONFIG dir (token containment) ------------------------ #
-# devrc now deploys a ~37 KB global ~/.config/opencode/AGENTS.md (PRINCIPLES +
+# devrc now deploys a ~43 KB global ~/.config/opencode/AGENTS.md (PRINCIPLES +
 # RULES + addendum). MEASURED on 1.18.4: that file IS injected into a run whose
 # --dir is an unrelated scratch project — a tool-less probe in a scratch dir
 # quoted a passphrase planted at the END of the file, so it arrives in FULL.
 #
 # Cost here: 8,343 input tokens vs 631 with an isolated config dir = ~7.7k
-# EXTRA PER REQUEST. `cache.read`/`cache.write` were 0 in every run, so it is
-# not amortised — it is multiplied by the agent-loop step count ($STEPS,
-# default 12), i.e. up to ~90k tokens per browser-agent run. For an agent whose
-# every host tool is DENIED (no shell, no file access), 100% of that is rules it
-# can neither use nor act on.
+# EXTRA PER REQUEST (re-measured 2026-08-19 on 1.18.18: 8,329 — the file grew,
+# the number did not really move). It is multiplied by the agent-loop step count
+# ($STEPS, default 12), i.e. up to ~100k tokens per browser-agent run. For an
+# agent whose every host tool is DENIED (no shell, no file access), 100% of that
+# is rules it can neither use nor act on.
+#
+# 🔴 SCOPE OF THE "not amortised" CLAIM. `cache.read`/`cache.write` were 0 in
+# every run measured HERE, and that is a fact about THIS harness's shape, not
+# about the engine: browser-agent runs are single-shot against a fresh scratch
+# project, so the prefix is cold every time. It does NOT generalise — across
+# 2,218 billed requests of ordinary opencode use on this box, only 60 (2.7%)
+# were cold and cache reads bill ~50x under input tokens, which makes the same
+# file ~7% of spend there rather than a per-request tax. So this dir is the
+# right call for browser-agent and the WRONG one as a general fix (it also drops
+# plugin/guard.js). Working: scripts/opencode/README.md → "Size, and what it
+# actually costs".
 #
 # Neither mitigation that looks obvious works: OPENCODE_DISABLE_CLAUDE_CODE=1
 # had ZERO effect (byte-identical token count), and a project-local AGENTS.md

--- a/scripts/opencode/README.md
+++ b/scripts/opencode/README.md
@@ -166,9 +166,59 @@ from the sources Claude Code reads. A project `AGENTS.md` also *suppresses*
 `CLAUDE.md` entirely (first match wins), which is why this is the file that
 matters.
 
-Size matters here: the generated file measures **38,363 B (37.5 KB) ≈ 8.9k
-tokens**, which is fine. A 331 KB `AGENTS.md` causes a permanent compaction loop.
-`scripts/tests/test_opencode_config.py` enforces a 100 KB ceiling.
+### Size, and what it actually costs
+
+Re-measured **2026-08-19** on engine **1.18.18**, model
+**`openrouter/xiaomi/mimo-v2.5`**. Instrument: opencode's own store,
+`~/.local/share/opencode/opencode-stable.db` (`session` / `message` tables carry
+`cost`, `tokens_input`, `tokens_cache_read`), read read-only.
+
+**The A/B pair.** One trivial prompt ("reply PONG, use no tools") run in an empty
+scratch project under two config dirs that were identical in every byte *except*
+this file — B was a `cp -a` of the live `~/.config/opencode` with `AGENTS.md`
+deleted, so skills, agents, plugins and `opencode.jsonc` were held constant:
+
+| run | `tokens_input` | `tokens_cache_read` | cost |
+|---|---|---|---|
+| **A** — with `AGENTS.md` | 22,019 | 1,024 | $0.0030964 |
+| **B** — without | 13,690 | 1,024 | $0.0019276 |
+
+→ the file is **8,329 input tokens** (43,676 B ÷ 8,329 = 5.24 B/token), i.e. 38%
+of a minimal prompt. `tokens_cache_read` is identical in both, so on a **cold**
+request the file really is paid in full.
+
+**But the steady state is cached, and that is the part an older note got wrong.**
+`AGENTS.md` sits at the *head* of the prompt prefix — exactly what a provider
+prefix-cache retains. Two controls:
+
+* A third run, a **fresh session with the same prompt** ~2 min after A:
+  `tokens_input` **3**, `tokens_cache_read` **23,040**, cost **$0.000074** — a
+  42x reduction, and cross-session, so the cache is not per-session.
+* Fleet-wide over engines 1.18.16+1.18.18 on this box: **2,218 billed requests,
+  of which 60 (2.7%) were cold**; 97.3% of prompt tokens arrived as cache reads.
+  Grouped by version, the cached fraction is 92.0% on 1.18.4, 93.0% on 1.18.9,
+  93.1% on 1.18.16, 97.2% on 1.18.18 — so **caching was already working on
+  1.18.4**; it was never engine-version-dependent.
+
+Prices solved from those three probe rows (three equations, three unknowns):
+input **≈$0.14/Mtok**, output **≈$0.28/Mtok**, cache read **≈$0.0028/Mtok** —
+a cached token bills **~50x under** an input token. Attributing this file across
+that 2,218-request window: 60 cold x 8,329 x $0.14/M + 2,158 warm x 8,329 x
+$0.0028/M ≈ **$0.12 of $1.77 total spend, ~7%**.
+
+**Conclusion: shrinking this file is not a token-cost lever.** The per-request
+number (8,329) is real and slightly larger than the 7.7k once measured on 1.18.4
+— the file grew — but it is not multiplied by every step of an agent loop.
+`browser-agent`'s isolated config dir is still correct *for its shape*: every one
+of its runs is single-shot with a fresh prefix, so it is the 2.7% cold case every
+time. Do not generalise that trick to normal dispatch — it also drops
+`plugin/guard.js`, the enforcement layer between an agent and an irreversible
+action.
+
+A 331 KB `AGENTS.md` causes a permanent compaction loop;
+`scripts/tests/test_opencode_config.py` enforces a 100 KB ceiling. That ceiling
+is a **context-window** guard, not a cost one, and it remains the reason to care
+about size.
 
 ## Why `plugin/env.js` is generated too
 

--- a/scripts/tests/test_opencode_config.py
+++ b/scripts/tests/test_opencode_config.py
@@ -2043,7 +2043,7 @@ def test_browser_agent_config_dir_is_not_the_live_one():
                 if ln.startswith("OC_CONFIG_DIR="))
     assert ".config/opencode" not in line, (
         "the isolated config dir must NOT be the live ~/.config/opencode — that "
-        "re-imports the ~37 KB AGENTS.md this mechanism exists to shed, and puts "
+        "re-imports the ~43 KB AGENTS.md this mechanism exists to shed, and puts "
         "the warm step's `rm -rf` on the managed directory"
     )
 

--- a/scripts/tests/test_opencode_engine.py
+++ b/scripts/tests/test_opencode_engine.py
@@ -886,6 +886,33 @@ HISTORICAL_VERSION_CLAIMS = (
      "the k8s index-74 record; its counts describe a tree that no longer exists"),
     ("scripts/tests/test_opencode_config.py", "is deprecated (last measured on opencode",
      "the DEPRECATED-key list, third copy — in the assertion message"),
+    # 🔴 A CROSS-VERSION COMPARISON. These are not claims about what the pinned
+    # engine does — the older versions ARE the evidence, and the comparison
+    # BETWEEN them is the whole finding: a prompt-cache hit rate measured at each
+    # engine in the series is what refutes the theory that caching arrived with a
+    # recent one. Re-deriving these against the pin is not "updating a stale
+    # number", it is deleting the control and leaving a single data point that
+    # cannot support the conclusion drawn from it. Newly VISIBLE rather than
+    # newly stale in one respect too: several end their sentence on the version,
+    # which the pre-#570 `_VERSION_RE` could not see.
+    #
+    # (This comment deliberately spells NO version literal. The first draft
+    # enumerated the series and the scanner flagged it — correctly, since this
+    # file is itself in PIN_SURFACE. Naming them here would also have needed a
+    # ledger entry exempting the ledger's own commentary, which is circular.)
+    ("scripts/opencode/README.md", "Fleet-wide over engines",
+     "spans two engines by design — the window the 2.7%-cold figure was counted over"),
+    ("scripts/opencode/README.md", "Grouped by version, the cached fraction is",
+     "per-version cache rates; each number is a measurement OF that version"),
+    ("scripts/opencode/README.md", "so **caching was already working on",
+     "same series, second line — the older rates are the control, not a stale claim"),
+    ("scripts/opencode/README.md", "it was never engine-version-dependent",
+     "the conclusion the older versions exist to support; re-keying it to the pin "
+     "would assert the opposite of what was measured"),
+    ("scripts/opencode/README.md", "is real and slightly larger than the 7.7k once measured on",
+     "cites the PRIOR measurement as the before-value of a then-vs-now comparison"),
+    ("nix/home.nix", "only 60 (2.7%) were cold",
+     "the same two-engine counting window, in the generator's own summary"),
     # 🔴 THE DEPLOYED-STATE EXEMPTIONS ARE GONE, and their absence is the record.
     # Five lines said "both hosts run 1.18.4" — TRUE while the lock pinned 1.18.16
     # and the hosts had not converged, which is exactly why they were exempt


### PR DESCRIPTION
## The measurement, with its control

Task was: confirm or refute that the generated `~/.config/opencode/AGENTS.md` costs ~7.7k **uncached** input tokens on every opencode request, on the **current** engine — and only then cut. Measured first. **The token count is confirmed; the "uncached" half is refuted.** No cut is warranted, so this PR changes only the claims.

Engine **1.18.18**, model **`openrouter/xiaomi/mimo-v2.5`**. Instrument: opencode's own store `~/.local/share/opencode/opencode-stable.db`, read read-only.

### A/B pair — same prompt, same model, one variable

One trivial prompt ("reply PONG, use no tools") in an empty scratch project, under two config dirs identical in every byte **except this file** — B was a `cp -a` of the live `~/.config/opencode` with only `AGENTS.md` deleted, so skills, agents, plugins and `opencode.jsonc` were held constant.

| run | `tokens_input` | `tokens_cache_read` | cost |
|---|---|---|---|
| **A** — with `AGENTS.md` | 22,019 | 1,024 | $0.0030964 |
| **B** — without | 13,690 | 1,024 | $0.0019276 |

→ the file is **8,329 input tokens** (43,676 B ÷ 8,329 = 5.24 B/token). Slightly **larger** than the 7.7k recorded on 1.18.4 — the file grew 38,363 → 43,676 B. On a **cold** request it really is paid in full.

### …but the steady state is cached, and that is what changes the verdict

`AGENTS.md` sits at the **head** of the prompt prefix, which is exactly what a provider prefix-cache retains. Two controls:

- **Third run** — fresh session, same prompt, ~2 min after A: `tokens_input` **3**, `tokens_cache_read` **23,040**, cost **$0.000074**. A 42× reduction, and *cross-session*, so the cache is not per-session.
- **Fleet-wide** on this box over 1.18.16+1.18.18: **2,218 billed requests, of which only 60 (2.7%) were cold.** By version the cached fraction is **92.0% on 1.18.4**, 93.0% on 1.18.9, 93.1% on 1.18.16, 97.2% on 1.18.18 — so caching was **already working on 1.18.4**. It was never engine-version-dependent; the zero in `browser-agent`'s note is a fact about *that harness's* single-shot shape, not about the engine.

Solving the three probe rows for prices (three equations, three unknowns): input **≈$0.14/Mtok**, output **≈$0.28/Mtok**, cache read **≈$0.0028/Mtok** — a cached token bills **~50× under** an input token. Attributing the file across that 2,218-request window: 60 cold × 8,329 × $0.14/M + 2,158 warm × 8,329 × $0.0028/M ≈ **$0.12 of $1.77 total spend, ~7%**.

**Verdict: not a token-cost lever.** Per the brief — "if the overhead is now small or cached, say so and stop" — Phase 2 was not entered. Nothing is cut, no ceiling is moved, `claude/RULES.md` is untouched.

## What this PR does change

Every hunk is a stale or over-general **claim**. The diff on `nix/home.nix` and `scripts/browser-bridge/browser-agent` contains **zero non-comment lines**, so the generated file's `.text` expression and browser-agent's behaviour are byte-identical.

- **`nix/home.nix`** — the generator comment recorded "38,363 B / 37.5 KB ≈ 8.9k tokens (at 4.31 B/token)" for a file that is now 43,676 B, and implied a per-request tax. Replaced with the current pair + the cache finding, pointing at the README for the working.
- **`scripts/opencode/README.md`** — same stale paragraph; now carries the measurement, its control, the price solve and the conclusion under **"Size, and what it actually costs"**.
- **`scripts/browser-bridge/browser-agent`** — "`cache.read`/`cache.write` were 0 in every run, so it is not amortised" reads as a claim about the **engine**. Scoped it to this harness, and stated plainly that the isolated-config-dir trick is right *here* and **wrong as a general fix** — it also drops `plugin/guard.js`, the enforcement layer between an agent and an irreversible action. Its `~37 KB` → `~43 KB`.
- **`scripts/tests/test_opencode_config.py`** — one assertion message said `~37 KB`.

## Verification

- `nix-instantiate --parse nix/home.nix` → OK.
- `test_opencode_config.py` + `test_browser_agent.py` → **688 passed** in the `pytests` devShell (`PYTHONDONTWRITEBYTECODE=1`, no `-x`).
- No new test: this is comment-only, and a byte-pin on the generated size would trip on every `RULES.md` edit — a permanently-red gate, which RULES.md forbids.

## What I could not verify

- The **price solve** ($0.14 / $0.28 / $0.0028 per Mtok) is derived from three probe rows, not from a published OpenRouter price sheet. It reproduces all three rows to within ~1%, but it is a fit, not a quoted tariff.
- **Cache TTL is unmeasured.** I measured warm at ~2 minutes and cold at first contact; I did not find the boundary between them. The 2.7%-cold figure is the empirical answer for *Zach's* usage pattern and would move for a workload of widely-spaced one-shot runs.
- The A/B delta is **one** cold pair. A second cold pair is not cheaply obtainable — a repeat run hits the very cache being measured. It is cross-checked against the independent historical figure: 7,700 × (43,676/38,363) = 8,766 vs 8,329 measured, agreeing within 5% across two different tokenizers.

## Notes for siblings

Touches nothing in `scripts/collector/opencode/activity-plugin.js`. The probe runs wrote 4 real rows to the shared opencode SQLite store and emitted `source=opencode` telemetry — expected, flagged for the session-attribution agent: titles `ZPROBE-A1-withagents`, `ZPROBE-B1-noagents`, `ZPROBE-A2-withagents-repeat`, total spend $0.0067.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
