### PR TITLE
fix(hooks): bash-guard FAILS OPEN for ~1s of every switch — pin every hook's interpreter to /nix/store

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -941,8 +941,13 @@ in
   # to displace a hand-placed regular file at this path — the switch returns
   # rc=0 and silently leaves it unmanaged. `dropStaleClaudeHooks` below is what
   # actually removes it; see the measurement in that comment. Registration in
-  # ~/.claude/settings.json stays per-host and needs no change — it already
-  # invokes `python3 ~/.claude/hooks/bash-guard.py`, which this symlink backs.
+  # ~/.claude/settings.json stays per-host — register-nudge-hook.py deliberately
+  # does NOT own it and will never create a bash-guard entry. What it DOES own is
+  # that entry's INTERPRETER: a bare `python3` there dies with `command not found`
+  # during the ~1s window where the switch's intermediate profile generation has
+  # no python3, and a PreToolUse hook exiting 127 is non-blocking — i.e. the guard
+  # FAILS OPEN mid-switch. The registrar rewrites the token to an absolute
+  # /nix/store python; see its module docstring.
   home.file.".claude/hooks/bash-guard.py" = {
     source = ../scripts/claude-hooks/bash-guard.py;
     force = true;
@@ -1004,7 +1009,9 @@ in
   # is likewise managed now). audit-pr-nudge fires
   # PostToolUse on `gh pr create` and injects context so Claude reflexively offers
   # `/audit-pr` (transcript audit: that request was hand-typed ≥14x while the skill
-  # sat unused). Registered as `python3 ~/.claude/hooks/audit-pr-nudge.py`.
+  # sat unused). Registered by register-nudge-hook.py, which writes an ABSOLUTE
+  # /nix/store interpreter into the command — never a bare `python3`, which is
+  # missing from the profile for ~1s of every switch.
   home.file.".claude/hooks/audit-pr-nudge.py" = {
     source = ../scripts/claude-hooks/audit-pr-nudge.py;
   };
@@ -1063,8 +1070,8 @@ in
   # 🔴 THE AGENT ACTIVITY LEDGER — writer 1 (Claude Code), plus the shared module
   # it and `scripts/session-manager` BOTH read the record shape from.
   #
-  # Why the module ships here and not only in the repo: the hook runs as
-  # `python3 ~/.claude/hooks/agent-ledger-hook.py`, and Python puts the SCRIPT's
+  # Why the module ships here and not only in the repo: the hook is invoked with
+  # the .claude/hooks/ copy as its script argument, and Python puts the SCRIPT's
   # directory on sys.path — so `agent_ledger.py` must sit beside it, exactly the
   # arrangement bash-guard.py already has with guard_core.py. Same source file as
   # `scripts/lib/agent_ledger.py`, which session-manager loads by explicit path,
@@ -1159,6 +1166,12 @@ in
   # The wrapper never returns non-zero, so this cannot abort a switch under
   # activation's `set -eu -o pipefail`; see the contract in its header.
   # $DRY_RUN_CMD keeps `home-manager build`/dry-run read-only.
+  #
+  # 🔴 ${pkgs.python312}/bin/python3 is not merely "an interpreter that works" —
+  # the registrar writes `os.path.realpath(sys.executable)` into every managed
+  # hook command, so THIS path is what lands in settings.json and pins the hooks
+  # to an immutable, GC-rooted store closure. Swapping it for a profile path
+  # would silently reopen the mid-switch `python3: command not found` window.
   home.activation.registerClaudeHooks =
     lib.hm.dag.entryAfter [ "writeBoundary" "linkGeneration" ] ''
       $DRY_RUN_CMD ${pkgs.bash}/bin/bash ${../scripts/claude-hooks/register-hooks-activation.sh} \

--- a/scripts/claude-hooks/register-hooks-activation.sh
+++ b/scripts/claude-hooks/register-hooks-activation.sh
@@ -23,10 +23,24 @@
 #      / "… no change") is echoed line by line, prefixed. A silent activation
 #      step is how the original failure went unnoticed for a full deploy cycle.
 #   3. IT DECIDES NOTHING ABOUT settings.json. Every read/merge/write belongs
-#      to the registrar, which is strictly APPEND-ONLY and never clobbers a
-#      hook it does not own (the clawgate Stop hook drives remote approval;
-#      losing it would silently break that). This wrapper adds no second
+#      to the registrar. That registrar has TWO surfaces of different widths —
+#      an APPEND surface (its own command tables, never touching a hook it does
+#      not own, so the clawgate Stop hook that drives remote approval survives)
+#      and, since 2026-08-20, a narrow REWRITE surface that normalises the
+#      INTERPRETER TOKEN of a devrc-managed hook command to an absolute
+#      /nix/store python. Read its module docstring before changing either; the
+#      claim this file used to make — "strictly APPEND-ONLY" — is no longer
+#      true and deleting the rewrite path would silently reopen the failure it
+#      closes (a hook firing mid-switch dies with `python3: command not found`,
+#      and bash-guard fails OPEN when it does). This wrapper adds no second
 #      writer — it must never grow one.
+#
+#      🔴 The interpreter the registrar writes is derived from its OWN
+#      sys.executable, so the `[python]` argument below is load-bearing beyond
+#      "something that can run python": home.nix passes
+#      ${pkgs.python312}/bin/python3, and that store path is what ends up in
+#      settings.json. Passing a blinking profile path here would pin the hooks
+#      to a blinking path.
 #
 # The registrar path defaults to the DEPLOYED copy rather than the store
 # source deliberately: if the `home.file` entry for it ever stops landing,

--- a/scripts/claude-hooks/register-nudge-hook.py
+++ b/scripts/claude-hooks/register-nudge-hook.py
@@ -3,11 +3,48 @@
 
 settings.json is per-host and unmanaged (holds permissions/allowlists/secrets), so the
 hook *scripts* are symlinked by home-manager but their *registration* is applied by
-running this once per host. Safe to re-run: it adds only the entries that are missing
-and NEVER clobbers hooks it doesn't own (clawgate PermissionRequest/Stop, bash-guard,
-tmux hooks, etc. are preserved — this only ever appends).
+running this once per host.
 
-Registers:
+🔴 THIS SCRIPT HAS **TWO** SURFACES, AND THEY ARE DELIBERATELY DIFFERENT WIDTHS.
+Until 2026-08-20 there was only the first, and its docstring said "strictly
+APPEND-ONLY / never rewrites". That is no longer true — read both before editing:
+
+  * APPEND surface (NARROW, unchanged): the command tables below. An entry is added
+    only when its exact command string is absent from that event's existing entries.
+    Nothing else is ever appended. In particular bash-guard is NOT in these tables and
+    must never be: this script does not own its registration, only its interpreter, so
+    if a host has no bash-guard entry it must come back with no bash-guard entry.
+  * REWRITE surface (WIDE, new): every hook entry on every event whose command invokes
+    a devrc-managed hook script gets its INTERPRETER TOKEN normalised to an absolute
+    /nix/store python — bash-guard INCLUDED. Only that token changes. The entry keeps
+    its position in its array, its `matcher`, its `type` and every other key verbatim,
+    and a command that does not resolve to a managed hook script comes back
+    byte-identical.
+
+WHY THE REWRITE EXISTS — the 127 window.
+`home-manager switch` updates ~/.nix-profile as remove-then-install, so every switch
+produces TWO profile generations. The intermediate one is a partial closure with NO
+python3 on it (measured on this host: 337 binaries vs 625 in the final generation). A
+hook registered as a bare `python3 ~/.claude/hooks/X.py` that fires inside that ~1s
+window dies with `/bin/sh: line 1: python3: command not found`. Correlating hook errors
+in ~/.claude/projects/**/*.jsonl against ~/.local/state/nix/profiles/profile-*-link
+mtimes matched four times to the second; it had hit 16 sessions across five repos.
+The serious half is bash-guard: it is a PreToolUse hook, exit 127 is classified
+non-blocking, so during that window the guard FAILS OPEN and `git add -A` /
+`git reset --hard` pass unchecked. A /nix/store path is immutable and GC-rooted by the
+current home-manager generation, so an absolute one closes the window completely.
+
+The interpreter is `os.path.realpath(sys.executable)` (override: $DEVRC_HOOK_PYTHON,
+which exists so tests can inject a deterministic path). Both invocation routes converge
+on the same immutable path, VERIFIED on this host rather than assumed:
+  * from activation, home.nix passes ${pkgs.python312}/bin/python3, so sys.executable is
+    already a store path and realpath only resolves python3 -> python3.12;
+  * run by hand as `python3 …/register-nudge-hook.py`, sys.executable is
+    ~/.nix-profile/bin/python3 — the blinking symlink — and realpath resolves it to the
+    same /nix/store/…-python3-3.12.14/bin/python3.12.
+So no plumbing change to home.nix or to register-hooks-activation.sh was needed.
+
+Registers (APPEND surface):
   * PostToolUse(Bash): audit-pr-nudge.py, shell-env-nudge.py, search-tool-nudge.py
   * UserPromptSubmit / Stop / SubagentStop: claude-notify.py (the turn-finished
     notifier — a best-effort side-effect hook, appended alongside any existing
@@ -45,11 +82,25 @@ call. That ordering is now reversed and pinned by a test.
 🔴 Stop is a SHARED event with three pre-existing owners this script does not own and
 must never disturb: the fuzzyclaw tmux writer (~/.config/tmux/task-hook.sh), the
 clawgate stop hook (drives remote approval) and claude-notify.py (drives turn-finished
-notifications). Clobbering any of them is a serious regression, so registration here is
-strictly APPEND-ONLY — an entry is added only when its exact command string is absent
-from the event's existing entries, and no existing entry is ever rewritten, reordered or
-removed. tests/test_register_nudge_hook.py asserts every owner coexists afterwards, as a
-SET EQUALITY so the assertion fails when the set grows as well as when it shrinks.
+notifications). Clobbering any of them is a serious regression, so the APPEND surface
+never reorders or removes anything, and the REWRITE surface never touches a command it
+cannot prove is a managed hook invocation — the tmux and clawgate hooks are `.sh`
+scripts and are left byte-identical. tests/test_register_nudge_hook.py asserts every
+owner coexists afterwards, as a SET EQUALITY so the assertion fails when the set grows
+as well as when it shrinks.
+
+🔴 THE FIRST POST-MIGRATION RUN MUST NOT DOUBLE-REGISTER EVERY HOOK — the readiest way
+to ship this fix broken. Two things prevent it, and only the second is sufficient:
+  * the rewrite pass runs FIRST, so by the time the append pass reads the file the
+    commands already carry the new interpreter;
+  * and the append pass keys on the SCRIPT (`managed_script_of`), not on the exact
+    command string. Exact-string keying was already fragile before this change — a
+    host spelling the hooks dir `$HOME/…` got the hook registered twice — and the
+    rewrite widens it, because a rewritten command matches the table's string only for
+    the `~/` spelling. One recogniser answers "is this hook already registered here"
+    for both surfaces, so they cannot disagree.
+tests/test_register_nudge_hook.py drives a fully pre-migration settings.json and
+asserts SET EQUALITY over each event afterwards, which fails on a duplicate.
 
 next-step-nudge is registered on Stop ONLY, not SubagentStop: a subagent's turn ends
 without ever reaching the operator, so it owes them no next step. The hook refuses that
