### PR TITLE
docs(bar): how to check the bar actually restarted — and the load-pill handoff, updated

### DIFF
--- a/claude/skills/bar/SKILL.md
+++ b/claude/skills/bar/SKILL.md
@@ -146,6 +146,22 @@ degrade to a missing glyph, it renders the whole pill as a red `Failed to render
   is authoritative. A threshold/format edit inside an existing script needs no restart — the
   block re-runs the same path on its next interval.
   *Applies to this PR:* `i3status-agent-ops` → `i3status-claude-runs`.
+- 🔴 **ADDING a block is in that same restart class — and "did it restart?" needs a real
+  check, not an assumption.** The bar holds the block LIST it parsed at startup, so a new
+  block is simply absent until `i3-msg restart`, on a host reporting a fully successful
+  deploy. Measured 2026-08-20 (the load pill): the live bar predated its own config by
+  **26 hours**. The check is the bar's start time against the config's mtime — but 🔴
+  **`pgrep -x i3status-rs` finds NOTHING while it is running**: `comm` is
+  `.i3status-rs-wr`, a nix wrapper. Match on `/bin/i3status-rs`, and take the process whose
+  **PARENT is `i3bar`** — orphaned copies from old sessions linger with `ppid 1` and are not
+  the bar. (`pgrep -f` additionally matches the checking shell itself.)
+  ```bash
+  ps -eo pid,ppid,lstart,comm,args | grep i3status-rs | grep -v grep
+  stat -c '%y' ~/.config/i3status-rust/config-top.toml   # the bar must start AFTER this
+  ```
+  🔴 **A hide-at-zero block cannot be confirmed by LOOKING at the bar** — its correct state
+  is invisible. Run the block's own `command =` line from the config, then force the visible
+  states with explicit thresholds; that is the only honest render check.
 - **Syntax check first:** `nix-instantiate --parse nix/graphical.nix >/dev/null`.
 - **Flake gotcha:** a NEW *block script* referenced from `graphical.nix` — and any new file in
   this skill dir — must be `git add`ed before switch (flakes only see tracked files). This skill

--- a/claudedocs/handoff-load-monitor-reap.md
+++ b/claudedocs/handoff-load-monitor-reap.md
@@ -1,108 +1,157 @@
-# Handoff: load-average bar pill (shipped) + auto-reap (dropped) — 2026-08-20
+# Handoff: load-average bar pill (shipped + deployed) + auto-reap (dropped) — 2026-08-20
 
-Supersedes the 2026-08-19 version of this file, which described the auto-reap as
-DONE and the bar block as ready to commit. Both claims are now wrong.
+Restructured onto the canonical `State now` / `Next steps` / `How to verify` headings so
+future `/handoff` runs can MERGE into it. The previous version used freehand headings, so
+an update appended a second status section instead of replacing the stale one and the doc
+briefly said both "NOT deployed" and "deployed". Nothing was dropped in the restructure.
 
-## Where things stand
-
-**Shipped:** the load pill — PR #590, merged to `main` as `1d2bc985`. Verified by
-CONTENT, not ancestry (a squash merge is never an ancestor): `scripts/i3status-load`
-exists on `origin/main` with `ICON = "cogs"` and `loadWarnAbove = 48`.
-
-**Dropped, by decision:** the `cpu-monitor.sh` auto-reap. Not shelved — deliberately
-discarded. The working tree is clean of it (`grep -c AUTO-REAP` → 0).
-
-**NOT deployed.** This is the one open action.
-
-## 🔴 The open action: deploy
-
-The change is on `main` and on **neither host**. `home-manager switch` is what makes
-a `home.file` real; `git pull` changes nothing nix manages.
-
-It was deliberately NOT shipped on 2026-08-20: `ship.sh` runs `git checkout main`
-per host, and `~/workspace/devrc` was on `espanso/ssh-reachability-and-three-snippets`
-with another session live on it (an `espanso/rebase-tmp` worktree sat at the same
-commit). Nothing would have been lost — the other session's uncommitted
-`claude/skills/resume/SKILL.md` edit is identical between its HEAD and `main`, so a
-checkout carries it across — but it would have moved a live session onto `main`, and
-a session on `main` that commits breaks this repo's 🔴 never-commit-to-main rule.
-
-**When that session has landed:**
+## Run this first — the index, one read-only command
 ```bash
