### PR TITLE
espanso: make all four :ssh* snippets reachable from search, add 3 measured snippets

### DIFF
--- a/claude/skills/espanso-audit/SKILL.md
+++ b/claude/skills/espanso-audit/SKILL.md
@@ -60,10 +60,37 @@ prune anything from a run that printed one.
 - **~97% of fires go through the Ctrl+Space SEARCH UI**, so `label` +
   `search_terms` ARE the interface. A zero-fire snippet is usually a
   discoverability bug, not a content one (`:acq`, 2026-08-05).
+- 🔴 **The SEARCH stream only records searches that FAILED — never infer what he
+  USES from it.** `--terms` shows queries that resolved to nothing, so it is a
+  sample of failures, and reading a preference off it inverts the meaning. On
+  2026-08-19 every observed ssh query was host-only (`lap`, `ssh wor`), which I
+  read as "he doesn't care about the network axis" and proposed collapsing the
+  four `:ssh*` to nebula-only. Wrong: those queries fired nothing, so he fell
+  back to hand-typing — and `activity.events` showed all four endpoints live
+  with **LAN ahead of nebula** (laptop-LAN 4 shell invocations, workbench-LAN 3,
+  workbench-nebula 1, laptop-nebula 0). The proposal would have deleted the two
+  most-used. **0 fires is equally consistent with "unused" and "used constantly
+  but unreachable" — both predict zero.** Before touching a snippet, query the
+  USAGE signal for what it expands to:
+  `SELECT countIf(text LIKE '%<expansion>%') FROM activity.events WHERE
+  source IN ('zsh','claude','opencode') AND kind IN ('command','prompt')`.
+- 🔴 **`search_terms` are not free-form — a new snippet can STEAL an existing
+  one's searches.** `espanso_detect._token_matches` is a SUBSTRING test over the
+  trigger, every **label word**, and every `search_term`, so `'bench'` ⊂
+  `'workbench'`, `'la'` ⊂ `'nebula'`, `'ask'` ⊂ `'task'`. A `:cgt` labelled
+  "task" would have silently hijacked all 58 of `:acq`'s `'ask'` fires. Two
+  consequences: (a) when two snippets both spell the same word, **no**
+  `search_terms` edit makes a bare query resolve — one of them must stop
+  spelling it; (b) always gate with `--replay --config <candidate>` and **diff
+  it against the deployed config for REGRESSIONS**, not just for new
+  resolutions. Validate that diff with a planted mutant before believing a
+  clean result.
 - DEMAND reads the LOCAL transcripts only; re-run on the other host if you need
   its demand. Retune-vs-prune is a judgement call, so the tool never edits
   `nix/home.nix`. The keystroke expansion itself can only be checked by the user
-  typing a trigger.
+  typing a trigger. **Path snippets read as huge demand with near-zero fires
+  (`:cdp` 300/3) — that is the `$DEVRC`/`$CIVITAI` env handles doing the job,
+  not a discoverability bug. Do not retune them on demand alone.**
 
 Notes:
 - Edit `claude/skills/<name>/SKILL.md` + `nix/home.nix` in the repo, NOT `~/.claude/*`

--- a/claude/skills/espanso-audit/SKILL.md
+++ b/claude/skills/espanso-audit/SKILL.md
@@ -85,6 +85,20 @@ prune anything from a run that printed one.
   it against the deployed config for REGRESSIONS**, not just for new
   resolutions. Validate that diff with a planted mutant before believing a
   clean result.
+  🔴 **The replay diff is NECESSARY, NOT SUFFICIENT — it only replays terms he
+  ACTUALLY TYPED in the window.** A term he never happened to search is
+  invisible to it, so "0 regressions" from `--replay` is a claim about the
+  observed stream, not about the config. On 2026-08-19 it reported 0 while a new
+  `:pdt` label had taken `'dispatch'` away from `:acq`; the repo's own pinned
+  list caught it. **Always also run
+  `pytest scripts/collector/keylog/tests/test_espanso_detect.py`**, which pins
+  `_EXISTING_RESOLUTIONS` — and add the new snippet's own terms to it.
+  🔴 That file's `test_live_scraper_observes_the_real_config` is a POSITIVE
+  CONTROL pinned to a LONG `search_terms` list, so a scraper regex matching
+  nothing cannot make the other guards vacuously true. If your edit strips the
+  pinned snippet's terms, **MOVE the pin to another long list — never relax it
+  to `== []`**, which exercises no list-splitting and silently disarms the
+  control.
 - DEMAND reads the LOCAL transcripts only; re-run on the other host if you need
   its demand. Retune-vs-prune is a judgement call, so the tool never edits
   `nix/home.nix`. The keystroke expansion itself can only be checked by the user

--- a/claude/skills/espanso-audit/SKILL.md
+++ b/claude/skills/espanso-audit/SKILL.md
@@ -80,8 +80,9 @@ prune anything from a run that printed one.
   used snippet reachable only by an ambiguous query reads as 0. On
   2026-08-19 every observed ssh query was host-only (`lap`, `ssh wor`), which I
   read as "he doesn't care about the network axis" and proposed collapsing the
-  four `:ssh*` to nebula-only. Wrong: those queries fired nothing, so he fell
-  back to hand-typing — and `activity.events` showed all four endpoints live
+  four `:ssh*` to nebula-only. Wrong twice over: those queries were AMBIGUOUS,
+  not dead — they listed two picker rows and their fires were logged with no
+  trigger — and `activity.events` showed all four endpoints live
   with **LAN ahead of nebula** (laptop-LAN 4 shell invocations, workbench-LAN 3,
   workbench-nebula 1, laptop-nebula 0). The proposal would have deleted the two
   most-used. **0 fires is equally consistent with "unused" and "used constantly

--- a/claude/skills/espanso-audit/SKILL.md
+++ b/claude/skills/espanso-audit/SKILL.md
@@ -60,9 +60,24 @@ prune anything from a run that printed one.
 - **~97% of fires go through the Ctrl+Space SEARCH UI**, so `label` +
   `search_terms` ARE the interface. A zero-fire snippet is usually a
   discoverability bug, not a content one (`:acq`, 2026-08-05).