@@ -59,36 +110,158 @@ state and the hook is the thing that actually ships.
 Run on each host after a home-manager switch that adds a new hook:
     python3 ~/workspace/devrc/scripts/claude-hooks/register-nudge-hook.py
 """
-import json, os, sys, tempfile
+import json, os, re, sys, tempfile
 
 SETTINGS = os.path.expanduser("~/.claude/settings.json")
+HOME = os.path.expanduser("~")
+
+
+def hook_python():
+    """The absolute interpreter to write into every managed hook command.
+
+    $DEVRC_HOOK_PYTHON is the test seam — without it a test would have to assert
+    against whatever interpreter pytest happened to run under. The fallback to a
+    bare name only fires when sys.executable is empty (an embedded interpreter),
+    which is not a configuration this ever runs in.
+    """
+    override = os.environ.get("DEVRC_HOOK_PYTHON")
+    if override:
+        return override
+    return os.path.realpath(sys.executable) if sys.executable else "python3"
+
+
+PYTHON = hook_python()
+
+
+def with_python(path):
+    return PYTHON + " " + path
+
+
+# --------------------------------------------------------------------------- #
+# THE REWRITE SURFACE: which scripts count as a devrc-managed hook.
+#
+# Derived from nix/home.nix's `home.file.".claude/hooks/*.py"` entries and pinned
+# TWO-WAY against that file by tests/test_registrar_activation.py (which already
+# owns the home.nix parsers), mirroring the idiom
+# scripts/drift-check.sh uses for its nix/pkgs set: adding a hook to
+# home.nix without accounting for it here fails the suite, and so does removing
+# one. It is a literal rather than a scan because the DEPLOYED registrar is a
+# /nix/store copy with no repo checkout to read.
+#
+# 🔴 The two exclusions are explicit and asserted, not incidental:
+#   * HOOK_LIBRARY_MODULES ship into the hooks dir so they sit on the hook's
+#     sys.path, but nothing ever invokes them AS a hook — there is no interpreter
+#     token of theirs to fix.
+#   * the registrar itself is invoked by home.nix's activation entry, which
+#     already passes ${pkgs.python312}/bin/python3, and never from settings.json.
+# --------------------------------------------------------------------------- #
+MANAGED_HOOK_SCRIPTS = frozenset({
+    "agent-ledger-hook.py",
+    "audit-pr-nudge.py",
+    "bash-guard.py",
+    "claude-notify.py",
+    "clawgate-writeback-guard.py",
+    "next-step-nudge.py",
+    "search-tool-nudge.py",
+    "shell-env-nudge.py",
+})
+
+HOOK_LIBRARY_MODULES = frozenset({"agent_ledger.py", "guard_core.py"})
+
+REGISTRAR_SCRIPT = "register-nudge-hook.py"
+
+# The three spellings of the hooks directory a settings.json command may use. A
+# command whose script path does not start with one of these is not something
+# this script can prove it owns, so it is left alone.
+HOOK_DIR_PREFIXES = tuple(dict.fromkeys(
+    ("~/.claude/hooks/", "$HOME/.claude/hooks/", HOME + "/.claude/hooks/")
+))
+
+# <interpreter> <hooks-dir><basename.py>[ <args>]  — anchored at the start, so a
+# command with a leading env assignment (`CLAUDE_HOST=wb …`) or any other prefix
+# does not match and comes back byte-identical.
+_MANAGED_CMD_RE = re.compile(
+    r"^(?P<interp>\S+)[ \t]+(?:%s)(?P<base>[A-Za-z0-9_.+-]+\.py)(?=$|[ \t])"
+    % "|".join(re.escape(p) for p in HOOK_DIR_PREFIXES)
+)
+
+
+def managed_script_of(cmd):
+    """The devrc-managed hook script this command invokes, or None.
+
+    THE single recogniser — both surfaces key on it, so "what counts as a
+    managed hook command" is answered in one place and cannot disagree between
+    the rewrite pass and the append pass.
+
+    Conservative on purpose — three independent conditions must all hold:
+      1. the command is `<one-token> <hooks-dir-path>[ args]`;
+      2. the script's basename is in MANAGED_HOOK_SCRIPTS;
+      3. the token that would be replaced is itself a python interpreter.
+    (3) is what stops this from mangling a hypothetical `bash <hooks-dir>/x.py`
+    or a wrapper; merely containing the word python is never enough, because the
+    match is anchored on the PATH.
+    """
+    if not isinstance(cmd, str):
+        return None
+    m = _MANAGED_CMD_RE.match(cmd)
+    if not m:
+        return None
+    if m.group("base") not in MANAGED_HOOK_SCRIPTS:
+        return None
+    if not os.path.basename(m.group("interp")).startswith("python"):
+        return None
+    return m.group("base")
+
+
+def normalized_command(cmd):
+    """Rewrite ONLY the interpreter token of a devrc-managed hook invocation.
+
+    Anything `managed_script_of` does not recognise is returned unchanged — the
+    identical object, so a caller's `new != old` check is exact.
+    """
+    if managed_script_of(cmd) is None:
+        return cmd
+    return PYTHON + cmd[_MANAGED_CMD_RE.match(cmd).end("interp"):]
+
+
+# --------------------------------------------------------------------------- #
+# THE APPEND SURFACE: the command tables. Unchanged in width — only the
+# interpreter half of each string moved.
+#
+# 🔴 Keep the `~/.claude/hooks/<name>.py` literals spelled out here rather than
+# built from MANAGED_HOOK_SCRIPTS: tests/test_registrar_activation.py parses this
+# file for exactly that pattern to check home.nix deploys everything registered,
+# and a computed path would make that check silently find nothing. For the same
+# reason, do not write a prefixed hook path into a comment or docstring below —
+# it would read as a registration that is not one.
+# --------------------------------------------------------------------------- #
 
 # PostToolUse(Bash) nudge hooks to ensure are registered.
 POST_BASH_CMDS = [
-    "python3 ~/.claude/hooks/audit-pr-nudge.py",
-    "python3 ~/.claude/hooks/shell-env-nudge.py",
-    "python3 ~/.claude/hooks/search-tool-nudge.py",
+    with_python("~/.claude/hooks/audit-pr-nudge.py"),
+    with_python("~/.claude/hooks/shell-env-nudge.py"),
+    with_python("~/.claude/hooks/search-tool-nudge.py"),
 ]
 
 # The turn-finished notifier fires on these three events (single script,
 # dispatched on the event name in its stdin payload).
-NOTIFY_CMD = "python3 ~/.claude/hooks/claude-notify.py"
+NOTIFY_CMD = with_python("~/.claude/hooks/claude-notify.py")
 NOTIFY_EVENTS = ["UserPromptSubmit", "Stop", "SubagentStop"]
 
 # The agent activity ledger's writer. Four events, and a PostToolUse entry with
 # no matcher — see the module docstring for why it is not scoped to Bash.
-LEDGER_CMD = "python3 ~/.claude/hooks/agent-ledger-hook.py"
+LEDGER_CMD = with_python("~/.claude/hooks/agent-ledger-hook.py")
 LEDGER_EVENTS = ["SessionStart", "UserPromptSubmit", "PostToolUse", "Stop"]
 
 # The clawgate write-back guard. Two events, and — like the ledger above — a
 # PostToolUse entry with NO matcher, because half of what it watches for is an
 # Edit/Write/NotebookEdit tool call. See the module docstring.
-WRITEBACK_CMD = "python3 ~/.claude/hooks/clawgate-writeback-guard.py"
+WRITEBACK_CMD = with_python("~/.claude/hooks/clawgate-writeback-guard.py")
 WRITEBACK_EVENTS = ["PostToolUse", "Stop"]
 
 # Hooks registered on exactly one event each: {event: [command, ...]}.
 SINGLE_EVENT_CMDS = {
-    "Stop": ["python3 ~/.claude/hooks/next-step-nudge.py"],
+    "Stop": [with_python("~/.claude/hooks/next-step-nudge.py")],
 }
 
 with open(SETTINGS) as f:
@@ -96,18 +269,70 @@ with open(SETTINGS) as f:
 
 hooks = data.setdefault("hooks", {})
 added = []
+rewritten = []
 
 
-def registered_commands(event_arrays):
-    """All command strings already present across an event's entry list."""
-    return {h.get("command") for entry in event_arrays for h in entry.get("hooks", [])}
+def registered_scripts(event_arrays):
+    """Which MANAGED hook scripts an event's entry list already invokes.
 
+    🔴 The append surface keys on the SCRIPT, not on the exact command string.
+    Exact-string keying was already fragile — a host spelling the hooks dir
+    `$HOME/…` instead of `~/…` got the hook registered a SECOND time — and the
+    interpreter rewrite widens that hazard, because the rewritten string and
+    the table's string agree only for the `~/` spelling. Keying on the script
+    means "this hook is already registered on this event" is one fact with one
+    answer, whatever spelling the host used.
+
+    It also preserves the pre-existing deliberate behaviour it replaces: the
+    scan covers the WHOLE event array, matchered entries included, so a
+    hand-edit that scoped a hook more narrowly is LEFT IN PLACE rather than
+    silently duplicated. That is the right failure — the append surface never
+    rewrites what it does not own.
+    """
+    found = {managed_script_of(h.get("command"))
+             for entry in event_arrays for h in entry.get("hooks", [])}
+    found.discard(None)
+    return found
+
+
+# --- PASS 1: normalise the interpreter of every managed hook, on every event --
+# 🔴 THE WIDE SURFACE, and the only place this script writes to an entry it does
+# not own. bash-guard is deliberately in scope here and deliberately absent from
+# the append tables above: its registration belongs to the host, its interpreter
+# belongs to this script. If a host has no bash-guard entry, none is created.
+#
+# Mutating `h["command"]` in place is what preserves the entry's position in its
+# array along with its `matcher`, its `type` and any key this script has never
+# heard of. Nothing is inserted, removed or reordered by this pass.
+#
+# It runs BEFORE the append pass so the append reads already-normalised strings.
+# That ordering is belt, not braces: what actually prevents the first
+# post-migration run from double-registering everything is that the append pass
+# keys on `managed_script_of`, not on an exact string. See the docstring.
+for _event in list(hooks):
+    _arr = hooks.get(_event)
+    if not isinstance(_arr, list):
+        continue
+    for _entry in _arr:
+        if not isinstance(_entry, dict):
+            continue
+        _entry_hooks = _entry.get("hooks")
+        if not isinstance(_entry_hooks, list):
+            continue
+        for _h in _entry_hooks:
+            if not isinstance(_h, dict):
+                continue
+            _old = _h.get("command")
+            _new = normalized_command(_old)
+            if _new != _old:
+                _h["command"] = _new
+                rewritten.append("%s: %s" % (_event, _new))
 
 # --- PostToolUse(Bash) nudge hooks (append-only, matcher=Bash) ---------------
 post = hooks.setdefault("PostToolUse", [])
