### PR TITLE
fix(signal): link an outbound group draft to its GROUP, not a phantom contact

### DIFF
--- a/claude/skills/signal/SKILL.md
+++ b/claude/skills/signal/SKILL.md
@@ -59,6 +59,9 @@ cd ~/workspace/devrc/scripts/signal
 python3 consumer.py conversations --limit 10
 python3 consumer.py search "harbour permit"
 python3 consumer.py draft --to +15550100 --body "on my way"   # -> pending + a clawgate card
+
+# draft to a GROUP: --to takes the `id` field (group.<double-base64>), NOT internal_id
+python3 consumer.py draft --to 'group.<double-base64>' --body "on my way"
 python3 consumer.py drafts --state pending
 python3 consumer.py approve 42 --ref clawgate-task-91
 python3 consumer.py send 42
@@ -98,10 +101,51 @@ kubectl -n signal exec deploy/signal-consumer -- python3 -c "
 import os,json,urllib.request
 api=os.environ['SIGNAL_API_URL'].rstrip('/'); acct=os.environ['SIGNAL_ACCOUNT']
 for g in json.load(urllib.request.urlopen(api+'/v1/groups/'+acct,timeout=20)):
-    print(g['internal_id'], repr(g['name']))"
+    print(g['internal_id'], repr(g['name']), g['id'])"
 ```
-Pass `internal_id`, **not** `id` — `id` is the same value wrapped in a `group.`-prefixed
-second encoding, and `mute` refuses it rather than muting 32 bytes that match nothing.
+
+### 🔴 `internal_id` vs `id` — the two commands want OPPOSITE halves of one value
+
+The API hands back the same 32 bytes twice, in two encodings, and **which one you need
+depends on the command**. Getting this backwards is silent in one direction and loud in
+the other, so read the table rather than guessing:
+
+| command | wants | shape | wrong one does what |
+|---|---|---|---|
+| `mute` / `unmute` | `internal_id` | bare base64, e.g. `zX3i…2IQ=` | **refuses** — `mute` will not mute 32 bytes that match nothing |
+| `draft --to` | `id` | `group.` + base64(base64(raw)) | **refuses** — not a canonical group address |
+
+`id` is `internal_id` wrapped in a `group.`-prefixed **second** base64 encoding. That is
+the literal string `/v2/send` addresses a group with, which is why `draft` takes it and
+`mute` — which writes a `BYTEA` key into `signal.excluded_groups` — does not.
+
+⚠️ **The `draft` refusal only catches a MALFORMED address, never a WRONG one.** Any
+canonically-encoded 32 bytes decodes perfectly, so a well-formed id for a group that does
+not exist is created on the spot and the message sends into a conversation nobody is in.
+`draft` therefore prints a **`WARNING: … matched NO stored group`** on stderr whenever it
+mints a group — that warning is the only signal you get, so do not ignore it. (It is a
+warning and not a refusal on purpose: a group can legitimately be drafted to before its
+first message has been ingested, because the pipeline is forward-only.)
+
+⚠️ **Group-draft linkage is NEW-ROWS-ONLY — old drafts are still unlinked, and a mute does
+not hide them.** Until 2026-08-21 `draft_message()` stored a group draft with
+`messages.group_id = NULL` and invented a phantom contact whose `phone_number` was the
+group address. `not_excluded()` keys on `group_id`, so **those rows walk straight through
+every mute.** Nothing repairs them automatically: `upsert_message`'s `ON CONFLICT` never
+sets `group_id`, so not even a device-sync echo can backfill one.
+
+Measured live scope: **1 contact and 1 message** (`signal.contacts` id 92,
+`signal.messages` id 51). A reviewed backfill is queued separately — it is **not** part of
+the code change and there is no migration. To check whether any remain:
+
+```bash
+# both should be 0 once the backfill has run; each row is a mute the filter cannot see
+psql -c "select count(*) from signal.contacts where phone_number like 'group.%'"
+psql -c "select count(*) from signal.messages
+         where is_outbound and send_state is not null and group_id is null
+           and dest_contact_id in (select id from signal.contacts
+                                   where phone_number like 'group.%')"
+```
 
 🔴 **The filter lives in `SignalDB`'s read methods, so RAW `psql` BYPASSES IT COMPLETELY** —
 an application predicate cannot bind a statement typed at a shell. So the body-printing

--- a/claude/skills/signal/SKILL.md
+++ b/claude/skills/signal/SKILL.md
@@ -113,11 +113,17 @@ the other, so read the table rather than guessing:
 | command | wants | shape | wrong one does what |
 |---|---|---|---|
 | `mute` / `unmute` | `internal_id` | bare base64, e.g. `zX3i…2IQ=` | **refuses** — `mute` will not mute 32 bytes that match nothing |
-| `draft --to` | `id` | `group.` + base64(base64(raw)) | **refuses** — not a canonical group address |
+| `draft --to` | `id` | `group.` + base64(base64(raw)) | **refuses**, naming the `id` you should have passed |
 
 `id` is `internal_id` wrapped in a `group.`-prefixed **second** base64 encoding. That is
 the literal string `/v2/send` addresses a group with, which is why `draft` takes it and
 `mute` — which writes a `BYTEA` key into `signal.excluded_groups` — does not.
+
+Both directions refuse, so crossing them is loud either way. That was **not** true until
+2026-08-22: `draft --to <bare internal_id>` used to be **accepted**, creating a phantom
+contact whose phone number was the group id, storing the message with `group_id` NULL and
+exiting 0 — a row no mute can ever see. It is now refused, and the refusal prints the
+`id` you should have passed.
 
 ⚠️ **The `draft` refusal only catches a MALFORMED address, never a WRONG one.** Any
 canonically-encoded 32 bytes decodes perfectly, so a well-formed id for a group that does
@@ -138,14 +144,32 @@ Measured live scope: **1 contact and 1 message** (`signal.contacts` id 92,
 `signal.messages` id 51). A reviewed backfill is queued separately — it is **not** part of
 the code change and there is no migration. To check whether any remain:
 
+🔴 **A phantom can wear either encoding, so do not filter on `'group.%'` alone.** The
+`group.`-prefixed form came from drafting with the `id`; the *bare base64* form came from
+drafting with the `internal_id`, which was accepted until 2026-08-22. A `LIKE 'group.%'`
+predicate is blind to the second, and would report a clean 0 while the rows sit there.
+
 ```bash
-# both should be 0 once the backfill has run; each row is a mute the filter cannot see
-psql -c "select count(*) from signal.contacts where phone_number like 'group.%'"
+# every phantom, BOTH encodings: a group-address contact, or one whose "phone number"
+# is 24/44 chars of canonical base64 (a bare internal_id) rather than +E164 or a uuid
+psql -c "select id, phone_number from signal.contacts
+         where phone_number like 'group.%'
+            or phone_number ~ '^[A-Za-z0-9+/]{22}==$'
+            or phone_number ~ '^[A-Za-z0-9+/]{43}=$'"
+
+# the drafts stranded against them — unlinked, and beyond every mute
 psql -c "select count(*) from signal.messages
          where is_outbound and send_state is not null and group_id is null
-           and dest_contact_id in (select id from signal.contacts
-                                   where phone_number like 'group.%')"
+           and dest_contact_id in (
+             select id from signal.contacts
+             where phone_number like 'group.%'
+                or phone_number ~ '^[A-Za-z0-9+/]{22}==$'
+                or phone_number ~ '^[A-Za-z0-9+/]{43}=$')"
 ```
+
+Both should be empty once the backfill has run. Measured 2026-08-21, only the
+`group.`-prefixed shape existed in prod (1 contact, 1 message) — the bare-base64 shape was
+reachable but had never been used, which is why the backfill covers one row and not two.
 
 🔴 **The filter lives in `SignalDB`'s read methods, so RAW `psql` BYPASSES IT COMPLETELY** —
 an application predicate cannot bind a statement typed at a shell. So the body-printing

--- a/claude/skills/signal/SKILL.md
+++ b/claude/skills/signal/SKILL.md
@@ -151,11 +151,14 @@ predicate is blind to the second, and would report a clean 0 while the rows sit 
 
 ```bash
 # every phantom, BOTH encodings: a group-address contact, or one whose "phone number"
-# is 24/44 chars of canonical base64 (a bare internal_id) rather than +E164 or a uuid
+# is 24/44 chars of canonical base64 (a bare internal_id) rather than +E164 or a uuid.
+# `_-` is in the class because `_decode_internal_id` folds the URL-safe alphabet before
+# decoding (consumer.py), so a phantom could wear that spelling too. `-` is LAST in the
+# bracket so POSIX reads it as a literal, not a range.
 psql -c "select id, phone_number from signal.contacts
          where phone_number like 'group.%'
-            or phone_number ~ '^[A-Za-z0-9+/]{22}==$'
-            or phone_number ~ '^[A-Za-z0-9+/]{43}=$'"
+            or phone_number ~ '^[A-Za-z0-9+/_-]{22}==$'
+            or phone_number ~ '^[A-Za-z0-9+/_-]{43}=$'"
 
 # the drafts stranded against them — unlinked, and beyond every mute
 psql -c "select count(*) from signal.messages
@@ -163,11 +166,11 @@ psql -c "select count(*) from signal.messages
            and dest_contact_id in (
              select id from signal.contacts
              where phone_number like 'group.%'
-                or phone_number ~ '^[A-Za-z0-9+/]{22}==$'
-                or phone_number ~ '^[A-Za-z0-9+/]{43}=$')"
+                or phone_number ~ '^[A-Za-z0-9+/_-]{22}==$'
+                or phone_number ~ '^[A-Za-z0-9+/_-]{43}=$')"
 ```
 
-Both should be empty once the backfill has run. Measured 2026-08-21, only the
+The first should return no rows and the second `0` once the backfill has run. Measured 2026-08-21, only the
 `group.`-prefixed shape existed in prod (1 contact, 1 message) — the bare-base64 shape was
 reachable but had never been used, which is why the backfill covers one row and not two.
 

--- a/claude/skills/signal/SKILL.md
+++ b/claude/skills/signal/SKILL.md
@@ -76,9 +76,13 @@ holds the mute list; **the rows are still there** — muting hides, it never del
 `unmute` restores a conversation exactly. That is why it is the default: this pipeline is
 forward-only, so a deleted message can never be re-fetched.
 
-🔴 **It is keyed on the group's BINARY id, never the name** — `signal.groups.name` is
-empty (`''`) for every group this consumer has stored, so a name-based filter would match
-nothing while looking like it worked.
+🔴 **It is keyed on the group's BINARY id, never the name.** `signal.excluded_groups` has
+one column to match on and it is `group_id BYTEA`, so a name-based filter matches nothing
+while looking like it worked. (An earlier version of this line justified that with "`name`
+is `''` for every group this consumer has stored" — **that is wrong**: `upsert_group()`
+persists the `groupName` an envelope carries, `Vetr app group` and `Family Winnipeg` are
+both populated in the live store, and `test_a_stored_group_keeps_the_name_the_envelope_carried`
+pins it. The advice is unchanged; only its reason was false.)
 
 ```bash
 python3 consumer.py muted
@@ -86,8 +90,9 @@ python3 consumer.py mute <internal_id> --note "why"     # base64, from the API b
 python3 consumer.py unmute <internal_id>
 ```
 
-Get `internal_id` (base64) — the pipeline does not store group names, so this is the only
-way to go from a name you recognise to the id the mute list wants:
+Get `internal_id` (base64). `signal.groups.name` may already hold the name (see above), but
+it is only as good as the envelope that last carried one, so the API is the reliable way to
+go from a name you recognise to the id the mute list wants:
 ```bash
 kubectl -n signal exec deploy/signal-consumer -- python3 -c "
 import os,json,urllib.request

--- a/scripts/signal/_signal_db.py
+++ b/scripts/signal/_signal_db.py
@@ -36,6 +36,7 @@ import os
 import re
 import socket
 import subprocess
+import sys
 import time
 import uuid
 from urllib.parse import urlparse
@@ -234,9 +235,19 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
     --
     -- 🔴 KEYED ON THE SIGNAL BINARY GROUP ID, not on `signal.groups.id` and NOT
     -- on the name. Two measured reasons, either one fatal on its own:
-    --   * `signal.groups.name` is EMPTY ('') for every group this consumer has
-    --     stored — it never captured names — so a name predicate matches nothing
-    --     and would read as a working filter that silently hides zero rows.
+    --   * a NAME IS NOT AN IDENTITY. It is operator-visible text: a group can be
+    --     renamed at any time by any member, two groups can share a name, and
+    --     the stored value is only as good as the last envelope that carried
+    --     one. The binary id never changes.
+    --     (🔴 RETRACTED, 2026-08-21: this bullet used to read "`signal.groups.name`
+    --     is EMPTY ('') for every group this consumer has stored — it never
+    --     captured names". That is FALSE. `upsert_group()` below persists the
+    --     envelope's `groupName`, `test_a_stored_group_keeps_the_name_the_envelope_carried`
+    --     pins it, and the live store has populated names. The advice was right
+    --     for the wrong reason — which is worse than no reason, because a
+    --     maintainer who checks the claim, finds names present, and concludes
+    --     the whole warning is stale is one step from keying a filter on a
+    --     column anyone can edit.)
     --   * the exclusion must be settable BEFORE the group has ever been seen;
     --     a FK to `signal.groups(id)` cannot express "mute this from now on"
     --     for a group with no row yet.
@@ -791,6 +802,19 @@ class SignalDB:
             )
             return cur.rowcount
 
+    def group_exists(self, group_id: bytes) -> bool:
+        """Has this binary group id EVER been stored?
+
+        Read-only, and separate from `upsert_group` on purpose: the upsert
+        cannot answer it, because `ON CONFLICT … DO UPDATE` returns a row id
+        identically whether it inserted or updated. `draft_message()` needs the
+        distinction to warn that it is minting a group nobody has seen.
+        """
+        with self._c.cursor() as cur:
+            cur.execute("SELECT 1 FROM signal.groups WHERE group_id = %s",
+                        (group_id,))
+            return cur.fetchone() is not None
+
     def upsert_group(self, *, group_id: bytes, name: str | None = None,
                      revision: int = 0) -> int:
         with self._c.cursor() as cur:
@@ -1258,13 +1282,40 @@ class SignalDB:
         )
         dest_id = None
         group_row_id = None
+        group_created = False
         if _looks_like_group_address(recipient):
             # `upsert_group`, not a lookup that refuses an unknown group: the
             # inbound path creates the row the same way, and refusing here would
             # make a group drafted to before its first message ever arrived
             # undraftable. A BAD address is still refused — `_group_address_to_id`
             # raises rather than inventing 32 bytes.
