### PR TITLE
fix(registrar): `matcher` was part of the de-dup identity on events that HAVE NO MATCHERS — every doubled Stop hook survived

### DIFF
--- a/scripts/claude-hooks/register-nudge-hook.py
+++ b/scripts/claude-hooks/register-nudge-hook.py
@@ -21,14 +21,24 @@ APPEND-ONLY / never rewrites". That is no longer true — read all three before 
     and a command that does not resolve to a managed hook script comes back
     byte-identical.
   * DE-DUP surface (NARROWEST, newest): a second registration of the SAME managed
-    script on the SAME event under the SAME matcher is deleted, keeping the FIRST
-    occurrence with its position and every key it arrived with. It is narrower
+    script on the SAME event under the SAME SCOPE is deleted, keeping the FIRST
+    occurrence with its position and every key it arrived with. SCOPE is the
+    entry's `matcher` on an event that HAS matchers, and nothing at all on an
+    event that does not — the two are enumerated in NO_MATCHER_EVENTS and
+    MATCHER_EVENTS below, from the hooks documentation. That distinction is
+    load-bearing rather than pedantic: `Stop` and `UserPromptSubmit`, where this
+    script registers most of its hooks, fire on every occurrence, so two entries
+    for one script there BOTH run however their matchers differ. It is narrower
     than the append surface in one direction and equal in the other: it removes
     only an entry of EXACTLY the shape this script writes (no foreign key, one
     hook, no arguments after the script path) AND only for a script this script
     registers — so a doubled bash-guard, whose registration belongs to the host,
-    is reported rather than removed. Anything still doubled after the pass is
-    named on stderr. See "WHY THE DE-DUP EXISTS" below.
+    is reported rather than removed. Any MANAGED hook script left registered
+    more than once on one event is named on stderr, and so is a `matcher` key
+    sitting on an event that has no matchers. A doubled FOREIGN command is NOT:
+    the recogniser cannot read it, so this script can neither count it reliably
+    nor tell a deliberate double from an accident in config it does not own.
+    See "WHY THE DE-DUP EXISTS" below.
 
 WHY THE REWRITE EXISTS — the 127 window.
 `home-manager switch` updates ~/.nix-profile as remove-then-install, so every switch
@@ -213,12 +223,17 @@ _MANAGED_CMD_RE = re.compile(
 )
 
 
-def managed_script_of(cmd):
-    """The devrc-managed hook script this command invokes, or None.
+def managed_match(cmd):
+    """The regex match for a devrc-managed hook invocation, or None.
 
     THE single recogniser — all three surfaces key on it, so "what counts as a
     managed hook command" is answered in one place and cannot disagree between
-    the rewrite pass, the de-dup pass and the append pass.
+    the rewrite pass, the de-dup pass and the append pass. It returns the MATCH
+    rather than a bool so the two callers that need a span (`bare_managed_command`,
+    `normalized_command`) reuse it instead of re-running the regex — a second
+    `.match()` is not only redundant, it is a `.end()` on an `Optional[Match]`
+    that only the earlier call proves is not None, which pyright flags and a
+    future refactor could make true.
 
     Conservative on purpose — three independent conditions must all hold:
       1. the command is `<one-token> <hooks-dir-path>[ args]`;
@@ -237,7 +252,13 @@ def managed_script_of(cmd):
         return None
     if not os.path.basename(m.group("interp")).startswith("python"):
         return None
-    return m.group("base")
+    return m
+
+
+def managed_script_of(cmd):
+    """The devrc-managed hook script this command invokes, or None."""
+    m = managed_match(cmd)
+    return None if m is None else m.group("base")
 
 
 def bare_managed_command(cmd):
@@ -247,20 +268,20 @@ def bare_managed_command(cmd):
     script but is a DIFFERENT configuration — somebody typed those arguments — and
     deleting it would be this script overwriting a decision it did not make.
     """
-    if managed_script_of(cmd) is None:
-        return False
-    return _MANAGED_CMD_RE.match(cmd).end() == len(cmd)
+    m = managed_match(cmd)
+    return m is not None and m.end() == len(cmd)
 
 
 def normalized_command(cmd):
     """Rewrite ONLY the interpreter token of a devrc-managed hook invocation.
 
-    Anything `managed_script_of` does not recognise is returned unchanged — the
+    Anything the recogniser does not recognise is returned unchanged — the
     identical object, so a caller's `new != old` check is exact.
     """
-    if managed_script_of(cmd) is None:
+    m = managed_match(cmd)
+    if m is None:
         return cmd
-    return PYTHON + cmd[_MANAGED_CMD_RE.match(cmd).end("interp"):]
+    return PYTHON + cmd[m.end("interp"):]
 
 
 # The probe the interpreter self-checks below are built from: the first managed
@@ -319,8 +340,13 @@ def hook_python():
     wrapper's exit-0 contract, because there is nothing to contain: no non-zero
     status is produced. The warning is the loud part.
 
-    The fallback to a bare name only fires when sys.executable is empty (an
-    embedded interpreter), which is not a configuration this ever runs in.
+    🔴 THE BARE-NAME FALLBACK IS NEVER WRITTEN ANYWHERE. It fires only when
+    sys.executable is empty (an embedded interpreter), and `python3` is relative,
+    so the module-level guard below refuses to touch settings.json and exits 2.
+    That is the whole point of spelling it: it makes "this process has no
+    interpreter path at all" refuse with `it is not an absolute path` instead of
+    with whatever `os.path.realpath("")` — the CWD — happens to trip, which would
+    blame the recogniser for something else entirely.
     """
     fallback = os.path.realpath(sys.executable) if sys.executable else "python3"
     override = os.environ.get("DEVRC_HOOK_PYTHON")
@@ -338,9 +364,15 @@ PYTHON = hook_python()
 
 # 🔴 INVARIANT GUARD, labelled honestly: it covers the case where the RESOLVED
 # interpreter — not an override, which hook_python already rejected — is one this
-# script's recogniser cannot read back. Reaching it requires running the registrar
-# under a CPython whose realpath basename is not `python*`, which no test here can
-# construct hermetically; it is mutation-checked reachable instead (drop the
+# script may not write. TWO routes reach it, and neither is constructible
+# hermetically from a test here:
+#   * a CPython whose realpath basename is not `python*`, which fails the
+#     recogniser condition; and
+#   * an empty sys.executable, which makes hook_python fall back to the bare name
+#     `python3` — caught by the ABSOLUTE-PATH condition, not the recogniser. So
+#     that fallback can never actually be written into a hook command; see
+#     hook_python for why it is spelled anyway.
+# It is mutation-checked reachable instead (drop the
 # validation from hook_python and run with DEVRC_HOOK_PYTHON=/bin/sh, and this
 # fires with this message). Refusing to write is the right failure: the wrapper
 # turns a non-zero status into a WARNING and exits 0, and settings.json — which
@@ -478,33 +510,106 @@ def _entry_hook_dicts(entry):
     return [h for h in hs if isinstance(h, dict)]
 
 
-def entry_identities(entry):
-    """The (matcher, script) pairs this entry registers.
+# --------------------------------------------------------------------------- #
+# WHICH EVENTS HAVE A `matcher` AT ALL — an explicit, enumerated ledger.
+#
+# From the Claude Code hooks documentation: the events in NO_MATCHER_EVENTS have
+# NO matcher support and "always fire on every occurrence". The ones in
+# MATCHER_EVENTS are narrowed by their `matcher` key — SessionStart's selects the
+# SOURCE (startup/resume/clear/compact/fork) rather than a tool name, but it is a
+# real scope either way, so it stays part of the de-dup identity.
+#
+# 🔴 An ENUMERATION, deliberately not a heuristic on the event name. An event in
+# NEITHER set is treated as matcher-supporting: that is the conservative default,
+# because keeping the matcher in the identity can only ever make this script
+# DECLINE to delete something.
+#
+# 🔴 AND THE HONEST LIMIT OF THE CLAIM: the docs do not say what Claude Code does
+# with a `matcher` key that is present on a non-matcher event, so nothing here
+# asserts it is "ignored". It does not need to. The event fires on every
+# occurrence, so two entries for one script on such an event BOTH run whatever
+# their matchers say — that, and not a claim about how the key is parsed, is why
+# the matcher is dropped from the identity below.
+#
+# Both sets are pinned by tests/test_registrar_activation.py: they must be
+# disjoint, and every event this script's own tables register on must appear in
+# one of them — otherwise the identity for one of THIS script's hooks would fall
+# through to the unknown-event default without anybody deciding that.
+# --------------------------------------------------------------------------- #
+NO_MATCHER_EVENTS = frozenset({
+    "UserPromptSubmit", "PostToolBatch", "Stop", "TeammateIdle", "TaskCreated",
+    "TaskCompleted", "WorktreeCreate", "WorktreeRemove", "CwdChanged",
+    "MessageDisplay",
+})
 
-    🔴 THE IDENTITY KEY FOR THE DE-DUP SURFACE, and the choice is load-bearing in
-    both directions:
+MATCHER_EVENTS = frozenset({
+    "PreToolUse", "PostToolUse", "PermissionRequest", "SessionStart",
+    "SubagentStop", "SessionEnd", "Notification",
+})
+
+
+def event_has_matchers(event):
+    """Does a `matcher` key narrow anything on this event? Unknown events: YES."""
+    return event not in NO_MATCHER_EVENTS
+
+
+def stray_matcher_value(entry, event):
+    """A non-empty `matcher` sitting on an event that has none — or None.
+
+    An empty string is NOT reported: `""` narrows nothing on any event, so
+    flagging it here would blame the event for something that is not
+    event-specific. A named matcher (`"Bash"`) is the misunderstanding worth
+    hearing about — somebody believed they had scoped a Stop hook.
+    """
+    if event_has_matchers(event) or not isinstance(entry, dict):
+        return None
+    matcher = entry.get("matcher")
+    return None if matcher in (None, "") else matcher
+
+
+def entry_identity_list(entry, event):
+    """The (scope, script) pairs this entry registers — one per hook, in order.
+
+    🔴 THE IDENTITY KEY FOR THE DE-DUP SURFACE, and every part of it is
+    load-bearing:
 
       * the SCRIPT, not the command string — the same identity `registered_scripts`
         uses for the append surface, so the two cannot disagree about what "already
         registered" means. It also catches the cross-spelling duplicate (`~/…` and
         `$HOME/…` naming the same hook) that a string key would miss.
