### PR TITLE
fix(hook-tests): the "12 parallel invocations" flake was never about load — two copies of the file shared ONE cache dir

### DIFF
--- a/scripts/claude-hooks/tests/test_search_tool_nudge.py
+++ b/scripts/claude-hooks/tests/test_search_tool_nudge.py
@@ -16,11 +16,42 @@ reassuring answer here is a ZERO (no false positives):
 
 Run: python3 scripts/claude-hooks/tests/test_search_tool_nudge.py
 """
-import os, sys, glob, json, time, shutil, subprocess, tempfile, threading, importlib.util
+import os, sys, glob, json, time, atexit, shutil, subprocess, tempfile, threading, importlib.util
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 HOOK = os.path.join(HERE, "..", "search-tool-nudge.py")
+
+# --------------------------------------------------------------------------- #
+# 🔴 PRIVATE HOME — this must happen BEFORE the hook module is imported.
+#
+# The hook derives its state root from $HOME (`~/.cache/claude-search-tool-nudge/s`),
+# and every session id below is a fixed literal. That made the state directory a
+# HOST-GLOBAL resource keyed by a constant, so two copies of this file running at the
+# same time silently decided each other's outcomes — one copy's `session()` rmtree or
+# `clear_test_state()` wiping the other's markers, or one copy's marker suppressing the
+# other's nudge.
+#
+# Two copies at once is the NORMAL case on this host, not an exotic one: run-tests.sh
+# runs this file, `scripts/tests/test_run_tests_floors.py` nests a SECOND run-tests.sh
+# that runs it again, and several checkouts (worktrees, agents, the pre-push hook) run
+# their own gates concurrently. MEASURED on the pre-fix file, two concurrent copies:
+# 10/10 copies red, including "concurrency: exactly one nudge across 12 parallel
+# invocations: got 0 want 1" — the exact interleaving being (A wipes) (B wipes)
+# (B's 12 racers create `content`) (A's 12 racers all find `content` already there and
+# stay silent). One copy at a time on an otherwise-busy host: 1/30, and that one was a
+# collision with a foreign gate run, not load.
+#
+# The fix is to remove the shared resource, not to widen a window: each RUN gets its own
+# HOME, so the state root is per-run and nothing is shared. Same convention the sibling
+# hook tests already use (test_claude_notify.py, test_registrar_activation.py).
+# Subprocesses inherit it because they inherit os.environ; the in-process import below
+# picks it up because expanduser("~") reads $HOME.
+# --------------------------------------------------------------------------- #
+SANDBOX_HOME = tempfile.mkdtemp(prefix="search-tool-nudge-home-")
+os.environ["HOME"] = SANDBOX_HOME
+atexit.register(shutil.rmtree, SANDBOX_HOME, True)
 HOME = os.path.expanduser("~")
+assert HOME == SANDBOX_HOME, "the sandbox HOME did not take effect"
 
 spec = importlib.util.spec_from_file_location("search_tool_nudge", HOOK)
 assert spec and spec.loader
@@ -162,11 +193,21 @@ def run(payload):
 
 
 STATE_ROOT = os.path.join(HOME, ".cache", "claude-search-tool-nudge", "s")
+# 🔴 ISOLATION, asserted rather than assumed. The sandbox HOME at the top of this file is
+# what makes every fixed session id below safe, and it is one careless `expanduser` away
+# from silently reverting to the real cache — at which point concurrent copies of this
+# file start deciding each other's outcomes again and the failures land on whichever
+# assertion happens to lose the race. Pinned as STATE, not as a spelling: both the hook's
+# own root and this file's mirror of it must live under the sandbox.
+check("the hook's state root is inside the sandbox HOME",
+      mod.STATE_ROOT.startswith(SANDBOX_HOME + os.sep), True)
+check("this file's mirror of the state root agrees with the hook's",
+      STATE_ROOT, mod.STATE_ROOT)
 # Every test session id starts with one of these, and the suite wipes their state dirs
-# both before and after. 🔴 This suite MUST be idempotent: state that survives a run
-# makes the NEXT run fail, which during a mutation sweep reads as "mutant killed" for
-# every mutant — a broken harness reporting a perfect score. Guarded below by
-# re-running the whole file and asserting the second run is identical.
+# both before and after. The cross-RUN half of that hazard is now structural — a private
+# HOME per run — so what these prefixes still buy is the WITHIN-run cleanup the io block
+# depends on, and the end-of-file check that the ledger has not drifted from the ids
+# `session()` actually creates.
 TEST_SID_PREFIXES = ("test-session-search-nudge-", "test-search-nudge-", "test-search-nudge-collide")
 
 
@@ -801,14 +842,28 @@ for i, bad_agent in enumerate((123, [], "../../etc", "a/b", "")):
     rc, out = run(payload)
     check("bad agent_id %r -> nudge unchanged" % (bad_agent,), (rc, bool(out)), (0, True))
 
+# 🔴 CLEANUP-LEDGER GUARD, with its own positive control.
+#
+# It used to read "no test state leaks into the next run", and the cross-run hazard it
+# named is now closed STRUCTURALLY by the per-run sandbox HOME — which would have left
+# this assertion passing forever no matter what `clear_test_state` did, i.e. reading as
+# coverage while providing none. So it is re-pointed at the claim that is still live and
+# can still go red: TEST_SID_PREFIXES must cover every session id this file actually
+# creates. Let that ledger drift — a `session()` id that starts with something else — and
+# the within-run `clear_test_state()` the io block depends on silently becomes a no-op.
+#
+# The zero below is only meaningful next to a non-zero: a glob wired to the wrong root
+# also reports "nothing left", so the same expression is first asserted to SEE the state
+# that provably exists at this point.
+def _state_entries():
+    return sorted(os.path.basename(p) for pref in TEST_SID_PREFIXES
+                  for p in glob.glob(os.path.join(STATE_ROOT, pref + "*")))
+
+
+check("state exists before the final cleanup (positive control for the zero below)",
+      len(_state_entries()) >= len(SESSIONS), True)
 clear_test_state()
-leaked = sorted(os.path.basename(p) for pref in TEST_SID_PREFIXES
-                for p in glob.glob(os.path.join(STATE_ROOT, pref + "*")))
-# 🔴 IDEMPOTENCE GUARD. State left behind by one run makes the NEXT run fail — and during
-# a mutation sweep that reads as "every mutant killed", including mutants that change
-# nothing. That is exactly what happened while writing this file: a 31/31 perfect score
-# from a harness that was simply dirty. Cheap to assert, so assert it.
-check("no test state leaks into the next run", leaked, [])
+check("TEST_SID_PREFIXES covers every session id this file creates", _state_entries(), [])
 shutil.rmtree(TMP, ignore_errors=True)
 
 MIN_CHECKS = 160  # floor: a suite that silently shrinks is a vacuous green

--- a/scripts/claude-hooks/tests/test_shell_env_nudge.py
+++ b/scripts/claude-hooks/tests/test_shell_env_nudge.py
@@ -1,11 +1,25 @@
 #!/usr/bin/env python3
 """Unit tests for shell-env-nudge.analyze() + the hook's IO contract.
 Run: python3 scripts/claude-hooks/tests/test_shell_env_nudge.py"""
-import os, sys, json, subprocess, importlib.util
+import os, sys, json, atexit, shutil, tempfile, subprocess, importlib.util
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 HOOK = os.path.join(HERE, "..", "shell-env-nudge.py")
+
+# 🔴 PRIVATE HOME, set BEFORE the hook is imported — same defect and same fix as
+# test_search_tool_nudge.py. The hook's dedupe cache is `~/.cache/claude-shell-env-nudge/
+# <session id>` and the session id below is a fixed literal, so the cache file was a
+# host-global resource keyed by a constant: a second copy of this file removing it
+# between this copy's two calls makes "io dedupe silent" fire, and a second copy WRITING
+# it before this copy's first call makes "io first-fire emits" silent. That is not
+# hypothetical — run-tests.sh runs this file, scripts/tests/test_run_tests_floors.py
+# nests a second run-tests.sh that runs it again, and concurrent checkouts run their own
+# gates. MEASURED pre-fix, two concurrent copies: 40/80 copies red.
+SANDBOX_HOME = tempfile.mkdtemp(prefix="shell-env-nudge-home-")
+os.environ["HOME"] = SANDBOX_HOME
+atexit.register(shutil.rmtree, SANDBOX_HOME, True)
 HOME = os.path.expanduser("~")
+assert HOME == SANDBOX_HOME, "the sandbox HOME did not take effect"
 
 spec = importlib.util.spec_from_file_location("shell_env_nudge", HOOK)
 assert spec and spec.loader


### PR DESCRIPTION
## The report, and why it was wrong about the cause

`test_search_tool_nudge.py` failed a gate run on
`concurrency: exactly one nudge across 12 parallel invocations: got 0 want 1`,
while the machine carried three concurrent suites, and passed on two later runs.
That reads as load-sensitive. It is not.

**The failure needs a second copy of the file. Load is only a proxy for "another
gate is running right now."** Measured: at concurrency 1 the pre-fix file is
`0/10` red on a busy host; at concurrency 2 it is `20/20`.

## Mechanism — the exact interleaving

The hook derives its state root from `$HOME`
(`~/.cache/claude-search-tool-nudge/s`) and every session id in the test is a
fixed literal (`test-search-nudge-concurrent-DO-NOT-COLLIDE`). So the state
directory is a **host-global resource keyed by a constant**, and two copies of
the file share it:

```
A: session("concurrent")   -> rmtree the shared state dir
B: session("concurrent")   -> rmtree it again
B: 12 racers; one wins _claim() and creates <dir>/content; B counts 1   (B green)
A: 12 racers; ALL find `content` already present, all exit at the fast path
   in main() (`fresh = [k for k in kinds if k not in _read_state(state_dir)]`),
   all silent; A counts 0                                              (A red)
```

Nothing in A is slow or late — A reads B's marker. `got 0` is the *only* value
this shape can produce, which is why widening a timeout or adding a retry would
not have touched it.

The same sharing walks every other assertion in the file (`clear_test_state()`
in one copy wipes the other's io-block state, `session()` wipes its scenarios),
which is why a colliding run reds out dozens of unrelated checks and looks like
anything but a shared-state bug.

Two copies at once is the **normal** case here: `run-tests.sh` runs this file,
`scripts/tests/test_run_tests_floors.py` nests a second `run-tests.sh` that runs
it again (its `runner_with_targets` call does not pass `hook_tests=`, so the
patched copy still drives the real `HOOK_TESTS`), and separate checkouts run
their own gates. While diagnosing this, the workbench had **seven** concurrent
`run-tests.sh` processes from different agent worktrees.

`test_shell_env_nudge.py` carries the identical defect with a wider window — its
dedupe cache is `~/.cache/claude-shell-env-nudge/<fixed session id>`, so a second
copy removing it between this copy's two calls fires `io dedupe silent`, and
writing it first silences `io first-fire emits`.

## The fix

Remove the shared resource, don't widen a window. Each **run** gets a private
`HOME` (`tempfile.mkdtemp`, set *before* the hook module is imported, cleaned via
`atexit`), so the state root is per-run and nothing is shared. Subprocesses
inherit it through `os.environ`; the in-process import picks it up because
`expanduser("~")` reads `$HOME`.

**No timeout changed, no retry added, no sleep touched.** This is the convention
the sibling hook tests already use (`test_claude_notify.py`,
`test_registrar_activation.py`).

## Measured, before and after

Same host, with foreign `run-tests.sh` gates live throughout both arms.

| test | concurrent copies | before | after |
|---|---|---|---|
| `test_search_tool_nudge.py` | 1 | 0/10 | 0/1 |
| `test_search_tool_nudge.py` | 2 | **20/20** | 0/20 |
| `test_search_tool_nudge.py` | 4 | **40/40** | 0/20 |
| `test_shell_env_nudge.py` | 2 | **40/80** | 0/80 |
| `test_shell_env_nudge.py` | 4 | **54/80** | 0/80 |

Copies are counted individually, so "20/20" means every copy of every pair was
red. The pre-fix arm was run from `git show origin/main:<path>` so both arms
measure the same code path.

## The guards, and why the old one had to change

The isolation is **asserted, not assumed**: the hook's own `STATE_ROOT` and this
file's mirror of it must both resolve inside the sandbox, so an `expanduser` that
drifts back to the real cache fails loudly instead of quietly reintroducing a
race that lands on whichever assertion loses it.

The end-of-file guard used to read *"no test state leaks into the next run"*. The
sandbox closes that hazard **structurally**, which would have left the assertion
passing forever whatever `clear_test_state` did — coverage in the docstring, none
in the body. It is re-pointed at the claim that is still live: `TEST_SID_PREFIXES`
must cover every session id `session()` creates, or the within-run
`clear_test_state()` the io block depends on silently becomes a no-op. Its zero is
paired with a positive control, because a glob against the wrong root also
reports "nothing left".

Mutation sweep over the three new checks (`PYTHONDONTWRITEBYTECODE=1`, unmutated
control in the same batch):

| mutant | outcome | killed by |
|---|---|---|
| CONTROL (unmutated) | green | — |
| M1 hook imported before `HOME` is redirected | **KILLED** | `the hook's state root is inside the sandbox HOME` |
| M2 `clear_test_state()` is a no-op | **KILLED** | `TEST_SID_PREFIXES covers every session id this file creates` |
| M3 `session()` id drifts out of the ledger | **KILLED** | the positive control |

Each died on **this** guard's own message, not a neighbour's.

Check count 174 -> 177; `MIN_CHECKS` floor of 160 unchanged.

## Gate, and a separate RED on `main` that is not mine

Run twice, because `main` moved mid-run (seven concurrent agent gates on the box).

**Gate 1 — branch at base `3c54918`** (`nix develop . --command bash scripts/gate.sh --tier pytest`):

```
RESULT: PASS (exit=0)
GATE: RESULT=PASS exit=0
TOTAL collected=13815  passed=13814  skipped=1  failed=0  (floor: 13034)
PASS  scripts/claude-hooks/tests/test_shell_env_nudge.py (script)
PASS  scripts/claude-hooks/tests/test_search_tool_nudge.py (script)
```

**Gate 2 — MERGED tree**, branch rebased onto `da11569` (`ed87afa`):

```
RESULT: FAIL (exit=1)
GATE: RESULT=FAIL exit=1
TOTAL collected=13815  passed=13813  skipped=1  failed=1  (floor: 13034)
PASS  scripts/claude-hooks/tests/test_shell_env_nudge.py (script)
PASS  scripts/claude-hooks/tests/test_search_tool_nudge.py (script)
FAIL  scripts/tests  (collected=6375 passed=6374 failed=1)
```

The one failure is **not this branch's**:

```
TestSkillDocsArePinned.test_the_recall_step_comes_AFTER_the_handoff_is_read
    read_it = doc.index("**Read it fully.**")
E   ValueError: substring not found
```

🔴 **`origin/main` is RED on its own.** `da11569` (#643) removed the literal
`**Read it fully.**` from `claude/skills/resume/SKILL.md`, and
`scripts/tests/test_subsystem_recall.py:3585` pins that exact string. Occurrences
of it: **1 at `3c54918`, 0 at `da11569` and 0 at `29ea6f8`.**

Control, on a **pristine detached worktree of `origin/main` (29ea6f8)** with none
of this branch's commits and a clean `git status`:

```
FAILED scripts/tests/test_subsystem_recall.py::TestSkillDocsArePinned::test_the_recall_step_comes_AFTER_the_handoff_is_read
1 failed, 444 deselected in 0.68s
```

This branch touches exactly two files, both under `scripts/claude-hooks/tests/`,
and can reach neither the skill doc nor that test. Anyone gating anything right
now will see this failure and should not read it as their own — and with no CI in
this repo it will stay red until #643's author decides whether the doc lost a
phrase it should keep or the test's spelled pin should become structural.

## Not fixed here, worth knowing

`test_run_tests_floors.py` (and the other `runner_with_targets` callers) leave
`HOOK_TESTS` unpatched, so every nested `run-tests.sh` re-runs all five hook
scripts plus the shell test. That is pure gate time — it is the *amplifier* that
put two copies of this file in flight, not the bug, and it is now harmless.
Passing `hook_tests=[]` where the fixture is testing floors would cut it, but
that is a separate change with its own coverage argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
