### PR TITLE
prune(browser): #669 landed a correction with no eviction — main went red at 29 B of headroom

### DIFF
--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -35,42 +35,41 @@ order) · **secret** — agent-read pages go to
 **OpenRouter/DeepSeek**: never banking, private mail, credential managers, or
 anything you wouldn't hand a third party. Nor **virtualised/lazy-loaded lists**.
 
-KNOW something from it → agent. Ambiguous → agent first: taking over is cheap, so
-agent-first wins even at a low success rate.
+Ambiguous → agent first: taking over is cheap, so agent-first wins even at a low
+success rate.
 
-🔴 The AGENT's auto-`wake` covers a hidden `text`/`html` read but **never `eval`/`js`** — so
+🔴 The AGENT's auto-`wake` covers a hidden `text`/`html` read but **never `js`** — so
 ASSERT a non-zero content count in any `js` measurement. Result handling
-(`blocked`/`partial`), why thin `evidence` is NOT protection, and the
-`--allow-domains` guardrail → `reference/agent.md`.
+(`blocked`/`partial`), why thin `evidence` is NOT protection, `--allow-domains`
+→ `reference/agent.md`.
 
 ## Ops
 
 Global flags, usable before any op: `--instance <key>` (which profile),
 `--tab <id>` (explicit tab), `--frame <numericId|urlSubstring>` (inside an iframe).
-Env defaults `$BB_INSTANCE`/`$BB_TAB`/`$BB_FRAME` (flag wins; zsh does NOT
-split an unquoted `$F`). ⚠ an export outlives the call — env-routed ops say so
-once, on stderr.
+Env defaults `$BB_INSTANCE`/`$BB_TAB`/`$BB_FRAME` (flag wins) — ⚠ an export
+outlives the call → `reference/tabs-instances.md`.
 Result payloads land under `.result.data`.
 
 | command | does |
 |---|---|
 | `whoami` | **read-only identity** (global; no `--instance`) — host label (`laptop`/`workbench`), connected instances (active-tab **domain** only), bridge diagnostics, `extension_version_current` |
-| `health` / `instances` | connected instances + count (JSON: key, label, instanceId, tab url/title). `extension_stale` on `health`+`whoami`, NOT `instances` — ⚠ `null` = "undecidable", NOT "fine" → `reference/errors.md` |
-| `ping` | **which extension CODE is loaded?** → `{pong,extensionVersion,buildMarker,id,ops}`; read `buildMarker` — version+id describe the DIRECTORY. Staleness is PER PROFILE |
+| `health` / `instances` | connected instances + count. `extension_stale` on `health`+`whoami`, NOT `instances` — ⚠ `null` = "undecidable", NOT "fine" → `reference/errors.md` |
+| `ping` | **which extension CODE is loaded?** — read `buildMarker`; version+id describe the DIRECTORY. Staleness is PER PROFILE → `reference/errors.md` |
 | `context` | **page metadata, no DOM read** — url/domain/path/query/title/tabId, tab-scoped. Cheapest read; ⚠ NOT a render check → `reference/read-envelopes.md` |
 | `open [url] [--wake[=MS]]` | open a NEW tab this session owns (default `about:blank`, **created in the BACKGROUND/hidden**), returns `tabId`. 🔴 A re-`open` does NOT navigate — it DISCARDS your url → `reference/tabs-instances.md` |
 | `close` / `release` | close this session's owned tab / drop ownership without closing it |
 | `tabs` | list open tabs (`.data.ownedTabId` flags yours) |
 | `nav <url> [--wake[=MS]]` | navigate the owned/active tab; it lands hidden, so `--wake` un-throttles in the SAME call |
-| `text [selector] [--max-bytes N] [--annotated]` | **cheap read** — visible `innerText` (optional CSS selector), byte-capped by default. ~98% smaller than `html` — **prefer it**. `--annotated` gives per-element extraction — use it when you need a SELECTOR to click/type; works with `--frame`. Byte cap, envelope fields, `--annotated` schema → `reference/read-envelopes.md` |
+| `text [selector] [--max-bytes N] [--annotated]` | **cheap read** — visible `innerText` (optional CSS selector), byte-capped by default. ~98% smaller than `html` — **prefer it**. `--annotated` gives per-element extraction — use it when you need a SELECTOR to click/type. Byte cap, envelope fields, `--annotated` schema → `reference/read-envelopes.md` |
 | `html [--max-bytes N]` | `outerHTML`, same byte cap and envelope. One uncapped `html` on a heavy SPA is ~100K tokens — the cap is ON by default |
