### PR TITLE
fix(freeze): #616's hard-lockup panic has never been armed — powertop disables the NMI watchdog

### DIFF
--- a/claudedocs/handoff-laptop-freezes.md
+++ b/claudedocs/handoff-laptop-freezes.md
@@ -21,9 +21,20 @@ what is actually happening and make the next occurrence diagnosable.
 
 ## State now
 
-- **Branch:** `main`, clean, at `origin/main` (`29d7913e`).
+- **Branch:** `main`, clean, at `origin/main` (`dc7ebb7b`).
 - **The freeze cause is NOT resolved.** Everything below is instrumentation plus
-  one decoded crash trace. See *Open investigations*.
+  **two** decoded crash traces. See *Open investigations*.
+
+🔴 **2026-08-21 19:0x — A 17TH STOP HAPPENED, AND IT CHANGED TWO CONCLUSIONS.**
+Boot `-1` ran Aug 20 17:20 → **Aug 21 18:45:09** and ended with no shutdown
+sequence. It captured a dump. Two things came out of it:
+
+1. **#616's hard-lockup panic has never once been armed.** `kernel.nmi_watchdog`
+   reads **0** at steady state despite #616's TLP fix being correct and working.
+   `powertop --auto-tune` runs *after* TLP and writes 0 itself. So
+   `hardlockup_panic=1` has been dead code on every boot since #616 merged.
+2. **The memory-corruption hypothesis got much stronger**, from a second dump
+   with a *different* signature that nevertheless points the same way.
 
 **Merged and deployed this session**
 
@@ -35,13 +46,22 @@ what is actually happening and make the next occurrence diagnosable.
 | #679 | browser-bridge SKILL.md was 221 B over its ceiling — **main was red**, unrelated to this work | `test_skill_size.py` 4 passed; 11,961 B / 327 free |
 | #680 | staged `panic_on_oops=1` + a memtest86+ boot entry, plus the diagnosis doc | fixture-tested: edits land, idempotent, refuses-and-restores on a missing anchor |
 
-**Live state right now (laptop):**
+**Live state right now (laptop), measured 2026-08-21 after the 17th stop:**
 
 ```
-kernel.nmi_watchdog      1     kernel.panic           20
-kernel.hardlockup_panic  1     kernel.panic_on_oops    0   <- #680 not yet applied
-memtest boot entry       0                                 <- #680 not yet applied
+kernel.nmi_watchdog      0  <- 🔴 NOT 1. An earlier reading of 1 was taken
+                           #    before powertop.service had run. See below.
+kernel.hardlockup_panic  1  <- inert while nmi_watchdog=0
+kernel.panic            20
+kernel.panic_on_oops     0  <- #680 not yet applied
+memtest boot entry       0  <- #680 not yet applied
 ```
+
+🔴 **`nmi_watchdog=1` in the table above is a CORRECTION, not a regression.**
+The value genuinely was 1 when the earlier session read it — TLP had just been
+restarted. It is 0 in steady state because powertop runs later. Reading it once,
+right after touching TLP, could not see that; the value must be read *after* the
+boot sequence settles, or better, re-read after restarting the writer.
 
 **Deploy status, honestly:** #616 is applied and verified. #634/#671 are deployed
 and shipping on the **laptop**. #680 is **staged only** — it needs a `sudo` run.
@@ -55,10 +75,40 @@ doc, neither of which deploys.
 
 ## Open investigations — live diagnosis state
 
+### 🔴 The NMI watchdog is disabled by powertop — RESOLVED, fix staged
+
+- **Measured** (`nix/system/diagnose-freeze-2026-08-21.sh`, a discriminating
+  control — each unit restarted in isolation from a known value of 1):
+
+  | action | resulting `kernel.nmi_watchdog` |
+  |---|---|
+  | write 1 by hand (positive control) | 1 — the file *is* writable |
+  | `systemctl restart powertop.service` | **0** |
+  | `systemctl restart tlp.service` | **1** |
+
+  So powertop is the writer and TLP is innocent — #616's TLP fix is correct and
+  necessary, just not sufficient. `powerManagement.powertop.enable = true` is set
+  in `/etc/nixos/configuration.nix`, its unit is `After=multi-user.target` (i.e.
+  after TLP), and disabling the NMI watchdog is one of `--auto-tune`'s standard
+  tunables.
+
+- **Why this matters more than a stray sysctl:** the hard-lockup detector is what
+  *makes* `hardlockup_panic=1` fire. With `nmi_watchdog=0` the detector never
+  runs, so #616's headline mechanism — "a hard lockup now panics instead of
+  hanging silently" — has been inoperative on every boot since it merged. The
+  16th and 17th stops were both unwatched.
+- **Fix:** step 3 of `apply-freeze-followup-2026-08-21.sh` adds an
+  `ExecStartPost` to `powertop.service` re-asserting 1. Not yet applied.
+- 🔴 **Verify it by restarting the WRITER, not by reading the value.** A bare
+  `sysctl kernel.nmi_watchdog` right after a switch reads 1 for the same reason
+  the earlier session's reading did, and proves nothing:
+  `sudo systemctl restart powertop.service && sysctl kernel.nmi_watchdog`.
+
 ### Laptop stops uncleanly ~every 1–2 weeks; cause unproven
 
 - **Symptom + exact repro:** no repro. The machine stops without reaching
