### PR TITLE
fix(signal): the D3 send path has never worked on real Postgres (COALESCE uuid/text)

### DIFF
--- a/scripts/signal/_signal_db.py
+++ b/scripts/signal/_signal_db.py
@@ -1292,8 +1292,21 @@ class SignalDB:
                 """
                 SELECT m.id, m.message_timestamp, m.body, m.send_state,
                        m.approval_ref, m.source_contact_id, m.dest_contact_id,
+                       -- `signal_uuid` is uuid, `phone_number` is text, and
+                       -- Postgres type-checks the WHOLE CASE regardless of which
+                       -- branch would run — so an uncast COALESCE here raises
+                       -- DatatypeMismatch for EVERY draft, breaking approve(),
+                       -- send() and reconcile() alike (they all reach this).
+                       -- The hermetic suite cannot see it: its substrate is
+                       -- SQLite, which is dynamically typed and accepts the
+                       -- uncast form.
+                       -- 🔴 Use ANSI `CAST(... AS text)`, NOT Postgres's `::`.
+                       -- SQLite cannot parse `::`, so the pg-only spelling
+                       -- turns 53 hermetic tests red — measured, not guessed.
+                       -- The cast must satisfy BOTH engines or one of the two
+                       -- gates goes blind.
                        CASE WHEN d.is_placeholder THEN d.phone_number
-                            ELSE COALESCE(d.signal_uuid, d.phone_number)
+                            ELSE COALESCE(CAST(d.signal_uuid AS text), d.phone_number)
                        END AS recipient
                 FROM signal.messages m
                 LEFT JOIN signal.contacts d ON d.id = m.dest_contact_id

--- a/scripts/signal/_signal_db.py
+++ b/scripts/signal/_signal_db.py
@@ -1433,10 +1433,20 @@ class SignalDB:
         errors = [entry["errors"] for entry in entries if entry.get("errors")]
         errors += [entry["error"] for entry in entries if entry.get("error")]
         if errors:
+            # 🔴 Carry the server timestamp into the error. A partly-failed GROUP
+            # send DID go out to the members that succeeded, and the reply
+            # carried the timestamp `reconcile --sent --timestamp` needs. Without
+            # it here the value is discarded and the operator has to hunt it in
+            # the Signal thread — which is exactly the position draft 51 left
+            # its operator in.
+            ts_hint = entries[0].get("timestamp")
             raise RuntimeError(
                 f"the Signal API reported per-recipient errors for draft "
                 f"{draft_id!r}: {errors!r}; the draft stays in {STATE_SENDING!r} "
                 f"for manual reconciliation — see `reconcile`"
+                + (f". The response carried timestamp {ts_hint!r}; if the message "
+                   f"DID reach the thread, reconcile with "
+                   f"`--sent --timestamp {ts_hint}`" if ts_hint else "")
             )
         server_ts = _server_timestamp(entries[0])
         # The terminal update carries the SAME state predicate as the claim. This

--- a/scripts/signal/_signal_db.py
+++ b/scripts/signal/_signal_db.py
@@ -387,6 +387,53 @@ def spend_authorization(auth: object) -> None:
 TYPE_DELETED = "deleted"
 
 
+def _normalize_send_response(result) -> list:
+    """The `/v2/send` reply as a list of per-recipient dicts.
+
+    🔴 MEASURED, not assumed. Against signal-cli-rest-api in **json-rpc** mode
+    the success reply is a LIST, one entry per recipient::
+
+        201  [{"timestamp":"1787331796630"}]
+
+    A bare dict is also accepted, because upstream documents
+    `ds.SendMessageResponse` as an object and other modes/versions return that
+    shape. Anything else raises, deliberately: the caller has already COMMITTED
+    `send_state=sending` before the POST, so a surprise here leaves a draft a
+    human reconciles — never a silent duplicate send.
+
+    Exactly one entry is required. Every caller sends to a single recipient
+    (`recipients: [recipient]`), so a longer list means the wire contract
+    changed and picking an entry would be a guess about which message the stored
+    timestamp belongs to — which is precisely what breaks sync-echo dedupe.
+    """
+    if isinstance(result, dict):
+        entries = [result]
+    elif isinstance(result, list):
+        entries = result
+    else:
+        raise ValueError(
+            f"unrecognised /v2/send response shape {type(result).__name__}: "
+            f"{result!r}; expected a list of per-recipient objects (json-rpc "
+            f"mode) or a single object"
+        )
+    if not entries:
+        raise ValueError(
+            "the Signal API returned an EMPTY /v2/send response; without a "
+            "per-recipient entry there is no timestamp to dedupe the sync echo"
+        )
+    if len(entries) != 1:
+        raise ValueError(
+            f"the Signal API returned {len(entries)} /v2/send entries for a "
+            f"single recipient: {entries!r}; refusing to guess which timestamp "
+            f"to store"
+        )
+    if not all(isinstance(e, dict) for e in entries):
+        raise ValueError(
+            f"the Signal API returned non-object entries in /v2/send: {entries!r}"
+        )
+    return entries
+
+
 def _server_timestamp(result) -> int:
     """The server-assigned send timestamp, coerced and sanity-checked (🔧 #4).
 
@@ -1365,17 +1412,33 @@ class SignalDB:
 
         result = transmit(auth, recipient=draft["recipient"], body=draft["body"],
                           number=number)
+        # 🔴 The live server returns a LIST, one entry per recipient — measured
+        # 2026-08-21 against signal-cli-rest-api in json-rpc mode:
+        #     201  [{"timestamp":"1787331796630"}]
+        # The previous `(result or {}).get("errors")` assumed a dict and raised
+        # `AttributeError: 'list' object has no attribute 'get'` AFTER a
+        # SUCCESSFUL send — the worst shape available, because a delivered
+        # message reports as a failure and invites a duplicate resend. Normalise
+        # first; refuse an unrecognised shape loudly rather than guessing.
+        entries = _normalize_send_response(result)
         # The per-recipient errors are read BEFORE the timestamp: a response that
         # carries both an error and an unusable timestamp must report the ERROR,
         # which says what went wrong, not a timestamp complaint that hides it.
-        errors = (result or {}).get("errors")
+        # 🔴 Collect the errors payload WHOLE, never flattened. Upstream shapes it
+        # as an object (`{"recipients": [{"message": "rate limited"}]}`) as well
+        # as a list, and iterating an object yields its KEYS — which would report
+        # `['recipients']` and silently discard the reason the operator needs to
+        # reconcile. Pinned by
+        # test_approval_gate::test_an_error_response_reports_the_ERROR_not_a_timestamp_complaint.
+        errors = [entry["errors"] for entry in entries if entry.get("errors")]
+        errors += [entry["error"] for entry in entries if entry.get("error")]
         if errors:
             raise RuntimeError(
                 f"the Signal API reported per-recipient errors for draft "
                 f"{draft_id!r}: {errors!r}; the draft stays in {STATE_SENDING!r} "
                 f"for manual reconciliation — see `reconcile`"
             )
-        server_ts = _server_timestamp(result)
+        server_ts = _server_timestamp(entries[0])
         # The terminal update carries the SAME state predicate as the claim. This
         # sender owns the row only while it is still `sending`; if an operator
         # reconciled it in the meantime, stamping over their decision silently is

--- a/scripts/signal/consumer.py
+++ b/scripts/signal/consumer.py
@@ -988,7 +988,7 @@ def conversation_key(msg: dict) -> str:
 # --------------------------------------------------------------------------- #
 def transmit_approved(auth, *, recipient: str, body: str, number: str,
                       poster=None, api_url: str | None = None,
-                      timeout: float = 20.0) -> dict:
+                      timeout: float = 20.0) -> dict | list:
     """POST an approved draft to the Signal API. Requires a `SendAuthorization`.
 
     🔴 `spend_authorization()` runs BEFORE anything touches the network, and it

--- a/scripts/signal/tests/test_approval_gate.py
+++ b/scripts/signal/tests/test_approval_gate.py
@@ -1120,3 +1120,36 @@ def test_the_error_message_carries_the_timestamp_the_response_returned(db):
     assert "1787331796630" in str(exc.value), (
         "the server timestamp must appear in the error — it is what "
         "`reconcile --sent --timestamp` needs and it is otherwise lost")
+
+
+def test_send_approved_refuses_an_EMPTY_response_rather_than_indexing_it(db):
+    """A malformed reply must raise the NORMALISER's error, not an IndexError.
+
+    Kills the `bypass-normaliser` mutant: replacing the call with
+    `result if isinstance(result, list) else [result]` produces identical
+    entries for well-formed input, so it survives every happy-path test. It
+    diverges only here — and it diverges into `entries[0]` on an empty list.
+    """
+    draft = _pending(db)
+    db.approve_draft(draft["id"], approval_ref="cg-empty-response")
+    with pytest.raises(ValueError, match="EMPTY"):
+        db.send_approved(draft["id"], transmit=lambda a, **kw: [])
+    assert db.get_draft(draft["id"])["send_state"] == "sending"
+
+
+def test_send_approved_refuses_a_MULTI_ENTRY_response_instead_of_guessing(db):
+    """🔴 The dangerous half of the same mutant.
+
+    Bypassing the normaliser on a two-entry reply does NOT raise — it silently
+    takes `entries[0]`, stores that timestamp and marks the draft `sent`. The
+    stored timestamp may belong to the OTHER message, which breaks sync-echo
+    dedupe (🔧 #4) exactly the way a locally generated one would.
+    """
+    draft = _pending(db)
+    db.approve_draft(draft["id"], approval_ref="cg-multi-response")
+    with pytest.raises(ValueError, match="refusing to guess"):
+        db.send_approved(draft["id"], transmit=lambda a, **kw: [
+            {"timestamp": "1787331796630"}, {"timestamp": "1787331796999"}])
+    assert db.get_draft(draft["id"])["send_state"] == "sending", (
+        "a response we cannot interpret must leave the draft for manual "
+        "reconciliation, never be recorded as sent")

--- a/scripts/signal/tests/test_approval_gate.py
+++ b/scripts/signal/tests/test_approval_gate.py
@@ -1038,3 +1038,85 @@ def test_clawgate_card_truncates_a_huge_body():
                                            body="z" * 5000)
     assert len(payload["body"]) < 2000
     assert payload["body"].count("z") == clawgate.BODY_PREVIEW_MAX
+
+
+# --------------------------------------------------------------------------- #
+# Route 12 — the LIVE wire shape, driven through send_approved()
+#
+# 🔴 Every other `transmit=` fixture in this file returns a bare DICT, because
+# the fixture authors read the upstream TYPE (`ds.SendMessageResponse`, an
+# object) rather than the wire. The live server in json-rpc mode returns a
+# LIST — measured 2026-08-21:
+#
+#     POST /v2/send  ->  201  [{"timestamp":"1787331796630"}]
+#
+# That mismatch shipped a defect where a SUCCESSFUL send raised AttributeError
+# and stranded the draft in `sending`, inviting a duplicate resend. Verifying
+# the normaliser in isolation was NOT enough: an adversarial audit ran two
+# mutants that survived the whole suite because nothing drove `send_approved`
+# with a list. These tests close that seam.
+# --------------------------------------------------------------------------- #
+def test_send_approved_accepts_the_LIVE_list_shape(db):
+    """The end-to-end happy path with the shape the real server sends."""
+    draft = _pending(db)
+    db.approve_draft(draft["id"], approval_ref="cg-live-list")
+    sent = db.send_approved(
+        draft["id"], transmit=lambda a, **kw: [{"timestamp": str(SERVER_TS)}])
+    assert sent["send_state"] == "sent"
+    assert sent["message_timestamp"] == SERVER_TS, (
+        "the server timestamp must be stored from the list entry — a locally "
+        "generated one would not dedupe the sync echo (🔧 #4)")
+
+
+def test_a_LIST_response_carrying_errors_is_NOT_recorded_as_sent(db):
+    """🔴 The inverse of the bug this seam fixed, and the worse direction.
+
+    Upstream sets `Errors` for any non-SUCCESS recipient while still returning
+    201 (`client/client.go` -> `api/api.go`). If the errors check were skipped
+    on the list path, a FAILED send would be recorded as `sent` — silently, and
+    unrecoverably, because nothing would remain to reconcile.
+
+    A mutant that checked errors only on the dict path SURVIVED the entire
+    suite before this test existed.
+    """
+    draft = _pending(db)
+    db.approve_draft(draft["id"], approval_ref="cg-live-list-errors")
+    with pytest.raises(RuntimeError) as exc:
+        db.send_approved(draft["id"], transmit=lambda a, **kw: [
+            {"timestamp": str(SERVER_TS),
+             "errors": {"recipients": [{"message": "rate limited"}]}}])
+    assert "rate limited" in str(exc.value), (
+        "the per-recipient reason must survive — it is what an operator needs "
+        "in order to reconcile")
+    assert db.get_draft(draft["id"])["send_state"] == "sending", (
+        "a failed send must stay in `sending` for manual reconciliation, never "
+        "be recorded as sent")
+
+
+def test_a_singular_error_key_in_the_list_shape_also_blocks_the_send(db):
+    """The `error` (singular) branch had ZERO coverage — deleting it survived."""
+    draft = _pending(db)
+    db.approve_draft(draft["id"], approval_ref="cg-live-list-singular")
+    with pytest.raises(RuntimeError) as exc:
+        db.send_approved(draft["id"], transmit=lambda a, **kw: [
+            {"error": "Invalid identifier", "timestamp": str(SERVER_TS)}])
+    assert "Invalid identifier" in str(exc.value)
+    assert db.get_draft(draft["id"])["send_state"] == "sending"
+
+
+def test_the_error_message_carries_the_timestamp_the_response_returned(db):
+    """A partly-failed GROUP send DID go out, and the reply carried its ts.
+
+    Without it in the error, the operator has to hunt the timestamp in the
+    Signal thread before they can `reconcile --sent`. Draft 51 was exactly that
+    situation.
+    """
+    draft = _pending(db)
+    db.approve_draft(draft["id"], approval_ref="cg-live-list-ts-in-error")
+    with pytest.raises(RuntimeError) as exc:
+        db.send_approved(draft["id"], transmit=lambda a, **kw: [
+            {"timestamp": "1787331796630",
+             "errors": {"recipients": [{"message": "unregistered"}]}}])
+    assert "1787331796630" in str(exc.value), (
+        "the server timestamp must appear in the error — it is what "
+        "`reconcile --sent --timestamp` needs and it is otherwise lost")

--- a/scripts/signal/tests/test_pg_type_compat.py
+++ b/scripts/signal/tests/test_pg_type_compat.py
@@ -50,35 +50,88 @@ def _source() -> str:
     return MODULE.read_text(encoding="utf-8")
 
 
+def _draft_select_sql() -> str:
+    """The SELECT `_draft_or_raise()` actually issues, EXTRACTED FROM SOURCE.
+
+    🔴 An earlier version of this test executed a HAND-COPIED copy of the query
+    — and spelled it `signal_uuid::text`, the exact spelling its sibling test
+    forbids shipping. A guard that runs its own copy of the SQL cannot fail when
+    the real SQL regresses; it only ever tests the copy. Extract, never
+    transcribe.
+    """
+    src = _source()
+    # Anchor on fields UNIQUE to the draft SELECT. An earlier version anchored on
+    # `SELECT m.id, m.message_timestamp` and matched a DIFFERENT query first —
+    # so the "real Postgres" guard would have planned the wrong statement and
+    # stayed green while `get_draft` regressed.
+    m = re.search(r'"""\s*(SELECT m\.id, m\.message_timestamp[^"]*?m\.send_state,'
+                  r'[^"]*?dest_contact_id[^"]*?)"""', src, re.S)
+    assert m, ("could not locate the _draft_or_raise SELECT in the source — the "
+               "query moved or was reshaped, and this guard is now testing "
+               "nothing. Fix the extraction rather than deleting the test.")
+    return m.group(1)
+
+
+def test_the_extractor_finds_the_real_query():
+    """Positive control for the extraction itself.
+
+    Without this, a regex that silently matched nothing would make the Postgres
+    test below execute an empty string and pass.
+    """
+    sql = _draft_select_sql()
+    assert "signal.messages" in sql and "dest_contact_id" in sql, sql[:200]
+    assert "COALESCE" in sql, "the extracted SQL is not the draft SELECT"
+    # 🔴 It must be the DRAFT select, not a look-alike: `send_state IS NOT NULL`
+    # is what distinguishes a draft from a device-sync echo.
+    assert "send_state IS NOT NULL" in sql, (
+        "extracted a query that is not `get_draft`'s — anchor the extraction "
+        f"more tightly. Got: {sql[:200]!r}")
+
+
 @pytest.mark.skipif(not os.environ.get("SIGNAL_PG_DSN"),
                     reason="needs a real Postgres (SIGNAL_PG_DSN); SQLite cannot "
                            "reproduce Postgres static type checking")
 def test_draft_query_runs_on_real_postgres():
-    """The actual `_draft_or_raise` SQL must plan on a real server.
+    """The actual `_draft_or_raise` SQL — read from source — must plan on a real
+    server.
 
-    Red at base: raises `DatatypeMismatch: COALESCE types uuid and text cannot
-    be matched`. Green once `signal_uuid` is cast.
+    Red at base: `DatatypeMismatch: COALESCE types uuid and text cannot be
+    matched`. Green once `signal_uuid` is cast.
     """
     import psycopg2  # imported lazily: absent in the default hermetic env
 
-    sql = (
-        "SELECT m.id, "
-        "       CASE WHEN d.is_placeholder THEN d.phone_number "
-        "            ELSE COALESCE(d.signal_uuid::text, d.phone_number) "
-        "       END AS recipient "
-        "FROM signal.messages m "
-        "LEFT JOIN signal.contacts d ON d.id = m.dest_contact_id "
-        "WHERE m.id = %s AND m.is_outbound AND m.send_state IS NOT NULL"
-    )
     with psycopg2.connect(os.environ["SIGNAL_PG_DSN"]) as conn:
         with conn.cursor() as cur:
-            # A row need not exist; planning is what type-checks.
-            cur.execute(sql, (-1,))
+            # A row need not exist; PLANNING is what type-checks.
+            cur.execute(_draft_select_sql(), (-1,))
             cur.fetchall()
 
 
-_COALESCE_WITH_UUID = re.compile(r"COALESCE\s*\((?:[^()]|\([^()]*\))*signal_uuid"
-                                 r"(?:[^()]|\([^()]*\))*\)", re.I)
+# Any SQL construct that can put `signal_uuid` (uuid) in a common-type position
+# with a text column. COALESCE was the shipped bug; an audit confirmed BOTH of
+# these refactors also raise DatatypeMismatch on the live server and walked a
+# COALESCE-only guard:
+#     CASE WHEN d.signal_uuid IS NOT NULL THEN d.signal_uuid ELSE d.phone_number
+#     COALESCE(NULLIF(d.signal_uuid, NULL), d.phone_number)
+# So match the HAZARD (a type-unifying construct naming signal_uuid), not one
+# spelling of it.
+#
+# 🔴 `CASE` must be anchored as `CASE WHEN` and BOUNDED. An earlier version used
+# a bare `\bCASE\b` with re.S, which matched the English word "case." in a
+# docstring and ran to a distant `END`, swallowing 17 KB of source into one
+# "offending expression". A guard that over-matches is as useless as one that
+# under-matches — it just fails noisily instead of silently.
+_TYPE_UNIFYING = re.compile(
+    r"(?:COALESCE|NULLIF|GREATEST|LEAST)\s*\((?:[^()]|\([^()]*\))*signal_uuid"
+    r"(?:[^()]|\([^()]*\))*\)"
+    r"|CASE\s+WHEN(?:(?!\bEND\b)[\s\S]){0,800}?\bsignal_uuid\b"
+    r"(?:(?!\bEND\b)[\s\S]){0,800}?\bEND\b",
+    re.I)
+
+# SQL `--` comments in this module deliberately DISCUSS `signal_uuid` (they
+# explain this very hazard). Strip them before matching, or the explanation
+# trips the guard that the explanation is about.
+_SQL_COMMENT = re.compile(r"--[^\n]*")
 
 
 def _uncast_coalesces(sql: str) -> list[str]:
@@ -91,11 +144,15 @@ def _uncast_coalesces(sql: str) -> list[str]:
     fail on a legitimate refactor to the other.
     """
     out = []
-    for m in _COALESCE_WITH_UUID.finditer(sql):
+    sql = _SQL_COMMENT.sub("", sql)
+    for m in _TYPE_UNIFYING.finditer(sql):
         expr = m.group(0)
-        stripped = re.sub(r"CAST\s*\(\s*[\w.]*signal_uuid\s+AS\s+\w+\s*\)", "", expr, flags=re.I)
+        stripped = re.sub(r"CAST\s*\(\s*[\w.]*signal_uuid\s+AS\s+[\w()\d ]+\)", "",
+                          expr, flags=re.I)
+        # `::` is tolerated by the matcher (a legitimate refactor) even though a
+        # sibling test forbids SHIPPING it — allow a space, which Postgres does.
         stripped = re.sub(r"[\w.]*signal_uuid\s*::\s*\w+", "", stripped, flags=re.I)
-        if re.search(r"signal_uuid", stripped, re.I):
+        if re.search(r"\bsignal_uuid\b", stripped, re.I):
             out.append(expr)
     return out
 
@@ -119,10 +176,13 @@ def test_the_shipped_sql_uses_the_ANSI_cast_not_the_pg_only_one():
     1 failed / 598 passed to 54 failed / 547 passed. Both gates must stay able
     to run the same SQL.
     """
-    src = _source()
-    assert "signal_uuid::" not in src, (
+    # 🔴 Allow whitespace before `::` — Postgres accepts `signal_uuid ::text`,
+    # so a bare substring check for "signal_uuid::" is walked by one space.
+    offenders = re.findall(r"signal_uuid\s*::", _source(), re.I)
+    assert not offenders, (
         "found a Postgres-only `::` cast on signal_uuid. SQLite cannot parse it, "
-        "so the hermetic suite goes red. Use CAST(signal_uuid AS text).")
+        "so the hermetic suite goes red (measured: 54 failed / 561 passed). "
+        "Use CAST(signal_uuid AS text).")
 
 
 def test_the_backstop_can_actually_fire():
@@ -140,3 +200,23 @@ def test_the_backstop_can_actually_fire():
         "nothing and would pass against any source at all")
     assert _uncast_coalesces(good_ansi) == [], "false positive on the ANSI cast"
     assert _uncast_coalesces(good_pg) == [], "false positive on the pg cast"
+    assert _uncast_coalesces("COALESCE(CAST(d.signal_uuid AS varchar(64)), d.x)") == [], \
+        "false positive on a parameterised cast type"
+
+
+@pytest.mark.parametrize("walk", [
+    # Both confirmed by an audit to raise DatatypeMismatch on the LIVE server,
+    # and both walked a COALESCE-only guard.
+    "CASE WHEN d.signal_uuid IS NOT NULL THEN d.signal_uuid ELSE d.phone_number END",
+    "COALESCE(NULLIF(d.signal_uuid, NULL), d.phone_number)",
+])
+def test_the_backstop_catches_the_refactors_that_walked_it(walk):
+    """🔴 Regression guard for finding 5 of the #657 audit.
+
+    A guard that covers one SPELLING of a hazard is walkable by rewriting the
+    expression. These two are not hypothetical: both were executed against the
+    live database and both failed with DatatypeMismatch.
+    """
+    assert _uncast_coalesces(walk), (
+        f"the backstop does not flag {walk!r}, which raises DatatypeMismatch on "
+        f"a real server — it is guarding a spelling, not the hazard")

--- a/scripts/signal/tests/test_pg_type_compat.py
+++ b/scripts/signal/tests/test_pg_type_compat.py
@@ -1,0 +1,142 @@
+"""Postgres TYPE compatibility for hand-written SQL in `_signal_db.py`.
+
+🔴 WHY THIS FILE EXISTS, AND WHAT IT CANNOT DO.
+
+The rest of this suite runs on `fakepg.SqliteConn` — "a REAL relational engine
+standing in for Postgres". It faithfully reproduces the properties those tests
+are about. It does NOT reproduce Postgres's *static type checking*, because
+SQLite is dynamically typed.
+
+That gap shipped a real outage. `_draft_or_raise()` carried:
+
+    CASE WHEN d.is_placeholder THEN d.phone_number
+         ELSE COALESCE(d.signal_uuid, d.phone_number)
+
+`contacts.signal_uuid` is `uuid`; `contacts.phone_number` is `text`. Postgres
+type-checks the WHOLE `CASE` regardless of which branch would execute, so this
+raised `DatatypeMismatch` for EVERY draft — and `approve()`, `send()` and
+`reconcile()` all reach `_draft_or_raise()`. The D3 send path had therefore
+never worked against production Postgres, while 387 hermetic tests stayed green
+because SQLite accepts the uncast form. Measured 2026-08-21: the outbound
+population was `pending: 1` and nothing else — nothing had ever been sent.
+
+Two guards, and they are deliberately different in kind:
+
+1. `test_draft_query_runs_on_real_postgres` — the REAL one. Executes the actual
+   SQL against a real server. Skips without `SIGNAL_PG_DSN`, so it is honest
+   about being unavailable rather than passing vacuously.
+
+2. `test_signal_uuid_is_never_coalesced_without_a_cast` — a SPELLED backstop,
+   and labelled as such. It reads source text, so it is walkable by rewriting
+   the expression in another shape (a `||`, a nested CASE, a different column
+   pair). It exists because guard 1 cannot run in the default gate, NOT because
+   it is sufficient. Do not mistake it for type checking.
+
+The durable fix is a Postgres-backed tier for the hand-written SQL. Until that
+exists, this file is the seam and its limits are stated rather than implied.
+"""
+from __future__ import annotations
+
+import os
+import re
+import pathlib
+
+import pytest
+
+MODULE = pathlib.Path(__file__).resolve().parents[1] / "_signal_db.py"
+
+
+def _source() -> str:
+    return MODULE.read_text(encoding="utf-8")
+
+
+@pytest.mark.skipif(not os.environ.get("SIGNAL_PG_DSN"),
+                    reason="needs a real Postgres (SIGNAL_PG_DSN); SQLite cannot "
+                           "reproduce Postgres static type checking")
+def test_draft_query_runs_on_real_postgres():
+    """The actual `_draft_or_raise` SQL must plan on a real server.
+
+    Red at base: raises `DatatypeMismatch: COALESCE types uuid and text cannot
+    be matched`. Green once `signal_uuid` is cast.
+    """
+    import psycopg2  # imported lazily: absent in the default hermetic env
+
+    sql = (
+        "SELECT m.id, "
+        "       CASE WHEN d.is_placeholder THEN d.phone_number "
+        "            ELSE COALESCE(d.signal_uuid::text, d.phone_number) "
+        "       END AS recipient "
+        "FROM signal.messages m "
+        "LEFT JOIN signal.contacts d ON d.id = m.dest_contact_id "
+        "WHERE m.id = %s AND m.is_outbound AND m.send_state IS NOT NULL"
+    )
+    with psycopg2.connect(os.environ["SIGNAL_PG_DSN"]) as conn:
+        with conn.cursor() as cur:
+            # A row need not exist; planning is what type-checks.
+            cur.execute(sql, (-1,))
+            cur.fetchall()
+
+
+_COALESCE_WITH_UUID = re.compile(r"COALESCE\s*\((?:[^()]|\([^()]*\))*signal_uuid"
+                                 r"(?:[^()]|\([^()]*\))*\)", re.I)
+
+
+def _uncast_coalesces(sql: str) -> list[str]:
+    """COALESCE expressions naming `signal_uuid` with no cast around it.
+
+    Accepts BOTH spellings deliberately: ANSI `CAST(x AS text)` (which SQLite
+    and Postgres both parse) and Postgres-only `x::text`. The shipped SQL must
+    use the ANSI form — `::` is unparseable by the SQLite substrate and turns
+    53 hermetic tests red — but a guard that accepted only one spelling would
+    fail on a legitimate refactor to the other.
+    """
+    out = []
+    for m in _COALESCE_WITH_UUID.finditer(sql):
+        expr = m.group(0)
+        stripped = re.sub(r"CAST\s*\(\s*[\w.]*signal_uuid\s+AS\s+\w+\s*\)", "", expr, flags=re.I)
+        stripped = re.sub(r"[\w.]*signal_uuid\s*::\s*\w+", "", stripped, flags=re.I)
+        if re.search(r"signal_uuid", stripped, re.I):
+            out.append(expr)
+    return out
+
+
+def test_signal_uuid_is_never_coalesced_without_a_cast():
+    """SPELLED backstop — see the module docstring for why it is not enough."""
+    offenders = _uncast_coalesces(_source())
+    assert not offenders, (
+        "COALESCE mixes the `uuid` column signal_uuid with a text column and "
+        "Postgres type-checks the whole expression regardless of branch, so this "
+        "raises DatatypeMismatch for EVERY row. Cast it — use ANSI "
+        "`CAST(signal_uuid AS text)`, not `::text`, which SQLite cannot parse. "
+        f"Offending: {offenders}"
+    )
+
+
+def test_the_shipped_sql_uses_the_ANSI_cast_not_the_pg_only_one():
+    """`::text` type-checks on Postgres and is UNPARSEABLE by the SQLite substrate.
+
+    Measured 2026-08-21: spelling it `::text` took the signal suite from
+    1 failed / 598 passed to 54 failed / 547 passed. Both gates must stay able
+    to run the same SQL.
+    """
+    src = _source()
+    assert "signal_uuid::" not in src, (
+        "found a Postgres-only `::` cast on signal_uuid. SQLite cannot parse it, "
+        "so the hermetic suite goes red. Use CAST(signal_uuid AS text).")
+
+
+def test_the_backstop_can_actually_fire():
+    """Positive control — a guard nobody has watched go red may match nothing.
+
+    Feeds the known-bad expression AND both good spellings, requiring the guard
+    to flag exactly the bad one.
+    """
+    bad = "COALESCE(d.signal_uuid, d.phone_number)"
+    good_ansi = "COALESCE(CAST(d.signal_uuid AS text), d.phone_number)"
+    good_pg = "COALESCE(d.signal_uuid::text, d.phone_number)"
+
+    assert _uncast_coalesces(bad) == [bad], (
+        "the backstop failed to flag the known-bad expression — it is matching "
+        "nothing and would pass against any source at all")
+    assert _uncast_coalesces(good_ansi) == [], "false positive on the ANSI cast"
+    assert _uncast_coalesces(good_pg) == [], "false positive on the pg cast"

--- a/scripts/signal/tests/test_send_response_shape.py
+++ b/scripts/signal/tests/test_send_response_shape.py
@@ -28,10 +28,6 @@ sys.path.insert(0, str(HERE.parent))
 import _signal_db as db  # noqa: E402
 
 
-class _Auth:
-    """Stand-in capability; `send_approved` is not under test here."""
-
-
 def test_the_live_list_shape_is_accepted():
     """The exact bytes the live server returned. Red at base: AttributeError."""
     entries = db._normalize_send_response([{"timestamp": "1787331796630"}])

--- a/scripts/signal/tests/test_send_response_shape.py
+++ b/scripts/signal/tests/test_send_response_shape.py
@@ -1,0 +1,113 @@
+"""`/v2/send` response-shape handling — the LIVE server returns a LIST.
+
+🔴 MEASURED 2026-08-21 against the running signal-cli-rest-api (json-rpc mode)::
+
+    POST /v2/send  ->  201  [{"timestamp":"1787331796630"}]
+
+`send_approved()` previously did `(result or {}).get("errors")`, which raises
+`AttributeError: 'list' object has no attribute 'get'` — **after the POST has
+already succeeded**. That is the worst available failure shape: the message IS
+delivered, the caller sees an exception, the draft is stranded in `sending`, and
+the natural human response (retry) would send it twice.
+
+Found the only way it could be: by being the first person to push a real draft
+through the D3 send path. Every prior test fed a dict, because the fixture
+authors read the upstream type (`ds.SendMessageResponse`, an object) rather than
+the wire.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+HERE = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))
+
+import _signal_db as db  # noqa: E402
+
+
+class _Auth:
+    """Stand-in capability; `send_approved` is not under test here."""
+
+
+def test_the_live_list_shape_is_accepted():
+    """The exact bytes the live server returned. Red at base: AttributeError."""
+    entries = db._normalize_send_response([{"timestamp": "1787331796630"}])
+    assert entries == [{"timestamp": "1787331796630"}]
+    assert db._server_timestamp(entries[0]) == 1787331796630
+
+
+def test_a_bare_dict_still_works():
+    """Back-compat: upstream documents an object, other modes return one."""
+    entries = db._normalize_send_response({"timestamp": "1787331796630"})
+    assert db._server_timestamp(entries[0]) == 1787331796630
+
+
+def test_per_recipient_errors_are_reachable_in_the_list_shape():
+    """The errors branch must survive normalisation, not just the happy path."""
+    entries = db._normalize_send_response([{"errors": ["boom"], "timestamp": "1"}])
+    errors = [entry["errors"] for entry in entries if entry.get("errors")]
+    assert errors == [["boom"]]
+
+
+def test_an_errors_OBJECT_keeps_its_reason_rather_than_collapsing_to_keys():
+    """🔴 Regression guard for a bug this fix introduced and the suite caught.
+
+    Upstream also shapes `errors` as an OBJECT. Flattening it with
+    `for e in entry["errors"]` yields the KEYS (`['recipients']`) and discards
+    the message — the single thing an operator needs in order to reconcile.
+    Collect the payload whole.
+    """
+    payload = {"recipients": [{"message": "rate limited"}]}
+    entries = db._normalize_send_response([{"errors": payload, "timestamp": ""}])
+    errors = [entry["errors"] for entry in entries if entry.get("errors")]
+    assert "rate limited" in repr(errors), (
+        "the errors payload was flattened and lost its reason — an operator "
+        f"would see only container keys: {errors!r}")
+
+
+def test_a_singular_error_key_is_also_collected():
+    entries = db._normalize_send_response([{"error": "Invalid identifier"}])
+    errors = [entry["error"] for entry in entries if entry.get("error")]
+    assert errors == ["Invalid identifier"]
+
+
+@pytest.mark.parametrize("bad", ["a string", 7, None, True])
+def test_an_unrecognised_shape_raises_rather_than_guessing(bad):
+    with pytest.raises(ValueError, match="unrecognised|EMPTY"):
+        db._normalize_send_response(bad)
+
+
+def test_an_empty_list_raises():
+    """No entry means no timestamp, which means the sync echo cannot dedupe."""
+    with pytest.raises(ValueError, match="EMPTY"):
+        db._normalize_send_response([])
+
+
+def test_more_than_one_entry_raises_instead_of_picking_one():
+    """We always send to exactly one recipient.
+
+    A longer list means the wire contract changed; choosing an entry would be a
+    guess about which message the stored timestamp belongs to — the exact thing
+    that breaks dedupe and duplicates messages.
+    """
+    with pytest.raises(ValueError, match="refusing to guess"):
+        db._normalize_send_response([{"timestamp": "1"}, {"timestamp": "2"}])
+
+
+def test_non_object_entries_raise():
+    with pytest.raises(ValueError, match="non-object"):
+        db._normalize_send_response([["nested"]])
+
+
+def test_the_old_dict_only_expression_would_have_failed_on_the_live_shape():
+    """Positive control for the whole file.
+
+    Pins that the live shape genuinely breaks the pre-fix expression — so these
+    tests are known to be exercising a real defect, not a hypothetical one.
+    """
+    live = [{"timestamp": "1787331796630"}]
+    with pytest.raises(AttributeError):
+        (live or {}).get("errors")  # type: ignore[union-attr]