-post_registered = registered_commands(post)
+post_registered = registered_scripts(post)
 for cmd in POST_BASH_CMDS:
-    if cmd in post_registered:
+    if managed_script_of(cmd) in post_registered:
         continue
     post.append({"matcher": "Bash", "hooks": [{"type": "command", "command": cmd}]})
     added.append("PostToolUse(Bash): " + cmd)
@@ -117,21 +342,21 @@ for cmd in POST_BASH_CMDS:
 # a tmux Stop hook) — only add claude-notify where it's missing.
 for event in NOTIFY_EVENTS:
     arr = hooks.setdefault(event, [])
-    if NOTIFY_CMD in registered_commands(arr):
+    if managed_script_of(NOTIFY_CMD) in registered_scripts(arr):
         continue
     arr.append({"hooks": [{"type": "command", "command": NOTIFY_CMD}]})
     added.append("%s: %s" % (event, NOTIFY_CMD))
 
 # --- the agent activity ledger writer (append-only, same discipline) ---------
-# 🔴 `registered_commands` looks across the WHOLE event array, matchered entries
+# 🔴 `registered_scripts` looks across the WHOLE event array, matchered entries
 # included, so re-running this after a hand-edit that scoped the ledger to Bash
 # would NOT add a second entry — it would leave the narrower one in place. That
-# is the right failure (append-only never rewrites what it does not own) and it
-# is the one case where this script's idempotence hides a real misconfiguration;
-# `tests/test_register_nudge_hook.py` pins the shape it writes.
+# is the right failure (the append surface never rewrites what it does not own)
+# and it is the one case where this script's idempotence hides a real
+# misconfiguration; `tests/test_register_nudge_hook.py` pins the shape it writes.
 for event in LEDGER_EVENTS:
     arr = hooks.setdefault(event, [])
-    if LEDGER_CMD in registered_commands(arr):
+    if managed_script_of(LEDGER_CMD) in registered_scripts(arr):
         continue
     arr.append({"hooks": [{"type": "command", "command": LEDGER_CMD}]})
     added.append("%s: %s" % (event, LEDGER_CMD))
@@ -143,7 +368,7 @@ for event in LEDGER_EVENTS:
 # consecutive blocks per task — well inside the CLI's own cap of 8.
 for event in WRITEBACK_EVENTS:
     arr = hooks.setdefault(event, [])
-    if WRITEBACK_CMD in registered_commands(arr):
+    if managed_script_of(WRITEBACK_CMD) in registered_scripts(arr):
         continue
     arr.append({"hooks": [{"type": "command", "command": WRITEBACK_CMD}]})
     added.append("%s: %s" % (event, WRITEBACK_CMD))
@@ -151,14 +376,17 @@ for event in WRITEBACK_EVENTS:
 # --- single-event hooks (append-only, same discipline) -----------------------
 for event, cmds in SINGLE_EVENT_CMDS.items():
     arr = hooks.setdefault(event, [])
-    present = registered_commands(arr)
+    present = registered_scripts(arr)
     for cmd in cmds:
-        if cmd in present:
+        if managed_script_of(cmd) in present:
             continue
         arr.append({"hooks": [{"type": "command", "command": cmd}]})
         added.append("%s: %s" % (event, cmd))
 
-if not added:
+# 🔴 Only write when something actually moved. The rewrite pass now re-runs on
+# every switch, so an unconditional write would re-dump (indent=2) the operator's
+# per-host settings.json — permissions and all — every time, for nothing.
+if not added and not rewritten:
     print("all devrc-managed hooks already registered — no change")
     sys.exit(0)
 
@@ -179,6 +407,11 @@ except Exception:
     except OSError:
         pass
     raise
-print("registered hooks:")
-for c in added:
-    print("  +", c)
+if rewritten:
+    print("pinned hook interpreters to %s:" % PYTHON)
+    for c in rewritten:
+        print("  ~", c)
+if added:
+    print("registered hooks:")
+    for c in added:
+        print("  +", c)

--- a/scripts/claude-hooks/tests/test_register_nudge_hook.py
+++ b/scripts/claude-hooks/tests/test_register_nudge_hook.py
@@ -3,13 +3,38 @@
 
 Runs the script against a temp HOME whose ~/.claude/settings.json already holds
 unrelated hooks (clawgate PermissionRequest/Stop, bash-guard, the PostToolUse
-nudges), and asserts:
+nudges), and asserts BOTH of the registrant's surfaces:
 
+  APPEND (narrow)
   1. It appends claude-notify on the 3 turn-boundary events, append-only.
   2. It NEVER clobbers pre-existing hooks (the clawgate Stop hook survives).
   3. It is idempotent (a 2nd run makes no change, no duplicates).
   4. The final settings.json is valid JSON.
   5. The write is ATOMIC (uses os.replace) and leaves no .settings.*.tmp litter.
