### PR TITLE
fix(writeback-guard): a card whose dispatched AGENT is alive is not this session's to write back

### DIFF
--- a/scripts/claude-hooks/clawgate-writeback-guard.py
+++ b/scripts/claude-hooks/clawgate-writeback-guard.py
@@ -337,6 +337,14 @@ WHAT THIS STRUCTURALLY CANNOT SEE (say it here, not in a report nobody re-reads)
     nothing distinguishes them (see SCOPE OF THE WORK FLAG above);
   * the `in_progress` flip, which it does not require: it gates the WRITE-BACK, which
     is the thing that was measured missing;
+  * 🔴 A CARD WHOSE DISPATCHED AGENT IS STILL ALIVE — deliberately, see
+    LIVE_AGENT_STATUSES. The write-back is owed by that agent; nagging the dispatching
+    session asks it to pre-empt a close-out that has not happened yet. Scoped to
+    pending/provisioning/running ONLY, so an agent that DIED without writing back is
+    still reported, and the card leaves the window by itself when the agent's close-out
+    sets `ready_for_review`. The residual blind spot is narrow and real: an agent that
+    is alive but has silently given up looks the same as one still working, and this
+    hook cannot tell them apart — the devpod reaper is what bounds that, not this;
   * 🔴 ANY LATER WORK ON A TASK THIS SESSION HAS DISMISSED. The tombstone is ABSOLUTE
     for the session: dismiss task N, then genuinely pick N up and work on it in the
     SAME session, and this guard stays silent for N until the session ends. That is a
@@ -415,6 +423,25 @@ AGENT_AUTHOR = "claude-code"
 # A card in either of these is already handed over — someone closed it, and nagging
 # about a missing comment on a card that is out for review is noise.
 CLOSED_STATUSES = ("ready_for_review", "complete")
+
+# 🔴 A card with a LIVE DISPATCHED AGENT owes its write-back to that AGENT, not to this
+# session. Dispatching is what clawgate is FOR, so this fired on every session that
+# dispatched — and its prescribed remedy (comment as `claude-code`, flip to
+# `ready_for_review`) is the WRONG action there: it pre-empts the agent's own close-out
+# and fires a push to the operator. Measured 2026-08-20 on tasks 241/294 while agents
+# `bright-fox`/`brave-finch` were still running; in that session the guard would have
+# manufactured the very signal the run was measuring.
+#
+# 🔴 ALIVE ONLY, and that is the whole safety argument. `stopped` and `error` are
+# DELIBERATELY absent: an agent that died without writing back is exactly the #193/#194
+# case this guard exists for, and suppressing those would reintroduce it. The card also
+# leaves this window on its own — the agent's close-out sets `ready_for_review`, which
+# CLOSED_STATUSES already absorbs — so `delegated` cannot become a permanent silence.
+#
+# The vocabulary is the CLOSED SET read from the server, not a guess:
+# `containers/clawgate/internal/agents/store.go:14-19` defines exactly
+# pending/provisioning/running/stopped/error.
+LIVE_AGENT_STATUSES = frozenset(("pending", "provisioning", "running"))
 
 # Per session, per task id. See the ladder in the module docstring; both are read
 # out of the CLI bundle's own cap of 8, which this is deliberately stricter than.
@@ -1157,9 +1184,30 @@ def live_task(task_id, timeout=PER_TASK_TIMEOUT_SECS, env_path=CLAWGATE_ENV):
         raise LiveReadError("%s: %s" % (type(e).__name__, e))
 
 
+def has_live_agent(task):
+    """True when a dispatched agent is still alive on this card, so the write-back is
+    OWED BY THAT AGENT and not by this session.
+
+    Costs nothing extra: `agent` already rides along in the `/api/tasks/{id}` payload
+    `live_task` fetches, so this reads a field that was paid for either way.
+
+    Anything that is not a dict with a live status is False — a card with no agent
+    (`"agent": null`, the common case), a payload shape this hook does not recognise,
+    or a dead one. False is the LOUD direction: it leaves the verdict at "missing".
+    """
+    agent = task.get("agent") if isinstance(task, dict) else None
+    if not isinstance(agent, dict):
+        return False
+    return agent.get("status") in LIVE_AGENT_STATUSES
+
+
 def writeback_state(task, first_read_ts, skew=CLOCK_SKEW_ALLOWANCE_SECS,
                     work_ts=None):
