### PR TITLE
skill(clawgate): the task-pickup RITUAL is a procedure — 18,858 -> 15,088 bytes on a body that loads for every `clawgatectl health`

### DIFF
--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -42,6 +42,7 @@ auto-fire — something must name it.
 | file | run it when |
 |---|---|
 | `task-authoring.md` | **CREATING a task** — pre-verify → interview → recommend → tags → confirm → create. 🔴 A PreToolUse hook DENIES a create with no `## Acceptance criteria`, or an unreadable body. Override `CLAWGATE_NO_INTERVIEW=1`. |
+| `task-pickup.md` | **PICKING UP a task** — "read and evaluate clawgate task N", then "local dispatch": read → evaluate → pre-start comment → `in_progress` → work → ONE completion comment → status. Carries the criteria detector, the ordering trap and the comment rules. 🔴 A Stop hook BLOCKS on a missing write-back and names this file. |
 
 Memories: `clawgate-phase2` · `clawgate-phase3` · `clawgate-runbooks` ·
 `clawgate-loop-validation` · `authelia-passkey-sso`.
@@ -103,85 +104,24 @@ version-from-the-live-pin, the ONE commit path (worktree off `origin/trunk`; nev
 test gate, build/push, pin bump, the CSS-cwd trap that fakes ~25 e2e failures, chart sync.
 
 ## task pickup — "read and evaluate clawgate task N", then "local dispatch"
-🔴 **The comment/status ritual is NOT optional and NOT a thing to be asked for.** Run it unprompted.
+🔴 **Run `flows/task-pickup.md`** — the comment/status ritual is NOT optional and NOT a thing to be
+asked for. Run it unprompted. The bash block, the criteria detector, the frozen-verdict rule, the
+completion-comment shape, the ordering trap and the two-comments rule are all there.
 
 🔴 **A hook ENFORCES this** (`~/.claude/hooks/clawgate-writeback-guard.py`): armed by the
 step-1 **read**, it **blocks Stop** when work followed (edit/commit/push/PR) and a **live** re-read
 shows no `claude-code` comment since. Read-and-evaluate-only never fires; commenting silences it.
+Its block message names `~/.claude/skills/clawgate/flows/task-pickup.md` by path.
 
-🔴 **A COMMENT is the only write that notifies a watcher.** A status flip pushes **only** on
-*entering* `ready_for_review` (`notifyTaskDone`), so going `in_progress` notifies **nobody**. That is
-*why* the pre-start comment exists: Zach's only chance to object **before** the work, not after.
-Route-level cites: `task-api.md` → "Notifications".
-
-```bash
-clawgatectl task get <id>            # 1. READ — body + comments are BOTH already here
-                                     #    (no /comments GET exists; it is 405)
-#  2. EVALUATE and report to Zach. Do NOT flip status yet — see the ordering trap below.
-#  3a. On "local dispatch": settle the acceptance criteria (detector below).
-clawgatectl task comment <id> --body "$(cat <<'EOF'
-**Starting** — host <host>, session <id>.
-Acceptance criteria (AUTHOR-SPECIFIED | DERIVED — not author-specified):
-1. … 2. …
-Plan: <2–3 lines>.
-Not doing: <explicit non-goals>.
-Assumptions: <the ones that would change the work if wrong>.
-<if DERIVED> These criteria are mine, not yours — object now if they are wrong.
-EOF
-)"                                                # 3b. PRE-START comment, BEFORE the flip
-clawgatectl task status <id> in_progress          # 3c. THEN flip, and work
-#     …4. implement per repo defaults: tests watched to FAIL at base, worktree, PR…
-clawgatectl task comment <id> --body "…"          # 5. ONE completion comment (shape below)
-clawgatectl task status <id> ready_for_review     # 6. …or `complete` — see the gate
-```
-
-**Acceptance-criteria detector — deterministic, not a judgement call.** A heading matching
-`## Acceptance criteria` (case-insensitive) → **AUTHOR-SPECIFIED**. Anything else — including a body
-that merely *reads* like criteria — means you **DERIVE** them and must label them
-`DERIVED — not author-specified` in the comment.
-
-🔴 **The verdict is frozen at your FIRST read (step 1).** Body edits are legal before the
-`in_progress` flip, so otherwise an agent could PATCH the heading in, re-read it as AUTHOR-SPECIFIED
-and self-complete — the exact self-grading the gate exists to stop. **Writing the criteria and
-grading them is one act, in either order**: touch or reword the author's and they become yours,
-DERIVED. **Quote them VERBATIM in the pre-start comment** (author-specified ones too) — that
-timestamped copy is what makes this auditable rather than honour-system.
-
-**The completion comment (5)** carries evidence **per criterion** — one line each, naming what proves
-it — plus an explicit **NOT verified** list. "All green" with no per-criterion mapping is not a
-completion report.
-
-🔴 **Status gate (6) — the only place `complete` is ever yours to set:**
+🔴 **Status gate — the only place `complete` is ever yours to set.** Criteria are
+**AUTHOR-SPECIFIED** only when the task body carries a `## Acceptance criteria` heading; anything
+else means you **DERIVED** them, and that verdict is frozen at your first read.
 
 | criteria | every criterion validated with evidence? | final status |
 |---|---|---|
 | AUTHOR-SPECIFIED | yes | **`complete`** |
 | DERIVED | yes | **`ready_for_review`** — you must not grade an exam you wrote |
 | either | **no** | **`ready_for_review`**, naming WHICH criterion and WHY it was not validatable |
-
-🔴 **That gate is LOCAL-pickup only, structurally.** The in-devpod agent route
-`PATCH /agent/task/status` **forbids `complete`** (`notes.StatusAllowedForAgent`), so a dispatched
-devpod agent ends at `ready_for_review` regardless of what this skill says. Only the machine route
-this ritual uses can set `complete` at all — the gate governs that permission, nothing else.
-
-📌 **For the task AUTHOR (Zach): a `## Acceptance criteria` section in the body is what unlocks agent
-self-completion.** Without one, every pickup comes back `ready_for_review` for a human read. That is
-the one lever you have; `flows/task-authoring.md` is the interview that produces it.
-
-- 🔴 **Ordering trap — flip to `in_progress` LAST, after any edit to the task ITSELF.** The
-  `in_progress` 409 is refined but real: once in progress, a `PATCH /api/tasks/{id}` carrying any
-  non-tag field (or any routing tag) is refused. Descriptive-tag-only edits still succeed.
-  **Comments are exempt** — different route, no in-progress guard. So derived criteria go in the
-  **comment, never PATCHed into the body**: it dodges the 409, leaves Zach's task text untouched, and
-  makes provenance unambiguous (body = the author's words, comments = the agent's).
-- **Exactly TWO comments per pickup — start and finish, never per turn.** Per-turn self-reporting was
-  measured as noise and removed once already (memory `clawgate-loop-validation`); do not reintroduce
-  it in a new costume.
-- **Comments author as `claude-code`** via `X-Clawgate-Source`; no `--author` flag — the header IS
-  the impersonation guard, and `user`/`operator` are unreachable by design. An unknown `--source`
-  silently downgrades to `api`, so the CLI warns on stderr when the author it gets back differs.
-- ⚠ **A comment/status write also refreshes the task's idle clock** — the 7d idle reaper, which is
-  non-destructive since 0.7.96 (one copy of that fact: "machine Task API" below).
 
 ## machine (hook-token) Task API
 🔴 **Authoring one? `flows/task-authoring.md` FIRST** — a hook denies a criteria-less create.

--- a/claude/skills/clawgate/flows/task-authoring.md
+++ b/claude/skills/clawgate/flows/task-authoring.md
@@ -174,7 +174,7 @@ readable).
 
 ## What this flow is NOT
 
