### PR TITLE
feat(system): stage panic_on_oops + a memtest boot entry — the crash dump reversed an earlier decision

### DIFF
--- a/claudedocs/laptop-freeze-diagnosis-2026-08-21.md
+++ b/claudedocs/laptop-freeze-diagnosis-2026-08-21.md
@@ -1,0 +1,111 @@
+# Laptop freezes — diagnosis as of 2026-08-21
+
+## The finding
+
+**16 unclean stops** across the retained journal, not the "twice in the past
+month" they were believed to be. The rate was invisible because the only
+detector was a human noticing that work had been interrupted — a freeze while
+away from the machine left no impression at all.
+
+Classified by whether the boot reached systemd's shutdown sequence:
+
+| kernel | unclean stops |
+|---|---|
+| 6.18.4 | Mar 22 |
+| 6.19.11 | Apr 12, Apr 17 |
+| 7.0.0 | May 18, May 19, May 24, Jul 29, **Jul 31**, Aug 6, Aug 10, Aug 17, Aug 20 |
+
+🔴 **There is no onset.** An early reading of this called Jul 29 the start and
+reasoned "no software change coincides with onset, so suspect recent hardware
+degradation". That framing was wrong — the stops go back to March. June through
+Jul 4 was genuinely clean, but a clean stretch is not an onset.
+
+## What the Jul 31 crash dump says
+
+`/var/lib/systemd/pstore/1785525502/002/dmesg.txt` (root-only). This is the one
+freeze that captured a trace, because it was a real kernel fault rather than a
+hardware hang.
+
+**Mechanism, decoded:**
+
+1. Page fault at `ct_kernel_enter_state+0x8`. The instruction decodes as
+
+   ```
+   mov  %gs:0x1a4d130(%rip),%rax      # load per-CPU context-tracking pointer
+   lock xadd %edi,-0x7b4b2138(%rax)   # atomic add into it
+   ```
+
+   with `RAX = 0x000000040001f30a` — **not a kernel address**. The arithmetic
+   closes exactly: `0x40001f30a - 0x7b4b2138 = 0x384b6d1d2 = CR2`. So the
+   per-CPU pointer was garbage; the access itself was fine.
+
+2. The fault handler re-entered the same path —
+   `irqentry_enter → ct_nmi_enter → ct_kernel_enter_state → fault` — recursing
+   ~272 bytes of stack per level across eleven visible frames.
+
+3. Stack exhausted → `#DF` double fault → `Thread overran stack, or stack
+   corrupted`, `stack recursion on stack type 5`. Unrecoverable, no clean panic
+   path, and the machine simply stopped rather than rebooting.
+
+**Two details that matter:**
+
+- `CPU: 4 PID: 0 Comm: swapper/4` — the **idle task**. The corruption was hit
+  transitioning out of idle, which fits freezes happening while nobody is at the
+  machine and explains why the rate went unnoticed.
+- `Tainted: G W` — something had already WARNed earlier in that boot. That
+  journal has rotated away, so the first symptom is unknown.
+
+## Leading hypothesis: memory corruption
+
+A garbage value where a per-CPU pointer belongs is a corruption signature, and
+the stops span **three kernel versions**. A regression in the entry /
+context-tracking path would not survive 6.18 → 6.19 → 7.0.
+
+Honest limits: there is **one** dump. Attributing the other fifteen stops to the
+same cause is inference. "Unclean" is also a symptom count, not a diagnosis — it
+covers a hard lockup, a flat battery, a held power button and a panic alike.
+
+Ruled out along the way: memory *pressure* (62 GB total, 40 GB free, zero swap
+used, no OOM), suspend/resume (no sleep transition precedes the Aug 17 or Aug 20
+stops), and any coincident config change (kernel and BIOS 03.17 constant across
+the boots examined; NixOS generations only Jun 23 and Aug 13).
+
+An upstream search for this signature (`ct_kernel_enter_state`, double fault,
+lazy preempt) found no matching report — which is not evidence either way.
+
+## Next step: memtest86+
+
+`nix/system/apply-freeze-followup-2026-08-21.sh` adds a memtest86+ entry to the
+systemd-boot menu, so the test is one reboot away.
+
+🔴 **Budget hours.** A full pass over 64 GiB is not quick, and **a short clean
+run is not evidence of good RAM** — let it complete at least one full pass,
+ideally overnight.
+
+If memtest is clean, the next discriminator is pinning an older kernel and
+watching whether the rate changes — but note the rate is roughly one stop every
+1–2 weeks, so that experiment needs weeks, which is exactly why the metric below
+exists.
+
+## What is now instrumented
+
+- **PR #616** — `kernel.nmi_watchdog=1` (TLP had been disabling the hard-lockup
+  detector on every AC↔battery transition), `hardlockup_panic=1`, `panic=20`,
+  journald `SyncIntervalSec=30s`. Applied and verified live 2026-08-21.
+- **PR #634 / #671** — host telemetry to homelab Prometheus + Loki. The
+  `host_unclean_boots_observed` / `host_boots_examined` pair makes the freeze
+  **rate** a queryable series instead of an anecdote. Read them together: a zero
+  from a scan that walked nothing is not an all-clear.
+- **This script** — `panic_on_oops=1`, reversing an explicit decision in #616.
+  That decision reasoned "an oops is already logged; the silent case is the hard
+  lockup". The dump refutes it for this machine: the first fault *was* an oops
+  and it cascaded into an unrecoverable double fault. Panicking at step 1 yields
+  one clean trace plus an automatic reboot on the `panic=20` already set.
+
+## Still open
+
+- The `Tainted: G W` warning that preceded the crash is unidentified.
+- Only one of sixteen stops has a captured trace. The instrumentation above is
+  what changes that for the next one.
+- The workbench also had an unclean stop (Jul 14, coredumps then silence), but
+  its journal retains only two boots, so no rate can be established there.

