### PR TITLE
feat(obs): ship host metrics + the journal to homelab — the freeze evidence died with the box 16 times

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -130,7 +130,10 @@ in
 {
   # Graphical (i3 + i3status-rust bar) config lives in ./graphical.nix; isLaptop is
   # threaded to it as a module arg so it can branch battery/backlight vs rig/DDC.
-  imports = [ ./graphical.nix ];
+  # ./observability.nix ships host metrics + the journal to the homelab stack.
+  # BOTH hosts, deliberately: cross-host comparison is the point, and the
+  # workbench is where the ship.sh drift incidents happened.
+  imports = [ ./graphical.nix ./observability.nix ];
   _module.args.isLaptop = isLaptop;
 
   programs = programs;

--- a/nix/observability.nix
+++ b/nix/observability.nix
@@ -91,10 +91,14 @@ in
         "${pkgs.prometheus-node-exporter}/bin/node_exporter"
         "--web.listen-address=127.0.0.1:${toString nodeExporterPort}"
         "--collector.textfile.directory=${textfileDir}"
-        # thermal_zone and drm are NOT on by default. Both matter here: the
-        # freeze hypotheses that remain open are thermal and GPU-adjacent.
+        # thermal_zone is NOT on by default and does work here (7 series).
         "--collector.thermal_zone"
-        "--collector.drm"
+        # NOTE: --collector.drm is deliberately ABSENT. It was tried and is
+        # INERT on this hardware: node_exporter's drm collector only supports
+        # amdgpu, and both hosts are Intel (this laptop reports DRIVER=i915,
+        # PCI_ID=8086:9A49). Measured `grep -c '^node_drm' == 0`. It would have
+        # read as coverage for the GPU-adjacent freeze hypothesis while
+        # providing none — worse than not claiming it.
         # Off by default and genuinely useful on a roaming laptop.
         "--collector.systemd"
         # Noise on a workstation: every docker veth churns netdev/arp series.
@@ -166,7 +170,9 @@ in
       # 2min: let journald settle and the previous boot's tail be readable.
       OnBootSec = "2min";
       OnUnitActiveSec = "1d";
-      Persistent = true;
+      # NOTE: no `Persistent = true` — it applies only to OnCalendar= timers and
+      # would be an inert line that reads as catch-up coverage. OnBootSec already
+      # guarantees a run after every boot, which is the case that matters.
     };
     Install.WantedBy = [ "timers.target" ];
   };

--- a/nix/observability.nix
+++ b/nix/observability.nix
@@ -1,0 +1,173 @@
+{ config, pkgs, lib, ... }:
+
+# Host telemetry -> homelab Prometheus + Loki.
+#
+# WHY USER-LEVEL, NOT /etc/nixos
+# ------------------------------
+# `services.alloy` and `services.prometheus.exporters.node` are NixOS options,
+# so they would live in /etc/nixos — which is per-host, NOT in this repo, and
+# needs sudo for every change. As user units they are managed here and ship to
+# both hosts through `ship.sh` like everything else.
+#
+# Nothing here needs root: node_exporter's /proc and /sys collectors are
+# world-readable, and `zach` is in `wheel`, which systemd's journal ACLs grant
+# full read of the system journal (verified: `journalctl -b -1` works unprivileged).
+#
+# The two pieces that DO need root are deliberately excluded and staged
+# separately: shipping /var/lib/systemd/pstore dumps (0600 root) and NVMe SMART.
+#
+# WHAT THIS IS FOR
+# ----------------
+# The laptop has stopped uncleanly 16 times across its retained journal, and the
+# rate was never visible — it was believed to be "twice in the past month". Six
+# of those were since 2026-07-29 alone. Two failures made that invisible:
+#
+#   1. The final minutes before each freeze were never written to disk. journald
+#      syncs periodically; a hard lockup takes the RAM buffer with it. Shipping
+#      the journal continuously moves those minutes OFF the box before it dies.
+#   2. Nothing counted the stops. `boot-outcome` below turns that into a series.
+#
+# See nix/system/apply-freeze-instrumentation.sh (PR #616) for the other half:
+# making the kernel capture a trace at all.
+
+let
+  # 🔴 The config is VALIDATED AT BUILD TIME, so an invalid one cannot be
+  # deployed — `home-manager switch` fails instead.
+  #
+  # This matters more than it looks: a broken Alloy config is SILENT from the
+  # consumer's side. The agent exits, the host simply stops appearing in
+  # Prometheus, and "no data for this host" is indistinguishable from the hard
+  # freeze this pipeline exists to detect. A deploy-time failure is loud; a
+  # runtime one impersonates the very signal we are trying to measure.
+  #
+  # `alloy validate` (not `alloy fmt`) is required: fmt checks SYNTAX only and
+  # accepted `faster_drop_reason = "..."` — a real typo in this file's first
+  # draft — with rc=0. validate resolves component names, attribute names and
+  # inter-component references. scripts/tests/test_obs_alloy_config.py pins that
+  # distinction with negative controls.
+  alloyConfig = pkgs.runCommandLocal "alloy-config-validated"
+    { nativeBuildInputs = [ pkgs.grafana-alloy ]; }
+    ''
+      export HOME="$TMPDIR"
+      # Placeholders only: validate resolves references and attribute names, and
+      # never contacts an endpoint. The real values arrive at RUNTIME from the
+      # gitignored EnvironmentFile — they must never enter the nix store, which
+      # is world-readable.
+      export OBS_PROM_URL="http://127.0.0.1:9090/api/v1/write"
+      export OBS_LOKI_URL="http://127.0.0.1:3100/loki/api/v1/push"
+      export OBS_USERNAME="validate"
+      export OBS_PASSWORD="validate"
+      export OBS_HOST="validate"
+
+      alloy validate ${../scripts/obs/alloy.alloy}
+      cp ${../scripts/obs/alloy.alloy} $out
+    '';
+
+  # node_exporter listens on loopback only. Nothing scrapes this host from
+  # outside: the laptop roams, so the agent PUSHES (remote_write) rather than
+  # being scraped. Binding to 0.0.0.0 would expose host metrics on every café
+  # network for no benefit.
+  nodeExporterPort = 9101;
+
+  textfileDir = "${config.home.homeDirectory}/.local/state/node-exporter-textfile";
+  bootOutcome = "${config.home.homeDirectory}/.local/share/obs/boot_outcome.py";
+in
+{
+  home.file.".local/share/obs/boot_outcome.py".source = ../scripts/obs/boot_outcome.py;
+
+  # ---------------------------------------------------------------- exporter --
+  systemd.user.services.node-exporter = {
+    Unit = {
+      Description = "Prometheus node_exporter (loopback only)";
+      After = [ "network.target" ];
+      OnFailure = [ "notify-failure@%n.service" ];
+    };
+    Service = {
+      Type = "simple";
+      # PATH must be explicit: a user service does not inherit the login PATH.
+      Environment = [ "PATH=${lib.makeBinPath [ pkgs.coreutils ]}" ];
+      ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p ${textfileDir}";
+      ExecStart = lib.concatStringsSep " " [
+        "${pkgs.prometheus-node-exporter}/bin/node_exporter"
+        "--web.listen-address=127.0.0.1:${toString nodeExporterPort}"
+        "--collector.textfile.directory=${textfileDir}"
+        # thermal_zone and drm are NOT on by default. Both matter here: the
+        # freeze hypotheses that remain open are thermal and GPU-adjacent.
+        "--collector.thermal_zone"
+        "--collector.drm"
+        # Off by default and genuinely useful on a roaming laptop.
+        "--collector.systemd"
+        # Noise on a workstation: every docker veth churns netdev/arp series.
+        "--no-collector.arp"
+        "--no-collector.infiniband"
+        "--no-collector.nfs"
+        "--no-collector.nfsd"
+      ];
+      Restart = "always";
+      RestartSec = 10;
+    };
+    Install.WantedBy = [ "default.target" ];
+  };
+
+  # ------------------------------------------------------------------- agent --
+  systemd.user.services.alloy = {
+    Unit = {
+      Description = "Grafana Alloy — ship host metrics + journal to homelab";
+      After = [ "network.target" "node-exporter.service" ];
+      Wants = [ "node-exporter.service" ];
+      OnFailure = [ "notify-failure@%n.service" ];
+    };
+    Service = {
+      Type = "simple";
+      Environment = [ "PATH=${lib.makeBinPath [ pkgs.coreutils ]}" ];
+
+      # 🔴 Endpoints and credentials come from OUTSIDE the nix store, which is
+      # world-readable — and this repo is PUBLIC, so they cannot be committed
+      # either. The leading `-` makes it optional: a host that has not been
+      # given credentials yet must not fail its switch, it just does not ship.
+      EnvironmentFile = [ "-%h/.config/obs-ship/env" ];
+
+      ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p %h/.local/state/alloy";
+      ExecStart = lib.concatStringsSep " " [
+        "${pkgs.grafana-alloy}/bin/alloy run"
+        "--storage.path=%h/.local/state/alloy"
+        # Loopback-only UI, and a non-default port so it cannot collide with the
+        # cluster's own Alloy conventions.
+        "--server.http.listen-addr=127.0.0.1:12349"
+        "${alloyConfig}"
+      ];
+      Restart = "always";
+      # Longer than node-exporter's: a restart loop against an unreachable
+      # endpoint should back off, not hammer a sleeping laptop's radio.
+      RestartSec = 30;
+    };
+    Install.WantedBy = [ "default.target" ];
+  };
+
+  # ------------------------------------------------------- unclean-boot count --
+  # Runs once shortly after boot (classifying the PREVIOUS boot, which is the
+  # one that just ended badly), then daily so the series does not go stale on a
+  # host that stays up for weeks.
+  systemd.user.services.boot-outcome = {
+    Unit = {
+      Description = "Classify whether the previous boot ended cleanly";
+      OnFailure = [ "notify-failure@%n.service" ];
+    };
+    Service = {
+      Type = "oneshot";
+      Environment = [ "PATH=${lib.makeBinPath [ pkgs.systemd pkgs.coreutils ]}" ];
+      ExecStart = "${pkgs.python3}/bin/python3 ${bootOutcome} --textfile ${textfileDir}/boot_outcome.prom";
+    };
+  };
+
+  systemd.user.timers.boot-outcome = {
+    Unit.Description = "Classify the previous boot shortly after startup, then daily";
+    Timer = {
+      # 2min: let journald settle and the previous boot's tail be readable.
+      OnBootSec = "2min";
+      OnUnitActiveSec = "1d";
+      Persistent = true;
+    };
+    Install.WantedBy = [ "timers.target" ];
+  };
+}

--- a/scripts/obs/README.md
+++ b/scripts/obs/README.md
@@ -23,8 +23,8 @@ because TLP disables the NMI hard-lockup detector — is
 
 ## One-time setup per host
 
-Endpoints and credentials are **not in this repo** (it is public) and **not in
-the nix store** (world-readable). Create, on each host:
+Endpoints and credentials live **outside the repo entirely** (it is public) and
+**outside the nix store** (world-readable). Create, on each host:
 
 ```bash
 mkdir -p ~/.config/obs-ship
@@ -52,7 +52,7 @@ credential must not break a deploy.
 ```bash
 systemctl --user status alloy node-exporter
 curl -s localhost:9101/metrics | grep -c '^node_'        # exporter is up
