### PR TITLE
docs(clawgate): the idle reaper stopped destroying things at 0.7.96 — the skill still said it did

### DIFF
--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -23,7 +23,7 @@ live pin, `git grep` for the feature.
 | file | read it when |
 |---|---|
 | `deploy.md` | **building + shipping a version**: manifest-vs-code + CSS-cwd traps; chart sync |
-| `task-api.md` | **writing/debugging a producer**; `clawgatectl` + exit codes; **the 22-route `/api/*` inventory with its auth**; tag grammar |
+| `task-api.md` | **writing/debugging a producer**; `clawgatectl` + exit codes; **the 23-route `/api/*` inventory with its auth**; tag grammar |
 | `agent-dispatch.md` | debugging the agent loop; `POST /agents`; the sandbox fixture; a silent non-start |
 | `extension.md` | you changed the extension, or need to know which build is loaded |
 | `changelog.md` | *when* a feature landed / why an old decision stands |
@@ -57,7 +57,7 @@ so **the LAN NodePort is fully unauthenticated** — including `DELETE /tasks/{i
 /api/auto-approve-all`** (arms a global window auto-approving **every** future request in **every**
 project *and* sweeps the pending queue; checkpoints excepted). `requireHookToken` is
 **enforce-when-set**: an empty token opens the machine endpoints too. All four wrappers across all
-118 routes: `task-api.md`.
+120 routes: `task-api.md`.
 
 ---
 
@@ -175,8 +175,9 @@ the one lever you have.
   flag: the header IS the impersonation guard, and `user`/`operator` are unreachable by design. An
   unknown `--source` is silently downgraded to `api`, so the CLI warns on stderr when the author it
   gets back differs from the one it asked for.
-- ⚠ **A comment/status write also refreshes the task's idle clock**, which matters: the reaper
-  dismisses anything untouched for 7d, and dismissing **tears down the linked agent pod**.
+- ⚠ **A comment/status write also refreshes the task's idle clock** — the daily reaper TAGS anything
+  untouched for 7d `stale` (+ a system comment). **Non-destructive since 0.7.96**: it no longer
+  dismisses the task or tears the agent pod down.
 
 ## machine (hook-token) Task API
 Read/create with `clawgatectl task ls --summary [--status open --tag t --limit n]` · `task get <id>`
@@ -187,11 +188,12 @@ DELETE, `/api/tags`, `/api/projects`, `/api/notify`) is still curl with `Authori
 $CLAWGATE_HOOK_TOKEN` or `X-Clawgate-Token`. Statuses are exactly `open` / `in_progress` /
 `ready_for_review` / `complete` — no `dismissed`; dismissing deletes.
 
-🔴 **Two paths delete a task, both TEARING DOWN its live dispatched agent pod** (shared
-`dismissTask`; **no in-progress guard, deliberately**): `DELETE
-/api/tasks/{id}`, unauthenticated on the LAN (above), and 🔴 **its automated twin the idle-task
-reaper** — the daily sweep dismisses any task untouched for **7d**, and `CLAWGATE_TASK_TTL` is
-**unset in the deployment** so that default is LIVE (`off`/`0` disables).
+🔴 **ONE path deletes a task and TEARS DOWN its live dispatched agent pod**: `DELETE /api/tasks/{id}`
+(`dismissTask`; **no in-progress guard, deliberately**), unauthenticated on the LAN (above).
+⚠ **Its automated twin is RETIRED — do not re-derive it.** Since **0.7.96** (`cf529d41`, live) the
+daily idle-task reaper **tags `stale` + posts a system comment** instead of calling `dismissTask`, so
+**nothing destroys a task or an agent pod on a timer**. `CLAWGATE_TASK_TTL` is still **unset in the
+deployment**, so the 7d default is LIVE — it now costs a tag, not the task (`off`/`0` disables).
 
 ⚠ **Tags are hard-validated: one invalid tag or unknown `runbook:` is a hard 400 that fails the whole
 create** — a load-bearing wire contract producers key their retry on.

