### PR TITLE
docs(gate): the EXPECTED_SKIPS header invites a conditional form that silently fails 8 tests

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1700,6 +1700,20 @@ _nolaunch_ack_reason() {
 # Built AFTER $HOME is settled: an entry may be conditional, but its condition
 # must be the SAME predicate the test itself uses — never a blanket allowance,
 # or the pin degrades into the numeric ceiling it exists to beat.
+#
+# 🔴 A conditional entry must still live INSIDE the array literal below — never
+# as an `EXPECTED_SKIPS+=(…)` appended after the closing paren. `runner_patch.py`
+# neutralises this array for patched copies by regex on the LITERAL
+# (`^EXPECTED_SKIPS=\(.*?^\)` -> `EXPECTED_SKIPS=()`), because a copy driving a
+# throwaway target observes zero skips and would die "FEWER than pinned" for a
+# reason unrelated to the guard under test. An appended entry SURVIVES that
+# substitution and reintroduces exactly that failure.
+# Measured 2026-08-21: the `[ -n "$VAR" ] || EXPECTED_SKIPS+=(…)` form — which
+# the paragraph above reads as inviting — failed 8 tests across
+# test_activity_spool_isolation.py, test_gate_exit_truthfulness.py and
+# test_no_real_launchers_all_targets.py, none of which name this array.
+# The two-line control: after any edit here, `re.subn` the pattern above against
+# this file and assert both `n == 1` and that no `EXPECTED_SKIPS+=` survives.
 EXPECTED_SKIPS=(
   # Opt-in drift check against the LIVE homelab store — needs a kubeconfig and
   # network, neither of which a hermetic gate may have. Skips everywhere unless


### PR DESCRIPTION
The pin itself landed concurrently in #687 — this PR is now **comment-only**, recording the trap we both hit.

`runner_patch.py` empties `EXPECTED_SKIPS` for patched runner copies by regex on the **literal**. An `EXPECTED_SKIPS+=(…)` appended after the closing paren survives that substitution and makes patched copies die `FEWER than pinned`. Measured: **8 failures** across three test files, none of which name this array.

The header paragraph reads as inviting exactly that form. Now it warns against it, with the measured evidence and a two-line control.

Note for reviewers: the comment contains the forbidden token, so any automated scan for it must be comment-aware — a naive substring check flags this file.