### PR TITLE
fix(prune-skill): client store prose — including a real threshold — reached the PUBLIC repo; reword to the shape

### DIFF
--- a/claude/skills/prune-skill/reference/verification-protocol.md
+++ b/claude/skills/prune-skill/reference/verification-protocol.md
@@ -114,14 +114,16 @@ transcode/VFE, or deploy-time 502s"*. Nothing about a duration query sends you t
 agent wrote `le="5"`, got silence, and the rows vanished from a unioned table. **In one fat
 body you scroll past the warning and are immune.** 🔴 **Postscript (2026-08-19), and it is half
 the lesson: when that warning was finally lifted into the core, RE-MEASURING it showed the
-warning's own EXAMPLE was wrong** — it named `"30.0"`/`"30"`, and there is no `le=30` on either
-image-cacher histogram (`count by (le)` → `0.0 5.0 10.0 25.0 50.0 …`; the nearest value anywhere
-is `le=300.0`, on a different metric). The RULE was load-bearing and correct; the example was
-fabricated. **Re-verify a documented EXAMPLE, not just the rule it illustrates** — an orphaned
-warning is unread, so nothing corrects its details either. Milder sibling in the same skill: the core's
-Redis hot-command prints saturation numbers with no interpretation, while the sidecar saying
-*"it is NOT a 503 lever, r = 0.029"* is a routing hop away — the agent nearly filed it as an
-availability contributor. **So: when you demote a block, ask what it was PROTECTING. If the
+warning's own EXAMPLE was wrong** — it quoted a specific histogram bucket that the metric in
+question does not define at all. Enumerating the real buckets showed the quoted one missing
+entirely, with the nearest similar value belonging to an unrelated series. The RULE was
+load-bearing and correct; the illustration attached to it had been invented. **An EXAMPLE earns
+its own re-measurement — the rule holding tells you nothing about whether the numbers beside it
+still do.** A warning nobody reads is also a warning nobody corrects, so a fabricated detail
+inside one survives indefinitely. Milder sibling in the same skill: the core printed saturation
+figures with no interpretation, while the sidecar that said those figures were NOT the lever —
+citing a near-zero correlation — sat a routing hop away, and the reader nearly filed them as a
+cause. **So: when you demote a block, ask what it was PROTECTING. If the
 trigger stays in the core, the guard goes with it or leaves a cross-reference.**
 
 🔴 **A lean core AMPLIFIES stale text.** Both agents said it independently: a wrong line in a


### PR DESCRIPTION
## `main` is red

```
claude/skills/prune-skill/reference/verification-protocol.md shares an
8-word phrase with store entry datapacket-talos/image-cacher.md
```

**15 phrases, in two runs.** The first is generic engineering prose. The **second carried client-confidential operational detail** — a histogram bucket enumeration and a specific threshold value lifted from the entry, plus a correlation figure from another. That's the class this gate exists for: not a secret, but a client's measured infrastructure detail sitting in a public repo.

## The fix

Reworded so the **lesson survives in full force** and nothing else does. The passage still says: an example earns its own re-measurement; the rule holding tells you nothing about the numbers beside it; a warning nobody reads is a warning nobody corrects. The borrowed specifics — bucket enumeration, threshold, correlation — are now described by shape.

**Deliberately not added to an exclusion list**, as the gate's own message instructs: the phrases themselves are the thing that must not be committed.

## Verification

- Gate **red before, green after**
- Cross-checked by importing the gate's own `_phrases()`: **15 shared → 0**
- Run standalone and **gated on its exit status**, never in the same command block as the commit

## Provenance

**Not mine** — introduced by #561 or #567. Nobody was mid-edit on the file and no open PR touched it when this was written, so fixing it here doesn't collide with anyone.

This is the **second** such leak closed today (the first was `handoff-subsystem-store.md`, #556). Both were the same mechanism: prose written in one place and echoed into the other. Note the direction differs between them — which is why the gate compares both ways rather than watching one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
