### PR TITLE
fix(browser-bridge): `type` could not say whether the text landed — plus stdout purity and BB_* targeting

### DIFF
--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -14,7 +14,7 @@ $BB --instance <key> --tab <id> text   # cheap read of a specific tab
 
 🔴 **Run `whoami` first on every fresh browser task.** Both hosts are hostname
 `nixos` and this bridge could be either, with several Brave profiles — confirm the
-host and pick the right `--instance` before acting. Architecture / security model:
+host and pick the right `--instance` first. Architecture / security model:
 `~/workspace/devrc/scripts/browser-bridge/README.md`.
 
 🔴 **Every `reference/<file>.md` named below lives at
@@ -51,24 +51,24 @@ Result payloads land under `.result.data`.
 
 | command | does |
 |---|---|
-| `whoami` | **read-only identity** (global; no `--instance`/`--tab`) — host label (`laptop`/`workbench`), connected instances (active-tab **domain** only), bridge diagnostics, `extension_version_current` |
-| `health` / `instances` | connected instances + count (JSON: key, label, instanceId, tab url/title). per-instance `extension_stale` on `health` + `whoami`, NOT `instances` — ⚠ `null` is "undecidable", NOT "fine"; tri-state → `reference/errors.md` |
+| `whoami` | **read-only identity** (global; no `--instance`) — host label (`laptop`/`workbench`), connected instances (active-tab **domain** only), bridge diagnostics, `extension_version_current` |
+| `health` / `instances` | connected instances + count (JSON: key, label, instanceId, tab url/title). `extension_stale` on `health`+`whoami`, NOT `instances` — ⚠ `null` = "undecidable", NOT "fine" → `reference/errors.md` |
 | `ping` | **which extension CODE is loaded?** → `{pong,extensionVersion,buildMarker,id,ops}`; read `buildMarker` — version+id describe the DIRECTORY. Staleness is PER PROFILE |
 | `context` | **page metadata, no DOM read** — url/domain/path/query/title/tabId, tab-scoped. Cheapest read; ⚠ NOT a render check → `reference/read-envelopes.md` |
 | `open [url] [--wake[=MS]]` | open a NEW tab this session owns (default `about:blank`, **created in the BACKGROUND/hidden**), returns `tabId`. 🔴 A re-`open` does NOT navigate — it DISCARDS your url → `reference/tabs-instances.md` |
 | `close` / `release` | close this session's owned tab / drop ownership without closing it |
 | `tabs` | list open tabs (`.data.ownedTabId` flags yours) |
 | `nav <url> [--wake[=MS]]` | navigate the owned/active tab; it lands hidden, so `--wake` un-throttles in the SAME call |
-| `text [selector] [--max-bytes N] [--annotated]` | **cheap read** — visible `innerText` (optional CSS selector), byte-capped by default. ~98% smaller than `html` — **prefer it**. `--annotated` swaps flat text for per-element extraction — use it when you need a SELECTOR to click/type; works with `--frame`. Byte cap, envelope fields, `--annotated` schema → `reference/read-envelopes.md` |
-| `html [--max-bytes N]` | `outerHTML`, same byte cap and same envelope. One uncapped `html` on a heavy SPA is ~100K tokens — the cap is ON by default |
-| `js '<expr>'` (alias: `eval`) | run JS in the tab, return its value; same op on the wire either way. **Prefer the `js` spelling in a worktree-isolated agent** — Claude Code's isolation guard refuses any command containing the literal token `eval` |
+| `text [selector] [--max-bytes N] [--annotated]` | **cheap read** — visible `innerText` (optional CSS selector), byte-capped by default. ~98% smaller than `html` — **prefer it**. `--annotated` gives per-element extraction — use it when you need a SELECTOR to click/type; works with `--frame`. Byte cap, envelope fields, `--annotated` schema → `reference/read-envelopes.md` |
+| `html [--max-bytes N]` | `outerHTML`, same byte cap and envelope. One uncapped `html` on a heavy SPA is ~100K tokens — the cap is ON by default |
+| `js '<expr>'` (alias: `eval`) | run JS in the tab, return its value; same wire op either way. **Prefer the `js` spelling in a worktree-isolated agent** — Claude Code's isolation guard refuses any command with the literal token `eval` |
 | `screenshot [path] [--fullpage] [--data-url]` | CDP capture — **works on a BACKGROUND/occluded tab**. **Always writes a `.png`** (to `path`, else a 0600 temp) and prints `{ok,path,bytes,url,via}`; the base64 is **NEVER** printed — **`Read` the `.png`**. `--data-url` is the escape hatch |
 | `frames` | list the tab's frames (`frameId`/`url`/`parentFrameId`) **incl. cross-origin OOPIFs** — pick a numeric `frameId` for `--frame` |
-| `click <selector>` · `type <text> [--selector S]` · `key <Enter\|Tab\|Escape\|Backspace\|Delete\|Arrow*\|Home\|End\|Page*> [--selector S]` | the input ops — click the element's centre, type text, send one bounded keypress. All three: **TRUSTED** CDP on the top frame, **SYNTHETIC** inside `--frame` |
+| `click <selector>` · `type <text> [--selector S] [--expect V\|--verify]` · `key <Enter\|Tab\|Escape\|Backspace\|Delete\|Arrow*\|Home\|End\|Page*> [--selector S]` | the input ops — click the element's centre, type text, send one bounded keypress. All three: **TRUSTED** CDP on the top frame, **SYNTHETIC** inside `--frame`. 🔴 `type` alone **cannot confirm it applied** — `--expect`/`--verify` → `reference/type-verify.md` |
 | `upload <selector> <path>` | fill an `<input type=file>` via CDP — Chrome reads the file BY PATH, **no bytes cross the bridge**. AUDIT-LOGGED, **operator-only** (agent → `op_not_allowed:upload`) |
-| `wake [--wait MS]`, or `text\|html\|js\|nav\|open --wake[=MS]` | **UN-THROTTLE a hidden/background tab with NO focus movement** — the fix for an empty or `hidden` read. **Wake once per PAGE, not per read.** `--wake` folds un-throttle+read into one call; refused with `--frame`. Settle/cap, the once-per-page rule, ISOLATED-vs-MAIN world → `reference/spa-wake.md` |
+| `wake [--wait MS]`, or `text\|html\|js\|nav\|open --wake[=MS]` | **UN-THROTTLE a hidden/background tab with NO focus movement.** **Wake once per PAGE, not per read.** `--wake` folds un-throttle+read into one call; refused with `--frame`. Settle/cap, ISOLATED-vs-MAIN world → `reference/spa-wake.md` |
 | `activate` | **⚠⚠ TAKES THE OPERATOR'S SCREEN — LAST RESORT.** The i3 raise is OPT-IN: `--focus` (auto-on on a TTY) → raise, else `withheld`; `skipped` where there is no i3. **NOT** the hidden-tab fix — that is `wake`, see `reference/spa-wake.md` |
-| `emulate <preset>\|--reset` | **device emulation** (mobile testing) on a tab you `open`ed; sticky, owned-tab-only. Presets, `--reset`, `--recreate` → `reference/emulation.md` |
+| `emulate <preset>\|--reset` | **device emulation** on a tab you `open`ed; sticky, owned-tab-only. Presets, `--reset`, `--recreate` → `reference/emulation.md` |
 | `agent "<goal>"` | the autonomous browser-agent — see **FIRST DECISION** above, then `reference/agent.md` |
 
 ## 🔴 Four traps that return a WRONG answer SILENTLY
@@ -83,31 +83,23 @@ Result payloads land under `.result.data`.
 3. **A background/hidden tab is THROTTLED → a shell-only DOM**, indistinguishable
    from a genuinely broken site. `open` creates tabs hidden, so this is the common
    case. Check `data.hidden` / `document.visibilityState`, then **`wake`** — never
-   `activate`, and spoofing `visibilityState` does not recover the page.
-   **A reload RE-throttles: re-`wake` or clicks go silently inert.**
-   → `reference/spa-wake.md`
-4. **A JS `.click()` does not open a React/Mantine popover — and the read then
-   reports a confident ABSENCE.** Use the trusted **`click`** op; click **ONCE** —
-   it is a TOGGLE, so a stale earlier click makes the next read lie — and read
-   `aria-expanded` to prove it opened. Not selector-reachable? **`screenshot`** it.
-   → `reference/css-hit-test.md`
+   `activate`. **A reload RE-throttles: re-`wake`.** → `reference/spa-wake.md`
+4. **A JS `.click()` does not open a React/Mantine popover — the read then
+   reports a confident ABSENCE.** Use the trusted **`click`** op, **ONCE** (it is a
+   TOGGLE). → `reference/css-hit-test.md`
 
 ## When things look broken — triage
 
-1. **A call that WORKED now fails, errors, or returns nothing** → re-run `browser
-   health` BEFORE debugging the page or the CLI; the extension drops mid-session
-   (`extension_connected:false`) with no user action and no error. Fix: ↻ **in the
-   profile you are driving** (`brave://extensions` is per-profile). A STALE BUILD is
-   a DIFFERENT failure — a Brave restart does NOT clear it; that needs per-profile
-   Remove + Load unpacked. → `reference/errors.md`
-2. **A read is empty / half-built / `data.hidden:true`** → the tab is throttled.
-   `browser wake`, then re-read. → `reference/spa-wake.md`
-3. **`null` from `js`/`eval`** → trap 1, then trap 2. Fall back to `text`/`html`
-   before concluding the bridge is down. **`unknown_op`** on an op the CLI knows →
-   stale extension, see 1. Any other error string → `reference/errors.md`.
+1. **A call that WORKED now fails or returns nothing** → `browser health` FIRST,
+   before debugging the page or the CLI: the extension drops mid-session with no
+   error. Fix: ↻ **in the profile you are driving**. A STALE BUILD is a DIFFERENT
+   failure — Remove + Load unpacked, not a restart. → `reference/errors.md`
+2. **Empty / half-built / `data.hidden:true` read** → throttled: `wake`, re-read.
+3. **`null` from `js`/`eval`** → traps 1 then 2; fall back to `text`/`html` before
+   concluding the bridge is down. **`unknown_op`** → stale extension (1). Any other
+   error string → `reference/errors.md`.
 4. **Never diagnose a site OUTAGE from a browser read** — "broken for real users?"
    needs server-side evidence (RUM, metrics, pod health, an anonymous `curl`).
-   → `reference/spa-wake.md`
 
 ## This is the user's LIVE session
 
@@ -125,6 +117,7 @@ explicitly. Why, and the commands → `reference/spa-wake.md`.
 | `reference/validation-prompt.md` | writing or dispatching a browser validation prompt — the standing rails, cited not retyped |
 | `reference/spa-wake.md` | a read came back empty/half-built, `data.hidden:true`, an SPA is stuck "Loading…", or you're about to call a site broken |
 | `reference/read-envelopes.md` | a read's exact envelope fields; `context` vs `text`; `text --annotated` + the `attrs` it returns; getting a SELECTOR out of a read |
+| `reference/type-verify.md` | a `type` may not have landed; `--expect`/`--verify`; `bad_target` / `input_not_applied`; typing a secret |
 | `reference/errors.md` | any op returned an error string you don't recognise; `unknown_op`; a reload ↻ didn't take |
 | `reference/frames-cdp.md` | `frame_not_found` / `ambiguous_frame` / `oopif_*_cap` / `cdp_attach_refused`; a `--frame` read returned the TOP page; reading or driving inside a cross-origin iframe; the debugger banner |
 | `reference/tabs-instances.md` | `ambiguous_instance` / `unknown_instance` / `superseded` / `no_owned_tab` / `owned_tab_gone`; two drivers fighting over one tab; concurrent subagents SHARE a session id; a re-`open` ignored your url |

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -206,9 +206,31 @@
 #   browser [--frame <f>] click <selector>
 #                             — click the element's center (TRUSTED CDP on the top
 #                               frame; SYNTHETIC in a cross-origin --frame)
-#   browser [--frame <f>] type <text> [--selector <sel>]
+#   browser [--frame <f>] type <text> [--selector <sel>] [--expect <value>|--verify]
 #                             — text input (TRUSTED CDP top frame; SYNTHETIC in-frame);
-#                               focus --selector first if given
+#                               focus --selector first if given.
+#                               ⚠ WITHOUT --expect/--verify the result is NOT a claim
+#                               that the text landed: `typed` is the length of the
+#                               string SENT. A type can silently fail to apply while
+#                               the page keeps rendering its previous state.
+#                               --expect <value>  re-read the target after a settle and
+#                                                 require it to EQUAL <value>; retries
+#                                                 the whole type up to 3× (BB_TYPE_ATTEMPTS),
+#                                                 then fails with `input_not_applied`
+#                                                 reporting wanted vs got.
+#                               --verify          same, but only requires the read-back
+#                                                 to CONTAIN the typed text — and reports
+#                                                 a LENGTH, never the value. Use it on a
+#                                                 secret field: --expect echoes the
+#                                                 PAGE's content on a miss.
+#                               Either adds `result.data.applied` (true/false/null — null
+#                               is "not verified", NOT "fine") and `result.data.verify`.
+#                               Each verified type READS THE FIELD FIRST, so it is 3 wire
+#                               ops on the happy path and up to 9 across 3 attempts;
+#                               a 429 on a read is rc 3, never `applied:false`.
+#                               Tuning: BB_TYPE_ATTEMPTS (default 3, max 10),
+#                               BB_TYPE_SETTLE_S (default 0.35, max 30 — the settle
+#                               between the type and the read-back IS the detector).
 #   browser [--frame <f>] key <Enter|Tab|Escape|...> [--selector <sel>]
 #                             — dispatch one bounded key (TRUSTED CDP top frame;
 #                               SYNTHETIC in-frame)
@@ -253,8 +275,18 @@
 #
 # EXIT CODES
 #   0  success
-#   1  the command failed — nothing was applied, or the primary op itself failed
-#   3  ONLY from `nav --wake` / `open --wake`: the nav/open SUCCEEDED and only the
+#   1  the command failed — nothing was applied, or the primary op itself failed.
+#      `type --expect/--verify` uses it for BOTH a confirmed miss and a
+#      `bad_target` (the --selector names nothing, or names something that
+#      cannot hold text — a wrapper <div>). Both mean "the text is not in what
+#      you named", which is what rc 3 explicitly does NOT mean.
+#   3  THE PRIMARY OP SUCCEEDED AND ONLY ITS FOLLOW-UP FAILED — never "nothing
+#      happened". Two sources:
+#      * `type --expect/--verify`: the text was typed, but the read-back could
+#        not be EVALUATED (strict page CSP, a chrome:// tab, a rate-limited
+#        follow-up), so `result.data.applied` is null — "not verified", NOT
+#        "fine". A confirmed miss and a bad target are rc 1, not 3.
+#      * `nav --wake` / `open --wake`: the nav/open SUCCEEDED and only the
 #      wake follow-up failed. The tab HAS navigated and its JSON is still on
 #      stdout, with `result.data.wake = {"ok":false,"error":"<real cause>"}`.
 #      Branch on 3 rather than treating it as a plain failure — and read that
