### PR TITLE
fix(session-manager): the NEVER-PASTE rule covered ONE of the two fields that publish operator text

### DIFF
--- a/claude/skills/session-manager/SKILL.md
+++ b/claude/skills/session-manager/SKILL.md
@@ -30,12 +30,12 @@ column — **how it is counted**) are different, and `caveats.kind_scope` carrie
 | `--lean` | 🔴 **with `--json`, prefer this.** Rows trimmed to the fields that answer this tool's question, **untruncated**, every discriminator and caveat kept |
 | `--host workbench\|laptop\|all` | default `all`; `tail` resolves `all` to LOCAL |
 | `--claude-only` | drop the **shell** rows (a `cluster` dispatch is an agent and is KEPT). Every count then describes the FILTERED set |
+| `--no-ch` | skip ClickHouse — drops the **largest non-row block** (17.4 KB below), which answers a different question |
 | `--no-capture` | skip the pane scrape; **every** `waiting_probable` AND `unsent_prompt` becomes `null` (both roll-ups `null`, never `0`) |
 | `--no-ledger` | skip the ledger read → **no age, no session id** on any row |
 | `--fuzzyclaw` | the task-file join, **OFF by default** (see below) |
 
-`--json`, `--no-ch`, `--no-fuzzyclaw`, `--plain`, `--stale-threshold`, `--lines`, and what
-each drops:
+`--json`, `--no-fuzzyclaw`, `--plain`, `--stale-threshold`, `--lines`, and what each drops:
 `~/.claude/skills/session-manager/reference/payload-contract.md`.
 
 ## 🔴 Which output to ask for — you are the only consumer
@@ -43,19 +43,22 @@ each drops:
 Measured: **0 interactive shell invocations in 30 days against 55 agent references**. An agent
 reads this, and pays by the token.
 
-| | cost, one 75-row scan | faithful? |
-|---|---|---|
-| table (default) | ~3,280 tok | ❌ **lossy** — 73 truncated cells, 45 tasks over the 25-char column |
-| `--json --lean` | ~9,629 tok | ✅ on what it keeps |
-| `--json` | ~14,017 tok | ✅ |
+One 77-row two-host scan, re-measured 2026-08-21:
 
-**Ask for `--json --lean` unless you need a dropped field** — cheaper than the full payload AND
-more faithful than the cheap one; `caveats`, the tri-states, `clawgate_queue` and every
-per-host measurement status are kept whole. ⚠ One scan, 2026-08-14, predating
-`unsent_prompt`/`not_measured` which add to all three: the RANKING is load-bearing, the
-absolute numbers are not current. `lean_row_fields`/`lean_host_fields` travel in the payload
-naming what the view CARRIES, so a key absent from a row was omitted by the view, never
-measured as null.
+| | bytes ≈ tokens | faithful? |
+|---|---|---|
+| table (default) | 24,658 ≈ 6.2k | ❌ **lossy** — truncated cells, tasks over the 25-char column |
+| `--json --lean` | 79,008 ≈ 20k | ✅ on what it keeps |
+| `--json` | 103,801 ≈ 26k | ✅ |
+
+🔴 **`--lean` trims ROW fields ONLY** — 39 KB of that lean payload is blocks it never touches:
+`clickhouse` 17.4 KB, `clawgate_queue` 12.7 KB (the queue is enumerated **uncapped**),
+`caveats` 4.3 KB, `ledger` 2.8 KB, `not_measured` 1.8 KB. **So ask for `--json --lean
+--no-ch`** unless you want the session history — that block is the largest single lever and it
+answers a different question than "is anything waiting on me". The tri-states, `caveats`,
+`clawgate_queue` and every per-host measurement status survive all three flags.
+`lean_row_fields`/`lean_host_fields` travel in the payload naming what the view CARRIES, so a
+key absent from a row was omitted by the view, never measured as null.
 
 ## 🔴 `waiting_probable` — is anything waiting on a HUMAN
 
