### PR TITLE
fix(gate): the browser-bridge figure was not just stale, it was WALKABLE — gate the claim, not the byte count

### DIFF
--- a/scripts/tests/test_prune_skill_size.py
+++ b/scripts/tests/test_prune_skill_size.py
@@ -28,12 +28,17 @@ is exactly how the drift regrows.
 
 WHY THE CEILING IS ABOVE THE 12,288 B TARGET, AND WHAT THAT COSTS
 -----------------------------------------------------------------
-The skill states a 12,288 B target and browser-bridge MEETS it (11,990 B while
-routing ~11x its own weight), so the target is achievable and is not in dispute.
+The skill states a 12,288 B target and browser-bridge MEETS it while routing ~11x
+its own weight, so the target is achievable and is not in dispute.
 This file does not: it sits at 12,859 B (12.56 KiB) after being cut from 14,918 B
 by demoting §6 (landing), §4's deployment table, §7's verification rationale, §0's
 axes and the always-loaded model to three sidecars, plus stripping evidence from
 every remaining section.
+
+(The browser-bridge sentence states no byte count on purpose. That count belongs
+to ANOTHER skill's file: restating it here made this gate red for someone else's
+cosmetic churn, and -- worse -- walkable by a one-number edit. The claim it
+carries is a RELATIONSHIP, and is gated as one; see `BB_CLAIM` below.)
 
 The residual is the classification taxonomy (§3) and the rule NAMES in §0/§7.
 Demoting those was considered and rejected on the record: §3 is consulted at the
@@ -404,11 +409,13 @@ def test_this_modules_own_stated_figures_are_re_measured():
             "extracting '§3 verdict bullets' needs a heading-and-bullet parser whose "
             "own drift would be invisible; the figure only sizes MIN_HEADROOM_BYTES, "
             "which this gate pins directly via 'true working room'",
-        "browser-bridge routes '~11x its own weight' (:32)":
+        "browser-bridge routes '~11x its own weight'":
             "measured 11.05x today, but deriving it means summing that skill's whole "
             "reference/ tree, which makes this gate depend on a SECOND skill's layout; "
             "the load-bearing half of that sentence (browser-bridge MEETS the target) "
-            "is gated via 'browser-bridge size'",
+            "is gated as a relationship by BB_CLAIM + the bb <= target assertion "
+            "below, and the phrase itself can no longer be reworded away because the "
+            "whole normalised sentence is pinned",
     }
 
     # (label, regex with ONE capturing group, expected literal)
@@ -425,7 +432,8 @@ def test_this_modules_own_stated_figures_are_re_measured():
         ("true working room",        r"must remain: ([\d,]+) B of true working",  f"{slack:,}"),
         ("routing-table bytes",      r"routing table \(3 rows, ([\d,]+) B",       f"{row_bytes:,}"),
         ("routing-table mean",       r"routing table \(3 rows, [\d,]+ B -> mean ([\d,]+) B/row", f"{row_bytes // len(rows):,}"),
-        ("browser-bridge size",      r"browser-bridge MEETS it \(([\d,]+) B",     f"{bb:,}"),
+        # NOTE: browser-bridge is NOT gated by a restated byte count any more.
+        # See BB_CLAIM below for the walk that made the literal indefensible.
         # The three hand-maintained restatements of the target, in the module whose
         # headline fix was "it pinned the cross-check against its own copy of the
         # number". Each is a separate sentence, so each needs its own anchor.
@@ -451,6 +459,57 @@ def test_this_modules_own_stated_figures_are_re_measured():
                             "pattern name exactly one sentence")
         elif found[0] != expected:
             problems.append(f"{label}: prose says {found[0]}, measured {expected}")
