### PR TITLE
fix(clawgate-guard): `task create --help` creates nothing and was DENIED for naming no body

### DIFF
--- a/scripts/claude-hooks/clawgate-task-interview-guard.py
+++ b/scripts/claude-hooks/clawgate-task-interview-guard.py
@@ -344,6 +344,48 @@ def is_clawgatectl_task_create(argv):
     return any(a == "task" and b == "create" for a, b in zip(ops, ops[1:]))
 
 
+HELP_FLAGS = ("--help", "-h")
+
+
+def is_help_invocation(argv):
+    """True for a create-shaped argv that only ASKS FOR HELP and cannot create.
+
+    🔴 This is a structural exemption, not a convenience one. cobra prints usage
+    and exits for any of these forms WITHOUT calling the command, so the argv
+    genuinely cannot reach `POST /api/tasks` — allowing it removes a false
+    positive rather than opening a hole. `--body` alongside `--help` changes
+    nothing: help still wins and nothing is created.
+
+    Both spellings cobra accepts are covered:
+      * a `--help`/`-h` FLAG anywhere (`clawgatectl task create --help`)
+      * the `help` SUBCOMMAND leading the operands (`clawgatectl help task create`)
+
+    The flag scan skips value-flag values with the same rule `_operands` uses, so
+    `--token --help` reads `--help` as the token's VALUE and does NOT exempt —
+    otherwise the exemption would be reachable by a token that merely looks like
+    a flag.
+
+    🔴 Scoped to `clawgatectl` BY NAME. `--help` is cobra's; it is not a curl flag
+    and curl posts the request anyway, so letting this predicate answer for a curl
+    create would hand every curl producer a one-word bypass. Caught by
+    `test_help_does_not_exempt_a_curl_create` — the first version of this function
+    had exactly that hole.
+    """
+    if not argv or os.path.basename(argv[0]) != "clawgatectl":
+        return False
+    skip = False
+    for tok in argv[1:]:
+        if skip:
+            skip = False
+            continue
+        if tok in CLAWGATECTL_VALUE_FLAGS:
+            skip = True
+            continue
+        if tok in HELP_FLAGS:
+            return True
+    return _operands(argv, CLAWGATECTL_VALUE_FLAGS)[:1] == ["help"]
+
+
 def _url_path(token):
     """The path component of a URL-ish token, or None."""
     if "://" not in token:
@@ -644,7 +686,8 @@ def evaluate(text, env, guard_core):
     if not PREFILTER.search(text):
         return None
     creates = [argv for argv in guard_core.commands(text)
-               if is_clawgatectl_task_create(argv) or is_curl_task_create(argv)]
+               if (is_clawgatectl_task_create(argv) or is_curl_task_create(argv))
+               and not is_help_invocation(argv)]
     if not creates:
         return None
     if override_requested(text, env):

--- a/scripts/claude-hooks/tests/test_clawgate_task_interview_guard.py
+++ b/scripts/claude-hooks/tests/test_clawgate_task_interview_guard.py
@@ -1173,3 +1173,75 @@ def test_the_hook_and_guard_core_agree_on_what_a_command_is():
     assert callable(getattr(guard_core, "commands", None))
     assert guard_core.commands("clawgatectl task create --body x")[0][:3] == [
         "clawgatectl", "task", "create"]