### PR DESCRIPTION
## The bug

`_draft_or_raise()` built `COALESCE(d.signal_uuid, d.phone_number)`. `contacts.signal_uuid` is `uuid`, `phone_number` is `text`, and **Postgres type-checks the whole `CASE` regardless of which branch would execute** — so it raises `DatatypeMismatch` for *every* draft. `approve()`, `send()` and `reconcile()` all reach `_draft_or_raise()`.

```
ERROR:  COALESCE types uuid and text cannot be matched
LINE 3:   ELSE COALESCE(d.signal_uuid, d.phone_number)
```

**Control:** the outbound population is `pending: 1` and nothing else — no draft has ever reached `approved`/`sending`/`sent`. Found by trying to approve the first real one.

## Why 599 green tests missed it

The hermetic substrate is **SQLite** — its own docstring calls it *"a REAL relational engine standing in for Postgres."* SQLite is dynamically typed and accepts the uncast form. The suite is **structurally blind** to Postgres static type errors in hand-written SQL.

## 🔴 The first fix was wrong, and the suite caught it

`signal_uuid::text` type-checks on Postgres but is **unparseable by SQLite**: it took the signal suite from `1 failed / 598 passed` to `54 failed / 547 passed`. Shipped the ANSI `CAST(signal_uuid AS text)` instead, which both engines accept.

