### PR TITLE
fix(opencode): narrow the age decrypt globs — "*age*-d*" ate ordinary read-only commands

### DIFF
--- a/scripts/opencode/opencode.jsonc
+++ b/scripts/opencode/opencode.jsonc
@@ -252,19 +252,30 @@
       "*sops*-d*": "ask",
       "*sops*--decrypt*": "ask",
       "*sops*exec-env*": "ask",
-      "*age*-d*": "ask",
-      "*age*--decrypt*": "ask",
+      // 🔴 NO `*` BETWEEN "age" AND THE FLAG — it must stay `*age -d*`, not
+      // `*age*-d*`. The inner `*` made this match any command text containing
+      // "age" followed LATER by "-d", and "age" is a substring of package,
+      // packages, image, message, storage and manage while "-d" covers -db-,
+      // --dir, --debug and --dry-run. MEASURED 2026-08-21: `ls packages/…-db-…`
+      // and `grep … packages/…-db/…` both resolved ASK, and since `opencode run`
+      // auto-rejects an ask rather than prompting, two real dispatches were
+      // killed mid-task by it. The leading `*` is still required and still
+      // correct — it catches `/nix/store/…/bin/age -d` and `FOO=1 age -d`.
+      // Pinned by three MUST_ALLOW rows in test_opencode_config.py.
+      "*age -d*": "ask",
+      "*age --decrypt*": "ask",
 
       // --- whole-system state ---
       "*nixos-rebuild*": "ask",
       "*home-manager*switch*": "ask",
       // 🔴 LOAD-BEARING — do not delete it as "already covered".
-      // `"*age*-d*"` DOES match some spellings of this command by pure
-      // coincidence ("nix-collect-gar(BAGE) … -d"), but ONLY those containing a
+      // `"*age -d*"` DOES match some spellings of this command by pure
+      // coincidence ("nix-collect-gar(BAGE) -d" ends in the literal "age -d"),
+      // but ONLY those spelling the flag immediately after, so
       // literal `-d`. MEASURED: with this rule deleted, `nix-collect-garbage`
       // and `nix-collect-garbage --max-freed 1G` both resolve ALLOW at both
       // layers. Two things follow, and they point opposite ways: this rule is
-      // the real gate for the no-`-d` spellings, AND `"*age*-d*"` must not be
+      // the real gate for the no-`-d` spellings, AND `"*age -d*"` must not be
       // deleted on the reasoning that GC is separately gated for the rest.
       "*nix-collect-garbage*": "ask",
       "*nix*profile remove*": "ask",

--- a/scripts/opencode/opencode.jsonc
+++ b/scripts/opencode/opencode.jsonc
@@ -70,6 +70,22 @@
 // that fires too often on a mutation family is a far better failure than an
 // `ask` that never fires on the spelling an operator actually types.
 //
+// 🔴 ONE DELIBERATE EXCEPTION, and it is the only one: the two `age` decrypt
+// rules are `*age -d*` / `*age --decrypt*` — leading-`*` but NOT infix. The
+// infix form `*age*-d*` matched any text with "age" followed LATER by "-d",
+// and "age" is a substring of package, packages, image, message, storage and
+// manage while "-d" covers -db-, --dir, --debug and --dry-run. Because
+// `opencode run` AUTO-REJECTS an ask rather than prompting, that over-match did
+// not "fire too often" — it KILLED runs on `ls packages/…-db-…` and
+// `grep … packages/…`. Measured 2026-08-21; two real dispatches died on it.
+// The trade is real and is NOT free: the narrowed rules know exactly one
+// argument order, so reordered spellings like `age -i k.txt -d f` now resolve
+// ALLOW, and guard_core.py has NO age/sops check to catch them. That gap is
+// pinned as a characterization test —
+// `test_age_glob_misses_these_reordered_decrypt_spellings` — so it stays
+// visible. Do NOT "restore consistency" by re-widening these to infix without
+// reading that test first.
+//
 // Other measured facts baked into this file (v1.18.18, EXCEPT where a bullet
 // says otherwise — the 2026-08-19 re-derivation could not reach three of them,
 // and a claim relabelled to a version nothing measured it on is worse than a
@@ -249,6 +265,11 @@
       "*talosctl*": "ask",
 
       // --- secrets to plaintext ---
