### PR TITLE
fix(gate): the merge-gating tier was RED on main — two guards that only work inside a git checkout

### DIFF
--- a/scripts/lib/subsystem_touch.py
+++ b/scripts/lib/subsystem_touch.py
@@ -5844,20 +5844,45 @@ def main(argv: Sequence[str] | None = None, *, today: str | None = None) -> int:
             return 0
 
         repo = Path(args.repo).resolve()
-        scope = args.scope if args.scope is not None else scope_for_repo(repo)
+
+        # 🔴 LAZY, and that is the entire point. `scope_for_repo` shells out to
+        # git, so deriving the scope EAGERLY made every subcommand require a git
+        # repo at cwd — including `--validate <file>`, which never reads the
+        # scope at all (it takes its policy scope from the file's own parent
+        # directory, below) and whose whole job is to answer "does this entry
+        # parse". MEASURED 2026-08-21: `--validate <file>` from a non-repo cwd
+        # exited 3 with "fatal: not a git repository", and the nix check sandbox
+        # runs at exactly such a cwd (`/build/src` is a copy, not a clone) — so
+        # the hermetic gate was RED on a path the dev host structurally could not
+        # exercise, because a dev host is always inside the repo.
+        #
+        # Memoized, so the paths that DO need it (the scope form, --template, and
+        # the report below) still pay for exactly one git call.
+        _scope_memo: list[str] = []
+
+        def scope_of() -> str:
+            if not _scope_memo:
+                _scope_memo.append(
+                    args.scope if args.scope is not None else scope_for_repo(repo)
+                )
+            return _scope_memo[0]
 
         if args.template is not None:
-            print(new_entry_template(normalize_ref(args.template), scope, today=stamp))
+            print(
+                new_entry_template(normalize_ref(args.template), scope_of(), today=stamp)
+            )
             return 0
 
         if args.validate is not None:
             if args.validate == VALIDATE_SCOPE:
+                scope = scope_of()
                 checked, malformed = validate_scope(args.store, scope)
                 policy_scope: str | None = scope
                 target = f"`{normalize_ref(scope)}/`"
                 scanned = [
                     Path(args.store) / normalize_ref(scope) / name for name in checked
                 ]
+                reported_scope: str | None = scope
             else:
                 bad = validate_entry_file(args.validate)
                 checked = (Path(args.validate).name,)
@@ -5865,11 +5890,15 @@ def main(argv: Sequence[str] | None = None, *, today: str | None = None) -> int:
                 policy_scope = Path(args.validate).parent.name
                 target = str(args.validate)
                 scanned = [Path(args.validate)]
