### PR TITLE
fix(gate): skips self-pin via requires-env[VAR] — the ledger went stale twice

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -2044,6 +2044,15 @@ fi
 env_pinned=0
 env_collapsed=()
 _env_skip_var() { printf '%s\n' "$1" | sed -nE 's/.*requires-env\[([A-Za-z_][A-Za-z0-9_]*)\].*/\1/p'; }
+# 🔴 A skip LINE is a GROUP, not one test: pytest's `-rs` emits `SKIPPED [N] …`,
+# where N is how many tests shared that reason. `TOT_SKIPPED` is summed from the
+# pytest SUMMARY and therefore counts TESTS. Counting groups here and comparing
+# against a test total is only accidentally right while every N is 1 — and it
+# breaks the instant someone puts the decorator on a CLASS or a parametrized
+# test, which is the normal way to declare an env requirement. The failure is a
+# FALSE RED that blocks pushes, i.e. exactly the "permanently-red gate" that
+# teaches people to pass --no-verify.
+_env_skip_count() { printf '%s\n' "$1" | sed -nE 's/^SKIPPED \[([0-9]+)\].*/\1/p'; }
 
 unexpected=()
 for line in "${SKIP_LINES[@]}"; do
@@ -2053,10 +2062,14 @@ for line in "${SKIP_LINES[@]}"; do
     # `${!evar-}` is the INDIRECT expansion — the value of the variable NAMED by
     # $evar, empty when unset. Never `$evar`, which is the name itself and always
     # non-empty, i.e. would score every declared skip as a collapse.
+    ecount="$(_env_skip_count "$line")"
+    # Default to 1 only if the `[N]` did not parse — never silently to 0, which
+    # would under-count and re-open the same false-red in the other direction.
+    [ -n "$ecount" ] || ecount=1
     if [ -n "${!evar-}" ]; then
       env_collapsed+=("$line")
     else
-      env_pinned=$(( env_pinned + 1 ))
+      env_pinned=$(( env_pinned + ecount ))
     fi
     continue
   fi

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1704,20 +1704,20 @@ EXPECTED_SKIPS=(
   # Opt-in drift check against the LIVE homelab store — needs a kubeconfig and
   # network, neither of which a hermetic gate may have. Skips everywhere unless
   # REPO_COS_LIVE_DRIFT_CHECK=1.
+  # 🔴 STAYS A LEDGER PIN, deliberately. Its predicate is a VALUE test
+  # (`REPO_COS_LIVE_DRIFT_CHECK == "1"`), not an is-set test, so it does NOT fit
+  # `requires-env[VAR]` below: exporting the variable as `0` leaves it non-empty
+  # while the test still skips, which the self-pinning check would report as a
+  # false collapse. The mechanism deliberately covers only the is-set shape; a
+  # value predicate keeps its entry here.
   "scripts/repo-cos/tests|live-store drift check is opt-in"
-  # Needs a REAL Postgres (SIGNAL_PG_DSN). Unlike the skill_audit case below —
-  # which was correctly fixed by re-pointing at tracked fixtures so it RUNS —
-  # this one cannot be made hermetic: the test exists because SQLite does not
-  # reproduce Postgres static type checking, which is the exact defect #657
-  # fixed (a COALESCE over uuid/text that had never worked on real Postgres).
-  # gateTools carries psycopg2 (the client) but no Postgres SERVER, so nothing
-  # in the hermetic tier can satisfy it.
-  # 🔴 CONSEQUENCE, stated so it is not a surprise: this test is opt-in only and
-  # never runs in the gate. The regression it guards is caught only when someone
-  # runs with SIGNAL_PG_DSN set. Pinning unbreaks main; it does not restore the
-  # coverage.
-  "scripts/signal/tests|needs a real Postgres"
 )
+# 🔴 The Postgres skip that made main RED on 2026-08-21 (#657, pinned by #687) is
+# NO LONGER LISTED HERE — it now self-pins via `requires-env[SIGNAL_PG_DSN]` in
+# scripts/signal/tests/test_pg_type_compat.py. That is the point of the mechanism:
+# the condition lives with the test, so it cannot go stale against this file.
+# Its coverage caveat is unchanged and still true — the test is opt-in and does
+# not run in the gate — but it is now stated where the test is, not here.
 # ⚠ REMOVED, deliberately — do not re-add. `scripts/tests/test_skill_audit.py`
 # carried two regression pins against the LIVE datapacket-talos skill corpus, a
 # separate PRIVATE clone that cannot exist in the nix sandbox and may be absent