That is the shape worth remembering — the cast has to satisfy *both* gates, or fixing one blinds the other.

## Evidence

| | |
|---|---|
| pre-fix SQL, live Postgres | `ERROR: COALESCE types uuid and text cannot be matched` |
| post-fix SQL, live Postgres | `51 \| pending \| group.elgzaTRRT2Nk…` (1 row) |
| backstop at `origin/main` | **red**, with its own message naming `COALESCE(d.signal_uuid, d.phone_number)` |
| signal suite at HEAD | `1 failed / 601 passed / 1 skipped` |
| signal suite at base | `1 failed / 598 passed` — same pre-existing failure |

## The two new guards are deliberately different in kind

- `test_draft_query_runs_on_real_postgres` — the **real** one. Executes the SQL against a live server; **skips without `SIGNAL_PG_DSN`** so it is honest about being unavailable rather than passing vacuously.
- `test_signal_uuid_is_never_coalesced_without_a_cast` — a **SPELLED** backstop, labelled as such in the source. It reads source text, so it is walkable by rewriting the expression in another shape or picking a different column pair. It exists because the real guard cannot run in the default gate, **not** because it is sufficient. It carries a positive control asserting it flags the known-bad expression and neither good spelling.

## NOT verified

- `nix build .#checks.x86_64-linux.pytests` was **not** run — counts are from an ad-hoc `nix-shell`. That tier decides which tests execute.
- The real-Postgres test has never run in CI; it was exercised by hand via `psql` against the live database, which is where the evidence above comes from.
- No other hand-written SQL in this module was audited for the same class. This fixes the one expression that blocks the send path; **a Postgres-backed tier is the durable fix** and is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)