### PR TITLE
fix(initiatives): the abandoned-worker test raced production's own socket timeout, and went red for a reason that was not the bug

### DIFF
--- a/scripts/initiatives/tasks.py
+++ b/scripts/initiatives/tasks.py
@@ -249,7 +249,7 @@ def _run_with_deadline(fn, deadline: float, *, label: str = "clawgate fetch"):
 
 
 def _get(url: str, token: str, *, deadline: float = FETCH_DEADLINE,
-         max_bytes: int = MAX_RESPONSE_BYTES) -> str:
+         max_bytes: int = MAX_RESPONSE_BYTES, clock=time.monotonic) -> str:
     """Isolated network GET (stdlib urllib) — injected/mocked in tests. Returns the body.
 
     Runs INSIDE the deadline thread, so its own guards are belt-and-braces for cleanup rather
@@ -257,8 +257,20 @@ def _get(url: str, token: str, *, deadline: float = FETCH_DEADLINE,
     body chunks (so an abandoned worker stops dribbling — this is why the body is read with
     `read1`, see the loop), and a `max_bytes` cap — the queue endpoint has no server-side
     `LIMIT` and rows carry full task bodies, so an unbounded `resp.read()` on the render path
-    is an amplifier we decline."""
-    started = time.monotonic()
+    is an amplifier we decline.
+
+    `clock` is a SEAM, defaulting to the real monotonic clock, and matches the one
+    `LinkedTaskCache` already takes as `now`. It exists because the per-operation socket
+    timeout below is `min(SOCKET_TIMEOUT, deadline)`: whenever the caller picks a deadline
+    under `SOCKET_TIMEOUT` the two become EQUAL, so a `read1` that blocks past the deadline is
+    a coin-flip between this loop's re-check and `socket.timeout` — and `socket.timeout` IS
+    `TimeoutError` on py3.10+, so the two are not even distinguishable by type. Nothing in
+    production cares which fires (both degrade to "no linked tasks"), but a test that asserts
+    WHICH guard ended the read cannot separate them in real time. Injecting the clock lets a
+    test pin the deadline DECISION while leaving the socket timeout at its maximum, instead of
+    racing the two. Do not use it to extend a deadline — it decides one, it does not widen it.
+    """
+    started = clock()
     req = urllib.request.Request(
         url, method="GET",
         headers={"Accept": "application/json", "Authorization": f"Bearer {token}"},
@@ -270,7 +282,7 @@ def _get(url: str, token: str, *, deadline: float = FETCH_DEADLINE,
         chunks: list[bytes] = []
         total = 0
         while True:
-            if (time.monotonic() - started) >= deadline:
+            if (clock() - started) >= deadline:
                 raise TimeoutError(
                     f"body read exceeded the {deadline}s wall-clock deadline "
                     f"after {total} bytes")

--- a/scripts/initiatives/tests/test_tasks.py
+++ b/scripts/initiatives/tests/test_tasks.py
@@ -445,23 +445,59 @@ def test_abandoned_worker_dies_promptly_on_a_chunk_spanning_body():
 
     This test asserts WHEN THE WORKER DIES, not what it parsed — a body that merely parses
     correctly does not reproduce the bug. So: a body several READ_CHUNKs long, paced so that
-    assembling ONE chunk takes ~6x the deadline, and every individual send well inside the
-    socket timeout — leaving the between-chunk clock re-check as the only thing that can end
-    the read. The worker function returning is the observable: `_run_with_deadline`'s target
-    does nothing afterwards, so the thread exits with it.
+    assembling ONE chunk takes far longer than the worker is allowed to outlive its
+    abandonment, and every individual send well inside the socket timeout — leaving the
+    between-chunk clock re-check as the only thing that can end the read. The worker function
+    returning is the observable: `_run_with_deadline`'s target does nothing afterwards, so the
+    thread exits with it.
+
+    🔴 WHY THE CLOCK IS INJECTED (2026-08-20) — this test used to FLAKE, and it flaked in the
+    one way a "died for the right reason" assertion must not: red for a reason that is not the
+    bug. Production reads with `urlopen(timeout=min(SOCKET_TIMEOUT, deadline))`, so the old
+    `deadline = 0.4` made the PER-OPERATION socket timeout EQUAL the deadline. Both then raced
+    to end the same blocked `read1`, and `socket.timeout` IS `TimeoutError`, so the type
+    assertion below could not tell them apart — but a socket timeout says only "timed out",
+    with no byte count, so the byte-count assertion failed. Any single stall of the paced
+    sender lasting a whole deadline (a loaded box running the full gate) handed the race to
+    the socket timeout. Measured 2026-08-20 by injecting the stall rather than loading the
+    machine: 0.45s stall at deadline=0.4 gave "timed out" 3/3, versus the module's own
+    "...after 12288 bytes" 1/1 unstalled.
+
+    The fix separates the two clocks instead of widening either. The JOIN deadline — what
+    actually abandons the worker — stays real wall clock at `join_deadline`. The BODY-READ
+    deadline decision is made by `abandonment_clock`, which blows the instant the caller has
+    abandoned the worker, so the re-check fires on the very next chunk. The deadline handed to
+    `_get` is then `SOCKET_TIMEOUT`, which pins the per-operation timeout at its MAXIMUM
+    (`min(SOCKET_TIMEOUT, SOCKET_TIMEOUT)`) — 2.0s against a 0.02s pacing gap, and strictly
+    longer than the 1.0s promptness bound this test allows. A socket timeout can therefore no
+    longer be the thing that ends the read before the promptness assertion has already spoken:
+    that failure mode is now unreachable, not merely rarer.
+
+    None of this weakens the guard. The pacing that gives the test its power is unchanged in
+    kind — with `read` the worker is still stuck mid-chunk for `chunk_seconds` (~2.6s) and
+    still fails the promptness assertion, which is the mutation that was re-run to confirm it.
     """
     import re
     import threading
     import time
 