@@ -1218,6 +1250,575 @@ cmd_op() {
 json_str() { python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$1"; }
 
 # --------------------------------------------------------------------------- #
+# `type` verification — CONFIRM the text actually landed.
+#
+# 🔴 WHY THIS EXISTS (measured live, 2026-08-20). `type <text> --selector <sel>`
+# replaces an input's value correctly MOST of the time and, intermittently, does
+# not apply AT ALL while the page keeps rendering its previous state. The op
+# returns `{typed:<N>,trusted:true}` either way — `typed` is the length of the
+# string the CLI SENT, never a claim about the DOM — so nothing in the envelope
+# distinguishes the two, and an agent reads the success envelope as evidence the
+# field now holds the text. That produced three confident, wrong conclusions
+# about a live site in one session.
+#
+# 🔴 THE SETTLE DELAY IS THE DETECTOR, NOT POLITENESS. CDP `Input.insertText`
+# mutates the DOM value SYNCHRONOUSLY, so a read-back inside the same op would
+# report success even in the failing case — the value is there for a moment and
+# a subsequent framework re-render from stale state overwrites it. Reading back
+# in a SEPARATE round-trip, after a settle, is what observes the state the USER
+# is left looking at. This is also why verification lives in the CLI rather than
+# in the extension's `type` handler: the extension can only see the instant
+# after the insert, which is exactly the instant that lies.
+#
+# 🔴 THE PRE-READ IS LOAD-BEARING, NOT AN OPTIMISATION TARGET. Every verified
+# type begins by READING THE FIELD, before typing anything. The first version of
+# this feature skipped it and inferred the field's prior content by stripping a
+# trailing copy of the typed text off the read-back. That inference is sound only
+# when the insert LANDED — and the case this whole feature exists to detect is
+# the one where it did NOT, where the read-back IS the pre-existing content. A
+# field holding `"my password"`, typed into with `"password"` and not applied,
+# read back as `"my password"`, ends with the typed text, so the "undo" amputated
+# it to `"my "` and then reported that value as what the page held. The CLI
+# created the damage and then misdescribed the page. A read costs one op; a
+# guess costs the user's data. Everything below derives from the MEASURED
+# pre-state or refuses to act:
+#   * the restore target is the pre-state, never a substring computed from the
+#     post-state;
+#   * with no pre-state (a CSP page, a rate-limited pre-read) there is NO retry,
+#     because a retry it cannot undo is a retry it must not make; and
+#   * `--verify` can finally tell "the text landed" from "the text was already
+#     there" — `contains` against the post-state alone cannot, and scored a
+#     complete no-op as `applied:true`.
+#
+# NOT ON BY DEFAULT, and that is a deliberate limit, not an oversight: a verified
+# type costs THREE wire ops instead of one (pre-read, type, read-back), which
+# spends the per-instance rate-limit budget, and the reads return `null` on a
+# strict-CSP page. Making it unconditional would change the wire behaviour of
+# every existing `type` caller. `--expect` / `--verify` are the opt-in.
+#
+# OP BUDGET (the numbers SKILL.md quotes):
+#   happy path                 3 ops  — pre-read, type, read-back
+#   3 attempts, insert lands   9 ops  — + 2 restores + 2 more type/read-back pairs
+#   3 attempts, nothing lands  7 ops  — the restore is SKIPPED when the read-back
+#                                       already equals the pre-state
+# A 429 on any of the reads is `unverifiable` (rc 3), never `applied:false`.
+# --------------------------------------------------------------------------- #
+
+# How many times the whole type→settle→read-back cycle may run before giving up,
+# and how long to wait after the type op before reading the value back. The
+# settle must be long enough for a framework re-render to land (that re-render is
+# the event being detected) and short enough that a verified type stays
+# interactive.
+#
+# Env-overridable because 0.35s is a DEFAULT, not a measurement that holds
+# everywhere: a heavy SPA may need longer.
+#
+# 🔴 BOTH ARE VALIDATED STRICTLY, AND THE SETTLE'S VALIDATION IS SAFETY-CRITICAL.
+# The first version accepted anything made of digits and dots — `0.3.5`, `1.2.3`,
+# a bare `.` — and then ran `sleep "$v" 2>/dev/null || true`, so `sleep` rejected
+# the value, the error was swallowed, and the command ran with NO SETTLE AT ALL,
+# rc 0, no warning. Per the header above, a read-back with no settle reports
+# success in exactly the failing case: a typo in an env var silently turned the
+# detector into a rubber stamp. So the pattern is anchored and exact, the bound
+# is real, and the `sleep` no longer has its failure discarded.
+#
+# The values are VALIDATED at the top of type_verified rather than here, so a
+# malformed BB_TYPE_* cannot break `health`/`text`/every other subcommand that
+# never reads them. type_verified is deliberately not run inside a subshell or a
+# pipeline, so a `die` there really does exit the CLI.
+TYPE_VERIFY_ATTEMPTS="${BB_TYPE_ATTEMPTS:-3}"
+TYPE_VERIFY_SETTLE_S="${BB_TYPE_SETTLE_S:-0.35}"
+# Upper bounds. The comment on the attempt count used to claim it "prevents an
+# unbounded op storm" while imposing no ceiling at all — and a huge value did not
+# even reach the intended message: bash's `[ "$n" -ge 1 ]` on a value past
+# LLONG_MAX prints `[: integer expected` first. Each attempt is up to 3 wire ops
+# against the operator's live browser, so 10 is already 30.
+TYPE_VERIFY_MAX_ATTEMPTS=10
+TYPE_VERIFY_MAX_SETTLE_S=30
+
+# _type_readback_expr SEL — the ONE-EXPRESSION JS that reads the target element's
+# current value back. One expression on purpose: `js`/`eval` evaluates an
+# expression, and a multi-statement body returns null with no error (SKILL.md
+# trap 1), which would look exactly like a CSP block.
+#
+# It returns a TAGGED object so the three outcomes stay distinguishable:
+#   {"v":"<current value>"}       — read it
+#   {"e":"element_not_found"}     — the selector matched nothing
+#   {"e":"no_editable_target"}    — matched, but it is not an input/contenteditable
+# A bare `null` therefore means only one thing: the eval itself did not run
+# (strict page CSP, a chrome:// tab). Returning a plain string instead would
+# collapse "not found" into "CSP blocked" — an EMPTY RESULT that cannot tell two
+# mechanisms apart.
+#
+# The active-element branch REQUIRES editability. `document.activeElement`
+# defaults to <body>, which has no `.value`, so falling back to textContent there
+# would hand back the WHOLE PAGE's text — and a `--verify` substring check
+# against the whole page passes whenever the typed word appears anywhere on it.
+_type_readback_expr() {
+  local sel="$1" pick
+  if [ -n "$sel" ]; then pick="document.querySelector($(json_str "$sel"))"
+  else pick="document.activeElement"; fi
+  printf '(function(){var e=%s;if(!e)return {e:"element_not_found"};var ed=("value" in e)||e.isContentEditable===true;if(!ed)return {e:"no_editable_target"};var v=("value" in e)?e.value:e.innerText;return {v:(v==null?"":String(v))};})()' "$pick"
+}
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE RETRY MUST UNDO ITS OWN INSERT — MEASURED 2026-08-21, LIVE.
+#
+# CDP `Input.insertText` inserts AT THE CARET; it does not select-all first. So a
+# retry that just re-sends the type CONCATENATES: three attempts against a real
+# SPA input left `got: "DreamDreamDreamDreamDreamDreamDreamDreamDreamDream"`
+# against `want: "Dream"`, and a later run left 13 copies. Two consequences, and
+# the second is the serious one:
+#   - attempts 2..N are GUARANTEED to fail whenever attempt 1 landed even
+#     partially — the field can only move further from `want`, so the retry is
+#     not merely useless, it is arithmetic against itself; and
+#   - the caller is handed back a field in a MUCH worse state than before the
+#     call. A verification feature that corrupts the thing it verifies is worse
+#     than no verification.
+#
+# So each retry RESTORES the field to the PRE-STATE measured before the first
+# type, using the native value setter + an `input` event (the technique the
+# civitai site-notes doc prescribes, and the only one a React-controlled input
+# honours — a plain `e.value = x` is invisible to React's synthetic-event layer).
+#
+# 🔴 AND IT IS VERIFIED, NOT ASSUMED: the restore expression returns the field's
+# resulting value, and a retry proceeds ONLY if that equals the pre-state. If the
+# page owns the value and puts its own content straight back, we stop with
+# `verify.retryStopped = "restore_failed"` rather than typing into it again.
+# --------------------------------------------------------------------------- #
+
+# _type_restore_expr SEL TARGET_JSON — the ONE-EXPRESSION JS that puts the field
+# back to TARGET_JSON (a JSON string literal, which is also a JS string literal)
+# and reports the value it ends up holding.
+#
+# The `/*bb-restore*/` and `/*bb-end*/` markers are load-bearing for a reader of
+# a wire trace (this eval is otherwise indistinguishable from the read-back) and
+# are what lets the offline stub in tests/test_browser_type_verify.py SIMULATE a
+# real field rather than only pattern-match the payload.
+_type_restore_expr() {
+  local sel="$1" tgt="$2" pick
+  if [ -n "$sel" ]; then pick="document.querySelector($(json_str "$sel"))"
+  else pick="document.activeElement"; fi
+  printf '/*bb-restore*/(function(){var e=%s;if(!e)return {e:"element_not_found"};var ed=("value" in e)||e.isContentEditable===true;if(!ed)return {e:"no_editable_target"};var v=%s/*bb-end*/;if("value" in e){var d=Object.getOwnPropertyDescriptor(Object.getPrototypeOf(e),"value");if(d&&d.set){d.set.call(e,v);}else{e.value=v;}}else{e.innerText=v;}e.dispatchEvent(new Event("input",{bubbles:true}));e.dispatchEvent(new Event("change",{bubbles:true}));return {v:(("value" in e)?e.value:e.innerText)};})()' "$pick" "$tgt"
+}
+
+# _type_classify RESP HAS_SELECTOR — what did a read (pre-read OR read-back)
+# actually tell us?
+#
+# Prints TWO lines: a KIND on line 1 and a JSON payload on line 2.
+#   value        — line 2 is the field's content, JSON-encoded
+#   bad_target   — line 2 is {"tag": "...", "reason": "..."}; the selector names
+#                  nothing, or names something that cannot hold text
+#   unverifiable — line 2 is {"reason": "..."}; the read could not be performed
+#
+# 🔴 `bad_target` IS SPLIT OUT OF `unverifiable` DELIBERATELY (it used to be
+# folded in, and that made both of them exit 3). Exit 3's documented contract is
+# "the primary op succeeded and only its follow-up failed — never 'nothing
+# happened'", and `element_not_found` / `no_editable_target` mean EXACTLY
+# "nothing happened to the thing you named". They are also the ordinary mistake,
+# not an exotic one: the extension's focusExpression only checks that the element
+# EXISTS and calls .focus(), so pointing --selector at a wrapper <div> — what you
+# get by lifting a selector out of `--annotated` output — makes the type op
+# report success while the insert goes to whatever was really focused. Reporting
+# that as "3, probably fine" is the worst available answer, so it is rc 1.
+#
+# 🔴 BUT ONLY WHEN A --selector WAS ACTUALLY GIVEN. With no selector the read
+# targets `document.activeElement`, and CDP types into whatever the RENDERER has
+# focused — which is NOT always document.activeElement: focus inside a shadow
+# root reports the shadow HOST, a custom element with no `.value` and no
+# contenteditable. Refusing there would be an error naming a flag that appears
+# nowhere in the caller's command line (the same defect the BB_TAB message had),
+# for a type that may well have landed. So the no-selector case is
+# `unverifiable` — "could not confirm", which is what it is — and says how to
+# get a definite answer.
+_type_classify() {
+  printf '%s' "$1" | python3 -c '
+import json, sys
+
+has_sel = sys.argv[1] == "1"
+
+def out(kind, payload):
+    sys.stdout.write(kind + "\n" + json.dumps(payload))
+    raise SystemExit(0)
+
+raw = sys.stdin.read()
+if not raw.strip():
+    out("unverifiable", {"reason": "the read op returned no response - its own "
+                                   "error is on stderr above. A rate-limited "
+                                   "(429) follow-up looks exactly like this."})
+try:
+    d = json.loads(raw)
+except Exception:
+    out("unverifiable", {"reason": "the read op returned unparseable JSON"})
+
+res = d.get("result") if isinstance(d, dict) else None
+if isinstance(res, dict) and res.get("ok") is False:
+    out("unverifiable", {"reason": "the read op itself failed: %s"
+                                   % res.get("error")})
+data = res.get("data") if isinstance(res, dict) else None
+val = data.get("value") if isinstance(data, dict) else None
+
+if val is None:
+    out("unverifiable", {"reason": "the read eval returned null - a strict page "
+                                   "CSP blocks the injected script (GitHub does "
+                                   "this), or the tab is a chrome:// page."})
+if isinstance(val, dict) and isinstance(val.get("e"), str):
+    tag = val["e"]
+    if not has_sel:
+        out("unverifiable", {"reason":
+            "no --selector was given, so the read targeted "
+            "document.activeElement and it is not editable (%s). CDP types into "
+            "whatever the RENDERER has focused, which is not always "
+            "document.activeElement - focus inside a shadow root reports its "
+            "HOST - so this is COULD NOT CONFIRM, not THE TYPE FAILED. Pass "
+            "--selector <sel> for a definite answer." % tag})
+    reason = {
+        "element_not_found":
+            "the --selector matched NO element, so nothing was typed into the "
+            "target you named.",
+        "no_editable_target":
+            "the --selector matched an element that cannot hold text (a wrapper "
+            "<div>, a <span>, a <label>). The extension focuses whatever the "
+            "selector finds without checking it is editable, so a type sent "
+            "there lands wherever focus actually is.",
+    }.get(tag, "the target could not be used: %s" % tag)
+    out("bad_target", {"tag": tag, "reason": reason})
+if not isinstance(val, dict) or not isinstance(val.get("v"), str):
+    out("unverifiable", {"reason": "the read eval returned an unexpected shape"})
+out("value", val["v"])
+' "$2"
+}
+
+# _type_verdict GOT_JSON BEFORE_JSON HAVE_PRE MODE WANT TYPED — did the text land?
+#
+# Prints TWO lines: the state on line 1 (`ok` / `miss`), then a one-line JSON
+# detail object. Two lines rather than one JSON blob so the caller can branch in
+# bash without a second python round-trip.
+#
+# 🔴 PRIVACY, AND WHY THE OLD JUSTIFICATION WAS WRONG. `--expect` used to echo
+# the field's content as `got` on EVERY outcome, justified by "the caller already
+# holds the value it passed as --expect". That is false precisely when it
+# matters: on a MISS the field holds something the caller never supplied — that
+# is the definition of a miss — so `got` is page content, not an echo. And on a
+# HIT the echo is pure leak: `--expect hunter2` wrote `"got": "hunter2"` into
+# stdout and every agent transcript that captured it, saying nothing the exit
+# code had not. So:
+#   * on `ok`, no field content and no `want` is emitted, in either mode;
+#   * on `miss`, `--expect` DOES report `got` — that is the diagnostic the flag
+#     exists for, and it is page content by construction. Use `--verify` on a
+#     secret field, which never emits content in any outcome.
+#
+# 🔴 CONTAINS MODE NEEDS THE PRE-STATE TO MEAN ANYTHING. `typed in got` alone
+# scores a field that ALREADY held the text as `applied: true` after a type that
+# did nothing whatsoever, and it also cannot see compounding (`"DreamDream"`
+# contains `"Dream"`). Both are decided against the measured pre-state here.
+_type_verdict() {
+  python3 -c '
+import json, sys
+
+got = json.loads(sys.argv[1])
+have_pre = sys.argv[3] == "1"
+before = json.loads(sys.argv[2]) if have_pre else None
+mode, want, typed = sys.argv[4], sys.argv[5], sys.argv[6]
+
+def out(state, detail):
+    sys.stdout.write(state + "\n" + json.dumps(detail))
+    raise SystemExit(0)
+
+unchanged = have_pre and got == before
+
+if mode == "expect":
+    if got == want:
+        # No content, no `want`: a passing assertion says everything the caller
+        # needs, and echoing either only puts a value in a transcript.
+        d = {"len": len(got)}
+        if unchanged:
+            # Informational, and a COUNT-free boolean: the assertion holds, but
+            # this type changed nothing - the field already read this way.
+            d["unchanged"] = True
+        out("ok", d)
+    out("miss", {"got": got, "len": len(got), "want": want})
+
+# contains mode - never emits the field content, in any branch.
+if typed not in got:
+    out("miss", {"len": len(got),
+                 "reason": "the field does not contain the typed text"})
+if unchanged:
+    out("miss", {"len": len(got), "unchanged": True,
+                 "reason": "the field is byte-identical to what it held BEFORE "
+                           "this type, so nothing landed - it already contained "
+                           "the text. Without the pre-read this scored as "
+                           "applied:true."})
+if have_pre:
+    added = got.count(typed) - before.count(typed)
+    if added > 1:
+        out("miss", {"len": len(got), "copiesAdded": added,
+                     "reason": "the field gained %d copies of the typed text, "
+                               "not one - it is compounding." % added})
+out("ok", {"len": len(got)})
+' "$1" "$2" "$3" "$4" "$5" "$6"
+}
+
+# _type_restore_ok RESTORE_RESP TARGET_JSON — rc 0 iff the field now holds the
+# target. A restore that did not stick must NOT be treated as one that did:
+# that is the whole difference between a bounded retry and 13 copies.
+_type_restore_ok() {
+  printf '%s' "$1" | python3 -c '
+import json, sys
+try:
+    val = json.loads(sys.stdin.read())["result"]["data"]["value"]
+except Exception:
+    raise SystemExit(1)
+if not isinstance(val, dict) or not isinstance(val.get("v"), str):
+    raise SystemExit(1)
+raise SystemExit(0 if val["v"] == json.loads(sys.argv[1]) else 1)
+' "$2"
+}
+
+# _type_merge TYPE_RESP DETAIL_JSON STATE ATTEMPTS MODE RETRY_STOP — fold the
+# verdict into the type envelope's result.data as `applied` + `verify`, print it.
+#
+# RETRY_STOP is empty on the ordinary paths and names the reason the retry loop
+# refused to go round again (`no_pre_state` / `restore_failed`) otherwise. It is
+# surfaced as `verify.retryStopped` so the distinction is MACHINE-readable, not
+# only a stderr sentence.
+#
+# ADDITIVE ONLY: every field the extension sent is preserved, so a consumer
+# reading `.result.data.typed` is untouched. `applied` is TRI-STATE — true /
+# false / null — and null means "not verified", never "fine". Only
+# `unverifiable` maps to null; `bad_target` is false, because the text is
+# demonstrably not in the target the caller named.
+#
+# On any parse failure it passes the ORIGINAL envelope through unchanged. Losing
+# the caller's result because the annotation step tripped would be a strictly
+# worse outcome than an un-annotated result.
+_type_merge() {
+  printf '%s\v%s' "$1" "$2" | python3 -c '
+import json, sys
+
+state, attempts, mode = sys.argv[1], sys.argv[2], sys.argv[3]
+retry_stop = sys.argv[4] if len(sys.argv) > 4 else ""
+env_raw, _, det_raw = sys.stdin.read().partition("\v")
+
+try:
+    d = json.loads(env_raw)
+    det = json.loads(det_raw)
+except Exception:
+    sys.stdout.write(env_raw)
+    raise SystemExit(0)
+
+res = d.get("result") if isinstance(d, dict) else None
+if not isinstance(res, dict):
+    sys.stdout.write(env_raw)
+    raise SystemExit(0)
+data = res.get("data")
+if not isinstance(data, dict):
+    data = {}
+    res["data"] = data
+
+data["applied"] = {"ok": True, "miss": False, "bad_target": False}.get(state)
+verify = {"mode": mode, "state": state, "attempts": int(attempts)}
+verify.update(det if isinstance(det, dict) else {})
+if retry_stop:
+    verify["retryStopped"] = retry_stop
+data["verify"] = verify
+json.dump(d, sys.stdout)
+' "$3" "$4" "$5" "$6"
+}
+
+# _type_bad_target_die DETAIL_JSON WHERE — refuse, loudly, on rc 1.
+#
+# WHERE is `pre` (caught by the pre-read, so NOTHING was typed) or `post` (the
+# target went away after the type). Both are rc 1: see the contract note on
+# _type_classify.
+_type_bad_target_die() {
+  local where="$2"
+  echo "browser: bad_target: the --selector does not name something this type could land in." >&2
+  printf '%s' "$1" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+sys.stderr.write("browser:   %s (%s)\n" % (d.get("reason", ""), d.get("tag", "")))
+' || true
+  if [ "$where" = "pre" ]; then
+    echo "browser:   Caught by the PRE-READ, so NOTHING was typed — no text went anywhere." >&2
+  else
+    echo "browser:   The target was usable before the type and is not now, so the page" >&2
+    echo "browser:   replaced or removed it. The text WAS sent; where it landed is unknown." >&2
+  fi
+  echo "browser:   Re-read the page with 'browser text --annotated' and pick a selector that" >&2
+  echo "browser:   names the <input>/<textarea>/[contenteditable] ITSELF, not its wrapper." >&2
+  echo "browser:   This is rc 1, not rc 3: rc 3 means the type applied and only the check" >&2
+  echo "browser:   failed, which is the opposite of what happened here." >&2
+}
+
+# type_verified EXTRA SEL MODE WANT TYPED — read the field, send `type`, confirm
+# it landed, retry the WHOLE cycle up to TYPE_VERIFY_ATTEMPTS times, print the
+# annotated envelope, and return the exit code. MODE is `expect` (exact equality
+# with WANT) or `contains` (the read-back must contain the typed text). TYPED is
+# the text actually sent, which `--expect` lets differ from WANT.
+#
+# 🔴 IT PRINTS AND RETURNS RATHER THAN `die`-ing, and the caller must NOT pipe it
+# into `pretty`: a `die`/`exit` inside a pipeline component exits only that
+# component's subshell, so the message would be printed and the failure then
+# swallowed as rc 0 — the precise shape of bug this whole flag exists to remove.
+type_verified() {
+  local extra="$1" sel="$2" mode="$3" want="$4" typed="$5"
+  local rexpr rb resp verdict state detail attempt=1
+  local kind pre_resp before="" have_pre=0 rr retry_stop="" sint got_json=""
+  # 1/0 for "a --selector was given", passed to _type_classify: it decides
+  # whether an un-editable target is the caller's selector (rc 1) or an
+  # unreadable activeElement (rc 3). See the note above _type_classify.
+  local has_sel=0; [ -n "$sel" ] && has_sel=1
+
+  # An unbounded/garbage attempt count would turn a typo into an op storm against
+  # the user's LIVE browser, so refuse before the first op goes on the wire.
+  case "$TYPE_VERIFY_ATTEMPTS" in
+    ""|*[!0-9]*) die "BB_TYPE_ATTEMPTS must be an integer 1..${TYPE_VERIFY_MAX_ATTEMPTS} (got: $TYPE_VERIFY_ATTEMPTS)" ;;
+  esac
+  # 🔴 Bound the STRING before ANY arithmetic. `[ "$n" -ge 1 ]` on a value past
+  # LLONG_MAX prints `browser: line NNN: [: integer expected` and the message
+  # below never runs — the caller is handed a bash internal instead of the rule
+  # they broke. Two digits cannot overflow, and the ceiling is 10.
+  if [ "${#TYPE_VERIFY_ATTEMPTS}" -gt 2 ] \
+     || [ "$TYPE_VERIFY_ATTEMPTS" -lt 1 ] \
+     || [ "$TYPE_VERIFY_ATTEMPTS" -gt "$TYPE_VERIFY_MAX_ATTEMPTS" ]; then
+    die "BB_TYPE_ATTEMPTS must be an integer 1..${TYPE_VERIFY_MAX_ATTEMPTS} (got: $TYPE_VERIFY_ATTEMPTS)"
+  fi
+  # 🔴 ANCHORED AND EXACT, not "digits and dots". The old test accepted `0.3.5`,
+  # `1.2.3` and a bare `.`; `sleep` then rejected them and the error was thrown
+  # away, so the command ran with NO SETTLE, rc 0, silently — and a read-back
+  # with no settle reports success in the exact case this feature detects.
+  if ! [[ "$TYPE_VERIFY_SETTLE_S" =~ ^([0-9]+(\.[0-9]+)?|\.[0-9]+)$ ]]; then
+    die "BB_TYPE_SETTLE_S must be a number of seconds like 0, 0.35 or .5 (got: $TYPE_VERIFY_SETTLE_S)"
+  fi
+  sint="${TYPE_VERIFY_SETTLE_S%%.*}"; sint="${sint:-0}"
+  if [ "${#sint}" -gt 2 ] || [ "$sint" -gt "$TYPE_VERIFY_MAX_SETTLE_S" ]; then
+    die "BB_TYPE_SETTLE_S must be <= ${TYPE_VERIFY_MAX_SETTLE_S} seconds (got: $TYPE_VERIFY_SETTLE_S)"
+  fi
+
+  rexpr="$(_type_readback_expr "$sel")"
+
+  # --- PRE-READ: measure the field BEFORE typing into it. --------------------
+  # This is the ground truth every later decision rests on (see the header). A
+  # failed pre-read is not fatal — the type still happens — but it forbids the
+  # retry, because a retry whose undo cannot be verified is a retry that can
+  # only make the field worse.
+  pre_resp="$(cmd_op eval "\"js\":$(json_str "$rexpr")")" || pre_resp=""
+  verdict="$(_type_classify "$pre_resp" "$has_sel")"
+  kind="${verdict%%$'\n'*}"
+  detail="${verdict#*$'\n'}"
+  case "$kind" in
+    bad_target)
+      # 🔴 Refuse BEFORE typing. The selector names nothing typeable, so sending
+      # the text would put it wherever focus happens to be — silently, in the
+      # user's live browser.
+      _type_bad_target_die "$detail" pre
+      return 1 ;;
+    value)
+      before="$detail"; have_pre=1 ;;
+  esac
+
+  while : ; do
+    # cmd_op runs in a command substitution, so its `die` can only kill that
+    # subshell — `|| exit 1` is what propagates a real type failure.
+    resp="$(cmd_op type "$extra")" || exit 1
+    # 🔴 NOT `2>/dev/null || true`. Swallowing this is how a malformed settle
+    # became "no settle, rc 0, no warning" — and with no settle the read-back is
+    # taken in the same tick as the insert, which reports success in the failing
+    # case. Validated above, so a failure here is a broken environment, not a
+    # typo, and must be loud.
+    sleep "$TYPE_VERIFY_SETTLE_S" || die "the ${TYPE_VERIFY_SETTLE_S}s settle failed to run; refusing to read back without it (an unsettled read-back reports success even when the type did not apply)"
+    # A failed read-back is NOT a failed type: keep the empty string and let
+    # _type_classify call it `unverifiable`.
+    rb="$(cmd_op eval "\"js\":$(json_str "$rexpr")")" || rb=""
+    verdict="$(_type_classify "$rb" "$has_sel")"
+    kind="${verdict%%$'\n'*}"
+    detail="${verdict#*$'\n'}"
+    case "$kind" in
+      unverifiable) state=unverifiable; break ;;
+      bad_target)   state=bad_target;   break ;;
+    esac
+    # Keep the read VALUE before `detail` is rebound to the verdict's detail:
+    # the restore decision below compares it against the pre-state, and both are
+    # JSON-encoded by the same encoder, so a byte comparison is an exact string
+    # comparison.
+    got_json="$detail"
+    verdict="$(_type_verdict "$got_json" "$before" "$have_pre" "$mode" "$want" "$typed")"
+    state="${verdict%%$'\n'*}"
+    detail="${verdict#*$'\n'}"
+    [ "$state" = "miss" ] || break
+    [ "$attempt" -lt "$TYPE_VERIFY_ATTEMPTS" ] || break
+    # 🔴 NO PRE-STATE, NO RETRY. `Input.insertText` appends at the caret, so a
+    # bare re-type CONCATENATES; undoing it requires knowing what was there
+    # before, and guessing that from the post-state is what amputated a user's
+    # field. Without the measurement we stop.
+    if [ "$have_pre" -eq 0 ]; then retry_stop="no_pre_state"; break; fi
+    # The restore is SKIPPED when the field already reads exactly as it did
+    # before this attempt — the insert did not apply, which is the commonest
+    # failure here, and there is nothing to undo. Saves an op AND cannot fail.
+    if [ "$got_json" != "$before" ]; then
+      rr="$(cmd_op eval "\"js\":$(json_str "$(_type_restore_expr "$sel" "$before")")")" || rr=""
+      if ! _type_restore_ok "$rr" "$before"; then retry_stop="restore_failed"; break; fi
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  _type_merge "$resp" "$detail" "$state" "$attempt" "$mode" "$retry_stop" | pretty
+
+  case "$state" in
+    ok) return 0 ;;
+    bad_target)
+      _type_bad_target_die "$detail" post
+      return 1 ;;
+    unverifiable)
+      echo "browser: input_not_verified: the type op succeeded but its result could NOT be confirmed." >&2
+      # 🔴 NO `2>/dev/null` HERE. The diagnostic these lines exist to print IS on
+      # stderr, so redirecting it silences the message instead of the failure —
+      # written that way once and caught by the tests below, which is the only
+      # reason it is not in the shipped CLI.
+      printf '%s' "$detail" | python3 -c 'import json,sys; sys.stderr.write("browser:   " + str(json.load(sys.stdin).get("reason","")) + "\n")' || true
+      echo "browser:   result.data.applied is null — 'not verified', NOT 'fine'. Exit 3 = the" >&2
+      echo "browser:   type was applied and only the check failed (rc 1 would mean the type failed)." >&2
+      return 3 ;;
+  esac
+
+  echo "browser: input_not_applied: the field does NOT hold the typed text after ${attempt} attempt(s)." >&2
+  if [ "$mode" = "expect" ]; then
+    printf '%s' "$detail" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+sys.stderr.write("browser:   wanted: %s\n" % json.dumps(d.get("want")))
+sys.stderr.write("browser:   got:    %s\n" % json.dumps(d.get("got")))
+sys.stderr.write("browser:   (that `got` is the PAGE’s content, not an echo of what you passed.\n")
+sys.stderr.write("browser:    Use --verify on a secret field - it never reports a value.)\n")
+' || true
+  else
+    printf '%s' "$detail" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+sys.stderr.write("browser:   %s (field length: %s)\n"
+                 % (d.get("reason", "the field does not contain the typed text"),
+                    d.get("len")))
+sys.stderr.write("browser:   re-run with --expect <value> to see the value it actually holds.\n")
+' || true
+  fi
+  case "$retry_stop" in
+    restore_failed)
+      echo "browser:   retry STOPPED early: putting the field back to what it held BEFORE this" >&2
+      echo "browser:   call did NOT stick — the page owns this value. Re-typing would CONCATENATE" >&2
+      echo "browser:   (insertText appends at the caret), so the loop refused;" >&2
+      echo "browser:   result.data.verify.retryStopped='restore_failed'." >&2 ;;
+    no_pre_state)
+      echo "browser:   retry STOPPED early: the field could not be read BEFORE the type, so there" >&2
+      echo "browser:   is no measured value to put back and re-typing would CONCATENATE;" >&2
+      echo "browser:   result.data.verify.retryStopped='no_pre_state'." >&2 ;;
+  esac
+  echo "browser:   The page most likely re-rendered from stale state over the insert. Try" >&2
+  echo "browser:   'browser wake' first (a throttled tab drops input), or click the field then re-type." >&2
+  return 1
+}
+
+# --------------------------------------------------------------------------- #
 # `emulate --reset --recreate` — REPLACE a tab instead of repairing it (#319).
 #
 # Since 0.8.1 plain `--reset` DOES repair the stuck viewport (arm-then-clear; see