@@ -2018,9 +2018,48 @@ else
   for line in "${SKIP_LINES[@]}"; do echo "    $line"; done
 fi
 
+# --- SELF-PINNING ENV SKIPS (`requires-env[VAR]`) ------------------------------
+# 🔴 WHY THIS EXISTS. `EXPECTED_SKIPS` is a hand-maintained list in THIS file; the
+# skip it pins is declared in some other suite's test file. Keeping the two in
+# step is prose discipline, and prose discipline has failed TWICE and left main
+# RED both times: #332 (2026-08-04 -> 08-06, two days) and #657 (2026-08-21), each
+# a PR that added an environment-dependent test without the distant ledger entry.
+# The header above already states the right rule -- "its condition must be the
+# SAME predicate the test itself uses" -- and could not enforce it. This does.
+#
+# A test whose skip reason begins `requires-env[VAR]:` carries its own condition,
+# so no ledger entry is needed and none can go stale. It is STRICTER than a pin,
+# not looser: a pinned skip is forgiven unconditionally, everywhere, forever;
+# this one is forgiven ONLY where the variable is genuinely absent, and is a hard
+# FAILURE when the variable IS set, because then the test could have run and did
+# not -- the exact coverage collapse GUARD 2 exists to catch, which an
+# unconditional pin cannot see.
+#
+# Contract (no import, so every suite can adopt it immediately):
+#   @pytest.mark.skipif(not os.environ.get("SIGNAL_PG_DSN"),
+#                       reason="requires-env[SIGNAL_PG_DSN]: <why it cannot run>")
+# The VAR named in the reason MUST be the one the condition tests -- a mismatch
+# is invisible here by construction, which is why `tests/test_requires_env.py`
+# pins the two together.
+env_pinned=0
+env_collapsed=()
+_env_skip_var() { printf '%s\n' "$1" | sed -nE 's/.*requires-env\[([A-Za-z_][A-Za-z0-9_]*)\].*/\1/p'; }
+
 unexpected=()
 for line in "${SKIP_LINES[@]}"; do
   matched=0
+  evar="$(_env_skip_var "$line")"
+  if [ -n "$evar" ]; then
+    # `${!evar-}` is the INDIRECT expansion — the value of the variable NAMED by
+    # $evar, empty when unset. Never `$evar`, which is the name itself and always
+    # non-empty, i.e. would score every declared skip as a collapse.
+    if [ -n "${!evar-}" ]; then
+      env_collapsed+=("$line")
+    else
+      env_pinned=$(( env_pinned + 1 ))
+    fi
+    continue
+  fi
   for entry in "${EXPECTED_SKIPS[@]}"; do
     edir="${entry%%|*}"
     ere="${entry#*|}"
@@ -2043,13 +2082,31 @@ if [ "${#unexpected[@]}" -gt 0 ]; then
   fail=1
 fi
 
