### PR TITLE
fix(clawgate-skill): the reference said the ClickUp mirror was inert — it has been writing to a shared board since 2026-08-20

### DIFF
--- a/claude/skills/clawgate/reference/task-api.md
+++ b/claude/skills/clawgate/reference/task-api.md
@@ -244,7 +244,17 @@ silently.** (4 is exempt — it reads clawgate's own secret rather than holding 
    dismissed ticket being resurrected — **it deliberately does NOT dedupe by tag**, so tasks created
    outside that ledger get duplicated on the next run. Reads `CLAWGATE_HOOK_TOKEN` from clawgate's
    **own `clawgate-secrets`** (same namespace, never copied — hence exempt from the rotation
-   coupling above). As of 2026-08-19 it ships **suspended**, dry-run, with write-back disabled.
+   coupling above). 🔴 **RE-MEASURED against the live cluster 2026-08-21: it is ON.** CronJob
+   `suspend: false` (hourly at `:17`, last run succeeded), env `CLICKUP_MIRROR_MODE=commit`, and the
+   ConfigMap's `writeback.enabled: true` — so phase 2 EXECUTES and **ClickUp may ALREADY have been
+   told** about a task you are looking at; only `writeback.allow_terminal_status` is still shut, so
+   it will not close a ticket. The older claim here — "as of 2026-08-19 it ships suspended, dry-run,
+   with write-back disabled" — was true the day it was written and is now WRONG; do not re-derive
+   it. ⚠ This is another repo's **deployment** state, which no devrc test can pin, so **verify
+   before acting on it**: `kubectl -n clawgate get cronjob clickup-mirror -o
+   jsonpath='{.spec.suspend}'`, the container's `CLICKUP_MIRROR_MODE`, and the `writeback` block of
+   `cm/clickup-mirror-config`. The four-gate ledger is kept in
+   `<homelab-talos>/clusters/workbench/apps/clickup-mirror/README.md`.
 
 ## Auth / access (0.7.37 — clawgate has NO human auth of its own)
 No magic-link `/login?token=`, no session cookie, no `CLAWGATE_AUTH_TOKEN` /


### PR DESCRIPTION
## The defect

`claude/skills/clawgate/reference/task-api.md` said clickup-mirror

> As of 2026-08-19 it ships **suspended**, dry-run, with write-back disabled.

`reference/` is defined by devrc's own CLAUDE.md as **"durable FACTS you verify against"**, and a
reference file loads verbatim into an agent's context as operating instructions. This one does not
read as stale prose — it reads as an instruction. An agent acting on it would conclude that ClickUp
had **not** been told about a task, which is the exact opposite of the truth, on a board that has
colleagues on it.

## What is actually true — measured against the live cluster, not against prose

The skill's own header warns it "drifts from the code in BOTH directions — weeks EARLY once, six
releases BEHIND once", and the app's README could equally be aspirational, so the **deployment** is
the authority here. Read-only, 2026-08-21:

| read | value |
|---|---|
| `cronjob/clickup-mirror -n clawgate` | `suspend: false`, schedule `17 * * * *` |
| `.status.lastSuccessfulTime` | `2026-08-21T20:17:16Z` (hourly pods `Completed`) |
| container env | `CLICKUP_MIRROR_MODE=commit`, `MIRROR_DIRECTION=both` |
| `cm/clickup-mirror-config` → `mapping.json` | `writeback.enabled: true`, `writeback.allow_terminal_status: false` |
| last run's log line | `mode=COMMIT store=postgres … "direction": "both"` |

So three of the four gates are open and phase 2 executes. Phase 2 landed in homelab-talos
`38546c60` (2026-08-20, on `trunk`); the app README agrees with the cluster, so the two independent
sources concur and devrc was the only one wrong.

Scope note the live read also settles: in the three retained runs `wb_executed` was `0` — not
because the leg is inert, but because nothing needed writing that hour (`wb_skipped: 34`). The
passage claims the leg is **armed**, which is what an agent needs to know, not that a write has
fired in any particular hour.

## The edit

Minimal — one sentence replaced, no restructuring. It now states the measurement with its date,
names the flag that is still shut, and carries the skill's existing "re-measured / do not
re-derive" idiom plus an explicit verify-before-acting instruction with the two read-only commands
that answer it.

## Duplication

`git grep -i 'clickup.mirror|dry.run|write.back' claude/skills/clawgate/` — the claim occurred
**exactly once** in the corpus, so there is nothing to consolidate. (`flows/task-authoring.md` and
`scripts/claude-hooks/clawgate-task-interview-guard.py` mention clickup-mirror but make no claim
about its gate state.)

## Surrounding claims re-checked (all hold)

Non-write-only consumer; comments **embedded** in the task read with no comment GET (`405`);
descriptive-tag-only `PATCH` surviving `in_progress` (409 only for a non-tag field); the
`clickup:<ticket-id>` correlation tag; the Postgres `clickup_mirror` ledger and the
deliberate no-dedupe-by-tag; `CLAWGATE_HOOK_TOKEN` read from clawgate's own `clawgate-secrets`
(hence exempt from the rotation coupling) — each verified against `mirror.py` / `writeback.py` and
the manifests.

**Flagged, not fixed** (out of scope): line 17's claim that `clickup` is a sixth `X-Clawgate-Source`
"NOT in any released image — probed live on **0.7.96**". The running deploy is now **0.7.98**
(shipped 2026-08-21), and the allowlist entry landed 2026-08-18, so the "five live, six in source"
split is probably stale too. Settling it requires POSTing a throwaway comment, which is a write, so
it was left alone — the entry already tells the reader to probe rather than assume.

## Test coverage — deliberately none, with reasoning

The corrected claim is about **another repo's deployment state**. devrc has no visibility into that
cluster, so any guard here could only assert the sentence against itself: green whether or not the
mirror is on, and red only if someone edits the prose. That is theatre, and a permanently-vacuous
guard is worse than none because it stops anyone looking. The passage instead carries an explicit
"verify before acting on it" marker naming the two commands.

`scripts/tests/test_doc_path_rot.py` does gate the new text's paths; the cross-repo README
reference is written `<homelab-talos>/…` per that module's stated convention, and `scripts/tests`
passes (6,853 collected).

## Gate

`nix develop . --command bash scripts/gate.sh`, run in a standalone clone:

```
  FAIL  pytest  exit=1  verdict='RESULT: FAIL (exit=1)'
  PASS  node    exit=0  verdict='RESULT: PASS (exit=0)'
GATE: RESULT=FAIL exit=1
```

pytest `TOTAL collected=14341 passed=14339 skipped=1 failed=1 (floor: 13324)`; node
`TOTAL suites=4 files=33 tests=1119 pass=1119 fail=0 (floor 1098)`.

🔴 **The one failure is inherited from `main`, not introduced here.**
`scripts/browser-bridge/tests/test_skill_size.py::…` — `scripts/browser-bridge/SKILL.md` is 12,259 B
against a 12,288 B ceiling, leaving 29 B of the 250 B required headroom (RECLAIM: 221 B). This diff
touches one file, `claude/skills/clawgate/reference/task-api.md`; the browser-bridge SKILL.md blob
is **byte-identical at `origin/main` and at HEAD** (`git cat-file -s` → 12259 both sides), and the
assertion reads nothing but that file's size — so the run that failed here is the same run
`origin/main` produces. It needs an eviction in browser-bridge, which is separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)