-curl -s localhost:9101/metrics | grep '^host_boot'       # boot-outcome metrics
+curl -s localhost:9101/metrics | grep '^host_'           # boot-outcome metrics
 journalctl --user -u alloy -n 20                         # shipping errors, if any
 ```
 

--- a/scripts/obs/README.md
+++ b/scripts/obs/README.md
@@ -1,0 +1,102 @@
+# Host telemetry → homelab Prometheus + Loki
+
+Ships this host's metrics and journal to the homelab observability stack, so
+that when the machine stops, the evidence is already off the box.
+
+Deployed by `nix/observability.nix` as **user** systemd units (no sudo, ships to
+both hosts via `ship.sh`).
+
+## Why
+
+The laptop stopped uncleanly **16 times** across its retained journal — six of
+them since 2026-07-29 — and it was believed to have frozen "twice in the past
+month". Two things made that invisible:
+
+1. **The last minutes never reached disk.** journald buffers, and a hard lockup
+   takes the buffer with it. Shipping continuously moves those minutes off the
+   host before it dies.
+2. **Nothing counted the stops.** `boot_outcome.py` turns them into a series.
+
+The other half of the problem — that the kernel recorded no trace at all,
+because TLP disables the NMI hard-lockup detector — is
+`nix/system/apply-freeze-instrumentation.sh`.
+
+## One-time setup per host
+
+Endpoints and credentials are **not in this repo** (it is public) and **not in
+the nix store** (world-readable). Create, on each host:
+
+```bash
+mkdir -p ~/.config/obs-ship
+cat > ~/.config/obs-ship/env <<'EOF'
+OBS_PROM_URL=http://<prometheus-host>:<port>/api/v1/write
+OBS_LOKI_URL=http://<loki-host>:<port>/loki/api/v1/push
+OBS_USERNAME=<user>
+OBS_PASSWORD=<pass>
+OBS_HOST=workbench          # or: laptop
+EOF
+chmod 600 ~/.config/obs-ship/env
+systemctl --user restart alloy
+```
+
+The homelab Prometheus already has `enableRemoteWriteReceiver: true`, so it
+accepts `remote_write` directly — no scrape target or ingress needed. Reach it
+over the Nebula mesh.
+
+`EnvironmentFile` is optional (`-` prefixed): a host without this file still
+switches cleanly, it just does not ship. That is deliberate — a missing
+credential must not break a deploy.
+
+## Verify
+
+```bash
+systemctl --user status alloy node-exporter
+curl -s localhost:9101/metrics | grep -c '^node_'        # exporter is up
+curl -s localhost:9101/metrics | grep '^host_boot'       # boot-outcome metrics
+journalctl --user -u alloy -n 20                         # shipping errors, if any
+```
+
+In Grafana, `host_boot_previous_clean == 0` means the last boot ended abruptly.
+
+## What it emits
+
+| metric | meaning |
+|---|---|
+| `host_boot_previous_clean` | 1 = previous boot reached systemd's shutdown sequence, 0 = stopped abruptly |
+| `host_boot_previous_end_timestamp_seconds` | when the previous boot's journal ends |
+| `host_unclean_boots_observed` | unclean endings across the retained journal |
+| `host_boots_examined` | boots actually classified — **read this beside the count above** |
+| `host_boot_outcome_scrape_ok` | 0 = could not measure; the counts are then absent, not zero |
+
+🔴 `host_unclean_boots_observed` is only interpretable next to
+`host_boots_examined`. A zero from a scan that walked nothing is a failure, not
+an all-clear, which is why the classifier omits the count entirely rather than
+emitting `0` when it cannot measure.
+
+"Unclean" is a **symptom count, not a diagnosis**: it covers a hard lockup, but
+also a flat battery, a held power button, and a panic.
+
+## Privacy
+
+The journal here is not neutral telemetry — it carries desktop-notification
+bodies, database errors echoing query values, and object-store credential
+errors. `alloy.alloy` drops `dunst` lines entirely and redacts credential-shaped
+assignments before anything is written. Scrubbing runs **before** the Loki
+write, and `test_obs_alloy_config.py` pins that ordering.
+
+## Not covered here (needs root)
+
+- Shipping `/var/lib/systemd/pstore/*` crash dumps (0600, root-owned)
+- NVMe SMART counters
+
+Both would follow the staged `nix/system/apply-*.sh` pattern.
+
+## Config validity
+
+`alloy.alloy` is validated **at build time** by `nix/observability.nix`, so an
+invalid config fails `home-manager switch` rather than silently taking the agent
+down — a dead agent looks exactly like a frozen host, which is the one thing
+this pipeline must not be ambiguous about.
+
+Use `alloy validate`, never `alloy fmt`: fmt checks syntax only and accepted a
+real `faster_drop_reason` typo with rc=0.

--- a/scripts/obs/README.md
+++ b/scripts/obs/README.md
@@ -76,13 +76,34 @@ emitting `0` when it cannot measure.
 "Unclean" is a **symptom count, not a diagnosis**: it covers a hard lockup, but
 also a flat battery, a held power button, and a panic.
 
-## Privacy
+## Privacy — a transport allowlist, not pattern-matching
 
-The journal here is not neutral telemetry — it carries desktop-notification
-bodies, database errors echoing query values, and object-store credential
-errors. `alloy.alloy` drops `dunst` lines entirely and redacts credential-shaped
-assignments before anything is written. Scrubbing runs **before** the Loki
-write, and `test_obs_alloy_config.py` pins that ordering.
+**Only `kernel`, `journal` and `syslog` are shipped. `stdout` is dropped.**
+
+That is the guarantee. It is a `keep` rule, so it is default-DENY: a transport
+that does not exist yet is dropped rather than shipped.
+
+Measured on this host (7 days, ~98k lines): `stdout` is **69.9%** of the journal
+and carries every content class that made shipping logs risky — container
+output, database errors echoing query values, object-store credential errors,
+agent tooling. The freeze evidence lives in `kernel` (1.9%) and `journal`
+(24.1%), which are kept.
+
+Why not redaction alone: five successive audit rounds each found a defect in the
+credential-redaction regexes, and three of those were introduced by the
+preceding fix. A denylist has to enumerate every shape a secret can take. The
+regex stages are still there as **defence-in-depth** for the retained 30%, and
+still run before the Loki write — but they are no longer the guarantee.
+
+Verified with a positive control, not just by reading the config: in a live run
+the source window held 57 `stdout` entries and the pipeline shipped **0** of
+them, while keeping all 30 `journal`, 1 `syslog` and 1 `kernel`.
+
+**Cost:** no application-level context around a freeze. Workload state is
+covered by metrics instead (PSI, thermals, memory, the boot-outcome counter).
+
+`dunst` notification bodies are dropped separately by identifier, since they
+arrive on a retained transport.
 
 ## Not covered here (needs root)
 

--- a/scripts/obs/alloy.alloy
+++ b/scripts/obs/alloy.alloy
@@ -136,6 +136,34 @@ loki.source.journal "system" {
 loki.relabel "journal" {
   forward_to = []
 
+  // 🔴 DEFAULT-DENY TRANSPORT ALLOWLIST. This is the primary privacy control;
+  // the redaction stages further down are defence-in-depth, not the guarantee.
+  //
+  // Why structural rather than pattern-matching: FIVE successive audit rounds
+  // each found a defect in the redaction regexes, and the last three were
+  // introduced by the preceding fix. A denylist has to enumerate every shape a
+  // secret can take, which is unbounded. Dropping the transport that carries
+  // application output removes the hazard class instead of chasing it.
+  //
+  // Measured on this host (7 days, ~98k lines):
+  //     stdout  69.9%   application output — docker, MinIO, Postgres, agent
+  //                     tooling. Every content class the scrubbing existed for.
+  //     journal 24.1%   systemd's own messages
+  //     syslog   4.2%   sudo, ssh, cron
+  //     kernel   1.9%   THE FREEZE EVIDENCE
+  //
+  // So the dropped 70% is almost exactly the risky part, and the freeze
+  // forensics this pipeline exists for live in the kept 30%.
+  //
+  // `keep` is an ALLOWLIST on purpose: a transport that does not exist yet is
+  // dropped by default rather than shipped by default. Adding one is a
+  // deliberate edit here, not an accident of some other change.
+  rule {
+    source_labels = ["__journal__transport"]
+    regex         = "kernel|journal|syslog"
+    action        = "keep"
+  }
+
   rule {
     source_labels = ["__journal__systemd_unit"]
     target_label  = "unit"
@@ -245,12 +273,24 @@ loki.process "scrub" {
   //        tail is what required the leaky value class above.
 
   // 2a. Quoted value — JSON, YAML, config dumps, and any secret containing a
-  //     comma, semicolon or space. `(?:[^'"\\]|\\.)*` rather than `[^'"]*` so an
-  //     ESCAPED quote inside the value does not end the match early: with the
-  //     simpler class, {"password": "a\\"b"} redacted to "[REDACTED]"b" and one
-  //     character of the secret survived (measured).
+  //     comma, semicolon or space.
+  //
+  //     🔴 The value class is `[^'"]*`, NOT an escape-aware `(?:[^'"\\]|\\.)*`.
+  //     The escape-aware form was tried, to stop `{"password": "a\\"b"}` leaving
+  //     one character behind — and it introduced a WORSE leak: it treats a lone
+  //     trailing backslash as an escape, so
+  //         token="abc\\" password="hunter2zz"
+  //     matched through the real closing quote to the NEXT quote, yielding
+  //         token="[REDACTED]"hunter2zz"     <- the second secret in CLEAR.
+  //     Both measured against alloy 1.17.1. A one-character residue is a
+  //     bounded cosmetic leak; a whole following credential is not. Reverted.
+  //
+  //     Residual, accepted and asserted: an ESCAPED quote inside a value leaves
+  //     the tail of that value behind. JSON is the main producer of that shape,
+  //     and JSON arrives on `stdout`, which the transport allowlist above now
+  //     drops entirely.
   stage.replace {
-    expression = "(?i)(?:access[_-]?key|secret[_-]?key|api[_-]?key|secret|token|password|passwd|authorization)[\"']?\\s*[=:]\\s*(?:bearer\\s+|basic\\s+)?['\"]((?:[^'\"\\\\]|\\\\.)*)['\"]"
+    expression = "(?i)(?:access[_-]?key|secret[_-]?key|api[_-]?key|secret|token|password|passwd|authorization)[\"']?\\s*[=:]\\s*(?:bearer\\s+|basic\\s+)?['\"]([^'\"]*)['\"]"
     replace    = "[REDACTED]"
   }
 
@@ -261,10 +301,20 @@ loki.process "scrub" {
   //     `password: "abcdef` (a line journald split at LineMax, say) shipped in
   //     CLEAR — a redaction the single-rule version did perform. Measured.
   //
-  //     The class excludes `"` but ALLOWS `'`: excluding `"` is what keeps this
-  //     idempotent over 2a's output (`"[REDACTED]", "user": ...`), while
-  //     allowing `'` stops `password=ab'cd` truncating to `[REDACTED]'cd` —
-  //     the same partial-leak class as everything else here.
+  //     The class excludes `"` but ALLOWS `'`. Excluding `"` keeps this
+  //     idempotent over 2a's DOUBLE-quoted output; allowing `'` stops
+  //     `password=ab'cd` truncating to `[REDACTED]'cd`.
+  //
+  //     🔴 BE PRECISE ABOUT THE COST — an earlier comment here called it
+  //     "consuming the closing quote", which understated it. For a SINGLE-quoted
+  //     value the match runs on to the next WHITESPACE, so following
+  //     comma/semicolon-joined fields are eaten too (measured):
+  //         password='abc',user=bob,host=h   ->  password='[REDACTED]
+  //         {'password': 'abc', 'user': 'bob'} -> {'password': '[REDACTED] 'user': 'bob'}
+  //     That is over-redaction (the acceptable direction) and no secret leaks,
+  //     but Python/Ruby dict reprs are a real shape. Idempotency likewise holds
+  //     for double-quoted and unquoted output but NOT for single-quoted: each
+  //     re-pass eats further. Production is single-pass.
   stage.replace {
     expression = "(?i)(?:access[_-]?key|secret[_-]?key|api[_-]?key|secret|token|password|passwd|authorization)[\"']?\\s*[=:]\\s*(?:bearer\\s+|basic\\s+)?['\"]?([^\\s\"]+)"
     replace    = "[REDACTED]"

--- a/scripts/obs/alloy.alloy
+++ b/scripts/obs/alloy.alloy
@@ -91,9 +91,18 @@ loki.write "homelab" {
   // A roaming laptop disconnects constantly (sleep, WiFi drop, travel), and the
   // journal is the highest-value stream here. `queue_config` on the metrics
   // remote_write does NOT cover this: that buffering is per-pipeline.
+  // NOTE: only `enabled` is set. `max_segment_age` was tried and removed — I
+  // could not confirm from the shipped binary whether "1h" differs from the
+  // default, and an argument that merely restates a default is an inert line
+  // that reads as a tuning decision.
+  //
+  // Scope, measured: the WAL replays after a disconnection AND across a process
+  // restart. The one gap is a COLD start — before `wal/remote/segment_marker`
+  // exists, alloy logs "marker segment file does not exist" and begins at the
+  // newest segment, so entries written during the very first run are not
+  // replayed by the first restart. Every restart after that replays.
   wal {
-    enabled           = true
-    max_segment_age   = "1h"
+    enabled = true
   }
 
   external_labels = {
@@ -196,18 +205,37 @@ loki.process "scrub" {
   // Keeping the keyword outside the group is what preserves "password: " as
   // readable context — the point of shipping the journal is to debug with it.
 
-  // 2. Credential-shaped assignments. The optional non-capturing `bearer` keeps
-  //    `Authorization: Bearer <jwt>` from leaking the token: without it `(\S+)`
-  //    captures the word "Bearer" and the JWT survives in clear (measured).
+  // 2. Credential-shaped assignments.
+  //
+  //    Three parts of this are load-bearing, each measured end-to-end:
+  //
+  //    a. `(?:bearer\s+|basic\s+)` — WITHOUT it, `(\S+)` captures the scheme
+  //       word and the credential survives in clear. Both schemes are covered:
+  //       an earlier version handled only `bearer`, so
+  //       `Authorization: Basic dXNlcjpwdw==` shipped the base64 unredacted.
+  //    b. `["']?` on BOTH sides of the separator — a quoted JSON key put a `"`
+  //       between the keyword and the `:`, so `{"password": "hunter2xyz"}` did
+  //       not match AT ALL and shipped byte-identical.
+  //    c. The value class EXCLUDES quote, comma, semicolon and `&` rather than
+  //       being `\S+`. `\S+` swallowed the rest of a JSON object and the rest of
+  //       a URL query string: a request log became
+  //       `?token=[REDACTED] HTTP/1.1` with `&user=&page=` eaten. Now only the
+  //       value dies:  `?token=[REDACTED]&user=bob&page=2`.
+  //
+  //    KNOWN AND ACCEPTED OVER-REDACTION: a keyword followed by a separator
+  //    redacts the next token whatever it is, so prose like `the token: is
+  //    missing` becomes `the token: [REDACTED] missing`. That direction is the
+  //    safe one — a missed secret is unrecoverable, a mangled sentence is not —
+  //    and it is asserted in the tests so it stays a decision, not a surprise.
   stage.replace {
-    expression = "(?i)(?:access[_-]?key|secret[_-]?key|api[_-]?key|secret|token|password|passwd|authorization)\\s*[=:]\\s*(?:bearer\\s+)?(\\S+)"
+    expression = "(?i)(?:access[_-]?key|secret[_-]?key|api[_-]?key|secret|token|password|passwd|authorization)[\"']?\\s*[=:]\\s*[\"']?(?:bearer\\s+|basic\\s+)?([^\\s\"',;&]+)"
     replace    = "[REDACTED]"
   }
 
-  // 3. A bare `Bearer <token>` with no `:` or `=` separator, which rule 2
-  //    cannot match because it requires one.
+  // 3. A bare `Bearer <token>` / `Basic <creds>` with no `:` or `=` separator,
+  //    which rule 2 cannot match because it requires one.
   stage.replace {
-    expression = "(?i)\\bbearer\\s+(\\S+)"
+    expression = "(?i)\\b(?:bearer|basic)\\s+([^\\s\"',;&]+)"
     replace    = "[REDACTED]"
   }
 

--- a/scripts/obs/alloy.alloy
+++ b/scripts/obs/alloy.alloy
@@ -1,0 +1,162 @@
+// Host telemetry -> homelab Prometheus + Loki.
+//
+// Runs as a USER service (see nix/observability.nix). That is deliberate: the
+// system-level alternative would live in /etc/nixos, which is per-host, not in
+// this repo, and needs sudo on every change. Everything here works unprivileged
+// because `zach` is in `wheel`, and systemd's journal ACLs grant `wheel` full
+// read of the system journal.
+//
+// 🔴 NO ENDPOINT, HOSTNAME OR CREDENTIAL MAY BE WRITTEN INTO THIS FILE.
+// devrc is a PUBLIC repo. Every site-specific value comes from the environment,
+// supplied by an EnvironmentFile outside the nix store:
+//     ~/.config/obs-ship/env      (gitignored, per-host, 0600)
+// Required: OBS_PROM_URL, OBS_LOKI_URL, OBS_USERNAME, OBS_PASSWORD, OBS_HOST
+//
+// Validated in CI by scripts/tests/test_obs_alloy_config.py, which parses this
+// file with `alloy fmt` — a config that does not parse takes the whole agent
+// down at start, and "the unit is running" is not evidence that it shipped
+// anything.
+
+logging {
+  level  = "warn"
+  format = "logfmt"
+}
+
+// ---------------------------------------------------------------- metrics --
+
+prometheus.remote_write "homelab" {
+  endpoint {
+    url = sys.env("OBS_PROM_URL")
+
+    basic_auth {
+      username = sys.env("OBS_USERNAME")
+      password = sys.env("OBS_PASSWORD")
+    }
+
+    // A laptop is off-network often (asleep, travelling, WiFi drop). Without a
+    // generous WAL the agent drops samples during every ordinary disconnection,
+    // and the gap looks identical to a host that froze — which is precisely the
+    // signal this whole pipeline exists to make legible.
+    queue_config {
+      capacity             = 10000
+      max_shards           = 4
+      min_backoff          = "1s"
+      max_backoff          = "5m"
+      retry_on_http_429    = true
+    }
+  }
+
+  external_labels = {
+    host   = sys.env("OBS_HOST"),
+    source = "devrc-host-telemetry",
+  }
+}
+
+prometheus.scrape "node" {
+  targets = [{
+    __address__ = "127.0.0.1:9101",
+    instance    = sys.env("OBS_HOST"),
+  }]
+
+  forward_to = [prometheus.remote_write.homelab.receiver]
+
+  // 15s, not the 60s default: the run-up to a freeze is minutes long at most.
+  // At 60s a thermal or IO cliff would be represented by one or two points.
+  scrape_interval = "15s"
+  scrape_timeout  = "10s"
+}
+
+// ------------------------------------------------------------------- logs --
+
+loki.write "homelab" {
+  endpoint {
+    url = sys.env("OBS_LOKI_URL")
+
+    basic_auth {
+      username = sys.env("OBS_USERNAME")
+      password = sys.env("OBS_PASSWORD")
+    }
+  }
+
+  external_labels = {
+    host = sys.env("OBS_HOST"),
+  }
+}
+
+// Journal -> Loki. This is the single highest-value part of the pipeline: the
+// local journal syncs to disk every 30s (and shipped as 5m before PR #616), so
+// the final minutes before every recorded freeze existed only in RAM and died
+// with the box. Shipped continuously, they survive the host.
+loki.source.journal "system" {
+  // Read the SYSTEM journal, not just this user's.
+  path = "/var/log/journal"
+
+  // On (re)start, replay recent history so a freeze that happened while the
+  // agent was down is not lost. Bounded so a long outage cannot flood Loki.
+  max_age = "12h"
+
+  labels = {
+    job = "systemd-journal",
+  }
+
+  relabel_rules = loki.relabel.journal.rules
+  forward_to    = [loki.process.scrub.receiver]
+}
+
+// Promote a small, FIXED set of journal fields to labels. Deliberately small:
+// every label is a Loki stream, and high-cardinality fields (PID, message hash,
+// boot id) multiply streams without making anything easier to find.
+loki.relabel "journal" {
+  forward_to = []
+
+  rule {
+    source_labels = ["__journal__systemd_unit"]
+    target_label  = "unit"
+  }
+
+  rule {
+    source_labels = ["__journal_syslog_identifier"]
+    target_label  = "identifier"
+  }
+
+  rule {
+    source_labels = ["__journal_priority_keyword"]
+    target_label  = "priority"
+  }
+
+  rule {
+    source_labels = ["__journal__transport"]
+    target_label  = "transport"
+  }
+}
+
+// Scrubbing. The journal on these hosts is NOT neutral telemetry: it carries
+// desktop-notification bodies, database errors that echo query values, and
+// object-store credential errors. Kernel and systemd lines are what this
+// pipeline is for; the rest is kept only after redaction.
+loki.process "scrub" {
+  forward_to = [loki.write.homelab.receiver]
+
+  // 1. Desktop notification BODIES are message content, not telemetry. Drop the
+  //    line entirely rather than trying to redact inside free text.
+  stage.drop {
+    source        = "identifier"
+    expression    = "^dunst$"
+    drop_counter_reason = "notification-body"
+  }
+
+  // 2. Redact credential-shaped assignments anywhere in the line. Case
+  //    insensitive, and deliberately greedy on the value side: a partially
+  //    redacted secret is a leaked secret.
+  stage.replace {
+    expression = "(?i)((?:access[_-]?key|secret[_-]?key|api[_-]?key|token|password|passwd|authorization|bearer)\\s*[=:]\\s*)(\\S+)"
+    replace    = "${1}[REDACTED]"
+  }
+
+  // 3. Redact bare AWS-style access key ids, which appear in MinIO errors
+  //    without an adjacent keyword.
+  stage.replace {
+    expression = "\\b(AKIA|ASIA)[0-9A-Z]{16}\\b"
+    replace    = "[REDACTED-KEYID]"
+  }
+}

--- a/scripts/obs/alloy.alloy
+++ b/scripts/obs/alloy.alloy
@@ -216,26 +216,59 @@ loki.process "scrub" {
   //    b. `["']?` on BOTH sides of the separator — a quoted JSON key put a `"`
   //       between the keyword and the `:`, so `{"password": "hunter2xyz"}` did
   //       not match AT ALL and shipped byte-identical.
-  //    c. The value class EXCLUDES quote, comma, semicolon and `&` rather than
-  //       being `\S+`. `\S+` swallowed the rest of a JSON object and the rest of
-  //       a URL query string: a request log became
-  //       `?token=[REDACTED] HTTP/1.1` with `&user=&page=` eaten. Now only the
-  //       value dies:  `?token=[REDACTED]&user=bob&page=2`.
+  //    c. There are TWO rules, split by SHAPE — quoted value, then unquoted.
+  //       One rule cannot serve both, and trying cost a real leak:
   //
-  //    KNOWN AND ACCEPTED OVER-REDACTION: a keyword followed by a separator
-  //    redacts the next token whatever it is, so prose like `the token: is
-  //    missing` becomes `the token: [REDACTED] missing`. That direction is the
-  //    safe one — a missed secret is unrecoverable, a mangled sentence is not —
-  //    and it is asserted in the tests so it stays a decision, not a surprise.
+  //       A single rule with value class `[^\s"',;&]+` (chosen to stop eating
+  //       URL query tails) TRUNCATED any secret containing one of those
+  //       characters. Measured:
+  //         password=p@ss;w0rd          -> password=[REDACTED];w0rd
+  //         password=a&b&c              -> password=[REDACTED]&b&c
+  //         SECRET_KEY='django-...ab,cd'-> SECRET_KEY='[REDACTED],cd'
+  //       `&` and `;` are in most password alphabets — Django's own
+  //       get_random_secret_key() includes `&`. That is the same partial-leak
+  //       class as the AKIA prefix bug above, reintroduced while fixing a
+  //       COSMETIC over-redaction. Under-redaction is a security cost;
+  //       over-redaction is a usability cost. They are not interchangeable.
+  //
+  //       So: the quoted rule takes everything between the quotes (commas,
+  //       semicolons and spaces included), and the unquoted rule runs to
+  //       whitespace, excluding only quotes so it stays idempotent over the
+  //       output of the first.
+  //
+  //    KNOWN AND ACCEPTED OVER-REDACTION, both asserted in the tests so they
+  //    stay decisions rather than surprises:
+  //      * a keyword plus separator redacts the next token whatever it is, so
+  //        `the token: is missing` -> `the token: [REDACTED] missing`;
+  //      * a URL query tail is eaten: `?token=abc&user=bob&page=2` ->
+  //        `?token=[REDACTED]`. Deliberately reverted to this: preserving the
+  //        tail is what required the leaky value class above.
+
+  // 2a. Quoted value — JSON, YAML, config dumps, and any secret containing a
+  //     comma, semicolon or space.
   stage.replace {
-    expression = "(?i)(?:access[_-]?key|secret[_-]?key|api[_-]?key|secret|token|password|passwd|authorization)[\"']?\\s*[=:]\\s*[\"']?(?:bearer\\s+|basic\\s+)?([^\\s\"',;&]+)"
+    expression = "(?i)(?:access[_-]?key|secret[_-]?key|api[_-]?key|secret|token|password|passwd|authorization)[\"']?\\s*[=:]\\s*(?:bearer\\s+|basic\\s+)?['\"]([^'\"]*)['\"]"
+    replace    = "[REDACTED]"
+  }
+
+  // 2b. Unquoted value — runs to whitespace. Excluding quotes keeps it
+  //     idempotent over 2a's output instead of re-eating `", "user": ...`.
+  stage.replace {
+    expression = "(?i)(?:access[_-]?key|secret[_-]?key|api[_-]?key|secret|token|password|passwd|authorization)[\"']?\\s*[=:]\\s*(?:bearer\\s+|basic\\s+)?([^\\s\"']+)"
     replace    = "[REDACTED]"
   }
 
   // 3. A bare `Bearer <token>` / `Basic <creds>` with no `:` or `=` separator,
-  //    which rule 2 cannot match because it requires one.
+  //    which the rules above cannot match because they require one.
+  //
+  //    OVER-REDACTS ENGLISH PROSE containing "basic ". Quantified against this
+  //    host's real journal (100,609 lines over 7 days): 8 lines altered, 7 of
+  //    them `Reached target Basic System.` -> `Reached target Basic [REDACTED]`.
+  //    0.008%, and nothing under scripts/ parses `Reached target`. Kept because
+  //    `Authorization: Basic` with no separator is a real credential shape and
+  //    missing it is the costlier error. Asserted in the tests.
   stage.replace {
-    expression = "(?i)\\b(?:bearer|basic)\\s+([^\\s\"',;&]+)"
+    expression = "(?i)\\b(?:bearer|basic)\\s+([^\\s\"']+)"
     replace    = "[REDACTED]"
   }
 

--- a/scripts/obs/alloy.alloy
+++ b/scripts/obs/alloy.alloy
@@ -245,16 +245,28 @@ loki.process "scrub" {
   //        tail is what required the leaky value class above.
 
   // 2a. Quoted value — JSON, YAML, config dumps, and any secret containing a
-  //     comma, semicolon or space.
+  //     comma, semicolon or space. `(?:[^'"\\]|\\.)*` rather than `[^'"]*` so an
+  //     ESCAPED quote inside the value does not end the match early: with the
+  //     simpler class, {"password": "a\\"b"} redacted to "[REDACTED]"b" and one
+  //     character of the secret survived (measured).
   stage.replace {
-    expression = "(?i)(?:access[_-]?key|secret[_-]?key|api[_-]?key|secret|token|password|passwd|authorization)[\"']?\\s*[=:]\\s*(?:bearer\\s+|basic\\s+)?['\"]([^'\"]*)['\"]"
+    expression = "(?i)(?:access[_-]?key|secret[_-]?key|api[_-]?key|secret|token|password|passwd|authorization)[\"']?\\s*[=:]\\s*(?:bearer\\s+|basic\\s+)?['\"]((?:[^'\"\\\\]|\\\\.)*)['\"]"
     replace    = "[REDACTED]"
   }
 
-  // 2b. Unquoted value — runs to whitespace. Excluding quotes keeps it
-  //     idempotent over 2a's output instead of re-eating `", "user": ...`.
+  // 2b. Unquoted value — runs to whitespace.
+  //
+  //     The leading `['"]?` catches an UNTERMINATED quoted value. Without it,
+  //     2a needs a closing quote and 2b cannot start on one, so
+  //     `password: "abcdef` (a line journald split at LineMax, say) shipped in
+  //     CLEAR — a redaction the single-rule version did perform. Measured.
+  //
+  //     The class excludes `"` but ALLOWS `'`: excluding `"` is what keeps this
+  //     idempotent over 2a's output (`"[REDACTED]", "user": ...`), while
+  //     allowing `'` stops `password=ab'cd` truncating to `[REDACTED]'cd` —
+  //     the same partial-leak class as everything else here.
   stage.replace {
-    expression = "(?i)(?:access[_-]?key|secret[_-]?key|api[_-]?key|secret|token|password|passwd|authorization)[\"']?\\s*[=:]\\s*(?:bearer\\s+|basic\\s+)?([^\\s\"']+)"
+    expression = "(?i)(?:access[_-]?key|secret[_-]?key|api[_-]?key|secret|token|password|passwd|authorization)[\"']?\\s*[=:]\\s*(?:bearer\\s+|basic\\s+)?['\"]?([^\\s\"]+)"
     replace    = "[REDACTED]"
   }
 
@@ -264,7 +276,8 @@ loki.process "scrub" {
   //    OVER-REDACTS ENGLISH PROSE containing "basic ". Quantified against this
   //    host's real journal (100,609 lines over 7 days): 8 lines altered, 7 of
   //    them `Reached target Basic System.` -> `Reached target Basic [REDACTED]`.
-  //    0.008%, and nothing under scripts/ parses `Reached target`. Kept because
+  //    0.008%, all `Reached`/`Stopped target Basic System.`, and nothing under
+  //    scripts/ parses those. Kept because
   //    `Authorization: Basic` with no separator is a real credential shape and
   //    missing it is the costlier error. Asserted in the tests.
   stage.replace {

--- a/scripts/obs/alloy.alloy
+++ b/scripts/obs/alloy.alloy
@@ -12,10 +12,15 @@
 //     ~/.config/obs-ship/env      (gitignored, per-host, 0600)
 // Required: OBS_PROM_URL, OBS_LOKI_URL, OBS_USERNAME, OBS_PASSWORD, OBS_HOST
 //
-// Validated in CI by scripts/tests/test_obs_alloy_config.py, which parses this
-// file with `alloy fmt` — a config that does not parse takes the whole agent
-// down at start, and "the unit is running" is not evidence that it shipped
-// anything.
+// Validated AT BUILD TIME by nix/observability.nix, which runs `alloy validate`
+// in a derivation — so an invalid config fails `home-manager switch` and cannot
+// deploy. `alloy fmt` is NOT sufficient and is forbidden there: it checks syntax
+// only. scripts/tests/test_obs_alloy_config.py runs no binary; it guards that
+// wiring plus the contracts checkable without one.
+//
+// 🔴 `alloy validate` accepts every redaction bug this file has already had.
+// Regex semantics are not a syntax property — they must be measured by running
+// lines through the pipeline. See the block above stage.replace below.
 
 logging {
   level  = "warn"
@@ -78,6 +83,19 @@ loki.write "homelab" {
     }
   }
 
+  // 🔴 Without this, journal lines are DROPPED for the entire duration of any
+  // disconnection while the source's position cursor advances anyway — so they
+  // are gone, not delayed. Measured: after a run where every write failed, the
+  // positions file had moved on and no Loki WAL directory existed.
+  //
+  // A roaming laptop disconnects constantly (sleep, WiFi drop, travel), and the
+  // journal is the highest-value stream here. `queue_config` on the metrics
+  // remote_write does NOT cover this: that buffering is per-pipeline.
+  wal {
+    enabled           = true
+    max_segment_age   = "1h"
+  }
+
   external_labels = {
     host = sys.env("OBS_HOST"),
   }
@@ -114,6 +132,18 @@ loki.relabel "journal" {
     target_label  = "unit"
   }
 
+  // 🔴 Collapse per-session scope units to a constant. Measured on one boot: 71
+  // distinct unit values, of which 39 were `session-<N>.scope` — and N
+  // increments forever, so this label would churn a new Loki stream per login,
+  // per boot, indefinitely. That is unbounded cardinality, which is exactly what
+  // the "deliberately small label set" above is meant to avoid.
+  rule {
+    source_labels = ["unit"]
+    regex         = "session-\\d+\\.scope"
+    target_label  = "unit"
+    replacement   = "session.scope"
+  }
+
   rule {
     source_labels = ["__journal_syslog_identifier"]
     target_label  = "identifier"
@@ -145,18 +175,46 @@ loki.process "scrub" {
     drop_counter_reason = "notification-body"
   }
 
-  // 2. Redact credential-shaped assignments anywhere in the line. Case
-  //    insensitive, and deliberately greedy on the value side: a partially
-  //    redacted secret is a leaked secret.
+  // 🔴 EXACTLY ONE CAPTURE GROUP PER RULE, WRAPPING PRECISELY WHAT MUST DIE.
+  //
+  // stage.replace does NOT do `$1` template expansion, and it does NOT operate
+  // on the whole match. It substitutes the `replace` string for EVERY capture
+  // group individually. All three consequences were measured against alloy
+  // 1.17.1 end-to-end (loki.source.file -> loki.process -> loki.echo), because
+  // all three are invisible to `alloy validate`, which accepts every variant:
+  //
+  //   two groups + replace="${1}[REDACTED]"
+  //     "password: hunter2"           -> "${1}[REDACTED]${1}[REDACTED]"
+  //     ...the literal characters ${1}, and the key name destroyed.
+  //   ZERO groups (non-capturing) + replace="[REDACTED-KEYID]"
+  //     "key AKIAIOSFODNN7EXAMPLE"    -> UNCHANGED. Nothing is replaced at all.
+  //   one group around the 4-char prefix only
+  //     "AKIAIOSFODNN7EXAMPLE"        -> "[REDACTED-KEYID]IOSFODNN7EXAMPLE"
+  //     ...16 of 20 characters leak. A partially redacted secret is leaked.
+  //
+  // So: one group, around the SECRET ITSELF, and `replace` is a literal.
+  // Keeping the keyword outside the group is what preserves "password: " as
+  // readable context — the point of shipping the journal is to debug with it.
+
+  // 2. Credential-shaped assignments. The optional non-capturing `bearer` keeps
+  //    `Authorization: Bearer <jwt>` from leaking the token: without it `(\S+)`
+  //    captures the word "Bearer" and the JWT survives in clear (measured).
   stage.replace {
-    expression = "(?i)((?:access[_-]?key|secret[_-]?key|api[_-]?key|token|password|passwd|authorization|bearer)\\s*[=:]\\s*)(\\S+)"
-    replace    = "${1}[REDACTED]"
+    expression = "(?i)(?:access[_-]?key|secret[_-]?key|api[_-]?key|secret|token|password|passwd|authorization)\\s*[=:]\\s*(?:bearer\\s+)?(\\S+)"
+    replace    = "[REDACTED]"
   }
 
-  // 3. Redact bare AWS-style access key ids, which appear in MinIO errors
-  //    without an adjacent keyword.
+  // 3. A bare `Bearer <token>` with no `:` or `=` separator, which rule 2
+  //    cannot match because it requires one.
   stage.replace {
-    expression = "\\b(AKIA|ASIA)[0-9A-Z]{16}\\b"
+    expression = "(?i)\\bbearer\\s+(\\S+)"
+    replace    = "[REDACTED]"
+  }
+
+  // 4. AWS-style access key ids, which appear in MinIO errors with no adjacent
+  //    keyword. The group wraps the WHOLE id, per the measurements above.
+  stage.replace {
+    expression = "\\b((?:AKIA|ASIA)[0-9A-Z]{16})\\b"
     replace    = "[REDACTED-KEYID]"
   }
 }

--- a/scripts/obs/boot_outcome.py
+++ b/scripts/obs/boot_outcome.py
@@ -158,9 +158,19 @@ def render(out: Outcome) -> str:
 
 
 def write_atomically(path: str, text: str) -> None:
-    """node_exporter's textfile collector reads whole files; a partial write is
-    a parse error that poisons the whole scrape. Write-then-rename is required,
-    not a nicety."""
+    """Write-then-rename, because node_exporter parses each textfile whole.
+
+    A partial or newline-less write is a parse error. MEASURED against
+    node_exporter 1.12.1: the scrape logs `text format parsing error in line 3:
+    unexpected end of input stream`, sets `node_textfile_scrape_error 1`, and
+    EVERY `host_*` metric from this file is ABSENT.
+
+    Scoped honestly: it kills THIS FILE's metrics, not the whole scrape — the
+    other ~1,700 series still serve and
+    `node_scrape_collector_success{collector="textfile"}` stays 1. That is worse
+    than it sounds for this particular file: the metrics vanish silently, and
+    absent freeze metrics look identical to a host that has not frozen.
+    """
     directory = os.path.dirname(path) or "."
     os.makedirs(directory, exist_ok=True)
     fd, tmp = tempfile.mkstemp(dir=directory, prefix=".boot_outcome.", suffix=".tmp")
@@ -178,19 +188,26 @@ def write_atomically(path: str, text: str) -> None:
 
 
 class SystemdJournal:
-    """Real journalctl-backed facts."""
+    """Real journalctl-backed facts.
 
-    def __init__(self, journalctl: str = "journalctl"):
+    `runner` is injectable so the suite can assert the ARGV this builds. Without
+    that seam every test monkeypatched this class away entirely, and the field
+    name `index`, the `-n <TAIL_LINES>` argument and the `-o short-unix`
+    timestamp parse had no coverage at all — mutating any of them left the suite
+    fully green while the real adapter was broken.
+    """
+
+    def __init__(self, journalctl: str = "journalctl", runner=None):
         self.journalctl = journalctl
+        self._runner = runner or self._subprocess_runner
+
+    def _subprocess_runner(self, argv: list[str]) -> str:
+        return subprocess.run(
+            argv, capture_output=True, text=True, check=True, timeout=60
+        ).stdout
 
     def _run(self, args: list[str]) -> str:
-        return subprocess.run(
-            [self.journalctl, *args],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=60,
-        ).stdout
+        return self._runner([self.journalctl, *args])
 
     def boot_offsets(self) -> list[int]:
         raw = self._run(["--list-boots", "-o", "json"])

--- a/scripts/obs/boot_outcome.py
+++ b/scripts/obs/boot_outcome.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Emit a Prometheus metric for whether the PREVIOUS boot ended cleanly.
+
+Why this exists
+---------------
+On 2026-08-20 the laptop was believed to have "hard-frozen twice in the past
+month". It had actually stopped uncleanly SIX times since 2026-07-29 (Jul 29,
+Jul 31, Aug 06, Aug 10, Aug 17, Aug 20). Nobody was wrong on purpose — the rate
+was simply never measured, because the only detector was a human noticing that
+work had been interrupted. A freeze that happens while you are away from the
+machine leaves no impression at all.
+
+So this turns "it froze a couple of times" into a timestamped series.
+
+A boot is CLEAN if its final journal entries contain systemd's shutdown
+sequence, and UNCLEAN otherwise. That is the same classification used in the
+original investigation.
+
+Honest limits of the classification
+-----------------------------------
+"Unclean" means "never reached systemd's shutdown sequence". That covers a hard
+lockup, but ALSO a battery running flat, a forced power-button hold, and a
+kernel panic. It is a symptom counter, not a diagnosis, and the metric name says
+`unclean`, not `frozen`, for exactly that reason.
+
+It is also blind past journal retention: a boot that has been rotated away
+cannot be classified. That is why `boots_examined` is emitted BESIDE the unclean
+count — a `0` from a scan that walked nothing is a failure, not an all-clear,
+and the two numbers are only interpretable together.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+
+# Markers that prove the boot reached systemd's shutdown path. "Journal stopped"
+# is the load-bearing one (journald logs it on SIGTERM from PID 1, on both
+# poweroff and reboot); the other two are corroborating.
+CLEAN_MARKERS = ("Journal stopped", "System Power Off", "Shutting down")
+
+TAIL_LINES = 12
+
+
+@dataclass
+class Outcome:
+    previous_clean: int | None = None
+    previous_end_timestamp: float | None = None
+    unclean_count: int | None = None
+    boots_examined: int = 0
+    scrape_ok: int = 1
+    errors: list[str] = field(default_factory=list)
+
+
+def ended_cleanly(tail: list[str]) -> bool:
+    """True if these final journal lines show systemd's shutdown sequence."""
+    return any(marker in line for line in tail for marker in CLEAN_MARKERS)
+
+
+def collect(journal) -> Outcome:
+    """Classify every retained boot. `journal` supplies the raw facts.
+
+    Deliberately tolerant of a partial journal: a boot whose tail cannot be read
+    is skipped and recorded as an error rather than silently counted as clean,
+    because counting an unreadable boot as clean is the failure mode that would
+    hide the very events this exists to count.
+    """
+    out = Outcome()
+    try:
+        offsets = journal.boot_offsets()
+    except Exception as exc:  # noqa: BLE001 - any failure means we know nothing
+        out.scrape_ok = 0
+        out.errors.append(f"boot_offsets: {exc}")
+        return out
+
+    # The current boot (offset 0) has not ended, so it is not classifiable.
+    past = [o for o in offsets if o < 0]
+
+    unclean = 0
+    for off in past:
+        try:
+            tail = journal.tail(off, TAIL_LINES)
+        except Exception as exc:  # noqa: BLE001
+            out.errors.append(f"tail({off}): {exc}")
+            continue
+        out.boots_examined += 1
+        if not ended_cleanly(tail):
+            unclean += 1
+
+    if out.boots_examined == 0:
+        # A zero here would read as "no unclean boots", which is precisely the
+        # reassuring-but-empty answer this guard exists to refuse to emit.
+        out.scrape_ok = 0
+        out.errors.append("no boots examined")
+        return out
+
+    out.unclean_count = unclean
+
+    if -1 in past:
+        try:
+            tail = journal.tail(-1, TAIL_LINES)
+            out.previous_clean = 1 if ended_cleanly(tail) else 0
+            out.previous_end_timestamp = journal.last_timestamp(-1)
+        except Exception as exc:  # noqa: BLE001
+            out.errors.append(f"previous boot: {exc}")
+            out.scrape_ok = 0
+
+    return out
+
+
+def render(out: Outcome) -> str:
+    """Prometheus text exposition. Unknown values are OMITTED, never zeroed."""
+    lines: list[str] = []
+
+    def metric(name: str, help_text: str, mtype: str, value):
+        if value is None:
+            return
+        lines.append(f"# HELP {name} {help_text}")
+        lines.append(f"# TYPE {name} {mtype}")
+        lines.append(f"{name} {value}")
+
+    metric(
+        "host_boot_previous_clean",
+        "Whether the previous boot ended with systemd's shutdown sequence (1) or stopped abruptly (0).",
+        "gauge",
+        out.previous_clean,
+    )
+    metric(
+        "host_boot_previous_end_timestamp_seconds",
+        "Unix time of the last journal entry of the previous boot.",
+        "gauge",
+        None if out.previous_end_timestamp is None else f"{out.previous_end_timestamp:.0f}",
+    )
+    metric(
+        "host_unclean_boots_observed",
+        "Unclean boot endings across the retained journal. Only meaningful beside host_boots_examined.",
+        "gauge",
+        out.unclean_count,
+    )
+    metric(
+        "host_boots_examined",
+        "Past boots actually classified. A zero unclean count from zero examined boots is not an all-clear.",
+        "gauge",
+        out.boots_examined,
+    )
+    metric(
+        "host_boot_outcome_scrape_ok",
+        "Whether the boot-outcome classifier ran successfully (1) or could not measure (0).",
+        "gauge",
+        out.scrape_ok,
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_atomically(path: str, text: str) -> None:
+    """node_exporter's textfile collector reads whole files; a partial write is
+    a parse error that poisons the whole scrape. Write-then-rename is required,
+    not a nicety."""
+    directory = os.path.dirname(path) or "."
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=".boot_outcome.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(text)
+        os.chmod(tmp, 0o644)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+class SystemdJournal:
+    """Real journalctl-backed facts."""
+
+    def __init__(self, journalctl: str = "journalctl"):
+        self.journalctl = journalctl
+
+    def _run(self, args: list[str]) -> str:
+        return subprocess.run(
+            [self.journalctl, *args],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=60,
+        ).stdout
+
+    def boot_offsets(self) -> list[int]:
+        raw = self._run(["--list-boots", "-o", "json"])
+        return [int(entry["index"]) for entry in json.loads(raw)]
+
+    def tail(self, offset: int, n: int = TAIL_LINES) -> list[str]:
+        # -b <offset> is scoped to that boot; -n <n> takes its final lines.
+        raw = self._run(["-b", str(offset), "-n", str(n), "--no-pager", "-o", "short-precise"])
+        return raw.splitlines()
+
+    def last_timestamp(self, offset: int) -> float | None:
+        raw = self._run(["-b", str(offset), "-n", "1", "--no-pager", "-o", "short-unix"])
+        line = raw.strip().split("\n")[-1] if raw.strip() else ""
+        if not line:
+            return None
+        try:
+            return float(line.split(" ", 1)[0])
+        except ValueError:
+            return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--textfile",
+        default=os.path.expanduser("~/.local/state/node-exporter-textfile/boot_outcome.prom"),
+        help="node_exporter textfile-collector target",
+    )
+    parser.add_argument("--stdout", action="store_true", help="print instead of writing")
+    args = parser.parse_args(argv)
+
+    out = collect(SystemdJournal())
+    text = render(out)
+
+    if args.stdout:
+        sys.stdout.write(text)
+    else:
+        write_atomically(args.textfile, text)
+
+    for err in out.errors:
+        print(f"boot_outcome: {err}", file=sys.stderr)
+
+    # Exit 0 even when we could not measure: scrape_ok=0 carries that fact to
+    # Prometheus, and a failing unit would only add noise on top of a metric
+    # that already says "unknown".
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_boot_outcome.py
+++ b/scripts/tests/test_boot_outcome.py
@@ -26,10 +26,12 @@ sys.modules["boot_outcome"] = boot_outcome
 _spec.loader.exec_module(boot_outcome)
 
 
+# SYNTHETIC, like ABRUPT_TAIL below — regenerated rather than pasted from this
+# host's journal, for the same public-repo reason.
 CLEAN_TAIL = [
-    "Aug 07 17:29:05.017654 nixos systemd[1]: Shutting down.",
-    "Aug 07 17:29:05.062434 nixos systemd-journald[758]: Received SIGTERM from PID 1 (systemd-shutdow).",
-    "Aug 07 17:29:05.062497 nixos systemd-journald[758]: Journal stopped",
+    "Jan 01 00:00:01.000000 host systemd[1]: Shutting down.",
+    "Jan 01 00:00:02.000000 host systemd-journald[100]: Received SIGTERM from PID 1 (systemd-shutdow).",
+    "Jan 01 00:00:03.000000 host systemd-journald[100]: Journal stopped",
 ]
 
 # SYNTHETIC, matching the SHAPE of a real freeze tail: ordinary application

--- a/scripts/tests/test_boot_outcome.py
+++ b/scripts/tests/test_boot_outcome.py
@@ -32,11 +32,15 @@ CLEAN_TAIL = [
     "Aug 07 17:29:05.062497 nixos systemd-journald[758]: Journal stopped",
 ]
 
-# Taken from the shape of the real Aug 20 freeze: ordinary activity, then nothing.
+# SYNTHETIC, matching the SHAPE of a real freeze tail: ordinary application
+# chatter, then silence — no shutdown sequence. Regenerated rather than pasted
+# from this host's journal: CLAUDE.md forbids committing captured text to this
+# public repo, and the gates that enforce it cover .json/.html but not .py, so
+# the rule has to be honoured by hand here.
 ABRUPT_TAIL = [
-    "Aug 20 17:02:27.363269 nixos xsession[3412331]: [312B blob data]",
-    "Aug 20 17:02:27.367734 nixos xsession[3412332]: jq: error (at <stdin>:0)",
-    "Aug 20 17:02:29.153604 nixos xsession[393625]: DidStartWorkerFail: 15",
+    "Jan 01 00:00:01.000000 host app[1000]: fetched 3 items",
+    "Jan 01 00:00:02.000000 host app[1000]: cache warm, 12 entries",
+    "Jan 01 00:00:03.000000 host app[1001]: worker heartbeat ok",
 ]
 
 
@@ -183,4 +187,91 @@ def test_main_writes_the_textfile(tmp_path, monkeypatch):
 @pytest.mark.parametrize("marker", boot_outcome.CLEAN_MARKERS)
 def test_each_declared_clean_marker_actually_classifies_clean(marker):
     """A marker in the tuple that never matches is dead config that reads as coverage."""
-    assert boot_outcome.ended_cleanly([f"Aug 07 17:29:05 nixos systemd[1]: {marker}"]) is True
+    assert boot_outcome.ended_cleanly([f"Jan 01 00:00:00 host systemd[1]: {marker}"]) is True
+
+
+def test_render_output_ends_with_a_newline():
+    """node_exporter's textfile parser rejects a file with no trailing newline
+    ('unexpected end of input stream') and then drops EVERY metric in it — the
+    freeze metrics vanish silently, which looks just like a host that has not
+    frozen. Measured against node_exporter 1.12.1."""
+    out = boot_outcome.collect(FakeJournal([-1, 0], {-1: ABRUPT_TAIL}))
+    assert boot_outcome.render(out).endswith("\n")
+
+
+def test_a_previous_boot_read_failure_is_reported_as_unmeasured():
+    """If the previous boot cannot be read we know nothing about the event we
+    most care about, so scrape_ok must drop — silently omitting the metric while
+    still claiming success would read as 'no freeze'."""
+
+    class OnlyPreviousFails(FakeJournal):
+        def tail(self, offset, n=12):
+            if offset == -1:
+                raise RuntimeError("boom")
+            return CLEAN_TAIL
+
+    out = boot_outcome.collect(OnlyPreviousFails([-2, -1, 0]))
+    assert out.scrape_ok == 0
+    assert out.previous_clean is None
+    assert "host_boot_previous_clean" not in parse(boot_outcome.render(out))
+
+
+# ---- the real journalctl adapter ----------------------------------------- #
+# Previously monkeypatched away in every test, so none of the argv or parsing
+# below was covered: mutating the `index` field name, or `-n <n>` to `-n 1`,
+# left the suite green while the deployed adapter was broken.
+
+
+def _recording_journal(responses):
+    calls = []
+
+    def runner(argv):
+        calls.append(argv)
+        for needle, out in responses.items():
+            if needle in argv:
+                return out
+        return ""
+
+    return boot_outcome.SystemdJournal(runner=runner), calls
+
+
+def test_boot_offsets_parses_the_index_field_from_json():
+    journal, calls = _recording_journal({"--list-boots": '[{"index":-1},{"index":0}]'})
+    assert journal.boot_offsets() == [-1, 0]
+    assert ["journalctl", "--list-boots", "-o", "json"] == calls[0]
+
+
+def test_tail_requests_the_configured_number_of_lines_for_that_boot():
+    journal, calls = _recording_journal({"-b": "line1\nline2\n"})
+    journal.tail(-3, 12)
+    argv = calls[0]
+    assert argv[argv.index("-b") + 1] == "-3"
+    assert argv[argv.index("-n") + 1] == "12", "must request N lines, not a fixed 1"
+
+
+def test_tail_defaults_to_a_dozen_lines():
+    """LITERAL, not `str(boot_outcome.TAIL_LINES)`.
+
+    Asserting against the constant makes both sides of the comparison move
+    together, so it cannot fail — measured: shrinking TAIL_LINES to 1 SURVIVED a
+    fully green run. Reading one line is a real defect: systemd's shutdown
+    markers are not reliably the FINAL journal entry (udev and journald
+    teardown lines routinely follow 'Journal stopped'), so a one-line tail
+    misclassifies clean shutdowns as freezes.
+    """
+    journal, calls = _recording_journal({"-b": ""})
+    journal.tail(-1)
+    argv = calls[0]
+    assert argv[argv.index("-n") + 1] == "12"
+    assert boot_outcome.TAIL_LINES >= 10, "too few lines to span a shutdown sequence"
+
+
+def test_last_timestamp_parses_the_short_unix_format():
+    journal, calls = _recording_journal({"-b": "1787263349.153604 host app[1]: msg\n"})
+    assert journal.last_timestamp(-1) == pytest.approx(1787263349.153604)
+    assert "short-unix" in calls[0]
+
+
+def test_last_timestamp_returns_none_rather_than_raising_on_junk():
+    journal, _ = _recording_journal({"-b": "not-a-timestamp\n"})
+    assert journal.last_timestamp(-1) is None

--- a/scripts/tests/test_boot_outcome.py
+++ b/scripts/tests/test_boot_outcome.py
@@ -1,0 +1,186 @@
+"""Coverage for scripts/obs/boot_outcome.py.
+
+The metric this emits is the reason we know the laptop froze six times rather
+than the two that were noticed. Its failure mode is therefore NOT "crashes" —
+it is "confidently reports zero". Most of what is asserted below is that an
+unmeasurable state produces `scrape_ok 0` and OMITS the count, rather than
+emitting a reassuring `host_unclean_boots_observed 0`.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO / "scripts" / "obs" / "boot_outcome.py"
+
+_spec = importlib.util.spec_from_file_location("boot_outcome", MODULE_PATH)
+boot_outcome = importlib.util.module_from_spec(_spec)
+# Registered BEFORE exec_module: @dataclass resolves its annotations through
+# sys.modules[cls.__module__], which is None for an unregistered dynamic module
+# once `from __future__ import annotations` makes them strings. Omitting this
+# fails at import with a bare AttributeError on NoneType.
+sys.modules["boot_outcome"] = boot_outcome
+_spec.loader.exec_module(boot_outcome)
+
+
+CLEAN_TAIL = [
+    "Aug 07 17:29:05.017654 nixos systemd[1]: Shutting down.",
+    "Aug 07 17:29:05.062434 nixos systemd-journald[758]: Received SIGTERM from PID 1 (systemd-shutdow).",
+    "Aug 07 17:29:05.062497 nixos systemd-journald[758]: Journal stopped",
+]
+
+# Taken from the shape of the real Aug 20 freeze: ordinary activity, then nothing.
+ABRUPT_TAIL = [
+    "Aug 20 17:02:27.363269 nixos xsession[3412331]: [312B blob data]",
+    "Aug 20 17:02:27.367734 nixos xsession[3412332]: jq: error (at <stdin>:0)",
+    "Aug 20 17:02:29.153604 nixos xsession[393625]: DidStartWorkerFail: 15",
+]
+
+
+class FakeJournal:
+    def __init__(self, boots, tails=None, timestamps=None, fail_on=()):
+        self._boots = boots
+        self._tails = tails or {}
+        self._timestamps = timestamps or {}
+        self._fail_on = fail_on
+
+    def boot_offsets(self):
+        if "boot_offsets" in self._fail_on:
+            raise RuntimeError("journalctl unavailable")
+        return self._boots
+
+    def tail(self, offset, n=12):
+        if offset in self._fail_on:
+            raise RuntimeError(f"cannot read boot {offset}")
+        return self._tails.get(offset, ABRUPT_TAIL)
+
+    def last_timestamp(self, offset):
+        return self._timestamps.get(offset)
+
+
+def parse(text):
+    """Prometheus text -> {name: value}, ignoring HELP/TYPE."""
+    out = {}
+    for line in text.splitlines():
+        if line.startswith("#") or not line.strip():
+            continue
+        name, _, value = line.partition(" ")
+        out[name] = value
+    return out
+
+
+# ---- classification ------------------------------------------------------
+
+
+def test_a_shutdown_sequence_reads_clean():
+    assert boot_outcome.ended_cleanly(CLEAN_TAIL) is True
+
+
+def test_ordinary_activity_then_silence_reads_unclean():
+    assert boot_outcome.ended_cleanly(ABRUPT_TAIL) is False
+
+
+def test_counts_the_real_august_pattern():
+    """Three clean, three abrupt — the actual shape of the investigated window."""
+    tails = {-6: ABRUPT_TAIL, -5: CLEAN_TAIL, -4: CLEAN_TAIL,
+             -3: ABRUPT_TAIL, -2: ABRUPT_TAIL, -1: ABRUPT_TAIL}
+    out = boot_outcome.collect(FakeJournal([-6, -5, -4, -3, -2, -1, 0], tails))
+    assert out.unclean_count == 4
+    assert out.boots_examined == 6
+    assert out.previous_clean == 0
+    assert out.scrape_ok == 1
+
+
+def test_the_current_boot_is_not_classified():
+    """Boot 0 has not ended; counting it would score every running host unclean."""
+    out = boot_outcome.collect(FakeJournal([-1, 0], {-1: CLEAN_TAIL}))
+    assert out.boots_examined == 1
+
+
+# ---- the "confident zero" failure mode -----------------------------------
+
+
+def test_zero_examined_boots_never_reports_zero_unclean():
+    out = boot_outcome.collect(FakeJournal([0]))
+    assert out.scrape_ok == 0
+    assert out.unclean_count is None, "a scan that walked nothing must not report 0"
+    metrics = parse(boot_outcome.render(out))
+    assert "host_unclean_boots_observed" not in metrics
+
+
+def test_journalctl_failure_reports_unmeasured_not_clean():
+    out = boot_outcome.collect(FakeJournal([-1, 0], fail_on=("boot_offsets",)))
+    assert out.scrape_ok == 0
+    assert out.unclean_count is None
+    metrics = parse(boot_outcome.render(out))
+    assert metrics["host_boot_outcome_scrape_ok"] == "0"
+    assert "host_boot_previous_clean" not in metrics
+
+
+def test_an_unreadable_boot_is_skipped_not_counted_clean():
+    """Counting an unreadable boot as clean would hide the events we are counting."""
+    tails = {-1: ABRUPT_TAIL, -3: ABRUPT_TAIL}
+    out = boot_outcome.collect(FakeJournal([-3, -2, -1, 0], tails, fail_on=(-2,)))
+    assert out.boots_examined == 2
+    assert out.unclean_count == 2
+    assert any("tail(-2)" in e for e in out.errors)
+
+
+def test_examined_count_is_always_emitted_beside_the_unclean_count():
+    """The two numbers are only interpretable together."""
+    out = boot_outcome.collect(FakeJournal([-1, 0], {-1: ABRUPT_TAIL}))
+    metrics = parse(boot_outcome.render(out))
+    assert "host_unclean_boots_observed" in metrics
+    assert "host_boots_examined" in metrics
+
+
+# ---- rendering / writing -------------------------------------------------
+
+
+def test_render_emits_help_and_type_for_every_metric():
+    out = boot_outcome.collect(FakeJournal([-1, 0], {-1: ABRUPT_TAIL}, {-1: 1787263349.0}))
+    text = boot_outcome.render(out)
+    for name in parse(text):
+        assert f"# HELP {name} " in text, f"{name} missing HELP"
+        assert f"# TYPE {name} " in text, f"{name} missing TYPE"
+
+
+def test_timestamp_is_rendered_as_integer_seconds_not_scientific_notation():
+    """Prometheus rejects a bare float rendered as 1.787263349e+09."""
+    out = boot_outcome.collect(FakeJournal([-1, 0], {-1: ABRUPT_TAIL}, {-1: 1787263349.0}))
+    metrics = parse(boot_outcome.render(out))
+    assert metrics["host_boot_previous_end_timestamp_seconds"] == "1787263349"
+
+
+def test_write_is_atomic_and_leaves_no_temp_files(tmp_path):
+    target = tmp_path / "sub" / "boot_outcome.prom"
+    boot_outcome.write_atomically(str(target), "host_boots_examined 3\n")
+    assert target.read_text() == "host_boots_examined 3\n"
+    leftovers = [p.name for p in target.parent.iterdir() if p.name != target.name]
+    assert leftovers == [], f"temp files left behind: {leftovers}"
+
+
+def test_rewrite_replaces_content_rather_than_appending(tmp_path):
+    target = tmp_path / "boot_outcome.prom"
+    boot_outcome.write_atomically(str(target), "host_boots_examined 1\n")
+    boot_outcome.write_atomically(str(target), "host_boots_examined 2\n")
+    assert target.read_text() == "host_boots_examined 2\n"
+
+
+def test_main_writes_the_textfile(tmp_path, monkeypatch):
+    target = tmp_path / "out.prom"
+    monkeypatch.setattr(
+        boot_outcome, "SystemdJournal",
+        lambda *a, **k: FakeJournal([-1, 0], {-1: ABRUPT_TAIL}, {-1: 1787263349.0}),
+    )
+    assert boot_outcome.main(["--textfile", str(target)]) == 0
+    assert parse(target.read_text())["host_boot_previous_clean"] == "0"
+
+
+@pytest.mark.parametrize("marker", boot_outcome.CLEAN_MARKERS)
+def test_each_declared_clean_marker_actually_classifies_clean(marker):
+    """A marker in the tuple that never matches is dead config that reads as coverage."""
+    assert boot_outcome.ended_cleanly([f"Aug 07 17:29:05 nixos systemd[1]: {marker}"]) is True

--- a/scripts/tests/test_obs_alloy_config.py
+++ b/scripts/tests/test_obs_alloy_config.py
@@ -148,6 +148,8 @@ def test_every_replace_stage_in_the_config_is_parsed():
     the new rule entirely unasserted. Counting the literal blocks makes an
     unparsed rule fail here instead of passing invisibly.
     """
+    import re
+
     text = CONFIG.read_text()
     # Count LIVE blocks only: this config discusses `stage.replace` in its
     # comments, and counting those too made the pin fail 3-vs-5 on its first
@@ -155,9 +157,15 @@ def test_every_replace_stage_in_the_config_is_parsed():
     live = "\n".join(
         ln for ln in text.splitlines() if not ln.strip().startswith("//")
     )
-    declared = live.count("stage.replace {")
+    # 🔴 A REGEX, not `live.count("stage.replace {")`. The literal missed
+    # `stage.replace{` (no space) — measured: alloy accepts it, the rule FIRES
+    # in a real run, and the pin still reported 3-of-3 PASS with that rule
+    # asserted by nothing. One absent space reopened the exact hole this closes.
+    # It was also brittle the other way: `stage.replace  {` failed with a
+    # message describing the opposite problem.
+    declared = len(re.findall(r"^\s*stage\.replace\s*\{", live, re.M))
     stages = _replace_stages(text)
-    assert declared >= 3, f"expected the redaction rules, found {declared} live blocks"
+    assert declared >= 4, f"expected the redaction rules, found {declared} live blocks"
     assert len(stages) == declared, (
         f"parsed {len(stages)} of {declared} live stage.replace blocks — "
         "an unparsed rule is asserted by nothing")
@@ -182,15 +190,26 @@ MEASURED_REDACTIONS = [
      "app: password: [REDACTED] done"),
     ("app: PASSWORD=hunter2xyz done",
      "app: PASSWORD=[REDACTED] done"),
-    ("req: Authorization: Bearer HEADERJWTaaa.bbb.ccc done",
+    # --- secrets containing delimiter characters -------------------------
+    # These were PARTIALLY redacted by a value class that stopped at , ; & " '
+    # — the same partial-leak class as the AKIA prefix bug. `&` and `;` are in
+    # most password alphabets; Django's get_random_secret_key() includes `&`.
+    ("app: password=p@ss;w0rd done",
+     "app: password=[REDACTED] done"),
+    ("app: password=a&b&c done",
+     "app: password=[REDACTED] done"),
+    ("app: password='sq;uote' done",
+     "app: password='[REDACTED]' done"),
+    ("env: SECRET_KEY='django-insecure-ab,cd' done",
+     "env: SECRET_KEY='[REDACTED]' done"),
+    ("app: password: \"two words here\" done",
+     "app: password: \"[REDACTED]\" done"),
+    # --- schemes ----------------------------------------------------------
+    ("req: Authorization: Bearer JWTaaa.bbb.ccc done",
      "req: Authorization: Bearer [REDACTED] done"),
-    ("req: authorization header bearer BAREJWTxxx.yyy.zzz done",
-     "req: authorization header bearer [REDACTED] done"),
-    # `Basic` as well as `Bearer`: handling only bearer leaked the base64.
     ("req: authorization: Basic dXNlcjpwdw== done",
      "req: authorization: Basic [REDACTED] done"),
-    # A quoted JSON key put a `"` between keyword and `:`, so this once did not
-    # match AT ALL and shipped byte-identical.
+    # --- structured shapes ------------------------------------------------
     ('app: {"password": "hunter2xyz", "user": "bob"}',
      'app: {"password": "[REDACTED]", "user": "bob"}'),
     ("mc: The Access Key Id you provided: access_key=KEYVALUE99",
@@ -199,21 +218,29 @@ MEASURED_REDACTIONS = [
      "mc: api_key: [REDACTED] rejected"),
     ("mc: error key AKIAIOSFODNN7EXAMPLE not found",
      "mc: error key [REDACTED-KEYID] not found"),
-    # The value class stops at `&`, so the rest of the query string survives.
-    # With `\\S+` this became `?token=[REDACTED] HTTP/1.1`, eating user and page.
-    ("nginx: GET /v1/items?token=abc123&user=bob&page=2 HTTP/1.1 200 1234",
-     "nginx: GET /v1/items?token=[REDACTED]&user=bob&page=2 HTTP/1.1 200 1234"),
-    # NEGATIVE CONTROLS — these must pass through untouched.
+    ("http: token=abc123; Path=/; HttpOnly",
+     "http: token=[REDACTED] Path=/; HttpOnly"),
+    # --- NEGATIVE CONTROLS: must pass through untouched --------------------
     ("app: ordinary line about a password policy with no value",
      "app: ordinary line about a password policy with no value"),
     ("systemd: Started foo.service key=value other=thing",
      "systemd: Started foo.service key=value other=thing"),
     ('app: {"password_reset": true, "user": "bob"}',
      'app: {"password_reset": true, "user": "bob"}'),
-    # ACCEPTED OVER-REDACTION, asserted so it stays a decision rather than a
-    # surprise: a keyword plus separator redacts the next token whatever it is.
+    # --- ACCEPTED OVER-REDACTION, asserted so it stays a decision ----------
+    # (a) keyword + separator redacts the next token whatever it is
     ("app: the token: is missing entirely",
      "app: the token: [REDACTED] missing entirely"),
+    # (b) a URL query tail is eaten. Preserving it is what required the leaky
+    #     value class, so this is the deliberate trade.
+    ("nginx: GET /v1/items?token=abc123&user=bob&page=2 HTTP/1.1 200",
+     "nginx: GET /v1/items?token=[REDACTED] HTTP/1.1 200"),
+    # (c) rule 3 eats the word after "basic" in English prose. 8 lines in
+    #     100,609 of this host's journal; 7 are `Reached target Basic System.`
+    ("systemd: Reached target Basic System.",
+     "systemd: Reached target Basic [REDACTED]"),
+    ("kernel: basic block device error",
+     "kernel: basic [REDACTED] device error"),
 ]
 
 

--- a/scripts/tests/test_obs_alloy_config.py
+++ b/scripts/tests/test_obs_alloy_config.py
@@ -14,6 +14,8 @@ controls below pin that distinction so nobody "simplifies" this to fmt.
 
 from pathlib import Path
 
+import pytest
+
 REPO = Path(__file__).resolve().parents[2]
 CONFIG = REPO / "scripts" / "obs" / "alloy.alloy"
 
@@ -79,11 +81,130 @@ def test_notification_bodies_are_dropped():
     assert "^dunst$" in text
 
 
-def test_credential_shaped_values_are_redacted():
-    text = CONFIG.read_text()
-    assert "stage.replace" in text
-    for keyword in ("password", "token", "secret", "authorization"):
-        assert keyword in text.lower(), f"no redaction rule mentions {keyword}"
+# --- redaction, BEHAVIOURALLY ---------------------------------------------- #
+# This replaced a guard that merely asserted the words "password"/"token"/
+# "secret"/"authorization" appeared somewhere in the file. That guard passed
+# while the redaction was broken in THREE independent ways, and it survived a
+# mutant that turned the replacement into a total no-op.
+#
+# The emulator below reproduces alloy 1.17.1's `stage.replace` semantics, each
+# clause MEASURED end-to-end (loki.source.file -> loki.process -> loki.echo):
+#
+#   * The `replace` value is a LITERAL. `${1}` is not expanded — it ships as the
+#     characters "${1}".
+#   * It substitutes that literal for EVERY CAPTURE GROUP individually, not for
+#     the whole match. Two groups => the literal appears twice.
+#   * With ZERO capture groups it replaces NOTHING. (This is why a
+#     `(?:AKIA|ASIA)...` non-capturing rule silently leaked the entire key.)
+#
+# Python `re` and Go RE2 agree on these patterns: no backreferences, no
+# lookaround, no possessive quantifiers. If a rule ever needs those, this
+# emulation stops being valid and the check must move to a real alloy run.
+
+
+def _replace_stages(text: str):
+    """[(expression, replace)] for each stage.replace block, in file order."""
+    import re
+
+    return [
+        (m.group(1).encode().decode("unicode_escape"), m.group(2))
+        for m in re.finditer(
+            r'stage\.replace\s*\{\s*expression\s*=\s*"((?:[^"\\]|\\.)*)"\s*'
+            r'replace\s*=\s*"((?:[^"\\]|\\.)*)"',
+            text,
+        )
+    ]
+
+
+def _apply(stages, line: str) -> str:
+    import re
+
+    for expression, replacement in stages:
+        pattern = re.compile(expression)
+        out, last = [], 0
+        for m in pattern.finditer(line):
+            if not m.groups():
+                continue  # zero capture groups: alloy replaces nothing
+            for gi in range(1, len(m.groups()) + 1):
+                if m.start(gi) < 0:
+                    continue
+                out.append(line[last:m.start(gi)])
+                out.append(replacement)
+                last = m.end(gi)
+        out.append(line[last:])
+        line = "".join(out)
+    return line
+
+
+def test_the_emulator_finds_the_configs_replace_stages():
+    """POSITIVE CONTROL. If the parser matched nothing, every redaction
+    assertion below would pass vacuously against an empty rule list."""
+    stages = _replace_stages(CONFIG.read_text())
+    assert len(stages) >= 3, f"expected the redaction rules, parsed {len(stages)}"
+    assert all(expr and repl for expr, repl in stages)
+
+
+# 🔴 The WHOLE output is pinned, not "the secret is absent".
+#
+# `secret not in output` is walkable by a PARTIAL redaction, which is the exact
+# bug this config shipped with: a rule capturing only the 4-char prefix turned
+# AKIAIOSFODNN7EXAMPLE into "[REDACTED-KEYID]IOSFODNN7EXAMPLE", leaking 16 of 20
+# characters — and that output does not contain the full key, so an absence
+# check passes it.
+#
+# Every expected value below was MEASURED by feeding these lines through real
+# alloy 1.17.1 using the stage.replace blocks extracted from this very config
+# (loki.source.file -> loki.process -> loki.echo). The trade is that a cosmetic
+# reword of a rule fails these tests; that is the price of a machine-checkable
+# claim about redaction.
+MEASURED_REDACTIONS = [
+    ("app: password: hunter2xyz done",
+     "app: password: [REDACTED] done"),
+    ("app: PASSWORD=hunter2xyz done",
+     "app: PASSWORD=[REDACTED] done"),
+    ("req: Authorization: Bearer HEADERJWTaaa.bbb.ccc done",
+     "req: Authorization: Bearer [REDACTED] done"),
+    ("req: authorization header bearer BAREJWTxxx.yyy.zzz done",
+     "req: authorization header bearer [REDACTED] done"),
+    ("mc: The Access Key Id you provided: access_key=KEYVALUE99",
+     "mc: The Access Key Id you provided: access_key=[REDACTED]"),
+    ("mc: api_key: APIKEYVALUE123 rejected",
+     "mc: api_key: [REDACTED] rejected"),
+    ("mc: error key AKIAIOSFODNN7EXAMPLE not found",
+     "mc: error key [REDACTED-KEYID] not found"),
+    # NEGATIVE CONTROL: no secret, so the line must be returned untouched.
+    ("app: ordinary line about a password policy with no value",
+     "app: ordinary line about a password policy with no value"),
+]
+
+
+@pytest.mark.parametrize("line,expected", MEASURED_REDACTIONS)
+def test_redaction_matches_measured_alloy_output(line, expected):
+    stages = _replace_stages(CONFIG.read_text())
+    assert _apply(stages, line) == expected
+
+
+def test_redaction_leaves_readable_context_behind():
+    """Redacting the whole line would defeat the point of shipping the journal.
+    The keyword must survive so the entry is still debuggable."""
+    stages = _replace_stages(CONFIG.read_text())
+    assert "password" in _apply(stages, "app: password: hunter2xyz done").lower()
+
+
+def test_redaction_emits_no_literal_template_placeholder():
+    """`${1}` is not expanded by stage.replace — a rule written that way ships
+    the characters ${1} and destroys the key name."""
+    stages = _replace_stages(CONFIG.read_text())
+    out = _apply(stages, "app: password: hunter2xyz done")
+    assert "${" not in out and "$1" not in out, out
+
+
+def test_an_ordinary_line_is_not_over_redacted():
+    """NEGATIVE CONTROL: a rule broad enough to eat normal log lines would make
+    the journal useless, and would pass every assertion above."""
+    stages = _replace_stages(CONFIG.read_text())
+    line = "app: ordinary line about a password policy with no value"
+    assert _apply(stages, line) == line
 
 
 def test_scrubbing_runs_BEFORE_the_write_not_after():

--- a/scripts/tests/test_obs_alloy_config.py
+++ b/scripts/tests/test_obs_alloy_config.py
@@ -74,6 +74,64 @@ def test_the_only_urls_present_are_env_lookups_or_loopback():
     assert offenders == [], f"hardcoded URL(s) in a public repo: {offenders}"
 
 
+# --- the transport allowlist: the PRIMARY privacy control ------------------ #
+# Five audit rounds each found a defect in the redaction regexes, three of them
+# introduced by the preceding fix. So the guarantee is no longer "we can pattern
+# -match every secret" — it is "the transport carrying application output is
+# never shipped". These pin that, because a `keep` rule silently turning into a
+# no-op would restore the whole hazard class with every test still green.
+
+
+def _relabel_rules(text: str):
+    """The rule blocks of loki.relabel "journal", as raw strings."""
+    import re
+
+    block = re.search(r'loki\.relabel "journal" \{(.*?)\n\}', text, re.S)
+    assert block, "loki.relabel \"journal\" not found"
+    live = "\n".join(
+        ln for ln in block.group(1).splitlines() if not ln.strip().startswith("//")
+    )
+    return re.findall(r"rule \{(.*?)\n  \}", live, re.S)
+
+
+def test_a_transport_allowlist_exists_and_is_a_keep_not_a_drop():
+    """`keep` is default-DENY: a transport that does not exist yet is dropped
+    rather than shipped. A `drop` rule listing bad transports would be
+    default-allow, and would ship anything new by accident."""
+    rules = _relabel_rules(CONFIG.read_text())
+    keeps = [r for r in rules if 'action' in r and '"keep"' in r]
+    assert len(keeps) == 1, f"expected exactly one keep rule, found {len(keeps)}"
+    assert "__journal__transport" in keeps[0], "the allowlist must key on transport"
+
+
+def test_stdout_is_not_in_the_allowlist():
+    """`stdout` is 69.9% of this host's journal and carries every content class
+    the scrubbing existed for: container output, DB errors echoing values,
+    object-store credential errors, agent tooling."""
+    import re
+
+    rules = _relabel_rules(CONFIG.read_text())
+    keep = next(r for r in rules if '"keep"' in r)
+    regex = re.search(r'regex\s*=\s*"([^"]*)"', keep).group(1)
+    allowed = regex.split("|")
+    assert "stdout" not in allowed, f"stdout would be shipped: {allowed}"
+    # And the transports the freeze investigation actually reads must survive.
+    for needed in ("kernel", "journal"):
+        assert needed in allowed, f"{needed} must be shipped — it is the evidence"
+
+
+def test_the_allowlist_regex_is_fully_anchored_by_alternation_not_a_substring():
+    """A regex like `kern` would match `kernel` but relabel anchors the whole
+    value, so assert the entries are exact transport names rather than prefixes."""
+    import re
+
+    keep = next(r for r in _relabel_rules(CONFIG.read_text()) if '"keep"' in r)
+    regex = re.search(r'regex\s*=\s*"([^"]*)"', keep).group(1)
+    known = {"kernel", "journal", "syslog", "stdout", "audit", "driver"}
+    for entry in regex.split("|"):
+        assert entry in known, f"{entry!r} is not a systemd transport name"
+
+
 # --- the scrubbing contract ----------------------------------------------- #
 
 def test_notification_bodies_are_dropped():
@@ -167,7 +225,12 @@ def test_every_replace_stage_in_the_config_is_parsed():
     # anchor. `_replace_stages` now also accepts either attribute order, so both
     # halves of that hole are closed rather than one.
     declared = len(re.findall(r"stage\.replace\s*\{", live))
-    stages = _replace_stages(text)
+    # 🔴 Parse `live`, not `text`. Parsing the full file let a COMMENTED-OUT
+    # block be read in place of a real one: the block regex spanned the dead
+    # block into the next rule's closing brace, so the parsed expression came
+    # from the comment while the counts still matched and this pin stayed green
+    # — with a live rule modelled by nothing. Measured.
+    stages = _replace_stages(live)
     assert declared >= 4, f"expected the redaction rules, found {declared} live blocks"
     assert len(stages) == declared, (
         f"parsed {len(stages)} of {declared} live stage.replace blocks — "
@@ -221,9 +284,19 @@ MEASURED_REDACTIONS = [
     # A quote INSIDE an unquoted value truncated to `[REDACTED]'cd`.
     ("app: password=ab'cd done",
      "app: password=[REDACTED] done"),
-    # An ESCAPED quote ended 2a's match early, leaving one character behind.
+    # ACCEPTED RESIDUAL: an escaped quote ends 2a's match early, leaving the
+    # tail of the value behind. The escape-aware class that fixed this caused a
+    # strictly worse leak (see the next case), so it was reverted. JSON is the
+    # main producer of this shape and arrives on `stdout`, which the transport
+    # allowlist drops entirely.
     ('app: {"password": "a\\"b", "user": "bob"}',
-     'app: {"password": "[REDACTED]", "user": "bob"}'),
+     'app: {"password": "[REDACTED]"b", "user": "bob"}'),
+    # 🔴 THE REASON that residual is accepted: with an escape-aware value class,
+    # a lone trailing backslash consumed the real closing quote and the match
+    # ran to the NEXT quote, shipping the following credential in CLEAR
+    # (`token="[REDACTED]"hunter2zz"`). Both are now redacted.
+    ('app: token="abc\\" password="hunter2zz"',
+     'app: token="[REDACTED]" password="[REDACTED]"'),
     # --- schemes ----------------------------------------------------------
     ("req: Authorization: Bearer JWTaaa.bbb.ccc done",
      "req: Authorization: Bearer [REDACTED] done"),

--- a/scripts/tests/test_obs_alloy_config.py
+++ b/scripts/tests/test_obs_alloy_config.py
@@ -108,14 +108,17 @@ def _replace_stages(text: str):
     """[(expression, replace)] for each stage.replace block, in file order."""
     import re
 
-    return [
-        (m.group(1).encode().decode("unicode_escape"), m.group(2))
-        for m in re.finditer(
-            r'stage\.replace\s*\{\s*expression\s*=\s*"((?:[^"\\]|\\.)*)"\s*'
-            r'replace\s*=\s*"((?:[^"\\]|\\.)*)"',
-            text,
-        )
-    ]
+    # BOTH attribute orders. Requiring expression-then-replace meant a block
+    # written the other way was skipped SILENTLY — alloy accepts it and the rule
+    # fires, so it was a live, unasserted redaction rule.
+    out = []
+    for block in re.finditer(r"stage\.replace\s*\{(.*?)\n\s*\}", text, re.S):
+        body = block.group(1)
+        expr = re.search(r'expression\s*=\s*"((?:[^"\\]|\\.)*)"', body)
+        repl = re.search(r'replace\s*=\s*"((?:[^"\\]|\\.)*)"', body)
+        if expr and repl:
+            out.append((expr.group(1).encode().decode("unicode_escape"), repl.group(1)))
+    return out
 
 
 def _apply(stages, line: str) -> str:
@@ -141,12 +144,12 @@ def _apply(stages, line: str) -> str:
 def test_every_replace_stage_in_the_config_is_parsed():
     """POSITIVE CONTROL, pinned TWO-WAY.
 
-    `>= 3` was not enough: the parser requires `expression` to be immediately
-    followed by `replace`, so a rule written with the attributes in the other
-    order is skipped silently. Measured — appending a valid 4th stage with
-    `replace` first left the parser returning 3 and the whole suite green, with
-    the new rule entirely unasserted. Counting the literal blocks makes an
-    unparsed rule fail here instead of passing invisibly.
+    A bare `>= N` floor is not enough: a rule this file's parser cannot read is
+    asserted by NOTHING while the suite stays green, and alloy runs it happily.
+    Measured three separate ways in: attributes in the reverse order, an opening
+    brace written `stage.replace{`, and a same-line comment prefix. Comparing
+    the parsed count against the count of live blocks makes an unreadable rule
+    fail HERE rather than pass invisibly.
     """
     import re
 
@@ -157,13 +160,13 @@ def test_every_replace_stage_in_the_config_is_parsed():
     live = "\n".join(
         ln for ln in text.splitlines() if not ln.strip().startswith("//")
     )
-    # 🔴 A REGEX, not `live.count("stage.replace {")`. The literal missed
-    # `stage.replace{` (no space) — measured: alloy accepts it, the rule FIRES
-    # in a real run, and the pin still reported 3-of-3 PASS with that rule
-    # asserted by nothing. One absent space reopened the exact hole this closes.
-    # It was also brittle the other way: `stage.replace  {` failed with a
-    # message describing the opposite problem.
-    declared = len(re.findall(r"^\s*stage\.replace\s*\{", live, re.M))
+    # 🔴 A REGEX, and deliberately UNANCHORED. Two bypasses were measured, each
+    # a live rule that alloy accepted and that FIRED, while this pin still
+    # passed: `stage.replace{` (no space) defeated a literal `count()`, and a
+    # same-line prefix such as `/* x */ stage.replace {` defeated a `^\s*`
+    # anchor. `_replace_stages` now also accepts either attribute order, so both
+    # halves of that hole are closed rather than one.
+    declared = len(re.findall(r"stage\.replace\s*\{", live))
     stages = _replace_stages(text)
     assert declared >= 4, f"expected the redaction rules, found {declared} live blocks"
     assert len(stages) == declared, (
@@ -198,12 +201,29 @@ MEASURED_REDACTIONS = [
      "app: password=[REDACTED] done"),
     ("app: password=a&b&c done",
      "app: password=[REDACTED] done"),
+    # The trailing quote is consumed: 2b allows `'` in the value class (so that
+    # `password=ab'cd` cannot truncate), and therefore eats 2a's closing quote.
+    # Cosmetic, and the right side of the trade — measured, not assumed.
     ("app: password='sq;uote' done",
-     "app: password='[REDACTED]' done"),
+     "app: password='[REDACTED] done"),
     ("env: SECRET_KEY='django-insecure-ab,cd' done",
-     "env: SECRET_KEY='[REDACTED]' done"),
+     "env: SECRET_KEY='[REDACTED] done"),
     ("app: password: \"two words here\" done",
      "app: password: \"[REDACTED]\" done"),
