### PR TITLE
feat(espanso-audit): --gate and --diff-config — the two-axis check that would have caught the 2026-08-19 regression

### DIFF
--- a/claude/skills/espanso-audit/SKILL.md
+++ b/claude/skills/espanso-audit/SKILL.md
@@ -44,21 +44,24 @@ nix-shell -p python3Packages.pyyaml --run \
    pre-ship command. Offline, no creds. It lints the candidate AND resolves a
    probe universe (single-token prefixes + within-snippet two-token queries)
    against the deployed config. **Two things FAIL it, both user-facing:**
-   - **snippets blinded** — a snippet that SURVIVES the edit but no query
-     reaches any more (its trigger aside). This is the 2026-08-19 regression.
+   - **snippets narrowed** — a snippet that SURVIVES the edit and strictly
+     loses ways of being found: reaching words go away and none arrive. This is
+     the 2026-08-19 shape, and it stays fatal even when the snippet keeps one
+     word — an earlier all-or-nothing rule passed exactly that case.
    - **expansion changed** — a query that resolved to one snippet now resolves
-     to another that types DIFFERENT text.
-   Everything else is **reported, never graded**: ambiguity costs telemetry,
-   not reach (espanso lists every match as a row), and pruning or renaming
-   drops words by design. Grading those would make it red on the skill's own
-   primary actions, and a permanently-red gate teaches you to ignore it.
-   🔴 **It models the picker with the KEYLOG matcher (`_term_matches`), not
-   espanso itself** — nothing in this repo checks that proxy against espanso, so
-   a `PASS` is "no regression under our model", not a guarantee. Multi-word
-   queries beyond within-snippet pairs, and non-prefix substrings, are outside
-   the universe. `--diff-config` is the diff without the lint;
-   `--replay --config <candidate>` still cross-checks against terms he really
-   typed — narrower, but real data rather than a model.
+     to another that types DIFFERENT text. A plain trigger rename is not this.
+   Everything else is **reported, never graded**: ambiguity costs telemetry, not
+   reach (espanso lists every match as a row), and pruning or rewording drops
+   words by design. Grading those made the gate red on this skill's own primary
+   actions, and a permanently-red gate teaches you to ignore it.
+   🔴 **Known limits — a PASS is "no regression under our model", not a
+   guarantee.** It models the picker with the KEYLOG matcher, not espanso, and
+   nothing in this repo checks that proxy. Multi-word queries beyond
+   within-snippet pairs, and non-prefix substrings, are outside the universe.
+   Correcting a typo whose right spelling was ALREADY reachable is flagged —
+   a real if trivial loss; the report names the queries, so a glance settles it.
+   `--diff-config` is the diff without the lint; `--replay --config <candidate>`
+   cross-checks against terms he really typed — narrower, but real data.
 5. Edit `services.espanso` in `nix/home.nix` on a branch → PR → merge →
    `scripts/ship.sh`.
 6. `--verify-deploy` → both hosts: deployed trigger set, `espanso` active, and

--- a/claude/skills/espanso-audit/SKILL.md
+++ b/claude/skills/espanso-audit/SKILL.md
@@ -44,10 +44,12 @@ nix-shell -p python3Packages.pyyaml --run \
    pre-ship command. Offline, no creds. It lints the candidate AND resolves a
    probe universe (single-token prefixes + within-snippet two-token queries)
    against the deployed config. **Two things FAIL it, both user-facing:**
-   - **snippets narrowed** — a snippet that SURVIVES the edit and strictly
-     loses ways of being found: reaching words go away and none arrive. This is
-     the 2026-08-19 shape, and it stays fatal even when the snippet keeps one
-     word — an earlier all-or-nothing rule passed exactly that case.
+   - **queries that stop working** — a WHOLE WORD that used to find a snippet
+     finds nothing now, and that snippet still exists. Four earlier rules each
+     tried to infer whether the loss was DELIBERATE and each was walked by a
+     one-line edit; intent is not in the config, so state it: acknowledge
+     deliberate losses with **`--accept word,word`**. A PRUNE needs no
+     acknowledgement — the word went with the snippet.
    - **expansion changed** — a query that resolved to one snippet now resolves
      to another that types DIFFERENT text. A plain trigger rename is not this.
    Everything else is **reported, never graded**: ambiguity costs telemetry, not

--- a/claude/skills/espanso-audit/SKILL.md
+++ b/claude/skills/espanso-audit/SKILL.md
@@ -41,17 +41,24 @@ nix-shell -p python3Packages.pyyaml --run \
    to: `_attribute` returns None on ambiguity, so it can never fire from the
    search UI.
 4. Propose changes, then run **`--gate <candidate base.yml>`** — the one
-   pre-ship command. Offline, no creds. It lints the candidate AND resolves the
-   whole prefix universe against the deployed config, reporting two axes that
-   are graded differently:
-   - **picker rows lost** — a query that listed snippets now reaches NOTHING.
-     A user-facing regression: **exit 1**, do not ship.
-   - **attribution lost/gained/moved** — telemetry only. An ambiguous query
-     still LISTS every match; only `_attribute` cannot name one. Adding any
-     snippet costs some, so this is reported and never fatal.
-   `--diff-config <candidate>` is the diff alone. `--replay --config <candidate>`
-   still cross-checks against terms he really typed — useful, but NOT sufficient:
-   it only replays observed terms, so a term he never searched is invisible to it.
+   pre-ship command. Offline, no creds. It lints the candidate AND resolves a
+   probe universe (single-token prefixes + within-snippet two-token queries)
+   against the deployed config. **Two things FAIL it, both user-facing:**
+   - **snippets blinded** — a snippet that SURVIVES the edit but no query
+     reaches any more (its trigger aside). This is the 2026-08-19 regression.
+   - **expansion changed** — a query that resolved to one snippet now resolves
+     to another that types DIFFERENT text.
+   Everything else is **reported, never graded**: ambiguity costs telemetry,
+   not reach (espanso lists every match as a row), and pruning or renaming
+   drops words by design. Grading those would make it red on the skill's own
+   primary actions, and a permanently-red gate teaches you to ignore it.
+   🔴 **It models the picker with the KEYLOG matcher (`_term_matches`), not
+   espanso itself** — nothing in this repo checks that proxy against espanso, so
+   a `PASS` is "no regression under our model", not a guarantee. Multi-word
+   queries beyond within-snippet pairs, and non-prefix substrings, are outside
+   the universe. `--diff-config` is the diff without the lint;
+   `--replay --config <candidate>` still cross-checks against terms he really
+   typed — narrower, but real data rather than a model.
 5. Edit `services.espanso` in `nix/home.nix` on a branch → PR → merge →
    `scripts/ship.sh`.
 6. `--verify-deploy` → both hosts: deployed trigger set, `espanso` active, and
@@ -121,18 +128,9 @@ prune anything from a run that printed one.
   `_EXISTING_RESOLUTIONS` — and add the new snippet's own terms to it.
   **Pin a term the snippet's LABEL does not spell**, or the guard passes with
   every `search_terms` entry deleted (three such pins shipped on 2026-08-19).
-  🔴 **Neither gate sweeps the whole input space — diff the WHOLE PREFIX
-  UNIVERSE.** Enumerate every prefix of every word in both configs' triggers,
-  labels and terms, resolve each against both, and report four buckets: picker
-  rows lost, attribution lost, attribution gained, resolution moved. That is
-  what surfaced the 8 blanked nebula prefixes AND 17 newly-ambiguous ones that
-  both the replay diff and the pinned list called clean.
-  🔴 That file's `test_live_scraper_observes_the_real_config` is a POSITIVE
-  CONTROL pinned to a LONG `search_terms` list, so a scraper regex matching
-  nothing cannot make the other guards vacuously true. If your edit strips the
-  pinned snippet's terms, **MOVE the pin to another long list — never relax it
-  to `== []`**, which exercises no list-splitting and silently disarms the
-  control.
+  🔴 **Neither sweeps the whole input space on its own — that is what
+  `--gate` is for** (step 4). It replaced the hand-rolled prefix-universe
+  diff this rule used to describe; do not re-derive it by hand.
 - DEMAND reads the LOCAL transcripts only; re-run on the other host if you need
   its demand. Retune-vs-prune is a judgement call, so the tool never edits
   `nix/home.nix`. The keystroke expansion itself can only be checked by the user

--- a/claude/skills/espanso-audit/SKILL.md
+++ b/claude/skills/espanso-audit/SKILL.md
@@ -40,8 +40,18 @@ nix-shell -p python3Packages.pyyaml --run \
 3. `--lint` → offline, no creds. Flags a snippet that NO term resolves uniquely
    to: `_attribute` returns None on ambiguity, so it can never fire from the
    search UI.
-4. Propose changes, then run **`--replay --config <candidate base.yml>` as a
-   PRE-SHIP gate** — prove the new `search_terms` resolve BEFORE shipping.
+4. Propose changes, then run **`--gate <candidate base.yml>`** — the one
+   pre-ship command. Offline, no creds. It lints the candidate AND resolves the
+   whole prefix universe against the deployed config, reporting two axes that
+   are graded differently:
+   - **picker rows lost** — a query that listed snippets now reaches NOTHING.
+     A user-facing regression: **exit 1**, do not ship.
+   - **attribution lost/gained/moved** — telemetry only. An ambiguous query
+     still LISTS every match; only `_attribute` cannot name one. Adding any
+     snippet costs some, so this is reported and never fatal.
+   `--diff-config <candidate>` is the diff alone. `--replay --config <candidate>`
+   still cross-checks against terms he really typed — useful, but NOT sufficient:
+   it only replays observed terms, so a term he never searched is invisible to it.
 5. Edit `services.espanso` in `nix/home.nix` on a branch → PR → merge →
    `scripts/ship.sh`.
 6. `--verify-deploy` → both hosts: deployed trigger set, `espanso` active, and

--- a/scripts/session-analysis/espanso-usage.py
+++ b/scripts/session-analysis/espanso-usage.py
@@ -786,6 +786,23 @@ GATE_OK = 0
 GATE_FAIL = 1
 
 
