### PR TITLE
fix(subsystem-touch): the right entry was printed under a heading that reads like a dead end — five runs re-found it by hand

### DIFF
--- a/scripts/lib/subsystem_touch.py
+++ b/scripts/lib/subsystem_touch.py
@@ -3975,6 +3975,33 @@ def render_text(report: TouchReport) -> str:
         )
         for m in report.below_threshold:
             out.append(f"  - {m.entry.ref}  ({m.path_count} path)")
+        # 🔴 THESE ARE EXISTING ENTRIES, AND THE HEADING DOES NOT SAY SO.
+        # `below_threshold` items carry `.entry` by construction — a ref only
+        # lands here after RESOLVING to a real file. "reported, not proposed"
+        # describes what the tool will do (not auto-propose a write), and five
+        # separate runs read it as "this is a dead end" and went looking for the
+        # right entry by hand — after which every one of them found exactly the
+        # entry named here.
+        #
+        # The sibling summary that says "Entries WERE reached" lives under
+        # `if not report.writes_proposed:` below, so a run that nominates
+        # ANYTHING suppresses it — which is precisely the run where a proposal to
+        # CREATE something sits next to an existing entry the reader should
+        # probably append to instead. Measured 2026-08-19 on `--pr 1146,1149`:
+        # `tests` (5 paths) was proposed for creation while `tekton-builds`
+        # (1 path, 18 KB, 15 bullets, already on disk) sat here unexplained.
+        one = len(report.below_threshold) == 1
+        out.append(
+            f"  ⇢ {'This entry EXISTS' if one else 'These entries EXIST'} — too few"
+            f" paths to auto-propose, NOT a dead end. If this session's subject is"
+            f" {'it' if one else 'one of them'}, APPEND there rather than creating"
+            f" anything below."
+        )
+        out.append(
+            "  ⇢ Paths cannot carry a subject: work ABOUT one subsystem often lands in"
+            " files under another (tests/, scripts/, a shared manifest dir). A low path"
+            " count is weak evidence about the FILES, not about the SUBJECT."
+        )
 
     if report.ambiguous:
         out.append("")

--- a/scripts/tests/test_subsystem_touch.py
+++ b/scripts/tests/test_subsystem_touch.py
@@ -816,6 +816,60 @@ class TestBelowThreshold:
         assert "NOTHING RESOLVED" in other
         assert "NOTHING CLEARED THE THRESHOLD" not in other
 
+    # --- the below-threshold block must stand on its own ------------------------
+    #
+    # 🔴 MEASURED 2026-08-19 on `--pr 1146,1149`. `tests` (5 paths) was proposed
+    # for CREATION while `tekton-builds` — 1 path, already on disk at 18 KB with
+    # 15 bullets — sat under "reported, not proposed" with no explanation. The
+    # "Entries WERE reached" tail lives under `if not report.writes_proposed:`,
+    # so ANY nomination suppresses it: exactly the run where a create-proposal
+    # sits beside an existing entry the reader should append to instead.
+    # Five separate runs read that heading as a dead end and re-found the entry
+    # by hand. Every one of them landed on the entry already named here.
+
+    def test_the_block_says_the_entry_EXISTS_even_when_something_is_nominated(
+        self, store: Path
+    ) -> None:
+        """🔴 The load-bearing case: a nomination present, so the tail is gone."""
+        rep = _report(
+            ["src/collector/only.py", "tests/a.py", "tests/b.py", "tests/c.py"], store
+        )
+        assert [m.entry.ref for m in rep.below_threshold] == ["collector"]
+        assert rep.nominations, "fixture must nominate, or this tests the wrong branch"
+        text = st.render_text(rep)
+        assert "NOTHING CLEARED THE THRESHOLD" not in text, (
+            "fixture assumption changed: the tail is supposed to be suppressed here"
+        )
+        assert "EXISTS" in text
+        assert "NOT a dead end" in text
+        assert "APPEND there" in text
+
+    def test_it_says_paths_cannot_carry_a_SUBJECT(self, store: Path) -> None:
+        """The reason the count is weak evidence, not just that it is weak. Work
+        ABOUT one subsystem routinely lands in files under another."""
+        text = st.render_text(_report(["src/collector/only.py", "docs/other.md"], store))
+        assert "Paths cannot carry a subject" in text
+        assert "weak evidence about the FILES, not about the SUBJECT" in text
+
+    def test_the_guidance_is_ABSENT_when_nothing_is_below_threshold(
+        self, store: Path
+    ) -> None:
+        """🔴 The negative control. Printed unconditionally it becomes wallpaper —
+        and would be actively wrong on a run that reached no entry at all."""
+        rep = _report(["docs/a.md", "notes/b.md"], store)
+        assert rep.below_threshold == (), "fixture must reach no entry"
+        text = st.render_text(rep)
+        assert "NOT a dead end" not in text
+        assert "Paths cannot carry a subject" not in text
+
+    def test_singular_and_plural_AGREE_with_the_count(self, store: Path) -> None:
+        """Prose that says "This entry EXISTS ... is one of them" is the kind of
+        near-miss this module complains about elsewhere."""
+        one = st.render_text(_report(["src/collector/only.py", "docs/other.md"], store))
+        assert "This entry EXISTS" in one
+        assert "subject is it," in one
+        assert "one of them" not in one
+
 
 # =============================================================================
 # 🔴 The store is never written.