+
+  REWRITE (wide, added 2026-08-20)
+  6. Every managed hook command — bash-guard INCLUDED, which the append surface
+     deliberately does not own — has its INTERPRETER TOKEN replaced with an
+     absolute store python, while the entry keeps its position, its `matcher`,
+     its `type` and every foreign key it arrived with.
+  7. Foreign commands (a `.sh` hook, a python script that is NOT a managed hook,
+     a command with a leading env assignment) come back BYTE-IDENTICAL.
+  8. The append surface compares against the REWRITTEN strings, so the first
+     post-migration run does not double-register everything.
+  9. bash-guard is rewritten but never CREATED: a settings.json with no
+     bash-guard entry comes back with no bash-guard entry.
+
+🔴 THE 127 WINDOW, which surface 6 exists to close: `home-manager switch`
+updates ~/.nix-profile as remove-then-install, so there is a ~1s window in which
+the live profile generation is a partial closure with NO python3 on it. A hook
+registered as a bare `python3 …` that fires in that window dies with
+`python3: command not found`, and a PreToolUse hook exiting 127 is classified
+NON-BLOCKING — i.e. bash-guard fails OPEN.
+
+$DEVRC_HOOK_PYTHON pins the interpreter to a deterministic literal here rather
+than letting the expectation depend on whatever interpreter runs this file. The
+UNPINNED resolution (`os.path.realpath(sys.executable)`) is covered separately,
+behaviourally, in test_registrar_activation.py.
 
 Run: python3 test_register_nudge_hook.py
 """
@@ -18,13 +43,29 @@ import os, sys, json, tempfile, subprocess
 HERE = os.path.dirname(os.path.abspath(__file__))
 SCRIPT = os.path.join(HERE, "..", "register-nudge-hook.py")
 
-NOTIFY = "python3 ~/.claude/hooks/claude-notify.py"
+# A synthetic store path — shaped like the real one, deliberately not any path
+# that exists on this host, so nothing can pass by accident of the environment.
+PY = "/nix/store/0000000000000000000000000000000-python3-3.12.14/bin/python3.12"
+
+NOTIFY = PY + " ~/.claude/hooks/claude-notify.py"
 CLAWGATE_STOP = "/home/zach/.claude/clawgate-stop-hook.sh"
-SEARCH_NUDGE = "python3 ~/.claude/hooks/search-tool-nudge.py"
-NEXT_STEP = "python3 ~/.claude/hooks/next-step-nudge.py"
+SEARCH_NUDGE = PY + " ~/.claude/hooks/search-tool-nudge.py"
+NEXT_STEP = PY + " ~/.claude/hooks/next-step-nudge.py"
 TMUX_STOP = "~/.config/tmux/task-hook.sh"
-LEDGER = "python3 ~/.claude/hooks/agent-ledger-hook.py"
-WRITEBACK = "python3 ~/.claude/hooks/clawgate-writeback-guard.py"
+LEDGER = PY + " ~/.claude/hooks/agent-ledger-hook.py"
+WRITEBACK = PY + " ~/.claude/hooks/clawgate-writeback-guard.py"
+BASH_GUARD = PY + " ~/.claude/hooks/bash-guard.py"
+
+# The pre-migration spellings, i.e. what is on both hosts right now.
+OLD_BASH_GUARD = "python3 ~/.claude/hooks/bash-guard.py"
+OLD_AUDIT_NUDGE = "python3 ~/.claude/hooks/audit-pr-nudge.py"
+OLD_SHELL_NUDGE = "python3 ~/.claude/hooks/shell-env-nudge.py"
+
+# Commands the registrant must never touch. The last one is the trap: it names
+# python AND a .py file, but the path is not under the hooks dir.
+FOREIGN_ELSEWHERE = "python3 ~/elsewhere/thing.py"
+FOREIGN_ENV_PREFIX = "CLAUDE_HOST=wb /home/zach/.claude/clawgate-hook.sh"
+FOREIGN_UNMANAGED_HOOK = "python3 ~/.claude/hooks/not-a-devrc-hook.py"
 
 failures = []
 
@@ -35,28 +76,49 @@ def check(name, cond):
         failures.append(name)
 
 
-BASE_SETTINGS = {
-    "hooks": {
-        "PermissionRequest": [
-            {"hooks": [{"type": "command", "command": "CLAUDE_HOST=wb /home/zach/.claude/clawgate-hook.sh", "timeout": 180}]}
-        ],
-        "PreToolUse": [
-            {"matcher": "Bash", "hooks": [{"type": "command", "command": "python3 ~/.claude/hooks/bash-guard.py"}]}
-        ],
-        "PostToolUse": [
-            {"matcher": "Bash", "hooks": [{"type": "command", "command": "python3 ~/.claude/hooks/audit-pr-nudge.py"}]},
-            {"matcher": "Bash", "hooks": [{"type": "command", "command": "python3 ~/.claude/hooks/shell-env-nudge.py"}]},
-        ],
-        # 🔴 Stop already has TWO foreign owners before this script ever runs: the
-        # fuzzyclaw tmux writer and the clawgate stop hook (remote approval). Both are
-        # in the fixture so "append-only" is tested against a populated event, not an
-        # empty one — an append-only bug is invisible on an empty array.
-        "Stop": [
-            {"hooks": [{"type": "command", "command": TMUX_STOP}]},
-            {"hooks": [{"type": "command", "command": CLAWGATE_STOP}]},
-        ],
+def base_settings(home):
+    """The fixture. `home` is needed because one command exercises the LITERAL
+    expanded home prefix, which only the registrant's own $HOME can produce."""
+    return {
+        "hooks": {
+            "PermissionRequest": [
+                {"hooks": [{"type": "command", "command": FOREIGN_ENV_PREFIX, "timeout": 180}]}
+            ],
+            # 🔴 bash-guard sits SECOND, behind a foreign entry, and carries two
+            # keys the registrant has no business knowing about. Position,
+            # matcher and both foreign keys must survive the interpreter rewrite.
+            "PreToolUse": [
+                {"matcher": "Read", "hooks": [{"type": "command", "command": FOREIGN_ELSEWHERE}]},
+                {
+                    "matcher": "Bash",
+                    "description": "the RULES.md enforcement guard",
+                    "hooks": [
+                        {"type": "command", "command": OLD_BASH_GUARD, "timeout": 12}
+                    ],
+                },
+                {"matcher": "Bash", "hooks": [{"type": "command", "command": FOREIGN_UNMANAGED_HOOK}]},
+            ],
+            # 🔴 All THREE accepted spellings of the hooks dir are here, so the
+            # prefix set is exercised and not merely declared — and two of them
+            # are hooks the APPEND surface also owns, which is what proves the
+            # append keys on the SCRIPT rather than on the exact string.
+            # search-tool-nudge is deliberately ABSENT: it is the one that must
+            # still be appended, so the fixture cannot pass by preserving only.
+            "PostToolUse": [
+                {"matcher": "Bash", "hooks": [{"type": "command", "command": OLD_AUDIT_NUDGE}]},
+                {"matcher": "Bash", "hooks": [{"type": "command", "command": "python3 $HOME/.claude/hooks/shell-env-nudge.py"}]},
+                {"hooks": [{"type": "command", "command": "python3 " + home + "/.claude/hooks/clawgate-writeback-guard.py"}]},
+            ],
+            # 🔴 Stop already has TWO foreign owners before this script ever runs: the
+            # fuzzyclaw tmux writer and the clawgate stop hook (remote approval). Both are
+            # in the fixture so "append-only" is tested against a populated event, not an
+            # empty one — an append-only bug is invisible on an empty array.
+            "Stop": [
+                {"hooks": [{"type": "command", "command": TMUX_STOP}]},
+                {"hooks": [{"type": "command", "command": CLAWGATE_STOP}]},
+            ],
+        }
     }
-}
 
 
 def run(env):
@@ -72,10 +134,11 @@ with tempfile.TemporaryDirectory() as tmp:
     os.makedirs(os.path.join(home, ".claude"))
     settings = os.path.join(home, ".claude", "settings.json")
     with open(settings, "w") as f:
-        json.dump(BASE_SETTINGS, f, indent=2)
+        json.dump(base_settings(home), f, indent=2)
 
     env = dict(os.environ)
     env["HOME"] = home
+    env["DEVRC_HOOK_PYTHON"] = PY
 
     p1 = run(env)
     check("1: first run exit 0", p1.returncode == 0)
@@ -102,25 +165,93 @@ with tempfile.TemporaryDirectory() as tmp:
     # longer BLOCKS — it returns additionalContext and exits 0 — but the turn still
     # continues, so the ordering argument is unchanged.)
     stop = cmds(d, "Stop")
+
+    def idx(seq, value):
+        """Position, or None. A missing command must report as a FAILED CHECK,
+        not as a ValueError that aborts the whole suite — this file is run
+        against pre-change code to prove it goes red, and a traceback there
+        hides every check after it."""
+        return seq.index(value) if value in seq else None
+
+    order = [idx(stop, c) for c in (TMUX_STOP, CLAWGATE_STOP, NOTIFY, NEXT_STEP)]
     check("2: foreign Stop hooks keep their original relative order",
-          stop.index(TMUX_STOP) < stop.index(CLAWGATE_STOP))
+          None not in order[:2] and order[0] < order[1])
     check("2: appended hooks come after the pre-existing ones",
-          max(stop.index(TMUX_STOP), stop.index(CLAWGATE_STOP))
-          < min(stop.index(NOTIFY), stop.index(NEXT_STEP)))
+          None not in order and max(order[:2]) < min(order[2:]))
     # next-step-nudge is Stop-only: it must NOT have been added to SubagentStop.
     check("1: next-step-nudge NOT registered on SubagentStop",
           NEXT_STEP not in cmds(d, "SubagentStop"))