-scripts/ship.sh                 # read EVERY per-host line, not the final verdict
-i3-msg restart                  # 🔴 REQUIRED — see below
+python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py --repo devrc
+```
+🔴 RECALL, NOT LIVE OBSERVATION — every line is a pointer to VERIFY. `scope-absent`/
+`scope-empty` means nothing recorded yet: ordinary, not a clean bill of health.
+Non-blocking: if it exits non-zero, print the stderr line and carry on.
+
+## Goal
+
+A load-average pill on the i3status-rust bar, calm by default (hidden until load is
+actually interesting). The `cpu-monitor.sh` auto-reap explored alongside it was dropped.
+
+## State now
+
+- Branch `main`. PRs **#590** (the pill, squash-merged as `1d2bc985`) and **#597** (the first
+  version of this doc), both merged. Verified by CONTENT, not ancestry — a squash merge is
+  never an ancestor, so `merge-base --is-ancestor` returns false forever and means nothing.
+- **DONE, DEPLOYED and VERIFIED on both hosts.** `scripts/ship.sh` converged both to
+  `origin/main` (`e7ceb1f`) and switched: workbench 488 managed artifacts / laptop 449,
+  **0 dangling, 0 stale, no host skipped** (every per-host line read, not the verdict).
+- The workbench had *already* been switched before that — another session's switch picked
+  up `main` including the pill.
+- Workbench bar restarted (`i3-msg restart`); the live `i3status-rs` now starts AFTER its
+  config mtime, so it has parsed the block. Before the restart it predated its own config
+  by **26 hours** — deployed but not live, exactly the failure this doc warned about.
+  Desktop state recorded and unchanged across the restart (same window, same workspace).
+- **Auto-reap: dropped by decision.** Not shelved. Tree is clean (`grep -c AUTO-REAP` → 0).
+
+### Verified, with the values
+
+```
+bar's exact command : i3status-load --warning 48 --critical 72
+  at live load 4.34 : {"text": "", "state": "Idle"}      <- correct: hides below 48
+  forced Warning    : {"icon":"cogs","text":"4.3",...,"state":"Warning"}
+  forced Critical   : {"icon":"cogs","text":"4.3",...,"state":"Critical"}
+  bad threshold     : {"icon":"cogs","text":"?",...,"state":"Warning"}
+  `cogs` present in the icon set the RUNNING binary loads: 1 hit
+LAPTOP (the host the original bug would have broken):
+  readlink -f -> /nix/store/spgql8n5z94bd8ma3v8m8vgzgq9ig328-hm_i3statusload
+  ICON = "cogs" | bar config refs: 1 | renders Warning when forced | nproc = 8
 ```
 
-🔴 **`ship.sh` alone is not enough for a NEW block.** A switch does not restart
-`i3status-rs`; the bar holds the config it parsed at startup, so the pill will be
-absent on a host reporting a fully successful deploy. `claude/skills/bar/SKILL.md`
-documents this; the original handoff omitted it and the first PR body did too.
+🔴 **NOT verified: the pill has never been SEEN on the bar.** At load 4.34 against a
+threshold of 48 it renders hidden — by design — so there is nothing to look at. What is
+proven is that the bar re-parsed the config and that the exact deployed command produces
+correct output in every state. Seeing it lit needs a genuinely loaded box.
 
-## Verification still owed
+⚠ Scope of the deploy claim: verified at `e7ceb1f`. `origin/main` has since moved
+(`ff26d43`), so the hosts are a couple of commits behind again — ordinary churn from other
+sessions, not a regression in this work.
 
-Nobody has seen this block render on a real bar. Pre-deploy state was measured, so
-there is a genuine before/after: `~/.config/i3status-rust/scripts/i3status-load` did
-not resolve, and the live `config-top.toml` had **0** references to it.
+## Next steps (ranked)
 
-After deploying:
+1. **Nothing is required.** Shipped, deployed, verified on both hosts.
+2. Opportunistic: next time the workbench is genuinely loaded (>48), glance at the bar and
+   confirm the pill shows yellow, red above 72. That is the only unverified claim.
+3. Consider whether the **laptop** threshold should be per-host. A flat 48 on a 4C/8T box is
+   ~6x oversubscription, so the pill is effectively unreachable there while still spawning
+   every 15s. It follows `CPU_MON_THRESHOLD`, itself unconditional — changing one without
+   the other reintroduces the drift `loadWarnAbove` exists to prevent.
+4. Unrelated, noticed while here: two orphaned `i3status-rs` processes from **Aug 4**
+   (`ppid 1`, dead tmux scope, NOT parented by `i3bar`). Deliberately not killed —
+   attributing and reaping stray processes was outside this task.
+
+## How to verify
+
 ```bash