-            group_row_id = self.upsert_group(group_id=_group_address_to_id(recipient))
+            gid = _group_address_to_id(recipient)
+            # 🔴 SAY SO WHEN THIS MINTS A GROUP. The strict decoder rejects a
+            # MALFORMED address; it cannot reject a canonically-encoded but WRONG
+            # 32 bytes, which decodes perfectly, creates a group that never
+            # existed, and sends into the void while reporting success. That is
+            # the silent-zero shape `mute` was deliberately hardened against
+            # (it EXITS 4 rather than report a mute that hides nothing).
+            #
+            # A warning, NOT a refusal: forward-only creation is deliberate and
+            # correct — a group can legitimately be drafted to before its first
+            # message has been ingested, and refusing would make that group
+            # undraftable. Only the SILENCE was wrong. The row is written either
+            # way; this just refuses to let it happen without saying so.
+            group_created = not self.group_exists(gid)
+            group_row_id = self.upsert_group(group_id=gid)
+            if group_created:
+                print(
+                    f"WARNING: {recipient} matched NO stored group, so a new one "
+                    f"was created (row {group_row_id}). If you expected an "
+                    f"existing conversation, this address is wrong — a "
+                    f"canonically-encoded but incorrect id decodes perfectly and "
+                    f"cannot be caught by validation. The draft will send into a "
+                    f"group nobody is in. Check `internal_id` against "
+                    f"GET /v1/groups/<account> before approving. (If this group "
+                    f"genuinely has not been seen yet, this is expected — the "
+                    f"pipeline is forward-only.)",
+                    file=sys.stderr)
         elif _looks_like_uuid(recipient):
             dest_id = self.upsert_contact(signal_uuid=recipient)
         else:
@@ -1295,7 +1346,8 @@ class SignalDB:
             "id": draft_id, "recipient": recipient, "body": body,
             "send_state": STATE_PENDING, "message_timestamp": ts,
             "source_contact_id": source_id, "dest_contact_id": dest_id,
-            "group_id": group_row_id, "approval_ref": approval_ref,
+            "group_id": group_row_id, "group_created": group_created,
+            "approval_ref": approval_ref,
         }
 
     def approve_draft(self, draft_id: int, *, approval_ref: str) -> dict:
@@ -1744,9 +1796,19 @@ def _group_address_to_id(recipient: str) -> bytes:
     the same strict reader the `mute` CLI uses, NOT a second base64 reader living
     here. It round-trips the encoding and demands 16 or 32 bytes, so a truncated
     paste or a display name is refused rather than resolved to some other 32
-    bytes — a draft addressed to a group that does not exist is worse than a
-    refusal, because `upsert_group` would happily CREATE it and the message would
-    go nowhere while reporting success.
+    bytes.
+
+    🔴 WHAT THIS DOES **NOT** CATCH — stated because an earlier version of this
+    docstring claimed it did. Validation rejects a MALFORMED address. It cannot
+    reject a WRONG one: any canonically-encoded 32 bytes decodes perfectly, and
+    there is no way from here to tell a real group id from a plausible one. Such
+    an address reaches `upsert_group`, which CREATES the group, and the draft
+    then sends into a conversation nobody is in — while reporting success.
+    `draft_message()` therefore WARNS on stderr whenever it mints a
+    previously-unseen group; that warning, not this function, is what covers the
+    wrong-but-well-formed case. It is a warning rather than a refusal because
+    drafting to a not-yet-ingested group is legitimate (the pipeline is
+    forward-only), so refusing would make that group undraftable.
 
     Raises `ValueError` on anything that is not a canonical group address.
     """

--- a/scripts/signal/_signal_db.py
+++ b/scripts/signal/_signal_db.py
@@ -243,7 +243,12 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
     --     is EMPTY ('') for every group this consumer has stored — it never
     --     captured names". That is FALSE. `upsert_group()` below persists the
     --     envelope's `groupName`, `test_a_stored_group_keeps_the_name_the_envelope_carried`
-    --     pins it, and the live store has populated names. The advice was right
+    --     pins it, and the live store has populated names — MEASURED 2026-08-21
+    --     against prod `signal.groups`, which holds 'Vetr app group' and
+    --     'Family Winnipeg'. (Stated as a measurement because an auditor
+    --     re-derived the opposite from `consumer.py`'s parse and doubted it;
+    --     reading the code cannot settle what the table contains.)
+    --     The advice was right
     --     for the wrong reason — which is worse than no reason, because a
     --     maintainer who checks the claim, finds names present, and concludes
     --     the whole warning is stale is one step from keying a filter on a
@@ -1318,6 +1323,37 @@ class SignalDB:
                     file=sys.stderr)
         elif _looks_like_uuid(recipient):
             dest_id = self.upsert_contact(signal_uuid=recipient)
+        elif _looks_like_bare_group_internal_id(recipient):
+            # 🔴 THE `mute`/`draft` MIX-UP, REFUSED RATHER THAN DOCUMENTED.
+            # `_looks_like_group_address` is a bare `group.` PREFIX test, so a
+            # bare `internal_id` — the form `mute` takes — has no prefix, is not
+            # a uuid, and used to fall through to `upsert_contact()`. That
+            # recreated EXACTLY the defect this whole change exists to remove: a
+            # phantom contact whose phone_number is a group id, `group_id` NULL,
+            # no warning, exit 0 — and a row that no mute can ever see, because
+            # `not_excluded()` keys on `group_id`. It was worse than the original
+            # bug, because SKILL.md had begun telling operators these two
+            # commands take different halves of the same value.
+            #
+            # Refusing is safe because the shapes cannot collide: a Signal
+            # recipient is `+E164` or a uuid, and `_decode_internal_id` rejects
+            # both (measured at both E.164 length extremes and for upper/lower
+            # uuids — see test_no_REAL_recipient_shape_is_mistaken_for_a_group_id).
+            # Only 24 or 44 characters of canonical base64 reach here.
+            # Hand back the exact string that WOULD have worked: a refusal that
+            # names the fix costs nothing and is the difference between a
+            # correction and a dead end.
+            from consumer import _decode_internal_id  # local import: no cycle
+
+            correct = _group_id_to_address(_decode_internal_id(recipient))
+            raise ValueError(
+                f"{recipient!r} is a bare group `internal_id` — that is what "
+                f"`mute` takes. `draft --to` needs the `id` form: {correct!r}. "
+                f"Drafting to the bare form would silently create a CONTACT "
+                f"whose phone number is a group id (the phantom-contact defect "
+                f"this refusal exists to prevent), store the message with "
+                f"group_id NULL, and put it beyond the reach of every mute."
+            )
         else:
             dest_id = self.upsert_contact(phone_number=recipient)
         ts = provisional_timestamp if provisional_timestamp is not None \
@@ -1787,6 +1823,39 @@ def _looks_like_group_address(recipient) -> bool:
     digits only), so there is no ambiguity to resolve.
     """
     return isinstance(recipient, str) and recipient.startswith(GROUP_ADDRESS_PREFIX)
+
+
+def _looks_like_bare_group_internal_id(recipient) -> bool:
+    """True for the `mute` form of a group id — bare base64, no `group.` prefix.
+
+    🔴 THIS EXISTS TO REFUSE, NOT TO RESOLVE. `mute` takes `internal_id` and
+    `draft --to` takes `id` (the same bytes wrapped in a second base64 layer
+    behind a `group.` prefix), so the two commands want opposite halves of one
+    value and an operator WILL cross them. Without this, the bare form fell
+    through to `upsert_contact(phone_number=...)` and recreated the phantom
+    contact — silently, exit 0, with `group_id` NULL and therefore invisible to
+    every mute.
+
+    🔴 WHY THIS CANNOT SWALLOW A REAL RECIPIENT. It reuses the strict operator
+    decoder, which requires a canonical base64 round-trip AND a 16- (GroupV1) or
+    32-byte (GroupV2) result. A Signal recipient is `+E164` or a uuid: E.164 is
+    at most 16 characters and never a multiple of 4, and a uuid's `-` separators
+    put it at 27 bytes when urlsafe-folded — all rejected. Measured for both
+    E.164 length extremes, upper- and lower-case uuids, a username and a display
+    name in `test_no_REAL_recipient_shape_is_mistaken_for_a_group_id`, which is
+    what keeps this claim true rather than merely argued. Callers must still
+    check `_looks_like_uuid` FIRST; this is the last branch before the
+    contact fallback for exactly that reason.
+    """
+    if not isinstance(recipient, str) or _looks_like_group_address(recipient):
+        return False
+    from consumer import _decode_internal_id  # local import: no cycle
+
+    try:
+        _decode_internal_id(recipient)
+        return True
+    except (ValueError, TypeError):
+        return False
 
 
 def _group_address_to_id(recipient: str) -> bytes:

--- a/scripts/signal/_signal_db.py
+++ b/scripts/signal/_signal_db.py
@@ -30,6 +30,7 @@ the gate is a missing edge in the call graph, not a documented convention.
 """
 from __future__ import annotations
 
+import base64
 import contextlib
 import os
 import re
@@ -1229,14 +1230,45 @@ class SignalDB:
         server timestamp is positive epoch-ms, so the provisional value can never
         be mistaken for one, and `send_approved()` overwrites it with the SERVER's
         (🔧 #4).
+
+        🔴 A GROUP recipient resolves to a GROUP, exactly as the inbound path
+        already does. `upsert_message()` calls `upsert_group()` and sets
+        `messages.group_id`; this used to send EVERY recipient through
+        `upsert_contact()` instead, which produced two silent faults at once:
+
+          * `group_id` stayed NULL, so `_muted_predicate` — which keys on
+            `m.group_id` — could not see the row. A draft to a MUTED group was
+            returned in full by every read that believed it was filtering, and
+            mute is the privacy control here. `idx_msg_group` and every
+            group-scoped read missed our own sent messages too, so a group
+            conversation read as inbound-only.
+          * a PHANTOM CONTACT was created — a fake person whose `phone_number`
+            was the group address — one per group ever drafted to.
+
+        The phantom was load-bearing, which is why removing it needed
+        `get_draft()` to derive the recipient from the group row FIRST (see the
+        LEFT JOIN there): `send_approved()` reads the recipient string back out
+        of the draft, so dropping the contact without rewiring that derivation
+        would have left every group send addressed to `None`.
         """
         if not (self_uuid or self_number):
             raise ValueError("draft_message needs the sending account's uuid or number")
         source_id = self.upsert_contact(
             signal_uuid=self_uuid, phone_number=self_number, display_name="me",
         )
-        dest_id = self.upsert_contact(phone_number=recipient) \
-            if not _looks_like_uuid(recipient) else self.upsert_contact(signal_uuid=recipient)
+        dest_id = None
+        group_row_id = None
+        if _looks_like_group_address(recipient):
+            # `upsert_group`, not a lookup that refuses an unknown group: the
+            # inbound path creates the row the same way, and refusing here would
+            # make a group drafted to before its first message ever arrived
+            # undraftable. A BAD address is still refused — `_group_address_to_id`
+            # raises rather than inventing 32 bytes.
+            group_row_id = self.upsert_group(group_id=_group_address_to_id(recipient))
+        elif _looks_like_uuid(recipient):
+            dest_id = self.upsert_contact(signal_uuid=recipient)
+        else:
+            dest_id = self.upsert_contact(phone_number=recipient)
         ts = provisional_timestamp if provisional_timestamp is not None \
             else -int(time.time() * 1000)
         if ts >= 0:
@@ -1249,11 +1281,13 @@ class SignalDB:
                 """
                 INSERT INTO signal.messages
                     (message_timestamp, source_contact_id, dest_contact_id,
-                     message_type, body, is_outbound, send_state, approval_ref)
-                VALUES (%s, %s, %s, 'draft', %s, true, %s, %s)
+                     group_id, message_type, body, is_outbound, send_state,
+                     approval_ref)
+                VALUES (%s, %s, %s, %s, 'draft', %s, true, %s, %s)
                 RETURNING id
                 """,
-                (ts, source_id, dest_id, body, STATE_PENDING, approval_ref),
+                (ts, source_id, dest_id, group_row_id, body, STATE_PENDING,
+                 approval_ref),
             )
             draft_id = _returned_id(cur, "draft_message")
         self._c.commit()
@@ -1261,7 +1295,7 @@ class SignalDB:
             "id": draft_id, "recipient": recipient, "body": body,
             "send_state": STATE_PENDING, "message_timestamp": ts,
             "source_contact_id": source_id, "dest_contact_id": dest_id,
-            "approval_ref": approval_ref,
+            "group_id": group_row_id, "approval_ref": approval_ref,
         }
 
     def approve_draft(self, draft_id: int, *, approval_ref: str) -> dict:
@@ -1329,10 +1363,26 @@ class SignalDB:
         `group_id`, so this method returned a muted group's body in full while
         `get_message` correctly returned None for the same row. Nothing exploited
         it (every caller goes through `_draft_or_raise`, and the D3 gate rejects
-        `send_state=None` before printing), but the mute ledger EXEMPTS this
-        method on the stated grounds that drafts carry no group — and that reason
-        was false until this line existed. A guard whose justification the code
+        `send_state=None` before printing). A guard whose justification the code
         contradicts is one refactor away from being a real leak.
+
+        🔴 THE EXEMPTION'S REASON CHANGED — read it, do not inherit it. The mute
+        ledger used to exempt this method because "drafts have no group_id".
+        Since `draft_message()` links a group draft to its group row that is NO
+        LONGER TRUE, and the exemption now rests on a different, narrower claim:
+        this is the OUTBOUND surface, and the only rows it can return are ones
+        `send_state IS NOT NULL` — i.e. bodies the OPERATOR composed, never a
+        third party's. Muting is about what you READ; a draft is what you WROTE.
+        Filtering here would also be actively harmful: `approve_draft()`,
+        `send_approved()` and `reconcile_send()` all reach this through
+        `_draft_or_raise()`, so a mute landing mid-flight would strand a draft in
+        `sending` with no route out and report it as "does not exist" — an
+        accidental seventh refusal path through the D3 gate.
+
+        What DOES have to hold, and is pinned by
+        `test_group_exclusions.py::test_a_muted_group_draft_is_hidden_from_every_filtered_read`:
+        every read that carries `not_excluded()` must hide a muted group's draft.
+        Those are the surfaces that can surface someone else's conversation.
         """
         with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
             cur.execute(
@@ -1354,15 +1404,33 @@ class SignalDB:
                        -- gates goes blind.
                        CASE WHEN d.is_placeholder THEN d.phone_number
                             ELSE COALESCE(CAST(d.signal_uuid AS text), d.phone_number)
-                       END AS recipient
+                       END AS recipient,
+                       -- A GROUP draft has NO dest contact, so the CASE above is
+                       -- NULL for it and the recipient is rebuilt in Python from
+                       -- the group's binary id. It is not built in SQL because
+                       -- the address is a DOUBLE base64 encoding, which neither
+                       -- engine spells the same way — and doing it here would be
+                       -- a second encoder alongside `_group_id_to_address`.
+                       m.group_id AS group_id,
+                       g.group_id AS group_signal_id
                 FROM signal.messages m
                 LEFT JOIN signal.contacts d ON d.id = m.dest_contact_id
+                LEFT JOIN signal.groups g ON g.id = m.group_id
                 WHERE m.id = %s AND m.is_outbound AND m.send_state IS NOT NULL
                 """,
                 (draft_id,),
             )
             row = cur.fetchone()