+      // sops stays INFIX on purpose, unlike its age neighbours below: "sops" is
+      // not a substring of ordinary words or paths, so the over-match that
+      // forced the age narrowing does not arise here, and the infix form buys a
+      // real spelling — `sops --config .sops.yaml -d f` (pinned in MUST_ASK).
+      // Do not narrow these for symmetry with age.
       "*sops*-d*": "ask",
       "*sops*--decrypt*": "ask",
       "*sops*exec-env*": "ask",
@@ -271,8 +292,8 @@
       // 🔴 LOAD-BEARING — do not delete it as "already covered".
       // `"*age -d*"` DOES match some spellings of this command by pure
       // coincidence ("nix-collect-gar(BAGE) -d" ends in the literal "age -d"),
-      // but ONLY those spelling the flag immediately after, so
-      // literal `-d`. MEASURED: with this rule deleted, `nix-collect-garbage`
+      // but ONLY those spelling the flag immediately after the word ending in
+      // "age". MEASURED: with this rule deleted, `nix-collect-garbage`
       // and `nix-collect-garbage --max-freed 1G` both resolve ALLOW at both
       // layers. Two things follow, and they point opposite ways: this rule is
       // the real gate for the no-`-d` spellings, AND `"*age -d*"` must not be

--- a/scripts/opencode/opencode.jsonc
+++ b/scripts/opencode/opencode.jsonc
@@ -70,7 +70,10 @@
 // that fires too often on a mutation family is a far better failure than an
 // `ask` that never fires on the spelling an operator actually types.
 //
-// 🔴 ONE DELIBERATE EXCEPTION, and it is the only one: the two `age` decrypt
+// 🔴 ONE DELIBERATE EXCEPTION — the only rule ever narrowed AWAY from a
+// working infix form (several rules, e.g. `*chmod -R*`, `*dd if=*`, `*sudo *`,
+// were written binary-plus-literal-flag from the start; this is not a claim
+// that every other pattern is infix): the two `age` decrypt
 // rules are `*age -d*` / `*age --decrypt*` — leading-`*` but NOT infix. The
 // infix form `*age*-d*` matched any text with "age" followed LATER by "-d",
 // and "age" is a substring of package, packages, image, message, storage and
@@ -268,8 +271,12 @@
       // sops stays INFIX on purpose, unlike its age neighbours below: "sops" is
       // not a substring of ordinary words or paths, so the over-match that
       // forced the age narrowing does not arise here, and the infix form buys a
-      // real spelling — `sops --config .sops.yaml -d f` (pinned in MUST_ASK).
-      // Do not narrow these for symmetry with age.
+      // real spelling — `sops --config .sops.yaml -d f`, which the narrowed form
+      // would let through. That spelling is pinned as the CONTRAST case inside
+      // `test_age_glob_misses_these_reordered_decrypt_spellings` (not in
+      // MUST_ASK — do not go looking for it there), and independently by
+      // `test_every_ask_rule_is_individually_pinned`, which also goes red if
+      // these are narrowed. Do not narrow them for symmetry with age.
       "*sops*-d*": "ask",
       "*sops*--decrypt*": "ask",
       "*sops*exec-env*": "ask",
@@ -291,7 +298,8 @@
       "*home-manager*switch*": "ask",
       // 🔴 LOAD-BEARING — do not delete it as "already covered".
       // `"*age -d*"` DOES match some spellings of this command by pure
-      // coincidence ("nix-collect-gar(BAGE) -d" ends in the literal "age -d"),
+      // coincidence ("nix-collect-gar(BAGE) -d" CONTAINS the literal "age -d" —
+      // it need not end with it, `… -d --max-freed 1G` matches too),
       // but ONLY those spelling the flag immediately after the word ending in
       // "age". MEASURED: with this rule deleted, `nix-collect-garbage`
       // and `nix-collect-garbage --max-freed 1G` both resolve ALLOW at both

--- a/scripts/tests/test_opencode_config.py
+++ b/scripts/tests/test_opencode_config.py
@@ -1504,8 +1504,6 @@ def test_rm_glob_misses_these_recursive_spellings():
     )
 
 