-| `js '<expr>'` (alias: `eval`) | run JS in the tab, return its value; same wire op either way. **Prefer the `js` spelling in a worktree-isolated agent** — Claude Code's isolation guard refuses any command with the literal token `eval` |
-| `screenshot [path] [--fullpage] [--data-url] [--json]` | CDP capture — **works on a BACKGROUND/occluded tab**. **Always writes a `.png`** (to `path`, else a 0600 temp); base64 **NEVER** printed — **`Read` it**. ⚠ with `path`, stdout is the bare path, NOT JSON — add `--json` (refused with `--data-url`). `--data-url` = escape hatch |
+| `js '<expr>'` (alias: `eval`) | run JS in the tab, return its value; same wire op either way. ⚠ **prefer the `js` spelling** — an isolation guard refuses the token `eval` → `reference/errors.md` |
+| `screenshot [path] [--fullpage] [--data-url] [--json]` | CDP capture — **works on a BACKGROUND/occluded tab**. **Always writes a `.png`** (to `path`, else a 0600 temp); base64 **NEVER** printed — **`Read` it**. ⚠ with `path`, stdout is the bare path, NOT JSON — add `--json`. Output modes → `reference/read-envelopes.md` |
 | `frames` | list the tab's frames (`frameId`/`url`/`parentFrameId`) **incl. cross-origin OOPIFs** — pick a numeric `frameId` for `--frame` |
 | `click <selector>` · `type <text> [--selector S]` · `key <Enter\|Tab\|Escape\|Backspace\|Delete\|Arrow*\|Home\|End\|Page*> [--selector S]` | the input ops — click the element's centre, type text, send one bounded keypress. All three: **TRUSTED** CDP on the top frame, **SYNTHETIC** inside `--frame` |
-| `upload <selector> <path>` | fill an `<input type=file>` via CDP — Chrome reads the file BY PATH, **no bytes cross the bridge**. AUDIT-LOGGED, **operator-only** (agent → `op_not_allowed:upload`) |
-| `wake [--wait MS]`, or `text\|html\|js\|nav\|open --wake[=MS]` | **UN-THROTTLE a hidden/background tab with NO focus movement** — the fix for an empty or `hidden` read. **Wake once per PAGE, not per read.** `--wake` folds un-throttle+read into one call; refused with `--frame`. Settle/cap, once-per-page, ISOLATED-vs-MAIN world → `reference/spa-wake.md` |
-| `activate` | **⚠⚠ TAKES THE OPERATOR'S SCREEN — LAST RESORT.** The i3 raise is OPT-IN: `--focus` (auto-on on a TTY) → raise, else `withheld`; `skipped` where there is no i3. **NOT** the hidden-tab fix — that is `wake`, see `reference/spa-wake.md` |
+| `upload <selector> <path>` | fill an `<input type=file>` via CDP (no bytes cross the bridge). AUDIT-LOGGED, **operator-only** (agent → `op_not_allowed:upload`) |
+| `wake [--wait MS]`, or `text\|html\|js\|nav\|open --wake[=MS]` | **UN-THROTTLE a hidden/background tab with NO focus movement** — the fix for an empty or `hidden` read. **Wake once per PAGE, not per read.** `--wake` folds un-throttle+read into one call; refused with `--frame`. Settle/cap, ISOLATED-vs-MAIN world → `reference/spa-wake.md` |
+| `activate` | **⚠⚠ TAKES THE OPERATOR'S SCREEN — LAST RESORT.** The i3 raise is OPT-IN (`--focus`, auto-on on a TTY) — read the `i3` field. **NOT** the hidden-tab fix — that is `wake` → `reference/spa-wake.md` |
 | `emulate <preset>\|--reset` | **device emulation** (mobile testing) on a tab you `open`ed; sticky, owned-tab-only. Presets, `--reset`, `--recreate` → `reference/emulation.md` |
 | `agent "<goal>"` | the autonomous browser-agent — see **FIRST DECISION** above, then `reference/agent.md` |
 
@@ -81,13 +80,12 @@ Result payloads land under `.result.data`.
    like a broken bridge and isn't. Wrap it: `(function(){ …; return x })()`.
 2. **Strict page CSP silently blocks the injected script — notably GitHub.** Even
    `document.title` comes back `null`, no error. **Use `text`/`html` there — they
-   work**, because they don't inject script. (`chrome://`/`brave://` URLs also give
-   `null` + `Cannot access a chrome:// URL`.)
+   work**, because they don't inject script. (`chrome://`/`brave://`: same `null`,
+   see `reference/errors.md`.)
 3. **A background/hidden tab is THROTTLED → a shell-only DOM**, indistinguishable
    from a genuinely broken site. `open` creates tabs hidden, so this is the common
    case. Check `data.hidden` / `document.visibilityState`, then **`wake`** — never