-- Not the **pickup** ritual — that is `SKILL.md` → "task pickup", enforced by a
+- Not the **pickup** ritual — that is `flows/task-pickup.md`, enforced by a
   different hook (`clawgate-writeback-guard.py`).
 - Not the **drafter** — `scripts/task-spec-drafter/` owns the unattended
   ticket→queue path and its safety-escalation gate. Do not reimplement it here.

--- a/claude/skills/clawgate/flows/task-pickup.md
+++ b/claude/skills/clawgate/flows/task-pickup.md
@@ -1,0 +1,96 @@
+# flow: picking up a clawgate task — the comment/status ritual
+
+**Run this on "read and evaluate clawgate task N", and on "local dispatch".** It is
+enforced: `~/.claude/hooks/clawgate-writeback-guard.py` (PostToolUse watches, Stop
+gates) BLOCKS the turn from ending when this session read a task, did real work
+after that read, and a live re-read of the board shows no `claude-code` comment
+since. The block message names this file, because a `flows/` file does not auto-fire
+the way a skill description does — the hook is the router.
+
+**The status gate that decides the FINAL status stays in `SKILL.md` → "Status
+gate"** — it is the part a reader must not miss, so it loads whether or not this
+flow was opened. Everything else about the pickup is here.
+
+🔴 **The comment/status ritual is NOT optional and NOT a thing to be asked for.** Run it unprompted.
+
+🔴 **A COMMENT is the only write that notifies a watcher.** A status flip pushes **only** on
+*entering* `ready_for_review` (`notifyTaskDone`), so going `in_progress` notifies **nobody**. That is
+*why* the pre-start comment exists: Zach's only chance to object **before** the work, not after.
+Route-level cites: `task-api.md` → "Notifications".
+
+```bash
+clawgatectl task get <id>            # 1. READ — body + comments are BOTH already here
+                                     #    (no /comments GET exists; it is 405)
+#  2. EVALUATE and report to Zach. Do NOT flip status yet — see the ordering trap below.
+#  3a. On "local dispatch": settle the acceptance criteria (detector below).
+clawgatectl task comment <id> --body "$(cat <<'EOF'
+**Starting** — host <host>, session <id>.
+Acceptance criteria (AUTHOR-SPECIFIED | DERIVED — not author-specified):
+1. … 2. …
+Plan: <2–3 lines>.
+Not doing: <explicit non-goals>.
+Assumptions: <the ones that would change the work if wrong>.
+<if DERIVED> These criteria are mine, not yours — object now if they are wrong.
+EOF
+)"                                                # 3b. PRE-START comment, BEFORE the flip
+clawgatectl task status <id> in_progress          # 3c. THEN flip, and work
+#     …4. implement per repo defaults: tests watched to FAIL at base, worktree, PR…
+clawgatectl task comment <id> --body "…"          # 5. ONE completion comment (shape below)
+clawgatectl task status <id> ready_for_review     # 6. …or `complete` — see the gate
+```
+
+**Acceptance-criteria detector — deterministic, not a judgement call.** A heading matching
+`## Acceptance criteria` (case-insensitive) → **AUTHOR-SPECIFIED**. Anything else — including a body
+that merely *reads* like criteria — means you **DERIVE** them and must label them
+`DERIVED — not author-specified` in the comment.
+
+🔴 **The verdict is frozen at your FIRST read (step 1).** Body edits are legal before the
+`in_progress` flip, so otherwise an agent could PATCH the heading in, re-read it as AUTHOR-SPECIFIED
+and self-complete — the exact self-grading the gate exists to stop. **Writing the criteria and
+grading them is one act, in either order**: touch or reword the author's and they become yours,
+DERIVED. **Quote them VERBATIM in the pre-start comment** (author-specified ones too) — that
+timestamped copy is what makes this auditable rather than honour-system.
+
+**The completion comment (5)** carries evidence **per criterion** — one line each, naming what proves
+it — plus an explicit **NOT verified** list. "All green" with no per-criterion mapping is not a
+completion report.
+
+🔴 **Step 6 is the STATUS GATE, and it lives in `SKILL.md` → "Status gate"** — the
+AUTHOR-SPECIFIED/DERIVED × validated table that decides `complete` vs `ready_for_review`. Read it
+there; it is deliberately not duplicated here.
+
+🔴 **That gate is LOCAL-pickup only, structurally.** The in-devpod agent route
+`PATCH /agent/task/status` **forbids `complete`** (`notes.StatusAllowedForAgent`), so a dispatched
+devpod agent ends at `ready_for_review` regardless of what this skill says. Only the machine route
+this ritual uses can set `complete` at all — the gate governs that permission, nothing else.
+
+📌 **For the task AUTHOR (Zach): a `## Acceptance criteria` section in the body is what unlocks agent
+self-completion.** Without one, every pickup comes back `ready_for_review` for a human read. That is
+the one lever you have; `flows/task-authoring.md` is the interview that produces it.
+
+- 🔴 **Ordering trap — flip to `in_progress` LAST, after any edit to the task ITSELF.** The
+  `in_progress` 409 is refined but real: once in progress, a `PATCH /api/tasks/{id}` carrying any
+  non-tag field (or any routing tag) is refused. Descriptive-tag-only edits still succeed.
+  **Comments are exempt** — different route, no in-progress guard. So derived criteria go in the
+  **comment, never PATCHed into the body**: it dodges the 409, leaves Zach's task text untouched, and
+  makes provenance unambiguous (body = the author's words, comments = the agent's).
+- **Exactly TWO comments per pickup — start and finish, never per turn.** Per-turn self-reporting was
+  measured as noise and removed once already (memory `clawgate-loop-validation`); do not reintroduce
+  it in a new costume.
+- **Comments author as `claude-code`** via `X-Clawgate-Source`; no `--author` flag — the header IS
+  the impersonation guard, and `user`/`operator` are unreachable by design. An unknown `--source`
+  silently downgrades to `api`, so the CLI warns on stderr when the author it gets back differs.
+- ⚠ **A comment/status write also refreshes the task's idle clock** — the 7d idle reaper, which is
+  non-destructive since 0.7.96 (one copy of that fact: `SKILL.md` → "machine (hook-token) Task API").
+
+---
+
+## What this flow is NOT
+
+- Not the **authoring** interview — that is `flows/task-authoring.md`, enforced by a
+  different hook (`clawgate-task-interview-guard.py`).
+- Not the **status gate** itself — that stays in `SKILL.md`, so a reader who never
+  opens this file still meets it.
+- Not a description of what the guard hook can and cannot see. Its blind spots,
+  escalation ladder and the `--dismiss` escape are in the hook's own module
+  docstring (`devrc/scripts/claude-hooks/clawgate-writeback-guard.py`).

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1170,6 +1170,11 @@ in
   # notice, silence per task per session, and NEVER blocks when the board could not
   # be reached (it says so instead). Every error path exits 0.
   #
