### PR TITLE
REJECTED: drop the kubectl-exec approval gate for opencode — measured, the gate is earning its keep

### DIFF
--- a/scripts/opencode/opencode.jsonc
+++ b/scripts/opencode/opencode.jsonc
@@ -222,7 +222,6 @@
       "*kubectl*drain*": "ask",
       "*kubectl*edit*": "ask",
       "*kubectl*replace*": "ask",
-      "*kubectl*exec*": "ask",
       "*kubectl*cp*": "ask",
       "*kubectl*rollout undo*": "ask",
       // `get secret -o yaml` prints every value base64-encoded, i.e. plaintext.

--- a/scripts/tests/test_opencode_config.py
+++ b/scripts/tests/test_opencode_config.py
@@ -564,7 +564,6 @@ MUST_ASK = [
     "KUBECONFIG=$KC_HOMELAB kubectl apply -f x",
     "kubectl get secret x -o yaml",
     "KUBECONFIG=$KC_HOMELAB kubectl get secret x -o yaml",
-    "kubectl exec -it x -- sh",
     "kubectl cp a b",
     "kubectl edit deploy x",
     "kubectl rollout undo deploy/x",
@@ -781,6 +780,7 @@ MUST_ALLOW = [
     "rg foo",
     "flux get kustomizations -A",
     "kubectl rollout restart deploy/x",
+    "kubectl exec -it x -- sh",
 ]
 
 # Every agent that ships, plus the implicit primary. `None` == no agent block.
@@ -1004,12 +1004,11 @@ def test_all_asks_precede_all_denies():
     """
     items = list(load_config()["permission"]["bash"].items())[1:]
     asks = [k for k, v in items if v == "ask"]
-    assert len(asks) == 51, (
-        f"{len(asks)} `ask` rules in the bash block, pinned at 51 (50 after the "
-        f"1fb8c2b restoration, +1 for `*sudoedit*`). This is `==`, not `>=`, on "
-        f"purpose — see the docstring: a one-sided floor lets the cushion regrow "
-        f"silently until it is the same slack that let ten dangerous families be "
-        f"deleted with the gate green.\n"
+    assert len(asks) == 50, (
+        f"{len(asks)} `ask` rules in the bash block, pinned at 50. This is `==`, "
+        f"not `>=`, on purpose — see the docstring: a one-sided floor lets the "
+        f"cushion regrow silently until it is the same slack that let ten dangerous "
+        f"families be deleted with the gate green.\n"
         f"  FEWER: a collapse is the signature of a blanket ask->allow rewrite, "
         f"which ALSO makes this test's ordering assertion and the "
         f"prefix-tolerance test vacuous. If you pruned deliberately, lower this "
@@ -1060,7 +1059,7 @@ def test_every_dangerous_pattern_is_prefix_tolerant():
 DANGEROUS_FAMILIES = [
         "git stash", "git reset --hard", "git add -A", "rm -rf /x",
         "talosctl reset", "kubectl delete pod x", "kubectl apply -f x",
-        "kubectl exec -it x -- sh", "kubectl cp a b", "kubectl edit deploy x",
+        "kubectl cp a b", "kubectl edit deploy x",
         "kubectl replace -f x", "kubectl rollout undo deploy/x",
         "kubectl get secret x -o yaml", "flux delete source git x",
         "flux suspend kustomization x", "helm uninstall x",


### PR DESCRIPTION
Not landing this. Closing the branch with the measurement, so it does not get re-litigated from scratch.

## What it does

`62f0539` removes `"*kubectl*exec*": "ask"` from opencode's bash permission block, drops `kubectl exec -it x -- sh` from `DANGEROUS_FAMILIES`, and lowers the ask-count pin 51 → 50. Net effect: an autonomous opencode agent could `kubectl exec` into a pod without approval.

## Why not

Measured over 30 days from `activity.events`, opencode's actual executed bash commands (`source='opencode' AND kind='tool-call'`, reading `payload.args_summary` — **not** `text`, which holds only the tool name):

| | count |
|---|---|
| `kubectl` any form | 247 |
| `kubectl exec` | **21** |
| `kubectl exec` against **prod** (`dpprod`) | **8** |

Positive control on the same field: `git` → 531, so the query can match.

So the gate is **live, not dead hardening** — removing it would let roughly eight unattended `kubectl exec` calls into client production per month.

Both figures are **lower bounds**: `args_summary` is capped at 200 chars (mean 90), so longer commands are truncated out of the match, and `dpprod` is a spelled match that a literal kubeconfig path would evade.

## Why not narrow it either

The obvious middle path — keep the gate for prod, drop it for dev — is not worth building:

- The friction actually removed is the **13 non-prod calls per month**, about one prompt every two days.
- `guard.js:20-40` records, as a measurement rather than an assumption, that **the guard can DENY but cannot ASK** (`permission.ask` never fires as a hook; `tool.execute.before` fires and throwing hard-blocks). So "ask on prod, allow on dev" cannot be expressed at the deterministic layer at all.
- Doing it with globs instead means `*KC_DPPROD*kubectl*exec*: "ask"`, which is a **spelled** guard: `KUBECONFIG=/path/to/dpprod.yaml kubectl exec` evades it silently. The env handle is a convention, not a guarantee.

A security-sensitive redesign of the permission layer, plus a new guard code path and the pin/test bookkeeping, to remove one prompt every 48 hours is a bad trade.

## Outcome

`"*kubectl*exec*": "ask"` stays exactly as it is. Nothing changed.

The branch is preserved at `62f0539` if the friction ever becomes real — the number to re-measure first is the non-prod call count, not the prod one.