-   `activate`, and spoofing `visibilityState` does not recover the page.
-   **A reload RE-throttles: re-`wake` or clicks go silently inert.**
+   `activate`, never a spoof. **A reload RE-throttles: re-`wake` or clicks go inert.**
    → `reference/spa-wake.md`
 4. **A JS `.click()` does not open a React/Mantine popover — and the read then
    reports a confident ABSENCE.** Use the trusted **`click`** op, **ONCE** (it is a
@@ -103,9 +101,9 @@ Result payloads land under `.result.data`.
    error. Fix: ↻ **in the profile you are driving**. A STALE BUILD is a DIFFERENT
    failure — Remove + Load unpacked, not a restart. → `reference/errors.md`
 2. **Empty / half-built / `data.hidden:true` read** → throttled: `wake`, re-read.
-3. **`null` from `js`/`eval`** → traps 1 then 2; fall back to `text`/`html` before
-   concluding the bridge is down. **`unknown_op`** → stale extension (1). Any other
-   error string → `reference/errors.md`.
+3. **`null` from `js`** → traps 1 then 2, then `text`/`html`, before concluding the
+   bridge is down. **`unknown_op`** → stale extension (1). Any other error string
+   → `reference/errors.md`.
 4. **Never diagnose a site OUTAGE from a browser read** — "broken for real users?"
    needs server-side evidence (RUM, metrics, pod health, an anonymous `curl`).
 
@@ -114,9 +112,8 @@ Result payloads land under `.result.data`.
 It's their real browser, not a scratch VM. Don't `nav` a tab that may hold unsaved
 work (a half-typed comment, a form) — `open` your own tab, or an obviously
 disposable one. 🔴 If ANYTHING takes their screen — `activate`, the X-fallback
-capture — RECORD focus AND workspace first, restore BOTH at the end, on failure
-too. Restoring focus usually carries the workspace, but not always — restore it
-explicitly. Why, and the commands → `reference/spa-wake.md`.
+capture — RECORD focus AND workspace first and restore BOTH, on failure too; the
+workspace is the axis that gets left behind → `reference/spa-wake.md`.
 
 ## Reference files — load ONE only when its trigger fires
 

--- a/scripts/browser-bridge/reference/errors.md
+++ b/scripts/browser-bridge/reference/errors.md
@@ -243,3 +243,20 @@ Symptom of a stale build: an op the CLI knows returns `unknown_op`, or `health` 
 shows the old `extension_version`. The `browser-bridge` **server** (not the extension)
 DOES restart automatically on a `home-manager switch` (X-Restart-Triggers) — only the
 extension needs the manual step.
+
+## ⚠ `js` vs `eval` — the refusal that never reaches the bridge
+
+`browser js '<expr>'` and `browser eval '<expr>'` are the **same wire op**: `js` is a
+first-class CLI-surface alias, the semantics and flags are identical, and the extension
+only ever sees `eval`. Neither spelling is deprecated.
+
+**Prefer the `js` spelling in a worktree-isolated agent.** Claude Code's
+worktree-isolation guard pattern-matches the literal token `eval` in a command string
+and REFUSES to run it ("this command runs a string through eval, which can't be verified
+to stay inside the worktree"). The guard is reacting to the WORD, not the behaviour —
+`browser eval` sends JS over loopback to Brave and runs it in the PAGE; it touches no
+filesystem and cannot escape the worktree.
+
+The consequence for triage: that refusal comes from the HARNESS, before the bridge is
+reached. It is not one of the error shapes above, `health` is irrelevant to it, and
+there is nothing to fix on the bridge side — re-issue the same expression as `js`.

--- a/scripts/browser-bridge/reference/read-envelopes.md
+++ b/scripts/browser-bridge/reference/read-envelopes.md
@@ -94,3 +94,28 @@ the envelope reflect the frame, not the top page.
 
 An element that `--annotated` lists but that will not click is a paint-order /
 hit-test problem, not an extraction problem → `reference/css-hit-test.md`.
+
+## `screenshot` output modes — the ONE op whose stdout is not JSON
+
+`screenshot` **always writes a `.png`**: to `<path>` when you give one, else to a
+mode-0600 temp file (honouring `TMPDIR`, auto-pruned after 24h). The base64 data URL is
+**never** printed — `Read` the `.png`.
+
+| invocation | stdout |
+|---|---|
+| `screenshot` | compact JSON `{ok,path,bytes,url,via,note}` |
+| `screenshot <path>` | ⚠ the **bare path** on line 1 and a `#`-prefixed `Read` hint on line 2 — NOT JSON |
+| `screenshot <path> --json` | the same compact envelope the no-path form prints |
+| `screenshot --data-url` | the RAW response envelope, data URL and all (100s of KB) — the escape hatch |
+
+Every other subcommand puts a JSON envelope and nothing else on stdout; the advisories
+(hidden tab, disconnected instance, routing help) all go to STDERR. `screenshot <path>`
+is the back-compat exception, so a caller doing `json.loads(subprocess.run(...).stdout)`
+gets `Expecting value: line 1 column 1` — measured 2026-08-20, and the reason three
+consumers broke. `--json` is the fix, and it is ADDITIVE: the default output is
+byte-identical to before.
+
+Two pairs are **refused**, not silently reconciled: `--data-url` with an explicit path,
+and `--data-url` with `--json` (the raw envelope has no `path`/`bytes` to report, so
+accepting the pair would hand back a different parseable envelope with none of the keys
+the caller was about to read).

--- a/scripts/browser-bridge/reference/spa-wake.md
+++ b/scripts/browser-bridge/reference/spa-wake.md
@@ -271,3 +271,26 @@ browser-agent at all**.
 **Caveat:** in-frame `click`/`type` are SYNTHETIC (`isTrusted:false`, the
 `chrome.scripting` OOPIF path) — but were verified to actually drive the real app
 (the Grid tab got selected). Top-frame input remains TRUSTED CDP.
+
+### The i3 raise is OPT-IN — read the `i3` field before believing the screen moved
+
+`activate` always activates the tab Chrome-side, but the host-side i3 raise is a separate,
+consent-gated step. The result reports it as `i3: applied | skipped | failed | withheld`:
+
+- **`withheld`** — the command did not carry `focus:true`, so the raise was never asked
+  for and the operator's screen was untouched. The CLI's `--focus` / `--no-focus`
+  decides, and the DEFAULT is **on iff stdout is a TTY**: a human typing `browser
+  activate` in a terminal gets the raise; an agent (Claude Code's Bash tool, opencode, any
+  script) runs with stdout on a pipe and gets the tab activated WITHOUT it. That is a
+  structural discriminator — a real property of the process's stdio, not a keyword
+  heuristic — and it is overridable in both directions, so a script that genuinely wants
+  the screen says `--focus` and says it out loud. Measured: over three weeks all 166
+  `activate` calls came from non-interactive callers, and 0 of the 9 interactive
+  `browser` commands in the same telemetry were an activate.
+- **`skipped`** — this host has no i3, so it could not have raised anything regardless of
+  consent. It is reported separately from `withheld` precisely so the `--focus` advice is
+  not offered where it would be a dead end.
+
+Either way, `withheld`/`skipped` mean the window was NOT raised — so anything that
+genuinely needed the real foreground (a browser permission prompt, a native file picker)
+did not happen.

--- a/scripts/browser-bridge/reference/tabs-instances.md
+++ b/scripts/browser-bridge/reference/tabs-instances.md
@@ -184,6 +184,11 @@ Several Brave profiles can each run the extension and be driven independently �
 each has its own command queue (routing key = the profile's **label** if set,
 else a stable auto-id; labels must be unique per host).
 
+`health` and `instances` both list the connected ones: each entry carries the routing
+**key**, the profile **label**, its **instanceId**, and that instance's active tab
+**url**/**title** — which is how you tell two same-labelled profiles apart before
+picking a key.
+
 - **One instance connected** → no `--instance` needed (back-compat).
 - **More than one and no `--instance`** → the command **ERRORS** and lists the
   connected instances. Do NOT retry blindly — run `browser instances`, pick the
@@ -203,3 +208,30 @@ else a stable auto-id; labels must be unique per host).
   shows a "superseded — set a unique label" state) instead of re-registering
   instantly, so two profiles sharing a label can't mutual-supersede in a tight
   loop. If you see `superseded` steadily, two profiles share a label → fix it.
+
+### Env defaults `$BB_INSTANCE` / `$BB_TAB` / `$BB_FRAME` — precedence is easy, LIFETIME is the risk
+
+`BB_INSTANCE`, `BB_TAB` and `BB_FRAME` seed `--instance`, `--tab` and `--frame`, so a
+caller driving one profile+tab for a whole run sets them ONCE instead of repeating the
+flags on every call:
+
+```bash
+export BB_INSTANCE=work BB_TAB=1234
+browser text ; browser click '#go'          # both routed, no flags
+```
+
+- **An explicit flag always wins** — the flag loop assigns over whatever the environment
+  seeded. `--instance ''` therefore genuinely CLEARS an inherited `BB_INSTANCE` (it is an
+  explicit empty, not an absent flag).
+- 🔴 **Prefer the env defaults to hoisting the flags into a shell variable.** Under zsh an
+  unquoted `$F` is NOT word-split, so `F="--instance work --tab 12"; browser $F text`
+  passes ONE argument — the whole string — and the error names a flag you did not type.
+- 🔴 **An env default outlives the command that set it.** `export BB_FRAME=evil.example`
+  is inherited by every descendant for the rest of that shell's life, so a later
+  `browser type '<secret>' --selector '#x'` is routed into that frame — or at another
+  profile's tab — with NOTHING in its command line saying so, and the envelope it prints
+  looks exactly like the un-routed one. So the CLI says so **ONCE, on stderr** (stdout
+  stays pure JSON), naming the variable and its value; `BB_NO_ROUTE_NOTE=1` silences it
+  for a long run that meant it. One line is the only thing that makes an inherited
+  destructive route visible at the moment it is used — unset the variable when the
+  multi-step job that wanted it is done.


### PR DESCRIPTION
## `main` is red; this unbreaks it

`scripts/browser-bridge/tests/test_skill_size.py::test_skill_md_keeps_working_headroom` has been failing on `origin/main` since `da804c9f` (#669). `SKILL.md` sat at **12,259 B** with **29 B** of headroom against the required margin the test owns. Nothing caught it — devrc has no automated merge gate (`gh pr view --json statusCheckRollup` returns 0 checks).

The regression is not *what* #669 said. That commit fixed a real factual error (the civitai account switcher EXISTS; the notes said it did not). It is that it added to a byte-capped always-on doc **without an eviction in the same commit**, which the project `CLAUDE.md` requires.

🔴 `MAX_BYTES` / `MIN_HEADROOM_BYTES` are **untouched**. Raising a ceiling to green a red test defeats the gate; this body loads on every browser task.

## What was evicted, and where it went

Every byte of #669 is **kept** — trap 4's second-view half, and the `sites/<host>.md` row's read-it-BEFORE-the-first-action rule. Older, colder and already-duplicated material went instead, following the eviction playbook the test itself prints.

**Demoted to `reference/` (content preserved, one routing pointer left behind):**

| what | new home |
|---|---|
| env defaults `$BB_INSTANCE`/`$BB_TAB`/`$BB_FRAME`: the zsh no-word-split trap, the ONCE-on-stderr route notice, `BB_NO_ROUTE_NOTE`; plus the `health`/`instances` entry fields | `reference/tabs-instances.md` |
| `js` vs `eval` — the whole worktree-isolation-guard explanation (core keeps the imperative) | `reference/errors.md` |
| `screenshot` output modes: `<path>` prints a bare path, `--json`, `--data-url`, and the two **refused** flag pairs | `reference/read-envelopes.md` |
| `activate`'s `--focus`/`withheld`/`skipped` mechanics, incl. the stdout-is-a-TTY default | `reference/spa-wake.md` |

**Dropped for a pointer, because the destination already carried the text:** `upload` reading the file BY PATH (`security-ops.md`), `text --annotated` working with `--frame` and the `chrome://` `null` (`read-envelopes.md` / `errors.md`), the visibilityState-spoof clause and restore-the-workspace-explicitly (`spa-wake.md` — verbatim there).

No new files, so nothing new needs `git add` for the flake to see it.

## Verification

**Every relocated claim was re-verified against `scripts/browser-bridge/browser`**, not paraphrased from the core: the stdout-is-a-TTY focus default, the mutually-exclusive `--data-url` pairs, `--instance ''` clearing an inherited env value, the guard matching the literal WORD `eval`. No stale claim found.

The matrix is inverted from usual — the test was **already red on `origin/main`**, which is its own negative control:

| | `test_skill_size.py` |
|---|---|
| `origin/main` (inherited) | **1 failed, 3 passed** — `RECLAIM: 221 bytes` |
| HEAD | **4 passed** |

Plus `scripts/tests/test_doc_path_rot.py` — **76 passed**, every routing pointer resolves.

```
before   12,259 B   headroom  29    (needs 250)
after    11,779 B   headroom 509    (-480 B)
```

Deliberately well past the 221 B minimum, and under the pre-#669 size of 11,807 B. Landing on the floor exactly would red `main` again on the next one-line correction — which is the failure this floor exists to *precede*. 509 B is ~2.7 mean ops rows of room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)