### PR TITLE
fix(gate): conditional EXPECTED_SKIPS entries — a set SIGNAL_PG_DSN meant a permanently red gate

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1692,14 +1692,24 @@ _nolaunch_ack_reason() {
 # the same way TARGET_FLOORS' two-way pin is tested.
 
 # --- GUARD 2: the pinned expected-skip set -------------------------------------
-# One "<dir>|<reason-regex>" per LEGITIMATELY skipped test. Both halves must match
-# a pytest `SKIPPED [n] <path>:<line>: <reason>` line, and the skip TOTAL must
-# equal the number of entries. Adding an entry is a deliberate act of accounting
-# — do it only when the skip is genuinely unavoidable, and say why.
+# An entry is "<dir>|<reason-regex>" or "<dir>|<reason-regex>|unset:VAR" per
+# LEGITIMATELY skipped test. `dir` and `reason` must both match a pytest
+# `SKIPPED [n] <path>:<line>: <reason>` line, and the skip TOTAL must equal the
+# number of entries THAT APPLY HERE — not the raw entry count. Adding an entry is
+# a deliberate act of accounting — do it only when the skip is genuinely
+# unavoidable, and say why.
 #
-# Built AFTER $HOME is settled: an entry may be conditional, but its condition
+# Built AFTER $HOME is settled: an entry may be conditional, and its condition
 # must be the SAME predicate the test itself uses — never a blanket allowance,
 # or the pin degrades into the numeric ceiling it exists to beat.
+#
+# 🔴 The third field is what makes that promise real. Without it the accounting
+# compared the skip total against a FLAT entry count, so on a host where a pinned
+# skip legitimately RUNS the gate went red — and the advice it printed ("delete
+# its EXPECTED_SKIPS entry") is wrong for a host-conditional pin, because
+# deleting it reds every OTHER host. `unset:VAR` means "expected only where VAR
+# is unset or empty". One predicate — `_skip_entry_applies` — decides both the
+# count and the forgiveness, so the two cannot drift apart.
 EXPECTED_SKIPS=(
   # Opt-in drift check against the LIVE homelab store — needs a kubeconfig and
   # network, neither of which a hermetic gate may have. Skips everywhere unless
@@ -2049,35 +2059,68 @@ _split_skip_entry() {
   if [ "$_rest" = "$ere" ]; then econd=""; else econd="${_rest#*|}"; fi
 }
 
-# Count only the entries whose condition HOLDS here. An unrecognised condition is
-# a hard error, never a silent "treat as unconditional" — a typo must not quietly
-# turn a conditional pin into a permanent one.
+# 🔴 ONE predicate, used by BOTH the counting loop and the matching loop below.
+# They previously evaluated applicability separately — counting honoured the
+# condition, matching ignored it — so a skip could be forgiven by a pin the
+# ledger said did not apply, and the totals still balanced. A rule open-coded at
+# two sites is wrong at one of them; this is the consolidation.
+#
+# Reads the `edir`/`ere`/`econd` that `_split_skip_entry` just set. Returns 0 if
+# the entry applies HERE, 1 if not. An invalid condition sets `fail` and returns
+# 1 — fail CLOSED, so a typo cannot silently widen a pin.
+_skip_entry_applies() {
+  case "$econd" in
+    "") return 0 ;;
+    unset:*)
+      local _v="${econd#unset:}"
+      # 🔴 VALIDATE BEFORE EXPANDING. `${!_v-}` on a non-identifier (a bare
+      # `unset:`, or a 4-field entry leaving `unset:FOO|typo`) raises bash's
+      # `invalid variable name`, and that error ABORTS THE ENCLOSING LOOP — every
+      # later entry goes silently unevaluated and `fail` stays 0. A typo in the
+      # pipe-delimited grammar is the LIKELIER shape than an unknown prefix, so
+      # it must not be the one that fails open.
+      if ! printf '%s' "$_v" | grep -qE '^[A-Za-z_][A-Za-z0-9_]*$'; then
+        echo "  ERROR: EXPECTED_SKIPS condition names an invalid variable: '$_v'" >&2
+        echo "         Expected 'unset:VAR' with VAR matching [A-Za-z_][A-Za-z0-9_]*." >&2
+        fail=1
+        return 1
+      fi
+      # `-z` is unset-OR-EMPTY. That is correct here — it mirrors the pinned
+      # test's own `not os.environ.get(...)` — but a future test using
+      # `"VAR" in os.environ` would disagree, so match the predicate you pin.
+      if [ -z "${!_v-}" ]; then return 0; fi
+      return 1
+      ;;
+    *)
+      echo "  ERROR: EXPECTED_SKIPS entry has an unknown condition: '$econd'" >&2
+      echo "         Supported: 'unset:VAR'." >&2
+      fail=1
+      return 1
+      ;;
+  esac
+}
+
+# Count only the entries whose condition HOLDS here.
 # NOTE (pre-existing, deliberately not changed here): this compares a count of
 # skipped TESTS against a count of ENTRIES, which assumes one test per entry.
 # Both current entries are `SKIPPED [1]`. Widening that is a separate change.
 pin_expected=0
 for entry in "${EXPECTED_SKIPS[@]}"; do
   _split_skip_entry "$entry"
