### PR TITLE
fix(tests): the test tier could rewrite the operator's clone and push to the PUBLIC repo — GUARD 9 makes the write impossible

### DIFF
--- a/scripts/analyze-service-index/commit.sh
+++ b/scripts/analyze-service-index/commit.sh
@@ -168,6 +168,19 @@ if [ "${#POSITIONAL[@]}" -gt 1 ]; then
   usage: commit.sh [--print-plan] [STORE_DIR]"
 fi
 
+# 🔴 A GIVEN-BUT-EMPTY STORE IS A BUG, NOT A REQUEST FOR THE DEFAULT. `:-`
+# cannot tell "no argument" from "an argument that is the empty string", so
+# `commit.sh ""` — the shape a caller produces when its own path computation
+# fails — would silently `git init`, `git add` and `git commit` in the
+# OPERATOR'S REAL STORE instead of the directory it meant. This is the same
+# class as ship.sh's SHIP_REPO and drift-check.sh's DRIFT_REPO; see
+# scripts/tests/test_no_real_repo_writes.py, which pins all four sites.
+if [ "${#POSITIONAL[@]}" -eq 1 ] && [ -z "${POSITIONAL[0]}" ]; then
+  die "STORE argument was given but is EMPTY.
+  That is a caller bug, not a request for the default — an empty value would
+  silently resolve to \${HOME}/.claude/analyze-service-index and commit in the
+  operator's real store. Pass no argument for the default, or pass a path."
+fi
 STORE="${POSITIONAL[0]:-${HOME}/.claude/analyze-service-index}"
 
 ASI_GIT_NAME="${ASI_GIT_NAME:-analyze-service index}"

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -441,6 +441,19 @@ if [ "${1:-}" = "--detect-role" ]; then
   exit 0
 fi
 
+# 🔴 SET-BUT-EMPTY IS A BUG, NOT A REQUEST FOR THE DEFAULT. `${VAR:-default}`
+# cannot tell "unset" from "set to the empty string", so a caller that computed
+# a repo path and got `""` silently checks — and `git fetch`es — the OPERATOR'S
+# OWN CLONE instead of the one it meant. UNSET must keep defaulting (this
+# variable is deliberately NOT forwarded over ssh, and the remote host's repo
+# lives at its own $HOME/workspace/devrc); EMPTY must stop the run.
+if [ "${DRIFT_REPO+set}" = set ] && [ -z "$DRIFT_REPO" ]; then
+  echo "drift-check: DRIFT_REPO is SET but EMPTY." >&2
+  echo "  That is a caller bug, not a request for the default — an empty value" >&2
+  echo "  would silently resolve to \$HOME/workspace/devrc and fetch into the" >&2
+  echo "  operator's own clone. Unset it to get the default, or give it a path." >&2
+  exit 2
+fi
 DRIFT_REPO="${DRIFT_REPO:-$HOME/workspace/devrc}"
 DRIFT_UNTRACKED_MAX="${DRIFT_UNTRACKED_MAX:-10}"
 DRIFT_DANGLING_MAX="${DRIFT_DANGLING_MAX:-10}"
@@ -589,6 +602,10 @@ severity() {
 # remote-tracking refs only.
 CHECK='
 set -uo pipefail
+if [ "${DRIFT_REPO+set}" = set ] && [ -z "$DRIFT_REPO" ]; then
+  echo "[${DRIFT_LABEL:-host}] DRIFT_REPO is SET but EMPTY — refusing to fall back to \$HOME/workspace/devrc." >&2
+  exit 2
+fi
 repo="${DRIFT_REPO:-$HOME/workspace/devrc}"
 label="${DRIFT_LABEL:-host}"
 maxu="${DRIFT_UNTRACKED_MAX:-10}"
@@ -970,6 +987,10 @@ echo "[$label] PARITY-RC=$p_rc"
 SRCREPO='
 set -uo pipefail
 label="${DRIFT_LABEL:-host}"
+if [ "${DRIFT_REPO+set}" = set ] && [ -z "$DRIFT_REPO" ]; then
+  echo "[$label] DRIFT_REPO is SET but EMPTY — refusing to fall back to \$HOME/workspace/devrc." >&2
+  exit 2
+fi
 repo="${DRIFT_REPO:-$HOME/workspace/devrc}"
 sfto="${DRIFT_SRC_FETCH_TIMEOUT:-30}"
 ssay() { echo "[$label] $*"; }

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1586,6 +1586,7 @@ export DEVRC_TEST_SPOOL_GUARD_DIR="$SPOOL_DIR"
 # how ten of this file's own regression tests work — would inherit the flag, and
 # every target inside it would be scored as a nested session with no marker.
 unset DEVRC_TEST_SPOOL_IN_SESSION
+unset DEVRC_TEST_GITGUARD_IN_SESSION
 SPOOL_SESSIONS_LOG="$SPOOL_DIR/sessions.log"
 SPOOL_ISOLATED_LOG="$SPOOL_ISOLATED/current.log"
 
@@ -1626,6 +1627,194 @@ esac
 echo "run-tests: activity telemetry isolated for this run (GUARD 8)"
 echo "  ACTIVITY_SPOOL_DIR=$ACTIVITY_SPOOL_DIR"
 echo "  fallback trap      =$SPOOL_TRAP_LOG"
+
+# --- GUARD 9: NO TEST MAY MUTATE A REAL REPOSITORY, IN ANY TARGET --------------
+# 🔴 THE THIRD ENFORCEMENT POINT, attached to the same line for the same reason.
+#
+# MEASURED 2026-08-21: running this tier set `core.bare = true` on the
+# operator's working clone, renamed its `main` to `trunk`, repointed its
+# `origin` at a pytest tmpdir, left ~50 fixture commits in it, and pushed ~40 of
+# them over `refs/heads/main` on the PUBLIC repo in 43 seconds. Three feature
+# branches were hit too. Nothing was lost only because another session still
+# had the good sha.
+#
+# 🔴 A CLEANUP STEP CANNOT FIX THIS, WHICH IS WHY THE GUARD IS HERE. Every
+# fixture that re-points a real repo restores it on TEARDOWN; a killed run, an
+# assertion that raises past the restore, or `pytest -x` leaves the operator's
+# clone pointed at a temp directory with no error anywhere. So the mutating
+# `git` process is prevented from starting, not undone afterwards.
+#
+# 🔴 AND IT IS NOT A `-C`-DISCIPLINE PROBLEM. Every fixture in this tree binds
+# `-C` or `cwd=` correctly — audited mechanically, twice. The route that
+# reproduces the damage byte-for-byte is a single ambient variable:
+#
+#     GIT_DIR OVERRIDES `git -C <path>`.
+#
+# MEASURED (git 2.55): with GIT_DIR naming repo V, replaying
+# `scripts/repo-cos/tests/test_prescan.py::_init_clone` verbatim against a
+# tmp_path fixture renamed V's branch to `trunk`, repointed V's HEAD, rewrote
+# V's `user.email` to the fixture's `t@t`, committed the fixture's `seed.py`
+# into V, and PUSHED it to V's own origin. No call site named V. So there are
+# two halves below, and they are different fixes:
+#
+#   * the RETARGETING VARIABLES are unset. That is the direct fix for the one
+#     mechanism the incident proved, and a run that never inherits them never
+#     generates the write at all.
+#   * a `git` shim goes first on PATH for the whole script. That is the
+#     structural fix, and it is here rather than in 17 conftests for the reason
+#     GUARD 7's header already argues: 24 targets, of which HOOK_TESTS and
+#     SHELL_TESTS can never have a conftest.
+#
+# 🔴 A WORKTREE IS NOT CONTAINMENT. `git rev-parse --git-common-dir` from a
+# linked worktree resolves to the REAL clone's `.git` — shared refs, remotes,
+# config, reflog — so the shim protects COMMON DIRS and every agent worktree
+# under a protected clone is protected with it. "Develop this in a worktree" is
+# the intuitive answer and it is wrong; a standalone clone with `origin`
+# removed is the correct one.
+unset GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE \
+      GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES \
+      GIT_CONFIG_COUNT \
+      GIT_NAMESPACE GIT_CEILING_DIRECTORIES GIT_PREFIX
+# GIT_CONFIG_KEY_<n>/VALUE_<n> are indexed, so there is no fixed name to unset;
+# git ignores them entirely without GIT_CONFIG_COUNT, which is unset above. The
+# indexed pairs are cleared anyway so a later `GIT_CONFIG_COUNT=` set by a test
+# cannot pick up an inherited value.
+for _i in 0 1 2 3 4 5 6 7 8 9; do
+  unset "GIT_CONFIG_KEY_$_i" "GIT_CONFIG_VALUE_$_i"
+done
+unset _i
+
+GITGUARD_DIR="$(mktemp -d)"
+# 🔴 `--allow-no-repos` is NOT a fallback for "resolution failed" — it is the
+# nix build sandbox, where the source is a copy with no `.git` and there is
+# genuinely no real clone to protect. The NETWORK and CONFIG rules still apply
+# there, and the count is PRINTED either way, because "armed against 1 repo" and
+# "armed against 0" are different claims and a silent zero reads like the first.
+GITGUARD_OUT="$(PYTHONPATH="$ROOT/scripts${PYTHONPATH:+:$PYTHONPATH}" \
+  python -m testlib.norepo --allow-no-repos "$GITGUARD_DIR" \
+    "$ROOT" "$HOME/workspace/devrc" 2>&1)" || {
+  echo "run-tests: FATAL — could not install the no-real-repo git shim into" >&2
+  echo "  $GITGUARD_DIR. Refusing to run: without it a test can set core.bare" >&2
+  echo "  on the operator's clone, rename its branches and push fixture" >&2
+  echo "  commits over the public repo's default branch (MEASURED 2026-08-21)." >&2
+  echo "$GITGUARD_OUT" | sed 's/^/    /' >&2
+  exit 2
+}
+GITGUARD_LOG="$GITGUARD_DIR/git-ops.log"
+GITGUARD_REPOS="$(printf '%s\n' "$GITGUARD_OUT" | grep -c '^protected=' || true)"
+export PATH="$GITGUARD_DIR:$PATH"
+export DEVRC_TEST_GITGUARD_DIR="$GITGUARD_DIR"
+
+# 🔴 TWO LEVERS THAT DO NOT DEPEND ON THE SHIM BEING REACHED. The shim
+# intercepts by PATH, so an absolute `/usr/bin/git`, or a test that REPLACES
+# $PATH rather than prepending to it, walks past it. These two are enforced by
+# git itself, in-process, and cover exactly the two halves of the incident that
+# left the machine. Adapted from devrc-62's `testlib/nogit_plugin` (PR #673,
+# not merged) — their measurement, our runner.
+#
+# 1. GIT_ALLOW_PROTOCOL=file — no transport but the local filesystem.
+#
+# 🔴 MEASURED 2026-08-21 ON THIS BOX, and it is worse than "a fixture might
+# reach the network": WITHOUT this lever and with the shim off PATH,
+# `git push git@github.com:innovation-upstream/devrc.git HEAD:refs/heads/main`
+# from a throwaway fixture printed `To github.com:innovation-upstream/devrc.git`
+# — a push PROGRESS header. It authenticated and CONNECTED over ssh; it failed
+# only because the update was rejected. That is the second half of this
+# incident, and it is one non-fast-forward away from landing.
+#
+# 🔴 AND THE OBVIOUS TEST OF THIS LEVER PROVES NOTHING. Without it the same push
+# still exits non-zero — by REJECTION (rc 1) or a credential prompt (rc 128) —
+# so `assert rc != 0` is satisfied whether or not the lever is doing anything.
+# The refusal is attributable ONLY when the message names the transport
+# (`fatal: transport 'ssh' not allowed`). `test_no_real_repo_writes.py` pins
+# that distinction rather than the exit status.
+#
+# Verified not to cost the suite anything: with the lever on, push to a
+# plain-path bare, push to a `file://` bare, and `git clone` from a plain-path
+# bare are all rc 0. Nothing in this tree needs https or ssh.
+export GIT_ALLOW_PROTOCOL=file
+
+# 2. The git CONFIG files are REDIRECTED, not merely protected.
+#
+# The shim already REFUSES a write whose resolved `--global`/`--system` file is
+# the operator's — including the measured vector, `githooks/install.sh` running
+# `git config --global core.hooksPath` with no env var set at all (verified:
+# rc 99, guard-named). But that refusal depends on the shim reading argv. This
+# makes the write STRUCTURALLY unable to land regardless of how git is invoked.
+# Belt and braces, deliberately: refuse AND redirect.
+#
+# 🔴 ORDER IS LOAD-BEARING — the guard is installed ABOVE this block. Deriving
+# the protected config set AFTER the redirect would protect the throwaway file
+# and leave `~/.gitconfig` unprotected, i.e. point the guard at the decoy it
+# just created. `testlib.norepo.main()` also protects `Path.home()/.gitconfig`
+# unconditionally so the two cannot drift apart.
+#
+# The throwaway is SEEDED with an identity: fixtures that commit without setting
+# their own `user.email` would otherwise fail "Please tell me who you are",
+# which would be this guard breaking the suite rather than protecting it.
+GITCONFIG_TRAP="$GITGUARD_DIR/gitconfig-trap"
+{ printf '[user]\n\tname = devrc test runner\n\temail = tests@localhost\n'
+  printf '[init]\n\tdefaultBranch = main\n'; } > "$GITCONFIG_TRAP" 2>/dev/null || {
+  echo "run-tests: FATAL — could not seed the git-config trap at $GITCONFIG_TRAP" >&2
+  exit 2
+}
+export GIT_CONFIG_GLOBAL="$GITCONFIG_TRAP"
+export GIT_CONFIG_SYSTEM=/dev/null
+export GIT_CONFIG_NOSYSTEM=1
+
+echo "run-tests: real repositories protected from this run (GUARD 9)"
+printf '%s\n' "$GITGUARD_OUT" | sed 's/^/  /'
+echo "  GIT_ALLOW_PROTOCOL=$GIT_ALLOW_PROTOCOL (no ssh/https transport for this run)"
+echo "  GIT_CONFIG_GLOBAL=$GIT_CONFIG_GLOBAL (redirected; the real one is also refused)"
+if [ "$GITGUARD_REPOS" -eq 0 ]; then
+  echo "  ⚠ NO real repository resolved — \$ROOT is not a git checkout and there is"
+  echo "    no \$HOME/workspace/devrc. That is expected ONLY in the nix build"
+  echo "    sandbox. The NETWORK and CONFIG rules below are still armed, and the"
+  echo "    per-target table says 'repo-probe=n/a' rather than printing a zero"
+  echo "    that would read as protection."
+fi
+
+# 🔴 THE PER-TARGET POSITIVE CONTROL, and the reason this guard is readable.
+# "0 refusals" is the observable a working guard and a guard wired to nothing
+# SHARE. Before every target the runner drives a case that MUST be refused and
+# watches the counter move, so each row is a PAIR — "N controls fired, 0 real
+# refusals" — never a bare zero. `DEVRC_TEST_GITGUARD_PROBE=1` changes only
+# WHICH ledger line the shim writes; the refusal is identical.
+#
+# The NETWORK probe works in every environment; the REPO probe needs a protected
+# repo, so it is run only when there is one and the count says so.
+GITGUARD_TAB="$(printf '\t')"
+GITGUARD_PROBE_TARGET="$(cat "$GITGUARD_DIR/probe-target.txt" 2>/dev/null || true)"
+GITGUARD_PROBES=1
+[ -n "$GITGUARD_PROBE_TARGET" ] && GITGUARD_PROBES=2
+GITGUARD_SEEN=()
+GITGUARD_B=0
+
+_gitguard_lines() {
+  if [ -f "$GITGUARD_LOG" ]; then wc -l < "$GITGUARD_LOG" | tr -d ' '; else echo 0; fi
+}
+_gitguard_slice() { # $1 = first line (1-based), $2 = last line
+  [ -f "$GITGUARD_LOG" ] || return 0
+  [ "$2" -ge "$1" ] || return 0
+  sed -n "$1,$2p" "$GITGUARD_LOG"
+}
+_gitguard_probe() {
+  # A remote that cannot exist, so a shim that somehow forwarded this would fail
+  # on DNS rather than reach anything real.
+  DEVRC_TEST_GITGUARD_PROBE=1 DEVRC_TEST_GITGUARD_VIA=inherited git ls-remote \
+    https://guard9-probe.invalid/probe.git >/dev/null 2>&1 || true
+  if [ -n "$GITGUARD_PROBE_TARGET" ]; then
+    DEVRC_TEST_GITGUARD_PROBE=1 DEVRC_TEST_GITGUARD_VIA=inherited \
+      git -C "$GITGUARD_PROBE_TARGET" config --local \
+      devrc.guard9.probe x >/dev/null 2>&1 || true
+  fi
+}
+_gitguard_mark_before() { GITGUARD_B="$(_gitguard_lines)"; }
+# $1 = target name. Every call MUST be preceded by the before-mark, or the range
+# it records belongs to whatever ran previously.
+_gitguard_account() {
+  GITGUARD_SEEN+=("$1|$(( GITGUARD_B + 1 ))|$(_gitguard_lines)")
+}
 
 # "<target>|<sess-from>|<sess-to>|<trap-from>|<trap-to>|<iso-from>|<iso-to>" —
 # three line ranges per target, so every count below is attributed to the target
@@ -1813,15 +2002,18 @@ run_pytest() {
   log="$(mktemp)"
   nl_before="$(_nolaunch_lines)"
   _spool_mark_before
+  _gitguard_mark_before
+  _gitguard_probe
   # 🔴 `-p testlib.nolaunch_plugin` is GUARD 7 and `-p testlib.spool_plugin` is
   # GUARD 8 (see each header). Both are on THIS line — the one place every
   # target is invoked — and not in two dozen conftests.
   python -m pytest "$d" -q -p no:cacheprovider -p testlib.nolaunch_plugin -p testlib.spool_plugin \
-    --no-header -rs >"$log" 2>&1
+    -p testlib.norepo_plugin --no-header -rs >"$log" 2>&1
   rc=$?
   nl_after="$(_nolaunch_lines)"
   NOLAUNCH_SEEN+=("$d|$(( nl_before + 1 ))|$nl_after")
   _spool_account "$d"
+  _gitguard_account "$d"
   cat "$log"
 
   # GUARD 4: parse pytest's summary line. `-q` emits it undecorated, e.g.
@@ -1942,6 +2134,8 @@ for HOOK_TEST in "${HOOK_TESTS[@]}"; do
   echo "=== script $HOOK_TEST ==="
   nl_before="$(_nolaunch_lines)"
   _spool_mark_before
+  _gitguard_mark_before
+  _gitguard_probe
   if python "$HOOK_TEST"; then
     RESULTS+=("PASS  $HOOK_TEST (script)")
   else
@@ -1956,6 +2150,10 @@ for HOOK_TEST in "${HOOK_TESTS[@]}"; do
   # marker and no fallback control — their protection is the two env exports,
   # and what is checked is that they leaked nothing into the trap.
   _spool_account "$HOOK_TEST"
+  # GUARD 9 accounts them identically: the shim is on PATH for this whole
+  # script, so a non-pytest target is protected and MEASURED exactly like a
+  # pytest one. This is the half no conftest could ever have reached.
+  _gitguard_account "$HOOK_TEST"
   echo
 done
 
@@ -1981,6 +2179,8 @@ for SHELL_TEST in "${SHELL_TESTS[@]}"; do
   echo "=== script $SHELL_TEST ==="
   nl_before="$(_nolaunch_lines)"
   _spool_mark_before
+  _gitguard_mark_before
+  _gitguard_probe
   if bash "$SHELL_TEST"; then
     RESULTS+=("PASS  $SHELL_TEST (script)")
   else
@@ -1989,6 +2189,7 @@ for SHELL_TEST in "${SHELL_TESTS[@]}"; do
   fi
   NOLAUNCH_SEEN+=("$SHELL_TEST|$(( nl_before + 1 ))|$(_nolaunch_lines)")
   _spool_account "$SHELL_TEST"
+  _gitguard_account "$SHELL_TEST"
   echo
 done
 
@@ -2193,6 +2394,79 @@ if [ "${#spool_problems[@]}" -gt 0 ]; then
   fail=1
 fi
 rm -rf "$SPOOL_DIR"
+
+# --- GUARD 9 (evaluation): per-target real-repository accounting ---------------
+# One line per target, ALWAYS printed — including the zeros, and NEVER the zero
+# alone. `refused=0` on its own is exactly what a guard wired to nothing prints,
+# so every row carries `control=` beside it: the refusals this run DELIBERATELY
+# provoked before that target ran. The pair is the claim.
+echo "  ---- real-repository protection (GUARD 9) ----"
+echo "    protected repos=$GITGUARD_REPOS  probes/target=$GITGUARD_PROBES"
+gitguard_problems=()
+for t in "${TARGETS[@]}"; do
+  seen=0
+  for entry in "${GITGUARD_SEEN[@]}"; do
+    [ "${entry%%|*}" = "$t" ] && seen=1 && break
+  done
+  [ "$seen" -eq 1 ] || gitguard_problems+=("$t  — never accounted: run_pytest returned before GUARD 9 could measure it")
+done
+
+for entry in "${GITGUARD_SEEN[@]}"; do
+  gt="${entry%%|*}"
+  grest="${entry#*|}"
+  gfrom="${grest%%|*}"
+  gto="${grest#*|}"
+  gslice="$(_gitguard_slice "$gfrom" "$gto")"
+  # 🔴 A LITERAL TAB, via $(printf '\t'), never the two characters \t in a BRE.
+  # MEASURED: `grep -c '^git(control)\tvia=plugin'` warns "stray \ before t",
+  # matches NOTHING, and reported control=0 for EVERY target -- the accounting
+  # failing while the guard was perfectly healthy, which is indistinguishable
+  # from the guard being dead. claude/RULES.md: validate the instrument before
+  # reading its verdict.
+  gctl_plug=$(printf '%s\n' "$gslice" | grep -c "^git(control)${GITGUARD_TAB}via=plugin" || true)
+  gctl_inh=$(printf '%s\n' "$gslice" | grep -c "^git(control)${GITGUARD_TAB}via=inherited" || true)
+  ghits="$(printf '%s\n' "$gslice" | grep '^git(refused)' || true)"
+  gref=0
+  [ -n "$ghits" ] && gref=$(printf '%s\n' "$ghits" | grep -c . || true)
+
+  g_is_pytest=0
+  for t in "${TARGETS[@]}"; do [ "$t" = "$gt" ] && g_is_pytest=1 && break; done
+  if [ "$g_is_pytest" -eq 1 ]; then g_via="plugin+inherited"; else g_via="inherited (not pytest)"; fi
+  echo "    $gt  refused=$gref  control=plugin:$gctl_plug inherited:$gctl_inh  via=$g_via"
+
+  # 🔴 THE LEAK ITSELF. A refusal that is not one of this run's own probes is a
+  # test that tried to mutate a real repository, rewrite the operator's git
+  # config, or reach the network — and only this guard stopped it.
+  if [ "$gref" -gt 0 ]; then
+    gitguard_problems+=("$gt  — made $gref real-repository/network git call(s). They were REFUSED and did NOT run; a test in this target tried to write outside its own fixtures:"$'\n'"$(printf '%s\n' "$ghits" | sed 's/^/           /')")
+  fi
+  # 🔴 The REQUIRED direction, and the whole reason the probe exists: a target
+  # whose controls did not fire ran with the guard unarmed, so its refused=0
+  # above is not evidence of anything.
+  # 🔴 THE INHERITED CONTROL: the shim is armed in the RUNNER's environment.
+  if [ "$gctl_inh" -ne "$GITGUARD_PROBES" ]; then
+    gitguard_problems+=("$gt  — the INHERITED control fired $gctl_inh time(s), expected $GITGUARD_PROBES. The shim was not on PATH (or stopped refusing), so its refused=$gref means nothing. See scripts/testlib/norepo.py.")
+  fi
+  # 🔴 THE IN-PROCESS CONTROL, and it is a different claim. Without it,
+  # refused=0 is a statement about the runner rather than about this target —
+  # the whole table would read as rigorous while measuring one thing N times.
+  # Non-pytest targets can never load a plugin, so 0 is CORRECT for them and
+  # anything else means the slices are misattributed.
+  if [ "$g_is_pytest" -eq 1 ]; then
+    if [ "$gctl_plug" -ne "$GITGUARD_PROBES" ]; then
+      gitguard_problems+=("$gt  — the IN-PROCESS control fired $gctl_plug time(s), expected $GITGUARD_PROBES. testlib.norepo_plugin did not load (or the shim is not armed INSIDE this target's process), so refused=$gref describes the runner, not this target.")
+    fi
+  elif [ "$gctl_plug" -ne 0 ]; then
+    gitguard_problems+=("$gt  — a NON-pytest target recorded $gctl_plug in-process control(s); it can load no plugin, so the per-target slices are misattributed.")
+  fi
+done
+
+if [ "${#gitguard_problems[@]}" -gt 0 ]; then
+  echo "  ERROR: ${#gitguard_problems[@]} GUARD 9 problem(s):" >&2
+  for p in "${gitguard_problems[@]}"; do echo "         $p" >&2; done
+  fail=1
+fi
+rm -rf "$GITGUARD_DIR"
 
 # GUARD 6. One writer, fed the same value `exit` is about to take, so the
 # printed verdict and the process status cannot disagree — including through a

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1705,6 +1705,31 @@ GITGUARD_REPOS="$(printf '%s\n' "$GITGUARD_OUT" | grep -c '^protected=' || true)
 export PATH="$GITGUARD_DIR:$PATH"
 export DEVRC_TEST_GITGUARD_DIR="$GITGUARD_DIR"
 
+# 🔴 OWN GIT'S OWN libexec, so a git-SPAWNED child is guarded too. Git prepends
+# `libexec/git-core` to PATH for everything it spawns, so a bare `git` inside a
+# `!`-alias, a hook, a filter or `rebase --exec` resolves to the REAL binary and
+# never reaches the PATH shim. MEASURED with an alias in a fixture's OWN config:
+# PATH shim alone -> rc 0 and the victim gained a commit; with this -> rc 99,
+# refused. `git --exec-path` reports 189 entries here; the farm symlinks the
+# non-git ones and SUBSTITUTES EVERY DISPATCH NAME -- `git` plus all 181
+# `git-<verb>` entries. Substituting only the literal `git` was the earlier,
+# WITHDRAWN version: git dispatches on argv[0], so `<farm>/git-config -f
+# <protected>/.git/config core.bare true` walked straight past it at rc 0.
+GITGUARD_FARM="$(printf '%s\n' "$GITGUARD_OUT" | sed -n 's/^exec-farm=//p')"
+if [ -n "$GITGUARD_FARM" ] && [ "$GITGUARD_FARM" != "UNAVAILABLE" ]; then
+  export GIT_EXEC_PATH="$GITGUARD_FARM"
+else
+  echo "run-tests: FATAL — GUARD 9 could not build the git exec-path farm." >&2
+  echo "  Without it, a \`!\`-alias, hook, filter or \`rebase --exec\` ALREADY IN" >&2
+  echo "  a repo's own config runs a git that this guard never sees — git" >&2
+  echo "  prepends its own libexec to PATH for everything it spawns." >&2
+  echo "  Refusing to run rather than proceed with a known hole: the farm is" >&2
+  echo "  derived from \`git --exec-path\` every run and verified as a SET, so" >&2
+  echo "  an unusable one means an entry could not be linked, not that the" >&2
+  echo "  list is stale." >&2
+  exit 2
+fi
+
 # 🔴 TWO LEVERS THAT DO NOT DEPEND ON THE SHIM BEING REACHED. The shim
 # intercepts by PATH, so an absolute `/usr/bin/git`, or a test that REPLACES
 # $PATH rather than prepending to it, walks past it. These two are enforced by
@@ -1765,6 +1790,7 @@ export GIT_CONFIG_NOSYSTEM=1
 echo "run-tests: real repositories protected from this run (GUARD 9)"
 printf '%s\n' "$GITGUARD_OUT" | sed 's/^/  /'
 echo "  GIT_ALLOW_PROTOCOL=$GIT_ALLOW_PROTOCOL (no ssh/https transport for this run)"
+echo "  GIT_EXEC_PATH=${GIT_EXEC_PATH:-<unchanged>} (git-spawned children are guarded too)"
 echo "  GIT_CONFIG_GLOBAL=$GIT_CONFIG_GLOBAL (redirected; the real one is also refused)"
 if [ "$GITGUARD_REPOS" -eq 0 ]; then
   echo "  ⚠ NO real repository resolved — \$ROOT is not a git checkout and there is"

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -86,6 +86,11 @@
 # converged.
 #
 # Exit codes:
+#   2  SHIP_REPO was SET but EMPTY — a caller bug, not a request for the
+#      default. `${SHIP_REPO:-…}` cannot tell "unset" from "set to the empty
+#      string", so an empty value would silently converge the operator's own
+#      $HOME/workspace/devrc. Refused instead. UNSET still defaults, which the
+#      remote leg relies on.
 #   3  repo missing on that host
 #   4  git fetch failed, or origin/main is missing / HEAD unborn
 #   5  SKIPPED — an unresolved merge/cherry-pick is in progress (conflicted
@@ -187,6 +192,20 @@ if [ "${1:-}" = "--detect-role" ]; then
   exit 0
 fi
 
+# 🔴 SET-BUT-EMPTY IS A BUG, NOT A REQUEST FOR THE DEFAULT. `${VAR:-default}`
+# cannot tell "unset" from "set to the empty string", so a caller that computed
+# a repo path and got `""` — a failed `git rev-parse`, an unexpanded template, a
+# `SHIP_REPO=$SOME_UNSET_VAR` — silently converges the OPERATOR'S OWN CLONE
+# instead of the one it meant. UNSET must keep defaulting (the remote leg
+# deliberately does not forward this variable, and the far host's repo is at its
+# own $HOME/workspace/devrc); EMPTY must stop the run.
+if [ "${SHIP_REPO+set}" = set ] && [ -z "$SHIP_REPO" ]; then
+  echo "ship: SHIP_REPO is SET but EMPTY." >&2
+  echo "  That is a caller bug, not a request for the default — an empty value" >&2
+  echo "  would silently resolve to \$HOME/workspace/devrc and converge the" >&2
+  echo "  operator's own clone. Unset it to get the default, or give it a path." >&2
+  exit 2
+fi
 SHIP_REPO="${SHIP_REPO:-$HOME/workspace/devrc}"
 SHIP_NO_SWITCH="${SHIP_NO_SWITCH:-0}"
 DO_LOCAL=1
@@ -232,6 +251,10 @@ fi
 # bash -c, remote via ssh). Single source of truth for the sequence.
 CONVERGE='
 set -uo pipefail
+if [ "${SHIP_REPO+set}" = set ] && [ -z "$SHIP_REPO" ]; then
+  echo "ship: SHIP_REPO is SET but EMPTY — refusing to fall back to \$HOME/workspace/devrc." >&2
+  exit 2
+fi
 repo="${SHIP_REPO:-$HOME/workspace/devrc}"
 no_switch="${SHIP_NO_SWITCH:-0}"
 host=$(hostname 2>/dev/null || echo local)
@@ -771,6 +794,7 @@ if [ "$rc" = 0 ]; then
   echo "ship: converged + verified at origin/main (local=$SHIP_ROLE remote=$REMOTE_ROLE)."
 else
   echo "ship: incomplete (rc=$rc) — see per-host lines above."
+  echo "  rc2=ship-repo-set-but-empty(caller bug — refused rather than defaulting to \$HOME/workspace/devrc)"
   echo "  rc3=no-repo  rc4=fetch/origin-main-unavailable  rc5=skipped:conflicted-tree(merge in progress)"
   echo "  rc6=host-unidentified"
   echo "  rc7=skipped:cannot-fast-forward(local changes in the way)  rc8=skipped:diverged(needs rebase)"

--- a/scripts/testlib/norepo.py
+++ b/scripts/testlib/norepo.py
@@ -213,6 +213,7 @@ from .mockbin import write_exec
 LOG_NAME = "git-ops.log"
 PROTECTED_LIST_NAME = "protected-repos.txt"
 PROTECTED_CONFIG_NAME = "protected-config.txt"
+EXEC_FARM_NAME = "execfarm"
 
 #: The handle `run-tests.sh` exports so anything under the runner can find the
 #: ONE guard directory. Same shape as `nolaunch.STUB_DIR_ENV`.
@@ -278,6 +279,48 @@ RETARGETING_ENV = (
     "GIT_CEILING_DIRECTORIES",
     "GIT_PREFIX",
 )
+
+#: 🔴 F3 — AN ALLOWLIST, NOT A DENYLIST. Injected config (`-c`, `--config-env`,
+#: `GIT_CONFIG_KEY_<n>`) can hand the REAL git binary a program to run, and the
+#: shim is not inherited by what git spawns. An earlier revision refused ONE key
+#: (`alias.*=!`) while its own prose NAMED `core.fsmonitor`, clean/smudge
+#: filters and `GIT_SSH_COMMAND` as surface and refused none of them.
+#:
+#: MEASURED against that revision: `-c core.hooksPath=<dir with a hook>` +
+#: `commit` landed ALL FOUR of the incident's documented damages on a victim
+#: (`core.bare` true, `main`->`trunk`, `remote.origin.url` repointed,
+#: `user.email` rewritten) plus a planted file -- at rc 0, ledger delta 0.
+#:
+#: So: an injected key must be on this list or it is REFUSED. Membership means
+#: "this key cannot name a program, a config file to load, or a write
+#: destination". Every entry is a key MEASURED in use in this tree.
+INJECTABLE_KEYS = (
+    "user.name", "user.email", "user.signingkey",
+    "init.defaultbranch",
+    "core.abbrev", "core.filemode", "core.autocrlf", "core.ignorecase",
+    "core.excludesfile", "core.bare", "core.logallrefupdates", "core.quotepath",
+    "core.safecrlf", "core.symlinks", "core.trustctime", "core.precomposeunicode",
+    "commit.gpgsign", "tag.gpgsign", "gpg.program",
+    "merge.autostash", "rebase.autostash", "pull.rebase", "push.default",
+    "fetch.prune", "gc.auto", "advice.detachedhead", "advice.addignoredfile",
+    "diff.algorithm", "diff.renames", "status.showuntrackedfiles",
+    "log.date", "i18n.logoutputencoding", "i18n.commitencoding",
+    "protocol.file.allow", "protocol.ext.allow",
+    "color.ui", "color.diff", "color.status", "color.branch",
+    "index.version", "feature.manyfiles", "extensions.worktreeconfig",
+)
+
+#: Keys that name a HOOK OR TEMPLATE DIRECTORY. `analyze-service-index/
+#: commit.sh` sets both ON PURPOSE, at an EMPTY dir, to NEUTRALISE hooks -- and
+#: its suite drives that path, so refusing them outright is a permanently-red
+#: gate. The distinction is MEASURABLE rather than spelled: neutralising points
+#: at a directory with no executable in it; arming points at one with a hook.
+HOOKDIR_KEYS = ("core.hookspath", "init.templatedir")
+
+#: Keys whose VALUE is a repository or remote. Allowed only when the value is
+#: neither a protected path nor a network remote -- checked by the same two
+#: predicates the operand scanner uses, so there is one rule, not two.
+LOCATION_KEY_SUFFIXES = (".url", ".pushurl")
 
 #: The subset of `RETARGETING_ENV` the shim actually REFUSES on. Everything
 #: here has been MEASURED to move an axis the battery asserts on; membership is
@@ -384,18 +427,33 @@ def _read_forms_case(sub: str) -> str:
     return "|".join(sh_pattern(p) for s, p in PROTECTED_READ_FORMS if s == sub)
 
 
+def _sh_list(items):
+    return "|".join(items)
+
+
 def shim_body(real_git: str, log: Path, protected_list: Path,
               protected_config: Path) -> str:
     """The POSIX-sh body of the `git` shim. No shebang -- write_exec owns it.
 
+    🔴 ORDER IS THE ARCHITECTURE (F4). The read FAST PATH sits BELOW the
+    injected-config scan, the environment scan and the GIT_CONFIG_COUNT scan,
+    and above nothing else. An earlier revision had it FIRST, so any subcommand
+    on the read list carried its injections straight to the real binary:
+    MEASURED, `-c diff.external=<script> ... diff` ran the script (planted a
+    file in the victim) and `GIT_DIR=<victim> ... rev-parse --absolute-git-dir`
+    printed the victim's git dir -- both rc 0, both with the ledger at 0, i.e.
+    a green `refused=0` row. `diff` and `rev-parse` are on the list this file
+    describes as "cannot write and cannot reach a network remote"; that is true
+    of the SUBCOMMAND and says nothing about what was injected alongside it.
+
     🔴 EVERY BRANCH EITHER `exec`s THE REAL BINARY OR REFUSES WITH A NON-ZERO
-    STATUS. There is no path that returns success without having done the work:
-    a git shim that silently no-opped a `commit` would leave the test asserting
-    against a commit that does not exist, and the failure would point anywhere
-    but here.
+    STATUS. There is no path that returns success without having done the work.
     """
-    always_read = "|".join(sorted(set(ALWAYS_READ)))
-    network = "|".join(NETWORK_SUBCOMMANDS)
+    always_read = _sh_list(sorted(set(ALWAYS_READ)))
+    network = _sh_list(NETWORK_SUBCOMMANDS)
+    refused_env = " ".join(v for v in REFUSED_ENV if v != "GIT_CONFIG_COUNT")
+    inj = _sh_list(INJECTABLE_KEYS)
+    hookdirs = _sh_list(HOOKDIR_KEYS)
     read_cases = "\n".join(
         f"    {sub}) case \"$rest\" in {_read_forms_case(sub)}) _pass \"$@\" ;; esac ;;"
         for sub in sorted({s for s, _ in PROTECTED_READ_FORMS})
@@ -409,7 +467,6 @@ PROTCFG='{protected_config}'
 
 _pass() {{ exec "$REAL" "$@"; }}
 
-# $1 = reason, rest = the original argv.
 _refuse() {{
   reason="$1"; shift
   if [ "${{{PROBE_ENV}:-0}}" = 1 ]; then
@@ -422,18 +479,37 @@ _refuse() {{
   echo "  argv   : git $*" >&2
   echo "  cwd    : $PWD" >&2
   echo "  No test may mutate a REAL repository, rewrite the operator's git" >&2
-  echo "  config, or reach a network remote. On 2026-08-21 this tier set" >&2
-  echo "  core.bare on the operator's clone, renamed its main branch and put" >&2
-  echo "  ~40 fixture commits over the PUBLIC repo's default branch." >&2
-  echo "  Build the fixture repo under tmp_path and target it explicitly." >&2
-  echo "  A legitimate READ belongs in norepo.PROTECTED_READ_FORMS." >&2
+  echo "  config, hand the real git binary a program to run, or reach a" >&2
+  echo "  network remote. Build the fixture under tmp_path and target it." >&2
   exit {REFUSED_EXIT}
 }}
 
+# ---- INVOKED AS `git-<verb>`? RECONSTRUCT THE EQUIVALENT `git <verb>` -------
+# 🔴 GIT DISPATCHES ON argv[0]. `libexec/git-core` holds ~181 `git-<verb>`
+# entries, and running one directly is an ordinary spelling -- `git-commit`,
+# `git-config` -- not an exotic one. MEASURED against an earlier revision, with
+# the farm installed and every other check in place:
+#
+#   <farm>/git-config -f <victim>/.git/config core.bale true
+#     -> core.bare false -> true, rc 0
+#
+# i.e. the INCIDENT'S OWN SIGNATURE, with `git` never spelled once. The farm
+# substituted only the literal name `git`, so all 181 verb entries pointed
+# straight at the real binary and sat FIRST on PATH in exactly the alias/hook
+# context the farm was added to cover.
+#
+# 🔴 ROUTED BY NAME, NEVER BY INODE. On this host none of those entries shares
+# git's inode (they are symlinks); on another packaging they are hardlinks. The
+# property that matters is "a name git dispatches on", which is satisfied by a
+# hardlink, a symlink, a copy or a wrapper -- so an inode/`stat` enumeration is
+# the WRONG attribute and would report a clean farm on one packaging and miss
+# every entry on another.
+_self=${{0##*/}}
+case "$_self" in
+  git-*) set -- "${{_self#git-}}" "$@" ;;
+esac
+
 # ---- parse git's GLOBAL options, stopping at the subcommand ------------------
-# Only -C and --git-dir change WHICH repo is targeted. -c/--work-tree/
-# --namespace/--config-env/--super-prefix take a value that must be skipped so
-# it cannot be mistaken for the subcommand.
 sub=''; tgt=''; gdir=''; want=''; cvals=''
 for a in "$@"; do
   case "$want" in
@@ -449,11 +525,6 @@ env:$a"; want=''; continue ;;
     -C) want=C; continue ;;
     --git-dir) want=D; continue ;;
     --git-dir=*) gdir="${{a#--git-dir=}}"; continue ;;
-    # 🔴 `-c key=value` is CAPTURED, not skipped. Skipping it is how
-    # `git -c alias.x='!git -C <victim> commit' x` and
-    # `git -c remote.origin.url=<github> push` both walked straight past an
-    # earlier revision of this shim -- MEASURED, victim commit landed and the
-    # push reached GitHub.
     -c) want=K; continue ;;
     --config-env) want=E; continue ;;
     --config-env=*) cvals="$cvals