-readlink -f ~/.config/i3status-rust/scripts/i3status-load   # must land in /nix/store
-grep -c i3status-load ~/.config/i3status-rust/config-top.toml   # must be > 0
-~/.config/i3status-rust/scripts/i3status-load --warning 0.1 --critical 999999
+# the artifact resolves into the store (readlink is the arbiter, never a diff)
+readlink -f ~/.config/i3status-rust/scripts/i3status-load
+grep -c i3status-load ~/.config/i3status-rust/config-top.toml     # must be > 0
+
+# run exactly what the bar runs, then force the states you cannot otherwise see
+CMD=$(grep -o '.*/i3status-load[^"]*' ~/.config/i3status-rust/config-top.toml | head -1)
+eval "$CMD"                                                        # hidden below 48
+~/.config/i3status-rust/scripts/i3status-load --warning 0.1 --critical 999999   # Warning
+~/.config/i3status-rust/scripts/i3status-load --warning nan --critical 9        # ? pill
+
+# is the RUNNING bar serving the current config? (a switch does NOT restart i3status-rs)
+#   comm is `.i3status-rs-wr` (a nix wrapper) — `pgrep -x i3status-rs` finds NOTHING.
+#   The real bar is the one whose PARENT is `i3bar`; the others are orphans.
+ps -eo pid,ppid,lstart,comm,args | grep i3status-rs | grep -v grep
+stat -c '%y' ~/.config/i3status-rust/config-top.toml   # the bar must start AFTER this
 ```
-The last line forces the pill visible regardless of ambient load — the honest way to
-confirm it renders, since at the shipped threshold (48) it is invisible most of the day.
 
-## What the audits caught (two rounds, both on #590)
+## Gotchas / decisions / dead-ends
 
-Worth reading before touching this again — three of these were invisible to a green suite.
+### From the deploy
 
-1. 🔴 **The icon was not an i3status-rust icon key.** `utilities-system-monitor` is an
-   XDG desktop-icon name. An unknown icon does not degrade to a missing glyph —
-   i3status-rust renders the whole block as a red `Failed to render full text`.
-   Measured against i3status-rs 0.36.1: `cpu` → ` 󰓅 9.9 `, `utilities-system-monitor`
-   → the error string, `cogs` → ` 󰒓 9.9 `. Both VISIBLE states carried it, so the only
-   payload that worked was the invisible one. The suite could not see it because the
-   test asserted `out["icon"] == ICON` against a constant copied from the
-   implementation — an expectation derived from the code under test never disagrees.
-2. 🔴 **A false parity claim.** The block warned at the core count while
-   `CPU_MON_THRESHOLD` is a flat **48**, raised deliberately on 2026-08-05 to cut
-   toasts from 123-267/day to 11-32/day. Keying the pill off `nproc` would have warned
-   at 24 on a workbench that idles in the twenties. Now single-sourced as
-   `loadWarnAbove`/`loadCritAbove` and pinned by a test.
-3. **Two ways it would have shipped dead**, both now gated: the block was ungated while
-   its `home.file` was `mkIf (!isLaptop)`, and the script was never `git add`ed (a
-   flake omits untracked files silently — confirmed against the derivation source).
-4. **A guard walkable by a comment**: `"--warning ..." in nix` was satisfied by the
-   flags sitting in a `#` comment beside a command that no longer passed them.
+- 🔴 **`ship.sh` succeeding says nothing about the CONSUMER.** The workbench was fully
+  deployed while the running bar still held a 26-hour-old config. A new block needs
+  `i3-msg restart`; the switch alone leaves a host reporting complete success with no pill.
+- 🔴 **`pgrep -x i3status-rs` returns NOTHING while the bar is running** — `comm` is
+  `.i3status-rs-wr`, a nix wrapper. An earlier check "found no bar" for this reason and was
+  an instrument failure, not a state reading. Match `/bin/i3status-rs` and identify the real
+  bar by `parent == i3bar`. `pgrep -f` additionally matches the checking shell itself.
+- The deploy was deliberately HELD one round: `ship.sh` does `git checkout main` per host,
+  and `~/workspace/devrc` was on another session's espanso branch. Nothing would have been
+  lost, but it would have moved a live session onto `main` — where a commit breaks this
+  repo's 🔴 never-commit-to-main rule. It resolved when that session landed. Worth
+  re-measuring rather than assuming: `claude/skills/resume/SKILL.md` went from "identical to
+  main, carries across" to "differs, would block" within the hour, because #594 touched it.
+
+### What the two audits caught (three were invisible to a green suite)
+
+1. 🔴 **The icon was not an i3status-rust icon key.** `utilities-system-monitor` is an XDG
+   desktop-icon name. An unknown icon does not degrade to a missing glyph — i3status-rust
+   renders the whole block as a red `Failed to render full text`. Measured against
+   i3status-rs 0.36.1: `cpu` → ` 󰓅 9.9 `, `utilities-system-monitor` → the error string,
+   `cogs` → ` 󰒓 9.9 `. Both VISIBLE states carried it, so the only payload that worked was
+   the invisible one. The suite could not see it because the test asserted
+   `out["icon"] == ICON` against a constant copied from the implementation — an expectation
+   derived from the code under test never disagrees with it.
+2. 🔴 **A false parity claim.** The block warned at the core count while `CPU_MON_THRESHOLD`
+   is a flat **48**, raised deliberately on 2026-08-05 to cut toasts from 123-267/day to
+   11-32/day. Keying the pill off `nproc` would have warned at 24 on a workbench that idles
+   in the twenties. Now single-sourced as `loadWarnAbove`/`loadCritAbove` and test-pinned.
+3. **Two ways it would have shipped dead**, both now gated: the block was ungated while its
+   `home.file` was `mkIf (!isLaptop)`, and the script was never `git add`ed (a flake omits
+   untracked files silently — confirmed against the derivation source).
+4. **A guard walkable by a comment**: `"--warning ..." in nix` was satisfied by the flags
+   sitting in a `#` comment beside a command that no longer passed them.
 5. **A gate that went red on a legitimate reformat** — nested `++` inside a gated
    `lib.optionals`. A permanently-red gate is worse than no gate.
 