@@ -2092,21 +2693,48 @@ else:
     # browser [--frame <f>] type <text> [--selector <sel>] — text input into the
     # focused element (or --selector first). Top frame: TRUSTED CDP. Cross-origin
     # --frame: SYNTHETIC input (set value + input/change) via chrome.scripting.
-    POS=""; POS_SEEN=0; tsel=""
+    #
+    # --expect <value> / --verify — CONFIRM the text landed (see type_verified).
+    # Both read the field FIRST, type, re-read after a settle, and retry the whole
+    # cycle up to 3×; --expect requires exact equality with <value>, --verify only
+    # that the read-back CONTAINS the typed text (and never reports a value).
+    POS=""; POS_SEEN=0; tsel=""; texpect=""; texpect_set=0; tverify=0
     while [ $# -gt 0 ]; do
       case "$1" in
         --selector) shift; [ $# -ge 1 ] || die "usage: browser type <text> [--selector <sel>]"; tsel="$1"; shift ;;
         --selector=*) tsel="${1#--selector=}"; shift ;;
+        # `--expect ''` is a legitimate assertion (the field ends up EMPTY), so
+        # "was it given?" is tracked separately from "is it non-empty".
+        --expect) shift; [ $# -ge 1 ] || die "usage: browser type <text> [--selector <sel>] [--expect <value>]"; texpect="$1"; texpect_set=1; shift ;;
+        --expect=*) texpect="${1#--expect=}"; texpect_set=1; shift ;;
+        --verify) tverify=1; shift ;;
         --) shift; pos_rest "type takes one text arg" "$@"; break ;;