@@ -464,184 +535,11 @@ env:${{a#--config-env=}}"; continue ;;
   esac
 done
 
-# ---- FAST PATH ---------------------------------------------------------------
-case "$sub" in
-  ''|{always_read}) _pass "$@" ;;
-esac
-
-# 🔴 PATHNAME EXPANSION OFF from here down. The loops below deliberately
-# word-split `$rest` and `$urls`, and an unquoted `$var` in a `for` list is
-# GLOBBED as well as split -- so a `*` inside a refspec or a path would expand
-# against the cwd and the guard would inspect filenames instead of arguments.
-# `exec` resets this for the real binary, so nothing downstream sees it.
+# 🔴 Pathname expansion OFF: the loops below word-split unquoted `$rest` and
+# `$cvals`, and an unquoted `$var` in a `for` list is GLOBBED as well as split.
 set -f
 
-# 🔴 IS THIS PATH INSIDE A PROTECTED REPOSITORY? One definition, used by BOTH
-# the resolved-repo check and the environment check below. A prefix match, not
-# equality: a linked worktree's git dir is `<protected>/.git/worktrees/<name>`,
-# and an equality test would report it as a different, unprotected repository.
-_prot_match() {{
-  [ -n "$1" ] || return 1
-  # 🔴 ABSOLUTE PATHS ONLY, and this is a CORRECTNESS rule, not a shortcut.
-  # `readlink -f` resolves a relative string against THIS SHIM's cwd -- which
-  # under `run-tests.sh` IS the protected repo. So every non-path operand
-  # matched: `worktree list` flagged the word `list`, `worktree add -b topic`
-  # flagged `topic`, and `-c user.email=t@t` flagged `t@t`. MEASURED: 15 tests
-  # failed on a correct tree, i.e. this guard made itself a permanently-red gate
-  # -- the failure mode claude/RULES.md says trains everyone to click through.
-  #
-  # ⚠ RESIDUAL, stated rather than hidden: a RELATIVE path aimed at a protected
-  # repo is not matched here. git resolves it against the CHILD's cwd, which
-  # this shim cannot know; the repo RESOLUTION below covers the cwd case, and
-  # every environment variable and injected config value that matters in
-  # practice is absolute.
-  case "$1" in
-    /*) ;;
-    *) return 1 ;;
-  esac
-  _rp=$(readlink -f "$1" 2>/dev/null || echo "$1")
-  while IFS= read -r _p; do
-    [ -z "$_p" ] && continue
-    case "$_rp" in
-      "$_p"|"$_p"/*) return 0 ;;
-    esac
-  done < "$PROT"
-  return 1
-}}
-
-# ---- GLOBAL `-c` / `--config-env` INJECTION ---------------------------------
-# 🔴 THE SAME CONFIG VALUES, ON THE COMMAND LINE. These reach git without
-# touching a file and without changing the resolved repo, so neither the config
-# redirect nor repo resolution can see them. MEASURED against an earlier
-# revision of this shim, from an INNOCENT fixture:
-#
-#   git -c 'alias.x=!git -C <victim> commit --allow-empty -m PWNED' x
-#     -> rc 0, the victim gained a commit
-#   git -c remote.origin.url=git@github.com:<real>/devrc.git push origin HEAD:main
-#     -> "To github.com:<real>/devrc.git  ! [rejected]" -- it REACHED GitHub
-#
-# 🔴 AND THE ALIAS CASE IS WHY THE PATH SHIM ALONE IS NOT ENOUGH. Git PREPENDS
-# its own `libexec/git-core` to PATH for every child it spawns, so the `git`
-# inside a `!`-alias resolves to the REAL binary and never sees this shim. The
-# shim is NOT inherited by git-spawned children; the module docstring says so
-# explicitly rather than implying coverage we do not have.
-# $1 = "key=value" (or "env:key=ENVVAR"); remaining args = the original argv.
-_scan_cval() {{
-  case "$1" in
-    env:*)
-      _e="${{1#env:}}"; _ck="${{_e%%=*}}"; _ev="${{_e#*=}}"
-      eval "_cv=\\${{$_ev:-}}"
-      ;;
-    *) _ck="${{1%%=*}}"; _cv="${{1#*=}}" ;;
-  esac
-  [ "$_ck" = "$1" ] && return 0
-  case "$_ck" in
-    alias.*)
-      case "$_cv" in
-        "!"*) _refuse "-c $_ck is a SHELL-ESCAPE alias ($_cv). Git prepends its own libexec to PATH, so the git inside it would NOT be guarded" "$@" ;;
-      esac
-      ;;
-  esac
-  if [ -n "$_cv" ] && _prot_match "$_cv"; then
-    _refuse "-c $_ck=$_cv points into a PROTECTED repository; this channel writes no file, so the config redirect cannot see it" "$@"
-  fi
-  case "$_cv" in
-    *://*|*@*:*) _refuse "-c $_ck=$_cv is a NETWORK remote; this tier is hermetic" "$@" ;;
-  esac
-}}
-if [ -n "$cvals" ]; then
-  _oifs="$IFS"; IFS='
-'
-  for _c in $cvals; do
-    [ -n "$_c" ] && _scan_cval "$_c"
-  done
-  IFS="$_oifs"
-fi
-
-# ---- THE ENVIRONMENT VECTOR, WHICH RESOLUTION ALONE DOES NOT COVER -----------
-# 🔴 THIS IS THE HALF THAT MAKES THE GUARD ENVIRONMENT-AWARE RATHER THAN
-# PATH-VALIDATING, AND IT IS NOT REDUNDANT WITH THE RESOLUTION BELOW.
-#
-# Two different kinds of variable, and only one of them is caught by asking git
-# which repo it is in:
-#
-#   * GIT_DIR / GIT_COMMON_DIR change the repo's IDENTITY. `rev-parse
-#     --git-common-dir` below inherits them and answers with the repo git will
-#     actually use, so those are already covered — that is why the guard
-#     delegates resolution to git instead of parsing `-C` itself.
-#
-#   * GIT_WORK_TREE / GIT_INDEX_FILE / GIT_OBJECT_DIRECTORY /
-#     GIT_ALTERNATE_OBJECT_DIRECTORIES do NOT. They leave the repo identity
-#     alone and redirect WHERE THE WRITE LANDS. With cwd in a throwaway fixture
-#     and GIT_WORK_TREE naming the operator's clone, `git checkout -f` or
-#     `git reset --hard` writes files into the OPERATOR'S WORKING TREE while
-#     every path argument, and the resolved repo, look entirely innocent.
-#     MEASURED, and pinned by `test_no_real_repo_writes.py`'s armed-environment
-#     battery.
-#
-# `run-tests.sh` unsets all of them, but that is a claim about SETUP: it stops
-# what the runner INHERITS, and does nothing about a test that builds its own
-# subprocess environment. So the shim refuses them here as well. The two layers
-# are deliberately not the same fix.
-for _v in GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE \
-          GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES; do
-  eval "_val=\\${{$_v:-}}"
-  if [ -n "$_val" ] && _prot_match "$_val"; then
-    _refuse "$_v points into a PROTECTED repository ($_val); it would redirect this write there whatever the arguments say" "$@"
-  fi
-done
-
-# ---- THE CHANNEL A FILE-WATCHING GUARD CANNOT SEE, EVEN IN PRINCIPLE ---------
-# 🔴 GIT_CONFIG_COUNT / GIT_CONFIG_KEY_<n> / GIT_CONFIG_VALUE_<n> are NOT in
-# `man git`, and git honours them. They set arbitrary config for ONE invocation
-# and TOUCH NO FILE. MEASURED on git 2.55 against an earlier revision of this
-# very shim:
-#
-#   GIT_CONFIG_GLOBAL=<decoy> GIT_CONFIG_SYSTEM=/dev/null
-#     git config --get core.hooksPath            -> <unset>        (guard held)
-#   ...plus GIT_CONFIG_COUNT=1 KEY_0=core.hooksPath VALUE_0=/tmp/PWNED-hooks
-#     git config --get core.hooksPath            -> /tmp/PWNED-hooks
-#   decoy file afterwards: 0 bytes, NEVER OPENED
-#
-# So the `GIT_CONFIG_GLOBAL` redirect above was not merely incomplete for this
-# vector — it was watching a channel the vector does not use. A guard is bounded
-# by the CHANNEL it observes, not by the completeness of its list.
-#
-# 🔴 THIS CHECK IS DELIBERATELY HERE, IN THE SHIM, AT CALL TIME. These variables
-# are per-invocation and live in the CHILD's environment, so a check run in the
-# plugin's process — or around a test — reads its OWN environment, comes back
-# clean, and PASSES while the child is fully injected. The shim is the only
-# place that sees the environment the guarded invocation will actually use.
-#
-# 🔴 AND IT IS SCOPED, NOT A BLANKET BAN. `scripts/analyze-service-index/
-# commit.sh` uses exactly this mechanism ON PURPOSE to NEUTRALISE hooks
-# (`GIT_CONFIG_KEY_0=core.hooksPath` at an empty dir), and its suite drives that
-# path. Refusing all of it would be a permanently-red gate. What is refused is
-# an injected value aimed INTO a protected path, or at a network remote.
-#
-# ⚠ RESIDUAL, STATED RATHER THAN HIDDEN: an injected value pointing somewhere
-# harmless-to-us (a tmpdir) is still arbitrary config, and `core.hooksPath` at a
-# tmpdir is arbitrary CODE EXECUTION during the run. That is outside this
-# guard's mandate (the operator's repo) and inside `commit.sh`'s legitimate
-# usage, so it is permitted here and documented rather than silently allowed.
-case "${{GIT_CONFIG_COUNT:-}}" in
-  ''|*[!0-9]*) : ;;
-  *)
-    _n=0
-    while [ "$_n" -lt "${{GIT_CONFIG_COUNT}}" ]; do
-      eval "_ik=\\${{GIT_CONFIG_KEY_$_n:-}}"
-      eval "_iv=\\${{GIT_CONFIG_VALUE_$_n:-}}"
-      # 🔴 THE SAME SCANNER as the `-c` form. It had its own copy of the checks
-      # and was missing the alias case, so `alias.y=!git -C <victim> commit`
-      # injected through the environment landed a commit on the victim while
-      # the byte-identical `-c` form was refused. One predicate, one place.
-      [ -n "$_ik" ] && _scan_cval "$_ik=$_iv" "$@"
-      _n=$(( _n + 1 ))
-    done
-    ;;
-esac
-
-# The arguments AFTER the subcommand, space-prefixed, for the read-form match.
+# The arguments AFTER the subcommand, space-prefixed.
 rest=''; seen=0
 for a in "$@"; do
   if [ "$seen" = 0 ]; then
@@ -651,20 +549,230 @@ for a in "$@"; do
   rest="$rest $a"
 done
 
-# ---- PROTECTED CONFIG FILES --------------------------------------------------
-# --global / --system reach ~/.gitconfig and /etc/gitconfig without touching any
-# repo at all, so no amount of repo protection sees them. githooks/install.sh
-# writes the global one for real, so this is a live shape, not a hypothetical.
+# ---- IS THIS PATH INSIDE A PROTECTED REPOSITORY? ----------------------------
+# 🔴 `readlink -m`, not `-f` (F6): `-f` returns EMPTY for a path that does not
+# exist yet, so `git clone <src> <victim>/planted` resolved to nothing and was
+# ALLOWED -- MEASURED, the clone landed inside the victim. `-m` canonicalises
+# without requiring existence and keeps the symlink handling that the same
+# check was verified 5/5 on.
+#
+# 🔴 ABSOLUTE ONLY: `readlink` resolves a relative string against THIS SHIM's
+# cwd, which under `run-tests.sh` IS the protected repo, so every non-path
+# operand matched and 15 tests failed on a correct tree. A relative path aimed
+# at a protected repo is left to the repo RESOLUTION below.
+_prot_match() {{
+  [ -n "$1" ] || return 1
+  case "$1" in
+    /*) ;;
+    *) return 1 ;;
+  esac
+  _rp=$(readlink -m "$1" 2>/dev/null || echo "$1")
+  while IFS= read -r _p; do
+    [ -z "$_p" ] && continue
+    case "$_rp" in
+      "$_p"|"$_p"/*) return 0 ;;
+    esac
+  done < "$PROT"
+  return 1
+}}
+
+# ---- IS THIS OPERAND A NETWORK REMOTE? --------------------------------------
+# 🔴 GIT'S OWN RULE, not two globs (F2). The previous test matched `*://*` and
+# `*@*:*` only, so USERLESS scp syntax -- `github.com:owner/repo`, which is
+# valid and has no `@` -- matched neither and was never classified. MEASURED
+# with the transport lever off: git attempted a real ssh connection to
+# github.com while the ledger stayed at 0, i.e. the guard never saw it.
+#
+# git's rule: `://` makes it a URL; otherwise a `:` BEFORE the first `/` makes
+# it scp-like. Checking the segment before the first slash is what keeps a
+# REFSPEC (`HEAD:refs/heads/main`, whose colon follows no slash but whose first
+# segment is `HEAD`) from being mistaken for a host -- and the operand scanner
+# below only ever inspects the REPOSITORY operand anyway, never a refspec.
+_is_network() {{
+  case "$1" in
+    file://*) return 1 ;;
+    *://*) return 0 ;;
+    /*|./*|../*) return 1 ;;
+  esac
+  case "$1" in
+    */*) case "${{1%%/*}}" in *:*) return 0 ;; esac; return 1 ;;
+    *:*) return 0 ;;
+  esac
+  return 1
+}}
+
+# ---- INJECTED CONFIG: AN ALLOWLIST (F3) -------------------------------------
+_hookdir_is_armed() {{ # $1 = directory
+  [ -d "$1" ] || return 1
+  # 🔴 `set +f` around the glob. Pathname expansion is OFF for this whole shim
+  # (the split loops need it off), and an earlier revision left it off HERE —
+  # so `"$1"/*` stayed a LITERAL string, matched nothing, and every armed hook
+  # directory was reported unarmed. MEASURED: the full four-damage
+  # `core.hooksPath` vector still landed at rc 0 with the check "passing".
+  set +f
+  _armed=1
+  for _h in "$1"/* "$1"/hooks/*; do
+    if [ -f "$_h" ] && [ -x "$_h" ]; then _armed=0; break; fi
+  done
+  set -f
+  return $_armed
+}}
+
+# $1 = "key=value" or "env:key=ENVVAR"; remaining args = the original argv.
+_scan_cval() {{
+  case "$1" in
+    env:*)
+      _e="${{1#env:}}"; _ck="${{_e%%=*}}"; _ev="${{_e#*=}}"
+      # 🔴 NEVER `eval` AN ARGV-DERIVED STRING. `--config-env=key=VAR` puts VAR
+      # on the command line, and an earlier revision did
+      # `eval "_cv=\${{$_ev:-}}"` with it. MEASURED:
+      #
+      #   git --config-env=core.pager='V:-$(touch /tmp/X)' --version
+      #     this shim  -> /tmp/X CREATED, then exit 99
+      #     real git   -> exit 128, "fatal: missing environment variable
+      #                   'V:-$(touch /tmp/X)'", nothing executed
+      #
+      # On that path the guard was STRICTLY WORSE THAN NO GUARD: it introduced
+      # code execution that the unguarded system refuses, on a pure READ
+      # (`--version`), before any check ran. A mitigation that adds an attack
+      # surface is not a mitigation.
+      #
+      # The name is validated as a shell identifier and the value is read with
+      # `printenv`, which does not interpret. An invalid name is REFUSED, which
+      # is also what real git does with it.
+      case "$_ev" in
+        ''|*[!A-Za-z0-9_]*|[0-9]*)
+          _refuse "--config-env names an invalid environment variable '$_ev'; real git rejects this and executes nothing, so neither will the guard" "$@" ;;
+      esac
+      _cv=$(printenv "$_ev" 2>/dev/null || true)
+      ;;
+    *) _ck="${{1%%=*}}"; _cv="${{1#*=}}" ;;
+  esac
+  [ "$_ck" = "$1" ] && return 0
+  _lk=$(printf '%s' "$_ck" | tr 'A-Z' 'a-z')
+
+  # A value naming a protected path or a network remote is refused whatever the
+  # key is -- one rule, shared with the operand scanner.
+  if [ -n "$_cv" ] && _prot_match "$_cv"; then
+    _refuse "-c $_ck=$_cv points into a PROTECTED repository" "$@"
+  fi
+  case "$_lk" in
+    *{_sh_list(LOCATION_KEY_SUFFIXES)})
+      if _is_network "$_cv"; then
+        _refuse "-c $_ck=$_cv is a NETWORK remote; this tier is hermetic" "$@"
+      fi
+      return 0 ;;
+  esac
+
+  case "$_lk" in
+    {hookdirs})
+      # Neutralising (an empty dir) is what commit.sh does on purpose. Arming
+      # (a dir holding an executable) is the measured full-incident vector.
+      if _hookdir_is_armed "$_cv"; then
+        _refuse "-c $_ck=$_cv points at a directory containing an EXECUTABLE hook; git would RUN it, and the shim is not inherited by what git spawns" "$@"
+      fi
+      return 0 ;;
+    {inj}) return 0 ;;
+  esac
+  _refuse "-c $_ck is not on the injectable-config allowlist (norepo.INJECTABLE_KEYS). Injected config can hand the REAL git binary a program to run -- aliases, hooks, fsmonitor, clean/smudge filters, pagers, external diff -- and this shim is NOT inherited by what git spawns. If this key genuinely cannot name a program, a config to load or a write destination, add it to the allowlist" "$@"
+}}
+
+if [ -n "$cvals" ]; then
+  _oifs="$IFS"; IFS='
+'
+  for _c in $cvals; do
+    [ -n "$_c" ] && _scan_cval "$_c" "$@"
+  done
+  IFS="$_oifs"
+fi
+
+# ---- THE ENVIRONMENT VECTOR -------------------------------------------------
+# GIT_DIR/GIT_COMMON_DIR change the repo's IDENTITY and are covered by
+# resolution below; GIT_WORK_TREE/GIT_INDEX_FILE/GIT_OBJECT_DIRECTORY leave
+# identity truthful and redirect only WHERE THE WRITE LANDS, which resolution
+# cannot see. All are refused here, above the fast path, because a read
+# subcommand carries them just as well as a write one.
+# The two `eval`s below take a HARDCODED variable name and a digit-validated
+# counter respectively -- never a value from argv. That distinction is the whole
+# audit: see `test_no_argv_derived_string_is_shell_interpreted`.
+for _v in {refused_env}; do
+  eval "_val=\\${{$_v:-}}"
+  if [ -n "$_val" ] && _prot_match "$_val"; then
+    _refuse "$_v points into a PROTECTED repository ($_val); it would redirect this write there whatever the arguments say" "$@"
+  fi
+done
+
+# GIT_CONFIG_COUNT / KEY_<n> / VALUE_<n>: undocumented in `man git`, honoured
+# anyway, and they write NO file -- so neither the config redirect nor path
+# protection can see them. Routed through the SAME scanner as `-c`.
+case "${{GIT_CONFIG_COUNT:-}}" in
+  ''|*[!0-9]*) : ;;
+  *)
+    _n=0
+    while [ "$_n" -lt "${{GIT_CONFIG_COUNT}}" ]; do
+      eval "_ik=\\${{GIT_CONFIG_KEY_$_n:-}}"
+      eval "_iv=\\${{GIT_CONFIG_VALUE_$_n:-}}"
+      [ -n "$_ik" ] && _scan_cval "$_ik=$_iv" "$@"
+      _n=$(( _n + 1 ))
+    done
+    ;;
+esac
+
+# ---- OPTIONS THAT WRITE OR EXECUTE, ON *ANY* SUBCOMMAND ---------------------
+# 🔴 A VERB'S CLASSIFICATION SAYS NOTHING ABOUT ITS OPTIONS. `log` and `grep`
+# are on the read list -- truthfully, as verbs -- and MEASURED against an
+# earlier revision, from an ALLOWED repo:
+#
+#   git -C <allowed> log -p --output=<victim>/.git/config
+#       -> the victim's config CLOBBERED, rc 0
+#   git -C <allowed> grep -O'touch <path>' A
+#       -> the command RAN, rc 0
+#
+# Both `exec`d on the fast path before any destination check. This is the same
+# lesson `status` taught (a read that writes) with a destination attached, so
+# the check sits ABOVE the fast path and applies to every subcommand.
+#
+# ⚠ AN ENUMERATION, AND SAID SO: these are the option spellings that carry a
+# destination or a command. It is a backstop, not the guard -- the guard for a
+# non-read verb is the repo resolution below. `--exec` is deliberately ABSENT:
+# `git --exec-path` is our own farm's mechanism and `rebase --exec` is ordinary
+# git, so refusing it would be a permanently-red gate.
+_dw=''
+for a in "$@"; do
+  if [ -n "$_dw" ]; then
+    _dw=''
+    if _prot_match "$a"; then
+      _refuse "an output destination ($a) inside a PROTECTED repository" "$@"
+    fi
+    continue
+  fi
+  case "$a" in
+    --output|--output-directory) _dw=1 ;;
+    --output=*|--output-directory=*)
+      _od="${{a#*=}}"
+      if _prot_match "$_od"; then
+        _refuse "an output destination ($_od) inside a PROTECTED repository" "$@"
+      fi
+      ;;
+    -O?*|--open-files-in-pager=*|--to-command=*|--upload-pack=*|--receive-pack=*)
+      _refuse "$a names a COMMAND for git to run; this shim is not inherited by what git spawns, so the command would be unguarded" "$@" ;;
+    -O|--open-files-in-pager|--to-command|--upload-pack|--receive-pack)
+      _refuse "$a names a COMMAND for git to run; this shim is not inherited by what git spawns, so the command would be unguarded" "$@" ;;
+  esac
+done
+
+# ---- FAST PATH (deliberately AFTER every scanner above) ---------------------
+case "$sub" in
+  ''|{always_read}) _pass "$@" ;;
+esac
+
+# ---- PROTECTED CONFIG FILES -------------------------------------------------
 if [ "$sub" = config ]; then
   cfgfile=''
   case "$rest" in
     *--global*) cfgfile="${{GIT_CONFIG_GLOBAL:-$HOME/.gitconfig}}" ;;
     *--system*) cfgfile="${{GIT_CONFIG_SYSTEM:-/etc/gitconfig}}" ;;
   esac
-  # 🔴 `--file <path>` / `-f <path>` names a config file DIRECTLY, in a repo the
-  # resolver reports as innocent. MEASURED: `git -C <fixture> config --file
-  # <victim>/.git/config core.bare true` set core.bare on the victim -- one of
-  # the two actual incident damages -- and was NOT refused.
   _cfw=''
   for a in $rest; do
     case "$_cfw" in F) cfgfile="$a"; _cfw=''; continue ;; esac
@@ -673,14 +781,14 @@ if [ "$sub" = config ]; then
       --file=*) cfgfile="${{a#--file=}}" ;;
     esac
   done
-  if [ -n "$cfgfile" ] && _prot_match "$cfgfile"; then
-    case "$rest" in
-      *--get*|*--list*|*" "-l*) _pass "$@" ;;
-    esac
-    _refuse "config --file/-f targets $cfgfile, inside a PROTECTED repository" "$@"
-  fi
   if [ -n "$cfgfile" ]; then
-    rcfg=$(readlink -f "$cfgfile" 2>/dev/null || echo "$cfgfile")
+    if _prot_match "$cfgfile"; then
+      case "$rest" in
+        *--get*|*--list*|*" "-l*) _pass "$@" ;;
+      esac
+      _refuse "config would write $cfgfile, inside a PROTECTED repository" "$@"
+    fi
+    rcfg=$(readlink -m "$cfgfile" 2>/dev/null || echo "$cfgfile")
     while IFS= read -r p; do
       [ -z "$p" ] && continue
       if [ "$rcfg" = "$p" ]; then
@@ -693,24 +801,9 @@ if [ "$sub" = config ]; then
   fi
 fi
 
-# ---- resolve the repo this invocation targets --------------------------------
-# 🔴 --git-common-dir, NEVER --git-dir: a linked worktree's git dir is a
-# subdirectory of the real clone's, and its refs/remotes/config ARE the real
-# clone's. Resolving the per-worktree dir would report a worktree of a protected
-# repo as unprotected -- the exact misconception that makes "just use a
-# worktree" the intuitive and wrong containment answer for this bug.
-#
-# `init` and `clone` name a DESTINATION that may not be a repo yet, so resolve
-# from there. `git init <dir>` on a path that IS already a repo is how a working
-# clone acquires core.bare = true.
-# 🔴 SUBCOMMANDS THAT NAME A DESTINATION INSIDE A DENIED TREE. The repo they
-# RUN in is innocent; the path they WRITE to is not. MEASURED, both unrefused:
-#   git init --separate-git-dir <victim>/planted-gitdir <newrepo>  -> planted
-#   git -C <fixture> worktree add --detach <victim>/planted-worktree -> planted
+# ---- SUBCOMMANDS THAT NAME A DESTINATION ------------------------------------
 for a in $rest; do
-  case "$a" in
-    -*) continue ;;
-  esac
+  case "$a" in -*) continue ;; esac
   case "$sub" in
     worktree|submodule)
       if _prot_match "$a"; then
@@ -719,8 +812,7 @@ for a in $rest; do
       ;;
   esac
 done
-_sgd=''
-_sgw=''
+_sgd=''; _sgw=''
 for a in $rest; do
   case "$_sgw" in S) _sgd="$a"; _sgw=''; continue ;; esac
   case "$a" in
@@ -732,27 +824,94 @@ if [ -n "$_sgd" ] && _prot_match "$_sgd"; then
   _refuse "--separate-git-dir would plant a git dir at $_sgd, inside a PROTECTED repository" "$@"
 fi
 
+# ---- REPOSITORY OPERANDS OF THE REMOTE SUBCOMMANDS (F1/F2) ------------------
+# 🔴 THE DESTINATION, not just the URL SHAPE. An earlier revision tested the
+# operand against two URL globs and `continue`d anything that looked like a
+# filesystem path -- so `git -C <fixture> push <victim-bare> +HEAD:refs/heads/
+# main` force-updated a protected bare repo at rc 0 with the ledger at 0.
+# MEASURED. That is the incident's own damage with the guard silent.
+#
+# Only the REPOSITORY operand is inspected (the first non-flag after the
+# subcommand; for `clone`, the source and then the destination), never a
+# refspec.
+case "$sub" in
+  {network})
+    _op1=''; _op2=''
+    for a in $rest; do
+      case "$a" in -*) continue ;; esac
+      if [ -z "$_op1" ]; then _op1="$a"; elif [ -z "$_op2" ]; then _op2="$a"; fi
+    done
+    # 🔴 ONLY `clone` HAS A SECOND REPOSITORY OPERAND. For push/fetch/pull/
+    # ls-remote the second operand is a REFSPEC, and `HEAD:refs/heads/main`
+    # looks exactly like scp syntax to any host:path rule -- its first
+    # slash-segment is `HEAD:refs`, which contains a colon. MEASURED: an
+    # earlier revision of THIS fix refused every legitimate fixture push with
+    # "would contact the NETWORK remote HEAD:refs/heads/main", i.e. it made
+    # itself a permanently-red gate while closing F1.
+    case "$sub" in
+      clone) _cands="$_op1 $_op2" ;;
+      *)     _cands="$_op1" ;;
+    esac
+    for _cand in $_cands; do
+      [ -n "$_cand" ] || continue
+      if _is_network "$_cand"; then
+        _refuse "$sub would contact the NETWORK remote $_cand; this tier is hermetic" "$@"
+      fi
+      case "$_cand" in
+        /*|./*|../*|file://*)
+          _p="${{_cand#file://}}"
+          if _prot_match "$_p"; then
+            _refuse "$sub names $_cand, inside a PROTECTED repository" "$@"
+          fi
+          ;;
+      esac
+    done
+    # A bare NAME resolves through config; `-c remote.<name>.url=` injections
+    # were already refused by the scanner above, so a fresh `git config` here
+    # cannot be fooled by one.
+    case "$_op1" in
+      ''|-*|*/*|*:*) : ;;
+      *)
+        _u=$( ( cd "${{tgt:-.}}" 2>/dev/null && "$REAL" config --get "remote.$_op1.url" 2>/dev/null ) )
+        if [ -n "$_u" ]; then
+          if _is_network "$_u"; then
+            _refuse "$sub would contact the NETWORK remote $_u (via remote.$_op1.url); this tier is hermetic" "$@"
+          fi
+          _prot_match "${{_u#file://}}" && _refuse "$sub targets remote.$_op1.url=$_u, inside a PROTECTED repository" "$@"
+        fi
+        ;;
+    esac
+    # With no operand at all, every configured remote is a candidate.
+    if [ -z "$_op1" ]; then
+      _urls=$( ( cd "${{tgt:-.}}" 2>/dev/null && "$REAL" config --get-regexp '^remote\\..*\\.url$' 2>/dev/null ) )
+      for _u in $_urls; do
+        case "$_u" in remote.*) continue ;; esac
+        if _is_network "$_u"; then
+          _refuse "$sub would contact the NETWORK remote $_u; this tier is hermetic" "$@"
+        fi
+        _prot_match "${{_u#file://}}" && _refuse "$sub targets $_u, inside a PROTECTED repository" "$@"
+      done
+    fi
+    ;;
+esac
+
+# ---- resolve the repo this invocation targets -------------------------------
 case "$sub" in
   init|clone)
     dest=''
     for a in $rest; do
-      case "$a" in
-        -*) continue ;;
-        *) dest="$a" ;;
-      esac
+      case "$a" in -*) continue ;; esac
+      dest="$a"
     done