-      * the MATCHER, so two entries for one script under DIFFERENT matchers are not
-        duplicates. A hand-scoped narrow entry is a real configuration this script
-        deliberately leaves in place (see `registered_scripts`); collapsing it into
-        the unmatchered one would silently widen a scope the operator narrowed.
+      * the SCOPE, which is the entry's `matcher` ONLY on an event that HAS
+        matchers. There, two entries for one script under DIFFERENT matchers are
+        not duplicates: a hand-scoped narrow entry is a real configuration this
+        script deliberately leaves in place (see `registered_scripts`), and
+        collapsing it into the unmatchered one would silently widen a scope the
+        operator narrowed. On a NO_MATCHER event there is no scope to narrow — the
+        event fires on every occurrence — so the identity is the script alone and
+        two such entries are a real double-fire this script may heal.
 
-    A missing `matcher` and an explicit null are the same identity: both mean
-    "every tool", so two such entries really are the same registration twice.
+    A missing `matcher` and an explicit null are the same identity on every event:
+    both mean "every tool", so two such entries really are one registration twice.
+
+    Returns a LIST, not a set, so a caller counting OCCURRENCES sees an entry that
+    lists the same hook twice inside its own `hooks` array. `entry_identities`
+    collapses it for the callers that want membership.
     """
-    matcher = entry.get("matcher") if isinstance(entry, dict) else None
-    if matcher is not None and not isinstance(matcher, str):
-        # Not a shape this script writes. Keep it hashable and keep it distinct
-        # from both "absent" and every string, so it can never collapse into
-        # another entry's identity and license a deletion.
-        matcher = ("<non-str matcher>", repr(matcher))
-    ids = {(matcher, managed_script_of(h.get("command")))
-           for h in _entry_hook_dicts(entry)}
-    return {i for i in ids if i[1] is not None}
+    if event_has_matchers(event):
+        scope = entry.get("matcher") if isinstance(entry, dict) else None
+        if scope is not None and not isinstance(scope, str):
+            # Not a shape this script writes. Keep it hashable and keep it
+            # distinct from both "absent" and every string, so it can never
+            # collapse into another entry's identity and license a deletion.
+            scope = ("<non-str matcher>", repr(scope))
+    else:
+        scope = None
+    ids = [(scope, managed_script_of(h.get("command")))
+           for h in _entry_hook_dicts(entry)]
+    return [i for i in ids if i[1] is not None]
+
+
+def entry_identities(entry, event):
+    """`entry_identity_list` as a set — membership, for the de-dup decision."""
+    return set(entry_identity_list(entry, event))
 
 
 def removable_duplicate(entry):
@@ -517,6 +622,11 @@ def removable_duplicate(entry):
     after the script path — means somebody configured something this script never
     wrote, so it is kept even when it duplicates. A duplicate is an annoyance; a
     deleted foreign entry is a broken host.
+
+    A `matcher` sitting on a NO_MATCHER event passes this shape check, and should:
+    the key narrows nothing there, so the entry is a plain duplicate of the
+    unmatchered one rather than a scope somebody chose. The stray-matcher warning
+    below names that key whenever such an entry SURVIVES the pass.
     """
     if not isinstance(entry, dict) or set(entry) - {"matcher", "hooks"}:
         return False
@@ -533,7 +643,10 @@ def removable_duplicate(entry):
 
 # --- PASS 1: heal a file an OLDER registrar double-registered ----------------
 # 🔴 Runs FIRST, before the rewrite, so the report cannot claim to have re-pinned
-# an entry it is about to delete.
+# an entry it is about to delete. Pinned behaviourally by scenario 15 of
+# tests/test_register_nudge_hook.py: a run that both removes a duplicate and pins
+# a survivor must name each in exactly one of the two report blocks. Swap these
+# two passes and the removed entry appears in BOTH.
 #
 # Keeping the FIRST occurrence is what preserves position, matcher and every
 # foreign key: the survivor is untouched and only later copies go. `seen` is fed
@@ -548,7 +661,7 @@ for _event in list(hooks):
     _seen = set()
     _kept = []
     for _entry in _arr:
-        _ids = entry_identities(_entry)
+        _ids = entry_identities(_entry, _event)
         if _ids and _ids <= _seen and removable_duplicate(_entry):
             deduped.append("%s: %s" % (_event, _entry["hooks"][0]["command"]))
             continue
@@ -556,22 +669,47 @@ for _event in list(hooks):
         _kept.append(_entry)
     if len(_kept) != len(_arr):
         hooks[_event] = _kept
-    # 🔴 AND SAY WHAT IT DECLINED TO REMOVE. Anything still registered twice under
-    # one matcher after this pass is a real double-fire that this script would not
-    # touch — a foreign key, an argument after the script path, or a script whose
-    # registration it does not own. Leaving that silent is the same failure mode as
-    # the unpinnable commands reported below.
+    # 🔴 AND SAY WHAT IT DECLINED TO REMOVE. A MANAGED hook script still registered
+    # more than once under one scope after this pass is a real double-fire that this
+    # script would not touch — a foreign key, an argument after the script path, or a
+    # script whose registration it does not own. Leaving that silent is the same
+    # failure mode as the unpinnable commands reported below.
+    #
+    # Counted by OCCURRENCE, not by set membership, so an entry that lists the same
+    # hook twice inside its own `hooks` array is counted twice — it fires twice.
+    # A doubled FOREIGN command is out of scope and the module docstring says so:
+    # `entry_identity_list` drops what the recogniser cannot read.
     _counts = {}
     for _entry in _kept:
-        for _id in entry_identities(_entry):
+        for _id in entry_identity_list(_entry, _event):
             _counts[_id] = _counts.get(_id, 0) + 1
     for _id in sorted(_counts, key=lambda i: (i[1], repr(i[0]))):
         if _counts[_id] > 1:
-            warn("%s: %s is registered %d times under matcher %r. This script "
+            _scope = (" under matcher %r" % (_id[0],) if event_has_matchers(_event)
+                      else ", and %s has no matcher support — every copy fires on "
+                           "every occurrence" % _event)
+            warn("%s: %s is registered %d times%s. This script "
                  "removed only the duplicates it wrote itself; the rest carry keys, "
                  "arguments or a registration it does not own, so they were left in "
                  "place and the hook fires %d times per event. Remove the extras by "
-                 "hand." % (_event, _id[1], _counts[_id], _id[0], _counts[_id]))
+                 "hand." % (_event, _id[1], _counts[_id], _scope, _counts[_id]))
+    # 🔴 AND SAY SO ABOUT A `matcher` THAT CANNOT NARROW ANYTHING. On a NO_MATCHER
+    # event the key is a configuration error: somebody believed they had scoped the
+    # hook, and the hook runs every time regardless. Reported over the SURVIVORS, so
+    # a stray matcher this pass has just deleted as a duplicate is not complained
+    # about. Foreign commands included — this is a fact about the EVENT, not about
+    # which script the entry invokes.
+    for _entry in _kept:
+        _stray = stray_matcher_value(_entry, _event)
+        if _stray is None:
+            continue
+        warn("%s: an entry carries matcher %r, but %s has no matcher support and "
+             "always fires on every occurrence — the key narrows nothing and this "
+             "hook runs every time. Remove the key, or move the entry to an event "
+             "that has matchers. Command(s): %s"
+             % (_event, _stray, _event,
+                ", ".join(repr(_h.get("command"))
+                          for _h in _entry_hook_dicts(_entry))))
 
 # --- PASS 2: normalise the interpreter of every managed hook, on every event --
 # 🔴 THE WIDE SURFACE, and the only place this script writes to an entry it does
@@ -736,7 +874,13 @@ except Exception:
         pass
     raise
 if deduped:
-    print("removed duplicate hook registrations:")
+    # 🔴 The spelling matters here. The de-dup pass runs BEFORE the interpreter
+    # rewrite, so a removed entry is reported with the command it was FOUND with —
+    # typically the bare `python3 …` an older registrar wrote. Printed above a
+    # "pinned hook interpreters to /nix/store/…" block, that reads as if the pinning
+    # had missed one. Say which it is instead of leaving the reader to guess.
+    print("removed duplicate hook registrations "
+          "(shown as they were FOUND — de-dup runs before the pinning below):")
     for c in deduped:
         print("  -", c)
 if rewritten:

--- a/scripts/claude-hooks/register-nudge-hook.py
+++ b/scripts/claude-hooks/register-nudge-hook.py
@@ -34,8 +34,12 @@ APPEND-ONLY / never rewrites". That is no longer true — read all three before 
     hook, no arguments after the script path) AND only for a script this script
     registers — so a doubled bash-guard, whose registration belongs to the host,
     is reported rather than removed. Any MANAGED hook script left registered
-    more than once on one event is named on stderr, and so is a `matcher` key
-    sitting on an event that has no matchers. A doubled FOREIGN command is NOT:
+    more than once UNDER ONE SCOPE is named on stderr — the same scope the
+    identity above uses, i.e. the entry's `matcher` on an event that has
+    matchers and the whole event on one that does not, so two entries for one
+    script under DIFFERENT matchers on a matcher-supporting event are not
+    counted and not reported. A `matcher` key sitting on an event that has no
+    matchers is named too. A doubled FOREIGN command is NOT:
     the recogniser cannot read it, so this script can neither count it reliably
     nor tell a deliberate double from an accident in config it does not own.
     See "WHY THE DE-DUP EXISTS" below.
