### PR TITLE
fix(docs): a CLIENT subdomain landed on main in a PUBLIC repo — redact to *.example.test

### DIFF
--- a/claudedocs/handoff-browser-bridge-session-attribution.md
+++ b/claudedocs/handoff-browser-bridge-session-attribution.md
@@ -86,9 +86,13 @@ DELTA +17            (reproduced twice; notcivitai.com +1)
    `civitai.com`, `example.com`, `""`, `notcivitai.com`, `model-benchmarking.example.test`,
    `x.test`. `notcivitai.com` exists in exactly ONE file in the repo
    (`tests/test_site_notes.py`, a negative control for suffix matching); `.test` is the
-   reserved testing TLD. Real `claude`-attributed traffic has a long tail —
-   `radio.civitai.com`, `auth-staging.civitaic.com`, `pr-4154.civitaic.com` — **none of which
-   ever appears in the unknown set.**
+   reserved testing TLD. Real `claude`-attributed traffic has a long tail of client
+   subdomains — a media host, a staging auth host, a per-PR preview host, of the shape
+   `radio.example.test`, `auth-staging.example.test`, `pr-4154.example.test` — **none of which
+   ever appears in the unknown set.** (The real hosts are redacted: this repo is PUBLIC and a
+   client's subdomains are internal topology. `scripts/tests/test_no_client_hostnames.py`
+   caught them here, which is the gate doing its job — the argument needs the SHAPE of a long
+   tail, never the names.)
 2. **The journal disproves the unit.** 18 unknown rows landed in a 5-minute window in which
    `browser-bridge.service` logged **0** `dispatch` lines. The unit *does* log `op=text` (636
    over 3 days), so this is not a logging blind spot — those rows never traversed the systemd


### PR DESCRIPTION
## A client subdomain is committed to this PUBLIC repo, and the gate is RED on `main`

`scripts/tests/test_no_client_hostnames.py::test_no_client_subdomain_literal_is_committed` fails on `origin/main` as of #619. `claudedocs/handoff-browser-bridge-session-attribution.md:90` carries a real client subdomain, with two more of the same class on the same line. A client's subdomains are internal topology, and `CLAUDE.md` forbids exactly this.

Found while running the by-hand gate on a merged tree for an unrelated PR — the repo has no CI (`<!-- merge-gate: none -->`), so nothing caught it at merge time.

### The fix

The names were never load-bearing. The sentence argues that real `claude`-attributed traffic has a **long tail** of subdomains, none of which appears in the unknown population — that argument needs the *shape*, not the hostnames. Replaced with `*.example.test` forms, which is the remedy the gate's own failure message prescribes, plus a short note recording why they are redacted so nobody helpfully restores them.

### Verified as a pair, not a bare green

| step | result |
|---|---|
| after the fix | `test_no_client_hostnames` + 3 sibling content gates → **227 passed** |
| positive control — reintroduce the literal | **RED**, same test, by name |
| restore | **18 passed** |

A zero from a scanner is worthless without evidence it can go red on this input; the middle row is that evidence.

### ⚠ What this does NOT do

The literal remains in this repo's **git history**, which is public and which all four content gates are structurally blind to (they read `git ls-files`) — see `SECRETS.md` → "Dead credentials in reachable history". This cleans `HEAD` and unbreaks the gate. It does not unpublish anything.