-- 🔴 **The SEARCH stream only records searches that FAILED — never infer what he
-  USES from it.** `--terms` shows queries that resolved to nothing, so it is a
-  sample of failures, and reading a preference off it inverts the meaning. On
+- 🔴 **AMBIGUOUS IS NOT DEAD. `--lint`'s "can never fire from the search UI" is
+  about the TELEMETRY, not about espanso** — and acting on it literally makes
+  the snippets worse. espanso's picker lists EVERY match and the user arrows to
+  one, so two matches means two rows. The only thing uniqueness buys is
+  `_attribute` being able to NAME the snippet; without it the fire is still a
+  fire, just recorded UNATTRIBUTED (`_close_search` emits a row either way).
+  A snippet with no `label` is worse off, not better: espanso falls back to
+  showing its raw expansion as the row text. On 2026-08-19 a pass stripped
+  `label`+`search_terms` from the two nebula ssh snippets to force uniqueness
+  and took `'nebula'`/`'mesh'`/`'remote'` from 2 picker rows to **0**. **Fix
+  ambiguity by changing which WORDS a snippet spells, never by removing its
+  label.** And judge any candidate on BOTH axes — picker rows *and* attribution;
+  a diff that improves attribution while blanking rows is a regression.
+- 🔴 **A zero-fire snippet is not an unused one — never infer USE from the
+  search stream.** `--terms` does report attributed searches (it prints an
+  `### attributed` section, so it is *not* only a sample of failures), but the
+  fires it cannot attribute vanish into an UNATTRIBUTED bucket, so a heavily
+  used snippet reachable only by an ambiguous query reads as 0. On
   2026-08-19 every observed ssh query was host-only (`lap`, `ssh wor`), which I
   read as "he doesn't care about the network axis" and proposed collapsing the
   four `:ssh*` to nebula-only. Wrong: those queries fired nothing, so he fell
@@ -93,6 +108,14 @@ prune anything from a run that printed one.
   list caught it. **Always also run
   `pytest scripts/collector/keylog/tests/test_espanso_detect.py`**, which pins
   `_EXISTING_RESOLUTIONS` — and add the new snippet's own terms to it.
+  **Pin a term the snippet's LABEL does not spell**, or the guard passes with
+  every `search_terms` entry deleted (three such pins shipped on 2026-08-19).
+  🔴 **Neither gate sweeps the whole input space — diff the WHOLE PREFIX
+  UNIVERSE.** Enumerate every prefix of every word in both configs' triggers,
+  labels and terms, resolve each against both, and report four buckets: picker
+  rows lost, attribution lost, attribution gained, resolution moved. That is
+  what surfaced the 8 blanked nebula prefixes AND 17 newly-ambiguous ones that
+  both the replay diff and the pinned list called clean.
   🔴 That file's `test_live_scraper_observes_the_real_config` is a POSITIVE
   CONTROL pinned to a LONG `search_terms` list, so a scraper regex matching
   nothing cannot make the other guards vacuously true. If your edit strips the

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -233,7 +233,7 @@ in
           # contained none of the words he actually types: feedback, dispatch,
           # process. Lead the label with "feedback" and add those three terms.
           { trigger = ":acq"; replace = "dispatch subagent to process feedback\nask clarifying questions and recommend improvements and anything useful to include before dispatching (include complete test coverage)"; label = "Process feedback: dispatch subagent + ask clarifying questions"; search_terms = ["feedback" "dispatch" "process" "ask" "clarify" "clarifying" "questions" "elicit" "scope" "include"]; }
-          { trigger = ":alo"; replace = "anything left outstanding from this thread?"; label = "Anything left outstanding?"; search_terms = ["anything" "left" "outstanding" ]; }
+          { trigger = ":alo"; replace = "anything left outstanding from this thread?"; label = "Anything left outstanding?"; search_terms = ["anything" "left" "outstanding" "loose" ]; }
           { trigger = ":kickoff"; replace = "give me the kickoff message to copy paste to next session"; label = "Kickoff message for next session"; search_terms = ["kickoff" "kick off" "next session" "copy paste" "handoff" "message"]; }
           # Added 2026-08-05 via /espanso-audit — both are WHOLE-STANDALONE-MESSAGE
           # shaped, the one shape that has stuck (:eos 72 fires, :kickoff 38); every
@@ -277,7 +277,6 @@ in
           # rather than "dispatch" on :pdt. Re-run
           # `espanso-usage.py --replay --config <candidate>` after ANY edit here
           # and diff it against the deployed config: 0 regressions is the gate.
-          { trigger = ":alo"; replace = "determine if anything is left open or unaddressed from this session and overall thread"; label = "Anything left open or unaddressed - session and thread"; search_terms = ["open" "left open" "loose" "outstanding" "remaining" "unfinished" "unaddressed"]; }
           { trigger = ":pdt"; replace = "proceed, dispatch, include complete test coverage"; label = "Proceed with complete test coverage"; search_terms = ["proceed" "coverage" "test coverage" "complete" "tests"]; }
           { trigger = ":cgt"; replace = "create a /clawgate task to pick up the issues"; label = "Create a clawgate ticket for the issues"; search_terms = ["clawgate" "ticket" "issues" "pick up"]; }
           # Removed 2026-07-25 via /espanso-audit — all keylog-evidence-backed:

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -186,9 +186,18 @@ in
           # prefix universe, checking BOTH picker rows and attribution — a
           # change that improves attribution while blanking picker rows is a
           # regression, and only the two-sided diff shows it.
-          { trigger = ":sshwn"; replace = "ssh zach@10.42.0.30"; label = "SSH rig via nebula mesh"; search_terms = ["nebula" "mesh" "remote" "rig"]; }
+          # 'rig' / 'portable' are deliberately NOT repeated in search_terms —
+          # they are already label words, and _token_matches reads labels, so a
+          # duplicate entry is dead config that only looks like a guard.
+          # They are COINED disambiguators, not measured queries: the repo says
+          # "rig" for the workbench (scripts/rig-control.sh, the rig-control bar
+          # button) but has no existing word for the laptop other than "laptop",
+          # which is the one word this snippet may not spell. Both nebula rows
+          # are found in practice via 'nebula'/'mesh'/'remote' + the picker;
+          # these words only stop the two rows reading identically.
+          { trigger = ":sshwn"; replace = "ssh zach@10.42.0.30"; label = "SSH rig via nebula mesh"; search_terms = ["nebula" "mesh" "remote"]; }
           { trigger = ":sshwl"; replace = "ssh zach@192.168.50.250"; label = "SSH workbench (LAN)"; search_terms = ["ssh" "workbench" "wb" "lan" "local"]; }
-          { trigger = ":sshln"; replace = "ssh zach@10.42.0.100"; label = "SSH portable via nebula mesh"; search_terms = ["nebula" "mesh" "remote" "portable"]; }
+          { trigger = ":sshln"; replace = "ssh zach@10.42.0.100"; label = "SSH portable via nebula mesh"; search_terms = ["nebula" "mesh" "remote"]; }
           { trigger = ":sshll"; replace = "ssh zach@192.168.50.155"; label = "SSH laptop (LAN)"; search_terms = ["ssh" "laptop" "lan" "local"]; }
 
           # hot singles

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -263,7 +263,7 @@ in
           # `espanso-usage.py --replay --config <candidate>` after ANY edit here
           # and diff it against the deployed config: 0 regressions is the gate.
           { trigger = ":alo"; replace = "determine if anything is left open or unaddressed from this session and overall thread"; label = "Anything left open or unaddressed - session and thread"; search_terms = ["open" "left open" "loose" "outstanding" "remaining" "unfinished" "unaddressed"]; }
