### PR TITLE
fix(hooks): a home-manager ROLLBACK re-registers every hook FOREVER — and the test seam grew settings.json without bound

### DIFF
--- a/scripts/claude-hooks/clawgate-writeback-guard.py
+++ b/scripts/claude-hooks/clawgate-writeback-guard.py
@@ -1261,9 +1261,20 @@ def dismiss_cmd(task_id, session_id):
     cannot see its own hook payload, so a command it has to fill in a session id for
     is a command it cannot run — which is how the previous escape ("say so and stop")
     ended up being no escape at all.
+
+    🔴 The interpreter is `sys.executable`, not a bare `python3` — this was the last
+    bare-`python3` spelling of a managed hook left in the tree after #609 pinned the
+    registrations in ~/.claude/settings.json. It is free and exact: this hook is
+    already RUNNING under the pinned absolute interpreter, so `sys.executable` is
+    that path. A bare name would be resolved from PATH, and PATH has no python3 for
+    the ~1s of every `home-manager switch` in which the intermediate profile
+    generation is a partial closure — the model would get `command not found` for
+    the one command that clears the block. The fallback covers an embedded
+    interpreter, where sys.executable is empty; nothing here runs that way.
     """
-    return ("python3 ~/.claude/hooks/clawgate-writeback-guard.py --dismiss %d "
-            "--session %s" % (int(task_id), _sanitize(session_id)))
+    return ("%s ~/.claude/hooks/clawgate-writeback-guard.py --dismiss %d "
+            "--session %s" % (sys.executable or "python3", int(task_id),
+                              _sanitize(session_id)))
 
 
 def missing_text(task_id, first_read_ts, session_id=""):

--- a/scripts/claude-hooks/register-hooks-activation.sh
+++ b/scripts/claude-hooks/register-hooks-activation.sh
@@ -20,20 +20,31 @@
 #      "failed switch" incident class (CLAUDE.md → Git discipline). Every
 #      failure path therefore warns on stderr and returns 0.
 #   2. IT SAYS WHAT IT DID. The registrar's own report ("registered hooks: …"
-#      / "… no change") is echoed line by line, prefixed. A silent activation
-#      step is how the original failure went unnoticed for a full deploy cycle.
+#      / "removed duplicate hook registrations: …" / "… no change") is echoed
+#      line by line, prefixed. A silent activation step is how the original
+#      failure went unnoticed for a full deploy cycle. 🔴 The capture is
+#      `2>&1`, which is load-bearing: the registrar sends its WARNINGs to
+#      stderr — a rejected $DEVRC_HOOK_PYTHON, a managed hook command in a
+#      shape it cannot pin, a duplicate registration it declined to remove —
+#      and this is the only thing that puts them in the switch log. Never
+#      split the streams here or those warnings become invisible again.
 #   3. IT DECIDES NOTHING ABOUT settings.json. Every read/merge/write belongs
-#      to the registrar. That registrar has TWO surfaces of different widths —
+#      to the registrar. That registrar has THREE surfaces of different widths:
 #      an APPEND surface (its own command tables, never touching a hook it does
-#      not own, so the clawgate Stop hook that drives remote approval survives)
-#      and, since 2026-08-20, a narrow REWRITE surface that normalises the
-#      INTERPRETER TOKEN of a devrc-managed hook command to an absolute
-#      /nix/store python. Read its module docstring before changing either; the
-#      claim this file used to make — "strictly APPEND-ONLY" — is no longer
-#      true and deleting the rewrite path would silently reopen the failure it
-#      closes (a hook firing mid-switch dies with `python3: command not found`,
-#      and bash-guard fails OPEN when it does). This wrapper adds no second
-#      writer — it must never grow one.
+#      not own, so the clawgate Stop hook that drives remote approval survives);
+#      a wide REWRITE surface that normalises the INTERPRETER TOKEN of a
+#      devrc-managed hook command to an absolute /nix/store python; and a
+#      narrow DE-DUP surface that deletes a second registration of a script it
+#      owns on the same event under the same matcher, keeping the first. Read
+#      its module docstring before changing any of them; the claim this file
+#      used to make — "strictly APPEND-ONLY" — is no longer true and deleting
+#      the rewrite path would silently reopen the failure it closes (a hook
+#      firing mid-switch dies with `python3: command not found`, and bash-guard
+#      fails OPEN when it does). The de-dup path is what makes a
+#      `home-manager rollback` — which re-runs an OLDER registrar that cannot
+#      see the pinned spelling and appends a second copy of everything —
+#      recoverable rather than permanent. This wrapper adds no second writer —
+#      it must never grow one.
 #
 #      🔴 The interpreter the registrar writes is derived from its OWN
 #      sys.executable, so the `[python]` argument below is load-bearing beyond

--- a/scripts/claude-hooks/register-nudge-hook.py
+++ b/scripts/claude-hooks/register-nudge-hook.py
@@ -5,21 +5,30 @@ settings.json is per-host and unmanaged (holds permissions/allowlists/secrets), 
 hook *scripts* are symlinked by home-manager but their *registration* is applied by
 running this once per host.
 
-🔴 THIS SCRIPT HAS **TWO** SURFACES, AND THEY ARE DELIBERATELY DIFFERENT WIDTHS.
+🔴 THIS SCRIPT HAS **THREE** SURFACES, AND THEY ARE DELIBERATELY DIFFERENT WIDTHS.
 Until 2026-08-20 there was only the first, and its docstring said "strictly
-APPEND-ONLY / never rewrites". That is no longer true — read both before editing:
+APPEND-ONLY / never rewrites". That is no longer true — read all three before editing:
 
-  * APPEND surface (NARROW, unchanged): the command tables below. An entry is added
-    only when its exact command string is absent from that event's existing entries.
-    Nothing else is ever appended. In particular bash-guard is NOT in these tables and
-    must never be: this script does not own its registration, only its interpreter, so
-    if a host has no bash-guard entry it must come back with no bash-guard entry.
-  * REWRITE surface (WIDE, new): every hook entry on every event whose command invokes
+  * APPEND surface (NARROW, oldest): the command tables below. An entry is added
+    only when that event does not already invoke the script. Nothing else is ever
+    appended. In particular bash-guard is NOT in these tables and must never be:
+    this script does not own its registration, only its interpreter, so if a host
+    has no bash-guard entry it must come back with no bash-guard entry.
+  * REWRITE surface (WIDE): every hook entry on every event whose command invokes
     a devrc-managed hook script gets its INTERPRETER TOKEN normalised to an absolute
     /nix/store python — bash-guard INCLUDED. Only that token changes. The entry keeps
     its position in its array, its `matcher`, its `type` and every other key verbatim,
     and a command that does not resolve to a managed hook script comes back
     byte-identical.
+  * DE-DUP surface (NARROWEST, newest): a second registration of the SAME managed
+    script on the SAME event under the SAME matcher is deleted, keeping the FIRST
+    occurrence with its position and every key it arrived with. It is narrower
+    than the append surface in one direction and equal in the other: it removes
+    only an entry of EXACTLY the shape this script writes (no foreign key, one
+    hook, no arguments after the script path) AND only for a script this script
+    registers — so a doubled bash-guard, whose registration belongs to the host,
+    is reported rather than removed. Anything still doubled after the pass is
+    named on stderr. See "WHY THE DE-DUP EXISTS" below.
 
 WHY THE REWRITE EXISTS — the 127 window.
 `home-manager switch` updates ~/.nix-profile as remove-then-install, so every switch
@@ -34,6 +43,18 @@ non-blocking, so during that window the guard FAILS OPEN and `git add -A` /
 `git reset --hard` pass unchecked. A /nix/store path is immutable and GC-rooted by the
 current home-manager generation, so an absolute one closes the window completely.
 
+WHY THE DE-DUP EXISTS — a home-manager ROLLBACK re-runs an OLDER registrar.
+`home-manager rollback` / `--switch-generation` (and a hand-run from an older
+checkout) runs the PREVIOUS registrar against a settings.json this one has already
+pinned. That older code keyed "is it already registered?" on the exact string
+`python3 ~/…`, does not find it, and appends a SECOND copy of every hook it owns —
+13 measured. Re-running THIS registrar then normalises both copies to identical
+strings, and because the append pass only asks "is this script registered on this
+event", it sees the hook as present and BOTH copies survive: every managed hook fires
+twice, forever. Duplicate ledger rows, double notifications, and the write-back guard
+— the only one that can BLOCK — running twice per event. So the file must HEAL, not
+merely fail to get worse.
+
 The interpreter is `os.path.realpath(sys.executable)` (override: $DEVRC_HOOK_PYTHON,
 which exists so tests can inject a deterministic path). Both invocation routes converge
 on the same immutable path, VERIFIED on this host rather than assumed:
@@ -43,6 +64,13 @@ on the same immutable path, VERIFIED on this host rather than assumed:
     ~/.nix-profile/bin/python3 — the blinking symlink — and realpath resolves it to the
     same /nix/store/…-python3-3.12.14/bin/python3.12.
 So no plumbing change to home.nix or to register-hooks-activation.sh was needed.
+
+🔴 $DEVRC_HOOK_PYTHON IS A TEST SEAM WITH PRODUCTION REACH, so it is VALIDATED.
+Activation inherits the operator's environment, so an exported override is a value
+this script would otherwise write verbatim into all 14 hook commands. An override
+that is relative, missing, non-executable, or not a single `python*` token is
+REJECTED with a warning and the resolved fallback is used instead — see
+`hook_python`, which also explains why it falls back rather than hard-failing.
 
 Registers (APPEND surface):
   * PostToolUse(Bash): audit-pr-nudge.py, shell-env-nudge.py, search-tool-nudge.py
@@ -83,16 +111,17 @@ call. That ordering is now reversed and pinned by a test.
 must never disturb: the fuzzyclaw tmux writer (~/.config/tmux/task-hook.sh), the
 clawgate stop hook (drives remote approval) and claude-notify.py (drives turn-finished
 notifications). Clobbering any of them is a serious regression, so the APPEND surface
-never reorders or removes anything, and the REWRITE surface never touches a command it
-cannot prove is a managed hook invocation — the tmux and clawgate hooks are `.sh`
-scripts and are left byte-identical. tests/test_register_nudge_hook.py asserts every
+never reorders or removes anything, the REWRITE surface never touches a command it
+cannot prove is a managed hook invocation (the tmux and clawgate hooks are `.sh`
+scripts and are left byte-identical), and the DE-DUP surface deletes only an entry
+whose every key it can account for. tests/test_register_nudge_hook.py asserts every
 owner coexists afterwards, as a SET EQUALITY so the assertion fails when the set grows
 as well as when it shrinks.
 
 🔴 THE FIRST POST-MIGRATION RUN MUST NOT DOUBLE-REGISTER EVERY HOOK — the readiest way
 to ship this fix broken. Two things prevent it, and only the second is sufficient:
-  * the rewrite pass runs FIRST, so by the time the append pass reads the file the
-    commands already carry the new interpreter;
+  * the rewrite pass runs before the append pass, so by the time the append pass reads
+    the file the commands already carry the new interpreter;
   * and the append pass keys on the SCRIPT (`managed_script_of`), not on the exact
     command string. Exact-string keying was already fragile before this change — a
     host spelling the hooks dir `$HOME/…` got the hook registered twice — and the
@@ -101,6 +130,14 @@ to ship this fix broken. Two things prevent it, and only the second is sufficien
     for both surfaces, so they cannot disagree.
 tests/test_register_nudge_hook.py drives a fully pre-migration settings.json and
 asserts SET EQUALITY over each event afterwards, which fails on a duplicate.
+
+🔴 CONSERVATIVE MATCHING IS NOT SILENT MATCHING. `python3 -u ~/…`, a leading
+`PYTHONPATH=…`, `${HOME}/…`, a quoted path and a `…; …` compound all come back
+byte-identical from the rewrite pass — correctly, since this script cannot prove it
+owns them — and each one stays in the 127 window. This whole change exists because a
+silent failure ran for months, so every command that NAMES a managed hook script and
+is not in the pinnable form is reported on stderr, which the activation wrapper
+relays into the switch log.
 
 next-step-nudge is registered on Stop ONLY, not SubagentStop: a subagent's turn ends
 without ever reaching the operator, so it owes them no next step. The hook refuses that
@@ -116,25 +153,14 @@ SETTINGS = os.path.expanduser("~/.claude/settings.json")
 HOME = os.path.expanduser("~")
 
 
-def hook_python():
-    """The absolute interpreter to write into every managed hook command.
+def warn(msg):
+    """Every diagnostic goes to stderr under one greppable token.
 
-    $DEVRC_HOOK_PYTHON is the test seam — without it a test would have to assert
-    against whatever interpreter pytest happened to run under. The fallback to a
-    bare name only fires when sys.executable is empty (an embedded interpreter),
-    which is not a configuration this ever runs in.
+    register-hooks-activation.sh captures the registrar with `2>&1` and relays the
+    block line by line into the switch log, so a warning here is something the
+    operator actually sees on the next `home-manager switch`.
     """
