### PR TITLE
feat(hooks): capture every backgrounded Bash command VERBATIM — the artifact 868ktvqf9 needs

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1151,6 +1151,28 @@ in
   home.file.".claude/hooks/agent_ledger.py" = {
     source = ../scripts/lib/agent_ledger.py;
   };
+  # 🔴 THE BACKGROUNDED-COMMAND CAPTURE LOG — instrumentation for ClickUp
+  # 868ktvqf9, where a unit run that exits non-zero is announced as "exit code 0"
+  # and the run's output file is 0 bytes at the moment the notification arrives.
+  # Both independent things an investigator would check report green over a red
+  # run, and the ONE artifact that discriminates between the live hypotheses —
+  # the VERBATIM command string that was backgrounded — is kept nowhere the
+  # investigator can reach afterwards. This records it.
+  #
+  # It never blocks, warns or rewrites anything; it appends a line and returns 0.
+  # `bg_command_capture.py --report` is the read that puts the captured command
+  # next to the exit code the harness announced for it.
+  #
+  # 🔴 BOTH files are NEW, and the hook imports the library as a SIBLING in
+  # ~/.claude/hooks/ — deploying one without the other is a green switch and an
+  # inert hook (the #452 shape). Both must be `git add`ed or the flake silently
+  # omits them, and the switch still succeeds with the hook absent.
+  home.file.".claude/hooks/bg-command-capture.py" = {
+    source = ../scripts/claude-hooks/bg-command-capture.py;
+  };
+  home.file.".claude/hooks/bg_command_capture.py" = {
+    source = ../scripts/lib/bg_command_capture.py;
+  };
   # 🔴 THE CLAWGATE WRITE-BACK GUARD — the deterministic replacement for a 🔴 prose
   # rule that lost 2/2. Tasks #193 and #194 were both picked up, the work shipped as
   # PRs, and both cards stayed `open` with ZERO comments; both were re-dispatched and