@@ -112,10 +115,11 @@ are never scraped. Scoped to the pane's OWN input line (only the lines *between 
 box-drawing rules*), so scrollback or a pane displaying another session's transcript cannot
 trip it.
 
-🔴 **NEVER PASTE A CAPTURED DRAFT INTO A COMMITTED FILE.** `unsent_prompt` hands you **text
-the operator typed**, and devrc is a **PUBLIC** repo — as is every `claudedocs/` note, commit
-message, PR body, comment or test fixture an agent writes into it. Report a draft as a
-**count, a length or a shape**, never verbatim. Quoting one back to Zach in chat is fine;
+🔴 **NEVER PASTE CAPTURED OPERATOR TEXT INTO A COMMITTED FILE.** TWO fields carry **text the
+operator typed** — `unsent_prompt` (the draft) and `clickhouse.rows[].first_msg` (the opening
+prompt of every recent session) — and devrc is a **PUBLIC** repo, as is every `claudedocs/`
+note, commit message, PR body, comment or test fixture an agent writes into it. Report either
+as a **count, a length or a shape**, never verbatim. Quoting one back to Zach in chat is fine;
 writing one to a file that gets committed is not.
 (`test_no_FIXTURE_DRAFT_string_appears_in_a_shipped_doc` fails on that shape — it has
 happened.)
@@ -130,18 +134,15 @@ it**: `pull_requests` → `standup`, `mail_queue` → `mailbox`, `cluster_alerts
 
 🔴 **It is DERIVED from the report's own keys, not a written-down list.** An entry is emitted
 only while the report carries no key for that population, so the day PR querying lands the
-claim stops being made with no edit anywhere. This file has shipped a constant masquerading as
-a measurement five times; a static list of "things we do not measure" is the same defect with
-a longer fuse. `clawgate_queue` is **not** listed — that one *is* measured.
+claim stops being made with no edit anywhere. `clawgate_queue` is **not** listed — that one
+*is* measured.
 
 ## 🔴 `clawgate_queue` — the clawgate approval queue
 
-🔴 **Renamed from `blocked_on_me` (2026-08-18).** The old name read as "everything waiting on
-you"; a caveat in this tool's own payload already said so, and a reader made that misread
-anyway and shipped it into a brief for three subagents — a field name is read a hundred times
-for every once its caveat is. **For panes that look like they are waiting on a human the field
-is `summary.waiting.probable` — a different population, never summed with this one.** No alias
-is kept and a test bans the old key at any depth.
+🔴 **Renamed from `blocked_on_me` (2026-08-18)** — no alias is kept and a test bans the old key
+at any depth; the misread it cost is in the reference. **For panes that look like they are
+waiting on a human the field is `summary.waiting.probable` — a different population, never
+summed with this one.**
 
 🔴 With the `agent-ops` TUI RETIRED this is the ONLY place the queue surfaces outside the bar
 pill: never answer "is anything waiting for my approval" by pointing somewhere else. Source:
@@ -194,12 +195,11 @@ measurements, and one succeeding says nothing about the others. `clickhouse.stat
 
 ## fuzzyclaw is OFF by default
 
-Measured 2026-08-12: 29 live of 401 task files and **every one of the 29 live rows read
-`paused`**, including a window demonstrably running an agent — 29 table rows, zero
-contribution, from a source `CLAUDE.md` marks UNTRUSTED. Opt in with `--fuzzyclaw`; off, every
-count is `null` rather than `0`. The intersection guard still runs when you do: a task file
-survives only when its `window_id` is live **and** that live window's real `(session, index)`
-equals the one the file recorded.
+Measured 2026-08-12: 29 live of 401 task files and **every one read `paused`**, including a
+window demonstrably running an agent — a source `CLAUDE.md` marks UNTRUSTED. Opt in with
+`--fuzzyclaw`; off, every count is `null` rather than `0`. The intersection guard still runs
+when you do: a task file survives only when its `window_id` is live **and** that live window's
+real `(session, index)` equals the one the file recorded.
 
 ## The agent activity ledger — where age / `stale` / `claude_session_id` come from
 