+  # Its block message names `claude/skills/clawgate/flows/task-pickup.md`, the flow
+  # the ritual moved into — same reason as the interview gate below: a file under a
+  # skill's flows/ dir does not auto-fire the way a skill DESCRIPTION does, so the
+  # hook is the router as well as the enforcer.
+  #
   # 🔴 A NEW file, so it must be `git add`ed or the flake silently omits it and the
   # switch still succeeds with the hook absent — this repo's standing trap.
   # Registered on PostToolUse (NO matcher — half of what it watches for is an Edit)

--- a/scripts/claude-hooks/clawgate-writeback-guard.py
+++ b/scripts/claude-hooks/clawgate-writeback-guard.py
@@ -488,6 +488,14 @@ STATE_TTL_SECS = 14 * 24 * 3600
 # PermissionRequest hook reads; see the clawgate skill.
 CLAWGATE_ENV = "~/.claude/clawgate.env"
 
+# Where the ritual this hook enforces is written down. BOTH spellings are printed:
+# the deployed path is what the model can open right now, the repo path is what it
+# edits. Same idiom as clawgate-task-interview-guard.py's FLOW_DEPLOYED/FLOW_REPO —
+# a file under a skill's `flows/` dir does NOT auto-fire the way a skill DESCRIPTION
+# does, so the hook that enforces a flow is also its router.
+FLOW_DEPLOYED = "~/.claude/skills/clawgate/flows/task-pickup.md"
+FLOW_REPO = "devrc/claude/skills/clawgate/flows/task-pickup.md"
+
 
 # --------------------------------------------------------------------------- #
 # Triggers
