### PR TITLE
feat(browser-bridge): `screenshot <path>` is the one non-JSON stdout — `--json` opts in; plus BB_* targeting defaults

### DIFF
--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -14,7 +14,7 @@ $BB --instance <key> --tab <id> text   # cheap read of a specific tab
 
 🔴 **Run `whoami` first on every fresh browser task.** Both hosts are hostname
 `nixos` and this bridge could be either, with several Brave profiles — confirm the
-host and pick the right `--instance` before acting. Architecture / security model:
+host and pick the right `--instance` first. Architecture / security model:
 `~/workspace/devrc/scripts/browser-bridge/README.md`.
 
 🔴 **Every `reference/<file>.md` named below lives at
@@ -47,26 +47,29 @@ ASSERT a non-zero content count in any `js` measurement. Result handling
 
 Global flags, usable before any op: `--instance <key>` (which profile),
 `--tab <id>` (explicit tab), `--frame <numericId|urlSubstring>` (inside an iframe).
+Env defaults `$BB_INSTANCE`/`$BB_TAB`/`$BB_FRAME` (flag wins; zsh does NOT
+split an unquoted `$F`). ⚠ an export outlives the call — env-routed ops say so
+once, on stderr.
 Result payloads land under `.result.data`.
 
 | command | does |
 |---|---|
-| `whoami` | **read-only identity** (global; no `--instance`/`--tab`) — host label (`laptop`/`workbench`), connected instances (active-tab **domain** only), bridge diagnostics, `extension_version_current` |
-| `health` / `instances` | connected instances + count (JSON: key, label, instanceId, tab url/title). per-instance `extension_stale` on `health` + `whoami`, NOT `instances` — ⚠ `null` is "undecidable", NOT "fine"; tri-state → `reference/errors.md` |
+| `whoami` | **read-only identity** (global; no `--instance`) — host label (`laptop`/`workbench`), connected instances (active-tab **domain** only), bridge diagnostics, `extension_version_current` |
+| `health` / `instances` | connected instances + count (JSON: key, label, instanceId, tab url/title). `extension_stale` on `health`+`whoami`, NOT `instances` — ⚠ `null` = "undecidable", NOT "fine" → `reference/errors.md` |
 | `ping` | **which extension CODE is loaded?** → `{pong,extensionVersion,buildMarker,id,ops}`; read `buildMarker` — version+id describe the DIRECTORY. Staleness is PER PROFILE |
 | `context` | **page metadata, no DOM read** — url/domain/path/query/title/tabId, tab-scoped. Cheapest read; ⚠ NOT a render check → `reference/read-envelopes.md` |
 | `open [url] [--wake[=MS]]` | open a NEW tab this session owns (default `about:blank`, **created in the BACKGROUND/hidden**), returns `tabId`. 🔴 A re-`open` does NOT navigate — it DISCARDS your url → `reference/tabs-instances.md` |
 | `close` / `release` | close this session's owned tab / drop ownership without closing it |
 | `tabs` | list open tabs (`.data.ownedTabId` flags yours) |
 | `nav <url> [--wake[=MS]]` | navigate the owned/active tab; it lands hidden, so `--wake` un-throttles in the SAME call |
-| `text [selector] [--max-bytes N] [--annotated]` | **cheap read** — visible `innerText` (optional CSS selector), byte-capped by default. ~98% smaller than `html` — **prefer it**. `--annotated` swaps flat text for per-element extraction — use it when you need a SELECTOR to click/type; works with `--frame`. Byte cap, envelope fields, `--annotated` schema → `reference/read-envelopes.md` |
-| `html [--max-bytes N]` | `outerHTML`, same byte cap and same envelope. One uncapped `html` on a heavy SPA is ~100K tokens — the cap is ON by default |
-| `js '<expr>'` (alias: `eval`) | run JS in the tab, return its value; same op on the wire either way. **Prefer the `js` spelling in a worktree-isolated agent** — Claude Code's isolation guard refuses any command containing the literal token `eval` |
-| `screenshot [path] [--fullpage] [--data-url]` | CDP capture — **works on a BACKGROUND/occluded tab**. **Always writes a `.png`** (to `path`, else a 0600 temp) and prints `{ok,path,bytes,url,via}`; the base64 is **NEVER** printed — **`Read` the `.png`**. `--data-url` is the escape hatch |
+| `text [selector] [--max-bytes N] [--annotated]` | **cheap read** — visible `innerText` (optional CSS selector), byte-capped by default. ~98% smaller than `html` — **prefer it**. `--annotated` gives per-element extraction — use it when you need a SELECTOR to click/type; works with `--frame`. Byte cap, envelope fields, `--annotated` schema → `reference/read-envelopes.md` |
+| `html [--max-bytes N]` | `outerHTML`, same byte cap and envelope. One uncapped `html` on a heavy SPA is ~100K tokens — the cap is ON by default |
+| `js '<expr>'` (alias: `eval`) | run JS in the tab, return its value; same wire op either way. **Prefer the `js` spelling in a worktree-isolated agent** — Claude Code's isolation guard refuses any command with the literal token `eval` |
+| `screenshot [path] [--fullpage] [--data-url] [--json]` | CDP capture — **works on a BACKGROUND/occluded tab**. **Always writes a `.png`** (to `path`, else a 0600 temp); base64 **NEVER** printed — **`Read` it**. ⚠ with `path`, stdout is the bare path, NOT JSON — add `--json` (refused with `--data-url`). `--data-url` = escape hatch |
 | `frames` | list the tab's frames (`frameId`/`url`/`parentFrameId`) **incl. cross-origin OOPIFs** — pick a numeric `frameId` for `--frame` |
 | `click <selector>` · `type <text> [--selector S]` · `key <Enter\|Tab\|Escape\|Backspace\|Delete\|Arrow*\|Home\|End\|Page*> [--selector S]` | the input ops — click the element's centre, type text, send one bounded keypress. All three: **TRUSTED** CDP on the top frame, **SYNTHETIC** inside `--frame` |
 | `upload <selector> <path>` | fill an `<input type=file>` via CDP — Chrome reads the file BY PATH, **no bytes cross the bridge**. AUDIT-LOGGED, **operator-only** (agent → `op_not_allowed:upload`) |
-| `wake [--wait MS]`, or `text\|html\|js\|nav\|open --wake[=MS]` | **UN-THROTTLE a hidden/background tab with NO focus movement** — the fix for an empty or `hidden` read. **Wake once per PAGE, not per read.** `--wake` folds un-throttle+read into one call; refused with `--frame`. Settle/cap, the once-per-page rule, ISOLATED-vs-MAIN world → `reference/spa-wake.md` |
+| `wake [--wait MS]`, or `text\|html\|js\|nav\|open --wake[=MS]` | **UN-THROTTLE a hidden/background tab with NO focus movement** — the fix for an empty or `hidden` read. **Wake once per PAGE, not per read.** `--wake` folds un-throttle+read into one call; refused with `--frame`. Settle/cap, once-per-page, ISOLATED-vs-MAIN world → `reference/spa-wake.md` |
 | `activate` | **⚠⚠ TAKES THE OPERATOR'S SCREEN — LAST RESORT.** The i3 raise is OPT-IN: `--focus` (auto-on on a TTY) → raise, else `withheld`; `skipped` where there is no i3. **NOT** the hidden-tab fix — that is `wake`, see `reference/spa-wake.md` |
 | `emulate <preset>\|--reset` | **device emulation** (mobile testing) on a tab you `open`ed; sticky, owned-tab-only. Presets, `--reset`, `--recreate` → `reference/emulation.md` |
 | `agent "<goal>"` | the autonomous browser-agent — see **FIRST DECISION** above, then `reference/agent.md` |