-  case "$econd" in
-    "") pin_expected=$(( pin_expected + 1 )) ;;
-    unset:*)
-      _v="${econd#unset:}"
-      # Indirect expansion: the VALUE of the variable NAMED by $_v, empty when
-      # unset. `$_v` alone is the NAME and always non-empty.
-      [ -z "${!_v-}" ] && pin_expected=$(( pin_expected + 1 ))
-      ;;
-    *)
-      echo "  ERROR: EXPECTED_SKIPS entry has an unknown condition: '$econd'" >&2
-      echo "         Supported: 'unset:VAR'. Entry: $entry" >&2
-      fail=1
-      ;;
-  esac
+  if _skip_entry_applies; then pin_expected=$(( pin_expected + 1 )); fi
 done
 
 for line in "${SKIP_LINES[@]}"; do
   matched=0
   for entry in "${EXPECTED_SKIPS[@]}"; do
     _split_skip_entry "$entry"
+    # 🔴 A pin that does NOT apply here must not forgive anything. Without this,
+    # the two halves of the accounting disagree: `pin_expected` excludes the
+    # entry while this loop still matches on it, so a skip the ledger says
+    # cannot happen here is silently absorbed and the totals still balance.
+    # Measured before the fix: with SIGNAL_PG_DSN set, the signal skip was
+    # forgiven by a pin whose own condition said it could not apply — green.
+    if ! _skip_entry_applies; then continue; fi
     # "SKIPPED [n] <path>:<line>: <reason>" — require BOTH the owning directory
     # and the reason, so a skip that migrates to another suite is not absorbed.
     if printf '%s\n' "$line" | grep -qE "\] $edir/" && printf '%s\n' "$line" | grep -qE "$ere"; then

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1716,7 +1716,11 @@ EXPECTED_SKIPS=(
   # never runs in the gate. The regression it guards is caught only when someone
   # runs with SIGNAL_PG_DSN set. Pinning unbreaks main; it does not restore the
   # coverage.
-  "scripts/signal/tests|needs a real Postgres"
+  # CONDITIONAL: expected only where the DSN is absent. Without the third field
+  # this pin made the gate permanently RED for any developer who exports
+  # SIGNAL_PG_DSN — the test then RUNS, the skip total drops to 1, and the flat
+  # entry count still said 2.
+  "scripts/signal/tests|needs a real Postgres|unset:SIGNAL_PG_DSN"
 )
 # ⚠ REMOVED, deliberately — do not re-add. `scripts/tests/test_skill_audit.py`
 # carried two regression pins against the LIVE datapacket-talos skill corpus, a
@@ -2019,11 +2023,61 @@ else
 fi
 
 unexpected=()
+# --- CONDITIONAL LEDGER ENTRIES ------------------------------------------------
+# An entry is `dir|reason` or `dir|reason|unset:VAR`. The third field makes the
+# pin CONDITIONAL: it is expected only where VAR is unset.
+#
+# 🔴 WHY. The header above already promises this ("an entry may be conditional"),
+# and the implementation compared the skip TOTAL against a flat entry COUNT, so a
+# host where a pinned skip legitimately RUNS went red — and the runner's own
+# advice there is "delete its EXPECTED_SKIPS entry", which is WRONG for a
+# host-conditional pin: deleting it reds every other host. Measured consequence:
+# any developer with SIGNAL_PG_DSN exported had a permanently-red gate and no
+# correct way to unbreak it, i.e. the state that teaches people to pass
+# DEVRC_SKIP_TESTS=1. A permanently-red gate is worse than no gate.
+#
+# 🔴 PARSING, and why it is not `${entry#*|}`. That takes everything after the
+# FIRST `|`, so on a 3-field entry the reason would become `reason|unset:VAR` —
+# fed straight to `grep -qE`, where `|` is ALTERNATION. The matcher would then
+# accept any skip whose reason contained EITHER side, silently widening the pin
+# instead of narrowing it. Split explicitly.
+_split_skip_entry() {
+  local _e="$1" _rest
+  edir="${_e%%|*}"
+  _rest="${_e#*|}"
+  ere="${_rest%%|*}"
+  if [ "$_rest" = "$ere" ]; then econd=""; else econd="${_rest#*|}"; fi
+}
+
+# Count only the entries whose condition HOLDS here. An unrecognised condition is
+# a hard error, never a silent "treat as unconditional" — a typo must not quietly
+# turn a conditional pin into a permanent one.
+# NOTE (pre-existing, deliberately not changed here): this compares a count of
+# skipped TESTS against a count of ENTRIES, which assumes one test per entry.
+# Both current entries are `SKIPPED [1]`. Widening that is a separate change.
+pin_expected=0
+for entry in "${EXPECTED_SKIPS[@]}"; do
+  _split_skip_entry "$entry"
+  case "$econd" in
+    "") pin_expected=$(( pin_expected + 1 )) ;;
+    unset:*)
+      _v="${econd#unset:}"
+      # Indirect expansion: the VALUE of the variable NAMED by $_v, empty when
+      # unset. `$_v` alone is the NAME and always non-empty.
+      [ -z "${!_v-}" ] && pin_expected=$(( pin_expected + 1 ))
+      ;;
+    *)
+      echo "  ERROR: EXPECTED_SKIPS entry has an unknown condition: '$econd'" >&2
+      echo "         Supported: 'unset:VAR'. Entry: $entry" >&2
+      fail=1
+      ;;
+  esac
+done
+
 for line in "${SKIP_LINES[@]}"; do
   matched=0
   for entry in "${EXPECTED_SKIPS[@]}"; do