+    # --- quote edge cases, each a leak that shipped at some point ---------
+    # UNTERMINATED quoted value (journald splits long lines at LineMax). 2a
+    # needs a closing quote and 2b could not start on one, so this shipped in
+    # CLEAR for one round — a redaction the earlier single-rule version did do.
+    ('app: password: "abcdef',
+     'app: password: "[REDACTED]'),
+    ("app: password: 'abcdef",
+     "app: password: '[REDACTED]"),
+    # A quote INSIDE an unquoted value truncated to `[REDACTED]'cd`.
+    ("app: password=ab'cd done",
+     "app: password=[REDACTED] done"),
+    # An ESCAPED quote ended 2a's match early, leaving one character behind.
+    ('app: {"password": "a\\"b", "user": "bob"}',
+     'app: {"password": "[REDACTED]", "user": "bob"}'),
     # --- schemes ----------------------------------------------------------
     ("req: Authorization: Bearer JWTaaa.bbb.ccc done",
      "req: Authorization: Bearer [REDACTED] done"),

--- a/scripts/tests/test_obs_alloy_config.py
+++ b/scripts/tests/test_obs_alloy_config.py
@@ -1,0 +1,156 @@
+"""Coverage for scripts/obs/alloy.alloy — the host-telemetry agent config.
+
+An invalid Alloy config takes the whole agent down at startup, and the failure
+is silent from the consumer's side: Prometheus simply has no data for that host,
+which looks exactly like a host that froze — the signal this pipeline exists to
+make legible. So the config is validated in CI rather than at deploy time.
+
+🔴 `alloy fmt` is NOT sufficient and must not be substituted here. It checks
+SYNTAX only: it accepted `faster_drop_reason = "..."` (a real typo in this
+file's first draft) with rc=0. `alloy validate` resolves component names,
+attribute names and inter-component references, and rejects it. The negative
+controls below pin that distinction so nobody "simplifies" this to fmt.
+"""
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+CONFIG = REPO / "scripts" / "obs" / "alloy.alloy"
+
+# WHERE `alloy validate` ACTUALLY RUNS, AND WHY NOT HERE
+# -----------------------------------------------------
+# It runs at BUILD TIME, in nix/observability.nix, so an invalid config fails
+# `home-manager switch` and cannot be deployed at all. That is strictly stronger
+# than a test: there is no window in which a broken config is committed-and-green
+# but undeployable-in-practice.
+#
+# It is not ALSO run here because `alloy`'s closure is 604 MiB — larger than
+# opencode and nodejs combined — and adding it to gateTools would charge every
+# gate run and every CI build for one file. Tests that skipif on `which("alloy")`
+# were written and then deleted: in the gate they would ALWAYS skip, which is
+# zero coverage plus skip-ledger churn (#608 consolidated those ledgers precisely
+# so a stray skip reds a gate).
+#
+# Measured 2026-08-20, so the claim above is not theoretical:
+#   * `alloy validate` rejects an unrecognized attribute name, a nonexistent
+#     component, and a dangling inter-component reference (rc=1 each).
+#   * `alloy fmt` accepts an unrecognized attribute name with rc=0 — it passed
+#     the real `faster_drop_reason` typo from this file's first draft.
+#   * Reintroducing that typo fails `home-manager build`:
+#       error: Cannot build '...-alloy-config-validated.drv'
+#       > Error: ...alloy.alloy:145:5: unrecognized attribute name "faster_drop_reason"
+#
+# The tests below therefore guard the WIRING of that guarantee and the contracts
+# that are checkable without the binary. All of them always run.
+
+
+# --- public-repo safety --------------------------------------------------- #
+
+def test_no_endpoint_or_credential_is_hardcoded():
+    """devrc is PUBLIC. Every site-specific value must come from the
+    environment, supplied by a gitignored per-host EnvironmentFile."""
+    text = CONFIG.read_text()
+    for name in ("OBS_PROM_URL", "OBS_LOKI_URL", "OBS_USERNAME", "OBS_PASSWORD", "OBS_HOST"):
+        assert f'sys.env("{name}")' in text, f"{name} must be read from the environment"
+
+
+def test_the_only_urls_present_are_env_lookups_or_loopback():
+    """A real hostname committed here is internal topology in a public repo.
+
+    Asserts the STATE (no absolute URL literal), not the spelling of any one
+    host, so a different real host cannot slip past by not matching a pattern.
+    """
+    import re
+
+    text = CONFIG.read_text()
+    # Strip comments: the prose deliberately mentions paths and rationale.
+    body = "\n".join(ln for ln in text.splitlines() if not ln.strip().startswith("//"))
+    urls = re.findall(r'"(https?://[^"]+)"', body)
+    offenders = [u for u in urls if not u.startswith(("http://127.0.0.1", "http://localhost"))]
+    assert offenders == [], f"hardcoded URL(s) in a public repo: {offenders}"
+
+
+# --- the scrubbing contract ----------------------------------------------- #
+
+def test_notification_bodies_are_dropped():
+    """dunst lines carry message CONTENT (observed: '<repo> — turn ran 1m 15s')."""
+    text = CONFIG.read_text()
+    assert "stage.drop" in text
+    assert "^dunst$" in text
+
+
+def test_credential_shaped_values_are_redacted():
+    text = CONFIG.read_text()
+    assert "stage.replace" in text
+    for keyword in ("password", "token", "secret", "authorization"):
+        assert keyword in text.lower(), f"no redaction rule mentions {keyword}"
+
+
+def test_scrubbing_runs_BEFORE_the_write_not_after():
+    """Ordering is the whole point: the journal source must forward into the
+    scrub stage, and only the scrub stage may forward to loki.write. A config
+    that ships first and scrubs second would validate cleanly and leak."""
+    text = CONFIG.read_text()
+    assert "forward_to    = [loki.process.scrub.receiver]" in text or \
+           "forward_to = [loki.process.scrub.receiver]" in text, \
+           "journal source must forward into the scrub stage"
+
+    # The journal source must NOT write straight to Loki.
+    source_block = text.split('loki.source.journal "system" {', 1)[1].split("\n}", 1)[0]
+    assert "loki.write" not in source_block, \
+        "journal source bypasses scrubbing and writes directly to Loki"
+
+
+def test_metrics_scrape_interval_is_short_enough_to_see_a_freeze():
+    """At the 60s default a thermal or IO cliff is one or two points."""
+    text = CONFIG.read_text()
+    assert 'scrape_interval = "15s"' in text
+
+
+# --- the deploy-time guarantee -------------------------------------------- #
+# `alloy` is not in the gate toolchain: its closure is 604 MiB, more than
+# opencode and nodejs combined, which is not worth paying on every CI run to
+# check one file. So the AUTHORITATIVE validation happens at build time in
+# nix/observability.nix, where the hosts already need the binary because they
+# run the agent. The tests above therefore skip without alloy — and these two,
+# which never skip, pin that the guarantee stays wired.
+
+MODULE = REPO / "nix" / "observability.nix"
+
+
+def _live_code(path: Path) -> str:
+    """Nix source with comment lines removed.
+
+    🔴 Load-bearing. This module DISCUSSES `alloy validate` at length in its
+    comments, so a plain `"alloy validate" in text` check passes even after the
+    call is deleted — measured: that exact mutant SURVIVED a fully green run.
+    A guard that reads the prose describing a mechanism, rather than the
+    mechanism, provides no coverage while looking like it does.
+    """
+    return "\n".join(
+        ln for ln in path.read_text().splitlines() if not ln.strip().startswith("#")
+    )
+
+
+def test_the_nix_module_validates_the_config_at_build_time():
+    """If this wiring is removed, an invalid config becomes deployable again and
+    the failure is silent: the host just stops appearing in Prometheus, which
+    looks exactly like the freeze this pipeline exists to detect."""
+    body = _live_code(MODULE)
+    assert "alloy validate" in body, "build-time validation is gone"
+    assert "runCommandLocal" in body
+    assert "grafana-alloy" in body
+
+
+def test_the_build_time_check_is_validate_not_fmt():
+    """`alloy fmt` passes an unrecognized attribute name with rc=0 — it accepted
+    the `faster_drop_reason` typo. Substituting it here would look equivalent
+    and check almost nothing."""
+    assert "alloy fmt" not in _live_code(MODULE), "fmt is not sufficient; use `alloy validate`"
+
+
+def test_credentials_are_read_from_outside_the_nix_store():
+    """The nix store is world-readable and this repo is public."""
+    text = MODULE.read_text()
+    assert "EnvironmentFile" in text
+    assert "obs-ship/env" in text