@@ -87,27 +90,22 @@ Result payloads land under `.result.data`.
    **A reload RE-throttles: re-`wake` or clicks go silently inert.**
    → `reference/spa-wake.md`
 4. **A JS `.click()` does not open a React/Mantine popover — and the read then
-   reports a confident ABSENCE.** Use the trusted **`click`** op; click **ONCE** —
-   it is a TOGGLE, so a stale earlier click makes the next read lie — and read
-   `aria-expanded` to prove it opened. Not selector-reachable? **`screenshot`** it.
-   → `reference/css-hit-test.md`
+   reports a confident ABSENCE.** Use the trusted **`click`** op, **ONCE** (it is a
+   TOGGLE, so a stale earlier click makes the next read lie); prove it with
+   `aria-expanded`. → `reference/css-hit-test.md`
 
 ## When things look broken — triage
 
-1. **A call that WORKED now fails, errors, or returns nothing** → re-run `browser
-   health` BEFORE debugging the page or the CLI; the extension drops mid-session
-   (`extension_connected:false`) with no user action and no error. Fix: ↻ **in the
-   profile you are driving** (`brave://extensions` is per-profile). A STALE BUILD is
-   a DIFFERENT failure — a Brave restart does NOT clear it; that needs per-profile
-   Remove + Load unpacked. → `reference/errors.md`
-2. **A read is empty / half-built / `data.hidden:true`** → the tab is throttled.
-   `browser wake`, then re-read. → `reference/spa-wake.md`
-3. **`null` from `js`/`eval`** → trap 1, then trap 2. Fall back to `text`/`html`
-   before concluding the bridge is down. **`unknown_op`** on an op the CLI knows →
-   stale extension, see 1. Any other error string → `reference/errors.md`.
+1. **A call that WORKED now fails or returns nothing** → `browser health` FIRST,
+   before debugging the page or the CLI: the extension drops mid-session with no
+   error. Fix: ↻ **in the profile you are driving**. A STALE BUILD is a DIFFERENT
+   failure — Remove + Load unpacked, not a restart. → `reference/errors.md`
+2. **Empty / half-built / `data.hidden:true` read** → throttled: `wake`, re-read.
+3. **`null` from `js`/`eval`** → traps 1 then 2; fall back to `text`/`html` before
+   concluding the bridge is down. **`unknown_op`** → stale extension (1). Any other
+   error string → `reference/errors.md`.
 4. **Never diagnose a site OUTAGE from a browser read** — "broken for real users?"
    needs server-side evidence (RUM, metrics, pod health, an anonymous `curl`).
-   → `reference/spa-wake.md`
 
 ## This is the user's LIVE session
 

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -185,13 +185,15 @@
 #                               un-throttles the (background → throttled) tab in
 #                               the SAME invocation, so the next read is not a
 #                               shell — it replaces the `nav` then `wake` pair.
-#   browser screenshot [path] [--fullpage] [--data-url]
+#   browser screenshot [path] [--fullpage] [--data-url] [--json]
 #                             — screenshot the owned/active tab via CDP
 #                               (Page.captureScreenshot) — WORKS on a background/
 #                               occluded tab and on each profile's own tab; a
 #                               foreground tab uses the cheap captureVisibleTab fast
 #                               path. --fullpage grabs the whole scrollable document.
-#                               Writes a .png: to <path> if given (prints the path),
+#                               Writes a .png: to <path> if given (prints the path
+#                               plus a `#` Read hint — the ONE non-JSON stdout in
+#                               this CLI; pass --json for the envelope instead),
 #                               else to a MODE-0600 temp file (honours TMPDIR) and
 #                               prints compact JSON {path,bytes,url,via}. The base64
 #                               data URL is NEVER printed — Read the .png instead.
@@ -242,6 +244,21 @@
 #
 # Global flags (before the subcommand): --instance <key>, --tab <id>,
 #   --frame <frameId|url-substring> (route a read/click INTO a cross-origin frame).
+#
+#   ENV DEFAULTS: BB_INSTANCE / BB_TAB / BB_FRAME seed those three, so a caller
+#   driving one profile+tab for a whole run sets them ONCE instead of repeating
+#   the flags on every call. An explicit flag always wins (and `--instance ''`
+#   deliberately clears an inherited BB_INSTANCE).
+#     export BB_INSTANCE=work BB_TAB=1234
+#     browser text ; browser click '#go'          # both routed, no flags
+#   🔴 Prefer these to hoisting the flags into a shell variable. Under zsh an
+#   unquoted `$F` is NOT word-split, so `F="--instance work --tab 12"; browser $F
+#   text` passes ONE argument — the whole string — and the error names a
+#   subcommand you never typed. An env var cannot be split wrong.
+#   🔴 An exported BB_* OUTLIVES the command that set it and is inherited by every
+#   descendant, so a later destructive op can be routed with nothing in its argv
+#   saying so. Any op whose target came from the ENVIRONMENT therefore prints ONE
+#   line on stderr naming the variable; `BB_NO_ROUTE_NOTE=1` silences it.
 # Frame enumeration + --frame reads/input use chrome.webNavigation + chrome.scripting,
 # which reach CROSS-ORIGIN out-of-process iframes (OOPIFs) that CDP getFrameTree could
 # NOT see. `screenshot` still uses chrome.debugger (CDP), attaching ONLY to the owned/
@@ -250,6 +267,12 @@
 #
 # Output is JSON on stdout (pretty-printed if `jq` is present). Exit non-zero on
 # transport/HTTP error so a caller can branch.
+#
+# STDOUT IS JSON, STDERR IS FOR HUMANS. Every advisory — the hidden-tab warning,
+# a disconnected instance, routing help — goes to STDERR, so
+# `json.loads(<stdout>)` is safe. The ONE exception is `screenshot <path>`, which
+# prints the bare path plus a `#` Read hint for back-compat: pass `--json` there
+# to get the same envelope the no-path form prints.
 #
 # EXIT CODES
 #   0  success
@@ -267,9 +290,43 @@ HOST="${BROWSER_BRIDGE_HOST:-127.0.0.1}"
 PORT="${BROWSER_BRIDGE_PORT:-8788}"
 TOKEN_FILE="${BROWSER_BRIDGE_TOKEN_FILE:-$HOME/.config/browser-bridge/token}"
 BASE="http://${HOST}:${PORT}"