-        -*) die "browser type: unknown flag: $1 (try: --selector <sel>; use '--' before text starting with '-')" ;;
+        -*) die "browser type: unknown flag: $1 (try: --selector <sel>, --expect <value>, --verify; use '--' before text starting with '-')" ;;
         *) pos_add "type takes one text arg" "$1"; shift ;;
       esac
     done
     txt="$POS"
-    [ -n "$txt" ] || die "usage: browser [--frame <f>] type <text> [--selector <sel>]"
+    [ -n "$txt" ] || die "usage: browser [--frame <f>] type <text> [--selector <sel>] [--expect <value>|--verify]"
     extra="\"text\":$(json_str "$txt")"
     if [ -n "$tsel" ]; then extra="${extra},\"selector\":$(json_str "$tsel")"; fi
-    cmd_op type "$extra" | pretty
+    if [ "$texpect_set" -eq 0 ] && [ "$tverify" -eq 0 ]; then
+      # Unverified (default): byte-identical wire behaviour to before.
+      cmd_op type "$extra" | pretty
+    else
+      # 🔴 NOT piped: type_verified must own the exit code (a `die` inside a
+      # pipeline component exits only that subshell — the failure would print
+      # and then be swallowed as rc 0). --expect wins over --verify: it is the
+      # strictly stronger assertion, so honouring the weaker one would silently
+      # downgrade what the caller asked for.
+      if [ "$texpect_set" -eq 1 ]; then
+        # TXT (what goes on the wire), not TEXPECT, is what `contains` counts and
+        # what a compounding check measures; the two may legitimately differ.
+        type_verified "$extra" "$tsel" expect "$texpect" "$txt"
+      else
+        type_verified "$extra" "$tsel" contains "$txt" "$txt"
+      fi
+      exit $?
+    fi
     ;;
   key)
     # browser [--frame <f>] key <Enter|Tab|Escape|Backspace|Delete|Arrow*|Home|End|Page*>

--- a/scripts/browser-bridge/reference/type-verify.md
+++ b/scripts/browser-bridge/reference/type-verify.md
@@ -1,0 +1,133 @@
+# Confirming a `type` actually landed — `--expect` / `--verify`
+
+**Load this when:** you typed into a field and need to KNOW the text is there ·
+a form submit behaved as if the field were empty · a value you set "disappeared"
+on a React/Mantine/SPA page · a `type` reported success and the page kept showing
+its old value · you got `bad_target`, `input_not_applied` or `input_not_verified`
+· you are choosing between `--expect` and `--verify` on a secret field.
+
+Core: `~/workspace/devrc/scripts/browser-bridge/SKILL.md`.
+
+## 🔴 A bare `type` is not a claim about the DOM
+
+`browser type <text> --selector <sel>` returns the same envelope whether the
+insert landed or not:
+
+```json
+{"typed": 5, "trusted": true, "url": "…"}
+```
+
+`typed` is the length of the string the CLI **sent**. Measured live 2026-08-20:
+the op replaces the value correctly most of the time and, intermittently, does
+not apply **at all** while the page keeps rendering its previous state. Three
+confident, wrong conclusions about a live site came out of reading `typed` as
+evidence in one session.
+
+## The two flags
+
+| flag | asserts | on failure |
+|---|---|---|
+| `--expect <value>` | the field's value **equals** `<value>` | rc 1 `input_not_applied`, reports **wanted** and **got** |
+| `--verify` | the typed text **arrived** — present, and the field CHANGED | rc 1 `input_not_applied`, reports a **length**, never a value |
+
+Both annotate `result.data`:
+
+```json
+{"typed": 5, "applied": true,
+ "verify": {"mode": "expect", "state": "ok", "attempts": 2, "len": 5}}
+```
+
+`applied` is **tri-state**: `true` / `false` / **`null` = NOT VERIFIED, not
+"fine"**. `verify.state` is `ok` · `miss` · `bad_target` · `unverifiable`.
+
+## Exit codes — the distinction that matters
+
+| rc | means | when |
+|---|---|---|
+| 0 | the assertion holds | |
+| 1 | the text is **not** in the target you named | a confirmed `miss`, or `bad_target` |
+| 3 | the type applied and only the CHECK failed | `unverifiable` — the read could not be EVALUATED |
+
+`bad_target` is rc **1**, deliberately. The extension's `focusExpression` only
+checks that the element EXISTS and calls `.focus()`, so pointing `--selector` at
+a wrapper `<div>` — what you get by lifting a selector out of `--annotated`
+output — makes the type op report success while the insert goes to whatever is
+actually focused. rc 3 says "never nothing happened", which would be false here.
+The pre-read normally catches it **before anything is typed at all**.
+
+rc **3** is reserved for reads that could not run: a strict page CSP (GitHub
+does this), a `chrome://` tab, a rate-limited (429) follow-up.
+
+With **no** `--selector` an un-editable target is rc 3, not `bad_target`: the
+read targets `document.activeElement` but CDP types into whatever the RENDERER
+has focused, and focus inside a shadow root reports the shadow HOST. Pass
+`--selector` for a definite answer.
+
+## 🔴 Why it costs 3 wire ops, and why that is not negotiable
+
+A verified type is **pre-read → type → settle → read-back**.
+
+| case | ops |
+|---|---|
+| happy path | **3** |
+| 3 attempts, the insert lands | 9 |
+| 3 attempts, nothing lands | 7 (the restore is skipped — nothing to undo) |
+
+Two of those three ops are load-bearing:
+
+**The settle is the DETECTOR, not politeness.** CDP `Input.insertText` mutates
+the DOM value SYNCHRONOUSLY, so a read-back in the same tick reports success even
+in the failing case — the value is there for a moment and a re-render from stale
+state overwrites it. `BB_TYPE_SETTLE_S` (default 0.35s, max 30) is what makes the
+read observe the state the USER is left looking at. This is why verification
+lives in the CLI, not the extension.
+
+**The pre-read is the ground truth.** `Input.insertText` inserts AT THE CARET and
+does not select-all, so a retry that re-types without clearing CONCATENATES —
+measured live: three attempts left ten copies of the text in a real SPA input,
+and a later run left thirteen. The retry therefore restores the field to the
+value the pre-read measured. Deriving that value instead — by stripping a
+trailing copy of the typed text off the read-back — is only correct when the
+insert LANDED, which is exactly the case this feature exists to detect: a field
+holding `"my password"`, typed into with `"password"` and not applied, was
+amputated to `"my "`.
+
+Consequences you will see:
+
+- `verify.retryStopped: "restore_failed"` — putting the field back did not stick
+  (the page owns the value). The loop refuses rather than concatenate.
+- `verify.retryStopped: "no_pre_state"` — the field could not be read BEFORE the
+  type, so there is nothing to restore to and no retry is made.
+- `verify.unchanged: true` — the field is byte-identical to what it held before.
+  Under `--verify` that is a **miss** (nothing landed; the text was already
+  there). Under `--expect` it is still a pass — the assertion is about the final
+  state — but you are told.
+- `verify.copiesAdded: N` — under `--verify`, the insert added more than one copy.
+
+## Privacy — `--verify` on anything secret
+
+`--verify` never reports a value, in any branch: a length and, at most, a count.
+
+`--expect` does **not** echo on a pass (no `got`, no `want` — only a length). On
+a **miss** it reports `got`, because that is the diagnostic the flag exists for —
+and `got` is the PAGE's content by construction, not an echo of your argument.
+On a password field, use `--verify`.
+
+## Tuning
+
+| var | default | bounds |
+|---|---|---|
+| `BB_TYPE_ATTEMPTS` | 3 | 1..10 — each attempt is up to 3 ops against the live browser |
+| `BB_TYPE_SETTLE_S` | 0.35 | 0..30, e.g. `0`, `0.35`, `.5` |
+
+Both are validated before any op reaches the wire; a malformed value is rc 1
+naming the variable, never a silent fallback. Raise the settle on a heavy SPA, or
+if a 429 trips.
+
+## Not covered by the headless suite
+
+`scripts/browser-bridge/tests/test_browser_type_verify.py` pins the control flow
+against a stub bridge. It cannot observe a real `Input.insertText` landing in a
+real renderer and then being overwritten by a framework re-render — see
+`reference/security-ops.md`, which makes live-verify-on-real-Brave the mandatory
+gate for any browser-bridge change.