-            return dict(row) if row else None
+            if row is None:
+                return None
+            out = dict(row)
+            # 🔴 The GROUP wins over the contact join, and the raw id never
+            # escapes: a `memoryview`/`bytes` in the returned dict would reach
+            # `json.dumps` in the CLI and the send payload alike.
+            group_signal_id = out.pop("group_signal_id", None)
+            if group_signal_id is not None:
+                out["recipient"] = _group_id_to_address(group_signal_id)
+            return out
 
     def list_drafts(self, state: str | None = None) -> list:
         sql = ("SELECT id, message_timestamp, body, send_state, approval_ref "
@@ -1643,3 +1711,67 @@ def _looks_like_uuid(value: str) -> bool:
         return True
     except (ValueError, AttributeError, TypeError):
         return False
+
+
+# --------------------------------------------------------------------------- #
+# GROUP ADDRESSES — the `group.` recipient the send endpoint takes
+# --------------------------------------------------------------------------- #
+# `/v2/send` addresses a group with the API's own `id` field, which is
+# `group.` + base64(base64(raw 16- or 32-byte group id)) — a DOUBLE encoding, so
+# the text after the prefix is base64 of the group's base64 `internal_id`. The
+# inner value is exactly what `signal.groups.group_id` stores as BYTEA and what
+# the mute list is keyed on, which is what lets an outbound draft join to the
+# same group row the inbound path writes.
+GROUP_ADDRESS_PREFIX = "group."
+
+
+def _looks_like_group_address(recipient) -> bool:
+    """True for a `group.`-prefixed recipient — a GROUP, not a person.
+
+    Deliberately a prefix test and nothing more: whether the rest DECODES is
+    `_group_address_to_id`'s job, and conflating the two would turn a malformed
+    group address into a silently-created contact — the exact defect this
+    replaces. A phone number or a uuid can never carry this prefix (`+` and hex
+    digits only), so there is no ambiguity to resolve.
+    """
+    return isinstance(recipient, str) and recipient.startswith(GROUP_ADDRESS_PREFIX)
+
+
+def _group_address_to_id(recipient: str) -> bytes:
+    """`group.<base64(base64(raw))>` → the raw BYTEA group id.
+
+    🔴 ONE RULE, ONE PLACE: the inner decode is `consumer._decode_internal_id`,
+    the same strict reader the `mute` CLI uses, NOT a second base64 reader living
+    here. It round-trips the encoding and demands 16 or 32 bytes, so a truncated
+    paste or a display name is refused rather than resolved to some other 32
+    bytes — a draft addressed to a group that does not exist is worse than a
+    refusal, because `upsert_group` would happily CREATE it and the message would
+    go nowhere while reporting success.
+
+    Raises `ValueError` on anything that is not a canonical group address.
+    """
+    from consumer import _decode_internal_id  # local import: no cycle
+
+    outer = recipient[len(GROUP_ADDRESS_PREFIX):]
+    try:
+        internal = base64.b64decode(outer, validate=True).decode("ascii")
+    except Exception as exc:
+        raise ValueError(
+            f"{recipient!r} is not a group address: the text after "
+            f"{GROUP_ADDRESS_PREFIX!r} must be base64 of the group's base64 "
+            f"`internal_id` (the API's `id` field is double-encoded) — {exc}"
+        ) from exc
+    return _decode_internal_id(internal)
+
+
+def _group_id_to_address(raw) -> str:
+    """A raw BYTEA group id back to the `group.` recipient `/v2/send` takes.
+
+    The inverse of `_group_address_to_id`, and the reason the phantom contact can
+    be retired: the recipient string is DERIVED from `signal.groups.group_id`
+    rather than read back out of a fake person whose `phone_number` was the
+    address. `bytes()` because psycopg2 hands BYTEA back as a `memoryview` and
+    the sqlite substrate as `bytes`.
+    """
+    return GROUP_ADDRESS_PREFIX + base64.b64encode(
+        base64.b64encode(bytes(raw))).decode()

--- a/scripts/signal/consumer.py
+++ b/scripts/signal/consumer.py
@@ -1167,7 +1167,12 @@ def build_parser() -> argparse.ArgumentParser:
     um.add_argument("internal_id")
 
     d = sub.add_parser("draft", help="compose an outbound draft (transmits NOTHING)")
-    d.add_argument("--to", required=True)
+    d.add_argument("--to", required=True,
+                   help="a PERSON (+15550100 or a uuid), or a GROUP as "
+                        "`group.<double-base64>` — the `id` field from "
+                        "GET /v1/groups/<account>, NOT the `internal_id` that "
+                        "`mute` takes. The two commands want opposite halves of "
+                        "the same value; see `internal_id vs id` in SKILL.md")
     d.add_argument("--body", required=True)
     d.add_argument("--from-number", default=ACCOUNT,
                    help="the sending account (default $SIGNAL_ACCOUNT)")
@@ -1328,8 +1333,18 @@ def main(argv=None) -> int:  # pragma: no cover - thin CLI shell over tested uni
                       else "that group was not muted — nothing changed")
         elif args.cmd == "draft":
             import clawgate
-            draft = db.draft_message(
-                recipient=args.to, body=args.body, self_number=args.from_number)
+            try:
+                draft = db.draft_message(
+                    recipient=args.to, body=args.body,
+                    self_number=args.from_number)
+            except ValueError as exc:
+                # 🔴 EXIT 3, like every sibling. `mute` catches ValueError and
+                # `send`/`reconcile` catch SendGateError, both exiting 3; this
+                # branch alone let a bad `--to` escape as an uncaught traceback
+                # and exit 1 — which a caller cannot distinguish from the
+                # interpreter dying for an unrelated reason.
+                print(f"refused: {exc}", file=sys.stderr)
+                return 3
             clawgate.emit_draft_task(
                 draft_id=draft["id"], recipient=args.to, body=args.body)
             print(json.dumps(draft))

--- a/scripts/signal/tests/mutation_battery.py
+++ b/scripts/signal/tests/mutation_battery.py
@@ -264,6 +264,193 @@ MUTANTS: list[Mutant] = [
            'want_choices="approve conversations draft drafts health mute muted reconcile run search send unmute "',
            'want_choices="approve conversations draft drafts health reconcile run search send "',
            "test_the_build_control_lists_EXACTLY_the_CLI_subcommands", SUITE_IMAGE),
+
+    # ------------------------------------------------------------------ #
+    # Outbound GROUP drafting (#686). Before this, `draft_message()` sent every
+    # recipient through `upsert_contact()`: a group draft stored `group_id`
+    # NULL — invisible to `not_excluded()`, which keys on it — and minted a
+    # PHANTOM CONTACT whose phone_number was the group address.
+    # ------------------------------------------------------------------ #
+    Mutant("GD1", "the shipped defect, in its narrowest form: the INSERT stops carrying "
+                  "`group_id`. The draft still resolves the group, so nothing about the "
+                  "address looks wrong — the row is simply unlinked, and every read that "
+                  "believes it is filtering returns a MUTED group's draft in full.",
+           DB,
+           "                (ts, source_id, dest_id, group_row_id, body, STATE_PENDING,",
+           "                (ts, source_id, dest_id, None, body, STATE_PENDING,",
+           "test_a_muted_group_draft_is_hidden_from_every_filtered_read", SUITE_EXCL),
+
+    Mutant("GD2", "the phantom contact returns: a group recipient ALSO resolved through "
+                  "`upsert_contact`. `group_id` is still set, so the mute keeps working "
+                  "and the mute test stays GREEN — only the contacts table shows it. A "
+                  "battery that checked mute alone would score this SURVIVED.",
+           DB,
+           "            gid = _group_address_to_id(recipient)",
+           "            dest_id = self.upsert_contact(phone_number=recipient)\n"
+           "            gid = _group_address_to_id(recipient)",
+           "test_a_group_draft_is_LINKED_to_the_group_row_not_a_contact", SUITE_EXCL),
+
+    Mutant("GD3", "`get_draft` stops deriving the recipient from the group row. The "
+                  "phantom contact was LOAD-BEARING — it was where the send address was "
+                  "read from — so removing it without this rewiring addresses every "
+                  "group send to None.",
+           DB,
+           "            if group_signal_id is not None:", "            if False:",
+           "test_the_SEND_recipient_is_derived_from_the_group_row_not_a_contact",
+           SUITE_EXCL),
+
+    Mutant("GD4", "the group address SINGLE-encodes. `/v2/send` takes `group.` + "
+                  "base64(base64(raw)) — a DOUBLE encoding — and the single form is "
+                  "well-formed base64 that decodes to something plausible, so only a "
+                  "literal anchor can tell them apart.",
+           DB,
+           "    return GROUP_ADDRESS_PREFIX + base64.b64encode(\n"
+           "        base64.b64encode(bytes(raw))).decode()",
+           "    return GROUP_ADDRESS_PREFIX + base64.b64encode(bytes(raw)).decode()",
+           "test_the_group_address_encoding_round_trips_against_a_LITERAL", SUITE_EXCL),
+
+    Mutant("GD5", "the group-address decoder drops the STRICT reader, so a display name "
+                  "or a truncated paste resolves to some other bytes and "
+                  "`upsert_group` CREATES that group — a send into the void, reported "
+                  "as success.",
+           DB,
+           "    return _decode_internal_id(internal)",
+           "    return base64.b64decode(internal)",
+           "test_a_MALFORMED_group_address_is_refused_and_stores_nothing", SUITE_EXCL),
+
+    Mutant("GD6", "🔴 [audit] a BARE `internal_id` — the form `mute` takes — is accepted "
+                  "instead of refused, falling through to `upsert_contact()`. This is "
+                  "the phantom-contact defect by the back door, and SKILL.md documented "
+                  "the opposite. Found by a delta re-audit AFTER the fix was called "
+                  "complete.",
+           DB,
+           "        elif _looks_like_bare_group_internal_id(recipient):",
+           "        elif False:",
+           "test_a_BARE_internal_id_is_REFUSED_not_turned_into_a_phantom_contact",
+           SUITE_EXCL),
+
+    Mutant("GD7", "the bare-internal-id refusal WIDENED to swallow real recipients — the "
+                  "risk the refusal itself carries. Dropping the length check makes "
+                  "`Team` (3 bytes) and any short base64 a 'group id', so ordinary "
+                  "contacts stop being draftable.",
+           CON,
+           "    if len(raw) not in (16, 32):",
+           "    if False:",
+           "test_no_REAL_recipient_shape_is_mistaken_for_a_group_id", SUITE_EXCL),
+
+    Mutant("GD8", "`draft` mints a previously-unseen group SILENTLY. A canonically "
+                  "encoded but WRONG id decodes perfectly and cannot be rejected, so the "
+                  "stderr warning is the ONLY signal that the message is going nowhere — "
+                  "the silent-zero shape `mute` was hardened against.",
+           DB,
+           "            group_created = not self.group_exists(gid)",
+           "            group_created = False",
+           "test_drafting_to_an_UNSEEN_group_WARNS_loudly_on_stderr", SUITE_EXCL),
+
+    Mutant("GD9", "the same warning fired UNCONDITIONALLY. A warning on every draft is "
+                  "one an operator learns to ignore, which is indistinguishable from no "
+                  "warning at all — so the SILENT case needs its own mutant.",
+           DB,
+           "            group_created = not self.group_exists(gid)",
+           "            group_created = True",
+           "test_drafting_to_a_KNOWN_group_is_SILENT", SUITE_EXCL),
+
+    Mutant("GD10", "the `draft` CLI loses its refusal branch, so a bad `--to` escapes as "
+                   "an uncaught traceback and exit 1 — indistinguishable, to a caller, "
+                   "from the interpreter dying for an unrelated reason. `mute` and "
+                   "`send` both exit 3.",
+            CON,
+            # 🔴 Anchored on TWO lines: `except ValueError as exc:` alone now
+            # matches twice (the `mute` branch has one too), and the battery's
+            # own exactly-once guard caught it. Keep the comment line in the
+            # anchor, or this silently re-ambiguates the day another branch
+            # grows a ValueError handler.
+            "            except ValueError as exc:\n"
+            "                # 🔴 EXIT 3, like every sibling.",
+            "            except ZeroDivisionError as exc:\n"
+            "                # 🔴 EXIT 3, like every sibling.",
+            "test_draft_REFUSES_a_bad_recipient_with_exit_3_like_its_siblings",
+            SUITE_EXCL),
+
+    # ------------------------------------------------------------------ #
+    # The mute LEDGER and its behavioural probes (#686). The ledger says which
+    # reads filter; these check the ledger cannot drift from the code.
+    # ------------------------------------------------------------------ #
+    Mutant("LP1", "a read method that is in NEITHER ledger. The seam this whole ledger "
+                  "exists for: a new read surface added without the filter.",
+           DB,
+           "    def commit(self) -> None:",
+           "    def list_archived_messages(self):\n"
+           "        with self._c.cursor() as cur:\n"
+           '            cur.execute("SELECT m.id, m.body FROM signal.messages m")\n'
+           "            return cur.fetchall()\n\n"
+           "    def commit(self) -> None:",
+           "test_the_two_ledgers_PARTITION_every_read_of_signal_messages", SUITE_EXCL),
+
+    Mutant("LP2", "🔴 `get_message` declared EXEMPT while it is still FILTERED, so the "
+                  "ledger now says the mute does not cover the id route. The two sets' "
+                  "UNION is IDENTICAL after this — the union check that preceded the "
+                  "partition scored exactly this class GREEN. Only a DISJOINTNESS check, "
+                  "plus comparing the ledger against what the CODE does, can see it.",
+           SUITE_EXCL,
+           "EXEMPT_READS = {\n",
+           'EXEMPT_READS = {\n    "get_message": "declared exempt while still calling the '
+           'predicate — the ledger and the code now disagree",\n',
+           "test_the_two_ledgers_PARTITION_every_read_of_signal_messages", SUITE_EXCL),
+
+    Mutant("LP7", "the mute filter removed from `list_conversations` — scored here against "
+                  "the LEDGER rather than the behavioural test. Same edit as M2, "
+                  "deliberately: M2 proves a muted group reappears, this proves the "
+                  "ledger notices the code drifted away from what it claims. A "
+                  "structural check that only ever agreed with the behavioural one would "
+                  "be decorative, and nothing else in the file distinguishes them.",
+           DB,
+           "                    WHERE {not_excluded('m')}\n", "",
+           "test_the_two_ledgers_PARTITION_every_read_of_signal_messages", SUITE_EXCL),
+
+    Mutant("LP3", "the predicate detector reverted to a SUBSTRING over source text. "
+                  "`get_draft` does NOT filter but its docstring EXPLAINS the mute "
+                  "predicate, so the substring form certified it as filtering — a guard "
+                  "satisfiable by PROSE. Measured on the shipped code, not imagined.",
+           SUITE_EXCL,
+           "    return any(isinstance(n, ast.Call) and isinstance(n.func, ast.Name)\n"
+           '               and n.func.id == "not_excluded" for n in ast.walk(node))',
+           '    return "not_excluded(" in inspect.getsource(fn)',
+           "test_the_predicate_detector_is_NOT_walked_by_a_DOCSTRING_mention", SUITE_EXCL),
+
+    Mutant("LP4", "`get_draft` loses `send_state IS NOT NULL`, which is the PREMISE its "
+                  "mute exemption rests on: without it the method also returns "
+                  "device-sync ECHOES, which carry OTHER PEOPLE's bodies from muted "
+                  "groups. The exemption silently becomes a real leak.",
+           DB,
+           "WHERE m.id = %s AND m.is_outbound AND m.send_state IS NOT NULL",
+           "WHERE m.id = %s AND m.is_outbound",
+           "test_the_draft_exemptions_PREMISE_is_still_in_the_code", SUITE_EXCL),
+
+    Mutant("LP5", "🔴 [audit] two behavioural probes SWAPPED — `get_message` given the "
+                  "`search` probe's body. The probe KEY set is unchanged, so "
+                  "`set(_MUTE_PROBES) == FILTERED_READS` cannot see it and the suite "
+                  "stayed fully green while `get_message` had NO behavioural coverage of "
+                  "a group draft. Found by an audit; the same set-invariant-under-a-swap "
+                  "shape as LP2.",
+           SUITE_EXCL,
+           '    "get_message": lambda db, draft, body: [\n'
+           '        r for r in [db.get_message(draft["id"])] if r],\n',
+           '    "get_message": lambda db, draft, body: [\n'
+           '        r for r in db.search(body) if r["id"] == draft["id"]],\n',
+           "test_each_MUTE_PROBE_actually_calls_the_method_it_is_keyed_under", SUITE_EXCL),
+
+    Mutant("LP6", "🔴 [audit] the recording proxy BLINDED — it still delegates, so every "
+                  "probe returns real rows and every downstream assertion passes, while "
+                  "`called` stays empty. This is what the old, vacuous negative control "
+                  "could not see: it PASSED under this mutant.",
+           SUITE_EXCL,
+           "            def recording(*a, **kw):\n"
+           "                self.called.append(name)\n"
+           "                return attr(*a, **kw)\n"
+           "            return recording",
+           "            return attr",
+           "test_each_MUTE_PROBE_actually_calls_the_method_it_is_keyed_under", SUITE_EXCL),
 ]
 
 