-          { trigger = ":pdt"; replace = "proceed, dispatch, include complete test coverage"; label = "Proceed - dispatch with complete test coverage"; search_terms = ["proceed" "coverage" "test coverage" "complete"]; }
+          { trigger = ":pdt"; replace = "proceed, dispatch, include complete test coverage"; label = "Proceed with complete test coverage"; search_terms = ["proceed" "coverage" "test coverage" "complete"]; }
           { trigger = ":cgt"; replace = "create a /clawgate task to pick up the issues"; label = "Create a clawgate ticket for the issues"; search_terms = ["clawgate" "ticket" "issues" "pick up"]; }
           # Removed 2026-07-25 via /espanso-audit — all keylog-evidence-backed:
           #  ZERO-FIRE set — 0 keylog fires + short-form hand-typing; steering already in

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -157,32 +157,38 @@ in
           { trigger = ":hlt"; replace = "${workspace}/homelab-talos "; label = "homelab-talos path"; search_terms = ["infra"]; }
           { trigger = ":kuc"; replace = "${workspace}/kubeclaw "; label = "kubeclaw path"; search_terms = ["kubeclaw"]; }
 
-          # SSH connect — 2026-08-19 /espanso-audit. All four were `unreachable`
-          # in --lint: `_token_matches` tests a token as a SUBSTRING of the
-          # trigger, of any LABEL word, or of any search_term, so while two
-          # snippets per host both spell that host, a bare host query matches
-          # both and `_attribute` returns None. Measured: 'lap', 'lap ',
-          # 'ssh lap', 'ssh wor' all fired NOTHING.
-          # No search_terms edit can fix that — the label collides on its own.
-          # So the LAN variants keep the searchable host word and the nebula
-          # ones become direct-trigger-only (the `dashbaord` shape, which is the
-          # one shape with proven direct traffic). That costs nothing they had:
-          # --lint proves they were ALREADY unreachable from search, 0 fires.
-          # LAN owns the word because LAN is the MORE-USED endpoint — over the
-          # 13-day window, real `ssh` invocations in activity.events were
-          # laptop-LAN 4, workbench-LAN 3, workbench-nebula 1, laptop-nebula 0.
-          # 🔴 Do NOT "simplify" this by deleting the LAN or the nebula pair:
-          # all four endpoints are in live use. An earlier pass in this audit
-          # proposed collapsing to nebula-only after reasoning from the SEARCH
-          # stream alone — which only records searches that FAILED to resolve,
-          # so it cannot see the endpoints being hand-typed instead. It would
-          # have deleted the two most-used ones. Query the usage signal, not the
-          # search signal, before touching this block.
-          # Gate: `espanso-usage.py --replay --config <candidate>` — 0 regressions,
-          # 4 newly-resolving searches, unreachable 4 -> 0.
-          { trigger = ":sshwn"; replace = "ssh zach@10.42.0.30"; }
+          # SSH connect — 2026-08-19 /espanso-audit, CORRECTED after review.
+          # 🔴 READ THIS BEFORE TRUSTING `--lint`: an AMBIGUOUS search is NOT a
+          # failed one. espanso's search UI lists EVERY match and the user picks
+          # a row; two matches means two rows, not a dead query. What breaks on
+          # ambiguity is only `espanso_detect._attribute`, which returns None
+          # when a term hits >=2 snippets and so records the fire as
+          # UNATTRIBUTED. `--lint`'s wording ("can never fire from the search
+          # UI") describes the TELEMETRY, not espanso, and overclaims.
+          # The first pass here read that literally, concluded 'lap'/'ssh wor'
+          # "fired nothing", and STRIPPED the nebula pair's label+search_terms.
+          # That traded the user's discoverability for tidier telemetry and was
+          # strictly worse: 'nebula', 'mesh' and 'remote' went from 2 picker
+          # rows to ZERO, and with no label espanso falls back to showing the
+          # raw `ssh zach@10.42.0.30` as the row's description.
+          # So: labels stay. The nebula pair simply stops SPELLING the host
+          # word, which is what made the bare host query ambiguous — `rig` and
+          # `portable` carry the host sense instead. Net effect:
+          #   'lap' / 'ssh lap' -> :sshll, 'ssh wor' -> :sshwl   (now unique)
+          #   'nebula'/'mesh'/'remote'   -> both nebula rows     (picker, kept)
+          # All four endpoints are in live use — real `ssh` invocations in
+          # activity.events over the window were laptop-LAN 4, workbench-LAN 3,
+          # workbench-nebula 1, laptop-nebula 0 — so do NOT "simplify" by
+          # deleting either pair. An earlier pass proposed collapsing to
+          # nebula-only by reasoning from the search stream; that would have
+          # deleted the two most-used endpoints. Query the USAGE signal.
+          # Gate: build both configs and diff resolutions across the whole
+          # prefix universe, checking BOTH picker rows and attribution — a
+          # change that improves attribution while blanking picker rows is a
+          # regression, and only the two-sided diff shows it.
+          { trigger = ":sshwn"; replace = "ssh zach@10.42.0.30"; label = "SSH rig via nebula mesh"; search_terms = ["nebula" "mesh" "remote" "rig"]; }
           { trigger = ":sshwl"; replace = "ssh zach@192.168.50.250"; label = "SSH workbench (LAN)"; search_terms = ["ssh" "workbench" "wb" "lan" "local"]; }
-          { trigger = ":sshln"; replace = "ssh zach@10.42.0.100"; }
+          { trigger = ":sshln"; replace = "ssh zach@10.42.0.100"; label = "SSH portable via nebula mesh"; search_terms = ["nebula" "mesh" "remote" "portable"]; }
           { trigger = ":sshll"; replace = "ssh zach@192.168.50.155"; label = "SSH laptop (LAN)"; search_terms = ["ssh" "laptop" "lan" "local"]; }
 
           # hot singles
@@ -263,7 +269,7 @@ in
           # `espanso-usage.py --replay --config <candidate>` after ANY edit here
           # and diff it against the deployed config: 0 regressions is the gate.
           { trigger = ":alo"; replace = "determine if anything is left open or unaddressed from this session and overall thread"; label = "Anything left open or unaddressed - session and thread"; search_terms = ["open" "left open" "loose" "outstanding" "remaining" "unfinished" "unaddressed"]; }
-          { trigger = ":pdt"; replace = "proceed, dispatch, include complete test coverage"; label = "Proceed with complete test coverage"; search_terms = ["proceed" "coverage" "test coverage" "complete"]; }
+          { trigger = ":pdt"; replace = "proceed, dispatch, include complete test coverage"; label = "Proceed with complete test coverage"; search_terms = ["proceed" "coverage" "test coverage" "complete" "tests"]; }
           { trigger = ":cgt"; replace = "create a /clawgate task to pick up the issues"; label = "Create a clawgate ticket for the issues"; search_terms = ["clawgate" "ticket" "issues" "pick up"]; }
           # Removed 2026-07-25 via /espanso-audit — all keylog-evidence-backed:
           #  ZERO-FIRE set — 0 keylog fires + short-form hand-typing; steering already in

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -262,7 +262,7 @@ in
           # rather than "dispatch" on :pdt. Re-run
           # `espanso-usage.py --replay --config <candidate>` after ANY edit here
           # and diff it against the deployed config: 0 regressions is the gate.