--- a/claude/skills/clawgate/reference/changelog.md
+++ b/claude/skills/clawgate/reference/changelog.md
@@ -137,7 +137,8 @@ FAB** (per-agent unread → session); session-id-in-URL; a consolidated **auto-a
   every platform (not an Android limit); `notificationText()`.
 - **0.7.61 — idle-task reaper.** The daily retention sweep auto-dismisses tasks untouched **>7d**
   AND tears down their linked agent pods. Env **`CLAWGATE_TASK_TTL`** (`off`/`0` disables);
-  centralized in `dismissTask`.
+  centralized in `dismissTask`. 🔴 **SUPERSEDED at 0.7.96 — the sweep now TAGS `stale` and destroys
+  nothing.** The `CLAWGATE_TASK_TTL` half still holds; see the 0.7.96 entry at the end.
 - **0.7.62** markdown chat title + status icon removed from the chat header + sticky autoscroll.
 - **0.7.63 — the SCROLL ROOT FIX.** The page is a fixed-height app shell (`h-dvh` +
   `overflow-hidden`) so **`#chat-log` is the ACTUAL scroller**.
@@ -189,5 +190,21 @@ FAB** (per-agent unread → session); session-id-in-URL; a consolidated **auto-a
   JS leak is unfixed (0.7.79 never touched `markdown.go`) — don't trust it. Residual: a backtick
   inside a URL renders a truncated autolink plus literal text (no control byte in the href).
 
