### PR TITLE
fix(browser): the civitai account switcher EXISTS — the notes said it did not

### DIFF
--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -92,7 +92,9 @@ Result payloads land under `.result.data`.
 4. **A JS `.click()` does not open a React/Mantine popover — and the read then
    reports a confident ABSENCE.** Use the trusted **`click`** op, **ONCE** (it is a
    TOGGLE, so a stale earlier click makes the next read lie); prove it with
-   `aria-expanded`. → `reference/css-hit-test.md`
+   `aria-expanded`. **And an OPEN menu can still hide a SECOND VIEW behind a
+   chevron-row drill-in — its items are not in the DOM until you click it, so
+   "not in the dropdown" is NOT "not in the UI".** → `reference/css-hit-test.md`
 
 ## When things look broken — triage
 
@@ -132,4 +134,4 @@ explicitly. Why, and the commands → `reference/spa-wake.md`.
 | `reference/auth-pages.md` | an authenticated request; you were about to read a cookie; a read looks logged-OUT; `extension_connected:false` |
 | `reference/security-ops.md` | 🔴 **you are MODIFYING browser-bridge** (the live-verify-on-real-Brave gate is mandatory); the user asks whether/what it records; first-time setup or a second profile |
 | `reference/x-fallback.md` | CDP `screenshot` is unsatisfactory and you must capture the raw X window (`DISPLAY`/`XAUTHORITY`, xdotool/maim) |
-| `reference/sites/<host>.md` | you are driving a site that has one — the CLI names it in the result envelope |
+| `reference/sites/<host>.md` | 🔴 **READ IT BEFORE the first action on that host, not after something fails** — the CLI names it in every result envelope (`site_notes`). It carries that site's **multi-step FLOWS** (sign-in, account switching, pickers, wizards) plus the reads that lie there. Skipping it is how a one-click flow gets reported to the operator as a blocker |

--- a/scripts/browser-bridge/reference/css-hit-test.md
+++ b/scripts/browser-bridge/reference/css-hit-test.md
@@ -186,3 +186,30 @@ that still bite after switching:
 - On some builds the dropdown's links are **not reachable** via
   `.mantine-Popover-dropdown a` even once open. **`screenshot` it** rather than
   selector-hunting — a selector that matches nothing looks exactly like missing content.
+
+## 🔴 A menu can have a SECOND VIEW — "not in the open dropdown" ≠ "not in the UI"
+
+Sibling of the trap above, and it survives everything that fixes that one: you used
+the trusted `click`, `aria-expanded` reads `true`, you settled, you read the whole
+dropdown — and the thing is still not there, because it lives behind a **drill-in**
+that swaps the menu's contents in place.
+
+Measured 2026-08-21 on civitai's header menu. The account switcher is a distinct view
+of the same popover, reached by clicking the **avatar row** (own username + a `›`
+chevron-right). Before that click its accounts are absent from `innerHTML` entirely —
+a full-document search for the username returned **false**, which read as "this
+profile does not have that account" and was recorded as a blocker. It was one click
+away. The generic tells:
+
+- a row whose only affordance is a **chevron-right** — that is a drill-in, not a link;
+- a `Back` item appearing after you click something (proof you were in view 2);
+- a dropdown that seems oddly short for the surface it belongs to.
+
+**So: before reporting a menu entry absent, click any chevron-row and re-read.** And
+prefer a `screenshot` for this judgement — a human glance settles "is there another
+view?" instantly, where a text scan cannot distinguish view 1 from the whole menu.
+
+🔴 **Related, same session: a text scan for a control's LABEL can miss it entirely
+when the control is an ICON.** Searching for `Logout` returned zero elements while a
+logout icon-button sat in the same footer. Match on `aria-label` / `role` / an icon
+class, not visible text, before concluding a control does not exist.

--- a/scripts/browser-bridge/reference/sites/civitai.com.md
+++ b/scripts/browser-bridge/reference/sites/civitai.com.md
@@ -38,11 +38,54 @@ Cost of checking: **one request**. Cost of trusting a recorded mapping: **hours*
 `{username, id, isModerator}` is the identity. Nothing else is — not the profile
 key, not the profile label, not the tab title, not what you did yesterday.
 
-## 🔴 There is no "switch accounts" flow
+## 🔴 There IS an in-product account switcher — CHECK IT BEFORE ESCALATING
 