+                # No scope, and NOT because it could not be derived: the
+                # single-file form is not scoped. Deriving one here is what made
+                # this branch need a git repo.
+                reported_scope = None
             path, basis = governing_policy(args.store, policy_scope or "")
             report = ValidationReport(
                 store_root=str(args.store),
                 target=target,
-                scope=scope if args.validate == VALIDATE_SCOPE else None,
+                scope=reported_scope,
                 checked=tuple(checked),
                 malformed=tuple(malformed),
                 policy_path=path,
@@ -5940,7 +5969,7 @@ def main(argv: Sequence[str] | None = None, *, today: str | None = None) -> int:
         report = build_report(
             source,
             args.store,
-            scope,
+            scope_of(),
             today=stamp,
             min_paths=args.min_paths,
             limit=args.limit,
@@ -5960,7 +5989,7 @@ def main(argv: Sequence[str] | None = None, *, today: str | None = None) -> int:
                 escalation=escalate_to_commit_window(
                     repo,
                     args.store,
-                    scope,
+                    scope_of(),
                     today=stamp,
                     min_paths=args.min_paths,
                     limit=args.limit,

--- a/scripts/tests/test_no_conflict_markers.py
+++ b/scripts/tests/test_no_conflict_markers.py
@@ -49,14 +49,49 @@ def _marker_lines(text: str) -> list[tuple[int, str]]:
     return hits
 
 
+# Directories a filesystem walk must never descend into. Only reachable on the
+# fallback path below; `git ls-files` already excludes every one of them.
+_WALK_SKIP_DIRS = frozenset(
+    {".git", "__pycache__", ".pytest_cache", "node_modules", "result"}
+)
+
+
 def _tracked_text_files() -> list[Path]:
+    """Every tracked text file — by `git ls-files` where that works, else a walk.
+
+    🔴 THE FALLBACK IS NOT A DEGRADATION, it is what makes this guard exist in
+    the tier that matters. MEASURED 2026-08-21: this ran `git ls-files` with
+    `check=True`, and the nix check sandbox builds from `/build/src` — a COPY of
+    the source, not a clone — so git exited 128 and the test ERRORED. This guard
+    was therefore structurally inert in the ONLY tier that gates a merge, which
+    is precisely the failure it was written to prevent (module docstring: a green
+    gate that cannot see the thing it forbids).
+
+    The fallback is faithful exactly where it fires: nix populates the flake
+    source from the git tree, so what is on disk in the sandbox IS the tracked
+    set. Where git answers we still prefer it, because a dev-host checkout also
+    carries ignored and untracked files that are none of this guard's business.
+
+    Either way the caller asserts the denominator, so a fallback that walked
+    nothing still cannot pass as a clean tree.
+    """
     out = subprocess.run(
         ["git", "-C", str(REPO), "ls-files", "-z"],
         capture_output=True,
         text=True,
-        check=True,
-    ).stdout
-    return [REPO / p for p in out.split("\0") if p]
+        check=False,
+    )
+    if out.returncode == 0:
+        return [REPO / p for p in out.stdout.split("\0") if p]
+
+    found: list[Path] = []
+    for path in REPO.rglob("*"):
+        if not path.is_file():
+            continue
+        if any(part in _WALK_SKIP_DIRS for part in path.relative_to(REPO).parts):
+            continue
+        found.append(path)
+    return found
 
 
 def test_no_tracked_file_carries_a_conflict_marker() -> None:
@@ -82,6 +117,44 @@ def test_no_tracked_file_carries_a_conflict_marker() -> None:
     assert not offenders, (
         f"{len(offenders)} conflict marker(s) in tracked files "
         f"(of {examined} examined):\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_it_still_scans_the_tree_when_git_cannot_answer(monkeypatch) -> None:
+    """🔴 REGRESSION, measured 2026-08-21: this guard ERRORED in the nix check.
+
+    `git ls-files` ran with `check=True`, and the check sandbox builds from
+    `/build/src` — a COPY of the source, not a clone — so git exited 128 and
+    raised. The guard was therefore dead in the ONE tier that gates a merge,
+    while passing on every dev host, which is the same shape of blindness the
+    module docstring exists to describe.
+
+    Simulates git refusing, then asserts the walk actually produced this repo's
+    files — not merely that nothing raised.
+    """
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(list(cmd))
+        if kwargs.get("check"):
+            # What the real subprocess.run does on a non-zero exit, which is the
+            # pre-fix behaviour this test must be able to see.
+            raise subprocess.CalledProcessError(128, cmd, output="", stderr="")
+        return subprocess.CompletedProcess(
+            cmd, 128, stdout="", stderr="fatal: not a git repository"
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    files = _tracked_text_files()
+
+    assert calls, "premise gone: it no longer asks git first"
+    assert len(files) > 500, (
+        f"the fallback walk produced only {len(files)} file(s) — it walked "
+        f"nothing useful, so the guard would report a vacuous clean tree"
+    )
+    assert REPO / "flake.nix" in files, "the walk did not reach this repo's root"
+    assert not [p for p in files if "__pycache__" in p.parts], (
+        "the walk descended into a skip directory"
     )
 
 

--- a/scripts/tests/test_subsystem_touch.py
+++ b/scripts/tests/test_subsystem_touch.py
@@ -4397,7 +4397,15 @@ class TestSessionMutationKillMatrix:
         falls back to git returns 0 and prints a plausible report — an answer to
         a question the caller did not ask, from a window that overlaps enough to
         look right. `/handoff` step 4 keys on the exit code, so this mutant would
-        cause a WRITE."""
+        cause a WRITE.
+
+        🔴 The payload says `scope_of()`, not `scope`: the scope is derived
+        lazily now, so a mutant naming the old local dies of UnboundLocalError —
+        a kill for the WRONG REASON, which proves nothing about this contract.
+        `scope_of()` returns exactly what `scope` used to hold, so the mutant
+        still means what it meant. `assert mod.main(argv) == 0` plus the
+        "collector" check below are what keep that honest: a mutant that merely
+        crashes fails them rather than passing quietly."""
         mod = _session_mutant(
             tmp_path,
             "ms_fallback",
@@ -4409,7 +4417,7 @@ class TestSessionMutationKillMatrix:
                     "    except (TouchError, ResolverError) as exc:\n"
                     '        print(f"subsystem-touch: {exc}", file=sys.stderr)\n'
                     "        print(render_text(build_report(collect_git_paths(repo), "
-                    "args.store, scope, today=stamp)))\n"
+                    "args.store, scope_of(), today=stamp)))\n"
                     "        return 0",
                 )
             ],
@@ -10703,6 +10711,44 @@ class TestValidateReportsUnreachableMarkers:
         )
         out = capsys.readouterr().out
         assert rc == 0
+        assert "MARKER(S) OUT OF REACH" in out
+
+    def test_the_SINGLE_FILE_form_needs_NO_git_repo_AT_CWD(
+        self, tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """🔴 REGRESSION, measured 2026-08-21. The scope was derived EAGERLY, and
+        `scope_for_repo` shells out to git — so this form exited 3 with "fatal:
+        not a git repository" from ANY cwd outside a checkout. The nix check
+        sandbox is exactly such a cwd (`/build/src` is a copy, not a clone), so
+        the hermetic gate that decides merges was red on a path a dev host
+        structurally cannot exercise: a dev host always runs inside the repo.
+
+        The single-file form never reads the scope — it takes its policy scope
+        from the file's own parent directory — so needing a repo was pure
+        coupling.
+
+        The non-repo cwd IS the test, so the premise is asserted rather than
+        assumed: a tmp dir that happened to sit inside a checkout would make this
+        pass without exercising anything.
+        """
+        store = _nuance_store(tmp_path, UNREACHABLE_NUANCE)
+
+        outside = tmp_path / "not-a-repo"
+        outside.mkdir()
+        monkeypatch.chdir(outside)
+        probe = subprocess.run(
+            ["git", "rev-parse", "--git-dir"], cwd=outside, capture_output=True
+        )
+        assert probe.returncode != 0, (
+            "premise gone: cwd resolves to a git repo, so this test cannot see "
+            "the defect it pins"
+        )
+
+        rc = st.main(
+            ["--store", str(store), "--validate", str(store / SCOPE / "collector.md")]
+        )
+        out = capsys.readouterr().out
+        assert rc == 0, f"exited {rc} outside a git repo; stdout={out!r}"
         assert "MARKER(S) OUT OF REACH" in out
 
     def test_the_CLI_json_carries_the_count_and_the_token(


### PR DESCRIPTION
## What was wrong

`nix build .#checks.x86_64-linux.pytests` — the hermetic tier `CLAUDE.md` names as authoritative — **failed on `main`**. Measured at `732db793`, still failing at `295753ae`. The dev-host runner passes both, which is why nobody saw it: nothing runs the hermetic gate on `main`, and there is no CI.

Both failures are the same shape — a check that quietly assumes it is running inside a git checkout. The check sandbox builds from `/build/src`, a **copy** of the source, not a clone.

| # | guard | what happened |
|---|---|---|
| 1 | `test_no_conflict_markers.py` | ran `git ls-files` with `check=True` → `CalledProcessError`, exit 128. The test **errored**, never ran. |
| 2 | `subsystem_touch.main()` | derived the scope eagerly via `scope_for_repo`, which shells out to git → `--validate <file>` exited 3 with `fatal: not a git repository`. |

(1) is the sharper one: that guard exists *because* of #653 — a conflict marker sat in `main` for days inside a docstring, where a green gate could not see it. It was then itself invisible in the only tier that gates a merge.

## Fixes

1. **`_tracked_text_files()` falls back to a filesystem walk when git cannot answer.** Faithful exactly where it fires — nix populates the flake source from the git tree, so what is on disk in the sandbox *is* the tracked set. Where git answers we still prefer it (a dev-host checkout also carries ignored/untracked files this guard has no business scanning). The caller still asserts the denominator, so a walk that found nothing cannot pass as a clean tree.
2. **Scope derivation is lazy and memoized.** The single-file `--validate` form never reads the scope — it takes its policy scope from the file's own parent directory — so the git coupling was gratuitous. Every path that genuinely needs a repo still pays for exactly one git call.

## Regression coverage

Both new tests were watched fail on pre-change code:

| test | at `295753ae` | at HEAD |
|---|---|---|
| `test_it_still_scans_the_tree_when_git_cannot_answer` | RED | GREEN |
| `test_the_SINGLE_FILE_form_needs_NO_git_repo_AT_CWD` | RED (`exited 3 outside a git repo`) | GREEN |

The second asserts its own premise (`git rev-parse` must actually refuse at that cwd) so it cannot pass vacuously from a tmp dir that happened to sit inside a checkout.

## One mutant had to be repaired, and that is worth reading

`TestSessionMutationKillMatrix::test_kills_the_NO_FALLBACK_contract` patches a replacement `except` body that **named `scope`**. Once the derivation went lazy, that mutant died of `UnboundLocalError` — a kill for the **wrong reason**, proving nothing about the contract. The payload now says `scope_of()`, which returns exactly what `scope` used to hold, so the mutant means what it meant. Caught only because the test asserts `mod.main(argv) == 0` and that the fallback actually produced output; a mutation harness that just checked "something failed" would have scored this green.

## Verification

```
nix build .#checks.x86_64-linux.pytests   →  exit 0
RESULT: PASS (exit=0)
TOTAL collected=14380  passed=14378  skipped=2  failed=0  (floor: 13324)
```

Both remaining skips are pinned in `EXPECTED_SKIPS`. Node tier untouched by this change (it was already PASS: 1119/1119).

🔴 **The pre-push tier was skipped deliberately** (`DEVRC_SKIP_TESTS=1`). It runs `--set all` against the real filesystem, which is the tier that wrote fixture commits onto `refs/heads/main` and overwrote `remote.origin.url` in the shared clone earlier today — the defect #673 / #676 / #683 are open against. The authoritative hermetic gate is green above; running the leaky tier to re-confirm it was not worth corrupting shared git state for.

## Not in scope

The third cause of the red gate — an unpinned `SIGNAL_PG_DSN` skip from #657 — was fixed on `main` concurrently while this was in progress.