--- a/scripts/browser-bridge/tests/test_browser_type_verify.py
+++ b/scripts/browser-bridge/tests/test_browser_type_verify.py
@@ -1,0 +1,928 @@
+"""`browser type --expect/--verify` — HEADLESS.
+
+Fully offline: a loopback stub HTTP server stands in for server.py (the same
+pattern as ``test_browser_cli_args.py``), so no Brave, no extension, no bridge.
+It records every /cmd body and answers a scripted envelope per op, which is what
+lets these tests exercise the RETRY loop — the stub can miss twice and then hit.
+
+🔴 WHAT THESE TESTS DO **NOT** COVER. They pin the CLI's control flow against a
+stub. They cannot observe the defect that motivated `--expect`: a real
+``Input.insertText`` landing in a real renderer and then being overwritten by a
+framework re-render. ``reference/security-ops.md`` makes live-verify-on-real-
+Brave the mandatory gate for any browser-bridge change precisely because a green
+suite here is a prerequisite, never verification. The live commands are listed in
+the PR body.
+
+🔴 TWO FIXTURE DIMENSIONS THAT USED TO BE PINNED, AND WHAT THAT COST
+--------------------------------------------------------------------
+An earlier revision of this file could not see two 🔴 defects in the code it
+tested, and in both cases the reason was the FIXTURE, not the assertions:
+
+1. **The simulated field could only APPEND.** ``on_type`` did ``state["v"] +=
+   text`` unconditionally, so the no-apply arm — the exact failure the feature
+   exists to detect — was never simulated. The retry's "undo" derived the field's
+   prior content by stripping a trailing copy of the typed text off the
+   READ-BACK, which is sound only when the insert landed. On a field holding
+   ``"my password"``, typed into with ``"password"`` and NOT applied, it
+   amputated the value to ``"my "`` and then reported that as the page's content.
+   ``Field(initial=..., applies=False)`` below is the arm that sees it, and
+   ``applies=True`` is its control.
+2. **The settle was pinned to ``0`` for every test.** Per the CLI's own header a
+   read-back taken in the same tick as the insert reports success even in the
+   failing case, so the whole suite ran with the detector disabled — deleting the
+   ``sleep`` line left 51/51 green. The fixture now uses a small but NON-ZERO
+   settle, and ``test_the_settle_actually_happens`` measures wall time at two
+   points so a deleted or skipped sleep is RED.
+
+Run: nix-shell -p python312Packages.pytest curl --run \\
+       "pytest scripts/browser-bridge/tests/test_browser_type_verify.py"
+"""
+import json
+import os
+import shutil
+import subprocess
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+BB = Path(__file__).resolve().parent.parent
+CLI = BB / "browser"
+
+# Small but NON-ZERO: the sleep must really run (and really be validated) in
+# every test, while 3 attempts x 20ms stays free. The wall-time assertions live
+# in test_the_settle_actually_happens, which overrides this.
+TEST_SETTLE_S = "0.02"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("curl") is None,
+    reason="the browser CLI is bash and talks to the bridge with curl")
+
+
+# --------------------------------------------------------------------------- #
+# Stub bridge — scriptable per op, records every body.
+# --------------------------------------------------------------------------- #
+def _ok(data):
+    return {"ok": True, "result": {"id": "c", "ok": True, "data": data}}
+
+
+@pytest.fixture
+def bridge(tmp_path):
+    """A stub bridge whose reply is chosen by a per-op QUEUE.
+
+    ``b.script("eval", [r1, r2, ...])`` queues responses for that op; the LAST
+    entry repeats once the queue drains, so a test only has to describe the
+    interesting prefix. A CALLABLE entry is a stateful responder: it gets the
+    request body and returns the envelope, which is what lets ``Field`` below
+    simulate an input instead of replaying canned reads.
+    """
+    scripts: dict = {}
+    bodies: list = []
+
+    class _H(BaseHTTPRequestHandler):
+        def _reply(self, code, payload):
+            raw = json.dumps(payload).encode()
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+
+        def do_POST(self):
+            n = int(self.headers.get("Content-Length") or 0)
+            body = json.loads(self.rfile.read(n).decode())
+            bodies.append(body)
+            op = body.get("op")
+            queue = scripts.get(op)
+            if queue:
+                # Pop until one left, then repeat it — "and thereafter" without
+                # making every test spell out a tail of identical entries.
+                item = queue.pop(0) if len(queue) > 1 else queue[0]
+                if callable(item):
+                    item = item(body)
+            elif op == "type":
+                item = _ok({"url": "https://a.test", "typed": 5,
+                            "frame": None, "trusted": True})
+            else:
+                item = _ok({"url": "https://a.test", "value": None})
+            code, payload = item if isinstance(item, tuple) else (200, item)
+            self._reply(code, payload)
+
+        def do_GET(self):
+            self._reply(200, {"ok": True, "instances": []})
+
+        def log_message(self, *a):
+            pass
+
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), _H)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+
+    tok = tmp_path / "token"
+    tok.write_text("type-verify-token\n")
+    env = dict(os.environ)
+    env.update({
+        "BROWSER_BRIDGE_HOST": "127.0.0.1",
+        "BROWSER_BRIDGE_PORT": str(srv.server_address[1]),
+        "BROWSER_BRIDGE_TOKEN_FILE": str(tok),
+        "CLAUDE_CODE_SESSION_ID": "pytest-type-verify",
+        "HOME": str(tmp_path),
+        "BB_TYPE_SETTLE_S": TEST_SETTLE_S,
+    })
+    # Never inherit the developer's own targeting defaults — that would make the
+    # routing assertions pass or fail on the ambient environment.
+    for k in ("BB_INSTANCE", "BB_TAB", "BB_FRAME", "BB_TYPE_ATTEMPTS"):
+        env.pop(k, None)
+
+    class _B:
+        @staticmethod
+        def script(op, responses):
+            scripts[op] = list(responses)
+
+        @staticmethod
+        def run(*args, **kw):
+            e = dict(_B.env)
+            e.update(kw.pop("extra_env", {}) or {})
+            return subprocess.run(["bash", str(CLI), *args], env=e,
+                                  capture_output=True, text=True, timeout=120)
+
+        @staticmethod
+        def ops():
+            return [b.get("op") for b in _B.bodies]
+
+        @staticmethod
+        def evals(kind="read"):
+            """The `js` payloads of the eval ops, split by what they DO.
+
+            The CLI marks a restore with a `/*bb-restore*/` prefix precisely so a
+            wire trace (and this) can tell the two apart."""
+            js = [b["js"] for b in _B.bodies if b.get("op") == "eval"]
+            restore = [j for j in js if j.startswith("/*bb-restore*/")]
+            return restore if kind == "restore" else [j for j in js
+                                                      if j not in restore]
+
+    # Assigned AFTER the class body on purpose: a class body does not close over
+    # the enclosing function's scope, so `bodies = bodies` in there is a
+    # NameError, not a copy (the same note the sibling fixture in
+    # test_browser_cli_args.py carries).
+    _B.bodies = bodies
+    _B.env = env
+
+    try:
+        yield _B
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def _value(v):
+    """An `eval` envelope carrying the read expression's tagged result."""
+    return _ok({"url": "https://a.test", "value": v})
+
+
+def _data(cp):
+    """`.result.data` out of the CLI's stdout, asserting stdout parses at all."""
+    return json.loads(cp.stdout)["result"]["data"]
+
+
+def _restore_target(js):
+    """The value a `/*bb-restore*/` eval is putting into the field.
+
+    The CLI splices the target in as a JSON string literal between two sentinel
+    comments precisely so a stub can read it back out without parsing JS."""
+    return json.loads(js.split("var v=", 1)[1].split("/*bb-end*/", 1)[0])
+
+
+# --------------------------------------------------------------------------- #
+# Op-sequence expectations.
+#
+# EVERY verified type opens with a read of the field — the pre-state the retry's
+# undo and `--verify`'s "did anything change?" both rest on. After that each
+# attempt is `type` + a read-back, with a restore `eval` between two attempts
+# ONLY when the failed attempt actually changed the field (when it did not, there
+# is nothing to undo and the op is skipped).
+# --------------------------------------------------------------------------- #
+def _ops(n, restores=True):
+    per = ["type", "eval", "eval"] if restores else ["type", "eval"]
+    return ["eval"] + per * (n - 1) + ["type", "eval"]
+
+
+class Field:
+    """A simulated text input: `type` inserts AT THE CARET (append), the read
+    eval reports the current value, a restore eval sets it.
+
+    ``applies`` is the dimension the old fixture pinned to True. ``applies=False``
+    is a type that does NOT land — the intermittent failure this whole feature
+    exists to detect, and the arm in which deriving the field's prior content
+    from the READ-BACK destroys real user content.
+
+    ``restore_sticks=False`` is a page that owns the value and writes its own
+    back over any restore.
+    """
+
+    def __init__(self, bridge, initial="", applies=False, restore_sticks=True,
+                 read_tag=None, pre_read=None):
+        self.v = initial
+        self.applies = applies
+        self.restore_sticks = restore_sticks
+        self.read_tag = read_tag      # e.g. {"e": "element_not_found"} post-type
+        self.pre_read = pre_read      # override for the FIRST read only
+        self.reads = 0
+        bridge.script("type", [self._on_type])
+        bridge.script("eval", [self._on_eval])
+        self.bridge = bridge
+
+    def _on_type(self, body):
+        if self.applies:
+            self.v += body["text"]
+        return _ok({"url": "https://a.test", "typed": len(body["text"]),
+                    "frame": None, "trusted": True})
+
+    def _on_eval(self, body):
+        js = body["js"]
+        if js.startswith("/*bb-restore*/"):
+            if self.restore_sticks:
+                self.v = _restore_target(js)
+            return _value({"v": self.v})
+        self.reads += 1
+        if self.reads == 1 and self.pre_read is not None:
+            return _value(self.pre_read)
+        if self.reads > 1 and self.read_tag is not None:
+            return _value(self.read_tag)
+        return _value({"v": self.v})
+
+
+# --------------------------------------------------------------------------- #
+# 0. the unverified default path is untouched
+# --------------------------------------------------------------------------- #
+def test_plain_type_is_unchanged_and_makes_exactly_one_request(bridge):
+    """INVARIANT GUARD (back-compat), not regression coverage.
+
+    Verification now costs THREE wire ops, so turning it on by default would
+    change the behaviour of every existing `type` caller. Pin that the default
+    path is still ONE request with no verification fields."""
+    cp = bridge.run("type", "hello", "--selector", "#q")
+    assert cp.returncode == 0, cp.stderr
+    assert bridge.ops() == ["type"]
+    assert bridge.bodies[0] == {"op": "type", "text": "hello", "selector": "#q"}
+    data = _data(cp)
+    assert "applied" not in data and "verify" not in data
+
+
+# --------------------------------------------------------------------------- #
+# 1. --expect — the measured defect
+# --------------------------------------------------------------------------- #
+def test_expect_match_reports_applied_true_after_one_attempt(bridge):
+    bridge.script("eval", [_value({"v": ""}), _value({"v": "hello"})])
+    cp = bridge.run("type", "hello", "--selector", "#q", "--expect", "hello")
+    assert cp.returncode == 0, cp.stderr
+    assert bridge.ops() == ["eval", "type", "eval"], "pre-read, type, read-back"
+    data = _data(cp)
+    assert data["applied"] is True
+    assert data["verify"]["mode"] == "expect"
+    assert data["verify"]["state"] == "ok"
+    assert data["verify"]["attempts"] == 1
+    # Additive: the extension's own fields survive the annotation.
+    assert data["typed"] == 5 and data["trusted"] is True
+
+
+def test_expect_retries_the_whole_type_and_succeeds_on_the_second(bridge):
+    """THE POINT OF THE FLAG. The first read-back shows the page's STALE value —
+    the measured failure — and the CLI re-types rather than reporting success.
+
+    The stale read equals the PRE-STATE, i.e. the insert did not land at all, so
+    there is nothing to undo and no restore op is spent."""
+    bridge.script("eval", [_value({"v": "stale"}), _value({"v": "stale"}),
+                           _value({"v": "hello"})])
+    cp = bridge.run("type", "hello", "--selector", "#q", "--expect", "hello")
+    assert cp.returncode == 0, cp.stderr
+    assert bridge.ops() == _ops(2, restores=False)
+    assert bridge.evals("restore") == [], "nothing changed; nothing to restore"
+    data = _data(cp)
+    assert data["applied"] is True
+    assert data["verify"]["attempts"] == 2
+
+
+def test_expect_mismatch_fails_loudly_with_wanted_and_got(bridge):
+    bridge.script("eval", [_value({"v": "stale"})])
+    cp = bridge.run("type", "hello", "--selector", "#q", "--expect", "hello")
+    assert cp.returncode == 1, f"rc={cp.returncode} out={cp.stdout}"
+    # Bounded: 3 attempts, not an unbounded retry against the live browser.
+    assert bridge.ops() == _ops(3, restores=False)
+    assert "input_not_applied" in cp.stderr
+    assert '"hello"' in cp.stderr and '"stale"' in cp.stderr
+    # The envelope still lands on stdout AND still parses — a failure must not
+    # cost the caller the result.
+    data = _data(cp)
+    assert data["applied"] is False
+    assert data["verify"]["state"] == "miss"
+    assert data["verify"]["attempts"] == 3
+    assert data["verify"]["got"] == "stale"
+    assert data["verify"]["want"] == "hello"
+
+
+def test_the_retry_bound_is_the_configured_attempt_count(bridge):
+    """Mutation control for the bound: change the knob, the op count MUST move.
+    A test that only ever sees 3 cannot tell a bound from a coincidence."""
+    bridge.script("eval", [_value({"v": "stale"})])
+    cp = bridge.run("type", "hi", "--selector", "#q", "--expect", "hello",
+                    extra_env={"BB_TYPE_ATTEMPTS": "2"})
+    assert cp.returncode == 1
+    assert bridge.ops() == _ops(2, restores=False)
+    assert _data(cp)["verify"]["attempts"] == 2
+
+
+@pytest.mark.parametrize("bad", ["0", "three", "-1", "3.5", " 3", "11", "999"])
+def test_a_malformed_attempt_count_is_refused_before_any_op(bridge, bad):
+    """An unbounded/garbage bound must never reach the loop: this drives the
+    user's LIVE browser, and each attempt is up to three wire ops.
+
+    `""` is deliberately NOT in this list: `${BB_TYPE_ATTEMPTS:-3}` treats an
+    empty value as unset, so an exported-but-empty variable means "the default",
+    not "invalid" — the next test pins that so the omission stays a decision
+    rather than a gap."""
+    cp = bridge.run("type", "hi", "--selector", "#q", "--expect", "hi",
+                    extra_env={"BB_TYPE_ATTEMPTS": bad})
+    assert cp.returncode == 1
+    assert "BB_TYPE_ATTEMPTS" in cp.stderr
+    assert bridge.ops() == [], "nothing may reach the wire on a bad bound"
+
+
+def test_a_huge_attempt_count_gets_the_rule_not_a_bash_internal(bridge):
+    """`[ "$n" -ge 1 ]` on a value past LLONG_MAX prints
+    `browser: line NNN: [: integer expected` and the intended message never runs,
+    so the caller is handed a bash internal instead of the rule they broke — and
+    the comment claiming this knob "prevents an unbounded op storm" imposed no
+    ceiling at all."""
+    cp = bridge.run("type", "hi", "--selector", "#q", "--expect", "hi",
+                    extra_env={"BB_TYPE_ATTEMPTS": "99999999999999999999999"})
+    assert cp.returncode == 1
+    assert "integer expected" not in cp.stderr, cp.stderr
+    assert "BB_TYPE_ATTEMPTS must be an integer 1..10" in cp.stderr
+    assert bridge.ops() == []
+
+
+def test_an_empty_attempt_count_means_the_default_not_an_error(bridge):
+    """An exported-but-empty BB_TYPE_ATTEMPTS is common (`export BB_TYPE_ATTEMPTS=`
+    in a sourced profile) and must fall back to the default rather than refusing
+    every verified type."""
+    bridge.script("eval", [_value({"v": "stale"})])
+    cp = bridge.run("type", "hello", "--selector", "#q", "--expect", "hello",
+                    extra_env={"BB_TYPE_ATTEMPTS": ""})
+    assert cp.returncode == 1
+    assert bridge.ops() == _ops(3, restores=False), "fell back to the default of 3"
+
+
+# --------------------------------------------------------------------------- #
+# 1a. THE SETTLE — a validation hole turned the detector into a rubber stamp
+#
+# The first version validated with `case ... ""|*[!0-9.]*)`, which accepts
+# `0.3.5`, `1.2.3` and a bare `.`; `sleep` then rejected them and the error was
+# discarded by `2>/dev/null || true`. So a typo ran with NO SETTLE, rc 0, no
+# warning — and per the CLI's own header a read-back taken in the same tick as
+# the insert reports success even in the failing case.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("bad", ["0.3.5", "1.2.3", ".", "abc", "-1", "1e3",
+                                 " 3", "0.", "31", "100"])
+def test_a_malformed_or_oversized_settle_is_refused_before_any_op(bridge, bad):
+    cp = bridge.run("type", "hi", "--selector", "#q", "--expect", "hi",
+                    extra_env={"BB_TYPE_SETTLE_S": bad})
+    assert cp.returncode == 1, f"{bad!r} was accepted"
+    assert "BB_TYPE_SETTLE_S" in cp.stderr
+    assert bridge.ops() == [], "nothing may reach the wire without a real settle"
+
+
+@pytest.mark.parametrize("good", ["0", "0.35", ".5", "3"])
+def test_the_accepted_settle_forms(bridge, good):
+    """CONTROL for the rejection above: a validator that refuses everything would
+    satisfy every arm of the previous test while breaking the feature."""
+    bridge.script("eval", [_value({"v": "hello"})])
+    cp = bridge.run("type", "hello", "--selector", "#q", "--expect", "hello",
+                    extra_env={"BB_TYPE_SETTLE_S": good})
+    assert cp.returncode == 0, cp.stderr
+
+
+def test_a_settle_that_fails_to_RUN_stops_the_command(bridge, tmp_path):
+    """🔴 The other half of finding 2, and it needs a REACHABLE input.
+
+    The old code was `sleep "$v" 2>/dev/null || true` — the failure discarded. The
+    validation above now makes a malformed value unreachable, which is good but
+    also means a mutation battery cannot kill the un-swallowing on its own: with
+    the value guaranteed valid, `sleep` never fails, so the two spellings are
+    equivalent. (Measured: mutant M3 SURVIVED for exactly that reason.)
+
+    So reach it the only way left — shadow `sleep` with one that exits non-zero.
+    A settle that did not run must stop the command, not silently read back in
+    the same tick as the insert, which reports success in the failing case."""
+    stub = tmp_path / "fakebin"
+    stub.mkdir()
+    (stub / "sleep").write_text("#!/usr/bin/env bash\nexit 7\n")
+    (stub / "sleep").chmod(0o755)
+    bridge.script("eval", [_value({"v": "hello"})])
+    cp = bridge.run("type", "hello", "--selector", "#q", "--expect", "hello",
+                    extra_env={"PATH": f"{stub}:{bridge.env['PATH']}"})
+    assert cp.returncode == 1, f"rc={cp.returncode} out={cp.stdout}"
+    assert "settle failed to run" in cp.stderr, cp.stderr
+    assert "refusing to read back without it" in cp.stderr
+    # The pre-read and the type went out; the read-back did NOT.
+    assert bridge.ops() == ["eval", "type"], bridge.ops()
+
+
+@pytest.mark.parametrize("settle,floor,ceil", [("0.6", 0.5, None),
+                                               ("0", None, 0.45)])
+def test_the_settle_actually_happens(bridge, settle, floor, ceil):
+    """🔴 THE SETTLE IS THE DETECTOR — so something must FAIL when it does not run.
+
+    Every other test here would stay green with the `sleep` line deleted (it was:
+    51/51 green with it removed). Wall time is the only observable that moves, so
+    it is measured at TWO points: a 0.6s settle must cost at least 0.5s of real
+    time, and a 0s settle must not. One point alone cannot tell a real sleep from
+    a slow test machine."""
+    bridge.script("eval", [_value({"v": "hello"})])
+    t0 = time.monotonic()
+    cp = bridge.run("type", "hello", "--selector", "#q", "--expect", "hello",
+                    extra_env={"BB_TYPE_ATTEMPTS": "1",
+                               "BB_TYPE_SETTLE_S": settle})
+    dt = time.monotonic() - t0
+    assert cp.returncode == 0, cp.stderr
+    if floor is not None:
+        assert dt >= floor, f"a {settle}s settle took only {dt:.3f}s — it did not run"
+    if ceil is not None:
+        assert dt <= ceil, (f"a {settle}s settle took {dt:.3f}s — the control arm "
+                            f"is too slow for the floor arm above to mean anything")
+
+
+# --------------------------------------------------------------------------- #
+# 1b. THE PRE-READ — the retry must not destroy content it never wrote
+#
+# 🔴 MEASURED-DEFECT REGRESSION. The undo used to be INFERRED: strip a trailing
+# copy of the typed text off the read-back. That is only the insert's own tail
+# when the insert LANDED — and the case this feature exists to detect is the one
+# where it did not, where the read-back IS the pre-existing content. A field
+# holding "my password", typed into with "password" and not applied, ends with
+# the typed text, so the CLI cut it to "my " and then reported that as the value
+# the page held.
+# --------------------------------------------------------------------------- #
+def test_a_type_that_does_not_land_never_amputates_the_field(bridge):
+    """The regression arm. `applies=False` is the no-apply failure; the field
+    ends with the typed text purely by coincidence of its content, which is all
+    the old inference needed to destroy it."""
+    f = Field(bridge, initial="my password", applies=False)
+    cp = bridge.run("type", "password", "--selector", "#q",
+                    "--expect", "password")
+    assert cp.returncode == 1
+    assert f.v == "my password", (
+        "the CLI must leave the field exactly as it found it; got %r" % f.v)
+    # And it must not report content it created itself.
+    assert _data(cp)["verify"]["got"] == "my password"
+    assert "my " not in cp.stderr.replace("my password", "")
+
+
+@pytest.mark.parametrize("attempts", ["1", "3"])
+def test_a_landing_insert_leaves_exactly_one_copy_however_many_attempts(bridge, attempts):
+    """The CONTROL for the arm above, and the compounding regression.
+
+    `applies=True` proves the simulator really does insert (a simulator that
+    silently dropped the text would make the no-apply arm pass vacuously), and
+    the property is that the field the caller is left with does NOT depend on how
+    many times the loop retried. Pre-fix this left "junkDreamDreamDream"."""
+    f = Field(bridge, initial="junk", applies=True)
+    cp = bridge.run("type", "Dream", "--selector", "#q", "--expect", "Dream",
+                    extra_env={"BB_TYPE_ATTEMPTS": attempts})
+    assert cp.returncode == 1, cp.stdout
+    assert _data(cp)["verify"]["attempts"] == int(attempts)
+    assert f.v == "junkDream", (
+        "the field must hold ONE copy however many attempts ran; got %r" % f.v)
+    assert f.v.count("Dream") == 1
+
+
+def test_the_restore_target_is_the_measured_pre_state_not_a_stripped_tail(bridge):
+    """The mechanism, not just the outcome. The restore must write the value the
+    PRE-READ measured — not a substring computed from the post-state, which is
+    what cut a user's field down to "my "."""
+    Field(bridge, initial="my password", applies=True)
+    cp = bridge.run("type", "password", "--selector", "#q",
+                    "--expect", "password", extra_env={"BB_TYPE_ATTEMPTS": "2"})
+    assert cp.returncode == 1
+    restores = bridge.evals("restore")
+    assert len(restores) == 1, "exactly one restore, between the two attempts"
+    assert _restore_target(restores[0]) == "my password"
+
+
+def test_the_restore_uses_the_native_setter_and_fires_input(bridge):
+    """A plain `e.value = x` is INVISIBLE to React's synthetic-event layer, so a
+    controlled input would re-render the old value straight back and the clear
+    would silently not happen. The prescribed technique (civitai site-notes) is
+    the prototype's native value setter plus a bubbling `input` event."""
+    Field(bridge, initial="junk", applies=True)
+    bridge.run("type", "Dream", "--selector", "#q", "--expect", "Dream",
+               extra_env={"BB_TYPE_ATTEMPTS": "2"})
+    js = bridge.evals("restore")[0]
+    assert "getOwnPropertyDescriptor" in js and "d.set.call(e,v)" in js
+    assert 'new Event("input",{bubbles:true})' in js
+
+
+def test_a_restore_that_does_not_stick_stops_the_retry(bridge):
+    """The page owns the value and puts it straight back. Re-typing would
+    CONCATENATE, so the loop must refuse rather than spend its remaining attempts
+    making the field worse — and must SAY which of the two it did."""
+    Field(bridge, initial="junk", applies=True, restore_sticks=False)
+    cp = bridge.run("type", "Dream", "--selector", "#q", "--expect", "Dream")
+    assert cp.returncode == 1
+    assert bridge.ops() == ["eval", "type", "eval", "eval"], (
+        "pre-read, one attempt, one restore, and NO second type")
+    data = _data(cp)
+    assert data["verify"]["retryStopped"] == "restore_failed"
+    assert data["verify"]["attempts"] == 1
+    assert data["applied"] is False
+    assert "restore_failed" in cp.stderr and "CONCATENATE" in cp.stderr
+
+
+def test_no_pre_state_means_no_retry(bridge):
+    """A pre-read that could not be evaluated (a rate-limited first op, a frame
+    that had not resolved yet) leaves nothing to restore TO. Re-typing would
+    concatenate with no way to undo it, so the loop refuses after one attempt and
+    names the reason — rather than guessing, which is the whole defect above."""
+    # Pre-read null (unreadable); the read-back afterwards works and misses.
+    bridge.script("eval", [_value(None), _value({"v": "stale"})])
+    cp = bridge.run("type", "hello", "--selector", "#q", "--expect", "hello")
+    assert cp.returncode == 1
+    assert bridge.ops() == ["eval", "type", "eval"], "one attempt only"
+    data = _data(cp)
+    assert data["verify"]["retryStopped"] == "no_pre_state"
+    assert data["verify"]["attempts"] == 1
+    assert "no_pre_state" in cp.stderr
+
+
+def test_a_successful_verify_reports_no_retry_stop(bridge):
+    """`retryStopped` must be ABSENT on the ordinary paths — a field that is
+    always present carries no information, and a consumer branching on its
+    presence would see every happy path as a stopped retry."""
+    bridge.script("eval", [_value({"v": ""}), _value({"v": "hello"})])
+    cp = bridge.run("type", "hello", "--selector", "#q", "--expect", "hello")
+    assert cp.returncode == 0, cp.stderr
+    assert "retryStopped" not in _data(cp)["verify"]
+
+
+# --------------------------------------------------------------------------- #
+# 1c. bad_target is rc 1 — rc 3 explicitly does not mean "nothing happened"
+#
+# The extension's focusExpression only checks that the element EXISTS and calls
+# .focus(), so a --selector naming a wrapper <div> — what you get by lifting a
+# selector out of `--annotated` output — makes the type op report success while
+# the insert goes wherever focus actually is. Scoring that as rc 3 ("the primary
+# op succeeded and only its follow-up failed") is the worst available answer.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("tag", ["element_not_found", "no_editable_target"])
+def test_a_bad_selector_is_refused_before_anything_is_typed(bridge, tag):
+    bridge.script("eval", [_value({"e": tag})])
+    cp = bridge.run("type", "hello", "--selector", "#wrapper", "--expect", "hello")
+    assert cp.returncode == 1, f"rc={cp.returncode}: rc 3 would read as 'probably fine'"
+    assert bridge.ops() == ["eval"], "the pre-read caught it; NOTHING was typed"
+    assert cp.stdout == ""
+    assert "bad_target" in cp.stderr and tag in cp.stderr
+    assert "NOTHING was typed" in cp.stderr
+
+
+def test_a_wrapper_div_selector_says_what_to_do_about_it(bridge):
+    """The message has to name the actual mistake — the selector points at
+    something that cannot hold text — or the reader re-runs the same command."""
+    bridge.script("eval", [_value({"e": "no_editable_target"})])
+    cp = bridge.run("type", "hello", "--selector", "div.wrap", "--expect", "hello")
+    assert "wrapper <div>" in cp.stderr
+    assert "--annotated" in cp.stderr
+    assert "rc 1, not rc 3" in cp.stderr
+
+
+@pytest.mark.parametrize("tag", ["element_not_found", "no_editable_target"])
+def test_with_NO_selector_an_uneditable_target_is_rc_3_not_a_refusal(bridge, tag):
+    """🔴 The SCOPE control for the rule above, and it is not a technicality.
+
+    With no `--selector` the read targets `document.activeElement`, but CDP types
+    into whatever the RENDERER has focused — and those differ: focus inside a
+    shadow root reports the shadow HOST, a custom element with no `.value` and no
+    contenteditable. Refusing there would (a) print an error naming a flag that
+    appears nowhere in the caller's command line — the exact defect the BB_TAB
+    message had — and (b) call a type that may well have landed a failure.
+
+    So this arm is `unverifiable`/rc 3, and it says how to get a definite
+    answer."""
+    bridge.script("eval", [_value({"e": tag})])
+    cp = bridge.run("type", "hello", "--verify")
+    assert cp.returncode == 3, f"rc={cp.returncode}"
+    assert "bad_target" not in cp.stderr, "no --selector was given to blame"
+    assert "--selector" in cp.stderr, "it must say how to get a definite answer"
+    assert "shadow" in cp.stderr
+    assert _data(cp)["verify"]["state"] == "unverifiable"
+
+
+def test_a_target_that_disappears_after_the_type_is_also_rc_1(bridge):
+    """Usable before the type, gone after: the page replaced the node. The text
+    WAS sent, but it is provably not in what the caller named, so `applied` is
+    false and the exit code is 1 — not the "only the check failed" code."""
+    Field(bridge, initial="", applies=True,
+          read_tag={"e": "element_not_found"})
+    cp = bridge.run("type", "hello", "--selector", "#q", "--expect", "hello")
+    assert cp.returncode == 1
+    data = _data(cp)
+    assert data["verify"]["state"] == "bad_target"
+    assert data["applied"] is False
+    assert "The text WAS sent" in cp.stderr
+
+
+# --------------------------------------------------------------------------- #
+# 1d. unverifiable is a THIRD state — rc 3, and never folded into "miss"
+# --------------------------------------------------------------------------- #
+def test_a_csp_blocked_readback_is_unverifiable_not_a_miss(bridge):
+    """A strict page CSP makes the injected eval return null (SKILL.md trap 2,
+    GitHub). "I could not look" and "the text is not there" need OPPOSITE next
+    actions, so null must not be scored as a failed type — and must not be
+    retried, which would spend more ops on an unanswerable question.
+
+    This is the NEGATIVE CONTROL for the bad_target tests above: a genuinely
+    unreadable page still exits 3, so moving element_not_found to rc 1 did not
+    just collapse everything into rc 1."""
+    bridge.script("eval", [_value(None)])
+    cp = bridge.run("type", "hello", "--selector", "#q", "--expect", "hello")
+    assert cp.returncode == 3, f"rc={cp.returncode} err={cp.stderr}"
+    assert bridge.ops() == ["eval", "type", "eval"], "no retry on an unverifiable read"
+    assert "input_not_verified" in cp.stderr
+    assert "CSP" in cp.stderr
+    data = _data(cp)
+    assert data["applied"] is None, "tri-state: null is 'not verified', not False"
+    assert data["verify"]["state"] == "unverifiable"
+
+
+def test_a_failed_readback_op_is_unverifiable_and_names_the_rate_limit(bridge):
+    """The reads are SEPARATE ops and can fail on their own. A verified type is
+    3 ops (up to 9 across retries), so a 429 on the follow-up is the realistic
+    failure — and it must not be reported as a CSP block, which sends the reader
+    to the wrong page."""
+    bridge.script("eval", [(200, {"ok": True, "result": {
+        "id": "e", "ok": False, "error": "rate_limited"}})])
+    cp = bridge.run("type", "hello", "--selector", "#q", "--expect", "hello")
+    assert cp.returncode == 3
+    assert "input_not_verified" in cp.stderr
+    assert "rate-limited" in cp.stderr or "rate_limited" in cp.stderr
+    assert _data(cp)["applied"] is None
+
+
+# --------------------------------------------------------------------------- #
+# 1e. --verify, and the privacy contract on BOTH flags
+# --------------------------------------------------------------------------- #
+def test_verify_passes_when_the_typed_text_arrives(bridge):
+    bridge.script("eval", [_value({"v": "prefix-"}),
+                           _value({"v": "prefix-hello"})])
+    cp = bridge.run("type", "hello", "--selector", "#q", "--verify")
+    assert cp.returncode == 0, cp.stderr
+    data = _data(cp)
+    assert data["applied"] is True
+    assert data["verify"]["mode"] == "contains"
+
+
+def test_verify_does_not_score_an_unchanged_field_as_applied(bridge):
+    """🔴 `typed in got` alone cannot tell "the text landed" from "the text was
+    already there": a field pre-holding `hello` plus a type that did NOTHING
+    scored rc 0 / `applied:true`. The pre-read is what makes the two
+    distinguishable, and an unchanged field is a MISS."""
+    Field(bridge, initial="hello", applies=False)
+    cp = bridge.run("type", "hello", "--selector", "#q", "--verify")
+    assert cp.returncode == 1, "an unchanged field must not read as applied"
+    data = _data(cp)
+    assert data["applied"] is False
+    assert data["verify"]["unchanged"] is True
+    assert "byte-identical" in cp.stderr
+
+
+def test_verify_sees_compounding_that_a_substring_check_cannot(bridge):
+    """`"DreamDream"` contains `"Dream"`, so contains-mode passed a field the
+    insert had doubled. Counted against the pre-state instead."""
+    bridge.script("eval", [_value({"v": ""}), _value({"v": "DreamDream"})])
+    cp = bridge.run("type", "Dream", "--selector", "#q", "--verify")
+    assert cp.returncode == 1
+    data = _data(cp)
+    assert data["verify"]["copiesAdded"] == 2
+    assert data["applied"] is False
+    assert "compounding" in cp.stderr
+
+
+def test_verify_never_echoes_the_field_value_back(bridge):
+    """The `type` op deliberately returns only the LENGTH typed and never echoes
+    text (extension/service_worker.js). `--verify` keeps that in EVERY branch: it
+    reports a length and, at most, a count."""
+    bridge.script("eval", [_value({"v": ""}), _value({"v": "s3cret-token-value"})])
+    cp = bridge.run("type", "hello", "--selector", "#q", "--verify")
+    assert cp.returncode == 1
+    assert "s3cret-token-value" not in cp.stdout
+    assert "s3cret-token-value" not in cp.stderr
+    data = _data(cp)
+    assert "got" not in data["verify"], "contains-mode must not carry the value"
+    assert data["verify"]["len"] == len("s3cret-token-value")
+
+
+def test_verify_does_not_echo_the_field_value_on_a_PASS_either(bridge):
+    """🔴 FOUND BY THE MUTATION BATTERY, not by reading the code.
+
+    The test above exercises only the MISS branch — its field does not contain
+    the typed text — so adding `got` to contains-mode's **ok** branch survived a
+    fully green suite (mutant M13). A privacy guard that covers one of two
+    branches reads as coverage while providing none on the other.
+
+    Here the field PASSES and still carries a secret around the typed text."""
+    bridge.script("eval", [_value({"v": ""}),
+                           _value({"v": "tok-SUPERSECRET-tail"})])
+    cp = bridge.run("type", "tok", "--selector", "#q", "--verify")
+    assert cp.returncode == 0, cp.stderr
+    assert _data(cp)["applied"] is True, "this must be the PASS branch"
+    assert "SUPERSECRET" not in cp.stdout
+    assert "SUPERSECRET" not in cp.stderr
+    assert "got" not in _data(cp)["verify"]
+
+
+def test_expect_does_not_echo_the_value_on_a_PASS(bridge):
+    """🔴 `--expect` used to report `got` on EVERY outcome, justified by "the
+    caller already holds the value". On a PASS that echo says nothing the exit
+    code did not, and writes the value into stdout and every agent transcript
+    that captured it — `--expect hunter2` printed `"got": "hunter2"`."""
+    bridge.script("eval", [_value({"v": ""}), _value({"v": "hunter2"})])
+    cp = bridge.run("type", "hunter2", "--selector", "#pw", "--expect", "hunter2")
+    assert cp.returncode == 0, cp.stderr
+    v = _data(cp)["verify"]
+    assert "got" not in v and "want" not in v, v
+    assert "hunter2" not in cp.stdout
+    assert "hunter2" not in cp.stderr
+    assert v["len"] == len("hunter2"), "a length still reaches the caller"
+
+
+def test_expect_still_reports_got_on_a_MISS_and_says_whose_content_it_is(bridge):
+    """CONTROL for the test above: the diagnostic `--expect` exists for must
+    survive. And the justification is corrected in the message — on a miss `got`
+    is the PAGE's content by construction, not an echo of the caller's argument,
+    which is exactly why `--verify` exists for secret fields."""
+    bridge.script("eval", [_value({"v": "other"})])
+    cp = bridge.run("type", "hunter2", "--selector", "#pw", "--expect", "hunter2")
+    assert cp.returncode == 1
+    assert _data(cp)["verify"]["got"] == "other"
+    assert "PAGE" in cp.stderr and "--verify" in cp.stderr
+
+
+def test_expect_flags_a_pass_where_nothing_actually_changed(bridge):
+    """`--expect` asserts the FINAL state, so a field that already held the value
+    is a legitimate pass — but the caller should be able to tell that this type
+    changed nothing. A boolean, never content."""
+    Field(bridge, initial="hello", applies=False)
+    cp = bridge.run("type", "hello", "--selector", "#q", "--expect", "hello")
+    assert cp.returncode == 0, cp.stderr
+    v = _data(cp)["verify"]
+    assert v["state"] == "ok" and v["unchanged"] is True
+
+
+def test_expect_wins_over_verify_when_both_are_given(bridge):
+    """--expect is the strictly stronger assertion; honouring the weaker one
+    would silently downgrade what the caller asked for."""
+    bridge.script("eval", [_value({"v": ""}), _value({"v": "hello world"})])
+    cp = bridge.run("type", "hello", "--selector", "#q",
+                    "--verify", "--expect", "hello")
+    assert cp.returncode == 1, "contains would have PASSED here; expect must not"
+    assert _data(cp)["verify"]["mode"] == "expect"
+
+
+def test_expect_empty_string_asserts_the_field_is_cleared(bridge):
+    """`--expect ''` is a real assertion, so "was the flag given?" is tracked
+    separately from "is its value non-empty?"."""
+    bridge.script("eval", [_value({"v": ""})])
+    cp = bridge.run("type", "x", "--selector", "#q", "--expect", "")
+    assert cp.returncode == 0, cp.stderr
+    assert _data(cp)["applied"] is True
+
+
+# --------------------------------------------------------------------------- #
+# 1f. the read expression itself, and routing
+# --------------------------------------------------------------------------- #
+def test_the_reads_target_the_same_selector_the_type_used(bridge):
+    bridge.script("eval", [_value({"v": "hello"})])
+    bridge.run("type", "hello", "--selector", "#q\"weird", "--expect", "hello")
+    reads = bridge.evals("read")
+    assert len(reads) >= 2, "a pre-read and a read-back"
+    for js in reads:
+        # The selector is JSON-escaped into the expression, not concatenated raw.
+        assert 'document.querySelector("#q\\"weird")' in js
+
+
+def test_the_read_without_a_selector_requires_an_EDITABLE_active_element(bridge):
+    """`document.activeElement` defaults to <body>. Falling back to its
+    textContent would hand back the WHOLE PAGE, and a `--verify` substring check
+    against the whole page passes whenever the word appears anywhere on it."""
+    bridge.script("eval", [_value({"v": "hello"})])
+    bridge.run("type", "hello", "--verify")
+    js = bridge.evals("read")[0]
+    assert "document.activeElement" in js
+    assert "isContentEditable" in js
+    assert "no_editable_target" in js
+
+
+def test_the_read_is_a_single_expression(bridge):
+    """`js`/`eval` evaluates ONE expression; a multi-statement body returns null
+    with no error (SKILL.md trap 1) — which this code would then have to report
+    as a CSP block. Pin the IIFE shape."""
+    bridge.script("eval", [_value({"v": "hello"})])
+    bridge.run("type", "hello", "--selector", "#q", "--expect", "hello")
+    js = bridge.evals("read")[0]
+    assert js.startswith("(function(){") and js.endswith("})()")
+    assert "\n" not in js
+
+
+def test_frame_routes_the_pre_read_the_type_and_the_readback(bridge):
+    """A --frame type verified against the TOP frame would be worse than no
+    verification: it would confirm the wrong document. All THREE ops carry it."""
+    bridge.script("eval", [_value({"v": ""}), _value({"v": "hello"})])
+    bridge.run("--frame", "7", "type", "hello", "--selector", "#q",
+               "--expect", "hello")
+    assert [b.get("op") for b in bridge.bodies] == ["eval", "type", "eval"]
+    for b in bridge.bodies:
+        assert b["frame"] == "7", b
+
+
+@pytest.mark.parametrize("order", [
+    ("type", "--selector", "#q", "--expect", "hello", "hello"),
+    ("type", "hello", "--selector", "#q", "--expect", "hello"),
+])
+def test_expect_works_with_the_flag_before_or_after_the_text(bridge, order):
+    """The repo's flag-order invariant (test_browser_cli_args.py) extends to the
+    new flags: the two orders must be the same command."""
+    bridge.script("eval", [_value({"v": ""}), _value({"v": "hello"})])
+    cp = bridge.run(*order)
+    assert cp.returncode == 0, cp.stderr
+    assert bridge.bodies[1] == {"op": "type", "text": "hello", "selector": "#q"}
+
+
+def test_unknown_type_flag_names_the_new_flags(bridge):
+    cp = bridge.run("type", "hello", "--nope")
+    assert cp.returncode == 1
+    assert "--expect" in cp.stderr and "--verify" in cp.stderr
+    assert bridge.ops() == [], "nothing may reach the wire on a usage error"
+
+
+def test_every_inline_python_body_in_the_cli_still_compiles():
+    """🔴 A literal `'` inside a `python3 -c '…'` body ENDS THE SHELL STRING, and
+    `bash -n` MAY NOT NOTICE: whether it does depends on where the quotes happen
+    to re-balance further down the file. When they re-balance cleanly the script
+    parses fine and every affected subcommand dies at RUNTIME with a SyntaxError
+    from a truncated program.
+
+    Both halves measured while writing this PR. The instance that bit: an error
+    message written as `'could not confirm'` — `bash -n` reported **SYNTAX OK**
+    over a CLI in which 38 of 63 tests then failed at runtime. The positive
+    control below: an apostrophe planted in a different body — `bash -n` DID
+    catch that one. So `bash -n` is not the guard; this is.
+
+    Extract every single-quoted inline body and `compile()` it. A truncated body
+    cannot compile, which is exactly the observable the defect produces.
+
+    POSITIVE CONTROL (run 2026-08-21 by hand, not asserted here — it would mean
+    mutating a tracked file): planting `"the read op's own failure"` in
+    `_type_classify` made this test RED with
+    `does not compile (unterminated string literal …)`, i.e. it fails for ITS
+    OWN reason, not because some other assertion tripped."""
+    src = CLI.read_text()
+    marker = "python3 -c '"
+    bodies, i = [], src.find(marker)
+    while i != -1:
+        start = i + len(marker)
+        end = src.find("'", start)
+        assert end != -1, "unterminated inline python body"
+        bodies.append((src[:start].count("\n") + 1, src[start:end]))
+        i = src.find(marker, end)
+    assert len(bodies) >= 20, (
+        f"only {len(bodies)} inline python bodies found — the extractor stopped "
+        "early, so a green result here would prove nothing")
+    for line, body in bodies:
+        try:
+            compile(body, f"{CLI}:{line}", "exec")
+        except SyntaxError as exc:
+            raise AssertionError(
+                f"the inline python at {CLI}:{line} does not compile ({exc}). "
+                "The usual cause is a literal apostrophe inside it, which ends "
+                "the surrounding shell string; bash -n cannot see it.") from None
+
+
+def test_the_op_budget_is_documented_where_an_agent_reads_it():
+    """A verified type is 3 wire ops, not 1, against a rate-limited channel. A
+    budget nobody can discover is how a 429 becomes a mystery.
+
+    SKILL.md is byte-capped (tests/test_skill_size.py), so the detail lives in
+    `reference/type-verify.md` and SKILL.md carries the pointer. This asserts the
+    whole CHAIN — the pointer exists, the file it names exists, and the number is
+    in it — because a pointer to a file without the fact is worse than no
+    pointer: it reads as coverage while providing none."""
+    help_text = subprocess.run(["bash", str(CLI), "--help"],
+                               capture_output=True, text=True, timeout=60).stdout
+    skill = (BB / "SKILL.md").read_text()
+    topic = BB / "reference" / "type-verify.md"
+    assert "3 wire" in help_text and "9" in help_text
+    assert "reference/type-verify.md" in skill, "SKILL.md must point at the topic"
+    assert topic.exists(), f"{topic} is referenced by SKILL.md but does not exist"
+    body = topic.read_text()
+    assert "3 wire ops" in body
+    assert "BB_TYPE_ATTEMPTS" in body and "BB_TYPE_SETTLE_S" in body