-    edir="${entry%%|*}"
-    ere="${entry#*|}"
+    _split_skip_entry "$entry"
     # "SKIPPED [n] <path>:<line>: <reason>" — require BOTH the owning directory
     # and the reason, so a skip that migrates to another suite is not absorbed.
     if printf '%s\n' "$line" | grep -qE "\] $edir/" && printf '%s\n' "$line" | grep -qE "$ere"; then
@@ -2043,11 +2097,12 @@ if [ "${#unexpected[@]}" -gt 0 ]; then
   fail=1
 fi
 
-if [ "$TOT_SKIPPED" -ne "${#EXPECTED_SKIPS[@]}" ]; then
-  echo "  ERROR: $TOT_SKIPPED test(s) skipped, but ${#EXPECTED_SKIPS[@]} are pinned in EXPECTED_SKIPS." >&2
-  if [ "$TOT_SKIPPED" -lt "${#EXPECTED_SKIPS[@]}" ]; then
+if [ "$TOT_SKIPPED" -ne "$pin_expected" ]; then
+  echo "  ERROR: $TOT_SKIPPED test(s) skipped, but $pin_expected of ${#EXPECTED_SKIPS[@]} pinned entries apply here." >&2
+  if [ "$TOT_SKIPPED" -lt "$pin_expected" ]; then
     echo "         FEWER than pinned: a pinned skip now RUNS (good) — delete its" >&2
-    echo "         EXPECTED_SKIPS entry so the pin keeps meaning something." >&2
+    echo "         EXPECTED_SKIPS entry, or make it conditional with '|unset:VAR'" >&2
+    echo "         if it only skips where that variable is absent." >&2
   else
     echo "         MORE than pinned: tests stopped running. See the skip list above." >&2
   fi