-INSTANCE=""   # routing key set via --instance <key> (empty → single-instance)
-TAB=""        # explicit tab id set via --tab <id> (overrides owned/active routing)
-FRAME=""      # --frame <frameId|url-substring>: route a read/click INTO that frame (CDP)
+# Targeting: --instance / --tab / --frame, each with an ENVIRONMENT DEFAULT.
+#
+# WHY THE ENV DEFAULTS EXIST (measured, 2026-08-20). Every op has to carry the
+# same three flags, so callers hoisted them into a shell variable and splatted it:
+#
+#     F="--instance work --tab 1234"; browser $F text        # ← WRONG under zsh
+#
+# zsh does NOT field-split an unquoted `$var` (bash does), so `$F` arrives as ONE
+# argument — the literal string `--instance work --tab 1234` — and the CLI reports
+# an unknown-subcommand error naming something the caller never typed. The failure
+# is silent in the sense that matters: nothing about it points at word splitting.
+# An env var cannot be word-split wrong because it is never split at all.
+#
+# PRECEDENCE: an explicit flag always wins, because the flag loop below ASSIGNS
+# over whatever the environment seeded here. `--instance ""` therefore genuinely
+# clears an inherited BB_INSTANCE (it is an explicit empty, not an absent flag).
+INSTANCE="${BB_INSTANCE:-}"   # routing key; --instance <key> (empty → single-instance)
+TAB="${BB_TAB:-}"             # explicit tab id; --tab <id> (overrides owned/active routing)
+FRAME="${BB_FRAME:-}"         # --frame <frameId|url-substring>: route INTO that frame (CDP)
+# Which SOURCE supplied TAB, so the numeric-validation error in cmd_op can name it.
+# A malformed `BB_TAB` reported as "--tab must be a numeric tab id" sends the reader
+# hunting a flag that appears nowhere in their command line.
+#
+# 🔴 AN ENV DEFAULT OUTLIVES THE COMMAND THAT SET IT, so each of the three also
+# records WHERE its value came from. Precedence is the easy half and it is
+# correct above; LIFETIME is the risk. `export BB_FRAME=evil.example` is inherited
+# by every descendant for the rest of that shell's life, so a later
+# `browser type '<secret>' --selector '#x'` is routed into that frame — or at
+# another profile's tab — with NOTHING in its command line saying so, and the
+# envelope it prints looks exactly like the un-routed one. Silence there makes an
+# inherited destructive route indistinguishable from a deliberate one, so cmd_op
+# says so ONCE on stderr (stdout stays pure JSON). The flag branches reset these
+# to the flag name, which is what keeps the note honest when a flag has won.
+INSTANCE_SRC="--instance"; [ -n "${BB_INSTANCE:-}" ] && INSTANCE_SRC="\$BB_INSTANCE"
+TAB_SRC="--tab";           [ -n "${BB_TAB:-}" ]      && TAB_SRC="\$BB_TAB"
+FRAME_SRC="--frame";       [ -n "${BB_FRAME:-}" ]    && FRAME_SRC="\$BB_FRAME"
+ENV_ROUTE_NOTED=0
 
 die() { echo "browser: $*" >&2; exit 1; }
 
@@ -419,12 +476,12 @@ derive_session_id() {
 # subcommand. --print-session-id short-circuits (no server/token needed).
 while [ $# -gt 0 ]; do
   case "$1" in
-    --instance) shift; [ $# -ge 1 ] || die "usage: browser --instance <key> <subcommand>"; INSTANCE="$1"; shift ;;
-    --instance=*) INSTANCE="${1#--instance=}"; shift ;;
-    --tab) shift; [ $# -ge 1 ] || die "usage: browser --tab <id> <subcommand>"; TAB="$1"; shift ;;
-    --tab=*) TAB="${1#--tab=}"; shift ;;
-    --frame) shift; [ $# -ge 1 ] || die "usage: browser --frame <frameId|url-substring> <subcommand>"; FRAME="$1"; shift ;;
-    --frame=*) FRAME="${1#--frame=}"; shift ;;
+    --instance) shift; [ $# -ge 1 ] || die "usage: browser --instance <key> <subcommand>"; INSTANCE="$1"; INSTANCE_SRC="--instance"; shift ;;
+    --instance=*) INSTANCE="${1#--instance=}"; INSTANCE_SRC="--instance"; shift ;;
+    --tab) shift; [ $# -ge 1 ] || die "usage: browser --tab <id> <subcommand>"; TAB="$1"; TAB_SRC="--tab"; shift ;;
+    --tab=*) TAB="${1#--tab=}"; TAB_SRC="--tab"; shift ;;
+    --frame) shift; [ $# -ge 1 ] || die "usage: browser --frame <frameId|url-substring> <subcommand>"; FRAME="$1"; FRAME_SRC="--frame"; shift ;;
+    --frame=*) FRAME="${1#--frame=}"; FRAME_SRC="--frame"; shift ;;
     --print-session-id) derive_session_id; echo; exit 0 ;;
     *) break ;;
   esac
@@ -1062,6 +1119,37 @@ json.dump(d, sys.stdout)
 '
 }
 
+# _note_env_routing — say ONCE, on stderr, that this op's target came from the
+# ENVIRONMENT and not from anything in the command line.
+#
+# 🔴 The hazard the env defaults introduce is LIFETIME, not precedence. An
+# exported BB_TAB/BB_FRAME/BB_INSTANCE silently steers every later `browser` call
+# in that shell AND in every descendant process — including a destructive
+# `type`/`click`/`upload` whose argv mentions no routing at all, and whose result
+# envelope is identical either way. One line naming the variable is the only thing
+# that makes an inherited route visible at the moment it is used.
+#
+# Called ONCE, from the subcommand dispatch below, NOT from cmd_op: several
+# subcommands invoke cmd_op inside a command substitution, and a subshell's
+# assignment to ENV_ROUTE_NOTED cannot reach this shell — so calling it there
+# printed the advisory once per op. STDERR only — `json.loads` on stdout must
+# stay safe, which is the contract the whole file is built around.
+# `BB_NO_ROUTE_NOTE=1` silences it for a caller that has deliberately exported the
+# variables for a long run and does not want the line on every op.
+_note_env_routing() {
+  [ "$ENV_ROUTE_NOTED" -eq 0 ] || return 0
+  ENV_ROUTE_NOTED=1
+  [ -z "${BB_NO_ROUTE_NOTE:-}" ] || return 0
+  local from=""
+  [ "$INSTANCE_SRC" = "\$BB_INSTANCE" ] && [ -n "$INSTANCE" ] && from="${from} \$BB_INSTANCE=${INSTANCE}"
+  [ "$TAB_SRC" = "\$BB_TAB" ] && [ -n "$TAB" ] && from="${from} \$BB_TAB=${TAB}"
+  [ "$FRAME_SRC" = "\$BB_FRAME" ] && [ -n "$FRAME" ] && from="${from} \$BB_FRAME=${FRAME}"
+  [ -n "$from" ] || return 0
+  echo "browser: routed from the ENVIRONMENT, not this command line:${from}" >&2
+  echo "browser:   (an exported BB_* is inherited by every later call — pass the flag" >&2
+  echo "browser:   explicitly, or unset it; BB_NO_ROUTE_NOTE=1 silences this line.)" >&2
+}
+
 # cmd_op OP [EXTRA_JSON_FIELDS] — POST /cmd, print the result JSON on a genuine
 # success; exit non-zero with a readable message on a transport, HTTP, OR
 # op-level (result.ok:false) error. Honours the global --instance (INSTANCE) by