### PR DESCRIPTION
> **⚠ THIS PR WAS SPLIT.** The `screenshot --json` and `BB_INSTANCE`/`BB_TAB`/`BB_FRAME` halves were reviewed as clean and separable and have moved to **#659**, which is open for review on its own. This PR now carries **only** the `type --expect` / `--verify` half, and stays **draft** until the live-Brave gate below is re-run against this revision.
>
> A blind adversarial audit returned **needs rework** on this half. Everything below is the rework: 5 defects fixed, 2 fixture dimensions un-pinned, and a 20-mutant battery whose one survivor is fixed and re-killed.

---

## The defect

`browser type <text> --selector <sel>` replaces an input's value correctly *most* of the time and, intermittently, does not apply **at all** while the page keeps rendering its previous state. The envelope is identical either way:

```json
{"typed": 5, "trusted": true, "url": "…"}
```

`typed` is the length of the string the CLI **sent**. It was never a claim about the DOM — but it reads as one, and three confident, wrong conclusions about a live site came out of reading it that way in one session.

## The fix

Two opt-in flags on `type`:

| flag | assertion | on failure |
|---|---|---|
| `--expect <value>` | the field's value **equals** `<value>` | rc 1, `input_not_applied`, reports **wanted** and **got** |
| `--verify` | the typed text **arrived** — present, and the field actually changed | rc 1, `input_not_applied`, reports a **length**, never a value |