--- a/scripts/claude-hooks/bg-command-capture.py
+++ b/scripts/claude-hooks/bg-command-capture.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Claude Code adapter for the backgrounded-command capture log — ClickUp 868ktvqf9.
+
+All the logic lives in `bg_command_capture.py`; read ITS docstring first, which
+carries the measured harness payload shapes and the reasoning. This file is the
+adapter and nothing more, in the arrangement `bash-guard.py` has with
+`guard_core.py` and `agent-ledger-hook.py` has with `agent_ledger.py`: deployed,
+both files sit in `~/.claude/hooks/`; in the repo the module is in
+`scripts/lib/` and only this file is under `scripts/claude-hooks/`.
+
+WHICH EVENTS, AND WHY EACH ONE
+
+    PreToolUse(Bash)   🔴 THE LOAD-BEARING ONE. `tool_input.command` is the
+                       verbatim string and `tool_input.run_in_background` is the
+                       boolean, and this is the ONLY event where either exists.
+                       Everything the ticket needs is captured here.
+    PostToolUse(Bash)  the `backgroundTaskId` — which names the output file the
+                       operator finds at 0 bytes — appears only in
+                       `tool_response`, and only on this event. It carries NO
+                       exit code, because it fires at LAUNCH, not completion.
+
+There is deliberately no third event: no hook fires when a backgrounded task
+finishes. The exit code the harness announces is injected into the transcript as
+`<summary>Background command "…" completed (exit code N)</summary>`, joined back
+to a captured command by its `description` — that join is `--report`, run by an
+investigator, not by a hook on anyone's hot path.
+
+🔴 FAIL-OPEN, ALWAYS, AND SILENTLY. This fires before and after EVERY Bash call
+in EVERY session on this host. A hook that raises breaks the operator's shell,
+and a PreToolUse hook that writes junk to stdout is read as a permission verdict.
+So: every path returns 0, nothing is ever printed, and the outermost handler is
+`BaseException` — not `Exception`. That widening is not defensive decoration; it
+is the measured lesson from `bash-guard.py`, where a `SystemExit` out of an
+imported module escaped an `except Exception` and changed the hook's verdict.
+Here the direction is the opposite one (this hook has no verdict to change) but
+the mechanism is identical, and a traceback on stderr for every Bash call would
+be its own kind of broken.
+
+This hook is INSTRUMENTATION. It never blocks, warns, rewrites or refuses
+anything. Turn it off with `CLAUDE_BG_CAPTURE_DISABLE=1`.
+
+Registered by `register-nudge-hook.py`; deployed by `nix/home.nix` alongside
+`bg_command_capture.py`. Both need a `home-manager switch` to take effect.
+"""
+import json
+import os
+import sys
+
+sys.dont_write_bytecode = True
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+EVENTS = ("PreToolUse", "PostToolUse")
+
+
+def _load():
+    """Import `bg_command_capture` from the deployed sibling, else the repo lib/.
+
+    Deployed, both files sit in `~/.claude/hooks/`. In the repo only this file is
+    under `scripts/claude-hooks/`, so the tests exercise the second branch and
+    the host exercises the first — the same two-branch arrangement
+    `agent-ledger-hook.py` uses, and for the same reason.
+    """
+    import importlib.machinery
+    import importlib.util
+    for path in (os.path.join(_HERE, "bg_command_capture.py"),
+                 os.path.join(_HERE, os.pardir, "lib", "bg_command_capture.py")):
+        if os.path.exists(path):
+            loader = importlib.machinery.SourceFileLoader("_bg_command_capture", path)
+            spec = importlib.util.spec_from_file_location(
+                "_bg_command_capture", path, loader=loader)
+            mod = importlib.util.module_from_spec(spec)
+            loader.exec_module(mod)
+            return mod
+    raise ImportError("bg_command_capture.py not found beside the hook or in ../lib/")
+
+
+def run(stdin=None):
+    """The whole hook. Returns an exit status; never raises, never prints."""
+    try:
+        BC = _load()
+    except BaseException:  # noqa: BLE001 — see the fail-open note in the docstring
+        return 0
+    try:
+        if BC.disabled():
+            return 0
+        payload = json.load(stdin if stdin is not None else sys.stdin)
+        event = (payload or {}).get("hook_event_name")
+        # A missing key means the event is not ours. Registration is per-host
+        # mutable state, so the hook decides what it handles rather than
+        # trusting settings.json to have been edited correctly.
+        if event not in EVENTS:
+            return 0
+        rec = BC.build_record(event, payload)
+        if rec is None:
+            return 0
+        BC.append_record(rec)
+    except BaseException:  # noqa: BLE001 — see the fail-open note in the docstring
+        return 0
+    return 0
+
+
+def main():
+    # `--selftest` is the positive control and is the ONE mode that may print and
+    # may report failure: it is run by hand, never by the harness.
+    if "--selftest" in sys.argv[1:]:
+        try:
+            return _load().selftest()
+        except BaseException as exc:  # noqa: BLE001
+            print("selftest error: %s: %s" % (type(exc).__name__, exc))
+            return 1
+    return run()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/claude-hooks/register-nudge-hook.py
+++ b/scripts/claude-hooks/register-nudge-hook.py
@@ -97,6 +97,15 @@ Registers (APPEND surface):
     task write-back non-optional — PostToolUse watches for a read of a specific task
     id and for real work after it, Stop re-reads the board live and blocks a turn
     that is about to end with the card still uncommented).
+  * PreToolUse(Bash) / PostToolUse(Bash): bg-command-capture.py — INSTRUMENTATION,
+    not a guard and not a nudge. It has no verdict, writes nothing to stdout and
+    returns 0 on every input; it appends the VERBATIM command string of every
+    backgrounded (or status-masking) Bash call to a bounded log, because that
+    string is the one artifact that discriminates between the open hypotheses in
+    ClickUp 868ktvqf9 and the harness keeps it nowhere reachable afterwards. Both
+    events, because they carry different halves: PreToolUse has the verbatim
+    command and `run_in_background`, PostToolUse has the `backgroundTaskId` that
+    names the run's output file.
 
 🔴 TWO of these carry NO `matcher` on PostToolUse — agent-ledger-hook.py and
 clawgate-writeback-guard.py — unlike the three nudges above. Those three are about
@@ -199,6 +208,7 @@ MANAGED_HOOK_SCRIPTS = frozenset({
     "agent-ledger-hook.py",
     "audit-pr-nudge.py",
     "bash-guard.py",
+    "bg-command-capture.py",
     "claude-notify.py",
     "clawgate-task-interview-guard.py",
     "clawgate-writeback-guard.py",
@@ -207,7 +217,8 @@ MANAGED_HOOK_SCRIPTS = frozenset({
     "shell-env-nudge.py",
 })
 
-HOOK_LIBRARY_MODULES = frozenset({"agent_ledger.py", "guard_core.py"})
+HOOK_LIBRARY_MODULES = frozenset({"agent_ledger.py", "bg_command_capture.py",
+                                  "guard_core.py"})
 
 REGISTRAR_SCRIPT = "register-nudge-hook.py"
 
@@ -422,6 +433,11 @@ POST_BASH_CMDS = [
     with_python("~/.claude/hooks/audit-pr-nudge.py"),
     with_python("~/.claude/hooks/shell-env-nudge.py"),
     with_python("~/.claude/hooks/search-tool-nudge.py"),
+    # Not a nudge — INSTRUMENTATION. It injects nothing and blocks nothing; on
+    # this event it exists only to capture `tool_response.backgroundTaskId`,
+    # which names the output file a backgrounded run writes to and appears on NO
+    # other event. See scripts/lib/bg_command_capture.py (ClickUp 868ktvqf9).
+    with_python("~/.claude/hooks/bg-command-capture.py"),
 ]
 
 # The turn-finished notifier fires on these three events (single script,
@@ -453,6 +469,19 @@ WRITEBACK_EVENTS = ["PostToolUse", "Stop"]
 # pins that): the append surface adds only what is in this table.
 PRE_BASH_CMDS = [
     with_python("~/.claude/hooks/clawgate-task-interview-guard.py"),
+    # 🔴 THE LOAD-BEARING HALF of the 868ktvqf9 instrument, and the SECOND
+    # PreToolUse entry this script registers. `tool_input.command` (verbatim) and
+    # `tool_input.run_in_background` exist on this event and on no other — a
+    # backgrounded run's PostToolUse response carries only a task id, and the
+    # completion notification is not a hook event at all. If this entry is
+    # missing, the one artifact that discriminates between the open hypotheses is
+    # never recorded and the next hit needs a reconstruction again.
+    #
+    # 🔴 Unlike its neighbour above, this hook has NO verdict: it never emits a
+    # permissionDecision, never writes to stdout, and returns 0 on every input.
+    # Registering it does not widen what PreToolUse can REFUSE — only what it
+    # observes.
+    with_python("~/.claude/hooks/bg-command-capture.py"),
 ]
 
 # Hooks registered on exactly one event each: {event: [command, ...]}.

--- a/scripts/claude-hooks/tests/test_bg_command_capture.py
+++ b/scripts/claude-hooks/tests/test_bg_command_capture.py
@@ -1,0 +1,711 @@
+#!/usr/bin/env python3
+"""The backgrounded-command capture log — ClickUp 868ktvqf9.
+
+WHAT EACH TEST HERE IS, because "it passes" is not a category:
+
+  * POSITIVE CONTROL   drives the REAL hook as a subprocess with the REAL
+    payload shape and asserts the recorded line. `test_the_hook_records_a_real_
+    trailing_semicolon_after_a_redirect_verbatim` is the one the ticket asks
+    for; without it this file would be a claim about functions nobody has
+    watched write to a disk.
+  * NEVER-THROWS       21 malformed / empty / huge / hostile inputs, each
+    asserting `rc == 0` AND empty stdout AND empty stderr. This hook fires
+    before and after every Bash call on the host; a raise breaks the shell and
+    a stray byte on stdout is read as a PreToolUse permission verdict.
+    `test_the_never_throws_harness_can_go_red` is its negative control — the
+    battery is otherwise indistinguishable from one wired to nothing.
+  * MARKER LEDGER      the scanner, pinned in BOTH directions. A marker test
+    that only asserts hits is satisfied by a scanner that marks everything;
+    the non-matches (`&&`, a bare trailing `;`, a heredoc body, a quoted `;`)
+    are the load-bearing half: 14 of the 28 rows expect NO marker.
+  * INSTRUMENT CONTROL `parse_completions` is pinned on BOTH spellings of the
+    notification — the escaped one that is actually on disk and the bare one —
+    because the first implementation matched only the bare form, returned `{}`
+    against a real transcript, and `report()` reported `announced_exit_codes:
+    []` for a record whose exit code was in the file. An empty result that
+    means "my pattern is wrong" reading as "the harness never announced one"
+    is the exact defect class this instrument exists to expose, reproduced
+    inside the instrument. It is red on a mutant that drops either spelling.
+  * ON-DISK NAMES      the COMPLETE set of relative paths the real writer
+    creates under a throwaway $HOME, compared to a literal list, in the shape
+    tests/test_on_disk_artifact_names.py established. Fails when the set grows
+    as well as when it shrinks.
+  * BOUND              rotation, measured against a cap the fixture cannot
+    reach by accident.
+
+NOT regression coverage: nothing here was red before this branch, because
+nothing here existed. Every test is a specification pin or a control, and the
+file says so rather than letting a green run imply otherwise.
+
+run:  python -m pytest scripts/claude-hooks/tests/test_bg_command_capture.py -q
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+HOOKS = os.path.abspath(os.path.join(HERE, os.pardir))
+ROOT = os.path.abspath(os.path.join(HOOKS, os.pardir, os.pardir))
+LIB = os.path.join(ROOT, "scripts", "lib")
+HOOK = os.path.join(HOOKS, "bg-command-capture.py")
+MODULE = os.path.join(LIB, "bg_command_capture.py")
+
+# Fixture values, pairwise distinct and distinct from every constant the module
+# names (SCHEMA, LOG_NAME, DEFAULT_MAX_BYTES, the marker strings). A fixture that
+# can only ever produce a constant's own value cannot see a mutant that hardcodes
+# that constant.
+SESSION = "sess-bgcap-4f2"
+TOOL_USE = "toolu_bgcap_9c7"
+TASK_ID = "bq7zk3m1x"
+DESCRIPTION = "Run the queued unit suite off-thread"
+
+# The shape from the ticket: a redirect, then a `;`-chained command. The reported
+# status is `echo`'s, not the suite's.
+MASKING_COMMAND = (
+    "node .claude/skills/dev-server/cli.mjs test run --suite unit"
+    " > /tmp/unit-4f2.log 2>&1; echo \"finished rc=$?\""
+)
+
+
+def load_module():
+    """Import the library by path, INSIDE a test — after $HOME is redirected.
+
+    `state_dir()` resolves `~` per call precisely so this is safe, but importing
+    at collection time would still be the wrong habit to establish here: the
+    module beside it in this directory (`agent_ledger`) does bake `~` at import,
+    and a reader copying this file should not learn the unsafe pattern.
+    """
+    loader = importlib.machinery.SourceFileLoader("_bgcap_under_test", MODULE)
+    spec = importlib.util.spec_from_file_location("_bgcap_under_test", MODULE, loader=loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def capture_dir(tmp_path, monkeypatch):
+    """A throwaway state dir AND a throwaway $HOME.
+
+    Both, not either: `$CLAUDE_BG_CAPTURE_DIR` is the documented override and is
+    what the hook subprocess uses, but redirecting `$HOME` as well means a defect
+    that ignores the override writes into the sandbox rather than into the
+    developer's real log — a test that pollutes the live evidence file would be a
+    poor guardian of an evidence file.
+    """
+    d = tmp_path / "state"
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("CLAUDE_BG_CAPTURE_DIR", str(d))
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("CLAUDE_BG_CAPTURE_DISABLE", raising=False)
+    monkeypatch.delenv("CLAUDE_BG_CAPTURE_MAX_BYTES", raising=False)
+    return d
+
+
+def pre_payload(command=MASKING_COMMAND, background=True, **over):
+    p = {
+        "session_id": SESSION,
+        "transcript_path": "/nonexistent/transcript.jsonl",
+        "cwd": "/tmp",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": TOOL_USE,
+        "tool_input": {
+            "command": command,
+            "description": DESCRIPTION,
+            "timeout": 1800000,
+            "run_in_background": background,
+        },
+    }
+    p.update(over)
+    return p
+
+
+def post_payload(**over):
+    p = pre_payload(**over)
+    p["hook_event_name"] = "PostToolUse"
+    # The MEASURED shape of a backgrounded Bash tool_response on this host: no
+    # exit code, empty output, a task id. Written out in full rather than
+    # summarised, because the point of the PostToolUse record is that this is
+    # everything the harness gives back.
+    p["tool_response"] = {
+        "stdout": "", "stderr": "", "interrupted": False, "isImage": False,
+        "noOutputExpected": False, "backgroundTaskId": TASK_ID,
+    }
+    return p
+
+
+def run_hook(payload, env=None, script=HOOK):
+    """Drive the REAL hook as a subprocess and return (rc, stdout, stderr)."""
+    proc = subprocess.run(
+        [sys.executable, script],
+        input=payload if isinstance(payload, str) else json.dumps(payload),
+        capture_output=True, text=True, timeout=120,
+        env={**os.environ, **(env or {})},
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+# --------------------------------------------------------------------------- #
+# POSITIVE CONTROL — the artifact the ticket needs
+# --------------------------------------------------------------------------- #
+
+def test_the_hook_records_a_real_trailing_semicolon_after_a_redirect_verbatim(capture_dir):
+    """🔴 THE POSITIVE CONTROL. Real hook, real payload shape, real disk.
+
+    Asserts the recorded command is byte-identical to the input — not that it
+    "contains" it. A `in` check would pass on a normalised, re-quoted or
+    shell-expanded record, and a normalised record cannot answer the question
+    this log exists to answer.
+    """
+    rc, out, err = run_hook(pre_payload())
+    assert (rc, out, err) == (0, "", ""), (rc, out, err)
+
+    log = capture_dir / "commands.jsonl"
+    assert log.exists(), f"the hook wrote nothing to {log}"
+    lines = [ln for ln in log.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert len(lines) == 1, lines
+    rec = json.loads(lines[0])
+
+    assert rec["command"] == MASKING_COMMAND, "the command was not stored VERBATIM"
+    assert rec["background"] is True
+    assert rec["description"] == DESCRIPTION, "the join key to the completion notification"
+    assert rec["session_id"] == SESSION
+    assert rec["tool_use_id"] == TOOL_USE
+    assert rec["event"] == "PreToolUse"
+    assert rec["schema"] == "BG_COMMAND_CAPTURE_V1"
+    # The grep target the ticket asks for.
+    assert "REDIRECT_THEN_SEMI" in rec["markers"]
+
+
+def test_the_post_event_records_the_background_task_id_and_no_invented_exit_code(capture_dir):
+    """The task id names the output file the operator finds at 0 bytes.
+
+    The second assertion is the honest half: `tool_response` on a backgrounded
+    call carries NO terminal status, and the record must say so with a null
+    rather than manufacturing a plausible zero — which is the very failure under
+    investigation. `response_keys` is the asserted ledger beside it: it fails
+    visibly if the harness's key set ever changes, in either direction.
+    """
+    rc, out, err = run_hook(post_payload())
+    assert (rc, out, err) == (0, "", ""), (rc, out, err)
+    rec = json.loads((capture_dir / "commands.jsonl").read_text().splitlines()[0])
+    assert rec["background_task_id"] == TASK_ID
+    assert rec["harness_exit_field"] is None
+    assert rec["response_keys"] == sorted(
+        ["stdout", "stderr", "interrupted", "isImage", "noOutputExpected", "backgroundTaskId"]
+    )
+    assert rec["stdout_len"] == 0 and rec["stderr_len"] == 0
+
+
+def test_a_harness_that_starts_supplying_an_exit_field_is_recorded_not_ignored(capture_dir):
+    """Forward guard, and the positive control for `harness_exit_field`.
+
+    Without it the null asserted above is indistinguishable from a field that is
+    hardcoded to null — a mutant returning a constant `None` survives the test
+    above and would silently discard the very thing a future harness might
+    finally give us.
+    """
+    payload = post_payload()
+    payload["tool_response"]["exitCode"] = 1
+    rc, _, _ = run_hook(payload)
+    assert rc == 0
+    rec = json.loads((capture_dir / "commands.jsonl").read_text().splitlines()[0])
+    assert rec["harness_exit_field"] == {"key": "exitCode", "value": 1}
+
+
+def test_the_module_selftest_passes_and_is_a_real_round_trip(capture_dir):
+    """The shipped `--selftest` must PASS, and must actually have written."""
+    proc = subprocess.run([sys.executable, HOOK, "--selftest"],
+                          capture_output=True, text=True, timeout=120,
+                          env={**os.environ})
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "positive control: 1 expected, 1 observed -> PASS" in proc.stdout
+    assert "verbatim round-trip: True" in proc.stdout
+
+
+# --------------------------------------------------------------------------- #
+# NEVER-THROWS
+# --------------------------------------------------------------------------- #
+
+HOSTILE = [
+    ("empty", ""),
+    ("whitespace", "   \n\t "),
+    ("not-json", "this is not json at all }{"),
+    ("json-null", "null"),
+    ("json-array", "[1,2,3]"),
+    ("json-string", '"hello"'),
+    ("json-number", "42"),
+    ("truncated", '{"hook_event_name":"PreToolUse","tool_in'),
+    ("no-event", json.dumps({"tool_name": "Bash", "tool_input": {"command": "x"}})),
+    ("unknown-event", json.dumps({"hook_event_name": "Frobnicate", "tool_name": "Bash",
+                                  "tool_input": {"command": "x"}})),
+    ("event-not-string", json.dumps({"hook_event_name": 7, "tool_name": "Bash",
+                                     "tool_input": {"command": "x"}})),
+    ("tool-input-null", json.dumps({"hook_event_name": "PreToolUse", "tool_name": "Bash",
+                                    "tool_input": None})),
+    ("tool-input-list", json.dumps({"hook_event_name": "PreToolUse", "tool_name": "Bash",
+                                    "tool_input": [1, 2]})),
+    ("command-int", json.dumps({"hook_event_name": "PreToolUse", "tool_name": "Bash",
+                                "tool_input": {"command": 123, "run_in_background": True}})),
+    ("command-empty", json.dumps({"hook_event_name": "PreToolUse", "tool_name": "Bash",
+                                  "tool_input": {"command": "", "run_in_background": True}})),
+    ("not-bash", json.dumps({"hook_event_name": "PreToolUse", "tool_name": "Edit",
+                             "tool_input": {"command": "a > f; echo x"}})),
+    ("response-string", json.dumps({"hook_event_name": "PostToolUse", "tool_name": "Bash",
+                                    "tool_input": {"command": "a > f; echo x",
+                                                   "run_in_background": True},
+                                    "tool_response": "Error: refused"})),
+    ("deep-nesting", "[" * 2000 + "]" * 2000),
+    ("unterminated-quote", json.dumps({"hook_event_name": "PreToolUse", "tool_name": "Bash",
+                                       "tool_input": {"command": "echo 'oops > f; echo hi",
+                                                      "run_in_background": True}})),
+    ("unterminated-heredoc", json.dumps({"hook_event_name": "PreToolUse", "tool_name": "Bash",
+                                         "tool_input": {"command": "python3 - <<PY\nx=1; y=2\n> f",
+                                                        "run_in_background": True}})),
+    ("nul-and-unicode", json.dumps({"hook_event_name": "PreToolUse", "tool_name": "Bash",
+                                    "tool_input": {"command": "echo \"日本語 \U0001f525\""
+                                                              " > /tmp/u; echo ok",
+                                                   "run_in_background": True}})),
+]
+
+
+@pytest.mark.parametrize("name, payload", HOSTILE, ids=[n for n, _ in HOSTILE])
+def test_the_hook_never_throws_and_never_speaks(name, payload, capture_dir):
+    """rc 0, empty stdout, empty stderr — all three, on every hostile input.
+
+    All three, and stdout is not the incidental one. This is registered on
+    PreToolUse, where stdout is parsed as a permission verdict: a traceback there
+    is not merely noise, it is a malformed verdict on the operator's command.
+    """
+    rc, out, err = run_hook(payload)
+    assert rc == 0, f"{name}: rc={rc}\nstdout={out}\nstderr={err}"
+    assert out == "", f"{name}: wrote to stdout: {out!r}"
+    assert err == "", f"{name}: wrote to stderr: {err!r}"
+
+
+def test_the_never_throws_harness_can_go_red(tmp_path):
+    """🔴 NEGATIVE CONTROL on the battery above.
+
+    Every assertion in `test_the_hook_never_throws_and_never_speaks` is of the
+    form "nothing happened". A harness that cannot observe something happening
+    passes them all against a hook that does not exist. This plants a script that
+    raises and exits non-zero and asserts the same three checks FAIL.
+    """
+    broken = tmp_path / "broken-hook.py"
+    broken.write_text("import sys\nsys.stderr.write('boom\\n')\nsys.exit(3)\n")
+    rc, out, err = run_hook("{}", script=str(broken))
+    assert rc == 3 and "boom" in err, (rc, out, err)
+
+
+def test_an_unwritable_state_directory_is_silent_not_fatal(tmp_path, monkeypatch):
+    """The disk can be full, read-only, or owned by someone else.
+
+    Degrading to "no record" is correct; that is the status quo this replaces, so
+    a silent failure is strictly no worse than not having the instrument. A raise
+    would be strictly worse than not having it.
+    """
+    ro = tmp_path / "ro"
+    ro.mkdir()
+    ro.chmod(0o500)
+    try:
+        rc, out, err = run_hook(pre_payload(), env={"CLAUDE_BG_CAPTURE_DIR": str(ro / "sub")})
+        assert (rc, out, err) == (0, "", ""), (rc, out, err)
+        assert not (ro / "sub").exists()
+    finally:
+        ro.chmod(0o700)
+
+
+def test_the_hook_is_inert_without_its_library(tmp_path, capture_dir):
+    """Copied away from its sibling module, the hook must do nothing, quietly.
+
+    A partial `home-manager switch` produces exactly this state. bash-guard fails
+    CLOSED here because it is a guard with a verdict to give; this one has no
+    verdict, so failing OPEN and silent is the correct direction — and it must be
+    a DECISION visible in a test, not an accident of an exception handler.
+    """
+    orphan = tmp_path / "orphan-hook.py"
+    orphan.write_text(open(HOOK, encoding="utf-8").read())
+    rc, out, err = run_hook(pre_payload(), script=str(orphan))
+    assert (rc, out, err) == (0, "", ""), (rc, out, err)
+    assert not (capture_dir / "commands.jsonl").exists()
+
+
+def test_the_disable_switch_turns_it_off(capture_dir):
+    rc, out, err = run_hook(pre_payload(), env={"CLAUDE_BG_CAPTURE_DISABLE": "1"})
+    assert (rc, out, err) == (0, "", "")
+    assert not (capture_dir / "commands.jsonl").exists()
+
+
+# --------------------------------------------------------------------------- #
+# MARKER LEDGER — both directions
+# --------------------------------------------------------------------------- #
+
+MARKS = [
+    # ---- REDIRECT_THEN_SEMI: the shape the ticket is about ----
+    ("a > f 2>&1; echo done", ["TRAILING_SEMI", "REDIRECT_THEN_SEMI"]),
+    ("run >> out.log; tail -5 out.log", ["TRAILING_SEMI", "REDIRECT_THEN_SEMI"]),
+    ("(x > f 2>&1; echo $?) ; echo end", ["TRAILING_SEMI"]),
+    ("run > f\necho done", ["TRAILING_SEMI", "REDIRECT_THEN_SEMI"]),
+    ("run 2> err.txt; ls", ["TRAILING_SEMI", "REDIRECT_THEN_SEMI"]),
+    ("run &> all.log; true", ["TRAILING_SEMI", "REDIRECT_THEN_SEMI"]),
+    # ---- masking WITHOUT a redirect ----
+    ("make test; echo done", ["TRAILING_SEMI"]),
+    ("pytest -q | tail -3", ["TRAILING_PIPE"]),
+    ("a > f 2>&1; b | tail -1",
+     ["TRAILING_SEMI", "REDIRECT_THEN_SEMI", "TRAILING_PIPE"]),
+    # ---- NON-MATCHES: the load-bearing half ----
+    ("ls -la", []),
+    ("kubectl get pods -o wide", []),
+    # && short-circuits, so the status is the failing command's — NOT masking.
+    ("run > f && echo done", []),
+    ("run > f || echo failed", []),
+    # a trailing `;` with nothing after it runs nothing and masks nothing.
+    ("run > f;", []),
+    ("run > f ;   ", []),
+    # a trailing comment is not a command.
+    ("run > f; # note", []),
+    # `;` inside quotes is data.
+    ("echo 'a > f; echo x'", []),
+    ('echo "a > f; echo x"', []),
+    # `;` inside a heredoc BODY is the false positive that would swamp this host.
+    ("python3 - <<'PY'\nx = 1; y = 2\nprint(x)\nPY", []),
+    ("python3 - <<PY > out.log\na; b\nPY", []),
+    ("cat <<-EOF > f\n\ta; b\n\tEOF", []),
+    # ...but a heredoc followed by a REAL trailing command still marks.
+    ("python3 - <<'PY' > out.log\nx = 1; y = 2\nPY\necho done",
+     ["TRAILING_SEMI", "REDIRECT_THEN_SEMI"]),
+    # a here-STRING is not a heredoc; the rest of the command must stay visible.
+    ("grep x <<< \"$data\" > f; echo done",
+     ["TRAILING_SEMI", "REDIRECT_THEN_SEMI"]),
+    # `;;` is a case terminator.
+    ("case $x in a) run > f;; esac", []),
+    # `||` is not a pipe.
+    ("run | grep x || true", ["TRAILING_PIPE"]),
+    # a `#` that is not a comment.
+    ("echo ${#arr[@]} > f; echo done", ["TRAILING_SEMI", "REDIRECT_THEN_SEMI"]),
+    # `$( ... ; ... )` is a subshell, not a top-level separator.
+    ("x=$(a > f; b); echo $x", ["TRAILING_SEMI"]),
+    ("echo $(a; b) > f", []),
+]
+
+
+@pytest.mark.parametrize("command, expected", MARKS, ids=[c[:44] for c, _ in MARKS])
+def test_the_marker_scanner_agrees_with_its_ledger(command, expected):
+    """The COMPLETE marker set, compared as a set, in both directions.
+
+    Comparing the complete set rather than asserting membership means a scanner
+    that marks everything fails here — 14 of these 28 rows expect NO marker, an
+    even split that is deliberate. A `REDIRECT_THEN_SEMI in marks` style assertion
+    is satisfied by exactly the mutant this population exists to kill.
+    """
+    mod = load_module()
+    assert sorted(mod.markers(command)) == sorted(expected), mod.markers(command)
+
+
+def test_the_marker_scanner_terminates_on_pathological_input():
+    """No marker is worth a hang on the hot path of every Bash call."""
+    mod = load_module()
+    for cmd in ("'" * 5000, '"' * 5000, "<" * 5000, "(" * 5000, "`" * 5000,
+                "<<" * 2000, ";" * 5000, "\\" * 5001, "a" * 200000 + "; b"):
+        assert isinstance(mod.markers(cmd), list)
+
+
+# --------------------------------------------------------------------------- #
+# INSTRUMENT CONTROL — the notification parser
+# --------------------------------------------------------------------------- #
+
+def test_the_completion_parser_reads_BOTH_spellings_of_the_notification():
+    """🔴 POSITIVE CONTROL, and the reason it exists is a measured failure.
+
+    The notification lives inside a JSON string in the transcript, so ON DISK its
+    quotes are backslash-escaped. The first pattern required a bare `"`, matched
+    nothing against a real transcript, and `report()` returned an empty
+    `announced_exit_codes` — indistinguishable from "the harness never announced
+    one". Both spellings are pinned, with a distinct exit code each, so a mutant
+    that handles only one is red and cannot be green for the other's reason.
+    """
+    mod = load_module()
+    escaped = (r'{"content":"<summary>Background command \"' + DESCRIPTION
+               + r'\" completed (exit code 1)</summary>"}')
+    bare = ('<summary>Background command "' + DESCRIPTION
+            + '" completed (exit code 7)</summary>')
+    assert mod.parse_completions(escaped) == {DESCRIPTION: [1]}
+    assert mod.parse_completions(bare) == {DESCRIPTION: [7]}
+
+
+def test_the_completion_parser_has_a_negative_control():
+    """It must be capable of finding NOTHING, or the test above proves little."""
+    mod = load_module()
+    assert mod.parse_completions("no notification here") == {}
+    assert mod.parse_completions('Background command "x" completed (exit code)') == {}
+    assert mod.parse_completions(None) == {}
+
+
+def test_a_repeated_description_keeps_every_exit_code():
+    """The notification is keyed on the description, which is not unique.
+
+    Returning the LIST keeps that ambiguity visible. Collapsing to the last value
+    would resolve, by write order, exactly the question an investigator is here
+    to answer.
+    """
+    mod = load_module()
+    text = ('Background command "dup" completed (exit code 0)\n'
+            'Background command "dup" completed (exit code 1)\n')
+    assert mod.parse_completions(text) == {"dup": [0, 1]}
+
+
+def test_report_puts_the_verbatim_command_and_the_announced_exit_code_on_one_row(capture_dir):
+    """END-TO-END: the artifact that settles 868ktvqf9.
+
+    Writes through the real hook, then joins through the real `report()` against
+    a transcript carrying the real (escaped) notification bytes, and asserts the
+    disagreeing pair land together: a command marked `REDIRECT_THEN_SEMI` next to
+    an announced exit code of 0.
+    """
+    mod = load_module()
+    rc, _, _ = run_hook(post_payload())
+    assert rc == 0
+    transcript = (r'{"content":"<summary>Background command \"' + DESCRIPTION
+                  + r'\" completed (exit code 0)</summary>"}')
+    res = mod.report(path=str(capture_dir / "commands.jsonl"),
+                     transcript_reader=lambda _p: transcript)
+    assert res["unparseable"] == 0
+    assert len(res["rows"]) == 1
+    row = res["rows"][0]
+    assert row["command"] == MASKING_COMMAND
+    assert row["announced_exit_codes"] == [0]
+    assert "REDIRECT_THEN_SEMI" in row["markers"]
+    assert row["background_task_id"] == TASK_ID
+
+
+def test_report_counts_unreadable_transcripts_instead_of_reporting_a_clean_zero(capture_dir):
+    """A transcript that cannot be read must be COUNTED, never absorbed.
+
+    Otherwise "no exit code was announced" and "I could not open the file that
+    holds it" render identically — which is the shape of the bug under
+    investigation, one layer down.
+    """
+    mod = load_module()
+    assert run_hook(pre_payload())[0] == 0
+
+    def boom(_p):
+        raise OSError("nope")
+
+    res = mod.report(path=str(capture_dir / "commands.jsonl"), transcript_reader=boom)
+    assert res["transcripts_unreadable"] == 1
+    assert res["rows"][0]["announced_exit_codes"] == []
+
+
+def test_read_records_counts_corrupt_lines_instead_of_dropping_them(capture_dir):
+    mod = load_module()
+    assert run_hook(pre_payload())[0] == 0
+    log = capture_dir / "commands.jsonl"
+    with open(log, "a", encoding="utf-8") as fh:
+        fh.write("{not json at all\n")
+        fh.write(json.dumps({"schema": "SOMETHING_ELSE"}) + "\n")
+    recs, bad = mod.read_records(str(log))
+    assert len(recs) == 1
+    assert bad == 2
+
+
+# --------------------------------------------------------------------------- #
+# BOUND, and FIDELITY under load
+# --------------------------------------------------------------------------- #
+
+def test_the_log_is_bounded_at_two_generations(capture_dir, monkeypatch):
+    """Rotation, measured against a cap the fixture overshoots rather than
+    lands on.
+
+    The cap is 4000 and each record is ~700 bytes of a 512-byte command — no
+    integer multiple of the record size equals the cap, so the rotation cannot
+    fire exactly on a boundary and pass for the wrong reason.
+
+    Asserts exactly two generations exist, never three, and that BOTH exist after
+    the final write: rotating after the append instead of before would leave no
+    live file in the window after a rotation, which reads to an investigator as
+    "the instrument never ran". The ceiling is `2 * (cap + one record)` — records
+    are never truncated, so a generation can overshoot by at most one of them.
+    """
+    mod = load_module()
+    log = capture_dir / "commands.jsonl"
+    os.makedirs(capture_dir, exist_ok=True)
+    cap = 4000
+    for i in range(60):
+        rec = mod.build_record("PreToolUse", pre_payload(
+            command="x" * 512 + " > /tmp/f%d 2>&1; echo %d" % (i, i)))
+        assert rec is not None
+        mod.append_record(rec, path=str(log), cap=cap)
+    files = sorted(p for p in os.listdir(capture_dir) if p.endswith(".jsonl"))
+    assert files == ["commands.1.jsonl", "commands.jsonl"], files
+    total = sum(os.path.getsize(capture_dir / f) for f in files)
+    assert total <= 2 * cap + 4096, total
+
+
+def test_a_huge_command_is_stored_verbatim_and_never_truncated(capture_dir):
+    """🔴 The bound is on the FILE, never on the record.
+
+    A truncated command is precisely the evidence that would be missing, so a
+    record larger than the whole cap must still round-trip byte-for-byte. Uses a
+    1 MiB command against the 4000-byte cap below it — the record is 260x the
+    cap, so any policy that bounded the record instead of the file is red here.
+    """
+    mod = load_module()
+    log = capture_dir / "commands.jsonl"
+    os.makedirs(capture_dir, exist_ok=True)
+    huge = "b" * (1024 * 1024) + " > /tmp/huge 2>&1; echo done"
+    rec = mod.build_record("PreToolUse", pre_payload(command=huge))
+    out = mod.append_record(rec, path=str(log), cap=4000)
+    assert out["written"] is True and out["error"] is None
+    # It rotated immediately (it is far over the cap), so read both generations.
+    recs, bad = mod.read_records(str(log))
+    assert bad == 0
+    assert len(recs) == 1
+    assert recs[0]["command"] == huge
+    assert len(recs[0]["command"]) == len(huge)
+
+
+def test_multibyte_and_control_characters_survive_the_round_trip(capture_dir):
+    mod = load_module()
+    log = capture_dir / "commands.jsonl"
+    os.makedirs(capture_dir, exist_ok=True)
+    cmd = "echo '日本語 \U0001f525\ttab' > /tmp/u; printf 'a\\nb'"
+    rec = mod.build_record("PreToolUse", pre_payload(command=cmd))
+    mod.append_record(rec, path=str(log))
+    recs, bad = mod.read_records(str(log))
+    assert bad == 0 and recs[0]["command"] == cmd
+
+
+# --------------------------------------------------------------------------- #
+# THE WRITE PREDICATE — a ledger, both directions
+# --------------------------------------------------------------------------- #
+
+PREDICATE = [
+    ("ls -la", False, False),
+    ("kubectl get pods", False, False),
+    ("run > f && echo ok", False, False),
+    ("python3 - <<'PY'\na; b\nPY", False, False),
+    # backgrounded, no marker: still recorded — the masking shape may be one
+    # nobody has thought of, which is the open question.
+    ("sleep 30", True, True),
+    ("pnpm test", True, True),
+    # foreground, marked: recorded — the self-inflicted `| tail` case was one.
+    ("pytest | tail -3", False, True),
+    ("run > f 2>&1; echo done", False, True),
+]
+
+
+@pytest.mark.parametrize("command, background, expected", PREDICATE,
+                         ids=[f"{c[:24]}|bg={b}" for c, b, _ in PREDICATE])
+def test_the_write_predicate_is_pinned_in_both_directions(command, background, expected):
+    """Neither half subsumes the other, and a one-way test would not show it.
+
+    A test that only pins hits is satisfied by "record everything", which would
+    turn a 16 MiB bound into hours of history instead of months. A test that only
+    pins misses is satisfied by "record nothing", which is the instrument being
+    absent. Four rows each way.
+    """
+    mod = load_module()
+    got = mod.should_record({"command": command, "run_in_background": background})
+    assert got is expected, mod.markers(command)
+
+
+# --------------------------------------------------------------------------- #
+# ON-DISK ARTIFACT NAMES
+# --------------------------------------------------------------------------- #
+
+def test_the_on_disk_artifact_names_are_pinned_as_whole_paths(tmp_path, monkeypatch):
+    """The COMPLETE set of paths the real writer creates under a throwaway $HOME.
+
+    Same form, and for the same reason, as
+    `scripts/claude-hooks/tests/test_on_disk_artifact_names.py`: writer and
+    reader here share one constant, so a rename is self-consistent and invisible
+    to every behavioural test above — while `home-manager switch` replaces this
+    file underneath live sessions, orphaning whatever the previous deploy wrote.
+    This log is EVIDENCE for an open ticket; orphaning it is how the next hit
+    gets captured into a file nobody looks at.
+
+    Compares the whole set, so it fails when the set GROWS as well as when it
+    shrinks: a future artifact arrives as a red test naming the new path.
+    """
+    mod = load_module()
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("CLAUDE_BG_CAPTURE_DIR", raising=False)
+    monkeypatch.delenv("CLAUDE_BG_CAPTURE_DISABLE", raising=False)
+    monkeypatch.delenv("CLAUDE_BG_CAPTURE_MAX_BYTES", raising=False)
+
+    rec = mod.build_record("PreToolUse", pre_payload())
+    # Twice, with a cap small enough to force the rotated generation to exist.
+    mod.append_record(rec, cap=1)
+    mod.append_record(rec, cap=1)
+
+    found = sorted(
+        os.path.relpath(os.path.join(dirpath, name), home)
+        for dirpath, _dirs, names in os.walk(home) for name in names
+    )
+    assert found == [
+        ".local/state/claude-bg-command-capture/commands.1.jsonl",
+        ".local/state/claude-bg-command-capture/commands.jsonl",
+    ], found
+
+
+def test_the_state_dir_is_resolved_per_call_not_baked_at_import(tmp_path, monkeypatch):
+    """A module constant resolved at import bakes the developer's real home into
+    every test — and, worse, into any long-lived process that imports it before
+    the environment is set."""
+    mod = load_module()
+    monkeypatch.setenv("HOME", str(tmp_path / "one"))
+    first = mod.state_dir()
+    monkeypatch.setenv("HOME", str(tmp_path / "two"))
+    assert mod.state_dir() != first
+
+
+# --------------------------------------------------------------------------- #
+# THE DELIVERY SEAM — deployed and registered, or it is inert
+# --------------------------------------------------------------------------- #
+
+def test_home_manager_deploys_both_files_beside_each_other():
+    """The hook imports its library as a SIBLING in `~/.claude/hooks/`.
+
+    Deploying one without the other is a green switch and an inert hook — the
+    #452 shape this repo has already paid for once. Pins both declarations.
+    """
+    nix = open(os.path.join(ROOT, "nix", "home.nix"), encoding="utf-8").read()
+    assert '".claude/hooks/bg-command-capture.py"' in nix
+    assert '".claude/hooks/bg_command_capture.py"' in nix
+    assert "../scripts/claude-hooks/bg-command-capture.py" in nix
+    assert "../scripts/lib/bg_command_capture.py" in nix
+
+
+def test_the_registrar_registers_it_on_both_bash_events():
+    """A script in `~/.claude/hooks/` registers NOTHING by itself.
+
+    Both events, because they capture different halves: PreToolUse has the
+    verbatim command and the background flag, PostToolUse has the task id.
+    Registering one is half an instrument.
+    """
+    src = open(os.path.join(HOOKS, "register-nudge-hook.py"), encoding="utf-8").read()
+    pre = src.split("PRE_BASH_CMDS = [", 1)[1].split("]", 1)[0]
+    post = src.split("POST_BASH_CMDS = [", 1)[1].split("]", 1)[0]
+    assert "bg-command-capture.py" in pre, "not registered on PreToolUse"
+    assert "bg-command-capture.py" in post, "not registered on PostToolUse"
+
+
+def test_the_gate_runs_this_file():
+    """This suite must be named by run-tests.sh, or nothing runs it.
+
+    The #276 shape: a suite that exists, passes locally, and no gate collects.
+    """
+    src = open(os.path.join(ROOT, "scripts", "run-tests.sh"), encoding="utf-8").read()
+    target = "scripts/claude-hooks/tests/test_bg_command_capture.py"
+    assert target in src.split("HERMETIC_TARGETS=(", 1)[1].split("\n)", 1)[0]
+    assert f'"{target}|' in src, "no TARGET_FLOORS entry"

--- a/scripts/claude-hooks/tests/test_on_disk_artifact_names.py
+++ b/scripts/claude-hooks/tests/test_on_disk_artifact_names.py
@@ -529,6 +529,18 @@ OWNS_NO_ON_DISK_STATE = {
                                  # a per-session "already asked" counter would let a
                                  # second create in the same turn through unchecked.
     "bash-guard.py",             # thin wrapper over guard_core.py
+    "bg-command-capture.py",     # delegates every path to lib/bg_command_capture.py,
+                                 # exactly as agent-ledger-hook.py does. Its names
+                                 # ARE pinned — as whole relative paths, in the same
+                                 # form as this file — by
+                                 # tests/test_bg_command_capture.py::
+                                 # test_the_on_disk_artifact_names_are_pinned_as_whole_paths.
+                                 # 🔴 Its state root is `.local/state`, which
+                                 # CACHE_LITERAL below does not match: the
+                                 # corroboration scan is blind to it by construction,
+                                 # which is precisely the blind spot that test's own
+                                 # docstring names. The enumeration, not the scan, is
+                                 # what covers this entry.
     "guard_core.py",             # pure predicate library
     "register-nudge-hook.py",    # writes ~/.claude/settings.json; the deployed-path
                                  # seam is pinned by test_registrar_activation.py

--- a/scripts/claude-hooks/tests/test_register_nudge_hook.py
+++ b/scripts/claude-hooks/tests/test_register_nudge_hook.py
@@ -118,6 +118,11 @@ LEDGER = PY + " ~/.claude/hooks/agent-ledger-hook.py"
 WRITEBACK = PY + " ~/.claude/hooks/clawgate-writeback-guard.py"
 INTERVIEW = PY + " ~/.claude/hooks/clawgate-task-interview-guard.py"
 BASH_GUARD = PY + " ~/.claude/hooks/bash-guard.py"
+# The backgrounded-command capture log (ClickUp 868ktvqf9) — the SECOND entry
+# PRE_BASH_CMDS owns, and the reason several whole-list equalities below moved.
+# It is instrumentation: no permissionDecision, no stdout, exit 0 always, so it
+# widens what PreToolUse OBSERVES and not what it can refuse.
+BG_CAPTURE = PY + " ~/.claude/hooks/bg-command-capture.py"
 
 # The pre-migration spellings, i.e. what is on both hosts right now.
 OLD_BASH_GUARD = "python3 ~/.claude/hooks/bash-guard.py"
@@ -276,10 +281,13 @@ with tempfile.TemporaryDirectory() as tmp:
     # owns — asserted by identity, not by a count, so "gained an entry" cannot be
     # confused with "gained the right entry". Before PRE_BASH_CMDS existed this
     # read `len(pre_entries) == 3`; PreToolUse was rewrite-only then.
-    check("6: PreToolUse gained exactly ONE entry, and it is the appended interview guard",
-          len(pre_entries) == 4
+    check("6: PreToolUse gained exactly TWO entries, and they are the two the "
+          "append table owns — the interview guard and the capture log",
+          len(pre_entries) == 5
           and pre_entries[3]["hooks"][0]["command"] == INTERVIEW
-          and pre_entries[3].get("matcher") == "Bash")
+          and pre_entries[3].get("matcher") == "Bash"
+          and pre_entries[4]["hooks"][0]["command"] == BG_CAPTURE
+          and pre_entries[4].get("matcher") == "Bash")
     check("6: the three pre-existing PreToolUse entries kept their positions",
           [e["hooks"][0]["command"] for e in pre_entries[:3]]
           == [FOREIGN_ELSEWHERE, BASH_GUARD, FOREIGN_UNMANAGED_HOOK])
@@ -295,10 +303,14 @@ with tempfile.TemporaryDirectory() as tmp:
           d["hooks"]["PermissionRequest"][0]["hooks"][0].get("timeout") == 180)
     check("7: the two foreign .sh Stop hooks are untouched",
           TMUX_STOP in stop and CLAWGATE_STOP in stop)
-    check("7: PreToolUse is the three commands it started with (one rewritten) plus the interview guard",
-          pre == [FOREIGN_ELSEWHERE, BASH_GUARD, FOREIGN_UNMANAGED_HOOK, INTERVIEW])
+    check("7: PreToolUse is the three commands it started with (one rewritten) "
+          "plus the two the append table owns",
+          pre == [FOREIGN_ELSEWHERE, BASH_GUARD, FOREIGN_UNMANAGED_HOOK,
+                  INTERVIEW, BG_CAPTURE])
     check("7: the interview guard is registered exactly once",
           pre.count(INTERVIEW) == 1)
+    check("7: the capture log is registered exactly once",
+          pre.count(BG_CAPTURE) == 1)
 
     check("2: both PostToolUse nudges preserved",
           any(c.endswith("/audit-pr-nudge.py") for c in cmds(d, "PostToolUse"))
@@ -317,8 +329,9 @@ with tempfile.TemporaryDirectory() as tmp:
     SHELL_HOMEVAR = PY + " $HOME/.claude/hooks/shell-env-nudge.py"
     check("8: PostToolUse holds exactly the three migrated hooks plus the two appended ones",
           set(post) == {PY + " ~/.claude/hooks/audit-pr-nudge.py",
-                        SHELL_HOMEVAR, WB_EXPANDED, SEARCH_NUDGE, LEDGER})
-    check("8: no hook was double-registered", len(post) == 5)
+                        SHELL_HOMEVAR, WB_EXPANDED, SEARCH_NUDGE, LEDGER,
+                        BG_CAPTURE})
+    check("8: no hook was double-registered", len(post) == 6)
     check("8: the $HOME/ spelling was rewritten in place, not re-added",
           post.count(SHELL_HOMEVAR) == 1
           and PY + " ~/.claude/hooks/shell-env-nudge.py" not in post)
@@ -503,8 +516,9 @@ with tempfile.TemporaryDirectory() as tmp:
         d4 = json.load(f)
     check("10: every unrecognised command came back BYTE-IDENTICAL, in place",
           cmds(d4, "PreToolUse")[:len(UNRECOGNISED)] == UNRECOGNISED)
-    check("10: ...and the ONLY thing added to PreToolUse is the interview guard",
-          cmds(d4, "PreToolUse") == UNRECOGNISED + [INTERVIEW])
+    check("10: ...and the ONLY things added to PreToolUse are the two the append "
+          "table owns",
+          cmds(d4, "PreToolUse") == UNRECOGNISED + [INTERVIEW, BG_CAPTURE])
     # Anti-vacuity: this run DID rewrite/append elsewhere in the same file, so
     # the check above is about the recogniser and not about a run that no-oped.
     check("10: ...while the run did its normal work on the same file",
@@ -701,7 +715,8 @@ with tempfile.TemporaryDirectory() as tmp:
           "distinct-matcher entry SURVIVED on a matcher-supporting event",
           entries(d12, "PostToolUse") == [
               ("Bash", AUDIT), ("Bash", SHELL), ("Bash", SEARCH_NUDGE),
-              (None, LEDGER), ("Bash", LEDGER), (None, WRITEBACK)])
+              (None, LEDGER), ("Bash", LEDGER), (None, WRITEBACK),
+              ("Bash", BG_CAPTURE)])
     check("12: Stop healed, keeping the first copy of each and the three survivors",
           entries(d12, "Stop") == [
               (None, TMUX_STOP), (None, CLAWGATE_STOP),
@@ -722,7 +737,7 @@ with tempfile.TemporaryDirectory() as tmp:
     # removed. Its registration belongs to the host.
     check("12: the doubled bash-guard entry is PINNED but NOT deleted",
           entries(d12, "PreToolUse") == [("Bash", BASH_GUARD), ("Bash", BASH_GUARD),
-                                         ("Bash", INTERVIEW)])
+                                         ("Bash", INTERVIEW), ("Bash", BG_CAPTURE)])
     # The first bash-guard entry keeps both keys this script knows nothing about.
     check("12: the surviving bash-guard entry kept its foreign keys",
           d12["hooks"]["PreToolUse"][0].get("description")
@@ -864,8 +879,13 @@ for hostile, why, hostile_cwd, expected_reason in HOSTILE_OVERRIDES:
               all(expected_reason in r.stderr for r in runs))
         # THE UNBOUNDED-GROWTH LOOP, CLOSED: a literal, not a comparison against
         # run 1 — a run that appended nothing at all would satisfy `a == b == c`.