--- a/scripts/signal/tests/test_group_exclusions.py
+++ b/scripts/signal/tests/test_group_exclusions.py
@@ -942,6 +942,84 @@ def test_draft_does_NOT_exit_3_on_a_GOOD_recipient(db, monkeypatch, capsys):
     assert db.conn.rows("SELECT count(*) AS n FROM signal.messages")[0]["n"] == 1
 
 
+def test_a_BARE_internal_id_is_REFUSED_not_turned_into_a_phantom_contact(db):
+    """🔴 The `mute`/`draft` mix-up — the defect this whole PR removes, by the back door.
+
+    `_looks_like_group_address` is a bare `group.` PREFIX test. A bare
+    `internal_id` — the form `mute` takes, and which SKILL.md had begun telling
+    operators about — has no prefix, is not a uuid, and fell through to
+    `upsert_contact(phone_number=...)`. Measured before this fix:
+
+        BARE internal_id -> ACCEPTED, dest_contact_id=2, group_id=None,
+                            group_created=False, stderr=''
+        contacts: [(1,'+15550000'), (2,'zX3i…2IQ=')]
+
+    A phantom contact, `group_id` NULL, NO warning, exit 0 — and a row no mute
+    can ever see, because `not_excluded()` keys on `group_id`. Worse than the
+    original bug, because the docs now point at it.
+    """
+    internal_id = base64.b64encode(GROUP_KEEP).decode()
+    assert not internal_id.startswith("group."), "fixture must be the BARE form"
+
+    with pytest.raises(ValueError) as exc:
+        db.draft_message(recipient=internal_id, body="should never be stored",
+                         self_number=SELF_NUMBER)
+
+    # The refusal must NAME THE FIX, or it is a dead end rather than a correction.
+    assert _group_address(GROUP_KEEP) in str(exc.value), (
+        f"the refusal does not tell the operator what to pass instead: {exc.value}")
+
+    # 🔴 And it must have written NOTHING. A refusal that already created the
+    # phantom is not a refusal.
+    assert db.conn.rows(
+        "SELECT count(*) AS n FROM signal.contacts "
+        "WHERE phone_number = ?", (internal_id,))[0]["n"] == 0, (
+        "the bare internal_id was stored as a contact's phone number — that IS "
+        "the phantom-contact defect")
+    assert db.conn.rows("SELECT count(*) AS n FROM signal.messages")[0]["n"] == 0
+    assert db.conn.rows("SELECT count(*) AS n FROM signal.groups")[0]["n"] == 0
+
+
+def test_a_bare_16_byte_GroupV1_internal_id_is_refused_too(db):
+    """The legacy id length is refused on the same footing — 16, not only 32.
+
+    A guard written for GroupV2 only would let the legacy form through into the
+    contact fallback, which is the same defect in a shape nobody tested.
+    """
+    with pytest.raises(ValueError):
+        db.draft_message(recipient=base64.b64encode(b"\x99" * 16).decode(),
+                         body="legacy", self_number=SELF_NUMBER)
+    assert db.conn.rows("SELECT count(*) AS n FROM signal.messages")[0]["n"] == 0
+
+
+@pytest.mark.parametrize("label,recipient", [
+    ("E.164 short", "+15550100"),
+    ("E.164 max length", "+123456789012345"),
+    ("uuid lower", "550e8400-e29b-41d4-a716-446655440000"),
+    ("uuid upper", "550E8400-E29B-41D4-A716-446655440000"),
+    ("signal username", "gyro.42"),
+    ("display name", "Team"),
+])
+def test_no_REAL_recipient_shape_is_mistaken_for_a_group_id(db, label, recipient):
+    """🔴 The blast radius of the refusal above, MEASURED rather than argued.
+
+    Refusing a whole input shape is only safe if no legitimate recipient can
+    land in it. The argument is that a Signal recipient is `+E164` or a uuid and
+    neither survives a canonical-base64 round-trip to 16 or 32 bytes — but that
+    is reasoning, and this is the measurement, at BOTH E.164 length extremes and
+    in both uuid cases. `Team` is here because it is valid base64 that decodes
+    to 3 bytes: it must be rejected by LENGTH, not by the alphabet.
+    """
+    assert not _signal_db._looks_like_bare_group_internal_id(recipient), (
+        f"{label} ({recipient!r}) would be refused as a group internal_id — "
+        f"the guard is too wide and has broken a legitimate recipient")
+    # …and it really does still draft, which the predicate alone cannot show.
+    draft = db.draft_message(recipient=recipient, body="ordinary recipient",
+                             self_number=SELF_NUMBER)
+    assert draft["dest_contact_id"] is not None
+    assert draft["group_id"] is None
+
+
 def test_the_SEND_recipient_is_derived_from_the_group_row_not_a_contact(db):
     """Criterion 3: what `send_approved()` hands `/v2/send` for a group draft.
 
@@ -1091,21 +1169,54 @@ def test_each_MUTE_PROBE_actually_calls_the_method_it_is_keyed_under(db):
             f"coverage at all.")
 
 
-def test_the_probe_pinning_guard_can_go_red():
-    """Negative control: the guard must reject a MIS-keyed probe.
+class _BlindRecordingReads(_RecordingReads):
+    """`_RecordingReads` with the recording removed — the BLINDING mutant.
 
-    Without this, the test above passing proves only that the current dict is
-    self-consistent — it would look identical if the proxy recorded nothing.
+    An audit produced exactly this: a proxy that still delegates, so every probe
+    returns real rows and every downstream assertion passes, while `called`
+    stays empty and the pinning test can no longer see anything.
     """
-    class _Fake:
-        called: list = []
 
-    spy = _RecordingReads.__new__(_RecordingReads)
-    spy._db = _Fake()
-    spy.called = ["search"]
-    assert spy.called != ["get_message"], (
-        "HARNESS BROKEN: a probe recorded as calling `search` compared equal to "
-        "the `get_message` expectation, so the pinning assertion cannot fail")
+    def __getattr__(self, name):                       # pragma: no cover - via test
+        return getattr(self._db, name)
+
+
+def test_the_probe_pinning_guard_can_go_red(db):
+    """🔴 Negative control that EXERCISES the recording path, not list equality.
+
+    The previous version of this test did `_RecordingReads.__new__`, hand-set
+    `spy.called = ["search"]`, and asserted `["search"] != ["get_message"]` — a
+    tautology about list comparison that never touched the proxy. Its docstring
+    claimed it ruled out "the proxy recorded nothing", which it structurally
+    could not: under an audit's BLINDING mutant, that control still PASSED while
+    the real pinning test went red. A negative control that cannot go red is
+    worse than none, because it stops anyone looking.
+
+    This runs the REAL probes through a blinded proxy and requires the pinning
+    assertion to become FALSE for every one of them.
+    """
+    db.upsert_group(group_id=GROUP_KEEP, name="")
+    draft = db.draft_message(recipient=_group_address(GROUP_KEEP),
+                             body="negative control fixture",
+                             self_number=SELF_NUMBER)
+
+    for name, probe in sorted(_MUTE_PROBES.items()):
+        blind = _BlindRecordingReads(db)
+        rows = probe(blind, draft, "negative control fixture")
+        # POSITIVE half: the probe still WORKS through the blind proxy, so the
+        # only thing this demonstrates is lost VISIBILITY, not a broken probe.
+        assert rows, (
+            f"the blinded proxy broke the {name} probe itself, so this control "
+            f"is measuring the wrong failure")
+        assert blind.called != [name], (
+            f"HARNESS BROKEN: the pinning assertion still holds for {name!r} "
+            f"against a proxy that records NOTHING — it is not reading `called` "
+            f"and would pass against any probe at all")
+
+    # …and the real proxy does record, or the two halves prove nothing together.
+    live = _RecordingReads(db)
+    _MUTE_PROBES["search"](live, draft, "negative control fixture")
+    assert live.called == ["search"], live.called
 
 
 def test_a_muted_group_draft_is_hidden_from_every_filtered_read(db):

--- a/scripts/signal/tests/test_group_exclusions.py
+++ b/scripts/signal/tests/test_group_exclusions.py
@@ -301,16 +301,30 @@ EXEMPT_READS = {
         "write: resolves a reaction's target message id",
     "apply_remote_delete":
         "write: blanks a deleted message's body",
-    # --- The DRAFT surface (D3). Drafts live in signal.messages with a NEGATIVE
-    # provisional timestamp and are addressed to a RECIPIENT, never a group, so
-    # `group_id` is NULL on every one of them and the predicate could only ever
-    # be a no-op. Filtering the compose/approve/send path by a mute list would
-    # also be wrong in principle: muting is about what you READ, and a draft is
-    # something you WROTE. 🔴 If drafting to a group is ever added, these move
-    # into FILTERED_READS — this test fails when that day comes only because the
-    # method set is pinned, so re-read this note then rather than trusting it.
-    "get_draft": "draft surface: drafts have no group_id",
-    "list_drafts": "draft surface: drafts have no group_id",
+    # --- The DRAFT surface (D3). 🔴 THAT DAY CAME. The note here used to read
+    # "drafts are addressed to a RECIPIENT, never a group, so `group_id` is NULL
+    # on every one of them", and said that if drafting to a group were ever added
+    # these move into FILTERED_READS. Drafting to a group IS now supported
+    # (`draft_message()` calls `upsert_group()` and sets `messages.group_id`), so
+    # that reason is dead and the exemption was RE-DERIVED rather than inherited:
+    #
+    #   * These three return ONLY rows with `send_state IS NOT NULL` — bodies the
+    #     OPERATOR composed. Muting is about what you READ; a draft is what you
+    #     WROTE. No third party's conversation can reach a caller through them.
+    #     (`test_get_draft_refuses_a_device_sync_ECHO_not_just_a_draft` is what
+    #     keeps that population claim true, and it is the reason this is not just
+    #     an assertion in prose.)
+    #   * Filtering them would be a live BUG, not merely conservative:
+    #     `approve_draft`, `send_approved` and `reconcile_send` all reach
+    #     `get_draft` through `_draft_or_raise`, so muting a group mid-flight
+    #     would strand its draft in `sending` and report "does not exist" — an
+    #     accidental extra refusal path through the D3 gate.
+    #
+    # The claim that DOES need measuring is that every FILTERED read hides a
+    # muted group's draft now that drafts can carry a group_id — see
+    # `test_a_muted_group_draft_is_hidden_from_every_filtered_read`.
+    "get_draft": "outbound surface: returns only bodies the operator composed",
+    "list_drafts": "outbound surface: returns only bodies the operator composed",
     "account_number": "draft surface: reads the sending account off a draft",
 }
 
@@ -393,19 +407,308 @@ def test_get_draft_refuses_a_device_sync_ECHO_not_just_a_draft(db):
     assert ids["mute"] is not None
 
 
-def test_a_draft_really_has_no_group_id(db):
-    """The draft surface's EXEMPTION, measured instead of asserted in prose.
+def test_a_DM_draft_still_has_no_group_id(db):
+    """A draft to a PERSON carries no group — the group linkage is not global.
 