-    piece, gap = 2048, 0.08
+    # Finer pacing than the defect-era 2048/0.08 — same chunk_seconds, but the worker comes
+    # back to the clock ~4x sooner after being abandoned, so the promptness bound is not
+    # spending most of its budget waiting for the next send.
+    piece, gap = 512, 0.02
     body = ("[" + ",".join(
         json.dumps(_task(i, ["initiative:alpha"], title="t" * 240)) for i in range(1000)
     ) + "]").encode()
     assert len(body) > 2 * tasks.READ_CHUNK, "the body must SPAN chunks to reproduce this"
     chunk_seconds = (tasks.READ_CHUNK / piece) * gap    # what ONE read() would block for
-    deadline = 0.4
-    assert chunk_seconds > 5 * deadline, "the pacing must dwarf the deadline"
+    join_deadline = 0.4      # real wall clock: when the caller gives up and abandons the worker
+    prompt_bound = 1.0       # how long after that the abandoned worker may still be running
+    # With `read` the worker is stuck for a whole chunk; that must dwarf the promptness bound,
+    # or the regression this test exists for would slip through green.
+    assert chunk_seconds > 2 * prompt_bound, "the pacing must dwarf the promptness bound"
+    # ...and the per-operation socket timeout must outlast that bound too, so it can never be
+    # the thing that ends the read while the promptness assertion still has budget left.
+    assert tasks.SOCKET_TIMEOUT > prompt_bound, "the socket timeout must not pre-empt the bound"
 
     def paced(conn, stop):
         try:
@@ -483,11 +519,25 @@ def test_abandoned_worker_dies_promptly_on_a_chunk_spanning_body():
             except OSError:
                 pass
 
+    entered = threading.Event()           # the worker actually reached `_get`
+    abandoned = threading.Event()         # the caller's join has expired — worker is orphaned
     worker_returned = threading.Event()   # set when `_get` returns/raises — i.e. when the
     box: dict = {}                        # abandoned thread is about to exit
     real_get = tasks._get
 
+    def abandonment_clock():
+        """Real monotonic time, then a ONE-WAY jump far past any deadline the moment the
+        caller has abandoned the worker. This — not a race between two equal timeouts — is
+        what decides the body-read deadline, so the re-check fires on the next chunk."""
+        t = time.monotonic()
+        return t + 1e6 if abandoned.is_set() else t
+
     def spy(url, token, **kw):
+        entered.set()
+        # The deadline handed to `_get` pins the per-operation socket timeout at its MAXIMUM;
+        # the deadline DECISION belongs to `abandonment_clock`, not to this number.
+        kw["deadline"] = tasks.SOCKET_TIMEOUT
+        kw["clock"] = abandonment_clock
         try:
             return real_get(url, token, **kw)
         except BaseException as exc:      # noqa: BLE001 - recorded, then re-raised verbatim