--- a/nix/system/apply-freeze-followup-2026-08-21.sh
+++ b/nix/system/apply-freeze-followup-2026-08-21.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Staged system-level change — LAPTOP host, 2026-08-21.
+#
+#   sudo bash nix/system/apply-freeze-followup-2026-08-21.sh
+#
+# Two changes, both consequences of reading the 2026-07-31 crash dump:
+#   1. kernel.panic_on_oops = 1   — reverses an explicit decision in #616
+#   2. a memtest86+ boot entry    — makes the leading hypothesis testable
+#
+# Idempotent: safe to re-run.
+#
+# ── WHY THIS REVERSES AN EARLIER DECISION ───────────────────────────────────
+#
+# apply-freeze-instrumentation.sh (PR #616) DELIBERATELY EXCLUDED
+# kernel.panic_on_oops, with this reasoning:
+#
+#     "An oops is ALREADY logged; the silent case is the hard lockup, which
+#      oopses nothing. Turning this on would convert today's survivable driver
+#      oopses into reboots — a real behaviour regression bought for no
+#      diagnostic gain."
+#
+# 🔴 THE 2026-07-31 CRASH DUMP REFUTES THAT FOR THIS MACHINE. Reading
+# /var/lib/systemd/pstore/1785525502/002/dmesg.txt (the capture from that
+# freeze) shows the first fault WAS an oops — and it was not survivable, and it
+# was not usefully logged. It cascaded:
+#
+#   1. Page fault at ct_kernel_enter_state+0x8. The instruction decodes as
+#        mov  %gs:0x1a4d130(%rip),%rax      # load per-CPU context-tracking ptr
+#        lock xadd %edi,-0x7b4b2138(%rax)   # atomic add into it
+#      with RAX = 0x000000040001f30a — NOT a kernel address. The arithmetic
+#      closes exactly: 0x40001f30a - 0x7b4b2138 = 0x384b6d1d2 = CR2. So the
+#      per-CPU pointer was garbage; the access itself was fine.
+#   2. The fault handler re-entered the same path
+#        irqentry_enter -> ct_nmi_enter -> ct_kernel_enter_state -> fault
+#      recursing ~272 bytes of stack per level across eleven visible frames.
+#   3. Stack exhausted -> #DF double fault -> "Thread overran stack, or stack
+#      corrupted", "stack recursion on stack type 5". Unrecoverable, no clean
+#      panic path, machine simply stopped. It did NOT reboot.
+#
+# With panic_on_oops=1 the kernel panics at step 1: one clean trace to
+# efi_pstore instead of hundreds of recursive frames, and an automatic reboot on
+# the kernel.panic=20 that #616 already set. The cost the original reasoning
+# feared — "survivable oopses become reboots" — is the correct trade on a host
+# whose oopses demonstrably are not survivable.
+#
+# ── WHAT THIS DOES NOT CLAIM ────────────────────────────────────────────────
+#
+# It does not fix anything. The leading hypothesis is MEMORY CORRUPTION, on this
+# evidence: a garbage per-CPU pointer, hit from the idle task (CPU 4, PID 0,
+# Comm: swapper/4), with unclean stops spanning THREE kernel versions —
+# 6.18.4 (Mar 22), 6.19.11 (Apr 12, Apr 17), 7.0.0 (May 18 onward). A
+# regression in the entry/context-tracking path would not survive
+# 6.18 -> 6.19 -> 7.0. Run memtest86+ before pursuing a software cause.
+#
+# Also unresolved: the dump reads "Tainted: G W", so something had already
+# WARNed earlier in that boot. That journal has rotated away.
+set -Eeuo pipefail
+
+CFG=${CFG:-/etc/nixos/configuration.nix}
+EDIT_ONLY=0
+[[ ${1:-} == "--edit-only" ]] && EDIT_ONLY=1
+
+if [[ $EDIT_ONLY -eq 0 ]]; then
+  [[ $EUID -eq 0 ]] || { echo "must run as root (sudo bash $0)"; exit 1; }
+fi
+[[ -f $CFG ]] || { echo "missing $CFG"; exit 1; }
+
+BAK="$CFG.bak-oops-$(date +%Y%m%d-%H%M%S)"
+cp -a "$CFG" "$BAK"
+echo "[0/4] backed up $CFG -> $BAK"
+
+restore_on_err() {
+  local rc=$?
+  echo "ERROR (rc=$rc) — restoring $CFG from $BAK" >&2
+  cp -a "$BAK" "$CFG"
+  exit "$rc"
+}
+trap restore_on_err ERR
+
+require_one_match() { # <regex> <human name>
+  local n
+  n=$(grep -cE "$1" "$CFG" || true)
+  if [[ $n -ne 1 ]]; then
+    echo "ERROR: expected exactly 1 match for $2, found $n — refusing to edit" >&2
+    false
+  fi
+}
+
+# ---- 1. panic_on_oops ----------------------------------------------------
+if grep -qE '"kernel\.panic_on_oops"' "$CFG"; then
+  echo "[1/4] kernel.panic_on_oops already declared — skipping"
+else
+  require_one_match '^[[:space:]]*boot\.kernel\.sysctl[[:space:]]*=' "boot.kernel.sysctl"
+  line=$(grep -nE '^[[:space:]]*boot\.kernel\.sysctl[[:space:]]*=' "$CFG" | cut -d: -f1)
+  ind="$(sed -n "${line}p" "$CFG" | sed -E 's/^([[:space:]]*).*/\1/')  "
+  sed -i "${line}a\\
+${ind}# Panic on the FIRST oops rather than letting it cascade. The 2026-07-31\\
+${ind}# capture shows an oops in the context-tracking entry path recursing into\\
+${ind}# a double fault and hanging the machine — see\\
+${ind}# nix/system/apply-freeze-followup-2026-08-21.sh for the decoded trace.\\
+${ind}\"kernel.panic_on_oops\" = 1;" "$CFG"
+  grep -qE '"kernel\.panic_on_oops"[[:space:]]*=[[:space:]]*1;' "$CFG" \
+    || { echo "ERROR: panic_on_oops edit did not apply" >&2; false; }
+  echo "[1/4] boot.kernel.sysctl: panic_on_oops=1"
+fi
+
+# ---- 2. memtest86+ boot entry -------------------------------------------
+# The leading hypothesis is memory corruption (see the header). Testing it
+# should not require finding a USB stick: systemd-boot can carry a memtest86+
+# entry, so the test is one reboot away.
+#
+# Budget REAL time: a full pass over 64 GiB takes hours. Run it overnight, and
+# let it complete at least one full pass — a short run that finds nothing is not
+# evidence of good RAM.
+if grep -qE '^[[:space:]]*boot\.loader\.systemd-boot\.memtest86\.enable' "$CFG"; then
+  echo "[2/4] memtest86 boot entry already declared — skipping"
+else
+  require_one_match '^[[:space:]]*boot\.loader\.systemd-boot\.enable' "boot.loader.systemd-boot.enable"
+  line=$(grep -nE '^[[:space:]]*boot\.loader\.systemd-boot\.enable' "$CFG" | cut -d: -f1)
+  ind="$(sed -n "${line}p" "$CFG" | sed -E 's/^([[:space:]]*).*/\1/')"
+  sed -i "${line}a\\
+${ind}# Adds a memtest86+ entry to the boot menu. The 2026-07-31 crash shows a\\
+${ind}# GARBAGE per-CPU pointer, and unclean stops span three kernel versions\\
+${ind}# (6.18.4, 6.19.11, 7.0.0), so memory corruption is the leading\\
+${ind}# hypothesis. Budget hours: a full pass over 64 GiB is not quick.\\
+${ind}boot.loader.systemd-boot.memtest86.enable = true;" "$CFG"
+  grep -qE 'boot\.loader\.systemd-boot\.memtest86\.enable[[:space:]]*=[[:space:]]*true;' "$CFG" \
+    || { echo "ERROR: memtest86 edit did not apply" >&2; false; }
+  echo "[2/4] boot.loader.systemd-boot.memtest86.enable = true"
+fi
+
+# ---- 3. Validate ---------------------------------------------------------
+if command -v nix-instantiate >/dev/null 2>&1; then
+  echo "[3/4] parsing $CFG ..."
+  nix-instantiate --parse "$CFG" >/dev/null
+  echo "[3/4] parse OK"
+else
+  echo "[3/4] nix-instantiate unavailable — SKIPPING parse validation" >&2
+fi
+
+trap - ERR
+
+echo
+echo "Review the diff before applying:"
+echo "    diff -u $BAK $CFG"
+echo
+
+if [[ $EDIT_ONLY -eq 1 ]]; then
+  echo "[4/4] --edit-only: config edited and validated, nothing applied."
+  exit 0
+fi
+
+if [[ -t 0 ]]; then
+  read -r -p "Run 'nixos-rebuild switch' now? [y/N] " ans || ans=n
+else
+  ans=n
+  echo "(non-interactive stdin — skipping the rebuild prompt)"
+fi
+
+if [[ ${ans:-n} =~ ^[Yy]$ ]]; then
+  if ! nixos-rebuild switch; then
+    echo
+    echo "nixos-rebuild FAILED. The config edits are still in place." >&2
+    echo "Rollback: cp -a $BAK $CFG && nixos-rebuild switch" >&2
+    exit 1
+  fi
+  # A `nixos-rebuild switch` does NOT restart systemd-sysctl
+  # (NixOS/nixpkgs#289174), so the edit is inert until it is.
+  systemctl restart systemd-sysctl
+  echo "[4/4] applied; restarted systemd-sysctl"
+else
+  echo "[4/4] Config edited and validated; nixos-rebuild NOT run. Run it when ready:"
+  echo "    sudo nixos-rebuild switch && sudo systemctl restart systemd-sysctl"
+fi
+
+echo
+echo "Verify:"
+echo "  sysctl kernel.panic_on_oops    # expect 1"
+echo "  sysctl kernel.panic            # expect 20  (set by #616)"
+echo "  sysctl kernel.nmi_watchdog     # expect 1   (set by #616)"
+echo
+echo "Then REBOOT and pick the memtest86+ entry from the boot menu."
+echo "Let it finish at least one FULL pass over 64 GiB — hours, not minutes."
+echo "A short clean run is NOT evidence of good RAM."
+echo
+echo "Rollback: cp -a $BAK $CFG && nixos-rebuild switch"