```json
{"typed": 5, "applied": true,
 "verify": {"mode": "expect", "state": "ok", "attempts": 2, "len": 5}}
```

**The settle between the type and the read-back is the detector, not politeness.** CDP `Input.insertText` mutates the DOM value *synchronously*, so a read-back inside the extension's own `type` handler would report success in exactly the failing case — the value is there for a moment and a re-render from stale state overwrites it. Verifying in the CLI, as a separate round-trip after `BB_TYPE_SETTLE_S` (default 0.35s), is what observes the state the user is actually left looking at. That is why this is not in the extension (and it means **no extension reload is needed to ship it**).

---

# Round 3 — what the audit found, and what changed

## 🔴 1. The restore destroyed pre-existing user content

The retry's undo was **inferred**: strip a trailing copy of the typed text off the read-back.

```python
out("go", got[:-len(typed)] if (typed and got.endswith(typed)) else got)
```

The comment claimed a trailing copy "is the insert THIS attempt made". True **only if the insert landed** — and the primary failure mode this feature exists to detect is the one where it did not, where `got` **is** the pre-existing content. A field holding `"my password"`, typed into with `"password"` and not applied, reads back as `"my password"`, ends with the typed text, and was amputated to `"my "`. The CLI then reported `"my "` as the value the page held: a diagnostic describing damage the CLI itself had just done. Strictly more destructive than the code it replaced.

**Fixed by measuring instead of guessing.** Every verified type now opens with a **pre-read** of the field. That measurement is the ground truth every later decision rests on:

- the restore target is the pre-state, never a substring computed from the post-state;
- with **no** pre-state (a CSP page, a rate-limited first op) there is **no retry** — `verify.retryStopped = "no_pre_state"` — because a retry whose undo cannot be verified is a retry that must not be made;
- the restore op is **skipped entirely** when the read-back already equals the pre-state, which is the commonest failure here (nothing landed, so there is nothing to undo).

Reproduced and pinned. `test_a_type_that_does_not_land_never_amputates_the_field` at the previous tip:

```
AssertionError: the CLI must leave the field exactly as it found it; got 'my '
```

## 🔴 2. The settle was bypassable, and the whole suite ran with it disabled

`case ... ""|*[!0-9.]*)` accepts `0.3.5`, `1.2.3` and a bare `.`. `sleep` then rejected them — and the error went into `2>/dev/null || true`. So `BB_TYPE_SETTLE_S=0.3.5` ran with **no settle, no warning, rc 0**, and per the code's own header a same-tick read-back reports success even in the failing case. A typo turned the feature into a rubber stamp.

Worse, the fixture pinned `BB_TYPE_SETTLE_S: "0"` for **every** test, so the suite could not see it: the auditor deleted the `sleep` line entirely and got **51/51 green**.

**Fixed on both sides.**

- The pattern is anchored and exact (`^([0-9]+(\.[0-9]+)?|\.[0-9]+)$`), with a real ceiling (30s). `0.3.5`, `1.2.3`, `.`, `0.`, `1e3`, `-1`, `31`, `100` are all refused **before any op reaches the wire** — and `0`, `0.35`, `.5`, `3` are accepted, which is the control that a validator refusing everything would fail.
- The `sleep` no longer has its failure discarded. Validated up front, so a failure there is a broken environment, not a typo, and it is loud.
- The fixture's settle is now small but **non-zero** (`0.02`), so the sleep genuinely runs and is genuinely validated in every test.
- `test_the_settle_actually_happens` measures **wall time at two points** — a `0.6s` settle must cost ≥ 0.5s, a `0s` settle must not. One point alone cannot tell a real sleep from a slow machine. This is the test that deleting the `sleep` line kills (mutant **M1**, below).

## 🔴 3. `no_editable_target` / `element_not_found` were rc 3

rc 3's contract says it never means "nothing happened". Both tags mean exactly that, and they are the **ordinary** mistake, not an exotic one: `focusExpression` (`extension/protocol.js`) only checks that the element exists and calls `.focus()`, so pointing `--selector` at a wrapper `<div>` — what you get by lifting a selector out of `--annotated` output — makes `type` report success while the insert goes to whatever is actually focused. "3, probably fine" is the worst available answer.

**They are now a fourth state, `bad_target`, on rc 1**, and — because the pre-read runs first — a bad selector is normally caught **before anything is typed at all**:

```
browser: bad_target: the --selector does not name something this type could land in.
browser:   the --selector matched an element that cannot hold text (a wrapper <div>, …) (no_editable_target)
browser:   Caught by the PRE-READ, so NOTHING was typed — no text went anywhere.
browser:   Re-read the page with 'browser text --annotated' and pick a selector that
browser:   names the <input>/<textarea>/[contenteditable] ITSELF, not its wrapper.
browser:   This is rc 1, not rc 3: rc 3 means the type applied and only the check
browser:   failed, which is the opposite of what happened here.
```

A target that was usable before the type and gone after is also rc 1, with `applied: false` and a message that says the text **was** sent and where it landed is unknown.

rc 3 keeps exactly what it should: the reads could not be **evaluated** — strict page CSP, a `chrome://` tab, a rate-limited follow-up. `test_a_csp_blocked_readback_is_unverifiable_not_a_miss` is the negative control proving this did not just collapse everything into rc 1.

## 🟡 4. `--verify` could not tell "landed" from "was already there"

`want in got` scored a field pre-holding `"hello"` plus a type that did **nothing** as rc 0 / `applied: true`, and it also could not see compounding (`"DreamDream"` contains `"Dream"`).

The pre-read fixes both. Contains-mode now requires the field to have **changed**, and counts copies against the pre-state:

- unchanged → `miss`, `verify.unchanged: true`, "the field is byte-identical to what it held BEFORE this type";
- more than one copy added → `miss`, `verify.copiesAdded: N`.

Both are booleans/counts — contains-mode still never reports a value. `--expect` keeps its final-state semantics (a field that already equals the value is a legitimate pass) but now reports `verify.unchanged: true` so the caller can tell.

## 🟡 5. `--expect` echoed the field's content on rc 0