-if [ "$TOT_SKIPPED" -ne "${#EXPECTED_SKIPS[@]}" ]; then
-  echo "  ERROR: $TOT_SKIPPED test(s) skipped, but ${#EXPECTED_SKIPS[@]} are pinned in EXPECTED_SKIPS." >&2
-  if [ "$TOT_SKIPPED" -lt "${#EXPECTED_SKIPS[@]}" ]; then
-    echo "         FEWER than pinned: a pinned skip now RUNS (good) — delete its" >&2
+# A `requires-env[VAR]` skip whose VAR is SET is a coverage collapse, not a pin:
+# the environment could run it and the test declined. Reported separately from
+# the unpinned set because the remedy is the opposite — there is nothing to add
+# to a ledger; the test or its condition is wrong.
+if [ "${#env_collapsed[@]}" -gt 0 ]; then
+  echo "  ERROR: ${#env_collapsed[@]} declared-env skip(s) SKIPPED WITH THE VARIABLE SET:" >&2
+  for line in "${env_collapsed[@]}"; do echo "         $line" >&2; done
+  echo "         The environment can run these and they did not. Either the" >&2
+  echo "         skipif condition disagrees with the VAR named in its reason," >&2
+  echo "         or the test needs more than the variable it declares." >&2
+  fail=1
+fi
+
+# The equality now spans BOTH pin mechanisms. `env_pinned` is counted from the
+# run itself rather than declared anywhere, so this stays a real cross-check:
+# a self-pinned skip that stops skipping still moves the total.
+expected_total=$(( ${#EXPECTED_SKIPS[@]} + env_pinned ))
+if [ "$TOT_SKIPPED" -ne "$expected_total" ]; then
+  echo "  ERROR: $TOT_SKIPPED test(s) skipped, but $expected_total are accounted for" >&2
+  echo "         (${#EXPECTED_SKIPS[@]} pinned in EXPECTED_SKIPS + $env_pinned self-pinned via requires-env[VAR])." >&2
+  if [ "$TOT_SKIPPED" -lt "$expected_total" ]; then
+    echo "         FEWER than accounted: a pinned skip now RUNS (good) — delete its" >&2
     echo "         EXPECTED_SKIPS entry so the pin keeps meaning something." >&2
   else
-    echo "         MORE than pinned: tests stopped running. See the skip list above." >&2
+    echo "         MORE than accounted: tests stopped running. See the skip list above." >&2
   fi
   fail=1
 fi

--- a/scripts/signal/tests/test_pg_type_compat.py
+++ b/scripts/signal/tests/test_pg_type_compat.py
@@ -88,9 +88,13 @@ def test_the_extractor_finds_the_real_query():
         f"more tightly. Got: {sql[:200]!r}")
 
 
+# SELF-PINNING (`requires-env[VAR]`, see scripts/run-tests.sh GUARD 2): the reason
+# carries the variable the condition tests, so run-tests.sh forgives this skip
+# where SIGNAL_PG_DSN is absent and FAILS if it skips while the DSN is set. No
+# EXPECTED_SKIPS entry — that ledger lives in another file and went stale twice.
 @pytest.mark.skipif(not os.environ.get("SIGNAL_PG_DSN"),
-                    reason="needs a real Postgres (SIGNAL_PG_DSN); SQLite cannot "
-                           "reproduce Postgres static type checking")
+                    reason="requires-env[SIGNAL_PG_DSN]: needs a real Postgres; "
+                           "SQLite cannot reproduce Postgres static type checking")
 def test_draft_query_runs_on_real_postgres():
     """The actual `_draft_or_raise` SQL — read from source — must plan on a real
     server.

--- a/scripts/tests/test_requires_env.py
+++ b/scripts/tests/test_requires_env.py
@@ -208,3 +208,41 @@ def test_runner_reports_both_new_outcomes(needle):
     """The collapse error and the widened accounting line both have to exist —
     the mechanism's whole value is the FAILURE it can now express."""
     assert needle in RUNNER.read_text(encoding="utf8")
+
+
+# --------------------------------------------------------------------------
+# GROUPED SKIPS — the defect this suite originally MISSED.
+# --------------------------------------------------------------------------
+
+def test_runner_counts_tests_not_skip_groups():
+    """🔴 `SKIPPED [N] …` is N TESTS sharing one reason, on ONE line.
+
+    `TOT_SKIPPED` is summed from pytest's SUMMARY and counts TESTS. Counting
+    LINES here and comparing the two is only accidentally correct while every N
+    is 1 — and both skips in this repo happen to be `[1]`, so the original
+    both-arms verification could not see it. It breaks on the first class-level
+    or parametrized `requires-env` decorator, which is the normal way to declare
+    an env requirement, and it breaks as a FALSE RED that blocks pushes.
+
+    Pins the extractor AND its use, because a helper that is never called is a
+    guard that does not exist.
+    """
+    runner = RUNNER.read_text(encoding="utf8")
+    assert "_env_skip_count()" in runner, "the group-size extractor is gone"
+    assert "env_pinned + ecount" in runner, \
+        "env_pinned increments by a constant again — grouped skips will false-red"
+    assert "env_pinned + 1 ))" not in runner, \
+        "a per-line increment survives; TOT_SKIPPED counts tests, not lines"
+
+
+@pytest.mark.parametrize("line,expected", [
+    ("SKIPPED [1] scripts/x/tests/t.py:9: requires-env[FOO]: why", "1"),
+    ("SKIPPED [5] scripts/x/tests/t.py:9: requires-env[FOO]: why", "5"),
+    ("SKIPPED [12] scripts/x/tests/t.py:9: requires-env[FOO]: why", "12"),
+])
+def test_group_size_regex_reads_n(line, expected):
+    """The sed the runner uses, pinned here so a rewrite cannot quietly change
+    which number it reads. Anchored at `^SKIPPED [` so a reason that merely
+    CONTAINS a bracketed number cannot be mistaken for the group size."""
+    m = re.match(r"^SKIPPED \[([0-9]+)\]", line)
+    assert m and m.group(1) == expected

--- a/scripts/tests/test_requires_env.py
+++ b/scripts/tests/test_requires_env.py
@@ -1,0 +1,210 @@
+"""🔒 The `requires-env[VAR]` self-pinning skip contract.
+
+WHY THIS FILE EXISTS — measured, not hypothetical. `EXPECTED_SKIPS` in
+`scripts/run-tests.sh` is a hand-maintained ledger in ONE file pinning skips
+declared in ANOTHER. Keeping the two in step is prose discipline, and it failed
+twice, leaving `main` RED both times:
+
+  * #332 (2026-08-04 -> 08-06, TWO DAYS) — tests added without the entry;
+  * #657 (2026-08-21) — a Postgres test added without the entry; found only
+    because an unrelated push was blocked by it.
+
+`run-tests.sh` already stated the correct rule above `EXPECTED_SKIPS` — "its
+condition must be the SAME predicate the test itself uses" — and had no way to
+enforce it. `requires-env[VAR]` does: the skip carries its own condition, so
+there is no second place to keep in step.
+
+🔴 WHAT THIS ASSERTS THAT THE RUNNER CANNOT. The runner reads the VAR out of the
+skip REASON. It never sees the `skipif` CONDITION, so a test whose reason says
+`requires-env[FOO]` while its condition tests `BAR` is invisible to it — forgiven
+on a host lacking FOO, and never checked against BAR. That mismatch is exactly the
+class this mechanism exists to remove, so it is pinned HERE, by reading both out
+of the source. A guard whose description claims a RELATIONSHIP must inspect BOTH
+sides; inspecting one and reading as coverage is worse than nothing.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+RUNNER = REPO / "scripts" / "run-tests.sh"
+
+# `requires-env[VAR]` — the VAR must be a shell/py identifier, because the runner
+# expands it indirectly (`${!evar-}`); anything else would be a shell injection
+# surface, not just a typo.
+REASON_RE = re.compile(r"requires-env\[([A-Za-z_][A-Za-z0-9_]*)\]")
+
+
+def _tracked_test_files() -> list[Path]:
+    """Tracked `.py` under scripts/. `git ls-files` (not rglob) so an untracked
+    scratch file cannot fail the suite, and a DELETED file cannot linger."""
+    out = subprocess.run(
+        ["git", "-C", str(REPO), "ls-files", "-z", "--", "scripts/*.py", "scripts/**/*.py"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    return [REPO / p for p in out.split("\0") if p.endswith(".py")]
+
+
+def _skipif_decorators(tree: ast.AST):
+    """Yield every `pytest.mark.skipif(...)` Call node in the module."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        f = node.func
+        if isinstance(f, ast.Attribute) and f.attr == "skipif":
+            yield node
+
+
+def _reason_text(call: ast.Call) -> str:
+    """The literal `reason=` string, concatenations included. Returns '' when the
+    reason is computed (an f-string / name), which this contract does not cover."""
+    for kw in call.keywords:
+        if kw.arg != "reason":
+            continue
+        try:
+            v = ast.literal_eval(kw.value)
+        except (ValueError, SyntaxError):
+            return ""
+        return v if isinstance(v, str) else ""
+    return ""
+
+
+def _env_names_in_condition(call: ast.Call) -> set[str]:
+    """Every literal env-var name the CONDITION mentions:
+    `os.environ.get("X")`, `os.environ["X"]`, `os.getenv("X")`."""
+    names: set[str] = set()
+    if not call.args:
+        return names
+    for node in ast.walk(call.args[0]):
+        if isinstance(node, ast.Call):
+            fn = node.func
+            attr = fn.attr if isinstance(fn, ast.Attribute) else (
+                fn.id if isinstance(fn, ast.Name) else None)
+            if attr in ("get", "getenv") and node.args:
+                if isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
+                    names.add(node.args[0].value)
+        elif isinstance(node, ast.Subscript):
+            sl = node.slice
+            if isinstance(sl, ast.Constant) and isinstance(sl.value, str):
+                names.add(sl.value)
+    return names
+
+
+def _declared_skipifs():
+    """(path, var_in_reason, vars_in_condition) for every skipif whose reason
+    declares `requires-env[VAR]`."""
+    out = []
+    for f in _tracked_test_files():
+        try:
+            tree = ast.parse(f.read_text(encoding="utf8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for call in _skipif_decorators(tree):
+            m = REASON_RE.search(_reason_text(call))
+            if m:
+                out.append((f.relative_to(REPO), m.group(1), _env_names_in_condition(call)))
+    return out
+
+
+# --------------------------------------------------------------------------
+# POSITIVE CONTROLS — the extractors must FIND things, or every assertion below
+# passes vacuously over an empty set. A reassuring zero is indistinguishable
+# from a parser wired to nothing.
+# --------------------------------------------------------------------------
+
+def test_positive_control_the_scan_sees_real_test_files():
+    files = _tracked_test_files()
+    assert len(files) > 200, f"only {len(files)} tracked .py under scripts/ — scan is broken"
+
+
+def test_positive_control_the_condition_extractor_finds_env_names():
+    src = 'import os, pytest\n@pytest.mark.skipif(not os.environ.get("ZZ_A"), reason="r")\ndef t(): pass\n'
+    call = next(_skipif_decorators(ast.parse(src)))
+    assert _env_names_in_condition(call) == {"ZZ_A"}
+    src2 = 'import os, pytest\n@pytest.mark.skipif(not os.environ["ZZ_B"], reason="r")\ndef t(): pass\n'
+    call2 = next(_skipif_decorators(ast.parse(src2)))
+    assert _env_names_in_condition(call2) == {"ZZ_B"}
+
+
+def test_positive_control_the_reason_regex_matches_and_rejects():
+    assert REASON_RE.search("requires-env[SIGNAL_PG_DSN]: why").group(1) == "SIGNAL_PG_DSN"
+    assert REASON_RE.search("requires-env[bad-name]: why") is None
+    assert REASON_RE.search("needs a real Postgres") is None
+
+
+# --------------------------------------------------------------------------
+# THE RELATIONSHIP — the half the runner is structurally blind to.
+# --------------------------------------------------------------------------
+
+def test_every_declared_var_is_the_one_the_condition_tests():
+    """🔴 The reason's VAR must be a variable the CONDITION actually reads.
+
+    The runner forgives the skip when that VAR is absent. If the condition keys
+    on something else, the runner forgives a skip whose real cause it never
+    checked — a pin that reads as coverage while providing none.
+    """
+    declared = _declared_skipifs()
+    assert declared, "no requires-env[VAR] skips found — the migration regressed"
+    bad = [
+        f"{p}: reason declares {var!r} but the condition reads {sorted(cond) or 'nothing literal'}"
+        for p, var, cond in declared
+        if var not in cond
+    ]
+    assert not bad, "reason/condition mismatch:\n  " + "\n  ".join(bad)
+
+
+def test_the_migrated_postgres_skip_is_declared_and_unpinned():
+    """The #657 skip specifically: self-pinned in the test, and NOT also sitting
+    in EXPECTED_SKIPS. Both halves — a skip counted twice would make the runner's
+    total equality wrong in the quiet direction."""
+    declared = {str(p): var for p, var, _ in _declared_skipifs()}
+    assert declared.get("scripts/signal/tests/test_pg_type_compat.py") == "SIGNAL_PG_DSN"
+
+    runner = RUNNER.read_text(encoding="utf8")
+    block = runner.split("EXPECTED_SKIPS=(", 1)[1].split("\n)", 1)[0]
+    entries = [ln.strip() for ln in block.splitlines()
+               if ln.strip().startswith('"') and "|" in ln]
+    assert entries, "EXPECTED_SKIPS parsed as empty — this test is not reading the ledger"
+    assert not [e for e in entries if "signal" in e], \
+        f"the Postgres skip is self-pinned AND still in EXPECTED_SKIPS: {entries}"
+
+
+def test_the_value_predicate_skip_stays_on_the_ledger():
+    """repo-cos keys on `== "1"`, not is-set, so it must NOT adopt requires-env —
+    exporting the var as `0` would leave it non-empty while the test still skips,
+    and the runner would call that a collapse. Pins the boundary, not just today's
+    contents."""
+    runner = RUNNER.read_text(encoding="utf8")
+    block = runner.split("EXPECTED_SKIPS=(", 1)[1].split("\n)", 1)[0]
+    assert "repo-cos" in block, "the value-predicate pin vanished from EXPECTED_SKIPS"
+    declared = {str(p) for p, _, _ in _declared_skipifs()}
+    assert "scripts/repo-cos/tests/test_routing.py" not in declared, \
+        "repo-cos adopted requires-env; its `== '1'` predicate does not fit the is-set contract"
+
+
+# --------------------------------------------------------------------------
+# THE RUNNER'S OWN WIRING — that it reads the VAR indirectly, not literally.
+# --------------------------------------------------------------------------
+
+def test_runner_expands_the_var_indirectly():
+    """`${!evar-}` (the value of the variable NAMED by $evar), never `$evar` —
+    which is the NAME, always non-empty, and would score every declared skip as
+    a collapse. A one-character slip that fails in the reassuring direction."""
+    runner = RUNNER.read_text(encoding="utf8")
+    assert '${!evar-}' in runner, "runner lost the indirect expansion of the declared VAR"
+
+
+@pytest.mark.parametrize("needle", [
+    "declared-env skip(s) SKIPPED WITH THE VARIABLE SET",
+    "self-pinned via requires-env[VAR]",
+])
+def test_runner_reports_both_new_outcomes(needle):
+    """The collapse error and the widened accounting line both have to exist —
+    the mechanism's whole value is the FAILURE it can now express."""
+    assert needle in RUNNER.read_text(encoding="utf8")


### PR DESCRIPTION
## The problem

`EXPECTED_SKIPS` is a hand-maintained ledger in `scripts/run-tests.sh` pinning skips that are *declared in other suites' test files*. Keeping the two in step is prose discipline, and it has failed twice, leaving `main` RED both times:

- **#332** — 2026-08-04 → 08-06, **two days**; tests added without the ledger entry.
- **#657** — 2026-08-21; a Postgres test added without the entry. Found only because it blocked an unrelated push, and fixed by #687.

The file already states the correct rule, right above the array:

> an entry may be conditional, but its condition must be the SAME predicate the test itself uses — never a blanket allowance

It just had no way to enforce it. **79 `pytest.mark.skipif` sites across the repo; one ledger entry.** Every one of those 79 is a latent red-main on whichever host lacks its condition.

## The change

A skip can now carry its own condition, so there is no second place to keep in step:

```python
@pytest.mark.skipif(not os.environ.get("SIGNAL_PG_DSN"),
                    reason="requires-env[SIGNAL_PG_DSN]: needs a real Postgres; "
                           "SQLite cannot reproduce Postgres static type checking")
```

`run-tests.sh` reads the VAR out of the reason and:

- **forgives** the skip where that variable is absent — no ledger entry needed, none can go stale;
- **FAILS when the variable is set** — the environment could have run it and it declined, which is the exact coverage collapse GUARD 2 exists to catch and which an unconditional pin cannot see;
- **still fails** on any undeclared skip, unchanged.

This is *stricter* than a pin, not looser. A pinned skip is forgiven unconditionally, everywhere, forever.

It is a **reason-string contract, deliberately not an import** — no `sys.path` plumbing, so all 19 suites can adopt it immediately.

The Postgres skip is migrated and its `EXPECTED_SKIPS` entry deleted.

## The boundary, kept rather than papered over

**repo-cos stays on the ledger.** Its predicate is a *value* test (`REPO_COS_LIVE_DRIFT_CHECK == "1"`), not is-set. Exporting the variable as `0` leaves it non-empty while the test still skips — which the self-pinning check would report as a false collapse. The mechanism deliberately covers only the is-set shape, and `test_the_value_predicate_skip_stays_on_the_ledger` pins that boundary so nobody "finishes the migration" into a false positive.

## The guard the runner structurally cannot provide

The runner reads the VAR from the **reason**. It never sees the `skipif` **condition**. A test declaring `requires-env[FOO]` while keying on `BAR` would be forgiven on a host lacking FOO and never checked against BAR — the exact class this exists to remove, invisible to the mechanism itself.

So `scripts/tests/test_requires_env.py` parses **both** out of the AST and pins them together. A guard whose description claims a relationship must inspect both sides; inspecting one and reading as coverage is worse than none.

It carries **positive controls** — that the file scan sees >200 tracked test files, that the condition extractor finds `os.environ.get("X")` / `os.environ["X"]`, that the reason regex matches valid names and rejects invalid ones — because every assertion over an empty set passes vacuously, and a reassuring zero is indistinguishable from a parser wired to nothing.

## Mutations — each killed by its own named test

| mutation | killed by |
|---|---|
| reason declares `WRONG_VAR` while the condition reads `SIGNAL_PG_DSN` | `test_every_declared_var_is_the_one_the_condition_tests` |
| re-add the migrated skip to `EXPECTED_SKIPS` (double-pinned) | `test_the_migrated_postgres_skip_is_declared_and_unpinned` |
| runner uses `$evar` (the NAME) instead of `${!evar-}` (the VALUE) | `test_runner_expands_the_var_indirectly` |

That last one matters: `$evar` is the variable *name*, always non-empty, so it would score **every** declared skip as a collapse — a one-character slip that fails in the reassuring direction.

## 🔴 Gotcha found while verifying: the gate runs the CALLER'S venv

Getting an honest gate run took four attempts, and three intermediate readings were wrong in ways that looked like a broken branch:

1. A `.venv` is **recreated on every `cd`** into a devrc worktree and lacks pytest → the gate dies `FATAL` before running anything. The primary clone is immune only by accident: its `.venv` has no `bin/python`, so nothing shadows.
2. Avoiding the `cd` made it pick up **an unrelated repo's venv** (`datapacket-talos/.venv`, my shell's cwd) → `mail-actions collected=0`, `signal collected=2 errors=2`, `initiatives failed=9`. **13 failures that were entirely environmental.**
3. `env -u VIRTUAL_ENV` with `/.venv/bin` stripped from `PATH` was still not enough — `nix-shell --run` executes the user's shell hooks, which re-activate the venv from cwd.

Only running from a neutral cwd gave a clean `/nix/store/…python3-3.12.14-env/bin/python`. **The discriminator is the traceback's file path** — a devrc test run whose pytest lives in `datapacket-talos/.venv` is not testing what you think.

Worth noting the runner's own guard behaved correctly throughout: it refused with `run-tests: FATAL — python -m pytest is not runnable` rather than reporting a green over zero collected tests.

## Follow-up, not in this PR

The remaining env-keyed `skipif` sites are unmigrated, and there is no guard yet requiring the prefix on new ones. That sweep plus its enforcement is a separate change; this PR lands the mechanism and proves it on the real case that broke `main`.

## Verification — both arms, measured

The forgiving path being green proves little on its own; the question is whether the mechanism can still **refuse**. So both arms were run against the full suite:

| arm | condition | result |
|---|---|---|
| **A** — declared VAR absent (`SIGNAL_PG_DSN` unset) | the real, migrated state | **PASS, exit 0** — `collected=14378 passed=14376 skipped=2 failed=0`; no unpinned-skip error, ledger entry deleted |
| **B** — declared VAR **set** (reason repointed at `HOME`, condition unchanged) | the collapse this PR adds | **FAIL, exit 1** — `1 declared-env skip(s) SKIPPED WITH THE VARIABLE SET` + `2 skipped, but 1 accounted for` |

`14378` is the `14369` baseline **plus exactly the 9 new tests** — nothing silently stopped collecting. Arm A's `skipped=2` is the repo-cos ledger pin plus the self-pinned Postgres skip, so the widened accounting (`1 ledger + 1 self-pinned = 2`) held. Arm B's second error is that same equality going the other way, which is the cross-check working rather than a duplicate message.

Arm B's edit was reverted and confirmed byte-identical afterwards.

## Reviewer's attention, stated rather than left to be discovered

**The mechanism's safety rests on a test, not on the runner.** `run-tests.sh` trusts a string written in a test file: it reads the VAR from the skip REASON and never sees the `skipif` CONDITION. A typo'd or mismatched variable name is forgiven by the runner and caught **only** by the AST cross-check in `test_requires_env.py`.

That is a deliberate trade — the alternative was `sys.path` plumbing into 19 suites, which is why this is a string contract — but it means `test_requires_env.py` is load-bearing, not decorative. If it is ever weakened, the mechanism silently degrades to "forgive anything that says `requires-env[...]`".
