### PR TITLE
feat(system): the laptop froze SIX times and recorded nothing — TLP had disabled the lockup detector

### DIFF
--- a/nix/system/apply-freeze-instrumentation.sh
+++ b/nix/system/apply-freeze-instrumentation.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# Staged system-level freeze instrumentation — LAPTOP host, 2026-08-20.
+#
+# Claude cannot run `sudo nixos-rebuild`, so the /etc/nixos edits are staged
+# here. Idempotent: safe to re-run.
+#
+#   sudo bash nix/system/apply-freeze-instrumentation.sh
+#
+# ── Why ─────────────────────────────────────────────────────────────────────
+#
+# The laptop has stopped uncleanly SIX times since 2026-07-29 (Jul 29, Jul 31,
+# Aug 06, Aug 10, Aug 17, Aug 20), after a clean June. "Unclean" here means the
+# boot never reached systemd's shutdown sequence — classified by tailing each
+# boot for `Journal stopped` / `System Power Off`.
+#
+# Not one of them recorded a cause: no MCE, no oops, no soft-lockup trace, no
+# GPU hang, no OOM, no thermal event. That absence is STRUCTURAL, not evidence
+# of health — this host is configured so that a hard lockup cannot be observed:
+#
+#   1. kernel.nmi_watchdog reads 0. The kernel enables the hard-lockup detector
+#      at boot ("NMI watchdog: Enabled", measured 2026-08-20 17:20:15), then TLP
+#      writes 0 seven seconds later (17:20:22). NMI_WATCHDOG is absent from the
+#      generated /etc/tlp.conf, so tlp falls back to its shipped
+#      share/tlp/defaults.conf, which sets NMI_WATCHDOG=0.
+#   2. kernel.panic = 0 and kernel.hardlockup_panic = 0, so even a DETECTED
+#      lockup hangs forever instead of panicking, capturing and rebooting.
+#   3. journald runs at the stock SyncIntervalSec=5m, so the last few minutes
+#      before any freeze were never written to disk.
+#
+# Net: a hard lockup on this box is silent by construction. Until that changes,
+# the next freeze will be exactly as blank as the last six. This script does NOT
+# fix the freezes — it makes the next one leave evidence.
+#
+# ── Why the fix goes in services.tlp.settings, not boot.kernel.sysctl ────────
+#
+# set_nmi_watchdog() is called from tlp's main `start` path
+# (sbin/tlp:32), which re-runs on EVERY AC<->battery transition via TLP's udev
+# rules, not just at boot. A sysctl.d entry or a boot.kernel.sysctl declaration
+# would therefore be silently reverted the next time the charger moves. Setting
+# NMI_WATCHDOG=1 in TLP's own config is the only placement TLP will not stomp.
+#
+# ── Deliberately NOT included ───────────────────────────────────────────────
+#
+#   - kernel.panic_on_oops. An oops is ALREADY logged; the silent case is the
+#     hard lockup, which oopses nothing. Turning this on would convert today's
+#     survivable driver oopses into reboots — a real behaviour regression bought
+#     for no diagnostic gain.
+#   - kernel.softlockup_panic. Soft-lockup warnings fire under heavy nix/docker
+#     load on a 4C/8T part; panicking on them would reboot this host during
+#     ordinary builds. The detector still WARNS with this left at 0.
+#   - ramoops. Unnecessary here: efi_pstore is proven working on this machine —
+#     it captured the 2026-07-31 14:18 crash to
+#     /var/lib/systemd/pstore/17855255*/. ramoops additionally needs a reserved
+#     memory region, which is awkward to place safely on x86+EFI.
+#   - netconsole. The gold standard for a hard freeze, but it needs a listener
+#     host configured and running. Worth doing if the pstore route comes up dry.
+#
+# ── Cost, stated honestly ───────────────────────────────────────────────────
+#
+#   - The NMI watchdog "permanently consumes one hw-PMU counter" (the kernel's
+#     own words at boot). If you ever profile with `perf` on this host, that is
+#     one fewer hardware counter available.
+#   - It also costs a little power, which is why TLP disables it by default.
+#   - SyncIntervalSec=30s raises journal write frequency ~10x. On NVMe this is
+#     negligible; on battery it is a small extra wakeup source.
+#
+# ── What this does NOT tell you ─────────────────────────────────────────────
+#
+# Nothing here identifies the cause. Kernel (7.0.0) and BIOS (03.17) were
+# CONSTANT across all 13 boots examined, and the only NixOS generations are
+# Jun 23 and Aug 13 — the Jul 29 onset sits inside a generation that had already
+# run cleanly for five weeks. An onset with no coincident software change also
+# fits hardware degradation (RAM, power delivery, NVMe), which this script does
+# not test. A memtest86+ pass remains the cheap discriminator.
+#
+# -E (errtrace) is load-bearing, not stylistic: without it the ERR trap below is
+# NOT inherited into shell functions, so a `false` inside require_one_match()
+# exits via `set -e` having skipped the restore entirely — leaving the config
+# half-edited, which is the exact state the trap exists to prevent. Caught by
+# test_refuses_when_an_anchor_is_duplicated.
+set -Eeuo pipefail
+
+# CFG is overridable so the test suite can exercise the edit logic against a
+# fixture. --edit-only additionally skips the root check and the rebuild.
+CFG=${CFG:-/etc/nixos/configuration.nix}
+EDIT_ONLY=0
+[[ ${1:-} == "--edit-only" ]] && EDIT_ONLY=1
+
+if [[ $EDIT_ONLY -eq 0 ]]; then
+  [[ $EUID -eq 0 ]] || { echo "must run as root (sudo bash $0)"; exit 1; }
+fi
+[[ -f $CFG ]] || { echo "missing $CFG"; exit 1; }
+
+BAK="$CFG.bak-freeze-$(date +%Y%m%d-%H%M%S)"
+cp -a "$CFG" "$BAK"
+echo "[0/5] backed up $CFG -> $BAK"
+
+restore_on_err() {
+  local rc=$?
+  echo "ERROR (rc=$rc) — restoring $CFG from $BAK" >&2
+  cp -a "$BAK" "$CFG"
+  exit "$rc"
+}
+trap restore_on_err ERR
+
+# An anchor that matches a different number of lines than we assume is the
+# `count=1 replace` hazard: the edit lands somewhere we never pictured. Assert
+# the count instead of trusting it.
+require_one_match() { # <regex> <human name>
+  local n
+  n=$(grep -cE "$1" "$CFG" || true)
+  if [[ $n -ne 1 ]]; then
+    echo "ERROR: expected exactly 1 match for $2, found $n — refusing to edit" >&2
+    false
+  fi
+}
+
+indent_of() { # <line-number> -> leading whitespace of that line
+  sed -n "${1}p" "$CFG" | sed -E 's/^([[:space:]]*).*/\1/'
+}
+
+# ---- 1. NMI watchdog, via TLP so power events cannot revert it -----------
+if grep -qE '^[[:space:]]*NMI_WATCHDOG[[:space:]]*=' "$CFG"; then
+  echo "[1/5] NMI_WATCHDOG already declared — skipping"
+else
+  require_one_match '^[[:space:]]*services\.tlp[[:space:]]*=' "services.tlp"
+  tlp_line=$(grep -nE '^[[:space:]]*services\.tlp[[:space:]]*=' "$CFG" | cut -d: -f1)
+  set_line=$(awk -v s="$tlp_line" \
+    'NR>s && /^[[:space:]]*settings[[:space:]]*=[[:space:]]*\{/ {print NR; exit}' "$CFG")
+  [[ -n ${set_line:-} ]] || { echo "ERROR: no 'settings = {' after services.tlp" >&2; false; }
+  ind="$(indent_of "$set_line")  "
+  sed -i "${set_line}a\\
+${ind}\\
+${ind}# Freeze instrumentation: TLP's shipped default is NMI_WATCHDOG=0, which\\
+${ind}# disables the hard-lockup detector the kernel enables at boot — and it is\\
+${ind}# re-applied on every AC<->battery transition, so this must live HERE and\\
+${ind}# not in boot.kernel.sysctl. Without it a hard lockup logs nothing at all.\\
+${ind}NMI_WATCHDOG = 1;" "$CFG"
+  grep -qE '^[[:space:]]*NMI_WATCHDOG[[:space:]]*=[[:space:]]*1;' "$CFG" \
+    || { echo "ERROR: NMI_WATCHDOG edit did not apply" >&2; false; }
+  echo "[1/5] services.tlp.settings.NMI_WATCHDOG = 1"
+fi
+
+# ---- 2/3. Panic on hard lockup, and actually reboot ----------------------
+require_one_match '^[[:space:]]*boot\.kernel\.sysctl[[:space:]]*=' "boot.kernel.sysctl"
+sysctl_line=$(grep -nE '^[[:space:]]*boot\.kernel\.sysctl[[:space:]]*=' "$CFG" | cut -d: -f1)
+
+if grep -qE '"kernel\.hardlockup_panic"' "$CFG"; then
+  echo "[2/5] kernel.hardlockup_panic already declared — skipping"
+else
+  ind="$(indent_of "$sysctl_line")  "
+  sed -i "${sysctl_line}a\\
+${ind}# A detected hard lockup must PANIC (so efi_pstore captures a trace) and\\
+${ind}# then reboot, rather than hanging forever as it does today.\\
+${ind}\"kernel.hardlockup_panic\" = 1;\\
+${ind}\"kernel.panic\" = 20;" "$CFG"
+  grep -qE '"kernel\.hardlockup_panic"[[:space:]]*=[[:space:]]*1;' "$CFG" \
+    || { echo "ERROR: hardlockup_panic edit did not apply" >&2; false; }
+  echo "[2/5] boot.kernel.sysctl: hardlockup_panic=1, panic=20"
+fi
+
+# ---- 4. Shrink the journald blind window ---------------------------------
+if grep -qE '^[[:space:]]*services\.journald\.extraConfig[[:space:]]*=' "$CFG"; then
+  echo "[3/5] services.journald.extraConfig already declared — skipping"
+else
+  # Recompute: edit 2 may have shifted the anchor.
+  sysctl_line=$(grep -nE '^[[:space:]]*boot\.kernel\.sysctl[[:space:]]*=' "$CFG" | cut -d: -f1)
+  ind="$(indent_of "$sysctl_line")"
+  sed -i "$((sysctl_line - 1))a\\
+${ind}# Stock SyncIntervalSec is 5m, so the final minutes before each freeze were\\
+${ind}# never written to disk. 30s narrows that blind window.\\
+${ind}services.journald.extraConfig = \"SyncIntervalSec=30s\";\\
+${ind}" "$CFG"
+  grep -qE '^[[:space:]]*services\.journald\.extraConfig[[:space:]]*=' "$CFG" \
+    || { echo "ERROR: journald edit did not apply" >&2; false; }
+  echo "[3/5] services.journald.extraConfig: SyncIntervalSec=30s"
+fi
+
+# ---- 5. Validate ---------------------------------------------------------
+if command -v nix-instantiate >/dev/null 2>&1; then
+  echo "[4/5] parsing $CFG ..."
+  nix-instantiate --parse "$CFG" >/dev/null
+  echo "[4/5] parse OK"
+else
+  echo "[4/5] nix-instantiate unavailable — SKIPPING parse validation" >&2
+fi
+
+trap - ERR
+
+echo
+echo "Review the diff before applying:"
+echo "    diff -u $BAK $CFG"
+echo
+
+if [[ $EDIT_ONLY -eq 1 ]]; then
+  echo "[5/5] --edit-only: config edited and validated, nothing applied."
+  exit 0
+fi
+
+if [[ -t 0 ]]; then
+  read -r -p "Run 'nixos-rebuild switch' now? [y/N] " ans || ans=n
+else
+  ans=n
+  echo "(non-interactive stdin — skipping the rebuild prompt)"
+fi
+
+if [[ ${ans:-n} =~ ^[Yy]$ ]]; then
+  if ! nixos-rebuild switch; then
+    echo
+    echo "nixos-rebuild FAILED. The config edits are still in place." >&2
+    echo "Rollback: cp -a $BAK $CFG && nixos-rebuild switch" >&2
+    exit 1
+  fi
+  # A `nixos-rebuild switch` does NOT restart systemd-sysctl
+  # (NixOS/nixpkgs#289174), so the sysctl edits above are inert until it is
+  # restarted or the host reboots. TLP likewise needs a restart to re-read
+  # NMI_WATCHDOG. Both are cheap and idempotent.
+  systemctl restart systemd-sysctl
+  systemctl restart tlp.service
+  echo "[5/5] applied; restarted systemd-sysctl and tlp"
+else
+  echo "[5/5] Config edited and validated; nixos-rebuild NOT run. Run it when ready:"
+  echo "    sudo nixos-rebuild switch && sudo systemctl restart systemd-sysctl tlp.service"
+fi
+
+echo
+echo "Verify (all three must hold — the first is the one that has been failing):"
+echo "  sysctl kernel.nmi_watchdog          # expect 1  (was 0, reverted by TLP)"
+echo "  sysctl kernel.hardlockup_panic      # expect 1"
+echo "  sysctl kernel.panic                 # expect 20"
+echo
+echo "Then re-check AFTER moving the charger, which is when TLP re-applies:"
+echo "  sysctl kernel.nmi_watchdog          # must STILL be 1"
+echo
+echo "Rollback: cp -a $BAK $CFG && nixos-rebuild switch"

