### PR TITLE
fix(tests): the suite built its git fixtures inside the REPO IT RUNS FROM — `main` was rewritten and pushed to the remote

### DIFF
--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -41,14 +41,25 @@ URL="${2:-}"
 STDIN_DATA="$(cat || true)"
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
-GIT_DIR="$(git rev-parse --git-dir 2>/dev/null || true)"
+# 🔴 NOT NAMED `GIT_DIR`, AND THE NAME IS THE WHOLE POINT. In bash, assigning to
+# a variable that is ALREADY EXPORTED keeps it exported — so if any caller (an
+# outer hook, a wrapper, a shell where someone exported it) has GIT_DIR in the
+# environment, `GIT_DIR=…` here silently hands this repository's git dir to
+# every child, including `tests-on-push.sh` -> `run-tests.sh` -> pytest. GIT_DIR
+# OVERRIDES `-C`, so the whole devrc suite would then build its fixtures inside
+# THIS checkout: that is the 2026-08-21 incident, in which `refs/heads/main` was
+# rewritten with fixture commits and pushed. `scripts/testlib/gitenv.py` closes
+# it from the suite's side; this rename closes the route.
+# `scripts/tests/test_git_repo_isolation.py` asserts no shell script that can
+# reach the runner assigns to one of those names.
+HOOK_GIT_DIR="$(git rev-parse --git-dir 2>/dev/null || true)"
 SELF="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 
 # --- 1. Chain to a repo-local pre-push hook, if any (and it isn't us) --------
 # Candidates: the repo's .git/hooks/pre-push and (defensively) a tracked
 # .githooks/pre-push. Skip any path that resolves to THIS file (no recursion).
 for candidate in \
-  "${GIT_DIR:+$GIT_DIR/hooks/pre-push}" \
+  "${HOOK_GIT_DIR:+$HOOK_GIT_DIR/hooks/pre-push}" \
   "${REPO_ROOT:+$REPO_ROOT/.githooks/pre-push}" \
 ; do
   [ -n "$candidate" ] || continue

--- a/scripts/gate.sh
+++ b/scripts/gate.sh
@@ -95,6 +95,30 @@ case "$TIMEOUT" in
   ''|*[!0-9]*) echo "gate: FATAL — --timeout must be a whole number of seconds, got '$TIMEOUT'" >&2; exit 2 ;;
 esac
 
+# --- GUARD 9: NO TEST MAY OPERATE ON THE REPO THE SUITE RUNS FROM -------------
+# 🔴 BEFORE the ROOT block below, not after it: with GIT_DIR set and no
+# GIT_WORK_TREE, git takes the CWD as the work tree, so
+# `rev-parse --show-toplevel` returns `<repo>/scripts` and this script dies
+# `exit 127` with no verdict. The 2026-08-21 incident, the reproduction, and the
+# reason this block is spelled in three files rather than sourced from one are
+# in `scripts/run-tests.sh`'s copy of this header. The SET is owned by
+# `scripts/testlib/gitenv.py::REPO_POINTER_VARS`; every spelling is pinned
+# two-way by `scripts/tests/test_git_repo_isolation.py`.
+DEVRC_GIT_REPO_POINTERS=(
+  GIT_DIR                            # the repository itself; beats -C
+  GIT_WORK_TREE                      # the working tree
+  GIT_COMMON_DIR                     # where refs/config actually live
+  GIT_INDEX_FILE                     # the index a `git add` writes
+  GIT_OBJECT_DIRECTORY               # where new objects are written
+  GIT_ALTERNATE_OBJECT_DIRECTORIES   # extra object stores
+  GIT_NAMESPACE                      # the ref namespace refs land in
+  GIT_PREFIX                         # hook-injected pathspec prefix
+  GIT_GRAFT_FILE                     # repo-scoped grafts
+  GIT_SHALLOW_FILE                   # repo-scoped shallow list
+  GIT_CONFIG                         # legacy: the file `git config` WRITES
+)
+unset "${DEVRC_GIT_REPO_POINTERS[@]}"
+
 if [ -z "$ROOT" ]; then
   ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null || true)"
   [ -n "$ROOT" ] || ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/run-node-tests.sh
+++ b/scripts/run-node-tests.sh
@@ -117,6 +117,30 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+# --- GUARD 9: NO TEST MAY OPERATE ON THE REPO THE SUITE RUNS FROM -------------
+# 🔴 BEFORE the ROOT block below, not after it: with GIT_DIR set and no
+# GIT_WORK_TREE, git takes the CWD as the work tree, so
+# `rev-parse --show-toplevel` returns `<repo>/scripts` and this script dies
+# `exit 127` with no verdict. The 2026-08-21 incident, the reproduction, and the
+# reason this block is spelled in three files rather than sourced from one are
+# in `scripts/run-tests.sh`'s copy of this header. The SET is owned by
+# `scripts/testlib/gitenv.py::REPO_POINTER_VARS`; every spelling is pinned
+# two-way by `scripts/tests/test_git_repo_isolation.py`.
+DEVRC_GIT_REPO_POINTERS=(
+  GIT_DIR                            # the repository itself; beats -C
+  GIT_WORK_TREE                      # the working tree
+  GIT_COMMON_DIR                     # where refs/config actually live
+  GIT_INDEX_FILE                     # the index a `git add` writes
+  GIT_OBJECT_DIRECTORY               # where new objects are written
+  GIT_ALTERNATE_OBJECT_DIRECTORIES   # extra object stores
+  GIT_NAMESPACE                      # the ref namespace refs land in
+  GIT_PREFIX                         # hook-injected pathspec prefix
+  GIT_GRAFT_FILE                     # repo-scoped grafts
+  GIT_SHALLOW_FILE                   # repo-scoped shallow list
+  GIT_CONFIG                         # legacy: the file `git config` WRITES
+)
+unset "${DEVRC_GIT_REPO_POINTERS[@]}"
+
 if [ -z "$ROOT" ]; then
   ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null || true)"
   [ -n "$ROOT" ] || ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -176,6 +176,64 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+# --- GUARD 9: NO TEST MAY OPERATE ON THE REPO THE SUITE RUNS FROM -------------
+# 🔴 THE THIRD ENFORCEMENT POINT, beside GUARDS 7 and 8 — but it has to run
+# HERE, at the top, and not down beside them.
+#
+# MEASURED 2026-08-21, on the operator's real clone and on the production
+# remote: a gate run rewrote `refs/heads/main` with fixture commits, created
+# `side`/`topic`/`trunk`/`master`/`only-branch`/`feat/behind-too`, DELETED
+# `refs/heads/main`, repointed HEAD at `trunk`, wrote `core.bare=true`,
+# `user.name=T`, a `core.hooksPath` under `pytest-0/test_install_does_not_
+# depend_o0/` and a `remote.origin.url` under `pytest-0/test_fetch_failure_is_
+# rc40/` — then pushed fixture refs to GitHub.
+#
+# 🔴 NOT ONE FIXTURE WAS SLOPPY. Every git fixture in this repo passes
+# `-C <tmp_path>/…`; several also pin HOME, GIT_CONFIG_GLOBAL and
+# GIT_CONFIG_SYSTEM. `GIT_DIR` OVERRIDES `-C`, so one inherited variable defeats
+# all of them at once — which is why this is an `unset` and not a patch in
+# fourteen test files. Reproduced on a throwaway clone: with GIT_DIR exported,
+# `git -C <tmp>/work branch -D main` DELETES the clone's main.
+#
+# 🔴 AND IT MUST PRECEDE THE ROOT BLOCK BELOW. With GIT_DIR set and no
+# GIT_WORK_TREE, git takes the CWD as the top of the work tree, so
+# `rev-parse --show-toplevel` returns `<repo>/scripts`; this script then hunts
+# for `<repo>/scripts/scripts/run-tests.sh` and dies `exit 127` with NO verdict
+# line. MEASURED — the first placement of this guard was two thirds of the way
+# down this file and the gate never reached it. Same class as the `unset CDPATH`
+# a few lines below ROOT: an inherited variable silently corrupting a resolution
+# every reader assumes is local.
+#
+# 🔴 SPELLED HERE RATHER THAN SOURCED, DELIBERATELY. `scripts/run-node-tests.sh`
+# and `scripts/gate.sh` carry the same block, and so does every COPY of this
+# runner that `testlib/runner_patch.py` writes into a tmp dir — about fifteen
+# tests drive such a copy, and a copy cannot source a sibling `lib/` that was
+# never copied with it. (The first version did source one; MEASURED, it turned
+# those fifteen into `run-tests: FATAL — cannot source lib/git-repo-pointers.sh`,
+# i.e. a permanently-red gate, which claude/RULES.md rates worse than no gate.)
+# The SET is owned once, by `scripts/testlib/gitenv.py::REPO_POINTER_VARS`, and
+# `scripts/tests/test_git_repo_isolation.py` pins all four spellings against it
+# in both directions plus the ordering above — the same treatment
+# `SPOOL_SESSION_MARKER` gets, for the same cross-process reason.
+#
+# UNCONDITIONAL, including over a deliberate ambient value: there is no workflow
+# in which the test gate should be pointed at a repository by inherited
+# environment.
+DEVRC_GIT_REPO_POINTERS=(
+  GIT_DIR                            # the repository itself; beats -C
+  GIT_WORK_TREE                      # the working tree
+  GIT_COMMON_DIR                     # where refs/config actually live
+  GIT_INDEX_FILE                     # the index a `git add` writes
+  GIT_OBJECT_DIRECTORY               # where new objects are written
+  GIT_ALTERNATE_OBJECT_DIRECTORIES   # extra object stores
+  GIT_NAMESPACE                      # the ref namespace refs land in
+  GIT_PREFIX                         # hook-injected pathspec prefix
+  GIT_GRAFT_FILE                     # repo-scoped grafts
+  GIT_SHALLOW_FILE                   # repo-scoped shallow list
+  GIT_CONFIG                         # legacy: the file `git config` WRITES
+)
+unset "${DEVRC_GIT_REPO_POINTERS[@]}"
+
 if [ -z "$ROOT" ]; then
   ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null || true)"
   [ -n "$ROOT" ] || ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -1627,36 +1685,15 @@ echo "run-tests: activity telemetry isolated for this run (GUARD 8)"
 echo "  ACTIVITY_SPOOL_DIR=$ACTIVITY_SPOOL_DIR"
 echo "  fallback trap      =$SPOOL_TRAP_LOG"
 
