### PR TITLE
fix(gate): main is RED on an UNPINNED skip — #657 added a Postgres test without its ledger entry

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1705,6 +1705,18 @@ EXPECTED_SKIPS=(
   # network, neither of which a hermetic gate may have. Skips everywhere unless
   # REPO_COS_LIVE_DRIFT_CHECK=1.
   "scripts/repo-cos/tests|live-store drift check is opt-in"
+  # Needs a REAL Postgres (SIGNAL_PG_DSN). Unlike the skill_audit case below —
+  # which was correctly fixed by re-pointing at tracked fixtures so it RUNS —
+  # this one cannot be made hermetic: the test exists because SQLite does not
+  # reproduce Postgres static type checking, which is the exact defect #657
+  # fixed (a COALESCE over uuid/text that had never worked on real Postgres).
+  # gateTools carries psycopg2 (the client) but no Postgres SERVER, so nothing
+  # in the hermetic tier can satisfy it.
+  # 🔴 CONSEQUENCE, stated so it is not a surprise: this test is opt-in only and
+  # never runs in the gate. The regression it guards is caught only when someone
+  # runs with SIGNAL_PG_DSN set. Pinning unbreaks main; it does not restore the
+  # coverage.
+  "scripts/signal/tests|needs a real Postgres"
 )
 # ⚠ REMOVED, deliberately — do not re-add. `scripts/tests/test_skill_audit.py`
 # carried two regression pins against the LIVE datapacket-talos skill corpus, a


### PR DESCRIPTION
**`main` is red.** The merged-tree gate reports `passed=14367 failed=0` and still exits 1:

```
TOTAL collected=14369  passed=14367  skipped=2  failed=0
---- skips (pinned: 1) ----
ERROR: 1 UNPINNED skip group(s) — coverage silently collapsed
```

A skip is a test that did not run, so the #608 ledger reds the gate rather than let coverage collapse quietly. **Zero test failures, and still correctly red.**

The unpinned skip is `scripts/signal/tests/test_pg_type_compat.py:91` — *"needs a real Postgres (`SIGNAL_PG_DSN`)"* — which arrived with #657 without an `EXPECTED_SKIPS` entry. Verified pre-existing; not caused by any change in the session that found it.

**This is the second time this exact failure has landed.** The ledger's own comment records: *"#332 added the tests without the entry, and the gate was RED on main from 2026-08-04 to 2026-08-06 on the unpinned-skip guard alone."*

## Why pin, when the ledger prefers not to

The `skill_audit` entry directly below was correctly **removed** by re-pointing its tests at tracked fixtures so they *run* in every tier. That route isn't available here: this test exists precisely because SQLite does not reproduce Postgres static type checking — which **is** the defect #657 fixed, a `COALESCE` over `uuid`/`text` that had never worked on real Postgres.

Checked rather than assumed: `gateTools` carries `psycopg2` (the client library) but **no Postgres server**, so nothing in the hermetic tier can satisfy it. Same shape as the `repo-cos` entry already pinned beside it.

## 🔴 What this does not fix

Written into the ledger comment so a green gate isn't mistaken for coverage: **pinning unbreaks main, it does not restore the coverage.** That test now never runs in the gate — the regression it guards is caught only when someone runs with `SIGNAL_PG_DSN` set.

## Both controls run

A pin is a claim about the instrument, so it needs to be shown to fail *and* to pass:

| control | result |
|---|---|
| **negative** — a reason-regex that cannot match | `1 UNPINNED skip group(s)`, `RESULT: FAIL` — so the entry matches on the **reason**, not a rubber stamp |
| **positive** — the correct entry | `RESULT: PASS`, 14367 passed, 0 failed, `skipped=2 / pinned=2` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