### PR DESCRIPTION
Both changes follow from reading the **2026-07-31 pstore capture** — the only one of sixteen unclean stops that produced a trace.

## 1. `kernel.panic_on_oops = 1` — reversing an explicit decision in #616

#616 deliberately excluded it, reasoning: *"an oops is already logged; the silent case is the hard lockup, which oopses nothing."*

**The dump refutes that for this machine.** The first fault *was* an oops, and it was neither survivable nor usefully logged:

```
mov  %gs:0x1a4d130(%rip),%rax      # load per-CPU context-tracking pointer
lock xadd %edi,-0x7b4b2138(%rax)   # atomic add into it
```

`RAX = 0x000000040001f30a` — not a kernel address. The arithmetic closes exactly: `0x40001f30a − 0x7b4b2138 = 0x384b6d1d2 = CR2`. The pointer was garbage; the access was fine.

The fault handler then re-entered the same path (`irqentry_enter → ct_nmi_enter → ct_kernel_enter_state → fault`), recursing ~272 bytes of stack per level across eleven visible frames until the stack was exhausted → `#DF` double fault → `Thread overran stack` → **machine stopped without rebooting**.

Panicking at the *first* fault gives one clean trace plus an automatic reboot on the `kernel.panic=20` #616 already set.

## 2. A memtest86+ boot entry