-    check("2: bash-guard preserved", "python3 ~/.claude/hooks/bash-guard.py" in cmds(d, "PreToolUse"))
+
+    # --- 6. THE INTERPRETER REWRITE, on the entry that matters most ------------
+    # 🔴 bash-guard is a PreToolUse hook and exit 127 is NON-blocking, so a bare
+    # `python3` here means the guard FAILS OPEN for the ~1s of every switch in
+    # which the intermediate profile generation has no python3 on it.
+    pre = cmds(d, "PreToolUse")
+    check("6: bash-guard's interpreter is now an absolute store path",
+          BASH_GUARD in pre)
+    check("6: the bare-python3 bash-guard command is GONE",
+          OLD_BASH_GUARD not in pre)
+    # ...and the rewrite touched ONLY the interpreter token: position in the
+    # array, matcher, type, and BOTH keys this script knows nothing about.
+    pre_entries = d["hooks"]["PreToolUse"]
+    guard_entry = pre_entries[1]
+    check("6: the rewritten entry kept its POSITION in the array",
+          guard_entry["hooks"][0]["command"] == BASH_GUARD)
+    check("6: the rewritten entry kept its matcher",
+          guard_entry.get("matcher") == "Bash")
+    check("6: the rewritten entry kept a foreign ENTRY-level key",
+          guard_entry.get("description") == "the RULES.md enforcement guard")
+    check("6: the rewritten entry kept a foreign HOOK-level key",
+          guard_entry["hooks"][0].get("timeout") == 12)
+    check("6: the rewritten entry kept its type",
+          guard_entry["hooks"][0].get("type") == "command")
+    check("6: PreToolUse gained no entries — the rewrite never appends",
+          len(pre_entries) == 3)
+
+    # --- 7. FOREIGN COMMANDS COME BACK BYTE-IDENTICAL -------------------------
+    check("7: a python command outside the hooks dir is untouched",
+          FOREIGN_ELSEWHERE in pre)
+    check("7: a python command naming a NON-managed hook script is untouched",
+          FOREIGN_UNMANAGED_HOOK in pre)
+    check("7: a command with a leading env assignment is untouched",
+          cmds(d, "PermissionRequest") == [FOREIGN_ENV_PREFIX])
+    check("7: the foreign PermissionRequest hook kept its timeout",
+          d["hooks"]["PermissionRequest"][0]["hooks"][0].get("timeout") == 180)
+    check("7: the two foreign .sh Stop hooks are untouched",
+          TMUX_STOP in stop and CLAWGATE_STOP in stop)
+    check("7: PreToolUse is EXACTLY the three commands it started with, one rewritten",
+          pre == [FOREIGN_ELSEWHERE, BASH_GUARD, FOREIGN_UNMANAGED_HOOK])
+
     check("2: both PostToolUse nudges preserved",
-          "python3 ~/.claude/hooks/audit-pr-nudge.py" in cmds(d, "PostToolUse")
-          and "python3 ~/.claude/hooks/shell-env-nudge.py" in cmds(d, "PostToolUse"))
-    # search-tool-nudge is absent from BASE_SETTINGS, so this also proves the registrant
-    # ADDS a missing PostToolUse nudge rather than only preserving existing ones.
-    check("1: search-tool-nudge registered on PostToolUse",
-          SEARCH_NUDGE in cmds(d, "PostToolUse"))
+          any(c.endswith("/audit-pr-nudge.py") for c in cmds(d, "PostToolUse"))
+          and any(c.endswith("/shell-env-nudge.py") for c in cmds(d, "PostToolUse")))
+
+    # --- 8. THE FIRST POST-MIGRATION RUN DOES NOT DOUBLE-REGISTER --------------
+    # 🔴 The single most likely way to ship this fix broken: rewrite the commands
+    # but leave the append step comparing against the OLD strings, and every hook
+    # is registered a second time on the first post-migration run. All three
+    # accepted hooks-dir spellings are in the fixture, and two of them name hooks
+    # the append surface also owns — so a string-keyed append duplicates them.
+    # Asserted as a SET EQUALITY plus a LENGTH over the whole event: equality
+    # alone cannot see a duplicate.
+    post = cmds(d, "PostToolUse")
+    WB_EXPANDED = PY + " " + home + "/.claude/hooks/clawgate-writeback-guard.py"
+    SHELL_HOMEVAR = PY + " $HOME/.claude/hooks/shell-env-nudge.py"
+    check("8: PostToolUse holds exactly the three migrated hooks plus the two appended ones",
+          set(post) == {PY + " ~/.claude/hooks/audit-pr-nudge.py",
+                        SHELL_HOMEVAR, WB_EXPANDED, SEARCH_NUDGE, LEDGER})
+    check("8: no hook was double-registered", len(post) == 5)
+    check("8: the $HOME/ spelling was rewritten in place, not re-added",
+          post.count(SHELL_HOMEVAR) == 1
+          and PY + " ~/.claude/hooks/shell-env-nudge.py" not in post)
+    check("8: the expanded-home spelling was rewritten in place, not re-added",
+          post.count(WB_EXPANDED) == 1 and WRITEBACK not in post)
+    # ...and the hook that was genuinely ABSENT was appended, so the three checks
+    # above are about de-duplication and not about a pass that appended nothing.
+    check("8: the absent nudge WAS appended", SEARCH_NUDGE in post)
 
     # --- the agent activity ledger writer: FOUR events, one of them brand new --
-    # 🔴 SessionStart is absent from BASE_SETTINGS entirely, so this also proves
+    # 🔴 SessionStart is absent from the fixture entirely, so this also proves
     # the registrant CREATES an event array rather than only appending to one
     # that already exists.
     for ev in ("SessionStart", "UserPromptSubmit", "PostToolUse", "Stop"):
@@ -144,40 +275,45 @@ with tempfile.TemporaryDirectory() as tmp:
     # the assertion above is about this entry and not about a matcher-stripping
     # bug that would pass it vacuously.
     bash_entries = [e for e in d["hooks"]["PostToolUse"]
-                    if any(h.get("command") == SEARCH_NUDGE
+                    if any(h.get("command", "").endswith("/search-tool-nudge.py")
                            for h in e.get("hooks", []))]
     check("1: the Bash nudges keep their matcher",
           len(bash_entries) == 1 and bash_entries[0].get("matcher") == "Bash")
 
     # --- the clawgate write-back guard: PostToolUse + Stop ---------------------
+    # By SUFFIX on PostToolUse: the fixture spells that one with the expanded
+    # home path, and the point of this check is the EVENT, not the spelling.
     for ev in ("PostToolUse", "Stop"):
         check("1: clawgate-writeback-guard registered on " + ev,
-              WRITEBACK in cmds(d, ev))
+              any(c.endswith("/clawgate-writeback-guard.py") for c in cmds(d, ev)))
     # Stop-and-PostToolUse only. It must NOT reach SubagentStop: a subagent's turn
     # never reaches the operator, so it owes them no write-back — and the hook
     # refuses that event itself as well, belt and braces, because registration is
     # per-host mutable state.
     check("1: clawgate-writeback-guard NOT registered on SubagentStop",
-          WRITEBACK not in cmds(d, "SubagentStop"))
+          not any(c.endswith("/clawgate-writeback-guard.py") for c in cmds(d, "SubagentStop")))
     check("1: clawgate-writeback-guard NOT registered on SessionStart",
-          WRITEBACK not in cmds(d, "SessionStart"))
-    # 🔴 UNMATCHERED on PostToolUse, for a DIFFERENT reason than the ledger's: half
-    # of what this guard watches for is an Edit/Write/NotebookEdit tool call, i.e.
-    # exactly the work a `Bash` matcher would never show it. Asserted on the ENTRY,
-    # because the command string alone cannot show which matcher it was filed under.
-    wb_entries = [e for e in d["hooks"]["PostToolUse"]
-                  if any(h.get("command") == WRITEBACK for h in e.get("hooks", []))]
-    check("1: clawgate-writeback-guard PostToolUse entry carries NO matcher",
-          len(wb_entries) == 1 and "matcher" not in wb_entries[0])
+          not any(c.endswith("/clawgate-writeback-guard.py") for c in cmds(d, "SessionStart")))
+    # (The registrant's own PostToolUse entry for this guard is unmatchered; that
+    # is asserted in scenario 9 below, where the registrant creates it rather
+    # than finding it already in the fixture.)
 
     # Idempotency: a second run changes nothing and never duplicates.
+    before_second = open(settings, "rb").read()
     p2 = run(env)
     check("3: second run exit 0", p2.returncode == 0)
     check("3: second run reports no change", "no change" in p2.stdout)
+    # --- 4/d. ALREADY-MIGRATED INPUT IS A NO-OP THAT DOES NOT REWRITE THE FILE -
+    # 🔴 settings.json is the operator's per-host file (permissions live in it).
+    # The rewrite pass now runs on EVERY switch, so an unconditional write would
+    # re-dump it — reordering nothing but rewriting everything — forever.
+    check("3: second run left settings.json BYTE-IDENTICAL",
+          open(settings, "rb").read() == before_second)
     with open(settings) as f:
         d2 = json.load(f)
     check("3: no duplicate claude-notify on Stop", cmds(d2, "Stop").count(NOTIFY) == 1)
-    check("3: no duplicate search-tool-nudge", cmds(d2, "PostToolUse").count(SEARCH_NUDGE) == 1)
+    check("3: no duplicate search-tool-nudge",
+          len([c for c in cmds(d2, "PostToolUse") if c.endswith("/search-tool-nudge.py")]) == 1)
     check("3: clawgate Stop still single + present", cmds(d2, "Stop").count(CLAWGATE_STOP) == 1)
     check("3: no duplicate next-step-nudge on Stop", cmds(d2, "Stop").count(NEXT_STEP) == 1)
     check("3: Stop set unchanged by the second run",
@@ -186,14 +322,159 @@ with tempfile.TemporaryDirectory() as tmp:
     check("3: no duplicate clawgate-writeback-guard on Stop",
           cmds(d2, "Stop").count(WRITEBACK) == 1)
     check("3: no duplicate clawgate-writeback-guard on PostToolUse",
-          cmds(d2, "PostToolUse").count(WRITEBACK) == 1)
+          len([c for c in cmds(d2, "PostToolUse")
+               if c.endswith("/clawgate-writeback-guard.py")]) == 1)
     check("3: no duplicate agent-ledger on Stop", cmds(d2, "Stop").count(LEDGER) == 1)
     check("3: no duplicate agent-ledger on PostToolUse",
           cmds(d2, "PostToolUse").count(LEDGER) == 1)