--- a/scripts/tests/test_freeze_instrumentation.py
+++ b/scripts/tests/test_freeze_instrumentation.py
@@ -1,0 +1,154 @@
+"""Coverage for nix/system/apply-freeze-instrumentation.sh.
+
+The script edits a root-owned /etc/nixos/configuration.nix, so the value of a
+test here is entirely in the EDIT LOGIC: does each declaration land inside the
+attrset it has to be in, and does the script refuse rather than guess when its
+anchor is not what it assumed?
+
+Placement is asserted STRUCTURALLY (by brace-matching the enclosing block), not
+by grepping for the text. `NMI_WATCHDOG = 1;` present *somewhere* in the file is
+worthless — the whole point of the change is that it sits inside
+services.tlp.settings, because anywhere else TLP reverts it on the next
+AC<->battery transition.
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "nix" / "system" / "apply-freeze-instrumentation.sh"
+
+# Mirrors the real laptop configuration.nix: a services.tlp block with a nested
+# settings attrset, and a top-level boot.kernel.sysctl block.
+FIXTURE = """\
+{ config, pkgs, ... }:
+
+{
+  services.tlp = {
+    enable = true;
+    settings = {
+      CPU_SCALING_GOVERNOR_ON_AC = "powersave";
+      CPU_BOOST_ON_AC = 1;
+      CPU_BOOST_ON_BAT = 0;
+    };
+  };
+
+  boot.kernel.sysctl = {
+    "fs.inotify.max_user_watches" = 1048576;
+    "fs.file-max" = 300000;
+  };
+
+  boot.kernelPackages = pkgs.linuxPackages_latest;
+}
+"""
+
+
+def run(cfg: Path, expect_ok: bool = True):
+    proc = subprocess.run(
+        ["bash", str(SCRIPT), "--edit-only"],
+        # Inherit the environment and override only CFG. Replacing PATH outright
+        # would drop the suite's launcher-stub dir — see test_no_real_launchers.py,
+        # which pins the set of files that clobber PATH.
+        env={**os.environ, "CFG": str(cfg)},
+        capture_output=True,
+        text=True,
+    )
+    if expect_ok:
+        assert proc.returncode == 0, f"script failed:\n{proc.stdout}\n{proc.stderr}"
+    return proc
+
+
+def block_range(text: str, header_re: str) -> range:
+    """Line range (0-indexed, half-open) of the attrset opened on the header line."""
+    import re
+
+    lines = text.splitlines()
+    starts = [i for i, ln in enumerate(lines) if re.match(header_re, ln)]
+    assert len(starts) == 1, f"expected 1 header for {header_re!r}, got {len(starts)}"
+    start = starts[0]
+    depth = 0
+    for i in range(start, len(lines)):
+        depth += lines[i].count("{") - lines[i].count("}")
+        if depth == 0 and i > start:
+            return range(start, i + 1)
+    raise AssertionError(f"unbalanced braces after {header_re!r}")
+
+
+def line_index(text: str, needle: str) -> int:
+    hits = [i for i, ln in enumerate(text.splitlines()) if needle in ln]
+    assert len(hits) == 1, f"expected exactly 1 line containing {needle!r}, got {len(hits)}"
+    return hits[0]
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Path:
+    p = tmp_path / "configuration.nix"
+    p.write_text(FIXTURE)
+    return p
+
+
+def test_nmi_watchdog_lands_inside_the_tlp_settings_block(cfg: Path):
+    """Anywhere else and TLP reverts it on the next power event."""
+    run(cfg)
+    text = cfg.read_text()
+    settings = block_range(text, r"^\s*settings\s*=\s*\{")
+    assert line_index(text, "NMI_WATCHDOG = 1;") in settings
+
+
+def test_panic_sysctls_land_inside_boot_kernel_sysctl(cfg: Path):
+    run(cfg)
+    text = cfg.read_text()
+    sysctl = block_range(text, r"^\s*boot\.kernel\.sysctl\s*=")
+    assert line_index(text, '"kernel.hardlockup_panic" = 1;') in sysctl
+    assert line_index(text, '"kernel.panic" = 20;') in sysctl
+
+
+def test_journald_lands_at_top_level_not_inside_the_sysctl_attrset(cfg: Path):
+    """It is inserted immediately before the sysctl anchor; off-by-one would bury
+    a `services.journald.extraConfig = ...` string inside boot.kernel.sysctl,
+    which parses but declares a nonexistent sysctl."""
+    run(cfg)
+    text = cfg.read_text()
+    sysctl = block_range(text, r"^\s*boot\.kernel\.sysctl\s*=")
+    assert line_index(text, "services.journald.extraConfig") not in sysctl
+
+
+def test_result_still_parses_as_nix(cfg: Path):
+    if not shutil.which("nix-instantiate"):
+        pytest.skip("nix-instantiate unavailable")
+    run(cfg)
+    proc = subprocess.run(
+        ["nix-instantiate", "--parse", str(cfg)], capture_output=True, text=True
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_is_idempotent(cfg: Path):
+    run(cfg)
+    once = cfg.read_text()
+    run(cfg)
+    assert cfg.read_text() == once, "second run mutated the file again"
+
+
+def test_refuses_when_the_tlp_anchor_is_missing(cfg: Path):
+    cfg.write_text(FIXTURE.replace("services.tlp =", "services.notlp ="))
+    before = cfg.read_text()
+    proc = run(cfg, expect_ok=False)
+    assert proc.returncode != 0
+    assert "services.tlp" in proc.stderr
+    assert cfg.read_text() == before, "failed run left the config mutated"
+
+
+def test_refuses_when_an_anchor_is_duplicated(cfg: Path):
+    """A `count=1` edit against a pattern occurring twice lands on whichever
+    match sed reaches first — not necessarily the one we pictured."""
+    cfg.write_text(FIXTURE + "\n{\n  boot.kernel.sysctl = {\n    \"vm.swappiness\" = 10;\n  };\n}\n")
+    before = cfg.read_text()
+    proc = run(cfg, expect_ok=False)
+    assert proc.returncode != 0
+    assert "found 2" in proc.stderr
+    assert cfg.read_text() == before


### PR DESCRIPTION
## The finding

The laptop (`.155`) has stopped **uncleanly six times since 2026-07-29** — Jul 29, Jul 31, Aug 06, Aug 10, Aug 17, Aug 20 — after a clean June. Classified by tailing each boot for `Journal stopped` / `System Power Off`:

| ended | verdict |
|---|---|
| Jun 22 / Jun 26 / Jul 04 | clean |
| Jul 29 11:07 · Jul 31 14:18 · Aug 06 16:39 | **unclean** |
| Aug 07 / Aug 09 | clean |
| Aug 10 15:26 · Aug 17 23:48 · Aug 20 17:02 | **unclean** |

Not one recorded a cause: no MCE, no oops, no soft-lockup trace, no GPU hang, no OOM, no thermal event.

## Why that absence is structural, not reassuring

1. **`kernel.nmi_watchdog` reads 0.** The kernel enables the hard-lockup detector at boot (`NMI watchdog: Enabled`, 17:20:15) and **TLP writes 0 seven seconds later** (17:20:22). `NMI_WATCHDOG` is absent from the generated `/etc/tlp.conf`, so tlp falls back to its shipped `defaults.conf`, which sets `NMI_WATCHDOG=0`.
2. **`kernel.panic = 0`, `kernel.hardlockup_panic = 0`** — even a *detected* lockup hangs forever instead of panicking, capturing and rebooting. That is the "hold the power button" symptom.
3. **journald at stock `SyncIntervalSec=5m`** — the final minutes before each freeze were never written to disk.

A hard lockup here is silent by construction. The next freeze would have been as blank as the last six.

## Why the NMI fix goes in `services.tlp.settings`

`set_nmi_watchdog()` is called from tlp's `start` path (`sbin/tlp:32`), which re-runs on **every AC↔battery transition** via TLP's udev rules — not just at boot. A `boot.kernel.sysctl` or `sysctl.d` declaration would be silently reverted the next time the charger moves.

## What this does and does not claim

**It does not fix the freezes.** It makes the next one leave evidence. Kernel (7.0.0) and BIOS (03.17) were *constant* across all 13 boots examined, and the only NixOS generations are Jun 23 and Aug 13 — the Jul 29 onset sits inside a generation that had already run cleanly for five weeks. No software change coincides with onset, a shape that also fits hardware degradation (RAM, power delivery, NVMe). A memtest86+ pass remains the cheap discriminator, and the **unread `efi_pstore` dump from the Jul 31 crash** (`/var/lib/systemd/pstore/17855255*/`, root-only) is still the highest-value evidence available.

Also ruled out: memory pressure (62 GB total, 40 GB free, zero swap used, no OOM); suspend/resume (no sleep transition precedes the Aug 17 or Aug 20 freezes); and `apply-perf-tuning-2026-07-30.sh`, which is scoped to the workbench and was never applied to this host.

## Deliberately excluded

- `panic_on_oops` — oopses are *already* logged; the silent case is the hard lockup, which oopses nothing. Would only convert survivable driver oopses into reboots.
- `softlockup_panic` — would reboot during ordinary nix/docker builds on a 4C/8T part. The detector still warns with it at 0.
- `ramoops` — unnecessary; `efi_pstore` is proven working on this machine.

## Tests

7 tests. Placement is asserted **structurally**, by brace-matching the enclosing attrset — `NMI_WATCHDOG = 1;` present *somewhere* in the file is worthless, since anywhere outside `services.tlp.settings` gets reverted on the next power event.

They caught a real bug in the script: `set -euo pipefail` omits `-E`, so the `ERR` trap was **not inherited into shell functions** — a refused edit exited without running the restore and left the config half-written, the exact state the trap exists to prevent. Red before the fix, green after.

Both placement guards were mutation-tested and each died on its own assertion, one test each. The journald off-by-one mutant **still parsed as valid Nix**, so the `nix-instantiate` check alone would never have caught it.

## Gate

`scripts/gate.sh --tier pytest --set hermetic`: `13398 collected, 3 failed`. All three investigated:

- `test_no_real_launchers.py` — **was mine**, now fixed: the test replaced `PATH` instead of inheriting it. Fixed by not clobbering `PATH`, rather than by adding myself to the pin list.
- `test_standup_local_health.py::test_a_running_daemon_shows_its_START_age` — **pre-existing**, reproduced on clean `main` with this change absent (ages render as `never run`).
- `test_standup_local_health.py::test_all_healthy_reads_clean` — same age-rendering root cause; does not reproduce in isolation on either base or this branch.

With this change applied, the targeted run shows the same single pre-existing failure and nothing else: `1 failed, 95 passed`.

⚠️ Worth a separate issue: that standup age-rendering failure is red on `main` today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
