### PR TITLE
fix(browser-bridge): the op-set LISTS were gated, the sentences beside them were not — "11 ops" for months

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -2071,7 +2071,7 @@ field** (the CDP ops are bounded typed ops only; see the CDP security model abov
   what it is NOT". (Deliberately a stronger stance than `upload`'s opt-in:
   `upload` is a risk an operator can knowingly accept for one run, whereas a model
   stealing the screen has no legitimate autonomous use at all.)
-- **`upload` is NOT in the agent's op set** (11 ops, above — no `upload`). The
+- **`upload` is NOT in the agent's op set** (13 ops, above — no `upload`). The
   `browser` CLI keeps it: an operator choosing a path by hand is a legitimate,
   audit-logged action. The autonomous model is different — it is by design pointed
   at untrusted, prompt-injecting pages, and `upload` takes a caller-chosen
@@ -2239,7 +2239,7 @@ set none of them; it only ever supplies typed tool args):
 
 | var | default | what it does |
 |---|---|---|
-| `BROWSER_AGENT_ALLOWED_OPS` | *(unset → the 11-op `ALLOWED_OPS_DEFAULT`)* | space/comma list that REPLACES the agent's op allowlist wholesale. Narrows it (`"text,html"`) or deliberately re-enables an off-by-default op — this is the ONLY supported way to give the autonomous agent `upload` |
+| `BROWSER_AGENT_ALLOWED_OPS` | *(unset → the 13-op `ALLOWED_OPS_DEFAULT`)* | space/comma list that REPLACES the agent's op allowlist wholesale. Narrows it (`"text,html"`) or deliberately re-enables an off-by-default op — this is the ONLY supported way to give the autonomous agent `upload` |
 | `BROWSER_AGENT_OPENCODE` | `opencode` | the opencode binary (test seam) |
 | `BROWSER_AGENT_BROWSER_BIN` | `./browser` | the `browser` CLI used for open/close/probe (test seam) |
 | `BROWSER_AGENT_MODEL` | `openrouter/deepseek/deepseek-v4-flash` | model baked into the per-run agent def |

--- a/scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs
+++ b/scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs
@@ -234,7 +234,7 @@ export function hostDenied(host, allowList, denyList) {
 }
 
 // BROWSER_AGENT_ALLOWED_OPS — the operator's explicit op-set override (a space/
-// comma separated list). Unset/empty → ALLOWED_OPS_DEFAULT (the 11-op browser-only
+// comma separated list). Unset/empty → ALLOWED_OPS_DEFAULT (the 13-op browser-only
 // set). Set → it REPLACES the default wholesale, so it can both narrow the agent
 // (`"text,html"`) and deliberately re-enable an off-by-default op such as `upload`.
 // It is read from the wrapper's environment, which the MODEL cannot influence.

--- a/scripts/browser-bridge/tests/browser_tool.test.mjs
+++ b/scripts/browser-bridge/tests/browser_tool.test.mjs
@@ -1142,6 +1142,41 @@ function opsFromReadme() {
   return [...m[1].matchAll(/`([a-z]+)`/g)].map((x) => x[1]);
 }
 
+test("OP-SET PARITY: the PROSE op COUNT matches the parsed list", () => {
+  // The four sources above are parsed as LISTS, so the parity test never read
+  // the sentences beside them -- and those sentences drifted. `emulate` landed
+  // in #321 and every list was updated; three prose counts were not, and said
+  // "11 ops" for months. One of them sits 75 lines below the constant that
+  // lists 13, so a single file asserted both numbers. A doc gate that reads the
+  // machine-readable half and ignores the human-readable half beside it is
+  // exactly how a reader ends up confidently wrong.
+  //
+  // Anything of the form "<N>-op" or "<N> ops" in an agent-facing source must
+  // therefore equal the real count. Deliberately spelling-tolerant on the
+  // hyphen only -- a NEW phrasing is caught by being absent, not by matching.
+  const n = ALLOWED_OPS_DEFAULT.length;
+  const sources = [
+    ["README.md", readBB("README.md")],
+    ["opencode/tools/browser_tool_impl.mjs", readBB("opencode/tools/browser_tool_impl.mjs")],
+    ["opencode/browser-agent.md", readBB("opencode/browser-agent.md")],
+    ["reference/agent.md", readBB("reference/agent.md")],
+  ];
+  const wrong = [];
+  for (const [label, src] of sources) {
+    for (const m of src.matchAll(/\b(\d+)[- ]ops?\b/g)) {
+      if (Number(m[1]) !== n) {
+        const line = src.slice(0, m.index).split("\n").length;
+        wrong.push(`${label}:${line} says "${m[0]}" but ALLOWED_OPS_DEFAULT has ${n}`);
+      }
+    }
+  }
+  assert.deepEqual(wrong, [],
+    "an agent-facing source states an op COUNT that disagrees with " +
+    `ALLOWED_OPS_DEFAULT (${n} ops):\n  ` + wrong.join("\n  ") +
+    "\nThe lists are gated; these sentences were not. Fix the prose, or if the " +
+    "number is genuinely about something else, reword so it is not '<N> ops'.");
+});
+
 test("OP-SET PARITY: browser.js enum == ALLOWED_OPS_DEFAULT == agent-md == README", () => {
   const sorted = (a) => [...a].sort();
   const impl = sorted(ALLOWED_OPS_DEFAULT);


### PR DESCRIPTION
## The defect

`emulate` landed in #321 and **every machine-readable list was updated with it**. The `OP-SET PARITY` test has been green throughout — because it parses the four sources as *lists*. It never read the prose beside them, and three prose counts still said **11**:

| | |
|---|---|
| `README.md:2074` | `(11 ops, above — no \`upload\`)` |
| `README.md:2242` | `the 11-op \`ALLOWED_OPS_DEFAULT\`` |
| `opencode/tools/browser_tool_impl.mjs:237` | `the 11-op browser-only` |

That last one sits **75 lines below the constant that lists 13** — a single file asserting both numbers.

`reference/agent.md` said 11 too and was corrected in #586. Fixing it there left the repo **disagreeing with itself**, which is a worse state than being uniformly wrong, so this closes the rest.

**Nothing about the runtime changes** — `ALLOWED_OPS_DEFAULT` has been 13 the whole time. What changes is that a reader of any of those sentences was confidently wrong about what the autonomous agent can reach, on the surface where being wrong costs an `op_not_allowed` mid-run.

## The prose is now gated too

A doc gate that reads the machine-readable half and ignores the human-readable half beside it is exactly how this happened. The new test asserts every `<N>-op` / `<N> ops` in the four agent-facing sources equals `ALLOWED_OPS_DEFAULT.length` — **derived from the constant, never restated**.

## Mutation battery

Each mutant killed, with the right `file:line` named in the failure:

| mutant | reported |
|---|---|
| README 13 → 11 | `README.md:2074 says "11 ops" but ALLOWED_OPS_DEFAULT has 13` |
| impl comment 13 → 11 | `browser_tool_impl.mjs:237 says "11-op" … has 13` |
| `agent.md` 13 → 11 (undoing #586) | `reference/agent.md:193 says "11 ops" … has 13` |
| **a 14th op added to the CODE** | 4 failures at once — every count now stale |

Positive control green. Node tier `1119/1119`, `RESULT: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)