@@ -1073,7 +1161,7 @@ cmd_op() {
   # --tab injects an explicit numeric tab override (validated as an integer).
   local tabf=""
   if [ -n "$TAB" ]; then
-    case "$TAB" in (*[!0-9]*|"") die "--tab must be a numeric tab id (got: $TAB)";; esac
+    case "$TAB" in (*[!0-9]*|"") die "${TAB_SRC} must be a numeric tab id (got: $TAB)";; esac
     tabf=",\"tab\":${TAB}"
   fi
   # --frame routes a read/click INTO a specific (cross-origin OOPIF) frame; the
@@ -1456,6 +1544,13 @@ pos_rest() {
 }
 
 sub="${1:-}"; shift || true
+# ONCE, here, and NOT inside cmd_op: several subcommands run cmd_op in a command
+# substitution (`resp="$(cmd_op nav …)"`), and a subshell cannot write the
+# "already noted" flag back to this shell — so a nav --wake printed the advisory
+# TWICE. Measured, not reasoned: the once-per-invocation test caught it.
+# The flag loop above exits for --help/--print-session-id before reaching this
+# line, so a command that never touches the wire never emits it.
+_note_env_routing
 case "$sub" in
   health)
     raw="$(_curl GET /health)" || die "curl failed talking to ${BASE}/health"
@@ -1947,13 +2042,27 @@ sys.stdout.write(json.dumps(fields)[1:-1])
     # DEFAULT (no path) now writes the PNG to a temp file and prints a compact
     # JSON result carrying the PATH + metadata. `--data-url` is the explicit
     # escape hatch that restores the old raw-data-URL output.
-    full=""; POS=""; POS_SEEN=0; dataurl=0
+    #
+    # 🔴 `--json` — THE ONE OP WHOSE STDOUT IS NOT JSON, MADE PARSEABLE ON REQUEST.
+    # Every other subcommand puts a JSON envelope and nothing else on stdout (the
+    # advisories — hidden tab, disconnected instance, routing help — all go to
+    # STDERR, and `tests/test_browser_cli_args.py` now pins that). `screenshot
+    # <path>` is the exception: for back-compat it prints the bare path on line 1
+    # and a `#`-prefixed Read hint on line 2, so a caller doing
+    # `json.loads(subprocess.run(...).stdout)` gets "Expecting value: line 1
+    # column 1" — measured 2026-08-20, and the reason three consumers broke.
+    #
+    # ADDITIVE, never a behaviour change: the default output is byte-identical to
+    # before. `--json` opts in to the SAME compact envelope the no-path branch has
+    # always printed ({ok,path,bytes,url,via,note}), so one parser handles both.
+    full=""; POS=""; POS_SEEN=0; dataurl=0; asjson=0
     while [ $# -gt 0 ]; do
       case "$1" in
         --fullpage) full="\"fullpage\":true"; shift ;;
         --data-url) dataurl=1; shift ;;
+        --json) asjson=1; shift ;;
         --) shift; pos_rest "screenshot takes at most one path" "$@"; break ;;
-        -*) die "browser screenshot: unknown flag: $1 (try: --fullpage, --data-url; use '--' before a path starting with '-')" ;;
+        -*) die "browser screenshot: unknown flag: $1 (try: --fullpage, --data-url, --json; use '--' before a path starting with '-')" ;;
         *) pos_add "screenshot takes at most one path" "$1"; shift ;;
       esac
     done
@@ -1966,6 +2075,15 @@ sys.stdout.write(json.dumps(fields)[1:-1])
     out="$POS"
     if [ "$dataurl" -eq 1 ] && [ -n "$out" ]; then
       die "browser screenshot: --data-url and an explicit path are mutually exclusive"
+    fi
+    # `--data-url` prints the RAW response envelope and never builds the compact
+    # {ok,path,bytes,…} shape, so `--json` has nothing to opt into there. Accepting
+    # the pair and ignoring one of them is the worst outcome: the caller asked for a
+    # parseable envelope, got a DIFFERENT parseable envelope with none of the keys
+    # they were about to read, and nothing said so. Refuse instead — the same rule
+    # the mutually-exclusive check above already applies to --data-url + a path.
+    if [ "$dataurl" -eq 1 ] && [ "$asjson" -eq 1 ]; then
+      die "browser screenshot: --data-url and --json are mutually exclusive (--data-url prints the raw response envelope, which has no path/bytes to report)"
     fi
     # cmd_op runs in a command substitution, so its `die`/exit can't propagate
     # on its own — `|| exit 1` forwards an op/transport error to the caller.
@@ -2039,37 +2157,76 @@ if not png.startswith(PNG_MAGIC):
     sys.exit(1)
 
 out=sys.argv[1]
+asjson=sys.argv[2]=="1"
 explicit=bool(out)
 tmpdir=tempfile.gettempdir()
 prune(tmpdir)
+
+def emit(payload):
+    """The ONE way this helper puts a result in front of the caller: FD 1.
+
+    Explicit rather than `print` because the whole point of `--json` is that
+    `json.loads(<stdout>)` works — every diagnostic in this script goes to
+    sys.stderr, and the two must never be confused. Flushed because the payload
+    is the last thing written and stdout is block-buffered when it is a pipe."""
+    sys.stdout.write(payload + "\n")
+    sys.stdout.flush()
+
+def envelope(path, note):
+    """The ONE compact result shape, shared by every JSON-printing branch.
+
+    It used to be built inline in the temp-file branch only, so `--json` had a
+    choice between duplicating it (two shapes that drift) and reusing it. One
+    rule, one place: the temp-file branch and `--json` now emit the SAME keys,
+    which is the whole point of --json — a caller writes one parser."""
+    data=d.get("result",{}).get("data",{}) or {}
+    res={"ok":True,"path":path,"bytes":len(png)}
+    for k in ("url","via"):
+        if data.get(k) is not None:
+            res[k]=data[k]
+    res["note"]=note
+    return json.dumps(res)
+
 if explicit:
-    with open(out,"wb") as fh:
-        fh.write(png)
-    print(out)
-    # A capture nobody Reads is pure waste: the 2026-08-02 usage audit measured
-    # 7 of 63 explicit-path captures never Read back. Exit 0 and a path on stdout
-    # look like success, so the one thing still required is easy to forget. ONE
-    # short line, and deliberately `#`-prefixed so line 1 stays the bare path for
-    # anything parsing it (and so the hint cannot be mistaken FOR a path).
-    # NOT printed for --data-url (no file exists) or the temp-file branch (whose
-    # JSON already carries an equivalent `note`) — printing it there would be
-    # wrong, and those two are the negative controls for the test.
-    print("# Read %s to view it." % out)
+    # A caller-supplied path can be a directory, a read-only dir, a dangling
+    # symlink. An uncaught OSError here prints a TRACEBACK on stderr and NOTHING
+    # on stdout — which reads exactly like "the --json payload went to stderr".
+    # One clean line instead, so a failed write can never be mistaken for a
+    # routing bug in the branch below.
+    try:
+        with open(out,"wb") as fh:
+            fh.write(png)
+    except OSError as exc:
+        sys.stderr.write("browser: screenshot: could not write %s (%s)\n" % (out, exc))
+        sys.exit(1)
+    if asjson:
+        # --json: the SAME envelope, so `json.loads(stdout)` works. The Read hint
+        # moves INTO `note` rather than being dropped — a caller that parses JSON
+        # still gets told the file has to be Read, and gets it in a field instead
+        # of a comment line their parser would choke on.
+        emit(envelope(out, "PNG written to %s — Read the file to view it "
+                           "(the base64 data URL is not printed; use --data-url "
+                           "to get it)" % out))
+    else:
+        print(out)
+        # A capture nobody Reads is pure waste: the 2026-08-02 usage audit measured
+        # 7 of 63 explicit-path captures never Read back. Exit 0 and a path on stdout
+        # look like success, so the one thing still required is easy to forget. ONE
+        # short line, and deliberately `#`-prefixed so line 1 stays the bare path for
+        # anything parsing it (and so the hint cannot be mistaken FOR a path).
+        # NOT printed for --data-url (no file exists) or the temp-file branch (whose
+        # JSON already carries an equivalent `note`) — printing it there would be
+        # wrong, and those two are the negative controls for the test.
+        print("# Read %s to view it." % out)
 else:
     # mkstemp: O_CREAT|O_EXCL at 0600 — not world-readable, not symlink-followable.
     fd,out=tempfile.mkstemp(prefix=PREFIX, suffix=SUFFIX, dir=tmpdir)
     with os.fdopen(fd,"wb") as fh:
         fh.write(png)
