### PR TITLE
fix(obs): a basic_auth block sourcing EMPTY env vars still sends `Basic Og==`

### DIFF
--- a/nix/observability.nix
+++ b/nix/observability.nix
@@ -55,8 +55,6 @@ let
       # is world-readable.
       export OBS_PROM_URL="http://127.0.0.1:9090/api/v1/write"
       export OBS_LOKI_URL="http://127.0.0.1:3100/loki/api/v1/push"
-      export OBS_USERNAME="validate"
-      export OBS_PASSWORD="validate"
       export OBS_HOST="validate"
 
       alloy validate ${../scripts/obs/alloy.alloy}

--- a/scripts/obs/README.md
+++ b/scripts/obs/README.md
@@ -31,8 +31,6 @@ mkdir -p ~/.config/obs-ship
 cat > ~/.config/obs-ship/env <<'EOF'
 OBS_PROM_URL=http://<prometheus-host>:<port>/api/v1/write
 OBS_LOKI_URL=http://<loki-host>:<port>/loki/api/v1/push
-OBS_USERNAME=<user>
-OBS_PASSWORD=<pass>
 OBS_HOST=workbench          # or: laptop
 EOF
 chmod 600 ~/.config/obs-ship/env
@@ -40,8 +38,25 @@ systemctl --user restart alloy
 ```
 
 The homelab Prometheus already has `enableRemoteWriteReceiver: true`, so it
-accepts `remote_write` directly — no scrape target or ingress needed. Reach it
-over the Nebula mesh.
+accepts `remote_write` directly — no scrape target or ingress needed. Both
+receivers are exposed as NodePorts and reachable over the LAN.
+
+### Authentication
+
+There is deliberately **no `basic_auth` block** — the receivers are
+unauthenticated, and Alloy has no conditionals, so a block sourcing empty
+environment values does not mean "no auth". Measured against alloy 1.17.1:
+
+| config | header sent |
+|---|---|
+| `basic_auth` with `username="" password=""` | `Authorization: Basic Og==` (i.e. `":"`) |
+| no `basic_auth` block | none |
+
+If an endpoint later requires credentials, add the block back explicitly in
+`alloy.alloy` and update `test_no_basic_auth_block_until_an_endpoint_actually_requires_one`
+in the same commit. **Do not** put credentials in the URL
+(`http://user:pass@host/...`): it produces the right header, but alloy logs
+`url=` in remote_write errors, so they land in the journal.
 
 `EnvironmentFile` is optional (`-` prefixed): a host without this file still
 switches cleanly, it just does not ship. That is deliberate — a missing

--- a/scripts/obs/alloy.alloy
+++ b/scripts/obs/alloy.alloy
@@ -6,11 +6,32 @@
 // because `zach` is in `wheel`, and systemd's journal ACLs grant `wheel` full
 // read of the system journal.
 //
+// AUTHENTICATION: there is deliberately NO `basic_auth` block.
+//
+// The receivers this ships to are unauthenticated, and a `basic_auth` block is
+// NOT conditional — Alloy has no `if`. Sourcing empty values from the
+// environment does NOT mean "no auth": measured against alloy 1.17.1 with a
+// header-echoing listener,
+//     basic_auth with username="" password=""  ->  Authorization: Basic Og==
+//     no basic_auth block at all               ->  no Authorization header
+// and `Og==` decodes to ":". So an env-driven block always asserts credentials,
+// which is a claim the deployment does not make. Omitting it is the honest
+// encoding of "these endpoints need no auth".
+//
+// IF AN ENDPOINT LATER REQUIRES AUTH, add the block back here explicitly:
+//     basic_auth {
+//       username = sys.env("OBS_USERNAME")
+//       password = sys.env("OBS_PASSWORD")
+//     }
+// Do NOT instead put credentials in the URL (`http://user:pass@host/...`).
+// That works — measured, it yields the correct header — but alloy logs `url=`
+// in remote_write error messages, so the credentials land in the journal.
+//
 // 🔴 NO ENDPOINT, HOSTNAME OR CREDENTIAL MAY BE WRITTEN INTO THIS FILE.
 // devrc is a PUBLIC repo. Every site-specific value comes from the environment,
 // supplied by an EnvironmentFile outside the nix store:
 //     ~/.config/obs-ship/env      (gitignored, per-host, 0600)
-// Required: OBS_PROM_URL, OBS_LOKI_URL, OBS_USERNAME, OBS_PASSWORD, OBS_HOST
+// Required: OBS_PROM_URL, OBS_LOKI_URL, OBS_HOST
 //
 // Validated AT BUILD TIME by nix/observability.nix, which runs `alloy validate`
 // in a derivation — so an invalid config fails `home-manager switch` and cannot