`boot.loader.systemd-boot.memtest86.enable = true`, so the leading hypothesis is one reboot away rather than a USB-stick errand.

**Why memory rather than a kernel regression:** unclean stops span **three kernel versions** — 6.18.4 (Mar 22), 6.19.11 (Apr 12, Apr 17), 7.0.0 (May 18 onward). A bug in the entry/context-tracking path would not survive 6.18 → 6.19 → 7.0. The fault was also hit from the **idle task** (`CPU 4, PID 0, swapper/4`), which fits stops happening while nobody is at the machine — and explains why the rate went unnoticed for months.

🔴 A short clean memtest pass is **not** evidence of good RAM. A full pass over 64 GiB takes hours; run it overnight.

## The diagnosis doc

`claudedocs/laptop-freeze-diagnosis-2026-08-21.md` records the whole chain, including a correction: an earlier reading called Jul 29 the onset and reasoned *"no software change coincides with onset, so suspect recent hardware degradation."* **There is no onset** — the stops go back to March. The doc says so explicitly so the next reader doesn't re-derive the wrong framing.

## Verification

Script tested against a fixture: both edits land, idempotent on re-run, refuses-and-restores on a missing anchor.

It also injected a **stale filename** into `/etc/nixos` on the first pass (pointing at the pre-rename script) — caught and fixed, since that comment would have sent a future reader to a file that doesn't exist.

Blast radius: two new files, nothing references them, neither is deployed by home-manager. Content gates (doc-path rot, captured text, client hostnames, public IPs) → 210 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