+def _vocab(ts) -> dict:
+    """trigger -> the WHOLE words it can be found by (label + search_terms).
+
+    The trigger itself is excluded: typing it verbatim is a different modality
+    from finding a snippet by describing it.
+    """
+    out = {}
+    for trig in ts.triggers:
+        meta = ts.meta.get(trig) or {}
+        words = set(LABEL_WORD_RE.findall((meta.get("label") or "").lower()))
+        for st in meta.get("search_terms") or []:
+            if isinstance(st, str):
+                words |= set(LABEL_WORD_RE.findall(st.lower()))
+        out[trig] = {w for w in words if w}
+    return out
+
+
 def _probe_universe(ts) -> set:
     """Every query the search bar can be driven with, as far as we model it.
 
@@ -853,32 +870,33 @@ def diff_configs(ts_before, ts_after) -> dict:
     probes = sorted(_probe_universe(ts_before) | _probe_universe(ts_after))
     reach_b, reach_a = _reaching(d_before, probes), _reaching(d_after, probes)
 
-    # THE FATAL AXIS: a snippet that SURVIVES the edit and STRICTLY LOSES ways
-    # of being found — words go away and none arrive to replace them.
+    # THE FATAL AXIS: a WHOLE WORD that used to find a snippet, finds nothing
+    # now, and at least one snippet it used to find still exists.
     #
-    # Three earlier shapes of this rule were each wrong, and each was caught by
-    # measurement rather than reasoning:
-    #   * per-probe "a query reaches nothing" made every PRUNE fail, and pruning
-    #     is the skill's own primary action — a permanently-red gate;
-    #   * per-snippet "reaches NOTHING at all" (all-or-nothing) let the actual
-    #     2026-08-19 incident through: relabelling the two nebula snippets to
-    #     `SSH rig` / `SSH portable` — which is exactly what SKILL.md advises,
-    #     "change which WORDS it spells" — took 'nebula'/'mesh'/'remote' from
-    #     two picker rows to ZERO while each snippet kept one word, so nothing
-    #     was "blinded" and the gate passed the very case it was built for;
-    #   * grading any shrinkage would fail an honest reword.
-    # LOST-WITH-NO-GAIN separates them: the incident loses four words and gains
-    # none; a typo fix trades 'alpah' for 'alpha'; a reword exchanges words; a
-    # prune leaves no surviving snippet to judge.
-    narrowed = []
-    for trig in reach_b:
-        if trig not in reach_a:
-            continue                      # pruned or renamed away — not judged
-        lost = reach_b[trig] - reach_a[trig]
-        gained = reach_a[trig] - reach_b[trig]
-        if lost and not gained:
-            narrowed.append((trig, sorted(lost)[:8], len(lost)))
-    narrowed.sort()
+    # 🔴 FOUR earlier rules were each walked by a one-line edit, because each
+    # tried to INFER INTENT from the config and intent is not in the config:
+    #   * "a query reaches nothing"        -> red on every prune;
+    #   * "snippet reaches nothing at all" -> walked by keeping ONE word;
+    #   * "lost with no gain"              -> walked by ADDING one junk word;
+    #   * any magnitude threshold          -> walked by staying under it.
+    # Removing 'nebula' from a label is byte-identical whether you retired the
+    # word deliberately or destroyed the only way you find that snippet. So
+    # this stops guessing: every such loss is reported and FATAL, and the
+    # operator acknowledges the deliberate ones with --accept. A prune needs no
+    # acknowledgement, because the snippet the word described is gone too.
+    vocab_b, vocab_a = _vocab(ts_before), _vocab(ts_after)
+    graded_words = sorted(set().union(*vocab_b.values()) if vocab_b else set())
+    lost_queries = []
+    for word in graded_words:
+        owners_b = [x for x in d_before.ts.triggers if d_before._term_matches(word, x)]
+        owners_a = [x for x in d_after.ts.triggers if d_after._term_matches(word, x)]
+        if not owners_b or owners_a:
+            continue
+        # Excused automatically when every snippet the word reached is GONE:
+        # the vocabulary went with the snippet, which is what a prune is.
+        survivors = [x for x in owners_b if x in vocab_a]
+        if survivors:
+            lost_queries.append((word, sorted(owners_b), sorted(survivors)))
 
     rows_lost, attr_lost, attr_gained, attr_moved, moved_expansion = [], [], [], [], []
     for probe in probes:
@@ -902,7 +920,7 @@ def diff_configs(ts_before, ts_after) -> dict:
                 moved_expansion.append((probe, att_b, att_a))
     return {
         "probes": len(probes),
-        "narrowed": narrowed,
+        "lost_queries": lost_queries,
         "rows_lost": rows_lost,
         "attr_lost": attr_lost,
         "attr_gained": attr_gained,
@@ -911,7 +929,7 @@ def diff_configs(ts_before, ts_after) -> dict:
     }
 
 
-def render_diff(d, before_label, after_label) -> list:
+def render_diff(d, before_label, after_label, accepted=frozenset()) -> list:
     def _listing(rows, fmt, cap=20):
         out = [f"       {fmt(r)}" for r in rows[:cap]]
         if len(rows) > cap:
@@ -919,33 +937,42 @@ def render_diff(d, before_label, after_label) -> list:
         return out
 
     out = [f"## CONFIG DIFF — {before_label} -> {after_label}", "",
-           f"   {d['probes']} probes (single-token prefixes + within-snippet",
-           "   two-token queries). FATAL = a snippet that SURVIVES the edit but",
-           "   can no longer be found by describing it, or a query that now types",
-           "   DIFFERENT text. Everything else is reported, not graded: espanso",
-           "   lists every match as a row, so ambiguity costs telemetry, not",
-           "   reach — and a gate red on every prune teaches people to ignore it.",
+           f"   {d['probes']} probes. FATAL = a WHOLE WORD that used to find a",
+           "   snippet finds nothing now while that snippet still exists, or a",
+           "   query that now types DIFFERENT text. Deliberate losses are",
+           "   acknowledged with --accept; a PRUNE needs none, because the word",
+           "   went with the snippet. Everything else is reported, not graded:",
+           "   espanso lists every match as a row, so ambiguity costs telemetry,",
+           "   not reach.",
            ""]
-    if d["narrowed"]:
-        out.append(f"  🔴 SNIPPETS NARROWED — {len(d['narrowed'])} survive the edit "
-                   "but strictly LOSE ways of being found (words gone, none added):")
+    unack = [r for r in d["lost_queries"] if r[0] not in accepted]
+    ack = [r for r in d["lost_queries"] if r[0] in accepted]
+    if unack:
+        out.append(f"  🔴 QUERIES THAT STOP WORKING — {len(unack)} word(s) find "
+                   "nothing now, and the snippet they found still exists:")
         out.extend(_listing(
-            d["narrowed"],
-            lambda r: f"{r[0]}: lost {r[2]} quer(y/ies) — {' '.join(r[1])}"
-                      + (" ..." if r[2] > len(r[1]) else "")))
+            unack, lambda r: f"{r[0]!r} reached {' '.join(r[1])} -> nothing"))
+        out.append("")
+        out.append("     If these losses are DELIBERATE, acknowledge them:")
+        out.append("       --accept " + ",".join(r[0] for r in unack[:12])
+                   + (" ..." if len(unack) > 12 else ""))
         out.append("")
     else:
-        out.append("  ✅ no surviving snippet lost findability without replacing it")
+        out.append("  ✅ every word that found a surviving snippet still does")
     if d["moved_expansion"]:
         out.append(f"  🔴 EXPANSION CHANGED — {len(d['moved_expansion'])} quer(y/ies) "
                    "now type DIFFERENT text:")
         out.extend(_listing(d["moved_expansion"],
                             lambda r: f"{r[0]!r}: {r[1]} -> {r[2]}"))
         out.append("")
+    if ack:
+        out.append(f"  ({len(ack)} loss(es) acknowledged via --accept: "
+                   + ", ".join(r[0] for r in ack[:12])
+                   + (" ..." if len(ack) > 12 else "") + ")")
     out.append("")
     out.append(f"  queries reaching nothing : {len(d['rows_lost'])}  "
-               "(normal when a snippet is PRUNED; if a snippet survived, the "
-               "NARROWED section above is where it is graded)")
+               "(includes prefixes and pairs; only WHOLE WORDS with a "
+               "surviving owner are graded, above)")
     out.extend(_listing(d["rows_lost"], lambda r: f"{r[0]!r} was {' '.join(r[1])} -> 0"))
     out.append(f"  attribution gained       : {len(d['attr_gained'])}")
     out.extend(_listing(d["attr_gained"], lambda r: f"{r[0]!r} -> {r[1]}"))
@@ -1223,10 +1250,15 @@ def parse_args(argv=None) -> argparse.Namespace:
                         "SURVIVING snippet strictly loses ways of being found, "
                         "or if a query now types DIFFERENT text; everything "
                         "else is reported, not graded.")
+    p.add_argument("--accept", default="", metavar="W,W",
+                   help="comma-separated words whose loss is DELIBERATE. Each "
+                        "one stops failing the gate; the report still lists it. "
+                        "Intent is not in the config, so it is stated here "
+                        "rather than guessed.")
     p.add_argument("--gate", default=None, metavar="PATH",
                    help="PRE-SHIP GATE, offline: --lint the candidate then diff "
                         "it against the deployed config, in one command with one "
-                        "verdict. Exits 1 on a narrowed snippet or a changed "
+                        "verdict. Exits 1 on a lost query or a changed "
                         "expansion.")
     p.add_argument("--lint", action="store_true",
                    help="offline discoverability/ambiguity check (no creds needed)")
@@ -1295,9 +1327,11 @@ def main(argv=None) -> int:
         # there looking like protection. test_gate_exit_codes pins the rc 3.
         if a.gate:
             out.extend(render_lint(lint(ts_after), candidate))
+        accepted = {w.strip().lower() for w in (a.accept or "").split(",") if w.strip()}
         d = diff_configs(ts_before, ts_after)
-        out.extend(render_diff(d, before_path, candidate))
-        rc = GATE_FAIL if (d["narrowed"] or d["moved_expansion"]) else GATE_OK
+        out.extend(render_diff(d, before_path, candidate, accepted))
+        unack = [r for r in d["lost_queries"] if r[0] not in accepted]
+        rc = GATE_FAIL if (unack or d["moved_expansion"]) else GATE_OK
         out.append("GATE: FAIL — see the 🔴 sections above"
                    if rc else "GATE: PASS — nothing lost its findability")
         print("\n".join(out))

--- a/scripts/session-analysis/espanso-usage.py
+++ b/scripts/session-analysis/espanso-usage.py
@@ -776,29 +776,68 @@ def declared_terms(ts, trig):
 #
 # Getting that backwards is the whole 2026-08-19 incident in one sentence.
 GATE_OK = 0
-GATE_ROWS_LOST = 1
+GATE_FAIL = 1
+GATE_ROWS_LOST = GATE_FAIL  # back-compat alias
 
 
 def _probe_universe(ts) -> set:
-    """Every prefix of every word the config can be searched by.
+    """Every query the search bar can be driven with, as far as we model it.
 
-    Prefixes, because the search bar matches as he types: 'nebu' must be
-    checked, not just 'nebula'. Words come from the trigger, the LABEL and the
-    search_terms — the exact three sources `_token_matches` reads.
+    Single-token PREFIXES, because he matches as he types ('nebu', not just
+    'nebula'), from the trigger, the LABEL and the search_terms — the exact
+    three sources `_token_matches` reads.
+
+    Plus TWO-TOKEN probes built from each snippet's OWN vocabulary. Multi-word
+    queries are how the bar is really driven — `espanso_detect` records that
+    19+ of 46 unattributed keylog rows were multi-word ('ssh work', 'civit
+    prod') — and a single-token universe is structurally blind to a regression
+    that only shows up for them. Pairs are drawn WITHIN a snippet rather than
+    across the whole vocabulary: the cross product is quadratic and mostly
+    nonsense, while the within-snippet pairs are exactly the queries a user
+    forms when naming one thing two ways.
     """
-    words = set()
+    probes, per_snippet = set(), []
     for trig in ts.triggers:
-        words.add(trig.lstrip(":").lower())
+        words = {trig.lstrip(":").lower()}
         meta = ts.meta.get(trig) or {}
         words |= set(LABEL_WORD_RE.findall((meta.get("label") or "").lower()))
         for st in meta.get("search_terms") or []:
             if isinstance(st, str):
                 words |= set(LABEL_WORD_RE.findall(st.lower()))
-    return {w[:i] for w in words if w for i in range(1, len(w) + 1)}
+        words = {w for w in words if w}
+        per_snippet.append(words)
+        probes |= {w[:i] for w in words for i in range(1, len(w) + 1)}
+    for words in per_snippet:
+        ordered = sorted(words)
+        for i, a in enumerate(ordered):
+            for b in ordered[i + 1:]:
+                probes.add(f"{a} {b}")
+    return probes
+
+
+def _reaching(det, probes) -> dict:
+    """trigger -> the probes that reach it WITHOUT typing its trigger.
+
+    The trigger is a different modality (type it verbatim and it fires); what
+    this gate is about is whether a snippet can still be FOUND by describing
+    it. Passing an empty trigger to the detector's own `_token_matches` turns
+    off the trigger arm and leaves the label+search_terms arms untouched — the
+    authoritative matcher, not a re-spelling of it.
+    """
+    out = {}
+    for trig in det.ts.triggers:
+        meta = det.ts.meta.get(trig) or {}
+        hit = set()
+        for probe in probes:
+            toks = probe.split()
+            if toks and all(det._token_matches(tok, "", meta) for tok in toks):
+                hit.add(probe)
+        out[trig] = hit
+    return out
 
 
 def diff_configs(ts_before, ts_after) -> dict:
-    """Resolve the whole prefix universe against both configs.
+    """Resolve the whole probe universe against both configs.
 
     Uses the detector's OWN matcher rather than re-spelling the rules — a
     re-spelt copy of its label tokenizer once invented findings for every