-          { trigger = ":alo"; replace = "anything left open from this thread?"; label = "Anything left open from this thread?"; search_terms = ["open" "left open" "loose" "outstanding" "remaining" "unfinished"]; }
+          { trigger = ":alo"; replace = "determine if anything is left open or unaddressed from this session and overall thread"; label = "Anything left open or unaddressed - session and thread"; search_terms = ["open" "left open" "loose" "outstanding" "remaining" "unfinished" "unaddressed"]; }
           { trigger = ":pdt"; replace = "proceed, dispatch, include complete test coverage"; label = "Proceed - dispatch with complete test coverage"; search_terms = ["proceed" "coverage" "test coverage" "complete"]; }
           { trigger = ":cgt"; replace = "create a /clawgate task to pick up the issues"; label = "Create a clawgate ticket for the issues"; search_terms = ["clawgate" "ticket" "issues" "pick up"]; }
           # Removed 2026-07-25 via /espanso-audit — all keylog-evidence-backed:

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -157,10 +157,32 @@ in
           { trigger = ":hlt"; replace = "${workspace}/homelab-talos "; label = "homelab-talos path"; search_terms = ["infra"]; }
           { trigger = ":kuc"; replace = "${workspace}/kubeclaw "; label = "kubeclaw path"; search_terms = ["kubeclaw"]; }
 
-          # SSH connect
-          { trigger = ":sshwn"; replace = "ssh zach@10.42.0.30"; label = "SSH workbench (nebula)"; search_terms = ["ssh" "workbench" "wb" "nebula" "mesh" "remote"]; }
+          # SSH connect — 2026-08-19 /espanso-audit. All four were `unreachable`
+          # in --lint: `_token_matches` tests a token as a SUBSTRING of the
+          # trigger, of any LABEL word, or of any search_term, so while two
+          # snippets per host both spell that host, a bare host query matches
+          # both and `_attribute` returns None. Measured: 'lap', 'lap ',
+          # 'ssh lap', 'ssh wor' all fired NOTHING.
+          # No search_terms edit can fix that — the label collides on its own.
+          # So the LAN variants keep the searchable host word and the nebula
+          # ones become direct-trigger-only (the `dashbaord` shape, which is the
+          # one shape with proven direct traffic). That costs nothing they had:
+          # --lint proves they were ALREADY unreachable from search, 0 fires.
+          # LAN owns the word because LAN is the MORE-USED endpoint — over the
+          # 13-day window, real `ssh` invocations in activity.events were
+          # laptop-LAN 4, workbench-LAN 3, workbench-nebula 1, laptop-nebula 0.
+          # 🔴 Do NOT "simplify" this by deleting the LAN or the nebula pair:
+          # all four endpoints are in live use. An earlier pass in this audit
+          # proposed collapsing to nebula-only after reasoning from the SEARCH
+          # stream alone — which only records searches that FAILED to resolve,
+          # so it cannot see the endpoints being hand-typed instead. It would
+          # have deleted the two most-used ones. Query the usage signal, not the
+          # search signal, before touching this block.
+          # Gate: `espanso-usage.py --replay --config <candidate>` — 0 regressions,
+          # 4 newly-resolving searches, unreachable 4 -> 0.
+          { trigger = ":sshwn"; replace = "ssh zach@10.42.0.30"; }
           { trigger = ":sshwl"; replace = "ssh zach@192.168.50.250"; label = "SSH workbench (LAN)"; search_terms = ["ssh" "workbench" "wb" "lan" "local"]; }
-          { trigger = ":sshln"; replace = "ssh zach@10.42.0.100"; label = "SSH laptop (nebula)"; search_terms = ["ssh" "laptop" "nebula" "mesh" "remote"]; }
+          { trigger = ":sshln"; replace = "ssh zach@10.42.0.100"; }
           { trigger = ":sshll"; replace = "ssh zach@192.168.50.155"; label = "SSH laptop (LAN)"; search_terms = ["ssh" "laptop" "lan" "local"]; }
 
           # hot singles
@@ -226,6 +248,23 @@ in
           # queries ("in the meantime", "what can we do") tokenize onto this
           # snippet (see espanso_detect._term_matches).
           { trigger = ":mt"; replace = "tee up what we can do in the meantime: identify work that is INDEPENDENT of what is currently running — nothing touching the same files — then dispatch it in parallel with complete test coverage. if we are actually blocked until that finishes, say so plainly instead of inventing filler work."; label = "Meantime: tee up independent parallel work while that runs"; search_terms = ["meantime" "in the meantime" "while" "while that runs" "parallel" "queue" "queue up" "tee" "tee up" "wait" "blocked" "idle" "what can we do"]; }
+          # Added 2026-08-19 via /espanso-audit — all three WHOLE-STANDALONE-MESSAGE
+          # shaped, the only shape that has ever stuck here. Transcript demand over
+          # the 13-day window: "anything left open from this thread/session?" 13,
+          # "proceed, dispatch(, include complete test coverage)" 29+3, "create a
+          # /clawgate task to pick up the issues" 3.
+          # 🔴 The search_terms below are NOT free-form — `_token_matches` is a
+          # SUBSTRING test over trigger + label words + search_terms, so a new
+          # label can silently STEAL an existing snippet's searches. The obvious
+          # term for :cgt was "task", and 'ask' ⊂ 'task' would have hijacked all
+          # 58 of :acq's 'ask' fires — caught by replaying the real search stream,
+          # not by reading the list. Hence "ticket" here, and "coverage"/"proceed"
+          # rather than "dispatch" on :pdt. Re-run
+          # `espanso-usage.py --replay --config <candidate>` after ANY edit here
+          # and diff it against the deployed config: 0 regressions is the gate.
+          { trigger = ":alo"; replace = "anything left open from this thread?"; label = "Anything left open from this thread?"; search_terms = ["open" "left open" "loose" "outstanding" "remaining" "unfinished"]; }
+          { trigger = ":pdt"; replace = "proceed, dispatch, include complete test coverage"; label = "Proceed - dispatch with complete test coverage"; search_terms = ["proceed" "coverage" "test coverage" "complete"]; }
+          { trigger = ":cgt"; replace = "create a /clawgate task to pick up the issues"; label = "Create a clawgate ticket for the issues"; search_terms = ["clawgate" "ticket" "issues" "pick up"]; }
           # Removed 2026-07-25 via /espanso-audit — all keylog-evidence-backed:
           #  ZERO-FIRE set — 0 keylog fires + short-form hand-typing; steering already in
           #   RULES.md / slash-commands: :rnx, :pst ("proceed, dispatch" typed 40+×),

