### PR TITLE
feat(opencode): a dispatch gate for the failure that exits 0 having done nothing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,17 @@ __pycache__/
 # committable.
 .envrc
 
+# Briefs and run logs written by `opencode-dispatch`. The brief is deliberately
+# placed INSIDE --dir (that is what makes an external-directory auto-reject
+# structurally impossible), so in devrc it lands in the working tree. It is
+# scratch work: it quotes task detail, paths and hostnames that belong to no
+# repo, and this repo is PUBLIC.
+#
+# Unanchored on purpose — `--dir` can be any subdirectory. The tool also writes
+# a self-ignoring `.gitignore` into the subdir on first use, so a target repo
+# that is not devrc is covered too; this line is the belt to that's braces.
+.opencode-dispatch/
+
 # opencode's per-repo runtime dir: node_modules, a generated package.json, and
 # a `commands` symlink into the gitignored .claude/. Its own inner .gitignore
 # covers the generated files but not the directory itself, so without this line

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ is preserved verbatim in `docs/LAYOUT.md` (not auto-loaded, and stale by design)
 | `scripts/mail-actions/` | `mailbox` | email-automation layer over the self-hosted inbox (**separate from activity telemetry**) |
 | `scripts/repo-cos/` | `repo-cos` | weekly repo "chief-of-staff" proposal digest + reply-driven exclusions |
 | `nix/i3/`, `nix/graphical.nix`, `scripts/bar-status-poll` | `bar` | i3 + i3status-rust bar, count blocks, dunst toasts |
+| `scripts/opencode/` | `opencode` | dispatch a task to the headless opencode agent (`opencode-dispatch`), + its config/agents/guard plugin |
 
 Repo-level facts that are NOT in any skill — they live here on purpose:
 - 🔴 **A NEW file must be `git add`ed or the flake silently omits it from the deploy.** Applies to every managed path: a new skill, a new `reference/*.md` inside one, an extension file, a hook or a test. The switch succeeds and the file simply is not there.

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -979,6 +979,26 @@ in
     config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/scripts/browser-bridge/SKILL.md";
   home.file.".claude/skills/browser/browser".source =
     config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/scripts/browser-bridge/browser";
+  # `opencode` skill — the SAME deliberate exception as `browser`/`dl-router`
+  # above, for the same reason: its source of truth is the opencode subsystem in
+  # THIS repo (scripts/opencode/), not devrc/claude/skills/, and the CLI reads
+  # scripts/opencode/opencode.jsonc + scripts/opencode/lib/ + scripts/claude-hooks/
+  # relative to its own resolved __file__. A store copy would resolve those into
+  # /nix/store and read a FROZEN permission block — so preflight would answer
+  # from whatever config was current at the last switch, which is exactly the
+  # stale-artifact failure mode CLAUDE.md warns about. Out-of-store keeps the
+  # resolver and the config it resolves against as one live tree.
+  #
+  # 🔴 Only these two paths are symlinked; `lib/` is NOT deployed and must not
+  # be. The CLI reaches it through the repo checkout via `__file__`, which is
+  # the same way `dl-route` reaches its siblings.
+  home.file.".claude/skills/opencode/SKILL.md".source =
+    config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/scripts/opencode/SKILL.md";
+  home.file.".claude/skills/opencode/opencode-dispatch".source =
+    config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/scripts/opencode/opencode-dispatch";
+  # …and on PATH, like dl-route, so the skill body's commands are copy-pasteable.
+  home.file.".local/bin/opencode-dispatch".source =
+    config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/scripts/opencode/opencode-dispatch";
   # Claude Code hooks managed here (the script only — the settings.json
   # registration is per-host/unmanaged, as for bash-guard.py above, whose script
   # is likewise managed now). audit-pr-nudge fires

--- a/scripts/opencode/SKILL.md
+++ b/scripts/opencode/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: opencode
+description: Dispatch a task to opencode — the separate headless CLI agent — instead of burning this session's context on it. Preflights the brief first (a brief naming paths outside --dir makes `opencode run` auto-reject and exit 0 having done nothing), then launches detached. Use for "dispatch opencode", "call opencode", "run this with opencode", "hand it to flash/mimo/pro", opencode token efficiency. NOT the Agent tool — "dispatch a subagent" means that, not this.
+---
+
+# opencode dispatch
+
+Hand a bounded task to **opencode**, a separate headless agent CLI with its own
+context window. The point is *your* context budget: seven weeks of opencode cost
+**$11.42** total, median dispatch **$0.014** — money is not the variable.
+
+## The whole invocation
+
+```bash
+opencode-dispatch run --dir <PROJECT-DIR> --title "<short title>" -m flash <<'BRIEF'
+<the complete task specification>
+BRIEF
+```
+
+That is it. Do **not** re-derive the CLI — `opencode --version`, `--help`,
+`run --help` and `models` were re-run from scratch in **nine** separate sessions
+and answered nothing that is not on this page.
+
+- The brief comes in on **stdin** (or `--brief FILE`). It is written **into
+  `--dir`** at `.opencode-dispatch/<ts>-<slug>.md`, which self-ignores in
+  whatever repo that is.
+- `--dir` is required and is opencode's project root. Every path the brief names
+  must be under it.
+- The run is **detached**. The call returns immediately and prints a log path.
+  There is no foreground mode and no flag to ask for one.
+
+### Models
+
+| alias | model |
+|---|---|
+| `flash` | `openrouter/deepseek/deepseek-v4-flash` |
+| `mimo` | `openrouter/xiaomi/mimo-v2.5` |
+| `pro` | `openrouter/deepseek/deepseek-v4-pro` |
+
+Omit `-m` to take the `opencode.jsonc` default (what 18 of 24 measured
+dispatches did). A full `provider/vendor/model` id passes through; an unknown
+bare word is a usage error, not a silent pass-through.
+
+### Other flags, in order of how often they actually get used
+
+`--dir` 18 · `--title` 7 · `--file` 7 (extra attachments; the brief is attached
+automatically) · `-m` 6 · `--auto` 4 · `-c` 2 (continue the last session).
+
+## Check a brief without dispatching
+
+```bash
+opencode-dispatch preflight --dir <PROJECT-DIR> --brief <FILE>   # or stdin
+```
+
+`--json` for a machine-readable report. Exit **3** means the brief was refused.
+
+## Reading the result
+
+`status` and `watch` are **deliberately not built** — they would depend on
+opencode's internal SQLite schema, which carries no stability guarantee. That
+dependency is worth taking only once this skill is proven to get used. For now:
+
+```bash
+tail -n 60 <the log path printed on dispatch>
+```
+
+## Why this exists — four measured failure modes, three success-shaped
+
+1. 🔴 **`external_directory: "ask"` → headless auto-reject → exit 0, no work.**
+   The brief named a path outside `--dir`. `opencode run` **auto-rejects** an
+   `ask` (only the interactive TUI prompts). Fingerprint in opencode's own
+   store: 10 of 321 sessions with `model IS NULL` and 0 tokens. Happened twice,
+   in both directions — a read, then a write.
+   *Closed two ways:* the brief is written **inside** `--dir`, and preflight
+   **refuses (rc 3)** if the brief's text names any absolute path outside it.
+2. **`--file` is an array option** and swallowed the message as a second
+   filename (`Error: File not found: Execute the task described in…`). The
+   message positional now always comes first, pinned by a test on its argv index.
+3. **`permission.bash` `ask` → auto-reject mid-run.** opencode needed
+   `kubectl exec … psql`, was auto-rejected, and the dispatch was abandoned.
+   Preflight **warns** (never blocks) and names the glob.
+4. **20% of opencode sessions exceed the Bash tool's hard 600,000 ms ceiling**
+   (p90 2508s, p95 9119s); one died at exactly 600s with `Exit code 143`. Hence
+   detached-always.
+
+## When preflight refuses
+
+It refused because a path in the brief is not under `--dir`. Fix the **brief or
+the `--dir`**, never the check — three options, in order of preference:
+
+1. move the file under `--dir`;
+2. widen `--dir` to a directory containing both;
+3. inline the content into the brief instead of pointing at it.
+
+There is no override flag. The failure it prevents is a silent exit 0, which is
+the one shape nobody notices.
+
+A `⚠ WARN` line is different — it is advisory and the dispatch proceeds. It goes
+through a parser that deliberately over-matches, so blocking on it would build a
+gate people learn to click through.
+
+## What this is NOT
+
+- **Not a Claude subagent.** "dispatch a subagent to implement X" is the **Agent
+  tool**. Only the literal word *opencode* routes here.
+- **Not the `browser` skill.** "dispatch a browser agent" is that one.
+- **No auto-retry.** The measured failures are corrective, not transient:
+  re-running a known-bad brief is not a fix. Fix the brief, dispatch again.
+
+## Writing a brief that lands
+
+- State the goal, the acceptance check, and where the code is — **relative to
+  `--dir`**.
+- Put commands in fenced ```bash blocks so preflight can see them.
+- Assume no follow-up questions are possible. opencode is unattended; every
+  `ask` is an auto-reject, not a prompt.
+
+## Files
+
+`scripts/opencode/` — `opencode-dispatch` (the CLI), `lib/oc_permissions.py`
+(the shared resolver `scripts/tests/test_opencode_config.py` also pins),
+`lib/brief_scan.py` (both scanners), `opencode.jsonc` (the permission block
+preflight reads). Config, agents and the guard plugin are documented in
+`scripts/opencode/README.md`.

--- a/scripts/opencode/SKILL.md
+++ b/scripts/opencode/SKILL.md
@@ -46,6 +46,10 @@ bare word is a usage error, not a silent pass-through.
 `--dir` 18 · `--title` 7 · `--file` 7 (extra attachments; the brief is attached
 automatically) · `-m` 6 · `--auto` 4 · `-c` 2 (continue the last session).
 
+**`--file` attachments are containment-checked too** — each must resolve under
+`--dir`, exactly like a path named in the brief. `preflight` accepts `--file`
+as well, so you can check them without dispatching.
+
 ## Check a brief without dispatching
 
 ```bash
@@ -85,8 +89,10 @@ tail -n 60 <the log path printed on dispatch>
 
 ## When preflight refuses
 
-It refused because a path in the brief is not under `--dir`. Fix the **brief or
-the `--dir`**, never the check — three options, in order of preference:
+It refused because a path — in the brief, or a `--file` attachment — does not
+resolve under `--dir`. The offender is printed as written *and* resolved, tagged
+`[brief]` or `[attachment]`. Fix the **brief or the `--dir`**, never the check —
+three options, in order of preference:
 
 1. move the file under `--dir`;
 2. widen `--dir` to a directory containing both;
@@ -94,6 +100,14 @@ the `--dir`**, never the check — three options, in order of preference:
 
 There is no override flag. The failure it prevents is a silent exit 0, which is
 the one shape nobody notices.
+
+Read the three verdict lines literally — they are different claims:
+
+- `external paths : none — all N examined resolve under --dir` — checked, clean.
+- `external paths : NOT EXAMINED — no resolvable path in the brief, and no
+  attachments` — **not** an all-clear. Nothing was there to check.
+- `UNMEASURED paths : N` — variable-built paths that cannot be decided
+  statically. Neither blocked nor cleared; check them yourself.
 
 A `⚠ WARN` line is different — it is advisory and the dispatch proceeds. It goes
 through a parser that deliberately over-matches, so blocking on it would build a
@@ -110,8 +124,16 @@ gate people learn to click through.
 ## Writing a brief that lands
 
 - State the goal, the acceptance check, and where the code is — **relative to
-  `--dir`**.
+  `--dir`, and never with a `..` segment**. `../other-repo/x` escapes just as
+  surely as an absolute path (opencode runs with `cwd=--dir`), and preflight
+  refuses it.
 - Put commands in fenced ```bash blocks so preflight can see them.
+- **Avoid `$VAR/path` and `${VAR}/path`.** A variable-built path cannot be
+  resolved statically, so preflight reports it as `UNMEASURED` — neither
+  blocked nor cleared — and you have to check it yourself. Write the literal
+  relative path instead.
+- The brief must not be empty. An empty one is refused (rc 2), because a dropped
+  heredoc otherwise dispatches a run that does nothing and exits 0.
 - Assume no follow-up questions are possible. opencode is unattended; every
   `ask` is an auto-reject, not a prompt.
 

--- a/scripts/opencode/lib/brief_scan.py
+++ b/scripts/opencode/lib/brief_scan.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Static analysis of an opencode dispatch BRIEF — the two measured failure
+modes that make a dispatch exit 0 having done nothing.
+
+FAILURE 1 — `external_directory: "ask"` -> headless auto-reject -> exit 0.
+    MEASURED twice, in both directions (a read, then a write). The brief named a
+    path outside `--dir`; opencode asked for external-directory access; `opencode
+    run` AUTO-REJECTS an `ask` rather than prompting; the run ended successfully
+    having done nothing. Its fingerprint in opencode's own store: 10 of 321
+    sessions with `model IS NULL` and 0 tokens.
+
+    `scan_paths` closes it EXACTLY: a path is under `--dir` or it is not. There
+    is no keyword heuristic here and no scoring. `opencode-dispatch` HARD-BLOCKS
+    on a non-empty result, because the failure it prevents is a silent exit 0 —
+    the one failure shape a human never notices.
+
+FAILURE 3 — `permission.bash` `ask` -> auto-reject MID-RUN.
+    MEASURED: opencode needed `kubectl exec … psql`, was auto-rejected, and the
+    dispatch was abandoned half-done. `scan_commands` extracts the brief's fenced
+    command blocks and resolves each command node against the same
+    `permission.bash` block the engine uses.
+
+    🔴 This one WARNS and never blocks. It runs through a parser that
+    deliberately OVER-MATCHES (guard_core's splitter plus opencode's own
+    `*`-crosses-everything globs), so blocking on it would create a
+    permanently-red gate — and RULES.md is explicit that a gate people learn to
+    click through is worse than no gate.
+
+ONE PARSER, NOT TWO
+-------------------
+🔴 Command splitting is `scripts/claude-hooks/guard_core.py`'s `split_commands`,
+imported, not reimplemented. It already splits on `;`/`&&`/`||`/`|`/`&`, strips
+`VAR=` prefixes and `sudo`/`env`/`timeout` wrappers, recurses into `bash -c`,
+and lifts heredoc bodies. A second splitter is how the two disagree, and the
+disagreement would be invisible: both would still print warnings.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from collections import namedtuple
+from pathlib import Path
+
+_LIB = Path(__file__).resolve().parent
+_HOOKS = _LIB.parent.parent / "claude-hooks"
+# Both, so this module imports cleanly however it is reached — the CLI, the test
+# suite, or a bare `python -c "import brief_scan"` from anywhere.
+for _p in (_LIB, _HOOKS):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import guard_core  # noqa: E402  — the repo's ONE command splitter + guard policy
+
+from oc_permissions import base_bash_rules, resolve_with_rule  # noqa: E402
+
+# --------------------------------------------------------------------------- #
+# Path containment
+# --------------------------------------------------------------------------- #
+
+# 🔴 AN EXPLICIT ENUMERATION, NOT A PATTERN — same shape as drift-check's
+# settings.json key allowlist, and for the same reason: an unlisted prefix is an
+# offender BY DEFAULT. Each entry is a read-only system location that is never a
+# work target, so naming one in a brief cannot be the "my brief lives outside
+# --dir" mistake this scanner exists for. It is NOT env-overridable.
+#
+# 🔴 `/tmp` is DELIBERATELY ABSENT. Claude Code's per-session scratchpad lives
+# under /tmp, and "the brief lived in the scratchpad" is failure 1's exact
+# vector — allowing /tmp here would exempt the only path the incident actually
+# involved.
+# 🔴 `/etc` and `/var` are likewise absent: `/etc/nixos` is a real edit target on
+# these hosts, and a brief naming it genuinely needs a wider `--dir`.
+SYSTEM_ALLOW = {
+    "/nix/store": "immutable nix store — read-only by construction",
+    "/usr": "distro-provided binaries/headers; never an edit target here",
+    "/bin": "distro-provided binaries",
+    "/sbin": "distro-provided binaries",
+    "/lib": "distro-provided libraries",
+    "/lib64": "distro-provided libraries",
+    "/proc": "kernel pseudo-filesystem",
+    "/sys": "kernel pseudo-filesystem",
+    "/dev": "device nodes; /dev/null and friends appear in every shell snippet",
+    "/run": "runtime state (sockets, /run/wrappers on NixOS)",
+}
+
+# A URL's `//host/path` is not a filesystem path. Strip URLs BEFORE scanning or
+# every `https://example.invalid/x` contributes a bogus `/x`.
+_URL_RE = re.compile(r"\b[A-Za-z][A-Za-z0-9+.\-]*://\S+")
+
+# An absolute POSIX path or a `~/`-relative one.
+#
+# The lookbehind is what keeps prose out: in `and/or`, `20/80` and `**/*.py` the
+# slash is preceded by a character in the excluded class, so none of them yields
+# a candidate. At least one segment character is REQUIRED after the leading
+# slash, so a bare `/` in prose ("read/write") is not a path.
+_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_.~*/@+-])"
+    r"(~/[A-Za-z0-9_./~+@-]*|/[A-Za-z0-9_.~+@-][A-Za-z0-9_./~+@-]*)"
+)
+
+# Sentence punctuation that sticks to the end of a path in prose. A `/` is NOT
+# stripped — a trailing slash is part of the path.
+_TRAILING_PUNCT = ".,;:!?)]}'\"`"
+
+Offender = namedtuple("Offender", "text resolved")
+
+
+def canon(path) -> str:
+    """One canonicalisation rule for both sides of the comparison.
+
+    `os.path.realpath` on a path that does not exist resolves the symlinks in
+    whatever prefix DOES exist and leaves the rest lexically — which is the
+    behaviour wanted here, since a brief routinely names files the dispatch is
+    about to create.
+    """
+    return os.path.realpath(os.path.expanduser(str(path)))
+
+
+def extract_paths(text: str) -> list[str]:
+    """Every absolute (or `~/`) path-shaped token in `text`, in order, deduped.
+
+    Pure and independently testable — the positive control in the test suite
+    calls this directly, so a scanner wired to nothing cannot report a
+    reassuring zero.
+    """
+    stripped = _URL_RE.sub(" ", text)
+    out, seen = [], set()
+    for m in _PATH_RE.finditer(stripped):
+        cand = m.group(1).rstrip(_TRAILING_PUNCT)
+        if not cand or cand in ("~/", "/"):
+            continue
+        if cand not in seen:
+            seen.add(cand)
+            out.append(cand)
+    return out
+
+
+def is_allowlisted(resolved: str) -> str | None:
+    """The SYSTEM_ALLOW prefix covering `resolved`, or None."""
+    for prefix, reason in SYSTEM_ALLOW.items():
+        if resolved == prefix or resolved.startswith(prefix + os.sep):
+            return reason
+    return None
+
+
+def is_under(resolved: str, root: str) -> bool:
+    """🔴 The whole predicate. Exact: a path is under `root` or it is not.
+
+    `os.sep` matters — a bare `startswith` would call `/home/zach/devrc-other`
+    a child of `/home/zach/devrc`.
+    """
+    return resolved == root or resolved.startswith(root.rstrip(os.sep) + os.sep)
+
+
+def scan_paths(text: str, directory) -> list[Offender]:
+    """Paths in `text` that are NOT under `directory` and not system-allowlisted.
+
+    An empty list means the brief is containable. A non-empty one is failure 1
+    waiting to happen, and `opencode-dispatch` refuses on it.
+    """
+    root = canon(directory)
+    offenders = []
+    for cand in extract_paths(text):
+        resolved = canon(cand)
+        if is_under(resolved, root):
+            continue
+        if is_allowlisted(resolved):
+            continue
+        offenders.append(Offender(cand, resolved))
+    return offenders
+
+
+# --------------------------------------------------------------------------- #
+# Fenced command blocks -> permission verdicts
+# --------------------------------------------------------------------------- #
+
+# ``` or ~~~ fences, with the closing fence at line start. Non-greedy body.
+_FENCE_RE = re.compile(
+    r"^(?P<fence>`{3,}|~{3,})[ \t]*(?P<info>[^\n]*)\n(?P<body>.*?)^(?P=fence)[ \t]*$",
+    re.M | re.S,
+)
+
+# Info strings that mean "this block is shell". An EMPTY info string counts:
+# a bare ``` block in a brief is overwhelmingly a command block, and missing a
+# real command is the failure mode that matters on a warn-only channel.
+SHELL_INFO = {
+    "", "bash", "sh", "shell", "zsh", "console", "shell-session",
+    "shellsession", "terminal", "command", "commands", "text",
+}
+
+# Bound on how many command nodes one brief contributes. A brief is prose; this
+# only exists so a pathological paste cannot spin the resolver.
+_MAX_COMMANDS = 400
+
+Verdict = namedtuple("Verdict", "command action pattern guard_reason")
+
+
+def shell_blocks(text: str) -> list[str]:
+    """The bodies of every fenced block whose info string reads as shell."""
+    out = []
+    for m in _FENCE_RE.finditer(text):
+        # `bash {.line-numbers}` and friends: the LANGUAGE is the first word.
+        words = m.group("info").strip().lower().split()
+        info = words[0] if words else ""
+        if info in SHELL_INFO:
+            out.append(m.group("body"))
+    return out
+
+
+def block_commands(body: str) -> list[str]:
+    """Command nodes in one fenced block, via guard_core's splitter.
+
+    Prompt markers (`$ `, `# ` at line start when followed by a space) and
+    whole-line comments are dropped FIRST — `split_commands` is a shell splitter,
+    not a transcript parser, and would otherwise emit `#` as argv[0] for every
+    comment line.
+    """
+    lines = []
+    for raw in body.split("\n"):
+        line = raw.rstrip()
+        stripped = line.lstrip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            continue
+        if stripped.startswith("$ "):
+            line = stripped[2:]
+        lines.append(line)
+    if not lines:
+        return []
+    return guard_core.split_commands("\n".join(lines))
+
+
+def scan_commands(text: str, directory=None, config: dict | None = None) -> list[Verdict]:
+    """Every command node in the brief's shell blocks that would NOT run clean.
+
+    Returns only the nodes whose resolved action is `ask` or `deny`, plus any the
+    guard's "opencode" policy hard-denies. An `ask` is the one that matters most:
+    `opencode run` auto-rejects it mid-run, so the dispatch stalls half-done
+    rather than erroring.
+    """
+    rules = base_bash_rules(config)
+    out, seen = [], set()
+    for body in shell_blocks(text):
+        for cmd in block_commands(body):
+            cmd = cmd.strip()
+            if not cmd or cmd in seen:
+                continue
+            seen.add(cmd)
+            if len(seen) > _MAX_COMMANDS:
+                return out
+            action, pattern = resolve_with_rule(rules, cmd)
+            try:
+                guard_reason = guard_core.evaluate(cmd, policy="opencode",
+                                                   cwd=str(directory) if directory else None)
+            except Exception:  # noqa: BLE001 — a warn-only channel never raises
+                guard_reason = None
+            if action in ("ask", "deny") or guard_reason:
+                out.append(Verdict(cmd, action, pattern, guard_reason))
+    return out