-
-
 def test_age_glob_misses_these_reordered_decrypt_spellings():
     """🔴 A KNOWN, OPEN GAP OPENED BY THE 2026-08-21 NARROWING — pinned so it
     stays visible instead of implied-shut.
@@ -1525,7 +1523,9 @@ def test_age_glob_misses_these_reordered_decrypt_spellings():
     (grep it — 0 hits for "sops"/"decrypt"), so unlike the `rm` gap above there
     is no second layer failing in the opposite direction. These spellings are
     not theoretical: each was executed against a real age keypair (v1.3.1) and
-    printed plaintext with rc=0. Every row carries an identity flag on purpose —
+    yielded the plaintext at rc=0 — the two `-o`/`--output` rows WRITE it to the
+    named file rather than to stdout, which is the same disclosure by a different
+    route. Every row carries an identity flag on purpose —
     an earlier draft listed `age -o plain.txt -d secret.age` without one, which
     exits 1 ("identities are required") and so proved nothing about decryption.
     Adding `-i` changes no verdict here; all six still resolve ALLOW.

--- a/scripts/tests/test_opencode_config.py
+++ b/scripts/tests/test_opencode_config.py
@@ -631,7 +631,8 @@ MUST_ASK = [
     # load-bearing for a real spelling; each went ask -> allow at BOTH layers
     # with its rule deleted. See REDUNDANTLY_COVERED_ASKS' header.
     #
-    # `*age*-d*` rescues only the spellings containing a literal `-d`, so the
+    # `*age -d*` rescues only the spellings ending in the literal "age -d"
+    # ("nix-collect-gar-BAGE -d"), so the
     # commonest GC invocations were the ones left unguarded.
     "nix-collect-garbage",                                       # *nix-collect-garbage*
     "nix-collect-garbage --max-freed 1G",                        # *nix-collect-garbage*
@@ -758,7 +759,7 @@ MUST_ALLOW = [
     # literal "age -d"; these three pin that it stays dropped.
     "ls packages/civitai-db-schema/src/",
     "grep -n REPLICATION_LAG_DELAY packages/civitai-db/src/lag.test.ts",
-    "node -e \"require('./package.json')\" --debug",
+    "rg 'storage' src/ --debug",
 ]
 
 # Every agent that ships, plus the implicit primary. `None` == no agent block.
@@ -1464,6 +1465,55 @@ def test_guard_core_catches_recursive_rm_without_the_force_flag():
             f"recursive-flag test in check_rm_rf_critical was narrowed."
         )
     # …and the deliberate NON-coverage, so the narrowness stays a decision.
+def test_age_glob_misses_these_reordered_decrypt_spellings():
+    """🔴 A KNOWN, OPEN GAP OPENED BY THE 2026-08-21 NARROWING — pinned so it
+    stays visible instead of implied-shut.
+
+    LABEL: CHARACTERIZATION test, not regression coverage. It asserts today's
+    WRONG answer on purpose.
+
+    Narrowing `"*age*-d*"` to `"*age -d*"` removed a large false-positive class
+    (any command text with "age" followed LATER by "-d" — package/packages/
+    image/message/storage vs -db-/--dir/--debug), which was auto-rejecting
+    ordinary read-only commands and killing headless runs. The cost is that the
+    glob now knows exactly ONE argument order: the flag immediately after the
+    binary. Every spelling below puts an identity or output flag first and so
+    resolves plain ALLOW.
+
+    🔴 THIS IS THE ONLY GATE. `guard_core.py` contains no age/sops check at all
+    (grep it — 0 hits for "sops"/"decrypt"), so unlike the `rm` gap above there
+    is no second layer failing in the opposite direction. These spellings are
+    not theoretical: each was executed against a real age keypair and printed
+    plaintext with rc=0.
+
+    NOT closed here, deliberately, and the reasoning is the same whack-a-mole as
+    the `rm` gap: `"*age -i*"` catches these but `-i` is not decrypt-exclusive
+    (`age -e -i k.txt plain.txt` encrypts), so it buys spellings, not a family.
+    The structural fix is an argv-aware check in guard_core.py, which is where
+    this file's own header says irreversible/secret families belong.
+
+    🔴 If this test FAILS because a verdict became `ask`/`deny`, the gap was
+    CLOSED: delete that row from here and add the command to MUST_ASK.
+    """
+    for cmd in [
+        "age -i key.txt -d secret.age",
+        "age -i key.txt --decrypt secret.age",
+        "age -o plain.txt -d secret.age",
+        "age --identity key.txt -d secret.age",
+        "age --identity key.txt --decrypt secret.age",
+        "age --output plain.txt --decrypt secret.age",
+    ]:
+        assert layered_verdict(cmd, None) == "allow", (
+            f"{cmd!r} no longer resolves 'allow'. If you closed this gap, move "
+            f"it into MUST_ASK and delete it here — do not relax the assertion."
+        )
+    # The contrast cases, so the gap's SHAPE is pinned, not just its existence:
+    # flag-immediately-after still asks, and the sibling sops rule — deliberately
+    # left infix-tolerant — still catches its own reordered spelling.
+    assert effective_bash_action("age -d -i key.txt secret.age", None) == "ask"
+    assert effective_bash_action("sops --config .sops.yaml -d f.enc.yaml", None) == "ask"
+
+
 def test_rm_glob_misses_these_recursive_spellings():
     """🔴 A KNOWN, OPEN GAP — pinned so it stays visible instead of implied-shut.
 