+
+    # ── The one figure this module does NOT own ──────────────────────────────
+    # Every other gated figure derives from something this module's own change
+    # set owns: prune-skill/SKILL.md, skill-audit.py's TARGET, this file. `bb`
+    # does not -- it measures `scripts/browser-bridge/SKILL.md`, which unrelated
+    # PRs edit. That coupling turned `main` RED for a 48 B cosmetic edit (#551
+    # grew the file, #581 was the one-line re-measure), the fourth stale-figure
+    # failure in a day; #581's own message asked for exactly this fix, to derive
+    # the claim at test time instead of restating a literal.
+    #
+    # 🔴 But brittleness was the lesser half. The literal form was WALKABLE, and
+    # the walk is executed rather than argued: pad browser-bridge to 12,388 B --
+    # over the target -- then update the prose literal to 12,388 to clear the
+    # pin, and this test reports `1 passed` while the sentence it guards asserts
+    # that browser-bridge MEETS a target it now breaches. The gate CERTIFIED a
+    # falsehood, and the repair that silences it is the one that installs it.
+    # That is `claude/RULES.md`'s SPELLED-not-STRUCTURAL guard: the byte count is
+    # a spelling of the claim; `bb <= target` IS the claim.
+    #
+    # Not vacuous despite browser-bridge's own ceiling being this same TARGET
+    # (skill-audit.py:40 defines TARGET as that skill's PROVEN ceiling). That
+    # constant is independent and raisable: raise browser-bridge's MAX_BYTES and
+    # grow the file, and its own gate stays GREEN while this sentence turns
+    # false. This assertion is the only thing watching that seam.
+    #
+    # Pinned as the WHOLE normalised sentence, not a phrase, so a reword cannot
+    # walk it -- and built from the imported `target`, never a second hand-copy
+    # of 12,288, which is the F2 defect this module was written to close.
+    BB_CLAIM = (
+        f"The skill states a {target:,} B target and browser-bridge MEETS it "
+        "while routing ~11x its own weight, so the target is achievable and is "
+        "not in dispute."
+    )
+    if " ".join(src.split()).count(BB_CLAIM) != 1:
+        problems.append(
+            "browser-bridge claim: the sentence asserting that browser-bridge "
+            f"meets the target is not present exactly once as written.\n    "
+            f"Expected verbatim (whitespace-normalised):\n      {BB_CLAIM}\n    "
+            "A reword makes this figure unchecked, so restore the wording or "
+            "re-point this pin deliberately."
+        )
+    if bb > target:
+        problems.append(
+            f"browser-bridge claim: prose says browser-bridge MEETS the "
+            f"{target:,} B target, but it measures {bb:,} B -- over by "
+            f"{bb - target:,} B. The sentence is now FALSE, and this module's "
+            "whole 'the target is achievable and is not in dispute' argument "
+            "rests on it. Fix browser-bridge or rewrite the argument -- do NOT "
+            "restate the new number, which is how the literal form of this "
+            "check certified the same falsehood."
+        )
 
     assert not problems, (
         "this module's own figures no longer describe what they measure:\n  "


### PR DESCRIPTION
## The red is already fixed. This closes the defect that produced it — and a hole underneath.

I was sent to fix `test_this_modules_own_stated_figures_are_re_measured`, reported RED on
`4740e40`. Reproduced, then found it already repaired upstream — so this PR is not the
re-measure. It is the durable fix #581's own commit message asked for.

### 1. The reported failure, reproduced verbatim

Detached worktree at `4740e40`:

```
E       AssertionError: this module's own figures no longer describe what they measure:
E           browser-bridge size: prose says 11,942, measured 11,990
E
E         Measured now: SKILL.md=12,859 B (12.56 KiB), target 12,288 (imported from
E         skill-audit.py), over by 571 B (4.65%), headroom 197 B, working slack 5 B,
E         routing table 435 B over 3 rows, browser-bridge 11,990 B.
E         Re-measure and update the prose; do NOT relax this test.

1 failed, 5920 deselected
```

**Category (1): the figure was genuinely stale, not a tolerance problem.** Nothing statistical
about it — the check is `stat` + regex, and it is red or green deterministically. `/proc/loadavg`
was 11.5–27 across this work and never moved the result.

**Already fixed by `210de3d` (#581), 2026-08-19 21:32 -0500** — a one-line re-measure,
`11,942 -> 11,990`. `4740e40` is an ancestor of today's `main`; the gate runs that saw red were
reading a tree at or before it. On my base (`a29b97b`) the test is **green**, unmodified.

### 2. What this PR fixes instead

#581's message ends:

> Third stale-figure failure today (the opencode pin, the browser-bridge floor, this). All the
> same shape [...] If a fourth appears, the fix is probably to DERIVE these figures at test time
> rather than restate and pin them.

`bb` is the only gated figure this module does **not** own. Every other one derives from
`prune-skill/SKILL.md`, `skill-audit.py`'s `TARGET`, or this file itself. `bb` measures
`scripts/browser-bridge/SKILL.md`, which unrelated PRs edit — #551 spent 48 B there and turned
`main` red in a module it never touched, with no signal to its author.

### 3. 🔴 The literal was not just brittle — it was WALKABLE, and the walk is executed

The sentence claims *browser-bridge MEETS the 12,288 B target*. The check pinned the **byte
count**, not the claim. So the repair that silences the gate is the one that installs a
falsehood. Executed on `a29b97b`, not argued:

1. pad `scripts/browser-bridge/SKILL.md` to **12,388 B** — 100 B **over** the target;
2. apply the ordinary repair: update the prose literal `11,990` → `12,388`;
3. run the gate → **`1 passed`**.

The gate certified `browser-bridge MEETS it (12,388 B ...)` against a 12,288 B target. That is
`claude/RULES.md`'s spelled-not-structural guard: the byte count is a *spelling* of the claim;
`bb <= target` **is** the claim.

`skill-audit.py:40` settles it — `TARGET` is *defined* as browser-bridge's proven ceiling.

### 4. The fix

The exact count leaves the prose (it belongs to another file). The claim is gated as a
relationship, in two halves that cover each other:

- **`bb <= target`** — the load-bearing assertion, computed, unsilenceable by editing a number.
- **`BB_CLAIM`** — the WHOLE normalised sentence pinned, exactly once, and **built from the
  imported `target`** rather than a second hand-copy of `12,288` (the F2 defect this module
  exists to close). A reword or a shadowing decoy fails loudly.

**Not vacuous** despite browser-bridge's own ceiling being this same 12,288: that constant is
independent and raisable. Raise `MAX_BYTES` in `scripts/browser-bridge/tests/test_skill_size.py`
and grow the file, and its own gate stays **green** while this sentence turns false. This
assertion is the only thing watching that seam.

**What it can still catch, stated plainly:** browser-bridge breaching the target (M1); the old
restate-the-number walk (M2); any reword, deletion or duplication of the claim (M3–M5); a
de-synced target literal (M7). **What it deliberately no longer catches:** browser-bridge
changing size *within* budget — which was never a defect in `prune-skill`, only noise that made
this gate red for someone else's cosmetic edit.

### 5. Proof the guard still goes RED

Isolated battery — each mutant touches the narrowest expression that can be wrong, is restored
from a pristine byte copy (never `git stash`), and is checked against the **assertion message**,
not the traceback's source echo. `PYTHONDONTWRITEBYTECODE=1` throughout.

| # | mutant | expect | got | died with |
|---|--------|--------|-----|-----------|
| M0 | pristine tree (control) | GREEN | GREEN | — |
| M1 | browser-bridge grows over target, **prose untouched** | RED | RED | `prose says browser-bridge MEETS the 12,288 B target, but it measures 12,388 B -- over by 100 B` |
| M2 | **the old walk**: over target + restate the literal | RED | RED | both the claim-pin *and* the over-by-100 assertion |
| M3 | claim reworded (`MEETS` → `SATISFIES`) | RED | RED | `not present exactly once as written` |
| M4 | claim deleted | RED | RED | claim-pin + `target in the preamble: PATTERN DID NOT MATCH` |
| M5 | claim duplicated (shadowing decoy) | RED | RED | claim-pin + `target in the preamble: pattern matched 2x` |
| M6 | **positive control** — an unrelated still-gated figure falsified | RED | RED | `size in the docstring: prose says 12,858, measured 12,859` |
| M7 | target literal de-synced from `skill-audit.TARGET` | RED | RED | `target in the preamble: prose says 12,299, measured 12,288` |

M1 fires **alone**, with its own error — so the `bb > target` branch is reachable, not shadowed
by an earlier check and not killed by a different guard's message. M2 is the headline: green
before this PR, red after. M6 proves the rest of the gate is intact.

### 6. Verification matrix

- **RED at `4740e40`** — `1 failed, 5920 deselected`, output quoted above.
- **GREEN at base `a29b97b`** (already fixed by #581) and **GREEN at HEAD**.
- Full `scripts/tests` target: see the run recorded in the commit.
- `collected` **unchanged** — this modifies an existing test body, adds no test — so the
  `TARGET_FLOORS` entry `scripts/tests|5764` needs no edit.
- No code elsewhere referenced the removed literal or the `browser-bridge size` label
  (`grep` for both). One historical mention survives in
  `claudedocs/handoff-skill-prune-and-gate-floor.md`, which is a dated record of past
  measurements and correctly says of that number "re-measure, it moves".

### Not verified

- I did **not** run the full `scripts/run-tests.sh` gate — other agents are active in this repo
  and concurrent full gates cause real flakes here. I ran the `scripts/tests` target directly.
- The `~11x` routing ratio stays hand-maintained and is still declared in `UNGATED`; only the
  *phrase* is now unrewordable, not the ratio.
- Whether the CI gate that reported red on 2026-08-20 has since re-run against post-#581 `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
