### PR TITLE
feat(clickup): `awaiting` — "someone else commented last" is the ONLY predicate this API can answer, so the scan prints what it walked

### DIFF
--- a/claude/skills/clickup/SKILL.md
+++ b/claude/skills/clickup/SKILL.md
@@ -61,6 +61,11 @@ node query.mjs edit-page <doc_id> <page_id> --file /tmp/page.md
   `--all-spaces` (includes archived) and `--all-time` have **no server-side filter** —
   they pull full history and are slow. `--me` / `--assignee` narrows server-side and
   stays near-instant at any window.
+- **`awaiting` measures ONE thing: the newest comment on a task is not the token
+  owner's.** Comment-level `resolved` is not readable through the API and ClickUp has
+  no bot identity, so "unresolved" is not computable and *anything* this token posts
+  reads as the owner answering. It fans out one request per task — hence `--max`, and
+  hence the examined/matched/truncated counts it always prints.
 - **`claim <task>`** links the current session to a task via the Session ID custom
   field, so work is resumable later. Non-obvious and easy to forget.
 - **`--account <name>`** targets a non-default identity on any command

--- a/claude/skills/clickup/api/inbox.mjs
+++ b/claude/skills/clickup/api/inbox.mjs
@@ -71,6 +71,105 @@ export async function fetchInboxNotifications(options = {}) {
 }
 
 /**
+ * The pagination cursor for the NEXT page of an inbox search, or null when the
+ * response says there is none.
+ *
+ * ⚠️ The request nests the cursor under `pagination.nextCursor`, and the
+ * response is assumed to answer in the same shape (or flat). That assumption is
+ * UNVERIFIED against the live API: every `inbox-*` command needs a JWT this
+ * host's accounts.json does not have, so no response body could be observed
+ * while writing this. It is written to read several plausible locations and to
+ * STOP rather than loop when it finds none — a missed cursor costs a page, a
+ * wrong-shaped guess that never terminates costs the command.
+ */
+export function nextInboxCursor(response) {
+  const candidates = [
+    response?.pagination?.nextCursor,
+    response?.nextCursor,
+    response?.data?.pagination?.nextCursor,
+    response?.data?.nextCursor,
+  ];
+  for (const c of candidates) {
+    if (c !== undefined && c !== null && c !== '') return String(c);
+  }
+  return null;
+}
+
+/** Bundles carried by one inbox search response. */
+export function bundlesOf(response) {
+  return response?.notificationBundleGroups?.flatMap((g) => g.notificationBundles || []) || [];
+}
+
+/**
+ * Merge consecutive inbox search pages into one response-shaped object.
+ * Resources are de-duplicated by `entityResourceName` (the key the formatter
+ * looks them up by); groups are concatenated in page order.
+ */
+export function mergeInboxPages(pages) {
+  const resources = [];
+  const seenResources = new Set();
+  const groups = [];
+  const users = {};
+
+  for (const page of pages) {
+    for (const r of page?.resources || []) {
+      const key = r?.entityResourceName ?? JSON.stringify(r);
+      if (seenResources.has(key)) continue;
+      seenResources.add(key);
+      resources.push(r);
+    }
+    for (const g of page?.notificationBundleGroups || []) groups.push(g);
+    Object.assign(users, page?.users || {});
+  }
+
+  return {
+    resources,
+    notificationBundleGroups: groups,
+    users,
+    pagesFetched: pages.length,
+  };
+}
+
+/**
+ * Fetch EVERY page of inbox notifications, following the cursor.
+ *
+ * 🔴 A single-page read is the bug `reference/raw-api.md` is about: it returns a
+ * number that looks like an answer. `inbox` read one page of 20 and
+ * `inbox-clear-all` one page of 140, so a deeper queue was silently truncated
+ * and "cleared all" cleared a prefix.
+ *
+ * @param {object} options - as fetchInboxNotifications, plus:
+ * @param {number} options.maxPages - safety bound on the loop (default 25)
+ * @param {function} options.fetchPage - injected transport. Every inbox
+ *        endpoint needs a JWT this host does not have, so the cursor loop is
+ *        only testable through a seam; this is it.
+ * @returns {Promise<object>} merged response, plus `pagesFetched` / `truncated`
+ */
+export async function fetchAllInboxNotifications(options = {}) {
+  const { maxPages = 25, fetchPage = fetchInboxNotifications, ...rest } = options;
+  const pages = [];
+  const seenCursors = new Set();
+  let cursor = rest.cursor || '';
+  let truncated = false;
+
+  for (let page = 0; page < maxPages; page++) {
+    const response = await fetchPage({ ...rest, cursor });
+    pages.push(response);
+
+    const next = nextInboxCursor(response);
+    // No cursor, an empty page, or a cursor the server already handed us: stop.
+    // The repeat check is what keeps a misread cursor shape from spinning.
+    if (!next || bundlesOf(response).length === 0 || seenCursors.has(next)) break;
+    seenCursors.add(next);
+    cursor = next;
+
+    if (page === maxPages - 1) truncated = true;
+  }
+
+  return { ...mergeInboxPages(pages), truncated, maxPages };
+}
+
+/**
  * Get inbox badge counts
  * @returns {Promise<{ messagesCount, activityCount, reminderCount, savedCount, lastUpdatedAt }>}
  */
@@ -122,11 +221,16 @@ export async function markInboxBundleRead(bundleId) {
 /**
  * Clear all uncleared bundles for a given tab
  * @param {'messages'|'activity'} bundleType
- * @returns {Promise<{ total: number, cleared: number, failed: number }>}
+ * @returns {Promise<{ total: number, cleared: number, failed: number,
+ *                     pagesFetched: number, truncated: boolean }>}
+ *          `total` is what was FOUND across every page read; `truncated` says
+ *          the page bound stopped the read, so bundles remain uncleared.
  */
 export async function clearAllInboxBundles(bundleType = 'messages') {
-  const data = await fetchInboxNotifications({ bundleType, status: 'uncleared', limit: 140 });
-  const bundles = data.notificationBundleGroups?.flatMap(g => g.notificationBundles) || [];
+  // Cursor-following: a single 140-item page made "clear all" mean "clear the
+  // first 140", with no sign that anything was left behind.
+  const data = await fetchAllInboxNotifications({ bundleType, status: 'uncleared', limit: 140 });
+  const bundles = bundlesOf(data);
 
   let cleared = 0;
   let failed = 0;
@@ -139,7 +243,13 @@ export async function clearAllInboxBundles(bundleType = 'messages') {
     }
   }
 
-  return { total: bundles.length, cleared, failed };
+  return {
+    total: bundles.length,
+    cleared,
+    failed,
+    pagesFetched: data.pagesFetched,
+    truncated: data.truncated,
+  };
 }
 
 // ============================================================================