### PR DESCRIPTION
## The right entry was printed under a heading that reads like a dead end

Measured on `--pr 1146,1149`. The window proposed **creating** `tests` (5 paths — a directory) while `tekton-builds` — **1 path, already on disk at 18 KB with 15 bullets** — sat above it under:

```
BELOW THRESHOLD (<2 paths — reported, not proposed):
  - tekton-builds  (1 path)
```

…and nothing else. **Five separate runs** read that as a dead end, went looking for the right home by hand, and every one of them landed on the entry already named there.

## Why the explanation never appeared

The sentence that would have disambiguated it — *"Entries WERE reached; none strongly enough"* — is real, and lives under:

```python
if not report.writes_proposed:          # writes_proposed = bool(known) or bool(nominations)
```

So **any** proposal suppresses it — precisely the run where a create-proposal sits beside an existing entry the reader should append to instead.

`below_threshold` items carry `.entry` **by construction**: a ref only lands there after resolving to a real file. The fact was already computed and simply not printed on the path that mattered.

## After

```
BELOW THRESHOLD (<2 paths — reported, not proposed):
  - tekton-builds  (1 path)
  ⇢ This entry EXISTS — too few paths to auto-propose, NOT a dead end. If this
    session's subject is it, APPEND there rather than creating anything below.
  ⇢ Paths cannot carry a subject: work ABOUT one subsystem often lands in files
    under another (tests/, scripts/, a shared manifest dir). A low path count is
    weak evidence about the FILES, not about the SUBJECT.
```

That second line is the durable half. The knowledge here was about tekton-builds' scheduling environment; the diff was five files under `tests/`. **No path-based association can bridge that**, and saying so is worth more than any ranking change.

## Deliberately unchanged

`nominate()`'s ranking, its thresholds, and its explicit **no-stoplist policy**. Its docstring argues that a stoplist of "generic" directory names would be a second predicate drifting from the matcher, and that argument holds. `coherent` and `fans_out` behaved correctly on the input they were given — **this was never a ranking bug**, which is what I first assumed and had to discard after reproducing it.

## Verification

`TOTAL collected=12789 passed=12788 skipped=1 failed=0`, `RESULT: PASS (exit=0)`, read from `nix log` content.

Four tests: the message renders when a nomination is present (the suppressed case); it names the paths-cannot-carry-a-subject reason; it is **absent** when nothing is below threshold (the negative control — printed unconditionally it becomes wallpaper); and singular/plural agree with the count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