@@ -500,18 +550,39 @@ def test_abandoned_worker_dies_promptly_on_a_chunk_spanning_body():
     try:
         creds = {"CLAWGATE_API_URL": url, "CLAWGATE_HOOK_TOKEN": "tok"}
         t0 = time.monotonic()
-        ok, got = tasks.fetch_tasks_result(creds=creds, env={}, deadline=deadline, getter=spy)
+        ok, got = tasks.fetch_tasks_result(creds=creds, env={},
+                                           deadline=join_deadline, getter=spy)
         caller_elapsed = time.monotonic() - t0
-        died_in_time = worker_returned.wait(1.0)
+        # ORDERING, not a stopwatch: the caller must have been released by the JOIN while the
+        # worker was STILL RUNNING. That is the PREMISE of everything below — if the worker had
+        # already finished, nothing was abandoned and the rest of this test proves nothing. An
+        # ordering fact is exact, unlike the wall-clock slack bound this replaces (see below).
+        worker_still_running = not worker_returned.is_set()
+        # The worker must already be inside `_get` — otherwise it captured `started` AFTER the
+        # jump and nothing was abandoned, which would make everything below vacuous.
+        assert entered.is_set(), "the worker never reached `_get` — nothing was abandoned"
+        abandoned.set()
+        died_in_time = worker_returned.wait(prompt_bound)
         worker_elapsed = time.monotonic() - t0
     finally:
         stop()
 
     assert (ok, got) == (False, [])                  # degrades to "no linked tasks"
-    assert caller_elapsed < deadline + 0.6           # the join bound is unaffected either way
+    assert worker_still_running, (
+        "the worker had already returned when the caller was released, so nothing was ever "
+        "abandoned and the promptness assertion below would be vacuous")
+    # The caller was released by the 0.4s JOIN, not by the read finishing. Had the join failed
+    # to bound it, it would have sat there for a whole chunk (`chunk_seconds`), so half a chunk
+    # is the bound the DEFECT'S OWN SIGNATURE gives us. This replaces a flat `join_deadline +
+    # 0.6`, which was a guess about how well the box schedules threads rather than a claim
+    # about this code: it measured 1.087s for a 0.4s join under load 38 on 2026-08-20 and
+    # failed, with nothing wrong. The ordering assertion above is what actually pins the
+    # premise; this one only has to exclude "the caller waited for the body".
+    assert caller_elapsed < chunk_seconds / 2, (
+        f"the caller took {caller_elapsed:.2f}s — the {join_deadline}s join did not bound it")
     assert died_in_time, (
         f"the ABANDONED worker was still running {worker_elapsed:.2f}s in — "
-        f"{caller_elapsed:.2f}s after the {deadline}s deadline was declared blown. It is "
+        f"{caller_elapsed:.2f}s after the {join_deadline}s deadline was declared blown. It is "
         f"blocked inside ONE read() waiting for a full {tasks.READ_CHUNK}-byte chunk "
         f"(~{chunk_seconds:.1f}s at this pace), so the wall-clock re-check never runs. "
         f"Read the body with read1().")


### PR DESCRIPTION
## What was wrong

`test_abandoned_worker_dies_promptly_on_a_chunk_spanning_body` was reported red on
pristine `main`, twice, in two independent full-gate runs.

**It is not a defect in `tasks.py`.** The abandoned worker does die promptly — in every
run measured, including the failing ones. `died_in_time` is true and `caller_elapsed` is
~0.40s on both the passing and the failing path. What fails is the assertion about *why*
it died, and it fails because the test could not tell two guards apart.

Production reads with `urlopen(timeout=min(SOCKET_TIMEOUT, deadline))`. The test picked
`deadline = 0.4` and `SOCKET_TIMEOUT` is `2.0`, so the **per-operation socket timeout came
out exactly equal to the deadline**. Both then raced to end the same blocked `read1` — and
`socket.timeout` *is* `TimeoutError` on py3.10+, so `assert isinstance(exc, TimeoutError)`
passed either way. The tell is the message: the module's own guard says
`"...deadline after 12288 bytes"`, a socket timeout says only `"timed out"`. So the
byte-count assertion was the one that blew up:

```
E   AssertionError: the deadline error must report the bytes read so far: timed out
```