-    `EXEMPT_READS` claims drafts carry no `group_id`, so the mute predicate on
-    them could only ever be a no-op. A comment is a claim like any other; this
-    reads the column. If drafting to a group is ever added, this goes red and
-    the exemption has to be revisited rather than inherited.
+    This used to be `test_a_draft_really_has_no_group_id` and carried the
+    exemption's whole reason. Group drafting has since been added, so the claim
+    it can honestly make is narrower: a DM draft is still ungrouped, which is
+    what stops `draft_message()`'s new branch from stamping a group onto every
+    outbound row. The mute-side claim moved to
+    `test_a_muted_group_draft_is_hidden_from_every_filtered_read`, where it is
+    measured against the reads rather than inferred from a NULL.
     """
     draft = db.draft_message(recipient="+15550009", body="drafted, never sent",
                              self_number="+15550000")
     rows = db.conn.rows("SELECT group_id FROM signal.messages WHERE id = ?",
                         (draft["id"],))
     assert rows and rows[0]["group_id"] is None
+
+
+# --------------------------------------------------------------------------- #
+# Drafting TO a group — the outbound path doing what the inbound path already did
+# --------------------------------------------------------------------------- #
+SELF_NUMBER = "+15550000"
+
+
+def _group_address(raw: bytes) -> str:
+    """The API's `id` field for a raw group id, built by the SAME rule as prod.
+
+    Built from `_signal_db._group_id_to_address` deliberately: a hand-rolled
+    double-b64 here would be a second encoder, and a test that carries its own
+    copy of the rule cannot fail when the shipped rule regresses. The ROUND-TRIP
+    against a literal is pinned separately, below, so this is not circular.
+    """
+    return _signal_db._group_id_to_address(raw)
+
+
+def test_the_group_address_encoding_round_trips_against_a_LITERAL():
+    """Non-circular anchor: the double encoding, spelled out once.
+
+    Every other group-draft test builds its address through
+    `_group_id_to_address`. If that function were wrong, those tests would all
+    agree with each other and with nothing else. This one pins the shape against
+    a literal computed the way the API documents it — `group.` + b64(b64(raw)) —
+    and pins the decode as its exact inverse.
+    """
+    raw = b"\x55" * 32
+    literal = "group." + base64.b64encode(base64.b64encode(raw)).decode()
+    assert _signal_db._group_id_to_address(raw) == literal
+    assert _signal_db._group_address_to_id(literal) == raw
+    # The shape the API actually emits, generated at module scope, decodes too.
+    assert _signal_db._group_address_to_id(GROUP_ID_FIELD_SHAPE) == b"\x44" * 32
+
+
+def test_a_group_draft_is_LINKED_to_the_group_row_not_a_contact(db):
+    """Criterion 1 + 2: `group_id` set, `dest_contact_id` NULL, no phantom contact.
+
+    The defect: `draft_message` never named `group_id` and resolved ANY recipient
+    through `upsert_contact`, so a group draft stored `group_id = NULL` AND
+    minted a fake person whose `phone_number` was the group address.
+    """
+    group_row = db.upsert_group(group_id=GROUP_KEEP, name="")
+    before = db.conn.rows(
+        "SELECT count(*) AS n FROM signal.contacts "
+        "WHERE phone_number LIKE 'group.%'")[0]["n"]
+
+    draft = db.draft_message(recipient=_group_address(GROUP_KEEP),
+                             body="pool car is booked", self_number=SELF_NUMBER)
+
+    row = db.conn.rows(
+        "SELECT group_id, dest_contact_id FROM signal.messages WHERE id = ?",
+        (draft["id"],))[0]
+    assert row["group_id"] == group_row, (
+        "the draft is not linked to the group row the inbound path uses — "
+        "`_muted_predicate` keys on m.group_id and cannot see it")
+    assert row["dest_contact_id"] is None, (
+        "a group draft addressed a CONTACT; the phantom-contact defect is back")
+    after = db.conn.rows(
+        "SELECT count(*) AS n FROM signal.contacts "
+        "WHERE phone_number LIKE 'group.%'")[0]["n"]
+    assert after == before, (
+        f"drafting to a group created {after - before} phantom contact(s) — a "
+        f"fake person whose phone_number is a group address")
+    assert draft["group_id"] == group_row, "the returned dict must say so too"
+
+
+def test_drafting_to_an_UNSEEN_group_creates_it_rather_than_refusing(db):
+    """Criterion 1's second half: `upsert_group`, not a lookup that refuses.
+
+    A group can be drafted to before its first message has been ingested (the
+    pipeline is forward-only). Refusing would make that group undraftable; the
+    inbound path creates the row the same way.
+    """
+    assert db.conn.rows("SELECT count(*) AS n FROM signal.groups")[0]["n"] == 0
+
+    draft = db.draft_message(recipient=_group_address(GROUP_UNSEEN),
+                             body="first thing ever said here",
+                             self_number=SELF_NUMBER)
+
+    groups = db.conn.rows("SELECT id, group_id FROM signal.groups")
+    assert len(groups) == 1, groups
+    assert bytes(groups[0]["group_id"]) == GROUP_UNSEEN
+    assert draft["group_id"] == groups[0]["id"]
+
+
+@pytest.mark.parametrize("bad", [
+    "group.",                       # prefix and nothing else
+    "group.not!base64",             # not base64 at all
+    "group." + base64.b64encode(b"Team").decode(),          # a DISPLAY NAME
+    "group." + base64.b64encode(
+        base64.b64encode(b"\x77" * 7)).decode(),            # 7 bytes: not 16/32
+])
+def test_a_MALFORMED_group_address_is_refused_and_stores_nothing(db, bad):
+    """A bad address must not become a group, a contact, or a draft.
+
+    🔴 The failure mode this forbids is the one the old code had in a new shape:
+    `upsert_contact(phone_number=<garbage>)` succeeded for ANYTHING, so a typo
+    produced a draft that reported success and could never be delivered. The
+    strict decoder refuses instead — and the assertions below check the STORE,
+    not just the exception, because a refusal that has already written a row is
+    not a refusal.
+    """
+    with pytest.raises(ValueError):
+        db.draft_message(recipient=bad, body="should never be stored",
+                         self_number=SELF_NUMBER)
+    assert db.conn.rows("SELECT count(*) AS n FROM signal.groups")[0]["n"] == 0
+    assert db.conn.rows("SELECT count(*) AS n FROM signal.messages")[0]["n"] == 0
+    assert db.conn.rows(
+        "SELECT count(*) AS n FROM signal.contacts "
+        "WHERE phone_number LIKE 'group.%'")[0]["n"] == 0
+
+
+def test_the_SEND_recipient_is_derived_from_the_group_row_not_a_contact(db):
+    """Criterion 3: what `send_approved()` hands `/v2/send` for a group draft.
+
+    The phantom contact was LOAD-BEARING — `get_draft`'s `CASE … END AS
+    recipient` read the address back out of it. This is the rewiring that let it
+    be deleted, so it is asserted on the value the send path actually uses, and
+    with the contacts table proven empty of any group-addressed row so the
+    string cannot have come from one.
+    """
+    address = _group_address(GROUP_KEEP)
+    draft = db.draft_message(recipient=address, body="see you at 6",
+                             self_number=SELF_NUMBER)
+
+    read_back = db.get_draft(draft["id"])
+    assert read_back["recipient"] == address, (
+        f"the send path would address {read_back['recipient']!r}, not the group")
+    assert db.conn.rows(
+        "SELECT count(*) AS n FROM signal.contacts "
+        "WHERE phone_number LIKE 'group.%'")[0]["n"] == 0, (
+        "the recipient could have come from a phantom contact — this test would "
+        "then prove nothing about the derivation")
+    # The raw BYTEA id must NOT escape: the CLI json.dumps()es this dict.
+    assert "group_signal_id" not in read_back
+    import json
+    json.dumps(read_back, default=str)
+
+
+def test_send_and_reconcile_work_END_TO_END_on_a_group_draft(db, monkeypatch):
+    """Criterion 3: the whole D3 path, on a group draft, with the wire captured.
+
+    Not "get_draft returns the right string" — the actual approve → send →
+    (strand) → reconcile sequence, asserting the recipient that reached the
+    transport.
+    """
+    address = _group_address(GROUP_MUTE)      # distinct from every other case
+    draft = db.draft_message(recipient=address, body="ride at seven",
+                             self_number=SELF_NUMBER)
+    db.approve_draft(draft["id"], approval_ref="clawgate/1")
+
+    seen = {}
+
+    def fake_transmit(auth, *, recipient, body, number):
+        seen.update(recipient=recipient, body=body, number=number,
+                    draft_id=auth.draft_id)
+        return [{"timestamp": "1787331796630"}]
+
+    out = db.send_approved(draft["id"], transmit=fake_transmit)
+    assert seen["recipient"] == address, seen
+    assert seen["number"] == SELF_NUMBER, (
+        "account_number() must still read the SENDING contact, which a group "
+        "draft still has")
+    assert out["send_state"] == "sent"
+    assert out["message_timestamp"] == 1787331796630
+    assert out["recipient"] == address
+
+    # …and reconcile, on a SECOND group draft stranded in `sending`.
+    other = db.draft_message(recipient=address, body="actually eight",
+                             self_number=SELF_NUMBER)
+    db.approve_draft(other["id"], approval_ref="clawgate/2")
+
+    def explode(auth, *, recipient, body, number):
+        raise RuntimeError("pod killed after the POST")
+
+    with pytest.raises(RuntimeError):
+        db.send_approved(other["id"], transmit=explode)
+    assert db.get_draft(other["id"])["send_state"] == "sending"
+    done = db.reconcile_send(other["id"], outcome="sent",
+                             server_timestamp=1787331799999)
+    assert done["send_state"] == "sent"
+    assert done["recipient"] == address
+
+
+def test_a_muted_group_draft_is_hidden_from_every_filtered_read(db):
+    """🔴 CRITERION 4 — the sharp one. Mute must not be bypassable by drafting.
+
+    `_muted_predicate` keys on `m.group_id`. With `group_id` NULL on every draft
+    the predicate matched nothing, so a draft to a MUTED group came back in full
+    from every read that believed it was filtering. Mute is the privacy control
+    here.
+
+    This walks the FILTERED_READS ledger rather than naming three methods, so a
+    read surface added to that set later is covered the day it is added — a
+    hand-written list here would silently stop being the whole set.
+
+    Each read gets a POSITIVE CONTROL first: it must SEE the draft before the
+    mute. Without that, "hidden" is indistinguishable from a query wired to
+    nothing, and this whole test would pass against a `draft_message` that
+    stored no row at all.
+    """
+    assert FILTERED_READS == {"list_conversations", "search", "get_message"}, (
+        "the filtered-read set moved; extend the probes below to match rather "
+        f"than letting this test cover less than it claims: {FILTERED_READS}")
+
+    db.upsert_group(group_id=GROUP_MUTE, name="")
+    body = "quarterly kestrel rendezvous"          # distinct from every _seed body
+    draft = db.draft_message(recipient=_group_address(GROUP_MUTE), body=body,
+                             self_number=SELF_NUMBER)
+
+    # 🔴 EVERY probe identifies the DRAFT, never the group row. Keying
+    # `list_conversations` on `group_row_id` looked equivalent and was not: on
+    # the BROKEN code the draft lands in the phantom contact's DM thread, so
+    # that probe returned [] before the mute and this test failed on its own
+    # positive control — reporting "the harness is blind" where the real finding
+    # is "the mute was bypassed". The provisional timestamp is negative and
+    # unique to this draft, so it names whichever conversation the row landed
+    # in, in both worlds.
+    #
+    # 🔴 Its ONE precondition, asserted rather than assumed: this draft must be
+    # the newest message in whatever conversation it lands in, because
+    # `list_conversations` reports `max(message_timestamp)` per conversation and
+    # a draft's provisional timestamp is NEGATIVE — so any real (positive) server
+    # timestamp in the same group would win the max and the probe would go blind.
+    # Measured on real Postgres while writing this: a second, already-sent draft
+    # in the same group made this probe report 0 before the mute.
+    assert db.conn.rows(
+        "SELECT count(*) AS n FROM signal.messages")[0]["n"] == 1, (
+        "the probe below reads max(message_timestamp) per conversation and this "
+        "draft's is NEGATIVE — another message in this group would mask it")
+
+    def probe() -> dict:
+        ts = draft["message_timestamp"]
+        return {
+            "list_conversations": [r for r in db.list_conversations()
+                                   if r["last_message_timestamp"] == ts],
+            "search": [r for r in db.search(body) if r["id"] == draft["id"]],
+            "get_message": [r for r in [db.get_message(draft["id"])] if r],
+        }
+
+    before = probe()
+    for name, rows in before.items():
+        assert rows, (
+            f"POSITIVE CONTROL FAILED: {name} cannot see the group draft even "
+            f"BEFORE the mute, so its 'hidden' assertion below would be vacuous")
+
+    db.exclude_group(GROUP_MUTE, note="muted by the operator")
+
+    after = probe()
+    for name, rows in after.items():
+        assert rows == [], (
+            f"MUTE BYPASSED: {name} returned a draft to a MUTED group "
+            f"({len(rows)} row(s)). `not_excluded()` keys on m.group_id, so a "
+            f"draft stored with group_id NULL walks straight through it.")
+
+    # Muting HIDES; it must not have deleted the operator's own draft, and the
+    # outbound surface (exempt, deliberately) must still reach it.
+    assert db.conn.rows("SELECT count(*) AS n FROM signal.messages "
+                        "WHERE id = ?", (draft["id"],))[0]["n"] == 1
+    assert db.get_draft(draft["id"])["body"] == body
+
+
+def test_group_drafts_appear_in_the_GROUP_conversation_not_a_phantom_DM(db):
+    """Criterion 2's other consequence: the conversation reads two-sided.
+
+    With `group_id` NULL the draft grouped by `dest_contact_id` — the phantom —
+    so the group thread showed inbound messages only and a fake one-person DM
+    appeared beside it.
+    """
+    ids = _seed(db)
+    keep_row = ids["_rows"]["keep"]
+    before = {r["group_row_id"]: r["message_count"]
+              for r in db.list_conversations()}
+
+    db.draft_message(recipient=_group_address(GROUP_KEEP), body="on my way",
+                     self_number=SELF_NUMBER)
+
+    after = {r["group_row_id"]: r["message_count"]
+             for r in db.list_conversations()}
+    assert after[keep_row] == before[keep_row] + 1, (
+        "the group conversation did not count our own outbound message")
+    assert set(after) == set(before), (
+        f"a NEW conversation appeared for a group draft — that is the phantom "
+        f"contact's DM thread: {set(after) - set(before)}")
 
 
 def test_the_ledger_would_notice_an_unfiltered_read():

--- a/scripts/signal/tests/test_group_exclusions.py
+++ b/scripts/signal/tests/test_group_exclusions.py
@@ -22,7 +22,9 @@ import ast
 import base64
 import inspect
 import re
+import sys
 import textwrap
+import types
 
 import pytest
 
@@ -792,6 +794,60 @@ def test_a_group_draft_is_LINKED_to_the_group_row_not_a_contact(db):
     assert draft["group_id"] == group_row, "the returned dict must say so too"
 
 
+def test_drafting_to_an_UNSEEN_group_WARNS_loudly_on_stderr(db, capsys):
+    """🔴 A canonically-encoded but WRONG id cannot be validated — so SAY SO.
+
+    The strict decoder rejects a MALFORMED address. It cannot reject a wrong
+    one: any well-formed 32 bytes decodes perfectly, `upsert_group` mints a
+    group nobody is in, and the send goes nowhere while reporting success. That
+    is the silent-zero shape `mute` was hardened against (it EXITS 4 rather than
+    report a mute that hides nothing).
+
+    A WARNING, not a refusal: drafting to a not-yet-ingested group is legitimate
+    on a forward-only pipeline, and refusing would make that group undraftable.
+    """
+    capsys.readouterr()                       # discard anything already buffered
+    draft = db.draft_message(recipient=_group_address(GROUP_UNSEEN),
+                             body="into the void?", self_number=SELF_NUMBER)
+    err = capsys.readouterr().err
+    assert "WARNING" in err and "matched NO stored group" in err, (
+        f"drafting to an unseen group said nothing on stderr: {err!r}")
+    assert _group_address(GROUP_UNSEEN) in err, (
+        "the warning must name the offending address, or the operator cannot "
+        "tell WHICH draft it is about")
+    assert draft["group_created"] is True, (
+        "the returned dict must also report it, so a programmatic caller that "
+        "never reads stderr can still branch on it")
+
+
+def test_drafting_to_a_KNOWN_group_is_SILENT(db, capsys):
+    """The other half — without this, a warning printed unconditionally passes.
+
+    🔴 This is the control that makes the warning INFORMATIVE rather than
+    decorative: a warning on every draft is one an operator learns to ignore,
+    which is indistinguishable from no warning at all.
+    """
+    db.upsert_group(group_id=GROUP_KEEP, name="")
+    capsys.readouterr()
+    draft = db.draft_message(recipient=_group_address(GROUP_KEEP),
+                             body="into a real conversation",
+                             self_number=SELF_NUMBER)
+    err = capsys.readouterr().err
+    assert err == "", (
+        f"drafting to a group that IS stored warned anyway: {err!r}. A warning "
+        f"that fires every time carries no information.")
+    assert draft["group_created"] is False
+
+
+def test_a_DM_draft_never_reports_group_created(db, capsys):
+    """A person is not a group — the flag must not leak into the DM path."""
+    capsys.readouterr()
+    draft = db.draft_message(recipient="+15550111", body="hello",
+                             self_number=SELF_NUMBER)
+    assert draft["group_created"] is False
+    assert capsys.readouterr().err == ""
+
+
 def test_drafting_to_an_UNSEEN_group_creates_it_rather_than_refusing(db):
     """Criterion 1's second half: `upsert_group`, not a lookup that refuses.
 
@@ -836,6 +892,54 @@ def test_a_MALFORMED_group_address_is_refused_and_stores_nothing(db, bad):
     assert db.conn.rows(
         "SELECT count(*) AS n FROM signal.contacts "
         "WHERE phone_number LIKE 'group.%'")[0]["n"] == 0
+
+
+def _cli(monkeypatch, db, argv):
+    """Run `consumer.main(argv)` against the hermetic db. Returns the exit code."""
+    class _Ctx:
+        def __enter__(self_inner):
+            return db
+
+        def __exit__(self_inner, *exc):
+            return False
+
+    monkeypatch.setattr(consumer, "SignalDB", lambda *a, **kw: _Ctx())
+    monkeypatch.setattr(db, "ensure_schema", lambda *a, **kw: None, raising=False)
+    return consumer.main(argv)
+
+
+def test_draft_REFUSES_a_bad_recipient_with_exit_3_like_its_siblings(
+        db, monkeypatch, capsys):
+    """🟢 Consistency: a refused `draft` must exit like a refused `mute`/`send`.
+
+    `mute` catches ValueError and `send`/`reconcile` catch SendGateError, both
+    printing `refused: …` and exiting 3. The `draft` branch alone let a bad
+    `--to` escape as an uncaught traceback and exit 1 — indistinguishable, to a
+    caller, from the interpreter dying for an unrelated reason.
+    """
+    rc = _cli(monkeypatch, db,
+              ["draft", "--to", "group.not!base64", "--body", "x",
+               "--from-number", SELF_NUMBER])
+    err = capsys.readouterr().err
+    assert rc == 3, f"expected exit 3 like `mute`/`send`, got {rc}"
+    assert err.startswith("refused: "), err
+    assert "group.not!base64" in err, (
+        "the refusal must name the offending address")
+    # …and nothing was written on the way out.
+    assert db.conn.rows("SELECT count(*) AS n FROM signal.messages")[0]["n"] == 0
+
+
+def test_draft_does_NOT_exit_3_on_a_GOOD_recipient(db, monkeypatch, capsys):
+    """Positive control — without it, `return 3` unconditionally would pass."""
+    stub = types.ModuleType("clawgate")
+    stub.emit_draft_task = lambda **kw: None
+    monkeypatch.setitem(sys.modules, "clawgate", stub)
+
+    rc = _cli(monkeypatch, db,
+              ["draft", "--to", _group_address(GROUP_KEEP), "--body", "hi",
+               "--from-number", SELF_NUMBER])
+    assert rc != 3, capsys.readouterr()
+    assert db.conn.rows("SELECT count(*) AS n FROM signal.messages")[0]["n"] == 1
 
 
 def test_the_SEND_recipient_is_derived_from_the_group_row_not_a_contact(db):
@@ -914,6 +1018,17 @@ def test_send_and_reconcile_work_END_TO_END_on_a_group_draft(db, monkeypatch):
 # set can be compared against the ledger instead of trusted. Each returns the
 # rows that read surfaces FOR THIS DRAFT — so an empty list means "hidden", and a
 # non-empty one before the mute is the positive control.
+#
+# 🔴 THE KEY IS NOT THE PROBE. `set(_MUTE_PROBES) == FILTERED_READS` is invariant
+# under SWAPPING TWO BODIES — an audit did exactly that (gave `get_message` the
+# `search` probe's body and vice versa) and the whole suite stayed green, 650
+# passed, while `get_message` had no behavioural coverage of a group draft at
+# all. It is the same set-invariant-under-a-swap shape already fixed once for the
+# two ledgers, and deleting a KEY (the half the old mutant covered) was never the
+# dangerous direction. `test_each_MUTE_PROBE_actually_calls_the_method_it_is_keyed_under`
+# closes it by RUNNING each probe against a recording proxy and asserting which
+# read it actually reached — a source-text check would be walked by a probe that
+# names the method in a comment.
 _MUTE_PROBES = {
     "list_conversations": lambda db, draft, body: [
         r for r in db.list_conversations()
@@ -923,6 +1038,74 @@ _MUTE_PROBES = {
     "get_message": lambda db, draft, body: [
         r for r in [db.get_message(draft["id"])] if r],
 }
+
+
+class _RecordingReads:
+    """Proxy over a real `SignalDB` that records WHICH filtered read was called.
+
+    Everything is delegated, so the probe runs for real and its return value is
+    genuine — this records, it does not stub. Only the names in
+    `FILTERED_READS` are recorded, because those are the ones a probe is
+    supposed to be pinned to.
+    """
+
+    def __init__(self, db):
+        self._db = db
+        self.called: list = []
+
+    def __getattr__(self, name):
+        attr = getattr(self._db, name)
+        if name in FILTERED_READS and callable(attr):
+            def recording(*a, **kw):
+                self.called.append(name)
+                return attr(*a, **kw)
+            return recording
+        return attr
+
+
+def test_each_MUTE_PROBE_actually_calls_the_method_it_is_keyed_under(db):
+    """🔴 The probe must EXERCISE the read it is filed under, not just be filed.
+
+    An audit swapped the `get_message` and `search` probe bodies and the suite
+    stayed fully green (650 passed, 0 failed): `set(_MUTE_PROBES) ==
+    FILTERED_READS` cannot see a swap, and the mute test's own assertions pass
+    as long as SOMETHING hides. `get_message` silently lost all behavioural
+    coverage of a group draft.
+
+    So each probe is RUN against a recording proxy and must reach exactly the
+    method its key names — measured, not read off the source text (a probe that
+    merely mentions `db.get_message` in a comment would satisfy a grep).
+    """
+    db.upsert_group(group_id=GROUP_KEEP, name="")
+    draft = db.draft_message(recipient=_group_address(GROUP_KEEP),
+                             body="probe pinning fixture", self_number=SELF_NUMBER)
+
+    for name, probe in sorted(_MUTE_PROBES.items()):
+        spy = _RecordingReads(db)
+        probe(spy, draft, "probe pinning fixture")
+        assert spy.called == [name], (
+            f"_MUTE_PROBES[{name!r}] exercised {spy.called or 'NO filtered read'} "
+            f"instead of exactly [{name!r}]. The dict key claims coverage of "
+            f"SignalDB.{name}; swapping two probe bodies leaves the key set "
+            f"identical, so that method would silently have no behavioural "
+            f"coverage at all.")
+
+
+def test_the_probe_pinning_guard_can_go_red():
+    """Negative control: the guard must reject a MIS-keyed probe.
+
+    Without this, the test above passing proves only that the current dict is
+    self-consistent — it would look identical if the proxy recorded nothing.
+    """
+    class _Fake:
+        called: list = []
+
+    spy = _RecordingReads.__new__(_RecordingReads)
+    spy._db = _Fake()
+    spy.called = ["search"]
+    assert spy.called != ["get_message"], (
+        "HARNESS BROKEN: a probe recorded as calling `search` compared equal to "
+        "the `get_message` expectation, so the pinning assertion cannot fail")
 
 
 def test_a_muted_group_draft_is_hidden_from_every_filtered_read(db):
@@ -942,7 +1125,12 @@ def test_a_muted_group_draft_is_hidden_from_every_filtered_read(db):
 
     `_MUTE_PROBES` is keyed by method name and asserted equal to FILTERED_READS
     below, so a read surface added to that ledger without a behavioural probe
-    fails HERE rather than being quietly uncovered.
+    fails HERE rather than being quietly uncovered. 🔴 That assertion covers the
+    KEY SET only — it is invariant under swapping two probe BODIES, which an
+    audit demonstrated with a fully green suite.
+    `test_each_MUTE_PROBE_actually_calls_the_method_it_is_keyed_under` is the
+    other half, and the implication in the paragraph above holds only because
+    BOTH exist.
 
     Each read gets a POSITIVE CONTROL first: it must SEE the draft before the
     mute. Without that, "hidden" is indistinguishable from a query wired to
@@ -1247,10 +1435,20 @@ def test_the_mute_table_is_in_the_schema_and_survives_translation():
 
 
 def test_the_mute_table_is_keyed_on_the_binary_id_not_the_name():
-    """`signal.groups.name` is EMPTY for every group this consumer has stored.
+    """The mute list keys on the binary group id, never on a NAME.
 
-    A name-keyed mute would match nothing while looking like a working filter,
-    which is the exact shape of a silent zero.
+    🔴 RETRACTED REASON (2026-08-21). This docstring used to open with
+    "`signal.groups.name` is EMPTY for every group this consumer has stored",
+    and rest the whole argument on it. That is FALSE: `upsert_group()` persists
+    the envelope's `groupName`, `test_a_stored_group_keeps_the_name_the_envelope_carried`
+    two functions below pins exactly that, and the live store has populated
+    names. The claim was already disproved by its own file.
+
+    The advice survives on a reason that does not decay: a NAME IS NOT AN
+    IDENTITY. Any member can rename a group at any time, two groups can share a
+    name, and the stored value is only as fresh as the last envelope that
+    carried one — so a name-keyed mute silently stops hiding the moment someone
+    renames the conversation. The binary id never changes.
     """
     ddl = next(s for s in _signal_db.SCHEMA_STATEMENTS
                if "excluded_groups" in s and "CREATE TABLE" in s)

--- a/scripts/signal/tests/test_group_exclusions.py
+++ b/scripts/signal/tests/test_group_exclusions.py
@@ -18,9 +18,11 @@ argument, and a behavioural check alone cannot see a NEW method that skipped it.
 """
 from __future__ import annotations
 
+import ast
 import base64
 import inspect
 import re
+import textwrap
 
 import pytest
 
@@ -282,101 +284,400 @@ def test_the_predicate_is_composable_with_AND():
 
 
 # --------------------------------------------------------------------------- #
-# 🔴 THE LEDGER — fails when the set of message-reading surfaces GROWS or SHRINKS
+# 🔴 THE LEDGER — two sets that must PARTITION every read of signal.messages
 # --------------------------------------------------------------------------- #
-# Every method here reads `signal.messages` and returns rows to a caller. Each
-# must either apply `not_excluded()` or be listed as EXEMPT with a reason. This
-# is the seam guard: the behavioural cases above can only see the surfaces that
-# existed when they were written, and a new read method that skipped the filter
-# is exactly the failure this pipeline has already shipped once (the sync
-# reaction branch, added without the guards its inbound twin already had).
+# Every method that reads `signal.messages` must either apply `not_excluded()`
+# or be listed as EXEMPT with a reason — in EXACTLY ONE of the two sets below,
+# never both, never neither. This is the seam guard: the behavioural cases above
+# can only see the surfaces that existed when they were written, and a new read
+# method that skipped the filter is exactly the failure this pipeline has already
+# shipped once (the sync reaction branch, added without the guards its inbound
+# twin already had).
+#
+# 🔴 WHY A PARTITION AND NOT A UNION. The earlier version asserted only
+# `found == FILTERED_READS | EXEMPT_READS`. That is HALF A GUARD: a method MOVED
+# from one set to the other leaves the union identical, so re-classifying
+# `get_message` as exempt — turning the mute off for it — was a green change.
+# The partition below is checked against what the CODE does (an AST scan for a
+# real call to `not_excluded`), so the ledger cannot disagree with the
+# implementation in either direction.
 FILTERED_READS = {"list_conversations", "search", "get_message"}
 
+# 🔴 THE REASON LIVES HERE, AT THE POINT OF DECISION — not in a comment
+# elsewhere that can rot on its own. This ledger's justification has ALREADY gone
+# stale once: it read "drafts have no group_id", which was true until
+# `draft_message()` learned to address a group, and had to be re-derived after
+# the fact. Everything a reviewer needs to re-litigate an exemption is in the
+# string beside it.
 EXEMPT_READS = {
-    # Counts what a mute is hiding — it must see muted rows, that is its job.
     "list_excluded_groups":
-        "reports the hidden count; filtering it would always print 0",
+        "Counts what a mute is HIDING — it must see muted rows, that is its "
+        "entire job. Filtering it would make every mute report 0 hidden "
+        "messages, which is the number `consumer.py mute` refuses to print.",
     # --- WRITES that name signal.messages in a subquery, not read surfaces.
     "upsert_reaction":
-        "write: resolves a reaction's target message id",
+        "WRITE, not a read surface: the SELECT resolves a reaction's target "
+        "message id. It returns no body to any caller.",
     "apply_remote_delete":
-        "write: blanks a deleted message's body",
-    # --- The DRAFT surface (D3). 🔴 THAT DAY CAME. The note here used to read
-    # "drafts are addressed to a RECIPIENT, never a group, so `group_id` is NULL
-    # on every one of them", and said that if drafting to a group were ever added
-    # these move into FILTERED_READS. Drafting to a group IS now supported
-    # (`draft_message()` calls `upsert_group()` and sets `messages.group_id`), so
-    # that reason is dead and the exemption was RE-DERIVED rather than inherited:
-    #
-    #   * These three return ONLY rows with `send_state IS NOT NULL` — bodies the
-    #     OPERATOR composed. Muting is about what you READ; a draft is what you
-    #     WROTE. No third party's conversation can reach a caller through them.
-    #     (`test_get_draft_refuses_a_device_sync_ECHO_not_just_a_draft` is what
-    #     keeps that population claim true, and it is the reason this is not just
-    #     an assertion in prose.)
-    #   * Filtering them would be a live BUG, not merely conservative:
-    #     `approve_draft`, `send_approved` and `reconcile_send` all reach
-    #     `get_draft` through `_draft_or_raise`, so muting a group mid-flight
-    #     would strand its draft in `sending` and report "does not exist" — an
-    #     accidental extra refusal path through the D3 gate.
-    #
-    # The claim that DOES need measuring is that every FILTERED read hides a
-    # muted group's draft now that drafts can carry a group_id — see
-    # `test_a_muted_group_draft_is_hidden_from_every_filtered_read`.
-    "get_draft": "outbound surface: returns only bodies the operator composed",
-    "list_drafts": "outbound surface: returns only bodies the operator composed",
-    "account_number": "draft surface: reads the sending account off a draft",
+        "WRITE, not a read surface: the SELECT scopes which rows to tombstone. "
+        "It returns a rowcount, never content.",
+    # --- The DRAFT / outbound surface (D3).
+    "get_draft":
+        "OUTBOUND surface (D3). Two independent reasons, both re-derived after "
+        "the previous reason ('drafts have no group_id') was falsified by group "
+        "drafting. (1) POPULATION: `send_state IS NOT NULL` restricts it to rows "
+        "the OPERATOR composed — muting is about what you READ, a draft is what "
+        "you WROTE, and no third party's words can reach a caller through it. "
+        "That predicate is load-bearing, not incidental: without it `is_outbound` "
+        "alone also matched every device-sync ECHO, which DOES carry another "
+        "person's body — pinned by "
+        "test_get_draft_refuses_a_device_sync_ECHO_not_just_a_draft and by "
+        "test_the_draft_exemptions_PREMISE_is_still_in_the_code. (2) FILTERING "
+        "IT WOULD BE A LIVE BUG: approve_draft, send_approved and reconcile_send "
+        "all reach it through _draft_or_raise, so a mute landing mid-flight "
+        "would strand that draft in 'sending' with no route out and report it as "
+        "'does not exist' — an undesigned extra refusal path through the D3 "
+        "approval gate.",
+    "list_drafts":
+        "OUTBOUND surface (D3), same two reasons as get_draft: `send_state IS "
+        "NOT NULL` restricts it to the operator's own composed rows, and "
+        "filtering the compose/approve/send path would hide a draft the operator "
+        "still has to resolve.",
+    "account_number":
+        "Returns the SENDING account's phone number for a draft — no message "
+        "content at all, so there is nothing for a mute to hide. Pinned by "
+        "test_the_draft_exemptions_PREMISE_is_still_in_the_code, which fails if "
+        "this ever starts selecting a body.",
 }
 