--- a/scripts/tests/test_obs_alloy_config.py
+++ b/scripts/tests/test_obs_alloy_config.py
@@ -3,7 +3,8 @@
 An invalid Alloy config takes the whole agent down at startup, and the failure
 is silent from the consumer's side: Prometheus simply has no data for that host,
 which looks exactly like a host that froze — the signal this pipeline exists to
-make legible. So the config is validated in CI rather than at deploy time.
+make legible. So the config is validated at BUILD time (see below), which is stronger
+than a test: an invalid config cannot be deployed at all.
 
 🔴 `alloy fmt` is NOT sufficient and must not be substituted here. It checks
 SYNTAX only: it accepted `faster_drop_reason = "..."` (a real typo in this
@@ -42,8 +43,9 @@ CONFIG = REPO / "scripts" / "obs" / "alloy.alloy"
 #       error: Cannot build '...-alloy-config-validated.drv'
 #       > Error: ...alloy.alloy:145:5: unrecognized attribute name "faster_drop_reason"
 #
-# The tests below therefore guard the WIRING of that guarantee and the contracts
-# that are checkable without the binary. All of them always run.
+# The tests here therefore guard the WIRING of that guarantee, plus the
+# contracts checkable without the binary. NONE of them skip — a skipping test
+# would be zero coverage in the gate, which is where this has to hold.
 
 
 # --- public-repo safety --------------------------------------------------- #
@@ -136,11 +138,29 @@ def _apply(stages, line: str) -> str:
     return line
 
 
-def test_the_emulator_finds_the_configs_replace_stages():
-    """POSITIVE CONTROL. If the parser matched nothing, every redaction
-    assertion below would pass vacuously against an empty rule list."""
-    stages = _replace_stages(CONFIG.read_text())
-    assert len(stages) >= 3, f"expected the redaction rules, parsed {len(stages)}"
+def test_every_replace_stage_in_the_config_is_parsed():
+    """POSITIVE CONTROL, pinned TWO-WAY.
+
+    `>= 3` was not enough: the parser requires `expression` to be immediately
+    followed by `replace`, so a rule written with the attributes in the other
+    order is skipped silently. Measured — appending a valid 4th stage with
+    `replace` first left the parser returning 3 and the whole suite green, with
+    the new rule entirely unasserted. Counting the literal blocks makes an
+    unparsed rule fail here instead of passing invisibly.
+    """
+    text = CONFIG.read_text()
+    # Count LIVE blocks only: this config discusses `stage.replace` in its
+    # comments, and counting those too made the pin fail 3-vs-5 on its first
+    # run — the same read-the-prose-not-the-code hazard the nix guard hit.
+    live = "\n".join(
+        ln for ln in text.splitlines() if not ln.strip().startswith("//")
+    )
+    declared = live.count("stage.replace {")
+    stages = _replace_stages(text)
+    assert declared >= 3, f"expected the redaction rules, found {declared} live blocks"
+    assert len(stages) == declared, (
+        f"parsed {len(stages)} of {declared} live stage.replace blocks — "
+        "an unparsed rule is asserted by nothing")
     assert all(expr and repl for expr, repl in stages)
 
 
@@ -166,15 +186,34 @@ MEASURED_REDACTIONS = [
      "req: Authorization: Bearer [REDACTED] done"),
     ("req: authorization header bearer BAREJWTxxx.yyy.zzz done",
      "req: authorization header bearer [REDACTED] done"),
+    # `Basic` as well as `Bearer`: handling only bearer leaked the base64.
+    ("req: authorization: Basic dXNlcjpwdw== done",
+     "req: authorization: Basic [REDACTED] done"),
+    # A quoted JSON key put a `"` between keyword and `:`, so this once did not
+    # match AT ALL and shipped byte-identical.
+    ('app: {"password": "hunter2xyz", "user": "bob"}',
+     'app: {"password": "[REDACTED]", "user": "bob"}'),
     ("mc: The Access Key Id you provided: access_key=KEYVALUE99",
      "mc: The Access Key Id you provided: access_key=[REDACTED]"),
     ("mc: api_key: APIKEYVALUE123 rejected",
      "mc: api_key: [REDACTED] rejected"),
     ("mc: error key AKIAIOSFODNN7EXAMPLE not found",
      "mc: error key [REDACTED-KEYID] not found"),
-    # NEGATIVE CONTROL: no secret, so the line must be returned untouched.
+    # The value class stops at `&`, so the rest of the query string survives.
+    # With `\\S+` this became `?token=[REDACTED] HTTP/1.1`, eating user and page.
+    ("nginx: GET /v1/items?token=abc123&user=bob&page=2 HTTP/1.1 200 1234",
+     "nginx: GET /v1/items?token=[REDACTED]&user=bob&page=2 HTTP/1.1 200 1234"),
+    # NEGATIVE CONTROLS — these must pass through untouched.
     ("app: ordinary line about a password policy with no value",
      "app: ordinary line about a password policy with no value"),
+    ("systemd: Started foo.service key=value other=thing",
+     "systemd: Started foo.service key=value other=thing"),
+    ('app: {"password_reset": true, "user": "bob"}',
+     'app: {"password_reset": true, "user": "bob"}'),
+    # ACCEPTED OVER-REDACTION, asserted so it stays a decision rather than a
+    # surprise: a keyword plus separator redacts the next token whatever it is.
+    ("app: the token: is missing entirely",
+     "app: the token: [REDACTED] missing entirely"),
 ]
 
 
