### PR TITLE
fix(service-recon): the index was asked at ONE scope — the one a path heuristic picked

### DIFF
--- a/claude/skills/analyze-service/SKILL.md
+++ b/claude/skills/analyze-service/SKILL.md
@@ -48,12 +48,12 @@ Pass the script's output through, tightened, in this order. Do NOT re-run its
 steps by hand; if something is missing, raise the matching limit and re-run.
 
 - **Service** + one-line "what it is".
-- **Pointers / nuance** (`from index`) — surfaced by the script's `index:` block. Omit if it missed.
+- **Pointers / nuance** (`from index`) — surfaced by the script's `index:` block. Omit if it missed, and when the line carries a `[scope via …]` marker say WHICH scope answered: that scope was not confirmed to own the service.
 - **Lives at** — repo + paths, namespace, owning kustomization.
 - **Config** — the load-bearing knobs (version, scale, resources, key values, routes, deps).
 - **Live** — only if `--live` ran and returned `ran`; otherwise say `unverified (static recon)`.
 - **Recent changes** — the log, calling out anything marked `⚠ MOVED` (a revert/bump is usually why you're looking).
-- **Gotchas** — anything non-obvious you hit, plus any `⚠` note the script emitted (`MULTI-DIRECTORY`, an ownership tie, a capped walk).
+- **Gotchas** — anything non-obvious you hit, plus any `⚠` note the script emitted (`MULTI-DIRECTORY`, an ownership tie, a `THIN MARGIN` under `lives at:`, a capped walk).
 
 **Provenance honesty:** nuance/pointers are `from index`; roots/locate/config/log
 are `re-derived live`; cluster state is `live @ <context>` or `unverified`. Never

--- a/claude/skills/analyze-service/reference/index-store.md
+++ b/claude/skills/analyze-service/reference/index-store.md
@@ -14,7 +14,7 @@ X" instead of re-discovering every gotcha. It holds **pointers + nuance only** �
 never live state, never re-derived config values.
 
 - **Location:** `~/.claude/analyze-service-index/<scope>/<slug>.md` — local, never inside a cluster repo or `devrc`. But **not "outside git": each `<scope>/` is its own remote-less git repo** (the store root is not one) — see 🔴 **Store safety** below before running any git command there.
-- **`<scope>`** defaults to the basename of the owning repo root the service resolved into: `datapacket-talos`, `homelab-talos`, else the current working repo's basename — derived from the locate step, no separate assumption. A scope **need not be a repo**: a ritual owned by no repo, or a client spanning several, may use a plain scope word — a deliberate choice, so say so in the brief.
+- **`<scope>`** defaults to the basename of the owning repo root the service resolved into: `datapacket-talos`, `homelab-talos`, else the current working repo's basename — derived from the locate step, no separate assumption. 🔴 **On READ, recon asks every searched root's scope, not only that one** — see "The index is NOT gated on `locate`" below; a WRITE still lands in exactly one scope, so check which scope already answered before creating an entry. A scope **need not be a repo**: a ritual owned by no repo, or a client spanning several, may use a plain scope word — a deliberate choice, so say so in the brief.
 
 ## Resolution rules
 
@@ -65,7 +65,7 @@ statuses come from `subsystem_recall.recall`, unchanged:
 | line | meaning |
 |---|---|
 | `index: <scope>/<ref> — HIT (from index) sensitivity=<s>` | resolved; `## Pointers` + `## Nuance / work-history` follow |
-| `index: ref-absent (scope <s>)` | the scope was read; nothing is recorded under that ref yet |
+| `index: ref-absent (scope <s>) … — checked N scope(s): …` | every scope named was read; nothing is recorded under that ref in any of them |
 | `index: scope-absent` | the store holds no directory for this repo yet |
 | `index: AMBIGUOUS in <scope> — a.md \| b.md` | 🔴 more than one candidate; **pick one, never guess** — no body is surfaced |
 | `index: store-missing` | the store root does not exist on this host |
@@ -74,10 +74,27 @@ statuses come from `subsystem_recall.recall`, unchanged:
 That last row is the one to read carefully: `not-attempted` and `ref-absent` both
 show "nothing from the index", and only one of them is a finding.
 
-🔴 **The index is NOT gated on `locate` succeeding.** If nothing matched by path,
-the scope falls back to the searched root(s) and the store is asked anyway — a
-curated pointer sheet is worth *most* when the path heuristic missed, since
-"where does this live?" is what the index can answer and the matcher just failed.
-A hit reached that way is marked `[scope via searched root (nothing located)]`,
-because that scope was **not** confirmed to own the service. `not-attempted` now
-means only one thing: nothing was examined at all.
+🔴 **EVERY searched root's scope is asked — not just the one that "won".** Root
+ranking is a path-name heuristic, so it answers two different questions badly:
+it can find NOTHING (and a curated pointer sheet is worth *most* exactly then,
+since "where does this live?" is what the index can answer and the matcher just
+failed), and it can find the WRONG thing (a lead of a few paths between two repos
+is a naming convention, not ownership). Both are covered the same way: the roots
+are asked in rank order, de-duplicated by SCOPE — a worktree and its base clone
+are one scope — and the FIRST hit wins, so widening the search can never move an
+answer the owner's scope already gave.
+
+The line says which scope answered and how it was reached:
+
+- no marker → the owning repo's scope, the ordinary case;
+- `[scope via the cwd repo (N paths matched)]` → the repo you are standing in;
+- `[scope via a searched root (N paths matched)]` → a root locate ranked lower;
+- `[scope via searched root (nothing located)]` → locate matched nothing at all.
+
+Anything but the first means that scope was **not** confirmed to own the service
+— treat the entry as a pointer to verify, and check the `lives at:` line's own
+`⚠ THIN MARGIN` note if it carries one.
+
+A miss prints `— checked N scope(s): …`, so "nothing recorded anywhere" arrives
+with its denominator. `not-attempted` still means only one thing: nothing was
+examined at all.

--- a/scripts/lib/service_recon.py
+++ b/scripts/lib/service_recon.py
@@ -31,6 +31,15 @@ and no sensitivity fold. A second reader of that store would be a second matcher
 free to drift from the resolver, and its failure mode is a miss that reads as
 "no index yet".
 
+🔴 THE INDEX IS ASKED AT EVERY SEARCHED ROOT, NOT AT THE ONE THAT "WON". Root
+ranking is a path-name heuristic — a lead of a few paths between two repos is a
+naming convention, not ownership — and asking only the leader reported a curated
+entry in the cwd's own scope as `ref-absent`. Every searched root is asked in
+rank order, de-duplicated by SCOPE, first hit wins, and the brief prints WHICH
+scope answered and on what BASIS. A miss then names every scope it checked, so
+"nothing recorded anywhere" is a claim with a denominator. See `index_scopes`
+for why a miss here is a store WRITE and not merely a wasted read.
+
 🔴 LIVE CLUSTER STATE IS OPT-IN AND OFF BY DEFAULT (`--live`). It was 124 of the
 359 measured Bash calls, it is the half that can be wrong by the time you read
 it, and it is the half a static question never needed. Static recon — locate,
@@ -73,7 +82,7 @@ import os
 import re
 import subprocess
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace as _dc_replace
 from pathlib import Path
 from typing import Iterable, Sequence
 
@@ -115,6 +124,10 @@ __all__ = [
     "DEFAULT_KNOBS_PER_FILE",
     "PATHSPEC_SHOWN",
     "UMBRELLA_PATHS",
+    "THIN_OWNERSHIP_MARGIN",
+    "CWD_ORIGIN",
+    "OWNER_BASIS",
+    "UNLOCATED_BASIS",
     "MAX_VALUE_CHARS",
     "WALK_FILE_CAP",
     "LIVE_TIMEOUT_SECONDS",
@@ -135,6 +148,7 @@ __all__ = [
     "search_roots",
     "scan_root",
     "locate",
+    "thin_runner_up",
     "index_scopes",
     "read_index",
     "dotted_paths",
@@ -287,6 +301,39 @@ PATHSPEC_SHOWN = 3
 #: ordinary two-directory shape and is not an umbrella.
 UMBRELLA_PATHS = 3
 
+#: 🔴 A LEAD THIS THIN IS A RANKING, NOT A FINDING. `locate` orders the roots by
+#: how many paths carry the token and prints the winner as `lives at:` — a
+#: sentence every reader takes as ownership. Two roots whose counts differ by a
+#: hair have established no such thing; that difference is one directory naming
+#: convention, or one repo that happens to keep more handoff docs. ONE number
+#: drives two behaviours, deliberately, so there is one rule to reason about:
+#:
+#:   1. `lives at:` NAMES THE RUNNER-UP when the lead is under it, so the claim
+#:      carries its own scope instead of reading as settled.
+#:   2. THE CWD'S ROOT IS ASKED FIRST when it is within this of the leader. The
+#:      index is asked at every root either way (see `index_scopes`), so this
+#:      only decides which scope wins when TWO of them carry an entry — and when
+#:      the path evidence cannot separate two repos, the one the human is
+#:      standing in is the better guess.
+#:
+#: A POLICY value, not a measurement: nothing observed is restated here, and
+#: `thin_runner_up` computes the margin from the scan at run time.
+THIN_OWNERSHIP_MARGIN = 0.20
+
+#: The `origin` `search_roots` stamps on the cwd's own toplevel. Spelled ONCE:
+#: the producer and the two consumers below must agree, and a literal that
+#: drifted would silently disable the cwd tie-break with no error anywhere.
+CWD_ORIGIN = "cwd"
+
+#: The basis string for the located owner. Also spelled once — `render_brief`
+#: suppresses the `[scope via …]` marker on exactly this value, so a mismatch
+#: would print the fallback marker over every ordinary hit.
+OWNER_BASIS = "owning repo"
+
+#: The basis for a root that was searched and matched NOTHING. Pinned by
+#: `test_a_fallback_hit_says_SO_rather_than_implying_ownership`.
+UNLOCATED_BASIS = "searched root (nothing located)"
+
 #: Values are truncated, and a truncation is MARKED (`…`). An un-truncated brief
 #: is one embedded cert away from being the dump this module exists to replace.
 MAX_VALUE_CHARS = 96
@@ -369,10 +416,19 @@ class IndexResult:
     candidates: tuple[str, ...] = ()
     sensitivity: str | None = None
     basis: str = ""
-    """🔴 WHICH REPO THE SCOPE CAME FROM, in words — `owning repo` or
-    `searched root (nothing located)`. Printed, never implied: a hit found via
-    the fallback is answering about a scope the locate step did NOT confirm owns
-    the service, and a reader must be able to see that."""
+    """🔴 WHICH REPO THE SCOPE CAME FROM, in words — `owning repo`, `the cwd repo
+    (N paths matched)`, `a searched root (N paths matched)` or
+    `searched root (nothing located)`. Printed, never implied: a hit found
+    anywhere but the owner is answering about a scope the locate step did NOT
+    confirm owns the service, and a reader must be able to see that."""
+    scopes_checked: tuple[str, ...] = ()
+    """🔴 EVERY SCOPE THIS LOOKUP ASKED, in the order asked, de-duplicated.
+
+    A `ref-absent` is a claim of the form "nothing recorded ANYWHERE", and until
+    this field exists the reader cannot tell it apart from "nothing recorded in
+    the one scope I happened to ask". The render prints the count beside the
+    names, so the claim carries its own denominator (`claude/RULES.md` → never a
+    silent zero)."""
     detail: str = ""
     report: RecallReport | None = None
 
@@ -495,7 +551,7 @@ def search_roots(
     if not explicit:
         for handle in ENV_ROOT_HANDLES:
             add(env.get(handle, ""), f"env:{handle}")
-        add(str(cwd) if cwd is not None else "", "cwd")
+        add(str(cwd) if cwd is not None else "", CWD_ORIGIN)
     return tuple(out)
 
 
@@ -623,10 +679,7 @@ def locate(
     if not any(s.searched for s in scans):
         return LocateResult("not-searched", token, tuple(scans))
 
-    ranked = sorted(
-        (s for s in scans if s.searched and s.matches),
-        key=lambda s: (-len(s.matches), s.path),
-    )
+    ranked = [s for s in _rank(scans) if s.matches]
     if not ranked:
         return LocateResult("no-match", token, tuple(scans))
 
@@ -635,27 +688,114 @@ def locate(
     return LocateResult("hits", token, tuple(scans), owner=ranked[0].path, owner_tied_with=tied)
 
 
+# --- Ranking the roots ---------------------------------------------------------
+
+
+def _n_paths(n: int) -> str:
+    """`1 path` / `N paths` — the basis string is read by a human."""
+    return f"{n} path" if n == 1 else f"{n} paths"
+
+
+def _rank(scans: Iterable[RootScan]) -> list[RootScan]:
+    """Searched roots, most matches first, ties broken by path.
+
+    🔴 THE KEY IS TOTAL AND CONTENT-DERIVED, so the order does not depend on the
+    order the roots were configured in. `locate`, `index_scopes` and
+    `thin_runner_up` all rank through here rather than each spelling the key —
+    three copies of a sort key is three chances for the brief to name one root as
+    the owner and ask a different one for its index entry.
+    """
+    return sorted((s for s in scans if s.searched), key=lambda s: (-len(s.matches), s.path))
+
+
+def thin_runner_up(loc: LocateResult) -> tuple[RootScan, int] | None:
+    """`(runner-up root, the winner's lead in percent)` when that lead is under
+    `THIN_OWNERSHIP_MARGIN`, else None.
+
+    🔴 AN EXACT TIE RETURNS None, and that is not an oversight. A tie already has
+    its own `OWNERSHIP IS TIED` note; reporting it here as well would print the
+    same finding twice in one brief, and the two wordings would then have to be
+    kept in agreement forever. The two cases are mutually exclusive by
+    construction: `second >= top` leaves here, `second == top` is the tie.
+    """
+    ranked = [s for s in _rank(loc.roots) if s.matches]
+    if len(ranked) < 2:
+        return None
+    top, second = len(ranked[0].matches), len(ranked[1].matches)
+    if top <= 0 or second >= top:
+        return None
+    lead = (top - second) / top
+    if lead >= THIN_OWNERSHIP_MARGIN:
+        return None
+    return ranked[1], round(lead * 100)
+
+
 # --- The index read ------------------------------------------------------------
 
 
 def index_scopes(loc: LocateResult) -> tuple[tuple[str, str], ...]:
-    """`(scope, basis)` pairs to ask the index about, in priority order.
+    """`(repo, basis)` pairs to ask the index about, in priority order.
 
     🔴 THE INDEX MUST NOT BE GATED ON `locate` SUCCEEDING, and the first version
     of this module got that backwards — it derived the scope from `loc.owner` and
     reported `not-attempted` whenever nothing matched. Measured against the real
-    store: `externaldns` matched no path component in its repo, so the run said
+    store: a service that matched no path component in its repo made the run say
     "no owning repo located to derive a scope from" over a scope whose entries
     were sitting right there. That is precisely inverted — a curated pointer
     sheet is worth MOST when the path heuristic missed, because "where does this
     live?" is the question the index can answer and the matcher just failed.
 
-    So: prefer the located owner, and fall back to EVERY root that was
-    successfully searched. The basis is carried and printed, never implied.
+    🔴 AND THE SECOND VERSION GOT THE OTHER HALF WRONG, which is why this asks
+    EVERY searched root rather than just the owner. The fallback above fired only
+    when `loc.owner is None` — it covered the case where locate found NOTHING and
+    left uncovered the case where locate found the WRONG thing. Reproduced on a
+    real run: a four-path margin between two repos handed the lookup to the
+    loser's neighbour and rendered `ref-absent` over a curated entry in the cwd's
+    own scope. That is worse than a wasted read — `claude/skills/analyze-service`
+    tells the agent to OMIT the pointer/nuance block when the index missed, so
+    the curated knowledge is silently dropped, and the next `/handoff` in that
+    repo sees `ref-absent` and may write a DUPLICATE entry into the wrong scope.
+    A miss here is a store WRITE, not just a bad read.
+
+    Reads are local and the whole store answers in tens of milliseconds, so there
+    is nothing to buy by asking one scope. Every searched root is asked, ranked
+    by match count, and `read_index` takes the FIRST HIT — so a lower-ranked
+    scope can only ever answer a question the higher-ranked ones did not.
+
+    The cwd's root is promoted to the front when it is within
+    `THIN_OWNERSHIP_MARGIN` of the leader: that only changes which scope wins
+    when more than one carries an entry, and the human's own repo is the better
+    guess when the path evidence cannot separate them. `--repo` roots carry no
+    `cwd` origin, so an explicit root set is never reordered.
+
+    The basis is carried and printed, never implied.
     """
-    if loc.owner is not None:
-        return ((loc.owner, "owning repo"),)
-    return tuple((s.path, "searched root (nothing located)") for s in loc.roots if s.searched)
+    ranked = _rank(loc.roots)
+    if not ranked:
+        return ()
+
+    top = len(ranked[0].matches)
+    for i, s in enumerate(ranked):
+        if s.origin != CWD_ORIGIN:
+            continue
+        if i:
+            lead = (top - len(s.matches)) / top if top else 0.0
+            if lead < THIN_OWNERSHIP_MARGIN:
+                ranked.insert(0, ranked.pop(i))
+        break
+
+    out: list[tuple[str, str]] = []
+    for s in ranked:
+        if s.path == loc.owner:
+            basis = OWNER_BASIS
+        elif not s.matches:
+            basis = UNLOCATED_BASIS
+        elif s.origin == CWD_ORIGIN:
+            basis = f"the cwd repo ({_n_paths(len(s.matches))} matched)"
+        else:
+            basis = f"a searched root ({_n_paths(len(s.matches))} matched)"
+        out.append((s.path, basis))
+    return tuple(out)
 
 
 def read_index(
@@ -684,17 +824,58 @@ def read_index(
                 detail="no root could be examined, so no scope could be derived",
             )
         # Ask each candidate; the FIRST hit wins and the rest are reported only
-        # if none hit — so a fallback can never silently shadow a real answer.
+        # if none hit — so a lower-ranked scope can never silently shadow a real
+        # answer, and the winner always carries the basis it was reached by.
+        #
+        # 🔴 DE-DUPLICATED BY SCOPE, NOT BY PATH. Two roots routinely derive to
+        # ONE scope — a worktree and its base clone are different directories and
+        # `scope_for_repo` maps both through `--git-common-dir` to the same name.
+        # Without this the store is read twice for the same answer and, worse,
+        # `checked 3 scope(s)` would name a scope twice and overstate how wide
+        # the search actually was.
         misses: list[IndexResult] = []
+        seen: set[str] = set()
+        checked: list[str] = []
         for repo, basis in candidates:
-            got = _read_index_one(repo, service, store_root=store_root, basis=basis)
+            scope, failure = _scope_of(repo)
+            key = scope if scope is not None else f"\0path:{repo}"
+            if key in seen:
+                continue
+            seen.add(key)
+            if failure is not None:
+                misses.append(failure)
+                continue
+            checked.append(scope or "")
+            got = _read_index_one(repo, service, store_root=store_root,
+                                  basis=basis, scope=scope)
             if got.status in ("hit", "ref-ambiguous"):
-                return got
+                return _dc_replace(got, scopes_checked=tuple(checked))
             misses.append(got)
-        return misses[0]
+        if not misses:  # pragma: no cover — `candidates` non-empty implies one
+            return IndexResult("not-attempted", detail="no candidate scope was reachable")
+        # The primary miss is the first one that actually REACHED a scope. A root
+        # git cannot name (a plain directory searched by the walk) yields
+        # `not-attempted`, which says nothing about the store; letting it outrank
+        # a genuine `ref-absent` would replace a measurement with a shrug.
+        primary = next((m for m in misses if m.scope), misses[0])
+        return _dc_replace(primary, scopes_checked=tuple(checked))
     if loc is None:
         return IndexResult("not-attempted", detail="no repo given to derive a scope from")
-    return _read_index_one(loc, service, store_root=store_root, basis="owning repo")
+    got = _read_index_one(loc, service, store_root=store_root, basis=OWNER_BASIS)
+    return _dc_replace(got, scopes_checked=(got.scope,) if got.scope else ())
+
+
+def _scope_of(repo: str | Path) -> tuple[str | None, IndexResult | None]:
+    """`(scope, failure)` — exactly one is not None.
+
+    Extracted so the candidate loop can de-duplicate BEFORE paying for a recall,
+    without re-spelling the failure wording that `_read_index_one` reports.
+    """
+    try:
+        return scope_for_repo(repo), None
+    except Exception as exc:  # a non-repo root, or git unavailable
+        return None, IndexResult(
+            "not-attempted", detail=f"scope not derivable from {repo}: {exc}")
 
 
 def _read_index_one(
@@ -702,14 +883,19 @@ def _read_index_one(
     service: str,
     *,
     store_root: str | Path = DEFAULT_STORE_ROOT,
-    basis: str = "owning repo",
+    basis: str = OWNER_BASIS,
+    scope: str | None = None,
 ) -> IndexResult:
     """One scope's answer. Split out so the multi-candidate loop above has a
-    single per-scope predicate rather than a copy of it per branch."""
-    try:
-        scope = scope_for_repo(owner)
-    except Exception as exc:  # a non-repo root, or git unavailable
-        return IndexResult("not-attempted", detail=f"scope not derivable from {owner}: {exc}")
+    single per-scope predicate rather than a copy of it per branch.
+
+    `scope` is accepted already-derived: the loop needs it to de-duplicate, and
+    deriving it twice would run `git rev-parse` twice per candidate.
+    """
+    if scope is None:
+        scope, failure = _scope_of(owner)
+        if failure is not None:
+            return failure
 
     try:
         rep = recall(store_root, scope, ref=service)
@@ -1135,6 +1321,16 @@ def render_brief(b: Brief, *, file_limit: int = DEFAULT_FILE_LIMIT) -> str:
         shown = list(scan.matches[:file_limit]) if scan else []
         L.append(f"lives at: {owner.name}  ({len(scan.matches) if scan else 0} paths matched, "
                  f"{b.locate.files_examined} files examined)")
+        # 🔴 THE CLAIM CARRIES ITS OWN SCOPE. A lead of a few paths is a ranking,
+        # not ownership, and it is printed HERE — beside the sentence the reader
+        # believes — rather than only in a note at the top of the brief.
+        thin = thin_runner_up(b.locate)
+        if thin is not None:
+            other, pct = thin
+            L.append(f"  ⚠ THIN MARGIN — {Path(other.path).name} matched "
+                     f"{_n_paths(len(other.matches))}, "
+                     f"only {pct}% behind. That is a RANKING, not a finding of ownership; "
+                     f"the index was asked in both.")
         for rel in shown:
             L.append(f"  {rel}")
         rest = (len(scan.matches) - len(shown)) if scan else 0
@@ -1144,9 +1340,15 @@ def render_brief(b: Brief, *, file_limit: int = DEFAULT_FILE_LIMIT) -> str:
     # --- index ---------------------------------------------------------------
     L.append("")
     i = b.index
-    # 🔴 The BASIS is printed on every branch that has one. A hit reached via the
-    # fallback answers about a scope `locate` did NOT confirm owns the service.
-    via = f" [scope via {i.basis}]" if i.basis and i.basis != "owning repo" else ""
+    # 🔴 The BASIS is printed on every branch that has one. A hit reached anywhere
+    # but the owner answers about a scope `locate` did NOT confirm owns the
+    # service, and the reader has to be able to see WHICH scope answered.
+    via = f" [scope via {i.basis}]" if i.basis and i.basis != OWNER_BASIS else ""
+    # 🔴 A `ref-absent` is a claim about EVERY scope asked, so it prints the
+    # denominator. Without it, "nothing recorded under that ref yet" is
+    # indistinguishable from "I asked one scope out of three".
+    checked = (f" — checked {len(i.scopes_checked)} scope(s): "
+               + ", ".join(i.scopes_checked)) if i.scopes_checked else ""
     if i.status == "hit":
         sens = f" sensitivity={i.sensitivity}" if i.sensitivity else ""
         L.append(f"index: {i.scope}/{i.ref} — HIT (from index){sens}{via}")
@@ -1167,7 +1369,8 @@ def render_brief(b: Brief, *, file_limit: int = DEFAULT_FILE_LIMIT) -> str:
         L.append(f"index: {i.status}"
                  + (f" (scope {i.scope})" if i.scope else "")
                  + via
-                 + (f" — {i.detail}" if i.detail else ""))
+                 + (f" — {i.detail}" if i.detail else "")
+                 + checked)
 
     # --- config --------------------------------------------------------------
     L.append("")
@@ -1229,6 +1432,7 @@ def render_brief(b: Brief, *, file_limit: int = DEFAULT_FILE_LIMIT) -> str:
 
 
 def brief_json(b: Brief) -> dict:
+    thin = thin_runner_up(b.locate)
     return {
         "service": b.service,
         "token": b.token,
@@ -1239,6 +1443,11 @@ def brief_json(b: Brief) -> dict:
             "status": b.locate.status,
             "owner": b.locate.owner,
             "owner_tied_with": list(b.locate.owner_tied_with),
+            "thin_runner_up": (
+                None if thin is None
+                else {"path": thin[0].path, "matches": len(thin[0].matches),
+                      "lead_percent": thin[1]}
+            ),
             "files_examined": b.locate.files_examined,
             "total_matches": b.locate.total_matches,
             "roots": [
@@ -1251,6 +1460,7 @@ def brief_json(b: Brief) -> dict:
         "index": {
             "status": b.index.status, "scope": b.index.scope, "ref": b.index.ref,
             "sensitivity": b.index.sensitivity, "basis": b.index.basis,
+            "scopes_checked": list(b.index.scopes_checked),
             "candidates": list(b.index.candidates),
             "pointers": b.index.pointers, "nuance": b.index.nuance, "detail": b.index.detail,
         },

--- a/scripts/tests/test_service_recon.py
+++ b/scripts/tests/test_service_recon.py
@@ -651,13 +651,24 @@ sensitivity: public
         assert b.index.basis == "owning repo"
         assert "scope via" not in sr.render_brief(b)
 
-    def test_index_scopes_prefers_the_owner_and_falls_back_to_searched_roots(self) -> None:
+    def test_index_scopes_asks_EVERY_searched_root_owner_ranked_FIRST(self) -> None:
+        """🔴 THE CONTRACT THAT CHANGED, and why.
+
+        This used to return ONLY the owner whenever locate found one. The
+        fallback below therefore covered the case where locate found NOTHING and
+        left uncovered the case where locate found the WRONG thing — which is the
+        case a thin margin between two repos produces every time. The owner is
+        still asked FIRST, so nothing can shadow it; the rest are asked after it.
+        """
         located = sr.LocateResult(
             "hits", "x",
-            (sr.RootScan("/a", "searched", "--repo"), sr.RootScan("/b", "searched", "--repo")),
+            (sr.RootScan("/a", "searched", "--repo", matches=("a/x.yaml", "a/x2.yaml")),
+             sr.RootScan("/b", "searched", "--repo", matches=("b/x.yaml",))),
             owner="/a",
         )
-        assert sr.index_scopes(located) == (("/a", "owning repo"),)
+        assert [p for p, _ in sr.index_scopes(located)] == ["/a", "/b"]
+        assert sr.index_scopes(located)[0][1] == sr.OWNER_BASIS
+        assert "1 path matched" in sr.index_scopes(located)[1][1]
 
         missed = sr.LocateResult(
             "no-match", "x",
@@ -680,6 +691,393 @@ sensitivity: public
         b = sr.recon(SERVICE, repos=[str(repo)], store_root=s)
         assert b.index.sensitivity == rc.SENSITIVITY_FAIL_SAFE
         assert b.index.sensitivity != "public"
+
+
+# =============================================================================
+# 🔴 THE INDEX IS ASKED AT EVERY SEARCHED ROOT, NOT AT THE ONE THAT "WON"
+# =============================================================================
+
+#: Pairwise-distinct and distinct from every constant these tests assert against:
+#: no scope word is a service word, and neither is `ledger-repo`/`roster`/`paging`
+#: from the fixtures above — so a wrong-field bug yields nothing, not a plausible
+#: answer. `BIG_ROOT` is the repo that WINS the path count; `SMALL_ROOT` loses it.
+BIG_ROOT = "atlas-repo"
+SMALL_ROOT = "harbor-repo"
+WIDGET = "turnstile"     # the service under test
+DECOY = "flywheel"       # an unrelated entry, so a store hit cannot be a store artefact
+
+
+def _repo_carrying(tmp_path: Path, name: str, token: str, n: int) -> Path:
+    """A committed git repo whose tracked paths carry `token` exactly `n` times.
+
+    All `n` files live under ONE directory: the match COUNT is the dimension
+    under test, and spreading them over directories would additionally trip the
+    umbrella note and change the brief for a reason unrelated to the claim.
+    """
+    r = tmp_path / name
+    r.mkdir()
+    _git(r, "init", "-q", "-b", "main")
+    for i in range(n):
+        _write(r / "apps" / token / f"m{i}.yaml", DEPLOYMENT.replace(SERVICE, token))
+    _write(r / "README.md", "synthetic\n")
+    _git(r, "add", "apps", "README.md")
+    _git(r, "commit", "-qm", f"feat({token}): seed")
+    return r
+
+
+def _entry(store: Path, scope: str, service: str) -> None:
+    """One synthetic, PUBLIC-marked entry. Nothing here comes from a real store."""
+    _write(store / scope / f"{service}.md", f"""\
+---
+service: {service}
+scope: {scope}
+sensitivity: public
+---
+
+## Pointers
+- manage-* skill: manage-{service}
+
+## Nuance / work-history
+- 2026-03-04 the {service} queue drains out of order under retry
+""")
+
+
+def _empty_store(tmp_path: Path, name: str = "two-scope-store") -> Path:
+    s = tmp_path / name
+    s.mkdir()
+    return s
+
+
+def _index_line(text: str) -> str:
+    return next(ln for ln in text.splitlines() if ln.startswith("index: "))
+
+
+class TestEveryScopeIsAsked:
+    """🔴 THE DEFECT: a four-path margin between two repos sent the lookup to the
+    loser's neighbour and rendered `ref-absent` over a curated entry in the cwd's
+    own scope.
+
+    The cost is not a wasted read. `claude/skills/analyze-service/SKILL.md` says
+    of the pointer/nuance block "Omit if it missed", so the curated knowledge is
+    silently DROPPED — and the next `/handoff` in that repo sees `ref-absent` and
+    may write a DUPLICATE entry into the wrong scope. A miss here ends in a store
+    WRITE.
+    """
+
+    @pytest.fixture
+    def roots(self, tmp_path: Path) -> tuple[Path, Path]:
+        """Two repos, a clear (33%) margin — wide enough that the tie-break plays
+        no part, so this class's assertions are about scope COVERAGE alone."""
+        return (_repo_carrying(tmp_path, BIG_ROOT, WIDGET, 3),
+                _repo_carrying(tmp_path, SMALL_ROOT, WIDGET, 2))
+
+    # --- the headline regression ---------------------------------------------
+
+    def test_an_entry_in_the_RUNNER_UP_scope_is_FOUND_not_reported_absent(
+        self, roots: tuple[Path, Path], tmp_path: Path
+    ) -> None:
+        big, small = roots
+        store = _empty_store(tmp_path)
+        _entry(store, SMALL_ROOT, WIDGET)        # ONLY the loser carries it
+        b = sr.recon(WIDGET, repos=[str(big), str(small)], store_root=store)
+
+        assert b.locate.owner == str(big), "the fixture must locate the OTHER repo"
+        assert b.index.status == "hit", b.index
+        assert b.index.scope == SMALL_ROOT
+        assert "manage-turnstile" in b.index.pointers
+        assert "drains out of order" in b.index.nuance
+
+    def test_the_brief_SAYS_which_scope_answered_and_on_what_basis(
+        self, roots: tuple[Path, Path], tmp_path: Path
+    ) -> None:
+        """A hit from a scope locate did NOT confirm owns the service is a
+        different claim from a hit in the owner's scope, and the reader has to be
+        able to see which one they are holding."""
+        big, small = roots
+        store = _empty_store(tmp_path)
+        _entry(store, SMALL_ROOT, WIDGET)
+        text = sr.render_brief(sr.recon(WIDGET, repos=[str(big), str(small)], store_root=store))
+
+        assert f"index: {SMALL_ROOT}/{WIDGET} — HIT" in text
+        assert "[scope via a searched root (2 paths matched)]" in text
+        assert "ref-absent" not in text
+
+    # --- the positive control -------------------------------------------------
+
+    def test_the_OWNER_scope_still_answers_and_prints_NOTHING_extra(
+        self, roots: tuple[Path, Path], tmp_path: Path
+    ) -> None:
+        """🔴 The common case must be untouched. A second scope carrying an
+        unrelated entry is present precisely so the extra lookups DO happen and
+        still change nothing a reader sees."""
+        big, small = roots
+        store = _empty_store(tmp_path)
+        _entry(store, BIG_ROOT, WIDGET)
+        _entry(store, SMALL_ROOT, DECOY)
+        b = sr.recon(WIDGET, repos=[str(big), str(small)], store_root=store)
+        text = sr.render_brief(b)
+
+        assert b.index.status == "hit"
+        assert b.index.scope == BIG_ROOT
+        assert b.index.basis == sr.OWNER_BASIS
+        for marker in ("scope via", "checked ", "THIN MARGIN"):
+            assert marker not in text, f"the common case grew a {marker!r} line"
+
+    def test_a_lower_ranked_scope_can_never_SHADOW_the_owner(
+        self, roots: tuple[Path, Path], tmp_path: Path
+    ) -> None:
+        """Both scopes carry the ref. First hit wins, and the owner is asked
+        first — so widening the search cannot move an answer that already worked.
+        """
+        big, small = roots
+        store = _empty_store(tmp_path)
+        _entry(store, BIG_ROOT, WIDGET)
+        _entry(store, SMALL_ROOT, WIDGET)
+        b = sr.recon(WIDGET, repos=[str(big), str(small)], store_root=store)
+        assert b.index.scope == BIG_ROOT
+        assert b.index.basis == sr.OWNER_BASIS
+
+    # --- the negative control -------------------------------------------------
+
+    def test_a_ref_in_NO_scope_is_still_ABSENT_and_names_its_denominator(
+        self, roots: tuple[Path, Path], tmp_path: Path
+    ) -> None:
+        """🔴 "Nothing recorded anywhere" is a claim about EVERY scope asked, so
+        it has to carry how many that was. Asking one scope and asking three are
+        indistinguishable outputs otherwise — the empty-result trap in
+        `claude/RULES.md`."""
+        big, small = roots
+        store = _empty_store(tmp_path)
+        _entry(store, BIG_ROOT, DECOY)      # the store is populated, just not for WIDGET
+        b = sr.recon(WIDGET, repos=[str(big), str(small)], store_root=store)
+        text = sr.render_brief(b)
+
+        assert b.index.status != "hit"
+        assert b.index.scopes_checked == (BIG_ROOT, SMALL_ROOT)
+        assert f"checked 2 scope(s): {BIG_ROOT}, {SMALL_ROOT}" in _index_line(text)
+
+    def test_the_denominator_is_a_MEASUREMENT_not_the_root_count(
+        self, tmp_path: Path
+    ) -> None:
+        """🔴 Two roots, ONE scope. A worktree and its base clone are different
+        directories that `scope_for_repo` maps to the same store scope; counting
+        roots would report `checked 2 scope(s)` naming one scope twice and
+        overstate how wide the search was."""
+        big = _repo_carrying(tmp_path, BIG_ROOT, WIDGET, 3)
+        wt = tmp_path / "a-worktree-of-it"
+        _git(big, "worktree", "add", "-q", str(wt), "-b", "side")
+        store = _empty_store(tmp_path)
+
+        b = sr.recon(WIDGET, repos=[str(big), str(wt)], store_root=store)
+        assert len(b.locate.roots) == 2, "the fixture must supply TWO roots"
+        assert b.index.scopes_checked == (BIG_ROOT,)
+        assert "checked 1 scope(s)" in _index_line(sr.render_brief(b))
+
+    # --- determinism ----------------------------------------------------------
+
+    def test_the_ORDER_scopes_are_asked_in_does_not_depend_on_the_ROOT_order(
+        self, roots: tuple[Path, Path], tmp_path: Path
+    ) -> None:
+        """Same inputs, same answer — asserted, not assumed. The rank key is
+        content-derived (matches desc, then path), so the configured order of
+        `--repo` cannot reach it."""
+        big, small = roots
+        store = _empty_store(tmp_path)
+        _entry(store, BIG_ROOT, DECOY)
+        forward = sr.recon(WIDGET, repos=[str(big), str(small)], store_root=store)
+        reverse = sr.recon(WIDGET, repos=[str(small), str(big)], store_root=store)
+        assert forward.index.scopes_checked == reverse.index.scopes_checked
+        assert forward.index.scopes_checked == (BIG_ROOT, SMALL_ROOT)
+        assert _index_line(sr.render_brief(forward)) == _index_line(sr.render_brief(reverse))
+
+    def test_the_candidate_order_is_stable_under_a_PERMUTED_scan_list(self) -> None:
+        """The unit form of the same claim, over `index_scopes` directly."""
+        scans = [
+            sr.RootScan("/one", "searched", "--repo", matches=("a", "b", "c")),
+            sr.RootScan("/two", "searched", "--repo", matches=("d", "e")),
+            sr.RootScan("/three", "searched", "--repo", matches=("f",)),
+        ]
+        expected = ["/one", "/two", "/three"]
+        for order in ((0, 1, 2), (2, 1, 0), (1, 2, 0), (2, 0, 1)):
+            loc = sr.LocateResult("hits", "x", tuple(scans[i] for i in order), owner="/one")
+            assert [p for p, _ in sr.index_scopes(loc)] == expected, order
+
+    def test_an_EQUAL_match_count_is_broken_by_PATH_never_by_arrival(self) -> None:
+        """Two roots with identical counts still need a total order, or the same
+        inputs answer differently on different hosts."""
+        a = sr.RootScan("/zulu", "searched", "--repo", matches=("x", "y"))
+        c = sr.RootScan("/alpha", "searched", "--repo", matches=("x", "y"))
+        for pair in ((a, c), (c, a)):
+            loc = sr.LocateResult("hits", "x", pair, owner="/zulu")
+            assert [p for p, _ in sr.index_scopes(loc)] == ["/alpha", "/zulu"]
+
+    # --- the store is still never written ------------------------------------
+
+    def test_a_MULTI_SCOPE_lookup_leaves_the_store_byte_identical(
+        self, roots: tuple[Path, Path], tmp_path: Path
+    ) -> None:
+        """The read-only contract, re-asserted on the path that now reads MORE of
+        the store than any previously-covered one."""
+        big, small = roots
+        store = _empty_store(tmp_path)
+        _entry(store, BIG_ROOT, DECOY)
+        _entry(store, SMALL_ROOT, WIDGET)
+        before = _tree_hash(store)
+        sr.recon(WIDGET, repos=[str(big), str(small)], store_root=store)
+        assert _tree_hash(store) == before
+
+
+# =============================================================================
+# 🔴 A THIN LEAD IS A RANKING, NOT OWNERSHIP
+# =============================================================================
+
+
+class TestThinMargin:
+    """`lives at:` is the sentence a reader turns into a belief. A lead of a few
+    paths does not support it, and the same number decides which scope the index
+    is asked FIRST.
+    """
+
+    @staticmethod
+    def _loc(*counts: int, origins: tuple[str, ...] = ()) -> sr.LocateResult:
+        scans = tuple(
+            sr.RootScan(f"/r{i}", "searched",
+                        origins[i] if i < len(origins) else "--repo",
+                        matches=tuple(f"p{i}-{j}" for j in range(n)))
+            for i, n in enumerate(counts)
+        )
+        ranked = sorted(scans, key=lambda s: (-len(s.matches), s.path))
+        top = len(ranked[0].matches)
+        tied = tuple(s.path for s in ranked[1:] if len(s.matches) == top)
+        return sr.LocateResult("hits", "x", scans, owner=ranked[0].path, owner_tied_with=tied)
+
+    # 🔴 MEASURED AT THREE POINTS on the margin dimension — under, exactly ON the
+    # threshold, and well over — because a predicate tested at one point cannot
+    # distinguish `<` from `<=` from "always true". The counts deliberately do
+    # not land on a round multiple of the threshold except at the boundary case,
+    # which is the point of the boundary case.
+    @pytest.mark.parametrize(
+        "counts, expect_runner_up",
+        [
+            ((6, 5), True),    # 16.7% — under the threshold
+            ((5, 4), False),   # exactly 20% — AT it, and therefore not thin
+            ((6, 4), False),   # 33% — well over
+            ((9, 8), True),    # 11.1% — the shape the real defect had
+        ],
+    )
+    def test_the_margin_predicate_moves_with_the_margin(
+        self, counts: tuple[int, int], expect_runner_up: bool
+    ) -> None:
+        got = sr.thin_runner_up(self._loc(*counts))
+        assert (got is not None) is expect_runner_up, got
+
+    def test_the_percent_it_reports_is_the_ACTUAL_lead(self) -> None:
+        runner, pct = sr.thin_runner_up(self._loc(9, 8))
+        assert pct == 11
+        assert len(runner.matches) == 8
+
+    def test_an_EXACT_TIE_is_left_to_the_TIE_note_not_reported_twice(self) -> None:
+        """A 0% lead is thinner than thin, and already has its own note. Two
+        wordings for one finding is two wordings to keep in agreement."""
+        loc = self._loc(4, 4)
+        assert loc.owner_tied_with, "the fixture must be a tie"
+        assert sr.thin_runner_up(loc) is None
+
+    def test_a_SINGLE_root_has_no_runner_up(self) -> None:
+        assert sr.thin_runner_up(self._loc(7)) is None
+
+    def test_the_LIVES_AT_line_names_the_runner_up_when_the_lead_is_thin(
+        self, tmp_path: Path
+    ) -> None:
+        big = _repo_carrying(tmp_path, BIG_ROOT, WIDGET, 6)
+        small = _repo_carrying(tmp_path, SMALL_ROOT, WIDGET, 5)
+        store = _empty_store(tmp_path)
+        text = sr.render_brief(sr.recon(WIDGET, repos=[str(big), str(small)], store_root=store))
+        assert f"THIN MARGIN — {SMALL_ROOT} matched 5 paths, only 17% behind" in text
+
+    def test_a_CLEAR_winner_prints_no_such_line(self, tmp_path: Path) -> None:
+        """The negative half — a marker that prints on the ordinary case is noise
+        nobody reads, and would make the common-case output non-identical."""
+        big = _repo_carrying(tmp_path, BIG_ROOT, WIDGET, 6)
+        small = _repo_carrying(tmp_path, SMALL_ROOT, WIDGET, 2)
+        store = _empty_store(tmp_path)
+        text = sr.render_brief(sr.recon(WIDGET, repos=[str(big), str(small)], store_root=store))
+        assert "THIN MARGIN" not in text
+
+    def test_the_JSON_surface_carries_the_runner_up_too(self, tmp_path: Path) -> None:
+        big = _repo_carrying(tmp_path, BIG_ROOT, WIDGET, 6)
+        small = _repo_carrying(tmp_path, SMALL_ROOT, WIDGET, 5)
+        store = _empty_store(tmp_path)
+        payload = sr.brief_json(sr.recon(WIDGET, repos=[str(big), str(small)], store_root=store))
+        assert payload["locate"]["thin_runner_up"]["lead_percent"] == 17
+        assert payload["locate"]["thin_runner_up"]["matches"] == 5
+
+
+class TestTheCwdWinsANearTie:
+    """🔴 When the path evidence cannot separate two repos, the one the human is
+    standing in is the better guess — and it is the one the defect's real case
+    hid an entry in. The tie-break only ever decides which scope answers when
+    MORE THAN ONE carries the ref; it never suppresses a lookup.
+    """
+
+    def _both_scopes(self, tmp_path: Path, big_n: int, small_n: int):
+        big = _repo_carrying(tmp_path, BIG_ROOT, WIDGET, big_n)
+        small = _repo_carrying(tmp_path, SMALL_ROOT, WIDGET, small_n)
+        store = _empty_store(tmp_path)
+        _entry(store, BIG_ROOT, WIDGET)
+        _entry(store, SMALL_ROOT, WIDGET)
+        # `repos=` stamps origin `--repo`; the cwd handle is what carries `cwd`.
+        return sr.recon(WIDGET, repos=[], env={"HOMELAB": str(big)},
+                        cwd=str(small), store_root=store)
+
+    def test_a_NEAR_TIE_is_answered_by_the_cwds_own_scope(self, tmp_path: Path) -> None:
+        b = self._both_scopes(tmp_path, 6, 5)          # 16.7% — under the threshold
+        assert b.locate.owner.endswith(BIG_ROOT), "locate must still rank the other repo first"
+        assert b.index.scope == SMALL_ROOT
+        assert b.index.basis == "the cwd repo (5 paths matched)"
+
+    def test_a_CLEAR_lead_is_answered_by_the_OWNER_not_the_cwd(self, tmp_path: Path) -> None:
+        """🔴 The control that makes the test above mean something. Measured at a
+        second point on the same dimension: if the cwd won here too, the
+        tie-break would be "always prefer the cwd" wearing a margin's clothes."""
+        b = self._both_scopes(tmp_path, 6, 3)          # 50% — well over
+        assert b.index.scope == BIG_ROOT
+        assert b.index.basis == sr.OWNER_BASIS
+
+    def test_when_NOTHING_matched_anywhere_the_cwd_is_still_asked_FIRST(
+        self, tmp_path: Path
+    ) -> None:
+        """🔴 The zero-denominator branch, which a percentage cannot express. A
+        total locate miss ranks every root at zero, so there is no margin to be
+        within — and the cwd is exactly where the alias-only case this fallback
+        was built for tends to live."""
+        big = _repo_carrying(tmp_path, BIG_ROOT, DECOY, 3)
+        small = _repo_carrying(tmp_path, SMALL_ROOT, DECOY, 2)
+        store = _empty_store(tmp_path)
+        b = sr.recon(WIDGET, repos=[], env={"HOMELAB": str(big)},
+                     cwd=str(small), store_root=store)
+        assert b.locate.status == "no-match", "the fixture must match NOTHING"
+        assert b.index.scopes_checked == (SMALL_ROOT, BIG_ROOT)
+
+    def test_an_EXPLICIT_repo_set_is_never_reordered(self, tmp_path: Path) -> None:
+        """`--repo` roots carry no `cwd` origin, so an operator who named the
+        roots gets exactly the ranking their counts imply."""
+        big = _repo_carrying(tmp_path, BIG_ROOT, WIDGET, 6)
+        small = _repo_carrying(tmp_path, SMALL_ROOT, WIDGET, 5)
+        store = _empty_store(tmp_path)
+        _entry(store, BIG_ROOT, WIDGET)
+        _entry(store, SMALL_ROOT, WIDGET)
+        b = sr.recon(WIDGET, repos=[str(big), str(small)], store_root=store)
+        assert b.index.scope == BIG_ROOT
+
+    def test_the_cwd_promotion_does_not_move_the_LOCATE_owner(self, tmp_path: Path) -> None:
+        """🔴 A deliberate limit, stated. `loc.owner` also selects which repo's
+        manifests are read and whose `git log` is shown — a far larger claim than
+        which scope to ask first, and one the match counts genuinely do decide.
+        The index read is cheap and non-exclusive; those are not."""
+        b = self._both_scopes(tmp_path, 6, 5)
+        assert Path(b.locate.owner).name == BIG_ROOT
+        assert b.git.repo is not None and Path(b.git.repo).name == BIG_ROOT
 
 
 # =============================================================================


### PR DESCRIPTION
## The defect, reproduced on `main`

`service_recon.py` asked the subsystem index **exactly one scope** — the located
owner — so a curated entry in a different scope was reported as absent.

```
$ python3 scripts/lib/service_recon.py <ref>
  repo-a   …   11 matched
  repo-b   …   35 matched
  repo-c   …   31 matched   (cwd)
lives at: repo-b  (35 paths matched)
index: ref-absent (scope repo-b) — nothing recorded under that ref yet
```

A **four-path margin** (35 vs 31) sent the lookup to the wrong repo and hid an
8-bullet curated entry sitting in the cwd's own scope.

`index_scopes()` returned only the owner whenever one existed; the
"ask every searched root" fallback fired only when `loc.owner is None` — so it
covered *locate found NOTHING* and left uncovered *locate found the WRONG thing*.
Its own docstring named the hazard ("a curated pointer sheet is worth MOST when
the path heuristic missed"); the code did not cover it.

**The cost is worse than a wasted read.** `analyze-service/SKILL.md` says of the
pointers/nuance block *"Omit if it missed"*, so the curated knowledge is silently
dropped — and the next `/handoff` in that repo sees `ref-absent` and may create a
**duplicate entry in the wrong scope**. A miss here ends in a store WRITE.

## The fix

Every **searched root** is asked, in rank order, **de-duplicated by SCOPE** (a
worktree and its base clone are one scope), and the **first hit wins** — so
widening the search can never move an answer the owner's scope already gave. The
brief prints **which scope answered and on what basis**, and a miss prints
`checked N scope(s): …` so "nothing recorded anywhere" arrives with its
denominator.

Two policy decisions, both driven by **one** constant (`THIN_OWNERSHIP_MARGIN =
0.20`) so there is one rule to reason about:

| decision | why |
|---|---|
| `lives at:` **names the runner-up** when the lead is under the margin | that line is where the reader forms the belief; a few paths of lead is a ranking, not ownership. An exact tie is left to the existing `OWNERSHIP IS TIED` note — one finding, one wording, and the two are mutually exclusive by construction. |
| the **cwd's root is asked FIRST** when within the margin of the leader | it only decides which scope wins when *more than one* carries the ref, and the repo the human is standing in is the better guess when the path evidence cannot separate them. `--repo` roots carry no `cwd` origin, so an explicit root set is never reordered. |

**`loc.owner` is deliberately NOT moved by the tie-break** (pinned by a test): it
also selects whose manifests are read and whose `git log` is shown — a far larger
claim than which scope to ask first. The index read is cheap and non-exclusive;
those are not.

## Verification

**Red at base → green at HEAD.** The new tests were run against
`service_recon.py` taken from the base commit: **21 failed, 87 passed**. Reds that
are *behavioural* (not merely "the new symbol does not exist"): the runner-up
lookup returns `scope-absent` instead of the entry; the brief never names the
answering scope; the permuted-order and path-tie-break determinism assertions;
the `THIN MARGIN` line; the JSON field; the cwd near-tie resolving to the wrong
scope. At HEAD: **109 passed, 0 failed**.

**The common case is byte-identical.** A fixed fixture (owner scope carries the
entry; a second scope carries an unrelated entry, so the extra lookups *do* run)
rendered under both trees:

```
cmp base.txt head.txt   -> identical
sha256                  -> 9fd8b08c… for both
```

and the comparison's own positive control (one byte prepended) goes red, so the
`cmp` is not wired to nothing. The `--json` surface gains **two additive fields**
(`locate.thin_runner_up: null`, `index.scopes_checked: [<owner scope>]`) and
changes **no existing value**.

**Mutation-tested per behaviour** — each mutant is the narrowest expression that
can be wrong, run in its own tree copy under `PYTHONDONTWRITEBYTECODE=1`, with an
unmutated copy as the negative control (**SURVIVED**, as required) and the whole
defect restored as the positive control (**KILLED**). 13/13 mutants killed, each
by the test that names the behaviour:

| mutant | killed by |
|---|---|
| the whole defect restored (owner-only early return) | 8 tests incl. the headline regression |
| ask only the owner | same 8 |
| rank ASCENDING | the shadow / owner-first tests |
| drop the path tie-break | `…broken_by_PATH_never_by_arrival` |
| never promote the cwd | `test_a_NEAR_TIE_is_answered_by_the_cwds_own_scope` |
| promote the cwd unconditionally | `test_a_CLEAR_lead_is_answered_by_the_OWNER_not_the_cwd` |
| zero-denominator blocks the promotion | `test_when_NOTHING_matched_anywhere_the_cwd_is_still_asked_FIRST` |
| `scopes_checked` records only the first | the denominator tests |
| no de-dup by scope | `test_the_denominator_is_a_MEASUREMENT_not_the_root_count` |
| thin-margin boundary `>=` → `>` | the exactly-at-threshold parametrised case |
| thin-margin reports an exact tie too | `test_an_EXACT_TIE_is_left_to_the_TIE_note…` |
| drop the `THIN MARGIN` render line | `test_the_LIVES_AT_line_names_the_runner_up…` |
| drop the `checked N scope(s)` clause | both denominator tests |
| basis always says `owning repo` | 4 tests incl. the pre-existing fallback-marker one |

**Cost.** Best-of-5 on the real worst case (a ref in no scope, three roots):
`0.090s` at base, `0.090s` at HEAD — the reads are local and the extra scopes do
not register.

**Gate verdict — read from the `nix log` CONTENT, never an exit code.** Built on
the tree rebased onto current `main` (both derivations, `--no-link`):

```
pytests   TOTAL collected=12900  passed=12899  skipped=1  failed=0
          (floor: 12069 = sum of 24 per-target floors)
          RESULT: PASS (exit=0)          `panic: test timed out` occurrences: 0
nodetests TOTAL suites=4 files=33 tests=1118 pass=1118 fail=0 skipped=0
          (floor: 1098)
          RESULT: PASS (exit=0)
```

The single skip is the pre-existing opt-in repo-cos live-store drift check.

**Store safety.** Every fixture is synthetic and built under `tmp_path`; no test
reads the real store, and nothing from it is quoted here or in the source.
`scripts/tests/test_store_content_not_copied.py` run standalone: **exit 0**, and
it reported that the live comparison actually ran.

## Docs kept honest

`analyze-service/reference/index-store.md` described the multi-root ask as a
*fallback for a locate miss* and said the scope is the owning repo's — both now
false. Updated, along with the status table and the two `SKILL.md` bullets that
tell the agent to name the answering scope and to surface the new `⚠ THIN MARGIN`
note.

## Contradicting the brief

One existing test, `test_index_scopes_prefers_the_owner_and_falls_back_to_searched_roots`,
**pinned the buggy contract** ("returns ONLY the owner when one exists"). It is
rewritten rather than deleted, and now asserts the owner is ranked first with the
rest following.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