@@ -806,10 +845,27 @@ def diff_configs(ts_before, ts_after) -> dict:
     """
     d_before, d_after = EspansoDetector(ts_before), EspansoDetector(ts_after)
     probes = sorted(_probe_universe(ts_before) | _probe_universe(ts_after))
-    rows_lost, attr_lost, attr_gained, attr_moved = [], [], [], []
+    reach_b, reach_a = _reaching(d_before, probes), _reaching(d_after, probes)
+
+    # THE FATAL AXIS: a snippet that SURVIVES the edit but can no longer be
+    # found by describing it. Deliberately per-SNIPPET, not per-probe:
+    #   * pruning a snippet drops its words too, and that is the skill's own
+    #     primary action — a per-probe rule made every prune a FAILURE, i.e.
+    #     the permanently-red gate this design exists to avoid;
+    #   * fixing a typo in a label loses the misspelt probe while the snippet
+    #     stays perfectly reachable — also not a regression;
+    #   * moving one snippet's vocabulary onto another leaves the first
+    #     unreachable while SOME row still answers the query, so a
+    #     "last row disappeared" rule misses it entirely.
+    blinded = sorted(
+        trig for trig in reach_b
+        if trig in reach_a and reach_b[trig] and not reach_a[trig]
+    )
+
+    rows_lost, attr_lost, attr_gained, attr_moved, moved_expansion = [], [], [], [], []
     for probe in probes:
-        rows_b = [t for t in d_before.ts.triggers if d_before._term_matches(probe, t)]
-        rows_a = [t for t in d_after.ts.triggers if d_after._term_matches(probe, t)]
+        rows_b = [x for x in d_before.ts.triggers if d_before._term_matches(probe, x)]
+        rows_a = [x for x in d_after.ts.triggers if d_after._term_matches(probe, x)]
         if rows_b and not rows_a:
             rows_lost.append((probe, sorted(rows_b)))
         att_b, att_a = d_before._attribute(probe), d_after._attribute(probe)
@@ -819,46 +875,67 @@ def diff_configs(ts_before, ts_after) -> dict:
             attr_gained.append((probe, att_a))
         elif att_b and att_a and att_b != att_a:
             attr_moved.append((probe, att_b, att_a))
+            # A MOVE only reaches the user if the EXPANSION changed. A plain
+            # trigger rename lands in attr_moved too and is harmless; pressing
+            # Enter still types the same text. Compare what gets typed.
+            exp_b = (ts_before.meta.get(att_b) or {}).get("replace")
+            exp_a = (ts_after.meta.get(att_a) or {}).get("replace")
+            if exp_b != exp_a:
+                moved_expansion.append((probe, att_b, att_a))
     return {
         "probes": len(probes),
+        "blinded": blinded,
         "rows_lost": rows_lost,
         "attr_lost": attr_lost,
         "attr_gained": attr_gained,
         "attr_moved": attr_moved,
+        "moved_expansion": moved_expansion,
     }
 
 
 def render_diff(d, before_label, after_label) -> list:
+    def _listing(rows, fmt, cap=20):
+        out = [f"       {fmt(r)}" for r in rows[:cap]]
+        if len(rows) > cap:
+            out.append(f"       ... and {len(rows) - cap} more (not shown)")
+        return out
+
     out = [f"## CONFIG DIFF — {before_label} -> {after_label}", "",
-           f"   {d['probes']} prefix probes. PICKER ROWS are what the user can",
-           "   reach; ATTRIBUTION is only whether telemetry can name the snippet.",
-           "   Losing a row FAILS. Losing attribution is reported, never fatal —",
-           "   adding any snippet costs some, and a permanently-red gate is worse",
-           "   than no gate.", ""]
-    if d["rows_lost"]:
-        out.append(f"  🔴 PICKER ROWS LOST — {len(d['rows_lost'])} "
-                   "quer(y/ies) now reach NOTHING:")
-        for probe, was in d["rows_lost"]:
-            out.append(f"       {probe!r} listed {len(was)} row(s) ({' '.join(was)}) -> 0")
+           f"   {d['probes']} probes (single-token prefixes + within-snippet",
+           "   two-token queries). FATAL = a snippet that SURVIVES the edit but",
+           "   can no longer be found by describing it, or a query that now types",
+           "   DIFFERENT text. Everything else is reported, not graded: espanso",
+           "   lists every match as a row, so ambiguity costs telemetry, not",
+           "   reach — and a gate red on every prune teaches people to ignore it.",
+           ""]
+    if d["blinded"]:
+        out.append(f"  🔴 SNIPPETS BLINDED — {len(d['blinded'])} still exist but no "
+                   "query reaches them (trigger aside):")
+        out.extend(_listing(d["blinded"], lambda x: x))
         out.append("")
     else:
-        out.append("  ✅ no picker rows lost")
+        out.append("  ✅ no surviving snippet lost its findability")
+    if d["moved_expansion"]:
+        out.append(f"  🔴 EXPANSION CHANGED — {len(d['moved_expansion'])} quer(y/ies) "
+                   "now type DIFFERENT text:")
+        out.extend(_listing(d["moved_expansion"],
+                            lambda r: f"{r[0]!r}: {r[1]} -> {r[2]}"))
         out.append("")
-    out.append(f"  attribution gained : {len(d['attr_gained'])}")
-    for probe, trig in d["attr_gained"][:20]:
-        out.append(f"       {probe!r} -> {trig}")
-    if len(d["attr_gained"]) > 20:
-        out.append(f"       ... and {len(d['attr_gained']) - 20} more")
-    out.append(f"  attribution lost   : {len(d['attr_lost'])}  (telemetry only, not a failure)")
-    for probe, was, now_rows in d["attr_lost"][:20]:
-        out.append(f"       {probe!r} was {was}, now {now_rows} rows")
-    if len(d["attr_lost"]) > 20:
-        out.append(f"       ... and {len(d['attr_lost']) - 20} more")
+    out.append("")
+    out.append(f"  queries reaching nothing : {len(d['rows_lost'])}  "
+               "(expected when a snippet is pruned; see BLINDED above for the "
+               "cases that matter)")
+    out.extend(_listing(d["rows_lost"], lambda r: f"{r[0]!r} was {' '.join(r[1])} -> 0"))
+    out.append(f"  attribution gained       : {len(d['attr_gained'])}")
+    out.extend(_listing(d["attr_gained"], lambda r: f"{r[0]!r} -> {r[1]}"))
+    out.append(f"  attribution lost         : {len(d['attr_lost'])}  "
+               "(telemetry only — the fire still happens, logged trigger=None)")
+    out.extend(_listing(d["attr_lost"], lambda r: f"{r[0]!r} was {r[1]}, now {r[2]} rows"))
     if d["attr_moved"]:
-        out.append(f"  🔴 attribution MOVED : {len(d['attr_moved'])} "
-                   "(a query now resolves to a DIFFERENT snippet)")
-        for probe, was, now in d["attr_moved"]:
-            out.append(f"       {probe!r} {was} -> {now}")
+        out.append(f"  attribution moved        : {len(d['attr_moved'])}  "
+                   f"({len(d['moved_expansion'])} of them change the EXPANSION — "
+                   "those are graded above)")
+        out.extend(_listing(d["attr_moved"], lambda r: f"{r[0]!r} {r[1]} -> {r[2]}"))
     out.append("")
     return out
 
@@ -1197,9 +1274,9 @@ def main(argv=None) -> int:
             out.extend(render_lint(lint(ts_after), candidate))
         d = diff_configs(ts_before, ts_after)
         out.extend(render_diff(d, before_path, candidate))
-        rc = GATE_ROWS_LOST if d["rows_lost"] else GATE_OK
-        out.append("GATE: FAIL — a query lost its last picker row (see above)"
-                   if rc else "GATE: PASS — no picker rows lost")
+        rc = GATE_FAIL if (d["blinded"] or d["moved_expansion"]) else GATE_OK
+        out.append("GATE: FAIL — see the 🔴 sections above"
+                   if rc else "GATE: PASS — nothing lost its findability")
         print("\n".join(out))
         return rc
 

--- a/scripts/session-analysis/espanso-usage.py
+++ b/scripts/session-analysis/espanso-usage.py
@@ -756,28 +756,34 @@ def declared_terms(ts, trig):
 # --------------------------------------------------------------------------- #
 # CONFIG DIFF — the two-axis check neither --lint nor --replay performs
 # --------------------------------------------------------------------------- #
-# 🔴 WHY THIS EXISTS, and why the two axes are graded DIFFERENTLY.
+# 🔴 WHY THIS EXISTS, and what is FATAL versus merely reported.
 #
 # --lint sees one config. --replay sees only terms he ACTUALLY TYPED in the
-# window, so a term he never happened to search is invisible to it. On
-# 2026-08-19 both called a change clean while it took 'nebula', 'mesh' and
-# 'remote' from TWO picker rows to ZERO — a real loss of discoverability,
-# introduced while chasing tidier telemetry.
+# window. On 2026-08-19 both called a change clean while it took 'nebula',
+# 'mesh' and 'remote' from TWO picker rows to ZERO.
 #
-# The two axes are not the same kind of fact:
-#   * PICKER ROWS — what the user can reach. espanso lists EVERY match as a row
-#     and the user arrows to one. Losing the last row for a query means that
-#     query now finds nothing. This is a REGRESSION and fails the gate.
-#   * ATTRIBUTION — whether `_attribute` can NAME one snippet. Ambiguity costs
-#     only telemetry: the fire still happens, it is logged with trigger=None.
-#     Adding any snippet adds vocabulary and so loses some attribution; grading
-#     that as failure would make this a permanently-red gate, which trains
-#     everyone to click through. It is REPORTED, never fatal.
+# FATAL (exit 1):
+#   NARROWED   a snippet that SURVIVES the edit and strictly loses ways of being
+#              found — reaching words go away and none arrive. That is the
+#              2026-08-19 shape, and it stays fatal even when the snippet keeps
+#              one word (an earlier all-or-nothing rule let exactly that pass).
+#   EXPANSION  a query that resolved to one snippet now resolves to another that
+#              types DIFFERENT text. `attr_moved` alone is NOT this: a plain
+#              trigger rename lands there and is harmless, so the discriminator
+#              is the `replace` text.
 #
-# Getting that backwards is the whole 2026-08-19 incident in one sentence.
+# REPORTED, never graded:
+#   queries reaching nothing, attribution lost/gained/moved. espanso lists EVERY
+#   match as a row, so ambiguity costs telemetry, not reach; and pruning or
+#   rewording drops words BY DESIGN. Grading those made this gate red on the
+#   skill's own primary actions — pruning a DEAD snippet, fixing a typo — and a
+#   permanently-red gate teaches everyone to click through.
+#
+# Both halves have been wrong in this file's history; neither is obvious. If you
+# change the grading, re-run the six-scenario matrix in
+# test_espanso_usage.py, which pins all of them.
 GATE_OK = 0
 GATE_FAIL = 1
-GATE_ROWS_LOST = GATE_FAIL  # back-compat alias
 
 
 def _probe_universe(ts) -> set:
@@ -847,20 +853,32 @@ def diff_configs(ts_before, ts_after) -> dict:
     probes = sorted(_probe_universe(ts_before) | _probe_universe(ts_after))
     reach_b, reach_a = _reaching(d_before, probes), _reaching(d_after, probes)
 
-    # THE FATAL AXIS: a snippet that SURVIVES the edit but can no longer be
-    # found by describing it. Deliberately per-SNIPPET, not per-probe:
-    #   * pruning a snippet drops its words too, and that is the skill's own
-    #     primary action — a per-probe rule made every prune a FAILURE, i.e.
-    #     the permanently-red gate this design exists to avoid;
-    #   * fixing a typo in a label loses the misspelt probe while the snippet
-    #     stays perfectly reachable — also not a regression;
-    #   * moving one snippet's vocabulary onto another leaves the first
-    #     unreachable while SOME row still answers the query, so a
-    #     "last row disappeared" rule misses it entirely.
-    blinded = sorted(
-        trig for trig in reach_b
-        if trig in reach_a and reach_b[trig] and not reach_a[trig]
-    )
+    # THE FATAL AXIS: a snippet that SURVIVES the edit and STRICTLY LOSES ways
+    # of being found — words go away and none arrive to replace them.
+    #
+    # Three earlier shapes of this rule were each wrong, and each was caught by
+    # measurement rather than reasoning:
+    #   * per-probe "a query reaches nothing" made every PRUNE fail, and pruning
+    #     is the skill's own primary action — a permanently-red gate;
+    #   * per-snippet "reaches NOTHING at all" (all-or-nothing) let the actual
+    #     2026-08-19 incident through: relabelling the two nebula snippets to
+    #     `SSH rig` / `SSH portable` — which is exactly what SKILL.md advises,
+    #     "change which WORDS it spells" — took 'nebula'/'mesh'/'remote' from
+    #     two picker rows to ZERO while each snippet kept one word, so nothing
+    #     was "blinded" and the gate passed the very case it was built for;
+    #   * grading any shrinkage would fail an honest reword.
+    # LOST-WITH-NO-GAIN separates them: the incident loses four words and gains
+    # none; a typo fix trades 'alpah' for 'alpha'; a reword exchanges words; a
+    # prune leaves no surviving snippet to judge.
+    narrowed = []
+    for trig in reach_b:
+        if trig not in reach_a:
+            continue                      # pruned or renamed away — not judged
+        lost = reach_b[trig] - reach_a[trig]
+        gained = reach_a[trig] - reach_b[trig]
+        if lost and not gained:
+            narrowed.append((trig, sorted(lost)[:8], len(lost)))
+    narrowed.sort()
 
     rows_lost, attr_lost, attr_gained, attr_moved, moved_expansion = [], [], [], [], []
     for probe in probes:
@@ -884,7 +902,7 @@ def diff_configs(ts_before, ts_after) -> dict:
                 moved_expansion.append((probe, att_b, att_a))
     return {
         "probes": len(probes),
-        "blinded": blinded,
+        "narrowed": narrowed,
         "rows_lost": rows_lost,
         "attr_lost": attr_lost,
         "attr_gained": attr_gained,
@@ -908,13 +926,16 @@ def render_diff(d, before_label, after_label) -> list:
            "   lists every match as a row, so ambiguity costs telemetry, not",
            "   reach — and a gate red on every prune teaches people to ignore it.",
            ""]
-    if d["blinded"]:
-        out.append(f"  🔴 SNIPPETS BLINDED — {len(d['blinded'])} still exist but no "
-                   "query reaches them (trigger aside):")
-        out.extend(_listing(d["blinded"], lambda x: x))
+    if d["narrowed"]:
+        out.append(f"  🔴 SNIPPETS NARROWED — {len(d['narrowed'])} survive the edit "
+                   "but strictly LOSE ways of being found (words gone, none added):")
+        out.extend(_listing(
+            d["narrowed"],
+            lambda r: f"{r[0]}: lost {r[2]} quer(y/ies) — {' '.join(r[1])}"
+                      + (" ..." if r[2] > len(r[1]) else "")))
         out.append("")
     else:
-        out.append("  ✅ no surviving snippet lost its findability")
+        out.append("  ✅ no surviving snippet lost findability without replacing it")
     if d["moved_expansion"]:
         out.append(f"  🔴 EXPANSION CHANGED — {len(d['moved_expansion'])} quer(y/ies) "
                    "now type DIFFERENT text:")
@@ -923,8 +944,8 @@ def render_diff(d, before_label, after_label) -> list:
         out.append("")
     out.append("")
     out.append(f"  queries reaching nothing : {len(d['rows_lost'])}  "
-               "(expected when a snippet is pruned; see BLINDED above for the "
-               "cases that matter)")
+               "(normal when a snippet is PRUNED; if a snippet survived, the "
+               "NARROWED section above is where it is graded)")
     out.extend(_listing(d["rows_lost"], lambda r: f"{r[0]!r} was {' '.join(r[1])} -> 0"))
     out.append(f"  attribution gained       : {len(d['attr_gained'])}")
     out.extend(_listing(d["attr_gained"], lambda r: f"{r[0]!r} -> {r[1]}"))
@@ -1197,14 +1218,16 @@ def parse_args(argv=None) -> argparse.Namespace:
     p.add_argument("--replay", action="store_true",
                    help="resolve observed search terms through the real detector")
     p.add_argument("--diff-config", default=None, metavar="PATH",
-                   help="resolve the whole prefix universe against the deployed "
-                        "config (or --config) AND this candidate; report picker "
-                        "rows lost / attribution lost, gained, moved. Exits 1 "
-                        "if any query loses its last picker row.")
+                   help="resolve a probe universe against the deployed config "
+                        "(or --config) AND this candidate. Exits 1 if a "
+                        "SURVIVING snippet strictly loses ways of being found, "
+                        "or if a query now types DIFFERENT text; everything "
+                        "else is reported, not graded.")
     p.add_argument("--gate", default=None, metavar="PATH",
                    help="PRE-SHIP GATE, offline: --lint the candidate then diff "
                         "it against the deployed config, in one command with one "
-                        "verdict. Exits 1 on a lost picker row.")
+                        "verdict. Exits 1 on a narrowed snippet or a changed "
+                        "expansion.")
     p.add_argument("--lint", action="store_true",
                    help="offline discoverability/ambiguity check (no creds needed)")
     p.add_argument("--config", default=None, metavar="PATH",
@@ -1274,7 +1297,7 @@ def main(argv=None) -> int:
             out.extend(render_lint(lint(ts_after), candidate))
         d = diff_configs(ts_before, ts_after)
         out.extend(render_diff(d, before_path, candidate))
-        rc = GATE_FAIL if (d["blinded"] or d["moved_expansion"]) else GATE_OK
+        rc = GATE_FAIL if (d["narrowed"] or d["moved_expansion"]) else GATE_OK
         out.append("GATE: FAIL — see the 🔴 sections above"
                    if rc else "GATE: PASS — nothing lost its findability")
         print("\n".join(out))

--- a/scripts/session-analysis/espanso-usage.py
+++ b/scripts/session-analysis/espanso-usage.py
@@ -753,6 +753,116 @@ def declared_terms(ts, trig):
     return terms
 
 
+# --------------------------------------------------------------------------- #
+# CONFIG DIFF — the two-axis check neither --lint nor --replay performs
+# --------------------------------------------------------------------------- #
+# 🔴 WHY THIS EXISTS, and why the two axes are graded DIFFERENTLY.
+#
+# --lint sees one config. --replay sees only terms he ACTUALLY TYPED in the
+# window, so a term he never happened to search is invisible to it. On
+# 2026-08-19 both called a change clean while it took 'nebula', 'mesh' and
+# 'remote' from TWO picker rows to ZERO — a real loss of discoverability,
+# introduced while chasing tidier telemetry.
+#
+# The two axes are not the same kind of fact:
+#   * PICKER ROWS — what the user can reach. espanso lists EVERY match as a row
+#     and the user arrows to one. Losing the last row for a query means that
+#     query now finds nothing. This is a REGRESSION and fails the gate.
+#   * ATTRIBUTION — whether `_attribute` can NAME one snippet. Ambiguity costs
+#     only telemetry: the fire still happens, it is logged with trigger=None.
+#     Adding any snippet adds vocabulary and so loses some attribution; grading
+#     that as failure would make this a permanently-red gate, which trains
+#     everyone to click through. It is REPORTED, never fatal.
+#
+# Getting that backwards is the whole 2026-08-19 incident in one sentence.
+GATE_OK = 0
+GATE_ROWS_LOST = 1
+
+
+def _probe_universe(ts) -> set:
+    """Every prefix of every word the config can be searched by.
+
+    Prefixes, because the search bar matches as he types: 'nebu' must be
+    checked, not just 'nebula'. Words come from the trigger, the LABEL and the
+    search_terms — the exact three sources `_token_matches` reads.
+    """
+    words = set()
+    for trig in ts.triggers:
+        words.add(trig.lstrip(":").lower())
+        meta = ts.meta.get(trig) or {}
+        words |= set(LABEL_WORD_RE.findall((meta.get("label") or "").lower()))
+        for st in meta.get("search_terms") or []:
+            if isinstance(st, str):
+                words |= set(LABEL_WORD_RE.findall(st.lower()))
+    return {w[:i] for w in words if w for i in range(1, len(w) + 1)}
+
+
+def diff_configs(ts_before, ts_after) -> dict:
+    """Resolve the whole prefix universe against both configs.
+
+    Uses the detector's OWN matcher rather than re-spelling the rules — a
+    re-spelt copy of its label tokenizer once invented findings for every
+    hyphenated label word (see LABEL_WORD_RE above).
+    """
+    d_before, d_after = EspansoDetector(ts_before), EspansoDetector(ts_after)
+    probes = sorted(_probe_universe(ts_before) | _probe_universe(ts_after))
+    rows_lost, attr_lost, attr_gained, attr_moved = [], [], [], []
+    for probe in probes:
+        rows_b = [t for t in d_before.ts.triggers if d_before._term_matches(probe, t)]
+        rows_a = [t for t in d_after.ts.triggers if d_after._term_matches(probe, t)]
+        if rows_b and not rows_a:
+            rows_lost.append((probe, sorted(rows_b)))
+        att_b, att_a = d_before._attribute(probe), d_after._attribute(probe)
+        if att_b and not att_a:
+            attr_lost.append((probe, att_b, len(rows_a)))
+        elif att_a and not att_b:
+            attr_gained.append((probe, att_a))
+        elif att_b and att_a and att_b != att_a:
+            attr_moved.append((probe, att_b, att_a))
+    return {
+        "probes": len(probes),
+        "rows_lost": rows_lost,
+        "attr_lost": attr_lost,
+        "attr_gained": attr_gained,
+        "attr_moved": attr_moved,
+    }
+
+
+def render_diff(d, before_label, after_label) -> list:
+    out = [f"## CONFIG DIFF — {before_label} -> {after_label}", "",
+           f"   {d['probes']} prefix probes. PICKER ROWS are what the user can",
+           "   reach; ATTRIBUTION is only whether telemetry can name the snippet.",
+           "   Losing a row FAILS. Losing attribution is reported, never fatal —",
+           "   adding any snippet costs some, and a permanently-red gate is worse",
+           "   than no gate.", ""]
+    if d["rows_lost"]:
+        out.append(f"  🔴 PICKER ROWS LOST — {len(d['rows_lost'])} "
+                   "quer(y/ies) now reach NOTHING:")
+        for probe, was in d["rows_lost"]:
+            out.append(f"       {probe!r} listed {len(was)} row(s) ({' '.join(was)}) -> 0")
+        out.append("")
+    else:
+        out.append("  ✅ no picker rows lost")
+        out.append("")
+    out.append(f"  attribution gained : {len(d['attr_gained'])}")
+    for probe, trig in d["attr_gained"][:20]:
+        out.append(f"       {probe!r} -> {trig}")
+    if len(d["attr_gained"]) > 20:
+        out.append(f"       ... and {len(d['attr_gained']) - 20} more")
+    out.append(f"  attribution lost   : {len(d['attr_lost'])}  (telemetry only, not a failure)")
+    for probe, was, now_rows in d["attr_lost"][:20]:
+        out.append(f"       {probe!r} was {was}, now {now_rows} rows")
+    if len(d["attr_lost"]) > 20:
+        out.append(f"       ... and {len(d['attr_lost']) - 20} more")
+    if d["attr_moved"]:
+        out.append(f"  🔴 attribution MOVED : {len(d['attr_moved'])} "
+                   "(a query now resolves to a DIFFERENT snippet)")
+        for probe, was, now in d["attr_moved"]:
+            out.append(f"       {probe!r} {was} -> {now}")
+    out.append("")
+    return out
+
+
 def lint(ts):
     """Offline findings, worst first.
 