--- a/scripts/collector/keylog/tests/test_espanso_detect.py
+++ b/scripts/collector/keylog/tests/test_espanso_detect.py
@@ -565,14 +565,17 @@ def test_live_scraper_observes_the_real_config():
     assert "what can we do" in by_trig[":mt"]["search_terms"]
     assert len(by_trig[":mt"]["search_terms"]) == 13
     assert by_trig[":kickoff"]["label"] == "Kickoff message for next session"
-    # The 2026-08-19 strip is itself pinned: :sshwn/:sshln are deliberately
-    # direct-trigger-only so the LAN pair owns the searchable host word. If a
-    # future edit re-adds terms here, the four ssh resolutions below go
-    # ambiguous again — which is the bug this shape exists to prevent.
-    assert by_trig[":sshwn"]["search_terms"] == []
-    assert by_trig[":sshwn"]["label"] == ""
-    assert by_trig[":sshln"]["search_terms"] == []
-    assert by_trig[":sshln"]["label"] == ""
+    # 🔴 Every snippet must keep a LABEL. espanso's picker falls back to showing
+    # the raw `replace` text as the row description when a label is absent, and
+    # a label is also the main thing a query can match. A 2026-08-19 pass
+    # stripped the label+search_terms from :sshwn/:sshln — which blanked the
+    # picker for 'nebula'/'mesh'/'remote' entirely. `dashbaord` is the one
+    # deliberate exception (a typo-correction fired by typing it verbatim).
+    labelless = sorted(t for t, m in by_trig.items() if not m["label"])
+    assert labelless == ["dashbaord"], (
+        "these snippets have no label, so espanso will show their raw expansion "
+        "as the picker row and most queries cannot reach them: " + repr(labelless)
+    )
 
 
 # The queries the 2026-08-05 /espanso-audit measured him actually typing (plus
@@ -613,6 +616,11 @@ _EXISTING_RESOLUTIONS = [
     ("rit", ":eos"), ("kick", ":kickoff"), ("kic", ":kickoff"),
     ("recom", ":rna"), ("recommend", ":rna"),
     ("limit", ":lr"), ("resume", ":lr"), ("restored", ":lr"),
+    # 'ask' is the HIGHEST-traffic term in the whole config (58 fires in the
+    # 2026-08-06..19 window) and was the one term not pinned here. A snippet
+    # labelled with the word "task" silently takes it, because 'ask' ⊂ 'task'
+    # — that exact mutant survived a full green suite on 2026-08-19.
+    ("ask", ":acq"),
     ("feedback", ":acq"), ("dispatch", ":acq"), ("process", ":acq"),
     ("cc", ":cc"), ("kubecl", ":kuc"), ("spine", ":csc"), ("orch", ":cmo"),
     ("home", ":hlt"), ("prod", ":cpk"), ("datap", ":cdp"), ("civit prod", ":cpk"),
@@ -632,14 +640,19 @@ def test_live_existing_resolutions_not_made_ambiguous():
     )
 
 
-# REGRESSION coverage for the 2026-08-19 /espanso-audit. Each of the four ssh
-# terms was measured firing NOTHING on the pre-change config (`_attribute` ->
-# None, because two snippets per host both spelled that host), so this list is
-# RED at the parent commit and green here — not an invariant guard.
-# The three trailing entries pin the snippets added in the same commit.
+# REGRESSION coverage for the 2026-08-19 /espanso-audit. On the pre-change
+# config each ssh term was AMBIGUOUS (`_attribute` -> None over two snippets
+# that both spelled the host), so the fire was recorded UNATTRIBUTED. RED at
+# merge-base a29b97b, green here — not an invariant guard.
+#
+# 🔴 Each trailing entry pins a term the snippet's LABEL does NOT contain, so
+# deleting its search_terms kills the test. The first version pinned
+# 'unaddressed'/'proceed'/'clawgate', every one of which is spelled in its own
+# label — deleting all three snippets' search_terms left the suite fully green.
 _AUDIT_2026_08_19_RESOLUTIONS = [
     ("lap", ":sshll"), ("ssh lap", ":sshll"), ("ssh wor", ":sshwl"),
-    ("unaddressed", ":alo"), ("proceed", ":pdt"), ("clawgate", ":cgt"),
+    ("rig", ":sshwn"), ("portable", ":sshln"),
+    ("loose", ":alo"), ("tests", ":pdt"), ("pick up", ":cgt"),
 ]
 # NOT listed: bare "wor". It stays ambiguous with :mt, whose label says
 # "parallel WORK while that runs" — and it was never a query he typed (the
@@ -657,6 +670,36 @@ def test_live_audit_2026_08_19_resolutions():
     assert not bad, (
         "the 2026-08-19 audit's resolutions regressed "
         "(term -> (expected, actual, matching snippets)): " + repr(bad)
+    )
+
+
+# 🔴 PICKER coverage — a DIFFERENT question from attribution above.
+# espanso lists EVERY match as a row and the user picks one; ambiguity means
+# "two rows", NOT a dead query. Only `_attribute` needs uniqueness, and only so
+# telemetry can name the snippet. Conflating the two is what led a 2026-08-19
+# pass to STRIP these labels to force uniqueness — which blanked the picker for
+# every word that describes the nebula endpoints ('nebula'/'mesh'/'remote' went
+# from 2 rows to 0). Assert the rows stay REACHABLE; do not demand uniqueness.
+_PICKER_ROWS = [
+    ("nebula", {":sshwn", ":sshln"}),
+    ("mesh", {":sshwn", ":sshln"}),
+    ("remote", {":sshwn", ":sshln"}),
+    ("lan", {":sshwl", ":sshll"}),
+    ("ssh", {":sshwn", ":sshwl", ":sshln", ":sshll"}),
+]
+
+
+def test_live_picker_rows_stay_reachable():
+    """A query that listed rows must keep listing them, unique or not."""
+    d = _live_det()
+    bad = {}
+    for term, want in _PICKER_ROWS:
+        got = {t for t in d.ts.triggers if d._term_matches(term, t)}
+        if not want.issubset(got):
+            bad[term] = {"expected at least": sorted(want), "actual": sorted(got)}
+    assert not bad, (
+        "these queries no longer reach snippets they used to list in the "
+        "espanso picker (term -> rows): " + repr(bad)
     )
 
 