-    """"closed" | "written" | "missing" | "unknown" for one live task payload.
+    """"closed" | "written" | "delegated" | "missing" | "unknown" for one live task.
+
+    🔴 "delegated" is checked LAST, after the comment scan — never before it. A card
+    can have both a live agent AND a real write-back, and that is "written"; ordering
+    the agent check first would relabel a satisfied card and lose that distinction.
 
     🔴 THE CUTOFF IS THE LATER OF THE FIRST READ AND THE LAST WORK EVENT. Anchoring on
     the read alone is what let the skill's own pre-start "Starting" comment — posted
@@ -1198,6 +1246,8 @@ def writeback_state(task, first_read_ts, skew=CLOCK_SKEW_ALLOWANCE_SECS,
         ts = parse_ts(c.get("createdAt"))
         if ts is None or ts >= cutoff:
             return "written"
+    if has_live_agent(task):
+        return "delegated"
     return "missing"
 
 
@@ -1417,7 +1467,10 @@ def stop_decision(data, reader=None, budget=STOP_BUDGET_SECS,
             state, err = "unknown", e
         except Exception as e:            # noqa: BLE001 — a reader that raises anything
             state, err = "unknown", e
-        if state in ("closed", "written"):
+        # "delegated" rides with closed/written: silent, and it spends NO counter.
+        # Burning a fire here would let a long agent run climb the ladder and then
+        # block on a genuinely missing write-back with its budget already gone.
+        if state in ("closed", "written", "delegated"):
             continue
         if state == "unknown":
             # 🔴 NEVER blocks, and spends its OWN counter. Cannot-measure is reported,

--- a/scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
+++ b/scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
@@ -163,9 +163,22 @@ def seed(task_id=193, ts=READ_TS, work=True, work_ts=WORK_EPOCH, session=SESSION
     return sd
 
 
-def task(status="open", comments=(), task_id=193):
+def task(status="open", comments=(), task_id=193, agent=None):
     return {"id": task_id, "status": status, "title": "t", "body": "b",
-            "comments": list(comments)}
+            "comments": list(comments), "agent": agent}
+
+
+def agent_obj(status="running", name="bright-fox"):
+    """A dispatched-agent object shaped like the one `/api/tasks/{id}` really returns.
+
+    🔴 The name is NOT "test-agent": it is a real name from the 2026-08-20 run this
+    case was found in, and the surrounding fields are the ones the live payload
+    carries, so a shape change at the far end shows up here rather than passing on a
+    fixture invented to fit the assertion.
+    """
+    return {"id": 59, "name": name, "namespace": "devpod-" + name,
+            "status": status, "noteId": 193, "repo": "civitai/civitai",
+            "kickedOff": False, "errorMessage": ""}
 
 
 def comment(author="claude-code", created="2026-08-15T13:00:00.000000Z", **kw):
@@ -600,6 +613,76 @@ def test_a_card_someone_already_closed_is_left_alone(status):
     assert guard.writeback_state(task(status=status, comments=[]), READ_TS) == "closed"
 
 
+# --------------------------------------------------------------------------- #
+# 4b. A card with a LIVE DISPATCHED AGENT is DELEGATED, not missing
+#
+# Regression for the 2026-08-20 false positive: a session that DISPATCHED agents at
+# tasks 241/294 was told to comment as `claude-code` and flip both to
+# `ready_for_review` while `bright-fox`/`brave-finch` were still running. That
+# remedy pre-empts the agent's own close-out and fires a push to the operator.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("status", ["pending", "provisioning", "running"])
+def test_a_live_dispatched_agent_owes_the_writeback_not_this_session(status):
+    t = task(comments=[], agent=agent_obj(status=status))
+    assert guard.writeback_state(t, READ_TS) == "delegated"
+
+
+@pytest.mark.parametrize("status", ["stopped", "error"])
+def test_a_DEAD_agent_still_reports_missing(status):
+    """🔴 The safety half, and the reason `delegated` is scoped to LIVE statuses only.
+
+    An agent that died without writing back is EXACTLY the #193/#194 case this guard
+    exists for. If this ever goes green as "delegated", the fix has eaten the guard.
+    """
+    t = task(comments=[], agent=agent_obj(status=status))
+    assert guard.writeback_state(t, READ_TS) == "missing"
+
+
+def test_the_status_vocabulary_is_partitioned_with_nothing_left_over():
+    """🔴 A LEDGER over the server's closed set (agents/store.go:14-19). It fails when
+    the set GROWS (a new status nobody classified) or SHRINKS, rather than silently
+    treating an unknown status as dead. Without this, a future `paused` would land on
+    the noisy side by accident and nobody would notice."""
+    server_statuses = {"pending", "provisioning", "running", "stopped", "error"}
+    live = set(guard.LIVE_AGENT_STATUSES)
+    assert live <= server_statuses, "a LIVE status the server does not define"
+    dead = server_statuses - live
+    assert dead == {"stopped", "error"}
+    for s in sorted(live):
+        assert guard.writeback_state(task(comments=[], agent=agent_obj(s)),
+                                     READ_TS) == "delegated", s
+    for s in sorted(dead):
+        assert guard.writeback_state(task(comments=[], agent=agent_obj(s)),
+                                     READ_TS) == "missing", s
+
+
+def test_no_agent_on_the_card_is_unchanged():
+    """The common case — `"agent": null`. Must stay exactly as loud as it was."""
+    assert guard.writeback_state(task(comments=[], agent=None), READ_TS) == "missing"
+
+
+@pytest.mark.parametrize("junk", ["running", ["running"], 7, {}, {"status": "bogus"}])
+def test_an_UNRECOGNISED_agent_shape_fails_LOUD(junk):
+    """🔴 Fails toward "missing", never toward silence. A payload shape this hook does
+    not understand must not be able to switch the guard off — including the near-miss
+    where `agent` is the STATUS STRING rather than the object."""
+    assert guard.writeback_state(task(comments=[], agent=junk), READ_TS) == "missing"
+
+
+def test_a_real_writeback_still_wins_over_a_live_agent():
+    """🔴 Pins the ORDER. `delegated` is checked after the comment scan, so a card that
+    has both a live agent and a genuine write-back reports "written" — the stronger,
+    more specific fact. Reordering the two makes this red."""
+    c = comment(created="2026-08-15T13:00:00.000000Z")
+    t = task(comments=[c], agent=agent_obj())
+    assert guard.writeback_state(t, READ_TS) == "written"
+
+
+def test_a_closed_card_with_a_live_agent_is_still_closed():
+    t = task(status="ready_for_review", comments=[], agent=agent_obj())
+    assert guard.writeback_state(t, READ_TS) == "closed"
+
+
 @pytest.mark.parametrize("status", ["open", "in_progress"])
 def test_an_open_or_in_progress_card_is_still_measured(status):
     assert guard.writeback_state(task(status=status, comments=[]), READ_TS) == "missing"
@@ -679,6 +762,38 @@ def test_a_read_and_evaluate_only_session_NEVER_fires(home):
     kind, text = guard.stop_decision(payload("Stop"), reader=r)
     assert (kind, text) == ("silent", "")
     assert r.calls == []
+
+
+def test_a_delegated_card_is_silent_END_TO_END(home):
+    """The false positive itself, driven through `stop_decision`.
+
+    🔴 The board IS read — unlike the no-work case, which asserts the absence of the
+    read. A `delegated` verdict is a MEASURED one, so a mutation that reaches silence
+    by skipping the live read instead of by classifying the agent is visible here.
+    """
+    seed(work=True)
+    r = Reader(result=task(comments=[], agent=agent_obj(status="running")))
+    assert guard.stop_decision(payload("Stop"), reader=r) == ("silent", "")
+    assert [c[0] for c in r.calls] == [193]
+
+
+def test_a_delegated_card_SPENDS_NO_COUNTER(home):
+    """🔴 Asserted through the LADDER, not by reading the counter file: a long agent
+    run must not exhaust the budget a genuinely missing write-back will need.
+
+    Four delegated Stops is strictly more than MAX_FIRES (3) and MAX_BLOCKS (2) — and
+    4 equals neither constant, so this cannot pass by construction. If `delegated`
+    burned a fire, the ladder would be spent and the final Stop — where the agent has
+    DIED with no write-back — would come back silent instead of blocking.
+    """
+    seed(work=True)
+    alive = Reader(result=task(comments=[], agent=agent_obj(status="running")))
+    for _ in range(4):
+        assert guard.stop_decision(payload("Stop"), reader=alive) == ("silent", "")
+    dead = Reader(result=task(comments=[], agent=agent_obj(status="error")))
+    kind, text = guard.stop_decision(payload("Stop"), reader=dead)
+    assert kind == "block"
+    assert "193" in text
 
 
 def test_the_positive_control_for_that_absence(home):

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1196,7 +1196,23 @@ TARGET_FLOORS=(
   # RED at the base sha. Read from the AUTHORITATIVE gate's own per-target line:
   #   PASS  scripts/claude-hooks/tests/test_clawgate_writeback_guard.py  (collected=280 passed=280 skipped=0 floor=260)
   #   _suggested_floor 280 = 280 - min(50, max(1, 280/20 = 14)) = 280 - 14 = 266.
-  "scripts/claude-hooks/tests/test_clawgate_writeback_guard.py|266"
+  #
+  # 2026-08-20, the `delegated` state: 280 -> 296. A card whose DISPATCHED AGENT is
+  # still alive owes its write-back to that AGENT, so nagging the dispatching session
+  # asked it to pre-empt a close-out that had not happened — measured on tasks 241/294
+  # while `bright-fox`/`brave-finch` were running, where following the guard's own
+  # remedy would have manufactured the signal that run was measuring.
+  # +6 are RED at the base sha (3 live statuses, the two-way status ledger, and the two
+  # end-to-end cases). The other +10 are INVARIANT GUARDS and are NOT regression
+  # coverage — they pin behaviour that was already correct and that the fix must not
+  # eat: dead agents still `missing`, `"agent": null` unchanged, four junk shapes
+  # (incl. `agent` as the status STRING), the comment-scan-wins ordering, and closed
+  # beating delegated. Each was mutation-checked to die for its OWN reason; the
+  # safety-critical inversion (dead treated as live) is killed three independent ways.
+  # ZERO new skips, so EXPECTED_SKIPS is untouched. Read from the AUTHORITATIVE gate:
+  #   PASS  scripts/claude-hooks/tests/test_clawgate_writeback_guard.py  (collected=296 passed=296 skipped=0 floor=266)
+  #   _suggested_floor 296 = 296 - min(50, max(1, 296/20 = 14)) = 296 - 14 = 282.
+  "scripts/claude-hooks/tests/test_clawgate_writeback_guard.py|282"
   # 2026-08-18, the on-disk artifact-name registry arrives as a NEW target: 13
   # collected. Deliberately small — one test per module whose names it pins, plus the
   # two-sided classification guard that fails when a hook module appears or vanishes.


### PR DESCRIPTION
## What

`clawgate-writeback-guard.py` cannot distinguish **"this session did the work on task N"** from **"this session dispatched an AGENT to do the work on task N."** Dispatching is what clawgate is *for*, so the guard fires on every session that dispatches — and the remedy it prescribes is the wrong action there:

> `clawgatectl task comment 241 …` / `clawgatectl task status 241 ready_for_review`

Doing that pre-empts the agent's own close-out and fires a push notification to Zach.

## How it was found

2026-08-20, mid-experiment. Tasks 241 and 294 had been dispatched to agents `bright-fox` and `brave-finch` specifically to measure **whether a dispatched agent self-reports a blocker instead of grinding**. The guard fired on both while the agents were still running. Complying would have manufactured the very signal the run was measuring.

## What this is *not*

This is not a fix to an unconsidered bug, and the PR should not be read that way. The module docstring already states that the hook cannot see devpod-agent work and cannot attribute an edit to a task, and `--dismiss` is the *designed* remedy.

What was actually missing: **the discriminator is already in the payload.** `live_task` fetches `/api/tasks/{id}`, which carries an `agent` object. The guard simply never looked at it. So this costs nothing extra at runtime.

## The change

A new state, `delegated`:

- checked **last**, after the comment scan — a card with both a live agent *and* a genuine write-back still reports `written`
- **spends no counter** — a long agent run must not exhaust the block budget a genuinely missing write-back will need later

### 🔴 Alive only — this is the whole safety argument

| status | verdict | why |
|---|---|---|
| `pending`, `provisioning`, `running` | `delegated` | the agent owes the write-back |
| `stopped`, `error` | `missing` | **nobody will do it** — this is the #193/#194 case the guard exists for |

The card also leaves the window on its own: the agent's close-out sets `ready_for_review`, which `CLOSED_STATUSES` already absorbs. So `delegated` cannot become a permanent silence.

The vocabulary is the **closed set read from the server** (`containers/clawgate/internal/agents/store.go:14-19`), not a guess, and is pinned by a two-way ledger test that fails if it grows *or* shrinks — so a future `paused` cannot land on the quiet side by accident.

## Test evidence

280 → 296, and the split is stated honestly:

- **6 are regression coverage.** Red at base `4740e40`: the 3 live statuses, the status ledger, and the two end-to-end cases.
- **10 are INVARIANT GUARDS, not regression coverage.** They pin behaviour that was already correct and that this fix must not eat: dead agents still `missing`, `"agent": null` unchanged, four junk shapes (including `agent` as the status *string* rather than the object), comment-scan-wins ordering, and closed beating delegated.

### Mutation results

Run under `PYTHONDONTWRITEBYTECODE=1` with `__pycache__` purged between mutants, and with a positive control on the battery itself.

| mutant | killed by |
|---|---|
| control — empty `LIVE_AGENT_STATUSES` | 3 live-agent cases |
| **dead agents treated as live** | dead-agent (×2), status ledger, **counter test** — 3 independent ways |
| agent check moved before the comment scan | ordering test |
| shape check removed | junk-shape (×5), dead-agent (×2) |

Guard restored byte-identical after the battery.

### The floor

Read from the authoritative gate's own line, per the convention in `run-tests.sh`:

```
PASS  scripts/claude-hooks/tests/test_clawgate_writeback_guard.py  (collected=296 passed=296 skipped=0 floor=282)
```

## Gate comparison — base vs branch, same environment

Both are **red on the same two pre-existing failures**: initiatives' `test_abandoned_worker_dies_promptly_on_a_chunk_spanning_body` and `test_this_modules_own_stated_figures_are_re_measured`.

The branch run showed one extra — `test_search_tool_nudge.py`'s `concurrency: exactly one nudge across 12 parallel invocations: got 0 want 1` — which cascaded into `test_a_green_real_run_says_pass_with_exit_zero`, since that test runs the whole runner and quotes the nested failure inside its own assertion. **It passes identically on both trees in isolation** (174 checks each). The contention was self-inflicted: two full gates were run simultaneously.

## Residual blind spot, named rather than hidden

An agent that is **alive but has silently given up** looks the same as one still working, and this hook cannot tell them apart. What bounds that is the devpod reaper, not this guard.

## Not fixed here

- `pytest scripts/claude-hooks/tests/` (as a directory) dies with `INTERNALERROR> SystemExit: 0` and reports `no tests ran` — a zero that reads clean and isn't. Pre-existing on pristine `origin/main`.
- The gate needs `logrotate` on `PATH` or it exits 2 for environment reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
