### PR TITLE
fix(gate): a crashing hook-test directory reported "no tests ran", and a missing tool read as a broken gate

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,43 @@
         inherit system;
         config.allowUnfree = true;
       };
+
+      # ---------------------------------------------------------------------
+      # THE GATE'S TOOLCHAIN — ONE list, TWO consumers.
+      #
+      # `scripts/run-tests.sh` asserts a REQUIRED_TOOLS precondition and exits 2
+      # when a binary is missing, because the suites `skipif` on these and a
+      # missing one would take the run GREEN while testing less. That
+      # precondition is correct and stays. What it lacked was a discoverable way
+      # to SATISFY it: the FATAL named `flake.nix checks.pytests
+      # nativeBuildInputs`, which is a derivation you cannot stand in, so a
+      # contributor's only route was to reverse-engineer the list into an ad-hoc
+      # `nix-shell -p ...`. Getting that list wrong reads as a red gate that
+      # looks like a code failure.
+      #
+      # So the same list now also backs `devShells.default`, and the FATAL names
+      # `nix develop` (see run-tests.sh's GUARD 1). Hoisted to ONE binding
+      # rather than copied: two hand-maintained copies is how the shell that is
+      # supposed to satisfy the precondition drifts out of satisfying it, and
+      # that drift would resurface as exactly the message this fixes.
+      # `scripts/tests/test_devshell_satisfies_required_tools.py` pins the
+      # relationship in the other direction -- every REQUIRED_TOOLS entry must
+      # be reachable from this list.
+      # ---------------------------------------------------------------------
+      gatePyEnv = pkgs.python312.withPackages (ps: with ps; [
+        pytest
+        requests
+        psycopg2
+        minio
+        pyyaml
+      ]);
+      # Read the per-entry justifications on checks.pytests' nativeBuildInputs
+      # below before adding or removing anything here.
+      gateTools = [
+        gatePyEnv pkgs.bash pkgs.ripgrep pkgs.git pkgs.util-linux pkgs.jq
+        pkgs.gnugrep pkgs.curl pkgs.nodejs pkgs.nix pkgs.opencode pkgs.logrotate
+        pkgs.rsync
+      ];
     in
     {
       # ---------------------------------------------------------------------
@@ -119,17 +156,27 @@
       # Deps below cover the modules-under-test's import-time requirements
       # (requests/psycopg2/minio/pyyaml); the tests themselves mock the I/O.
       # ---------------------------------------------------------------------
+      # ---------------------------------------------------------------------
+      # `nix develop` — the environment `scripts/run-tests.sh` demands, by name.
+      #
+      # Built from the SAME `gateTools` list as checks.pytests below, so the
+      # shell a contributor is told to enter cannot drift out of satisfying the
+      # precondition that told them to enter it.
+      #
+      # This is a shell, NOT a second gate: `nix flake check` remains the
+      # hermetic authority (no network, no /home). The shell just makes the
+      # authoritative runner runnable by hand.
+      # ---------------------------------------------------------------------
+      devShells.${system}.default = pkgs.mkShell {
+        name = "devrc-gate";
+        packages = gateTools;
+        shellHook = ''
+          echo "devrc: gate toolchain ready — bash scripts/run-tests.sh ." >&2
+        '';
+      };
+
       checks.${system} = {
         pytests =
-        let
-          pyEnv = pkgs.python312.withPackages (ps: with ps; [
-            pytest
-            requests
-            psycopg2
-            minio
-            pyyaml
-          ]);
-        in
         pkgs.runCommandLocal "devrc-pytests"
           {
             # ripgrep: one repo-cos prescan test skipif's without it on PATH.
@@ -245,7 +292,12 @@
             # nix-shell-stripped-PATH method as the `nix` entry above reproduced
             # it. Present on the workbench (`~/.nix-profile/bin/rsync`), so the
             # pre-push tier is unaffected.
-            nativeBuildInputs = [ pyEnv pkgs.bash pkgs.ripgrep pkgs.git pkgs.util-linux pkgs.jq pkgs.gnugrep pkgs.curl pkgs.nodejs pkgs.nix pkgs.opencode pkgs.logrotate pkgs.rsync ];
+            # `gateTools` is defined in the outer `let` and is SHARED verbatim
+            # with devShells.default — see the block that defines it. Adding a
+            # tool there is what makes `nix develop` able to run this same
+            # runner by hand; adding it only here would put the gate and the
+            # shell back out of sync.
+            nativeBuildInputs = gateTools;
           }
           ''
             cp -r ${./.} src

--- a/scripts/claude-hooks/tests/conftest.py
+++ b/scripts/claude-hooks/tests/conftest.py
@@ -27,11 +27,12 @@ directory invocation did, and got a reassuring zero over a crash.
 
 THE FIX, in two layers:
 
-  1. CLASSIFY STRUCTURALLY, then never import a script suite. `pytest_collect_
-     file` claims each script suite BEFORE pytest's python collector can import
-     it, and runs it the way run-tests.sh does -- as a subprocess, one pytest
-     item, exit 0 is pass. So the directory now runs ALL eleven suites instead
-     of crashing on the first script.
+  1. CLASSIFY STRUCTURALLY, then never import a script suite.
+     `pytest_pycollect_makemodule` REPLACES the Module pytest would have built
+     for a script suite, so the import never happens, and runs it the way
+     run-tests.sh does -- as a subprocess, one pytest item, exit 0 is pass. So
+     the directory now runs ALL eleven suites instead of crashing on the first
+     script.
 
      The classifier is STRUCTURAL, not a hard-coded list: a file is a script
      suite iff it has no top-level `def test_*` / `class Test*`, read with
@@ -54,9 +55,10 @@ THE FIX, in two layers:
      offending file -- never again as "no tests ran".
 
 Both layers are inert for the gate: it targets the six collectable files by
-path, and for those `pytest_collect_file` returns None (normal collection) and
-the Module subclass behaves exactly like `pytest.Module`. Per-target collected
-counts are unchanged, so no TARGET_FLOORS entry moves.
+path, and for those the hook returns the Module subclass, whose collect() is a
+passthrough on the success path. MEASURED across all six targets, HEAD vs
+a29b97b: 1442/130/17/40/296/13 collected on both. No TARGET_FLOORS entry for a
+hook-test target moves.
 """
 import ast
 import subprocess

--- a/scripts/claude-hooks/tests/conftest.py
+++ b/scripts/claude-hooks/tests/conftest.py
@@ -68,15 +68,50 @@ from pathlib import Path
 import pytest
 
 _THIS_DIR = Path(__file__).resolve().parent
-# scripts/claude-hooks/tests -> scripts/claude-hooks -> scripts -> <repo root>.
+
+
+def _find_repo_root(start: Path) -> Path:
+    """Repo root by LANDMARK, with a positional fallback.
+
+    🔴 This used to be a bare `_THIS_DIR.parents[2]` -- correct in the real tree
+    (tests -> claude-hooks -> scripts -> root) and GARBAGE in a copy. That is not
+    hypothetical: this file is deliberately `shutil.copy`d into a tmp dir by
+    scripts/tests/test_hook_tests_dir_collects.py, and `repr_failure` below
+    calls `relative_to(_REPO_ROOT)`. A wrong root makes that raise ValueError
+    *inside the failure-reporting path*, which would mask the real failure with
+    an unrelated traceback -- the worst place to put a landmine.
+
+    Walking up for `scripts/run-tests.sh` finds the true root wherever this file
+    is copied to, and the positional value is kept only as a last resort so this
+    can never raise on its own.
+    """
+    for candidate in (start, *start.parents):
+        if (candidate / "scripts" / "run-tests.sh").is_file():
+            return candidate
+    return start.parents[2] if len(start.parents) > 2 else start
+
+
 # The script suites are invoked with cwd=<repo root> because that is what
 # run-tests.sh does (it cd's to the git toplevel first), and at least one of
 # them resolves repo-relative paths.
-_REPO_ROOT = _THIS_DIR.parents[2]
+_REPO_ROOT = _find_repo_root(_THIS_DIR)
 
 # A script suite that hangs must fail loudly rather than wedge the session.
 # Generous: the slowest of these forks a dozen subprocesses of its own.
 _SCRIPT_TIMEOUT_SECONDS = 900
+
+
+def _display_path(path: Path) -> str:
+    """Repo-relative if we can, absolute if we cannot -- but NEVER raise.
+
+    Belt to `_find_repo_root`'s braces. This runs only while REPORTING a
+    failure, so an exception here replaces a real diagnosis with an unrelated
+    one; there is no error worth raising from a path-prettifier.
+    """
+    try:
+        return str(path.relative_to(_REPO_ROOT))
+    except ValueError:
+        return str(path)
 
 
 def has_toplevel_test_functions(path: Path) -> bool:
@@ -131,7 +166,7 @@ class ScriptSuiteItem(pytest.Item):
         )
         if proc.returncode != 0:
             raise ScriptSuiteFailure(
-                f"{self.path.relative_to(_REPO_ROOT)} exited {proc.returncode} "
+                f"{_display_path(self.path)} exited {proc.returncode} "
                 f"(this is a hand-rolled script suite; it prints its own PASS/FAIL "
                 f"lines).\n\n--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
             )

--- a/scripts/claude-hooks/tests/conftest.py
+++ b/scripts/claude-hooks/tests/conftest.py
@@ -1,0 +1,195 @@
+"""Make `pytest scripts/claude-hooks/tests/` work on the WHOLE directory.
+
+THE DEFECT THIS FIXES (measured on origin/main, a29b97b):
+
+    $ python3 -m pytest scripts/claude-hooks/tests/ -q
+    INTERNALERROR> ... File ".../tests/test_bash_guard.py", line 436, in <module>
+    INTERNALERROR>     sys.exit(1 if fail else 0)
+    INTERNALERROR> SystemExit: 0
+
+    no tests ran in 4.99s
+
+Root cause: this directory mixes TWO kinds of file behind ONE `test_*.py`
+name. Six are ordinary pytest modules. Five are hand-rolled SCRIPT suites --
+they do all their work at import, print their own PASS/FAIL lines, and end in
+`sys.exit()`. pytest collects a script suite by IMPORTING it, so the script
+runs during collection and its `sys.exit()` raises SystemExit out of the
+collector. SystemExit derives from BaseException, so pytest does not treat it
+as a collection error; it escapes as INTERNALERROR and the session ends
+"no tests ran".
+
+Why that is worse than a crash: **"no tests ran" is indistinguishable from a
+clean zero.** `scripts/run-tests.sh` is unaffected -- it names the collectable
+files INDIVIDUALLY and runs the five scripts itself (see HERMETIC_TARGETS'
+"A FILE, not a dir, and deliberately so" comment, and the HOOK_TESTS array) --
+so the gate never saw this. Every human or agent who reached for the obvious
+directory invocation did, and got a reassuring zero over a crash.
+
+THE FIX, in two layers:
+
+  1. CLASSIFY STRUCTURALLY, then never import a script suite. `pytest_collect_
+     file` claims each script suite BEFORE pytest's python collector can import
+     it, and runs it the way run-tests.sh does -- as a subprocess, one pytest
+     item, exit 0 is pass. So the directory now runs ALL eleven suites instead
+     of crashing on the first script.
+
+     The classifier is STRUCTURAL, not a hard-coded list: a file is a script
+     suite iff it has no top-level `def test_*` / `class Test*`, read with
+     `ast.parse` (no import, so a script suite is never executed to find out
+     what it is). Measured over this directory today, that splits it exactly:
+
+         top-level test funcs == 0   ->  the 5 scripts in HOOK_TESTS
+         top-level test funcs >  0   ->  the 6 files named in HERMETIC_TARGETS
+
+     A hard-coded list would rot the first time a suite is added -- and the
+     rotted state is precisely the crash above. `scripts/tests/
+     test_hook_tests_dir_collects.py` pins the classifier against run-tests.sh's
+     two lists as a ledger, so the sets cannot drift apart silently.
+
+  2. TURN THE WHOLE CLASS LOUD. Layer 1 removes today's SystemExit. Layer 2
+     makes any FUTURE one land as a named collection error instead of
+     INTERNALERROR: `pytest_pycollect_makemodule` returns a Module subclass
+     that catches SystemExit around collection and re-raises it as a
+     `CollectError`. pytest reports that as a red, named error against the
+     offending file -- never again as "no tests ran".
+
+Both layers are inert for the gate: it targets the six collectable files by
+path, and for those `pytest_collect_file` returns None (normal collection) and
+the Module subclass behaves exactly like `pytest.Module`. Per-target collected
+counts are unchanged, so no TARGET_FLOORS entry moves.
+"""
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_THIS_DIR = Path(__file__).resolve().parent
+# scripts/claude-hooks/tests -> scripts/claude-hooks -> scripts -> <repo root>.
+# The script suites are invoked with cwd=<repo root> because that is what
+# run-tests.sh does (it cd's to the git toplevel first), and at least one of
+# them resolves repo-relative paths.
+_REPO_ROOT = _THIS_DIR.parents[2]
+
+# A script suite that hangs must fail loudly rather than wedge the session.
+# Generous: the slowest of these forks a dozen subprocesses of its own.
+_SCRIPT_TIMEOUT_SECONDS = 900
+
+
+def has_toplevel_test_functions(path: Path) -> bool:
+    """True if `path` looks like an ordinary pytest module.
+
+    Read with `ast.parse`, deliberately: deciding this by importing is the very
+    thing that detonates a script suite. A syntax error returns True so pytest
+    -- not this classifier -- reports it, with its own error message.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (SyntaxError, UnicodeDecodeError, OSError):
+        return True
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test"):
+            return True
+        if isinstance(node, ast.ClassDef) and node.name.startswith("Test"):
+            return True
+    return False
+
+
+def is_script_suite(path: Path) -> bool:
+    """True for the hand-rolled `asserts + sys.exit` suites in THIS directory.
+
+    Scoped to this directory on purpose. Every other tests/ tree in this repo is
+    pure pytest, and a classifier that reached into them could silently demote a
+    real module whose tests are all inside classes or generated at import.
+    """
+    path = Path(path)
+    return (
+        path.suffix == ".py"
+        and path.name.startswith("test_")
+        and path.resolve().parent == _THIS_DIR
+        and not has_toplevel_test_functions(path)
+    )
+
+
+class ScriptSuiteFailure(Exception):
+    """Carries a script suite's own stdout/stderr into pytest's failure report."""
+
+
+class ScriptSuiteItem(pytest.Item):
+    """One hand-rolled suite, run as a subprocess exactly as the gate runs it."""
+
+    def runtest(self):
+        proc = subprocess.run(
+            [sys.executable, str(self.path)],
+            cwd=str(_REPO_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=_SCRIPT_TIMEOUT_SECONDS,
+        )
+        if proc.returncode != 0:
+            raise ScriptSuiteFailure(
+                f"{self.path.relative_to(_REPO_ROOT)} exited {proc.returncode} "
+                f"(this is a hand-rolled script suite; it prints its own PASS/FAIL "
+                f"lines).\n\n--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+            )
+
+    def repr_failure(self, excinfo, style=None):
+        if isinstance(excinfo.value, ScriptSuiteFailure):
+            return str(excinfo.value)
+        if isinstance(excinfo.value, subprocess.TimeoutExpired):
+            return (
+                f"{self.path.name} did not finish within {_SCRIPT_TIMEOUT_SECONDS}s. "
+                "A hung script suite is a failure, not a skip."
+            )
+        return super().repr_failure(excinfo, style=style)
+
+    def reportinfo(self):
+        return self.path, 0, f"script suite: {self.path.name}"
+
+
+class ScriptSuiteFile(pytest.File):
+    def collect(self):
+        yield ScriptSuiteItem.from_parent(self, name=self.path.name)
+
+
+def pytest_pycollect_makemodule(module_path, parent):
+    """The single interception point for BOTH layers.
+
+    🔴 This is `pytest_pycollect_makemodule` and NOT `pytest_collect_file`, and
+    the difference is load-bearing. `pytest_collect_file` is not a firstresult
+    hook: pytest UNIONS every plugin's return, so claiming the file there left
+    the builtin python plugin free to ALSO collect it as a Module -- measured,
+    the suite was collected twice and the import still detonated (1943 items
+    *and* an error on test_bash_guard.py). `pytest_pycollect_makemodule` IS
+    firstresult, so returning a node here REPLACES the Module pytest would have
+    built, and the import never happens.
+
+    Layer 1: a script suite becomes a subprocess-backed node.
+    Layer 2: everything else becomes a Module that reports a SystemExit at
+             import as a named CollectError instead of an INTERNALERROR.
+    """
+    if is_script_suite(module_path):
+        return ScriptSuiteFile.from_parent(parent, path=module_path)
+    return _SystemExitIsACollectError.from_parent(parent, path=module_path)
+
+
+class _SystemExitIsACollectError(pytest.Module):
+    def collect(self):
+        try:
+            return list(super().collect())
+        except SystemExit as exc:
+            raise self.CollectError(
+                f"{self.path.name} called sys.exit({exc.code!r}) while pytest was "
+                "IMPORTING it, so it never yielded any tests.\n"
+                "\n"
+                "This file is a hand-rolled script suite living under a `test_*.py` "
+                "name. Give it top-level `def test_*` functions to be collected "
+                "normally, or leave it script-shaped -- conftest.py in this "
+                "directory classifies a file with no top-level test functions as a "
+                "script suite and runs it as a subprocess instead of importing it.\n"
+                "\n"
+                "You are seeing this message rather than an INTERNALERROR / "
+                "'no tests ran' because that pair was indistinguishable from a "
+                "clean zero."
+            ) from exc

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -951,8 +951,24 @@ TARGET_FLOORS=(
   #
   #   _suggested_floor 5814 = 5814 - min(50, max(1, 290)) = 5814 - 50 = 5764
   #
+  #
+  # 2026-08-20, the gate-harness DX fix (the hook-tests directory that reported
+  # "no tests ran" over an INTERNALERROR, and the missing-tool FATAL that read
+  # as a broken gate): 5947 -> 5962 collected, +15 across
+  # test_hook_tests_dir_collects.py and test_devshell_satisfies_required_tools.py.
+  #
+  # 🔴 The previous entry documented 5814, not 5947. The 5814 -> 5947 difference
+  # (+133) is NOT this contribution — it landed on main between that entry and
+  # a29b97b without the floor being re-pinned, so the pin had drifted 183 below
+  # the real count and its sensitivity had decayed accordingly. Both counts were
+  # MEASURED here rather than inferred: `--collect-only` on scripts/tests at a
+  # pristine a29b97b worktree gave 5947, and the gate's own line at HEAD gave
+  #   PASS  scripts/tests  (collected=5962 passed=5962 skipped=0 floor=5764)
+  #
+  #   _suggested_floor 5962 = 5962 - min(50, max(1, 298)) = 5962 - 50 = 5912
+  #
   # ⚠ ZERO new skips from any contribution.
-  "scripts/tests|5764"
+  "scripts/tests|5912"
   # 2026-08-11, the session-summary changed-paths work: 230 -> 273 collected,
   # +43 for scripts/collector/tests/test_changed_paths.py (the shared
   # `changed_paths*` module). The gate printed this replacement itself —

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -954,21 +954,27 @@ TARGET_FLOORS=(
   #
   # 2026-08-20, the gate-harness DX fix (the hook-tests directory that reported
   # "no tests ran" over an INTERNALERROR, and the missing-tool FATAL that read
-  # as a broken gate): 5947 -> 5962 collected, +15 across
-  # test_hook_tests_dir_collects.py and test_devshell_satisfies_required_tools.py.
+  # as a broken gate), re-measured after a rebase onto fc1f581:
+  # 6201 -> 6219 collected, +18 across test_hook_tests_dir_collects.py and
+  # test_devshell_satisfies_required_tools.py.
   #
-  # 🔴 The previous entry documented 5814, not 5947. The 5814 -> 5947 difference
-  # (+133) is NOT this contribution — it landed on main between that entry and
-  # a29b97b without the floor being re-pinned, so the pin had drifted 183 below
-  # the real count and its sensitivity had decayed accordingly. Both counts were
-  # MEASURED here rather than inferred: `--collect-only` on scripts/tests at a
-  # pristine a29b97b worktree gave 5947, and the gate's own line at HEAD gave
-  #   PASS  scripts/tests  (collected=5962 passed=5962 skipped=0 floor=5764)
+  # BOTH numbers MEASURED with `--collect-only` on scripts/tests, one in a clean
+  # detached worktree of origin/main and one on the rebased branch — not
+  # inferred, and not carried over from the earlier round of this same entry
+  # (which read 5947 -> 5962 against a29b97b and is now superseded: main moved
+  # four times while this branch was in review).
   #
-  #   _suggested_floor 5962 = 5962 - min(50, max(1, 298)) = 5962 - 50 = 5912
+  # 🔴 The pin this REPLACES was 5912, against a real count of 6201 on main
+  # alone — 289 of drift, none of it from here. The same thing happened to the
+  # entry before it (5764 pinned against 5947). Tests keep landing without the
+  # floor being re-pinned, so this table's sensitivity decays continuously
+  # between the contributions that happen to notice. Re-measure before trusting
+  # a number here; do not assume the last entry describes the current tree.
+  #
+  #   _suggested_floor 6219 = 6219 - min(50, max(1, 310)) = 6219 - 50 = 6169
   #
   # ⚠ ZERO new skips from any contribution.
-  "scripts/tests|5912"
+  "scripts/tests|6169"
   # 2026-08-11, the session-summary changed-paths work: 230 -> 273 collected,
   # +43 for scripts/collector/tests/test_changed_paths.py (the shared
   # `changed_paths*` module). The gate printed this replacement itself —

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -216,6 +216,12 @@ cd "$ROOT" || { echo "run-tests: cannot cd to ROOT=$ROOT" >&2; exit 2; }
 #           pytest.FAIL, not skip, when absent: this is the ONLY file that can
 #           see a resolver-semantics change under an unchanged config, so a skip
 #           there is precisely the silent green the version pin exists to stop.
+#   rsync   scripts/tests/test_subsystem_store_api.py, which drives the real
+#           scripts/subsystem-store-api/seed.sh — its copy step is
+#           `rsync -a --delete "$STORE"/ "$STAGE"/`. Without the binary those
+#           tests fail with rc 127 rather than skipping, deliberately: the
+#           property they pin is that seeding never writes to the local store,
+#           and that store is the only copy of client-confidential content.
 # logrotate: scripts/tests/test_claude_log_rotate.py drives the REAL binary
 # against a temp directory (rotation, truncation, generation cap, and the .bak
 # scope fence). Those tests FAIL rather than skip when it is absent — a skipped
@@ -238,9 +244,21 @@ fi
 if [ "${#missing_tools[@]}" -gt 0 ]; then
   echo "run-tests: FATAL — required tool(s) missing from PATH: ${missing_tools[*]}" >&2
   echo "  The suites SKIP the tests that need these, so the run would go green while" >&2
-  echo "  testing less. Add them to the caller's inputs (flake.nix checks.pytests" >&2
-  echo "  nativeBuildInputs / the pre-push nix-shell) — do NOT drop them from" >&2
-  echo "  REQUIRED_TOOLS to make this pass." >&2
+  echo "  testing less. This is a MISSING ENVIRONMENT, not a code failure — nothing" >&2
+  echo "  in the repo is broken and no test has run yet." >&2
+  echo >&2
+  echo "  FIX — enter the repo's own dev shell, which carries exactly this list," >&2
+  echo "  and re-run from there:" >&2
+  echo >&2
+  echo "      nix develop \"$ROOT\" --command bash \"$ROOT/scripts/run-tests.sh\" \"$ROOT\"" >&2
+  echo >&2
+  echo "  (or \`nix develop\` once, then \`bash scripts/run-tests.sh .\` as often as" >&2
+  echo "  you like). That shell is built from the SAME flake.nix \`gateTools\` list" >&2
+  echo "  as the \`nix flake check\` gate, so it cannot drift out of satisfying this" >&2
+  echo "  precondition." >&2
+  echo >&2
+  echo "  Do NOT drop entries from REQUIRED_TOOLS to make this pass — each one is" >&2
+  echo "  justified in the comment block directly above it." >&2
   exit 2
 fi
 

--- a/scripts/tests/test_devshell_satisfies_required_tools.py
+++ b/scripts/tests/test_devshell_satisfies_required_tools.py
@@ -87,6 +87,21 @@ def emitted_fatal(tmp_path_factory):
     (stub / "bash").symlink_to(bash)
     home = tmp_path_factory.mktemp("home")
 
+    # 🔴 This REPLACES PATH rather than prepending, so it is a registered entry
+    # in test_no_real_launchers.py's PINNED_PATH_CLOBBERS ledger -- the guard
+    # that stops a new clobber from silently dropping the launcher-stub dir.
+    # Replacing is correct here (a precondition about ABSENT binaries cannot be
+    # tested by prepending), and that ledger entry justifies it by ENUMERATING
+    # this directory's contents. The assertion below is what makes the
+    # enumeration a live invariant instead of a claim in a comment: if anything
+    # ever lands in this dir besides the bash symlink, this fails here rather
+    # than quietly widening what the subprocess can reach.
+    assert sorted(p.name for p in stub.iterdir()) == ["bash"], (
+        "the stub PATH dir must hold exactly one entry (a bash symlink); it "
+        f"holds {sorted(p.name for p in stub.iterdir())}. PINNED_PATH_CLOBBERS "
+        "justifies this clobber by enumerating those contents."
+    )
+
     proc = subprocess.run(
         [bash, str(RUN_TESTS), str(REPO_ROOT)],
         env={"PATH": str(stub), "HOME": str(home)},

--- a/scripts/tests/test_devshell_satisfies_required_tools.py
+++ b/scripts/tests/test_devshell_satisfies_required_tools.py
@@ -31,26 +31,94 @@ WHAT EACH TEST HERE IS:
         SEAM guard, NOT regression coverage. They pin the RELATIONSHIP that
         makes the fix durable: one list, two consumers.
 
-🔴 SCOPE OF THE CLAIM. These are source-level checks; they do NOT build the
-shell. That `gateTools` actually satisfies REQUIRED_TOOLS is proven elsewhere
-and better — `checks.pytests` runs this very runner with
-`nativeBuildInputs = gateTools` in the nix sandbox, so if the list were
-insufficient the gate would exit 2 on the precondition. The only way that proof
-stops transferring to the devShell is the two consumers drifting apart, which is
-exactly what the seam tests below forbid. Deliberately not re-verified by a nix
-build here: nested nix builds are not available in the hermetic sandbox tier,
-so such a test would be a skip pretending to be coverage.
+🔴 SCOPE OF THE CLAIM — two tiers, and they are NOT the same strength.
+
+  * The FATAL guard is BEHAVIOURAL. It runs the real runner with a PATH holding
+    only `bash` and reads what it prints. Two text-matching versions of it were
+    walked by auditors before it got here; see the fixture.
+
+  * The flake guards are SOURCE-level, comment-stripped. They can see that
+    `devShells.default` is written and live; they CANNOT see that it evaluates.
+    The behavioural check would be `nix eval ...#devShells.x86_64-linux.default`,
+    which needs the flake's inputs — unavailable in the hermetic tier, which
+    evaluates a `cp -r` of the tree with no inputs and no network. The section
+    header restates this where the guards are.
+
+That `gateTools` actually satisfies REQUIRED_TOOLS is proven elsewhere and
+better: `checks.pytests` runs this very runner with
+`nativeBuildInputs = gateTools` in the nix sandbox, so an insufficient list
+exits 2 on the precondition. The only way that proof stops transferring to the
+devShell is the two consumers drifting apart — which is what the seam guards
+forbid.
 """
 import re
+import shutil
+import subprocess
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 RUN_TESTS = REPO_ROOT / "scripts" / "run-tests.sh"
 FLAKE = REPO_ROOT / "flake.nix"
 
 
+@pytest.fixture(scope="module")
+def emitted_fatal(tmp_path_factory):
+    """RUN the runner with an empty PATH and return what it actually printed.
+
+    🔴 This fixture is the whole point of this file's second review round. The
+    guard here used to READ run-tests.sh as text and match strings in it. That
+    is walkable by a single `#`: an auditor commented out the one copy-pasteable
+    remedy line and the guard reported 6 passed, while the FATAL a human sees
+    had a blank gap where the remedy used to be. Source text is not behaviour.
+
+    Driving the real path is cheap and fully deterministic: the tool
+    precondition is GUARD 1, before any test runs, so with a PATH containing
+    only `bash` the runner exits 2 in milliseconds. `env -i`-style isolation
+    (an explicit env dict) is what makes it independent of the ambient PATH --
+    inside the nix sandbox every REQUIRED_TOOLS binary IS present, so a test
+    that relied on one being absent would measure the environment, not the code.
+    """
+    bash = shutil.which("bash")
+    assert bash, "bash is not on PATH; this suite cannot drive the runner"
+
+    stub = tmp_path_factory.mktemp("only-bash")
+    (stub / "bash").symlink_to(bash)
+    home = tmp_path_factory.mktemp("home")
+
+    proc = subprocess.run(
+        [bash, str(RUN_TESTS), str(REPO_ROOT)],
+        env={"PATH": str(stub), "HOME": str(home)},
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    combined = proc.stdout + proc.stderr
+
+    # POSITIVE CONTROL. Without this, every assertion below could be matching
+    # against output from some OTHER failure -- or against nothing at all -- and
+    # a reassuring pass would mean only "the string I looked for was absent".
+    assert "required tool(s) missing from PATH" in combined, (
+        "driving run-tests.sh with an empty PATH did NOT produce the tool "
+        f"precondition FATAL, so this fixture is measuring the wrong thing.\n"
+        f"exit={proc.returncode}\n{combined[-3000:]}"
+    )
+    assert proc.returncode == 2, (
+        f"expected the precondition to exit 2, got {proc.returncode}\n"
+        f"{combined[-3000:]}"
+    )
+    return combined
+
+
 def _fatal_block() -> str:
-    """The `required tool(s) missing` FATAL block, from its echo to the exit."""
+    """The `required tool(s) missing` FATAL block AS SOURCE TEXT.
+
+    ⚠ Retained only for the assertions that are genuinely about the SOURCE (that
+    the precondition is still spelled as a hard failure). Anything about what
+    the operator SEES must use the `emitted_fatal` fixture instead -- this
+    function cannot tell a live line from a commented-out one.
+    """
     src = RUN_TESTS.read_text()
     start = src.find("required tool(s) missing from PATH")
     assert start != -1, (
@@ -67,42 +135,49 @@ def _fatal_block() -> str:
 # REGRESSION
 # ---------------------------------------------------------------------------
 
-def test_the_missing_tool_fatal_names_a_runnable_invocation():
+def test_the_missing_tool_fatal_names_a_runnable_invocation(emitted_fatal):
     """RED at a29b97b, GREEN at HEAD.
 
     At a29b97b the message named only `flake.nix checks.pytests
     nativeBuildInputs` and `the pre-push nix-shell` -- neither of which is
     something a reader can run.
-    """
-    block = _fatal_block()
 
-    # 🔴 Asserted on a SINGLE LINE carrying BOTH halves, not on the two strings
-    # appearing anywhere in the block. The first version of this guard checked
-    # `"nix develop" in block` and `"run-tests.sh" in block` separately, and a
-    # mutation SURVIVED it: deleting the copy-pasteable invocation line entirely
-    # still left the prose sentence "(or `nix develop` once, then `bash
-    # scripts/run-tests.sh .` ...)" spelling both words, so the guard passed
-    # while the actionable remedy was gone. A word another sentence can spell is
-    # not a guard; what makes the message useful is one runnable line.
+    🔴 Asserted against what the runner PRINTS, not against its source. Two
+    walks have been measured against earlier versions of this guard, and only
+    the second one is closed by wording:
+      round 1 -- checked `"nix develop" in src` and `"run-tests.sh" in src`
+                 separately. SURVIVED deleting the whole invocation line,
+                 because the block's own prose sentence spells both words.
+      round 2 -- required one LINE carrying both. SURVIVED commenting that line
+                 out with a single `#`, because the text was still in the file.
+    Reading stderr closes both: a commented-out echo prints nothing.
+    """
+    # The remedy must survive as ONE line the reader can copy -- not two words
+    # scattered across the prose, which is what round 1 walked.
     invocations = [
-        ln for ln in block.splitlines()
+        ln for ln in emitted_fatal.splitlines()
         if "nix develop" in ln and "run-tests.sh" in ln
     ]
     assert invocations, (
-        "the missing-tool FATAL has no single line that both enters the dev "
-        "shell AND runs the gate. A contributor hitting this gets a red gate "
-        "and no copy-pasteable remedy, which reads as 'the gate is broken'.\n\n"
-        f"FATAL block was:\n{block}"
+        "the missing-tool FATAL printed no single line that both enters the "
+        "dev shell AND runs the gate. A contributor hitting this gets a red "
+        "gate and no copy-pasteable remedy, which reads as 'the gate is "
+        f"broken'.\n\nWhat it actually printed:\n{emitted_fatal}"
     )
-    # The line must be parameterised by the resolved repo root, not a literal
-    # relative path that only works from one cwd.
-    assert any("$ROOT" in ln for ln in invocations), (
-        "the invocation line hardcodes a path instead of using the runner's "
-        f"own resolved $ROOT:\n{invocations}"
+    # $ROOT must have been EXPANDED, not printed literally: the line is only
+    # copy-pasteable if it names a real path. This also pins that the remedy is
+    # parameterised by the runner's own resolved root rather than a fixed
+    # relative path that works from exactly one cwd.
+    assert any(str(REPO_ROOT) in ln for ln in invocations), (
+        "the printed invocation does not contain the resolved repo root, so it "
+        f"is not copy-pasteable:\n{invocations}"
+    )
+    assert not any("$ROOT" in ln for ln in invocations), (
+        f"`$ROOT` was printed literally instead of expanded:\n{invocations}"
     )
     # And it must say this is an environment problem, not a code failure --
     # that misreading is the whole defect.
-    assert "not a code failure" in block, (
+    assert "not a code failure" in emitted_fatal, (
         "the FATAL does not tell the reader the repo is fine; without that, a "
         "red gate on a missing binary still reads as a broken build"
     )
@@ -125,12 +200,69 @@ def test_the_fatal_still_forbids_deleting_the_precondition():
 
 # ---------------------------------------------------------------------------
 # SEAM — one list, two consumers
+#
+# 🔴 SHAPE THIS SECTION CANNOT CATCH, stated rather than left to be discovered.
+# These read flake.nix as SOURCE, because the behavioural check (`nix eval
+# ...#devShells.x86_64-linux.default`) needs the flake's INPUTS, and the
+# hermetic tier evaluates a `cp -r` of the tree with no inputs and no network.
+# So they can see that the attribute is WRITTEN and not commented out; they
+# cannot see that it EVALUATES. A change that leaves the text intact but breaks
+# evaluation (a typo in `gateTools`, a bad `pkgs.` attr, a shadowed binding) is
+# invisible here and is caught only by `nix flake check` / a real `nix develop`.
+#
+# What they DO now catch, and did not before: commenting the block out. An
+# auditor wrapped the whole devShells block in `/* ... */`, leaving flake.nix
+# valid, and every test in this file passed while `nix develop` answered
+#     error: flake '...' does not provide attribute 'devShells.x86_64-linux.default'
+# `_uncommented_flake()` strips nix comments before matching, so that mutant now
+# dies. Comment-stripping is a TEXT defence against a TEXT walk -- it is not a
+# substitute for evaluation, which is why the gap above is spelled out.
 # ---------------------------------------------------------------------------
 
-def test_a_default_devshell_exists():
-    """The thing the FATAL tells you to enter must actually be defined."""
+def _uncommented_flake() -> str:
+    """flake.nix with nix comments removed, so a commented-out block cannot match.
+
+    Handles both nix comment forms: `/* ... */` blocks and `#` line comments.
+    Deliberately simple rather than a real nix lexer -- a `#` inside a string
+    literal (a URL fragment, say) truncates that line, which is harmless for the
+    structural anchors matched here and is the conservative direction: it can
+    only ever HIDE text from a match, never invent it. The positive control
+    below proves it does not hide the anchors we depend on.
+    """
     src = FLAKE.read_text()
-    assert re.search(r"devShells\.\$\{system\}\.default\s*=", src), (
+    src = re.sub(r"/\*.*?\*/", "", src, flags=re.S)
+    src = re.sub(r"#[^\n]*", "", src)
+    return src
+
+
+def test_the_comment_stripper_keeps_live_code_positive_control():
+    """A stripper that ate everything would make every test below vacuous.
+
+    Pins both directions: live anchors SURVIVE stripping, and text that is only
+    present inside a comment DOES NOT.
+    """
+    stripped = _uncommented_flake()
+    assert "devShells" in stripped, "the stripper removed live code"
+    assert "gateTools" in stripped, "the stripper removed live code"
+    # A sentence that exists only inside a comment in flake.nix must be gone.
+    raw = FLAKE.read_text()
+    assert "THE GATE'S TOOLCHAIN" in raw, (
+        "the comment this control keys on was reworded; pick another "
+        "comment-only string rather than deleting the control"
+    )
+    assert "THE GATE'S TOOLCHAIN" not in stripped, (
+        "the stripper did NOT remove comment text, so every guard below is "
+        "still walkable by commenting the code out"
+    )
+
+
+def test_a_default_devshell_exists():
+    """The thing the FATAL tells you to enter must actually be defined.
+
+    Matched against comment-stripped source: a `/* ... */` around this block
+    used to pass here while `nix develop` 404'd.
+    """
+    assert re.search(r"devShells\.\$\{system\}\.default\s*=", _uncommented_flake()), (
         "flake.nix defines no devShells.<system>.default, but run-tests.sh's "
         "FATAL tells the reader to run `nix develop`. The remedy would 404."
     )
@@ -141,9 +273,10 @@ def test_the_devshell_and_the_gate_share_one_tool_list():
 
     Fails if either side inlines its own list again -- the drift that would
     silently make `nix develop` stop satisfying the precondition it is
-    advertised as satisfying.
+    advertised as satisfying. Comment-stripped for the same reason as above:
+    `packages = gateTools;` stayed spelled inside the auditor's block comment.
     """
-    src = FLAKE.read_text()
+    src = _uncommented_flake()
 
     assert re.search(r"nativeBuildInputs\s*=\s*gateTools\s*;", src), (
         "checks.pytests no longer uses `gateTools` for nativeBuildInputs. If "
@@ -157,8 +290,7 @@ def test_the_devshell_and_the_gate_share_one_tool_list():
 
 def test_gate_tools_is_defined_exactly_once():
     """SEAM guard: a SECOND definition of gateTools would defeat the sharing."""
-    src = FLAKE.read_text()
-    definitions = re.findall(r"^\s*gateTools\s*=", src, re.M)
+    definitions = re.findall(r"^\s*gateTools\s*=", _uncommented_flake(), re.M)
     assert len(definitions) == 1, (
         f"expected exactly one `gateTools =` binding, found {len(definitions)}. "
         "Two bindings means the gate and the shell can be given different lists "
@@ -178,10 +310,30 @@ def test_every_required_tool_is_justified_in_the_comment_block():
     tools = m.group(1).split()
     assert len(tools) >= 10, f"parsed only {tools} -- the parser is broken, not the list"
 
-    # The justification block is the comment run immediately preceding it.
-    block = src[:m.start()]
-    block = block[block.rfind("\n\n"):]
-    unjustified = [t for t in tools if t not in block]
+    # 🔴 The justification block is the CONTIGUOUS RUN OF `#` LINES immediately
+    # above the array -- walked backwards line by line, not `rfind("\n\n")`.
+    # Measured: `rfind` reached 51 lines back, swallowing the `unset CDPATH`
+    # prose, so unrelated English was being accepted as justification.
+    block_lines = []
+    for line in reversed(src[:m.start()].splitlines()):
+        if line.lstrip().startswith("#"):
+            block_lines.append(line)
+        elif line.strip() == "":
+            continue  # blank lines inside the comment run are fine
+        else:
+            break  # first line of real code ends the block
+    block = "\n".join(block_lines)
+
+    # 🔴 WORD matching, not substring containment. `t not in block` reported
+    # "justified" for any tool whose name is a substring of unrelated prose --
+    # `ed`, `tr`, `cat`, `id` and `who` all passed with zero justification, and
+    # `at` passed on the English word "at" even under word boundaries, which is
+    # why the block above had to be narrowed as well. Both fixes are load-
+    # bearing; neither alone closes it.
+    def justified(tool):
+        return re.search(rf"(?<![\w-]){re.escape(tool)}(?![\w-])", block) is not None
+
+    unjustified = [t for t in tools if not justified(t)]
     assert not unjustified, (
         f"REQUIRED_TOOLS entries with no justification in the comment block "
         f"above them: {unjustified}. The FATAL promises the reader one."

--- a/scripts/tests/test_devshell_satisfies_required_tools.py
+++ b/scripts/tests/test_devshell_satisfies_required_tools.py
@@ -1,0 +1,174 @@
+"""The gate's tool precondition must be DISCOVERABLE, and stay satisfiable.
+
+THE DEFECT (measured on origin/main, a29b97b):
+
+    $ nix-shell -p 'python312.withPackages(...)' \
+        --run "bash scripts/run-tests.sh ." 2>&1 | tail -5
+    run-tests: FATAL — required tool(s) missing from PATH: logrotate
+      ...  Add them to the caller's inputs (flake.nix checks.pytests
+      nativeBuildInputs / the pre-push nix-shell) — do NOT drop them from
+      REQUIRED_TOOLS to make this pass.
+    RESULT: FAIL (exit=2)
+
+The precondition itself is CORRECT and is not what changed: the suites `skipif`
+on these binaries, so a missing one takes the run green while testing less.
+What was wrong was discoverability. The remedy it named — `flake.nix
+checks.pytests nativeBuildInputs` — is a derivation you cannot stand inside, and
+the repo had NO devShell, so a contributor's only route was to reverse-engineer
+the list into an ad-hoc `nix-shell -p ...`. Get it wrong and you get a red gate
+that reads like a code failure.
+
+The fix is a `devShells.default` built from the SAME `gateTools` list as
+`checks.pytests`, and a FATAL that names the exact invocation.
+
+WHAT EACH TEST HERE IS:
+
+  * test_the_missing_tool_fatal_names_a_runnable_invocation
+        REGRESSION. Red at a29b97b (no `nix develop` anywhere in the message),
+        green at HEAD.
+  * test_a_default_devshell_exists  /  test_the_devshell_and_the_gate_share_one
+    tool_list  /  test_gate_tools_is_defined_exactly_once
+        SEAM guard, NOT regression coverage. They pin the RELATIONSHIP that
+        makes the fix durable: one list, two consumers.
+
+🔴 SCOPE OF THE CLAIM. These are source-level checks; they do NOT build the
+shell. That `gateTools` actually satisfies REQUIRED_TOOLS is proven elsewhere
+and better — `checks.pytests` runs this very runner with
+`nativeBuildInputs = gateTools` in the nix sandbox, so if the list were
+insufficient the gate would exit 2 on the precondition. The only way that proof
+stops transferring to the devShell is the two consumers drifting apart, which is
+exactly what the seam tests below forbid. Deliberately not re-verified by a nix
+build here: nested nix builds are not available in the hermetic sandbox tier,
+so such a test would be a skip pretending to be coverage.
+"""
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUN_TESTS = REPO_ROOT / "scripts" / "run-tests.sh"
+FLAKE = REPO_ROOT / "flake.nix"
+
+
+def _fatal_block() -> str:
+    """The `required tool(s) missing` FATAL block, from its echo to the exit."""
+    src = RUN_TESTS.read_text()
+    start = src.find("required tool(s) missing from PATH")
+    assert start != -1, (
+        "could not find the 'required tool(s) missing from PATH' FATAL in "
+        "run-tests.sh. If it was reworded, update this parser -- do NOT delete "
+        "the test, or the message goes back to being unguarded."
+    )
+    end = src.find("exit 2", start)
+    assert end != -1, "found the FATAL but not its `exit 2`; the parser is broken"
+    return src[start:end]
+
+
+# ---------------------------------------------------------------------------
+# REGRESSION
+# ---------------------------------------------------------------------------
+
+def test_the_missing_tool_fatal_names_a_runnable_invocation():
+    """RED at a29b97b, GREEN at HEAD.
+
+    At a29b97b the message named only `flake.nix checks.pytests
+    nativeBuildInputs` and `the pre-push nix-shell` -- neither of which is
+    something a reader can run.
+    """
+    block = _fatal_block()
+
+    assert "nix develop" in block, (
+        "the missing-tool FATAL does not name `nix develop`. A contributor "
+        "hitting this gets a red gate and no runnable remedy, which reads as "
+        "'the gate is broken'."
+    )
+    # It must name the RUNNER too, or `nix develop` alone still leaves the
+    # reader to reconstruct what to run inside it.
+    assert "run-tests.sh" in block, (
+        "the FATAL names a shell to enter but not the command to run in it"
+    )
+    # And it must say this is an environment problem, not a code failure --
+    # that misreading is the whole defect.
+    assert "not a code failure" in block, (
+        "the FATAL does not tell the reader the repo is fine; without that, a "
+        "red gate on a missing binary still reads as a broken build"
+    )
+
+
+def test_the_fatal_still_forbids_deleting_the_precondition():
+    """INVARIANT guard — the precondition must not be softened into advice.
+
+    Making the message friendlier is exactly the edit that would also make
+    "just drop logrotate from REQUIRED_TOOLS" sound reasonable. It must not.
+    """
+    block = _fatal_block()
+    assert "Do NOT drop entries from REQUIRED_TOOLS" in block or \
+           "do NOT drop them from" in block, block
+    assert "go green while" in block, (
+        "the message no longer explains WHY a missing tool is fatal (the run "
+        "would go green while testing less)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# SEAM — one list, two consumers
+# ---------------------------------------------------------------------------
+
+def test_a_default_devshell_exists():
+    """The thing the FATAL tells you to enter must actually be defined."""
+    src = FLAKE.read_text()
+    assert re.search(r"devShells\.\$\{system\}\.default\s*=", src), (
+        "flake.nix defines no devShells.<system>.default, but run-tests.sh's "
+        "FATAL tells the reader to run `nix develop`. The remedy would 404."
+    )
+
+
+def test_the_devshell_and_the_gate_share_one_tool_list():
+    """SEAM guard: both consumers must reference `gateTools`, not a copy.
+
+    Fails if either side inlines its own list again -- the drift that would
+    silently make `nix develop` stop satisfying the precondition it is
+    advertised as satisfying.
+    """
+    src = FLAKE.read_text()
+
+    assert re.search(r"nativeBuildInputs\s*=\s*gateTools\s*;", src), (
+        "checks.pytests no longer uses `gateTools` for nativeBuildInputs. If "
+        "the gate gets its own inlined list again, the devShell can drift out "
+        "of satisfying REQUIRED_TOOLS with nothing to notice."
+    )
+    assert re.search(r"packages\s*=\s*gateTools\s*;", src), (
+        "devShells.default no longer uses `gateTools`. Same drift, other side."
+    )
+
+
+def test_gate_tools_is_defined_exactly_once():
+    """SEAM guard: a SECOND definition of gateTools would defeat the sharing."""
+    src = FLAKE.read_text()
+    definitions = re.findall(r"^\s*gateTools\s*=", src, re.M)
+    assert len(definitions) == 1, (
+        f"expected exactly one `gateTools =` binding, found {len(definitions)}. "
+        "Two bindings means the gate and the shell can be given different lists "
+        "while every other test here still passes."
+    )
+
+
+def test_every_required_tool_is_justified_in_the_comment_block():
+    """INVARIANT guard, and a positive control on the REQUIRED_TOOLS parser.
+
+    The FATAL now claims 'each one is justified in the comment block directly
+    above it'. That is a claim about the file, so it is checked.
+    """
+    src = RUN_TESTS.read_text()
+    m = re.search(r"^REQUIRED_TOOLS=\((.*?)\)\s*$", src, re.M)
+    assert m, "could not parse REQUIRED_TOOLS from run-tests.sh"
+    tools = m.group(1).split()
+    assert len(tools) >= 10, f"parsed only {tools} -- the parser is broken, not the list"
+
+    # The justification block is the comment run immediately preceding it.
+    block = src[:m.start()]
+    block = block[block.rfind("\n\n"):]
+    unjustified = [t for t in tools if t not in block]
+    assert not unjustified, (
+        f"REQUIRED_TOOLS entries with no justification in the comment block "
+        f"above them: {unjustified}. The FATAL promises the reader one."
+    )

--- a/scripts/tests/test_devshell_satisfies_required_tools.py
+++ b/scripts/tests/test_devshell_satisfies_required_tools.py
@@ -76,15 +76,29 @@ def test_the_missing_tool_fatal_names_a_runnable_invocation():
     """
     block = _fatal_block()
 
-    assert "nix develop" in block, (
-        "the missing-tool FATAL does not name `nix develop`. A contributor "
-        "hitting this gets a red gate and no runnable remedy, which reads as "
-        "'the gate is broken'."
+    # 🔴 Asserted on a SINGLE LINE carrying BOTH halves, not on the two strings
+    # appearing anywhere in the block. The first version of this guard checked
+    # `"nix develop" in block` and `"run-tests.sh" in block` separately, and a
+    # mutation SURVIVED it: deleting the copy-pasteable invocation line entirely
+    # still left the prose sentence "(or `nix develop` once, then `bash
+    # scripts/run-tests.sh .` ...)" spelling both words, so the guard passed
+    # while the actionable remedy was gone. A word another sentence can spell is
+    # not a guard; what makes the message useful is one runnable line.
+    invocations = [
+        ln for ln in block.splitlines()
+        if "nix develop" in ln and "run-tests.sh" in ln
+    ]
+    assert invocations, (
+        "the missing-tool FATAL has no single line that both enters the dev "
+        "shell AND runs the gate. A contributor hitting this gets a red gate "
+        "and no copy-pasteable remedy, which reads as 'the gate is broken'.\n\n"
+        f"FATAL block was:\n{block}"
     )
-    # It must name the RUNNER too, or `nix develop` alone still leaves the
-    # reader to reconstruct what to run inside it.
-    assert "run-tests.sh" in block, (
-        "the FATAL names a shell to enter but not the command to run in it"
+    # The line must be parameterised by the resolved repo root, not a literal
+    # relative path that only works from one cwd.
+    assert any("$ROOT" in ln for ln in invocations), (
+        "the invocation line hardcodes a path instead of using the runner's "
+        f"own resolved $ROOT:\n{invocations}"
     )
     # And it must say this is an environment problem, not a code failure --
     # that misreading is the whole defect.

--- a/scripts/tests/test_hook_tests_dir_collects.py
+++ b/scripts/tests/test_hook_tests_dir_collects.py
@@ -62,10 +62,24 @@ def _pytest(*args, cwd=None):
 # ---------------------------------------------------------------------------
 
 def test_the_hook_tests_directory_collects_without_an_internal_error():
-    """RED at a29b97b (INTERNALERROR + 'no tests ran'), GREEN at HEAD.
+    """RED at a29b97b, GREEN at HEAD — but only ONE of its three assertions is
+    regression coverage, and the split is measured, not assumed.
 
     Asserted on --collect-only so this stays cheap: the bug was in COLLECTION,
-    and running the ~1900 real tests here would just be the gate again.
+    and running the ~1900 real tests here would just be the gate again. That
+    choice has a consequence worth naming rather than glossing:
+
+        MEASURED at a29b97b under --collect-only:
+            "INTERNALERROR>"  105 occurrences
+            "no tests ran"      0 occurrences
+
+    So the INTERNALERROR assertion is what fails on pre-change code -- it is the
+    REGRESSION. The "no tests ran" assertion is an INVARIANT GUARD riding along
+    inside this test: the phrase belongs to a full run (which is how the defect
+    was originally reported), and --collect-only never prints it, so that
+    assertion has never been red and pins the reassuring-zero wording rather
+    than proving anything about the bug. The collected-count check below is a
+    positive control. Three assertions, three different jobs.
     """
     proc = _pytest(str(HOOK_TESTS_DIR), "-q", "--collect-only")
     out = proc.stdout + proc.stderr
@@ -130,6 +144,51 @@ def test_a_module_that_exits_at_import_is_a_named_error_not_no_tests_ran(tmp_pat
         "the failure is not the named, actionable one conftest.py raises:\n\n"
         + out[-4000:]
     )
+
+
+@pytest.mark.parametrize("exit_code, want_outcome", [(0, "passed"), (1, "failed")])
+def test_a_script_suites_exit_code_decides_its_verdict(tmp_path, exit_code, want_outcome):
+    """The verdict mapping, pinned in BOTH directions.
+
+    Without this nothing ever RAN a script suite through conftest.py -- the
+    directory test uses --collect-only, which builds the item but never executes
+    it. A mutant that made `runtest` ignore the subprocess's return code (so
+    every script suite passes, forever, including a genuinely broken one) would
+    therefore have SURVIVED the whole battery. Measured, and it did: that is why
+    this test exists.
+
+    Parametrized rather than asserted one-way on purpose. A test that only pins
+    "exit 1 fails" is satisfied by a runtest that fails EVERYTHING; a test that
+    only pins "exit 0 passes" is satisfied by one that passes everything. The
+    pair is what makes the mapping, not either half.
+
+    Runs in a tmp sandbox, which also exercises `_find_repo_root`'s copy path:
+    the positional `parents[2]` this replaced produced a garbage root here.
+    """
+    sandbox = tmp_path / "tests"
+    sandbox.mkdir()
+    shutil.copy(CONFTEST, sandbox / "conftest.py")
+    # Script-shaped: no top-level `def test_*`, so the classifier must route it
+    # to the subprocess path rather than importing it.
+    (sandbox / "test_script_suite.py").write_text(
+        "import sys\n"
+        "print('the suite ran and is reporting its own verdict')\n"
+        f"sys.exit({exit_code})\n"
+    )
+
+    proc = _pytest(str(sandbox), "-q", cwd=tmp_path)
+    out = proc.stdout + proc.stderr
+
+    assert f"1 {want_outcome}" in out, (
+        f"a script suite exiting {exit_code} should be reported {want_outcome!r}, "
+        f"and was not.\n\n{out[-4000:]}"
+    )
+    if want_outcome == "failed":
+        # The script's own output must reach the report, or a failing suite is
+        # undiagnosable from the gate log.
+        assert "the suite ran and is reporting its own verdict" in out, (
+            "the failing script suite's stdout was swallowed:\n\n" + out[-4000:]
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_hook_tests_dir_collects.py
+++ b/scripts/tests/test_hook_tests_dir_collects.py
@@ -1,0 +1,249 @@
+"""`pytest scripts/claude-hooks/tests/` must run, or fail LOUDLY — never zero.
+
+THE DEFECT (measured on origin/main, a29b97b):
+
+    $ python3 -m pytest scripts/claude-hooks/tests/ -q
+    INTERNALERROR> ... File ".../tests/test_bash_guard.py", line 436, in <module>
+    INTERNALERROR>     sys.exit(1 if fail else 0)
+    INTERNALERROR> SystemExit: 0
+
+    no tests ran in 4.99s
+
+That directory mixes ordinary pytest modules with hand-rolled SCRIPT suites
+that do their work at import and end in `sys.exit()`. Collecting one imports
+it, so it ran and exited during collection; SystemExit is a BaseException, so
+it escaped as INTERNALERROR and the session reported **"no tests ran"** —
+indistinguishable from a clean zero.
+
+`scripts/run-tests.sh` never saw it: it names the collectable files
+individually and runs the scripts itself. So the gate was green while the
+obvious directory invocation was a crash wearing a zero's clothes.
+
+WHAT EACH TEST HERE IS (labelled, because "it passes" is not a category):
+
+  * test_the_hook_tests_directory_collects_without_an_internal_error
+        REGRESSION. Red at a29b97b, green at HEAD.
+  * test_a_module_that_exits_at_import_is_a_named_error_not_no_tests_ran
+        REGRESSION for the CLASS, via a synthetic module planted in a copy of
+        the directory. Red at a29b97b, green at HEAD.
+  * test_the_classifier_matches_run_tests_shs_own_two_lists (+ its parser
+    positive controls)
+        SEAM / LEDGER guard, not regression coverage. conftest.py decides
+        script-vs-module structurally; run-tests.sh decides it with two
+        hand-maintained lists. Nothing made those agree. This fails when the
+        sets GROW or SHRINK on either side.
+"""
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_TESTS_DIR = REPO_ROOT / "scripts" / "claude-hooks" / "tests"
+RUN_TESTS = REPO_ROOT / "scripts" / "run-tests.sh"
+CONFTEST = HOOK_TESTS_DIR / "conftest.py"
+
+
+def _pytest(*args, cwd=None):
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", "-p", "no:cacheprovider", *args],
+        cwd=str(cwd or REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+
+
+# ---------------------------------------------------------------------------
+# REGRESSION
+# ---------------------------------------------------------------------------
+
+def test_the_hook_tests_directory_collects_without_an_internal_error():
+    """RED at a29b97b (INTERNALERROR + 'no tests ran'), GREEN at HEAD.
+
+    Asserted on --collect-only so this stays cheap: the bug was in COLLECTION,
+    and running the ~1900 real tests here would just be the gate again.
+    """
+    proc = _pytest(str(HOOK_TESTS_DIR), "-q", "--collect-only")
+    out = proc.stdout + proc.stderr
+
+    # The literal symptom, both halves. Matched on `INTERNALERROR>` WITH the
+    # angle bracket -- that is pytest's own line prefix, and the bare word
+    # appears in conftest.py's explanatory error text, so asserting on it made
+    # this guard match its own fix.
+    assert "INTERNALERROR>" not in out, (
+        "collecting the hook tests directory raised INTERNALERROR again.\n"
+        "Something in it calls sys.exit() at import and conftest.py did not "
+        f"classify it as a script suite.\n\n{out[-4000:]}"
+    )
+    assert "no tests ran" not in out, (
+        "collecting the hook tests directory reported 'no tests ran' — the "
+        "reassuring zero this whole file exists to stop.\n\n" + out[-4000:]
+    )
+    assert proc.returncode == 0, f"exit={proc.returncode}\n\n{out[-4000:]}"
+
+    # Positive control: prove collection actually SAW the suites, so a future
+    # regression cannot satisfy the two assertions above by collecting nothing
+    # in some quieter way.
+    m = re.search(r"(\d+) tests collected", out)
+    assert m, f"could not find a 'N tests collected' line:\n\n{out[-4000:]}"
+    collected = int(m.group(1))
+    assert collected > 1500, (
+        f"only {collected} tests collected from {HOOK_TESTS_DIR.name}/; the "
+        "directory holds ~1900. A collapse this large means most of it stopped "
+        "being collected."
+    )
+
+
+def test_a_module_that_exits_at_import_is_a_named_error_not_no_tests_ran(tmp_path):
+    """RED at a29b97b, GREEN at HEAD — the CLASS, not just today's file.
+
+    A file with real top-level `def test_*` functions that ALSO calls sys.exit()
+    at import is not classified as a script suite, so layer 1 does not catch it.
+    Layer 2 must turn it into a named CollectError rather than an INTERNALERROR.
+    """
+    sandbox = tmp_path / "tests"
+    sandbox.mkdir()
+    shutil.copy(CONFTEST, sandbox / "conftest.py")
+    (sandbox / "test_exits_at_import.py").write_text(
+        "import sys\n"
+        "def test_never_reached():\n"
+        "    assert True\n"
+        "sys.exit(0)\n"
+    )
+
+    proc = _pytest(str(sandbox), "-q", "--collect-only", cwd=tmp_path)
+    out = proc.stdout + proc.stderr
+
+    # `INTERNALERROR>` with the bracket -- see the note in the test above.
+    assert "INTERNALERROR>" not in out, f"still an INTERNALERROR:\n\n{out[-4000:]}"
+    assert proc.returncode != 0, (
+        "a module that exits at import was reported as SUCCESS — that is the "
+        f"reassuring zero.\n\n{out[-4000:]}"
+    )
+    # Named, and it says what to do. Pin the distinctive phrase, not a word any
+    # other error could spell.
+    assert "called sys.exit(0) while pytest was IMPORTING it" in out, (
+        "the failure is not the named, actionable one conftest.py raises:\n\n"
+        + out[-4000:]
+    )
+
+
+# ---------------------------------------------------------------------------
+# SEAM / LEDGER — conftest.py's classifier vs run-tests.sh's two lists
+# ---------------------------------------------------------------------------
+
+def _bash_array(name: str) -> list[str]:
+    """Parse a `NAME=( ... )` array out of run-tests.sh, dropping comments."""
+    src = RUN_TESTS.read_text()
+    m = re.search(rf"^{name}=\((.*?)^\)", src, re.S | re.M)
+    assert m, (
+        f"could not find a {name}=( ... ) block in run-tests.sh. If the array "
+        "was renamed, update this parser -- do NOT delete the test, or the "
+        "classifier goes back to being unguarded."
+    )
+    out = []
+    for raw in m.group(1).splitlines():
+        line = raw.strip().strip('"')
+        if not line or line.startswith("#"):
+            continue
+        out.append(line)
+    return out
+
+
+def _classifier():
+    """Import conftest.py's classifier by path, without importing the package."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("_hook_tests_conftest", CONFTEST)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_the_parsers_find_something_positive_control():
+    """Both parsers must be shown capable of a NON-EMPTY answer.
+
+    Without this, every set comparison below could compare empty to empty and
+    pass while measuring nothing.
+    """
+    hook_tests = [t for t in _bash_array("HOOK_TESTS") if t.startswith("scripts/")]
+    hermetic = [t for t in _bash_array("HERMETIC_TARGETS") if t.startswith("scripts/")]
+    assert len(hook_tests) >= 5, hook_tests
+    assert len(hermetic) >= 10, len(hermetic)
+
+    mod = _classifier()
+    scripts = [p for p in sorted(HOOK_TESTS_DIR.glob("test_*.py")) if mod.is_script_suite(p)]
+    modules = [p for p in sorted(HOOK_TESTS_DIR.glob("test_*.py")) if not mod.is_script_suite(p)]
+    assert scripts, "the classifier found NO script suites -- it is broken, not the directory"
+    assert modules, "the classifier found NO pytest modules -- it is broken, not the directory"
+
+
+def test_the_classifier_matches_run_tests_shs_own_two_lists():
+    """INVARIANT / SEAM guard — NOT regression coverage.
+
+    conftest.py classifies structurally; run-tests.sh carries two hand-written
+    lists that mean the same thing. This asserts the ledger both ways, so the
+    set cannot grow or shrink on one side only. It fails when a suite is added
+    to the directory and to one list but not the other -- the state in which
+    the directory invocation crashes again, or the gate silently stops running
+    a suite.
+    """
+    mod = _classifier()
+    on_disk = sorted(HOOK_TESTS_DIR.glob("test_*.py"))
+
+    classified_scripts = {p.name for p in on_disk if mod.is_script_suite(p)}
+    classified_modules = {p.name for p in on_disk if not mod.is_script_suite(p)}
+
+    prefix = "scripts/claude-hooks/tests/"
+    gate_scripts = {t[len(prefix):] for t in _bash_array("HOOK_TESTS") if t.startswith(prefix)}
+    gate_modules = {t[len(prefix):] for t in _bash_array("HERMETIC_TARGETS") if t.startswith(prefix)}
+
+    assert classified_scripts == gate_scripts, (
+        "conftest.py's script-suite classification disagrees with run-tests.sh's "
+        f"HOOK_TESTS.\n  conftest says: {sorted(classified_scripts)}\n"
+        f"  HOOK_TESTS says: {sorted(gate_scripts)}\n"
+        "Add the new suite to BOTH, or give it top-level `def test_` functions."
+    )
+    assert classified_modules == gate_modules, (
+        "conftest.py's pytest-module classification disagrees with run-tests.sh's "
+        f"HERMETIC_TARGETS.\n  conftest says: {sorted(classified_modules)}\n"
+        f"  HERMETIC_TARGETS says: {sorted(gate_modules)}\n"
+        "A collectable suite here that the gate does not name is a suite NOTHING runs."
+    )
+
+
+@pytest.mark.parametrize(
+    "source, expected_script",
+    [
+        ("import sys\nprint('work')\nsys.exit(0)\n", True),
+        ("def test_a():\n    assert True\n", False),
+        ("class TestThing:\n    def test_a(self):\n        assert True\n", False),
+        ("async def test_a():\n    assert True\n", False),
+        ("def helper():\n    return 1\n", True),
+    ],
+)
+def test_the_classifier_reads_structure_not_names(tmp_path, source, expected_script):
+    """INVARIANT guard on `has_toplevel_test_functions` itself.
+
+    The set comparison above would still pass if the classifier were replaced by
+    a hard-coded filename list, which is the version that rots. This pins that
+    the decision is made from the file's STRUCTURE.
+
+    Exercised in tmp_path, deliberately: `is_script_suite` additionally requires
+    the file to live in the hook tests directory, and planting probe files there
+    would be visible to a concurrently-running gate.
+    """
+    mod = _classifier()
+    probe = tmp_path / "test_probe.py"
+    probe.write_text(source)
+    # `is_script_suite` == "in that directory" AND "no top-level tests"; the
+    # second half is the part that can be wrong, so it is the part pinned here.
+    assert mod.has_toplevel_test_functions(probe) is (not expected_script)
+    assert mod.is_script_suite(probe) is False, (
+        "is_script_suite must stay scoped to the hook tests directory -- every "
+        "other tests/ tree in this repo is pure pytest and must not be reclassified"
+    )

--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -931,6 +931,25 @@ PINNED_PATH_CLOBBERS = {
         "SC_FAIL_ALL/SC_FAIL_SHOW modes of the stub, with systemctl very much "
         "on PATH. No launcher in HAZARD_VOCABULARY is reachable "
         "from it: no systemctl, kubectl, gh, ssh, home-manager or pkill"),
+    "test_devshell_satisfies_required_tools.py": (
+        '{"PATH"' + ': str(stub)',
+        "the SECOND clobber justified by ENUMERATION rather than emptiness, and "
+        "the stronger case of the two: the replacement directory is created by "
+        "the fixture itself two lines above the clobber "
+        "(`tmp_path_factory.mktemp(\"only-bash\")`, then one "
+        "`(stub / \"bash\").symlink_to(bash)`), so its contents are not merely "
+        "audited but CONSTRUCTED — it holds exactly one entry, a bash symlink, "
+        "and nothing else can appear in a freshly-minted tmp dir. No "
+        "HAZARD_VOCABULARY name is reachable from it: no systemd-run, "
+        "systemctl, notify-send, rofi, yad, xdotool, i3-msg, openrgb, espanso, "
+        "home-manager or nixos-rebuild. 🔴 REPLACING is the point, not an "
+        "oversight: the fixture drives run-tests.sh's tool precondition, whose "
+        "whole job is to react to binaries being ABSENT, and no amount of "
+        "PREPENDING can make a binary unfindable — inside the nix sandbox every "
+        "REQUIRED_TOOLS binary IS present, so a prepending version would "
+        "measure the environment instead of the code. The fixture ASSERTS the "
+        "one-entry contents itself, so this justification is a live invariant "
+        "rather than prose that can rot"),
 }
 
 


### PR DESCRIPTION
Two harness/DX defects. Both reproduced verbatim on a pristine `origin/main` worktree before any change, and both re-measured against it after.

> **Baseline note.** The brief cited `4740e40`; `origin/main` had advanced 7 commits by the time I branched, so **every "red at" claim below is against `a29b97b`** (the actual pre-change ref, with `4740e40` as an ancestor). Both symptoms reproduce identically there.

---

## Defect 1 — running the hook tests as a DIRECTORY reported a reassuring zero

**Symptom, verbatim on `a29b97b`:**

```
$ python3 -m pytest scripts/claude-hooks/tests/ -q
INTERNALERROR> ... File ".../tests/test_bash_guard.py", line 436, in <module>
INTERNALERROR>     sys.exit(1 if fail else 0)
INTERNALERROR> SystemExit: 0

no tests ran in 4.99s
```

**Root cause.** That directory hides *two kinds of file* behind one `test_*.py` name. Six are ordinary pytest modules. Five are hand-rolled **script suites**: they do all their work at import, print their own PASS/FAIL lines, and end in `sys.exit()`. pytest collects one by *importing* it — so the script ran during collection and exited. `SystemExit` derives from `BaseException`, so pytest does not treat it as a collection error; it escaped as `INTERNALERROR` and the session ended **"no tests ran"**.

`scripts/run-tests.sh` never saw this: it names the collectable files *individually* and runs the five scripts itself. So the gate was green while the obvious directory invocation was a crash wearing a zero's clothes.

Exactly one file exits unconditionally at module scope (`test_bash_guard.py:436`); the other four exit only on failure, so they merely *executed their whole body* during collection — which is why the pre-fix collection also emitted stray tracebacks and took 9.77s.

**Fix — two layers, one interception point.**

1. **Classify structurally, then never import a script suite.** A file is a script suite iff it has no top-level `def test_*` / `class Test*`, decided with `ast.parse` — no import, so a script suite is never executed to find out what it is. Measured over the directory, that splits it exactly: the 5 files with zero top-level test functions are precisely `HOOK_TESTS`; the 6 with many are precisely the `HERMETIC_TARGETS` entries. Script suites run as a subprocess, one item, exit 0 is pass — the same way the gate runs them. A hard-coded list would rot on the next suite added, and the rotted state *is* the crash.
2. **Turn the whole class loud.** Any *future* `sys.exit()` at import now lands as a named `CollectError` naming the file and what to do — never again as `INTERNALERROR` / "no tests ran".

> 🔴 Interception is `pytest_pycollect_makemodule`, **not** `pytest_collect_file`. The latter is not a `firstresult` hook — pytest unions every plugin's return, so claiming the file there left the builtin python collector free to *also* import it. Measured: 1943 items **and** an error on the same file. That first attempt is in the branch history.

**Result:** `pytest scripts/claude-hooks/tests/` → **1943 passed in 23.90s**, all eleven suites, collection 9.77s → 0.76s.

---

## Defect 2 — the gate FATAL'd on a missing tool in a way that read as "the gate is broken"

**Symptom, verbatim on `a29b97b`:**

```
run-tests: FATAL — required tool(s) missing from PATH: logrotate
  ... Add them to the caller's inputs (flake.nix checks.pytests
  nativeBuildInputs / the pre-push nix-shell) — do NOT drop them from
  REQUIRED_TOOLS to make this pass.
RESULT: FAIL (exit=2)
```

**The precondition is correct and is kept** — the suites `skipif` on these binaries, so a missing one takes the run green while testing less. The defect is discoverability: the remedy it named (`flake.nix checks.pytests nativeBuildInputs`) is a derivation you cannot stand inside, and **the repo had no devShell at all**, so the only route was to reverse-engineer the list into an ad-hoc `nix-shell -p …`. Get it wrong and you get a red gate that reads like a code failure.

**Fix — chosen deliberately over just rewording the message.** A better message alone would still leave the contributor assembling the toolchain by hand, and would rot the moment `REQUIRED_TOOLS` grew. So:

- `flake.nix` gains `devShells.default`, built from a **hoisted `gateTools` binding that `checks.pytests.nativeBuildInputs` now also consumes**. One list, two consumers — the shell a contributor is told to enter *cannot* drift out of satisfying the precondition that told them to enter it.
- The FATAL names the exact, copy-pasteable invocation, says plainly that this is a **missing environment, not a code failure**, and still forbids deleting entries from `REQUIRED_TOOLS`.
- `rsync` had **no** justification in the runner's comment block, which made the message's promise ("each one is justified above") false. Added, naming the real consumer (`test_subsystem_store_api.py` → `seed.sh`).

**Verified end-to-end, not just by eval:** the final gate runs were launched *through the new shell* — `nix develop <repo> --command bash scripts/run-tests.sh <repo>` — which built the shell and cleared the tool precondition. That is the fix exercising itself.

---

## Red / green matrix

**18** new tests (15 + 3 added in the audit round). Copied verbatim into a pristine detached `a29b97b` worktree:

| | `a29b97b` | HEAD |
|---|---|---|
| both new files | **17 failed, 1 passed** | **18 passed** |

The headline regression fails at baseline **for the right reason** — the assertion message quotes real `INTERNALERROR>` lines from the collector.

The 1 test passing at both is `test_the_fatal_still_forbids_deleting_the_precondition`, **labelled in-file as an INVARIANT GUARD** — it pins pre-existing correct behaviour and is deliberately *not* counted as regression coverage. Every test in both files carries such a label (REGRESSION vs SEAM/LEDGER vs INVARIANT), and one docstring was corrected this round for overstating by half.

## Mutation testing

> **⚠ CORRECTION.** An earlier revision of this PR body carried a 4-mutant table and presented it as verification. **That claim was false.** An adversarial audit built mutants from a class the table never enumerated — *"comment it out; the text is still there"* — and **two SURVIVED**. Both were reproduced here before being fixed. The table below replaces it; the round-2 commits fix the guards.

### The two that survived, and why

Both guards read **source text**, so both were walkable by a single `#`.

**A — the FATAL-message guard.** It parsed `run-tests.sh` as text and never executed the FATAL path. Commenting out the one copy-pasteable remedy line gave **6 passed**, while the message a human actually sees had a blank gap where the remedy used to be:

```
  FIX — enter the repo's own dev shell, which carries exactly this list,
  and re-run from there:

                          ← the remedy, gone. Guard still green.
  (or `nix develop` once, then `bash scripts/run-tests.sh .` as often as
```

Round 2 of this PR had closed the *reword* walk; it did not close the *comment-out* walk. Now **behavioural**: a fixture runs the real runner with a `PATH` holding only `bash` — the tool precondition is GUARD 1, so it exits 2 in milliseconds before any test — and the assertions read what it actually **printed**. A commented-out `echo` prints nothing. The fixture carries its own positive control (the FATAL must have fired, exit must be 2) so it cannot pass by matching unrelated output.

**B — the devShell guards.** Wrapping the whole `devShells.${system}.default` block in a `/* … */` nix comment left `flake.nix` valid and **all 15 tests passed**, while the remedy the FATAL advertises answered:

```
error: flake '…' does not provide attribute 'devShells.x86_64-linux.default'
```

`test_a_default_devshell_exists`'s own docstring says *"The remedy would 404"* — and it 404'd with the guard green. `test_the_devshell_and_the_gate_share_one_tool_list` passed too, because `packages = gateTools;` was still *spelled* inside the comment. Now matched against comment-stripped source, with a two-way positive control proving the stripper keeps live code **and** removes comment text.

### Full battery, re-run from scratch (round 3)

A fix round resets the verification gate, so this is the **whole** battery each time, not just the changed guards — enumerated from each expression's semantic failure modes (comment-out, branch removal, branch inversion, wrong bind, verdict inversion, reword, duplicate binding, and the symmetric *other* side of a shared binding). `PYTHONDONTWRITEBYTECODE=1`, `__pycache__` purged between mutants, and **every mutant is `ast.parse`d before it counts** — see the retraction below for why.

| # | Mutant | Verdict | Killed by |
|---|---|---|---|
| 0 | **IDENTITY — harness control, MUST survive** | **SURVIVED** ✅ | *(88 passed)* |
| 1 | `run-tests.sh`: **comment out** the invocation line | KILLED | `…fatal_names_a_runnable_invocation` |
| 2 | `run-tests.sh`: delete the invocation line | KILLED | `…fatal_names_a_runnable_invocation` |
| 3 | `run-tests.sh`: reword `nix develop` → `nix-shell` | KILLED | `…fatal_names_a_runnable_invocation` |
| 4 | `run-tests.sh`: `$ROOT` printed literally (single-quoted) | KILLED | `…fatal_names_a_runnable_invocation` |
| 5 | `run-tests.sh`: drop the "not a code failure" sentence | KILLED | `…fatal_names_a_runnable_invocation` |
| 6 | `run-tests.sh`: add unjustified tool `ed` to `REQUIRED_TOOLS` | KILLED | `…every_required_tool_is_justified…` |
| 7 | `flake.nix`: **`/* */` comment out** the devShells block | KILLED | `…default_devshell_exists` + stripper control + seam |
| 8 | `flake.nix`: **`#` comment out** the devShells block | KILLED | `…default_devshell_exists` + stripper control + seam |
| 9 | `flake.nix`: inline a divergent list (gate side) | KILLED | `…share_one_tool_list` |
| 10 | `flake.nix`: inline a divergent list (**shell** side) | KILLED | `…share_one_tool_list` |
| 11 | `flake.nix`: a SECOND `gateTools` binding | KILLED | `…gate_tools_is_defined_exactly_once` |
| 12 | `conftest`: layer 1 never fires (branch removal) | KILLED | directory test + verdict test |
| 13 | `conftest`: layer 1 **commented out** | KILLED | directory test + verdict test |
| 14 | `conftest`: layer 1 returns `None` (wrong bind) | KILLED | directory test + verdict test |
| 15 | `conftest`: classifier **inverted** | KILLED | 4 tests incl. the ledger |
| 16 | `conftest`: layer 2 catches the wrong exception | KILLED | `…named_error_not_no_tests_ran` |
| 17 | `conftest`: `runtest` **ignores the exit code** | KILLED | `…exit_code_decides_its_verdict` |
| 18 | `conftest`: `runtest` verdict **inverted** | KILLED | `…exit_code_decides_its_verdict` |
| 19 | **ledger: remove the new `PINNED_PATH_CLOBBERS` entry** | KILLED | `test_every_path_clobbering_site_is_pinned` |
| 20 | **ledger: pin present but its needle does not match** | KILLED | `test_every_path_clobbering_site_is_pinned` |
| 21 | **fixture: prepend ambient PATH (site *vanishes*)** | KILLED | `test_every_path_clobbering_site_is_pinned` |
| 22a | fixture: remove the one-entry enumeration assertion | **SURVIVED** *(expected)* | — |
| 22b | **fixture: plant a stray `systemctl` in the stub dir** | KILLED | the assertion's **own** message |

**23 mutants + 1 retraction: 21 killed, 2 survived — and both survivors are supposed to.** #0 is the IDENTITY control, which is what proves the harness can emit `SURVIVED` at all rather than reporting `KILLED` unconditionally. #22a survives *honestly*: it removes a **defensive** assertion on a condition that is true in normal operation, so nothing observable changes. Reporting that as a kill would be exactly the overstatement this PR keeps correcting — so #22b is the one that matters, and it is the **reachability** proof: it makes the guarded condition genuinely false and confirms the failure carries *this* guard's own wording (`the stub PATH dir must hold exactly one entry…`), not some other test's error.

> **🔴 Retraction.** The first round-3 run reported this row as `KILLED (?)` — killed with **no failing test name**. It was a `SyntaxError`: the mutant produced `if False:` followed by an unindented block, so it died at import, for the wrong reason, proving nothing. Rather than let a green-looking row stand, it was discarded and replaced by 22a/22b, and the harness now `ast.parse`s every mutant before scoring it. *A mutant that does not parse never ran.*

#### Ledger mutants 19–21, and why they matter

Entry #4 in `PINNED_PATH_CLOBBERS` is the first added since the ledger was written, so the ledger itself was mutation-tested rather than assumed. #21 is the interesting one: switching the fixture back to *prepending* makes the site **disappear**, and the ledger catches that too — it pins the set in **both** directions, so neither a new clobber nor a vanished one slips through.

## Also fixed this round

- **Substring containment → word matching, and a 51-line-too-wide block.** The justification guard used `t not in block` over a block that `rfind("\n\n")` widened into unrelated prose. Measured: `ed`, `tr`, `cat`, `id`, `who` all reported "justified" with none, and `at` survived word boundaries alone on the English word *"at"*. The block is now the contiguous `#` run above the array **and** matching is word-boundary — neither fix alone closes it.
- **A landmine in the file designed to be copied.** `conftest.py`'s `_REPO_ROOT` was a positional `parents[2]` — correct in the real tree, garbage in a copy — and its own test `shutil.copy`s the file into a tmp dir. `repr_failure` then called `relative_to(_REPO_ROOT)`, which would raise `ValueError` **inside the failure-reporting path**, masking the real failure with an unrelated traceback. Now resolved by landmark, with a never-raising path prettifier.
- **An overstated label, corrected.** `test_the_hook_tests_directory_collects_without_an_internal_error` was labelled REGRESSION, but measured at baseline under its own `--collect-only` invocation: `INTERNALERROR>` **105×**, `no tests ran` **0×**. So its second assertion is an invariant guard riding inside a regression test. The docstring now says which of its three assertions does which job.

## Gate impact

- **Per-target collected counts for all six hook-test gate targets are unchanged**, re-verified after each round's `conftest.py` edits: `1442 / 130 / 17 / 40 / 296 / 13`. No hook-test floor moves. All five script suites still run as scripts in the gate, and `pytest scripts/claude-hooks/tests/` is **1943 passed**.
- **New `PINNED_PATH_CLOBBERS` ledger entry** in `scripts/tests/test_no_real_launchers.py` — the round-2 behavioural fixture replaces `PATH` instead of prepending, which is a new clobbering site. Details in "Round 3" below.
- `TARGET_FLOORS`: `scripts/tests` re-pinned to **6169**, re-measured after rebasing onto `fc1f581`. Both numbers measured with `--collect-only` — **6201** in a clean detached worktree of `origin/main`, **6219** on the branch — so this branch contributes exactly **+18**. The final gate confirms it: `collected=6219 … floor=6169`.
- 🔴 The pin this replaces was `5912` against a real count of `6201` on main alone — **289 of drift, none of it from here**, and the entry before it drifted the same way (`5764` vs `5947`). Tests keep landing without the floor being re-pinned, so the table's sensitivity decays continuously between the contributions that happen to notice. The comment now says that out loud instead of presenting the table as if it tracked the tree.
- `--check-floors` and `--check-targets`: both `RESULT: PASS (exit=0)`. Runner self-tests (`test_run_tests_targets.py`, `test_gate_exit_truthfulness.py`): **21 passed**.

## Round 3 — the ledger was right to fire

The round-2 fixture passes `env={"PATH": str(stub), …}`. That **replaces** `PATH` rather than prepending, dropping the launcher-stub dir — a new PATH-clobbering site, and `test_every_path_clobbering_site_is_pinned` went red on it. Attribution was clean: the round-1 tip merged with #593/#595 was green, so this was introduced by my own round-2 fix. Textbook *"a fix round resets the verification gate."*

**The ledger is not weakened, not excluded, and not dodged by switching to prepending.** Replacing is *correct* here: the fixture drives `run-tests.sh`'s tool precondition, whose whole job is to react to binaries being **absent**, and no amount of prepending can make a binary unfindable — inside the nix sandbox every `REQUIRED_TOOLS` binary *is* present, so a prepending version would measure the environment instead of the code.

So the site is **registered, with the reasoning written down** rather than just the filename. It is the second entry justified by **enumeration** rather than emptiness, and the stronger of the two: the replacement directory is *constructed* by the fixture two lines above the clobber (`mktemp("only-bash")`, then one `symlink_to(bash)`), so it holds exactly one entry and nothing in `HAZARD_VOCABULARY` is reachable from it.

Two details the file itself warns about, both handled:
- **Self-match.** Written whole, the needle would itself be a PATH-clobbering line *in the ledger file*, making that file report as an unpinned site. Split across a `+` like the existing three entries. Verified: the scan finds four sites and `test_no_real_launchers.py` is not among them.
- **The needle must actually match.** The per-needle loop checks it appears verbatim; mutant #20 confirms that check fires.

The fixture now **asserts its own one-entry contents**, so the ledger's enumeration justification is a live invariant rather than prose that can rot — and mutant #22b proves that assertion is reachable, not merely present.

## Authoritative gate

Run on the round-3 tip through the new shell — `nix develop <repo> --command bash scripts/run-tests.sh <repo>`, verdict read from the `RESULT:` line, never a piped exit code:

```
RESULT: PASS (exit=0)
  PASS  scripts/tests  (collected=6219 passed=6219 skipped=0 floor=6169)
  TOTAL collected=13099  passed=13098  skipped=1  failed=0
```

Log validated rather than trusted: **30 PASS rows, 0 FAIL rows**, zero `INTERNALERROR>`, zero `test timed out` panics, zero unparseable summaries, and all five hook script suites present as `=== script …` entries.

## What I could NOT verify / caveats

- **The flake guards are source-level, not evaluation-level.** They now see that `devShells.default` is *written and live* (comment-stripped); they cannot see that it *evaluates*. A change leaving the text intact but breaking evaluation — a typo in `gateTools`, a bad `pkgs.` attr, a shadowed binding — is invisible to them and is caught only by `nix flake check` or a real `nix develop`. The behavioural check needs the flake's inputs, which the hermetic tier (a `cp -r` of the tree, no inputs, no network) does not have. **This gap is stated in-file**, next to the guards.
- **A pre-existing flake in `browser-bridge`.** An early full-gate run ended `RESULT: FAIL (exit=1)` on `test_server.py::test_the_two_origin_tokens_are_distinct_and_recorded_verbatim`, a telemetry-event ordering race. I ran the discriminating control rather than assuming it was mine: it fails **on the pristine unmodified `a29b97b` worktree** too, and it passed on every later run including the final one. Order/timing-dependent, present on `main`, **not fixed here**.
- **The two known-red baselines I was warned about both PASSED** in every gate run I did. I did not investigate why they were expected red.
- **One more non-reproducing flake:** `test_a_green_real_run_says_pass_with_exit_zero` failed once in an ad-hoc 4-file invocation, then passed in isolation, on identical re-run (36/36), and in every gate run. No root cause claimed.
- **The comment stripper is not a nix lexer.** A `#` inside a string literal truncates that line. That is the conservative direction — it can only ever *hide* text from a match, never invent it — and the positive control proves it does not hide the anchors the guards depend on. Noted in-file.
- **`main` moves fast.** The floor was re-measured against `fc1f581`; `origin/main` has advanced since. The pin is 50 below the measured count per the file's own allowance, and floors are minimums, so branch-vs-main drift can only make it *more* conservative — but the number describes `fc1f581`, not whatever `main` is at merge time.
- A stray `json.decoder.JSONDecodeError` traceback appears above every command in my logs. It is **environmental, not this repo** — `nix-shell -p coreutils --run "echo hello"` reproduces it on this host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
