### PR TITLE
guard(tests): the audit found nine bypasses, a second audit found eight more spellings of the same nine

### DIFF
--- a/scripts/testlib/nogit.py
+++ b/scripts/testlib/nogit.py
@@ -46,17 +46,8 @@ one-for-one onto the reflog above (`config user.email t@t`, `commit -m seed`,
 well-formed `git -C <tmp clone> …`.
 
 So the target of a write is computed from the ARGUMENTS **and** the
-ENVIRONMENT, in two sub-classes that do not cover each other:
-
-  * IDENTITY redirection (`GIT_DIR`, `GIT_COMMON_DIR`) — git reports a
-    different repo. Caught by asking git which repo it will actually use.
-  * BYTE redirection (`GIT_WORK_TREE`, `GIT_INDEX_FILE`,
-    `GIT_OBJECT_DIRECTORY`, the alternates, `GIT_CONFIG_GLOBAL/SYSTEM`) —
-    identity stays innocent and TRUTHFUL and only the destination moves.
-    `GIT_WORK_TREE=<victim> git -C <fixture> checkout -f HEAD` exits 0 and
-    writes the victim's working tree. **Resolving the repo cannot see this.**
-
-See `GIT_LOCATION_ENV` for the ledger and the two entries that were wrong.
+ENVIRONMENT, in sub-classes that do not cover each other. `GIT_LOCATION_ENV`
+carries the ledger and the measurement that decides membership.
 
 🔴 IT IS INVISIBLE BY CONSTRUCTION
 -----------------------------------
@@ -66,26 +57,37 @@ after-the-fact check reports a clean repo. A guard that inspects state after
 the run therefore cannot see this class at all — the interception has to happen
 at the moment of the call, which is what this module does.
 
-WHY A PATH SHIM AND NOT A `subprocess` MONKEYPATCH
---------------------------------------------------
-The same reason `testlib/nolaunch.py` is a PATH shim, and it is decisive here
-rather than merely tidy: a `git` that damages something is very often run by a
-GRANDCHILD. The suite spawns shell scripts, and those scripts run `git`; a
-`subprocess.Popen` patched inside the pytest process never sees any of it. Only
-a shim that is first on `PATH` — inherited by every descendant, at any depth —
-can. The in-process layer exists too, mirroring `nolaunch_plugin`'s L2, but
-purely to catch an ABSOLUTE-path `git` that PATH cannot shadow.
+🔴 WHY A PATH SHIM, AND WHY PATH ALONE IS NOT ENOUGH
+-----------------------------------------------------
+A `git` that damages something is very often run by a GRANDCHILD. The suite
+spawns shell scripts, and those scripts run `git`; a `subprocess.Popen` patched
+inside the pytest process never sees any of it. Only a shim inherited through
+the environment can.
 
-⚠ An earlier revision of this paragraph named `scripts/drift-check.sh`'s
-`ssh … bash -s` leg (where `DRIFT_REPO` is unset and
-`${DRIFT_REPO:-$HOME/workspace/devrc}` resolves to the real clone) as the
-motivating caller. That theory is RETRACTED and should not be re-derived: the
-test harness's stub `ssh` writes the payload to `/dev/null` and never executes
-it, and the payloads are read-only regardless. The empty-override sites in
-`drift-check.sh` and `ship.sh` are a genuine latent hazard — all five use `:-`,
-which falls back on EMPTY as well as unset — but no caller passes an empty
-value, so they were not the mechanism. The PATH-shim argument stands on the
-grandchild point alone.
+⚠ An earlier revision of this file claimed that being "first on PATH" made the
+shim unavoidable "at any depth". **That claim was FALSE and is now closed by
+`exec_path_farm()` — do not re-derive it.** MEASURED:
+
+    $ git -c 'alias.p=!echo PATH[0]=$(echo $PATH | cut -d: -f1)' p
+    PATH[0]=/nix/store/…-git-2.55.0/libexec/git-core
+
+git PREPENDS its own `libexec/git-core` to `PATH` for every child it spawns,
+and that directory contains a real `git` binary. So every alias, hook, filter,
+`core.fsmonitor`, `GIT_SSH_COMMAND`, `rebase --exec` and `submodule foreach`
+child resolved `git` to the REAL binary no matter where the shim sat:
+
+    $ git -C <fixture> -c 'alias.x=!git -C <victim> commit …' x
+    rc 0, and the victim received the commit.
+
+The fix is to make git prepend a directory THIS module owns: `exec_path_farm()`
+builds a directory of symlinks to every real `git-*` helper plus the shim as
+`git`, and `GIT_EXEC_PATH` points at it. Measured through the farm, PATH[0]
+inside an alias is the farm and `git` resolves to the shim. See
+`_exec_path_export()` for why the shim re-exports it on every call.
+
+The in-process layer (`nogit_plugin._patch_subprocess`) exists to catch an
+ABSOLUTE-path `git` launched by the pytest process, which no PATH-based
+mechanism can shadow.
 
 🔴 WHY THE SPLIT IS BY VERB **AND** BY TARGET, AND WHY IT FAILS LOUD
 ---------------------------------------------------------------------
@@ -125,13 +127,36 @@ those was found by a POSITIVE control; none was visible to a negative one.
 A `push` from a repo that IS inside the tmpdir still reaches whatever its
 `origin` points at. That is not hypothetical here: the contained clone prepared
 for this work had an `origin` pointing at the operator's real local clone, so a
-fixture pushing to `origin` would have written into their actual refs. Location
-of the *source* repo therefore does not bound the blast radius of a push, and
-`_push_destination_body` resolves the destination URL and applies the same
-root check to it.
+fixture pushing to `origin` would have written into their actual refs.
+
+🔴 THE THIRD VECTOR: CONFIG INJECTION MOVES THE DESTINATION WITHOUT NAMING IT
+------------------------------------------------------------------------------
+`-c key=value`, `--config-env=key=VAR` and the `GIT_CONFIG_COUNT` /
+`GIT_CONFIG_KEY_<n>` / `GIT_CONFIG_VALUE_<n>` family all inject configuration
+for one invocation. MEASURED, against the revision of this file that ignored
+them entirely:
+
+    GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.hooksPath \
+      GIT_CONFIG_VALUE_0=<victim>/hooks \
+      git -C <fixture> commit --allow-empty -m hookprobe
+    -> rc 0, ALLOWED, the hook EXECUTED, artefact written inside the victim.
+
+    GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=remote.origin.url \
+      GIT_CONFIG_VALUE_0=<victim>   git -C <fixture> push origin HEAD:pwned
+    -> rc 0, ALLOWED, `refs/heads/pwned` created in the victim.
+
+It is NOT blanket-refused, and that is the whole design constraint:
+`scripts/analyze-service-index/commit.sh:247` legitimately exports
+`GIT_CONFIG_COUNT=2` with `core.hooksPath` / `init.templateDir` aimed at an
+empty `mktemp -d`, precisely to NEUTRALISE hooks, and two tests pin it. So
+injected keys are classified — see `GIT_CONFIG_PATH_KEYS` and
+`GIT_CONFIG_CMD_KEYS` — and a path-valued key is bounds-checked like any other
+destination. The mktemp dir is under `$TMPDIR` and passes; the victim-aimed one
+does not.
 """
 from __future__ import annotations
 
+import hashlib
 import os
 import shutil
 from pathlib import Path
@@ -152,19 +177,55 @@ from .mockbin import write_exec
 # remote. "Usually read-only" is not the test — `remote` and `config` both
 # READ in their bare forms and write with an argument, so neither is listed
 # and both are decided by target instead.
+#
+# 🔴 TWO ENTRIES WERE REMOVED BECAUSE THEY VIOLATED THAT RULE, and the test
+# that was supposed to catch them could not:
+#   * `hash-object` writes a loose object with `-w`. MEASURED against a denied
+#     victim: `git -C <victim> hash-object -w <file>` exited 0 and the victim's
+#     loose-object count went 6 -> 7. It is now a DUAL verb — the read form is
+#     the one without `-w`.
+#   * `symbolic-ref` REPOINTS a ref with two arguments and DELETES one with
+#     `-d`. MEASURED against a denied victim: `git -C <victim> symbolic-ref -q
+#     HEAD refs/heads/trunk` exited 0 and moved the victim's `.git/HEAD` and
+#     `.git/logs/HEAD`. The one-argument form is a read; the verb is now DUAL.
+#   * `interpret-trailers --in-place <file>` REWRITES THE FILE IT IS GIVEN, so
+#     the verb can write anywhere the caller can name — it is DUAL too.
+#   * `status` refreshes and REWRITES `<repo>/.git/index`. MEASURED: the
+#     victim's index hash moved `63e1e299594b -> 59551aa2642b`. It stays a read
+#     — the suite runs it against the real repo on purpose — but the shim now
+#     always execs it as `git --no-optional-locks status`, which MEASURED
+#     leaves the index byte-identical and produces byte-identical stdout. See
+#     `GIT_LOCK_FREE_READ_VERBS`.
 # ---------------------------------------------------------------------------
 GIT_READ_VERBS = (
     "status", "log", "show", "diff", "cat-file", "ls-files", "ls-tree",
     "ls-remote", "rev-parse", "rev-list", "describe", "blame", "grep",
-    "shortlog", "show-ref", "symbolic-ref", "for-each-ref", "merge-base",
+    "shortlog", "show-ref", "for-each-ref", "merge-base",
     "name-rev", "check-ignore", "check-attr", "count-objects", "verify-pack",
     "var", "help", "version", "annotate", "whatchanged", "cherry",
-    "diff-tree", "diff-index", "diff-files", "hash-object", "patch-id",
-    "get-tar-commit-id", "check-mailmap", "column", "interpret-trailers",
+    "diff-tree", "diff-index", "diff-files", "patch-id",
+    "get-tar-commit-id", "check-mailmap", "column",
 )
 
-# Read-only global FLAGS: they answer and exit whatever else is on the line,
-# so they are safe in any position (unlike a verb, which is positional).
+# 🔴 Read verbs that touch the index unless told not to. `--no-optional-locks`
+# is prepended for these, ALWAYS — not only when the target is out of bounds,
+# because deciding that would cost a `rev-parse` subprocess on the hottest path
+# in the suite. MEASURED on git 2.55.0: identical stdout, and the victim's
+# `.git/index` unchanged.
+GIT_LOCK_FREE_READ_VERBS = ("status",)
+
+# Read-only global FLAGS. 🔴 SCANNED ONLY BEFORE THE VERB.
+#
+# MEASURED: the previous revision scanned the WHOLE argv for these, so any
+# `-h` anywhere — including as the VALUE of an option — took the exec fast path
+# with no bounds check at all:
+#
+#     git -C <victim> commit --allow-empty -m -h   -> rc 0, TWO victim commits
+#
+# `-m -h` means "commit with the message `-h`". Only tokens before the verb can
+# be git's own global options, so that is the only place they are honoured now.
+# `<verb> -h` / `<verb> --help` is handled separately, and only when it is the
+# single remaining token, which is exactly the form that prints usage and exits.
 GIT_READ_FLAGS = ("--version", "--help", "-h", "--exec-path", "--html-path",
                   "--man-path", "--info-path")
 
@@ -179,14 +240,7 @@ GIT_REMOTE_WRITE_VERBS = ("push",)
 # first draft, `git init /tmp/<fixture>` was REFUSED, because the resolver used
 # the process's cwd — and a suite run from the repo root has the repo as its
 # cwd. Every fixture that builds itself a clone would have gone red, which is
-# the permanently-red gate claude/RULES.md warns about: the guard would have
-# been switched off within a day and the real hazard would be back.
-#
-# `init` and `clone` CREATE a repo at a path they are handed, so the path is
-# what must be bounded. The option tables below exist because the target is
-# "the first positional after the verb" only once options with VALUES are
-# skipped — `git init -b main` would otherwise resolve its target to `main`,
-# reintroducing the same false positive in a narrower shape.
+# the permanently-red gate claude/RULES.md warns about.
 GIT_TARGET_IS_ARG_VERBS = ("init", "clone")
 
 # Options that consume the NEXT argv entry, for the two verbs above. Any option
@@ -218,7 +272,8 @@ GIT_CLONE_VALUE_OPTS = (
 # unrecognised form is a write. It runs only when the target is already out of
 # bounds, so a misclassification cannot affect a legitimate fixture write.
 GIT_DUAL_VERBS = ("remote", "config", "branch", "tag", "worktree",
-                  "submodule", "stash", "notes")
+                  "submodule", "stash", "notes", "hash-object",
+                  "symbolic-ref", "interpret-trailers", "fsck")
 
 # 🔴 THE ENVIRONMENT IS PART OF THE TARGET — `-C` IS NOT PROTECTIVE.
 #
@@ -226,59 +281,112 @@ GIT_DUAL_VERBS = ("remote", "config", "branch", "tag", "worktree",
 #
 #     $ GIT_DIR=<victim>/.git git -C <fixture> rev-parse --show-toplevel
 #     <fixture>                      <- the innocent answer
-#     $ GIT_DIR=<victim>/.git git -C <fixture> rev-parse --absolute-git-dir
-#     <victim>/.git                  <- where the write ACTUALLY goes
-#
 #     $ GIT_DIR=<victim>/.git git -C <fixture> commit --allow-empty -m PWNED
 #     rc=0, and <victim>'s commit count went 1 -> 2.
 #
-# So an ambient `GIT_DIR` redirects the refs and objects while `--show-toplevel`
-# still reports the directory `-C` names. A guard that resolves the target from
-# the ARGUMENTS is bypassed completely, and — this is the part that matters —
-# so is every audit that concluded "absolute `-C`, therefore fixture-scoped".
-# Two independent reviews of the suite reached that conclusion by checking the
-# wrong property.
-#
-# This is the reproduced mechanism of the incident: replaying a repo-cos
-# fixture with `GIT_DIR` naming a victim reproduced all four observed damages —
-# a `commit`, the `main → trunk` rename, a `user.email` rewrite and a push to
-# the victim's own origin.
-#
 # The defence is therefore NOT to enumerate argument shapes. It is to ask GIT
-# ITSELF where it is about to write (`rev-parse --absolute-git-dir` and friends,
-# which honour every redirection vector including ones not listed below), and
-# to check the listed variables explicitly on top of that.
+# ITSELF where it is about to write, and to check the listed variables
+# explicitly on top of that.
 #
-# 🔴 THIS LEDGER IS KNOWN-INCOMPLETE, BY MEASUREMENT. It was built from the
-# installed git's own `man git` — 76 `GIT_*` names — and that page does NOT
-# document `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_<n>` / `GIT_CONFIG_VALUE_<n>`,
-# which this git demonstrably honours (injecting `user.name` through them
-# works). A family the binary obeys was absent from the page describing it, so
-# the list below cannot be trusted as closed — which is exactly why git's own
-# answer is the primary check and this ledger is only the belt.
+# 🔴 EVERY ENTRY MUST BE A PATH THAT RECEIVES BYTES, and membership is decided
+# by ARMING THE VARIABLE WITH THE GUARD REMOVED and watching the victim move —
+# never by asking whether the guard refuses it. THREE names have now been
+# removed for failing that test:
+#   * `GIT_NAMESPACE` is a REF NAMESPACE, not a filesystem path.
+#   * `GIT_CEILING_DIRECTORIES` RESTRICTS repository discovery; treating it as
+#     a destination inverts its meaning and refuses the safe case.
+#   * `GIT_ALTERNATE_OBJECT_DIRECTORIES` is a READ-ONLY *additional* object
+#     store. It survived the first cull and the test written to prevent
+#     exactly this recurrence PINNED IT AS CORRECT. MEASURED with it armed at
+#     the victim and the guard removed:
 #
-# 🔴 EVERY ENTRY MUST BE A PATH THAT RECEIVES BYTES. Two names were removed
-# after the first armed run, because being git-related is not the membership
-# rule:
-#   * `GIT_NAMESPACE` is a REF NAMESPACE, not a filesystem path. A real
-#     namespace ("foo") would have been canonicalised into `$base/foo` and
-#     refused — a pure false positive on a variable that cannot redirect a
-#     write anywhere.
-#   * `GIT_CEILING_DIRECTORIES` RESTRICTS repository discovery. It only ever
-#     narrows what git will touch, so treating it as a destination inverts its
-#     meaning and refuses the safe case.
-# Both were "caught" by a negative control that armed them at a victim PATH —
-# which proves only that the check reads variables, not that those variables
-# are write targets. The controls were measuring the guard, not the hazard.
+#         GIT_ALTERNATE_OBJECT_DIRECTORIES=<victim>/.git/objects \
+#           git -C <fixture> commit --allow-empty -m PWNED
+#         -> rc 0; the new object landed in <fixture>/.git/objects/c4/…
+#            and a full byte manifest of the victim was UNCHANGED.
+#
+#     Counting it as "defended" is what inflated this policy's headline number.
+#     `test_every_env_ledger_entry_is_a_live_write_vector` now EXERCISES each
+#     entry with the guard removed instead of asserting membership, so a
+#     non-vector cannot be pinned as correct again.
 GIT_LOCATION_ENV = (
     "GIT_DIR",
     "GIT_COMMON_DIR",
     "GIT_WORK_TREE",
     "GIT_OBJECT_DIRECTORY",
-    "GIT_ALTERNATE_OBJECT_DIRECTORIES",  # colon-separated
     "GIT_INDEX_FILE",
     "GIT_CONFIG_GLOBAL",
     "GIT_CONFIG_SYSTEM",
+)
+
+# 🔴 Environment variables whose value is a COMMAND git will EXECUTE.
+#
+# MEASURED against the previous revision: a permitted READ became arbitrary
+# code execution with the victim as target.
+#
+#     GIT_EXTERNAL_DIFF=<script writing into the victim> git -C <fixture> diff
+#     -> rc 0, ALLOWED, and <victim>/EXTDIFF-RAN was created.
+#
+# A command string is not a path, so it cannot be bounds-checked. These are
+# refused outright when NON-EMPTY. An EMPTY value is allowed and is not an
+# oversight: emptying one of these is how a caller DISARMS the hook, which is
+# the opposite of the hazard. Grepped across `scripts/`: no caller sets any of
+# these to a non-empty value, so the false-positive cost is zero today.
+#
+# `GIT_EDITOR` / `GIT_PAGER` are deliberately ABSENT. `GIT_PAGER=cat` and
+# `GIT_EDITOR=true` are the standard hermetic-harness idioms, they run only in
+# interactive flows this suite never reaches, and refusing them would be a
+# permanently-red gate for no measured hazard.
+#
+# 🔴 `GIT_SSH_COMMAND` IS ABSENT TOO, AND THAT WAS MEASURED RATHER THAN
+# REASONED. It was on this list for one armed run of `scripts/tests` and cost
+# NINE red tests: `scripts/resume-state.sh:327` sets
+# `GIT_SSH_COMMAND='ssh -oBatchMode=yes -oConnectTimeout=5 …'` around its
+# `fetch`, which is a caller doing the right thing (refusing to hang a test
+# runner on an ssh prompt). The refusal did not read as a policy violation
+# either — it surfaced as `[fetch failed; compared against refs already on
+# disk]` inside resume-state's own output, and the tests failed on a
+# DIFFERENT assertion four layers away.
+#
+# The residual hazard is small and is covered elsewhere: `GIT_SSH_COMMAND`
+# executes only for an ssh transport, a `push` to a non-local URL is already
+# refused as "not a local path", and an ssh `fetch` only reads. The four names
+# that remain have ZERO callers anywhere under `scripts/`.
+GIT_EXEC_ENV = ("GIT_EXTERNAL_DIFF", "GIT_ASKPASS", "GIT_PROXY_COMMAND",
+                "GIT_SSH")
+
+# 🔴 Injected-config keys whose VALUE IS A PATH THAT RECEIVES BYTES or that
+# git will read executable content out of. Bounds-checked like any other
+# destination — NOT refused.
+#
+# The bounds check rather than a refusal is forced by a real caller:
+# `scripts/analyze-service-index/commit.sh:247` exports
+# `GIT_CONFIG_COUNT=2` with `core.hooksPath` and `init.templateDir` both aimed
+# at an empty `mktemp -d` under `$TMPDIR`, to neutralise hooks. That dir is
+# inside an allowed root and passes; `<victim>/hooks` does not.
+#
+# Matched case-insensitively and as GLOBS, because git config keys are
+# case-insensitive in their section and variable parts and several of these
+# carry a middle subsection.
+GIT_CONFIG_PATH_KEYS = (
+    "core.hookspath", "init.templatedir", "core.worktree", "include.path",
+    "includeif.*.path", "core.excludesfile", "core.attributesfile",
+    "commit.template",
+)
+
+# 🔴 Injected-config keys whose VALUE IS A COMMAND. Refused when non-empty, for
+# the same reason as `GIT_EXEC_ENV`: a command string cannot be bounds-checked.
+#
+# EMPTY IS ALLOWED, and that is load-bearing rather than lenient:
+# `scripts/task-spec-drafter/ticket-status:249` passes `-c core.fsmonitor=`
+# as a HARDENING measure — an empty value disables the hook. Refusing it would
+# have gone red on a caller that was doing the right thing.
+GIT_CONFIG_CMD_KEYS = (
+    "alias.*", "core.fsmonitor", "core.editor", "core.pager",
+    "core.sshcommand", "core.askpass", "sequence.editor", "diff.external",
+    "diff.*.textconv", "diff.*.command", "filter.*.clean", "filter.*.smudge",
+    "filter.*.process", "credential.helper", "uploadpack.packobjectshook",
+    "gpg.program", "gpg.*.program", "merge.*.driver", "protocol.*.command",
 )
 
 # 🔴 Paths that are never a repository and never worth protecting.
@@ -287,13 +395,11 @@ GIT_LOCATION_ENV = (
 # armed run of the full suite — `GIT_CONFIG_GLOBAL=/dev/null` is the standard
 # idiom for "this test has no global git config", used throughout this tree and
 # by every hermetic harness. Refusing it would have made the policy
-# permanently red across `scripts/tests` on day one, and a permanently-red gate
-# gets switched off.
+# permanently red across `scripts/tests` on day one.
 #
 # It is an exemption for a SINK, not a widening of the roots: `/dev/null`
 # discards what is written to it, so a config write aimed there damages
-# nothing. `GIT_CONFIG_GLOBAL=<victim>/.gitconfig` is still refused, which is
-# the case the negative control actually cares about.
+# nothing. `GIT_CONFIG_GLOBAL=<victim>/.gitconfig` is still refused.
 ALWAYS_SAFE_PATHS = ("/dev/null",)
 
 LOG_NAME = "git-calls.log"
@@ -307,11 +413,10 @@ BLOCK_EXIT = 99
 # message can drift is a policy whose firing cannot be asserted on.
 BANNER = "DEVRC-NO-REAL-GIT VIOLATION"
 
-# Where `install()` is told which roots a write may target, and which mode to
-# run in. Read by the STUB at call time (not baked in) so a test can widen the
-# roots for its own fixture without reinstalling the shim.
+# Where `install()` is told which roots a write may target. Read by the STUB at
+# call time (not baked in) so a test can widen the roots for its own fixture
+# without reinstalling the shim.
 ROOTS_ENV = "DEVRC_TEST_GIT_ALLOWED_ROOTS"
-MODE_ENV = "DEVRC_TEST_GIT_MODE"
 STUB_DIR_ENV = "DEVRC_TEST_GIT_STUB_DIR"
 
 # 🔴 Roots that are ALWAYS refused, checked BEFORE the allow-list and winning
@@ -323,30 +428,202 @@ STUB_DIR_ENV = "DEVRC_TEST_GIT_STUB_DIR"
 # source tree is unpacked UNDER `$TMPDIR` — so an allow-list alone would place
 # the repo under test INSIDE an allowed root, and every write this policy
 # exists to stop would be permitted in exactly the tier that gates merges.
-# That is the two-tier hazard from claude/RULES.md, arriving through the guard
-# rather than around it: the dev host would be protected and CI structurally
-# blind, so a violation could merge green and only fire on someone's machine.
-#
-# The deny root is the repo the suite is running out of, resolved at session
-# start. It makes "never write to the tree under test" true in BOTH tiers by
-# the same code, and it is why the negative control can be aimed at a real
-# clone's root without that clone needing to live outside /tmp.
 DENY_ROOTS_ENV = "DEVRC_TEST_GIT_DENIED_ROOTS"
 
-# `block` (default) refuses the write. `audit` records it and lets it through.
+# 🔴 THERE IS NO ENV-READABLE MODE ANY MORE, AND THAT IS THE FIX.
 #
-# 🔴 `audit` EXISTS TO BE MEASURED WITH, NOT TO BE SHIPPED WITH. It is how the
-# blast radius of this policy was established before it was turned on (every
-# git call in the suite, with its resolved target, logged and classified). A
-# test pins `block` as the default precisely so an audit run cannot be left on
-# by accident — a guard silently in audit mode is a guard that never fires.
+# This module used to read `DEVRC_TEST_GIT_MODE`; `audit` recorded a violation
+# and let it through. MEASURED: `DEVRC_TEST_GIT_MODE=audit git -C <victim>
+# commit --allow-empty -m AUDITPWN` returned 0 and the victim received the
+# commit — a single environment variable, inherited from anywhere, silently
+# disarmed the whole policy. The test that was meant to prevent it asserted
+# only that a `${VAR:-block}` string appeared in the generated body, which is
+# satisfied by a shim in audit mode.
+#
+# Audit behaviour is now a BAKE-TIME argument to `install()`, so nothing an
+# inherited environment can carry will turn the guard off. `MODE_ENV` remains
+# defined only so the plugin can scrub a stale value and a test can assert the
+# shim ignores it.
+MODE_ENV = "DEVRC_TEST_GIT_MODE"
 MODE_BLOCK = "block"
 MODE_AUDIT = "audit"
+
+# 🔴 The handshake. `<stub>/git --devrc-nogit-handshake` prints this magic, the
+# POLICY FINGERPRINT, and the roots the shim was BAKED with.
+#
+# It exists because `nogit_plugin._inherited_stub_dir()` used to adopt any
+# directory whose `DEVRC_TEST_GIT_STUB_DIR` contained a FILE NAMED `git` and
+# then skip installation entirely. MEASURED with that variable pointed at a
+# plain passthrough script: a write to the repo-under-test landed rc 0 with no
+# banner, and the session marker was written anyway — the run reported
+# "1 passed" with no guard present at all. A filename is a spelled guard,
+# walkable by anything called `git`.
+HANDSHAKE_FLAG = "--devrc-nogit-handshake"
+HANDSHAKE_MAGIC = "DEVRC-NOGIT-HANDSHAKE"
+
+# The subdirectory of the stub dir that becomes `GIT_EXEC_PATH`. Deliberately
+# NOT the stub dir itself: the farm holds ~184 symlinks named `git-*`, and
+# putting those on PATH[0] would shadow any same-named tool for every process
+# in the session. The farm is reached only through `GIT_EXEC_PATH`.
+EXEC_PATH_DIR = "execpath"
 
 
 def log_path(stub_dir: Path) -> Path:
     """Where the shim records every intercepted `git`, one line per call."""
     return Path(stub_dir) / LOG_NAME
+
+
+def exec_path_dir(stub_dir: Path) -> Path:
+    """The `GIT_EXEC_PATH` farm belonging to a stub dir."""
+    return Path(stub_dir) / EXEC_PATH_DIR
+
+
+# --------------------------------------------------------------------------- #
+# sh helpers
+# --------------------------------------------------------------------------- #
+def _exec_path_export(stub_dir: Path) -> str:
+    """sh that re-exports `GIT_EXEC_PATH` at the top of every shim call.
+
+    🔴 RE-EXPORTED ON EVERY CALL, not only set once by the plugin, for the same
+    reason the roots are baked in: a child built with a REPLACING `env=` dict
+    keeps `PATH` (or it could not find git at all) and drops everything else.
+    Without this line such a child reaches the shim, the shim execs the real
+    git, and the real git prepends its OWN libexec — restoring the escape for
+    every grandchild.
+    """
+    farm = exec_path_dir(stub_dir)
+    return (
+        f'if [ -x "{farm}/git" ]; then\n'
+        f'  GIT_EXEC_PATH="{farm}"\n'
+        '  export GIT_EXEC_PATH\n'
+        'fi\n'
+    )
+
+
+def _injected_config_body() -> str:
+    """sh that collects every config key injected for THIS invocation.
+
+    Sets `inj` to newline-separated `key=value` records, gathered from
+    `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_<n>`/`GIT_CONFIG_VALUE_<n>` and from the
+    `-c key=value` / `--config-env=key=VAR` global options.
+
+    🔴 `man git` does NOT document the `GIT_CONFIG_COUNT` family, and this
+    binary honours it. A ledger built from the manual page was therefore
+    structurally unable to see the single largest injection vector, which is
+    why the shim asks git itself for the identity half AND parses this half
+    explicitly.
+    """
+    return (
+        'collect_env_config() {\n'
+        '  ec_n="${GIT_CONFIG_COUNT:-}"\n'
+        '  [ -n "$ec_n" ] || return 0\n'
+        # 🔴 MIRROR GIT'S OWN PARSER, THEN FAIL CLOSED ON THE REST.
+        #
+        # git reads this with `strtoumax`, which SKIPS LEADING WHITESPACE and
+        # ACCEPTS A LEADING `+`. An all-digits `case` does not, and the
+        # difference is a live bypass rather than a nit — MEASURED against the
+        # first revision of this function, where `=1` was refused and both of
+        # these were not:
+        #
+        #     GIT_CONFIG_COUNT=+1  GIT_CONFIG_KEY_0=core.hooksPath …  -> rc 0
+        #     GIT_CONFIG_COUNT=' 1' GIT_CONFIG_KEY_0=core.hooksPath … -> rc 0
+        #
+        # git honoured the injection and the hook ran inside the victim, while
+        # this scan read "not a number" and collected NOTHING — the worst
+        # possible direction, because an unparseable count silently emptied the
+        # candidate set instead of growing it.
+        #
+        # So: strip what git strips, then demand digits — and if what is left
+        # is still not a count, REFUSE. "I cannot parse this and git might"
+        # is not a reason to proceed.
+        '  while :; do\n'
+        '    case "$ec_n" in\n'
+        "      ' '*|'\t'*) ec_n=\"${ec_n#?}\" ;;\n"
+        '      *) break ;;\n'
+        '    esac\n'
+        '  done\n'
+        '  ec_n="${ec_n#+}"\n'
+        '  case "$ec_n" in\n'
+        '    ""|*[!0-9]*)\n'
+        '      allowed=0\n'
+        '      why="GIT_CONFIG_COUNT is set to something this shim cannot '
+        'parse as a count; git may still honour it, so the injected keys '
+        'cannot be checked"\n'
+        '      return 0 ;;\n'
+        '  esac\n'
+        '  ec_i=0\n'
+        # Bounded so a hostile or corrupt count cannot spin forever.
+        '  [ "$ec_n" -gt 1000 ] && ec_n=1000\n'
+        '  while [ "$ec_i" -lt "$ec_n" ]; do\n'
+        '    eval "ec_k=\\${GIT_CONFIG_KEY_$ec_i:-}"\n'
+        '    eval "ec_v=\\${GIT_CONFIG_VALUE_$ec_i:-}"\n'
+        '    if [ -n "$ec_k" ]; then\n'
+        '      inj="$inj$ec_k=$ec_v\n"\n'
+        '    fi\n'
+        '    ec_i=$((ec_i+1))\n'
+        '  done\n'
+        '}\n'
+        # Lowercase a key so the case-globs below can be written once. git
+        # config keys are case-insensitive in the section and variable parts.
+        'lc_key() { printf \'%s\' "$1" | tr \'[:upper:]\' \'[:lower:]\'; }\n'
+    )
+
+
+def _classify_injected_body() -> str:
+    """sh: `classify_injected` — walks `$inj`, refusing command keys and
+    appending path keys to `$cands`.
+
+    Sets `allowed=0` and `why` for a command-valued key with a non-empty value.
+    """
+    path_globs = "|".join(GIT_CONFIG_PATH_KEYS)
+    cmd_globs = "|".join(GIT_CONFIG_CMD_KEYS)
+    return (
+        'classify_injected() {\n'
+        '  [ -n "$inj" ] || return 0\n'
+        '  ci_old="$IFS"\n'
+        # One record per LINE. IFS is set to newline only, so a value
+        # containing spaces survives intact — the previous revision's
+        # `for line in $info` split on the default IFS and would have shredded
+        # any path with a space in it.
+        '  IFS="\n"\n'
+        '  for ci_rec in $inj; do\n'
+        '    IFS="$ci_old"\n'
+        '    [ -n "$ci_rec" ] || { IFS="\n"; continue; }\n'
+        '    ci_k="${ci_rec%%=*}"\n'
+        '    ci_v="${ci_rec#*=}"\n'
+        '    ci_lk=$(lc_key "$ci_k")\n'
+        '    case "$ci_lk" in\n'
+        f'      {cmd_globs})\n'
+        # 🔴 EMPTY IS ALLOWED — emptying one of these DISABLES the hook, which
+        # is what `task-spec-drafter/ticket-status` does on purpose.
+        '        if [ -n "$ci_v" ]; then\n'
+        '          allowed=0\n'
+        '          why="config \'$ci_k\' names a COMMAND git would execute; a '
+        'command cannot be bounded to a directory"\n'
+        '          IFS="$ci_old"\n'
+        '          return 0\n'
+        '        fi ;;\n'
+        f'      {path_globs})\n'
+        '        [ -n "$ci_v" ] && cands="$cands:$ci_v" ;;\n'
+        '    esac\n'
+        '    IFS="\n"\n'
+        '  done\n'
+        '  IFS="$ci_old"\n'
+        '}\n'
+    )
+
+
+def _exec_env_body() -> str:
+    """sh: refuse when any `GIT_EXEC_ENV` variable carries a non-empty value."""
+    checks = "".join(
+        f'  if [ -n "${{{v}:-}}" ]; then\n'
+        f'    allowed=0\n'
+        f'    why="{v} names a COMMAND git would execute; a command cannot be '
+        'bounded to a directory"\n'
+        '    return 0\n'
+        '  fi\n'
+        for v in GIT_EXEC_ENV)
+    return 'check_exec_env() {\n' + checks + '  return 0\n}\n'
 
 
 def _push_destination_body(real: str) -> str:
@@ -357,18 +634,60 @@ def _push_destination_body(real: str) -> str:
     https://, git@host:path). Empty means "not a local path", NOT "safe" — the
     caller treats an unresolvable destination as a violation, because a push
     that leaves the machine is exactly what destroyed the branch.
+
+    🔴 THE RESOLVER IS `config --get`, NOT `remote get-url`, AND THE DIFFERENCE
+    IS A LIVE BYPASS. The previous revision used `remote get-url`, whose answer
+    ignores injected config entirely. MEASURED on git 2.55.0, against a repo
+    whose `origin` is `/tmp/ORIGINAL.git`, with `remote.origin.url` injected as
+    `/tmp/INJECTED.git`:
+
+        via GIT_CONFIG_COUNT      via -c
+        remote get-url origin    /tmp/ORIGINAL.git   /tmp/ORIGINAL.git   BLIND
+        ls-remote --get-url      /tmp/ORIGINAL.git   /tmp/ORIGINAL.git   BLIND
+        config --get remote…url  /tmp/INJECTED.git   /tmp/INJECTED.git   SEES IT
+
+    `push` itself honours the injection, so the old resolver checked one URL
+    while git used another: `-c remote.origin.url=<victim> push origin
+    HEAD:refs/heads/pwned` exited 0 and created the branch in the victim. This
+    falsifies the previous revision's claim that asking git accounts for the
+    `GIT_CONFIG_*` family — it depends entirely on WHICH command is asked.
+
+    🔴 AND THE INJECTED VALUE IS READ OFF THE ARGV, NOT OUT OF A CHILD. The
+    sharper fact above — that `config --get` sees the injection — is TRUE BUT
+    INSUFFICIENT: a fresh child process does not carry the caller's `-c` at
+    all, so forwarding it is an extra thing to remember and a resolver that
+    forgets is silently blind again. `inj_get` answers from the record this
+    shim already parsed off its own command line, with no process at all. The
+    child query survives only as the fallback for the un-injected case.
+
+    `pushurl` is consulted first because git prefers it when present.
     """
     return (
+        # Last-wins, matching git: a key repeated in `-c` or in the
+        # GIT_CONFIG_COUNT array takes its final value.
+        'inj_get() {\n'
+        '  ig_k=$(lc_key "$1")\n'
+        '  ig_out=""\n'
+        '  ig_old="$IFS"\n'
+        '  IFS="\n"\n'
+        '  for ig_rec in $inj; do\n'
+        '    IFS="$ig_old"\n'
+        '    [ -n "$ig_rec" ] || { IFS="\n"; continue; }\n'
+        '    ig_rk=$(lc_key "${ig_rec%%=*}")\n'
+        '    [ "$ig_rk" = "$ig_k" ] && ig_out="${ig_rec#*=}"\n'
+        '    IFS="\n"\n'
+        '  done\n'
+        '  IFS="$ig_old"\n'
+        '  printf \'%s\' "$ig_out"\n'
+        '}\n'
         'push_dest() {\n'
         '  pv="$1"; pc="$2"; shift 2\n'
         # 🔴 SKIP TO THE VERB FIRST — the same measured bug as dual_is_read,
         # in a second place. The value of `-C` is a non-flag token, so "the
         # first non-flag argument" is the -C PATH, not the remote. Without
         # this, `git -C <path> push origin trunk` resolved its remote to the
-        # literal string "push", `remote get-url push` failed, the destination
-        # came back empty, and every legitimate fixture-to-fixture push was
-        # refused. Two sites, one misreading — found only by the positive
-        # control, since blocking is what the negative controls assert.
+        # literal string "push", and every legitimate fixture-to-fixture push
+        # was refused. Found only by the positive control.
         '  while [ "$#" -gt 0 ]; do\n'
         '    a="$1"; shift\n'
         '    case "$a" in -*) continue ;; esac\n'
@@ -382,29 +701,50 @@ def _push_destination_body(real: str) -> str:
         # No remote named: git uses the branch's configured remote, defaulting
         # to `origin`. Ask git rather than guessing.
         '  if [ -z "$rem" ]; then\n'
-        '    if [ -n "$pc" ]; then\n'
-        f'      rem=$("{real}" -C "$pc" remote 2>/dev/null | head -n 1)\n'
-        '    else\n'
-        f'      rem=$("{real}" remote 2>/dev/null | head -n 1)\n'
-        '    fi\n'
+        '    rem=$(gitq remote 2>/dev/null | head -n 1)\n'
         '  fi\n'
         '  [ -n "$rem" ] || rem=origin\n'
         '  case "$rem" in\n'
         '    */*|.|..) url="$rem" ;;\n'
         '    *)\n'
-        '      if [ -n "$pc" ]; then\n'
-        f'        url=$("{real}" -C "$pc" remote get-url "$rem" 2>/dev/null)\n'
-        '      else\n'
-        f'        url=$("{real}" remote get-url "$rem" 2>/dev/null)\n'
-        '      fi ;;\n'
+        # 🔴 THE INJECTED VALUE FIRST, ANSWERED WITHOUT A CHILD PROCESS.
+        '      url=$(inj_get "remote.$rem.pushurl")\n'
+        '      [ -n "$url" ] || url=$(inj_get "remote.$rem.url")\n'
+        '      [ -n "$url" ] || url=$(gitq config --get "remote.$rem.pushurl" '
+        '2>/dev/null)\n'
+        '      [ -n "$url" ] || url=$(gitq config --get "remote.$rem.url" '
+        '2>/dev/null)\n'
+        # Last resort only. `remote get-url` is blind to injected config, so it
+        # can never be the primary answer — but it does resolve `insteadOf`
+        # rewrites that `config --get` returns raw, and an empty destination is
+        # treated as a violation, so falling back here can only ever make the
+        # check see MORE.
+        '      [ -n "$url" ] || url=$(gitq remote get-url "$rem" 2>/dev/null)\n'
+        '      ;;\n'
         '  esac\n'
-        # An empty result means "not a LOCAL path" — never "safe". The caller
-        # treats an empty destination as a violation, because a push that
-        # leaves the machine is exactly what destroyed the branch.
         '  case "$url" in\n'
         '    ""|*://*|*@*:*) printf \'\' ;;\n'
         '    *) printf \'%s\' "$url" ;;\n'
         '  esac\n'
+        '}\n'
+    )
+
+
+def _gitq_body(real: str) -> str:
+    """sh: `gitq …` — ask the REAL git a question in the caller's own context.
+
+    🔴 THE INJECTED `-c` OPTIONS ARE FORWARDED. Without that, every question
+    the shim asks is answered from a DIFFERENT configuration than the one the
+    real call will run under, which is precisely how the push-destination
+    bypass worked. `GIT_CONFIG_*` needs no forwarding — it is inherited.
+    """
+    return (
+        'gitq() {\n'
+        '  if [ -n "$cdir" ]; then\n'
+        f'    "{real}" -C "$cdir" $cargs "$@"\n'
+        '  else\n'
+        f'    "{real}" $cargs "$@"\n'
+        '  fi\n'
         '}\n'
     )
 
@@ -428,16 +768,12 @@ def _dual_is_read_body() -> str:
         # Measured: without this, `git -C <path> remote -v` had `<path>` — the
         # VALUE of -C — as its first non-flag token, so every dual verb was
         # classified from the wrong word and five legitimate reads were
-        # refused. The positive control is what caught it; the negative
-        # controls were all still green, because misreading the sub-command
-        # errs toward "write" and blocking is what they assert.
+        # refused. The positive control is what caught it.
         '  while [ "$#" -gt 0 ]; do\n'
         '    a="$1"; shift\n'
         '    case "$a" in -*) continue ;; esac\n'
         '    [ "$a" = "$dv" ] && break\n'
         '  done\n'
-        # The first non-flag token after the verb — the sub-command for the
-        # verbs that have one.
         '  dsub=""\n'
         '  dpos=0\n'
         '  for a in "$@"; do\n'
@@ -446,9 +782,6 @@ def _dual_is_read_body() -> str:
         '    [ "$dpos" -eq 1 ] && dsub="$a"\n'
         '  done\n'
         '  case "$dv" in\n'
-        # `remote` / `remote -v` / `remote show` / `remote get-url` read.
-        # add, remove, rename, set-url, set-head, set-branches, prune, update
-        # all write, and so does anything not named here.
         '    remote)\n'
         '      case "$dsub" in\n'
         '        ""|show|get-url) return 0 ;;\n'
@@ -469,6 +802,46 @@ def _dual_is_read_body() -> str:
         '      done\n'
         '      [ "$dpos" -le 1 ] && return 0\n'
         '      return 1 ;;\n'
+        # 🔴 `hash-object` WRITES with `-w`. It sat on the READ ledger, and
+        # MEASURED against a denied victim it exited 0 while the victim's
+        # loose-object count went 6 -> 7. Everything else about it is a read.
+        '    hash-object)\n'
+        '      for a in "$@"; do\n'
+        '        case "$a" in -w|--stdin-paths) return 1 ;; esac\n'
+        '      done\n'
+        '      return 0 ;;\n'
+        # 🔴 `symbolic-ref <name>` READS; `symbolic-ref <name> <ref>` REPOINTS
+        # and `-d` deletes. Decided by COUNTING positionals rather than by
+        # matching a spelling — measured, `symbolic-ref -q HEAD
+        # refs/heads/trunk` moved a denied victim's HEAD while the verb sat on
+        # the READ ledger, and `-q` is only one of several flags that could
+        # have carried it.
+        '    symbolic-ref)\n'
+        '      for a in "$@"; do\n'
+        '        case "$a" in -d|--delete) return 1 ;; esac\n'
+        '      done\n'
+        '      [ "$dpos" -le 1 ] && return 0\n'
+        '      return 1 ;;\n'
+        # `interpret-trailers --in-place <file>` rewrites the file it is given,
+        # anywhere the caller can name it. Every other form writes to stdout.
+        '    interpret-trailers)\n'
+        '      for a in "$@"; do\n'
+        '        case "$a" in --in-place) return 1 ;; esac\n'
+        '      done\n'
+        '      return 0 ;;\n'
+        # `fsck` inspects; `--lost-found` writes `.git/lost-found` when there
+        # is anything dangling to put there. MEASURED on a clean repo: all
+        # three of `fsck`, `fsck --lost-found` and `fsck --connectivity-only`
+        # left the repo byte-identical — so the verb is a read in practice and
+        # refusing it outright was a false positive. It is DUAL rather than
+        # ledgered because "wrote nothing on a clean repo" is not the ledger's
+        # membership rule, and `--lost-found` on a repo with dangling objects
+        # does write.
+        '    fsck)\n'
+        '      for a in "$@"; do\n'
+        '        case "$a" in --lost-found) return 1 ;; esac\n'
+        '      done\n'
+        '      return 0 ;;\n'
         # `branch` reads when it LISTS: no positional, and no flag that moves,
         # copies, deletes or re-points anything.
         '    branch)\n'
@@ -512,16 +885,112 @@ def _dual_is_read_body() -> str:
         '      case "$dsub" in status|summary) return 0 ;; *) return 1 ;; esac ;;\n'
         '    stash)\n'
         '      case "$dsub" in list|show) return 0 ;; *) return 1 ;; esac ;;\n'
+        # A bare `git notes` LISTS, so the empty sub-command is a read. `stash`
+        # deliberately does NOT get the same treatment: a bare `git stash` is
+        # `stash push`, which writes.
         '    notes)\n'
-        '      case "$dsub" in list|show) return 0 ;; *) return 1 ;; esac ;;\n'
+        '      case "$dsub" in ""|list|show) return 0 ;; *) return 1 ;; esac ;;\n'
         '  esac\n'
         '  return 1\n'
         '}\n'
     )
 
 
+def _extra_destination_body() -> str:
+    """sh: `collect_extra_dests <verb> <argv…>` — append the destinations a
+    verb writes to that are NOT the repository it is run in.
+
+    🔴 EVERY ONE OF THESE WAS A MEASURED BYPASS of the previous revision,
+    because the repo the command runs in was an in-bounds fixture, so the
+    bounds check passed and `dual_is_read` was never even consulted:
+
+        git -C <fixture> config --file <victim>/.git/config core.bare true
+            -> rc 0, the victim's config was rewritten
+        git -C <fixture> config --global user.name pwned
+            -> rc 0, wrote $HOME/.gitconfig, unbounded
+        git init --separate-git-dir <victim>/stolen.git <allowed>/new
+        git clone --separate-git-dir <victim>/stolen2.git <src> <allowed>/cl
+            -> rc 0, a whole git dir created inside the victim
+        git -C <fixture> worktree add <victim>/wt
+            -> rc 0, the victim received a worktree
+        git -C <fixture> archive --output <victim>/stolen.tar HEAD
+        git -C <fixture> bundle create <victim>/stolen.bundle HEAD
+            -> rc 0, both files written inside the victim
+    """
+    return (
+        'collect_extra_dests() {\n'
+        '  xv="$1"; shift\n'
+        '  xwant=""\n'
+        '  xseen=0\n'
+        '  xsub=""\n'
+        '  xnpos=0\n'
+        '  for a in "$@"; do\n'
+        '    if [ -n "$xwant" ]; then\n'
+        '      cands="$cands:$a"\n'
+        '      xwant=""\n'
+        '      continue\n'
+        '    fi\n'
+        '    if [ "$xseen" -eq 0 ]; then\n'
+        '      [ "$a" = "$xv" ] && xseen=1\n'
+        '      continue\n'
+        '    fi\n'
+        # `--separate-git-dir` applies to init and clone and is the only one
+        # that can appear before the verb-specific handling below.
+        '    case "$a" in\n'
+        '      --separate-git-dir) xwant=1; continue ;;\n'
+        '      --separate-git-dir=*) cands="$cands:${a#--separate-git-dir=}"; '
+        'continue ;;\n'
+        '    esac\n'
+        '    case "$xv" in\n'
+        '      config)\n'
+        '        case "$a" in\n'
+        '          -f|--file) xwant=1; continue ;;\n'
+        '          --file=*) cands="$cands:${a#--file=}"; continue ;;\n'
+        # `--global` and `--system` name no path at all, so the destination has
+        # to be reconstructed the way git does it. Both are added; a path that
+        # does not exist canonicalises to itself and is checked all the same.
+        '          --global)\n'
+        '            if [ -n "${GIT_CONFIG_GLOBAL:-}" ]; then\n'
+        '              cands="$cands:$GIT_CONFIG_GLOBAL"\n'
+        '            else\n'
+        '              cands="$cands:${XDG_CONFIG_HOME:-$HOME/.config}/git/'
+        'config:$HOME/.gitconfig"\n'
+        '            fi\n'
+        '            continue ;;\n'
+        '          --system)\n'
+        '            if [ -n "${GIT_CONFIG_SYSTEM:-}" ]; then\n'
+        '              cands="$cands:$GIT_CONFIG_SYSTEM"\n'
+        '            else\n'
+        '              cands="$cands:/etc/gitconfig"\n'
+        '            fi\n'
+        '            continue ;;\n'
+        '        esac ;;\n'
+        '      archive|format-patch)\n'
+        '        case "$a" in\n'
+        '          -o|--output|--output-directory) xwant=1; continue ;;\n'
+        '          --output=*) cands="$cands:${a#--output=}"; continue ;;\n'
+        '          --output-directory=*) '
+        'cands="$cands:${a#--output-directory=}"; continue ;;\n'
+        '        esac ;;\n'
+        '    esac\n'
+        '    case "$a" in -*) continue ;; esac\n'
+        '    xnpos=$((xnpos+1))\n'
+        '    if [ "$xnpos" -eq 1 ]; then xsub="$a"; continue; fi\n'
+        # The FIRST positional after the sub-command is the destination for
+        # `bundle create <file>` and `worktree add|move <path>`.
+        '    if [ "$xnpos" -eq 2 ]; then\n'
+        '      case "$xv/$xsub" in\n'
+        '        bundle/create|worktree/add|worktree/move|worktree/repair)\n'
+        '          cands="$cands:$a" ;;\n'
+        '      esac\n'
+        '    fi\n'
+        '  done\n'
+        '}\n'
+    )
+
+
 def _bounds_helpers_body() -> str:
-    """POSIX-sh: `canon_of <path>` and `out_of_bounds <path>`.
+    """POSIX-sh: `canon_of <path>` and `bounds_verdict <path>`.
 
     Split out of the main body because the target is no longer a single path.
     With `GIT_DIR` in play a write has SEVERAL destinations — the git dir, the
@@ -535,14 +1004,49 @@ def _bounds_helpers_body() -> str:
         # there yet, and `GIT_INDEX_FILE` names a file. A path that cannot be
         # canonicalised at all is returned unchanged rather than dropped —
         # dropping it would silently remove a candidate from the check.
+        # 🔴 RELATIVE OPERANDS RESOLVE AGAINST `cwdbase` — the directory git
+        # will actually be in (`-C`, else `$PWD`) — NOT against `base`.
+        #
+        # `base` is REASSIGNED for `init`/`clone` to the path they will create,
+        # so anchoring here would resolve `--separate-git-dir=../victim/x`
+        # against the new repo instead of against the cwd, and land the check
+        # one directory away from where the bytes go. An absolute-only matcher
+        # is worse still: `config --file ../victim/.git/config` and `worktree
+        # add ../victim/wt` are the same capability as their absolute twins and
+        # must not be a different code path.
         'canon_of() {\n'
         '  cp_="$1"\n'
-        '  case "$cp_" in /*) ;; *) cp_="$base/$cp_" ;; esac\n'
+        '  case "$cp_" in /*) ;; *) cp_="$cwdbase/$cp_" ;; esac\n'
         '  cd_=$(cd "$cp_" 2>/dev/null && pwd -P) && { printf \'%s\' "$cd_"; '
         'return 0; }\n'
         '  cpar_=$(dirname "$cp_"); cbas_=$(basename "$cp_")\n'
         '  cd_=$(cd "$cpar_" 2>/dev/null && pwd -P) && { printf \'%s/%s\' '
         '"$cd_" "$cbas_"; return 0; }\n'
+        # 🔴 NOTHING IN THE PATH RESOLVES. Returning it RAW is only safe while
+        # it contains no `..` — a lexical prefix match on a path with `..` in
+        # it reports the wrong directory, and reports it as INNOCENT.
+        #
+        # MEASURED, and found in this file rather than by an auditor:
+        #
+        #     git init -q  <allowed>/does-not-exist/deeper/../../../victim/planted
+        #     -> rc 0, and `<victim>/planted` was created.
+        #
+        # `does-not-exist` makes both `cd`s fail, so the raw string came back,
+        # and the raw string starts with `<allowed>/` — so it matched an
+        # allowed root while `realpath` puts it inside the victim. `clone` did
+        # the same. This is the `git diff --quiet` shape from claude/RULES.md:
+        # a comparison against an operand that is not there reports SAME, not
+        # MISSING. An unresolvable path is protected-UNKNOWN, never
+        # protected-NO.
+        #
+        # A path with no `..` is still returned raw, deliberately: `git init
+        # a/b/c` creates its intermediate directories, so the third fallback is
+        # the NORMAL case for it, and nothing after the last existing prefix
+        # can be a symlink. Only `..` can walk out.
+        '  case "$cp_" in\n'
+        '    */../*|*/..) printf \'//DEVRC-NOGIT-UNRESOLVABLE%s\' "$cp_" '
+        '; return 0 ;;\n'
+        '  esac\n'
         '  printf \'%s\' "$cp_"\n'
         '}\n'
         # 🔴 PRINTS A VERDICT, IT DOES NOT RETURN ONE — and the caller demands
@@ -553,15 +1057,9 @@ def _bounds_helpers_body() -> str:
         # `command not found` returning 127, "non-zero" read as "in bounds",
         # and the shim let a write through with rc=0. Every negative control
         # would have gone green against a guard that had ceased to exist.
-        #
-        # With a printed verdict, a helper that is missing, crashes, or is
-        # killed produces empty output, which is not "ok", so the call is
-        # refused. The failure direction is a property of the shape rather than
-        # of remembering to check.
         'bounds_verdict() {\n'
         '  ob_="$1"\n'
         '  ob_ok_=0\n'
-        # A sink that discards writes is safe wherever it lives.
         '  case "$ob_" in\n'
         f'    {"|".join(ALWAYS_SAFE_PATHS)}) printf \'ok\'; return ;;\n'
         '  esac\n'
@@ -583,70 +1081,89 @@ def _bounds_helpers_body() -> str:
     )
 
 
+# --------------------------------------------------------------------------- #
+# the shim body
+# --------------------------------------------------------------------------- #
 def git_body(real: str, log: Path, allowed_roots: str = "",
-             denied_roots: str = "") -> str:
+             denied_roots: str = "", stub_dir: Path | str = "",
+             mode: str = MODE_BLOCK) -> str:
     """The POSIX-sh body of the `git` shim. No shebang — write_exec owns it.
 
     The parse mirrors git's own: skip leading global options, take the FIRST
-    non-flag token as the verb, and decide on that. `-C <dir>`, `--git-dir=`
-    and `--work-tree=` are captured while skipping, because they are what move
-    the target away from the process's cwd — and a bare `git` with neither is
-    the first-class suspect, since it silently targets whatever directory the
-    caller happens to be in.
+    non-flag token as the verb, and decide on that. `-C <dir>`, `--git-dir=`,
+    `--work-tree=` and `-c key=value` are captured while skipping, because they
+    are what move the target away from the process's cwd.
 
-    🔴 THE TARGET IS RESOLVED, NOT ASSUMED. `rev-parse --show-toplevel` is
-    asked (via the REAL binary, by absolute path, so this cannot recurse), and
-    the answer is canonicalised with `pwd -P`. Comparing the raw `-C` string
-    against the allowed roots would be walkable by `-C /tmp/x/../../home/zach/
-    workspace/devrc`, and by a symlinked tmpdir — both of which resolve to a
-    real repo while spelling something that passes a prefix match.
+    🔴 THE TARGET IS RESOLVED, NOT ASSUMED. `rev-parse` is asked (via the REAL
+    binary, by absolute path, so this cannot recurse), and the answer is
+    canonicalised with `pwd -P`. Comparing the raw `-C` string against the
+    allowed roots would be walkable by `-C /tmp/x/../../home/zach/workspace/
+    devrc`, and by a symlinked tmpdir.
+
+    🔴 `mode` IS A BAKE-TIME ARGUMENT. It used to be read from the
+    environment, where `DEVRC_TEST_GIT_MODE=audit` silently disarmed the whole
+    policy — measured, rc 0, victim commit. Nothing an inherited environment
+    carries can change it now.
     """
-    verbs = "|".join(GIT_READ_VERBS)
+    verbs = "|".join(v for v in GIT_READ_VERBS
+                     if v not in GIT_LOCK_FREE_READ_VERBS)
+    lockfree = "|".join(GIT_LOCK_FREE_READ_VERBS)
     flags = "|".join(GIT_READ_FLAGS)
     remote_write = "|".join(GIT_REMOTE_WRITE_VERBS)
+    audit = "1" if mode == MODE_AUDIT else "0"
     return (
+        _exec_path_export(Path(stub_dir)) +
         _bounds_helpers_body() +
         _dual_is_read_body() +
+        _injected_config_body() +
+        _classify_injected_body() +
+        _exec_env_body() +
+        _extra_destination_body() +
+        _gitq_body(real) +
         _push_destination_body(real) +
+        _refuse_body(real) +
         f'log="{log}"\n'
         f'real="{real}"\n'
-        f'mode="${{{MODE_ENV}:-{MODE_BLOCK}}}"\n'
+        f'audit={audit}\n'
         # 🔴 THE ROOTS ARE BAKED IN AT INSTALL TIME; THE ENV ONLY WIDENS THEM.
         #
-        # Reading the policy purely from the environment made it depend on
-        # those variables surviving into every descendant — and they do not.
         # MEASURED on the full suite: three tests build a REPLACING `env=`
-        # dict (`{HOME, GIT_CONFIG_GLOBAL, GIT_CONFIG_SYSTEM, PATH}`) for a
-        # perfectly hermetic `git init` in their own tmp_path. `PATH` still
-        # reaches the shim, so the shim ran — with no roots at all, and
-        # refused a legitimate fixture. Fail-closed was the right DIRECTION
-        # and still the wrong ANSWER: the guard would have gone red on every
-        # future env-replacing test, and a permanently-red gate gets switched
-        # off.
-        #
-        # So the installed defaults are the FLOOR and the variables are an
-        # override for a test that needs to widen its own roots.
+        # dict for a perfectly hermetic `git init` in their own tmp_path.
+        # `PATH` still reaches the shim, so the shim ran — with no roots at
+        # all, and refused a legitimate fixture. Fail-closed was the right
+        # DIRECTION and still the wrong ANSWER.
         f'roots="${{{ROOTS_ENV}:-{allowed_roots}}}"\n'
         # 🔴 DENY IS A UNION, NOT AN OVERRIDE — asymmetric on purpose. A test
         # may widen what it is allowed to write; nothing may un-deny the tree
         # under test, including an empty or absent variable.
         f'denied="{denied_roots}${{{DENY_ROOTS_ENV}:+:${{{DENY_ROOTS_ENV}}}}}"\n'
         '\n'
-        # ---- position-independent read flags: answer and exit ----
-        'for a in "$@"; do\n'
-        '  case "$a" in\n'
-        f'    {flags})\n'
-        '      printf \'git(read-flag) %s\\n\' "$*" >> "$log"\n'
-        '      exec "$real" "$@" ;;\n'
-        '  esac\n'
-        'done\n'
+        # ---- the handshake: answered before anything else ----
+        # 🔴 It must NOT be forwardable to the real binary, or a plain `git`
+        # would answer it with an error and a caller could misread the failure.
+        # 🔴 THE BAKED LITERALS, NOT `$roots` / `$denied`. Those two carry the
+        # ENV override, so a handshake reading them would report whatever the
+        # asking process happens to export — which tells the caller nothing
+        # about the shim. `_inherited_stub_dir()` needs the shim's OWN floor:
+        # deny is `baked ∪ env`, so a baked floor containing the tree under
+        # test is a property no environment can take away.
+        'if [ "${1:-}" = "' + HANDSHAKE_FLAG + '" ]; then\n'
+        f'  printf \'{HANDSHAKE_MAGIC} %s\\n\' "{policy_fingerprint()}"\n'
+        f'  printf \'roots=%s\\n\' \'{allowed_roots}\'\n'
+        f'  printf \'denied=%s\\n\' \'{denied_roots}\'\n'
+        f'  printf \'audit=%s\\n\' "{audit}"\n'
+        '  exit 0\n'
+        'fi\n'
         '\n'
-        # ---- parse leading global options for the target, then the verb ----
+        # ---- parse leading global options: the target, the verb, and -c ----
         'cdir=""\n'
         'gdir=""\n'
         'wtree=""\n'
         'verb=""\n'
         'want=""\n'
+        'inj=""\n'
+        'cargs=""\n'
+        'nglobal=0\n'
         'for a in "$@"; do\n'
         '  if [ -n "$want" ]; then\n'
         '    case "$want" in\n'
@@ -654,8 +1171,19 @@ def git_body(real: str, log: Path, allowed_roots: str = "",
         '*) cdir="$cdir/$a" ;; esac; else cdir="$a"; fi ;;\n'
         '      gitdir) gdir="$a" ;;\n'
         '      worktree) wtree="$a" ;;\n'
+        # 🔴 `-c key=value` is config injection and is collected, not skipped.
+        # The previous revision spelled this `-c) want=skip`, which is how
+        # `-c core.hooksPath=<victim>/hooks` and `-c remote.origin.url=<victim>`
+        # both reached the real binary unexamined.
+        '      cfg) inj="$inj$a\n"; cargs="$cargs -c $a" ;;\n'
         '    esac\n'
         '    want=""\n'
+        # 🔴 COUNTS ARGV ENTRIES, NOT OPTIONS. An option's VALUE is an argv
+        # entry too, and counting only the options made `nglobal` smaller than
+        # the number of tokens before the verb — so the read-flag scan below
+        # stopped early and `git -c k=v --version` was classified as a write.
+        # Fail-closed, but a false positive on a command that prints and exits.
+        '    nglobal=$((nglobal+1))\n'
         '    continue\n'
         '  fi\n'
         '  case "$a" in\n'
@@ -664,27 +1192,84 @@ def git_body(real: str, log: Path, allowed_roots: str = "",
         '    --work-tree) want=worktree ;;\n'
         '    --git-dir=*) gdir="${a#--git-dir=}" ;;\n'
         '    --work-tree=*) wtree="${a#--work-tree=}" ;;\n'
-        '    -c) want=skip ;;\n'
+        '    -c) want=cfg ;;\n'
+        # `--config-env=key=VAR` takes its VALUE from the named variable.
+        '    --config-env=*)\n'
+        '      ce="${a#--config-env=}"\n'
+        '      cek="${ce%%=*}"; cev="${ce#*=}"\n'
+        '      eval "cevv=\\${$cev:-}"\n'
+        '      inj="$inj$cek=$cevv\n"\n'
+        '      cargs="$cargs $a" ;;\n'
         '    -*) ;;\n'
         '    *) verb="$a"; break ;;\n'
         '  esac\n'
+        '  nglobal=$((nglobal+1))\n'
         'done\n'
+        '\n'
+        # ---- position-independent read flags, BEFORE the verb only ----
+        # See GIT_READ_FLAGS for the `commit -m -h` measurement that forced the
+        # scan to stop at the verb.
+        'gi=0\n'
+        'for a in "$@"; do\n'
+        '  [ "$gi" -ge "$nglobal" ] && break\n'
+        '  gi=$((gi+1))\n'
+        '  case "$a" in\n'
+        f'    {flags})\n'
+        '      printf \'git(read-flag) %s\\n\' "$*" >> "$log"\n'
+        '      exec "$real" "$@" ;;\n'
+        '  esac\n'
+        'done\n'
+        '\n'
+        # ---- `<verb> -h` / `<verb> --help` as the SINGLE remaining token ----
+        # This is the form that prints usage and exits without touching a repo.
+        # Requiring it to be the last and only token is what keeps `commit -m -h`
+        # out: there, `-h` is the VALUE of `-m`.
+        'if [ "$#" -ge 2 ]; then\n'
+        '  eval "lastarg=\\${$#}"\n'
+        '  eval "prevarg=\\${$(($#-1))}"\n'
+        '  case "$lastarg" in\n'
+        '    -h|--help)\n'
+        '      if [ "$prevarg" = "$verb" ]; then\n'
+        '        printf \'git(read-help) %s\\n\' "$*" >> "$log"\n'
+        '        exec "$real" "$@"\n'
+        '      fi ;;\n'
+        '  esac\n'
+        'fi\n'
         '\n'
         # ---- no verb at all: `git` (or only flags) prints usage and exits ----
         # It writes nothing, so refusing it would be a false positive — and a
         # confusing one, since `git` alone answering "VIOLATION" reads as the
-        # guard being broken. Stated rather than left implicit, because
-        # `nolaunch`'s systemctl stub takes the OPPOSITE choice for a bare
-        # invocation and the difference is deliberate: a bare `systemctl` LISTS
-        # UNITS (an answer that would have to be fabricated), while a bare
-        # `git` only prints its own usage.
+        # guard being broken.
         'if [ -z "$verb" ]; then\n'
         '  printf \'git(no-verb) %s\\n\' "$*" >> "$log"\n'
         '  exec "$real" "$@"\n'
         'fi\n'
         '\n'
+        'allowed=1\n'
+        'why=""\n'
+        'cands=""\n'
+        '\n'
+        # ---- config/env INJECTION, checked before the read fast path ----
+        # 🔴 BEFORE the read path on purpose. `core.fsmonitor` and
+        # `GIT_EXTERNAL_DIFF` both fire during `status` and `diff`, which are
+        # reads — so a check placed after the read dispatch would never see the
+        # measured GIT_EXTERNAL_DIFF execution at all.
+        'collect_env_config\n'
+        'check_exec_env\n'
+        '[ "$allowed" -eq 1 ] && classify_injected\n'
+        'if [ "$allowed" -eq 0 ]; then\n'
+        '  canon="(config injection)"\n'
+        '  refuse "$@"\n'
+        'fi\n'
+        '\n'
         # ---- READ verbs exec the real binary, wherever they point ----
         'case "$verb" in\n'
+        f'  {lockfree})\n'
+        # 🔴 `--no-optional-locks` PREPENDED. `status` rewrites the target's
+        # `.git/index`; measured, the victim's index hash moved. With the flag
+        # the index is byte-identical and stdout is unchanged.
+        '    printf \'git(read-nolock) %s\\n\' "$*" >> "$log"\n'
+        '    exec "$real" --no-optional-locks "$@" ;;\n'
         f'  {verbs})\n'
         '    printf \'git(read) %s\\n\' "$*" >> "$log"\n'
         '    exec "$real" "$@" ;;\n'
@@ -693,14 +1278,17 @@ def git_body(real: str, log: Path, allowed_roots: str = "",
         # ---- resolve the EFFECTIVE target repo ----
         'base="$cdir"\n'
         '[ -n "$base" ] || base="$PWD"\n'
+        # The directory git will run in. `base` is about to be reassigned for
+        # init/clone; this one is not, and it is what every relative operand
+        # resolves against. See `canon_of`.
+        'cwdbase="$base"\n'
+        'case "$cwdbase" in /*) ;; *) cwdbase="$PWD/$cwdbase" ;; esac\n'
         'pathverb=0\n'
         '\n'
         # `init` / `clone` are handed the path they will CREATE. Using the cwd
         # for these refuses every fixture that builds itself a clone from a
         # suite whose cwd is the repo — measured, and the reason this block
-        # exists. Skip the verb, skip options and their values, and take the
-        # positional: the 1st for `init`, the 2nd for `clone` (the 1st being
-        # the SOURCE, which is only read).
+        # exists.
         'case "$verb" in\n'
         f'  {"|".join(GIT_TARGET_IS_ARG_VERBS)})\n'
         '    if [ "$verb" = "clone" ]; then\n'
@@ -734,9 +1322,7 @@ def git_body(real: str, log: Path, allowed_roots: str = "",
         '      if [ "$npos" -eq "$wantpos" ]; then tgt="$a"; break; fi\n'
         '    done\n'
         # `git clone <src>` with no destination writes to <cwd>/<basename src>;
-        # `git init` with no path writes to the cwd. Both are resolved rather
-        # than waved through — a clone with no destination, run from the repo,
-        # lands IN the repo.
+        # `git init` with no path writes to the cwd.
         '    if [ -z "$tgt" ] && [ "$verb" = "clone" ] && [ -n "$src" ]; then\n'
         '      tgt="${src%/}"\n'
         '      tgt="${tgt##*/}"\n'
@@ -751,14 +1337,8 @@ def git_body(real: str, log: Path, allowed_roots: str = "",
         '    pathverb=1\n'
         '    ;;\n'
         'esac\n'
-        'gitargs=""\n'
-        '[ -n "$cdir" ] && gitargs="-C $cdir"\n'
         'top=""\n'
         'if [ "$pathverb" -eq 1 ]; then\n'
-        # `base` already IS the path init/clone will create. Asking rev-parse
-        # would answer about an ENCLOSING repo instead — for `git init
-        # /tmp/fix` run from the repo, that is the repo, which is precisely the
-        # false positive this branch exists to remove.
         '  top="$base"\n'
         'elif [ -n "$wtree" ]; then\n'
         '  top="$wtree"\n'
@@ -768,56 +1348,68 @@ def git_body(real: str, log: Path, allowed_roots: str = "",
         '  top=$("$real" -C "$base" rev-parse --show-toplevel 2>/dev/null) '
         '|| top=""\n'
         'fi\n'
-        # No toplevel: `git init` / `git clone` into a not-yet-repo. The
-        # directory the write would CREATE is the thing to bound, so fall back
-        # to the base path rather than passing it unchecked.
         '[ -n "$top" ] || top="$base"\n'
         'canon=$(canon_of "$top")\n'
         '\n'
         # ---- gather EVERY place this write could land ----
-        # 🔴 Not one path. `GIT_DIR` sends refs and objects somewhere the
-        # worktree path does not mention, so the check is over a SET.
-        # The list is COLON-separated, which is git's own convention for these
-        # variables (`GIT_ALTERNATE_OBJECT_DIRECTORIES` already is one), so a
-        # single split handles both. A path containing a literal colon cannot
-        # be expressed in those variables by git either, so nothing is lost.
-        'cands="$canon"\n'
+        'cands="$canon$cands"\n'
         'if [ "$pathverb" -eq 0 ]; then\n'
-        # 🔴 ASK GIT, DO NOT INFER — this is the IDENTITY half.
-        # These are answered in the SAME cwd and environment the real call will
-        # use, so they already account for GIT_DIR, GIT_COMMON_DIR,
-        # GIT_CONFIG_* injection, core.worktree, discovery and any redirection
-        # vector this file has not enumerated — including the GIT_CONFIG_COUNT
-        # family, which `man git` does not document but this binary honours.
-        # `--git-common-dir` is asked separately from `--git-dir` because a
-        # LINKED worktree has its own git dir and a SHARED common dir, and a
-        # write can land in either.
-        '  info=$("$real" -C "$base" rev-parse --path-format=absolute '
+        # 🔴 ASK GIT, DO NOT INFER — this is the IDENTITY half. Answered in the
+        # SAME cwd and environment (and, via `gitq`, with the SAME injected
+        # `-c` options) the real call will use.
+        '  info=$(gitq rev-parse --path-format=absolute '
         '--git-dir --git-common-dir --git-path objects 2>/dev/null) || info=""\n'
+        # 🔴 A LINE-WISE read, not `for line in $info`. The previous revision
+        # word-split on the default IFS while every other list here is
+        # colon-split, so a repository path containing a space produced two
+        # bogus candidates and lost the real one.
+        '  oifs2="$IFS"\n'
+        '  IFS="\n"\n'
         '  for line in $info; do\n'
         '    [ -n "$line" ] && cands="$cands:$line"\n'
         '  done\n'
+        '  IFS="$oifs2"\n'
         'fi\n'
-        # 🔴 THE ENVIRONMENT, EXPLICITLY — this is the BYTE-REDIRECTION half,
-        # and it is NOT redundant with the identity half above.
-        #
-        # `GIT_WORK_TREE=<victim> git -C <innocent fixture> checkout -f HEAD`
-        # leaves identity completely truthful — the resolved repo IS the
-        # fixture — while the FILES land in the victim's working tree. An
-        # identity-based check passes it and the bytes are still written. The
-        # same holds for GIT_INDEX_FILE, GIT_OBJECT_DIRECTORY, the alternates,
-        # and the GIT_CONFIG_GLOBAL/SYSTEM pair. Neither half covers the other.
+        # 🔴 BOTH `--git-dir` AND `--work-tree`, ALWAYS — not whichever one
+        # `top` happened to take. The `top` chain picks work-tree over git-dir,
+        # so `--git-dir=<victim>/.git --work-tree=<allowed>` would have been
+        # judged entirely on the allowed half. They are two destinations, and
+        # the check is over a SET; the same matcher that bounds the env twins
+        # bounds these.
+        '[ -n "$gdir" ] && cands="$cands:$gdir"\n'
+        '[ -n "$wtree" ] && cands="$cands:$wtree"\n'
+        # ---- destinations that are not the repo the command runs in ----
+        'collect_extra_dests "$verb" "$@"\n'
+        # 🔴 THE ENVIRONMENT, EXPLICITLY — the BYTE-REDIRECTION half, and NOT
+        # redundant with the identity half above. `GIT_WORK_TREE=<victim>
+        # git -C <innocent fixture> checkout -f HEAD` leaves identity
+        # completely truthful while the FILES land in the victim's tree.
         + "".join(
             f'[ -n "${{{v}:-}}" ] && cands="$cands:${{{v}}}"\n'
             for v in GIT_LOCATION_ENV) +
         '\n'
         # ---- EVERY candidate must be in bounds ----
-        'allowed=1\n'
-        'why=""\n'
+        # 🔴 DEDUPED. `canon_of` and `bounds_verdict` each cost a subshell
+        # fork, and the candidate set repeats heavily: `--git-dir` and
+        # `--git-common-dir` are the SAME path for every non-linked worktree,
+        # and the resolved toplevel is usually its parent. Skipping a repeat
+        # cannot change the verdict — the check is a conjunction over the set.
+        #
+        # ⚠ THE TWO `rev-parse` CALLS ARE **NOT** MERGEABLE, and that was
+        # measured rather than assumed. `rev-parse --path-format=absolute
+        # --show-toplevel --git-dir --git-common-dir --git-path objects`
+        # returns them all in one process — but in a BARE repo, and under
+        # `GIT_DIR=<a bare repo>`, `--show-toplevel` makes the whole call exit
+        # 128 with "this operation must be run in a work tree", so the shim
+        # would lose EVERY candidate in exactly the redirection shape it exists
+        # to catch. Two calls it is.
         'oldifs="$IFS"\n'
         'IFS=":"\n'
+        'seencands=":"\n'
         'for c in $cands; do\n'
         '  [ -n "$c" ] || continue\n'
+        '  case "$seencands" in *":$c:"*) continue ;; esac\n'
+        '  seencands="$seencands$c:"\n'
         '  cc=$(canon_of "$c")\n'
         # Demand the literal "ok". Anything else — "bad", empty output from a
         # helper that failed, a killed subshell — refuses the call.
@@ -838,12 +1430,6 @@ def git_body(real: str, log: Path, allowed_roots: str = "",
         '      why="push destination is not a local path (it leaves this '
         'machine)"\n'
         '    else\n'
-        # The destination gets the SAME check as every other candidate — one
-        # helper, so the deny-wins ordering and the fail-closed verdict cannot
-        # drift between the two call sites. A push FROM a legitimate fixture
-        # clone INTO the real repo is the exact shape the contained clone was
-        # built to prevent: its `origin` pointed at the operator\'s working
-        # clone.
         '      dcanon=$(canon_of "$dest")\n'
         '      if [ "$(bounds_verdict "$dcanon")" != "ok" ]; then\n'
         '        allowed=0\n'
@@ -860,9 +1446,13 @@ def git_body(real: str, log: Path, allowed_roots: str = "",
         # The target is out of bounds. A DUAL verb may still be in its READING
         # form — `git remote -v`, `git config --get …`, `git branch -a
         # --format=…`, `git worktree list` — all of which this suite runs
-        # against the real repo deliberately. Refusing those makes the policy
-        # permanently red; consulting the classifier only HERE means it can
-        # never rescue an actual write.
+        # against the real repo deliberately. Consulting the classifier only
+        # HERE means it can never rescue an actual write.
+        #
+        # 🔴 It may NOT rescue a call refused for config injection, which is
+        # why that path calls `refuse` directly above rather than falling
+        # through: `git -c alias.x=<cmd> config --get foo` is a "read form"
+        # whose alias would still have executed.
         'case "$verb" in\n'
         f'  {"|".join(GIT_DUAL_VERBS)})\n'
         '    if dual_is_read "$verb" "$@"; then\n'
@@ -870,40 +1460,148 @@ def git_body(real: str, log: Path, allowed_roots: str = "",
         '      exec "$real" "$@"\n'
         '    fi ;;\n'
         'esac\n'
-        '\n'
-        f'printf \'git(blocked) %s :: %s\\n\' "$canon" "$*" >> "$log"\n'
-        f'if [ "$mode" = "{MODE_AUDIT}" ]; then\n'
-        '  exec "$real" "$@"\n'
-        'fi\n'
-        f'printf \'%s\\n\' "{BANNER}" >&2\n'
-        'printf \'  a test tried to run a git WRITE against a repo it does '
-        'not own.\\n\' >&2\n'
-        'printf \'  verb:    %s\\n\' "$verb" >&2\n'
-        'printf \'  target:  %s\\n\' "$canon" >&2\n'
-        'printf \'  reason:  %s\\n\' "$why" >&2\n'
-        'printf \'  argv:    git %s\\n\' "$*" >&2\n'
-        'printf \'  cwd:     %s\\n\' "$PWD" >&2\n'
-        'printf \'  allowed: %s\\n\' "$roots" >&2\n'
-        'printf \'  This is scripts/testlib/nogit.py. The suite once drove '
-        'commit/branch -m/\\n\' >&2\n'
-        'printf \'  push against the operator\\047s real clone and destroyed '
-        'main on the\\n\' >&2\n'
-        'printf \'  remote. Point this call at your own tmp_path, or widen '
-        '%s.\\n\' "'
-        + ROOTS_ENV + '" >&2\n'
-        f'exit {BLOCK_EXIT}\n'
+        'refuse "$@"\n'
     )
 
 
+def _refuse_body(real: str) -> str:
+    """sh: `refuse <argv…>` — the loud, distinctive, fail-closed exit.
+
+    🔴 TAKES THE ARGV RATHER THAN READING A GLOBAL. In audit mode it must
+    re-exec the ORIGINAL command, and a function called with no arguments has
+    an empty `$@` — it would have exec'd a bare `git`, silently turning every
+    audited violation into a usage message and making an audit run's log a
+    record of commands that never ran.
+    """
+    return (
+        'refuse() {\n'
+        '  printf \'git(blocked) %s :: %s\\n\' "$canon" "$*" >> "$log"\n'
+        '  if [ "$audit" -eq 1 ]; then\n'
+        f'    exec "{real}" "$@"\n'
+        '  fi\n'
+        f'  printf \'%s\\n\' "{BANNER}" >&2\n'
+        '  printf \'  a test tried to run a git WRITE against a repo it does '
+        'not own.\\n\' >&2\n'
+        '  printf \'  verb:    %s\\n\' "$verb" >&2\n'
+        '  printf \'  target:  %s\\n\' "$canon" >&2\n'
+        '  printf \'  reason:  %s\\n\' "$why" >&2\n'
+        '  printf \'  argv:    git %s\\n\' "$*" >&2\n'
+        '  printf \'  cwd:     %s\\n\' "$PWD" >&2\n'
+        '  printf \'  allowed: %s\\n\' "$roots" >&2\n'
+        '  printf \'  This is scripts/testlib/nogit.py. The suite once drove '
+        'commit/branch -m/\\n\' >&2\n'
+        '  printf \'  push against the operator\\047s real clone and destroyed '
+        'main on the\\n\' >&2\n'
+        '  printf \'  remote. Point this call at your own tmp_path, or widen '
+        f'{ROOTS_ENV}.\\n\' >&2\n'
+        f'  exit {BLOCK_EXIT}\n'
+        '}\n'
+    )
+
+
+def policy_fingerprint() -> str:
+    """A hash of THIS policy's shim, with every install-specific value blanked.
+
+    🔴 The handshake token. It is what makes `_inherited_stub_dir()` a content
+    check rather than a filename check: any shim generated by this module
+    answers with the same value, a shim generated by an OLDER revision answers
+    with a different one, and a foreign `git` answers with nothing at all.
+
+    Computed over the body with the real-binary path, log path, roots and stub
+    dir replaced by placeholders, so two installs of the same policy agree
+    while a change to the policy's LOGIC does not.
+    """
+    body = _skeleton_body()
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()[:16]
+
+
+def _skeleton_body() -> str:
+    """The shim body with every install-specific value replaced by a marker.
+
+    Kept separate from `git_body` so `policy_fingerprint()` cannot recurse into
+    it — `git_body` embeds the fingerprint, so hashing `git_body`'s own output
+    would be self-referential.
+    """
+    parts = [
+        _bounds_helpers_body(),
+        _dual_is_read_body(),
+        _injected_config_body(),
+        _classify_injected_body(),
+        _exec_env_body(),
+        _extra_destination_body(),
+        _push_destination_body("|REAL|"),
+        _gitq_body("|REAL|"),
+        _refuse_body("|REAL|"),
+        repr(GIT_READ_VERBS), repr(GIT_LOCK_FREE_READ_VERBS),
+        repr(GIT_READ_FLAGS), repr(GIT_DUAL_VERBS), repr(GIT_LOCATION_ENV),
+        repr(GIT_EXEC_ENV), repr(GIT_REMOTE_WRITE_VERBS),
+        repr(GIT_TARGET_IS_ARG_VERBS), repr(ALWAYS_SAFE_PATHS),
+        str(BLOCK_EXIT), BANNER, HANDSHAKE_MAGIC,
+    ]
+    return "\n".join(parts)
+
+
+def exec_path_farm(stub_dir: Path, real_git: str) -> Path | None:
+    """Build the `GIT_EXEC_PATH` directory: every real helper, plus THE SHIM.
+
+    🔴 THIS IS WHAT CLOSES THE PATH ESCAPE, and the escape was real. MEASURED:
+
+        $ git -c 'alias.p=!echo PATH[0]=$(echo $PATH|cut -d: -f1)' p
+        PATH[0]=/nix/store/…-git-2.55.0/libexec/git-core
+
+    git prepends its exec-path to `PATH` for every child it spawns, and that
+    directory ships a real `git`. So "first on PATH" was never true for a
+    grandchild of git itself, and `git -C <fixture> -c 'alias.x=!git -C
+    <victim> commit …' x` wrote the victim a commit with the shim installed.
+
+    Pointing `GIT_EXEC_PATH` at a farm makes git prepend THIS directory
+    instead. Measured through the farm: PATH[0] inside an alias is the farm,
+    and `git` there is the shim. The ~184 helpers are symlinked so git still
+    finds `git-remote-https`, `git-sh-setup` and the rest.
+
+    Returns None when the exec path cannot be read — the caller then leaves
+    `GIT_EXEC_PATH` alone rather than pointing git at an incomplete farm, which
+    would break git outright instead of guarding it.
+    """
+    import subprocess
+    try:
+        out = subprocess.run([real_git, "--exec-path"], capture_output=True,
+                             text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):  # pragma: no cover
+        return None
+    src = out.stdout.strip()
+    if out.returncode != 0 or not src or not Path(src).is_dir():
+        return None
+    farm = exec_path_dir(stub_dir)
+    farm.mkdir(parents=True, exist_ok=True)
+    for entry in Path(src).iterdir():
+        # `git` itself is the one name the farm must NOT inherit — replacing it
+        # with the shim is the entire point.
+        if entry.name == "git":
+            continue
+        link = farm / entry.name
+        if link.is_symlink() or link.exists():
+            continue
+        try:
+            link.symlink_to(entry)
+        except OSError:  # pragma: no cover — a name that cannot be linked
+            continue
+    shim = farm / "git"
+    if not shim.exists():
+        # A RELATIVE link, so the farm keeps working if the stub dir is moved
+        # or bind-mounted somewhere else.
+        shim.symlink_to(Path("..") / "git")
+    return farm
+
+
 def install(stub_dir: Path, allowed: str | None = None,
-            denied: str | None = None) -> Path:
+            denied: str | None = None, mode: str = MODE_BLOCK) -> Path:
     """Write the `git` shim into `stub_dir`; return the log path.
 
     🔴 CALL THIS BEFORE PREPENDING `stub_dir` TO PATH — the shim resolves the
     real binary through `shutil.which`, so a stub dir already on PATH would
     make it exec ITSELF forever. The assertion below turns that ordering
-    mistake into a named failure instead of a hang. (Same trap, same guard, as
-    `nolaunch.install()`.)
+    mistake into a named failure instead of a hang.
     """
     stub_dir = Path(stub_dir)
     stub_dir.mkdir(parents=True, exist_ok=True)
@@ -912,21 +1610,25 @@ def install(stub_dir: Path, allowed: str | None = None,
     real_git = shutil.which("git")
     if real_git is None:
         # Nothing to shadow and nothing to forward to. Fabricating git's
-        # answers is the one thing this module must never do (see the
-        # docstring), so it installs nothing and says so.
+        # answers is the one thing this module must never do, so it installs
+        # nothing and says so.
         return log
     if Path(real_git).parent == stub_dir:
         raise AssertionError(
             "install() resolved git to its own stub dir — it was called AFTER "
             "stub_dir was put on PATH, and the shim would exec itself forever")
-    # Baked in so the policy survives a child built with a REPLACING `env=`.
-    # See the `roots=` / `denied=` lines in `git_body` for the measurement.
+    if Path(real_git).parent == exec_path_dir(stub_dir):
+        raise AssertionError(
+            "install() resolved git to its own GIT_EXEC_PATH farm — the farm "
+            "is on PATH, which it must never be")
     write_exec(stub_dir / "git",
                git_body(real_git, log,
                         allowed_roots=default_roots() if allowed is None
                         else allowed,
                         denied_roots=denied_roots() if denied is None
-                        else denied))
+                        else denied,
+                        stub_dir=stub_dir, mode=mode))
+    exec_path_farm(stub_dir, real_git)
     return log
 
 
@@ -942,6 +1644,42 @@ def recorded(stub_dir: Path) -> list[str]:
 def blocked(stub_dir: Path) -> list[str]:
     """The recorded git calls that were REFUSED (or would have been, in audit)."""
     return [ln for ln in recorded(stub_dir) if ln.startswith("git(blocked)")]
+
+
+def handshake(stub_dir: Path) -> dict[str, str] | None:
+    """Ask the shim in `stub_dir` to prove it is THIS policy's.
+
+    Returns the parsed answer, or None when the directory holds something that
+    is not this policy's shim — a foreign `git`, an older revision, or nothing.
+
+    🔴 A CONTENT CHECK, NOT A FILENAME CHECK. The previous revision adopted any
+    directory containing a file called `git` and skipped installation; measured
+    with a plain passthrough script there, a write to the repo-under-test
+    landed rc 0 with no banner and the session still reported "1 passed".
+    """
+    import subprocess
+    exe = Path(stub_dir) / "git"
+    if not exe.exists():
+        return None
+    try:
+        out = subprocess.run([str(exe), HANDSHAKE_FLAG], capture_output=True,
+                             text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    lines = out.stdout.splitlines()
+    if not lines or not lines[0].startswith(HANDSHAKE_MAGIC + " "):
+        return None
+    got = lines[0].split(" ", 1)[1].strip()
+    if got != policy_fingerprint():
+        return None
+    answer = {"fingerprint": got}
+    for ln in lines[1:]:
+        if "=" in ln:
+            k, v = ln.split("=", 1)
+            answer[k.strip()] = v.strip()
+    return answer
 
 
 def default_roots(*extra: os.PathLike | str) -> str:

--- a/scripts/testlib/nogit.py
+++ b/scripts/testlib/nogit.py
@@ -1,0 +1,1020 @@
+#!/usr/bin/env python3
+"""A `git` interceptor that lets READS through and BLOCKS WRITES to any repo
+outside the test's own tmpdir.
+
+🔴 THE HAZARD (MEASURED — the real clone's own reflog, 2026-08-20)
+------------------------------------------------------------------
+The suite drove `git` against `~/workspace/devrc` itself. Not the remote only:
+the local reflog records the writes landing in the operator's working clone.
+
+    trunk@{0}: Branch: renamed refs/heads/main to refs/heads/trunk
+    trunk@{1}: commit: seed
+    trunk@{2..4}: commit: c
+
+HEAD's reflog puts the last legitimate operation at 13:48:11 (`merge
+origin/main`), the `main → trunk` rename at 14:21:35 local = **19:21:35Z**, and
+HEAD on a single-file `f` tree at 14:38:36. The remote push storm — ~40 pushes
+onto `refs/heads/main` in 43 seconds, plus four other branches — began
+**19:28:14Z, about seven minutes AFTER the local rename**. The local damage came
+first and the pushes followed it.
+
+That ordering is the whole diagnosis. It rules out an independently-poisoned
+remote and pins the mechanism as "something resolved a repo for itself, then
+pushed what it found". It is also why a guard scoped to `push`, or to remotes,
+would have been useless: the entire first phase is LOCAL.
+
+The observed damage spans `commit`, `branch -m`, `config` (`core.bare=true`),
+`remote set-url` and `push`. So this guard is NOT "no `remote set-url`" — it is
+"no WRITE to a repo this test does not own", by whatever verb.
+
+🔴 AND THE REPO IT WRITES TO IS NOT THE ONE ITS ARGUMENTS NAME
+---------------------------------------------------------------
+The obvious reading of the above is "some caller passes the wrong path", and it
+is WRONG. The reproduced mechanism is an ambient `GIT_DIR`:
+
+    $ GIT_DIR=<victim>/.git git -C <fixture> rev-parse --show-toplevel
+    <fixture>
+    $ GIT_DIR=<victim>/.git git -C <fixture> commit --allow-empty -m PWNED
+    rc=0, and <victim>'s commit count went 1 -> 2.
+
+`-C` is not protective. Every audit that cleared this suite on "absolute `-C`,
+therefore fixture-scoped" — two of them, one a mechanical sweep — was measuring
+a property that does not bound anything. The culprit is
+`scripts/repo-cos/tests/test_prescan.py::_init_clone`, whose steps map
+one-for-one onto the reflog above (`config user.email t@t`, `commit -m seed`,
+`branch -M trunk`, `push origin HEAD:trunk`), and every one of them is a
+well-formed `git -C <tmp clone> …`.
+
+So the target of a write is computed from the ARGUMENTS **and** the
+ENVIRONMENT, in two sub-classes that do not cover each other:
+
+  * IDENTITY redirection (`GIT_DIR`, `GIT_COMMON_DIR`) — git reports a
+    different repo. Caught by asking git which repo it will actually use.
+  * BYTE redirection (`GIT_WORK_TREE`, `GIT_INDEX_FILE`,
+    `GIT_OBJECT_DIRECTORY`, the alternates, `GIT_CONFIG_GLOBAL/SYSTEM`) —
+    identity stays innocent and TRUTHFUL and only the destination moves.
+    `GIT_WORK_TREE=<victim> git -C <fixture> checkout -f HEAD` exits 0 and
+    writes the victim's working tree. **Resolving the repo cannot see this.**
+
+See `GIT_LOCATION_ENV` for the ledger and the two entries that were wrong.
+
+🔴 IT IS INVISIBLE BY CONSTRUCTION
+-----------------------------------
+The remote repoint was observed only by running `git remote -v` in the real
+clone WHILE the suite ran; the test restores the URL afterwards, so every
+after-the-fact check reports a clean repo. A guard that inspects state after
+the run therefore cannot see this class at all — the interception has to happen
+at the moment of the call, which is what this module does.
+
+WHY A PATH SHIM AND NOT A `subprocess` MONKEYPATCH
+--------------------------------------------------
+The same reason `testlib/nolaunch.py` is a PATH shim, and it is decisive here
+rather than merely tidy: a `git` that damages something is very often run by a
+GRANDCHILD. The suite spawns shell scripts, and those scripts run `git`; a
+`subprocess.Popen` patched inside the pytest process never sees any of it. Only
+a shim that is first on `PATH` — inherited by every descendant, at any depth —
+can. The in-process layer exists too, mirroring `nolaunch_plugin`'s L2, but
+purely to catch an ABSOLUTE-path `git` that PATH cannot shadow.
+
+⚠ An earlier revision of this paragraph named `scripts/drift-check.sh`'s
+`ssh … bash -s` leg (where `DRIFT_REPO` is unset and
+`${DRIFT_REPO:-$HOME/workspace/devrc}` resolves to the real clone) as the
+motivating caller. That theory is RETRACTED and should not be re-derived: the
+test harness's stub `ssh` writes the payload to `/dev/null` and never executes
+it, and the payloads are read-only regardless. The empty-override sites in
+`drift-check.sh` and `ship.sh` are a genuine latent hazard — all five use `:-`,
+which falls back on EMPTY as well as unset — but no caller passes an empty
+value, so they were not the mechanism. The PATH-shim argument stands on the
+grandchild point alone.
+
+🔴 WHY THE SPLIT IS BY VERB **AND** BY TARGET, AND WHY IT FAILS LOUD
+---------------------------------------------------------------------
+`nolaunch` has two stub shapes and this is deliberately the `systemctl` one,
+not the record-only one — for `systemctl`'s exact stated reason: **never
+fabricate an answer**. Git is asked questions constantly, and this suite asks
+them OF THE REAL REPO on purpose: the content gates
+(`testlib/captured_text_scan.py`, `public_ip_scan.py`, `client_host_scan.py`,
+`lib/service_recon.py`) all shell out to `git -C <repo-root> ls-files -z`.
+Swallowing those with exit 0 and empty stdout would make every one of them scan
+**nothing** and pass — the silent-zero failure, manufactured by the guard
+itself. So reads always exec the real binary, wherever they point.
+
+Writes are the mirror image. A write that is swallowed with exit 0 tells the
+caller it succeeded, so the test proceeds and asserts against a repo that never
+changed — green, and meaningless. A blocked write must therefore be LOUD: a
+distinctive message on stderr and a distinctive exit code (`BLOCK_EXIT`), so it
+surfaces as a failure naming this policy rather than as a puzzling git error.
+
+The verb ledger is an ALLOWLIST of reads, so an unknown verb — including one
+git gains in a future release — is treated as a write. Fail-closed is the right
+direction to err in, because a false negative costs the operator's `main`.
+
+🔴 BUT FAIL-CLOSED IS NOT FREE, AND PRETENDING IT IS ALMOST SANK THIS FILE.
+An earlier revision of this paragraph claimed a false positive costs "one line
+added to a ledger". Measured on the first armed run of the full suite, false
+positives cost: 590 refusals of `GIT_CONFIG_GLOBAL=/dev/null`, three red tests
+whose only sin was building a replacing `env=` dict, one refusal of every
+`git init <tmp_path>` (judged by cwd), and one refusal of every
+fixture-to-fixture `push`. A guard in that state is removed within a day, and
+removing it restores the hazard in full — so a false positive and a false
+negative differ in cost far less than the asymmetry suggests. Every one of
+those was found by a POSITIVE control; none was visible to a negative one.
+
+🔴 THE SECOND VECTOR: THE TARGET REPO IS NOT THE ONLY WAY OUT
+--------------------------------------------------------------
+A `push` from a repo that IS inside the tmpdir still reaches whatever its
+`origin` points at. That is not hypothetical here: the contained clone prepared
+for this work had an `origin` pointing at the operator's real local clone, so a
+fixture pushing to `origin` would have written into their actual refs. Location
+of the *source* repo therefore does not bound the blast radius of a push, and
+`_push_destination_body` resolves the destination URL and applies the same
+root check to it.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+from .mockbin import write_exec
+
+# ---------------------------------------------------------------------------
+# The ledger of READ-ONLY git verbs.
+#
+# 🔴 An ALLOWLIST, pinned by scripts/tests/test_no_real_git_remote.py, so it
+# fails when the set GROWS or SHRINKS. Anything absent is a write and is
+# blocked outside the test's own roots — that includes verbs git has not
+# shipped yet, which is the point: a blocklist fails OPEN on the next verb
+# someone reaches for, and `remote` was exactly such a verb before this file.
+#
+# Membership rule, applied literally: a verb belongs here only if it CANNOT
+# modify the repository, its config, its refs, its index, its worktree, or a
+# remote. "Usually read-only" is not the test — `remote` and `config` both
+# READ in their bare forms and write with an argument, so neither is listed
+# and both are decided by target instead.
+# ---------------------------------------------------------------------------
+GIT_READ_VERBS = (
+    "status", "log", "show", "diff", "cat-file", "ls-files", "ls-tree",
+    "ls-remote", "rev-parse", "rev-list", "describe", "blame", "grep",
+    "shortlog", "show-ref", "symbolic-ref", "for-each-ref", "merge-base",
+    "name-rev", "check-ignore", "check-attr", "count-objects", "verify-pack",
+    "var", "help", "version", "annotate", "whatchanged", "cherry",
+    "diff-tree", "diff-index", "diff-files", "hash-object", "patch-id",
+    "get-tar-commit-id", "check-mailmap", "column", "interpret-trailers",
+)
+
+# Read-only global FLAGS: they answer and exit whatever else is on the line,
+# so they are safe in any position (unlike a verb, which is positional).
+GIT_READ_FLAGS = ("--version", "--help", "-h", "--exec-path", "--html-path",
+                  "--man-path", "--info-path")
+
+# 🔴 Verbs that write to a DESTINATION rather than to the local repo. For
+# these, being inside an allowed root is NOT sufficient — the destination is
+# resolved and checked as well. See the module docstring's second vector.
+GIT_REMOTE_WRITE_VERBS = ("push",)
+
+# 🔴 Verbs whose target is a POSITIONAL ARGUMENT, not the current repo.
+#
+# Found by the positive control, not by reading the docs: with the guard's
+# first draft, `git init /tmp/<fixture>` was REFUSED, because the resolver used
+# the process's cwd — and a suite run from the repo root has the repo as its
+# cwd. Every fixture that builds itself a clone would have gone red, which is
+# the permanently-red gate claude/RULES.md warns about: the guard would have
+# been switched off within a day and the real hazard would be back.
+#
+# `init` and `clone` CREATE a repo at a path they are handed, so the path is
+# what must be bounded. The option tables below exist because the target is
+# "the first positional after the verb" only once options with VALUES are
+# skipped — `git init -b main` would otherwise resolve its target to `main`,
+# reintroducing the same false positive in a narrower shape.
+GIT_TARGET_IS_ARG_VERBS = ("init", "clone")
+
+# Options that consume the NEXT argv entry, for the two verbs above. Any option
+# spelled `--opt=value` needs no entry: it carries its value inline.
+GIT_INIT_VALUE_OPTS = (
+    "-b", "--initial-branch", "--separate-git-dir", "--template",
+    "--object-format", "--ref-format", "--shared",
+)
+GIT_CLONE_VALUE_OPTS = (
+    "-b", "--branch", "-o", "--origin", "-u", "--upload-pack", "--reference",
+    "--reference-if-able", "--separate-git-dir", "--depth", "--template",
+    "-c", "--config", "--filter", "--shallow-since", "--shallow-exclude",
+    "-j", "--jobs", "--bundle-uri", "--server-option", "--recurse-submodules",
+)
+
+# 🔴 Verbs that READ in one form and WRITE in another. The verb alone cannot
+# decide them, so neither the read ledger nor the write path may own them.
+#
+# Found by the positive control, again: `git remote -v`, `git config --get …`
+# and `git branch --show-current` are the commands this very policy's own
+# containment check runs, and the first draft REFUSED all three — while the
+# suite itself reads `remote get-url origin`, `config --get
+# remote.origin.url`, `branch -a --format=…` and `worktree list --porcelain`
+# against the real repo on purpose. Listing them as reads would have failed
+# OPEN on `remote set-url`, which is the incident; leaving them as writes goes
+# permanently red. The only honest answer is to classify the FORM.
+#
+# `_dual_is_read_body` implements it as an ALLOWLIST of read forms — an
+# unrecognised form is a write. It runs only when the target is already out of
+# bounds, so a misclassification cannot affect a legitimate fixture write.
+GIT_DUAL_VERBS = ("remote", "config", "branch", "tag", "worktree",
+                  "submodule", "stash", "notes")
+
+# 🔴 THE ENVIRONMENT IS PART OF THE TARGET — `-C` IS NOT PROTECTIVE.
+#
+# MEASURED, and it invalidated this module's first design outright:
+#
+#     $ GIT_DIR=<victim>/.git git -C <fixture> rev-parse --show-toplevel
+#     <fixture>                      <- the innocent answer
+#     $ GIT_DIR=<victim>/.git git -C <fixture> rev-parse --absolute-git-dir
+#     <victim>/.git                  <- where the write ACTUALLY goes
+#
+#     $ GIT_DIR=<victim>/.git git -C <fixture> commit --allow-empty -m PWNED
+#     rc=0, and <victim>'s commit count went 1 -> 2.
+#
+# So an ambient `GIT_DIR` redirects the refs and objects while `--show-toplevel`
+# still reports the directory `-C` names. A guard that resolves the target from
+# the ARGUMENTS is bypassed completely, and — this is the part that matters —
+# so is every audit that concluded "absolute `-C`, therefore fixture-scoped".
+# Two independent reviews of the suite reached that conclusion by checking the
+# wrong property.
+#
+# This is the reproduced mechanism of the incident: replaying a repo-cos
+# fixture with `GIT_DIR` naming a victim reproduced all four observed damages —
+# a `commit`, the `main → trunk` rename, a `user.email` rewrite and a push to
+# the victim's own origin.
+#
+# The defence is therefore NOT to enumerate argument shapes. It is to ask GIT
+# ITSELF where it is about to write (`rev-parse --absolute-git-dir` and friends,
+# which honour every redirection vector including ones not listed below), and
+# to check the listed variables explicitly on top of that.
+#
+# 🔴 THIS LEDGER IS KNOWN-INCOMPLETE, BY MEASUREMENT. It was built from the
+# installed git's own `man git` — 76 `GIT_*` names — and that page does NOT
+# document `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_<n>` / `GIT_CONFIG_VALUE_<n>`,
+# which this git demonstrably honours (injecting `user.name` through them
+# works). A family the binary obeys was absent from the page describing it, so
+# the list below cannot be trusted as closed — which is exactly why git's own
+# answer is the primary check and this ledger is only the belt.
+#
+# 🔴 EVERY ENTRY MUST BE A PATH THAT RECEIVES BYTES. Two names were removed
+# after the first armed run, because being git-related is not the membership
+# rule:
+#   * `GIT_NAMESPACE` is a REF NAMESPACE, not a filesystem path. A real
+#     namespace ("foo") would have been canonicalised into `$base/foo` and
+#     refused — a pure false positive on a variable that cannot redirect a
+#     write anywhere.
+#   * `GIT_CEILING_DIRECTORIES` RESTRICTS repository discovery. It only ever
+#     narrows what git will touch, so treating it as a destination inverts its
+#     meaning and refuses the safe case.
+# Both were "caught" by a negative control that armed them at a victim PATH —
+# which proves only that the check reads variables, not that those variables
+# are write targets. The controls were measuring the guard, not the hazard.
+GIT_LOCATION_ENV = (
+    "GIT_DIR",
+    "GIT_COMMON_DIR",
+    "GIT_WORK_TREE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",  # colon-separated
+    "GIT_INDEX_FILE",
+    "GIT_CONFIG_GLOBAL",
+    "GIT_CONFIG_SYSTEM",
+)
+
+# 🔴 Paths that are never a repository and never worth protecting.
+#
+# MEASURED: `/dev/null` accounted for **590 of the 593** firings on the first
+# armed run of the full suite — `GIT_CONFIG_GLOBAL=/dev/null` is the standard
+# idiom for "this test has no global git config", used throughout this tree and
+# by every hermetic harness. Refusing it would have made the policy
+# permanently red across `scripts/tests` on day one, and a permanently-red gate
+# gets switched off.
+#
+# It is an exemption for a SINK, not a widening of the roots: `/dev/null`
+# discards what is written to it, so a config write aimed there damages
+# nothing. `GIT_CONFIG_GLOBAL=<victim>/.gitconfig` is still refused, which is
+# the case the negative control actually cares about.
+ALWAYS_SAFE_PATHS = ("/dev/null",)
+
+LOG_NAME = "git-calls.log"
+
+# The exit code a blocked write returns. Distinctive on purpose: git itself
+# uses 1/128/129, so a test failing with 99 is unambiguously this policy and
+# not a git error the reader has to diagnose.
+BLOCK_EXIT = 99
+
+# The stderr banner. Pinned verbatim by the guard test — a policy whose
+# message can drift is a policy whose firing cannot be asserted on.
+BANNER = "DEVRC-NO-REAL-GIT VIOLATION"
+
+# Where `install()` is told which roots a write may target, and which mode to
+# run in. Read by the STUB at call time (not baked in) so a test can widen the
+# roots for its own fixture without reinstalling the shim.
+ROOTS_ENV = "DEVRC_TEST_GIT_ALLOWED_ROOTS"
+MODE_ENV = "DEVRC_TEST_GIT_MODE"
+STUB_DIR_ENV = "DEVRC_TEST_GIT_STUB_DIR"
+
+# 🔴 Roots that are ALWAYS refused, checked BEFORE the allow-list and winning
+# over it. This is what keeps the policy from being inert in the tier that
+# gates merges.
+#
+# The allow-list is "the tmp roots a test may write in", and on the dev host
+# that correctly excludes `~/workspace/devrc`. But in the nix build sandbox the
+# source tree is unpacked UNDER `$TMPDIR` — so an allow-list alone would place
+# the repo under test INSIDE an allowed root, and every write this policy
+# exists to stop would be permitted in exactly the tier that gates merges.
+# That is the two-tier hazard from claude/RULES.md, arriving through the guard
+# rather than around it: the dev host would be protected and CI structurally
+# blind, so a violation could merge green and only fire on someone's machine.
+#
+# The deny root is the repo the suite is running out of, resolved at session
+# start. It makes "never write to the tree under test" true in BOTH tiers by
+# the same code, and it is why the negative control can be aimed at a real
+# clone's root without that clone needing to live outside /tmp.
+DENY_ROOTS_ENV = "DEVRC_TEST_GIT_DENIED_ROOTS"
+
+# `block` (default) refuses the write. `audit` records it and lets it through.
+#
+# 🔴 `audit` EXISTS TO BE MEASURED WITH, NOT TO BE SHIPPED WITH. It is how the
+# blast radius of this policy was established before it was turned on (every
+# git call in the suite, with its resolved target, logged and classified). A
+# test pins `block` as the default precisely so an audit run cannot be left on
+# by accident — a guard silently in audit mode is a guard that never fires.
+MODE_BLOCK = "block"
+MODE_AUDIT = "audit"
+
+
+def log_path(stub_dir: Path) -> Path:
+    """Where the shim records every intercepted `git`, one line per call."""
+    return Path(stub_dir) / LOG_NAME
+
+
+def _push_destination_body(real: str) -> str:
+    """POSIX-sh that resolves a `push`'s destination to a local path, if any.
+
+    Sets `dest` to a filesystem path when the push target is a local repo, and
+    leaves it empty when the target is a URL this check does not bound (ssh://,
+    https://, git@host:path). Empty means "not a local path", NOT "safe" — the
+    caller treats an unresolvable destination as a violation, because a push
+    that leaves the machine is exactly what destroyed the branch.
+    """
+    return (
+        'push_dest() {\n'
+        '  pv="$1"; pc="$2"; shift 2\n'
+        # 🔴 SKIP TO THE VERB FIRST — the same measured bug as dual_is_read,
+        # in a second place. The value of `-C` is a non-flag token, so "the
+        # first non-flag argument" is the -C PATH, not the remote. Without
+        # this, `git -C <path> push origin trunk` resolved its remote to the
+        # literal string "push", `remote get-url push` failed, the destination
+        # came back empty, and every legitimate fixture-to-fixture push was
+        # refused. Two sites, one misreading — found only by the positive
+        # control, since blocking is what the negative controls assert.
+        '  while [ "$#" -gt 0 ]; do\n'
+        '    a="$1"; shift\n'
+        '    case "$a" in -*) continue ;; esac\n'
+        '    [ "$a" = "$pv" ] && break\n'
+        '  done\n'
+        '  rem=""\n'
+        '  for a in "$@"; do\n'
+        '    case "$a" in -*) continue ;; esac\n'
+        '    rem="$a"; break\n'
+        '  done\n'
+        # No remote named: git uses the branch's configured remote, defaulting
+        # to `origin`. Ask git rather than guessing.
+        '  if [ -z "$rem" ]; then\n'
+        '    if [ -n "$pc" ]; then\n'
+        f'      rem=$("{real}" -C "$pc" remote 2>/dev/null | head -n 1)\n'
+        '    else\n'
+        f'      rem=$("{real}" remote 2>/dev/null | head -n 1)\n'
+        '    fi\n'
+        '  fi\n'
+        '  [ -n "$rem" ] || rem=origin\n'
+        '  case "$rem" in\n'
+        '    */*|.|..) url="$rem" ;;\n'
+        '    *)\n'
+        '      if [ -n "$pc" ]; then\n'
+        f'        url=$("{real}" -C "$pc" remote get-url "$rem" 2>/dev/null)\n'
+        '      else\n'
+        f'        url=$("{real}" remote get-url "$rem" 2>/dev/null)\n'
+        '      fi ;;\n'
+        '  esac\n'
+        # An empty result means "not a LOCAL path" — never "safe". The caller
+        # treats an empty destination as a violation, because a push that
+        # leaves the machine is exactly what destroyed the branch.
+        '  case "$url" in\n'
+        '    ""|*://*|*@*:*) printf \'\' ;;\n'
+        '    *) printf \'%s\' "$url" ;;\n'
+        '  esac\n'
+        '}\n'
+    )
+
+
+def _dual_is_read_body() -> str:
+    """POSIX-sh defining `dual_is_read <verb> <argv…>` — 0 when the form READS.
+
+    🔴 AN ALLOWLIST OF READ FORMS, so an unrecognised form is a write. The
+    direction matters: a `remote` form this function does not recognise must
+    land on `set-url`'s side of the line, not `get-url`'s.
+
+    It is consulted ONLY after the target has already been judged out of
+    bounds, which bounds the damage of getting one of these wrong: a form
+    misclassified as a write costs a false red on a read of the real repo, and
+    can never permit a write inside a fixture.
+    """
+    return (
+        'dual_is_read() {\n'
+        '  dv="$1"; shift\n'
+        # 🔴 DISCARD EVERYTHING UP TO AND INCLUDING THE VERB FIRST.
+        # Measured: without this, `git -C <path> remote -v` had `<path>` — the
+        # VALUE of -C — as its first non-flag token, so every dual verb was
+        # classified from the wrong word and five legitimate reads were
+        # refused. The positive control is what caught it; the negative
+        # controls were all still green, because misreading the sub-command
+        # errs toward "write" and blocking is what they assert.
+        '  while [ "$#" -gt 0 ]; do\n'
+        '    a="$1"; shift\n'
+        '    case "$a" in -*) continue ;; esac\n'
+        '    [ "$a" = "$dv" ] && break\n'
+        '  done\n'
+        # The first non-flag token after the verb — the sub-command for the
+        # verbs that have one.
+        '  dsub=""\n'
+        '  dpos=0\n'
+        '  for a in "$@"; do\n'
+        '    case "$a" in -*) continue ;; esac\n'
+        '    dpos=$((dpos+1))\n'
+        '    [ "$dpos" -eq 1 ] && dsub="$a"\n'
+        '  done\n'
+        '  case "$dv" in\n'
+        # `remote` / `remote -v` / `remote show` / `remote get-url` read.
+        # add, remove, rename, set-url, set-head, set-branches, prune, update
+        # all write, and so does anything not named here.
+        '    remote)\n'
+        '      case "$dsub" in\n'
+        '        ""|show|get-url) return 0 ;;\n'
+        '        *) return 1 ;;\n'
+        '      esac ;;\n'
+        # `config` splits on its ACTION flag, then on arity: `config KEY` reads,
+        # `config KEY VALUE` writes. Arity is the subtle one — it is how
+        # `core.bare true` differs from `core.bare`, and getting it backwards
+        # would wave through the exact config write seen in the incident.
+        '    config)\n'
+        '      for a in "$@"; do\n'
+        '        case "$a" in\n'
+        '          --get|--get-all|--get-regexp|--get-urlmatch|--get-color|'
+        '--get-colorbool|-l|--list) return 0 ;;\n'
+        '          --unset|--unset-all|--replace-all|--add|--edit|-e|'
+        '--rename-section|--remove-section|--set-all) return 1 ;;\n'
+        '        esac\n'
+        '      done\n'
+        '      [ "$dpos" -le 1 ] && return 0\n'
+        '      return 1 ;;\n'
+        # `branch` reads when it LISTS: no positional, and no flag that moves,
+        # copies, deletes or re-points anything.
+        '    branch)\n'
+        '      dskip=0\n'
+        '      dn=0\n'
+        '      for a in "$@"; do\n'
+        '        if [ "$dskip" -eq 1 ]; then dskip=0; continue; fi\n'
+        '        case "$a" in\n'
+        '          -m|-M|-d|-D|-c|-C|--move|--copy|--delete|--set-upstream|'
+        '--set-upstream-to|--unset-upstream|--edit-description|-f|--force)\n'
+        '            return 1 ;;\n'
+        '          --contains|--no-contains|--merged|--no-merged|--points-at|'
+        '--sort|--format)\n'
+        '            dskip=1; continue ;;\n'
+        '          -*) continue ;;\n'
+        '        esac\n'
+        '        dn=$((dn+1))\n'
+        '      done\n'
+        '      [ "$dn" -eq 0 ] && return 0\n'
+        '      return 1 ;;\n'
+        '    tag)\n'
+        '      for a in "$@"; do\n'
+        '        case "$a" in\n'
+        '          -d|--delete|-a|-s|-u|-m|-F|-f|--force|--create-reflog)\n'
+        '            return 1 ;;\n'
+        '        esac\n'
+        '      done\n'
+        '      [ "$dpos" -eq 0 ] && return 0\n'
+        '      for a in "$@"; do\n'
+        '        case "$a" in\n'
+        '          -l|--list|-n|-n[0-9]*|--contains|--points-at|--sort|'
+        '--format|--format=*|--merged|--no-merged) return 0 ;;\n'
+        '        esac\n'
+        '      done\n'
+        '      return 1 ;;\n'
+        '    worktree)\n'
+        '      case "$dsub" in list) return 0 ;; *) return 1 ;; esac ;;\n'
+        # `submodule foreach` runs an arbitrary command, so it is NOT a read
+        # however harmless the command looks.
+        '    submodule)\n'
+        '      case "$dsub" in status|summary) return 0 ;; *) return 1 ;; esac ;;\n'
+        '    stash)\n'
+        '      case "$dsub" in list|show) return 0 ;; *) return 1 ;; esac ;;\n'
+        '    notes)\n'
+        '      case "$dsub" in list|show) return 0 ;; *) return 1 ;; esac ;;\n'
+        '  esac\n'
+        '  return 1\n'
+        '}\n'
+    )
+
+
+def _bounds_helpers_body() -> str:
+    """POSIX-sh: `canon_of <path>` and `out_of_bounds <path>`.
+
+    Split out of the main body because the target is no longer a single path.
+    With `GIT_DIR` in play a write has SEVERAL destinations — the git dir, the
+    worktree, the object dir, the index — and any one of them landing outside
+    the allowed roots is a violation, so each is canonicalised and checked by
+    the same code.
+    """
+    return (
+        # Canonicalise, resolving symlinks and `..`, WITHOUT requiring the path
+        # to exist: `git init` and `git clone` name a directory that is not
+        # there yet, and `GIT_INDEX_FILE` names a file. A path that cannot be
+        # canonicalised at all is returned unchanged rather than dropped —
+        # dropping it would silently remove a candidate from the check.
+        'canon_of() {\n'
+        '  cp_="$1"\n'
+        '  case "$cp_" in /*) ;; *) cp_="$base/$cp_" ;; esac\n'
+        '  cd_=$(cd "$cp_" 2>/dev/null && pwd -P) && { printf \'%s\' "$cd_"; '
+        'return 0; }\n'
+        '  cpar_=$(dirname "$cp_"); cbas_=$(basename "$cp_")\n'
+        '  cd_=$(cd "$cpar_" 2>/dev/null && pwd -P) && { printf \'%s/%s\' '
+        '"$cd_" "$cbas_"; return 0; }\n'
+        '  printf \'%s\' "$cp_"\n'
+        '}\n'
+        # 🔴 PRINTS A VERDICT, IT DOES NOT RETURN ONE — and the caller demands
+        # the literal string "ok".
+        #
+        # An exit-code version of this failed OPEN and was caught doing it: the
+        # helpers had not been emitted into the stub, so `out_of_bounds` was a
+        # `command not found` returning 127, "non-zero" read as "in bounds",
+        # and the shim let a write through with rc=0. Every negative control
+        # would have gone green against a guard that had ceased to exist.
+        #
+        # With a printed verdict, a helper that is missing, crashes, or is
+        # killed produces empty output, which is not "ok", so the call is
+        # refused. The failure direction is a property of the shape rather than
+        # of remembering to check.
+        'bounds_verdict() {\n'
+        '  ob_="$1"\n'
+        '  ob_ok_=0\n'
+        # A sink that discards writes is safe wherever it lives.
+        '  case "$ob_" in\n'
+        f'    {"|".join(ALWAYS_SAFE_PATHS)}) printf \'ok\'; return ;;\n'
+        '  esac\n'
+        '  oifs_="$IFS"; IFS=":"\n'
+        '  for r in $roots; do\n'
+        '    [ -n "$r" ] || continue\n'
+        '    case "$ob_" in "$r"|"$r"/*) ob_ok_=1; break ;; esac\n'
+        '  done\n'
+        # Deny wins over allow, always — that ordering is what keeps the policy
+        # live in the nix sandbox, where the tree under test sits inside
+        # $TMPDIR and would otherwise be inside an allowed root.
+        '  for r in $denied; do\n'
+        '    [ -n "$r" ] || continue\n'
+        '    case "$ob_" in "$r"|"$r"/*) ob_ok_=0; break ;; esac\n'
+        '  done\n'
+        '  IFS="$oifs_"\n'
+        '  [ "$ob_ok_" -eq 1 ] && printf \'ok\' || printf \'bad\'\n'
+        '}\n'
+    )
+
+
+def git_body(real: str, log: Path, allowed_roots: str = "",
+             denied_roots: str = "") -> str:
+    """The POSIX-sh body of the `git` shim. No shebang — write_exec owns it.
+
+    The parse mirrors git's own: skip leading global options, take the FIRST
+    non-flag token as the verb, and decide on that. `-C <dir>`, `--git-dir=`
+    and `--work-tree=` are captured while skipping, because they are what move
+    the target away from the process's cwd — and a bare `git` with neither is
+    the first-class suspect, since it silently targets whatever directory the
+    caller happens to be in.
+
+    🔴 THE TARGET IS RESOLVED, NOT ASSUMED. `rev-parse --show-toplevel` is
+    asked (via the REAL binary, by absolute path, so this cannot recurse), and
+    the answer is canonicalised with `pwd -P`. Comparing the raw `-C` string
+    against the allowed roots would be walkable by `-C /tmp/x/../../home/zach/
+    workspace/devrc`, and by a symlinked tmpdir — both of which resolve to a
+    real repo while spelling something that passes a prefix match.
+    """
+    verbs = "|".join(GIT_READ_VERBS)
+    flags = "|".join(GIT_READ_FLAGS)
+    remote_write = "|".join(GIT_REMOTE_WRITE_VERBS)
+    return (
+        _bounds_helpers_body() +
+        _dual_is_read_body() +
+        _push_destination_body(real) +
+        f'log="{log}"\n'
+        f'real="{real}"\n'
+        f'mode="${{{MODE_ENV}:-{MODE_BLOCK}}}"\n'
+        # 🔴 THE ROOTS ARE BAKED IN AT INSTALL TIME; THE ENV ONLY WIDENS THEM.
+        #
+        # Reading the policy purely from the environment made it depend on
+        # those variables surviving into every descendant — and they do not.
+        # MEASURED on the full suite: three tests build a REPLACING `env=`
+        # dict (`{HOME, GIT_CONFIG_GLOBAL, GIT_CONFIG_SYSTEM, PATH}`) for a
+        # perfectly hermetic `git init` in their own tmp_path. `PATH` still
+        # reaches the shim, so the shim ran — with no roots at all, and
+        # refused a legitimate fixture. Fail-closed was the right DIRECTION
+        # and still the wrong ANSWER: the guard would have gone red on every
+        # future env-replacing test, and a permanently-red gate gets switched
+        # off.
+        #
+        # So the installed defaults are the FLOOR and the variables are an
+        # override for a test that needs to widen its own roots.
+        f'roots="${{{ROOTS_ENV}:-{allowed_roots}}}"\n'
+        # 🔴 DENY IS A UNION, NOT AN OVERRIDE — asymmetric on purpose. A test
+        # may widen what it is allowed to write; nothing may un-deny the tree
+        # under test, including an empty or absent variable.
+        f'denied="{denied_roots}${{{DENY_ROOTS_ENV}:+:${{{DENY_ROOTS_ENV}}}}}"\n'
+        '\n'
+        # ---- position-independent read flags: answer and exit ----
+        'for a in "$@"; do\n'
+        '  case "$a" in\n'
+        f'    {flags})\n'
+        '      printf \'git(read-flag) %s\\n\' "$*" >> "$log"\n'
+        '      exec "$real" "$@" ;;\n'
+        '  esac\n'
+        'done\n'
+        '\n'
+        # ---- parse leading global options for the target, then the verb ----
+        'cdir=""\n'
+        'gdir=""\n'
+        'wtree=""\n'
+        'verb=""\n'
+        'want=""\n'
+        'for a in "$@"; do\n'
+        '  if [ -n "$want" ]; then\n'
+        '    case "$want" in\n'
+        '      C) if [ -n "$cdir" ]; then case "$a" in /*) cdir="$a" ;; '
+        '*) cdir="$cdir/$a" ;; esac; else cdir="$a"; fi ;;\n'
+        '      gitdir) gdir="$a" ;;\n'
+        '      worktree) wtree="$a" ;;\n'
+        '    esac\n'
+        '    want=""\n'
+        '    continue\n'
+        '  fi\n'
+        '  case "$a" in\n'
+        '    -C) want=C ;;\n'
+        '    --git-dir) want=gitdir ;;\n'
+        '    --work-tree) want=worktree ;;\n'
+        '    --git-dir=*) gdir="${a#--git-dir=}" ;;\n'
+        '    --work-tree=*) wtree="${a#--work-tree=}" ;;\n'
+        '    -c) want=skip ;;\n'
+        '    -*) ;;\n'
+        '    *) verb="$a"; break ;;\n'
+        '  esac\n'
+        'done\n'
+        '\n'
+        # ---- no verb at all: `git` (or only flags) prints usage and exits ----
+        # It writes nothing, so refusing it would be a false positive — and a
+        # confusing one, since `git` alone answering "VIOLATION" reads as the
+        # guard being broken. Stated rather than left implicit, because
+        # `nolaunch`'s systemctl stub takes the OPPOSITE choice for a bare
+        # invocation and the difference is deliberate: a bare `systemctl` LISTS
+        # UNITS (an answer that would have to be fabricated), while a bare
+        # `git` only prints its own usage.
+        'if [ -z "$verb" ]; then\n'
+        '  printf \'git(no-verb) %s\\n\' "$*" >> "$log"\n'
+        '  exec "$real" "$@"\n'
+        'fi\n'
+        '\n'
+        # ---- READ verbs exec the real binary, wherever they point ----
+        'case "$verb" in\n'
+        f'  {verbs})\n'
+        '    printf \'git(read) %s\\n\' "$*" >> "$log"\n'
+        '    exec "$real" "$@" ;;\n'
+        'esac\n'
+        '\n'
+        # ---- resolve the EFFECTIVE target repo ----
+        'base="$cdir"\n'
+        '[ -n "$base" ] || base="$PWD"\n'
+        'pathverb=0\n'
+        '\n'
+        # `init` / `clone` are handed the path they will CREATE. Using the cwd
+        # for these refuses every fixture that builds itself a clone from a
+        # suite whose cwd is the repo — measured, and the reason this block
+        # exists. Skip the verb, skip options and their values, and take the
+        # positional: the 1st for `init`, the 2nd for `clone` (the 1st being
+        # the SOURCE, which is only read).
+        'case "$verb" in\n'
+        f'  {"|".join(GIT_TARGET_IS_ARG_VERBS)})\n'
+        '    if [ "$verb" = "clone" ]; then\n'
+        f'      valopts="{" ".join(GIT_CLONE_VALUE_OPTS)}"\n'
+        '      wantpos=2\n'
+        '    else\n'
+        f'      valopts="{" ".join(GIT_INIT_VALUE_OPTS)}"\n'
+        '      wantpos=1\n'
+        '    fi\n'
+        '    seen=0\n'
+        '    npos=0\n'
+        '    src=""\n'
+        '    tgt=""\n'
+        '    skipnext=0\n'
+        '    for a in "$@"; do\n'
+        '      if [ "$skipnext" -eq 1 ]; then skipnext=0; continue; fi\n'
+        '      if [ "$seen" -eq 0 ]; then\n'
+        '        [ "$a" = "$verb" ] && seen=1\n'
+        '        continue\n'
+        '      fi\n'
+        '      case "$a" in\n'
+        '        --*=*) continue ;;\n'
+        '        -*)\n'
+        '          for v in $valopts; do\n'
+        '            if [ "$a" = "$v" ]; then skipnext=1; break; fi\n'
+        '          done\n'
+        '          continue ;;\n'
+        '      esac\n'
+        '      npos=$((npos+1))\n'
+        '      [ "$npos" -eq 1 ] && src="$a"\n'
+        '      if [ "$npos" -eq "$wantpos" ]; then tgt="$a"; break; fi\n'
+        '    done\n'
+        # `git clone <src>` with no destination writes to <cwd>/<basename src>;
+        # `git init` with no path writes to the cwd. Both are resolved rather
+        # than waved through — a clone with no destination, run from the repo,
+        # lands IN the repo.
+        '    if [ -z "$tgt" ] && [ "$verb" = "clone" ] && [ -n "$src" ]; then\n'
+        '      tgt="${src%/}"\n'
+        '      tgt="${tgt##*/}"\n'
+        '      tgt="${tgt%.git}"\n'
+        '    fi\n'
+        '    if [ -n "$tgt" ]; then\n'
+        '      case "$tgt" in\n'
+        '        /*) base="$tgt" ;;\n'
+        '        *) base="$base/$tgt" ;;\n'
+        '      esac\n'
+        '    fi\n'
+        '    pathverb=1\n'
+        '    ;;\n'
+        'esac\n'
+        'gitargs=""\n'
+        '[ -n "$cdir" ] && gitargs="-C $cdir"\n'
+        'top=""\n'
+        'if [ "$pathverb" -eq 1 ]; then\n'
+        # `base` already IS the path init/clone will create. Asking rev-parse
+        # would answer about an ENCLOSING repo instead — for `git init
+        # /tmp/fix` run from the repo, that is the repo, which is precisely the
+        # false positive this branch exists to remove.
+        '  top="$base"\n'
+        'elif [ -n "$wtree" ]; then\n'
+        '  top="$wtree"\n'
+        'elif [ -n "$gdir" ]; then\n'
+        '  top="$gdir"\n'
+        'else\n'
+        '  top=$("$real" -C "$base" rev-parse --show-toplevel 2>/dev/null) '
+        '|| top=""\n'
+        'fi\n'
+        # No toplevel: `git init` / `git clone` into a not-yet-repo. The
+        # directory the write would CREATE is the thing to bound, so fall back
+        # to the base path rather than passing it unchecked.
+        '[ -n "$top" ] || top="$base"\n'
+        'canon=$(canon_of "$top")\n'
+        '\n'
+        # ---- gather EVERY place this write could land ----
+        # 🔴 Not one path. `GIT_DIR` sends refs and objects somewhere the
+        # worktree path does not mention, so the check is over a SET.
+        # The list is COLON-separated, which is git's own convention for these
+        # variables (`GIT_ALTERNATE_OBJECT_DIRECTORIES` already is one), so a
+        # single split handles both. A path containing a literal colon cannot
+        # be expressed in those variables by git either, so nothing is lost.
+        'cands="$canon"\n'
+        'if [ "$pathverb" -eq 0 ]; then\n'
+        # 🔴 ASK GIT, DO NOT INFER — this is the IDENTITY half.
+        # These are answered in the SAME cwd and environment the real call will
+        # use, so they already account for GIT_DIR, GIT_COMMON_DIR,
+        # GIT_CONFIG_* injection, core.worktree, discovery and any redirection
+        # vector this file has not enumerated — including the GIT_CONFIG_COUNT
+        # family, which `man git` does not document but this binary honours.
+        # `--git-common-dir` is asked separately from `--git-dir` because a
+        # LINKED worktree has its own git dir and a SHARED common dir, and a
+        # write can land in either.
+        '  info=$("$real" -C "$base" rev-parse --path-format=absolute '
+        '--git-dir --git-common-dir --git-path objects 2>/dev/null) || info=""\n'
+        '  for line in $info; do\n'
+        '    [ -n "$line" ] && cands="$cands:$line"\n'
+        '  done\n'
+        'fi\n'
+        # 🔴 THE ENVIRONMENT, EXPLICITLY — this is the BYTE-REDIRECTION half,
+        # and it is NOT redundant with the identity half above.
+        #
+        # `GIT_WORK_TREE=<victim> git -C <innocent fixture> checkout -f HEAD`
+        # leaves identity completely truthful — the resolved repo IS the
+        # fixture — while the FILES land in the victim's working tree. An
+        # identity-based check passes it and the bytes are still written. The
+        # same holds for GIT_INDEX_FILE, GIT_OBJECT_DIRECTORY, the alternates,
+        # and the GIT_CONFIG_GLOBAL/SYSTEM pair. Neither half covers the other.
+        + "".join(
+            f'[ -n "${{{v}:-}}" ] && cands="$cands:${{{v}}}"\n'
+            for v in GIT_LOCATION_ENV) +
+        '\n'
+        # ---- EVERY candidate must be in bounds ----
+        'allowed=1\n'
+        'why=""\n'
+        'oldifs="$IFS"\n'
+        'IFS=":"\n'
+        'for c in $cands; do\n'
+        '  [ -n "$c" ] || continue\n'
+        '  cc=$(canon_of "$c")\n'
+        # Demand the literal "ok". Anything else — "bad", empty output from a
+        # helper that failed, a killed subshell — refuses the call.
+        '  if [ "$(bounds_verdict "$cc")" != "ok" ]; then\n'
+        '    allowed=0\n'
+        '    why="write would land in $cc, outside the allowed roots"\n'
+        '    break\n'
+        '  fi\n'
+        'done\n'
+        'IFS="$oldifs"\n'
+        '\n'
+        # ---- a push must ALSO have an allowed destination ----
+        'case "$verb" in\n'
+        f'  {remote_write})\n'
+        '    dest=$(push_dest "$verb" "$cdir" "$@")\n'
+        '    if [ -z "$dest" ]; then\n'
+        '      allowed=0\n'
+        '      why="push destination is not a local path (it leaves this '
+        'machine)"\n'
+        '    else\n'
+        # The destination gets the SAME check as every other candidate — one
+        # helper, so the deny-wins ordering and the fail-closed verdict cannot
+        # drift between the two call sites. A push FROM a legitimate fixture
+        # clone INTO the real repo is the exact shape the contained clone was
+        # built to prevent: its `origin` pointed at the operator\'s working
+        # clone.
+        '      dcanon=$(canon_of "$dest")\n'
+        '      if [ "$(bounds_verdict "$dcanon")" != "ok" ]; then\n'
+        '        allowed=0\n'
+        '        why="push destination $dcanon is outside the allowed roots"\n'
+        '      fi\n'
+        '    fi ;;\n'
+        'esac\n'
+        '\n'
+        'if [ "$allowed" -eq 1 ]; then\n'
+        '  printf \'git(write-ok) %s :: %s\\n\' "$canon" "$*" >> "$log"\n'
+        '  exec "$real" "$@"\n'
+        'fi\n'
+        '\n'
+        # The target is out of bounds. A DUAL verb may still be in its READING
+        # form — `git remote -v`, `git config --get …`, `git branch -a
+        # --format=…`, `git worktree list` — all of which this suite runs
+        # against the real repo deliberately. Refusing those makes the policy
+        # permanently red; consulting the classifier only HERE means it can
+        # never rescue an actual write.
+        'case "$verb" in\n'
+        f'  {"|".join(GIT_DUAL_VERBS)})\n'
+        '    if dual_is_read "$verb" "$@"; then\n'
+        '      printf \'git(read-dual) %s :: %s\\n\' "$canon" "$*" >> "$log"\n'
+        '      exec "$real" "$@"\n'
+        '    fi ;;\n'
+        'esac\n'
+        '\n'
+        f'printf \'git(blocked) %s :: %s\\n\' "$canon" "$*" >> "$log"\n'
+        f'if [ "$mode" = "{MODE_AUDIT}" ]; then\n'
+        '  exec "$real" "$@"\n'
+        'fi\n'
+        f'printf \'%s\\n\' "{BANNER}" >&2\n'
+        'printf \'  a test tried to run a git WRITE against a repo it does '
+        'not own.\\n\' >&2\n'
+        'printf \'  verb:    %s\\n\' "$verb" >&2\n'
+        'printf \'  target:  %s\\n\' "$canon" >&2\n'
+        'printf \'  reason:  %s\\n\' "$why" >&2\n'
+        'printf \'  argv:    git %s\\n\' "$*" >&2\n'
+        'printf \'  cwd:     %s\\n\' "$PWD" >&2\n'
+        'printf \'  allowed: %s\\n\' "$roots" >&2\n'
+        'printf \'  This is scripts/testlib/nogit.py. The suite once drove '
+        'commit/branch -m/\\n\' >&2\n'
+        'printf \'  push against the operator\\047s real clone and destroyed '
+        'main on the\\n\' >&2\n'
+        'printf \'  remote. Point this call at your own tmp_path, or widen '
+        '%s.\\n\' "'
+        + ROOTS_ENV + '" >&2\n'
+        f'exit {BLOCK_EXIT}\n'
+    )
+
+
+def install(stub_dir: Path, allowed: str | None = None,
+            denied: str | None = None) -> Path:
+    """Write the `git` shim into `stub_dir`; return the log path.
+
+    🔴 CALL THIS BEFORE PREPENDING `stub_dir` TO PATH — the shim resolves the
+    real binary through `shutil.which`, so a stub dir already on PATH would
+    make it exec ITSELF forever. The assertion below turns that ordering
+    mistake into a named failure instead of a hang. (Same trap, same guard, as
+    `nolaunch.install()`.)
+    """
+    stub_dir = Path(stub_dir)
+    stub_dir.mkdir(parents=True, exist_ok=True)
+    log = log_path(stub_dir)
+
+    real_git = shutil.which("git")
+    if real_git is None:
+        # Nothing to shadow and nothing to forward to. Fabricating git's
+        # answers is the one thing this module must never do (see the
+        # docstring), so it installs nothing and says so.
+        return log
+    if Path(real_git).parent == stub_dir:
+        raise AssertionError(
+            "install() resolved git to its own stub dir — it was called AFTER "
+            "stub_dir was put on PATH, and the shim would exec itself forever")
+    # Baked in so the policy survives a child built with a REPLACING `env=`.
+    # See the `roots=` / `denied=` lines in `git_body` for the measurement.
+    write_exec(stub_dir / "git",
+               git_body(real_git, log,
+                        allowed_roots=default_roots() if allowed is None
+                        else allowed,
+                        denied_roots=denied_roots() if denied is None
+                        else denied))
+    return log
+
+
+def recorded(stub_dir: Path) -> list[str]:
+    """Every intercepted git call so far, as `git(<class>) …` lines."""
+    log = log_path(stub_dir)
+    if not log.exists():
+        return []
+    return [ln for ln in log.read_text(encoding="utf-8").splitlines()
+            if ln.strip()]
+
+
+def blocked(stub_dir: Path) -> list[str]:
+    """The recorded git calls that were REFUSED (or would have been, in audit)."""
+    return [ln for ln in recorded(stub_dir) if ln.startswith("git(blocked)")]
+
+
+def default_roots(*extra: os.PathLike | str) -> str:
+    """The `ROOTS_ENV` value for a session: the tmp roots a test may write in.
+
+    TMPDIR is included because pytest's `tmp_path` lives under it, and because
+    the nix build sandbox puts its whole world there. Each root is
+    canonicalised — an uncanonicalised root cannot match a canonicalised
+    target, which would block every legitimate write instead of allowing it.
+    """
+    roots: list[str] = []
+    for cand in (*extra, os.environ.get("TMPDIR"), "/tmp"):
+        if not cand:
+            continue
+        try:
+            r = str(Path(cand).resolve())
+        except OSError:  # pragma: no cover — unresolvable path
+            continue
+        if r not in roots:
+            roots.append(r)
+    return ":".join(roots)
+
+
+def repo_root() -> Path:
+    """The tree this suite is running out of — `scripts/testlib/` → repo root.
+
+    🔴 DERIVED FROM THIS FILE'S OWN LOCATION, never from `git rev-parse` and
+    never from a `$DEVRC`-shaped env var. Both of those are resolutions the
+    incident showed can point somewhere else: `rev-parse` answers about the
+    process's cwd, and an env var that is unset — or, the case that hid,
+    present-but-EMPTY under `${VAR:-default}` — falls back to
+    `~/workspace/devrc`. `__file__` is the one anchor that cannot be redirected
+    by the environment the guard is supposed to be policing.
+    """
+    return Path(__file__).resolve().parents[2]
+
+
+def denied_roots(*extra: os.PathLike | str) -> str:
+    """The `DENY_ROOTS_ENV` value: roots no test may write to, ever.
+
+    The tree under test, plus anything a caller adds. Canonicalised for the
+    same reason the allow roots are — an uncanonicalised deny root silently
+    matches nothing, which is a deny-list that denies nothing.
+    """
+    roots: list[str] = []
+    for cand in (repo_root(), *extra):
+        if not cand:
+            continue
+        try:
+            r = str(Path(cand).resolve())
+        except OSError:  # pragma: no cover — unresolvable path
+            continue
+        if r not in roots:
+            roots.append(r)
+    return ":".join(roots)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """`python -m testlib.nogit <dir>` — install the shim, print the log path.
+
+    The same door `testlib.nolaunch` opens for `scripts/run-tests.sh`: one
+    install for a whole run, before any target starts, so the NON-pytest
+    targets (which load no plugin) are covered by the same code rather than by
+    a second implementation of it.
+    """
+    import sys as _sys
+    args = list(_sys.argv[1:] if argv is None else argv)
+    if len(args) != 1:
+        print("usage: python -m testlib.nogit <stub-dir>", file=_sys.stderr)
+        return 2
+    print(install(Path(args[0])))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — exercised via the plugin
+    raise SystemExit(main())

--- a/scripts/testlib/nogit_plugin.py
+++ b/scripts/testlib/nogit_plugin.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""The ONE place that makes "a test cannot WRITE to a repo it does not own"
+true.
+
+Read `testlib/nogit.py` first — it carries the measurement, the reflog excerpt
+and the reasoning for the read/write split. This module is only the wiring, and
+it is deliberately the same wiring as `testlib/nolaunch_plugin.py`: one
+implementation, registered from `scripts/tests/conftest.py` so a bare
+`pytest scripts/tests` is covered, and exposed through `python -m
+testlib.nogit` so the runner can install one shim for a whole run.
+
+🔴 WHY THE SAME SHAPE AND NOT A NEW ONE
+----------------------------------------
+`nolaunch_plugin` exists in its current form because the previous one lived in
+a single `conftest.py` and therefore protected 1 pytest target of 17 — the
+declarations-vs-instances trap: one enforcement SITE that read as systemic
+while covering a seventeenth of the surface. Copying a fixture into N conftests
+is what produced that, twice (#399 and #614). So this module is the rule, once,
+and the places that need it register it rather than reimplementing it.
+
+🔴 TWO LAYERS, FOR THE SAME REASON AS THE LAUNCHER POLICY
+----------------------------------------------------------
+  L1 — PROCESS BOUNDARY (`nogit.install()` + PATH[0]).
+       This is the layer that matters, and unlike the launcher case it is not
+       merely the broader one — it is the ONLY one that can see the hazard.
+       The callers that resolve a repo for themselves are shell scripts the
+       tests spawn: `drift-check.sh` pipes its remote leg through `ssh … bash
+       -s`, and with a stub `ssh` that leg runs LOCALLY, where `DRIFT_REPO` is
+       unset and `${DRIFT_REPO:-$HOME/workspace/devrc}` resolves to the real
+       clone. Those `git` calls are made by a grandchild process. A
+       `subprocess` patch inside the pytest process cannot observe them at all;
+       only something inherited through the environment can.
+
+  L2 — IN-PROCESS, BY BASENAME (`_patch_subprocess()`).
+       PATH cannot shadow an ABSOLUTE path, and this tree contains
+       absolute-path git invocations. L2 keys on the basename of argv[0] and
+       rewrites the launch to the shim, so an absolute reach lands in the same
+       log and under the same policy. Its stated limit is identical to the
+       launcher policy's: it sees only launches made by THIS python process, so
+       a child that execs an absolute git path is invisible to both layers.
+
+🔴 THIS IS AN INVARIANT, NOT A CLEANUP
+---------------------------------------
+Stated because the obvious alternative was tried and failed in this very
+incident: the offending test DID restore the `origin` URL it clobbered, and the
+real clone was nevertheless found still poisoned long after every run had
+ended — because a restore only happens on clean teardown, and a killed or
+failing run skips it. Anything whose safety depends on teardown running is
+therefore not a fix. The shim refuses the write at the moment of the call, so
+there is nothing to undo and a crash mid-test cannot leave damage behind.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from . import nogit
+
+# Written to the log once per pytest SESSION — the per-target positive control
+# for the plugin itself, exactly as `nolaunch_plugin.SESSION_MARKER` is. A
+# target with no marker never loaded this plugin, and a guard that never loaded
+# is indistinguishable from a guard that found nothing: both produce a clean
+# log. The marker is what separates those two.
+SESSION_MARKER = "nogit(session)"
+
+
+def _log_marker(stub_dir: Path, note: str) -> None:
+    log = nogit.log_path(stub_dir)
+    log.parent.mkdir(parents=True, exist_ok=True)
+    with log.open("a", encoding="utf-8") as fh:
+        fh.write(f"{SESSION_MARKER} {note}\n")
+
+
+def _inherited_stub_dir() -> Path | None:
+    """The shim dir an outer runner already installed, if there is one.
+
+    Verified, not trusted — an env var naming a directory that does not carry
+    the shim would silently downgrade this session to no protection at all,
+    which is the failure mode that looks exactly like success.
+    """
+    raw = os.environ.get(nogit.STUB_DIR_ENV)
+    if not raw:
+        return None
+    d = Path(raw)
+    if not (d / "git").exists():
+        return None
+    return d
+
+
+# --------------------------------------------------------------------------- #
+# L2 — in-process interception of ABSOLUTE-path git launches
+# --------------------------------------------------------------------------- #
+_ORIGINAL_POPEN = subprocess.Popen
+
+
+def _redirect_argv(argv, stub_dir: Path):
+    """Rewrite an absolute-path `git` invocation to the shim. Else None.
+
+    Deliberately narrow, for the same reason `nolaunch_plugin._redirect_argv`
+    is — it must not perturb the thousands of tests that have nothing to do
+    with this:
+      * only a LIST/TUPLE argv (a `shell=True` string goes through /bin/sh,
+        which resolves on PATH, so L1 already owns it);
+      * only when argv[0] contains a path separator (a bare `git` is a PATH
+        lookup — L1's job, and rewriting it here would HIDE L1 breaking);
+      * only when the basename is exactly `git`;
+      * never when it already points into the shim dir.
+    """
+    if not isinstance(argv, (list, tuple)) or not argv:
+        return None
+    first = argv[0]
+    if isinstance(first, bytes):
+        first = os.fsdecode(first)
+    if not isinstance(first, str) or os.sep not in first:
+        return None
+    if os.path.basename(first) != "git":
+        return None
+    try:
+        if Path(first).resolve().parent == Path(stub_dir).resolve():
+            return None
+    except OSError:  # pragma: no cover — a path that cannot be resolved
+        pass
+    return [str(Path(stub_dir) / "git"), *list(argv)[1:]]
+
+
+def _patch_subprocess(stub_dir: Path):
+    """Route absolute-path git calls through the shim.
+
+    `Popen` is the choke point: `run`, `call`, `check_call` and `check_output`
+    all go through it, so patching it once covers the module rather than four
+    names that must each be remembered.
+    """
+    class _NoGitPopen(_ORIGINAL_POPEN):
+        def __init__(self, args, *a, **kw):
+            redirected = _redirect_argv(args, stub_dir)
+            if redirected is not None:
+                log = nogit.log_path(stub_dir)
+                with log.open("a", encoding="utf-8") as fh:
+                    fh.write("git(abs) %s\n"
+                             % " ".join(str(x) for x in list(args)[1:]))
+                args = redirected
+            super().__init__(args, *a, **kw)
+
+    subprocess.Popen = _NoGitPopen
+    return _ORIGINAL_POPEN
+
+
+# --------------------------------------------------------------------------- #
+# The fixture
+# --------------------------------------------------------------------------- #
+@pytest.fixture(scope="session", autouse=True)
+def no_real_git_writes(tmp_path_factory):
+    """Put a policy-enforcing `git` first on PATH for the whole session.
+
+    Session-scoped and AUTOUSE, for the reason the launcher fixture is:
+    protection a test has to remember to ask for is protection the next test
+    forgets — and the test that forgets is the one that renames a branch in the
+    operator's clone.
+
+    The allowed roots include this session's pytest basetemp, so a fixture that
+    builds a clone under `tmp_path` writes freely and every legitimate git
+    operation in the suite is untouched. The DENIED root is the tree under
+    test, and it wins over the allow-list — which is what keeps the policy live
+    in the nix sandbox, where the source is unpacked under `$TMPDIR` and would
+    otherwise be inside an allowed root.
+    """
+    basetemp = Path(tmp_path_factory.getbasetemp()).resolve()
+    allowed = nogit.default_roots(basetemp)
+    denied = nogit.denied_roots()
+
+    inherited = _inherited_stub_dir()
+    if inherited is not None:
+        stub_dir = inherited
+    else:
+        stub_dir = Path(tmp_path_factory.mktemp("nogit"))
+        # install() BEFORE the prepend — the shim resolves the real binary via
+        # `shutil.which`, so a shim dir already on PATH makes it exec ITSELF.
+        #
+        # The roots are BAKED IN here, not left to the environment: a test that
+        # builds a replacing `env=` dict (keeping only HOME/PATH/GIT_CONFIG_*)
+        # still reaches the shim through PATH, and would otherwise run it with
+        # no policy at all. Three such tests exist in this suite.
+        nogit.install(stub_dir, allowed=allowed, denied=denied)
+
+    prev = {k: os.environ.get(k) for k in (
+        "PATH", nogit.STUB_DIR_ENV, nogit.ROOTS_ENV, nogit.DENY_ROOTS_ENV,
+        *nogit.GIT_LOCATION_ENV)}
+
+    # 🔴 Scrub the repository-location environment for the whole session.
+    #
+    # An AMBIENT `GIT_DIR` is the reproduced mechanism of the incident: it
+    # redirects a `git -C <fixture>` write into whatever repo it names, while
+    # `--show-toplevel` still reports the fixture. A pytest session has no
+    # business inheriting any of these, so they are removed rather than
+    # validated.
+    #
+    # 🔴 THIS IS THE WEAKEST LAYER, AND IT IS NOT THE GUARD. It only helps when
+    # the variable arrives from OUTSIDE. A test that sets `GIT_DIR` itself —
+    # in an `env=` dict, a `monkeypatch.setenv`, or a shell it spawns — hands
+    # it straight to the child and this scrub never sees it. The shim's
+    # per-call check is what covers that case, and it is the thing to keep
+    # working if these two ever disagree.
+    for var in nogit.GIT_LOCATION_ENV:
+        os.environ.pop(var, None)
+
+    entries = [p for p in prev["PATH"].split(os.pathsep) if p] if prev["PATH"] else []
+    # FIRST, unconditionally. A later entry cannot shadow a real binary sitting
+    # in an earlier one, so "on PATH" is not the property that matters —
+    # "before every ambient entry" is.
+    if not entries or entries[0] != str(stub_dir):
+        os.environ["PATH"] = str(stub_dir) + os.pathsep + (prev["PATH"] or "")
+    os.environ[nogit.STUB_DIR_ENV] = str(stub_dir)
+    # Also exported, so a test can READ the policy and a child that inherits
+    # the environment sees the same values the shim was built with. The baked
+    # copy is what makes the policy hold when this does not survive.
+    os.environ[nogit.ROOTS_ENV] = allowed
+    os.environ[nogit.DENY_ROOTS_ENV] = denied
+
+    original_popen = _patch_subprocess(stub_dir)
+    _log_marker(stub_dir, " ".join(sys.argv[1:]) or "(no args)")
+    try:
+        yield stub_dir
+    finally:
+        subprocess.Popen = original_popen
+        for k, v in prev.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v

--- a/scripts/testlib/nogit_plugin.py
+++ b/scripts/testlib/nogit_plugin.py
@@ -1,43 +1,60 @@
 #!/usr/bin/env python3
-"""The ONE place that makes "a test cannot WRITE to a repo it does not own"
-true.
+"""The wiring that makes "a test cannot WRITE to a repo it does not own" true.
 
 Read `testlib/nogit.py` first — it carries the measurement, the reflog excerpt
-and the reasoning for the read/write split. This module is only the wiring, and
-it is deliberately the same wiring as `testlib/nolaunch_plugin.py`: one
-implementation, registered from `scripts/tests/conftest.py` so a bare
-`pytest scripts/tests` is covered, and exposed through `python -m
-testlib.nogit` so the runner can install one shim for a whole run.
+and the reasoning for the read/write split. This module is only the wiring.
 
-🔴 WHY THE SAME SHAPE AND NOT A NEW ONE
-----------------------------------------
-`nolaunch_plugin` exists in its current form because the previous one lived in
-a single `conftest.py` and therefore protected 1 pytest target of 17 — the
-declarations-vs-instances trap: one enforcement SITE that read as systemic
-while covering a seventeenth of the surface. Copying a fixture into N conftests
-is what produced that, twice (#399 and #614). So this module is the rule, once,
-and the places that need it register it rather than reimplementing it.
+🔴 WHAT THIS MODULE DOES **NOT** CLAIM — REGISTRATION SCOPE
+------------------------------------------------------------
+`scripts/run-tests.sh` runs ONE pytest process per target and there are 25 of
+them. This module is registered from `scripts/tests/conftest.py` ONLY, so a
+bare `pytest scripts/tests` is covered and **the other 24 targets are not**.
+MEASURED, running the same write through each target's own pytest process:
+`scripts/tests` -> rc 99 (refused); `scripts/repo-cos/tests` — which contains
+the culprit `test_prescan.py::_init_clone` — -> **rc 0, the write landed**;
+`scripts/dl-router/tests` -> rc 0.
 
-🔴 TWO LAYERS, FOR THE SAME REASON AS THE LAUNCHER POLICY
-----------------------------------------------------------
-  L1 — PROCESS BOUNDARY (`nogit.install()` + PATH[0]).
-       This is the layer that matters, and unlike the launcher case it is not
-       merely the broader one — it is the ONLY one that can see the hazard.
-       The callers that resolve a repo for themselves are shell scripts the
-       tests spawn: `drift-check.sh` pipes its remote leg through `ssh … bash
-       -s`, and with a stub `ssh` that leg runs LOCALLY, where `DRIFT_REPO` is
-       unset and `${DRIFT_REPO:-$HOME/workspace/devrc}` resolves to the real
-       clone. Those `git` calls are made by a grandchild process. A
-       `subprocess` patch inside the pytest process cannot observe them at all;
-       only something inherited through the environment can.
+That gap is NOT closed here, deliberately. `scripts/run-tests.sh` belongs to
+another change which registers ITS guard with `-p` on the single pytest command
+line, and `-p` reaches every target regardless of conftest inheritance. Adding
+a second `-p`, or a second auto-loading `scripts/conftest.py`, would put two
+plugins on the same class — the exact collision measured below with `Popen`.
+So the runner registration is that change's to own, and the residual gap is
+stated rather than papered over.
+
+(A single `scripts/conftest.py` WOULD close it: measured, pytest auto-loads it
+for all 13 sampled targets, directory and file targets alike, with no runner
+edit. It is not added here only because it would duplicate enforcement.)
+
+🔴 TWO LAYERS
+--------------
+  L1 — PROCESS BOUNDARY (`nogit.install()` + PATH + `GIT_EXEC_PATH`).
+       The layer that matters. The callers that resolve a repo for themselves
+       are shell scripts the tests spawn, and their `git` calls are made by a
+       grandchild process; a `subprocess` patch inside the pytest process
+       cannot observe them at all. `GIT_EXEC_PATH` is what extends this to
+       git's OWN children — see `nogit.exec_path_farm()` for the measurement
+       that made it necessary.
 
   L2 — IN-PROCESS, BY BASENAME (`_patch_subprocess()`).
        PATH cannot shadow an ABSOLUTE path, and this tree contains
        absolute-path git invocations. L2 keys on the basename of argv[0] and
-       rewrites the launch to the shim, so an absolute reach lands in the same
-       log and under the same policy. Its stated limit is identical to the
-       launcher policy's: it sees only launches made by THIS python process, so
-       a child that execs an absolute git path is invisible to both layers.
+       rewrites the launch to the shim.
+
+🔴 L2 WAS COMPLETELY INERT, AND THE MECHANISM IS WORTH STATING
+---------------------------------------------------------------
+MEASURED: `subprocess.Popen.__mro__` during a session was
+`['_NoLaunchPopen', 'Popen', 'object']` — this module's class was simply GONE,
+and an absolute-path `git config` against a denied repo returned 0 with no
+banner. Both plugins captured the PRISTINE `subprocess.Popen` at IMPORT time
+and each assigned its own subclass *of that pristine class*, so whichever
+fixture ran last discarded the other's patch entirely; and each teardown
+restored the pristine class, discarding the survivor too.
+
+The fix is to capture whatever `subprocess.Popen` IS at PATCH time, subclass
+that, and restore that — then the two compose in either order.
+`test_both_launch_policies_survive_in_the_popen_chain` pins it, because a
+silently-inert layer is indistinguishable from a working one.
 
 🔴 THIS IS AN INVARIANT, NOT A CLEANUP
 ---------------------------------------
@@ -45,9 +62,8 @@ Stated because the obvious alternative was tried and failed in this very
 incident: the offending test DID restore the `origin` URL it clobbered, and the
 real clone was nevertheless found still poisoned long after every run had
 ended — because a restore only happens on clean teardown, and a killed or
-failing run skips it. Anything whose safety depends on teardown running is
-therefore not a fix. The shim refuses the write at the moment of the call, so
-there is nothing to undo and a crash mid-test cannot leave damage behind.
+failing run skips it. The shim refuses the write at the moment of the call, so
+there is nothing to undo.
 """
 from __future__ import annotations
 
@@ -61,32 +77,95 @@ import pytest
 from . import nogit
 
 # Written to the log once per pytest SESSION — the per-target positive control
-# for the plugin itself, exactly as `nolaunch_plugin.SESSION_MARKER` is. A
-# target with no marker never loaded this plugin, and a guard that never loaded
-# is indistinguishable from a guard that found nothing: both produce a clean
-# log. The marker is what separates those two.
+# for the plugin itself. A target with no marker never loaded this plugin, and
+# a guard that never loaded is indistinguishable from a guard that found
+# nothing: both produce a clean log.
 SESSION_MARKER = "nogit(session)"
 
+# The names the marker's `via=` field can carry.
+VIA_SELF = "self"
+VIA_INHERITED = "inherited"
 
-def _log_marker(stub_dir: Path, note: str) -> None:
+
+class ForeignGitShim(RuntimeError):
+    """`DEVRC_TEST_GIT_STUB_DIR` names something that is not this policy's shim."""
+
+
+def _log_marker(stub_dir: Path, note: str, via: str) -> None:
+    """Record the session marker, INCLUDING how the shim was obtained.
+
+    🔴 `via=` exists because the marker used to be written identically whether
+    this session installed the shim or adopted an inherited one — so a run that
+    adopted a FOREIGN `git` and installed nothing at all still reported a
+    healthy marker. The field makes those two states distinguishable in the log
+    a runner reads.
+    """
     log = nogit.log_path(stub_dir)
     log.parent.mkdir(parents=True, exist_ok=True)
     with log.open("a", encoding="utf-8") as fh:
-        fh.write(f"{SESSION_MARKER} {note}\n")
+        fh.write(f"{SESSION_MARKER} via={via} {note}\n")
 
 
 def _inherited_stub_dir() -> Path | None:
-    """The shim dir an outer runner already installed, if there is one.
+    """The shim dir an outer runner already installed — VERIFIED BY CONTENT.
 
-    Verified, not trusted — an env var naming a directory that does not carry
-    the shim would silently downgrade this session to no protection at all,
-    which is the failure mode that looks exactly like success.
+    🔴 THE PREVIOUS VERSION OF THIS FUNCTION WAS A SPELLED GUARD, AND IT WAS
+    WALKED. It adopted any directory whose `DEVRC_TEST_GIT_STUB_DIR` contained
+    a FILE NAMED `git`, then skipped `install()` entirely — while its own
+    docstring claimed it verified the shim. MEASURED with the variable pointed
+    at a plain passthrough script: a write to the repo-under-test landed
+    **rc 0, no banner**, the session marker was written anyway, and pytest
+    reported "1 passed". A filename is walkable by anything called `git`.
+
+    It now asks the shim to prove itself (`nogit.handshake`), which no foreign
+    binary can answer and no OLDER revision of this policy can answer either —
+    the token is a hash of the policy's own generated body.
+
+    🔴 A FAILED HANDSHAKE RAISES RATHER THAN FALLING BACK. Falling back to
+    self-installation would be safe for this session but would silently hide a
+    misconfigured outer runner, which is the state that produced the measured
+    "1 passed" above. The session fails and names the directory.
+
+    🔴 A SHIM THAT IS OURS BUT SCOPED TO ANOTHER TREE RETURNS None INSTEAD —
+    self-install, do not raise. See the deny-floor branch for the measurement
+    that forced the distinction.
     """
     raw = os.environ.get(nogit.STUB_DIR_ENV)
     if not raw:
         return None
     d = Path(raw)
-    if not (d / "git").exists():
+    answer = nogit.handshake(d)
+    if answer is None:
+        raise ForeignGitShim(
+            f"{nogit.STUB_DIR_ENV}={raw!r} does not hold THIS policy's git "
+            f"shim: it did not answer `{nogit.HANDSHAKE_FLAG}` with "
+            f"`{nogit.HANDSHAKE_MAGIC} {nogit.policy_fingerprint()}`. That is "
+            "either a foreign `git`, or a shim generated by a different "
+            "revision of testlib/nogit.py. Adopting it would run this session "
+            "with NO git policy while still writing a healthy session marker — "
+            "measured, that reports '1 passed' with the guard absent. Unset "
+            f"{nogit.STUB_DIR_ENV} to let this session install its own.")
+    # 🔴 GENUINELY OURS, BUT SCOPED TO A DIFFERENT TREE -> SELF-INSTALL, DO NOT
+    # RAISE. The deny floor is what keeps the policy live in the nix sandbox
+    # (where the source sits inside an allowed root), so an inherited shim that
+    # does not carry THIS tree is not usable as-is.
+    #
+    # Raising here was measured to be WRONG, and the case is ordinary: several
+    # tests in this suite COPY the repo to a tmp dir and run a nested pytest in
+    # it. The nested session inherits `DEVRC_TEST_GIT_STUB_DIR` from the outer
+    # one, its `repo_root()` is the copy, and the outer shim's baked deny roots
+    # name the original — a perfectly healthy arrangement that a raise turned
+    # into nine red tests. Installing our own correctly-scoped shim is both
+    # safe and what the caller wants; `via=` records that it happened.
+    #
+    # The FOREIGN case above still raises, because there the question is not
+    # "which tree" but "is this a guard at all".
+    denied = [p for p in answer.get("denied", "").split(":") if p]
+    if str(nogit.repo_root()) not in denied:
+        return None
+    # An inherited shim in AUDIT mode records violations and lets every one of
+    # them through. Same treatment: replace it rather than adopt it.
+    if answer.get("audit") == "1":
         return None
     return d
 
@@ -94,21 +173,33 @@ def _inherited_stub_dir() -> Path | None:
 # --------------------------------------------------------------------------- #
 # L2 — in-process interception of ABSOLUTE-path git launches
 # --------------------------------------------------------------------------- #
-_ORIGINAL_POPEN = subprocess.Popen
-
-
-def _redirect_argv(argv, stub_dir: Path):
+def _redirect_argv(argv, stub_dir: Path, tmp_root: Path | None = None):
     """Rewrite an absolute-path `git` invocation to the shim. Else None.
 
-    Deliberately narrow, for the same reason `nolaunch_plugin._redirect_argv`
-    is — it must not perturb the thousands of tests that have nothing to do
-    with this:
+    Deliberately narrow, so it cannot perturb the thousands of tests that have
+    nothing to do with this:
       * only a LIST/TUPLE argv (a `shell=True` string goes through /bin/sh,
         which resolves on PATH, so L1 already owns it);
       * only when argv[0] contains a path separator (a bare `git` is a PATH
         lookup — L1's job, and rewriting it here would HIDE L1 breaking);
       * only when the basename is exactly `git`;
-      * never when it already points into the shim dir.
+      * never when it already points into the shim dir or its exec-path farm;
+      * never when it lives inside THIS SESSION'S tmp tree.
+
+    🔴 THE LAST EXCLUSION IS NOT TIDINESS — WITHOUT IT, L2 REPLACES A TEST'S
+    OWN INSTRUMENT WITH THE GUARD. MEASURED as two red tests the moment L2
+    started working: `scripts/tests/test_ship_converge.py::_git_shim` builds a
+    `git` under `tmp_path` that is real for every subcommand except one
+    deliberately sabotaged verb, then calls it by absolute path to prove
+    `ship.sh`'s currency guard reacts. L2 rewrote that call to the shim, the
+    sabotage never happened, `ls-files` returned its real output, and the test
+    failed on an assertion about the guard it was validating.
+
+    A `git` a test built inside its own tmp tree is a DOUBLE, not a reach
+    around PATH to the real binary — which is the only thing L2 exists to
+    catch. It is also not an escape: such a double resolves whatever it
+    delegates to through `PATH` (or a `shutil.which` taken inside the session),
+    both of which lead back to the shim.
     """
     if not isinstance(argv, (list, tuple)) or not argv:
         return None
@@ -120,33 +211,44 @@ def _redirect_argv(argv, stub_dir: Path):
     if os.path.basename(first) != "git":
         return None
     try:
-        if Path(first).resolve().parent == Path(stub_dir).resolve():
+        resolved = Path(first).resolve()
+        if resolved.parent in (Path(stub_dir).resolve(),
+                               nogit.exec_path_dir(stub_dir).resolve()):
+            return None
+        if tmp_root is not None and resolved.is_relative_to(
+                Path(tmp_root).resolve()):
             return None
     except OSError:  # pragma: no cover — a path that cannot be resolved
         pass
     return [str(Path(stub_dir) / "git"), *list(argv)[1:]]
 
 
-def _patch_subprocess(stub_dir: Path):
-    """Route absolute-path git calls through the shim.
+def _patch_subprocess(stub_dir: Path, tmp_root: Path | None = None):
+    """Route absolute-path git calls through the shim; return what to restore.
 
-    `Popen` is the choke point: `run`, `call`, `check_call` and `check_output`
-    all go through it, so patching it once covers the module rather than four
-    names that must each be remembered.
+    🔴 SUBCLASSES WHATEVER `subprocess.Popen` IS RIGHT NOW, not a pristine copy
+    captured at import. See this module's docstring for the measurement — with
+    an import-time capture the two launch policies silently deleted each
+    other's patch and L2 was inert.
     """
-    class _NoGitPopen(_ORIGINAL_POPEN):
+    current = subprocess.Popen
+
+    class _NoGitPopen(current):  # type: ignore[misc,valid-type]
         def __init__(self, args, *a, **kw):
-            redirected = _redirect_argv(args, stub_dir)
+            redirected = _redirect_argv(args, stub_dir, tmp_root)
             if redirected is not None:
                 log = nogit.log_path(stub_dir)
-                with log.open("a", encoding="utf-8") as fh:
-                    fh.write("git(abs) %s\n"
-                             % " ".join(str(x) for x in list(args)[1:]))
+                try:
+                    with log.open("a", encoding="utf-8") as fh:
+                        fh.write("git(abs) %s\n"
+                                 % " ".join(str(x) for x in list(args)[1:]))
+                except OSError:  # pragma: no cover — log dir gone
+                    pass
                 args = redirected
             super().__init__(args, *a, **kw)
 
     subprocess.Popen = _NoGitPopen
-    return _ORIGINAL_POPEN
+    return current
 
 
 # --------------------------------------------------------------------------- #
@@ -162,11 +264,8 @@ def no_real_git_writes(tmp_path_factory):
     operator's clone.
 
     The allowed roots include this session's pytest basetemp, so a fixture that
-    builds a clone under `tmp_path` writes freely and every legitimate git
-    operation in the suite is untouched. The DENIED root is the tree under
-    test, and it wins over the allow-list — which is what keeps the policy live
-    in the nix sandbox, where the source is unpacked under `$TMPDIR` and would
-    otherwise be inside an allowed root.
+    builds a clone under `tmp_path` writes freely. The DENIED root is the tree
+    under test, and it wins over the allow-list.
     """
     basetemp = Path(tmp_path_factory.getbasetemp()).resolve()
     allowed = nogit.default_roots(basetemp)
@@ -175,6 +274,7 @@ def no_real_git_writes(tmp_path_factory):
     inherited = _inherited_stub_dir()
     if inherited is not None:
         stub_dir = inherited
+        via = VIA_INHERITED
     else:
         stub_dir = Path(tmp_path_factory.mktemp("nogit"))
         # install() BEFORE the prepend — the shim resolves the real binary via
@@ -185,26 +285,32 @@ def no_real_git_writes(tmp_path_factory):
         # still reaches the shim through PATH, and would otherwise run it with
         # no policy at all. Three such tests exist in this suite.
         nogit.install(stub_dir, allowed=allowed, denied=denied)
+        via = VIA_SELF
 
+    scrubbed = (*nogit.GIT_LOCATION_ENV, *nogit.GIT_EXEC_ENV,
+                nogit.MODE_ENV, "GIT_CONFIG_COUNT", "GIT_EXEC_PATH",
+                "GIT_ALTERNATE_OBJECT_DIRECTORIES")
     prev = {k: os.environ.get(k) for k in (
         "PATH", nogit.STUB_DIR_ENV, nogit.ROOTS_ENV, nogit.DENY_ROOTS_ENV,
-        *nogit.GIT_LOCATION_ENV)}
+        *scrubbed)}
+    # `GIT_CONFIG_KEY_<n>` / `GIT_CONFIG_VALUE_<n>` are indexed, so the names
+    # are not knowable in advance — they are collected from the live env.
+    indexed = [k for k in os.environ
+               if k.startswith(("GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_"))]
+    prev.update({k: os.environ.get(k) for k in indexed})
 
     # 🔴 Scrub the repository-location environment for the whole session.
     #
-    # An AMBIENT `GIT_DIR` is the reproduced mechanism of the incident: it
-    # redirects a `git -C <fixture>` write into whatever repo it names, while
-    # `--show-toplevel` still reports the fixture. A pytest session has no
-    # business inheriting any of these, so they are removed rather than
-    # validated.
+    # An AMBIENT `GIT_DIR` is the reproduced mechanism of the incident.
+    # `MODE_ENV` is scrubbed too: it no longer does anything (the mode is baked
+    # in), but leaving a stale value in the environment invites the next reader
+    # to wire it back up.
     #
     # 🔴 THIS IS THE WEAKEST LAYER, AND IT IS NOT THE GUARD. It only helps when
-    # the variable arrives from OUTSIDE. A test that sets `GIT_DIR` itself —
-    # in an `env=` dict, a `monkeypatch.setenv`, or a shell it spawns — hands
-    # it straight to the child and this scrub never sees it. The shim's
-    # per-call check is what covers that case, and it is the thing to keep
-    # working if these two ever disagree.
-    for var in nogit.GIT_LOCATION_ENV:
+    # the variable arrives from OUTSIDE. A test that sets `GIT_DIR` itself
+    # hands it straight to the child and this scrub never sees it. The shim's
+    # per-call check is what covers that case.
+    for var in (*scrubbed, *indexed):
         os.environ.pop(var, None)
 
     entries = [p for p in prev["PATH"].split(os.pathsep) if p] if prev["PATH"] else []
@@ -214,14 +320,21 @@ def no_real_git_writes(tmp_path_factory):
     if not entries or entries[0] != str(stub_dir):
         os.environ["PATH"] = str(stub_dir) + os.pathsep + (prev["PATH"] or "")
     os.environ[nogit.STUB_DIR_ENV] = str(stub_dir)
+    # 🔴 The exec-path farm, so git's OWN children resolve `git` to the shim.
+    # Without it an alias, hook or filter reaches the real binary at PATH[0] —
+    # measured, and it let `-c 'alias.x=!git -C <victim> commit …' x` write the
+    # victim a commit with the shim installed.
+    farm = nogit.exec_path_dir(stub_dir)
+    if (farm / "git").exists():
+        os.environ["GIT_EXEC_PATH"] = str(farm)
     # Also exported, so a test can READ the policy and a child that inherits
     # the environment sees the same values the shim was built with. The baked
     # copy is what makes the policy hold when this does not survive.
     os.environ[nogit.ROOTS_ENV] = allowed
     os.environ[nogit.DENY_ROOTS_ENV] = denied
 
-    original_popen = _patch_subprocess(stub_dir)
-    _log_marker(stub_dir, " ".join(sys.argv[1:]) or "(no args)")
+    original_popen = _patch_subprocess(stub_dir, basetemp)
+    _log_marker(stub_dir, " ".join(sys.argv[1:]) or "(no args)", via)
     try:
         yield stub_dir
     finally:

--- a/scripts/testlib/nolaunch_plugin.py
+++ b/scripts/testlib/nolaunch_plugin.py
@@ -106,7 +106,10 @@ def _inherited_stub_dir() -> Path | None:
 # --------------------------------------------------------------------------- #
 # L2 — in-process interception of ABSOLUTE-path launches
 # --------------------------------------------------------------------------- #
-_ORIGINAL_POPEN = subprocess.Popen
+# 🔴 DELIBERATELY NOT CAPTURED HERE. An import-time snapshot of
+# `subprocess.Popen` is what made this policy and `nogit_plugin` delete each
+# other's patch — see `_patch_subprocess` for the measurement. The class to
+# subclass, and the class to restore, are both read at PATCH time.
 
 
 def _redirect_argv(argv, stub_dir: Path):
@@ -145,8 +148,27 @@ def _patch_subprocess(stub_dir: Path):
     Popen is the choke point: `run`, `call`, `check_call` and `check_output` all
     go through it, so patching it once covers the whole module rather than four
     names that must each be remembered.
+
+    🔴 SUBCLASSES WHATEVER `subprocess.Popen` IS RIGHT NOW, not the pristine
+    class captured at import.
+
+    MEASURED: with the import-time capture, this policy and `nogit_plugin` —
+    both session-autouse, both subclassing the pristine class, both restoring
+    it — silently DELETED each other. `subprocess.Popen.__mro__` during a
+    session was `['_NoLaunchPopen', 'Popen', 'object']`: the other policy's L2
+    was simply gone, and an absolute-path `git` write against a denied repo
+    returned 0 with no banner. Whichever fixture happened to run last won, and
+    nothing was red.
+
+    Capturing here rather than at import makes the two compose in either
+    order, and the teardown restores what was live when this patch was applied
+    instead of unwinding the other policy as well.
+    `scripts/tests/test_no_real_git_remote.py::
+    test_both_launch_policies_survive_in_the_popen_chain` pins it.
     """
-    class _NoLaunchPopen(_ORIGINAL_POPEN):
+    current = subprocess.Popen
+
+    class _NoLaunchPopen(current):  # type: ignore[misc,valid-type]
         def __init__(self, args, *a, **kw):
             redirected = _redirect_argv(args, stub_dir)
             if redirected is not None:
@@ -158,7 +180,7 @@ def _patch_subprocess(stub_dir: Path):
             super().__init__(args, *a, **kw)
 
     subprocess.Popen = _NoLaunchPopen
-    return _ORIGINAL_POPEN
+    return current
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -42,3 +42,22 @@ from testlib.nolaunch_plugin import STUB_DIR_ENV, no_real_launchers  # noqa: E40
 # calls scattered through this directory stay as defence in depth — they narrow
 # the spool per test, which this session-wide floor deliberately does not.
 from testlib.spool_plugin import no_real_activity_spool  # noqa: E402,F401
+
+# 🔴 The SAME shape again, for GIT. `testlib/nogit_plugin.py` is the
+# implementation and this import is one entry point; the runner loads the same
+# module for every target, so this is not a per-directory copy.
+#
+# It exists because the suite drove `git commit`, `git branch -m`, `git config
+# core.bare true`, `remote set-url` and `git push` against the operator's REAL
+# clone — the local reflog puts the `main → trunk` rename at 19:21:35Z and the
+# ~40-push storm onto `refs/heads/main` at 19:28:14Z, seven minutes later. The
+# offending code RESTORED the URL it clobbered, so every after-the-fact check
+# reported a clean repo; the only way to see it was `git remote -v` in the real
+# clone WHILE the suite ran.
+#
+# The policy is therefore an invariant at the moment of the call, not a
+# cleanup: a shim first on PATH that lets READS through anywhere and refuses
+# WRITES to any repo outside this session's tmp roots. Read
+# `testlib/nogit.py` before changing it — in particular the read-verb ledger,
+# which is an allowlist so an unknown verb fails CLOSED.
+from testlib.nogit_plugin import no_real_git_writes  # noqa: E402,F401

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -43,9 +43,21 @@ from testlib.nolaunch_plugin import STUB_DIR_ENV, no_real_launchers  # noqa: E40
 # the spool per test, which this session-wide floor deliberately does not.
 from testlib.spool_plugin import no_real_activity_spool  # noqa: E402,F401
 
-# 🔴 The SAME shape again, for GIT. `testlib/nogit_plugin.py` is the
-# implementation and this import is one entry point; the runner loads the same
-# module for every target, so this is not a per-directory copy.
+# 🔴 GIT — and unlike the two above, this import is the ONLY entry point.
+#
+# The runner does NOT load `testlib.nogit_plugin`, so this registration covers
+# `scripts/tests` and NOTHING ELSE. MEASURED, per target: `scripts/tests` -> rc
+# 99 (refused); `scripts/repo-cos/tests`, which contains the culprit
+# `test_prescan.py::_init_clone`, -> **rc 0, the write landed**;
+# `scripts/dl-router/tests` -> rc 0. 1 target of 25, and not the culprit's.
+#
+# That is stated rather than closed here on purpose: `scripts/run-tests.sh`
+# belongs to another change which registers ITS guard with `-p` on the single
+# pytest line, and `-p` reaches every target regardless of conftest
+# inheritance. A second registration — here, or via an auto-loaded
+# `scripts/conftest.py` — would put two plugins on the same class, which is the
+# collision already measured with `subprocess.Popen`. Read
+# `testlib/nogit_plugin.py`'s "REGISTRATION SCOPE" header before changing this.
 #
 # It exists because the suite drove `git commit`, `git branch -m`, `git config
 # core.bare true`, `remote set-url` and `git push` against the operator's REAL
@@ -56,8 +68,11 @@ from testlib.spool_plugin import no_real_activity_spool  # noqa: E402,F401
 # clone WHILE the suite ran.
 #
 # The policy is therefore an invariant at the moment of the call, not a
-# cleanup: a shim first on PATH that lets READS through anywhere and refuses
-# WRITES to any repo outside this session's tmp roots. Read
+# cleanup: a shim that lets READS through anywhere and refuses WRITES to any
+# repo outside this session's tmp roots. It is reached through PATH **and**
+# through `GIT_EXEC_PATH` — PATH alone is not enough, because git prepends its
+# own `libexec/git-core` (which ships a real `git`) for every child it spawns,
+# so aliases, hooks and filters escaped a PATH-only shim entirely. Read
 # `testlib/nogit.py` before changing it — in particular the read-verb ledger,
 # which is an allowlist so an unknown verb fails CLOSED.
 from testlib.nogit_plugin import no_real_git_writes  # noqa: E402,F401

--- a/scripts/tests/test_no_real_git_remote.py
+++ b/scripts/tests/test_no_real_git_remote.py
@@ -1,65 +1,61 @@
 """🔴 The guard: no test may WRITE to a git repo it does not own.
 
 This file exists because the suite drove `git` against the operator's REAL
-clone and destroyed `main` on the remote. The ordering is the diagnosis, so it
-is recorded here rather than only in a PR body:
+clone and destroyed `main` on the remote. The ordering is the diagnosis:
 
     $ git -C ~/workspace/devrc reflog show trunk
     5d91acdd trunk@{0}: Branch: renamed refs/heads/main to refs/heads/trunk
     5d91acdd trunk@{1}: commit: seed
     2e7a85b3 trunk@{2}: commit: c
 
-    HEAD reflog (local, UTC-5):
-      13:48:11  merge origin/main: Fast-forward   <- last legitimate operation
-      14:21:35  Branch: renamed main to trunk     = 19:21:35Z
-      14:38:36  HEAD at 14200130 (a single-file tree)
-
 Local corruption at **19:21:35Z**; the remote push storm — ~40 pushes onto
-`refs/heads/main` in 43 seconds, four other branches hit — began **19:28:14Z**,
-seven minutes LATER. So the local writes came first and the pushes followed
-them. That rules out an independently-poisoned remote and pins the mechanism as
-"something resolved a repo for itself, then pushed what it found".
+`refs/heads/main` in 43 seconds — began **19:28:14Z**, seven minutes LATER. The
+local writes came first and the pushes followed them, which rules out an
+independently-poisoned remote and is why a push-scoped or remote-scoped guard
+would have been useless.
 
-🔴 IT IS WHY A PUSH-SCOPED OR REMOTE-SCOPED GUARD WOULD BE USELESS. The whole
-first phase — `commit`, `branch -m`, `config core.bare true` — is local, and a
-guard watching remotes would have let all of it through. The assertions below
-therefore cover LOCAL porcelain with no reference to whether anything would
-ever be pushed.
+🔴 HOW THIS FILE IS BUILT, AND WHY THE PREVIOUS SHAPE WAS WORTH ~4× ITS VALUE
+------------------------------------------------------------------------------
+The previous revision asserted, for each vector, "the guard returned 99 AND the
+victim is byte-identical". Running each vector's identical command **with the
+guard removed** showed that of 11 entries only **3** could move the victim on
+an axis the comparison actually looked at: 4 wrote bytes the comparison was
+blind to, and 4 moved nothing at all — for those, "the victim is unchanged" was
+equally true with the guard DELETED. A vector that cannot move the victim is
+not evidence about the guard.
 
-🔴 AND WHY CLEANUP IS NOT A FIX. The offending code restored the `origin` URL
-it clobbered, so an after-the-fact `git remote -v` showed a clean repo; the
-only way to see it was to look WHILE the suite ran. A restore also only happens
-on clean teardown, and the real clone was found still poisoned long after every
-run had ended. `test_a_restore_afterwards_does_not_hide_the_write` pins that
-the guard fires at the moment of the call, so there is nothing to undo.
+So every negative control here runs THREE ways, and `_expect_closed` is the
+only way a hazard is scored:
 
-SCOPE, stated so the title cannot be read as more than it is: this covers what
-`testlib/nogit_plugin.py` is loaded into. It bounds writes by TARGET PATH, so
-it cannot stop a test that clobbers PATH wholesale, and its in-process layer
-sees only launches made by the pytest process itself.
+  NOOP      build the fixtures and run NOTHING. The victim must not move.
+            This is the probe validating ITSELF — a sibling implementation had
+            two findings contaminated by the probe creating the very file it
+            then scored as a leak.
+  UNGUARDED run the identical argv against the real binary with the shim off
+            PATH. The victim MUST move, or the case is vacuous and is reported
+            as such rather than counted.
+  GUARDED   run it through the shim. The victim must not move, and the refusal
+            must carry this policy's banner.
 
-What is asserted, and why none is enough alone:
+`_victim_state` is a full byte manifest of the victim tree plus its ref list,
+because the previous narrow tuple (HEAD, branch, count, user.email, one file)
+was blind to loose objects, to `.git/index`, and to `.gitconfig` creation —
+which is what made four live vectors score as uninformative.
 
-  * RESOLUTION — `which("git")` lands in the shim dir.
-  * ORDERING   — the shim dir is PATH[0]. "On PATH" is not the property that
-    matters; "before every ambient entry" is.
-  * READS PASS — the suite reads the real repo on purpose (`ls-files` in four
-    content gates). A guard that broke those would be switched off in a day,
-    so the read path is asserted to reach the REAL binary and forward its
-    output faithfully.
-  * WRITES BLOCK — with this policy's own exit code and banner, so a firing is
-    identifiable rather than a puzzling git error.
-  * FAIL-CLOSED — an unknown verb blocks. A blocklist would fail OPEN on the
-    next verb someone reaches for, which is exactly how `remote` got through.
-  * THE LEDGER — the read-verb set is pinned, so it fails when it GROWS or
-    SHRINKS.
-  * AUTOUSE — one test deliberately does not request the fixture.
-  * THE MUTATION — the same command is run with the shim removed and asserted
-    to SUCCEED, so "blocked" is attributed to the guard and not to the command
-    being impossible anyway.
+SCOPE, stated so the title cannot be read as more than it is:
+  * This covers what `testlib/nogit_plugin.py` is loaded into, which is
+    `scripts/tests` and no other target. See that module's REGISTRATION SCOPE
+    header for the measurement and why the gap is not closed here.
+  * It bounds writes by TARGET PATH, so a test that clobbers PATH wholesale is
+    outside it.
+  * It cannot bound arbitrary SHELL run by an alias or hook — only the `git`
+    such code spawns. `test_a_shell_alias_writing_the_victim_is_NOT_covered`
+    pins that limit as a measured fact rather than leaving it implied.
 """
 from __future__ import annotations
 
+import contextlib
+import hashlib
 import os
 import shutil
 import subprocess
@@ -72,16 +68,100 @@ SCRIPTS = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SCRIPTS))
 
 from testlib import nogit  # noqa: E402
+from testlib.mockbin import write_exec  # noqa: E402
 from testlib import nogit_plugin  # noqa: E402
 
-TIMEOUT = 60
+TIMEOUT = 90
 
 
 # --------------------------------------------------------------------------- #
 # helpers
 # --------------------------------------------------------------------------- #
+@contextlib.contextmanager
+def _l2_off():
+    """🔴 TAKE THE IN-PROCESS LAYER OUT OF THE WAY FOR AN UNGUARDED CONTROL.
+
+    MEASURED, and it silently invalidated thirteen cases on the first run of
+    this rebuilt battery: every "unguarded" control launched from inside the
+    pytest process goes through `subprocess.Popen`, which L2 has patched — so
+    `subprocess.run([<real git>, …])` was REWRITTEN to the shim and came back
+    **rc 99 with the banner**. The harness reported "this vector is VACUOUS"
+    for thirteen vectors that are demonstrably live outside pytest.
+
+    Removing the shim from `PATH` is NOT enough, because L2 keys on the
+    basename of an ABSOLUTE argv[0] — which is exactly its job. So an
+    unguarded control has to unwind L1 *and* L2, and a control that unwinds
+    only one is measuring the guard it forgot about.
+
+    This walks the `Popen` MRO down to the real `subprocess.Popen` and puts it
+    back for the duration, then restores the full chain — including the
+    launcher policy's patch, which sits in the same chain.
+    """
+    saved = subprocess.Popen
+    base = next((c for c in saved.__mro__
+                 if c.__module__ == "subprocess" and c.__name__ == "Popen"),
+                saved)
+    subprocess.Popen = base
+    try:
+        yield
+    finally:
+        subprocess.Popen = saved
+
+
+def _install(stub: Path, **kw):
+    """`nogit.install`, but resolving the REAL git and dodging L2.
+
+    🔴 A test that calls `nogit.install()` naively gets a shim whose baked
+    `real` is THE SESSION'S OWN SHIM — `shutil.which("git")` inside a live
+    session resolves to PATH[0], which is the session stub dir. The result is a
+    double shim: the new policy runs, then execs the old one, which applies the
+    SESSION's roots on top. Every assertion about the new shim's roots then
+    measures the wrong policy.
+
+    `exec_path_farm()` has the same problem one level down — it asks the
+    resolved binary for `--exec-path` through `subprocess`, which L2 rewrites.
+    """
+    saved = os.environ.get("PATH")
+    os.environ["PATH"] = _real_path()
+    try:
+        with _l2_off():
+            return nogit.install(stub, **kw)
+    finally:
+        if saved is None:
+            os.environ.pop("PATH", None)
+        else:
+            os.environ["PATH"] = saved
+
+
+def _handshake(stub: Path):
+    """`nogit.handshake`, with L2 out of the way.
+
+    In production `_inherited_stub_dir()` runs BEFORE `_patch_subprocess`, so
+    the real call is never redirected. Inside a live session it would be — and
+    a foreign `git` would then be answered by the SESSION's shim, which is how
+    the foreign-shim rejection tests first passed for the wrong reason.
+    """
+    with _l2_off():
+        return nogit.handshake(stub)
+
+
+def _real_path() -> str:
+    """PATH with the shim directory removed — the ambient, unprotected one."""
+    stub = os.environ.get(nogit.STUB_DIR_ENV, "")
+    farm = str(nogit.exec_path_dir(stub)) if stub else ""
+    return os.pathsep.join(
+        p for p in os.environ.get("PATH", "").split(os.pathsep)
+        if p and p != stub and p != farm)
+
+
+def _real() -> str:
+    real = shutil.which("git", path=_real_path())
+    assert real is not None, "no real git outside the shim dir"
+    return real
+
+
 def _git(*args: str, cwd: Path, env: dict | None = None,
-         ) -> subprocess.CompletedProcess:
+         stdin_text: str | None = None) -> subprocess.CompletedProcess:
     """Run git with an EXPLICIT cwd — never inheriting this process's.
 
     `cwd` is keyword-only and required on purpose: a helper with a default cwd
@@ -89,35 +169,110 @@ def _git(*args: str, cwd: Path, env: dict | None = None,
     start in, which is the shape that caused the incident.
     """
     return subprocess.run(["git", *args], cwd=str(cwd), env=env,
-                          capture_output=True, text=True, timeout=TIMEOUT)
+                          input=stdin_text, capture_output=True, text=True,
+                          timeout=TIMEOUT)
 
 
-def _make_repo(path: Path, origin: str | None = None) -> Path:
+def _make_repo(path: Path, origin: str | None = None,
+               tree: dict[str, str] | None = None) -> Path:
     """A real, minimal git repo at `path`, built with the REAL binary.
 
     It bypasses the shim deliberately: these repos are the fixtures the tests
     then point the shim at, and building them through the shim would make every
     test depend on the very thing under test.
+
+    🔴 `tree` EXISTS BECAUSE AN EMPTY SEED MADE A VECTOR VACUOUS. The previous
+    version always seeded with a single `--allow-empty` commit, so the fixture's
+    HEAD tree was EMPTY and `GIT_WORK_TREE=<victim> git -C <fixture> checkout
+    -f HEAD` wrote nothing anywhere — the negative control passed against a
+    command that could not have done damage in the first place. Give a fixture
+    a tree that DIFFERS from the victim's and the same command clobbers the
+    victim's working files.
     """
-    real = shutil.which("git", path=_real_path())
+    real = _real()
     path.mkdir(parents=True, exist_ok=True)
-    run = lambda *a: subprocess.run([real, *a], cwd=str(path), check=True,
-                                    capture_output=True, timeout=TIMEOUT)
+    def run(*a):
+        return subprocess.run([real, *a], cwd=str(path), check=True,
+                              capture_output=True, timeout=TIMEOUT)
     run("init", "-q", "-b", "main")
     run("config", "user.email", "t@example.invalid")
-    run("config", "user.name", "t")
-    run("commit", "-q", "--allow-empty", "-m", "seed")
+    # 🔴 A PER-PATH IDENTITY, SO TWO FIXTURES CANNOT SHARE A COMMIT SHA.
+    # MEASURED as an intermittent failure: with every repo seeded identically
+    # (`t <t@example.invalid>`, message "seed", empty tree), the victim's and
+    # the fixture's seed commits had the SAME sha whenever both were created in
+    # the same second. `GIT_OBJECT_DIRECTORY=<victim>/.git/objects git -C
+    # <fixture> commit` then "worked" — because the fixture's HEAD object
+    # happened to exist in the victim's object store — and failed `fatal: could
+    # not parse HEAD` when the clock ticked between them. A vector whose
+    # liveness depends on a sha collision is not a vector.
+    run("config", "user.name", f"t-{path.name}")
+    if tree:
+        for rel, content in tree.items():
+            p = path / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(content, encoding="utf-8")
+        run("add", "-A")
+        run("commit", "-q", "-m", "seed-tree")
+    else:
+        run("commit", "-q", "--allow-empty", "-m", "seed")
     if origin is not None:
         run("remote", "add", "origin", origin)
     return path
 
 
-def _real_path() -> str:
-    """PATH with the shim directory removed — the ambient, unprotected one."""
-    stub = os.environ.get(nogit.STUB_DIR_ENV, "")
-    return os.pathsep.join(
-        p for p in os.environ.get("PATH", "").split(os.pathsep)
-        if p and p != stub)
+def _victim(path: Path) -> Path:
+    """A repo that must survive every negative control untouched."""
+    real = _real()
+    _make_repo(path)
+    (path / "keep.txt").write_text("PRECIOUS", encoding="utf-8")
+    for a in (("add", "keep.txt"), ("commit", "-q", "-m", "victimseed")):
+        subprocess.run([real, "-C", str(path), *a], check=True,
+                       capture_output=True, timeout=TIMEOUT)
+    return path
+
+
+def _manifest(root: Path) -> dict[str, str]:
+    out: dict[str, str] = {}
+    if not root.exists():
+        return out
+    for p in sorted(root.rglob("*")):
+        k = str(p.relative_to(root))
+        if p.is_file():
+            try:
+                out[k] = hashlib.sha256(p.read_bytes()).hexdigest()[:12]
+            except OSError:
+                out[k] = "<unreadable>"
+        elif p.is_dir():
+            out[k + "/"] = "<dir>"
+        else:
+            out[k] = "<other>"
+    return out
+
+
+def _victim_state(repo: Path) -> tuple:
+    """Everything an intruder could disturb, as one comparable value.
+
+    🔴 A FULL BYTE MANIFEST, not a hand-picked tuple. The previous version
+    compared (HEAD, branch, commit count, user.email, keep.txt) and was
+    therefore blind to loose objects (`GIT_OBJECT_DIRECTORY`,
+    `GIT_COMMON_DIR`, `hash-object -w`), to `.git/index` (`GIT_INDEX_FILE`,
+    `status`), and to a `.gitconfig` created beside the repo
+    (`GIT_CONFIG_GLOBAL`/`_SYSTEM`). Four live vectors scored as "the victim
+    did not change" when bytes had landed in it.
+
+    The ref list is kept alongside because a push creates a ref whose only
+    on-disk trace may be inside `packed-refs`, and reading it through git is
+    the honest way to see it.
+    """
+    real = _real()
+    refs = subprocess.run(
+        [real, "-C", str(repo), "for-each-ref",
+         "--format=%(refname) %(objectname)"],
+        capture_output=True, text=True, timeout=TIMEOUT).stdout
+    head = subprocess.run(
+        [real, "-C", str(repo), "rev-parse", "HEAD"],
+        capture_output=True, text=True, timeout=TIMEOUT).stdout.strip()
+    return (head, refs, _manifest(repo))
 
 
 def _env(*, allowed: str, denied: str, path: str | None = None) -> dict:
@@ -126,7 +281,112 @@ def _env(*, allowed: str, denied: str, path: str | None = None) -> dict:
     e[nogit.DENY_ROOTS_ENV] = denied
     if path is not None:
         e["PATH"] = path
+        # Removing the shim from PATH is not enough to unguard a call: the
+        # exec-path farm would still hand `git` back to the shim for any child.
+        e.pop("GIT_EXEC_PATH", None)
     return e
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE THREE-WAY HAZARD HARNESS
+# --------------------------------------------------------------------------- #
+def _stage(root: Path, builder) -> tuple[Path, list[str], Path, dict, Path]:
+    """Build one throwaway world and ask `builder` for the command to run.
+
+    `builder(root, victim, allowed) -> (argv_after_git, cwd, extra_env, home)`
+    """
+    victim = _victim(root / "victim")
+    allowed = root / "allowed"
+    allowed.mkdir(parents=True, exist_ok=True)
+    home = root / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    argv, cwd, extra, home_override = builder(root, victim, allowed)
+    return victim, argv, cwd, extra, (home_override or home)
+
+
+def _expect_closed(tmp_path: Path, builder, *, name: str) -> None:
+    """Score one hazard the only way a hazard may be scored.
+
+    Fails with a DIFFERENT message for each of the three ways this can go
+    wrong, because "the victim did not change" means three different things
+    depending on which run produced it.
+    """
+    # ---- NOOP: does the probe itself disturb the victim? -------------------
+    noop_root = tmp_path / "noop"
+    noop_root.mkdir()
+    victim, _argv, _cwd, _extra, _home = _stage(noop_root, builder)
+    assert _victim_state(victim) == _victim_state(victim), (
+        f"{name}: the victim's state is not stable between two reads with "
+        "NOTHING run — this probe cannot score anything.")
+    before_noop = _victim_state(victim)
+    after_noop = _victim_state(victim)
+    assert before_noop == after_noop
+
+    # ---- UNGUARDED: is the vector LIVE? ------------------------------------
+    un_root = tmp_path / "unguarded"
+    un_root.mkdir()
+    victim, argv, cwd, extra, home = _stage(un_root, builder)
+    env = _env(allowed=str(un_root / "allowed"), denied=str(victim),
+               path=_real_path())
+    env["HOME"] = str(home)
+    env.update(extra)
+    before = _victim_state(victim)
+    with _l2_off():
+        unguarded = subprocess.run([_real(), *argv], cwd=str(cwd), env=env,
+                                   capture_output=True, text=True,
+                                   timeout=TIMEOUT)
+    after = _victim_state(victim)
+    assert unguarded.returncode != nogit.BLOCK_EXIT, (
+        f"{name}: the UNGUARDED control was itself refused by this policy "
+        f"(rc={nogit.BLOCK_EXIT}). The control is not unguarded — see "
+        "`_l2_off`, which exists because L2 rewrites an absolute-path git "
+        "even when the shim is off PATH.")
+    assert after != before, (
+        f"{name}: with the guard REMOVED the victim did not change "
+        f"(rc={unguarded.returncode}, stderr={unguarded.stderr.strip()[:200]!r}). "
+        "This vector is VACUOUS: the 'refused' result below would be equally "
+        "true of a guard that had been deleted, so it is not evidence. Either "
+        "make the command able to reach the victim, or drop the case.")
+
+    # ---- GUARDED -----------------------------------------------------------
+    g_root = tmp_path / "guarded"
+    g_root.mkdir()
+    victim, argv, cwd, extra, home = _stage(g_root, builder)
+    env = _env(allowed=str(g_root / "allowed"), denied=str(victim))
+    env["HOME"] = str(home)
+    env.update(extra)
+    before = _victim_state(victim)
+    guarded = _git(*argv, cwd=cwd, env=env)
+    after = _victim_state(victim)
+    assert after == before, (
+        f"{name}: the guard returned {guarded.returncode} but the victim "
+        f"CHANGED.\n  argv: git {' '.join(argv)}\n"
+        f"  stderr: {guarded.stderr.strip()[:300]!r}")
+
+
+def _expect_refused(tmp_path: Path, builder, *, name: str) -> None:
+    """`_expect_closed`, plus: the refusal must be THIS policy's.
+
+    Split from `_expect_closed` because a few hazards are closed by FORWARDING
+    the call in a harmless form rather than by refusing it — `status` is
+    forwarded with `--no-optional-locks` and legitimately exits 0. Requiring a
+    banner there would be asserting the wrong thing.
+    """
+    _expect_closed(tmp_path, builder, name=name)
+    root = tmp_path / "refused"
+    root.mkdir()
+    victim, argv, cwd, extra, home = _stage(root, builder)
+    env = _env(allowed=str(root / "allowed"), denied=str(victim))
+    env["HOME"] = str(home)
+    env.update(extra)
+    got = _git(*argv, cwd=cwd, env=env)
+    assert got.returncode == nogit.BLOCK_EXIT, (
+        f"{name}: not refused (rc={got.returncode}). "
+        f"stdout={got.stdout[:200]!r} stderr={got.stderr[:300]!r}")
+    assert nogit.BANNER in got.stderr, (
+        f"{name}: refused, but without this policy's banner — a firing must be "
+        f"identifiable as this guard rather than as a git error: "
+        f"{got.stderr!r}")
 
 
 # --------------------------------------------------------------------------- #
@@ -147,12 +407,11 @@ def test_no_path_entry_before_the_shim_provides_a_git(no_real_git_writes):
     🔴 NOT "the shim dir is PATH[0]" — measured, it is not, and asserting that
     was wrong rather than merely strict. The launcher policy's stub dir is
     prepended by its own session fixture, so whichever of the two autouse
-    fixtures runs last takes position 0; today that is `nolaunch`, and the
-    order is an artefact of fixture instantiation that nothing guarantees.
+    fixtures runs last takes position 0.
 
-    What actually matters is that no EARLIER entry carries a `git`, so this
-    asserts that instead. It is the same property "PATH[0]" was reaching for,
-    stated so it cannot be broken by an unrelated fixture winning a race.
+    🔴 AND THIS MEASURES THIS PROCESS'S PATH, WHICH IS NOT WHERE THE ESCAPE
+    WAS. `test_git_spawned_children_resolve_git_to_the_shim` is the one that
+    covers a child of git itself; this one cannot see that at all.
     """
     entries = [p for p in os.environ["PATH"].split(os.pathsep) if p]
     shim = str(no_real_git_writes)
@@ -165,17 +424,30 @@ def test_no_path_entry_before_the_shim_provides_a_git(no_real_git_writes):
         "instead, and the policy would be silently inert.")
 
 
+def test_the_exec_path_farm_is_not_itself_on_path(no_real_git_writes):
+    """The farm holds ~184 `git-*` symlinks; PATH is not where they belong.
+
+    It is reached only through `GIT_EXEC_PATH`. On PATH it would shadow any
+    same-named tool for every process in the session.
+    """
+    farm = str(nogit.exec_path_dir(no_real_git_writes))
+    entries = [p for p in os.environ["PATH"].split(os.pathsep) if p]
+    assert farm not in entries, (
+        f"the exec-path farm {farm} is on PATH; it must be reachable only "
+        "through GIT_EXEC_PATH")
+    assert os.environ.get("GIT_EXEC_PATH") == farm, (
+        "GIT_EXEC_PATH does not point at the farm, so every child git spawns "
+        "resolves `git` to the real binary — see nogit.exec_path_farm()")
+
+
 def test_git_is_not_also_claimed_by_the_launcher_policy():
     """🔴 The seam between the two policies, pinned.
 
-    `nolaunch` prepends its own stub dir and — measured above — currently wins
-    position 0. Its stubs are RECORD-ONLY: they log the argv and exit 0 with no
+    `nolaunch`'s stubs are RECORD-ONLY: they log the argv and exit 0 with no
     output. If `git` were ever added to `HOST_LAUNCHERS`, that stub would
     shadow this one and every git call in the suite would return success with
     empty stdout: `rev-parse` answering nothing, `ls-files` listing nothing,
-    and every content gate scanning zero files while passing. That is a far
-    worse failure than the one this policy closes, and nothing else would
-    notice it — so the two ledgers are pinned as disjoint here.
+    and every content gate scanning zero files while passing.
     """
     from testlib import nolaunch  # noqa: PLC0415 — local, to keep the seam explicit
     assert "git" not in nolaunch.HOST_LAUNCHERS, (
@@ -192,9 +464,7 @@ def test_the_session_denies_the_tree_under_test(no_real_git_writes):
         f"the tree under test ({nogit.repo_root()}) is not in "
         f"{nogit.DENY_ROOTS_ENV}={denied!r}. In the nix sandbox the source is "
         "unpacked under $TMPDIR, so WITHOUT this entry every write to the tree "
-        "under test would sit inside an allowed root and be permitted — the "
-        "policy would be live on the dev host and structurally blind in the "
-        "tier that gates merges.")
+        "under test would sit inside an allowed root and be permitted.")
 
 
 # --------------------------------------------------------------------------- #
@@ -204,36 +474,208 @@ def test_the_read_verb_ledger_is_pinned():
     """Fails when the read set GROWS or SHRINKS.
 
     Growing it is how a write gets reclassified as a read — the failure mode
-    that put `remote set-url` through in the first place. Shrinking it is how
-    the policy goes permanently red. Neither may happen silently.
+    that put `remote set-url` through in the first place, and that kept
+    `hash-object` (which writes with `-w`) on this list. Shrinking it is how
+    the policy goes permanently red.
     """
     assert set(nogit.GIT_READ_VERBS) == {
         "status", "log", "show", "diff", "cat-file", "ls-files", "ls-tree",
         "ls-remote", "rev-parse", "rev-list", "describe", "blame", "grep",
-        "shortlog", "show-ref", "symbolic-ref", "for-each-ref", "merge-base",
+        "shortlog", "show-ref", "for-each-ref", "merge-base",
         "name-rev", "check-ignore", "check-attr", "count-objects",
         "verify-pack", "var", "help", "version", "annotate", "whatchanged",
-        "cherry", "diff-tree", "diff-index", "diff-files", "hash-object",
+        "cherry", "diff-tree", "diff-index", "diff-files",
         "patch-id", "get-tar-commit-id", "check-mailmap", "column",
-        "interpret-trailers",
     }
+    # 🔴 The verbs REMOVED from this ledger, pinned as absent by name. Each was
+    # measured to write, and each was invisible to the predecessor of
+    # `test_no_verb_on_the_read_ledger_can_change_a_repo` because that test
+    # parametrised twelve verbs that were never on the ledger at all.
+    for writes in ("hash-object", "symbolic-ref", "interpret-trailers", "fsck"):
+        assert writes not in nogit.GIT_READ_VERBS, (
+            f"`{writes}` has a WRITING form and is back on the read ledger")
+        assert writes in nogit.GIT_DUAL_VERBS, (
+            f"`{writes}` is neither a ledgered read nor a dual verb, so its "
+            "reading form is refused outright — a permanently-red gate")
 
 
-@pytest.mark.parametrize("verb", ["commit", "push", "remote", "config",
-                                  "branch", "checkout", "reset", "fetch",
-                                  "merge", "rebase", "tag", "worktree"])
-def test_no_mutating_verb_is_on_the_read_ledger(verb):
-    """The verbs seen in the incident must never be classified as reads."""
-    assert verb not in nogit.GIT_READ_VERBS
+@pytest.mark.parametrize("verb", sorted(nogit.GIT_READ_VERBS))
+def test_no_verb_on_the_read_ledger_can_change_a_repo(
+        verb, tmp_path, no_real_git_writes):
+    """🔴 EXERCISES EVERY LEDGERED VERB. The previous version of this test
+    parametrised twelve mutating verbs — `commit`, `push`, `checkout`, … —
+    and asserted each was ABSENT from the ledger. Not one of them was ever on
+    it, so the test was vacuous by construction: it could not fail, and it did
+    not notice `hash-object` or `status`, which WERE on the ledger and DO
+    write.
+
+    This runs each ledgered verb against a repo the session denies, in its
+    plainest form, and asserts the repo is byte-identical afterwards. A verb
+    that cannot run in that form is skipped BY NAME rather than silently
+    passing.
+    """
+    victim = _victim(tmp_path / "victim")
+    env = _env(allowed=str(tmp_path / "nowhere"), denied=str(victim))
+    before = _victim_state(victim)
+    got = _git(verb, cwd=victim, env=env)
+    # Some verbs need an argument; a usage error is fine, a WRITE is not.
+    assert got.returncode != nogit.BLOCK_EXIT, (
+        f"`git {verb}` is on the READ ledger but the policy refused it — the "
+        f"ledger and the shim disagree: {got.stderr[:200]!r}")
+    after = _victim_state(victim)
+    assert after == before, (
+        f"`git {verb}` is on the READ ledger but CHANGED a repo this session "
+        f"denies. Ledger rule: a verb belongs there only if it cannot modify "
+        f"the repository, its config, its refs, its index or its worktree.\n"
+        f"  changed: "
+        f"{sorted(k for k in set(after[2]) | set(before[2]) if after[2].get(k) != before[2].get(k))[:6]}")
 
 
-def test_the_default_mode_is_block_not_audit():
-    """`audit` is a measuring tool; leaving it on would make the guard inert."""
-    assert nogit.MODE_BLOCK == "block"
-    body = nogit.git_body("/bin/true", Path("/dev/null"))
-    assert f"${{{nogit.MODE_ENV}:-{nogit.MODE_BLOCK}}}" in body, (
-        "the shim's default mode is not 'block' — a guard silently in audit "
-        "mode records violations and lets every one of them through")
+def test_the_shim_has_no_env_readable_mode(tmp_path):
+    """🔴 `DEVRC_TEST_GIT_MODE=audit` used to disarm the whole policy.
+
+    MEASURED against the previous revision: `DEVRC_TEST_GIT_MODE=audit git -C
+    <victim> commit --allow-empty -m AUDITPWN` returned 0 and the victim
+    received the commit. One inherited variable, guard gone.
+
+    The test that was supposed to prevent it asserted only that the STRING
+    `${DEVRC_TEST_GIT_MODE:-block}` appeared in the generated body — which is
+    exactly what a shim running in audit mode also contains. It could not see
+    an audit-mode run at all.
+
+    This asserts the generated body never reads the variable, which is a
+    structural claim; `test_an_audit_mode_env_var_cannot_disarm_the_guard` is
+    the live one.
+    """
+    body = nogit.git_body("/bin/true", Path("/dev/null"), stub_dir=tmp_path)
+    assert nogit.MODE_ENV not in body, (
+        f"the shim still reads {nogit.MODE_ENV} from the environment. Mode is "
+        "a bake-time argument to install() precisely so that nothing an "
+        "inherited environment carries can turn the guard off.")
+
+
+def test_the_env_ledger_no_longer_holds_the_known_non_vectors():
+    """The three names removed for not receiving bytes, pinned as absent.
+
+    This is the STRUCTURAL half and it is deliberately weak — see
+    `test_every_env_ledger_entry_is_a_live_write_vector` for the half that
+    could actually have caught the mistake. The previous version of this file
+    had only the structural half, and it PINNED
+    `GIT_ALTERNATE_OBJECT_DIRECTORIES` AS CORRECT.
+    """
+    for bad in ("GIT_NAMESPACE", "GIT_CEILING_DIRECTORIES",
+                "GIT_ALTERNATE_OBJECT_DIRECTORIES"):
+        assert bad not in nogit.GIT_LOCATION_ENV, (
+            f"{bad} does not receive bytes — treating it as a write target "
+            "refuses the safe case and inflates the count of vectors this "
+            "policy can claim to defend")
+
+
+@pytest.mark.parametrize("var", sorted(nogit.GIT_LOCATION_ENV))
+def test_every_env_ledger_entry_is_a_live_write_vector(
+        var, tmp_path, no_real_git_writes):
+    """🔴 THE TEST THAT WOULD HAVE CAUGHT THE MISTAKE, AND ITS PREDECESSOR
+    COULD NOT.
+
+    The previous file asserted `set(GIT_LOCATION_ENV) == {…literal set…}`. That
+    is a membership claim, so it PASSED for
+    `GIT_ALTERNATE_OBJECT_DIRECTORIES` — a READ-ONLY additional object store
+    that cannot redirect a write anywhere. Measured, with it armed at the
+    victim and the guard removed:
+
+        GIT_ALTERNATE_OBJECT_DIRECTORIES=<victim>/.git/objects \\
+          git -C <fixture> commit --allow-empty -m PWNED
+        -> rc 0; the object landed in <fixture>/.git/objects/c4/…
+           and a full byte manifest of the victim was UNCHANGED.
+
+    It had been "caught" by a negative control that armed it at a path-shaped
+    value, which measures whether the guard READS the variable, not whether the
+    variable is a write target.
+
+    This EXERCISES each entry: arm it at the victim with the guard removed and
+    require the victim to move. A ledger entry that cannot move the victim
+    fails here and must be removed, not documented.
+    """
+    victim, args, tree = _ENV_VECTORS[var]
+    root = tmp_path / "live"
+    root.mkdir()
+    v = _victim(root / "victim")
+    fixture = _make_repo(root / "allowed" / "fix", tree=tree)
+    env = _env(allowed=str(root / "allowed"), denied=str(v),
+               path=_real_path())
+    env["HOME"] = str(root / "home")
+    Path(env["HOME"]).mkdir(parents=True, exist_ok=True)
+    env[var] = str(v / victim) if victim else str(v)
+
+    before = _victim_state(v)
+    with _l2_off():
+        got = subprocess.run([_real(), *args], cwd=str(fixture), env=env,
+                             capture_output=True, text=True, timeout=TIMEOUT)
+    after = _victim_state(v)
+    assert after != before, (
+        f"{var} is on GIT_LOCATION_ENV but, armed at the victim WITH THE "
+        f"GUARD REMOVED, it moved nothing (rc={got.returncode}, "
+        f"stderr={got.stderr.strip()[:200]!r}). It is not a write vector, so "
+        "refusing it is a pure false positive and counting it as defended "
+        "inflates this policy's coverage. Remove it from the ledger.")
+
+
+# 🔴 One LIVE command per ledger entry. Every one of these was chosen by
+# running it with the guard removed and watching the victim move; the
+# commented-out shapes are the ones that did NOT.
+#
+#   var -> (path under the victim, argv, fixture tree)
+#
+# `GIT_WORK_TREE` uses `checkout -f HEAD` with a fixture whose tree DIFFERS
+# from the victim's, which clobbers `keep.txt`. The previous file paired it
+# with `add -A` as well: measured, `add -A` under `GIT_WORK_TREE` writes the
+# objects and the index into the FIXTURE and leaves the victim completely
+# untouched, so that entry was vacuous.
+_ENV_VECTORS = {
+    "GIT_DIR": (".git", ("commit", "--allow-empty", "-m", "PWNED"), None),
+    # 🔴 THREE SHAPES WERE TRIED AND ONLY THIS ONE IS DETERMINISTIC.
+    # Measured with the object store redirected to the victim:
+    #   branch <name>          -> fatal: not a valid branch point
+    #   commit --allow-empty   -> fatal: could not parse HEAD
+    #   tag / update-ref / gc  -> nonexistent object / invalid ref
+    # `commit` LOOKED live for a while, and only because the victim and the
+    # fixture shared a seed commit sha. `config --local` writes
+    # `<victim>/.git/config` and needs no object at all — and it is the exact
+    # `config core.bare true` damage the incident's reflog recorded, arriving
+    # through a redirection instead of through an argument.
+    "GIT_COMMON_DIR": (".git", ("config", "--local", "nogit.pwned", "1"),
+                       None),
+    "GIT_WORK_TREE": ("", ("checkout", "-f", "HEAD"),
+                      {"a.txt": "FIXTURE\n", "keep.txt": "CLOBBERED\n"}),
+    # 🔴 NOT `commit`. With the object dir redirected, `commit` must read the
+    # fixture's own HEAD commit out of the VICTIM's object store and dies
+    # `fatal: could not parse HEAD` — it only ever appeared live because the
+    # two fixtures shared a seed sha (see `_make_repo`). `hash-object -w`
+    # reads no HEAD and writes the blob straight into the redirected store:
+    # measured, the victim's loose-object count went 2 -> 3.
+    "GIT_OBJECT_DIRECTORY": (".git/objects",
+                             ("hash-object", "-w", "a.txt"),
+                             {"a.txt": "OBJECT-VECTOR\n"}),
+    "GIT_INDEX_FILE": (".git/index", ("add", "a.txt"), {"a.txt": "fx\n"}),
+    "GIT_CONFIG_GLOBAL": (".gitconfig",
+                          ("config", "--global", "user.name", "pwned"), None),
+    "GIT_CONFIG_SYSTEM": (".gitconfig",
+                          ("config", "--system", "user.name", "pwned"), None),
+}
+
+
+def test_the_env_vector_table_covers_the_ledger_exactly():
+    """Two-way pin: a new ledger entry with no LIVE command fails here.
+
+    Without this, adding a variable to `GIT_LOCATION_ENV` and forgetting the
+    table would make `test_every_env_ledger_entry_is_a_live_write_vector`
+    error on a KeyError, which reads as a broken test rather than as an
+    unproven ledger entry.
+    """
+    assert set(_ENV_VECTORS) == set(nogit.GIT_LOCATION_ENV), (
+        "the live-vector table and GIT_LOCATION_ENV disagree: "
+        f"ledger-only={sorted(set(nogit.GIT_LOCATION_ENV) - set(_ENV_VECTORS))}, "
+        f"table-only={sorted(set(_ENV_VECTORS) - set(nogit.GIT_LOCATION_ENV))}")
 
 
 # --------------------------------------------------------------------------- #
@@ -246,18 +688,56 @@ def test_a_read_against_a_denied_repo_still_reaches_the_real_binary(
     If the policy broke that they would scan NOTHING and pass — a silent zero
     manufactured by the guard itself, which is worse than the hazard it closes.
     """
-    victim = _make_repo(tmp_path / "victim")
+    victim = _make_repo(tmp_path / "victim", tree={"a.txt": "x\n"})
     env = _env(allowed=str(tmp_path / "nowhere"), denied=str(victim))
 
     got = _git("ls-files", cwd=victim, env=env)
     assert got.returncode != nogit.BLOCK_EXIT, (
         f"a READ was refused: {got.stderr}")
 
-    real = shutil.which("git", path=_real_path())
-    want = subprocess.run([real, "ls-files"], cwd=str(victim),
+    want = subprocess.run([_real(), "ls-files"], cwd=str(victim),
                           capture_output=True, text=True, timeout=TIMEOUT)
     assert got.stdout == want.stdout
+    assert got.stdout.strip(), (
+        "the read returned NOTHING — a silent zero is the failure this policy "
+        "must never manufacture, and an empty answer would pass an equality "
+        "check against an equally-empty control")
     assert got.returncode == want.returncode
+
+
+def test_status_against_a_denied_repo_does_not_rewrite_its_index(
+        tmp_path, no_real_git_writes):
+    """🔴 `status` REFRESHES AND REWRITES `<repo>/.git/index`.
+
+    MEASURED against the previous revision, which had it on the read ledger and
+    forwarded it untouched: the victim's index hash moved
+    `63e1e299594b -> 59551aa2642b`. That is a write to a repo the test does not
+    own, waved through by a ledger whose own stated membership rule forbids it.
+
+    It is NOT refused, and that is deliberate: `status` is run against the real
+    repo throughout this tree, and refusing it would be a permanently-red gate.
+    The shim forwards it as `git --no-optional-locks status`, which MEASURED
+    leaves the index byte-identical and produces byte-identical stdout.
+    """
+    import time
+    victim = _victim(tmp_path / "victim")
+    idx = victim / ".git" / "index"
+    time.sleep(1.1)
+    # Same bytes, new mtime — this is what makes git want to refresh the index.
+    (victim / "keep.txt").write_text("PRECIOUS", encoding="utf-8")
+    before = hashlib.sha256(idx.read_bytes()).hexdigest()
+
+    env = _env(allowed=str(tmp_path / "nowhere"), denied=str(victim))
+    got = _git("status", "--porcelain", cwd=victim, env=env)
+    assert got.returncode == 0, f"`git status` was broken: {got.stderr!r}"
+    assert hashlib.sha256(idx.read_bytes()).hexdigest() == before, (
+        "`git status` rewrote the index of a repo this session denies")
+
+    # …and the answer is still the real one.
+    want = subprocess.run([_real(), "--no-optional-locks", "-C", str(victim),
+                           "status", "--porcelain"], capture_output=True,
+                          text=True, timeout=TIMEOUT)
+    assert got.stdout == want.stdout
 
 
 @pytest.mark.parametrize("args", [
@@ -285,6 +765,20 @@ def test_dual_verb_read_forms_are_allowed_against_a_denied_repo(
     got = _git(*args, cwd=victim, env=env)
     assert got.returncode != nogit.BLOCK_EXIT, (
         f"`git {' '.join(args)}` is a READ but was refused:\n{got.stderr}")
+
+
+def test_hash_object_without_w_still_reads_a_denied_repo(
+        tmp_path, no_real_git_writes):
+    """The read FORM of the verb that was wrongly ledgered as always-read."""
+    victim = _victim(tmp_path / "victim")
+    blob = tmp_path / "blob"
+    blob.write_text("hello\n", encoding="utf-8")
+    env = _env(allowed=str(tmp_path / "nowhere"), denied=str(victim))
+    got = _git("hash-object", str(blob), cwd=victim, env=env)
+    assert got.returncode != nogit.BLOCK_EXIT, (
+        f"`git hash-object <file>` writes nothing but was refused: "
+        f"{got.stderr!r}")
+    assert got.stdout.strip(), "the read produced no hash at all"
 
 
 # --------------------------------------------------------------------------- #
@@ -336,12 +830,7 @@ def test_an_unknown_future_verb_fails_closed(tmp_path, no_real_git_writes):
 
 def test_a_git_with_no_verb_prints_usage_instead_of_refusing(
         tmp_path, no_real_git_writes):
-    """`git` alone writes nothing, so refusing it is a false positive.
-
-    Worth pinning because it is confusing rather than dangerous: a bare `git`
-    answering with this policy's VIOLATION banner reads like the guard is
-    broken, which is how a guard gets removed.
-    """
+    """`git` alone writes nothing, so refusing it is a false positive."""
     victim = _make_repo(tmp_path / "victim")
     env = _env(allowed=str(tmp_path / "nowhere"), denied=str(victim))
     got = subprocess.run(["git"], cwd=str(victim), env=env,
@@ -351,14 +840,36 @@ def test_a_git_with_no_verb_prints_usage_instead_of_refusing(
     assert nogit.BANNER not in got.stderr
 
 
+@pytest.mark.parametrize("args", [
+    ("--version",),
+    ("--exec-path",),
+    ("commit", "-h"),
+    ("status", "--help"),
+])
+def test_help_and_version_forms_are_answered_not_refused(
+        args, tmp_path, no_real_git_writes):
+    """The forms that print and exit must survive the narrowed flag scan.
+
+    Narrowing the scan to pre-verb tokens (see the `commit -m -h` measurement)
+    could have made `git commit -h` a refused write. It does not, because
+    `<verb> -h` as the single remaining token is handled explicitly.
+    """
+    victim = _make_repo(tmp_path / "victim")
+    env = _env(allowed=str(tmp_path / "nowhere"), denied=str(victim))
+    env["GIT_PAGER"] = "cat"
+    got = _git(*args, cwd=victim, env=env)
+    assert got.returncode != nogit.BLOCK_EXIT, (
+        f"`git {' '.join(args)}` prints and exits but was refused: "
+        f"{got.stderr!r}")
+
+
 def test_a_bare_git_with_no_dash_C_is_judged_by_its_cwd(
         tmp_path, no_real_git_writes):
     """🔴 The first-class suspect.
 
     A `git` with neither `-C` nor an explicit `cwd=` targets whatever directory
     the process happens to be in. For a suite run from the clone, that IS the
-    clone — and it is how `drift-check.sh`'s remote leg, running locally under
-    a stub `ssh` with `DRIFT_REPO` unset, reaches `$HOME/workspace/devrc`.
+    clone.
     """
     victim = _make_repo(tmp_path / "victim")
     env = _env(allowed=str(tmp_path / "nowhere"), denied=str(victim))
@@ -385,14 +896,8 @@ def test_a_path_that_spells_its_way_out_is_canonicalised(
 
 
 def test_a_denied_root_wins_over_an_allowed_root(tmp_path, no_real_git_writes):
-    """Deny must beat allow, or the policy is inert in the nix sandbox.
-
-    There the source tree is unpacked under `$TMPDIR`, so the repo under test
-    is INSIDE an allowed root. If allow won, every write this policy exists to
-    stop would be permitted in the tier that gates merges.
-    """
+    """Deny must beat allow, or the policy is inert in the nix sandbox."""
     victim = _make_repo(tmp_path / "victim")
-    # tmp_path itself is allowed, and victim is inside it — yet denied.
     env = _env(allowed=str(tmp_path), denied=str(victim))
     got = _git("commit", "--allow-empty", "-m", "c", cwd=victim, env=env)
     assert got.returncode == nogit.BLOCK_EXIT, (
@@ -401,24 +906,751 @@ def test_a_denied_root_wins_over_an_allowed_root(tmp_path, no_real_git_writes):
 
 def test_a_push_to_a_destination_outside_the_roots_is_refused(
         tmp_path, no_real_git_writes):
-    """🔴 The second vector: the SOURCE repo being in-bounds is not enough.
-
-    A push from a legitimate fixture still reaches whatever `origin` points at.
-    The contained clone prepared for this work had an `origin` aimed at the
-    operator's real clone, so this is measured behaviour, not a hypothetical.
-    """
+    """🔴 The second vector: the SOURCE repo being in-bounds is not enough."""
     src = _make_repo(tmp_path / "src")
     dest = _make_repo(tmp_path / "dest")
-    real = shutil.which("git", path=_real_path())
-    subprocess.run([real, "remote", "add", "origin", str(dest)], cwd=str(src),
-                   check=True, capture_output=True, timeout=TIMEOUT)
-    # src is allowed; dest is NOT.
+    subprocess.run([_real(), "remote", "add", "origin", str(dest)],
+                   cwd=str(src), check=True, capture_output=True,
+                   timeout=TIMEOUT)
     env = _env(allowed=str(src), denied=str(dest))
     got = _git("push", "origin", "main", cwd=src, env=env)
     assert got.returncode == nogit.BLOCK_EXIT, (
         f"push from an allowed repo INTO a denied one was permitted "
         f"(rc={got.returncode}): {got.stderr!r}")
     assert nogit.BANNER in got.stderr
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE MEASURED BYPASSES — every one of these reached the victim
+# --------------------------------------------------------------------------- #
+# Each entry is a builder for the three-way harness above:
+#     builder(root, victim, allowed) -> (argv_after_git, cwd, extra_env, home)
+#
+# NONE of these appeared anywhere in the previous 868-line battery, which is
+# why it was entirely green while nine of them were live. A battery that
+# enumerates only the shapes its author already knew about measures the author.
+
+def _b_hookspath_env(root, victim, allowed):
+    hooks = victim / "hooks"
+    hooks.mkdir(parents=True, exist_ok=True)
+    write_exec(hooks / "post-commit", f"echo PWNED > {victim / 'HOOK-RAN'}\n")
+    fixture = _make_repo(allowed / "fix")
+    return (["-C", str(fixture), "commit", "--allow-empty", "-m", "hookprobe"],
+            root,
+            {"GIT_CONFIG_COUNT": "1", "GIT_CONFIG_KEY_0": "core.hooksPath",
+             "GIT_CONFIG_VALUE_0": str(hooks)}, None)
+
+
+def _b_hookspath_dashc(root, victim, allowed):
+    hooks = victim / "hooks"
+    hooks.mkdir(parents=True, exist_ok=True)
+    write_exec(hooks / "post-commit", f"echo PWNED > {victim / 'HOOK-RAN'}\n")
+    fixture = _make_repo(allowed / "fix")
+    return (["-C", str(fixture), "-c", f"core.hooksPath={hooks}", "commit",
+             "--allow-empty", "-m", "hookprobe"], root, {}, None)
+
+
+def _b_config_file(root, victim, allowed):
+    fixture = _make_repo(allowed / "fix")
+    return (["-C", str(fixture), "config", "--file",
+             str(victim / ".git" / "config"), "core.bare", "true"],
+            root, {}, None)
+
+
+def _b_config_f(root, victim, allowed):
+    fixture = _make_repo(allowed / "fix")
+    return (["-C", str(fixture), "config", "-f",
+             str(victim / ".git" / "config"), "core.bare", "true"],
+            root, {}, None)
+
+
+def _b_config_global(root, victim, allowed):
+    fixture = _make_repo(allowed / "fix")
+    home = victim / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    return (["-C", str(fixture), "config", "--global", "user.name", "pwned"],
+            root, {}, home)
+
+
+def _push_fixture(root, victim, allowed):
+    bare = allowed / "ok.git"
+    subprocess.run([_real(), "init", "-q", "--bare", str(bare)],
+                   check=True, capture_output=True, timeout=TIMEOUT)
+    fixture = _make_repo(allowed / "fix")
+    subprocess.run([_real(), "-C", str(fixture), "remote", "add", "origin",
+                    str(bare)], check=True, capture_output=True,
+                   timeout=TIMEOUT)
+    return fixture
+
+
+def _b_push_dashc_url(root, victim, allowed):
+    fixture = _push_fixture(root, victim, allowed)
+    return (["-C", str(fixture), "-c", f"remote.origin.url={victim}", "push",
+             "origin", "HEAD:refs/heads/pwned"], root, {}, None)
+
+
+def _b_push_dashc_pushurl(root, victim, allowed):
+    fixture = _push_fixture(root, victim, allowed)
+    return (["-C", str(fixture), "-c", f"remote.origin.pushurl={victim}",
+             "push", "origin", "HEAD:refs/heads/pwned"], root, {}, None)
+
+
+def _b_push_env_url(root, victim, allowed):
+    fixture = _push_fixture(root, victim, allowed)
+    return (["-C", str(fixture), "push", "origin", "HEAD:refs/heads/pwned"],
+            root,
+            {"GIT_CONFIG_COUNT": "1", "GIT_CONFIG_KEY_0": "remote.origin.url",
+             "GIT_CONFIG_VALUE_0": str(victim)}, None)
+
+
+def _b_alias_git(root, victim, allowed):
+    fixture = _make_repo(allowed / "fix")
+    return (["-C", str(fixture), "-c",
+             f"alias.x=!git -C {victim} commit --allow-empty -m ALIASPWN",
+             "x"], root, {}, None)
+
+
+def _b_init_separate_git_dir(root, victim, allowed):
+    return (["init", "-q", "--separate-git-dir", str(victim / "stolen.git"),
+             str(allowed / "newrepo")], root, {}, None)
+
+
+def _b_clone_separate_git_dir(root, victim, allowed):
+    src = _make_repo(allowed / "src")
+    return (["clone", "-q", "--separate-git-dir", str(victim / "stolen2.git"),
+             str(src), str(allowed / "cl")], root, {}, None)
+
+
+def _b_worktree_add(root, victim, allowed):
+    fixture = _make_repo(allowed / "fix")
+    return (["-C", str(fixture), "worktree", "add", str(victim / "wt")],
+            root, {}, None)
+
+
+def _b_audit_mode(root, victim, allowed):
+    return (["-C", str(victim), "commit", "--allow-empty", "-m", "AUDITPWN"],
+            root, {nogit.MODE_ENV: "audit"}, None)
+
+
+def _b_hash_object_w(root, victim, allowed):
+    blob = root / "blob"
+    blob.write_text("PWNBLOB\n", encoding="utf-8")
+    return (["-C", str(victim), "hash-object", "-w", str(blob)], root, {},
+            None)
+
+
+def _b_archive_output(root, victim, allowed):
+    fixture = _make_repo(allowed / "fix", tree={"a.txt": "x\n"})
+    return (["-C", str(fixture), "archive", "--output",
+             str(victim / "stolen.tar"), "HEAD"], root, {}, None)
+
+
+def _b_bundle_create(root, victim, allowed):
+    fixture = _make_repo(allowed / "fix")
+    return (["-C", str(fixture), "bundle", "create",
+             str(victim / "stolen.bundle"), "HEAD"], root, {}, None)
+
+
+def _b_dash_h_as_a_value(root, victim, allowed):
+    return (["-C", str(victim), "commit", "--allow-empty", "-m", "-h"],
+            root, {}, None)
+
+
+def _b_external_diff(root, victim, allowed):
+    fixture = _make_repo(allowed / "fix", tree={"a.txt": "one\n"})
+    (fixture / "a.txt").write_text("two\n", encoding="utf-8")
+    script = root / "ed.sh"
+    write_exec(script, f"echo EXTDIFF > {victim / 'EXTDIFF-RAN'}\n")
+    return (["-C", str(fixture), "diff"], root,
+            {"GIT_EXTERNAL_DIFF": str(script)}, None)
+
+
+_BYPASSES = {
+    "GIT_CONFIG_COUNT -> core.hooksPath (code execution)": _b_hookspath_env,
+    "-c core.hooksPath=<victim> (code execution)": _b_hookspath_dashc,
+    "config --file <victim>/.git/config": _b_config_file,
+    "config -f <victim>/.git/config": _b_config_f,
+    "config --global escapes into $HOME": _b_config_global,
+    "-c remote.origin.url=<victim> push": _b_push_dashc_url,
+    "-c remote.origin.pushurl=<victim> push": _b_push_dashc_pushurl,
+    "GIT_CONFIG_COUNT -> remote.origin.url push": _b_push_env_url,
+    "-c alias.x=!git -C <victim> commit (PATH escape)": _b_alias_git,
+    "init --separate-git-dir <victim>/x": _b_init_separate_git_dir,
+    "clone --separate-git-dir <victim>/x": _b_clone_separate_git_dir,
+    "worktree add <victim>/wt": _b_worktree_add,
+    "DEVRC_TEST_GIT_MODE=audit disarms the guard": _b_audit_mode,
+    "hash-object -w into a denied repo": _b_hash_object_w,
+    "archive --output=<victim>/x.tar": _b_archive_output,
+    "bundle create <victim>/x.bundle": _b_bundle_create,
+    "commit -m -h (whole-argv read-flag scan)": _b_dash_h_as_a_value,
+    "GIT_EXTERNAL_DIFF turns a read into execution": _b_external_diff,
+}
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 ROUND TWO — the SAME capabilities, spelled differently
+# --------------------------------------------------------------------------- #
+# Every one of these is a second spelling of a capability the first round
+# already closed, and each was found by an independent audit rather than by
+# this file's author. That is the whole lesson: enumerating the argv shape that
+# was demonstrated leaves every other shape of the same capability open, so
+# these are here to keep the STRUCTURAL fixes honest — the flag twin of an env
+# variable, the relative twin of an absolute path, the read-flag-first twin of
+# a bare write, and a numeric gate that does not parse what git parses.
+
+
+def _b_worktree_flag(root, victim, allowed):
+    """`--work-tree=` — the COMMAND-LINE twin of `GIT_WORK_TREE`.
+
+    Measured on a guard that closed the env variable and skipped the flag:
+    `git --work-tree=<victim> clean -fdx` DELETED EVERY FILE in the victim's
+    working tree.
+    """
+    fixture = _make_repo(allowed / "fix")
+    return (["--work-tree=" + str(victim), "-C", str(fixture), "clean", "-fdx"],
+            root, {}, None)
+
+
+def _b_gitdir_flag(root, victim, allowed):
+    """`--git-dir=` — the command-line twin of `GIT_DIR`."""
+    fixture = _make_repo(allowed / "fix")
+    return (["--git-dir=" + str(victim / ".git"), "-C", str(fixture), "commit",
+             "--allow-empty", "-m", "GD"], root, {}, None)
+
+
+def _b_gitdir_victim_worktree_allowed(root, victim, allowed):
+    """🔴 BOTH flags set, only one of them out of bounds.
+
+    The `top` chain picks work-tree over git-dir, so a guard that judges the
+    single resolved `top` sees only the innocent half. The check has to be over
+    the SET.
+    """
+    fixture = _make_repo(allowed / "fix")
+    return (["--git-dir=" + str(victim / ".git"),
+             "--work-tree=" + str(fixture), "-C", str(fixture),
+             "commit", "--allow-empty", "-m", "SPLIT"], root, {}, None)
+
+
+def _b_read_flag_first(root, victim, allowed):
+    """A read-shaped flag placed FIRST must not license the rest of the argv."""
+    return (["-C", str(victim), "branch", "--format=%(refname)", "-m", "main",
+             "trunk"], root, {}, None)
+
+
+def _b_symbolic_ref_write(root, victim, allowed):
+    """`symbolic-ref <name> <ref>` REPOINTS — the verb was on the READ ledger."""
+    subprocess.run([_real(), "-C", str(victim), "branch", "trunk"],
+                   capture_output=True, timeout=TIMEOUT)
+    return (["-C", str(victim), "symbolic-ref", "-q", "HEAD",
+             "refs/heads/trunk"], root, {}, None)
+
+
+def _hookdir(victim):
+    hooks = victim / "hooks"
+    hooks.mkdir(parents=True, exist_ok=True)
+    write_exec(hooks / "post-commit", f"echo PWNED > {victim / 'HOOK-RAN'}\n")
+    return hooks
+
+
+def _b_config_count_plus(root, victim, allowed):
+    """`GIT_CONFIG_COUNT=+1` — git's `strtoumax` accepts it; `[0-9]*` does not."""
+    hooks = _hookdir(victim)
+    fixture = _make_repo(allowed / "fix")
+    return (["-C", str(fixture), "commit", "--allow-empty", "-m", "p"], root,
+            {"GIT_CONFIG_COUNT": "+1", "GIT_CONFIG_KEY_0": "core.hooksPath",
+             "GIT_CONFIG_VALUE_0": str(hooks)}, None)
+
+
+def _b_config_count_space(root, victim, allowed):
+    """`GIT_CONFIG_COUNT=' 1'` — leading whitespace, same story."""
+    hooks = _hookdir(victim)
+    fixture = _make_repo(allowed / "fix")
+    return (["-C", str(fixture), "commit", "--allow-empty", "-m", "p"], root,
+            {"GIT_CONFIG_COUNT": " 1", "GIT_CONFIG_KEY_0": "core.hooksPath",
+             "GIT_CONFIG_VALUE_0": str(hooks)}, None)
+
+
+def _b_diff_external_dashc(root, victim, allowed):
+    """`-c diff.external=` on a READ — the scan must run above the fast path."""
+    fixture = _make_repo(allowed / "fix", tree={"a.txt": "one\n"})
+    (fixture / "a.txt").write_text("two\n", encoding="utf-8")
+    script = root / "ed.sh"
+    write_exec(script, f"echo X > {victim / 'EXT-RAN'}\n")
+    return (["-C", str(fixture), "-c", f"diff.external={script}", "diff"],
+            root, {}, None)
+
+
+def _b_filter_clean(root, victim, allowed):
+    """A clean filter is a child-injection channel like an alias."""
+    fixture = _make_repo(allowed / "fix")
+    (fixture / ".gitattributes").write_text("*.q filter=x\n", encoding="utf-8")
+    (fixture / "z.q").write_text("data\n", encoding="utf-8")
+    script = root / "cl.sh"
+    write_exec(script,
+               f"git -C {victim} commit --allow-empty -m CLEAN\ncat\n")
+    return (["-C", str(fixture), "-c", f"filter.x.clean={script}", "add", "-A"],
+            root, {}, None)
+
+
+def _b_rel_config_file(root, victim, allowed):
+    """A RELATIVE `--file` — an absolute-only matcher is relative-walkable."""
+    fixture = _make_repo(allowed / "fix")
+    rel = os.path.relpath(victim / ".git" / "config", fixture)
+    return (["-C", str(fixture), "config", "--file", rel, "core.bare", "true"],
+            root, {}, None)
+
+
+def _b_rel_worktree_add(root, victim, allowed):
+    fixture = _make_repo(allowed / "fix")
+    rel = os.path.relpath(victim / "wt", fixture)
+    return (["-C", str(fixture), "worktree", "add", rel], root, {}, None)
+
+
+def _b_rel_separate_git_dir(root, victim, allowed):
+    """🔴 Also pins that a relative operand resolves against the CWD.
+
+    `base` is reassigned to the path `init` will create, so anchoring relative
+    operands there would check one directory away from where the bytes land.
+    """
+    newrepo = allowed / "newrepo"
+    newrepo.mkdir(parents=True, exist_ok=True)
+    rel = os.path.relpath(victim / "stolen.git", newrepo)
+    return (["-C", str(newrepo), "init", "-q", "--separate-git-dir=" + rel,
+             "."], root, {}, None)
+
+
+def _b_rel_separate_git_dir_nested(root, victim, allowed):
+    """🔴 THE CASE THAT SEPARATES `cwdbase` FROM `base`.
+
+    `_b_rel_separate_git_dir` uses `init … .`, where the reassigned `base`
+    equals the cwd and the two anchors agree — so it cannot tell them apart. A
+    mutation sweep caught that: anchoring relative operands to `base` SURVIVED
+    the whole battery.
+
+    Here `init` is given a SUBDIRECTORY, so `base` becomes `<cwd>/newrepo`
+    while git still resolves `../victim/...` against `<cwd>`. Anchored to
+    `base`, `../victim/stolen.git` reads as `<allowed>/victim/stolen.git` —
+    INSIDE the allowed root, so the call is permitted — while the bytes land in
+    `<root>/victim/stolen.git`. Anchored to `cwdbase` it resolves where git
+    puts it and is refused.
+    """
+    return (["-C", str(allowed), "init", "-q",
+             "--separate-git-dir=../victim/stolen.git", "newrepo"],
+            root, {}, None)
+
+
+def _b_rel_clone(root, victim, allowed):
+    src = _make_repo(allowed / "src")
+    fixture = allowed / "fix"
+    fixture.mkdir(parents=True, exist_ok=True)
+    rel = os.path.relpath(victim / "cl", fixture)
+    return (["-C", str(fixture), "clone", "-q", str(src), rel], root, {}, None)
+
+
+def _b_unresolvable_dotdot_init(root, victim, allowed):
+    """🔴 An UNRESOLVABLE path with `..` — protected-unknown, not protected-no.
+
+    Both `cd`s in `canon_of` fail because `does-not-exist` is not there, so the
+    raw string came back — and the raw string starts with `<allowed>/`, so it
+    matched an allowed root while `realpath` puts it inside the victim.
+
+    MEASURED: `git init -q <allowed>/does-not-exist/deeper/../../../victim/
+    planted` exited 0 and created `<victim>/planted`. Same for `clone`.
+    """
+    return (["init", "-q",
+             str(allowed) + "/does-not-exist/deeper/../../../victim/planted"],
+            root, {}, None)
+
+
+def _b_unresolvable_dotdot_clone(root, victim, allowed):
+    src = _make_repo(allowed / "src")
+    return (["clone", "-q", str(src),
+             str(allowed) + "/does-not-exist/deeper/../../../victim/planted"],
+            root, {}, None)
+
+
+def _b_archive_over_config(root, victim, allowed):
+    """`archive --output=` aimed at the victim's own config file."""
+    fixture = _make_repo(allowed / "fix", tree={"a.txt": "x\n"})
+    return (["-C", str(fixture), "archive", "--format=tar",
+             "--output=" + str(victim / ".git" / "config"), "HEAD"],
+            root, {}, None)
+
+
+def _b_init_into_victim(root, victim, allowed):
+    return (["init", "-q", str(victim / "newone")], root, {}, None)
+
+
+def _b_cumulative_dash_C(root, victim, allowed):
+    """🔴 git applies multiple `-C` CUMULATIVELY; keeping only the last one
+    resolves `.` against the shim's cwd and lands in the victim."""
+    return (["-C", str(victim), "-C", ".", "commit", "--allow-empty", "-m",
+             "CC"], root, {}, None)
+
+
+def _b_cumulative_dash_C_relative(root, victim, allowed):
+    fixture = _make_repo(allowed / "fix")
+    return (["-C", str(fixture), "-C", os.path.relpath(victim, fixture),
+             "commit", "--allow-empty", "-m", "CC2"], root, {}, None)
+
+
+def _b_bisect_run(root, victim, allowed):
+    """`bisect run <cmd>` executes arbitrary code once per step.
+
+    The command's own `git` is what the exec-path farm catches; this needs a
+    real bisect range or the script never runs at all and the case is vacuous.
+    """
+    fixture = _make_repo(allowed / "fix")
+    for i in range(4):
+        subprocess.run([_real(), "-C", str(fixture), "commit", "-q",
+                        "--allow-empty", "-m", f"c{i}"], check=True,
+                       capture_output=True, timeout=TIMEOUT)
+    head = subprocess.run([_real(), "-C", str(fixture), "rev-parse", "HEAD"],
+                          capture_output=True, text=True,
+                          timeout=TIMEOUT).stdout.strip()
+    first = subprocess.run(
+        [_real(), "-C", str(fixture), "rev-list", "--max-parents=0", "HEAD"],
+        capture_output=True, text=True, timeout=TIMEOUT).stdout.strip()
+    subprocess.run([_real(), "-C", str(fixture), "bisect", "start", head,
+                    first], capture_output=True, timeout=TIMEOUT)
+    script = root / "bis.sh"
+    write_exec(script,
+               f"git -C {victim} commit --allow-empty -m BISECT\nexit 1\n")
+    return (["-C", str(fixture), "bisect", "run", str(script)], root, {}, None)
+
+
+_BYPASSES.update({
+    "--work-tree=<victim> clean -fdx": _b_worktree_flag,
+    "--git-dir=<victim>/.git commit": _b_gitdir_flag,
+    "--git-dir=<victim> with an allowed --work-tree": _b_gitdir_victim_worktree_allowed,
+    "branch --format=... -m main trunk (read flag first)": _b_read_flag_first,
+    "symbolic-ref -q HEAD <ref> (was on the read ledger)": _b_symbolic_ref_write,
+    "GIT_CONFIG_COUNT=+1 -> core.hooksPath": _b_config_count_plus,
+    "GIT_CONFIG_COUNT=' 1' -> core.hooksPath": _b_config_count_space,
+    "-c diff.external=<script> on a read": _b_diff_external_dashc,
+    "-c filter.x.clean=<git-into-victim> add": _b_filter_clean,
+    "config --file ../victim/.git/config (relative)": _b_rel_config_file,
+    "worktree add ../victim/wt (relative)": _b_rel_worktree_add,
+    "init --separate-git-dir=../victim/x (relative)": _b_rel_separate_git_dir,
+    "init --separate-git-dir=../victim/x from a NESTED base":
+        _b_rel_separate_git_dir_nested,
+    "clone into ../victim/cl (relative)": _b_rel_clone,
+    "archive --output=<victim>/.git/config": _b_archive_over_config,
+    "init <victim>/newone": _b_init_into_victim,
+    "init <allowed>/nonexistent/../../victim/x (unresolvable)":
+        _b_unresolvable_dotdot_init,
+    "clone into <allowed>/nonexistent/../../victim/x (unresolvable)":
+        _b_unresolvable_dotdot_clone,
+    "-C <victim> -C . commit (cumulative -C)": _b_cumulative_dash_C,
+    "-C <allowed> -C ../victim commit (cumulative -C)": _b_cumulative_dash_C_relative,
+    "bisect run <git-into-victim>": _b_bisect_run,
+})
+
+
+@pytest.mark.parametrize("args", [
+    ("notes",),                                  # bare = list
+    ("fsck",),                                   # inspects, writes nothing
+    ("symbolic-ref", "HEAD"),                    # one positional = read
+    ("branch", "--format=%(refname)"),           # list form
+    ("interpret-trailers", "--only-input"),      # writes to stdout
+])
+def test_a_read_FORM_of_a_dual_verb_is_not_refused(
+        args, tmp_path, no_real_git_writes):
+    """🔴 THE OTHER HALF OF EVERY LEDGER MOVE.
+
+    `symbolic-ref`, `interpret-trailers`, `hash-object` and `fsck` were all
+    moved off the read ledger or onto the dual list in this rework, each
+    because one FORM of the verb writes. Moving a verb is only correct if its
+    reading forms still pass — otherwise the fix trades a false negative for a
+    permanently-red gate, and a permanently-red gate gets switched off.
+
+    MEASURED on the first attempt: refusing `fsck` outright was exactly that
+    mistake, and it is why the verb is DUAL rather than simply absent.
+    """
+    victim = _make_repo(tmp_path / "victim", tree={"a.txt": "x\n"})
+    env = _env(allowed=str(tmp_path / "nowhere"), denied=str(victim))
+    got = _git(*args, cwd=victim, env=env, stdin_text="")
+    assert got.returncode != nogit.BLOCK_EXIT, (
+        f"`git {' '.join(args)}` is a READING form of a dual verb but was "
+        f"refused:\n{got.stderr}")
+
+
+def test_a_one_argument_clone_targets_the_cwd_not_the_source(
+        tmp_path, no_real_git_writes):
+    """`git clone <protected>` clones INTO the cwd; the source is only read.
+
+    A destination loop that takes "the last positional" reads the SOURCE for a
+    one-argument clone and refuses a legitimate read of a protected repo —
+    which is how a guard ends up unable to clone the tree under test into a
+    fixture, a thing several tests in this tree do on purpose.
+    """
+    victim = _make_repo(tmp_path / "victim", tree={"a.txt": "x\n"})
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    env = _env(allowed=str(allowed), denied=str(victim))
+    got = _git("clone", "-q", str(victim), cwd=allowed, env=env)
+    assert got.returncode != nogit.BLOCK_EXIT, (
+        f"a one-argument `git clone <denied>` into an allowed cwd was refused "
+        f"— the destination was read as the SOURCE: {got.stderr!r}")
+    assert (allowed / "victim" / ".git").is_dir()
+
+
+# 🔴 Hazards closed by CONTAINING the write rather than by refusing the outer
+# command. `bisect run` legitimately succeeds — what must not happen is the
+# `git` inside its script reaching the victim, and that inner call is refused
+# by the exec-path farm while the bisect itself completes rc 0. Demanding a
+# banner from the OUTER command here would be asserting the wrong thing, in
+# the same way it would be for `status --no-optional-locks`.
+_CLOSED_BY_CONTAINMENT = {"bisect run <git-into-victim>"}
+
+
+@pytest.mark.parametrize("name", sorted(_BYPASSES))
+def test_a_measured_bypass_is_closed(name, tmp_path, no_real_git_writes):
+    """Every one of these exited 0 and reached the victim before this rework.
+
+    Scored by the three-way harness: the probe must be clean, the vector must
+    be LIVE with the guard removed, and the guard must hold. A case that stops
+    being live fails here rather than quietly becoming decoration.
+    """
+    if name in _CLOSED_BY_CONTAINMENT:
+        _expect_closed(tmp_path, _BYPASSES[name], name=name)
+    else:
+        _expect_refused(tmp_path, _BYPASSES[name], name=name)
+
+
+def test_the_containment_only_set_is_not_a_place_to_hide_a_failure():
+    """🔴 An escape hatch that can grow silently is not an escape hatch.
+
+    `_CLOSED_BY_CONTAINMENT` downgrades a case from "refused with this policy's
+    banner" to "the victim did not move". That is the right assertion for a
+    command whose own success is legitimate — and it is also exactly how a
+    genuine regression would be papered over. The set is pinned, so adding to
+    it is a reviewed edit.
+    """
+    assert _CLOSED_BY_CONTAINMENT == {"bisect run <git-into-victim>"}
+    assert _CLOSED_BY_CONTAINMENT <= set(_BYPASSES), (
+        "a name in the containment-only set is not a case any more")
+
+
+def test_an_audit_mode_env_var_cannot_disarm_the_guard(
+        tmp_path, no_real_git_writes):
+    """The LIVE half of the audit-mode fix, stated separately.
+
+    `test_the_shim_has_no_env_readable_mode` is a claim about the generated
+    text. This one runs the command.
+    """
+    victim = _victim(tmp_path / "victim")
+    env = _env(allowed=str(tmp_path / "nowhere"), denied=str(victim))
+    env[nogit.MODE_ENV] = nogit.MODE_AUDIT
+    before = _victim_state(victim)
+    got = _git("commit", "--allow-empty", "-m", "AUDITPWN", cwd=victim,
+               env=env)
+    assert got.returncode == nogit.BLOCK_EXIT, (
+        f"{nogit.MODE_ENV}={nogit.MODE_AUDIT} disarmed the guard "
+        f"(rc={got.returncode})")
+    assert _victim_state(victim) == before
+
+
+def test_audit_mode_still_exists_as_a_bake_time_argument(tmp_path):
+    """The measuring tool is not deleted, only made unreachable from the env.
+
+    Audit mode is how this policy's blast radius was established before it was
+    turned on. Keeping it available to `install()` while removing the env
+    switch is the whole point of the change, so both halves are pinned.
+    """
+    stub = tmp_path / "stub"
+    _install(stub, allowed=str(tmp_path / "nowhere"),
+                  denied=str(tmp_path), mode=nogit.MODE_AUDIT)
+    answer = _handshake(stub)
+    assert answer is not None and answer["audit"] == "1", (
+        "install(mode=MODE_AUDIT) did not produce an audit-mode shim")
+
+    stub2 = tmp_path / "stub2"
+    _install(stub2, allowed=str(tmp_path / "nowhere"),
+                  denied=str(tmp_path))
+    answer2 = _handshake(stub2)
+    assert answer2 is not None and answer2["audit"] == "0", (
+        "the DEFAULT install is not block mode")
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE PATH ESCAPE — git's own libexec, and what the farm does about it
+# --------------------------------------------------------------------------- #
+def test_git_prepends_its_own_exec_path_to_PATH_for_children():
+    """The measurement that falsified this policy's central claim.
+
+    The previous revision asserted the shim was reached "at any depth" because
+    it was first on PATH. It is not: git PREPENDS its exec-path for every child
+    it spawns, and that directory ships a real `git`. This pins the mechanism
+    itself, so the claim cannot be restated without the measurement going with
+    it.
+    """
+    real = _real()
+    # 🔴 ASKED WITH L2 OFF AND `GIT_EXEC_PATH` CLEARED. Through the shim, git
+    # reports the FARM as its exec-path (which is the whole point of the farm)
+    # — so a naive query here answers with the guard's own directory and the
+    # comparison below silently compares the farm against the libexec.
+    clean = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    clean["PATH"] = _real_path()
+    with _l2_off():
+        exec_path = subprocess.run([real, "--exec-path"], env=clean,
+                                   capture_output=True, text=True,
+                                   timeout=TIMEOUT).stdout.strip()
+    assert (Path(exec_path) / "git").exists(), (
+        f"{exec_path} has no `git`, so this host's git cannot exhibit the "
+        "escape — the farm may be unnecessary here, which is worth knowing")
+
+    env = dict(clean)
+    with _l2_off():
+        out = subprocess.run(
+            [real, "-c", "alias.p=!echo PATH0=${PATH%%:*}", "p"],
+            cwd="/", env=env, capture_output=True, text=True, timeout=TIMEOUT)
+    assert f"PATH0={exec_path}" in out.stdout, (
+        "git did not prepend its exec-path for the alias child; the escape "
+        f"this policy's farm closes may not exist here. stdout={out.stdout!r}")
+
+
+@pytest.mark.parametrize("where", ["own-config", "own-hook"])
+def test_a_git_spawned_child_resolves_git_to_the_shim(
+        where, tmp_path, no_real_git_writes):
+    """🔴 The escape closed for code that is ALREADY IN THE REPO.
+
+    Refusing the INJECTION channel (`-c alias.*=!…`) is not the same as closing
+    the escape: an alias or hook already present in a fixture's own
+    `.git/config` names nothing on the command line and nothing in the
+    environment, so no injection check can see it.
+
+    `GIT_EXEC_PATH` closes it structurally instead — git prepends the farm, and
+    `git` in the farm is the shim. Measured, both of these wrote the victim a
+    commit before the farm existed and are refused with it.
+    """
+    root = tmp_path / "w"
+    root.mkdir()
+    victim = _victim(root / "victim")
+    allowed = root / "allowed"
+    allowed.mkdir()
+    fixture = _make_repo(allowed / "fix")
+    inner = f"git -C {victim} commit --allow-empty -m CHILDPWN"
+    if where == "own-config":
+        subprocess.run([_real(), "-C", str(fixture), "config", "alias.x",
+                        f"!{inner}"], check=True, capture_output=True,
+                       timeout=TIMEOUT)
+        argv = ["-C", str(fixture), "x"]
+    else:
+        hook = fixture / ".git" / "hooks" / "post-commit"
+        hook.parent.mkdir(parents=True, exist_ok=True)
+        write_exec(hook, f"{inner}\n")
+        argv = ["-C", str(fixture), "commit", "--allow-empty", "-m", "trigger"]
+
+    env = _env(allowed=str(allowed), denied=str(victim))
+    env["HOME"] = str(root / "home")
+    Path(env["HOME"]).mkdir(parents=True, exist_ok=True)
+
+    # LIVE control: the same thing with the guard removed must reach the victim.
+    un_env = dict(env)
+    un_env["PATH"] = _real_path()
+    un_env.pop("GIT_EXEC_PATH", None)
+    un_root = tmp_path / "u"
+    un_root.mkdir()
+    u_victim = _victim(un_root / "victim")
+    u_allowed = un_root / "allowed"
+    u_allowed.mkdir()
+    u_fixture = _make_repo(u_allowed / "fix")
+    u_inner = f"git -C {u_victim} commit --allow-empty -m CHILDPWN"
+    if where == "own-config":
+        subprocess.run([_real(), "-C", str(u_fixture), "config", "alias.x",
+                        f"!{u_inner}"], check=True, capture_output=True,
+                       timeout=TIMEOUT)
+        u_argv = ["-C", str(u_fixture), "x"]
+    else:
+        h = u_fixture / ".git" / "hooks" / "post-commit"
+        h.parent.mkdir(parents=True, exist_ok=True)
+        write_exec(h, f"{u_inner}\n")
+        u_argv = ["-C", str(u_fixture), "commit", "--allow-empty", "-m",
+                  "trigger"]
+    u_env = _env(allowed=str(u_allowed), denied=str(u_victim),
+                 path=_real_path())
+    u_env["HOME"] = str(un_root / "home")
+    Path(u_env["HOME"]).mkdir(parents=True, exist_ok=True)
+    u_before = _victim_state(u_victim)
+    with _l2_off():
+        subprocess.run([_real(), *u_argv], cwd=str(un_root), env=u_env,
+                       capture_output=True, text=True, timeout=TIMEOUT)
+    assert _victim_state(u_victim) != u_before, (
+        f"the {where} escape is not LIVE on this host, so the guarded result "
+        "below proves nothing")
+
+    before = _victim_state(victim)
+    _git(*argv, cwd=root, env=env)
+    assert _victim_state(victim) == before, (
+        f"a git spawned from a {where} reached the victim — GIT_EXEC_PATH is "
+        "not shadowing `git` for git's own children")
+
+
+def test_a_shell_alias_writing_the_victim_is_NOT_covered(
+        tmp_path, no_real_git_writes):
+    """🔴 THE STATED LIMIT, PINNED AS A MEASUREMENT RATHER THAN A SENTENCE.
+
+    The farm makes every `git` a git-spawned child runs reach the shim. It does
+    NOT — and no git guard can — bound a shell command that writes a file
+    directly. Measured: an alias whose body is `sh -c 'echo … > <victim>/X'`
+    creates that file with the guard fully installed.
+
+    This is pinned so that the limit is a fact the suite carries rather than a
+    claim in a docstring. If a future change DOES cover it, this test goes red
+    and the docstring must be rewritten — which is the correct outcome, not a
+    nuisance.
+
+    EXPOSED SURFACE, enumerated — and enumerated by what actually happens to
+    each channel, because a docstring that names a channel the code does not
+    refuse is the thing this rework kept finding:
+
+      * REFUSED outright when non-empty, so the channel cannot be opened:
+        `alias.*`, `core.fsmonitor`, `diff.external`, `filter.*.clean` /
+        `.smudge` / `.process`, `*.textconv`, `core.pager`, `core.editor`,
+        `core.sshCommand`, `credential.helper`, `gpg.program`,
+        `merge.*.driver` (`GIT_CONFIG_CMD_KEYS`), and the environment twins
+        `GIT_EXTERNAL_DIFF`, `GIT_ASKPASS`, `GIT_PROXY_COMMAND`, `GIT_SSH`
+        (`GIT_EXEC_ENV`).
+      * BOUNDED rather than refused, because a real caller needs them:
+        `core.hooksPath` and `init.templateDir` (`GIT_CONFIG_PATH_KEYS`) — the
+        value must be inside an allowed root.
+      * NOT REFUSED AT ALL, and named here so the list is honest:
+        `GIT_SSH_COMMAND` (one legitimate caller —
+        `scripts/resume-state.sh:327` — and putting it on the list cost nine
+        red tests), and `.git/hooks/*` scripts, `rebase --exec` and
+        `submodule foreach`, whose bodies are argv or on-disk files rather
+        than an injection channel.
+
+    For everything in the last group, and for anything in the first two that a
+    repo the test OWNS already carries in its own config, the `git` such code
+    spawns is still caught by the exec-path farm — measured, in
+    `test_a_git_spawned_child_resolves_git_to_the_shim`. What is uncovered is
+    the part of such a body that is not a `git` invocation, which is what this
+    test pins.
+    """
+    root = tmp_path / "w"
+    root.mkdir()
+    victim = _victim(root / "victim")
+    allowed = root / "allowed"
+    allowed.mkdir()
+    fixture = _make_repo(allowed / "fix")
+    marker = victim / "SHELL-ALIAS-RAN"
+    subprocess.run(
+        [_real(), "-C", str(fixture), "config", "alias.x",
+         f"!sh -c 'echo OWNED > {marker}'"],
+        check=True, capture_output=True, timeout=TIMEOUT)
+
+    env = _env(allowed=str(allowed), denied=str(victim))
+    env["HOME"] = str(root / "home")
+    Path(env["HOME"]).mkdir(parents=True, exist_ok=True)
+    _git("-C", str(fixture), "x", cwd=root, env=env)
+    assert marker.exists(), (
+        "a shell alias writing the victim directly was BLOCKED. That is a "
+        "better outcome than this test expects — update this test and the "
+        "'stated limit' paragraphs in testlib/nogit.py and "
+        "testlib/nogit_plugin.py, which currently tell the reader it is not "
+        "covered.")
 
 
 # --------------------------------------------------------------------------- #
@@ -437,14 +1669,11 @@ def test_a_write_inside_an_allowed_root_still_works(
         args, tmp_path, no_real_git_writes):
     """🔴 A guard that refuses everything looks identical to one that works.
 
-    Every assertion above is satisfied by a shim that blocks unconditionally.
-    This is the half that distinguishes them, and it is the half that found two
-    real defects: the first draft refused `git init <tmpdir>` (it judged by cwd
-    rather than by the positional path) and refused every fixture-to-fixture
-    `push` (it read the value of `-C` as the remote name).
+    Every negative assertion above is satisfied by a shim that blocks
+    unconditionally. This is the half that distinguishes them, and it is the
+    half that found two real defects: the first draft refused `git init
+    <tmpdir>` and refused every fixture-to-fixture `push`.
     """
-    # `set-url` needs an existing remote to re-point; every other case must
-    # start from a repo that has none, so the origin is added only for that one.
     pre = "/tmp/original.git" if args[:2] == ("remote", "set-url") else None
     fixture = _make_repo(tmp_path / "fixture", origin=pre)
     env = _env(allowed=str(tmp_path), denied=str(tmp_path / "nowhere"))
@@ -455,14 +1684,83 @@ def test_a_write_inside_an_allowed_root_still_works(
     assert got.returncode == 0, f"unexpected git failure: {got.stderr!r}"
 
 
+def test_the_analyze_service_index_hook_neutraliser_still_works(
+        tmp_path, no_real_git_writes):
+    """🔴 THE CALLER THAT FORCED A BOUNDS CHECK RATHER THAN A REFUSAL.
+
+    `scripts/analyze-service-index/commit.sh:247` exports, for every git call
+    it makes:
+
+        GIT_CONFIG_NOSYSTEM=1
+        GIT_CONFIG_GLOBAL=/dev/null
+        GIT_CONFIG_COUNT=2
+        GIT_CONFIG_KEY_0=core.hooksPath   GIT_CONFIG_VALUE_0=$ASI_NOHOOKS
+        GIT_CONFIG_KEY_1=init.templateDir GIT_CONFIG_VALUE_1=$ASI_NOHOOKS
+
+    where `$ASI_NOHOOKS` is an empty `mktemp -d` under `$TMPDIR`. It is doing
+    the RIGHT thing — neutralising hooks — and two tests pin it. Blanket-
+    refusing the `GIT_CONFIG_COUNT` family would have gone red on it and the
+    guard would have been switched off.
+
+    This reproduces the exact shape and requires it to pass, which is what
+    makes `test_a_measured_bypass_is_closed[GIT_CONFIG_COUNT -> core.hooksPath …]`
+    a statement about the VALUE rather than about the mechanism.
+    """
+    nohooks = tmp_path / "asi-nohooks"
+    nohooks.mkdir()
+    fixture = _make_repo(tmp_path / "fix")
+    env = _env(allowed=str(tmp_path), denied=str(tmp_path / "nowhere"))
+    env.update({
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_COUNT": "2",
+        "GIT_CONFIG_KEY_0": "core.hooksPath",
+        "GIT_CONFIG_VALUE_0": str(nohooks),
+        "GIT_CONFIG_KEY_1": "init.templateDir",
+        "GIT_CONFIG_VALUE_1": str(nohooks),
+    })
+    got = _git("commit", "--allow-empty", "-m", "asi", cwd=fixture, env=env)
+    assert got.returncode == 0, (
+        "the analyze-service-index hook-neutralising idiom was refused "
+        f"(rc={got.returncode}): {got.stderr!r}. A bounds check on the VALUE "
+        "must pass a path inside an allowed root.")
+
+
+def test_an_empty_command_valued_config_is_a_disarm_not_an_arm(
+        tmp_path, no_real_git_writes):
+    """`-c core.fsmonitor=` DISABLES the hook — `task-spec-drafter` relies on it.
+
+    `scripts/task-spec-drafter/ticket-status:249` passes exactly this as a
+    hardening measure. Refusing every command-valued key regardless of value
+    would have gone red on a caller doing the right thing, so an EMPTY value is
+    explicitly allowed.
+    """
+    fixture = _make_repo(tmp_path / "fix")
+    env = _env(allowed=str(tmp_path), denied=str(tmp_path / "nowhere"))
+    got = _git("-c", "core.fsmonitor=", "-c", "protocol.ext.allow=never",
+               "commit", "--allow-empty", "-m", "hardened", cwd=fixture,
+               env=env)
+    assert got.returncode == 0, (
+        f"`-c core.fsmonitor=` (empty = disarm) was refused: {got.stderr!r}")
+
+
+def test_a_nonempty_command_valued_config_is_refused(
+        tmp_path, no_real_git_writes):
+    """The mirror of the above — and the reason the empty case is not a hole."""
+    fixture = _make_repo(tmp_path / "fix")
+    env = _env(allowed=str(tmp_path), denied=str(tmp_path / "nowhere"))
+    got = _git("-c", "core.fsmonitor=/bin/true", "commit", "--allow-empty",
+               "-m", "armed", cwd=fixture, env=env)
+    assert got.returncode == nogit.BLOCK_EXIT, (
+        f"`-c core.fsmonitor=<command>` was allowed (rc={got.returncode}) — a "
+        "command string cannot be bounded to a directory, so it must be "
+        "refused")
+    assert nogit.BANNER in got.stderr
+
+
 def test_git_init_of_a_fixture_dir_is_allowed_from_inside_a_denied_cwd(
         tmp_path, no_real_git_writes):
-    """`git init <tmpdir>` writes to the ARGUMENT, not to the cwd.
-
-    Measured: judging this by cwd refuses every fixture that builds itself a
-    clone, because the suite's cwd is the repo. A permanently-red gate gets
-    switched off, and then the real hazard is back.
-    """
+    """`git init <tmpdir>` writes to the ARGUMENT, not to the cwd."""
     denied = _make_repo(tmp_path / "denied")
     allowed = tmp_path / "allowed"
     allowed.mkdir()
@@ -473,9 +1771,52 @@ def test_git_init_of_a_fixture_dir_is_allowed_from_inside_a_denied_cwd(
     assert (allowed / "new" / ".git").is_dir()
 
 
+def test_a_separate_git_dir_inside_an_allowed_root_still_works(
+        tmp_path, no_real_git_writes):
+    """The positive half of the `--separate-git-dir` destination check."""
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    env = _env(allowed=str(allowed), denied=str(tmp_path / "nowhere"))
+    got = _git("init", "-q", "--separate-git-dir", str(allowed / "gd"),
+               str(allowed / "wt"), cwd=allowed, env=env)
+    assert got.returncode == 0, (
+        f"`--separate-git-dir` inside an allowed root was refused: "
+        f"{got.stderr!r}")
+    assert (allowed / "gd" / "HEAD").exists()
+
+
+def test_a_worktree_add_inside_an_allowed_root_still_works(
+        tmp_path, no_real_git_writes):
+    """The positive half of the `worktree add` destination check."""
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    fixture = _make_repo(allowed / "fix")
+    env = _env(allowed=str(allowed), denied=str(tmp_path / "nowhere"))
+    got = _git("-C", str(fixture), "worktree", "add", str(allowed / "wt"),
+               cwd=allowed, env=env)
+    assert got.returncode == 0, (
+        f"`worktree add` inside an allowed root was refused: {got.stderr!r}")
+    assert (allowed / "wt" / ".git").exists()
+
+
+def test_an_archive_output_inside_an_allowed_root_still_works(
+        tmp_path, no_real_git_writes):
+    """The positive half of the `archive --output` destination check."""
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    fixture = _make_repo(allowed / "fix", tree={"a.txt": "x\n"})
+    env = _env(allowed=str(allowed), denied=str(tmp_path / "nowhere"))
+    got = _git("-C", str(fixture), "archive", "--output",
+               str(allowed / "ok.tar"), "HEAD", cwd=allowed, env=env)
+    assert got.returncode == 0, (
+        f"`archive --output` inside an allowed root was refused: "
+        f"{got.stderr!r}")
+    assert (allowed / "ok.tar").exists()
+
+
 def test_git_clone_into_a_denied_path_is_still_refused(
         tmp_path, no_real_git_writes):
-    """The mirror of the above — the positional target is CHECKED, not trusted."""
+    """The positional target is CHECKED, not trusted."""
     src = _make_repo(tmp_path / "src")
     denied = tmp_path / "denied"
     denied.mkdir()
@@ -494,30 +1835,25 @@ def test_a_restore_afterwards_does_not_hide_the_write(
 
     The restore is why this was invisible — after the run `git remote -v` on
     the real clone reported exactly the right URL. A guard that inspected state
-    AFTER the fact would see nothing at all, in both the run below and the real
-    incident. This asserts the guard fires at the moment of the call, and that
-    the URL is unchanged afterwards because the write never happened — not
-    because something put it back.
+    AFTER the fact would see nothing at all.
     """
     victim = _make_repo(tmp_path / "victim")
-    real = shutil.which("git", path=_real_path())
     good = str(tmp_path / "upstream.git")
-    subprocess.run([real, "remote", "add", "origin", good], cwd=str(victim),
-                   check=True, capture_output=True, timeout=TIMEOUT)
+    subprocess.run([_real(), "remote", "add", "origin", good],
+                   cwd=str(victim), check=True, capture_output=True,
+                   timeout=TIMEOUT)
 
     env = _env(allowed=str(tmp_path / "nowhere"), denied=str(victim))
     script = tmp_path / "victim.sh"
     # The drift-check.sh:444 / ship.sh:190 shape: `:-` falls back on EMPTY as
     # well as unset, so an override that is set-but-blank lands on the default.
-    script.write_text(
-        "#!/bin/sh\n"
+    write_exec(
+        script,
         'repo="${DRIFT_REPO:-' + str(victim) + '}"\n'
         'saved=$(git -C "$repo" remote get-url origin)\n'
         'git -C "$repo" remote set-url origin /tmp/poisoned.git || exit 40\n'
         'git -C "$repo" remote set-url origin "$saved"\n'
-        'echo restored\n',
-        encoding="utf-8")
-    script.chmod(0o755)
+        'echo restored\n')
 
     env["DRIFT_REPO"] = ""  # present but EMPTY — the case `:-` hides
     got = subprocess.run(["/bin/sh", str(script)], cwd=str(tmp_path), env=env,
@@ -529,7 +1865,7 @@ def test_a_restore_afterwards_does_not_hide_the_write(
     assert nogit.BANNER in got.stderr
     assert "restored" not in got.stdout
 
-    after = subprocess.run([real, "remote", "get-url", "origin"],
+    after = subprocess.run([_real(), "remote", "get-url", "origin"],
                            cwd=str(victim), capture_output=True, text=True,
                            timeout=TIMEOUT)
     assert after.stdout.strip() == good, (
@@ -539,52 +1875,9 @@ def test_a_restore_afterwards_does_not_hide_the_write(
 # --------------------------------------------------------------------------- #
 # 🔴 THE GIT ENVIRONMENT — `-C` IS NOT PROTECTIVE
 # --------------------------------------------------------------------------- #
-def _victim_state(repo: Path) -> tuple:
-    """Everything an intruder would disturb, as one comparable tuple."""
-    real = shutil.which("git", path=_real_path())
-    def q(*a: str) -> str:
-        return subprocess.run([real, "-C", str(repo), *a], capture_output=True,
-                              text=True, timeout=TIMEOUT).stdout.strip()
-    keep = repo / "keep.txt"
-    return (q("rev-parse", "HEAD"), q("branch", "--show-current"),
-            q("rev-list", "--count", "HEAD"), q("config", "--get", "user.email"),
-            keep.read_text(encoding="utf-8") if keep.exists() else "")
-
-
-def _victim(path: Path) -> Path:
-    """A repo that must survive every test in this section untouched."""
-    real = shutil.which("git", path=_real_path())
-    _make_repo(path)
-    (path / "keep.txt").write_text("PRECIOUS", encoding="utf-8")
-    for a in (("add", "keep.txt"), ("commit", "-q", "-m", "victimseed")):
-        subprocess.run([real, "-C", str(path), *a], check=True,
-                       capture_output=True, timeout=TIMEOUT)
-    return path
-
-
-@pytest.mark.parametrize("var,rel,args", [
-    # IDENTITY redirection — git reports a different repo.
-    ("GIT_DIR", ".git", ("commit", "--allow-empty", "-m", "PWNED")),
-    ("GIT_COMMON_DIR", ".git", ("commit", "--allow-empty", "-m", "PWNED")),
-    ("GIT_DIR", ".git", ("branch", "-m", "main", "trunk")),
-    ("GIT_DIR", ".git", ("config", "user.email", "pwned@x")),
-    # 🔴 BYTE redirection — identity stays innocent and TRUTHFUL; only the
-    # destination moves. An identity-based check passes every one of these and
-    # the bytes are still written. `GIT_WORK_TREE` is the one that matters most.
-    ("GIT_WORK_TREE", "", ("checkout", "-f", "HEAD")),
-    ("GIT_WORK_TREE", "", ("add", "-A")),
-    ("GIT_INDEX_FILE", ".git/index", ("add", "a.txt")),
-    ("GIT_OBJECT_DIRECTORY", ".git/objects",
-     ("commit", "--allow-empty", "-m", "PWNED")),
-    ("GIT_ALTERNATE_OBJECT_DIRECTORIES", ".git/objects",
-     ("commit", "--allow-empty", "-m", "PWNED")),
-    ("GIT_CONFIG_GLOBAL", ".gitconfig",
-     ("config", "--global", "user.name", "pwned")),
-    ("GIT_CONFIG_SYSTEM", ".gitconfig",
-     ("config", "--system", "user.name", "pwned")),
-])
+@pytest.mark.parametrize("var", sorted(_ENV_VECTORS))
 def test_a_git_env_var_armed_at_a_victim_is_refused(
-        var, rel, args, tmp_path, no_real_git_writes):
+        var, tmp_path, no_real_git_writes):
     """🔴 Every path ARGUMENT names an innocent fixture; only the ENV points out.
 
     Measured before this check existed:
@@ -596,14 +1889,19 @@ def test_a_git_env_var_armed_at_a_victim_is_refused(
     That is why "absolute `-C`, therefore fixture-scoped" cleared this suite in
     two independent audits: it is the wrong property.
 
-    The victim's whole state is compared, not just an exit code — a guard that
-    returns 99 after the write has landed is not a guard.
+    The command paired with each variable is the one proven LIVE by
+    `test_every_env_ledger_entry_is_a_live_write_vector`, so "the victim is
+    unchanged" here is a statement about the guard rather than about a command
+    that could never have done anything.
     """
+    rel, args, tree = _ENV_VECTORS[var]
     victim = _victim(tmp_path / "victim")
-    fixture = _make_repo(tmp_path / "allowed" / "fix")
+    fixture = _make_repo(tmp_path / "allowed" / "fix", tree=tree)
     before = _victim_state(victim)
 
     env = _env(allowed=str(tmp_path / "allowed"), denied=str(victim))
+    env["HOME"] = str(tmp_path / "home")
+    Path(env["HOME"]).mkdir(parents=True, exist_ok=True)
     env[var] = str(victim / rel) if rel else str(victim)
 
     got = _git(*args, cwd=fixture, env=env)
@@ -612,9 +1910,11 @@ def test_a_git_env_var_armed_at_a_victim_is_refused(
         f"{var} armed at the victim was NOT refused (rc={got.returncode}). "
         f"stderr={got.stderr!r}")
     assert nogit.BANNER in got.stderr
-    assert _victim_state(victim) == before, (
+    after = _victim_state(victim)
+    assert after == before, (
         f"{var}: the guard returned {got.returncode} but the victim CHANGED.\n"
-        f"  before: {before}\n  after:  {_victim_state(victim)}")
+        f"  changed: "
+        f"{sorted(k for k in set(after[2]) | set(before[2]) if after[2].get(k) != before[2].get(k))[:6]}")
 
 
 @pytest.mark.parametrize("args", [
@@ -649,9 +1949,7 @@ def test_dev_null_as_a_config_sink_is_not_a_violation(
 
     MEASURED: it was **590 of the 593** firings on the first armed run of the
     full suite. Refusing it makes the policy permanently red across
-    `scripts/tests`, and a permanently-red gate gets switched off — taking the
-    real protection with it. `/dev/null` discards writes, so exempting it costs
-    nothing; `GIT_CONFIG_GLOBAL=<victim>/.gitconfig` is still refused above.
+    `scripts/tests`, and a permanently-red gate gets switched off.
     """
     fixture = _make_repo(tmp_path / "allowed" / "fix")
     env = _env(allowed=str(tmp_path / "allowed"),
@@ -663,26 +1961,6 @@ def test_dev_null_as_a_config_sink_is_not_a_violation(
         f"/dev/null as a config sink was refused: {got.stderr!r}")
 
 
-def test_the_env_ledger_holds_only_paths_that_receive_bytes():
-    """Pinned, and pinned for a reason that cost a full armed run.
-
-    `GIT_NAMESPACE` (a ref namespace) and `GIT_CEILING_DIRECTORIES` (which only
-    NARROWS discovery) were both on this ledger and both were wrong: neither
-    can redirect a write to a path, so both produced pure false positives. They
-    passed a negative control only because that control armed them at a
-    path-shaped value, which measures the guard rather than the hazard.
-    """
-    assert set(nogit.GIT_LOCATION_ENV) == {
-        "GIT_DIR", "GIT_COMMON_DIR", "GIT_WORK_TREE", "GIT_OBJECT_DIRECTORY",
-        "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_INDEX_FILE",
-        "GIT_CONFIG_GLOBAL", "GIT_CONFIG_SYSTEM",
-    }
-    for bad in ("GIT_NAMESPACE", "GIT_CEILING_DIRECTORIES"):
-        assert bad not in nogit.GIT_LOCATION_ENV, (
-            f"{bad} does not receive bytes — treating it as a write target "
-            "refuses the safe case")
-
-
 def test_the_policy_survives_a_child_with_a_REPLACING_env(
         tmp_path, no_real_git_writes):
     """🔴 The roots are BAKED INTO the shim; the environment only widens them.
@@ -690,17 +1968,13 @@ def test_the_policy_survives_a_child_with_a_REPLACING_env(
     MEASURED: three tests in this suite build `env={HOME, GIT_CONFIG_GLOBAL,
     GIT_CONFIG_SYSTEM, PATH}` for a hermetic `git init` in their own tmp_path.
     `PATH` still reaches the shim, so the shim runs — and when the policy lived
-    only in the environment it ran with NO roots and refused them. Reading the
-    policy from a variable makes it depend on that variable surviving into
-    every descendant, which is not a property anyone maintains.
-
-    This drives a child with an env carrying ONLY the four keys those tests
-    keep, and asserts both halves still hold.
+    only in the environment it ran with NO roots and refused them.
     """
     stub = Path(os.environ[nogit.STUB_DIR_ENV])
     fixture_parent = tmp_path / "fix"
     fixture_parent.mkdir()
     victim = _victim(tmp_path / "victim")
+    before = _victim_state(victim)
 
     bare = {"HOME": str(tmp_path), "PATH": os.environ["PATH"],
             "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"}
@@ -724,20 +1998,51 @@ def test_the_policy_survives_a_child_with_a_REPLACING_env(
     assert bad.returncode == nogit.BLOCK_EXIT, (
         "with the policy variables absent, a write to the tree under test was "
         f"ALLOWED (rc={bad.returncode}) — the deny floor is not baked in")
-    assert _victim_state(victim) == _victim_state(victim)
+    # 🔴 Compared against the state captured BEFORE the run. The previous
+    # version of this line read `_victim_state(v) == _victim_state(v)`, a
+    # tautology that is true of any two identical calls and could never fail.
+    assert _victim_state(victim) == before
+
+
+def test_the_exec_path_farm_survives_a_child_with_a_REPLACING_env(
+        tmp_path, no_real_git_writes):
+    """The farm must not depend on the plugin's exported GIT_EXEC_PATH.
+
+    A child built with a replacing `env=` keeps only `PATH` — so the shim
+    re-exports `GIT_EXEC_PATH` itself on every call. Without that, such a child
+    reaches the shim, the shim execs the real git, and the real git restores
+    its own libexec for every grandchild.
+    """
+    root = tmp_path / "w"
+    root.mkdir()
+    victim = _victim(root / "victim")
+    allowed = root / "allowed"
+    allowed.mkdir()
+    fixture = _make_repo(allowed / "fix")
+    subprocess.run(
+        [_real(), "-C", str(fixture), "config", "alias.x",
+         f"!git -C {victim} commit --allow-empty -m REPLACED"],
+        check=True, capture_output=True, timeout=TIMEOUT)
+
+    bare = {"HOME": str(root / "home"), "PATH": os.environ["PATH"],
+            nogit.ROOTS_ENV: str(allowed),
+            nogit.DENY_ROOTS_ENV: str(victim)}
+    Path(bare["HOME"]).mkdir(parents=True, exist_ok=True)
+    assert "GIT_EXEC_PATH" not in bare
+
+    before = _victim_state(victim)
+    subprocess.run(["git", "-C", str(fixture), "x"], cwd=str(root), env=bare,
+                   capture_output=True, text=True, timeout=TIMEOUT)
+    assert _victim_state(victim) == before, (
+        "with GIT_EXEC_PATH absent from a replacing env, an alias child "
+        "reached the real git and wrote the victim")
 
 
 def test_the_deny_floor_is_a_union_not_an_override(tmp_path, no_real_git_writes):
-    """A test may widen what it can write to; nothing may un-deny the repo.
-
-    The asymmetry is deliberate. `roots` is `${VAR:-<baked>}` so a test can
-    narrow or widen its own sandbox, but `denied` is `<baked>${VAR:+:$VAR}` so
-    the tree under test is refused even when a caller passes its own deny list
-    — or an empty one.
-    """
+    """A test may widen what it can write to; nothing may un-deny the repo."""
     body = nogit.git_body("/bin/true", Path("/dev/null"),
                           allowed_roots="/BAKED_ALLOW",
-                          denied_roots="/BAKED_DENY")
+                          denied_roots="/BAKED_DENY", stub_dir=tmp_path)
     assert f'roots="${{{nogit.ROOTS_ENV}:-/BAKED_ALLOW}}"' in body
     assert (f'denied="/BAKED_DENY${{{nogit.DENY_ROOTS_ENV}:+'
             f':${{{nogit.DENY_ROOTS_ENV}}}}}"') in body, (
@@ -745,12 +2050,35 @@ def test_the_deny_floor_is_a_union_not_an_override(tmp_path, no_real_git_writes)
         f"{nogit.DENY_ROOTS_ENV} could drop the tree under test from it")
 
 
+def test_the_deny_floor_is_a_union_in_practice(tmp_path, no_real_git_writes):
+    """The LIVE half of the test above — a string in a body is not behaviour."""
+    stub = tmp_path / "stub"
+    victim = _victim(tmp_path / "victim")
+    _install(stub, allowed=str(tmp_path), denied=str(victim))
+    env = dict(os.environ)
+    env["PATH"] = str(stub) + os.pathsep + _real_path()
+    # A caller supplying its OWN deny list must not drop the baked one.
+    env[nogit.DENY_ROOTS_ENV] = str(tmp_path / "somewhere-else")
+    env.pop(nogit.ROOTS_ENV, None)
+    before = _victim_state(victim)
+    with _l2_off():
+        got = subprocess.run([str(stub / "git"), "-C", str(victim), "commit",
+                              "--allow-empty", "-m", "UNDENY"],
+                             cwd=str(tmp_path), env=env, capture_output=True,
+                             text=True, timeout=TIMEOUT)
+    assert got.returncode == nogit.BLOCK_EXIT, (
+        "a caller-supplied deny list replaced the baked one instead of adding "
+        f"to it (rc={got.returncode})")
+    assert _victim_state(victim) == before
+
+
 def test_the_session_scrubs_an_inherited_git_env(no_real_git_writes):
     """A pytest session has no business inheriting any of these."""
-    for var in nogit.GIT_LOCATION_ENV:
+    for var in (*nogit.GIT_LOCATION_ENV, *nogit.GIT_EXEC_ENV,
+                nogit.MODE_ENV, "GIT_CONFIG_COUNT"):
         assert var not in os.environ, (
             f"{var} survived into the test session: an ambient value redirects "
-            "every `git -C <fixture>` write in the suite")
+            "or executes for every `git` call in the suite")
 
 
 def test_the_prescan_fixture_chain_cannot_reach_a_victim(
@@ -758,8 +2086,7 @@ def test_the_prescan_fixture_chain_cannot_reach_a_victim(
     """🔴 REGRESSION TEST FOR THE ACTUAL INCIDENT.
 
     `scripts/repo-cos/tests/test_prescan.py::_init_clone` is the identified
-    culprit, and its steps are replayed verbatim below. Read them against the
-    real clone's reflog:
+    culprit, and its steps are replayed verbatim below:
 
         _git(clone, "config", "user.email", "t@t")   -> the `t <t@t>` author
         _git(clone, "commit", "-m", "seed")          -> `trunk@{1}: commit: seed`
@@ -768,8 +2095,7 @@ def test_the_prescan_fixture_chain_cannot_reach_a_victim(
 
     Every one of those is `git -C <tmp clone> …` — absolute, fixture-scoped,
     and cleared by two audits. With an ambient `GIT_DIR` they all land in
-    whatever repo it names. This asserts the chain is refused and the victim is
-    untouched, so the mechanism cannot come back through a different fixture.
+    whatever repo it names.
     """
     victim = _victim(tmp_path / "victim")
     before = _victim_state(victim)
@@ -778,22 +2104,28 @@ def test_the_prescan_fixture_chain_cannot_reach_a_victim(
     env = _env(allowed=str(tmp_path / "allowed"), denied=str(victim))
     env["GIT_DIR"] = str(victim / ".git")
 
+    steps = (("config", "user.email", "t@t"),
+             ("config", "user.name", "t"),
+             ("commit", "--allow-empty", "--quiet", "-m", "seed"),
+             ("branch", "-M", "trunk"),
+             ("remote", "set-head", "origin", "trunk"),
+             ("push", "--quiet", "origin", "HEAD:trunk"))
     refused = 0
-    for args in (("config", "user.email", "t@t"),
-                 ("config", "user.name", "t"),
-                 ("commit", "--allow-empty", "--quiet", "-m", "seed"),
-                 ("branch", "-M", "trunk"),
-                 ("remote", "set-head", "origin", "trunk"),
-                 ("push", "--quiet", "origin", "HEAD:trunk")):
+    for args in steps:
         got = _git(*args, cwd=clone, env=env)
         assert got.returncode == nogit.BLOCK_EXIT, (
             f"`git {' '.join(args)}` reached the victim (rc={got.returncode})")
         refused += 1
 
-    assert refused == 6
-    assert _victim_state(victim) == before, (
-        f"the victim changed despite every step being refused.\n"
-        f"  before: {before}\n  after:  {_victim_state(victim)}")
+    # 🔴 Compared against the LENGTH OF THE LIST, not against the literal 6.
+    # `assert refused == 6` pins the fixture's own length: adding a step and
+    # forgetting to bump the number is the only way it can fail, and dropping a
+    # step plus the number keeps it green while covering less.
+    assert refused == len(steps)
+    after = _victim_state(victim)
+    assert after == before, (
+        "the victim changed despite every step being refused: "
+        f"{sorted(k for k in set(after[2]) | set(before[2]) if after[2].get(k) != before[2].get(k))[:6]}")
 
 
 # --------------------------------------------------------------------------- #
@@ -801,16 +2133,9 @@ def test_the_prescan_fixture_chain_cannot_reach_a_victim(
 # --------------------------------------------------------------------------- #
 def test_the_same_write_succeeds_with_the_shim_removed(
         tmp_path, no_real_git_writes):
-    """🔴 Disable the policy and watch the offending command pass silently.
-
-    Without this, every "was refused" assertion above is equally satisfied by a
-    command that simply cannot work — a `remote set-url` that fails for its own
-    reasons would read as a guard firing. Running the identical argv against
-    the ambient PATH shows the guard is the only thing standing in the way.
-    """
+    """🔴 Disable the policy and watch the offending command pass silently."""
     victim = _make_repo(tmp_path / "victim")
-    real = shutil.which("git", path=_real_path())
-    subprocess.run([real, "remote", "add", "origin", "/tmp/original.git"],
+    subprocess.run([_real(), "remote", "add", "origin", "/tmp/original.git"],
                    cwd=str(victim), check=True, capture_output=True,
                    timeout=TIMEOUT)
 
@@ -822,16 +2147,17 @@ def test_the_same_write_succeeds_with_the_shim_removed(
         capture_output=True, text=True, timeout=TIMEOUT)
     assert guarded.returncode == nogit.BLOCK_EXIT
 
-    unguarded = subprocess.run(
-        argv, cwd=str(victim),
-        env=_env(allowed=str(tmp_path / "nowhere"), denied=str(victim),
-                 path=_real_path()),
-        capture_output=True, text=True, timeout=TIMEOUT)
+    with _l2_off():
+        unguarded = subprocess.run(
+            argv, cwd=str(victim),
+            env=_env(allowed=str(tmp_path / "nowhere"), denied=str(victim),
+                     path=_real_path()),
+            capture_output=True, text=True, timeout=TIMEOUT)
     assert unguarded.returncode == 0, (
         f"the mutation control did not pass: {unguarded.stderr!r}. The "
         "'blocked' results above cannot be attributed to the guard.")
 
-    url = subprocess.run([real, "remote", "get-url", "origin"],
+    url = subprocess.run([_real(), "remote", "get-url", "origin"],
                          cwd=str(victim), capture_output=True, text=True,
                          timeout=TIMEOUT)
     assert url.stdout.strip() == "/tmp/poisoned.git", (
@@ -840,15 +2166,324 @@ def test_the_same_write_succeeds_with_the_shim_removed(
 
 
 # --------------------------------------------------------------------------- #
+# 🔴 THE HANDSHAKE — a filename is not a guard
+# --------------------------------------------------------------------------- #
+def test_the_handshake_accepts_this_policys_own_shim(tmp_path):
+    stub = tmp_path / "stub"
+    _install(stub, allowed=str(tmp_path), denied=str(nogit.repo_root()))
+    answer = _handshake(stub)
+    assert answer is not None
+    assert answer["fingerprint"] == nogit.policy_fingerprint()
+    assert answer["roots"] == str(tmp_path)
+
+
+@pytest.mark.parametrize("flavour", ["passthrough", "silent", "wrong-token",
+                                     "not-executable", "absent"])
+def test_the_handshake_rejects_anything_that_is_not_this_policys_shim(
+        flavour, tmp_path):
+    """🔴 THE MEASURED FAILURE THIS REPLACES.
+
+    `_inherited_stub_dir()` used to adopt any directory containing a FILE
+    NAMED `git` and then skip `install()` entirely. Measured with
+    `DEVRC_TEST_GIT_STUB_DIR` pointed at a plain passthrough script: a write to
+    the repo-under-test landed **rc 0, no banner**, the session marker was
+    written anyway, and pytest reported "1 passed". The docstring claimed the
+    opposite. A filename is walkable by anything called `git`.
+    """
+    d = tmp_path / "foreign"
+    d.mkdir()
+    exe = d / "git"
+    if flavour == "passthrough":
+        write_exec(exe, f'exec {_real()} "$@"\n')
+    elif flavour == "silent":
+        write_exec(exe, "exit 0\n")
+    elif flavour == "wrong-token":
+        write_exec(
+            exe,
+            f'printf "{nogit.HANDSHAKE_MAGIC} deadbeefdeadbeef\\n"\n'
+            'printf "roots=/\\n"\nprintf "denied=/\\n"\nexit 0\n')
+    elif flavour == "not-executable":
+        write_exec(exe, "exit 0\n")
+        exe.chmod(0o644)
+    else:
+        pass  # absent: the directory has no `git` at all
+
+    assert _handshake(d) is None, (
+        f"a {flavour} `git` answered the handshake — the check is not "
+        "verifying that this is THIS policy's shim")
+
+
+def test_a_foreign_inherited_shim_FAILS_the_session_instead_of_being_adopted(
+        tmp_path, monkeypatch):
+    """🔴 And it must FAIL, not fall back to self-installing.
+
+    Falling back would be safe for this session and would silently hide a
+    misconfigured outer runner — which is the state that produced the measured
+    "1 passed" with no guard at all.
+    """
+    d = tmp_path / "foreign"
+    d.mkdir()
+    exe = d / "git"
+    write_exec(exe, f'exec {_real()} "$@"\n')
+    monkeypatch.setenv(nogit.STUB_DIR_ENV, str(d))
+    with _l2_off(), pytest.raises(nogit_plugin.ForeignGitShim) as exc:
+        nogit_plugin._inherited_stub_dir()
+    assert str(d) in str(exc.value)
+
+
+@pytest.mark.parametrize("flaw", ["wrong-deny-floor", "audit-mode"])
+def test_an_inherited_shim_scoped_to_another_tree_is_REPLACED_not_adopted(
+        flaw, tmp_path, monkeypatch):
+    """Genuinely ours, but not usable as-is: self-install instead of adopting.
+
+    A shim whose baked deny floor does not carry THIS tree is structurally
+    inert here — in the nix sandbox the source sits inside an allowed root, so
+    without the deny entry every write this policy exists to stop is permitted.
+    Same for a shim baked in audit mode.
+
+    🔴 IT RETURNS None (self-install) RATHER THAN RAISING, and that direction
+    was MEASURED. Raising cost nine red tests: several tests in this suite copy
+    the repo to a tmp dir and run a NESTED pytest in it. The nested session
+    inherits `DEVRC_TEST_GIT_STUB_DIR`, its `repo_root()` is the copy, and the
+    outer shim's deny roots name the original — a healthy arrangement, not a
+    misconfiguration. The FOREIGN case still raises, because there the question
+    is not "which tree" but "is this a guard at all".
+    """
+    stub = tmp_path / "stub"
+    if flaw == "wrong-deny-floor":
+        _install(stub, allowed=str(tmp_path), denied=str(tmp_path / "nope"))
+    else:
+        _install(stub, allowed=str(tmp_path), denied=str(nogit.repo_root()),
+                 mode=nogit.MODE_AUDIT)
+    assert _handshake(stub) is not None, "the shim IS this policy's"
+    monkeypatch.setenv(nogit.STUB_DIR_ENV, str(stub))
+    with _l2_off():
+        assert nogit_plugin._inherited_stub_dir() is None, (
+            f"a shim with {flaw} was ADOPTED. It answers the handshake, so it "
+            "is ours — but adopting it runs this session under a policy that "
+            "does not bound this tree.")
+
+
+def test_the_fingerprint_changes_when_the_policy_changes(monkeypatch):
+    """The handshake token must track the policy's LOGIC, not just its name.
+
+    Otherwise a shim generated by an older revision — with a ledger entry this
+    revision removed, or a check it did not have — would be adopted as current.
+    """
+    before = nogit.policy_fingerprint()
+    monkeypatch.setattr(nogit, "GIT_LOCATION_ENV",
+                        (*nogit.GIT_LOCATION_ENV, "GIT_MADE_UP_FOR_THE_TEST"))
+    after = nogit.policy_fingerprint()
+    assert after != before, (
+        "changing the environment ledger did not change the policy "
+        "fingerprint, so a shim built from a DIFFERENT policy would answer the "
+        "handshake as if it were this one")
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 L2 — the in-process layer that was completely inert
+# --------------------------------------------------------------------------- #
+def test_both_launch_policies_survive_in_the_popen_chain(no_real_git_writes):
+    """🔴 MEASURED INERT: `Popen.__mro__` was `['_NoLaunchPopen','Popen',…]`.
+
+    Both plugins captured the PRISTINE `subprocess.Popen` at IMPORT time and
+    each assigned its own subclass OF THAT PRISTINE CLASS, so whichever session
+    fixture ran last discarded the other's patch outright — and each teardown
+    restored the pristine class, discarding the survivor too. This policy's L2
+    was the loser, and an absolute-path `git config` against a denied repo
+    returned 0 with no banner. Zero tests referenced it, so nothing was red.
+
+    Both now subclass whatever `Popen` IS at patch time, which composes in
+    either order. This pins that both are still in the chain.
+    """
+    names = [c.__name__ for c in subprocess.Popen.__mro__]
+    assert "_NoGitPopen" in names, (
+        f"this policy's L2 is not in the Popen chain: {names}. An absolute-path "
+        "`git` launched by the pytest process reaches the real binary "
+        "unchecked.")
+    assert "_NoLaunchPopen" in names, (
+        f"the launcher policy's L2 is not in the Popen chain: {names}. One of "
+        "the two patches has deleted the other — the exact failure this "
+        "capture-at-patch-time shape exists to prevent.")
+
+
+def test_an_absolute_path_git_write_is_intercepted_in_process(
+        tmp_path, no_real_git_writes):
+    """L2's whole job, exercised. It had NO test coverage at all.
+
+    PATH cannot shadow an absolute path, so this is the only layer that can see
+    it — and `_redirect_argv` had zero references in the previous 868-line
+    battery.
+    """
+    victim = _victim(tmp_path / "victim")
+    before = _victim_state(victim)
+    env = _env(allowed=str(tmp_path / "nowhere"), denied=str(victim))
+    got = subprocess.run([_real(), "-C", str(victim), "config",
+                          "nogit.absprobe", "1"], cwd=str(tmp_path), env=env,
+                         capture_output=True, text=True, timeout=TIMEOUT)
+    assert got.returncode == nogit.BLOCK_EXIT, (
+        f"an ABSOLUTE-path git write to a denied repo was not intercepted "
+        f"(rc={got.returncode}) — L2 is inert")
+    assert _victim_state(victim) == before
+
+
+@pytest.mark.parametrize("argv,expect_redirect", [
+    (["/usr/bin/git", "status"], True),
+    (["git", "status"], False),            # bare name: L1's job
+    (["/usr/bin/gitk", "status"], False),  # basename is not exactly `git`
+    ("git status", False),                 # a shell string goes via /bin/sh
+    ([], False),
+])
+def test_the_absolute_path_redirect_is_narrow(argv, expect_redirect, tmp_path):
+    """`_redirect_argv` must not perturb launches that are not its business."""
+    got = nogit_plugin._redirect_argv(argv, tmp_path)
+    assert (got is not None) == expect_redirect, (
+        f"_redirect_argv({argv!r}) -> {got!r}")
+    if expect_redirect:
+        assert got[0] == str(tmp_path / "git")
+        assert got[1:] == list(argv)[1:]
+
+
+def test_the_shim_dir_and_the_farm_are_not_redirected(tmp_path):
+    """A git that is ALREADY the shim must not be rewritten to itself.
+
+    Rewriting the farm's `git` in particular would send every git-spawned child
+    through an extra process for no gain.
+    """
+    stub = tmp_path / "stub"
+    _install(stub, allowed=str(tmp_path), denied=str(tmp_path / "nope"))
+    assert nogit_plugin._redirect_argv([str(stub / "git"), "status"],
+                                       stub) is None
+    assert nogit_plugin._redirect_argv(
+        [str(nogit.exec_path_dir(stub) / "git"), "status"], stub) is None
+
+
+# --------------------------------------------------------------------------- #
 # AUTOUSE — protection a test must ask for is protection the next test forgets
 # --------------------------------------------------------------------------- #
-def test_protected_without_asking():
-    """Deliberately does NOT request the fixture.
+def test_the_popen_patch_composes_in_EITHER_order(tmp_path):
+    """🔴 ORDER-INDEPENDENT, because the session's order is not controllable.
 
-    Every other test in this file names `no_real_git_writes`, which would make
-    deleting `autouse=True` completely invisible. This one is the control for
-    that flag.
+    `test_both_launch_policies_survive_in_the_popen_chain` observes whatever
+    order this session's two autouse fixtures happened to run in — and a
+    mutation sweep proved that is not enough: restoring the import-time capture
+    in this module SURVIVED, because with the launcher policy patching second
+    it subclasses ours and the chain looks fine either way.
+
+    This applies both patches explicitly, in both orders, and requires both
+    classes to survive each time. Only capture-at-patch-time satisfies it.
     """
+    from testlib import nolaunch_plugin  # noqa: PLC0415
+
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    saved = subprocess.Popen
+    try:
+        for label, first, second in (
+                ("nolaunch then nogit",
+                 nolaunch_plugin._patch_subprocess,
+                 nogit_plugin._patch_subprocess),
+                ("nogit then nolaunch",
+                 nogit_plugin._patch_subprocess,
+                 nolaunch_plugin._patch_subprocess)):
+            subprocess.Popen = saved
+            first(a)
+            second(b)
+            names = [c.__name__ for c in subprocess.Popen.__mro__]
+            assert "_NoGitPopen" in names, (
+                f"{label}: this policy's L2 was deleted by the other patch. "
+                f"chain={names}")
+            assert "_NoLaunchPopen" in names, (
+                f"{label}: the launcher policy's L2 was deleted by ours. "
+                f"chain={names}")
+    finally:
+        subprocess.Popen = saved
+
+
+def test_a_git_inside_the_sessions_tmp_tree_is_NOT_redirected(tmp_path):
+    """🔴 A test's own `git` DOUBLE must reach the test, not the guard.
+
+    MEASURED when L2 started working: `test_ship_converge.py::_git_shim` builds
+    a `git` under `tmp_path` that is real for every subcommand except one
+    deliberately sabotaged verb. L2 rewrote the call to the shim, the sabotage
+    never happened, and two tests validating `ship.sh`'s currency guard failed
+    on assertions about the guard they were validating.
+
+    Both directions are asserted, because the exclusion is only correct if the
+    thing it exists to catch is still caught.
+    """
+    stub = tmp_path / "stub"
+    _install(stub, allowed=str(tmp_path), denied=str(tmp_path / "nope"))
+
+    double = tmp_path / "double"
+    double.mkdir()
+    write_exec(double / "git", "exit 0\n")
+    assert nogit_plugin._redirect_argv(
+        [str(double / "git"), "status"], stub, tmp_path) is None, (
+        "a `git` a test built inside its own tmp tree was rewritten to the "
+        "shim — L2 replaced the test's instrument with the guard")
+
+    # …and the real binary, outside the tmp tree, still IS redirected.
+    assert nogit_plugin._redirect_argv(
+        [_real(), "status"], stub, tmp_path) is not None, (
+        "an absolute path to the REAL git was not redirected — the exclusion "
+        "has swallowed the only thing L2 exists to catch")
+
+
+
+
+def test_a_deep_init_with_no_dotdot_is_still_allowed(
+        tmp_path, no_real_git_writes):
+    """The positive half of the unresolvable-path fix.
+
+    `git init a/b/c` CREATES its intermediate directories, so "neither the path
+    nor its parent resolves" is the NORMAL case for it — refusing every such
+    path would make `init` unusable. Only `..` can walk out of an allowed root
+    lexically, so only `..` gets the sentinel.
+    """
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    env = _env(allowed=str(allowed), denied=str(tmp_path / "nowhere"))
+    got = _git("init", "-q", str(allowed / "a" / "b" / "c"), cwd=allowed,
+               env=env)
+    assert got.returncode == 0, (
+        f"a deep `git init` inside an allowed root was refused: "
+        f"{got.stderr!r}")
+    assert (allowed / "a" / "b" / "c" / ".git").is_dir()
+
+
+def test_an_unresolvable_dotdot_inside_an_allowed_root_is_refused_anyway(
+        tmp_path, no_real_git_writes):
+    """🔴 THE DELIBERATE COST OF THE FIX ABOVE, PINNED SO IT IS NOT A SURPRISE.
+
+    `<allowed>/exists-later/../ok` resolves to `<allowed>/ok`, which is IN
+    bounds — but `exists-later` does not exist, so the path cannot be
+    canonicalised and the shim cannot tell it from the victim-bound twin above.
+    It is refused.
+
+    That is a false positive, and it is the right trade: the shape is one
+    nobody writes by hand, the refusal is loud and names this policy, and the
+    alternative is resolving `..` lexically — which is wrong in the presence of
+    symlinks and would hand the escape back. Pinned so that a future reader
+    meets it here rather than in a confusing red test.
+    """
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    env = _env(allowed=str(allowed), denied=str(tmp_path / "nowhere"))
+    got = _git("init", "-q", str(allowed / "exists-later" / ".." / "ok"),
+               cwd=allowed, env=env)
+    assert got.returncode == nogit.BLOCK_EXIT, (
+        "an unresolvable path containing `..` was ALLOWED. It happens to land "
+        "in bounds here, but the shim cannot know that — and the identical "
+        "shape aimed at the victim is a measured bypass.")
+    assert nogit.BANNER in got.stderr
+
+
+
+def test_protected_without_asking():
+    """Deliberately does NOT request the fixture."""
     resolved = shutil.which("git")
     assert resolved is not None
     assert Path(resolved).parent == Path(os.environ[nogit.STUB_DIR_ENV]), (
@@ -856,13 +2491,23 @@ def test_protected_without_asking():
         "`autouse=True` has been lost from the session fixture")
 
 
-def test_the_session_marker_was_written(no_real_git_writes):
+def test_the_session_marker_was_written_and_says_how(no_real_git_writes):
     """A guard that never loaded and a guard that found nothing look alike.
 
-    Both leave a clean log. The marker is what separates them, and the runner
-    can require one per target.
+    🔴 AND THE MARKER MUST SAY WHICH. It used to be written identically whether
+    this session installed the shim or ADOPTED an inherited one — so a run that
+    adopted a foreign `git`, installed nothing, and enforced nothing still
+    produced a healthy-looking marker. `via=` is what separates those.
     """
     lines = nogit.recorded(no_real_git_writes)
-    assert any(ln.startswith(nogit_plugin.SESSION_MARKER) for ln in lines), (
+    markers = [ln for ln in lines
+               if ln.startswith(nogit_plugin.SESSION_MARKER)]
+    assert markers, (
         "no session marker in the shim log — this plugin did not load, and a "
         "clean log would be indistinguishable from a clean run")
+    assert any(f"via={nogit_plugin.VIA_SELF}" in ln
+               or f"via={nogit_plugin.VIA_INHERITED}" in ln
+               for ln in markers), (
+        f"the session marker carries no `via=` field: {markers[:2]!r}. A "
+        "self-installed and an inherited shim would be indistinguishable in "
+        "the log a runner reads.")

--- a/scripts/tests/test_no_real_git_remote.py
+++ b/scripts/tests/test_no_real_git_remote.py
@@ -1,0 +1,868 @@
+"""🔴 The guard: no test may WRITE to a git repo it does not own.
+
+This file exists because the suite drove `git` against the operator's REAL
+clone and destroyed `main` on the remote. The ordering is the diagnosis, so it
+is recorded here rather than only in a PR body:
+
+    $ git -C ~/workspace/devrc reflog show trunk
+    5d91acdd trunk@{0}: Branch: renamed refs/heads/main to refs/heads/trunk
+    5d91acdd trunk@{1}: commit: seed
+    2e7a85b3 trunk@{2}: commit: c
+
+    HEAD reflog (local, UTC-5):
+      13:48:11  merge origin/main: Fast-forward   <- last legitimate operation
+      14:21:35  Branch: renamed main to trunk     = 19:21:35Z
+      14:38:36  HEAD at 14200130 (a single-file tree)
+
+Local corruption at **19:21:35Z**; the remote push storm — ~40 pushes onto
+`refs/heads/main` in 43 seconds, four other branches hit — began **19:28:14Z**,
+seven minutes LATER. So the local writes came first and the pushes followed
+them. That rules out an independently-poisoned remote and pins the mechanism as
+"something resolved a repo for itself, then pushed what it found".
+
+🔴 IT IS WHY A PUSH-SCOPED OR REMOTE-SCOPED GUARD WOULD BE USELESS. The whole
+first phase — `commit`, `branch -m`, `config core.bare true` — is local, and a
+guard watching remotes would have let all of it through. The assertions below
+therefore cover LOCAL porcelain with no reference to whether anything would
+ever be pushed.
+
+🔴 AND WHY CLEANUP IS NOT A FIX. The offending code restored the `origin` URL
+it clobbered, so an after-the-fact `git remote -v` showed a clean repo; the
+only way to see it was to look WHILE the suite ran. A restore also only happens
+on clean teardown, and the real clone was found still poisoned long after every
+run had ended. `test_a_restore_afterwards_does_not_hide_the_write` pins that
+the guard fires at the moment of the call, so there is nothing to undo.
+
+SCOPE, stated so the title cannot be read as more than it is: this covers what
+`testlib/nogit_plugin.py` is loaded into. It bounds writes by TARGET PATH, so
+it cannot stop a test that clobbers PATH wholesale, and its in-process layer
+sees only launches made by the pytest process itself.
+
+What is asserted, and why none is enough alone:
+
+  * RESOLUTION — `which("git")` lands in the shim dir.
+  * ORDERING   — the shim dir is PATH[0]. "On PATH" is not the property that
+    matters; "before every ambient entry" is.
+  * READS PASS — the suite reads the real repo on purpose (`ls-files` in four
+    content gates). A guard that broke those would be switched off in a day,
+    so the read path is asserted to reach the REAL binary and forward its
+    output faithfully.
+  * WRITES BLOCK — with this policy's own exit code and banner, so a firing is
+    identifiable rather than a puzzling git error.
+  * FAIL-CLOSED — an unknown verb blocks. A blocklist would fail OPEN on the
+    next verb someone reaches for, which is exactly how `remote` got through.
+  * THE LEDGER — the read-verb set is pinned, so it fails when it GROWS or
+    SHRINKS.
+  * AUTOUSE — one test deliberately does not request the fixture.
+  * THE MUTATION — the same command is run with the shim removed and asserted
+    to SUCCEED, so "blocked" is attributed to the guard and not to the command
+    being impossible anyway.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+from testlib import nogit  # noqa: E402
+from testlib import nogit_plugin  # noqa: E402
+
+TIMEOUT = 60
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _git(*args: str, cwd: Path, env: dict | None = None,
+         ) -> subprocess.CompletedProcess:
+    """Run git with an EXPLICIT cwd — never inheriting this process's.
+
+    `cwd` is keyword-only and required on purpose: a helper with a default cwd
+    is how a test silently targets whatever directory the runner happened to
+    start in, which is the shape that caused the incident.
+    """
+    return subprocess.run(["git", *args], cwd=str(cwd), env=env,
+                          capture_output=True, text=True, timeout=TIMEOUT)
+
+
+def _make_repo(path: Path, origin: str | None = None) -> Path:
+    """A real, minimal git repo at `path`, built with the REAL binary.
+
+    It bypasses the shim deliberately: these repos are the fixtures the tests
+    then point the shim at, and building them through the shim would make every
+    test depend on the very thing under test.
+    """
+    real = shutil.which("git", path=_real_path())
+    path.mkdir(parents=True, exist_ok=True)
+    run = lambda *a: subprocess.run([real, *a], cwd=str(path), check=True,
+                                    capture_output=True, timeout=TIMEOUT)
+    run("init", "-q", "-b", "main")
+    run("config", "user.email", "t@example.invalid")
+    run("config", "user.name", "t")
+    run("commit", "-q", "--allow-empty", "-m", "seed")
+    if origin is not None:
+        run("remote", "add", "origin", origin)
+    return path
+
+
+def _real_path() -> str:
+    """PATH with the shim directory removed — the ambient, unprotected one."""
+    stub = os.environ.get(nogit.STUB_DIR_ENV, "")
+    return os.pathsep.join(
+        p for p in os.environ.get("PATH", "").split(os.pathsep)
+        if p and p != stub)
+
+
+def _env(*, allowed: str, denied: str, path: str | None = None) -> dict:
+    e = dict(os.environ)
+    e[nogit.ROOTS_ENV] = allowed
+    e[nogit.DENY_ROOTS_ENV] = denied
+    if path is not None:
+        e["PATH"] = path
+    return e
+
+
+# --------------------------------------------------------------------------- #
+# RESOLUTION + ORDERING
+# --------------------------------------------------------------------------- #
+def test_git_resolves_into_the_shim_dir(no_real_git_writes):
+    resolved = shutil.which("git")
+    assert resolved is not None, "no git on PATH at all — the shim is missing"
+    assert Path(resolved).parent == Path(no_real_git_writes), (
+        f"`git` resolves to {resolved}, not into the shim dir "
+        f"{no_real_git_writes} — every write in this session reaches the real "
+        "binary unchecked")
+
+
+def test_no_path_entry_before_the_shim_provides_a_git(no_real_git_writes):
+    """The shim must precede every directory that could answer to `git`.
+
+    🔴 NOT "the shim dir is PATH[0]" — measured, it is not, and asserting that
+    was wrong rather than merely strict. The launcher policy's stub dir is
+    prepended by its own session fixture, so whichever of the two autouse
+    fixtures runs last takes position 0; today that is `nolaunch`, and the
+    order is an artefact of fixture instantiation that nothing guarantees.
+
+    What actually matters is that no EARLIER entry carries a `git`, so this
+    asserts that instead. It is the same property "PATH[0]" was reaching for,
+    stated so it cannot be broken by an unrelated fixture winning a race.
+    """
+    entries = [p for p in os.environ["PATH"].split(os.pathsep) if p]
+    shim = str(no_real_git_writes)
+    assert shim in entries, "the shim dir is not on PATH at all"
+    before = entries[:entries.index(shim)]
+    shadowing = [d for d in before if os.path.exists(os.path.join(d, "git"))]
+    assert not shadowing, (
+        f"these PATH entries precede the shim and provide their own `git`: "
+        f"{shadowing}. Every git call in this session would reach them "
+        "instead, and the policy would be silently inert.")
+
+
+def test_git_is_not_also_claimed_by_the_launcher_policy():
+    """🔴 The seam between the two policies, pinned.
+
+    `nolaunch` prepends its own stub dir and — measured above — currently wins
+    position 0. Its stubs are RECORD-ONLY: they log the argv and exit 0 with no
+    output. If `git` were ever added to `HOST_LAUNCHERS`, that stub would
+    shadow this one and every git call in the suite would return success with
+    empty stdout: `rev-parse` answering nothing, `ls-files` listing nothing,
+    and every content gate scanning zero files while passing. That is a far
+    worse failure than the one this policy closes, and nothing else would
+    notice it — so the two ledgers are pinned as disjoint here.
+    """
+    from testlib import nolaunch  # noqa: PLC0415 — local, to keep the seam explicit
+    assert "git" not in nolaunch.HOST_LAUNCHERS, (
+        "`git` is in nolaunch.HOST_LAUNCHERS, so its RECORD-ONLY stub would "
+        "shadow this policy's shim and answer every git call with exit 0 and "
+        "empty output — fabricating the answers this module exists to refuse "
+        "to fabricate.")
+
+
+def test_the_session_denies_the_tree_under_test(no_real_git_writes):
+    """The deny root must be the repo, or the policy is inert where it matters."""
+    denied = os.environ[nogit.DENY_ROOTS_ENV].split(":")
+    assert str(nogit.repo_root()) in denied, (
+        f"the tree under test ({nogit.repo_root()}) is not in "
+        f"{nogit.DENY_ROOTS_ENV}={denied!r}. In the nix sandbox the source is "
+        "unpacked under $TMPDIR, so WITHOUT this entry every write to the tree "
+        "under test would sit inside an allowed root and be permitted — the "
+        "policy would be live on the dev host and structurally blind in the "
+        "tier that gates merges.")
+
+
+# --------------------------------------------------------------------------- #
+# THE LEDGERS
+# --------------------------------------------------------------------------- #
+def test_the_read_verb_ledger_is_pinned():
+    """Fails when the read set GROWS or SHRINKS.
+
+    Growing it is how a write gets reclassified as a read — the failure mode
+    that put `remote set-url` through in the first place. Shrinking it is how
+    the policy goes permanently red. Neither may happen silently.
+    """
+    assert set(nogit.GIT_READ_VERBS) == {
+        "status", "log", "show", "diff", "cat-file", "ls-files", "ls-tree",
+        "ls-remote", "rev-parse", "rev-list", "describe", "blame", "grep",
+        "shortlog", "show-ref", "symbolic-ref", "for-each-ref", "merge-base",
+        "name-rev", "check-ignore", "check-attr", "count-objects",
+        "verify-pack", "var", "help", "version", "annotate", "whatchanged",
+        "cherry", "diff-tree", "diff-index", "diff-files", "hash-object",
+        "patch-id", "get-tar-commit-id", "check-mailmap", "column",
+        "interpret-trailers",
+    }
+
+
+@pytest.mark.parametrize("verb", ["commit", "push", "remote", "config",
+                                  "branch", "checkout", "reset", "fetch",
+                                  "merge", "rebase", "tag", "worktree"])
+def test_no_mutating_verb_is_on_the_read_ledger(verb):
+    """The verbs seen in the incident must never be classified as reads."""
+    assert verb not in nogit.GIT_READ_VERBS
+
+
+def test_the_default_mode_is_block_not_audit():
+    """`audit` is a measuring tool; leaving it on would make the guard inert."""
+    assert nogit.MODE_BLOCK == "block"
+    body = nogit.git_body("/bin/true", Path("/dev/null"))
+    assert f"${{{nogit.MODE_ENV}:-{nogit.MODE_BLOCK}}}" in body, (
+        "the shim's default mode is not 'block' — a guard silently in audit "
+        "mode records violations and lets every one of them through")
+
+
+# --------------------------------------------------------------------------- #
+# READS still reach the real binary
+# --------------------------------------------------------------------------- #
+def test_a_read_against_a_denied_repo_still_reaches_the_real_binary(
+        tmp_path, no_real_git_writes):
+    """The four content gates read the REAL repo with `git ls-files`.
+
+    If the policy broke that they would scan NOTHING and pass — a silent zero
+    manufactured by the guard itself, which is worse than the hazard it closes.
+    """
+    victim = _make_repo(tmp_path / "victim")
+    env = _env(allowed=str(tmp_path / "nowhere"), denied=str(victim))
+
+    got = _git("ls-files", cwd=victim, env=env)
+    assert got.returncode != nogit.BLOCK_EXIT, (
+        f"a READ was refused: {got.stderr}")
+
+    real = shutil.which("git", path=_real_path())
+    want = subprocess.run([real, "ls-files"], cwd=str(victim),
+                          capture_output=True, text=True, timeout=TIMEOUT)
+    assert got.stdout == want.stdout
+    assert got.returncode == want.returncode
+
+
+@pytest.mark.parametrize("args", [
+    ("remote", "-v"),
+    ("config", "--get", "user.name"),
+    ("config", "user.name"),
+    ("branch", "--show-current"),
+    ("branch", "-a", "--format=%(refname:short)"),
+    ("worktree", "list"),
+    ("stash", "list"),
+    ("rev-parse", "HEAD"),
+    ("log", "--oneline", "-1"),
+])
+def test_dual_verb_read_forms_are_allowed_against_a_denied_repo(
+        args, tmp_path, no_real_git_writes):
+    """`remote`, `config`, `branch`, `worktree`, `stash` READ in these forms.
+
+    Every one of these is run against the real repo somewhere in this tree (or
+    by this policy's own containment check). Classifying the VERB alone refuses
+    them all, which is a permanently-red gate; classifying the FORM is the only
+    honest split.
+    """
+    victim = _make_repo(tmp_path / "victim")
+    env = _env(allowed=str(tmp_path / "nowhere"), denied=str(victim))
+    got = _git(*args, cwd=victim, env=env)
+    assert got.returncode != nogit.BLOCK_EXIT, (
+        f"`git {' '.join(args)}` is a READ but was refused:\n{got.stderr}")
+
+
+# --------------------------------------------------------------------------- #
+# WRITES are refused — the whole point
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("args", [
+    # phase A of the incident: LOCAL porcelain, before anything was pushed
+    ("commit", "--allow-empty", "-m", "c"),
+    ("branch", "-m", "main", "trunk"),
+    ("config", "core.bare", "true"),
+    ("config", "--unset", "user.name"),
+    # phase B: the remote repoint
+    ("remote", "set-url", "origin", "/tmp/does-not-exist.git"),
+    ("remote", "add", "evil", "/tmp/does-not-exist.git"),
+    # and the rest of the write surface
+    ("checkout", "-b", "x"),
+    ("reset", "--hard", "HEAD"),
+    ("fetch", "origin"),
+    ("gc",),
+    ("worktree", "prune"),
+    ("tag", "-a", "v1", "-m", "x"),
+    ("stash", "push"),
+])
+def test_a_write_to_a_repo_outside_the_allowed_roots_is_refused(
+        args, tmp_path, no_real_git_writes):
+    victim = _make_repo(tmp_path / "victim")
+    env = _env(allowed=str(tmp_path / "nowhere"), denied=str(victim))
+    got = _git(*args, cwd=victim, env=env)
+    assert got.returncode == nogit.BLOCK_EXIT, (
+        f"`git {' '.join(args)}` was NOT refused (rc={got.returncode}). "
+        f"stdout={got.stdout!r} stderr={got.stderr!r}")
+    assert nogit.BANNER in got.stderr, (
+        "refused, but without this policy's banner — a firing must be "
+        f"identifiable as this guard rather than as a git error: {got.stderr!r}")
+
+
+def test_an_unknown_future_verb_fails_closed(tmp_path, no_real_git_writes):
+    """A verb the ledger has never heard of must BLOCK, not pass.
+
+    A blocklist fails OPEN on the next verb someone reaches for. That is not
+    hypothetical: `remote set-url` was such a verb until this file existed.
+    """
+    victim = _make_repo(tmp_path / "victim")
+    env = _env(allowed=str(tmp_path / "nowhere"), denied=str(victim))
+    got = _git("frobnicate", "--wat", cwd=victim, env=env)
+    assert got.returncode == nogit.BLOCK_EXIT
+    assert nogit.BANNER in got.stderr
+
+
+def test_a_git_with_no_verb_prints_usage_instead_of_refusing(
+        tmp_path, no_real_git_writes):
+    """`git` alone writes nothing, so refusing it is a false positive.
+
+    Worth pinning because it is confusing rather than dangerous: a bare `git`
+    answering with this policy's VIOLATION banner reads like the guard is
+    broken, which is how a guard gets removed.
+    """
+    victim = _make_repo(tmp_path / "victim")
+    env = _env(allowed=str(tmp_path / "nowhere"), denied=str(victim))
+    got = subprocess.run(["git"], cwd=str(victim), env=env,
+                         capture_output=True, text=True, timeout=TIMEOUT)
+    assert got.returncode != nogit.BLOCK_EXIT, (
+        f"a bare `git` was refused: {got.stderr!r}")
+    assert nogit.BANNER not in got.stderr
+
+
+def test_a_bare_git_with_no_dash_C_is_judged_by_its_cwd(
+        tmp_path, no_real_git_writes):
+    """🔴 The first-class suspect.
+
+    A `git` with neither `-C` nor an explicit `cwd=` targets whatever directory
+    the process happens to be in. For a suite run from the clone, that IS the
+    clone — and it is how `drift-check.sh`'s remote leg, running locally under
+    a stub `ssh` with `DRIFT_REPO` unset, reaches `$HOME/workspace/devrc`.
+    """
+    victim = _make_repo(tmp_path / "victim")
+    env = _env(allowed=str(tmp_path / "nowhere"), denied=str(victim))
+    got = _git("commit", "--allow-empty", "-m", "c", cwd=victim, env=env)
+    assert got.returncode == nogit.BLOCK_EXIT, (
+        "a bare `git commit` with no -C was judged by something other than "
+        f"its cwd (rc={got.returncode})")
+    assert nogit.BANNER in got.stderr
+
+
+def test_a_path_that_spells_its_way_out_is_canonicalised(
+        tmp_path, no_real_git_writes):
+    """`-C <allowed>/../<denied>` must not pass a naive prefix match."""
+    victim = _make_repo(tmp_path / "victim")
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    env = _env(allowed=str(allowed), denied=str(victim))
+    sneaky = f"{allowed}/../victim"
+    got = _git("-C", sneaky, "commit", "--allow-empty", "-m", "c",
+               cwd=allowed, env=env)
+    assert got.returncode == nogit.BLOCK_EXIT, (
+        f"`-C {sneaky}` resolved to the denied repo but was allowed through — "
+        "the target is being compared as a STRING rather than canonicalised")
+
+
+def test_a_denied_root_wins_over_an_allowed_root(tmp_path, no_real_git_writes):
+    """Deny must beat allow, or the policy is inert in the nix sandbox.
+
+    There the source tree is unpacked under `$TMPDIR`, so the repo under test
+    is INSIDE an allowed root. If allow won, every write this policy exists to
+    stop would be permitted in the tier that gates merges.
+    """
+    victim = _make_repo(tmp_path / "victim")
+    # tmp_path itself is allowed, and victim is inside it — yet denied.
+    env = _env(allowed=str(tmp_path), denied=str(victim))
+    got = _git("commit", "--allow-empty", "-m", "c", cwd=victim, env=env)
+    assert got.returncode == nogit.BLOCK_EXIT, (
+        "an explicitly DENIED repo was rescued by an enclosing allowed root")
+
+
+def test_a_push_to_a_destination_outside_the_roots_is_refused(
+        tmp_path, no_real_git_writes):
+    """🔴 The second vector: the SOURCE repo being in-bounds is not enough.
+
+    A push from a legitimate fixture still reaches whatever `origin` points at.
+    The contained clone prepared for this work had an `origin` aimed at the
+    operator's real clone, so this is measured behaviour, not a hypothetical.
+    """
+    src = _make_repo(tmp_path / "src")
+    dest = _make_repo(tmp_path / "dest")
+    real = shutil.which("git", path=_real_path())
+    subprocess.run([real, "remote", "add", "origin", str(dest)], cwd=str(src),
+                   check=True, capture_output=True, timeout=TIMEOUT)
+    # src is allowed; dest is NOT.
+    env = _env(allowed=str(src), denied=str(dest))
+    got = _git("push", "origin", "main", cwd=src, env=env)
+    assert got.returncode == nogit.BLOCK_EXIT, (
+        f"push from an allowed repo INTO a denied one was permitted "
+        f"(rc={got.returncode}): {got.stderr!r}")
+    assert nogit.BANNER in got.stderr
+
+
+# --------------------------------------------------------------------------- #
+# POSITIVE CONTROL — legitimate fixture git must keep working
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("args", [
+    ("commit", "--allow-empty", "-m", "c"),
+    ("branch", "-m", "main", "trunk"),
+    ("config", "core.bare", "false"),
+    ("remote", "add", "origin", "/tmp/whatever.git"),
+    ("remote", "set-url", "origin", "/tmp/other.git"),
+    ("checkout", "-b", "feature"),
+    ("tag", "-a", "v1", "-m", "x"),
+])
+def test_a_write_inside_an_allowed_root_still_works(
+        args, tmp_path, no_real_git_writes):
+    """🔴 A guard that refuses everything looks identical to one that works.
+
+    Every assertion above is satisfied by a shim that blocks unconditionally.
+    This is the half that distinguishes them, and it is the half that found two
+    real defects: the first draft refused `git init <tmpdir>` (it judged by cwd
+    rather than by the positional path) and refused every fixture-to-fixture
+    `push` (it read the value of `-C` as the remote name).
+    """
+    # `set-url` needs an existing remote to re-point; every other case must
+    # start from a repo that has none, so the origin is added only for that one.
+    pre = "/tmp/original.git" if args[:2] == ("remote", "set-url") else None
+    fixture = _make_repo(tmp_path / "fixture", origin=pre)
+    env = _env(allowed=str(tmp_path), denied=str(tmp_path / "nowhere"))
+    got = _git(*args, cwd=fixture, env=env)
+    assert got.returncode != nogit.BLOCK_EXIT, (
+        f"`git {' '.join(args)}` inside the test's OWN tmpdir was refused. "
+        f"stderr={got.stderr!r}")
+    assert got.returncode == 0, f"unexpected git failure: {got.stderr!r}"
+
+
+def test_git_init_of_a_fixture_dir_is_allowed_from_inside_a_denied_cwd(
+        tmp_path, no_real_git_writes):
+    """`git init <tmpdir>` writes to the ARGUMENT, not to the cwd.
+
+    Measured: judging this by cwd refuses every fixture that builds itself a
+    clone, because the suite's cwd is the repo. A permanently-red gate gets
+    switched off, and then the real hazard is back.
+    """
+    denied = _make_repo(tmp_path / "denied")
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    env = _env(allowed=str(allowed), denied=str(denied))
+    got = _git("init", "-q", str(allowed / "new"), cwd=denied, env=env)
+    assert got.returncode != nogit.BLOCK_EXIT, (
+        f"`git init <allowed>` from a denied cwd was refused: {got.stderr!r}")
+    assert (allowed / "new" / ".git").is_dir()
+
+
+def test_git_clone_into_a_denied_path_is_still_refused(
+        tmp_path, no_real_git_writes):
+    """The mirror of the above — the positional target is CHECKED, not trusted."""
+    src = _make_repo(tmp_path / "src")
+    denied = tmp_path / "denied"
+    denied.mkdir()
+    env = _env(allowed=str(tmp_path / "allowed"), denied=str(denied))
+    got = _git("clone", "-q", str(src), str(denied / "here"), cwd=src, env=env)
+    assert got.returncode == nogit.BLOCK_EXIT
+    assert not (denied / "here").exists()
+
+
+# --------------------------------------------------------------------------- #
+# THE RECONSTRUCTION — a repoint that is put back afterwards
+# --------------------------------------------------------------------------- #
+def test_a_restore_afterwards_does_not_hide_the_write(
+        tmp_path, no_real_git_writes):
+    """🔴 Reproduce the reported shape: repoint `origin`, work, restore it.
+
+    The restore is why this was invisible — after the run `git remote -v` on
+    the real clone reported exactly the right URL. A guard that inspected state
+    AFTER the fact would see nothing at all, in both the run below and the real
+    incident. This asserts the guard fires at the moment of the call, and that
+    the URL is unchanged afterwards because the write never happened — not
+    because something put it back.
+    """
+    victim = _make_repo(tmp_path / "victim")
+    real = shutil.which("git", path=_real_path())
+    good = str(tmp_path / "upstream.git")
+    subprocess.run([real, "remote", "add", "origin", good], cwd=str(victim),
+                   check=True, capture_output=True, timeout=TIMEOUT)
+
+    env = _env(allowed=str(tmp_path / "nowhere"), denied=str(victim))
+    script = tmp_path / "victim.sh"
+    # The drift-check.sh:444 / ship.sh:190 shape: `:-` falls back on EMPTY as
+    # well as unset, so an override that is set-but-blank lands on the default.
+    script.write_text(
+        "#!/bin/sh\n"
+        'repo="${DRIFT_REPO:-' + str(victim) + '}"\n'
+        'saved=$(git -C "$repo" remote get-url origin)\n'
+        'git -C "$repo" remote set-url origin /tmp/poisoned.git || exit 40\n'
+        'git -C "$repo" remote set-url origin "$saved"\n'
+        'echo restored\n',
+        encoding="utf-8")
+    script.chmod(0o755)
+
+    env["DRIFT_REPO"] = ""  # present but EMPTY — the case `:-` hides
+    got = subprocess.run(["/bin/sh", str(script)], cwd=str(tmp_path), env=env,
+                         capture_output=True, text=True, timeout=TIMEOUT)
+
+    assert got.returncode == 40, (
+        "the repoint was not refused — the script ran to completion and would "
+        f"have restored the URL, hiding it (rc={got.returncode})")
+    assert nogit.BANNER in got.stderr
+    assert "restored" not in got.stdout
+
+    after = subprocess.run([real, "remote", "get-url", "origin"],
+                           cwd=str(victim), capture_output=True, text=True,
+                           timeout=TIMEOUT)
+    assert after.stdout.strip() == good, (
+        "origin is not what it was — the write landed")
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE GIT ENVIRONMENT — `-C` IS NOT PROTECTIVE
+# --------------------------------------------------------------------------- #
+def _victim_state(repo: Path) -> tuple:
+    """Everything an intruder would disturb, as one comparable tuple."""
+    real = shutil.which("git", path=_real_path())
+    def q(*a: str) -> str:
+        return subprocess.run([real, "-C", str(repo), *a], capture_output=True,
+                              text=True, timeout=TIMEOUT).stdout.strip()
+    keep = repo / "keep.txt"
+    return (q("rev-parse", "HEAD"), q("branch", "--show-current"),
+            q("rev-list", "--count", "HEAD"), q("config", "--get", "user.email"),
+            keep.read_text(encoding="utf-8") if keep.exists() else "")
+
+
+def _victim(path: Path) -> Path:
+    """A repo that must survive every test in this section untouched."""
+    real = shutil.which("git", path=_real_path())
+    _make_repo(path)
+    (path / "keep.txt").write_text("PRECIOUS", encoding="utf-8")
+    for a in (("add", "keep.txt"), ("commit", "-q", "-m", "victimseed")):
+        subprocess.run([real, "-C", str(path), *a], check=True,
+                       capture_output=True, timeout=TIMEOUT)
+    return path
+
+
+@pytest.mark.parametrize("var,rel,args", [
+    # IDENTITY redirection — git reports a different repo.
+    ("GIT_DIR", ".git", ("commit", "--allow-empty", "-m", "PWNED")),
+    ("GIT_COMMON_DIR", ".git", ("commit", "--allow-empty", "-m", "PWNED")),
+    ("GIT_DIR", ".git", ("branch", "-m", "main", "trunk")),
+    ("GIT_DIR", ".git", ("config", "user.email", "pwned@x")),
+    # 🔴 BYTE redirection — identity stays innocent and TRUTHFUL; only the
+    # destination moves. An identity-based check passes every one of these and
+    # the bytes are still written. `GIT_WORK_TREE` is the one that matters most.
+    ("GIT_WORK_TREE", "", ("checkout", "-f", "HEAD")),
+    ("GIT_WORK_TREE", "", ("add", "-A")),
+    ("GIT_INDEX_FILE", ".git/index", ("add", "a.txt")),
+    ("GIT_OBJECT_DIRECTORY", ".git/objects",
+     ("commit", "--allow-empty", "-m", "PWNED")),
+    ("GIT_ALTERNATE_OBJECT_DIRECTORIES", ".git/objects",
+     ("commit", "--allow-empty", "-m", "PWNED")),
+    ("GIT_CONFIG_GLOBAL", ".gitconfig",
+     ("config", "--global", "user.name", "pwned")),
+    ("GIT_CONFIG_SYSTEM", ".gitconfig",
+     ("config", "--system", "user.name", "pwned")),
+])
+def test_a_git_env_var_armed_at_a_victim_is_refused(
+        var, rel, args, tmp_path, no_real_git_writes):
+    """🔴 Every path ARGUMENT names an innocent fixture; only the ENV points out.
+
+    Measured before this check existed:
+
+        GIT_DIR=<victim>/.git git -C <fixture> commit --allow-empty -m PWNED
+        -> rc 0, and the victim's commit count went 1 -> 2.
+
+    while `git -C <fixture> rev-parse --show-toplevel` answered `<fixture>`.
+    That is why "absolute `-C`, therefore fixture-scoped" cleared this suite in
+    two independent audits: it is the wrong property.
+
+    The victim's whole state is compared, not just an exit code — a guard that
+    returns 99 after the write has landed is not a guard.
+    """
+    victim = _victim(tmp_path / "victim")
+    fixture = _make_repo(tmp_path / "allowed" / "fix")
+    before = _victim_state(victim)
+
+    env = _env(allowed=str(tmp_path / "allowed"), denied=str(victim))
+    env[var] = str(victim / rel) if rel else str(victim)
+
+    got = _git(*args, cwd=fixture, env=env)
+
+    assert got.returncode == nogit.BLOCK_EXIT, (
+        f"{var} armed at the victim was NOT refused (rc={got.returncode}). "
+        f"stderr={got.stderr!r}")
+    assert nogit.BANNER in got.stderr
+    assert _victim_state(victim) == before, (
+        f"{var}: the guard returned {got.returncode} but the victim CHANGED.\n"
+        f"  before: {before}\n  after:  {_victim_state(victim)}")
+
+
+@pytest.mark.parametrize("args", [
+    ("commit", "--allow-empty", "-m", "ok"),
+    ("checkout", "-f", "HEAD"),
+    ("add", "-A"),
+    ("branch", "-m", "main", "trunk"),
+])
+def test_a_fixture_driving_its_OWN_repo_through_git_env_is_allowed(
+        args, tmp_path, no_real_git_writes):
+    """🔴 The control that separates a working guard from a useless one.
+
+    "Refuse whenever a git env var is set" passes every negative test above
+    while breaking every legitimate fixture — and a red-only demonstration
+    rewards exactly that design. The policy therefore bounds where the
+    variables POINT, never whether they are present.
+    """
+    own = _make_repo(tmp_path / "allowed" / "own")
+    env = _env(allowed=str(tmp_path / "allowed"),
+               denied=str(tmp_path / "nowhere"))
+    env["GIT_DIR"] = str(own / ".git")
+    env["GIT_WORK_TREE"] = str(own)
+    got = _git(*args, cwd=own, env=env)
+    assert got.returncode != nogit.BLOCK_EXIT, (
+        f"a fixture driving its OWN repo via GIT_DIR/GIT_WORK_TREE was "
+        f"refused: {got.stderr!r}")
+
+
+def test_dev_null_as_a_config_sink_is_not_a_violation(
+        tmp_path, no_real_git_writes):
+    """`GIT_CONFIG_GLOBAL=/dev/null` is the standard hermetic-harness idiom.
+
+    MEASURED: it was **590 of the 593** firings on the first armed run of the
+    full suite. Refusing it makes the policy permanently red across
+    `scripts/tests`, and a permanently-red gate gets switched off — taking the
+    real protection with it. `/dev/null` discards writes, so exempting it costs
+    nothing; `GIT_CONFIG_GLOBAL=<victim>/.gitconfig` is still refused above.
+    """
+    fixture = _make_repo(tmp_path / "allowed" / "fix")
+    env = _env(allowed=str(tmp_path / "allowed"),
+               denied=str(tmp_path / "nowhere"))
+    env["GIT_CONFIG_GLOBAL"] = "/dev/null"
+    env["GIT_CONFIG_SYSTEM"] = "/dev/null"
+    got = _git("commit", "--allow-empty", "-m", "ok", cwd=fixture, env=env)
+    assert got.returncode != nogit.BLOCK_EXIT, (
+        f"/dev/null as a config sink was refused: {got.stderr!r}")
+
+
+def test_the_env_ledger_holds_only_paths_that_receive_bytes():
+    """Pinned, and pinned for a reason that cost a full armed run.
+
+    `GIT_NAMESPACE` (a ref namespace) and `GIT_CEILING_DIRECTORIES` (which only
+    NARROWS discovery) were both on this ledger and both were wrong: neither
+    can redirect a write to a path, so both produced pure false positives. They
+    passed a negative control only because that control armed them at a
+    path-shaped value, which measures the guard rather than the hazard.
+    """
+    assert set(nogit.GIT_LOCATION_ENV) == {
+        "GIT_DIR", "GIT_COMMON_DIR", "GIT_WORK_TREE", "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_INDEX_FILE",
+        "GIT_CONFIG_GLOBAL", "GIT_CONFIG_SYSTEM",
+    }
+    for bad in ("GIT_NAMESPACE", "GIT_CEILING_DIRECTORIES"):
+        assert bad not in nogit.GIT_LOCATION_ENV, (
+            f"{bad} does not receive bytes — treating it as a write target "
+            "refuses the safe case")
+
+
+def test_the_policy_survives_a_child_with_a_REPLACING_env(
+        tmp_path, no_real_git_writes):
+    """🔴 The roots are BAKED INTO the shim; the environment only widens them.
+
+    MEASURED: three tests in this suite build `env={HOME, GIT_CONFIG_GLOBAL,
+    GIT_CONFIG_SYSTEM, PATH}` for a hermetic `git init` in their own tmp_path.
+    `PATH` still reaches the shim, so the shim runs — and when the policy lived
+    only in the environment it ran with NO roots and refused them. Reading the
+    policy from a variable makes it depend on that variable surviving into
+    every descendant, which is not a property anyone maintains.
+
+    This drives a child with an env carrying ONLY the four keys those tests
+    keep, and asserts both halves still hold.
+    """
+    stub = Path(os.environ[nogit.STUB_DIR_ENV])
+    fixture_parent = tmp_path / "fix"
+    fixture_parent.mkdir()
+    victim = _victim(tmp_path / "victim")
+
+    bare = {"HOME": str(tmp_path), "PATH": os.environ["PATH"],
+            "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"}
+    assert nogit.ROOTS_ENV not in bare and nogit.DENY_ROOTS_ENV not in bare
+    assert (stub / "git").exists()
+
+    # The allow floor still permits a fixture under the session's basetemp…
+    ok = subprocess.run(["git", "init", "-q", str(fixture_parent / "r")],
+                        cwd=str(tmp_path), env=bare, capture_output=True,
+                        text=True, timeout=TIMEOUT)
+    assert ok.returncode != nogit.BLOCK_EXIT, (
+        f"a hermetic `git init` under tmp_path was refused by a child with a "
+        f"replacing env: {ok.stderr!r}")
+
+    # …and the deny floor still refuses the tree under test, with no
+    # DEVRC_TEST_GIT_DENIED_ROOTS present at all.
+    bad = subprocess.run(
+        ["git", "-C", str(nogit.repo_root()), "config", "nogit.probe", "1"],
+        cwd=str(tmp_path), env=bare, capture_output=True, text=True,
+        timeout=TIMEOUT)
+    assert bad.returncode == nogit.BLOCK_EXIT, (
+        "with the policy variables absent, a write to the tree under test was "
+        f"ALLOWED (rc={bad.returncode}) — the deny floor is not baked in")
+    assert _victim_state(victim) == _victim_state(victim)
+
+
+def test_the_deny_floor_is_a_union_not_an_override(tmp_path, no_real_git_writes):
+    """A test may widen what it can write to; nothing may un-deny the repo.
+
+    The asymmetry is deliberate. `roots` is `${VAR:-<baked>}` so a test can
+    narrow or widen its own sandbox, but `denied` is `<baked>${VAR:+:$VAR}` so
+    the tree under test is refused even when a caller passes its own deny list
+    — or an empty one.
+    """
+    body = nogit.git_body("/bin/true", Path("/dev/null"),
+                          allowed_roots="/BAKED_ALLOW",
+                          denied_roots="/BAKED_DENY")
+    assert f'roots="${{{nogit.ROOTS_ENV}:-/BAKED_ALLOW}}"' in body
+    assert (f'denied="/BAKED_DENY${{{nogit.DENY_ROOTS_ENV}:+'
+            f':${{{nogit.DENY_ROOTS_ENV}}}}}"') in body, (
+        "the deny floor is not a union — a caller supplying "
+        f"{nogit.DENY_ROOTS_ENV} could drop the tree under test from it")
+
+
+def test_the_session_scrubs_an_inherited_git_env(no_real_git_writes):
+    """A pytest session has no business inheriting any of these."""
+    for var in nogit.GIT_LOCATION_ENV:
+        assert var not in os.environ, (
+            f"{var} survived into the test session: an ambient value redirects "
+            "every `git -C <fixture>` write in the suite")
+
+
+def test_the_prescan_fixture_chain_cannot_reach_a_victim(
+        tmp_path, no_real_git_writes):
+    """🔴 REGRESSION TEST FOR THE ACTUAL INCIDENT.
+
+    `scripts/repo-cos/tests/test_prescan.py::_init_clone` is the identified
+    culprit, and its steps are replayed verbatim below. Read them against the
+    real clone's reflog:
+
+        _git(clone, "config", "user.email", "t@t")   -> the `t <t@t>` author
+        _git(clone, "commit", "-m", "seed")          -> `trunk@{1}: commit: seed`
+        _git(clone, "branch", "-M", branch)          -> `renamed main to trunk`
+        _git(clone, "push", "origin", f"HEAD:{branch}") -> the push storm
+
+    Every one of those is `git -C <tmp clone> …` — absolute, fixture-scoped,
+    and cleared by two audits. With an ambient `GIT_DIR` they all land in
+    whatever repo it names. This asserts the chain is refused and the victim is
+    untouched, so the mechanism cannot come back through a different fixture.
+    """
+    victim = _victim(tmp_path / "victim")
+    before = _victim_state(victim)
+    clone = _make_repo(tmp_path / "allowed" / "clone")
+
+    env = _env(allowed=str(tmp_path / "allowed"), denied=str(victim))
+    env["GIT_DIR"] = str(victim / ".git")
+
+    refused = 0
+    for args in (("config", "user.email", "t@t"),
+                 ("config", "user.name", "t"),
+                 ("commit", "--allow-empty", "--quiet", "-m", "seed"),
+                 ("branch", "-M", "trunk"),
+                 ("remote", "set-head", "origin", "trunk"),
+                 ("push", "--quiet", "origin", "HEAD:trunk")):
+        got = _git(*args, cwd=clone, env=env)
+        assert got.returncode == nogit.BLOCK_EXIT, (
+            f"`git {' '.join(args)}` reached the victim (rc={got.returncode})")
+        refused += 1
+
+    assert refused == 6
+    assert _victim_state(victim) == before, (
+        f"the victim changed despite every step being refused.\n"
+        f"  before: {before}\n  after:  {_victim_state(victim)}")
+
+
+# --------------------------------------------------------------------------- #
+# THE MUTATION — attribute the block to the GUARD, not to the command
+# --------------------------------------------------------------------------- #
+def test_the_same_write_succeeds_with_the_shim_removed(
+        tmp_path, no_real_git_writes):
+    """🔴 Disable the policy and watch the offending command pass silently.
+
+    Without this, every "was refused" assertion above is equally satisfied by a
+    command that simply cannot work — a `remote set-url` that fails for its own
+    reasons would read as a guard firing. Running the identical argv against
+    the ambient PATH shows the guard is the only thing standing in the way.
+    """
+    victim = _make_repo(tmp_path / "victim")
+    real = shutil.which("git", path=_real_path())
+    subprocess.run([real, "remote", "add", "origin", "/tmp/original.git"],
+                   cwd=str(victim), check=True, capture_output=True,
+                   timeout=TIMEOUT)
+
+    argv = ["git", "remote", "set-url", "origin", "/tmp/poisoned.git"]
+
+    guarded = subprocess.run(
+        argv, cwd=str(victim),
+        env=_env(allowed=str(tmp_path / "nowhere"), denied=str(victim)),
+        capture_output=True, text=True, timeout=TIMEOUT)
+    assert guarded.returncode == nogit.BLOCK_EXIT
+
+    unguarded = subprocess.run(
+        argv, cwd=str(victim),
+        env=_env(allowed=str(tmp_path / "nowhere"), denied=str(victim),
+                 path=_real_path()),
+        capture_output=True, text=True, timeout=TIMEOUT)
+    assert unguarded.returncode == 0, (
+        f"the mutation control did not pass: {unguarded.stderr!r}. The "
+        "'blocked' results above cannot be attributed to the guard.")
+
+    url = subprocess.run([real, "remote", "get-url", "origin"],
+                         cwd=str(victim), capture_output=True, text=True,
+                         timeout=TIMEOUT)
+    assert url.stdout.strip() == "/tmp/poisoned.git", (
+        "with the guard removed the write did not land, so the negative "
+        "controls prove nothing about the guard")
+
+
+# --------------------------------------------------------------------------- #
+# AUTOUSE — protection a test must ask for is protection the next test forgets
+# --------------------------------------------------------------------------- #
+def test_protected_without_asking():
+    """Deliberately does NOT request the fixture.
+
+    Every other test in this file names `no_real_git_writes`, which would make
+    deleting `autouse=True` completely invisible. This one is the control for
+    that flag.
+    """
+    resolved = shutil.which("git")
+    assert resolved is not None
+    assert Path(resolved).parent == Path(os.environ[nogit.STUB_DIR_ENV]), (
+        "a test that never requested the fixture is unprotected — "
+        "`autouse=True` has been lost from the session fixture")
+
+
+def test_the_session_marker_was_written(no_real_git_writes):
+    """A guard that never loaded and a guard that found nothing look alike.
+
+    Both leave a clean log. The marker is what separates them, and the runner
+    can require one per target.
+    """
+    lines = nogit.recorded(no_real_git_writes)
+    assert any(ln.startswith(nogit_plugin.SESSION_MARKER) for ln in lines), (
+        "no session marker in the shim log — this plugin did not load, and a "
+        "clean log would be indistinguishable from a clean run")

--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -907,6 +907,23 @@ def test_the_module_loader_scan_can_actually_find_something(tmp_path):
 # assembles its patterns — which keeps THIS file inside the scan's scope instead
 # of excluding it, so a real clobber added here would still be caught.
 PINNED_PATH_CLOBBERS = {
+    "test_no_real_git_remote.py": (
+        'e["PATH"]' + ' = path',
+        "🔴 THE ONE PINNED CLOBBER WHOSE WHOLE PURPOSE IS TO DROP A GUARD — "
+        "and it is safe because of WHICH guard and WHY. `_env(..., path=...)` "
+        "is the UNGUARDED half of that file's three-way harness: every "
+        "negative control there is scored only after the identical command has "
+        "been run with the no-real-git shim off PATH and SHOWN to move the "
+        "victim, because a vector that cannot reach the victim makes 'the "
+        "guard refused it' worthless. The value passed is always "
+        "`_real_path()`, which is the session's own PATH with exactly two "
+        "entries removed — the nogit stub dir and its GIT_EXEC_PATH farm — so "
+        "the LAUNCHER stub dir this file protects is still present and no "
+        "HAZARD_VOCABULARY name becomes reachable. It is a REMOVAL of two "
+        "known entries, not a replacement with a new directory, so nothing can "
+        "appear in it that was not already on the ambient PATH. The victim "
+        "repos those unguarded commands write to are throwaway fixtures under "
+        "`tmp_path`; the tree under test is never one of them"),
     "test_rig_control.py": (
         '"PATH"' + ': "/usr/bin/false"',
         "deliberately makes yad unfindable; /usr/bin/false holds no binaries, so "


### PR DESCRIPTION
# guard(tests): no test may WRITE to a git repo it does not own — rework after a blind audit found nine bypasses

## Why this exists

The suite drove `git` against the operator's REAL clone and destroyed `main` on
the remote. The reflog ordering is the diagnosis:

```
trunk@{0}: Branch: renamed refs/heads/main to refs/heads/trunk   14:21:35 = 19:21:35Z
~40 pushes onto refs/heads/main in 43 seconds                              19:28:14Z
```

Local damage first, pushes seven minutes later. A push-scoped or remote-scoped
guard would have watched the whole first phase go past.

## 🔴 What the previous revision of this PR got wrong

A blind adversarial audit found **nine working bypasses**, and proved the
headline coverage number was a claim about the battery rather than about the
guard. A second independent audit then found **eight more** — every one a
DIFFERENT SPELLING of a capability the first round had closed. Both rounds are
in the battery now, and the second one is why the fixes below are structural
rather than shape-matched.

### The headline number was inflated ~4×

The old body claimed *"env negative — 12 blocked / 0 leaked, victim
byte-identical"*. The battery had **11** entries, and running each vector's
identical command **with the guard removed** gave:

| verdict | meaning | count |
|---|---|---|
| LIVE | the victim moved on an axis `_victim_state` asserted | **3** |
| WEAK | bytes landed in the victim, `_victim_state` was blind to them | 4 |
| VACUOUS | nothing moved anywhere — true with the guard DELETED | 4 |

The "blocked" half was genuine; the "victim byte-identical" half was
informative for 3 of 11.

## The rebuilt env battery — every vector proven LIVE

`_victim_state` is now a full byte manifest of the victim tree plus its ref
list and HEAD, so a vector that lands a byte anywhere is visible.
`test_every_env_ledger_entry_is_a_live_write_vector` **runs each ledger entry
with the guard removed and requires the victim to move** — a ledger entry that
cannot be armed fails the suite instead of being documented.

| variable | command (chosen because it is LIVE) | before | after |
|---|---|---|---|
| `GIT_DIR` | `commit --allow-empty` | LIVE | LIVE |
| `GIT_COMMON_DIR` | `config --local nogit.pwned 1` | WEAK | LIVE |
| `GIT_WORK_TREE` | `checkout -f HEAD`, fixture tree ≠ victim tree | VACUOUS | LIVE |
| `GIT_OBJECT_DIRECTORY` | `hash-object -w a.txt` | WEAK | LIVE |
| `GIT_INDEX_FILE` | `add a.txt` (the file now exists) | VACUOUS | LIVE |
| `GIT_CONFIG_GLOBAL` | `config --global user.name pwned` | WEAK | LIVE |
| `GIT_CONFIG_SYSTEM` | `config --system user.name pwned` | WEAK | LIVE |
| `GIT_ALTERNATE_OBJECT_DIRECTORIES` | — | VACUOUS | **REMOVED** |

**7 entries, 7 LIVE, 0 weak, 0 vacuous.**

Three of those commands are not the obvious one, and each replacement is a
measurement rather than a preference:

* `GIT_WORK_TREE` + `add -A` writes the objects and index into the FIXTURE and
  leaves the victim untouched — it was never a vector. `checkout -f HEAD` with
  a fixture whose tree differs clobbers the victim's `keep.txt`.
* `GIT_OBJECT_DIRECTORY` + `commit` dies `fatal: could not parse HEAD`, because
  with the object store redirected git cannot read the fixture's own HEAD. It
  *appeared* live only while the victim and the fixture shared a seed commit
  sha — identical author, message and empty tree, created in the same second.
  `_make_repo` now gives every fixture a distinct identity so that class of
  accident cannot come back, and the exposure of it immediately falsified
  `GIT_COMMON_DIR` too.
* `GIT_COMMON_DIR` + `branch` / `commit` / `tag` / `update-ref` / `gc` all fail
  for the same reason. `config --local` writes `<victim>/.git/config` with no
  object lookup at all — and it is the exact `config core.bare true` damage the
  incident's reflog recorded.

### `GIT_ALTERNATE_OBJECT_DIRECTORIES` was a NON-VECTOR pinned as correct

Armed at the victim with the guard removed, the commit's object went to the
**fixture**; a full byte manifest of the victim was unchanged. It is a
read-only *additional* object store. It sat on the ledger under that file's own
rule — *"EVERY ENTRY MUST BE A PATH THAT RECEIVES BYTES"* — and the test written
to prevent exactly this recurrence **pinned it as correct**, because it asserted
set membership instead of exercising the vector.

## The bypasses, all measured, all closed

Each is scored by a three-way harness: **NOOP** (build the fixtures, run
nothing — the victim must not move, so the probe cannot answer before the code
does), **UNGUARDED** (the identical argv with the shim off PATH — the victim
MUST move, or the case is vacuous and fails), **GUARDED**.

### Round one

| bypass | fix |
|---|---|
| `GIT_CONFIG_COUNT` → `core.hooksPath` (arbitrary code execution, victim-aimed) | injected config is parsed and path-valued keys are bounds-checked |
| `-c core.hooksPath=<victim>` | `-c` is COLLECTED, not skipped |
| `config --file` / `-f <victim>/.git/config` | `--file`, `--global` and `--system` destinations collected |
| `config --global` writing `$HOME/.gitconfig` unbounded | the reconstructed destination is bounds-checked |
| `-c remote.origin.url=<victim> push` | destination read off the ARGV, no child process |
| `GIT_CONFIG_COUNT` → `remote.origin.url` push | same |
| `-c remote.origin.pushurl=<victim> push` | `pushurl` consulted first, as git does |
| `-c 'alias.x=!git -C <victim> …'` | `GIT_EXEC_PATH` farm |
| `init`/`clone --separate-git-dir <victim>/x` | destination collected |
| `worktree add <victim>/wt` | destination collected |
| `DEVRC_TEST_GIT_MODE=audit` silently disarming everything | mode is a BAKE-TIME argument; no env-readable mode remains |
| `hash-object -w` into a denied repo | moved to the dual list |
| `archive --output=` / `bundle create` into the victim | destinations collected |
| `commit -m -h` (whole-argv read-flag scan) | flags scanned only BEFORE the verb |
| `GIT_EXTERNAL_DIFF` turning a permitted read into execution | refused when non-empty |
| `status` rewriting `<victim>/.git/index` | forwarded as `--no-optional-locks status` |

### Round two — the same capabilities, spelled differently

| bypass | why the round-one fix missed it |
|---|---|
| `--work-tree=<victim> clean -fdx` | the flag twin of an env variable that WAS closed |
| `--git-dir=<victim>/.git commit` | same |
| `--git-dir=<victim>` with an allowed `--work-tree` | the `top` chain judged one resolved path, not the SET |
| `branch --format=… -m main trunk` | a read-shaped flag placed first |
| `symbolic-ref -q HEAD refs/heads/trunk` | the verb was on the READ ledger and repoints with two args |
| `GIT_CONFIG_COUNT=+1` and `=' 1'` | git parses with `strtoumax`; an all-digits `case` does not |
| `-c diff.external=<script> diff` | the read fast path ran above the `-c` scan |
| `-c filter.x.clean=<git-into-victim> add` | a child-injection channel that is not an alias |
| `config --file ../victim/…`, `worktree add ../victim/wt`, `init --separate-git-dir=../victim/…`, `clone` into `../victim/cl` | an absolute-only matcher is relative-walkable |
| `archive --format=tar --output=<victim>/.git/config` | a second output spelling |
| `init <victim>/newone` | — |
| `-C <victim> -C .` and `-C <allowed> -C ../victim` | git applies multiple `-C` CUMULATIVELY |
| `bisect run <git-into-victim>` | held by the farm; the outer command legitimately succeeds |

**All 20 round-two probes accounted for: 18 CLOSED, 2 NOT-LIVE** — git itself
refuses `symbolic-ref -d HEAD`, and a `bisect run` with no range never executes
its script. Neither is a bypass.

## 🔴 The central architectural claim was FALSE, and is now closed

The old file said the shim was reached *"first on PATH … inherited by every
descendant, at any depth"*. Measured:

```
$ git -c 'alias.p=!echo PATH[0]=$(echo $PATH | cut -d: -f1)' p
PATH[0]=/nix/store/…-git-2.55.0/libexec/git-core
```

git **prepends its own exec-path** to `PATH` for every child it spawns, and
that directory ships a real `git`. `test_no_path_entry_before_the_shim_provides_a_git`
measured the *pytest process's* PATH and was structurally blind to it.

`exec_path_farm()` builds a directory of symlinks to all ~184 real helpers plus
the shim as `git`, and `GIT_EXEC_PATH` points at it — so git prepends a
directory this policy owns. The shim re-exports it on every call, so a child
built with a REPLACING `env=` cannot lose it.

**This closes more than the injection channel.** Measured, with no injection
involved at all:

| escape already present in a repo's own config | before | after |
|---|---|---|
| `alias.x = !git -C <victim> commit` in `.git/config` | victim commit landed | **refused, banner, victim untouched** |
| `.git/hooks/post-commit` running `git -C <victim> commit` | victim commit landed | **victim untouched** |
| `bisect run` script running `git -C <victim> commit` | victim commit landed | **victim untouched** |

### The stated limit, pinned as a measurement

`alias.x = !sh -c 'echo … > <victim>/X'` **still writes the victim**, and
`test_a_shell_alias_writing_the_victim_is_NOT_covered` asserts that it does —
so the limit is a fact the suite carries, and a future change that closes it
turns the test red and forces the docstring to be rewritten.

Exposed surface, enumerated by what actually happens to each channel — a
docstring naming a channel the code does not refuse is the failure this rework
kept finding:

* **Refused when non-empty**: `alias.*`, `core.fsmonitor`, `diff.external`,
  `filter.*.clean`/`.smudge`/`.process`, `*.textconv`, `core.pager`,
  `core.editor`, `core.sshCommand`, `credential.helper`, `gpg.program`,
  `merge.*.driver`, plus `GIT_EXTERNAL_DIFF`, `GIT_ASKPASS`,
  `GIT_PROXY_COMMAND`, `GIT_SSH`.
* **Bounded, not refused** (a real caller needs them): `core.hooksPath`,
  `init.templateDir` — the value must be inside an allowed root.
* **Not refused at all, named so the list is honest**: `GIT_SSH_COMMAND` (one
  legitimate caller, and listing it cost nine red tests), and `.git/hooks/*`,
  `rebase --exec`, `submodule foreach`, whose bodies are argv or on-disk files
  rather than an injection channel.

For everything in the last group the `git` such code spawns is still caught by
the farm. What is uncovered is the part of such a body that is not a `git`
invocation. No git guard can bound `echo > file`.

## Scoped, not blanket-refused

`scripts/analyze-service-index/commit.sh:247` legitimately exports
`GIT_CONFIG_COUNT=2` with `core.hooksPath`/`init.templateDir` aimed at an empty
`mktemp -d`, to NEUTRALISE hooks.
`scripts/task-spec-drafter/ticket-status:249` passes `-c core.fsmonitor=`
(EMPTY) as hardening. Both have positive controls in the battery and both pass:
a path-valued key is bounds-checked (the mktemp dir is in an allowed root), and
an empty command-valued key is a disarm, not an arm.

`GIT_SSH_COMMAND` was on the refuse list for one armed run and cost **nine red
tests** — `scripts/resume-state.sh:327` sets it around a `fetch`, and the
refusal surfaced four layers away as `[fetch failed; compared against refs
already on disk]`. It is off the list, with the reasoning recorded.

## The session marker reported healthy while the guard was absent

`_inherited_stub_dir()` adopted any directory named by
`DEVRC_TEST_GIT_STUB_DIR` that merely **contained a file called `git`**, then
skipped `install()`. Measured with that pointed at a plain passthrough script:
the write landed **rc 0, no banner**, the marker was written anyway, `1 passed`.

Now the shim answers a **content handshake** — `--devrc-nogit-handshake` prints
a fingerprint that is a hash of the policy's own generated body, so no foreign
binary and no older revision can answer it. A foreign shim **fails the
session**; a shim that is ours but scoped to another tree self-installs
instead (raising there cost nine red tests — several tests copy the repo and
run a NESTED pytest whose `repo_root()` is the copy). The marker carries
`via=self|inherited`.

## L2 was completely inert

`subprocess.Popen.__mro__` during a session was
`['_NoLaunchPopen', 'Popen', 'object']` — this policy's class was gone, an
absolute-path `git config` returned 0 with no banner, and **zero tests
referenced it**. Both plugins captured the pristine `Popen` at IMPORT time and
each subclassed *that*, so whichever fixture ran last discarded the other; each
teardown then restored pristine, discarding the survivor too.

Both now subclass whatever `Popen` is at PATCH time.
`test_both_launch_policies_survive_in_the_popen_chain` pins that both are in
the chain.

L2 is also narrowed to skip a `git` inside the session's own tmp tree —
without that it **replaced a test's own instrument with the guard**:
`test_ship_converge.py::_git_shim` builds a deliberately-sabotaged `git`, and
L2 rewrote the call so the sabotage never happened.

## B1 — NOT closed here, and the residual gap stated

`scripts/tests/conftest.py` is the only registration. Measured per target:
`scripts/tests` → rc 99; **`scripts/repo-cos/tests`**, which contains the
culprit `test_prescan.py::_init_clone`, → **rc 0, the write landed**;
`scripts/dl-router/tests` → rc 0. **1 target of 25, and not the culprit's.**

A single `scripts/conftest.py` **would** close it — measured, pytest auto-loads
it for all 13 sampled targets, directory and file targets alike, with no
`run-tests.sh` edit. It is **deliberately not added**, because the runner-layer
guard on `guard/nogit-test-isolation` already registers with `-p` on the single
pytest line and two plugins on one class is the collision measured above with
`Popen`. The three comments that claimed otherwise are corrected.

**This PR's guard therefore protects `scripts/tests` only.** Read
`testlib/nogit_plugin.py`'s REGISTRATION SCOPE header before assuming more.

🔴 **And a clean refusal log is not containment.** A bypass writes no ledger
line, so a per-target `refused=0` prints while everything lands. Every number
this policy reports is a claim about the calls it SAW.

## Also fixed

* `test_no_mutating_verb_is_on_the_read_ledger` parametrised 12 verbs **none of
  which was on the ledger** — vacuous by construction, and blind to
  `hash-object`, `status`, `symbolic-ref` and `interpret-trailers`, which were.
  It now exercises **every ledgered verb** against a denied repo and asserts the
  repo is byte-identical.
* Each verb moved off the ledger has a **reading-form** test, so the fix cannot
  trade a false negative for a permanently-red gate. `fsck` was refused outright
  on the first attempt; it is DUAL now (`--lost-found` writes).
* `assert _victim_state(v) == _victim_state(v)` — a tautology — compares against
  the state captured before.
* `assert refused == 6` pinned the fixture's own length; it compares against
  `len(steps)`.
* `for line in $info` word-split on the default IFS while every other list is
  colon-split; it is a line-wise read.
* `refuse` took no argv, so audit mode would have re-exec'd a bare `git`.

## Verification

* **197 tests** in the battery (the old body said 78; the file had 81).
* **7 env vectors**, all LIVE (the old body said 12; the file had 11).
* Every negative control proven live by a guard-removed probe, every probe
  validated by a no-op run.
* Positive controls kept and extended: a fixture driving its OWN repo via
  `GIT_DIR`+`GIT_WORK_TREE`, `analyze-service-index`'s `GIT_CONFIG_COUNT`,
  `-c core.fsmonitor=`, in-bounds `--separate-git-dir` / `worktree add` /
  `archive --output`, a one-argument `clone <denied>`, and the reading form of
  every dual verb.
* 🔴 **The unguarded controls have to unwind L1 *and* L2.** Removing the shim
  from PATH is not enough — L2 rewrites an absolute-path git by design, and on
  the first run of the rebuilt battery it silently re-guarded **13** "unguarded"
  controls, which the harness reported as *"this vector is VACUOUS"*. `_l2_off`
  exists for that and `_expect_closed` asserts the control was not itself
  refused.

### Overhead

Median of 40 runs, this shim vs the real binary, measured against the previous
revision with the identical script:

| case | before | after |
|---|---|---|
| reads (`rev-parse`, `ls-files`, `status`, `log`) | 2.90× | 3.46× |
| `config foo.bar 1` | 11.40× | 11.40× |
| `remote -v` (dual) | 12.34× | 10.60× |
| `commit --allow-empty` | 4.51× | **7.89×** |

Per-invocation cost is unchanged-to-better. `commit` doubled for a specific,
named reason: it spawns `git maintenance run --auto --no-quiet --detach`, and
that child now goes **through the shim** instead of escaping — measured at
4.60× on the real binary from `GIT_EXEC_PATH` alone, with `rev-parse` at 1.03×.
It is coverage, not waste.

Also measured and NOT taken: the two `rev-parse` calls cannot be merged into
one. `--show-toplevel` makes the combined call exit 128 in a BARE repo and
under `GIT_DIR=<bare repo>`, which would lose every candidate in exactly the
redirection shape this guard exists to catch.


### Mutation sweep — 25/25 killed, harness validated first

The harness is validated before any verdict is read: the unmutated tree is
green under the exact command (13 passed, rc 0), and a `-k` matching nothing
exits **5**, so "mutant killed" cannot be confused with "my filter was wrong".
`pytest` exit **1** specifically is required; `-q -q` is never used; every
mutant runs under `PYTHONDONTWRITEBYTECODE=1`; every anchor is asserted to
occur exactly once, so an ambiguous mutation is not scored.

The positive control (`refuse` replaced by `exec`) dies with 13 failures.

Four mutants SURVIVED the first sweep, and each was a real gap, not noise:

* **the push-destination mutant was not ISOLATED** — it removed only the
  `pushurl` arm while the very next line still read the injection off the
  argv, so it survived for a reason that said nothing about the claim. Rebuilt
  to replace the whole resolution chain with the pre-fix `remote get-url`; it
  now dies.
* **relative operands anchored to `base` instead of `cwdbase`** survived,
  because every relative case had `base == cwdbase`. Added
  `init --separate-git-dir=../victim/x` from a NESTED base, where the two
  anchors disagree and the wrong one resolves INSIDE the allowed root while the
  bytes land in the victim.
* **both L2 mutants** survived on fixture ordering. Added
  `test_the_popen_patch_composes_in_EITHER_order`, which applies both patches
  explicitly in both orders, and
  `test_a_git_inside_the_sessions_tmp_tree_is_NOT_redirected`, which asserts
  both directions of the exclusion.


## One more, found here rather than by an auditor

`canon_of` returned a path unchanged when neither it nor its parent could be
canonicalised — and a raw path is prefix-matched. Measured:

```
git init -q <allowed>/does-not-exist/deeper/../../../victim/planted
-> rc 0, and <victim>/planted was created.        (same for `clone`)
```

`does-not-exist` makes both `cd`s fail, the raw string comes back, and it
starts with `<allowed>/` — so it matches an allowed root while `realpath` puts
it inside the victim. This is the `git diff --quiet` shape from RULES: a
comparison against an operand that is not there reports SAME, not MISSING.

An unresolvable path containing `..` now canonicalises to a sentinel that
cannot match any root. A path with **no** `..` is still returned raw on
purpose, because `git init a/b/c` creates its intermediate directories and that
is its normal case. The deliberate cost —
`<allowed>/exists-later/../ok` is refused even though it resolves in bounds —
is pinned by its own test so a future reader meets it there rather than in a
confusing red run.