-  systemd's shutdown sequence. **16 occurrences** across the retained journal.
+  systemd's shutdown sequence. **17 occurrences** across the retained journal
+  (the 17th: Aug 21 18:45:09, boot `-1`).
   Classify with:
   `for b in $(seq -29 -1); do journalctl -b $b --no-pager | tail -12 | grep -q 'Journal stopped\|System Power Off\|Shutting down' || echo "$b UNCLEAN"; done`
 
@@ -83,6 +133,76 @@ doc, neither of which deploys.
   - Hardware: `Framework Laptop/FRANBMCP06, BIOS 03.17 10/27/2022`, i7-1165G7,
     64 GiB. Both `xe` (used_by=0) and `i915` (bound) are loaded.
 
+  - 🔴 **The SECOND captured trace, from the 2026-08-21 18:45 stop.** Five
+    decoded `dmesg.txt` files under `/var/lib/systemd/pstore/17873559{36,37,39}/`
+    (root-only; `diagnose-freeze-2026-08-21.sh` dumps them world-readable). The
+    pstore fragments are labelled `Oops#N PartM` in **descending** M — read them
+    bottom-up or the trace looks scrambled.
+
+    **First fault (`[#1]`), the only one that matters — the rest are fallout:**
+    ```
+    Oops: general protection fault, probably for non-canonical
+          address 0x4000000000000018: 0000 [#1] SMP NOPTI
+    CPU: 2  UID: 1000  PID: 2792101  Comm: alloy  Not tainted  7.0.0
+    RIP: 0010:timerqueue_add+0x37/0xd0
+    RAX: 4000000000000000  RCX: 4000000000000010  RDX: 4000000000000000
+    RSI: 0000533d7a14cfa8  R09/R11..R15: ffff8dde........  (sane heap ptrs)
+    Call Trace: epoll_pwait -> do_epoll_wait
+                -> schedule_hrtimeout_range_clock
+                -> hrtimer_start_range_ns -> timerqueue_add
+    ```
+    Decoding `Code:` — `48 89 d0` (`mov %rdx,%rax`), `48 8d 48 10`
+    (`lea 0x10(%rax),%rcx`), then the faulting `<48> 3b 70 18`
+    (`cmp 0x18(%rax),%rsi`). `RAX + 0x18 = 0x4000000000000018` = the reported
+    address exactly, so the decode is confirmed by arithmetic, not by eyeballing.
+    RDX is the rbtree node pointer loaded by the descent loop's `mov (%rcx),%rdx`.
+
+    **The finding: `0x4000000000000000` is NULL with exactly one bit set —
+    bit 62.** And NULL is precisely the value that belongs there: `timerqueue_add`
+    descends `while (*link)`, so the leaf's child pointer *is* NULL and is what
+    terminates the loop. One flipped bit turned the terminator into a
+    non-canonical pointer, the loop failed to stop, and it dereferenced it.
+    Corroborating that the surrounding state was otherwise healthy:
+    - every genuine kernel pointer in the frame reads `0xffff8dde…`/`0xffffd249…`
+      — only this one word is wrong;
+    - `RSI` (the new timer's expiry) `= 0x533d7a14cfa8` = 91,523.5 s, against an
+      uptime at fault of 91,522.67 s — an expiry 0.84 s in the future. **The
+      timer being inserted is perfectly sane; only the tree pointer is corrupt.**
+
+    **`Not tainted`** — unlike Jul 31. See the `Tainted: G W` section below.
+
+    Cascade after the first fault (all within ~20 ms, `[#2]`–`[#6]`):
+    `seq_read_iter` on CPU 5 (`.claude-wrapped`), `__queue_work` on CPU 1
+    (`tmux: server`), then `[#3]`–`[#6]` are `__show_trace_log_lvl` repeatedly
+    hitting `Thread overran stack, or stack corrupted` — the oops *printer*
+    blowing the stack while dumping the earlier oopses. Machine stopped.
+
+  - **The two dumps do NOT share a signature — and that is itself informative.**
+    Jul 31 was a page fault at `ct_kernel_enter_state` from the idle task on
+    CPU 4; Aug 21 is a GP fault at `timerqueue_add` from `alloy` on CPU 2.
+    Different subsystem, different CPU, different task, different fault class.
+    A software bug that reproduced twice would be expected to look alike; a
+    corrupted word landing wherever it happens to land would not. What the two
+    *do* share is shape: **a single 64-bit word carrying one anomalous high bit**
+    (bit 62 here; bit 34 in Jul 31's `RAX = 0x000000040001f30a`) where a pointer
+    belonged. Honest limit: the bit positions differ, so this is not a stuck bit
+    at one fixed position, and two samples cannot establish a distribution.
+
+  - **ECC cannot help here — checked, not assumed.** `igen6_edac v2.5.1` loads,
+    but `/sys/devices/system/edac/mc/` contains **no `mc0`**: the driver
+    registered no controller, i.e. Tiger Lake IBECC is disabled in firmware.
+    There are no correctable-error counters to read, so memtest86+ is the only
+    available discriminator. (`lsmem`: 66 G online; one `ee1004` SPD EEPROM at
+    `0-0050` enumerated, so this appears to be a single SODIMM — worth
+    confirming with `dmidecode -t memory` before planning any swap test.)
+
+  - Two lines immediately preceding the fault, unexplained and possibly relevant:
+    `[88942] perf: interrupt took too long (3941 > 3940), lowering
+    kernel.perf_event_max_sample_rate to 50000` and, ~600 µs before the oops,
+    `[91522.675527] Scheduler frequency invariance went wobbly, disabling!` —
+    the latter means the APERF/MPERF MSR ratio read implausibly. Not a diagnosis;
+    noted because it is the only anomaly in the seconds before the crash.
+
 - **Ruled out:**
   - *Memory pressure* — 62 GiB total, 40 GiB free, zero swap used, no OOM kills.
   - *Suspend/resume* — no sleep transition precedes the Aug 17 or Aug 20 stops.
@@ -96,11 +216,19 @@ doc, neither of which deploys.
   - Upstream search for `ct_kernel_enter_state` + double fault + lazy preempt
     found no matching report. Not evidence either way.
 
-- **Leading hypothesis:** **memory corruption.** A garbage value where a per-CPU
-  pointer belongs, hit from the idle task, across three kernel versions.
-  Honest limit: **one** dump for sixteen stops — attributing the rest is inference.
-  "Unclean" is a symptom count, not a diagnosis (covers flat battery, held power
-  button, panic).
+- **Leading hypothesis:** **memory corruption**, and the Aug 21 dump strengthens
+  it materially. The single-bit corruption of a word whose correct value (NULL)
+  is *known from the algorithm* is much tighter evidence than Jul 31's "this
+  pointer looks like garbage": here the expected value, the observed value, and
+  the one-bit distance between them are all pinned. Add that the two dumps differ
+  in every particular except that shape, and a software bug fits poorly.
+  Honest limits, unchanged in kind: **two** dumps for seventeen stops — attributing
+  the other fifteen is inference. "Unclean" is a symptom count, not a diagnosis
+  (covers flat battery, held power button, panic). And a bit flip observed in DRAM
+  *contents* does not by itself localise the fault to the DIMM — CPU, IMC, or
+  cache can corrupt a word in flight, and memtest86+ exercises all of them
+  together without separating them. A **clean** memtest is therefore the more
+  informative outcome, because it is the one that redirects the search.
 
 - **Next probe:** run the staged script, reboot, pick memtest86+ from the boot
   menu, let it complete **at least one full pass** (hours on 64 GiB).
@@ -109,21 +237,40 @@ doc, neither of which deploys.
   ```
   🔴 A short clean pass is **not** evidence of good RAM.
 
-### Unidentified `Tainted: G W` warning preceding the Jul 31 crash
+### Unidentified `Tainted: G W` warning preceding the Jul 31 crash — DOWNGRADED
 
-- **Observed:** the dump reads `Tainted: [W]=WARN`, so a WARN fired earlier in
-  that boot. Boot `-7`'s journal no longer retains it
+- **Observed:** the Jul 31 dump reads `Tainted: [W]=WARN`, so a WARN fired earlier
+  in that boot. Boot `-7`'s journal no longer retains it
   (`journalctl -b -7 -k | grep WARNING` → empty).
-- **Next probe:** nothing to run retroactively. With #680 applied, the next event
-  panics at the first fault and captures it, so the *first* symptom should be in
-  the next trace rather than lost behind hundreds of recursive frames.
+- 🔴 **The Aug 21 crash's first fault reads `Not tainted`**, and boot `-1`'s
+  journal contains **zero** `WARNING:`/`BUG:`/`Oops` lines across its whole
+  25-hour life. So an identical class of crash occurred with no preceding WARN:
+  **the earlier WARN was not a precondition.** Worth no further effort unless it
+  recurs. (`Tainted: [D]=DIE` on the Aug 21 *cascade* oopses is just the `[#1]`
+  oops having already happened — not a third signal.)
+- Note the same journal fact cuts against journald as a witness generally: the
+  freeze left **no kernel messages at all** in the final two minutes of boot `-1`.
+  pstore is the only channel that captured anything. Do not read an empty journal
+  as "nothing happened".
 
 ## Next steps (ranked)
 
 1. **Run the staged script + memtest** (command above). This is the discriminator.
-2. **If memtest is clean:** pin an older kernel and watch the rate. Note the rate
-   is ~1 stop per 1–2 weeks, so that experiment needs *weeks* — which is what
-   `host_unclean_boots_observed` is for.
+   It now carries the powertop fix too, so it arms the watchdog *and* stages the
+   memtest entry in one rebuild. After the rebuild and **before** rebooting into
+   memtest, confirm the watchdog survives its writer:
+   `sudo systemctl restart powertop.service && sysctl kernel.nmi_watchdog` → 1.
+2. **If memtest is clean:** it does *not* clear memory — it clears the DIMM under
+   memtest's access patterns. Before pinning an older kernel, prefer the cheaper
+   discriminators: (a) `dmidecode -t memory` to establish how many sticks there
+   are — if two, reseat and run one at a time, which is the only test that
+   localises; (b) check for a BIOS newer than 03.17 (10/27/2022) — this is a
+   2022 firmware on an 11th-gen Framework, and IMC/training fixes are exactly
+   the class of thing that shows up as rare single-bit corruption; (c) *then*
+   pin an older kernel. Note the rate is ~1 stop per 1–2 weeks, so a kernel
+   experiment needs *weeks* — which is what `host_unclean_boots_observed` is for.
+   🔴 Whatever you change, change **one** thing: at ~1 event per 1–2 weeks, two
+   simultaneous changes cost a month to disambiguate.
 3. **Converge the workbench** once another session frees `main` there, then
    `scripts/ship.sh` (it will pick up #680's files).
 4. **Optional:** alert on `host_boot_previous_clean == 0` → the existing
@@ -136,6 +283,25 @@ doc, neither of which deploys.
   generated `/etc/tlp.conf` and it falls back to its shipped `defaults.conf`. It
   re-applies on **every AC↔battery transition**, so the fix must live in
   `services.tlp.settings`, never `boot.kernel.sysctl`.
+- 🔴 **…and so does `powertop --auto-tune`, which runs AFTER TLP.** Fixing the
+  first writer and verifying the value immediately is how #616 shipped a fix that
+  read correct and was inert for weeks. The general lesson, worth more than the
+  sysctl: **for any value that a daemon owns, "I set it and read it back" is not
+  verification — restart every writer you know of and read it again.** Finding
+  one writer is not evidence there is only one; enumerate what else runs later
+  (`systemctl list-units`, ordering after `multi-user.target`).
+- 🔴 **An `Oops` beyond `[#1]` is fallout — read the FIRST one.** The Aug 21
+  capture has six, on three CPUs, in unrelated subsystems, spanning 20 ms. Four of
+  them are the stack-trace printer itself overrunning the stack. Diagnosing from
+  `[#3]` would have produced a confident, entirely wrong story about
+  `__show_trace_log_lvl`. Likewise pstore's `Oops#N PartM` fragments run
+  **descending in M**, so a naive `cat` reads the trace backwards.
+- **Decode `Code:` and check the arithmetic closes.** Both dumps were pinned this
+  way — computing the faulting address from the registers and matching it against
+  the kernel's own reported address. When those agree, the decode is proven rather
+  than plausible, and the register holding the corrupt value is identified
+  unambiguously. It is what turns "a pointer looks wrong" into "this specific
+  word differs from its correct value by one bit".
 - 🔴 **`panic_on_oops` was excluded from #616 and that was wrong.** The reasoning
   was "an oops is already logged; the silent case is the hard lockup". This
   machine's oops was neither survivable nor usefully logged. #680 reverses it.
@@ -166,6 +332,9 @@ doc, neither of which deploys.
 sysctl kernel.nmi_watchdog kernel.hardlockup_panic kernel.panic kernel.panic_on_oops
 grep NMI_WATCHDOG "$(readlink -f /etc/tlp.conf)"      # must be 1 — survives power events
 #    then move the charger and re-check nmi_watchdog
+# 🔴 the reading above is NOT sufficient for nmi_watchdog — restart its writers:
+sudo systemctl restart powertop.service && sysctl kernel.nmi_watchdog   # expect 1
+sudo systemctl restart tlp.service      && sysctl kernel.nmi_watchdog   # expect 1
 
 # 2. telemetry is shipping, and stdout is NOT
 systemctl --user status alloy node-exporter

--- a/nix/system/apply-freeze-followup-2026-08-21.sh
+++ b/nix/system/apply-freeze-followup-2026-08-21.sh
@@ -3,11 +3,40 @@
 #
 #   sudo bash nix/system/apply-freeze-followup-2026-08-21.sh
 #
-# Two changes, both consequences of reading the 2026-07-31 crash dump:
+# Three changes:
 #   1. kernel.panic_on_oops = 1   — reverses an explicit decision in #616
 #   2. a memtest86+ boot entry    — makes the leading hypothesis testable
+#   3. re-assert kernel.nmi_watchdog=1 after powertop — see below; ADDED after
+#      the 2026-08-21 18:45 freeze, which proved #616's headline fix inert
 #
 # Idempotent: safe to re-run.
+#
+# ── 🔴 #616'S HARD-LOCKUP PANIC HAS NEVER ONCE BEEN ARMED ───────────────────
+#
+# #616 set hardlockup_panic=1 and fixed TLP's NMI_WATCHDOG=0 default. That fix
+# is correct and it works. It is also not sufficient: `powertop --auto-tune`
+# runs AFTER TLP and writes 0 to /proc/sys/kernel/nmi_watchdog itself.
+#
+#     19:06:31  kernel: "NMI watchdog: Enabled"
+#     19:06:38  tlp:    "Applying power save settings...done."   (writes 1)
+#     19:06:38  powertop --auto-tune                             (writes 0)
+#     steady state: kernel.nmi_watchdog = 0
+#
+# Measured with a discriminating control on 2026-08-21 (both units restarted in
+# isolation, from a known value of 1):
+#
+#     after `systemctl restart powertop.service` -> 0
+#     after `systemctl restart tlp.service`      -> 1
+#
+# So powertop is the writer and TLP is innocent. hardlockup_panic=1 is DEAD
+# CODE while nmi_watchdog=0 — the detector never runs, so it can never fire the
+# panic. Every freeze since #616 has been unwatched.
+#
+# powertop.service is a `RemainAfterExit=yes` oneshot ordered
+# After=multi-user.target, so ExecStartPost is enough to re-assert the value
+# after it has done its tuning; TLP independently re-writes 1 on every AC<->BAT
+# transition, so the two together cover both the boot path and power events.
+# The rest of powertop's tuning is left alone — this reverses ONE tunable.
 #
 # ── WHY THIS REVERSES AN EARLIER DECISION ───────────────────────────────────
 #
@@ -67,7 +96,7 @@ fi
 
 BAK="$CFG.bak-oops-$(date +%Y%m%d-%H%M%S)"
 cp -a "$CFG" "$BAK"
-echo "[0/4] backed up $CFG -> $BAK"
+echo "[0/5] backed up $CFG -> $BAK"
 
 restore_on_err() {
   local rc=$?
@@ -88,7 +117,7 @@ require_one_match() { # <regex> <human name>
 
 # ---- 1. panic_on_oops ----------------------------------------------------
 if grep -qE '"kernel\.panic_on_oops"' "$CFG"; then
-  echo "[1/4] kernel.panic_on_oops already declared — skipping"
+  echo "[1/5] kernel.panic_on_oops already declared — skipping"
 else
   require_one_match '^[[:space:]]*boot\.kernel\.sysctl[[:space:]]*=' "boot.kernel.sysctl"
   line=$(grep -nE '^[[:space:]]*boot\.kernel\.sysctl[[:space:]]*=' "$CFG" | cut -d: -f1)
@@ -101,7 +130,7 @@ ${ind}# nix/system/apply-freeze-followup-2026-08-21.sh for the decoded trace.\\
 ${ind}\"kernel.panic_on_oops\" = 1;" "$CFG"
   grep -qE '"kernel\.panic_on_oops"[[:space:]]*=[[:space:]]*1;' "$CFG" \
     || { echo "ERROR: panic_on_oops edit did not apply" >&2; false; }
-  echo "[1/4] boot.kernel.sysctl: panic_on_oops=1"
+  echo "[1/5] boot.kernel.sysctl: panic_on_oops=1"
 fi
 
 # ---- 2. memtest86+ boot entry -------------------------------------------
@@ -113,7 +142,7 @@ fi
 # let it complete at least one full pass — a short run that finds nothing is not
 # evidence of good RAM.
 if grep -qE '^[[:space:]]*boot\.loader\.systemd-boot\.memtest86\.enable' "$CFG"; then
-  echo "[2/4] memtest86 boot entry already declared — skipping"
+  echo "[2/5] memtest86 boot entry already declared — skipping"
 else
   require_one_match '^[[:space:]]*boot\.loader\.systemd-boot\.enable' "boot.loader.systemd-boot.enable"
   line=$(grep -nE '^[[:space:]]*boot\.loader\.systemd-boot\.enable' "$CFG" | cut -d: -f1)
@@ -126,16 +155,46 @@ ${ind}# hypothesis. Budget hours: a full pass over 64 GiB is not quick.\\
 ${ind}boot.loader.systemd-boot.memtest86.enable = true;" "$CFG"
   grep -qE 'boot\.loader\.systemd-boot\.memtest86\.enable[[:space:]]*=[[:space:]]*true;' "$CFG" \
     || { echo "ERROR: memtest86 edit did not apply" >&2; false; }
-  echo "[2/4] boot.loader.systemd-boot.memtest86.enable = true"
+  echo "[2/5] boot.loader.systemd-boot.memtest86.enable = true"
 fi
 
-# ---- 3. Validate ---------------------------------------------------------
-if command -v nix-instantiate >/dev/null 2>&1; then
-  echo "[3/4] parsing $CFG ..."
-  nix-instantiate --parse "$CFG" >/dev/null
-  echo "[3/4] parse OK"
+# ---- 3. Re-assert the NMI watchdog after powertop -------------------------
+# Inserted at TOP LEVEL, immediately before `boot.kernel.sysctl = {`.
+#
+# NOT anchored on `powerManagement.powertop.enable` even though that is the
+# obviously related line: it sits at 4-space indent inside a nested block, so an
+# insertion there could land in the wrong attrset and still parse. The
+# boot.kernel.sysctl line is confirmed top-level (2-space indent).
+#
+# /run/current-system/sw/bin/sysctl rather than ${pkgs.procps}: this is inserted
+# by sed into a file whose `let` bindings we cannot see, so it must not depend
+# on any identifier being in scope.
+if grep -qE 'systemd\.services\.powertop\.serviceConfig\.ExecStartPost' "$CFG"; then
+  echo "[3/5] powertop ExecStartPost already declared — skipping"
 else
-  echo "[3/4] nix-instantiate unavailable — SKIPPING parse validation" >&2
+  require_one_match '^[[:space:]]*boot\.kernel\.sysctl[[:space:]]*=' "boot.kernel.sysctl"
+  line=$(grep -nE '^[[:space:]]*boot\.kernel\.sysctl[[:space:]]*=' "$CFG" | cut -d: -f1)
+  ind="$(sed -n "${line}p" "$CFG" | sed -E 's/^([[:space:]]*).*/\1/')"
+  sed -i "$((line - 1))a\\
+${ind}# 🔴 powertop --auto-tune writes 0 to /proc/sys/kernel/nmi_watchdog, AFTER\\
+${ind}# TLP has correctly written 1 (#616). That left hardlockup_panic=1 inert —\\
+${ind}# the hard-lockup detector was never running, so it could never fire the\\
+${ind}# panic. Confirmed 2026-08-21 by restarting each unit in isolation:\\
+${ind}# powertop -> 0, tlp -> 1. See nix/system/diagnose-freeze-2026-08-21.sh.\\
+${ind}systemd.services.powertop.serviceConfig.ExecStartPost =\\
+${ind}  \"/run/current-system/sw/bin/sysctl -w kernel.nmi_watchdog=1\";" "$CFG"
+  grep -qE 'systemd\.services\.powertop\.serviceConfig\.ExecStartPost' "$CFG" \
+    || { echo "ERROR: powertop ExecStartPost edit did not apply" >&2; false; }
+  echo "[3/5] systemd.services.powertop.serviceConfig.ExecStartPost = sysctl -w kernel.nmi_watchdog=1"
+fi
+
+# ---- 4. Validate ---------------------------------------------------------
+if command -v nix-instantiate >/dev/null 2>&1; then
+  echo "[4/5] parsing $CFG ..."
+  nix-instantiate --parse "$CFG" >/dev/null
+  echo "[4/5] parse OK"
+else
+  echo "[4/5] nix-instantiate unavailable — SKIPPING parse validation" >&2
 fi
 
 trap - ERR
@@ -146,7 +205,7 @@ echo "    diff -u $BAK $CFG"
 echo
 
 if [[ $EDIT_ONLY -eq 1 ]]; then
-  echo "[4/4] --edit-only: config edited and validated, nothing applied."
+  echo "[5/5] --edit-only: config edited and validated, nothing applied."
   exit 0
 fi
 
@@ -167,17 +226,28 @@ if [[ ${ans:-n} =~ ^[Yy]$ ]]; then
   # A `nixos-rebuild switch` does NOT restart systemd-sysctl
   # (NixOS/nixpkgs#289174), so the edit is inert until it is.
   systemctl restart systemd-sysctl
-  echo "[4/4] applied; restarted systemd-sysctl"
+  # Nor does it restart powertop.service: it is a RemainAfterExit oneshot that
+  # is already "active (exited)", so the new ExecStartPost would not run until
+  # the next boot. Deployed != restarted.
+  systemctl restart powertop.service
+  echo "[5/5] applied; restarted systemd-sysctl + powertop"
 else
-  echo "[4/4] Config edited and validated; nixos-rebuild NOT run. Run it when ready:"
-  echo "    sudo nixos-rebuild switch && sudo systemctl restart systemd-sysctl"
+  echo "[5/5] Config edited and validated; nixos-rebuild NOT run. Run it when ready:"
+  echo "    sudo nixos-rebuild switch \\"
+  echo "      && sudo systemctl restart systemd-sysctl powertop.service"
 fi
 
 echo
 echo "Verify:"
 echo "  sysctl kernel.panic_on_oops    # expect 1"
 echo "  sysctl kernel.panic            # expect 20  (set by #616)"
-echo "  sysctl kernel.nmi_watchdog     # expect 1   (set by #616)"
+echo "  sysctl kernel.nmi_watchdog     # expect 1   <- THE ONE THAT WAS 0."
+echo "                                 #    #616 alone did NOT achieve this;"
+echo "                                 #    powertop stomped it every boot."
+echo
+echo "  # and prove it SURVIVES the writer, rather than trusting the read above:"
+echo "  sudo systemctl restart powertop.service && sysctl kernel.nmi_watchdog"
+echo "                                 # STILL 1 — this is the real check"
 echo
 echo "Then REBOOT and pick the memtest86+ entry from the boot menu."
 echo "Let it finish at least one FULL pass over 64 GiB — hours, not minutes."

--- a/nix/system/diagnose-freeze-2026-08-21.sh
+++ b/nix/system/diagnose-freeze-2026-08-21.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Read-only diagnostic — LAPTOP host, 2026-08-21, after the 17th unclean stop.
+#
+#   sudo bash nix/system/diagnose-freeze-2026-08-21.sh
+#
+# Answers two questions this session cannot answer without root:
+#
+#   A. WHAT DID THE 2026-08-21 18:45 FREEZE CAPTURE?
+#      systemd-pstore archived three new records at 19:06 (epoch ~1787355936,
+#      which is 18:45:36 — the stop). The decoded dmesg.txt files are 0600 root.
+#      This is the first freeze WITH #616's instrumentation in place, so its
+#      trace is the highest-value evidence available.
+#
+#   B. WHO TURNS THE NMI WATCHDOG BACK OFF?
+#      kernel.nmi_watchdog reads 0 on this boot even though #616 put
+#      NMI_WATCHDOG=1 in TLP's config and TLP applied it. Observed timeline:
+#          19:06:31  kernel: "NMI watchdog: Enabled"
+#          19:06:38  tlp: "Applying power save settings...done."
+#          19:06:38  powertop --auto-tune ("Powertop tunings" finished)
+#          now:      /proc/sys/kernel/nmi_watchdog = 0
+#      powertop's binary contains the string /proc/sys/kernel/nmi_watchdog and
+#      --auto-tune disables it. That is a STRONG CORRELATION, NOT A PROOF — both
+#      units finished in the same second, so the journal cannot separate them.
+#      Section B runs the discriminating control: set the value to 1, restart
+#      ONLY powertop.service, and re-read. If it flips to 0, powertop is the
+#      writer. If it stays 1, it is not, and the search continues.
+#
+#      This matters more than it sounds: hardlockup_panic=1 (set by #616) is
+#      INERT while nmi_watchdog=0. The hard-lockup detector never runs, so it
+#      can never fire the panic. The instrumentation from #616 is, in its
+#      headline case, currently doing nothing.
+#
+# The only state this script writes is /proc/sys/kernel/nmi_watchdog, and it
+# restores the value it found. Everything else is a read.
+set -Eeuo pipefail
+
+[[ $EUID -eq 0 ]] || { echo "must run as root (sudo bash $0)"; exit 1; }
+
+OUT=${OUT:-/tmp/freeze-diag-2026-08-21.txt}
+: >"$OUT"
+chmod 644 "$OUT"
+exec > >(tee -a "$OUT") 2>&1
+
+echo "===================== A. CRASH DUMPS ====================="
+# Only the records archived on 2026-08-21 — the earlier ones (1785525502 etc.)
+# were already read in the 07-31 analysis and are in the handoff doc.
+found=0
+while IFS= read -r f; do
+  found=$((found + 1))
+  echo
+  echo "----- $f -----"
+  echo "(size: $(stat -c %s "$f") bytes, mtime: $(stat -c %y "$f"))"
+  cat "$f"
+done < <(find /var/lib/systemd/pstore/1787355936 \
+              /var/lib/systemd/pstore/1787355937 \
+              /var/lib/systemd/pstore/1787355939 \
+              -name 'dmesg.txt' 2>/dev/null | sort)
+
+echo
+echo "decoded dmesg.txt files found: $found"
+if [[ $found -eq 0 ]]; then
+  echo "🔴 ZERO decoded dumps. That is NOT 'the freeze left no trace' — the raw"
+  echo "   dmesg-efi_pstore-* fragments are still there. Falling back to them:"
+  find /var/lib/systemd/pstore/17873559?? -type f 2>/dev/null | sort | head -40
+fi
+
+echo
+echo "===================== B. NMI WATCHDOG WRITER ====================="
+NMIWD=/proc/sys/kernel/nmi_watchdog
+orig=$(cat "$NMIWD")
+echo "value now (before control): $orig"
+
+restore() { echo "$orig" >"$NMIWD" 2>/dev/null || true; }
+trap restore EXIT
+
+echo "--- positive control: can this file be written at all? ---"
+echo 1 >"$NMIWD"
+after_write=$(cat "$NMIWD")
+echo "wrote 1, reads back: $after_write"
+if [[ $after_write -ne 1 ]]; then
+  echo "🔴 The kernel REFUSED the write (reads $after_write). Neither TLP nor"
+  echo "   powertop is the cause — the hard-lockup detector is unavailable on"
+  echo "   this kernel/CPU (no usable PMU counter?). Stop here; section B's"
+  echo "   result below would be meaningless."
+  echo "   Check: dmesg | grep -i 'nmi watchdog'"
+  exit 0
+fi
+
+echo
+echo "--- the control: restart ONLY powertop.service ---"
+systemctl restart powertop.service
+sleep 2
+after_powertop=$(cat "$NMIWD")
+echo "after powertop.service restart: $after_powertop"
+
+echo
+echo "--- cross-check: restart ONLY tlp.service (should KEEP it at 1) ---"
+echo 1 >"$NMIWD"
+systemctl restart tlp.service
+sleep 2
+after_tlp=$(cat "$NMIWD")
+echo "after tlp.service restart:      $after_tlp"
+
+echo
+echo "===================== VERDICT ====================="
+if [[ $after_powertop -eq 0 && $after_tlp -eq 1 ]]; then
+  echo "CONFIRMED: powertop --auto-tune is the writer. TLP is correctly holding"
+  echo "it at 1 (#616 works); powertop runs after and stomps it."
+elif [[ $after_powertop -eq 1 && $after_tlp -eq 0 ]]; then
+  echo "UNEXPECTED: TLP is the writer and #616's NMI_WATCHDOG=1 is not taking"
+  echo "effect. Re-read /etc/tlp.conf and TLP's config precedence."
+elif [[ $after_powertop -eq 1 && $after_tlp -eq 1 ]]; then
+  echo "NEITHER unit clears it in isolation. The writer is something else, or it"
+  echo "only acts on a power-source transition. Next probe: move the charger and"
+  echo "re-read, then audit units ordered After=multi-user.target."
+else
+  echo "BOTH cleared it (powertop=$after_powertop tlp=$after_tlp). Treat powertop"
+  echo "as the boot-time writer and TLP as a second one; fix must cover both."
+fi
+
+echo
+echo "value restored on exit to: $orig"
+echo
+echo "Full output saved to $OUT (world-readable, so the session can read it)."


### PR DESCRIPTION
## What happened

The laptop hard-froze again on **2026-08-21 18:45:09** — the 17th unclean stop, and the first one since #616 landed the freeze instrumentation. It captured a dump. Reading it changed two conclusions.

## 1. 🔴 #616's hard-lockup panic has never once been armed

`kernel.nmi_watchdog` reads **0** at steady state, even though #616's TLP fix is correct and works. `powertop --auto-tune` is ordered `After=multi-user.target` — i.e. after TLP — and writes 0 itself.

**`hardlockup_panic=1` is dead code while `nmi_watchdog=0`**: the detector never runs, so it can never fire the panic. The 16th and 17th stops were both unwatched.

Measured with a discriminating control rather than inferred from the journal — both units log within the same second, so timestamps cannot separate them:

| action | resulting `kernel.nmi_watchdog` |
|---|---|
| write 1 by hand (positive control) | 1 — the file *is* writable |
| `systemctl restart powertop.service` | **0** |
| `systemctl restart tlp.service` | **1** |

### The fix

`apply-freeze-followup-2026-08-21.sh` gains step 3: an `ExecStartPost` on `powertop.service` re-asserting 1. Two details that are deliberate:

- **Anchored on the top-level `boot.kernel.sysctl` line**, not on `powerManagement.powertop.enable` — the latter sits at 4-space indent inside a nested block, where an insertion could land in the wrong attrset *and still parse*.
- **The script now restarts powertop after the rebuild.** It is a `RemainAfterExit` oneshot, so a switch alone leaves the new `ExecStartPost` unrun until the next boot.

The old verify block asserted `nmi_watchdog # expect 1 (set by #616)`, which was false. It now tells you to restart the writer and re-read — a bare read right after a switch returns 1 for the wrong reason, which is exactly how this shipped looking correct and stayed inert for weeks.

**The transferable lesson:** for a value some daemon owns, "I set it and read it back" is not verification. Restart every writer and read again — and finding one writer is not evidence there is only one.

## 2. The memory-corruption hypothesis got materially stronger

```
Oops: general protection fault, probably for non-canonical
      address 0x4000000000000018: 0000 [#1] SMP NOPTI
CPU: 2  UID: 1000  PID: 2792101  Comm: alloy  Not tainted  7.0.0
RIP: 0010:timerqueue_add+0x37/0xd0
RAX: 4000000000000000  RCX: 4000000000000010  RDX: 4000000000000000
RSI: 0000533d7a14cfa8  R09/R11..R15: ffff8dde........
Call Trace: epoll_pwait -> schedule_hrtimeout_range_clock
            -> hrtimer_start_range_ns -> timerqueue_add
```

`0x4000000000000000` is **NULL with exactly one bit set (bit 62)** — and NULL is precisely the value that belongs there: `timerqueue_add` descends `while (*link)`, so the leaf's child pointer is what terminates the loop. One flipped bit turned the terminator into a non-canonical pointer, the loop failed to stop, and it dereferenced it.

Supporting detail, all of it checkable:

- The decode is confirmed **by arithmetic**, not by eye: `RAX + 0x18` equals the kernel's own reported fault address.
- Every other pointer in the frame is a sane `0xffff8dde…`/`0xffffd249…` — one word is wrong, not the region.
- `RSI` (the new timer's expiry) `= 91,523.5 s` against an uptime at fault of `91,522.67 s` — an expiry 0.84 s out. **The timer being inserted is entirely normal; only the tree word is corrupt.**

The two dumps **share no signature** — Jul 31 was a page fault at `ct_kernel_enter_state` from the idle task on CPU 4; this is a GP fault at `timerqueue_add` from `alloy` on CPU 2. A software bug reproducing would be expected to look alike; a corrupted word landing wherever it lands would not. What they share is shape: one anomalous high bit where a pointer belonged (bit 62 here, bit 34 on Jul 31).

### Honest limits

- Two dumps for seventeen stops — attributing the other fifteen is inference.
- The bit positions differ, so this is **not** a stuck bit at a fixed position, and two samples are not a distribution.
- A bit flip in DRAM contents **does not localise the fault to the DIMM** — CPU, IMC or cache can corrupt a word in flight, and memtest86+ exercises all of them together without separating them. A *clean* memtest is the more informative outcome, because it is the one that redirects the search.
- ECC cannot arbitrate: `igen6_edac` loads but registers **no controller** (`/sys/devices/system/edac/mc` has no `mc0`), so IBECC is disabled in firmware. Checked, not assumed.

## Also

Downgrades the Jul 31 `Tainted: G W` thread: the Aug 21 first fault reads `Not tainted`, and boot `-1` carries **zero** `WARNING:`/`BUG:` lines across 25 hours. The earlier WARN was not a precondition.

Adds `diagnose-freeze-2026-08-21.sh` — the read-only root diagnostic that produced both results. It dumps the root-only pstore traces world-readable, runs the watchdog control with a positive control first, and restores the value it found.

## Verification performed

- **Fixture-tested** against a real `configuration.nix` copy: all three edits land at correct top-level indentation and `nix-instantiate --parse` passes; a re-run is **byte-identical** (idempotent); a missing anchor **refuses, restores the file, and exits 1** (re-measured directly after my first harness swallowed the exit code).
- The watchdog verdict comes from the control table above, with the positive control run *first* so a non-writable file could not masquerade as a result.

## NOT done

🔴 **Not applied.** Still needs `sudo bash nix/system/apply-freeze-followup-2026-08-21.sh`, then a reboot into memtest86+ for at least one full pass. Nothing in this PR changes a running system on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