+# The subset of EXEMPT_READS whose exemption rests on the `send_state IS NOT
+# NULL` population claim. Named here so the premise can be pinned structurally
+# rather than trusted from the prose above.
+_POPULATION_CLAIM_READS = {"get_draft", "list_drafts"}
 
-def _read_methods_touching_messages() -> set[str]:
-    """Methods whose body SELECTs from `signal.messages`.
 
-    🔴 SCOPE, stated because this guard is SPELLED rather than structural and
-    the difference matters. It greps the method's own source text, so it detects
-    exactly one shape: SQL written inline, naming `signal.messages`, in a method
-    defined directly on `SignalDB`. Measured evasions — all four confirmed to
-    slip past it: SQL held in a module-level constant; `SET search_path` plus an
+# --------------------------------------------------------------------------- #
+# Discovery — over the AST, never over raw source text
+# --------------------------------------------------------------------------- #
+def _method_tree(fn):
+    """The parsed `FunctionDef` for a method, or None if it has no source."""
+    try:
+        src = inspect.getsource(fn)
+    except (OSError, TypeError):            # pragma: no cover - defensive
+        return None
+    try:
+        return ast.parse(textwrap.dedent(src)).body[0]
+    except (SyntaxError, IndexError):       # pragma: no cover - defensive
+        return None
+
+
+def _docstring_node(node):
+    """The method's docstring Constant NODE, or None."""
+    first = node.body[0] if node.body else None
+    if (isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)):
+        return first.value
+    return None
+
+
+def _sql_strings(node) -> list:
+    """Every string literal in a method EXCEPT its docstring.
+
+    🔴 The docstring is excluded on purpose. These methods' docstrings DISCUSS
+    the schema and the mute predicate at length — that is prose, not SQL, and
+    reading it as either is how a guard certifies the opposite of the truth.
+
+    🔴 EXCLUDED BY NODE IDENTITY, not by comparing the string. The first version
+    of this function did `n.value != ast.get_docstring(node)` — and
+    `ast.get_docstring()` CLEANS (dedents) what it returns, so the comparison
+    only ever matched a SINGLE-LINE docstring. Every multi-line docstring in the
+    module was therefore still being read as SQL, which is the exact confusion
+    this helper exists to prevent. Measured: a mutant that deleted
+    `send_state IS NOT NULL` from `get_draft`'s SQL left
+    `test_the_draft_exemptions_PREMISE_is_still_in_the_code` GREEN, because the
+    docstring above that SQL also contains the phrase.
+    """
+    doc = _docstring_node(node)
+    return [n.value for n in ast.walk(node)
+            if isinstance(n, ast.Constant) and isinstance(n.value, str)
+            and n is not doc]
+
+
+def _reads_messages(fn) -> bool:
+    node = _method_tree(fn)
+    if node is None:
+        return False
+    strings = _sql_strings(node)
+    return (any("signal.messages" in s for s in strings)
+            and any(re.search(r"\bSELECT\b", s, re.IGNORECASE) for s in strings))
+
+
+def _calls_the_mute_predicate(fn) -> bool:
+    """True iff the method REALLY CALLS `not_excluded(...)`.
+
+    🔴 AST, not a substring search, and this is not fastidiousness — the
+    substring version was WRONG on the shipped code. `SignalDB.get_draft` does
+    not filter, and must not, but its docstring explains the mute predicate and
+    contains the characters `not_excluded(`. The old guard therefore reported
+    get_draft as filtered; had anyone moved it into FILTERED_READS the suite
+    would have stayed green while the method filtered nothing. A guard SPELLED
+    over source text is satisfiable by PROSE. A call node is not.
+
+    (f-strings are covered: `f"... {not_excluded('m')}"` parses to a
+    `FormattedValue` wrapping a real `Call`, which `ast.walk` reaches.)
+    """
+    node = _method_tree(fn)
+    if node is None:
+        return False
+    return any(isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+               and n.func.id == "not_excluded" for n in ast.walk(node))
+
+
+def _read_methods_touching_messages(cls=None) -> set[str]:
+    """Methods on `cls` whose SQL SELECTs from `signal.messages`.
+
+    🔴 SCOPE, stated because this discovery is still SHAPE-BASED and the
+    difference matters. It parses the method's own source, so it detects exactly
+    one shape: SQL written as a literal naming `signal.messages`, in a method
+    defined directly on the class. Measured evasions — all confirmed to slip
+    past it: SQL held in a module-level constant; `SET search_path` plus an
     unqualified `FROM messages`; delegation to a module-level helper; a method
-    inherited from a mixin (absent from `vars(SignalDB)`). It also FALSE-positives
-    on a method whose comment merely names both tokens.
+    inherited from a mixin (absent from `vars(cls)`).
+
+    What it no longer does is FALSE-POSITIVE on prose: the docstring is excluded,
+    so a method that merely discusses the schema is not counted as reading it.
 
     So this catches the copy-paste shape — which is how every read method here
     was actually written, and how the next one will be — and it is not a proof
     of completeness. Claim it as the former.
     """