@@ -32,11 +53,6 @@ logging {
 prometheus.remote_write "homelab" {
   endpoint {
     url = sys.env("OBS_PROM_URL")
-
-    basic_auth {
-      username = sys.env("OBS_USERNAME")
-      password = sys.env("OBS_PASSWORD")
-    }
 
     // A laptop is off-network often (asleep, travelling, WiFi drop). Without a
     // generous WAL the agent drops samples during every ordinary disconnection,
@@ -77,10 +93,6 @@ loki.write "homelab" {
   endpoint {
     url = sys.env("OBS_LOKI_URL")
 
-    basic_auth {
-      username = sys.env("OBS_USERNAME")
-      password = sys.env("OBS_PASSWORD")
-    }
   }
 
   // 🔴 Without this, journal lines are DROPPED for the entire duration of any

--- a/scripts/tests/test_obs_alloy_config.py
+++ b/scripts/tests/test_obs_alloy_config.py
@@ -54,8 +54,42 @@ def test_no_endpoint_or_credential_is_hardcoded():
     """devrc is PUBLIC. Every site-specific value must come from the
     environment, supplied by a gitignored per-host EnvironmentFile."""
     text = CONFIG.read_text()
-    for name in ("OBS_PROM_URL", "OBS_LOKI_URL", "OBS_USERNAME", "OBS_PASSWORD", "OBS_HOST"):
+    for name in ("OBS_PROM_URL", "OBS_LOKI_URL", "OBS_HOST"):
         assert f'sys.env("{name}")' in text, f"{name} must be read from the environment"
+
+
+def test_no_basic_auth_block_until_an_endpoint_actually_requires_one():
+    """The receivers are unauthenticated, and Alloy has no conditionals — so a
+    `basic_auth` block sourcing empty env values does NOT mean "no auth".
+
+    MEASURED against alloy 1.17.1 with a header-echoing listener:
+        basic_auth, username="" password=""  ->  Authorization: Basic Og==
+        no basic_auth block                  ->  no Authorization header
+    and `Og==` decodes to ":". So the block always asserts credentials. Omitting
+    it is the only honest encoding of "these endpoints need no auth".
+
+    Asserts LIVE code only — the config discusses basic_auth at length in its
+    comments, including the snippet to paste back if an endpoint ever needs it.
+    """
+    live = "\n".join(
+        ln for ln in CONFIG.read_text().splitlines() if not ln.strip().startswith("//")
+    )
+    assert "basic_auth" not in live, (
+        "a basic_auth block is present: it will send an Authorization header on "
+        "every request. If an endpoint genuinely requires auth, update this test "
+        "deliberately alongside the config.")
+
+
+def test_credentials_are_never_embedded_in_a_url():
+    """URL userinfo (`http://user:pass@host/...`) does produce a correct auth
+    header — measured — but alloy logs `url=` in remote_write error messages, so
+    the credentials land in the journal. Never encode them that way."""
+    import re
+
+    live = "\n".join(
+        ln for ln in CONFIG.read_text().splitlines() if not ln.strip().startswith("//")
+    )
+    assert not re.search(r'"https?://[^"/]*@', live), "credentials embedded in a URL"
 
 
 def test_the_only_urls_present_are_env_lookups_or_loopback():


### PR DESCRIPTION
Follow-up to #634. The config asserted credentials the deployment doesn't have: the receivers are unauthenticated NodePorts, and both hosts were shipping placeholder `OBS_USERNAME`/`OBS_PASSWORD` values the servers ignore.

## "Optional" isn't expressible the way I assumed

Alloy has no conditionals, and an env-driven block with empty values is **not** no-auth. Measured against alloy 1.17.1 with a header-echoing listener:

| config | header sent |
|---|---|
| `basic_auth` with `username="" password=""` | `Authorization: Basic Og==` |
| no `basic_auth` block | none |

`Og==` decodes to `":"`. The block's **presence** is the only switch — so omitting it is the honest encoding of "these endpoints need no auth". Both blocks removed, with the measurement and the exact snippet to paste back recorded in the config.

## Rejected alternative, also measured

URL userinfo (`http://user:pass@host/...`) **does** produce a correct header — `alice:s3cret` decoded back exactly — and would have made auth switchable purely from the env file with no code change. But alloy logs `url=` in remote_write error messages (observed on the deployed unit as `url=""`), so credentials would land in the journal.

That's a leak channel this change would have *invented*. The README forbids it explicitly rather than leaving it as an attractive option for the next person.

## Verification

Against the **real receivers**, not just `alloy validate`: a trial run of this exact config shipped **64 metric series and 200 log entries** under `host="authtrial"` to the homelab Prometheus and Loki, with `stdout` still absent.

Two tests pin it, both comment-stripped (the config now discusses `basic_auth` at length): no live `basic_auth` block, and no credentials embedded in any URL.

## Gate

`14244 passed, 1 failed`. The failure is `browser-bridge/tests/test_server.py:5632`, a target this change cannot reach — four files, all `scripts/obs/*` plus the nix module and its test.

Diagnosed rather than waved off: the captured stderr shows `cmd_timeout op=getHtml` events from an **earlier test** landing in this test's spool — the late-emit race #614 documented, where `emit_cmd_event` runs off the critical path after the HTTP response. Full-target re-run on this branch: **779 passed**, comparable wall time (259s vs 239s), so ordering-dependent rather than load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