@@ -522,7 +526,23 @@ def _entry_hook_dicts(entry):
 # 🔴 An ENUMERATION, deliberately not a heuristic on the event name. An event in
 # NEITHER set is treated as matcher-supporting: that is the conservative default,
 # because keeping the matcher in the identity can only ever make this script
-# DECLINE to delete something.
+# DECLINE to delete something. That default is not merely asserted here — it is
+# driven behaviourally by scenario 17 of tests/test_register_nudge_hook.py, on an
+# event name the docs have not shipped, and both sets are pinned by EXACT EQUALITY
+# (not a subset) in tests/test_registrar_activation.py. Between them, flipping the
+# default's direction or moving one event across is red. Before that, moving an
+# event into NO_MATCHER_EVENTS was a one-token, deletion-free change that turned
+# the default destructive with the whole suite green.
+#
+# 🔴 BOTH SETS ARE COMPLETE AGAINST THE DOCUMENTED EVENT LIST as of 2026-08-20,
+# re-read from code.claude.com/docs/en/hooks rather than remembered. The 14 events
+# added to MATCHER_EVENTS in that pass were ALL already handled correctly by the
+# unknown-event default, so completing the ledger changed NO behaviour — it moved
+# them from an untested default to a decision somebody made. DirectoryAdded is the
+# one worth naming: it looks like a fire-and-forget event and it is NOT — the docs
+# give it a matcher over how the directory was added (slash_command /
+# register_repo_root), so filing it under NO_MATCHER_EVENTS would license deleting
+# a genuinely distinct registration.
 #
 # 🔴 AND THE HONEST LIMIT OF THE CLAIM: the docs do not say what Claude Code does
 # with a `matcher` key that is present on a non-matcher event, so nothing here
@@ -543,8 +563,12 @@ NO_MATCHER_EVENTS = frozenset({
 })
 
 MATCHER_EVENTS = frozenset({
-    "PreToolUse", "PostToolUse", "PermissionRequest", "SessionStart",
-    "SubagentStop", "SessionEnd", "Notification",
+    "PreToolUse", "PostToolUse", "PostToolUseFailure", "PermissionRequest",
+    "PermissionDenied", "SessionStart", "SessionEnd", "Setup",
+    "SubagentStart", "SubagentStop", "Notification", "PreCompact",
+    "PostCompact", "ConfigChange", "DirectoryAdded", "FileChanged",
+    "StopFailure", "InstructionsLoaded", "UserPromptExpansion", "Elicitation",
+    "ElicitationResult",
 })
 
 
@@ -597,8 +621,20 @@ def entry_identity_list(entry, event):
         scope = entry.get("matcher") if isinstance(entry, dict) else None
         if scope is not None and not isinstance(scope, str):
             # Not a shape this script writes. Keep it hashable and keep it
-            # distinct from both "absent" and every string, so it can never
-            # collapse into another entry's identity and license a deletion.
+            # distinct from both "absent" and every string, so ON THIS BRANCH it
+            # cannot collapse into another entry's identity and license a
+            # deletion.
+            #
+            # 🔴 THAT PROTECTION IS BRANCH-LOCAL, NOT UNCONDITIONAL — this whole
+            # arm is inside `if event_has_matchers(event)`. On a NO_MATCHER event
+            # the `else` below drops the scope to None for EVERY entry, so a
+            # list-valued matcher DOES collapse into an unmatchered copy of the
+            # same script and the later one is deleted. Measured, and correct:
+            # such an event fires on every occurrence, so the two entries really
+            # are one registration twice however the key is spelled. The claim
+            # this branch makes is only "a matcher this script cannot read is
+            # never mistaken for a matcher it can" — read as blanket protection
+            # it would be false, which is why it says where it applies.
             scope = ("<non-str matcher>", repr(scope))
     else:
         scope = None
@@ -610,6 +646,28 @@ def entry_identity_list(entry, event):
 def entry_identities(entry, event):
     """`entry_identity_list` as a set — membership, for the de-dup decision."""
     return set(entry_identity_list(entry, event))
+
+
+def removal_scope_note(entry, event):
+    """How a REMOVED entry was scoped, for the report line.
+
+    🔴 The command alone does not identify which entry went. Two entries for one
+    script differing ONLY by `matcher` both print the same command, so a report
+    keyed on the command emits byte-identical lines and the operator cannot tell
+    which of their registrations this script deleted — nor that it deleted two.
+
+    The note states the matcher AS FOUND (absent and `null` are distinguished
+    from `""`, which is a different thing somebody typed), and on a NO_MATCHER
+    event it also says the key had nothing to narrow — the reason the entry was
+    a duplicate at all rather than a scope.
+    """
+    if isinstance(entry, dict) and "matcher" in entry:
+        found = "matcher %r" % (entry["matcher"],)
+    else:
+        found = "no matcher"
+    if event_has_matchers(event):
+        return "  (%s)" % found
+    return "  (%s; %s has none to narrow)" % (found, event)
 
 
 def removable_duplicate(entry):
@@ -663,7 +721,8 @@ for _event in list(hooks):
     for _entry in _arr:
         _ids = entry_identities(_entry, _event)
         if _ids and _ids <= _seen and removable_duplicate(_entry):
-            deduped.append("%s: %s" % (_event, _entry["hooks"][0]["command"]))
+            deduped.append("%s: %s%s" % (_event, _entry["hooks"][0]["command"],
+                                         removal_scope_note(_entry, _event)))
             continue
         _seen |= _ids
         _kept.append(_entry)
@@ -879,8 +938,15 @@ if deduped:
     # typically the bare `python3 …` an older registrar wrote. Printed above a
     # "pinned hook interpreters to /nix/store/…" block, that reads as if the pinning
     # had missed one. Say which it is instead of leaving the reader to guess.
-    print("removed duplicate hook registrations "
-          "(shown as they were FOUND — de-dup runs before the pinning below):")
+    # 🔴 ...and the clause only says "below" when a pinning block actually
+    # follows. `rewritten` is what builds that block, so pointing at it
+    # unconditionally sends the reader looking for a section that is not there
+    # whenever every command was already pinned — the commonest healing run once
+    # both hosts have been through one switch.
+    print("removed duplicate hook registrations (shown as they were FOUND — %s):"
+          % ("de-dup runs before the pinning below" if rewritten else
+             "de-dup runs before the interpreter pinning, and nothing needed "
+             "pinning this run"))
     for c in deduped:
         print("  -", c)
 if rewritten:

--- a/scripts/claude-hooks/tests/test_register_nudge_hook.py
+++ b/scripts/claude-hooks/tests/test_register_nudge_hook.py
@@ -26,19 +26,29 @@ nudges), and asserts BOTH of the registrant's surfaces:
 
   DE-DUP (narrowest, added 2026-08-20 as the follow-up to the rewrite)
  12. A settings.json an OLDER registrant double-registered — the state a
-     `home-manager rollback` produces — HEALS to one entry per (matcher, script),
+     `home-manager rollback` produces — HEALS to one entry per (scope, script),
      keeping the FIRST occurrence with its position and its foreign keys, while a
-     same-script entry under a DIFFERENT matcher, one carrying ARGUMENTS, one
-     carrying a foreign key and one whose registration this script does not own
-     (bash-guard) all SURVIVE.
+     same-script entry under a DIFFERENT matcher ON A MATCHER-SUPPORTING EVENT,
+     one carrying ARGUMENTS, one carrying a foreign key and one whose
+     registration this script does not own (bash-guard) all SURVIVE.
 
   THE VALIDATED SEAM AND THE WARNINGS (same follow-up)
- 13. A hostile $DEVRC_HOOK_PYTHON — an argument-carrying, relative, non-python or
-     missing interpreter — is rejected with a warning and the resolved fallback is
-     used, so three consecutive runs hold the same number of entries instead of
-     growing without bound.
+ 13. A hostile $DEVRC_HOOK_PYTHON — argument-carrying, relative, non-python,
+     missing, a directory, or a real python file with no execute bit — is rejected
+     with the warning THAT condition owns, and the resolved fallback is used, so
+     three consecutive runs hold the same number of entries instead of growing
+     without bound.
  14. Every command that NAMES a managed hook but is not in the pinnable form is
      reported on stderr, and nothing else is.
+
+  PASS ORDERING AND THE NON-MATCHER EVENTS (2026-08-20, this round)
+ 15. De-dup runs BEFORE the interpreter rewrite, so a run that removes one entry
+     and pins another names each in exactly ONE of the two report blocks.
+ 16. `matcher` is part of the de-dup identity only on an event that HAS matchers.
+     On `Stop` / `UserPromptSubmit` — which always fire on every occurrence — two
+     entries for one script are a double-fire whatever their matchers say, so they
+     heal; and a `matcher` key that SURVIVES on such an event is named on stderr as
+     the configuration error it is.
 
 🔴 THE 127 WINDOW, which surface 6 exists to close: `home-manager switch`
 updates ~/.nix-profile as remove-then-install, so there is a ~1s window in which
@@ -545,18 +555,23 @@ with tempfile.TemporaryDirectory() as tmp:
 # 🔴 `home-manager rollback` / `--switch-generation` (and a hand-run from an older
 # checkout) runs the PREVIOUS registrant against a settings.json this one already
 # pinned. That code keyed "already registered?" on the exact string `python3 ~/…`,