-    data=d.get("result",{}).get("data",{}) or {}
-    res={"ok":True,"path":out,"bytes":len(png)}
-    for k in ("url","via"):
-        if data.get(k) is not None:
-            res[k]=data[k]
-    res["note"]=("PNG written to disk (mode 0600, auto-pruned after 24h) — Read the "
-                 "file to view it (the base64 data URL is not printed; use --data-url "
-                 "to get it)")
-    print(json.dumps(res))
-' "$out"
+    emit(envelope(out, "PNG written to disk (mode 0600, auto-pruned after 24h) "
+                       "— Read the file to view it (the base64 data URL is not "
+                       "printed; use --data-url to get it)"))
+' "$out" "$asjson"
     fi
     ;;
   frames)

--- a/scripts/browser-bridge/tests/test_browser_screenshot_json_and_env.py
+++ b/scripts/browser-bridge/tests/test_browser_screenshot_json_and_env.py
@@ -1,0 +1,408 @@
+"""`screenshot --json` and the `BB_INSTANCE`/`BB_TAB`/`BB_FRAME` targeting
+defaults — all HEADLESS.
+
+Fully offline: a loopback stub HTTP server stands in for server.py (the same
+pattern as ``test_browser_cli_args.py``), so no Brave, no extension, no bridge.
+It records every /cmd body and answers a scripted envelope per op.
+
+WHY EACH GROUP EXISTS
+---------------------
+1. ``screenshot --json`` — the CLI's advisories were ALREADY on stderr (measured
+   at ``origin/main`` 2026-08-20;
+   ``test_stdout_is_pure_json_even_when_the_hidden_advisory_fires`` pins it, and
+   its passing THERE is the measurement that refutes the "advisories pollute
+   stdout" premise). The one command whose stdout genuinely is not JSON is
+   ``screenshot <path>``, which prints a bare path plus a ``#`` comment. That is
+   what breaks ``json.loads(stdout)``.
+2. ``BB_INSTANCE`` / ``BB_TAB`` / ``BB_FRAME`` — callers hoisted the three
+   targeting flags into a shell variable and splatted it (``F="--instance work
+   --tab 12"; browser $F text``). zsh does not field-split an unquoted ``$var``,
+   so the whole string arrives as ONE argument and the CLI reports an unknown
+   subcommand naming something the caller never typed.
+
+   Precedence is only half the contract. The other half is LIFETIME: an exported
+   ``BB_*`` is inherited by every descendant process, so a later destructive op
+   can be routed with nothing in its argv saying so. The routing NOTE tests below
+   cover that half.
+
+RED/GREEN MATRIX — measured, not assumed; see the PR body for the run.
+
+Run: nix-shell -p python312Packages.pytest curl --run \\
+       "pytest scripts/browser-bridge/tests/test_browser_screenshot_json_and_env.py"
+"""
+import base64
+import json
+import os
+import shutil
+import subprocess
+import threading
+import zlib
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+BB = Path(__file__).resolve().parent.parent
+CLI = BB / "browser"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("curl") is None,
+    reason="the browser CLI is bash and talks to the bridge with curl")
+
+
+def _ok(data):
+    return {"ok": True, "result": {"id": "c", "ok": True, "data": data}}
+
+
+@pytest.fixture
+def bridge(tmp_path):
+    """A stub bridge whose reply is chosen by a per-op QUEUE.
+
+    ``b.script("eval", [r1, r2, ...])`` queues responses for that op; the LAST
+    entry repeats once the queue drains, so a test only has to describe the
+    interesting prefix. Anything unscripted gets a generic success envelope.
+    """
+    scripts: dict = {}
+    bodies: list = []
+
+    class _H(BaseHTTPRequestHandler):
+        def _reply(self, code, payload):
+            raw = json.dumps(payload).encode()
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+
+        def do_POST(self):
+            n = int(self.headers.get("Content-Length") or 0)
+            body = json.loads(self.rfile.read(n).decode())
+            bodies.append(body)
+            op = body.get("op")
+            queue = scripts.get(op)
+            if queue:
+                item = queue.pop(0) if len(queue) > 1 else queue[0]
+            else:
+                item = _ok({"url": "https://a.test", "value": None})
+            code, payload = item if isinstance(item, tuple) else (200, item)
+            self._reply(code, payload)
+
+        def do_GET(self):
+            self._reply(200, {"ok": True, "instances": []})
+
+        def log_message(self, *a):
+            pass
+
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), _H)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+
+    tok = tmp_path / "token"
+    tok.write_text("screenshot-env-token\n")
+    env = dict(os.environ)
+    env.update({
+        "BROWSER_BRIDGE_HOST": "127.0.0.1",
+        "BROWSER_BRIDGE_PORT": str(srv.server_address[1]),
+        "BROWSER_BRIDGE_TOKEN_FILE": str(tok),
+        "CLAUDE_CODE_SESSION_ID": "pytest-screenshot-env",
+        "HOME": str(tmp_path),
+    })
+    # Never inherit the developer's own targeting defaults — that would make the
+    # BB_* tests below pass or fail on the ambient environment.
+    for k in ("BB_INSTANCE", "BB_TAB", "BB_FRAME", "BB_NO_ROUTE_NOTE"):
+        env.pop(k, None)
+
+    class _B:
+        @staticmethod
+        def script(op, responses):
+            scripts[op] = list(responses)
+
+        @staticmethod
+        def run(*args, **kw):
+            e = dict(_B.env)
+            e.update(kw.pop("extra_env", {}) or {})
+            return subprocess.run(["bash", str(CLI), *args], env=e,
+                                  capture_output=True, text=True, timeout=60)
+
+        @staticmethod
+        def ops():
+            return [b.get("op") for b in _B.bodies]
+
+    # Assigned AFTER the class body on purpose: a class body does not close over
+    # the enclosing function's scope, so `bodies = bodies` in there is a
+    # NameError, not a copy (the same note the sibling fixture in
+    # test_browser_cli_args.py carries).
+    _B.bodies = bodies
+    _B.env = env
+
+    try:
+        yield _B
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+# --------------------------------------------------------------------------- #
+# 1. stdout purity — the advisory premise, and the one real offender
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("args", [
+    ["text"], ["html"], ["type", "hi", "--selector", "#q"], ["context"],
+])
+def test_stdout_is_pure_json_even_when_the_hidden_advisory_fires(bridge, args):
+    """MEASURED at origin/main 2026-08-20: the advisories were ALREADY on stderr,
+    so `json.loads(stdout)` worked. This is the guard that keeps it that way —
+    the reported breakage was `screenshot <path>` (below), not this."""
+    bridge.script("getHtml", [_ok({"html": "<i>", "hidden": True})])
+    bridge.script("text", [_ok({"text": "hi", "hidden": True})])
+    bridge.script("type", [_ok({"typed": 2, "hidden": True})])
+    bridge.script("context", [_ok({"url": "https://a.test", "hidden": True})])
+    cp = bridge.run(*args)
+    assert cp.returncode == 0, cp.stderr
+    json.loads(cp.stdout)                       # would raise on any stray line
+    assert "browser: tab is hidden" in cp.stderr, (
+        "positive control: the advisory must actually have FIRED, or this test "
+        "proves stdout purity for a case that never emits an advisory")
+
+
+def _png_1x1():
+    def chunk(tag, data):
+        return (len(data).to_bytes(4, "big") + tag + data
+                + zlib.crc32(tag + data).to_bytes(4, "big"))
+    ihdr = (1).to_bytes(4, "big") + (1).to_bytes(4, "big") + bytes([8, 0, 0, 0, 0])
+    return (b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr)
+            + chunk(b"IDAT", zlib.compress(b"\x00\x00")) + chunk(b"IEND", b""))
+
+
+def _shot_reply(**extra):
+    d = {"dataUrl": "data:image/png;base64," + base64.b64encode(_png_1x1()).decode(),
+         "url": "https://a.test", "via": "cdp"}
+    d.update(extra)
+    return _ok(d)
+
+
+@pytest.fixture
+def shot(bridge):
+    bridge.script("screenshot", [_shot_reply()])
+    return bridge
+
+
+def test_screenshot_with_a_path_still_prints_the_bare_path(shot, tmp_path):
+    """INVARIANT GUARD: the default output is back-compat and must NOT change —
+    `--json` is additive. This is also the negative control for the next test:
+    it demonstrates the stdout that breaks `json.loads`."""
+    out = tmp_path / "s.png"
+    cp = shot.run("screenshot", str(out))
+    assert cp.returncode == 0, cp.stderr
+    assert cp.stdout.splitlines()[0] == str(out)
+    with pytest.raises(ValueError):
+        json.loads(cp.stdout)
+
+
+def test_screenshot_json_makes_stdout_parseable(shot, tmp_path):
+    out = tmp_path / "s.png"
+    cp = shot.run("screenshot", str(out), "--json")
+    assert cp.returncode == 0, cp.stderr
+    res = json.loads(cp.stdout)
+    assert res["ok"] is True
+    assert res["path"] == str(out)
+    assert res["bytes"] == out.stat().st_size > 0
+    assert res["url"] == "https://a.test" and res["via"] == "cdp"
+    # The Read hint survives, in a FIELD instead of a comment line.
+    assert "Read the file" in res["note"]
+
+
+def test_screenshot_without_a_path_is_json_either_way(shot):
+    """The temp-file branch already printed JSON; --json must not change it, and
+    both branches must emit the SAME keys so one parser handles both."""
+    plain = json.loads(shot.run("screenshot").stdout)
+    shot.script("screenshot", [_shot_reply()])
+    flagged = json.loads(shot.run("screenshot", "--json").stdout)
+    assert set(plain) == set(flagged)
+    for p in (plain["path"], flagged["path"]):
+        os.unlink(p)
+
+
+@pytest.mark.parametrize("explicit", [True, False])
+def test_screenshot_json_payload_is_on_stdout_not_stderr(bridge, tmp_path, explicit):
+    """Reported 2026-08-21 after the live gate: `screenshot <path> --json` was
+    seen printing its envelope on STDERR with stdout empty. This pins the
+    routing with the two streams captured on SEPARATE pipes, so a payload on the
+    wrong one cannot satisfy both halves of the assertion.
+
+    🔴 POSITIVE CONTROL: the tab is hidden, so the advisory MUST land on stderr.
+    Without it, "no envelope on stderr" is also true of a run where stderr was
+    never written to at all, and the test would prove nothing about routing."""
+    bridge.script("screenshot", [_shot_reply(hidden=True)])
+    args = ["screenshot"] + ([str(tmp_path / "s.png")] if explicit else []) + ["--json"]
+    cp = bridge.run(*args)
+    assert cp.returncode == 0, cp.stderr
+    assert "browser: tab is hidden" in cp.stderr, (
+        "positive control: stderr must actually have been written to, or this "
+        "test passes for a run that never emits on stderr at all")
+    res = json.loads(cp.stdout)
+    assert res["ok"] is True and res["bytes"] > 0
+    assert '"path"' not in cp.stderr and '"bytes"' not in cp.stderr, (
+        "the envelope must be on stdout ONLY, never duplicated onto stderr")
+    if explicit:
+        assert res["path"] == str(tmp_path / "s.png")
+    else:
+        os.unlink(res["path"])
+
+
+def test_screenshot_an_unwritable_path_says_so_instead_of_a_traceback(shot, tmp_path):
+    """A caller-supplied path can be a directory or a read-only dir. An uncaught
+    OSError printed a TRACEBACK on stderr and NOTHING on stdout — which reads
+    exactly like "the --json payload went to stderr", and is how a failed write
+    gets misfiled as a routing bug."""
+    d = tmp_path / "adir"
+    d.mkdir()
+    cp = shot.run("screenshot", str(d), "--json")
+    assert cp.returncode == 1
+    assert "could not write" in cp.stderr
+    assert "Traceback" not in cp.stderr, "a stack trace is not a diagnosis"
+    assert cp.stdout == ""
+
+
+def test_data_url_and_json_are_refused_rather_than_one_being_ignored(shot):
+    """`--data-url` prints the RAW response envelope and never builds the compact
+    {ok,path,bytes,…} shape, so `--json` has nothing to opt into. Silently
+    ignoring it is the worst outcome — the caller asked for a parseable envelope,
+    would get a DIFFERENT parseable envelope with none of the keys they were
+    about to read, and nothing would say so.
+
+    The negative control is the pre-existing `--data-url` + path rejection, which
+    proves this branch is a real refusal and not a no-op that happens to exit 1
+    for some other reason."""
+    cp = shot.run("screenshot", "--data-url", "--json")
+    assert cp.returncode == 1, cp.stdout
+    assert "--data-url and --json are mutually exclusive" in cp.stderr
+    assert shot.ops() == [], "the refusal must precede the wire op"
+
+
+def test_data_url_alone_still_prints_the_raw_envelope(shot):
+    """CONTROL for the refusal above: `--data-url` on its own is unchanged, so
+    the new check cannot be passing by breaking the flag it guards."""
+    cp = shot.run("screenshot", "--data-url")
+    assert cp.returncode == 0, cp.stderr
+    assert "data:image/png;base64," in cp.stdout
+    assert shot.ops() == ["screenshot"]
+
+
+def test_unknown_screenshot_flag_names_json(bridge):
+    cp = bridge.run("screenshot", "--nope")
+    assert cp.returncode == 1
+    assert "--json" in cp.stderr
+
+
+# --------------------------------------------------------------------------- #
+# 2. BB_INSTANCE / BB_TAB / BB_FRAME — precedence
+# --------------------------------------------------------------------------- #
+def test_env_vars_supply_the_targeting_defaults(bridge):
+    cp = bridge.run("text", extra_env={"BB_INSTANCE": "work", "BB_TAB": "1234",
+                                       "BB_FRAME": "7"})
+    assert cp.returncode == 0, cp.stderr
+    body = bridge.bodies[0]
+    assert body["target"] == "work"
+    assert body["tab"] == 1234
+    assert body["frame"] == "7"
+
+
+@pytest.mark.parametrize("flag,env,key,want", [
+    (["--instance", "home"], {"BB_INSTANCE": "work"}, "target", "home"),
+    (["--tab", "99"], {"BB_TAB": "1234"}, "tab", 99),
+    (["--frame", "2"], {"BB_FRAME": "7"}, "frame", "2"),
+])
+def test_an_explicit_flag_beats_the_env_default(bridge, flag, env, key, want):
+    cp = bridge.run(*flag, "text", extra_env=env)
+    assert cp.returncode == 0, cp.stderr
+    assert bridge.bodies[0][key] == want
+
+
+def test_an_explicit_empty_instance_clears_an_inherited_one(bridge):
+    """`--instance ''` is an explicit empty, not an absent flag — it must be able
+    to undo an ambient BB_INSTANCE, or a caller in an exported environment has no
+    way back to single-instance routing."""
+    cp = bridge.run("--instance", "", "text", extra_env={"BB_INSTANCE": "work"})
+    assert cp.returncode == 0, cp.stderr
+    assert "target" not in bridge.bodies[0]
+
+
+def test_a_malformed_BB_TAB_names_BB_TAB_not_the_flag(bridge):
+    """Reporting "--tab must be a numeric tab id" for a value that came from the
+    environment sends the reader hunting a flag that appears nowhere in their
+    command line."""
+    cp = bridge.run("text", extra_env={"BB_TAB": "not-a-number"})
+    assert cp.returncode == 1
+    assert "BB_TAB" in cp.stderr
+    assert "--tab must be" not in cp.stderr
+    assert bridge.ops() == [], "nothing may reach the wire on a bad target"
+
+
+def test_the_env_vars_are_documented_where_the_flags_are():
+    """A targeting default nobody can discover is not a fix. Both the CLI's own
+    --help header and the agent-facing SKILL.md must name all three."""
+    help_text = subprocess.run(["bash", str(CLI), "--help"],
+                               capture_output=True, text=True, timeout=60).stdout
+    skill = (BB / "SKILL.md").read_text()
+    for var in ("BB_INSTANCE", "BB_TAB", "BB_FRAME"):
+        assert var in help_text, f"{var} missing from `browser --help`"
+        assert var in skill, f"{var} missing from SKILL.md"
+
+
+# --------------------------------------------------------------------------- #
+# 3. BB_* lifetime — an inherited route must be VISIBLE at the moment it is used
+#
+# Precedence is the easy half. An exported BB_TAB/BB_FRAME/BB_INSTANCE steers
+# every later `browser` call in that shell and in every descendant process,
+# including a destructive `type`/`click`/`upload` whose argv mentions no routing
+# at all — and the result envelope is identical either way.
+# --------------------------------------------------------------------------- #
+def test_an_env_routed_op_says_so_on_stderr(bridge):
+    cp = bridge.run("type", "secret", "--selector", "#q",
+                    extra_env={"BB_FRAME": "evil.example"})
+    assert cp.returncode == 0, cp.stderr
+    assert "routed from the ENVIRONMENT" in cp.stderr
+    assert "$BB_FRAME=evil.example" in cp.stderr
+    json.loads(cp.stdout), "the note must not touch stdout"
+
+
+def test_the_route_note_names_every_variable_that_supplied_a_target(bridge):
+    cp = bridge.run("text", extra_env={"BB_INSTANCE": "work", "BB_TAB": "1234",
+                                       "BB_FRAME": "7"})
+    assert cp.returncode == 0, cp.stderr
+    for frag in ("$BB_INSTANCE=work", "$BB_TAB=1234", "$BB_FRAME=7"):
+        assert frag in cp.stderr, f"{frag} missing from the routing note"
+
+
+def test_a_flag_supplied_target_is_NOT_reported_as_env_routed(bridge):
+    """The note claims 'this came from the environment'. A flag that has beaten
+    the env default must therefore drop OUT of it, or the note is a false
+    statement about the very case it exists to distinguish."""
+    cp = bridge.run("--frame", "2", "text",
+                    extra_env={"BB_FRAME": "7", "BB_TAB": "1234"})
+    assert cp.returncode == 0, cp.stderr
+    assert "$BB_TAB=1234" in cp.stderr, "BB_TAB really did supply the tab"
+    assert "$BB_FRAME" not in cp.stderr, "--frame won; the env did not supply it"
+
+
+def test_no_note_at_all_when_nothing_came_from_the_environment(bridge):
+    """The negative control. A note that fires unconditionally carries no
+    information, and would train a reader to skip the line that matters."""
+    cp = bridge.run("--tab", "99", "text")
+    assert cp.returncode == 0, cp.stderr
+    assert "routed from the ENVIRONMENT" not in cp.stderr
+
+
+def test_the_route_note_is_printed_once_per_invocation(bridge):
+    """A verified/multi-op command calls cmd_op several times. Three copies of
+    the same advisory is noise, and noise is what gets skimmed."""
+    cp = bridge.run("nav", "https://a.test", "--wake",
+                    extra_env={"BB_INSTANCE": "work"})
+    assert bridge.ops() == ["nav", "wake"], "this command really is two ops"
+    assert cp.stderr.count("routed from the ENVIRONMENT") == 1
+
+
+def test_BB_NO_ROUTE_NOTE_silences_it_without_changing_the_routing(bridge):
+    cp = bridge.run("text", extra_env={"BB_TAB": "1234", "BB_NO_ROUTE_NOTE": "1"})
+    assert cp.returncode == 0, cp.stderr
+    assert "routed from the ENVIRONMENT" not in cp.stderr
+    assert bridge.bodies[0]["tab"] == 1234, "silencing must not change the route"