Any single stall of the paced sender lasting a whole deadline — an ordinary scheduling
event on a box running the full gate — handed the race to the socket timeout.

A **second, independent** flake mode surfaced while measuring:
`assert caller_elapsed < deadline + 0.6` is a guess about how well the host schedules
threads, not a claim about this code. It measured `1.0868s` for a `0.4s` join at load 38
and failed with nothing wrong.

This is category (2) — a test with a timing dependency — not a production defect. The
discriminating evidence: `scripts/initiatives/tasks.py` and `test_tasks.py` are
**byte-identical** between the reported-red commit `4740e40` and `main` `a29b97b`
(sha256 `1b3810d0…` / `438d9235…` on both), and that identical code ran 129/130 green in
isolation here. Nothing about the production path changed between red and green — only
the machine's load did.

## The fix — no timeout widened, no assertion weakened

* `_get` takes a `clock` seam, defaulting to `time.monotonic` and matching the one
  `LinkedTaskCache` already takes as `now`. The test drives the body-read deadline
  **decision** off an abandonment event, and hands `_get` a deadline of `SOCKET_TIMEOUT`,
  pinning the per-operation timeout at its **maximum** — 2.0s against a 0.02s pacing gap,
  and strictly longer than the 1.0s promptness bound. A socket timeout can no longer end
  the read before the promptness assertion has already spoken, so that failure mode is
  **unreachable now, not merely rarer**.
* The wall-clock slack bound is replaced by an **ordering fact** — the worker was still
  running when the caller was released — plus a bound derived from the defect's own
  signature (`chunk_seconds / 2`) instead of a scheduling guess. The ordering assertion is
  strictly *new* power: it pins the premise that anything was abandoned at all, which the
  stopwatch never did.

The promptness bound itself (`1.0s`) and the byte-count assertion are **unchanged**.

## Evidence

Both modes reproduced by **injection** rather than by loading the machine (other agents
share this box):

| control | before | after |
|---|---|---|
| socket-timeout race — 0.45s sender stall | **0/3 green** (3/3 `"timed out"`) | **3/3 green** (also green at 0.6s, 0.9s) |
| scheduling overshoot — 0.7s caller stall | **RED** `assert 1.1017 < (0.4 + 0.6)` | **GREEN** |

The 0.7s injected stall reproduces the live observation (`1.0868`) as `1.1017`.

| measurement | main `a29b97b` | HEAD |
|---|---|---|
| isolated runs | 129/130 (1 fail: the slack bound, load 38) | **100/100** at load 32–36 |
| full target `scripts/initiatives/tests` | 784 passed | **784 passed** |

Test count unchanged, so `TARGET_FLOORS` (`scripts/initiatives/tests|745`) is untouched.

## Mutation battery

Every mutant killed by **its own** assertion's message, positive control green, trees
restored byte-identical afterwards:

| mutant | killed by |
|---|---|
| `read1` → `read` (the original defect) | `"Read the body with read1()."` |
| wall-clock re-check deleted (`if False`) | `"Read the body with read1()."` |
| deadline error loses its byte count | `"must report the bytes read so far"` |
| join no longer bounds the caller | `"nothing was ever abandoned"` |
| worker finishes before the join (early EOF) | `"nothing was ever abandoned"` |
| join bounds at 4× the deadline | `"the 0.4s join did not bound it"` |

Two earlier mutants (`th.join()` unbounded, unpaced sender) were discarded as bad
mutants: both trip the `(ok, got) == (False, [])` check first, leaving the new guards
**unreached**. They were rebuilt as the last three rows above specifically to reach them.

The byte-count assertion was re-confirmed **still sensitive** to the exact `"timed out"`
shape it exists to exclude — a real socket timeout would still be caught, so excluding it
was not traded away.

## Not verified

* I could not read the original full-gate failure output, so I cannot prove *which* of the
  two modes the two reported runs hit. Both are reproduced and both are fixed.
* One HEAD run failed early in this session (1/30, load ~21) with output not captured —
  it predates the slack-bound change and is most likely that same mode, but I cannot
  demonstrate it. Since that change: 100/100.
* `main` moved from the briefed `4740e40` to `a29b97b` during this work; measurements are
  against `a29b97b`, with the two relevant files proven identical across both.
* I did not run the full `scripts/run-tests.sh` gate — the brief forbade running it
  concurrently with other agents on this host. Only the `scripts/initiatives/tests` target
  was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