-# does not find it, and appends a SECOND copy of every hook it owns — 13 of them,
-# which is exactly what this fixture holds. Re-running the CURRENT registrant then
+# does not find it, and appends a SECOND copy of every hook it owns — 14 of them
+# once the interview guard joined the append tables, which is exactly what this
+# fixture holds in the pre-migration spelling. Re-running the CURRENT registrant then
 # normalises both copies to identical strings and the append pass, which keys on
 # the SCRIPT, sees the hook as present — so WITHOUT a de-dup pass both survive and
 # every managed hook fires twice forever: duplicate ledger rows, double
 # notifications, and the write-back guard (the only one that can BLOCK) running
 # twice per event.
 #
-# Both directions are asserted: the duplicates go, and a genuinely DISTINCT
-# registration — same script, different `matcher` — SURVIVES. A hand-scoped narrow
-# entry is a real configuration (see `registered_scripts` in the registrant), and
-# collapsing it into the broad one would silently widen a scope somebody narrowed.
+# Both directions are asserted, and the direction turns on the EVENT. On a
+# matcher-supporting event (PostToolUse here) a same-script entry under a DIFFERENT
+# matcher SURVIVES: it is a real hand-scoped configuration (see `registered_scripts`
+# in the registrant), and collapsing it into the broad one would silently widen a
+# scope somebody narrowed. On an event with NO matcher support (Stop) the same shape
+# is NOT a scope — the event always fires on every occurrence — so it is a genuine
+# double-fire and it is removed. Which events those are is an enumerated ledger in
+# the registrant, pinned by test_registrar_activation.py.
 OLD = "python3 ~/.claude/hooks/"
 AUDIT = PY + " ~/.claude/hooks/audit-pr-nudge.py"
 SHELL = PY + " ~/.claude/hooks/shell-env-nudge.py"