### PR DESCRIPTION
Two independent `browser` CLI fixes, **split out of #646** so they can land on their own merits. They were reviewed as clean and separable; the `type --expect/--verify` half stays in #646, still draft, pending the redesign the review asked for.

---

## 1. `screenshot <path> --json`

**The defect.** `browser screenshot <path>` prints, for back-compat:

```
/tmp/shot.png
# Read /tmp/shot.png to view it.
```

so `json.loads(subprocess.run(...).stdout)` raises `Expecting value: line 1 column 1`. Measured 2026-08-20; it is what broke three consumers.

**The premise it did NOT reproduce.** Every *other* advisory in this CLI was already on stderr. That was measured against a clean `origin/main` **before changing anything**, with a stub bridge answering `data.hidden: true`:

```
ARGS ['text']  rc 0
  STDOUT: '{\n  "ok": true, …}'          json.loads(stdout): OK
  STDERR: "browser: tab is hidden (background) — content may not have rendered; …"
```

`test_stdout_is_pure_json_even_when_the_hidden_advisory_fires` is green at **both** ends as the record of that, and is kept so it stays true.

**The fix.** The default output is byte-identical to before. `--json` opts into the SAME compact `{ok,path,bytes,url,via,note}` envelope the *no-path* form has always printed, so a caller writes one parser. The Read hint survives inside `note` rather than being dropped.

