### PR TITLE
prune(session-manager): a section restated, in prose, the caveats the TOOL already emits structurally — 23,233 → 16,159 B

### DIFF
--- a/claude/skills/session-manager/SKILL.md
+++ b/claude/skills/session-manager/SKILL.md
@@ -34,7 +34,8 @@ column — **how it is counted**) are different, and `caveats.kind_scope` carrie
 | `--no-ledger` | skip the ledger read → **no age, no session id** on any row |
 | `--fuzzyclaw` | the task-file join, **OFF by default** (see below) |
 
-`--json`, `--no-ch`, `--plain`, `--stale-threshold`, `--lines`, and what each drops:
+`--json`, `--no-ch`, `--no-fuzzyclaw`, `--plain`, `--stale-threshold`, `--lines`, and what
+each drops:
 `~/.claude/skills/session-manager/reference/payload-contract.md`.
 
 ## 🔴 Which output to ask for — you are the only consumer
@@ -143,8 +144,8 @@ is `summary.waiting.probable` — a different population, never summed with this
 is kept and a test bans the old key at any depth.
 
 🔴 With the `agent-ops` TUI RETIRED this is the ONLY place the queue surfaces outside the bar
-pill: never answer "is anything waiting for my approval" by pointing somewhere else. Read from
-the bar poller's cache, not the API.
+pill: never answer "is anything waiting for my approval" by pointing somewhere else. Source:
+the bar poller's cache, not a live API call.
 
 - **`count` = pending + STUCK.** `pending_count` is the `{open, ready_for_review}` half;
   `stuck_count` is `in_progress` tasks whose agent looks dead — excluding those is what hid a
@@ -172,8 +173,8 @@ So read them from the run, not from here. `report["caveats"]` is structured and 
 prints one footer line each **unconditionally**, so an agent that runs the script cold gets
 them anyway. The vocabulary is the keys of `CAVEATS` in `scripts/session-manager` —
 `claude_detection`, `fuzzyclaw_scope`, `kind_scope`, `ledger_scope`, `waiting_signal`,
-`unsent_prompt` — which `measured_caveats` fills in per scan. The script is the authority; a
-prose copy here could only rot, and this section was one for three of them.
+`unsent_prompt` — which `measured_caveats` fills in per scan. That list is gated against the
+script's own `CAVEATS`; the prose this section used to hold was not, and had rotted to five.
 
 ## 🔴 Read the exit code — the two zeroes are different facts
 

--- a/claude/skills/session-manager/SKILL.md
+++ b/claude/skills/session-manager/SKILL.md
@@ -8,7 +8,7 @@ description: "Live cross-host view of every tmux window on workbench + laptop �
 `scripts/session-manager`. One-shot, **read-only**, `--json`-first, both hosts.
 
 ```bash
-python3 $DEVRC/scripts/session-manager --json                      # everything
+python3 $DEVRC/scripts/session-manager --json --lean               # everything, agent-shaped
 python3 $DEVRC/scripts/session-manager --host workbench --no-ch    # fast + offline
 python3 $DEVRC/scripts/session-manager detail scratch7:3           # one window + prompts
 python3 $DEVRC/scripts/session-manager tail scratch7:3 --plain     # scrollback, no ANSI
@@ -19,66 +19,42 @@ level. Roll-ups: `summary.waiting`, `summary.unsent_prompt`, `summary.status[buc
 `summary.kind`, `clawgate_queue`. And `report["not_measured"]` for what this tool does **not**
 see at all.
 
-🔴 **`summary.status[bucket]` is one key per CLASS plus `total`** — `{claude, shell, total}`
-on every scan today. `claude` and `shell` are **always present** (pre-seeded, so a zero there
-is a real zero); every class **beyond** those two — `cluster`, `unknown_kind` — appears only
-when such a row exists, so the *absence* of a `cluster` key is not a measured zero. Same at
-the top level (`summary.claude`/`summary.shell` always; others on demand).
-
-🔴 **`kind` (row field) and `CLASS` (table column) are DIFFERENT axes — do not conflate.**
-`kind` is `tmux` | `cluster`: **what the entity is**. `CLASS` is `claude` | `shell` |
-`cluster`: **how it is counted**. Every row today is `kind: tmux`; `cluster` is enumerated
-for a clawgate dispatch with no pane and is **not produced yet**, which
-`caveats.kind_scope` states in the payload (`kinds_produced` is **measured from the rows**,
-not asserted). So an absence of cluster rows is **not** a measured absence of cluster work —
-clawgate lives in `clawgate_queue`, a different population that is never double-counted with
-these rows. `kind` is never null; `runtime` frequently is, and means something else
-(**which agent software**, from the ledger).
+🔴 **An ABSENT summary key is not a measured zero.** `summary.status[bucket]` pre-seeds
+`claude` and `shell`, so a zero in those is real and a missing `cluster` key is not. Same
+trap on the other axis: `kind` (row field — **what the entity is**) and `CLASS` (table
+column — **how it is counted**) are different, and `caveats.kind_scope` carries
+`kinds_produced` **measured from the rows** rather than asserted.
 
 | flag | effect |
 |---|---|
-| `--json` | JSON (default is a table). Compact, not indented — 34% of the payload was whitespace for a reader that does not exist |
-| `--lean` | 🔴 **with `--json`, prefer this.** The agent-shaped view: rows trimmed to the fields that answer this tool's question, **untruncated**, with every measurement discriminator and the caveats kept |
+| `--lean` | 🔴 **with `--json`, prefer this.** Rows trimmed to the fields that answer this tool's question, **untruncated**, every discriminator and caveat kept |
 | `--host workbench\|laptop\|all` | default `all`; `tail` resolves `all` to LOCAL |
-| `--claude-only` | drop the **shell** rows (`CLASS=shell`) — a `cluster` dispatch is an agent and is KEPT. Every count then describes the FILTERED set; `summary.excluded_shells` says how many went and `summary.kinds_excluded_by_filter` names any kind removed entirely |
-| `--no-ch` | skip ClickHouse — the client is never constructed |
-| `--no-capture` | skip the pane scrape; **every** `waiting_probable` AND `unsent_prompt` becomes `null` (both roll-up numbers `null`, never `0`) |
-| `--fuzzyclaw` / `--no-fuzzyclaw` | the task-file join is **OFF by default** (see below) |
-| `--no-ledger` | skip the per-host agent-ledger read. Rows then have **no age and no session id** — the #419 view, reproducible on demand |
-| `--plain` | `tail` only: strip ANSI at the source instead of `sed`-ing it out |
-| `--stale-threshold <secs>` | default 3600; `age >= threshold` is stale |
-| `--lines N` | `tail` scrollback depth (default 100) |
+| `--claude-only` | drop the **shell** rows (a `cluster` dispatch is an agent and is KEPT). Every count then describes the FILTERED set |
+| `--no-capture` | skip the pane scrape; **every** `waiting_probable` AND `unsent_prompt` becomes `null` (both roll-ups `null`, never `0`) |
+| `--no-ledger` | skip the ledger read → **no age, no session id** on any row |
+| `--fuzzyclaw` | the task-file join, **OFF by default** (see below) |
+
+`--json`, `--no-ch`, `--plain`, `--stale-threshold`, `--lines`, and what each drops:
+`~/.claude/skills/session-manager/reference/payload-contract.md`.
 
 ## 🔴 Which output to ask for — you are the only consumer
 
-Measured: **0 interactive shell invocations in 30 days against 55 agent references**, confirmed
-by the operator 2026-08-14. An agent reads this, and pays by the token.
+Measured: **0 interactive shell invocations in 30 days against 55 agent references**. An agent
+reads this, and pays by the token.
 
-| | cost on a 75-row scan | faithful? |
+| | cost, one 75-row scan | faithful? |
 |---|---|---|
-| table (default) | ~3,280 tok | ❌ **lossy** — 73 truncated cells, 45 rows whose task exceeds the 25-char column |
-| `--json` | ~14,017 tok | ✅ |
+| table (default) | ~3,280 tok | ❌ **lossy** — 73 truncated cells, 45 tasks over the 25-char column |
 | `--json --lean` | ~9,629 tok | ✅ on what it keeps |
+| `--json` | ~14,017 tok | ✅ |
 
-⚠ Those three figures were measured on ONE 75-row scan on 2026-08-14 and **predate the
-`unsent_prompt` pair and `not_measured`**, which add to all three. The RANKING is what the
-table is for and that is unchanged; do not quote the absolute numbers as current.
-
-**Ask for `--json --lean` unless you need a dropped field.** It is cheaper than the full payload
-AND more faithful than the cheap one. `lean_row_fields` and `lean_host_fields` travel in the payload
-naming exactly what this view CARRIES — so a key absent from a row was omitted by the view, never
-measured as null. `caveats`, `summary.waiting`'s tri-state, `clawgate_queue` and every per-host
-measurement status are kept in full, because a cheap payload that can lie is worse than an
-expensive one.
-
-Dropped from **rows** (8): `window_id`, `window_name`, `codename`, `pane_id`, `command`, `panes`,
-and the `ledger`/`fuzzyclaw` sub-objects — duplication, their useful contents are already flat on
-the row. `label_source` is deliberately KEPT: like `age_source` it is provenance, and it is the
-only thing separating a row labelled from a real directory from one labelled because the cwd
-yielded nothing.
-
-Dropped from **hosts** (2): `ssh_target` (fixed config the caller already knows) and
-`live_window_ids` (a ~346 B array no consumer reads).
+**Ask for `--json --lean` unless you need a dropped field** — cheaper than the full payload AND
+more faithful than the cheap one; `caveats`, the tri-states, `clawgate_queue` and every
+per-host measurement status are kept whole. ⚠ One scan, 2026-08-14, predating
+`unsent_prompt`/`not_measured` which add to all three: the RANKING is load-bearing, the
+absolute numbers are not current. `lean_row_fields`/`lean_host_fields` travel in the payload
+naming what the view CARRIES, so a key absent from a row was omitted by the view, never
+measured as null.
 
 ## 🔴 `waiting_probable` — is anything waiting on a HUMAN
 
@@ -96,158 +72,108 @@ scraped (one batched `capture-pane` per host) for three signals, and every row c
 "this window needs nothing."** Recall is partial by construction: measured on 40 live panes
 2026-08-12, a window parked on `Press Enter to continue…` matches none of them, and text
 typed at the `❯` prompt is deliberately **excluded** (a window one Enter away reads `no` —
-see `~/.claude/skills/session-manager/reference/waiting-signal.md` for the evidence and what would justify turning it on).
+the evidence, and what would justify turning it on, is in
+`~/.claude/skills/session-manager/reference/waiting-signal.md`).
 
-🔴 **`waiting_probable: null` is not `false`.** Read `waiting_status`: `ok` (scraped),
-`not_claude` (never scraped — the signals are Claude-TUI shapes and a shell's last line
-ending in `?` would be a false positive), `uncaptured` (the batch ran, this pane was not in
-it), `skipped` / `error`. `summary.waiting.probable` is likewise **`null`, never `0`**, when
-nothing was scraped — the one sentence this tool must never emit is "nothing is waiting on
-you" off a look that never happened.
+🔴 **`waiting_probable: null` is not `false`.** Read `waiting_status` — `ok` (scraped),
+`not_claude` (never scraped: the signals are Claude-TUI shapes, so a shell's last line ending
+in `?` would be a false positive), `uncaptured`, `skipped`, `error`.
+`summary.waiting.probable` is likewise **`null`, never `0`**, when nothing was scraped: the
+one sentence this tool must never emit is "nothing is waiting on you" off a look that never
+happened.
 
 ## 🔴 `unsent_prompt` — work PARKED one Enter away (a DIFFERENT question)
 
-Measured 2026-08-15 across all 79 panes on both hosts: **five** held text typed at the prompt
-and never sent — real work, some of it hours old — and the one-call answer reported none of
-them. So it is now measured, on the row as `unsent_prompt` (**the text**, so you can triage
-without opening the pane) plus `unsent_prompt_status`, and rolled up as
+Five of 79 panes held text typed at the prompt and never sent — real work, hours old — and the
+one-call answer reported none of them (2026-08-15). Now on the row as `unsent_prompt` (**the
+text**, so you can triage without opening the pane) + `unsent_prompt_status`, rolled up as
 `summary.unsent_prompt`.
 
 🔴 **It is NOT part of `waiting_probable` and is never summed into it.** The same sweep
-measured `waiting_probable` at **11 flagged, 11 true positives, ZERO false positives**. That
-precision is this tool's most valuable property and a noisier signal folded into it would
-destroy exactly that. Read both — they answer different questions:
+measured `waiting_probable` at **11 flagged, 11 true positives, ZERO false positives** — that
+precision is this tool's most valuable property, and a noisier signal folded in would destroy
+exactly it. Read both:
 
 | | means | |
 |---|---|---|
 | `waiting_probable` | this window is **BLOCKED** and cannot proceed without you | go unblock it |
 | `unsent_prompt` | this window has **WORK PARKED** in its input box | send it, or clear it |
 
-🔴 **Scoped to the pane's OWN input line, not "any matching line in the capture."** Only the
-lines *between the two box-drawing rules* are read, so scrollback, an echoed prompt, and a
-pane **displaying another session's transcript** cannot trip it — a live false positive of
-exactly that class already bit the `waiting` scrape.
+🔴 **A row can carry BOTH, and that is correct** — the agent asked a question and you
+half-typed a reply. Separation does not mean they never co-occur; it means neither can raise
+or be summed into the other.
 
-🔴 **`unsent_prompt: null` is an empty box ONLY when `unsent_prompt_status == "ok"`.** The
-statuses are `ok`, `no_input_box`, `uncaptured`, `not_claude`, `skipped`, `error`;
+🔴 **`unsent_prompt: null` is an empty box ONLY when `unsent_prompt_status == "ok"`.**
+Statuses: `ok`, `no_input_box`, `uncaptured`, `not_claude`, `skipped`, `error`; and
 `summary.unsent_prompt.count` is **`null`, never `0`**, when no box was read. `no_input_box`
-is a modal (which replaces the box) or a draft taller than the box — **unmeasured**, never
-"nothing typed". Shell panes are **never** scraped (`not_claude`): a half-typed shell command
-is a different and noisier thing.
+is a modal or a draft taller than the box — **unmeasured**, never "nothing typed". Shell panes
+are never scraped. Scoped to the pane's OWN input line (only the lines *between the two
+box-drawing rules*), so scrollback or a pane displaying another session's transcript cannot
+trip it.
 
 🔴 **NEVER PASTE A CAPTURED DRAFT INTO A COMMITTED FILE.** `unsent_prompt` hands you **text
 the operator typed**, and devrc is a **PUBLIC** repo — as is every `claudedocs/` note, commit
 message, PR body, comment or test fixture an agent writes into it. Report a draft as a
 **count, a length or a shape**, never verbatim. Quoting one back to Zach in chat is fine;
-writing one to a file that gets committed is not. (Four real drafts were quoted verbatim in
-`~/.claude/skills/session-manager/reference/waiting-signal.md` and re-used as fixtures before this rule existed —
-`test_no_FIXTURE_DRAFT_string_appears_in_a_shipped_doc` now fails on that shape.)
-
-🔴 **A row can carry BOTH, and that is correct** — the agent asked a question and you
-half-typed a reply. Separation does **not** mean the two never co-occur; it means neither
-signal can raise or be summed into the other. Read both columns.
+writing one to a file that gets committed is not.
+(`test_no_FIXTURE_DRAFT_string_appears_in_a_shipped_doc` fails on that shape — it has
+happened.)
 
 ## 🔴 `not_measured` — what this tool CANNOT see, and who owns it
 
 A blind dogfood found this tool "precise about what it measured but it does not tell a cold
