### PR TITLE
fix(gates): running `pytest` reds a gate — consolidate four skip lists without blinding two security scanners

### DIFF
--- a/scripts/testlib/client_host_scan.py
+++ b/scripts/testlib/client_host_scan.py
@@ -66,6 +66,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from . import skip_dirs as _skip_dirs
+
 #: Registrable domains belonging to CLIENTS / third parties whose internal
 #: subdomains must not be written down here. Apexes only — a subdomain in this
 #: list would defeat the point of the list.
@@ -83,10 +85,12 @@ CLIENT_DOMAINS = frozenset({
 #: the same 🔴 trap: this is matched against the path RELATIVE to the root,
 #: because every agent worktree lives under `…/.claude/worktrees/<id>/` and an
 #: absolute-parts test skips the entire repo while reporting a confident zero.
-SKIP_DIRS = frozenset({
-    ".git", ".direnv", "result", "node_modules", "__pycache__",
-    ".pytest_cache", ".mypy_cache", ".ruff_cache", "worktrees",
-})
+#:
+#: 🔴 THE BASE SET AND NOTHING ELSE, for the same reason as public_ip_scan: this
+#: is a SECURITY gate on a PUBLIC repo, so it must not inherit the `.claude` /
+#: `claudedocs` entries the `scripts/tests/` ledgers add to the same shared
+#: base. `test_skip_dirs_ledger.py` pins this two-way.
+SKIP_DIRS = _skip_dirs.GENERATED
 
 SKIP_SUFFIXES = frozenset({
     ".png", ".jpg", ".jpeg", ".gif", ".ico", ".webp", ".pdf", ".zip", ".gz",

--- a/scripts/testlib/public_ip_scan.py
+++ b/scripts/testlib/public_ip_scan.py
@@ -74,6 +74,8 @@ import re
 import sys
 from pathlib import Path
 
+from . import skip_dirs as _skip_dirs
+
 _REPO = Path(__file__).resolve().parents[2]
 # guard_core is a hook module, not a package; it is import-safe (its only
 # top-level work is building regexes — the CLI is behind `if __name__`).
@@ -126,10 +128,14 @@ DOC_NETWORKS = (
 #: Directories never scanned. `.claude/worktrees` matters most: on a dev host it
 #: holds FULL copies of this repo, so without it the scan re-reports every other
 #: agent's tree as if it were this one.
-SKIP_DIRS = frozenset({
-    ".git", ".direnv", "result", "node_modules", "__pycache__",
-    ".pytest_cache", ".mypy_cache", ".ruff_cache", "worktrees",
-})
+#:
+#: 🔴 THE BASE SET AND NOTHING ELSE. This is a SECURITY gate on a PUBLIC repo:
+#: every name added here is a directory a real address may be committed into
+#: unseen. In particular it must never inherit `.claude`/`claudedocs` from the
+#: `scripts/tests/` ledgers that share `skip_dirs.GENERATED` -- `claudedocs/` is
+#: committed prose and one of the likeliest places an address gets written down.
+#: `test_skip_dirs_ledger.py` pins this two-way. See `testlib/skip_dirs.py`.
+SKIP_DIRS = _skip_dirs.GENERATED
 
 SKIP_SUFFIXES = frozenset({
     ".png", ".jpg", ".jpeg", ".gif", ".ico", ".webp", ".pdf", ".zip", ".gz",

--- a/scripts/testlib/skip_dirs.py
+++ b/scripts/testlib/skip_dirs.py
@@ -1,0 +1,99 @@
+"""ONE definition of the directories a repo-wide filesystem walk must not read.
+
+WHY THIS FILE EXISTS
+--------------------
+Four repo-wide scanners each carried their own hand-written skip set, and
+`claude/RULES.md` -> "One rule, one place" predicted the outcome exactly: the
+predicate was wrong at N-1 of the N sites, in the same direction. Measured
+2026-08-20, before this module existed:
+
+    scripts/testlib/public_ip_scan.py            9 entries, HAS .pytest_cache
+    scripts/testlib/client_host_scan.py          9 entries, HAS .pytest_cache
+    the shared-detector ledger in scripts/tests  7 entries, MISSING it
+    scripts/tests/test_clawgate_predicate_...py  6 entries, MISSING it
+
+The two shared copies had learned about `.pytest_cache`; the two open-coded
+copies in `scripts/tests/` had not. So an ORDINARY `pytest` run -- one that
+writes `.pytest_cache/v/cache/nodeids`, a JSON list of every collected node id
+-- planted a file naming the shared /proc session detector 29 times inside the
+tree that ledger walks, and the ledger went red on an artefact the developer
+never wrote. That is the permanently-red-gate failure `claude/RULES.md` names: a
+gate nobody can keep green trains everyone to click through it.
+
+Not hypothetical and not latent: the operator's own `~/workspace/devrc` checkout
+was RED on that test at the moment this module was written, from a
+`.pytest_cache` last touched by a routine run.
+
+(Deliberately NOT spelling that ledger's module name here. It hunts for its own
+trigger token repo-wide, so naming it would make this file one of its findings
+-- the same self-reference trap `test_clawgate_predicate_single_source.py` and
+`shebang_scan.py` document.)
+
+WHY THERE IS A BASE PLUS PER-SITE ADDITIONS, AND NOT ONE UNION
+--------------------------------------------------------------
+🔴 Unioning the four sets would have BLINDED TWO SECURITY GATES. This repo is
+PUBLIC; `public_ip_scan` and `client_host_scan` exist to stop a real address or
+a client hostname reaching it. The two `scripts/tests/` sets skip `.claude` and
+`claudedocs` -- and `claudedocs/` is 98 COMMITTED files of handoff prose, which
+is precisely the highest-yield place for a real IP or hostname to get written
+down. A union would have deleted those 98 files from both gates' view while
+every test stayed green. A skip entry is a blind spot, so it is granted per
+site, with a reason, never inherited by default.
+
+The inverse direction is a hazard too, which is why `GENERATED` is exactly the
+set those two gates already had: consolidation must not silently NARROW them
+either. Their effective sets are unchanged by this module, byte for byte, and
+`scripts/tests/test_skip_dirs_ledger.py` pins all four two-way so a future edit
+cannot widen one (blinding a gate) or narrow one (re-opening this bug) unseen.
+"""
+from __future__ import annotations
+
+#: Machine-generated or foreign-repo directories. Nothing here is written by
+#: hand, so nothing here is this repo's source, so no repo-wide scanner has a
+#: reason to read it. Every entry has a reason, because every entry is a blind
+#: spot:
+#:
+#:   .git            VCS internals; also most of the file count in the repo.
+#:   .direnv         direnv's per-repo nix profile cache.
+#:   result          the `nix build` output symlink (gitignored, at the root).
+#:   node_modules    npm dependency trees -- vendored third-party source.
+#:   __pycache__     CPython bytecode.
+#:   .pytest_cache   MEASURED: `v/cache/nodeids` is a JSON list of every
+#:                   collected test node id, so it names, verbatim, every module
+#:                   and function in the repo. A content ledger reading it sees
+#:                   its own trigger tokens reflected back. Written by any
+#:                   ordinary `pytest` run and gitignored -- this is the entry
+#:                   this module was created for.
+#:   .mypy_cache     mypy's serialized ASTs; carries source string constants.
+#:   .ruff_cache     ruff's diagnostic cache. MEASURED PRESENT in the operator's
+#:                   checkout (`.ruff_cache/0.16.2/`) even though this repo has
+#:                   no ruff config -- an agent ran it once. "We do not use that
+#:                   tool" is not evidence the directory is absent.
+#:   worktrees       agent worktrees live under `.claude/worktrees/<id>/` and are
+#:                   FULL copies of this repo. Without this, a scan re-reports
+#:                   every other agent's tree as if it were this one.
+#:
+#: 🔴 Matched against the path RELATIVE to the scan root, never the absolute
+#: one. This checkout can itself sit under a directory named here (a worktree
+#: does), and an absolute-parts test then walks ZERO files while reporting a
+#: perfect green. Every consumer's positive control exists for that failure.
+GENERATED = frozenset({
+    ".git", ".direnv", "result", "node_modules", "__pycache__",
+    ".pytest_cache", ".mypy_cache", ".ruff_cache", "worktrees",
+})
+
+#: A Python virtualenv: `python -m venv .venv`, `uv venv`, `virtualenv venv`.
+#:
+#: 🔴 Granted ONLY to walkers that have no `git ls-files` tier, i.e. the two
+#: `scripts/tests/` ledgers, which read whatever is on disk. MEASURED in the
+#: operator's checkout: `.venv/` holds 476 files, 395 of them `.py`, and both
+#: ledgers were parsing every one of them on every run. It contains no trigger
+#: token TODAY (measured, zero hits) -- so this is not a fix for a live red, it
+#: is the same class of bug one `pip install` away, and creating a virtualenv is
+#: exactly the ordinary developer action that must not red a gate.
+#:
+#: Deliberately NOT granted to `public_ip_scan` / `client_host_scan`. Those two
+#: prefer `git ls-files`, so a virtualenv is already outside their view on the
+#: dev host and outside the flake source in the nix sandbox -- adding it there
+#: would buy a security gate nothing and cost it a stated blind spot.
+VIRTUALENVS = frozenset({".venv", "venv"})

--- a/scripts/tests/test_claude_sessions.py
+++ b/scripts/tests/test_claude_sessions.py
@@ -24,11 +24,15 @@ import json
 import os
 import pathlib
 import subprocess
+import sys
 import time
 
 import pytest
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(_HERE))  # scripts/
+from testlib import skip_dirs  # noqa: E402
+
 _MODULE = os.path.join(_HERE, "..", "lib", "claude_sessions.py")
 
 _spec = importlib.util.spec_from_loader(
@@ -731,6 +735,10 @@ _MENTION_ONLY = {
     # because the /proc walk is not reachable over SSH and session-manager has
     # to report both hosts by ONE rule.
     "scripts/session-manager":                   "names it in a caveat, on purpose",
+    # Imports THIS SUITE (not the detector) to read `_SKIP_DIRS` and pin it
+    # against the three sibling walkers. It names this module because that is
+    # the import; it never loads `scripts/lib/`.
+    "scripts/tests/test_skip_dirs_ledger.py":    "pins this suite's skip set",
 }
 
 _DOC_SUFFIXES = {".md", ".txt", ".org"}
@@ -739,8 +747,28 @@ _DOC_SUFFIXES = {".md", ".txt", ".org"}
 def _is_doc(rel) -> bool:
     return os.path.splitext(rel)[1].lower() in _DOC_SUFFIXES
 
-_SKIP_DIRS = {".git", "node_modules", "__pycache__", ".direnv", "result",
-              ".claude", "claudedocs"}
+#: 🔴 SHARED BASE + THIS SITE'S OWN ADDITIONS, spelled here so the effective set
+#: is readable where it is used. The base is `testlib/skip_dirs.GENERATED` —
+#: machine-generated directories no walker should read. Before the four skip
+#: sets were consolidated this one was missing `.pytest_cache`, so an
+#: ordinary `pytest` run wrote `.pytest_cache/v/cache/nodeids` — a JSON list of
+#: every collected node id, naming `claude_sessions` 29 times — into the tree
+#: this ledger walks, and the ledger went red on an artefact nobody wrote. The
+#: operator's checkout was in exactly that state when this was fixed.
+#:
+#: The two additions are NOT in the base, because the base is also what the two
+#: PUBLIC-repo security gates use and neither may inherit them:
+#:   .claude      per-host Claude Code state; gitignored, ~41k files locally,
+#:                and it is where agent worktrees (full repo copies) live.
+#:   claudedocs   committed handoff prose. Excluded HERE only because the
+#:                mention scan is scoped to code — `_is_doc` already drops
+#:                `.md`, and this makes the walk skip the directory outright.
+#:                🔴 `public_ip_scan` / `client_host_scan` MUST keep reading it.
+#: `VIRTUALENVS` is granted because this walker has no `git ls-files` tier: it
+#: reads whatever is on disk, and `.venv/` is 476 files of vendored pip source
+#: in the operator's checkout today.
+_SKIP_DIRS = set(skip_dirs.GENERATED | skip_dirs.VIRTUALENVS) | {
+    ".claude", "claudedocs"}
 
 
 def _repo_files():

--- a/scripts/tests/test_clawgate_predicate_single_source.py
+++ b/scripts/tests/test_clawgate_predicate_single_source.py
@@ -35,11 +35,16 @@ in isolation is the new vacuous green".
 from __future__ import annotations
 
 import ast
+import sys
 from pathlib import Path
 
 import pytest
 
 REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "scripts"))
+
+from testlib import skip_dirs  # noqa: E402
+
 LIB_REL = "scripts/lib/clawgate_tasks.py"
 
 #: The pending states, spelled here ONCE so this guard can look for them. This
@@ -94,8 +99,20 @@ EXPECTED_IMPORTERS = {
 # predicate live, and dropping it here is the SHRINK case this ledger is built
 # to make audible, recorded rather than silently absorbed.
 
-SKIP_DIRS = {".git", "node_modules", "__pycache__", ".direnv", "result",
-             ".claude"}
+#: 🔴 SHARED BASE + THIS SITE'S OWN ADDITION, spelled here so the effective set
+#: is readable where it is used. The base is `testlib/skip_dirs.GENERATED`; this
+#: set was one of the two that had NOT learned about `.pytest_cache` (see that
+#: module's header for the measurement and for the red it caused in the sibling
+#: shared-detector ledger — not named here, because that ledger hunts for its
+#: own trigger token repo-wide and naming it makes this file a finding).
+#:
+#: `.claude` is added HERE and deliberately not in the base: per-host Claude Code
+#: state, gitignored, and the parent of the agent worktrees. It must NOT reach
+#: `public_ip_scan` / `client_host_scan`, which are security gates on a PUBLIC
+#: repo. `VIRTUALENVS` is granted because this walker has no `git ls-files`
+#: tier — it AST-parses whatever `.py` files are on disk, which in the
+#: operator's checkout is 395 files of vendored pip source under `.venv/`.
+SKIP_DIRS = set(skip_dirs.GENERATED | skip_dirs.VIRTUALENVS) | {".claude"}
 
 #: `#!`, assembled from character codes rather than written as a quoted literal.
 #: Same reason as `scripts/testlib/shebang_scan.py`'s needles: the repo-wide

--- a/scripts/tests/test_skip_dirs_ledger.py
+++ b/scripts/tests/test_skip_dirs_ledger.py
@@ -1,0 +1,168 @@
+"""🔴 SEAM GUARD: every repo-wide walker's EFFECTIVE skip set, pinned two-way.
+
+WHY
+---
+Four scanners walk this repo's filesystem and each one used to carry its own
+hand-written skip set. Measured 2026-08-20, they disagreed:
+
+    public_ip_scan / client_host_scan   9 entries, HAD .pytest_cache
+    test_claude_sessions                7 entries, MISSING it
+    test_clawgate_predicate_single_...  6 entries, MISSING it
+
+so an ordinary `pytest` run wrote `.pytest_cache/v/cache/nodeids` into the tree
+and `test_claude_sessions` went red on it. `claude/RULES.md` -> "One rule, one
+place": a predicate open-coded at N sites is wrong at N-1 of them, in the same
+direction. Consolidating without pinning just resets the clock.
+
+WHAT THIS PINS, AND WHY IT IS THE RELATIONSHIP AND NOT THE COMPONENT
+--------------------------------------------------------------------
+Consolidation creates a hazard it did not have before: the four sites now share
+a base, so an edit to that base moves ALL FOUR. Two directions, both bad:
+
+  WIDER  -- a name added to the base BLINDS the two security gates. This repo is
+            PUBLIC and `public_ip_scan` / `client_host_scan` are what stop a real
+            address or client hostname reaching it. Unioning the four sets --
+            the obvious refactor -- would have pulled `.claude` and `claudedocs`
+            into both, deleting 98 committed prose files from their view while
+            every test stayed green.
+  NARROWER-- a name removed re-opens the red gate above.
+
+So the pin is on each scanner's EFFECTIVE set -- the exact frozen value it uses
+at runtime -- not on the shared base. A structural check that "they all import
+skip_dirs" would type-check right past a wrong operand. `claude/RULES.md` ->
+"Verified in isolation is the new vacuous green": the defect lives in the seam.
+
+Every assertion below names the pinned set literally, so a reword cannot walk
+it and a mutation must move a number this file spells.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "scripts"))
+
+import test_claude_sessions as CS  # noqa: E402
+import test_clawgate_predicate_single_source as CP  # noqa: E402
+from testlib import client_host_scan as H  # noqa: E402
+from testlib import public_ip_scan as P  # noqa: E402
+from testlib import skip_dirs  # noqa: E402
+
+#: The shared base, spelled out. Any edit to `skip_dirs.GENERATED` must move
+#: this literal too, which is what forces the four effective sets below to be
+#: re-read rather than assumed.
+BASE = {
+    ".git", ".direnv", "result", "node_modules", "__pycache__",
+    ".pytest_cache", ".mypy_cache", ".ruff_cache", "worktrees",
+}
+
+VENVS = {".venv", "venv"}
+
+#: 🔴 THE LEDGER. scanner -> its exact effective skip set.
+#:
+#: The two `testlib/` entries are the SECURITY gates and get the base alone.
+#: They are spelled as `BASE` with no additions on purpose: reading this table
+#: must make it obvious that neither of them skips `.claude` or `claudedocs`.
+#:
+#: The two `scripts/tests/` entries are content LEDGERS with no `git ls-files`
+#: tier, so they read raw disk and additionally skip a virtualenv and the
+#: per-host `.claude` state.
+EFFECTIVE = {
+    "testlib/public_ip_scan.SKIP_DIRS":                    BASE,
+    "testlib/client_host_scan.SKIP_DIRS":                  BASE,
+    "test_claude_sessions._SKIP_DIRS":                     BASE | VENVS | {".claude", "claudedocs"},
+    "test_clawgate_predicate_single_source.SKIP_DIRS":     BASE | VENVS | {".claude"},
+}
+
+LIVE = {
+    "testlib/public_ip_scan.SKIP_DIRS":                    P.SKIP_DIRS,
+    "testlib/client_host_scan.SKIP_DIRS":                  H.SKIP_DIRS,
+    "test_claude_sessions._SKIP_DIRS":                     CS._SKIP_DIRS,
+    "test_clawgate_predicate_single_source.SKIP_DIRS":     CP.SKIP_DIRS,
+}
+
+
+def test_the_shared_base_is_exactly_what_this_ledger_says():
+    """`skip_dirs.GENERATED` cannot move without this literal moving with it."""
+    assert set(skip_dirs.GENERATED) == BASE, (
+        "skip_dirs.GENERATED changed.\n  pinned: %s\n  actual: %s\n"
+        "Adding a name here WIDENS all four scanners at once, including two "
+        "security gates on a PUBLIC repo. Removing one can re-open the "
+        "permanently-red-gate bug. Update this literal only with the reason."
+        % (sorted(BASE), sorted(skip_dirs.GENERATED)))
+    assert set(skip_dirs.VIRTUALENVS) == VENVS, (
+        "skip_dirs.VIRTUALENVS changed: pinned %s, actual %s"
+        % (sorted(VENVS), sorted(skip_dirs.VIRTUALENVS)))
+
+
+def test_every_scanners_effective_skip_set_is_pinned_two_way():
+    """Each walker's runtime value, asserted whole. Not a subset check."""
+    assert set(LIVE) == set(EFFECTIVE), (
+        "the scanner ledger and the live table disagree about WHICH scanners "
+        "exist: %s" % sorted(set(LIVE) ^ set(EFFECTIVE)))
+    for name, expected in sorted(EFFECTIVE.items()):
+        actual = set(LIVE[name])
+        assert actual == expected, (
+            "%s changed its effective skip set.\n"
+            "  extra (a NEW BLIND SPOT):  %s\n"
+            "  missing (a REOPENED GAP):  %s\n"
+            "Every skip entry is a directory this scanner can no longer see. "
+            "Add one only with a reason, in skip_dirs.py or at the site."
+            % (name, sorted(actual - expected), sorted(expected - actual)))
+
+
+def test_the_security_gates_never_inherit_the_ledgers_additions():
+    """🔴 The consolidation hazard, asserted as a RELATIONSHIP.
+
+    `claudedocs/` is committed prose on a PUBLIC repo and is one of the
+    likeliest places a real address or client hostname gets written down;
+    `.claude/` is per-host state that a fallback walk can reach. Neither may
+    ever become invisible to the two gates that exist to catch that. This fails
+    for ANY future addition too, not just these two names: the security gates'
+    sets must stay a strict subset of the base.
+    """
+    for gate, live in (("public_ip_scan", P.SKIP_DIRS),
+                       ("client_host_scan", H.SKIP_DIRS)):
+        for blinding in ("claudedocs", ".claude"):
+            assert blinding not in live, (
+                "%s now skips %r — it is a security gate on a PUBLIC repo and "
+                "that directory holds committed content it must read"
+                % (gate, blinding))
+        assert set(live) <= BASE, (
+            "%s gained skip entries beyond the shared base: %s. A security "
+            "gate widens only by an explicit, reasoned edit to THIS test."
+            % (gate, sorted(set(live) - BASE)))
+
+
+def test_pytest_cache_is_skipped_by_every_walker():
+    """🔴 THE REGRESSION. Red at the parent of #582, green here.
+
+    An ordinary `pytest` run writes `.pytest_cache/v/cache/nodeids`, a JSON list
+    of every collected test node id — so it names, verbatim, every module and
+    function in this repo. Any content ledger that walks it reads its own
+    trigger tokens back out of a file the developer never wrote. Named
+    separately from the table above so the failure message says WHY.
+    """
+    for name, live in sorted(LIVE.items()):
+        assert ".pytest_cache" in live, (
+            "%s does not skip .pytest_cache — running plain `pytest` will red "
+            "this gate on a generated artefact" % name)
+
+
+def test_the_skip_sets_actually_reject_a_generated_path():
+    """POSITIVE + NEGATIVE CONTROL for the predicate itself, not just the set.
+
+    A pinned set proves nothing if the matcher that consumes it is wrong. Every
+    consumer applies `any(part in SKIP_DIRS for part in <relative>.parts)`, so
+    exercise that shape: a path INSIDE a skipped directory must be rejected at
+    every depth, and an ordinary source path must NOT be.
+    """
+    skipped = Path(".pytest_cache/v/cache/nodeids")
+    nested = Path("scripts/browser-bridge/tests/.pytest_cache/v/cache/nodeids")
+    kept = Path("scripts/lib/claude_sessions.py")
+    for name, live in sorted(LIVE.items()):
+        assert any(p in live for p in skipped.parts), name
+        assert any(p in live for p in nested.parts), name
+        assert not any(p in live for p in kept.parts), (
+            "%s would skip %s — the scan is walking nothing" % (name, kept))


### PR DESCRIPTION
## The bug: running `pytest` reds a gate

`.pytest_cache/v/cache/nodeids` is a JSON list of every collected test node id — so it names, **verbatim**, every module and function in this repo. Two repo-wide content ledgers walked it, because their skip lists never learned about `.pytest_cache`:

```
$ pytest scripts/tests/test_claude_sessions.py        # ordinary run, cache enabled
27 passed
$ pytest scripts/tests/test_claude_sessions.py        # re-run
FAILED test_exactly_these_files_load_the_shared_detector
  these files name claude_sessions without importing it:
    ['.pytest_cache/v/cache/nodeids']
```

🔴 **Not latent.** `~/workspace/devrc` was red on this test at the moment the fix was written, from a `.pytest_cache` last written by a routine run. `RULES.md` → *"a permanently-red gate is worse than no gate — it trains everyone to click through."*

## The four-way diff

`RULES.md` → *"One rule, one place"* called the shape exactly: a predicate open-coded at N sites is wrong at N−1 of them, in the same direction.

| site | n | `.pytest_cache` | `.mypy_cache` | `.ruff_cache` | `worktrees` | `.claude` | `claudedocs` |
|---|---|---|---|---|---|---|---|
| `testlib/public_ip_scan.py` | 9 | ✅ | ✅ | ✅ | ✅ | — | — |
| `testlib/client_host_scan.py` | 9 | ✅ | ✅ | ✅ | ✅ | — | — |
| `tests/test_claude_sessions.py` | 7 | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
| `tests/test_clawgate_predicate_single_source.py` | 6 | ❌ | ❌ | ❌ | ❌ | ✅ | — |

All four shared `.git`, `.direnv`, `result`, `node_modules`, `__pycache__`.

## 🔴 Why this is a BASE + additions, and not a union

**Unioning the four sets — the obvious refactor — would have blinded two security gates.** This repo is PUBLIC; `public_ip_scan` and `client_host_scan` exist to stop a real address or a client hostname reaching it. The two `scripts/tests/` sets skip `.claude` and `claudedocs`, and `claudedocs/` is **98 committed prose files** — the single likeliest place an address or hostname gets written down. A union deletes those from both gates' view while every test stays green.

So `scripts/testlib/skip_dirs.py` exports:

- **`GENERATED`** — machine-generated dirs, each with its reason in the source. Deliberately **exactly** what the two security gates already had, so their effective sets are unchanged byte for byte. Consolidation must not silently *narrow* them either.
- **`VIRTUALENVS`** — granted **only** to the two walkers with no `git ls-files` tier. Measured: `.venv/` is 476 files / 395 `.py` of vendored pip source in the operator's checkout, AST-parsed on every run. Not granted to the security gates, where it would buy nothing (they prefer `git ls-files`, and the nix sandbox gets git-derived source) and cost a stated blind spot.

Each site spells its own effective set inline, so it is readable where it is used.

## The two-way pin

`scripts/tests/test_skip_dirs_ledger.py` pins each scanner's **effective** set — the runtime value, asserted whole, not a subset check and not "they all import the module" (a structural check type-checks right past a wrong operand). Plus:

- a **strict-subset guard**: the two security gates can never exceed the base, so *any* future widening fails, not just `.claude`/`claudedocs`;
- a **matcher control**: a pinned set proves nothing if the `any(part in SKIP_DIRS ...)` predicate consuming it is wrong, so a skipped path is exercised at root *and* nested depth, and a real source path is asserted **not** skipped.

## Verification

**Regression matrix** (identical planted `.pytest_cache` both sides):

| tree | result |
|---|---|
| `f94ebd5` (base) | 🔴 **1 failed**, 61 passed — `['.pytest_cache/v/cache/nodeids']` |
| this branch | 🟢 **67 passed** |

**Mutation battery — 7/7 killed, each on its own node id with its own message.** Negative control (unmutated) green; every patch site asserted unique; `PYTHONDONTWRITEBYTECODE=1`; `__pycache__` purged between mutants; restore in `finally` with SHA-256 asserted identical.

| mutant | killed by |
|---|---|
| remove `.pytest_cache` from the base | `test_pytest_cache_is_skipped_by_every_walker` |
| **same mutant, reachability** — reds the *real* ledger on a real cache | `test_exactly_these_files_load_the_shared_detector` |
| widen the base with a bogus name | `test_the_shared_base_is_exactly_what_this_ledger_says` |
| **`claudedocs` into the base (blind the security gates)** | `test_the_security_gates_never_inherit_the_ledgers_additions` |
| drop `.claude` from one site | `..._pinned_two_way` → `REOPENED GAP` |
| widen one site | `..._pinned_two_way` → `NEW BLIND SPOT` |
| remove `.venv` from `VIRTUALENVS` | `test_the_shared_base_is_exactly_what_this_ledger_says` |

The reachability mutant matters: it proves the guard protects a hazard that actually occurs, rather than only proving the new pin can go red.

## Probed and deliberately NOT added

A skip entry is a blind spot, so each needs a reason. Measured in the operator's checkout with a validated instrument:

| dir | present? | carries a trigger token? | verdict |
|---|---|---|---|
| `.pytest_cache` | yes (root + 5 nested) | **yes, 2 files** | added |
| `.ruff_cache` | yes (`0.16.2/`) | no | already in base |
| `.venv` | yes, 476 files | no | added, **filesystem-only walkers** |
| `.serena` `.opencode` `.playwright-mcp` | yes | no | **not added** |
| `.mypy_cache` `.tox` `htmlcov` `dist` `build` `.eggs` `*.egg-info` | absent | n/a | not added (`.mypy_cache` already in base) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
