### PR TITLE
fix(gate): the browser-bridge size figure went stale the moment #551 edited the file — re-measure, do not relax

### DIFF
--- a/scripts/tests/test_prune_skill_size.py
+++ b/scripts/tests/test_prune_skill_size.py
@@ -28,7 +28,7 @@ is exactly how the drift regrows.
 
 WHY THE CEILING IS ABOVE THE 12,288 B TARGET, AND WHAT THAT COSTS
 -----------------------------------------------------------------
-The skill states a 12,288 B target and browser-bridge MEETS it (11,942 B while
+The skill states a 12,288 B target and browser-bridge MEETS it (11,990 B while
 routing ~11x its own weight), so the target is achievable and is not in dispute.
 This file does not: it sits at 12,859 B (12.56 KiB) after being cut from 14,918 B
 by demoting §6 (landing), §4's deployment table, §7's verification rationale, §0's


### PR DESCRIPTION
## `main` is red

`test_prune_skill_size.py:31` states *"browser-bridge MEETS it (11,942 B …)"* while the file on `main` is **11,990 B**. The module guards its own prose against a live measurement:

```
this module's own figures no longer describe what they measure:
    browser-bridge size: prose says 11,942, measured 11,990
Re-measure and update the prose; do NOT relax this test.
```

**Cause:** #551 edited `scripts/browser-bridge/SKILL.md` (its own body records `11,821 → 11,921 B`) and the figure didn't follow. It landed *after* the last green measurement of `main`, which is why an earlier reading of the same suite was clean and this one isn't.

## The fix

Re-measured, not relaxed. **One number, one line**, nothing else in the diff — so the red→green attribution has nothing to hide behind.

| | prose says | file actually is |
|---|---|---|
| `origin/main` | 11,942 B | **11,990 B** |
| this branch | **11,990 B** | 11,990 B |

## Verification

`TOTAL collected=12785 passed=12784 skipped=1 failed=0`, `RESULT: PASS (exit=0)` — read from `nix log` content, not an exit code.

## Flagged, not bundled

The same failure output reports this skill at **571 B over its 12,288 B target with 5 B of working slack**, plus two deliberately ungated figures. That's a real headroom problem, but closing it means deciding what to evict — a judgment call that would muddy this attribution. Separate change.

## 🔴 Third stale-figure failure today

The opencode pin, the browser-bridge floor, and this. All the same shape: prose asserting a measurement of an artifact someone later edited; all caught by a gate built for exactly that. The gates are working.

If a fourth appears, the fix is probably to **derive** these figures at test time rather than restate and pin them — the way `TARGET_FLOORS` already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