@@ -606,7 +621,15 @@ DUPLICATED = {"hooks": {
     ],
     "PostToolUse": [
         one(AUDIT, "Bash"), one(SHELL, "Bash"), one(SEARCH_NUDGE, "Bash"),
-        one(LEDGER), one(WRITEBACK),
+        one(LEDGER),
+        # SURVIVOR A: same script, DIFFERENT matcher, on a MATCHER-SUPPORTING
+        # event. THAT is where a matcher is a real scope and collapsing two
+        # entries into one would widen something somebody narrowed. It used to
+        # live on `Stop` and was described there as "a hand-scoped narrow entry",
+        # which was simply wrong: Stop has no matcher support and always fires on
+        # every occurrence, so that entry was a genuine double-fire, not a scope.
+        one(LEDGER, "Bash"),
+        one(WRITEBACK),
         one(OLD + "audit-pr-nudge.py", "Bash"),
         one(OLD + "shell-env-nudge.py", "Bash"),
         one(OLD + "search-tool-nudge.py", "Bash"),
@@ -616,7 +639,10 @@ DUPLICATED = {"hooks": {
     "Stop": [
         one(TMUX_STOP), one(CLAWGATE_STOP),
         one(NOTIFY), one(NEXT_STEP),
-        # SURVIVOR A: same script, DIFFERENT matcher — a real configuration.
+        # 🔴 NOT a survivor, and it used to be: a `matcher` on `Stop`. Stop has no
+        # matcher support and always fires on every occurrence, so this is the
+        # SAME registration twice and next-step-nudge fires twice per turn. It is
+        # removed, and the surviving copy is the unmatchered FIRST one.
         one(NEXT_STEP, "Bash"),
         one(LEDGER), one(WRITEBACK),
         # SURVIVOR B: same script and matcher, but ARGUMENTS after the script path.
@@ -661,16 +687,23 @@ with tempfile.TemporaryDirectory() as tmp:
 
     # Literal expected end state per event — not derived from the fixture, so a
     # de-dup that removed the WRONG copy (or reordered) fails here.
-    check("12: PostToolUse healed to one entry per (matcher, script)",
+    check("12: PostToolUse healed to one entry per (matcher, script), and the "
+          "distinct-matcher entry SURVIVED on a matcher-supporting event",
           entries(d12, "PostToolUse") == [
               ("Bash", AUDIT), ("Bash", SHELL), ("Bash", SEARCH_NUDGE),
-              (None, LEDGER), (None, WRITEBACK)])
-    check("12: Stop healed, keeping the first copy of each and all three survivors",
+              (None, LEDGER), ("Bash", LEDGER), (None, WRITEBACK)])
+    check("12: Stop healed, keeping the first copy of each and the three survivors",
           entries(d12, "Stop") == [
               (None, TMUX_STOP), (None, CLAWGATE_STOP),
-              (None, NOTIFY), (None, NEXT_STEP), ("Bash", NEXT_STEP),
+              (None, NOTIFY), (None, NEXT_STEP),
               (None, LEDGER), (None, WRITEBACK),
               (None, NOTIFY_ARGS), (None, LEDGER), (None, WRITEBACK)])
+    # 🔴 The matchered Stop copy is GONE, and the unmatchered one is what stayed.
+    # Spelled out on its own because the list equality above would also pass if
+    # BOTH had been removed, or if the wrong one had survived.
+    check("12: the matchered Stop duplicate was removed, keeping the FIRST copy",
+          entries(d12, "Stop").count((None, NEXT_STEP)) == 1
+          and ("Bash", NEXT_STEP) not in entries(d12, "Stop"))
     check("12: SessionStart healed", entries(d12, "SessionStart") == [(None, LEDGER)])
     check("12: UserPromptSubmit healed",
           entries(d12, "UserPromptSubmit") == [(None, NOTIFY), (None, LEDGER)])
@@ -691,14 +724,37 @@ with tempfile.TemporaryDirectory() as tmp:
     check("12: the survivor with a foreign ENTRY-level key kept it",
           [e for e in d12["hooks"]["Stop"]
            if e.get("description") == "the write-back guard, annotated"] != [])
-    # It says what it removed, and how many.
-    check("12: it reports the removals", "removed duplicate hook registrations:"
-          in p12.stdout)
-    check("12: exactly 14 duplicate registrations were removed",
-          len([ln for ln in p12.stdout.splitlines() if ln.startswith("  - ")]) == 14)
-    # ...and it is LOUD about the three double-fires it declined to touch.
+    # It says what it removed, and how many. The header is pinned as a WHOLE
+    # normalised line, not by keyword: the block prints commands with the
+    # spelling they were FOUND with, directly above a "pinned … to /nix/store/…"
+    # block, and the clause that says so is the entire point of the line.
+    check("12: it reports the removals under a header that says the spellings "
+          "are pre-pinning",
+          "removed duplicate hook registrations "
+          "(shown as they were FOUND — de-dup runs before the pinning below):"
+          in p12.stdout.splitlines())
+    # 🔴 15, counted off the FIXTURE above and not off a previous value of this
+    # literal. It is the number two independent changes each moved by one, from
+    # the 13 that predates both: the interview guard's doubled PreToolUse pair
+    # heals to one (+1), and the matchered `Stop` copy of next-step-nudge stopped
+    # being a survivor (+1). Each side of the merge that produced this tree wrote
+    # 14 — correct on its own branch, and wrong here — which is exactly what a
+    # count assertion does when two changes to one fixture land together.
+    check("12: exactly 15 duplicate registrations were removed",
+          len([ln for ln in p12.stdout.splitlines() if ln.startswith("  - ")]) == 15)
+    # ...and it is LOUD about the four double-fires it declined to touch. Counted
+    # on the stem alone, because the scope clause after it now differs by event:
+    # a matcher-supporting event names the matcher, a NO_MATCHER event says why
+    # there is none to name.
     check("12: it warns about the duplicates it declined to remove",
-          p12.stderr.count("is registered 2 times under matcher") == 4)
+          p12.stderr.count("is registered 2 times") == 4)
+    check("12: only the MATCHER-SUPPORTING event's warning names a matcher",
+          p12.stderr.count("is registered 2 times under matcher") == 1
+          and "PreToolUse: bash-guard.py is registered 2 times under matcher "
+              "'Bash'." in p12.stderr)
+    check("12: the Stop warnings say Stop has no matcher support instead",
+          p12.stderr.count("and Stop has no matcher support — every copy fires "
+                           "on every occurrence") == 3)
     check("12: the declined warnings name all four scripts",
           all(s in p12.stderr for s in ("bash-guard.py", "claude-notify.py",
                                         "agent-ledger-hook.py",
@@ -721,30 +777,47 @@ with tempfile.TemporaryDirectory() as tmp:
 # but are just as wrong to write: a relative name reopens the exact PATH window
 # this pinning closes, and a missing path turns every hook into a permanent 127.
 #
-# 🔴 EACH CONDITION IS ISOLATED BY ITS OWN CASE, because these checks MASK one
-# another and a mutant that dies for the neighbour's reason proves nothing about
-# the guard it removed. `os.access(X_OK)` is False for a path that does not
-# exist, so it hides the exists check unless the value is a real EXECUTABLE
-# DIRECTORY; and a bare relative name is not a file in any plausible cwd, so the
-# exists check hides the absolute check unless the value really does resolve from
-# the directory the registrant runs in. Both of those cases are here for exactly
-# that reason — without them, dropping either check is a surviving mutant.
+# 🔴 EACH CONDITION IS ISOLATED BY ITS OWN CASE, AND EACH CASE PINS THE MESSAGE
+# THAT CONDITION OWNS, because these checks MASK one another and a mutant that
+# dies for the neighbour's reason proves nothing about the guard it removed.
+# `os.access(X_OK)` is False for a path that does not exist, so it hides the
+# exists check unless the value is a real EXECUTABLE DIRECTORY; the exists check
+# in turn hides `os.access(X_OK)` unless the value is a real FILE with the
+# execute bit off; and a bare relative name is not a file in any plausible cwd,
+# so the exists check hides the absolute check unless the value really does
+# resolve from the directory the registrant runs in. All four of those cases are
+# here for exactly that reason — without them, dropping the matching check is a
+# surviving mutant. The `reason` column is what makes each one attributable:
+# asserting only that SOMETHING was rejected scores a kill for whichever
+# neighbour fired.
 NOT_A_PYTHON = fake_python("not-a-python", basename="sh")
 _REL_BIN = os.path.dirname(fake_python("relative-store"))
 EXEC_DIR = os.path.join(_FAKE_STORE, "a-directory", "bin", "python3.12")
 os.makedirs(EXEC_DIR, exist_ok=True)
+# A REAL regular file, absolute, with a `python*` basename — every other
+# condition passes — whose only defect is the missing execute bit. 0644 has no
+# execute bit at all, so `access(X_OK)` is False even for root.
+NOT_EXECUTABLE = fake_python("no-execute-bit")
+os.chmod(NOT_EXECUTABLE, 0o644)
 
 HOSTILE_OVERRIDES = [
-    (PY + " -X utf8", "carries an argument", None),
-    ("python3", "relative", None),
-    ("python3.12", "relative but resolvable from the cwd", _REL_BIN),
-    (NOT_A_PYTHON, "absolute and executable but not a python", None),
-    (PY + "-gone", "absolute python path that does not exist", None),
-    (EXEC_DIR, "an executable DIRECTORY with a python name", None),
+    (PY + " -X utf8", "carries an argument", None,
+     "not recognised by this script's own recogniser"),
+    ("python3", "relative", None, "it is not an absolute path"),
+    ("python3.12", "relative but resolvable from the cwd", _REL_BIN,
+     "it is not an absolute path"),
+    (NOT_A_PYTHON, "absolute and executable but not a python", None,
+     "not recognised by this script's own recogniser"),
+    (PY + "-gone", "absolute python path that does not exist", None,
+     "no such file"),
+    (EXEC_DIR, "an executable DIRECTORY with a python name", None,
+     "no such file"),
+    (NOT_EXECUTABLE, "an absolute python FILE with no execute bit", None,
+     "not executable"),
 ]
 RESOLVED = os.path.realpath(sys.executable)
 
-for hostile, why, hostile_cwd in HOSTILE_OVERRIDES:
+for hostile, why, hostile_cwd, expected_reason in HOSTILE_OVERRIDES:
     with tempfile.TemporaryDirectory() as tmp:
         home = os.path.join(tmp, "home")
         os.makedirs(os.path.join(home, ".claude"))
@@ -772,6 +845,13 @@ for hostile, why, hostile_cwd in HOSTILE_OVERRIDES:
               all(r.returncode == 0 for r in runs))
         check(tag + ": the override is rejected OUT LOUD",
               all("DEVRC_HOOK_PYTHON" in r.stderr for r in runs))
+        # 🔴 ...for THIS condition's own reason. Without this the whole loop is
+        # satisfied by any rejection at all, so deleting the one check this case
+        # exists to cover scores as KILLED by whichever neighbour happened to
+        # fire — or, when no neighbour fires, the case is the only thing standing
+        # between the guard and a silent survival.
+        check(tag + ": rejected for the reason THIS condition owns",
+              all(expected_reason in r.stderr for r in runs))
         # THE UNBOUNDED-GROWTH LOOP, CLOSED: a literal, not a comparison against
         # run 1 — a run that appended nothing at all would satisfy `a == b == c`.
         check(tag + ": three consecutive runs hold exactly 16 hook commands",
@@ -836,6 +916,159 @@ with tempfile.TemporaryDirectory() as tmp:
     # above are about the warning and not about a run that died early.
     check("14: ...while the run did its normal work on the same file",
           NEXT_STEP in cmds(d14, "Stop"))
+
+# --- 15. THE DE-DUP PASS RUNS BEFORE THE REWRITE PASS ------------------------
+# 🔴 The registrant claims this ordering in a comment ("so the report cannot claim
+# to have re-pinned an entry it is about to delete") and NOTHING measured it:
+# swapping the two passes left the whole suite green. It is observable in the
+# report, because the two blocks are built from what each pass touched.
+#
+# The fixture makes one entry removable and a DIFFERENT one pinnable in the same
+# run, so the pinned block is non-empty either way — the positive control that
+# stops "0 pinned lines" from passing this vacuously.
+#
+#   de-dup first (correct): the removed entry never reaches the rewrite, so it is
+#   named ONLY under "removed"; the pinned block holds exactly bash-guard.
+#   rewrite first (the mutant): the duplicate is pinned, reported, and THEN
+#   deleted — so claude-notify appears in BOTH blocks and the pinned block holds
+#   two lines.
+with tempfile.TemporaryDirectory() as tmp:
+    home = os.path.join(tmp, "home")
+    os.makedirs(os.path.join(home, ".claude"))
+    settings = os.path.join(home, ".claude", "settings.json")
+    with open(settings, "w") as f:
+        json.dump({"hooks": {
+            # Pinnable and NOT a duplicate — it must appear under "pinned".
+            "PreToolUse": [one(OLD + "bash-guard.py", "Bash")],
+            # A duplicate in the pre-migration spelling — it must appear under
+            # "removed", and nowhere else.
+            "Stop": [one(NOTIFY), one(OLD + "claude-notify.py")],
+        }}, f, indent=2)
+
+    env = dict(os.environ)
+    env["HOME"] = home
+    env["DEVRC_HOOK_PYTHON"] = PY
+
+    p15 = run(env)
+    check("15: run exits 0", p15.returncode == 0)
+    removed_lines = [ln for ln in p15.stdout.splitlines() if ln.startswith("  - ")]
+    pinned_lines = [ln for ln in p15.stdout.splitlines() if ln.startswith("  ~ ")]
+    check("15: exactly one duplicate was removed, and it is claude-notify",
+          len(removed_lines) == 1 and "claude-notify.py" in removed_lines[0])
+    # POSITIVE CONTROL: the pinned block CAN be non-empty in this run.
+    check("15: exactly one entry was pinned, and it is bash-guard",
+          len(pinned_lines) == 1 and "bash-guard.py" in pinned_lines[0])
+    check("15: the entry it deleted is NOT reported as re-pinned",
+          not any("claude-notify.py" in ln for ln in pinned_lines))
+    check("15: no command is named in BOTH report blocks",
+          {ln[4:] for ln in removed_lines}.isdisjoint({ln[4:] for ln in pinned_lines}))
+    with open(settings) as f:
+        d15 = json.load(f)
+    check("15: the surviving claude-notify is the already-pinned one, exactly once",
+          cmds(d15, "Stop").count(NOTIFY) == 1
+          and OLD + "claude-notify.py" not in cmds(d15, "Stop"))
+
+# --- 16. `matcher` IS A SCOPE ONLY ON AN EVENT THAT HAS MATCHERS -------------
+# 🔴 `Stop`, `UserPromptSubmit` and the other NO_MATCHER events always fire on
+# every occurrence, so a `matcher` there narrows nothing and two entries for one
+# script BOTH run. The de-dup identity used to carry the matcher on every event,
+# so those pairs survived and produced NO warning: the hook fired twice forever.
+#
+# Both halves are asserted here, plus the case that must NOT change: the same
+# shape on a MATCHER-SUPPORTING event still survives.
+STRAY = {"hooks": {
+    "Stop": [
+        one(TMUX_STOP),
+        # (a) the exact shape the audit found: `matcher: ""` beside an absent one.
+        one(NOTIFY), one(NOTIFY, ""),
+        # (b) a NAMED matcher on Stop — a double-fire, not a narrowed scope.
+        one(NEXT_STEP), one(NEXT_STEP, "Bash"),
+        # (c) the matchered copy FIRST, so it is the SURVIVOR: de-dup keeps the
+        #     first occurrence, the useless matcher rides along with it, and it
+        #     is what the stray-matcher warning has to name.
+        one(LEDGER, "Bash"), one(LEDGER),
+        # (c2) the SURVIVING copy carries `matcher: ""`, which narrows nothing on
+        #      ANY event — so it is a duplicate like the rest, but it must NOT be
+        #      reported as a stray matcher: an empty matcher is not an
+        #      event-specific mistake. Without this entry, narrowing the
+        #      stray-matcher test from `in (None, "")` to `is None` is a mutant
+        #      nothing can see.
+        one(WRITEBACK, ""), one(WRITEBACK),
+    ],
+    # (d) THE CONTROL: identical shape on a matcher-supporting event. Here the
+    #     matcher is a real scope and both entries must survive — without this
+    #     line, "drop the matcher from every event's identity" is a mutant this
+    #     scenario cannot see.
+    "PostToolUse": [one(LEDGER), one(LEDGER, "Bash")],
+    # (e) ONE entry listing the SAME hook twice. It fires twice, so the ledger of
+    #     what is still doubled has to COUNT occurrences rather than ask whether
+    #     an identity is present — and it is not removable (two hooks in the list
+    #     is not a shape this script writes), so the only correct behaviour is to
+    #     name it. Counting by set membership scores this entry as one.
+    "UserPromptSubmit": [{"hooks": [{"type": "command", "command": NOTIFY},
+                                    {"type": "command", "command": NOTIFY}]}],
+}}
+
+with tempfile.TemporaryDirectory() as tmp:
+    home = os.path.join(tmp, "home")
+    os.makedirs(os.path.join(home, ".claude"))
+    settings = os.path.join(home, ".claude", "settings.json")
+    with open(settings, "w") as f:
+        json.dump(STRAY, f, indent=2)
+
+    env = dict(os.environ)
+    env["HOME"] = home
+    env["DEVRC_HOOK_PYTHON"] = PY
+
+    p16 = run(env)
+    check("16: run exits 0", p16.returncode == 0)
+    with open(settings) as f:
+        d16 = json.load(f)
+    # Literal end state, not derived from the fixture.
+    check("16: Stop healed to one entry per script, keeping the FIRST of each",
+          entries(d16, "Stop") == [
+              (None, TMUX_STOP), (None, NOTIFY), (None, NEXT_STEP),
+              ("Bash", LEDGER), ("", WRITEBACK)])
+    check("16: exactly four Stop duplicates were removed",
+          len([ln for ln in p16.stdout.splitlines() if ln.startswith("  - ")]) == 4)
+    # THE CONTROL: unchanged on a matcher-supporting event.
+    check("16: the same shape on PostToolUse kept BOTH entries",
+          [i for i in entries(d16, "PostToolUse") if i[1] == LEDGER]
+          == [(None, LEDGER), ("Bash", LEDGER)])
+    # The surviving stray matcher is named on stderr — once, naming the event,
+    # the matcher and the command.
+    check("16: the surviving stray matcher is reported exactly once",
+          p16.stderr.count("has no matcher support and always fires on every "
+                           "occurrence") == 1)
+    check("16: the stray-matcher warning names the event, the matcher and the command",
+          "Stop: an entry carries matcher 'Bash', but Stop has no matcher support"
+          in p16.stderr and repr(LEDGER) in p16.stderr)
+    # ...and it does NOT complain about a stray matcher it just deleted, nor
+    # about the SURVIVING empty-string one, which narrows nothing on ANY event
+    # and so is not a mistake about THIS event.
+    check("16: it does not report a stray matcher on an entry it removed, "
+          "nor an empty one it kept",
+          p16.stderr.count("an entry carries matcher") == 1
+          and "an entry carries matcher ''" not in p16.stderr)
+    check("16: nothing on Stop is left doubled, so Stop gets no double-fire warning",
+          not any(ln.startswith("WARNING Stop:") and "is registered" in ln
+                  for ln in p16.stderr.splitlines()))
+    # 🔴 ...and the ONE entry that lists the same hook twice IS named. Counting by
+    # set membership instead of by occurrence scores it as a single registration
+    # and says nothing, while the hook fires twice on every prompt.
+    check("16: two hooks inside ONE entry are counted as two registrations",
+          p16.stderr.count("is registered 2 times") == 1
+          and "UserPromptSubmit: claude-notify.py is registered 2 times, and "
+              "UserPromptSubmit has no matcher support" in p16.stderr)
+    # A FIXED POINT: the stray matcher survives, is warned about again, and does
+    # not make the registrant rewrite the file on every run.
+    healed16 = open(settings, "rb").read()
+    p16b = run(env)
+    check("16: the second run reports no change", "no change" in p16b.stdout)
+    check("16: the healed file is BYTE-IDENTICAL after a second run",
+          open(settings, "rb").read() == healed16)
+    check("16: ...and the second run still names the stray matcher",
+          "an entry carries matcher 'Bash'" in p16b.stderr)
 
 with open(SCRIPT) as f:
     src = f.read()

--- a/scripts/claude-hooks/tests/test_register_nudge_hook.py
+++ b/scripts/claude-hooks/tests/test_register_nudge_hook.py
@@ -50,6 +50,16 @@ nudges), and asserts BOTH of the registrant's surfaces:
      heal; and a `matcher` key that SURVIVES on such an event is named on stderr as
      the configuration error it is.
 
+  THE UNKNOWN-EVENT DEFAULT AND THE REPORT LINES (2026-08-20, this round)
+ 17. An event in NEITHER ledger is treated as matcher-supporting, so two entries
+     for one script under different matchers there BOTH survive and draw no
+     warning — the 🔴 claim the registrant's own comment makes, which nothing
+     measured. Same run: the double-fire ledger is scoped by matcher (so a
+     cross-matcher pair on a matcher-supporting event is silent, which is what
+     the de-dup docstring now says), two removals differing ONLY by matcher print
+     distinguishable lines, and the removal header stops promising a pinning
+     block when nothing was pinned.
+
 🔴 THE 127 WINDOW, which surface 6 exists to close: `home-manager switch`
 updates ~/.nix-profile as remove-then-install, so there is a ~1s window in which
 the live profile generation is a partial closure with NO python3 on it. A hook
@@ -1069,6 +1079,132 @@ with tempfile.TemporaryDirectory() as tmp:
           open(settings, "rb").read() == healed16)
     check("16: ...and the second run still names the stray matcher",
           "an entry carries matcher 'Bash'" in p16b.stderr)
+
+# --- 17. THE UNKNOWN-EVENT DEFAULT, AND WHAT THE REPORT SAYS -----------------
+# 🔴 THE CONSERVATIVE DEFAULT HAD DELETION POWER AND NO COVERAGE. The registrant
+# claims, in a 🔴 comment, that an event in NEITHER ledger is treated as
+# matcher-supporting and that this "can only ever make this script DECLINE to
+# delete something". Nothing measured it. Two deletion-free one-token mutants
+# survived BOTH suites and the full gate:
+#
+#   M2  `event not in NO_MATCHER_EVENTS`  ->  `event in MATCHER_EVENTS`
+#   M8  add one event name to NO_MATCHER_EVENTS
+#
+# Both flip the default from conservative to DESTRUCTIVE for every event the
+# ledgers do not name: the matcher leaves the identity, two genuinely distinct
+# registrations collapse to one, and the survivor draws a false "has no matcher
+# support" warning. M8 is now caught by the exact-equality pin in
+# test_registrar_activation.py; M2 leaves both ledgers untouched and is caught
+# HERE, behaviourally.
+#
+# The event name is deliberately one the hooks documentation has not shipped —
+# every documented event is now in a ledger, so nothing real would exercise the
+# default. This is the case the comment's claim is actually ABOUT.
+UNKNOWN_EVENT = "AnEventTheHooksDocsHaveNotShippedYet"
+
+# 🔴 Every command in this fixture is ALREADY pinned to PY, so the run rewrites
+# NOTHING. That is load-bearing twice over: it is the state both real hosts are in
+# after one switch, and it is what makes the "nothing needed pinning" report
+# header reachable at all.
+DEFAULTED = {"hooks": {
+    # (a) THE SUBJECT: two entries, one script, DIFFERENT matchers, on an event
+    #     nobody classified. Both are exactly the shape this script writes, so
+    #     the entry-shape check cannot be what saves them — only the scope in the
+    #     identity can. Under M2/M8 the second is deleted.
+    UNKNOWN_EVENT: [one(LEDGER, "manual"), one(LEDGER, "auto")],
+    # (b) THE SENTENCE THE DOCSTRING NOW MAKES: the same shape on a
+    #     matcher-supporting event is not a duplicate AND draws no double-fire
+    #     warning — even though both entries really do fire on every Bash call.
+    #     The docstring used to promise a warning for "more than once on one
+    #     event", which this state falsifies.
+    "PostToolUse": [one(LEDGER), one(LEDGER, "Bash")],
+    # (c) POSITIVE CONTROL for the whole scenario plus the report lines: three
+    #     copies of one script on a NO_MATCHER event, two of them differing ONLY
+    #     by `matcher`. A run that removed nothing would pass (a) and (b)
+    #     vacuously; this makes the removal count non-zero, and the two NOTIFY
+    #     removals print the same command, so their report lines can only differ
+    #     if the line names the scope.
+    "Stop": [one(NOTIFY), one(NOTIFY, "Bash"), one(NOTIFY, "Edit"),
+             one(WRITEBACK), one(WRITEBACK)],
+}}
+
+with tempfile.TemporaryDirectory() as tmp:
+    home = os.path.join(tmp, "home")
+    os.makedirs(os.path.join(home, ".claude"))
+    settings = os.path.join(home, ".claude", "settings.json")
+    with open(settings, "w") as f:
+        json.dump(DEFAULTED, f, indent=2)
+
+    env = dict(os.environ)
+    env["HOME"] = home
+    env["DEVRC_HOOK_PYTHON"] = PY
+
+    p17 = run(env)
+    check("17: run exits 0", p17.returncode == 0)
+    with open(settings) as f:
+        d17 = json.load(f)
+
+    # (a) THE CONSERVATIVE DEFAULT, MEASURED. Literal end state, in order.
+    check("17: an UNCLASSIFIED event keeps BOTH same-script entries under their "
+          "different matchers",
+          entries(d17, UNKNOWN_EVENT) == [("manual", LEDGER), ("auto", LEDGER)])
+    check("17: ...and says nothing about them being doubled",
+          not any(ln.startswith("WARNING " + UNKNOWN_EVENT) and "is registered" in ln
+                  for ln in p17.stderr.splitlines()))
+    check("17: ...and does not call their matchers stray",
+          UNKNOWN_EVENT + ": an entry carries matcher" not in p17.stderr)
+
+    # (c) POSITIVE CONTROL: the harness CAN observe a removal in this same run.
+    removed17 = [ln for ln in p17.stdout.splitlines() if ln.startswith("  - ")]
+    check("17: POSITIVE CONTROL — three Stop duplicates were removed in the very "
+          "run that removed neither unclassified entry", len(removed17) == 3)
+    check("17: Stop healed to the FIRST copy of each script",
+          [i for i in entries(d17, "Stop") if i[1] in (NOTIFY, WRITEBACK)]
+          == [(None, NOTIFY), (None, WRITEBACK)])
+
+    # (b) THE DOCSTRING'S SCOPE: no warning, and both entries survive.
+    check("17: a cross-matcher pair on a MATCHER-supporting event survives",
+          [i for i in entries(d17, "PostToolUse") if i[1] == LEDGER]
+          == [(None, LEDGER), ("Bash", LEDGER)])
+    check("17: ...and the double-fire ledger is scoped by matcher, so it says "
+          "NOTHING about that pair — which is why the docstring says 'under one "
+          "scope' and not 'on one event'",
+          not any(ln.startswith("WARNING PostToolUse:") and "is registered" in ln
+                  for ln in p17.stderr.splitlines()))
+
+    # 🟢 THE REPORT LINES. Two removals name the SAME command and differ only in
+    # the matcher their entry carried; without the scope note they are byte-
+    # identical and the operator cannot tell that two things went.
+    check("17: every removal line is distinct", len(set(removed17)) == 3)
+    notify_lines = sorted(ln for ln in removed17 if NOTIFY in ln)
+    check("17: the two removals that differ ONLY by matcher print differently, "
+          "each naming the matcher it was found under",
+          len(notify_lines) == 2
+          and "(matcher 'Bash'; Stop has none to narrow)" in notify_lines[0]
+          and "(matcher 'Edit'; Stop has none to narrow)" in notify_lines[1])
+    check("17: an absent matcher is reported as absent, not as a value",
+          [ln for ln in removed17 if WRITEBACK in ln
+           and ln.endswith("  (no matcher; Stop has none to narrow)")] != [])
+
+    # 🟢 THE REPORT HEADER. Nothing was pinned in this run — the state a host is
+    # in after one switch — so the header must not send the reader looking for a
+    # pinning block below it.
+    pinned17 = [ln for ln in p17.stdout.splitlines() if ln.startswith("  ~ ")]
+    check("17: POSITIVE CONTROL — this run genuinely pinned nothing",
+          pinned17 == [] and not any(ln.startswith("pinned hook interpreters")
+                                     for ln in p17.stdout.splitlines()))
+    check("17: so the removal header does not promise a pinning block below it",
+          "removed duplicate hook registrations (shown as they were FOUND — "
+          "de-dup runs before the interpreter pinning, and nothing needed "
+          "pinning this run):" in p17.stdout.splitlines())
+
+    # A FIXED POINT, including the unclassified event: the default must not
+    # oscillate, and the second run must not re-append anything.
+    healed17 = open(settings, "rb").read()
+    p17b = run(env)
+    check("17: the second run reports no change", "no change" in p17b.stdout)
+    check("17: the healed file is BYTE-IDENTICAL after a second run",
+          open(settings, "rb").read() == healed17)
 
 with open(SCRIPT) as f:
     src = f.read()

--- a/scripts/claude-hooks/tests/test_registrar_activation.py
+++ b/scripts/claude-hooks/tests/test_registrar_activation.py
@@ -673,18 +673,100 @@ def test_every_event_the_registrar_writes_to_is_classified():
         "default: " + ", ".join(sorted(unclassified)))
 
 
-def test_the_documented_classification_of_the_events_that_drive_the_behaviour():
-    """The ledger's CONTENT, not just its shape — these six are what the de-dup
-    identity actually turns on, and a silent edit to either set would change how
-    real entries are deleted with no other test moving.
+# 🔴 THE LEDGER'S CONTENT, PINNED LITERALLY — re-read from the Claude Code hooks
+# documentation (code.claude.com/docs/en/hooks) on 2026-08-20, NOT derived from the
+# registrar. The registrar's copy is the implementation under test; deriving the
+# expectation from it would make this assert `x == x`.
+#
+# 🔴 EXACT EQUALITY, DELIBERATELY, AND THIS IS THE POINT OF THE TEST. These sets
+# have DELETION POWER: `event_has_matchers` drops `matcher` from the de-dup
+# identity for every event in NO_MATCHER_EVENTS, so moving one event across is a
+# one-token, deletion-free edit that makes the registrar delete registrations it
+# must keep. The predecessor of this test asserted `<=` over six events, so every
+# event outside those six could be moved into the destructive direction with the
+# whole suite — and the full gate — green. Measured on `PreCompact`: adding it to
+# NO_MATCHER_EVENTS made a manual/auto pair for one script collapse to one entry
+# plus a false "has no matcher support" warning, and nothing went red.
+#
+# The cost is real and is the intended trade: adding a hook event to the registrar
+# requires editing this literal in the same commit. That is a decision somebody
+# makes, which is exactly what the old subset let people skip.
+#
+# The docs' wording for the first group is "no matcher support" / "always fires on
+# every occurrence". The second group is narrowed by `matcher`, though not always
+# by a TOOL name — SessionStart's selects the source (startup/resume/clear/compact/
+# fork), PreCompact's the trigger (manual/auto), DirectoryAdded's how the directory
+# was added (slash_command/register_repo_root). A real scope either way, which is
+# all the de-dup identity needs.
+DOCUMENTED_NO_MATCHER_EVENTS = {
+    "UserPromptSubmit", "PostToolBatch", "Stop", "TeammateIdle", "TaskCreated",
+    "TaskCompleted", "WorktreeCreate", "WorktreeRemove", "CwdChanged",
+    "MessageDisplay",
+}
 
-    Values are from the Claude Code hooks documentation: the NO_MATCHER events
-    "always fire on every occurrence"; the others are narrowed by `matcher`
-    (SessionStart's selects the SOURCE — startup/resume/clear/compact/fork —
-    rather than a tool name, but it is a real scope either way).
+DOCUMENTED_MATCHER_EVENTS = {
+    "PreToolUse", "PostToolUse", "PostToolUseFailure", "PermissionRequest",
+    "PermissionDenied", "SessionStart", "SessionEnd", "Setup", "SubagentStart",
+    "SubagentStop", "Notification", "PreCompact", "PostCompact", "ConfigChange",
+    "DirectoryAdded", "FileChanged", "StopFailure", "InstructionsLoaded",
+    "UserPromptExpansion", "Elicitation", "ElicitationResult",
+}
+
+
+def test_the_documented_classification_of_the_events_that_drive_the_behaviour():
+    """Both ledgers, pinned by EXACT EQUALITY against the documented lists.
+
+    A silent edit to either set changes how real entries are deleted, and until
+    this pinned the whole set rather than a six-event subset, most such edits
+    moved nothing else. See the block comment above for the measurement.
     """
     no_matcher = set(registrar_literal("NO_MATCHER_EVENTS"))
     with_matcher = set(registrar_literal("MATCHER_EVENTS"))
-    assert {"Stop", "UserPromptSubmit"} <= no_matcher, sorted(no_matcher)
-    assert {"PreToolUse", "PostToolUse", "SessionStart",
-            "SubagentStop"} <= with_matcher, sorted(with_matcher)
+
+    # Positive control: a parser that returned nothing would make both equalities
+    # fail loudly rather than pass — but say so, so a future reader does not have
+    # to re-derive that this cannot go vacuous.
+    assert len(no_matcher) >= 5 and len(with_matcher) >= 5, (no_matcher, with_matcher)
+
+    assert no_matcher == DOCUMENTED_NO_MATCHER_EVENTS, (
+        "NO_MATCHER_EVENTS no longer matches the documented list. This set has "
+        "DELETION POWER — an event here loses its `matcher` from the de-dup "
+        "identity, so two entries for one script collapse to one. Extra: %r. "
+        "Missing: %r" % (sorted(no_matcher - DOCUMENTED_NO_MATCHER_EVENTS),
+                         sorted(DOCUMENTED_NO_MATCHER_EVENTS - no_matcher)))
+    assert with_matcher == DOCUMENTED_MATCHER_EVENTS, (
+        "MATCHER_EVENTS no longer matches the documented list. Extra: %r. "
+        "Missing: %r" % (sorted(with_matcher - DOCUMENTED_MATCHER_EVENTS),
+                         sorted(DOCUMENTED_MATCHER_EVENTS - with_matcher)))
+
+
+def test_the_dedup_warning_docstring_is_no_wider_than_the_warning_it_describes():
+    """🔴 A DOCSTRING IS A CLAIM ABOUT COVERAGE, and this one was MEASURED FALSE.
+
+    It read "Any MANAGED hook script left registered more than once on one event
+    is named on stderr". It is not: the double-fire ledger counts by the de-dup
+    IDENTITY, whose scope is the entry's `matcher` on a matcher-supporting event.
+    So agent-ledger-hook.py registered twice on PostToolUse — once unmatchered,
+    once under `Bash` — produces ZERO warnings while both entries fire on every
+    Bash call. Scenario 17 of test_register_nudge_hook.py drives that case.
+
+    Pinned as a WHOLE NORMALISED STRING rather than by keyword: the previous
+    sentence and the corrected one share almost every word, so any keyword guard
+    passes on both. A cosmetic reword fails this test — pay it, and re-check that
+    the new wording is still true of `_counts` before updating the literal.
+    """
+    doc = ast.get_docstring(ast.parse(REGISTRAR.read_text())) or ""
+    normalised = " ".join(doc.split())
+    expected = (
+        "Any MANAGED hook script left registered more than once UNDER ONE SCOPE "
+        "is named on stderr — the same scope the identity above uses, i.e. the "
+        "entry's `matcher` on an event that has matchers and the whole event on "
+        "one that does not, so two entries for one script under DIFFERENT "
+        "matchers on a matcher-supporting event are not counted and not reported."
+    )
+    assert expected in normalised, (
+        "the de-dup docstring no longer carries the sentence this test pins. It "
+        "described the stderr ledger as covering a whole EVENT when the code "
+        "scopes it by matcher; if you reworded it, verify the new sentence "
+        "against the `_counts` loop and update the literal here.\nExpected:\n%s"
+        % expected)

--- a/scripts/claude-hooks/tests/test_registrar_activation.py
+++ b/scripts/claude-hooks/tests/test_registrar_activation.py
@@ -606,3 +606,85 @@ def test_the_activation_entry_runs_after_the_hook_files_land():
         "the registrar would run before ~/.claude/hooks/ is populated on a fresh "
         "host; declared dependencies: " + ", ".join(sorted(deps))
     )
+
+
+# --- the EVENT-MATCHER LEDGER, pinned against the tables that depend on it --- #
+def registrar_dict_keys(name):
+    """The KEYS of a module-level dict literal in the registrar.
+
+    `registrar_literal` cannot read SINGLE_EVENT_CMDS: its values are
+    `with_python(...)` CALLS, which `ast.literal_eval` refuses. The keys are
+    plain strings, and the keys are the whole question here.
+    """
+    tree = ast.parse(REGISTRAR.read_text(), filename=str(REGISTRAR))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == name for t in node.targets):
+            continue
+        assert isinstance(node.value, ast.Dict), name
+        return [ast.literal_eval(k) for k in node.value.keys]
+    raise AssertionError("%s is not a module-level dict in %s" % (name, REGISTRAR))
+
+
+def registrar_events():
+    """Every event the registrar's own command tables register a hook on."""
+    events = set()
+    for name in ("NOTIFY_EVENTS", "LEDGER_EVENTS", "WRITEBACK_EVENTS"):
+        events |= set(registrar_literal(name))
+    events |= set(registrar_dict_keys("SINGLE_EVENT_CMDS"))
+    # POST_BASH_CMDS has no event table — its event is spelled in the loop that
+    # appends it — so it is named here rather than derived.
+    events.add("PostToolUse")
+    return events
+
+
+def test_every_event_the_registrar_writes_to_is_classified():
+    """🔴 THE DE-DUP IDENTITY DEPENDS ON THIS CLASSIFICATION, so an event the
+    registrar registers on must not fall through to the unknown-event default.
+
+    `matcher` is part of the de-dup identity only on an event that HAS matchers;
+    on `Stop` / `UserPromptSubmit` the event always fires on every occurrence, so
+    two entries for one script are a double-fire whatever their matchers say.
+    An unclassified event is treated as matcher-supporting — safe, because it can
+    only make the registrar DECLINE to remove something — but for an event it
+    registers on itself that silence is a decision nobody made.
+
+    ⚠ Labelled honestly: an INVARIANT GUARD, not regression coverage. It is green
+    for every event that exists in the tables today; it is here because the NEXT
+    event added to a table lands the same way. Mutation-checked reachable: adding
+    an event to a table without classifying it turns this red naming it.
+    """
+    no_matcher = set(registrar_literal("NO_MATCHER_EVENTS"))
+    with_matcher = set(registrar_literal("MATCHER_EVENTS"))
+
+    # Positive controls: a parser that found nothing would make this vacuous.
+    assert len(registrar_events()) >= 5, registrar_events()
+    assert "Stop" in registrar_events(), registrar_events()
+    assert len(no_matcher) >= 5 and len(with_matcher) >= 5
+
+    assert no_matcher & with_matcher == set(), (
+        "an event is claimed BOTH to have and not to have matcher support: %r"
+        % sorted(no_matcher & with_matcher))
+    unclassified = registrar_events() - (no_matcher | with_matcher)
+    assert unclassified == set(), (
+        "the registrar registers hooks on these events but classifies neither "
+        "way, so their de-dup identity falls through to the unknown-event "
+        "default: " + ", ".join(sorted(unclassified)))
+
+
+def test_the_documented_classification_of_the_events_that_drive_the_behaviour():
+    """The ledger's CONTENT, not just its shape — these six are what the de-dup
+    identity actually turns on, and a silent edit to either set would change how
+    real entries are deleted with no other test moving.
+
+    Values are from the Claude Code hooks documentation: the NO_MATCHER events
+    "always fire on every occurrence"; the others are narrowed by `matcher`
+    (SessionStart's selects the SOURCE — startup/resume/clear/compact/fork —
+    rather than a tool name, but it is a real scope either way).
+    """
+    no_matcher = set(registrar_literal("NO_MATCHER_EVENTS"))
+    with_matcher = set(registrar_literal("MATCHER_EVENTS"))
+    assert {"Stop", "UserPromptSubmit"} <= no_matcher, sorted(no_matcher)
+    assert {"PreToolUse", "PostToolUse", "SessionStart",
+            "SubagentStop"} <= with_matcher, sorted(with_matcher)


### PR DESCRIPTION
Final cleanup round on the hook registrar, following #609 (interpreter pinning) and #615 (de-dup surface). Six items from the delta re-audit.

## 🔴 The behavioural bug — `matcher` was a scope on events that have none

Per the Claude Code hooks documentation, `UserPromptSubmit`, `PostToolBatch`, **`Stop`**, `TeammateIdle`, `TaskCreated`, `TaskCompleted`, `WorktreeCreate`, `WorktreeRemove`, `CwdChanged` and `MessageDisplay` have **no matcher support** and "always fire on every occurrence". `Stop` and `UserPromptSubmit` are where this registrar puts most of its hooks.

`entry_identities` keyed on `(matcher, script)` for **every** event. So on `Stop`, two entries for one script — one with `matcher: ""` or `matcher: "Bash"`, one with the key absent — read as *different registrations*: both survived the de-dup pass, **no warning was printed**, and the hook fired twice per turn forever. The test fixture even labelled such an entry "a hand-scoped narrow entry", which was simply wrong.

Now: the identity is the **script alone** on a non-matcher event and keeps the matcher on an event that has one, classified from an explicit enumerated ledger (`NO_MATCHER_EVENTS` / `MATCHER_EVENTS`), not a heuristic. An event in neither set defaults to matcher-supporting — the conservative direction, since it can only make the script *decline* to delete. A **named** matcher that SURVIVES on a non-matcher event is now reported on stderr as the configuration error it is (`""` is not reported: it narrows nothing on any event, so it is not an event-specific mistake).

Honest limit, kept in the comments: the docs do **not** say what Claude Code does with a `matcher` key on a non-matcher event, so nothing here claims it is "ignored". The operative fact is that the event fires either way.

## The other five

- **`os.access(X_OK)` had no covering test** — deleting it SURVIVED the full suite at base (reproduced). Scenario 13 gains a real `0644` python-named file (absolute, exists, `python*` basename — only the execute bit missing, so the sibling checks cannot mask it), and **every** hostile-override case now asserts the reason *its own* condition owns. Without that column a mutant scores a kill off a neighbour's message.
- **The pass-ordering claim was untested** — swapping the de-dup and rewrite passes left the whole suite green at base (reproduced). Scenario 15 pins it through the two report blocks: a run that removes one entry and pins another must name each in exactly one block; with the passes swapped the removed entry appears in both.
- **Two false claims fixed.** The docstring's "Anything still doubled after the pass is named on stderr" was wider than the code — foreign commands are not counted, and within-entry repeats were collapsed by set membership. The sentence now names its scope *and* the ledger counts OCCURRENCES, so an entry listing one hook twice is reported. The `_UNUSABLE` comment claimed the guard is only reachable via a non-`python*` basename; it missed the `isabs` route, which is also why `hook_python`'s `"python3"` fallback can never be written into a hook command. The fallback is **kept** — it turns "no interpreter path at all" into a refusal that says `it is not an absolute path` rather than one built from `realpath("") == cwd`, which would blame the recogniser — and the docstring now says so.
- **Report cosmetics**: the removal block printed pre-rewrite spellings directly above `pinned hook interpreters to /nix/store/…`. Its header now says which it is.
- **pyright**: `normalized_command` / `bare_managed_command` re-ran `_MANAGED_CMD_RE.match()` purely for a span — `"end" is not a known attribute of "None"` at both sites. One `managed_match()` returns the match and both reuse it. **2 errors → 0.**

## Red-at-base / green-at-HEAD

Base `e7ceb1f` (rebased onto `d12f84c`). New tests run against the base registrar:

| item | at base | at HEAD |
|---|---|---|
| 2 — de-dup identity + stray-matcher warning (scenarios 12, 16) | **13 checks RED** | green |
| 5 — removal-block header | RED (part of the 13) | green |
| 1 — X_OK covering fixture (scenario 13) | green (new coverage, not a behaviour change) — the *mutant* it exists for **SURVIVED at base** | green, mutant killed |
| 3 — pass ordering (scenario 15) | green — the *mutant* it exists for **SURVIVED at base** | green, mutant killed |
| 4 — comment/docstring only | n/a | n/a |
| 6 — pyright | 2 errors | 0 errors |

The two `test_registrar_activation.py` tests are labelled **invariant guards**, not regression coverage.

## Mutation sweep

14 mutants, isolated sandbox, `PYTHONDONTWRITEBYTECODE=1`, restored by `cp` between runs. **All 14 KILLED by the check that owns them** — none by a neighbour. Harness negative control (comment-only edit) correctly reported SURVIVED; `isfile → exists` was carried as the known-caught positive control.

The X_OK deletion mutant fails **only** its own four checks, including `rejected for the reason THIS condition owns` (`not executable`) — no neighbour fires.

Kinds used: deletion, operand swap (`X_OK→R_OK`), branch inversion, comment-out-with-text-retained, stale rebind, off-by-one (`== len` → `<= len`), block reorder, predicate narrowing, set-vs-list.

## Blast radius — measured, both hosts, no-op

Ran base and new registrar against **read-only copies** of both hosts' real `~/.claude/settings.json` under a throwaway `HOME` (the live files were never opened for writing; the laptop was read over ssh only):

```
BASE  / workbench : "no change", exit 0, byte-identical, no stderr
BASE  / laptop    : "no change", exit 0, byte-identical, no stderr
AFTER / workbench : "no change", exit 0, byte-identical, no stderr
AFTER / laptop    : "no change", exit 0, byte-identical, no stderr
```

Neither host has a matchered non-matcher-event entry or any duplicate today, so this is a no-op on both.

## Gate

`nix develop <worktree> --command bash scripts/gate.sh --tier both --set all` on the rebased branch:

```
PASS  pytest  exit=0  verdict='RESULT: PASS (exit=0)'   collected=13428 passed=13427 skipped=1 failed=0
PASS  node    exit=0  verdict='RESULT: PASS (exit=0)'   tests=1119 pass=1119 fail=0
GATE: RESULT=PASS exit=0
```

<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code)</sub>
