### PR TITLE
fix(tests): `main` is RED — a pin whose docstring said "structural, not a phrase" was a phrase

### DIFF
--- a/scripts/tests/test_subsystem_recall.py
+++ b/scripts/tests/test_subsystem_recall.py
@@ -43,6 +43,7 @@ import collections
 import hashlib
 import importlib.util
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -3582,14 +3583,47 @@ class TestSkillDocsArePinned:
         """Structural, not a phrase: recall is context for a doc already read,
         not a substitute for reading it."""
         doc = RESUME_DOC.read_text(encoding="utf-8")
-        read_it = doc.index("**Read it fully.**")
+
+        def _at(anchor: str, what: str, *, regex: bool = False) -> int:
+            """Offset of `anchor`, or a failure that says the doc was reworded.
+
+            🔴 `str.index` raises a bare `ValueError: substring not found` with
+            no mention of which anchor, which file, or what to do — #643
+            reworded step 2 and left exactly that, so `main` sat RED with a
+            traceback that named nothing. Every anchor goes through here.
+            """
+            if regex:
+                m = re.search(anchor, doc, re.MULTILINE)
+                found = m.start() if m else -1
+            else:
+                found = doc.find(anchor)
+            assert found != -1, (
+                f"claude/skills/resume/SKILL.md no longer contains the {what} "
+                f"anchor ({anchor!r}). The doc was almost certainly REWORDED, "
+                f"not broken — re-read the step order and update this anchor. "
+                f"Do NOT delete the assertion: it pins that recall is context "
+                f"for a doc already read, not a substitute for reading it."
+            )
+            return found
+
+        # 🔴 The read-step anchor is a PREFIX on the numbered-list marker, not
+        # the whole bolded sentence. The old pin was the exact string
+        # `**Read it fully.**`; #643 appended a clause inside the bold, moving
+        # the closing `**`, and a guard whose docstring says "structural, not a
+        # phrase" broke on a pure reword. Anchoring on `<n>. **Read it fully`
+        # survives any continuation of that sentence.
+        read_it = _at(r"^\d+\.\s+\*\*Read it fully", "handoff-read step", regex=True)
         # The INVOCATION, not the bare filename: `resume-state.sh` is also named
         # in step 1's prose, so `.index()` on the bare name finds a point BEFORE
         # the handoff is read and the ordering claim inverts.
-        reconcile = doc.index("bash ~/workspace/devrc/scripts/resume-state.sh")
-        step = doc.index("subsystem_recall.py")
-        report = doc.index("**Report**")
-        assert read_it < reconcile < step < report
+        reconcile = _at("bash ~/workspace/devrc/scripts/resume-state.sh", "reconciler invocation")
+        step = _at("subsystem_recall.py", "recall invocation")
+        report = _at("**Report**", "report step")
+        assert read_it < reconcile < step < report, (
+            "claude/skills/resume/SKILL.md steps are out of order — recall must "
+            f"come AFTER the handoff is read. Offsets: read={read_it} "
+            f"reconcile={reconcile} recall={step} report={report}"
+        )
 
     def test_the_pin_can_report_absence(self) -> None:
         """Negative control on the pin: a check against a doc that happens to


### PR DESCRIPTION
fix(tests): `main` is RED — a pin whose docstring said "structural, not a phrase" was a phrase

#643 reworded step 2 of `claude/skills/resume/SKILL.md`:

    -2. **Read it fully.**
    +2. **Read it fully — but treat its "Open investigations" section as RECALL, not live state.**

That moved the closing `**`, and `test_the_recall_step_comes_AFTER_the_handoff_is_read`
did `doc.index("**Read it fully.**")` on the exact old string. Every gate run on
`main` has been red since — verified on a pristine detached worktree at 29ea6f8:
1 failed, 444 passed. A permanently-red gate trains everyone to click through, so
this is not a cosmetic fix.

The defect is the one `claude/RULES.md` names: the guard's own docstring says
"Structural, not a phrase" while the implementation was a phrase, walkable by a
pure reword. Patching the literal would have rebuilt the same trap, so:

* the read-step anchor is a PREFIX regex on the numbered-list marker
  (`^\d+\.\s+\*\*Read it fully`), which survives any continuation of that
  sentence inside the bold. The other three anchors are literal commands the
  skill runs, which is genuinely structural.
* every anchor goes through `_at()`, which fails with WHICH anchor, WHICH file,
  that the doc was almost certainly reworded, and "do NOT delete the assertion".
  `str.index` raised a bare `ValueError: substring not found` naming none of
  that — which is why a red `main` was easy to look past.
* the ordering assertion carries the four offsets in its message.

Both assertions were watched fire, each with its own message:

* pure reword (`Read`->`Peruse`) -> the anchor message, `assert -1 != -1`
* `**Report**` hoisted to offset 0 -> the ordering message, `assert 5163 < 0`

Matrix: red at 29ea6f8 (1 failed, 444 passed), green at HEAD (445 passed).
Full gate on the branch: `GATE: RESULT=PASS exit=0` — pytest 13814 passed /
0 failed, node 1119/1119, both tiers' own RESULT lines agreeing.

`re` is newly imported; it had no prior use in this module.
