### PR TITLE
fix(tests): main is RED — a docstring said "structural, not a phrase" while pinning the phrase closed

### DIFF
--- a/scripts/tests/test_subsystem_recall.py
+++ b/scripts/tests/test_subsystem_recall.py
@@ -3580,9 +3580,21 @@ class TestSkillDocsArePinned:
 
     def test_the_recall_step_comes_AFTER_the_handoff_is_read(self) -> None:
         """Structural, not a phrase: recall is context for a doc already read,
-        not a substitute for reading it."""
+        not a substitute for reading it.
+
+        🔴 THE ANCHOR IS A PREFIX, AND THE CLOSING `**` IS DELIBERATELY NOT IN
+        IT. This docstring said "structural, not a phrase" while `.index()`
+        pinned the phrase `**Read it fully.**` closed — so `#643` appending a
+        clause inside the same bold span (`**Read it fully — but treat …**`)
+        reddened `main` for a reword that preserved every claim this test makes.
+        The subject here is the ORDERING, not the wording, so the anchor must
+        survive a continuation of that step and still vanish if the step does.
+        Pinning the whole normalised line is the right move when the PROSE is
+        the claim; it is the wrong move here, where it would fail on any edit to
+        an unrelated clause.
+        """
         doc = RESUME_DOC.read_text(encoding="utf-8")
-        read_it = doc.index("**Read it fully.**")
+        read_it = doc.index("**Read it fully")
         # The INVOCATION, not the bare filename: `resume-state.sh` is also named
         # in step 1's prose, so `.index()` on the bare name finds a point BEFORE
         # the handoff is read and the ordering claim inverts.


### PR DESCRIPTION
## `main` is RED right now, and this is the one-line fix

`test_the_recall_step_comes_AFTER_the_handoff_is_read` fails on `origin/main` (`29ea6f81`). Verified directly on a clean main worktree, not inferred: **1 failed / 49 passed**.

### Cause

#643 (`da115695`) appended a clause **inside the same bold span** of the resume skill's step 2:

```diff
- 2. **Read it fully.**
+ 2. **Read it fully — but treat its "Open investigations" section as RECALL, not live state.**
```

The test anchored on `doc.index("**Read it fully.**")` — closing `**` included. Every claim the test actually makes (`read_it < reconcile < step < report`) still holds; only the anchor broke. #643's wording change is good and is left alone.

The shape is worth naming: the test's own docstring said *"Structural, not a phrase"* while the implementation pinned the phrase. That's guard-narrower-than-its-description, inverted — here the **description was the honest half** and the code was narrower than it claimed.

### Fix

Anchor on the prefix `**Read it fully`, and record in the docstring **why the closing `**` is deliberately absent**, so nobody "tightens" it back. The subject of this test is the ORDERING, not the wording: the anchor must survive a continuation of that step and still vanish if the step does. Pinning the whole normalised line is the right move when the PROSE is the claim; it is the wrong move here, where it would fail on any edit to an unrelated clause.

### Verified as a pair, not a bare green

| step | result |
|---|---|
| before, on `main` | **1 failed** / 49 passed |
| after | **445 passed** (whole file) |
| negative control — reword step 2 away | the **same test fails again, by name** |
| restore | passes |

The negative control is the part that matters: it shows the anchor was loosened, not gutted.

### How it was found, and the pattern

By gating a **merged tree** for an unrelated PR — the branch was green and `main` was red, so a branch-only gate would have missed it entirely.

This is the **third** defect sitting on `main` today that no gate caught: #619's client-subdomain leak (fixed in #622), the branch-dependent guard-core tests (fixed in #623), and now this. All three have the same root cause — this repo has **no CI** (`<!-- merge-gate: none -->`) and the gate is run by hand, so it only runs when someone chooses to. `ZacxDev/homelab-infra#370` is the pipeline that would close that hole; it is open and blocked on a one-click GitHub App install.
