### PR TITLE
fix(hook-tests): the nudge suites ran against the OPERATOR'S REAL $HOME — and the live hook was writing into the state they asserted on

### DIFF
--- a/scripts/claude-hooks/tests/test_search_tool_nudge.py
+++ b/scripts/claude-hooks/tests/test_search_tool_nudge.py
@@ -16,11 +16,42 @@ reassuring answer here is a ZERO (no false positives):
 
 Run: python3 scripts/claude-hooks/tests/test_search_tool_nudge.py
 """
-import os, sys, glob, json, time, shutil, subprocess, tempfile, threading, importlib.util
+import os, sys, glob, json, time, shutil, subprocess, tempfile, threading, atexit, importlib.util
+
+# --------------------------------------------------------------------------- #
+# 🔴 HOME ISOLATION — must run BEFORE anything reads `~`, including the import
+# of the hook below.
+#
+# This suite GLOBS AND DELETES state directories, and it drives the hook as a
+# real subprocess a hundred-odd times. The hook resolves its CACHE_DIR from
+# `os.path.expanduser("~")`, which on POSIX is `os.environ["HOME"]` (verified:
+# posixpath.expanduser returns $HOME when set, and only falls back to the passwd
+# entry when it is absent). Pointed at the operator's real home that means:
+#
+#   * the suite deletes real `~/.cache/claude-search-tool-nudge/` entries, and
+#   * the LIVE search-tool-nudge hook — which fires on every Bash call of any
+#     Claude Code session running on this box, including the one running the
+#     gate — writes into the very state directory the suite is asserting on.
+#     Measured: the suite fails spuriously that way, and anyone running
+#     scripts/gate.sh from inside an active session hits it.
+#
+# So: one throwaway HOME, set before line-one of the constants below, exported
+# into `os.environ` so EVERY subprocess spawned from here inherits it. Every
+# spawn in this file either passes no `env=` (inherits `os.environ`) or builds
+# it as `dict(os.environ, …)`, so all of them carry it —
+# `scripts/tests/test_hook_suites_do_not_touch_the_inherited_home.py` pins that
+# structurally so a hand-built `env=` cannot quietly reintroduce the leak.
+# --------------------------------------------------------------------------- #
+TEST_HOME = tempfile.mkdtemp(prefix="search-tool-nudge-HOME-")
+os.environ["HOME"] = TEST_HOME
+atexit.register(shutil.rmtree, TEST_HOME, ignore_errors=True)
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 HOOK = os.path.join(HERE, "..", "search-tool-nudge.py")
-HOME = os.path.expanduser("~")
+HOME = os.path.expanduser("~")  # == TEST_HOME; the hook resolves the same value
+assert HOME == TEST_HOME, (
+    "HOME redirection did not take effect (%r != %r) — every path below would "
+    "resolve into the operator's real home." % (HOME, TEST_HOME))
 
 spec = importlib.util.spec_from_file_location("search_tool_nudge", HOOK)
 assert spec and spec.loader
@@ -801,6 +832,20 @@ for i, bad_agent in enumerate((123, [], "../../etc", "a/b", "")):
     rc, out = run(payload)
     check("bad agent_id %r -> nudge unchanged" % (bad_agent,), (rc, bool(out)), (0, True))
 
+# --------------------------------------------------------------------------- #
+# 🔴 ISOLATION POSITIVE CONTROL — counted BEFORE the cleanup below wipes it.
+#
+# "the real home was untouched" is the same reassuring ZERO a suite that stopped
+# exercising the hook entirely would produce. So the pair is reported: N files
+# written under the throwaway HOME, 0 changes to the inherited one. The external
+# half lives in scripts/tests/test_hook_suites_do_not_touch_the_inherited_home.py
+# and PARSES the number printed at the bottom of this file, so a suite that
+# silently stopped writing state cannot pass it either.
+# --------------------------------------------------------------------------- #
+TEMP_HOME_FILES = sum(len(fs) for _, _, fs in os.walk(TEST_HOME))
+check("isolation positive control: the suite wrote state under the temp HOME",
+      TEMP_HOME_FILES > 0, True)
+
 clear_test_state()
 leaked = sorted(os.path.basename(p) for pref in TEST_SID_PREFIXES
                 for p in glob.glob(os.path.join(STATE_ROOT, pref + "*")))
@@ -824,3 +869,8 @@ print(f"all search-tool-nudge tests passed ({len(ran)} checks: "
       f"{len(MUST_FIRE)} must-fire, {len(BENIGN)} benign, "
       f"1 harness negative control, 1 benign-counter positive control, "
       f"{len(SESSIONS)} availability-suppression scenarios)")
+# Machine-readable, and PARSED by the external isolation guard — keep the wording.
+# This half is only the number this file measured itself; the other half of the
+# pair (writes to the INHERITED home, which must be 0) is measured from outside,
+# because a suite cannot be its own witness for a home it no longer looks at.
+print(f"isolation: {TEMP_HOME_FILES} files under the temp HOME")

--- a/scripts/claude-hooks/tests/test_shell_env_nudge.py
+++ b/scripts/claude-hooks/tests/test_shell_env_nudge.py
@@ -1,11 +1,25 @@
 #!/usr/bin/env python3
 """Unit tests for shell-env-nudge.analyze() + the hook's IO contract.
 Run: python3 scripts/claude-hooks/tests/test_shell_env_nudge.py"""
-import os, sys, json, subprocess, importlib.util
+import os, sys, json, shutil, subprocess, tempfile, atexit, importlib.util
+
+# 🔴 HOME ISOLATION — before anything reads `~`, including the hook import below.
+# Same defect as test_search_tool_nudge.py: this file DELETES a cache entry and
+# spawns the hook, and shell-env-nudge.py resolves both its repo/kubeconfig map
+# and its CACHE_DIR from `os.path.expanduser("~")` == $HOME on POSIX. Against the
+# real home that writes and removes files in `~/.cache/claude-shell-env-nudge/`.
+# Redirecting $HOME moves the hook's map AND the suite's expectations together —
+# they are built from the same constant — so the assertions are unchanged.
+TEST_HOME = tempfile.mkdtemp(prefix="shell-env-nudge-HOME-")
+os.environ["HOME"] = TEST_HOME
+atexit.register(shutil.rmtree, TEST_HOME, ignore_errors=True)
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 HOOK = os.path.join(HERE, "..", "shell-env-nudge.py")
-HOME = os.path.expanduser("~")
+HOME = os.path.expanduser("~")  # == TEST_HOME; the hook resolves the same value
+assert HOME == TEST_HOME, (
+    "HOME redirection did not take effect (%r != %r) — every path below would "
+    "resolve into the operator's real home." % (HOME, TEST_HOME))
 
 spec = importlib.util.spec_from_file_location("shell_env_nudge", HOOK)
 assert spec and spec.loader
@@ -75,6 +89,15 @@ check("io non-bash silent", (rc3, out3), (0, ""))
 p = subprocess.run([sys.executable, HOOK], input="not json", capture_output=True, text=True)
 check("io malformed rc", p.returncode, 0)
 
+# 🔴 ISOLATION POSITIVE CONTROL, counted BEFORE the cleanup below removes it.
+# "the real home was untouched" is the same reassuring zero a suite that stopped
+# driving the hook at all would print, so the count under the throwaway HOME is
+# measured and reported beside it. The inherited-home half is measured from
+# outside, in scripts/tests/test_hook_suites_do_not_touch_the_inherited_home.py.
+TEMP_HOME_FILES = sum(len(fs) for _, _, fs in os.walk(TEST_HOME))
+check("isolation positive control: the suite wrote state under the temp HOME",
+      TEMP_HOME_FILES > 0, True)
+
 if os.path.exists(cache):
     os.remove(cache)
 
@@ -84,3 +107,5 @@ if fails:
         print("  -", f)
     sys.exit(1)
 print("all shell-env-nudge tests passed")
+# Machine-readable, and PARSED by the external isolation guard — keep the wording.
+print(f"isolation: {TEMP_HOME_FILES} files under the temp HOME")

--- a/scripts/tests/test_hook_suites_do_not_touch_the_inherited_home.py
+++ b/scripts/tests/test_hook_suites_do_not_touch_the_inherited_home.py
@@ -1,0 +1,268 @@
+"""A hook test suite must never write into the `$HOME` it inherits.
+
+THE DEFECT (measured on origin/main, 3c54918):
+
+    scripts/claude-hooks/tests/test_search_tool_nudge.py computed
+    `HOME = os.path.expanduser("~")` at import and derived
+    `STATE_ROOT = $HOME/.cache/claude-search-tool-nudge/s` from it. It then
+    GLOBBED AND DELETED under that path, and drove the hook as a subprocess
+    ~130 times with the same real `$HOME` inherited, so the child resolved the
+    identical directory.
+
+    Two consequences, both real:
+
+      * it deleted entries from the operator's own nudge state, and
+      * the LIVE search-tool-nudge hook fires on every Bash call of every Claude
+        Code session on the box — including the session running the gate — so an
+        agent's own commands mutated the state the suite was asserting on, mid
+        run. The suite failed spuriously and the failure looked like a code bug.
+
+    test_shell_env_nudge.py had the same shape (it created and removed
+    `~/.cache/claude-shell-env-nudge/<sid>`).
+
+WHAT EACH TEST HERE IS (labelled, because "it passes" is not a category):
+
+  * test_the_suite_writes_nothing_into_the_home_it_inherits
+        REGRESSION. Red at 3c54918, green at HEAD, for both suites.
+  * test_the_suite_does_write_state_under_its_own_temp_home
+        POSITIVE CONTROL for the test above. A suite that silently stopped
+        driving the hook would ALSO leave the inherited home untouched — the
+        same reassuring zero as a harness wired to nothing. This reads the count
+        the suite prints for its own throwaway HOME and requires it non-zero, so
+        the pair is always reported together.
+  * test_every_subprocess_env_in_an_isolated_suite_derives_from_os_environ
+        SEAM / LEDGER guard, not regression coverage. The isolation works by
+        mutating `os.environ`, which only reaches a child that inherits it or
+        builds its env from it. A future spawn with a hand-assembled `env=`
+        would reintroduce the leak with every existing assertion still green.
+        This reads the suites' own source and fails when one appears.
+
+🔴 This file never touches the operator's real home. Each suite is run with
+`HOME` pointed at a fresh empty tmp_path, which stands in for the real one: the
+assertion is "the suite wrote nothing into the home it was GIVEN", which is the
+same property, measured somewhere harmless. Nothing here stats, creates or
+reads `~/.cache/*`.
+"""
+import ast
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_TESTS = REPO_ROOT / "scripts" / "claude-hooks" / "tests"
+
+# The script suites that redirect `$HOME` for themselves. Named explicitly and
+# pinned by `test_the_ledger_names_only_files_that_exist` so a rename cannot
+# silently drop one out of coverage.
+ISOLATED_SUITES = (
+    "test_search_tool_nudge.py",
+    "test_shell_env_nudge.py",
+)
+
+# The line each isolated suite prints with the count it measured under its OWN
+# throwaway HOME. Pinned as a whole normalised shape, not a keyword: a guard on
+# the word "isolation" alone is walkable by any other line that spells it.
+ISOLATION_LINE = re.compile(r"^isolation: (\d+) files under the temp HOME$", re.M)
+
+_TIMEOUT = 900
+
+
+def _run_suite(suite: str, home: Path):
+    """Run one script suite with `$HOME` pointed at `home`.
+
+    `home` is a throwaway directory standing in for the operator's real one, so
+    a suite that leaks writes there is caught without any real state at risk.
+    """
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    return subprocess.run(
+        [sys.executable, str(HOOK_TESTS / suite)],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=_TIMEOUT,
+    )
+
+
+def _tree(root: Path):
+    """Every path under `root`, relative — WITHOUT creating `root`.
+
+    `os.walk` on a missing directory yields nothing rather than raising or
+    creating anything, which is the property that keeps this safe to point at a
+    path that must not come into existence.
+    """
+    out = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        for name in list(dirnames) + list(filenames):
+            out.append(str(Path(dirpath, name).relative_to(root)))
+    return sorted(out)
+
+
+@pytest.fixture(scope="module")
+def suite_runs(tmp_path_factory):
+    """Run each suite ONCE, against its own empty stand-in home.
+
+    Module-scoped because the two tests below ask different questions of the
+    same run, and re-running would double the gate's cost for no new evidence.
+    """
+    runs = {}
+    for suite in ISOLATED_SUITES:
+        home = tmp_path_factory.mktemp("stand-in-home-" + suite.replace(".py", ""))
+        before = _tree(home)
+        proc = _run_suite(suite, home)
+        runs[suite] = (proc, before, _tree(home))
+    return runs
+
+
+# ---------------------------------------------------------------------------
+# REGRESSION
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("suite", ISOLATED_SUITES)
+def test_the_suite_writes_nothing_into_the_home_it_inherits(suite, suite_runs):
+    """RED at 3c54918, GREEN at HEAD.
+
+    Pre-change, `test_search_tool_nudge.py` left 60-odd entries under the
+    inherited home (`.cache/claude-search-tool-nudge/s/<session>/<token>`) and
+    `test_shell_env_nudge.py` left `.cache/claude-shell-env-nudge/`. Both are
+    now zero because each suite makes its own `$HOME` before reading `~`.
+
+    Asserted on the FULL tree, not just `.cache`: the hazard is "writes into the
+    operator's home", and naming one subdirectory would let the next state path
+    a hook invents walk straight past this guard.
+    """
+    proc, before, after = suite_runs[suite]
+    assert proc.returncode == 0, (
+        f"{suite} failed before this guard could measure anything "
+        f"(exit={proc.returncode}).\n--- stdout ---\n{proc.stdout}\n"
+        f"--- stderr ---\n{proc.stderr}"
+    )
+    assert before == [], f"the stand-in home was not empty to begin with: {before}"
+    assert after == [], (
+        f"{suite} wrote {len(after)} entries into the $HOME it inherited:\n"
+        f"  {json.dumps(after[:20], indent=2)}\n"
+        "Run against the operator's real home that is their own hook state being "
+        "created and deleted — and the LIVE hook writing into the state the suite "
+        "asserts on. Redirect `os.environ['HOME']` to a tempfile.mkdtemp BEFORE the "
+        "suite computes anything from `~` (including its import of the hook)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# POSITIVE CONTROL for the regression above
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("suite", ISOLATED_SUITES)
+def test_the_suite_does_write_state_under_its_own_temp_home(suite, suite_runs):
+    """The other half of the pair — a ZERO alone is not evidence.
+
+    A suite that stopped exercising the hook, or whose subprocesses all failed
+    silently, would leave the inherited home untouched too. So the count the
+    suite measured under its OWN throwaway HOME must be non-zero, and the two
+    numbers are reported together: "N under the temp HOME, 0 in the inherited
+    one".
+    """
+    proc, _before, after = suite_runs[suite]
+    m = ISOLATION_LINE.search(proc.stdout)
+    assert m, (
+        f"{suite} printed no `isolation: N files under the temp HOME` line, so "
+        "there is no positive control and the zero above proves nothing.\n"
+        f"--- stdout ---\n{proc.stdout}"
+    )
+    written = int(m.group(1))
+    assert written > 0, (
+        f"{suite} wrote NOTHING under its own temp HOME. The inherited home being "
+        "clean is then indistinguishable from a suite wired to nothing — it is not "
+        "evidence of isolation."
+    )
+    # Report the pair, so the passing message carries its own scope.
+    print(f"{suite}: {written} files under the temp HOME, "
+          f"{len(after)} writes to the inherited HOME")
+
+
+# ---------------------------------------------------------------------------
+# SEAM / LEDGER
+# ---------------------------------------------------------------------------
+
+def _spawn_env_sources(path: Path):
+    """Source text of every `env=` kwarg passed to subprocess.run/Popen in `path`.
+
+    Read with `ast`, not imported: importing a script suite runs it.
+    """
+    src = path.read_text(encoding="utf-8")
+    tree = ast.parse(src, filename=str(path))
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        name = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", None)
+        if name not in {"run", "Popen", "call", "check_output", "check_call"}:
+            continue
+        for kw in node.keywords:
+            if kw.arg == "env":
+                found.append(ast.get_source_segment(src, kw.value) or ast.dump(kw.value))
+    return found
+
+
+def test_the_ledger_names_only_files_that_exist():
+    """Positive control for the two tests above and the seam guard below.
+
+    Every one of them is parametrized over `ISOLATED_SUITES`; a typo'd or
+    renamed entry would make each parametrisation fail loudly, but an entry
+    silently REMOVED would make the whole file measure less while staying green.
+    Pinned here as a set so the coverage cannot shrink unnoticed.
+    """
+    assert len(ISOLATED_SUITES) >= 2
+    for suite in ISOLATED_SUITES:
+        assert (HOOK_TESTS / suite).is_file(), f"{suite} is not in {HOOK_TESTS}"
+
+
+@pytest.mark.parametrize("suite", ISOLATED_SUITES)
+def test_every_subprocess_env_in_an_isolated_suite_derives_from_os_environ(suite):
+    """SEAM guard — NOT regression coverage.
+
+    The isolation is `os.environ["HOME"] = <tmp>`, which reaches a child only if
+    the child inherits `os.environ` (no `env=` at all) or the env is BUILT from
+    it (`dict(os.environ, …)` / `{**os.environ, …}`). A spawn with a
+    hand-assembled env would silently hand the hook the real `$HOME` back while
+    every behavioural assertion in the suite stayed green — the leak is in the
+    seam, not in either component.
+    """
+    envs = _spawn_env_sources(HOOK_TESTS / suite)
+    offenders = [e for e in envs if "os.environ" not in e]
+    assert not offenders, (
+        f"{suite} spawns a subprocess with an env not derived from os.environ: "
+        f"{offenders}\nThat child gets the operator's REAL $HOME back. Build it "
+        "as dict(os.environ, …) or {**os.environ, …}, or pass no env= at all."
+    )
+
+
+def test_the_env_scanner_can_actually_see_an_offender(tmp_path):
+    """Positive control for the scanner itself.
+
+    `offenders == []` above is exactly the reassuring zero a parser wired to
+    nothing returns — a renamed call, a changed AST shape, a wrong attribute
+    name all produce it. So the same function is fed a file it MUST flag, and
+    one it must NOT, and both answers are pinned.
+    """
+    bad = tmp_path / "bad.py"
+    bad.write_text(
+        "import subprocess, sys\n"
+        "subprocess.run([sys.executable], env={'HOME': '/real/home'})\n"
+    )
+    assert _spawn_env_sources(bad) == ["{'HOME': '/real/home'}"]
+
+    good = tmp_path / "good.py"
+    good.write_text(
+        "import os, subprocess, sys\n"
+        "subprocess.run([sys.executable], env=dict(os.environ, X='1'))\n"
+        "subprocess.Popen([sys.executable])\n"
+    )
+    assert [e for e in _spawn_env_sources(good) if "os.environ" not in e] == []

--- a/scripts/tests/test_hook_suites_do_not_touch_the_inherited_home.py
+++ b/scripts/tests/test_hook_suites_do_not_touch_the_inherited_home.py
@@ -69,6 +69,32 @@ ISOLATED_SUITES = (
 # the word "isolation" alone is walkable by any other line that spells it.
 ISOLATION_LINE = re.compile(r"^isolation: (\d+) files under the temp HOME$", re.M)
 
+# DECOYS — pre-existing state planted in the stand-in home before the suite runs.
+#
+# 🔴 Without these the guard could only see the suite CREATING things, and the
+# other half of the defect is that both suites DELETE: search-tool-nudge globs
+# `$HOME/.cache/claude-search-tool-nudge/s/<prefix>*` and rmtree's each hit (plus
+# a legacy flat-file layout one directory up), and shell-env-nudge `os.remove`s
+# its cache entry. A destructive run that tidies up after itself leaves an
+# end-state diff of zero, so deletion is invisible to a create-only check. Each
+# decoy is a path the PRE-CHANGE suite provably removes; they must all survive.
+DECOYS = {
+    "test_search_tool_nudge.py": (
+        # matches TEST_SID_PREFIXES -> rmtree'd by the pre-change clear_test_state
+        ".cache/claude-search-tool-nudge/s/test-session-search-nudge-DECOY/content",
+        # the LEGACY flat-file layout, one directory up -> os.remove'd
+        ".cache/claude-search-tool-nudge/test-search-nudge-DECOY-legacy",
+    ),
+    "test_shell_env_nudge.py": (
+        # the exact cache entry the pre-change suite removes, twice
+        ".cache/claude-shell-env-nudge/test-session-io-DO-NOT-COLLIDE",
+    ),
+}
+# Planted for every suite: a bystander no cleanup glob names, so a guard that
+# went red only because a decoy was deliberately collidable still has one path
+# whose survival means "ordinary home content was left alone".
+BYSTANDER = ".cache/an-unrelated-file-the-suite-must-not-touch"
+
 _TIMEOUT = 900
 
 
@@ -104,16 +130,25 @@ def _tree(root: Path):
     return sorted(out)
 
 
+def _plant(home: Path, relpaths):
+    """Create each `relpath` under `home` as a file with known content."""
+    for rel in relpaths:
+        p = home / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("decoy — the suite under test must not touch this\n")
+
+
 @pytest.fixture(scope="module")
 def suite_runs(tmp_path_factory):
-    """Run each suite ONCE, against its own empty stand-in home.
+    """Run each suite ONCE, against its own stand-in home seeded with decoys.
 
-    Module-scoped because the two tests below ask different questions of the
-    same run, and re-running would double the gate's cost for no new evidence.
+    Module-scoped because the tests below ask different questions of the same
+    run, and re-running would double the gate's cost for no new evidence.
     """
     runs = {}
     for suite in ISOLATED_SUITES:
         home = tmp_path_factory.mktemp("stand-in-home-" + suite.replace(".py", ""))