-## Known limitations (accepted, not bugs to re-discover)
+### Known limitations (accepted, not bugs to re-discover)
 
-- **The icon guard's strongest half is inert in the authoritative gate.** Inside the
-  nix sandbox `/nix/store` holds only the derivation closure, so i3status-rust is not
-  reachable and the in-file allowlist is the whole check. It now emits a warning when
-  it falls back, so a weak green is distinguishable from a strong one. Making it strong
-  there means adding i3status-rust to the check's inputs — not done.
-- **The laptop pill is effectively unreachable.** The threshold is a flat 48 on both
-  hosts (following `CPU_MON_THRESHOLD`, itself unconditional), so on a 4C/8T laptop it
-  is ~6x oversubscription away. It still spawns every 15s. Make both per-host if that
-  is wrong.
-- **`i3status-rust ships a native `load` block.** It was rejected only because it has
-  no hide-below-threshold behaviour. If it ever grows one, delete `scripts/i3status-load`.
+- **The icon guard's strongest half is inert in the authoritative gate.** Inside the nix
+  sandbox `/nix/store` holds only the derivation closure, so i3status-rust is unreachable
+  and the in-file allowlist is the whole check. It warns when it falls back, so a weak green
+  is distinguishable from a strong one. Making it strong means adding i3status-rust to the
+  check's inputs — not done.
+- **The laptop pill is effectively unreachable** (see Next steps 3).
+- **i3status-rust ships a native `load` block.** Rejected only because it has no
+  hide-below-threshold behaviour. If it ever grows one, delete `scripts/i3status-load`.
 
-## Why the auto-reap was dropped
+### Why the auto-reap was dropped
 
-Recorded so it is not rebuilt from the same premise. A dry run of its selection path
-against the live process table picked **Brave, a running game, and an in-progress
-vitest run** — none protected by `is_protected()`, which covered only root-owned
-processes plus an exact-comm list. Its ignore-list safety valve was defeated by
-`top`'s COMMAND truncation (`Farthes+` vs `FarthestFronti`), so a game the operator
-had explicitly ignore-listed could still be killed. It had no off switch —
-`CPU_MON_REAP_KILLS_PER_DAY=0` meant *unlimited*, not disabled. And the premise was
-weaker than assumed: the trigger was 2x cores = 48, against a measured 15-minute load
-baseline of 30 on 24 cores, i.e. 63% of the way there during ordinary work.
+Recorded so it is not rebuilt from the same premise. A dry run of its selection path against
+the live process table picked **Brave, a running game, and an in-progress vitest run** —
+none protected by `is_protected()`, which covered only root-owned processes plus an exact
+comm list. Its ignore-list safety valve was defeated by `top`'s COMMAND truncation
+(`Farthes+` vs `FarthestFronti`), so a game the operator had explicitly ignore-listed could
+still be killed. It had no off switch — `CPU_MON_REAP_KILLS_PER_DAY=0` meant *unlimited*,
+not disabled. And the premise was weaker than assumed: the trigger was 2x cores = 48 against
+a measured 15-minute baseline of 30 on 24 cores, i.e. 63% of the way there during ordinary
+work.
 
-Decision: the three existing cpu-monitor triggers (sustained load, runaway process,
-thermal) already alert; a killer added risk without adding information.
+Decision: the three existing cpu-monitor triggers (sustained load, runaway process, thermal)
+already alert; a killer added risk without adding information.


### PR DESCRIPTION
Two docs, one lesson between them.

### `bar` SKILL.md — the gap that cost real time

It already said a **renamed/removed** block needs `i3-msg restart`. It did not say **adding** one does, nor how to check the restart actually took. Measured 2026-08-20 while deploying the load pill: the live bar predated its own config by **26 hours**, on a host `ship.sh` reported as fully successful.

The check is the bar's start time vs the config mtime — and the obvious way to find the bar does not work:

```
pgrep -x i3status-rs   ->   (nothing, while it is running)
```

`comm` is `.i3status-rs-wr`, a nix wrapper. An earlier check "found no bar" for that reason and was an **instrument failure, not a state reading**. Match `/bin/i3status-rs` and take the process whose **parent is `i3bar`** — orphans from old sessions linger at `ppid 1`.

Also recorded: a hide-at-zero block **cannot be confirmed by looking at the bar**, because its correct state is invisible. The only honest render check is running the block's own `command =` line from the config and forcing the visible states.

### The handoff doc

It said "NOT deployed" as its one open action; that is now done and verified on both hosts. Restructured onto the canonical `State now` / `Next steps` / `How to verify` headings — the freehand ones meant `handoff_doc.py --update` **appended** a second status section rather than replacing the stale one, producing a doc that claimed both "NOT deployed" and "deployed". Nothing was dropped; verified by grepping the old version's load-bearing phrases.

### Verification
726 tests pass across `test_handoff_doc`, `test_doc_path_rot`, `test_bar_status`, `test_prune_skill_size`. Docs-only — no executable surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)