@@ -233,8 +272,8 @@ def test_metrics_scrape_interval_is_short_enough_to_see_a_freeze():
 # opencode and nodejs combined, which is not worth paying on every CI run to
 # check one file. So the AUTHORITATIVE validation happens at build time in
 # nix/observability.nix, where the hosts already need the binary because they
-# run the agent. The tests above therefore skip without alloy — and these two,
-# which never skip, pin that the guarantee stays wired.
+# run the agent. NOTHING in this file skips or invokes a binary; the tests below
+# pin that the build-time guarantee stays wired.
 
 MODULE = REPO / "nix" / "observability.nix"
 


### PR DESCRIPTION
Companion to #616. That PR made the kernel *able* to record a freeze; this one makes the evidence leave the machine before it dies.

## Why

The laptop has stopped uncleanly **16 times** across its retained journal — six since 2026-07-29 — and was believed to have frozen "twice in the past month". Two independent failures made the real rate invisible:

1. **The last minutes never reached disk.** journald buffers, and a hard lockup takes the buffer with it. Shipping the journal continuously moves those minutes off the host *before* it dies. This is the highest-value part of the change.
2. **Nothing counted the stops.** The only detector was a human noticing that work had been interrupted — so a freeze while away from the machine left no impression at all.

## 🔴 Correction carried into the docs