+        _plant(home, DECOYS[suite] + (BYSTANDER,))
         before = _tree(home)
         proc = _run_suite(suite, home)
         runs[suite] = (proc, before, _tree(home))
@@ -128,12 +163,12 @@ def suite_runs(tmp_path_factory):
 def test_the_suite_writes_nothing_into_the_home_it_inherits(suite, suite_runs):
     """RED at 3c54918, GREEN at HEAD.
 
-    Pre-change, `test_search_tool_nudge.py` left 60-odd entries under the
-    inherited home (`.cache/claude-search-tool-nudge/s/<session>/<token>`) and
-    `test_shell_env_nudge.py` left `.cache/claude-shell-env-nudge/`. Both are
-    now zero because each suite makes its own `$HOME` before reading `~`.
+    Asserted in BOTH directions — created AND removed — because the two suites
+    do both, and a create-only check is blind to a destructive run that tidies
+    up after itself. The decoys planted by the fixture are what make the removal
+    half measurable at all.
 
-    Asserted on the FULL tree, not just `.cache`: the hazard is "writes into the
+    Asserted on the FULL tree, not just `.cache`: the hazard is "touches the
     operator's home", and naming one subdirectory would let the next state path
     a hook invents walk straight past this guard.
     """
@@ -143,10 +178,17 @@ def test_the_suite_writes_nothing_into_the_home_it_inherits(suite, suite_runs):
         f"(exit={proc.returncode}).\n--- stdout ---\n{proc.stdout}\n"
         f"--- stderr ---\n{proc.stderr}"
     )