-# --- GUARD 9: NO TEST MAY OPERATE ON THE REPO THE SUITE RUNS FROM -------------
-# 🔴 THE THIRD ENFORCEMENT POINT, beside GUARDS 7 and 8 and for the same reason.
-#
-# MEASURED 2026-08-21, on the operator's real clone and on the production
-# remote: a gate run rewrote `refs/heads/main` with fixture commits, DELETED the
-# branch, repointed HEAD at a fixture `trunk`, wrote `core.bare=true`,
-# `user.name=T`, a `core.hooksPath` under `pytest-0/test_install_does_not_
-# depend_o0/` and a `remote.origin.url` under `pytest-0/test_fetch_failure_is_
-# rc40/` — then pushed fixture refs to GitHub.
-#
-# 🔴 THE FIXTURES WERE NOT SLOPPY. Every git fixture in this repo passes
-# `-C <tmp_path>/…`, and `GIT_DIR` OVERRIDES `-C`. One inherited environment
-# variable defeats all of them at once, which is why the fix is an `unset` here
-# and not a patch in fourteen test files. Reproduced exactly on a throwaway
-# clone: with `GIT_DIR` exported, `git -C <tmp>/work branch -D main` deletes the
-# CLONE's main.
-#
-# The names live in `scripts/testlib/gitenv.py::REPO_POINTER_VARS`; this line is
-# the second spelling, needed because the non-pytest targets (HOOK_TESTS,
-# SHELL_TESTS) never load a plugin. `scripts/tests/test_git_repo_isolation.py`
-# pins the two lists against each other in BOTH directions, so they cannot
-# drift apart into a guard that protects twelve targets and not five.
-#
-# UNCONDITIONAL, including over a deliberate ambient value — same argument as
-# GUARD 8's overrides. There is no workflow in which the test suite should be
-# pointed at a repository by inherited environment.
-unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE \
-      GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES \
-      GIT_NAMESPACE GIT_PREFIX GIT_GRAFT_FILE GIT_SHALLOW_FILE GIT_CONFIG
+# --- GUARD 9's REPORTING LINE ------------------------------------------------
+# The clearing itself happens at the TOP of this file (before ROOT is resolved —
+# see the GUARD 9 header there); this is only the announcement, printed here so
+# it sits beside GUARDS 7 and 8 where a reader looks for the run's isolation
+# summary. It reports the PAIR: the shell half cleared the pointers for EVERY
+# target including the non-pytest ones, and each pytest target additionally
+# loads the detector that names whichever test moves a ref.
 echo "run-tests: git repo pointers cleared for this run (GUARD 9)"
+echo "  cleared     =${DEVRC_GIT_REPO_POINTERS[*]}"
 echo "  detector    =-p testlib.gitenv_plugin (per pytest target)"
 
 # "<target>|<sess-from>|<sess-to>|<trap-from>|<trap-to>|<iso-from>|<iso-to>" —

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1627,6 +1627,38 @@ echo "run-tests: activity telemetry isolated for this run (GUARD 8)"
 echo "  ACTIVITY_SPOOL_DIR=$ACTIVITY_SPOOL_DIR"
 echo "  fallback trap      =$SPOOL_TRAP_LOG"
 
+# --- GUARD 9: NO TEST MAY OPERATE ON THE REPO THE SUITE RUNS FROM -------------
+# 🔴 THE THIRD ENFORCEMENT POINT, beside GUARDS 7 and 8 and for the same reason.
+#
+# MEASURED 2026-08-21, on the operator's real clone and on the production
+# remote: a gate run rewrote `refs/heads/main` with fixture commits, DELETED the
+# branch, repointed HEAD at a fixture `trunk`, wrote `core.bare=true`,
+# `user.name=T`, a `core.hooksPath` under `pytest-0/test_install_does_not_
+# depend_o0/` and a `remote.origin.url` under `pytest-0/test_fetch_failure_is_
+# rc40/` — then pushed fixture refs to GitHub.
+#
+# 🔴 THE FIXTURES WERE NOT SLOPPY. Every git fixture in this repo passes
+# `-C <tmp_path>/…`, and `GIT_DIR` OVERRIDES `-C`. One inherited environment
+# variable defeats all of them at once, which is why the fix is an `unset` here
+# and not a patch in fourteen test files. Reproduced exactly on a throwaway
+# clone: with `GIT_DIR` exported, `git -C <tmp>/work branch -D main` deletes the
+# CLONE's main.
+#
+# The names live in `scripts/testlib/gitenv.py::REPO_POINTER_VARS`; this line is
+# the second spelling, needed because the non-pytest targets (HOOK_TESTS,
+# SHELL_TESTS) never load a plugin. `scripts/tests/test_git_repo_isolation.py`
+# pins the two lists against each other in BOTH directions, so they cannot
+# drift apart into a guard that protects twelve targets and not five.
+#
+# UNCONDITIONAL, including over a deliberate ambient value — same argument as
+# GUARD 8's overrides. There is no workflow in which the test suite should be
+# pointed at a repository by inherited environment.
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE \
+      GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES \
+      GIT_NAMESPACE GIT_PREFIX GIT_GRAFT_FILE GIT_SHALLOW_FILE GIT_CONFIG
+echo "run-tests: git repo pointers cleared for this run (GUARD 9)"
+echo "  detector    =-p testlib.gitenv_plugin (per pytest target)"
+
 # "<target>|<sess-from>|<sess-to>|<trap-from>|<trap-to>|<iso-from>|<iso-to>" —
 # three line ranges per target, so every count below is attributed to the target
 # that produced it rather than to the run as a whole.