--- a/scripts/collector/keylog/tests/test_espanso_detect.py
+++ b/scripts/collector/keylog/tests/test_espanso_detect.py
@@ -540,9 +540,15 @@ def test_live_scraper_observes_the_real_config():
     The pinned metadata is READ OFF nix/home.nix, never off the scraper's own
     output — deriving it from the implementation is exactly what would make this
     control vacuous. (`:date` used to be the metadata pin; #351 pruned that
-    snippet, so the pin moved to `:sshwn`, added in #134 and untouched since,
-    whose `search_terms` list is longer and therefore a stricter test of the
-    list-splitting regex.)
+    snippet, so the pin moved to `:sshwn`, whose `search_terms` list was longer
+    and therefore a stricter test of the list-splitting regex. The 2026-08-19
+    audit then STRIPPED `:sshwn` to direct-trigger-only to make the search UI
+    unambiguous, which would have left this control asserting `== []` — i.e.
+    exactly the vacuous state the paragraph above forbids, since an empty list
+    exercises no splitting at all. So the pin moved again, to `:eos` for a long
+    single-word list and `:mt` for MULTI-WORD entries, which are the strictest
+    case for the regex. Whenever a pinned snippet's terms are removed, MOVE this
+    pin to another long list — never relax it to the empty one.)
     """
     base = _live_base()
     trigs = [m["trigger"] for m in base["matches"]]
@@ -550,10 +556,23 @@ def test_live_scraper_observes_the_real_config():
     assert len(set(trigs)) == len(trigs), "duplicate trigger in nix/home.nix"
     assert ":sshwn" in trigs and "dashbaord" in trigs
     by_trig = {m["trigger"]: m for m in base["matches"]}
-    assert by_trig[":sshwn"]["search_terms"] == [
-        "ssh", "workbench", "wb", "nebula", "mesh", "remote"]
-    assert by_trig[":sshwn"]["label"] == "SSH workbench (nebula)"
+    assert by_trig[":eos"]["search_terms"] == [
+        "end", "session", "wrap", "handoff", "skills", "review", "update",
+        "docs", "ritual", "prune", "evict", "bloat"]
+    assert by_trig[":eos"]["label"].startswith("End-of-session ritual")
+    # Multi-word entries: the case a naive whitespace split would shred.
+    assert "in the meantime" in by_trig[":mt"]["search_terms"]
+    assert "what can we do" in by_trig[":mt"]["search_terms"]
+    assert len(by_trig[":mt"]["search_terms"]) == 13
     assert by_trig[":kickoff"]["label"] == "Kickoff message for next session"
+    # The 2026-08-19 strip is itself pinned: :sshwn/:sshln are deliberately
+    # direct-trigger-only so the LAN pair owns the searchable host word. If a
+    # future edit re-adds terms here, the four ssh resolutions below go
+    # ambiguous again — which is the bug this shape exists to prevent.
+    assert by_trig[":sshwn"]["search_terms"] == []
+    assert by_trig[":sshwn"]["label"] == ""
+    assert by_trig[":sshln"]["search_terms"] == []
+    assert by_trig[":sshln"]["label"] == ""
 
 
 # The queries the 2026-08-05 /espanso-audit measured him actually typing (plus
@@ -610,6 +629,34 @@ def test_live_existing_resolutions_not_made_ambiguous():
     assert not bad, (
         "search terms regressed (term -> (expected, actual, matching snippets)): "
         + repr(bad)
+    )
+
+
+# REGRESSION coverage for the 2026-08-19 /espanso-audit. Each of the four ssh
+# terms was measured firing NOTHING on the pre-change config (`_attribute` ->
+# None, because two snippets per host both spelled that host), so this list is
+# RED at the parent commit and green here — not an invariant guard.
+# The three trailing entries pin the snippets added in the same commit.
+_AUDIT_2026_08_19_RESOLUTIONS = [
+    ("lap", ":sshll"), ("ssh lap", ":sshll"), ("ssh wor", ":sshwl"),
+    ("unaddressed", ":alo"), ("proceed", ":pdt"), ("clawgate", ":cgt"),
+]
+# NOT listed: bare "wor". It stays ambiguous with :mt, whose label says
+# "parallel WORK while that runs" — and it was never a query he typed (the
+# measured one is the two-token "ssh wor"). Asserting it would have been an
+# expectation invented from the fix rather than read off the search stream.
+
+
+def test_live_audit_2026_08_19_resolutions():
+    d = _live_det()
+    bad = {}
+    for term, want in _AUDIT_2026_08_19_RESOLUTIONS:
+        got = d._attribute(term)
+        if got != want:
+            bad[term] = (want, got, [t for t in d.ts.triggers if d._term_matches(term, t)])
+    assert not bad, (
+        "the 2026-08-19 audit's resolutions regressed "
+        "(term -> (expected, actual, matching snippets)): " + repr(bad)
     )
 
 

--- a/scripts/collector/keylog/tests/test_espanso_detect.py
+++ b/scripts/collector/keylog/tests/test_espanso_detect.py
@@ -563,7 +563,10 @@ def test_live_scraper_observes_the_real_config():
     # Multi-word entries: the case a naive whitespace split would shred.
     assert "in the meantime" in by_trig[":mt"]["search_terms"]
     assert "what can we do" in by_trig[":mt"]["search_terms"]
-    assert len(by_trig[":mt"]["search_terms"]) == 13
+    # `>=` not `==`: an exact count reds on adding an unrelated :mt term, which
+    # breaks nothing this control is about (it exists to prove the list-splitting
+    # regex works, and the two multi-word asserts above carry that).
+    assert len(by_trig[":mt"]["search_terms"]) >= 13
     assert by_trig[":kickoff"]["label"] == "Kickoff message for next session"
     # 🔴 Every snippet must keep a LABEL. espanso's picker falls back to showing
     # the raw `replace` text as the row description when a label is absent, and
@@ -571,10 +574,13 @@ def test_live_scraper_observes_the_real_config():
     # stripped the label+search_terms from :sshwn/:sshln — which blanked the
     # picker for 'nebula'/'mesh'/'remote' entirely. `dashbaord` is the one
     # deliberate exception (a typo-correction fired by typing it verbatim).
+    # `<=` not `==`: `dashbaord` is a zero-fire typo-correction and pruning it is
+    # a legitimate outcome of /espanso-audit, which `==` would turn red.
     labelless = sorted(t for t, m in by_trig.items() if not m["label"])
-    assert labelless == ["dashbaord"], (
+    assert set(labelless) <= {"dashbaord"}, (
         "these snippets have no label, so espanso will show their raw expansion "
-        "as the picker row and most queries cannot reach them: " + repr(labelless)
+        "as the picker row and most queries cannot reach them: "
+        + repr([t for t in labelless if t != "dashbaord"])
     )
 
 
@@ -590,6 +596,9 @@ _MT_TERMS = [
 
 
 def test_live_mt_search_terms_all_resolve_to_mt():
+    # ANTI-VACUITY: emptying the table below left this test green (measured
+    # 2026-08-19). A floor, not an exact count — adding terms is fine.
+    assert len(_MT_TERMS) >= 14, "_MT_TERMS shrank; this guard weakens silently"
     d = _live_det()
     unresolved = {}
     for term in _MT_TERMS:
@@ -628,6 +637,14 @@ _EXISTING_RESOLUTIONS = [
 
 
 def test_live_existing_resolutions_not_made_ambiguous():
+    # ANTI-VACUITY: emptying _EXISTING_RESOLUTIONS left this green (measured
+    # 2026-08-19), so the cheap way to "fix" a future failure is to delete the
+    # row that broke — which is exactly the regression this guard exists to
+    # catch. A floor, not an exact count.
+    assert len(_EXISTING_RESOLUTIONS) >= 20, (
+        "_EXISTING_RESOLUTIONS shrank — a pinned resolution was deleted rather "
+        "than fixed; that is the failure mode, not the fix"
+    )
     d = _live_det()
     bad = {}
     for term, want in _EXISTING_RESOLUTIONS:
@@ -645,10 +662,16 @@ def test_live_existing_resolutions_not_made_ambiguous():
 # that both spelled the host), so the fire was recorded UNATTRIBUTED. RED at
 # merge-base a29b97b, green here — not an invariant guard.
 #
-# 🔴 Each trailing entry pins a term the snippet's LABEL does NOT contain, so
-# deleting its search_terms kills the test. The first version pinned
+# 🔴 The LAST THREE pin a term the snippet's LABEL does NOT contain, so deleting
+# its search_terms kills the test. The first version pinned
 # 'unaddressed'/'proceed'/'clawgate', every one of which is spelled in its own
 # label — deleting all three snippets' search_terms left the suite fully green.
+# ('rig', ':sshwn') and ('portable', ':sshln') resolve via their LABEL by
+# design: for those two the label IS the interface, and their search_terms hold
+# no unique word at all. They pin the RESOLUTION, not the search_terms — an
+# earlier version of this comment claimed every entry was label-independent,
+# and a mutation sweep showed these two survive deleting the entry they were
+# supposed to guard. Do not count them as search_terms coverage.
 _AUDIT_2026_08_19_RESOLUTIONS = [
     ("lap", ":sshll"), ("ssh lap", ":sshll"), ("ssh wor", ":sshwl"),
     ("rig", ":sshwn"), ("portable", ":sshln"),
@@ -661,6 +684,10 @@ _AUDIT_2026_08_19_RESOLUTIONS = [
 
 
 def test_live_audit_2026_08_19_resolutions():
+    # ANTI-VACUITY: emptying the table left this green (measured 2026-08-19).
+    assert len(_AUDIT_2026_08_19_RESOLUTIONS) >= 8, (
+        "_AUDIT_2026_08_19_RESOLUTIONS shrank; this guard weakens silently"
+    )
     d = _live_det()
     bad = {}
     for term, want in _AUDIT_2026_08_19_RESOLUTIONS:
@@ -690,7 +717,20 @@ _PICKER_ROWS = [
 
 
 def test_live_picker_rows_stay_reachable():
-    """A query that listed rows must keep listing them, unique or not."""
+    """A query that listed rows must keep listing them, unique or not.
+
+    ANTI-VACUITY first: the relation below is `issubset`, deliberately (rows are
+    additive — a new snippet spelling 'nebula' is not a regression), but that
+    makes the cheap way to green a future failure "shrink `want`", degrading the
+    guard to nothing. Emptying the table, or any one expectation, must fail
+    HERE rather than pass silently.
+    """
+    assert _PICKER_ROWS, "_PICKER_ROWS is empty — this guard would pass vacuously"
+    empty = [term for term, want in _PICKER_ROWS if not want]
+    assert not empty, (
+        "these _PICKER_ROWS entries expect no rows, so they assert nothing "
+        "(set().issubset(x) is always True): " + repr(empty)
+    )
     d = _live_det()
     bad = {}
     for term, want in _PICKER_ROWS:

--- a/scripts/session-analysis/espanso-usage.py
+++ b/scripts/session-analysis/espanso-usage.py
@@ -117,11 +117,21 @@ DEMAND_TEXTS = {
     # pre-rewrite text and the eviction-half rewrite, because transcripts from
     # earlier in any window still carry the old wording.
     ":eos":     ["may need updating", "write the handoff first"],
-    ":acq":     ["recommend anything you think would be useful to include"],
+    # :acq's probe was "recommend anything you think would be useful to
+    # include", which matched NEITHER the pre- nor the post-2026-08-19
+    # expansion — a silent UNPROBED on the config's second-busiest snippet.
+    # Match the opener instead: it is the half that has never been reworded.
+    ":acq":     ["dispatch subagent to process feedback"],
     ":kickoff": ["kickoff message to copy paste to next session"],
     ":rna":     ["recommend next actions"],
     ":lr":      ["limit restored, resume agent"],
     ":mt":      ["tee up what we can do in the meantime"],
+    # Added 2026-08-19 with the snippets themselves. Without these the next
+    # /espanso-audit reports them UNPROBED and cannot re-measure the transcript
+    # demand that justified adding them in the first place.
+    ":alo":     ["left open or unaddressed from this session"],
+    ":pdt":     ["proceed, dispatch, include complete test coverage"],
+    ":cgt":     ["clawgate task to pick up the issues"],
 }
 # Substrings that DISQUALIFY a demand hit (one expansion containing another).
 DEMAND_EXCLUDE = {":cdp": ["prod-kubeconfig"]}
@@ -746,11 +756,23 @@ def declared_terms(ts, trig):
 def lint(ts):
     """Offline findings, worst first.
 