-    assert before == [], f"the stand-in home was not empty to begin with: {before}"
-    assert after == [], (
-        f"{suite} wrote {len(after)} entries into the $HOME it inherited:\n"
-        f"  {json.dumps(after[:20], indent=2)}\n"
+    # The decoys must have been planted, or "unchanged" is a comparison against
+    # an absent operand and reports SAME for a home holding nothing.
+    for rel in DECOYS[suite] + (BYSTANDER,):
+        assert rel in before, f"decoy {rel} was never planted; before={before}"
+
+    created = sorted(set(after) - set(before))
+    removed = sorted(set(before) - set(after))
+    assert (created, removed) == ([], []), (
+        f"{suite} modified the $HOME it inherited:\n"
+        f"  created: {json.dumps(created[:20], indent=2)}\n"
+        f"  REMOVED: {json.dumps(removed[:20], indent=2)}\n"
         "Run against the operator's real home that is their own hook state being "
         "created and deleted — and the LIVE hook writing into the state the suite "
         "asserts on. Redirect `os.environ['HOME']` to a tempfile.mkdtemp BEFORE the "
@@ -168,7 +210,7 @@ def test_the_suite_does_write_state_under_its_own_temp_home(suite, suite_runs):
     numbers are reported together: "N under the temp HOME, 0 in the inherited
     one".
     """
-    proc, _before, after = suite_runs[suite]
+    proc, before, after = suite_runs[suite]
     m = ISOLATION_LINE.search(proc.stdout)
     assert m, (
         f"{suite} printed no `isolation: N files under the temp HOME` line, so "
@@ -181,9 +223,12 @@ def test_the_suite_does_write_state_under_its_own_temp_home(suite, suite_runs):
         "clean is then indistinguishable from a suite wired to nothing — it is not "
         "evidence of isolation."
     )
-    # Report the pair, so the passing message carries its own scope.
+    # Report the pair, so the passing message carries its own scope. The second
+    # number is the CHANGE to the inherited home (created + removed), never the
+    # size of that tree — it holds the fixture's decoys, which must all survive.
+    changed = len(set(after) ^ set(before))
     print(f"{suite}: {written} files under the temp HOME, "
-          f"{len(after)} writes to the inherited HOME")
+          f"{changed} changes to the inherited HOME")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_hook_suites_do_not_touch_the_inherited_home.py
+++ b/scripts/tests/test_hook_suites_do_not_touch_the_inherited_home.py
@@ -1,13 +1,13 @@
-"""A hook test suite must never write into the `$HOME` it inherits.
+"""A hook test suite must never touch the `$HOME` it inherits.
 
 THE DEFECT (measured on origin/main, 3c54918):
 
     scripts/claude-hooks/tests/test_search_tool_nudge.py computed
     `HOME = os.path.expanduser("~")` at import and derived
     `STATE_ROOT = $HOME/.cache/claude-search-tool-nudge/s` from it. It then
-    GLOBBED AND DELETED under that path, and drove the hook as a subprocess
-    ~130 times with the same real `$HOME` inherited, so the child resolved the
-    identical directory.
+    GLOBBED AND DELETED under that path, and drove the hook as a real
+    subprocess once per scenario in the file with that same real `$HOME`
+    inherited, so every child resolved the identical directory.
 
     Two consequences, both real:
 
@@ -22,8 +22,9 @@ THE DEFECT (measured on origin/main, 3c54918):
 
 WHAT EACH TEST HERE IS (labelled, because "it passes" is not a category):
 
-  * test_the_suite_writes_nothing_into_the_home_it_inherits
-        REGRESSION. Red at 3c54918, green at HEAD, for both suites.
+  * test_the_suite_does_not_touch_the_home_it_inherits
+        REGRESSION. Red at 3c54918, green at HEAD, for both suites — and red on
+        the DELETION, which is the half a create-only check cannot see.
   * test_the_suite_does_write_state_under_its_own_temp_home
         POSITIVE CONTROL for the test above. A suite that silently stopped
         driving the hook would ALSO leave the inherited home untouched — the
@@ -38,10 +39,10 @@ WHAT EACH TEST HERE IS (labelled, because "it passes" is not a category):
         This reads the suites' own source and fails when one appears.
 
 🔴 This file never touches the operator's real home. Each suite is run with
-`HOME` pointed at a fresh empty tmp_path, which stands in for the real one: the
-assertion is "the suite wrote nothing into the home it was GIVEN", which is the
-same property, measured somewhere harmless. Nothing here stats, creates or
-reads `~/.cache/*`.
+`HOME` pointed at a fresh tmp_path seeded with decoys, standing in for the real
+one: the assertion is "the suite left the home it was GIVEN exactly as it found
+it", which is the same property, measured somewhere harmless. Nothing here
+stats, creates or reads `~/.cache/*`.
 """
 import ast
 import json
@@ -160,7 +161,7 @@ def suite_runs(tmp_path_factory):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("suite", ISOLATED_SUITES)
-def test_the_suite_writes_nothing_into_the_home_it_inherits(suite, suite_runs):
+def test_the_suite_does_not_touch_the_home_it_inherits(suite, suite_runs):
     """RED at 3c54918, GREEN at HEAD.
 
     Asserted in BOTH directions — created AND removed — because the two suites


### PR DESCRIPTION
## The defect

`scripts/claude-hooks/tests/test_search_tool_nudge.py` computed
`HOME = os.path.expanduser("~")` at import and derived
`STATE_ROOT = $HOME/.cache/claude-search-tool-nudge/s` from it — the **operator's
real home**. It then globbed and `rmtree`'d under that path, and drove the hook as
a real subprocess once per scenario with that same real `$HOME` inherited, so
every child resolved the identical directory (`search-tool-nudge.py` builds its
own `CACHE_DIR` from `expanduser("~")` too).

Two consequences, both real:

* it **deleted** entries from the operator's own nudge state, and
* the **live** `search-tool-nudge` hook fires on every Bash call of every Claude
  Code session on the box — including the session running the gate — so an agent's
  own commands mutated the state the suite was asserting on, mid-run. The suite
  failed spuriously and the failure read as a code defect. Anyone running
  `scripts/gate.sh` from inside an active session hits this.

`test_shell_env_nudge.py` had the same shape: it created and `os.remove`d
`~/.cache/claude-shell-env-nudge/<sid>`, and its hook derives its whole
repo/kubeconfig map from `~` as well.

## The fix

Each suite makes its own throwaway `$HOME` with `tempfile.mkdtemp` and exports it
into `os.environ` **before anything reads `~`** — including the import of the hook
module. `os.path.expanduser("~")` is `os.environ["HOME"]` on POSIX (verified in
this session, not assumed: `posixpath.expanduser` returns `$HOME` when set and
only falls back to the passwd entry when it is absent), so that one assignment
redirects the suite's own constants and every inheriting child at once. Removed at
exit via `atexit`. An assertion right after the redirect fails loudly if it did
not take.

All eight spawn sites were checked individually — six in `test_search_tool_nudge.py`
(lines 190, 252, 618, 645, 662, 700), two in `test_shell_env_nudge.py`. Each either
passes no `env=` (inherits `os.environ`) or builds it as `dict(os.environ, …)`.

Both files keep their **script-suite** shape — no top-level `def test_`, so
`conftest.py`'s structural classifier and `run-tests.sh`'s `HOOK_TESTS` list still
agree and `test_hook_tests_dir_collects.py` stays green.

## The new guard

`scripts/tests/test_hook_suites_do_not_touch_the_inherited_home.py` (8 tests).

**REGRESSION** — runs each suite with `$HOME` pointed at a stand-in `tmp_path`
seeded with **decoys**, and asserts the tree is byte-for-byte unchanged, both
directions (created **and** removed). The decoys matter: both suites *delete*, and
a run that tidies up after itself leaves a create-only diff of zero. The decoys are
paths the pre-change suite provably removes, plus a bystander no cleanup glob names.
Their presence is asserted in the `before` snapshot first, so "unchanged" can never
be a comparison against an absent operand.

**POSITIVE CONTROL** — a suite that silently stopped driving the hook would leave
the inherited home clean too; that zero is indistinguishable from a harness wired to
nothing. Each suite now prints the file count it measured under its **own** temp
HOME, and the guard requires it non-zero, so the pair is always reported together.

**SEAM guard** — the isolation is a mutation of `os.environ`, so a spawn with a
hand-assembled `env=` would hand the real `$HOME` straight back while every
behavioural assertion stayed green. The suites' source is parsed with `ast` and any
such spawn fails. The scanner has its own must-flag / must-not-flag control, and the
suite ledger is pinned so coverage cannot shrink silently.

🔴 The guard never touches the operator's real home: it only ever points `HOME` at a
`tmp_path`. Nothing in it stats, creates or reads `~/.cache/*`.

## Verification

**Red at base, green at HEAD** (base = `3c54918`, measured by reverting only the two
suite files with `git checkout origin/main -- …` and re-running the guard):

| test | 3c54918 | HEAD |
|---|---|---|
| `…does_not_touch_the_home_it_inherits[test_search_tool_nudge.py]` | **FAIL** — REMOVED `.cache/claude-search-tool-nudge/s/test-session-search-nudge-DECOY`, `…/DECOY/content`, `.cache/claude-search-tool-nudge/test-search-nudge-DECOY-legacy` | PASS |
| `…does_not_touch_the_home_it_inherits[test_shell_env_nudge.py]` | **FAIL** — REMOVED `.cache/claude-shell-env-nudge/test-session-io-DO-NOT-COLLIDE` | PASS |
| `…does_write_state_under_its_own_temp_home[×2]` | **FAIL** — no isolation line printed | PASS |

An earlier create-only version of the same guard was also measured red at
`3c54918`, on 3 and 2 created entries respectively — so both directions have been
watched to fail.

**Positive-isolation pair** (printed by the guard):

```
test_search_tool_nudge.py: 69 files under the temp HOME, 0 changes to the inherited HOME
test_shell_env_nudge.py:    1 files under the temp HOME, 0 changes to the inherited HOME
```

**Suite size, before → after:** `test_search_tool_nudge.py` 174 → **175** checks
(floor `MIN_CHECKS = 160`); the one added check is the temp-HOME positive control.
`test_shell_env_nudge.py` has no counter; its check list grew by the same one.

## Sibling suites examined

| suite | verdict |
|---|---|
| `test_shell_env_nudge.py` | **same defect — fixed here** |
| `test_claude_notify.py` | already isolated (temp HOME + PATH stubs; its single spawn sets `env["HOME"]`) |
| `test_next_step_nudge.py` | already isolated (all three spawns set `HOME` to a tmp path) |
| `test_agent_ledger_hook.py` | already isolated (`e["HOME"] = str(home)` on both spawns; the ledger dir is derived from it) |
| `test_clawgate_writeback_guard.py` | already isolated (`monkeypatch.setenv("HOME", …)` plus `env["HOME"]` on all five spawns) |
| `test_bash_guard.py` | needs no redirect — `bash-guard.py` and `guard_core.py` contain **no** `makedirs`, no write-mode `open`, no `write_text`; they write nothing at all. Their `expanduser` calls are read-only path resolution of the command under test. |

## Gate

`nix develop … --command bash scripts/gate.sh --tier both --set all`, run on this
branch **rebased onto `29ea6f8`** (the merged tree, not the branch-as-authored):

```
FAIL  pytest  exit=1  verdict='RESULT: FAIL (exit=1)'
PASS  node    exit=0  verdict='RESULT: PASS (exit=0)'
GATE: RESULT=FAIL exit=1
```

TOTAL collected=13823 passed=13821 skipped=1 **failed=1** (floor 13034).
Node tier: suites=4 files=33 tests=1119 pass=1119 fail=0 (floor 1098).

🔴 **The one failure is PRE-EXISTING on `main` and is not from this PR:**

```
scripts/tests/test_subsystem_recall.py::TestSkillDocsArePinned
    ::test_the_recall_step_comes_AFTER_the_handoff_is_read
ValueError: substring not found   (doc.index("**Read it fully.**"))
```

`da11569` (#643) rewrote that line in `claude/skills/resume/SKILL.md` to
`**Read it fully — but treat its "Open investigations" section as RECALL, not live
state.**`, and the pin still looks for the old literal. Attributed three ways:

1. `git diff --quiet origin/main HEAD -- claude/skills/resume/SKILL.md
   scripts/tests/test_subsystem_recall.py` → rc 0; both files also proven to
   **exist** at `origin/main` (`git cat-file -e`), so that is a real match and not
   a comparison against an absent operand.
2. Reproduced in a **pristine detached worktree at `29ea6f8`** with this branch
   entirely absent — same `ValueError`, same line.
3. An earlier full gate run of this branch, based on `3c54918` (before #643
   landed), was **`GATE_EXIT=0`, both tiers PASS**.

This is exactly the merged-tree shape RULES.md warns about: #643 was green on its
own branch and turns `main` red. It needs a one-line fix in either the SKILL.md or
the pin, and it belongs to #643 rather than here — mixing it in would blur this
PR's red/green matrix. **Do not merge this until `main` is unbroken.**
