### PR TITLE
fix(browser-bridge): SKILL.md has 29 bytes of headroom — main is RED

### DIFF
--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -98,16 +98,14 @@ Result payloads land under `.result.data`.
 
 ## When things look broken — triage
 
-1. **A call that WORKED now fails or returns nothing** → `browser health` FIRST,
-   before debugging the page or the CLI: the extension drops mid-session with no
-   error. Fix: ↻ **in the profile you are driving**. A STALE BUILD is a DIFFERENT
-   failure — Remove + Load unpacked, not a restart. → `reference/errors.md`
-2. **Empty / half-built / `data.hidden:true` read** → throttled: `wake`, re-read.
-3. **`null` from `js`/`eval`** → traps 1 then 2; fall back to `text`/`html` before
-   concluding the bridge is down. **`unknown_op`** → stale extension (1). Any other
-   error string → `reference/errors.md`.
-4. **Never diagnose a site OUTAGE from a browser read** — "broken for real users?"
-   needs server-side evidence (RUM, metrics, pod health, an anonymous `curl`).
+`health` FIRST (the extension drops mid-session with no error), then `wake` a
+throttled/empty read, then fall back to `text`/`html` before concluding the
+bridge is down. Full flow — including stale-build vs restart, and what `null` /
+`unknown_op` each mean — →
+`~/workspace/devrc/scripts/browser-bridge/reference/errors.md`.
+
+🔴 **Never diagnose a site OUTAGE from a browser read** — "broken for real
+users?" needs server-side evidence (RUM, metrics, pod health, anonymous `curl`).
 
 ## This is the user's LIVE session
 

--- a/scripts/browser-bridge/reference/errors.md
+++ b/scripts/browser-bridge/reference/errors.md
@@ -10,6 +10,23 @@ instance you're driving is still dead.
 Core: `~/workspace/devrc/scripts/browser-bridge/SKILL.md`. This file is the catch-all: no error string
 should strand you.
 
+## Triage — start here
+
+1. **A call that WORKED now fails or returns nothing** → `browser health` FIRST,
+   before debugging the page or the CLI: the extension drops mid-session with no
+   error. Fix: ↻ **in the profile you are driving**. A STALE BUILD is a DIFFERENT
+   failure — Remove + Load unpacked, not a restart. → `reference/errors.md`
+2. **Empty / half-built / `data.hidden:true` read** → throttled: `wake`, re-read.
+3. **`null` from `js`/`eval`** → traps 1 then 2; fall back to `text`/`html` before
+   concluding the bridge is down. **`unknown_op`** → stale extension (1). Any other
+   error string → `reference/errors.md`.
+4. **Never diagnose a site OUTAGE from a browser read** — "broken for real users?"
+   needs server-side evidence (RUM, metrics, pod health, an anonymous `curl`).
+
+(Moved from SKILL.md 2026-08-21 to restore its working headroom: #669 added
+content without the eviction the byte ceiling requires. The outage rail stays
+inline in SKILL.md — it is a correctness rail, not a debugging step.)
+
 ## Error shapes (from `/cmd`)
 
 - `503 extension_not_connected` → extension not loaded/paired, or Brave closed.


### PR DESCRIPTION
**`main` is currently red.** #669 added content to `SKILL.md` without the eviction the byte ceiling requires in the same commit:

```
current:   12,259 bytes
ceiling:   12,288 bytes
free:      29 bytes  (minimum required: 250)
RECLAIM:   221 bytes
```

Verified pre-existing: `test_skill_md_keeps_working_headroom` fails at `origin/main` with no local changes. Found while gating an unrelated PR.

## The eviction

Moved, not deleted — per the test's own playbook. `## When things look broken — triage` is a coherent block needed for exactly **one** kind of task (a failure mode), it already pointed at `reference/errors.md` twice, and that file's "Load this when" list already names every trigger it describes. The full flow now lives there under `## Triage — start here`.

The pointer left behind names the **repo-absolute** path, because `nix/home.nix` symlinks only `SKILL.md` and the `browser` CLI into `~/.claude/skills/browser/` — not `reference/` — so a relative path doesn't resolve for the reader.

## 🔴 What deliberately stayed inline

The outage rail — *"never diagnose a site OUTAGE from a browser read"* — is a correctness rail about what conclusions the tool can support, not a debugging step. It has to be readable **without** loading a reference file, so it stays in the core even though moving it would have been a cheaper byte win.

## Verification

Content preservation checked **per item**, not by byte delta (a delta can look right while something is dropped): `browser health`, `STALE BUILD`, `data.hidden`, `unknown_op`, `Remove + Load unpacked` all confirmed present in `errors.md`.

Result: **11,961 bytes, 327 free** (needs ≥250). `test_skill_size.py` → 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