--- a/scripts/opencode/lib/brief_scan.py
+++ b/scripts/opencode/lib/brief_scan.py
@@ -70,6 +70,15 @@ from oc_permissions import base_bash_rules, resolve_with_rule  # noqa: E402
 # involved.
 # 🔴 `/etc` and `/var` are likewise absent: `/etc/nixos` is a real edit target on
 # these hosts, and a brief naming it genuinely needs a wider `--dir`.
+#
+# 🔴 MATCHED AGAINST THE PATH AS WRITTEN (lexically normalised), NOT its
+# realpath — and that is a FIX, not an oversight. Matching the realpath made the
+# two comments above FALSE on NixOS: `/etc/hosts` realpaths into
+# `/nix/store/…-hosts`, hit the `/nix/store` entry, and passed. So every `/etc`
+# path this list claims to block was silently allowed, invisibly, because the
+# under-blocking looked identical to a clean brief. A symlink out of a listed
+# prefix now blocks (fail-closed), which is the correct side to err on for an
+# enumeration whose whole premise is "unlisted is an offender by default".
 SYSTEM_ALLOW = {
     "/nix/store": "immutable nix store — read-only by construction",
     "/usr": "distro-provided binaries/headers; never an edit target here",
@@ -84,8 +93,34 @@ SYSTEM_ALLOW = {
 }
 
 # A URL's `//host/path` is not a filesystem path. Strip URLs BEFORE scanning or
-# every `https://example.invalid/x` contributes a bogus `/x`.
+# a path in a QUERY or FRAGMENT (`?f=/etc/passwd`, `#/opt/thing`) is extracted as
+# a real one — those are preceded by `=` or `#`, which the lookbehind does not
+# exclude. A plain `https://host/a/b` needs no stripping; every `/` in it is
+# already preceded by an excluded character.
 _URL_RE = re.compile(r"\b[A-Za-z][A-Za-z0-9+.\-]*://\S+")
+
+# 🔴 A path built from a VARIABLE cannot be resolved statically, and must be
+# reported as UNMEASURED rather than folded into either verdict.
+#
+# Both spellings were wrong before this pattern existed, in OPPOSITE directions,
+# and both are the most likely content of a brief written in this repo:
+#   `${pkgs.python312}/bin/python3`  -> FALSE BLOCK. `}` is not in the
+#       lookbehind's excluded class, so `/bin/python3` was extracted as a real
+#       absolute path and refused the dispatch. Same for a Python f-string's
+#       `{base}/sub/file.py`, and for `${DEVRC}/scripts/tests`.
+#   `$DEVRC/scripts/tests`          -> SILENT PASS. The `/` follows a letter,
+#       which IS excluded, so nothing was extracted at all — and CLAUDE.md
+#       actively tells agents to use those `$DEVRC`/`$HOMELAB` handles.
+# With no override flag, a false block leaves the operator only "reword or
+# abandon the tool", which is the gate-people-route-around outcome this design
+# exists to avoid; a silent pass is the failure the gate exists to catch. So
+# neither verdict is honest here: say UNMEASURED and let the operator decide.
+_VAR_PATH_RE = re.compile(
+    r"(?:\$\{[^}\s]*\}"           # ${DEVRC}, ${pkgs.python312}
+    r"|\$[A-Za-z_][A-Za-z0-9_]*"  # $DEVRC
+    r"|\{[A-Za-z_][A-Za-z0-9_.]*\})"  # {base} — a Python f-string slot
+    r"(?:/[A-Za-z0-9_.~+@${}-]+)+/?"  # …followed by at least one path segment
+)
 
 # An absolute POSIX path or a `~/`-relative one.
 #
@@ -98,15 +133,35 @@ _PATH_RE = re.compile(
     r"(~/[A-Za-z0-9_./~+@-]*|/[A-Za-z0-9_.~+@-][A-Za-z0-9_./~+@-]*)"
 )
 
+# 🔴 A RELATIVE path can escape `--dir` too, and the docs invite it: SKILL.md
+# tells the brief's author to name locations RELATIVE to `--dir`, and opencode
+# runs with `cwd=--dir`, so `../other-repo/x` genuinely leaves the directory.
+# Measured before this pattern existed: `"Read ../outside/extra.md and apply
+# it."` reported `paths examined : 0` and an unconditional all-clear.
+#
+# Scoped to tokens containing a `..` SEGMENT, because those are the only
+# relative tokens that can escape at all — `src/x.py` resolves under `--dir` by
+# construction and matching it would drag in every prose slash. A bare `..` with
+# no `/` is dropped (see `extract_paths`), which is what keeps `...`, `v1..v2`
+# and `HEAD~2..HEAD` out; in each of those the `..` is preceded by an excluded
+# character anyway.
+_REL_ESCAPE_RE = re.compile(
+    r"(?<![A-Za-z0-9_.~*/@+$}-])"
+    r"((?:[A-Za-z0-9_.~+@-]+/)*\.\.(?:/[A-Za-z0-9_.~+@-]+)*/?)"
+)
+
 # Sentence punctuation that sticks to the end of a path in prose. A `/` is NOT
 # stripped — a trailing slash is part of the path.
 _TRAILING_PUNCT = ".,;:!?)]}'\"`"
 
-Offender = namedtuple("Offender", "text resolved")
+# `kind` distinguishes a path NAMED IN THE BRIEF from one handed to opencode as
+# an `--file` ATTACHMENT, because the operator's fix differs: reword the brief,
+# versus drop or move the attachment.
+Offender = namedtuple("Offender", "text resolved kind")
 
 
 def canon(path) -> str:
-    """One canonicalisation rule for both sides of the comparison.
+    """Canonical form for the CONTAINMENT comparison — symlinks resolved.
 
     `os.path.realpath` on a path that does not exist resolves the symlinks in
     whatever prefix DOES exist and leaves the rest lexically — which is the
@@ -116,29 +171,78 @@ def canon(path) -> str:
     return os.path.realpath(os.path.expanduser(str(path)))
 
 
-def extract_paths(text: str) -> list[str]:
-    """Every absolute (or `~/`) path-shaped token in `text`, in order, deduped.
+def lexical(path) -> str:
+    """Canonical form for the ALLOWLIST comparison — symlinks NOT resolved.
 
-    Pure and independently testable — the positive control in the test suite
-    calls this directly, so a scanner wired to nothing cannot report a
-    reassuring zero.
+    Deliberately different from `canon`: see the SYSTEM_ALLOW header. Resolving
+    symlinks here made `/etc/hosts` land in `/nix/store` and pass.
     """
-    stripped = _URL_RE.sub(" ", text)
+    return os.path.normpath(os.path.expanduser(str(path)))
+
+
+def extract_unresolved_paths(text: str) -> list[str]:
+    """Variable-interpolated path tokens — reported UNMEASURED, never clean."""
     out, seen = [], set()
-    for m in _PATH_RE.finditer(stripped):
-        cand = m.group(1).rstrip(_TRAILING_PUNCT)
-        if not cand or cand in ("~/", "/"):
-            continue
-        if cand not in seen:
-            seen.add(cand)
-            out.append(cand)
+    for m in _VAR_PATH_RE.finditer(_URL_RE.sub(" ", text)):
+        tok = m.group(0).rstrip(_TRAILING_PUNCT)
+        if tok and tok not in seen:
+            seen.add(tok)
+            out.append(tok)
     return out
 
 
-def is_allowlisted(resolved: str) -> str | None:
-    """The SYSTEM_ALLOW prefix covering `resolved`, or None."""
+def _mask(text: str) -> str:
+    """Text with URLs and variable-interpolated paths blanked out.
+
+    Both are handled BEFORE `_PATH_RE` runs, so a fragment of either cannot be
+    mistaken for a real path. One masking step, so `extract_paths` and
+    `extract_unresolved_paths` cannot disagree about which spans are which.
+    """
+    return _VAR_PATH_RE.sub(" ", _URL_RE.sub(" ", text))
+
+
+def extract_paths(text: str) -> list[str]:
+    """Every RESOLVABLE path-shaped token in `text`, in order, deduped.
+
+    Three shapes: absolute (`/a/b`), home-relative (`~/a`), and a relative token
+    carrying a `..` segment (`../a`, `a/../../b`). Variable-interpolated tokens
+    are NOT here — they are `extract_unresolved_paths`.
+
+    Pure and independently testable — the positive controls in the test suite
+    call this directly, so a scanner wired to nothing cannot report a reassuring
+    zero.
+    """
+    masked = _mask(text)
+    out, seen = [], set()
+    for rx in (_PATH_RE, _REL_ESCAPE_RE):
+        for m in rx.finditer(masked):
+            cand = m.group(1).rstrip(_TRAILING_PUNCT)
+            # 🔴 A bare `..` (an ellipsis, `v1..v2`) is dropped HERE, by the
+            # rstrip above emptying it — `_TRAILING_PUNCT` contains `.`, and
+            # `_REL_ESCAPE_RE`'s only slashless token is exactly `..`.
+            #
+            # An explicit `if "/" not in cand: continue` guard USED to sit below
+            # this line. It was DEAD: a mutation sweep removed it and the full
+            # suite stayed green, because this check had already consumed every
+            # input it could see. Its comment claimed to be what kept `...` out,
+            # which was false. The coupling to `_TRAILING_PUNCT` is real and now
+            # asserted by test_dispatch.py rather than left implicit.
+            if not cand or cand in ("~/", "/"):
+                continue
+            if cand not in seen:
+                seen.add(cand)
+                out.append(cand)
+    return out
+
+
+def is_allowlisted(path_as_written: str) -> str | None:
+    """The SYSTEM_ALLOW prefix covering `path_as_written`, or None.
+
+    🔴 Takes the LEXICAL form, not the realpath — see the SYSTEM_ALLOW header.
+    """
+    p = lexical(path_as_written)
     for prefix, reason in SYSTEM_ALLOW.items():
-        if resolved == prefix or resolved.startswith(prefix + os.sep):
+        if p == prefix or p.startswith(prefix + os.sep):
             return reason
     return None
 
@@ -152,22 +256,54 @@ def is_under(resolved: str, root: str) -> bool:
     return resolved == root or resolved.startswith(root.rstrip(os.sep) + os.sep)
 
 
+def resolve_candidate(cand: str, directory) -> str:
+    """A candidate's absolute form. A RELATIVE one resolves against `--dir`,
+    because that is the cwd opencode runs in."""
+    if cand.startswith(("/", "~")):
+        return canon(cand)
+    return canon(os.path.join(str(directory), cand))
+
+
+def _judge(cand: str, directory, root: str, kind: str):
+    """`Offender` if `cand` escapes `--dir`, else None. ONE predicate, so the
+    brief scan and the attachment scan cannot disagree."""
+    resolved = resolve_candidate(cand, directory)
+    if is_under(resolved, root):
+        return None
+    # Only an absolute/`~` token can be system-allowlisted; a relative one that
+    # escaped `--dir` is an offender whatever it lands on.
+    if cand.startswith(("/", "~")) and is_allowlisted(cand):
+        return None
+    return Offender(cand, resolved, kind)
+
+
 def scan_paths(text: str, directory) -> list[Offender]:
     """Paths in `text` that are NOT under `directory` and not system-allowlisted.
 
-    An empty list means the brief is containable. A non-empty one is failure 1
-    waiting to happen, and `opencode-dispatch` refuses on it.
+    An empty list means every path the scanner COULD resolve is containable —
+    which is not the same as "the brief is clean", and the report must not say
+    otherwise when nothing was examined.
     """
     root = canon(directory)
-    offenders = []
-    for cand in extract_paths(text):
-        resolved = canon(cand)
-        if is_under(resolved, root):
-            continue
-        if is_allowlisted(resolved):
-            continue
-        offenders.append(Offender(cand, resolved))
-    return offenders
+    return [o for o in (_judge(c, directory, root, "brief")
+                        for c in extract_paths(text)) if o]
+
+
+def scan_attachments(attachments, directory) -> list[Offender]:
+    """🔴 The same predicate, applied to `--file` ATTACHMENTS.
+
+    Measured before this existed: `run --dir <proj> --file <outside>/extra.md`
+    printed "external paths : none — every path is under --dir" and handed
+    opencode the outside file. `--file` is the #3 most-used flag and SKILL.md
+    advertises it, so this was the advertised path.
+
+    Whether opencode itself raises an `external_directory` ask for an attachment
+    is UNVERIFIED. It does not matter: the printed claim was false either way,
+    and a report that overstates what it checked is the defect.
+    """
+    root = canon(directory)
+    return [o for o in (_judge(str(a), directory, root, "attachment")
+                        for a in attachments) if o]
 
 
 # --------------------------------------------------------------------------- #
@@ -193,6 +329,29 @@ SHELL_INFO = {
 _MAX_COMMANDS = 400
 
 Verdict = namedtuple("Verdict", "command action pattern guard_reason")
+
+# 🔴 The prefix a guard_core failure wears, so it is IMPOSSIBLE to confuse with
+# a clean brief. The channel used to sit behind a bare `except: guard_reason =
+# None` — a mutant making `evaluate` raise SURVIVED all 717 tests, because a
+# broken channel and a brief with no dangerous commands both printed nothing.
+# `evaluate` raises on an unknown policy name BY DESIGN ("a typo must not
+# silently degrade to no checks"), so a rename of the "opencode" policy is
+# exactly the shape that would have gone dark forever.
+GUARD_UNMEASURED = "COULD NOT MEASURE"
+
+
+def _guard_verdict(cmd: str, directory) -> str | None:
+    """guard_core's "opencode"-policy verdict, or a loud `COULD NOT MEASURE`.
+
+    Never raises — this is an advisory channel and must not break a preflight —
+    but a failure is REPORTED, never swallowed into a reassuring None.
+    """
+    try:
+        return guard_core.evaluate(
+            cmd, policy="opencode",
+            cwd=str(directory) if directory else None)
+    except Exception as e:  # noqa: BLE001 — reported, not swallowed
+        return f"{GUARD_UNMEASURED}: guard_core.evaluate raised {type(e).__name__}: {e}"
 
 
 def shell_blocks(text: str) -> list[str]:
@@ -250,11 +409,7 @@ def scan_commands(text: str, directory=None, config: dict | None = None) -> list
             if len(seen) > _MAX_COMMANDS:
                 return out
             action, pattern = resolve_with_rule(rules, cmd)
-            try:
-                guard_reason = guard_core.evaluate(cmd, policy="opencode",
-                                                   cwd=str(directory) if directory else None)
-            except Exception:  # noqa: BLE001 — a warn-only channel never raises
-                guard_reason = None
+            guard_reason = _guard_verdict(cmd, directory)
             if action in ("ask", "deny") or guard_reason:
                 out.append(Verdict(cmd, action, pattern, guard_reason))
     return out

--- a/scripts/opencode/lib/oc_permissions.py
+++ b/scripts/opencode/lib/oc_permissions.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""opencode's permission resolver — ONE implementation, two callers.
+
+WHY THIS FILE EXISTS
+--------------------
+`scripts/tests/test_opencode_config.py` already carried a faithful port of
+opencode 1.18.18's `Wildcard.match` + its `findLast` resolver, validated against
+the real engine (`opencode debug agent <a> --tool bash`: 18 deny cases and 3
+allow cases agreed). `opencode-dispatch preflight` needs exactly that predicate
+to answer "would this command in the brief resolve to `ask`, i.e. be
+AUTO-REJECTED mid-run?".
+
+RULES.md 🔴 "One rule, one place": a second copy of a resolver is a predicate
+that will disagree eventually and silently. So the port moved HERE and both
+callers import it. The test file keeps everything that is genuinely about the
+TEST (the agent-frontmatter ruleset, the deletion mutants, the ledgers); this
+module owns only the parts a non-test caller also needs.
+
+SCOPE — read before using `effective_bash_action`
+-------------------------------------------------
+🔴 `command` must be a SINGLE command node. opencode parses the shell with
+tree-sitter and matches each `command` descendant's text separately, denying the
+whole call if ANY node resolves deny (measured: `cd /tmp && git status` is
+checked as just `git status`, since `cd` is in opencode's skip set). This model
+deliberately does NOT reimplement that AST split. Callers that start from a
+whole command LINE must split it first — `scripts/claude-hooks/guard_core.py`'s
+`split_commands()` is the repo's splitter and the one `brief_scan.py` uses.
+Chains are SAFER than this model would suggest, never less safe: an extra node
+can only add a deny.
+
+🔴 `ask` is not a control. `opencode run` AUTO-REJECTS an `ask` (it prints
+"auto-rejecting"); only the interactive TUI turns one into a prompt. That is the
+whole reason preflight cares: an `ask` inside an unattended dispatch is a
+mid-run abandonment, not a question.
+"""
+from __future__ import annotations
+
+import functools
+import json
+import re
+from pathlib import Path
+
+# The repo's canonical config. `scripts/opencode/lib/` -> `scripts/opencode/`.
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parent.parent / "opencode.jsonc"
+
+
+def strip_jsonc(text: str) -> str:
+    """Strip `//` and `/* */` comments, leaving string literals untouched.
+
+    Hand-rolled rather than regex because opencode.jsonc contains `https://`
+    inside a string — a naive `//`-to-end-of-line regex would eat the rest of
+    the `$schema` line and the file would not parse.
+    """
+    out = []
+    i, n = 0, len(text)
+    in_str = False
+    while i < n:
+        c = text[i]
+        if in_str:
+            out.append(c)
+            if c == "\\" and i + 1 < n:
+                out.append(text[i + 1])
+                i += 2
+                continue
+            if c == '"':
+                in_str = False
+            i += 1
+            continue
+        if c == '"':
+            in_str = True
+            out.append(c)
+            i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "*":
+            i += 2
+            while i + 1 < n and not (text[i] == "*" and text[i + 1] == "/"):
+                i += 1
+            i += 2
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def load_config(path: Path | None = None) -> dict:
+    """Parse opencode.jsonc, PRESERVING key order.
+
+    json.loads yields a dict, and dicts preserve insertion order — which is what
+    makes the resolver model possible at all (LAST match wins over the file's
+    own key order).
+
+    Deliberately UNCACHED and MUTABLE: `scripts/tests/test_opencode_engine.py`
+    mutates a parsed config in place to build its "trailing `git *: allow`"
+    mutant, and a cached mutable result is poisonable.
+    """
+    return json.loads(strip_jsonc((path or DEFAULT_CONFIG_PATH).read_text()))
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 the resolver model
+#
+# Faithful port of opencode 1.18.18's `Wildcard.match` + the `findLast` resolver:
+#
+#     pattern.replace(/[.+^${}()|[\]\\]/g,"\\$&").replace(/\*/g,".*")
+#            .replace(/\?/g,".")   ->   new RegExp("^"+p+"$","s")
+#
+# so `*` is an unrestricted `.*` (dotAll) that CROSSES spaces, `/` and `-`.
+# --------------------------------------------------------------------------- #
+_GLOB_ESCAPE = re.compile(r"[.+^${}()|\[\]\\]")
+
+
+@functools.lru_cache(maxsize=None)
+def wildcard_match(text: str, pattern: str) -> bool:
+    # Memoised: pure function of (text, pattern), and the test ledgers resolve
+    # ~50 rules x ~115 commands x ~65 patterns per pass, once per detector
+    # control. Without this that file took 46 s; with it, ~5 s.
+    t = text.replace("\\", "/")
+    p = _GLOB_ESCAPE.sub(lambda m: "\\" + m.group(0), pattern.replace("\\", "/"))
+    p = p.replace("*", ".*").replace("?", ".")
+    # opencode special case: a pattern ending in " *" also matches without it,
+    # so `rg *` matches a bare `rg`.
+    if p.endswith(" .*"):
+        p = p[:-3] + "( .*)?"
+    return re.match("^" + p + "$", t, re.S) is not None
+
+
+def resolve_with_rule(rules, command: str):
+    """`(action, pattern)` — LAST match wins, over an EXPLICIT ordered ruleset.
+
+    🔴 THE ONLY implementation of the resolution loop in this repo. It briefly
+    had two inside the test file alone, and two copies with nothing pinning them
+    together is a predicate that will disagree eventually and silently.
+
+    The PATTERN is returned alongside the action because a warning that says
+    "this resolves to ask" and cannot name the glob is not actionable — the
+    operator's next move is to widen `--dir`, reword the brief, or accept the
+    stall, and all three need the rule's name. `pattern` is None only when
+    nothing matched at all (opencode's fallback, `ask`).
+    """
+    action, matched = "ask", None      # opencode's fallback when nothing matches
+    for pattern, act in rules:
+        if wildcard_match(command, pattern):
+            action, matched = act, pattern
+    return action, matched
+
+
+def resolve(rules, command: str) -> str:
+    """`resolve_with_rule` without the pattern. One loop, two shapes."""
+    return resolve_with_rule(rules, command)[0]
+
+
+def base_bash_rules(config: dict | None = None) -> tuple:
+    """The ORDERED (pattern, action) list opencode resolves a bash command
+    against, for an agent with NO agent-level `permission.bash` of its own.
+
+    Order mirrors the real merge: the built-in `permission:"*" pattern:"*"
+    allow` first, then the global config block. A caller with an agent block
+    appends it LAST — which is precisely why an agent-level `"*": "allow"` would
+    nullify every global rule.
+    """
+    cfg = config if config is not None else load_config()
+    return (("*", "allow"),) + tuple(cfg["permission"]["bash"].items())
+
+
+def effective_bash_action(command: str, config: dict | None = None) -> str:
+    """The action opencode's PRIMARY agent resolves for one command node."""
+    return resolve(base_bash_rules(config), command)

--- a/scripts/opencode/opencode-dispatch
+++ b/scripts/opencode/opencode-dispatch
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""opencode-dispatch — hand a task to opencode without spending this session's
+context on it, and without the four measured ways a dispatch quietly does
+nothing.
+
+    opencode-dispatch preflight --dir DIR [--brief FILE|-] [--json]
+    opencode-dispatch run       --dir DIR [--brief FILE|-] [--title T]
+                                [-m flash|mimo|pro|<full/model/id>]
+                                [--auto] [-c] [--file F]...
+
+WHY A WRAPPER AND NOT JUST `opencode run`
+-----------------------------------------
+Four failure modes, all measured over 17 days of real dispatches, and THREE of
+them success-shaped — the dispatch exits 0 and nothing happened:
+
+  1. 🔴 `external_directory: "ask"` -> headless AUTO-REJECT -> exit 0, no work.
+     The brief named a path outside `--dir`. `opencode run` auto-rejects an
+     `ask` (only the interactive TUI prompts). Fingerprint in opencode's own
+     store: 10 of 321 sessions with `model IS NULL` and 0 tokens. Happened
+     twice, in both directions (a read, then a write).
+     CLOSED TWO WAYS here: the brief is WRITTEN INTO `--dir` (so its own
+     location can never be the problem), and `preflight` refuses — rc 3 — if the
+     brief's text names any absolute path outside `--dir`.
+
+  2. `--file` is an ARRAY option and greedily swallowed the message as a second
+     filename: `Error: File not found: Execute the task described in …`. Only
+     message-positional-FIRST worked. `build_argv` pins that order and a test
+     asserts the emitted index.
+
+  3. `permission.bash` `ask` -> AUTO-REJECT mid-run. opencode needed
+     `kubectl exec … psql`, was auto-rejected, and the dispatch was abandoned
+     half-done. `preflight` WARNS (never blocks) when a command in the brief's
+     fenced blocks resolves to `ask`, naming the glob.
+
+  4. 20% of opencode sessions exceed the Bash tool's hard 600,000 ms ceiling
+     (p90 2508s, p95 9119s); one measured dispatch died at exactly 600s with
+     `Exit code 143`. So this tool NEVER runs opencode in the foreground and
+     offers no flag to. It detaches into its own session, tees to a log file
+     inside `--dir`, and returns immediately.
+
+🔴 WHY THE PATH CHECK BLOCKS AND THE GLOB CHECK ONLY WARNS.
+The path check is EXACT — a path is under `--dir` or it is not — and the failure
+it prevents is a silent exit 0, the one shape a human never notices. The glob
+check runs through a parser that deliberately OVER-MATCHES, so blocking on it
+would build a permanently-red gate, which RULES.md says is worse than no gate.
+
+NOT BUILT, deliberately (stage 1):
+  * `status` / `watch` — they need opencode's internal SQLite schema, which has
+    no stability guarantee. Worth taking only once this skill is proven to get
+    used. Read the log file instead; its path is printed on dispatch.
+  * result-capture, auto-retry, a model router — each considered and rejected on
+    measured grounds. Retries in particular are CORRECTIVE, not transient:
+    re-running a known-bad brief is not a fix.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+for _p in (_HERE / "lib", _HERE.parent / "collector"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import brief_scan  # noqa: E402
+
+TOOL = "opencode-dispatch"
+
+# Every outcome this tool can emit. Pinned three ways by
+# tests/test_dispatch.py: against the literals at the `emit(` call sites,
+# against adoption-scan's REGISTRY row, and against a check that no call site
+# passes a COMPUTED outcome (which the call-site grep could not see).
+OUTCOMES = ("dispatched", "preflight-ok", "preflight-blocked", "error")
+
+# --------------------------------------------------------------------------- #
+# Exit codes. Each failure gets its OWN code so a caller can branch, and rc 3 in
+# particular is the one that means "I refused; the brief is wrong", as distinct
+# from "opencode is missing" or "you typed it wrong".
+# --------------------------------------------------------------------------- #
+RC_OK = 0
+RC_USAGE = 2
+RC_PATH_ESCAPE = 3      # 🔴 failure 1: the brief names a path outside --dir
+RC_DIR = 4              # --dir missing / not a directory
+RC_LAUNCH = 5           # opencode could not be started
+
+# --------------------------------------------------------------------------- #
+# Model aliases — ONLY the three that actually get retyped. No router, no
+# defaulting: with no `-m` the argv omits the flag entirely and opencode uses
+# the config default, which is what 18 of 24 measured dispatches did.
+# --------------------------------------------------------------------------- #
+MODEL_ALIASES = {
+    "flash": "openrouter/deepseek/deepseek-v4-flash",
+    "mimo": "openrouter/xiaomi/mimo-v2.5",
+    "pro": "openrouter/deepseek/deepseek-v4-pro",
+}
+
+# Where the brief lands, INSIDE --dir. This is the structural half of failure 1:
+# a brief that lives in the project directory cannot be an external-directory
+# read, regardless of what any scanner concludes.
+BRIEF_SUBDIR = ".opencode-dispatch"
+
+# 🔴 The subdir ignores ITSELF, in whatever repo it lands in. devrc's own
+# .gitignore covers devrc; every other target repo is covered by this file,
+# written on first use. A brief is scratch work and must never be stageable.
+BRIEF_GITIGNORE = (
+    "# Written by opencode-dispatch. Briefs and run logs are scratch work and\n"
+    "# must never be committed — they routinely quote paths, hostnames and\n"
+    "# task detail that belong to no repo.\n"
+    "*\n"
+)
+
+# 🔴 THE CANONICAL ARGV ORDER. The message is the POSITIONAL and it comes FIRST,
+# at this index, because `--file` is an ARRAY option: with the message after it,
+# opencode consumed the message as a second filename and died with
+# `Error: File not found: Execute the task described in the attached brief…`.
+MESSAGE_ARGV_INDEX = 2
+
+
+# --------------------------------------------------------------------------- #
+# Pure builders — the parts a test can pin without running anything
+# --------------------------------------------------------------------------- #
+def resolve_model(value: str | None) -> str | None:
+    """Alias -> full model id. A full id (contains `/`) passes through.
+
+    An unknown bare word is a USAGE ERROR, never a pass-through: silently
+    forwarding a typo'd alias would hand opencode a nonexistent model and turn a
+    typo into a failed dispatch discovered minutes later.
+    """
+    if value is None:
+        return None
+    if value in MODEL_ALIASES:
+        return MODEL_ALIASES[value]
+    if "/" in value:
+        return value
+    raise ValueError(
+        f"unknown model alias {value!r}. Known aliases: "
+        + ", ".join(f"{k} -> {v}" for k, v in MODEL_ALIASES.items())
+        + ". Pass a full provider/vendor/model id to use anything else."
+    )
+
+
+def build_argv(message: str, directory, model=None, title=None, auto=False,
+               continue_session=False, files=(), binary="opencode") -> list[str]:
+    """The exact argv `run` executes. Pure, so the ORDER is testable.
+
+    🔴 `message` is argv[MESSAGE_ARGV_INDEX] and precedes every `--file`. That is
+    not style — see failure 2 in the module docstring.
+    """
+    argv = [binary, "run", message, "--dir", str(directory)]
+    if title:
+        argv += ["--title", title]
+    if model:
+        argv += ["-m", model]
+    if auto:
+        argv += ["--auto"]
+    if continue_session:
+        argv += ["-c"]
+    for f in files:
+        argv += ["--file", str(f)]
+    return argv
+
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def slugify(text: str, fallback: str = "brief") -> str:
+    s = _SLUG_RE.sub("-", (text or "").lower()).strip("-")
+    return (s[:48].strip("-") or fallback)
+
+
+def brief_message(rel_brief_path: str) -> str:
+    """The message positional. It names the brief by a path RELATIVE to `--dir`.
+
+    Relative on purpose: an absolute path in the message is the same
+    external-directory hazard the whole tool exists to prevent, and a relative
+    one cannot be outside `--dir` by construction.
+    """
+    return (
+        f"Read {rel_brief_path} first — it is the complete task specification — "
+        "then carry it out. Everything you need is inside this directory; do not "
+        "read or write outside it."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Telemetry — best-effort, never changes this process's exit code
+# --------------------------------------------------------------------------- #
+def emit(outcome: str, dims: dict | None = None, exit_code: int | None = None,
+         duration_ms: int | None = None) -> None:
+    try:
+        from invocation import emit_invocation
+        emit_invocation(TOOL, outcome, dims=dims or {},
+                        exit_code=exit_code, duration_ms=duration_ms)
+    except Exception:  # noqa: BLE001 — telemetry must never break its caller
+        pass
+
+
+# --------------------------------------------------------------------------- #
+# I/O helpers
+# --------------------------------------------------------------------------- #
+def read_brief(source: str | None) -> str:
+    """Brief text from a file, or from stdin when `source` is `-` or omitted."""
+    if source in (None, "-"):
+        return sys.stdin.read()
+    return Path(source).read_text(encoding="utf-8")
+
+
+def install_brief(directory: Path, text: str, slug: str) -> tuple[Path, Path]:
+    """Write the brief INSIDE `--dir` and return `(brief_path, log_path)`.
+
+    🔴 This is the structural half of failure 1. The brief is not merely CHECKED
+    for external paths — it is placed where an external-directory read is not
+    possible in the first place. Nothing here ever writes to Claude's scratchpad.
+    """
+    subdir = directory / BRIEF_SUBDIR
+    subdir.mkdir(parents=True, exist_ok=True)
+    ignore = subdir / ".gitignore"
+    if not ignore.exists():
+        ignore.write_text(BRIEF_GITIGNORE, encoding="utf-8")
+    stem = f"{time.strftime('%Y%m%d-%H%M%S')}-{slug}"
+    brief = subdir / f"{stem}.md"
+    brief.write_text(text, encoding="utf-8")
+    return brief, subdir / f"{stem}.log"
+
+
+def resolve_dir(raw: str):
+    d = Path(raw).expanduser()
+    if not d.is_dir():
+        return None
+    return d.resolve()
+
+
+# --------------------------------------------------------------------------- #
+# preflight
+# --------------------------------------------------------------------------- #
+def preflight(text: str, directory: Path) -> dict:
+    """The full report. Pure w.r.t. the filesystem apart from path resolution."""
+    offenders = brief_scan.scan_paths(text, directory)
+    warnings = brief_scan.scan_commands(text, directory)
+    return {
+        "dir": str(directory),
+        "blocked": bool(offenders),
+        "external_paths": [
+            {"as_written": o.text, "resolved": o.resolved} for o in offenders
+        ],
+        "command_warnings": [
+            {"command": v.command, "action": v.action, "rule": v.pattern,
+             "guard": v.guard_reason}
+            for v in warnings
+        ],
+        "paths_examined": len(brief_scan.extract_paths(text)),
+        "commands_examined": sum(
+            len(brief_scan.block_commands(b)) for b in brief_scan.shell_blocks(text)
+        ),
+    }
+
+
+def print_report(rep: dict) -> None:
+    # 🔴 Always print what was EXAMINED beside what was found. A bare "0
+    # external paths" from a scan that walked nothing is the failure, not the
+    # all-clear (same reasoning as drift-check's "links examined" line).
+    print(f"preflight  dir={rep['dir']}")
+    print(f"  paths examined    : {rep['paths_examined']}")
+    print(f"  commands examined : {rep['commands_examined']}")
+
+    if rep["external_paths"]:
+        print()
+        print("🔴 BLOCKED — the brief names paths OUTSIDE --dir. `opencode run` "
+              "auto-rejects the")
+        print("   external-directory prompt and exits 0 having done nothing "
+              "(measured twice).")
+        for p in rep["external_paths"]:
+            shown = p["as_written"]
+            extra = "" if shown == p["resolved"] else f"   -> {p['resolved']}"
+            print(f"     {shown}{extra}")
+        print()
+        print("   Fix one of these, not this check:")
+        print("     * move the file under --dir, or")
+        print("     * widen --dir to a directory that contains both, or")
+        print("     * inline the content into the brief instead of pointing at it.")
+    else:
+        print("  external paths    : none — every path is under --dir")
+
+    if rep["command_warnings"]:
+        print()
+        print("⚠ WARN — these commands would meet friction. `opencode run` "
+              "AUTO-REJECTS an `ask`,")
+        print("  so the dispatch stalls MID-RUN rather than prompting. "
+              "Not blocking: this parser")
+        print("  deliberately over-matches.")
+        for w in rep["command_warnings"]:
+            rule = f" (rule {w['rule']!r})" if w["rule"] else ""
+            print(f"     [{w['action']}]{rule}  {w['command']}")
+            if w["guard"]:
+                print(f"        🔴 guard_core would HARD-DENY this: "
+                      f"{w['guard'].splitlines()[0]}")
+    else:
+        print("  command warnings  : none")
+
+
+# --------------------------------------------------------------------------- #
+# commands
+# --------------------------------------------------------------------------- #
+def cmd_preflight(args) -> int:
+    directory = resolve_dir(args.dir)
+    if directory is None:
+        print(f"--dir {args.dir!r} is not a directory", file=sys.stderr)
+        emit("error", {"stage": "preflight", "reason": "bad-dir"}, exit_code=RC_DIR)
+        return RC_DIR
+    text = read_brief(args.brief)
+    rep = preflight(text, directory)
+    if args.json:
+        print(json.dumps(rep, indent=2))
+    else:
+        print_report(rep)
+    dims = {"external_paths": len(rep["external_paths"]),
+            "command_warnings": len(rep["command_warnings"]),
+            "paths_examined": rep["paths_examined"],
+            "commands_examined": rep["commands_examined"]}
+    # 🔴 Two literal call sites, not one ternary. The outcome ledger in
+    # tests/test_dispatch.py is a GREP over these call sites — a computed
+    # argument is invisible to it, and an outcome the ledger cannot see is one
+    # adoption-scan silently buckets as "unknown".
+    if rep["blocked"]:
+        emit("preflight-blocked", dims, exit_code=RC_PATH_ESCAPE)
+        return RC_PATH_ESCAPE
+    emit("preflight-ok", dims, exit_code=RC_OK)
+    return RC_OK
+
+
+def cmd_run(args) -> int:
+    started = time.time()
+    directory = resolve_dir(args.dir)
+    if directory is None:
+        print(f"--dir {args.dir!r} is not a directory", file=sys.stderr)
+        emit("error", {"stage": "run", "reason": "bad-dir"}, exit_code=RC_DIR)
+        return RC_DIR
+    try:
+        model = resolve_model(args.model)
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        emit("error", {"stage": "run", "reason": "bad-model"}, exit_code=RC_USAGE)
+        return RC_USAGE
+
+    text = read_brief(args.brief)
+    rep = preflight(text, directory)
+    print_report(rep)
+    if rep["blocked"]:
+        print()
+        print("NOT DISPATCHED.")
+        emit("preflight-blocked",
+             {"stage": "run", "external_paths": len(rep["external_paths"]),
+              "command_warnings": len(rep["command_warnings"]),
+              "model_alias": args.model or "default"},
+             exit_code=RC_PATH_ESCAPE)
+        return RC_PATH_ESCAPE
+
+    brief_path, log_path = install_brief(
+        directory, text, slugify(args.title or "", "brief"))
+    rel = brief_path.relative_to(directory).as_posix()
+    argv = build_argv(
+        brief_message(rel), directory,
+        model=model, title=args.title, auto=args.auto,
+        continue_session=args.continue_session,
+        files=[str(brief_path)] + list(args.file or []),
+        binary=args.binary,
+    )
+
+    # 🔴 NEVER IN THE FOREGROUND, and no flag to make it so. 20% of opencode
+    # sessions exceed the Bash tool's hard 600,000 ms ceiling; one measured
+    # dispatch died at exactly 600s with `Exit code 143`. `start_new_session`
+    # puts it in its own process group so killing the calling shell — which is
+    # what a Bash-tool timeout does — cannot reach it.
+    try:
+        log = open(log_path, "wb")
+    except OSError as e:
+        print(f"cannot open log {log_path}: {e}", file=sys.stderr)
+        emit("error", {"stage": "run", "reason": "log-open"}, exit_code=RC_LAUNCH)
+        return RC_LAUNCH
+    try:
+        proc = subprocess.Popen(
+            argv, cwd=str(directory), stdin=subprocess.DEVNULL,
+            stdout=log, stderr=subprocess.STDOUT, start_new_session=True,
+        )
+    except OSError as e:
+        log.close()
+        print(f"could not start {args.binary!r}: {e}", file=sys.stderr)
+        emit("error", {"stage": "run", "reason": "spawn"}, exit_code=RC_LAUNCH)
+        return RC_LAUNCH
+    finally:
+        try:
+            log.close()
+        except OSError:
+            pass
+
+    print()
+    print(f"DISPATCHED  pid={proc.pid}")
+    print(f"  brief : {brief_path}")
+    print(f"  log   : {log_path}")
+    print(f"  argv  : {' '.join(argv)}")
+    print()
+    print("It is DETACHED — this call has already returned and the run is not")
+    print("bounded by any tool timeout. Check on it with:")
+    print(f"  tail -n 40 {log_path}")
+    emit("dispatched",
+         {"model_alias": args.model or "default",
+          "model": model or "config-default",
+          "auto": bool(args.auto), "continued": bool(args.continue_session),
+          "extra_files": len(args.file or []),
+          "command_warnings": len(rep["command_warnings"]),
+          "paths_examined": rep["paths_examined"],
+          "commands_examined": rep["commands_examined"]},
+         exit_code=RC_OK, duration_ms=int((time.time() - started) * 1000))
+    return RC_OK
+
+
+def build_parser() -> argparse.ArgumentParser:
+    epilog = (
+        "model aliases:\n  "
+        + "\n  ".join(f"{k:<6} {v}" for k, v in MODEL_ALIASES.items())
+        + "\n  (no -m)  the opencode.jsonc default\n\n"
+        "There is deliberately NO foreground mode: 20% of opencode sessions\n"
+        "outlive the Bash tool's 600,000 ms ceiling.\n"
+    )
+    p = argparse.ArgumentParser(
+        prog=TOOL, description=__doc__.split("\n\n")[0],
+        epilog=epilog, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    def common(sp):
+        sp.add_argument("--dir", required=True,
+                        help="opencode's project directory. The brief is written "
+                             "INSIDE it and every path it names must be under it.")
+        sp.add_argument("--brief", default="-",
+                        help="brief file, or `-` for stdin (default).")
+
+    pf = sub.add_parser("preflight", help="check a brief; never dispatches")
+    common(pf)
+    pf.add_argument("--json", action="store_true")
+    pf.set_defaults(func=cmd_preflight)
+
+    rn = sub.add_parser("run", help="preflight, then dispatch in the background")
+    common(rn)
+    rn.add_argument("--title", help="opencode session title")
+    rn.add_argument("-m", "--model", dest="model",
+                    help="flash | mimo | pro | a full provider/vendor/model id")
+    rn.add_argument("--auto", action="store_true")
+    rn.add_argument("-c", "--continue", dest="continue_session",
+                    action="store_true", help="continue the last session")
+    rn.add_argument("--file", action="append", default=[],
+                    help="extra attachment; repeatable. The brief is attached "
+                         "automatically.")
+    rn.add_argument("--binary", default=os.environ.get("OPENCODE_BIN", "opencode"),
+                    help=argparse.SUPPRESS)
+    rn.set_defaults(func=cmd_run)
+    return p
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/opencode/opencode-dispatch
+++ b/scripts/opencode/opencode-dispatch
@@ -204,11 +204,45 @@ def emit(outcome: str, dims: dict | None = None, exit_code: int | None = None,
 # --------------------------------------------------------------------------- #
 # I/O helpers
 # --------------------------------------------------------------------------- #
+class BriefError(Exception):
+    """A brief that cannot be used. Carries its own operator-facing message.
+
+    🔴 It exists so an unreadable `--brief` lands in the DOCUMENTED rc vocabulary
+    with telemetry attached. Before it, a missing file raised an uncaught
+    `FileNotFoundError` -> rc 1 (a code this tool never documents) and emitted
+    NOTHING, so adoption-scan's `error` bucket undercounted exactly the failures
+    an operator hits most.
+    """
+
+
 def read_brief(source: str | None) -> str:
-    """Brief text from a file, or from stdin when `source` is `-` or omitted."""
+    """Brief text from a file, or from stdin when `source` is `-` or omitted.
+
+    🔴 An EMPTY brief is refused, not dispatched. Measured before this check:
+    `printf '' | … run --dir <d>` wrote a 0-byte brief, returned rc 0, printed
+    `DISPATCHED` and emitted `outcome=dispatched`. A dropped heredoc is the
+    single most likely operator error, and a tool whose entire purpose is to
+    kill exit-0-having-done-nothing must not manufacture a fresh instance of it.
+    Whitespace-only counts as empty — `</dev/null` and a stray newline are the
+    same mistake.
+    """
     if source in (None, "-"):
-        return sys.stdin.read()
-    return Path(source).read_text(encoding="utf-8")
+        text = sys.stdin.read()
+        where = "stdin"
+    else:
+        try:
+            text = Path(source).read_text(encoding="utf-8")
+        except OSError as e:
+            raise BriefError(f"cannot read --brief {source!r}: {e}") from e
+        where = f"--brief {source}"
+    if not text.strip():
+        raise BriefError(
+            f"the brief read from {where} is EMPTY. Refusing to dispatch: an "
+            "empty brief is a dropped heredoc or a closed stdin, and opencode "
+            "would run, do nothing, and exit 0 — the exact failure this tool "
+            "exists to prevent. Pipe the brief in, or pass --brief <file>."
+        )
+    return text
 
 
 def install_brief(directory: Path, text: str, slug: str) -> tuple[Path, Path]:
@@ -239,69 +273,120 @@ def resolve_dir(raw: str):
 # --------------------------------------------------------------------------- #
 # preflight
 # --------------------------------------------------------------------------- #
-def preflight(text: str, directory: Path) -> dict:
-    """The full report. Pure w.r.t. the filesystem apart from path resolution."""
-    offenders = brief_scan.scan_paths(text, directory)
+def preflight(text: str, directory: Path, attachments=()) -> dict:
+    """The full report. Pure w.r.t. the filesystem apart from path resolution.
+
+    🔴 `attachments` is not optional in spirit. `--file` is the #3 most-used flag
+    and SKILL.md advertises it; leaving it out of the scan is what let
+    `run --dir <proj> --file <outside>/extra.md` print an all-clear.
+    """
+    offenders = (brief_scan.scan_paths(text, directory)
+                 + brief_scan.scan_attachments(attachments, directory))
     warnings = brief_scan.scan_commands(text, directory)
+    unresolved = brief_scan.extract_unresolved_paths(text)
     return {
         "dir": str(directory),
         "blocked": bool(offenders),
         "external_paths": [
-            {"as_written": o.text, "resolved": o.resolved} for o in offenders
+            {"as_written": o.text, "resolved": o.resolved, "kind": o.kind}
+            for o in offenders
         ],
+        "unresolved_paths": unresolved,
         "command_warnings": [
             {"command": v.command, "action": v.action, "rule": v.pattern,
              "guard": v.guard_reason}
             for v in warnings
         ],
         "paths_examined": len(brief_scan.extract_paths(text)),
+        "attachments_examined": len(attachments),
         "commands_examined": sum(
             len(brief_scan.block_commands(b)) for b in brief_scan.shell_blocks(text)
         ),
     }
 
 
+# 🔴 THE VERDICT SENTENCES, AS WHOLE NORMALISED STRINGS.
+#
+# They are constants because the tests pin them ENTIRE rather than by substring:
+# a guard on words is walkable by rewording, and these three sentences are the
+# tool's central CLAIM about what it checked. A cosmetic reword failing the
+# suite is the price of a machine-readable claim, and it is worth paying.
+#
+# 🔴 The `NOT EXAMINED` line is the finding that produced this block. The report
+# used to print "external paths : none — every path is under --dir"
+# UNCONDITIONALLY, including beside `paths examined : 0` — which is precisely a
+# guard whose description is wider than its implementation. "I found nothing"
+# and "there was nothing to find" are different claims and now read differently.
+VERDICT_NOT_EXAMINED = ("  external paths    : NOT EXAMINED — no resolvable path "
+                        "in the brief, and no attachments")
+VERDICT_CLEAN = "  external paths    : none — all {n} examined resolve under --dir"
+
+
 def print_report(rep: dict) -> None:
     # 🔴 Always print what was EXAMINED beside what was found. A bare "0
     # external paths" from a scan that walked nothing is the failure, not the
     # all-clear (same reasoning as drift-check's "links examined" line).
+    examined = rep["paths_examined"] + rep["attachments_examined"]
     print(f"preflight  dir={rep['dir']}")
-    print(f"  paths examined    : {rep['paths_examined']}")
-    print(f"  commands examined : {rep['commands_examined']}")
+    print(f"  paths examined       : {rep['paths_examined']}")
+    print(f"  attachments examined : {rep['attachments_examined']}")
+    print(f"  commands examined    : {rep['commands_examined']}")
 
     if rep["external_paths"]:
         print()
-        print("🔴 BLOCKED — the brief names paths OUTSIDE --dir. `opencode run` "
-              "auto-rejects the")
+        print("🔴 BLOCKED — paths OUTSIDE --dir. `opencode run` auto-rejects the")
         print("   external-directory prompt and exits 0 having done nothing "
               "(measured twice).")
         for p in rep["external_paths"]:
             shown = p["as_written"]
             extra = "" if shown == p["resolved"] else f"   -> {p['resolved']}"
-            print(f"     {shown}{extra}")
+            print(f"     [{p['kind']}] {shown}{extra}")
         print()
         print("   Fix one of these, not this check:")
         print("     * move the file under --dir, or")
         print("     * widen --dir to a directory that contains both, or")
         print("     * inline the content into the brief instead of pointing at it.")
+    elif examined == 0:
+        print(VERDICT_NOT_EXAMINED)
     else:
-        print("  external paths    : none — every path is under --dir")
+        print(VERDICT_CLEAN.format(n=examined))
+
+    # 🔴 UNMEASURED is its own category and is never folded into either verdict
+    # above — the same discipline drift-check applies to `absent`/`fetch failed`.
+    if rep["unresolved_paths"]:
+        print()
+        print(f"  UNMEASURED paths     : {len(rep['unresolved_paths'])} — built "
+              "from a variable, so containment")
+        print("                         cannot be decided statically. Check "
+              "these yourself:")
+        for tok in rep["unresolved_paths"]:
+            print(f"     {tok}")
 
     if rep["command_warnings"]:
+        rows = rep["command_warnings"]
         print()
-        print("⚠ WARN — these commands would meet friction. `opencode run` "
-              "AUTO-REJECTS an `ask`,")
-        print("  so the dispatch stalls MID-RUN rather than prompting. "
-              "Not blocking: this parser")
-        print("  deliberately over-matches.")
-        for w in rep["command_warnings"]:
+        # The header names the mechanism that actually applies. It used to
+        # assert "auto-rejects an `ask`" even when every row was a `deny`.
+        if any(w["action"] == "ask" for w in rows):
+            print("⚠ WARN — these commands would meet friction. `opencode run` "
+                  "AUTO-REJECTS an `ask`,")
+            print("  so the dispatch stalls MID-RUN rather than prompting. "
+                  "Not blocking: this parser")
+            print("  deliberately over-matches.")
+        else:
+            print("⚠ WARN — these commands are DENIED outright and will fail "
+                  "mid-run. Not blocking:")
+            print("  this parser deliberately over-matches.")
+        for w in rows:
             rule = f" (rule {w['rule']!r})" if w["rule"] else ""
             print(f"     [{w['action']}]{rule}  {w['command']}")
             if w["guard"]:
-                print(f"        🔴 guard_core would HARD-DENY this: "
-                      f"{w['guard'].splitlines()[0]}")
+                lead = ("⚠ guard_core could not judge this"
+                        if w["guard"].startswith(brief_scan.GUARD_UNMEASURED)
+                        else "🔴 guard_core would HARD-DENY this")
+                print(f"        {lead}: {w['guard'].splitlines()[0]}")
     else:
-        print("  command warnings  : none")
+        print(f"  command warnings     : none of {rep['commands_examined']} examined")
 
 
 # --------------------------------------------------------------------------- #
@@ -313,15 +398,23 @@ def cmd_preflight(args) -> int:
         print(f"--dir {args.dir!r} is not a directory", file=sys.stderr)
         emit("error", {"stage": "preflight", "reason": "bad-dir"}, exit_code=RC_DIR)
         return RC_DIR
-    text = read_brief(args.brief)
-    rep = preflight(text, directory)
+    try:
+        text = read_brief(args.brief)
+    except BriefError as e:
+        print(str(e), file=sys.stderr)
+        emit("error", {"stage": "preflight", "reason": "bad-brief"},
+             exit_code=RC_USAGE)
+        return RC_USAGE
+    rep = preflight(text, directory, attachments=args.file or [])
     if args.json:
         print(json.dumps(rep, indent=2))
     else:
         print_report(rep)
     dims = {"external_paths": len(rep["external_paths"]),
+            "unresolved_paths": len(rep["unresolved_paths"]),
             "command_warnings": len(rep["command_warnings"]),
             "paths_examined": rep["paths_examined"],
+            "attachments_examined": rep["attachments_examined"],
             "commands_examined": rep["commands_examined"]}
     # 🔴 Two literal call sites, not one ternary. The outcome ledger in
     # tests/test_dispatch.py is a GREP over these call sites — a computed
@@ -348,14 +441,24 @@ def cmd_run(args) -> int:
         emit("error", {"stage": "run", "reason": "bad-model"}, exit_code=RC_USAGE)
         return RC_USAGE
 
-    text = read_brief(args.brief)
-    rep = preflight(text, directory)
+    try:
+        text = read_brief(args.brief)
+    except BriefError as e:
+        print(str(e), file=sys.stderr)
+        emit("error", {"stage": "run", "reason": "bad-brief"}, exit_code=RC_USAGE)
+        return RC_USAGE
+
+    # 🔴 The attachments are preflighted BEFORE the brief is installed, so a bad
+    # `--file` cannot leave a stray brief in the target directory.
+    rep = preflight(text, directory, attachments=args.file or [])
     print_report(rep)
     if rep["blocked"]:
         print()
         print("NOT DISPATCHED.")
         emit("preflight-blocked",
              {"stage": "run", "external_paths": len(rep["external_paths"]),
+              "attachments_examined": rep["attachments_examined"],
+              "unresolved_paths": len(rep["unresolved_paths"]),
               "command_warnings": len(rep["command_warnings"]),
               "model_alias": args.model or "default"},
              exit_code=RC_PATH_ESCAPE)
@@ -439,6 +542,12 @@ def build_parser() -> argparse.ArgumentParser:
                              "INSIDE it and every path it names must be under it.")
         sp.add_argument("--brief", default="-",
                         help="brief file, or `-` for stdin (default).")
+        # On BOTH subcommands: an attachment is subject to the same containment
+        # check as the brief, so `preflight` must be able to see it too.
+        sp.add_argument("--file", action="append", default=[],
+                        help="extra attachment; repeatable. The brief is "
+                             "attached automatically. Each one must resolve "
+                             "under --dir.")
 
     pf = sub.add_parser("preflight", help="check a brief; never dispatches")
     common(pf)
@@ -453,9 +562,6 @@ def build_parser() -> argparse.ArgumentParser:
     rn.add_argument("--auto", action="store_true")
     rn.add_argument("-c", "--continue", dest="continue_session",
                     action="store_true", help="continue the last session")
-    rn.add_argument("--file", action="append", default=[],
-                    help="extra attachment; repeatable. The brief is attached "
-                         "automatically.")
     rn.add_argument("--binary", default=os.environ.get("OPENCODE_BIN", "opencode"),
                     help=argparse.SUPPRESS)
     rn.set_defaults(func=cmd_run)

--- a/scripts/opencode/tests/test_dispatch.py
+++ b/scripts/opencode/tests/test_dispatch.py
@@ -194,6 +194,100 @@ def test_scan_paths_refuses_a_path_outside_dir(tmp_path):
     outside = tmp_path / "elsewhere" / "brief.md"
     offenders = brief_scan.scan_paths(f"Start from {outside}.", d)
     assert [o.text for o in offenders] == [str(outside)]
+    assert offenders[0].kind == "brief"
+
+
+# --------------------------------------------------------------------------- #
+# 2b. the three "claims wider than what it checked" findings
+# --------------------------------------------------------------------------- #
+def test_a_relative_path_with_a_dotdot_segment_escapes_and_is_caught(tmp_path):
+    """🔴 opencode runs with `cwd=--dir`, so `../outside/x` genuinely leaves it —
+    and SKILL.md used to tell the brief's author to name locations relative to
+    `--dir`, which invited exactly this. Measured before the fix:
+    `paths examined : 0` plus an unconditional all-clear."""
+    d = tmp_path / "proj"
+    d.mkdir()
+    (tmp_path / "outside").mkdir()
+    offenders = brief_scan.scan_paths("Read ../outside/extra.md and apply it.", d)
+    assert [o.text for o in offenders] == ["../outside/extra.md"]
+
+
+def test_a_relative_path_that_stays_inside_is_not_an_offender(tmp_path):
+    """The in-dir control for the rule above. `a/../b` resolves back inside, so
+    a blanket 'any `..` is an offender' rule would be wrong."""
+    d = tmp_path / "proj"
+    d.mkdir()
+    assert brief_scan.scan_paths("Edit sub/../src/x.py then stop.", d) == []
+
+
+@pytest.mark.parametrize("prose", [
+    "compare v1..v2 for the delta",
+    "run git log origin/main..HEAD",
+    "and then... it stops",
+    "the range HEAD~2..HEAD is what changed",
+])
+def test_the_dotdot_scanner_does_not_fire_on_prose_or_git_ranges(prose, tmp_path):
+    """The negative control. A `..` between two words is not a path, and a
+    scanner that thinks it is blocks every brief mentioning a git range."""
+    d = tmp_path / "proj"
+    d.mkdir()
+    assert brief_scan.scan_paths(prose, d) == []
+
+
+@pytest.mark.parametrize("token", [
+    "${pkgs.python312}/bin/python3",
+    "${DEVRC}/scripts/tests",
+    "$DEVRC/scripts/tests",
+    "{base}/sub/file.py",
+])
+def test_a_variable_built_path_is_UNMEASURED_never_blocked_and_never_clean(token, tmp_path):
+    """🔴 Both spellings were wrong, in OPPOSITE directions, and both are the
+    likeliest content of a brief written in this repo.
+
+    `${X}/y` FALSE-BLOCKED (the `}` is not in the lookbehind's excluded class,
+    so `/y` was read as an absolute path); `$X/y` SILENTLY PASSED (the `/`
+    follows a letter, which is excluded) — and CLAUDE.md tells agents to use the
+    `$DEVRC`/`$HOMELAB` handles. With no override flag, a false block leaves
+    'reword or abandon the tool'.
+    """
+    d = tmp_path / "proj"
+    d.mkdir()
+    text = f"Run the thing at {token} when ready."
+    assert brief_scan.scan_paths(text, d) == [], "must not BLOCK an unresolvable path"
+    assert brief_scan.extract_paths(text) == [], "must not count it as examined"
+    assert brief_scan.extract_unresolved_paths(text) == [token], \
+        "must be reported UNMEASURED, not silently dropped"
+
+
+def test_an_attachment_outside_dir_is_an_offender(tmp_path):
+    """🔴 `--file` is the #3 most-used flag and SKILL.md advertises it. Measured
+    before this: `run --dir <proj> --file <outside>/extra.md` printed
+    'external paths : none — every path is under --dir' and handed opencode the
+    outside file."""
+    d = tmp_path / "proj"
+    d.mkdir()
+    outside = tmp_path / "elsewhere" / "extra.md"
+    offenders = brief_scan.scan_attachments([str(outside)], d)
+    assert [(o.text, o.kind) for o in offenders] == [(str(outside), "attachment")]
+
+
+def test_an_attachment_inside_dir_is_accepted(tmp_path):
+    d = tmp_path / "proj"
+    d.mkdir()
+    assert brief_scan.scan_attachments([str(d / "notes.md")], d) == []
+
+
+def test_the_system_allowlist_is_judged_lexically_not_by_realpath(tmp_path):
+    """🔴 The comment claimed `/etc` and `/var` are deliberately absent. On NixOS
+    `/etc/hosts` realpaths into `/nix/store/…-hosts`, hit the `/nix/store` entry
+    and passed — so every `/etc` path the list claimed to block was silently
+    allowed. Under-blocking, invisible, and the comment asserted the opposite."""
+    d = tmp_path / "proj"
+    d.mkdir()
+    assert brief_scan.is_allowlisted("/etc/hosts") is None
+    assert brief_scan.is_allowlisted("/usr/bin/env") is not None
+    assert [o.text for o in brief_scan.scan_paths("edit /etc/hosts", d)] == \
+        ["/etc/hosts"]
 
 
 def test_scan_paths_accepts_the_in_dir_control(tmp_path):
@@ -256,6 +350,150 @@ def test_preflight_json_reports_examined_beside_found(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
+# 2c. 🔴 THE PRINTED CLAIM. Pinned as WHOLE NORMALISED LINES, not substrings —
+#     a guard on words is walkable by rewording, and these sentences ARE the
+#     tool's central claim about what it checked.
+# --------------------------------------------------------------------------- #
+def _lines(out: str) -> list[str]:
+    return [ln.rstrip() for ln in out.split("\n")]
+
+
+# 🔴 THE LITERAL SENTENCES, WRITTEN OUT HERE — deliberately NOT imported from
+# the CLI. A mutation sweep caught the earlier version doing
+# `D.VERDICT_CLEAN.format(n=2) in lines`: mutating the constant mutated the
+# expectation with it, so a reworded claim SURVIVED a fully green suite. That is
+# RULES.md's "never derive a test's expectation from the implementation it
+# tests", in the one place where the implementation IS a claim about itself.
+#
+# A cosmetic reword now fails this file. That is the price of a machine-readable
+# claim and it is worth paying.
+LINE_NOT_EXAMINED = ("  external paths    : NOT EXAMINED — no resolvable path "
+                     "in the brief, and no attachments")
+LINE_CLEAN_2 = "  external paths    : none — all 2 examined resolve under --dir"
+
+
+def test_the_verdict_constants_match_the_sentences_pinned_here():
+    """The two-way pin. The literals above are the source of truth; this asserts
+    the CLI still emits exactly them, so the other tests can use either."""
+    assert D.VERDICT_NOT_EXAMINED == LINE_NOT_EXAMINED
+    assert D.VERDICT_CLEAN.format(n=2) == LINE_CLEAN_2
+
+
+def test_an_empty_scan_says_NOT_EXAMINED_not_an_all_clear(tmp_path):
+    """🔴 THE finding. The report used to print
+    'external paths : none — every path is under --dir' UNCONDITIONALLY, right
+    beside 'paths examined : 0'. "I found nothing" and "there was nothing to
+    find" are different claims."""
+    d = tmp_path / "proj"
+    d.mkdir()
+    p = _run_cli(["preflight", "--dir", str(d)], "Just tidy the code up.")
+    lines = _lines(p.stdout)
+    assert LINE_NOT_EXAMINED in lines, p.stdout
+    assert "  paths examined       : 0" in lines
+    assert "  attachments examined : 0" in lines
+    # …and the clean sentence must be ABSENT, in every arity it can take.
+    assert not any(ln.startswith("  external paths    : none") for ln in lines)
+    assert p.returncode == D.RC_OK
+
+
+def test_a_real_clean_scan_says_how_many_it_examined(tmp_path):
+    d = tmp_path / "proj"
+    d.mkdir()
+    (d / "a.md").write_text("x")
+    p = _run_cli(["preflight", "--dir", str(d), "--file", str(d / "a.md")],
+                 f"Edit {d / 'src.py'} please.")
+    lines = _lines(p.stdout)
+    assert LINE_CLEAN_2 in lines, p.stdout
+    assert LINE_NOT_EXAMINED not in lines
+    assert p.returncode == D.RC_OK
+
+
+def test_the_report_never_claims_containment_for_an_unchecked_attachment(tmp_path):
+    """The end-to-end shape of finding 1: an out-of-dir attachment must BLOCK,
+    and the clean sentence must not appear anywhere in the output."""
+    d = tmp_path / "proj"
+    d.mkdir()
+    outside = tmp_path / "elsewhere" / "extra.md"
+    outside.parent.mkdir()
+    outside.write_text("x")
+    p = _run_cli(["run", "--dir", str(d), "--file", str(outside)], "do a thing")
+    lines = _lines(p.stdout)
+    assert p.returncode == D.RC_PATH_ESCAPE, p.stdout + p.stderr
+    assert not any(ln.startswith("  external paths    : none") for ln in lines)
+    assert LINE_NOT_EXAMINED not in lines
+    assert f"     [attachment] {outside}" in lines
+    assert "NOT DISPATCHED." in lines
+
+
+def test_unresolved_paths_are_reported_separately_from_both_verdicts(tmp_path):
+    d = tmp_path / "proj"
+    d.mkdir()
+    p = _run_cli(["preflight", "--dir", str(d)], "run ${DEVRC}/scripts/tests now")
+    lines = _lines(p.stdout)
+    assert p.returncode == D.RC_OK
+    # Not blocked, not counted as clean, and named.
+    assert LINE_NOT_EXAMINED in lines
+    assert "     ${DEVRC}/scripts/tests" in lines
+    assert any(ln.startswith("  UNMEASURED paths     : 1") for ln in lines)
+
+
+def test_the_warn_header_names_the_mechanism_that_applies(tmp_path):
+    """The header asserted "`opencode run` AUTO-REJECTS an `ask`" even when every
+    row was a `deny` — a claim about a mechanism that did not fire."""
+    d = tmp_path / "proj"
+    d.mkdir()
+    deny_only = "```bash\ngit stash push -m wip\n```\n"
+    p = _run_cli(["preflight", "--dir", str(d)], deny_only)
+    assert "[deny]" in p.stdout, p.stdout
+    assert "AUTO-REJECTS an `ask`" not in p.stdout
+    ask_case = "```bash\nkubectl -n d exec p -- sh\n```\n"
+    q = _run_cli(["preflight", "--dir", str(d)], ask_case)
+    assert "AUTO-REJECTS an `ask`" in q.stdout
+
+
+# --------------------------------------------------------------------------- #
+# 2d. an EMPTY brief must never dispatch
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("text", ["", "\n", "   \n\t\n"])
+def test_an_empty_brief_is_refused_and_never_dispatches(text, tmp_path):
+    """🔴 Measured before this check: a 0-byte brief returned rc 0, printed
+    DISPATCHED and emitted outcome=dispatched. A dropped heredoc is the single
+    most likely operator error, and this tool exists to kill
+    exit-0-having-done-nothing — it was manufacturing a fresh instance."""
+    d = tmp_path / "proj"
+    d.mkdir()
+    p = _run_cli(["run", "--dir", str(d)], text)
+    assert p.returncode == D.RC_USAGE == 2, p.stdout + p.stderr
+    assert "DISPATCHED" not in p.stdout
+    assert "EMPTY" in p.stderr
+    assert not (d / D.BRIEF_SUBDIR).exists(), "an empty brief was still installed"
+
+
+def test_a_missing_brief_file_lands_in_the_documented_rc_vocabulary(tmp_path):
+    """It raised an uncaught FileNotFoundError -> rc 1, a code this tool never
+    documents, and emitted NO telemetry — so adoption-scan's `error` bucket
+    undercounted the failure an operator hits most."""
+    d = tmp_path / "proj"
+    d.mkdir()
+    p = _run_cli(["preflight", "--dir", str(d), "--brief",
+                  str(tmp_path / "nope.md")], "")
+    assert p.returncode == D.RC_USAGE, p.stdout + p.stderr
+    assert "Traceback" not in p.stderr
+    assert "cannot read --brief" in p.stderr
+
+
+def test_the_brief_error_path_emits_telemetry(tmp_path, monkeypatch):
+    """The other half: rc alone is not the fix — the `error` bucket has to see it."""
+    seen = []
+    monkeypatch.setattr(D, "emit", lambda o, *a, **k: seen.append(o))
+    monkeypatch.setattr(D.sys, "stdin", _Stdin(""))
+    d = tmp_path / "proj"
+    d.mkdir()
+    assert D.main(["run", "--dir", str(d)]) == D.RC_USAGE
+    assert seen == ["error"]
+
+
+# --------------------------------------------------------------------------- #
 # 3b. the command scanner's positive control
 # --------------------------------------------------------------------------- #
 KUBECTL_BRIEF = """\
@@ -277,6 +515,31 @@ def test_scan_commands_positive_control_names_the_glob(tmp_path):
     asks = [w for w in warnings if w.action == "ask"]
     assert asks, "the ask scanner produced ZERO on a brief that must produce one"
     assert any(w.pattern == "*kubectl*exec*" for w in asks), [w.pattern for w in asks]
+
+
+def test_the_guard_core_channel_positive_control(tmp_path):
+    """🔴 The channel used to sit behind a bare `except: guard_reason = None`,
+    and a mutant making `evaluate` raise SURVIVED all 717 tests — a broken
+    channel and a clean brief printed identically. `evaluate` raises on an
+    unknown policy name BY DESIGN, so renaming the "opencode" policy is exactly
+    the shape that would have gone dark forever."""
+    brief = "```bash\nrm -rf /\n```\n"
+    reasons = [w.guard_reason for w in brief_scan.scan_commands(brief, tmp_path)]
+    assert any(r for r in reasons), \
+        "positive control: guard_core produced ZERO verdicts on `rm -rf /`"
+    assert not any(r.startswith(brief_scan.GUARD_UNMEASURED) for r in reasons if r)
+
+
+def test_a_broken_guard_core_channel_reports_COULD_NOT_MEASURE(tmp_path, monkeypatch):
+    """…and when it genuinely cannot judge, it says so instead of returning the
+    same None a clean brief produces."""
+    def boom(*a, **k):
+        raise TypeError("evaluate() got an unexpected keyword argument 'cwd'")
+    monkeypatch.setattr(brief_scan.guard_core, "evaluate", boom)
+    verdicts = brief_scan.scan_commands("```bash\nrm -rf /\n```\n", tmp_path)
+    assert verdicts, "a broken guard channel silently produced no rows at all"
+    assert all(v.guard_reason.startswith(brief_scan.GUARD_UNMEASURED)
+               for v in verdicts)
 
 
 def test_scan_commands_is_silent_on_a_read_only_brief(tmp_path):
@@ -399,10 +662,29 @@ def test_preflight_resolves_through_the_same_object_the_config_suite_pins():
     assert cfg.strip_jsonc is oc_permissions.strip_jsonc
 
 
-def test_the_base_ruleset_is_the_config_file_itself():
-    rules = oc_permissions.base_bash_rules()
-    assert rules[0] == ("*", "allow")
-    assert ("*kubectl*exec*", "ask") in rules
+def test_the_base_ruleset_prepends_the_builtin_catch_all():
+    """🔴 The fixture must be able to DISAGREE with the constant.
+
+    The previous version asserted `rules[0] == ("*", "allow")` against the real
+    config — whose own first bash key IS `"*": "allow"` — so the fixture could
+    only ever produce the value the assertion named, and a mutant dropping the
+    built-in prepend SURVIVED. Feed it a config whose first key cannot equal the
+    constant, and the prepend becomes observable.
+    """
+    synthetic = {"permission": {"bash": {"*never*": "deny", "ls*": "allow"}}}
+    rules = oc_permissions.base_bash_rules(synthetic)
+    assert rules[0] == ("*", "allow"), "the built-in catch-all is not prepended"
+    assert rules[1] == ("*never*", "deny"), "config order is not preserved"
+    assert len(rules) == 3
+    # …and without the prepend, an unmatched command would fall through to
+    # opencode's `ask` fallback instead of `allow`. That is the behaviour the
+    # constant exists for, so assert it rather than the tuple alone.
+    assert oc_permissions.resolve(rules, "echo hi") == "allow"
+    assert oc_permissions.resolve(rules[1:], "echo hi") == "ask"
+
+
+def test_the_base_ruleset_reads_the_real_config_file():
+    assert ("*kubectl*exec*", "ask") in oc_permissions.base_bash_rules()
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/opencode/tests/test_dispatch.py
+++ b/scripts/opencode/tests/test_dispatch.py
@@ -1,0 +1,513 @@
+r"""Tests for `opencode-dispatch` — the stage-1 opencode dispatch gate.
+
+WHAT IS UNDER TEST, and why each one exists (every claim below is a MEASURED
+failure, not a hypothetical):
+
+  1. THE CANONICAL ARGV ORDER. `--file` is an ARRAY option and greedily
+     swallowed the message as a second filename (`Error: File not found:
+     Execute the task described in the attached brief…`). Only
+     message-positional-FIRST worked. Pinned by INDEX, not by "the message is
+     in there somewhere".
+
+  2. PATH CONTAINMENT — the hard block. `external_directory: "ask"` +
+     `opencode run`'s auto-reject = exit 0 having done nothing, twice. Both
+     directions are pinned: it REFUSES an out-of-dir path (rc 3) and it ACCEPTS
+     the in-dir control (rc 0). A refuser that refuses everything is not a gate.
+
+  3. POSITIVE CONTROLS on both scanners. `extract_paths` and `scan_commands`
+     each get a fixture that MUST produce a non-zero count, so a reassuring
+     "0 external paths / 0 warnings" can never mean "wired to nothing".
+     RULES.md 🔴: report the pair, never the zero alone.
+
+  4. NO FOREGROUND MODE. 20% of opencode sessions exceed the Bash tool's hard
+     600,000 ms ceiling; one dispatch died at exactly 600s with `Exit code 143`.
+     Asserted structurally (the parser has no such flag) AND behaviourally
+     (the spawn is `start_new_session=True`, detached from the caller's process
+     group, which is what a tool timeout kills).
+
+  5. THE SEAM. preflight's permission verdicts must come from the SAME resolver
+     `scripts/tests/test_opencode_config.py` pins with ~500 assertions. Asserted
+     by object identity, because "verified in isolation" is how a defect lives
+     in the seam nobody owns.
+
+  6. THE TELEMETRY LEDGER. Every outcome string the CLI can emit must appear in
+     adoption-scan's REGISTRY row, and vice versa — otherwise the adoption
+     report silently buckets a real outcome as "unknown".
+
+  7. GIT TRACKING. 🔴 A new file that is not `git add`ed is silently omitted
+     from the flake, and the switch SUCCEEDS with the file simply absent.
+
+    run:  python -m pytest scripts/opencode/tests/test_dispatch.py -q
+"""
+from __future__ import annotations
+
+import importlib.util
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+OC_DIR = ROOT / "scripts" / "opencode"
+CLI_PATH = OC_DIR / "opencode-dispatch"
+SKILL_PATH = OC_DIR / "SKILL.md"
+HOME_NIX = ROOT / "nix" / "home.nix"
+ADOPTION = ROOT / "scripts" / "session-analysis" / "adoption-scan.py"
+
+sys.path.insert(0, str(OC_DIR / "lib"))
+sys.path.insert(0, str(ROOT / "scripts" / "tests"))
+
+import brief_scan  # noqa: E402
+import oc_permissions  # noqa: E402
+
+
+def _load_cli():
+    """Import the extensionless executable as a module."""
+    spec = importlib.util.spec_from_loader(
+        "opencode_dispatch",
+        importlib.machinery.SourceFileLoader("opencode_dispatch", str(CLI_PATH)),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+D = _load_cli()
+
+
+# --------------------------------------------------------------------------- #
+# 1. the canonical argv order
+# --------------------------------------------------------------------------- #
+MESSAGE = "Read .opencode-dispatch/x.md first"
+
+
+def test_message_is_the_positional_at_the_pinned_index():
+    argv = D.build_argv(MESSAGE, "/some/dir")
+    assert argv[:2] == ["opencode", "run"]
+    assert argv.index(MESSAGE) == D.MESSAGE_ARGV_INDEX == 2, (
+        "the message must be the FIRST positional. Measured: with the message "
+        "after `--file`, opencode consumed it as a second filename and died "
+        f"with `Error: File not found: <message>`. Got argv={argv}"
+    )
+
+
+def test_message_precedes_every_file_flag():
+    argv = D.build_argv(MESSAGE, "/d", files=["/d/a.md", "/d/b.md"])
+    assert argv.index(MESSAGE) < argv.index("--file")
+    assert argv.count("--file") == 2
+
+
+def test_the_flags_that_actually_recur_are_all_emitted():
+    # --dir 18 / --title 7 / --file 7 / -m 6 / --auto 4 / -c 2 over n=24.
+    argv = D.build_argv(MESSAGE, "/d", model="m/x", title="T", auto=True,
+                        continue_session=True, files=["/d/a.md"])
+    for pair in (["--dir", "/d"], ["--title", "T"], ["-m", "m/x"],
+                 ["--file", "/d/a.md"]):
+        i = argv.index(pair[0])
+        assert argv[i:i + 2] == pair
+    assert "--auto" in argv and "-c" in argv
+
+
+def test_no_model_flag_when_no_alias_is_given():
+    # 18 of 24 measured dispatches passed no -m at all; the config default must
+    # survive, so the flag has to be ABSENT rather than filled in here.
+    assert "-m" not in D.build_argv(MESSAGE, "/d")
+
+
+@pytest.mark.parametrize("alias,expected", [
+    ("flash", "openrouter/deepseek/deepseek-v4-flash"),
+    ("mimo", "openrouter/xiaomi/mimo-v2.5"),
+    ("pro", "openrouter/deepseek/deepseek-v4-pro"),
+])
+def test_model_aliases_resolve(alias, expected):
+    assert D.resolve_model(alias) == expected
+
+
+def test_a_full_model_id_passes_through():
+    assert D.resolve_model("openrouter/vendor/thing") == "openrouter/vendor/thing"
+
+
+def test_an_unknown_bare_alias_is_a_usage_error_not_a_passthrough():
+    with pytest.raises(ValueError):
+        D.resolve_model("flsah")
+
+
+# --------------------------------------------------------------------------- #
+# 2 + 3. path containment, both directions, with positive controls
+# --------------------------------------------------------------------------- #
+def test_extract_paths_positive_control():
+    """🔴 The scanner MUST be able to produce a non-zero count.
+
+    Without this, every "0 external paths" below is indistinguishable from a
+    scanner wired to nothing.
+    """
+    found = brief_scan.extract_paths(
+        "Read /opt/example/input.txt and also ~/notes/todo.md before starting."
+    )
+    assert "/opt/example/input.txt" in found
+    assert "~/notes/todo.md" in found
+    assert len(found) == 2
+
+
+def test_extract_paths_does_not_fire_on_prose_or_urls():
+    """The negative half of the same control: a scanner that matches everything
+    reports a confident non-zero on any text and is equally useless."""
+    text = ("Weigh read/write costs at 20/80 and glob **/*.py; "
+            "the docs are at https://example.invalid/a/b/c.")
+    assert brief_scan.extract_paths(text) == []
+
+
+@pytest.mark.parametrize("url,leaked", [
+    ("https://example.invalid/a?f=/etc/passwd", "/etc/passwd"),
+    ("https://example.invalid/a#/opt/thing", "/opt/thing"),
+    ("see https://example.invalid/q?path=~/notes.md now", "~/notes.md"),
+])
+def test_the_url_strip_is_load_bearing_for_query_and_fragment_paths(url, leaked):
+    """🔴 Found by a SURVIVING mutant: deleting the URL strip passed the whole
+    suite, because the lookbehind alone already rejects `https://host/a/b` —
+    every `/` there is preceded by an excluded character.
+
+    A path in a QUERY or FRAGMENT is different: it is preceded by `=` or `#`,
+    which are NOT in the excluded class, so it IS extracted. Without the strip a
+    brief that merely LINKS to documentation would be refused, which is the
+    permanently-red-gate failure this whole design is trying to avoid.
+
+    The `leaked` column is the positive control: it names what the regex
+    genuinely can see, so "extract_paths returned []" here cannot mean "the
+    scanner is wired to nothing".
+    """
+    assert brief_scan._PATH_RE.search(url).group(1) == leaked
+    assert brief_scan.extract_paths(url) == []
+
+
+def test_is_under_does_not_treat_a_sibling_prefix_as_a_child():
+    assert brief_scan.is_under("/w/repo/x", "/w/repo") is True
+    assert brief_scan.is_under("/w/repo", "/w/repo") is True
+    assert brief_scan.is_under("/w/repo-other/x", "/w/repo") is False
+
+
+def test_scan_paths_refuses_a_path_outside_dir(tmp_path):
+    d = tmp_path / "proj"
+    d.mkdir()
+    outside = tmp_path / "elsewhere" / "brief.md"
+    offenders = brief_scan.scan_paths(f"Start from {outside}.", d)
+    assert [o.text for o in offenders] == [str(outside)]
+
+
+def test_scan_paths_accepts_the_in_dir_control(tmp_path):
+    d = tmp_path / "proj"
+    (d / "sub").mkdir(parents=True)
+    inside = d / "sub" / "thing.py"
+    assert brief_scan.scan_paths(f"Edit {inside} and re-run.", d) == []
+
+
+def test_scan_paths_ignores_the_enumerated_system_prefixes(tmp_path):
+    d = tmp_path / "proj"
+    d.mkdir()
+    assert brief_scan.scan_paths("pipe it to /dev/null with /usr/bin/env", d) == []
+
+
+def test_tmp_is_deliberately_not_allowlisted(tmp_path):
+    """🔴 Claude's scratchpad lives under /tmp and 'the brief lived in the
+    scratchpad' is failure 1's exact vector."""
+    assert not any(p.startswith("/tmp") for p in brief_scan.SYSTEM_ALLOW)
+    d = tmp_path / "proj"
+    d.mkdir()
+    assert brief_scan.scan_paths("see /tmp/claude-1000/scratchpad/brief.md", d)
+
+
+def _run_cli(args, stdin_text):
+    """Drive the real CLI end to end, as a subprocess, over stdin."""
+    return subprocess.run(
+        [sys.executable, str(CLI_PATH), *args],
+        input=stdin_text, capture_output=True, text=True, timeout=120,
+    )
+
+
+def test_preflight_exits_with_the_distinct_rc_on_an_external_path(tmp_path):
+    d = tmp_path / "proj"
+    d.mkdir()
+    outside = tmp_path / "other" / "spec.md"
+    p = _run_cli(["preflight", "--dir", str(d)], f"Implement what {outside} says.")
+    assert p.returncode == D.RC_PATH_ESCAPE == 3, p.stdout + p.stderr
+    assert str(outside) in p.stdout
+
+
+def test_preflight_accepts_the_in_dir_control(tmp_path):
+    d = tmp_path / "proj"
+    d.mkdir()
+    (d / "spec.md").write_text("x")
+    p = _run_cli(["preflight", "--dir", str(d)],
+                 f"Implement what {d / 'spec.md'} says.")
+    assert p.returncode == D.RC_OK, p.stdout + p.stderr
+
+
+def test_preflight_json_reports_examined_beside_found(tmp_path):
+    import json
+    d = tmp_path / "proj"
+    d.mkdir()
+    p = _run_cli(["preflight", "--dir", str(d), "--json"],
+                 f"Touch {d / 'a'} and /opt/elsewhere/b")
+    rep = json.loads(p.stdout)
+    assert rep["paths_examined"] == 2
+    assert len(rep["external_paths"]) == 1
+
+
+# --------------------------------------------------------------------------- #
+# 3b. the command scanner's positive control
+# --------------------------------------------------------------------------- #
+KUBECTL_BRIEF = """\
+Do the migration.
+
+```bash
+kubectl -n data exec deploy/pg -- psql -c 'select 1'
+```
+"""
+
+
+def test_scan_commands_positive_control_names_the_glob(tmp_path):
+    """🔴 The measured failure-3 command, and the rule it trips.
+
+    `kubectl exec … psql` was auto-rejected mid-run and the dispatch abandoned.
+    A warning that cannot name the glob is not actionable.
+    """
+    warnings = brief_scan.scan_commands(KUBECTL_BRIEF, tmp_path)
+    asks = [w for w in warnings if w.action == "ask"]
+    assert asks, "the ask scanner produced ZERO on a brief that must produce one"
+    assert any(w.pattern == "*kubectl*exec*" for w in asks), [w.pattern for w in asks]
+
+
+def test_scan_commands_is_silent_on_a_read_only_brief(tmp_path):
+    clean = "Look around.\n\n```bash\ngit -C . status\nls -la\n```\n"
+    assert brief_scan.scan_commands(clean, tmp_path) == []
+
+
+def test_scan_commands_ignores_a_non_shell_fence(tmp_path):
+    py = "```python\nkubectl_exec = 1\n```\n"
+    assert brief_scan.scan_commands(py, tmp_path) == []
+
+
+def test_the_command_scanner_uses_guard_cores_splitter_not_its_own():
+    """🔴 One parser. A second splitter is how the two disagree — invisibly,
+    since both would still print warnings."""
+    src = Path(brief_scan.__file__).read_text()
+    assert "import guard_core" in src
+    assert "guard_core.split_commands" in src
+    # …and no home-grown substitute alongside it. 🔴 The paren is load-bearing:
+    # a bare `"re.split"` substring test matched `guard_co(re.split)_commands`
+    # and failed on the correct code — a spelled guard catching its own subject.
+    assert "re.split(" not in src, "a second command splitter has appeared"
+
+
+def test_the_splitter_really_reaches_a_wrapped_command(tmp_path):
+    """Behavioural proof of the line above: a `VAR=… sudo …` prefix and a `&&`
+    chain are exactly what a hand-rolled splitter gets wrong."""
+    brief = ("```bash\n"
+             "cd /x && KUBECONFIG=$KC_HOMELAB kubectl -n ns exec pod -- sh\n"
+             "```\n")
+    assert any(w.pattern == "*kubectl*exec*"
+               for w in brief_scan.scan_commands(brief, tmp_path))
+
+
+# --------------------------------------------------------------------------- #
+# 4. never in the foreground
+# --------------------------------------------------------------------------- #
+def test_the_parser_offers_no_foreground_escape_hatch():
+    help_text = D.build_parser().format_help()
+    run_help = D.build_parser().parse_args  # keep the parser built
+    assert run_help is not None
+    for banned in ("--foreground", "--fg", "--wait", "--sync", "--blocking"):
+        assert banned not in help_text, (
+            f"{banned} would reintroduce failure 4: 20% of opencode sessions "
+            "exceed the Bash tool's hard 600,000 ms ceiling."
+        )
+
+
+def test_the_dispatch_is_detached_into_its_own_session(tmp_path, monkeypatch):
+    d = tmp_path / "proj"
+    d.mkdir()
+    seen = {}
+
+    class FakeProc:
+        pid = 4242
+
+    def fake_popen(argv, **kw):
+        seen["argv"] = argv
+        seen["kw"] = kw
+        return FakeProc()
+
+    monkeypatch.setattr(D.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(D.sys, "stdin", _Stdin("do the thing"))
+    rc = D.main(["run", "--dir", str(d), "--title", "T", "-m", "flash"])
+    assert rc == D.RC_OK
+    assert seen["kw"]["start_new_session"] is True, (
+        "without its own session the run dies with the calling shell — which is "
+        "exactly what a Bash-tool timeout kills (measured: Exit code 143 at 600s)"
+    )
+    assert seen["kw"]["stdin"] is D.subprocess.DEVNULL
+    assert seen["argv"][D.MESSAGE_ARGV_INDEX].startswith("Read .opencode-dispatch/")
+    assert "openrouter/deepseek/deepseek-v4-flash" in seen["argv"]
+
+
+class _Stdin:
+    def __init__(self, text):
+        self._t = text
+
+    def read(self):
+        return self._t
+
+
+def test_run_does_not_dispatch_when_preflight_blocks(tmp_path, monkeypatch):
+    d = tmp_path / "proj"
+    d.mkdir()
+    called = []
+    monkeypatch.setattr(D.subprocess, "Popen",
+                        lambda *a, **k: called.append(a) or (_ for _ in ()).throw(
+                            AssertionError("dispatched despite a blocked preflight")))
+    monkeypatch.setattr(D.sys, "stdin", _Stdin("use /opt/elsewhere/spec.md"))
+    assert D.main(["run", "--dir", str(d)]) == D.RC_PATH_ESCAPE
+    assert called == []
+
+
+def test_the_brief_is_written_inside_dir_and_self_ignores(tmp_path, monkeypatch):
+    d = tmp_path / "proj"
+    d.mkdir()
+    monkeypatch.setattr(D.subprocess, "Popen",
+                        lambda *a, **k: type("P", (), {"pid": 1})())
+    monkeypatch.setattr(D.sys, "stdin", _Stdin("a clean brief"))
+    assert D.main(["run", "--dir", str(d)]) == D.RC_OK
+    sub = d / D.BRIEF_SUBDIR
+    briefs = list(sub.glob("*.md"))
+    assert len(briefs) == 1
+    assert briefs[0].read_text() == "a clean brief"
+    # 🔴 Never the scratchpad, and never stageable in whatever repo it lands in.
+    assert (sub / ".gitignore").read_text().rstrip().endswith("*")
+
+
+# --------------------------------------------------------------------------- #
+# 5. the seam
+# --------------------------------------------------------------------------- #
+def test_preflight_resolves_through_the_same_object_the_config_suite_pins():
+    """🔴 "Verified in isolation" is the new vacuous green. Both surfaces must
+    load ONE resolver, asserted by identity — a matrix that merely AGREES today
+    is what a duplicate looks like right up until it does not."""
+    import test_opencode_config as cfg
+    assert cfg.wildcard_match is oc_permissions.wildcard_match
+    assert cfg._resolve_over is oc_permissions.resolve
+    assert cfg.strip_jsonc is oc_permissions.strip_jsonc
+
+
+def test_the_base_ruleset_is_the_config_file_itself():
+    rules = oc_permissions.base_bash_rules()
+    assert rules[0] == ("*", "allow")
+    assert ("*kubectl*exec*", "ask") in rules
+
+
+# --------------------------------------------------------------------------- #
+# 6. the telemetry ledger
+# --------------------------------------------------------------------------- #
+REGISTRY_ID = "opencode-dispatch"
+
+
+def _registry_row() -> dict:
+    src = ADOPTION.read_text()
+    m = re.search(r'\{\s*"id":\s*"opencode-dispatch".*?\n    \}', src, re.S)
+    assert m, "adoption-scan REGISTRY has no opencode-dispatch row"
+    return m.group(0)
+
+
+def test_the_registry_row_declares_the_tool_correctly():
+    row = _registry_row()
+    assert '"via": "tool"' in row
+    assert '"tool": "opencode-dispatch"' in row
+    assert '"opt_in": True' in row
+
+
+def test_every_emitted_outcome_is_declared_in_the_registry():
+    """THREE-WAY, both directions. An undeclared outcome is silently bucketed as
+    "unknown" in the adoption report; a declared-but-unreachable one makes the
+    report claim coverage that cannot exist."""
+    emitted = set(re.findall(r'\bemit\(\s*"([a-z-]+)"', CLI_PATH.read_text()))
+    assert emitted, "positive control: found ZERO emit() call sites"
+    declared = set(re.findall(r'"([a-z-]+)"', re.search(
+        r'"outcomes":\s*\[([^\]]*)\]', _registry_row()).group(1)))
+    assert emitted == declared == set(D.OUTCOMES), (
+        f"emitted={sorted(emitted)} declared={sorted(declared)} "
+        f"OUTCOMES={sorted(D.OUTCOMES)}")
+
+
+def test_no_call_site_passes_a_computed_outcome():
+    """🔴 The ledger above is a GREP over literal call sites, so a ternary or a
+    variable would be INVISIBLE to it — which is exactly what happened while
+    this was being written: `emit(a if x else b, …)` scored as one outcome and
+    the second was never seen. Pin the shape the grep can read."""
+    src = CLI_PATH.read_text()
+    # Statement-position calls only, so prose and comments that merely MENTION
+    # the call cannot be mistaken for one (they did, on the first draft).
+    call_lines = [ln.strip() for ln in src.split("\n")
+                  if ln.strip().startswith("emit(")]
+    assert len(call_lines) >= len(D.OUTCOMES), (
+        f"positive control: only {len(call_lines)} emit() statements found")
+    bad = [ln for ln in call_lines if not re.match(r'^emit\(\s*"', ln)]
+    assert bad == [], f"emit() called with a computed outcome: {bad}"
+    # …and the ledger's own regex must see EVERY one of them.
+    assert len(re.findall(r'^\s*emit\(\s*"', src, re.M)) == len(call_lines)
+
+
+def test_telemetry_never_changes_the_exit_code(monkeypatch, tmp_path):
+    """The invocation contract's hard promise, exercised through THIS caller."""
+    def boom(*a, **k):
+        raise RuntimeError("spool exploded")
+    monkeypatch.setattr(D, "emit", D.emit)          # keep the real wrapper
+    monkeypatch.setitem(sys.modules, "invocation",
+                        type("M", (), {"emit_invocation": staticmethod(boom)}))
+    d = tmp_path / "proj"
+    d.mkdir()
+    monkeypatch.setattr(D.sys, "stdin", _Stdin("clean"))
+    assert D.main(["preflight", "--dir", str(d)]) == D.RC_OK
+
+
+# --------------------------------------------------------------------------- #
+# 7. deployment: git-tracked + declared in home.nix
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("rel", [
+    "scripts/opencode/SKILL.md",
+    "scripts/opencode/opencode-dispatch",
+    "scripts/opencode/lib/oc_permissions.py",
+    "scripts/opencode/lib/brief_scan.py",
+    "scripts/opencode/tests/test_dispatch.py",
+])
+def test_every_new_file_is_git_tracked(rel):
+    """🔴 A new file that is not `git add`ed is silently omitted from the flake.
+    The switch SUCCEEDS and the file is simply not there."""
+    p = subprocess.run(["git", "-C", str(ROOT), "ls-files", "--error-unmatch", rel],
+                       capture_output=True, text=True)
+    assert p.returncode == 0, f"{rel} is not tracked — `git add` it"
+
+
+def test_home_nix_deploys_the_skill_as_an_out_of_store_symlink():
+    src = HOME_NIX.read_text()
+    for target in ('".claude/skills/opencode/SKILL.md"',
+                   '".claude/skills/opencode/opencode-dispatch"',
+                   '".local/bin/opencode-dispatch"'):
+        assert target in src, f"home.nix does not deploy {target}"
+    block = src[src.index('".claude/skills/opencode/SKILL.md"'):]
+    assert "mkOutOfStoreSymlink" in block[:400], (
+        "the executable must be an mkOutOfStoreSymlink like browser/dl-route, so "
+        "an edit applies without a home-manager switch"
+    )
+
+
+def test_the_skill_description_disambiguates_from_a_claude_subagent():
+    """🔴 MEASURED: 'dispatch a subagent to implement X' means the Agent tool;
+    'dispatch opencode …' means this. The only disambiguating token is literally
+    `opencode`, so bare "dispatch" must not route here."""
+    fm = SKILL_PATH.read_text().split("---")[1]
+    desc = re.search(r"^description:\s*(.+)$", fm, re.M).group(1)
+    assert desc.lower().count("opencode") >= 2
+    assert "subagent" in desc.lower()
+    # The listing budget is 1% of the window with a 1,536-char per-entry cap;
+    # on overflow Claude Code silently DROPS descriptions.
+    assert len(desc) <= 1536, len(desc)

--- a/scripts/opencode/tests/test_dispatch.py
+++ b/scripts/opencode/tests/test_dispatch.py
@@ -63,6 +63,30 @@ import brief_scan  # noqa: E402
 import oc_permissions  # noqa: E402
 
 
+# 🔴 A `/usr/…` path used as TEST DATA — an argument to a pure string predicate,
+# never an interpreter and never written to a file.
+#
+# It deliberately does NOT spell `/usr/bin/env`. `scripts/tests/
+# test_runtime_shebangs.py` scans every `test_*.py` for that literal and flagged
+# the earlier spelling here. Two routes were open and this is the chosen one:
+#
+#   * ALLOWLIST the hit — CLOSED by that file's own 🔴: "Nothing here may be
+#     `/usr/bin/env`". Taking it would mean changing the rule, not satisfying it,
+#     and its docstring names adding an entry to go green as the anti-pattern.
+#   * RESTRUCTURE — taken. The assertion never needed that specific string: it
+#     proves "an enumerated /usr prefix returns a reason", which ANY /usr path
+#     demonstrates. Narrowing my own fixture is strictly cheaper and lower-risk
+#     than widening a repo-wide gate.
+#
+# The scanner IS over-broad in the narrow sense that it cannot tell a path being
+# *mentioned* from one being *written as a shebang* — but making it able to
+# would mean parsing Python, which is the trap guard_core's DESIGN NOTE records
+# (three rounds of a regex "is this inert text?" helper, each with a fresh hole).
+# A fixed-string gate that fails closed for one retype is the better trade, and
+# it is the same stance guard_core takes about quoted commit messages.
+ALLOWLISTED_USR_PATH = "/usr/share/doc/example/readme"
+
+
 def _load_cli():
     """Import the extensionless executable as a module."""
     spec = importlib.util.spec_from_loader(
@@ -285,7 +309,7 @@ def test_the_system_allowlist_is_judged_lexically_not_by_realpath(tmp_path):
     d = tmp_path / "proj"
     d.mkdir()
     assert brief_scan.is_allowlisted("/etc/hosts") is None
-    assert brief_scan.is_allowlisted("/usr/bin/env") is not None
+    assert brief_scan.is_allowlisted(ALLOWLISTED_USR_PATH) is not None
     assert [o.text for o in brief_scan.scan_paths("edit /etc/hosts", d)] == \
         ["/etc/hosts"]
 
@@ -300,7 +324,8 @@ def test_scan_paths_accepts_the_in_dir_control(tmp_path):
 def test_scan_paths_ignores_the_enumerated_system_prefixes(tmp_path):
     d = tmp_path / "proj"
     d.mkdir()
-    assert brief_scan.scan_paths("pipe it to /dev/null with /usr/bin/env", d) == []
+    assert brief_scan.scan_paths(
+        f"pipe it to /dev/null and read {ALLOWLISTED_USR_PATH}", d) == []
 
 
 def test_tmp_is_deliberately_not_allowlisted(tmp_path):
@@ -754,19 +779,169 @@ def test_telemetry_never_changes_the_exit_code(monkeypatch, tmp_path):
 # --------------------------------------------------------------------------- #
 # 7. deployment: git-tracked + declared in home.nix
 # --------------------------------------------------------------------------- #
-@pytest.mark.parametrize("rel", [
+SHIPPED_FILES = [
     "scripts/opencode/SKILL.md",
     "scripts/opencode/opencode-dispatch",
     "scripts/opencode/lib/oc_permissions.py",
     "scripts/opencode/lib/brief_scan.py",
     "scripts/opencode/tests/test_dispatch.py",
-])
-def test_every_new_file_is_git_tracked(rel):
+]
+
+# 🔴 THE TWO TIERS RUN THIS FILE IN DIFFERENT TREES, AND ONLY ONE HAS A `.git`.
+# `nix build .#checks.x86_64-linux.pytests` builds from `/build/src`, a copy with
+# no git dir at all — so `git ls-files` exits **128** ("not a git repository"),
+# and an assertion that reads that as "not tracked" turns a required gate
+# permanently red on a message that is FALSE. Measured on the integration tree:
+# five failures, all reporting a tracking problem that did not exist.
+def git_dir_present(root: Path) -> bool:
+    """Which tier are we in? A FUNCTION of the tree, not a constant.
+
+    🔴 Written as a helper so both answers are reachable from either tier. As a
+    bare module-level `(ROOT / ".git").exists()` the obvious pin —
+    `assert GIT_DIR_PRESENT == (ROOT / ".git").exists()` — is a fixture that can
+    only ever produce the value the assertion names, so a mutant hardcoding it
+    to `True` passes on a dev host and the tier switch goes unpinned exactly
+    where it matters.
+
+    🔴 `.git` is a FILE, not a directory, inside a git worktree (it holds
+    `gitdir: …`), and this repo is developed in worktrees. Hence `.exists()`
+    rather than `.is_dir()`: the latter would report "no git" in every worktree
+    and silently disable the tracking half on the tier that has it.
+    """
+    return (root / ".git").exists()
+
+
+# 🔴 There is deliberately NO `GIT_DIR_PRESENT = git_dir_present(ROOT)` module
+# constant. One existed and a mutation sweep hardcoded it to `True`, which
+# SURVIVED — on a dev host the probe returns True anyway, so any assertion about
+# its value is a fixture that can only produce the constant it names. Removing
+# the constant removes the thing that can be hardcoded; every caller computes
+# the tier from the tree it is actually looking at.
+#
+# The use-site wiring is verified by running this whole file in a `.git`-free
+# copy of the tree (the sandbox tier reproduced faithfully) — no unit test on a
+# dev host can distinguish a correct flag from a hardcoded `True`, because both
+# tiers agree there whenever the files really are tracked.
+
+
+def file_ship_problems(rel: str, root: Path, git_present: bool) -> list[str]:
+    """Reasons `rel` would be silently absent from the flake. Empty == fine.
+
+    🔴 TWO INDEPENDENT CHECKS, because neither alone covers both tiers, and the
+    git one is made CONDITIONAL rather than skipped outright so it cannot go
+    quietly vacuous on the tier that does have a git dir:
+
+      * EXISTENCE is what means something INSIDE the nix sandbox. The store copy
+        is built from tracked files only, so an untracked file would simply not
+        be there — which this check sees, and `git` could not.
+      * TRACKEDNESS is what means something on a DEV HOST, where the file exists
+        on disk whether or not git has ever heard of it. That is the actual
+        hazard: the switch succeeds and the file is not deployed.
+
+    `git_present` is a PARAMETER rather than a module-level read so both branches
+    are exercisable from either tier — see the three control tests below.
+    """
+    problems = []
+    if not (root / rel).is_file():
+        problems.append(f"{rel} is missing from this tree")
+        return problems          # trackedness of an absent file is not a claim
+    if not git_present:
+        return problems          # nix sandbox tier: no .git, nothing more to check
+    p = subprocess.run(["git", "-C", str(root), "ls-files", "--error-unmatch", rel],
+                       capture_output=True, text=True)
+    if p.returncode != 0:
+        problems.append(f"{rel} is not git-tracked — `git add` it")
+    return problems
+
+
+@pytest.mark.parametrize("rel", SHIPPED_FILES)
+def test_every_new_file_ships(rel):
     """🔴 A new file that is not `git add`ed is silently omitted from the flake.
     The switch SUCCEEDS and the file is simply not there."""
-    p = subprocess.run(["git", "-C", str(ROOT), "ls-files", "--error-unmatch", rel],
-                       capture_output=True, text=True)
-    assert p.returncode == 0, f"{rel} is not tracked — `git add` it"
+    assert file_ship_problems(rel, ROOT, git_dir_present(ROOT)) == []
+
+
+def test_the_tier_probe_answers_BOTH_ways_from_either_tier(tmp_path):
+    """🔴 The pin on the tier switch, built so it cannot agree with itself.
+
+    Both fixtures are constructed here, so this runs identically in the nix
+    sandbox and on a dev host, and a mutant hardcoding the probe to either
+    constant dies in one of the two arms.
+    """
+    (tmp_path / "with").mkdir()
+    (tmp_path / "with" / ".git").write_text("gitdir: /elsewhere\n")   # worktree shape
+    (tmp_path / "without").mkdir()
+    assert git_dir_present(tmp_path / "with") is True
+    assert git_dir_present(tmp_path / "without") is False
+
+
+# --- the three controls on the tier guard ---------------------------------- #
+# 🔴 These build their own fixtures, so they run identically in BOTH tiers —
+# which is the point: a guard that can only be exercised on a dev host is a
+# guard nobody re-checks after the sandbox breaks it.
+def test_a_missing_file_is_reported_in_either_tier(tmp_path):
+    """Positive control. Without this, every `== []` above is indistinguishable
+    from a helper wired to nothing."""
+    assert file_ship_problems("nope.md", tmp_path, False) == \
+        ["nope.md is missing from this tree"]
+    assert file_ship_problems("nope.md", tmp_path, True) == \
+        ["nope.md is missing from this tree"]
+
+
+def test_a_DIRECTORY_at_the_path_is_not_a_shipped_file(tmp_path):
+    """🔴 Found by a SURVIVING mutant: weakening `is_file()` to `exists()` passed
+    the whole suite, because nothing ever put a non-file at a shipped path.
+
+    The claim these entries make is "this FILE ships". A directory standing where
+    `SKILL.md` should be satisfies `exists()` and would be reported clean while
+    the deploy has no skill — the same silent-absence failure, one level in.
+    """
+    (tmp_path / "SKILL.md").mkdir()
+    assert file_ship_problems("SKILL.md", tmp_path, False) == \
+        ["SKILL.md is missing from this tree"]
+
+
+def test_an_untracked_file_is_reported_when_git_is_present(tmp_path):
+    """The check the sandbox CANNOT make, made here against a real git repo.
+
+    This is what proves the dev-host tier still catches the real hazard — the
+    thing the `.git` guard must not have thrown away.
+    """
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True,
+                   capture_output=True)
+    (tmp_path / "tracked.md").write_text("x")
+    (tmp_path / "untracked.md").write_text("x")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "tracked.md"], check=True,
+                   capture_output=True)
+    assert file_ship_problems("tracked.md", tmp_path, True) == []
+    assert file_ship_problems("untracked.md", tmp_path, True) == \
+        ["untracked.md is not git-tracked — `git add` it"]
+
+
+def test_a_present_file_in_a_git_free_tree_reports_NOTHING(tmp_path):
+    """🔴 THE REGRESSION CASE, and it fails in an ORDINARY checkout if the
+    `.git` guard is ever deleted.
+
+    It reproduces the sandbox tier exactly — a real file in a tree with no git
+    dir — so `git ls-files` would exit 128 here just as it does at `/build/src`.
+    With the guard: no problems. Without it: `128 != 0`, and the suite goes red
+    on a dev host instead of only in CI, which is where this defect hid.
+    """
+    (tmp_path / "shipped.md").write_text("x")
+    assert not (tmp_path / ".git").exists()
+    assert file_ship_problems("shipped.md", tmp_path, False) == []
+
+
+def test_the_tier_guard_short_circuits_before_invoking_git(tmp_path, monkeypatch):
+    """…and it must not merely SWALLOW git's failure — it must not call git at
+    all. A helper that ran git and ignored rc 128 would pass the test above
+    while still paying for, and depending on, a binary the sandbox may not have.
+    """
+    def explode(*a, **k):
+        raise AssertionError("git was invoked despite git_present=False")
+    monkeypatch.setattr(subprocess, "run", explode)
+    (tmp_path / "shipped.md").write_text("x")
+    assert file_ship_problems("shipped.md", tmp_path, False) == []
 
 
 def test_home_nix_deploys_the_skill_as_an_out_of_store_symlink():

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1204,7 +1204,23 @@ TARGET_FLOORS=(
   "scripts/claude-hooks/tests/test_on_disk_artifact_names.py|12"
   # 2026-08-14, writer 2 (opencode) arrives as a NEW target: 15 collected.
   #   _suggested_floor 15 = 15 - min(50, max(1, 15/20 = 0 -> 1)) = 14.
-  "scripts/opencode/tests|14"
+  #
+  # 2026-08-20, the opencode-dispatch skill (#583) lands in this target:
+  # 15 -> 90 collected. +75 for scripts/opencode/tests/test_dispatch.py, which is
+  # a NEW FILE in an existing directory target — so HERMETIC_TARGETS needs no
+  # entry and this line is the only evidence the gate runs it at all. ZERO new
+  # skips, so EXPECTED_SKIPS is untouched.
+  #
+  # 🔴 COPIED FROM THE AUTHORITATIVE GATE'S OWN DRIFT MESSAGE on the MERGED
+  # integration tree (main + #578 + #580 + #583 + #584), not computed here and
+  # not derived from this branch alone — this line is a churn magnet, `rerere`
+  # has replayed a stale resolution onto its neighbours before, and arithmetic
+  # across two sides of a conflict is what gave the old global literal eleven
+  # values in one day:
+  #   run-tests: ERROR — scripts/opencode/tests collected 90 tests but its floor
+  #   is only 14. Raise the TARGET_FLOORS entry to "scripts/opencode/tests|86"
+  # (which is `_suggested_floor 90` = 90 - min(50, max(1, 90/20 = 4)) = 86.)
+  "scripts/opencode/tests|86"
 )
 
 # The allowance rule, in one place, used by BOTH the drift message and anyone

--- a/scripts/session-analysis/adoption-scan.py
+++ b/scripts/session-analysis/adoption-scan.py
@@ -144,6 +144,15 @@ REGISTRY = [
         "outcomes": [], "impact_outcomes": [], "impact_label": "",
     },
     {
+        "id": "opencode-dispatch",
+        "label": "opencode-dispatch — preflighted, detached opencode dispatch",
+        "via": "tool", "tool": "opencode-dispatch", "opt_in": True,
+        "outcomes": ["dispatched", "preflight-ok", "preflight-blocked", "error"],
+        "impact_outcomes": ["preflight-blocked"],
+        "impact_label": ("silent no-op dispatches prevented (brief named a path "
+                         "outside --dir; `opencode run` auto-rejects and exits 0)"),
+    },
+    {
         "id": "browser-bridge",
         "label": "browser — drive live Brave",
         "via": "source", "source": "browser-bridge", "kind": "cmd",

--- a/scripts/tests/test_opencode_config.py
+++ b/scripts/tests/test_opencode_config.py
@@ -138,56 +138,32 @@ def generated_agents_md() -> str:
     )
 
 
-def strip_jsonc(text: str) -> str:
-    """Strip `//` and `/* */` comments, leaving string literals untouched.
-
-    Hand-rolled rather than regex because opencode.jsonc contains `https://`
-    inside a string — a naive `//`-to-end-of-line regex would eat the rest of
-    the `$schema` line and the file would not parse. Validated by
-    test_strip_jsonc_preserves_urls_in_strings below.
-    """
-    out = []
-    i, n = 0, len(text)
-    in_str = False
-    while i < n:
-        c = text[i]
-        if in_str:
-            out.append(c)
-            if c == "\\" and i + 1 < n:
-                out.append(text[i + 1])
-                i += 2
-                continue
-            if c == '"':
-                in_str = False
-            i += 1
-            continue
-        if c == '"':
-            in_str = True
-            out.append(c)
-            i += 1
-            continue
-        if c == "/" and i + 1 < n and text[i + 1] == "/":
-            while i < n and text[i] != "\n":
-                i += 1
-            continue
-        if c == "/" and i + 1 < n and text[i + 1] == "*":
-            i += 2
-            while i + 1 < n and not (text[i] == "*" and text[i + 1] == "/"):
-                i += 1
-            i += 2
-            continue
-        out.append(c)
-        i += 1
-    return "".join(out)
+# 🔴 `strip_jsonc`, `load_config`, `wildcard_match` and the resolution loop
+# USED to be defined in this file. They now live in
+# `scripts/opencode/lib/oc_permissions.py` and are imported, because
+# `opencode-dispatch preflight` needs the same predicate to answer "would this
+# command in the brief resolve to `ask`, i.e. be AUTO-REJECTED mid-run?" — and
+# RULES.md 🔴 "One rule, one place" says a second copy of a resolver is a
+# predicate that will disagree eventually and silently. The names below are
+# re-exported unchanged so every assertion in this file still reads the same.
+sys.path.insert(0, str(OC_DIR / "lib"))
+from oc_permissions import (  # noqa: E402
+    base_bash_rules,
+    load_config as _load_config,
+    resolve as _resolve_over,
+    strip_jsonc,
+    wildcard_match,
+)
 
 
 def load_config() -> dict:
     """Parse scripts/opencode/opencode.jsonc, PRESERVING key order.
 
-    json.loads yields a dict, and dicts preserve insertion order — which is what
-    makes the resolver model below possible at all.
+    Thin wrapper over the shared loader so this file's ~30 call sites keep their
+    zero-argument spelling. Deliberately UNCACHED and MUTABLE — see the loader's
+    docstring for the caller that mutates the result in place.
     """
-    return json.loads(strip_jsonc((OC_DIR / "opencode.jsonc").read_text()))
+    return _load_config(OC_DIR / "opencode.jsonc")
 
 
 def parse_frontmatter(text: str):
@@ -225,26 +201,12 @@ def agent_permission(name: str) -> dict:
 #
 # Faithful port of opencode 1.18.18's `Wildcard.match` + the `findLast` resolver.
 # See the module docstring for the verbatim source it was ported from and for
-# how it was validated against the real engine.
+# how it was validated against the real engine. THE PORT ITSELF now lives in
+# scripts/opencode/lib/oc_permissions.py (imported above) so that
+# `opencode-dispatch preflight` resolves commands through the SAME code these
+# ~500 assertions pin. Everything below composes on top of it and is genuinely
+# test-only: the agent-frontmatter ruleset and the deletion mutants.
 # --------------------------------------------------------------------------- #
-_GLOB_ESCAPE = re.compile(r"[.+^${}()|\[\]\\]")
-
-
-@functools.lru_cache(maxsize=None)
-def wildcard_match(text: str, pattern: str) -> bool:
-    # Memoised: pure function of (text, pattern), and the ledgers below resolve
-    # ~50 rules x ~115 commands x ~65 patterns per pass, once per detector
-    # control. Without this the file took 46 s; with it, ~5 s.
-    t = text.replace("\\", "/")
-    p = _GLOB_ESCAPE.sub(lambda m: "\\" + m.group(0), pattern.replace("\\", "/"))
-    p = p.replace("*", ".*").replace("?", ".")
-    # opencode special case: a pattern ending in " *" also matches without it,
-    # so `rg *` matches a bare `rg`.
-    if p.endswith(" .*"):
-        p = p[:-3] + "( .*)?"
-    return re.match("^" + p + "$", t, re.S) is not None
-
-
 @functools.lru_cache(maxsize=None)
 def bash_ruleset(agent: str | None = None) -> tuple:
     """The ORDERED (pattern, action) list opencode resolves a bash command against.
@@ -263,8 +225,9 @@ def bash_ruleset(agent: str | None = None) -> tuple:
         `add_trailing_git_allow`). `load_config()` is deliberately left UNCACHED
         for exactly that caller.
     """
-    rules = [("*", "allow")]  # built-in catch-all
-    rules += list(load_config()["permission"]["bash"].items())
+    # The built-in catch-all + the global config block come from the shared
+    # library, so preflight and this suite cannot drift on the base ruleset.
+    rules = list(base_bash_rules(load_config()))
     if agent:
         perm = agent_permission(agent).get("bash")
         if isinstance(perm, str):
@@ -274,21 +237,15 @@ def bash_ruleset(agent: str | None = None) -> tuple:
     return tuple(rules)
 
 
-def _resolve_over(rules, command: str) -> str:
-    """LAST match wins, over an EXPLICIT ordered ruleset.
-
-    🔴 THE ONLY implementation of the resolution loop in this file. It briefly
-    had two — `_ask_ledger` carried a private copy so it could run against a
-    synthetic ruleset — and two copies with nothing pinning them together is a
-    predicate that will disagree eventually and silently. They agreed on all 51
-    ask rules at the time, which is exactly how a duplicate survives review.
-    Everything that resolves a command goes through here.
-    """
-    action = "ask"  # opencode's fallback when nothing matches
-    for pattern, act in rules:
-        if wildcard_match(command, pattern):
-            action = act
-    return action
+# `_resolve_over` is `oc_permissions.resolve`, imported above.
+#
+# 🔴 THE ONLY implementation of the resolution loop in this repo. It briefly had
+# two inside THIS FILE — `_ask_ledger` carried a private copy so it could run
+# against a synthetic ruleset — and two copies with nothing pinning them
+# together is a predicate that will disagree eventually and silently. They
+# agreed on all 51 ask rules at the time, which is exactly how a duplicate
+# survives review. When `opencode-dispatch preflight` needed the same predicate,
+# the loop moved to the library rather than being copied a third time.
 
 
 def _rules_without(rules, drop: str):


### PR DESCRIPTION
Stage 1 of an opencode dispatch skill: **`preflight`**, **`run`**, and the SKILL body. Designed from 36 real dispatches over 17 days (5,226 transcript files / 294,686 Bash calls), not from the CLI's help text.

---

## The literal `description`, clause by clause

```
Dispatch a task to opencode — the separate headless CLI agent — instead of burning
this session's context on it. Preflights the brief first (a brief naming paths
outside --dir makes `opencode run` auto-reject and exit 0 having done nothing),
then launches detached. Use for "dispatch opencode", "call opencode", "run this
with opencode", "hand it to flash/mimo/pro", opencode token efficiency. NOT the
Agent tool — "dispatch a subagent" means that, not this.
```

**452 characters**, against a per-entry cap of 1,536 and a listing budget of 1% of the window. On overflow Claude Code silently drops descriptions starting with the least-invoked skills, so every clause has to earn its bytes:

| clause | measured justification |
|---|---|
| "Dispatch a task to **opencode**" | `dispatch` ×18 and `call opencode` ×8 in n=25 real utterances. The literal token `opencode` is the *only* disambiguator, so it leads. |
| "the separate headless CLI agent" | Tells the router what it is without a second lookup, and is the phrase that makes "headless"/"CLI agent" phrasings land. |
| "instead of burning this session's context on it" | **"token efficiency" ×3.** The stated motive is his own context budget, not money — seven weeks of opencode cost **$11.42** total, median dispatch **$0.014**. Framing it as cost would route on the wrong intent. |
| "Preflights the brief first (… auto-reject and exit 0 having done nothing)" | This is the *reason to use the skill instead of typing `opencode run`*. Without it the skill is a synonym for the raw command and will not be reached for. |
| "then launches detached" | 22 of 31 measurable dispatches already ran in Claude's background; the 9 foreground ones all hand-set long timeouts. States the behaviour so nobody re-derives the backgrounding. |
| `"dispatch opencode"`, `"call opencode"`, `"run this with opencode"` | Verbatim utterances. |
| "hand it to **flash/mimo/pro**" | *names a model* ×10. The alias words are the trigger tokens. |
| "**opencode** token efficiency" | The one phrasing where the motive is said out loud; kept adjacent to `opencode` so it cannot route a bare "token efficiency". |
| "NOT the Agent tool — 'dispatch a subagent' means that, not this." | 🔴 **The required disambiguation.** Measured: *"dispatch a subagent to implement X"* means the **Agent tool**; *"dispatch opencode …"* means this. Bare "dispatch" must not route here. Pinned by `test_the_skill_description_disambiguates_from_a_claude_subagent`. |

Deliberately **absent**: any mention of `browser`. *mentions `browser` ×14* is the sibling `browser agent` dispatch — a different tool — and putting the word here would steal 14 utterances from the skill that owns them.

Narrative (the four failure modes, brief-writing guidance, what to do when preflight refuses) is in the **body**, which costs zero until invoked.

---

## Built vs deferred

### Built

- **`opencode-dispatch preflight --dir D [--brief F|-] [--json]`** — checks a brief, never dispatches.
- **`opencode-dispatch run --dir D [--brief F|-] [--title T] [-m flash|mimo|pro|<id>] [--auto] [-c] [--file F]…`**
- **`scripts/opencode/SKILL.md`** — the body.
- **`scripts/opencode/lib/{oc_permissions,brief_scan}.py`** — the shared resolver and the two scanners.

**Canonical argv order, pinned by index**: `opencode run <MESSAGE> --dir D [--title] [-m] [--auto] [-c] [--file …]`. `MESSAGE_ARGV_INDEX = 2` is a named constant and the test asserts `argv.index(message) == 2` and `index(message) < index("--file")`.

**Failure 1 closed structurally, not merely checked.** The brief is written **into `--dir`** at `.opencode-dispatch/<ts>-<slug>.md`; the tool also drops a self-ignoring `.gitignore` (`*`) into that subdir so it is unstageable in *any* target repo, and `.gitignore` here covers devrc itself. Nothing is ever written to Claude's scratchpad. On top of that, preflight scans the brief for absolute paths and **refuses with rc 3**, naming each offender and its resolved form.

**Path containment is exact, with an explicit enumeration rather than a heuristic.** `SYSTEM_ALLOW` lists ten read-only system prefixes (`/nix/store`, `/usr`, `/dev`, `/proc`, …), each with its reason in the source, not env-overridable, unknown-is-an-offender-by-default — the same shape as drift-check's `settings.json` key allowlist. 🔴 **`/tmp` is deliberately absent**: Claude's scratchpad lives there and "the brief lived in the scratchpad" is failure 1's exact vector. `/etc` and `/var` are absent too, since `/etc/nixos` is a real edit target here.

**Failure 3 warns and never blocks**, per the brief. It resolves each command node against `permission.bash` and prints the glob (`[ask] (rule '*kubectl*exec*')  kubectl -n data exec …`). It also surfaces anything `guard_core`'s `opencode` policy would hard-deny.

**Never in the foreground, no escape hatch.** `subprocess.Popen(..., start_new_session=True, stdin=DEVNULL)`, stdout+stderr to a log inside `--dir`, returns immediately. `test_the_parser_offers_no_foreground_escape_hatch` asserts the parser has no `--foreground`/`--fg`/`--wait`/`--sync`/`--blocking`.

**Model aliases**: `flash`/`mimo`/`pro` only. No alias → the `-m` flag is **omitted entirely** so the config default applies (18 of 24 measured dispatches). A full `provider/vendor/model` id passes through; an unknown bare word is a usage error, never a silent pass-through.

### Deferred, with the reason

- **`status` / `watch`** — they depend on opencode's internal SQLite schema, which carries no stability guarantee. Worth taking only once this skill is proven to get used. The dispatch prints a log path instead.
- **Result capture, auto-retry, a model router** — each considered and rejected on measured grounds. Retries in particular are *corrective, not transient*: re-running a known-bad brief is not a fix.

---

## 🔴 One rule, one place: the resolver moved

`scripts/tests/test_opencode_config.py` already carried a faithful, engine-validated port of opencode 1.18.18's `Wildcard.match` + `findLast` resolver. Preflight needs exactly that predicate. Rather than copy it, the port moved to **`scripts/opencode/lib/oc_permissions.py`** and both callers import it. Command *splitting* likewise reuses **`guard_core.split_commands`** — no second splitter.

The seam is pinned by **object identity**, not by an agreement matrix:

```python
assert cfg.wildcard_match is oc_permissions.wildcard_match
assert cfg._resolve_over is oc_permissions.resolve
```

`test_opencode_config.py`'s **628 assertions are unchanged and green** after the move.

---

## Red-at-base matrix

There is no pre-change code for a brand-new tool, so the honest matrix has two halves.

**Half 1 — the suite cannot be green without the implementation.** The new test file was run against the base tree (`210de3d`, produced with `git archive` into a plain directory — no `.git`, nothing that can touch a ref):

```
CLI present at base?  : NO
lib present at base?  : NO
registry row at base? : 0
→ ModuleNotFoundError: No module named 'brief_scan'
   1 error in 0.12s   (collection error — 0 tests could pass)
```

**Half 2 — per-test red, via mutation.** A collection error is a coarse red; the fine-grained evidence is the mutation matrix below, where every guard was watched to fail against a specific defect with a named killer.

**Plus one genuine reproduction of an original symptom.** Failure 2 was reproduced verbatim on the live `opencode 1.18.18` binary:

```
$ opencode run --dir <d> --file <brief> "Execute the task described in the attached brief."
Error: File not found: Execute the task described in the attached brief.
rc=1
```

…and the canonical order was verified end to end: `opencode-dispatch run --dir <d> --title "dispatch smoke" -m flash` dispatched, `deepseek/deepseek-v4-flash` ran, `hello.txt` was created with the expected contents, the process detached and the log captured the transcript.

---

## Mutation results

**18 mutants, 18 killed. `PYTHONDONTWRITEBYTECODE=1`, `__pycache__` purged between mutants, no `-x`,** each anchor asserted to occur exactly once before being applied, and all three source files `cmp`-verified byte-identical to their backups at the end.

| mutant (narrowest expression) | killers |
|---|---|
| `MPC` positive control: `run` verb → `RUNX` | **1** |
| `M1` `is_under` loses the `os.sep` boundary | **1** `test_is_under_does_not_treat_a_sibling_prefix_as_a_child` |
| `M2` `is_under` → `True` | 6 |
| `M3` `is_under` → `False` | 4 |
| `M4` `scan_paths` drops the containment skip | 3 |
| `M5` `scan_paths` drops the allowlist skip | **1** |
| `M6` `extract_paths` drops the URL strip | 3 |
| `M7` path regex loses the prose lookbehind | 4 |
| `M8` `/tmp` quietly added to `SYSTEM_ALLOW` | 3 |
| `M9` resolver → first-match-wins | 2 |
| `M10` message moved after `--dir` | 2 |
| `M11` message appended last | 3 |
| `M12` `start_new_session=False` | **1** |
| `M13` brief written outside `--dir` | 2 |
| `M14` subdir `.gitignore` not written | **1** |
| `M15` unknown alias passes through | **1** |
| `M16` `run` dispatches despite a blocked preflight | **1** |
| `M17` `-m` flag suppressed | 2 |

**`-k` filter validated**: an alternation of all 18 distinct killer names selects exactly **21 items** (18 names, one of which is parametrised ×3) — so no killer is unreachable by the filter.

### 🔴 The battery found two real defects, both fixed in this PR

1. **`M6` SURVIVED on the first run.** The URL strip in `extract_paths` looked redundant — the regex lookbehind already rejects `https://host/a/b`, since every `/` there is preceded by an excluded character. Probing found the case where it *is* load-bearing: a path in a **query or fragment** is preceded by `=` or `#`, which are not in the excluded class, so `https://example.invalid/a?f=/etc/passwd` yields `/etc/passwd` without the strip. A brief that merely *links to documentation* would have been refused. Now covered by `test_the_url_strip_is_load_bearing_for_query_and_fragment_paths`, parametrised ×3, each carrying its own positive control (the raw regex match it *can* see), which is what kills M6.

2. **The outcome ledger was blind to a computed argument.** `emit("preflight-blocked" if blocked else "preflight-ok", …)` scored as one outcome; the second was never seen by the grep. The call sites are now two literals, `OUTCOMES` is a named constant, and `test_no_call_site_passes_a_computed_outcome` pins the shape the ledger can read — including a check that the ledger's own regex sees *every* statement-position `emit(` call.

A third, smaller one: my own `assert "re.split" not in src` guard was **spelled, not structural** — it matched `guard_co(re.split)_commands` and failed on correct code. Now `"re.split("`.

---

## How adoption will be measured

New `adoption-scan` REGISTRY row:

```python
{
    "id": "opencode-dispatch",
    "label": "opencode-dispatch — preflighted, detached opencode dispatch",
    "via": "tool", "tool": "opencode-dispatch", "opt_in": True,
    "outcomes": ["dispatched", "preflight-ok", "preflight-blocked", "error"],
    "impact_outcomes": ["preflight-blocked"],
    "impact_label": "silent no-op dispatches prevented (brief named a path outside --dir; `opencode run` auto-rejects and exits 0)",
}
```

Emitted through `scripts/collector/invocation.py::emit_invocation` — best-effort, swallows every failure, never changes the caller's exit code (exercised by `test_telemetry_never_changes_the_exit_code`, which makes the spool raise and asserts rc is unmoved).

`opt_in=True` because it is: nothing forces the operator to route through this instead of typing `opencode run`. The **impact** signal is `preflight-blocked` — every one of those is a dispatch that would have exited 0 having done nothing.

The ledger is pinned **three ways**: the literals at the `emit(` call sites, `OUTCOMES`, and the registry row must all be the same set, both directions.

---

## Verification I ran

- `scripts/tests/test_opencode_config.py` — **628 passed** after the resolver move.
- Targeted rebased run over every plausibly-affected target — **4,537 passed, exit 0**: `test_opencode_{config,engine,guard_plugin}`, `test_doc_path_rot`, `test_no_captured_{text,markup}`, `test_no_{public_ips,client_hostnames}`, `test_rules_size`, `test_skills_mapping_guard`, `test_subsystem_{recall,touch}`, `test_prune_skill_size`, `test_skill_audit`, `scripts/opencode/tests`, `scripts/session-analysis/tests`, `scripts/collector/tests`, `test_guard_core`.
- `nix-instantiate --parse nix/home.nix` — OK.
- Live end-to-end dispatch + live reproduction of the failure-2 error (above).
- All five new files confirmed `git ls-files`-tracked by a test, because 🔴 an unstaged new file is silently omitted from the flake and the switch still succeeds.

## What I could NOT verify

- **Failure 1 was not reproduced live.** I did not drive opencode into an actual `external_directory` auto-reject; the block is built from the recorded measurement (10 of 321 sessions with `model IS NULL` and 0 tokens) plus the config's own documented `ask` semantics. What *is* verified live is that preflight refuses the shape with rc 3 and names the path.
- **Failure 3's mid-run auto-reject was not reproduced live** either — same reason. The glob resolution itself goes through the engine-validated resolver, and the warning is advisory.
- **Not deployed.** `home.file` targets only change on a `home-manager switch`, so nothing is live on either host yet. Merged ≠ deployed. The `mkOutOfStoreSymlink` means that after one switch, later edits to the CLI or SKILL.md apply with no further switch.
- **I did not run the full hermetic gate** (instructed not to; the box was at load average 25 with siblings running). The targeted set above is what I can vouch for. I make no claim about the ~3,900-test `scripts/tests` target as a whole.
- **The `--file` array behaviour was verified on 1.18.18 only**, the version installed here.

## Sibling-agent interactions (flagged, not coordinated)

- **`scripts/tests/test_opencode_config.py`** is edited here (the resolver extraction: two function bodies removed, an import added). An agent working on **AGENTS.md size** is likely to touch that same file's §1 / `test_generated_agents_md_size_is_sane`, which is a different region — a textual conflict is unlikely and a semantic one is nil, but it is the file to watch.
- **`scripts/collector/opencode/activity-plugin.js` was NOT touched**, per the standing instruction — the **opencode session attribution** agent owns it.
- This branch was **rebased onto `210de3d`**, which is a sibling's `#581` fixing a `test_prune_skill_size` figure. That test was red at my original base (`4740e40`) for reasons unrelated to this change; it is green after the rebase.
- `scripts/opencode/opencode.jsonc` is **read**, never written, so the config-tuning surface is untouched.

## Open questions for you

- **No override flag on the path block.** A brief that legitimately spans two repos has to widen `--dir` or inline the content; there is no `--allow-path`. That is deliberate (an escape hatch on the one exact check turns it into the advisory check), but it is the decision most likely to annoy in practice. Say the word and I will add one.
- The skill is deployed to **Claude Code only**, not to `~/.config/opencode/skills/` — opencode dispatching opencode seemed like the wrong default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