-    # 🔴 THE DESTINATION IS RELATIVE TO `-C`, NOT TO THIS SHIM'S CWD. `git -C X
-    # init .` means "init X", because git chdirs to X BEFORE reading the
-    # positional. MEASURED as a FALSE POSITIVE: a fixture running
-    # `git -C <tmp_path>/plain-repo init -q -b trunk .` was refused, because the
-    # `.` was resolved against the runner's cwd -- the repo root -- and landed
-    # on the protected repo. A guard that refuses a legitimate fixture is a
-    # permanently-red gate, which is the failure mode that trains everyone to
-    # click through. GUARD 9's own per-target accounting is what surfaced it.
     case "$dest" in
       '') : ;;
       /*) tgt="$dest" ;;
       *)  tgt="${{tgt:-.}}/$dest" ;;
+    esac
+    # F6: the destination need not exist yet, and `_prot_match` no longer needs
+    # it to. Checked directly, because resolution below cannot `cd` into it.
+    case "$dest" in
+      /*) _prot_match "$dest" && _refuse "$sub would create a repository at $dest, inside a PROTECTED repository" "$@" ;;
     esac
     ;;
 esac
@@ -766,34 +925,15 @@ fi
 protected=0
 rcommon=''
 if [ -n "$common" ]; then
-  rcommon=$(readlink -f "$common" 2>/dev/null || echo "$common")
+  rcommon=$(readlink -m "$common" 2>/dev/null || echo "$common")
   _prot_match "$common" && protected=1
 fi
 
-# ---- NETWORK REMOTES: refused in ANY repo, protected or not ------------------
-case "$sub" in
-  {network})
-    urls=$( ( cd "${{tgt:-.}}" 2>/dev/null && "$REAL" config --get-regexp '^remote\\..*\\.url$' 2>/dev/null ) )
-    urls="$urls $rest"
-    for u in $urls; do
-      case "$u" in
-        file://*|/*|./*|../*) continue ;;
-        *://*) _refuse "would contact the NETWORK remote $u; this tier is hermetic" "$@" ;;
-        *@*:*) _refuse "would contact the NETWORK remote $u; this tier is hermetic" "$@" ;;
-      esac
-    done
-    ;;
-esac
-
 # ---- PROTECTED REPO: only an enumerated READ form is forwarded ---------------
 if [ "$protected" = 1 ]; then
-  # 🔴 `status` is a READ that WRITES: it refreshes and rewrites `.git/index`.
-  # MEASURED on a protected repo -- index bytes and mtime both changed. It is
-  # far too common in this suite to refuse (that would be a permanently-red
-  # gate), and the write is a cache refresh that cannot lose data, so the shim
-  # forwards it with `--no-optional-locks`, which git provides for exactly this
-  # and which was MEASURED to leave the index byte-identical with identical
-  # output.
+  # `status` is a READ that WRITES -- it rewrites `.git/index`. Refusing it
+  # would be a permanently-red gate, and the write is a stat-cache refresh, so
+  # it is forwarded with the flag git provides for exactly this.
   if [ "$sub" = status ]; then
     exec "$REAL" --no-optional-locks "$@"
   fi
@@ -824,7 +964,7 @@ def install(guard_dir: Path, protected_repos, protected_config_files,
     guard_dir = Path(guard_dir)
     guard_dir.mkdir(parents=True, exist_ok=True)
 
-    real = shutil.which("git")
+    real = real_git() if shutil.which("git") else None
     if real is None:
         raise RuntimeError("testlib.norepo.install: no `git` on PATH to shadow.")
     if Path(real).parent.resolve() == guard_dir.resolve():
@@ -882,6 +1022,160 @@ def probe_target(guard_dir) -> str:
         return ""
 
 
+def real_git() -> str:
+    """The real `git`, with any GUARD 9 shim dir removed from the search path.
+
+    🔴 THE INSTALLER MUST NOT BE SUBJECT TO THE GUARD IT INSTALLS. `run-tests.sh`
+    puts a shim first on PATH, and a nested `install()` (every test that builds
+    its own guard) then resolves `git` to THAT shim. `protected_paths` asks git
+    to enumerate worktrees; when the outer shim refuses that call, the protected
+    set silently comes back SMALLER and the new guard protects less.
+
+    MEASURED: a mutant that made `_prot_match` accept relative operands
+    SURVIVED for exactly this reason -- it caused the outer shim to refuse
+    `git worktree list` inside `protected_paths`, so the victim's work-tree
+    root dropped out of the protected set and the assertion it should have
+    tripped no longer applied. A mutant that disables the guard by shrinking
+    what the guard covers is not an isolated mutation, and the fix is to make
+    the installer independent rather than to reword the test.
+
+    A guard dir is identified STRUCTURALLY, by the ledger file `install()`
+    writes beside the shim -- not by a name pattern a future dir could miss.
+    """
+    parts = os.environ.get("PATH", "").split(os.pathsep)
+    clean = [d for d in parts
+             if d and not (Path(d) / PROTECTED_LIST_NAME).exists()]
+    found = shutil.which("git", path=os.pathsep.join(clean))
+    # Fall back to the ordinary lookup rather than failing: a caller with no
+    # real git on PATH has a different problem, and `install()` reports it.
+    return found or (shutil.which("git") or "git")
+
+
+def farm_is_complete(farm, src_names) -> bool:
+    """Is `farm` a COMPLETE stand-in for git's exec-path?
+
+    🔴 THE SET, NOT THE COUNT. A count matches when one helper is swapped for
+    another; only the set catches a missing or renamed one. And `git` must be
+    OUR COPY, not a symlink to the binary it is meant to shadow -- a farm whose
+    `git` links to the real one is a farm that guards nothing while looking
+    complete.
+
+    Extracted so it can be tested directly: inside `install_exec_farm` the
+    check is unreachable on a healthy box (the build starts from a clean
+    directory and always produces the right set), and an unreachable guard is
+    one nobody has watched work.
+    """
+    farm = Path(farm)
+    try:
+        have = set(os.listdir(farm))
+    except OSError:
+        return False
+    if have != set(src_names):
+        return False
+    # 🔴 EVERY name git dispatches on must be OUR copy, not a link to the
+    # binary it is meant to shadow. Checked by NAME -- `git` and `git-*` --
+    # because that is the property git uses, and it holds whether the original
+    # was a hardlink, a symlink or a copy.
+    for n in have:
+        if n == "git" or n.startswith("git-"):
+            if (farm / n).is_symlink() or not (farm / n).is_file():
+                return False
+    return True
+
+
+def install_exec_farm(guard_dir) -> str:
+    """Own `git`'s OWN libexec, so a git-SPAWNED child is guarded too.
+
+    🔴 THIS CLOSES THE RESIDUAL THIS MODULE PREVIOUSLY ONLY DOCUMENTED. Git
+    PREPENDS `libexec/git-core` to PATH for every process it spawns, so a bare
+    `git` inside a `!`-alias, a hook, a clean/smudge filter or `rebase --exec`
+    resolves to the REAL binary and never reaches a PATH shim. That covered the
+    case where the alias or hook is ALREADY IN a repo's own config, which no
+    amount of scanning the CURRENT invocation can see.
+
+    The farm is a directory of symlinks to every entry of `git --exec-path`
+    that is NOT a dispatch name, plus a copy of the shim under EVERY dispatch
+    name -- `git` and each of the ~181 `git-<verb>` entries. Exported as
+    GIT_EXEC_PATH, it is what git hands its children, so the child's `git` is
+    ours. Copying the shim only as `git` was the earlier, WITHDRAWN version:
+    git dispatches on argv[0], so `git-config` reached the real binary.
+
+    MEASURED, with an alias in the fixture's OWN `.git/config`:
+        PATH shim only   -> rc 0, the victim gained a commit  (residual)
+        + the farm       -> rc 99, refused, victim unchanged  (closed)
+    and ordinary work is unaffected: status / log / commit / diff /
+    `rebase --help` all rc 0 through the farm.
+
+    ⚠ THE REMAINING ESCAPES ARE **TWO**, AND THEY WERE DERIVED, NOT ASSUMED.
+    Six alias-body shapes were measured against the farm:
+
+        !git …                    guarded      (resolves through the farm)
+        !sh -c 'git …'            guarded
+        !env git …                guarded
+        !command git …            guarded
+        !/abs/path/to/git …       🔴 ESCAPES   (PATH is never consulted)
+        !touch <victim>/file      🔴 ESCAPES   (never invokes git at all)
+
+    An earlier revision of this comment claimed the residual was ONE -- the
+    shell case -- and omitted the absolute-path case entirely. Owning git's
+    exec path bounds what GIT will resolve for a child; it cannot bind a
+    command that bypasses resolution or never asks for git.
+
+    Returns the farm path, or "" when the exec-path cannot be resolved (the
+    caller reports that rather than proceeding as if it were armed).
+    """
+    guard_dir = Path(guard_dir)
+    shim = guard_dir / "git"
+    if not shim.exists():
+        return ""
+    try:
+        r = subprocess.run([real_git(), "--exec-path"], capture_output=True,
+                           text=True, timeout=15)
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if r.returncode != 0 or not r.stdout.strip():
+        return ""
+    src_dir = Path(r.stdout.strip())
+    if not src_dir.is_dir():
+        return ""
+
+    # 🔴 DERIVED EVERY RUN, AND VERIFIED AS A SET. `os.listdir(src_dir)` is
+    # re-read on every call, so a helper added by a git upgrade is picked up
+    # automatically -- this is not a snapshot ledger. MEASURED: 189 source
+    # entries, 189 in the farm, sets equal.
+    #
+    # 🔴 AND IT FAILS CLOSED. An earlier revision `continue`d past any entry
+    # that already existed, so a pre-existing NON-symlink was left in place and
+    # the farm was returned as usable anyway -- MEASURED: a planted regular
+    # file at `.git-archimport-wrapped` survived and `install_exec_farm` still
+    # handed back a path. That is a hole in the fix for the
+    # channel-vs-list lesson, which is the same shape all over again. Entries
+    # are now REPLACED, and the final set is compared against the source before
+    # the farm is declared usable.
+    src_names = set(os.listdir(src_dir))
+    farm = guard_dir / EXEC_FARM_NAME
+    if farm.exists():
+        shutil.rmtree(farm, ignore_errors=True)
+    try:
+        farm.mkdir(parents=True, exist_ok=True)
+        for name in src_names:
+            if name == "git" or name.startswith("git-"):
+                # 🔴 EVERY DISPATCH NAME IS OURS. Substituting only `git` left
+                # ~181 `git-<verb>` entries pointing at the real binary, and
+                # git dispatches on argv[0] -- `git-config -f <denied>/config`
+                # landed the incident's own signature without spelling `git`.
+                shutil.copy2(shim, farm / name)
+                continue
+            (farm / name).symlink_to(src_dir / name)
+        shutil.copy2(shim, farm / "git")
+    except OSError:
+        return ""
+
+    if not farm_is_complete(farm, src_names):
+        return ""
+    return str(farm)
+
+
 def protected_paths(*starts) -> list[str]:
     """Every path that IS the repo each start sits in: its `--git-common-dir`
     AND the root of every working tree attached to it.
@@ -917,7 +1211,7 @@ def protected_paths(*starts) -> list[str]:
             continue
         try:
             r = subprocess.run(
-                ["git", "-C", str(p), "rev-parse", "--path-format=absolute",
+                [real_git(), "-C", str(p), "rev-parse", "--path-format=absolute",
                  "--git-common-dir"],
                 capture_output=True, text=True, timeout=15)
         except (OSError, subprocess.SubprocessError):
@@ -930,7 +1224,7 @@ def protected_paths(*starts) -> list[str]:
         # entry or `GIT_WORK_TREE=<that worktree>` walks straight past.
         try:
             w = subprocess.run(
-                ["git", "-C", str(p), "worktree", "list", "--porcelain"],
+                [real_git(), "-C", str(p), "worktree", "list", "--porcelain"],
                 capture_output=True, text=True, timeout=15)
         except (OSError, subprocess.SubprocessError):
             continue
@@ -938,6 +1232,34 @@ def protected_paths(*starts) -> list[str]:
             for line in w.stdout.splitlines():
                 if line.startswith("worktree "):
                     add(line[len("worktree "):].strip())
+
+        # 🔴 A PROTECTED REPO'S LOCAL REMOTES ARE PART OF IT. Pushing to the
+        # bare repository a protected clone pushes to is the same damage as
+        # writing the clone -- and MEASURED, it was allowed: `git -C <fixture>
+        # push <victim-bare> +HEAD:refs/heads/main` force-updated it at rc 0
+        # with the ledger at 0. For the operator's own clone the analogue is
+        # the PUBLIC repo, which the network rule already refuses; this closes
+        # the local-bare case so a caller does not have to know to pass it.
+        try:
+            r2 = subprocess.run(
+                [real_git(), "-C", str(p), "config", "--get-regexp", r"^remote\..*\.url$"],
+                capture_output=True, text=True, timeout=15)
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if r2.returncode != 0:
+            continue
+        for line in r2.stdout.splitlines():
+            parts = line.split(None, 1)
+            if len(parts) != 2:
+                continue
+            url = parts[1].strip()
+            if url.startswith("file://"):
+                url = url[len("file://"):]
+            # Only LOCAL paths: a network remote is handled by the network rule,
+            # and adding one here would put a URL in a path ledger.
+            if not url.startswith("/"):
+                continue
+            add(url)
     return out
 
 
@@ -978,19 +1300,52 @@ def main(argv: list[str] | None = None) -> int:
     # decoy it created. The measured incident vector is `githooks/install.sh`
     # running `git config --global core.hooksPath` with NO env var set at all,
     # which resolves to exactly this path.
+    # 🔴 F5 -- ASK GIT WHERE `--global` LIVES; do not hardcode `~/.gitconfig`.
+    # MEASURED on this host: `~/.gitconfig` DOES NOT EXIST. git uses
+    # `${XDG_CONFIG_HOME:-~/.config}/git/config`, and `git config --global
+    # --list --show-origin` reports `file:/home/<user>/.config/git/config`. The
+    # ledger was therefore protecting a file that is never written while the
+    # operator's real global config was unprotected -- non-exploitable here
+    # only because the store path it would be reached through is read-only,
+    # i.e. blocked by the filesystem rather than by this guard.
     cfg: list[str] = []
-    for p in (Path.home() / ".gitconfig",
-              Path(os.environ.get("GIT_CONFIG_GLOBAL") or Path.home() / ".gitconfig"),
-              Path("/etc/gitconfig"),
-              Path(os.environ.get("GIT_CONFIG_SYSTEM") or "/etc/gitconfig")):
-        s = str(p)
-        if s not in cfg:
-            cfg.append(s)
+
+    def _add(x) -> None:
+        v = str(Path(x).expanduser())
+        if v not in cfg:
+            cfg.append(v)
+
+    xdg = os.environ.get("XDG_CONFIG_HOME") or (Path.home() / ".config")
+    _add(Path(xdg) / "git" / "config")     # where git actually looks first
+    _add(Path.home() / ".gitconfig")       # the other candidate, still guarded
+    _add(Path("/etc/gitconfig"))
+    if os.environ.get("GIT_CONFIG_GLOBAL"):
+        _add(os.environ["GIT_CONFIG_GLOBAL"])
+    if os.environ.get("GIT_CONFIG_SYSTEM"):
+        _add(os.environ["GIT_CONFIG_SYSTEM"])
+    # ...and whatever git itself reports, with our own overrides stripped so
+    # the answer is the OPERATOR's, not this run's redirect.
+    try:
+        _env = {k: v for k, v in os.environ.items()
+                if not k.startswith("GIT_CONFIG")}
+        _r = subprocess.run(
+            [real_git(), "config", "--global", "--list", "--show-origin"],
+            capture_output=True, text=True, timeout=15, env=_env)
+        for _line in _r.stdout.splitlines():
+            if _line.startswith("file:") and "\t" in _line:
+                _add(_line.split("\t", 1)[0][len("file:"):])
+    except (OSError, subprocess.SubprocessError):
+        pass
     try:
         install(guard_dir, repos, cfg, allow_no_repos=allow)
     except RuntimeError as exc:
         print(f"norepo: {exc}", file=_sys.stderr)
         return 2
+    farm = install_exec_farm(guard_dir)
+    if farm:
+        print(f"exec-farm={farm}")
+    else:
+        print("exec-farm=UNAVAILABLE")
     for r in repos:
         print(f"protected={r}")
     for c in cfg:

--- a/scripts/testlib/norepo.py
+++ b/scripts/testlib/norepo.py
@@ -1,0 +1,1003 @@
+#!/usr/bin/env python3
+"""A `git` interceptor that makes "no test may mutate a REAL repository" true.
+
+🔴 THE HAZARD (MEASURED 2026-08-21, on the operator's own workbench)
+---------------------------------------------------------------------
+Running the Python test tier reconfigured and rewrote the operator's real
+`~/workspace/devrc` clone, and pushed to the real GitHub remote. What was found
+on the clone afterwards:
+
+    core.bare = true                 on a WORKING clone -- every later
+                                     `git status` failed "must be run in a work
+                                     tree"
+    local `main` renamed to `trunk`, HEAD left on `trunk`
+    origin repointed at a pytest tmpdir that no longer existed
+    fixture commits by `t <t@t>` in its history
+
+and on the PUBLIC repo, 63 fixture commits reached `refs/heads/main` in a
+26-second burst starting 19:27:57Z, leaving the default branch at a single-file
+fixture tree. `trunk` and three feature branches were hit too. Nothing was lost
+only because another session still had the good sha.
+
+🔴 THE CULPRIT IS COMMITTED ON `origin/main` AND WILL FIRE AGAIN
+-----------------------------------------------------------------
+`scripts/repo-cos/tests/test_prescan.py::_init_clone` maps one-for-one onto the
+reflog: `config user.email t@t` -> the `t <t@t>` author, `commit -m seed`,
+`branch -M trunk`, `push origin HEAD:trunk`. It is ordinary, correctly written
+test code -- every call binds `-C` to a `tmp_path` fixture -- which is exactly
+why reading call sites found nothing to fix.
+
+Two OTHER mechanisms were traced and both were REFUTED by measurement (see
+`scripts/tests/test_no_real_repo_writes.py`, which pins the refutations so they
+are not re-derived). What makes correct code dangerous is a whole class rather
+than a call site:
+
+    An ambient GIT_DIR OVERRIDES `git -C <path>`.
+
+MEASURED, git 2.55: with `GIT_DIR` naming repo V, `git -C <elsewhere> branch -m
+main trunk` renames V's branch and repoints V's HEAD, and `git -C <elsewhere>
+remote set-url origin <tmp>/does-not-exist.git` repoints V's origin -- which is
+byte-for-byte the shape of the damage above. Every fixture in this repo binds
+`-C` or `cwd=` correctly; a single inherited variable retargets ALL of them at
+once, and no call site looks wrong. GIT_WORK_TREE, GIT_INDEX_FILE,
+GIT_OBJECT_DIRECTORY and GIT_COMMON_DIR are the same shape.
+
+So auditing call sites cannot close this. `run-tests.sh` scrubs those variables
+(the direct fix) AND installs this shim (the structural one), because the next
+route will not be a variable anyone has heard of either.
+
+🔴 A GUARD IS BOUNDED BY THE CHANNEL IT OBSERVES, NOT BY THE COMPLETENESS OF ITS
+LIST -- AND THE SECOND FAILURE IS INVISIBLE TO ANY CARE SPENT ON THE FIRST
+--------------------------------------------------------------------------------
+MEASURED, git 2.55: `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_<n>` /
+`GIT_CONFIG_VALUE_<n>` are NOT in `man git` and git honours them. They set
+arbitrary config for one invocation and TOUCH NO FILE:
+
+    GIT_CONFIG_GLOBAL=<decoy> GIT_CONFIG_SYSTEM=/dev/null
+      git config --get core.hooksPath          -> <unset>          (guard held)
+    ...plus GIT_CONFIG_COUNT=1 KEY_0=core.hooksPath VALUE_0=/tmp/PWNED-hooks
+      git config --get core.hooksPath          -> /tmp/PWNED-hooks
+    decoy afterwards: 0 bytes, NEVER OPENED
+
+An enumerated ledger fails on entries nobody knew about; a CHANNEL-scoped guard
+fails on mechanisms that do not use that channel at all. This one reproduces the
+measured `core.hooksPath` vector while a config-FILE redirect watches a file
+that is never written and a path-protection model sees no protected path. Both
+config defences look green and neither is engaged.
+
+That is the argument for asking GIT for the effective answer wherever possible
+and treating `RETARGETING_ENV` as a backstop rather than as the guard.
+
+🔴 WHY A CLEANUP STEP IS NOT AN ACCEPTABLE FIX
+-----------------------------------------------
+Every fixture that re-points a real repo restores it on TEARDOWN. A killed run,
+an assertion that raises past the restore, a `pytest -x` that stops the session
+-- each leaves the operator's clone pointed at a temp directory with no error
+anywhere. This guard does not undo the write. The mutating `git` process never
+starts.
+
+🔴 A WORKTREE IS NOT CONTAINMENT -- THE COMMON DIR IS THE UNIT
+---------------------------------------------------------------
+"Develop this in a worktree" is the intuitive answer and it is WRONG. A linked
+worktree's `.git` is a FILE pointing back into the real clone's
+`.git/worktrees/<name>`, and `git rev-parse --git-common-dir` from inside it
+resolves to the REAL clone's `.git`: refs, remotes, config and reflog are
+shared. A push from a worktree reaches the real remote. So this file protects
+COMMON DIRS, and `protected_paths()` maps every path to one -- which makes
+protecting `~/workspace/devrc` automatically protect all of its agent
+worktrees. The only safe place to develop against this guard is a STANDALONE
+clone with `origin` removed.
+
+🔴 PATH-VALIDATING OR ENVIRONMENT-NEUTRALISING? BOTH, AND NEITHER ALONE IS ENOUGH
+---------------------------------------------------------------------------------
+The question matters because the vector BYPASSES PATH ARGUMENTS ENTIRELY, so a
+guard that only inspected `-C` would be a guard whose description is wider than
+its reach. The honest answer, in three parts:
+
+  1. The shim NEVER validates the path ARGUMENTS. It asks git itself --
+     `rev-parse --path-format=absolute --git-common-dir`, from the same cwd and
+     with the same environment -- so what it validates is the repo git WILL
+     use. GIT_DIR and GIT_COMMON_DIR are therefore covered by construction:
+     they change git's answer, and the shim reads that answer.
+  2. That is NOT sufficient on its own. GIT_WORK_TREE, GIT_INDEX_FILE and
+     GIT_OBJECT_DIRECTORY leave the repo identity alone and redirect only WHERE
+     THE WRITE LANDS -- so resolution answers "the fixture", truthfully, while
+     the bytes go to the operator's clone. GIT_CONFIG_COUNT is worse still: it
+     writes no file at all. All of them are refused explicitly, by the
+     environment check in the shim -- which is DELIBERATELY in the shim, at call
+     time, because these are per-invocation variables living in the CHILD's
+     environment. A check run in the plugin's process, or around a test, reads
+     its OWN environment, comes back clean, and PASSES while the child is fully
+     injected.
+  3. `run-tests.sh` also UNSETS the whole family. That is the weakest of the
+     three and is not the guard: it governs what the runner INHERITS and does
+     nothing about a test that builds its own subprocess environment. It is
+     kept because a run that never inherits the variable never generates the
+     write at all.
+
+So: environment-neutralising at the runner, environment-AWARE resolution in the
+shim, and an explicit environment refusal for the variables resolution cannot
+see. `test_no_real_repo_writes.py` arms every one of the eight vectors against a
+real victim and asserts the victim is byte-unchanged -- an assertion that a
+variable is UNSET would be a claim about setup, not about the guard.
+
+🔴 AND EACH ARMED VECTOR PROVES ITS OWN DANGER. Every one runs a second,
+UNGUARDED arm that must move an asserted axis. MEASURED: four of ten vectors
+originally written there moved NOTHING -- `checkout -f HEAD` against a victim
+already at HEAD writes nothing observable whether refused or not, so the
+assertion set passed identically either way. An armed control that can only
+agree with itself is the same defect as a mutant that dies for the wrong
+reason.
+
+HOW IT WORKS
+------------
+`install()` writes a `git` shim into a directory that `run-tests.sh` prepends to
+PATH for the whole run, exactly as `testlib.nolaunch` does for the host
+launchers -- the same enforcement point, for the same reason: 24 targets, of
+which the non-pytest ones (HOOK_TESTS, SHELL_TESTS) no conftest can ever reach.
+The shim:
+
+  1. parses git's GLOBAL options to find the subcommand and the repo targeted;
+  2. sends anything on `ALWAYS_READ` straight to the real binary with no extra
+     work -- the overwhelming majority of calls, and it must stay cheap;
+  3. otherwise resolves the target's `--git-common-dir` and compares it against
+     the PROTECTED list;
+  4. for a protected repo, forwards ONLY an enumerated read form. Everything
+     else -- including a subcommand this shim has never heard of -- is refused,
+     recorded, and exits 99.
+
+🔴 IT FAILS CLOSED, AND A FALSE REFUSAL IS LOUD
+------------------------------------------------
+An unknown subcommand against a protected repo is REFUSED, not forwarded. The
+alternative (block a known-bad list, forward the rest) fails open on the next
+subcommand someone uses -- `testlib.nolaunch` makes the same argument for
+`systemctl`'s verb split. The cost is that a legitimate READ not on the list is
+refused; that is why every refusal prints the full argv, the cwd and this file's
+path. A false refusal is one line added to `PROTECTED_READ_FORMS`, diagnosable
+from the message alone.
+
+WHAT IT DELIBERATELY STILL ALLOWS
+---------------------------------
+  * every mutating git operation on a repo that is NOT protected -- i.e. every
+    fixture repo built under `tmp_path`. That is the positive control the runner
+    requires: a guard that refuses everything is indistinguishable from a guard
+    that works, so `run-tests.sh` fails a target whose legitimate git work
+    stopped happening.
+  * every enumerated READ of a protected repo. Tests legitimately read the tree
+    under test (`git ls-files`, `git log`, `git branch --show-current`) and
+    several gates are built on exactly that.
+
+🔴 KNOWN BLIND SPOTS, STATED RATHER THAN HIDDEN
+-----------------------------------------------
+Interception is by PATH, so a call that spells an ABSOLUTE `/usr/bin/git`
+bypasses it, as does a test that REPLACES `$PATH` outright rather than
+prepending to it.
+
+🔴 AND THE SHIM IS **NOT** INHERITED BY GIT-SPAWNED CHILDREN. Git PREPENDS its
+own `libexec/git-core` to `PATH` for every process it spawns, so a bare `git`
+inside anything git launches resolves to the REAL binary and never reaches this
+shim -- at ANY depth. MEASURED: `git -c 'alias.x=!git -C <victim> commit …' x`
+returned rc 0 with the victim commit landed. That surface is large: `!`-aliases,
+hooks, `core.fsmonitor`, clean/smudge filters, `GIT_SSH_COMMAND`,
+`rebase --exec`, `submodule foreach`.
+
+What is done about it: the shim refuses the CHANNELS that INJECT such a child
+(`-c alias.*=!…`, the same via `GIT_CONFIG_KEY_<n>`, and any injected value
+aimed at a protected path or a network remote), and the network rule refuses the
+push before an ssh child is ever spawned. What is NOT covered, and is stated
+rather than implied: a `!`-alias, hook or filter ALREADY PRESENT in a repo's own
+config, executed by a git command this shim forwarded. Nothing in this tree does
+that, and nothing here would stop it. Nothing in this tree does either today
+(`test_no_real_repo_writes.py` pins that).
+
+The per-target control comes in TWO flavours for exactly this reason:
+`via=inherited` (fired from the runner's environment) proves the shim is armed
+for the RUNNER, and on its own would make every `refused=0` a statement about
+the runner -- a 32-row table reading as rigorous while measuring one thing
+thirty-two times. `via=plugin` (fired by `testlib.norepo_plugin` from INSIDE the
+target's process) is the claim about the target. The runner counts and prints
+them separately and requires both from a pytest target. The five HOOK_TESTS and
+the SHELL_TEST can load no plugin, so `plugin:0` is CORRECT for them and is
+labelled `via=inherited (not pytest)` rather than being summed into one number
+where a dead plugin would look like a healthy non-pytest target.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from .mockbin import write_exec
+
+LOG_NAME = "git-ops.log"
+PROTECTED_LIST_NAME = "protected-repos.txt"
+PROTECTED_CONFIG_NAME = "protected-config.txt"
+
+#: The handle `run-tests.sh` exports so anything under the runner can find the
+#: ONE guard directory. Same shape as `nolaunch.STUB_DIR_ENV`.
+GUARD_DIR_ENV = "DEVRC_TEST_GITGUARD_DIR"
+
+#: Set for the runner's OWN per-target probe. It does not weaken the refusal --
+#: the probe is refused exactly like any other write -- it only changes which
+#: ledger line is written, so the control can be counted separately from a leak.
+PROBE_ENV = "DEVRC_TEST_GITGUARD_PROBE"
+
+#: Which MECHANISM fired a control: `plugin` (the target's own process, via
+#: `testlib.norepo_plugin`) or `inherited` (the runner's environment). Counted
+#: separately, because a runner-side control proves the shim is armed for the
+#: RUNNER and says nothing about the target's process.
+PROBE_VIA_ENV = "DEVRC_TEST_GITGUARD_VIA"
+
+#: Written by `install()`: the path the repo probe should target, or empty when
+#: no real repository is protected. ONE definition, read by both the runner and
+#: the plugin, so they cannot disagree about what is protected.
+PROBE_TARGET_NAME = "probe-target.txt"
+
+#: The two line prefixes the shim writes and `run-tests.sh` counts. Spelled on
+#: both sides of a process boundary, so `test_no_real_repo_writes.py` pins them
+#: BOTH ways: a rename on one side alone would leave the accounting matching
+#: nothing and reporting a clean run.
+REFUSED_PREFIX = "git(refused)"
+CONTROL_PREFIX = "git(control)"
+
+#: Exit status a refused invocation takes. Deliberately NOT 0. Unlike a
+#: fire-and-forget desktop launcher, a caller that asked git to WRITE and got a
+#: silent success would assert against a state that was never created and fail
+#: somewhere else entirely. 99 is outside the range git uses for its own
+#: outcomes, so it is recognisable in a traceback.
+REFUSED_EXIT = 99
+
+#: Environment variables that RETARGET git independently of `-C` and cwd.
+#: 🔴 GIT_DIR beats `-C` -- MEASURED, see the module docstring. Scrubbing these
+#: is the direct fix for the one mechanism this incident proved possible, and it
+#: is separate from the shim on purpose: the shim would catch the write, but a
+#: run that never inherits the variable never generates it.
+#:
+#: 🔴 THIS LEDGER IS INCOMPLETE BY CONSTRUCTION, AND SAYING SO IS THE POINT.
+#: It was enumerated from `man git`, and git honours variables the man page
+#: does not document — `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_<n>` /
+#: `GIT_CONFIG_VALUE_<n>` are the measured example, and they were missing from
+#: this tuple until a peer session reproduced the bypass. So this list is a
+#: BACKSTOP, not the guard. The guard is the shim asking git for the answer it
+#: will actually use.
+RETARGETING_ENV = (
+    "GIT_DIR",
+    "GIT_COMMON_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    # Undocumented in `man git`; honoured anyway. Unsetting COUNT disables the
+    # whole KEY_<n>/VALUE_<n> mechanism, so one name covers all of them.
+    "GIT_CONFIG_COUNT",
+    # ⚠ NOT WRITE TARGETS, and deliberately NOT in the shim's refusal set: a
+    # guard that refuses harmless things is a permanently-red gate. They are
+    # scrubbed only so the runner's environment is predictable.
+    "GIT_NAMESPACE",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_PREFIX",
+)
+
+#: The subset of `RETARGETING_ENV` the shim actually REFUSES on. Everything
+#: here has been MEASURED to move an axis the battery asserts on; membership is
+#: earned by that measurement, not by looking dangerous.
+REFUSED_ENV = (
+    "GIT_DIR",
+    "GIT_COMMON_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_CONFIG_COUNT",
+)
+
+#: Subcommands that cannot write and cannot reach a network remote. They go
+#: straight through with no repo resolution at all.
+#:
+#: 🔴 Membership is "cannot mutate in ANY argument form". `branch`, `config`,
+#: `remote`, `tag`, `stash`, `worktree`, `notes`, `reflog`, `symbolic-ref` and
+#: `submodule` all have read forms and are deliberately ABSENT: they are
+#: classified per-invocation below, because an ARGUMENT must never be able to
+#: promote a mutation (the `systemctl --user stop status` shape from
+#: `testlib.nolaunch`).
+ALWAYS_READ = (
+    "annotate", "blame", "cat-file", "check-attr", "check-ignore",
+    "check-ref-format", "cherry", "column", "count-objects", "describe",
+    "diff", "diff-files", "diff-index", "diff-tree", "for-each-ref", "grep",
+    "help", "interpret-trailers", "log", "ls-files", "ls-tree", "merge-base",
+    "name-rev", "rev-list", "rev-parse", "shortlog", "show", "show-ref",
+    "stripspace", "var", "verify-commit", "verify-pack",
+    "verify-tag", "version", "whatchanged",
+)
+
+#: Subcommands that CONTACT A REMOTE. Refused whenever the remote they would
+#: reach is not a local filesystem path -- in ANY repo, protected or not. This
+#: is the only rule that covers a real clone nobody enumerated, and it is what
+#: stands between a fixture and the public repo's default branch.
+NETWORK_SUBCOMMANDS = ("push", "fetch", "pull", "clone", "ls-remote")
+
+#: Read forms of the dual-mode subcommands, as `(<sub>, <sh-case-pattern>)`
+#: matched against the arguments FOLLOWING the subcommand, space-prefixed (so a
+#: pattern cannot match the tail of a longer flag, and a bare subcommand matches
+#: the empty pattern). Adding one is a deliberate act of accounting.
+PROTECTED_READ_FORMS = (
+    ("config", "*--get*"),
+    ("config", "*--list*"),
+    ("config", "* -l*"),
+    ("remote", ""),
+    ("remote", " -v"),
+    ("remote", " --verbose"),
+    ("remote", " get-url*"),
+    # `branch`: the read flags only. `-m/-M/-d/-D/-f/-c/-C/-u/--set-upstream-to`
+    # and a bare positional branch name are NOT here, so they are refused --
+    # `branch -m main trunk` is one half of the measured damage.
+    ("branch", " --show-current*"),
+    ("branch", " -r*"),
+    ("branch", " -a*"),
+    ("branch", " --list*"),
+    ("branch", " -v"),
+    ("branch", " -vv"),
+    ("branch", " --contains*"),
+    ("branch", " --format*"),
+    ("worktree", " list*"),
+    ("tag", " -l*"),
+    ("tag", " --list*"),
+    ("stash", " list*"),
+    ("stash", " show*"),
+    ("reflog", ""),
+    ("reflog", " show*"),
+    ("notes", " list*"),
+    ("notes", " show*"),
+    ("submodule", " status*"),
+    ("submodule", " summary*"),
+    # One-argument `symbolic-ref` READS a ref; the TWO-argument form WRITES it,
+    # and that is how a HEAD gets repointed at another branch. `--delete` is
+    # deliberately absent.
+    ("symbolic-ref", " -q*"),
+    ("symbolic-ref", " --short*"),
+    ("symbolic-ref", " HEAD"),
+)
+
+
+def log_path(guard_dir: Path) -> Path:
+    """Where the shim records refusals and the runner's per-target controls."""
+    return Path(guard_dir) / LOG_NAME
+
+
+def sh_pattern(pat: str) -> str:
+    """Render `pat` as a POSIX-sh `case` pattern with its SPACES made literal.
+
+    🔴 QUOTING THE WHOLE PATTERN IS THE BUG, NOT THE FIX. Inside a `case`, a
+    quoted character is LITERAL -- so `'*--get*'` matches the four-character
+    string `*--get*` and nothing else, while an UNQUOTED pattern containing a
+    space is a syntax error that kills the whole shim. Measured: the first
+    revision did both, and every branch of the guard died at parse time. So the
+    spaces are quoted and the wildcards are not.
+    """
+    if pat == "":
+        return "''"
+    return pat.replace(" ", '" "')
+
+
+def _read_forms_case(sub: str) -> str:
+    return "|".join(sh_pattern(p) for s, p in PROTECTED_READ_FORMS if s == sub)
+
+
+def shim_body(real_git: str, log: Path, protected_list: Path,
+              protected_config: Path) -> str:
+    """The POSIX-sh body of the `git` shim. No shebang -- write_exec owns it.
+
+    🔴 EVERY BRANCH EITHER `exec`s THE REAL BINARY OR REFUSES WITH A NON-ZERO
+    STATUS. There is no path that returns success without having done the work:
+    a git shim that silently no-opped a `commit` would leave the test asserting
+    against a commit that does not exist, and the failure would point anywhere
+    but here.
+    """
+    always_read = "|".join(sorted(set(ALWAYS_READ)))
+    network = "|".join(NETWORK_SUBCOMMANDS)
+    read_cases = "\n".join(
+        f"    {sub}) case \"$rest\" in {_read_forms_case(sub)}) _pass \"$@\" ;; esac ;;"
+        for sub in sorted({s for s, _ in PROTECTED_READ_FORMS})
+    )
+
+    return f"""
+REAL='{real_git}'
+LOG='{log}'
+PROT='{protected_list}'
+PROTCFG='{protected_config}'
+
+_pass() {{ exec "$REAL" "$@"; }}
+
+# $1 = reason, rest = the original argv.
+_refuse() {{
+  reason="$1"; shift
+  if [ "${{{PROBE_ENV}:-0}}" = 1 ]; then
+    printf '{CONTROL_PREFIX}\\tvia=%s\\t%s\\tgit %s\\n' "${{{PROBE_VIA_ENV}:-inherited}}" "$reason" "$*" >> "$LOG" 2>/dev/null || true
+  else
+    printf '{REFUSED_PREFIX}\\t%s\\tgit %s\\n' "$reason" "$*" >> "$LOG" 2>/dev/null || true
+  fi
+  echo "GUARD 9 (scripts/testlib/norepo.py) REFUSED a git invocation." >&2
+  echo "  reason : $reason" >&2
+  echo "  argv   : git $*" >&2
+  echo "  cwd    : $PWD" >&2
+  echo "  No test may mutate a REAL repository, rewrite the operator's git" >&2
+  echo "  config, or reach a network remote. On 2026-08-21 this tier set" >&2
+  echo "  core.bare on the operator's clone, renamed its main branch and put" >&2
+  echo "  ~40 fixture commits over the PUBLIC repo's default branch." >&2
+  echo "  Build the fixture repo under tmp_path and target it explicitly." >&2
+  echo "  A legitimate READ belongs in norepo.PROTECTED_READ_FORMS." >&2
+  exit {REFUSED_EXIT}
+}}
+
+# ---- parse git's GLOBAL options, stopping at the subcommand ------------------
+# Only -C and --git-dir change WHICH repo is targeted. -c/--work-tree/
+# --namespace/--config-env/--super-prefix take a value that must be skipped so
+# it cannot be mistaken for the subcommand.
+sub=''; tgt=''; gdir=''; want=''; cvals=''
+for a in "$@"; do
+  case "$want" in
+    C) tgt="$a"; want=''; continue ;;
+    D) gdir="$a"; want=''; continue ;;
+    K) cvals="$cvals
+$a"; want=''; continue ;;
+    E) cvals="$cvals
+env:$a"; want=''; continue ;;
+    X) want=''; continue ;;
+  esac
+  case "$a" in
+    -C) want=C; continue ;;
+    --git-dir) want=D; continue ;;
+    --git-dir=*) gdir="${{a#--git-dir=}}"; continue ;;
+    # 🔴 `-c key=value` is CAPTURED, not skipped. Skipping it is how
+    # `git -c alias.x='!git -C <victim> commit' x` and
+    # `git -c remote.origin.url=<github> push` both walked straight past an
+    # earlier revision of this shim -- MEASURED, victim commit landed and the
+    # push reached GitHub.
+    -c) want=K; continue ;;
+    --config-env) want=E; continue ;;
+    --config-env=*) cvals="$cvals
+env:${{a#--config-env=}}"; continue ;;
+    --work-tree|--namespace|--super-prefix) want=X; continue ;;
+    -*) continue ;;
+    *) sub="$a"; break ;;
+  esac
+done
+
+# ---- FAST PATH ---------------------------------------------------------------
+case "$sub" in
+  ''|{always_read}) _pass "$@" ;;
+esac
+
+# 🔴 PATHNAME EXPANSION OFF from here down. The loops below deliberately
+# word-split `$rest` and `$urls`, and an unquoted `$var` in a `for` list is
+# GLOBBED as well as split -- so a `*` inside a refspec or a path would expand
+# against the cwd and the guard would inspect filenames instead of arguments.
+# `exec` resets this for the real binary, so nothing downstream sees it.
+set -f
+
+# 🔴 IS THIS PATH INSIDE A PROTECTED REPOSITORY? One definition, used by BOTH
+# the resolved-repo check and the environment check below. A prefix match, not
+# equality: a linked worktree's git dir is `<protected>/.git/worktrees/<name>`,
+# and an equality test would report it as a different, unprotected repository.
+_prot_match() {{
+  [ -n "$1" ] || return 1
+  # 🔴 ABSOLUTE PATHS ONLY, and this is a CORRECTNESS rule, not a shortcut.
+  # `readlink -f` resolves a relative string against THIS SHIM's cwd -- which
+  # under `run-tests.sh` IS the protected repo. So every non-path operand
+  # matched: `worktree list` flagged the word `list`, `worktree add -b topic`
+  # flagged `topic`, and `-c user.email=t@t` flagged `t@t`. MEASURED: 15 tests
+  # failed on a correct tree, i.e. this guard made itself a permanently-red gate
+  # -- the failure mode claude/RULES.md says trains everyone to click through.
+  #
+  # ⚠ RESIDUAL, stated rather than hidden: a RELATIVE path aimed at a protected
+  # repo is not matched here. git resolves it against the CHILD's cwd, which
+  # this shim cannot know; the repo RESOLUTION below covers the cwd case, and
+  # every environment variable and injected config value that matters in
+  # practice is absolute.
+  case "$1" in
+    /*) ;;
+    *) return 1 ;;
+  esac
+  _rp=$(readlink -f "$1" 2>/dev/null || echo "$1")
+  while IFS= read -r _p; do
+    [ -z "$_p" ] && continue
+    case "$_rp" in
+      "$_p"|"$_p"/*) return 0 ;;
+    esac
+  done < "$PROT"
+  return 1
+}}
+
+# ---- GLOBAL `-c` / `--config-env` INJECTION ---------------------------------
+# 🔴 THE SAME CONFIG VALUES, ON THE COMMAND LINE. These reach git without
+# touching a file and without changing the resolved repo, so neither the config
+# redirect nor repo resolution can see them. MEASURED against an earlier
+# revision of this shim, from an INNOCENT fixture:
+#
+#   git -c 'alias.x=!git -C <victim> commit --allow-empty -m PWNED' x
+#     -> rc 0, the victim gained a commit
+#   git -c remote.origin.url=git@github.com:<real>/devrc.git push origin HEAD:main
+#     -> "To github.com:<real>/devrc.git  ! [rejected]" -- it REACHED GitHub
+#
+# 🔴 AND THE ALIAS CASE IS WHY THE PATH SHIM ALONE IS NOT ENOUGH. Git PREPENDS
+# its own `libexec/git-core` to PATH for every child it spawns, so the `git`
+# inside a `!`-alias resolves to the REAL binary and never sees this shim. The
+# shim is NOT inherited by git-spawned children; the module docstring says so
+# explicitly rather than implying coverage we do not have.
+# $1 = "key=value" (or "env:key=ENVVAR"); remaining args = the original argv.
+_scan_cval() {{
+  case "$1" in
+    env:*)
+      _e="${{1#env:}}"; _ck="${{_e%%=*}}"; _ev="${{_e#*=}}"
+      eval "_cv=\\${{$_ev:-}}"
+      ;;
+    *) _ck="${{1%%=*}}"; _cv="${{1#*=}}" ;;
+  esac
+  [ "$_ck" = "$1" ] && return 0
+  case "$_ck" in
+    alias.*)
+      case "$_cv" in
+        "!"*) _refuse "-c $_ck is a SHELL-ESCAPE alias ($_cv). Git prepends its own libexec to PATH, so the git inside it would NOT be guarded" "$@" ;;
+      esac
+      ;;
+  esac
+  if [ -n "$_cv" ] && _prot_match "$_cv"; then
+    _refuse "-c $_ck=$_cv points into a PROTECTED repository; this channel writes no file, so the config redirect cannot see it" "$@"
+  fi
+  case "$_cv" in
+    *://*|*@*:*) _refuse "-c $_ck=$_cv is a NETWORK remote; this tier is hermetic" "$@" ;;
+  esac
+}}
+if [ -n "$cvals" ]; then
+  _oifs="$IFS"; IFS='
+'
+  for _c in $cvals; do
+    [ -n "$_c" ] && _scan_cval "$_c"
+  done
+  IFS="$_oifs"
+fi
+
+# ---- THE ENVIRONMENT VECTOR, WHICH RESOLUTION ALONE DOES NOT COVER -----------
+# 🔴 THIS IS THE HALF THAT MAKES THE GUARD ENVIRONMENT-AWARE RATHER THAN
+# PATH-VALIDATING, AND IT IS NOT REDUNDANT WITH THE RESOLUTION BELOW.
+#
+# Two different kinds of variable, and only one of them is caught by asking git
+# which repo it is in:
+#
+#   * GIT_DIR / GIT_COMMON_DIR change the repo's IDENTITY. `rev-parse
+#     --git-common-dir` below inherits them and answers with the repo git will
+#     actually use, so those are already covered — that is why the guard
+#     delegates resolution to git instead of parsing `-C` itself.
+#
+#   * GIT_WORK_TREE / GIT_INDEX_FILE / GIT_OBJECT_DIRECTORY /
+#     GIT_ALTERNATE_OBJECT_DIRECTORIES do NOT. They leave the repo identity
+#     alone and redirect WHERE THE WRITE LANDS. With cwd in a throwaway fixture
+#     and GIT_WORK_TREE naming the operator's clone, `git checkout -f` or
+#     `git reset --hard` writes files into the OPERATOR'S WORKING TREE while
+#     every path argument, and the resolved repo, look entirely innocent.
+#     MEASURED, and pinned by `test_no_real_repo_writes.py`'s armed-environment
+#     battery.
+#
+# `run-tests.sh` unsets all of them, but that is a claim about SETUP: it stops
+# what the runner INHERITS, and does nothing about a test that builds its own
+# subprocess environment. So the shim refuses them here as well. The two layers
+# are deliberately not the same fix.
+for _v in GIT_DIR GIT_COMMON_DIR GIT_WORK_TREE GIT_INDEX_FILE \
+          GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES; do
+  eval "_val=\\${{$_v:-}}"
+  if [ -n "$_val" ] && _prot_match "$_val"; then
+    _refuse "$_v points into a PROTECTED repository ($_val); it would redirect this write there whatever the arguments say" "$@"
+  fi
+done
+
+# ---- THE CHANNEL A FILE-WATCHING GUARD CANNOT SEE, EVEN IN PRINCIPLE ---------
+# 🔴 GIT_CONFIG_COUNT / GIT_CONFIG_KEY_<n> / GIT_CONFIG_VALUE_<n> are NOT in
+# `man git`, and git honours them. They set arbitrary config for ONE invocation
+# and TOUCH NO FILE. MEASURED on git 2.55 against an earlier revision of this
+# very shim:
+#
+#   GIT_CONFIG_GLOBAL=<decoy> GIT_CONFIG_SYSTEM=/dev/null
+#     git config --get core.hooksPath            -> <unset>        (guard held)
+#   ...plus GIT_CONFIG_COUNT=1 KEY_0=core.hooksPath VALUE_0=/tmp/PWNED-hooks
+#     git config --get core.hooksPath            -> /tmp/PWNED-hooks
+#   decoy file afterwards: 0 bytes, NEVER OPENED
+#
+# So the `GIT_CONFIG_GLOBAL` redirect above was not merely incomplete for this
+# vector — it was watching a channel the vector does not use. A guard is bounded
+# by the CHANNEL it observes, not by the completeness of its list.
+#
+# 🔴 THIS CHECK IS DELIBERATELY HERE, IN THE SHIM, AT CALL TIME. These variables
+# are per-invocation and live in the CHILD's environment, so a check run in the
+# plugin's process — or around a test — reads its OWN environment, comes back
+# clean, and PASSES while the child is fully injected. The shim is the only
+# place that sees the environment the guarded invocation will actually use.
+#
+# 🔴 AND IT IS SCOPED, NOT A BLANKET BAN. `scripts/analyze-service-index/
+# commit.sh` uses exactly this mechanism ON PURPOSE to NEUTRALISE hooks
+# (`GIT_CONFIG_KEY_0=core.hooksPath` at an empty dir), and its suite drives that
+# path. Refusing all of it would be a permanently-red gate. What is refused is
+# an injected value aimed INTO a protected path, or at a network remote.
+#
+# ⚠ RESIDUAL, STATED RATHER THAN HIDDEN: an injected value pointing somewhere
+# harmless-to-us (a tmpdir) is still arbitrary config, and `core.hooksPath` at a
+# tmpdir is arbitrary CODE EXECUTION during the run. That is outside this
+# guard's mandate (the operator's repo) and inside `commit.sh`'s legitimate
+# usage, so it is permitted here and documented rather than silently allowed.
+case "${{GIT_CONFIG_COUNT:-}}" in
+  ''|*[!0-9]*) : ;;
+  *)
+    _n=0
+    while [ "$_n" -lt "${{GIT_CONFIG_COUNT}}" ]; do
+      eval "_ik=\\${{GIT_CONFIG_KEY_$_n:-}}"
+      eval "_iv=\\${{GIT_CONFIG_VALUE_$_n:-}}"
+      # 🔴 THE SAME SCANNER as the `-c` form. It had its own copy of the checks
+      # and was missing the alias case, so `alias.y=!git -C <victim> commit`
+      # injected through the environment landed a commit on the victim while
+      # the byte-identical `-c` form was refused. One predicate, one place.
+      [ -n "$_ik" ] && _scan_cval "$_ik=$_iv" "$@"
+      _n=$(( _n + 1 ))
+    done
+    ;;
+esac
+
+# The arguments AFTER the subcommand, space-prefixed, for the read-form match.
+rest=''; seen=0
+for a in "$@"; do
+  if [ "$seen" = 0 ]; then
+    [ "$a" = "$sub" ] && seen=1
+    continue
+  fi
+  rest="$rest $a"
+done
+
+# ---- PROTECTED CONFIG FILES --------------------------------------------------
+# --global / --system reach ~/.gitconfig and /etc/gitconfig without touching any
+# repo at all, so no amount of repo protection sees them. githooks/install.sh
+# writes the global one for real, so this is a live shape, not a hypothetical.
+if [ "$sub" = config ]; then
+  cfgfile=''
+  case "$rest" in
+    *--global*) cfgfile="${{GIT_CONFIG_GLOBAL:-$HOME/.gitconfig}}" ;;
+    *--system*) cfgfile="${{GIT_CONFIG_SYSTEM:-/etc/gitconfig}}" ;;
+  esac
+  # 🔴 `--file <path>` / `-f <path>` names a config file DIRECTLY, in a repo the
+  # resolver reports as innocent. MEASURED: `git -C <fixture> config --file
+  # <victim>/.git/config core.bare true` set core.bare on the victim -- one of
+  # the two actual incident damages -- and was NOT refused.
+  _cfw=''
+  for a in $rest; do
+    case "$_cfw" in F) cfgfile="$a"; _cfw=''; continue ;; esac
+    case "$a" in
+      --file|-f) _cfw=F ;;
+      --file=*) cfgfile="${{a#--file=}}" ;;
+    esac
+  done
+  if [ -n "$cfgfile" ] && _prot_match "$cfgfile"; then
+    case "$rest" in
+      *--get*|*--list*|*" "-l*) _pass "$@" ;;
+    esac
+    _refuse "config --file/-f targets $cfgfile, inside a PROTECTED repository" "$@"
+  fi
+  if [ -n "$cfgfile" ]; then
+    rcfg=$(readlink -f "$cfgfile" 2>/dev/null || echo "$cfgfile")
+    while IFS= read -r p; do
+      [ -z "$p" ] && continue
+      if [ "$rcfg" = "$p" ]; then
+        case "$rest" in
+          *--get*|*--list*|*" "-l*) _pass "$@" ;;
+        esac
+        _refuse "would rewrite the operator's git config file $rcfg" "$@"
+      fi
+    done < "$PROTCFG"
+  fi
+fi
+
+# ---- resolve the repo this invocation targets --------------------------------
+# 🔴 --git-common-dir, NEVER --git-dir: a linked worktree's git dir is a
+# subdirectory of the real clone's, and its refs/remotes/config ARE the real
+# clone's. Resolving the per-worktree dir would report a worktree of a protected
+# repo as unprotected -- the exact misconception that makes "just use a
+# worktree" the intuitive and wrong containment answer for this bug.
+#
+# `init` and `clone` name a DESTINATION that may not be a repo yet, so resolve
+# from there. `git init <dir>` on a path that IS already a repo is how a working
+# clone acquires core.bare = true.
+# 🔴 SUBCOMMANDS THAT NAME A DESTINATION INSIDE A DENIED TREE. The repo they
+# RUN in is innocent; the path they WRITE to is not. MEASURED, both unrefused:
+#   git init --separate-git-dir <victim>/planted-gitdir <newrepo>  -> planted
+#   git -C <fixture> worktree add --detach <victim>/planted-worktree -> planted
+for a in $rest; do
+  case "$a" in
+    -*) continue ;;
+  esac
+  case "$sub" in
+    worktree|submodule)
+      if _prot_match "$a"; then
+        _refuse "$sub would write to $a, inside a PROTECTED repository" "$@"
+      fi
+      ;;
+  esac
+done
+_sgd=''
+_sgw=''
+for a in $rest; do
+  case "$_sgw" in S) _sgd="$a"; _sgw=''; continue ;; esac
+  case "$a" in
+    --separate-git-dir) _sgw=S ;;
+    --separate-git-dir=*) _sgd="${{a#--separate-git-dir=}}" ;;
+  esac
+done
+if [ -n "$_sgd" ] && _prot_match "$_sgd"; then
+  _refuse "--separate-git-dir would plant a git dir at $_sgd, inside a PROTECTED repository" "$@"
+fi
+
+case "$sub" in
+  init|clone)
+    dest=''
+    for a in $rest; do
+      case "$a" in
+        -*) continue ;;
+        *) dest="$a" ;;
+      esac
+    done
+    # 🔴 THE DESTINATION IS RELATIVE TO `-C`, NOT TO THIS SHIM'S CWD. `git -C X
+    # init .` means "init X", because git chdirs to X BEFORE reading the
+    # positional. MEASURED as a FALSE POSITIVE: a fixture running
+    # `git -C <tmp_path>/plain-repo init -q -b trunk .` was refused, because the
+    # `.` was resolved against the runner's cwd -- the repo root -- and landed
+    # on the protected repo. A guard that refuses a legitimate fixture is a
+    # permanently-red gate, which is the failure mode that trains everyone to
+    # click through. GUARD 9's own per-target accounting is what surfaced it.
+    case "$dest" in
+      '') : ;;
+      /*) tgt="$dest" ;;
+      *)  tgt="${{tgt:-.}}/$dest" ;;
+    esac
+    ;;
+esac
+
+if [ -n "$gdir" ]; then
+  common=$( cd "${{tgt:-.}}" 2>/dev/null && "$REAL" --git-dir="$gdir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null )
+else
+  common=$( cd "${{tgt:-.}}" 2>/dev/null && "$REAL" rev-parse --path-format=absolute --git-common-dir 2>/dev/null )
+fi
+
+protected=0
+rcommon=''
+if [ -n "$common" ]; then
+  rcommon=$(readlink -f "$common" 2>/dev/null || echo "$common")
+  _prot_match "$common" && protected=1
+fi
+
+# ---- NETWORK REMOTES: refused in ANY repo, protected or not ------------------
+case "$sub" in
+  {network})
+    urls=$( ( cd "${{tgt:-.}}" 2>/dev/null && "$REAL" config --get-regexp '^remote\\..*\\.url$' 2>/dev/null ) )
+    urls="$urls $rest"
+    for u in $urls; do
+      case "$u" in
+        file://*|/*|./*|../*) continue ;;
+        *://*) _refuse "would contact the NETWORK remote $u; this tier is hermetic" "$@" ;;
+        *@*:*) _refuse "would contact the NETWORK remote $u; this tier is hermetic" "$@" ;;
+      esac
+    done
+    ;;
+esac
+
+# ---- PROTECTED REPO: only an enumerated READ form is forwarded ---------------
+if [ "$protected" = 1 ]; then
+  # 🔴 `status` is a READ that WRITES: it refreshes and rewrites `.git/index`.
+  # MEASURED on a protected repo -- index bytes and mtime both changed. It is
+  # far too common in this suite to refuse (that would be a permanently-red
+  # gate), and the write is a cache refresh that cannot lose data, so the shim
+  # forwards it with `--no-optional-locks`, which git provides for exactly this
+  # and which was MEASURED to leave the index byte-identical with identical
+  # output.
+  if [ "$sub" = status ]; then
+    exec "$REAL" --no-optional-locks "$@"
+  fi
+  case "$sub" in
+{read_cases}
+  esac
+  _refuse "would mutate the PROTECTED repository $rcommon" "$@"
+fi
+
+case "$sub" in
+  status) _pass "$@" ;;
+esac
+
+_pass "$@"
+"""
+
+
+def install(guard_dir: Path, protected_repos, protected_config_files,
+            allow_no_repos: bool = False) -> Path:
+    """Write the `git` shim into `guard_dir`; return the log path.
+
+    🔴 CALL THIS BEFORE PREPENDING `guard_dir` TO PATH. The shim resolves the
+    real binary through `shutil.which`, so a guard dir already on PATH would
+    make it exec ITSELF -- an infinite fork loop rather than a passthrough. The
+    check below turns that ordering mistake into a named failure instead of a
+    hang, exactly as `testlib.nolaunch.install` does.
+    """
+    guard_dir = Path(guard_dir)
+    guard_dir.mkdir(parents=True, exist_ok=True)
+
+    real = shutil.which("git")
+    if real is None:
+        raise RuntimeError("testlib.norepo.install: no `git` on PATH to shadow.")
+    if Path(real).parent.resolve() == guard_dir.resolve():
+        raise RuntimeError(
+            "testlib.norepo.install: `git` already resolves INSIDE the guard "
+            f"dir ({real}). install() must run BEFORE {guard_dir} is put on "
+            "PATH, or the shim execs itself.")
+    if not protected_repos and not allow_no_repos:
+        raise RuntimeError(
+            "testlib.norepo.install: refusing to install a guard that protects "
+            "NO repository without `allow_no_repos=True`. An empty list is a "
+            "guard wired to nothing, and its zero refusals would read exactly "
+            "like a clean run. Pass the flag only where you can SAY why there "
+            "is no real repo -- the nix build sandbox is the one such place, "
+            "and the NETWORK and CONFIG rules still apply there.")
+
+    # 🔴 BOTH LISTS ARE REALPATH'd HERE, because the shim compares against
+    # `readlink -f` output. Comparing a resolved path to an unresolved one is a
+    # guard that silently matches nothing the moment any component is a symlink
+    # -- and `~/.gitconfig` behind a dotfile symlink is the ordinary case on
+    # this host, not an exotic one. Normalising on ONE side only is how a guard
+    # reports a clean run while protecting nothing.
+    prot = guard_dir / PROTECTED_LIST_NAME
+    prot.write_text(
+        "".join(f"{os.path.realpath(Path(p).expanduser())}\n" for p in protected_repos),
+        encoding="utf-8")
+    protcfg = guard_dir / PROTECTED_CONFIG_NAME
+    protcfg.write_text(
+        "".join(f"{os.path.realpath(Path(p).expanduser())}\n"
+                for p in protected_config_files),
+        encoding="utf-8")
+
+    # The repo probe's target: a WORKING TREE among the protected paths (a
+    # bare `.git` is not somewhere `git -C` can write a --local config from).
+    # Empty when nothing real is protected, which is the nix build sandbox.
+    target = ""
+    for p in protected_repos:
+        rp = Path(os.path.realpath(Path(p).expanduser()))
+        if rp.name != ".git" and (rp / ".git").exists():
+            target = str(rp)
+            break
+    (guard_dir / PROBE_TARGET_NAME).write_text(target + "\n", encoding="utf-8")
+
+    log = log_path(guard_dir)
+    write_exec(guard_dir / "git", shim_body(real, log, prot, protcfg))
+    return log
+
+
+def probe_target(guard_dir) -> str:
+    """The path the repo probe targets, or "" when nothing real is protected."""
+    try:
+        return (Path(guard_dir) / PROBE_TARGET_NAME).read_text(
+            encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def protected_paths(*starts) -> list[str]:
+    """Every path that IS the repo each start sits in: its `--git-common-dir`
+    AND the root of every working tree attached to it.
+
+    🔴 THE COMMON DIR IS NOT ENOUGH, AND THE GAP IS NOT THEORETICAL. It was
+    MEASURED here: with only common dirs protected, `GIT_WORK_TREE=<the
+    operator's clone> git checkout -f HEAD` was ALLOWED, because the work-tree
+    root is the PARENT of `<clone>/.git` and so is under no protected prefix.
+    Repo identity stayed truthful and innocent while the files would have landed
+    in the operator's tree. The armed-environment battery in
+    `scripts/tests/test_no_real_repo_writes.py` is what caught it.
+
+    🔴 The COMMON dir, not the git dir. `~/workspace/devrc` and every
+    `.claude/worktrees/agent-*` under it resolve to the SAME common dir, so
+    protecting one protects all of them -- correct, because a write in a linked
+    worktree lands on the real clone's refs and config, and a push from one
+    reaches the real remote.
+
+    A path that is not a repo, or that git cannot answer for, contributes
+    nothing; the caller must treat an empty result as a failure rather than as
+    "nothing to protect" (`install` does).
+    """
+    out: list[str] = []
+
+    def add(p) -> None:
+        real = str(Path(p).resolve())
+        if real not in out:
+            out.append(real)
+
+    for s in starts:
+        p = Path(s).expanduser()
+        if not p.is_dir():
+            continue
+        try:
+            r = subprocess.run(
+                ["git", "-C", str(p), "rev-parse", "--path-format=absolute",
+                 "--git-common-dir"],
+                capture_output=True, text=True, timeout=15)
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if r.returncode != 0 or not r.stdout.strip():
+            continue
+        add(r.stdout.strip())
+        # Every attached working tree, the main one and every linked one. A
+        # linked worktree lives OUTSIDE the common dir, so it needs its own
+        # entry or `GIT_WORK_TREE=<that worktree>` walks straight past.
+        try:
+            w = subprocess.run(
+                ["git", "-C", str(p), "worktree", "list", "--porcelain"],
+                capture_output=True, text=True, timeout=15)
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if w.returncode == 0:
+            for line in w.stdout.splitlines():
+                if line.startswith("worktree "):
+                    add(line[len("worktree "):].strip())
+    return out
+
+
+#: Kept as the old name so an out-of-tree caller does not break silently; the
+#: behaviour it described was measurably insufficient, so it forwards.
+protected_common_dirs = protected_paths
+
+
+def main(argv: list[str] | None = None) -> int:
+    """`python -m testlib.norepo <guard-dir> <candidate-repo>...`
+
+    Resolves each candidate to its `--git-common-dir`, installs the shim, and
+    prints ONE `protected=<path>` line per repo actually protected followed by
+    `guard-dir=<dir>`. `run-tests.sh` reads that count: it is the difference
+    between "armed against N real repositories" and the reassuring zero of a
+    guard wired to nothing, and the runner PRINTS it either way rather than
+    letting a silent zero read as protection.
+
+    `--allow-no-repos` is the nix build sandbox's door: there is genuinely no
+    real clone in it, and the NETWORK and CONFIG rules still apply.
+    """
+    import sys as _sys
+
+    args = list(_sys.argv[1:] if argv is None else argv)
+    allow = "--allow-no-repos" in args
+    args = [a for a in args if a != "--allow-no-repos"]
+    if len(args) < 2:
+        print("usage: python -m testlib.norepo [--allow-no-repos] "
+              "<guard-dir> <candidate-repo>...", file=_sys.stderr)
+        return 2
+    guard_dir, candidates = Path(args[0]), args[1:]
+    repos = protected_paths(*candidates)
+    # 🔴 `Path.home()/".gitconfig"` IS ALWAYS PROTECTED, not just whatever
+    # GIT_CONFIG_GLOBAL happens to say right now. `run-tests.sh` REDIRECTS that
+    # variable at a throwaway file for the run, and deriving the protected set
+    # from the redirected value would protect the throwaway and leave the
+    # operator's real file unprotected — the guard would then be pointed at the
+    # decoy it created. The measured incident vector is `githooks/install.sh`
+    # running `git config --global core.hooksPath` with NO env var set at all,
+    # which resolves to exactly this path.
+    cfg: list[str] = []
+    for p in (Path.home() / ".gitconfig",
+              Path(os.environ.get("GIT_CONFIG_GLOBAL") or Path.home() / ".gitconfig"),
+              Path("/etc/gitconfig"),
+              Path(os.environ.get("GIT_CONFIG_SYSTEM") or "/etc/gitconfig")):
+        s = str(p)
+        if s not in cfg:
+            cfg.append(s)
+    try:
+        install(guard_dir, repos, cfg, allow_no_repos=allow)
+    except RuntimeError as exc:
+        print(f"norepo: {exc}", file=_sys.stderr)
+        return 2
+    for r in repos:
+        print(f"protected={r}")
+    for c in cfg:
+        print(f"protected-config={c}")
+    print(f"guard-dir={guard_dir}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — exercised via run-tests.sh
+    raise SystemExit(main())

--- a/scripts/testlib/norepo_plugin.py
+++ b/scripts/testlib/norepo_plugin.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""GUARD 9's IN-PROCESS control: proof the shim is armed for THIS target.
+
+🔴 WHY A RUNNER-SIDE PROBE IS NOT ENOUGH
+-----------------------------------------
+`run-tests.sh` fires two deliberate refusals before each target and counts them.
+That proves the shim is armed **in the runner's environment**. It does not prove
+it is armed inside the target's own process — and if it isn't, every
+`refused=0` in the per-target table is a statement about the runner, so the
+32/32 table reads as rigorous while measuring one thing thirty-two times.
+
+This plugin fires the same two probes from INSIDE the pytest process, tagged
+`via=plugin`. The runner requires BOTH counts, and prints them separately, so a
+target protected only by inheritance cannot be mistaken for one whose own
+process was checked.
+
+🔴 AND THE TWO MECHANISMS ARE GENUINELY DIFFERENT, WHICH IS WHY BOTH ARE COUNTED
+--------------------------------------------------------------------------------
+The five `HOOK_TESTS` and the `SHELL_TEST` are not pytest. They can never load a
+plugin, so their protection IS inheritance — the exported environment plus the
+PATH shim — and their `plugin=0` is correct rather than a failure. Collapsing
+the two into one number would make a dead plugin on a pytest target look exactly
+like a healthy non-pytest target, which is precisely where a future regression
+would hide.
+
+🔴 NESTING, and it is load-bearing accounting rather than tidiness
+-------------------------------------------------------------------
+Some tests START ANOTHER PYTEST (`test_no_real_launchers.py` builds control /
+mutant pairs that way), so this plugin loads in those child sessions too and
+they inherit the guard-dir handle. A nested session must still be PROTECTED —
+that is the half that matters — but it must not write into the runner's
+per-target ledger, where an extra control looks like a miscount. The flag below
+is set for children and checked on entry, the same shape as
+`spool_plugin.NESTED_ENV`.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from . import norepo
+
+#: Set for CHILD sessions. Its presence means "you are not a target".
+NESTED_ENV = "DEVRC_TEST_GITGUARD_IN_SESSION"
+
+
+def _probe(env: dict, argv: list[str]) -> None:
+    try:
+        subprocess.run(argv, env=env, capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.SubprocessError):
+        # A probe that cannot run writes no control line, which the runner
+        # turns into a loud per-target failure. Swallowing here keeps the
+        # failure in the ONE place that reports it.
+        pass
+
+
+def pytest_configure(config) -> None:  # noqa: D401 - pytest hook
+    guard_dir = os.environ.get(norepo.GUARD_DIR_ENV)
+    if not guard_dir:
+        # Not under `run-tests.sh`. There is no ledger to write into, and
+        # inventing one here would report a control nobody asked for.
+        return
+    if os.environ.get(NESTED_ENV):
+        return
+    os.environ[NESTED_ENV] = "1"
+
+    env = dict(os.environ)
+    env[norepo.PROBE_ENV] = "1"
+    env[norepo.PROBE_VIA_ENV] = "plugin"
+
+    # 1. The NETWORK probe. Works in every environment, including the nix build
+    #    sandbox where no real repository exists to protect.
+    _probe(env, ["git", "ls-remote", "https://guard9-probe.invalid/probe.git"])
+
+    # 2. The PROTECTED-REPO probe, only where there is one. The target path is
+    #    read from the guard dir rather than re-derived, so the runner and this
+    #    plugin cannot disagree about what is protected.
+    target = norepo.probe_target(Path(guard_dir))
+    if target:
+        _probe(env, ["git", "-C", target, "config", "--local",
+                     "devrc.guard9.probe", "x"])

--- a/scripts/tests/test_no_real_repo_writes.py
+++ b/scripts/tests/test_no_real_repo_writes.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -274,6 +275,143 @@ ARMED_VECTOR_IDS = (
     "GIT_CONFIG_COUNT",
 )
 
+#: 🔴 THE AXIS EACH VECTOR MUST MOVE — not merely "some axis".
+#: MEASURED: with only "something moved", a mutant that changed the
+#: GIT_CONFIG_SYSTEM vector's command to `--global` SURVIVED. Both arms still
+#: passed: the global file moved, and the guard still refused. The test proved
+#: a real thing about the WRONG variable, which is how a vector silently stops
+#: covering what its name says.
+ARMED_EXPECTED_AXIS = {
+    "GIT_DIR": "branches",
+    "GIT_COMMON_DIR": "HEAD",
+    "GIT_WORK_TREE": "worktree",
+    "GIT_INDEX_FILE": "index",
+    "GIT_OBJECT_DIRECTORY": "objects",
+    "GIT_CONFIG_GLOBAL": "global-config",
+    "GIT_CONFIG_SYSTEM": "system-config",
+    "GIT_CONFIG_COUNT": "worktree",
+}
+
+
+def _unguarded_env(*extra_guard_dirs) -> dict:
+    """An environment with EVERY GUARD 9 shim removed from PATH.
+
+    🔴 THE ISOLATION SEAM, MEASURED. An "unguarded" arm built from
+    `dict(os.environ)` is only unguarded when nothing else installed a shim.
+    Under `run-tests.sh` the RUNNER has already put its own guard dir first on
+    PATH and exported it as `DEVRC_TEST_GITGUARD_DIR`, so five arms that had
+    passed standalone were REFUSED by the outer guard the moment they ran in
+    the real gate — the live-axis assertion then failed with "this vector is
+    harmless", which is the opposite of what had happened.
+
+    So the runner's dir is stripped by NAME from the env handle, not guessed.
+    """
+    env = dict(os.environ)
+    drop = {str(d) for d in extra_guard_dirs if d}
+    runner_dir = env.get(norepo.GUARD_DIR_ENV)
+    if runner_dir:
+        drop.add(runner_dir)
+    env["PATH"] = os.pathsep.join(
+        p for p in env["PATH"].split(os.pathsep) if p not in drop)
+    # Every layer the runner adds, not just the shim: the env scrub, the
+    # transport lever and the config redirect are all part of "guarded".
+    for v in ("GIT_DIR", "GIT_COMMON_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE",
+              "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+              "GIT_CONFIG_COUNT", "GIT_ALLOW_PROTOCOL",
+              "GIT_CONFIG_SYSTEM", "GIT_CONFIG_NOSYSTEM"):
+        env.pop(v, None)
+    return env
+
+
+def _discriminating_canary(env, target, label):
+    """A MUTATING write to a PROTECTED repo: refused when the guard is live.
+
+    🔴 This is the leg whose SUCCESS is evidence of ABSENCE. Its predecessor
+    committed inside an UNPROTECTED fixture -- an op the guard permits by
+    design -- and MEASURED as passing both with the guard loaded and without,
+    so it proved permission rather than absence.
+    """
+    key = f"devrc.guard9.canary{abs(hash(label)) % 100000}"
+    r = subprocess.run(["git", "-C", str(target), "config", "--local", key, "1"],
+                       env=env, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(target), "config", "--local", "--unset", key],
+                   env=env, capture_output=True)
+    return r
+
+
+def _assert_truly_unguarded(env, tmp_path, label, protected_hint=None):
+    """🔴 PROVE the arm is unguarded; never assume it.
+
+    A sibling layer reported its own L2 silently re-guarding 13 "unguarded"
+    controls, whose harness then dutifully reported them VACUOUS. "The victim
+    did not move" would then mean STILL GUARDED, not harmless.
+
+    🔴 AND THE POSITIVE LEG MUST DISCRIMINATE. Its first revision committed
+    inside an UNPROTECTED fixture repo -- an operation the guard PERMITS BY
+    DESIGN. MEASURED: it passed with the guard deliberately loaded AND with it
+    absent, so its success was evidence of permission, not of absence, and it
+    contributed nothing to catching a guarded arm. That is the
+    instrument-answers-before-the-code-is-consulted class, one level inside the
+    check built to prevent it. The legs now are:
+
+      1. STRUCTURAL   -- no directory on PATH carries a guard ledger.
+      2. NEGATIVE     -- a network call the guard WOULD refuse is not refused.
+      3. DISCRIMINATING POSITIVE -- a MUTATING write to a PROTECTED repository
+         succeeds. MEASURED: refused (exit 99) with the guard live, rc 0
+         without it. Its success is evidence of ABSENCE.
+      4. LIVENESS     -- `git --version` runs at all, which is what leg 3 was
+         really testing before, now labelled honestly.
+
+    Leg 3 needs a path the guard would protect. It is DERIVED -- from the
+    caller's hint, else from the runner's own ledger -- never guessed; when
+    neither exists there is no guard to detect and the leg is skipped with a
+    reason rather than replaced by a permitted op.
+    """
+    # --- leg 1: structural ---------------------------------------------------
+    for d in env.get("PATH", "").split(os.pathsep):
+        if d and (Path(d) / norepo.PROTECTED_LIST_NAME).exists():
+            raise AssertionError(
+                f"{label}: a GUARD 9 dir is STILL on PATH ({d}); this arm is "
+                "not unguarded and any 'nothing moved' from it is meaningless")
+
+    # --- leg 2: negative canary ---------------------------------------------
+    probe = subprocess.run(
+        ["git", "ls-remote", "https://guard9-probe.invalid/probe.git"],
+        env=env, capture_output=True, text=True, timeout=60)
+    out = probe.stdout + probe.stderr
+    assert probe.returncode != norepo.REFUSED_EXIT and "GUARD 9" not in out, (
+        f"{label}: the negative canary was REFUSED — this arm is still guarded:\n{out}")
+
+    # --- leg 4: liveness (cheap, and it catches a mangled PATH) --------------
+    v = subprocess.run(["git", "--version"], env=env, capture_output=True, text=True)
+    assert v.returncode == 0, (
+        f"{label}: git does not run at all in this arm, so 'nothing moved' "
+        f"proves nothing:\n{v.stdout}{v.stderr}")
+
+    # --- leg 3: DISCRIMINATING positive canary ------------------------------
+    target = protected_hint
+    if target is None:
+        gdir = os.environ.get(norepo.GUARD_DIR_ENV)
+        if gdir:
+            ledger = Path(gdir) / norepo.PROTECTED_LIST_NAME
+            try:
+                for line in ledger.read_text().splitlines():
+                    p = Path(line.strip())
+                    if p.is_dir() and (p / ".git").exists():
+                        target = p
+                        break
+            except OSError:
+                target = None
+    if target is None:
+        return env      # nothing protected anywhere: no guard to detect
+    r = _discriminating_canary(env, target, label)
+    assert r.returncode == 0 and "GUARD 9" not in (r.stdout + r.stderr), (
+        f"{label}: the DISCRIMINATING canary — a write to the protected repo "
+        f"{target} — was refused (rc={r.returncode}). This arm is STILL "
+        f"GUARDED, so any 'nothing moved' from it is meaningless:\n"
+        f"{r.stdout}{r.stderr}")
+    return env
+
 
 def _digest(f: Path) -> str:
     try:
@@ -287,6 +425,12 @@ def _wt_digest(root: Path) -> str:
         f"{f.relative_to(root)}={_digest(f)}"
         for f in sorted(root.rglob("*"))
         if f.is_file() and ".git" not in f.parts)
+
+
+def _system_cfg(gitconfig: Path) -> Path:
+    """A file distinct from the global one, so a `--global` write cannot be
+    mistaken for a `--system` write."""
+    return gitconfig.with_name(gitconfig.name + ".system")
 
 
 def _full_state(victim: Path, gitconfig: Path) -> dict:
@@ -304,6 +448,7 @@ def _full_state(victim: Path, gitconfig: Path) -> dict:
         "objects": str(sum(1 for f in objs.rglob("*") if f.is_file())),
         "worktree": _wt_digest(victim),
         "global-config": _digest(gitconfig),
+        "system-config": _digest(_system_cfg(gitconfig)),
     }
 
 
@@ -345,8 +490,12 @@ def _vector(vec, victim: Path, gitconfig: Path):
                                  ["hash-object", "-w", "--stdin"], "payload\n"),
         "GIT_CONFIG_GLOBAL": ({"GIT_CONFIG_GLOBAL": str(gitconfig)},
                               ["config", "--global", "user.email", "evil@example.com"], None),
-        "GIT_CONFIG_SYSTEM": ({"GIT_CONFIG_SYSTEM": str(gitconfig)},
-                              ["config", "--global", "user.email", "evil@example.com"], None),
+        # 🔴 `--system`, not `--global`. With `--global` this vector moved the
+        # GLOBAL file and proved nothing about GIT_CONFIG_SYSTEM — a mislabel
+        # the probe-integrity sweep caught. MEASURED: `config --system` with
+        # GIT_CONFIG_SYSTEM set does write that file (rc 0, contents changed).
+        "GIT_CONFIG_SYSTEM": ({"GIT_CONFIG_SYSTEM": str(_system_cfg(gitconfig))},
+                              ["config", "--system", "user.email", "evil@example.com"], None),
         # 🔴 The channel a file-watching guard cannot see: this writes NO
         # config file anywhere. MEASURED with `core.worktree` first, which moved
         # NOTHING (git ignores it for a `-C`-discovered repo) — a vector that
@@ -370,9 +519,10 @@ def test_the_armed_vector_is_DANGEROUS_and_the_guard_HOLDS(guarded, tmp_path, ve
     v1 = _mkrepo(tmp_path / "victim-unguarded")
     cfg1 = tmp_path / "gitconfig-unguarded"
     cfg1.write_text("[user]\n\tname = t\n\temail = t@t\n")
+    _system_cfg(cfg1).write_text("")
     env_add, argv, stdin = _vector(vec, v1, cfg1)
-    unguarded = dict(os.environ)
-    unguarded.pop("GIT_DIR", None)
+    unguarded = _unguarded_env(guarded.dir)
+    _assert_truly_unguarded(unguarded, tmp_path, f"armed-{vec}")
     unguarded["GIT_CONFIG_GLOBAL"] = str(cfg1)
     unguarded.update(env_add)
     before = _full_state(v1, cfg1)
@@ -384,14 +534,22 @@ def test_the_armed_vector_is_DANGEROUS_and_the_guard_HOLDS(guarded, tmp_path, ve
         f"{vec}: UNGUARDED this command moved NO asserted axis (rc={u.returncode}). "
         "The vector is harmless, so refusing it proves nothing — replace it with "
         f"a command that actually writes.\n{u.stdout}{u.stderr}")
+    want = ARMED_EXPECTED_AXIS[vec]
+    assert want in moved, (
+        f"{vec}: moved {moved}, but not its OWN axis `{want}`. The vector is "
+        f"exercising something real about a DIFFERENT mechanism — which is how "
+        f"a named vector silently stops covering what it claims.\n"
+        f"{u.stdout}{u.stderr}")
 
     # --- arm 2: GUARDED. Same command, fresh victim, guard installed. --------
     v2 = _mkrepo(tmp_path / "victim-guarded")
     cfg2 = tmp_path / "gitconfig-guarded"
     cfg2.write_text("[user]\n\tname = t\n\temail = t@t\n")
+    _system_cfg(cfg2).write_text("")
     env_add2, argv2, stdin2 = _vector(vec, v2, cfg2)
     gd = tmp_path / "guard2"
-    norepo.install(gd, norepo.protected_paths(v2), [str(cfg2)])
+    norepo.install(gd, norepo.protected_paths(v2),
+                   [str(cfg2), str(_system_cfg(cfg2))])
     genv = dict(os.environ)
     genv.pop("GIT_DIR", None)
     genv["PATH"] = f"{gd}{os.pathsep}" + os.environ["PATH"]
@@ -1162,6 +1320,755 @@ def test_a_config_write_FROM_A_WORKTREE_cannot_reach_the_base_clone(guarded, tmp
     assert p.returncode == norepo.REFUSED_EXIT, f"NOT refused:\n{out}"
     assert "GUARD 9" in out, out
     assert basecfg2.read_text() == b2, "refused, but the base config CHANGED"
+
+
+# --------------------------------------------------------------------------- #
+# 3e. THE OUTSIDE REVIEW'S F1-F6
+#
+# 🔴 Each was MEASURED to land at rc 0 with LEDGER DELTA 0 against the revision
+# that had already passed every battery above — i.e. the per-target table would
+# have printed `refused=0` for them. Each carries its own live-axis arm, so a
+# vector that stops being dangerous fails loudly instead of reassuring.
+#
+# The shared root, and the reason these are grouped: the guard asked git "which
+# repo am I in" and then reasoned over enumerated shapes. F1 is a write whose
+# REPO is innocent and whose DESTINATION is not; F2 is a URL one character
+# outside two globs; F3/F4 hand a program to the real binary, which never sees
+# this shim because git prepends its own libexec to PATH.
+# --------------------------------------------------------------------------- #
+def _rev689_victim(tmp_path, name):
+    v = _mkrepo(tmp_path / name)
+    bare = _mkrepo(tmp_path / f"{name}-origin.git", bare=True)
+    subprocess.run(["git", "-C", str(v), "remote", "add", "origin", str(bare)],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(v), "push", "-q", "origin", "main"],
+                   check=True, capture_output=True)
+    return v, bare
+
+
+def _rev689_state(v, bare):
+    def q(*a):
+        return _git("-C", str(v), *a).stdout.strip()
+    return {
+        "config": q("config", "--local", "--list"),
+        "branches": q("for-each-ref", "--format=%(refname) %(objectname)", "refs/heads"),
+        "HEAD": q("symbolic-ref", "-q", "HEAD"),
+        "commits": q("rev-list", "--count", "--all"),
+        "worktree": _wt_digest(v),
+        # 🔴 DIRECTORY-AWARE. `git init <victim>/planted` creates ONLY
+        # `planted/.git/**`, which a file digest that skips `.git` cannot see —
+        # the vector looked harmless because the PROBE was blind, not because
+        # nothing happened.
+        "tree-entries": "|".join(sorted(
+            str(p.relative_to(v)) for p in v.iterdir() if p.name != ".git")),
+        "bare-refs": _git("-C", str(bare), "for-each-ref",
+                          "--format=%(refname) %(objectname)").stdout.strip(),
+    }
+
+
+def _rev689_case(tag, v, bare, fixture, tmp_path):
+    """(argv, env-additions) for `tag`, aimed at this victim."""
+    if tag == "F1-push-worktree":
+        return ["-C", str(fixture), "push", str(v), "+HEAD:refs/heads/main"], {}
+    if tag == "F1-push-bare":
+        return ["-C", str(fixture), "push", str(bare), "+HEAD:refs/heads/main"], {}
+    if tag == "F2-userless-scp":
+        return ["-C", str(fixture), "push",
+                "github.com:innovation-upstream/devrc.git", "HEAD:refs/heads/main"], {}
+    if tag in ("F3-hookspath", "F3-hookspath-env"):
+        hooks = tmp_path / f"evilhooks-{tag}"
+        hooks.mkdir(exist_ok=True)
+        write_exec(hooks / "post-commit",
+                   f'git -C "{v}" config core.bare true\n'
+                   f'git -C "{v}" branch -m main trunk\n'
+                   f'git -C "{v}" config remote.origin.url /tmp/PWNED.git\n'
+                   f'touch "{v}/PLANTED"\n')
+        if tag == "F3-hookspath":
+            return ["-C", str(fixture), "-c", f"core.hooksPath={hooks}",
+                    "commit", "--allow-empty", "-m", "x"], {}
+        return (["-C", str(fixture), "commit", "--allow-empty", "-m", "x"],
+                {"GIT_CONFIG_COUNT": "1", "GIT_CONFIG_KEY_0": "core.hooksPath",
+                 "GIT_CONFIG_VALUE_0": str(hooks)})
+    if tag == "F4-diff-external":
+        scr = tmp_path / f"extdiff-{tag}.sh"
+        write_exec(scr, f'touch "{v}/PLANTED-DIFF"\nexit 0\n')
+        # A TRACKED file: `git diff` shows nothing for an untracked one, so
+        # the external differ would never be invoked and the vector would
+        # look harmless.
+        (fixture / "f").write_text("CHANGED\n")
+        return ["-C", str(fixture), "-c", f"diff.external={scr}", "diff"], {}
+    if tag == "F6-init":
+        return ["init", "-q", str(v / "planted-init")], {}
+    if tag == "F6-clone":
+        return ["clone", "-q", str(fixture), str(v / "planted-clone")], {}
+    # 🔴 THE ABSENT-OPERAND-REPORTS-INNOCENT SHAPE. Both `cd`s fail, so a
+    # resolver that returns the RAW string prefix-matches an allowed directory
+    # and lets the write through — the same family as `git diff --quiet`
+    # reporting SAME for a path on neither side. MEASURED: `readlink -m`
+    # normalises `<allowed>/does-not-exist/deeper/../../../victim/planted` to
+    # `<victim>/planted`, so the traversal is caught by the same fix as F6.
+    if tag == "F6-traversal-init":
+        allowed = tmp_path / f"allowed-{tag}"
+        allowed.mkdir(exist_ok=True)
+        return ["init", "-q",
+                f"{allowed}/does-not-exist/deeper/../../../{v.name}/planted-trav"], {}
+    if tag == "F6-traversal-clone":
+        allowed = tmp_path / f"allowed-{tag}"
+        allowed.mkdir(exist_ok=True)
+        return ["clone", "-q", str(fixture),
+                f"{allowed}/does-not-exist/deeper/../../../{v.name}/planted-trav2"], {}
+    raise AssertionError(tag)
+
+
+#: ⚠ `F1-push-worktree` is deliberately ABSENT: MEASURED, git's own
+#: `receive.denyCurrentBranch` refuses a push to a checked-out branch
+#: ("refusing to update checked out branch"), so on this git it is NOT a live
+#: vector and a battery entry for it could only ever agree with itself.
+#: `F1-push-bare` is the live form — and the more serious one, since the
+#: public repo is a bare remote.
+REV689_VECTORS = (
+    "F1-push-bare", "F2-userless-scp",
+    "F3-hookspath", "F3-hookspath-env", "F4-diff-external",
+    "F6-init", "F6-clone", "F6-traversal-init", "F6-traversal-clone",
+)
+
+
+@pytest.mark.parametrize("tag", REV689_VECTORS)
+def test_the_reviewed_vector_is_DANGEROUS_and_the_guard_HOLDS(guarded, tmp_path, tag):
+    """🔴 BOTH ARMS. Arm 1 must damage an asserted axis with the guard OFF, or
+    the vector was never dangerous; arm 2 must be refused by THIS guard with the
+    victim byte-unchanged.
+
+    🔴 `GIT_ALLOW_PROTOCOL` is REMOVED in both arms. The review's point about F2
+    is that the transport lever — which this PR itself calls the weakest of the
+    three and not the guard — is what stopped it, and 229 in-tree `env={...}`
+    sites would drop that lever. Crediting the guard for it would be measuring
+    the wrong thing.
+    """
+    # --- arm 1: UNGUARDED --------------------------------------------------
+    v1, b1 = _rev689_victim(tmp_path, f"victim-u-{tag}")
+    argv, envadd = _rev689_case(tag, v1, b1, guarded.fixture, tmp_path)
+    ue = _unguarded_env(guarded.dir)
+    _assert_truly_unguarded(ue, tmp_path, f"reviewed-{tag}")
+    ue["GIT_CONFIG_GLOBAL"] = str(tmp_path / f"gc-u-{tag}")
+    ue.update(envadd)
+    before = _rev689_state(v1, b1)
+    u = subprocess.run(["git", *argv], env=ue, capture_output=True, text=True,
+                       timeout=180)
+    moved = [k for k in before if before[k] != _rev689_state(v1, b1)[k]]
+    if tag == "F2-userless-scp":
+        # A real host cannot be reached from the gate, so the damage axis here
+        # is REACH, not victim state: git must have attempted the ssh
+        # connection rather than been stopped by anything of ours.
+        out = u.stdout + u.stderr
+        assert "github.com" in out and "GUARD 9" not in out, (
+            f"unguarded, the userless-scp push was not even attempted:\n{out}")
+    else:
+        assert moved, (
+            f"{tag}: UNGUARDED this moved NO asserted axis (rc={u.returncode}); "
+            f"the vector is harmless and refusing it proves nothing.\n"
+            f"{u.stdout}{u.stderr}")
+
+    # --- arm 2: GUARDED ----------------------------------------------------
+    v2, b2 = _rev689_victim(tmp_path, f"victim-g-{tag}")
+    argv2, envadd2 = _rev689_case(tag, v2, b2, guarded.fixture, tmp_path)
+    gd = tmp_path / f"guard-{tag}"
+    # 🔴 ONLY THE VICTIM IS PASSED. Its local bare origin must be protected
+    # AUTOMATICALLY by `protected_paths`, or F1b is closed only when the caller
+    # already knew to pass it. MEASURED: passing both made a mutant that
+    # deleted the automatic protection SURVIVE — the test was supplying the
+    # very thing it was meant to be checking.
+    norepo.install(gd, norepo.protected_paths(v2), [str(guarded.gitconfig)])
+    ge = dict(os.environ)
+    ge.pop("GIT_DIR", None)
+    ge.pop("GIT_ALLOW_PROTOCOL", None)
+    ge["PATH"] = f"{gd}{os.pathsep}" + os.environ["PATH"]
+    ge["GIT_CONFIG_GLOBAL"] = str(guarded.gitconfig)
+    ge.update(envadd2)
+    b = _rev689_state(v2, b2)
+    p = subprocess.run(["git", *argv2], env=ge, capture_output=True, text=True,
+                       timeout=180)
+    out = p.stdout + p.stderr
+    assert p.returncode == norepo.REFUSED_EXIT, (
+        f"{tag}: expected the guard's exit {norepo.REFUSED_EXIT}, got "
+        f"{p.returncode}\n{out}")
+    assert "GUARD 9" in out, f"{tag}: refused, but not by this guard:\n{out}"
+    a = _rev689_state(v2, b2)
+    assert a == b, f"{tag}: refused but state moved: {[k for k in b if b[k] != a[k]]}"
+
+
+def test_the_injectable_key_list_is_an_ALLOWLIST_not_a_denylist():
+    """🔴 F3's framing, pinned in the CODE. A denylist fails on the next key
+    nobody thought of; the shim must refuse an unknown key by default."""
+    shim = norepo.shim_body("/usr/bin/git", Path("/tmp/l"), Path("/tmp/p"),
+                            Path("/tmp/c"))
+    assert "is not on the injectable-config allowlist" in shim
+    # ...and an obviously-executable key must NOT be on it.
+    for k in ("core.fsmonitor", "diff.external", "core.pager", "core.editor",
+              "include.path", "alias.x", "sequence.editor"):
+        assert k not in norepo.INJECTABLE_KEYS, (
+            f"{k} names a program or a config to load; it must not be injectable")
+
+
+def test_a_neutralising_hookdir_is_allowed_but_an_ARMED_one_is_not(guarded, tmp_path):
+    """🔴 The distinction is MEASURED, not spelled. `analyze-service-index/
+    commit.sh` sets `core.hooksPath` at an EMPTY dir on purpose to NEUTRALISE
+    hooks, and its suite drives that path — refusing the key outright would be
+    a permanently-red gate. What is refused is a directory holding an
+    executable, which is the measured full-incident vector."""
+    empty = tmp_path / "empty-hooks"
+    empty.mkdir()
+    p = subprocess.run(["git", "-C", str(guarded.fixture), "-c",
+                        f"core.hooksPath={empty}", "commit", "--allow-empty",
+                        "-m", "neutralised"], env=guarded.env,
+                       capture_output=True, text=True)
+    assert p.returncode == 0, (
+        f"neutralising hooks was refused — permanently-red gate:\n{p.stdout}{p.stderr}")
+
+    armed = tmp_path / "armed-hooks"
+    armed.mkdir()
+    write_exec(armed / "post-commit", "true\n")
+    q = subprocess.run(["git", "-C", str(guarded.fixture), "-c",
+                        f"core.hooksPath={armed}", "commit", "--allow-empty",
+                        "-m", "armed"], env=guarded.env,
+                       capture_output=True, text=True)
+    assert q.returncode == norepo.REFUSED_EXIT, (
+        f"an ARMED hook directory was allowed:\n{q.stdout}{q.stderr}")
+
+
+def test_the_scanners_run_ABOVE_the_read_fast_path():
+    """🔴 F4, the structural root. With the fast path first, any subcommand on
+    the read list carried its injections straight to the real binary."""
+    src = (REPO_ROOT / "scripts" / "testlib" / "norepo.py").read_text()
+    body = src[src.index("def shim_body("):src.index("def install(")]
+    fast = body.index("---- FAST PATH")
+    for marker in ("_scan_cval", "THE ENVIRONMENT VECTOR", "GIT_CONFIG_COUNT"):
+        assert body.index(marker) < fast, (
+            f"the read fast path precedes `{marker}`; a read subcommand would "
+            "carry its injections to the real binary unscanned")
+
+
+def test_the_protected_config_set_is_RESOLVED_not_hardcoded(tmp_path):
+    """🔴 F5. `~/.gitconfig` does not exist on this host — git uses
+    `${XDG_CONFIG_HOME:-~/.config}/git/config`. Hardcoding the former protected
+    a file that is never written."""
+    guard = tmp_path / "g"
+    repo = _mkrepo(tmp_path / "r")
+    assert norepo.main([str(guard), str(repo)]) == 0
+    listed = (guard / norepo.PROTECTED_CONFIG_NAME).read_text().splitlines()
+    xdg = Path(os.environ.get("XDG_CONFIG_HOME") or (Path.home() / ".config"))
+    assert str(xdg / "git" / "config") in listed, (
+        f"git's actual --global location is not protected. Listed: {listed}")
+    assert str(Path.home() / ".gitconfig") in listed, "the other candidate is unguarded"
+
+
+def test_a_NOT_YET_EXISTING_path_behind_a_SYMLINK_still_resolves(guarded, tmp_path):
+    """🔴 The case that separates `readlink -m` from `readlink -f`.
+
+    For a plain absolute path the two agree by accident: `-f` fails on a
+    non-existent leaf, the `|| echo "$1"` fallback hands back the raw string,
+    and the raw string still has the protected prefix. MEASURED — a mutant
+    reverting `-m` to `-f` SURVIVED the F6 vectors for exactly that reason.
+
+    It stops agreeing when an ANCESTOR is a symlink: `-f` cannot canonicalise
+    the leaf, the raw string keeps the symlink spelling, and it no longer
+    matches the resolved protected path. `-m` canonicalises regardless of
+    existence, which is what makes the destination check hold under a symlinked
+    path — the shape `~/workspace` genuinely has on this host.
+    """
+    real = tmp_path / "real-parent"
+    real.mkdir()
+    victim = _mkrepo(real / "victim")
+    link = tmp_path / "linked-parent"
+    link.symlink_to(real)
+
+    gd = tmp_path / "guard-symlink"
+    norepo.install(gd, norepo.protected_paths(victim), [str(guarded.gitconfig)])
+    env = dict(os.environ)
+    env.pop("GIT_DIR", None)
+    env["PATH"] = f"{gd}{os.pathsep}" + os.environ["PATH"]
+    env["GIT_CONFIG_GLOBAL"] = str(guarded.gitconfig)
+
+    # 🔴 TWO missing components, not one. MEASURED: `readlink -f` canonicalises
+    # fine when only the LAST component is missing, so a one-level destination
+    # made `-f` and `-m` agree and a mutant reverting `-m` SURVIVED. It fails —
+    # returning empty, so the raw symlink spelling is kept and no longer
+    # matches the resolved protected path — only when more than the last
+    # component is absent.
+    dest = link / "victim" / "planted" / "through-symlink"
+    p = subprocess.run(["git", "init", "-q", str(dest)], env=env,
+                       capture_output=True, text=True)
+    out = p.stdout + p.stderr
+    assert p.returncode == norepo.REFUSED_EXIT, (
+        f"a not-yet-existing path behind a symlink was NOT refused:\n{out}")
+    assert "GUARD 9" in out, out
+    assert not dest.exists(), "refused, but the repository was still created"
+
+
+def _farm_env(guard_dir, gitconfig):
+    env = dict(os.environ)
+    env.pop("GIT_DIR", None)
+    env["PATH"] = f"{guard_dir}{os.pathsep}" + os.environ["PATH"]
+    env["GIT_CONFIG_GLOBAL"] = str(gitconfig)
+    return env
+
+
+def test_an_alias_in_a_repos_OWN_config_is_guarded_by_the_exec_farm(guarded, tmp_path):
+    """🔴 THE RESIDUAL THIS MODULE USED TO ONLY DOCUMENT, NOW CLOSED.
+
+    Git PREPENDS `libexec/git-core` to PATH for every process it spawns, so a
+    bare `git` inside a `!`-alias resolves to the REAL binary and never reaches
+    a PATH shim. Scanning the current invocation cannot help when the alias is
+    ALREADY IN the repo's own `.git/config`.
+
+    BOTH ARMS, because the point is that one layer is insufficient:
+      without GIT_EXEC_PATH -> the alias lands a commit on the victim
+      with the farm         -> refused by THIS guard, victim unchanged
+    """
+    victim = _mkrepo(tmp_path / "farm-victim")
+    fixture = _mkrepo(tmp_path / "farm-fixture")
+    subprocess.run(["git", "-C", str(fixture), "config", "alias.pwn",
+                    f"!git -C {victim} commit --allow-empty -m PWNED-OWN-ALIAS"],
+                   check=True, capture_output=True)
+    gd = tmp_path / "farm-guard"
+    norepo.install(gd, norepo.protected_paths(victim), [str(guarded.gitconfig)])
+
+    def commits():
+        return _git("-C", str(victim), "rev-list", "--count", "--all").stdout.strip()
+
+    # --- arm 1: PATH shim only. The residual must be REAL. -------------------
+    base = commits()
+    env = _farm_env(gd, guarded.gitconfig)
+    env.pop("GIT_EXEC_PATH", None)
+    subprocess.run(["git", "-C", str(fixture), "pwn"], env=env,
+                   capture_output=True, text=True, timeout=120)
+    assert commits() != base, (
+        "the alias-in-own-config residual no longer reproduces. If git stopped "
+        "prepending its libexec, say so — do not delete the farm.")
+
+    # --- arm 2: with the farm. ----------------------------------------------
+    victim2 = _mkrepo(tmp_path / "farm-victim2")
+    fixture2 = _mkrepo(tmp_path / "farm-fixture2")
+    subprocess.run(["git", "-C", str(fixture2), "config", "alias.pwn",
+                    f"!git -C {victim2} commit --allow-empty -m PWNED-OWN-ALIAS"],
+                   check=True, capture_output=True)
+    gd2 = tmp_path / "farm-guard2"
+    norepo.install(gd2, norepo.protected_paths(victim2), [str(guarded.gitconfig)])
+    farm = norepo.install_exec_farm(gd2)
+    assert farm, "the exec farm could not be built"
+    env2 = _farm_env(gd2, guarded.gitconfig)
+    env2["GIT_EXEC_PATH"] = farm
+
+    def commits2():
+        return _git("-C", str(victim2), "rev-list", "--count", "--all").stdout.strip()
+
+    base2 = commits2()
+    p = subprocess.run(["git", "-C", str(fixture2), "pwn"], env=env2,
+                       capture_output=True, text=True, timeout=120)
+    out = p.stdout + p.stderr
+    assert commits2() == base2, (
+        f"the farm did not stop the alias; victim moved {base2} -> {commits2()}\n{out}")
+    assert "GUARD 9" in out, f"stopped, but not by this guard:\n{out}"
+
+
+def test_the_exec_farm_does_not_break_ordinary_git(guarded, tmp_path):
+    """🔴 A farm that broke git would be a permanently-red gate. Substituting
+    `git` inside libexec must leave every other helper reachable."""
+    gd = tmp_path / "ok-guard"
+    norepo.install(gd, norepo.protected_paths(guarded.victim), [str(guarded.gitconfig)])
+    farm = norepo.install_exec_farm(gd)
+    assert farm
+    env = _farm_env(gd, guarded.gitconfig)
+    env["GIT_EXEC_PATH"] = farm
+    for label, argv in (("status", ["-C", str(guarded.fixture), "status", "--porcelain"]),
+                        ("log", ["-C", str(guarded.fixture), "log", "--oneline", "-1"]),
+                        ("commit", ["-C", str(guarded.fixture), "commit", "--allow-empty", "-m", "ok"]),
+                        ("diff", ["-C", str(guarded.fixture), "diff"]),
+                        ("rebase --help", ["rebase", "--help"])):
+        r = subprocess.run(["git", *argv], env=env, capture_output=True, text=True)
+        assert r.returncode == 0, f"the farm broke `git {label}`:\n{r.stdout}{r.stderr}"
+    # The farm must carry essentially all of git's helpers, not a token few.
+    assert len(list(Path(farm).iterdir())) > 50, "the farm is suspiciously small"
+
+
+#: 🔴 THE ESCAPE SET, DERIVED BY MEASUREMENT, PINNED BOTH WAYS.
+#: An earlier revision asserted the residual was ONE — the shell case — and
+#: omitted the absolute-path case entirely. Six shapes were measured; the
+#: guard's reach is exactly the four that go through PATH resolution.
+ALIAS_SHAPES = {
+    "bare git": ("!git -C {v} commit --allow-empty -m PWN", "guarded"),
+    "git via sh -c": ("!sh -c 'git -C {v} commit --allow-empty -m PWN'", "guarded"),
+    "git via env": ("!env git -C {v} commit --allow-empty -m PWN", "guarded"),
+    "git via command": ("!command git -C {v} commit --allow-empty -m PWN", "guarded"),
+    "absolute git path": ("!{git} -C {v} commit --allow-empty -m PWN", "escapes"),
+    "no git at all": ("!touch {v}/PLANTED-SHELL", "escapes"),
+}
+
+
+@pytest.mark.parametrize("shape", sorted(ALIAS_SHAPES))
+def test_the_farms_reach_is_exactly_the_derived_set(guarded, tmp_path, shape):
+    """🔴 BOTH DIRECTIONS. A shape marked `guarded` must be refused; a shape
+    marked `escapes` must STILL escape.
+
+    The second half matters as much as the first: if an escape silently stops
+    escaping, the module's stated residual is now too pessimistic and should be
+    corrected with a measurement — and if a guarded shape starts escaping, the
+    farm has regressed. Either way this test says which.
+    """
+    body, expect = ALIAS_SHAPES[shape]
+    victim = _mkrepo(tmp_path / f"as-v-{abs(hash(shape)) % 9999}")
+    fixture = _mkrepo(tmp_path / f"as-f-{abs(hash(shape)) % 9999}")
+    real = shutil.which("git")
+    subprocess.run(["git", "-C", str(fixture), "config", "alias.pwn",
+                    body.format(v=victim, git=real)], check=True, capture_output=True)
+    gd = tmp_path / f"as-g-{abs(hash(shape)) % 9999}"
+    norepo.install(gd, norepo.protected_paths(victim), [str(guarded.gitconfig)])
+    farm = norepo.install_exec_farm(gd)
+    assert farm, "the exec farm could not be built"
+    env = dict(os.environ)
+    env.pop("GIT_DIR", None)
+    env["PATH"] = f"{gd}{os.pathsep}" + os.environ["PATH"]
+    env["GIT_CONFIG_GLOBAL"] = str(guarded.gitconfig)
+    env["GIT_EXEC_PATH"] = farm
+
+    def moved():
+        n = _git("-C", str(victim), "rev-list", "--count", "--all").stdout.strip()
+        return n != "1" or (victim / "PLANTED-SHELL").exists()
+
+    p = subprocess.run(["git", "-C", str(fixture), "pwn"], env=env,
+                       capture_output=True, text=True, timeout=120)
+    out = p.stdout + p.stderr
+    if expect == "guarded":
+        assert not moved(), f"{shape} was expected GUARDED but it landed:\n{out}"
+        assert "GUARD 9" in out, f"{shape} was stopped, but not by this guard:\n{out}"
+    else:
+        assert moved(), (
+            f"{shape} was expected to ESCAPE and did not. If the farm now covers "
+            "it, the module's stated residual is too pessimistic — correct it "
+            f"with the measurement rather than leaving a stale claim.\n{out}")
+
+
+def test_the_exec_farm_is_DERIVED_and_verified_as_a_SET(guarded, tmp_path):
+    """🔴 A COUNT TEST PASSES WHEN ONE HELPER IS SWAPPED FOR ANOTHER.
+
+    The farm is rebuilt from `git --exec-path` on every call, so a helper added
+    by a git upgrade is picked up automatically — it is not a snapshot ledger.
+    This asserts the SET, and that our own `git` is a real copy rather than a
+    link to the binary it is meant to shadow.
+    """
+    gd = tmp_path / "setfarm-guard"
+    norepo.install(gd, norepo.protected_paths(guarded.victim), [str(guarded.gitconfig)])
+    farm = Path(norepo.install_exec_farm(gd))
+    src = Path(subprocess.run([norepo.real_git(), "--exec-path"],
+                              capture_output=True, text=True).stdout.strip())
+    assert set(os.listdir(farm)) == set(os.listdir(src)), (
+        "the farm's entry SET differs from git's exec-path; a helper git looks "
+        "for would reach the real binary unguarded")
+    assert not (farm / "git").is_symlink(), "the farm's `git` must be OUR shim"
+
+
+def test_a_farm_that_cannot_be_BUILT_makes_install_REFUSE(guarded, tmp_path):
+    """🔴 FAIL CLOSED when the farm cannot be completed.
+
+    MEASURED on an earlier revision: a pre-existing regular file at
+    `.git-archimport-wrapped` was `continue`d past and the farm was returned as
+    usable anyway — a hole handed to git silently. The build now starts from a
+    clean directory, so a stale blocker cannot survive; what remains is the
+    case where the directory cannot be written at all, and that must refuse
+    rather than return a partial farm.
+    """
+    gd = tmp_path / "closed-guard"
+    norepo.install(gd, norepo.protected_paths(guarded.victim), [str(guarded.gitconfig)])
+    # Sanity: it builds normally here, so a refusal below is about the block.
+    assert norepo.install_exec_farm(gd), "the farm does not build even unblocked"
+    shutil.rmtree(gd / norepo.EXEC_FARM_NAME, ignore_errors=True)
+    gd.chmod(0o500)                       # read+execute, not writable
+    try:
+        res = norepo.install_exec_farm(gd)
+    finally:
+        gd.chmod(0o700)
+    assert res == "", (
+        "a farm that could not be built did not refuse; a partial exec-path "
+        "would be handed to git with a hole in it")
+
+
+def test_the_runner_treats_an_unusable_farm_as_FATAL():
+    """Proceeding with a known hole is the thing being refused."""
+    text = RUN_TESTS.read_text(encoding="utf-8")
+    i = text.index("GITGUARD_FARM=")
+    tail = text[i:i + 2000]
+    assert "FATAL" in tail and "exit 2" in tail, (
+        "run-tests.sh no longer refuses to run when the exec farm is unusable")
+
+
+def test_the_runner_exports_the_exec_farm():
+    text = RUN_TESTS.read_text(encoding="utf-8")
+    assert 'export GIT_EXEC_PATH="$GITGUARD_FARM"' in text, (
+        "run-tests.sh does not export the exec farm; a git-spawned child would "
+        "resolve `git` to the real binary")
+    assert "exec-farm=" in (REPO_ROOT / "scripts/testlib/norepo.py").read_text()
+
+
+def test_the_integrity_check_FAILS_on_a_DELIBERATELY_GUARDED_arm(guarded, tmp_path):
+    """🔴 THE CHECK BUILT TO PREVENT A FAKE GREEN, CHECKED ITSELF.
+
+    Every VACUOUS verdict in this file rests on `_assert_truly_unguarded`
+    having passed. If it can pass on a GUARDED arm, every one of them is
+    inherited from a broken instrument. So: hand it an arm that is guarded on
+    purpose and require it to raise.
+    """
+    with pytest.raises(AssertionError):
+        _assert_truly_unguarded(dict(guarded.env), tmp_path, "deliberately-guarded",
+                                protected_hint=guarded.victim)
+
+
+def test_the_positive_canary_ALONE_discriminates(guarded, tmp_path):
+    """🔴 LEG 3 IN ISOLATION. MEASURED on its predecessor: a commit inside an
+    unprotected fixture passed with the guard loaded AND absent — it could not
+    distinguish the two states, so its success proved permission.
+
+    This asserts the pair directly: refused under the guard, rc 0 without it.
+    """
+    guarded_r = _discriminating_canary(dict(guarded.env), guarded.victim, "g")
+    assert guarded_r.returncode == norepo.REFUSED_EXIT, (
+        "the positive canary is an operation the guard PERMITS; its success "
+        "would be evidence of permission, not of the guard being absent:\n"
+        f"{guarded_r.stdout}{guarded_r.stderr}")
+    unguarded_r = _discriminating_canary(
+        _unguarded_env(guarded.dir), guarded.victim, "u")
+    assert unguarded_r.returncode == 0, (
+        f"the canary does not succeed even unguarded, so it cannot be used as "
+        f"evidence of absence:\n{unguarded_r.stdout}{unguarded_r.stderr}")
+
+
+def test_farm_is_complete_rejects_a_missing_or_shadowed_entry(tmp_path):
+    """🔴 The set check, tested DIRECTLY because it is unreachable inside
+    `install_exec_farm` on a healthy box — the build starts clean and always
+    produces the right set. An unreachable guard is one nobody has watched
+    work."""
+    farm = tmp_path / "farm"
+    farm.mkdir()
+    for n in ("a", "b"):
+        (farm / n).write_text("x")
+    (farm / "git").write_text("shim")
+    assert norepo.farm_is_complete(farm, {"a", "b", "git"})
+    # a MISSING helper
+    assert not norepo.farm_is_complete(farm, {"a", "b", "git", "c"})
+    # a SWAPPED helper: same count, different set
+    assert not norepo.farm_is_complete(farm, {"a", "zzz", "git"})
+    # `git` that merely LINKS to the real binary guards nothing
+    (farm / "git").unlink()
+    (farm / "git").symlink_to(shutil.which("git") or "/bin/true")
+    assert not norepo.farm_is_complete(farm, {"a", "b", "git"})
+
+
+# --------------------------------------------------------------------------- #
+# 3f. THE MITIGATION'S OWN ATTACK SURFACE, AND THE DISPATCH-NAME FARM
+# --------------------------------------------------------------------------- #
+def test_the_shim_NEVER_shell_interprets_an_argv_derived_string(guarded, tmp_path):
+    """🔴 A GUARD THAT IS WORSE THAN NO GUARD.
+
+    `--config-env=key=VAR` puts VAR on the command line. An earlier revision did
+    `eval "_cv=${$_ev:-}"` with it, so a command substitution in the NAME ran
+    inside the shim, before any check, on a pure READ. MEASURED:
+
+        git --config-env=core.pager='V:-$(touch X)' --version
+          this shim -> X CREATED, then exit 99
+          real git  -> exit 128, "fatal: missing environment variable", nothing run
+
+    Real git rejects the name and executes nothing, so the mitigation was
+    introducing execution the unguarded system refuses. Both halves are
+    asserted: nothing runs, AND the invocation is refused.
+    """
+    marker = tmp_path / "PWNED-BY-SHIM"
+    p = subprocess.run(
+        ["git", f"--config-env=core.pager=V:-$(touch {marker})", "--version"],
+        env=guarded.env, capture_output=True, text=True, timeout=60)
+    assert not marker.exists(), (
+        "the shim EXECUTED a command taken from argv. On this path the guard is "
+        "strictly worse than no guard — real git refuses the name and runs "
+        f"nothing.\n{p.stdout}{p.stderr}")
+    assert p.returncode == norepo.REFUSED_EXIT, (
+        f"the injection did not run but was not refused either:\n{p.stdout}{p.stderr}")
+
+
+def test_a_VALID_config_env_name_still_works(guarded):
+    """The other direction: `--config-env` with an ordinary name must not be
+    refused, or the fix is a permanently-red gate."""
+    env = dict(guarded.env)
+    env["G9_VALID_NAME"] = "someone@example.com"
+    p = subprocess.run(["git", "-C", str(guarded.fixture),
+                        "--config-env=user.email=G9_VALID_NAME",
+                        "config", "--get", "user.email"],
+                       env=env, capture_output=True, text=True)
+    assert p.returncode == 0, f"a valid --config-env was refused:\n{p.stdout}{p.stderr}"
+
+
+def test_the_eval_family_is_audited_not_just_the_one_instance():
+    r"""🔴 THE PATTERN, NOT THE INSTANCE.
+
+    Every `eval` in the rendered shim must take a HARDCODED variable name or a
+    digit-validated counter -- never a value from argv. Anything that
+    shell-interprets an argv-derived string belongs to the same family as the
+    `--config-env` RCE by construction, so the audit is over the whole set.
+
+    🔴 CODE ONLY. The first revision of this test searched every line and
+    matched the COMMENT documenting the bug -- the prose-walkable shape that
+    has now caught three separate structural checks in this file.
+    """
+    raw = norepo.shim_body("/usr/bin/git", Path("/tmp/l"), Path("/tmp/p"),
+                           Path("/tmp/c"))
+    # Strip comments ONCE, up front: every assertion below is about code.
+    shim = "\n".join(ln for ln in raw.splitlines()
+                     if not ln.strip().startswith("#"))
+    evals = [ln.strip() for ln in shim.splitlines() if "eval " in ln]
+    # $_v comes from REFUSED_ENV (hardcoded); $_n is the digit-validated
+    # GIT_CONFIG_COUNT index. Neither can carry a value from the command line.
+    allowed_names = ("$_v", "GIT_CONFIG_KEY_$_n", "GIT_CONFIG_VALUE_$_n")
+    for e in evals:
+        assert any(n in e for n in allowed_names), (
+            "an `eval` in the shim takes an operand that is not a hardcoded "
+            f"name or a validated counter — if it can come from argv that is "
+            f"remote code execution inside the guard:\n  {e}")
+    assert len(evals) == 3, (
+        f"the shim's `eval` set changed ({len(evals)} found). Re-audit each "
+        f"operand before widening this pin:\n" + "\n".join(evals))
+    # ...and the argv-derived path must be read WITHOUT interpretation.
+    assert "printenv" in shim, "the --config-env value is not read with printenv"
+    assert 'eval "_cv=' not in shim, (
+        "the --config-env value is being eval'd again")
+
+
+FARM_DISPATCH_CASES = [
+    ("git-config -f into a protected repo", "refuse",
+     lambda farm, v, f: ([f"{farm}/git-config", "-f", str(v / ".git" / "config"),
+                          "core.bale", "true"], None)),
+    ("git-commit into a protected repo", "refuse",
+     lambda farm, v, f: ([f"{farm}/git-commit", "--allow-empty", "-m", "PWN"], str(v))),
+    ("git-status on a fixture", "allow",
+     lambda farm, v, f: ([f"{farm}/git-status", "--porcelain"], str(f))),
+    ("git-log on a PROTECTED repo (a read)", "allow",
+     lambda farm, v, f: ([f"{farm}/git-log", "--oneline", "-1"], str(v))),
+]
+
+
+@pytest.mark.parametrize("label,expect,build", FARM_DISPATCH_CASES,
+                         ids=[c[0] for c in FARM_DISPATCH_CASES])
+def test_the_farm_routes_every_DISPATCH_NAME_not_just_git(guarded, tmp_path,
+                                                          label, expect, build):
+    """🔴 GIT DISPATCHES ON argv[0], AND THE FARM MUST OWN EVERY SUCH NAME.
+
+    MEASURED against an earlier revision that substituted only the literal
+    `git`: all 181 `git-<verb>` entries pointed at the real binary and sat
+    FIRST on PATH in exactly the alias/hook context the farm exists for —
+
+        <farm>/git-config -f <victim>/.git/config core.bale true
+          -> core.bare false -> true, rc 0
+
+    the incident's own signature, with `git` never spelled.
+
+    🔴 ROUTED BY NAME, NEVER BY INODE. On this host those entries are SYMLINKS
+    and none shares git's inode; on another packaging they are hardlinks. The
+    property git uses is the NAME, so an inode/`stat` enumeration is the wrong
+    attribute and would report a clean farm on one packaging while missing
+    every entry on the other.
+    """
+    victim = _mkrepo(tmp_path / f"fd-v-{abs(hash(label)) % 9999}")
+    fixture = _mkrepo(tmp_path / f"fd-f-{abs(hash(label)) % 9999}")
+    gd = tmp_path / f"fd-g-{abs(hash(label)) % 9999}"
+    norepo.install(gd, norepo.protected_paths(victim), [str(guarded.gitconfig)])
+    farm = norepo.install_exec_farm(gd)
+    assert farm
+    argv, cwd = build(farm, victim, fixture)
+    env = dict(os.environ)
+    env.pop("GIT_DIR", None)
+    env["PATH"] = f"{gd}{os.pathsep}" + os.environ["PATH"]
+    env["GIT_CONFIG_GLOBAL"] = str(guarded.gitconfig)
+    env["GIT_EXEC_PATH"] = farm
+    before = (victim / ".git" / "config").read_text()
+    p = subprocess.run(argv, env=env, cwd=cwd, capture_output=True, text=True,
+                       timeout=60)
+    out = p.stdout + p.stderr
+    if expect == "refuse":
+        assert p.returncode == norepo.REFUSED_EXIT, f"{label} not refused:\n{out}"
+        assert "GUARD 9" in out, out
+        assert (victim / ".git" / "config").read_text() == before
+    else:
+        assert p.returncode == 0, (
+            f"{label} was refused — a permanently-red gate; the shim must "
+            f"dispatch correctly when invoked AS git-<verb>:\n{out}")
+
+
+def test_every_git_dispatch_name_in_the_farm_is_OUR_shim(guarded, tmp_path):
+    """Derived at run time and checked as a SET, by name."""
+    gd = tmp_path / "dispatch-guard"
+    norepo.install(gd, norepo.protected_paths(guarded.victim), [str(guarded.gitconfig)])
+    farm = Path(norepo.install_exec_farm(gd))
+    names = set(os.listdir(farm))
+    dispatch = {n for n in names if n == "git" or n.startswith("git-")}
+    assert len(dispatch) > 100, f"only {len(dispatch)} dispatch names — suspicious"
+    unrouted = [n for n in dispatch
+                if (farm / n).is_symlink() or not (farm / n).is_file()]
+    assert not unrouted, (
+        f"{len(unrouted)} dispatch names still reach the real binary: "
+        f"{sorted(unrouted)[:8]}")
+
+
+READ_PATH_CASES = [
+    ("log --output= into a protected repo", "refuse",
+     lambda v, f, tmp: ["-C", str(f), "log", "-p",
+                        f"--output={v / '.git' / 'config'}"]),
+    ("log --output= into an ALLOWED path", "allow",
+     lambda v, f, tmp: ["-C", str(f), "log", f"--output={tmp / 'ok.txt'}"]),
+    # 🔴 THE SPACE-SEPARATED FORM. MEASURED: with only `--output=<path>`
+    # covered, a mutant that deleted the `--output <path>` branch SURVIVED —
+    # the two spellings are handled by different branches and only one was
+    # exercised. A synonym walks a guard tested on one spelling.
+    ("log --output <path> (space-separated) into a protected repo", "refuse",
+     lambda v, f, tmp: ["-C", str(f), "log", "-p", "--output",
+                        str(v / ".git" / "config")]),
+    ("grep -O<cmd>", "refuse",
+     lambda v, f, tmp: ["-C", str(f), "grep", f"-O touch {tmp / 'PWN-GREP'}", "A"]),
+]
+
+
+@pytest.mark.parametrize("label,expect,build", READ_PATH_CASES,
+                         ids=[c[0] for c in READ_PATH_CASES])
+def test_a_read_verb_carrying_a_destination_or_command_is_checked(
+        guarded, tmp_path, label, expect, build):
+    """🔴 A VERB'S CLASSIFICATION SAYS NOTHING ABOUT ITS OPTIONS.
+
+    `log` and `grep` are truthfully read verbs. MEASURED against an earlier
+    revision, from an ALLOWED repo: `log -p --output=<victim>/.git/config`
+    clobbered the victim's config and `grep -O<cmd>` ran the command — both rc
+    0, both `exec`d on the fast path before any destination check. Same lesson
+    as `status`, with a destination attached.
+    """
+    victim = _mkrepo(tmp_path / f"rp-v-{abs(hash(label)) % 9999}")
+    fixture = _mkrepo(tmp_path / f"rp-f-{abs(hash(label)) % 9999}")
+    (fixture / "A").write_text("hello\n")
+    subprocess.run(["git", "-C", str(fixture), "add", "A"], check=True,
+                   capture_output=True)
+    subprocess.run(["git", "-C", str(fixture), "commit", "-qm", "A"], check=True,
+                   capture_output=True)
+    gd = tmp_path / f"rp-g-{abs(hash(label)) % 9999}"
+    norepo.install(gd, norepo.protected_paths(victim), [str(guarded.gitconfig)])
+    env = dict(os.environ)
+    env.pop("GIT_DIR", None)
+    env["PATH"] = f"{gd}{os.pathsep}" + os.environ["PATH"]
+    env["GIT_CONFIG_GLOBAL"] = str(guarded.gitconfig)
+    before = (victim / ".git" / "config").read_text()
+    p = subprocess.run(["git", *build(victim, fixture, tmp_path)], env=env,
+                       capture_output=True, text=True, timeout=60)
+    out = p.stdout + p.stderr
+    if expect == "refuse":
+        assert p.returncode == norepo.REFUSED_EXIT, f"{label} not refused:\n{out}"
+        assert (victim / ".git" / "config").read_text() == before
+        assert not (tmp_path / "PWN-GREP").exists(), "the -O command still ran"
+    else:
+        assert p.returncode == 0, (
+            f"{label} was refused — an output destination OUTSIDE any protected "
+            f"repo must be allowed:\n{out}")
 
 
 def test_no_two_testlib_plugins_patch_Popen_the_same_way():

--- a/scripts/tests/test_no_real_repo_writes.py
+++ b/scripts/tests/test_no_real_repo_writes.py
@@ -1,0 +1,1473 @@
+"""GUARD 9's pins: no test may mutate a REAL repository, and the proof it can't.
+
+🔴 WHAT HAPPENED (2026-08-21, the operator's own workbench)
+------------------------------------------------------------
+Running the Python test tier set `core.bare = true` on the working clone at
+`~/workspace/devrc`, renamed its `main` to `trunk`, repointed its `origin` at a
+pytest tmpdir, left ~50 fixture commits in it, and pushed ~40 of them over
+`refs/heads/main` on the PUBLIC repo in 43 seconds. `trunk` and three feature
+branches were hit too.
+
+🔴 TWO TRACED MECHANISMS WERE REFUTED. THEY ARE PINNED HERE SO NOBODY RE-DERIVES
+--------------------------------------------------------------------------------
+  1. "drift-check.sh's REMOTE leg pipes the payload through a STUB `ssh` that
+     runs it LOCALLY against `$HOME/workspace/devrc`." FALSE: the stub drains
+     stdin and exits, so the payload is never executed. Pinned by
+     `test_the_drift_check_ssh_stub_never_executes_its_payload`.
+  2. "git exports GIT_DIR into the pre-push hook, so `githooks/tests-on-push.sh`
+     runs the suite with it set." FALSE, measured on git 2.55: a pre-push hook
+     gets GIT_EDITOR, GIT_EXEC_PATH and GIT_PREFIX, and no GIT_DIR. Pinned by
+     `test_a_pre_push_hook_does_not_inherit_git_dir`.
+
+🔴 THE MECHANISM THAT DOES REPRODUCE IT
+-----------------------------------------
+An ambient **GIT_DIR overrides `git -C <path>`**. Every fixture in this tree
+binds `-C` or `cwd=` correctly; one inherited variable retargets all of them at
+once and no call site looks wrong.
+`test_an_ambient_git_dir_reproduces_the_incident_signature` replays
+`scripts/repo-cos/tests/test_prescan.py::_init_clone` verbatim against a
+tmp_path fixture with GIT_DIR naming a victim, and asserts the victim's branch
+is renamed, its identity rewritten, the fixture commit landed in it, and the
+commit PUSHED to the victim's own remote -- the incident, byte for byte.
+
+🔴 WHY THE FIX IS NOT "AUDIT THE CALL SITES" AND NOT A CLEANUP STEP
+--------------------------------------------------------------------
+Auditing found nothing because there is nothing at any call site to find. And a
+teardown that restores the repo cannot help: a killed run, an assertion that
+raises past the restore, or `pytest -x` leaves the operator's clone pointed at a
+temp directory with no error anywhere. So `scripts/run-tests.sh` scrubs the
+retargeting variables AND installs `scripts/testlib/norepo.py`'s `git` shim
+first on PATH, at the single point all 24 targets are invoked -- including
+HOOK_TESTS and SHELL_TESTS, which no conftest can reach.
+
+🔴 A WORKTREE IS NOT CONTAINMENT
+----------------------------------
+A linked worktree shares the real clone's `--git-common-dir`: refs, remotes,
+config and reflog. `test_a_linked_worktree_of_a_protected_repo_is_protected`
+pins that the guard resolves to the COMMON dir, because "develop this in a
+worktree" is the intuitive containment answer and it is wrong -- a push from a
+worktree reaches the real remote.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from testlib import norepo  # noqa: E402
+from testlib.mockbin import write_exec  # noqa: E402
+
+RUN_TESTS = REPO_ROOT / "scripts" / "run-tests.sh"
+SHIP = REPO_ROOT / "scripts" / "ship.sh"
+DRIFT = REPO_ROOT / "scripts" / "drift-check.sh"
+ASI_COMMIT = REPO_ROOT / "scripts" / "analyze-service-index" / "commit.sh"
+DRIFT_TESTS = REPO_ROOT / "scripts" / "tests" / "test_drift_check.py"
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _git(*args, cwd=None, env=None):
+    return subprocess.run(["git", *args], cwd=cwd, env=env,
+                          capture_output=True, text=True)
+
+
+def _mkrepo(path: Path, *, bare=False, initial="main") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    argv = ["git", "init", "-q", "-b", initial, str(path)]
+    if bare:
+        argv.insert(2, "--bare")
+    subprocess.run(argv, check=True, capture_output=True)
+    if not bare:
+        for k, v in (("user.email", "t@t"), ("user.name", "t")):
+            subprocess.run(["git", "-C", str(path), "config", k, v], check=True,
+                           capture_output=True)
+        (path / "f").write_text("x\n")
+        subprocess.run(["git", "-C", str(path), "add", "f"], check=True,
+                       capture_output=True)
+        subprocess.run(["git", "-C", str(path), "commit", "-qm", "base"],
+                       check=True, capture_output=True)
+    return path
+
+
+@pytest.fixture
+def guarded(tmp_path):
+    """A victim repo with a NETWORK origin, an unprotected fixture repo, and a
+    PATH with the shim in front — i.e. the runner's own arrangement, in miniature.
+
+    🔴 The shim it installs nests INSIDE the one `run-tests.sh` already put on
+    PATH. That is deliberate and harmless: the outer shim resolves this
+    fixture's repos to a common dir it does not protect and forwards them, so
+    what these tests observe is THIS guard's verdict. It also means a mutation
+    that escaped the inner shim would still be caught by the outer one, which is
+    why every assertion below checks the VICTIM'S STATE, not only the exit code.
+    """
+    victim = _mkrepo(tmp_path / "victim")
+    subprocess.run(["git", "-C", str(victim), "remote", "add", "origin",
+                    "git@github.com:innovation-upstream/devrc.git"],
+                   check=True, capture_output=True)
+    fixture = _mkrepo(tmp_path / "fixture")
+    # 🔴 The fixture's tree must DIFFER from a victim's, or `GIT_WORK_TREE`
+    # checkouts write byte-identical content and the vector looks harmless.
+    # MEASURED: with both repos holding the same `f`, the GIT_WORK_TREE arm moved
+    # no axis and the battery correctly called it vacuous.
+    (fixture / "fixture-only.py").write_text("x = 1  # seed\n")
+    subprocess.run(["git", "-C", str(fixture), "add", "fixture-only.py"],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(fixture), "commit", "-qm", "fixture only"],
+                   check=True, capture_output=True)
+    bare = _mkrepo(tmp_path / "fixture-origin.git", bare=True)
+    subprocess.run(["git", "-C", str(fixture), "remote", "add", "origin", str(bare)],
+                   check=True, capture_output=True)
+
+    gitconfig = tmp_path / "gitconfig"
+    gitconfig.write_text("[user]\n\tname = t\n\temail = t@t\n")
+
+    guard_dir = tmp_path / "guard"
+    log = norepo.install(guard_dir,
+                         norepo.protected_paths(victim),
+                         [str(gitconfig)])
+    env = dict(os.environ)
+    env["PATH"] = f"{guard_dir}{os.pathsep}{env['PATH']}"
+    env["GIT_CONFIG_GLOBAL"] = str(gitconfig)
+    env.pop("GIT_DIR", None)
+
+    class G:
+        pass
+
+    g = G()
+    g.victim, g.fixture, g.bare = victim, fixture, bare
+    g.env, g.log, g.dir, g.gitconfig = env, Path(log), guard_dir, gitconfig
+    g.tmp = tmp_path
+    return g
+
+
+def _victim_state(victim: Path) -> dict:
+    def cfg(k):
+        return _git("-C", str(victim), "config", "--get", k).stdout.strip()
+
+    return {
+        "core.bare": cfg("core.bare"),
+        "core.hooksPath": cfg("core.hooksPath"),
+        "origin": cfg("remote.origin.url"),
+        "branches": sorted(
+            _git("-C", str(victim), "for-each-ref", "--format=%(refname)",
+                 "refs/heads").stdout.split()),
+        "HEAD": _git("-C", str(victim), "symbolic-ref", "-q", "HEAD").stdout.strip(),
+        "commits": len(
+            _git("-C", str(victim), "log", "--oneline").stdout.splitlines()),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# 1. THE NEGATIVE CONTROL — every one of these must be REFUSED
+# --------------------------------------------------------------------------- #
+def _negatives(g):
+    v, f, t = str(g.victim), str(g.fixture), g.tmp
+    return {
+        "repoint origin": ["git", "-C", v, "remote", "set-url", "origin",
+                           str(t / "does-not-exist.git")],
+        "set core.bare": ["git", "-C", v, "config", "core.bare", "true"],
+        "re-init as bare": ["git", "-C", v, "init", "--bare"],
+        "rename main": ["git", "-C", v, "branch", "-m", "main", "trunk"],
+        "repoint HEAD": ["git", "-C", v, "symbolic-ref", "HEAD", "refs/heads/trunk"],
+        "commit a fixture commit": ["git", "-C", v, "commit", "--allow-empty",
+                                    "-m", "seed"],
+        "push to the real remote": ["git", "-C", v, "push", "origin",
+                                    "HEAD:refs/heads/main"],
+        "set core.hooksPath": ["git", "-C", v, "config", "core.hooksPath", "/tmp/x"],
+        "rewrite the global config": ["git", "config", "--global", "user.email",
+                                      "evil@example.com"],
+        "push a fixture to a network URL": ["git", "-C", f, "push",
+                                            "https://example.com/x.git", "HEAD:main"],
+    }
+
+
+#: 🔴 One entry per SHAPE of the measured damage, named so a red run says which
+#: half of the incident came back. The list is pinned against `_negatives`'s own
+#: keys below, so a shape cannot be dropped from the battery unnoticed.
+INCIDENT_SHAPES = (
+    "repoint origin", "set core.bare", "re-init as bare", "rename main",
+    "repoint HEAD", "commit a fixture commit", "push to the real remote",
+    "set core.hooksPath", "rewrite the global config",
+    "push a fixture to a network URL",
+)
+
+
+def test_the_incident_shape_ledger_matches_the_battery(guarded):
+    assert sorted(INCIDENT_SHAPES) == sorted(_negatives(guarded)), (
+        "INCIDENT_SHAPES and the negative-control battery disagree; a shape "
+        "listed in one and not the other is either never run or never named.")
+
+
+@pytest.mark.parametrize("name", INCIDENT_SHAPES)
+def test_the_guard_refuses_every_shape_of_the_incident(guarded, name):
+    """🔴 THE NEGATIVE CONTROL, one case per shape of the measured damage.
+
+    The exit status is checked AND the refusal must name THIS guard — an
+    unrelated failure (a missing binary, a bad path) also produces a non-zero
+    exit, and would let a guard that had stopped working read as one that works.
+    """
+    before = _victim_state(guarded.victim)
+    argv = _negatives(guarded)[name]
+    p = subprocess.run(argv, env=guarded.env, capture_output=True, text=True)
+    out = p.stdout + p.stderr
+    assert p.returncode == norepo.REFUSED_EXIT, (
+        f"{name}: expected the guard's own exit {norepo.REFUSED_EXIT}, "
+        f"got {p.returncode}\n{out}")
+    assert "GUARD 9" in out and "norepo.py" in out, (
+        f"{name}: refused, but not by THIS guard — the message must name it, or a "
+        f"different failure is being read as protection:\n{out}")
+    assert _victim_state(guarded.victim) == before, (
+        f"{name}: the guard exited {norepo.REFUSED_EXIT} but the repository "
+        f"CHANGED. A refusal that still writes is worse than no refusal.")
+
+
+def test_the_guard_refuses_a_write_that_arrives_via_an_ambient_git_dir(guarded):
+    """🔴 THE MEASURED MECHANISM: GIT_DIR beats `-C`.
+
+    The argv names the FIXTURE. Only the environment names the victim. This is
+    the shape no call-site audit can see, and it is why the guard resolves the
+    repo the way git will rather than trusting the arguments.
+    """
+    before = _victim_state(guarded.victim)
+    env = dict(guarded.env)
+    env["GIT_DIR"] = str(guarded.victim / ".git")
+    p = subprocess.run(
+        ["git", "-C", str(guarded.fixture), "branch", "-m", "main", "trunk"],
+        env=env, capture_output=True, text=True)
+    assert p.returncode == norepo.REFUSED_EXIT, p.stdout + p.stderr
+    assert "GUARD 9" in p.stdout + p.stderr
+    assert _victim_state(guarded.victim) == before
+
+
+# 🔴 THE ARMED-ENVIRONMENT BATTERY, AND IT PROVES ITS OWN DANGER
+#
+# Asserting "the victim is unchanged" under the guard is worth nothing unless
+# the SAME command WITHOUT the guard demonstrably changes something. MEASURED:
+# of ten vectors originally written here, FOUR moved no asserted axis at all —
+# `git checkout -f HEAD` against a victim already at HEAD writes nothing
+# observable whether it was refused or not, and the assertion set passed
+# identically either way. That is an armed control that can only agree with
+# itself, the same shape as a mutation that dies for the wrong reason.
+#
+# So every vector runs BOTH arms inside one test:
+#   unguarded -> at least one asserted axis MUST move, or the test fails saying
+#                this vector was never dangerous
+#   guarded   -> refused by THIS guard, every axis unchanged
+#
+# `GIT_ALTERNATE_OBJECT_DIRECTORIES` is deliberately ABSENT: measured, it is a
+# read-only ADDITIONAL object store and moves nothing. It is still scrubbed by
+# the runner; `norepo.REFUSED_ENV` vs `RETARGETING_ENV` records that difference
+# instead of implying it was tested here.
+ARMED_VECTOR_IDS = (
+    "GIT_DIR", "GIT_COMMON_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY", "GIT_CONFIG_GLOBAL", "GIT_CONFIG_SYSTEM",
+    "GIT_CONFIG_COUNT",
+)
+
+
+def _digest(f: Path) -> str:
+    try:
+        return hashlib.sha256(f.read_bytes()).hexdigest()[:12]
+    except OSError:
+        return "<absent>"
+
+
+def _wt_digest(root: Path) -> str:
+    return "|".join(
+        f"{f.relative_to(root)}={_digest(f)}"
+        for f in sorted(root.rglob("*"))
+        if f.is_file() and ".git" not in f.parts)
+
+
+def _full_state(victim: Path, gitconfig: Path) -> dict:
+    """Every axis the battery asserts on — wide enough that a live vector shows."""
+    def q(*a):
+        return _git("-C", str(victim), *a).stdout.strip()
+
+    objs = victim / ".git" / "objects"
+    return {
+        "config": q("config", "--local", "--list"),
+        "branches": q("for-each-ref", "--format=%(refname) %(objectname)", "refs/heads"),
+        "HEAD": q("symbolic-ref", "-q", "HEAD"),
+        "commits": q("rev-list", "--count", "--all"),
+        "index": _digest(victim / ".git" / "index"),
+        "objects": str(sum(1 for f in objs.rglob("*") if f.is_file())),
+        "worktree": _wt_digest(victim),
+        "global-config": _digest(gitconfig),
+    }
+
+
+def _plant_hook(victim: Path) -> None:
+    """A post-commit hook INSIDE the victim that writes into its working tree.
+
+    This is what makes the GIT_CONFIG_COUNT vector observable: the injected
+    `core.hooksPath` causes git to execute code out of the protected repo, and
+    the marker it drops moves the `worktree` axis. Without it the vector writes
+    no file anywhere and the battery cannot tell a refusal from a no-op.
+    """
+    hooks = victim / ".git" / "hooks"
+    hooks.mkdir(parents=True, exist_ok=True)
+    # `write_exec`, never a hand-written shebang: `scripts/tests` has a gate
+    # forbidding those at runtime, because `/usr/bin/env` does not exist in the
+    # nix build sandbox and the stub would fail to exec there only.
+    write_exec(hooks / "post-commit", f'touch "{victim}/HOOK-EXECUTED"\n')
+
+
+def _vector(vec, victim: Path, gitconfig: Path):
+    """(env-to-arm, argv, stdin) for `vec`, aimed at `victim`."""
+    if vec == "GIT_CONFIG_COUNT":
+        _plant_hook(victim)
+    return {
+        "GIT_DIR": ({"GIT_DIR": str(victim / ".git")},
+                    ["branch", "-m", "main", "trunk"], None),
+        "GIT_COMMON_DIR": ({"GIT_COMMON_DIR": str(victim / ".git")},
+                           ["branch", "-m", "main", "trunk"], None),
+        "GIT_WORK_TREE": ({"GIT_WORK_TREE": str(victim)},
+                          ["checkout", "-f", "HEAD"], None),
+        "GIT_INDEX_FILE": ({"GIT_INDEX_FILE": str(victim / ".git" / "index")},
+                           ["add", "-A", "."], None),
+        # 🔴 `hash-object -w`, NOT `commit`. With GIT_OBJECT_DIRECTORY pointed at
+        # the victim, a commit cannot find the FIXTURE's own objects and dies
+        # rc 128 having written nothing — the vector LOOKED refused when it had
+        # merely failed. `hash-object` needs no pre-existing objects, so the
+        # victim's object count actually moves.
+        "GIT_OBJECT_DIRECTORY": ({"GIT_OBJECT_DIRECTORY": str(victim / ".git" / "objects")},
+                                 ["hash-object", "-w", "--stdin"], "payload\n"),
+        "GIT_CONFIG_GLOBAL": ({"GIT_CONFIG_GLOBAL": str(gitconfig)},
+                              ["config", "--global", "user.email", "evil@example.com"], None),
+        "GIT_CONFIG_SYSTEM": ({"GIT_CONFIG_SYSTEM": str(gitconfig)},
+                              ["config", "--global", "user.email", "evil@example.com"], None),
+        # 🔴 The channel a file-watching guard cannot see: this writes NO
+        # config file anywhere. MEASURED with `core.worktree` first, which moved
+        # NOTHING (git ignores it for a `-C`-discovered repo) — a vector that
+        # would have been "refused" while being harmless. `core.hooksPath` at
+        # the victim's OWN hooks dir is the live form: the planted hook RUNS and
+        # writes into the victim's working tree, which `_full_state` observes.
+        "GIT_CONFIG_COUNT": ({"GIT_CONFIG_COUNT": "1",
+                              "GIT_CONFIG_KEY_0": "core.hooksPath",
+                              "GIT_CONFIG_VALUE_0": str(victim / ".git" / "hooks")},
+                             ["commit", "--allow-empty", "-m", "x"], None),
+    }[vec]
+
+
+@pytest.mark.parametrize("vec", ARMED_VECTOR_IDS)
+def test_the_armed_vector_is_DANGEROUS_and_the_guard_HOLDS(guarded, tmp_path, vec):
+    """🔴 BOTH ARMS IN ONE TEST, so they cannot drift apart.
+
+    Each arm gets its OWN victim, because arm 1 is expected to damage one.
+    """
+    # --- arm 1: UNGUARDED. Prove the vector can actually do damage. -----------
+    v1 = _mkrepo(tmp_path / "victim-unguarded")
+    cfg1 = tmp_path / "gitconfig-unguarded"
+    cfg1.write_text("[user]\n\tname = t\n\temail = t@t\n")
+    env_add, argv, stdin = _vector(vec, v1, cfg1)
+    unguarded = dict(os.environ)
+    unguarded.pop("GIT_DIR", None)
+    unguarded["GIT_CONFIG_GLOBAL"] = str(cfg1)
+    unguarded.update(env_add)
+    before = _full_state(v1, cfg1)
+    u = subprocess.run(["git", "-C", str(guarded.fixture), *argv], env=unguarded,
+                       input=stdin, capture_output=True, text=True)
+    after = _full_state(v1, cfg1)
+    moved = [k for k in before if before[k] != after[k]]
+    assert moved, (
+        f"{vec}: UNGUARDED this command moved NO asserted axis (rc={u.returncode}). "
+        "The vector is harmless, so refusing it proves nothing — replace it with "
+        f"a command that actually writes.\n{u.stdout}{u.stderr}")
+
+    # --- arm 2: GUARDED. Same command, fresh victim, guard installed. --------
+    v2 = _mkrepo(tmp_path / "victim-guarded")
+    cfg2 = tmp_path / "gitconfig-guarded"
+    cfg2.write_text("[user]\n\tname = t\n\temail = t@t\n")
+    env_add2, argv2, stdin2 = _vector(vec, v2, cfg2)
+    gd = tmp_path / "guard2"
+    norepo.install(gd, norepo.protected_paths(v2), [str(cfg2)])
+    genv = dict(os.environ)
+    genv.pop("GIT_DIR", None)
+    genv["PATH"] = f"{gd}{os.pathsep}" + os.environ["PATH"]
+    genv["GIT_CONFIG_GLOBAL"] = str(cfg2)
+    genv.update(env_add2)
+    b2 = _full_state(v2, cfg2)
+    p = subprocess.run(["git", "-C", str(guarded.fixture), *argv2], env=genv,
+                       input=stdin2, capture_output=True, text=True)
+    a2 = _full_state(v2, cfg2)
+    out = p.stdout + p.stderr
+    assert p.returncode == norepo.REFUSED_EXIT, (
+        f"{vec}: GUARDED, expected the guard's exit {norepo.REFUSED_EXIT}, got "
+        f"{p.returncode}. The unguarded arm moved {moved}, so this is a live "
+        f"bypass.\n{out}")
+    assert "GUARD 9" in out, f"{vec}: refused, but not by this guard:\n{out}"
+    assert a2 == b2, (
+        f"{vec}: the guard exited {norepo.REFUSED_EXIT} but the victim CHANGED: "
+        f"{[k for k in b2 if b2[k] != a2[k]]}")
+
+
+def test_the_armed_ledger_distinguishes_REFUSED_from_merely_SCRUBBED():
+    """🔴 BOTH WAYS, AGAINST THE SHIM ITSELF — not against a second list.
+
+    `RETARGETING_ENV` was enumerated from `man git` and is INCOMPLETE BY
+    CONSTRUCTION: `GIT_CONFIG_COUNT` is undocumented, honoured, and was missing
+    from it until a peer session reproduced the bypass. It is a BACKSTOP.
+    `REFUSED_ENV` is the subset the shim acts on.
+
+    🔴 MEASURED: the first version of this test only computed
+    `REFUSED_ENV - armed`, so DELETING an entry made the set smaller and the
+    test PASSED. A mutant that dropped `GIT_CONFIG_COUNT` survived. A ledger
+    that only catches additions is half a pin, so the truth is now read out of
+    the SHIM TEXT and compared in both directions.
+    """
+    shim = norepo.shim_body("/usr/bin/git", Path("/tmp/l"), Path("/tmp/p"),
+                            Path("/tmp/c"))
+
+    # The variables the shim's environment loop actually branches on.
+    m = re.search(r"for _v in ((?:[A-Z_ ]|\\\n\s*)+); do", shim)
+    assert m, "the shim's armed-environment loop is gone entirely"
+    in_shim = set(m.group(1).replace("\\", " ").split())
+
+    # ...plus the one that is checked by its own block rather than the loop,
+    # because it is indexed (KEY_<n>/VALUE_<n>) rather than a single value.
+    assert 'case "${GIT_CONFIG_COUNT:-}" in' in shim, (
+        "the shim no longer inspects GIT_CONFIG_COUNT. That channel writes NO "
+        "file, so neither the config redirect nor path protection can see it.")
+    in_shim.add("GIT_CONFIG_COUNT")
+
+    assert set(norepo.REFUSED_ENV) == in_shim, (
+        "REFUSED_ENV and the shim disagree about what is refused.\n"
+        f"  ledger: {sorted(norepo.REFUSED_ENV)}\n"
+        f"  shim  : {sorted(in_shim)}\n"
+        "Do NOT delete a ledger entry to make this pass.")
+
+    armed = set(ARMED_VECTOR_IDS)
+    not_a_write_vector = {"GIT_ALTERNATE_OBJECT_DIRECTORIES"}
+    missing = set(norepo.REFUSED_ENV) - armed - not_a_write_vector
+    assert not missing, (
+        f"{sorted(missing)} are REFUSED by the shim but never armed against a "
+        "victim, so their protection is a claim about setup only.")
+    assert set(norepo.REFUSED_ENV) <= set(norepo.RETARGETING_ENV), (
+        "the shim refuses a variable the runner does not scrub")
+    harmless = {"GIT_NAMESPACE", "GIT_CEILING_DIRECTORIES", "GIT_PREFIX"}
+    assert not (harmless & set(norepo.REFUSED_ENV)), (
+        f"{sorted(harmless & set(norepo.REFUSED_ENV))} are NOT write targets; "
+        "refusing them would be a pure false positive and a permanently-red gate.")
+
+
+def test_a_linked_worktree_of_a_protected_repo_is_protected(guarded):
+    """🔴 A WORKTREE IS NOT CONTAINMENT — the common dir is the unit.
+
+    Resolving `--git-dir` instead of `--git-common-dir` would report this
+    worktree as a different, unprotected repository, while a write in it lands
+    on the real clone's refs and a push from it reaches the real remote.
+    """
+    wt = guarded.tmp / "victim-wt"
+    subprocess.run(["git", "-C", str(guarded.victim), "worktree", "add", "-q",
+                    "-b", "wt", str(wt)], check=True, capture_output=True)
+    before = _victim_state(guarded.victim)
+    p = subprocess.run(["git", "-C", str(wt), "branch", "-m", "wt", "wt2"],
+                       env=guarded.env, capture_output=True, text=True)
+    assert p.returncode == norepo.REFUSED_EXIT, p.stdout + p.stderr
+    assert _victim_state(guarded.victim) == before
+
+
+def test_a_write_with_no_dash_C_from_inside_the_protected_repo_is_refused(guarded):
+    """The cwd route: `run-tests.sh` runs every pytest target with cwd = the repo
+    root, so a git call that binds NEITHER `-C` nor `cwd=` lands in the real
+    clone. Nothing in this tree does that today; the guard does not depend on
+    that staying true."""
+    before = _victim_state(guarded.victim)
+    p = subprocess.run(["git", "config", "core.bare", "true"],
+                       cwd=str(guarded.victim), env=guarded.env,
+                       capture_output=True, text=True)
+    assert p.returncode == norepo.REFUSED_EXIT, p.stdout + p.stderr
+    assert _victim_state(guarded.victim) == before
+
+
+# --------------------------------------------------------------------------- #
+# 2. THE POSITIVE CONTROL — the guard must DISCRIMINATE, not just refuse
+# --------------------------------------------------------------------------- #
+POSITIVE_MUTATIONS = [
+    ("commit in a fixture repo", ["commit", "--allow-empty", "-m", "ok"]),
+    ("rename a fixture branch", ["branch", "-m", "main", "renamed"]),
+    ("repoint a fixture remote", ["remote", "set-url", "origin", "REPLACED"]),
+    ("push a fixture to its LOCAL bare origin",
+     ["push", "-q", "origin", "HEAD:refs/heads/main"]),
+]
+
+
+@pytest.mark.parametrize("name,args", POSITIVE_MUTATIONS, ids=[n for n, _ in POSITIVE_MUTATIONS])
+def test_a_fixture_repo_may_still_be_mutated_freely(guarded, name, args):
+    """🔴 THE POSITIVE CONTROL. A guard that refuses everything is
+    indistinguishable from a guard that works, and it would be a permanently-red
+    gate — the failure mode `claude/RULES.md` says trains everyone to click
+    through. Every one of these is a MUTATION, on a repo the guard does not
+    protect, and it must go through untouched."""
+    args = [str(guarded.bare) if a == "REPLACED" else a for a in args]
+    p = subprocess.run(["git", "-C", str(guarded.fixture), *args],
+                       env=guarded.env, capture_output=True, text=True)
+    assert p.returncode == 0, f"{name} was broken by the guard:\n{p.stdout}{p.stderr}"
+
+
+POSITIVE_READS = [
+    ("ls-files", ["ls-files"]),
+    ("log", ["log", "--oneline", "-1"]),
+    ("status", ["status", "--porcelain"]),
+    ("rev-parse", ["rev-parse", "HEAD"]),
+    ("branch --show-current", ["branch", "--show-current"]),
+    ("remote -v", ["remote", "-v"]),
+    ("config --get", ["config", "--get", "core.bare"]),
+    ("symbolic-ref -q HEAD", ["symbolic-ref", "-q", "HEAD"]),
+    ("worktree list", ["worktree", "list"]),
+]
+
+
+@pytest.mark.parametrize("name,args", POSITIVE_READS, ids=[n for n, _ in POSITIVE_READS])
+def test_a_protected_repo_may_still_be_READ(guarded, name, args):
+    """Several gates in this repo read the tree under test. Refusing those would
+    make the guard unshippable, so the read forms are enumerated and pinned."""
+    p = subprocess.run(["git", "-C", str(guarded.victim), *args],
+                       env=guarded.env, capture_output=True, text=True)
+    assert p.returncode == 0, f"read `{name}` was refused:\n{p.stdout}{p.stderr}"
+
+
+def test_a_fixture_repo_may_be_mutated_with_the_environment_vectors_ARMED_AT_ITSELF(
+        guarded):
+    """🔴 THE POSITIVE CONTROL FOR THE ARMED BATTERY, and the one that proves the
+    environment check DISCRIMINATES rather than banning the variables outright.
+
+    The same variables, set to the FIXTURE's own paths, must still work: this is
+    how `git` is legitimately driven by tooling, and a guard that refused
+    `GIT_DIR=<my own fixture>` would be a permanently-red gate. Reported beside
+    the armed battery as the pair — refused when aimed at the victim, allowed
+    when aimed at itself.
+    """
+    env = dict(guarded.env)
+    env["GIT_DIR"] = str(guarded.fixture / ".git")
+    env["GIT_WORK_TREE"] = str(guarded.fixture)
+    p = subprocess.run(["git", "commit", "--allow-empty", "-m", "own-fixture"],
+                       cwd=str(guarded.fixture), env=env,
+                       capture_output=True, text=True)
+    assert p.returncode == 0, (
+        "the guard refused a fixture driving git at its OWN repo through the "
+        f"environment; that is a permanently-red gate:\n{p.stdout}{p.stderr}")
+
+
+def test_the_positive_control_examines_a_reported_number_of_cases():
+    """🔴 Report the COUNT, never a bare "the positive control passed". A
+    positive control that shrank to zero cases still reports success."""
+    assert len(POSITIVE_MUTATIONS) >= 4, POSITIVE_MUTATIONS
+    assert len(POSITIVE_READS) >= 9, POSITIVE_READS
+    assert len(ARMED_VECTOR_IDS) == 8, ARMED_VECTOR_IDS
+    assert len(INCIDENT_SHAPES) == 10, INCIDENT_SHAPES
+
+
+def test_git_init_with_a_RELATIVE_dest_resolves_against_dash_C_not_the_cwd(guarded):
+    """🔴 A MEASURED FALSE POSITIVE, pinned so it cannot come back.
+
+    `git -C X init .` means "init X": git chdirs to X BEFORE reading the
+    positional. Resolving that `.` against the SHIM's cwd — which under
+    `run-tests.sh` is the repo root — made the guard refuse
+    `git -C <tmp_path>/plain-repo init -q -b trunk .`, a completely legitimate
+    fixture. It was caught by GUARD 9's own per-target accounting on a full
+    run, not by any test, which is exactly what that accounting is for.
+
+    A guard that refuses legitimate work is a permanently-red gate, and
+    `claude/RULES.md` is explicit that those train everyone to click through.
+    """
+    dest = guarded.tmp / "plain-repo"
+    dest.mkdir()
+    p = subprocess.run(["git", "-C", str(dest), "init", "-q", "-b", "trunk", "."],
+                       cwd=str(guarded.victim), env=guarded.env,
+                       capture_output=True, text=True)
+    assert p.returncode == 0, (
+        "a fixture's own `git -C <tmp> init .` was refused; the relative "
+        f"destination is being resolved against the wrong directory:\n{p.stdout}{p.stderr}")
+    assert (dest / ".git").exists(), "the repo was not actually created"
+    # ...and the protected repo is untouched by it.
+    assert _victim_state(guarded.victim)["branches"] == ["refs/heads/main"]
+
+
+def test_git_init_and_clone_of_new_fixture_paths_still_work(guarded):
+    """`init`/`clone` name a destination that is not a repo yet, so the guard
+    resolves them from that destination. Getting that wrong in the safe
+    direction breaks every fixture in the suite."""
+    for argv in (["git", "init", "-q", "-b", "main", str(guarded.tmp / "newfix")],
+                 ["git", "clone", "-q", str(guarded.bare), str(guarded.tmp / "cloned")]):
+        p = subprocess.run(argv, env=guarded.env, capture_output=True, text=True)
+        assert p.returncode == 0, f"{argv}:\n{p.stdout}{p.stderr}"
+
+
+def test_the_ledger_records_the_refusal_and_says_what_it_was(guarded):
+    """A refusal that is not RECORDED cannot be attributed to a target, and
+    `run-tests.sh` would print a clean zero for the target that caused it."""
+    subprocess.run(["git", "-C", str(guarded.victim), "config", "core.bare", "true"],
+                   env=guarded.env, capture_output=True, text=True)
+    lines = guarded.log.read_text().splitlines()
+    assert len(lines) == 1, f"expected exactly one ledger line, got: {lines}"
+    assert lines[0].startswith(norepo.REFUSED_PREFIX)
+    assert "PROTECTED" in lines[0] and "core.bare" in lines[0]
+
+
+def test_the_probe_env_records_a_CONTROL_and_still_refuses(guarded):
+    """🔴 The per-target positive control the runner counts. It must not weaken
+    the refusal — a control that let the write through would be the guard
+    proving it works by not working."""
+    before = _victim_state(guarded.victim)
+    env = dict(guarded.env)
+    env[norepo.PROBE_ENV] = "1"
+    p = subprocess.run(["git", "-C", str(guarded.victim), "config", "core.bare", "true"],
+                       env=env, capture_output=True, text=True)
+    assert p.returncode == norepo.REFUSED_EXIT
+    assert _victim_state(guarded.victim) == before
+    lines = guarded.log.read_text().splitlines()
+    assert lines and lines[0].startswith(norepo.CONTROL_PREFIX), lines
+
+
+def test_install_refuses_to_arm_against_nothing_without_an_explicit_flag(tmp_path):
+    """🔴 An empty protected list is a guard wired to nothing, and its zero
+    refusals read exactly like a clean run. Saying so must be deliberate."""
+    with pytest.raises(RuntimeError, match="protects"):
+        norepo.install(tmp_path / "g1", [], [])
+    norepo.install(tmp_path / "g2", [], [], allow_no_repos=True)  # the sandbox door
+
+
+# --------------------------------------------------------------------------- #
+# 3. THE `${VAR:-default}` SITES — pinned BOTH ways
+# --------------------------------------------------------------------------- #
+#: "<file>|<the assignment line, verbatim>|<the variable the guard must test>".
+#: A ledger, not a convenience list: the test below fails when a site GROWS
+#: (a new HOME-defaulting repo path with no set-but-empty guard) *or* SHRINKS
+#: (an entry naming a line that no longer exists — deleted, renamed, or a typo).
+EMPTY_DEFAULT_SITES = (
+    ("scripts/ship.sh", 'SHIP_REPO="${SHIP_REPO:-$HOME/workspace/devrc}"', "SHIP_REPO"),
+    ("scripts/ship.sh", 'repo="${SHIP_REPO:-$HOME/workspace/devrc}"', "SHIP_REPO"),
+    ("scripts/drift-check.sh", 'DRIFT_REPO="${DRIFT_REPO:-$HOME/workspace/devrc}"', "DRIFT_REPO"),
+    # TWICE, deliberately: the CHECK payload and the SRCREPO payload each carry
+    # their own copy, because each is piped to a `bash -s` on ANOTHER host and
+    # cannot source anything. Both need their own guard.
+    ("scripts/drift-check.sh", 'repo="${DRIFT_REPO:-$HOME/workspace/devrc}"', "DRIFT_REPO"),
+    ("scripts/drift-check.sh", 'repo="${DRIFT_REPO:-$HOME/workspace/devrc}"', "DRIFT_REPO"),
+    ("scripts/analyze-service-index/commit.sh",
+     'STORE="${POSITIONAL[0]:-${HOME}/.claude/analyze-service-index}"', "POSITIONAL"),
+)
+
+#: Any `${SOMETHING:-…$HOME…}` / `${…:-…~/…}` that names a path this repo's
+#: scripts then run git against. The scan below finds them mechanically so a
+#: SIXTH site cannot be added without either a guard or a ledger entry.
+_HOME_DEFAULT_RE = re.compile(
+    r'^\s*\w+="\$\{[A-Za-z_][A-Za-z0-9_]*(?:\[0\])?:-\$?\{?HOME\}?/[^"]*'
+    r'(?:workspace/devrc|\.claude/analyze-service-index)[^"]*"\s*$')
+
+
+def _sites_in(path: Path):
+    return [(n, ln.rstrip("\n")) for n, ln in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), 1)
+        if _HOME_DEFAULT_RE.match(ln)]
+
+
+def test_every_home_defaulting_repo_path_is_pinned_in_the_ledger():
+    """🔴 BOTH WAYS. A new site with no ledger entry is a new copy of the bug; a
+    ledger entry naming no line is accounting that describes nothing."""
+    found = []
+    for rel in sorted({s[0] for s in EMPTY_DEFAULT_SITES}):
+        for _, line in _sites_in(REPO_ROOT / rel):
+            found.append((rel, line.strip()))
+    pinned = [(f, line) for f, line, _ in EMPTY_DEFAULT_SITES]
+    assert sorted(found) == sorted(pinned), (
+        "the HOME-defaulting repo-path sites and EMPTY_DEFAULT_SITES disagree.\n"
+        f"  on disk: {sorted(found)}\n"
+        f"  pinned : {sorted(pinned)}\n"
+        "Do NOT delete an entry to make this pass — every one of these silently "
+        "resolves to the operator's own clone when its variable is set-but-EMPTY.")
+
+
+@pytest.mark.parametrize(
+    "rel,line,var", sorted(set(EMPTY_DEFAULT_SITES)),
+    ids=[f"{f.split('/')[-1]}:{v}" for f, _, v in sorted(set(EMPTY_DEFAULT_SITES))])
+def test_each_site_is_immediately_preceded_by_a_set_but_empty_guard(rel, line, var):
+    """🔴 `${VAR:-default}` CANNOT TELL UNSET FROM EMPTY. Unset must keep
+    defaulting — the remote legs deliberately do not forward these variables —
+    but a set-but-EMPTY value is a caller bug that would silently target the
+    operator's own clone, and it must stop the run.
+
+    🔴 EVERY OCCURRENCE, not the first. Two of these lines are byte-identical
+    (`drift-check.sh`'s CHECK and SRCREPO payloads), and checking only
+    `text.index(line)` would have declared the second one guarded on the
+    strength of the first — a guard's DESCRIPTION claiming coverage its body
+    does not provide.
+    """
+    text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+    starts = [m.start() for m in re.finditer(re.escape(line), text)]
+    assert starts, f"{rel}: `{line}` is not in the file at all"
+    for n, idx in enumerate(starts, 1):
+        # The guard must be the NEAREST thing above the assignment, not somewhere
+        # else in the file: 25 lines is generous for the comment block plus the
+        # test, and small enough that a distant unrelated guard cannot satisfy it.
+        window = "\n".join(text[:idx].splitlines()[-25:])
+        where = f"{rel}: occurrence {n}/{len(starts)} of `{line}`"
+        if var == "POSITIONAL":
+            assert '[ -z "${POSITIONAL[0]}" ]' in window, (
+                f"{where} has no given-but-EMPTY guard above it.")
+        else:
+            assert f'"${{{var}+set}}" = set' in window and f'[ -z "${var}" ]' in window, (
+                f"{where} has no set-but-EMPTY guard above it. Without one, "
+                f"{var}='' resolves to $HOME/workspace/devrc.")
+
+
+@pytest.mark.parametrize("script,var", [(SHIP, "SHIP_REPO"), (DRIFT, "DRIFT_REPO")],
+                         ids=["ship.sh", "drift-check.sh"])
+def test_an_empty_repo_override_stops_the_run_instead_of_targeting_the_real_clone(
+        tmp_path, script, var):
+    """🔴 BEHAVIOURAL, not structural. A structural check type-checks past a
+    guard that is present but wrong.
+
+    The fake HOME contains a REAL repository at `workspace/devrc` — the place an
+    empty value resolves to. If the guard were absent the script would fetch and
+    report on it; with the guard it must exit non-zero having said the variable
+    is empty, and that repo must be untouched.
+    """
+    home = tmp_path / "home"
+    victim = _mkrepo(home / "workspace" / "devrc")
+    before = _victim_state(victim)
+    env = dict(os.environ)
+    env.update(HOME=str(home), SHIP_ROLE="workbench", GIT_CONFIG_GLOBAL=str(tmp_path / "gc"))
+    env[var] = ""
+    p = subprocess.run(["bash", str(script), "--no-remote"], env=env,
+                       capture_output=True, text=True)
+    out = p.stdout + p.stderr
+    # 🔴 THE EXACT STATUS, not merely non-zero. MEASURED: a mutant that kept the
+    # message and dropped the `exit 2` SURVIVED an earlier version of this test
+    # — the script carried on, defaulted to $HOME/workspace/devrc, converged the
+    # victim, and failed later for an unrelated reason, so "non-zero" and
+    # "EMPTY appears in the output" were both still true. A green for the wrong
+    # reason is the failure this whole PR is about.
+    assert p.returncode == 2, (
+        f"an EMPTY {var} did not stop the run with exit 2 (got {p.returncode}). "
+        f"If the guard printed but did not exit, the script continued to the "
+        f"default:\n{out}")
+    assert "EMPTY" in out, f"the run stopped, but not for this reason:\n{out}"
+    # 🔴 AND NOTHING DOWNSTREAM RAN. Both scripts announce each host before doing
+    # any work — `=== local (…) ===` and `[<host>] …`. Either line means the
+    # guard did not stop the run, whatever the exit status said.
+    started = [ln for ln in out.splitlines()
+               if ln.startswith("===") or ln.lstrip().startswith("[")]
+    assert not started, (
+        f"{script.name} began operating on a host despite {var}='':\n"
+        + "\n".join(started))
+    assert _victim_state(victim) == before, (
+        f"{script.name} touched $HOME/workspace/devrc despite {var}=''")
+
+
+def test_an_unset_repo_override_still_defaults(tmp_path):
+    """The other direction, and it is load-bearing: the remote legs deliberately
+    do NOT forward these variables, so an UNSET value must keep resolving to
+    `$HOME/workspace/devrc`. A guard that failed on unset too would break the
+    remote leg of both scripts."""
+    home = tmp_path / "home"
+    _mkrepo(home / "workspace" / "devrc")
+    env = dict(os.environ)
+    env.update(HOME=str(home), SHIP_ROLE="workbench",
+               GIT_CONFIG_GLOBAL=str(tmp_path / "gc"))
+    env.pop("DRIFT_REPO", None)
+    env["DRIFT_STATE_DIR"] = str(tmp_path / "state")
+    env["DRIFT_SESSION_MANAGER"] = str(tmp_path / "no-such-session-manager")
+    p = subprocess.run(["bash", str(DRIFT), "--no-remote"], env=env,
+                       capture_output=True, text=True)
+    out = p.stdout + p.stderr
+    assert "SET but EMPTY" not in out, f"unset was treated as empty:\n{out}"
+    assert "no repo at" not in out, (
+        f"the default no longer resolves to $HOME/workspace/devrc:\n{out}")
+
+
+# --------------------------------------------------------------------------- #
+# 3b. THE TWO LEVERS THAT DO NOT DEPEND ON THE SHIM BEING REACHED
+#
+# The shim intercepts by PATH, so an absolute `/usr/bin/git` or a test that
+# REPLACES $PATH walks past it. These two are enforced by git itself, in-process.
+# Adapted from devrc-62's `testlib/nogit_plugin` (PR #673, not merged).
+# --------------------------------------------------------------------------- #
+NETWORK_URLS = (
+    "git@github.com:innovation-upstream/devrc.git",
+    "https://github.com/innovation-upstream/devrc.git",
+    "ssh://git@github.com/innovation-upstream/devrc.git",
+)
+
+
+@pytest.mark.parametrize("url", NETWORK_URLS)
+def test_a_fixture_push_to_a_real_remote_url_is_refused_by_the_shim(guarded, url):
+    """🔴 The source repo is INNOCENT and the destination is a URL, so a guard
+    that reasoned only about protected PATHS would be blind to this — and this
+    is the half of the incident that reached the public repo.
+
+    MEASURED on this box with the shim OFF PATH: the scp-style push printed
+    `To github.com:innovation-upstream/devrc.git`, a push PROGRESS header. It
+    authenticated and CONNECTED over ssh and failed only because the update was
+    rejected. One fast-forward away from landing.
+    """
+    p = subprocess.run(["git", "-C", str(guarded.fixture), "push", url,
+                        "HEAD:refs/heads/main"],
+                       env=guarded.env, capture_output=True, text=True, timeout=120)
+    out = p.stdout + p.stderr
+    assert p.returncode == norepo.REFUSED_EXIT, f"{url} was not refused:\n{out}"
+    assert "GUARD 9" in out, f"{url} failed, but not by this guard:\n{out}"
+    assert "NETWORK" in out, f"the refusal did not name the network rule:\n{out}"
+
+
+@pytest.mark.parametrize("url", NETWORK_URLS)
+def test_GIT_ALLOW_PROTOCOL_refuses_the_transport_ATTRIBUTABLY(guarded, url):
+    """🔴 THE DISCRIMINATING CONTROL, and the reason `assert rc != 0` is useless
+    here.
+
+    WITHOUT the lever these pushes ALREADY exit non-zero — by REJECTION (rc 1,
+    having connected) or a credential prompt (rc 128). So a test that only
+    checked the status would pass whether or not the lever did anything, and
+    would keep passing if someone deleted it.
+
+    The refusal is attributable ONLY when git names the transport. This runs
+    with the shim REMOVED from PATH, so what it measures is the lever alone.
+    """
+    env = dict(guarded.env)
+    gd = env.get(norepo.GUARD_DIR_ENV) or str(guarded.dir)
+    env["PATH"] = os.pathsep.join(
+        x for x in env["PATH"].split(os.pathsep)
+        if x != gd and x != str(guarded.dir))
+    env["GIT_ALLOW_PROTOCOL"] = "file"
+    p = subprocess.run(["git", "-C", str(guarded.fixture), "push", url,
+                        "HEAD:refs/heads/main"],
+                       env=env, capture_output=True, text=True, timeout=120)
+    out = p.stdout + p.stderr
+    assert "not allowed" in out, (
+        "GIT_ALLOW_PROTOCOL=file did not refuse this transport by name. A "
+        f"non-zero exit alone is NOT evidence — it happens anyway:\n{out}")
+    assert p.returncode != 0
+
+
+def test_GIT_ALLOW_PROTOCOL_still_permits_every_LOCAL_fixture_operation(guarded):
+    """The positive control for the lever. A transport allowlist that broke
+    `file://` or plain-path fixtures would be a permanently-red gate."""
+    env = dict(guarded.env)
+    env["GIT_ALLOW_PROTOCOL"] = "file"
+    for name, argv in (
+        ("push to a plain-path bare",
+         ["-C", str(guarded.fixture), "push", "-q", str(guarded.bare), "HEAD:refs/heads/m1"]),
+        ("push to a file:// bare",
+         ["-C", str(guarded.fixture), "push", "-q", f"file://{guarded.bare}", "HEAD:refs/heads/m2"]),
+        ("clone from a plain-path bare",
+         ["clone", "-q", str(guarded.bare), str(guarded.tmp / "lever-clone")]),
+    ):
+        p = subprocess.run(["git", *argv], env=env, capture_output=True, text=True)
+        assert p.returncode == 0, f"the lever broke `{name}`:\n{p.stdout}{p.stderr}"
+
+
+def test_the_runner_sets_both_levers_and_redirects_the_config_files():
+    """🔴 Pinned in the RUNNER, because that is the only place that covers the
+    non-pytest targets. A lever set in a conftest protects one directory."""
+    text = RUN_TESTS.read_text(encoding="utf-8")
+    # 🔴 AN `export` STATEMENT AT LINE START, never a substring search.
+    # MEASURED: the first version of this test was `token in text`, and a mutant
+    # that renamed the export to `GIT_ALLOW_PROTOCOL_DISABLED=file` SURVIVED —
+    # because the COMMENT block above it still spelled `GIT_ALLOW_PROTOCOL=file`
+    # in prose. The test was reading the documentation and reporting on the code.
+    # `^export` cannot match a `#` line, so prose can no longer satisfy it.
+    for token in ("GIT_ALLOW_PROTOCOL=file", "GIT_CONFIG_SYSTEM=/dev/null",
+                  "GIT_CONFIG_NOSYSTEM=1", 'GIT_CONFIG_GLOBAL="$GITCONFIG_TRAP"'):
+        assert re.search(rf"^export {re.escape(token)}\s*$", text, re.M), (
+            f"run-tests.sh has no `export {token}` statement (a mention in a "
+            "comment does not count)")
+
+
+def test_the_config_redirect_happens_AFTER_the_guard_is_installed():
+    """🔴 ORDER IS THE WHOLE THING. Deriving the protected config set after the
+    redirect would protect the throwaway file and leave `~/.gitconfig`
+    unprotected — the guard pointed at the decoy it just created."""
+    text = RUN_TESTS.read_text(encoding="utf-8")
+    assert text.index("python -m testlib.norepo") < text.index('export GIT_CONFIG_GLOBAL=')
+
+
+def test_the_real_global_config_is_protected_even_when_the_env_is_redirected(tmp_path,
+                                                                             monkeypatch):
+    """🔴 The complement of the ordering test, at the level of the code rather
+    than the file. With GIT_CONFIG_GLOBAL pointed at a throwaway — exactly what
+    the runner does — `~/.gitconfig` must STILL be in the protected set."""
+    decoy = tmp_path / "decoy-gitconfig"
+    decoy.write_text("")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(decoy))
+    monkeypatch.setattr(norepo.sys if hasattr(norepo, "sys") else os, "environ",
+                        os.environ, raising=False)
+    guard = tmp_path / "g"
+    repo = _mkrepo(tmp_path / "r")
+    rc = norepo.main([str(guard), str(repo)])
+    assert rc == 0
+    listed = (guard / norepo.PROTECTED_CONFIG_NAME).read_text().splitlines()
+    real = os.path.realpath(Path.home() / ".gitconfig")
+    assert real in listed, (
+        f"~/.gitconfig ({real}) is NOT protected when GIT_CONFIG_GLOBAL is "
+        f"redirected. Protected set was: {listed}")
+    assert os.path.realpath(decoy) in listed, "the redirected file should be protected too"
+
+
+# --------------------------------------------------------------------------- #
+# 3c. TWO ADJACENT HAZARDS THIS GUARD NOW COVERS
+#
+# Neither is fixed by this PR. Both are live shapes in the tree that GUARD 9
+# turns from "safe by accident" into "safe by construction", and pinning them
+# here is what makes that claim checkable rather than asserted.
+# --------------------------------------------------------------------------- #
+ADJACENT_HAZARDS = [
+    # scripts/repo-cos/prescan.py drives these against every repo in
+    # scan.py's DEFAULT_REPOS, whose FIRST entry is `~/workspace/devrc`.
+    # Every current test monkeypatches that list away — the hazard is one
+    # deleted patch from being live.
+    ("repo-cos prescan: worktree add", ["worktree", "add", "--detach", "/tmp/x"]),
+    ("repo-cos prescan: worktree remove", ["worktree", "remove", "--force", "/tmp/x"]),
+    ("repo-cos prescan: worktree prune", ["worktree", "prune"]),
+    ("repo-cos prescan: fetch origin", ["fetch", "--quiet", "origin"]),
+    # ship.sh's CONVERGE, which `test_drift_check.py` invokes with the REAL
+    # $HOME and no SHIP_REPO. It is safe today only because an unrelated
+    # exit-6 path fires first — safe by accident.
+    ("ship.sh CONVERGE: fetch origin", ["fetch", "origin", "-q"]),
+    ("ship.sh CONVERGE: merge --ff-only", ["merge", "--ff-only", "origin/main"]),
+]
+
+
+@pytest.mark.parametrize("name,args", ADJACENT_HAZARDS,
+                         ids=[n for n, _ in ADJACENT_HAZARDS])
+def test_the_adjacent_hazards_are_refused_against_a_protected_repo(guarded, name, args):
+    """🔴 `git worktree list` is a READ and stays allowed; `worktree add`,
+    `remove`, `prune`, `fetch` and `merge` are not, and none of them is on the
+    read-form list. So a prescan or a converge pointed at the operator's clone
+    is refused rather than merely unlikely."""
+    before = _victim_state(guarded.victim)
+    p = subprocess.run(["git", "-C", str(guarded.victim), *args],
+                       env=guarded.env, capture_output=True, text=True)
+    out = p.stdout + p.stderr
+    assert p.returncode == norepo.REFUSED_EXIT, f"{name} was NOT refused:\n{out}"
+    assert "GUARD 9" in out
+    assert _victim_state(guarded.victim) == before
+
+
+def test_worktree_list_is_still_a_permitted_read(guarded):
+    """The other direction: prescan's own bookkeeping read must keep working, or
+    the guard is a permanently-red gate for the very tool it protects."""
+    p = subprocess.run(["git", "-C", str(guarded.victim), "worktree", "list"],
+                       env=guarded.env, capture_output=True, text=True)
+    assert p.returncode == 0, f"{p.stdout}{p.stderr}"
+
+
+# --------------------------------------------------------------------------- #
+# 3d. THE ADVERSARIAL-AUDIT BYPASSES
+#
+# 🔴 SIX of these were MEASURED to work against an earlier revision of this
+# shim, from an INNOCENT fixture repo, with the guard fully installed. They are
+# pinned here as their own battery because each attacks a DIFFERENT assumption:
+#   * the alias pair  -- git prepends its own libexec to PATH, so the shim is
+#                        NOT inherited by git-spawned children, at any depth
+#   * `config --file` -- a config file named DIRECTLY, in an innocent repo
+#   * `-c remote.*.url` -- config injected on the argv, which a resolver that
+#                        shells a FRESH `git config` cannot see
+#   * `--separate-git-dir` / `worktree add` -- a DESTINATION inside a denied
+#                        tree, from a repo that resolves as innocent
+#   * `status`        -- a "read" that rewrites `.git/index`
+#
+# Each asserts the guard's own exit AND that the victim is byte-unchanged: an
+# unrelated failure also exits non-zero, and would let a dead guard read as a
+# live one.
+AUDIT_BYPASSES = [
+    ("alias shell-escape via -c", "refuse",
+     lambda v, f: ["-C", str(f), "-c",
+                   f"alias.x=!git -C {v} commit --allow-empty -m PWNED", "x"]),
+    ("alias shell-escape via GIT_CONFIG_COUNT", "refuse-env",
+     lambda v, f: ["-C", str(f), "y"]),
+    ("config --file into the victim", "refuse",
+     lambda v, f: ["-C", str(f), "config", "--file",
+                   str(v / ".git" / "config"), "core.bare", "true"]),
+    ("config -f into the victim", "refuse",
+     lambda v, f: ["-C", str(f), "config", "-f",
+                   str(v / ".git" / "config"), "user.email", "evil@example.com"]),
+    ("-c remote.origin.url=<network> push", "refuse",
+     lambda v, f: ["-C", str(f), "-c",
+                   "remote.origin.url=git@github.com:innovation-upstream/devrc.git",
+                   "push", "origin", "HEAD:refs/heads/main"]),
+    ("--separate-git-dir into the victim", "refuse",
+     lambda v, f: ["init", "--separate-git-dir", str(v / "planted-gitdir"),
+                   str(f.parent / "sep-clone")]),
+    ("worktree add into the victim", "refuse",
+     lambda v, f: ["-C", str(f), "worktree", "add", "--detach",
+                   str(v / "planted-worktree")]),
+    ("hash-object -w into the victim", "refuse",
+     lambda v, f: ["-C", str(v), "hash-object", "-w", "--stdin"]),
+    ("GIT_SSH_COMMAND escape on a network push", "refuse",
+     lambda v, f: ["-C", str(f), "push",
+                   "git@github.com:innovation-upstream/devrc.git",
+                   "HEAD:refs/heads/main"]),
+]
+
+
+@pytest.mark.parametrize("name,mode,argv", AUDIT_BYPASSES,
+                         ids=[n for n, _, _ in AUDIT_BYPASSES])
+def test_the_audited_bypasses_are_closed(guarded, name, mode, argv):
+    before = _victim_state(guarded.victim)
+    env = dict(guarded.env)
+    if mode == "refuse-env":
+        env.update({
+            "GIT_CONFIG_COUNT": "1", "GIT_CONFIG_KEY_0": "alias.y",
+            "GIT_CONFIG_VALUE_0":
+                f"!git -C {guarded.victim} commit --allow-empty -m PWNED"})
+    if "SSH" in name:
+        env["GIT_SSH_COMMAND"] = (
+            f"sh -c 'git -C {guarded.victim} commit --allow-empty -m PWNED' --")
+    p = subprocess.run(["git", *argv(guarded.victim, guarded.fixture)],
+                       env=env, input="payload\n", capture_output=True,
+                       text=True, timeout=120)
+    out = p.stdout + p.stderr
+    assert p.returncode == norepo.REFUSED_EXIT, f"{name} was NOT refused:\n{out}"
+    assert "GUARD 9" in out, f"{name} failed, but not by this guard:\n{out}"
+    assert _victim_state(guarded.victim) == before, f"{name}: the victim CHANGED"
+
+
+def test_status_is_forwarded_WITHOUT_rewriting_the_protected_index(guarded):
+    """🔴 A "read" that WRITES. MEASURED: `git status` on a protected repo
+    rewrote `.git/index` (bytes and mtime both moved) while sitting on the
+    read-only fast path.
+
+    Refusing it would be a permanently-red gate — this suite runs `git status`
+    against the tree under test constantly — and the write is a stat-cache
+    refresh that cannot lose data. So the shim forwards it with
+    `--no-optional-locks`, which git provides for exactly this. Both halves are
+    asserted: the command still WORKS, and the index does not move.
+    """
+    idx = guarded.victim / ".git" / "index"
+    before = idx.read_bytes()
+    os.utime(guarded.victim / "f", (0, 0))   # make the cached stat data stale
+    p = subprocess.run(["git", "-C", str(guarded.victim), "status", "--porcelain"],
+                       env=guarded.env, capture_output=True, text=True)
+    assert p.returncode == 0, f"status was refused:\n{p.stdout}{p.stderr}"
+    assert idx.read_bytes() == before, (
+        "`git status` rewrote the protected repo's index; the "
+        "--no-optional-locks forward is not being applied")
+
+
+def test_status_on_an_UNPROTECTED_repo_is_untouched(guarded):
+    """The other direction: fixtures must keep git's ordinary behaviour."""
+    p = subprocess.run(["git", "-C", str(guarded.fixture), "status", "--porcelain"],
+                       env=guarded.env, capture_output=True, text=True)
+    assert p.returncode == 0, f"{p.stdout}{p.stderr}"
+
+
+def test_a_c_option_aimed_at_the_fixture_ITSELF_is_still_allowed(guarded):
+    """🔴 The positive control for the `-c` scanner. `-c` is normal git usage;
+    refusing all of it would be a permanently-red gate. Only values aimed at a
+    protected path, a network remote, or a shell-escape alias are refused."""
+    for args in (["-c", "user.email=t@t", "commit", "--allow-empty", "-m", "ok"],
+                 ["-c", "core.hooksPath=/tmp/harmless-hooks", "status", "--porcelain"],
+                 ["-c", f"remote.origin.url={guarded.bare}", "remote", "-v"]):
+        p = subprocess.run(["git", "-C", str(guarded.fixture), *args],
+                           env=guarded.env, capture_output=True, text=True)
+        assert p.returncode == 0, f"`-c` misuse refused a legitimate call {args}:\n{p.stdout}{p.stderr}"
+
+
+def test_a_NON_PATH_operand_is_not_mistaken_for_a_protected_path(guarded):
+    """🔴 THE PERMANENTLY-RED-GATE REGRESSION, and it is not hypothetical.
+
+    `readlink -f` resolves a RELATIVE string against the shim's own cwd — which
+    under `run-tests.sh` IS the protected repo. An earlier revision therefore
+    treated ordinary WORDS as protected paths: `worktree list` flagged `list`,
+    `worktree add -b topic <tmp>` flagged `topic`, and `-c user.email=t@t`
+    flagged `t@t`. MEASURED: 15 tests failed on a correct tree.
+
+    Run from INSIDE the protected repo, which is the condition that triggers it.
+    """
+    cases = [
+        ["worktree", "list"],
+        ["config", "--get", "core.bare"],
+        ["-c", "user.email=t@t", "log", "--oneline", "-1"],
+        ["-c", "core.abbrev=12", "rev-parse", "HEAD"],
+        ["branch", "--show-current"],
+    ]
+    for args in cases:
+        p = subprocess.run(["git", *args], cwd=str(guarded.victim),
+                           env=guarded.env, capture_output=True, text=True)
+        assert p.returncode == 0, (
+            f"a non-path operand in `git {' '.join(args)}` was mistaken for a "
+            f"protected path — this is a permanently-red gate:\n{p.stdout}{p.stderr}")
+
+
+def test_a_config_write_FROM_A_WORKTREE_cannot_reach_the_base_clone(guarded, tmp_path):
+    """🔴 THE MECHANISM THAT RE-ARMED `core.hooksPath` ON THE OPERATOR'S CLONE.
+
+    A worktree shares the common git dir, so a plain `git config` inside one
+    lands on the BASE CLONE's `.git/config`. MEASURED, both arms:
+
+        UNGUARDED  git -C <worktree> config core.hooksPath /tmp/PWNED
+                     -> rc 0, the BASE clone's config changed, hooksPath set
+        UNGUARDED  git -C <worktree> config --worktree core.hooksPath X
+                     -> rc 128 "fatal: --worktree cannot be used ... unless the
+                        config extension worktreeConfig is enabled"
+        GUARDED    -> rc 99, refused, base config byte-unchanged
+
+    🔴 The correctly-scoped `--worktree` form FAILS BY DEFAULT, so the
+    shared-write behaviour is not a mistake someone makes — it is the only form
+    that works without prior setup. That is why this needs a structural guard
+    rather than a convention.
+
+    ⚠ SCOPE, stated honestly: this closes the TEST-SIDE. It does not stop an
+    agent or a human running `git config` from a worktree by hand, and the
+    observed instance came from an agent's tooling, not from a test.
+    """
+    base = _mkrepo(tmp_path / "wtbase")
+    wt = tmp_path / "wtlinked"
+    subprocess.run(["git", "-C", str(base), "worktree", "add", "-q", "-b",
+                    "topic", str(wt)], check=True, capture_output=True)
+    basecfg = base / ".git" / "config"
+
+    # --- arm 1: UNGUARDED — the write must actually reach the BASE config -----
+    unguarded = dict(os.environ)
+    unguarded.pop("GIT_DIR", None)
+    unguarded["GIT_CONFIG_GLOBAL"] = str(tmp_path / "gc-unguarded")
+    before = basecfg.read_text()
+    subprocess.run(["git", "-C", str(wt), "config", "core.hooksPath", "/tmp/PWNED"],
+                   env=unguarded, capture_output=True, text=True)
+    assert basecfg.read_text() != before, (
+        "a config write from a worktree no longer reaches the base clone — if "
+        "git changed this, say so; do not delete the guard.")
+
+    # --- arm 2: GUARDED — refused, base config untouched ----------------------
+    base2 = _mkrepo(tmp_path / "wtbase2")
+    wt2 = tmp_path / "wtlinked2"
+    subprocess.run(["git", "-C", str(base2), "worktree", "add", "-q", "-b",
+                    "topic", str(wt2)], check=True, capture_output=True)
+    prot = norepo.protected_paths(base2)
+    assert str(wt2.resolve()) in prot, (
+        f"the linked worktree is not in the protected set {prot}; "
+        "protected_paths must enumerate `git worktree list`")
+    gd = tmp_path / "guard-wt"
+    norepo.install(gd, prot, [str(guarded.gitconfig)])
+    genv = dict(os.environ)
+    genv.pop("GIT_DIR", None)
+    genv["PATH"] = f"{gd}{os.pathsep}" + os.environ["PATH"]
+    genv["GIT_CONFIG_GLOBAL"] = str(guarded.gitconfig)
+    basecfg2 = base2 / ".git" / "config"
+    b2 = basecfg2.read_text()
+    p = subprocess.run(["git", "-C", str(wt2), "config", "core.hooksPath", "/tmp/PWNED"],
+                       env=genv, capture_output=True, text=True)
+    out = p.stdout + p.stderr
+    assert p.returncode == norepo.REFUSED_EXIT, f"NOT refused:\n{out}"
+    assert "GUARD 9" in out, out
+    assert basecfg2.read_text() == b2, "refused, but the base config CHANGED"
+
+
+def test_no_two_testlib_plugins_patch_Popen_the_same_way():
+    """🔴 A sibling layer had `nolaunch` and its own plugin both subclass a
+    PRISTINE `Popen` captured at import, so the second assignment ERASED the
+    first and its controls still reported green — fail-open caused by a
+    sibling rather than by absence.
+
+    Ours does not collide: only `nolaunch_plugin` patches `Popen`, and it does
+    so inside a hook rather than at import. Pinned so a future plugin that
+    patches at import is caught here rather than by a silent disarm.
+    """
+    import subprocess as _sp
+    pristine = _sp.Popen
+    from testlib import nolaunch_plugin, norepo_plugin, spool_plugin  # noqa: F401
+    assert _sp.Popen is pristine, (
+        f"importing the testlib plugins patched Popen at import time: "
+        f"{[c.__name__ for c in _sp.Popen.__mro__]}. Two such plugins silently "
+        "erase each other.")
+    patchers = [m for m, src in (
+        ("nolaunch_plugin", (REPO_ROOT / "scripts/testlib/nolaunch_plugin.py").read_text()),
+        ("spool_plugin", (REPO_ROOT / "scripts/testlib/spool_plugin.py").read_text()),
+        ("norepo_plugin", (REPO_ROOT / "scripts/testlib/norepo_plugin.py").read_text()),
+    ) if "Popen" in src]
+    assert patchers == ["nolaunch_plugin"], (
+        f"more than one testlib plugin now touches Popen: {patchers}. If two "
+        "subclass the same pristine class, the second assignment wins and the "
+        "first is inert while still reporting green.")
+
+
+# --------------------------------------------------------------------------- #
+# 4. THE RUNNER WIRING — tokens spelled on both sides of a process boundary
+# --------------------------------------------------------------------------- #
+def test_run_tests_scrubs_every_retargeting_variable():
+    """🔴 The direct fix for the one mechanism the incident proved. A variable
+    added to `norepo.RETARGETING_ENV` and not to the runner's `unset` is a
+    variable the runner still inherits."""
+    text = RUN_TESTS.read_text(encoding="utf-8")
+    unset_block = re.search(r"^unset GIT_DIR[^\n]*(?:\n[ \t]+[A-Z_ \\]+)*", text,
+                            re.MULTILINE)
+    assert unset_block, "run-tests.sh no longer unsets the git retargeting variables"
+    block = unset_block.group(0)
+    missing = [v for v in norepo.RETARGETING_ENV if v not in block]
+    assert not missing, (
+        f"run-tests.sh does not unset {missing}. GIT_DIR alone is measured to "
+        "override `git -C`; the rest are the same shape.")
+
+
+def test_the_runner_and_the_shim_agree_on_every_shared_token():
+    """🔴 Spelled on BOTH sides of a process boundary. A rename on one side alone
+    leaves the runner's accounting matching nothing and printing a clean run."""
+    text = RUN_TESTS.read_text(encoding="utf-8")
+    for token in (norepo.REFUSED_PREFIX, norepo.CONTROL_PREFIX, norepo.PROBE_ENV,
+                  norepo.GUARD_DIR_ENV, norepo.LOG_NAME):
+        assert token in text, (
+            f"run-tests.sh does not mention `{token}`; GUARD 9's accounting "
+            "would match nothing and report every target clean.")
+
+
+def test_the_runner_installs_the_shim_before_putting_it_on_PATH():
+    """`install()` resolves the real binary through `shutil.which`, so a guard
+    dir already on PATH would make the shim exec ITSELF. The ordering is the
+    difference between a passthrough and an infinite fork loop."""
+    text = RUN_TESTS.read_text(encoding="utf-8")
+    assert text.index("python -m testlib.norepo") < text.index('export PATH="$GITGUARD_DIR')
+
+
+def test_the_in_process_control_is_loaded_on_the_pytest_line():
+    """🔴 `control` must be a claim about the TARGET, not about the runner.
+
+    The runner-side probe proves the shim is armed in the RUNNER's environment.
+    If that were the only control, every `refused=0` would describe the runner
+    and the 32-row table would read as rigorous while measuring one thing
+    thirty-two times. `testlib.norepo_plugin` fires the same probes from INSIDE
+    the target's process, and the runner counts the two separately.
+
+    MEASURED by breaking the plugin for EXACTLY ONE target: that target's row
+    went `control=plugin:0 inherited:2`, the run FAILED naming it, and its
+    sibling stayed `plugin:2`.
+    """
+    text = RUN_TESTS.read_text(encoding="utf-8")
+    assert "-p testlib.norepo_plugin" in text, (
+        "the in-process control is not loaded on the pytest line")
+    assert (REPO_ROOT / "scripts" / "testlib" / "norepo_plugin.py").is_file()
+    # And the runner must distinguish the two mechanisms, not sum them.
+    assert "gctl_plug" in text and "gctl_inh" in text, (
+        "the runner collapses the in-process and inherited controls into one "
+        "number; a dead plugin on a pytest target would then look exactly like "
+        "a healthy non-pytest target")
+    assert "IN-PROCESS control" in text and "INHERITED control" in text
+
+
+# ~20s: it drives two real runner copies. That is the price of a
+# behavioural check, and a token check demonstrably could not see the
+# mutant this replaces.
+def test_a_dead_in_process_control_FAILS_the_run(tmp_path):
+    """🔴 BEHAVIOURAL, because a token check cannot see a disabled branch.
+
+    MEASURED: a mutant that turned the in-process requirement into `if [ 0 -eq 1
+    ]` SURVIVED a structural test, because every token it looked for was still
+    in the file. The guard's DESCRIPTION was intact and its body did nothing.
+
+    So this drives a real runner COPY with one small target — the shape the
+    repo's other runner regressions use — and requires that removing the plugin
+    flag flips that target's row AND fails the run. Without this, `control=` is
+    a number nobody has watched change.
+    """
+    src = RUN_TESTS.read_text(encoding="utf-8")
+
+    def replace_array(text, name, body):
+        i = text.index(f"{name}=(")
+        j = text.index("\n)", i) + 2
+        return text[:i] + f"{name}=(\n{body}\n)" + text[j:]
+
+    target, floor = "scripts/collector/i3/tests", 12
+    mini = replace_array(src, "HERMETIC_TARGETS", f"  {target}")
+    mini = replace_array(mini, "TARGET_FLOORS", f'  "{target}|{floor}"')
+    mini = replace_array(mini, "EXPECTED_SKIPS", "")
+    broken = mini.replace("-p testlib.norepo_plugin --no-header", "--no-header")
+    assert broken != mini, "the plugin flag anchor moved"
+
+    env = dict(os.environ)
+    # 🔴 The nesting flags MUST be cleared: this runner is being driven FROM a
+    # target of another runner, and an inherited flag would make its own target
+    # score as nested and report zero markers for the wrong reason.
+    for k in ("DEVRC_TEST_GITGUARD_IN_SESSION", "DEVRC_TEST_SPOOL_IN_SESSION"):
+        env.pop(k, None)
+
+    out = {}
+    for label, text in (("healthy", mini), ("broken", broken)):
+        path = tmp_path / f"run-tests-{label}.sh"
+        path.write_text(text)
+        p = subprocess.run(["bash", str(path), "--set", "hermetic", str(REPO_ROOT)],
+                           cwd=REPO_ROOT, env=env, capture_output=True, text=True,
+                           timeout=900)
+        out[label] = (p.returncode, p.stdout + p.stderr)
+
+    hrc, htxt = out["healthy"]
+    brc, btxt = out["broken"]
+    assert f"{target}  refused=0  control=plugin:2 inherited:2" in htxt, (
+        f"healthy run did not report an in-process control:\n{htxt[-4000:]}")
+    assert "control=plugin:0" in btxt and target in btxt, (
+        f"breaking the plugin did not flip the row:\n{btxt[-4000:]}")
+    assert brc != 0, "a dead in-process control did NOT fail the run"
+    assert "IN-PROCESS control" in btxt, (
+        "the run failed but not for this reason — a different failure is being "
+        f"read as the guard working:\n{btxt[-4000:]}")
+
+
+def test_the_control_tab_is_a_LITERAL_tab_not_a_BRE_escape():
+    r"""🔴 VALIDATE THE INSTRUMENT BEFORE READING ITS VERDICT.
+
+    In a BRE, `grep -c '^git(control)\tvia=plugin'` treats `\t` as a literal
+    `t`, warns "stray \ before t", matches NOTHING, and reports control=0 for
+    EVERY target — the accounting failing while the guard is perfectly healthy,
+    which is indistinguishable from the guard being dead. MEASURED on the first
+    revision of this accounting.
+
+    🔴 AND THIS TEST ONLY READS CODE. Its first revision searched the whole file
+    and matched the COMMENT that documents the bug, so it failed on a correct
+    tree — a guard walkable by prose, in the test written to stop exactly that.
+    """
+    lines = [ln for ln in RUN_TESTS.read_text(encoding="utf-8").splitlines()
+             if not ln.lstrip().startswith("#")]
+    code = "\n".join(lines)
+    assert "GITGUARD_TAB=" in code, "no literal-tab variable"
+    bad = [ln for ln in lines if "git(control)" in ln and "\\t" in ln]
+    assert not bad, (
+        "the control counter matches a BRE `\\t`, which is a literal `t` and "
+        f"matches nothing:\n" + "\n".join(bad))
+
+
+def test_the_nested_session_flag_keeps_child_pytests_out_of_the_ledger():
+    """Some tests START another pytest. A nested session must still be PROTECTED
+    but must not write into the runner's per-target ledger, where an extra
+    control reads as a miscount. Same shape as GUARD 8's NESTED_ENV."""
+    from testlib import norepo_plugin
+    assert norepo_plugin.NESTED_ENV
+    text = RUN_TESTS.read_text(encoding="utf-8")
+    assert f"unset {norepo_plugin.NESTED_ENV}" in text, (
+        "a fresh RUN must clear the nesting flag, or a runner driven FROM a "
+        "test inherits it and every target is scored as nested")
+
+
+def test_every_target_kind_is_accounted_by_guard_9():
+    """The non-pytest targets are the half no conftest can ever reach, so the
+    runner must account HOOK_TESTS and SHELL_TESTS exactly like a pytest one."""
+    text = RUN_TESTS.read_text(encoding="utf-8")
+    assert text.count("_gitguard_account") >= 3, (
+        "GUARD 9 accounts fewer than the three target kinds (pytest, HOOK_TESTS, "
+        "SHELL_TESTS); an unaccounted kind reads as a clean zero.")
+    assert text.count("_gitguard_probe") >= 3, (
+        "a target with no probe has no positive control, so its refused=0 is "
+        "indistinguishable from a guard wired to nothing.")
+
+
+# --------------------------------------------------------------------------- #
+# 5. THE REFUTATIONS — pinned so they are not re-derived
+# --------------------------------------------------------------------------- #
+def test_the_drift_check_ssh_stub_never_executes_its_payload():
+    """🔴 REFUTED THEORY #1: "drift-check's remote leg runs the payload LOCALLY
+    under the stub ssh, with DRIFT_REPO unset, so it operates on the real clone."
+
+    The stub drains stdin and exits. It never execs anything. Whatever wrote to
+    the operator's clone, it was not this.
+    """
+    src = DRIFT_TESTS.read_text(encoding="utf-8")
+    body = src[src.index("def stub_ssh"):]
+    body = body[:body.index("\n    def ", 1)]
+    assert 'body = ["cat >/dev/null"]' in body, (
+        "the drift-check ssh stub no longer starts by DRAINING stdin. If it now "
+        "EXECUTES the payload, the remote leg runs locally against "
+        "$HOME/workspace/devrc and refuted theory #1 becomes true.")
+    # The stub's whole body is: drain, optionally echo a canned line, exit N.
+    # Anything that could RUN what it drained — a shell, an eval, `"$@"` — would
+    # make the remote leg execute locally, which is theory #1.
+    assert body.count("body.append(") == 2, (
+        "the ssh stub gained a body line; check it does not RUN what it drained.")
+    for runner in ('"$@"', "eval", "bash", "sh -s", "source ", "exec "):
+        assert runner not in body, (
+            f"the drift-check ssh stub now contains `{runner}` — if it EXECUTES "
+            "the piped payload, drift-check's remote leg runs LOCALLY against "
+            "$HOME/workspace/devrc and refuted theory #1 becomes true.")
+
+
+def test_a_pre_push_hook_does_not_inherit_git_dir(tmp_path):
+    """🔴 REFUTED THEORY #2: "githooks/tests-on-push.sh runs the suite from a
+    pre-push hook, where git exports GIT_DIR."
+
+    Measured here rather than asserted from memory, because the whole point of
+    theory #1 and #2 was that both were plausible and both were wrong. If a
+    future git DOES start exporting it, this test goes red and the theory is
+    live again — which is the useful direction for it to fail in.
+    """
+    bare = _mkrepo(tmp_path / "o.git", bare=True)
+    clone = _mkrepo(tmp_path / "c")
+    subprocess.run(["git", "-C", str(clone), "remote", "add", "origin", str(bare)],
+                   check=True, capture_output=True)
+    seen = tmp_path / "seen.txt"
+    write_exec(clone / ".git" / "hooks" / "pre-push",
+               f'cat >/dev/null\nenv | grep "^GIT_" | sort > "{seen}"\nexit 1\n')
+    subprocess.run(["git", "-C", str(clone), "push", "origin", "main"],
+                   capture_output=True, text=True)
+    names = {ln.split("=", 1)[0] for ln in seen.read_text().splitlines()}
+    assert "GIT_DIR" not in names, (
+        f"git now exports GIT_DIR to pre-push hooks ({sorted(names)}). "
+        "githooks/tests-on-push.sh runs the WHOLE suite from that hook, so "
+        "every fixture's `git -C <tmp_path>` would retarget the real clone.")
+
+
+def test_an_ambient_git_dir_reproduces_the_incident_signature(tmp_path):
+    """🔴 THE MECHANISM, MEASURED — and the reason a call-site audit finds nothing.
+
+    Replays `scripts/repo-cos/tests/test_prescan.py::_init_clone` verbatim: every
+    call correctly `-C`-bound to a tmp_path fixture. One ambient GIT_DIR names
+    the victim, which no command mentions. The result is the incident's own
+    signature: the victim's branch renamed, its HEAD repointed, its committer
+    identity rewritten to the fixture's, the fixture commit landed in it, and
+    that commit PUBLISHED to the victim's own remote.
+
+    This test does NOT run under the guard — it is the pre-fix behaviour, kept
+    red-in-spirit so the fix above is never mistaken for a fix to a theory.
+    """
+    origin = _mkrepo(tmp_path / "sacrificial-origin.git", bare=True)
+    victim = _mkrepo(tmp_path / "victim")
+    subprocess.run(["git", "-C", str(victim), "config", "user.email", "real@op"],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(victim), "remote", "add", "origin", str(origin)],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(victim), "push", "-q", "origin", "main"],
+                   check=True, capture_output=True)
+
+    env = dict(os.environ)
+    env["GIT_DIR"] = str(victim / ".git")
+    env["PATH"] = os.environ["PATH"]
+    # 🔴 The guard is NOT on PATH for this one: it is the pre-fix control.
+    gd = env.get(norepo.GUARD_DIR_ENV)
+    if gd:
+        env["PATH"] = os.pathsep.join(
+            p for p in env["PATH"].split(os.pathsep) if p != gd)
+
+    bare = tmp_path / "fixture" / "remote.git"
+    clone = tmp_path / "fixture" / "clone"
+    bare.parent.mkdir(parents=True, exist_ok=True)
+    for argv in (["git", "init", "--quiet", "--bare", str(bare)],
+                 ["git", "clone", "--quiet", str(bare), str(clone)],
+                 ["git", "-C", str(clone), "config", "user.email", "t@t"],
+                 ["git", "-C", str(clone), "config", "user.name", "t"]):
+        subprocess.run(argv, env=env, capture_output=True, text=True)
+    clone.mkdir(parents=True, exist_ok=True)
+    (clone / "seed.py").write_text("x = 1  # seed\n")
+    for argv in (["git", "-C", str(clone), "add", "seed.py"],
+                 ["git", "-C", str(clone), "commit", "--quiet", "-m", "seed"],
+                 ["git", "-C", str(clone), "push", "--quiet", "origin", "HEAD:trunk"],
+                 ["git", "-C", str(clone), "branch", "-M", "trunk"]):
+        subprocess.run(argv, env=env, capture_output=True, text=True)
+
+    state = _victim_state(victim)
+    assert state["branches"] == ["refs/heads/trunk"], (
+        f"GIT_DIR no longer retargets `git -C` (branches={state['branches']}). "
+        "If that is genuinely true of this git, say so — but do not delete the "
+        "guard: it is the only thing that made the class impossible.")
+    assert state["HEAD"] == "refs/heads/trunk"
+    assert _git("-C", str(victim), "config", "--get", "user.email").stdout.strip() == "t@t"
+    assert "seed.py" in _git("-C", str(victim), "ls-tree", "--name-only", "HEAD").stdout
+    pushed = _git("-C", str(origin), "for-each-ref", "--format=%(refname)").stdout
+    assert "refs/heads/trunk" in pushed, (
+        "the fixture commit did not reach the victim's own remote — the half of "
+        "the incident that reached the PUBLIC repo")


### PR DESCRIPTION
The test tier could rewrite the operator's clone and push to the **public** repo. It
did, once — `main` was wiped on GitHub. GUARD 9 makes that write impossible from a
test.

Root cause of the incident: an ambient `GIT_DIR` overrides `git -C <path>`, so "every
call passes `-C`" confers no safety. And a git **worktree is not isolation** — it
shares the base clone's common dir, so a `git config` from inside one writes the
operator's real `.git/config`.

---

## 🔴 GATE STATUS: **RED**. Do not merge this as it stands.

`scripts/gate.sh --tier pytest`, run against this exact head in a standalone sandbox
clone, ends:

```
RESULT: FAIL (exit=1)
GATE: RESULT=FAIL exit=1
```

`TOTAL collected=14505 passed=14281 skipped=2 failed=222` — 3 targets red
(`scripts/tests` 37 failed / 177 errors, `scripts/repo-cos/tests` 7,
`scripts/task-spec-drafter/tests` 1); the other 22 pytest targets and all 6 script
targets pass, every per-target floor clears.

**The guard is refusing its own fixtures.** ~221 of the 224 refusals are one shape:

```
git(refused)  would mutate the PROTECTED repository <sandbox>/.git
              git upload-pack <tmp_path>/…/origin.git
```

A **local** `git clone <fixture>` makes git spawn `git-upload-pack <dir>`. Now that
the farm substitutes every dispatch name (below), that child is the shim — and the
repo it targets arrives as a **positional** argument, which the shim's global-option
parser (`-C`, `--git-dir`, …) cannot see. With no target parsed it falls back to
**cwd**, which in a test run is the protected repo, and refuses. The remaining 3 are a
second, smaller class: `-c core.fsmonitor=` is not on `INJECTABLE_KEYS`.

Isolated with a three-arm control — one variable moved between arms 2 and 3, cwd held
at the protected repo throughout:

| arm | `git clone <local fixture>` |
|---|---|
| 1 · no farm | rc 0 |
| 2 · farm as shipped | **rc 128, GUARD 9 REFUSED** |
| 3 · farm, only `git-upload-pack` pointed back at the real binary | rc 0 |

So it is specifically the interception of `git-upload-pack`, not the farm as such.
Both classes are **false refusals** — no test is actually reaching a real repo — but a
permanently-red gate is worse than no gate, so this needs a fix before merge. Fixing
it is a design call (which plumbing verbs carry a positional repo path, and whether
`core.fsmonitor` belongs on the allowlist), deliberately not made here.

The RCE fix and the retraction below stand on their own and are why this head is
pushed now.

---

## 🔴 RETRACTION: the exec-path farm did **not** close the alias/hook residual

An earlier version of this PR claimed a `GIT_EXEC_PATH` symlink farm **closed** the
alias/hook residual. **That claim was false and is withdrawn.** Two reviewers were
told it on that evidence, so it is stated here rather than silently edited away.

The farm substituted only the literal name `git`. `libexec/git-core` holds **181
`git-<verb>` entries**, and **git dispatches on `argv[0]`** — so all 181 reached the
real binary while sitting *first* on `PATH` in exactly the alias/hook context the farm
was added to cover. Measured against that revision, with the farm installed and every
other check in place:

```
<farm>/git-config -f <victim>/.git/config core.bare true
  -> core.bare false -> true, rc 0
```

That is **the incident's own signature**, landed at rc 0, without the word `git` being
spelled once.

The farm now substitutes every dispatch name. The residual is **two derived escapes**,
not zero — narrowed, **not closed**. Six alias-body shapes were measured:

```
!git …                 guarded
!sh -c 'git …'         guarded
!env git …             guarded
!command git …         guarded
!/abs/path/to/git …    🔴 ESCAPES  (PATH is never consulted)
!touch <victim>/file   🔴 ESCAPES  (never invokes git at all)
```

Owning git's exec path bounds what **git** will resolve for a child; it cannot bind a
command that bypasses resolution or never asks for git.

## 🔴 This PR fixes a code-execution bug in its own guard

`--config-env=key=VAR` puts `VAR` on the command line, and the shim did
`eval "_cv=\${$_ev:-}"` with it. So:

```
git --config-env=core.pager='V:-$(touch X)' --version
```

executed the `touch` **inside the shim, on a pure read, before any check ran**. Real
git rejects that name, exits 128 and runs nothing. **On that path the guard was
strictly worse than no guard** — it created execution where the unguarded binary had
none.

Fixed by validating the name as a shell identifier (an invalid one is now **refused**,
matching real git) and reading the value with `printenv`, which does not interpret.
All four `eval`s in the shim were audited; only that one took an argv-derived operand.
A test fails if a new `eval` appears **or the count changes**.

## Why the fix is keyed on NAME, not inode

A reviewer will reach for `stat -c %i` here; it is the wrong attribute, and it audits
green over a live hole. This host carries **two git binaries from unrelated nix
closures**:

| binary | inode | version |
|---|---|---|
| `~/.nix-profile/bin/git` — what bare `git` resolves to, and whose libexec `--exec-path` reports | 53015695 | 2.55.0 |
| `/run/current-system/sw/bin/git` | 62031535 | 2.52.0 |

Measured **inside the single directory `--exec-path` reports** (i.e. the one the farm
is built from), counting entries by resolved inode:

- keyed on the profile git's inode → **146**
- keyed on the system git's inode → **0**

So an inode-keyed enumeration is **`PATH`-dependent within one machine**: pick the
other binary — trivially done by a `nix-shell`, a `PATH` order change, or a `sudo` —
and it matches nothing while reporting a clean farm.

It is worse than that even when keyed correctly. That directory holds **181** `git-*`
dispatch names but only **146** of them resolve to git's inode; the other 35 are
separate executables (perl/shell helpers). An inode enumeration therefore misses 35
live dispatch names outright, on the *right* binary.

The property that actually matters is the **dispatch name** — 181 `git-*` entries,
identical on both hosts, and satisfied equally by a hardlink, a symlink, a copy or a
wrapper.

## Scope of the guard

The guard closes the **test tier's route** into these classes, not the classes
themselves — an agent or human running `git config` from a worktree by hand is still
unguarded, and that is what actually re-armed the operator's hooks today.

## What is in the change

- `scripts/testlib/norepo.py` — the shim: fail-closed allowlist of read forms,
  protected-path resolution via `--git-common-dir` **plus** every attached work-tree
  root, injected-config allowlist, the exec-path farm.
- `scripts/testlib/norepo_plugin.py` — pytest-side installation.
- `scripts/run-tests.sh` — installs the guard for all 24 targets (including the
  non-pytest ones no conftest can reach), plus `GIT_ALLOW_PROTOCOL`,
  `GIT_CONFIG_NOSYSTEM`, a redirected `GIT_CONFIG_GLOBAL`, and the GUARD 9 report.
- `scripts/tests/test_no_real_repo_writes.py` — arms every vector against a real
  victim and asserts it is byte-unchanged; each armed vector carries an **unguarded**
  arm that must move an asserted axis, because four of the ten originally written
  moved nothing and passed identically either way.
- Destination- and command-bearing options (`--output=`, `grep -O`) are checked
  **above** the read fast path — they are reachable from subcommands on the
  always-read list, so a "read" could otherwise still write a file or run a command.