+
+
+# =========================================================================== #
+# 15. THE HELP EXEMPTION — a create-shaped argv that CANNOT create
+# =========================================================================== #
+# Found by live use, not by review: `clawgatectl task create --help` was DENIED
+# for naming no readable body. It creates nothing — cobra prints usage and exits
+# without calling the command — so the deny was a false positive, and the kind
+# that trains an operator to reach for the override reflexively. The exemption is
+# structural: these argvs cannot reach `POST /api/tasks` at all.
+def test_help_flag_on_a_create_is_allowed():
+    assert allowed("clawgatectl task create --help")
+
+
+def test_help_shorthand_on_a_create_is_allowed():
+    assert allowed("clawgatectl task create -h")
+
+
+def test_help_subcommand_form_is_allowed():
+    """`clawgatectl help task create` puts `task`+`create` adjacent in the operand
+    list, so the create detector matches it. It still creates nothing."""
+    assert allowed("clawgatectl help task create")
+
+
+def test_help_wins_even_next_to_a_body_with_no_criteria():
+    """cobra prints usage and exits regardless of the other flags, so a `--body`
+    riding along cannot be created either."""
+    assert allowed('clawgatectl task create --body "%s" --help' % NO_AC)
+
+
+def test_help_as_a_VALUE_does_not_exempt():
+    """🔴 The anti-walk case. `--token --help` makes `--help` the token's VALUE,
+    not a flag — if the scan missed that, the exemption would be reachable by any
+    create willing to spell one of its flag values `--help`."""
+    assert denied_missing('clawgatectl --token --help task create --body "%s"' % NO_AC)
+
+
+def test_help_in_the_BODY_does_not_exempt():
+    """The word inside the body text is not a flag."""
+    assert denied_missing('clawgatectl task create --body "please --help me"')
+
+
+def test_help_on_ONE_create_does_not_exempt_a_SECOND_create_on_the_line():
+    """🔴 The exemption is per-argv. A compound line must still be judged on the
+    create that really runs — this is the multi-create rule from section 10,
+    re-asserted against the new escape."""
+    assert denied_missing(
+        'clawgatectl task create --help; clawgatectl task create --body "%s"' % NO_AC)
+
+
+def test_help_does_not_exempt_a_curl_create():
+    """`--help` is not a curl flag that suppresses the request, so a curl create
+    carrying it still posts. The exemption must not generalise to curl."""
+    assert denied_missing(
+        "curl -X POST http://192.168.50.250:30302/api/tasks --help "
+        "-d '{\"body\":\"%s\"}'" % NO_AC)
+
+
+def test_help_exemption_unit_level():
+    """Driven directly, so the predicate is pinned independently of `evaluate`."""
+    assert guard.is_help_invocation(["clawgatectl", "task", "create", "--help"]) is True
+    assert guard.is_help_invocation(["clawgatectl", "task", "create", "-h"]) is True
+    assert guard.is_help_invocation(["clawgatectl", "help", "task", "create"]) is True
+    assert guard.is_help_invocation(["clawgatectl", "task", "create"]) is False
+    assert guard.is_help_invocation(
+        ["clawgatectl", "--token", "--help", "task", "create"]) is False
+    assert guard.is_help_invocation([]) is False
+
+
+def test_help_is_not_a_blanket_allow_for_the_word_anywhere():
+    """`help` as a NON-leading operand is a task title, not the subcommand."""
+    assert denied_missing('clawgatectl task create --title help --body "%s"' % NO_AC)


### PR DESCRIPTION
fix(clawgate-guard): `task create --help` creates nothing and was DENIED for naming no body

Found by using it, not by reviewing it: the first thing the interview guard
blocked after deploy was my own `clawgatectl task create --help`. It names no
readable body, so the unseeable-body rule fired — but cobra prints usage and
exits WITHOUT calling the command, so that argv cannot reach POST /api/tasks at
all. A gate that denies a read is the kind that trains an operator to reach for
CLAWGATE_NO_INTERVIEW=1 reflexively, which costs more than the papercut.

`is_help_invocation()` exempts a create-shaped argv that only asks for help:
  * a `--help`/`-h` FLAG anywhere        (clawgatectl task create --help)
  * the `help` SUBCOMMAND leading        (clawgatectl help task create)
The exemption is STRUCTURAL, not a convenience: these argvs genuinely cannot
create. `--body` riding along changes nothing — help still wins.

Three ways it deliberately does NOT widen:

1. Scoped to `clawgatectl` BY NAME. My first version was not, and my own test
   caught it: `--help` is not a curl flag and curl posts the request anyway, so
   an unscoped predicate would have handed every curl producer a one-word bypass
   of the entire gate. Pinned by test_help_does_not_exempt_a_curl_create.
2. The flag scan skips value-flag values with the same rule `_operands` uses, so
   `--token --help` reads `--help` as the token's VALUE and does not exempt —
   otherwise any create willing to spell a flag value `--help` would walk it.
3. `help` only counts as the LEADING operand, so `--title help` is a task title.
   And the exemption is per-argv: a compound line still gets judged on the create
   that really runs.

Tests: 300 -> 310 in scripts/claude-hooks/tests/, including all three anti-walk
cases above.

Mutation sweep, 5 mutants, 5 KILLED, under PYTHONDONTWRITEBYTECODE=1 with
__pycache__ cleared between mutants and the guard restored byte-identical
(verified by cmp):
  always-exempt        KILLED (2 tests)
  drop-curl-scope      KILLED (1 test)   <- exactly one; that test IS the guard
  drop-value-flag-skip KILLED (2 tests)
  help-anywhere        KILLED (1 test)
  POSITIVE CONTROL (HELP_FLAGS = ()) KILLED (4 tests)

Gate, by hand (devrc has no CI):
  nix develop <wt> --command bash <wt>/scripts/run-tests.sh <wt>
  RESULT: PASS (exit=0) — 13757 passed / 1 skipped / 0 failed, 25/25 floors,
  no FAIL rows, no timeout panic.

KNOWN AND NOT FIXED HERE, found the same way: a Bash command whose HEREDOC
merely mentions a create is blocked, because heredoc content is read as a
candidate body. That is how this commit's own tests had to be written with the
Write tool instead of `cat >> … <<EOF`. It is defensible — a heredoc piped to
`bash` really would create — and narrowing it (distinguish `cat >>` from `bash
<<`) risks opening a hole, so it is left alone deliberately rather than
overlooked. The override clears it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
