### PR TITLE
feat(store-api): every report dates the COPY it serves — a stale snapshot could not be told from the source

### DIFF
--- a/scripts/subsystem-store-api/README.md
+++ b/scripts/subsystem-store-api/README.md
@@ -50,8 +50,34 @@ GET /api/v1/search/{scope}?q=…[&threshold=&max_hits=&context=&all_scopes=]
 ```
 
 Every `/api/*` response carries `X-Store-Status`, `X-Store-Exit` (the CLI's own
-exit code, from the CLI's own `_exit_for`) and `X-Store-Revision` (the scope's
-git HEAD, or `unknown` — never a fabricated sha).
+exit code, from the CLI's own `_exit_for`), `X-Store-Revision` (the scope's
+git HEAD, or `unknown` — never a fabricated sha) and `X-Store-Snapshot`.
+
+🔴 **This server does NOT serve the authoritative store — it serves a COPY, and
+nothing syncs that copy.** `seed.sh` pushes it by hand; there is no CronJob and
+no timer. Yet every report opens with `ALL N entries in <scope>/, none omitted`
+— a completeness claim that is *true of this disk* and says nothing about the
+source. MEASURED 2026-08-20, four days after cutover: the public endpoint
+answered `200` with `ALL 5 entries in devrc/` while the source held **9**, and
+one served entry was a 40-day-old version of a file edited that morning.
+Reachability, auth, the client-IP chain and the firewall all verified green
+throughout, because none of them compares served bytes to the source.
+
+So every report now **dates itself**, in the body (first, before the claim it
+qualifies) and in `X-Store-Snapshot`:
+
+```
+seeded=<when seed.sh took the stage> newest=<newest entry mtime> entry-files=<N>
+```
+
+Two independent facts, because each covers the other's blind spot — a quiet week
+makes `newest` old while the copy is current; a forgotten re-seed makes `seeded`
+old while `newest` merely lags. **Each failure is its own name, never an
+omission**: `seeded=UNSTAMPED` (no stamp), `seeded=UNREADABLE` (present but
+empty/unreadable), `newest=UNREADABLE` (the walk hit an error) — all distinct
+from a genuinely empty store, which reads `newest=NONE entry-files=0`. The walk
+uses `os.walk(onerror=…)` rather than `Path.rglob` precisely because `rglob`
+swallows a permission error and would report an unreadable store as an empty one.
 
 🔴 **`scope-empty` and `store-unreachable` do not render alike.** Reached the
 store and found nothing → `200` + `X-Store-Status: scope-empty`. Read nothing at

--- a/scripts/subsystem-store-api/seed.sh
+++ b/scripts/subsystem-store-api/seed.sh
@@ -91,6 +91,31 @@ if [[ ${staged_scopes} -eq 0 ]]; then
   exit 5
 fi
 
+# 🔴 DATE THE COPY, IN THE COPY. The server cannot otherwise know how old the
+# tree it serves is, and it renders "ALL N entries ... none omitted" over it —
+# a completeness claim that reads identically whether the content was copied
+# this minute or four days ago. MEASURED 2026-08-20: the public endpoint served
+# `ALL 5 entries in devrc/` against a source holding 9, with nothing in the
+# payload able to say so. `server.snapshot_freshness` reads this file, and
+# reports its ABSENCE as `seeded=UNSTAMPED` rather than omitting the line, so an
+# unstamped store is loud rather than indistinguishable from a current one.
+#
+# 🔴 WRITTEN IN THE STAGING HALF, DELIBERATELY — not next to the push. Two
+# reasons, and the first is a bug this was moved to fix:
+#   * `--push` is optional and returns early, so a stamp written down there is
+#     absent from every stage-only run — including the hermetic tests, which is
+#     how the omission would have gone unnoticed;
+#   * it dates the CONTENT SNAPSHOT, which is the honest thing for it to date.
+#     The tar is built from the stage, so stamp and content are consistent even
+#     if the push happens later; stamping at transfer time would claim currency
+#     the bytes do not have.
+#
+# Into the STAGE, never the source — the source is read-only here (see header).
+printf '%s staged_entries=%s host=%s\n' \
+  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$staged_entries" "${HOSTNAME:-unknown}" \
+  > "$STAGE/.seed-stamp"
+echo "seed: STAMPED $STAGE/.seed-stamp"
+
 if [[ -z "$PUSH" ]]; then
   echo "seed: PUSH skipped (no --push given). This run proves nothing about any pod."
   exit 0
@@ -117,8 +142,14 @@ echo "seed: pushing $STAGE -> $ns/$pod:$DEST"
 # — after the CONTENT has already landed. That is the worst possible shape: a
 # non-zero exit on a push that mostly worked, which reads as "nothing was
 # seeded" and invites a retry that changes nothing.
+# 🔴 THE STAMP MUST BE NAMED EXPLICITLY. This member list is built from
+# `"$STAGE"/*/` — DIRECTORIES ONLY — so a top-level file is silently left out
+# of the archive, and the push would land content with no date on it while
+# reporting OK. It is not `*.md`, so it does not disturb the entry counts the
+# mismatch guard below compares.
 members=()
 for d in "$STAGE"/*/; do members+=("$(basename "$d")"); done
+members+=(".seed-stamp")
 tar -C "$STAGE" -cf - -- "${members[@]}" \
   | kubectl -n "$ns" exec -i "$pod" -- \
       tar -C "$DEST" --no-same-owner --no-same-permissions -xf -

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -963,6 +963,132 @@ def scope_revision(store_root: str | Path, scope: str) -> str:
     return "unknown"
 
 
+SEED_STAMP_NAME = ".seed-stamp"
+
+# How deep to walk when dating the served copy. Deliberately the SAME depth
+# `seed.sh` uses for its own `remote_entries` count (`find -maxdepth 2 -name
+# '*.md'`), so the two numbers are answers to the same question and a
+# disagreement between them means something real rather than a units mismatch.
+_FRESHNESS_MAXDEPTH = 2
+
+
+def snapshot_freshness(store_root: str | Path) -> tuple[str, str]:
+    """`(header_value, prose_line)` dating the copy this process is serving.
+
+    🔴 WHY THIS EXISTS, AND IT IS NOT A NICETY. This server does not serve the
+    authoritative store — it serves a COPY pushed into a PVC by `seed.sh`, and
+    NOTHING syncs that copy continuously (no CronJob, no timer; measured
+    2026-08-20). Yet every report it renders opens with a line of the form
+    "ALL N entries in `<scope>/`, none omitted" — a COMPLETENESS assertion, and
+    a truthful one *about the bytes on this disk*. Off-mesh there is no way to
+    tell that disk from the source.
+
+    That combination was measured live on 2026-08-20, four days after cutover:
+    the public endpoint answered 200 with `ALL 5 entries in devrc/, none
+    omitted` while the source held **9**, and one served entry was a 40-day-old
+    version of a file edited that morning. Nothing in the payload, the headers
+    or the status was wrong; nothing in it was current either. `claude/RULES.md`
+    → "a reassuring zero from a check that could not see anything".
+
+    So every response now dates itself. Two INDEPENDENT facts, because each
+    covers the other's blind spot:
+
+      * `seeded` — when `seed.sh` last pushed, read from a stamp file it writes.
+        Answers "how old is this COPY", which is the question a caller has.
+      * `newest` — the newest entry mtime on this disk, derived from the files
+        themselves and owing nothing to the stamp. Answers "how old is this
+        CONTENT", and survives a store seeded by any other means.
+
+    A quiet week makes `newest` old while the copy is perfectly current; a
+    forgotten re-seed makes `seeded` old while `newest` merely lags. Neither
+    alone is the answer, which is why both are printed and neither is derived
+    from the other.
+
+    🔴 EVERY FAILURE IS ITS OWN NAMED STATE — never a silent omission and never
+    a fabricated date, for the same reason `scope_revision` returns "unknown"
+    rather than inventing a sha. A missing stamp says `seeded=UNSTAMPED`, an
+    unreadable one says `seeded=UNREADABLE`, and a walk that hit an error says
+    `newest=UNREADABLE` — each distinguishable from the genuinely empty store,
+    which says `newest=NONE entry-files=0`. An absent block would read as "this
+    is the source"; that is the exact confusion the block exists to remove.
+    """
+    root = Path(store_root)
+
+    seeded = "UNSTAMPED"
+    try:
+        text = (root / SEED_STAMP_NAME).read_text(encoding="utf-8").strip()
+        seeded = text.splitlines()[0].strip() if text else "UNREADABLE"
+    except FileNotFoundError:
+        seeded = "UNSTAMPED"
+    except OSError:
+        seeded = "UNREADABLE"
+
+    newest: float | None = None
+    count = 0
+    walk_failed = False
+
+    def _walk_error(_exc: OSError) -> None:
+        nonlocal walk_failed
+        walk_failed = True
+
+    # 🔴 `os.walk(onerror=...)`, NOT `Path.rglob`, AND THAT IS THE WHOLE POINT.
+    # `rglob` swallows a permission error and yields nothing, so an UNREADABLE
+    # scope is indistinguishable from an EMPTY one — it would report
+    # `newest=NONE entry-files=0`, a confident zero from a walk that saw
+    # nothing. That is the precise failure this function was written to stop it
+    # committing itself, and the first draft committed it: caught by
+    # `test_an_UNREADABLE_scope_is_UNREADABLE_not_an_empty_store`, which passed
+    # only after this rewrite. `os.walk` is the one that can be TOLD to report.
+    try:
+        scopes = sorted(
+            p for p in root.iterdir() if p.is_dir() and not p.name.startswith(".")
+        )
+    except OSError:
+        scopes, walk_failed = [], True
+
+    for scope in scopes:
+        for dirpath, _dirnames, filenames in os.walk(scope, onerror=_walk_error):
+            # Depth relative to the store root: `<scope>/<entry>.md` is 2.
+            depth = len(Path(dirpath).relative_to(root).parts) + 1
+            if depth > _FRESHNESS_MAXDEPTH:
+                continue
+            for name in filenames:
+                if not name.endswith(".md"):
+                    continue
+                try:
+                    mtime = os.stat(os.path.join(dirpath, name)).st_mtime
+                except OSError:
+                    walk_failed = True
+                    continue
+                count += 1
+                if newest is None or mtime > newest:
+                    newest = mtime
+
+    if walk_failed:
+        newest_text = "UNREADABLE"
+    elif newest is None:
+        newest_text = "NONE"
+    else:
+        newest_text = (
+            datetime.fromtimestamp(newest, timezone.utc)
+            .strftime("%Y-%m-%dT%H:%M:%SZ")
+        )
+
+    header = f"seeded={seeded} newest={newest_text} entry-files={count}"
+    prose = (
+        f"🔴 SNAPSHOT, NOT THE SOURCE — seeded={seeded} newest-entry={newest_text} "
+        f"entry-files={count}. This host serves a COPY of the authoritative store, "
+        f"pushed by `seed.sh`; nothing syncs it continuously, so it can be "
+        f"arbitrarily behind and it CANNOT KNOW BY HOW MUCH. The "
+        f"\"none omitted\" below is true of THIS DISK and says nothing about the "
+        f"source. Before trusting an absence — a missing entry, a missing badge, "
+        f"a zero — re-run the read against the local store, or re-seed. "
+        f"UNSTAMPED/UNREADABLE/NONE each mean the stated fact could not be "
+        f"established, never that it is fine."
+    )
+    return header, prose
+
+
 def _int_param(params: dict[str, list[str]], name: str) -> int | None:
     """Parse an optional int query param, or raise ValueError with the param name.
 
@@ -1538,7 +1664,16 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         # and it needs the REAL malformed tuple, or that sentence would count 0
         # rejects on the one status that exists to report them.
         code = rc._exit_for(status, label, malformed)
-        body = (text + "\n").encode("utf-8")
+        # 🔴 THE STAMP GOES IN THE BODY, NOT ONLY THE HEADER, AND IT GOES FIRST.
+        # `_serve_report` is the one place every report — recall AND search —
+        # passes through, so stamping here cannot be forgotten by a future route
+        # (RULES.md: one rule, one place). A header alone would not do: the
+        # measured failure was an AGENT reading the rendered text and believing
+        # its "none omitted" line, and an agent that pipes the body never sees a
+        # header. It precedes the report because a caveat printed after the
+        # thing it qualifies has already been believed.
+        fresh_header, fresh_prose = snapshot_freshness(self.store_root)
+        body = (fresh_prose + "\n\n" + text + "\n").encode("utf-8")
         self._respond(
             200,
             body,
@@ -1546,6 +1681,7 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
                 "X-Store-Status": status,
                 "X-Store-Exit": str(code),
                 "X-Store-Revision": scope_revision(self.store_root, scope),
+                "X-Store-Snapshot": fresh_header,
             },
         )
         self._audit(path, 200, status)

--- a/scripts/subsystem-store-api/verify-byte-identity.sh
+++ b/scripts/subsystem-store-api/verify-byte-identity.sh
@@ -158,8 +158,21 @@ for scope in "${SCOPES[@]}"; do
   raw=$(diff "$local_out" "$remote_out" | grep -c '^[<>]' || true)
   store_lines=$(diff "$local_out" "$remote_out" | grep -c '^[<>]   store: ' || true)
 
+  # 🔴 THE SNAPSHOT BLOCK IS A TRANSPORT ANNOTATION, NOT PART OF THE REPORT.
+  # The server prepends one line dating the COPY it serves (plus a blank
+  # separator) to every report — see `server.snapshot_freshness`, and the README
+  # for the measured incident that put it there. The local CLI reads the
+  # authoritative store and correctly emits no such line, so leaving it in would
+  # make this script FAIL on every scope for a difference that is not about the
+  # render at all — the same excuse the `store:` line above already earns.
+  #
+  # Stripped from the REMOTE only, and by an anchored two-line delete, so it
+  # cannot reach into a report body. An image WITHOUT the stamp is unaffected
+  # (the sed matches nothing), which is what keeps this runnable against 0.2.0.
+  snapshot_lines=$(grep -c '^🔴 SNAPSHOT, NOT THE SOURCE' "$remote_out" || true)
   sed "s|^  store: .*|$CANON|" "$local_out"  > "$tmp/l.canon"
-  sed "s|^  store: .*|$CANON|" "$remote_out" > "$tmp/r.canon"
+  sed -e '/^🔴 SNAPSHOT, NOT THE SOURCE/,+1d' \
+      -e "s|^  store: .*|$CANON|" "$remote_out" > "$tmp/r.canon"
 
   rev=$(awk 'tolower($1)=="x-store-revision:"{print $2}' "$tmp/hdr" | tr -d '\r' | tail -1)
 
@@ -167,7 +180,12 @@ for scope in "${SCOPES[@]}"; do
   # The two counts ride along as evidence: 0/0 is the case where both sides read
   # the SAME root (a local self-check), 2/2 is pod-vs-workbench.
   if cmp -s "$tmp/l.canon" "$tmp/r.canon"; then
-    echo "PASS scope=$scope bytes=$(wc -c <"$tmp/l.canon") raw-diff-lines=$raw store-root-lines=$store_lines revision=${rev:-unknown}"
+    # `snapshot-line` rides along as EVIDENCE, exactly like the two counts above
+    # and gated for the same reason they are not: a `0` here means the remote
+    # served no stamp, which is true and expected against a pre-0.3.0 image, so
+    # failing on it would make this script permanently red until a deploy lands
+    # (RULES.md). Printed so a reader can see WHICH of the two the green means.
+    echo "PASS scope=$scope bytes=$(wc -c <"$tmp/l.canon") raw-diff-lines=$raw store-root-lines=$store_lines snapshot-line=$snapshot_lines revision=${rev:-unknown}"
     pass=$((pass + 1))
   else
     echo "FAIL scope=$scope canonicalised-cmp=$(cmp -s "$tmp/l.canon" "$tmp/r.canon" && echo same || echo differs) raw-diff-lines=$raw store-lines=$store_lines"

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -1177,9 +1177,40 @@ class TestSeedIsNonDestructive:
         assert not (stage / "leftover-from-an-older-run.md").exists()
         assert tree_hash(store) == before
 
-    def test_the_stage_is_a_faithful_copy(self, store: Path, tmp_path: Path):
+    def test_the_stage_is_a_faithful_copy_APART_FROM_THE_STAMP(
+        self, store: Path, tmp_path: Path
+    ):
+        """The stage mirrors the source byte-for-byte, plus EXACTLY one file.
+
+        🔴 THIS ASSERTION GOT NARROWER, NOT WEAKER, AND THAT IS THE POINT.
+        It used to be a bare `tree_hash(stage) == tree_hash(store)`, which
+        `.seed-stamp` breaks: the stage is deliberately no longer a pure
+        byte-copy, because a copy that cannot say when it was taken is the
+        entire defect the stamp exists to fix (`server.snapshot_freshness`, and
+        the incident in the README). RULES.md — "when a test documents a
+        contract, ask whether the contract is right": the contract changed, so
+        the test states the NEW one exactly rather than being loosened to
+        "mostly the same", which would have surrendered the property actually
+        worth keeping — that nothing ELSE ever appears in the stage.
+
+        So: the extra-path set is pinned to exactly `{.seed-stamp}` (it fails if
+        that set GROWS *or* SHRINKS), and with the stamp removed the remaining
+        tree is still hashed byte-for-byte against the source.
+        """
         stage = tmp_path / "stage"
         assert run_seed("--store", str(store), "--stage", str(stage)).returncode == 0
+
+        stamp = stage / ".seed-stamp"
+        assert stamp.exists(), "the stage carries no stamp — seed.sh did not date it"
+
+        staged = {p.relative_to(stage) for p in stage.rglob("*") if p.is_file()}
+        source = {p.relative_to(store) for p in store.rglob("*") if p.is_file()}
+        assert staged - source == {Path(".seed-stamp")}, (
+            f"unexpected extra path(s) in the stage: {staged - source}"
+        )
+        assert not source - staged, f"the stage is MISSING: {source - staged}"
+
+        stamp.unlink()
         assert tree_hash(stage) == tree_hash(store)
 
     def test_the_summary_prints_the_COUNT_beside_what_produced_it(
@@ -1374,12 +1405,31 @@ class TestByteIdentityVerifier:
         assert "verify: scopes=4" in r.stdout
         assert "pass=3 fail=1" in r.stdout
 
-    def test_the_STORE_ROOT_line_is_the_only_permitted_difference(
+    def test_every_permitted_difference_is_ACCOUNTED_FOR_not_merely_small(
         self, store: Path, tmp_path: Path, token_file: Path
     ):
-        """The pod serves `/data`; the workbench serves `~/.claude/…`. The
-        verifier canonicalises exactly one line — and proves it was exactly one,
-        by counting the RAW differing lines too."""
+        """The pod serves `/data`; the workbench serves `~/.claude/…`.
+
+        🔴 RENAMED, BECAUSE THE OLD NAME BECAME FALSE. This was
+        `test_the_STORE_ROOT_line_is_the_only_permitted_difference`, asserting a
+        flat `raw-diff-lines=2 store-root-lines=2`. The snapshot block
+        (`server.snapshot_freshness`) is a SECOND legitimate difference — the
+        remote dates the copy it serves and the local CLI, reading the
+        authoritative store, correctly does not — so "the only permitted
+        difference" stopped being true the moment that shipped. RULES.md: "a
+        comment is a claim too"; a name is louder than a comment.
+
+        The replacement is STRONGER than a bumped constant. It asserts the raw
+        difference is FULLY DECOMPOSED by its two named causes:
+
+            raw == store_root_lines + 2 * snapshot_lines
+
+        (the block contributes its prose line AND its blank separator, and both
+        appear one-sided in the diff). An unexplained differing line therefore
+        still fails — which a hardcoded `raw-diff-lines=4` would not, since it
+        would go on passing if a store-root line vanished and some other
+        difference appeared in its place.
+        """
         served = tmp_path / "served-elsewhere"
         subprocess.run(
             ["cp", "-a", str(store), str(served)], check=True, capture_output=True
@@ -1389,8 +1439,21 @@ class TestByteIdentityVerifier:
                 "--store", str(store), "--url", base, "--token-file", str(token_file)
             )
         assert r.returncode == 0, r.stdout + r.stderr
-        # 2 raw differing lines: one `<`, one `>`, both the store-root line.
-        assert "raw-diff-lines=2 store-root-lines=2" in r.stdout
+
+        rows = re.findall(
+            r"raw-diff-lines=(\d+) store-root-lines=(\d+) snapshot-line=(\d+)",
+            r.stdout,
+        )
+        assert rows, f"the verifier printed no evidence triples:\n{r.stdout}"
+        for raw, store_root, snapshot in rows:
+            assert int(raw) == int(store_root) + 2 * int(snapshot), (
+                f"unaccounted differing lines: raw={raw} "
+                f"store-root={store_root} snapshot={snapshot}"
+            )
+        # …and the two causes are each genuinely PRESENT, or the identity above
+        # is satisfiable by a run that compared nothing (0 == 0 + 2*0).
+        assert any(int(s) == 1 for _r, _sr, s in rows), "no snapshot line observed"
+        assert any(int(sr) == 2 for _r, sr, _s in rows), "no store-root line observed"
 
     def test_an_UNREACHABLE_pod_FAILS_rather_than_comparing_nothing(
         self, store: Path, token_file: Path

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -49,13 +49,16 @@ import hashlib
 import http.client
 import importlib.util
 import os
+import re
 import secrets
 import subprocess
 import sys
 import threading
+import time
 import urllib.error
 import urllib.request
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -893,6 +896,190 @@ class TestScopeRevision:
             "1111111111111111111111111111111111111111 refs/heads/main\n"
         )
         assert api.scope_revision(store, SCOPE) == "1" * 40
+
+
+# =============================================================================
+# 8b. The snapshot stamp — every report dates the COPY it is serving.
+#
+# 🔴 REGRESSION, NOT AN INVARIANT GUARD. Measured on the live public endpoint
+# 2026-08-20, four days after cutover: an authed GET returned 200 with
+# `ALL 5 entries in devrc/, none omitted` while the source held 9, and one
+# served entry was a 40-day-old copy of a file edited that morning. Every
+# existing check passed — reachability, auth, client-IP chain, firewall — because
+# none of them compares the served bytes to the source. The defect was that a
+# stale snapshot and the live source produce byte-identical-looking answers.
+#
+# 🔴 WHICH OF THESE ARE REGRESSION TESTS, HONESTLY — 3 of 11, not 11.
+# Measured by running this class against `main` at `19756d5`: 11 failed, but
+# only THREE failed on BEHAVIOUR. The other eight raise `AttributeError: module
+# has no attribute 'snapshot_freshness' / 'SEED_STAMP_NAME'`, which is the
+# symbol not existing, not the defect being caught — the same "red at base is a
+# collection error and proves nothing" this file's own header records about
+# `server.py`. Those eight are INVARIANT GUARDS on the four-state contract; they
+# are worth having and they are not evidence.
+#
+# The three that genuinely bite, each with an assertion failure at base:
+#   * test_a_report_that_does_not_date_itself_is_the_regression  (body undated)
+#   * test_the_stamp_is_on_search_too_not_only_recall            (body undated)
+#   * test_seed_sh_writes_a_stamp_and_puts_it_IN_THE_ARCHIVE     (no stamp)
+# =============================================================================
+
+
+class TestSnapshotStamp:
+    def _fresh(self, store: Path):
+        return api.snapshot_freshness(store)
+
+    def test_a_report_that_does_not_date_itself_is_the_regression(self, store: Path):
+        """The whole point: the body — not just a header — must say SNAPSHOT.
+
+        Asserted on the BODY because the measured failure was an agent reading
+        rendered text; a caller that pipes the body never sees a header.
+        """
+        with running(store) as (base, _):
+            _c, _h, body = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+        text = body.decode()
+        assert "SNAPSHOT, NOT THE SOURCE" in text
+        # It must come BEFORE the completeness claim it qualifies.
+        assert text.index("SNAPSHOT, NOT THE SOURCE") < text.index("none omitted")
+
+    def test_the_stamp_is_on_search_too_not_only_recall(self, store: Path):
+        """Both routes go through `_serve_report`; pin that they both stamp.
+
+        If a future route stamps only recall, the copy it serves is undated on
+        exactly the surface a caller reaches for when an entry seems missing.
+        """
+        with running(store) as (base, _):
+            _c, headers, body = fetch(
+                f"{base}/api/v1/search/{SCOPE}?q=alpha", token=GOOD_TOKEN
+            )
+        assert "SNAPSHOT, NOT THE SOURCE" in body.decode()
+        assert "X-Store-Snapshot" in headers
+
+    def test_newest_entry_is_the_newest_mtime_and_MOVES_when_content_changes(
+        self, store: Path
+    ):
+        """A value that cannot move is indistinguishable from a hardcoded string.
+
+        Feeds a timestamp the fixture CANNOT already equal and watches the
+        output follow it (RULES.md: the mechanical control for a constant).
+        """
+        header_before, _ = self._fresh(store)
+        target = time.time() + 86_400  # a day ahead: no fixture file can hold it
+        os.utime(store / SCOPE / "thing-alpha.md", (target, target))
+        header_after, _ = self._fresh(store)
+
+        assert header_before != header_after
+        stamp = datetime.fromtimestamp(target, timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        assert f"newest={stamp}" in header_after
+
+    def test_entry_files_counts_entries_and_not_the_stamp_file(self, store: Path):
+        """The count must be of *.md, or it drifts against seed.sh's own number.
+
+        `.seed-stamp` is not an entry; counting it would make the API and the
+        seeder disagree by exactly one and read as a lost file.
+        """
+        header_before, _ = self._fresh(store)
+        assert "entry-files=3" in header_before
+        (store / api.SEED_STAMP_NAME).write_text("2026-08-20T00:00:00Z\n")
+        header_after, _ = self._fresh(store)
+        assert "entry-files=3" in header_after
+
+    def test_a_seeded_stamp_is_read_and_reported(self, store: Path):
+        (store / api.SEED_STAMP_NAME).write_text(
+            "2026-08-20T17:30:00Z staged_entries=71 host=box\n"
+        )
+        header, prose = self._fresh(store)
+        assert "seeded=2026-08-20T17:30:00Z staged_entries=71 host=box" in header
+        assert "UNSTAMPED" not in header
+
+    def test_an_ABSENT_stamp_is_named_never_omitted(self, store: Path):
+        """The failure this whole block exists to prevent is a SILENT absence."""
+        header, prose = self._fresh(store)
+        assert "seeded=UNSTAMPED" in header
+        assert "SNAPSHOT, NOT THE SOURCE" in prose
+
+    def test_an_EMPTY_stamp_is_UNREADABLE_and_distinct_from_absent(
+        self, store: Path
+    ):
+        """Two mechanisms, two names — an empty file is not a missing one."""
+        (store / api.SEED_STAMP_NAME).write_text("   \n")
+        header, _ = self._fresh(store)
+        assert "seeded=UNREADABLE" in header
+        assert "UNSTAMPED" not in header
+
+    def test_an_EMPTY_store_says_NONE_and_zero_not_a_fabricated_date(
+        self, tmp_path: Path
+    ):
+        """`newest=NONE entry-files=0` must be distinguishable from UNREADABLE."""
+        empty = tmp_path / "empty-store"
+        empty.mkdir()
+        header, _ = self._fresh(empty)
+        assert "newest=NONE" in header
+        assert "entry-files=0" in header
+        assert "UNREADABLE" not in header
+
+    def test_an_UNREADABLE_scope_is_UNREADABLE_not_an_empty_store(
+        self, store: Path
+    ):
+        """🔴 The two zeros that must never be confused.
+
+        A store that cannot be WALKED and a store that is genuinely EMPTY both
+        yield "no entries". This file's own header calls that out; the stamp
+        would be worthless if it collapsed them.
+        """
+        if os.geteuid() == 0:
+            pytest.skip("root ignores directory permissions; the case is unreachable")
+        locked = store / SCOPE
+        mode = locked.stat().st_mode
+        locked.chmod(0o000)
+        try:
+            header, _ = self._fresh(store)
+        finally:
+            locked.chmod(mode)
+        assert "UNREADABLE" in header
+        assert "newest=NONE" not in header
+
+    def test_the_header_and_the_prose_carry_the_SAME_facts(self, store: Path):
+        """One derivation, two renderings — they must not drift apart.
+
+        A header saying `seeded=UNSTAMPED` beside prose implying a known date is
+        the shape where a reader believes whichever they happened to read.
+        """
+        (store / api.SEED_STAMP_NAME).write_text("2026-08-20T17:30:00Z\n")
+        header, prose = self._fresh(store)
+        for field in ("2026-08-20T17:30:00Z", "entry-files=3"):
+            assert field in header
+            assert field.replace("entry-files=", "entry-files=") in prose
+
+    def test_seed_sh_writes_a_stamp_and_puts_it_IN_THE_ARCHIVE(
+        self, tmp_path: Path, store: Path
+    ):
+        """🔴 The member list globs `*/` — directories only.
+
+        A top-level stamp file is silently dropped from the tar unless named,
+        which would push undated content while reporting OK. Drives the real
+        script's stage half, then asserts the stamp is both written and listed
+        as a tar member by the script's own source.
+        """
+        stage = tmp_path / "stage"
+        seed = API_DIR / "seed.sh"
+        proc = subprocess.run(
+            [str(seed), "--store", str(store), "--stage", str(stage)],
+            capture_output=True,
+            text=True,
+        )
+        assert proc.returncode == 0, proc.stderr
+        stamp = stage / ".seed-stamp"
+        assert stamp.exists(), "seed.sh staged no .seed-stamp"
+        assert re.match(
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z staged_entries=\d+ host=",
+            stamp.read_text().strip(),
+        ), stamp.read_text()
+        # The stage half never tars; pin the member list from the source, since
+        # this is exactly the line whose omission is silent.
+        assert 'members+=(".seed-stamp")' in seed.read_text()
 
 
 # =============================================================================


### PR DESCRIPTION
Follows the live verification of the hosted store. **The service landed; the data pipeline never did**, and nothing in the payload could say so.

## The measurement that motivated this
2026-08-20, four days after cutover, against `store.zacx.dev` over the public internet:

* authed `GET /api/v1/recall/devrc` → **200**, body `ALL 5 entries in devrc/, none omitted`
* the source held **9**
* 47 of 72 entry files on the PVC; newest byte dated **08-16**
* one served entry was a **40-day-old** version of a file edited that morning

Nothing was broken. Pod ready on `0.2.0`, restarts=0, auth correct, client-IP chain intact, firewall right — and the handoff's entire "How to verify" block passed, because **not one of those checks compares served bytes to the source**. This process serves a COPY that `seed.sh` pushes by hand; there is no CronJob and no timer. The completeness line is true of that disk and says nothing about the source.

## The change
Every report now dates itself — in the **body first** (a caveat printed after the claim it qualifies has already been believed) and in a new `X-Store-Snapshot` header. Body and not merely header because the measured victim is an agent reading rendered text, which never sees a header. Stamped in `_serve_report`, the single choke point recall **and** search both pass through.

```
seeded=<when seed.sh took the stage> newest=<newest entry mtime> entry-files=<N>
```

Two independent facts, each covering the other's blind spot: a quiet week makes `newest` old while the copy is current; a forgotten re-seed makes `seeded` old while `newest` merely lags. Neither is derived from the other. **Every failure is its own name** — `seeded=UNSTAMPED`, `seeded=UNREADABLE`, `newest=UNREADABLE` — each distinct from a genuinely empty store's `newest=NONE entry-files=0`. An omitted block would read as "this is the source".

## Two bugs my own tests caught
* the walk used `Path.rglob`, which **swallows a permission error and yields nothing** — so an UNREADABLE store reported `newest=NONE entry-files=0`. A confident zero from a walk that saw nothing: precisely the confusion this function exists to prevent, committed by the function itself. Now `os.walk(onerror=…)`.
* the stamp was written next to the push, which `--push` skips on stage-only runs — absent from every hermetic test, which is how it would have gone unnoticed. Moved into staging, where it also more honestly dates the CONTENT SNAPSHOT rather than the transfer.

## One seam, found by looking rather than by a failure
`verify-byte-identity.sh` `cmp`s the local CLI render against the remote body, so the prepend would have failed it on **every scope**. Stripped there as a transport annotation — the same excuse the `store:` line already earns — by an anchored two-line delete that cannot reach into a report body. A pre-0.3.0 image is unaffected.

## Two EXISTING tests asserted contracts this changed (second commit)
Neither was mine; the gate caught both. Both were **restated, not loosened**:
* `test_the_stage_is_a_faithful_copy` → extra-path set pinned to exactly `{.seed-stamp}`, failing if it GROWS *or* SHRINKS, nothing from the source may be MISSING, and the remaining tree still hashes byte-for-byte with the stamp removed.
* `test_the_STORE_ROOT_line_is_the_only_permitted_difference` — the **name** went false, not just the constant. Renamed, and rewritten to assert the difference is fully decomposed: `raw == store_root_lines + 2*snapshot_lines`, so an *unexplained* differing line still fails (a bumped `=4` would not). Plus presence assertions, since the identity alone is satisfied by a run that compared nothing.

## Coverage, honestly: 3 regressions, not 11
All 11 new tests fail at base — but **eight fail with `AttributeError`**, the symbol not existing, which proves nothing (this file's own header says exactly that about `server.py`). The three that fail on BEHAVIOUR are named in the class comment. Mutation control: dropping the body prepend while keeping the header kills exactly the two body tests and leaves the header tests green, so the body assertion is load-bearing on its own. Run under `PYTHONDONTWRITEBYTECODE=1`.

## Gate
`nix build .#checks.x86_64-linux.{pytests,nodetests}` — genuinely built, not cached. `RESULT: PASS (exit=0)` in both real logs, **`passed=13308 failed=0`**, 0 timeout panics.

## Not deployed by this PR
Needs `build-push.sh 0.3.0`, a manifest bump and a re-seed. `0.3.0` is confirmed absent from harbor (with a `0.2.0` pull as the control). Until a re-seed lands the live store has no stamp and will correctly read `seeded=UNSTAMPED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)