@@ -1801,10 +1833,11 @@ run_pytest() {
   log="$(mktemp)"
   nl_before="$(_nolaunch_lines)"
   _spool_mark_before
-  # 🔴 `-p testlib.nolaunch_plugin` is GUARD 7 and `-p testlib.spool_plugin` is
-  # GUARD 8 (see each header). Both are on THIS line — the one place every
-  # target is invoked — and not in two dozen conftests.
-  python -m pytest "$d" -q -p no:cacheprovider -p testlib.nolaunch_plugin -p testlib.spool_plugin \
+  # 🔴 `-p testlib.nolaunch_plugin` is GUARD 7, `-p testlib.spool_plugin` is
+  # GUARD 8 and `-p testlib.gitenv_plugin` is GUARD 9 (see each header). All
+  # three are on THIS line — the one place every target is invoked — and not in
+  # two dozen conftests.
+  python -m pytest "$d" -q -p no:cacheprovider -p testlib.nolaunch_plugin -p testlib.spool_plugin -p testlib.gitenv_plugin \
     --no-header -rs >"$log" 2>&1
   rc=$?
   nl_after="$(_nolaunch_lines)"

--- a/scripts/testlib/gitenv.py
+++ b/scripts/testlib/gitenv.py
@@ -1,0 +1,335 @@
+"""GUARD 9 — the suite may not operate on the git repository it RUNS FROM.
+
+🔴 WHY THIS FILE EXISTS — measured 2026-08-21, on the operator's real clone AND
+on the real GitHub remote.
+
+A gate run rewrote `refs/heads/main` with fixture commits (`seed`, `base`,
+`ahead`, `local side`, `un-pushed work stranded on main`, `autocommit: N
+change(s) in the some-scope analyze-service index`), created the fixture
+branches `side`/`topic`/`trunk`/`master`/`only-branch`/`feat/behind-too`,
+DELETED `refs/heads/main` outright, repointed `HEAD` at `trunk`, wrote
+`core.bare=true`, `user.name=T`, `user.email=t@example.invalid`, a
+`core.hooksPath` pointing into `pytest-0/test_install_does_not_depend_o0/…`
+and a `remote.origin.url` pointing into `pytest-0/test_fetch_failure_is_rc40/…`
+— and then a push carried fixture refs to the production remote.
+
+THE MECHANISM, reproduced exactly on a throwaway clone:
+
+    export GIT_DIR=<clone>/.git
+    git -C <tmp>/work checkout -q -b topic   -> creates `topic` in <clone>
+    git -C <tmp>/work branch  -D  main       -> DELETES <clone>'s main
+    git -C <tmp>/work config user.name T     -> writes <clone>/.git/config
+
+🔴 `GIT_DIR` OVERRIDES `-C`. Every fixture in this repo is hygienic in the way
+everyone checks for — it passes `-C <tmp_path>/…` and never runs bare `git` —
+and every one of them is defeated by one inherited environment variable. The
+repo already knew this: `scripts/claude-hooks/guard_core.py` judges a
+`GIT_DIR=` prefix IN ADDITION to a resolving `-C` for exactly this reason
+("even though `GIT_DIR` OVERRIDES the working directory"). The knowledge lived
+in the hook that polices the OPERATOR's commands and nowhere in the harness
+that runs 7,000 of our own.
+
+And the fixture VALUES are the tell that identifies the mechanism rather than
+merely being consistent with it: the tmpdir paths written into the clone's
+config are the tests' OWN correct values. The tests computed the right thing
+and git wrote it into the wrong repository.
+
+WHAT THIS MODULE OWNS (one rule, one place — it is spelled in bash in
+`scripts/run-tests.sh` and in Python here, and `scripts/tests/
+test_git_repo_isolation.py` pins the two lists against each other):
+
+  1. `REPO_POINTER_VARS` — the environment variables that decide WHICH
+     repository a git command lands in. Stripping them is the FIX.
+  2. `protected_git_dirs()` / `snapshot()` / `diff_snapshots()` — the
+     DETECTOR: a content fingerprint of the host repo's refs, HEAD and config
+     that `gitenv_plugin` compares around every test, so the NEXT escape —
+     by any mechanism, in any test, including one nobody has thought of — is
+     attributed to the test that caused it instead of being found days later
+     on the remote.
+
+DELIBERATELY NOT STRIPPED, and the reason, so the next reader does not have to
+re-derive it:
+
+  * `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` — these point git AWAY from the
+    operator's real config; several fixtures set them on purpose. They cannot
+    change which repository a `-C` resolves to.
+  * `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_n` / `GIT_CONFIG_VALUE_n` — they
+    inject config VALUES into whatever repo git already resolved. Same reason.
+  * `GIT_AUTHOR_*` / `GIT_COMMITTER_*` — identity, not location.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+# --------------------------------------------------------------------------- #
+# 1. THE LEDGER: what redirects git at a repository
+# --------------------------------------------------------------------------- #
+# 🔴 ORDERED and EXACT. `scripts/run-tests.sh` spells the same names in its
+# GUARD 9 `unset` line — it has to, because the non-pytest targets (HOOK_TESTS,
+# SHELL_TESTS) never load a pytest plugin — and
+# `test_git_repo_isolation.py::test_the_shell_and_python_pointer_ledgers_agree`
+# fails if the two sets diverge in EITHER direction. Adding a name here without
+# adding it there would leave five targets unprotected while this file's
+# docstring claimed otherwise.
+REPO_POINTER_VARS: tuple[str, ...] = (
+    "GIT_DIR",                            # the repository itself; beats -C
+    "GIT_WORK_TREE",                      # the working tree
+    "GIT_COMMON_DIR",                     # where refs/config actually live
+    "GIT_INDEX_FILE",                     # the index a `git add` writes
+    "GIT_OBJECT_DIRECTORY",               # where new objects are written
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",   # extra object stores
+    "GIT_NAMESPACE",                      # the ref namespace refs land in
+    "GIT_PREFIX",                         # hook-injected pathspec prefix
+    "GIT_GRAFT_FILE",                     # repo-scoped grafts
+    "GIT_SHALLOW_FILE",                   # repo-scoped shallow list
+    "GIT_CONFIG",                         # legacy: the file `git config` WRITES
+)
+
+# The marker the plugin prints once per pytest session. `run-tests.sh` does not
+# count it today, but it is the only way to tell "this target loaded GUARD 9 and
+# saw nothing" apart from "this target never loaded GUARD 9" — the reassuring
+# zero that RULES.md's positive-control rule is about. Spelled on both sides of
+# a process boundary, so it is pinned by the test file.
+SESSION_MARKER = "gitenv(session)"
+
+# The token every violation message carries. Asserted verbatim by the
+# reachability control, so a control cannot pass off a DIFFERENT guard's error
+# as this one's.
+VIOLATION_TOKEN = "DEVRC-GITENV-VIOLATION"
+
+# TEST SEAM. A colon-separated list of git dirs to protect INSTEAD of the
+# discovered host repo. It exists so the controls in test_git_repo_isolation.py
+# can drive a nested pytest against a throwaway repo and watch this guard go
+# red — a guard nobody has watched fail proves nothing. It is a seam for tests,
+# not a supported way to run the suite.
+PROTECT_ENV = "DEVRC_GITENV_PROTECT"
+
+
+def strip_repo_pointers(env: "dict[str, str] | os._Environ | None" = None) -> "dict[str, str]":
+    """Remove every `REPO_POINTER_VARS` entry from `env` (default `os.environ`).
+
+    Returns what was removed, so the caller can REPORT it. Mutating
+    `os.environ` in place is the point: a fixture that builds a subprocess
+    environment with `dict(os.environ)` — which is what every git fixture in
+    this repo does — copies the sanitised mapping, so the fix reaches fixtures
+    that have never heard of this module and fixtures not yet written.
+    """
+    target = os.environ if env is None else env
+    removed: dict[str, str] = {}
+    for name in REPO_POINTER_VARS:
+        if name in target:
+            removed[name] = target[name]
+            del target[name]
+    return removed
+
+
+# --------------------------------------------------------------------------- #
+# 2. THE DETECTOR: which repositories must not move
+# --------------------------------------------------------------------------- #
+def resolve_git_dir(start: Path) -> "Path | None":
+    """The git dir governing `start`, walking up — no subprocess, no `git`.
+
+    Deliberately pure Python. Asking `git rev-parse` would make the DETECTOR
+    depend on the same binary and the same environment the detector exists to
+    police, and it would silently return nothing on a host where `git` is
+    missing — an unarmed detector that still prints a clean report.
+
+    Handles a WORKTREE, where `.git` is a FILE holding `gitdir: <path>`
+    (claude/RULES.md → "any COPY you make OF it").
+    """
+    try:
+        start = start.resolve()
+    except OSError:
+        return None
+    for candidate in (start, *start.parents):
+        dot = candidate / ".git"
+        if dot.is_dir():
+            return dot
+        if dot.is_file():
+            try:
+                text = dot.read_text(encoding="utf-8", errors="replace").strip()
+            except OSError:
+                return None
+            if text.startswith("gitdir:"):
+                target = Path(text.split(":", 1)[1].strip())
+                if not target.is_absolute():
+                    target = (candidate / target)
+                try:
+                    return target.resolve()
+                except OSError:
+                    return target
+    return None
+
+
+def common_dir_of(git_dir: Path) -> "Path | None":
+    """A linked worktree's SHARED git dir — where refs and config really live.
+
+    `git_dir/commondir` holds the path (usually `../..`). Without this, a suite
+    running inside a worktree would fingerprint the per-worktree HEAD and miss
+    every ref and config write, which all land in the common dir.
+    """
+    marker = git_dir / "commondir"
+    if not marker.is_file():
+        return None
+    try:
+        text = marker.read_text(encoding="utf-8", errors="replace").strip()
+    except OSError:
+        return None
+    if not text:
+        return None
+    target = Path(text)
+    if not target.is_absolute():
+        target = git_dir / target
+    try:
+        resolved = target.resolve()
+    except OSError:
+        return None
+    return resolved if resolved != git_dir else None
+
+
+def global_config_paths() -> "list[Path]":
+    """The user-level git config files a `git config --global` would write.
+
+    Included in the fingerprint because the incident's config damage
+    (`user.name`, `core.hooksPath`, `remote.origin.url`) is the same class of
+    escape as the ref damage, and a `--global` write leaves the repo itself
+    untouched — so a guard watching only refs would report a clean run.
+    """
+    override = os.environ.get("GIT_CONFIG_GLOBAL")
+    if override:
+        return [Path(override)]
+    home = Path(os.path.expanduser("~"))
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    xdg_dir = Path(xdg) if xdg else home / ".config"
+    return [home / ".gitconfig", xdg_dir / "git" / "config"]
+
+
+def protected_git_dirs(starts: "list[Path] | None" = None) -> "list[Path]":
+    """Every git dir the suite must leave byte-identical.
+
+    Two roots by default and both are needed: the CWD (what `run-tests.sh` cd's
+    to, and what a bare `pytest` inherits) and this file's own location (which
+    survives a runner invoked from somewhere else entirely). A worktree
+    contributes its common dir as well.
+
+    `DEVRC_GITENV_PROTECT` replaces the discovery entirely — see PROTECT_ENV.
+    """
+    override = os.environ.get(PROTECT_ENV)
+    if override:
+        return [Path(p) for p in override.split(os.pathsep) if p]
+
+    if starts is None:
+        starts = [Path.cwd(), Path(__file__).resolve().parent]
+
+    found: list[Path] = []
+    for start in starts:
+        git_dir = resolve_git_dir(start)
+        if git_dir is None:
+            continue
+        for candidate in (git_dir, common_dir_of(git_dir)):
+            if candidate is not None and candidate not in found:
+                found.append(candidate)
+    return found
+
+
+# The per-git-dir files whose content IS the repository's identity for our
+# purposes. `index` is deliberately absent: a plain `git status` rewrites it as
+# a racy-timestamp refresh, and a detector that reds on a READ is a
+# permanently-red gate (claude/RULES.md), which trains everyone to ignore it.
+# Every damage class from the incident lands in one of these instead —
+# commits/branch creates/deletes and HEAD moves in `refs/`+`HEAD`+`packed-refs`,
+# and `core.bare`/`user.*`/`core.hooksPath`/`remote.origin.url` in `config`.
+_GIT_DIR_FILES = ("config", "HEAD", "packed-refs", "ORIG_HEAD", "logs/HEAD")
+_GIT_DIR_TREES = ("refs",)
+
+_LABEL_MISSING = "<absent>"
+
+
+def _digest(path: Path) -> str:
+    try:
+        with path.open("rb") as fh:
+            h = hashlib.sha256()
+            for chunk in iter(lambda: fh.read(1 << 16), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except FileNotFoundError:
+        return _LABEL_MISSING
+    except OSError as exc:  # unreadable is a CHANGE we must not hide
+        return f"<unreadable: {exc.__class__.__name__}>"
+
+
+def snapshot(git_dirs: "list[Path]", extra_files: "list[Path] | None" = None) -> "dict[str, str]":
+    """A content fingerprint of every protected repository.
+
+    Content hashes rather than `stat`: an mtime is a claim about WHEN, and two
+    writes inside one timestamp tick would report SAME. The set is small (five
+    files plus the loose refs per repo), so exactness is affordable.
+    """
+    out: dict[str, str] = {}
+    for git_dir in git_dirs:
+        for rel in _GIT_DIR_FILES:
+            out[f"{git_dir}/{rel}"] = _digest(git_dir / rel)
+        for tree in _GIT_DIR_TREES:
+            root = git_dir / tree
+            if not root.is_dir():
+                out[f"{git_dir}/{tree}/"] = _LABEL_MISSING
+                continue
+            for dirpath, _dirnames, filenames in os.walk(root):
+                for name in filenames:
+                    p = Path(dirpath) / name
+                    out[str(p)] = _digest(p)
+    for path in extra_files or []:
+        out[str(path)] = _digest(path)
+    return out
+
+
+def diff_snapshots(before: "dict[str, str]", after: "dict[str, str]") -> "list[str]":
+    """Human-readable deltas, one line each. Empty list == nothing moved."""
+    lines: list[str] = []
+    for key in sorted(set(before) | set(after)):
+        was = before.get(key, _LABEL_MISSING)
+        now = after.get(key, _LABEL_MISSING)
+        if was == now:
+            continue
+        if was == _LABEL_MISSING:
+            lines.append(f"  CREATED  {key}")
+        elif now == _LABEL_MISSING:
+            lines.append(f"  DELETED  {key}")
+        else:
+            lines.append(f"  CHANGED  {key}  {was[:12]} -> {now[:12]}")
+    return lines
+
+
+def violation_message(where: str, deltas: "list[str]", git_dirs: "list[Path]") -> str:
+    """The one place a GUARD 9 failure is worded.
+
+    Carries `VIOLATION_TOKEN` so a control can assert THIS guard fired and not a
+    neighbour's error (claude/RULES.md → "prove it REACHABLE"), and names the
+    remediation, because the reader is about to conclude the harness is flaky.
+    """
+    listed = "\n".join(f"    {d}" for d in git_dirs) or "    (none discovered)"
+    return (
+        f"{VIOLATION_TOKEN}: {where} MUTATED a git repository that is not its own tmpdir.\n"
+        "\n"
+        "Protected git dir(s):\n"
+        f"{listed}\n"
+        "\n"
+        "What moved:\n" + "\n".join(deltas) + "\n"
+        "\n"
+        "🔴 This is the 2026-08-21 incident's shape. On that day a gate run rewrote\n"
+        "`refs/heads/main` with fixture commits, deleted the branch, rewrote\n"
+        "`core.hooksPath` and `remote.origin.url`, and pushed fixture refs to the\n"
+        "production remote. The fixtures were NOT sloppy — they all passed\n"
+        "`-C <tmp_path>`; an inherited GIT_DIR simply overrides `-C`.\n"
+        "\n"
+        "Check, in this order:\n"
+        f"  1. Was one of {', '.join(REPO_POINTER_VARS[:4])}… set in the environment?\n"
+        "     `scripts/testlib/gitenv.py` strips them; something re-set one AFTER\n"
+        "     the plugin loaded (a monkeypatch.setenv, a conftest, a wrapper).\n"
+        "  2. Does the failing test run git with a path it did not build under\n"
+        "     `tmp_path` — e.g. a repo root derived from `__file__`?\n"
+        "  3. Restore this checkout before doing anything else: `git reflog` is the\n"
+        "     one-command diagnosis for a branch that looks like it moved backwards."
+    )

--- a/scripts/testlib/gitenv.py
+++ b/scripts/testlib/gitenv.py
@@ -34,9 +34,15 @@ merely being consistent with it: the tmpdir paths written into the clone's
 config are the tests' OWN correct values. The tests computed the right thing
 and git wrote it into the wrong repository.
 
-WHAT THIS MODULE OWNS (one rule, one place — it is spelled in bash in
-`scripts/run-tests.sh` and in Python here, and `scripts/tests/
-test_git_repo_isolation.py` pins the two lists against each other):
+WHAT THIS MODULE OWNS. `REPO_POINTER_VARS` below is the ONE owner of the set.
+It is re-spelled as a bash array at the top of `run-tests.sh`,
+`run-node-tests.sh` and `gate.sh` — each BEFORE that script resolves its own
+ROOT — and `scripts/tests/test_git_repo_isolation.py` pins every spelling
+against this tuple in both directions, plus the ordering. Three shell copies
+rather than one sourced file because `testlib/runner_patch.py` writes a patched
+COPY of `run-tests.sh` into a tmp dir that ~15 tests drive, and a copy cannot
+source a sibling `lib/` that was never copied with it (measured: the sourced
+version turned all fifteen into a FATAL):
 
   1. `REPO_POINTER_VARS` — the environment variables that decide WHICH
      repository a git command lands in. Stripping them is the FIX.
@@ -66,13 +72,15 @@ from pathlib import Path
 # --------------------------------------------------------------------------- #
 # 1. THE LEDGER: what redirects git at a repository
 # --------------------------------------------------------------------------- #
-# 🔴 ORDERED and EXACT. `scripts/run-tests.sh` spells the same names in its
-# GUARD 9 `unset` line — it has to, because the non-pytest targets (HOOK_TESTS,
-# SHELL_TESTS) never load a pytest plugin — and
-# `test_git_repo_isolation.py::test_the_shell_and_python_pointer_ledgers_agree`
-# fails if the two sets diverge in EITHER direction. Adding a name here without
-# adding it there would leave five targets unprotected while this file's
-# docstring claimed otherwise.
+# 🔴 ORDERED and EXACT. Each of the three shell runners spells the same names
+# in a `DEVRC_GIT_REPO_POINTERS` array — they have to, because the non-pytest
+# targets (HOOK_TESTS, SHELL_TESTS, the node tier) never load a pytest plugin,
+# and because an inherited GIT_DIR corrupts each runner's ROOT resolution before
+# any Python runs. `test_git_repo_isolation.py::
+# test_the_shell_and_python_pointer_ledgers_agree` is parametrised over all
+# three and fails if any diverges from this tuple in EITHER direction. Adding a
+# name here without adding it there would leave those targets unprotected while
+# this file's docstring claimed otherwise.
 REPO_POINTER_VARS: tuple[str, ...] = (
     "GIT_DIR",                            # the repository itself; beats -C
     "GIT_WORK_TREE",                      # the working tree

--- a/scripts/testlib/gitenv_plugin.py
+++ b/scripts/testlib/gitenv_plugin.py
@@ -10,7 +10,10 @@ Loaded two ways, exactly like `nolaunch_plugin` and `spool_plugin`:
 
 Two layers, and they answer different questions:
 
-  LAYER 1 — SANITISE (prevention). Strips `REPO_POINTER_VARS` from `os.environ`
+  LAYER 1 — SANITISE (prevention), a second time and deliberately so. The
+  shell side already cleared these at the top of whichever runner started this
+  process, before it resolved its ROOT; this repeats it for a BARE `pytest` that never
+  went through a runner. Strips `REPO_POINTER_VARS` from `os.environ`
   at IMPORT time, before pytest collects anything. Import time matters: several
   suites build real git repos at MODULE scope (`test_bash_guard.py::_mkrepo`,
   `test_guard_core.py`'s module-scoped cwd fixtures), which run during

--- a/scripts/testlib/gitenv_plugin.py
+++ b/scripts/testlib/gitenv_plugin.py
@@ -1,0 +1,122 @@
+"""GUARD 9's pytest half: strip the git repo pointers, then WATCH.
+
+Loaded two ways, exactly like `nolaunch_plugin` and `spool_plugin`:
+
+  * `scripts/run-tests.sh` puts `-p testlib.gitenv_plugin` on the ONE pytest
+    line every target goes through, so all seventeen get it rather than the one
+    directory that happens to have a conftest.
+  * `scripts/tests/conftest.py` imports it, so a bare `pytest scripts/tests`
+    outside the runner is protected too — by the same module, not a second copy.
+
+Two layers, and they answer different questions:
+
+  LAYER 1 — SANITISE (prevention). Strips `REPO_POINTER_VARS` from `os.environ`
+  at IMPORT time, before pytest collects anything. Import time matters: several
+  suites build real git repos at MODULE scope (`test_bash_guard.py::_mkrepo`,
+  `test_guard_core.py`'s module-scoped cwd fixtures), which run during
+  collection, and a fixture-scoped strip would land after them.
+
+  LAYER 2 — DETECT (attribution). Fingerprints the protected repositories and
+  compares around collection, around every test, and at session end. Layer 1
+  closes the mechanism we MEASURED; layer 2 is what catches the next one, by
+  any mechanism, and names the test that did it. Neither is sufficient: a strip
+  with no detector is a claim, and a detector with no strip is an incident
+  report.
+
+🔴 The strip runs at import, NOT in `pytest_configure`, and that ordering is
+load-bearing rather than stylistic — see above.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from testlib.gitenv import (  # noqa: F401  (re-exported for tests)
+    PROTECT_ENV,
+    REPO_POINTER_VARS,
+    SESSION_MARKER,
+    VIOLATION_TOKEN,
+    diff_snapshots,
+    global_config_paths,
+    protected_git_dirs,
+    snapshot,
+    strip_repo_pointers,
+    violation_message,
+)
+
+# --- LAYER 1, at import ------------------------------------------------------ #
+STRIPPED: dict[str, str] = strip_repo_pointers()
+
+# --- LAYER 2's state --------------------------------------------------------- #
+_GIT_DIRS = protected_git_dirs()
+_EXTRA = global_config_paths()
+
+
+def _take() -> "dict[str, str]":
+    return snapshot(_GIT_DIRS, _EXTRA)
+
+
+# 🔴 ARMED AT IMPORT, not in `pytest_configure`. `pytest_configure` is an
+# INITIALISATION hook: pytest calls it for plugins given with `-p` and for the
+# rootdir conftest, but NOT for a conftest loaded later during collection. The
+# conftest entry point (`scripts/tests/conftest.py`) is exactly that case, so a
+# baseline taken only in `pytest_configure` would be an empty dict there and the
+# first `_check` would report every protected file as CREATED. Taking it here
+# makes both entry points identical, and `pytest_configure` merely re-arms it
+# and prints the marker.
+_BASELINE: dict[str, str] = _take()
+
+
+def _check(where: str) -> None:
+    """Compare against the baseline and FAIL LOUDLY on any delta.
+
+    The baseline is re-armed after a violation is reported, deliberately: the
+    next test is not responsible for damage this one did, and a guard that
+    re-reports the same delta for every remaining test buries the attribution
+    it exists to provide.
+    """
+    global _BASELINE
+    if not _GIT_DIRS and not _EXTRA:
+        return
+    after = _take()
+    deltas = diff_snapshots(_BASELINE, after)
+    if not deltas:
+        return
+    _BASELINE = after
+    pytest.fail(violation_message(where, deltas, _GIT_DIRS), pytrace=False)
+
+
+def pytest_configure(config):
+    global _BASELINE
+    _BASELINE = _take()
+    # ONE marker line per pytest session. A target that never prints it is a
+    # target this guard never loaded in, and "no marker" is otherwise
+    # indistinguishable from "loaded, saw nothing" — the reassuring zero
+    # claude/RULES.md's positive-control rule is about. It also reports the
+    # PAIR: what was stripped, and how many repos are being watched.
+    stripped = ",".join(sorted(STRIPPED)) or "none"
+    watching = len(_GIT_DIRS)
+    print(f"{SESSION_MARKER} stripped={stripped} protected-git-dirs={watching}")
+
+
+def pytest_collection_finish(session):
+    # Module-scope repo building happens HERE, not inside a test, so a check
+    # that only ran per-test would attribute import-time damage to whichever
+    # test happened to run first — or miss it entirely in a collect-only run.
+    _check("collection (a module-level fixture, at import)")
+
+
+@pytest.fixture(autouse=True)
+def _devrc_git_repo_isolation(request):
+    yield
+    _check(f"test `{request.node.nodeid}`")
+
+
+def pytest_sessionfinish(session, exitstatus):
+    _check("session teardown (after the last test)")
+
+
+def _os_environ_is_clean() -> bool:
+    """Exposed for the controls: nothing re-set a pointer after the strip."""
+    return not any(name in os.environ for name in REPO_POINTER_VARS)

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -42,3 +42,26 @@ from testlib.nolaunch_plugin import STUB_DIR_ENV, no_real_launchers  # noqa: E40
 # calls scattered through this directory stay as defence in depth — they narrow
 # the spool per test, which this session-wide floor deliberately does not.
 from testlib.spool_plugin import no_real_activity_spool  # noqa: E402,F401
+
+# 🔴 The SAME shape a third time, for the repository the suite RUNS FROM
+# (GUARD 9). On 2026-08-21 a gate run rewrote this checkout's `main` with
+# fixture commits, deleted the branch, rewrote `core.hooksPath` and
+# `remote.origin.url`, and pushed fixture refs to the production remote —
+# because `GIT_DIR` overrides the `-C <tmp_path>` every git fixture here
+# already passes. `scripts/run-tests.sh` clears the pointers for EVERY target
+# (pytest and non-pytest alike); this import is the second entry point, so a
+# bare `pytest scripts/tests` gets the same strip plus the per-test detector
+# that names whichever test moved a ref.
+#
+# 🔴 The names are imported INTO THIS CONFTEST'S NAMESPACE, which is what
+# registers them — pytest reads hooks and fixtures off the conftest module
+# object. `pytest_configure` is deliberately NOT among them: it is an
+# initialisation hook and pytest does not call it for a conftest loaded during
+# collection, so importing it would look like coverage while providing none.
+# The plugin arms its baseline at IMPORT for exactly that reason, so this entry
+# point loses nothing but the marker line.
+from testlib.gitenv_plugin import (  # noqa: E402,F401
+    _devrc_git_repo_isolation,
+    pytest_collection_finish,
+    pytest_sessionfinish,
+)

--- a/scripts/tests/test_git_repo_isolation.py
+++ b/scripts/tests/test_git_repo_isolation.py
@@ -1,0 +1,563 @@
+"""GUARD 9 — the suite must not operate on the git repository it RUNS FROM.
+
+🔴 WHAT HAPPENED, 2026-08-21, measured on the operator's real clone and on the
+production GitHub remote. A gate run:
+
+  * rewrote `refs/heads/main` with fixture commits (`seed`, `base`, `ahead`,
+    `local side`, `un-pushed work stranded on main`, `autocommit: N change(s)
+    in the some-scope analyze-service index`),
+  * created the fixture branches `side`, `topic`, `trunk`, `master`,
+    `only-branch`, `feat/behind-too`,
+  * DELETED `refs/heads/main` and repointed `HEAD` at `trunk`,
+  * wrote `core.bare=true`, `user.name=T`, `user.email=t@example.invalid`, a
+    `core.hooksPath` under `pytest-0/test_install_does_not_depend_o0/` and a
+    `remote.origin.url` under `pytest-0/test_fetch_failure_is_rc40/`,
+  * and pushed fixture refs to the real remote.
+
+🔴 AND NOT ONE FIXTURE WAS SLOPPY. Every git fixture in this repo passes
+`-C <tmp_path>/…`; several also pin `HOME`, `GIT_CONFIG_GLOBAL` and
+`GIT_CONFIG_SYSTEM`. `GIT_DIR` overrides `-C`, so one inherited environment
+variable defeats all of them simultaneously — which is why the fix is one
+`unset` and one plugin rather than a patch in fourteen test files. The tmpdir
+paths written into the real config are the tell: the tests computed the RIGHT
+value and git wrote it into the WRONG repository.
+
+HOW THIS FILE IS BUILT, and why each layer is not redundant with the next:
+
+  1. LEDGERS. The variable list is spelled in Python (`testlib/gitenv.py`) and
+     in bash (`scripts/run-tests.sh`, because HOOK_TESTS and SHELL_TESTS never
+     load a pytest plugin). Pinned in BOTH directions — a set that only grows
+     on one side is a guard that protects twelve targets and not five.
+  2. THE DETECTOR, as a unit. Does `snapshot` actually MOVE when a ref moves?
+     Reported as a pair with a no-op control, never as a bare zero.
+  3. 🔴 THE INCIDENT ITSELF, as a nested-pytest control pair. One run WITHOUT
+     the plugin reproduces the damage (a fixture-shaped `git -C <tmp>` writing
+     a branch into the ambient repo); one run WITH it does not. A guard nobody
+     has watched fail proves nothing, and a fix nobody has watched CHANGE the
+     outcome proves nothing either.
+  4. REACHABILITY. The violation is asserted by `VIOLATION_TOKEN` — this
+     guard's own marker — so a control cannot pass because a DIFFERENT check
+     errored first (claude/RULES.md → "prove it REACHABLE, not just breakable").
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+RUN_TESTS = SCRIPTS / "run-tests.sh"
+CONFTEST = SCRIPTS / "tests" / "conftest.py"
+
+sys.path.insert(0, str(SCRIPTS))
+
+from testlib.gitenv import (  # noqa: E402
+    PROTECT_ENV,
+    REPO_POINTER_VARS,
+    VIOLATION_TOKEN,
+    diff_snapshots,
+    protected_git_dirs,
+    resolve_git_dir,
+    snapshot,
+    strip_repo_pointers,
+)
+
+# 🔴 NOT a skipif. `git` is in run-tests.sh's REQUIRED_TOOLS and in the flake's
+# pytests check, so its absence is an ERROR: a skipped isolation test reports a
+# safety property it never measured, which is the exact failure mode that let
+# the incident happen on a green suite.
+if shutil.which("git") is None:  # pragma: no cover - the gate puts git on PATH
+    raise RuntimeError(
+        "git is not on PATH. Add it to REQUIRED_TOOLS in scripts/run-tests.sh "
+        "and to the pytests check in flake.nix rather than skipping these tests."
+    )
+
+_GIT_ENV = {
+    "GIT_CONFIG_SYSTEM": "/dev/null",
+    "GIT_TERMINAL_PROMPT": "0",
+    "GIT_AUTHOR_NAME": "guard nine",
+    "GIT_AUTHOR_EMAIL": "guard9@example.invalid",
+    "GIT_COMMITTER_NAME": "guard nine",
+    "GIT_COMMITTER_EMAIL": "guard9@example.invalid",
+}
+
+
+def _env(**extra) -> dict:
+    e = dict(os.environ)
+    e.update(_GIT_ENV)
+    e.update({k: str(v) for k, v in extra.items()})
+    return e
+
+
+def _git(repo: Path, *args, env=None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, env=env or _env(),
+    )
+
+
+def _mkrepo(path: Path, branch: str = "main") -> Path:
+    """A real, committed repo at `path` — the stand-in for the operator's clone."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", branch, str(path)],
+                   check=True, capture_output=True, env=_env())
+    (path / "f.txt").write_text("base\n", encoding="utf-8")
+    assert _git(path, "add", "f.txt").returncode == 0
+    assert _git(path, "commit", "-qm", "base").returncode == 0
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# 0. harness self-validation
+# --------------------------------------------------------------------------- #
+def test_the_runner_and_the_conftest_exist():
+    """Every ledger assertion below reads these two files. If either moved, the
+    assertions would parse an empty string and pass while measuring nothing."""
+    assert RUN_TESTS.is_file(), f"{RUN_TESTS} missing — the ledger tests are vacuous"
+    assert CONFTEST.is_file(), f"{CONFTEST} missing — the ledger tests are vacuous"
+
+
+# --------------------------------------------------------------------------- #
+# 1. THE LEDGERS — one rule, two spellings, pinned both ways
+# --------------------------------------------------------------------------- #
+def _shell_unset_names() -> list[str]:
+    """The names GUARD 9's `unset` line in run-tests.sh actually clears.
+
+    Joins backslash continuations first: reading only the first physical line
+    would silently measure three names out of eleven and report agreement on a
+    ledger that is two thirds unimplemented.
+    """
+    text = RUN_TESTS.read_text(encoding="utf-8")
+    joined = re.sub(r"\\\n\s*", " ", text)
+    matches = re.findall(r"^\s*unset\s+(GIT_[A-Z_ ]+)$", joined, re.M)
+    assert matches, (
+        "no `unset GIT_…` line found in scripts/run-tests.sh. GUARD 9's shell "
+        "half is what protects the NON-pytest targets (HOOK_TESTS, SHELL_TESTS) "
+        "— they never load a plugin."
+    )
+    names: list[str] = []
+    for m in matches:
+        names.extend(m.split())
+    return names
+
+
+def test_the_shell_and_python_pointer_ledgers_agree():
+    """🔴 BOTH DIRECTIONS. A name in Python and not in bash leaves the five
+    non-pytest targets exposed; a name in bash and not in Python leaves a bare
+    `pytest` exposed. Either way the guard's docstring claims coverage it does
+    not have."""
+    shell = _shell_unset_names()
+    python = list(REPO_POINTER_VARS)
+    assert sorted(shell) == sorted(python), (
+        "GUARD 9's two ledgers disagree.\n"
+        f"  only in run-tests.sh : {sorted(set(shell) - set(python))}\n"
+        f"  only in gitenv.py    : {sorted(set(python) - set(shell))}\n"
+        "Update both, in the same commit."
+    )
+
+
+def test_the_shell_ledger_has_no_duplicates():
+    """A duplicated name reads as a longer list than it is."""
+    shell = _shell_unset_names()
+    assert len(shell) == len(set(shell)), f"duplicate names in the unset line: {shell}"
+
+
+def test_GIT_DIR_is_on_the_ledger():
+    """The one that actually happened. Pinned by name so a future prune of the
+    list cannot quietly drop the variable the incident was made of."""
+    assert "GIT_DIR" in REPO_POINTER_VARS
+    assert "GIT_DIR" in _shell_unset_names()
+
+
+def test_every_pytest_target_gets_the_detector():
+    """`-p testlib.gitenv_plugin` must sit on the ONE pytest line, beside GUARD
+    7's and GUARD 8's. `scripts/run-tests.sh` runs one pytest process per target
+    and there are seventeen of them; a plugin registered from a conftest reaches
+    one directory (that is #399's and #614's measured failure, twice)."""
+    text = re.sub(r"\\\n\s*", " ", RUN_TESTS.read_text(encoding="utf-8"))
+    pytest_lines = [ln for ln in text.splitlines()
+                    if "python -m pytest" in ln and "$d" in ln]
+    assert pytest_lines, "could not find the per-target pytest invocation in run-tests.sh"
+    for ln in pytest_lines:
+        assert "-p testlib.gitenv_plugin" in ln, (
+            "a per-target pytest invocation runs without GUARD 9:\n"
+            f"  {ln.strip()}"
+        )
+
+
+def test_the_scripts_tests_conftest_is_the_second_entry_point():
+    """A bare `pytest scripts/tests` outside the runner must get the same guard
+    — by the same module, not a second copy of the logic.
+
+    🔴 STRUCTURAL, NOT SPELLED. The first version of this test grepped the
+    conftest for the strings `testlib.gitenv_plugin` and
+    `_devrc_git_repo_isolation`, and a mutant that moved the whole import under
+    `if False:` SURVIVED it: both words were still on the page. What pytest acts
+    on is the module OBJECT's attributes, so that is what is asserted — and the
+    objects must be the plugin's own, not same-named look-alikes.
+    """
+    import importlib.util
+
+    from testlib import gitenv_plugin
+
+    spec = importlib.util.spec_from_file_location("_devrc_conftest_probe", CONFTEST)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    for attr in ("_devrc_git_repo_isolation", "pytest_collection_finish",
+                 "pytest_sessionfinish"):
+        got = getattr(module, attr, None)
+        assert got is getattr(gitenv_plugin, attr), (
+            f"scripts/tests/conftest.py does not re-export `{attr}` from "
+            "testlib.gitenv_plugin, so a bare `pytest scripts/tests` runs "
+            f"without that half of GUARD 9 (found: {got!r})"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# 2. NO SHELL SCRIPT MAY HAND A REPO POINTER TO THE RUNNER
+# --------------------------------------------------------------------------- #
+# `githooks/pre-push` did exactly this: `GIT_DIR="$(git rev-parse --git-dir)"`.
+# In bash, assigning to an ALREADY-EXPORTED name keeps it exported, so that line
+# hands this repository's git dir to `tests-on-push.sh` -> `run-tests.sh` ->
+# pytest whenever a caller has GIT_DIR in the environment. A concrete route from
+# `git push` to the incident, and invisible to every test that existed.
+_SHELL_SCRIPTS = ("githooks", "scripts")
+
+
+def _shell_files() -> list[Path]:
+    out: list[Path] = []
+    for rel in _SHELL_SCRIPTS:
+        base = ROOT / rel
+        if not base.is_dir():
+            continue
+        for p in sorted(base.rglob("*")):
+            if not p.is_file():
+                continue
+            if p.suffix == ".sh" or (p.parent.name == "githooks" and p.suffix == ""):
+                out.append(p)
+    return out
+
+
+def test_the_shell_scan_sees_files_at_all():
+    """The positive control for the scan below. A zero from a walker that
+    matched nothing is indistinguishable from a clean repo."""
+    files = _shell_files()
+    assert len(files) >= 10, f"the shell-script walk found only {len(files)} files"
+    assert any(p.name == "pre-push" for p in files), (
+        "githooks/pre-push is not in the scanned set — it is the file this "
+        "check exists for."
+    )
+
+
+def test_no_shell_script_that_can_reach_the_runner_assigns_a_git_repo_pointer():
+    pattern = re.compile(
+        r"^[ \t]*(?:export[ \t]+)?(" + "|".join(REPO_POINTER_VARS) + r")=", re.M)
+    offenders: list[str] = []
+    for path in _shell_files():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for m in pattern.finditer(text):
+            line = text[:m.start()].count("\n") + 1
+            offenders.append(f"{path.relative_to(ROOT)}:{line}: {m.group(1)}=")
+    assert not offenders, (
+        "a shell script assigns to a git repo-pointer variable:\n  "
+        + "\n  ".join(offenders)
+        + "\n\nIn bash an assignment to an already-exported name STAYS exported, "
+          "so this hands a repository to every child process — including the test "
+          "runner, whose fixtures then build themselves inside it. Rename the "
+          "variable (githooks/pre-push uses HOOK_GIT_DIR)."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 3. THE SANITISER, measured
+# --------------------------------------------------------------------------- #
+def test_strip_removes_exactly_the_ledger_and_reports_what_it_removed():
+    env = {name: f"/tmp/whatever/{name}" for name in REPO_POINTER_VARS}
+    env["GIT_CONFIG_GLOBAL"] = "/tmp/keep-me"     # deliberately NOT stripped
+    env["GIT_AUTHOR_NAME"] = "keep me too"
+    # 🔴 NOT spelled "PATH". `testlib/launcher_scan.py` AST-scans this directory
+    # for keys named PATH and pins every site, because a literal PATH drops the
+    # nolaunch stub dir (GUARD 7). This dict never reaches a subprocess, but the
+    # scanner cannot know that, and a new pin entry here would read as a real
+    # PATH clobber to the next person auditing that list.
+    env["UNRELATED_SETTING"] = "kept"
+    removed = strip_repo_pointers(env)
+    assert sorted(removed) == sorted(REPO_POINTER_VARS)
+    assert sorted(env) == ["GIT_AUTHOR_NAME", "GIT_CONFIG_GLOBAL",
+                           "UNRELATED_SETTING"], env
+    # Report the PAIR: what moved, and what deliberately did not.
+    assert removed["GIT_DIR"] == "/tmp/whatever/GIT_DIR"
+
+
+def test_strip_on_a_clean_environment_removes_nothing():
+    """The no-op control. Without it, `removed == {}` above would be
+    indistinguishable from a stripper wired to nothing."""
+    env = {"UNRELATED_SETTING": "kept"}
+    assert strip_repo_pointers(env) == {}
+    assert env == {"UNRELATED_SETTING": "kept"}
+
+
+def test_the_live_environment_is_already_clean_under_this_guard():
+    """This suite is itself running under GUARD 9, so nothing should be left."""
+    still_set = [n for n in REPO_POINTER_VARS if n in os.environ]
+    assert not still_set, (
+        f"{still_set} survived into a guarded pytest session — the strip did not "
+        "run, or something re-set it afterwards."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 4. THE DETECTOR, as a unit — it must MOVE, and it must stay still
+# --------------------------------------------------------------------------- #
+def test_the_detector_observes_nothing_when_nothing_happens(tmp_path):
+    repo = _mkrepo(tmp_path / "repo")
+    git_dir = resolve_git_dir(repo)
+    assert git_dir is not None
+    before = snapshot([git_dir])
+    after = snapshot([git_dir])
+    assert diff_snapshots(before, after) == []
+
+
+@pytest.mark.parametrize("mutation,expect", [
+    (("checkout", "-q", "-b", "topic"), "refs/heads/topic"),
+    (("branch", "-q", "side"), "refs/heads/side"),
+    (("config", "user.name", "T"), "config"),
+    (("config", "core.hooksPath", "/tmp/elsewhere"), "config"),
+    (("remote", "add", "origin", "/tmp/nowhere.git"), "config"),
+])
+def test_the_detector_moves_for_every_damage_class_from_the_incident(
+        tmp_path, mutation, expect):
+    """🔴 REPORTED BESIDE THE NO-OP CONTROL ABOVE. Each row is a shape that was
+    actually found in the operator's clone: a branch create, a HEAD move, a
+    `user.name`, a `core.hooksPath`, a rewritten remote URL."""
+    repo = _mkrepo(tmp_path / "repo")
+    git_dir = resolve_git_dir(repo)
+    before = snapshot([git_dir])
+    assert _git(repo, *mutation).returncode == 0
+    deltas = diff_snapshots(before, snapshot([git_dir]))
+    assert deltas, f"the detector did not see `git {' '.join(mutation)}`"
+    assert any(expect in d for d in deltas), (
+        f"expected a delta naming {expect!r}, got:\n" + "\n".join(deltas))
+
+
+def test_the_detector_sees_a_branch_DELETION(tmp_path):
+    """The incident's worst single act: `refs/heads/main` removed outright.
+    A detector that only hashes files it finds would report SAME for a file that
+    stopped existing (claude/RULES.md → a comparison against an absent operand
+    reports SAME, not MISSING)."""
+    repo = _mkrepo(tmp_path / "repo")
+    git_dir = resolve_git_dir(repo)
+    assert _git(repo, "checkout", "-q", "-b", "other").returncode == 0
+    before = snapshot([git_dir])
+    assert _git(repo, "branch", "-D", "main").returncode == 0
+    deltas = diff_snapshots(before, snapshot([git_dir]))
+    assert any("DELETED" in d and "refs/heads/main" in d for d in deltas), (
+        "a deleted branch was not reported as DELETED:\n" + "\n".join(deltas))
+
+
+def test_the_detector_covers_a_WORKTREE_via_its_common_dir(tmp_path):
+    """A worktree's `.git` is a FILE, and its refs live in the COMMON dir.
+    Fingerprinting only the per-worktree dir would miss every ref and config
+    write — and `claude/RULES.md` makes worktree isolation the standing default
+    for file-modifying agents, so this is the normal case, not the exotic one."""
+    repo = _mkrepo(tmp_path / "repo")
+    wt = tmp_path / "wt"
+    assert _git(repo, "worktree", "add", "-q", "-b", "wt-branch", str(wt)).returncode == 0
+    assert (wt / ".git").is_file(), "expected a worktree .git FILE, not a directory"
+    dirs = protected_git_dirs([wt])
+    assert dirs, "no git dir resolved from inside a worktree"
+    before = snapshot(dirs)
+    assert _git(wt, "branch", "-q", "made-from-the-worktree").returncode == 0
+    deltas = diff_snapshots(before, snapshot(dirs))
+    assert any("made-from-the-worktree" in d for d in deltas), (
+        "a ref created from a worktree was invisible — the common dir is not "
+        "being watched:\n" + "\n".join(deltas))
+
+
+# --------------------------------------------------------------------------- #
+# 5. 🔴 THE INCIDENT, REPRODUCED AND THEN PREVENTED
+# --------------------------------------------------------------------------- #
+# Both halves run a NESTED pytest in a tmp rootdir, so no conftest of this repo
+# is loaded and the only difference between them is the `-p` flag.
+
+_FIXTURE_SHAPED_TEST = '''
+"""A fixture written exactly the way every git fixture in this repo is: the
+repo path is passed with `-C`, built under tmp_path, never a bare `git`."""
+import subprocess
+
+
+def test_a_hygienic_fixture(tmp_path):
+    work = tmp_path / "work"
+    subprocess.run(["git", "init", "-q", "-b", "main", str(work)],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(work), "checkout", "-q", "-b", "topic"],
+                   check=True, capture_output=True)
+'''
+
+_ABSOLUTE_PATH_MUTATOR = '''
+"""Writes to the protected repo by ABSOLUTE PATH, so the environment strip
+cannot prevent it. This is the escape route the strip does NOT close, and
+therefore exactly what the detector has to catch."""
+import os
+import subprocess
+
+
+def test_writes_where_it_should_not():
+    target = os.environ["GUARD9_TARGET_REPO"]
+    subprocess.run(["git", "-C", target, "branch", "-q", "escaped-branch"],
+                   check=True, capture_output=True)
+'''
+
+_INNOCENT_TEST = '''
+def test_touches_nothing():
+    assert 1 + 1 == 2
+'''
+
+_IMPORT_TIME_MUTATOR = '''
+import os
+import subprocess
+
+# At MODULE scope — this runs during COLLECTION, like test_bash_guard.py's
+# _mkrepo and test_guard_core.py's module-scoped repos.
+subprocess.run(["git", "-C", os.environ["GUARD9_TARGET_REPO"],
+                "branch", "-q", "escaped-at-import"],
+               check=True, capture_output=True)
+
+
+def test_placeholder():
+    assert True
+'''
+
+
+def _nested_pytest(tmp_path, body: str, *, plugin: bool, env_extra: dict) -> subprocess.CompletedProcess:
+    rootdir = tmp_path / "nested"
+    rootdir.mkdir(exist_ok=True)
+    (rootdir / "test_nested.py").write_text(body, encoding="utf-8")
+    argv = [sys.executable, "-m", "pytest", str(rootdir / "test_nested.py"),
+            "-q", "-p", "no:cacheprovider"]
+    if plugin:
+        argv += ["-p", "testlib.gitenv_plugin"]
+    env = _env(**env_extra)
+    env["PYTHONPATH"] = str(SCRIPTS) + os.pathsep + env.get("PYTHONPATH", "")
+    return subprocess.run(argv, capture_output=True, text=True, env=env,
+                          cwd=str(rootdir))
+
+
+def test_an_inherited_GIT_DIR_makes_a_hygienic_fixture_write_to_the_ambient_repo(tmp_path):
+    """🔴 THE BUG, REPRODUCED. Without GUARD 9, a fixture that does everything
+    right — `git init <tmp>`, then `git -C <tmp> checkout -b topic` — creates
+    `topic` in whatever repo GIT_DIR names. This is the RED half of the pair; it
+    is what the operator's clone experienced on 2026-08-21.
+
+    If this test ever stops reproducing the damage, the pair below stops being
+    evidence: a fix is only observable against a control that shows the defect.
+    """
+    ambient = _mkrepo(tmp_path / "ambient")
+    proc = _nested_pytest(tmp_path, _FIXTURE_SHAPED_TEST, plugin=False,
+                          env_extra={"GIT_DIR": str(ambient / ".git")})
+    assert proc.returncode == 0, f"the nested run did not even pass:\n{proc.stdout}\n{proc.stderr}"
+    branches = _git(ambient, "branch", "--format=%(refname:short)").stdout.split()
+    assert "topic" in branches, (
+        "the reproduction no longer reproduces — this control is the only thing "
+        "that makes the guarded run below meaningful.\n"
+        f"ambient branches: {branches}"
+    )
+
+
+def test_with_GUARD_9_the_same_fixture_leaves_the_ambient_repo_alone(tmp_path):
+    """🔴 THE GREEN HALF. Identical run, identical env, one extra `-p`."""
+    ambient = _mkrepo(tmp_path / "ambient")
+    proc = _nested_pytest(tmp_path, _FIXTURE_SHAPED_TEST, plugin=True,
+                          env_extra={"GIT_DIR": str(ambient / ".git")})
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    branches = _git(ambient, "branch", "--format=%(refname:short)").stdout.split()
+    assert "topic" not in branches, (
+        f"GUARD 9 did not stop the escape; ambient branches: {branches}\n"
+        f"{proc.stdout}"
+    )
+    assert branches == ["main"], f"the ambient repo moved anyway: {branches}"
+    # 🔴 AND THE FIXTURE'S OWN REPO STILL GOT THE BRANCH. Without this the test
+    # would pass just as well if the strip had merely BROKEN git — "the ambient
+    # repo did not move" is also true when nothing ran at all. The nested test
+    # asserted its own `check=True`, but its tmp repo is gone by now, so the
+    # standing evidence is the nested run's own green plus the marker below.
+    assert "1 passed" in proc.stdout, (
+        f"the fixture did not actually run to completion:\n{proc.stdout}")
+    assert "gitenv(session)" in proc.stdout, (
+        "the guard did not announce itself; this run may not have loaded it at "
+        f"all:\n{proc.stdout}"
+    )
+
+
+def test_the_detector_fails_the_test_that_moved_a_ref(tmp_path):
+    """🔴 REACHABILITY, not merely breakability. The nested test writes by
+    ABSOLUTE PATH, so the environment strip is bypassed and the ONLY thing that
+    can go red is the detector. Asserted by this guard's own token, so a failure
+    from some neighbouring check cannot be scored as a kill."""
+    ambient = _mkrepo(tmp_path / "ambient")
+    proc = _nested_pytest(
+        tmp_path, _ABSOLUTE_PATH_MUTATOR, plugin=True,
+        env_extra={PROTECT_ENV: str(ambient / ".git"),
+                   "GUARD9_TARGET_REPO": str(ambient)})
+    out = proc.stdout + proc.stderr
+    assert proc.returncode != 0, f"the detector stayed green on a real escape:\n{out}"
+    assert VIOLATION_TOKEN in out, (
+        f"the run failed, but not with GUARD 9's message — green for the wrong "
+        f"reason:\n{out}")
+    assert "test_writes_where_it_should_not" in out, (
+        f"the violation did not name the offending test:\n{out}")
+    assert "escaped-branch" in out, (
+        f"the violation did not name the ref that moved:\n{out}")
+
+
+def test_the_detector_is_silent_on_a_test_that_touches_nothing(tmp_path):
+    """The other half of the pair. A detector that reds on everything is a
+    permanently-red gate, which claude/RULES.md rates worse than no gate."""
+    ambient = _mkrepo(tmp_path / "ambient")
+    proc = _nested_pytest(
+        tmp_path, _INNOCENT_TEST, plugin=True,
+        env_extra={PROTECT_ENV: str(ambient / ".git")})
+    out = proc.stdout + proc.stderr
+    assert proc.returncode == 0, f"a harmless test was failed by GUARD 9:\n{out}"
+    assert VIOLATION_TOKEN not in out, out
+    assert "1 passed" in out, out
+
+
+def test_the_detector_catches_damage_done_at_IMPORT_time(tmp_path):
+    """Two suites in this repo build real git repos at MODULE scope, so their
+    git runs during COLLECTION — before any test starts. A per-test-only check
+    would attribute that to an arbitrary test, or to none."""
+    ambient = _mkrepo(tmp_path / "ambient")
+    proc = _nested_pytest(
+        tmp_path, _IMPORT_TIME_MUTATOR, plugin=True,
+        env_extra={PROTECT_ENV: str(ambient / ".git"),
+                   "GUARD9_TARGET_REPO": str(ambient)})
+    out = proc.stdout + proc.stderr
+    assert proc.returncode != 0, f"import-time damage went unnoticed:\n{out}"
+    assert VIOLATION_TOKEN in out, out
+    assert "escaped-at-import" in out, out
+    assert "collection" in out, (
+        f"the violation was not attributed to collection:\n{out}")
+
+
+def test_the_violation_message_names_the_remediation(tmp_path):
+    """A red gate whose message does not say what to do gets clicked through."""
+    ambient = _mkrepo(tmp_path / "ambient")
+    proc = _nested_pytest(
+        tmp_path, _ABSOLUTE_PATH_MUTATOR, plugin=True,
+        env_extra={PROTECT_ENV: str(ambient / ".git"),
+                   "GUARD9_TARGET_REPO": str(ambient)})
+    out = proc.stdout + proc.stderr
+    assert "git reflog" in out, f"no recovery instruction in the failure:\n{out}"
+    assert "GIT_DIR" in out, f"the failure does not name the known mechanism:\n{out}"

--- a/scripts/tests/test_git_repo_isolation.py
+++ b/scripts/tests/test_git_repo_isolation.py
@@ -17,17 +17,19 @@ production GitHub remote. A gate run:
 🔴 AND NOT ONE FIXTURE WAS SLOPPY. Every git fixture in this repo passes
 `-C <tmp_path>/…`; several also pin `HOME`, `GIT_CONFIG_GLOBAL` and
 `GIT_CONFIG_SYSTEM`. `GIT_DIR` overrides `-C`, so one inherited environment
-variable defeats all of them simultaneously — which is why the fix is one
-`unset` and one plugin rather than a patch in fourteen test files. The tmpdir
+variable defeats all of them simultaneously — which is why the fix is an `unset`
+and a plugin rather than a patch in fourteen test files. The tmpdir
 paths written into the real config are the tell: the tests computed the RIGHT
 value and git wrote it into the WRONG repository.
 
 HOW THIS FILE IS BUILT, and why each layer is not redundant with the next:
 
-  1. LEDGERS. The variable list is spelled in Python (`testlib/gitenv.py`) and
-     in bash (`scripts/run-tests.sh`, because HOOK_TESTS and SHELL_TESTS never
-     load a pytest plugin). Pinned in BOTH directions — a set that only grows
-     on one side is a guard that protects twelve targets and not five.
+  1. LEDGERS. The variable list is owned once in Python (`testlib/gitenv.py`)
+     and re-spelled in each of the three shell runners — they need it because
+     HOOK_TESTS, SHELL_TESTS and the node tier never load a pytest plugin, and
+     because an inherited GIT_DIR breaks ROOT resolution before any Python runs.
+     Pinned in BOTH directions for every spelling: a set that only grows on one
+     side is a guard that protects twelve targets and not five.
   2. THE DETECTOR, as a unit. Does `snapshot` actually MOVE when a ref moves?
      Reported as a pair with a no-op control, never as a bare zero.
   3. 🔴 THE INCIDENT ITSELF, as a nested-pytest control pair. One run WITHOUT
@@ -54,6 +56,21 @@ ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS = ROOT / "scripts"
 RUN_TESTS = SCRIPTS / "run-tests.sh"
 CONFTEST = SCRIPTS / "tests" / "conftest.py"
+
+# Every entry point that resolves a ROOT with `git rev-parse --show-toplevel`
+# and then runs tests. All three carry GUARD 9's `unset`, and all three must run
+# it BEFORE that line — see test_every_runner_clears_BEFORE_it_resolves_its_root.
+#
+# 🔴 THREE SPELLINGS RATHER THAN ONE SOURCED FILE, and the reason is measured,
+# not aesthetic: `testlib/runner_patch.py` writes a patched COPY of
+# `run-tests.sh` into a tmp dir and about fifteen tests drive that copy. A copy
+# cannot source a sibling `lib/` that was never copied with it — the first
+# version of this guard did exactly that and turned those fifteen red with
+# `run-tests: FATAL — cannot source lib/git-repo-pointers.sh`. So the SET is
+# owned once, in `testlib/gitenv.py`, and every spelling is pinned to it here.
+RUNNERS = (SCRIPTS / "run-tests.sh",
+           SCRIPTS / "run-node-tests.sh",
+           SCRIPTS / "gate.sh")
 
 sys.path.insert(0, str(SCRIPTS))
 
@@ -116,63 +133,126 @@ def _mkrepo(path: Path, branch: str = "main") -> Path:
 # --------------------------------------------------------------------------- #
 # 0. harness self-validation
 # --------------------------------------------------------------------------- #
-def test_the_runner_and_the_conftest_exist():
-    """Every ledger assertion below reads these two files. If either moved, the
-    assertions would parse an empty string and pass while measuring nothing."""
-    assert RUN_TESTS.is_file(), f"{RUN_TESTS} missing — the ledger tests are vacuous"
-    assert CONFTEST.is_file(), f"{CONFTEST} missing — the ledger tests are vacuous"
+def test_every_file_the_ledgers_read_exists():
+    """Every ledger assertion below reads one of these. If one moved, the
+    assertion would parse an empty string and pass while measuring nothing."""
+    for path in (RUN_TESTS, CONFTEST, *RUNNERS):
+        assert path.is_file(), f"{path} missing — the ledger tests are vacuous"
 
 
 # --------------------------------------------------------------------------- #
-# 1. THE LEDGERS — one rule, two spellings, pinned both ways
+# 1. THE LEDGERS — one owner (gitenv.py), four spellings, pinned both ways
 # --------------------------------------------------------------------------- #
-def _shell_unset_names() -> list[str]:
-    """The names GUARD 9's `unset` line in run-tests.sh actually clears.
+def _shell_unset_names(runner: Path) -> list[str]:
+    """The names `runner`'s GUARD 9 block actually clears.
 
-    Joins backslash continuations first: reading only the first physical line
-    would silently measure three names out of eleven and report agreement on a
-    ledger that is two thirds unimplemented.
+    Read out of the ARRAY LITERAL, comments stripped, and the array is then
+    required to be what the `unset` line expands — so a runner that keeps the
+    array for show and unsets something else cannot pass.
     """
-    text = RUN_TESTS.read_text(encoding="utf-8")
-    joined = re.sub(r"\\\n\s*", " ", text)
-    matches = re.findall(r"^\s*unset\s+(GIT_[A-Z_ ]+)$", joined, re.M)
-    assert matches, (
-        "no `unset GIT_…` line found in scripts/run-tests.sh. GUARD 9's shell "
-        "half is what protects the NON-pytest targets (HOOK_TESTS, SHELL_TESTS) "
-        "— they never load a plugin."
+    text = runner.read_text(encoding="utf-8")
+    m = re.search(r"^DEVRC_GIT_REPO_POINTERS=\(\n(.*?)^\)$", text, re.M | re.S)
+    assert m, (
+        f"no DEVRC_GIT_REPO_POINTERS array in {runner.name}. GUARD 9's shell half "
+        "is what protects the NON-pytest targets (HOOK_TESTS, SHELL_TESTS, the "
+        "node tier) and what keeps ROOT resolvable at all under an inherited "
+        "GIT_DIR."
+    )
+    assert 'unset "${DEVRC_GIT_REPO_POINTERS[@]}"' in text, (
+        f"{runner.name} declares the array but never unsets it. 🔴 A declaration "
+        "is not a code path (claude/RULES.md)."
     )
     names: list[str] = []
-    for m in matches:
-        names.extend(m.split())
+    for line in m.group(1).splitlines():
+        line = line.split("#", 1)[0].strip()
+        if line:
+            names.extend(line.split())
     return names
 
 
-def test_the_shell_and_python_pointer_ledgers_agree():
-    """🔴 BOTH DIRECTIONS. A name in Python and not in bash leaves the five
-    non-pytest targets exposed; a name in bash and not in Python leaves a bare
-    `pytest` exposed. Either way the guard's docstring claims coverage it does
-    not have."""
-    shell = _shell_unset_names()
+@pytest.mark.parametrize("runner", RUNNERS, ids=lambda p: p.name)
+def test_the_shell_and_python_pointer_ledgers_agree(runner):
+    """🔴 BOTH DIRECTIONS, for EVERY runner. A name in Python and not in a
+    runner leaves that runner's non-pytest targets exposed and its ROOT
+    resolvable only by luck; a name in a runner and not in Python leaves a bare
+    `pytest` exposed. Either way the guard claims coverage it does not have."""
+    shell = _shell_unset_names(runner)
     python = list(REPO_POINTER_VARS)
     assert sorted(shell) == sorted(python), (
-        "GUARD 9's two ledgers disagree.\n"
-        f"  only in run-tests.sh : {sorted(set(shell) - set(python))}\n"
+        f"GUARD 9's ledgers disagree between {runner.name} and gitenv.py.\n"
+        f"  only in {runner.name}: {sorted(set(shell) - set(python))}\n"
         f"  only in gitenv.py    : {sorted(set(python) - set(shell))}\n"
-        "Update both, in the same commit."
+        "Update every spelling, in the same commit."
     )
 
 
-def test_the_shell_ledger_has_no_duplicates():
+@pytest.mark.parametrize("runner", RUNNERS, ids=lambda p: p.name)
+def test_the_shell_ledger_has_no_duplicates(runner):
     """A duplicated name reads as a longer list than it is."""
-    shell = _shell_unset_names()
-    assert len(shell) == len(set(shell)), f"duplicate names in the unset line: {shell}"
+    shell = _shell_unset_names(runner)
+    assert len(shell) == len(set(shell)), f"duplicates in {runner.name}: {shell}"
 
 
-def test_GIT_DIR_is_on_the_ledger():
+def test_GIT_DIR_is_on_every_ledger():
     """The one that actually happened. Pinned by name so a future prune of the
     list cannot quietly drop the variable the incident was made of."""
     assert "GIT_DIR" in REPO_POINTER_VARS
-    assert "GIT_DIR" in _shell_unset_names()
+    for runner in RUNNERS:
+        assert "GIT_DIR" in _shell_unset_names(runner), runner.name
+
+
+def _root_line(text: str) -> int:
+    """The line that ASSIGNS ROOT from `rev-parse --show-toplevel`.
+
+    🔴 Comment lines are skipped, and `ROOT=` is required on the line. The first
+    version matched any mention of the phrase and therefore matched GUARD 9's
+    own explanatory COMMENT — which sits above the assignment, so all three
+    runners reported "clears AFTER ROOT" while being correctly ordered. A
+    parser that cannot tell code from prose is measuring the wrong thing.
+    """
+    for i, line in enumerate(text.splitlines(), 1):
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        if "ROOT=" in line and "rev-parse" in line and "--show-toplevel" in line:
+            return i
+    return -1
+
+
+def _clear_line(text: str) -> int:
+    for i, line in enumerate(text.splitlines(), 1):
+        if line.strip() == 'unset "${DEVRC_GIT_REPO_POINTERS[@]}"':
+            return i
+    return -1
+
+
+@pytest.mark.parametrize("runner", RUNNERS, ids=lambda p: p.name)
+def test_every_runner_clears_BEFORE_it_resolves_its_root(runner):
+    """🔴 ORDER, not merely presence — and this is a MEASURED requirement, not a
+    tidiness preference.
+
+    All three runners resolve their root with
+    `git -C "$(dirname "$0")" rev-parse --show-toplevel`. With GIT_DIR set and
+    no GIT_WORK_TREE, git takes the CWD as the top of the work tree, so that
+    returns `<repo>/scripts`; the runner then looks for
+    `<repo>/scripts/scripts/run-tests.sh` and exits 127 having produced NO
+    verdict line. Found by running the gate end-to-end with a poisoned GIT_DIR —
+    the first placement of this guard was *after* the ROOT block and the whole
+    gate died before reaching it.
+
+    Same class as the `unset CDPATH` sitting a few lines under run-tests.sh's
+    ROOT block, and recorded in the same spirit.
+    """
+    text = runner.read_text(encoding="utf-8")
+    clear = _clear_line(text)
+    root = _root_line(text)
+    assert clear > 0, f"{runner.name} has no GUARD 9 `unset` line at all"
+    assert root > 0, f"{runner.name} has no `rev-parse --show-toplevel` line to order against"
+    assert clear < root, (
+        f"{runner.name} clears the git repo pointers at line {clear}, AFTER it "
+        f"resolves ROOT at line {root}. An inherited GIT_DIR then makes ROOT "
+        f"`<repo>/scripts` and the run dies exit 127 with no verdict."
+    )
 
 
 def test_every_pytest_target_gets_the_detector():


### PR DESCRIPTION
## What happened

Measured **2026-08-21**, on the operator's real `~/workspace/devrc` clone **and on the production GitHub remote**. A gate run:

- rewrote `refs/heads/main` with fixture commits — `seed`, `base`, `ahead`, `local side`, `un-pushed work stranded on main`, `autocommit: N change(s) in the some-scope analyze-service index`;
- created the fixture branches `side`, `topic`, `trunk`, `master`, `only-branch`, `feat/behind-too`;
- **DELETED `refs/heads/main`** and repointed `HEAD` at `trunk`;
- wrote `core.bare=true`, `user.name=T`, `user.email=t@example.invalid`, a `core.hooksPath` under `pytest-0/test_install_does_not_depend_o0/` and a `remote.origin.url` under `pytest-0/test_fetch_failure_is_rc40/`;
- and **pushed fixture refs to GitHub**, force-overwriting `main`.

## Root cause

🔴 **Not one fixture was sloppy.** Every git fixture in this repo passes `-C <tmp_path>/…`; several also pin `HOME`, `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM`. **`GIT_DIR` overrides `-C`**, so a single inherited environment variable defeats all of them at once. Reproduced exactly on a throwaway clone:

```
export GIT_DIR=<clone>/.git
git -C <tmp>/work checkout -b topic   ->  creates `topic` in <clone>
git -C <tmp>/work branch  -D  main    ->  DELETES <clone>'s main
git -C <tmp>/work config user.name T  ->  writes <clone>/.git/config
```

The damage itself is what identifies the mechanism rather than merely being consistent with it: the tmpdir paths written into the real `.git/config` are the tests' **own correct values**. They computed the right thing and git wrote it into the wrong repository.

Every fixture builds its subprocess environment as `dict(os.environ)` plus a few overrides, so any repo pointer in the caller's environment passes straight through and wins over `-C`. The repo already knew the rule — `scripts/claude-hooks/guard_core.py` judges a `GIT_DIR=` prefix *in addition* to a resolving `-C`, "even though `GIT_DIR` OVERRIDES the working directory". It lived in the hook that polices the operator's commands and nowhere in the harness that runs 14,000 of our own.

## The fix — GUARD 9, two layers

**PREVENTION.** `scripts/testlib/gitenv.py::REPO_POINTER_VARS` owns the eleven variables that decide *which* repository a git command lands in. Each of `run-tests.sh`, `run-node-tests.sh` and `gate.sh` unsets them at the **top** of the file, and `testlib/gitenv_plugin.py` strips them from `os.environ` at **import** — so every fixture that copies `os.environ` inherits the sanitised mapping without knowing this module exists, and the five non-pytest targets (HOOK_TESTS, SHELL_TESTS) plus the node tier are covered by the shell half.

**DETECTION.** The plugin fingerprints the host repository's `refs/`, `HEAD`, `packed-refs`, `ORIG_HEAD`, `logs/HEAD` and `config` (plus the user-level git config, and a worktree's *common* dir) and compares around collection, around **every test**, and at session end — failing the test that moved something, with the ref named. Prevention closes the mechanism we measured; detection is what catches the next one, by any mechanism, and names the culprit. Neither alone is enough: a strip with no detector is a claim, and a detector with no strip is an incident report.

`githooks/pre-push` assigned to the literal name `GIT_DIR`. In bash, assigning to an already-exported name **stays exported**, so that line is a concrete route from `git push` to a poisoned suite (`pre-push` → `tests-on-push.sh` → `run-tests.sh` → pytest). Renamed to `HOOK_GIT_DIR`, and a scan now asserts no shell script that can reach the runner assigns to one of those names.

### Two design decisions that were measured, not chosen

1. **The clear must precede each runner's `ROOT=` line.** All three resolve their root with `git -C "$(dirname "$0")" rev-parse --show-toplevel`; with `GIT_DIR` set and no `GIT_WORK_TREE`, git takes the CWD as the work tree, so that returns `<repo>/scripts` and the runner hunts for `<repo>/scripts/scripts/run-tests.sh` — `exit 127`, **no verdict line**. The first placement was beside GUARDS 7/8, two thirds down `run-tests.sh`, and the gate never got there. Same class as the `unset CDPATH` already documented a few lines below that ROOT block. The ordering is now pinned per runner.
2. **The `unset` is spelled three times rather than sourced from one file.** The DRY version put it in `scripts/lib/git-repo-pointers.sh` — and turned **fifteen tests red** with `run-tests: FATAL — cannot source lib/git-repo-pointers.sh`, because `testlib/runner_patch.py` writes a patched **copy** of `run-tests.sh` into a tmp dir and a copy cannot source a sibling `lib/` that was never copied with it. A guard that FATALs in every copy is a permanently-red gate. So the **set** is owned once, in Python, and all four spellings are pinned to it in both directions — the same treatment `SPOOL_SESSION_MARKER` gets, for the same cross-process reason. A copied runner now carries its own guard, which the sourced version never did.

## Before / after — same two test files, same poisoned `GIT_DIR`, throwaway clone

| | `origin/main` (3116225d) | this branch |
|---|---|---|
| result | **165 passed, 230 ERRORS** | **395 passed, 0 errors** |
| `refs/heads/main` | advanced to a fixture commit `base` | **byte-identical** |
| `git config --local --list` | gained `commit.gpgsign=false`; `user.name`/`user.email` overwritten with `Test Runner` / `test@example.invalid` | **byte-identical** |
| branch list / `HEAD` | — | **byte-identical** |

An earlier run of the same shape (stopped at the first failure) put `local side`, `ahead`, `base` and `commit the workbench never pushed` onto `main` and rewrote `refs/remotes/origin/main` — i.e. the reported evidence, character for character.

## Mutation-verified 12/12

Each mutant killed by its **own named assertion**, not by a neighbour's error; an in-batch positive control (strip `VIOLATION_TOKEN` from the message) is included, and the sweep ran under `PYTHONDONTWRITEBYTECODE=1` with the control green before and after.

| mutant | killed by |
|---|---|
| strip disabled | `…_leaves_the_ambient_repo_alone` — *ambient branches: ['main', 'topic']* |
| per-test check removed | `…_fails_the_test_that_moved_a_ref` |
| collection check removed | `…_catches_damage_done_at_IMPORT_time` |
| worktree common dir ignored | `…_covers_a_WORKTREE_via_its_common_dir` |
| deletions invisible | `…_sees_a_branch_DELETION` |
| `pre-push` reverts to `GIT_DIR=` | `…_assigns_a_git_repo_pointer` |
| runner drops `-p testlib.gitenv_plugin` | `…_every_pytest_target_gets_the_detector` |
| shell ledger loses one name | `…_pointer_ledgers_agree` |
| gate.sh clears **after** ROOT (reordered) | `…_clears_BEFORE_it_resolves_its_root[gate.sh]` |
| node runner drops the guard | `…_clears_BEFORE_it_resolves_its_root[run-node-tests.sh]` |
| conftest entry point removed | `…_is_the_second_entry_point` |
| **positive control:** token dropped | `…_fails_the_test_that_moved_a_ref` (*"failed, but not with GUARD 9's message"*) |

Two guards were rewritten after a mutant SURVIVED them:

- the conftest check grepped for the strings `testlib.gitenv_plugin` and `_devrc_git_repo_isolation`; a mutant that moved the import under `if False:` survived — both words were still on the page. It now asserts the **module object's attributes are the plugin's own objects**. (RULES: *a guard can be SPELLED rather than STRUCTURAL*.)
- the ordering test's parser matched any mention of `rev-parse --show-toplevel` and so matched GUARD 9's own explanatory **comment**, reporting all three runners mis-ordered while they were correct. It now skips comments and requires `ROOT=` on the line.

## Gate

```
env GIT_DIR=<tree>/.git nix develop . --command bash scripts/gate.sh --tier both --set hermetic
```

Run with a **poisoned `GIT_DIR` deliberately exported** — the end-to-end negative control, on the rebased tree (`29d7913e` + these two commits):

```
pytest: TOTAL collected=14401  passed=14399  skipped=2  failed=0   (floor 13324)
        every one of the 31 targets PASS
node:   TOTAL suites=4 files=33 tests=1119 pass=1119 fail=0        (floor 1098)
GATE: RESULT=FAIL exit=1
```

…and afterwards the tree's `HEAD`, branch list, `git show-ref` and `git config --local --list` were **byte-identical to the pre-run baseline**.

🔴 **The `FAIL` is not a test failure and is not from this branch.** `failed=0` everywhere; the gate is red on GUARD 6's unpinned-skip accounting, for a skip that arrives with #657:

```
scripts/signal/tests/test_pg_type_compat.py:91: needs a real Postgres (SIGNAL_PG_DSN);
  SQLite cannot reproduce Postgres static type checking
```

Measured on a clean detached checkout of `github/main` @ **29d7913e**, untouched by this branch: that skip is emitted (`624 passed, 1 skipped`) and `EXPECTED_SKIPS` contains only the `repo-cos` entry. `EXPECTED_SKIPS` is an exact set, so **`main` is currently red on that guard on its own** — the same shape the comment under `EXPECTED_SKIPS` records happening before (#332, red for two days). It needs a one-entry pin, in its own PR; it is deliberately not bundled here.

## Scope this does NOT cover

- The **detector** watches the repository the suite runs from and the user-level git config. A test that writes to some *other* repo by absolute path is caught only if that repo is one of those.
- The **strip** cannot stop a test that names a repo by absolute path; that is the detector's job, and the reachability control drives exactly that case.
- `TARGET_FLOORS` is untouched — the 60 added tests keep every target above its floor (`scripts/tests` 6887 vs floor 6459).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