-    override = os.environ.get("DEVRC_HOOK_PYTHON")
-    if override:
-        return override
-    return os.path.realpath(sys.executable) if sys.executable else "python3"
-
-
-PYTHON = hook_python()
-
-
-def with_python(path):
-    return PYTHON + " " + path
+    print("WARNING " + msg, file=sys.stderr)
 
 
 # --------------------------------------------------------------------------- #
@@ -189,9 +215,9 @@ _MANAGED_CMD_RE = re.compile(
 def managed_script_of(cmd):
     """The devrc-managed hook script this command invokes, or None.
 
-    THE single recogniser — both surfaces key on it, so "what counts as a
+    THE single recogniser — all three surfaces key on it, so "what counts as a
     managed hook command" is answered in one place and cannot disagree between
-    the rewrite pass and the append pass.
+    the rewrite pass, the de-dup pass and the append pass.
 
     Conservative on purpose — three independent conditions must all hold:
       1. the command is `<one-token> <hooks-dir-path>[ args]`;
@@ -213,6 +239,18 @@ def managed_script_of(cmd):
     return m.group("base")
 
 
+def bare_managed_command(cmd):
+    """A managed hook invocation with NOTHING after the script path.
+
+    The de-dup surface removes only these. `<interp> <path> --flag` names the same
+    script but is a DIFFERENT configuration — somebody typed those arguments — and
+    deleting it would be this script overwriting a decision it did not make.
+    """
+    if managed_script_of(cmd) is None:
+        return False
+    return _MANAGED_CMD_RE.match(cmd).end() == len(cmd)
+
+
 def normalized_command(cmd):
     """Rewrite ONLY the interpreter token of a devrc-managed hook invocation.
 
@@ -222,6 +260,112 @@ def normalized_command(cmd):
     if managed_script_of(cmd) is None:
         return cmd
     return PYTHON + cmd[_MANAGED_CMD_RE.match(cmd).end("interp"):]
+
+
+# The probe the interpreter self-checks below are built from: the first managed
+# script under the first accepted hooks-dir prefix. COMPUTED, never spelled out —
+# tests/test_registrar_activation.py parses this file for a hooks-dir path literal
+# and reads every hit as a registration this script performs, so a literal here
+# would read as one.
+_PROBE_SCRIPT = sorted(MANAGED_HOOK_SCRIPTS)[0]
+
+
+def unusable_interpreter(interp):
+    """Why `interp` may not be written into a hook command — or None if it may.
+
+    🔴 THE SELF-CHECK, and the first condition is the important one: a command
+    built from this interpreter must be one `managed_script_of` RECOGNISES. Without
+    it, an interpreter carrying an argument (`python3 -X utf8`) or a non-python
+    basename makes the registrar's own output invisible to its own recogniser, so
+    the append pass re-appends every hook on every run — MEASURED against the
+    pre-fix code at 14 -> 27 -> 40 commands over three runs, +13 every time,
+    unbounded and silent. Deriving the check from the recogniser
+    rather than restating its rules is what stops the two from drifting apart.
+
+    The remaining three are about the value being a usable interpreter at all:
+    relative would reopen the very PATH window this pinning closes, and a missing
+    or non-executable path would turn every hook into a permanent 127.
+    """
+    if managed_script_of(
+            interp + " " + HOOK_DIR_PREFIXES[0] + _PROBE_SCRIPT) != _PROBE_SCRIPT:
+        return ("commands built from it are not recognised by this script's own "
+                "recogniser — it must be ONE token whose basename starts with "
+                "`python` (no arguments, no wrapper, no spaces)")
+    if not os.path.isabs(interp):
+        return ("it is not an absolute path, and a PATH-resolved interpreter is "
+                "the exact failure this pinning exists to close")
+    if not os.path.isfile(interp):
+        return "no such file"
+    if not os.access(interp, os.X_OK):
+        return "not executable"
+    return None
+
+
+def hook_python():
+    """The absolute interpreter to write into every managed hook command.
+
+    $DEVRC_HOOK_PYTHON is the test seam — without it a test would have to assert
+    against whatever interpreter pytest happened to run under. It is validated
+    because activation inherits the operator's environment, so an exported value
+    reaches production and would otherwise be written verbatim into every hook.
+
+    🔴 A REJECTED OVERRIDE FALLS BACK; IT DOES NOT HARD-FAIL. Deliberate: the
+    fallback (`realpath(sys.executable)`) is what activation wants anyway, since
+    home.nix invokes this under ${pkgs.python312}/bin/python3 — so falling back
+    produces a CORRECTLY pinned settings.json, while hard-failing would leave the
+    hooks on whatever they carried before, i.e. it would keep the 127 window open
+    on the strength of a stray environment variable. It also cannot endanger the
+    wrapper's exit-0 contract, because there is nothing to contain: no non-zero
+    status is produced. The warning is the loud part.
+
+    The fallback to a bare name only fires when sys.executable is empty (an
+    embedded interpreter), which is not a configuration this ever runs in.
+    """
+    fallback = os.path.realpath(sys.executable) if sys.executable else "python3"
+    override = os.environ.get("DEVRC_HOOK_PYTHON")
+    if not override:
+        return fallback
+    reason = unusable_interpreter(override)
+    if reason is None:
+        return override
+    warn("$DEVRC_HOOK_PYTHON=%r IGNORED: %s. Using %s instead. Unset it, or point "
+         "it at an absolute python binary." % (override, reason, fallback))
+    return fallback
+
+
+PYTHON = hook_python()
+
+# 🔴 INVARIANT GUARD, labelled honestly: it covers the case where the RESOLVED
+# interpreter — not an override, which hook_python already rejected — is one this
+# script's recogniser cannot read back. Reaching it requires running the registrar
+# under a CPython whose realpath basename is not `python*`, which no test here can
+# construct hermetically; it is mutation-checked reachable instead (drop the
+# validation from hook_python and run with DEVRC_HOOK_PYTHON=/bin/sh, and this
+# fires with this message). Refusing to write is the right failure: the wrapper
+# turns a non-zero status into a WARNING and exits 0, and settings.json — which
+# has not been opened yet — keeps whatever registrations it already had.
+_UNUSABLE = unusable_interpreter(PYTHON)
+if _UNUSABLE is not None:
+    warn("refusing to touch %s: the interpreter this script resolved (%r) cannot be "
+         "written into a hook command — %s. The file is left exactly as it was."
+         % (SETTINGS, PYTHON, _UNUSABLE))
+    sys.exit(2)
+
+
+def with_python(path):
+    """Build a command for the append tables — and prove this script can read it back.
+
+    Second half of the self-check above, applied to the strings actually written
+    rather than to a probe. Same invariant-guard caveat: with PYTHON validated it
+    cannot fire, and it exists so that "my own output is unrecognisable to me"
+    cannot come back through some future refactor of the tables.
+    """
+    cmd = PYTHON + " " + path
+    if managed_script_of(cmd) is None:
+        raise AssertionError(
+            "register-nudge-hook.py would write a command its own recogniser does "
+            "not recognise, so every run would re-append it: %r" % cmd)
+    return cmd
 
 
 # --------------------------------------------------------------------------- #
@@ -264,12 +408,25 @@ SINGLE_EVENT_CMDS = {
     "Stop": [with_python("~/.claude/hooks/next-step-nudge.py")],
 }
 
+# 🔴 THE OWNERSHIP BOUNDARY OF THE DE-DUP SURFACE, derived from the tables above
+# so it cannot drift from them. This script may delete a duplicate registration
+# only of a script it REGISTERS. bash-guard is the case that makes the
+# distinction real: its interpreter is managed here, its registration is not, so
+# a doubled bash-guard entry came from something else and is not this script's to
+# remove. It is reported instead — see the end of the de-dup pass.
+REGISTERED_SCRIPTS = frozenset(
+    managed_script_of(c)
+    for c in POST_BASH_CMDS + [NOTIFY_CMD, LEDGER_CMD, WRITEBACK_CMD]
+    + [c for cmds in SINGLE_EVENT_CMDS.values() for c in cmds]
+)
+
 with open(SETTINGS) as f:
     data = json.load(f)
 
 hooks = data.setdefault("hooks", {})
 added = []
 rewritten = []
+deduped = []
 
 
 def registered_scripts(event_arrays):
@@ -295,7 +452,112 @@ def registered_scripts(event_arrays):
     return found
 
 
-# --- PASS 1: normalise the interpreter of every managed hook, on every event --
+def _entry_hook_dicts(entry):
+    """The hook dicts inside one settings.json entry, skipping anything malformed."""
+    if not isinstance(entry, dict):
+        return []
+    hs = entry.get("hooks")
+    if not isinstance(hs, list):
+        return []
+    return [h for h in hs if isinstance(h, dict)]
+
+
+def entry_identities(entry):
+    """The (matcher, script) pairs this entry registers.
+
+    🔴 THE IDENTITY KEY FOR THE DE-DUP SURFACE, and the choice is load-bearing in
+    both directions:
+
+      * the SCRIPT, not the command string — the same identity `registered_scripts`
+        uses for the append surface, so the two cannot disagree about what "already
+        registered" means. It also catches the cross-spelling duplicate (`~/…` and
+        `$HOME/…` naming the same hook) that a string key would miss.
+      * the MATCHER, so two entries for one script under DIFFERENT matchers are not
+        duplicates. A hand-scoped narrow entry is a real configuration this script
+        deliberately leaves in place (see `registered_scripts`); collapsing it into
+        the unmatchered one would silently widen a scope the operator narrowed.
+
+    A missing `matcher` and an explicit null are the same identity: both mean
+    "every tool", so two such entries really are the same registration twice.
+    """
+    matcher = entry.get("matcher") if isinstance(entry, dict) else None
+    if matcher is not None and not isinstance(matcher, str):
+        # Not a shape this script writes. Keep it hashable and keep it distinct
+        # from both "absent" and every string, so it can never collapse into
+        # another entry's identity and license a deletion.
+        matcher = ("<non-str matcher>", repr(matcher))
+    ids = {(matcher, managed_script_of(h.get("command")))
+           for h in _entry_hook_dicts(entry)}
+    return {i for i in ids if i[1] is not None}
+
+
+def removable_duplicate(entry):
+    """Is this entry one THIS script wrote, and therefore one it may delete?
+
+    Exactly the shape the append pass emits and nothing else: `{"hooks": [h]}` or
+    `{"matcher": M, "hooks": [h]}` with h exactly `{"type": "command", "command": …}`
+    and the command carrying no arguments. Any extra key — an entry-level
+    `description`, a hook-level `timeout`, a second hook in the list, an argument
+    after the script path — means somebody configured something this script never
+    wrote, so it is kept even when it duplicates. A duplicate is an annoyance; a
+    deleted foreign entry is a broken host.
+    """
+    if not isinstance(entry, dict) or set(entry) - {"matcher", "hooks"}:
+        return False
+    hs = entry.get("hooks")
+    if not isinstance(hs, list) or len(hs) != 1 or not isinstance(hs[0], dict):
+        return False
+    h = hs[0]
+    if set(h) != {"type", "command"} or h.get("type") != "command":
+        return False
+    if not bare_managed_command(h.get("command")):
+        return False
+    return managed_script_of(h.get("command")) in REGISTERED_SCRIPTS
+
+
+# --- PASS 1: heal a file an OLDER registrar double-registered ----------------
+# 🔴 Runs FIRST, before the rewrite, so the report cannot claim to have re-pinned
+# an entry it is about to delete.
+#
+# Keeping the FIRST occurrence is what preserves position, matcher and every
+# foreign key: the survivor is untouched and only later copies go. `seen` is fed
+# by EVERY entry, including ones this script may not delete, so a foreign-shaped
+# first copy still suppresses a plain second one rather than the other way round.
+# See the module docstring for how a file gets into this state (a home-manager
+# rollback runs the previous registrar, which cannot see the new spelling).
+for _event in list(hooks):
+    _arr = hooks.get(_event)
+    if not isinstance(_arr, list):
+        continue
+    _seen = set()
+    _kept = []
+    for _entry in _arr:
+        _ids = entry_identities(_entry)
+        if _ids and _ids <= _seen and removable_duplicate(_entry):
+            deduped.append("%s: %s" % (_event, _entry["hooks"][0]["command"]))
+            continue
+        _seen |= _ids
+        _kept.append(_entry)
+    if len(_kept) != len(_arr):
+        hooks[_event] = _kept
+    # 🔴 AND SAY WHAT IT DECLINED TO REMOVE. Anything still registered twice under
+    # one matcher after this pass is a real double-fire that this script would not
+    # touch — a foreign key, an argument after the script path, or a script whose
+    # registration it does not own. Leaving that silent is the same failure mode as
+    # the unpinnable commands reported below.
+    _counts = {}
+    for _entry in _kept:
+        for _id in entry_identities(_entry):
+            _counts[_id] = _counts.get(_id, 0) + 1
+    for _id in sorted(_counts, key=lambda i: (i[1], repr(i[0]))):
+        if _counts[_id] > 1:
+            warn("%s: %s is registered %d times under matcher %r. This script "
+                 "removed only the duplicates it wrote itself; the rest carry keys, "
+                 "arguments or a registration it does not own, so they were left in "
+                 "place and the hook fires %d times per event. Remove the extras by "
+                 "hand." % (_event, _id[1], _counts[_id], _id[0], _counts[_id]))
+
+# --- PASS 2: normalise the interpreter of every managed hook, on every event --
 # 🔴 THE WIDE SURFACE, and the only place this script writes to an entry it does
 # not own. bash-guard is deliberately in scope here and deliberately absent from
 # the append tables above: its registration belongs to the host, its interpreter
@@ -325,8 +587,44 @@ for _event in list(hooks):
             _old = _h.get("command")
             _new = normalized_command(_old)
             if _new != _old:
+                if managed_script_of(_new) is None:
+                    # Same invariant guard as `with_python`, on the other write
+                    # path: a rewrite whose product this script cannot read back
+                    # would be re-appended on every subsequent run.
+                    raise AssertionError(
+                        "the interpreter rewrite produced a command this script's "
+                        "own recogniser does not recognise: %r" % _new)
                 _h["command"] = _new
                 rewritten.append("%s: %s" % (_event, _new))
+
+# --- PASS 2b: SAY SO about the managed hooks this script declined to pin ------
+# 🔴 Conservative matching is correct; conservative SILENCE is what let the 127
+# window run for months. A command naming a managed hook in any shape the
+# recogniser refuses (`python3 -u …`, a leading `PYTHONPATH=…`, `${HOME}/…`, a
+# quoted path, a `…; …` compound) is left byte-identical AND still resolves its
+# interpreter from PATH, so it keeps dying mid-switch. Warn, never rewrite: this
+# script cannot prove it owns those, and guessing is how a foreign hook gets
+# mangled. Emitted whether or not anything else changed, so the "no change" run
+# reports it too.
+for _event in sorted(hooks):
+    _arr = hooks.get(_event)
+    if not isinstance(_arr, list):
+        continue
+    for _entry in _arr:
+        for _h in _entry_hook_dicts(_entry):
+            _cmd = _h.get("command")
+            if not isinstance(_cmd, str) or managed_script_of(_cmd) is not None:
+                continue
+            _named = sorted(s for s in MANAGED_HOOK_SCRIPTS if s in _cmd)
+            if not _named:
+                continue
+            warn("%s: this command names the managed hook %s but is not in the form "
+                 "this script can pin (<absolute-python> <hooks-dir>%s), so its "
+                 "interpreter is still resolved from PATH and it dies with `command "
+                 "not found` during the ~1s of every home-manager switch in which the "
+                 "intermediate profile generation has no python3 on it. Left "
+                 "byte-identical; rewrite it to that form by hand. The command: %r"
+                 % (_event, ", ".join(_named), _named[0], _cmd))
 
 # --- PostToolUse(Bash) nudge hooks (append-only, matcher=Bash) ---------------
 post = hooks.setdefault("PostToolUse", [])
@@ -386,7 +684,7 @@ for event, cmds in SINGLE_EVENT_CMDS.items():
 # 🔴 Only write when something actually moved. The rewrite pass now re-runs on
 # every switch, so an unconditional write would re-dump (indent=2) the operator's
 # per-host settings.json — permissions and all — every time, for nothing.
-if not added and not rewritten:
+if not added and not rewritten and not deduped:
     print("all devrc-managed hooks already registered — no change")
     sys.exit(0)
 
@@ -407,6 +705,10 @@ except Exception:
     except OSError:
         pass
     raise
+if deduped:
+    print("removed duplicate hook registrations:")
+    for c in deduped:
+        print("  -", c)
 if rewritten:
     print("pinned hook interpreters to %s:" % PYTHON)
     for c in rewritten:

--- a/scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
+++ b/scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
@@ -1676,6 +1676,29 @@ def test_the_dismiss_command_from_the_block_text_RUNS_and_ENDS_the_nagging(home,
     assert again.stdout == ""
 
 
+def test_the_dismiss_command_names_an_absolute_interpreter(home, tmp_path):
+    """🔴 THE 127 WINDOW, on the one command that clears a block.
+
+    `home-manager switch` updates ~/.nix-profile as remove-then-install, so for ~1s
+    the live generation is a partial closure with NO python3 on it, and anything
+    resolved from PATH dies with `command not found`. #609 pinned every hook
+    REGISTRATION in ~/.claude/settings.json to an absolute /nix/store interpreter;
+    this string — advertised to the model as its escape — was the last bare
+    `python3` spelling of a managed hook left in the tree. The hook is already
+    running under the pinned interpreter, so writing `sys.executable` costs nothing.
+
+    Asserted on the STATE (absolute, and equal to the running interpreter), not on
+    the absence of the word python3 — the store path contains it.
+    """
+    cmd = guard.dismiss_cmd(193, SESSION)
+    interpreter = cmd.split(" ", 1)[0]
+    assert interpreter == sys.executable, cmd
+    assert os.path.isabs(interpreter), cmd
+    # Anti-vacuity: it is still the same command, with the same flags, that the
+    # extraction test above drives as a real subprocess.
+    assert "--dismiss 193 --session %s" % SESSION in cmd, cmd
+
+
 def test_the_positive_control_for_that_dismissal(home, tmp_path):
     """Without the dismiss step the same sequence blocks a SECOND time — so the
     silence above is the mechanism working, not a session that had gone quiet anyway

--- a/scripts/claude-hooks/tests/test_register_nudge_hook.py
+++ b/scripts/claude-hooks/tests/test_register_nudge_hook.py
@@ -24,6 +24,22 @@ nudges), and asserts BOTH of the registrant's surfaces:
   9. bash-guard is rewritten but never CREATED: a settings.json with no
      bash-guard entry comes back with no bash-guard entry.
 
+  DE-DUP (narrowest, added 2026-08-20 as the follow-up to the rewrite)
+ 12. A settings.json an OLDER registrant double-registered — the state a
+     `home-manager rollback` produces — HEALS to one entry per (matcher, script),
+     keeping the FIRST occurrence with its position and its foreign keys, while a
+     same-script entry under a DIFFERENT matcher, one carrying ARGUMENTS, one
+     carrying a foreign key and one whose registration this script does not own
+     (bash-guard) all SURVIVE.
+
+  THE VALIDATED SEAM AND THE WARNINGS (same follow-up)
+ 13. A hostile $DEVRC_HOOK_PYTHON — an argument-carrying, relative, non-python or
+     missing interpreter — is rejected with a warning and the resolved fallback is
+     used, so three consecutive runs hold the same number of entries instead of
+     growing without bound.
+ 14. Every command that NAMES a managed hook but is not in the pinnable form is
+     reported on stderr, and nothing else is.
+
 🔴 THE 127 WINDOW, which surface 6 exists to close: `home-manager switch`
 updates ~/.nix-profile as remove-then-install, so there is a ~1s window in which
 the live profile generation is a partial closure with NO python3 on it. A hook
@@ -38,14 +54,40 @@ behaviourally, in test_registrar_activation.py.
 
 Run: python3 test_register_nudge_hook.py
 """
-import os, sys, json, tempfile, subprocess
+import os, sys, json, shutil, tempfile, subprocess, atexit
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 SCRIPT = os.path.join(HERE, "..", "register-nudge-hook.py")
 
 # A synthetic store path — shaped like the real one, deliberately not any path
 # that exists on this host, so nothing can pass by accident of the environment.
-PY = "/nix/store/0000000000000000000000000000000-python3-3.12.14/bin/python3.12"
+#
+# 🔴 It is a REAL, executable file. $DEVRC_HOOK_PYTHON is a test seam with
+# PRODUCTION REACH (activation inherits the operator's environment), so the
+# registrant validates it — absolute, exists, executable, one `python*` token —
+# and falls back to its own sys.executable with a warning when it is not. Scenario
+# 13 below drives that validation with four hostile values.
+_FAKE_STORE = tempfile.mkdtemp(prefix="devrc-fake-store-")
+atexit.register(shutil.rmtree, _FAKE_STORE, True)
+
+
+def fake_python(store_name, basename="python3.12"):
+    """A stand-in interpreter path: real file, executable bit set, never RUN.
+
+    The registrant only stat()s it (`isfile` + `access(X_OK)`) — nothing here
+    ever execs it — so it deliberately carries NO shebang. Adding one would
+    make it a runtime-written executable stub, which `scripts/tests/
+    test_runtime_shebangs.py` gates repo-wide.
+    """
+    p = os.path.join(_FAKE_STORE, store_name, "bin", basename)
+    os.makedirs(os.path.dirname(p), exist_ok=True)
+    with open(p, "w") as f:
+        f.write("stand-in for an interpreter binary: stat()ed, never executed\n")
+    os.chmod(p, 0o755)
+    return p
+
+
+PY = fake_python("0000000000000000000000000000000-python3-3.12.14")
 
 NOTIFY = PY + " ~/.claude/hooks/claude-notify.py"
 CLAWGATE_STOP = "/home/zach/.claude/clawgate-stop-hook.sh"
@@ -121,8 +163,11 @@ def base_settings(home):
     }
 
 
-def run(env):
-    return subprocess.run([sys.executable, SCRIPT], env=env, capture_output=True, text=True)
+def run(env, cwd=None):
+    """`cwd` matters for exactly one case: a RELATIVE $DEVRC_HOOK_PYTHON that
+    resolves to a real executable from the directory the registrant is run in."""
+    return subprocess.run([sys.executable, SCRIPT], env=env, cwd=cwd,
+                          capture_output=True, text=True)
 
 
 def cmds(data, event):
@@ -434,7 +479,7 @@ with tempfile.TemporaryDirectory() as tmp:
 # forever. Under that mutant the run prints "no change" and the stale store path
 # stays in settings.json, which is the 127 window reopening the day that path is
 # garbage-collected.
-PY2 = "/nix/store/1111111111111111111111111111111-python3-3.12.15/bin/python3.12"
+PY2 = fake_python("1111111111111111111111111111111-python3-3.12.15")
 
 with tempfile.TemporaryDirectory() as tmp:
     home = os.path.join(tmp, "home")
@@ -475,6 +520,294 @@ with tempfile.TemporaryDirectory() as tmp:
     # number — a rewrite that emptied the file would satisfy an `all()` too.
     check("11: bash-guard is still registered exactly once",
           cmds(d5, "PreToolUse").count(PY2 + " ~/.claude/hooks/bash-guard.py") == 1)
+
+# --- 12. A HOME-MANAGER ROLLBACK DOUBLE-REGISTERED EVERYTHING — IT MUST HEAL --
+# 🔴 `home-manager rollback` / `--switch-generation` (and a hand-run from an older
+# checkout) runs the PREVIOUS registrant against a settings.json this one already
+# pinned. That code keyed "already registered?" on the exact string `python3 ~/…`,
+# does not find it, and appends a SECOND copy of every hook it owns — 13 of them,
+# which is exactly what this fixture holds. Re-running the CURRENT registrant then
+# normalises both copies to identical strings and the append pass, which keys on
+# the SCRIPT, sees the hook as present — so WITHOUT a de-dup pass both survive and
+# every managed hook fires twice forever: duplicate ledger rows, double
+# notifications, and the write-back guard (the only one that can BLOCK) running
+# twice per event.
+#
+# Both directions are asserted: the duplicates go, and a genuinely DISTINCT
+# registration — same script, different `matcher` — SURVIVES. A hand-scoped narrow
+# entry is a real configuration (see `registered_scripts` in the registrant), and
+# collapsing it into the broad one would silently widen a scope somebody narrowed.
+OLD = "python3 ~/.claude/hooks/"
+AUDIT = PY + " ~/.claude/hooks/audit-pr-nudge.py"
+SHELL = PY + " ~/.claude/hooks/shell-env-nudge.py"
+NOTIFY_ARGS = NOTIFY + " --verbose"
+
+
+def one(cmd, matcher=None, entry_extra=None, hook_extra=None):
+    """One settings.json entry holding one hook — the shape the registrant writes."""
+    h = {"type": "command", "command": cmd}
+    if hook_extra:
+        h.update(hook_extra)
+    e = {"hooks": [h]}
+    if matcher is not None:
+        e["matcher"] = matcher
+    if entry_extra:
+        e.update(entry_extra)
+    return e
+
+
+def entries(data, event):
+    """(matcher, command) per hook, in file order.
+
+    The de-dup identity is the PAIR, and a command string on its own cannot show
+    which matcher its entry was filed under — which is the whole distinction
+    between a duplicate and a deliberately narrowed registration.
+    """
+    return [(e.get("matcher"), h.get("command"))
+            for e in data.get("hooks", {}).get(event, [])
+            for h in e.get("hooks", [])]
+
+
+DUPLICATED = {"hooks": {
+    # 🔴 bash-guard, doubled. This script owns bash-guard's INTERPRETER and not its
+    # REGISTRATION, so the second copy is NOT its to delete — it is rewritten and
+    # left, and reported on stderr instead. The first copy carries two foreign keys.
+    "PreToolUse": [
+        one(BASH_GUARD, "Bash", {"description": "the RULES.md enforcement guard"},
+            {"timeout": 12}),
+        one(OLD + "bash-guard.py", "Bash"),
+    ],
+    "PostToolUse": [
+        one(AUDIT, "Bash"), one(SHELL, "Bash"), one(SEARCH_NUDGE, "Bash"),
+        one(LEDGER), one(WRITEBACK),
+        one(OLD + "audit-pr-nudge.py", "Bash"),
+        one(OLD + "shell-env-nudge.py", "Bash"),
+        one(OLD + "search-tool-nudge.py", "Bash"),
+        one(OLD + "agent-ledger-hook.py"),
+        one(OLD + "clawgate-writeback-guard.py"),
+    ],
+    "Stop": [
+        one(TMUX_STOP), one(CLAWGATE_STOP),
+        one(NOTIFY), one(NEXT_STEP),
+        # SURVIVOR A: same script, DIFFERENT matcher — a real configuration.
+        one(NEXT_STEP, "Bash"),
+        one(LEDGER), one(WRITEBACK),
+        # SURVIVOR B: same script and matcher, but ARGUMENTS after the script path.
+        one(NOTIFY_ARGS),
+        # SURVIVOR C: same script and matcher, but a foreign hook-level key.
+        one(LEDGER, None, None, {"timeout": 7}),
+        # SURVIVOR D: same script and matcher, but a foreign ENTRY-level key — and
+        # for a script this registrant DOES own, so the entry-shape check is the
+        # only thing that can save it. Without this line, dropping that check is a
+        # mutant the suite cannot see: the only other foreign-entry-keyed duplicate
+        # in this fixture is bash-guard's, which the ownership filter already
+        # protects, so it would die for the wrong guard's reason.
+        one(WRITEBACK, None, {"description": "the write-back guard, annotated"}),
+        one(OLD + "claude-notify.py"),
+        one(OLD + "agent-ledger-hook.py"),
+        one(OLD + "clawgate-writeback-guard.py"),
+        one(OLD + "next-step-nudge.py"),
+    ],
+    "SessionStart": [one(LEDGER), one(OLD + "agent-ledger-hook.py")],
+    "UserPromptSubmit": [
+        one(NOTIFY), one(LEDGER),
+        one(OLD + "claude-notify.py"), one(OLD + "agent-ledger-hook.py"),
+    ],
+    "SubagentStop": [one(NOTIFY), one(OLD + "claude-notify.py")],
+}}
+
+with tempfile.TemporaryDirectory() as tmp:
+    home = os.path.join(tmp, "home")
+    os.makedirs(os.path.join(home, ".claude"))
+    settings = os.path.join(home, ".claude", "settings.json")
+    with open(settings, "w") as f:
+        json.dump(DUPLICATED, f, indent=2)
+
+    env = dict(os.environ)
+    env["HOME"] = home
+    env["DEVRC_HOOK_PYTHON"] = PY
+
+    p12 = run(env)
+    check("12: the healing run exits 0", p12.returncode == 0)
+    with open(settings) as f:
+        d12 = json.load(f)
+
+    # Literal expected end state per event — not derived from the fixture, so a
+    # de-dup that removed the WRONG copy (or reordered) fails here.
+    check("12: PostToolUse healed to one entry per (matcher, script)",
+          entries(d12, "PostToolUse") == [
+              ("Bash", AUDIT), ("Bash", SHELL), ("Bash", SEARCH_NUDGE),
+              (None, LEDGER), (None, WRITEBACK)])
+    check("12: Stop healed, keeping the first copy of each and all three survivors",
+          entries(d12, "Stop") == [
+              (None, TMUX_STOP), (None, CLAWGATE_STOP),
+              (None, NOTIFY), (None, NEXT_STEP), ("Bash", NEXT_STEP),
+              (None, LEDGER), (None, WRITEBACK),
+              (None, NOTIFY_ARGS), (None, LEDGER), (None, WRITEBACK)])
+    check("12: SessionStart healed", entries(d12, "SessionStart") == [(None, LEDGER)])
+    check("12: UserPromptSubmit healed",
+          entries(d12, "UserPromptSubmit") == [(None, NOTIFY), (None, LEDGER)])
+    check("12: SubagentStop healed", entries(d12, "SubagentStop") == [(None, NOTIFY)])
+    # 🔴 THE OWNERSHIP BOUNDARY: bash-guard's second entry is rewritten, never
+    # removed. Its registration belongs to the host.
+    check("12: the doubled bash-guard entry is PINNED but NOT deleted",
+          entries(d12, "PreToolUse") == [("Bash", BASH_GUARD), ("Bash", BASH_GUARD)])
+    # The first bash-guard entry keeps both keys this script knows nothing about.
+    check("12: the surviving bash-guard entry kept its foreign keys",
+          d12["hooks"]["PreToolUse"][0].get("description")
+          == "the RULES.md enforcement guard"
+          and d12["hooks"]["PreToolUse"][0]["hooks"][0].get("timeout") == 12)
+    check("12: the survivor with a foreign hook-level key kept it",
+          [e for e in d12["hooks"]["Stop"]
+           if e["hooks"][0].get("timeout") == 7] != [])
+    check("12: the survivor with a foreign ENTRY-level key kept it",
+          [e for e in d12["hooks"]["Stop"]
+           if e.get("description") == "the write-back guard, annotated"] != [])
+    # It says what it removed, and how many.
+    check("12: it reports the removals", "removed duplicate hook registrations:"
+          in p12.stdout)
+    check("12: exactly 13 duplicate registrations were removed",
+          len([ln for ln in p12.stdout.splitlines() if ln.startswith("  - ")]) == 13)
+    # ...and it is LOUD about the three double-fires it declined to touch.
+    check("12: it warns about the duplicates it declined to remove",
+          p12.stderr.count("is registered 2 times under matcher") == 4)
+    check("12: the declined warnings name all four scripts",
+          all(s in p12.stderr for s in ("bash-guard.py", "claude-notify.py",
+                                        "agent-ledger-hook.py",
+                                        "clawgate-writeback-guard.py")))
+    # 🔴 AND THE HEALED FILE IS A FIXED POINT. A de-dup that re-ran forever, or one
+    # that healed into a state the append pass then re-populated, would fail here.
+    healed = open(settings, "rb").read()
+    p12b = run(env)
+    check("12: the second run reports no change", "no change" in p12b.stdout)
+    check("12: the healed file is BYTE-IDENTICAL after a second run",
+          open(settings, "rb").read() == healed)
+
+# --- 13. A HOSTILE $DEVRC_HOOK_PYTHON CANNOT GROW THE FILE WITHOUT BOUND ------
+# 🔴 The override is a test seam with PRODUCTION REACH: home-manager activation
+# inherits the operator's environment, so an exported value is written verbatim
+# into all 14 hook commands. An interpreter carrying an argument, or one whose
+# basename is not `python*`, makes `managed_script_of` fail to recognise the
+# registrant's OWN output — so the append pass re-appends everything on EVERY run:
+# 15 -> 30 -> 45 entries, unbounded and silent. The other two are not growth bugs
+# but are just as wrong to write: a relative name reopens the exact PATH window
+# this pinning closes, and a missing path turns every hook into a permanent 127.
+#
+# 🔴 EACH CONDITION IS ISOLATED BY ITS OWN CASE, because these checks MASK one
+# another and a mutant that dies for the neighbour's reason proves nothing about
+# the guard it removed. `os.access(X_OK)` is False for a path that does not
+# exist, so it hides the exists check unless the value is a real EXECUTABLE
+# DIRECTORY; and a bare relative name is not a file in any plausible cwd, so the
+# exists check hides the absolute check unless the value really does resolve from
+# the directory the registrant runs in. Both of those cases are here for exactly
+# that reason — without them, dropping either check is a surviving mutant.
+NOT_A_PYTHON = fake_python("not-a-python", basename="sh")
+_REL_BIN = os.path.dirname(fake_python("relative-store"))
+EXEC_DIR = os.path.join(_FAKE_STORE, "a-directory", "bin", "python3.12")
+os.makedirs(EXEC_DIR, exist_ok=True)
+
+HOSTILE_OVERRIDES = [
+    (PY + " -X utf8", "carries an argument", None),
+    ("python3", "relative", None),
+    ("python3.12", "relative but resolvable from the cwd", _REL_BIN),
+    (NOT_A_PYTHON, "absolute and executable but not a python", None),
+    (PY + "-gone", "absolute python path that does not exist", None),
+    (EXEC_DIR, "an executable DIRECTORY with a python name", None),
+]
+RESOLVED = os.path.realpath(sys.executable)
+
+for hostile, why, hostile_cwd in HOSTILE_OVERRIDES:
+    with tempfile.TemporaryDirectory() as tmp:
+        home = os.path.join(tmp, "home")
+        os.makedirs(os.path.join(home, ".claude"))
+        settings = os.path.join(home, ".claude", "settings.json")
+        with open(settings, "w") as f:
+            json.dump({"hooks": {
+                "PreToolUse": [one(OLD + "bash-guard.py", "Bash")],
+                "Stop": [one(TMUX_STOP)],
+            }}, f, indent=2)
+
+        env = dict(os.environ)
+        env["HOME"] = home
+        env["DEVRC_HOOK_PYTHON"] = hostile
+
+        runs, counts = [], []
+        for _ in range(3):
+            runs.append(run(env, cwd=hostile_cwd))
+            with open(settings) as f:
+                dd = json.load(f)
+            counts.append(len([c for ev in dd.get("hooks", {})
+                               for c in cmds(dd, ev)]))
+
+        tag = "13 (%s)" % why
+        check(tag + ": all three runs exit 0",
+              all(r.returncode == 0 for r in runs))
+        check(tag + ": the override is rejected OUT LOUD",
+              all("DEVRC_HOOK_PYTHON" in r.stderr for r in runs))
+        # THE UNBOUNDED-GROWTH LOOP, CLOSED: a literal, not a comparison against
+        # run 1 — a run that appended nothing at all would satisfy `a == b == c`.
+        check(tag + ": three consecutive runs hold exactly 15 hook commands",
+              counts == [15, 15, 15])
+        with open(settings) as f:
+            d13 = json.load(f)
+        written = [c for ev in d13.get("hooks", {}) for c in cmds(d13, ev)
+                   if c != TMUX_STOP]
+        check(tag + ": every hook command names the resolved fallback instead",
+              written and all(c.startswith(RESOLVED + " ") for c in written))
+        # By PREFIX, not substring: the resolved fallback is itself a path ending
+        # in `python3`, so a substring test would report the relative override as
+        # "reached" purely because the honest answer contains its spelling.
+        check(tag + ": the hostile value is not the interpreter of any command",
+              not any(c.startswith(hostile + " ") for c in written))
+
+# --- 14. IT SAYS WHICH MANAGED HOOKS IT DECLINED TO PIN ----------------------
+# 🔴 Conservative matching is right; conservative SILENCE is what let the 127
+# window run for months. Each of these names a managed hook, comes back
+# byte-identical, and stays on a PATH-resolved interpreter — so each one keeps
+# dying mid-switch with nothing in the switch log to say so.
+UNPINNABLE = [
+    "python3 -u ~/.claude/hooks/bash-guard.py",
+    "PYTHONPATH=/x python3 ~/.claude/hooks/bash-guard.py",
+    "python3 ${HOME}/.claude/hooks/bash-guard.py",
+    "python3 '~/.claude/hooks/bash-guard.py'",
+    "cd /tmp && python3 ~/.claude/hooks/bash-guard.py",
+]
+# The other half of the claim: it must NOT warn about a command that names no
+# managed hook. Without these the warning could be "print something for every
+# unrecognised command" and still pass.
+SILENT = ["python3 ~/.claude/hooks/not-a-devrc-hook.py", TMUX_STOP]
+
+with tempfile.TemporaryDirectory() as tmp:
+    home = os.path.join(tmp, "home")
+    os.makedirs(os.path.join(home, ".claude"))
+    settings = os.path.join(home, ".claude", "settings.json")
+    with open(settings, "w") as f:
+        json.dump({"hooks": {"PreToolUse": [one(c, "Bash")
+                                            for c in UNPINNABLE + SILENT]}},
+                  f, indent=2)
+
+    env = dict(os.environ)
+    env["HOME"] = home
+    env["DEVRC_HOOK_PYTHON"] = PY
+
+    p14 = run(env)
+    check("14: run exits 0", p14.returncode == 0)
+    with open(settings) as f:
+        d14 = json.load(f)
+    check("14: every unpinnable command came back BYTE-IDENTICAL",
+          cmds(d14, "PreToolUse") == UNPINNABLE + SILENT)
+    check("14: exactly one warning per unpinnable command, and no more",
+          p14.stderr.count("is not in the form this script can pin") == 5)
+    for c in UNPINNABLE:
+        check("14: it names the command it declined to pin: " + c,
+              repr(c) in p14.stderr)
+    for c in SILENT:
+        check("14: it stays quiet about a command naming no managed hook: " + c,
+              repr(c) not in p14.stderr)
+    # Anti-vacuity: the run did its normal work on the same file, so the checks
+    # above are about the warning and not about a run that died early.
+    check("14: ...while the run did its normal work on the same file",
+          NEXT_STEP in cmds(d14, "Stop"))
 
 with open(SCRIPT) as f:
     src = f.read()

--- a/scripts/claude-hooks/tests/test_registrar_activation.py
+++ b/scripts/claude-hooks/tests/test_registrar_activation.py
@@ -38,12 +38,14 @@ WHAT THIS FILE IS FOR
 Fixtures are synthetic. This repo is public: no real paths, hostnames or task titles.
 """
 import ast
+import atexit
 import json
 import os
 import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -54,10 +56,35 @@ HOME_NIX = ROOT / "nix" / "home.nix"
 BASH = shutil.which("bash") or "/bin/bash"
 
 # The interpreter the registrant writes into every managed hook command. Pinned
-# to a synthetic literal via $DEVRC_HOOK_PYTHON so the expectations below do not
+# to a synthetic path via $DEVRC_HOOK_PYTHON so the expectations below do not
 # depend on whichever interpreter happens to run pytest; the UNPINNED resolution
 # is covered behaviourally by its own test at the bottom of section 1.
-HOOK_PY = "/nix/store/0000000000000000000000000000000-python3-3.12.14/bin/python3.12"
+#
+# 🔴 It must be a REAL, executable file. $DEVRC_HOOK_PYTHON is a test seam with
+# PRODUCTION REACH — activation inherits the operator's environment — so the
+# registrant validates it (absolute / exists / executable / one `python*` token)
+# and falls back to its own sys.executable with a warning when it is not. The
+# file is created under a private temp dir, never at a path that exists on this
+# host, so nothing here can pass by accident of the environment.
+_FAKE_STORE = tempfile.mkdtemp(prefix="devrc-fake-store-")
+atexit.register(shutil.rmtree, _FAKE_STORE, True)
+
+
+def fake_python(store_name):
+    """A stand-in for a /nix/store python: real file, executable, `python*` name.
+
+    The registrant only stat()s it (`isfile` + `access(X_OK)`); nothing execs it,
+    so it deliberately carries NO shebang — a runtime-written executable stub is
+    what `scripts/tests/test_runtime_shebangs.py` gates repo-wide.
+    """
+    p = Path(_FAKE_STORE) / store_name / "bin" / "python3.12"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("stand-in for an interpreter binary: stat()ed, never executed\n")
+    p.chmod(0o755)
+    return str(p)
+
+
+HOOK_PY = fake_python("0000000000000000000000000000000-python3-3.12.14")
 
 NEXT_STEP = HOOK_PY + " ~/.claude/hooks/next-step-nudge.py"
 NOTIFY = HOOK_PY + " ~/.claude/hooks/claude-notify.py"


### PR DESCRIPTION
#609 pinned every managed hook's interpreter to an absolute `/nix/store` python and
closed the ~1s window in which `bash-guard.py` fails OPEN. Its adversarial audit passed
it as safe to merge and left three 🟡 findings, all silent failure modes. This closes
all three.

**Measured mitigating fact first, so nobody reads this as an outage:** neither host is
in any of these states today. Read-only inspection of the live
`~/.claude/settings.json` on **both** the workbench and the laptop (over nebula) says
the same thing — 14 managed hook commands, every one already pinned to an absolute
store path, **zero** duplicate `(event, matcher, script)` keys, **zero** commands in a
spelling the registrar declines to pin. All three fixes are tripwires for the future,
not live bugs.

## Finding 1 — a `home-manager rollback` double-registers every hook, permanently

`home-manager rollback` / `--switch-generation` (and a hand-run from an older checkout)
runs the PREVIOUS registrar against a `settings.json` the current one already pinned.
That older code keyed "already registered?" on the exact string `python3 ~/…`, does not
find it, and appends a SECOND copy of every hook it owns. Re-running the CURRENT
registrar then normalises both copies to identical strings, and because its append pass
asks only "is this script registered on this event", it sees the hook as present and
**both survive**. Every managed hook fires twice, forever — duplicate ledger rows,
double notifications, and `clawgate-writeback-guard.py` (the only hook that can BLOCK)
running twice per event.

**Fix: a third surface — DE-DUP — that HEALS the file rather than merely not making it
worse.** It is the narrowest of the three, and the boundaries are deliberate:

* **Identity is `(matcher, managed_script_of(command))`.** The script half is the same
  identity the append surface already uses (`registered_scripts`), so the two cannot
  disagree about what "already registered" means, and it catches the cross-spelling
  duplicate (`~/…` vs `$HOME/…`) a string key would miss. The matcher half is what keeps
  a hand-scoped narrow entry alive: two entries for one script under *different*
  matchers are NOT duplicates, and collapsing them would silently widen a scope the
  operator narrowed. A missing `matcher` and an explicit `null` are one identity.
* **The FIRST occurrence survives**, untouched — its position, its matcher, and every
  key the registrar has never heard of.
* **It removes only what it could have written**: exactly `{"hooks": [h]}` or
  `{"matcher": M, "hooks": [h]}` with `h` exactly `{"type": "command", "command": …}` and
  no arguments after the script path, AND only for a script this registrar actually
  registers. So a doubled **bash-guard** — whose registration belongs to the host, not to
  this script — is re-pinned and LEFT. An entry with a `description`, a `timeout`, a
  second hook, or a `--flag` is a configuration somebody made; it stays.
* **…and it says what it declined.** Anything still registered twice under one matcher
  after the pass is named on stderr. Declining silently is the same failure mode as
  finding 3.

## Finding 2 — `$DEVRC_HOOK_PYTHON` was a test seam with production reach and no validation

Activation inherits the operator's environment, so an exported override was written
verbatim into all 14 hook commands. An interpreter carrying an argument
(`python3 -X utf8`) or a non-`python*` basename makes `managed_script_of()` fail to
recognise the registrar's OWN output, so the append pass re-appends everything on every
run. **Measured against the pre-fix code: 14 → 27 → 40 commands over three runs, +13
each time, unbounded and silent.**

**Fix:** the override is validated on four conditions, and the first one is derived from
the recogniser rather than restating its rules, so the two cannot drift apart:

1. a command built from it must be one `managed_script_of()` recognises;
2. absolute (a relative name reopens the exact PATH window this pinning closes);
3. it exists;
4. it is executable.

**A rejected override FALLS BACK to `realpath(sys.executable)` with a warning; it does
not hard-fail.** Deliberate, and argued in the code: the fallback is what activation
wants anyway (home.nix invokes the registrar under `${pkgs.python312}/bin/python3`), so
falling back produces a *correctly* pinned `settings.json`, while hard-failing would
leave the hooks on whatever they carried before — i.e. it would keep the 127 window open
on the strength of a stray environment variable. It also cannot endanger the activation
wrapper's exit-0 contract, because it produces no non-zero status at all.

**Plus the self-check the finding asked for**, at both write points: a command the
registrar is about to write must be one its own recogniser recognises. Both are labelled
in the source as INVARIANT GUARDS, not regression coverage — with `PYTHON` validated
they cannot fire from any test. Reachability was demonstrated by mutation instead, and
each dies with **its own** message:

* drop `hook_python`'s validation → the module-level refusal fires, `rc=2`,
  `WARNING refusing to touch …/settings.json: the interpreter this script resolved … cannot be written into a hook command`,
  and `settings.json` is never opened;
* drop that too → `with_python()`'s `AssertionError` fires at the first table entry.

## Finding 3 — the rewrite was silent about hooks it declined to pin

`python3 -u ~/…`, `PYTHONPATH=… python3 ~/…`, `${HOME}/…`, a quoted path and
`cd /x && python3 ~/…` all come back byte-identical (correctly — the registrar cannot
prove it owns them) and all stay in the fail-open window with nothing in the switch log
to say so. This whole PR line exists because a silent failure ran for months.

**Fix:** every command that NAMES a managed hook basename but is not in the pinnable form
is reported on stderr, naming the event and the exact command. The activation wrapper
captures the registrar with `2>&1` and relays it line-by-line, so these land in the
switch log — that `2>&1` is now documented as load-bearing in the wrapper's contract.

## Nit — the last bare-`python3` spelling: CHANGED

`clawgate-writeback-guard.py`'s `dismiss_cmd()` advertised
`python3 ~/.claude/hooks/clawgate-writeback-guard.py --dismiss …` to the model as its one
escape from a block. Changed to `sys.executable`. It is free and exact — the hook is
already RUNNING under the pinned absolute interpreter — and a bare name would give the
model `command not found` for the one command that clears the block, during the same
window. New test asserts the STATE (absolute, equal to the running interpreter), not the
absence of the string `python3`, since the store path contains it.

## `scripts/opencode/plugin/guard.js` — NOT done, deliberately

`process.env.DEVRC_GUARD_PYTHON || "python3"` has the same mid-switch window. It fails
CLOSED (during the window every opencode bash call is refused with a clear error), so it
is not a fail-open hole. Pinning it is **not** a small change in the same style:
`guard.js` is deployed as a plain `home.file.….source` copy, so pinning needs a
substitution derivation (`.source` → `.text` + a `@PYTHON@` placeholder), a fallback path
for running it out of the repo where the placeholder is unsubstituted, and updates to the
node-tier deployed-layout tests. Left as follow-up rather than ballooning this PR.

## Testing

Every fix has a regression test shown RED on the pre-change tree. Matrix — base
`d3ce028` (the #609 squash), tests from this branch, implementation swapped via
`git checkout d3ce028 -- <impl>`:

| finding | scenario | at `d3ce028` | at HEAD |
|---|---|---|---|
| 1 — de-dup | `test_register_nudge_hook.py` scenario 12 | **RED** (9 checks) | green |
| 2 — validated seam | scenario 13, 6 hostile overrides × 3 runs each | **RED** (20 checks) | green |
| 3 — unpinnable warnings | scenario 14 | **RED** (6 checks) | green |
| nit | `test_the_dismiss_command_names_an_absolute_interpreter` | **RED** (`'python3' != '/nix/store/…/bin/python3'`) | green |

35 checks red at base in the standalone suite, 0 at HEAD. `test_registrar_activation.py`
is green at base and gained no regression coverage — only fixture fidelity (its
`HOOK_PY` had to become a real executable file, since the override is now validated);
that is stated rather than counted.

Scenario 12 builds an actually-duplicated `settings.json` — the exact 13 extra
registrations an older registrar appends — and asserts the healed end state as a literal
per-event `(matcher, command)` list, plus that four survivors are untouched: a
different-matcher entry, an argument-carrying one, one with a foreign hook-level key, one
with a foreign entry-level key, and the doubled bash-guard whose registration this script
does not own. Scenario 13 runs each hostile override three times and pins the command
count at a literal `[15, 15, 15]` — not `a == b == c`, which a run that appended nothing
would also satisfy.

**Mutation sweep: 17/17 killed**, under `PYTHONDONTWRITEBYTECODE=1`, each mutant applied
to a pristine copy and restored by `cp` (never `git checkout`), each scored KILLED only
when a failing check belongs to the scenario that OWNS the guard. Negative control: the
pristine tree is green. Positive control (M0): a two-space separator in `with_python` —
still recognised by the regex, so only the expectations catch it — killed.

Mutants: delete the de-dup decision · drop the matcher from the identity · invert the
branch so the FIRST copy is removed · drop the entry-shape check · drop the ownership
filter · drop the no-arguments check · mark an entry seen BEFORE deciding on it (stale
rebind) · raise the declined-duplicate threshold · delete the override validation · invert
it to accept only INVALID overrides · drop the absolute check · drop the recogniser
self-check · drop the exists check · delete the unpinnable warning · invert it to warn
about the PINNED commands · swap the operands of the basename scan.

**Three of those SURVIVED the first sweep**, each masked by a neighbouring check, and
fixing them is a real coverage gain rather than a scoring adjustment:

* the entry-shape check was masked by the ownership filter, because the only
  foreign-entry-keyed duplicate in the fixture was bash-guard's → added a
  foreign-entry-keyed duplicate of a script the registrar DOES own;
* `os.access(X_OK)` is False for a path that does not exist, so it masked the exists
  check → added an override that is a real, executable **directory** with a `python*`
  name;
* a bare relative name is not a file in any plausible cwd, so the exists check masked
  the absolute check → added an override that is relative **and resolvable from the cwd
  the registrant runs in**.

## Docs

`register-nudge-hook.py`'s module docstring now says THREE surfaces (it said two) and
carries the rollback mechanism; `register-hooks-activation.sh`'s contract items 2 and 3
name the third surface and pin the `2>&1` capture as load-bearing; the identity key, the
ownership boundary and the fall-back-don't-hard-fail decision each carry their argument
at the code that implements them.

Gate: `scripts/gate.sh --tier both --set all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