My earlier "onset 2026-07-29" framing was **wrong**. Unclean stops go back to at least March: `Mar 22`, `Mar 28`, `Apr 12`, `Apr 17`, `May 18`, `May 19`, `May 24`. June through Jul 4 genuinely *was* clean, but there is no onset to explain — which weakens the "no software change coincides with onset, so suspect recent hardware degradation" reasoning I gave earlier. This is a long-running intermittent condition.

## Design

**User-level, not `/etc/nixos`.** `services.alloy` and the node exporter are NixOS options, so they'd live per-host outside this repo and need sudo for every change. As user units they ship to **both hosts** through `ship.sh`. Nothing needs root: `/proc` and `/sys` collectors are world-readable, and `zach` is in `wheel`, which systemd's journal ACLs grant full journal read (verified unprivileged).

**Config validity is enforced at build time, not by a test.** A broken Alloy config is silent from the consumer's side — the agent exits, the host stops appearing in Prometheus, and "no data for this host" is *indistinguishable from the freeze this exists to detect*. `nix/observability.nix` runs `alloy validate` in a derivation, so an invalid config fails `home-manager switch`. Measured:

```
error: Cannot build '...-alloy-config-validated.drv'
  > Error: ...alloy.alloy:145:5: unrecognized attribute name "faster_drop_reason"
```