The justification comment — "the caller already holds the value" — is false exactly when it matters: on a **miss**, `got` is page content the caller never supplied (finding 1's `got` was `"my "`). And on a **pass** the echo said nothing the exit code did not, while writing the value into stdout and every agent transcript that captured it: `--expect hunter2` printed `"got": "hunter2"`.

- On `ok`, neither `got` **nor** `want` is emitted, in either mode — only a length.
- On a miss, `--expect` still reports `got`: that is the diagnostic the flag exists for, and it is page content **by construction**. The stderr block now says so, and points at `--verify` for secret fields.

## 🟡 6. `BB_TAB`/`BB_FRAME` inherited with no signal

Fixed in **#659** (that half's PR), since that is where the env defaults now live: an op whose target came from the environment prints one stderr line naming the variable, `BB_NO_ROUTE_NOTE=1` silences it, and a flag that beat the env default drops out of the note.

## 🟡 7. Rate-limit budget documented

A verified type is **3 wire ops** on the happy path (pre-read, type, read-back), **9** across 3 attempts when the insert lands, **7** when nothing lands (the restore is skipped). Stated in `SKILL.md`, in the CLI's `--help` header, and in the block comment — with a test asserting it appears in both surfaces.

A 429 on a read is `unverifiable` → rc 3, and it no longer misreports itself as a CSP block: `_type_classify` reads `result.ok:false` and names the error, and the empty-response branch says a rate-limited follow-up looks exactly like this.

## 🟢 8. `BB_TYPE_ATTEMPTS` had no ceiling and leaked a bash internal

A huge all-digit value passed the digit check and then hit `[ "$n" -ge 1 ]`, which prints `browser: line 1590: [: integer expected` before the intended message ever runs — so the caller got a bash internal instead of the rule they broke. And the comment claiming this knob "prevents an unbounded op storm" imposed no ceiling at all.

Now `1..10` (each attempt is up to 3 ops against the operator's live browser), with the **string length** bounded before any arithmetic so the message survives. `test_a_huge_attempt_count_gets_the_rule_not_a_bash_internal` asserts `"integer expected" not in stderr`.

## 🟢 9 / 🟢 10

9 (`--data-url --json`) travelled with the clean half → **#659**. 10 (`no_restore_target` unreachable) no longer exists: with the restore target taken from a verified pre-read, that state cannot arise and has been deleted rather than kept as an untested backstop.

---

# Test quality — the root cause, not a nit

The old suite could not see findings 1 or 2 because **the fixtures pinned the dimensions under test**. Both are un-pinned:

| dimension | before | now |
|---|---|---|
| does the type LAND? | `state["v"] += text` — always appended, so the no-apply arm (the failure the feature exists to detect) was never simulated | `Field(initial=…, applies=False)` is a type that does **not** land; `applies=True` is its control, and proves the simulator really inserts |
| does the settle RUN? | `BB_TYPE_SETTLE_S: "0"` in the fixture, everywhere — deleting `sleep` left 51/51 green | non-zero (`0.02`) fixture default, plus a two-point wall-time test |

`Field` also models a page that **owns** the value (`restore_sticks=False`) and a target that **disappears** after the type (`read_tag=`), neither of which canned replies can express.

## RED/GREEN matrix

| run | result |
|---|---|
| new suite at the **previous tip** (`2c818acc` — the audited code) | **39 RED, 26 green** |
| new suite at HEAD | **66 green** |
| full `scripts/browser-bridge/tests` at HEAD | **819 passed, 0 failed** (run 2; run 1 had 1 unrelated flake — see below) |

The RED list at `2c818acc` names each finding directly:

```
test_a_type_that_does_not_land_never_amputates_the_field
    AssertionError: the CLI must leave the field exactly as it found it; got 'my '
test_a_bad_selector_is_refused_before_anything_is_typed[element_not_found]
    AssertionError: rc=3: rc 3 would read as 'probably fine'
test_a_malformed_or_oversized_settle_is_refused_before_any_op[0.3.5]
    AssertionError: '0.3.5' was accepted
test_verify_does_not_score_an_unchanged_field_as_applied
    AssertionError: an unchanged field must not read as applied
test_expect_does_not_echo_the_value_on_a_PASS
test_a_huge_attempt_count_gets_the_rule_not_a_bash_internal
test_verify_sees_compounding_that_a_substring_check_cannot   KeyError: 'copiesAdded'
test_no_pre_state_means_no_retry
test_a_target_that_disappears_after_the_type_is_also_rc_1
…
```

## Mutation battery

| mutant | kind | verdict | killed by |
|---|---|---|---|
| `M1-settle-deleted` | comment-out | **KILLED** | `test_a_settle_that_fails_to_RUN_stops_the_command` *(+1 more)* |
| `M2-settle-validation-relaxed` | operand-swap | **KILLED** | `test_a_malformed_or_oversized_settle_is_refused_before_any_op` |
| `M3-settle-error-swallowed` | comment-out | **KILLED** | `test_a_settle_that_fails_to_RUN_stops_the_command` |
| `M4-preread-bad_target-ignored` | comment-out | **KILLED** | `test_a_bad_selector_is_refused_before_anything_is_typed` |
| `M5-bad_target-returns-3` | operand-swap | **KILLED** | `test_a_target_that_disappears_after_the_type_is_also_rc_1` |
| `M6-unchanged-branch-inverted` | branch-inversion | **KILLED** | `test_verify_does_not_score_an_unchanged_field_as_applied` *(+2 more)* |
| `M7-restore-skip-operand-swapped` | operand-swap | **KILLED** | `test_a_landing_insert_leaves_exactly_one_copy_however_many_attempts` *(+7 more)* |
| `M8-restore-target-stale-rebind` | stale-rebind | **KILLED** | `test_a_landing_insert_leaves_exactly_one_copy_however_many_attempts` *(+1 more)* |
| `M9-ORIGINAL-DEFECT-strip-the-tail` | regression-control | **KILLED** | `test_a_type_that_does_not_land_never_amputates_the_field` *(+1 more)* |
| `M10-restore-check-removed` | comment-out | **KILLED** | `test_a_restore_that_does_not_stick_stops_the_retry` |
| `M11-no_pre_state-guard-removed` | comment-out | **KILLED** | `test_no_pre_state_means_no_retry` |
| `M12-expect-leaks-got-on-ok` | privacy | **KILLED** | `test_expect_does_not_echo_the_value_on_a_PASS` |
| `M13-contains-leaks-got` | privacy | **KILLED** | `test_verify_does_not_echo_the_field_value_on_a_PASS_either` |
| `M14-attempts-ceiling-removed` | bound-removal | **KILLED** | `test_a_malformed_attempt_count_is_refused_before_any_op` |
| `M15-attempts-length-guard-removed` | bound-removal | **KILLED** | `test_a_huge_attempt_count_gets_the_rule_not_a_bash_internal` |
| `M16-copies-threshold-off-by-one` | operand-swap | **KILLED** | `test_verify_sees_compounding_that_a_substring_check_cannot` |
| `M17-settle-ceiling-removed` | bound-removal | **KILLED** | `test_a_malformed_or_oversized_settle_is_refused_before_any_op` |
| `M18-has_sel-always-true` | operand-swap | **KILLED** | `test_with_NO_selector_an_uneditable_target_is_rc_3_not_a_refusal` |
| `M19-has_sel-always-false` | operand-swap | **KILLED** | `test_a_bad_selector_is_refused_before_anything_is_typed` *(+2 more)* |
| `M20-preread-not-routed-to-classify` | stale-rebind | **KILLED** | `test_a_bad_selector_is_refused_before_anything_is_typed` *(+11 more)* |

**20 mutants, 20 killed** — and one of them, `M13`, **SURVIVED the first clean run**. That is the finding, not a footnote: the privacy test for `--verify` used a field that does not contain the typed text, so it only ever exercised the **miss** branch; adding `got` to contains-mode's **ok** branch was invisible to a fully green 65-test suite. `test_verify_does_not_echo_the_field_value_on_a_PASS_either` closes it, and was then shown to kill M13 specifically (`1 failed`, that test named).

`M3` was also first reported SURVIVED, for a different reason worth stating: with the settle now strictly validated, `sleep` can never fail on a valid value, so un-swallowing its error is **unobservable by any input the CLI accepts**. Rather than record an equivalent mutant, the guard was made REACHABLE — `test_a_settle_that_fails_to_RUN_stops_the_command` shadows `sleep` with one that exits 7 — and M3 then dies to it.



🔴 **The battery's own instrument was validated first, and its first run was WRONG.** The FAILED scan was `line.startswith("FAILED")` against output pytest **colours** — so it matched nothing and scored the very first mutant `SURVIVED` while the same result dict reported `1 failed`. It now strips ANSI, and carries a cross-check that raises if `n_failed > 0` with an empty FAILED list, plus two controls per run: the unmutated tree must be fully green (or every SURVIVED is a claim about a broken baseline), and ripping the verification dispatch out entirely must go RED (or the harness is wired to nothing).

The mutants are deliberately **not** all deletions — the audit named deletion as the weak half — and cover operand-swap, branch-inversion, comment-out, stale-rebind, bound-removal, privacy-leak, and one **regression control** that re-introduces finding 1's exact stripped-tail inference.

### The one non-green run

The first full-suite run showed `1 failed` — `test_server.py::test_activate_telemetry_records_the_consent_decision`, which this change does not touch (it tests `server.py`; this PR is entirely in the `browser` CLI). Measured rather than assumed: it **passes in isolation on this branch and on `origin/main`**, a full run on a pristine `origin/main` worktree was **753 passed / 0 failed**, and a second full run on this branch was **819 passed / 0 failed**. A concurrent session has a `fix/browser-bridge-test-spool-isolation` branch open, which is the class this looks like. I am reporting it, not claiming to have diagnosed it.

### SKILL.md byte budget — this needed a real eviction

`tests/test_skill_size.py` enforces **12,038 bytes**; `main` sat at 12,007 with **31 free**. #659 pays for its own two additions by compressing rows. The `type` half does not fit on top of that, so per the eviction playbook in that test the detail moved **whole** into a new `scripts/browser-bridge/reference/type-verify.md`, leaving a pointer row.

Measured, not summed from deltas: this branch alone is **11,596 bytes**, #659 alone is 11,807, and the file a rebase of this branch onto a `main` containing #659 produces is **11,820 — 218 under the budget, 468 under the ceiling** (up from 31). The two branches carry byte-identical copies of the shared compressions, so those hunks rebase without a conflict.

Four unrelated rows were also compressed, each checked present in the topic it points at **first**: trap 4's `aria-expanded`/TOGGLE detail (`css-hit-test.md` L176-186), trap 3's `visibilityState` spoof and reload-re-throttle clauses (`spa-wake.md` L32 and the RE-THROTTLE section), the `emulate` row's "(mobile testing)" (`emulation.md`, 13 mentions), and two `wake`-row clauses that duplicate trap 3 and the same row's own bold rule.

---

## 🔴 LIVE VERIFY — REQUIRED, and the previous gate could not have caught finding 1

The last gate passed while missing finding 1 **because every arm it ran exercised inserts that DID land**. The amputation only happens when the insert does **not** apply, which is precisely the arm that was missing. So the arms below are ordered by which finding they falsify, and the no-apply one is first.

🔴 **Preflight — validate the instrument.** `browser` on `$PATH` is a home-manager symlink to the **primary clone, which is on `main`**; none of these flags exist there and every arm fails in a way that looks like a defect in this branch.

```bash
BB=/path/to/a/worktree/of/this/branch/scripts/browser-bridge/browser
sha256sum "$BB"                                    # record it; quote it in any defect report
"$BB" type --nope 2>&1 | grep -q -- --expect && echo "OK: --expect present" || echo "WRONG BINARY"
"$BB" type 'x' --selector '#q' --expect x 2>&1 | grep -q 'bad_target\|verify' || true
```

```bash
export BB_INSTANCE=work
TAB=$($BB open https://example.com | jq -r .result.data.tabId); export BB_TAB="$TAB"
```

### Arm A — 🔴 falsifies finding 1. THE ONE THE LAST GATE DID NOT RUN.

On a field that **already holds content**, on the SPA where `type` was flaky, with content whose tail equals the text you are about to type:

```bash
# 1. put "my password" in the field BY HAND (or with a plain `type`), and READ IT ON SCREEN.
# 2. now:
$BB type 'password' --selector '<that selector>' --expect 'password'; echo "rc=$?"
```

**Pass:** the field still reads **exactly `my password`** on screen afterwards, however many attempts ran, and `verify.got` in the JSON is `"my password"` — the page's content, not `"my "`. **Fail:** the field reads `my ` (the old defect), or `verify.got` is a value that is not on screen.

Repeat once with a field whose content does **not** end with the typed text, as the control.

### Arm B — falsifies finding 1's control half (compounding)

On a field holding `junk`:

```bash
$BB type 'Dream' --selector '<sel>' --expect 'Dream'; echo "rc=$?  (expect 1)"
```

**Pass:** the field is left holding exactly **one** copy of `Dream` (i.e. `junkDream`), not ten and not thirteen. If `verify.retryStopped` appears, that is the loop refusing to make it worse; the stderr block names `restore_failed` or `no_pre_state`.

### Arm C — the core premise (unchanged from the last gate, still required)

```bash
$BB type '<the value that used to vanish>' --selector '<that selector>' --expect '<same value>'; echo "rc=$?"
```

Must either come back `applied:true` after `attempts:2-3`, or fail rc 1 `input_not_applied` with wanted vs got — never a silent success over a stale field. Read the field **on screen** and agree with it.

### Arm D — 🔴 falsifies finding 3. Point `--selector` at a WRAPPER.

```bash
$BB text --annotated | head -40          # pick a <div> that CONTAINS an input
$BB type 'x' --selector '<that div>' --expect 'x'; echo "rc=$?  (expect 1, NOT 3)"
```

**Pass:** rc **1**, `bad_target`, "Caught by the PRE-READ, so NOTHING was typed", and — check this — the text really is **nowhere** on the page. **Fail:** rc 3, or the text appears in some other field.

### Arm E — falsifies finding 3's negative control (CSP must still be rc 3)

```bash
$BB nav https://github.com --wake
$BB type 'x' --selector 'input[name=q]' --expect 'x'; echo "rc=$?  (expect 3)"
```

Must be rc **3**, `applied:null`, `input_not_verified` — not rc 1. If this became rc 1, the bad_target split over-reached.

### Arm F — 🔴 falsifies finding 2. The settle must actually elapse.

```bash
time BB_TYPE_SETTLE_S=2 BB_TYPE_ATTEMPTS=1 $BB type 'hello' --selector '<sel>' --expect 'hello'
BB_TYPE_SETTLE_S=0.3.5 $BB type 'hello' --selector '<sel>' --expect 'hello'; echo "rc=$?  (expect 1)"
```

**Pass:** the first takes ≥ 2s of wall time; the second **fails rc 1** naming `BB_TYPE_SETTLE_S` and sends **no ops at all**. **Fail:** the second exits 0 (the old bypass).

### Arm G — falsifies finding 5. Privacy on a real secret field.

```bash
$BB type 's3cret' --selector 'input[type=password]' --verify 1>/tmp/v.out 2>/tmp/v.err; echo "rc=$?"
grep -c 's3cret' /tmp/v.out /tmp/v.err        # both must be 0
$BB type 'hunter2' --selector 'input[type=password]' --expect 'hunter2' 1>/tmp/e.out 2>/tmp/e.err
grep -c 'hunter2' /tmp/e.out                  # must be 0 ON A PASS
```

### Arm H — falsifies finding 4.

Put `hello` in a field by hand, then:

```bash
$BB type 'hello' --selector '<sel>' --verify; echo "rc=$?  (expect 1 — unchanged)"
```

**Pass:** rc 1 with `verify.unchanged: true`. **Fail:** rc 0 `applied:true` (the old behaviour, which scored a complete no-op as success).

### Arm I — the frame arm (both reads and the type must carry `--frame`)

```bash
$BB frames
$BB --frame <id> type 'hello' --selector '#in' --expect 'hello'
```

### Arm J — rate limiting

A verified type is 3 ops, up to 9 across 3 attempts. Watch for `rate_limited` (429); it must come back as rc **3** / `applied:null`, never `applied:false`. Raise `BB_TYPE_SETTLE_S` if it trips.

```bash
$BB close; unset BB_INSTANCE BB_TAB
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