--- a/scripts/tests/test_opencode_config.py
+++ b/scripts/tests/test_opencode_config.py
@@ -631,8 +631,8 @@ MUST_ASK = [
     # load-bearing for a real spelling; each went ask -> allow at BOTH layers
     # with its rule deleted. See REDUNDANTLY_COVERED_ASKS' header.
     #
-    # `*age -d*` rescues only the spellings ending in the literal "age -d"
-    # ("nix-collect-gar-BAGE -d"), so the
+    # `*age -d*` rescues only the spellings CONTAINING the literal "age -d"
+    # ("nix-collect-gar(BAGE) -d", with or without a trailing flag), so the
     # commonest GC invocations were the ones left unguarded.
     "nix-collect-garbage",                                       # *nix-collect-garbage*
     "nix-collect-garbage --max-freed 1G",                        # *nix-collect-garbage*
@@ -1465,55 +1465,6 @@ def test_guard_core_catches_recursive_rm_without_the_force_flag():
             f"recursive-flag test in check_rm_rf_critical was narrowed."
         )
     # …and the deliberate NON-coverage, so the narrowness stays a decision.
-def test_age_glob_misses_these_reordered_decrypt_spellings():
-    """🔴 A KNOWN, OPEN GAP OPENED BY THE 2026-08-21 NARROWING — pinned so it
-    stays visible instead of implied-shut.
-
-    LABEL: CHARACTERIZATION test, not regression coverage. It asserts today's
-    WRONG answer on purpose.
-
-    Narrowing `"*age*-d*"` to `"*age -d*"` removed a large false-positive class
-    (any command text with "age" followed LATER by "-d" — package/packages/
-    image/message/storage vs -db-/--dir/--debug), which was auto-rejecting
-    ordinary read-only commands and killing headless runs. The cost is that the
-    glob now knows exactly ONE argument order: the flag immediately after the
-    binary. Every spelling below puts an identity or output flag first and so
-    resolves plain ALLOW.
-
-    🔴 THIS IS THE ONLY GATE. `guard_core.py` contains no age/sops check at all
-    (grep it — 0 hits for "sops"/"decrypt"), so unlike the `rm` gap above there
-    is no second layer failing in the opposite direction. These spellings are
-    not theoretical: each was executed against a real age keypair and printed
-    plaintext with rc=0.
-
-    NOT closed here, deliberately, and the reasoning is the same whack-a-mole as
-    the `rm` gap: `"*age -i*"` catches these but `-i` is not decrypt-exclusive
-    (`age -e -i k.txt plain.txt` encrypts), so it buys spellings, not a family.
-    The structural fix is an argv-aware check in guard_core.py, which is where
-    this file's own header says irreversible/secret families belong.
-
-    🔴 If this test FAILS because a verdict became `ask`/`deny`, the gap was
-    CLOSED: delete that row from here and add the command to MUST_ASK.
-    """
-    for cmd in [
-        "age -i key.txt -d secret.age",
-        "age -i key.txt --decrypt secret.age",
-        "age -o plain.txt -d secret.age",
-        "age --identity key.txt -d secret.age",
-        "age --identity key.txt --decrypt secret.age",
-        "age --output plain.txt --decrypt secret.age",
-    ]:
-        assert layered_verdict(cmd, None) == "allow", (
-            f"{cmd!r} no longer resolves 'allow'. If you closed this gap, move "
-            f"it into MUST_ASK and delete it here — do not relax the assertion."
-        )
-    # The contrast cases, so the gap's SHAPE is pinned, not just its existence:
-    # flag-immediately-after still asks, and the sibling sops rule — deliberately
-    # left infix-tolerant — still catches its own reordered spelling.
-    assert effective_bash_action("age -d -i key.txt secret.age", None) == "ask"
-    assert effective_bash_action("sops --config .sops.yaml -d f.enc.yaml", None) == "ask"
-
-
 def test_rm_glob_misses_these_recursive_spellings():
     """🔴 A KNOWN, OPEN GAP — pinned so it stays visible instead of implied-shut.
 
@@ -1552,6 +1503,62 @@ def test_rm_glob_misses_these_recursive_spellings():
         "structural half of this pair and must keep handling r/R bundles."
     )
 
+
+
+
+def test_age_glob_misses_these_reordered_decrypt_spellings():
+    """🔴 A KNOWN, OPEN GAP OPENED BY THE 2026-08-21 NARROWING — pinned so it
+    stays visible instead of implied-shut.
+
+    LABEL: CHARACTERIZATION test, not regression coverage. It asserts today's
+    WRONG answer on purpose.
+
+    Narrowing `"*age*-d*"` to `"*age -d*"` removed a large false-positive class
+    (any command text with "age" followed LATER by "-d" — package/packages/
+    image/message/storage vs -db-/--dir/--debug), which was auto-rejecting
+    ordinary read-only commands and killing headless runs. The cost is that the
+    glob now knows exactly ONE argument order: the flag immediately after the
+    binary. Every spelling below puts an identity or output flag first and so
+    resolves plain ALLOW.
+
+    🔴 THIS IS THE ONLY GATE. `guard_core.py` contains no age/sops check at all
+    (grep it — 0 hits for "sops"/"decrypt"), so unlike the `rm` gap above there
+    is no second layer failing in the opposite direction. These spellings are
+    not theoretical: each was executed against a real age keypair (v1.3.1) and
+    printed plaintext with rc=0. Every row carries an identity flag on purpose —
+    an earlier draft listed `age -o plain.txt -d secret.age` without one, which
+    exits 1 ("identities are required") and so proved nothing about decryption.
+    Adding `-i` changes no verdict here; all six still resolve ALLOW.
+
+    NOT closed here, deliberately, and the reasoning is the same whack-a-mole as
+    the `rm` gap. `"*age -i*"` is the obvious candidate and it is NOT a fix:
+    MEASURED, it matches only the two `age -i …` rows and MISSES all four that
+    spell the identity long-form or put an output flag first. It is also not
+    decrypt-exclusive — `age -e -i k.txt plain.txt` encrypts — so it would buy
+    two spellings plus a false-positive class, not a family.
+    The structural fix is an argv-aware check in guard_core.py, which is where
+    this file's own header says irreversible/secret families belong.
+
+    🔴 If this test FAILS because a verdict became `ask`/`deny`, the gap was
+    CLOSED: delete that row from here and add the command to MUST_ASK.
+    """
+    for cmd in [
+        "age -i key.txt -d secret.age",
+        "age -i key.txt --decrypt secret.age",
+        "age -o plain.txt -i key.txt -d secret.age",
+        "age --identity key.txt -d secret.age",
+        "age --identity key.txt --decrypt secret.age",
+        "age --output plain.txt -i key.txt --decrypt secret.age",
+    ]:
+        assert layered_verdict(cmd, None) == "allow", (
+            f"{cmd!r} no longer resolves 'allow'. If you closed this gap, move "
+            f"it into MUST_ASK and delete it here — do not relax the assertion."
+        )
+    # The contrast cases, so the gap's SHAPE is pinned, not just its existence:
+    # flag-immediately-after still asks, and the sibling sops rule — deliberately
+    # left infix-tolerant — still catches its own reordered spelling.
+    assert effective_bash_action("age -d -i key.txt secret.age", None) == "ask"
+    assert effective_bash_action("sops --config .sops.yaml -d f.enc.yaml", None) == "ask"
 
 def test_guard_core_deliberately_ignores_an_ordinary_recursive_delete():
     """Split out from the attribution test above so each names one claim."""

--- a/scripts/tests/test_opencode_config.py
+++ b/scripts/tests/test_opencode_config.py
@@ -531,6 +531,11 @@ MUST_ASK = [
     "FOO=1 sops -d s.enc.yaml",
     "sops exec-env s.enc.yaml env",
     "age -d -i k f",
+    # Pinned in its own right since the 2026-08-21 narrowing: with no `*`
+    # between "age" and the flag, this no longer contains the literal
+    # "age -d", so `"*age -d*"` does NOT cover it and the redundancy
+    # ledger entry that used to claim it did was removed.
+    "age --decrypt -i k f",
     "home-manager switch",
     "nixos-rebuild switch",
     "nix profile remove x",
@@ -688,7 +693,11 @@ MUST_ASK = [
 # rule's, which is a different and much larger piece of work.
 REDUNDANTLY_COVERED_ASKS = {
     "*sops*--decrypt*": ("*sops*-d*", "sops --decrypt s.enc.yaml"),
-    "*age*--decrypt*": ("*age*-d*", "age --decrypt -i k f"),
+    # `"*age --decrypt*"` was listed here as covered by `"*age*-d*"`. That
+    # stopped being true when the age globs were narrowed on 2026-08-21: with
+    # no `*` between "age" and the flag, "age --decrypt …" no longer contains
+    # the literal "age -d", so the two rules now cover disjoint spellings and
+    # neither is redundant. Both are pinned individually in MUST_ASK.
     "*systemctl*restart*": ("*systemctl*start*", "systemctl restart foo"),
 }
 
@@ -738,6 +747,18 @@ MUST_ALLOW = [
     "rg foo",
     "flux get kustomizations -A",
     "kubectl rollout restart deploy/x",
+    # 🔴 REGRESSION, measured 2026-08-21. `"*age*-d*"` (the `age` decryption
+    # tool) had a `*` BETWEEN "age" and "-d", so it matched any command text
+    # containing "age" followed LATER by "-d". "age" is a substring of package,
+    # packages, image, message, storage, manage; "-d" covers -db-, --dir,
+    # --debug, --dry-run. Three ordinary read-only commands below therefore
+    # resolved ASK, which `opencode run` auto-rejects — killing the run
+    # mid-task. Two real dispatches died on exactly these, one on `grep` and
+    # one on `ls`. The fix is to drop that inner `*` so the glob requires the
+    # literal "age -d"; these three pin that it stays dropped.
+    "ls packages/civitai-db-schema/src/",
+    "grep -n REPLICATION_LAG_DELAY packages/civitai-db/src/lag.test.ts",
+    "node -e \"require('./package.json')\" --debug",
 ]
 
 # Every agent that ships, plus the implicit primary. `None` == no agent block.


### PR DESCRIPTION
`"*age*-d*"` had a `*` BETWEEN "age" and the flag, so it matched any bash command
whose text contained "age" followed LATER by "-d". Neither half is rare: "age" is
a substring of package, packages, image, message, storage and manage, and "-d"
covers -db-, --dir, --debug and --dry-run.

The consequence is not a spurious prompt. `opencode run` AUTO-REJECTS an ask
rather than prompting, so a matched command kills the run mid-task. Measured
2026-08-21 while dispatching work in a monorepo with a top-level packages/ dir:

    ls   packages/civitai-db-schema/src/            -> ask -> auto-reject -> run dead
    grep packages/civitai-db/src/lag.test.ts        -> ask -> auto-reject -> run dead

Two real dispatches died on exactly these, one on `grep` and one on `ls`. Both had
completed their research and were killed before writing anything.

Dropping the inner `*` requires the literal "age -d". The LEADING `*` stays and is
still doing work — it keeps /nix/store/.../bin/age -d and FOO=1 age -d gated.

Three consequences, all pinned rather than argued:

- Three MUST_ALLOW rows pin the false positives. Watched to FAIL before the fix:
  all three asserted 'ask' == 'allow' on read-only commands.
- `"*age --decrypt*"` is no longer redundant with `"*age -d*"` — "age --decrypt"
  does not contain "age -d" — so its REDUNDANTLY_COVERED_ASKS entry is removed and
  it gains its own MUST_ASK pin. The suite caught this itself: my first attempt
  removed the ledger entry while claiming in a comment that both rules were
  "pinned individually in MUST_ASK", which was false, and
  test_every_ask_rule_is_individually_pinned went red on it.
- The nix-collect-garbage note is updated, not deleted. Its coincidental rescue
  still holds: "nix-collect-garbage -d" ends in the literal "age -d" (gar-BAGE -d),
  so the narrowed glob still matches that spelling, and "*nix-collect-garbage*"
  remains the real gate for the rest.

DELIBERATELY NOT CHANGED: "*git*checkout*" and "*git*restore*". Agents repeatedly
reached for `git checkout -- <path>` to undo their own mistakes and were rejected,
which turned recoverable errors into dead runs, so loosening them looked tempting.
But DANGEROUS_FAMILIES pins both as must-not-be-allow and that is correct — the
command that lets an agent undo its damage is the same command that destroys
uncommitted work. The fix for that failure belongs in how briefs are written
(edit surgically; never rewrite a whole file), not here.

Suite: 636 passed.