@@ -1292,6 +1300,9 @@ def missing_text(task_id, first_read_ts, session_id=""):
         "Use `complete` instead of `ready_for_review` ONLY when the task body carried "
         "a `## Acceptance criteria` heading AND every criterion is validated — see the "
         "clawgate skill's status gate.\n"
+        "The full pickup ritual — the comment shapes, the criteria detector, the "
+        "ordering trap — is %(flow)s\n"
+        "  (repo: %(flow_repo)s)\n"
         "🔴 IF THIS SESSION'S WORK WAS NOT FOR TASK %(id)d — you only read the card, or "
         "the work belongs to a different task or repo — do NOT comment and do NOT flip "
         "the status: a junk comment permanently silences this guard for the card, and "
@@ -1300,7 +1311,8 @@ def missing_text(task_id, first_read_ts, session_id=""):
         "card again, and a new session starts fresh:\n"
         "  %(dismiss)s"
         % {"id": int(task_id), "ts": first_read_ts,
-           "dismiss": dismiss_cmd(task_id, session_id)}
+           "dismiss": dismiss_cmd(task_id, session_id),
+           "flow": FLOW_DEPLOYED, "flow_repo": FLOW_REPO}
     )
 
 

--- a/scripts/claude-hooks/tests/test_clawgate_task_interview_guard.py
+++ b/scripts/claude-hooks/tests/test_clawgate_task_interview_guard.py
@@ -1121,13 +1121,15 @@ def test_the_skill_did_not_grow():
     """🔴 SKILL.md loads in FULL on every invocation of this skill. The addition was
     paid for by an eviction in the same commit; this pins that it stays paid.
 
-    The ceiling is the size measured at the commit that added the flow pointer,
-    which is BELOW the size it had before — so this fails on a regrowth rather than
-    merely on a doubling."""
-    assert SKILL.stat().st_size <= 18868, (
-        "claude/skills/clawgate/SKILL.md is %d bytes; it was 18868 before the "
-        "task-authoring flow landed and 18858 after. Any addition needs an "
-        "eviction in the SAME commit." % SKILL.stat().st_size)
+    The ceiling is the size measured at the commit that last SHRANK the file, not
+    a round number above it — so this fails on a regrowth rather than merely on a
+    doubling. 🔴 RE-PIN IT WHENEVER THE FILE SHRINKS: a ceiling left at an old,
+    larger size silently licenses the regrowth it was installed to catch."""
+    assert SKILL.stat().st_size <= 15088, (
+        "claude/skills/clawgate/SKILL.md is %d bytes. History: 18868 before the "
+        "task-authoring flow, 18858 after, 15088 after the task-pickup ritual "
+        "moved out to flows/task-pickup.md. Any addition needs an eviction in the "
+        "SAME commit." % SKILL.stat().st_size)
 
 
 def test_the_flow_carries_the_body_template_with_the_required_heading():

--- a/scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
+++ b/scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
@@ -3034,3 +3034,182 @@ def test_the_WHOLE_LOOP_THROUGH_THE_REAL_PROCESS(home, tmp_path):
     assert again.returncode == 0
     assert again.stdout == ""
     assert again.stderr == ""
+
+
+# =========================================================================== #
+# THE FLOW SEAM — three surfaces, ONE path
+#
+# 🔴 THE DEFECT THIS SECTION EXISTS FOR IS A SEAM DEFECT, NOT A COMPONENT ONE.
+# The pickup ritual used to sit inline in `claude/skills/clawgate/SKILL.md`; it
+# now lives in `claude/skills/clawgate/flows/task-pickup.md`. A file under a
+# skill's `flows/` dir does NOT auto-fire the way a skill DESCRIPTION does
+# (devrc CLAUDE.md -> "reference/ vs flows/"), so THREE surfaces have to name the
+# SAME file or the ritual is unreachable from wherever the reader entered:
+#
+#   * this hook's BLOCK TEXT       — for the reader who is already being gated;
+#   * SKILL.md's `## Flow files`   — for the reader who loaded the skill and is not;
+#   * the file itself, git-TRACKED — or the nix flake silently omits it and the
+#     deployed path both of the above print resolves to nothing (CLAUDE.md's
+#     standing trap: a new file must be `git add`ed or the switch succeeds with
+#     the file absent).
+#
+# Each of the three is individually reviewable and individually green while the
+# other two disagree — RULES.md -> "Verified in isolation is the new vacuous
+# green". So the assertions below pin a RELATIONSHIP (one path string, shared)
+# rather than each component, and where the artifact is PROSE they pin the whole
+# normalised claim rather than a word, because a guard on words is walkable by
+# rewording.
+# =========================================================================== #
+SKILL = ROOT / "claude" / "skills" / "clawgate" / "SKILL.md"
+DEPLOYED_SKILLS_PREFIX = "~/.claude/skills/"
+
+#: 🔴 The status gate, pinned as the WHOLE NORMALISED TABLE. It is the one part of
+#: the ritual that deliberately did NOT move — burying it costs more than it saves,
+#: and both `flows/task-authoring.md` and clawgate-task-interview-guard.py cite it
+#: as `SKILL.md -> "Status gate"`. Pinning the word "complete" would pass while the
+#: table said the opposite; pinning the rows means a cosmetic reword fails this test
+#: and gets paid for deliberately, which is the trade RULES.md asks for.
+STATUS_GATE_ROWS = (
+    "| criteria | every criterion validated with evidence? | final status |",
+    "| AUTHOR-SPECIFIED | yes | **`complete`** |",
+    "| DERIVED | yes | **`ready_for_review`** — you must not grade an exam you wrote |",
+    "| either | **no** | **`ready_for_review`**, naming WHICH criterion and WHY it "
+    "was not validatable |",
+)
+
+#: Claims that MOVED, pinned whole so the move cannot silently drop one. Each is a
+#: normalised sentence from the pre-move SKILL.md, not a keyword.
+MOVED_CLAIMS = (
+    "**Acceptance-criteria detector — deterministic, not a judgement call.** A heading "
+    "matching `## Acceptance criteria` (case-insensitive) → **AUTHOR-SPECIFIED**.",
+    "🔴 **The verdict is frozen at your FIRST read (step 1).**",
+    "🔴 **Ordering trap — flip to `in_progress` LAST, after any edit to the task ITSELF.**",
+    "**Exactly TWO comments per pickup — start and finish, never per turn.**",
+    "**Comments author as `claude-code`** via `X-Clawgate-Source`; no `--author` flag",
+    "⚠ **A comment/status write also refreshes the task's idle clock**",
+    "clawgatectl task status <id> in_progress          # 3c. THEN flip, and work",
+)
+
+
+def _repo_path_for(deployed):
+    """The in-tree file a `~/.claude/skills/...` token names.
+
+    `nix/home.nix` populates `~/.claude/skills` from `claude/skills` wholesale
+    (`cp -R`, so `flows/` ships with no nix change), which makes the mapping one
+    prefix swap. Derived rather than hardcoded on purpose: MOVING the flow means
+    editing FLOW_DEPLOYED, and the check must then land on a file that has to
+    exist, not on a second literal somebody would edit to match.
+    """
+    assert deployed.startswith(DEPLOYED_SKILLS_PREFIX), deployed
+    return ROOT / "claude" / "skills" / deployed[len(DEPLOYED_SKILLS_PREFIX):]
+
+
+def test_the_block_text_names_the_pickup_flow_by_its_DEPLOYED_path():
+    """🔴 The hook is the ROUTER as well as the enforcer. Same idiom as
+    clawgate-task-interview-guard.py: the deployed spelling is what the model can
+    open right now, the repo spelling is what it edits, and both are printed."""
+    text = guard.missing_text(207, READ_TS, SESSION)
+    assert guard.FLOW_DEPLOYED in text, (
+        "the write-back block text no longer names the pickup flow (%s). A model "
+        "that is being blocked for skipping the ritual is handed no way to read "
+        "it, and a `flows/` file has no other router." % guard.FLOW_DEPLOYED)
+    assert guard.FLOW_REPO in text, guard.FLOW_REPO
+    # Anti-vacuity: `in` against an empty or truncated constant is satisfied by
+    # anything, so pin what the constants must END in.
+    assert guard.FLOW_DEPLOYED.endswith("/flows/task-pickup.md"), guard.FLOW_DEPLOYED
+    assert guard.FLOW_REPO.endswith("/flows/task-pickup.md"), guard.FLOW_REPO
+
+
+def test_the_flow_the_block_text_names_EXISTS_and_is_git_tracked():
+    """🔴 Both halves, because neither covers both tiers. EXISTENCE is what means
+    something inside the nix sandbox (the store copy is built from tracked files
+    only, so an untracked flow would simply not be here). TRACKEDNESS is what means
+    something on a dev host, where the file exists whether or not git knows about
+    it — and an untracked file is exactly the CLAUDE.md trap: the switch succeeds
+    and the deployed path this hook prints is not there."""
+    target = _repo_path_for(guard.FLOW_DEPLOYED)
+    assert target.is_file(), (
+        "the hook's FLOW_DEPLOYED (%s) maps to %s, which does not exist in this "
+        "tree." % (guard.FLOW_DEPLOYED, target))
+    rel = target.relative_to(ROOT).as_posix()
+    # The repo spelling the block text also prints must name the same file.
+    assert guard.FLOW_REPO.endswith(rel), (
+        "FLOW_DEPLOYED and FLOW_REPO name different files: %s vs %s"
+        % (rel, guard.FLOW_REPO))
+    if not (ROOT / ".git").exists():
+        return
+    out = subprocess.run(["git", "-C", str(ROOT), "ls-files", "--error-unmatch", rel],
+                         capture_output=True, text=True)
+    assert out.returncode == 0, (
+        "%s is not git-tracked, so the flake omits it from the deploy and the "
+        "switch succeeds with the flow absent." % rel)
+
+
+def test_the_skill_routes_to_the_pickup_flow_from_its_flow_table():
+    """The flow must be reachable from the ALWAYS-LOADED surface too, not only from
+    a block — a reader who never trips the hook still has to find it."""
+    text = SKILL.read_text(encoding="utf-8")
+    parts = text.split("## Flow files", 1)
+    assert len(parts) == 2, "SKILL.md no longer has a `## Flow files` section"
+    table = parts[1].split("\n## ", 1)[0]
+    assert "`task-pickup.md`" in table, (
+        "SKILL.md's Flow files table does not name task-pickup.md. A flows/ file "
+        "does not auto-fire the way a skill description does; without a router row "
+        "it is dead weight.")
+    # Anti-vacuity: the split really did isolate the table, not the whole file.
+    assert "`task-authoring.md`" in table and "machine (hook-token)" not in table
+
+
+def test_the_skill_names_the_same_DEPLOYED_path_the_hook_prints():
+    """🔴 THE SEAM ITSELF. Three surfaces, one string. The failure this catches is
+    a MOVE that updates two of them: the hook keeps blocking with a path nobody
+    maintains, or SKILL.md points somewhere the enforcer never mentions."""
+    text = SKILL.read_text(encoding="utf-8")
+    assert guard.FLOW_DEPLOYED in text, (
+        "SKILL.md does not carry the deployed flow path the hook's block text "
+        "prints (%s). Both surfaces must name the SAME file." % guard.FLOW_DEPLOYED)
+
+
+def test_the_status_gate_table_did_NOT_leave_the_skill():
+    """🔴 AN INVARIANT GUARD, NOT REGRESSION COVERAGE — it is green at the commit
+    before this one too, and is labelled so nobody counts it as proof the move was
+    tested. What it pins is the half of the ritual that must NOT move: the gate is
+    cited as `SKILL.md -> "Status gate"` by flows/task-authoring.md AND by
+    clawgate-task-interview-guard.py's `_WHY`, so demoting it into the flow would
+    break two live pointers and hide the one table a reader must not miss."""
+    text = _norm(SKILL.read_text(encoding="utf-8"))
+    missing = [r for r in STATUS_GATE_ROWS if _norm(r) not in text]
+    assert not missing, (
+        "the status gate table changed or left claude/skills/clawgate/SKILL.md:\n  "
+        + "\n  ".join(missing)
+        + "\n\nIt is pinned WHOLE on purpose — a guard on the word `complete` "
+        "would pass while the table said the opposite. If the reword is "
+        "deliberate, update STATUS_GATE_ROWS in the SAME commit, and re-check "
+        "flows/task-authoring.md and clawgate-task-interview-guard.py, which both "
+        "cite this table by name.")
+
+
+def test_every_claim_that_MOVED_landed_in_the_flow():
+    """The other direction of the same seam: a move that drops a claim is silent.
+    Pinned as whole normalised sentences rather than keywords."""
+    text = _norm(_repo_path_for(guard.FLOW_DEPLOYED).read_text(encoding="utf-8"))
+    missing = [c for c in MOVED_CLAIMS if _norm(c) not in text]
+    assert not missing, (
+        "these claims were moved out of SKILL.md but are not in the flow:\n  "
+        + "\n  ".join(missing))
+
+
+def test_positive_control_the_seam_assertions_can_actually_fail():
+    """🔴 A guard that reports clean is indistinguishable from a guard wired to
+    nothing until it has been watched to go red. Each helper is fed a case it MUST
+    reject, so a zero above is a measurement rather than an empty glob."""
+    # the prose pin: a rewording of one row is caught, not waved through
+    broken = _norm("| DERIVED | yes | **`complete`** |")
+    assert _norm(STATUS_GATE_ROWS[2]) != broken
+    assert broken not in _norm(SKILL.read_text(encoding="utf-8"))
+    # the path mapping: a deployed spelling outside the skills tree is refused
+    with pytest.raises(AssertionError):
+        _repo_path_for("~/.claude/hooks/clawgate-writeback-guard.py")
+    # ...and one INSIDE it that names no file resolves to a path that is not there
+    assert not _repo_path_for(
+        DEPLOYED_SKILLS_PREFIX + "clawgate/flows/no-such-flow.md").is_file()


### PR DESCRIPTION
## What

Moves the clawgate **task-pickup ritual** out of the always-loaded
`claude/skills/clawgate/SKILL.md` and into a new
`claude/skills/clawgate/flows/task-pickup.md`, and makes the hook that enforces
the ritual **name that file by path**.

`SKILL.md` loads in FULL the moment the skill fires — a `clawgatectl health`, a
log tail, a deploy. ~30% of its 18,858 bytes was a step-by-step PROCEDURE that
every one of those callers paid for and none of them ran. This repo's own
convention (`CLAUDE.md` → "reference/ vs flows/"): `reference/` holds FACTS you
verify against, `flows/` holds PROCEDURES you execute. The ritual's sibling,
`flows/task-authoring.md`, already lives there.

**18,858 → 15,088 bytes** (−3,770, −20%).

## Moved verbatim

The six-step bash block · the acceptance-criteria detector · the frozen-verdict
rule · the completion-comment shape · the ordering trap (`in_progress` LAST) ·
the two-comments rule · the `X-Clawgate-Source` note · the idle-clock note · the
LOCAL-pickup-only scope note · the 📌 note to the task author.

Two lines were re-pointed rather than moved byte-identically, both because a
POSITIONAL reference stops being true once the text lands in another file — the
claims themselves are unchanged:

| before | after | why |
|---|---|---|
| `🔴 **Status gate (6) — …**` | `🔴 **Status gate — …**` | the numbered steps moved out; "(6)" no longer resolves in SKILL.md |
| `…(one copy of that fact: "machine Task API" below)` | `…(one copy of that fact: `SKILL.md` → "machine (hook-token) Task API")` | "below" is false from inside `flows/` |

Verified mechanically: of the 68 lines removed from SKILL.md, 66 appear
byte-for-byte (whitespace-normalised) in the flow or in the trimmed SKILL.md, and
the 2 exceptions are exactly the rows above.

## Stayed inline, on purpose

* **the STATUS GATE table** (AUTHOR-SPECIFIED/DERIVED × validated →
  `complete`/`ready_for_review`) — it is the part a reader must not miss, and it
  is cited BY NAME as `SKILL.md -> "Status gate"` from both
  `flows/task-authoring.md` and `clawgate-task-interview-guard.py`'s deny text.
  Burying it would break two live pointers to save a table. Kept with a one-line
  lead-in defining AUTHOR-SPECIFIED vs DERIVED, without which the left column is
  meaningless standing alone;
* **the 🔴 hook-enforcement note**, so a reader who skips the flow still learns
  they are gated;
* **a router row in `## Flow files`** — a `flows/` file does NOT auto-fire the way
  a skill `description` does, so an unrouted one is dead weight.

`test_the_skill_did_not_grow`'s ceiling is re-pinned 18868 → 15088. A ceiling left
at the old, larger number silently licenses exactly the regrowth it was installed
to catch.

## The hook is the second router

`clawgate-writeback-guard.py`'s block text now names
`~/.claude/skills/clawgate/flows/task-pickup.md` (deployed — what the model can
open right now) and `devrc/claude/skills/clawgate/flows/task-pickup.md` (repo —
what it edits), through `FLOW_DEPLOYED`/`FLOW_REPO` constants. That is the exact
idiom `clawgate-task-interview-guard.py` already uses, for the same reason: a
model being blocked for skipping the ritual is otherwise handed no way to read it.

```
+"The full pickup ritual — the comment shapes, the criteria detector, the "
+"ordering trap — is %(flow)s\n"
+"  (repo: %(flow_repo)s)\n"
```

Only `missing_text` (the BLOCK) changed; `unknown_text` (the non-blocking
could-not-measure NOTICE) is untouched.

## Test coverage — a SEAM guard

The defect this change can produce is a seam defect, not a component one: three
surfaces have to name ONE path — the hook's block text, SKILL.md's `## Flow files`
table, and the git-tracked file itself — and each is individually reviewable and
individually green while the other two disagree. So the new section in
`scripts/claude-hooks/tests/test_clawgate_writeback_guard.py` pins the
RELATIONSHIP, derives the repo path FROM `FLOW_DEPLOYED` rather than from a second
literal somebody would edit to match, and — the artifact being prose — pins the
WHOLE normalised status-gate rows rather than a word another feature could spell.

**Matrix — red at `origin/main`, green at HEAD.** Run against a pristine
`git archive origin/main` tree with only the new test file overlaid:

| test | at origin/main | at HEAD |
|---|---|---|
| `…block_text_names_the_pickup_flow_by_its_DEPLOYED_path` | **FAIL** (no `FLOW_DEPLOYED`) | pass |
| `…flow_the_block_text_names_EXISTS_and_is_git_tracked` | **FAIL** (no `FLOW_DEPLOYED`) | pass |
| `…skill_routes_to_the_pickup_flow_from_its_flow_table` | **FAIL** (no router row) | pass |
| `…skill_names_the_same_DEPLOYED_path_the_hook_prints` | **FAIL** (no `FLOW_DEPLOYED`) | pass |
| `…every_claim_that_MOVED_landed_in_the_flow` | **FAIL** (no flow file) | pass |
| `…status_gate_table_did_NOT_leave_the_skill` | pass | pass |
| `…positive_control_the_seam_assertions_can_actually_fail` | pass | pass |

The last two are labelled in-source as what they are: an **INVARIANT GUARD** (the
gate must not vanish — green at base too, so it is not regression coverage) and a
**positive control** (a scanner reporting clean is indistinguishable from one wired
to nothing until it has been watched to go red).

**Mutation, isolated to the narrowest expression that can be wrong:**
`"flow": FLOW_DEPLOYED` → `"flow": FLOW_REPO` in `missing_text` — so the block text
still prints A path, just not the openable one. Exactly ONE test failed, carrying
**this guard's own message** ("the write-back block text no longer names the pickup
flow"), not a different check's error or an `AttributeError`.

## Deploy note

`flows/` ships via the same `cp -R ${../claude/skills}` as `reference/`, so no nix
change was needed for delivery — but the new file IS `git add`ed explicitly (this
repo's standing trap: an untracked file is silently omitted from the flake and the
switch succeeds with it absent). `test_the_flow_the_block_text_names_EXISTS_and_is_git_tracked`
now pins that in both tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