-    found = set()
-    for name, fn in vars(SignalDB).items():
-        if not callable(fn) or name.startswith("__"):
-            continue
-        try:
-            src = inspect.getsource(fn)
-        except (OSError, TypeError):        # pragma: no cover - defensive
-            continue
-        if re.search(r"\bSELECT\b", src, re.IGNORECASE) and "signal.messages" in src:
-            found.add(name)
-    return found
+    cls = cls or SignalDB
+    return {name for name, fn in vars(cls).items()
+            if callable(fn) and not name.startswith("__") and _reads_messages(fn)}
 
 
-def test_the_ledger_of_message_reads_is_pinned_both_ways():
+def _filtered_by_the_code(cls=None) -> set[str]:
+    cls = cls or SignalDB
+    return {n for n in _read_methods_touching_messages(cls)
+            if _calls_the_mute_predicate(getattr(cls, n))}
+
+
+# --------------------------------------------------------------------------- #
+# Controls for the discovery itself — synthetic surfaces, never called
+# --------------------------------------------------------------------------- #
+class _LedgerProbeSubject:      # pragma: no cover - parsed, never executed
+    """Read surfaces built to order, so the scanners can be watched to work.
+
+    Nothing here is ever CALLED — only `inspect.getsource`d and parsed. That is
+    why the bodies reference a `self._c` that does not exist.
+    """
+
+    def unfiltered_read(self):
+        with self._c.cursor() as cur:
+            cur.execute("SELECT m.id FROM signal.messages m WHERE m.id = %s", (1,))
+
+    def filtered_read(self):
+        with self._c.cursor() as cur:
+            cur.execute(f"SELECT m.id FROM signal.messages m "
+                        f"WHERE {not_excluded('m')}")
+
+    def docstring_CLAIMS_the_predicate(self):
+        """Applies not_excluded() to every row it returns.
+
+        🔴 It does not. This is the exact shape found in the shipped code:
+        `get_draft`'s docstring explains the mute predicate, and a substring
+        guard read that explanation as a call.
+        """
+        with self._c.cursor() as cur:
+            cur.execute("SELECT m.id FROM signal.messages m")
+
+    def prose_only_mentions_the_schema(self):
+        """Talks about a SELECT over signal.messages without issuing one."""
+        return None
+
+    def MULTILINE_prose_only_mentions_the_schema(self):
+        """Talks about the schema across several lines, and issues nothing.
+
+        🔴 THE MULTI-LINE CASE IS A SEPARATE CONTROL, not a duplicate of the
+        one above. `ast.get_docstring()` CLEANS what it returns, so excluding
+        the docstring by comparing its VALUE silently worked for a single-line
+        docstring and silently failed for every multi-line one. With only the
+        one-line control present, that bug was invisible and shipped.
+
+        This method issues no SQL: it must NOT be seen as a read, and it names
+        SELECT and signal.messages purely as prose.
+        """
+        return None
+
+    def not_a_read_at_all(self):
+        return "nothing to do with the schema"
+
+
+def test_the_scan_and_the_predicate_detector_can_BOTH_go_red():
+    """🔴 Validate the instrument before reading its verdict.
+
+    Negative control (can it go red?) and positive control (can it ever observe
+    the thing?) for both scanners, on surfaces built to order. Without this, the
+    partition test passing proves only that two sets match each other — it would
+    look identical if the scan were wired to nothing.
+    """
+    found = _read_methods_touching_messages(_LedgerProbeSubject)
+    assert found == {"unfiltered_read", "filtered_read",
+                     "docstring_CLAIMS_the_predicate"}, sorted(found)
+    # POSITIVE: it detects a real read.  NEGATIVE: prose alone is not a read —
+    # asserted for BOTH docstring shapes, because they fail differently.
+    for prose in ("prose_only_mentions_the_schema",
+                  "MULTILINE_prose_only_mentions_the_schema"):
+        assert prose not in found, (
+            f"the scan counted {prose}, a method that only DISCUSSES the "
+            f"schema — it is matching prose and would read a docstring as SQL")
+    assert "not_a_read_at_all" not in found
+
+    filtered = _filtered_by_the_code(_LedgerProbeSubject)
+    assert filtered == {"filtered_read"}, sorted(filtered)
+
+
+def test_the_predicate_detector_is_NOT_walked_by_a_DOCSTRING_mention():
+    """🔴 The regression this rebuild exists for, pinned on the REAL method.
+
+    Measured on the shipped code: `SignalDB.get_draft`'s docstring contains the
+    characters `not_excluded(` while the method deliberately does not filter. A
+    substring guard therefore certified it as filtered — so moving it into
+    FILTERED_READS would have been a GREEN change that turned mute off for it.
+    """
+    src = inspect.getsource(SignalDB.get_draft)
+    assert "not_excluded(" in src, (
+        "POSITIVE CONTROL FAILED: get_draft's source no longer contains the "
+        "characters this test is about, so it can no longer detect the "
+        "confusion. Point it at whichever method now discusses the predicate.")
+    assert not _calls_the_mute_predicate(SignalDB.get_draft), (
+        "the detector reported get_draft as filtering. It does not — the match "
+        "is its DOCSTRING. A guard spelled over source text is satisfiable by "
+        "prose; use the AST.")
+
+
+# --------------------------------------------------------------------------- #
+# THE PARTITION
+# --------------------------------------------------------------------------- #
+def test_the_two_ledgers_PARTITION_every_read_of_signal_messages():
+    """Every read of `signal.messages` is in EXACTLY ONE ledger — and the
+    ledger it is in must agree with what the METHOD ACTUALLY DOES.
+
+    Four independent failure directions, each with its own message so the
+    diagnosis arrives with the failure:
+
+      * a new read method in NEITHER set,
+      * a method listed in BOTH,
+      * a name in a ledger that is no longer a read method (renamed/deleted),
+      * a method MISCLASSIFIED — listed as filtered while it does not call the
+        predicate, or listed as exempt while it does. This is the direction a
+        union check cannot see, and it is the one that turns mute off.
+    """
     found = _read_methods_touching_messages()
     assert found, (
         "HARNESS BROKEN: the scan found no message-reading methods at all, so "
         "every assertion below would pass vacuously")
