### PR TITLE
test(standup): two tests needed 25h of UPTIME — from the laptop that keeps freezing

### DIFF
--- a/claude/skills/standup/standup.sh
+++ b/claude/skills/standup/standup.sh
@@ -298,7 +298,12 @@ scan_local(){
     echo "  (systemctl unavailable — skipped)"; LOCAL_DEGRADED=1; return; }
   local up raw rc failed nfailed spec unit label show load active sub result
   local runflag mono age mark
-  up=$(awk '{print int($1)}' /proc/uptime 2>/dev/null)
+  # STANDUP_UPTIME_SECONDS is a TEST SEAM. Unit ages are derived from monotonic
+  # stamps relative to boot, so without it every age assertion is capped by the
+  # HOST'S REAL UPTIME: a fixture claiming "started 25h ago" silently clamps to 0
+  # on a host up 5h and renders "never run" — which reads as a standup bug and is
+  # not one. Measured 2026-08-20 on the laptop (up ~5h, and it reboots often).
+  up=${STANDUP_UPTIME_SECONDS:-$(awk '{print int($1)}' /proc/uptime 2>/dev/null)}
 
   # 1. failed user units. Only tokens ending in a real unit suffix are kept, so
   #    a stray header or legend line can never leak in as a "failed unit".

--- a/scripts/tests/test_standup_local_health.py
+++ b/scripts/tests/test_standup_local_health.py
@@ -46,6 +46,12 @@ from testlib.mockbin import write_exec  # noqa: E402
 STANDUP = Path(os.environ.get(
     "STANDUP_SH", REPO_ROOT / "claude" / "skills" / "standup" / "standup.sh"))
 
+#: Fake host uptime shared by the harness and standup.sh, so unit ages are a
+#: function of the fixture alone. Comfortably larger than the largest `*_ago`
+#: any test uses (90000s = 25h), because an age exceeding uptime is physically
+#: unrepresentable and clamps to "never run".
+SYNTHETIC_UPTIME = 604800  # 7 days
+
 pytestmark = pytest.mark.skipif(
     not shutil.which("bash"), reason="needs bash on PATH")
 
@@ -111,8 +117,14 @@ class Harness:
         self.bin.mkdir(parents=True, exist_ok=True)
         self.fix.mkdir(parents=True, exist_ok=True)
         write_exec(self.bin / "systemctl", SYSTEMCTL_STUB)
-        with open("/proc/uptime") as fh:
-            self.uptime = int(float(fh.read().split()[0]))
+        # SYNTHETIC, not /proc/uptime. Reading the real uptime made every age
+        # assertion depend on how long the host happened to have been up: an
+        # `*_ago` larger than the real uptime clamps to 0 in `mono()` below and
+        # renders "never run", so `test_a_running_daemon_shows_its_START_age`
+        # (start_ago=90000, i.e. 25h) passed only on a host up more than a day.
+        # It failed on the laptop, which is up ~5h and reboots often. standup.sh
+        # honours STANDUP_UPTIME_SECONDS so both sides share this clock.
+        self.uptime = SYNTHETIC_UPTIME
 
     def failed(self, *units):
         (self.fix / "failed.txt").write_text(
@@ -171,6 +183,7 @@ class Harness:
             env["PATH"] = str(self._restricted_bin())
         env["SC_FIX"] = str(self.fix)
         env["STANDUP_LOCAL_UNITS"] = units
+        env["STANDUP_UPTIME_SECONDS"] = str(self.uptime)
         env.pop("SC_FAIL_ALL", None)
         env.pop("SC_FAIL_SHOW", None)
         env.pop("SC_FAIL_FAILED", None)


### PR DESCRIPTION
Gating the **merged tree** after #616 landed found five failures. **#622 and #623 have since fixed three of them on main** (the client-subdomain leak and the guard_core branch dependence) — and #623's approach, building real git repos on named branches with a self-validating fixture, is better than the non-repo-dir approach I had. This PR is now **only the remaining two**, which are the same class of defect.

## The defect

The harness derived systemd monotonic stamps from the **real `/proc/uptime`**. An `*_ago` larger than the host's uptime clamps to `0` in `mono()`, and standup then *correctly* renders `never run`.

`test_a_running_daemon_shows_its_START_age` asks for `start_ago=90000` — 25 hours. So it only ever passed on a host that had been up more than a day.

It failed on the laptop, which is up ~5h and reboots often: the same laptop whose unclean-stop history prompted #616. **A test that requires 25h of uptime from a machine that keeps hard-freezing is not a test of standup.**

## The fix

`standup.sh` honours `STANDUP_UPTIME_SECONDS` (a documented test seam, defaulting to `/proc/uptime`), and the harness supplies a synthetic 7-day clock. Both sides share one clock, and the whole file stops depending on the host it runs on.

## Verification

| check | result |
|---|---|
| this 5h-uptime host | **19/19** (was 18 passed / 1 failed) |
| mutation control — seam removed | **both** failures return |

The mutation control is the load-bearing part: it confirms the seam is what makes the tests pass, and it explains `test_all_healthy_reads_clean` — which had looked like an unreproducible flake in the full gate — as the same uptime dependence rather than timing noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