--- a/scripts/tests/test_conditional_skip_pins.py
+++ b/scripts/tests/test_conditional_skip_pins.py
@@ -1,0 +1,175 @@
+"""🔒 Conditional `EXPECTED_SKIPS` entries (`dir|reason|unset:VAR`).
+
+WHY THIS FILE EXISTS. The `EXPECTED_SKIPS` header has always promised that "an
+entry may be conditional", while the accounting compared the skipped-TEST total
+against a flat entry COUNT. So on a host where a pinned skip legitimately RUNS,
+the gate went RED — and the advice it printed ("delete its EXPECTED_SKIPS entry")
+is WRONG for a host-conditional pin, because deleting it reds every other host.
+Measured: any developer exporting `SIGNAL_PG_DSN` had a permanently-red gate with
+no correct way to unbreak it. A permanently-red gate is worse than no gate — it
+is what teaches people to pass `DEVRC_SKIP_TESTS=1`.
+
+🔴 THESE TESTS EXECUTE THE SHIPPED CODE. Each one extracts the real block out of
+`scripts/run-tests.sh` and runs it under bash with synthetic inputs. That is
+deliberate and it is the point: a previous attempt at this area asserted only
+that certain STRINGS appeared in the script, and every one of those assertions
+was satisfied by the identical string sitting in a COMMENT two lines above the
+code — a guard that passed with the code under it mutated. Substring checks
+against a shell script are not tests of that script.
+
+🔴 NO `git ls-files` HERE. `nix flake check` builds `checks.pytests` from a
+tracked-file copy with NO `.git`; an unguarded `git` call exits 128 and reds the
+hermetic tier while the pre-push tier (which has `.git`) stays green. That
+two-tier blind spot is documented in `test_doc_path_rot.py` and has bitten this
+repo before. This file only reads `run-tests.sh`.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+RUNNER = REPO / "scripts" / "run-tests.sh"
+
+
+def _runner_text() -> str:
+    return RUNNER.read_text(encoding="utf8")
+
+
+def _extract(start: str, end: str) -> str:
+    """Lift a verbatim block out of run-tests.sh, so the code under test is the
+    code that ships. Fails loudly rather than returning an empty string — an
+    empty harness would make every assertion below pass vacuously."""
+    txt = _runner_text()
+    i = txt.index(start)
+    j = txt.index(end, i)
+    block = txt[i:j]
+    assert block.strip(), f"extracted an EMPTY block for {start!r}"
+    return block
+
+
+def _bash(script: str, env_extra: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    import os
+    env = dict(os.environ)
+    # Start from a known state: the variable under test must be genuinely absent
+    # unless a case sets it, or "unset" cases would silently test "set".
+    env.pop("ZZ_PROBE_DSN", None)
+    env.update(env_extra or {})
+    return subprocess.run(["bash", "-uo", "pipefail", "-c", script],
+                          capture_output=True, text=True, env=env)
+
+
+SPLIT_FN = None
+
+
+def _split_fn() -> str:
+    global SPLIT_FN
+    if SPLIT_FN is None:
+        SPLIT_FN = _extract("_split_skip_entry() {", "\n}\n") + "\n}\n"
+    return SPLIT_FN
+
+
+# --------------------------------------------------------------------------
+# The parser — including the alternation trap that motivated it.
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("entry,want_dir,want_re,want_cond", [
+    ("scripts/x/tests|some reason", "scripts/x/tests", "some reason", ""),
+    ("scripts/x/tests|some reason|unset:FOO", "scripts/x/tests", "some reason", "unset:FOO"),
+    # A reason containing a regex alternation must survive intact.
+    ("scripts/x/tests|a or b|unset:FOO", "scripts/x/tests", "a or b", "unset:FOO"),
+])
+def test_split_parses_two_and_three_field_entries(entry, want_dir, want_re, want_cond):
+    r = _bash(_split_fn() + f'''
+      _split_skip_entry {entry!r}
+      printf '%s\\n%s\\n%s\\n' "$edir" "$ere" "$econd"
+    ''')
+    assert r.returncode == 0, r.stderr
+    got_dir, got_re, got_cond = r.stdout.split("\n")[:3]
+    assert (got_dir, got_re, got_cond) == (want_dir, want_re, want_cond)
+
+
+def test_three_field_entry_does_not_leak_the_condition_into_the_regex():
+    """🔴 The trap this parser exists for. `${entry#*|}` takes everything after
+    the FIRST `|`, so a 3-field entry would yield `reason|unset:VAR` — and that
+    string goes to `grep -qE`, where `|` is ALTERNATION. The matcher would then
+    accept any skip whose reason contained EITHER side, silently WIDENING the
+    pin. Asserts the reason is exactly the middle field, with no `|` in it."""
+    r = _bash(_split_fn() + '''
+      _split_skip_entry "scripts/x/tests|needs a real Postgres|unset:SIGNAL_PG_DSN"
+      printf '%s' "$ere"
+    ''')
+    assert r.returncode == 0, r.stderr
+    assert r.stdout == "needs a real Postgres"
+    assert "|" not in r.stdout, "the condition leaked into the grep -E pattern"
+
+
+# --------------------------------------------------------------------------
+# The counting loop — driven, not grepped. Both arms.
+# --------------------------------------------------------------------------
+
+def _count_harness(entries: list[str]) -> str:
+    loop = _extract("pin_expected=0", "\nfor line in ")
+    decl = "\n".join(f'  {e!r}' for e in entries)
+    return textwrap.dedent(f"""
+        fail=0
+        EXPECTED_SKIPS=(
+        {decl}
+        )
+    """) + _split_fn() + loop + '\nprintf "%s %s\\n" "$pin_expected" "$fail"\n'
+
+
+def test_unconditional_entry_always_counts():
+    r = _bash(_count_harness(["scripts/a/tests|plain"]))
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.split() == ["1", "0"]
+
+
+def test_conditional_entry_counts_only_when_the_var_is_UNSET():
+    """Both arms. The forgiving arm alone proves nothing — the whole defect was a
+    count that was right in one environment and wrong in the other."""
+    harness = _count_harness(["scripts/a/tests|needs pg|unset:ZZ_PROBE_DSN"])
+
+    unset_arm = _bash(harness)
+    assert unset_arm.returncode == 0, unset_arm.stderr
+    assert unset_arm.stdout.split() == ["1", "0"], "absent VAR must COUNT the pin"
+
+    set_arm = _bash(harness, {"ZZ_PROBE_DSN": "postgres://x"})
+    assert set_arm.returncode == 0, set_arm.stderr
+    assert set_arm.stdout.split() == ["0", "0"], \
+        "VAR set means the test RUNS, so the pin must NOT be counted"
+
+
+def test_the_real_ledger_behaves_the_same_way():
+    """The shipped entries, not a synthetic pair — so a future edit that drops the
+    condition from the Postgres pin is caught here and not only in production."""
+    block = _extract("EXPECTED_SKIPS=(", "\n)")
+    entries = re.findall(r'^\s*"([^"]+)"', block, re.M)
+    assert len(entries) >= 2, f"parsed {len(entries)} ledger entries — extraction is broken"
+    assert any(e.startswith("scripts/signal/tests|") and e.endswith("|unset:SIGNAL_PG_DSN")
+               for e in entries), "the Postgres pin lost its condition"
+
+    harness = _count_harness(entries)
+    with_dsn = _bash(harness, {"SIGNAL_PG_DSN": "postgres://x"})
+    without = _bash(harness)
+    assert without.returncode == 0 and with_dsn.returncode == 0
+    n_without = int(without.stdout.split()[0])
+    n_with = int(with_dsn.stdout.split()[0])
+    assert n_with == n_without - 1, (
+        f"exporting SIGNAL_PG_DSN must drop exactly one expected pin "
+        f"(got {n_without} -> {n_with}); this is the permanently-red-gate bug")
+
+
+def test_an_unknown_condition_is_a_HARD_ERROR_not_a_silent_pass():
+    """Fail closed. A typo'd condition must not quietly degrade a conditional pin
+    into an unconditional one — that would restore the original bug invisibly."""
+    r = _bash(_count_harness(["scripts/a/tests|reason|whenever:FOO"]))
+    assert r.returncode == 0, r.stderr
+    _, fail = r.stdout.split()
+    assert fail == "1", "an unrecognised condition must set fail=1"
+    assert "unknown condition" in r.stderr.lower()

--- a/scripts/tests/test_conditional_skip_pins.py
+++ b/scripts/tests/test_conditional_skip_pins.py
@@ -209,27 +209,36 @@ def test_an_unknown_condition_is_a_HARD_ERROR_not_a_silent_pass():
 # THE COMPARISON ITSELF — the line the whole change turns on.
 # --------------------------------------------------------------------------
 
-def _verdict_harness(entries: list[str], tot_skipped: int) -> str:
-    """Counting loop + the real comparison block, driven with a synthetic
-    TOT_SKIPPED. Extends to the end of the equality's `fi` so the branch under
-    test is the shipped one.
+def _verdict_harness(entries: list[str], tot_skipped: int,
+                     skip_lines: list[str] | None = None) -> str:
+    """ONE CONTIGUOUS slice of the shipped gate: the counting loop, the matching
+    loop, the unpinned-skip report, and the comparison — driven with synthetic
+    `SKIP_LINES` and `TOT_SKIPPED`.
 
-    🔴 WHY THIS EXISTS. The first version of this file extracted only up to
-    `for line in `, which stops BEFORE the comparison. So it pinned how
-    `pin_expected` is COMPUTED and never that the gate BRANCHES on it — and an
-    audit demonstrated that reverting the comparison to `${#EXPECTED_SKIPS[@]}`,
-    i.e. deleting the entire fix, left the full suite green. A test that proves a
-    value is calculated proves nothing about whether anything reads it.
+    🔴 WHY CONTIGUOUS, and why that word is load-bearing. Two earlier versions of
+    this harness were BOTH defeated by the same shape:
+
+      * v1 extracted only up to `for line in `, stopping BEFORE the comparison —
+        so it pinned how `pin_expected` is COMPUTED and never that the gate
+        BRANCHES on it. Reverting the comparison (deleting the whole fix) left
+        the suite green.
+      * v2 stitched the count loop to the comparison across a GAP, skipping the
+        matching loop and the report block. Injecting `pin_expected=${#EXPECTED_SKIPS[@]}`
+        INTO that gap — the same revert, different placement — survived green.
+
+    A harness assembled from disjoint slices cannot see anything in the seams,
+    and the seams are where a revert hides. Taking one slice removes the class
+    rather than the instance.
     """