-**Live pin as of 2026-08-13: 0.7.87** (`clawgatectl health`). Zach ships concurrently — this line is
+## 0.7.90–0.7.97 (2026-08-18→20)
+- 🔴 **0.7.96 — the idle-task reaper is NO LONGER DESTRUCTIVE** (`cf529d41`). `reapIdleTasks` now
+  `AddTags`+`AddComment` (tag `stale` + a system comment) instead of calling `dismissTask`, so the
+  **7d sweep no longer soft-deletes a task or tears down its linked agent pod**. This RETRACTS the
+  0.7.61 entry above for anything ≥0.7.96 — the only remaining pod-destroying path is the manual
+  `DELETE /api/tasks/{id}`. ⚠ `internal/api/server.go:1316-1321` still carries the OLD comment
+  ("the reaper is destructive", "calls `dismissTask`") ~70 lines above the function that
+  contradicts it — don't trust it.
+- **0.7.97** repo-backed agents get the task-API guidance without touching the repo's `AGENTS.md`,
+  plus a close-out branch for blockers they cannot resolve (`790aeb09`).
+- ⏳ **NOT YET PINNED (trunk only): task↔session threads** (#357, `3c0062ea`). Migration 0023
+  `task_sessions`; `clawgatectl` sends `X-Clawgate-Session-Id` + `X-Clawgate-Host` on **every** task
+  subcommand; `sessions` embedded on task reads (`omitempty`); one new route
+  `GET /api/sessions/{id}/tasks`. When this pins, the pickup ritual's prose `session <id>` line in
+  SKILL.md is superseded by the structural link — re-read the commit before documenting it.
+
+**Live pin as of 2026-08-20: 0.7.97** (`clawgatectl health`). Zach ships concurrently — this line is
 stale by design; always re-check.

--- a/claude/skills/clawgate/reference/task-api.md
+++ b/claude/skills/clawgate/reference/task-api.md
@@ -275,12 +275,16 @@ and **no login QR to manage**.
   Runbook **checkpoints** (`store.TypeCheckpoint`) are skipped in the sweep — an approval gate stays
   a human decision. Disable with `enabled=false`, which clears the window and falls back to the
   per-project rules. e2e coverage: `e2e/tests/auto-approve-all.spec.ts` (2 tests, **not** Docker-gated).
-- 🔴 **The idle-task reaper is a second unattended destroyer.** `defaultTaskReapAfter = 7d`
-  (`internal/api/server.go:1229`); the daily retention sweep calls `reapIdleTasks` (`:1303`) which
-  calls the **same `dismissTask`** as `DELETE /api/tasks/{id}` (`:1318`) — so an idle task's linked
-  agent pod is torn down too. `CLAWGATE_TASK_TTL` is **unset in the live deployment** (verified
-  2026-08-12), so the 7d default is what is running; `off` or `0` disables the reaper. Measured live 0.7.85, 2026-08-11: `GET /api/requests` → **200
-  with no credential**, `GET /api/tasks` → **401**. Never infer exposure from the path prefix.
+- ⚠ **The idle-task reaper is NOT a second unattended destroyer — not since 0.7.96.** It used to
+  call the **same `dismissTask`** as `DELETE /api/tasks/{id}`, tearing down the linked agent pod on a
+  timer; `cf529d41` replaced that with `AddTags`+`AddComment`, so a task untouched past the window is
+  **tagged `stale` and left intact** (`reapIdleTasks`, `internal/api/server.go:1398`). Re-read the
+  function before re-deriving the old claim — the 60 lines of comment ABOVE it still describe the
+  destructive version. `defaultTaskReapAfter = 7d` (`:1284`) and `CLAWGATE_TASK_TTL` is **unset in
+  the live deployment** (re-verified 2026-08-20, live 0.7.97), so the 7d default is what runs;
+  `off`/`0` disables it.
+- 🔴 **Never infer exposure from the path prefix.** Measured live 0.7.85, 2026-08-11:
+  `GET /api/requests` → **200 with no credential**, `GET /api/tasks` → **401**.
 - 🔴 **`/operator/*` is a THIRD credential** — `requireOperatorToken` demands the reserved Operator
   *agent's* hooks token, not the hook token, which gets `401 {"error":"not the operator"}`. It
   covers **11 of the 13** `/operator*` routes; `GET /operator` and `POST /operator/provision` are
@@ -294,17 +298,25 @@ and **no login QR to manage**.
 
 ---
 
-## The complete machine surface — all 22 `/api/*` routes, with auth
+## The complete machine surface — all 23 `/api/*` routes, with auth
 
 🔴 **Read this before concluding a capability does not exist.** The core SKILL.md used to name
-three clawgate routes (`/health`, `/api/send`, `POST /agents`) out of **118 registered**. That gap
+three clawgate routes (`/health`, `/api/send`, `POST /agents`) out of **120 registered**. That gap
 is not cosmetic: it is why `GET /api/agents` went unnoticed and someone reached into Postgres with
 `SELECT id FROM agents WHERE name=…` for a lookup one authenticated GET already answered.
 
-**Source of truth: `containers/clawgate/internal/api/testdata/routes.golden`** — 118 routes, checked
-in, diffed by `TestRoutesMatchGolden` against what `registerRoutes` actually registers, so a route
+**Source of truth: `containers/clawgate/internal/api/testdata/routes.golden`** — checked in, diffed
+by `TestRoutesMatchGolden` against what `registerRoutes` actually registers, so a route
 added/removed/re-verbed cannot land without a human eyeballing the diff. Regenerate with
 `UPDATE_ROUTES_GOLDEN=1 go test ./internal/api -run TestRoutesMatchGolden`.
+
+⚠ **The golden lives on `trunk`; the surface you can CALL is the deployed pin — they are different
+numbers and the counts here are the DEPLOYED ones.** Re-derived 2026-08-20 against live `0.7.97`:
+**120 routes / 23 `/api/*` deployed**, vs **121 / 24 on trunk**. The single difference is
+`GET /api/sessions/{id}/tasks` (`requireHookToken`, PR #357 — task↔session threads), committed
+without a pin bump, so it is **not callable yet**. Count the golden with
+`grep -vc '^#' routes.golden` (the file's first three lines are comments) and subtract anything
+committed after the live pin.
 
 🔴 **The golden records PATTERNS ONLY — it is BLIND to auth.** By the time a handler reaches the
 mux it is already wrapped, so `requireHookToken(h)` and `requireSession(h)` are the same type and
@@ -325,7 +337,11 @@ two until it was corrected):
 ### `requireHookToken` — 16 routes (what clawgatectl and every producer use)
 <!-- COUNT RE-DERIVED from source on trunk 2026-08-15: 14 registrations in server.go
      + `GET /api/agents` (agents.go:50) + `POST /api/suggest` (suggest.go:30) = 16.
-     Was 15 before the comment-delete route (0.7.90). -->
+     Was 15 before the comment-delete route (0.7.90).
+     RE-CONFIRMED 2026-08-20 (live 0.7.97): still 16 deployed. Trunk carries a 17th,
+     `GET /api/sessions/{id}/tasks` (#357), NOT yet pinned — see the note above.
+     Re-derive with: grep -hoE 'HandleFunc\("(GET|POST|PATCH|DELETE) /api/[^"]*",\s*s\.require[A-Za-z]+' \
+       internal/api/*.go | sort | uniq -c -->
 
 | route | clawgatectl | note |
 |---|---|---|
@@ -351,7 +367,7 @@ two until it was corrected):
 `POST /api/push/subscribe` · `POST /api/push/unsubscribe` · `POST /api/auto-approve` ·
 🔴🔴 `POST /api/auto-approve-all` (the firehose — see above).
 
-### The other 96 routes
+### The other 97 routes
 Not `/api/*` and mostly not machine-facing: `/ui/*` htmx fragments, the page routes, `/agents*`
 (dispatch, **form-encoded**, `requireSession`), `/tasks/*` session routes (incl. `POST /tasks/merge`,
 which has **no `/api` counterpart** — deliberately, since its audit comments are authored `user`),


### PR DESCRIPTION
Came out of a read-and-evaluate pass over the `clawgate` skill. Two real drifts, both verified against source and live state rather than against the doc.

## 1. 🔴 The idle-task reaper claim is FALSE in production

Three places asserted the daily sweep **dismisses** a 7d-idle task **and tears down its linked agent pod**. Since **0.7.96** (`cf529d41`) `reapIdleTasks` calls `AddTags`+`AddComment` — tag `stale` + a system comment — instead of `dismissTask`. Live pin is **0.7.97**, so this is deployed, not pending.

| where | was |
|---|---|
| `SKILL.md:178` | idle-clock bullet: "dismissing tears down the linked agent pod" |
| `SKILL.md:190` | "**Two paths** delete a task, both TEARING DOWN its live dispatched agent pod" |
| `reference/task-api.md:278` | "The idle-task reaper is a **second unattended destroyer**" |

`DELETE /api/tasks/{id}` is now the only pod-destroying path. The retired twin is named with its sha so it does not get re-derived, and `changelog.md`'s 0.7.61 entry is marked SUPERSEDED **in place** as well as retracted in a new 0.7.90–0.7.97 section.

Re-verified live, not restated: `CLAWGATE_TASK_TTL` is genuinely absent from the running deployment (only `CLAWGATE_REQUEST_TTL=5m`), so the 7d window is still live — it now costs a tag, not the task.

Drive-by: that same `task-api.md` bullet had the `GET /api/requests` → 200 / `GET /api/tasks` → 401 auth measurement mashed onto its tail, unrelated to the reaper. Split into its own bullet.

## 2. Route counts were low — fixed as instances, not declarations

Deployed `0.7.97` = **120 routes / 23 `/api/*`**; trunk = **121 / 24**. The sole difference is `GET /api/sessions/{id}/tasks` (`requireHookToken`, #357), committed without a pin bump, so it is not callable yet. The doc said 118 / 22 / "the other 96".

Its own two wrapper tables already summed to **23**, so the "22" heading had been inconsistent with its own contents since the 0.7.90 comment-delete route landed. Re-derived the 16 + 7 split against the registration sites: the tables were complete for the deployed surface, only the headings were wrong. Added the re-derive one-liner to the breadcrumb comment so the next count is measured.

## Queued, deliberately not documented

Task↔session threads (**#357**) is on trunk but **unpinned**. When it pins it supersedes the pickup ritual's prose `session <id>` line in `SKILL.md` — flagged in the changelog as `⏳ NOT YET PINNED` with a pointer to re-read the commit rather than guess.

## Not fixed here (different repo)

`homelab-talos` `internal/api/server.go:1316-1321` still documents the destructive reaper ("the reaper is destructive", "calls `dismissTask`") ~70 lines above the function that contradicts it. Worth a one-liner there.

## Gate

`RESULT: PASS (exit=0)` — **13390 passed / 1 skipped / 0 failed**, 24/24 per-target floors met, no timeout panic. Run under `nix develop` in an isolated worktree off `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)