--- a/claude/skills/session-manager/reference/clickhouse-queries.md
+++ b/claude/skills/session-manager/reference/clickhouse-queries.md
@@ -31,6 +31,14 @@ WHERE source IN ('claude','opencode') AND ts > now() - INTERVAL 1 DAY
 GROUP BY session ORDER BY last_seen DESC LIMIT 20
 ```
 
+🔴 **NEVER PASTE CAPTURED OPERATOR TEXT INTO A COMMITTED FILE.** `first_msg` is **text the
+operator typed** — the opening prompt of every recent session, up to 20 of them, ~17 KB in a
+default scan — and devrc is a **PUBLIC** repo, as is every `claudedocs/` note, commit message,
+PR body, comment or test fixture an agent writes into it. Report it as a **count, a length or
+a shape**, never verbatim; `--no-ch` drops the block entirely. Identical rule, identical
+reason, to `unsent_prompt` in `waiting-signal.md` — and that rule named only the draft until
+2026-08-21, which is why this paragraph exists here rather than being assumed.
+
 🔴 **There is no `first_message` column.** `activity.events` has 13 columns — `ts, host,
 source, kind, project, cwd, session, app, text, duration_ms, exit_code, payload,
 ingested_at` — and an earlier draft of this query named `first_message`, which fails

--- a/claude/skills/session-manager/reference/payload-contract.md
+++ b/claude/skills/session-manager/reference/payload-contract.md
@@ -47,17 +47,28 @@ these rows. `kind` is never null; `runtime` frequently is, and means something e
 Measured: **0 interactive shell invocations in 30 days against 55 agent references**, confirmed
 by the operator 2026-08-14. An agent reads this, and pays by the token.
 
-| | cost on a 75-row scan | faithful? |
-|---|---|---|
-| table (default) | ~3,280 tok | ❌ **lossy** — 73 truncated cells, 45 rows whose task exceeds the 25-char column |
-| `--json` | ~14,017 tok | ✅ |
-| `--json --lean` | ~9,629 tok | ✅ on what it keeps |
+| | 77 rows, both hosts, 2026-08-21 | 75 rows, 2026-08-14 | faithful? |
+|---|---|---|---|
+| table (default) | 24,658 B ≈ 6.2k tok | ~3,280 tok | ❌ **lossy** — truncated cells, rows whose task exceeds the 25-char column |
+| `--json` | 103,801 B ≈ 26k tok | ~14,017 tok | ✅ |
+| `--json --lean` | 79,008 B ≈ 20k tok | ~9,629 tok | ✅ on what it keeps |
 
-⚠ Those three figures were measured on ONE 75-row scan on 2026-08-14 and **predate the
-`unsent_prompt` pair and `not_measured`**, which add to all three. The RANKING is what the
-table is for and that is unchanged; do not quote the absolute numbers as current.
+⚠ Both columns are single scans of a live fleet whose size moves; the RANKING is what the
+table is for. The 08-14 column is kept only to show the drift — it predates the
+`unsent_prompt` pair and `not_measured`, and was quoted as current for a week after it stopped
+being so.
 
-**Ask for `--json --lean` unless you need a dropped field.** It is cheaper than the full payload
+🔴 **`--lean` TRIMS ROW FIELDS ONLY, and the row fields are barely half the payload.** Measured
+2026-08-21 on the lean output: `hosts` 42.5 KB (of which rows 42.1 KB), `clickhouse` 17.4 KB,
+`clawgate_queue` 12.7 KB, `caveats` 4.3 KB, `ledger` 2.8 KB, `not_measured` 1.8 KB,
+`summary` 1.0 KB. So `--lean` alone buys 24% off the full payload, not the ~31% the 08-14
+figures implied, and **the second-largest block is one flag away**: `--no-ch` drops the
+ClickHouse rows, which answer session-history questions rather than "is anything waiting on
+me". Two smaller structural costs, neither capped: `clawgate_queue` enumerates the whole queue
+(96 entries / 12.1 KB that day) and `ledger.conflicts` is emitted twice, top-level and again
+per host.
+
+**Ask for `--json --lean --no-ch` unless you need a dropped field.** It is cheaper than the full payload
 AND more faithful than the cheap one. `lean_row_fields` and `lean_host_fields` travel in the payload
 naming exactly what this view CARRIES — so a key absent from a row was omitted by the view, never
 measured as null. `caveats`, `summary.waiting`'s tri-state, `clawgate_queue` and every per-host

--- a/claude/skills/session-manager/reference/waiting-signal.md
+++ b/claude/skills/session-manager/reference/waiting-signal.md
@@ -128,16 +128,27 @@ So the fact is now measured under its **own** name: row fields `unsent_prompt` (
 `unsent_prompt_status`, roll-up `summary.unsent_prompt`, `caveats.unsent_prompt`, and a
 `✎ UNSENT PROMPT` block in the table.
 
-### 🔴 NEVER PASTE A CAPTURED DRAFT INTO A COMMITTED FILE
+### 🔴 NEVER PASTE CAPTURED OPERATOR TEXT INTO A COMMITTED FILE
 
 This signal's entire job is publishing **text the operator typed**, and it lands in an agent's
 payload — from there into transcripts, commit messages, handoff notes and any `claudedocs/`
 an agent writes. **This repo is PUBLIC.** So: report a draft as a **count, a length or a
 shape**, never verbatim, in any file that gets committed — a doc, a test fixture, a comment,
-a PR body. Every fixture in `test_session_manager.py` is invented for exactly this reason,
+a PR body.
+
+Every fixture in `test_session_manager.py` is invented for exactly this reason,
 and `test_no_FIXTURE_DRAFT_string_appears_in_a_shipped_doc` fails if a string ever appears in
 both places, which is the shape a copied-in real draft takes. This paragraph replaced four
 real drafts that had been quoted here verbatim.
+
+🔴 **`unsent_prompt` is not the only such field, and this rule named it alone while a second
+one shipped unmentioned.** `clickhouse.rows[].first_msg` is the opening prompt of every recent
+session — the same class of text, in the same payload, from a query this skill runs by
+default. Measured: the rule landed 2026-08-17, `first_msg` had been in the payload since the
+tool's first commit on 2026-08-11, and nothing in the skill tree connected them until
+2026-08-21. It is covered by the same rule; `--no-ch` is how you avoid carrying it at all, and
+`test_EVERY_field_that_publishes_OPERATOR_TEXT_is_named_by_the_NEVER_PASTE_rule` now fails if
+a ledgered field goes unnamed. See `clickhouse-queries.md`.
 
 **It is never mixed into `waiting_probable` and never summed into its counts.** The same 79-pane
 sweep measured `waiting_probable` at **11 flagged / 11 true positives / 0 false positives**,
@@ -326,10 +337,11 @@ is a modal (which replaces the box) or a draft taller than the box — **unmeasu
 "nothing typed". Shell panes are **never** scraped (`not_claude`): a half-typed shell command
 is a different and noisier thing.
 
-🔴 **NEVER PASTE A CAPTURED DRAFT INTO A COMMITTED FILE.** `unsent_prompt` hands you **text
-the operator typed**, and devrc is a **PUBLIC** repo — as is every `claudedocs/` note, commit
-message, PR body, comment or test fixture an agent writes into it. Report a draft as a
-**count, a length or a shape**, never verbatim. Quoting one back to Zach in chat is fine;
+🔴 **NEVER PASTE CAPTURED OPERATOR TEXT INTO A COMMITTED FILE.** TWO fields carry **text the
+operator typed** — `unsent_prompt` (the draft) and `clickhouse.rows[].first_msg` (the opening
+prompt of every recent session) — and devrc is a **PUBLIC** repo, as is every `claudedocs/`
+note, commit message, PR body, comment or test fixture an agent writes into it. Report either
+as a **count, a length or a shape**, never verbatim. Quoting one back to Zach in chat is fine;
 writing one to a file that gets committed is not. (Four real drafts were quoted verbatim in
 this file and re-used as fixtures before this rule existed —
 `test_no_FIXTURE_DRAFT_string_appears_in_a_shipped_doc` now fails on that shape.)

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -9572,7 +9572,23 @@ _SKILL_DIR = os.path.join(_REPO_ROOT, "claude", "skills", "session-manager")
 # which is the route all six real drafts actually took.
 _SKILL_BODY = os.path.join(_SKILL_DIR, "SKILL.md")
 _WAITING_REF = os.path.join(_SKILL_DIR, "reference", "waiting-signal.md")
+_CH_REF = os.path.join(_SKILL_DIR, "reference", "clickhouse-queries.md")
 _KICKOFF_DOC = os.path.join(_REPO_ROOT, "claudedocs", "kickoff-waiting-signal.md")
+
+# 🔴 THE LEDGER OF FIELDS THAT PUBLISH OPERATOR-TYPED TEXT, and the reason it is
+# a ledger rather than a sentence. The NEVER-PASTE rule named `unsent_prompt`
+# alone while `clickhouse.rows[].first_msg` — the opening prompt of every recent
+# session, shipped by a query that runs by DEFAULT — sat in the same payload
+# with nothing said about it anywhere in the skill tree.
+#
+# Every member must be NAMED in the core's rule (asserted below), and every
+# member is bound to the code that produces it, so this list cannot rot into
+# fields that no longer exist. 🔴 ITS HONEST LIMIT, stated rather than implied:
+# it cannot see a THIRD such field appearing in the payload on its own — nothing
+# derives "carries operator text" from the code. What it does buy is that adding
+# one here, which is where anyone widening the rule starts, fails until the
+# docs name it too.
+_OPERATOR_TEXT_FIELDS = ("unsent_prompt", "clickhouse.rows[].first_msg")
 # Six files at the time of writing, against the two the hand-list named. The
 # three above are NAMED as well as derived because the prose guard below asserts
 # a specific sentence in a specific one of them — a positional index into a
@@ -9790,14 +9806,28 @@ def test_INSTRUMENT_the_leak_guards_NEEDLES_and_HAYSTACK_are_both_derived():
         _MODAL_OPTION_LABELS_NOT_DRAFTS
 
 
-def test_BOTH_shipped_docs_carry_the_NEVER_PASTE_A_CAPTURED_DRAFT_rule():
-    """🔴 THE MISSING GUARDRAIL. Neither the skill body nor the reference told
-    anyone not to paste a captured draft into a committed file — and this
-    feature hands operator-typed text to an agent, which writes it onward into
-    transcripts, commit messages and any `claudedocs/` note in this PUBLIC repo.
-    The rule has to be where a reader hits it, in BOTH places: the skill body is
-    what an agent loads to use the tool, the reference is what it loads to
-    change the tool.
+def test_EVERY_field_that_publishes_OPERATOR_TEXT_is_named_by_the_NEVER_PASTE_rule():
+    """🔴 THE GUARD WAS NARROWER THAN ITS OWN SENTENCE, which is the defect it
+    now exists to stop.
+
+    The original rule — and the original version of this test — named
+    `unsent_prompt` alone, from the day it landed (2026-08-17).
+    `clickhouse.rows[].first_msg` is the opening prompt of every recent session,
+    shipped in the SAME payload by a query that runs by DEFAULT (~17 KB of
+    operator-typed text in an ordinary scan), and it had been there since the
+    tool's first commit (2026-08-11) with no document in the skill tree
+    mentioning it. Nothing about the sentence was false; it was NARROWER THAN
+    THE PAYLOAD IT GOVERNED, and a rule that reads as complete is worse than
+    none because it stops anyone looking.
+    `claude/RULES.md`: "a guard's DESCRIPTION claims COVERAGE — check the
+    implementation is as wide as the sentence."
+
+    So the width is now the thing that is CHECKED, not the thing that is
+    written. `_OPERATOR_TEXT_FIELDS` is an asserted LEDGER: it fails when the
+    set grows (a third such field cannot ship without a doc naming it) and when
+    it shrinks (a field cannot be quietly dropped from the rule while the
+    payload still carries it), and each member is bound to the code that
+    produces it below, so the ledger cannot drift from reality either.
 
     Pinned as WHOLE normalised strings. A word check here is walkable by a
     reword — four prose guards in this repo were walked exactly that way, one by
@@ -9815,16 +9845,50 @@ def test_BOTH_shipped_docs_carry_the_NEVER_PASTE_A_CAPTURED_DRAFT_rule():
         skill = _norm(fh.read())
     with open(_WAITING_REF, encoding="utf-8") as fh:
         ref = _norm(fh.read())
+    with open(_CH_REF, encoding="utf-8") as fh:
+        ch_ref = _norm(fh.read())
 
-    assert ("🔴 **NEVER PASTE A CAPTURED DRAFT INTO A COMMITTED FILE.** "
-            "`unsent_prompt` hands you **text the operator typed**, and devrc "
-            "is a **PUBLIC** repo — as is every `claudedocs/` note, commit "
-            "message, PR body, comment or test fixture an agent writes into "
-            "it. Report a draft as a **count, a length or a shape**, never "
-            "verbatim.") in skill
-    assert ("### 🔴 NEVER PASTE A CAPTURED DRAFT INTO A COMMITTED FILE") in ref
+    assert ("🔴 **NEVER PASTE CAPTURED OPERATOR TEXT INTO A COMMITTED FILE.** "
+            "TWO fields carry **text the operator typed** — `unsent_prompt` "
+            "(the draft) and `clickhouse.rows[].first_msg` (the opening prompt "
+            "of every recent session) — and devrc is a **PUBLIC** repo, as is "
+            "every `claudedocs/` note, commit message, PR body, comment or "
+            "test fixture an agent writes into it. Report either as a "
+            "**count, a length or a shape**, never verbatim.") in skill
+    assert ("### 🔴 NEVER PASTE CAPTURED OPERATOR TEXT INTO A COMMITTED "
+            "FILE") in ref
     assert ("report a draft as a **count, a length or a shape**, never "
             "verbatim, in any file that gets committed") in ref
+
+    # 🔴 AND WHERE THE SECOND FIELD ACTUALLY LIVES. A reader who opens the
+    # ClickHouse reference to write a query never passes the `unsent_prompt`
+    # section, so the rule has to be on the query's own page too — the same
+    # "put it where the reader hits it" argument that put it in two files
+    # originally, applied to the file the original pass missed.
+    assert ("🔴 **NEVER PASTE CAPTURED OPERATOR TEXT INTO A COMMITTED FILE.** "
+            "`first_msg` is **text the operator typed**") in ch_ref
+
+    # 🔴 THE WIDTH CHECK. Every ledgered field must be NAMED in the core's rule
+    # — not merely present somewhere in the file, which `unsent_prompt` would
+    # satisfy from its own section heading while the rule ignored it.
+    rule = skill.split("NEVER PASTE CAPTURED OPERATOR TEXT")[1].split("never verbatim.")[0]
+    for field in _OPERATOR_TEXT_FIELDS:
+        assert field in rule, (
+            f"`{field}` publishes operator-typed text and the core's "
+            f"NEVER-PASTE rule does not name it. Widen the rule (and its pin in "
+            f"test_session_manager_skill_size.py) in the SAME commit — or, if "
+            f"the field no longer carries operator text, remove it from "
+            f"_OPERATOR_TEXT_FIELDS and say why.")
+
+    # 🔴 AND THE LEDGER IS BOUND TO THE CODE, so it cannot drift into a list of
+    # fields that no longer exist while a real one ships uncovered. Each member
+    # is checked against the thing that PRODUCES it, not against another doc.
+    assert "first_msg" in sm.SQL_RECENT_SESSIONS, (
+        "the ledger names `clickhouse.rows[].first_msg`, but the query no "
+        "longer selects it — drop it from _OPERATOR_TEXT_FIELDS if the payload "
+        "genuinely stopped carrying operator text")
+    assert "unsent_prompt" in sm.LEAN_ROW_FIELDS, (
+        "the ledger names `unsent_prompt`, but no row carries it")
     # 🔴 AND THE CO-OCCURRENCE CORRECTION, in the same pass: the reference used
     # to promote "0 rows flagged BOTH" on ONE live run to the separation claim.
     # The next run measured 1, and suppressing co-occurrence would make the tool

--- a/scripts/tests/test_session_manager_skill_size.py
+++ b/scripts/tests/test_session_manager_skill_size.py
@@ -217,12 +217,24 @@ PROTECTED_CLAIMS: dict[str, tuple[str, ...]] = {
         "`summary.waiting.probable` — a different population, never summed with "
         "this one.**",
     ),
-    "the NEVER-PASTE-A-CAPTURED-DRAFT rule": (
-        "🔴 **NEVER PASTE A CAPTURED DRAFT INTO A COMMITTED FILE.** "
-        "`unsent_prompt` hands you **text the operator typed**, and devrc is a "
-        "**PUBLIC** repo — as is every `claudedocs/` note, commit message, PR "
-        "body, comment or test fixture an agent writes into it. Report a draft as "
-        "a **count, a length or a shape**, never verbatim.",
+    # 🔴 WIDENED 2026-08-21, and the widening is the point. The rule named
+    # `unsent_prompt` alone from the day it landed (2026-08-17) while
+    # `clickhouse.rows[].first_msg` -- the opening prompt of every recent
+    # session, ~17 KB of operator-typed text in a DEFAULT scan -- had been in
+    # the same payload since the tool's first commit (2026-08-11), with no rule
+    # attached in any document. Nothing was wrong with the sentence; it was NARROWER than the
+    # payload it governed, which is `claude/RULES.md`'s "a guard's DESCRIPTION
+    # claims COVERAGE -- check the implementation is as wide as the sentence".
+    # The pin is what stops it narrowing back: naming BOTH fields is now the
+    # thing that is checked, not merely the thing that is written.
+    "the NEVER-PASTE-CAPTURED-OPERATOR-TEXT rule": (
+        "🔴 **NEVER PASTE CAPTURED OPERATOR TEXT INTO A COMMITTED FILE.** TWO "
+        "fields carry **text the operator typed** — `unsent_prompt` (the draft) "
+        "and `clickhouse.rows[].first_msg` (the opening prompt of every recent "
+        "session) — and devrc is a **PUBLIC** repo, as is every `claudedocs/` "
+        "note, commit message, PR body, comment or test fixture an agent writes "
+        "into it. Report either as a **count, a length or a shape**, never "
+        "verbatim.",
     ),
 }
 


### PR DESCRIPTION
Two defects found by reading the `session-manager` skill against the script it documents and against a live two-host run.

## 1. 🔴 The NEVER-PASTE rule covered ONE of the two fields that publish operator text

`clickhouse.rows[].first_msg` is the opening prompt of every recent session — operator-typed text, ~17 KB of it in a **default** scan — and no document in the skill tree mentioned it. The rule, both of its shipped copies, and the test pinning them all named `unsent_prompt` alone.

Nothing about the sentence was false. It was **narrower than the payload it governed**, which is worse than absent: it reads as complete and stops anyone looking. `claude/RULES.md` — *"a guard's DESCRIPTION claims COVERAGE — check the implementation is as wide as the sentence."*

Measured from git rather than asserted: the rule landed **2026-08-17**; `first_msg` has been in the payload since the tool's first commit, **2026-08-11**.

**Fix.** Widened in all three places a reader can hit it — `SKILL.md`, `reference/waiting-signal.md`, and `reference/clickhouse-queries.md` (new: a reader who opens the query page to write a query never passes the `unsent_prompt` section).

The width is now **checked, not written**. `_OPERATOR_TEXT_FIELDS` is an asserted ledger: every member must be NAMED in the core's rule, and each is bound to the code that produces it (`SQL_RECENT_SESSIONS`, `LEAN_ROW_FIELDS`) so the ledger cannot rot into fields that no longer exist. Its honest limit is stated in the source rather than implied — it cannot notice a third such field appearing on its own; what it buys is that adding one to the ledger, which is where anyone widening the rule starts, fails until the docs name it.

### Mutation-tested, each mutant dying on THIS guard's own assertion

| mutant | died on |
|---|---|
| ledger grows by an undocumented field | the width check, with its own message |
| the `clickhouse-queries.md` paragraph deleted | the `ch_ref` assertion |
| the query stops selecting `first_msg` | the ledger↔code binding |
| **the real regression** — rule narrowed back to `unsent_prompt` alone | BOTH this guard and the `PROTECTED_CLAIMS` pin |

Run under `PYTHONDONTWRITEBYTECODE=1`; all four files restored byte-identical afterwards (checksums verified).

## 2. The cost table was stale by >2×, and its own headline advice was the expensive path

Re-measured on a 77-row two-host scan:

| | SKILL.md said | actual |
|---|---|---|
| table | ~3,280 tok | 24,658 B ≈ 6.2k tok |
| `--json --lean` | ~9,629 tok | **79,008 B ≈ 20k tok** |
| `--json` | ~14,017 tok | 103,801 B ≈ 26k tok |

The file flagged its absolutes as stale and said only the ranking was load-bearing — the ranking does still hold. But the cause is **structural, not drift**: `--lean` trims ROW fields only. 39 KB of the lean payload is blocks it never touches — `clickhouse` 17.4 KB, `clawgate_queue` 12.7 KB (enumerated uncapped), `caveats` 4.3 KB, `ledger` 2.8 KB, `not_measured` 1.8 KB. So `--lean` alone buys 24% off the full payload, not the ~31% the old figures implied.

So a section titled *"you are the only consumer, and you pay by the token"* was recommending a 20k-token call while the single biggest lever — `--no-ch`, which drops a block answering session-history questions rather than "is anything waiting on me" — appeared only in the reference file.

**Fix.** `--no-ch` promoted into the core's flag table; the recommendation is now `--json --lean --no-ch`; the structural fact and the block-by-block breakdown are stated in both the core and `payload-contract.md`. Two smaller uncapped costs are now disclosed rather than advertised as features: `clawgate_queue` enumerates the whole queue, and `ledger.conflicts` is emitted twice (top-level and again per host).

## Budget

`SKILL.md` **16,200 → 16,191 B** — under its ceiling without raising it, per the gate's own eviction playbook. Paid for by compressing three passages whose full form already lives in the reference file that owns each (`fuzzyclaw-guard.md`, `clawgate-queue.md`) plus one piece of archaeology already present in the script's own comments. `MAX_BYTES` is untouched.

## Gate

Run by hand — there is no CI on this repo.

- **pytest tier** (`scripts/run-tests.sh` inside `nix develop`): `collected=14369 passed=14367 skipped=2 failed=0`, floor 13324, `RESULT: PASS (exit=0)`, no timeout panics. Counted from the SUMMARY block, not read off an exit code.
- **node tier** (`scripts/gate.sh`): `suites=4 files=33 tests=1119 pass=1119 fail=0`, floor 1098, `RESULT: PASS (exit=0)`.
- The `PROTECTED_CLAIMS` pin for this rule was updated in the same commit, as that gate's failure message instructs.

⚠ The pre-push hook did **not** fire on this push — `core.hooksPath` reads unset from the worktree. The gate above is mine, run by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