-        check(tag + ": three consecutive runs hold exactly 16 hook commands",
-              counts == [16, 16, 16])
+        # 16 -> 18: the backgrounded-command capture log (868ktvqf9) joined BOTH
+        # PRE_BASH_CMDS and POST_BASH_CMDS, so one converged run holds two more
+        # commands than it did. The literal stays a literal — `a == b == c` is
+        # satisfied by a run that appends nothing at all, which is the unbounded-
+        # growth guard's own failure mode inverted.
+        check(tag + ": three consecutive runs hold exactly 18 hook commands",
+              counts == [18, 18, 18])
         with open(settings) as f:
             d13 = json.load(f)
         written = [c for ev in d13.get("hooks", {}) for c in cmds(d13, ev)
@@ -913,7 +933,7 @@ with tempfile.TemporaryDirectory() as tmp:
     with open(settings) as f:
         d14 = json.load(f)
     check("14: every unpinnable command came back BYTE-IDENTICAL",
-          cmds(d14, "PreToolUse") == UNPINNABLE + SILENT + [INTERVIEW])
+          cmds(d14, "PreToolUse") == UNPINNABLE + SILENT + [INTERVIEW, BG_CAPTURE])
     check("14: exactly one warning per unpinnable command, and no more",
           p14.stderr.count("is not in the form this script can pin") == 5)
     for c in UNPINNABLE:

--- a/scripts/claude-hooks/tests/test_registrar_activation.py
+++ b/scripts/claude-hooks/tests/test_registrar_activation.py
@@ -92,6 +92,7 @@ LEDGER = HOOK_PY + " ~/.claude/hooks/agent-ledger-hook.py"
 WRITEBACK = HOOK_PY + " ~/.claude/hooks/clawgate-writeback-guard.py"
 INTERVIEW = HOOK_PY + " ~/.claude/hooks/clawgate-task-interview-guard.py"
 BASH_GUARD = HOOK_PY + " ~/.claude/hooks/bash-guard.py"
+BG_CAPTURE = HOOK_PY + " ~/.claude/hooks/bg-command-capture.py"
 CLAWGATE_STOP = "/home/zach/.claude/clawgate-stop-hook.sh"
 TMUX_STOP = "~/.config/tmux/task-hook.sh"
 
@@ -247,10 +248,14 @@ def test_unrelated_settings_content_is_untouched(tmp_path):
     # 127 mid-switch, and a PreToolUse hook exiting 127 fails OPEN) while its
     # REGISTRATION is left exactly as it was — still ONE entry, still first, never
     # created and never duplicated. Two surfaces, two widths; see the registrant's
-    # docstring. The only other entry is the clawgate task interview guard, which
-    # the registrant DOES own. Asserted as a whole-list equality so a third entry,
-    # or a doubled bash-guard, fails it.
-    assert pre == [BASH_GUARD, INTERVIEW], pre
+    # docstring. The other entries are ones the registrant DOES own: the clawgate
+    # task interview guard, and the backgrounded-command capture log (868ktvqf9),
+    # which is INSTRUMENTATION — it emits no permissionDecision and cannot refuse a
+    # command, so its presence here widens what PreToolUse OBSERVES and not what it
+    # can block. Asserted as a whole-list equality, IN ORDER, so a fourth entry or a
+    # doubled bash-guard fails it — the strictness is the point, and is why adding a
+    # PreToolUse hook has to come through this line.
+    assert pre == [BASH_GUARD, INTERVIEW, BG_CAPTURE], pre
 
 
 def test_a_settings_file_that_already_has_the_nudge_is_left_byte_identical(tmp_path):

