### PR TITLE
docs(handoff): the browser-bridge session column is joinable — and populated for a MINORITY of traffic

### DIFF
--- a/claudedocs/handoff-browser-bridge-session-attribution.md
+++ b/claudedocs/handoff-browser-bridge-session-attribution.md
@@ -1,0 +1,181 @@
+# Handoff: browser-bridge session attribution — 2026-08-20
+
+## Run this first — the index, one read-only command
+```bash
+python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py --repo ~/workspace/devrc
+```
+Terse pointers this doc does not carry, curated by past sessions and outliving it.
+🔴 RECALL, NOT LIVE OBSERVATION — every line is a pointer to VERIFY, never a current
+reading, and it may describe a gotcha already fixed. `scope-absent`/`scope-empty` means
+nothing is recorded yet: ordinary, not an error, and not a clean bill of health.
+Non-blocking: if it exits non-zero, print the stderr line and carry on.
+
+## Goal
+
+Started as a question — *"find sessions where I call opencode and use the browser skill"* —
+which required scanning 1.49M transcript records because `activity.events` could not answer
+it: `source='browser-bridge'` rows had an **empty `session` column, 0 of 6,937 over 14 days**.
+The goal became making that join answerable from telemetry, and closing what was found
+on the way.
+
+## State now
+
+- **Branch:** `main`, clean tree (3 untracked, none deployed). Both hosts converged at the
+  time of writing; main has since moved (other sessions are landing PRs continuously).
+- **Deploy/verify status: DEPLOYED AND VERIFIED**, with one honest gap — see the open
+  investigation below, which means the fix covers **less traffic than the headline implies**.
+
+### Merged and deployed this session
+
+| PR | what | verification actually performed |
+|---|---|---|
+| #549 `13f4278` | browser-bridge `session` column, tier-prefixed `X-Session-Id` | live: last empty cmd row `19:20:51`, first filled `19:21:12`, unit restarted `19:20:56` |
+| #551 `f199f23` | `activate` consent gate (`focus:true`) | live: non-TTY caller → `i3:"withheld"`, screen unmoved, **0** i3 focus events vs a **293** positive control |
+| #564 `f95edb5` | `RULES.md` ceiling eviction | 37,448 B, 914 headroom, gate green |
+| #570 `d621460` | opencode pin re-keyed 1.18.16 → 1.18.18 | measurements re-derived, four carried forward as explicitly unverified |
+| #578 `33f4275` | the `guards-narrower` rule | +38 B net, paid for by eviction in the same commit |
+| #580 `c1d30a4` | AGENTS.md cost claims corrected | premise **half-refuted** — nothing cut |
+| #583 `975d757` | `opencode-dispatch` preflight + skill | deployed; skill appears in the listing |
+| #584 `f33a9f8` | `opencode:` session tier via `shell.env` | **live end-to-end join, below** |
+
+### The join works — measured 2026-08-20 16:44 UTC
+
+From inside a real `opencode run`:
+
+```
+$ ~/workspace/devrc/scripts/browser-bridge/browser --print-session-id
+opencode:ses_fdff0fcd8ffeA1ebWc9FdhNcJQ
+```
+
+and the resulting bridge row:
+
+```
+ts:       2026-08-20 16:44:33.725
+session:  ses_fdff0ae65ffeOUzSkKJ7Mq23PK
+op:       whoami
+sess_src: opencode
+```
+
+joined against `source='opencode'` on the same id: **1 bridge command ⋈ 1 opencode session.**
+An exact key join, not a string match or a time-window correlation.
+
+## Open investigations — live diagnosis state
+
+### `sess_src='unknown'` is the MAJORITY of browser-bridge cmd rows, from an unidentified producer
+
+- **Symptom:** since #549 deployed, most bridge `cmd` rows carry `sess_src='unknown'` and an
+  empty `session`. This is fail-closed (no wrong attribution) but means the column is far
+  less populated than the deploy-window measurement suggested.
+- **Observed (values, `activity.events`, window `ts > '2026-08-19 19:20:56'`):**
+  - at 2026-08-19 ~23:00 — `unknown 504 / claude 217`, `unknown` had **0** with a session
+  - at 2026-08-20 ~17:00 — `unknown 884 / claude 217 / opencode 1`
+    → `claude` is **static**; `unknown` is **actively growing** (~380 rows in ~18h, ≈21/h)
+  - op breakdown of the unknown population, last 6h: **`text` 68 — and nothing else**
+  - `key` (instance) is **empty** on all of them; `host` is **workbench** only
+  - **`countIf(JSONHas(payload,'origin'))` = 0 of 721** — *no row has ever carried an
+    `origin` key*
+- **Ruled out:**
+  - **the `browser-agent` path** — `browser_tool_impl.mjs` sets `X-Session-Origin`, and the
+    origin count is a hard zero. If browser-agent were the producer there would be origin rows.
+  - **a stale `server.py`** — the deployed copy has the tier code (`grep -c
+    'SESSION_JOINABLE_TIERS\|_is_joinable'` → 10) and the unit restarted with the switch.
+  - **the laptop** — every row is `host=workbench`.
+- **Leading hypothesis:** a caller that reaches `/cmd` **without** an `X-Session-Id` header at
+  all, or with a value carrying no `tier:` prefix. `sess_src='unknown'` is exactly the
+  fail-closed bucket for both. `op=text` exclusively + empty instance key suggests a
+  scripted/repeated cheap read rather than interactive agent use. **Not diagnosed** — an
+  absent header is consistent with several producers and I have no signal separating them.
+- **Next probe** (run verbatim; the bridge logs structured lines per request):
+  ```bash
+  journalctl --user -u browser-bridge --since "1 hour ago" --no-pager | grep -i 'cmd\|text' | tail -40
+  ```
+  If that is silent, the discriminating move is to add the caller's identity to the existing
+  `cmd` telemetry — the server already has the raw header — rather than guessing. A grep for
+  direct `/cmd` POSTs (`grep -rn 'localhost.*\/cmd' ~/workspace/devrc/scripts/`) is the cheap
+  second source.
+
+🔴 **Do not read `unknown` as "server.py is stale"** — on this host it does not discriminate.
+That reading is explicitly retracted in #584's post-deploy check.
+
+## Next steps (ranked)
+
+1. **Diagnose the `unknown` producer** (above). It is the difference between "the column is
+   populated" and "the column is populated for 20% of traffic".
+2. **Decide `wip/opencode-kubectl-exec-allow`** (`62f0539`, on origin, NOT deployed) — found
+   uncommitted in the shared checkout, 2 days stale, not authored by this session. It removes
+   `*kubectl*exec*` from opencode's bash `ask` list and from `DANGEROUS_FAMILIES`, lowering the
+   ask-count pin 51→50. Net effect: an autonomous opencode agent could `kubectl exec` into a
+   pod **without approval**. Coherent and deliberate, but unreviewed.
+3. **Open a PR for `wip/resume-open-investigations-are-recall`** (`99aa87a`) — someone's
+   uncommitted improvement to the `resume` skill, preserved rather than deployed. It is a good
+   change: it says a handoff's open-investigation block is RECALL, not live state. *(Which is
+   why this doc's block above carries values and eliminations, not narrative.)*
+4. **The historical-claims ledger cannot tell "historical by design" from "stale and
+   forgotten"** — `reason` in `HISTORICAL_VERSION_CLAIMS` is never asserted on; it appears only
+   in failure-message f-strings, and an **empty** reason string passes. Structurally the same
+   blind-spot shape #570 fixed in `_VERSION_RE`.
+5. **The gate reports `RESULT: FAIL (exit=1)` while naming no failing target.** Cost two agents
+   and this session multiple cycles; every diagnosis required `nix log <drv>` plus grep. The
+   highest-traffic tool in the repo omits the one fact you need.
+6. Smaller, all recorded and none blocking: the flaky `test_the_throttle_path_carries_both_the_hash_and_the_join_key`
+   (2/12 runs, 3s `_wait_events` budget); `_clean_session_field` accepts C1 control chars
+   (0x80–0x9F); `browser --tab <parent> emulate` now raises `not_owned_tab` across the
+   claude→opencode boundary; opencode `task` subagents get their own id so **routing** (not
+   telemetry) fragments within one run.
+
+## Gotchas / decisions / dead-ends
+
+- 🔴 **Every red gate this session was someone else's**, inherited from a base that moved:
+  `test_rules_size` (a rule added without its eviction), the browser-bridge floor (twice),
+  `test_opencode_engine` (the flake bumped the binary), `test_prune_skill_size` (my own #551
+  invalidating a size figure). **None was ever the PR under test.** Gate the merged tree.
+- 🔴 **The integration branch found what four branch gates could not.** #583 and #584 had the
+  **identical** `.git`-in-the-nix-sandbox bug (`git ls-files` exits 128 at `/build/src`, read
+  as "untracked"). The audit caught it in #584; nobody checked the sibling. It was in #583 in
+  five places. A per-PR audit structurally cannot see that.
+- **`ls -l` on a home-manager symlink reports the LINK's size** (89 B), not the target's
+  (42,671 B). Use `stat -Lc %s`. This nearly made me refute a correct measurement.
+- **`sed` with `|` as delimiter silently no-ops on a pattern containing `|`.** It reported
+  success and changed nothing; only diffing caught it.
+- **`-x` and mutation testing do not mix** — first-failure-wins mis-attributed two mutants to
+  an unrelated flaky test and produced a **false KILL** that hid a real finding.
+- **`nix build` exit status through a pipe is the pipe's**, and zsh has `pipestatus`, not
+  `PIPESTATUS`. The authoritative signal is whether the derivation's **output path exists**.
+  A `RESULT: PASS` line in the log can coexist with a non-realised derivation (interrupted build).
+- **The AGENTS.md "7.7k uncached tokens/request" premise is HALF true.** The tokens are real
+  (measured 8,329; the file grew to 43,676 B). The "uncached" half is **refuted**: 330/332
+  billed sessions (99.4%) have `tokens_cache_read > 0`, cache reads ~50× cheaper, so the file
+  is ~$0.12 of $1.77 (~7%). Caching already worked on 1.18.4 — it was never version-dependent.
+  The original `cache.read=0` was true of **browser-agent's own single-shot shape** and got
+  generalised. **Not a cost lever; nothing was cut.**
+- **Do not adopt browser-agent's isolated `OPENCODE_CONFIG_DIR` as a general fix** — it also
+  drops `plugin/guard.js`, the enforcement layer. Safe there (that agent has no shell), unsafe
+  generally.
+
+## How to verify
+
+```bash
+# 1. the Claude-side attribution and the opencode-side join, in one query
+CH=http://192.168.50.94:30123
+RPW=$(SOPS_AGE_KEY_FILE=~/workspace/homelab-talos/.secrets/age.key sops -d --extract \
+  '["stringData"]["reader-password"]' \
+  <(git -C ~/workspace/homelab-talos show origin/trunk:clusters/homelab/apps/activity/secrets.enc.yaml))
+curl -s --user "activity_reader:$RPW" --data-binary "
+  SELECT JSONExtractString(payload,'sess_src') s, count(), countIf(session!='')
+  FROM activity.events WHERE source='browser-bridge' AND kind='cmd'
+    AND ts > now() - INTERVAL 24 HOUR GROUP BY s FORMAT TSV" "$CH/"
+
+# 2. the focus gate — from a NON-TTY caller this must print withheld and NOT move the screen
+~/workspace/devrc/scripts/browser-bridge/browser --instance work activate | \
+  python3 -c 'import json,sys; d=json.load(sys.stdin)["result"]["data"]; print(d["i3"], d.get("i3_detail"))'
+# expect: withheld not_requested
+
+# 3. the opencode tier, end to end (~$0.02, one deepseek turn)
+opencode run --dir /tmp/ocv -m openrouter/deepseek/deepseek-v4-flash \
+  'Run exactly: ~/workspace/devrc/scripts/browser-bridge/browser --print-session-id'
+# expect: opencode:ses_...   (NOT claude:... — that would mean the leak guard regressed)
+```
+
+🔴 **Merged ≠ deployed.** `server.py` and the plugin are `home.file` copies needing
+`scripts/ship.sh`; the `browser` CLI and the `opencode` SKILL.md are `mkOutOfStoreSymlink`s
+and apply immediately. `readlink -f` is the arbiter, never a diff.