`alloy validate`, never `alloy fmt` — fmt checks syntax only and accepted that exact typo with `rc=0`.

I wrote four tests calling `alloy validate` directly and then **deleted them**: alloy's closure is **604 MiB** (more than opencode and nodejs combined), so it isn't in `gateTools`, so they would *always* skip in the gate — zero coverage plus skip-ledger churn after #608. The build-time check is strictly stronger.

**Privacy.** The journal here is not neutral telemetry: it carries dunst notification **bodies**, Postgres errors echoing query values, and MinIO access-key errors. dunst lines are dropped outright and credential-shaped assignments redacted — **before** the Loki write. A test pins that ordering, because a config that ships first and scrubs second would validate cleanly and leak.

No endpoint, hostname or credential is committed (public repo) or placed in the nix store (world-readable). All five come from a gitignored per-host `EnvironmentFile`, optional so a host without credentials still switches cleanly.

## Verification

| check | result |
|---|---|
| `boot_outcome` under the unit's **exact restricted PATH** | `examined=32 unclean=16 previous_clean=0 end=1787263349` — independently reproduces the Aug 20 17:02:29 freeze found by hand |
| with `journalctl` unreachable | emits `scrape_ok=0` and **omits** the counts, rather than a reassuring `unclean 0` |
| `home-manager build` | succeeds; validated config lands in the store |
| mutation: journal → `loki.write` directly, bypassing scrubbing | guard reds |
| mutation: delete the `alloy validate` call | **found a real defect — see below** |
| full gate | **13450 passed, 0 failed, 1 skipped** (pre-existing pinned skip; this PR adds none) |

**The mutation that found a defect in my own test:** deleting the `alloy validate` call left the wiring guard **green**, because the module *discusses* `alloy validate` in its comments and the guard grepped the whole file — a guard reading the prose that describes a mechanism rather than the mechanism. It now strips comments first, and the mutant dies on its own assertion.

## Not included (needs root)

Shipping `/var/lib/systemd/pstore/*` crash dumps (0600) and NVMe SMART. Both would follow the staged `nix/system/apply-*.sh` pattern.

## After merging

Two manual steps — see `scripts/obs/README.md`:
1. Create `~/.config/obs-ship/env` per host with the homelab endpoints and credentials.
2. `sudo bash nix/system/apply-freeze-instrumentation.sh` — **#616 is merged but not applied**, so `kernel.nmi_watchdog` is still `0` and a seventh freeze would still record no kernel trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