-reader what it did **not** measure" — while **60 open PRs**, one conflicting for eleven days,
-sat outside every number it prints. `report["not_measured"]` names each such population and
-the **skill that answers it**: `pull_requests` → `standup`, `mail_queue` → `mailbox`,
-`cluster_alerts` → `standup`, `initiative_board` → `initiatives`,
-`gui_windows_outside_tmux` → `i3`.
+reader what it did **not** measure" — while **60 open PRs** sat outside every number it
+prints. `report["not_measured"]` names each such population and the **skill that answers
+it**: `pull_requests` → `standup`, `mail_queue` → `mailbox`, `cluster_alerts` → `standup`,
+`initiative_board` → `initiatives`, `gui_windows_outside_tmux` → `i3`.
 
 🔴 **It is DERIVED from the report's own keys, not a written-down list.** An entry is emitted
 only while the report carries no key for that population, so the day PR querying lands the
-claim stops being made with no edit anywhere. This file has shipped a constant masquerading
-as a measurement five times; a static list of "things we do not measure" is the same defect
-with a longer fuse. `clawgate_queue` (clawgate) is **not** listed — that one *is* measured.
+claim stops being made with no edit anywhere. This file has shipped a constant masquerading as
+a measurement five times; a static list of "things we do not measure" is the same defect with
+a longer fuse. `clawgate_queue` is **not** listed — that one *is* measured.
 
 ## 🔴 `clawgate_queue` — the clawgate approval queue
 
 🔴 **Renamed from `blocked_on_me` (2026-08-18).** The old name read as "everything waiting on
-you" and was measured doing exactly that damage: a caveat in this tool's own payload already
-said *"reading it as one is the misread this entry exists to prevent"*, and a reader made that
-misread anyway and shipped it into a brief for three subagents. A field name is read a hundred
-times for every once its caveat is, so the name changed rather than the wording.
-**For panes that look like they are waiting on a human, the field is `summary.waiting.probable`
-— a different population, never summed with this one.** No alias is kept: the old key is gone,
-and a test bans it at any depth in the payload, because a key that silently means something
-else is worse than a key that is absent.
+you"; a caveat in this tool's own payload already said so, and a reader made that misread
+anyway and shipped it into a brief for three subagents — a field name is read a hundred times
+for every once its caveat is. **For panes that look like they are waiting on a human the field
+is `summary.waiting.probable` — a different population, never summed with this one.** No alias
+is kept and a test bans the old key at any depth.
 
-Read from the bar poller's cache. It is here because an accurate cross-reference once cost
-real signal: a dogfooding agent read that the (now retired) `agent-ops` TUI had no JSON API,
-correctly preferred this script, never opened agent-ops, and **missed 11 pending approvals —
-four of them credential-exposure or cross-user-data-leak.** 🔴 With that TUI gone this
-section is the ONLY place the queue surfaces outside the bar pill, so the lesson binds
-harder, not less: never answer an "is anything waiting for my approval" question by pointing
-somewhere else.
+🔴 With the `agent-ops` TUI RETIRED this is the ONLY place the queue surfaces outside the bar
+pill: never answer "is anything waiting for my approval" by pointing somewhere else. Read from
+the bar poller's cache, not the API.
 
 - **`count` = pending + STUCK.** `pending_count` is the `{open, ready_for_review}` half;
-  `stuck_count` is `in_progress` tasks whose agent looks dead. The two always travel with
-  the total. 🔴 Excluding `in_progress` ("an agent is working = not on the human") is exactly
-  what hid a dispatch whose agent had been dead **four hours** — invisible on every surface,
-  because this script reads the poller's cache rather than the API. The predicate is
-  `scripts/lib/clawgate_tasks.py`, shared with the poller.
-- **`open` / `ready_for_review` / `stuck` ENUMERATE the queue** — a count that moves without
-  naming what moved is how three finished tasks appeared in no list anywhere. Each `stuck`
-  row carries `reasons` (`no_agent` / `agent_error` / `not_kicked_off` / `agent_idle` /
-  `activity_unknown`) and `agent_idle_secs`: **`idle 16m` and `idle 4h` are the same
-  boolean** and only one is worth acting on. Idle time cannot see progress *within* an
-  in-flight turn, so it errs toward a false alarm — the intended direction.
-- **`count` is the measurement; `detail` is not.** Nothing here parses it. Schema-2 detail
-  states its own cap (`(+N more)`); a schema-1 string truncated silently to ~6 ids and has
-  dropped `ready_for_review` items.
-- 🔴 **`schema_ok: false` means STUCK WAS NOT MEASURED, not zero stuck** — the cache came
-  from a poller predating the predicate (i.e. `home-manager switch` + restart
-  `bar-status-poll` has not happened yet). `stuck_count` is `null` in that case.
+  `stuck_count` is `in_progress` tasks whose agent looks dead — excluding those is what hid a
+  dispatch dead **four hours**. Predicate `scripts/lib/clawgate_tasks.py`, shared with the poller.
+- **`open` / `ready_for_review` / `stuck` ENUMERATE the queue**, each `stuck` row with its
+  `reasons` and `agent_idle_secs` — **`idle 16m` and `idle 4h` are the same boolean.**
+- 🔴 **`schema_ok: false` means STUCK WAS NOT MEASURED, not zero stuck** — the cache predates
+  the predicate (no `switch` + `bar-status-poll` restart yet); `stuck_count` is `null` there.
 - Four states: `ok` / `stale` (cache older than 300s — the poller writes every 45s) /
   `absent` / `unparseable`. The last three publish **`count: null`, never `0`**.
-- ⚠ **Nothing enumerates the queue with TASK TITLES any more.** `agent-ops` did — the tmux
-  popup on `$mod+i` / `prefix+A` / the ▦ bar button — and it is **RETIRED**; do not send a
-  reader there. The bar's clawgate pill carries the live count (`22!2` = 22 needing you, 2
-  stuck) and the **clawgate API** is where the titles are. The one part of agent-ops worth
-  keeping, its `/proc` walk that finds a `claude` buried under a wrapper shell, now lives in
-  `scripts/lib/claude_sessions.py` and feeds the bar's Claude-runs pill.
 
 ## `label` + `hotkey` — a name for the sessions the slot table never named
 
-`codename` is null for anything outside `tmux-scratch-slots.sh`; on the workbench that was
-9 of ~30 windows. Every row now also carries `label` (+ `label_source`, the tier that
-answered, + `hotkey`): **`codename`** if the session is a scratch slot → else the **leaf of
-the pane's cwd** (`path`) → else **`main`** (`fallback`, i.e. cwd was `$HOME`/`/`/empty).
-The table's old CODENAME column is now LABEL and renders `Grove (S)`.
+Every row carries `label` (+ `label_source`, + `hotkey`): **`codename`** if the session is a
+scratch slot → else the **leaf of the pane's cwd** → else **`main`** (`fallback`).
 
-🔴 **`hotkey` is the actionable half** — it is the `$mod+Shift+<k>` that gets you to the
-window, read from the slot table's own `key` field. It is **`null` (never `""`) on tiers 2
-and 3**: no binding exists for a session outside the table, so quoting a key there would
-send the operator to press something and land nowhere.
-
-🔴 **`label` is NOT an address — `session:window` still is.** Two sessions sitting in one
-repo resolve to the SAME label, so quote both. New non-scratch sessions get a real tmux name
-at creation from `scripts/tmux-autoname-session.sh`; `label` is what covers the ones that
-predate it.
+🔴 **`hotkey` is the actionable half** — the `$mod+Shift+<k>` that gets you there — and it is
+**`null` (never `""`) on tiers 2 and 3**: no binding exists, so quoting a key would send the
+operator to press something and land nowhere. 🔴 **`label` is NOT an address —
+`session:window` still is**; two sessions in one repo resolve to the SAME label, so quote both.
 
 ## The caveats are in the OUTPUT, not just in this file
 
-`report["caveats"]` (structured) + one footer line each in the table, printed
-unconditionally — an agent that runs the script cold never reads this file:
-
-- `claude_detection` — `pane_current_command =~ /claude/`; a claude under a wrapper shell
-  reads as `shell` (shallower than the `/proc` walk in `scripts/lib/claude_sessions.py`,
-  which is not reachable over SSH — so both hosts are reported by ONE rule).
-- `fuzzyclaw_scope` — `local_host_only`; a REMOTE row carries null `fuzzyclaw`. It says
-  **nothing** about age/session-id/stale (it used to, and that was wrong — see below).
-- `ledger_scope` — `per_host`; `age_secs` / `claude_session_id` come from the agent ledger,
-  read on EVERY scanned host, so a REMOTE row has both and **can** be `stale`.
-- `waiting_signal` — the enumerated signal set, the claude-rows-only scope, and the
-  prompt-text exclusion with its reason. 🔴 That text is still excluded from `waiting` but is
-  **no longer discarded** — the caveat points at `unsent_prompt`, which now carries it.
-- `unsent_prompt` — the status vocabulary, the claude-rows-only scope, and `separate_from:
-  waiting_probable` as a FIELD rather than a sentence a consumer has to parse.
-
-…plus `report["not_measured"]` and a `▸ NOT MEASURED HERE` section, which are the same idea
-one level out: not a qualification on a number this tool produced, but the list of
-populations it produced nothing about.
+So read them from the run, not from here. `report["caveats"]` is structured and the table
+prints one footer line each **unconditionally**, so an agent that runs the script cold gets
+them anyway. The vocabulary is the keys of `CAVEATS` in `scripts/session-manager` —
+`claude_detection`, `fuzzyclaw_scope`, `kind_scope`, `ledger_scope`, `waiting_signal`,
+`unsent_prompt` — which `measured_caveats` fills in per scan. The script is the authority; a
+prose copy here could only rot, and this section was one for three of them.
 
 ## 🔴 Read the exit code — the two zeroes are different facts
 
@@ -259,8 +185,6 @@ populations it produced nothing about.
 | `4` | **no** host could be reached — the zero is unmeasured, not measured |
 | `5` | **`tail` only**: the host answered and there is **no tmux server** on it |
 
-Rationale, and why 5 had to be split out of 3: `~/.claude/skills/session-manager/reference/exit-codes.md`.
-
 Same discipline inside the payload: `hosts.<n>.reachable`/`.error` describe the
 **`list-panes`** call, `.windows_measured`/`.windows_error` the **`list-windows`** call, and
 `.captures_measured`/`.captures_status` the **capture batch** — three independent