### PR DESCRIPTION
docs(handoff): the browser-bridge session column is joinable — and populated for a MINORITY of traffic

The question that started this — "find sessions where I call opencode and use the
browser skill" — needed a subagent scanning 1.49M transcript records, because
`source='browser-bridge'` rows carried an empty `session` column: 0 of 6,937 over
14 days. It is now an exact two-source key join, verified live:

    $ browser --print-session-id          (inside a real opencode run)
    opencode:ses_fdff0fcd8ffeA1ebWc9FdhNcJQ

    ts: 2026-08-20 16:44:33  session: ses_fdff0ae65ffe...  op: whoami  sess_src: opencode
    -> 1 bridge command JOIN 1 opencode session, on the id, not a time window.

Eight PRs merged and deployed to both hosts (#549 #551 #564 #570 #578 #580 #583 #584),
each row in the doc stating what verification was ACTUALLY performed rather than that
it passed.

🔴 The doc leads with the correction, not the win. I reported the column as "100%
attributed" off a ten-minute window; over 22.6h it is ~30%, and `sess_src='unknown'`
is the MAJORITY — 884 rows and growing, exclusively `op=text`, empty instance key,
workbench-only, and zero rows carrying an `origin` key. That last fact rules out the
browser-agent path. NOT DIAGNOSED. The Open-investigations block carries the values,
the eliminations and the verbatim next probe, so the next session does not re-run
what has already been run.

Also recorded because they cost real time: `ls -l` on a home-manager symlink reports
the LINK's size (89 B) not the target's (42,671 B); `sed` with `|` as delimiter
silently no-ops on a pattern containing `|`; `-x` and mutation testing do not mix
(first-failure-wins produced a false KILL that hid a real finding); `nix build`'s
status through a pipe is the pipe's, and a `RESULT: PASS` line can coexist with a
NON-realised derivation — output-path existence is the only gate signal that means
anything.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