+    check("3: bash-guard still single after the second run",
+          cmds(d2, "PreToolUse").count(BASH_GUARD) == 1)
 
     # Atomicity: no temp litter left in the dir, and the source uses os.replace.
     leftovers = [n for n in os.listdir(os.path.dirname(settings)) if n.startswith(".settings.")]
     check("5: no leftover temp files after atomic write", leftovers == [])
+
+# --- 9. bash-guard IS REWRITTEN, NEVER CREATED -------------------------------
+# 🔴 The two surfaces have different widths and this is where they are told
+# apart. This script owns bash-guard's INTERPRETER; it does not own its
+# REGISTRATION. A host that has deliberately no bash-guard entry must come back
+# with none — otherwise the rewrite surface has quietly become an append surface.
+with tempfile.TemporaryDirectory() as tmp:
+    home = os.path.join(tmp, "home")
+    os.makedirs(os.path.join(home, ".claude"))
+    settings = os.path.join(home, ".claude", "settings.json")
+    with open(settings, "w") as f:
+        json.dump({"hooks": {"Stop": [{"hooks": [{"type": "command", "command": TMUX_STOP}]}]}}, f, indent=2)
+
+    env = dict(os.environ)
+    env["HOME"] = home
+    env["DEVRC_HOOK_PYTHON"] = PY
+
+    p3 = run(env)
+    check("9: run on a bash-guard-less settings.json exits 0", p3.returncode == 0)
+    with open(settings) as f:
+        d3 = json.load(f)
+    all_cmds = [c for ev in d3.get("hooks", {}) for c in cmds(d3, ev)]
+    check("9: bash-guard was NOT registered where it was absent",
+          not any("bash-guard.py" in (c or "") for c in all_cmds))
+    # Anti-vacuity: the run DID do its normal work on that same file, so the
+    # check above is about bash-guard and not about a run that did nothing.
+    check("9: ...while the hooks it DOES own were registered",
+          NEXT_STEP in cmds(d3, "Stop") and LEDGER in cmds(d3, "SessionStart"))
+    # 🔴 THE SHAPE THE REGISTRANT WRITES, asserted where it actually writes it.
+    # Two PostToolUse entries carry NO matcher — the ledger (scoping it to Bash
+    # would stop the heartbeat through a long Read/Edit stretch, and
+    # `classify_status` lets `stale` beat `busy`) and the write-back guard (half
+    # of what it watches for IS an Edit/Write/NotebookEdit). The three nudges are
+    # about the shape of a Bash command, so they keep `matcher: "Bash"`. Asserted
+    # on the ENTRY: a command string cannot show which matcher it was filed under.
+    def matchers_for(data, event, suffix):
+        return [e.get("matcher", None) for e in data["hooks"][event]
+                if any((h.get("command") or "").endswith(suffix)
+                       for h in e.get("hooks", []))]
+
+    check("9: the ledger's PostToolUse entry carries NO matcher",
+          matchers_for(d3, "PostToolUse", "/agent-ledger-hook.py") == [None])
+    check("9: the write-back guard's PostToolUse entry carries NO matcher",
+          matchers_for(d3, "PostToolUse", "/clawgate-writeback-guard.py") == [None])
+    check("9: the three nudges are filed under matcher Bash",
+          matchers_for(d3, "PostToolUse", "/audit-pr-nudge.py") == ["Bash"]
+          and matchers_for(d3, "PostToolUse", "/shell-env-nudge.py") == ["Bash"]
+          and matchers_for(d3, "PostToolUse", "/search-tool-nudge.py") == ["Bash"])
+    # Every command this run wrote carries the pinned absolute interpreter — no
+    # bare `python3` survives anywhere in the file it produced.
+    check("9: every managed command it wrote names the absolute interpreter",
+          all(c.startswith(PY + " ") for c in all_cmds if c != TMUX_STOP))
+
+# --- 10. THE RECOGNISER IS CONSERVATIVE -------------------------------------
+# 🔴 Each command below names a MANAGED hook script under the hooks dir and must
+# STILL come back byte-identical, because one of the recogniser's three
+# conditions fails. They live on PreToolUse, the one event the append surface
+# never writes to, so "unchanged" is a clean claim about the rewrite pass alone.
+# Without these, dropping either the python-interpreter check or the start
+# anchor is a mutation no test can see.
+NOT_A_PYTHON_INTERP = "bash ~/.claude/hooks/bash-guard.py"
+NOT_AT_THE_START = "CLAUDE_HOST=wb python3 ~/.claude/hooks/bash-guard.py"
+QUOTED_PATH = "python3 '~/.claude/hooks/bash-guard.py'"
+NOT_UNDER_THE_HOOKS_DIR = "python3 ~/.claude/other/bash-guard.py"
+UNRECOGNISED = [NOT_A_PYTHON_INTERP, NOT_AT_THE_START, QUOTED_PATH,
+                NOT_UNDER_THE_HOOKS_DIR]
+
+with tempfile.TemporaryDirectory() as tmp:
+    home = os.path.join(tmp, "home")
+    os.makedirs(os.path.join(home, ".claude"))
+    settings = os.path.join(home, ".claude", "settings.json")
+    with open(settings, "w") as f:
+        json.dump({"hooks": {"PreToolUse": [
+            {"matcher": "Bash", "hooks": [{"type": "command", "command": c}]}
+            for c in UNRECOGNISED
+        ]}}, f, indent=2)
+
+    env = dict(os.environ)
+    env["HOME"] = home
+    env["DEVRC_HOOK_PYTHON"] = PY
+
+    p4 = run(env)
+    check("10: run exits 0", p4.returncode == 0)
+    with open(settings) as f:
+        d4 = json.load(f)
+    check("10: every unrecognised command came back BYTE-IDENTICAL",
+          cmds(d4, "PreToolUse") == UNRECOGNISED)
+    # Anti-vacuity: this run DID rewrite/append elsewhere in the same file, so
+    # the check above is about the recogniser and not about a run that no-oped.
+    check("10: ...while the run did its normal work on the same file",
+          NEXT_STEP in cmds(d4, "Stop"))
+
+# --- 11. A PYTHON BUMP: REWRITES WITH NO APPENDS ----------------------------
+# 🔴 FOUND BY A SURVIVING MUTANT, not by review. Weakening the write condition
+# from `not added and not rewritten` to `not added` survived every check above,
+# because in all of them the first run appends something. But the steady state
+# after this migration is the OPPOSITE: every hook is already registered, and
+# the ONLY thing that changes is the interpreter — on every nixpkgs python bump,
+# forever. Under that mutant the run prints "no change" and the stale store path
+# stays in settings.json, which is the 127 window reopening the day that path is
+# garbage-collected.
+PY2 = "/nix/store/1111111111111111111111111111111-python3-3.12.15/bin/python3.12"
+
+with tempfile.TemporaryDirectory() as tmp:
+    home = os.path.join(tmp, "home")
+    os.makedirs(os.path.join(home, ".claude"))
+    settings = os.path.join(home, ".claude", "settings.json")
+    with open(settings, "w") as f:
+        json.dump({"hooks": {"PreToolUse": [
+            {"matcher": "Bash", "hooks": [{"type": "command", "command": OLD_BASH_GUARD}]}
+        ]}}, f, indent=2)
+
+    env = dict(os.environ)
+    env["HOME"] = home
+    env["DEVRC_HOOK_PYTHON"] = PY
+    check("11: setup run exits 0", run(env).returncode == 0)
+    # Everything is registered now, so a re-run at the SAME python is a no-op...
+    p5 = run(env)
+    check("11: re-run at the same python reports no change", "no change" in p5.stdout)
+
+    # ...and a re-run at a BUMPED python must rewrite every command, with nothing
+    # left to append.
+    env["DEVRC_HOOK_PYTHON"] = PY2
+    p6 = run(env)
+    check("11: the bumped run exits 0", p6.returncode == 0)
+    check("11: the bumped run did NOT report 'no change'",
+          "no change" not in p6.stdout)
+    check("11: the bumped run says it re-pinned the interpreter",
+          PY2 in p6.stdout)
+    check("11: the bumped run registered NOTHING — rewrites only",
+          "registered hooks:" not in p6.stdout)
+    with open(settings) as f:
+        d5 = json.load(f)
+    every = [c for ev in d5.get("hooks", {}) for c in cmds(d5, ev)]
+    check("11: every command now names the BUMPED interpreter",
+          every and all(c.startswith(PY2 + " ") for c in every))
+    check("11: not one command still names the old interpreter",
+          not any(c.startswith(PY + " ") for c in every))
+    # Anti-vacuity: the file still holds the hooks it held before, in the same
+    # number — a rewrite that emptied the file would satisfy an `all()` too.
+    check("11: bash-guard is still registered exactly once",
+          cmds(d5, "PreToolUse").count(PY2 + " ~/.claude/hooks/bash-guard.py") == 1)
 
 with open(SCRIPT) as f:
     src = f.read()