-    count_loop = _extract("pin_expected=0\nfor entry in", "\nfor line in ")
-    cmp_start = _runner_text().index('if [ "$TOT_SKIPPED" -ne "$pin_expected" ]')
-    cmp_end = _runner_text().index("\nfi\n", cmp_start) + len("\nfi\n")
-    comparison = _runner_text()[cmp_start:cmp_end]
+    block = _extract("pin_expected=0\nfor entry in", "\n# --- GUARD 7")
     decl = "\n".join(f'  {e!r}' for e in entries)
+    lines = "\n".join(f'  {l!r}' for l in (skip_lines or []))
     return (
-        f"fail=0\nTOT_SKIPPED={tot_skipped}\nEXPECTED_SKIPS=(\n{decl}\n)\n"
-        + _split_fn() + _applies_fn() + count_loop + comparison
-        + '\nprintf "fail=%s pin_expected=%s\\n" "$fail" "$pin_expected"\n'
+        f"fail=0\nTOT_SKIPPED={tot_skipped}\nunexpected=()\n"
+        f"SKIP_LINES=(\n{lines}\n)\n"
+        f"EXPECTED_SKIPS=(\n{decl}\n)\n"
+        + _split_fn() + _applies_fn() + block
+        + '\nprintf "fail=%s pin_expected=%s unexpected=%s\\n" "$fail" "$pin_expected" "${#unexpected[@]}"\n'
     )
 
 
@@ -273,18 +282,35 @@ def test_a_non_applicable_pin_does_not_FORGIVE_a_skip():
     """🔴 The two halves must agree. A pin whose condition does not hold here
     must not absorb a skip in the matching loop while being excluded from the
     count — that combination balanced the totals and hid a real discrepancy."""
-    matching = _extract('for line in "${SKIP_LINES[@]}"; do\n  matched=0', "\nif [ \"${#unexpected[@]}\"")
-    h = (
-        "fail=0\nunexpected=()\n"
-        'SKIP_LINES=("SKIPPED [1] scripts/a/tests/t.py:9: reason here")\n'
-        "EXPECTED_SKIPS=(\n  'scripts/a/tests|reason here|unset:ZZ_PROBE_DSN'\n)\n"
-        + _split_fn() + _applies_fn() + matching
-        + '\nprintf "unexpected=%s\\n" "${#unexpected[@]}"\n'
-    )
-    applies = _bash(h)
+    entries = ["scripts/a/tests|reason here|unset:ZZ_PROBE_DSN"]
+    lines = ["SKIPPED [1] scripts/a/tests/t.py:9: reason here"]
+
+    applies = _bash(_verdict_harness(entries, 1, lines))
     assert "unexpected=0" in applies.stdout, f"applicable pin must forgive: {applies.stdout!r}"
 
