### PR TITLE
fix(run-tests): the gate wrote 43 REAL rows per run into production activity.events

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1526,6 +1526,11 @@ fi
 export ACTIVITY_SPOOL_DIR="$SPOOL_ISOLATED"
 export XDG_STATE_HOME="$SPOOL_TRAP"
 export DEVRC_TEST_SPOOL_GUARD_DIR="$SPOOL_DIR"
+# A fresh RUN is the ROOT of the session-nesting chain (see spool_plugin's
+# NESTED_ENV). Without this, a runner copy driven FROM a pytest test — which is
+# how ten of this file's own regression tests work — would inherit the flag, and
+# every target inside it would be scored as a nested session with no marker.
+unset DEVRC_TEST_SPOOL_IN_SESSION
 SPOOL_SESSIONS_LOG="$SPOOL_DIR/sessions.log"
 SPOOL_ISOLATED_LOG="$SPOOL_ISOLATED/current.log"
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1479,6 +1479,121 @@ export PATH="$NOLAUNCH_DIR:$PATH"
 export DEVRC_TEST_LAUNCH_STUB_DIR="$NOLAUNCH_DIR"
 export PYTHONPATH="$ROOT/scripts${PYTHONPATH:+:$PYTHONPATH}"
 
+# --- GUARD 8: NO TEST MAY WRITE TO THE REAL ACTIVITY SPOOL, IN ANY TARGET ------
+# 🔴 THE SECOND ENFORCEMENT POINT, attached to the same line for the same reason.
+#
+# `scripts/collector/invocation.py` emits one `source=tool kind=invocation` row
+# per tool run into `<ACTIVITY_SPOOL_DIR>/current.log`, and the activity
+# collector daemon ships that spool to the PRODUCTION ClickHouse
+# `activity.events`. Several suites drive tools that emit. Measured before this
+# guard existed, a full `scripts/gate.sh --tier pytest` run wrote real rows into
+# the operator's own dataset, where they are indistinguishable from real
+# activity.
+#
+# #614 fixed ONE directory with a conftest. Thirteen test directories under
+# `scripts/` have `.py` tests and no conftest, and the non-pytest targets
+# (HOOK_TESTS, SHELL_TESTS) can never have one — so the fix is attached HERE,
+# beside GUARD 7, and it is two exports:
+#
+#   * ACTIVITY_SPOOL_DIR -> a temp dir. The direct lever.
+#   * XDG_STATE_HOME     -> a temp dir. The FALLBACK lever, and the reason this
+#     guard can MEASURE itself: `spool_emit.default_spool_dir()` reads
+#     ACTIVITY_SPOOL_DIR at call time and otherwise resolves
+#     `${XDG_STATE_HOME:-~/.local/state}/activity/spool`. A test that takes the
+#     variable away (monkeypatch.delenv, a hand-built subprocess env, a fixture
+#     teardown restoring an unset ambient) drops through to the fallback — which
+#     now lands in a TRAP under this run's dir instead of in production, where
+#     the accounting at the bottom of this file counts it PER TARGET.
+#
+# 🔴 BOTH OVERRIDES ARE UNCONDITIONAL, INCLUDING OVER AN AMBIENT VALUE. A test
+# runner must never write to a real spool, and an inherited ACTIVITY_SPOOL_DIR
+# is far likelier to be a shell with the collector's env sourced than a
+# deliberate intent. The consequence is stated rather than hidden: exporting
+# ACTIVITY_SPOOL_DIR before calling this script no longer measures leakage into
+# YOUR directory — it is overridden. That workflow still works, because the
+# chosen paths are PRINTED below and the GUARD 8 table at the end reports the
+# per-target row counts and the per-target fallback leaks directly.
+SPOOL_DIR="$(mktemp -d)"
+SPOOL_ISOLATED="$SPOOL_DIR/isolated"
+SPOOL_TRAP="$SPOOL_DIR/xdg"
+if ! mkdir -p "$SPOOL_ISOLATED" "$SPOOL_TRAP"; then
+  echo "run-tests: FATAL — could not create the activity-spool isolation dirs" >&2
+  echo "  under $SPOOL_DIR. Refusing to run: without them the suites append" >&2
+  echo "  real rows to ~/.local/state/activity/spool, which the collector ships" >&2
+  echo "  to the production ClickHouse activity.events." >&2
+  exit 2
+fi
+export ACTIVITY_SPOOL_DIR="$SPOOL_ISOLATED"
+export XDG_STATE_HOME="$SPOOL_TRAP"
+export DEVRC_TEST_SPOOL_GUARD_DIR="$SPOOL_DIR"
+SPOOL_SESSIONS_LOG="$SPOOL_DIR/sessions.log"
+SPOOL_ISOLATED_LOG="$SPOOL_ISOLATED/current.log"
+
+# The three tokens shared with `scripts/testlib/spool_plugin.py`. They are
+# spelled on both sides of a process boundary, so they are PINNED both ways by
+# `scripts/tests/test_activity_spool_isolation.py` — a rename on one side alone
+# would leave this accounting matching nothing and reporting a clean run.
+SPOOL_SESSION_MARKER="spool(session)"
+SPOOL_CONTROL_SOURCE="devrc-spool-guard"
+SPOOL_CONTROL_OK="emitted"
+
+# Where the fallback lands, asked of `spool_emit` ITSELF with the variable
+# removed — never restated here. A second copy of the "…/activity/spool" layout
+# would agree with the first until the day the rule changed, and the trap would
+# then watch a directory nothing writes to while still printing a reassuring
+# zero. This also VERIFIES the trap up front: a fallback that did not land
+# inside this run's dir means the two exports above do not actually govern it,
+# and the run must stop rather than proceed with an unarmed detector.
+SPOOL_TRAP_LOG="$(env -u ACTIVITY_SPOOL_DIR XDG_STATE_HOME="$SPOOL_TRAP" \
+  python -c 'import importlib.util,sys
+p=sys.argv[1]
+s=importlib.util.spec_from_file_location("_se",p)
+m=importlib.util.module_from_spec(s); s.loader.exec_module(m)
+print(m.default_spool_dir()/m.CURRENT_NAME)' \
+  "$ROOT/scripts/collector/keylog/spool_emit.py" 2>/dev/null)"
+case "$SPOOL_TRAP_LOG" in
+  "$SPOOL_DIR"/*) : ;;
+  *)
+    echo "run-tests: FATAL — the activity-spool FALLBACK does not resolve inside" >&2
+    echo "  this run's guard dir. Resolved: '${SPOOL_TRAP_LOG:-<could not resolve>}'" >&2
+    echo "  Expected something under $SPOOL_DIR. XDG_STATE_HOME no longer governs" >&2
+    echo "  spool_emit.default_spool_dir(), so a test that drops ACTIVITY_SPOOL_DIR" >&2
+    echo "  would write to the operator's REAL spool and this guard would not see it." >&2
+    exit 2
+    ;;
+esac
+
+echo "run-tests: activity telemetry isolated for this run (GUARD 8)"
+echo "  ACTIVITY_SPOOL_DIR=$ACTIVITY_SPOOL_DIR"
+echo "  fallback trap      =$SPOOL_TRAP_LOG"
+
+# "<target>|<sess-from>|<sess-to>|<trap-from>|<trap-to>|<iso-from>|<iso-to>" —
+# three line ranges per target, so every count below is attributed to the target
+# that produced it rather than to the run as a whole.
+SPOOL_SEEN=()
+SPOOL_B_S=0
+SPOOL_B_T=0
+SPOOL_B_I=0
+
+_spool_lines() { # total lines in $1 (0 when absent)
+  if [ -f "$1" ]; then wc -l < "$1" | tr -d ' '; else echo 0; fi
+}
+_spool_slice() { # $1 = file, $2 = first line (1-based), $3 = last line
+  [ -f "$1" ] || return 0
+  [ "$3" -ge "$2" ] || return 0
+  sed -n "$2,$3p" "$1"
+}
+_spool_mark_before() {
+  SPOOL_B_S="$(_spool_lines "$SPOOL_SESSIONS_LOG")"
+  SPOOL_B_T="$(_spool_lines "$SPOOL_TRAP_LOG")"
+  SPOOL_B_I="$(_spool_lines "$SPOOL_ISOLATED_LOG")"
+}
+# $1 = target name. Every call MUST be preceded by the before-mark above, or the
+# range it records belongs to whatever ran previously.
+_spool_account() {
+  SPOOL_SEEN+=("$1|$(( SPOOL_B_S + 1 ))|$(_spool_lines "$SPOOL_SESSIONS_LOG")|$(( SPOOL_B_T + 1 ))|$(_spool_lines "$SPOOL_TRAP_LOG")|$(( SPOOL_B_I + 1 ))|$(_spool_lines "$SPOOL_ISOLATED_LOG")")
+}
+
 # 🔴 THE ACKNOWLEDGEMENT LEDGER — "<target>|<reason>". A target listed here is
 # EXPECTED to drive launchers into the stub, and is REQUIRED to: an entry whose
 # target records zero intercepts fails the run. That direction is the point.
@@ -1625,13 +1740,16 @@ run_pytest() {
   local log rc nl_before nl_after
   log="$(mktemp)"
   nl_before="$(_nolaunch_lines)"
-  # 🔴 `-p testlib.nolaunch_plugin` is GUARD 7 (see its header). It is on THIS
-  # line — the one place every target is invoked — and not in 17 conftests.
-  python -m pytest "$d" -q -p no:cacheprovider -p testlib.nolaunch_plugin \
+  _spool_mark_before
+  # 🔴 `-p testlib.nolaunch_plugin` is GUARD 7 and `-p testlib.spool_plugin` is
+  # GUARD 8 (see each header). Both are on THIS line — the one place every
+  # target is invoked — and not in two dozen conftests.
+  python -m pytest "$d" -q -p no:cacheprovider -p testlib.nolaunch_plugin -p testlib.spool_plugin \
     --no-header -rs >"$log" 2>&1
   rc=$?
   nl_after="$(_nolaunch_lines)"
   NOLAUNCH_SEEN+=("$d|$(( nl_before + 1 ))|$nl_after")
+  _spool_account "$d"
   cat "$log"
 
   # GUARD 4: parse pytest's summary line. `-q` emits it undecorated, e.g.
@@ -1751,6 +1869,7 @@ for HOOK_TEST in "${HOOK_TESTS[@]}"; do
   fi
   echo "=== script $HOOK_TEST ==="
   nl_before="$(_nolaunch_lines)"
+  _spool_mark_before
   if python "$HOOK_TEST"; then
     RESULTS+=("PASS  $HOOK_TEST (script)")
   else
@@ -1761,6 +1880,10 @@ for HOOK_TEST in "${HOOK_TESTS[@]}"; do
   # stub dir this script put first on PATH. They are accounted the same way, and
   # get no session marker — GUARD 7 requires a marker only from pytest targets.
   NOLAUNCH_SEEN+=("$HOOK_TEST|$(( nl_before + 1 ))|$(_nolaunch_lines)")
+  # GUARD 8 accounts them too. They load no plugin, so they get no session
+  # marker and no fallback control — their protection is the two env exports,
+  # and what is checked is that they leaked nothing into the trap.
+  _spool_account "$HOOK_TEST"
   echo
 done
 
@@ -1785,6 +1908,7 @@ for SHELL_TEST in "${SHELL_TESTS[@]}"; do
   fi
   echo "=== script $SHELL_TEST ==="
   nl_before="$(_nolaunch_lines)"
+  _spool_mark_before
   if bash "$SHELL_TEST"; then
     RESULTS+=("PASS  $SHELL_TEST (script)")
   else
@@ -1792,6 +1916,7 @@ for SHELL_TEST in "${SHELL_TESTS[@]}"; do
     fail=1
   fi
   NOLAUNCH_SEEN+=("$SHELL_TEST|$(( nl_before + 1 ))|$(_nolaunch_lines)")
+  _spool_account "$SHELL_TEST"
   echo
 done
 
@@ -1914,6 +2039,88 @@ if [ "${#nolaunch_problems[@]}" -gt 0 ]; then
   fail=1
 fi
 rm -rf "$NOLAUNCH_DIR"
+
+# --- GUARD 8 (evaluation): per-target activity-spool accounting ----------------
+# One line per target, ALWAYS printed — including the zeros, and never the zero
+# ALONE. `leaked=0` on its own is exactly what a guard wired to nothing prints,
+# so every line carries `control=` beside it: the row this run DELIBERATELY sent
+# down the real fallback path and watched land in the trap. The pair is the
+# claim — "1 on the positive control, 0 under test" — and `control=0` on a
+# pytest target fails the run.
+echo "  ---- activity-spool isolation (GUARD 8) ----"
+echo "    isolated=$SPOOL_ISOLATED"
+echo "    fallback-trap=$SPOOL_TRAP_LOG"
+spool_problems=()
+for t in "${TARGETS[@]}"; do
+  seen=0
+  for entry in "${SPOOL_SEEN[@]}"; do
+    [ "${entry%%|*}" = "$t" ] && seen=1 && break
+  done
+  [ "$seen" -eq 1 ] || spool_problems+=("$t  — never accounted: run_pytest returned before GUARD 8 could measure it")
+done
+
+for entry in "${SPOOL_SEEN[@]}"; do
+  IFS='|' read -r st sfrom sto tfrom tto ifrom ito <<<"$entry"
+
+  sess_slice="$(_spool_slice "$SPOOL_SESSIONS_LOG" "$sfrom" "$sto")"
+  markers=$(printf '%s\n' "$sess_slice" | grep -c "^$SPOOL_SESSION_MARKER" || true)
+  marker_iso="$(printf '%s\n' "$sess_slice" | grep "^$SPOOL_SESSION_MARKER" | head -1 \
+    | awk -F'\t' '{for(i=1;i<=NF;i++) if($i ~ /^isolated=/) print substr($i,10)}')"
+  marker_ctl="$(printf '%s\n' "$sess_slice" | grep "^$SPOOL_SESSION_MARKER" | head -1 \
+    | awk -F'\t' '{for(i=1;i<=NF;i++) if($i ~ /^control=/) print substr($i,9)}')"
+  marker_fb="$(printf '%s\n' "$sess_slice" | grep "^$SPOOL_SESSION_MARKER" | head -1 \
+    | awk -F'\t' '{for(i=1;i<=NF;i++) if($i ~ /^fallback=/) print substr($i,10)}')"
+
+  trap_slice="$(_spool_slice "$SPOOL_TRAP_LOG" "$tfrom" "$tto")"
+  controls=$(printf '%s\n' "$trap_slice" | grep -cF "source=$SPOOL_CONTROL_SOURCE" || true)
+  leak_rows="$(printf '%s\n' "$trap_slice" | grep -vF "source=$SPOOL_CONTROL_SOURCE" | grep -c . || true)"
+  rows=$(_spool_slice "$SPOOL_ISOLATED_LOG" "$ifrom" "$ito" | grep -c . || true)
+
+  is_pytest=0
+  for t in "${TARGETS[@]}"; do [ "$t" = "$st" ] && is_pytest=1 && break; done
+
+  echo "    $st  spool-rows=$rows  fallback-leaked=$leak_rows  control=$controls  plugin=$markers"
+
+  # 🔴 THE LEAK ITSELF. Any row in the trap that is not this guard's own control
+  # reached the FALLBACK — i.e. it would have gone to ~/.local/state/activity/
+  # spool and been shipped to the production activity.events.
+  if [ "$leak_rows" -gt 0 ]; then
+    # Only the plain scalar fields are echoed. The rest of a v1 line is
+    # base64 free text, and this log is read by humans and pasted into PRs.
+    kinds="$(printf '%s\n' "$trap_slice" | grep -vF "source=$SPOOL_CONTROL_SOURCE" \
+      | tr '\t' '\n' | grep -E '^(source|kind)=' | sort | uniq -c \
+      | sed 's/^/             /' || true)"
+    spool_problems+=("$st  — wrote $leak_rows row(s) down the REAL spool fallback. They were trapped and did NOT reach the operator's dataset; a test in this target emits activity telemetry without isolating it:"$'\n'"$kinds")
+  fi
+
+  if [ "$is_pytest" -eq 1 ]; then
+    if [ "$markers" -ne 1 ]; then
+      spool_problems+=("$st  — the spool plugin emitted $markers session marker(s), expected exactly 1. This target ran WITHOUT the guard, so its fallback-leaked=$leak_rows means nothing (see GUARD 8's header: -p testlib.spool_plugin on the pytest line).")
+    elif [ "$marker_iso" != "$SPOOL_ISOLATED" ]; then
+      spool_problems+=("$st  — ran with ACTIVITY_SPOOL_DIR='$marker_iso', not this run's '$SPOOL_ISOLATED'. Something between this script and pytest is re-pointing the spool.")
+    elif [ "$marker_ctl" != "$SPOOL_CONTROL_OK" ]; then
+      spool_problems+=("$st  — the plugin WITHHELD its fallback control (control=$marker_ctl): it resolved the fallback to '$marker_fb', which is not inside $SPOOL_DIR. The leak detector for this target is UNARMED, so its zero is not evidence.")
+    elif [ "$controls" -ne 1 ]; then
+      # The control was emitted and did not arrive. The trap is not where the
+      # fallback goes, so `fallback-leaked=0` is the reassuring zero of a
+      # counter wired to nothing.
+      spool_problems+=("$st  — the fallback trap recorded $controls control row(s), expected exactly 1. The detector is wired to nothing and its fallback-leaked=$leak_rows is unreadable.")
+    fi
+  else
+    # Non-pytest targets load no plugin, so a marker or a control from one means
+    # the accounting slices are misaligned, not that they are better protected.
+    if [ "$markers" -ne 0 ] || [ "$controls" -ne 0 ]; then
+      spool_problems+=("$st  — a NON-pytest target recorded $markers session marker(s) and $controls control row(s); it can have neither, so the per-target slices are misattributed.")
+    fi
+  fi
+done
+
+if [ "${#spool_problems[@]}" -gt 0 ]; then
+  echo "  ERROR: ${#spool_problems[@]} GUARD 8 problem(s):" >&2
+  for p in "${spool_problems[@]}"; do echo "         $p" >&2; done
+  fail=1
+fi
+rm -rf "$SPOOL_DIR"
 
 # GUARD 6. One writer, fed the same value `exit` is about to take, so the
 # printed verdict and the process status cannot disagree — including through a

--- a/scripts/testlib/spool_plugin.py
+++ b/scripts/testlib/spool_plugin.py
@@ -76,6 +76,25 @@ import pytest
 # attribution needs one log, not one per session.
 GUARD_DIR_ENV = "DEVRC_TEST_SPOOL_GUARD_DIR"
 
+# 🔴 THE NESTING FLAG, and it is load-bearing accounting, not tidiness.
+#
+# Some tests START ANOTHER PYTEST. `scripts/tests/test_no_real_launchers.py`
+# builds control/mutant pairs by copying `scripts/tests/conftest.py` into a
+# throwaway tree and running pytest there, so this plugin loads in those child
+# sessions too — and they inherit GUARD_DIR_ENV. Measured: `scripts/tests`
+# reported THREE session markers where the runner requires exactly one, which
+# read as "this target ran without the guard".
+#
+# A nested session is not a TARGET. It must still be ISOLATED — that is the half
+# that protects production — but it must not write into the runner's per-target
+# ledger, where an extra marker looks like a coverage failure and an extra
+# control row inflates a count the runner reads as evidence.
+#
+# `run-tests.sh` UNSETS this when it installs GUARD 8: a fresh run is the root of
+# the chain, so the runner-copy sessions that `test_activity_spool_isolation.py`
+# drives still record their own markers.
+NESTED_ENV = "DEVRC_TEST_SPOOL_IN_SESSION"
+
 # The two variables that decide where a spool write lands. BOTH are levers:
 # ACTIVITY_SPOOL_DIR is the direct one, XDG_STATE_HOME governs the FALLBACK that
 # a test taking the variable away (monkeypatch.delenv, a hand-built subprocess
@@ -211,6 +230,15 @@ def no_real_activity_spool(tmp_path_factory):
         # what the runner adds, not the isolation.
         guard_dir = Path(tmp_path_factory.mktemp("spool-guard"))
         install(guard_dir)
+
+    nested = os.environ.get(NESTED_ENV) == "1"
+    os.environ[NESTED_ENV] = "1"
+    if nested:
+        # Isolated, but silent — see NESTED_ENV. Yielding without writing is the
+        # whole difference; the marker and the control belong to the session the
+        # RUNNER started, and only to that one.
+        yield guard_dir
+        return
 
     note = " ".join(sys.argv[1:]) or "(no args)"
     se = load_spool_emit()

--- a/scripts/testlib/spool_plugin.py
+++ b/scripts/testlib/spool_plugin.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""The ONE place that makes "a test cannot write to the REAL activity spool"
+true — for EVERY target, not for one directory.
+
+🔴 WHAT LEAKS, AND WHERE IT ENDS UP
+------------------------------------
+`scripts/collector/invocation.py` emits one `source=tool kind=invocation` row
+per tool run, and several suites drive tools that call it. The row is appended
+to `<ACTIVITY_SPOOL_DIR>/current.log`; `spool_emit.default_spool_dir()` resolves
+that env var **at call time** and otherwise falls back to
+`${XDG_STATE_HOME:-~/.local/state}/activity/spool` — which the activity
+collector daemon ships to the production ClickHouse `activity.events`. A test
+run therefore writes real rows into a real dataset, where they are
+indistinguishable from the operator's own activity.
+
+🔴 WHY THIS IS A PLUGIN AND NOT N CONFTESTS
+--------------------------------------------
+#614 fixed `scripts/browser-bridge/tests` with a `conftest.py`. That closed one
+directory. A full `scripts/gate.sh --tier pytest` run still leaked, because
+`run-tests.sh` runs ONE pytest process per target and there are two dozen of
+them — thirteen test directories under `scripts/` have `.py` tests and no
+conftest at all, so the class recurs at every one of them and at every target
+added next month. `claude/RULES.md` → "a count of enforcement DECLARATIONS is
+not a count of protected INSTANCES", and `run-tests.sh`'s GUARD 7 header records
+the same lesson from #399, which protected 1 target of 17.
+
+So the isolation is installed at the single place every target is invoked — the
+env exports in `run-tests.sh` — which covers the NON-pytest targets
+(`HOOK_TESTS`, `SHELL_TESTS`) that no conftest can ever reach. This module is
+the pytest-side half: it is what makes the protection OBSERVABLE per target,
+and it re-installs the isolation for a session that is not under the runner.
+
+🔴 THE POSITIVE CONTROL, WHICH IS THE POINT OF THE FILE
+--------------------------------------------------------
+"0 rows leaked" is the observable that a working guard and a guard wired to
+nothing SHARE. Two per-target records make them distinguishable, and
+`run-tests.sh` REQUIRES both:
+
+  * the SESSION MARKER (`spool(session)`) — one line per pytest session,
+    recording the `ACTIVITY_SPOOL_DIR` this process actually saw. A target with
+    no marker is a target the guard never loaded in, and the runner fails it
+    rather than reading its zero as protection.
+
+  * the FALLBACK CONTROL — one row deliberately emitted down the REAL fallback
+    path (`ACTIVITY_SPOOL_DIR` absent, resolved by `spool_emit` itself, not by a
+    restatement of its rule). It must land in the trap the runner set up. That
+    is "feed it a case that MUST produce a non-zero count and watch the number
+    move", per target: it proves the leak counter for THIS target can move at
+    all, so its zero for real rows means something.
+
+The control is FAIL-CLOSED: if the resolved fallback is not inside the guard
+directory, nothing is emitted (it would land in production) and the marker
+records `control=WITHHELD-UNCONTAINED`, which the runner turns into a loud
+failure. A guard that writes to production to prove it does not write to
+production would be worse than no guard.
+
+🔴 IT DELIBERATELY NEVER UNDOES ITSELF — the same lesson as
+`scripts/browser-bridge/tests/conftest.py`'s session backstop. `emit_cmd_event`
+and friends run OFF the critical path, so a thread can still be on its way to an
+emit when a fixture tears down; restoring the ambient value at teardown reopens
+the hole for exactly the rows that are hardest to see. The variable is
+process-local and the process is exiting.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# The handle `run-tests.sh` exports so a session under the runner can find the
+# ONE guard directory and write into the ONE ledger the runner reads. Same shape
+# as nolaunch_plugin.STUB_DIR_ENV, and for the same reason: per-target
+# attribution needs one log, not one per session.
+GUARD_DIR_ENV = "DEVRC_TEST_SPOOL_GUARD_DIR"
+
+# The two variables that decide where a spool write lands. BOTH are levers:
+# ACTIVITY_SPOOL_DIR is the direct one, XDG_STATE_HOME governs the FALLBACK that
+# a test taking the variable away (monkeypatch.delenv, a hand-built subprocess
+# env) drops through.
+SPOOL_ENV = "ACTIVITY_SPOOL_DIR"
+STATE_ENV = "XDG_STATE_HOME"
+
+SESSIONS_LOG = "sessions.log"
+SESSION_MARKER = "spool(session)"
+
+# The control row's `source`. `spool_emit` writes `source=` as a PLAIN scalar
+# (it is in its _PLAIN_KEYS), so this string appears verbatim in the line and
+# the runner can separate controls from leaks with a fixed-string grep. It is
+# deliberately not any real source name in `activity.events`.
+CONTROL_SOURCE = "devrc-spool-guard"
+CONTROL_KIND = "fallback-control"
+
+CONTROL_EMITTED = "emitted"
+CONTROL_WITHHELD = "WITHHELD-UNCONTAINED"
+
+# `scripts/collector/keylog/spool_emit.py` is the single source of truth for
+# both the fallback RULE and the line format. It is loaded by path rather than
+# by `sys.path` insertion so this plugin cannot shadow, or be shadowed by, a
+# test's own `import spool_emit` (several suites do exactly that).
+SPOOL_EMIT_PATH = (Path(__file__).resolve().parents[1]
+                   / "collector" / "keylog" / "spool_emit.py")
+
+
+def load_spool_emit():
+    """Import `spool_emit` from its path, or return None if that is impossible.
+
+    None is a real outcome, not a swallowed error: the runner is told about it
+    through the marker's `control=` field and fails the target, because a
+    session that could not load the emitter also could not run its own control.
+    """
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_devrc_spool_guard_emit", SPOOL_EMIT_PATH)
+        if spec is None or spec.loader is None:
+            return None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    except Exception:  # noqa: BLE001 — an unimportable emitter must not crash pytest
+        return None
+
+
+def resolve_fallback(se) -> Path:
+    """Where a write lands when `ACTIVITY_SPOOL_DIR` is ABSENT.
+
+    Asked of `spool_emit` itself rather than restated here — a second copy of
+    the rule would agree with the first right up until the rule changed, and the
+    trap would then be pointed at a directory nothing writes to while still
+    reporting a reassuring zero.
+
+    The variable is removed for the duration of one function call and restored
+    in a `finally`. That window is microseconds wide and opens at session start,
+    before any test body or server thread exists; it is named here rather than
+    hidden because it is the one moment this file is not protected by itself.
+    """
+    prev = os.environ.pop(SPOOL_ENV, None)
+    try:
+        return se.default_spool_dir()
+    finally:
+        if prev is not None:
+            os.environ[SPOOL_ENV] = prev
+
+
+def _contained(child: Path, parent: Path) -> bool:
+    """True when `child` is `parent` or lives under it, symlinks resolved."""
+    try:
+        c = Path(child).resolve()
+        p = Path(parent).resolve()
+    except OSError:  # pragma: no cover — an unresolvable path is not contained
+        return False
+    return c == p or p in c.parents
+
+
+def _write_marker(guard_dir: Path, fields: dict[str, str]) -> None:
+    """Append one TAB-separated session marker to `<guard_dir>/sessions.log`.
+
+    TAB-separated because the values are filesystem paths: a space-separated
+    record would be mis-parsed under a TMPDIR containing a space, and the
+    mis-parse would read as "this target ran with the wrong spool dir".
+    """
+    line = SESSION_MARKER + "".join(f"\t{k}={v}" for k, v in fields.items())
+    try:
+        guard_dir.mkdir(parents=True, exist_ok=True)
+        with (guard_dir / SESSIONS_LOG).open("a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+    except OSError:  # pragma: no cover — an unwritable guard dir fails the run
+        pass          # via the missing marker, which is the louder signal
+
+
+def _inherited_guard_dir() -> Path | None:
+    """The guard dir `run-tests.sh` already installed, if this session is under it.
+
+    Verified, not trusted — the same check `nolaunch_plugin` makes: an env var
+    naming a directory that does not exist would silently downgrade this session
+    to no accounting at all.
+    """
+    raw = os.environ.get(GUARD_DIR_ENV)
+    if not raw:
+        return None
+    d = Path(raw)
+    return d if d.is_dir() else None
+
+
+def install(guard_dir: Path) -> None:
+    """Point BOTH levers inside `guard_dir`. Never undone — see the header.
+
+    Unconditional, including over an ambient value. A test runner that honoured
+    an inherited `ACTIVITY_SPOOL_DIR` would write real rows the moment someone's
+    shell had the collector's env sourced, and that is a likelier accident than
+    a deliberate intent.
+    """
+    os.environ[SPOOL_ENV] = str(guard_dir / "isolated")
+    os.environ[STATE_ENV] = str(guard_dir / "xdg")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def no_real_activity_spool(tmp_path_factory):
+    """Isolate the activity spool for the whole session, and record that it was.
+
+    AUTOUSE and session-scoped: protection a test has to ask for is protection
+    the next test forgets, and per-test isolation was measured (#614) to have a
+    teardown-shaped hole that only a session-wide floor closes.
+    """
+    guard_dir = _inherited_guard_dir()
+    if guard_dir is None:
+        # Not under the runner (a bare `pytest <dir>`). The protection must not
+        # be conditional on the runner, so install our own — the accounting is
+        # what the runner adds, not the isolation.
+        guard_dir = Path(tmp_path_factory.mktemp("spool-guard"))
+        install(guard_dir)
+
+    note = " ".join(sys.argv[1:]) or "(no args)"
+    se = load_spool_emit()
+    if se is None:
+        fallback, control = "(spool_emit-unimportable)", CONTROL_WITHHELD
+    else:
+        fb = resolve_fallback(se)
+        fallback = str(fb)
+        if _contained(fb, guard_dir):
+            se.emit({"source": CONTROL_SOURCE, "kind": CONTROL_KIND,
+                     "text": note}, spool_dir=fb)
+            control = CONTROL_EMITTED
+        else:
+            # FAIL-CLOSED. Emitting here would put the guard's own row in the
+            # operator's production dataset.
+            control = CONTROL_WITHHELD
+
+    _write_marker(guard_dir, {
+        "isolated": os.environ.get(SPOOL_ENV, "(unset)"),
+        "fallback": fallback,
+        "control": control,
+        "args": note,
+    })
+    yield guard_dir

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -28,3 +28,17 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # scripts/
 # the whole file: one implementation, two entry points (this import and the
 # runner's `-p` flag), no duplicated logic to drift.
 from testlib.nolaunch_plugin import STUB_DIR_ENV, no_real_launchers  # noqa: E402,F401
+
+# 🔴 The SAME shape for the activity spool (GUARD 8). `testlib/spool_plugin.py`
+# is the implementation and `scripts/run-tests.sh` loads it for EVERY target;
+# this import is the second entry point, so a bare `pytest scripts/tests`
+# outside the runner cannot append rows to `~/.local/state/activity/spool` —
+# which the collector ships to the production ClickHouse `activity.events`.
+#
+# It is NOT a per-directory copy, and the difference matters: adding the fixture
+# to N conftests is exactly what #399 and #614 both did and what left 1 target
+# of 17 (and 1 directory of 13) protected. The rule lives in one module; this
+# line only registers it. The per-test `monkeypatch.setenv(ACTIVITY_SPOOL_DIR…)`
+# calls scattered through this directory stay as defence in depth — they narrow
+# the spool per test, which this session-wide floor deliberately does not.
+from testlib.spool_plugin import no_real_activity_spool  # noqa: E402,F401

--- a/scripts/tests/test_activity_spool_isolation.py
+++ b/scripts/tests/test_activity_spool_isolation.py
@@ -1,0 +1,404 @@
+"""🔴 No target may write to the REAL activity spool — and the guard PROVES it
+covered every target, rather than asserting that a variable was set once.
+
+WHY THIS FILE EXISTS
+--------------------
+`scripts/collector/invocation.py` appends a `source=tool kind=invocation` row to
+`<ACTIVITY_SPOOL_DIR>/current.log` on every instrumented tool run, and the
+activity collector ships that spool to the production ClickHouse
+`activity.events`. `spool_emit.default_spool_dir()` resolves the variable at
+call time and otherwise falls back to
+`${XDG_STATE_HOME:-~/.local/state}/activity/spool` — so a test that simply runs
+a tool writes a real row into the operator's own dataset.
+
+#614 closed `scripts/browser-bridge/tests` with a conftest. A full
+`scripts/gate.sh --tier pytest` run still leaked, from targets that have no
+conftest at all — the identical shape as #399's no-real-launcher guard, which
+was installed from ONE conftest and protected 1 target of 17. So GUARD 8 is
+attached where GUARD 7 is: the two env exports in `scripts/run-tests.sh`, on the
+single line every target goes through, which also covers the non-pytest
+`HOOK_TESTS`/`SHELL_TESTS` that no conftest can ever reach.
+
+WHAT IS REGRESSION COVERAGE HERE AND WHAT IS NOT (RULES.md asks for the label):
+
+  * `test_an_emitting_target_writes_to_the_run_dir_not_the_home_spool` is THE
+    regression test for the measured leak. It is RED at origin/main — where the
+    planted emit lands in `$HOME/.local/state/activity/spool/current.log` — and
+    green here, with `spool-rows=1` as its own positive control that the emit
+    really happened.
+  * `test_a_target_that_drops_the_variable_is_named_and_red` and
+    `test_a_non_pytest_target_that_leaks_is_named_and_red` are REGRESSION
+    coverage for the residual hazard the exports alone do not close: code that
+    takes `ACTIVITY_SPOOL_DIR` away and drops through to the fallback. At
+    origin/main both write to the real spool and the run is green.
+  * `test_the_missing_plugin_is_named_and_red` and
+    `test_an_unarmed_fallback_trap_is_named_and_red` are the MUTATION tests for
+    the two mutants that matter, both of which leave a green suite: the guard
+    loading in NO target, and the leak detector pointing at a directory nothing
+    writes to. Each asserts THIS guard's own message, not merely that the run
+    went red.
+  * `test_the_control_of_those_mutants_is_green` is the positive control for all
+    four, and pins the accounting line the others read.
+  * the two-way token pin, the single-invocation pin and the accounting-site
+    count are INVARIANT GUARDS. The bug never violated them; they exist so the
+    enforcement point cannot be narrowed to nothing by an edit that still looks
+    like a guard.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from testlib import spool_plugin  # noqa: E402
+from testlib.runner_patch import runner_with_targets, write_pytest_suite  # noqa: E402
+
+RUN_TESTS = SCRIPTS / "run-tests.sh"
+RUNNER_SRC = RUN_TESTS.read_text(encoding="utf-8")
+# 🔴 CODE ONLY. run-tests.sh is 40% commentary and GUARD 8's header quotes every
+# token these pins look for — the variable names, the plugin flag, the marker
+# string. A pin read off the raw text answers a question about the PROSE.
+RUNNER_CODE = "\n".join(ln for ln in RUNNER_SRC.splitlines()
+                        if not ln.lstrip().startswith("#"))
+
+COLLECTOR = SCRIPTS / "collector"
+
+# Assembled, not spelled, so this file's own text cannot satisfy a pin that
+# greps the runner for it.
+_SPOOL_FLAG = "-p testlib.spool" + "_plugin"
+_NOLAUNCH_FLAG = "-p testlib.nolaunch" + "_plugin"
+
+
+# --------------------------------------------------------------------------- #
+# Planted probes. Both go through `invocation.emit_invocation` — the REAL leak
+# shape, not a stand-in for it: that is the function whose rows were measured in
+# production.
+# --------------------------------------------------------------------------- #
+_EMITTING_TEST = f'''\
+import sys
+
+sys.path.insert(0, {str(COLLECTOR)!r})
+import invocation
+
+
+def test_emits_activity_telemetry():
+    # The ordinary shape: a test that drives an instrumented tool. It does not
+    # know or care where the spool is; the runner decided that.
+    assert invocation.emit_invocation("spool-probe", "ok") != ""
+'''
+
+_DROPPING_TEST = f'''\
+import os
+import sys
+
+sys.path.insert(0, {str(COLLECTOR)!r})
+import invocation
+
+
+def test_emits_after_dropping_the_spool_variable():
+    # The residual hazard the exports alone do not close: something takes the
+    # variable away (monkeypatch.delenv, a hand-built subprocess env, a fixture
+    # teardown restoring an unset ambient) and the write drops to the FALLBACK.
+    os.environ.pop("ACTIVITY_SPOOL_DIR", None)
+    assert invocation.emit_invocation("spool-probe", "dropped") != ""
+'''
+
+_DROPPING_SCRIPT = f'''\
+import os
+import sys
+
+sys.path.insert(0, {str(COLLECTOR)!r})
+import invocation
+
+os.environ.pop("ACTIVITY_SPOOL_DIR", None)
+assert invocation.emit_invocation("spool-probe", "dropped") != ""
+'''
+
+
+def _pytest_invocations(src: str) -> list[str]:
+    """The lines that actually RUN pytest — not the ones that talk about it."""
+    return [ln for ln in src.splitlines()
+            if ln.strip().startswith("python -m pytest")
+            and "--version" not in ln]
+
+
+def _run(args: list[str], env: dict | None = None,
+         timeout: int = 300) -> subprocess.CompletedProcess:
+    full = {**os.environ, **(env or {})}
+    for k, v in list(full.items()):
+        if v is None:
+            del full[k]
+    return subprocess.run(["bash", *args], capture_output=True, text=True,
+                          timeout=timeout, cwd=str(REPO_ROOT), env=full)
+
+
+def _clean_home(tmp_path: Path) -> dict:
+    """A scratch HOME with XDG_STATE_HOME REMOVED from the child environment.
+
+    This is the measurement method, and it is sound for one reason: it moves the
+    root of the SAME fallback `spool_emit.default_spool_dir()` computes, without
+    changing the code path at all. A row that would go to the operator's
+    `~/.local/state/activity/spool` goes to `<tmp>/.local/state/activity/spool`
+    instead — so "did this leak" becomes a question about a directory this test
+    owns, and the production spool is never touched, read or relied upon.
+
+    XDG_STATE_HOME must be removed rather than set: it takes precedence over
+    HOME in the fallback, so leaving the outer gate run's value in place would
+    point the probe at the OUTER runner's trap and every measurement here would
+    read zero for a reason that has nothing to do with the tree under test.
+    """
+    home = tmp_path / "scratch-home"
+    home.mkdir(parents=True, exist_ok=True)
+    return {"HOME": str(home), "XDG_STATE_HOME": None,
+            "ACTIVITY_SPOOL_DIR": None}
+
+
+def _home_spool(tmp_path: Path) -> Path:
+    return (tmp_path / "scratch-home" / ".local" / "state" / "activity"
+            / "spool" / "current.log")
+
+
+# --------------------------------------------------------------------------- #
+# INVARIANT GUARDS — the enforcement point cannot be narrowed to nothing
+# --------------------------------------------------------------------------- #
+def test_the_single_pytest_invocation_loads_the_spool_plugin():
+    """One `python -m pytest` line, carrying BOTH guards' plugins.
+
+    That is what makes "every target" true by construction rather than by two
+    dozen conftests that drift — and what protects the target added next month.
+    """
+    invocations = _pytest_invocations(RUNNER_CODE)
+    assert len(invocations) == 1, (
+        "run-tests.sh must invoke pytest from exactly ONE place — both guards "
+        f"are attached to that line. Found {len(invocations)}: {invocations}")
+    assert _SPOOL_FLAG in invocations[0], (
+        "the single pytest invocation no longer loads the spool-isolation "
+        f"plugin, so no target is accounted:\n  {invocations[0].strip()}")
+    assert _NOLAUNCH_FLAG in invocations[0], (
+        "the no-real-launcher plugin was dropped from the same line — GUARD 8's "
+        f"edit must not cost GUARD 7:\n  {invocations[0].strip()}")
+
+
+def test_both_levers_are_exported_by_the_runner():
+    """ACTIVITY_SPOOL_DIR alone is not the guard.
+
+    It is the direct lever; XDG_STATE_HOME governs the FALLBACK a test reaches
+    by taking the direct one away. Exporting only the first leaves that path
+    pointed at the operator's real spool — and leaves the leak DETECTOR pointed
+    there too, which is the worse half.
+    """
+    assert re.search(r"^export ACTIVITY_SPOOL_DIR=", RUNNER_CODE, re.M), (
+        "run-tests.sh no longer exports ACTIVITY_SPOOL_DIR; every target writes "
+        "to whatever the ambient environment says, which in a gate run is the "
+        "operator's real spool")
+    assert re.search(r"^export XDG_STATE_HOME=", RUNNER_CODE, re.M), (
+        "run-tests.sh no longer exports XDG_STATE_HOME; the fallback resolves "
+        "to ~/.local/state/activity/spool again")
+
+
+def test_the_runner_and_the_plugin_agree_on_the_shared_tokens():
+    """The three strings crossing the process boundary, pinned BOTH ways.
+
+    The runner greps for them in bash; the plugin writes them in Python.
+    Renaming either side alone leaves the accounting matching nothing — and a
+    grep that matches nothing prints a clean run, which is the failure that
+    looks most like success.
+    """
+    for var, value in (("SPOOL_SESSION_MARKER", spool_plugin.SESSION_MARKER),
+                       ("SPOOL_CONTROL_SOURCE", spool_plugin.CONTROL_SOURCE),
+                       ("SPOOL_CONTROL_OK", spool_plugin.CONTROL_EMITTED)):
+        assert f'{var}="{value}"' in RUNNER_CODE, (
+            f"run-tests.sh's {var} does not match spool_plugin's "
+            f"'{value}'. The accounting would silently match nothing.")
+
+
+def test_every_target_kind_feeds_the_accounting():
+    """Three call sites: pytest targets, hook scripts, shell scripts.
+
+    A loop that stopped accounting reports no leaks for the most reassuring
+    possible reason. (`TARGETS` membership additionally fails any pytest target
+    that produced no record at all.)
+    """
+    assert RUNNER_CODE.count('_spool_account "') == 3, (
+        "expected exactly three sites to feed SPOOL_SEEN (pytest, hook scripts, "
+        "shell scripts)")
+    assert RUNNER_CODE.count("_spool_mark_before") == 4, (
+        "each accounting site needs its matching before-mark (plus the "
+        "definition); an unpaired one attributes a leak to the wrong target")
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE REGRESSION TEST — the measured leak, in the ordinary shape
+# --------------------------------------------------------------------------- #
+def test_an_emitting_target_writes_to_the_run_dir_not_the_home_spool(tmp_path):
+    """🔴 PLANT A REAL EMIT IN A TARGET AND FOLLOW THE ROW.
+
+    At origin/main this run is GREEN and the row is sitting in
+    `$HOME/.local/state/activity/spool/current.log`, on its way to production.
+    Here the run is green AND that file does not exist, because the row went to
+    the runner's own dir instead.
+
+    `spool-rows=1` is this test's positive control. Without it, "no file under
+    HOME" is satisfied by an emit that never happened — the reassuring zero of a
+    probe wired to nothing.
+    """
+    target = tmp_path / "emitting_tests"
+    write_pytest_suite(target, 1, prefix="test_filler")
+    (target / "test_emit.py").write_text(_EMITTING_TEST, encoding="utf-8")
+    runner = runner_with_targets(tmp_path, [str(target)], {str(target): 1},
+                                 hook_tests=[], shell_tests=[])
+    proc = _run([str(runner), str(REPO_ROOT)], env=_clean_home(tmp_path))
+    out = proc.stdout + proc.stderr
+
+    assert proc.returncode == 0, f"an isolated emit should not fail the run:\n{out}"
+    assert f"{target}  spool-rows=1" in out, (
+        "the planted emit produced no row in the runner's spool dir — the probe "
+        f"never fired, so the assertion below would prove nothing:\n{out}")
+    leaked = _home_spool(tmp_path)
+    assert not leaked.exists(), (
+        f"the emit reached the REAL spool fallback at {leaked}:\n"
+        f"{leaked.read_text(encoding='utf-8')[:500]}")
+
+
+def test_a_target_that_drops_the_variable_is_named_and_red(tmp_path):
+    """🔴 THE RESIDUAL HAZARD: code that takes ACTIVITY_SPOOL_DIR away.
+
+    The exports cannot stop that — but the fallback TRAP catches it, and the
+    accounting names the target. At origin/main the same row lands in the real
+    spool and the run is green.
+    """
+    target = tmp_path / "dropping_tests"
+    write_pytest_suite(target, 1, prefix="test_filler")
+    (target / "test_drop.py").write_text(_DROPPING_TEST, encoding="utf-8")
+    runner = runner_with_targets(tmp_path, [str(target)], {str(target): 1},
+                                 hook_tests=[], shell_tests=[])
+    proc = _run([str(runner), str(REPO_ROOT)], env=_clean_home(tmp_path))
+    out = proc.stdout + proc.stderr
+
+    assert proc.returncode != 0, f"a planted fallback write produced a PASSING run:\n{out}"
+    assert "GUARD 8 problem" in out, (
+        f"the run failed, but not for the spool reason:\n{out}")
+    assert str(target) in out, f"the failure did not NAME the target:\n{out}"
+    assert "REAL spool fallback" in out, out
+    assert "source=tool" in out, (
+        f"the guard reported a leak whose rows it never actually recorded:\n{out}")
+    assert not _home_spool(tmp_path).exists(), (
+        "the trap did not contain the row — it reached the real fallback")
+
+
+def test_a_non_pytest_target_that_leaks_is_named_and_red(tmp_path):
+    """🔴 THE HALF NO CONFTEST CAN EVER COVER.
+
+    `HOOK_TESTS` are plain scripts, not pytest: they load no plugin and could
+    not be reached by a per-directory fixture at all. Their protection is the
+    runner's exports, and their accounting is the same trap.
+    """
+    target = tmp_path / "clean_tests"
+    write_pytest_suite(target, 1, prefix="test_clean")
+    script = tmp_path / "leaky_hook.py"
+    script.write_text(_DROPPING_SCRIPT, encoding="utf-8")
+    runner = runner_with_targets(tmp_path, [str(target)], {str(target): 1},
+                                 hook_tests=[str(script)], shell_tests=[])
+    proc = _run([str(runner), str(REPO_ROOT)], env=_clean_home(tmp_path))
+    out = proc.stdout + proc.stderr
+
+    assert proc.returncode != 0, f"a leaking hook script produced a PASSING run:\n{out}"
+    assert "GUARD 8 problem" in out, f"the run failed, but not for the spool reason:\n{out}"
+    assert str(script) in out, f"the failure did not NAME the script:\n{out}"
+    assert not _home_spool(tmp_path).exists()
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 MUTATION TESTS — the two mutants that leave a green suite
+# --------------------------------------------------------------------------- #
+def test_the_missing_plugin_is_named_and_red(tmp_path):
+    """🔴 MUTANT 1: the guard loading in NO target, silently.
+
+    Strip `-p testlib.spool_plugin` — the shape of every "narrow the glob /
+    comment it out" mutation. The session marker is what makes it observable:
+    without the marker requirement this target's `fallback-leaked=0` is
+    indistinguishable from real protection, and the run stays green.
+    """
+    target = tmp_path / "plain_tests"
+    write_pytest_suite(target, 2, prefix="test_plain")
+    runner = runner_with_targets(tmp_path, [str(target)], {str(target): 1},
+                                 hook_tests=[], shell_tests=[])
+    src = runner.read_text(encoding="utf-8")
+    # 🔴 The CODE line, not the prose. GUARD 8's own failure message names the
+    # flag, so a blanket replace would edit a string literal and leave the
+    # invocation untouched — a mutation that never happened, scored SURVIVED.
+    hits = _pytest_invocations(src)
+    assert len(hits) == 1 and _SPOOL_FLAG in hits[0], (
+        f"expected exactly one live site to mutate, found {hits}")
+    runner.write_text(src.replace(hits[0], hits[0].replace(" " + _SPOOL_FLAG, "")),
+                      encoding="utf-8")
+
+    proc = _run([str(runner), str(REPO_ROOT)], env=_clean_home(tmp_path))
+    out = proc.stdout + proc.stderr
+    assert proc.returncode != 0, (
+        f"a target that ran with NO spool guard produced a PASSING run:\n{out}")
+    assert "session marker" in out, (
+        f"the run failed, but not because the plugin was missing:\n{out}")
+
+
+def test_an_unarmed_fallback_trap_is_named_and_red(tmp_path):
+    """🔴 MUTANT 2: the leak DETECTOR wired to nothing.
+
+    Drop `export XDG_STATE_HOME` and the fallback resolves to the operator's
+    real `~/.local/state/activity/spool` again. Every leak then bypasses the
+    trap, and `fallback-leaked=0` becomes the reassuring zero of a counter
+    watching an empty directory — while the suite stays green.
+
+    The plugin is FAIL-CLOSED about it: an uncontained fallback means its
+    control row is WITHHELD rather than written to production, and the withheld
+    control is what the runner turns into this failure. A guard that wrote to
+    production to prove it does not write to production would be worse than
+    none — so the target here is CLEAN, and nothing plants an emit.
+    """
+    target = tmp_path / "plain_tests"
+    write_pytest_suite(target, 2, prefix="test_plain")
+    runner = runner_with_targets(tmp_path, [str(target)], {str(target): 1},
+                                 hook_tests=[], shell_tests=[])
+    src = runner.read_text(encoding="utf-8")
+    mutated, n = re.subn(r'^export XDG_STATE_HOME="\$SPOOL_TRAP"$',
+                         ': "$SPOOL_TRAP"', src, count=1, flags=re.M)
+    assert n == 1, "the XDG_STATE_HOME export was not found to mutate"
+    runner.write_text(mutated, encoding="utf-8")
+
+    proc = _run([str(runner), str(REPO_ROOT)], env=_clean_home(tmp_path))
+    out = proc.stdout + proc.stderr
+    assert proc.returncode != 0, (
+        f"an unarmed fallback trap produced a PASSING run:\n{out}")
+    assert "UNARMED" in out, (
+        f"the run failed, but not because the detector was pointed away:\n{out}")
+    assert not _home_spool(tmp_path).exists(), (
+        "the withheld control was not actually withheld — the guard wrote a row "
+        "down the very path it was reporting as uncontained")
+
+
+def test_the_control_of_those_mutants_is_green(tmp_path):
+    """The positive control for all four behavioural tests above.
+
+    Unmutated, a plain target with no emit PASSES — and prints the accounting
+    line the others read, with the control row beside the zero. Without this,
+    "the run went red" is satisfied by the runner being red about anything.
+    """
+    target = tmp_path / "clean_tests"
+    write_pytest_suite(target, 2, prefix="test_clean")
+    runner = runner_with_targets(tmp_path, [str(target)], {str(target): 1},
+                                 hook_tests=[], shell_tests=[])
+    proc = _run([str(runner), str(REPO_ROOT)], env=_clean_home(tmp_path))
+    out = proc.stdout + proc.stderr
+
+    assert proc.returncode == 0, f"the clean control run was not green:\n{out}"
+    assert (f"{target}  spool-rows=0  fallback-leaked=0  control=1  plugin=1"
+            in out), (
+        "the per-target spool line is missing or its shape changed — the "
+        f"accounting the other tests read is not actually printed:\n{out}")
+    assert not _home_spool(tmp_path).exists()

--- a/scripts/tests/test_activity_spool_isolation.py
+++ b/scripts/tests/test_activity_spool_isolation.py
@@ -37,6 +37,15 @@ WHAT IS REGRESSION COVERAGE HERE AND WHAT IS NOT (RULES.md asks for the label):
     loading in NO target, and the leak detector pointing at a directory nothing
     writes to. Each asserts THIS guard's own message, not merely that the run
     went red.
+  * `test_a_nested_pytest_session_does_not_write_into_the_targets_ledger` is
+    REGRESSION coverage for a defect this guard found in ITSELF on its first
+    full run: `scripts/tests` reported `plugin=3`, because
+    `test_no_real_launchers.py` copies `scripts/tests/conftest.py` into nested
+    control/mutant sessions. Its sibling
+    `test_the_positive_control_for_that_is_a_nested_session_that_DOES_count`
+    exists so the `plugin=1` it asserts is not satisfied by a nested session
+    that never loaded the plugin — it removes the nesting flag from the child
+    environment and watches the count move to 2.
   * `test_the_control_of_those_mutants_is_green` is the positive control for all
     four, and pins the accounting line the others read.
   * the two-way token pin, the single-invocation pin and the accounting-site
@@ -118,6 +127,34 @@ import invocation
 
 os.environ.pop("ACTIVITY_SPOOL_DIR", None)
 assert invocation.emit_invocation("spool-probe", "dropped") != ""
+'''
+
+
+# A target whose test STARTS ANOTHER PYTEST that loads this plugin — the shape
+# `test_no_real_launchers.py` uses for its control/mutant pairs, and the shape
+# that first made `scripts/tests` report three session markers. `{extra}` is
+# substituted with either "" (inherit the nesting flag) or the code that removes
+# it, which is the whole control pair.
+_NESTING_TEST = '''\
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_starts_a_nested_pytest_session(tmp_path):
+    inner = tmp_path / "inner"
+    inner.mkdir()
+    (inner / "test_inner.py").write_text("def test_ok():\\n    assert True\\n")
+    env = dict(os.environ)
+    {extra}
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", str(inner), "-q", "-p", "no:cacheprovider",
+         "-p", "testlib.spool_plugin", "--no-header"],
+        capture_output=True, text=True, env=env)
+    # The nested session must really have RUN and really have loaded the plugin,
+    # or "it wrote no marker" is satisfied by it never starting.
+    assert "1 passed" in proc.stdout, proc.stdout + proc.stderr
 '''
 
 
@@ -380,6 +417,53 @@ def test_an_unarmed_fallback_trap_is_named_and_red(tmp_path):
     assert not _home_spool(tmp_path).exists(), (
         "the withheld control was not actually withheld — the guard wrote a row "
         "down the very path it was reporting as uncontained")
+
+
+def _nesting_runner(tmp_path: Path, extra: str):
+    target = tmp_path / "nesting_tests"
+    write_pytest_suite(target, 1, prefix="test_filler")
+    (target / "test_nest.py").write_text(_NESTING_TEST.format(extra=extra),
+                                         encoding="utf-8")
+    runner = runner_with_targets(tmp_path, [str(target)], {str(target): 1},
+                                 hook_tests=[], shell_tests=[])
+    proc = _run([str(runner), str(REPO_ROOT)], env=_clean_home(tmp_path))
+    return target, proc.stdout + proc.stderr, proc.returncode
+
+
+def test_a_nested_pytest_session_does_not_write_into_the_targets_ledger(tmp_path):
+    """🔴 MEASURED DEFECT, closed: `scripts/tests` reported plugin=3.
+
+    `test_no_real_launchers.py` builds control/mutant pairs by copying
+    `scripts/tests/conftest.py` into a throwaway tree and running pytest there.
+    Those child sessions load this plugin and inherit the guard dir, so each one
+    appended a marker to the runner's ledger — and "3 markers, expected 1" reads
+    as "this target ran WITHOUT the guard", which is a false red on the one
+    check that exists to catch a true one.
+
+    A nested session is still ISOLATED; it is only silent in the ledger.
+    """
+    target, out, rc = _nesting_runner(tmp_path, extra="")
+    assert rc == 0, f"a target that starts a nested pytest went red:\n{out}"
+    assert f"{target}  spool-rows=0  fallback-leaked=0  control=1  plugin=1" in out, (
+        f"the nested session polluted the target's accounting:\n{out}")
+
+
+def test_the_positive_control_for_that_is_a_nested_session_that_DOES_count(tmp_path):
+    """The other half of the pair — without it, `plugin=1` above is satisfied by
+    a nested session that never loaded the plugin at all.
+
+    Same planted target, one difference: the child environment has the nesting
+    flag REMOVED, so that session believes it is a root. The marker count moves
+    to 2 and the runner goes red with its own message. That is the number moving
+    on a case that MUST produce it.
+    """
+    target, out, rc = _nesting_runner(
+        tmp_path, extra='env.pop("DEVRC_TEST_SPOOL_IN_SESSION", None)')
+    assert rc != 0, (
+        "a second session marker was accepted — the marker count cannot move, "
+        f"so plugin=1 in the sibling test proves nothing:\n{out}")
+    assert "emitted 2 session marker(s)" in out, (
+        f"the run went red, but not on the marker count:\n{out}")
 
 
 def test_the_control_of_those_mutants_is_green(tmp_path):


### PR DESCRIPTION
## The leak, measured before anything was changed

On a **pristine clone of `e7ceb1f`**, `scripts/gate.sh --tier pytest` appended **43 rows** to the activity spool the collector ships to the production ClickHouse `activity.events`. All 43 are `source=tool kind=invocation` — `scripts/collector/invocation.py`, fired by tools the suites drive.

| target | rows / run |
|---|---|
| `scripts/task-spec-drafter/tests` | 23 |
| `scripts/opencode/tests` | 16 |
| `scripts/tests` | 4 |
| the other 21 targets | 0 |
| **total** | **43** |

**Measurement method.** `spool_emit.default_spool_dir()` resolves `ACTIVITY_SPOOL_DIR` first and otherwise `${XDG_STATE_HOME:-~/.local/state}/activity/spool`. Pointing `XDG_STATE_HOME` at a probe dir moves the **root of that same fallback** without changing the code path at all — so a row that would have gone to the operator's spool goes somewhere the run owns and can count. Production was never written to and never read. The per-directory split comes from running each target's pytest line individually against a second pristine clone, each with its own probe dir; the three non-zero numbers sum to the full-gate total exactly.

## Why not another conftest

#614 closed `scripts/browser-bridge/tests` with one. That is **one directory**: thirteen test directories under `scripts/` have `.py` tests and no conftest, and the non-pytest `HOOK_TESTS`/`SHELL_TESTS` can never have one at all. It is the same shape `run-tests.sh`'s GUARD 7 header already records from #399 — a guard installed from one conftest that protected 1 target of 17 while reading as systemic. *A count of enforcement DECLARATIONS is not a count of protected INSTANCES.*

So GUARD 8 is attached beside GUARD 7, at the single place every target is invoked. Two exports:

* `ACTIVITY_SPOOL_DIR` → a temp dir. The direct lever.
* `XDG_STATE_HOME` → a temp dir. The **fallback** lever — and the reason the guard can measure itself.

## The guard is not "the variable was exported"

A test asserting the export exists is walkable. What this answers is *did the protection cover every target*, per target, the way GUARD 7's session-marker accounting does.

`scripts/testlib/spool_plugin.py` writes two records per pytest session, and `run-tests.sh` **requires both**:

1. **the session marker** — one `spool(session)` line carrying the `ACTIVITY_SPOOL_DIR` that process actually saw. A target with no marker is a target the guard never loaded in; its `fallback-leaked=0` is rejected, not believed.
2. **the fallback control** — one row deliberately emitted down the **real** fallback path, resolved by `spool_emit` itself rather than by a restatement of its rule, which must arrive in the trap. That is *feed it a case that MUST produce a non-zero count and watch the number move*, per target. It is **fail-closed**: if the resolved fallback is not inside the run's own dir, nothing is emitted (it would land in production) and the withheld control fails the run.

Every accounting line prints as a pair, never the zero alone:

```
  ---- activity-spool isolation (GUARD 8) ----
    isolated=/tmp/tmp.XXXX/isolated
    fallback-trap=/tmp/tmp.XXXX/xdg/activity/spool/current.log
    scripts/tests  spool-rows=4  fallback-leaked=0  control=1  plugin=1
```

Non-pytest targets load no plugin, so they get no marker and no control — stated explicitly rather than left as an unexplained zero — and are still accounted for leaks, which is the half no conftest could ever cover.

## Red before green

`scripts/tests/test_activity_spool_isolation.py` (12 tests) applied to a pristine `e7ceb1f` with only the plugin copied alongside it — i.e. the guard against the unfixed runner:

```
12 failed in 59.83s     (e7ceb1f)
12 passed in 2.69s      (this branch)
```

The regression case fails at main with its own text:

```
E   AssertionError: the emit reached the REAL spool fallback at
E     .../scratch-home/.local/state/activity/spool/current.log
```

and its own positive control (`spool-rows=1`) is what stops "no file under HOME" being satisfied by an emit that never happened.

Hand-driven confirmation of both directions, same planted probe, two trees:

| tree | ordinary emit | emit after dropping `ACTIVITY_SPOOL_DIR` |
|---|---|---|
| `e7ceb1f` | `RESULT: PASS`, 1 row in the real fallback | `RESULT: PASS`, 2 rows in the real fallback |
| this branch | `RESULT: PASS`, `spool-rows=1 fallback-leaked=0` | `RESULT: FAIL`, target named, `fallback-leaked=1` |

The two mutation tests cover the mutants that leave a green suite: the plugin flag stripped (guard loads in **no** target), and `export XDG_STATE_HOME` removed (leak **detector** pointed at a directory nothing writes to). Each asserts GUARD 8's own message, and the mutation is applied to the pytest **code line** rather than by a blanket string replace — GUARD 8's failure text names the flag, so a blanket replace would edit a string literal and score SURVIVED without ever mutating anything.

## The guard's first full run failed on itself, and that is the best evidence in the PR

```
scripts/tests  spool-rows=4  fallback-leaked=0  control=1  plugin=3
ERROR: 1 GUARD 8 problem(s):
  scripts/tests — the spool plugin emitted 3 session marker(s), expected exactly 1.
  This target ran WITHOUT the guard, so its fallback-leaked=0 means nothing
```

`scripts/tests/test_no_real_launchers.py` builds control/mutant pairs by copying `scripts/tests/conftest.py` into a throwaway tree and running pytest there. Those **child** sessions loaded the plugin and inherited the guard dir, so each appended to the runner's per-target ledger. The marker's own `args=` field named them without any further investigation.

A nested session is not a target: it must still be **isolated** — that is the half that protects production — but it must not write into the ledger. `spool_plugin` sets `DEVRC_TEST_SPOOL_IN_SESSION`; a session that inherits it isolates silently. `run-tests.sh` unsets the flag when it installs GUARD 8, because a fresh run is the root of the chain — without that, the ten regression tests that drive a runner copy *from* a pytest test would score every target inside as nested.

Covered by a **control pair**, because "the nested session wrote no marker" is also what a nested session that never loaded the plugin produces: one test requires `plugin=1` while asserting the nested session really ran and really loaded the plugin; its sibling removes the flag from the child environment and watches the count move to 2 and the run go red on it.

Note what this says about the design: a guard that only counted leaks would have printed `fallback-leaked=0` and been believed.

## Two design decisions, made deliberately

**Unconditional override, including over an ambient value.** A test runner must never write to a real spool, and an inherited `ACTIVITY_SPOOL_DIR` is far likelier to be a shell with the collector's env sourced than an intent. The consequence is real and is paid for rather than hidden: exporting `ACTIVITY_SPOOL_DIR` before calling `run-tests.sh` no longer measures leakage into *your* directory. So the runner **prints both chosen paths** at startup, and the GUARD 8 table reports per-target rows and per-target fallback leaks directly — that workflow no longer needs the env var at all.

**The existing per-test `monkeypatch.setenv` calls stay.** They are defence in depth and they do something this session-wide floor deliberately does not — narrow the spool *per test*, so tests cannot read each other's rows. browser-bridge's conftest also still matters for a bare `pytest scripts/browser-bridge/tests`. `scripts/tests/conftest.py` gains the same one-line registration of the shared module that it already has for nolaunch: one implementation, two entry points, no second copy of the rule. Nothing under `scripts/browser-bridge/tests/` is touched.

## After: the gate, on the merged tree

`nix develop . --command bash scripts/gate.sh --tier pytest`, run with `HOME` pointed at a scratch dir and no ambient `XDG_STATE_HOME` — so that **if the fix were inert** the rows would land somewhere the run owns and could be counted, rather than in production.

```
GATE: RESULT=PASS exit=0
TOTAL collected=13438  passed=13437  skipped=1  failed=0  (floor: 12749 = sum of 24 per-target floors)
--- rows reaching the REAL fallback root (scratch HOME) ---
(no output above == zero)
```

The tree gated is `origin/main` (`d12f84c`) with this branch rebased on top, so HEAD *is* the merged tree (`git merge-base --is-ancestor origin/main HEAD` holds). All 24 pytest targets report `control=1 plugin=1`, the 6 script targets `control=0 plugin=0`, and every one of the 30 reports `fallback-leaked=0`.

Per directory, before → after:

| target | before | after |
|---|---|---|
| `scripts/task-spec-drafter/tests` | 23 | 0 (23 rows, all in the run's own dir) |
| `scripts/opencode/tests` | 16 | 0 (16 rows, all in the run's own dir) |
| `scripts/tests` | 4 | 0 (4 rows, all in the run's own dir) |
| the other 27 targets | 0 | 0 |
| **total reaching the real spool** | **43** | **0** |

The `spool-rows` column is what makes the zeros readable: the same 43 emits still happen, they just land in a directory the run deletes on the way out.

## Notes from the run

* **`main` was red at `e7ceb1f`** on `test_no_client_subdomain_literal_is_committed` — a real client subdomain committed to this public repo in #619's handoff doc. Independently fixed on main by #622 while this work was in flight; nothing here touches it.
* `test_run_tests_floors.py::test_ordinary_growth_needs_no_hand_edit` failed on that same pristine `e7ceb1f` run, and the reason inside its nested runner was `scripts/claude-hooks/tests/test_search_tool_nudge.py`: *"concurrency: exactly one nudge across 12 parallel invocations: got 0 want 1"*. That is a load-sensitive concurrency check, and the box was carrying three concurrent suites at the time. It did not recur on either run of this branch. Pre-existing and unrelated to this change, but a real flake worth its own fix.
* GUARD 8 also closes two smaller production writes as a side effect of the `XDG_STATE_HOME` export: `session_insight/prepare.py`'s `~/.local/state/activity/insights` and `drift-check.sh`'s state dir now resolve inside the run.