@@ -269,80 +193,62 @@ measurements, and one succeeding says nothing about the others. `clickhouse.stat
 
 ## fuzzyclaw is OFF by default
 
-Measured 2026-08-12: **29 live of 401 files, 363 stale, 9 slot-mismatched — and every one of
-the 29 live rows read `paused`**, including a window demonstrably running an agent. 29 table
-rows, zero contribution, from a source `CLAUDE.md` marks UNTRUSTED. Opt in with
-`--fuzzyclaw`; `--no-fuzzyclaw` still works and now names the default. Off, every count is
-`null` rather than `0`.
-
-The intersection guard is unchanged and still runs when you opt in — a task file survives
-only when its `window_id` is live **and** that live window's real `(session, index)` equals
-the one the file recorded. Why that relationship (not mere existence) is the guard, what the
-slot-conflict drop does and does not still catch, and the field ledger:
-`~/.claude/skills/session-manager/reference/fuzzyclaw-guard.md`.
+Measured 2026-08-12: 29 live of 401 task files and **every one of the 29 live rows read
+`paused`**, including a window demonstrably running an agent — 29 table rows, zero
+contribution, from a source `CLAUDE.md` marks UNTRUSTED. Opt in with `--fuzzyclaw`; off, every
+count is `null` rather than `0`. The intersection guard still runs when you do: a task file
+survives only when its `window_id` is live **and** that live window's real `(session, index)`
+equals the one the file recorded.
 
 ## The agent activity ledger — where age / `stale` / `claude_session_id` come from
 
-#419 switched fuzzyclaw off, which also switched off the only supplier of `age_secs`, the
-`stale` bucket derived from it, and the `claude_session_id` the ClickHouse join needs.
-Measured 2026-08-12 on the shipped default view: **0 rows with an age, 0 with a session id,
-no `stale` bucket at all** — and nothing in the output said so.
+Two writers record one file per tmux PANE into `~/.cache/agent-ledger/` — a devrc-owned Claude
+hook and an opencode plugin — read per host (locally and over SSH). Row fields: `age_secs`,
+`age_source` (`ledger`/`fuzzyclaw`/null — which SOURCE answered; the ledger wins), `runtime`
+(`claude`/`opencode`/null — which AGENT recorded it), `ledger`, `claude_session_id`.
 
-Two writers now record one file per tmux PANE into `~/.cache/agent-ledger/` — a devrc-owned
-Claude hook, and an opencode plugin — and the script reads each host's ledger with one `sh -c`
-(locally and over SSH). Read `report["ledger"]`, never just the row:
-
-- `status` — `ok` / `partial` (some host did not answer) / `error` / `skipped`. Only `ok`
-  and `partial` publish integers; the rest are `null`, never `0`.
-- `hosts.<host>` — per host: `live of seen`, its `tmux_pid`, and the rejections
-  (`not_live`, `generation_mismatch`, `unparseable`, `no_window`) plus
-  `generation_unchecked`, which counts records that were **kept while unverified**.
-- `summary.rows_with_age` / `rows_with_session_id` / `age_sources` — the meter. A `stale=0`
-  bucket means *either* nothing is stale *or* nothing has an age; only this tells them apart.
-
-Row fields: `age_secs`, `age_source` (`ledger` / `fuzzyclaw` / `null` — which SOURCE answered;
-the ledger wins), `runtime` (`claude` / `opencode` / `null` — which AGENT recorded it), `ledger`
-(the joined record), `claude_session_id`.
+🔴 **Read `report["ledger"]`, never just the row.** `status` is `ok` / `partial` / `error` /
+`skipped` and only the first two publish integers — the rest are `null`, never `0`;
+`summary.rows_with_age` is the meter separating a `stale=0` bucket that means *nothing is
+stale* from one that means *nothing has an age*.
 
 🔴 `runtime` is not `claude`. The `claude` column is `pane_current_command =~ /claude/`, so an
-opencode window reads `shell` — an agent counted as a bare prompt in every bucket. `runtime` is
-what the row says it actually is.
+opencode window reads `shell` — an agent counted as a bare prompt in every bucket.
 
-🔴 **A null age is not age 0** — it means no writer has recorded that window. A session that
-has not taken a turn since the hook was registered has none yet.
+🔴 **A null age is not age 0** — no writer has recorded that window yet.
 
-🔴 **Records carry the tmux SERVER pid and the reader checks it.** Window ids restart at `@0`
-when the server does, so after a reboot a stale `@41` record and a fresh `@41` window would
-otherwise collide and hand the new window a dead session's id. Spec:
+🔴 **Records carry the tmux SERVER pid and the reader checks it**, so after a reboot a stale
+`@41` cannot hand a fresh `@41` window a dead session's id. Spec:
 `claudedocs/spec-agent-activity-ledger.md`.
 
 ## Where everything lives
 
-| path | what |
-|---|---|
-| `scripts/session-manager` | the script |
-| `scripts/tests/test_session_manager.py` | the hermetic suite (mocks tmux, SSH, CH, FS) |
-| `scripts/tmux-scratch-slots.sh` | codename table |
-| `scripts/validation/chquery.py` | shared CH client — a LIBRARY, `sys.path`-inserted |
-| `~/.config/activity-collector/env` | CH endpoint + creds (never hardcoded) |
-| `~/.cache/bar-status/clawgate.json` | the clawgate-queue cache (`scripts/bar-status-poll`) |
-| `~/.tmux/tasks/*.json` | fuzzyclaw task files (UNTRUSTED) |
-| `~/.cache/agent-ledger/*.json` | the agent activity ledger, one record per pane |
-| `scripts/lib/agent_ledger.py` | its record shape, read protocol and join filter |
-| `scripts/claude-hooks/agent-ledger-hook.py` | writer 1 (Claude Code) |
+`scripts/tests/test_session_manager.py` is the hermetic suite (mocks tmux, SSH, CH, FS);
+`scripts/lib/agent_ledger.py` owns the ledger record shape. State it reads:
+`~/.cache/agent-ledger/*.json` (the ledger), `~/.cache/bar-status/clawgate.json` (the queue
+cache, written by `scripts/bar-status-poll`), `~/.tmux/tasks/*.json` (fuzzyclaw, UNTRUSTED),
+`scripts/tmux-scratch-slots.sh` (codenames).
 
-Reference: `waiting-signal.md`, `exit-codes.md`, `fuzzyclaw-guard.md`,
-`clickhouse-queries.md`, `cross-host.md`.
+**Reference topics** — each costs nothing until you open it:
+
+| load it when | file |
+|---|---|
+| reading `--json` field by field — every flag, summary buckets, the lean view, row/label tiers, what each caveat entry carries, ledger internals | `~/.claude/skills/session-manager/reference/payload-contract.md` |
+| changing or doubting the `waiting` / `unsent_prompt` detector | `~/.claude/skills/session-manager/reference/waiting-signal.md` |
+| a caller must branch on an exit code | `~/.claude/skills/session-manager/reference/exit-codes.md` |
+| reading the approval queue field by field | `~/.claude/skills/session-manager/reference/clawgate-queue.md` |
+| touching the fuzzyclaw task-file join | `~/.claude/skills/session-manager/reference/fuzzyclaw-guard.md` |
+| writing a ClickHouse query over the session history | `~/.claude/skills/session-manager/reference/clickhouse-queries.md` |
+| the SSH call, its failure taxonomy, or which host is which | `~/.claude/skills/session-manager/reference/cross-host.md` |
 
 ## Gotchas
 
-- Both hosts report `hostname` as `nixos`. The local label comes from `ACTIVITY_HOST` (env,
+- Both hosts report `hostname` as `nixos`; the local label comes from `ACTIVITY_HOST` (env,
   then the collector env file), defaulting to `workbench`.
 - `tmux` saying *"no server running"* is a **reachable** host with zero windows, not an
   unreachable one. Keep the two separate.
-- `signal` / `kill` are **not implemented, deliberately.** This tool never writes to,
-  signals or kills a window — which is the only reason it is safe to point at a live machine
-  holding 40+ windows of real work. A `waiting` flag is a read; acting on it is not. A
-  destructive verb needs its own PR and its own guards.
+- `signal` / `kill` are **not implemented, deliberately** — this tool never writes to, signals
+  or kills a window, which is the only reason it is safe to point at a live machine holding
+  40+ windows of real work. A `waiting` flag is a read; acting on it is not.
 - Merged ≠ deployed: this file only reaches `~/.claude/skills/` on a `home-manager switch` /
-  `ship.sh`. The script itself runs straight from the repo checkout.
+  `ship.sh`. The script runs straight from the repo checkout.

--- a/claude/skills/session-manager/reference/clawgate-queue.md
+++ b/claude/skills/session-manager/reference/clawgate-queue.md
@@ -46,9 +46,12 @@ somewhere else.
   `bar-status-poll` has not happened yet). `stuck_count` is `null` in that case.
 - Four states: `ok` / `stale` (cache older than 300s — the poller writes every 45s) /
   `absent` / `unparseable`. The last three publish **`count: null`, never `0`**.
-- ⚠ **Nothing enumerates the queue with TASK TITLES any more.** `agent-ops` did — the tmux
-  popup on `$mod+i` / `prefix+A` / the ▦ bar button — and it is **RETIRED**; do not send a
-  reader there. The bar's clawgate pill carries the live count (`22!2` = 22 needing you, 2
-  stuck) and the **clawgate API** is where the titles are. The one part of agent-ops worth
-  keeping, its `/proc` walk that finds a `claude` buried under a wrapper shell, now lives in
+- ⚠ **`agent-ops` used to be the titled enumeration and it is RETIRED** — the tmux popup on
+  `$mod+i` / `prefix+A` / the ▦ bar button. Do not send a reader there. **This tool replaced
+  it**: `clawgate_queue.open[]` / `.ready_for_review[]` / `.stuck[]` each carry `{id, title}`
+  (`stuck` also `reasons` + `agent_idle_secs`), read out of the poller's cache — so the titles
+  are here, no API call needed. Measured 2026-08-21: 63 / 19 / 5 rows, every one titled. The
+  bar's clawgate pill carries only the live count (`22!2` = 22 needing you, 2 stuck), which is
+  why the pill alone is not an answer. The one part of agent-ops worth keeping, its `/proc`
+  walk that finds a `claude` buried under a wrapper shell, now lives in
   `scripts/lib/claude_sessions.py` and feeds the bar's Claude-runs pill.

--- a/claude/skills/session-manager/reference/clawgate-queue.md
+++ b/claude/skills/session-manager/reference/clawgate-queue.md
@@ -1,0 +1,54 @@
+# `clawgate_queue` — the field ledger and the archaeology
+
+Loaded when you are reading the approval-queue block field by field, or want the
+evidence behind the rename and the `stuck` predicate. The SKILL body carries the claims
+a consumer must act on; this is the full text behind them.
+
+_Moved verbatim out of `SKILL.md` on 2026-08-21, when the body was cut from 23,233 B. The core keeps every load-bearing claim below in compressed form; this is the wording it was cut from, and the evidence behind it._
+
+## 🔴 `clawgate_queue` — the clawgate approval queue
+
+🔴 **Renamed from `blocked_on_me` (2026-08-18).** The old name read as "everything waiting on
+you" and was measured doing exactly that damage: a caveat in this tool's own payload already
+said *"reading it as one is the misread this entry exists to prevent"*, and a reader made that
+misread anyway and shipped it into a brief for three subagents. A field name is read a hundred
+times for every once its caveat is, so the name changed rather than the wording.
+**For panes that look like they are waiting on a human, the field is `summary.waiting.probable`
+— a different population, never summed with this one.** No alias is kept: the old key is gone,
+and a test bans it at any depth in the payload, because a key that silently means something
+else is worse than a key that is absent.
+
+Read from the bar poller's cache. It is here because an accurate cross-reference once cost
+real signal: a dogfooding agent read that the (now retired) `agent-ops` TUI had no JSON API,
+correctly preferred this script, never opened agent-ops, and **missed 11 pending approvals —
+four of them credential-exposure or cross-user-data-leak.** 🔴 With that TUI gone this
+section is the ONLY place the queue surfaces outside the bar pill, so the lesson binds
+harder, not less: never answer an "is anything waiting for my approval" question by pointing
+somewhere else.
+
+- **`count` = pending + STUCK.** `pending_count` is the `{open, ready_for_review}` half;
+  `stuck_count` is `in_progress` tasks whose agent looks dead. The two always travel with
+  the total. 🔴 Excluding `in_progress` ("an agent is working = not on the human") is exactly
+  what hid a dispatch whose agent had been dead **four hours** — invisible on every surface,
+  because this script reads the poller's cache rather than the API. The predicate is
+  `scripts/lib/clawgate_tasks.py`, shared with the poller.
+- **`open` / `ready_for_review` / `stuck` ENUMERATE the queue** — a count that moves without
+  naming what moved is how three finished tasks appeared in no list anywhere. Each `stuck`
+  row carries `reasons` (`no_agent` / `agent_error` / `not_kicked_off` / `agent_idle` /
+  `activity_unknown`) and `agent_idle_secs`: **`idle 16m` and `idle 4h` are the same
+  boolean** and only one is worth acting on. Idle time cannot see progress *within* an
+  in-flight turn, so it errs toward a false alarm — the intended direction.
+- **`count` is the measurement; `detail` is not.** Nothing here parses it. Schema-2 detail
+  states its own cap (`(+N more)`); a schema-1 string truncated silently to ~6 ids and has
+  dropped `ready_for_review` items.
+- 🔴 **`schema_ok: false` means STUCK WAS NOT MEASURED, not zero stuck** — the cache came
+  from a poller predating the predicate (i.e. `home-manager switch` + restart
+  `bar-status-poll` has not happened yet). `stuck_count` is `null` in that case.
+- Four states: `ok` / `stale` (cache older than 300s — the poller writes every 45s) /
+  `absent` / `unparseable`. The last three publish **`count: null`, never `0`**.
+- ⚠ **Nothing enumerates the queue with TASK TITLES any more.** `agent-ops` did — the tmux
+  popup on `$mod+i` / `prefix+A` / the ▦ bar button — and it is **RETIRED**; do not send a
+  reader there. The bar's clawgate pill carries the live count (`22!2` = 22 needing you, 2
+  stuck) and the **clawgate API** is where the titles are. The one part of agent-ops worth
+  keeping, its `/proc` walk that finds a `claude` buried under a wrapper shell, now lives in
+  `scripts/lib/claude_sessions.py` and feeds the bar's Claude-runs pill.

--- a/claude/skills/session-manager/reference/exit-codes.md
+++ b/claude/skills/session-manager/reference/exit-codes.md
@@ -102,7 +102,7 @@ _Moved verbatim out of `SKILL.md` on 2026-08-21, when the body was cut from 23,2
 | `4` | **no** host could be reached — the zero is unmeasured, not measured |
 | `5` | **`tail` only**: the host answered and there is **no tmux server** on it |
 
-Rationale, and why 5 had to be split out of 3: `~/.claude/skills/session-manager/reference/exit-codes.md`.
+Rationale, and why 5 had to be split out of 3: this file, below.
 
 Same discipline inside the payload: `hosts.<n>.reachable`/`.error` describe the
 **`list-panes`** call, `.windows_measured`/`.windows_error` the **`list-windows`** call, and

--- a/claude/skills/session-manager/reference/exit-codes.md
+++ b/claude/skills/session-manager/reference/exit-codes.md
@@ -86,3 +86,27 @@ the checkout. Between a `git pull` and the switch the two genuinely disagree, an
 the stale one. Settle it by reading the emitter, never the prose:
 `git grep -n 'excluded_' scripts/session-manager`, or just run a scan and look at the key.
 Same rule for every field named here.
+
+## The consumer-facing text, moved out of the SKILL body
+
+_Moved verbatim out of `SKILL.md` on 2026-08-21, when the body was cut from 23,233 B. The core keeps every load-bearing claim below in compressed form; this is the wording it was cut from, and the evidence behind it._
+
+
+## 🔴 Read the exit code — the two zeroes are different facts
+
+| code | meaning |
+|---|---|
+| `0` | ran, found windows (**including** a partial scan where one host was unreachable) |
+| `2` | usage / bad `<session>:<window>` / **`tail`: the host answered, no such window** |
+| `3` | every requested host answered and the answer is a **real zero** |
+| `4` | **no** host could be reached — the zero is unmeasured, not measured |
+| `5` | **`tail` only**: the host answered and there is **no tmux server** on it |
+
+Rationale, and why 5 had to be split out of 3: `~/.claude/skills/session-manager/reference/exit-codes.md`.
+
+Same discipline inside the payload: `hosts.<n>.reachable`/`.error` describe the
+**`list-panes`** call, `.windows_measured`/`.windows_error` the **`list-windows`** call, and
+`.captures_measured`/`.captures_status` the **capture batch** — three independent
+measurements, and one succeeding says nothing about the others. `clickhouse.status` must be
+`ok` before `rows: []` is believable. **Never read a bare count without its status.**
+

--- a/claude/skills/session-manager/reference/fuzzyclaw-guard.md
+++ b/claude/skills/session-manager/reference/fuzzyclaw-guard.md
@@ -115,5 +115,4 @@ rows, zero contribution, from a source `CLAUDE.md` marks UNTRUSTED. Opt in with
 The intersection guard is unchanged and still runs when you opt in — a task file survives
 only when its `window_id` is live **and** that live window's real `(session, index)` equals
 the one the file recorded. Why that relationship (not mere existence) is the guard, what the
-slot-conflict drop does and does not still catch, and the field ledger:
-`~/.claude/skills/session-manager/reference/fuzzyclaw-guard.md` — i.e. this file, above.
+slot-conflict drop does and does not still catch, and the field ledger: this file, above.

--- a/claude/skills/session-manager/reference/fuzzyclaw-guard.md
+++ b/claude/skills/session-manager/reference/fuzzyclaw-guard.md
@@ -99,3 +99,21 @@ integers are **gone** — a deliberate break in the loud direction, since keepin
 have left every reader on the mixed number while the fix sat in keys they never learned
 about. `summary["status"]["idle"]["total"]` is the same number and you have to type `total`
 to get it. All four buckets split, not just `idle`.
+
+## Why it was switched off — the measurement, moved out of the SKILL body
+
+_Moved verbatim out of `SKILL.md` on 2026-08-21, when the body was cut from 23,233 B. The core keeps every load-bearing claim below in compressed form; this is the wording it was cut from, and the evidence behind it._
+
+## fuzzyclaw is OFF by default
+
+Measured 2026-08-12: **29 live of 401 files, 363 stale, 9 slot-mismatched — and every one of
+the 29 live rows read `paused`**, including a window demonstrably running an agent. 29 table
+rows, zero contribution, from a source `CLAUDE.md` marks UNTRUSTED. Opt in with
+`--fuzzyclaw`; `--no-fuzzyclaw` still works and now names the default. Off, every count is
+`null` rather than `0`.
+
+The intersection guard is unchanged and still runs when you opt in — a task file survives
+only when its `window_id` is live **and** that live window's real `(session, index)` equals
+the one the file recorded. Why that relationship (not mere existence) is the guard, what the
+slot-conflict drop does and does not still catch, and the field ledger:
+`~/.claude/skills/session-manager/reference/fuzzyclaw-guard.md` — i.e. this file, above.

--- a/claude/skills/session-manager/reference/payload-contract.md
+++ b/claude/skills/session-manager/reference/payload-contract.md
@@ -1,0 +1,202 @@
+# The JSON payload contract — flags, counts, views, row fields, caveats
+
+Loaded when you are reading `--json` output field by field, when you need a flag the
+SKILL body's table does not list, or when you are wondering whether an absent key is a
+measured zero. 🔴 **The payload is the authority on all of it** — everything here was
+written against `scripts/session-manager` and can only ever be a snapshot of it.
+
+_Moved verbatim out of `SKILL.md` on 2026-08-21, when the body was cut from 23,233 B. The core keeps every load-bearing claim below in compressed form; this is the wording it was cut from, and the evidence behind it._
+
+## Every flag
+
+| flag | effect |
+|---|---|
+| `--json` | JSON (default is a table). Compact, not indented — 34% of the payload was whitespace for a reader that does not exist |
+| `--lean` | 🔴 **with `--json`, prefer this.** The agent-shaped view: rows trimmed to the fields that answer this tool's question, **untruncated**, with every measurement discriminator and the caveats kept |
+| `--host workbench\|laptop\|all` | default `all`; `tail` resolves `all` to LOCAL |
+| `--claude-only` | drop the **shell** rows (`CLASS=shell`) — a `cluster` dispatch is an agent and is KEPT. Every count then describes the FILTERED set; `summary.excluded_shells` says how many went and `summary.kinds_excluded_by_filter` names any kind removed entirely |
+| `--no-ch` | skip ClickHouse — the client is never constructed |
+| `--no-capture` | skip the pane scrape; **every** `waiting_probable` AND `unsent_prompt` becomes `null` (both roll-up numbers `null`, never `0`) |
+| `--fuzzyclaw` / `--no-fuzzyclaw` | the task-file join is **OFF by default** (see below) |
+| `--no-ledger` | skip the per-host agent-ledger read. Rows then have **no age and no session id** — the #419 view, reproducible on demand |
+| `--plain` | `tail` only: strip ANSI at the source instead of `sed`-ing it out |
+| `--stale-threshold <secs>` | default 3600; `age >= threshold` is stale |
+| `--lines N` | `tail` scrollback depth (default 100) |
+
+
+## Summary buckets, and `kind` vs `CLASS`
+
+🔴 **`summary.status[bucket]` is one key per CLASS plus `total`** — `{claude, shell, total}`
+on every scan today. `claude` and `shell` are **always present** (pre-seeded, so a zero there
+is a real zero); every class **beyond** those two — `cluster`, `unknown_kind` — appears only
+when such a row exists, so the *absence* of a `cluster` key is not a measured zero. Same at
+the top level (`summary.claude`/`summary.shell` always; others on demand).
+
+🔴 **`kind` (row field) and `CLASS` (table column) are DIFFERENT axes — do not conflate.**
+`kind` is `tmux` | `cluster`: **what the entity is**. `CLASS` is `claude` | `shell` |
+`cluster`: **how it is counted**. Every row today is `kind: tmux`; `cluster` is enumerated
+for a clawgate dispatch with no pane and is **not produced yet**, which
+`caveats.kind_scope` states in the payload (`kinds_produced` is **measured from the rows**,
+not asserted). So an absence of cluster rows is **not** a measured absence of cluster work —
+clawgate lives in `clawgate_queue`, a different population that is never double-counted with
+these rows. `kind` is never null; `runtime` frequently is, and means something else
+(**which agent software**, from the ledger).
+
+## 🔴 Which output to ask for — you are the only consumer
+
+Measured: **0 interactive shell invocations in 30 days against 55 agent references**, confirmed
+by the operator 2026-08-14. An agent reads this, and pays by the token.
+
+| | cost on a 75-row scan | faithful? |
+|---|---|---|
+| table (default) | ~3,280 tok | ❌ **lossy** — 73 truncated cells, 45 rows whose task exceeds the 25-char column |
+| `--json` | ~14,017 tok | ✅ |
+| `--json --lean` | ~9,629 tok | ✅ on what it keeps |
+
+⚠ Those three figures were measured on ONE 75-row scan on 2026-08-14 and **predate the
+`unsent_prompt` pair and `not_measured`**, which add to all three. The RANKING is what the
+table is for and that is unchanged; do not quote the absolute numbers as current.
+
+**Ask for `--json --lean` unless you need a dropped field.** It is cheaper than the full payload
+AND more faithful than the cheap one. `lean_row_fields` and `lean_host_fields` travel in the payload
+naming exactly what this view CARRIES — so a key absent from a row was omitted by the view, never
+measured as null. `caveats`, `summary.waiting`'s tri-state, `clawgate_queue` and every per-host
+measurement status are kept in full, because a cheap payload that can lie is worse than an
+expensive one.
+
+Dropped from **rows** (8): `window_id`, `window_name`, `codename`, `pane_id`, `command`, `panes`,
+and the `ledger`/`fuzzyclaw` sub-objects — duplication, their useful contents are already flat on
+the row. `label_source` is deliberately KEPT: like `age_source` it is provenance, and it is the
+only thing separating a row labelled from a real directory from one labelled because the cwd
+yielded nothing.
+
+Dropped from **hosts** (2): `ssh_target` (fixed config the caller already knows) and
+`live_window_ids` (a ~346 B array no consumer reads).
+
+
+## `label` + `hotkey` — a name for the sessions the slot table never named
+
+`codename` is null for anything outside `tmux-scratch-slots.sh`; on the workbench that was
+9 of ~30 windows. Every row now also carries `label` (+ `label_source`, the tier that
+answered, + `hotkey`): **`codename`** if the session is a scratch slot → else the **leaf of
+the pane's cwd** (`path`) → else **`main`** (`fallback`, i.e. cwd was `$HOME`/`/`/empty).
+The table's old CODENAME column is now LABEL and renders `Grove (S)`.
+
+🔴 **`hotkey` is the actionable half** — it is the `$mod+Shift+<k>` that gets you to the
+window, read from the slot table's own `key` field. It is **`null` (never `""`) on tiers 2
+and 3**: no binding exists for a session outside the table, so quoting a key there would
+send the operator to press something and land nowhere.
+
+🔴 **`label` is NOT an address — `session:window` still is.** Two sessions sitting in one
+repo resolve to the SAME label, so quote both. New non-scratch sessions get a real tmux name
+at creation from `scripts/tmux-autoname-session.sh`; `label` is what covers the ones that
+predate it.
+
+## The caveats are in the OUTPUT, not just in this file
+
+`report["caveats"]` (structured) + one footer line each in the table, printed
+unconditionally — an agent that runs the script cold never reads this file:
+
+- `claude_detection` — `pane_current_command =~ /claude/`; a claude under a wrapper shell
+  reads as `shell` (shallower than the `/proc` walk in `scripts/lib/claude_sessions.py`,
+  which is not reachable over SSH — so both hosts are reported by ONE rule).
+- `fuzzyclaw_scope` — `local_host_only`; a REMOTE row carries null `fuzzyclaw`. It says
+  **nothing** about age/session-id/stale (it used to, and that was wrong — see below).
+- `ledger_scope` — `per_host`; `age_secs` / `claude_session_id` come from the agent ledger,
+  read on EVERY scanned host, so a REMOTE row has both and **can** be `stale`.
+- `waiting_signal` — the enumerated signal set, the claude-rows-only scope, and the
+  prompt-text exclusion with its reason. 🔴 That text is still excluded from `waiting` but is
+  **no longer discarded** — the caveat points at `unsent_prompt`, which now carries it.
+- `unsent_prompt` — the status vocabulary, the claude-rows-only scope, and `separate_from:
+  waiting_probable` as a FIELD rather than a sentence a consumer has to parse.
+
+…plus `report["not_measured"]` and a `▸ NOT MEASURED HERE` section, which are the same idea
+one level out: not a qualification on a number this tool produced, but the list of
+populations it produced nothing about.
+
+## The agent activity ledger — where age / `stale` / `claude_session_id` come from
+
+#419 switched fuzzyclaw off, which also switched off the only supplier of `age_secs`, the
+`stale` bucket derived from it, and the `claude_session_id` the ClickHouse join needs.
+Measured 2026-08-12 on the shipped default view: **0 rows with an age, 0 with a session id,
+no `stale` bucket at all** — and nothing in the output said so.
+
+Two writers now record one file per tmux PANE into `~/.cache/agent-ledger/` — a devrc-owned
+Claude hook, and an opencode plugin — and the script reads each host's ledger with one `sh -c`
+(locally and over SSH). Read `report["ledger"]`, never just the row:
+
+- `status` — `ok` / `partial` (some host did not answer) / `error` / `skipped`. Only `ok`
+  and `partial` publish integers; the rest are `null`, never `0`.
+- `hosts.<host>` — per host: `live of seen`, its `tmux_pid`, and the rejections
+  (`not_live`, `generation_mismatch`, `unparseable`, `no_window`) plus
+  `generation_unchecked`, which counts records that were **kept while unverified**.
+- `summary.rows_with_age` / `rows_with_session_id` / `age_sources` — the meter. A `stale=0`
+  bucket means *either* nothing is stale *or* nothing has an age; only this tells them apart.
+
+Row fields: `age_secs`, `age_source` (`ledger` / `fuzzyclaw` / `null` — which SOURCE answered;
+the ledger wins), `runtime` (`claude` / `opencode` / `null` — which AGENT recorded it), `ledger`
+(the joined record), `claude_session_id`.
+
+🔴 `runtime` is not `claude`. The `claude` column is `pane_current_command =~ /claude/`, so an
+opencode window reads `shell` — an agent counted as a bare prompt in every bucket. `runtime` is
+what the row says it actually is.
+
+🔴 **A null age is not age 0** — it means no writer has recorded that window. A session that
+has not taken a turn since the hook was registered has none yet.
+
+🔴 **Records carry the tmux SERVER pid and the reader checks it.** Window ids restart at `@0`
+when the server does, so after a reboot a stale `@41` record and a fresh `@41` window would
+otherwise collide and hand the new window a dead session's id. Spec:
+`claudedocs/spec-agent-activity-ledger.md`.
+
+
+## 🔴 `not_measured` — what this tool CANNOT see, and who owns it
+
+A blind dogfood found this tool "precise about what it measured but it does not tell a cold
+reader what it did **not** measure" — while **60 open PRs**, one conflicting for eleven days,
+sat outside every number it prints. `report["not_measured"]` names each such population and
+the **skill that answers it**: `pull_requests` → `standup`, `mail_queue` → `mailbox`,
+`cluster_alerts` → `standup`, `initiative_board` → `initiatives`,
+`gui_windows_outside_tmux` → `i3`.
+
+🔴 **It is DERIVED from the report's own keys, not a written-down list.** An entry is emitted
+only while the report carries no key for that population, so the day PR querying lands the
+claim stops being made with no edit anywhere. This file has shipped a constant masquerading
+as a measurement five times; a static list of "things we do not measure" is the same defect
+with a longer fuse. `clawgate_queue` (clawgate) is **not** listed — that one *is* measured.
+
+
+
+## Where everything lives
+
+| path | what |
+|---|---|
+| `scripts/session-manager` | the script |
+| `scripts/tests/test_session_manager.py` | the hermetic suite (mocks tmux, SSH, CH, FS) |
+| `scripts/tmux-scratch-slots.sh` | codename table |
+| `scripts/validation/chquery.py` | shared CH client — a LIBRARY, `sys.path`-inserted |
+| `~/.config/activity-collector/env` | CH endpoint + creds (never hardcoded) |
+| `~/.cache/bar-status/clawgate.json` | the clawgate-queue cache (`scripts/bar-status-poll`) |
+| `~/.tmux/tasks/*.json` | fuzzyclaw task files (UNTRUSTED) |
+| `~/.cache/agent-ledger/*.json` | the agent activity ledger, one record per pane |
+| `scripts/lib/agent_ledger.py` | its record shape, read protocol and join filter |
+| `scripts/claude-hooks/agent-ledger-hook.py` | writer 1 (Claude Code) |
+
+🔴 _Corrected on the way out, rather than moved verbatim: the line here used to name five
+topics as bare basenames — not routes, so two of them (`clickhouse-queries.md`,
+`cross-host.md`) were reachable from nothing. **The registry is the table under "Reference
+topics" in `SKILL.md`**, and `scripts/tests/test_session_manager_skill_size.py` now fails on
+an orphan or a route that does not resolve. Do not re-create a second registry here._
+
+## Gotchas
+
+- Both hosts report `hostname` as `nixos`. The local label comes from `ACTIVITY_HOST` (env,
+  then the collector env file), defaulting to `workbench`.
+- `tmux` saying *"no server running"* is a **reachable** host with zero windows, not an
+  unreachable one. Keep the two separate.
+- `signal` / `kill` are **not implemented, deliberately.** This tool never writes to,
+  signals or kills a window — which is the only reason it is safe to point at a live machine
+  holding 40+ windows of real work. A `waiting` flag is a read; acting on it is not. A
+  destructive verb needs its own PR and its own guards.
+- Merged ≠ deployed: this file only reaches `~/.claude/skills/` on a `home-manager switch` /
+  `ship.sh`. The script itself runs straight from the repo checkout.

--- a/claude/skills/session-manager/reference/waiting-signal.md
+++ b/claude/skills/session-manager/reference/waiting-signal.md
@@ -266,3 +266,74 @@ the LOCAL host with the read-only scan (`--host workbench --no-ch --no-ledger`):
 🔴 **Scope of that run, stated:** local host only, one point in time. `no_input_box` did NOT
 occur on it, so that status is exercised by fixtures rather than by this observation — an
 unmeasured status here, not a measured zero.
+
+## The consumer-facing text, moved out of the SKILL body
+
+_Moved verbatim out of `SKILL.md` on 2026-08-21, when the body was cut from 23,233 B. The core keeps every load-bearing claim below in compressed form; this is the wording it was cut from, and the evidence behind it._
+
+## 🔴 `waiting_probable` — is anything waiting on a HUMAN
+
+`status: idle` merges four states that need four different actions. Each Claude pane is
+scraped (one batched `capture-pane` per host) for three signals, and every row carries the
+**matched line** so you can disagree with it:
+
+| signal | means | do |
+|---|---|---|
+| `trailing_question` | the agent's last sentence ends in `?` | answer it |
+| `selection_menu` | `❯ 1./2./3.` modal is up | press a key |
+| `context_exhausted` | `ctx: 0%` | `/clear` it |
+
+🔴 **`waiting_probable: false` means "these three were looked for and none matched" — NOT
+"this window needs nothing."** Recall is partial by construction: measured on 40 live panes
+2026-08-12, a window parked on `Press Enter to continue…` matches none of them, and text
+typed at the `❯` prompt is deliberately **excluded** (a window one Enter away reads `no` —
+see `~/.claude/skills/session-manager/reference/waiting-signal.md` for the evidence and what would justify turning it on).
+
+🔴 **`waiting_probable: null` is not `false`.** Read `waiting_status`: `ok` (scraped),
+`not_claude` (never scraped — the signals are Claude-TUI shapes and a shell's last line
+ending in `?` would be a false positive), `uncaptured` (the batch ran, this pane was not in
+it), `skipped` / `error`. `summary.waiting.probable` is likewise **`null`, never `0`**, when
+nothing was scraped — the one sentence this tool must never emit is "nothing is waiting on
+you" off a look that never happened.
+
+## 🔴 `unsent_prompt` — work PARKED one Enter away (a DIFFERENT question)
+
+Measured 2026-08-15 across all 79 panes on both hosts: **five** held text typed at the prompt
+and never sent — real work, some of it hours old — and the one-call answer reported none of
+them. So it is now measured, on the row as `unsent_prompt` (**the text**, so you can triage
+without opening the pane) plus `unsent_prompt_status`, and rolled up as
+`summary.unsent_prompt`.
+
+🔴 **It is NOT part of `waiting_probable` and is never summed into it.** The same sweep
+measured `waiting_probable` at **11 flagged, 11 true positives, ZERO false positives**. That
+precision is this tool's most valuable property and a noisier signal folded into it would
+destroy exactly that. Read both — they answer different questions:
+
+| | means | |
+|---|---|---|
+| `waiting_probable` | this window is **BLOCKED** and cannot proceed without you | go unblock it |
+| `unsent_prompt` | this window has **WORK PARKED** in its input box | send it, or clear it |
+
+🔴 **Scoped to the pane's OWN input line, not "any matching line in the capture."** Only the
+lines *between the two box-drawing rules* are read, so scrollback, an echoed prompt, and a
+pane **displaying another session's transcript** cannot trip it — a live false positive of
+exactly that class already bit the `waiting` scrape.
+
+🔴 **`unsent_prompt: null` is an empty box ONLY when `unsent_prompt_status == "ok"`.** The
+statuses are `ok`, `no_input_box`, `uncaptured`, `not_claude`, `skipped`, `error`;
+`summary.unsent_prompt.count` is **`null`, never `0`**, when no box was read. `no_input_box`
+is a modal (which replaces the box) or a draft taller than the box — **unmeasured**, never
+"nothing typed". Shell panes are **never** scraped (`not_claude`): a half-typed shell command
+is a different and noisier thing.
+
+🔴 **NEVER PASTE A CAPTURED DRAFT INTO A COMMITTED FILE.** `unsent_prompt` hands you **text
+the operator typed**, and devrc is a **PUBLIC** repo — as is every `claudedocs/` note, commit
+message, PR body, comment or test fixture an agent writes into it. Report a draft as a
+**count, a length or a shape**, never verbatim. Quoting one back to Zach in chat is fine;
+writing one to a file that gets committed is not. (Four real drafts were quoted verbatim in
+`~/.claude/skills/session-manager/reference/waiting-signal.md` and re-used as fixtures before this rule existed —
+`test_no_FIXTURE_DRAFT_string_appears_in_a_shipped_doc` now fails on that shape.)
+
+🔴 **A row can carry BOTH, and that is correct** — the agent asked a question and you
+half-typed a reply. Separation does **not** mean the two never co-occur; it means neither
+signal can raise or be summed into the other. Read both columns.

--- a/claude/skills/session-manager/reference/waiting-signal.md
+++ b/claude/skills/session-manager/reference/waiting-signal.md
@@ -287,7 +287,7 @@ scraped (one batched `capture-pane` per host) for three signals, and every row c
 "this window needs nothing."** Recall is partial by construction: measured on 40 live panes
 2026-08-12, a window parked on `Press Enter to continue…` matches none of them, and text
 typed at the `❯` prompt is deliberately **excluded** (a window one Enter away reads `no` —
-see `~/.claude/skills/session-manager/reference/waiting-signal.md` for the evidence and what would justify turning it on).
+the evidence, and what would justify turning it on, is in this file, below).
 
 🔴 **`waiting_probable: null` is not `false`.** Read `waiting_status`: `ok` (scraped),
 `not_claude` (never scraped — the signals are Claude-TUI shapes and a shell's last line
@@ -331,7 +331,7 @@ the operator typed**, and devrc is a **PUBLIC** repo — as is every `claudedocs
 message, PR body, comment or test fixture an agent writes into it. Report a draft as a
 **count, a length or a shape**, never verbatim. Quoting one back to Zach in chat is fine;
 writing one to a file that gets committed is not. (Four real drafts were quoted verbatim in
-`~/.claude/skills/session-manager/reference/waiting-signal.md` and re-used as fixtures before this rule existed —
+this file and re-used as fixtures before this rule existed —
 `test_no_FIXTURE_DRAFT_string_appears_in_a_shipped_doc` now fails on that shape.)
 
 🔴 **A row can carry BOTH, and that is correct** — the agent asked a question and you

--- a/scripts/tests/test_prune_skill_size.py
+++ b/scripts/tests/test_prune_skill_size.py
@@ -250,23 +250,48 @@ def _resolve_routing_path(token: str) -> Path:
     return _under_repo(SKILL_DIR, token)
 
 
-def _dangling_routes(body: str) -> list[str]:
+def dangling_routes_in(body: str, resolve) -> list[str]:
     """Direction 1 of the gate: routing paths in `body` that resolve to no file.
 
     Factored out so the probes at the bottom of this module grade THE GATE
     rather than a re-implementation of it. A probe that rebuilt this pipeline
     out of `_routing_paths` and `_resolve_routing_path` by hand would stay green
     against a mutation of the wiring between them.
+
+    🔴 AND PARAMETERISED BY `resolve`, NOT BOUND TO THIS SKILL. A second
+    size-gate module (`test_session_manager_skill_size.py`) gates a different
+    skill through the same tokenizer with its own resolver base, and it started
+    life with the pipeline open-coded inside each assertion AND again inside
+    each probe. Measured on that module before this refactor: forcing the
+    verdict to a constant (`dangling = sorted(set())`, `unrouted = []`) left all
+    nine of its routing tests GREEN -- the probes graded a copy, so the gate
+    could be deleted without a red. One rule, one place: both modules now bind
+    their own `resolve` to this body.
     """
-    return sorted(
-        {t for t in _routing_paths(body) if not _resolve_routing_path(t).is_file()}
-    )
+    return sorted({t for t in _routing_paths(body) if not resolve(t).is_file()})
+
+
+def unrouted_topics_in(registry: str, topics, reference_dir: Path, resolve) -> list[str]:
+    """Direction 2 of the gate: topics on disk the registry does not route to.
+
+    Takes the ALREADY-EXTRACTED registry block rather than the whole body: each
+    skill locates its own registry (different marker, different terminator), and
+    that extraction is the one part of the pipeline that is genuinely per-skill.
+    """
+    routed = {resolve(t) for t in _routing_paths(registry)}
+    return [t for t in topics if reference_dir / t not in routed]
+
+
+def _dangling_routes(body: str) -> list[str]:
+    """This skill's binding of `dangling_routes_in`."""
+    return dangling_routes_in(body, _resolve_routing_path)
 
 
 def _unrouted_topics(body: str) -> list[str]:
-    """Direction 2 of the gate: topics on disk the registry does not route to."""
-    routed = {_resolve_routing_path(t) for t in _routing_paths(_registry_block(body))}
-    return [t for t in _existing_topics() if REFERENCE_DIR / t not in routed]
+    """This skill's binding of `unrouted_topics_in`."""
+    return unrouted_topics_in(
+        _registry_block(body), _existing_topics(), REFERENCE_DIR, _resolve_routing_path
+    )
 
 
 def _existing_topics() -> list[str]:

--- a/scripts/tests/test_session_manager_skill_size.py
+++ b/scripts/tests/test_session_manager_skill_size.py
@@ -1,0 +1,307 @@
+"""Deterministic byte-size + routing gate for `claude/skills/session-manager/SKILL.md`.
+
+Lives in `scripts/tests/` for the reasons `test_prune_skill_size.py` states for
+the skill it gates: this directory is already a HERMETIC_TARGET, every hermetic
+target must start with `scripts/`, and keeping the test here stops it shipping
+into `~/.claude/skills/session-manager/` as dead weight in the deployed tree.
+
+WHY THIS EXISTS
+---------------
+`session-manager` was the largest skill body in the repo -- 23,233 B, ~6k tokens
+that displace the task the skill was loaded FOR, on every single invocation.
+It got there the way every skill body does: each real incident appended its
+lesson and nothing ever applied pressure the other way, because a SKILL.md costs
+zero until its trigger fires and then costs all of it at once. Prose budgets do
+not hold; `scripts/browser-bridge/tests/test_skill_size.py` and
+`scripts/tests/test_prune_skill_size.py` both document that failure for their own
+files. This is the same deterministic replacement, for this one.
+
+THE CEILING IS A RATCHET, AND IT SITS ABOVE THE 12,288 B TARGET
+---------------------------------------------------------------
+`scripts/skill-audit.py` targets 12,288 B and browser-bridge MEETS it, so the
+target is achievable in general and is not in dispute. This file does not meet
+it, deliberately, and the reason is recorded here rather than left to be
+rediscovered:
+
+The prune moved every procedure, field ledger, measurement and piece of
+archaeology out to `reference/` (7 topics, ~66 KB, zero cost until opened). What
+remains is almost entirely a set of claims that MUST be read at the moment of
+consumption, because each one exists to stop the tool being MISREAD in a way
+that has already happened:
+
+  * every null-vs-zero discriminator -- `waiting_probable: null` is not `false`,
+    `summary.unsent_prompt.count` is `null` never `0`, `clawgate_queue` publishes
+    `count: null` in three of its four states, `schema_ok: false` means stuck was
+    NOT measured. Demoting any of these behind a load is how "nothing is waiting
+    on you" gets emitted off a look that never happened;
+  * the `waiting_probable` / `unsent_prompt` separation, which is the reason
+    neither number is summed into the other;
+  * the `clawgate_queue` rename, which records a misread that shipped into a
+    brief for three subagents;
+  * the `not_measured` derivation, the exit-code table and the three independent
+    per-host measurement statuses;
+  * 🔴 the NEVER-PASTE-A-CAPTURED-DRAFT rule -- devrc is a PUBLIC repo and
+    `unsent_prompt` hands an agent text the operator typed.
+
+A guard the reader has to take a second load to see is not a guard, so those
+stay in the core and the ceiling is set where the demotion left the file. It
+forbids regrowth; it does not endorse the size. LOWERING it as more moves out is
+the intended direction of travel. Raising it needs the same kind of justification
+recorded above, in the commit that raises it.
+
+No figure derived from the file is restated in this docstring -- the constants
+below and the failure messages are the only place the numbers live, so there is
+nothing here that can go stale silently. (`test_prune_skill_size.py` gates its own
+docstring's arithmetic with a regex battery because that module states figures in
+prose. This one solves the same problem by not stating them.)
+"""
+from pathlib import Path
+
+import pytest
+
+# 🔴 ONE RULE, ONE PLACE. The tokenizer that decides what counts as a routing
+# path carries a lot of measured detail -- URL authorities, `..` containment,
+# trailing sentence punctuation, the dot-in-last-segment rule that keeps a bare
+# directory and a `<placeholder>` out of the route set -- and six spellings that
+# resolve to nothing walked through earlier hand-rolled versions of it. Import it
+# rather than growing a second copy that drifts.
+from test_prune_skill_size import (  # noqa: E402
+    PREFIX_BASES,
+    REPO_ROOT,
+    _routing_paths,
+    _under_repo,
+)
+
+SKILL_DIR = REPO_ROOT / "claude" / "skills" / "session-manager"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+REFERENCE_DIR = SKILL_DIR / "reference"
+
+# The hard ceiling: SKILL.md must never exceed this many bytes.
+#
+# A measured position, not a derivation: the file landed at 16,039 B after the
+# 2026-08-21 prune (23,233 -> 16,039, with 7 reference topics carrying the rest),
+# and 16,384 is the next 16 KiB boundary above it. See the docstring for why this
+# is above the 12,288 B target.
+MAX_BYTES = 16_384
+
+# Required working margin below the ceiling. A file sitting one byte under
+# technically holds the line but leaves no room for a one-line correction.
+#
+# Sized in units of a REAL edit, and DERIVED at test time rather than restated:
+# the structure that actually grows here is the reference routing table, so the
+# floor is one mean routing row. A hand-written literal would be the same
+# stale-figure defect `test_prune_skill_size.py` was bitten by three times.
+MIN_HEADROOM_ROWS = 1
+
+# The block the core uses as its reference registry -- the lines a reader loads
+# from. Located structurally; if the marker is gone the registry moved, and that
+# is a loud failure by design.
+REGISTRY_MARKER = "**Reference topics**"
+
+EVICTION_PLAYBOOK = (
+    "Do NOT raise MAX_BYTES to make this pass.\n"
+    "  Demote to reference/ instead -- and per the `prune-skill` skill's Sec.5, by\n"
+    "  VERBATIM LINE-RANGE SLICING (a python slice of the ORIGINAL, never retyping),\n"
+    "  then run its Sec.7 verification (un-sliced gap audit + a >=5-population\n"
+    "  survival check, one population being NUMBERS) over the result.\n"
+    "  Rewording does not work: measured on this very file during the 2026-08-21\n"
+    "  prune, a full hand-tightening pass over eight sections bought ~590 B, while\n"
+    "  moving whole sections out to reference/ bought over 6,000 B.\n"
+    "  What must NOT move out of the core, because a guard behind a second load is\n"
+    "  not a guard: any null-vs-zero discriminator, the waiting/unsent separation,\n"
+    "  the exit-code table, and the NEVER-PASTE-A-CAPTURED-DRAFT rule."
+)
+
+
+def _resolve_routing_path(token: str) -> Path:
+    """Where the string the core wrote actually points, resolved AS WRITTEN.
+
+    Same contract as `test_prune_skill_size._resolve_routing_path`, with this
+    skill's directory as the fallback base: a prefix that names the deployed
+    tree (`~/.claude/...`) or the repo root is settled IN-TREE, and anything
+    else resolves against the skill's own directory -- which is what a reader
+    following the core from there opens.
+
+    HERMETIC by construction: `_under_repo` keeps every resolution inside this
+    repo, so the verdict cannot depend on whether this host has ever run
+    `home-manager switch`.
+    """
+    for prefix, base in PREFIX_BASES:
+        if token.startswith(prefix):
+            return _under_repo(base, token[len(prefix):])
+    head = token.split("/", 1)[0]
+    if head not in ("", ".", "..") and (REPO_ROOT / head).is_dir():
+        return _under_repo(REPO_ROOT, token)
+    return _under_repo(SKILL_DIR, token)
+
+
+def _registry_block(body: str) -> str:
+    start = body.find(REGISTRY_MARKER)
+    assert start != -1, (
+        f"{REGISTRY_MARKER!r} not found in {SKILL_MD}. This test pins that block as "
+        "the core's reference registry; if the registry moved, re-point the test."
+    )
+    end = body.find("\n## ", start)
+    return body[start:] if end == -1 else body[start:end]
+
+
+def _existing_topics() -> list[str]:
+    """Reference topics that exist RIGHT NOW, read off the filesystem.
+
+    Globbed, never hard-coded: browser-bridge's hand-maintained literal drifted
+    to 8 of 11 and steered a maintainer into duplicating a topic that already
+    had a home.
+    """
+    return sorted(p.name for p in REFERENCE_DIR.glob("*.md"))
+
+
+def _routing_rows(body: str) -> list[str]:
+    return [
+        ln for ln in body.splitlines()
+        if ln.startswith("| ") and "reference/" in ln and "load it when" not in ln
+    ]
+
+
+def _min_headroom_bytes(body: str) -> int:
+    rows = _routing_rows(body)
+    assert rows, (
+        "no reference routing rows found -- the registry is not a table any more, "
+        "so the headroom floor cannot be derived from one. Re-point this helper."
+    )
+    return MIN_HEADROOM_ROWS * (sum(len(ln.encode()) + 1 for ln in rows) // len(rows))
+
+
+def test_skill_md_exists():
+    assert SKILL_MD.is_file(), f"{SKILL_MD} is missing -- did the skill move?"
+
+
+def test_skill_md_under_hard_ceiling():
+    size = SKILL_MD.stat().st_size
+    assert size <= MAX_BYTES, (
+        f"SKILL.md is {size:,} B, over the {MAX_BYTES:,} B ceiling by "
+        f"{size - MAX_BYTES:,} B.\n  " + EVICTION_PLAYBOOK
+    )
+
+
+def test_skill_md_keeps_working_headroom():
+    """Fire BEFORE the ceiling, so a breach is never a surprise."""
+    body = SKILL_MD.read_text(encoding="utf-8")
+    size = SKILL_MD.stat().st_size
+    headroom = MAX_BYTES - size
+    floor = _min_headroom_bytes(body)
+    assert headroom >= floor, (
+        f"SKILL.md is {size:,} B, leaving only {headroom:,} B under the "
+        f"{MAX_BYTES:,} B ceiling -- below the {floor:,} B working floor (one mean "
+        "reference routing row). The next routine edit will breach it. Evict now, "
+        "while there is still room to do it deliberately.\n  " + EVICTION_PLAYBOOK
+    )
+
+
+def test_every_reference_topic_is_routed_and_no_route_dangles():
+    """Both directions, and the positive control that keeps a ZERO readable.
+
+    An ORPHANED sidecar is unreachable content and it happens silently -- that
+    is exactly the state this skill was in before the prune: `clickhouse-queries.md`
+    and `cross-host.md` were NAME-DROPPED in a prose sentence ("Reference:
+    waiting-signal.md, exit-codes.md, ...") and routed by nothing, so a reader
+    following the core could not open either. A bare mention of a basename is not
+    a route.
+    """
+    body = SKILL_MD.read_text(encoding="utf-8")
+    topics = _existing_topics()
+    assert topics, f"no reference topics found under {REFERENCE_DIR}"
+
+    # 🔴 POSITIVE CONTROL FIRST. Everything below reports a count of PROBLEMS, and
+    # a zero from a tokenizer that saw nothing is indistinguishable from a zero
+    # from a clean file. Prove the instrument can see this body's routes at all
+    # before believing any zero it produces.
+    routes = _routing_paths(body)
+    assert len(routes) >= len(topics), (
+        f"the route tokenizer found {len(routes)} routing path(s) in SKILL.md but "
+        f"there are {len(topics)} reference topic(s). Either the core stopped "
+        "routing to them, or this gate is wired to nothing -- do not read the "
+        "assertions below as clean until this one holds."
+    )
+
+    dangling = sorted({t for t in routes if not _resolve_routing_path(t).is_file()})
+    assert not dangling, (
+        "the core writes routing paths that do not resolve to a file:\n"
+        + "\n".join(f"  {t}  ->  {_resolve_routing_path(t)}" for t in dangling)
+        + "\nA reader follows the pointer AS WRITTEN and lands nowhere. Fix the "
+        "path -- prefix, skill segment and extension all count -- or restore the file."
+    )
+
+    routed = {_resolve_routing_path(t) for t in _routing_paths(_registry_block(body))}
+    unrouted = [t for t in topics if REFERENCE_DIR / t not in routed]
+    assert not unrouted, (
+        f"reference topics exist but the core's registry does not route to them by "
+        f"a path that resolves to them: {unrouted}\n"
+        f"Routed by the registry: {sorted(str(p) for p in routed) or 'NOTHING'}.\n"
+        "A bare mention of the filename is NOT a route -- write the deployed path, "
+        "`~/.claude/skills/session-manager/reference/<topic>.md`. Either add the "
+        "routing line (the default -- an orphan is usually a demoted topic that "
+        "lost its pointer) or delete the file and say in the commit why it is dead."
+    )
+
+
+# ---------------------------------------------------------------------------
+# NEGATIVE CONTROLS -- a gate whose red has never been watched is a claim about
+# the gate, not about the file. Each case is planted into a copy of the REAL
+# body and graded by the REAL resolver, so a mutation anywhere in the pipeline
+# moves a verdict here.
+# ---------------------------------------------------------------------------
+
+_TOPIC = "payload-contract.md"
+
+
+def _plant(spelling: str) -> str:
+    return SKILL_MD.read_text(encoding="utf-8") + "\n\nPlanted: " + spelling + "\n"
+
+
+@pytest.mark.parametrize(
+    "spelling",
+    [
+        # The deployed prefix with one character wrong in the skill segment.
+        "`~/.claude/skills/session-managr/reference/payload-contract.md`",
+        # A topic that does not exist.
+        "`~/.claude/skills/session-manager/reference/does-not-exist.md`",
+        # Another skill's directory.
+        "`~/.claude/skills/browser/reference/payload-contract.md`",
+    ],
+    ids=["wrong-skill-segment", "missing-topic", "other-skills-dir"],
+)
+def test_a_planted_dangling_route_is_reported(spelling):
+    body = _plant(spelling)
+    dangling = [t for t in _routing_paths(body) if not _resolve_routing_path(t).is_file()]
+    assert dangling, (
+        f"planting {spelling} left the gate GREEN. A reader follows that pointer "
+        "AS WRITTEN and lands nowhere; the gate must say so."
+    )
+
+
+def test_a_registry_of_bare_prose_mentions_routes_nothing():
+    """The pre-prune shape, executed: a filename name-dropped in prose is not a
+    route, so every topic must read as an orphan."""
+    body = SKILL_MD.read_text(encoding="utf-8")
+    prose = (
+        REGISTRY_MARKER + ":\n\n"
+        + "Reference: " + ", ".join(_existing_topics()) + ".\n"
+    )
+    rewritten = body.replace(_registry_block(body), prose)
+    assert rewritten != body, "fixture broken: the registry block was not replaced"
+    routed = {
+        _resolve_routing_path(t) for t in _routing_paths(_registry_block(rewritten))
+    }
+    unrouted = [t for t in _existing_topics() if REFERENCE_DIR / t not in routed]
+    assert unrouted == _existing_topics()
+
+
+def test_the_deployed_spelling_is_never_stat_where_it_points():
+    """HERMETICITY: the `~/.claude/...` route is settled IN-TREE, so the verdict
+    is the same in a fresh clone and on a host that has never deployed."""
+    token = f"~/.claude/skills/session-manager/reference/{_TOPIC}"
+    resolved = _resolve_routing_path(token)
+    assert resolved == REFERENCE_DIR / _TOPIC, (
+        f"{token} resolved to {resolved} -- the gate is reading the deployed tree, "
+        "so its verdict depends on machine state."
+    )

--- a/scripts/tests/test_session_manager_skill_size.py
+++ b/scripts/tests/test_session_manager_skill_size.py
@@ -1,4 +1,5 @@
-"""Deterministic byte-size + routing gate for `claude/skills/session-manager/SKILL.md`.
+"""Deterministic byte-size + routing + PROTECTED-CLAIM gate for
+`claude/skills/session-manager/SKILL.md`.
 
 Lives in `scripts/tests/` for the reasons `test_prune_skill_size.py` states for
 the skill it gates: this directory is already a HERMETIC_TARGET, every hermetic
@@ -27,34 +28,42 @@ The prune moved every procedure, field ledger, measurement and piece of
 archaeology out to `reference/` (7 topics, ~66 KB, zero cost until opened). What
 remains is almost entirely a set of claims that MUST be read at the moment of
 consumption, because each one exists to stop the tool being MISREAD in a way
-that has already happened:
+that has already happened -- the null-vs-zero discriminators, the
+waiting/unsent separation, the exit-code table, the NEVER-PASTE rule. A guard
+the reader has to take a second load to see is not a guard, so those stay in the
+core and the ceiling is set where the demotion left the file.
 
-  * every null-vs-zero discriminator -- `waiting_probable: null` is not `false`,
-    `summary.unsent_prompt.count` is `null` never `0`, `clawgate_queue` publishes
-    `count: null` in three of its four states, `schema_ok: false` means stuck was
-    NOT measured. Demoting any of these behind a load is how "nothing is waiting
-    on you" gets emitted off a look that never happened;
-  * the `waiting_probable` / `unsent_prompt` separation, which is the reason
-    neither number is summed into the other;
-  * the `clawgate_queue` rename, which records a misread that shipped into a
-    brief for three subagents;
-  * the `not_measured` derivation, the exit-code table and the three independent
-    per-host measurement statuses;
-  * 🔴 the NEVER-PASTE-A-CAPTURED-DRAFT rule -- devrc is a PUBLIC repo and
-    `unsent_prompt` hands an agent text the operator typed.
+🔴 THAT JUSTIFICATION IS NOW ENFORCED, NOT ASSERTED. It used to be prose only:
+an audit MUTATED all four protected claims -- deleted the exit-code `4` row,
+rewrote `schema_ok: false` to "means zero stuck", turned
+`summary.waiting.probable` "`null`, never `0`" into "`0`", and INVERTED the
+waiting/unsent separation -- and all four survived a fully green 584-test suite.
+The module's entire argument for sitting over the target was a set nothing
+checked, which is the "a guard's DESCRIPTION claims COVERAGE while its body
+covers one side" shape `claude/RULES.md` names. `PROTECTED_CLAIMS` below is the
+machine-readable version of the paragraph above, each entry pinned as a WHOLE
+NORMALISED STRING (a keyword check is walkable by rewording, and "`null`, never
+`0`" -> "`0`" is exactly a reword). The eviction playbook's list of what may not
+move out is GENERATED from it, so the sentence a maintainer reads cannot be
+wider than the check that backs it. The cost is real and accepted: a cosmetic
+reword of a protected sentence fails this suite, and the fix is to update the
+pin in the same commit -- that is the trade for a machine-readable claim.
 
-A guard the reader has to take a second load to see is not a guard, so those
-stay in the core and the ceiling is set where the demotion left the file. It
-forbids regrowth; it does not endorse the size. LOWERING it as more moves out is
-the intended direction of travel. Raising it needs the same kind of justification
-recorded above, in the commit that raises it.
+The ceiling forbids regrowth; it does not endorse the size. LOWERING it as more
+moves out is the intended direction of travel. Raising it needs the same kind of
+justification recorded above, in the commit that raises it.
 
-No figure derived from the file is restated in this docstring -- the constants
-below and the failure messages are the only place the numbers live, so there is
-nothing here that can go stale silently. (`test_prune_skill_size.py` gates its own
-docstring's arithmetic with a regex battery because that module states figures in
-prose. This one solves the same problem by not stating them.)
+No figure derived from the CURRENT file is restated in this docstring -- the
+constants below and the failure messages are the only place those numbers live,
+so there is nothing here that can go stale silently. (An earlier revision made
+exactly that mistake anyway: it restated a post-prune size that was already
+120 B out of date on the branch that introduced it. The number is gone rather
+than corrected. `test_prune_skill_size.py` gates its own docstring's arithmetic
+with a regex battery because that module states figures in prose; this one
+solves the same problem by not stating them.)
 """
+import ast
+import re
 from pathlib import Path
 
 import pytest
@@ -65,23 +74,36 @@ import pytest
 # directory and a `<placeholder>` out of the route set -- and six spellings that
 # resolve to nothing walked through earlier hand-rolled versions of it. Import it
 # rather than growing a second copy that drifts.
+#
+# 🔴 AND THE TWO GATE DIRECTIONS THEMSELVES, for a sharper reason. This module
+# used to compute `dangling` and `unrouted` inline in the assertion AND again,
+# by hand, in each probe below. Measured by an audit: forcing the verdict to a
+# constant (`dangling = sorted(set())`, `unrouted = []`) left all NINE routing
+# tests green -- the four planted-route probes, this module's only evidence that
+# the routing gate works, graded a re-implementation rather than the gate. The
+# sibling factored `dangling_routes_in`/`unrouted_topics_in` out for precisely
+# that failure; both modules bind their own resolver to them now.
 from test_prune_skill_size import (  # noqa: E402
     PREFIX_BASES,
     REPO_ROOT,
     _routing_paths,
     _under_repo,
+    dangling_routes_in,
+    unrouted_topics_in,
 )
 
 SKILL_DIR = REPO_ROOT / "claude" / "skills" / "session-manager"
 SKILL_MD = SKILL_DIR / "SKILL.md"
 REFERENCE_DIR = SKILL_DIR / "reference"
+SESSION_MANAGER = REPO_ROOT / "scripts" / "session-manager"
 
 # The hard ceiling: SKILL.md must never exceed this many bytes.
 #
-# A measured position, not a derivation: the file landed at 16,039 B after the
-# 2026-08-21 prune (23,233 -> 16,039, with 7 reference topics carrying the rest),
-# and 16,384 is the next 16 KiB boundary above it. See the docstring for why this
-# is above the 12,288 B target.
+# A measured position, not a derivation: 16,384 is the 16 KiB boundary
+# immediately above where the 2026-08-21 prune left the file, with 7 reference
+# topics carrying what came out. The post-prune size itself is deliberately NOT
+# restated here -- see the docstring. Where this file actually sits is printed
+# by the failure messages below, which read it at test time.
 MAX_BYTES = 16_384
 
 # Required working margin below the ceiling. A file sitting one byte under
@@ -98,6 +120,112 @@ MIN_HEADROOM_ROWS = 1
 # is a loud failure by design.
 REGISTRY_MARKER = "**Reference topics**"
 
+# The core's enumeration of the caveat vocabulary, bracketed by the two phrases
+# that introduce and close it. A prose list of a set ANOTHER file owns is the
+# exact defect the 2026-08-21 prune was opened to fix -- the section it deleted
+# listed five of the six `CAVEATS` keys, `kind_scope` missing, and nothing
+# noticed. The replacement pointer kept a six-key enumeration, so the defect was
+# re-created at one sixth the size: an audit dropped `kind_scope` from the new
+# list and invented a seventh key, and each left the suite green.
+CAVEAT_LIST_HEAD = "The vocabulary is the keys of `CAVEATS` in `scripts/session-manager` —"
+CAVEAT_LIST_TAIL = "— which `measured_caveats` fills in per scan."
+
+
+def _norm(text: str) -> str:
+    """Whitespace-run normalisation, and nothing else.
+
+    Line WRAPPING is cosmetic and must not decide a verdict; wording is not.
+    Same normaliser `test_session_manager.py` uses for its whole-string prose
+    pins, so a sentence pinned in both places is pinned the same way.
+    """
+    return " ".join(text.split())
+
+
+# ---------------------------------------------------------------------------
+# 🔴 THE PROTECTED CLAIMS -- the ceiling's entire justification, as data.
+#
+# Each entry is a claim that may NOT leave the core, pinned as one or more WHOLE
+# NORMALISED STRINGS. Whole strings, never keywords: `claude/RULES.md` -- "when
+# the artifact under test IS prose, a guard on WORDS is walkable by REWORDING --
+# pin the WHOLE normalised string", and every mutation that survived the audit
+# was a reword, not a deletion.
+#
+# The NEVER-PASTE rule is pinned here as well as by
+# `test_session_manager.py::test_BOTH_shipped_docs_carry_the_NEVER_PASTE_A_
+# CAPTURED_DRAFT_rule`, and that is not duplication: the sibling pins a
+# RELATIONSHIP (the core and the reference both carry it), this pins a
+# CONSEQUENCE OF THIS MODULE'S CEILING (it did not get evicted by someone making
+# room). Deleting either leaves a real gap.
+# ---------------------------------------------------------------------------
+PROTECTED_CLAIMS: dict[str, tuple[str, ...]] = {
+    "the exit-code table": (
+        # The WHOLE table, header rules included, so deleting or rewriting ANY
+        # row reds -- the audit deleted the `4` row specifically, and `4` is the
+        # row that separates an unmeasured zero from a measured one.
+        "| code | meaning |\n"
+        "|---|---|\n"
+        "| `0` | ran, found windows (**including** a partial scan where one host "
+        "was unreachable) |\n"
+        "| `2` | usage / bad `<session>:<window>` / **`tail`: the host answered, "
+        "no such window** |\n"
+        "| `3` | every requested host answered and the answer is a **real zero** |\n"
+        "| `4` | **no** host could be reached — the zero is unmeasured, not measured |\n"
+        "| `5` | **`tail` only**: the host answered and there is **no tmux server** "
+        "on it |",
+    ),
+    "the null-vs-zero discriminators": (
+        # `--no-capture` collapses BOTH signals to null, and the roll-ups with them.
+        "**every** `waiting_probable` AND `unsent_prompt` becomes `null` (both "
+        "roll-ups `null`, never `0`)",
+        # `waiting_probable`: null is not false, and the roll-up is null not 0.
+        "🔴 **`waiting_probable: null` is not `false`.**",
+        "`summary.waiting.probable` is likewise **`null`, never `0`**, when nothing "
+        "was scraped: the one sentence this tool must never emit is \"nothing is "
+        "waiting on you\" off a look that never happened.",
+        # `unsent_prompt`: the same pair, plus the unmeasured status.
+        "🔴 **`unsent_prompt: null` is an empty box ONLY when "
+        "`unsent_prompt_status == \"ok\"`.**",
+        "`summary.unsent_prompt.count` is **`null`, never `0`**, when no box was "
+        "read.",
+        # clawgate_queue: the two the audit rewrote.
+        "🔴 **`schema_ok: false` means STUCK WAS NOT MEASURED, not zero stuck**",
+        "The last three publish **`count: null`, never `0`**.",
+        # the ledger and the age field. Whole sentences, not the `null, never
+        # 0` fragment on its own: a fragment survives a reword of everything
+        # around it, which is the walk this whole battery exists to close.
+        "`status` is `ok` / `partial` / `error` / `skipped` and only the first two "
+        "publish integers — the rest are `null`, never `0`; "
+        "`summary.rows_with_age` is the meter separating a `stale=0` bucket that "
+        "means *nothing is stale* from one that means *nothing has an age*.",
+        "🔴 **A null age is not age 0** — no writer has recorded that window yet.",
+    ),
+    "the waiting/unsent separation": (
+        "🔴 **It is NOT part of `waiting_probable` and is never summed into it.**",
+        # The two-row table that says what each one means and what to DO. An
+        # inversion has to rewrite this to survive.
+        "| `waiting_probable` | this window is **BLOCKED** and cannot proceed "
+        "without you | go unblock it |\n"
+        "| `unsent_prompt` | this window has **WORK PARKED** in its input box | "
+        "send it, or clear it |",
+        # Separation is not disjointness -- suppressing co-occurrence would make
+        # the tool worse, and the reference was corrected for claiming otherwise.
+        "🔴 **A row can carry BOTH, and that is correct** — the agent asked a "
+        "question and you half-typed a reply. Separation does not mean they never "
+        "co-occur; it means neither can raise or be summed into the other.",
+        # and the same separation stated from the clawgate_queue side.
+        "**For panes that look like they are waiting on a human the field is "
+        "`summary.waiting.probable` — a different population, never summed with "
+        "this one.**",
+    ),
+    "the NEVER-PASTE-A-CAPTURED-DRAFT rule": (
+        "🔴 **NEVER PASTE A CAPTURED DRAFT INTO A COMMITTED FILE.** "
+        "`unsent_prompt` hands you **text the operator typed**, and devrc is a "
+        "**PUBLIC** repo — as is every `claudedocs/` note, commit message, PR "
+        "body, comment or test fixture an agent writes into it. Report a draft as "
+        "a **count, a length or a shape**, never verbatim.",
+    ),
+}
+
 EVICTION_PLAYBOOK = (
     "Do NOT raise MAX_BYTES to make this pass.\n"
     "  Demote to reference/ instead -- and per the `prune-skill` skill's Sec.5, by\n"
@@ -108,8 +236,10 @@ EVICTION_PLAYBOOK = (
     "  prune, a full hand-tightening pass over eight sections bought ~590 B, while\n"
     "  moving whole sections out to reference/ bought over 6,000 B.\n"
     "  What must NOT move out of the core, because a guard behind a second load is\n"
-    "  not a guard: any null-vs-zero discriminator, the waiting/unsent separation,\n"
-    "  the exit-code table, and the NEVER-PASTE-A-CAPTURED-DRAFT rule."
+    "  not a guard (this list is GENERATED from PROTECTED_CLAIMS, so it cannot\n"
+    "  claim more than is checked):\n"
+    + "".join(f"    - {name}\n" for name in PROTECTED_CLAIMS)
+    + "  Each is pinned as a whole normalised string; evicting one fails this suite."
 )
 
 
@@ -155,6 +285,25 @@ def _existing_topics() -> list[str]:
     return sorted(p.name for p in REFERENCE_DIR.glob("*.md"))
 
 
+def _dangling_routes(body: str) -> list[str]:
+    """This skill's binding of the sibling's direction-1 gate."""
+    return dangling_routes_in(body, _resolve_routing_path)
+
+
+def _unrouted_topics(body: str, topics: list[str] | None = None) -> list[str]:
+    """This skill's binding of the sibling's direction-2 gate.
+
+    `topics` is injectable ONLY so a probe can hand it a topic that is not on
+    disk yet; the gate itself always passes the globbed set.
+    """
+    return unrouted_topics_in(
+        _registry_block(body),
+        _existing_topics() if topics is None else topics,
+        REFERENCE_DIR,
+        _resolve_routing_path,
+    )
+
+
 def _routing_rows(body: str) -> list[str]:
     return [
         ln for ln in body.splitlines()
@@ -171,16 +320,114 @@ def _min_headroom_bytes(body: str) -> int:
     return MIN_HEADROOM_ROWS * (sum(len(ln.encode()) + 1 for ln in rows) // len(rows))
 
 
+def _ceiling_overshoot(size: int) -> int:
+    """Bytes by which `size` breaches the ceiling; 0 when it does not.
+
+    A NAMED predicate rather than `size <= MAX_BYTES` inline, so the BOUNDARY is
+    reachable by a fixture. Written inline it is one character from rejecting a
+    file that sits exactly ON the ceiling, and no real file ever sits there --
+    so that mutant survives a green suite. `test_the_ceiling_boundary_is_
+    inclusive` feeds it MAX_BYTES-1 / MAX_BYTES / MAX_BYTES+1 and watches the
+    answer move.
+    """
+    return max(0, size - MAX_BYTES)
+
+
+def _missing_protected_claims(body: str) -> list[tuple[str, str]]:
+    """Every protected claim NOT present in `body`, as `(claim name, sentence)`.
+
+    One implementation, used by the gate AND by the mutation probes below, for
+    the reason the routing helpers are shared: a probe that re-implemented the
+    lookup would stay green against a mutation of the gate.
+    """
+    haystack = _norm(body)
+    return [
+        (name, sentence)
+        for name, sentences in PROTECTED_CLAIMS.items()
+        for sentence in sentences
+        if _norm(sentence) not in haystack
+    ]
+
+
+def _script_caveat_keys() -> list[str]:
+    """The keys of `CAVEATS` in `scripts/session-manager`, read by `ast`.
+
+    Parsed rather than imported: the script is 4k lines with import-time work,
+    and the only thing wanted here is a literal. Parsed rather than grepped:
+    a regex over a dict spanning ~150 lines of commentary that itself quotes
+    key names is how a "count of declarations" becomes wrong.
+    """
+    tree = ast.parse(SESSION_MANAGER.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == "CAVEATS" for t in node.targets):
+            continue
+        assert isinstance(node.value, ast.Dict), (
+            f"`CAVEATS` in {SESSION_MANAGER} is no longer a dict literal, so this "
+            "gate can no longer read its keys. Re-point it."
+        )
+        keys = [k.value for k in node.value.keys
+                if isinstance(k, ast.Constant) and isinstance(k.value, str)]
+        assert len(keys) == len(node.value.keys), (
+            f"a `CAVEATS` key in {SESSION_MANAGER} is not a plain string literal; "
+            "this gate cannot read the vocabulary."
+        )
+        return keys
+    raise AssertionError(
+        f"no `CAVEATS = {{...}}` assignment found in {SESSION_MANAGER} -- the "
+        "caveat vocabulary moved, and the core's prose list is now ungated."
+    )
+
+
+def _cores_caveat_list(body: str) -> list[str]:
+    """The caveat keys the core ENUMERATES, between its two anchor phrases."""
+    text = _norm(body)
+    head, tail = _norm(CAVEAT_LIST_HEAD), _norm(CAVEAT_LIST_TAIL)
+    start = text.find(head)
+    assert start != -1, (
+        f"{CAVEAT_LIST_HEAD!r} not found in {SKILL_MD}.\n"
+        "That phrase brackets the core's enumeration of the caveat vocabulary and "
+        "is what this gate uses to find it. If the section was reworded, re-point "
+        "the anchor; if the enumeration was DELETED in favour of the bare pointer, "
+        "delete this gate in the same commit and say so -- do not leave an "
+        "unanchored prose list of a set the script owns."
+    )
+    end = text.find(tail, start)
+    assert end != -1, (
+        f"{CAVEAT_LIST_TAIL!r} not found after the head anchor in {SKILL_MD}; the "
+        "enumeration has no closing anchor, so this gate cannot bound it."
+    )
+    return re.findall(r"`([a-z_]+)`", text[start + len(head):end])
+
+
 def test_skill_md_exists():
     assert SKILL_MD.is_file(), f"{SKILL_MD} is missing -- did the skill move?"
 
 
 def test_skill_md_under_hard_ceiling():
     size = SKILL_MD.stat().st_size
-    assert size <= MAX_BYTES, (
-        f"SKILL.md is {size:,} B, over the {MAX_BYTES:,} B ceiling by "
-        f"{size - MAX_BYTES:,} B.\n  " + EVICTION_PLAYBOOK
+    over = _ceiling_overshoot(size)
+    assert not over, (
+        f"SKILL.md is {size:,} B, over the {MAX_BYTES:,} B ceiling by {over:,} B.\n  "
+        + EVICTION_PLAYBOOK
     )
+
+
+@pytest.mark.parametrize(
+    "size,expected",
+    [(MAX_BYTES - 1, 0), (MAX_BYTES, 0), (MAX_BYTES + 1, 1)],
+    ids=["one-under", "exactly-on-the-ceiling", "one-over"],
+)
+def test_the_ceiling_boundary_is_inclusive(size, expected):
+    """🔴 THE BOUNDARY, WHICH NO REAL FIXTURE EVER SITS ON.
+
+    A file exactly AT MAX_BYTES holds the line; one byte over does not. Without
+    this, flipping `<=` to `<` (or the arithmetic by one) is a mutation that
+    cannot be caught by any file on disk, because the odds of SKILL.md landing
+    on precisely 16,384 B are nil.
+    """
+    assert _ceiling_overshoot(size) == expected
 
 
 def test_skill_md_keeps_working_headroom():
@@ -196,6 +443,169 @@ def test_skill_md_keeps_working_headroom():
         "while there is still room to do it deliberately.\n  " + EVICTION_PLAYBOOK
     )
 
+
+# ---------------------------------------------------------------------------
+# PROTECTED CLAIMS -- the ceiling's justification, checked
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("claim", list(PROTECTED_CLAIMS), ids=list(PROTECTED_CLAIMS))
+def test_a_protected_claim_has_not_left_the_core(claim):
+    """🔴 PROTECTED CLAIM STILL IN THE CORE -- pinned as a whole string.
+
+    See the module docstring: this module argues the ceiling belongs above the
+    12,288 B target *because* these claims must be readable without a second
+    load. Until this test existed the argument was unbacked -- an audit mutated
+    every one of them and the suite stayed green.
+    """
+    body = SKILL_MD.read_text(encoding="utf-8")
+    missing = [s for name, s in _missing_protected_claims(body) if name == claim]
+    assert not missing, (
+        f"PROTECTED CLAIM ALTERED OR MISSING FROM THE CORE: {claim}\n"
+        + "".join(f"  not found: {_norm(s)!r}\n" for s in missing)
+        + "This sentence is why `MAX_BYTES` sits above the 12,288 B target -- a "
+        "reader must hit it WITHOUT a second load, so it may not be demoted to "
+        "reference/, softened, or reworded away.\n"
+        "  * Evicting it to make room under the ceiling is the wrong fix: shrink "
+        "somewhere that is not on this list.\n"
+        "  * Rewording it deliberately (a typo, punctuation, a genuine "
+        "correction)? Update the literal in PROTECTED_CLAIMS in the SAME commit. "
+        "Pinning the whole string is what makes a REWORD-shaped weakening -- "
+        "'`null`, never `0`' -> '`0`' -- fail here instead of shipping.\n  "
+        + EVICTION_PLAYBOOK
+    )
+
+
+def test_the_eviction_playbook_cannot_claim_more_than_is_checked():
+    """🔴 THE DESCRIPTION IS AS WIDE AS THE IMPLEMENTATION, structurally.
+
+    The playbook's "what must NOT move out" list is what a maintainer under
+    byte pressure actually reads. Before, it was a hand-written sentence naming
+    four things and NONE of them were checked -- reading as coverage while
+    providing none, which `claude/RULES.md` calls worse than no coverage at all.
+    It is generated from `PROTECTED_CLAIMS` now; this pins that it still is, so
+    the two cannot be edited apart.
+    """
+    for name in PROTECTED_CLAIMS:
+        assert f"- {name}\n" in EVICTION_PLAYBOOK, (
+            f"{name!r} is protected but the eviction playbook does not name it."
+        )
+    named = re.findall(r"^    - (.+)$", EVICTION_PLAYBOOK, re.M)
+    assert named == list(PROTECTED_CLAIMS), (
+        "the eviction playbook names a protected item that PROTECTED_CLAIMS does "
+        f"not check: playbook={named}, checked={list(PROTECTED_CLAIMS)}. The list "
+        "must be generated from the dict, never restated beside it."
+    )
+
+
+# 🔴 NEGATIVE CONTROLS ON THE CLAIM GATE -- the four mutations that survived.
+# Each is the audit's own mutation, replayed against a COPY of the real body and
+# graded by the REAL `_missing_protected_claims`. `expect` names which entry must
+# report it, so a mutant that dies against a DIFFERENT claim (green for the wrong
+# reason) is caught too.
+_CLAIM_MUTATIONS = (
+    (
+        "delete-the-exit-code-4-row",
+        "| `4` | **no** host could be reached — the zero is unmeasured, "
+        "not measured |\n",
+        "",
+        "the exit-code table",
+    ),
+    (
+        "schema_ok-false-means-zero-stuck",
+        "**`schema_ok: false` means STUCK WAS NOT MEASURED, not zero stuck**",
+        "**`schema_ok: false` means zero stuck**",
+        "the null-vs-zero discriminators",
+    ),
+    (
+        "waiting-probable-rollup-is-zero",
+        "`summary.waiting.probable` is likewise **`null`, never `0`**",
+        "`summary.waiting.probable` is likewise **`0`**",
+        "the null-vs-zero discriminators",
+    ),
+    (
+        "invert-the-waiting-unsent-separation",
+        "🔴 **It is NOT part of `waiting_probable` and is never summed into it.**",
+        "🔴 **It IS part of `waiting_probable` and is summed into it.**",
+        "the waiting/unsent separation",
+    ),
+)
+
+
+def test_the_unmutated_core_reports_NO_missing_claim():
+    """The green control the mutations below are read against."""
+    assert _missing_protected_claims(SKILL_MD.read_text(encoding="utf-8")) == []
+
+
+@pytest.mark.parametrize(
+    "old,new,expect", [m[1:] for m in _CLAIM_MUTATIONS], ids=[m[0] for m in _CLAIM_MUTATIONS]
+)
+def test_a_mutated_protected_claim_is_reported(old, new, expect):
+    body = SKILL_MD.read_text(encoding="utf-8")
+    assert body.count(old) == 1, (
+        f"fixture broken: {old!r} occurs {body.count(old)} times in the core, so "
+        "this mutation does not plant what it says it plants."
+    )
+    reported = _missing_protected_claims(body.replace(old, new))
+    assert reported, (
+        f"mutating {old!r} -> {new!r} left the claim gate GREEN. That mutation is "
+        "one of the four an audit shipped past a 584-test suite; it must red."
+    )
+    assert {name for name, _ in reported} == {expect}, (
+        f"the mutation was caught, but by {sorted({n for n, _ in reported})} rather "
+        f"than {expect!r} -- a mutant that dies for the wrong reason is not a kill."
+    )
+
+
+# ---------------------------------------------------------------------------
+# THE CAVEAT VOCABULARY -- a prose list of a set the SCRIPT owns
+# ---------------------------------------------------------------------------
+
+def test_the_cores_caveat_list_matches_the_scripts_CAVEATS():
+    """🔴 THE DEFECT THIS PRUNE WAS OPENED TO FIX, RE-CREATED SMALLER.
+
+    The deleted section restated five caveat entries in prose and had rotted to
+    five of six keys. The replacement pointer still enumerates the vocabulary --
+    which is legitimate (a reader needs the words) but is still a copy of a set
+    `scripts/session-manager` owns, and an audit walked it both ways on a green
+    suite: dropping `kind_scope` (the pre-prune bug, exactly) and inventing a
+    seventh key. Equality, not containment, so BOTH directions red.
+    """
+    listed = _cores_caveat_list(SKILL_MD.read_text(encoding="utf-8"))
+    owned = _script_caveat_keys()
+    assert listed, "the core's caveat enumeration parsed as EMPTY -- gate wired to nothing"
+    assert sorted(listed) == sorted(owned), (
+        "the core's caveat list disagrees with `CAVEATS` in "
+        f"{SESSION_MANAGER}:\n"
+        f"  core lists : {listed}\n"
+        f"  script owns: {owned}\n"
+        f"  only in the core  : {sorted(set(listed) - set(owned))}\n"
+        f"  only in the script: {sorted(set(owned) - set(listed))}\n"
+        "The script is the authority. Fix the core's list -- or delete the "
+        "enumeration and this gate together, keeping only the pointer."
+    )
+
+
+@pytest.mark.parametrize(
+    "mutate,label",
+    [
+        (lambda ks: [k for k in ks if k != "kind_scope"], "drop-kind_scope"),
+        (lambda ks: ks + ["invented_key"], "invent-a-seventh-key"),
+    ],
+    ids=["drop-kind_scope", "invent-a-seventh-key"],
+)
+def test_a_mutated_caveat_list_is_reported(mutate, label):
+    """Both audit mutations, graded by the same comparison the gate makes."""
+    listed = _cores_caveat_list(SKILL_MD.read_text(encoding="utf-8"))
+    owned = _script_caveat_keys()
+    assert sorted(listed) == sorted(owned), "green control failed before the mutation"
+    assert sorted(mutate(listed)) != sorted(owned), (
+        f"{label} did not move the verdict -- the comparison is wired to nothing."
+    )
+
+
+# ---------------------------------------------------------------------------
+# ROUTING
+# ---------------------------------------------------------------------------
 
 def test_every_reference_topic_is_routed_and_no_route_dangles():
     """Both directions, and the positive control that keeps a ZERO readable.
@@ -215,15 +625,29 @@ def test_every_reference_topic_is_routed_and_no_route_dangles():
     # a zero from a tokenizer that saw nothing is indistinguishable from a zero
     # from a clean file. Prove the instrument can see this body's routes at all
     # before believing any zero it produces.
+    #
+    # 🔴 IT ASKS WHETHER THE TOKENIZER SAW ANYTHING -- NOT `len(routes) >=
+    # len(topics)`, WHICH IS WHAT IT USED TO ASK. Routes and topics are both 7,
+    # so that comparison fired FIRST on the one hazard the orphan check exists
+    # for: add an eighth sidecar and nobody routes to it, and the reader got
+    # "this gate is wired to nothing" instead of the `unrouted` playbook naming
+    # the file and telling them to add a routing line. An instrument check that
+    # pre-empts the finding is not a control, it is a shadow. Counting is also
+    # strictly weaker than the per-topic resolution below, which is the real
+    # version of the same question.
     routes = _routing_paths(body)
-    assert len(routes) >= len(topics), (
-        f"the route tokenizer found {len(routes)} routing path(s) in SKILL.md but "
-        f"there are {len(topics)} reference topic(s). Either the core stopped "
-        "routing to them, or this gate is wired to nothing -- do not read the "
-        "assertions below as clean until this one holds."
+    assert routes, (
+        "the route tokenizer found NO routing path anywhere in SKILL.md. Either "
+        "the core stopped routing to reference/ entirely, or this gate is wired "
+        "to nothing -- do not read the assertions below as clean until this holds."
+    )
+    assert _routing_paths(_registry_block(body)), (
+        f"the {REGISTRY_MARKER} block yielded no routing path. The registry is "
+        "what a reader loads topics from; a zero from it is a broken instrument "
+        "or a broken registry, and either way not an all-clear."
     )
 
-    dangling = sorted({t for t in routes if not _resolve_routing_path(t).is_file()})
+    dangling = _dangling_routes(body)
     assert not dangling, (
         "the core writes routing paths that do not resolve to a file:\n"
         + "\n".join(f"  {t}  ->  {_resolve_routing_path(t)}" for t in dangling)
@@ -232,7 +656,7 @@ def test_every_reference_topic_is_routed_and_no_route_dangles():
     )
 
     routed = {_resolve_routing_path(t) for t in _routing_paths(_registry_block(body))}
-    unrouted = [t for t in topics if REFERENCE_DIR / t not in routed]
+    unrouted = _unrouted_topics(body)
     assert not unrouted, (
         f"reference topics exist but the core's registry does not route to them by "
         f"a path that resolves to them: {unrouted}\n"
@@ -244,11 +668,60 @@ def test_every_reference_topic_is_routed_and_no_route_dangles():
     )
 
 
+def test_a_NEW_orphan_sidecar_reaches_the_unrouted_verdict():
+    """🔴 REACHABILITY, not just breakability.
+
+    The headline hazard for direction 2 is an eighth reference topic that
+    nobody routes to. Fed through the SAME helper the gate calls, with a topic
+    name the registry cannot possibly mention, the verdict must name exactly
+    that file -- and must not sweep in the seven that ARE routed.
+    """
+    body = SKILL_MD.read_text(encoding="utf-8")
+    assert _unrouted_topics(body) == [], "green control failed before the mutation"
+    orphan = "orphan-sidecar-nobody-routes-to.md"
+    assert _unrouted_topics(body, _existing_topics() + [orphan]) == [orphan], (
+        "an eighth reference topic that the registry does not mention was NOT "
+        "reported as unrouted (or the seven routed ones were swept in with it). "
+        "Direction 2 of the routing gate is the only thing that catches an "
+        "orphaned sidecar, and an orphan is silent by nature -- nothing else in "
+        "this repo would say a word about it."
+    )
+
+
+def test_no_reference_topic_ROUTES_TO_ITSELF():
+    """🔴 THE BLIND SPOT OF THE ROUTING GATE ABOVE: it reads SKILL.md only.
+
+    A self-pointer RESOLVES, so `_dangling_routes` is green on it, and it lives
+    in a file the core-only gate never opens. Three shipped in the 2026-08-21
+    prune, because the demoted text was sliced VERBATIM out of the core, where
+    "see reference/<this file>.md" had been a correct forward pointer and became
+    a loop the moment it landed inside its own target. One of the three was
+    hand-patched with "-- i.e. this file, above"; the other two were not, and
+    nothing could have told anyone.
+    """
+    loops = {}
+    for topic in sorted(REFERENCE_DIR.glob("*.md")):
+        hits = [t for t in _routing_paths(topic.read_text(encoding="utf-8"))
+                if _resolve_routing_path(t) == topic]
+        if hits:
+            loops[topic.name] = hits
+    assert not loops, (
+        "a reference topic routes to ITSELF -- a reader following the pointer "
+        "lands back where they already are:\n"
+        + "".join(f"  {name}: {hits}\n" for name, hits in loops.items())
+        + "This is what verbatim slicing out of the core produces. Replace the "
+        "path with 'this file, above/below', or point at the topic that really "
+        "holds the detail."
+    )
+
+
 # ---------------------------------------------------------------------------
 # NEGATIVE CONTROLS -- a gate whose red has never been watched is a claim about
 # the gate, not about the file. Each case is planted into a copy of the REAL
-# body and graded by the REAL resolver, so a mutation anywhere in the pipeline
-# moves a verdict here.
+# body and graded by the REAL `_dangling_routes` / `_unrouted_topics`, so a
+# mutation anywhere in the pipeline moves a verdict here. The unplanted body is
+# green (asserted above), so EQUALITY on the verdict is available and is used:
+# it catches a mutation that ADDS a route as well as one that drops it.
 # ---------------------------------------------------------------------------
 
 _TOPIC = "payload-contract.md"
@@ -258,24 +731,53 @@ def _plant(spelling: str) -> str:
     return SKILL_MD.read_text(encoding="utf-8") + "\n\nPlanted: " + spelling + "\n"
 
 
-@pytest.mark.parametrize(
-    "spelling",
-    [
-        # The deployed prefix with one character wrong in the skill segment.
-        "`~/.claude/skills/session-managr/reference/payload-contract.md`",
-        # A topic that does not exist.
-        "`~/.claude/skills/session-manager/reference/does-not-exist.md`",
-        # Another skill's directory.
-        "`~/.claude/skills/browser/reference/payload-contract.md`",
-    ],
-    ids=["wrong-skill-segment", "missing-topic", "other-skills-dir"],
-)
-def test_a_planted_dangling_route_is_reported(spelling):
-    body = _plant(spelling)
-    dangling = [t for t in _routing_paths(body) if not _resolve_routing_path(t).is_file()]
-    assert dangling, (
-        f"planting {spelling} left the gate GREEN. A reader follows that pointer "
-        "AS WRITTEN and lands nowhere; the gate must say so."
+DANGLING_SPELLINGS = [
+    # The deployed prefix with one character wrong in the skill segment.
+    ("`~/.claude/skills/session-managr/reference/payload-contract.md`",
+     "~/.claude/skills/session-managr/reference/payload-contract.md"),
+    # A topic that does not exist.
+    ("`~/.claude/skills/session-manager/reference/does-not-exist.md`",
+     "~/.claude/skills/session-manager/reference/does-not-exist.md"),
+    # Another skill's directory.
+    ("`~/.claude/skills/browser/reference/payload-contract.md`",
+     "~/.claude/skills/browser/reference/payload-contract.md"),
+    # A doubled segment -- what a BASENAME resolver collapses onto the real file.
+    ("`reference/reference/payload-contract.md`",
+     "reference/reference/payload-contract.md"),
+    # A near-miss extension, which backtracks onto a real `.md` prefix.
+    ("`~/.claude/skills/session-manager/reference/payload-contract.mdx`",
+     "~/.claude/skills/session-manager/reference/payload-contract.mdx"),
+]
+
+
+@pytest.mark.parametrize("spelling,token", DANGLING_SPELLINGS, ids=lambda v: v)
+def test_a_planted_dangling_route_is_reported(spelling, token):
+    assert _dangling_routes(_plant(spelling)) == [token], (
+        f"planting {spelling} left the gate GREEN (or reported something else). "
+        "A reader follows that pointer AS WRITTEN and lands nowhere; the gate "
+        "must say so, and must name that token and no other."
+    )
+
+
+# 🔴 THE PERMANENTLY-RED-GATE CONTROL. `claude/RULES.md`: a gate that reds on
+# CORRECT input is worse than no gate, because it trains everyone to click
+# through. Every spelling a reader may legitimately write must stay green --
+# without this, "report everything as dangling" is a mutation that kills the
+# five probes above and passes.
+LEGITIMATE_SPELLINGS = [
+    f"`~/.claude/skills/session-manager/reference/{_TOPIC}`",
+    f"`.claude/skills/session-manager/reference/{_TOPIC}`",
+    f"`claude/skills/session-manager/reference/{_TOPIC}`",
+    f"`~/workspace/devrc/claude/skills/session-manager/reference/{_TOPIC}`",
+    f"`reference/{_TOPIC}`",
+    f"`./reference/{_TOPIC}`",
+]
+
+
+@pytest.mark.parametrize("spelling", LEGITIMATE_SPELLINGS, ids=lambda v: v)
+def test_a_planted_legitimate_route_stays_green(spelling):
+    assert _dangling_routes(_plant(spelling)) == [], (
+        f"planting {spelling} turned the gate RED on a CORRECT pointer."
     )
 
 
@@ -289,11 +791,7 @@ def test_a_registry_of_bare_prose_mentions_routes_nothing():
     )
     rewritten = body.replace(_registry_block(body), prose)
     assert rewritten != body, "fixture broken: the registry block was not replaced"
-    routed = {
-        _resolve_routing_path(t) for t in _routing_paths(_registry_block(rewritten))
-    }
-    unrouted = [t for t in _existing_topics() if REFERENCE_DIR / t not in routed]
-    assert unrouted == _existing_topics()
+    assert _unrouted_topics(rewritten) == _existing_topics()
 
 
 def test_the_deployed_spelling_is_never_stat_where_it_points():


### PR DESCRIPTION
## What

`claude/skills/session-manager/SKILL.md` was the largest skill body in the repo — **23,233 B**, ~6k tokens loaded **in full** every time the skill fires, displacing the task it was loaded for. This prunes it to **16,159 B (−30.4%)** by moving every procedure, field ledger, measurement and piece of archaeology behind `reference/` pointers, which cost zero until opened.

Run through the repo's own `prune-skill` skill: `scripts/skill-audit.py` → classify → **verbatim line-range slicing** into sidecars → lean core hand-written → gap audit + survival check + controls → re-measure.

## The pre-identified target: a section that argued for its own deletion

`## The caveats are in the OUTPUT, not just in this file` then spent **1,490 B** restating five caveat entries in prose. The tool already emits them structurally in `report["caveats"]` **and** as unconditional table footer lines, and `measured_caveats()` fills the measured fields per scan.

It had also already rotted in exactly the way its own heading predicts: it listed **five of the six** keys in `CAVEATS` (`kind_scope` missing). It is now a pointer naming where the caveats actually live (the payload key + the table footer) and what the vocabulary's source of truth is (the `CAVEATS` keys in `scripts/session-manager`), with the per-entry detail demoted.

## What moved where — all by verbatim line-range slicing of the original

| destination | content |
|---|---|
| `reference/payload-contract.md` **(new)** | the full flag table, summary buckets + `kind` vs `CLASS`, the output-view/lean-field ledger, `label`/`hotkey` tiers, what each caveat entry carries, ledger internals, `not_measured`, the paths table |
| `reference/clawgate-queue.md` **(new)** | the queue's field ledger, the `detail` schema cap, the agent-ops archaeology |
| `reference/waiting-signal.md` | += the pre-prune `waiting_probable` + `unsent_prompt` sections in full |
| `reference/exit-codes.md` | += the pre-prune consumer-facing exit section |
| `reference/fuzzyclaw-guard.md` | += the pre-prune fuzzyclaw measurement |

Core : reference is now 16 KB : ~67 KB across 7 topics.

## What deliberately stayed in the core

A guard behind a second load is not a guard, so these stay where a reader hits them: **every null-vs-zero discriminator** (`waiting_probable: null` ≠ `false`; `summary.unsent_prompt.count` is `null` never `0`; `clawgate_queue` publishes `count: null` in three of four states; `schema_ok: false` means stuck was NOT measured), the `waiting_probable`/`unsent_prompt` **separation**, the `clawgate_queue` **rename history**, the `not_measured` **derivation**, the **exit-code table** with its three independent per-host measurement statuses, and the 🔴 **NEVER PASTE A CAPTURED DRAFT** rule.

The `description:` frontmatter is byte-identical (`cmp`-verified).

## 🔴 It lands OVER the 12,288 B target, deliberately

Recorded rather than left to be rediscovered: what remains is almost entirely the protected set above plus the routing surface. Getting under the target would mean demoting a null-vs-zero rule behind a load — which is how "nothing is waiting on you" gets emitted off a look that never happened.

`scripts/tests/test_session_manager_skill_size.py` pins it as a **ratchet at 16,384 B** with a derived headroom floor (one mean routing row). It forbids regrowth; it does not endorse the size. The test owns its constants and prints an eviction playbook on failure, so no number is restated in prose.

## Two other real findings

1. **Two orphaned sidecars.** `clickhouse-queries.md` and `cross-host.md` were reachable from nothing — the core name-dropped five basenames in a prose sentence, which is not a route. All seven topics now have a resolving deployed path in a routing table, and the new test fails on an orphan **or** a dangling route, in either direction. The stale copy of that sentence inside the demoted text was corrected on the way out rather than moved verbatim.
2. **The first example contradicted the file's own recommendation** — `--json` in the command block, `--json --lean` two sections down. Now `--json --lean`.

## 🔴 The gate caught one real break, and it is why that guard is shaped the way it is

`test_session_manager.py::test_BOTH_shipped_docs_carry_the_NEVER_PASTE_A_CAPTURED_DRAFT_rule` pins that rule as a **whole normalised string**, precisely because a prose guard is walkable by a reword. The compression pass repunctuated its tail (`never verbatim;` for `never verbatim.`) and the suite went red on a change that reads as cosmetic. Restored verbatim.

## Verification

- **Test matrix:** RED at `origin/main` (4 failed — ceiling, headroom, routing, the prose-registry control), GREEN at HEAD (9 passed). Measured by restoring the pristine pre-prune skill dir over the tree and re-running, then restoring the pruned copy (md5-verified both ways).
- **Un-sliced gap audit:** `[(1,21)]` + four blank lines — only the frontmatter, H1, command block and "rows are at" note, all carried into the core.
- **Content survival**, 6 populations (backticked spans, path-like tokens, numeric constants, issue refs, table row keys, whole normalised lines) over the union of new core + all 7 sidecars: **4 missing whole-lines, every one a deliberate edit named above**.
- **Controls, each mutating a DESTINATION**, reported as counts against a baseline of 4: hide `payload-contract` **166**, hide `clawgate-queue` **47**, hide `waiting-signal` **31**, hide `fuzzyclaw-guard` **12**, hide `exit-codes` **2**, drop table rows from `payload-contract` **31**, mutate numbers in `clawgate-queue` **4**. Two controls came back **at** baseline and are reported as **INVALID, not clean** — hiding `clickhouse-queries.md` / `cross-host.md` moves nothing because no sliced content landed in either.
- **Driven live**, read-only, `--no-capture --no-ch`: every kept claim holds against the script — the six `CAVEATS` keys, the five `not_measured` populations and their owner skills, `summary.status[bucket]` = `{claude, shell, total}` per bucket, `lean_row_fields`, and both roll-ups coming back `null` (not `0`) under `--no-capture`. **No skill-vs-script disagreement found** beyond the caveat-count omission fixed here.
- **Gate:** `nix develop <worktree> --command bash scripts/gate.sh` — **`GATE: RESULT=PASS exit=0`**. pytest `TOTAL collected=13944 passed=13943 skipped=1 failed=0` (floor 13034, 25 targets, every target PASS); node `TOTAL suites=4 files=33 tests=1119 pass=1119 fail=0` (floor 1098). The first run of this gate was RED on the pinned-sentence break above; this is the re-run after the fix.

Not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