-    not_applies = _bash(h, {"ZZ_PROBE_DSN": "set"})
+    not_applies = _bash(_verdict_harness(entries, 1, lines), {"ZZ_PROBE_DSN": "set"})
     assert "unexpected=1" in not_applies.stdout, (
         "a pin whose condition does NOT hold here still forgave the skip; the "
         f"matching loop is condition-blind. stdout={not_applies.stdout!r}")
+
+
+def test_a_malformed_unset_tail_is_a_hard_error_and_does_NOT_abort_the_loop():
+    """🔴 The `unset:*` arm is reached by a MALFORMED tail too — `unset:FOO|typo`
+    from a 4-field entry, or a bare `unset:`. Before validation, `${!_v-}` raised
+    bash's `invalid variable name`, and that error ABORTED the enclosing loop:
+    every later entry went unevaluated, `pin_expected` was truncated, and `fail`
+    stayed 0 — a silent widening.
+
+    Asserts BOTH halves, because either alone is satisfiable by the broken code:
+    `fail=1` (it was 0), AND that the entry AFTER the bad one was still counted
+    (it was not). The previously-covered case (`whenever:FOO`) takes the `*)` arm
+    and never exercised this path — the likelier typo shape was the untested one.
+    """
+    for bad in ("unset:FOO|typo", "unset:", "unset:1BAD"):
+        h = _verdict_harness([f"scripts/a/tests|r1|{bad}", "scripts/b/tests|r2"], 1)
+        r = _bash(h)
+        assert "fail=1" in r.stdout, f"{bad!r} must hard-error, got {r.stdout!r}"
+        assert "pin_expected=1" in r.stdout, (
+            f"{bad!r} aborted the loop — the entry after it was never counted. "
+            f"stdout={r.stdout!r} stderr={r.stderr!r}")
+        assert "invalid variable" in r.stderr.lower(), r.stderr