Two smaller things fixed here:

- 🟢 **`--data-url --json` used to silently ignore `--json`.** `--data-url` prints the raw response envelope and never builds the compact shape, so accepting the pair handed the caller a *different* parseable envelope with none of the keys they were about to read, and nothing said so. It is now refused — the same rule the pre-existing `--data-url` + explicit-path rejection already applies. `--data-url` alone is unchanged, and there is a control test that proves it.
- **An unwritable explicit path** (a directory, a read-only dir) printed a **traceback** on stderr with nothing on stdout — which reads exactly like "the `--json` payload went to stderr", and is how a failed write gets misfiled as a routing bug. One `browser: screenshot: could not write …` line instead.

## 2. `BB_INSTANCE` / `BB_TAB` / `BB_FRAME`

`--instance` / `--tab` / `--frame` now take environment defaults. An explicit flag always wins, and `--instance ''` deliberately clears an inherited `BB_INSTANCE` (an explicit empty is not an absent flag).

```bash
export BB_INSTANCE=work BB_TAB=1234
browser text ; browser click '#go'      # both routed, no flags
```

The failure this removes: `F="--instance work --tab 12"; browser $F text` — zsh does not field-split an unquoted `$var`, so the whole string arrives as **one** argument and the CLI reports an unknown subcommand naming something the caller never typed. An env var cannot be split wrong. A malformed `BB_TAB` now names `BB_TAB` in the error instead of `--tab`, which otherwise sends the reader hunting a flag that appears nowhere in their command line.