-Brave profiles are **separate cookie jars, one account each**. So the real
-operation is not *switching* — it is **PICKING the profile that already holds the
-account you need**. Enumerate; never assume:
+🔴 **This section used to say "there is no switch accounts flow". That was WRONG,
+and it cost a whole session on 2026-08-21**: the only open check in a 13-PR arc was
+declared blocked on the operator signing an account in, twice, while the account sat
+in the device roster one click away. **A recorded absence is the cheapest kind of
+claim to be wrong about — this file asserted it, so nobody looked.**
+
+Civitai keeps a **device account set** (`AccountProvider`, `swapAccount`) and the
+header menu can swap between its members **with no re-authentication**, provided the
+entry is inside the seamless-switch window. Try this FIRST; escalate to the operator
+only after the roster has been read and the account you need is genuinely not in it.
+
+### The recipe (measured 2026-08-21, all four steps required)
+
+🔴 **The roster is a SECOND VIEW of the menu — its accounts are NOT in the DOM until
+you drill in.** Searching the opened menu for a username returns nothing, and that
+reads exactly like "this profile doesn't have that account". It is not the same
+claim. The drill-in trigger is the **avatar row at the top of the dropdown** (the one
+showing your own username plus a `›` chevron-right).
+
+```bash
+BB=~/workspace/devrc/scripts/browser-bridge/browser
+TAB=…                       # from `open`; reuse it — a re-`open` discards your url
+$BB --instance <key> --tab $TAB click '[aria-label="Account menu"]'
+$BB --instance <key> --tab $TAB wake --wait 3500     # settle, or the popover is empty
+# now tag+click the avatar row (the button whose text is your CURRENT username),
+# settle again, and only THEN read the roster / tag the target row and click it.
+```
+
+After the swap, **verify identity from the server**, never from the avatar:
+`nav https://civitai.com/api/auth/session` → assert `user.id` is the one you wanted
+and `impersonatedBy` is absent. Then purge account-scoped `localStorage` (below).
+
+🔴 **Read `needsSignIn` on the target row before clicking.** A row rendered with a
+`Sign in` hint has aged out of the seamless window and clicking it lands you in the
+SSO gate you cannot automate — a different outcome from a silent swap, and the only
+signal distinguishing them is that hint.
+
+🔴 **A text scan for `Logout` finds nothing even though it is right there** — the
+switcher's footer actions are ICON buttons with no text nodes. Do not conclude a
+control is missing from a text read; look for the icon/`aria-label`.
+
+### Profiles are still separate cookie jars
+
+The switcher moves between accounts **already on this device/profile**. Different
+Brave profiles remain independent jars, so picking the right profile is still a real
+operation. Enumerate; never assume:
 
 ```bash
 # every connected instance, then the session in each — read the pair, not the key
@@ -61,9 +104,12 @@ narrow the candidate set. Re-check it, or hand it to the operator.
 
 ### 🔴 Sign-in is Google SSO and CANNOT be automated
 
-Same class as the GitHub sudo-mode gate: you will not get through it. If **no**
-profile holds the account you need, **STOP** and hand it to the operator with
-exact steps (which profile to open, which account to sign in as, what to confirm).
+Same class as the GitHub sudo-mode gate: you will not get through it. But **that is
+the LAST resort, not the first** — it applies only once you have (a) read each
+profile's session, AND (b) opened the account switcher's roster in the promising
+one. If the account is in the roster without a `Sign in` hint, no SSO is involved.
+Only when it is genuinely absent everywhere do you **STOP** and hand it to the
+operator with exact steps (which profile, which account, what to confirm).
 
 🔴 **Do NOT route around it** — not via a direct DB write, not by calling the
 service layer. Those skip the side effects the UI action exists to produce


### PR DESCRIPTION
fix(browser): the civitai account switcher EXISTS — the notes said it did not

reference/sites/civitai.com.md led with a section headed "There is no 'switch
accounts' flow". Measured false on 2026-08-21: civitai keeps a device account set
and the header menu swaps between its members with no re-authentication. The only
open check in a 13-PR arc was reported to the operator as blocked on a manual
sign-in, twice, while the account sat in the roster one click away.

Why it stayed invisible: the roster is a SECOND VIEW of the same popover, reached
by clicking the avatar row (own username + chevron-right). Before that click its
accounts are absent from innerHTML entirely, so a full-document search for the
username returns false — which reads exactly like "this profile lacks that
account" and got recorded as one.

- sites/civitai.com.md: replace the false headline with the real recipe (drill-in,
  settle, read needsSignIn before clicking, verify via /api/auth/session). Keep the
  parts that were true (separate cookie jars, connected != drivable, never route
  around the UI). Demote the SSO-cannot-be-automated escalation to LAST resort,
  reached only after the roster has actually been read.
- css-hit-test.md: generalise it — a menu can have a second view; the tells are a
  chevron-only row, a Back item, an oddly short dropdown. Plus its sibling: a text
  scan for a control's LABEL misses it when the control is an ICON (searching for
  "Logout" found zero elements while the logout icon-button sat in the footer).
- SKILL.md: trap 4 gains the second-view half, and the sites/<host>.md row now says
  to read it BEFORE the first action on that host — it carries the multi-step flows,
  and skipping it is how a one-click flow becomes a blocker.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
