### PR TITLE
fix(handoff): the `behind` message recommended an operation the target repo FORBIDS, and made a devrc-only claim about every repo

### DIFF
--- a/scripts/lib/handoff_doc.py
+++ b/scripts/lib/handoff_doc.py
@@ -312,6 +312,44 @@ def resolve_branch(repo: Path, override: str | None) -> str:
     return branch
 
 
+def uncommitted_paths(repo: Path) -> list[str]:
+    """Paths with uncommitted changes in `repo`'s working tree, staged or not.
+
+    🔴 THIS DECIDES WHICH REMEDY THE `behind` MESSAGE OFFERS, and the hazard it
+    measures is NOT "which repo is this". `merge --ff-only` into a tree holding
+    someone else's uncommitted work either refuses or overwrites it, and in a
+    shared clone that work is routinely not yours: measured in `$DATAPACKET`
+    2026-08-19, **38 dirty paths** across at least three sessions while the clone
+    sat **90 commits behind**. That repo's own rules forbid `commit`, `add`,
+    `stash`, `checkout` and `switch` in the primary clone for exactly this reason.
+
+    So the tool measures the tree instead of enumerating repos — an enumeration
+    would be wrong for the next shared checkout nobody added to it.
+
+    UNREADABLE ⇒ TREAT AS DIRTY. A tree we cannot inspect is one we must not
+    recommend mutating; the fail-safe direction is the cautious remedy.
+
+    🔴 `--no-optional-locks`, AND IT IS NOT OPTIONAL HERE. A plain `git status`
+    REFRESHES THE INDEX and writes `.git/index` — on a shared gitdir that is a
+    side effect on every other worktree, and this module already forbids exactly
+    that. The existing no-write guard caught this the first time the check
+    shipped, which is the guard doing its job. The flag makes the read take no
+    lock and write nothing; the cost is that a stat-dirty file can be reported
+    as modified when its content matches, which errs toward the cautious remedy
+    and is the right direction for this decision.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "--no-optional-locks", "-C", str(repo), "status", "--porcelain"],
+            capture_output=True, text=True, timeout=30, check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ["<could not read the working tree>"]
+    if out.returncode != 0:
+        return ["<could not read the working tree>"]
+    return [ln[3:].strip() for ln in out.stdout.splitlines() if ln.strip()]
+
+
 def remote_has_commits_we_lack(repo: Path, remote: str, branch: str) -> bool:
     """Would a push to `<remote>/<branch>` be rejected non-fast-forward?
 
@@ -521,15 +559,54 @@ def main(argv: list[str] | None = None) -> int:
             # 🔴 The RESOLVED branch in every line. An earlier version printed
             # `HEAD` and a literal `<branch>`, so the recovery could not be
             # pasted — and this message is the entire second half of the fix.
+            dirty = uncommitted_paths(repo)
             ff = f"git -C {repo} merge --ff-only {args.remote}/{push_branch}"