--- a/scripts/lib/bg_command_capture.py
+++ b/scripts/lib/bg_command_capture.py
@@ -1,0 +1,768 @@
+#!/usr/bin/env python3
+"""Verbatim capture of every BACKGROUNDED (and every status-MASKING) Bash call.
+
+WHY THIS EXISTS — ClickUp 868ktvqf9
+-----------------------------------
+A full unit-suite run routed through the civitai dev-server test queue exits
+non-zero and the harness's background-task notification reports **exit 0**.
+`cli.mjs test list` says `exitCode: 1`; the notification says `0`. At the moment
+the notification arrives the run's output file is **0 bytes**, so the two
+independent things an investigator would check BOTH report green over a red run.
+Four hits in one day across four agents; never reproduced deliberately since.
+
+The leading hypothesis is that a trailing `; echo` / `; tail` **after a
+redirect** makes the notification carry THAT command's status rather than the
+run's — which is why "no pipe is involved" did not rule it out. `;` is not a
+pipe. The investigating agent did it to itself twice.
+
+🔴 **THE SINGLE ARTIFACT THAT DISCRIMINATES IS THE VERBATIM COMMAND STRING THAT
+WAS BACKGROUNDED**, and nothing in the harness keeps it anywhere an investigator
+can reach after the fact in a form they can trust. This module is that record.
+It is INSTRUMENTATION, not a fix: it does not change, wrap, rewrite or refuse any
+command. It writes a line and gets out of the way.
+
+WHAT THE HARNESS ACTUALLY GIVES US — MEASURED, not assumed
+----------------------------------------------------------
+Measured 2026-08-21 by reading real `~/.claude/projects/**/*.jsonl` transcripts
+on this host, not from documentation (the docs are silent on three of the four):
+
+  1. `PreToolUse{tool_name:"Bash"}.tool_input` is exactly
+         {command, description, timeout, run_in_background}
+     `command` is the VERBATIM string and `run_in_background` is the boolean.
+     This is the one place the discriminating artifact is available at all.
+
+  2. `PostToolUse{tool_name:"Bash"}.tool_response` for a BACKGROUNDED call is
+         {stdout:"", stderr:"", interrupted:false, isImage:false,
+          noOutputExpected:false, backgroundTaskId:"bqj4lb0w5"}
+     🔴 **There is NO exit code, and there cannot be**: PostToolUse fires when the
+     command is LAUNCHED, not when it finishes. stdout/stderr are empty strings
+     because nothing has run yet. `backgroundTaskId` names the output file the
+     operator later finds at 0 bytes.
+
+  3. The completion notification is NOT a hook event. It is injected into the
+     conversation as a user-role message reading, verbatim:
+         <summary>Background command "DESCRIPTION" completed (exit code N)</summary>
+     🔴 It is keyed on the `description` field — NOT on `backgroundTaskId`. That
+     is why this record captures `description` verbatim alongside the command:
+     the description is the ONLY join key between a captured command and the
+     exit code the harness announced for it.
+
+  4. No hook event fires at background completion. Searched every event this
+     host registers; none carries a terminal status for a backgrounded task.
+
+So the honest division of labour is:
+
+     THIS MODULE (hook, live)   ->  the verbatim command + description + task id
+     `report()` (CLI, later)    ->  joins that against the transcript's
+                                    `completed (exit code N)` line
+
+Two halves, in one file, both greppable. `report()` is where the two numbers are
+put next to each other; the hook never claims to know an exit code it cannot see.
+🔴 `harness_exit_field` on a PostToolUse record is therefore almost always null,
+and that is a MEASUREMENT ("we looked for an exit field in tool_response and
+there was none"), not a placeholder. `response_keys` is the asserted ledger
+beside it: if a future harness starts supplying a status key, it appears there
+and the null stops being the whole story.
+
+WHAT IS RECORDED, AND WHAT IS NOT
+---------------------------------
+Recorded: an invocation that is BACKGROUNDED, **or** one whose command carries a
+status-masking marker (see below). Everything else is skipped without touching
+the disk — that predicate is a single pass over a string, no I/O, and it is what
+keeps a hook on the hot path of every Bash call cheap.
+
+🔴 The command is stored VERBATIM — no truncation, no expansion, no
+normalisation, no shell parsing applied to the stored value. A normalised record
+cannot answer the question this exists to answer. Boundedness is enforced at the
+FILE (one rotation generation, hard ceiling `2 * max_bytes`), never at the
+record: a truncated command is exactly the evidence that would be missing.
+
+THE MARKERS
+-----------
+`REDIRECT_THEN_SEMI` is the one the ticket asks for: a top-level redirect appears
+BEFORE the final top-level `;`/newline separator, and that separator has a real
+command after it — i.e. `run > out.log 2>&1; echo done`, whose reported status is
+`echo`'s. `TRAILING_SEMI` is the same shape with no redirect; `TRAILING_PIPE` is
+its better-known sibling (`... | tail`), included because it is the variant the
+investigating agent hit twice and it costs nothing to detect in the same pass.
+
+They are TRIAGE MARKERS, not a gate. Nothing is blocked, warned or rewritten on
+them; they exist so `grep REDIRECT_THEN_SEMI` finds the population. A marker is
+allowed to be wrong in the false-positive direction — an extra grep hit costs a
+glance. The scanner does track quotes, escapes, `$(...)`/backtick nesting,
+comments and HEREDOC BODIES, because heredocs are pervasive on this host and an
+untracked one turns every `;` in a Python payload into a false marker.
+
+FAIL-OPEN, ALWAYS
+-----------------
+🔴 This runs before AND after every Bash call in every Claude Code session on
+this box. A hook that raises breaks the operator's shell. Every entry point here
+returns rather than raises, the adapter wraps everything in a bare `except
+BaseException`, and nothing is ever written to stdout or stderr. The worst case
+of a total failure of this module is that the next hit is not captured — which is
+the status quo it is replacing, so degrading silently is strictly no worse.
+
+Set `CLAUDE_BG_CAPTURE_DISABLE=1` to turn it off without a switch.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+
+# --- on-disk names -----------------------------------------------------------
+# 🔴 Pinned behaviourally by tests/test_bg_command_capture.py, in the shape
+# scripts/claude-hooks/tests/test_on_disk_artifact_names.py established: the real
+# writer is driven against a throwaway $HOME and the COMPLETE set of resulting
+# relative paths is compared to a literal list. Renaming any component here
+# orphans whatever the previous deploy wrote, and a `home-manager switch`
+# replaces this file underneath live sessions — so the rename is invisible to
+# every behavioural test and visible only as evidence that quietly stops
+# accumulating.
+SCHEMA = "BG_COMMAND_CAPTURE_V1"
+STATE_SUBDIR = os.path.join(".local", "state", "claude-bg-command-capture")
+LOG_NAME = "commands.jsonl"
+ROTATED_NAME = "commands.1.jsonl"
+
+# 8 MiB live + 8 MiB rotated = a 16 MiB hard ceiling for the whole instrument.
+# Sized against the measured Bash volume on this host (37.5k calls / 30 days, of
+# which only the backgrounded and marker-carrying minority are written): months
+# of history, and bounded whatever happens.
+DEFAULT_MAX_BYTES = 8 * 1024 * 1024
+
+MARK_REDIRECT_THEN_SEMI = "REDIRECT_THEN_SEMI"
+MARK_TRAILING_SEMI = "TRAILING_SEMI"
+MARK_TRAILING_PIPE = "TRAILING_PIPE"
+
+# The completion notification, verbatim from the transcripts (see docstring §3).
+#
+# 🔴 `\\?"` — THE OPTIONAL BACKSLASH IS LOAD-BEARING AND WAS MEASURED, NOT
+# ANTICIPATED. The notification lives inside a JSON string in the transcript, so
+# on disk its quotes are ESCAPED: the bytes read `\"Run main unit suite\"`, not
+# `"Run main unit suite"`. The first version of this pattern required a bare `"`,
+# matched nothing, and `report()` returned `announced_exit_codes: []` for a
+# record whose exit code was sitting in the file three inches away. That is the
+# reassuring-zero shape this whole instrument exists to stop, reproduced inside
+# the instrument — an empty result that reads as "the harness never announced
+# one" when it means "my pattern is wrong". `parse_completions` therefore ships
+# with a positive control in its own test: a line that MUST produce a non-zero
+# count, in BOTH spellings.
+#
+# `.*?` is LAZY, and that too was measured rather than chosen. Greedy, the
+# capture swallowed the escaping backslash itself — the optional `\\?` then
+# matched zero characters and the joined key came back as
+# `'Run main unit suite in background\\'`, which matches no record's
+# description. The join failed for a SECOND reason after the first was fixed,
+# still reporting an empty list rather than an error. Lazy plus the long literal
+# anchor `" completed (exit code N)` gives the backslash to the delimiter where
+# it belongs; a description containing that whole anchor phrase is not a case
+# worth trading this for.
+COMPLETION_RE = re.compile(
+    r'Background command (?:\\)?"(.*?)(?:\\)?" completed \(exit code (-?\d+)\)'
+)
+
+# Keys in a `tool_response` that could plausibly carry a terminal status. Looked
+# for explicitly so the null in `harness_exit_field` is a measurement rather than
+# an assumption — see the docstring.
+_EXIT_KEYS = ("exitCode", "exit_code", "exitStatus", "returnCode",
+              "return_code", "returncode", "code", "status")
+
+
+def state_dir() -> str:
+    """The directory records are written to. `$CLAUDE_BG_CAPTURE_DIR` wins.
+
+    Resolved per CALL, never into a module constant: the tests redirect `$HOME`,
+    and a constant baked at import would bake the developer's real home into
+    every one of them (the trap `test_on_disk_artifact_names.py` documents).
+    """
+    override = os.environ.get("CLAUDE_BG_CAPTURE_DIR")
+    if override:
+        return override
+    return os.path.join(os.path.expanduser("~"), STATE_SUBDIR)
+
+
+def log_path() -> str:
+    return os.path.join(state_dir(), LOG_NAME)
+
+
+def max_bytes() -> int:
+    raw = os.environ.get("CLAUDE_BG_CAPTURE_MAX_BYTES")
+    if raw:
+        try:
+            val = int(raw)
+            if val > 0:
+                return val
+        except (TypeError, ValueError):
+            pass
+    return DEFAULT_MAX_BYTES
+
+
+def disabled() -> bool:
+    return (os.environ.get("CLAUDE_BG_CAPTURE_DISABLE") or "").strip() not in ("", "0")
+
+
+# --------------------------------------------------------------------------- #
+# The scanner
+# --------------------------------------------------------------------------- #
+
+def _scan(cmd):
+    """One pass over `cmd`. Returns (redirects, separators, pipes) — the byte
+    offsets of TOP-LEVEL redirect operators, `;`/newline separators and single
+    `|` pipes.
+
+    "Top level" means: not inside `'...'`, not inside `"..."`, not inside a
+    `$(...)`/`(...)` group, not inside backticks, not in a `#` comment, and NOT
+    inside a heredoc body. That last exclusion is the one that earns its
+    complexity here — `python3 - <<'PY' … PY` payloads are pervasive on this
+    host, and every `;` and newline in one would otherwise read as a top-level
+    separator and mark the command.
+
+    `&&` and `||` are deliberately NOT separators: they short-circuit, so the
+    status of `a > f && echo` is `a`'s when `a` fails. They do not mask. `;`,
+    a bare newline and `|` do.
+    """
+    redirects, separators, pipes = [], [], []
+    if not isinstance(cmd, str):
+        return redirects, separators, pipes
+    i, n = 0, len(cmd)
+    in_sq = in_dq = in_bt = False
+    depth = 0
+    heredocs = []  # queued (delimiter, strip_leading_tabs) awaiting a newline
+
+    def top():
+        return depth == 0 and not in_bt
+
+    while i < n:
+        c = cmd[i]
+
+        if in_sq:
+            if c == "'":
+                in_sq = False
+            i += 1
+            continue
+        if in_dq:
+            if c == "\\" and i + 1 < n:
+                i += 2
+                continue
+            if c == '"':
+                in_dq = False
+            i += 1
+            continue
+        if c == "\\" and i + 1 < n:
+            i += 2
+            continue
+        if c == "'":
+            in_sq = True
+            i += 1
+            continue
+        if c == '"':
+            in_dq = True
+            i += 1
+            continue
+        if c == "`":
+            in_bt = not in_bt
+            i += 1
+            continue
+        if c == "#" and (i == 0 or cmd[i - 1] in " \t\n;|&("):
+            j = cmd.find("\n", i)
+            if j < 0:
+                break
+            i = j
+            continue
+        if c == "(":
+            depth += 1
+            i += 1
+            continue
+        if c == ")":
+            if depth:
+                depth -= 1
+            i += 1
+            continue
+
+        if c == "<":
+            # `<<<` is a here-STRING, not a heredoc. Checked first, and skipped
+            # whole: advancing by one would leave the remaining `<<` looking like
+            # a heredoc introducer and swallow the rest of the command as a body.
+            if cmd.startswith("<<<", i):
+                if top():
+                    redirects.append(i)
+                i += 3
+                continue
+            if cmd.startswith("<<", i):
+                j = i + 2
+                strip = False
+                if j < n and cmd[j] == "-":
+                    strip = True
+                    j += 1
+                while j < n and cmd[j] in " \t":
+                    j += 1
+                delim = ""
+                if j < n and cmd[j] in "'\"":
+                    q = cmd[j]
+                    j += 1
+                    start = j
+                    while j < n and cmd[j] != q:
+                        j += 1
+                    delim = cmd[start:j]
+                    if j < n:
+                        j += 1
+                else:
+                    start = j
+                    while j < n and (cmd[j].isalnum() or cmd[j] in "_-."):
+                        j += 1
+                    delim = cmd[start:j]
+                if delim:
+                    heredocs.append((delim, strip))
+                    if top():
+                        redirects.append(i)
+                    i = j
+                    continue
+                i += 2
+                continue
+            if top():
+                redirects.append(i)
+            i += 1
+            continue
+
+        if c == ">":
+            if top():
+                redirects.append(i)
+            i += 1
+            continue
+
+        if c == "\n":
+            if heredocs:
+                i += 1
+                while heredocs:
+                    delim, strip = heredocs.pop(0)
+                    while i < n:
+                        j = cmd.find("\n", i)
+                        line = cmd[i:] if j < 0 else cmd[i:j]
+                        i = n if j < 0 else j + 1
+                        probe = line.lstrip("\t") if strip else line
+                        if probe.rstrip("\r") == delim:
+                            break
+                # 🔴 THE SEPARATOR IS THE NEWLINE AFTER THE DELIMITER LINE, NOT
+                # THE ONE THAT OPENED THE BODY. Recording the opening newline
+                # would make `_real_tail` see the heredoc BODY as the trailing
+                # command and mark every heredoc; recording nothing at all loses
+                # the genuine separator in `python3 - <<'PY' > log\n…\nPY\necho
+                # done`, which is exactly the masking shape, and the first draft
+                # did precisely that — the suite caught it.
+                if top() and i - 1 >= 0 and cmd[i - 1] == "\n":
+                    separators.append(i - 1)
+                continue
+            if top():
+                separators.append(i)
+            i += 1
+            continue
+
+        if c == ";":
+            # `;;` and `;&` are `case` terminators, not command separators.
+            if cmd.startswith(";;", i) or cmd.startswith(";&", i):
+                i += 2
+                continue
+            if top():
+                separators.append(i)
+            i += 1
+            continue
+
+        if c == "|":
+            if cmd.startswith("||", i):
+                i += 2
+                continue
+            if top():
+                pipes.append(i)
+            i += 1
+            continue
+
+        if c == "&":
+            if cmd.startswith("&&", i):
+                i += 2
+                continue
+            i += 1
+            continue
+
+        i += 1
+
+    return redirects, separators, pipes
+
+
+def _real_tail(cmd, pos):
+    """Is there a REAL command after the separator at `pos`?
+
+    A trailing `;`, trailing whitespace, or a trailing `# comment` is not a
+    masking command — `a > f;` reports `a`'s status, so marking it would be a
+    false positive on the shape the ticket is about.
+    """
+    tail = cmd[pos + 1:].strip()
+    return bool(tail) and not tail.startswith("#")
+
+
+def markers(cmd):
+    """The status-masking markers this command carries. Never raises."""
+    try:
+        redirects, separators, pipes = _scan(cmd)
+    except Exception:  # noqa: BLE001 — a marker is never worth breaking a shell
+        return []
+    out = []
+
+    last_sep = None
+    for pos in separators:
+        if _real_tail(cmd, pos):
+            last_sep = pos
+    if last_sep is not None:
+        out.append(MARK_TRAILING_SEMI)
+        if any(r < last_sep for r in redirects):
+            out.append(MARK_REDIRECT_THEN_SEMI)
+
+    seg_start = 0 if last_sep is None else last_sep + 1
+    if any(p >= seg_start and _real_tail(cmd, p) for p in pipes):
+        out.append(MARK_TRAILING_PIPE)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Records
+# --------------------------------------------------------------------------- #
+
+def now_iso(now=None):
+    t = time.time() if now is None else now
+    return time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(t)) + "Z"
+
+
+def should_record(tool_input, marks=None):
+    """The write predicate: BACKGROUNDED, or status-MASKING.
+
+    Both halves matter and neither subsumes the other. Backgrounded-only would
+    miss the foreground `cmd | tail` that produced the same false green twice;
+    marker-only would miss a backgrounded run whose masking shape nobody has
+    thought of yet, which is precisely the open question.
+    """
+    if not isinstance(tool_input, dict):
+        return False
+    if bool(tool_input.get("run_in_background")):
+        return True
+    if marks is None:
+        marks = markers(tool_input.get("command") or "")
+    return bool(marks)
+
+
+def build_record(event, payload, now=None):
+    """Payload -> record, or None when this invocation is not ours to write.
+
+    🔴 `command` and `description` are copied through UNMODIFIED. Everything
+    else on the record is derived; these two are evidence.
+    """
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("tool_name") != "Bash":
+        return None
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return None
+    command = tool_input.get("command")
+    if not isinstance(command, str) or not command:
+        return None
+
+    marks = markers(command)
+    if not should_record(tool_input, marks):
+        return None
+
+    rec = {
+        "schema": SCHEMA,
+        "event": event,
+        "ts": now_iso(now),
+        "session_id": payload.get("session_id"),
+        "tool_use_id": payload.get("tool_use_id"),
+        "cwd": payload.get("cwd"),
+        "transcript_path": payload.get("transcript_path"),
+        "background": bool(tool_input.get("run_in_background")),
+        "timeout_ms": tool_input.get("timeout"),
+        # The JOIN KEY for the completion notification. See docstring §3 — the
+        # notification quotes this string and nothing else that identifies the
+        # run, so a record without it cannot be tied to an exit code.
+        "description": tool_input.get("description"),
+        "markers": marks,
+        "command": command,
+    }
+
+    if event == "PostToolUse":
+        resp = payload.get("tool_response")
+        if isinstance(resp, dict):
+            rec["background_task_id"] = resp.get("backgroundTaskId")
+            # The asserted ledger: the COMPLETE key set the harness sent. If a
+            # future harness starts carrying a terminal status, it shows up here
+            # rather than being silently absent forever.
+            rec["response_keys"] = sorted(resp.keys())
+            rec["interrupted"] = resp.get("interrupted")
+            for k in _EXIT_KEYS:
+                if k in resp:
+                    rec["harness_exit_field"] = {"key": k, "value": resp[k]}
+                    break
+            else:
+                rec["harness_exit_field"] = None
+            for name, key in (("stdout_len", "stdout"), ("stderr_len", "stderr")):
+                val = resp.get(key)
+                rec[name] = len(val) if isinstance(val, str) else None
+        else:
+            rec["background_task_id"] = None
+            rec["response_keys"] = None
+            rec["harness_exit_field"] = None
+    return rec
+
+
+def append_record(rec, path=None, cap=None):
+    """Append one JSON line, then rotate if the file has outgrown its cap.
+
+    Returns a small dict describing what happened; never raises.
+
+    THE WRITE IS ONE `os.write()` ON AN `O_APPEND` FD. Concurrency here is real —
+    many sessions share this host and each has its own hook process — and
+    `O_APPEND` makes the offset update atomic, so two writers cannot overwrite
+    one another. Interleaving WITHIN a single very large record (a multi-megabyte
+    heredoc) is not formally excluded by POSIX; that is why every reader in this
+    module COUNTS unparseable lines and reports the count rather than dropping
+    them silently. A reassuring zero is not on offer.
+
+    Rotation keeps exactly ONE generation, so the instrument's total footprint is
+    hard-bounded no matter how long it runs. `os.replace` is atomic; if two
+    processes rotate at once the loser's generation is lost, which costs history
+    and cannot corrupt the live file.
+
+    🔴 THE ROTATION HAPPENS BEFORE THE APPEND, NOT AFTER, and the ordering is
+    behavioural rather than cosmetic. Rotating after leaves NO live file in the
+    window between a rotation and the next write — so an investigator arriving in
+    that window finds `commands.jsonl` missing and reads it as "the instrument
+    never ran", which is the reassuring-absence this whole thing exists to
+    remove. Checked before, the live file exists after every write.
+
+    The exact ceiling that follows: each generation is at most `cap` plus ONE
+    record, because a record is never split or truncated (see the module
+    docstring — a truncated command is the evidence that would be missing), so
+    the total is `2 * (cap + largest_record)`. Stating it as plain `2 * cap`
+    would be wrong in the one direction that matters, on exactly the
+    multi-megabyte heredoc commands this host runs.
+    """
+    out = {"written": False, "rotated": False, "error": None}
+    if rec is None:
+        return out
+    try:
+        path = path or log_path()
+        cap = cap or max_bytes()
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        try:
+            if os.path.getsize(path) > cap:
+                os.replace(path, os.path.join(os.path.dirname(path), ROTATED_NAME))
+                out["rotated"] = True
+        except FileNotFoundError:
+            pass
+        line = json.dumps(rec, ensure_ascii=False) + "\n"
+        blob = line.encode("utf-8")
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        try:
+            os.write(fd, blob)
+        finally:
+            os.close(fd)
+        out["written"] = True
+    except Exception as exc:  # noqa: BLE001 — see the module docstring
+        out["error"] = "%s: %s" % (type(exc).__name__, exc)
+    return out
+
+
+def read_records(path=None, include_rotated=True):
+    """Every record on disk, newest file last, plus a count of lines that did
+    not parse. Returns `(records, unparseable)`.
+
+    🔴 `unparseable` is returned, not swallowed. An investigator reading this log
+    is answering a question about a false green; a reader that quietly drops rows
+    it cannot understand would be the same defect one layer down.
+    """
+    path = path or log_path()
+    paths = []
+    if include_rotated:
+        paths.append(os.path.join(os.path.dirname(path), ROTATED_NAME))
+    paths.append(path)
+    records, bad = [], 0
+    for p in paths:
+        try:
+            with open(p, encoding="utf-8", errors="replace") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        obj = json.loads(line)
+                    except Exception:  # noqa: BLE001
+                        bad += 1
+                        continue
+                    if isinstance(obj, dict) and obj.get("schema") == SCHEMA:
+                        records.append(obj)
+                    else:
+                        bad += 1
+        except FileNotFoundError:
+            continue
+        except Exception:  # noqa: BLE001
+            continue
+    return records, bad
+
+
+def parse_completions(text):
+    """`{description: [exit_code, ...]}` from a transcript's notification lines.
+
+    The notification is keyed on the description (docstring §3), so a repeated
+    description genuinely maps to several exit codes. Returning the LIST rather
+    than the last value keeps that ambiguity visible instead of resolving it by
+    a coin flip.
+    """
+    out = {}
+    if not isinstance(text, str):
+        return out
+    for desc, code in COMPLETION_RE.findall(text):
+        # The description was captured out of a JSON string literal, so it still
+        # carries that literal's escapes. Undo them with the JSON decoder rather
+        # than a hand-rolled replace: `\"`, `\\` and `\uXXXX` are all in scope and
+        # a partial unescape would silently fail to join on exactly the
+        # descriptions that contain them. Falls back to the raw capture if the
+        # fragment is not a well-formed literal.
+        try:
+            desc = json.loads('"%s"' % desc)
+        except Exception:  # noqa: BLE001
+            pass
+        out.setdefault(desc, []).append(int(code))
+    return out
+
+
+def report(path=None, transcript_reader=None, only_background=True):
+    """Join captured commands against the exit codes the harness ANNOUNCED.
+
+    This is the half the hook structurally cannot do (no completion hook event
+    exists), and it is where the two numbers that disagree in 868ktvqf9 end up on
+    one line. It is a READ — it opens the transcript each record names and looks
+    for that record's own description.
+
+    Returns `{"rows": [...], "unparseable": n, "transcripts_unreadable": n}`.
+    """
+    records, bad = read_records(path)
+    if transcript_reader is None:
+        def transcript_reader(p):
+            with open(p, encoding="utf-8", errors="replace") as fh:
+                return fh.read()
+
+    cache, unreadable = {}, 0
+    rows = []
+    for rec in records:
+        if only_background and not rec.get("background"):
+            continue
+        tp = rec.get("transcript_path")
+        if tp and tp not in cache:
+            try:
+                cache[tp] = parse_completions(transcript_reader(tp))
+            except Exception:  # noqa: BLE001
+                cache[tp] = {}
+                unreadable += 1
+        codes = cache.get(tp, {}).get(rec.get("description"), [])
+        rows.append({
+            "ts": rec.get("ts"),
+            "event": rec.get("event"),
+            "session_id": rec.get("session_id"),
+            "background_task_id": rec.get("background_task_id"),
+            "description": rec.get("description"),
+            "markers": rec.get("markers") or [],
+            "announced_exit_codes": codes,
+            "command": rec.get("command"),
+        })
+    return {"rows": rows, "unparseable": bad, "transcripts_unreadable": unreadable}
+
+
+# --------------------------------------------------------------------------- #
+# CLI — positive control + the investigator's read
+# --------------------------------------------------------------------------- #
+
+_SELFTEST_COMMAND = (
+    "pnpm run test:unit:run > /tmp/bg-capture-selftest.log 2>&1; echo done"
+)
+
+
+def selftest(directory=None):
+    """🔴 POSITIVE CONTROL. Drive the REAL writer with the REAL masking shape,
+    read it back through the REAL reader, and print the pair of counts.
+
+    An instrument nobody has watched succeed is a claim about the instrument. A
+    log that is empty when the next hit lands is indistinguishable from a log
+    wired to nothing, so this exists to be run BEFORE believing an empty one.
+
+    It drives the shipped functions, not lookalikes, and it never touches the
+    real log — `directory` defaults to a throwaway.
+    """
+    import shutil
+    import tempfile
+    tmp = directory or tempfile.mkdtemp(prefix="bg-command-capture-selftest-")
+    owned = directory is None
+    try:
+        path = os.path.join(tmp, LOG_NAME)
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "session_id": "selftest-session",
+            "tool_use_id": "toolu_selftest",
+            "cwd": tmp,
+            "tool_input": {
+                "command": _SELFTEST_COMMAND,
+                "description": "selftest positive control",
+                "timeout": 1800000,
+                "run_in_background": True,
+            },
+        }
+        rec = build_record("PreToolUse", payload)
+        wrote = append_record(rec, path=path)
+        back, bad = read_records(path)
+        ok = (
+            wrote["written"]
+            and len(back) == 1
+            and bad == 0
+            and back[0]["command"] == _SELFTEST_COMMAND
+            and MARK_REDIRECT_THEN_SEMI in back[0]["markers"]
+        )
+        print("wrote: %s  read back: %d  unparseable: %d" % (wrote["written"], len(back), bad))
+        print("verbatim round-trip: %s" % (back[0]["command"] == _SELFTEST_COMMAND if back else False))
+        print("markers: %s" % (back[0]["markers"] if back else []))
+        print("positive control: 1 expected, %d observed -> %s"
+              % (len(back), "PASS" if ok else "FAIL"))
+        return 0 if ok else 1
+    finally:
+        if owned:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+def _main(argv):
+    if "--selftest" in argv:
+        return selftest()
+    if "--report" in argv:
+        res = report()
+        for row in res["rows"]:
+            first = (row["command"] or "").splitlines()[:1]
+            print("%s  %s  task=%s  exit=%s  marks=%s  desc=%r  cmd=%s"
+                  % (row["ts"], row["event"], row["background_task_id"],
+                     row["announced_exit_codes"] or "-",
+                     ",".join(row["markers"]) or "-",
+                     row["description"], first[0] if first else ""))
+        print("rows: %d  unparseable: %d  transcripts_unreadable: %d"
+              % (len(res["rows"]), res["unparseable"], res["transcripts_unreadable"]))
+        return 0
+    if "--dump" in argv:
+        records, bad = read_records()
+        for rec in records:
+            print(json.dumps(rec, ensure_ascii=False))
+        print("# records: %d  unparseable: %d" % (len(records), bad), file=sys.stderr)
+        return 0
+    print(__doc__)
+    print("usage: bg_command_capture.py [--selftest | --report | --dump]")
+    print("log: %s" % log_path())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main(sys.argv[1:]))

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -395,6 +395,15 @@ HERMETIC_TARGETS=(
   # orphaned by the switch that deploys it. Gated here because it is the only test
   # that asserts a property ACROSS the hook modules, so no per-hook target owns it.
   scripts/claude-hooks/tests/test_on_disk_artifact_names.py
+  # Same reason again — a FILE, not the directory. The backgrounded-command
+  # capture log (ClickUp 868ktvqf9). It fires PreToolUse AND PostToolUse on every
+  # Bash call, so its fail-open contract is felt on every command the operator
+  # runs: 21 hostile inputs each asserting exit 0 with an empty stdout AND an
+  # empty stderr, plus the negative control proving that battery can go red. The
+  # marker scanner's NON-matches are the load-bearing half (14 of 28 rows expect
+  # no marker), because a scanner that marks everything would satisfy a one-way
+  # test while turning the 16 MiB bound into hours of history instead of months.
+  scripts/claude-hooks/tests/test_bg_command_capture.py
   # Writer 2 of the agent activity ledger — the OPENCODE half. A Python suite
   # driving real `node`, mirroring scripts/collector/opencode/tests/test_plugin.py
   # (this repo's established way to test an opencode plugin; there is no node
@@ -1322,6 +1331,13 @@ TARGET_FLOORS=(
   # two-sided classification guard that fails when a hook module appears or vanishes.
   #   _suggested_floor 13 = 13 - min(50, max(1, 13/20 = 0 -> 1)) = 12.
   "scripts/claude-hooks/tests/test_on_disk_artifact_names.py|12"
+  # 2026-08-21, the backgrounded-command capture log (868ktvqf9) arrives as a NEW
+  # target: 80 collected, 0 skipped, measured by this gate on this branch.
+  #   _suggested_floor 80 = 80 - min(50, max(1, 80/20 = 4)) = 76.
+  # The number is the gate's own function applied to the gate's own printed
+  # count, not arithmetic — if this line conflicts, re-run the gate on the MERGED
+  # tree and copy what it prints rather than reconciling the two sides.
+  "scripts/claude-hooks/tests/test_bg_command_capture.py|76"
   # 2026-08-14, writer 2 (opencode) arrives as a NEW target: 15 collected.
   #   _suggested_floor 15 = 15 - min(50, max(1, 15/20 = 0 -> 1)) = 14.
   #


### PR DESCRIPTION
Instrumentation that guarantees the **next** hit of ClickUp **868ktvqf9** carries its own
evidence. **This is not a fix for that ticket** and does not attempt one — the standing
instruction is that no further fix may be attempted until the next hit is captured.

## The defect this enables the diagnosis of

A full unit-suite run routed through the civitai dev-server test queue exits non-zero and
the harness's background-task notification reports **exit 0**. `cli.mjs test list` shows
`exitCode: 1`; the notification says `0`. At the moment the notification arrives the run's
output file is **0 bytes** — so the two independent things an investigator would check both
report green over a red run. Four hits in one day across four agents; never reproduced
deliberately since.

**The single artifact that discriminates between the open hypotheses is the VERBATIM command
string that was backgrounded**, and the harness keeps it nowhere reachable afterwards.

## Mechanism, and why this one

I read this host's real transcripts rather than trusting the docs, which are silent on three
of the four points that decided the design:

| | measured |
|---|---|
| `PreToolUse{Bash}.tool_input` | exactly `{command, description, timeout, run_in_background}` — **the only place the verbatim string and the background flag exist** |
| `PostToolUse{Bash}.tool_response` (backgrounded) | `{stdout:"", stderr:"", interrupted:false, isImage:false, noOutputExpected:false, backgroundTaskId:"…"}` — 🔴 **no exit code, and there cannot be one**: it fires at *launch*, which is why stdout/stderr are empty strings |
| completion notification | **not a hook event.** Injected as `<summary>Background command "DESC" completed (exit code N)</summary>` — 🔴 keyed on the **`description`**, not on the task id |
| a hook at background completion | **does not exist** |

So the honest split is: **the hook** captures the verbatim command + description + task id;
**`--report`** (a read, run later by an investigator) joins that against the transcript's
`completed (exit code N)` line. The hook never claims an exit code it cannot see — it records
`harness_exit_field: null` as a *measurement* ("we looked, there was none") beside a complete
`response_keys` ledger that goes visibly non-null if a future harness ever supplies one.

Registered on **PreToolUse(Bash)** (the load-bearing half) and **PostToolUse(Bash)** (the only
place `backgroundTaskId` — which names the output file found at 0 bytes — appears).

**Scope:** writes only when the call is backgrounded **or** the command carries a masking
marker. Neither half subsumes the other: backgrounded-only misses the foreground `| tail` that
bit the investigating agent twice; marker-only misses a backgrounded run whose masking shape
nobody has thought of yet, which is the open question.

## The grep marker

`REDIRECT_THEN_SEMI` — a top-level redirect *before* the final top-level `;`/newline separator
that has a real command after it. Siblings `TRAILING_SEMI` and `TRAILING_PIPE` come free in the
same pass. They are **triage markers, not a gate**: nothing is blocked, warned or rewritten.

The scanner tracks quotes, escapes, `$(…)`/backtick nesting, comments and **heredoc bodies** —
without the last, every `python3 - <<'PY' … PY` payload on this host would false-positive.
`&&`/`||` are deliberately *not* separators: they short-circuit, so they do not mask.

## 🔴 Positive control — a real trailing-`;`-after-redirect command, captured verbatim

Real hook binary, real payload shape, real disk:

```
$ python3 scripts/claude-hooks/bg-command-capture.py < pre.json   # rc=0, silent
$ cat "$CLAUDE_BG_CAPTURE_DIR/commands.jsonl"
```
```json
{"schema":"BG_COMMAND_CAPTURE_V1","event":"PreToolUse","ts":"2026-08-21T18:37:56Z",
 "session_id":"a248d005-f3c6-4318-a8d5-f806d462b026","tool_use_id":"toolu_01LzjqnUJokwRCPSLvhoscDJ",
 "cwd":"/home/zach/workspace/civit/civitai","transcript_path":"…","background":true,
 "timeout_ms":1800000,"description":"Run main unit suite in background",
 "markers":["TRAILING_SEMI","REDIRECT_THEN_SEMI"],
 "command":"node .claude/skills/dev-server/cli.mjs test run --suite unit > /tmp/unit.log 2>&1; echo \"done rc=$?\""}
{"schema":"BG_COMMAND_CAPTURE_V1","event":"PostToolUse",…,"background_task_id":"b6v7iqmsd",
 "response_keys":["backgroundTaskId","interrupted","isImage","noOutputExpected","stderr","stdout"],
 "interrupted":false,"harness_exit_field":null,"stdout_len":0,"stderr_len":0}
```

And the join — the two numbers that disagree, on one row:

```
ANNOUNCED [0] | marks TRAILING_SEMI,REDIRECT_THEN_SEMI | task b6v7iqmsd
   cmd: node .claude/skills/dev-server/cli.mjs test run --suite unit > /tmp/unit.log 2>&1; echo "done rc=$?"
```

Also shipped as `--selftest`, so a live empty log can be distinguished from an instrument wired
to nothing before anyone concludes "it never fired":

```
$ python3 scripts/claude-hooks/bg-command-capture.py --selftest
wrote: True  read back: 1  unparseable: 0
verbatim round-trip: True
markers: ['TRAILING_SEMI', 'REDIRECT_THEN_SEMI']
positive control: 1 expected, 1 observed -> PASS
```

## 🔴 Never-throws evidence

21 hostile inputs through the real hook — empty, whitespace, non-JSON, `null`, array, string,
number, truncated JSON, missing/unknown/non-string event, `tool_input` null and list, non-string
and empty command, non-Bash tool, string `tool_response`, 2000-deep nesting, **an 8 MiB
command**, unterminated quote, unterminated heredoc, unicode+emoji — plus an unwritable state
directory and the hook copied away from its library. **All 21+2: `rc=0`, empty stdout, empty
stderr.** stdout matters as much as the exit code here: on PreToolUse it is parsed as a
permission verdict.

`test_the_never_throws_harness_can_go_red` is the battery's **negative control** — every
assertion in it is of the form "nothing happened", so without it the battery is
indistinguishable from one wired to nothing. It plants a script that exits 3 and writes to
stderr and asserts the same three checks fail. Verified red.

**Bound:** rotate-*before*-append, one generation, ceiling `2 * (8 MiB + one record)`. Measured
under that ordering (re-measured after the ordering changed, not quoted from the earlier run):
an 8 MiB command wrote an `8,388,930`-byte live log; the *next* write rotated it to
`commands.1.jsonl` and left the live log at `309` bytes, with **both generations still readable
and the 8 MiB command byte-intact** (2 records, 0 unparseable). The bound is on the **file**,
never the record — a truncated command is exactly the evidence that would be missing, and the
suite additionally round-trips a 1 MiB command byte-for-byte against a 4000-byte cap.

Rotating *before* rather than *after* is behavioural, not cosmetic: rotating after leaves **no
live file at all** in the window until the next write, which an investigator reads as "the
instrument never ran" — the reassuring absence this whole thing exists to remove.

## Two defects the suite caught — both reproducing the ticket's shape inside the instrument

1. The notification regex required a bare `"`. Transcripts store the notification inside a JSON
   string, so its quotes are **backslash-escaped**; the join returned `announced_exit_codes: []`
   for a record whose exit code was in the same file.
2. Fixed, the greedy capture then **swallowed the escaping backslash**, so the key came back as
   `'…background\\'` and matched nothing — an empty list again, for a second reason.

Both read as "the harness never announced one" rather than "my pattern is wrong". Now pinned in
**both** spellings with distinct exit codes, plus a negative control.

A third, from the scanner: the separator after a heredoc's delimiter line was not recorded, so
`python3 - <<'PY' > log … PY` + `echo done` — the masking shape *with* a heredoc — went
unmarked. Red in the ledger, fixed, pinned.

## Tests

`scripts/claude-hooks/tests/test_bg_command_capture.py` — **80 tests**, added to
`HERMETIC_TARGETS` with floor `76` (`_suggested_floor 80`). Marker ledger is 28 rows, **14
expecting no marker**; write predicate 4/4 both ways.

Three cross-module seam ledgers went red and were updated rather than worked around — each did
its job: the registrar's own idempotency self-check (`MANAGED_HOOK_SCRIPTS`), the deployed-path
ledger (`HOOK_LIBRARY_MODULES`), and `test_on_disk_artifact_names.py`'s
every-hook-is-classified enumeration.

Baseline control run first: `test_a_module_that_exits_at_import_is_a_named_error_not_no_tests_ran`
is **already red at `origin/main`** and is not from this branch.

### Gate

Authoritative gate, in the repo's own dev shell:

```
RESULT: PASS (exit=0)
  TOTAL collected=14173  passed=14172  skipped=1  failed=0  (floor: 13400 = sum of 26 per-target floors)
  PASS  scripts/claude-hooks/tests/test_bg_command_capture.py  (collected=80 passed=80 skipped=0 floor=76)
```

An earlier run of the same tree came back `failed=1` on
`scripts/browser-bridge/tests::test_the_throttle_path_carries_both_the_hash_and_the_join_key`.
Attributed to load, not to this branch, on four pieces of evidence rather than a re-run alone:
it passes in isolation at **both** `origin/main` and this branch; the full 779-test
browser-bridge suite passes **779/779** on this branch; this diff touches no browser-bridge
file; and the whole suite took ~224 s in both runs under a host load average of 8–14 with a
second devrc gate running concurrently — load inflating every test, not one assertion timing
out. The clean re-run above is green.

## 🔴 What I could NOT verify

- **The hook has never run inside a live Claude Code session.** It is deployed by home-manager
  as a read-only `/nix/store` symlink and registered by `register-nudge-hook.py`, so
  **`home-manager switch` is required to activate it** — I did not run one, and did not touch
  `~/.claude/settings.json`. Everything above is the hook driven as a subprocess with payloads
  whose shape I measured from real transcripts. "The shape is right" and "the harness sends it"
  are different claims and only the first is evidenced here.
- **It cannot observe a backgrounded run's true exit status**, because no hook event fires at
  completion. It records what the harness *announced*; the truth still has to come from the
  queue's own record or the output file.
- **Per-call overhead is not benchmarked.** It adds one Python process to PreToolUse and one to
  PostToolUse (currently 2 and 5). The write predicate is a single string pass with no I/O when
  it misses, but I have not measured the added latency on a real session.
- **The marker scanner is a heuristic**, deliberately allowed to be wrong in the false-positive
  direction. It is not a shell parser and will misjudge exotic constructs.
- **Concurrent single-record atomicity** is `O_APPEND` + one `os.write()`, which POSIX does not
  formally guarantee for very large records. Every reader therefore *counts* unparseable lines
  and reports the count rather than dropping them.

## Live corroboration, unplanned — the symptom reproduced while building the instrument

I backgrounded this PR's own gate as `nix develop … run-tests.sh … | tail -50`. Both halves of
the 868ktvqf9 symptom appeared:

- the output file sat at **0 bytes** for the entire run (`tail` buffers until the pipeline ends);
- the completion notification read **`completed (exit code 0)`** while the file's own last line
  read **`RESULT: FAIL (exit=2)`**.

A trailing pipe, no `;` needed, and a confident green over a red run. Reading the *content*
rather than the status is what caught it — which is precisely the manual step this log exists to
make unnecessary. (That particular FAIL was self-inflicted for an unrelated reason: I edited
`run-tests.sh` while bash was still executing it, shifting its byte offsets mid-run. `bash -n`
passed on both the branch and `origin/main`, which is how that was distinguished from a real
defect. The gate was then re-run on a frozen tree with no trailing pipe.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