### 🔴 Lifetime, not precedence — the half the review flagged

Precedence is the easy half and it was already right. The risk is **lifetime**: an exported `BB_FRAME`/`BB_TAB`/`BB_INSTANCE` is inherited by every descendant process for the rest of that shell's life, so a later

```bash
browser type '<secret>' --selector '#x'
```

is routed into that frame — or at another profile's tab — with **nothing in its command line saying so**, and the envelope it prints is identical either way. Silence there makes an inherited destructive route indistinguishable from a deliberate one.

So an op whose target came from the **environment** now says so, once, on stderr:

```
browser: routed from the ENVIRONMENT, not this command line: $BB_FRAME=evil.example
browser:   (an exported BB_* is inherited by every later call — pass the flag
browser:   explicitly, or unset it; BB_NO_ROUTE_NOTE=1 silences this line.)
```

stdout stays pure JSON. A flag that *beat* the env default drops out of the note — otherwise the note would be a false statement about the very case it exists to distinguish — and there is a test for exactly that.

The note is emitted from the **subcommand dispatch**, not from `cmd_op`: several subcommands run `cmd_op` inside a command substitution, and a subshell cannot write the "already noted" flag back to the parent, so `nav --wake` printed it **twice**. That was found by the once-per-invocation test, not reasoned about.

Documented in `SKILL.md`'s global-flags line and in the CLI's own `--help` header, with a test asserting all three names appear in both.

---

## Tested

`scripts/browser-bridge/tests/test_browser_screenshot_json_and_env.py` — **26 tests**, headless against a scriptable stub bridge (same pattern as `test_browser_cli_args.py`).

| run | result |
|---|---|
| new file at a clean worktree of `origin/main` (only the test file copied in) | **15 RED, 11 green** |
| new file at HEAD | 26 green |
| full `scripts/browser-bridge/tests` at HEAD | **779 passed, 0 failed, 0 skipped** |

The 11 green at both ends are **invariant guards**, labelled as such in place — back-compat the change must not take away, *not* evidence anything works:

- the four stdout-purity cases, whose passing at `origin/main` **is** the measurement refuting premise 1;
- `test_screenshot_with_a_path_still_prints_the_bare_path` — the negative control for `--json`, and the demonstration of the stdout that *does* break `json.loads`;
- `test_data_url_alone_still_prints_the_raw_envelope` — the control proving the new `--data-url`/`--json` refusal did not break the flag it guards;
- the three "explicit flag beats the env default" cases and `test_an_explicit_empty_instance_clears_an_inherited_one`, green at base **for the wrong reason** (`BB_*` was ignored entirely there);
- `test_no_note_at_all_when_nothing_came_from_the_environment` — the negative control for the routing note.

### SKILL.md byte budget

`tests/test_skill_size.py` enforces a **12,038-byte** budget. The file stood at 12,007 (31 free), so several unrelated rows were compressed to pay for the new lines. No fact was dropped — each compressed detail was checked present in the reference topic the row already points at (`aria-expanded` and the screenshot fallback in `css-hit-test.md`; `extension_connected`, per-profile `brave://extensions`, Remove + Load unpacked in `errors.md`). The `screenshot` row's old claim that it "prints `{ok,path,bytes,url,via}`" was **false** for the explicit-path case; it now says what it does. Now **11,807 bytes** (231 under the enforced budget). The env-defaults paragraph is deliberately terse for the same reason.

---

## 🔴 LIVE VERIFY — not yet run

`reference/security-ops.md`: *"a green test suite and a clean security audit are prerequisites, NOT verification — CI cannot drive a real Brave."*

Point `$BB` at a worktree of THIS branch and prove it first — `browser` on `$PATH` is a home-manager symlink to the primary clone, which is on `main`, where `--json` does not exist and every arm below fails in a way that looks like a defect in this branch:

```bash
BB=/path/to/a/worktree/of/this/branch/scripts/browser-bridge/browser
sha256sum "$BB"
"$BB" screenshot --nope 2>&1 | grep -q -- --json && echo "OK: --json present" || echo "WRONG BINARY"
```

```bash
# the payload must be on STDOUT. Capture the two streams SEPARATELY —
# a terminal merges them and cannot settle the question.
$BB screenshot /tmp/v.png --json 1>/tmp/v.out 2>/tmp/v.err; echo "rc=$?"
wc -c /tmp/v.out /tmp/v.err          # .out must be NON-zero
jq -e .path </tmp/v.out              # must parse and print the path
grep -c '"bytes"' /tmp/v.err         # must be 0
$BB screenshot /tmp/v2.png | head -2 # bare path + '# Read …' (unchanged)
$BB screenshot --data-url --json     # must FAIL rc 1, "mutually exclusive"
$BB screenshot /tmp                  # a directory: one clean line, no traceback

export BB_INSTANCE=work
$BB whoami                           # routed; ONE stderr note naming $BB_INSTANCE
$BB --instance home whoami           # flag wins; NO note (nothing came from the env)
unset BB_INSTANCE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