-    declared = FILTERED_READS | set(EXEMPT_READS)
-    assert found == declared, (
-        f"the set of methods that SELECT from signal.messages changed.\n"
-        f"  new (add to FILTERED_READS and apply not_excluded(), or to "
-        f"EXEMPT_READS with a reason): {sorted(found - declared)}\n"
-        f"  gone (drop from the ledger): {sorted(declared - found)}")
+
+    both = FILTERED_READS & set(EXEMPT_READS)
+    assert not both, (
+        f"these methods are in BOTH ledgers, so the partition is meaningless "
+        f"and a union check would not notice: {sorted(both)}")
+
+    unclassified = found - (FILTERED_READS | set(EXEMPT_READS))
+    assert not unclassified, (
+        f"these methods SELECT from signal.messages and are in NEITHER ledger: "
+        f"{sorted(unclassified)}. Add each to FILTERED_READS and apply "
+        f"not_excluded(), or to EXEMPT_READS with a reason that says why a "
+        f"muted group's content cannot reach a caller through it.")
+
+    stale = (FILTERED_READS | set(EXEMPT_READS)) - found
+    assert not stale, (
+        f"these names are in a ledger but no longer read signal.messages "
+        f"(renamed, deleted, or the SQL moved out of the method): "
+        f"{sorted(stale)}. Drop them from the ledger.")
+
+    # 🔴 THE DIRECTION A UNION CHECK IS BLIND TO.
+    by_code = _filtered_by_the_code()
+    assert by_code == FILTERED_READS, (
+        f"the ledger disagrees with the CODE about who filters.\n"
+        f"  listed as filtered but does NOT call not_excluded(): "
+        f"{sorted(FILTERED_READS - by_code)}\n"
+        f"  calls not_excluded() but is listed EXEMPT: "
+        f"{sorted(by_code - FILTERED_READS)}\n"
+        f"Moving a method between the ledgers leaves their UNION identical, so "
+        f"this assertion is the only one that can see it.")
+    assert set(EXEMPT_READS) == found - by_code, (
+        f"EXEMPT_READS is not the complement of the filtered set: "
+        f"{sorted(set(EXEMPT_READS) ^ (found - by_code))}")
 
 
 @pytest.mark.parametrize("name", sorted(FILTERED_READS))
 def test_every_filtered_read_actually_calls_the_predicate(name):
-    src = inspect.getsource(getattr(SignalDB, name))
-    assert "not_excluded(" in src, (
-        f"SignalDB.{name} SELECTs from signal.messages without the mute "
+    assert _calls_the_mute_predicate(getattr(SignalDB, name)), (
+        f"SignalDB.{name} SELECTs from signal.messages without calling the mute "
         f"predicate — muted rows leak through it")
+
+
+@pytest.mark.parametrize("name", sorted(EXEMPT_READS))
+def test_every_exempt_read_really_does_NOT_call_the_predicate(name):
+    """The mirror. Without it, "exempt" is an unchecked assertion.
+
+    A method that both filters AND is listed exempt is not a leak, but it means
+    the ledger is describing something other than the code — and the ledger is
+    what the next person reads before deciding whether a new method is safe.
+    """
+    assert not _calls_the_mute_predicate(getattr(SignalDB, name)), (
+        f"SignalDB.{name} is listed in EXEMPT_READS but DOES call "
+        f"not_excluded(). Move it to FILTERED_READS: the ledger is now lying "
+        f"about which surfaces the mute covers.")
+
+
+@pytest.mark.parametrize("name", sorted(EXEMPT_READS))
+def test_every_exemption_carries_a_REASON_at_the_point_of_decision(name):
+    """An exemption with no argument beside it is the stale-prose failure again.
+
+    🔴 SCOPE: this is a FLOOR, not a check that the reason is TRUE. It stops
+    `"name": ""` and one-word placeholders; it cannot tell a correct reason from
+    a confident wrong one. The reasons that are load-bearing are pinned
+    STRUCTURALLY instead — see
+    `test_the_draft_exemptions_PREMISE_is_still_in_the_code`.
+    """
+    reason = EXEMPT_READS[name]
+    assert isinstance(reason, str) and len(reason.split()) >= 12, (
+        f"EXEMPT_READS[{name!r}] does not carry an argument a reviewer could "
+        f"disagree with: {reason!r}")
+
+
+def test_the_draft_exemptions_PREMISE_is_still_in_the_code():
+    """🔴 The load-bearing half of the draft exemption, pinned STRUCTURALLY.
+
+    The reason strings claim `get_draft`/`list_drafts` return only rows the
+    OPERATOR composed, and that `account_number` returns no content. Those are
+    claims about SQL, so they are checked against the SQL — a prose reason that
+    is merely re-read each time is exactly how the previous justification
+    survived being false.
+
+    If `send_state IS NOT NULL` is ever dropped, the population widens to every
+    device-sync ECHO — which carries OTHER PEOPLE's bodies, in groups — and the
+    exemption becomes a real leak. This goes red on that edit.
+    """
+    assert _POPULATION_CLAIM_READS <= set(EXEMPT_READS), (
+        f"a method whose exemption rests on the population claim is no longer "
+        f"exempt: {sorted(_POPULATION_CLAIM_READS - set(EXEMPT_READS))}")
+    for name in sorted(_POPULATION_CLAIM_READS):
+        sql = " ".join(_sql_strings(_method_tree(getattr(SignalDB, name))))
+        assert re.search(r"send_state\s+IS\s+NOT\s+NULL", sql, re.IGNORECASE), (
+            f"SignalDB.{name} no longer restricts itself to drafts with "
+            f"`send_state IS NOT NULL`. Its EXEMPT_READS reason depends on that "
+            f"predicate: without it the method also returns device-sync ECHOES, "
+            f"which carry other people's bodies from muted groups.")
+
+    account_sql = " ".join(_sql_strings(_method_tree(SignalDB.account_number)))
+    assert "signal.messages" in account_sql, (
+        "POSITIVE CONTROL FAILED: no SQL extracted for account_number")
+    assert not re.search(r"\bbody\b", account_sql, re.IGNORECASE), (
+        "SignalDB.account_number now selects a message body. Its exemption is "
+        "'returns no message content at all' — that is no longer true.")
 
 
 def test_get_draft_refuses_a_device_sync_ECHO_not_just_a_draft(db):
@@ -609,6 +910,21 @@ def test_send_and_reconcile_work_END_TO_END_on_a_group_draft(db, monkeypatch):
     assert done["recipient"] == address
 
 
+# One behavioural probe per FILTERED read, keyed by the method's own name so the
+# set can be compared against the ledger instead of trusted. Each returns the
+# rows that read surfaces FOR THIS DRAFT — so an empty list means "hidden", and a
+# non-empty one before the mute is the positive control.
+_MUTE_PROBES = {
+    "list_conversations": lambda db, draft, body: [
+        r for r in db.list_conversations()
+        if r["last_message_timestamp"] == draft["message_timestamp"]],
+    "search": lambda db, draft, body: [
+        r for r in db.search(body) if r["id"] == draft["id"]],
+    "get_message": lambda db, draft, body: [
+        r for r in [db.get_message(draft["id"])] if r],
+}
+
+
 def test_a_muted_group_draft_is_hidden_from_every_filtered_read(db):
     """🔴 CRITERION 4 — the sharp one. Mute must not be bypassable by drafting.
 
@@ -617,18 +933,27 @@ def test_a_muted_group_draft_is_hidden_from_every_filtered_read(db):
     from every read that believed it was filtering. Mute is the privacy control
     here.
 
-    This walks the FILTERED_READS ledger rather than naming three methods, so a
-    read surface added to that set later is covered the day it is added — a
-    hand-written list here would silently stop being the whole set.
+    🔴 STRUCTURE ALONE IS NOT ENOUGH, WHICH IS WHY THIS EXISTS. The partition
+    test checks that every method in FILTERED_READS really CALLS the predicate.
+    A call is not an effect: the predicate could be ANDed onto a subquery that
+    is later discarded, or parenthesised so it never binds. Only running the
+    reads against a muted row settles it. Together the two mean "listed as
+    filtered" implies "measurably filters".
+
+    `_MUTE_PROBES` is keyed by method name and asserted equal to FILTERED_READS
+    below, so a read surface added to that ledger without a behavioural probe
+    fails HERE rather than being quietly uncovered.
 
     Each read gets a POSITIVE CONTROL first: it must SEE the draft before the
     mute. Without that, "hidden" is indistinguishable from a query wired to
     nothing, and this whole test would pass against a `draft_message` that
     stored no row at all.
     """
-    assert FILTERED_READS == {"list_conversations", "search", "get_message"}, (
-        "the filtered-read set moved; extend the probes below to match rather "
-        f"than letting this test cover less than it claims: {FILTERED_READS}")
+    assert set(_MUTE_PROBES) == FILTERED_READS, (
+        f"every method in FILTERED_READS needs a behavioural probe here, or "
+        f"this test covers less than its name claims.\n"
+        f"  filtered but unprobed: {sorted(FILTERED_READS - set(_MUTE_PROBES))}\n"
+        f"  probed but not filtered: {sorted(set(_MUTE_PROBES) - FILTERED_READS)}")
 
     db.upsert_group(group_id=GROUP_MUTE, name="")
     body = "quarterly kestrel rendezvous"          # distinct from every _seed body
@@ -657,13 +982,7 @@ def test_a_muted_group_draft_is_hidden_from_every_filtered_read(db):
         "draft's is NEGATIVE — another message in this group would mask it")
 
     def probe() -> dict:
-        ts = draft["message_timestamp"]
-        return {
-            "list_conversations": [r for r in db.list_conversations()
-                                   if r["last_message_timestamp"] == ts],
-            "search": [r for r in db.search(body) if r["id"] == draft["id"]],
-            "get_message": [r for r in [db.get_message(draft["id"])] if r],
-        }
+        return {name: fn(db, draft, body) for name, fn in _MUTE_PROBES.items()}
 
     before = probe()
     for name, rows in before.items():


### PR DESCRIPTION
> **This PR body was wrong until now.** It contained the body of an unrelated PR (`vetrllc/vetr-app#153`, a CSS width fix) — written by a *concurrent* agent whose `--body-file` collided with this one's on a shared scratchpad path. The title, branch, commits and diff were always correct; only the description was another PR's. Corrected below, publicly rather than silently, in case a reviewer read the wrong version. See the comment thread.

Links an outbound group draft to its **group**, instead of storing it as a DM to a person who does not exist. Clawgate task 313.

## The defect

`draft_message()` never set `messages.group_id`, and resolved *any* recipient through `upsert_contact` — so drafting to a group minted a **phantom contact**: a fake person whose `phone_number` was the group address.

Measured on the live store (the message that exposed it):

```
signal.messages  id 51 | is_outbound t | send_state sent | group_id NULL | dest_contact_id 92
signal.contacts  id 92 | phone_number 'group.elgzaTRR…' | uuid5 placeholder
```

Consequences, sharpest first:

1. **Mute was bypassed.** `_muted_predicate` keys on `m.group_id`, so a draft to a MUTED group was returned in full by every read that believed it was filtering.
2. Group-scoped reads and `idx_msg_group` never saw our own sent messages — a conversation read as one-sided, inbound only.
3. `signal.contacts` accumulated one fake person per group drafted to.

The phantom was also load-bearing: `send` read the recipient string back out of it, which is why the fix had to rewire recipient derivation rather than just stop creating the row.

**The inbound path already did this correctly** (`store_message` calls `upsert_group` and sets `group_id`). This makes the outbound path do what inbound already does — one rule, one place.

## The change

- `draft_message()` branches on recipient shape: group address → `upsert_group` + `group_id` set, `dest_contact_id` NULL; uuid / phone → contact, unchanged.
- `send`/`reconcile` derive the wire recipient from a `LEFT JOIN signal.groups`, not from a contact.
- A strict decoder refuses a malformed group address rather than inventing 32 bytes.
- `db77d014` (test-only): `FILTERED_READS` / `EXEMPT_READS` now **partition** every read of `signal.messages`, checked by AST scan against what the code does.

## Verification

| | passed | failed | skipped |
|---|---|---|---|
| base `732db793` | 624 | 0 | 1 |
| commit 1 `53a0c8ab` | 635 | 0 | 1 |
| **HEAD `db77d014`** | **650** | **0** | **1** |

Counted from `PASSED`/`FAILED` lines, not exit codes.

**Red at base**, verbatim, with the mute test dying on its own assertion and its positive control passing first:

```
AssertionError: MUTE BYPASSED: list_conversations returned a draft to a MUTED group (1 row(s)).
`not_excluded()` keys on m.group_id, so a draft stored with group_id NULL walks straight through it.
```

All three filtered reads bypassed at base (`list_conversations 1, search 1, get_message 1`); `0/0/0` at HEAD.

**Mutation-tested**, isolated, `PYTHONDONTWRITEBYTECODE=1` with `__pycache__` cleared between mutants and an unmutated control each run. Includes the union-preserving **move** mutant (`get_message` FILTERED→EXEMPT, union byte-identical), which a set-union check cannot see and which dies on the code-vs-ledger assertion.

**Not relying on the SQLite substrate.** `tests/fakepg.py` is dynamically typed and has previously let a send path that was dead on real Postgres pass 599 green tests. The real schema was applied to a throwaway `postgres:18` and the whole path exercised there; `test_pg_type_compat.py::test_draft_query_runs_on_real_postgres`, normally skipped, ran and passed. All new SQL is ANSI `CAST(… AS text)` — never `::text`, which type-checks on Postgres and is unparseable by SQLite.

**The external wire contract is measured, not inferred.** `_group_id_to_address()` applied to the Vetr app group's raw id reproduces **byte-for-byte** the exact string that the live `signal-cli-rest-api` accepted with a `201` (4 recipients) on 2026-08-21, and round-trips back to the same raw id. The old code passed the operator's string through opaquely; the new code round-trips it through a decoder/encoder, so this equality is the thing that needed proving.

## Two guards this work found in its own tests

Both are the "spelled rather than structural" shape, and neither was a logic bug:

1. The predicate check was `"not_excluded(" in inspect.getsource(fn)` — a substring over source **including docstrings**. `get_draft` does not filter and must not, but its docstring *explains* the mute predicate, so the guard reported it as filtering. It was one commit from certifying the opposite of the truth.
2. The first fix for that excluded the docstring by comparing **values** against `ast.get_docstring()`, which cleans and dedents — so only single-line docstrings matched and every multi-line one was still read as SQL. Caught only by a mutant targeting a *named* test rather than accepting "something failed". Fixed by excluding the docstring by **node identity**, plus a multi-line control.

## Known limits

- **New rows only.** Production rows written by the old code keep `group_id` NULL until backfilled; `upsert_message`'s `ON CONFLICT` does not set `group_id`, so a sync echo cannot repair them either. Scope is measured and small — exactly **1** contact and **1** message on the live store. Backfill is queued separately and is guarded so a re-run is a no-op.
- Group discovery on draft is **forward-only**: a canonically-encoded but wrong 32 bytes creates a group row that never existed and the send goes nowhere while reporting success. Malformed spellings are refused; this case is not warned about. Follow-up.
- The exemption of `get_draft`/`list_drafts` from the mute predicate is deliberate — they return only rows the operator composed, and filtering them would strand a muted group's `sending` draft with no route out, an undesigned refusal path through the D3 gate. The reason lives in the `EXEMPT_READS` ledger itself, at the point of decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