@@ -183,7 +293,7 @@ function parseAuthor(author) {
  * @returns {string} - Formatted output
  */
 export function formatInboxNotifications(data, userMap = {}) {
-  const bundles = data.notificationBundleGroups?.flatMap(g => g.notificationBundles) || [];
+  const bundles = bundlesOf(data);
   const resourceMap = new Map((data.resources || []).map(r => [r.entityResourceName, r]));
   // Also map by root entity resource name for name lookups
   const rootMap = new Map();
@@ -244,7 +354,16 @@ export function formatInboxNotifications(data, userMap = {}) {
     lines.push('');
   }
 
-  lines.push(`Total: ${bundles.length} notification bundle(s)`);
+  // Say how much was READ, not just how much matched: a total from a
+  // single-page read is a number that looks like an answer.
+  const pages = data.pagesFetched ? ` over ${data.pagesFetched} page(s)` : '';
+  lines.push(`Total: ${bundles.length} notification bundle(s)${pages}`);
+  if (data.truncated) {
+    lines.push(
+      `🔴 TRUNCATED: stopped at the ${data.maxPages}-page safety bound — there are more ` +
+        `notifications than this listing shows.`
+    );
+  }
   return lines.join('\n');
 }
 

--- a/claude/skills/clickup/lib/awaiting.mjs
+++ b/claude/skills/clickup/lib/awaiting.mjs
@@ -1,0 +1,389 @@
+/**
+ * `awaiting` — tasks whose newest comment is NOT the token owner's.
+ *
+ * 🔴 WHY THIS PREDICATE, and not a better one. Measured against the live API
+ * (read-only) before this was written:
+ *
+ *   * `resolved` is NOT readable on a task comment. The union of every field
+ *     across a sample of 84 comments on 29 tasks was
+ *     ['assignee','comment','comment_text','date','group_assignee','id',
+ *      'reactions','reply_count','user'] — `resolved` never appears, not even
+ *     as `false`, even though `resolve-comment` can WRITE it. So "unresolved
+ *     comments" is not computable from this API. Do not try.
+ *   * `assignee` was null on all 84 sampled comments, so comment-level
+ *     assignment cannot narrow anything either.
+ *   * The `inbox-*` commands — ClickUp's own "@mentioned me / unread" surface —
+ *     need a JWT this host's accounts.json does not have.
+ *
+ * What is left, and all that is left: the newest comment on a task was written
+ * by somebody who is not the token owner.
+ *
+ * 🔴 The blind spot that comes with it: ClickUp has no bot identity. Every
+ * comment posted through the `pk_` token comes back authored as the token
+ * owner, whoever actually typed it. "The owner answered" and "a machine
+ * answered on the owner's behalf" are the SAME observable. The formatter prints
+ * that in the command's own output — not only in this comment — because a
+ * caveat that lives only in docs is a caveat nobody reads at the moment it
+ * matters.
+ *
+ * Everything here is pure except `findAwaiting`, whose two effects (fetching
+ * comments, sleeping) are injected, so the cap and pacing are testable without
+ * a network.
+ */
+
+export const MS_PER_DAY = 86400000;
+
+/**
+ * Fan-out and pacing defaults.
+ *
+ * The token's limit is 100 requests/minute. An unpaced loop over an assigned
+ * board bursts far past that (~190/min measured), so fetches go out in small
+ * batches with a sleep sized to hold the average rate at `ratePerMin`, which is
+ * set below the ceiling for headroom — `getMyTasks` itself spends requests on
+ * the same budget.
+ *
+ * ⚠️ The budget is counted in FETCHES, not HTTP requests: `getComments`
+ * paginates at 25 comments per request, so a heavily-commented task costs more
+ * than one. `ratePerMin` is therefore a ceiling on fetches and only an
+ * approximation of the request rate — the headroom below 100 is what absorbs
+ * that, and it is why the number reported is labelled a fetch count.
+ *
+ * `maxTasks` is a HARD cap on the fan-out: one request per task, so an
+ * unbounded board is an unbounded scan. Truncation is reported, never silent.
+ */
+export const AWAITING_DEFAULTS = Object.freeze({
+  maxTasks: 60,
+  batchSize: 5,
+  ratePerMin: 80,
+  minAgeDays: 0,
+});
+
+/** Sleep, the default injectable effect. */
+export function sleep(ms) {
+  if (!(ms > 0)) return Promise.resolve();
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * How long to pause after a batch of `batchSize` requests to hold an average of
+ * `ratePerMin` requests per minute, given the batch itself took `elapsedMs`.
+ * Never negative: a batch slower than its own budget pauses not at all.
+ */
+export function batchPauseMs(batchSize, ratePerMin, elapsedMs = 0) {
+  if (!(ratePerMin > 0)) {
+    throw new RangeError(`ratePerMin must be > 0, got ${ratePerMin}`);
+  }
+  const budgetMs = (batchSize * 60000) / ratePerMin;
+  return Math.max(0, Math.ceil(budgetMs - elapsedMs));
+}
+
+/** Split `items` into consecutive chunks of at most `size`. */
+export function chunk(items, size) {
+  if (!Number.isInteger(size) || size < 1) {
+    throw new RangeError(`chunk size must be a positive integer, got ${size}`);
+  }
+  const out = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+/**
+ * Apply the fan-out cap.
+ *
+ * Returns the slice that will be examined ALONGSIDE what was left out, so the
+ * caller can say "20 of 51" rather than printing a number that looks like the
+ * whole board.
+ */
+export function capFanOut(tasks, maxTasks) {
+  if (!Number.isInteger(maxTasks) || maxTasks < 1) {
+    throw new RangeError(`--max must be a positive integer, got ${maxTasks}`);
+  }
+  const examined = tasks.slice(0, maxTasks);
+  return {
+    examined,
+    total: tasks.length,
+    skipped: tasks.length - examined.length,
+    truncated: tasks.length > maxTasks,
+  };
+}
+
+/** A comment's timestamp in epoch ms, or null when it has none/unparseable. */
+export function commentTimeMs(comment) {
+  const raw = comment?.date;
+  if (raw === undefined || raw === null || raw === '') return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** A comment's author id as a string, or null when the API gave none. */
+export function commentAuthorId(comment) {
+  const id = comment?.user?.id;
+  if (id === undefined || id === null || id === '') return null;
+  return String(id);
+}
+
+/** A human label for a comment's author. */
+export function commentAuthorName(comment) {
+  const user = comment?.user;
+  if (user?.username) return user.username;
+  if (user?.email) return user.email;
+  const id = commentAuthorId(comment);
+  return id ? `user ${id}` : 'unknown';
+}
+
+/**
+ * The newest comment in a list, by timestamp. Undated comments sort oldest, so
+ * a dated comment always wins over one the API gave no date.
+ */
+export function newestComment(comments) {
+  if (!Array.isArray(comments) || comments.length === 0) return null;
+  let best = null;
+  let bestAt = -Infinity;
+  for (const c of comments) {
+    const at = commentTimeMs(c) ?? -Infinity;
+    if (best === null || at > bestAt) {
+      best = c;
+      bestAt = at;
+    }
+  }
+  return best;
+}
+
+/**
+ * Is this task awaiting the token owner?
+ *
+ * True when the newest comment was authored by someone else. An author the API
+ * did not identify counts as SOMEONE ELSE: a false positive costs one glance,
+ * a false negative hides the thing the command exists to find. The row carries
+ * `unknown` as the author so the reader can see which case they are looking at.
+ */
+export function isAwaiting(comments, ownerUserId) {
+  const newest = newestComment(comments);
+  if (!newest) return false;
+  const author = commentAuthorId(newest);
+  if (author === null) return true;
+  return author !== String(ownerUserId);
+}
+
+/**
+ * Build the awaiting rows from already-fetched comments.
+ *
+ * @param {object[]} tasks              tasks whose comments were fetched
+ * @param {Map<string,object[]>} commentsByTaskId
+ * @param {string|number} ownerUserId   the TOKEN owner (never the --assignee)
+ * @param {number} minAgeDays           keep rows whose newest comment is at
+ *                                      least this old
+ * @param {number} now                  epoch ms, injected for determinism
+ * @returns {{rows: object[], examined: number, withComments: number, matched: number}}
+ */
+export function selectAwaiting({
+  tasks,
+  commentsByTaskId,
+  ownerUserId,
+  minAgeDays = AWAITING_DEFAULTS.minAgeDays,
+  now = Date.now(),
+}) {
+  const minAgeMs = minAgeDays * MS_PER_DAY;
+  const rows = [];
+  let withComments = 0;
+
+  for (const task of tasks) {
+    const comments = commentsByTaskId.get(task.id) || [];
+    if (comments.length > 0) withComments++;
+    if (!isAwaiting(comments, ownerUserId)) continue;
+
+    const newest = newestComment(comments);
+    const lastCommentAtMs = commentTimeMs(newest);
+    const ageMs = lastCommentAtMs === null ? null : now - lastCommentAtMs;
+    if (ageMs !== null && ageMs < minAgeMs) continue;
+    if (ageMs === null && minAgeMs > 0) continue; // cannot prove it is old enough
+
+    rows.push({
+      id: task.id,
+      name: task.name,
+      url: task.url,
+      list: task.list?.name || null,
+      status: task.status?.status || null,
+      lastCommentAtMs,
+      ageMs,
+      lastCommentBy: commentAuthorName(newest),
+      lastCommentById: commentAuthorId(newest),
+      commentCount: comments.length,
+    });
+  }
+
+  // Oldest first: the thing that has been waiting longest is the thing to read.
+  rows.sort((a, b) => (a.lastCommentAtMs ?? -Infinity) - (b.lastCommentAtMs ?? -Infinity));
+
+  return {
+    rows,
+    examined: tasks.length,
+    withComments,
+    matched: rows.length,
+  };
+}
+
+/**
+ * Fetch comments for (at most `maxTasks`) tasks, paced, and select the awaiting
+ * ones.
+ *
+ * A task whose comments could not be fetched is counted as UNREADABLE and
+ * reported separately — never folded into the examined count, because a scan
+ * that silently dropped failures reads as broader coverage than it had.
+ *
+ * @param {object}   p.tasks          tasks from getMyTasks()
+ * @param {string}   p.ownerUserId    the token owner's user id
+ * @param {function} p.fetchComments  async (taskId) => comment[]
+ * @param {function} [p.sleepFn]      injected sleep
+ * @param {function} [p.clock]        injected () => epoch ms
+ */
+export async function findAwaiting({
+  tasks,
+  ownerUserId,
+  fetchComments,
+  sleepFn = sleep,
+  clock = Date.now,
+  maxTasks = AWAITING_DEFAULTS.maxTasks,
+  batchSize = AWAITING_DEFAULTS.batchSize,
+  ratePerMin = AWAITING_DEFAULTS.ratePerMin,
+  minAgeDays = AWAITING_DEFAULTS.minAgeDays,
+  onProgress = null,
+}) {
+  const cap = capFanOut(tasks, maxTasks);
+  const commentsByTaskId = new Map();
+  const unreadable = [];
+  // FETCHES, not HTTP requests — one per task, each of which may paginate.
+  let commentFetches = 0;
+
+  const batches = chunk(cap.examined, batchSize);
+  for (let i = 0; i < batches.length; i++) {
+    const batch = batches[i];
+    const startedAt = clock();
+    const results = await Promise.all(
+      batch.map(async (task) => {
+        try {
+          return { id: task.id, comments: await fetchComments(task.id) };
+        } catch (err) {
+          return { id: task.id, error: err?.message || String(err) };
+        }
+      })
+    );
+    commentFetches += batch.length;
+    for (const r of results) {
+      if (r.error) unreadable.push({ id: r.id, error: r.error });
+      else commentsByTaskId.set(r.id, r.comments || []);
+    }
+    if (onProgress) onProgress({ done: commentFetches, total: cap.examined.length });
+    if (i < batches.length - 1) {
+      await sleepFn(batchPauseMs(batch.length, ratePerMin, clock() - startedAt));
+    }
+  }
+
+  const readable = cap.examined.filter((t) => commentsByTaskId.has(t.id));
+  const selection = selectAwaiting({
+    tasks: readable,
+    commentsByTaskId,
+    ownerUserId,
+    minAgeDays,
+    now: clock(),
+  });
+
+  return {
+    rows: selection.rows,
+    matched: selection.matched,
+    examined: selection.examined,
+    withComments: selection.withComments,
+    unreadable,
+    assigned: cap.total,
+    skipped: cap.skipped,
+    truncated: cap.truncated,
+    maxTasks,
+    minAgeDays,
+    commentFetches,
+  };
+}
+
+/** "5d 3h" / "4h 10m" / "12m" — coarse, because the point is "how stale". */
+export function formatAge(ms) {
+  if (ms === null || ms === undefined || !Number.isFinite(ms)) return 'unknown';
+  if (ms < 0) return '0m';
+  const minutes = Math.floor(ms / 60000);
+  const days = Math.floor(minutes / 1440);
+  const hours = Math.floor((minutes % 1440) / 60);
+  const mins = minutes % 60;
+  if (days > 0) return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+  if (hours > 0) return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+  return `${mins}m`;
+}
+
+function formatWhen(ms) {
+  if (ms === null || ms === undefined || !Number.isFinite(ms)) return 'unknown date';
+  return new Date(ms).toLocaleString('en-US', {
+    year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+  });
+}
+
+/**
+ * Render a findAwaiting() result.
+ *
+ * 🔴 Three things this ALWAYS prints, whatever the outcome:
+ *   1. tasks EXAMINED beside tasks MATCHED — a bare "0 awaiting" from a scan
+ *      that walked nothing is the failure mode, not the all-clear;
+ *   2. truncation, explicitly, when the cap cut the scan short;
+ *   3. the predicate and its blind spot, in the command's own output.
+ */
+export function formatAwaiting(result, { scopeLabel = 'you', ownerLabel = 'the API token owner' } = {}) {
+  const lines = [];
+
+  for (const row of result.rows) {
+    lines.push(`[${row.status || '?'}] ${row.name}`);
+    const bits = [
+      `List: ${row.list || '?'}`,
+      `Waiting: ${formatAge(row.ageMs)}`,
+      `Last comment: ${row.lastCommentBy} on ${formatWhen(row.lastCommentAtMs)}`,
+    ];
+    lines.push(`  ${bits.join(' | ')}`);
+    if (row.url) lines.push(`  ${row.url}`);
+    lines.push('');
+  }
+
+  const window = result.minAgeDays > 0 ? `, quiet for at least ${result.minAgeDays}d` : '';
+  lines.push(
+    `Awaiting a reply from ${scopeLabel}: ${result.matched} matched of ` +
+      `${result.examined} task(s) examined (${result.withComments} had any comment` +
+      `${window}).`
+  );
+  lines.push(
+    `Assigned tasks found: ${result.assigned}; comment fetches issued: ${result.commentFetches} ` +
+      '(one per task; getComments paginates, so a busy task costs more than one request).'
+  );
+
+  if (result.truncated) {
+    lines.push(
+      `🔴 TRUNCATED: --max ${result.maxTasks} capped the scan — ${result.skipped} of ` +
+        `${result.assigned} assigned task(s) were NOT examined. This is not a clean sweep; ` +
+        `raise --max to cover them.`
+    );
+  }
+  if (result.unreadable.length > 0) {
+    lines.push(
+      `🔴 UNREADABLE: comments could not be fetched for ${result.unreadable.length} task(s) ` +
+        `(${result.unreadable.map((u) => u.id).join(', ')}) — they are excluded from the ` +
+        `examined count, not counted as answered.`
+    );
+  }
+
+  lines.push('');
+  lines.push(`Predicate: the NEWEST comment on the task was not authored by ${ownerLabel}.`);
+  lines.push(
+    'Blind spot: ClickUp has no bot identity — every comment posted with this API token ' +
+      'comes back authored as the token owner, so an automated write-back is ' +
+      'indistinguishable from you answering. A task answered by a machine on your behalf ' +
+      'will NOT appear here. Comment-level `resolved` is not readable through the API, so ' +
+      '"unresolved comments" is not what this measures.'
+  );
+
+  return lines.join('\n');
+}

--- a/claude/skills/clickup/query.mjs
+++ b/claude/skills/clickup/query.mjs
@@ -38,6 +38,7 @@ import {
   setPriority,
   moveTask,
   parseDateInput,
+  parseSinceInput,
   addWatcher,
   addTag,
   addDependency,
@@ -71,7 +72,7 @@ import {
   formatDocComments,
 } from './api/doc-comments.mjs';
 import {
-  fetchInboxNotifications,
+  fetchAllInboxNotifications,
   fetchInboxStats,
   clearInboxBundle,
   markInboxBundleRead,
@@ -97,6 +98,7 @@ import {
   formatList,
 } from './lib/format.mjs';
 import { stateBaseDir } from './lib/paths.mjs';
+import { findAwaiting, formatAwaiting, AWAITING_DEFAULTS } from './lib/awaiting.mjs';
 
 // Parse arguments
 const args = process.argv.slice(2);
@@ -124,6 +126,12 @@ let attachArgs = [];
 let allSpacesFlag = false;
 let sinceArg = null;
 let allTimeFlag = false;
+let daysArg = null;
+let maxArg = null;
+let mentionedFlag = false;
+let unreadFlag = false;
+let clearedFlag = false;
+let cursorArg = null;
 
 for (let i = 0; i < args.length; i++) {
   const arg = args[i];
@@ -167,6 +175,18 @@ for (let i = 0; i < args.length; i++) {
     sinceArg = args[++i];
   } else if (arg === '--all-time') {
     allTimeFlag = true;
+  } else if (arg === '--days') {
+    daysArg = args[++i];
+  } else if (arg === '--max') {
+    maxArg = args[++i];
+  } else if (arg === '--mentioned') {
+    mentionedFlag = true;
+  } else if (arg === '--unread') {
+    unreadFlag = true;
+  } else if (arg === '--cleared') {
+    clearedFlag = true;
+  } else if (arg === '--cursor') {
+    cursorArg = args[++i];
   } else if (!command) {
     command = arg;
   } else if (!targetInput) {
@@ -217,6 +237,8 @@ Task Commands:
   me                            Show current user info
   create [list_id] "title"      Create a new task (list_id optional if default set)
   my-tasks                      List all tasks assigned to me
+  awaiting                      My tasks whose NEWEST comment is someone else's
+                                (--days N quiet-for, --assignee, --max fan-out cap)
   search "query"                Search tasks across workspace
   assign <task> <user>          Assign task to user
   due <task> "date"             Set due date
@@ -263,7 +285,10 @@ Document Commands:
   doc-reply <comment_id> "text" Reply to a doc comment thread (requires --page)
 
 Inbox Commands (requires JWT):
-  inbox [messages|activity]     View inbox notifications (default: messages)
+  inbox [messages|activity]     View inbox notifications (default: messages; follows
+                                the cursor across pages)
+                                Filters: --me --mentioned --unread --cleared
+                                         --since <window> --cursor <cursor>
   inbox-stats                   Get unread badge counts
   inbox-clear <bundle_id>       Dismiss a notification bundle
   inbox-read <bundle_id>        Mark a notification bundle as read
@@ -292,7 +317,15 @@ Options:
   --all-spaces Search across ALL spaces incl. archived (for search; slow — pulls full history)
   --since      Search look-back window by date_updated (e.g. "90d","6m","1y",date). Default 30d
                (tip: --me / --assignee narrows server-side and is near-instant)
+               Also bounds inbox to notifications after that date
   --all-time   Search with no recency bound (slowest; scans full history)
+  --mentioned  inbox: only bundles that @mention me
+  --unread     inbox: only unread bundles
+  --cleared    inbox: read the CLEARED bundles instead of the uncleared ones
+  --cursor     inbox: start from a specific pagination cursor
+  --days       awaiting: only tasks quiet for at least N days (default 0)
+  --max        awaiting: cap the comment fan-out at N tasks (default ${AWAITING_DEFAULTS.maxTasks};
+               one request per task, paced under the 100 req/min token limit)
   --content    Inline content (markdown). For short text only.
   --file       Read content from a file path (preferred for long content)
   --cleanup    Delete the --file after successful execution
@@ -316,6 +349,8 @@ Examples:
   node query.mjs create 900000000001 "New feature: dark mode"
   node query.mjs create "Quick task" (uses CLICKUP_DEFAULT_LIST_ID)
   node query.mjs my-tasks
+  node query.mjs awaiting                    # someone commented last, and it wasn't me
+  node query.mjs awaiting --days 2 --max 40  # quiet 2+ days, scan at most 40 tasks
   node query.mjs search "dark mode"
   node query.mjs assign 86a1b2c3d alex
   node query.mjs due 86a1b2c3d "tomorrow"
@@ -356,6 +391,9 @@ Inbox Examples:
   node query.mjs inbox                                         # Messages tab
   node query.mjs inbox activity                                # Activity tab
   node query.mjs inbox --me                                    # Assigned to me
+  node query.mjs inbox --mentioned --unread                    # Unread @mentions
+  node query.mjs inbox --since 7d                              # Only the last 7 days
+  node query.mjs inbox --cleared                               # Already-cleared bundles
   node query.mjs inbox-stats                                   # Badge counts
   node query.mjs inbox-clear "<bundle_id>"                     # Dismiss notification
   node query.mjs inbox-read "<bundle_id>"                      # Mark as read
@@ -469,6 +507,68 @@ async function main() {
         console.log(JSON.stringify(tasks, null, 2));
       } else {
         console.log(formatTaskList(tasks));
+      }
+    } catch (err) {
+      console.error('Error:', err.message);
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (command === 'awaiting') {
+    try {
+      // Numeric flags are validated up front: a typo'd --max would otherwise
+      // reach capFanOut() as NaN and be reported as a scan, not as a mistake.
+      let minAgeDays = AWAITING_DEFAULTS.minAgeDays;
+      if (daysArg !== null) {
+        minAgeDays = Number(daysArg);
+        if (!Number.isFinite(minAgeDays) || minAgeDays < 0) {
+          console.error(`Error: --days must be a non-negative number, got "${daysArg}"`);
+          process.exit(1);
+        }
+      }
+      let maxTasks = AWAITING_DEFAULTS.maxTasks;
+      if (maxArg !== null) {
+        maxTasks = Number(maxArg);
+        if (!Number.isInteger(maxTasks) || maxTasks < 1) {
+          console.error(`Error: --max must be a positive integer, got "${maxArg}"`);
+          process.exit(1);
+        }
+      }
+
+      const teamId = await getTeamId();
+      // The AUTHOR test is always against the token owner — that is the only
+      // identity the API reports for anything this token writes. --assignee
+      // only changes WHOSE tasks are scanned, never who counts as "answered".
+      const ownerUserId = await getUserId();
+      let scanUserId = ownerUserId;
+      let scopeLabel = 'you';
+      if (assigneeArg && assigneeArg.toLowerCase() !== 'me') {
+        const user = await findUser(teamId, assigneeArg);
+        if (!user) {
+          console.error(`Error: User "${assigneeArg}" not found in team`);
+          process.exit(1);
+        }
+        scanUserId = user.id.toString();
+        scopeLabel = `${user.username || assigneeArg} (author test still: not the token owner)`;
+      }
+
+      const tasks = await getMyTasks(teamId, scanUserId);
+      const result = await findAwaiting({
+        tasks,
+        ownerUserId,
+        fetchComments: (taskId) => getComments(taskId),
+        maxTasks,
+        minAgeDays,
+        onProgress: ({ done, total }) => {
+          if (!jsonOutput) console.error(`  …read comments on ${done}/${total} task(s)`);
+        },
+      });
+
+      if (jsonOutput) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(formatAwaiting(result, { scopeLabel }));
       }
     } catch (err) {
       console.error('Error:', err.message);
@@ -643,9 +743,17 @@ async function main() {
     try {
       if (command === 'inbox') {
         const bundleType = targetInput || 'messages';
+        // api/inbox.mjs has always accepted mentioned / unread / dateStart /
+        // cursor; only --me was reachable from here, so the other filters
+        // existed and could not be used.
         const opts = { bundleType, status: 'uncleared' };
         if (filterMe) opts.assignedToMe = true;
-        const result = await fetchInboxNotifications(opts);
+        if (mentionedFlag) opts.mentioned = true;
+        if (unreadFlag) opts.unread = true;
+        if (clearedFlag) opts.status = 'cleared';
+        if (sinceArg) opts.dateStart = parseSinceInput(sinceArg).toISOString();
+        if (cursorArg) opts.cursor = cursorArg;
+        const result = await fetchAllInboxNotifications(opts);
         if (jsonOutput) {
           console.log(JSON.stringify(result, null, 2));
         } else {
@@ -661,9 +769,15 @@ async function main() {
       } else if (command === 'inbox-clear-all') {
         const bundleType = targetInput || 'messages';
         const result = await clearAllInboxBundles(bundleType);
-        console.log(`Cleared ${result.cleared}/${result.total} ${bundleType} notification(s).`);
+        console.log(
+          `Cleared ${result.cleared}/${result.total} ${bundleType} notification(s) ` +
+            `found over ${result.pagesFetched} page(s).`
+        );
         if (result.failed > 0) {
           console.log(`Failed: ${result.failed}`);
+        }
+        if (result.truncated) {
+          console.log('🔴 TRUNCATED: hit the page safety bound — notifications remain uncleared.');
         }
       }
     } catch (err) {

--- a/claude/skills/clickup/reference/maintaining.md
+++ b/claude/skills/clickup/reference/maintaining.md
@@ -42,6 +42,8 @@ The hermetic gates are `node:test` suites, run by devrc's node gate
 node test/help-coverage.test.mjs      # hermetic; pins showUsage() completeness
 node test/state-paths.test.mjs        # hermetic; pins state OUT of the skill dir
 node test/js-source.test.mjs          # hermetic; controls for the source scanner
+node test/awaiting.test.mjs           # hermetic; the awaiting predicate, cap,
+                                      # pacing + the inbox cursor loop (fake transport)
 node test/smoke-test.mjs --readonly   # live API, needs credentials — NOT in any gate
 ```
 

--- a/claude/skills/clickup/test/awaiting.test.mjs
+++ b/claude/skills/clickup/test/awaiting.test.mjs
@@ -1,0 +1,484 @@
+#!/usr/bin/env node
+
+/**
+ * `awaiting` gate (hermetic — no credentials, no network).
+ *
+ * The command's whole value is a NUMBER a human will act on, so what is pinned
+ * here is not "it runs" but:
+ *   * the predicate matches a foreign last comment and NOT the owner's;
+ *   * the fan-out cap truncates, and SAYS it truncated — the failure mode is a
+ *     confident "0 awaiting" from a scan that walked a fraction of the board;
+ *   * a task whose comments could not be read is reported, never folded into
+ *     the examined count;
+ *   * the output carries its own blind spot (no bot identity).
+ *
+ * 🔴 Fixture values are pairwise distinct — distinct ids, distinct authors,
+ * distinct timestamps, distinct list/status strings — because a fixture built
+ * from repeated or default values collapses distinct implementations into
+ * identical output, and a mutant that swaps two fields then survives a green
+ * suite.
+ *
+ * Every id, name and author below is SYNTHETIC. This repo is public.
+ *
+ * Usage:
+ *   node test/awaiting.test.mjs
+ *   node --test test/awaiting.test.mjs
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  AWAITING_DEFAULTS,
+  MS_PER_DAY,
+  batchPauseMs,
+  capFanOut,
+  chunk,
+  commentAuthorId,
+  commentAuthorName,
+  commentTimeMs,
+  findAwaiting,
+  formatAge,
+  formatAwaiting,
+  isAwaiting,
+  newestComment,
+  selectAwaiting,
+} from '../lib/awaiting.mjs';
+import {
+  bundlesOf,
+  mergeInboxPages,
+  nextInboxCursor,
+  fetchAllInboxNotifications,
+} from '../api/inbox.mjs';
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+//
+// One fixed "now" so every age is arithmetic, not wall-clock.
+const NOW = 1_760_000_000_000; // epoch ms, arbitrary and fixed
+const OWNER_ID = '111';
+
+const t = (n) => String(NOW - n * MS_PER_DAY); // "n days ago", as the API's ms STRING
+
+/** A comment. Every field distinct per call site. */
+function comment({ id, userId, username, date, text }) {
+  return {
+    id,
+    date,
+    comment_text: text,
+    user: { id: userId, username, email: `${username}@example.invalid` },
+  };
+}
+
+/** A task. */
+function task({ id, name, list, status }) {
+  return {
+    id,
+    name,
+    url: `https://app.clickup.test/t/${id}`,
+    list: { id: `9${id}`, name: list },
+    status: { status },
+  };
+}
+
+const TASK_FOREIGN = task({ id: 'aaa1', name: 'Wire the widget', list: 'Platform', status: 'in progress' });
+const TASK_OWNER = task({ id: 'bbb2', name: 'Retire the gadget', list: 'Backlog', status: 'open' });
+const TASK_SILENT = task({ id: 'ccc3', name: 'Nobody said anything', list: 'Icebox', status: 'blocked' });
+const TASK_OLD_FOREIGN = task({ id: 'ddd4', name: 'Stale question', list: 'Support', status: 'review' });
+
+const COMMENTS = new Map([
+  // Newest is FOREIGN (author 222) → awaiting. Deliberately NOT last in the
+  // array, so an implementation that reads comments[length-1] instead of the
+  // newest is caught.
+  [TASK_FOREIGN.id, [
+    comment({ id: 'c10', userId: '222', username: 'dana', date: t(3), text: 'any update?' }),
+    comment({ id: 'c11', userId: OWNER_ID, username: 'owner', date: t(9), text: 'looking' }),
+  ]],
+  // Newest is the OWNER's → not awaiting.
+  [TASK_OWNER.id, [
+    comment({ id: 'c20', userId: '333', username: 'ravi', date: t(12), text: 'ping' }),
+    comment({ id: 'c21', userId: OWNER_ID, username: 'owner', date: t(1), text: 'done' }),
+  ]],
+  // No comments at all → not awaiting.
+  [TASK_SILENT.id, []],
+  // Foreign and 20 days old → awaiting, and the OLDEST, so it sorts first.
+  [TASK_OLD_FOREIGN.id, [
+    comment({ id: 'c30', userId: '444', username: 'mira', date: t(20), text: 'still waiting' }),
+  ]],
+]);
+
+const ALL_TASKS = [TASK_FOREIGN, TASK_OWNER, TASK_SILENT, TASK_OLD_FOREIGN];
+
+const fetchFixtureComments = async (taskId) => {
+  if (!COMMENTS.has(taskId)) throw new Error(`no fixture for ${taskId}`);
+  return COMMENTS.get(taskId);
+};
+
+// ── The predicate ──────────────────────────────────────────────────────────
+
+test('a task whose NEWEST comment is foreign is awaiting', () => {
+  assert.equal(isAwaiting(COMMENTS.get(TASK_FOREIGN.id), OWNER_ID), true);
+});
+
+test("a task whose NEWEST comment is the token owner's is NOT awaiting", () => {
+  assert.equal(isAwaiting(COMMENTS.get(TASK_OWNER.id), OWNER_ID), false);
+});
+
+test('a task with no comments is NOT awaiting', () => {
+  assert.equal(isAwaiting([], OWNER_ID), false);
+  assert.equal(isAwaiting(undefined, OWNER_ID), false);
+});
+
+test('newest is by DATE, not array position', () => {
+  // The foreign comment is FIRST in the array and newest by date. An
+  // implementation reading the last element gets the owner's and inverts the
+  // whole answer.
+  const newest = newestComment(COMMENTS.get(TASK_FOREIGN.id));
+  assert.equal(newest.id, 'c10');
+  assert.equal(commentAuthorId(newest), '222');
+  assert.equal(commentAuthorName(newest), 'dana');
+});
+
+test('the owner id compares across string/number — an id is an id', () => {
+  const owned = [comment({ id: 'c40', userId: 111, username: 'owner', date: t(2), text: 'mine' })];
+  assert.equal(isAwaiting(owned, '111'), false, 'numeric user.id vs string owner id must still match');
+  assert.equal(isAwaiting(owned, 111), false);
+});
+
+test('an author the API did not identify counts as SOMEONE ELSE, not as answered', () => {
+  const anon = [{ id: 'c50', date: t(4), comment_text: 'from nowhere' }];
+  assert.equal(isAwaiting(anon, OWNER_ID), true);
+  assert.equal(commentAuthorName(anon[0]), 'unknown');
+});
+
+test('commentTimeMs reads the API ms STRING, and refuses garbage', () => {
+  assert.equal(commentTimeMs({ date: '1700000000000' }), 1700000000000);
+  assert.equal(commentTimeMs({ date: 'not-a-date' }), null);
+  assert.equal(commentTimeMs({}), null);
+});
+
+// ── Selection, ordering, age window ────────────────────────────────────────
+
+test('selectAwaiting matches the foreign ones and orders OLDEST first', () => {
+  const r = selectAwaiting({
+    tasks: ALL_TASKS, commentsByTaskId: COMMENTS, ownerUserId: OWNER_ID, now: NOW,
+  });
+  assert.deepEqual(r.rows.map((x) => x.id), [TASK_OLD_FOREIGN.id, TASK_FOREIGN.id],
+    'oldest-first: the 20-day-old question must precede the 3-day-old one');
+  assert.equal(r.matched, 2);
+  assert.equal(r.examined, 4, 'examined counts every task walked, matched or not');
+  assert.equal(r.withComments, 3, 'the silent task had none');
+});
+
+test('a row carries the task facts a human needs to act', () => {
+  const r = selectAwaiting({
+    tasks: [TASK_FOREIGN], commentsByTaskId: COMMENTS, ownerUserId: OWNER_ID, now: NOW,
+  });
+  // Pairwise-distinct fixture values: a mutant that swaps list for status, or
+  // name for id, cannot produce this row.
+  assert.deepEqual(
+    {
+      id: r.rows[0].id, name: r.rows[0].name, list: r.rows[0].list,
+      status: r.rows[0].status, by: r.rows[0].lastCommentBy, ageMs: r.rows[0].ageMs,
+    },
+    {
+      id: 'aaa1', name: 'Wire the widget', list: 'Platform',
+      status: 'in progress', by: 'dana', ageMs: 3 * MS_PER_DAY,
+    }
+  );
+});
+
+test('--days keeps only what has been quiet at least that long', () => {
+  const strict = selectAwaiting({
+    tasks: ALL_TASKS, commentsByTaskId: COMMENTS, ownerUserId: OWNER_ID, now: NOW, minAgeDays: 7,
+  });
+  assert.deepEqual(strict.rows.map((x) => x.id), [TASK_OLD_FOREIGN.id],
+    '--days 7 must drop the 3-day-old one and keep the 20-day-old one');
+  assert.equal(strict.examined, 4, 'the age filter narrows MATCHES, never the examined count');
+
+  const boundary = selectAwaiting({
+    tasks: ALL_TASKS, commentsByTaskId: COMMENTS, ownerUserId: OWNER_ID, now: NOW, minAgeDays: 3,
+  });
+  assert.equal(boundary.rows.length, 2, '--days N is "at least N days", inclusive at the boundary');
+
+  const past = selectAwaiting({
+    tasks: ALL_TASKS, commentsByTaskId: COMMENTS, ownerUserId: OWNER_ID, now: NOW, minAgeDays: 21,
+  });
+  assert.equal(past.rows.length, 0);
+  assert.equal(past.examined, 4);
+});
+
+// ── The fan-out cap ────────────────────────────────────────────────────────
+
+test('capFanOut examines exactly max and reports what it left out', () => {
+  const items = ['t1', 't2', 't3', 't4', 't5', 't6', 't7'];
+  const c = capFanOut(items, 3);
+  assert.deepEqual(c.examined, ['t1', 't2', 't3'], 'off-by-one on the cap changes this list');
+  assert.equal(c.total, 7);
+  assert.equal(c.skipped, 4);
+  assert.equal(c.truncated, true);
+});
+
+test('capFanOut does not claim truncation when the cap was not reached', () => {
+  const exact = capFanOut(['t1', 't2', 't3'], 3);
+  assert.equal(exact.truncated, false, 'max == length is a COMPLETE scan, not a truncated one');
+  assert.equal(exact.skipped, 0);
+
+  const under = capFanOut(['t1'], 9);
+  assert.equal(under.truncated, false);
+  assert.equal(under.examined.length, 1);
+});
+
+test('capFanOut refuses a nonsense cap rather than scanning nothing quietly', () => {
+  assert.throws(() => capFanOut(['t1'], 0), RangeError);
+  assert.throws(() => capFanOut(['t1'], -2), RangeError);
+  assert.throws(() => capFanOut(['t1'], 1.5), RangeError);
+  assert.throws(() => capFanOut(['t1'], NaN), RangeError);
+});
+
+test('chunk splits without dropping or duplicating', () => {
+  assert.deepEqual(chunk([1, 2, 3, 4, 5], 2), [[1, 2], [3, 4], [5]]);
+  assert.deepEqual(chunk([], 3), []);
+  assert.throws(() => chunk([1], 0), RangeError);
+});
+
+// ── Pacing ─────────────────────────────────────────────────────────────────
+
+test('batchPauseMs spends the batch budget, minus the time the batch already took', () => {
+  // 60 req/min = 1000ms per request. A 5-request batch owes 5000ms.
+  assert.equal(batchPauseMs(5, 60, 0), 5000);
+  assert.equal(batchPauseMs(5, 60, 1200), 3800, 'a batch that took 1.2s owes 1.2s less');
+  assert.equal(batchPauseMs(5, 60, 9000), 0, 'never negative — a slow batch paid its own way');
+  // A different rate must move the number: a constant would survive the cases
+  // above but not this one.
+  assert.equal(batchPauseMs(4, 120, 0), 2000);
+});
+
+test('batchPauseMs refuses a rate of zero rather than dividing by it', () => {
+  assert.throws(() => batchPauseMs(5, 0), RangeError);
+  assert.throws(() => batchPauseMs(5, -10), RangeError);
+});
+
+test('the default pacing stays under the 100 req/min token limit', () => {
+  assert.ok(AWAITING_DEFAULTS.ratePerMin < 100,
+    `default ratePerMin ${AWAITING_DEFAULTS.ratePerMin} must leave headroom under the ` +
+      '100 req/min token limit — getMyTasks spends from the same budget');
+  // 5 requests at 80/min = 3750ms of budget per batch.
+  assert.equal(
+    batchPauseMs(AWAITING_DEFAULTS.batchSize, AWAITING_DEFAULTS.ratePerMin, 0),
+    3750
+  );
+});
+
+// ── findAwaiting: the orchestration ────────────────────────────────────────
+
+/** A clock that advances a fixed step per read, so pacing is deterministic. */
+function fakeClock(startMs, stepMs) {
+  let now = startMs;
+  return () => {
+    const v = now;
+    now += stepMs;
+    return v;
+  };
+}
+
+test('findAwaiting reads every task under the cap and reports both numbers', async () => {
+  const slept = [];
+  const r = await findAwaiting({
+    tasks: ALL_TASKS,
+    ownerUserId: OWNER_ID,
+    fetchComments: fetchFixtureComments,
+    sleepFn: async (ms) => { slept.push(ms); },
+    clock: () => NOW,
+    batchSize: 2,
+    ratePerMin: 60,
+  });
+  assert.equal(r.examined, 4);
+  assert.equal(r.matched, 2);
+  assert.equal(r.assigned, 4);
+  assert.equal(r.commentFetches, 4);
+  assert.equal(r.truncated, false);
+  assert.deepEqual(r.unreadable, []);
+  assert.deepEqual(r.rows.map((x) => x.id), [TASK_OLD_FOREIGN.id, TASK_FOREIGN.id]);
+  // 2 batches → exactly ONE pause, between them, never after the last.
+  assert.deepEqual(slept, [2000], 'one pause of 2 requests @60/min; no trailing sleep');
+});
+
+test('🔴 a capped scan is reported as EXAMINED-but-TRUNCATED, never as a clean zero', async () => {
+  const r = await findAwaiting({
+    tasks: ALL_TASKS,
+    ownerUserId: OWNER_ID,
+    // Cap at 2 → only TASK_FOREIGN and TASK_OWNER are read, so exactly one match.
+    maxTasks: 2,
+    fetchComments: fetchFixtureComments,
+    sleepFn: async () => {},
+    clock: () => NOW,
+    batchSize: 5,
+  });
+  assert.equal(r.examined, 2);
+  assert.equal(r.assigned, 4);
+  assert.equal(r.skipped, 2);
+  assert.equal(r.truncated, true);
+  assert.equal(r.matched, 1, 'the 20-day-old one lay beyond the cap and was never read');
+  assert.equal(r.commentFetches, 2, 'the cap bounds FETCHES, not just the reported list');
+
+  const out = formatAwaiting(r);
+  assert.match(out, /TRUNCATED/,
+    'a truncated scan MUST say so: silence here reads as "covered everything"');
+  assert.match(out, /2 of 4/, 'the notice must carry both numbers, not just the cap');
+  assert.match(out, /1 matched of 2 task\(s\) examined/,
+    'matched must be printed BESIDE examined — a bare count is unreadable');
+});
+
+test('🔴 a scan that matches nothing still prints how much it examined', async () => {
+  const r = await findAwaiting({
+    tasks: [TASK_OWNER, TASK_SILENT],
+    ownerUserId: OWNER_ID,
+    fetchComments: fetchFixtureComments,
+    sleepFn: async () => {},
+    clock: () => NOW,
+  });
+  assert.equal(r.matched, 0);
+  const out = formatAwaiting(r);
+  assert.match(out, /0 matched of 2 task\(s\) examined/,
+    'a bare "0 awaiting" from a scan that walked nothing is the failure mode this pins');
+});
+
+test('🔴 a task whose comments could not be read is reported, not counted as answered', async () => {
+  const r = await findAwaiting({
+    tasks: [TASK_FOREIGN, TASK_OWNER],
+    ownerUserId: OWNER_ID,
+    fetchComments: async (id) => {
+      if (id === TASK_OWNER.id) throw new Error('rate limited');
+      return COMMENTS.get(id);
+    },
+    sleepFn: async () => {},
+    clock: () => NOW,
+  });
+  assert.equal(r.examined, 1, 'an unreadable task is NOT examined');
+  assert.equal(r.unreadable.length, 1);
+  assert.equal(r.unreadable[0].id, TASK_OWNER.id);
+  assert.match(formatAwaiting(r), /UNREADABLE/);
+});
+
+test('findAwaiting subtracts the batch time from the pause', async () => {
+  const slept = [];
+  await findAwaiting({
+    tasks: ALL_TASKS,
+    ownerUserId: OWNER_ID,
+    fetchComments: fetchFixtureComments,
+    sleepFn: async (ms) => { slept.push(ms); },
+    // Each clock() read advances 500ms, so a batch "takes" 500ms.
+    clock: fakeClock(NOW, 500),
+    batchSize: 1,
+    ratePerMin: 60,
+  });
+  // 4 batches of 1 → 3 pauses, each 1000ms of budget minus 500ms elapsed.
+  assert.deepEqual(slept, [500, 500, 500]);
+});
+
+test('findAwaiting makes no requests at all for an empty board', async () => {
+  let calls = 0;
+  const r = await findAwaiting({
+    tasks: [],
+    ownerUserId: OWNER_ID,
+    fetchComments: async () => { calls++; return []; },
+    sleepFn: async () => { throw new Error('must not sleep with nothing to do'); },
+    clock: () => NOW,
+  });
+  assert.equal(calls, 0);
+  assert.equal(r.examined, 0);
+  assert.equal(r.matched, 0);
+});
+
+// ── The output's own blind spot ────────────────────────────────────────────
+
+test('🔴 the output states the predicate AND the no-bot-identity blind spot', async () => {
+  const r = await findAwaiting({
+    tasks: ALL_TASKS,
+    ownerUserId: OWNER_ID,
+    fetchComments: fetchFixtureComments,
+    sleepFn: async () => {},
+    clock: () => NOW,
+  });
+  const out = formatAwaiting(r);
+  assert.match(out, /NEWEST comment/, 'the predicate must be stated in the output itself');
+  assert.match(out, /no bot identity/i);
+  assert.match(out, /indistinguishable from you answering/i);
+  assert.match(out, /`resolved` is not readable/i,
+    'the output must say what it does NOT measure, or a reader will assume it does');
+});
+
+test('formatAge is coarse but never lies about scale', () => {
+  assert.equal(formatAge(0), '0m');
+  assert.equal(formatAge(45 * 60000), '45m');
+  assert.equal(formatAge(3 * 3600000), '3h');
+  assert.equal(formatAge(3 * 3600000 + 25 * 60000), '3h 25m');
+  assert.equal(formatAge(2 * MS_PER_DAY + 5 * 3600000), '2d 5h');
+  assert.equal(formatAge(null), 'unknown');
+});
+
+// ── Inbox pagination (the second fix) ──────────────────────────────────────
+//
+// These commands cannot be exercised live on this host — every inbox endpoint
+// needs a JWT accounts.json does not carry — so what is pinned is the CURSOR
+// LOOP itself, against a fake transport. The response's cursor FIELD NAME
+// remains an unverified assumption; that is stated in api/inbox.mjs and is not
+// something a test can settle.
+
+const bundle = (id) => ({ id, unreadCount: 1, countByNotificationType: {}, rootEntityResourceName: `clickup:task:1:${id}` });
+const page = (ids, next) => ({
+  notificationBundleGroups: [{ notificationBundles: ids.map(bundle) }],
+  resources: ids.map((id) => ({ entityResourceName: `clickup:task:1:${id}`, name: `task ${id}` })),
+  users: {},
+  pagination: { nextCursor: next },
+});
+
+test('nextInboxCursor reads the cursor, and reports absence as null', () => {
+  assert.equal(nextInboxCursor(page(['b1'], 'CURSOR-2')), 'CURSOR-2');
+  assert.equal(nextInboxCursor({ nextCursor: 'FLAT-3' }), 'FLAT-3', 'a flat response shape too');
+  assert.equal(nextInboxCursor(page(['b1'], '')), null, 'an empty cursor means no more pages');
+  assert.equal(nextInboxCursor(page(['b1'], null)), null);
+  assert.equal(nextInboxCursor({}), null);
+  assert.equal(nextInboxCursor(undefined), null);
+});
+
+test('mergeInboxPages concatenates bundles and de-duplicates resources', () => {
+  const merged = mergeInboxPages([page(['b1', 'b2'], 'c2'), page(['b2', 'b3'], null)]);
+  assert.deepEqual(bundlesOf(merged).map((b) => b.id), ['b1', 'b2', 'b2', 'b3']);
+  assert.deepEqual(merged.resources.map((r) => r.name), ['task b1', 'task b2', 'task b3']);
+  assert.equal(merged.pagesFetched, 2);
+});
+
+test('🔴 fetchAllInboxNotifications follows the cursor past page one', async () => {
+  const pages = [page(['b1', 'b2'], 'C2'), page(['b3'], 'C3'), page(['b4'], null)];
+  const seenCursors = [];
+  let i = 0;
+  const merged = await fetchAllInboxNotifications({
+    // The injected transport is the control: a single-page read returns 2
+    // bundles here, the whole queue is 4. That gap is the bug being fixed.
+    fetchPage: async (opts) => { seenCursors.push(opts.cursor); return pages[i++]; },
+  });
+  assert.deepEqual(seenCursors, ['', 'C2', 'C3'], 'each page must be requested with the PREVIOUS page\'s cursor');
+  assert.deepEqual(bundlesOf(merged).map((b) => b.id), ['b1', 'b2', 'b3', 'b4']);
+  assert.equal(merged.pagesFetched, 3);
+  assert.equal(merged.truncated, false);
+});
+
+test('the cursor loop stops on a repeated cursor instead of spinning', async () => {
+  let calls = 0;
+  const merged = await fetchAllInboxNotifications({
+    fetchPage: async () => { calls++; return page(['b9'], 'SAME'); },
+    maxPages: 50,
+  });
+  assert.ok(calls <= 3, `a server that repeats its cursor must not loop; made ${calls} calls`);
+  assert.ok(bundlesOf(merged).length > 0);
+});
+
+test('the page bound is reported as TRUNCATED, not as the whole queue', async () => {
+  let n = 0;
+  const merged = await fetchAllInboxNotifications({
+    fetchPage: async () => page([`b${n++}`], `C${n}`),
+    maxPages: 3,
+  });
+  assert.equal(merged.pagesFetched, 3);
+  assert.equal(merged.truncated, true, 'hitting the bound is not a complete read');
+});

--- a/scripts/run-node-tests.sh
+++ b/scripts/run-node-tests.sh
@@ -171,7 +171,10 @@ SUITES=(
   # floor 68 = 71 - min(50, max(1, 71/20)).
   # 92 tests measured 2026-08-14 (the astral-character controls js-source.mjs
   # never had), floor 88 = 92 - min(50, max(1, 92/20)) = 92 - 4.
-  "claude/skills/clickup/test|3|88"
+  # 122 tests / 4 files measured 2026-08-21: test/awaiting.test.mjs, the gate for
+  # the `awaiting` command (predicate, fan-out cap, pacing) and for the inbox
+  # cursor loop. Floor 116 = 122 - min(50, max(1, 122/20)) = 122 - 6.
+  "claude/skills/clickup/test|4|116"
 )
 
 # --- discovery roots -----------------------------------------------------------

--- a/scripts/tests/test_run_node_tests_suites.py
+++ b/scripts/tests/test_run_node_tests_suites.py
@@ -90,7 +90,12 @@ FORMERLY_UNGATED = {
     # on, split by CODE POINT while indexing by CODE UNIT, so one emoji shifted
     # every later offset. Its own controls asserted exactly the right property
     # and had never been handed a non-ASCII character.
-    "claude/skills/clickup/test": 92,
+    #
+    # 122 on 2026-08-21: test/awaiting.test.mjs, added with the `awaiting`
+    # command — the predicate, the fan-out cap and its truncation notice, the
+    # pacing arithmetic, and the inbox cursor loop against a fake transport
+    # (every inbox endpoint needs a JWT, so that loop has no other witness).
+    "claude/skills/clickup/test": 122,
 }
 
 


### PR DESCRIPTION
## `awaiting` — "who is waiting on me", answered with the only predicate this API can answer

```
node query.mjs awaiting [--days N] [--assignee <user>] [--max N] [--json]
```

From `getMyTasks()`, read each task's comments and keep the tasks whose **newest
comment was not authored by the token owner**, oldest first, with the task name,
list, status, how long it has been waiting, and who spoke last.

### Why that predicate and not a better one — measured, read-only, before writing code

| wanted | why it is not computable |
|---|---|
| "unresolved comments" | `resolved` is **not readable** on a task comment. Union of every field over 84 comments / 29 tasks: `assignee, comment, comment_text, date, group_assignee, id, reactions, reply_count, user`. It never appears, not even as `false` — though `resolve-comment` can *write* it. |
| "comments assigned to me" | `assignee` was **null on all 84** sampled comments. |
| ClickUp's own "@mentioned me / unread" | that is the `inbox-*` group, which needs a **JWT** this host's `accounts.json` does not carry (`apiToken`, `teamId`, `userId` only). |

🔴 **The blind spot ships in the command's own output, not just in docs.** ClickUp
has no bot identity: every comment posted through the `pk_` token comes back
authored as the token owner, so "you answered" and "a machine answered for you"
are the same observable. A task answered by an automated write-back will not
appear here, and the command says so every run.

### What the output always carries

* tasks **EXAMINED** beside tasks **MATCHED** — a bare "0 awaiting" from a scan
  that walked nothing is the failure mode, not the all-clear;
* **TRUNCATED**, with both numbers, when `--max` cut the fan-out short;
* **UNREADABLE**, separately, for any task whose comments could not be fetched —
  never folded into the examined count.

Fan-out is one fetch per task, so it is capped (`--max`, default 60) and paced in
batches of 5 at 80 fetches/min, under the 100 req/min token limit (`getMyTasks`
spends from the same budget; an unpaced loop bursts ~190/min).

### Also fixed (same file, independently real)

* **`inbox` read ONE page of 20 and never touched a cursor**; `inbox-clear-all`
  one page of 140, so "clear all" meant "clear a prefix". Both now follow
  `nextCursor` via `fetchAllInboxNotifications`, which stops on an absent cursor,
  an empty page, or a repeated cursor, and reports `pagesFetched` / `truncated`
  instead of presenting a bounded read as the whole queue. This is the exact bug
  `reference/raw-api.md` warns about.
  ⚠️ The **response's** cursor field name is an assumption — no inbox endpoint is
  callable on this host, so no response body was ever observed. The reader tries
  several plausible locations and terminates rather than spins; the limit is
  written into `api/inbox.mjs`. **These commands were not exercised live.**
* `api/inbox.mjs` had always accepted `mentioned`, `unread`, `dateStart`,
  `cursor`; `query.mjs` exposed only `--me`. Now `--mentioned`, `--unread`,
  `--since` (reusing the existing window parser), `--cursor`, plus `--cleared`.

### Verification

* **Live, read-only** (`awaiting`, `awaiting --max/--days/--json`; no mutating
  verb was run): 53 assigned tasks, 29 with any comment, **2 matched**, 53
  comment fetches, ~45 s wall. `--max 5` printed the truncation notice with both
  numbers; `--max 0` and `--days abc` are rejected before any request.
* **Red/green:** the new suite cannot even import at `origin/main` — neither
  `lib/awaiting.mjs` nor the inbox exports exist there — so it is red at base and
  green at HEAD. The discriminating evidence is the mutation sweep below, where
  the pre-fix single-page inbox read is one of the mutants.
* **Mutation sweep, 14 semantic mutants** (cap off-by-one, truncation boundary,
  inverted author test, oldest-instead-of-newest, reversed sort, age boundary,
  pacing that ignores batch size, a trailing sleep, unreadable folded into
  examined, dropped blind-spot and truncation notices, the single-page inbox
  regression, a non-advancing cursor): **13 KILLED**; the 14th, a cosmetic
  comment reword kept as the **negative control**, SURVIVED — which is what shows
  the sweep can report a survivor at all.
* **Help gate mutated too:** deleting the `awaiting` line from `showUsage()`
  fails `test/help-coverage.test.mjs` naming `awaiting`.
* Node suite floor raised `3|88` → `4|116` (122 measured; `122 - min(50, max(1,
  122/20))`), and the pinned measurement in `test_run_node_tests_suites.py` with
  it. `TARGET_FLOORS` in `run-tests.sh` untouched.

`SKILL.md` still does not list commands — `showUsage()` remains the single source
of truth; only the non-obvious facts about `awaiting` were added to it.

### Gate

`nix develop . --command bash scripts/gate.sh` (both tiers, run from the standalone clone):

```
PASS  claude/skills/clickup/test  (files=4 tests=122 pass=122 skipped=0 floor=116)
TOTAL suites=4 files=34 tests=1149 pass=1149 fail=0 skipped=0  (floor: 1126)
RESULT: PASS (exit=0)          # node tier
pytest: TOTAL collected=14341 passed=14339 skipped=1 failed=1 (floor: 13324)
GATE: RESULT=FAIL exit=1
```

🔴 The one pytest failure is **pre-existing on `origin/main` and unrelated to this
branch**: `scripts/browser-bridge/tests/test_skill_size.py::test_skill_md_keeps_
working_headroom` — `scripts/browser-bridge/SKILL.md` is 12,259 B, 29 B under its
12,288 B ceiling and short of the 250 B required headroom. Control run: the same
test fails identically (`assert 29 >= 250`) against a pristine `origin/main`
checkout, and this branch's diff touches nothing under `scripts/browser-bridge/`
(the file is byte-identical to `origin/main`). So the gate is red at base for a
reason this PR neither causes nor fixes; everything this PR does touch is green.
