### PR TITLE
docs(CLAUDE.md): "githooks ships uninstalled" was measured FALSE — and the value is volatile, not just per-clone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,17 +153,26 @@ Repo-level facts that are NOT in any skill — they live here on purpose:
   statusCheckRollup` returns **0 checks** on every PR, merged ones included. This line used to
   read `CI gates both suites`, which was false — the exact kind of claim nobody re-checks: an
   agent reads it, believes the merge is protected, and skips the run.
-  🔴 **But a gate SHIPS IN THIS REPO, uninstalled** — `githooks/` (`install.sh`, `pre-push`,
-  `tests-on-push.sh`) is a real blocking pre-push test gate, and `scripts/run-tests.sh` treats
-  it as a first-class consumer. It is simply not installed: `git config --get core.hooksPath`
-  is what answers that, **never** `ls .git/hooks` — githooks installs by pointing
-  `core.hooksPath` elsewhere, so `.git/hooks` stays sample-only whether or not the gate is
-  live. ⚠ **Check for a REPO-LOCAL `core.hooksPath` before installing**: `install.sh` sets the
-  key `--global`, and a local one wins. Measured 2026-08-20: the workbench's `devrc` *and*
-  `homelab-talos` clones both carry `core.hooksPath` pointing back at their own `.git/hooks`
-  while the laptop's `devrc` carries none — so it is per-clone environmental (it correlates
-  with agent-worktree creation), NOT a devrc setting, and it is not safe to assume either way.
-  `git config --local --get core.hooksPath` per clone is the only answer.
+  🔴 **But a gate SHIPS IN THIS REPO, and whether it is INSTALLED is not a fact this file can
+  state** — `githooks/` (`install.sh`, `pre-push`, `tests-on-push.sh`) is a real blocking
+  pre-push test gate, and `scripts/run-tests.sh` treats it as a first-class consumer.
+  `git config --get core.hooksPath` is what answers that, **never** `ls .git/hooks` — githooks
+  installs by pointing `core.hooksPath` elsewhere, so `.git/hooks` stays sample-only whether or
+  not the gate is live. 🔴 **The value is VOLATILE, not merely per-clone — re-measure at the
+  moment you act, never earlier in the session.** This line read "uninstalled" until
+  2026-08-21, when a push from a worktree hung ~2 min and came back with the branch REWRITTEN:
+  the commit gone, the index wrecked, and `autocommit: N change(s) in the some-scope
+  analyze-service index` fixture commits on the branch (reproduced twice; task #322). At that
+  moment `core.hooksPath` was set **repo-LOCALLY** to `<repo>/githooks`. Hours later, same
+  session, it was unset everywhere with no action by anyone here — and `install.sh` sets the
+  key `--global`, so the `--local` value came from something else. **Neither "installed" nor
+  "uninstalled" is safe to carry in prose.** 🔴 **A pre-push gate that runs the suite IN the
+  worktree can corrupt the branch it is pushing** — see #322 before using `--no-verify` to get
+  past it, and re-check the branch afterwards. ⚠ **Check for a REPO-LOCAL `core.hooksPath` before installing**: `install.sh` sets the
+  key `--global`, and a local one wins — observed pointing at `.git/hooks` (08-20, workbench
+  `devrc` + `homelab-talos`; laptop none) and at `githooks/` (08-21). It correlates with
+  agent-worktree creation, is NOT a devrc setting, and `git config --local --get
+  core.hooksPath` per clone is the only answer.
   **Until then: run the gate yourself before you merge, and say which command you ran.**
   `nix build .#checks.x86_64-linux.pytests` / `.#checks.x86_64-linux.nodetests` (or
   `scripts/gate.sh`) are authoritative — they assert collected-test FLOORS and parse structured


### PR DESCRIPTION
docs(CLAUDE.md): "githooks ships uninstalled" was measured FALSE — and the value is volatile, not just per-clone

This file stated flatly that the `githooks/` pre-push gate "SHIPS IN THIS REPO,
uninstalled" and that "It is simply not installed". On 2026-08-21 that was false,
and believing it cost real work.

WHAT HAPPENED. A push of a two-file docs change from a worktree hung ~2 minutes
and came back with the branch REWRITTEN: my commit gone, the index wrecked
(nearly every tracked file reading as untracked), and fixture commits on the
branch —

    <sha> m
    <sha> autocommit: 1 change(s) in the some-scope analyze-service index

— plus test fixtures (`a.md`, `alpha.md`, `beta.md`,
`claude/skills/ghost/SKILL.md`) left in the tree. Reproduced twice,
deterministically. At that moment `core.hooksPath` was set **repo-LOCALLY** to
`<repo>/githooks`, so `githooks/pre-push` was running the suite inside the
worktree being pushed. Filed as task #322.

🔴 WHY THE FIX IS "THIS FILE CANNOT SAY", NOT "FLIP IT TO INSTALLED". Hours later,
in the SAME session, `core.hooksPath` was unset everywhere with no action by
anyone here. `githooks/install.sh` sets the key `--global`, so the `--local` value
came from something else. The state is VOLATILE, not merely per-clone — a reading
taken at the start of a session is not evidence about the moment you push. Writing
"installed" would have been the identical error in the opposite direction, and
would have been wrong within the hour.

So the line now says installation is not a fact this file can state, names
`git config --get core.hooksPath` as the only authority, and says to re-measure AT
the moment you act rather than earlier in the session. It also warns that a
pre-push gate running the suite in-tree can corrupt the branch it is pushing, and
to re-check the branch after any `--no-verify`.

NET SIZE. CLAUDE.md loads every session, so the addition is paid for in the same
commit rather than appended: the "Measured 2026-08-20" block is compressed, since
the new volatility rule supersedes its conclusion. Both observed values are kept
as data points (`.git/hooks` on 08-20, `githooks/` on 08-21) because the pair is
what demonstrates the volatility — one reading alone would not.

MARKER. The load-bearing `<!-- merge-gate: none -->` marker is UNTOUCHED and still
correct: nothing is installed right now, and `none` is what the repo state says.
`scripts/tests/test_ci_claim_matches_reality.py` passes (5/5). There is still
exactly one marker; the second grep hit is the prose that describes it, which
predates this change.

Gate, by hand (devrc has no CI): see the PR conversation for the RESULT line and
counts.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