--- a/scripts/claude-hooks/tests/test_registrar_activation.py
+++ b/scripts/claude-hooks/tests/test_registrar_activation.py
@@ -37,6 +37,7 @@ WHAT THIS FILE IS FOR
 
 Fixtures are synthetic. This repo is public: no real paths, hostnames or task titles.
 """
+import ast
 import json
 import os
 import re
@@ -52,10 +53,17 @@ HOME_NIX = ROOT / "nix" / "home.nix"
 
 BASH = shutil.which("bash") or "/bin/bash"
 
-NEXT_STEP = "python3 ~/.claude/hooks/next-step-nudge.py"
-NOTIFY = "python3 ~/.claude/hooks/claude-notify.py"
-LEDGER = "python3 ~/.claude/hooks/agent-ledger-hook.py"
-WRITEBACK = "python3 ~/.claude/hooks/clawgate-writeback-guard.py"
+# The interpreter the registrant writes into every managed hook command. Pinned
+# to a synthetic literal via $DEVRC_HOOK_PYTHON so the expectations below do not
+# depend on whichever interpreter happens to run pytest; the UNPINNED resolution
+# is covered behaviourally by its own test at the bottom of section 1.
+HOOK_PY = "/nix/store/0000000000000000000000000000000-python3-3.12.14/bin/python3.12"
+
+NEXT_STEP = HOOK_PY + " ~/.claude/hooks/next-step-nudge.py"
+NOTIFY = HOOK_PY + " ~/.claude/hooks/claude-notify.py"
+LEDGER = HOOK_PY + " ~/.claude/hooks/agent-ledger-hook.py"
+WRITEBACK = HOOK_PY + " ~/.claude/hooks/clawgate-writeback-guard.py"
+BASH_GUARD = HOOK_PY + " ~/.claude/hooks/bash-guard.py"
 CLAWGATE_STOP = "/home/zach/.claude/clawgate-stop-hook.sh"
 TMUX_STOP = "~/.config/tmux/task-hook.sh"
 
@@ -103,10 +111,18 @@ def make_home(tmp_path, settings, name="home"):
     return home
 
 
-def run_activation(home, registrar=REGISTRAR, python=None, args=None):
-    """Drive the SHIPPED wrapper exactly as home.nix drives it."""
+def run_activation(home, registrar=REGISTRAR, python=None, args=None,
+                   hook_python=HOOK_PY):
+    """Drive the SHIPPED wrapper exactly as home.nix drives it.
+
+    `hook_python=None` drops the $DEVRC_HOOK_PYTHON override so the registrant
+    resolves the interpreter the way it does in production.
+    """
     env = dict(os.environ)
     env["HOME"] = str(home)
+    env.pop("DEVRC_HOOK_PYTHON", None)
+    if hook_python is not None:
+        env["DEVRC_HOOK_PYTHON"] = hook_python
     if args is None:
         args = [str(registrar), python or sys.executable]
     return subprocess.run(
@@ -199,7 +215,12 @@ def test_unrelated_settings_content_is_untouched(tmp_path):
         for e in data["hooks"]["PreToolUse"]
         for h in e.get("hooks", [])
     ]
-    assert pre == ["python3 ~/.claude/hooks/bash-guard.py"], pre
+    # 🔴 bash-guard's INTERPRETER is normalised (a bare `python3` here dies with
+    # 127 mid-switch, and a PreToolUse hook exiting 127 fails OPEN) while its
+    # REGISTRATION is left exactly as it was: still one entry, still the only
+    # one on this event. Two surfaces, two widths — see the registrant's
+    # docstring. Asserted as a whole-list equality so an extra entry fails it.
+    assert pre == [BASH_GUARD], pre
 
 
 def test_a_settings_file_that_already_has_the_nudge_is_left_byte_identical(tmp_path):
@@ -227,6 +248,80 @@ def test_no_temp_files_are_left_beside_settings_json(tmp_path):
     assert p.returncode == 0 and NEXT_STEP in stop_commands(home), p.stderr
     leftovers = [n for n in os.listdir(home / ".claude") if n != "settings.json"]
     assert leftovers == [], leftovers
+
+
+def test_a_pre_migration_settings_file_has_every_interpreter_pinned(tmp_path):
+    """🔴 THE 127 WINDOW, at the seam that actually runs on every switch.
+
+    `home-manager switch` updates ~/.nix-profile as remove-then-install, so for
+    ~1s the live generation is a partial closure with NO python3 on it (measured
+    on this host: 337 binaries against 625 in the final one). A hook registered
+    as a bare `python3 …` firing in that window dies with
+    `python3: command not found` — and bash-guard is a PreToolUse hook whose 127
+    is classified NON-BLOCKING, so the guard fails OPEN exactly there.
+
+    The fixture is the shape both hosts were in before this change.
+    """
+    home = make_home(
+        tmp_path,
+        settings_with([TMUX_STOP, "python3 ~/.claude/hooks/claude-notify.py"]),
+    )
+
+    p = run_activation(home)
+
+    assert p.returncode == 0, p.stderr
+    data = json.loads(settings_bytes(home))
+    commands = [
+        h.get("command")
+        for arr in data["hooks"].values()
+        for e in arr
+        for h in e.get("hooks", [])
+    ]
+    unpinned = [c for c in commands if c.startswith("python3 ")]
+    assert unpinned == [], (
+        "these hook commands still start with a bare `python3`, so they die with "
+        "127 during the switch's profile window: " + repr(unpinned)
+    )
+    # Anti-vacuity: the file really does still carry hooks, and one of them is
+    # the guard whose 127 fails open.
+    assert BASH_GUARD in commands, commands
+    assert HOOK_PY in p.stdout, p.stdout
+
+
+def test_the_interpreter_is_resolved_through_the_blinking_symlink(tmp_path):
+    """🔴 THE RESOLUTION ITSELF, with $DEVRC_HOOK_PYTHON deliberately UNSET.
+
+    Every other test here pins the interpreter to a literal, which would leave
+    `os.path.realpath(sys.executable)` — the whole mechanism — untested. Run by
+    hand, the registrant's sys.executable is `~/.nix-profile/bin/python3`: a
+    symlink that BLINKS during a switch, which is the bug. Writing that path
+    would close nothing.
+
+    Launching through a symlink reproduces it hermetically: CPython leaves
+    sys.executable as the path it was invoked by, so a registrant that skipped
+    the realpath would write the symlink and this goes red.
+    """
+    blink = tmp_path / "blinking-profile" / "bin"
+    blink.mkdir(parents=True)
+    link = blink / "python3"
+    link.symlink_to(sys.executable)
+    resolved = os.path.realpath(link)
+    assert resolved != str(link), "fixture must not resolve to itself"
+
+    home = make_home(tmp_path, settings_with([TMUX_STOP]))
+    p = run_activation(home, python=str(link), hook_python=None)
+
+    assert p.returncode == 0, p.stderr
+    written = stop_commands(home)
+    nudges = [c for c in written if c.endswith("/next-step-nudge.py")]
+    assert len(nudges) == 1, written
+    interpreter = nudges[0].split(" ", 1)[0]
+    assert interpreter == resolved, (
+        "the registrant wrote %r; it must write the REALPATH %r, never the "
+        "symlink it was invoked through" % (interpreter, resolved)
+    )
+    assert os.path.isabs(interpreter), interpreter
+    assert str(link) not in nudges[0], nudges[0]
 
 
 # --------------------------------------------------------------------------- #
@@ -364,6 +459,88 @@ def test_home_nix_deploys_the_registrar_itself():
         "comments for weeks, which is why nothing ever registered the hooks"
     )
     assert REGISTRAR.exists()
+
+
+# --- the REWRITE surface's managed set, DERIVED and pinned two-way ----------- #
+def registrar_literal(name):
+    """A module-level literal out of the registrar, read with `ast` — never by
+    importing it, because importing runs it against the operator's real
+    ~/.claude/settings.json. `frozenset({...})` is unwrapped to its set literal."""
+    tree = ast.parse(REGISTRAR.read_text(), filename=str(REGISTRAR))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == name for t in node.targets):
+            continue
+        value = node.value
+        if isinstance(value, ast.Call) and getattr(value.func, "id", "") == "frozenset":
+            value = value.args[0]
+        return ast.literal_eval(value)
+    raise AssertionError("%s is not a module-level literal in %s" % (name, REGISTRAR))
+
+
+def test_the_managed_hook_set_is_pinned_two_way_against_home_nix():
+    """🔴 THE REWRITE SURFACE'S LEDGER — the set of scripts whose interpreter the
+    registrant will rewrite, pinned against the `home.file.".claude/hooks/*.py"`
+    entries it is derived from. Same idiom as drift-check.sh's nix/pkgs scan:
+    a literal a human reviewed, checked against the tree it claims to describe.
+
+    Fails when the set GROWS — a new hook lands in home.nix and nobody decides
+    whether its interpreter is managed, which is how the 127 window reopens for
+    exactly one hook — and when it SHRINKS.
+
+    It is a literal in the registrant rather than a scan because the DEPLOYED
+    registrant is a /nix/store copy with no repo checkout to read; the price of
+    that is one line per new hook, and this test is what charges it.
+    """
+    deployed = {n for n in home_nix_deploys() if n.endswith(".py")}
+    managed = set(registrar_literal("MANAGED_HOOK_SCRIPTS"))
+    libraries = set(registrar_literal("HOOK_LIBRARY_MODULES"))
+    registrar = registrar_literal("REGISTRAR_SCRIPT")
+
+    # Positive control: a parser that found nothing would make this vacuous.
+    assert len(deployed) >= 8, deployed
+    assert "bash-guard.py" in deployed, deployed
+
+    assert deployed == managed | libraries | {registrar}, (
+        "nix/home.nix's .claude/hooks/*.py set no longer matches the registrant's "
+        "ledger. Unaccounted (deployed, but neither managed nor explicitly "
+        "excluded): %r. Stale (claimed, but not deployed): %r. A new hook must be "
+        "added to MANAGED_HOOK_SCRIPTS — or, if it is a library module that is "
+        "never invoked as a hook, to HOOK_LIBRARY_MODULES."
+        % (sorted(deployed - (managed | libraries | {registrar})),
+           sorted((managed | libraries | {registrar}) - deployed))
+    )
+
+
+def test_the_two_exclusions_are_explicit_and_justified():
+    """🔴 The exclusions must be a DECISION, not an accident of omission.
+
+    A hook missing from MANAGED_HOOK_SCRIPTS and from every exclusion list would
+    fail the pin above; these assertions add the other half — that the things
+    excluded really are excluded for the reason claimed, and that no script is
+    both managed and excluded.
+    """
+    managed = set(registrar_literal("MANAGED_HOOK_SCRIPTS"))
+    libraries = set(registrar_literal("HOOK_LIBRARY_MODULES"))
+    registrar = registrar_literal("REGISTRAR_SCRIPT")
+
+    assert managed & libraries == set(), managed & libraries
+    assert registrar not in managed, registrar
+    assert registrar == REGISTRAR.name, registrar
+    # A library module is one that nothing ever registers AS a hook — so none of
+    # them may appear in the registrant's own command tables.
+    assert libraries & registrar_registers() == set(), (
+        "a module excluded as a never-invoked library IS in the command tables: "
+        + repr(sorted(libraries & registrar_registers()))
+    )
+    # ...and every hook the registrant registers must be one it will also keep
+    # pinned, or the append surface would write a command the rewrite surface
+    # refuses to maintain.
+    assert registrar_registers() <= managed, (
+        "registered but not in the managed set, so its interpreter would never "
+        "be re-pinned: " + repr(sorted(registrar_registers() - managed))
+    )
 
 
 def activation_block():


### PR DESCRIPTION
## The bug

`home-manager switch` updates `~/.nix-profile` as **remove-then-install**, so every switch produces **two** profile generations. The intermediate one is a partial closure with **no `python3`** on it. Measured on this host:

| store path | binaries | `python3` |
|---|---|---|
| `…lrhqph9dw99whm3i1w22ngjsxydchx00-profile` | 337 | **absent** |
| `…7msd1dxhwg8g4800hf3wb72ar5i4yj8p-profile` | 625 | present |

Every Claude Code hook is registered in `~/.claude/settings.json` as a bare `python3 ~/.claude/hooks/X.py`, so a hook firing inside that ~1s window dies with:

```
/bin/sh: line 1: python3: command not found
```

Confirmed by correlating hook-error timestamps in `~/.claude/projects/**/*.jsonl` against `~/.local/state/nix/profiles/profile-*-link` mtimes — four independent matches to the second. It has hit **16 sessions across five repos** since July.

**The serious half:** `bash-guard.py` is a `PreToolUse` hook registered the same way, and a 127 exit is classified **non-blocking**. During that window the guard **fails OPEN** — `git add -A` / `git reset --hard` pass unchecked.

## The fix

`register-nudge-hook.py` now writes an **absolute `/nix/store` interpreter** into every managed hook command. Store paths are immutable and GC-rooted by the current home-manager generation, so the window closes completely. No sudo, no system-package change, and **no plumbing change to `home.nix` or the activation wrapper** — the registrar already runs under `${pkgs.python312}/bin/python3` at activation, and `os.path.realpath(sys.executable)` converges on the same immutable path from both invocation routes. Verified for both rather than assumed:

```
$ python3 -c 'import sys,os; print(sys.executable); print(os.path.realpath(sys.executable))'
/home/zach/.nix-profile/bin/python3                                  # the blinking symlink
/nix/store/sgr5…-python3-3.12.14/bin/python3.12                      # → immutable

$ /nix/store/sgr5…-python3-3.12.14/bin/python3 -c '…'                # the activation route
/nix/store/sgr5…-python3-3.12.14/bin/python3
/nix/store/sgr5…-python3-3.12.14/bin/python3.12                      # → same path
```

`$DEVRC_HOOK_PYTHON` overrides it so tests inject a deterministic path.

## Two surfaces, deliberately different widths

This is the crux, and it is spelled out in code, in comments and in tests:

* **REWRITE (new, wide)** — every hook entry on every event whose command invokes a devrc-managed hook script, **`bash-guard` included**. Only the interpreter token moves. Position in the array, `matcher`, `type` and every foreign key survive verbatim. A command that merely *contains* the word python, or names a script outside the managed set, or carries a leading env assignment, comes back **byte-identical**.
* **APPEND (existing, narrow)** — the same command tables as before. `bash-guard` is **not** in them and must never be: the registrar owns its *interpreter*, not its *registration*. A host with no `bash-guard` entry comes back with none.

The managed set is derived from `nix/home.nix`'s `home.file.".claude/hooks/*.py"` entries and **pinned two-way by a test**, mirroring `drift-check.sh`'s `nix/pkgs` idiom — a hook added to `home.nix` without being classified fails the suite. `guard_core.py` / `agent_ledger.py` (library modules, never invoked as hooks) and the registrar itself are excluded **explicitly**, and the exclusions are asserted, not incidental.

The append surface now keys on the **script**, not the exact command string. That is what stops the first post-migration run double-registering everything — and it closes a pre-existing hazard on the way: a host spelling the hooks dir `$HOME/…` got its hooks registered twice.

`settings.json` is still written **only when something changed** (the rewrite pass runs on every switch; an unconditional write would re-dump the operator's per-host permissions file forever), and the atomic tempfile + `os.replace` write is unchanged.

## Symptom reproduction — not just a green suite

Both command strings driven through `/bin/sh -c` with an **empty `PATH`** — precisely the state the intermediate profile creates:

```
--- OLD: python3 ~/.claude/hooks/bash-guard.py
exit   : 127
output : /bin/sh: line 1: python3: command not found

--- NEW: /nix/store/sgr5…-python3-3.12.14/bin/python3.12 ~/.claude/hooks/bash-guard.py
exit   : 0
output : <empty>          (allow)
```

Positive control, same empty `PATH`, feeding the guard a command it must **deny**:

```
NEW string, "git add --all" -> exit 0, {"permissionDecision": "deny", …}   ← the guard RAN
OLD string, "git add --all" -> exit 127, python3: command not found        ← FAILS OPEN
```

## Tests — red at base, green at HEAD

Base = `f94ebd5`.

| suite | at base | at HEAD |
|---|---|---|
| `test_register_nudge_hook.py` | **35 FAIL** / 42 PASS, exit 1 | 0 FAIL / **77 PASS**, exit 0 |
| `test_registrar_activation.py` | **10 failed** / 11 passed | **21 passed** |

Red-at-base was measured by running the *new* test files against a `git archive` extraction of `f94ebd5`, not by reasoning.

New coverage:

* the `bash-guard` rewrite, with position / `matcher` / entry-level and hook-level foreign keys all pinned;
* set equality over each event after a fully **pre-migration** fixture — no growth, no double registration — with all three hooks-dir spellings present;
* four unrecognised commands asserted byte-identical (non-python interpreter, leading env assignment, quoted path, path outside the hooks dir);
* an already-migrated file left **byte-identical** with no rewrite;
* a python **bump** — rewrites with zero appends, which is the steady state after this lands — **found by a surviving mutant, not by review**;
* the two-way managed-set pin against `nix/home.nix`, plus explicit assertions that the exclusions are disjoint and justified;
* the realpath resolution covered **behaviourally**, by launching the registrar through a symlink (CPython leaves `sys.executable` as the path it was invoked by — exactly the blinking profile symlink).

Existing set-equality assertions were updated to the new normalised strings, **not** weakened into substring checks.

**Mutation sweep** (under `PYTHONDONTWRITEBYTECODE=1`, since CPython's `.pyc` cache is keyed on whole-second mtime + size): 6 of 7 killed. The survivor is **equivalent** — the start anchor is spelled twice (`^` in the pattern and `re.match`), so removing either alone changes nothing; removing **both** is killed by the byte-identity check.

## Stale claims corrected

A comment is a claim. The registrar docstring and `register-hooks-activation.sh`'s contract both asserted *"strictly APPEND-ONLY / never rewrites"* — now false, and a maintainer reading it would delete the rewrite path. Three `nix/home.nix` comments quoting the old `python3 …` command strings are corrected too.

## Gate

`scripts/gate.sh` → `GATE: RESULT=PASS exit=0` (pytest and node tiers both PASS, both agreeing with their own `RESULT:` line).

## Not deployed

Both hosts still carry the bare-`python3` registrations. The fix takes effect on the next `home-manager switch`, which runs the new registrar. Not merged, not switched, not shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