@@ -1009,6 +1119,15 @@ def parse_args(argv=None) -> argparse.Namespace:
                    help="raw search-term breakdown instead of the report")
     p.add_argument("--replay", action="store_true",
                    help="resolve observed search terms through the real detector")
+    p.add_argument("--diff-config", default=None, metavar="PATH",
+                   help="resolve the whole prefix universe against the deployed "
+                        "config (or --config) AND this candidate; report picker "
+                        "rows lost / attribution lost, gained, moved. Exits 1 "
+                        "if any query loses its last picker row.")
+    p.add_argument("--gate", default=None, metavar="PATH",
+                   help="PRE-SHIP GATE, offline: --lint the candidate then diff "
+                        "it against the deployed config, in one command with one "
+                        "verdict. Exits 1 on a lost picker row.")
     p.add_argument("--lint", action="store_true",
                    help="offline discoverability/ambiguity check (no creds needed)")
     p.add_argument("--config", default=None, metavar="PATH",
@@ -1052,6 +1171,35 @@ def main(argv=None) -> int:
     # ---- modes that need no ClickHouse ----
     if a.verify_deploy:
         rc = _run_verify(a, out)
+        print("\n".join(out))
+        return rc
+
+    if a.diff_config or a.gate:
+        candidate = a.gate or a.diff_config
+        before_path = a.config or default_config_path()
+        try:
+            ts_before = load_config(a.config)
+        except ConfigUnavailable as e:
+            print("\n".join(unmeasured_banner(e, what="CONFIG (deployed side)")))
+            return 3
+        try:
+            ts_after = load_config(candidate)
+        except ConfigUnavailable as e:
+            print("\n".join(unmeasured_banner(e, what="CONFIG (candidate)")))
+            return 3
+        # NOTE: a candidate that parses to ZERO snippets is already refused by
+        # load_config (it raises ConfigUnavailable), so the empty side can never
+        # reach the diff and produce a confident wall of "rows lost". A guard
+        # here as well was UNREACHABLE — a mutation sweep showed disabling it
+        # changed nothing — so it is deliberately absent rather than sitting
+        # there looking like protection. test_gate_exit_codes pins the rc 3.
+        if a.gate:
+            out.extend(render_lint(lint(ts_after), candidate))
+        d = diff_configs(ts_before, ts_after)
+        out.extend(render_diff(d, before_path, candidate))
+        rc = GATE_ROWS_LOST if d["rows_lost"] else GATE_OK
+        out.append("GATE: FAIL — a query lost its last picker row (see above)"
+                   if rc else "GATE: PASS — no picker rows lost")
         print("\n".join(out))
         return rc
 

--- a/scripts/session-analysis/tests/test_espanso_usage.py
+++ b/scripts/session-analysis/tests/test_espanso_usage.py
@@ -759,30 +759,41 @@ def test_diff_identical_configs_reports_nothing():
     ts = _ts([_A, _B])
     d = M.diff_configs(ts, ts)
     assert d["probes"] > 20, f"only {d['probes']} probes — buckets would be vacuous"
-    for bucket in ("blinded", "rows_lost", "attr_lost", "attr_gained",
+    for bucket in ("narrowed", "rows_lost", "attr_lost", "attr_gained",
                    "attr_moved", "moved_expansion"):
         assert d[bucket] == [], f"{bucket} should be empty for an identical diff"
 
 
-def test_stripping_a_label_blinds_the_snippet():
+def test_stripping_a_label_narrows_the_snippet():
     """The 2026-08-19 regression: label+terms removed, snippet survives."""
     after = _mut([_A, _B], ":aa", label=None, search_terms=[])
     d = M.diff_configs(_ts([_A, _B]), _ts(after))
-    assert d["blinded"] == [":aa"], f"expected :aa blinded, got {d['blinded']}"
+    assert [r[0] for r in d["narrowed"]] == [":aa"], d["narrowed"]
 
 
 def test_pruning_a_snippet_is_NOT_a_failure():
     """`DEAD` is the skill's only prune verdict. A per-probe rule failed here,
     which would have made this a permanently-red gate."""
     d = M.diff_configs(_ts([_A, _B]), _ts([_B]))
-    assert d["blinded"] == [], "a pruned snippet cannot be 'blinded' — it is gone"
+    assert d["narrowed"] == [], "a pruned snippet is not judged — it is gone"
     assert d["rows_lost"], "its words DO stop reaching anything; that is reported"
 
 
 def test_fixing_a_typo_in_a_label_is_NOT_a_failure():
-    typo = _mut([_A, _B], ":aa", label="Alpah thing")
-    d = M.diff_configs(_ts(typo), _ts([_A, _B]))
-    assert d["blinded"] == [], f"a typo fix blinded something: {d['blinded']}"
+    """A typo fix EXCHANGES a word, so it is a gain-and-loss, not a strict loss.
+
+    RESIDUAL, deliberately not fixed: if the corrected spelling was ALREADY
+    reachable by another route (e.g. it duplicates an existing search_term),
+    the fix is a strict loss of the misspelling and IS flagged. That is a real
+    if trivial reduction in findability, and softening the rule to excuse it
+    would reopen the 2026-08-19 case — see
+    test_keeping_ONE_word_does_not_excuse_losing_the_rest. The report names the
+    lost queries, so a glance settles it.
+    """
+    only_typo = [dict(_A, label="Alpah thing", search_terms=["firstword"]), _B]
+    corrected = [dict(_A, label="Alpha thing", search_terms=["firstword"]), _B]
+    d = M.diff_configs(_ts(only_typo), _ts(corrected))
+    assert d["narrowed"] == [], f"a typo fix must not be graded: {d['narrowed']}"
 
 
 def test_renaming_a_trigger_keeping_the_expansion_is_NOT_a_failure():
@@ -809,7 +820,7 @@ def test_lost_attribution_is_reported_but_is_NOT_a_failure():
     after = [_A, dict(_B, label="Alpha other", search_terms=["alpha"])]
     d = M.diff_configs(_ts([_A, _B]), _ts(after))
     assert d["attr_lost"], "'alpha' should have become ambiguous"
-    assert d["blinded"] == [] and d["moved_expansion"] == [], (
+    assert d["narrowed"] == [] and d["moved_expansion"] == [], (
         "an ambiguous query still LISTS both rows — not a regression"
     )
 
@@ -825,13 +836,13 @@ def test_probe_universe_covers_prefixes_AND_multiword_queries():
     assert "alpha thing" in u or "alpha firstword" in u, sorted(multi)[:10]
 
 
-def test_render_diff_names_the_blinded_snippet_and_says_what_it_hid():
+def test_render_diff_names_the_narrowed_snippet_and_says_what_it_hid():
     after = _mut([_A, _B], ":aa", label=None, search_terms=[])
     text = "\n".join(M.render_diff(M.diff_configs(_ts([_A, _B]), _ts(after)), "a", "b"))
-    assert "SNIPPETS BLINDED" in text and ":aa" in text
+    assert "SNIPPETS NARROWED" in text and ":aa" in text
     clean = "\n".join(M.render_diff(M.diff_configs(_ts([_A, _B]), _ts([_A, _B])), "a", "b"))
-    assert "SNIPPETS BLINDED" not in clean
-    assert "no surviving snippet lost its findability" in clean
+    assert "SNIPPETS NARROWED" not in clean
+    assert "no surviving snippet lost findability" in clean
     # Truncation must SAY it truncated — a silently cut report hides findings.
     many = [dict(_A, trigger=f":t{i}", label=f"Label{i} word{i}",
                  search_terms=[f"term{i}"]) for i in range(40)]
@@ -851,17 +862,17 @@ def test_gate_exit_codes_and_that_it_actually_lints(tmp_path, capsys):
     yaml = pytest.importorskip("yaml")
     before = tmp_path / "before.yml"
     before.write_text(yaml.safe_dump({"matches": [_A, _B]}))
-    blinded = tmp_path / "blinded.yml"
-    blinded.write_text(yaml.safe_dump(
+    narrowed = tmp_path / "narrowed.yml"
+    narrowed.write_text(yaml.safe_dump(
         {"matches": _mut([_A, _B], ":aa", label=None, search_terms=[])}))
     pruned = tmp_path / "pruned.yml"
     pruned.write_text(yaml.safe_dump({"matches": [_B]}))
     empty = tmp_path / "empty.yml"
     empty.write_text("matches: []\n")
 
-    assert M.main(["--config", str(before), "--gate", str(blinded)]) == 1
+    assert M.main(["--config", str(before), "--gate", str(narrowed)]) == 1
     out = capsys.readouterr().out
-    assert "SNIPPETS BLINDED" in out
+    assert "SNIPPETS NARROWED" in out
     # --gate promises lint + diff in ONE verdict; prove the lint really ran.
     assert "LINT" in out, "--gate claims to lint the candidate but did not"
 
@@ -872,5 +883,106 @@ def test_gate_exit_codes_and_that_it_actually_lints(tmp_path, capsys):
     assert "UNMEASURED" in capsys.readouterr().out
 
     # --diff-config shares the engine but has its own CLI path.
-    assert M.main(["--config", str(before), "--diff-config", str(blinded)]) == 1
+    assert M.main(["--config", str(before), "--diff-config", str(narrowed)]) == 1
     assert "LINT" not in capsys.readouterr().out, "--diff-config must not lint"
+
+
+def test_keeping_ONE_word_does_not_excuse_losing_the_rest():
+    """🔴 The exact case a delta audit used to falsify an earlier fatal axis.
+
+    Following SKILL.md's own advice — "change which WORDS a snippet spells,
+    never remove its label" — relabelling two snippets to `SSH rig` /
+    `SSH portable` took 'nebula', 'mesh' and 'remote' from two picker rows to
+    ZERO. An all-or-nothing "reaches NOTHING" rule passed it, because each
+    snippet kept one word. LOST-WITH-NO-GAIN catches it.
+    """
+    before = [
+        {"trigger": ":wn", "replace": "ssh a", "label": "SSH rig via nebula mesh",
+         "search_terms": ["nebula", "mesh", "remote"]},
+        {"trigger": ":ln", "replace": "ssh b", "label": "SSH portable via nebula mesh",
+         "search_terms": ["nebula", "mesh", "remote"]},
+    ]
+    after = [
+        {"trigger": ":wn", "replace": "ssh a", "label": "SSH rig", "search_terms": ["rig"]},
+        {"trigger": ":ln", "replace": "ssh b", "label": "SSH portable",
+         "search_terms": ["portable"]},
+    ]
+    d = M.diff_configs(_ts(before), _ts(after))
+    narrowed = {r[0] for r in d["narrowed"]}
+    assert narrowed == {":wn", ":ln"}, (
+        "both snippets strictly lost 'nebula'/'mesh'/'remote' and gained "
+        f"nothing new, so both must be graded: {d['narrowed']}"
+    )
+
+
+def test_a_vocabulary_less_snippet_never_makes_the_gate_red():
+    """`dashbaord` has no label and no search_terms by design.
+
+    The survives-guard (`reach_b[trig] and ...`) is what stops it being graded;
+    dropping that guard made an IDENTICAL-config diff exit 1 on the real config.
+    No fixture covered it, so the suite was blind to the failure mode this
+    whole design exists to avoid.
+    """
+    cfg = [_A, {"trigger": "typotypo", "replace": "typo"}]
+    d = M.diff_configs(_ts(cfg), _ts(cfg))
+    assert d["narrowed"] == [], (
+        "a config diffed against ITSELF must never be graded: " f"{d['narrowed']}"
+    )
+    d2 = M.diff_configs(_ts(cfg), _ts([_A]))
+    assert d2["narrowed"] == [], "removing a vocabulary-less snippet is a prune"
+
+
+def test_reaching_requires_ALL_tokens_of_a_multiword_query():
+    """`_term_matches` ANDs whitespace-separated tokens — that is the entire
+    reason pair probes exist. `any` instead of `all` would make the fatal axis
+    far too lenient and no other test would notice."""
+    ts = _ts([_A])
+    det = M.EspansoDetector(ts)
+    reach = M._reaching(det, {"alpha", "bravo", "alpha bravo", "alpha thing"})
+    assert "alpha" in reach[":aa"]
+    assert "alpha thing" in reach[":aa"], "both tokens match :aa"
+    assert "alpha bravo" not in reach[":aa"], (
+        "'bravo' does not describe :aa, so the AND must reject the pair"
+    )
+    # The TRIGGER arm must stay off: typing a trigger verbatim is a different
+    # modality from finding a snippet by describing it, and the report says
+    # "trigger aside". Unpinned, a mutant re-enabling it survived the suite.
+    reach2 = M._reaching(det, {"aa", "a", "alpha"})
+    assert "aa" not in reach2[":aa"], (
+        "':aa' is the trigger — it must NOT count as a way of FINDING the "
+        "snippet, or a snippet stripped of its label reads as still reachable"
+    )
+    assert "alpha" in reach2[":aa"], "the label/search_terms arms must stay on"
+
+
+def test_attribution_gained_and_moved_have_positive_controls():
+    """This file's contract: every zero comes with an N that MUST count."""
+    before = [_A]
+    after = [_A, {"trigger": ":cc", "replace": "z", "label": "Quebec",
+                  "search_terms": ["quebec"]}]
+    d = M.diff_configs(_ts(before), _ts(after))
+    assert any(pr == "quebec" and tr == ":cc" for pr, tr in d["attr_gained"]), d["attr_gained"]
+    renamed = _mut([_A], ":aa", trigger=":dd")
+    dm = M.diff_configs(_ts([_A]), _ts(renamed))
+    assert any(pr == "alpha" and a == ":aa" and b == ":dd"
+               for pr, a, b in dm["attr_moved"]), dm["attr_moved"]
+
+
+def test_a_changed_expansion_alone_drives_the_exit_code(tmp_path, capsys):
+    """N3: `moved_expansion`'s contribution to rc was unpinned — a mutant
+    grading only `narrowed` kept the suite green while the report still
+    printed 🔴 EXPANSION CHANGED and exited 0."""
+    yaml = pytest.importorskip("yaml")
+    before = [_A, _B]
+    after = _mut(before, ":bb", label="Alpha thing", search_terms=["alpha", "firstword"])
+    after = _mut(after, ":aa", label="Unrelated wording", search_terms=["zzz", "yyy"])
+    b = tmp_path / "b.yml"; b.write_text(yaml.safe_dump({"matches": before}))
+    a = tmp_path / "a.yml"; a.write_text(yaml.safe_dump({"matches": after}))
+    d = M.diff_configs(_ts(before), _ts(after))
+    assert d["moved_expansion"], "fixture must produce an expansion move"
+    assert d["narrowed"] == [], (
+        "fixture must isolate the expansion axis — :aa gains zzz/yyy, so it is "
+        f"not narrowed: {d['narrowed']}"
+    )
+    assert M.main(["--config", str(b), "--gate", str(a)]) == 1
+    assert "EXPANSION CHANGED" in capsys.readouterr().out

--- a/scripts/session-analysis/tests/test_espanso_usage.py
+++ b/scripts/session-analysis/tests/test_espanso_usage.py
@@ -726,127 +726,151 @@ def test_bad_source_is_rejected():
 
 
 # --------------------------------------------------------------------------- #
-# --diff-config / --gate : the two-axis check
+# --diff-config / --gate
 # --------------------------------------------------------------------------- #
-# 🔴 These pin the 2026-08-19 incident. `--lint` and `--replay` both called a
-# change clean while it took 'nebula'/'mesh'/'remote' from TWO picker rows to
-# ZERO. The axes are graded differently ON PURPOSE: a lost ROW is a user-facing
-# regression and FAILS; lost ATTRIBUTION costs only telemetry and is REPORTED,
-# because adding any snippet loses some and a permanently-red gate is worse than
-# no gate at all.
-_SSH_BEFORE = [
-    {"trigger": ":sshwn", "replace": "ssh a", "label": "SSH rig via nebula mesh",
-     "search_terms": ["nebula", "mesh", "remote"]},
-    {"trigger": ":sshwl", "replace": "ssh b", "label": "SSH workbench (LAN)",
-     "search_terms": ["ssh", "workbench", "lan"]},
-]
-_SSH_STRIPPED = [
-    {"trigger": ":sshwn", "replace": "ssh a"},          # label+terms removed
-    {"trigger": ":sshwl", "replace": "ssh b", "label": "SSH workbench (LAN)",
-     "search_terms": ["ssh", "workbench", "lan"]},
-]
+# 🔴 What is FATAL and what is merely reported is the whole design, and an audit
+# showed the first cut got it wrong in BOTH directions: pruning a snippet (the
+# skill's only prune verdict) FAILED, while a snippet quietly losing all of its
+# own vocabulary PASSED. The axis is therefore per-SNIPPET findability, not
+# per-probe row loss. These tests pin the six scenarios that pinned it down.
+_A = {"trigger": ":aa", "replace": "alpha text", "label": "Alpha thing",
+      "search_terms": ["alpha", "firstword"]}
+_B = {"trigger": ":bb", "replace": "bravo text", "label": "Bravo thing",
+      "search_terms": ["bravo"]}
+
+
+def _mut(base, trig, **changes):
+    out = []
+    for m in base:
+        m = dict(m)
+        if m["trigger"] == trig:
+            for k, v in changes.items():
+                if v is None:
+                    m.pop(k, None)
+                else:
+                    m[k] = v
+        out.append(m)
+    return out
 
 
 def test_diff_identical_configs_reports_nothing():
-    """POSITIVE CONTROL for the whole diff: a config against itself is clean.
-
-    Without this, a probe universe that came out EMPTY would make every
-    assertion below pass vacuously — the reassuring zero this file is built to
-    refuse. The probe count is asserted non-trivial for the same reason.
-    """
-    ts = _ts(_SSH_BEFORE)
+    """POSITIVE CONTROL: a config against itself is clean, and the universe is
+    non-trivial — otherwise every assertion below passes vacuously."""
+    ts = _ts([_A, _B])
     d = M.diff_configs(ts, ts)
-    assert d["probes"] > 20, (
-        f"only {d['probes']} probes — the universe is near-empty, so the "
-        "buckets below would be vacuously clean"
+    assert d["probes"] > 20, f"only {d['probes']} probes — buckets would be vacuous"
+    for bucket in ("blinded", "rows_lost", "attr_lost", "attr_gained",
+                   "attr_moved", "moved_expansion"):
+        assert d[bucket] == [], f"{bucket} should be empty for an identical diff"
+
+
+def test_stripping_a_label_blinds_the_snippet():
+    """The 2026-08-19 regression: label+terms removed, snippet survives."""
+    after = _mut([_A, _B], ":aa", label=None, search_terms=[])
+    d = M.diff_configs(_ts([_A, _B]), _ts(after))
+    assert d["blinded"] == [":aa"], f"expected :aa blinded, got {d['blinded']}"
+
+
+def test_pruning_a_snippet_is_NOT_a_failure():
+    """`DEAD` is the skill's only prune verdict. A per-probe rule failed here,
+    which would have made this a permanently-red gate."""
+    d = M.diff_configs(_ts([_A, _B]), _ts([_B]))
+    assert d["blinded"] == [], "a pruned snippet cannot be 'blinded' — it is gone"
+    assert d["rows_lost"], "its words DO stop reaching anything; that is reported"
+
+
+def test_fixing_a_typo_in_a_label_is_NOT_a_failure():
+    typo = _mut([_A, _B], ":aa", label="Alpah thing")
+    d = M.diff_configs(_ts(typo), _ts([_A, _B]))
+    assert d["blinded"] == [], f"a typo fix blinded something: {d['blinded']}"
+
+
+def test_renaming_a_trigger_keeping_the_expansion_is_NOT_a_failure():
+    renamed = _mut([_A, _B], ":aa", trigger=":zz")
+    d = M.diff_configs(_ts([_A, _B]), _ts(renamed))
+    assert d["moved_expansion"] == [], (
+        "a rename types the SAME text, so it must not be graded: "
+        f"{d['moved_expansion']}"
     )
-    assert d["rows_lost"] == []
-    assert d["attr_lost"] == []
-    assert d["attr_gained"] == []
-    assert d["attr_moved"] == []
 
 
-def test_diff_catches_the_2026_08_19_picker_blanking():
-    """Stripping a label takes every word describing it from 2 rows to 0."""
-    d = M.diff_configs(_ts(_SSH_BEFORE), _ts(_SSH_STRIPPED))
-    lost = {probe for probe, _ in d["rows_lost"]}
-    for probe in ("nebula", "mesh", "remote", "nebu"):
-        assert probe in lost, (
-            f"{probe!r} reached :sshwn before and reaches nothing after, but the "
-            f"diff did not flag it. rows_lost={sorted(lost)}"
-        )
+def test_a_query_that_now_types_DIFFERENT_text_is_fatal():
+    """`attr_moved` alone is ambiguous (a rename lands there). What reaches the
+    user is the EXPANSION changing."""
+    after = _mut([_A, _B], ":bb", label="Alpha thing", search_terms=["alpha", "firstword"])
+    after = _mut(after, ":aa", label="Unrelated wording", search_terms=["zzz"])
+    d = M.diff_configs(_ts([_A, _B]), _ts(after))
+    assert d["moved_expansion"], "'firstword' now types bravo text, not alpha text"
+    probes = {r[0] for r in d["moved_expansion"]}
+    assert "firstword" in probes, probes
 
 
 def test_lost_attribution_is_reported_but_is_NOT_a_failure():
-    """Adding a snippet costs attribution; grading that as failure would make
-    this a permanently-red gate, which trains everyone to click through."""
-    before = [{"trigger": ":aa", "replace": "x", "label": "Alpha thing",
-               "search_terms": ["alpha"]}]
-    after = before + [{"trigger": ":bb", "replace": "y", "label": "Alpha other",
-                       "search_terms": ["alphaother"]}]
-    d = M.diff_configs(_ts(before), _ts(after))
+    after = [_A, dict(_B, label="Alpha other", search_terms=["alpha"])]
+    d = M.diff_configs(_ts([_A, _B]), _ts(after))
     assert d["attr_lost"], "'alpha' should have become ambiguous"
-    assert d["rows_lost"] == [], (
-        "no query lost its last row — an ambiguous query still LISTS both, so "
-        "this must not be graded as a regression"
+    assert d["blinded"] == [] and d["moved_expansion"] == [], (
+        "an ambiguous query still LISTS both rows — not a regression"
     )
 
 
-def test_diff_reports_gained_and_moved_attribution():
-    before = [{"trigger": ":aa", "replace": "x", "label": "Zulu", "search_terms": ["zulu"]}]
-    after = [{"trigger": ":aa", "replace": "x", "label": "Zulu", "search_terms": ["zulu"]},
-             {"trigger": ":cc", "replace": "z", "label": "Quebec", "search_terms": ["quebec"]}]
-    d = M.diff_configs(_ts(before), _ts(after))
-    assert any(p == "quebec" and t == ":cc" for p, t in d["attr_gained"])
-    # and a MOVE: the same word changes owner
-    moved_after = [{"trigger": ":dd", "replace": "x", "label": "Zulu", "search_terms": ["zulu"]}]
-    dm = M.diff_configs(_ts(before), _ts(moved_after))
-    assert any(p == "zulu" and a == ":aa" and b == ":dd" for p, a, b in dm["attr_moved"])
+def test_probe_universe_covers_prefixes_AND_multiword_queries():
+    """Multi-word queries are how the bar is really driven; a single-token
+    universe is structurally blind to regressions that only show up there."""
+    u = M._probe_universe(_ts([_A]))
+    for probe in ("a", "alph", "alpha", "firstword", "aa"):
+        assert probe in u, f"{probe!r} missing"
+    multi = [p for p in u if " " in p]
+    assert multi, "no multi-token probes at all — 'ssh workbench' is invisible"
+    assert "alpha thing" in u or "alpha firstword" in u, sorted(multi)[:10]
 
 
-def test_probe_universe_covers_prefixes_of_all_three_sources():
-    """The search bar matches as he TYPES, so 'nebu' must be probed, not just
-    'nebula'. Words come from trigger + label + search_terms."""
-    u = M._probe_universe(_ts([
-        {"trigger": ":xyz", "replace": "x", "label": "Alpha bravo",
-         "search_terms": ["charlie"]}]))
-    for probe in ("x", "xy", "xyz", "a", "alph", "alpha", "b", "bravo", "c", "charlie"):
-        assert probe in u, f"{probe!r} missing from the probe universe"
+def test_render_diff_names_the_blinded_snippet_and_says_what_it_hid():
+    after = _mut([_A, _B], ":aa", label=None, search_terms=[])
+    text = "\n".join(M.render_diff(M.diff_configs(_ts([_A, _B]), _ts(after)), "a", "b"))
+    assert "SNIPPETS BLINDED" in text and ":aa" in text
+    clean = "\n".join(M.render_diff(M.diff_configs(_ts([_A, _B]), _ts([_A, _B])), "a", "b"))
+    assert "SNIPPETS BLINDED" not in clean
+    assert "no surviving snippet lost its findability" in clean
+    # Truncation must SAY it truncated — a silently cut report hides findings.
+    many = [dict(_A, trigger=f":t{i}", label=f"Label{i} word{i}",
+                 search_terms=[f"term{i}"]) for i in range(40)]
+    blindall = [dict(m, label=None, search_terms=[]) for m in many]
+    big = "\n".join(M.render_diff(M.diff_configs(_ts(many), _ts(blindall)), "a", "b"))
+    assert "more (not shown)" in big, "truncated silently"
 
 
-def test_render_diff_names_the_lost_rows():
-    """A gate whose output does not say WHICH query broke costs a round trip."""
-    d = M.diff_configs(_ts(_SSH_BEFORE), _ts(_SSH_STRIPPED))
-    text = "\n".join(M.render_diff(d, "before.yml", "after.yml"))
-    assert "PICKER ROWS LOST" in text
-    assert "nebula" in text and ":sshwn" in text
-    clean = "\n".join(M.render_diff(M.diff_configs(_ts(_SSH_BEFORE), _ts(_SSH_BEFORE)),
-                                    "a", "b"))
-    assert "no picker rows lost" in clean
-    assert "PICKER ROWS LOST" not in clean
+def test_gate_exit_codes_and_that_it_actually_lints(tmp_path, capsys):
+    """Exit codes are pinned to LITERALS.
 
-
-def test_gate_exit_codes(tmp_path, capsys):
-    """CLI-level: red on a lost row, green on a benign add, UNMEASURED on empty."""
-    import yaml
-    pytest.importorskip("yaml")
+    The first version asserted `== M.GATE_ROWS_LOST`, i.e. it read the answer
+    out of the module under test — so setting that constant to 0 kept the suite
+    fully green while the gate printed its 🔴 findings and exited 0. The exit
+    code IS the product here.
+    """
+    yaml = pytest.importorskip("yaml")
     before = tmp_path / "before.yml"
-    before.write_text(yaml.safe_dump({"matches": _SSH_BEFORE}))
-    stripped = tmp_path / "stripped.yml"
-    stripped.write_text(yaml.safe_dump({"matches": _SSH_STRIPPED}))
-    benign = tmp_path / "benign.yml"
-    benign.write_text(yaml.safe_dump({"matches": _SSH_BEFORE + [
-        {"trigger": ":zz", "replace": "q", "label": "Totally new",
-         "search_terms": ["totallynew"]}]}))
+    before.write_text(yaml.safe_dump({"matches": [_A, _B]}))
+    blinded = tmp_path / "blinded.yml"
+    blinded.write_text(yaml.safe_dump(
+        {"matches": _mut([_A, _B], ":aa", label=None, search_terms=[])}))
+    pruned = tmp_path / "pruned.yml"
+    pruned.write_text(yaml.safe_dump({"matches": [_B]}))
     empty = tmp_path / "empty.yml"
     empty.write_text("matches: []\n")
 
-    assert M.main(["--config", str(before), "--gate", str(stripped)]) == M.GATE_ROWS_LOST
-    assert "PICKER ROWS LOST" in capsys.readouterr().out
+    assert M.main(["--config", str(before), "--gate", str(blinded)]) == 1
+    out = capsys.readouterr().out
+    assert "SNIPPETS BLINDED" in out
+    # --gate promises lint + diff in ONE verdict; prove the lint really ran.
+    assert "LINT" in out, "--gate claims to lint the candidate but did not"
 
-    assert M.main(["--config", str(before), "--gate", str(benign)]) == M.GATE_OK
+    assert M.main(["--config", str(before), "--gate", str(pruned)]) == 0
     assert "GATE: PASS" in capsys.readouterr().out
 
-    # A candidate that parses to nothing is UNMEASURED, never "everything broke".
     assert M.main(["--config", str(before), "--gate", str(empty)]) == 3
     assert "UNMEASURED" in capsys.readouterr().out
+
+    # --diff-config shares the engine but has its own CLI path.
+    assert M.main(["--config", str(before), "--diff-config", str(blinded)]) == 1
+    assert "LINT" not in capsys.readouterr().out, "--diff-config must not lint"

--- a/scripts/session-analysis/tests/test_espanso_usage.py
+++ b/scripts/session-analysis/tests/test_espanso_usage.py
@@ -723,3 +723,130 @@ def test_parse_args_keeps_every_legacy_flag():
 def test_bad_source_is_rejected():
     with pytest.raises(SystemExit):
         M.parse_args(["--source", "nope"])
+
+
+# --------------------------------------------------------------------------- #
+# --diff-config / --gate : the two-axis check
+# --------------------------------------------------------------------------- #
+# 🔴 These pin the 2026-08-19 incident. `--lint` and `--replay` both called a
+# change clean while it took 'nebula'/'mesh'/'remote' from TWO picker rows to
+# ZERO. The axes are graded differently ON PURPOSE: a lost ROW is a user-facing
+# regression and FAILS; lost ATTRIBUTION costs only telemetry and is REPORTED,
+# because adding any snippet loses some and a permanently-red gate is worse than
+# no gate at all.
+_SSH_BEFORE = [
+    {"trigger": ":sshwn", "replace": "ssh a", "label": "SSH rig via nebula mesh",
+     "search_terms": ["nebula", "mesh", "remote"]},
+    {"trigger": ":sshwl", "replace": "ssh b", "label": "SSH workbench (LAN)",
+     "search_terms": ["ssh", "workbench", "lan"]},
+]
+_SSH_STRIPPED = [
+    {"trigger": ":sshwn", "replace": "ssh a"},          # label+terms removed
+    {"trigger": ":sshwl", "replace": "ssh b", "label": "SSH workbench (LAN)",
+     "search_terms": ["ssh", "workbench", "lan"]},
+]
+
+
+def test_diff_identical_configs_reports_nothing():
+    """POSITIVE CONTROL for the whole diff: a config against itself is clean.
+
+    Without this, a probe universe that came out EMPTY would make every
+    assertion below pass vacuously — the reassuring zero this file is built to
+    refuse. The probe count is asserted non-trivial for the same reason.
+    """
+    ts = _ts(_SSH_BEFORE)
+    d = M.diff_configs(ts, ts)
+    assert d["probes"] > 20, (
+        f"only {d['probes']} probes — the universe is near-empty, so the "
+        "buckets below would be vacuously clean"
+    )
+    assert d["rows_lost"] == []
+    assert d["attr_lost"] == []
+    assert d["attr_gained"] == []
+    assert d["attr_moved"] == []
+
+
+def test_diff_catches_the_2026_08_19_picker_blanking():
+    """Stripping a label takes every word describing it from 2 rows to 0."""
+    d = M.diff_configs(_ts(_SSH_BEFORE), _ts(_SSH_STRIPPED))
+    lost = {probe for probe, _ in d["rows_lost"]}
+    for probe in ("nebula", "mesh", "remote", "nebu"):
+        assert probe in lost, (
+            f"{probe!r} reached :sshwn before and reaches nothing after, but the "
+            f"diff did not flag it. rows_lost={sorted(lost)}"
+        )
+
+
+def test_lost_attribution_is_reported_but_is_NOT_a_failure():
+    """Adding a snippet costs attribution; grading that as failure would make
+    this a permanently-red gate, which trains everyone to click through."""
+    before = [{"trigger": ":aa", "replace": "x", "label": "Alpha thing",
+               "search_terms": ["alpha"]}]
+    after = before + [{"trigger": ":bb", "replace": "y", "label": "Alpha other",
+                       "search_terms": ["alphaother"]}]
+    d = M.diff_configs(_ts(before), _ts(after))
+    assert d["attr_lost"], "'alpha' should have become ambiguous"
+    assert d["rows_lost"] == [], (
+        "no query lost its last row — an ambiguous query still LISTS both, so "
+        "this must not be graded as a regression"
+    )
+
+
+def test_diff_reports_gained_and_moved_attribution():
+    before = [{"trigger": ":aa", "replace": "x", "label": "Zulu", "search_terms": ["zulu"]}]
+    after = [{"trigger": ":aa", "replace": "x", "label": "Zulu", "search_terms": ["zulu"]},
+             {"trigger": ":cc", "replace": "z", "label": "Quebec", "search_terms": ["quebec"]}]
+    d = M.diff_configs(_ts(before), _ts(after))
+    assert any(p == "quebec" and t == ":cc" for p, t in d["attr_gained"])
+    # and a MOVE: the same word changes owner
+    moved_after = [{"trigger": ":dd", "replace": "x", "label": "Zulu", "search_terms": ["zulu"]}]
+    dm = M.diff_configs(_ts(before), _ts(moved_after))
+    assert any(p == "zulu" and a == ":aa" and b == ":dd" for p, a, b in dm["attr_moved"])
+
+
+def test_probe_universe_covers_prefixes_of_all_three_sources():
+    """The search bar matches as he TYPES, so 'nebu' must be probed, not just
+    'nebula'. Words come from trigger + label + search_terms."""
+    u = M._probe_universe(_ts([
+        {"trigger": ":xyz", "replace": "x", "label": "Alpha bravo",
+         "search_terms": ["charlie"]}]))
+    for probe in ("x", "xy", "xyz", "a", "alph", "alpha", "b", "bravo", "c", "charlie"):
+        assert probe in u, f"{probe!r} missing from the probe universe"
+
+
+def test_render_diff_names_the_lost_rows():
+    """A gate whose output does not say WHICH query broke costs a round trip."""
+    d = M.diff_configs(_ts(_SSH_BEFORE), _ts(_SSH_STRIPPED))
+    text = "\n".join(M.render_diff(d, "before.yml", "after.yml"))
+    assert "PICKER ROWS LOST" in text
+    assert "nebula" in text and ":sshwn" in text
+    clean = "\n".join(M.render_diff(M.diff_configs(_ts(_SSH_BEFORE), _ts(_SSH_BEFORE)),
+                                    "a", "b"))
+    assert "no picker rows lost" in clean
+    assert "PICKER ROWS LOST" not in clean
+
+
+def test_gate_exit_codes(tmp_path, capsys):
+    """CLI-level: red on a lost row, green on a benign add, UNMEASURED on empty."""
+    import yaml
+    pytest.importorskip("yaml")
+    before = tmp_path / "before.yml"
+    before.write_text(yaml.safe_dump({"matches": _SSH_BEFORE}))
+    stripped = tmp_path / "stripped.yml"
+    stripped.write_text(yaml.safe_dump({"matches": _SSH_STRIPPED}))
+    benign = tmp_path / "benign.yml"
+    benign.write_text(yaml.safe_dump({"matches": _SSH_BEFORE + [
+        {"trigger": ":zz", "replace": "q", "label": "Totally new",
+         "search_terms": ["totallynew"]}]}))
+    empty = tmp_path / "empty.yml"
+    empty.write_text("matches: []\n")
+
+    assert M.main(["--config", str(before), "--gate", str(stripped)]) == M.GATE_ROWS_LOST
+    assert "PICKER ROWS LOST" in capsys.readouterr().out
+
+    assert M.main(["--config", str(before), "--gate", str(benign)]) == M.GATE_OK
+    assert "GATE: PASS" in capsys.readouterr().out
+
+    # A candidate that parses to nothing is UNMEASURED, never "everything broke".
+    assert M.main(["--config", str(before), "--gate", str(empty)]) == 3
+    assert "UNMEASURED" in capsys.readouterr().out

--- a/scripts/session-analysis/tests/test_espanso_usage.py
+++ b/scripts/session-analysis/tests/test_espanso_usage.py
@@ -728,11 +728,10 @@ def test_bad_source_is_rejected():
 # --------------------------------------------------------------------------- #
 # --diff-config / --gate
 # --------------------------------------------------------------------------- #
-# 🔴 What is FATAL and what is merely reported is the whole design, and an audit
-# showed the first cut got it wrong in BOTH directions: pruning a snippet (the
-# skill's only prune verdict) FAILED, while a snippet quietly losing all of its
-# own vocabulary PASSED. The axis is therefore per-SNIPPET findability, not
-# per-probe row loss. These tests pin the six scenarios that pinned it down.
+# 🔴 FOUR earlier fatal rules were each walked by a one-line edit, because each
+# tried to infer INTENT from the config. These pin the rule that stopped
+# guessing: a WHOLE WORD that used to find a surviving snippet and now finds
+# nothing is FATAL, and deliberate losses are stated with --accept.
 _A = {"trigger": ":aa", "replace": "alpha text", "label": "Alpha thing",
       "search_terms": ["alpha", "firstword"]}
 _B = {"trigger": ":bb", "replace": "bravo text", "label": "Bravo thing",
@@ -745,156 +744,41 @@ def _mut(base, trig, **changes):
         m = dict(m)
         if m["trigger"] == trig:
             for k, v in changes.items():
-                if v is None:
-                    m.pop(k, None)
-                else:
-                    m[k] = v
+                m.pop(k, None) if v is None else m.__setitem__(k, v)
         out.append(m)
     return out
 
 
 def test_diff_identical_configs_reports_nothing():
-    """POSITIVE CONTROL: a config against itself is clean, and the universe is
-    non-trivial — otherwise every assertion below passes vacuously."""
+    """POSITIVE CONTROL — and the probe count is asserted non-trivial, or every
+    bucket below would be vacuously empty."""
     ts = _ts([_A, _B])
     d = M.diff_configs(ts, ts)
-    assert d["probes"] > 20, f"only {d['probes']} probes — buckets would be vacuous"
-    for bucket in ("narrowed", "rows_lost", "attr_lost", "attr_gained",
-                   "attr_moved", "moved_expansion"):
-        assert d[bucket] == [], f"{bucket} should be empty for an identical diff"
+    assert d["probes"] > 20, f"only {d['probes']} probes"
+    for b in ("lost_queries", "rows_lost", "attr_lost", "attr_gained",
+              "attr_moved", "moved_expansion"):
+        assert d[b] == [], f"{b} non-empty on an identical diff"
 
 
-def test_stripping_a_label_narrows_the_snippet():
-    """The 2026-08-19 regression: label+terms removed, snippet survives."""
-    after = _mut([_A, _B], ":aa", label=None, search_terms=[])
+def test_losing_a_word_from_a_SURVIVING_snippet_is_fatal():
+    after = _mut([_A, _B], ":aa", label="Alpha", search_terms=["alpha"])
     d = M.diff_configs(_ts([_A, _B]), _ts(after))
-    assert [r[0] for r in d["narrowed"]] == [":aa"], d["narrowed"]
+    lost = {r[0] for r in d["lost_queries"]}
+    assert "firstword" in lost, d["lost_queries"]
+    # 'thing' is in :bb's label too, so it keeps an owner and is NOT graded —
+    # the rule is per-WORD across the whole config, not per-snippet.
+    assert "thing" not in lost, d["lost_queries"]
 
 
-def test_pruning_a_snippet_is_NOT_a_failure():
-    """`DEAD` is the skill's only prune verdict. A per-probe rule failed here,
-    which would have made this a permanently-red gate."""
-    d = M.diff_configs(_ts([_A, _B]), _ts([_B]))
-    assert d["narrowed"] == [], "a pruned snippet is not judged — it is gone"
-    assert d["rows_lost"], "its words DO stop reaching anything; that is reported"
+def test_the_rule_cannot_be_walked_by_keeping_or_adding_a_word():
+    """🔴 The four walks that defeated the four earlier rules, as one test.
 
-
-def test_fixing_a_typo_in_a_label_is_NOT_a_failure():
-    """A typo fix EXCHANGES a word, so it is a gain-and-loss, not a strict loss.
-
-    RESIDUAL, deliberately not fixed: if the corrected spelling was ALREADY
-    reachable by another route (e.g. it duplicates an existing search_term),
-    the fix is a strict loss of the misspelling and IS flagged. That is a real
-    if trivial reduction in findability, and softening the rule to excuse it
-    would reopen the 2026-08-19 case — see
-    test_keeping_ONE_word_does_not_excuse_losing_the_rest. The report names the
-    lost queries, so a glance settles it.
-    """
-    only_typo = [dict(_A, label="Alpah thing", search_terms=["firstword"]), _B]
-    corrected = [dict(_A, label="Alpha thing", search_terms=["firstword"]), _B]
-    d = M.diff_configs(_ts(only_typo), _ts(corrected))
-    assert d["narrowed"] == [], f"a typo fix must not be graded: {d['narrowed']}"
-
-
-def test_renaming_a_trigger_keeping_the_expansion_is_NOT_a_failure():
-    renamed = _mut([_A, _B], ":aa", trigger=":zz")
-    d = M.diff_configs(_ts([_A, _B]), _ts(renamed))
-    assert d["moved_expansion"] == [], (
-        "a rename types the SAME text, so it must not be graded: "
-        f"{d['moved_expansion']}"
-    )
-
-
-def test_a_query_that_now_types_DIFFERENT_text_is_fatal():
-    """`attr_moved` alone is ambiguous (a rename lands there). What reaches the
-    user is the EXPANSION changing."""
-    after = _mut([_A, _B], ":bb", label="Alpha thing", search_terms=["alpha", "firstword"])
-    after = _mut(after, ":aa", label="Unrelated wording", search_terms=["zzz"])
-    d = M.diff_configs(_ts([_A, _B]), _ts(after))
-    assert d["moved_expansion"], "'firstword' now types bravo text, not alpha text"
-    probes = {r[0] for r in d["moved_expansion"]}
-    assert "firstword" in probes, probes
-
-
-def test_lost_attribution_is_reported_but_is_NOT_a_failure():
-    after = [_A, dict(_B, label="Alpha other", search_terms=["alpha"])]
-    d = M.diff_configs(_ts([_A, _B]), _ts(after))
-    assert d["attr_lost"], "'alpha' should have become ambiguous"
-    assert d["narrowed"] == [] and d["moved_expansion"] == [], (
-        "an ambiguous query still LISTS both rows — not a regression"
-    )
-
-
-def test_probe_universe_covers_prefixes_AND_multiword_queries():
-    """Multi-word queries are how the bar is really driven; a single-token
-    universe is structurally blind to regressions that only show up there."""
-    u = M._probe_universe(_ts([_A]))
-    for probe in ("a", "alph", "alpha", "firstword", "aa"):
-        assert probe in u, f"{probe!r} missing"
-    multi = [p for p in u if " " in p]
-    assert multi, "no multi-token probes at all — 'ssh workbench' is invisible"
-    assert "alpha thing" in u or "alpha firstword" in u, sorted(multi)[:10]
-
-
-def test_render_diff_names_the_narrowed_snippet_and_says_what_it_hid():
-    after = _mut([_A, _B], ":aa", label=None, search_terms=[])
-    text = "\n".join(M.render_diff(M.diff_configs(_ts([_A, _B]), _ts(after)), "a", "b"))
-    assert "SNIPPETS NARROWED" in text and ":aa" in text
-    clean = "\n".join(M.render_diff(M.diff_configs(_ts([_A, _B]), _ts([_A, _B])), "a", "b"))
-    assert "SNIPPETS NARROWED" not in clean
-    assert "no surviving snippet lost findability" in clean
-    # Truncation must SAY it truncated — a silently cut report hides findings.
-    many = [dict(_A, trigger=f":t{i}", label=f"Label{i} word{i}",
-                 search_terms=[f"term{i}"]) for i in range(40)]
-    blindall = [dict(m, label=None, search_terms=[]) for m in many]
-    big = "\n".join(M.render_diff(M.diff_configs(_ts(many), _ts(blindall)), "a", "b"))
-    assert "more (not shown)" in big, "truncated silently"
-
-
-def test_gate_exit_codes_and_that_it_actually_lints(tmp_path, capsys):
-    """Exit codes are pinned to LITERALS.
-
-    The first version asserted `== M.GATE_ROWS_LOST`, i.e. it read the answer
-    out of the module under test — so setting that constant to 0 kept the suite
-    fully green while the gate printed its 🔴 findings and exited 0. The exit
-    code IS the product here.
-    """
-    yaml = pytest.importorskip("yaml")
-    before = tmp_path / "before.yml"
-    before.write_text(yaml.safe_dump({"matches": [_A, _B]}))
-    narrowed = tmp_path / "narrowed.yml"
-    narrowed.write_text(yaml.safe_dump(
-        {"matches": _mut([_A, _B], ":aa", label=None, search_terms=[])}))
-    pruned = tmp_path / "pruned.yml"
-    pruned.write_text(yaml.safe_dump({"matches": [_B]}))
-    empty = tmp_path / "empty.yml"
-    empty.write_text("matches: []\n")
-
-    assert M.main(["--config", str(before), "--gate", str(narrowed)]) == 1
-    out = capsys.readouterr().out
-    assert "SNIPPETS NARROWED" in out
-    # --gate promises lint + diff in ONE verdict; prove the lint really ran.
-    assert "LINT" in out, "--gate claims to lint the candidate but did not"
-
-    assert M.main(["--config", str(before), "--gate", str(pruned)]) == 0
-    assert "GATE: PASS" in capsys.readouterr().out
-
-    assert M.main(["--config", str(before), "--gate", str(empty)]) == 3
-    assert "UNMEASURED" in capsys.readouterr().out
-
-    # --diff-config shares the engine but has its own CLI path.
-    assert M.main(["--config", str(before), "--diff-config", str(narrowed)]) == 1
-    assert "LINT" not in capsys.readouterr().out, "--diff-config must not lint"
-
-
-def test_keeping_ONE_word_does_not_excuse_losing_the_rest():
-    """🔴 The exact case a delta audit used to falsify an earlier fatal axis.
-
-    Following SKILL.md's own advice — "change which WORDS a snippet spells,
-    never remove its label" — relabelling two snippets to `SSH rig` /
-    `SSH portable` took 'nebula', 'mesh' and 'remote' from two picker rows to
-    ZERO. An all-or-nothing "reaches NOTHING" rule passed it, because each
-    snippet kept one word. LOST-WITH-NO-GAIN catches it.
+    Each variant does the SAME modelled damage — 'nebula'/'mesh'/'remote' stop
+    finding anything — and each defeated a previous rule: keeping one word
+    (defeated all-or-nothing), and adding a brand-new word (defeated
+    lost-with-no-gain). The expectation must not depend on WHICH word replaces
+    them; an earlier regression test passed only because its fixture reused a
+    word that was already present.
     """
     before = [
         {"trigger": ":wn", "replace": "ssh a", "label": "SSH rig via nebula mesh",
@@ -902,87 +786,152 @@ def test_keeping_ONE_word_does_not_excuse_losing_the_rest():
         {"trigger": ":ln", "replace": "ssh b", "label": "SSH portable via nebula mesh",
          "search_terms": ["nebula", "mesh", "remote"]},
     ]
-    after = [
-        {"trigger": ":wn", "replace": "ssh a", "label": "SSH rig", "search_terms": ["rig"]},
-        {"trigger": ":ln", "replace": "ssh b", "label": "SSH portable",
-         "search_terms": ["portable"]},
-    ]
-    d = M.diff_configs(_ts(before), _ts(after))
-    narrowed = {r[0] for r in d["narrowed"]}
-    assert narrowed == {":wn", ":ln"}, (
-        "both snippets strictly lost 'nebula'/'mesh'/'remote' and gained "
-        f"nothing new, so both must be graded: {d['narrowed']}"
-    )
+    variants = {
+        "keeps a word already present": ("SSH rig", "SSH portable"),
+        "introduces brand-new words": ("SSH box", "SSH lap2"),
+        "adds a junk token": ("SSH rig zzq", "SSH portable zzq2"),
+    }
+    for name, (lw, ll) in variants.items():
+        after = [dict(before[0], label=lw, search_terms=[lw.split()[-1]]),
+                 dict(before[1], label=ll, search_terms=[ll.split()[-1]])]
+        d = M.diff_configs(_ts(before), _ts(after))
+        lost = {r[0] for r in d["lost_queries"]}
+        assert {"nebula", "mesh", "remote"} <= lost, (
+            f"variant that {name} was not graded: lost={sorted(lost)}"
+        )
+
+
+def test_pruning_a_snippet_needs_no_acknowledgement():
+    """The word went with the snippet — that is what a prune IS."""
+    d = M.diff_configs(_ts([_A, _B]), _ts([_B]))
+    assert d["lost_queries"] == [], f"a prune must be excused: {d['lost_queries']}"
+    assert d["rows_lost"], "its words DO stop reaching anything; that is reported"
+
+
+def test_renaming_a_trigger_keeping_the_expansion_is_NOT_a_failure():
+    renamed = _mut([_A, _B], ":aa", trigger=":zz")
+    d = M.diff_configs(_ts([_A, _B]), _ts(renamed))
+    assert d["moved_expansion"] == [], d["moved_expansion"]
+    assert d["lost_queries"] == [], "the vocabulary is untouched"
+
+
+def test_a_query_that_now_types_DIFFERENT_text_is_fatal():
+    # 'firstword' moves from :aa to :bb: both survive, the word keeps an owner
+    # (so nothing is LOST), but pressing Enter now types bravo text.
+    after = _mut([_A, _B], ":aa", search_terms=["alpha"])
+    after = _mut(after, ":bb", search_terms=["bravo", "firstword"])
+    d = M.diff_configs(_ts([_A, _B]), _ts(after))
+    assert d["lost_queries"] == [], f"isolate the expansion axis: {d['lost_queries']}"
+    assert any(pr == "firstword" for pr, _, _ in d["moved_expansion"]), d["moved_expansion"]
 
 
 def test_a_vocabulary_less_snippet_never_makes_the_gate_red():
-    """`dashbaord` has no label and no search_terms by design.
-
-    The survives-guard (`reach_b[trig] and ...`) is what stops it being graded;
-    dropping that guard made an IDENTICAL-config diff exit 1 on the real config.
-    No fixture covered it, so the suite was blind to the failure mode this
-    whole design exists to avoid.
-    """
+    """`dashbaord` has no label and no search_terms by design."""
     cfg = [_A, {"trigger": "typotypo", "replace": "typo"}]
-    d = M.diff_configs(_ts(cfg), _ts(cfg))
-    assert d["narrowed"] == [], (
-        "a config diffed against ITSELF must never be graded: " f"{d['narrowed']}"
-    )
-    d2 = M.diff_configs(_ts(cfg), _ts([_A]))
-    assert d2["narrowed"] == [], "removing a vocabulary-less snippet is a prune"
+    assert M.diff_configs(_ts(cfg), _ts(cfg))["lost_queries"] == []
+    assert M.diff_configs(_ts(cfg), _ts([_A]))["lost_queries"] == []
 
 
-def test_reaching_requires_ALL_tokens_of_a_multiword_query():
-    """`_term_matches` ANDs whitespace-separated tokens — that is the entire
-    reason pair probes exist. `any` instead of `all` would make the fatal axis
-    far too lenient and no other test would notice."""
+def test_reaching_requires_ALL_tokens_and_ignores_the_trigger():
     ts = _ts([_A])
     det = M.EspansoDetector(ts)
-    reach = M._reaching(det, {"alpha", "bravo", "alpha bravo", "alpha thing"})
-    assert "alpha" in reach[":aa"]
-    assert "alpha thing" in reach[":aa"], "both tokens match :aa"
-    assert "alpha bravo" not in reach[":aa"], (
-        "'bravo' does not describe :aa, so the AND must reject the pair"
-    )
-    # The TRIGGER arm must stay off: typing a trigger verbatim is a different
-    # modality from finding a snippet by describing it, and the report says
-    # "trigger aside". Unpinned, a mutant re-enabling it survived the suite.
-    reach2 = M._reaching(det, {"aa", "a", "alpha"})
-    assert "aa" not in reach2[":aa"], (
-        "':aa' is the trigger — it must NOT count as a way of FINDING the "
-        "snippet, or a snippet stripped of its label reads as still reachable"
-    )
-    assert "alpha" in reach2[":aa"], "the label/search_terms arms must stay on"
+    reach = M._reaching(det, {"alpha", "alpha bravo", "alpha thing"})
+    assert "alpha thing" in reach[":aa"] and "alpha bravo" not in reach[":aa"]
+    r2 = M._reaching(det, {"aa", "alpha"})
+    assert "aa" not in r2[":aa"], "the trigger is not a way of FINDING a snippet"
+    assert "alpha" in r2[":aa"]
 
 
 def test_attribution_gained_and_moved_have_positive_controls():
-    """This file's contract: every zero comes with an N that MUST count."""
-    before = [_A]
-    after = [_A, {"trigger": ":cc", "replace": "z", "label": "Quebec",
-                  "search_terms": ["quebec"]}]
-    d = M.diff_configs(_ts(before), _ts(after))
+    d = M.diff_configs(_ts([_A]), _ts([_A, {"trigger": ":cc", "replace": "z",
+                                            "label": "Quebec", "search_terms": ["quebec"]}]))
     assert any(pr == "quebec" and tr == ":cc" for pr, tr in d["attr_gained"]), d["attr_gained"]
-    renamed = _mut([_A], ":aa", trigger=":dd")
-    dm = M.diff_configs(_ts([_A]), _ts(renamed))
+    dm = M.diff_configs(_ts([_A]), _ts(_mut([_A], ":aa", trigger=":dd")))
     assert any(pr == "alpha" and a == ":aa" and b == ":dd"
                for pr, a, b in dm["attr_moved"]), dm["attr_moved"]
 
 
+def test_render_diff_names_the_lost_words_and_offers_the_accept_line():
+    after = _mut([_A, _B], ":aa", label="Alpha", search_terms=["alpha"])
+    d = M.diff_configs(_ts([_A, _B]), _ts(after))
+    text = "\n".join(M.render_diff(d, "a", "b"))
+    assert "QUERIES THAT STOP WORKING" in text
+    assert "firstword" in text and "--accept" in text
+    ack = "\n".join(M.render_diff(d, "a", "b", accepted={"firstword", "thing"}))
+    assert "QUERIES THAT STOP WORKING" not in ack
+    assert "acknowledged via --accept" in ack
+    clean = "\n".join(M.render_diff(M.diff_configs(_ts([_A]), _ts([_A])), "a", "b"))
+    assert "every word that found a surviving snippet still does" in clean
+
+
+def test_gate_exit_codes_accept_semantics_and_that_it_lints(tmp_path, capsys):
+    """Exit codes pinned to LITERALS — an earlier version read the expected
+    value out of the module under test, so flipping that constant kept the
+    suite green while the gate printed 🔴 findings and exited 0."""
+    yaml = pytest.importorskip("yaml")
+    b = tmp_path / "b.yml"; b.write_text(yaml.safe_dump({"matches": [_A, _B]}))
+    lossy = _mut([_A, _B], ":aa", label="Alpha", search_terms=["alpha"])
+    a = tmp_path / "a.yml"; a.write_text(yaml.safe_dump({"matches": lossy}))
+    pruned = tmp_path / "p.yml"; pruned.write_text(yaml.safe_dump({"matches": [_B]}))
+    empty = tmp_path / "e.yml"; empty.write_text("matches: []\n")
+
+    assert M.main(["--config", str(b), "--gate", str(a)]) == 1
+    out = capsys.readouterr().out
+    assert "QUERIES THAT STOP WORKING" in out
+    assert "LINT" in out, "--gate claims to lint the candidate but did not"
+
+    # PARTIAL acknowledgement must still fail — otherwise --accept is a bypass.
+    assert M.main(["--config", str(b), "--gate", str(a), "--accept", "thing"]) == 1
+    capsys.readouterr()
+    assert M.main(["--config", str(b), "--gate", str(a),
+                   "--accept", "thing,firstword"]) == 0
+    assert "GATE: PASS" in capsys.readouterr().out
+
+    assert M.main(["--config", str(b), "--gate", str(pruned)]) == 0
+    capsys.readouterr()
+    assert M.main(["--config", str(b), "--gate", str(empty)]) == 3
+    assert "UNMEASURED" in capsys.readouterr().out
+
+
+def test_vocab_excludes_the_trigger_and_reads_both_sources():
+    """The graded word set must be what DESCRIBES a snippet, not its trigger —
+    otherwise stripping a label leaves the trigger words 'covering' the loss."""
+    v = M._vocab(_ts([_A]))[":aa"]
+    assert {"alpha", "thing", "firstword"} <= v
+    assert "aa" not in v, "the trigger must not be a graded way of finding it"
+
+
+def test_probe_universe_has_prefixes_AND_multiword_pairs():
+    u = M._probe_universe(_ts([_A]))
+    assert {"a", "alph", "alpha", "firstword"} <= u, "prefixes missing"
+    pairs = [p for p in u if " " in p]
+    assert pairs, "no multi-token probes — 'ssh workbench' would be invisible"
+    assert any(p.startswith("alpha ") for p in pairs), sorted(pairs)[:8]
+
+
+def test_render_diff_signals_truncation():
+    many = [dict(_A, trigger=f":t{i}", label=f"Label{i} word{i}",
+                 search_terms=[f"term{i}"]) for i in range(40)]
+    stripped = [dict(m, label=f"Label{i}", search_terms=[])
+                for i, m in enumerate(many)]
+    text = "\n".join(M.render_diff(M.diff_configs(_ts(many), _ts(stripped)), "a", "b"))
+    assert "more (not shown)" in text, "a silently truncated report hides findings"
+
+
 def test_a_changed_expansion_alone_drives_the_exit_code(tmp_path, capsys):
-    """N3: `moved_expansion`'s contribution to rc was unpinned — a mutant
-    grading only `narrowed` kept the suite green while the report still
-    printed 🔴 EXPANSION CHANGED and exited 0."""
+    """Pinned at the CLI: a mutant grading only lost_queries kept the suite
+    green while the report printed 🔴 EXPANSION CHANGED and exited 0."""
     yaml = pytest.importorskip("yaml")
     before = [_A, _B]
-    after = _mut(before, ":bb", label="Alpha thing", search_terms=["alpha", "firstword"])
-    after = _mut(after, ":aa", label="Unrelated wording", search_terms=["zzz", "yyy"])
-    b = tmp_path / "b.yml"; b.write_text(yaml.safe_dump({"matches": before}))
-    a = tmp_path / "a.yml"; a.write_text(yaml.safe_dump({"matches": after}))
+    after = _mut(before, ":aa", search_terms=["alpha"])
+    after = _mut(after, ":bb", search_terms=["bravo", "firstword"])
+    b = tmp_path / "b.yml"
+    b.write_text(yaml.safe_dump({"matches": before}))
+    a = tmp_path / "a.yml"
+    a.write_text(yaml.safe_dump({"matches": after}))
     d = M.diff_configs(_ts(before), _ts(after))
-    assert d["moved_expansion"], "fixture must produce an expansion move"
-    assert d["narrowed"] == [], (
-        "fixture must isolate the expansion axis — :aa gains zzz/yyy, so it is "
-        f"not narrowed: {d['narrowed']}"
+    assert d["lost_queries"] == [] and d["moved_expansion"], (
+        "fixture must isolate the expansion axis"
     )
     assert M.main(["--config", str(b), "--gate", str(a)]) == 1
     assert "EXPANSION CHANGED" in capsys.readouterr().out


### PR DESCRIPTION
## The pre-ship checks that already existed didn't catch the thing they were for

On 2026-08-19 an espanso change took `nebula`, `mesh` and `remote` from **two picker rows to zero**, and both existing checks called it clean:

| check | why it missed |
|---|---|
| `--lint` | sees **one** config, so it cannot see what a change *removed* |
| `--replay` | replays only terms actually typed in the window — a term never searched is invisible. It reported **"0 regressions"** while the strip was live |

```
espanso-usage.py --gate <candidate.yml>      # lint + diff, one verdict, offline, no creds
espanso-usage.py --diff-config <candidate>   # the diff alone
```

## What is fatal — and why it stopped trying to be clever

**Four earlier versions of the fatal rule were each walked by a one-line edit**, every one caught by an audit round rather than by me:

| rule | walked by |
|---|---|
| a query reaches nothing | pruning — red on every prune, the skill's own primary action |
| snippet reaches nothing at all | keeping **one** word |
| lost with no gain | adding **one junk** word |
| any magnitude threshold | staying under it |

All four tried to infer whether a loss was **deliberate**. That information is not in the config: removing `nebula` from a label is byte-identical whether the word was retired on purpose or the only way to find that snippet was destroyed.

So the gate states it instead of guessing:

**FATAL — queries that stop working.** A whole word that used to find a snippet finds nothing now, and at least one snippet it used to find still exists.

```
🔴 QUERIES THAT STOP WORKING — 6 word(s) find nothing now,
   and the snippet they found still exists:
     'nebula' reached :sshln :sshwn -> nothing
     'mesh'   reached :sshln :sshwn -> nothing
   If these losses are DELIBERATE, acknowledge them:
     --accept mesh,nebula,portable,remote,rig,via
GATE: FAIL
```

**FATAL — expansion changed.** A query that resolved to one snippet now resolves to another that types *different* text. A plain trigger rename is not this.

A **prune needs no acknowledgement** — every snippet the word described is gone, so the vocabulary went with it. `--accept` is **per-word**: acknowledging 2 of 6 still fails. Three mutants attack that specifically, because an acknowledgement flag that can be walked is worse than no gate.

Everything else — ambiguity, attribution lost/gained/moved — is **reported, never graded**. espanso lists every match as a row, so ambiguity costs telemetry, not reach.

## Verification

Matrix on the **real deployed config**, including every walk that defeated a previous version:

| scenario | verdict |
|---|---|
| `rig`→`box` relabel *(walked lost-with-no-gain)* | **FAIL** |
| SKILL.md-advice relabel *(walked all-or-nothing)* | **FAIL** |
| label strip — the 2026-08-19 case | **FAIL** |
| vocabulary-less snippet | **FAIL** |
| expansion moved across snippets | **FAIL** |
| prune a `DEAD` snippet | PASS |
| typo fix / label reword | PASS |
| trigger rename, same expansion | PASS |

**75 tests. Mutation battery 24/24 killed** with a green positive control.

Authoritative gate: **`RESULT: all good`, collected 13827, passed 13826, skipped 1, failed 0**, 0 FAIL suites, 0 timeout panics.

## Known limits — a PASS is "no regression under our model"

- It models the picker with the **keylog matcher**, not espanso itself, and nothing in this repo checks that proxy.
- Multi-word queries beyond within-snippet pairs, and non-prefix substrings, are outside the probe universe.
- Correcting a typo whose right spelling was **already** reachable is flagged. It is a real if trivial loss; `--accept` states it.

## Provenance

This PR took four adversarial audit rounds, and **each round found a real inversion in the previous round's fix** — including two claims in my own commit messages that later measurement falsified, a regression test that pinned its fixture rather than the rule, and a renderer edit of mine that cut the section explaining why the gate failed. The rule that survived is the one that stopped trying to infer intent.
