### PR TITLE
fix(skill-audit): the documented auditor said "✓ stop" about the file the gate was REJECTING

### DIFF
--- a/scripts/skill-audit.py
+++ b/scripts/skill-audit.py
@@ -31,17 +31,65 @@ scripts/browser-bridge/tests/test_skill_size.py — that skill is the existence
 proof that 12 KB is achievable for a genuinely complex tool.
 """
 import argparse
+import importlib.machinery
+import importlib.util
 import os
 import re
 import sys
 from pathlib import Path
 
 # --- budgets -------------------------------------------------------------------
-# TARGET is the browser skill's PROVEN ceiling (MAX_BYTES in
-# scripts/browser-bridge/tests/test_skill_size.py): 11 reference topics and a
-# 21-op CLI routed from 11,845 B of core. It is a demonstrated budget, not an
-# aspiration, which is why it is the default rather than something rounder.
-TARGET = 12_288
+# 🔴 THE BUDGET IS NOT RE-DECLARED HERE. scripts/browser-bridge/tests/test_skill_size.py
+# OWNS both numbers, each with the measurement that sized it, and it is the gate
+# that actually blocks a merge. This module used to restate the ceiling as a
+# literal and check ONLY against it -- so it printed
+#
+#     ✓ all 1 skill(s) within budget -- no prune needed (stop; do not churn the files)
+#
+# for scripts/browser-bridge/SKILL.md on a day that gate was RED (12,259 B: inside
+# the 12,288 B ceiling, 221 B inside the 250 B working margin). The documented
+# audit tool told a maintainer to stop about the exact file the authoritative test
+# was rejecting. Reading the constants out of the gate is what makes that
+# disagreement impossible; a fallback literal here would be the duplicate this
+# exists to prevent, so a missing/unreadable gate is a hard failure, not a default.
+_BUDGET_SOURCE = (Path(__file__).resolve().parent
+                  / "browser-bridge" / "tests" / "test_skill_size.py")
+
+
+def _load_budget(path=_BUDGET_SOURCE):
+    """(ceiling, working margin) read from the gate module itself.
+
+    That module imports nothing but pathlib and runs no code at import time, so
+    loading it here is cheap and side-effect free.
+    """
+    if not path.is_file():
+        raise SystemExit(
+            f"skill-audit: cannot read the budget -- {path} is missing.\n"
+            "That file OWNS the ceiling and the working-margin floor. This tool "
+            "deliberately keeps no copy of them (a second hand-maintained number "
+            "is how the audit and the gate came to disagree), so it cannot run "
+            "without it."
+        )
+    loader = importlib.machinery.SourceFileLoader("_skill_size_gate", str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    try:
+        return int(mod.MAX_BYTES), int(mod.MIN_HEADROOM_BYTES)
+    except AttributeError as e:  # the gate renamed a constant
+        raise SystemExit(
+            f"skill-audit: {path} no longer exports the budget constants "
+            f"({e}). Re-point _load_budget at their new names -- do NOT paste "
+            "the numbers back in here."
+        )
+
+
+# TARGET is the browser skill's PROVEN ceiling; MIN_HEADROOM is the working margin
+# that must stay below it, sized off a MEASURED mean table row so the warning
+# precedes the breach. BUDGET is what is actually ENFORCED -- a body between
+# BUDGET and TARGET is inside the ceiling and still fails the gate.
+TARGET, MIN_HEADROOM = _load_budget()
+BUDGET = TARGET - MIN_HEADROOM
 # HARD is where a skill stops being a skill. ~40 KB is ~10k tokens — already a
 # 5% bite out of a 200k context before any work starts. Past this the body
 # routinely displaces the task it was loaded for.
@@ -470,7 +518,7 @@ def audit_one(skill_md):
         # copy under scratchpad/ as the skill "scratchpad".
         "name": skill_md.parent.name if skill_md.name == "SKILL.md" else skill_md.stem,
         "size": size,
-        "status": "OK" if size <= TARGET else ("OVER TARGET" if size <= HARD else "OVER HARD CAP"),
+        "status": status_for(size),
         "preamble_bytes": _bytes(lines[:first_h2]),
         "h2": h2,
         "fattest_h2": fattest,
@@ -517,8 +565,35 @@ def resolve_targets(args):
     return uniq
 
 
+def status_for(size):
+    """The four bands, widest-first in severity.
+
+    NO HEADROOM is the band the ceiling-only check could not see: under TARGET,
+    so the old comparison called it OK, while the gate rejects it. It is a
+    FINDING, not a note -- everything downstream that asks "is this skill over"
+    tests `status != "OK"`, so naming it here is what makes the verdict move.
+    """
+    if size <= BUDGET:
+        return "OK"
+    if size <= TARGET:
+        return "NO HEADROOM"
+    if size <= HARD:
+        return "OVER TARGET"
+    return "OVER HARD CAP"
+
+
 def _mark(status):
-    return {"OK": "✓", "OVER TARGET": "⚠", "OVER HARD CAP": "✗"}[status]
+    return {"OK": "✓", "NO HEADROOM": "⚠", "OVER TARGET": "⚠",
+            "OVER HARD CAP": "✗"}[status]
+
+
+def _overage(a):
+    """(what it is over, by how many bytes) for a non-OK skill."""
+    if a["status"] == "OVER HARD CAP":
+        return "hard cap", a["size"] - HARD
+    if a["status"] == "OVER TARGET":
+        return "target", a["size"] - TARGET
+    return "enforced budget", a["size"] - BUDGET
 
 
 def render(audits, show_all, n_sections, n_detail, out=sys.stdout):
@@ -526,14 +601,24 @@ def render(audits, show_all, n_sections, n_detail, out=sys.stdout):
     audits = sorted(audits, key=lambda a: -a["size"])
     over = [a for a in audits if a["status"] != "OK"]
     p(f"# SKILL.md audit — {len(audits)} skill(s)")
-    p(f"\ntarget {TARGET:,} B   hard cap {HARD:,} B   (the browser skill holds "
-      f"{TARGET:,} with 11 reference topics — the budget is proven, not aspirational)")
+    p(f"\nbudget {BUDGET:,} B ENFORCED   = ceiling {TARGET:,} B − {MIN_HEADROOM:,} B "
+      f"working margin   ·   hard cap {HARD:,} B")
+    p(f"  ({BUDGET:,} is the number the gate rejects at — a body between it and the "
+      f"{TARGET:,} B\n   ceiling is 'under the ceiling' and still RED. Both constants are read "
+      f"from\n   {_BUDGET_SOURCE.relative_to(Path(__file__).resolve().parent.parent)}, "
+      f"which owns them.)")
 
     p("\n## sizes (worst first)")
     listed = audits if show_all else over
     for a in listed:
-        ratio = f"  {a['size'] / TARGET:.1f}x target" if a["size"] > TARGET else ""
-        p(f"  {a['size']:>9,} B  {_mark(a['status'])} {a['status']:<13} {a['name']}{ratio}")
+        if a["status"] == "OK":
+            note = ""
+        elif a["status"] == "NO HEADROOM":
+            note = (f"  {a['size'] - BUDGET:,} B over the enforced budget "
+                    f"(only {TARGET - a['size']:,} B of the {MIN_HEADROOM:,} B margin left)")
+        else:
+            note = f"  {a['size'] / TARGET:.1f}x target"
+        p(f"  {a['size']:>9,} B  {_mark(a['status'])} {a['status']:<13} {a['name']}{note}")
     hidden = len(audits) - len(listed)
     if hidden:
         p(f"  ({hidden} skill(s) within budget — not listed; --all to see them)")
@@ -541,9 +626,8 @@ def render(audits, show_all, n_sections, n_detail, out=sys.stdout):
         p("  (none over budget)")
 
     for a in over[:n_detail]:
-        p(f"\n## {a['name']} — {a['size']:,} B "
-          f"(over {'hard cap' if a['status'] == 'OVER HARD CAP' else 'target'} by "
-          f"{a['size'] - (HARD if a['status'] == 'OVER HARD CAP' else TARGET):,} B)")
+        what, by = _overage(a)
+        p(f"\n## {a['name']} — {a['size']:,} B (over {what} by {by:,} B)")
         p(f"  {a['path']}")
         if not a["fence_ok"]:
             p("  🔴 UNCLOSED ``` FENCE — every heading after it is invisible to this "
@@ -569,8 +653,12 @@ def render(audits, show_all, n_sections, n_detail, out=sys.stdout):
         if a["dated"]:
             pct = 100.0 * a["dated_bytes"] / a["size"]
             after = a["size"] - a["dated_bytes"]
-            verdict = "under target" if after <= TARGET else (
-                "still over target" if after <= HARD else "still over the HARD CAP")
+            verdict = {
+                "OK": "under the enforced budget",
+                "NO HEADROOM": "still inside the working margin — the gate stays RED",
+                "OVER TARGET": "still over target",
+                "OVER HARD CAP": "still over the HARD CAP",
+            }[status_for(after)]
             p(f"    {len(a['dated'])} block(s), {a['dated_bytes']:,} B ({pct:.1f}% of the file)")
             p(f"    → evicting them to a claudedocs/ doc leaves {after:,} B — {verdict}")
             for title, _s, _e, b in sorted(a["dated"], key=lambda s: -s[3])[:5]:
@@ -677,16 +765,23 @@ def render(audits, show_all, n_sections, n_detail, out=sys.stdout):
     p("\n## verdict")
     n_hard = sum(1 for a in audits if a["status"] == "OVER HARD CAP")
     n_over = sum(1 for a in audits if a["status"] == "OVER TARGET")
+    n_tight = sum(1 for a in audits if a["status"] == "NO HEADROOM")
     if not over and not any_ref_issue and not broken_fence:
-        p(f"  ✓ all {len(audits)} skill(s) within budget, references intact — "
-          f"no prune needed (stop; do not churn the files)")
+        p(f"  ✓ all {len(audits)} skill(s) within budget ({BUDGET:,} B enforced), "
+          f"references intact — no prune needed (stop; do not churn the files)")
     else:
         need = []
         if n_hard:
             need.append(f"{n_hard} over the {HARD:,} B hard cap")
         if n_over:
             need.append(f"{n_over} over the {TARGET:,} B target")
-        excess = sum(a["size"] - TARGET for a in over)
+        if n_tight:
+            need.append(f"{n_tight} inside the {TARGET:,} B ceiling but past the "
+                        f"{MIN_HEADROOM:,} B working margin — the gate REJECTS these")
+        # Measured against the ENFORCED budget, not the ceiling: against the
+        # ceiling a NO HEADROOM skill contributes a NEGATIVE number, which
+        # silently cancelled out real overage elsewhere in the same run.
+        excess = sum(a["size"] - BUDGET for a in over)
         if excess > 0:
             need.append(f"cut ~{excess:,} B total")
         if any_ref_issue:

--- a/scripts/tests/test_skill_audit.py
+++ b/scripts/tests/test_skill_audit.py
@@ -949,3 +949,194 @@ def test_two_spellings_of_one_topic_count_once(tmp_path):
             "`.claude/skills/rr/reference/alpha.md` in the repo-layout section\n")
     a = sa.audit_one(_rr_skill(tmp_path, core, ("alpha.md",)))
     assert len(a["refs"]) == 1, f"same file counted {len(a['refs'])}x: {a['refs']}"
+
+
+# --- the working-margin band: the auditor must not disagree with the gate ------
+# 🔴 REGRESSION. Measured on main at 3393c60b: scripts/browser-bridge/SKILL.md was
+# 12,259 B. test_skill_size.py::test_skill_md_keeps_working_headroom was RED (29 B
+# of free space against a 250 B required margin — "RECLAIM: 221 bytes") while this
+# auditor — the tool /prune-skill documents a maintainer to run — printed
+#
+#     ✓ all 1 skill(s) within budget — no prune needed (stop; do not churn the files)
+#
+# about that same file. It compared against the CEILING only and was structurally
+# blind to the headroom floor, so the documented instrument said STOP about a file
+# the authoritative gate was rejecting. These tests pin both halves: the constants
+# are READ from the gate rather than restated, and a file in the band is a FINDING
+# — checked in BOTH directions, because a checker that always says "prune needed"
+# is as useless as one that never does.
+
+GATE_PY = SCRIPTS / "browser-bridge" / "tests" / "test_skill_size.py"
+gate = _load("browser-bridge/tests/test_skill_size.py", "browser_skill_size_gate")
+
+
+def _skill_of_size(tmp_path, name, size):
+    """A well-formed SKILL.md of EXACTLY `size` bytes and nothing else wrong.
+
+    No reference/ dir: a skill that HAS one but routes nowhere is an ORPHAN
+    finding, which would move the verdict for a reason that is not the size band
+    — red for the wrong reason, and still red with the band check deleted.
+    """
+    d = tmp_path / name
+    d.mkdir(parents=True)
+    head = (f"---\nname: {name}\ndescription: a fixture sized to the byte.\n"
+            f"---\n\n## Ops\n\n").encode()
+    assert size >= len(head) + 1, f"{size} is too small to build a valid fixture"
+    remaining = size - len(head)
+    chunks = []
+    while remaining > 80:
+        chunks.append(b"x" * 79 + b"\n")
+        remaining -= 80
+    chunks.append(b"x" * (remaining - 1) + b"\n")
+    p = d / "SKILL.md"
+    p.write_bytes(head + b"".join(chunks))
+    assert len(p.read_bytes()) == size, (
+        "the fixture builder is wrong — every size test below is void")
+    return p
+
+
+def test_the_gate_module_is_the_one_the_auditor_reads():
+    """Guard the guard: if this path is wrong, everything below measures a module
+    the auditor never loads."""
+    assert GATE_PY.is_file()
+    assert sa._BUDGET_SOURCE == GATE_PY.resolve()
+
+
+def test_the_budget_constants_come_from_the_gate_not_a_second_copy():
+    assert sa.TARGET == gate.MAX_BYTES
+    assert sa.MIN_HEADROOM == gate.MIN_HEADROOM_BYTES
+    assert sa.BUDGET == gate.MAX_BYTES - gate.MIN_HEADROOM_BYTES
+
+
+def test_no_budget_number_is_written_as_a_literal_in_the_auditor():
+    """Equality alone cannot separate a derived value from a coincidence — a
+    pasted literal satisfies it until the day the gate moves.
+
+    MIN_HEADROOM is deliberately NOT checked: it could legitimately equal an
+    unrelated constant (FAT_LINE is 500), and a false failure on a coincidence is
+    worse than the narrower pin. The mechanical control in
+    test_changing_the_gates_numbers_changes_what_the_auditor_reads covers it.
+    """
+    import ast
+    literals = {n.value for n in ast.walk(ast.parse(AUDIT_PY.read_text()))
+                if isinstance(n, ast.Constant) and isinstance(n.value, int)
+                and not isinstance(n.value, bool)}
+    assert sa.TARGET not in literals, (
+        f"{sa.TARGET} is a numeric literal in skill-audit.py — the ceiling is "
+        f"owned by {GATE_PY}, and a second hand-maintained copy is exactly how "
+        "the audit and the gate came to disagree.")
+    assert sa.BUDGET not in literals, (
+        f"{sa.BUDGET} (the ENFORCED budget) is a literal in skill-audit.py; it "
+        "must be derived as TARGET - MIN_HEADROOM.")
+
+
+def test_changing_the_gates_numbers_changes_what_the_auditor_reads(tmp_path):
+    """The mechanical control for the derivation: feed _load_budget a DIFFERENT
+    gate file and watch the numbers move. Values picked so neither can equal the
+    real ones by accident."""
+    fake = tmp_path / "fake_gate.py"
+    fake.write_text("MAX_BYTES = 9_001\nMIN_HEADROOM_BYTES = 137\n")
+    assert sa._load_budget(fake) == (9_001, 137)
+
+
+def test_a_missing_gate_file_is_a_hard_failure_not_a_fallback(tmp_path):
+    """A default literal on the missing-file path would BE the duplicate this
+    design removes — and it would apply silently, which is the worse half."""
+    with pytest.raises(SystemExit) as e:
+        sa._load_budget(tmp_path / "not-there.py")
+    assert "OWNS the ceiling" in str(e.value)
+
+
+def test_a_renamed_gate_constant_fails_loudly(tmp_path):
+    fake = tmp_path / "renamed.py"
+    fake.write_text("CEILING = 9_001\n")
+    with pytest.raises(SystemExit) as e:
+        sa._load_budget(fake)
+    assert "no longer exports the budget constants" in str(e.value)
+
+
+# --- the band itself, in BOTH directions ---------------------------------------
+
+def test_a_file_in_the_warning_band_says_prune_needed(tmp_path):
+    """THE non-vacuity test: a body inside the ceiling but past the working margin
+    is exactly what the ceiling-only check called ✓."""
+    size = sa.BUDGET + 1
+    assert size < sa.TARGET, "the band is empty — this test would prove nothing"
+    p = _skill_of_size(tmp_path, "tight", size)
+    assert sa.audit_one(p)["status"] == "NO HEADROOM"
+    out = _run(tmp_path)
+    assert "⚠ prune needed" in out, out
+    assert "no prune needed" not in out, out
+    assert "the gate REJECTS these" in out, out
+
+
+def test_a_comfortably_small_file_still_says_no_prune_needed(tmp_path):
+    p = _skill_of_size(tmp_path, "lean", 2_000)
+    assert sa.audit_one(p)["status"] == "OK"
+    out = _run(tmp_path)
+    assert "no prune needed" in out
+    assert "prune needed —" not in out
+
+
+@pytest.mark.parametrize("offset,expected", [(-1, "OK"), (0, "OK"), (1, "NO HEADROOM")])
+def test_the_enforced_budget_boundary_is_exact(tmp_path, offset, expected):
+    """Inclusive: BUDGET bytes leaves exactly MIN_HEADROOM free, which is what the
+    gate requires (>=, not >). One byte more is a finding."""
+    p = _skill_of_size(tmp_path, "b", sa.BUDGET + offset)
+    assert sa.audit_one(p)["status"] == expected
+
+
+@pytest.mark.parametrize("offset,expected",
+                         [(-1, "NO HEADROOM"), (0, "NO HEADROOM"), (1, "OVER TARGET")])
+def test_the_ceiling_boundary_is_exact(tmp_path, offset, expected):
+    p = _skill_of_size(tmp_path, "c", sa.TARGET + offset)
+    assert sa.audit_one(p)["status"] == expected
+
+
+def test_the_hard_cap_boundary_is_unchanged_by_the_new_band(tmp_path):
+    assert sa.audit_one(_skill_of_size(tmp_path / "a", "h", sa.HARD))["status"] == "OVER TARGET"
+    assert sa.audit_one(_skill_of_size(tmp_path / "b", "h", sa.HARD + 1))["status"] == "OVER HARD CAP"
+
+
+@pytest.mark.parametrize("base,delta", [
+    (None, 2_000),
+    ("BUDGET", -100), ("BUDGET", -1), ("BUDGET", 0), ("BUDGET", 1), ("BUDGET", 100),
+    ("TARGET", -1), ("TARGET", 0), ("TARGET", 1), ("TARGET", 5_000),
+])
+def test_the_auditor_and_the_gate_never_disagree(tmp_path, base, delta):
+    """The disagreement itself, pinned. For ANY size, "the auditor reports a
+    finding" must equal "the gate's headroom assertion fails" — the right-hand
+    side computed from the GATE's own constants, never from the auditor's.
+
+    This is the property the bug violated: at 12,259 B the gate said RED and the
+    auditor said ✓.
+    """
+    size = delta if base is None else {"BUDGET": sa.BUDGET, "TARGET": sa.TARGET}[base] + delta
+    p = _skill_of_size(tmp_path, "x", size)
+    gate_is_red = (gate.MAX_BYTES - size) < gate.MIN_HEADROOM_BYTES
+    auditor_reports_finding = sa.audit_one(p)["status"] != "OK"
+    assert auditor_reports_finding == gate_is_red, (
+        f"at {size:,} B the gate says {'RED' if gate_is_red else 'green'} and the "
+        f"auditor says {'finding' if auditor_reports_finding else '✓'} — that is "
+        "the exact disagreement this block exists to prevent.")
+
+
+def test_the_budget_line_states_the_ENFORCED_number_not_only_the_ceiling(tmp_path):
+    """A maintainer reads the header to learn what they must fit under. Printing
+    only the ceiling is what makes 12,2xx B look like room."""
+    _skill_of_size(tmp_path, "lean", 2_000)
+    out = _run(tmp_path)
+    assert f"budget {sa.BUDGET:,} B ENFORCED" in out, out
+    assert f"ceiling {sa.TARGET:,} B" in out, out
+    assert f"{sa.MIN_HEADROOM:,} B working margin" in out, out
+
+
+def test_the_real_browser_skill_agrees_with_its_own_gate():
+    """The live cross-check on the file the whole pattern is the exemplar for —
+    the repo's CURRENT SKILL.md, so a regrowth into the band is caught on the next
+    commit that touches it, not only in fixtures."""
+    browser = SCRIPTS / "browser-bridge" / "SKILL.md"
+    size = len(browser.read_bytes())
+    gate_is_red = (gate.MAX_BYTES - size) < gate.MIN_HEADROOM_BYTES
+    assert sa.audit_one(browser)["status"] == "OK" and not gate_is_red, (
+        f"browser SKILL.md is {size:,} B; the enforced budget is {sa.BUDGET:,} B")


### PR DESCRIPTION
`scripts/skill-audit.py` — the tool `/prune-skill` documents a maintainer to run — printed, for `scripts/browser-bridge/SKILL.md` at 12,259 B:

```
✓ all 1 skill(s) within budget — no prune needed (stop; do not churn the files)
```

while `test_skill_size.py::test_skill_md_keeps_working_headroom` was **RED about that exact file**: 29 B of free space against a 250 B required margin, `RECLAIM: 221 bytes`. The auditor restated the ceiling as a literal and compared against **it alone**, structurally blind to the headroom floor. The documented instrument said STOP about a file the authoritative gate was rejecting.

> **Scope note.** The SKILL.md breach itself was fixed independently on `main` by **#679** while this was in flight (it demoted the same triage block into `reference/errors.md`). This PR is the **instrument half only** — rebased onto that fix, with my duplicate eviction dropped. It is *not* made redundant by #679: at 11,961 B `main` sits **77 B** inside the enforced budget, so the next unevicted addition puts it straight back into the band the auditor could not see.

## What changed

- **The constants are no longer declared here at all.** `_load_budget()` reads `MAX_BYTES` / `MIN_HEADROOM_BYTES` out of `test_skill_size.py`, which OWNS them together with the measurement that sized each. There is **no fallback literal** — a missing file or a renamed constant is a hard `SystemExit`, because a default would *be* the duplicate this removes, and would apply silently.
- **New `NO HEADROOM` band** between `BUDGET` (= ceiling − margin) and the ceiling, reported in the verdict's **existing** vocabulary, so everything downstream that tests `status != "OK"` moves with it.
- **The header states the ENFORCED number**, not only the ceiling — printing only the ceiling is what makes 12,2xx B look like room. The eviction projection and the `cut ~N B total` figure are now measured against `BUDGET`; against the ceiling a `NO HEADROOM` skill contributed a **negative** number that cancelled real overage elsewhere in the same run.

Before / after on the same input:

| file | old auditor | new auditor | the gate |
|---|---|---|---|
| pre-#679 SKILL.md, 12,259 B | `✓ OK` · "no prune needed (stop)" | `⚠ NO HEADROOM` · "221 B over the enforced budget" · **"⚠ prune needed … cut ~221 B total"** | **RED**, `RECLAIM: 221 bytes` |
| current `main` SKILL.md, 11,961 B | `✓ OK` | `✓ OK` | green |
| 116 B control | `✓ OK` | `✓ OK` · "no prune needed" | green |

`cut ~221 B` is the same 221 the gate itself prints, computed independently.

## Verification

**Not vacuous, both directions** — proven above: a file in the band says "prune needed", a comfortably-small file still says `✓`. A checker that always says "prune needed" is as useless as one that never does, so both are pinned.

**Mutation controls, watched to fail on this rebased tree:**

1. revert `status_for` to ceiling-only → **8** of the new tests fail, each with *this* band's own assertion. The OK-side tests stay green, so they are not always-red.
2. paste the constants back as literals → the AST-literal test fails, naming `12288`.

`MIN_HEADROOM` is deliberately **excluded** from the AST-literal pin — it could legitimately equal an unrelated constant (`FAT_LINE` is 500), and a false failure on a coincidence is worse than the narrower pin. The mechanical control that feeds `_load_budget` a *different* gate file and watches the numbers move covers it instead.

**New tests** (`scripts/tests/test_skill_audit.py`): the gate-module path is pinned; constants equal the gate's, are absent as literals, and move when the gate file moves; a missing/renamed constant fails loudly; both budget boundaries are exact (`BUDGET`, `BUDGET+1`, `TARGET`, `TARGET+1`) and the hard cap is unchanged; the header states the enforced number; and `test_the_auditor_and_the_gate_never_disagree` sweeps 10 sizes asserting **"auditor reports a finding" == "the gate's headroom assertion fails"**, with the right-hand side computed from the *gate's* own constants — the exact property the bug violated.

## 🔴 Which tests were run — and which were NOT

A repo-wide test freeze is in effect (a suite recently pushed fixture commits to the real `origin/main`), so **`scripts/gate.sh`, `run-tests.sh` and `nix build .#checks…pytests` were NOT run.** Only targeted files.

On this rebased tree:

```
nix develop ~/workspace/devrc --command python3 -m pytest \
  scripts/browser-bridge/tests/test_skill_size.py \
  scripts/tests/test_skill_audit.py -p no:cacheprovider          # 93 passed
```

Pre-rebase, over the files the diff implicated:

```
nix develop ~/workspace/devrc --command python3 -m pytest \
  scripts/tests/test_doc_path_rot.py scripts/tests/test_skill_descriptions.py \
  scripts/tests/test_prune_skill_size.py scripts/browser-bridge/tests/ \
  -p no:cacheprovider                                            # 901 passed
```

**Nothing here is a claim about the full suite.** The branch *is* rebased onto current `main` (`29d7913e`), so the 93-test run is against the merged tree for these files — but not for the rest of the suite.

## Known gap, deliberately not closed

`claude/skills/prune-skill/SKILL.md` still frames **12,288 B** as the number to fit under. It sits **5 B** inside its own ratchet's margin (`test_prune_skill_size.py`: 13,056 / 192), so any addition there turns a second always-loaded file red — a separate eviction job, and out of scope under the freeze. The auditor now prints the enforced number on every run, and that file already delegates the numbers to the owning gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