-            print(
+            head = (
                 f"status=behind remote={args.remote} branch={push_branch}\n"
                 f"NOTHING WRITTEN — not the doc, not a commit, not a ref.\n"
                 f"  {args.remote}/{push_branch} has commit(s) this checkout does "
                 f"not, so the push would be rejected and the commit would be left "
-                f"behind on a shared branch. That is the state that silently "
-                f"blocks `ship.sh`.\n"
-                f"  Fast-forward, then re-run this exact command:\n"
+                f"behind on a shared branch. In a devrc checkout that is the state "
+                f"that silently blocks `ship.sh`; elsewhere it is a stranded commit "
+                f"on a branch other people push to.\n"
+            )
+            if dirty:
+                # 🔴 A DIRTY TREE CHANGES THE REMEDY, and this is the branch that
+                # matters. `merge --ff-only` here either refuses or overwrites work
+                # that is very often NOT the caller's: measured in a shared clone
+                # 2026-08-19, 38 dirty paths across three sessions at 90 behind.
+                # Repos with a shared primary clone forbid mutating it at all, so
+                # the tool must not print that command as if it were the fix.
+                shown = ", ".join(sorted(dirty)[:4])
+                more = f" (+{len(dirty) - 4} more)" if len(dirty) > 4 else ""
+                print(
+                    f"{head}"
+                    f"  🔴 THIS CHECKOUT IS DIRTY — {len(dirty)} uncommitted "
+                    f"path(s): {shown}{more}\n"
+                    f"  DO NOT fast-forward it. Some or all of that work is "
+                    f"probably another session's, and `merge --ff-only` would "
+                    f"either refuse or overwrite it. Several repos forbid "
+                    f"committing in a shared primary clone for exactly this "
+                    f"reason.\n"
+                    f"  Commit and push from a THROWAWAY WORKTREE off the remote "
+                    f"branch instead, leaving this tree untouched:\n"
+                    f"    git -C {repo} worktree add /tmp/handoff-wt "
+                    f"{args.remote}/{push_branch}\n"
+                    f"    # write the doc there, commit it path-limited, then:\n"
+                    f"    git -C /tmp/handoff-wt push {args.remote} "
+                    f"HEAD:{push_branch}\n"
+                    f"  🔴 Remove the worktree only AFTER the push succeeds — "
+                    f"removing it after a failed push deletes the branch ref and "
+                    f"orphans the commit.\n"
+                    f"  Verify by CONTENT, never ancestry: a squash merge never "
+                    f"makes your head an ancestor of {push_branch}.",
+                    file=sys.stderr,
+                )
+                return EXIT_BEHIND
+            print(
+                f"{head}"
+                f"  This checkout is CLEAN, so a fast-forward is safe. Run it, "
+                f"then re-run this exact command:\n"
                 f"    {ff}\n"
                 f"  🔴 If `--branch {push_branch}` is not the branch you are ON, "
                 f"do NOT run that merge — it would merge an unrelated branch into "

--- a/scripts/tests/test_handoff_doc.py
+++ b/scripts/tests/test_handoff_doc.py
@@ -650,6 +650,93 @@ class TestBehindRemoteWritesNothing:
         assert "reset --keep" in err
         assert "ship.sh" in err, "the consequence is what makes this worth obeying"
 
+    # --- the remedy DEPENDS on the tree, and a dirty tree gets a different one ---
+    #
+    # 🔴 MEASURED 2026-08-19. An agent hit this refusal in a shared clone that was
+    # 90 commits behind with 38 uncommitted paths belonging to at least three
+    # sessions. It correctly declined the `merge --ff-only` this message printed —
+    # that repo's own rules forbid committing, adding, stashing, checking out or
+    # switching in the primary clone precisely because the tree is shared. The
+    # tool was recommending an operation the target repo bans, and the message's
+    # `ship.sh` framing (devrc-specific) was repeated back as fact about a repo
+    # `ship.sh` does not converge.
+
+    def _dirty_the_tree(self, repo: Path) -> str:
+        """Leave an uncommitted path that is NOT the handoff doc — i.e. the shape
+        of someone else's in-progress work."""
+        other = repo / "SOMEONE_ELSES_WIP.md"
+        other.write_text("another session is mid-edit here\n", encoding="utf-8")
+        return other.name
+
+    def test_a_DIRTY_checkout_is_NOT_told_to_fast_forward(
+        self, repo: Path, update_file: Path, tmp_path: Path
+    ) -> None:
+        """🔴 The load-bearing half. `merge --ff-only` into a tree holding another
+        session's work either refuses or overwrites it."""
+        self._advance_remote(repo, tmp_path)
+        self._dirty_the_tree(repo)
+        res = run_tool(repo, "--confirm", "--push", update=update_file)
+        assert res.returncode == 6, (res.returncode, res.stderr)
+        err = res.stderr
+        # 🔴 The property is "no PASTEABLE COMMAND", not "the string never
+        # appears". The dirty branch NAMES `merge --ff-only` inside the sentence
+        # explaining why not to run it, which is correct and must stay legal —
+        # an earlier version of this assertion forbade the string outright and
+        # would have banned explaining the hazard at all.
+        assert f"git -C {repo} merge --ff-only" not in err, (
+            "the tool handed over a runnable fast-forward for a tree that holds "
+            "uncommitted work"
+        )
+        assert "merge --ff-only" in err, (
+            "it should still NAME the operation it is warning against"
+        )
+        assert "THIS CHECKOUT IS DIRTY" in err
+        assert "worktree add" in err, "it must name the remedy, not just refuse one"
+        assert "HEAD:" in err, "the push must go HEAD->branch from the worktree"
+
+    def test_the_dirty_message_NAMES_the_paths_it_is_protecting(
+        self, repo: Path, update_file: Path, tmp_path: Path
+    ) -> None:
+        """A refusal that does not say WHAT it saw is one the caller second-guesses."""
+        self._advance_remote(repo, tmp_path)
+        name = self._dirty_the_tree(repo)
+        err = run_tool(repo, "--confirm", "--push", update=update_file).stderr
+        assert name in err, "the dirty path is the evidence for the whole branch"
+        assert "uncommitted path(s)" in err
+
+    def test_the_dirty_message_gates_worktree_REMOVAL_on_the_push(
+        self, repo: Path, update_file: Path, tmp_path: Path
+    ) -> None:
+        """Removing a worktree after a FAILED push deletes the branch ref and
+        orphans the commit — the recipe is incomplete without this."""
+        self._advance_remote(repo, tmp_path)
+        self._dirty_the_tree(repo)
+        err = run_tool(repo, "--confirm", "--push", update=update_file).stderr
+        assert "AFTER the push succeeds" in err
+        assert "orphans the commit" in err
+
+    def test_a_CLEAN_checkout_still_gets_the_fast_forward(
+        self, repo: Path, update_file: Path, tmp_path: Path
+    ) -> None:
+        """🔴 The negative control. Without it, "never suggest ff-only" would pass
+        every test above while making the clean case needlessly heavy — the
+        fast-forward is correct there and is the cheaper remedy."""
+        self._advance_remote(repo, tmp_path)
+        err = run_tool(repo, "--confirm", "--push", update=update_file).stderr
+        assert "merge --ff-only" in err
+        assert "This checkout is CLEAN" in err
+        assert "THIS CHECKOUT IS DIRTY" not in err
+
+    def test_the_ship_sh_claim_is_SCOPED_not_asserted_of_every_repo(
+        self, repo: Path, update_file: Path, tmp_path: Path
+    ) -> None:
+        """`ship.sh` converges devrc only. Stating it flatly taught a reader that a
+        stranded commit in an unrelated repo blocks it — they repeated the claim."""
+        self._advance_remote(repo, tmp_path)
+        err = run_tool(repo, "--confirm", "--push", update=update_file).stderr
+        assert "In a devrc checkout" in err, "the ship.sh consequence must be scoped"
+        assert "elsewhere" in err, "and the other case must be stated, not implied"
+
     def test_it_does_not_fire_when_the_remote_has_not_moved(
         self, repo: Path, update_file: Path
     ) -> None:


### PR DESCRIPTION
## What happened

An agent hit `status=behind` in a shared clone that was **90 commits behind with 38 uncommitted paths** belonging to at least three sessions. The message told it to run `merge --ff-only` there.

That repo's own rules **forbid** `commit`/`add`/`stash`/`checkout`/`switch` in the primary clone, precisely because the tree is shared. So the tool recommended a banned operation — one that would have refused or overwritten someone else's work. The agent checked and declined. The next one might not.

## Two fixes

**1. The remedy now depends on the tree, measured — not on a repo allowlist.** An enumeration would be wrong for the next shared checkout nobody added to it. The hazard is uncommitted work, which `git status` can see. A dirty tree gets the throwaway-worktree recipe, with the paths named as evidence, worktree removal **gated on a successful push** (removing it after a failed one orphans the commit), and verify-by-content-never-ancestry. A clean tree still gets the fast-forward — correct and cheaper there.

**2. The `ship.sh` consequence is scoped.** It was asserted flat, and `ship.sh` converges devrc only. The agent repeated the false claim back as fact about a repo `ship.sh` does not touch. Message text becomes belief.

## 🔴 The module's own guard caught me

My first version used plain `git status --porcelain`, which **refreshes and writes `.git/index`**. On a shared gitdir that's a side effect on every other worktree, and this module already forbids writing there — it's what made an earlier pushability check racy. The existing no-write test caught it immediately.

Fixed with `--no-optional-locks`, and **measured**:

```
plain  status: .git 🔴 WROTE
no-opt status: .git UNCHANGED
```

Cost: a stat-dirty file can read as modified when its content matches — which errs toward the cautious remedy, the right direction for this decision.

## One of my own assertions was wrong

It forbade the substring `merge --ff-only`, which would have banned **naming** the operation being warned against. The property is *no pasteable command* — it now asserts the command form is absent **and** that the prose still names it.

## Verification

`TOTAL collected=12790 passed=12789 skipped=1 failed=0`, `RESULT: PASS (exit=0)`, read from `nix log` content. Store-content gate `rc=0`, run standalone and **gated on its status**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