-    `unreachable` is the one that matters: `_attribute` returns None whenever a
-    term matches >=2 snippets, so a snippet with NO uniquely-resolving term
-    cannot be reached through the search UI AT ALL — which is how the four
-    :ssh* snippets read as dead while being searched for weekly. The old
-    "no trigger is a prefix of another" check is kept, but it has never fired.
+    🔴 EVERY finding here is about ATTRIBUTION, never about reachability.
+    espanso's search UI lists EVERY match as a row and the user picks one, so a
+    term matching >=2 snippets shows two rows — it does NOT fail. What breaks is
+    `_attribute`, which returns None on >=2 matches, so the fire is recorded
+    UNATTRIBUTED (`_close_search` emits the row either way). A snippet with no
+    uniquely-resolving term is therefore INVISIBLE TO THIS TOOL, not unreachable
+    to the user.
+
+    This docstring used to say such a snippet "cannot be reached through the
+    search UI AT ALL". That is false, and on 2026-08-19 an audit acted on it:
+    it stripped `label`+`search_terms` from the two nebula :ssh* snippets to
+    force uniqueness, which took 'nebula'/'mesh'/'remote' from 2 picker rows to
+    ZERO and made those rows render as their raw `ssh zach@...` expansion
+    (espanso falls back to the replacement text when a label is absent).
+    Fix ambiguity by changing which WORDS a snippet spells — never by removing
+    its label. The old "no trigger is a prefix of another" check is kept, but it
+    has never fired.
     """
     findings = []
     det = EspansoDetector(ts)
@@ -788,8 +810,11 @@ def lint(ts):
         if terms and not unique:
             findings.append({"kind": "unreachable", "trigger": trig,
                              "message": "NO declared term resolves uniquely to it — "
-                                        "every search that reaches it is ambiguous, "
-                                        "so it can never fire from the search UI"})
+                                        "every search that reaches it is ambiguous, so "
+                                        "its fires are recorded UNATTRIBUTED. It is "
+                                        "still reachable: espanso lists it as one row "
+                                        "among several. Fix by changing which WORDS it "
+                                        "spells — NEVER by removing its label"})
     for term in sorted(owners):
         m = _matches(term)
         if len(m) > 1:
@@ -804,10 +829,14 @@ _LINT_ORDER = {"unreachable": 0, "self-miss": 1, "undiscoverable": 2,
 
 
 def render_lint(findings, config_path):
-    out = [f"## LINT — offline discoverability check ({config_path})", "",
-           "   `_attribute` returns None when a term matches >=2 snippets, so an",
-           "   AMBIGUOUS term is a search that silently fires nothing — and a",
-           "   snippet with no unique term is UNREACHABLE from the search UI.", ""]
+    out = [f"## LINT — offline ATTRIBUTION check ({config_path})", "",
+           "   🔴 AMBIGUOUS IS NOT DEAD. espanso lists EVERY match as a row and",
+           "   the user picks one, so an ambiguous term still fires. What breaks",
+           "   is `_attribute` (None on >=2 matches), so the fire is logged",
+           "   UNATTRIBUTED — these findings are about TELEMETRY, not reach.",
+           "   Fix one by changing which WORDS a snippet spells. NEVER by",
+           "   removing its label: espanso then shows the raw expansion as the",
+           "   row text, and the snippet loses the picker entirely.", ""]
     if not findings:
         out.append("  (no findings)")
         out.append("")


### PR DESCRIPTION
`/espanso-audit` over 2026-08-06 → 08-19. **231 fires, 90% attributed, nothing DEAD — zero prune candidates.**

> ⚠️ The first version of this description was **wrong** about why the `:ssh*` snippets showed zero fires, and the first two commits acted on it. Both are retracted in [this comment](https://github.com/innovation-upstream/devrc/pull/592#issuecomment-5352400248), which is kept as the record. What follows is the corrected account.

## The actual problem: attribution, not reachability

`--lint` reported the four `:ssh*` snippets as `unreachable`. That word is wrong, and the tool now says so itself.

espanso's search UI lists **every** match as a row and the user picks one — two matches means two rows, not a dead query. What breaks on ambiguity is `espanso_detect._attribute`, which returns `None` on ≥2 matches, so `_close_search` logs the fire with **no trigger**. `'lap'` was never dead; it listed two rows and its fires were recorded UNATTRIBUTED.

Because two snippets per host both spelled that host (`_token_matches` is a substring test over trigger + label words + search_terms), every bare host query was ambiguous.

**Fix: the nebula pair stops *spelling* the host word.** Labels stay — `rig` / `portable` carry the host sense instead.

| query | before | after |
|---|---|---|
| `lap`, `ssh lap` | 2 rows, unattributed | **1 row → `:sshll`** |
| `ssh wor` | 2 rows, unattributed | **1 row → `:sshwl`** |
| `nebula` / `mesh` / `remote` | 2 rows | 2 rows (unchanged) |
| `rig` / `portable` | — | new unique handles |

All four endpoints stay live: real `ssh` invocations in `activity.events` were laptop-LAN **4**, workbench-LAN **3**, workbench-nebula **1**, laptop-nebula **0**.

`rig` and `portable` are **coined disambiguators, not measured queries** — the repo says "rig" for the workbench, but has no word for the laptop other than "laptop", which is the one word `:sshln` may not spell. Both nebula rows are found via `nebula`/`mesh`/`remote` + the picker; these words only stop the two rows reading identically.

## Three new snippets

`:alo` "determine if anything is left open or unaddressed from this session and overall thread" · `:pdt` "proceed, dispatch, include complete test coverage" · `:cgt` "create a /clawgate task to pick up the issues".

`:cgt` says **"ticket"**, not "task" — `'ask'` ⊂ `'task'` would hijack all 58 of `:acq`'s `'ask'` fires.

## The false claim, fixed at its source

`espanso-usage.py`'s own `lint()` docstring, its `unreachable` message and `render_lint()`'s header all asserted an ambiguous term "silently fires nothing" / is "UNREACHABLE from the search UI". That is the sentence that caused this. All three now state that the findings are about **attribution**, and that the fix is to change which *words* a snippet spells — **never** to remove its label (espanso then shows the raw expansion as the row text).

## Guards

| guard | what it pins |
|---|---|
| `_EXISTING_RESOLUTIONS` | now includes `("ask", ":acq")` — the config's highest-traffic term, previously unpinned |
| `_AUDIT_2026_08_19_RESOLUTIONS` | regression coverage; last three pin a term the label does **not** spell |
| `_PICKER_ROWS` (new) | **rows**, not uniqueness — the axis nothing guarded and this PR regressed |
| labelless check | every snippet must keep a label (`dashbaord` excepted) |

**Three guards were vacuous** — emptying `_MT_TERMS`, `_EXISTING_RESOLUTIONS` or `_AUDIT_2026_08_19_RESOLUTIONS` left the suite green, so deleting the row that broke was a way to "fix" a failure. Two predate this PR. All now carry floors; `_PICKER_ROWS` also rejects an empty table and any empty expectation (`set().issubset(x)` is always True).

Also: `:acq`'s demand probe matched **neither** the pre- nor post-rewrite expansion, silently un-probing the second-busiest snippet; `DEMAND_TEXTS` gains the three new snippets so the next audit can re-measure them.

## Verification

- **Full `checks.pytests` on the merged tree: `RESULT: all good`, collected 12877, passed 12876, skipped 1, failed 0**, 0 timeout panics.
- **Prefix-universe diff** (563 probes, base vs head): **0 picker rows lost**, 4 ssh attributions gained. 19 prefixes (`proc`, `res`, `main`…) become ambiguous — under the corrected framing that costs *telemetry attribution*, not reachability, and is the unavoidable price of adding vocabulary. Stated, not omitted.
- **Mutation battery**: 8/8 config mutants killed (incl. the `'ask'` hijack, three `search_terms` deletions, a re-strip, a host-word re-spell) with a green positive control; all four emptied-table mutants killed. *The first attempt at those four survived because the mutants were malformed — `[] or [...]` is the non-empty list — and were rebuilt before being believed.*
- Regression test confirmed **red at merge-base `a29b97b`** with the diagnosed mechanism, green at head.

## Not verified

- **No CI check has run on this PR** (`statusCheckRollup` is empty). The local gate above is the only test evidence.
- **Every ClickHouse figure is unverifiable by a reviewer** — 231 fires, the 58 `'ask'` fires, and the `activity.events` ssh counts that are the *sole* basis for "LAN owns the word".
- Every "picker row" claim here is computed with `_term_matches`, the **telemetry** matcher. The correction in this PR is precisely that the telemetry model ≠ espanso, so read those as "as modelled by `_term_matches`". espanso's real search matching was not verified from this repo.
- The keystroke expansion itself can only be confirmed by typing a trigger after `ship.sh`; then run `--verify-deploy`.
