### PR TITLE
fix(handoff_doc): a BLOCKED commit left the doc written and STAGED — roll it back

### DIFF
--- a/scripts/lib/handoff_doc.py
+++ b/scripts/lib/handoff_doc.py
@@ -968,6 +968,15 @@ def not_pushed_report(repo: Path, remote: str, branch: str | None) -> str:
     return f"{NOT_PUSHED_HEADLINE}\n{why}\n{topic}\n{NOT_PUSHED_RETRY_NOTE}"
 
 
+COMMIT_LANDED_NOTE = (
+    "\n🔴 THE COMMIT LANDED — a later step failed, so nothing was rolled back "
+    "(rolling back here would DISCARD a committed change). This is the one "
+    "`status=failed` that does NOT mean 'nothing happened': the commit exists "
+    "locally and is un-pushed. Find it with `git log -1` and push it or open a "
+    "PR; do not re-run this tool, which would append the update a second time."
+)
+
+
 def _undo_write(
     repo: Path, doc: Path, relpath: str, original: bytes | None
 ) -> str:
@@ -989,12 +998,12 @@ def _undo_write(
         # clean, because a staged path is the half that another session's
         # `git commit` picks up.
         git(repo, "restore", "--staged", "--", relpath)
-    except GitError:
+    except (GitError, OSError):
         # `git restore` predates nothing we support, but a very old git or a
         # path git no longer knows about can still refuse.
         try:
             git(repo, "reset", "--quiet", "HEAD", "--", relpath)
-        except GitError:
+        except (GitError, OSError):
             left.append(f"still STAGED: {relpath}")
     try:
         if original is None:
@@ -1004,18 +1013,40 @@ def _undo_write(
     except OSError:
         left.append(f"still MODIFIED: {relpath}")
     if left:
+        # 🔴 DO NOT name `restore --source=HEAD --worktree` here. It is wrong in
+        # BOTH shapes this can print for: if the doc had UNCOMMITTED local edits
+        # — exactly what `original` exists to preserve — it discards them; and if
+        # the doc did not exist at HEAD (a first-ever handoff) it fails outright
+        # (`pathspec … did not match any file(s) known to git`). Advice printed
+        # on an already-degraded path must not be the thing that loses the work.
+        index_fix = f"    git -C {repo} restore --staged -- {relpath}"
+        worktree_fix = (
+            f"    # the doc did not exist before this run — delete it:\n"
+            f"    rm -f -- {doc}"
+            if original is None
+            else
+            "    # its previous CONTENT was never committed, so no git command "
+            "can\n    # recover it — the bytes are only in this process. Restore "
+            "by hand."
+        )
         return (
             "\n🔴 ROLLBACK INCOMPLETE — the commit did not happen, but this tree "
             "was left changed: " + "; ".join(left) + "\n"
-            "  Restore it before doing anything else; in a shared checkout a "
-            "staged path is one `git commit` away from being swept into "
-            "someone else's commit:\n"
-            f"    git -C {repo} restore --source=HEAD --staged --worktree -- {relpath}"
+            "  Fix it before doing anything else; in a shared checkout a staged "
+            "path is one `git commit` away from being swept into someone else's "
+            "commit.\n"
+            f"{index_fix}\n{worktree_fix}"
         )
+    # 🔴 Deliberately NOT "byte-identical": two measured exceptions. If the doc
+    # was STAGED-modified before the run, `restore --staged` resets its index
+    # entry to HEAD rather than to that staged content; and a `claudedocs/`
+    # directory this run created is not removed. Both are harmless, and neither
+    # is what the sentence would be claiming. A comment is a claim — say the
+    # thing that is true, which is the thing the caller actually needs.
     return (
-        "\n(no trace left: the doc was restored and unstaged, so this tree is "
-        "byte-identical to before the run — re-running is safe and will not "
-        "append the update twice.)"
+        "\n(rolled back: the doc was restored and unstaged, so nothing from this "
+        "run is left staged or written — re-running is safe and will not append "
+        "the update twice.)"
     )
 
 
@@ -1380,7 +1411,10 @@ def main(argv: list[str] | None = None) -> int:
         # Only roll back what did NOT happen. If the commit landed and only
         # `rev-parse` failed, the tree is already correct and restoring the file
         # would DISCARD a committed change — the opposite of the fix.
-        note = "" if committed else _undo_write(repo, doc, relpath, original)
+        note = (
+            COMMIT_LANDED_NOTE if committed
+            else _undo_write(repo, doc, relpath, original)
+        )
         print(f"status=failed\n{exc}{note}", file=sys.stderr)
         return EXIT_FAIL
 

--- a/scripts/lib/handoff_doc.py
+++ b/scripts/lib/handoff_doc.py
@@ -1013,29 +1013,38 @@ def _undo_write(
     except OSError:
         left.append(f"still MODIFIED: {relpath}")
     if left:
-        # 🔴 DO NOT name `restore --source=HEAD --worktree` here. It is wrong in
-        # BOTH shapes this can print for: if the doc had UNCOMMITTED local edits
-        # — exactly what `original` exists to preserve — it discards them; and if
-        # the doc did not exist at HEAD (a first-ever handoff) it fails outright
-        # (`pathspec … did not match any file(s) known to git`). Advice printed
-        # on an already-degraded path must not be the thing that loses the work.
-        index_fix = f"    git -C {repo} restore --staged -- {relpath}"
-        worktree_fix = (
-            f"    # the doc did not exist before this run — delete it:\n"
-            f"    rm -f -- {doc}"
-            if original is None
-            else
-            "    # its previous CONTENT was never committed, so no git command "
-            "can\n    # recover it — the bytes are only in this process. Restore "
-            "by hand."
-        )
+        # 🔴 EMIT ADVICE ONLY FOR THE HALF THAT ACTUALLY FAILED. The two halves
+        # fail independently, and printing both was measured to produce a message
+        # that CONTRADICTS what happened: with only the index half failing, it
+        # told the operator their content "was never committed … restore by hand"
+        # while the bytes had in fact been restored and the content WAS in HEAD.
+        # An operator who believes that hand-rewrites a doc they still have.
+        #
+        # 🔴 And do not name `restore --source=HEAD --worktree` in the worktree
+        # arm: it discards UNCOMMITTED local edits — exactly what `original`
+        # exists to preserve — and fails outright when the doc did not exist at
+        # HEAD. Advice printed on an already-degraded path must not be the thing
+        # that loses the work.
+        fixes: list[str] = []
+        if any(s.startswith("still STAGED") for s in left):
+            fixes.append(f"    git -C {repo} restore --staged -- {relpath}")
+        if any(s.startswith("still MODIFIED") for s in left):
+            fixes.append(
+                f"    # the doc did not exist before this run — delete it:\n"
+                f"    rm -f -- {doc}"
+                if original is None
+                else
+                "    # its previous content is the bytes this process read, and "
+                "they are\n    # not necessarily in git — check `git status` "
+                "first, and only use\n    # `git restore -- <path>` if the doc "
+                "was clean at HEAD before the run."
+            )
         return (
             "\n🔴 ROLLBACK INCOMPLETE — the commit did not happen, but this tree "
             "was left changed: " + "; ".join(left) + "\n"
             "  Fix it before doing anything else; in a shared checkout a staged "
             "path is one `git commit` away from being swept into someone else's "
-            "commit.\n"
-            f"{index_fix}\n{worktree_fix}"
+            "commit.\n" + "\n".join(fixes)
         )
     # 🔴 Deliberately NOT "byte-identical": two measured exceptions. If the doc
     # was STAGED-modified before the run, `restore --staged` resets its index

--- a/scripts/lib/handoff_doc.py
+++ b/scripts/lib/handoff_doc.py
@@ -1027,6 +1027,13 @@ def _undo_write(
         # that loses the work.
         fixes: list[str] = []
         if any(s.startswith("still STAGED") for s in left):
+            # 🔴 CONTRACT: the index arm is ONE bare command line, no comment
+            # lines. The worktree arm is comment lines in every wording it has
+            # had, so "no comment lines present" is how the test proves the
+            # worktree half was NOT advised — a check that survives rewording
+            # AND reindenting. Adding a comment here will fail that test; that
+            # is deliberate (a loud false failure beats a silent false pass),
+            # so move any explanation into the message body above instead.
             fixes.append(f"    git -C {repo} restore --staged -- {relpath}")
         if any(s.startswith("still MODIFIED") for s in left):
             fixes.append(
@@ -1035,9 +1042,10 @@ def _undo_write(
                 if original is None
                 else
                 "    # its previous content is the bytes this process read, and "
-                "they are\n    # not necessarily in git — check `git status` "
-                "first, and only use\n    # `git restore -- <path>` if the doc "
-                "was clean at HEAD before the run."
+                "they are\n    # not necessarily in git. Run the unstage line "
+                "above FIRST — until you do,\n    # the index still holds THIS "
+                "run's merged text, so `git restore -- <path>`\n    # would "
+                "restore that and look like it worked. Only after unstaging,\n"                "    # and only if the doc was clean at HEAD, is it safe."
             )
         return (
             "\n🔴 ROLLBACK INCOMPLETE — the commit did not happen, but this tree "

--- a/scripts/lib/handoff_doc.py
+++ b/scripts/lib/handoff_doc.py
@@ -968,6 +968,57 @@ def not_pushed_report(repo: Path, remote: str, branch: str | None) -> str:
     return f"{NOT_PUSHED_HEADLINE}\n{why}\n{topic}\n{NOT_PUSHED_RETRY_NOTE}"
 
 
+def _undo_write(
+    repo: Path, doc: Path, relpath: str, original: bytes | None
+) -> str:
+    """Undo the doc write + `git add` after a commit that never happened.
+
+    🔴 PATH-LIMITED, exactly like the commit it is undoing. A blanket
+    `git reset` would unstage a co-worker's staged files as a side effect of OUR
+    failure — trading one shared-checkout defect for a worse one. `git restore
+    --staged -- <path>` touches only the index entry for that path.
+
+    Best-effort and non-raising: this runs on an error path, and a rollback that
+    threw would replace the caller's real diagnosis with its own. Whatever it
+    could not undo is RETURNED as text so the caller prints it — silence here
+    would be the same defect one level down.
+    """
+    left: list[str] = []
+    try:
+        # Unstage first: if restoring the bytes fails we still want the index
+        # clean, because a staged path is the half that another session's
+        # `git commit` picks up.
+        git(repo, "restore", "--staged", "--", relpath)
+    except GitError:
+        # `git restore` predates nothing we support, but a very old git or a
+        # path git no longer knows about can still refuse.
+        try:
+            git(repo, "reset", "--quiet", "HEAD", "--", relpath)
+        except GitError:
+            left.append(f"still STAGED: {relpath}")
+    try:
+        if original is None:
+            doc.unlink(missing_ok=True)
+        else:
+            doc.write_bytes(original)
+    except OSError:
+        left.append(f"still MODIFIED: {relpath}")
+    if left:
+        return (
+            "\n🔴 ROLLBACK INCOMPLETE — the commit did not happen, but this tree "
+            "was left changed: " + "; ".join(left) + "\n"
+            "  Restore it before doing anything else; in a shared checkout a "
+            "staged path is one `git commit` away from being swept into "
+            "someone else's commit:\n"
+            f"    git -C {repo} restore --source=HEAD --staged --worktree -- {relpath}"
+        )
+    return (
+        "\n(no trace left: the doc was restored and unstaged, so this tree is "
+        "byte-identical to before the run — re-running is safe and will not "
+        "append the update twice.)"
+    )
+
+
 def uncommitted_paths(repo: Path) -> list[str]:
     """Paths with uncommitted changes in `repo`'s working tree, staged or not.
 
@@ -1305,6 +1356,16 @@ def main(argv: list[str] | None = None) -> int:
             )
             return EXIT_BEHIND
 
+    # 🔴 A BLOCKED COMMIT IS NOT A NO-OP — capture enough to undo the write.
+    # MEASURED 2026-08-21: a PreToolUse hook enforcing "never commit in the
+    # primary clone" refused the commit below — correct behaviour — but the doc
+    # had already been written AND `git add`ed, so `status=failed` left a
+    # modified, STAGED file in a checkout shared with other sessions, where the
+    # next person's `git commit` sweeps it in. The caller then re-ran the tool to
+    # read the error and the merge appended the same block a SECOND time.
+    # `status=failed` reads as "nothing happened"; it must therefore BE that.
+    original: bytes | None = doc.read_bytes() if doc.exists() else None
+    committed = False
     try:
         doc.parent.mkdir(parents=True, exist_ok=True)
         doc.write_text(merged_text, encoding="utf-8")
@@ -1313,9 +1374,14 @@ def main(argv: list[str] | None = None) -> int:
         # Path-limited on purpose: exactly one commit, carrying exactly the
         # diff that was shown, even if the caller had other work staged.
         git(repo, "commit", "-m", subject, "--", relpath)
+        committed = True
         sha = git(repo, "rev-parse", "HEAD").strip()
     except (GitError, OSError) as exc:
-        print(f"status=failed\n{exc}", file=sys.stderr)
+        # Only roll back what did NOT happen. If the commit landed and only
+        # `rev-parse` failed, the tree is already correct and restoring the file
+        # would DISCARD a committed change — the opposite of the fix.
+        note = "" if committed else _undo_write(repo, doc, relpath, original)
+        print(f"status=failed\n{exc}{note}", file=sys.stderr)
         return EXIT_FAIL
 
     if args.push:

--- a/scripts/tests/test_handoff_doc.py
+++ b/scripts/tests/test_handoff_doc.py
@@ -2271,11 +2271,14 @@ class TestBlockedCommitLeavesNoTrace:
         # `git()` invokes ["git", "-C", <repo>, *args] — the SUBCOMMAND is $3,
         # not $1. Scan all args instead of indexing, which is what the earlier
         # broken shim got wrong.
+        fired = shim / "intercepted.marker"
         write_exec(
             shim / "git",
             f'for a in "$@"; do [ "$a" = "commit" ] && : > "{marker}"; done\n'
             f'for a in "$@"; do\n'
-            f'  if [ "$a" = "rev-parse" ] && [ -f "{marker}" ]; then exit 7; fi\n'
+            f'  if [ "$a" = "rev-parse" ] && [ -f "{marker}" ]; then\n'
+            f'    : > "{fired}"; exit 7\n'
+            f'  fi\n'
             f'done\n'
             f'exec {real_git} "$@"\n',
         )
@@ -2283,13 +2286,23 @@ class TestBlockedCommitLeavesNoTrace:
         env = dict(os.environ, **GIT_ENV)
         env["PATH"] = f"{shim}:{env['PATH']}"
 
-        subprocess.run(
+        res = subprocess.run(
             [sys.executable, str(TOOL), "--repo", str(repo), "--topic",
              "sample-topic", "--update", str(update_file), "--advanced",
              "a landed commit must survive a later failure", "--confirm"],
             capture_output=True, text=True, env=env,
         )
 
+        # 🔴 POSITIVE CONTROL. Without these two the test passes with an INERT
+        # shim — measured: reverting the shim to its known-broken form left this
+        # green. `doc_of == head_doc` is ALSO true on the plain success path, so
+        # it cannot on its own prove the failure branch ran.
+        assert fired.exists(), (
+            "the git shim never intercepted rev-parse — this test proved nothing"
+        )
+        assert res.returncode == 3, (
+            f"expected EXIT_FAIL (the later step failed), got {res.returncode}"
+        )
         assert commit_shas(repo) != shas_before, (
             "fixture inert: no commit was made, so the guard was never exercised"
         )
@@ -2348,9 +2361,10 @@ class TestBlockedCommitLeavesNoTrace:
         # 🔴 `git()` invokes ["git", "-C", <repo>, *args], so the subcommand is
         # $3 — an earlier version tested $1, never intercepted anything, and the
         # fallback arm was never exercised (the mutant survived). Scan all args.
+        fired = shim / "intercepted.marker"
         write_exec(shim / "git",
                    f'for a in "$@"; do\n'
-                   f'  [ "$a" = "restore" ] && exit 129\n'
+                   f'  if [ "$a" = "restore" ]; then : > "{fired}"; exit 129; fi\n'
                    f'done\n'
                    f'exec {real_git} "$@"\n')
         (repo / "OTHER.md").write_text("someone else's staged work\n", encoding="utf-8")
@@ -2359,14 +2373,114 @@ class TestBlockedCommitLeavesNoTrace:
 
         env = dict(os.environ, **GIT_ENV)
         env["PATH"] = f"{shim}:{env['PATH']}"
-        subprocess.run(
+        res = subprocess.run(
             [sys.executable, str(TOOL), "--repo", str(repo), "--topic",
              "sample-topic", "--update", str(update_file), "--advanced",
              "forcing the reset fallback", "--confirm"],
             capture_output=True, text=True, env=env,
         )
 
+        # 🔴 POSITIVE CONTROL — see the sibling above. An inert shim means the
+        # PRIMARY `restore` arm succeeded and the fallback never ran, so the
+        # path-limit this test exists to prove was never exercised. Measured:
+        # with a broken shim AND a blanket-reset mutant, this stayed green.
+        assert fired.exists(), (
+            "the git shim never intercepted `restore` — the fallback arm did not "
+            "run, so this test proved nothing"
+        )
+        assert res.returncode == 3, (
+            f"expected EXIT_FAIL, got {res.returncode}"
+        )
+
         staged = _sh("git", "diff", "--cached", "--name-only", cwd=repo).split()
         assert staged == ["OTHER.md"], (
             f"the reset fallback must be path-limited too; staged={staged}"
         )
+
+    def test_incomplete_rollback_advises_ONLY_the_half_that_failed(
+        self, repo: Path, update_file: Path
+    ) -> None:
+        """🔴 A message that contradicts what happened is worse than none.
+
+        The index and worktree halves fail INDEPENDENTLY. Printing advice for
+        both was measured to tell an operator their content "was never committed
+        … restore by hand" while the bytes HAD been restored and the content WAS
+        in HEAD — advice that makes someone hand-rewrite a doc they still have.
+        Here the index half fails and the worktree half succeeds."""
+        real_git = shutil.which("git")
+        assert real_git, "git not on PATH"
+        shim = repo / "gitshim-index"
+        shim.mkdir()
+        fired = shim / "intercepted.marker"
+        write_exec(shim / "git",
+                   f'for a in "$@"; do\n'
+                   f'  case "$a" in restore|reset) : > "{fired}"; exit 129 ;; esac\n'
+                   f'done\n'
+                   f'exec {real_git} "$@"\n')
+        before = doc_of(repo)
+        self._block_commits(repo)
+        env = dict(os.environ, **GIT_ENV)
+        env["PATH"] = f"{shim}:{env['PATH']}"
+
+        res = subprocess.run(
+            [sys.executable, str(TOOL), "--repo", str(repo), "--topic",
+             "sample-topic", "--update", str(update_file), "--advanced",
+             "only the index half fails", "--confirm"],
+            capture_output=True, text=True, env=env,
+        )
+
+        assert fired.exists(), "the shim never intercepted — test proved nothing"
+        assert res.returncode == 3
+        assert "still STAGED" in res.stderr, res.stderr
+        # The worktree half SUCCEEDED, so nothing may claim otherwise.
+        assert "still MODIFIED" not in res.stderr, res.stderr
+        # 🔴 COUNT the advice lines, do not grep for a PHRASE. An earlier
+        # version asserted the absence of the new wording — so reverting the
+        # message to its old, false text satisfied it vacuously (measured: that
+        # mutant SURVIVED). One half failed, so exactly one fix line may appear.
+        block = res.stderr.split("ROLLBACK INCOMPLETE", 1)[1]
+        fix_lines = [ln for ln in block.splitlines() if ln.startswith("    ")]
+        assert len(fix_lines) == 1, (
+            f"expected exactly ONE fix line (only the index half failed), got "
+            f"{len(fix_lines)}:\n" + "\n".join(fix_lines)
+        )
+        assert "restore --staged" in fix_lines[0], fix_lines[0]
+        assert doc_of(repo) == before, "the worktree half did not actually restore"
+
+    def test_a_landed_commit_says_so_instead_of_a_bare_status_failed(
+        self, repo: Path, update_file: Path
+    ) -> None:
+        """`status=failed` now contracts to "nothing happened" — so the ONE
+        branch where a commit DOES exist must say so, or the contract lies."""
+        real_git = shutil.which("git")
+        assert real_git, "git not on PATH"
+        shim = repo / "gitshim-note"
+        shim.mkdir()
+        marker = shim / "committed.marker"
+        fired = shim / "intercepted.marker"
+        write_exec(
+            shim / "git",
+            f'for a in "$@"; do [ "$a" = "commit" ] && : > "{marker}"; done\n'
+            f'for a in "$@"; do\n'
+            f'  if [ "$a" = "rev-parse" ] && [ -f "{marker}" ]; then\n'
+            f'    : > "{fired}"; exit 7\n'
+            f'  fi\n'
+            f'done\n'
+            f'exec {real_git} "$@"\n',
+        )
+        env = dict(os.environ, **GIT_ENV)
+        env["PATH"] = f"{shim}:{env['PATH']}"
+
+        res = subprocess.run(
+            [sys.executable, str(TOOL), "--repo", str(repo), "--topic",
+             "sample-topic", "--update", str(update_file), "--advanced",
+             "the commit landed", "--confirm"],
+            capture_output=True, text=True, env=env,
+        )
+
+        assert fired.exists(), "the shim never intercepted — test proved nothing"
+        assert res.returncode == 3
+        assert "THE COMMIT LANDED" in res.stderr, (
+            "a commit exists but status=failed said nothing about it:\n" + res.stderr
+        )
+        assert "un-pushed" in res.stderr, res.stderr

--- a/scripts/tests/test_handoff_doc.py
+++ b/scripts/tests/test_handoff_doc.py
@@ -2445,6 +2445,21 @@ class TestBlockedCommitLeavesNoTrace:
             f"{len(fix_lines)}:\n" + "\n".join(fix_lines)
         )
         assert "restore --staged" in fix_lines[0], fix_lines[0]
+        # 🔴 Indent-INDEPENDENT complement. The count above pins how many lines
+        # are indented, which a reword can walk in one direction (emit the
+        # worktree advice at a different indent) and break in the other (add an
+        # explanatory comment to the index arm). The worktree arm is comment
+        # lines in BOTH its old and new wording, so their absence is the claim
+        # that survives rewording AND reindenting.
+        # 🔴 The trade, stated: this ALSO fires if the index arm ever gains a
+        # comment line — a false FAILURE on a legitimate reword. That direction
+        # is chosen deliberately over a false PASS, and the invariant it depends
+        # on ("the index arm is one bare command line") is pinned as a contract
+        # beside that line in handoff_doc.py.
+        assert not any(ln.lstrip().startswith("#") for ln in block.splitlines()), (
+            "worktree advice (comment lines) printed although that half "
+            "succeeded:\n" + block
+        )
         assert doc_of(repo) == before, "the worktree half did not actually restore"
 
     def test_a_landed_commit_says_so_instead_of_a_bare_status_failed(
@@ -2484,3 +2499,34 @@ class TestBlockedCommitLeavesNoTrace:
             "a commit exists but status=failed said nothing about it:\n" + res.stderr
         )
         assert "un-pushed" in res.stderr, res.stderr
+
+    def test_worktree_only_failure_does_NOT_print_index_advice(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The MIRROR of the only-the-failed-half test, and it was unpinned.
+
+        Round 2 gated both halves but tested only one, so ungating the INDEX arm
+        survived the suite — a worktree-only failure would tell the operator to
+        `git restore --staged` an index that had already been cleaned. Behaviour
+        was correct; the coverage was not.
+
+        Driven directly because the worktree half only fails on a real `OSError`
+        from `write_bytes`, which no subprocess fixture can force.
+        """
+        doc = repo / "claudedocs" / "handoff-sample-topic.md"
+        original = doc.read_bytes()
+
+        def boom(self, data):  # noqa: ANN001, ANN202 - patched Path.write_bytes
+            raise OSError("disk full")
+
+        monkeypatch.setattr(Path, "write_bytes", boom)
+        note = hd._undo_write(repo, doc, "claudedocs/handoff-sample-topic.md",
+                              original)
+
+        assert "still MODIFIED" in note, note
+        assert "still STAGED" not in note, (
+            "claimed the index was left staged although that half succeeded:\n" + note
+        )
+        assert "restore --staged" not in note, (
+            "printed unstage advice although the index half succeeded:\n" + note
+        )

--- a/scripts/tests/test_handoff_doc.py
+++ b/scripts/tests/test_handoff_doc.py
@@ -26,6 +26,7 @@ import hashlib
 import importlib.util
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -33,6 +34,10 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from testlib.mockbin import write_exec  # noqa: E402
+
 TOOL = REPO_ROOT / "scripts" / "lib" / "handoff_doc.py"
 HANDOFF_SKILL = REPO_ROOT / "claude" / "skills" / "handoff" / "SKILL.md"
 
@@ -2182,10 +2187,11 @@ class TestBlockedCommitLeavesNoTrace:
     @staticmethod
     def _block_commits(repo: Path) -> None:
         """Refuse every commit, the way a real guard hook does."""
-        hook = repo / ".git" / "hooks" / "pre-commit"
-        hook.write_text("#!/bin/sh\necho 'blocked by guard' >&2\nexit 1\n",
-                        encoding="utf-8")
-        hook.chmod(0o755)
+        # write_exec owns the shebang — a call site that supplies its own
+        # trips scripts/tests/test_runtime_shebangs.py, a REPO-WIDE scan that a
+        # three-file test run structurally cannot see.
+        write_exec(repo / ".git" / "hooks" / "pre-commit",
+                   "echo 'blocked by guard' >&2\nexit 1\n")
 
     def test_the_hook_actually_blocks(self, repo: Path) -> None:
         """POSITIVE CONTROL for the fixture itself.
@@ -2239,4 +2245,128 @@ class TestBlockedCommitLeavesNoTrace:
         staged = _sh("git", "diff", "--cached", "--name-only", cwd=repo).split()
         assert staged == ["OTHER.md"], (
             f"the rollback must leave unrelated staged work alone; staged={staged}"
+        )
+
+    def test_a_LANDED_commit_is_never_rolled_back(
+        self, repo: Path, update_file: Path
+    ) -> None:
+        """🔴 THE HIGHEST-CONSEQUENCE BRANCH, and it had no test.
+
+        The `committed` flag exists so a commit that LANDED and then hit a later
+        failure is left alone. Roll back there and the tool DISCARDS a committed
+        change — strictly worse than the defect it was written to fix.
+
+        🔴 THE FIRST VERSION OF THIS TEST WAS VACUOUS and only mutation testing
+        found it: it used a failing `post-commit` hook, and git IGNORES that
+        hook's exit status (measured: `git commit` rc=0, commit created). The
+        except-branch was never reached, so deleting the guard still passed.
+        A `git` shim that fails `rev-parse` ONLY AFTER a commit has run is the
+        real shape — the commit lands, then a later git step errors.
+        """
+        real_git = shutil.which("git")
+        assert real_git, "git not on PATH"
+        shim = repo / "gitshim-revparse"
+        shim.mkdir()
+        marker = shim / "committed.marker"
+        # `git()` invokes ["git", "-C", <repo>, *args] — the SUBCOMMAND is $3,
+        # not $1. Scan all args instead of indexing, which is what the earlier
+        # broken shim got wrong.
+        write_exec(
+            shim / "git",
+            f'for a in "$@"; do [ "$a" = "commit" ] && : > "{marker}"; done\n'
+            f'for a in "$@"; do\n'
+            f'  if [ "$a" = "rev-parse" ] && [ -f "{marker}" ]; then exit 7; fi\n'
+            f'done\n'
+            f'exec {real_git} "$@"\n',
+        )
+        shas_before = commit_shas(repo)
+        env = dict(os.environ, **GIT_ENV)
+        env["PATH"] = f"{shim}:{env['PATH']}"
+
+        subprocess.run(
+            [sys.executable, str(TOOL), "--repo", str(repo), "--topic",
+             "sample-topic", "--update", str(update_file), "--advanced",
+             "a landed commit must survive a later failure", "--confirm"],
+            capture_output=True, text=True, env=env,
+        )
+
+        assert commit_shas(repo) != shas_before, (
+            "fixture inert: no commit was made, so the guard was never exercised"
+        )
+        head_doc = _sh("git", "show", "HEAD:claudedocs/handoff-sample-topic.md",
+                       cwd=repo)
+        assert doc_of(repo) == head_doc, (
+            "the worktree was rolled back even though the commit LANDED — that "
+            "discards committed work"
+        )
+
+    def test_first_ever_handoff_leaves_no_untracked_file_behind(
+        self, repo: Path, update_file: Path
+    ) -> None:
+        """The `original is None` -> `unlink` branch, which had no fixture.
+
+        Every other fixture pre-creates the doc, so the first-ever-handoff path
+        was never exercised: dropping the `unlink` survived the suite. A doc left
+        behind here is an UNTRACKED file in a shared checkout — invisible to
+        `git status -s` habits that scan for ` M`, and it makes a re-run append
+        to a doc the caller believes was never written."""
+        doc = repo / "claudedocs" / "handoff-brand-new-topic.md"
+        assert not doc.exists()
+        self._block_commits(repo)
+
+        res = subprocess.run(
+            [sys.executable, str(TOOL), "--repo", str(repo), "--topic",
+             "brand-new-topic", "--update", str(update_file), "--advanced",
+             "a first-ever handoff for this topic", "--confirm"],
+            capture_output=True, text=True, env=dict(os.environ, **GIT_ENV),
+        )
+
+        assert res.returncode == 3, f"expected EXIT_FAIL, got {res.returncode}"
+        assert not doc.exists(), (
+            "the doc the run CREATED was left behind after the commit was refused"
+        )
+        untracked = _sh("git", "status", "--porcelain", "--untracked-files=all",
+                        cwd=repo).strip()
+        assert untracked == "", f"left untracked residue: {untracked!r}"
+
+    def test_the_reset_FALLBACK_is_also_path_limited(
+        self, repo: Path, update_file: Path
+    ) -> None:
+        """The fallback arm had no test — only the primary `restore` arm did.
+
+        `git reset` without `-- <path>` unstages EVERYTHING, so a co-worker's
+        staged file would be unstaged by our failure. Forcing the fallback by
+        making `git restore` unavailable proves the second arm carries the same
+        path limit as the first."""
+        # 🔴 Resolve the real git ABSOLUTELY. `exec /usr/bin/env git` searches
+        # PATH — which this shim is prepended to — so the shim re-execs itself
+        # forever. (Measured: the run had to be killed.)
+        real_git = shutil.which("git")
+        assert real_git, "git not on PATH"
+        shim = repo / "gitshim"
+        shim.mkdir()
+        # 🔴 `git()` invokes ["git", "-C", <repo>, *args], so the subcommand is
+        # $3 — an earlier version tested $1, never intercepted anything, and the
+        # fallback arm was never exercised (the mutant survived). Scan all args.
+        write_exec(shim / "git",
+                   f'for a in "$@"; do\n'
+                   f'  [ "$a" = "restore" ] && exit 129\n'
+                   f'done\n'
+                   f'exec {real_git} "$@"\n')
+        (repo / "OTHER.md").write_text("someone else's staged work\n", encoding="utf-8")
+        _sh("git", "add", "--", "OTHER.md", cwd=repo)
+        self._block_commits(repo)
+
+        env = dict(os.environ, **GIT_ENV)
+        env["PATH"] = f"{shim}:{env['PATH']}"
+        subprocess.run(
+            [sys.executable, str(TOOL), "--repo", str(repo), "--topic",
+             "sample-topic", "--update", str(update_file), "--advanced",
+             "forcing the reset fallback", "--confirm"],
+            capture_output=True, text=True, env=env,
+        )
+
+        staged = _sh("git", "diff", "--cached", "--name-only", cwd=repo).split()
+        assert staged == ["OTHER.md"], (
+            f"the reset fallback must be path-limited too; staged={staged}"
         )

--- a/scripts/tests/test_handoff_doc.py
+++ b/scripts/tests/test_handoff_doc.py
@@ -2162,3 +2162,81 @@ class TestSkillAndModuleAgree:
             "omit it from the deploy and `home-manager switch` will succeed with "
             "the file simply absent."
         )
+
+
+class TestBlockedCommitLeavesNoTrace:
+    """A REFUSED commit must not leave the doc written and staged.
+
+    🔴 MEASURED 2026-08-21, and this is the failure the class exists for. A
+    PreToolUse hook enforcing "never commit in the primary clone" refused the
+    `git commit` — correct behaviour — but the tool had ALREADY written the
+    merged doc and `git add`ed it. The refusal therefore left a modified, STAGED
+    file in a checkout shared with other sessions, where the next person's
+    `git commit` sweeps it in. The caller then re-ran the tool to read the error
+    and the merge appended the same block a SECOND time.
+
+    A blocked commit is not a no-op, and the caller has no reason to expect it
+    left anything behind: `status=failed` reads as "nothing happened".
+    """
+
+    @staticmethod
+    def _block_commits(repo: Path) -> None:
+        """Refuse every commit, the way a real guard hook does."""
+        hook = repo / ".git" / "hooks" / "pre-commit"
+        hook.write_text("#!/bin/sh\necho 'blocked by guard' >&2\nexit 1\n",
+                        encoding="utf-8")
+        hook.chmod(0o755)
+
+    def test_the_hook_actually_blocks(self, repo: Path) -> None:
+        """POSITIVE CONTROL for the fixture itself.
+
+        Without this, a hook that silently failed to install would make every
+        assertion below pass for the wrong reason — the commit would simply
+        succeed and there would be nothing to roll back."""
+        self._block_commits(repo)
+        (repo / "canary.txt").write_text("x\n", encoding="utf-8")
+        _sh("git", "add", "--", "canary.txt", cwd=repo)
+        out = subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "should be refused"],
+            capture_output=True, text=True, env=dict(os.environ, **GIT_ENV),
+        )
+        assert out.returncode != 0, "the pre-commit hook did not block — fixture is inert"
+
+    def test_doc_is_restored_and_nothing_is_staged(
+        self, repo: Path, update_file: Path
+    ) -> None:
+        before = doc_of(repo)
+        shas_before = commit_shas(repo)
+        self._block_commits(repo)
+
+        res = run_tool(repo, "--confirm", update=update_file)
+
+        assert res.returncode == 3, f"expected EXIT_FAIL, got {res.returncode}"
+        assert "status=failed" in res.stderr
+        # 🔴 The two assertions this class exists for.
+        assert doc_of(repo) == before, (
+            "the doc was left MODIFIED after the commit was refused — in a shared "
+            "checkout that is another session's `git commit` away from being swept in"
+        )
+        staged = _sh("git", "diff", "--cached", "--name-only", cwd=repo).split()
+        assert staged == [], f"paths left STAGED after a refused commit: {staged}"
+        assert commit_shas(repo) == shas_before, "a commit was made despite the refusal"
+
+    def test_unrelated_staged_work_is_not_unstaged_by_the_rollback(
+        self, repo: Path, update_file: Path
+    ) -> None:
+        """The rollback must be PATH-LIMITED, like the commit it undoes.
+
+        A blanket `git reset` would unstage a co-worker's staged files as a side
+        effect of our own failure — trading one shared-checkout defect for a
+        worse one."""
+        (repo / "OTHER.md").write_text("someone else's staged work\n", encoding="utf-8")
+        _sh("git", "add", "--", "OTHER.md", cwd=repo)
+        self._block_commits(repo)
+
+        run_tool(repo, "--confirm", update=update_file)
+
+        staged = _sh("git", "diff", "--cached", "--name-only", cwd=repo).split()
+        assert staged == ["OTHER.md"], (
+            f"the rollback must leave unrelated staged work alone; staged={staged}"
+        )


### PR DESCRIPTION
## The defect

`handoff_doc.py --confirm` writes the merged doc and stages it **before** attempting the commit:

```python
doc.write_text(merged_text, ...)   # file now modified
git(repo, "add", "--", relpath)    # now staged
git(repo, "commit", ...)           # ← can be refused here
except (GitError, OSError) as exc:
    print(f"status=failed\n{exc}", ...)   # ← no rollback
```

So a **refused** commit leaves a modified, **staged** file behind — and `status=failed` reads as "nothing happened".

## How it was found

Measured 2026-08-21 in a client repo's shared primary clone. A PreToolUse hook enforcing the no-commits-in-a-shared-clone rule refused the commit (correct behaviour), and the tool left the doc staged in a checkout **other sessions work in** — one `git commit` away from being swept into someone else's commit.

It then compounded: re-running the tool to read the error made the merge append the same block a **second time**. That was caught only by counting a marker string — 2 occurrences, 1102 lines against a 934-line base.

## The fix

On any failure before the commit lands, undo the write and the staging. Three things it is careful about:

| concern | why |
|---|---|
| **Path-limited**, like the commit it undoes | a blanket `git reset` would unstage a **co-worker's** staged files as a side effect of *our* failure — trading one shared-checkout defect for a worse one |
| **Only rolls back what did NOT happen** | a `committed` flag means a commit that landed and then failed at `rev-parse` is left alone; restoring there would **discard a committed change** |
| **Non-raising, best-effort** | it runs on an error path, so a rollback that threw would replace the caller's real diagnosis with its own. Anything it cannot undo is reported with the exact restore command, never left silent |

## Verification

**Red at base, green at HEAD** — both new assertions fail on unfixed code, with the failure naming the real defect (`staged=['OTHER.md', 'claudedocs/handoff-sample-topic.md']`).

`test_the_hook_actually_blocks` is a **positive control on the fixture**: without it, a `pre-commit` hook that silently failed to install would make every other assertion pass for the wrong reason, because the commit would simply succeed and there would be nothing to roll back.

**Mutation-verified** — each mutant killed by its **own** named test, source restored byte-identical, control re-run green:

| mutation | killed by |
|---|---|
| drop the unstage | staged-paths assertion |
| drop the file restore | doc-restored assertion |
| blanket `reset` instead of `-- <path>` | unrelated-staged-work assertion |

That third one matters: it proves the path-limited requirement is actually **tested**, not just asserted in a comment.

**358 tests green** across `test_handoff_doc.py` + both resume-state suites (132 in the handoff suite: 129 pre-existing, 3 new).

## Note

The `git commit`/`git add` ordering is unchanged — the fix is purely additive on the failure path, so nothing about the success path moves.
