### PR TITLE
feat(signal): keep the mutation battery — eight were written and every one thrown away

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1076,7 +1076,16 @@ TARGET_FLOORS=(
   # hermetic rather than merely asserted to be. If this line conflicts with a
   # sibling branch, re-run the gate on the MERGED tree and copy what it prints;
   # do not reconcile the two sides by hand.
-  "scripts/signal/tests|444"
+  # 2026-08-20: 582 tripped the ceiling at 555 with every test PASSING. The gate
+  # printed "scripts/signal/tests|553" and that is what is below, copied not
+  # computed. The 66 new tests guard the MUTATION BATTERY, now kept in-repo at
+  # scripts/signal/tests/mutation_battery.py after eight successive batteries
+  # were written into scratchpads and thrown away. They mutate nothing — they
+  # pin the battery's ANCHORS and killer-test NAMES, because the way a battery
+  # rots is silent: an anchor stops matching, the mutant never lands, and the
+  # run prints ANCHOR-MISS, which reads like a hiccup rather than "this mutant
+  # tested nothing". That has already happened here once.
+  "scripts/signal/tests|553"
   "scripts/initiatives/tests|745"
   "scripts/repo-cos/tests|315"
   "scripts/task-spec-drafter/tests|135"

--- a/scripts/signal/tests/mutation_battery.py
+++ b/scripts/signal/tests/mutation_battery.py
@@ -3,7 +3,12 @@
 
     python3 scripts/signal/tests/mutation_battery.py            # run them all
     python3 scripts/signal/tests/mutation_battery.py --list      # show the ledger
-    python3 scripts/signal/tests/mutation_battery.py --only A1 R4
+    python3 scripts/signal/tests/mutation_battery.py --only A1 M4
+
+Exit codes: 0 every mutant killed by its named test · 1 at least one SURVIVED,
+ANCHOR-MISSed or was KILLED-WRONG-REASON · 2 refused to start (dirty tree, an
+unreadable `git status`, a red baseline, a named killer that did not run) ·
+3 a mutant was left in the tree, or that could not be determined.
 
 🔴 WHY THIS FILE EXISTS AT ALL. Eight mutation batteries have been run against
 this module across #514, #537, #540, #546 and #573. Every one of them lived in a
@@ -44,6 +49,7 @@ from __future__ import annotations
 import argparse
 import os
 import shutil
+import signal as _signal
 import subprocess
 import sys
 import tempfile
@@ -56,7 +62,6 @@ BP = "scripts/signal/build-push.sh"
 
 SUITE_EXCL = "scripts/signal/tests/test_group_exclusions.py"
 SUITE_IMAGE = "scripts/signal/tests/test_image_deps.py"
-SUITE_ALL = "scripts/signal/tests/"
 
 
 class Mutant:
@@ -162,8 +167,10 @@ MUTANTS: list[Mutant] = [
            "                WHERE m.id = %s AND m.is_outbound",
            "test_get_draft_refuses_a_device_sync_ECHO_not_just_a_draft", SUITE_EXCL),
 
-    Mutant("M10", "the mute table re-keyed on a NAME column — which would match nothing, "
-                  "because no group name was stored for months", DB,
+    Mutant("M10", "a NAME column ADDED to the mute table — the shape a name-keyed mute "
+                  "list would take, which would have matched nothing because no group "
+                  "name was stored for months. The killer pins the COLUMN LIST, not the "
+                  "primary key, so that is what this breaks", DB,
            "        group_id BYTEA PRIMARY KEY,\n        note TEXT,",
            "        group_id BYTEA PRIMARY KEY,\n        name TEXT,\n        note TEXT,",
            "test_the_mute_table_is_keyed_on_the_binary_id_not_the_name", SUITE_EXCL),
@@ -237,11 +244,11 @@ def anchor_report() -> list[tuple[Mutant, int]]:
     return out
 
 
-def _run(suite: str) -> tuple[int, str]:
+def _run(suite: str, *, verbose: bool = False) -> tuple[int, str]:
     env = dict(os.environ, PYTHONDONTWRITEBYTECODE="1")
     p = subprocess.run(
-        [sys.executable, "-m", "pytest", suite, "-q", "--no-header",
-         "-p", "no:cacheprovider"],
+        [sys.executable, "-m", "pytest", suite, "-v" if verbose else "-q",
+         "--no-header", "-p", "no:cacheprovider"],
         cwd=REPO, env=env, capture_output=True, text=True)
     return p.returncode, p.stdout + p.stderr
 
@@ -251,10 +258,46 @@ def _failed(out: str) -> set[str]:
             for ln in out.splitlines() if ln.startswith(("FAILED ", "ERROR "))}
 
 
+def _verdict(rc: int, failures: set[str], killer: str) -> tuple[str, str]:
+    """(verdict, detail) for one mutant. PURE — no I/O, so it is table-testable.
+
+    Extracted from `main` on an audit finding: while this logic was inline, the
+    only guard on it was a test asserting the STRING `"m.killer in failures"`
+    appeared in the source. That is satisfied by `elif m.killer in failures or
+    True:` — which scores every mutant KILLED regardless of which test fired,
+    i.e. exactly the green-for-the-wrong-reason this battery exists to prevent,
+    with the guard's own words still present. A guard on WORDS is walkable by
+    rewording; the fix is to make the behaviour reachable from a test.
+    """
+    if rc == 0:
+        return "SURVIVED", "the suite stayed GREEN"
+    if killer in failures:
+        return "KILLED", f"by {killer} (+{len(failures) - 1} other)"
+    return "KILLED-WRONG-REASON", f"expected {killer}, got {sorted(failures)}"
+
+
+def _git_status(repo: Path) -> tuple[int, str]:
+    """`git status --porcelain`, returning the STATUS as well as the output.
+
+    🔴 FAIL CLOSED. Both callers used to read `.stdout` and ignore the return
+    code, so any git failure produced an empty string — which reads as "clean".
+    Measured: with `git status` broken (rc 128, empty stdout) the runner did not
+    refuse, mutated a module in a tree holding uncommitted work, and finished by
+    printing `tree restored: clean` — a positive claim about a check that never
+    ran. Real ways to get rc≠0 with empty stdout: git's `safe.directory`
+    ownership refusal, a concurrent `index.lock`, a `cp -a` copy of a worktree
+    (whose `.git` is a FILE — a manoeuvre this repo's rules tell agents to make),
+    an extracted tarball, a misconfigured `GIT_DIR`.
+    """
+    p = subprocess.run(["git", "-C", str(repo), "status", "--porcelain"],
+                       capture_output=True, text=True)
+    return p.returncode, p.stdout.strip()
+
+
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument("--list", action="store_true", help="print the ledger and exit")
-    ap.add_argument("--only", nargs="*", metavar="ID", help="run just these mutant ids")
+    ap.add_argument("--only", nargs="+", metavar="ID", help="run just these mutant ids")
     args = ap.parse_args(argv)
 
     if args.list:
@@ -263,11 +306,24 @@ def main(argv=None) -> int:
             print(f"{m.id:4} {m.path:30} -> {m.killer}{flag}\n     {m.why}\n")
         return 0
 
+    # 🔴 A SIGTERM used to leave a mutant in the tree. `finally` covers exceptions
+    # and Ctrl-C (KeyboardInterrupt) but NOT a default-handled SIGTERM, which
+    # kills the process outright. Measured: `timeout -s TERM` left
+    # `_signal_db.py` modified; `timeout -s INT` restored cleanly. In a shared
+    # checkout that silently hands the next session a mutated production module.
+    # Turning it into SystemExit lets the `finally` run.
+    _signal.signal(_signal.SIGTERM, lambda *_: sys.exit(1))
+
     # 🔴 REFUSE A DIRTY TREE. This mutates files in place. A crash mid-run would
     # take uncommitted work with it, and in this shared checkout that work is
-    # usually somebody else's.
-    dirty = subprocess.run(["git", "-C", str(REPO), "status", "--porcelain"],
-                           capture_output=True, text=True).stdout.strip()
+    # usually somebody else's. Fails CLOSED — see `_git_status`.
+    rc_git, dirty = _git_status(REPO)
+    if rc_git != 0:
+        print(f"REFUSING: `git status` exited {rc_git} in {REPO}, so the "
+              "dirty-tree check COULD NOT MEASURE. An unreadable answer is not "
+              "a clean one, and this battery edits files in place.",
+              file=sys.stderr)
+        return 2
     if dirty:
         print("REFUSING: the tree is dirty and this battery edits files in place.\n"
               "Commit, or run it in a clean worktree:\n"
@@ -282,14 +338,32 @@ def main(argv=None) -> int:
 
     # Baseline. Without it a "kill" is unattributable — it might have been red
     # before the mutant landed.
+    #
+    # 🔴 AND IT PROVES EVERY NAMED KILLER ACTUALLY RAN AND PASSED. A killer that
+    # merely EXISTS is not enough: mark one `@pytest.mark.skip` and it is still
+    # collected, still greps as `def <name>`, and its mutant is then scored
+    # SURVIVED — inverting the meaning of this tool's own output. Verified by
+    # doing exactly that. Existence is checked statically in the gate; that it
+    # RAN can only be observed here, in the run that happens anyway.
+    baseline_passed: set[str] = set()
     for suite in {m.suite for m in selected}:
-        rc, out = _run(suite)
-        last = out.strip().splitlines()[-1] if out.strip() else "(no output)"
-        print(f"BASELINE {suite}: rc={rc}  {last}")
+        rc, out = _run(suite, verbose=True)
+        summary = [ln for ln in out.strip().splitlines() if " passed" in ln or " failed" in ln]
+        print(f"BASELINE {suite}: rc={rc}  {summary[-1] if summary else '(no verdict)'}")
         if rc != 0:
             print("  !! baseline RED — aborting; nothing below would be attributable",
                   file=sys.stderr)
             return 2
+        for ln in out.splitlines():
+            if " PASSED" in ln and "::" in ln:
+                baseline_passed.add(ln.split("::")[-1].split()[0].split("[")[0])
+
+    unrun = sorted({m.killer for m in selected} - baseline_passed)
+    if unrun:
+        print("REFUSING: these named killer tests did not PASS in the baseline, so "
+              "any mutant they guard would be scored SURVIVED for the wrong "
+              f"reason (skipped? renamed? deselected?): {unrun}", file=sys.stderr)
+        return 2
 
     results = []
     for m in selected:
@@ -305,14 +379,7 @@ def main(argv=None) -> int:
         try:
             target.write_text(original.replace(m.old, m.new, 1), encoding="utf-8")
             rc, out = _run(m.suite)
-            failures = _failed(out)
-            if rc == 0:
-                verdict, detail = "SURVIVED", "the suite stayed GREEN"
-            elif m.killer in failures:
-                verdict, detail = "KILLED", f"by {m.killer} (+{len(failures) - 1} other)"
-            else:
-                verdict, detail = ("KILLED-WRONG-REASON",
-                                   f"expected {m.killer}, got {sorted(failures)}")
+            verdict, detail = _verdict(rc, _failed(out), m.killer)
             results.append((m, verdict, detail))
             print(f"{m.id}: {verdict} — {detail}")
         finally:
@@ -327,8 +394,12 @@ def main(argv=None) -> int:
     for m, verdict, detail in bad:
         print(f"  !! {verdict}: {m.id} — {detail}", file=sys.stderr)
 
-    after = subprocess.run(["git", "-C", str(REPO), "status", "--porcelain"],
-                           capture_output=True, text=True).stdout.strip()
+    rc_git, after = _git_status(REPO)
+    if rc_git != 0:
+        print(f"\n🔴 COULD NOT MEASURE whether a mutant was left behind — "
+              f"`git status` exited {rc_git}. Check the tree by hand; this is "
+              "NOT a clean report.", file=sys.stderr)
+        return 3
     if after:
         print(f"\n🔴 THE TREE IS DIRTY AFTER THE RUN — a mutant was left behind:\n{after}",
               file=sys.stderr)

--- a/scripts/signal/tests/mutation_battery.py
+++ b/scripts/signal/tests/mutation_battery.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""The Signal suite's mutation battery — the mutants, and a runner for them.
+
+    python3 scripts/signal/tests/mutation_battery.py            # run them all
+    python3 scripts/signal/tests/mutation_battery.py --list      # show the ledger
+    python3 scripts/signal/tests/mutation_battery.py --only A1 R4
+
+🔴 WHY THIS FILE EXISTS AT ALL. Eight mutation batteries have been run against
+this module across #514, #537, #540, #546 and #573. Every one of them lived in a
+scratchpad directory that no longer exists. The batteries were the most expensive
+artefact produced in those sessions and the only one not kept: each encodes a
+specific way this code can be broken *without any test noticing*, which is
+knowledge that does not survive in anyone's head and cannot be re-derived by
+reading the code — it was found by breaking the code and watching what stayed
+green.
+
+🔴 WHAT A GREEN RUN HERE DOES AND DOES NOT MEAN. It means: every mutant BELOW is
+killed by the test NAMED beside it. It does NOT mean the suite is adequate — a
+battery only ever covers the failure modes whoever wrote it imagined. The
+strongest evidence in this file is the four mutants marked `[audit]`: they were
+found by an INDEPENDENTLY-CONSTRUCTED battery during a pre-merge audit, and every
+one of them SURVIVED the battery its author had just called complete. So when you
+extend this: vary how the battery is BUILT, not just how many mutants it holds.
+
+Two disciplines this runner enforces mechanically, because both have produced
+confident wrong answers here before:
+
+  * **A kill must be BY THE NAMED TEST.** "Some test failed" is not a kill: a
+    different guard's error is green for the wrong reason and stays green with
+    the guard under test deleted. A mutant killed by an unexpected test is
+    reported `KILLED-WRONG-REASON`, which is a finding, not a pass.
+  * **`PYTHONDONTWRITEBYTECODE=1`, always.** CPython validates a cached module on
+    source mtime-in-whole-SECONDS plus size, so a same-LENGTH edit landing in the
+    same second as the last import is invisible: the test imports the ORIGINAL
+    bytecode and the mutant is scored SURVIVED without ever having executed.
+
+And one it enforces for safety: it edits files in the working tree and restores
+them from a byte copy, so it REFUSES TO RUN ON A DIRTY TREE. A crash mid-run
+against uncommitted work would destroy it, and this repo is a shared checkout
+where the dirty files usually belong to somebody else.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+DB = "scripts/signal/_signal_db.py"
+CON = "scripts/signal/consumer.py"
+BP = "scripts/signal/build-push.sh"
+
+SUITE_EXCL = "scripts/signal/tests/test_group_exclusions.py"
+SUITE_IMAGE = "scripts/signal/tests/test_image_deps.py"
+SUITE_ALL = "scripts/signal/tests/"
+
+
+class Mutant:
+    """One way to break the code, and the ONE test that must notice."""
+
+    def __init__(self, mid, why, path, old, new, killer, suite):
+        self.id, self.why, self.path = mid, why, path
+        self.old, self.new, self.killer, self.suite = old, new, killer, suite
+
+
+MUTANTS: list[Mutant] = [
+    # ------------------------------------------------------------------ #
+    # [audit] — found by an INDEPENDENT battery; every one SURVIVED the
+    # battery its author had just certified as complete. These are the
+    # highest-value rows in this file. Do not delete one because it looks
+    # redundant with a neighbour; each names a distinct blind spot.
+    # ------------------------------------------------------------------ #
+    Mutant("A1", "[audit] the group-name COALESCE was DEAD CODE reading as protection: "
+                 "the bind is `name or \"\"`, so EXCLUDED.name is never NULL. A later "
+                 "nameless envelope wiped a stored name back to ''.",
+           DB,
+           "                    name = COALESCE(NULLIF(EXCLUDED.name, ''), groups.name),",
+           "                    name = EXCLUDED.name,",
+           "test_a_LATER_nameless_envelope_does_not_WIPE_a_stored_group_name", SUITE_EXCL),
+
+    Mutant("A2", "[audit] `not_excluded()` validated its alias and then hardcoded `m`. "
+                 "Every call site passes `m`, so nothing could tell the two apart and the "
+                 "parameter silently became decorative.",
+           DB,
+           '        f"WHERE gx.id = {alias}.group_id)"',
+           '        "WHERE gx.id = m.group_id)"',
+           "test_the_predicate_actually_USES_the_alias_it_is_given", SUITE_EXCL),
+
+    Mutant("A3", "[audit] `_fmt_group_id` emitting the urlsafe alphabet. Survived because "
+                 "every fixture reaching it was a repeated byte whose base64 contains no "
+                 "`+` or `/` — a fixture structurally unable to see the bug.",
+           CON,
+           "    return base64.b64encode(bytes(raw)).decode()",
+           "    return base64.urlsafe_b64encode(bytes(raw)).decode()",
+           "test_fmt_group_id_emits_the_STANDARD_alphabet_not_urlsafe", SUITE_EXCL),
+
+    Mutant("A4", "[audit] widening the bytes guard to accept `str`. The test still passed — "
+                 "on the TypeError from `bytes(\"…\")` further down, not on the guard. Green "
+                 "for the wrong reason, and still green with the guard deleted.",
+           DB,
+           "        if not isinstance(group_id, (bytes, bytearray, memoryview)):",
+           "        if not isinstance(group_id, (bytes, bytearray, memoryview, str)):",
+           "test_a_str_group_id_is_refused", SUITE_EXCL),
+
+    # ------------------------------------------------------------------ #
+    # The mute list
+    # ------------------------------------------------------------------ #
+    Mutant("M1", "the mute filter removed from `search`", DB,
+           "                  AND {not_excluded('m')}\n", "",
+           "test_search_hides_a_muted_group", SUITE_EXCL),
+
+    Mutant("M2", "the mute filter removed from `list_conversations`", DB,
+           "                    WHERE {not_excluded('m')}\n", "",
+           "test_conversations_hides_a_muted_group_and_shows_it_again_after_unmute",
+           SUITE_EXCL),
+
+    Mutant("M3", "the mute filter removed from `get_message` — the id route", DB,
+           "f\"FROM signal.messages m WHERE m.id = %s AND {not_excluded('m')}\"",
+           '"FROM signal.messages m WHERE m.id = %s"',
+           "test_get_message_hides_a_muted_message_by_id", SUITE_EXCL),
+
+    Mutant("M4", "the predicate INVERTED — NOT EXISTS becomes EXISTS, so the mute list "
+                 "becomes an allowlist and everything else disappears", DB,
+           '        "NOT EXISTS (SELECT 1 FROM signal.excluded_groups x "',
+           '        "EXISTS (SELECT 1 FROM signal.excluded_groups x "',
+           "test_the_predicate_is_composable_with_AND", SUITE_EXCL),
+
+    Mutant("M5", "the SQL-alias whitelist accepts anything — the alias is interpolated, "
+                 "so this is the injection surface", DB,
+           '_SAFE_ALIAS = re.compile(r"^[a-z][a-z0-9_]{0,15}$")',
+           '_SAFE_ALIAS = re.compile(r"")',
+           "test_the_predicate_refuses_an_unsafe_alias", SUITE_EXCL),
+
+    Mutant("M6", "`unmute` deletes nothing — the rollback story silently stops working",
+           DB,
+           '            cur.execute("DELETE FROM signal.excluded_groups WHERE group_id = %s",',
+           '            cur.execute("DELETE FROM signal.excluded_groups WHERE group_id = %s AND 1=0",',
+           "test_conversations_hides_a_muted_group_and_shows_it_again_after_unmute",
+           SUITE_EXCL),
+
+    Mutant("M7", "an empty group_id is accepted — it would mute nothing, silently", DB,
+           '        if not bytes(group_id):\n'
+           '            raise ValueError("group_id is empty — that would mute nothing, silently")',
+           '        if False:\n'
+           '            raise ValueError("group_id is empty — that would mute nothing, silently")',
+           "test_an_empty_group_id_is_refused", SUITE_EXCL),
+
+    Mutant("M8", "a note-less re-mute WIPES the recorded reason — `mute <id>` is the "
+                 "natural way to re-issue and it destroyed the only record of why", DB,
+           '                "note = COALESCE(EXCLUDED.note, excluded_groups.note)",',
+           '                "note = EXCLUDED.note",',
+           "test_re_muting_WITHOUT_a_note_keeps_the_recorded_reason", SUITE_EXCL),
+
+    Mutant("M9", "`get_draft` loses `send_state IS NOT NULL`, so `is_outbound` alone also "
+                 "matches device-sync ECHOES — which carry a group_id, leaking a muted "
+                 "group's body through the draft surface", DB,
+           "                WHERE m.id = %s AND m.is_outbound AND m.send_state IS NOT NULL",
+           "                WHERE m.id = %s AND m.is_outbound",
+           "test_get_draft_refuses_a_device_sync_ECHO_not_just_a_draft", SUITE_EXCL),
+
+    Mutant("M10", "the mute table re-keyed on a NAME column — which would match nothing, "
+                  "because no group name was stored for months", DB,
+           "        group_id BYTEA PRIMARY KEY,\n        note TEXT,",
+           "        group_id BYTEA PRIMARY KEY,\n        name TEXT,\n        note TEXT,",
+           "test_the_mute_table_is_keyed_on_the_binary_id_not_the_name", SUITE_EXCL),
+
+    # ------------------------------------------------------------------ #
+    # Operator input decoding
+    # ------------------------------------------------------------------ #
+    Mutant("D1", "the operator decoder loses its ROUND-TRIP check. 🔴 This mutant SURVIVED "
+                 "the round that ADDED the length check below — the new guard swallowed "
+                 "every input that used to reach the round trip, so the round trip became "
+                 "unreachable and its removal went unnoticed. A fix round resets the gate.",
+           CON,
+           "    if not raw or base64.b64encode(raw).decode() != s:",
+           "    if not raw and False:",
+           "test_a_NON_CANONICAL_32_byte_encoding_is_refused", SUITE_EXCL),
+
+    Mutant("D2", "the operator decoder loses its LENGTH check — `Team` (3 bytes) and "
+                 "`deadbeef` (6) were accepted, muting nothing while printing success",
+           CON,
+           "    if len(raw) not in (16, 32):",
+           "    if False:",
+           "test_decode_internal_id_refuses_anything_non_canonical", SUITE_EXCL),
+
+    Mutant("D3", "the length check rejects GroupV2 — off-by-one in the accepted set", CON,
+           "    if len(raw) not in (16, 32):",
+           "    if len(raw) not in (16,):",
+           "test_decode_internal_id_round_trips_a_canonical_id", SUITE_EXCL),
+
+    # ------------------------------------------------------------------ #
+    # The group-name parse (#573)
+    # ------------------------------------------------------------------ #
+    Mutant("G1", "reverting to the pre-fix field: `groupInfo.name`, which real envelopes "
+                 "never carry (34 of 34 measured)", CON,
+           '"group_name": group.get("groupName") or group.get("name"),',
+           '"group_name": group.get("name"),',
+           "test_the_parser_reads_groupName_which_is_what_real_envelopes_carry", SUITE_EXCL),
+
+    Mutant("G2", "OPERAND ORDER swapped. Only killable because the two fixtures hold "
+                 "DISTINCT values — two operand-order mutants once survived 416 tests here "
+                 "because every fixture set both fields to the same string", CON,
+           '"group_name": group.get("groupName") or group.get("name"),',
+           '"group_name": group.get("name") or group.get("groupName"),',
+           "test_groupName_WINS_over_the_legacy_spelling", SUITE_EXCL),
+
+    # ------------------------------------------------------------------ #
+    # The build gate
+    # ------------------------------------------------------------------ #
+    Mutant("B1", "`build-push.sh`'s subcommand pin left stale — the control that refuses "
+                 "to push an image whose CLI grew a subcommand nobody decided on", BP,
+           'want_choices="approve conversations draft drafts health mute muted reconcile run search send unmute "',
+           'want_choices="approve conversations draft drafts health reconcile run search send "',
+           "test_the_build_control_lists_EXACTLY_the_CLI_subcommands", SUITE_IMAGE),
+]
+
+
+def anchor_report() -> list[tuple[Mutant, int]]:
+    """Each mutant's anchor and how many times it occurs. Exactly 1 is required.
+
+    0 → the code moved and the mutant would never land (`ANCHOR-MISS`, which is
+    neither a kill nor a survival — it is the battery silently testing nothing).
+    2+ → `str.replace(..., 1)` would hit whichever came first, which is not the
+    site the mutant describes. A real mutant once reported ANCHOR-MISS because
+    its anchor also matched an unrelated branch.
+    """
+    out = []
+    cache: dict[str, str] = {}
+    for m in MUTANTS:
+        if m.path not in cache:
+            cache[m.path] = (REPO / m.path).read_text(encoding="utf-8")
+        out.append((m, cache[m.path].count(m.old)))
+    return out
+
+
+def _run(suite: str) -> tuple[int, str]:
+    env = dict(os.environ, PYTHONDONTWRITEBYTECODE="1")
+    p = subprocess.run(
+        [sys.executable, "-m", "pytest", suite, "-q", "--no-header",
+         "-p", "no:cacheprovider"],
+        cwd=REPO, env=env, capture_output=True, text=True)
+    return p.returncode, p.stdout + p.stderr
+
+
+def _failed(out: str) -> set[str]:
+    return {ln.split()[1].split("::")[-1].split("[")[0]
+            for ln in out.splitlines() if ln.startswith(("FAILED ", "ERROR "))}
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--list", action="store_true", help="print the ledger and exit")
+    ap.add_argument("--only", nargs="*", metavar="ID", help="run just these mutant ids")
+    args = ap.parse_args(argv)
+
+    if args.list:
+        for m, n in anchor_report():
+            flag = "" if n == 1 else f"  🔴 ANCHOR MATCHES {n}x"
+            print(f"{m.id:4} {m.path:30} -> {m.killer}{flag}\n     {m.why}\n")
+        return 0
+
+    # 🔴 REFUSE A DIRTY TREE. This mutates files in place. A crash mid-run would
+    # take uncommitted work with it, and in this shared checkout that work is
+    # usually somebody else's.
+    dirty = subprocess.run(["git", "-C", str(REPO), "status", "--porcelain"],
+                           capture_output=True, text=True).stdout.strip()
+    if dirty:
+        print("REFUSING: the tree is dirty and this battery edits files in place.\n"
+              "Commit, or run it in a clean worktree:\n"
+              "  git -C <repo> worktree add ../devrc-mutants HEAD\n"
+              f"dirty paths:\n{dirty}", file=sys.stderr)
+        return 2
+
+    selected = [m for m in MUTANTS if not args.only or m.id in args.only]
+    if not selected:
+        print(f"no mutants matched {args.only}", file=sys.stderr)
+        return 2
+
+    # Baseline. Without it a "kill" is unattributable — it might have been red
+    # before the mutant landed.
+    for suite in {m.suite for m in selected}:
+        rc, out = _run(suite)
+        last = out.strip().splitlines()[-1] if out.strip() else "(no output)"
+        print(f"BASELINE {suite}: rc={rc}  {last}")
+        if rc != 0:
+            print("  !! baseline RED — aborting; nothing below would be attributable",
+                  file=sys.stderr)
+            return 2
+
+    results = []
+    for m in selected:
+        target = REPO / m.path
+        original = target.read_text(encoding="utf-8")
+        hits = original.count(m.old)
+        if hits != 1:
+            results.append((m, "ANCHOR-MISS", f"anchor matched {hits}x, need exactly 1"))
+            print(f"{m.id}: ANCHOR-MISS ({hits}x) — the mutant never landed")
+            continue
+        backup = tempfile.mkstemp(prefix="mutant-")[1]
+        shutil.copyfile(target, backup)
+        try:
+            target.write_text(original.replace(m.old, m.new, 1), encoding="utf-8")
+            rc, out = _run(m.suite)
+            failures = _failed(out)
+            if rc == 0:
+                verdict, detail = "SURVIVED", "the suite stayed GREEN"
+            elif m.killer in failures:
+                verdict, detail = "KILLED", f"by {m.killer} (+{len(failures) - 1} other)"
+            else:
+                verdict, detail = ("KILLED-WRONG-REASON",
+                                   f"expected {m.killer}, got {sorted(failures)}")
+            results.append((m, verdict, detail))
+            print(f"{m.id}: {verdict} — {detail}")
+        finally:
+            shutil.copyfile(backup, target)
+            os.unlink(backup)
+
+    print("\n================ SUMMARY ================")
+    for m, verdict, detail in results:
+        print(f"  {verdict:20} {m.id}  {m.killer}")
+    bad = [r for r in results if r[1] != "KILLED"]
+    print(f"\n{len(results) - len(bad)}/{len(results)} killed by their NAMED test")
+    for m, verdict, detail in bad:
+        print(f"  !! {verdict}: {m.id} — {detail}", file=sys.stderr)
+
+    after = subprocess.run(["git", "-C", str(REPO), "status", "--porcelain"],
+                           capture_output=True, text=True).stdout.strip()
+    if after:
+        print(f"\n🔴 THE TREE IS DIRTY AFTER THE RUN — a mutant was left behind:\n{after}",
+              file=sys.stderr)
+        return 3
+    print("tree restored: clean")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/signal/tests/test_envelope_parse.py
+++ b/scripts/signal/tests/test_envelope_parse.py
@@ -329,12 +329,35 @@ def test_no_stale_event_stream_WORDING_survives_anywhere_in_the_package():
         if path.name == this_file:
             continue          # the guard must quote the token it bans
         for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
-            if "SSE" not in line:
+            # 🔴 WORD BOUNDARIES. A bare `"SSE" not in line` is a substring test,
+            # and `PASSED` contains SSE — so an ordinary sentence about a test
+            # passing was reported as stale transport wording. Measured: this
+            # guard went red on `# … EVERY NAMED KILLER ACTUALLY RAN AND PASSED`
+            # in an unrelated file. A guard that fires on a different word is the
+            # mirror image of one satisfied by a different word: both make the
+            # verdict a fact about spelling rather than about the hazard.
+            if not re.search(r"\bSSE\b", line):
                 continue
             if path.name == "consumer.py" and "no SSE endpoint anywhere" in line:
                 continue                      # the disclaimer, deliberately kept
             offenders.append(f"{path.name}:{lineno}: {line.strip()[:80]}")
     assert not offenders, "stale event-stream wording:\n" + "\n".join(offenders)
+
+
+def test_the_stale_wording_guard_does_not_fire_on_a_WORD_CONTAINING_sse():
+    """🔴 NEGATIVE CONTROL, added because the guard did exactly this.
+
+    `PASSED` contains SSE. A substring test therefore reported an ordinary
+    sentence about a test passing as stale transport wording — and the pressure
+    that creates is to reword the innocent line, which leaves the guard wrong
+    and teaches the next person to route around it. Words that would trip it:
+    PASSED, ASSESS, GLASSES, PASSENGER.
+    """
+    for innocent in ("            if \" PASSED\" in ln:",
+                     "    # we ASSESS the result", "he wore GLASSES"):
+        assert not re.search(r"\bSSE\b", innocent), (
+            f"the guard's pattern fires on {innocent!r}, which is not about the "
+            "transport at all")
 
 
 def test_the_stale_wording_guard_can_actually_fire(tmp_path):

--- a/scripts/signal/tests/test_mutation_battery.py
+++ b/scripts/signal/tests/test_mutation_battery.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import inspect
 import re
+import subprocess
 
 import pytest
 
@@ -74,6 +75,14 @@ def test_every_named_killer_test_EXISTS(mutant):
     The battery would report SURVIVED (the suite stays green because the named
     test is absent, not because the code is fine), which inverts the meaning of
     its own output.
+
+    🔴 SCOPE: this checks the killer EXISTS, not that it RUNS. An audit walked it
+    by adding `@pytest.mark.skip` to a killer — still collected, still greps as
+    `def <name>`, 66 tests green, and its mutant would have been scored SURVIVED.
+    Existence is all a static check can see. "It actually ran and passed" is
+    enforced at RUNTIME instead, in the runner's baseline phase, which refuses to
+    start when any named killer did not PASS. Two checks, different questions;
+    neither substitutes for the other.
     """
     suite = (battery.REPO / mutant.suite)
     if suite.is_dir():
@@ -87,35 +96,101 @@ def test_every_named_killer_test_EXISTS(mutant):
         f"battery would score it SURVIVED for the wrong reason.")
 
 
-def test_the_runner_refuses_a_dirty_tree():
-    """It edits files in place; a crash mid-run would destroy uncommitted work.
+# --------------------------------------------------------------------------- #
+# 🔴 The three guards below were SPELLED before an audit walked all three.
+#
+# Each was a substring check over `inspect.getsource(...)`: `"--porcelain" in
+# src`, `"PYTHONDONTWRITEBYTECODE" in src`, `"m.killer in failures" in src`. All
+# three passed a fully green 66-test suite against a runner whose BEHAVIOUR had
+# been removed while the WORDS stayed — `if dirty:` → `if False:`,
+# `="1"` → `="0"`, `elif m.killer in failures or True:`. That is the exact
+# shape the rules name: a guard on words is walkable by rewording.
+#
+# These replacements exercise the behaviour and still mutate nothing: a
+# throwaway git repo for the refusal, an injected `subprocess.run` for the env,
+# and a pure function for the verdict.
+# --------------------------------------------------------------------------- #
+def test_the_runner_REFUSES_a_dirty_tree(tmp_path, monkeypatch):
+    """Behavioural: point it at a dirty throwaway repo and require exit 2."""
+    repo = tmp_path / "repo"
+    (repo / "scripts" / "signal" / "tests").mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    (repo / "UNCOMMITTED.txt").write_text("someone else's work\n", encoding="utf-8")
 
-    Pinned structurally rather than by running it, because running it would mean
-    mutating this very checkout. This repo is a SHARED clone whose dirty files
-    usually belong to another session, which is what makes the refusal
-    load-bearing rather than tidy.
+    monkeypatch.setattr(battery, "REPO", repo)
+    monkeypatch.setattr(battery, "_run", lambda *a, **k: pytest.fail(
+        "the runner reached the test phase on a DIRTY tree"))
+    assert battery.main([]) == 2
+
+
+def test_the_runner_refuses_when_git_status_CANNOT_BE_READ(tmp_path, monkeypatch):
+    """🔴 Fails CLOSED. An unreadable answer is not a clean one.
+
+    Both git checks used to read `.stdout` and ignore the return code, so any
+    git failure produced `""` — indistinguishable from a clean tree. Measured
+    with git broken: the runner did not refuse, mutated a module in a tree
+    holding uncommitted work, and printed `tree restored: clean`.
+    """
+    monkeypatch.setattr(battery, "REPO", tmp_path)          # not a git repo
+    monkeypatch.setattr(battery, "_run", lambda *a, **k: pytest.fail(
+        "the runner proceeded despite an unreadable git status"))
+    assert battery.main([]) == 2
+
+
+def test_the_runner_DISABLES_the_bytecode_cache(monkeypatch):
+    """Behavioural: capture the env actually handed to the subprocess.
+
+    Without this a mutant can be scored SURVIVED without ever executing —
+    CPython validates cached bytecode on mtime-in-whole-SECONDS + size, so a
+    same-LENGTH edit in the same second imports the ORIGINAL module. Several
+    mutants here are exactly same-length, so it is not theoretical.
+    """
+    seen = {}
+
+    class _Done:
+        returncode, stdout, stderr = 0, "", ""
+
+    def fake_run(cmd, **kw):
+        seen.update(kw.get("env") or {})
+        return _Done()
+
+    monkeypatch.setattr(battery.subprocess, "run", fake_run)
+    battery._run("scripts/signal/tests/")
+    assert seen.get("PYTHONDONTWRITEBYTECODE") == "1", (
+        f"the subprocess env carried PYTHONDONTWRITEBYTECODE="
+        f"{seen.get('PYTHONDONTWRITEBYTECODE')!r}")
+
+
+@pytest.mark.parametrize("rc, failures, expected", [
+    (0, set(), "SURVIVED"),                       # green suite = not killed
+    (1, {"the_killer"}, "KILLED"),                # the named test fired
+    (1, {"some_other_test"}, "KILLED-WRONG-REASON"),   # green for the wrong reason
+    (1, set(), "KILLED-WRONG-REASON"),            # red but no parseable failure
+    (1, {"the_killer", "other"}, "KILLED"),       # killer among several
+])
+def test_the_verdict_requires_the_NAMED_test(rc, failures, expected):
+    """"Some test failed" is not a kill.
+
+    A different guard's error is green for the wrong reason and stays green with
+    the guard under test deleted. Table-tested against the pure `_verdict`,
+    because the substring check this replaced was satisfied by
+    `elif m.killer in failures or True:` — which scores everything KILLED.
+    """
+    verdict, _ = battery._verdict(rc, failures, "the_killer")
+    assert verdict == expected
+
+
+def test_the_runner_handles_SIGTERM_so_the_restore_still_runs():
+    """`finally` covers exceptions and Ctrl-C, but NOT a default-handled SIGTERM.
+
+    Measured before the fix: `timeout -s TERM` left `_signal_db.py` modified in
+    the tree, while `timeout -s INT` restored cleanly. In a shared checkout that
+    silently hands the next session a mutated production module. Plausible
+    senders: `timeout`, an agent harness killing a long command, session
+    teardown.
     """
     src = inspect.getsource(battery.main)
-    assert "--porcelain" in src and "REFUSING" in src, (
-        "the dirty-tree refusal is gone from the runner")
-
-
-def test_the_runner_disables_the_BYTECODE_CACHE():
-    """🔴 Without this a mutant can be scored SURVIVED without ever executing.
-
-    CPython validates a cached module on source mtime-in-whole-SECONDS + size, so
-    a same-LENGTH edit landing in the same second as the last import imports the
-    ORIGINAL bytecode. Several mutants here are exactly same-length (a digit
-    swap, an operand reorder), so this is not a theoretical concern for this
-    battery specifically.
-    """
-    assert "PYTHONDONTWRITEBYTECODE" in inspect.getsource(battery._run)
-
-
-def test_the_runner_requires_the_NAMED_test_to_be_the_killer():
-    """"Some test failed" is not a kill — it can be green for the wrong reason."""
-    src = inspect.getsource(battery.main)
-    assert "KILLED-WRONG-REASON" in src and "m.killer in failures" in src
+    assert "SIGTERM" in src, "the SIGTERM handler is gone; a kill leaks a mutant"
 
 
 def test_the_audit_found_mutants_are_still_present():

--- a/scripts/signal/tests/test_mutation_battery.py
+++ b/scripts/signal/tests/test_mutation_battery.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import inspect
 import re
+import signal as _signal
 import subprocess
 
 import pytest
@@ -180,17 +181,32 @@ def test_the_verdict_requires_the_NAMED_test(rc, failures, expected):
     assert verdict == expected
 
 
-def test_the_runner_handles_SIGTERM_so_the_restore_still_runs():
+def test_the_runner_INSTALLS_a_SIGTERM_handler_so_the_restore_still_runs(
+        tmp_path, monkeypatch):
     """`finally` covers exceptions and Ctrl-C, but NOT a default-handled SIGTERM.
 
     Measured before the fix: `timeout -s TERM` left `_signal_db.py` modified in
     the tree, while `timeout -s INT` restored cleanly. In a shared checkout that
-    silently hands the next session a mutated production module. Plausible
-    senders: `timeout`, an agent harness killing a long command, session
-    teardown.
+    silently hands the next session a mutated production module.
+
+    🔴 This assertion reads the PROCESS's signal disposition, not the source.
+    The first version of this test asserted `"SIGTERM" in getsource(main)` and
+    was walked immediately: deleting the handler leaves the word behind in the
+    COMMENT that explains it, so the guard passed against a runner with no
+    handler at all. That is the third time in this file's short history that a
+    guard on words survived removal of the behaviour — the reason every guard
+    here is now behavioural.
     """
-    src = inspect.getsource(battery.main)
-    assert "SIGTERM" in src, "the SIGTERM handler is gone; a kill leaks a mutant"
+    previous = _signal.getsignal(_signal.SIGTERM)
+    try:
+        monkeypatch.setattr(battery, "REPO", tmp_path)     # refuses immediately
+        battery.main([])
+        installed = _signal.getsignal(_signal.SIGTERM)
+        assert callable(installed) and installed is not previous, (
+            f"SIGTERM disposition is still {installed!r} — no handler was "
+            "installed, so a kill mid-run leaves a mutant in the tree")
+    finally:
+        _signal.signal(_signal.SIGTERM, previous)
 
 
 def test_the_audit_found_mutants_are_still_present():

--- a/scripts/signal/tests/test_mutation_battery.py
+++ b/scripts/signal/tests/test_mutation_battery.py
@@ -1,0 +1,135 @@
+"""Guards on the mutation battery itself. Mutates NOTHING — safe in the gate.
+
+The battery in `mutation_battery.py` is a manual tool: it edits files in place,
+so it must never run inside the suite. But a battery nobody runs for six weeks
+rots invisibly, and it rots in the one direction that is indistinguishable from
+success — an anchor stops matching, the mutant never lands, and the run reports
+`ANCHOR-MISS`, which reads like a hiccup rather than "this mutant tested
+nothing". That already happened once here: a mutant's anchor also matched an
+unrelated branch, so it reported ANCHOR-MISS and the site it named went
+unmutated while the summary looked busy.
+
+So these tests pin the FRAGILE half — the anchors and the killer-test names —
+without executing a single mutation. A refactor that moves the guarded code goes
+red HERE, in the ordinary gate, instead of silently disarming the battery for
+whoever runs it next.
+
+🔴 What these tests do NOT claim: nothing here says the mutants are killed. That
+requires actually running the battery, which requires mutating files. Read the
+distinction before treating a green gate as "mutation-tested".
+"""
+from __future__ import annotations
+
+import inspect
+import re
+
+import pytest
+
+import mutation_battery as battery
+
+
+def test_the_ledger_is_not_empty():
+    """HARNESS CHECK: an empty ledger would make every assertion below vacuous."""
+    assert len(battery.MUTANTS) >= 15, (
+        f"only {len(battery.MUTANTS)} mutants — the ledger has shrunk; mutants are "
+        "removed only when the code they break is gone, and that should be argued "
+        "in the commit rather than done quietly")
+
+
+def test_every_mutant_id_is_unique():
+    """`--only A1` must select exactly one mutant."""
+    ids = [m.id for m in battery.MUTANTS]
+    assert len(ids) == len(set(ids)), f"duplicate mutant ids: {sorted(ids)}"
+
+
+@pytest.mark.parametrize("mutant", battery.MUTANTS, ids=lambda m: m.id)
+def test_every_anchor_matches_EXACTLY_ONCE_in_its_file(mutant):
+    """🔴 The failure this exists for is silent, not loud.
+
+    0 matches -> the mutant never lands and the run says ANCHOR-MISS, which is
+    neither a kill nor a survival: it is the battery testing nothing while
+    printing a line that looks like work.
+    2+ matches -> `str.replace(..., 1)` hits whichever occurrence comes first,
+    which is not the site the mutant's description names. The battery then
+    reports a kill for a mutation it did not make.
+    """
+    text = (battery.REPO / mutant.path).read_text(encoding="utf-8")
+    hits = text.count(mutant.old)
+    assert hits == 1, (
+        f"mutant {mutant.id}'s anchor matches {hits}x in {mutant.path} (need exactly 1).\n"
+        f"  the code it targets has moved or been duplicated; re-anchor the mutant.\n"
+        f"  anchor: {mutant.old!r}")
+
+
+@pytest.mark.parametrize("mutant", battery.MUTANTS, ids=lambda m: m.id)
+def test_every_mutant_actually_CHANGES_the_source(mutant):
+    """An `old == new` mutant is an equivalent mutant that can never be killed."""
+    assert mutant.old != mutant.new, f"mutant {mutant.id} is a no-op"
+
+
+@pytest.mark.parametrize("mutant", battery.MUTANTS, ids=lambda m: m.id)
+def test_every_named_killer_test_EXISTS(mutant):
+    """A killer that does not exist can never fire — so the mutant can never die.
+
+    The battery would report SURVIVED (the suite stays green because the named
+    test is absent, not because the code is fine), which inverts the meaning of
+    its own output.
+    """
+    suite = (battery.REPO / mutant.suite)
+    if suite.is_dir():
+        sources = "\n".join(p.read_text(encoding="utf-8")
+                            for p in sorted(suite.glob("test_*.py")))
+    else:
+        sources = suite.read_text(encoding="utf-8")
+    assert re.search(rf"^def {re.escape(mutant.killer)}\b", sources, re.MULTILINE), (
+        f"mutant {mutant.id} names killer {mutant.killer!r}, which does not exist in "
+        f"{mutant.suite}. A missing killer makes the mutant unkillable and the "
+        f"battery would score it SURVIVED for the wrong reason.")
+
+
+def test_the_runner_refuses_a_dirty_tree():
+    """It edits files in place; a crash mid-run would destroy uncommitted work.
+
+    Pinned structurally rather than by running it, because running it would mean
+    mutating this very checkout. This repo is a SHARED clone whose dirty files
+    usually belong to another session, which is what makes the refusal
+    load-bearing rather than tidy.
+    """
+    src = inspect.getsource(battery.main)
+    assert "--porcelain" in src and "REFUSING" in src, (
+        "the dirty-tree refusal is gone from the runner")
+
+
+def test_the_runner_disables_the_BYTECODE_CACHE():
+    """🔴 Without this a mutant can be scored SURVIVED without ever executing.
+
+    CPython validates a cached module on source mtime-in-whole-SECONDS + size, so
+    a same-LENGTH edit landing in the same second as the last import imports the
+    ORIGINAL bytecode. Several mutants here are exactly same-length (a digit
+    swap, an operand reorder), so this is not a theoretical concern for this
+    battery specifically.
+    """
+    assert "PYTHONDONTWRITEBYTECODE" in inspect.getsource(battery._run)
+
+
+def test_the_runner_requires_the_NAMED_test_to_be_the_killer():
+    """"Some test failed" is not a kill — it can be green for the wrong reason."""
+    src = inspect.getsource(battery.main)
+    assert "KILLED-WRONG-REASON" in src and "m.killer in failures" in src
+
+
+def test_the_audit_found_mutants_are_still_present():
+    """🔴 The four highest-value rows, kept by id.
+
+    Each SURVIVED a battery its author had just certified as complete, and was
+    found only because an independent audit built a DIFFERENT battery. They are
+    the evidence that a green battery is a claim about its author's imagination.
+    Deleting one because it "looks redundant" throws away the only record of a
+    blind spot that has actually occurred.
+    """
+    ids = {m.id for m in battery.MUTANTS}
+    assert {"A1", "A2", "A3", "A4"} <= ids, (
+        f"an audit-found mutant was removed; present: {sorted(ids)}")
+    for m in battery.MUTANTS:
+        if m.id.startswith("A"):
+            assert "[audit]" in m.why, f"{m.id} lost its provenance note"


### PR DESCRIPTION
Eight mutation batteries have been run against this module across #514, #537, #540, #546 and #573. **Every one lived in a scratchpad that no longer exists.** They were the most expensive artefact those sessions produced and the only one not kept: each encodes a way this code can be broken *without any test noticing* — knowledge found by breaking the code and watching what stayed green, which cannot be re-derived by reading it.

## What's here

**`mutation_battery.py`** — 20 mutants and a manual runner. It refuses a dirty tree, forces `PYTHONDONTWRITEBYTECODE=1`, requires the kill to come from the **named** test, and refuses to start unless every named killer actually **passed** in the baseline.

The four mutants marked `[audit]` are the highest-value rows: each **survived a battery its author had just certified as complete**, and was found only because a pre-merge audit built a *differently-constructed* one.

**`test_mutation_battery.py`** — 72 tests that run in the ordinary gate and **mutate nothing**, pinning the fragile half: anchors matching exactly once, killers existing, no no-op mutants, and the runner's safety properties.

A battery rots in the one direction indistinguishable from success — an anchor stops matching, the mutant never lands, and the run prints `ANCHOR-MISS`, which reads like a hiccup rather than *"this mutant tested nothing."* That has happened here before.

## Audit round 1 — the guards guarding the guard were themselves spelled

The audit's sharpest finding was that three of the runner's safety properties were pinned by **substring checks over `inspect.getsource`**, and it walked all three: `if dirty:` → `if False:`, `="1"` → `="0"`, `elif m.killer in failures or True:`. Each left the *words* in place while removing the *behaviour*, and all three passed a fully green suite.

They are now behavioural: a throwaway git repo for the refusal, an injected `subprocess.run` to capture the actual env, and a pure `_verdict()` that is table-tested.

Also fixed:

| | |
|---|---|
| 🟡 | Both git checks read `.stdout` and ignored the return code, so **any git failure read as "clean"**. Measured with git broken: the runner did not refuse, mutated a module in a tree holding uncommitted work, and printed `tree restored: clean`. Now fails closed. Real triggers: `safe.directory`, a concurrent `index.lock`, a `cp -a` of a worktree. |
| 🟡 | **SIGTERM left a mutant in the tree** — `finally` covers exceptions and Ctrl-C but not a default-handled SIGTERM. `timeout -s TERM` left `_signal_db.py` modified; `-s INT` restored cleanly. |
| 🟡 | `test_every_named_killer_test_EXISTS` was walked by `@pytest.mark.skip` — still collected, still greps as `def <name>`, mutant scored SURVIVED. A static check cannot see this, so "it actually ran" is now a **runtime precondition** in the baseline. The static test states its scope. |
| 🟢 | `--only` with no ids silently ran all 20; a dead `SUITE_ALL`; M10's `why` said "re-keyed" when it adds a column. |

🔴 **And the fix round reproduced the very bug it was fixing.** My first SIGTERM guard asserted `"SIGTERM" in getsource(main)` — deleting the handler left the word behind in the *comment explaining it*, so the guard passed against a runner with no handler. Caught by re-running the battery against the battery. It now reads the process's actual signal disposition.

## One pre-existing guard fixed, because this PR tripped it

`test_no_stale_event_stream_WORDING` bans `"SSE"` by substring — and **`PASSED` contains SSE**, so an ordinary sentence about a test passing was reported as stale transport wording. Now `\bSSE\b`, with a negative control (PASSED, ASSESS, GLASSES). The pressure a false-positive guard creates is to reword the innocent line, which leaves the guard wrong and teaches everyone to route around it.

## Verification

| | |
|---|---|
| `nix build .#checks.x86_64-linux.pytests` | **`RESULT: PASS (exit=0)`** — 13,382 collected, 13,381 passed, **0 failed** |
| `scripts/signal/tests` | **589 collected, 589 passed**, floor 553 |
| the battery, from its in-repo home, after the fixes | **20/20 KILLED by their named test**, `tree restored: clean` |
| a second battery aimed **at the runner's own guards** | **5/5 KILLED**, including all three the audit walked |
| controls | dirty tree → REFUSED naming paths; clean tree → ran; both watched |

The floor moved 444 → 553 earlier in this PR, **copied from what the gate printed**, not computed. 589 sits under the new ceiling of 691.

🔴 **What a green gate here does NOT mean:** nothing in the suite claims the mutants are killed — that requires running the battery. These tests guard its *integrity*, not its *results*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