--- a/scripts/tests/test_conditional_skip_pins.py
+++ b/scripts/tests/test_conditional_skip_pins.py
@@ -46,6 +46,12 @@ def _extract(start: str, end: str) -> str:
     code that ships. Fails loudly rather than returning an empty string — an
     empty harness would make every assertion below pass vacuously."""
     txt = _runner_text()
+    # 🔴 The anchor must be UNIQUE. `for line in "${SKIP_LINES[@]}"; do` occurs
+    # twice — the print loop and the matching loop — and an ambiguous anchor
+    # silently extracted the wrong block, which is the "executes a stale copy"
+    # failure an extraction-based test is most exposed to.
+    assert txt.count(start) == 1, (
+        f"anchor {start!r} occurs {txt.count(start)} times — not unique")
     i = txt.index(start)
     j = txt.index(end, i)
     block = txt[i:j]
@@ -53,12 +59,25 @@ def _extract(start: str, end: str) -> str:
     return block
 
 
+def _ledger_condition_vars() -> set[str]:
+    """Every variable named by an `unset:VAR` condition in the real ledger.
+    Derived, so a new conditional entry cannot leave a stale hardcoded pop-set
+    behind — the failure mode that shipped in the first version of this file."""
+    block = _extract("EXPECTED_SKIPS=(", "\n)")
+    return set(re.findall(r"\|unset:([A-Za-z_][A-Za-z0-9_]*)", block))
+
+
 def _bash(script: str, env_extra: dict[str, str] | None = None) -> subprocess.CompletedProcess:
     import os
     env = dict(os.environ)
-    # Start from a known state: the variable under test must be genuinely absent
-    # unless a case sets it, or "unset" cases would silently test "set".
-    env.pop("ZZ_PROBE_DSN", None)
+    # 🔴 Start from a known state: EVERY variable any case or the real ledger
+    # depends on must be genuinely absent unless a case sets it, or an "unset"
+    # arm silently tests "set". Derived from the ledger rather than hardcoded —
+    # the first version of this popped only the synthetic probe var and left
+    # SIGNAL_PG_DSN alone, so `test_the_real_ledger_behaves_the_same_way` FAILED
+    # for exactly the developer this whole change exists to unbreak.
+    for _v in _ledger_condition_vars() | {"ZZ_PROBE_DSN"}:
+        env.pop(_v, None)
     env.update(env_extra or {})
     return subprocess.run(["bash", "-uo", "pipefail", "-c", script],
                           capture_output=True, text=True, env=env)
@@ -72,6 +91,17 @@ def _split_fn() -> str:
     if SPLIT_FN is None:
         SPLIT_FN = _extract("_split_skip_entry() {", "\n}\n") + "\n}\n"
     return SPLIT_FN
+
+
+APPLIES_FN = None
+
+
+def _applies_fn() -> str:
+    """The shipped `_skip_entry_applies`, verbatim."""
+    global APPLIES_FN
+    if APPLIES_FN is None:
+        APPLIES_FN = _extract("_skip_entry_applies() {", "\n}\n") + "\n}\n"
+    return APPLIES_FN
 
 
 # --------------------------------------------------------------------------
@@ -121,7 +151,7 @@ def _count_harness(entries: list[str]) -> str:
         EXPECTED_SKIPS=(
         {decl}
         )
-    """) + _split_fn() + loop + '\nprintf "%s %s\\n" "$pin_expected" "$fail"\n'
+    """) + _split_fn() + _applies_fn() + loop + '\nprintf "%s %s\\n" "$pin_expected" "$fail"\n'
 
 
 def test_unconditional_entry_always_counts():
@@ -173,3 +203,88 @@ def test_an_unknown_condition_is_a_HARD_ERROR_not_a_silent_pass():
     _, fail = r.stdout.split()
     assert fail == "1", "an unrecognised condition must set fail=1"
     assert "unknown condition" in r.stderr.lower()
+
+
+# --------------------------------------------------------------------------
+# THE COMPARISON ITSELF — the line the whole change turns on.
+# --------------------------------------------------------------------------
+
+def _verdict_harness(entries: list[str], tot_skipped: int) -> str:
+    """Counting loop + the real comparison block, driven with a synthetic
+    TOT_SKIPPED. Extends to the end of the equality's `fi` so the branch under
+    test is the shipped one.
+
+    🔴 WHY THIS EXISTS. The first version of this file extracted only up to
+    `for line in `, which stops BEFORE the comparison. So it pinned how
+    `pin_expected` is COMPUTED and never that the gate BRANCHES on it — and an
+    audit demonstrated that reverting the comparison to `${#EXPECTED_SKIPS[@]}`,
+    i.e. deleting the entire fix, left the full suite green. A test that proves a
+    value is calculated proves nothing about whether anything reads it.
+    """
+    count_loop = _extract("pin_expected=0\nfor entry in", "\nfor line in ")
+    cmp_start = _runner_text().index('if [ "$TOT_SKIPPED" -ne "$pin_expected" ]')
+    cmp_end = _runner_text().index("\nfi\n", cmp_start) + len("\nfi\n")
+    comparison = _runner_text()[cmp_start:cmp_end]
+    decl = "\n".join(f'  {e!r}' for e in entries)
+    return (
+        f"fail=0\nTOT_SKIPPED={tot_skipped}\nEXPECTED_SKIPS=(\n{decl}\n)\n"
+        + _split_fn() + _applies_fn() + count_loop + comparison
+        + '\nprintf "fail=%s pin_expected=%s\\n" "$fail" "$pin_expected"\n'
+    )
+
+
+def test_comparison_is_GREEN_when_the_total_matches_applicable_pins():
+    """DSN set: the pinned test RUNS, so one skip and one applicable pin."""
+    h = _verdict_harness(["scripts/signal/tests|needs a real Postgres|unset:ZZ_PROBE_DSN"], 0)
+    r = _bash(h, {"ZZ_PROBE_DSN": "postgres://x"})
+    assert r.returncode == 0, r.stderr
+    assert "fail=0" in r.stdout, f"expected green, got {r.stdout!r} {r.stderr!r}"
+
+
+def test_comparison_is_RED_when_the_total_exceeds_applicable_pins():
+    """The variable is set (pin does not apply) but a skip happened anyway —
+    the discrepancy the gate exists to surface."""
+    h = _verdict_harness(["scripts/signal/tests|needs a real Postgres|unset:ZZ_PROBE_DSN"], 1)
+    r = _bash(h, {"ZZ_PROBE_DSN": "postgres://x"})
+    assert "fail=1" in r.stdout, f"expected red, got {r.stdout!r}"
+    assert "MORE than" in r.stderr
+
+
+def test_comparison_USES_pin_expected_not_the_raw_entry_count():
+    """🔴 THE ANTI-REVERT TEST. Reverting the comparison to
+    `${#EXPECTED_SKIPS[@]}` deletes the fix; this case distinguishes the two,
+    because the raw count (1) and the applicable count (0) differ.
+
+    With the var SET the pin does not apply, so `pin_expected` is 0 and a
+    TOT_SKIPPED of 0 must be GREEN. Under the reverted comparison the raw entry
+    count is 1, so 0 != 1 and it goes RED. Any harness where the two counts are
+    equal cannot tell the versions apart — which is exactly how the reverted
+    mutant survived before.
+    """
+    h = _verdict_harness(["scripts/a/tests|reason|unset:ZZ_PROBE_DSN"], 0)
+    r = _bash(h, {"ZZ_PROBE_DSN": "set"})
+    assert "pin_expected=0" in r.stdout, r.stdout
+    assert "fail=0" in r.stdout, (
+        "the comparison is reading the raw entry count, not pin_expected — "
+        f"the fix is reverted or bypassed. stdout={r.stdout!r} stderr={r.stderr!r}")
+
+
+def test_a_non_applicable_pin_does_not_FORGIVE_a_skip():
+    """🔴 The two halves must agree. A pin whose condition does not hold here
+    must not absorb a skip in the matching loop while being excluded from the
+    count — that combination balanced the totals and hid a real discrepancy."""
+    matching = _extract('for line in "${SKIP_LINES[@]}"; do\n  matched=0', "\nif [ \"${#unexpected[@]}\"")
+    h = (
+        "fail=0\nunexpected=()\n"
+        'SKIP_LINES=("SKIPPED [1] scripts/a/tests/t.py:9: reason here")\n'
+        "EXPECTED_SKIPS=(\n  'scripts/a/tests|reason here|unset:ZZ_PROBE_DSN'\n)\n"
+        + _split_fn() + _applies_fn() + matching
+        + '\nprintf "unexpected=%s\\n" "${#unexpected[@]}"\n'
+    )
+    applies = _bash(h)
+    assert "unexpected=0" in applies.stdout, f"applicable pin must forgive: {applies.stdout!r}"
+
+    not_applies = _bash(h, {"ZZ_PROBE_DSN": "set"})
+    assert "unexpected=1" in not_applies.stdout, (
+        "a pin whose condition does NOT hold here still forgave the skip; the "
+        f"matching loop is condition-blind. stdout={not_applies.stdout!r}")


### PR DESCRIPTION
## The bug

`EXPECTED_SKIPS` compares a count of skipped **TESTS** against a flat count of ledger **ENTRIES**. So on a host where a pinned skip legitimately *runs*, the gate goes RED — and the advice it prints is wrong:

> FEWER than pinned: a pinned skip now RUNS (good) — delete its EXPECTED_SKIPS entry

Deleting it reds every *other* host, where the skip still happens. There was no correct action.

**Measured consequence:** any developer who exports `SIGNAL_PG_DSN` had a **permanently red gate**. That is the state that teaches people to reach for `DEVRC_SKIP_TESTS=1`, and a permanently-red gate is worse than no gate.

The `EXPECTED_SKIPS` header has promised the remedy all along — *"an entry may be conditional, but its condition must be the SAME predicate the test itself uses"* — there was simply no mechanism.

## The change

An entry is `dir|reason` or `dir|reason|unset:VAR`. The third field makes the pin conditional: expected only where `VAR` is unset. Counting asks which entries apply *here* instead of assuming all of them do.

Demonstrated with the shipped code against the real ledger:

| | entries | applicable here | `TOT_SKIPPED` | old | new |
|---|---|---|---|---|---|
| `SIGNAL_PG_DSN` unset | 2 | 2 | 2 | ✅ | ✅ |
| `SIGNAL_PG_DSN` **set** | 2 | **1** | 1 | 🔴 `1 skipped, but 2 pinned` | ✅ |

An unrecognised condition is a **hard error**, never a silent "treat as unconditional" — a typo must not quietly restore the original bug.

### A parsing trap worth naming

`ere="${entry#*|}"` takes everything after the **first** `|`. On a three-field entry that yields `reason|unset:VAR`, which goes straight to `grep -qE` — where `|` is **alternation**. The matcher would then accept any skip whose reason contained *either* side, silently **widening** the pin instead of narrowing it. `_split_skip_entry` splits explicitly, and `test_three_field_entry_does_not_leak_the_condition_into_the_regex` pins it.

## Verification

**The tests execute the shipped code.** Each lifts the real block out of `run-tests.sh` and drives it under bash with synthetic inputs. This is deliberate: a previous attempt in this area (#692, closed) asserted only that certain *strings* appeared in the script, and every one of those assertions was satisfied by the same string sitting in a **comment two lines above the mutated code** — the guard passed with the code under it broken. Substring checks against a shell script are not tests of that script.

**No `git ls-files` anywhere in the new test.** `nix flake check` builds `checks.pytests` from a tracked-file copy with **no `.git`**; an unguarded `git` call exits 128 and reds the hermetic tier while the pre-push tier stays green. That two-tier blind spot is what #692's audit caught, and it is documented in `test_doc_path_rot.py`.

| check | result |
|---|---|
| full suite, `SIGNAL_PG_DSN` unset | **PASS exit 0** — `collected=14386 passed=14384 skipped=2 failed=0` |
| hermetic tier simulated (tracked files, **no `.git`**) | **8/8 pass** — the tier #692 would have redded |
| count transition on the real ledger | `applicable_here` 2 → **1** when the DSN is exported |

**Mutations, isolated to code lines only** (the previous attempt's `sed` also rewrote a comment, so a reported kill was not one):

| mutation | killed by |
|---|---|
| parser reverts to `${_rest}` (restores the alternation bug) | 6 tests |
| condition ignored — every entry counts unconditionally | `test_the_real_ledger_behaves_the_same_way` |
| unknown condition silently counted instead of erroring | `test_an_unknown_condition_is_a_HARD_ERROR_not_a_silent_pass` |

### What I could NOT verify

**The full suite with `SIGNAL_PG_DSN` set to a working DSN.** A faithful run needs a real Postgres: with a bogus DSN the test runs and errors on connection, so the suite fails for an unrelated reason. The *accounting* half — the actual subject of this PR — is verified above at unit level against the real ledger entries under both conditions. What a full green would add is confidence that nothing else in the run reacts to that variable, which is a weaker claim than the one already pinned.

## Scope

Deliberately narrow. `run-tests.sh` still compares skipped TESTS against a count of ENTRIES, assuming one test per entry; both current entries are `SKIPPED [1]`. Widening that is a separate change and is noted in the code rather than attempted here.
