### PR TITLE
feat(analyze-service-index): encrypted off-machine backup — and `git bundle verify` does NOT detect corruption

### DIFF
--- a/SECRETS.md
+++ b/SECRETS.md
@@ -42,6 +42,39 @@ completeness:
 | MinIO invoice archiver | k8s secret `minio-archive-config`, key `config.env` → `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD`, ns `minio-archive` (or env `MINIO_ARCHIVE_ENDPOINT`/`_ACCESS_KEY`/`_SECRET_KEY`) | homelab cluster (`_minio.py`) |
 | LLM extraction (Stage 2) | `OPENROUTER_API_KEY` (env) | OpenRouter dashboard |
 
+### analyze-service index backup — no new secret, REUSES the SOPS age key
+
+`scripts/analyze-service-index/backup.py` (systemd user timer
+`analyze-service-index-backup`, daily, **both hosts**) bundles each scope of the
+`/analyze-service` index store, encrypts it with `age`, and uploads it to the
+`minio-archive` tenant. It introduces **no new credential**:
+
+| what | key / secret (names only) | source of truth |
+|---|---|---|
+| encryption identity | the **existing** SOPS age key — file `~/workspace/homelab-talos/.secrets/age.key`, handle `SOPS_AGE_KEY_FILE` (override: `ASIB_AGE_IDENTITY`) | the `homelab-talos` repo; the same key already used for every `*.enc.yaml` in the homelab clusters |
+| MinIO destination | reuses `_minio.py` entirely — k8s secret `minio-archive-config` (see the row above) | homelab cluster |
+| cluster route | `KUBECONFIG`; the unit sets the workbench path and `backup.py` falls back to `~/.kube/homelab-nebula.yaml` on the laptop | see the Kubeconfigs table below |
+
+🔴 **The recipient is DERIVED from that key file at run time** (`age-keygen -y`),
+never hardcoded — devrc is public, and more importantly a hardcoded recipient can
+drift from the key the operator actually holds, producing archives that encrypt
+cleanly and decrypt never. **No new key is minted**: a backup encrypted to a key
+nobody keeps alive is a backup nobody can open. If the key file is missing the
+backup FAILS loudly rather than falling back to an unencrypted upload.
+
+**Restoring** (the whole point — rehearse it before you need it):
+
+```
+age --decrypt -i ~/workspace/homelab-talos/.secrets/age.key \
+    -o <scope>.bundle  <scope>-<stamp>.bundle.age
+git clone <scope>.bundle <scope>            # a full scope repo, history intact
+```
+
+Objects live at `<host>/<scope>/<UTC stamp>.bundle.age` in bucket
+`analyze-service-index-backups`. The host segment carries the machine ID because
+**both machines are hostname `nixos`** and their stores are divergent — a shared
+prefix would make each host's retention pass evict the other's backups.
+
 ---
 
 ## Kubeconfigs (`$KC_*` handles from `nix/programs/zsh/default.nix`)

--- a/SECRETS.md
+++ b/SECRETS.md
@@ -62,18 +62,64 @@ cleanly and decrypt never. **No new key is minted**: a backup encrypted to a key
 nobody keeps alive is a backup nobody can open. If the key file is missing the
 backup FAILS loudly rather than falling back to an unencrypted upload.
 
-**Restoring** (the whole point — rehearse it before you need it):
-
-```
-age --decrypt -i ~/workspace/homelab-talos/.secrets/age.key \
-    -o <scope>.bundle  <scope>-<stamp>.bundle.age
-git clone <scope>.bundle <scope>            # a full scope repo, history intact
-```
-
 Objects live at `<host>/<scope>/<UTC stamp>.bundle.age` in bucket
 `analyze-service-index-backups`. The host segment carries the machine ID because
 **both machines are hostname `nixos`** and their stores are divergent — a shared
 prefix would make each host's retention pass evict the other's backups.
+
+**Restoring** (the whole point — rehearse it before you need it). 🔴 **Step 1 is
+the retrieval, and it is the one thing you will not already have in the scenario
+this exists for.** The bucket is reachable only in-cluster, so bridge to it the
+same way the backup does — `_minio.py`'s `kubectl port-forward`:
+
+```sh
+cd ~/workspace/devrc
+KEY=<host>/<scope>/<UTC stamp>.bundle.age     # from the listing below
+
+# 1a. list what is there (per host, per scope, newest last)
+KUBECONFIG=$KC_HOMELAB nix-shell -p 'python3.withPackages(p:[p.minio])' --run '
+python3 -c "
+import sys; sys.path.insert(0, \"scripts/mail-actions\")
+from _minio import MinioArchive
+with MinioArchive() as mc:
+    for o in sorted(x.object_name for x in mc.client.list_objects(
+            \"analyze-service-index-backups\", recursive=True)):
+        print(o)
+"'
+
+# 1b. fetch ONE object to disk
+KUBECONFIG=$KC_HOMELAB KEY="$KEY" nix-shell -p 'python3.withPackages(p:[p.minio])' --run '
+python3 -c "
+import os, sys; sys.path.insert(0, \"scripts/mail-actions\")
+from _minio import MinioArchive
+key = os.environ[\"KEY\"]
+with MinioArchive() as mc:
+    r = mc.client.get_object(\"analyze-service-index-backups\", key)
+    open(\"restore.bundle.age\", \"wb\").write(r.read()); r.close(); r.release_conn()
+"'
+
+# 2. decrypt
+age --decrypt -i ~/workspace/homelab-talos/.secrets/age.key \
+    -o restore.bundle  restore.bundle.age
+
+# 3. restore, then IMMEDIATELY drop the remote the clone just added
+git clone restore.bundle <scope>
+git -C <scope> remote remove origin
+git -C <scope> remote          # must print NOTHING
+```
+
+🔴 **Step 3's second line is not optional.** `git clone <bundle> <dir>` sets
+`origin` to the bundle's path, which breaks the `remote = none` invariant every
+scope README, `commit.sh`'s `PrivateNetwork` unit and this feature's own
+`test_no_scope_gains_a_remote` rest on. A scope restored and left with a remote
+looks healthy and violates the one property the store is supposed to have.
+
+🔴 **`git clone` restores `refs/heads/*` and tags ONLY.** Measured: a bundle
+created with `--all` that declares `refs/notes/commits` restores through a plain
+(or `--bare`) clone with that ref silently missing. `backup.py`'s own restore
+rehearsal is a `--mirror` clone for exactly this reason. If the scope carried
+non-branch refs, restore with `git clone --mirror restore.bundle <scope>.git`
+instead — or check with `git bundle list-heads restore.bundle` first.
 
 ---
 

--- a/flake.nix
+++ b/flake.nix
@@ -95,10 +95,18 @@
       ]);
       # Read the per-entry justifications on checks.pytests' nativeBuildInputs
       # below before adding or removing anything here.
+      # age: scripts/tests/test_analyze_service_index_backup.py resolves `age` and
+      # `age-keygen` at IMPORT and raises rather than skipping — deliberately, and
+      # for the same reason test_analyze_service_index_commit.py does: a skipped
+      # backup test reports safety it never measured, which for a disaster-recovery
+      # feature is quiet exactly when it is wrong. That suite runs the real
+      # encrypt/decrypt round trip (it generates its own throwaway identity; the
+      # operator's key is never touched), so without age here the whole file is an
+      # import error inside the sandbox rather than a green-with-skips.
       gateTools = [
         gatePyEnv pkgs.bash pkgs.ripgrep pkgs.git pkgs.util-linux pkgs.jq
         pkgs.gnugrep pkgs.curl pkgs.nodejs pkgs.nix pkgs.opencode pkgs.logrotate
-        pkgs.rsync pkgs.zsh
+        pkgs.rsync pkgs.zsh pkgs.age
       ];
     in
     {

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -3084,6 +3084,142 @@ in
     };
   };
 
+  # Encrypted OFF-MACHINE backup for the /analyze-service index store.
+  #
+  # WHAT THIS CLOSES, AND WHY THE AUTOCOMMIT ABOVE DOES NOT CLOSE IT. The
+  # committer gives every scope local git history. That defends against exactly
+  # one thing: an agent's Write clobbering a file a previous run had already
+  # committed. Measured on the workbench 2026-08-21: 10 scope repos, 1-65
+  # commits each, every one of them `remote = none`, and not one byte of any of
+  # them anywhere off this disk. The history lives INSIDE the thing a disk
+  # failure or an `rm -rf` of the store root destroys, so until now the store
+  # had a versioning story and no recovery story at all. The content is not
+  # re-derivable — it records gotchas, retracted theories and measurements that
+  # were true at a moment.
+  #
+  # The laptop's store is DIVERGENT CONTENT, not a copy. It is a second thing to
+  # lose, which is why this is NOT gated on serverMode (see below).
+  #
+  # 🔴 A SIBLING UNIT, NOT AN EXTENSION OF THE COMMITTER. The obvious move is to
+  # bolt an upload onto analyze-service-index-commit, and it is the wrong one.
+  # That unit's containment — `PrivateNetwork = true`, `InaccessiblePaths` on
+  # /dev/shm, both bind lists frozen at exactly one entry — IS its
+  # no-exfiltration control, arrived at over several measured rounds after three
+  # earlier attempts to make exfiltration merely DETECTABLE were each evaded a
+  # new way. Backing up needs the network by definition. Giving that unit a
+  # network is not a small edit to it; it is deleting the property it was built
+  # to have, and it would do so for a job that runs on a completely different
+  # schedule. Two units, two threat models, two failure signals.
+  #
+  # DAILY, not hourly. The committer is hourly because its cost is ~200 ms of
+  # local git and the window it narrows is the same-day write-then-clobber. This
+  # one uploads full bundles of every scope over a port-forward: the window it
+  # narrows is "the disk died", which is not a per-hour risk, and 24 full-store
+  # uploads a day would buy nothing over one. Persistent=true catches up a
+  # missed run; RandomizedDelaySec keeps it off a predictable boundary and off
+  # the same instant as the 06:00 mail archiver.
+  #
+  # 🔴 DELIBERATELY NOT GATED ON serverMode, unlike mail-actions-archive which
+  # it otherwise resembles. That gate exists because those jobs need a server
+  # role. This one needs the homelab kubeconfig — which the laptop HAS, over
+  # nebula — and gating it out would leave the laptop's divergent, equally
+  # unrecoverable store with no off-machine copy while the workbench looked
+  # healthy. Same reasoning as the committer above, and the same silent gap.
+  # `backup.py` resolves the right kubeconfig per host itself; KUBECONFIG below
+  # is the workbench's and is simply the first candidate it checks.
+  #
+  # THE STORE IS MOUNTED READ-ONLY. `backup.py` runs no git subcommand outside
+  # its own allowlist (bundle/rev-list/remote/rev-parse) and the test suite
+  # checksums a synthetic store across a full run to prove byte identity — but
+  # BindReadOnlyPaths makes it a property of the namespace too, so a future bug
+  # in the producer cannot reach the only copy of the data it is protecting.
+  # Note the contrast with the committer, which needs the store WRITABLE.
+  #
+  # The age identity is bound in read-only as a single FILE, not its directory:
+  # `~/workspace/homelab-talos/.secrets/` also holds cluster credentials this
+  # job has no business seeing.
+  #
+  # Python comes from a pinned `withPackages` env rather than the runtime
+  # `nix-shell -p` that run-archive.sh uses. nix-shell inside a hardened unit
+  # needs the daemon, a writable cache and a NIX_PATH; a built env needs none of
+  # those and cannot drift between the two hosts.
+  systemd.user.services.analyze-service-index-backup =
+    let
+      pyEnv = pkgs.python3.withPackages (p: [ p.minio ]);
+    in
+    {
+      Unit = {
+        Description = "Encrypted off-machine backup of the /analyze-service index store";
+        After = [ "network-online.target" ];
+        Wants = [ "network-online.target" ];
+        OnFailure = [ "notify-failure@%n.service" ];
+      };
+      Service = {
+        Type = "oneshot";
+        # Ten scopes of a few hundred KB each, bundled, encrypted and uploaded
+        # over a port-forward. Generous, but a hang must not pin the timer.
+        TimeoutStartSec = 900;
+        Environment = [
+          "PATH=${lib.makeBinPath [ pkgs.git pkgs.age pkgs.kubectl pkgs.coreutils ]}"
+          "HOME=%h"
+          "KUBECONFIG=%h/workspace/homelab-talos/homelab-kubeconfig"
+          # The identity this encrypts to: the operator's EXISTING SOPS age key,
+          # the same handle the homelab repos already use. No new key is minted —
+          # a backup encrypted to a key nobody keeps alive is a backup nobody can
+          # open. See SECRETS.md.
+          "SOPS_AGE_KEY_FILE=%h/workspace/homelab-talos/.secrets/age.key"
+          # 🔴 THE TWO HOSTS MUST NOT SHARE A KEY PREFIX. Both machines are
+          # hostname `nixos` and their stores are DIVERGENT content, so a shared
+          # prefix would make each host's retention pass evict the other's
+          # backups — turning the backup into a second way to lose the data.
+          #
+          # `isLaptop` alone is not enough to rely on here. It is a backlight
+          # probe, and the note at the top of this file records that it fails
+          # OPEN: a laptop with an ACPI-only backlight evaluates `false`, which
+          # would label BOTH machines `workbench` and produce exactly the
+          # collision above — silently, and only visible as backups going
+          # missing. So the readable name is joined to `%m`, systemd's machine
+          # ID, which is distinct per host by construction and needs no probe.
+          # The name is for a human reading the bucket; the machine ID is what
+          # actually guarantees separation.
+          "ASIB_HOST=${if isLaptop then "laptop" else "workbench"}-%m"
+        ];
+        ProtectSystem = "strict";
+        ProtectHome = "read-only";
+        # `-` on the store: a host that has never run /analyze-service must start
+        # and no-op cleanly, which is the one empty outcome backup.py treats as a
+        # success. No `-` on the script: it ships with the repo, so its absence is
+        # a real deployment fault and the mount failure names it (measured for the
+        # committer above; the same reasoning applies unchanged).
+        BindReadOnlyPaths = [
+          "%h/workspace/devrc/scripts"
+          "-%h/.claude/analyze-service-index"
+          "-%h/workspace/homelab-talos/.secrets/age.key"
+          "-%h/workspace/homelab-talos/homelab-kubeconfig"
+          "-%h/.kube/homelab-nebula.yaml"
+        ];
+        InaccessiblePaths = [ "/dev/shm" "/dev/mqueue" ];
+        PrivateTmp = true;
+        NoNewPrivileges = true;
+        ExecStart = "${pyEnv}/bin/python3 %h/workspace/devrc/scripts/analyze-service-index/backup.py";
+        X-Restart-Triggers = [ "${../scripts/analyze-service-index/backup.py}" ];
+      };
+    };
+
+  systemd.user.timers.analyze-service-index-backup = {
+    Unit = {
+      Description = "Daily timer for the /analyze-service index off-machine backup";
+    };
+    Timer = {
+      OnCalendar = "*-*-* 04:30:00";
+      Persistent = true;
+      RandomizedDelaySec = 1800;
+    };
+    Install = {
+      WantedBy = [ "timers.target" ];
+    };
+  };
+
   # ClickHouse regrowth check for the activity store.
   #
   # 2026-08-03 the store was cut 112.4 GB -> 82.1 MB after `system.trace_log`

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -3135,9 +3135,37 @@ in
   # in the producer cannot reach the only copy of the data it is protecting.
   # Note the contrast with the committer, which needs the store WRITABLE.
   #
-  # The age identity is bound in read-only as a single FILE, not its directory:
-  # `~/workspace/homelab-talos/.secrets/` also holds cluster credentials this
-  # job has no business seeing.
+  # 🔴 ProtectHome=tmpfs, NOT read-only. THIS UNIT HAS A NETWORK — it is the one
+  # job here that can carry bytes off the box — so what it can READ is the whole
+  # containment question, and `read-only` answers a different one. `read-only`
+  # makes $HOME unwritable and leaves it fully READABLE, which means the bind
+  # list below confers no confinement whatsoever: it is a list of things already
+  # visible. MEASURED 2026-08-22 with `systemd-run --user`, same directive set
+  # otherwise, probing readability from inside the namespace:
+  #
+  #   ProtectHome=read-only  ~/.ssh/id_ed25519 READABLE, ~/.kube/config READABLE,
+  #                          `.secrets/` listed 6 entries
+  #   ProtectHome=tmpfs      ~/.ssh ABSENT, ~/.kube/config ABSENT,
+  #                          `.secrets/` listed 1 entry — the bound key file
+  #
+  # The comment here used to say the age identity was bound "as a single FILE,
+  # not its directory: `.secrets/` also holds cluster credentials this job has
+  # no business seeing." Under `read-only` that was false in the way that
+  # matters — the job could read all six, and the sentence would have led a
+  # maintainer to believe the narrow bind was doing work.
+  #
+  # NOTHING NEEDED BINDING BACK for the switch. The list below was already
+  # exactly what the job reads, which is why the leak was invisible: measured by
+  # running `backup.py --print-plan` (pure read, writes nothing) inside the
+  # tmpfs namespace — rc=0, identity resolved, all 10 scopes discovered and
+  # commit-counted. Both kubeconfigs are self-contained (`*-data`, no external
+  # cert paths) and `_minio.py` reads nothing from $HOME beyond KUBECONFIG.
+  #
+  # 🔴 The bind list is therefore load-bearing now and pinned as an EXACT LIST by
+  # test_the_backup_unit_pins_its_CONTAINMENT_directives_exactly. Appending an
+  # entry — or widening the age key to its directory — is the one-token hole the
+  # committer unit's comment describes, and it is worse here because this unit
+  # has a route off the machine.
   #
   # Python comes from a pinned `withPackages` env rather than the runtime
   # `nix-shell -p` that run-archive.sh uses. nix-shell inside a hardened unit
@@ -3185,7 +3213,7 @@ in
           "ASIB_HOST=${if isLaptop then "laptop" else "workbench"}-%m"
         ];
         ProtectSystem = "strict";
-        ProtectHome = "read-only";
+        ProtectHome = "tmpfs";
         # `-` on the store: a host that has never run /analyze-service must start
         # and no-op cleanly, which is the one empty outcome backup.py treats as a
         # success. No `-` on the script: it ships with the repo, so its absence is

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -25,6 +25,16 @@ with pkgs; [
   git
   lefthook
 
+  # age — file encryption for the /analyze-service index off-machine backup
+  # (scripts/analyze-service-index/backup.py). The store is client-confidential
+  # and every scope README says the content never leaves the machine; encrypting
+  # to the operator's EXISTING SOPS age identity before upload keeps that
+  # literally true, so the homelab MinIO tenant holds ciphertext it cannot read.
+  # Provides both `age` and `age-keygen` (the backup derives its recipient from
+  # the identity file rather than hardcoding one, so the key it encrypts to and
+  # the key it can decrypt with cannot drift apart).
+  age
+
   # Nix
   nix-direnv
 

--- a/scripts/analyze-service-index/backup.py
+++ b/scripts/analyze-service-index/backup.py
@@ -71,8 +71,18 @@ Usage:
     backup.py [--store DIR] [--bucket B] [--keep N] [--no-upload] [--print-plan]
 
   --print-plan   pure text; reads the store, writes nothing anywhere
-  --no-upload    bundle + verify + encrypt into --work-dir, then stop. Used for
-                 a read-only smoke run against the real store.
+  --no-upload    bundle + verify + encrypt, then stop. WITHOUT --work-dir the
+                 artifacts are built in a private temp dir that is DELETED on
+                 exit, so nothing survives the run; WITH --work-dir they are left
+                 there for inspection. Used for a read-only smoke run against the
+                 real store.
+
+🔴 THE PLAINTEXT BUNDLE IS A FULL, UNENCRYPTED COPY OF A CLIENT-CONFIDENTIAL
+SCOPE. It exists only between `git bundle create` and `age`, and it is unlinked
+on EVERY path out of that window including the failure paths. Everything this
+script creates is mode 0600 inside a 0700 work directory — `PrivateTmp` contains
+the default case under the unit, but the documented `--no-upload --work-dir X`
+smoke run against the real store has no namespace around it at all.
 """
 from __future__ import annotations
 
@@ -85,6 +95,7 @@ import socket
 import subprocess
 import sys
 import tempfile
+import traceback
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -94,6 +105,13 @@ DEFAULT_STORE = Path.home() / ".claude" / "analyze-service-index"
 DEFAULT_BUCKET = "analyze-service-index-backups"
 DEFAULT_KEEP = 14
 DEFAULT_IDENTITY = Path.home() / "workspace" / "homelab-talos" / ".secrets" / "age.key"
+
+# Everything created by this script: a 0700 work directory holding 0600 files.
+# The bundle is plaintext history and the ciphertext is still a backup of
+# confidential content; neither may be world- or group-readable, and the
+# `--no-upload --work-dir X` smoke run has no PrivateTmp around it.
+_DIR_MODE = 0o700
+_FILE_MODE = 0o600
 
 # 🔴 THE READ-ONLY ALLOWLIST. Every git invocation in this file goes through
 # `_git()`, which refuses a subcommand that is not in here. This is the guard
@@ -107,9 +125,48 @@ DEFAULT_IDENTITY = Path.home() / "workspace" / "homelab-talos" / ".secrets" / "a
 _READ_ONLY_SUBCOMMANDS = frozenset(
     {"bundle", "rev-list", "remote", "rev-parse", "for-each-ref"})
 
+# 🔴 A VERB IS NOT GRANULAR ENOUGH, AND THE COMMENT ABOVE USED TO CLAIM IT WAS.
+# `remote` and `bundle` are DISPATCHERS: the verb reads, the SUBVERB decides.
+# MEASURED 2026-08-22 against the verb-only allowlist, on a synthetic scope:
+#
+#   git remote add exfil file:///tmp/x   -> rc=0, `.git/config` gained a
+#                                           [remote "exfil"] section
+#   git bundle unbundle <foreign.bundle> -> rc=0, a foreign packfile written
+#                                           into the scope's object store
+#
+# Both are writes to the only copy of the data, both were allowed, and the
+# allowlist comment above named `git remote add` as an example of what it
+# refused. Neither has a call site today and the unit's BindReadOnlyPaths would
+# have blocked them — but a guard narrower than its own description is the kind
+# that gets trusted at exactly the moment it stops being true.
+#
+# So the allowlist is a (verb, subverb) pair set. The subverb is the first
+# argument after the verb that is not an option, which is where git's own
+# grammar puts it for both dispatchers. `None` means "the bare verb, options
+# only": `git remote` LISTS remotes and is the form `scope_remotes()` uses,
+# while `git bundle` with no subverb is a usage error and is not permitted.
+# Pinned as an exact mapping by the test suite, same as the set above.
+_ALLOWED_SUBVERBS: dict[str, frozenset] = {
+    "bundle": frozenset({"create", "verify"}),
+    "remote": frozenset({None}),
+}
+
 
 class BackupError(RuntimeError):
     """A failure that must make the whole run non-zero."""
+
+
+def _private_dir(d: Path) -> Path:
+    """Create (or tighten) `d` to 0700.
+
+    `mkdir(mode=…)` is not enough: it is masked by the umask AND it does nothing
+    at all when the directory already exists, which is the case every run after
+    the first with an explicit `--work-dir`. The chmod is unconditional for that
+    reason.
+    """
+    d.mkdir(parents=True, exist_ok=True)
+    os.chmod(d, _DIR_MODE)
+    return d
 
 
 # --------------------------------------------------------------------------- #
@@ -150,6 +207,21 @@ def _git_env() -> dict:
     return env
 
 
+def _subverb(args: tuple[str, ...]) -> str | None:
+    """The dispatcher subverb in `args`, or None for a bare verb.
+
+    git's grammar for both dispatchers this script allowlists puts the subverb
+    first among the non-option arguments (`git bundle create -q <file> …`,
+    `git remote -v`), so the first argument after the verb that does not start
+    with `-` IS the subverb. Returning None for `git remote` is meaningful, not
+    a miss: that form lists remotes and is the one `scope_remotes()` uses.
+    """
+    for a in args[1:]:
+        if not a.startswith("-"):
+            return a
+    return None
+
+
 def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
     """Run one read-only git subcommand against `repo`.
 
@@ -167,6 +239,19 @@ def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
             f"genuinely needed, prove it cannot write and add it to "
             f"_READ_ONLY_SUBCOMMANDS in the same commit as the test that pins it."
         )
+    verb = args[0]
+    if verb in _ALLOWED_SUBVERBS:
+        sub = _subverb(args)
+        if sub not in _ALLOWED_SUBVERBS[verb]:
+            raise BackupError(
+                f"refusing `git {verb} {sub}`: {sub!r} is not a READ-ONLY mode of "
+                f"`git {verb}`. The verb is allowlisted; its subverbs are not all "
+                f"reads — `git remote add` writes .git/config and `git bundle "
+                f"unbundle` writes objects into the repository, both against the "
+                f"only copy of the data. Allowed here: "
+                f"{sorted(s for s in _ALLOWED_SUBVERBS[verb] if s is not None)}"
+                f"{' (or the bare verb)' if None in _ALLOWED_SUBVERBS[verb] else ''}."
+            )
     return subprocess.run(
         ["git", "-C", str(repo), "-c", "gc.auto=0", "-c", "core.hooksPath=" + os.devnull, *args],
         capture_output=True, text=True, env=_git_env(),
@@ -294,20 +379,41 @@ def encrypt(plain: Path, cipher: Path, recipient: str) -> None:
             f"age reported success but {cipher} is missing or empty. An empty "
             f"ciphertext uploads happily and restores never."
         )
+    # Ciphertext, but still a backup of client-confidential content sitting on a
+    # real filesystem under `--no-upload --work-dir X`. age creates it 0644.
+    os.chmod(cipher, _FILE_MODE)
 
 
 # --------------------------------------------------------------------------- #
 # bundling
 # --------------------------------------------------------------------------- #
-def _git_scratch(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+def _git_scratch(cwd: Path, *args: str, forbidden: Path) -> subprocess.CompletedProcess:
     """git in a THROWAWAY directory — never the store.
 
     The allowlist on `_git` exists because that function is pointed at the only
     copy of the data. This one is pointed at a directory we created moments ago
-    and are about to delete, so it may run writing subcommands (`clone`). It
-    refuses to run anywhere near the store, so the two cannot be confused by a
-    later edit.
+    and are about to delete, so it may run writing subcommands (`clone`).
+
+    🔴 `forbidden` IS THE REFUSAL, AND IT IS REQUIRED AND KEYWORD-ONLY. An
+    earlier version of this docstring claimed the function "refuses to run
+    anywhere near the store" and no such check existed — a comment describing a
+    guard that is not there is worse than no guard, because it stops the next
+    person looking. Making the parameter mandatory is what makes the refusal
+    structural: a later call site cannot inherit it by forgetting it, because
+    omitting it is a TypeError at the call rather than a silently unguarded
+    write. Pass the STORE ROOT; `cwd` may be neither it nor anything under it.
     """
+    c = Path(cwd).resolve()
+    f = Path(forbidden).resolve()
+    if c == f or f in c.parents:
+        raise BackupError(
+            f"refusing to run `git {' '.join(args[:2])}` with cwd {c}: that is "
+            f"inside the /analyze-service index store ({f}). `_git_scratch` may "
+            f"run WRITING subcommands, so the only thing keeping it safe is "
+            f"where it is aimed — and aiming it at the store would put a "
+            f"writing git inside the only copy of the data this script exists "
+            f"to protect."
+        )
     return subprocess.run(
         ["git", "-c", "gc.auto=0", "-c", "core.hooksPath=" + os.devnull,
          "-c", "protocol.file.allow=always", "-C", str(cwd), *args],
@@ -316,7 +422,10 @@ def _git_scratch(cwd: Path, *args: str) -> subprocess.CompletedProcess:
 
 
 def _refs(run: subprocess.CompletedProcess) -> set[str]:
+    """`{"<refname> <objectname>"}` from a `for-each-ref` in that format."""
     return {ln.strip() for ln in run.stdout.splitlines() if ln.strip()}
+
+
 
 
 def bundle_scope(scope: Path, out: Path, work_dir: Path) -> None:
@@ -353,7 +462,8 @@ def bundle_scope(scope: Path, out: Path, work_dir: Path) -> None:
     # data corruption for a missing directory, which is a message that names the
     # wrong cause at the exact moment someone is deciding whether their backups
     # are intact.
-    work_dir.mkdir(parents=True, exist_ok=True)
+    _private_dir(work_dir)
+    store = scope.parent
 
     p = _git(scope, "bundle", "create", str(out), "--all")
     if p.returncode != 0:
@@ -363,6 +473,10 @@ def bundle_scope(scope: Path, out: Path, work_dir: Path) -> None:
         )
     if not out.is_file() or out.stat().st_size == 0:
         raise BackupError(f"{scope.name}: bundle {out} is missing or empty after create")
+    # Plaintext history of a client-confidential scope, on a real filesystem
+    # under the documented `--no-upload --work-dir X` smoke run. git creates it
+    # 0644 under the operator's umask.
+    os.chmod(out, _FILE_MODE)
 
     v = _git(scope, "bundle", "verify", str(out))
     if v.returncode != 0:
@@ -376,8 +490,24 @@ def bundle_scope(scope: Path, out: Path, work_dir: Path) -> None:
     if rehearsal.exists():
         shutil.rmtree(rehearsal)
     try:
-        c = _git_scratch(work_dir, "clone", "--bare", "--quiet",
-                         str(out), str(rehearsal))
+        # 🔴 `--mirror`, NOT `--bare`. MEASURED 2026-08-22 on a scope carrying
+        # `refs/notes/commits` and `refs/weird/thing` beside `refs/heads/trunk`,
+        # from a bundle created with `--all` that declared all three:
+        #
+        #   git clone --bare   <bundle>  ->  restored refs/heads/trunk ONLY
+        #   git clone --mirror <bundle>  ->  restored all three
+        #
+        # `--bare` uses the default `+refs/heads/*:refs/heads/*` refspec and
+        # SILENTLY DROPS everything else. Two consequences, both bad. It is not
+        # a restore rehearsal at all for those refs — the bundle holds them and
+        # the rehearsal never checks they come back. And because the comparison
+        # below is against what the bundle DECLARES, a scope that ever gained a
+        # notes ref would fail its backup on every run, forever: a
+        # permanently-red gate on a disaster-recovery job. `--mirror` restores
+        # `+refs/*:refs/*`, which is what "this bundle can be restored from"
+        # has to mean for a backup.
+        c = _git_scratch(work_dir, "clone", "--mirror", "--quiet",
+                         str(out), str(rehearsal), forbidden=store)
         if c.returncode != 0:
             raise BackupError(
                 f"{scope.name}: the bundle passed `git bundle verify` but could "
@@ -388,24 +518,59 @@ def bundle_scope(scope: Path, out: Path, work_dir: Path) -> None:
             )
 
         fmt = "--format=%(refname) %(objectname)"
-        want = _refs(_git(scope, "for-each-ref", fmt))
-        got = _refs(_git_scratch(rehearsal, "for-each-ref", fmt))
-        if got != want:
+        got = _refs(_git_scratch(rehearsal, "for-each-ref", fmt, forbidden=store))
+
+        # 🔴 COMPLETENESS BY REF **NAME**, NOT BY (name, objectname) PAIR — AND
+        # THE DIFFERENCE IS A DATA-LOSS BUG, NOT A STYLE CHOICE.
+        #
+        # An earlier version compared the pairs. Nothing locks the scope against
+        # the hourly `analyze-service-index-commit` while this runs, and the
+        # window being compared across contains a FULL CLONE of the scope — so
+        # one ordinary commit landing in it moved `refs/heads/trunk`, the pair
+        # comparison mismatched, and the run reported "the bundle restores to a
+        # DIFFERENT set of refs". The scope lost that day's backup and the
+        # operator was told their archive was corrupt while it cloned cleanly.
+        # REPRODUCED 2026-08-22 with a single commit injected between
+        # `bundle create` and the comparison.
+        #
+        # Names do not race, because `commit.sh` only ever MOVES an existing
+        # branch: it never creates or deletes a ref (it has no code that does,
+        # and no network to fetch one). Which of two adjacent commits the
+        # snapshot captured is not a property a backup needs to have; which REFS
+        # it captured is.
+        #
+        # What still pins the objects: the `--mirror` clone above runs
+        # `index-pack`, which validates every object's hash and the pack
+        # checksum, so a bundle whose bytes do not reconstruct cannot reach this
+        # point at all.
+        #
+        # 🔴 AN OBJECT-LEVEL COMPARISON AGAINST THE BUNDLE'S OWN HEADER WAS
+        # TRIED HERE AND REMOVED. `git bundle list-heads` gives a race-free
+        # reference, and comparing the restore against it looked like a
+        # strictly-better check. A mutation sweep scored it SURVIVED: under a
+        # `--mirror` clone git writes exactly the refs the header declares, so
+        # no input can make the two disagree while the clone succeeds. Same
+        # verdict, and the same reason, as the commit-count comparison noted
+        # below — a guard that cannot fail reads as coverage while providing
+        # none, which is worse than not being there.
+        want_names = {ln.split(" ", 1)[0]
+                      for ln in _refs(_git(scope, "for-each-ref", fmt))}
+        got_names = {ln.split(" ", 1)[0] for ln in got}
+        if got_names != want_names:
             raise BackupError(
                 f"{scope.name}: the bundle restores to a DIFFERENT set of refs "
                 f"than the scope holds. Missing from the restore: "
-                f"{sorted(want - got)}; unexpected in the restore: "
-                f"{sorted(got - want)}. Not uploading it."
+                f"{sorted(want_names - got_names)}; unexpected in the restore: "
+                f"{sorted(got_names - want_names)}. Not uploading it."
             )
 
-        # NOTE: there is deliberately NO separate commit-count comparison here.
-        # An earlier draft had one, and a mutation sweep showed it SURVIVED every
-        # mutation — because it is unreachable: the clone above validates every
-        # object, and matching (refname, objectname) pairs pin the same reachable
-        # commit set by construction, so no input can make the counts differ
-        # while the refs agree. A guard that cannot fail reads as coverage while
-        # providing none, which is worse than not being there, because it stops
-        # the next person looking.
+        # NOTE: there is deliberately NO separate commit-count comparison here
+        # either — the second guard removed from this function for being
+        # unreachable, and for the same measured reason. The `--mirror` clone
+        # validates every object, so a count against the RESTORE cannot differ
+        # from the bundle; and a count against the LIVE SCOPE would be worse
+        # than merely unreachable, because it is exactly the race described
+        # above, reintroduced under a different name.
     finally:
         shutil.rmtree(rehearsal, ignore_errors=True)
 
@@ -479,7 +644,19 @@ class MinioUploader:
 
         self._ctx = MinioArchive()
         self._mc = self._ctx.__enter__()
-        self._mc.ensure_bucket(self.bucket)
+        # 🔴 `__exit__` is NOT called when `__enter__` raises, so anything after
+        # the inner enter must clean up after itself or the `kubectl
+        # port-forward` child outlives the run. `ensure_bucket` is a live call
+        # to the tenant and can absolutely raise (S3Error, a dead forward, a
+        # credential that no longer works) — leaving a forwarder holding a local
+        # port until the unit's TimeoutStartSec kills the cgroup.
+        try:
+            self._mc.ensure_bucket(self.bucket)
+        except BaseException:
+            self._ctx.__exit__(*sys.exc_info())
+            self._ctx = None
+            self._mc = None
+            raise
         return self
 
     def __exit__(self, *exc):
@@ -546,13 +723,30 @@ def prune(uploader, prefix: str, keep: int, just_uploaded: str) -> list[str]:
     Keys embed a UTC timestamp in a fixed-width sortable form, so lexical order
     IS chronological order and no per-object stat is needed.
 
-    🔴 Two refusals, both of which are the difference between retention and data
-    loss. If the listing does not contain the object we just uploaded, the view
-    we are about to prune from is not the bucket we just wrote to — a wrong
+    🔴 Three refusals, all of which are the difference between retention and
+    data loss.
+
+    MEMBERSHIP. If the listing does not contain the object we just uploaded, the
+    view we are about to prune from is not the bucket we just wrote to — a wrong
     prefix, a stale list, a different bucket — and deleting from it would remove
     real backups on the strength of a listing we have already caught being
-    wrong. And `keep` below 1 is refused outright: a retention policy that keeps
-    nothing is a delete-everything policy wearing a retention policy's name.
+    wrong.
+
+    🔴 SURVIVAL, WHICH IS NOT THE SAME CLAIM AND IS THE ONE THAT MATTERS.
+    Membership only says the new object is *somewhere* in the listing; it says
+    nothing about whether it is in the set about to be DELETED. Lexical order is
+    chronological order only while the clock moves forward, and it does not
+    always: an NTP correction, or a laptop RTC after a suspend, steps it
+    BACKWARDS. Today's key then sorts OLDEST, and every subsequent run uploads,
+    verifies, prints "verified", and immediately deletes its own upload —
+    membership satisfied throughout. The bucket silently stops advancing while
+    the timer stays green and the log says the backup succeeded, which is the
+    exact false all-clear this file exists to prevent. Deleting what we just
+    wrote is never the correct outcome of a retention pass, whatever the clock
+    says, so it is refused outright rather than reordered around.
+
+    KEEP. `keep` below 1 is refused: a retention policy that keeps nothing is a
+    delete-everything policy wearing a retention policy's name.
     """
     if keep < 1:
         raise BackupError(f"--keep must be at least 1, got {keep}: a retention "
@@ -566,6 +760,18 @@ def prune(uploader, prefix: str, keep: int, just_uploaded: str) -> list[str]:
             f"so pruning from it could delete real backups."
         )
     doomed = keys[:-keep] if len(keys) > keep else []
+    if just_uploaded in doomed:
+        raise BackupError(
+            f"refusing to prune {prefix}: retention would DELETE THE OBJECT "
+            f"THIS RUN JUST UPLOADED ({just_uploaded}). Its key sorts among the "
+            f"{len(doomed)} oldest of {len(keys)}, which means this host's clock "
+            f"has moved backwards relative to the existing backups (an NTP "
+            f"correction, or an RTC restored after suspend). Pruning here would "
+            f"leave the run reporting a verified backup that no longer exists, "
+            f"and would do so on every future run — a bucket that silently "
+            f"stops advancing behind a green timer. Fix the clock; nothing has "
+            f"been deleted."
+        )
     for k in doomed:
         uploader.remove(k)
     return doomed
@@ -626,8 +832,10 @@ def run(store: Path, *, bucket: str, keep: int, upload: bool,
     # `run()` owns its scratch directory. It used to rely on the caller having
     # made it, which meant `git bundle create` failed with "Unable to create
     # …/x.bundle.lock: No such file or directory" — a message that names the
-    # bundle and points at git, for a fault that is neither.
-    work_dir.mkdir(parents=True, exist_ok=True)
+    # bundle and points at git, for a fault that is neither. 0700 because a
+    # plaintext bundle and a rehearsal clone of a client-confidential scope both
+    # live here, and `--work-dir` may be an ordinary directory on a real disk.
+    _private_dir(work_dir)
 
     identity = resolve_identity()
     recipient = resolve_recipient(identity)
@@ -660,8 +868,20 @@ def run(store: Path, *, bucket: str, keep: int, upload: bool,
 
                 plain = work_dir / f"{scope.name}.bundle"
                 cipher = work_dir / f"{scope.name}.bundle.age"
-                bundle_scope(scope, plain, work_dir)
-                encrypt(plain, cipher, recipient)
+                try:
+                    bundle_scope(scope, plain, work_dir)
+                    encrypt(plain, cipher, recipient)
+                finally:
+                    # 🔴 THE PLAINTEXT BUNDLE DIES HERE, ON EVERY PATH. It is a
+                    # complete unencrypted copy of a client-confidential scope,
+                    # and the whole design rests on the content being encrypted
+                    # BEFORE it exists anywhere durable. `finally`, not the
+                    # success path: a failed encryption is exactly when a
+                    # plaintext copy is most likely to be left behind and least
+                    # likely to be noticed. PrivateTmp contains the default case
+                    # under the unit; the documented `--no-upload --work-dir X`
+                    # smoke run against the real store has no namespace at all.
+                    plain.unlink(missing_ok=True)
                 data = cipher.read_bytes()
 
                 if uploader is not None:
@@ -674,12 +894,33 @@ def run(store: Path, *, bucket: str, keep: int, upload: bool,
                     print(f"{PROG}: {scope.name}: {n} commits -> {cipher} "
                           f"({len(data)} bytes, verified, NOT uploaded)")
                 done += 1
-            except BackupError as exc:
+            except Exception as exc:  # noqa: BLE001 — see below; this is the point
                 # One scope failing must not stop the others being backed up —
                 # but it MUST make the run fail. A partial backup reported as a
                 # success is the false all-clear this file exists to prevent.
-                failures.append(str(exc))
-                print(f"{PROG}: FAILED {scope.name}: {exc}", file=sys.stderr)
+                #
+                # 🔴 `Exception`, NOT `BackupError`. This handler used to catch
+                # only the latter, and the comment above claimed isolation the
+                # code did not provide: `uploader.put/list/remove` go through
+                # the minio client, which raises `S3Error` and urllib3
+                # connection errors — neither a BackupError. One scope hitting a
+                # dead port-forward therefore escaped this handler AND `run()`
+                # entirely, abandoning every scope after it in the alphabet and
+                # handing the operator a bare traceback. The scopes are
+                # independent by construction; nothing about scope N failing
+                # says anything about scope N+1, so the isolation has to be as
+                # wide as the failures that can actually arrive.
+                #
+                # The class name is recorded because for a non-BackupError the
+                # type IS most of the diagnosis (`S3Error` vs `TimeoutError` vs
+                # `FileNotFoundError` are three different faults), and str() on
+                # them is frequently uninformative.
+                label = (str(exc) if isinstance(exc, BackupError)
+                         else f"{type(exc).__name__}: {exc}")
+                failures.append(label)
+                print(f"{PROG}: FAILED {scope.name}: {label}", file=sys.stderr)
+                if not isinstance(exc, BackupError):
+                    traceback.print_exc()
     finally:
         if ctx is not None:
             ctx.__exit__(None, None, None)
@@ -737,9 +978,14 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--bucket", default=os.environ.get("ASIB_BUCKET", DEFAULT_BUCKET))
     ap.add_argument("--keep", type=int, default=int(os.environ.get("ASIB_KEEP", DEFAULT_KEEP)))
     ap.add_argument("--no-upload", action="store_true",
-                    help="bundle+verify+encrypt only; leave the artifacts in --work-dir")
+                    help="bundle+verify+encrypt only, no upload. WITH --work-dir "
+                         "the encrypted artifact is left there; WITHOUT it, "
+                         "everything is built in a private temp dir that is "
+                         "deleted on exit and nothing survives the run. The "
+                         "plaintext bundle is unlinked either way.")
     ap.add_argument("--work-dir", type=Path, default=None,
-                    help="where to build artifacts (default: a private temp dir)")
+                    help="where to build artifacts, created 0700 (default: a "
+                         "private temp dir, deleted on exit)")
     ap.add_argument("--print-plan", action="store_true",
                     help="print what would happen; write nothing")
     args = ap.parse_args(argv)
@@ -750,7 +996,7 @@ def main(argv: list[str] | None = None) -> int:
             return 0
 
         if args.work_dir is not None:
-            args.work_dir.mkdir(parents=True, exist_ok=True)
+            _private_dir(args.work_dir)
             n = run(args.store, bucket=args.bucket, keep=args.keep,
                     upload=not args.no_upload, work_dir=args.work_dir)
         else:
@@ -763,6 +1009,22 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     except BackupError as exc:
         print(f"{PROG}: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:  # noqa: BLE001 — the timer's failure signal, not a swallow
+        # 🔴 NOT EVERY FAILURE IS A BackupError, and the ones that are not are
+        # the ones nobody wrote a message for. `S3Error` from the minio client,
+        # a urllib3 connection error, a `FileNotFoundError` for a binary the
+        # unit's PATH forgot — each previously reached the interpreter's default
+        # handler, which prints a traceback with no statement of what it means
+        # for the BACKUP. The traceback is kept, because for these the type and
+        # the stack ARE the diagnosis; what is added is the sentence that says
+        # this run backed nothing up. Still exit 1: `OnFailure` on the unit is
+        # what turns this into a notification.
+        traceback.print_exc()
+        print(f"{PROG}: FAILED with an unexpected {type(exc).__name__}: {exc}. "
+              f"Nothing was backed up on this run, or only part of it was — "
+              f"treat this as NO backup for today and read the traceback above.",
+              file=sys.stderr)
         return 1
 
 

--- a/scripts/analyze-service-index/backup.py
+++ b/scripts/analyze-service-index/backup.py
@@ -1,0 +1,770 @@
+#!/usr/bin/env python3
+"""Encrypted OFF-MACHINE backup for the /analyze-service index store.
+
+WHAT THIS CLOSES
+----------------
+`~/.claude/analyze-service-index/<scope>/` is one independent git repository per
+scope. `commit.sh` (the hourly autocommit) gives every scope local history, which
+defends against exactly one failure mode: an agent's Write clobbering a file that
+a previous run had already committed.
+
+It defends against NOTHING ELSE. Measured on the workbench 2026-08-21: 10 scope
+repos, every one of them `remote = none`, and no copy of any of them anywhere off
+this disk. A disk failure, a filesystem corruption, or an `rm -rf` of the store
+root loses the whole thing permanently, history included — the history lives
+*inside* the thing being destroyed. The content is not re-derivable: it records
+gotchas, retracted theories and measurements that were true at a moment.
+
+The laptop's store is DIVERGENT content, not a copy. It is a second thing to
+lose, not a backup of the first.
+
+WHY BUNDLES, AND WHY NO REMOTE
+------------------------------
+🔴 Every scope README states the no-remote invariant, and `commit.sh` is built
+around it (its systemd unit runs with `PrivateNetwork=true` so the invariant is
+enforced by the namespace, not by prose). A `git bundle` preserves that
+literally: it is a single file containing the full object graph and all refs,
+produced by a command that only READS the repository. No remote is added, no
+push happens, no `git config` is written, and this script never runs a git
+subcommand outside `_READ_ONLY_SUBCOMMANDS` below.
+
+That read-only-ness is not asserted, it is measured: the test suite checksums a
+synthetic store before and after a full run and requires byte identity, and
+separately requires that every scope still reports zero remotes.
+
+WHY age, WHEN MINIO IS SELF-HOSTED
+----------------------------------
+🔴 The store is client-confidential and the scope READMEs say the content never
+leaves the machine. MinIO being on the operator's own homelab makes that *nearly*
+true, not true. Encrypting to the operator's age identity before the bytes leave
+the process makes it literally true: MinIO stores ciphertext it cannot read, and
+a compromised or misconfigured bucket policy discloses nothing.
+
+The identity is the one that ALREADY EXISTS — the SOPS age key used across the
+homelab repos (`~/workspace/homelab-talos/.secrets/age.key`, recipient
+`age1g0nf…dj64t` in that repo's `.sops.yaml`). No new key is minted, because a
+backup encrypted to a key the operator does not already keep alive is a backup
+that will not decrypt when it is finally needed. The RECIPIENT is DERIVED from
+the identity file at run time rather than hardcoded here: devrc is public, and
+more importantly a hardcoded recipient can silently drift from the key the
+operator actually holds, producing archives nobody can open. Deriving it makes
+"the thing we encrypt to" and "the thing we can decrypt with" the same fact.
+
+🔴 EVERY EMPTY OUTCOME IS LOUD
+------------------------------
+A backup system that reports success having stored nothing is worse than no
+backup system, because it is also a false all-clear. So:
+
+  * a store directory that EXISTS but holds no scopes  -> failure
+  * a scope whose repository holds zero commits        -> failure
+  * a bundle that does not pass `git bundle verify`    -> failure, not uploaded
+  * an upload whose read-back size/etag disagrees      -> failure
+  * a run that backed up zero scopes                   -> failure
+
+The single exception is an ABSENT store: a host that has never run
+/analyze-service has nothing to lose, and failing there would make the timer a
+permanently-red gate on the laptop (RULES.md: "a permanently-red gate is worse
+than no gate"). That path prints its reason and exits 0, and it is the only one
+that may.
+
+Usage:
+    backup.py [--store DIR] [--bucket B] [--keep N] [--no-upload] [--print-plan]
+
+  --print-plan   pure text; reads the store, writes nothing anywhere
+  --no-upload    bundle + verify + encrypt into --work-dir, then stop. Used for
+                 a read-only smoke run against the real store.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+PROG = "analyze-service-index-backup"
+
+DEFAULT_STORE = Path.home() / ".claude" / "analyze-service-index"
+DEFAULT_BUCKET = "analyze-service-index-backups"
+DEFAULT_KEEP = 14
+DEFAULT_IDENTITY = Path.home() / "workspace" / "homelab-talos" / ".secrets" / "age.key"
+
+# 🔴 THE READ-ONLY ALLOWLIST. Every git invocation in this file goes through
+# `_git()`, which refuses a subcommand that is not in here. This is the guard
+# that makes "the store is treated as read-only" a property of the code rather
+# than of the author's care — a future edit that reaches for `git gc`, `git
+# remote add` or `git config` fails at the call, not in review.
+#
+# It is pinned by the test suite as an EXACT SET, not a subset: widening it is a
+# deliberate act that has to be argued for in a diff, and shrinking it below
+# what the code needs breaks the tests that exercise those paths.
+_READ_ONLY_SUBCOMMANDS = frozenset(
+    {"bundle", "rev-list", "remote", "rev-parse", "for-each-ref"})
+
+
+class BackupError(RuntimeError):
+    """A failure that must make the whole run non-zero."""
+
+
+# --------------------------------------------------------------------------- #
+# git — read-only by construction
+# --------------------------------------------------------------------------- #
+def _git_env() -> dict:
+    """Environment that makes git structurally incapable of writing to the repo.
+
+    Each entry earns its place:
+
+      GIT_OPTIONAL_LOCKS=0   DEFENCE IN DEPTH, and stated at the scope it was
+                             measured. Some git reads (`git status` is the
+                             standard example) refresh and REWRITE `.git/index`
+                             as a side effect, which would move the store's
+                             mtimes without changing a byte of content. MEASURED
+                             2026-08-21 against a repo with a deliberately stale
+                             index: none of the four subcommands in
+                             `_READ_ONLY_SUBCOMMANDS` touches the index with this
+                             set to 0 OR to 1, while `git status` in the same
+                             probe DID rewrite it. So today this variable changes
+                             nothing — it is here for the subcommand somebody
+                             adds later, not because the current set needs it.
+                             It is NOT what makes the store read-only; the
+                             allowlist and the unit's BindReadOnlyPaths are.
+      GIT_CONFIG_NOSYSTEM=1  no /etc/gitconfig
+      GIT_CONFIG_GLOBAL      no ~/.gitconfig — so the operator's own config can
+      GIT_CONFIG_SYSTEM      neither change what we produce nor be written to.
+      GIT_TERMINAL_PROMPT=0  never block a timer-driven run on a prompt.
+    """
+    env = dict(os.environ)
+    env.update({
+        "GIT_OPTIONAL_LOCKS": "0",
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_SYSTEM": os.devnull,
+        "GIT_TERMINAL_PROMPT": "0",
+    })
+    return env
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    """Run one read-only git subcommand against `repo`.
+
+    Refuses anything outside `_READ_ONLY_SUBCOMMANDS`. `gc.auto=0` stops git
+    from deciding, mid-read, that this repository is due a repack — which is a
+    write, would be perfectly reasonable behaviour, and would silently break the
+    read-only guarantee this whole file rests on. `core.hooksPath=/dev/null`
+    stops a hook in the store from running under the backup's privileges.
+    """
+    if not args or args[0] not in _READ_ONLY_SUBCOMMANDS:
+        raise BackupError(
+            f"refusing git subcommand {args[0] if args else '(none)'!r}: the "
+            f"/analyze-service index store is READ-ONLY to this script. "
+            f"Allowed: {sorted(_READ_ONLY_SUBCOMMANDS)}. If a new subcommand is "
+            f"genuinely needed, prove it cannot write and add it to "
+            f"_READ_ONLY_SUBCOMMANDS in the same commit as the test that pins it."
+        )
+    return subprocess.run(
+        ["git", "-C", str(repo), "-c", "gc.auto=0", "-c", "core.hooksPath=" + os.devnull, *args],
+        capture_output=True, text=True, env=_git_env(),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# discovery
+# --------------------------------------------------------------------------- #
+def discover_scopes(store: Path) -> list[Path]:
+    """Every scope repository directly under `store`, sorted by name.
+
+    A scope is a real directory (never a symlink — `commit.sh` refuses those for
+    the same reason, and following one here would bundle a repository from
+    outside the store) that contains a `.git`.
+    """
+    out: list[Path] = []
+    for child in sorted(store.iterdir()):
+        if child.name.startswith("."):
+            continue
+        if child.is_symlink() or not child.is_dir():
+            continue
+        if (child / ".git").exists():
+            out.append(child)
+    return out
+
+
+def commit_count(scope: Path) -> int:
+    p = _git(scope, "rev-list", "--count", "--all")
+    if p.returncode != 0:
+        raise BackupError(
+            f"{scope.name}: could not count commits (git rev-list rc="
+            f"{p.returncode}): {p.stderr.strip()}. A scope whose history cannot "
+            f"be READ must never be reported as a scope that is EMPTY."
+        )
+    return int(p.stdout.strip() or "0")
+
+
+def scope_remotes(scope: Path) -> list[str]:
+    p = _git(scope, "remote")
+    return [ln for ln in p.stdout.split("\n") if ln.strip()]
+
+
+# --------------------------------------------------------------------------- #
+# age
+# --------------------------------------------------------------------------- #
+def resolve_identity() -> Path:
+    """Path to the operator's age identity file.
+
+    Order: ASIB_AGE_IDENTITY -> SOPS_AGE_KEY_FILE (the handle the homelab repos
+    already use, per SECRETS.md) -> the default homelab-talos path.
+    """
+    for var in ("ASIB_AGE_IDENTITY", "SOPS_AGE_KEY_FILE"):
+        v = os.environ.get(var)
+        if v:
+            return Path(v)
+    return DEFAULT_IDENTITY
+
+
+def resolve_recipient(identity: Path) -> str:
+    """The age recipient to encrypt to, DERIVED from the identity we can decrypt with.
+
+    `ASIB_AGE_RECIPIENT` overrides — but only to a public key, and it is still
+    checked for shape, because a typo here produces archives that encrypt fine
+    and decrypt never.
+    """
+    override = os.environ.get("ASIB_AGE_RECIPIENT")
+    if override:
+        if not re.fullmatch(r"age1[0-9a-z]{58}", override.strip()):
+            raise BackupError(
+                f"ASIB_AGE_RECIPIENT={override!r} is not a well-formed age public "
+                f"key (expected age1 + 58 base32 chars). Refusing to encrypt to "
+                f"it: a backup encrypted to a malformed recipient is a backup "
+                f"that cannot be restored, and nothing downstream would notice."
+            )
+        return override.strip()
+
+    if not identity.is_file():
+        raise BackupError(
+            f"no age identity at {identity}. This backup encrypts to the "
+            f"operator's EXISTING SOPS age key; it deliberately does not mint a "
+            f"new one, because a key nobody keeps alive is a backup nobody can "
+            f"open. Set ASIB_AGE_IDENTITY or SOPS_AGE_KEY_FILE to the key file "
+            f"(see SECRETS.md)."
+        )
+    if shutil.which("age-keygen") is None:
+        raise BackupError(
+            "age-keygen is not on PATH — it is declared in nix/pkgs/default.nix "
+            "and set explicitly on the systemd unit's PATH; add it there rather "
+            "than working around it."
+        )
+    p = subprocess.run(["age-keygen", "-y", str(identity)],
+                       capture_output=True, text=True)
+    if p.returncode != 0:
+        raise BackupError(
+            f"could not derive an age recipient from {identity} (rc="
+            f"{p.returncode}): {p.stderr.strip()}"
+        )
+    recipient = p.stdout.strip()
+    if not recipient.startswith("age1"):
+        raise BackupError(
+            f"age-keygen -y on {identity} produced {recipient!r}, which is not an "
+            f"age public key. Refusing to encrypt to it."
+        )
+    return recipient
+
+
+def encrypt(plain: Path, cipher: Path, recipient: str) -> None:
+    if shutil.which("age") is None:
+        raise BackupError(
+            "age is not on PATH — it is declared in nix/pkgs/default.nix and set "
+            "explicitly on the systemd unit's PATH; add it there rather than "
+            "working around it. Uploading the plaintext bundle instead is NOT an "
+            "acceptable fallback and this script will not do it."
+        )
+    p = subprocess.run(
+        ["age", "--encrypt", "--recipient", recipient, "--output", str(cipher), str(plain)],
+        capture_output=True, text=True,
+    )
+    if p.returncode != 0:
+        raise BackupError(f"age encryption of {plain.name} failed (rc={p.returncode}): "
+                          f"{p.stderr.strip()}")
+    if not cipher.is_file() or cipher.stat().st_size == 0:
+        raise BackupError(
+            f"age reported success but {cipher} is missing or empty. An empty "
+            f"ciphertext uploads happily and restores never."
+        )
+
+
+# --------------------------------------------------------------------------- #
+# bundling
+# --------------------------------------------------------------------------- #
+def _git_scratch(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    """git in a THROWAWAY directory — never the store.
+
+    The allowlist on `_git` exists because that function is pointed at the only
+    copy of the data. This one is pointed at a directory we created moments ago
+    and are about to delete, so it may run writing subcommands (`clone`). It
+    refuses to run anywhere near the store, so the two cannot be confused by a
+    later edit.
+    """
+    return subprocess.run(
+        ["git", "-c", "gc.auto=0", "-c", "core.hooksPath=" + os.devnull,
+         "-c", "protocol.file.allow=always", "-C", str(cwd), *args],
+        capture_output=True, text=True, env=_git_env(),
+    )
+
+
+def _refs(run: subprocess.CompletedProcess) -> set[str]:
+    return {ln.strip() for ln in run.stdout.splitlines() if ln.strip()}
+
+
+def bundle_scope(scope: Path, out: Path, work_dir: Path) -> None:
+    """`git bundle create --all`, then PROVE the bundle restores, before upload.
+
+    🔴 `git bundle verify` IS NOT AN INTEGRITY CHECK, AND READS EXACTLY LIKE ONE.
+    Measured 2026-08-21, git 2.x, on a 504-byte bundle with a single byte flipped
+    in the middle of the packfile:
+
+        git bundle verify <corrupted>  ->  rc=0
+        "<oid> HEAD"
+        "The bundle records a complete history."
+
+    It validates the bundle HEADER and the PREREQUISITES. It does not walk the
+    pack, so bit rot, a truncated write or a partial copy all pass it — and it
+    says "complete history" while doing so. A backup pipeline that stops there
+    uploads corrupt archives under a green verdict, which is worse than not
+    checking at all: it manufactures confidence. The same byte flip fails a
+    clone at rc=128, `error: index-pack died`.
+
+    So the real check is a RESTORE REHEARSAL: clone the bundle into a throwaway
+    bare repository — which forces `index-pack` to validate every object's hash
+    and the pack checksum — and then compare the restored ref set and commit
+    count against the source. That is the same standard applied to the upload
+    read-back, and for the same reason: the only evidence a backup is restorable
+    is having restored it.
+
+    `bundle verify` is kept in front of it because it is cheap and its message
+    for a genuine prerequisite problem is clearer than a clone failure's.
+    """
+    # Own the scratch directory here too. Without this the rehearsal clone
+    # failed with "cannot change to <work_dir>: No such file or directory" and
+    # was reported as "the bundle could NOT BE RESTORED FROM" — a guard blaming
+    # data corruption for a missing directory, which is a message that names the
+    # wrong cause at the exact moment someone is deciding whether their backups
+    # are intact.
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    p = _git(scope, "bundle", "create", str(out), "--all")
+    if p.returncode != 0:
+        raise BackupError(
+            f"{scope.name}: `git bundle create` failed (rc={p.returncode}): "
+            f"{p.stderr.strip()}"
+        )
+    if not out.is_file() or out.stat().st_size == 0:
+        raise BackupError(f"{scope.name}: bundle {out} is missing or empty after create")
+
+    v = _git(scope, "bundle", "verify", str(out))
+    if v.returncode != 0:
+        raise BackupError(
+            f"{scope.name}: `git bundle verify` REJECTED the bundle (rc="
+            f"{v.returncode}): {v.stderr.strip() or v.stdout.strip()}. Not "
+            f"uploading it — an unverified bundle is a claim, not a backup."
+        )
+
+    rehearsal = work_dir / f".rehearse-{scope.name}.git"
+    if rehearsal.exists():
+        shutil.rmtree(rehearsal)
+    try:
+        c = _git_scratch(work_dir, "clone", "--bare", "--quiet",
+                         str(out), str(rehearsal))
+        if c.returncode != 0:
+            raise BackupError(
+                f"{scope.name}: the bundle passed `git bundle verify` but could "
+                f"NOT BE RESTORED FROM (clone rc={c.returncode}): "
+                f"{c.stderr.strip()}. `bundle verify` does not walk the packfile, "
+                f"so this is what a corrupted or truncated bundle looks like. Not "
+                f"uploading it."
+            )
+
+        fmt = "--format=%(refname) %(objectname)"
+        want = _refs(_git(scope, "for-each-ref", fmt))
+        got = _refs(_git_scratch(rehearsal, "for-each-ref", fmt))
+        if got != want:
+            raise BackupError(
+                f"{scope.name}: the bundle restores to a DIFFERENT set of refs "
+                f"than the scope holds. Missing from the restore: "
+                f"{sorted(want - got)}; unexpected in the restore: "
+                f"{sorted(got - want)}. Not uploading it."
+            )
+
+        # NOTE: there is deliberately NO separate commit-count comparison here.
+        # An earlier draft had one, and a mutation sweep showed it SURVIVED every
+        # mutation — because it is unreachable: the clone above validates every
+        # object, and matching (refname, objectname) pairs pin the same reachable
+        # commit set by construction, so no input can make the counts differ
+        # while the refs agree. A guard that cannot fail reads as coverage while
+        # providing none, which is worse than not being there, because it stops
+        # the next person looking.
+    finally:
+        shutil.rmtree(rehearsal, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# upload boundary
+# --------------------------------------------------------------------------- #
+def resolve_kubeconfig() -> Path | None:
+    """Which kubeconfig reaches the homelab from THIS host.
+
+    🔴 The two hosts reach the same cluster by different files, and both stores
+    need backing up: the workbench has the checked-out
+    `homelab-talos/homelab-kubeconfig`, the laptop reaches it over nebula via
+    `~/.kube/homelab-nebula.yaml` (SECRETS.md, `$KC_NEBULA`). Hardcoding the
+    workbench's path in the unit would leave the laptop's — DIVERGENT, equally
+    unrecoverable — store with no off-machine copy while the workbench looked
+    healthy. That is the exact silent gap this whole change exists to close, so
+    the resolution is done here where it can adapt, not in the unit where it
+    cannot.
+
+    An already-set KUBECONFIG always wins: the operator and the unit both set it
+    deliberately.
+    """
+    existing = os.environ.get("KUBECONFIG")
+    if existing and Path(existing).is_file():
+        return Path(existing)
+    for candidate in (
+        Path.home() / "workspace" / "homelab-talos" / "homelab-kubeconfig",
+        Path.home() / ".kube" / "homelab-nebula.yaml",
+    ):
+        if candidate.is_file():
+            os.environ["KUBECONFIG"] = str(candidate)
+            return candidate
+    return None
+
+
+class MinioUploader:
+    """The real object store: the homelab `minio-archive` tenant.
+
+    🔴 Deliberately a THIN wrapper over `scripts/mail-actions/_minio.py` rather
+    than a second implementation. That module already owns how this host reaches
+    the tenant — the `kubectl port-forward` to `svc/minio` in namespace
+    `minio-archive`, the credential read from the `minio-archive-config` secret's
+    `config.env`, the path-style client — and a second convention for the same
+    endpoint is a defect: it is one more thing to rotate, and the copy that
+    nobody exercises is the one that is broken when it is needed.
+
+    stat/list/remove are not on `MinioArchive`'s surface, so they go through its
+    `.client`. That reuses the connection, credentials and port-forward while
+    leaving another subsystem's file untouched.
+    """
+
+    def __init__(self, bucket: str):
+        self.bucket = bucket
+        self._ctx = None
+        self._mc = None
+
+    def __enter__(self):
+        if resolve_kubeconfig() is None and not os.environ.get("MINIO_ARCHIVE_ENDPOINT"):
+            raise BackupError(
+                "no kubeconfig reaches the homelab from this host (looked at "
+                "KUBECONFIG, ~/workspace/homelab-talos/homelab-kubeconfig and "
+                "~/.kube/homelab-nebula.yaml) and MINIO_ARCHIVE_ENDPOINT is not "
+                "set. Refusing to continue: without a route to the tenant there "
+                "is nowhere to put the backup, and a run that discovers that "
+                "AFTER reporting success is the false all-clear this script "
+                "exists to prevent."
+            )
+        sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "mail-actions"))
+        from _minio import MinioArchive  # noqa: E402  (lazy: needs the minio pkg)
+
+        self._ctx = MinioArchive()
+        self._mc = self._ctx.__enter__()
+        self._mc.ensure_bucket(self.bucket)
+        return self
+
+    def __exit__(self, *exc):
+        if self._ctx is not None:
+            self._ctx.__exit__(*exc)
+
+    def put(self, key: str, data: bytes) -> None:
+        self._mc.put_object(self.bucket, key, data, "application/octet-stream")
+
+    def stat(self, key: str) -> tuple[int, str]:
+        st = self._mc.client.stat_object(self.bucket, key)
+        return int(st.size), str(st.etag or "").strip('"')
+
+    def list(self, prefix: str) -> list[str]:
+        return [o.object_name for o in
+                self._mc.client.list_objects(self.bucket, prefix=prefix, recursive=True)]
+
+    def remove(self, key: str) -> None:
+        self._mc.client.remove_object(self.bucket, key)
+
+
+def upload_and_verify(uploader, key: str, data: bytes) -> None:
+    """Upload, then READ BACK and compare. A 200 is not evidence the bytes landed.
+
+    🔴 The read-back is the whole point of this function. `put_object` returning
+    without raising says the client was satisfied; it says nothing about what is
+    now in the bucket. We compare the size always, and the etag whenever it looks
+    like a plain single-part MD5 (32 hex chars, no `-N` multipart suffix) —
+    a multipart etag is a digest of digests and is NOT comparable to the
+    object's MD5, so treating it as one would either fail every large upload or,
+    worse, be "fixed" later by dropping the check.
+    """
+    uploader.put(key, data)
+    try:
+        size, etag = uploader.stat(key)
+    except Exception as exc:  # noqa: BLE001 — any read-back failure is a failed backup
+        raise BackupError(
+            f"upload of {key} reported success but the object could not be read "
+            f"back ({exc.__class__.__name__}: {exc}). Treating it as a FAILED "
+            f"backup: an upload nobody confirmed is indistinguishable from one "
+            f"that never happened."
+        ) from exc
+
+    if size != len(data):
+        raise BackupError(
+            f"upload of {key} did not land intact: sent {len(data)} bytes, the "
+            f"store reports {size}."
+        )
+    if re.fullmatch(r"[0-9a-f]{32}", etag):
+        local = hashlib.md5(data).hexdigest()  # noqa: S324 — S3 etag, not a security digest
+        if etag != local:
+            raise BackupError(
+                f"upload of {key} landed with the wrong content: etag {etag} != "
+                f"local md5 {local}."
+            )
+
+
+# --------------------------------------------------------------------------- #
+# retention
+# --------------------------------------------------------------------------- #
+def prune(uploader, prefix: str, keep: int, just_uploaded: str) -> list[str]:
+    """Keep the newest `keep` objects under `prefix`; delete the rest.
+
+    Keys embed a UTC timestamp in a fixed-width sortable form, so lexical order
+    IS chronological order and no per-object stat is needed.
+
+    🔴 Two refusals, both of which are the difference between retention and data
+    loss. If the listing does not contain the object we just uploaded, the view
+    we are about to prune from is not the bucket we just wrote to — a wrong
+    prefix, a stale list, a different bucket — and deleting from it would remove
+    real backups on the strength of a listing we have already caught being
+    wrong. And `keep` below 1 is refused outright: a retention policy that keeps
+    nothing is a delete-everything policy wearing a retention policy's name.
+    """
+    if keep < 1:
+        raise BackupError(f"--keep must be at least 1, got {keep}: a retention "
+                          f"policy that keeps zero backups is not a retention policy.")
+    keys = sorted(uploader.list(prefix))
+    if just_uploaded not in keys:
+        raise BackupError(
+            f"refusing to prune {prefix}: the object just uploaded "
+            f"({just_uploaded}) is not in the listing of {len(keys)} object(s). "
+            f"The listing does not describe the bucket that was just written to, "
+            f"so pruning from it could delete real backups."
+        )
+    doomed = keys[:-keep] if len(keys) > keep else []
+    for k in doomed:
+        uploader.remove(k)
+    return doomed
+
+
+# --------------------------------------------------------------------------- #
+# naming
+# --------------------------------------------------------------------------- #
+def host_label() -> str:
+    """Which machine this store came from.
+
+    🔴 Both machines are hostname `nixos` (see MEMORY.md / SECRETS.md), and the
+    two stores are DIVERGENT content. Without a distinct label per host they
+    would share a key prefix and silently evict each other under retention —
+    turning the backup into a second way to lose the data.
+    """
+    for var in ("ASIB_HOST", "ACTIVITY_HOST"):
+        v = os.environ.get(var)
+        if v and v.strip():
+            return re.sub(r"[^A-Za-z0-9._-]", "-", v.strip())
+    return re.sub(r"[^A-Za-z0-9._-]", "-", socket.gethostname() or "unknown")
+
+
+def object_key(host: str, scope: str, when: datetime) -> str:
+    stamp = when.strftime("%Y%m%dT%H%M%SZ")
+    return f"{host}/{scope}/{stamp}.bundle.age"
+
+
+def scope_prefix(host: str, scope: str) -> str:
+    return f"{host}/{scope}/"
+
+
+# --------------------------------------------------------------------------- #
+# main
+# --------------------------------------------------------------------------- #
+def run(store: Path, *, bucket: str, keep: int, upload: bool,
+        work_dir: Path, uploader_factory=None) -> int:
+    """Back up every scope. Returns the number of scopes backed up (never 0)."""
+    if not store.exists():
+        # The ONLY empty outcome permitted to be a success. See module docstring.
+        print(f"{PROG}: no store at {store} — nothing to back up", file=sys.stderr)
+        return -1
+
+    if not store.is_dir():
+        raise BackupError(f"{store} exists but is not a directory")
+
+    scopes = discover_scopes(store)
+    if not scopes:
+        raise BackupError(
+            f"{store} EXISTS but contains no scope repositories. That is not an "
+            f"empty backup, it is an unexplained one: the directory being there "
+            f"means /analyze-service has run on this host, so a store with "
+            f"nothing in it means the scopes were removed, not that there was "
+            f"never anything to save. Refusing to report a successful backup of "
+            f"nothing."
+        )
+
+    # `run()` owns its scratch directory. It used to rely on the caller having
+    # made it, which meant `git bundle create` failed with "Unable to create
+    # …/x.bundle.lock: No such file or directory" — a message that names the
+    # bundle and points at git, for a fault that is neither.
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    identity = resolve_identity()
+    recipient = resolve_recipient(identity)
+    host = host_label()
+    when = datetime.now(timezone.utc)
+
+    ctx = None
+    uploader = None
+    if upload:
+        factory = uploader_factory or (lambda: MinioUploader(bucket))
+        ctx = factory()
+        uploader = ctx.__enter__()
+
+    done = 0
+    failures: list[str] = []
+    try:
+        for scope in scopes:
+            try:
+                n = commit_count(scope)
+                if n == 0:
+                    raise BackupError(
+                        f"{scope.name}: the scope repository has ZERO commits. "
+                        f"`git bundle create --all` cannot make a bundle from it, "
+                        f"and a scope skipped quietly here is a scope with no "
+                        f"off-machine copy that the run would still call a "
+                        f"success. Either the hourly autocommit has not run since "
+                        f"the scope was created, or its history was destroyed — "
+                        f"both need a human."
+                    )
+
+                plain = work_dir / f"{scope.name}.bundle"
+                cipher = work_dir / f"{scope.name}.bundle.age"
+                bundle_scope(scope, plain, work_dir)
+                encrypt(plain, cipher, recipient)
+                data = cipher.read_bytes()
+
+                if uploader is not None:
+                    key = object_key(host, scope.name, when)
+                    upload_and_verify(uploader, key, data)
+                    pruned = prune(uploader, scope_prefix(host, scope.name), keep, key)
+                    print(f"{PROG}: {scope.name}: {n} commits -> {len(data)} bytes "
+                          f"-> {key} (verified; pruned {len(pruned)})")
+                else:
+                    print(f"{PROG}: {scope.name}: {n} commits -> {cipher} "
+                          f"({len(data)} bytes, verified, NOT uploaded)")
+                done += 1
+            except BackupError as exc:
+                # One scope failing must not stop the others being backed up —
+                # but it MUST make the run fail. A partial backup reported as a
+                # success is the false all-clear this file exists to prevent.
+                failures.append(str(exc))
+                print(f"{PROG}: FAILED {scope.name}: {exc}", file=sys.stderr)
+    finally:
+        if ctx is not None:
+            ctx.__exit__(None, None, None)
+
+    if failures:
+        raise BackupError(
+            f"{len(failures)} of {len(scopes)} scope(s) failed to back up; "
+            f"{done} succeeded. First failure: {failures[0]}"
+        )
+    if done == 0:
+        raise BackupError(
+            f"backed up 0 of {len(scopes)} scope(s) without recording a failure. "
+            f"This is a bug in the backup script itself; refusing to exit 0."
+        )
+    return done
+
+
+def print_plan(store: Path, bucket: str, keep: int) -> None:
+    """Pure text. Reads the store; writes nothing, anywhere, ever."""
+    print(f"store:     {store}")
+    print(f"bucket:    {bucket}")
+    print(f"keep:      {keep} per scope")
+    print(f"host:      {host_label()}")
+    print("remote:    NONE — no git remote is added to any scope, ever")
+    print("encrypt:   age, to the operator's existing SOPS identity, BEFORE upload")
+    # Written from what the code DOES, not from what the design intended. An
+    # earlier version of this line said "git bundle verify before upload", which
+    # was true and badly incomplete: `bundle verify` passes a byte-flipped
+    # bundle at rc=0, so it is the restore rehearsal that carries the claim.
+    print("verify:    bundle verify, then a RESTORE REHEARSAL (bare clone + ref")
+    print("           comparison) — `git bundle verify` alone passes a corrupted")
+    print("           bundle at rc=0; then a read-back of size/etag after upload")
+    identity = resolve_identity()
+    print(f"identity:  {identity} ({'present' if identity.is_file() else 'MISSING'})")
+    if not store.exists():
+        print(f"scope:     (no store at {store})")
+        return
+    scopes = discover_scopes(store)
+    if not scopes:
+        print(f"scope:     (none found under {store}) — this would FAIL the run")
+        return
+    for s in scopes:
+        try:
+            n = commit_count(s)
+        except BackupError:
+            n = -1
+        note = " — ZERO COMMITS, would FAIL the run" if n == 0 else ""
+        print(f"scope:     {s.name} ({n} commits){note}")
+        print(f"  key:     {object_key(host_label(), s.name, datetime.now(timezone.utc))}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog=PROG, description=__doc__)
+    ap.add_argument("--store", type=Path, default=DEFAULT_STORE)
+    ap.add_argument("--bucket", default=os.environ.get("ASIB_BUCKET", DEFAULT_BUCKET))
+    ap.add_argument("--keep", type=int, default=int(os.environ.get("ASIB_KEEP", DEFAULT_KEEP)))
+    ap.add_argument("--no-upload", action="store_true",
+                    help="bundle+verify+encrypt only; leave the artifacts in --work-dir")
+    ap.add_argument("--work-dir", type=Path, default=None,
+                    help="where to build artifacts (default: a private temp dir)")
+    ap.add_argument("--print-plan", action="store_true",
+                    help="print what would happen; write nothing")
+    args = ap.parse_args(argv)
+
+    try:
+        if args.print_plan:
+            print_plan(args.store, args.bucket, args.keep)
+            return 0
+
+        if args.work_dir is not None:
+            args.work_dir.mkdir(parents=True, exist_ok=True)
+            n = run(args.store, bucket=args.bucket, keep=args.keep,
+                    upload=not args.no_upload, work_dir=args.work_dir)
+        else:
+            with tempfile.TemporaryDirectory(prefix="asi-backup.") as td:
+                n = run(args.store, bucket=args.bucket, keep=args.keep,
+                        upload=not args.no_upload, work_dir=Path(td))
+        if n < 0:
+            return 0
+        print(f"{PROG}: backed up {n} scope(s)")
+        return 0
+    except BackupError as exc:
+        print(f"{PROG}: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_analyze_service_index_backup.py
+++ b/scripts/tests/test_analyze_service_index_backup.py
@@ -1,0 +1,1096 @@
+"""Tests for scripts/analyze-service-index/backup.py — the ENCRYPTED OFF-MACHINE backup.
+
+WHAT IS BEING PROTECTED
+-----------------------
+`~/.claude/analyze-service-index/<scope>/` is one git repository per scope. Until
+this change every one of them had `remote = none` and no copy anywhere off the
+local disk, so the local history — the thing `commit.sh` exists to create — was
+stored inside the same object that a disk failure or an `rm -rf` destroys. The
+content is not re-derivable.
+
+🔴 THE ONLY TEST THAT PROVES THE FEATURE IS THE RESTORE DRILL.
+Everything else here is a supporting control. A backup that produces bytes is
+not a backup; a backup you have restored from is. `test_round_trip_*` builds a
+synthetic store, runs the real producer end to end, decrypts the artifact it
+actually uploaded, clones a repository out of it, and requires the restored
+entry set and commit count to match the source EXACTLY. If that test is ever
+deleted or weakened, this suite stops making any claim worth having.
+
+🔴 ALL FIXTURES ARE SYNTHETIC. devrc is a public repo and the real store is
+client-confidential: no scope name, entry title or path from the live store
+appears here. The synthetic scopes are `scope-alpha`/`scope-beta`/`scope-gamma`
+and their content is lorem-grade filler. Aggregate integers are the only real
+numbers quoted anywhere in this change.
+
+🔴 NOTHING HERE SKIPS. `git` and `age` are both hard requirements, resolved once
+at import: a skipped backup test reports safety it never measured, which for a
+disaster-recovery feature is the worst possible failure mode — it is quiet
+exactly when it is wrong. `age` is declared in nix/pkgs/default.nix and in
+flake.nix's `gateTools`, so its absence is a deployment fault to fix there, not
+a condition to skip on.
+
+Every negative control asserts THIS guard's own message, not merely a non-zero
+exit. A control that goes red because a different guard fired is green for the
+wrong reason and stays green with the guard it claims to test deleted.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+SCRIPT = SCRIPTS / "analyze-service-index" / "backup.py"
+HOME_NIX = ROOT / "nix" / "home.nix"
+FLAKE_NIX = ROOT / "flake.nix"
+PKGS_NIX = ROOT / "nix" / "pkgs" / "default.nix"
+
+sys.path.insert(0, str(SCRIPTS / "analyze-service-index"))
+sys.path.insert(0, str(SCRIPTS))
+
+import backup as B  # noqa: E402
+from testlib.mockbin import write_exec  # noqa: E402
+
+
+def _require(tool: str, why: str) -> str:
+    p = shutil.which(tool)
+    if p is None:  # pragma: no cover - the flake check puts both on PATH
+        raise RuntimeError(
+            f"{tool} is not on PATH. {why} It is declared in nix/pkgs/default.nix "
+            f"and in flake.nix `gateTools`; add it there rather than skipping "
+            f"these tests — a skipped backup test reports safety it never measured."
+        )
+    return p
+
+
+GIT: str = _require("git", "Every scope is a real git repository.")
+AGE: str = _require("age", "The backup is encrypted before it leaves the box.")
+AGE_KEYGEN: str = _require("age-keygen", "The recipient is derived from the identity.")
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _git_env() -> dict:
+    """A git environment that cannot read or write the OPERATOR's real config.
+
+    RULES.md: never `git config --global`. These tests create many repositories;
+    without this they would inherit (and a misbehaving code path could write)
+    the real `~/.gitconfig`.
+    """
+    e = dict(os.environ)
+    e.update({
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_SYSTEM": os.devnull,
+        "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@localhost",
+        "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@localhost",
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_ALLOW_PROTOCOL": "file",
+    })
+    return e
+
+
+def _git_run(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run([GIT, "-C", str(repo), *args],
+                          capture_output=True, text=True, env=_git_env())
+
+
+def _make_scope(store: Path, name: str, entries: dict[str, str], commits: int = 1) -> Path:
+    """A synthetic scope repository: `commits` commits over `entries`."""
+    scope = store / name
+    scope.mkdir(parents=True)
+    subprocess.run([GIT, "init", "-q", "-b", "trunk", str(scope)],
+                   check=True, capture_output=True, env=_git_env())
+    for i in range(commits):
+        for fname, body in entries.items():
+            (scope / fname).write_text(f"{body}\nrevision {i}\n", encoding="utf-8")
+        _git_run(scope, "add", *entries.keys())
+        _git_run(scope, "commit", "-q", "-m", f"synthetic commit {i}")
+    return scope
+
+
+def _empty_scope(store: Path, name: str) -> Path:
+    """A scope repository with a working file but ZERO commits."""
+    scope = store / name
+    scope.mkdir(parents=True)
+    subprocess.run([GIT, "init", "-q", "-b", "trunk", str(scope)],
+                   check=True, capture_output=True, env=_git_env())
+    (scope / "uncommitted.md", )[0].write_text("never committed\n", encoding="utf-8")
+    return scope
+
+
+@pytest.fixture()
+def identity(tmp_path_factory) -> Path:
+    """A throwaway age identity for the suite.
+
+    🔴 NEVER the operator's real key. The tests must exercise the real derive →
+    encrypt → decrypt path, but with key material that is created and destroyed
+    inside the test run.
+    """
+    d = tmp_path_factory.mktemp("age-id")
+    key = d / "test.key"
+    p = subprocess.run([AGE_KEYGEN, "-o", str(key)], capture_output=True, text=True)
+    assert p.returncode == 0, f"age-keygen failed: {p.stderr}"
+    key.chmod(0o600)
+    return key
+
+
+class FakeUploader:
+    """The upload boundary, faked. Records every put; serves stat/list/remove.
+
+    This is where the object store is cut out. The bundling, verification and
+    encryption above it are all REAL — only the network hop is replaced, so the
+    round-trip drill still proves the artifact is restorable.
+    """
+
+    def __init__(self):
+        self.objects: dict[str, bytes] = {}
+        self.puts: list[str] = []
+        self.removed: list[str] = []
+        self.entered = 0
+
+    def __enter__(self):
+        self.entered += 1
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def put(self, key, data):
+        self.puts.append(key)
+        self.objects[key] = data
+
+    def stat(self, key):
+        data = self.objects[key]          # KeyError -> "could not be read back"
+        return len(data), hashlib.md5(data).hexdigest()  # noqa: S324
+
+    def list(self, prefix):
+        return [k for k in self.objects if k.startswith(prefix)]
+
+    def remove(self, key):
+        self.removed.append(key)
+        self.objects.pop(key, None)
+
+
+def _run_backup(store: Path, work: Path, uploader, identity: Path,
+                keep: int = 14) -> int:
+    """Drive the real `run()` with the upload boundary faked."""
+    os.environ["ASIB_AGE_IDENTITY"] = str(identity)
+    os.environ["ASIB_HOST"] = "synthetic-host"
+    try:
+        return B.run(store, bucket="test-bucket", keep=keep, upload=True,
+                     work_dir=work, uploader_factory=lambda: uploader)
+    finally:
+        os.environ.pop("ASIB_AGE_IDENTITY", None)
+        os.environ.pop("ASIB_HOST", None)
+
+
+def _cli(store: Path, *args: str, identity: Path | None = None,
+         env: dict | None = None) -> subprocess.CompletedProcess:
+    e = dict(os.environ)
+    e.update(_git_env())
+    if identity is not None:
+        e["ASIB_AGE_IDENTITY"] = str(identity)
+    e["ASIB_HOST"] = "synthetic-host"
+    if env:
+        e.update(env)
+    return subprocess.run([sys.executable, str(SCRIPT), "--store", str(store), *args],
+                          capture_output=True, text=True, env=e)
+
+
+def _manifest(root: Path) -> dict[str, tuple[int, int, str]]:
+    """Byte-level fingerprint of every file under `root`: size, mtime_ns, sha256.
+
+    🔴 mtime_ns is IN the fingerprint on purpose. A git read that refreshes
+    `.git/index` leaves the content identical and moves the mtime; a manifest
+    that only hashed content would call that "unchanged" and the read-only claim
+    would be false in exactly the way nobody checks.
+    """
+    out = {}
+    for p in sorted(root.rglob("*")):
+        if p.is_symlink() or not p.is_file():
+            continue
+        st = p.stat()
+        out[str(p.relative_to(root))] = (
+            st.st_size, st.st_mtime_ns,
+            hashlib.sha256(p.read_bytes()).hexdigest(),
+        )
+    return out
+
+
+def _decrypt(cipher: bytes, identity: Path, out: Path) -> subprocess.CompletedProcess:
+    src = out.with_suffix(".age")
+    src.write_bytes(cipher)
+    return subprocess.run(
+        [AGE, "--decrypt", "--identity", str(identity), "--output", str(out), str(src)],
+        capture_output=True, text=True)
+
+
+# --------------------------------------------------------------------------- #
+# 0. harness self-validation — validate the INSTRUMENT before reading its verdict
+# --------------------------------------------------------------------------- #
+def test_the_producer_exists():
+    assert SCRIPT.is_file(), f"{SCRIPT} missing — every test below is vacuous"
+
+
+def test_the_fake_uploader_can_observe_a_put():
+    """POSITIVE CONTROL for the instrument every upload test reads.
+
+    A FakeUploader wired to nothing would record zero puts, and every assertion
+    of the form "the object landed" would then be a reassuring zero rather than
+    a measurement. Watch the counter move before trusting it.
+    """
+    u = FakeUploader()
+    assert u.puts == []
+    u.put("k", b"abc")
+    assert u.puts == ["k"] and u.stat("k")[0] == 3
+    assert u.list("") == ["k"], "list() must see what put() stored"
+
+
+def test_the_synthetic_scope_builder_really_makes_commits(tmp_path):
+    """POSITIVE CONTROL for the fixture: if _make_scope produced 0 commits, the
+    zero-commit guard test below would pass for the wrong reason and the
+    round-trip drill would be testing an empty repository."""
+    s = _make_scope(tmp_path / "store", "scope-alpha", {"a.md": "x"}, commits=3)
+    assert B.commit_count(s) == 3
+
+
+# --------------------------------------------------------------------------- #
+# 1. 🔴 THE RESTORE DRILL — the only test that proves the backup is sufficient
+# --------------------------------------------------------------------------- #
+def test_round_trip_restores_the_exact_entry_set_and_commit_count(tmp_path, identity):
+    """bundle -> verify -> encrypt -> (upload boundary) -> decrypt -> clone.
+
+    The assertion that matters: the CLONED repository's tracked entry set and
+    commit count equal the source's, exactly. Not "a repo came out" — the same
+    repo came out.
+    """
+    store = tmp_path / "store"
+    sources = {
+        "scope-alpha": ({"one.md": "alpha one", "two.md": "alpha two"}, 4),
+        "scope-beta": ({"only.md": "beta only"}, 1),
+        "scope-gamma": ({"a.md": "g a", "b.md": "g b", "c.md": "g c"}, 7),
+    }
+    for name, (entries, n) in sources.items():
+        _make_scope(store, name, entries, commits=n)
+
+    up = FakeUploader()
+    done = _run_backup(store, tmp_path / "work", up, identity)
+    assert done == 3, "all three synthetic scopes must be backed up"
+    assert len(up.puts) == 3
+
+    for name, (entries, n) in sources.items():
+        key = next(k for k in up.objects if f"/{name}/" in k)
+
+        # decrypt what was ACTUALLY uploaded — not a local by-product
+        plain = tmp_path / f"{name}.bundle"
+        d = _decrypt(up.objects[key], identity, plain)
+        assert d.returncode == 0, f"{name}: decryption failed: {d.stderr}"
+
+        # restore by cloning FROM THE BUNDLE, the way a real recovery would
+        dest = tmp_path / f"restored-{name}"
+        c = subprocess.run([GIT, "clone", "-q", str(plain), str(dest)],
+                           capture_output=True, text=True, env=_git_env())
+        assert c.returncode == 0, f"{name}: clone from bundle failed: {c.stderr}"
+
+        restored_entries = set(
+            _git_run(dest, "ls-tree", "-r", "--name-only", "HEAD").stdout.split())
+        assert restored_entries == set(entries), (
+            f"{name}: restored entry set {sorted(restored_entries)} != source "
+            f"{sorted(entries)}")
+
+        restored_commits = int(
+            _git_run(dest, "rev-list", "--count", "HEAD").stdout.strip())
+        assert restored_commits == n, (
+            f"{name}: restored {restored_commits} commits, source had {n}")
+
+        source_head = _git_run(store / name, "rev-parse", "HEAD").stdout.strip()
+        assert _git_run(dest, "rev-parse", "HEAD").stdout.strip() == source_head, (
+            f"{name}: restored HEAD is a different commit than the source's")
+
+
+def test_round_trip_restores_the_entry_CONTENT_byte_for_byte(tmp_path, identity):
+    """The set of names matching is not the content matching.
+
+    A bundle that restored the right filenames with the wrong bytes would pass
+    the test above. This one pins the bytes.
+    """
+    store = tmp_path / "store"
+    entries = {"one.md": "distinctive alpha body", "two.md": "distinctive beta body"}
+    _make_scope(store, "scope-alpha", entries, commits=2)
+
+    up = FakeUploader()
+    _run_backup(store, tmp_path / "work", up, identity)
+
+    plain = tmp_path / "restore.bundle"
+    assert _decrypt(up.objects[up.puts[0]], identity, plain).returncode == 0
+    dest = tmp_path / "restored"
+    subprocess.run([GIT, "clone", "-q", str(plain), str(dest)],
+                   check=True, capture_output=True, env=_git_env())
+
+    for fname in entries:
+        assert (dest / fname).read_bytes() == (store / "scope-alpha" / fname).read_bytes(), (
+            f"{fname} restored with different bytes than the source")
+
+
+def test_the_uploaded_object_is_CIPHERTEXT_not_the_bundle(tmp_path, identity):
+    """🔴 The confidentiality claim, measured rather than asserted.
+
+    MinIO must hold something it cannot read. If the producer ever uploaded the
+    plaintext bundle, every other test here would still pass — the round trip
+    would work fine. This is the only control that would notice.
+    """
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"one.md": "canary-plaintext-marker"}, commits=1)
+
+    up = FakeUploader()
+    _run_backup(store, tmp_path / "work", up, identity)
+    blob = up.objects[up.puts[0]]
+
+    assert blob.startswith(b"age-encryption.org/"), (
+        "the uploaded object is not an age file — it may be the plaintext bundle")
+    assert b"canary-plaintext-marker" not in blob, (
+        "entry content is readable in the uploaded object")
+    assert b"PACK" not in blob[:64], "the uploaded object looks like a raw git bundle"
+
+
+# --------------------------------------------------------------------------- #
+# 2. 🔴 READ-ONLY PROOF — the store must come out byte-identical
+# --------------------------------------------------------------------------- #
+def test_a_full_backup_run_leaves_the_store_byte_identical(tmp_path, identity):
+    store = tmp_path / "store"
+    for name, n in (("scope-alpha", 3), ("scope-beta", 1), ("scope-gamma", 5)):
+        _make_scope(store, name, {"e.md": name}, commits=n)
+
+    before = _manifest(store)
+    assert before, "manifest is empty — this test would pass vacuously"
+
+    up = FakeUploader()
+    assert _run_backup(store, tmp_path / "work", up, identity) == 3
+
+    after = _manifest(store)
+    assert after == before, (
+        "the backup MODIFIED the store. Differing paths: "
+        f"{sorted(set(before) ^ set(after)) or [k for k in before if before[k] != after.get(k)]}")
+
+
+def test_no_scope_gains_a_remote(tmp_path, identity):
+    """🔴 The invariant every scope README states. Bundles exist to preserve it."""
+    store = tmp_path / "store"
+    for name in ("scope-alpha", "scope-beta"):
+        _make_scope(store, name, {"e.md": name}, commits=2)
+    assert all(B.scope_remotes(store / n) == [] for n in ("scope-alpha", "scope-beta"))
+
+    _run_backup(store, tmp_path / "work", FakeUploader(), identity)
+
+    for name in ("scope-alpha", "scope-beta"):
+        assert B.scope_remotes(store / name) == [], (
+            f"{name} gained a git remote — the no-remote invariant is broken")
+
+
+def test_the_git_config_of_every_scope_is_untouched(tmp_path, identity):
+    """A remote is one way to write `.git/config`; `git config` is another.
+
+    Pinning the file's mtime AND bytes catches both, plus anything else that
+    writes it for a reason nobody anticipated.
+    """
+    store = tmp_path / "store"
+    for name in ("scope-alpha", "scope-beta"):
+        _make_scope(store, name, {"e.md": name}, commits=2)
+    cfgs = {n: (store / n / ".git" / "config") for n in ("scope-alpha", "scope-beta")}
+    before = {n: (p.stat().st_mtime_ns, p.read_bytes()) for n, p in cfgs.items()}
+
+    _run_backup(store, tmp_path / "work", FakeUploader(), identity)
+
+    for n, p in cfgs.items():
+        assert (p.stat().st_mtime_ns, p.read_bytes()) == before[n], (
+            f"{n}/.git/config changed during a backup run")
+
+
+def test_the_read_only_subcommand_allowlist_is_pinned_exactly(tmp_path):
+    """An EXACT set, not a subset.
+
+    Widening this is how a write verb arrives in a script whose whole premise is
+    that it cannot write. Adding one has to be a visible diff against this line.
+    """
+    assert B._READ_ONLY_SUBCOMMANDS == frozenset(
+        {"bundle", "rev-list", "remote", "rev-parse", "for-each-ref"})
+
+
+def test_the_scratch_git_helper_is_never_pointed_at_the_store(tmp_path, identity):
+    """`_git_scratch` may run WRITING subcommands (`clone`), so the thing that
+    keeps it safe is where it is aimed. A full run must leave no rehearsal
+    directory behind and must not have created one inside the store."""
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "x"}, commits=2)
+    work = tmp_path / "work"
+    _run_backup(store, work, FakeUploader(), identity)
+
+    assert not list(store.glob("**/.rehearse-*")), "a rehearsal clone landed in the store"
+    assert not list(work.glob(".rehearse-*")), (
+        "the rehearsal clone was not cleaned up; it holds a full copy of the "
+        "scope's history in plaintext")
+
+
+@pytest.mark.parametrize("verb", ["config", "remote-add", "gc", "commit", "push", "fetch"])
+def test_git_refuses_a_write_subcommand(tmp_path, verb):
+    """NEGATIVE CONTROL, watched to fail with THIS guard's own message."""
+    repo = _make_scope(tmp_path / "store", "scope-alpha", {"e.md": "x"}, commits=1)
+    with pytest.raises(B.BackupError) as exc:
+        B._git(repo, verb, "whatever")
+    assert "READ-ONLY to this script" in str(exc.value), (
+        f"{verb} was refused by some OTHER guard — this control is green for the "
+        f"wrong reason")
+
+
+def test_the_git_environment_disables_optional_locks():
+    """DEFENCE IN DEPTH — and this test is honest about being a SPELLING check.
+
+    🔴 MEASURED 2026-08-21, against a repo with a deliberately stale index: none
+    of the four allowlisted subcommands rewrites `.git/index` with
+    GIT_OPTIONAL_LOCKS set to 0 OR to 1, while `git status` in the same probe DID
+    rewrite it — so the probe could observe a change and simply had none to see.
+    A mutation flipping the value to "1" is therefore killed by THIS assertion
+    only, not by the byte-identity test, and calling it a behavioural guard would
+    be a coverage claim wider than the code.
+
+    It stays because the cost is one line and the subcommand somebody adds later
+    may well need it. What makes the store read-only is the allowlist and the
+    unit's BindReadOnlyPaths, not this.
+    """
+    assert B._git_env()["GIT_OPTIONAL_LOCKS"] == "0"
+    assert B._git_env()["GIT_CONFIG_GLOBAL"] == os.devnull
+
+
+# --------------------------------------------------------------------------- #
+# 3. 🔴 NEGATIVE CONTROLS — each watched to fail, each on its own message
+# --------------------------------------------------------------------------- #
+def test_git_bundle_verify_ALONE_does_not_detect_corruption(tmp_path):
+    """🔴 THE MEASUREMENT THAT CHANGED THE DESIGN. Pinned so nobody re-simplifies.
+
+    `git bundle verify` validates the bundle HEADER and PREREQUISITES. It does
+    NOT walk the packfile. Measured here, every run: a bundle with one byte
+    flipped in the middle passes it at rc=0, printing "The bundle records a
+    complete history."
+
+    This test asserts the WEAKNESS, deliberately. The original design said
+    "`git bundle verify` the bundle before upload — an unverified bundle is a
+    claim, not a backup", which is right about the principle and wrong about the
+    command: stopping there uploads corrupt archives under a green verdict. If a
+    future git ever tightens `bundle verify`, this test goes red and whoever
+    sees it can delete the restore rehearsal with evidence rather than hope.
+    """
+    scope = _make_scope(tmp_path / "store", "scope-alpha", {"e.md": "x"}, commits=2)
+    good = tmp_path / "good.bundle"
+    B.bundle_scope(scope, good, tmp_path / "work")   # positive control: passes
+    assert good.stat().st_size > 0
+
+    bad = tmp_path / "bad.bundle"
+    raw = bytearray(good.read_bytes())
+    raw[len(raw) // 2] ^= 0xFF
+    bad.write_bytes(bytes(raw))
+
+    v = B._git(scope, "bundle", "verify", str(bad))
+    assert v.returncode == 0, (
+        "git bundle verify now REJECTS a byte-flipped bundle. The restore "
+        "rehearsal in bundle_scope() was added because it did not; re-measure "
+        "and simplify if that has genuinely changed.")
+
+
+def test_a_corrupted_bundle_is_caught_by_the_restore_rehearsal(tmp_path):
+    """The guard that ACTUALLY catches the corruption `bundle verify` waves through."""
+    scope = _make_scope(tmp_path / "store", "scope-alpha", {"e.md": "x"}, commits=2)
+    work = tmp_path / "work"
+    good = tmp_path / "good.bundle"
+    B.bundle_scope(scope, good, work)
+
+    raw = bytearray(good.read_bytes())
+    raw[len(raw) // 2] ^= 0xFF
+    good.write_bytes(bytes(raw))
+
+    c = B._git_scratch(work, "clone", "--bare", "--quiet",
+                       str(good), str(tmp_path / "rehearse.git"))
+    assert c.returncode != 0, (
+        "a clone from a byte-flipped bundle SUCCEEDED — the restore rehearsal "
+        "would not catch corruption and the whole verification story is vacuous")
+
+
+def test_a_corrupted_bundle_fails_the_run_and_is_never_uploaded(tmp_path, identity):
+    """END-TO-END reachability proof, through the real CLI.
+
+    A `git` shim earlier on PATH passes everything through to the real binary,
+    then TRUNCATES whatever `bundle create` produced. `create` still exits 0 —
+    exactly the case the guard exists for — and the corrupt bundle reaches
+    verification. Asserting on the guard's own wording, and on the run failing.
+    """
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "x"}, commits=2)
+
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    write_exec(shim_dir / "git", f"""
+{GIT} "$@"
+rc=$?
+for a in "$@"; do
+  case "$a" in
+    *.bundle) if [ -f "$a" ]; then printf 'not-a-bundle' > "$a"; fi ;;
+  esac
+done
+exit $rc
+""")
+
+    r = _cli(store, "--no-upload", "--work-dir", str(tmp_path / "work"),
+             identity=identity,
+             env={"PATH": f"{shim_dir}:{os.environ['PATH']}"})
+    assert r.returncode != 0, "a corrupted bundle produced a SUCCESSFUL backup run"
+    assert "Not uploading it" in r.stderr, f"failed for the wrong reason:\n{r.stderr}"
+    assert "could NOT BE RESTORED FROM" in r.stderr or "REJECTED the bundle" in r.stderr, (
+        f"failed for the wrong reason:\n{r.stderr}")
+
+
+def _mangle_bundle_after_create(monkeypatch, mangle):
+    """Let `bundle_scope` create a REAL bundle, then damage it before it is checked.
+
+    🔴 This exists because the obvious end-to-end control does not reach the
+    guards it appears to test. Replacing the bundle with junk breaks the HEADER,
+    so `git bundle verify` rejects it and the restore rehearsal never runs — a
+    mutation sweep scored the clone-failure and ref-comparison guards SURVIVED
+    while that test was green. Damaging the bundle in ways that PASS verify is
+    what actually reaches them.
+    """
+    real = B._git
+
+    def fake(repo, *args):
+        p = real(repo, *args)
+        if args[:2] == ("bundle", "create") and p.returncode == 0:
+            mangle(Path(args[2]), repo)
+        return p
+
+    monkeypatch.setattr(B, "_git", fake)
+
+
+def test_a_pack_corrupted_bundle_that_PASSES_verify_fails_the_rehearsal(
+        tmp_path, monkeypatch):
+    """🔴 The guard the whole redesign rests on, reached with an input no earlier
+    check rejects: a byte flipped in the packfile, header intact."""
+    scope = _make_scope(tmp_path / "store", "scope-alpha", {"e.md": "x"}, commits=3)
+
+    def flip(bundle: Path, _repo):
+        raw = bytearray(bundle.read_bytes())
+        raw[len(raw) // 2] ^= 0xFF
+        bundle.write_bytes(bytes(raw))
+
+    _mangle_bundle_after_create(monkeypatch, flip)
+    with pytest.raises(B.BackupError) as exc:
+        B.bundle_scope(scope, tmp_path / "out.bundle", tmp_path / "work")
+    assert "could NOT BE RESTORED FROM" in str(exc.value), (
+        f"failed for the wrong reason: {exc.value}")
+    assert "Not uploading it" in str(exc.value)
+
+
+def test_a_bundle_that_RESTORES_CLEANLY_but_INCOMPLETELY_is_rejected(
+        tmp_path, monkeypatch):
+    """🔴 The quiet failure: a perfectly valid bundle holding less than the scope.
+
+    It passes `bundle verify` AND clones without error. Only comparing the
+    restored refs against the source can see it. Before this test the ref
+    comparison survived being replaced with `if False:`.
+    """
+    scope = _make_scope(tmp_path / "store", "scope-alpha", {"e.md": "x"}, commits=4)
+
+    def make_partial(bundle: Path, repo):
+        first = _git_run(repo, "rev-list", "--max-parents=0", "HEAD").stdout.strip()
+        _git_run(repo, "branch", "-f", "partial-probe", first)
+        bundle.unlink()
+        p = subprocess.run(
+            [GIT, "-C", str(repo), "bundle", "create", str(bundle),
+             "refs/heads/partial-probe"],
+            capture_output=True, text=True, env=_git_env())
+        assert p.returncode == 0, p.stderr
+
+    _mangle_bundle_after_create(monkeypatch, make_partial)
+    with pytest.raises(B.BackupError) as exc:
+        B.bundle_scope(scope, tmp_path / "out.bundle", tmp_path / "work")
+    assert "DIFFERENT set of refs" in str(exc.value), (
+        f"failed for the wrong reason: {exc.value}")
+
+
+def test_the_rehearsal_ACCEPTS_a_good_bundle(tmp_path):
+    """POSITIVE CONTROL for the two above: the rehearsal is not simply always red.
+
+    Without this, a `bundle_scope` that raised unconditionally would satisfy
+    every negative control in this file."""
+    scope = _make_scope(tmp_path / "store", "scope-alpha", {"e.md": "x"}, commits=3)
+    B.bundle_scope(scope, tmp_path / "ok.bundle", tmp_path / "work")
+    assert (tmp_path / "ok.bundle").stat().st_size > 0
+
+
+def test_a_bundle_missing_commits_fails_the_rehearsal(tmp_path):
+    """A bundle that restores CLEANLY but INCOMPLETELY is the quiet failure:
+    the clone succeeds, so only the ref/commit comparison can see it."""
+    scope = _make_scope(tmp_path / "store", "scope-alpha", {"e.md": "x"}, commits=4)
+    work = tmp_path / "work"
+    work.mkdir()
+
+    # A legitimate, uncorrupted bundle carrying only the FIRST commit, via a
+    # branch created for the purpose (a bundle needs refs, not a bare sha).
+    first = _git_run(scope, "rev-list", "--max-parents=0", "HEAD").stdout.strip()
+    _git_run(scope, "branch", "partial-probe", first)
+    partial = work / "partial.bundle"
+    p = subprocess.run(
+        [GIT, "-C", str(scope), "bundle", "create", str(partial), "refs/heads/partial-probe"],
+        capture_output=True, text=True, env=_git_env())
+    assert p.returncode == 0, p.stderr
+
+    # POSITIVE CONTROL: it is a perfectly valid bundle. Both weaker checks pass.
+    assert B._git(scope, "bundle", "verify", str(partial)).returncode == 0
+    c = B._git_scratch(work, "clone", "--bare", "--quiet", str(partial), str(work / "r.git"))
+    assert c.returncode == 0, "the partial bundle must clone fine, or this proves nothing"
+    got = B._git_scratch(work / "r.git", "rev-list", "--count", "--all").stdout.strip()
+    assert got == "1" and B.commit_count(scope) == 4
+
+    # Only the ref/commit comparison can see the shortfall.
+    fmt = "--format=%(refname) %(objectname)"
+    want = B._refs(B._git(scope, "for-each-ref", fmt))
+    restored = B._refs(B._git_scratch(work / "r.git", "for-each-ref", fmt))
+    assert restored != want, (
+        "a bundle holding 1 of 4 commits restored the SAME ref set as the "
+        "source — the comparison in bundle_scope() cannot detect a partial "
+        "backup and its guard is unreachable")
+
+
+def test_a_truncated_ciphertext_fails_decryption(tmp_path, identity):
+    """NEGATIVE CONTROL: the ciphertext is not silently recoverable when damaged."""
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "x"}, commits=2)
+    up = FakeUploader()
+    _run_backup(store, tmp_path / "work", up, identity)
+    blob = up.objects[up.puts[0]]
+
+    assert _decrypt(blob, identity, tmp_path / "ok.bundle").returncode == 0, (
+        "positive control failed: the INTACT ciphertext did not decrypt, so the "
+        "negative result below would prove nothing")
+
+    d = _decrypt(blob[: len(blob) // 2], identity, tmp_path / "trunc.bundle")
+    assert d.returncode != 0, "a truncated ciphertext decrypted successfully"
+
+
+def test_an_altered_ciphertext_fails_decryption(tmp_path, identity):
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "x"}, commits=2)
+    up = FakeUploader()
+    _run_backup(store, tmp_path / "work", up, identity)
+    raw = bytearray(up.objects[up.puts[0]])
+    raw[-1] ^= 0xFF
+    d = _decrypt(bytes(raw), identity, tmp_path / "alt.bundle")
+    assert d.returncode != 0, "an altered ciphertext decrypted successfully"
+
+
+def test_a_wrong_identity_cannot_decrypt(tmp_path, identity, tmp_path_factory):
+    """The confidentiality claim's other half: only the operator's key opens it."""
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "x"}, commits=1)
+    up = FakeUploader()
+    _run_backup(store, tmp_path / "work", up, identity)
+
+    other = tmp_path / "other.key"
+    subprocess.run([AGE_KEYGEN, "-o", str(other)], check=True, capture_output=True)
+    d = _decrypt(up.objects[up.puts[0]], other, tmp_path / "nope.bundle")
+    assert d.returncode != 0, "an unrelated age identity decrypted the backup"
+
+
+class _DroppingUploader(FakeUploader):
+    """Accepts the put, stores nothing. The '200 OK, object absent' case."""
+    def put(self, key, data):
+        self.puts.append(key)
+
+
+class _TruncatingUploader(FakeUploader):
+    def put(self, key, data):
+        self.puts.append(key)
+        self.objects[key] = data[:-16]
+
+
+class _CorruptingUploader(FakeUploader):
+    """Same LENGTH, different bytes — invisible to a size-only check."""
+    def put(self, key, data):
+        self.puts.append(key)
+        self.objects[key] = bytes(len(data))
+
+
+@pytest.mark.parametrize("cls,needle", [
+    (_DroppingUploader, "could not be read back"),
+    (_TruncatingUploader, "did not land intact"),
+    (_CorruptingUploader, "landed with the wrong content"),
+])
+def test_a_failed_upload_is_caught_by_the_read_back(tmp_path, identity, cls, needle):
+    """🔴 NEGATIVE CONTROLS: a put that returns without raising is NOT evidence.
+
+    Three distinct ways an upload can 'succeed' and store nothing usable, each
+    asserted on its own message so a single over-broad catch cannot make all
+    three pass.
+    """
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "x"}, commits=2)
+    with pytest.raises(B.BackupError) as exc:
+        _run_backup(store, tmp_path / "work", cls(), identity)
+    assert needle in str(exc.value), f"failed for the wrong reason: {exc.value}"
+
+
+def test_the_read_back_passes_on_a_good_upload(tmp_path, identity):
+    """POSITIVE CONTROL for the three above: the check is not simply always red."""
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "x"}, commits=2)
+    assert _run_backup(store, tmp_path / "work", FakeUploader(), identity) == 1
+
+
+def test_a_malformed_recipient_override_is_refused(tmp_path):
+    with pytest.raises(B.BackupError) as exc:
+        B.resolve_recipient(Path("/nonexistent"))  # no identity, no override
+    assert "no age identity at" in str(exc.value)
+
+    os.environ["ASIB_AGE_RECIPIENT"] = "age1-obviously-not-a-key"
+    try:
+        with pytest.raises(B.BackupError) as exc:
+            B.resolve_recipient(Path("/nonexistent"))
+        assert "not a well-formed age public key" in str(exc.value)
+    finally:
+        os.environ.pop("ASIB_AGE_RECIPIENT", None)
+
+
+def test_a_valid_recipient_override_is_accepted(tmp_path, identity):
+    """POSITIVE CONTROL: the shape check accepts a REAL key, so the rejection
+    above is discriminating rather than universal."""
+    real = subprocess.run([AGE_KEYGEN, "-y", str(identity)],
+                          capture_output=True, text=True).stdout.strip()
+    os.environ["ASIB_AGE_RECIPIENT"] = real
+    try:
+        assert B.resolve_recipient(Path("/nonexistent")) == real
+    finally:
+        os.environ.pop("ASIB_AGE_RECIPIENT", None)
+
+
+def test_the_derived_recipient_is_the_one_that_can_decrypt(tmp_path, identity):
+    """🔴 The reason the recipient is DERIVED rather than hardcoded.
+
+    A hardcoded recipient can drift from the key the operator holds, producing
+    archives that encrypt cleanly and never open. This pins that the thing we
+    encrypt to and the thing we decrypt with are the same fact.
+    """
+    derived = B.resolve_recipient(identity)
+    plain = tmp_path / "p.txt"
+    plain.write_text("payload\n", encoding="utf-8")
+    cipher = tmp_path / "p.age"
+    B.encrypt(plain, cipher, derived)
+    out = tmp_path / "back.txt"
+    assert _decrypt(cipher.read_bytes(), identity, out).returncode == 0
+    assert out.read_text(encoding="utf-8") == "payload\n"
+
+
+# --------------------------------------------------------------------------- #
+# 4. 🔴 EMPTY-CASE GUARDS — a zero that looks like success is the failure mode
+# --------------------------------------------------------------------------- #
+def test_a_store_with_zero_scopes_fails_loudly(tmp_path, identity):
+    store = tmp_path / "store"
+    store.mkdir()
+    with pytest.raises(B.BackupError) as exc:
+        _run_backup(store, tmp_path / "work", FakeUploader(), identity)
+    assert "contains no scope repositories" in str(exc.value)
+    assert "Refusing to report a successful backup of nothing" in str(exc.value)
+
+
+def test_a_store_with_zero_scopes_exits_non_zero_through_the_cli(tmp_path, identity):
+    """The library raising is not the same claim as the PROCESS failing — and
+    the process exit code is what systemd reads."""
+    store = tmp_path / "store"
+    store.mkdir()
+    r = _cli(store, "--no-upload", "--work-dir", str(tmp_path / "w"), identity=identity)
+    assert r.returncode != 0, "an empty store produced exit 0"
+    assert "contains no scope repositories" in r.stderr
+
+
+def test_a_scope_with_zero_commits_fails_loudly(tmp_path, identity):
+    store = tmp_path / "store"
+    _empty_scope(store, "scope-alpha")
+    with pytest.raises(B.BackupError) as exc:
+        _run_backup(store, tmp_path / "work", FakeUploader(), identity)
+    assert "ZERO commits" in str(exc.value)
+
+
+def test_a_zero_commit_scope_fails_the_run_even_beside_healthy_ones(tmp_path, identity):
+    """🔴 The partial-success trap. Two good scopes and one broken one must not
+    add up to a green run: a backup missing one scope is a backup that will be
+    discovered to be missing it at recovery time."""
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "a"}, commits=2)
+    _empty_scope(store, "scope-beta")
+    _make_scope(store, "scope-gamma", {"e.md": "g"}, commits=2)
+
+    up = FakeUploader()
+    with pytest.raises(B.BackupError) as exc:
+        _run_backup(store, tmp_path / "work", up, identity)
+    assert "1 of 3 scope(s) failed" in str(exc.value)
+    assert len(up.puts) == 2, "the healthy scopes should still have been uploaded"
+
+
+def test_an_absent_store_is_the_ONLY_permitted_clean_no_op(tmp_path, identity):
+    """A host that has never run /analyze-service has nothing to lose. Failing
+    here would make the timer a permanently-red gate on the laptop."""
+    r = _cli(tmp_path / "does-not-exist", "--no-upload",
+             "--work-dir", str(tmp_path / "w"), identity=identity)
+    assert r.returncode == 0
+    assert "nothing to back up" in r.stderr
+    assert "backed up" not in r.stdout, (
+        "an absent store must not print a success count")
+
+
+def test_print_plan_names_a_zero_commit_scope_as_a_failure(tmp_path, identity):
+    store = tmp_path / "store"
+    _empty_scope(store, "scope-alpha")
+    r = _cli(store, "--print-plan", identity=identity)
+    assert r.returncode == 0
+    assert "ZERO COMMITS, would FAIL the run" in r.stdout
+
+
+def test_print_plan_mutates_nothing(tmp_path, identity):
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "x"}, commits=2)
+    before = _manifest(store)
+    _cli(store, "--print-plan", identity=identity)
+    assert _manifest(store) == before
+
+
+def test_print_plan_states_the_no_remote_invariant(tmp_path, identity):
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "x"}, commits=1)
+    r = _cli(store, "--print-plan", identity=identity)
+    assert "remote:    NONE" in r.stdout
+    assert "age" in r.stdout and "BEFORE upload" in r.stdout
+
+
+def test_print_plan_does_not_overstate_what_bundle_verify_proves():
+    """🔴 A claim in operator-facing output is a claim like any other.
+
+    `--print-plan` is what someone reads when deciding whether to trust these
+    backups. It said "git bundle verify before upload" while the guarantee
+    actually comes from the restore rehearsal — a sentence narrower than the
+    code, describing the weaker half. Pinned so it cannot drift back.
+    """
+    src = SCRIPT.read_text(encoding="utf-8")
+    plan = src.split("def print_plan(")[1].split("\ndef ")[0]
+    assert "RESTORE REHEARSAL" in plan
+    assert "passes a corrupted" in plan
+
+
+# --------------------------------------------------------------------------- #
+# 5. retention
+# --------------------------------------------------------------------------- #
+def test_retention_keeps_the_newest_and_prunes_the_rest():
+    up = FakeUploader()
+    prefix = "h/scope-alpha/"
+    for i in range(6):
+        up.objects[f"{prefix}2026010{i}T000000Z.bundle.age"] = b"x"
+    newest = f"{prefix}20260105T000000Z.bundle.age"
+    doomed = B.prune(up, prefix, keep=3, just_uploaded=newest)
+    assert len(doomed) == 3
+    assert sorted(up.objects) == sorted([
+        f"{prefix}20260103T000000Z.bundle.age",
+        f"{prefix}20260104T000000Z.bundle.age",
+        newest,
+    ])
+
+
+def test_retention_does_nothing_when_under_the_limit():
+    up = FakeUploader()
+    prefix = "h/scope-alpha/"
+    up.objects[f"{prefix}20260101T000000Z.bundle.age"] = b"x"
+    assert B.prune(up, prefix, keep=5,
+                   just_uploaded=f"{prefix}20260101T000000Z.bundle.age") == []
+    assert up.removed == []
+
+
+def test_retention_refuses_when_the_listing_omits_the_new_object():
+    """NEGATIVE CONTROL: pruning from a listing already caught being wrong would
+    delete real backups."""
+    up = FakeUploader()
+    prefix = "h/scope-alpha/"
+    for i in range(4):
+        up.objects[f"{prefix}2026010{i}T000000Z.bundle.age"] = b"x"
+    with pytest.raises(B.BackupError) as exc:
+        B.prune(up, prefix, keep=1, just_uploaded=f"{prefix}NOT-THERE.bundle.age")
+    assert "is not in the listing" in str(exc.value)
+    assert up.removed == [], "it deleted objects before refusing"
+
+
+@pytest.mark.parametrize("keep", [0, -1])
+def test_retention_refuses_to_keep_nothing(keep):
+    up = FakeUploader()
+    up.objects["h/s/a.age"] = b"x"
+    with pytest.raises(B.BackupError) as exc:
+        B.prune(up, "h/s/", keep=keep, just_uploaded="h/s/a.age")
+    assert "not a retention policy" in str(exc.value)
+    assert up.removed == []
+
+
+def test_retention_never_reaches_another_scope_or_host(tmp_path):
+    """The prefix is per (host, scope). A prune that spanned scopes would
+    evict good backups of one scope because another was written often."""
+    up = FakeUploader()
+    for i in range(4):
+        up.objects[f"hostA/scope-alpha/2026010{i}T000000Z.bundle.age"] = b"x"
+    up.objects["hostA/scope-beta/20260101T000000Z.bundle.age"] = b"x"
+    up.objects["hostB/scope-alpha/20260101T000000Z.bundle.age"] = b"x"
+
+    B.prune(up, "hostA/scope-alpha/", keep=1,
+            just_uploaded="hostA/scope-alpha/20260103T000000Z.bundle.age")
+    assert "hostA/scope-beta/20260101T000000Z.bundle.age" in up.objects
+    assert "hostB/scope-alpha/20260101T000000Z.bundle.age" in up.objects
+
+
+def test_the_object_key_separates_the_two_hosts(tmp_path):
+    """🔴 Both machines are hostname `nixos` and their stores are DIVERGENT.
+    A shared prefix would make retention on one host evict the other's backups."""
+    from datetime import datetime, timezone
+    t = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    a = B.object_key("workbench", "scope-alpha", t)
+    b = B.object_key("laptop", "scope-alpha", t)
+    assert a != b
+    assert not a.startswith(B.scope_prefix("laptop", "scope-alpha"))
+    assert a == "workbench/scope-alpha/20260102T030405Z.bundle.age"
+
+
+def test_the_host_label_prefers_an_explicit_handle():
+    os.environ["ASIB_HOST"] = "workbench"
+    try:
+        assert B.host_label() == "workbench"
+    finally:
+        os.environ.pop("ASIB_HOST", None)
+    os.environ["ACTIVITY_HOST"] = "laptop"
+    try:
+        assert B.host_label() == "laptop"
+    finally:
+        os.environ.pop("ACTIVITY_HOST", None)
+
+
+def test_the_host_label_is_sanitised_for_use_as_a_key_prefix():
+    os.environ["ASIB_HOST"] = "weird/host name"
+    try:
+        assert "/" not in B.host_label() and " " not in B.host_label()
+    finally:
+        os.environ.pop("ASIB_HOST", None)
+
+
+# --------------------------------------------------------------------------- #
+# 6. discovery
+# --------------------------------------------------------------------------- #
+def test_a_symlinked_scope_is_not_followed(tmp_path, identity):
+    """`commit.sh` refuses symlinked scopes because supporting them means
+    widening its BindPaths. Following one here would bundle a repository from
+    outside the store — a different confidentiality question entirely."""
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "x"}, commits=1)
+    outside = _make_scope(tmp_path / "elsewhere", "scope-outside", {"e.md": "y"}, commits=1)
+    (store / "scope-linked").symlink_to(outside)
+
+    names = [p.name for p in B.discover_scopes(store)]
+    assert names == ["scope-alpha"], f"symlinked scope was followed: {names}"
+
+
+def test_a_non_repo_directory_is_not_treated_as_a_scope(tmp_path):
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "x"}, commits=1)
+    (store / "not-a-repo").mkdir()
+    (store / "not-a-repo" / "loose.md").write_text("x", encoding="utf-8")
+    assert [p.name for p in B.discover_scopes(store)] == ["scope-alpha"]
+
+
+def test_scopes_are_discovered_in_a_stable_order(tmp_path):
+    store = tmp_path / "store"
+    for n in ("scope-gamma", "scope-alpha", "scope-beta"):
+        _make_scope(store, n, {"e.md": n}, commits=1)
+    assert [p.name for p in B.discover_scopes(store)] == [
+        "scope-alpha", "scope-beta", "scope-gamma"]
+
+
+# --------------------------------------------------------------------------- #
+# 7. 🔴 SEAM — a perfect producer wired to the wrong path is a dead feature
+# --------------------------------------------------------------------------- #
+def _home_nix() -> str:
+    return HOME_NIX.read_text(encoding="utf-8")
+
+
+def test_the_unit_execstart_resolves_to_the_file_these_tests_exercise():
+    import re
+    m = re.search(r'ExecStart\s*=\s*"([^"]*backup\.py[^"]*)"', _home_nix())
+    assert m, "no systemd unit ExecStart references backup.py — the producer is not wired up"
+    tail = m.group(1).split("%h/")[-1]
+    assert tail.startswith("workspace/devrc/scripts/analyze-service-index/backup.py"), tail
+    assert (ROOT / "scripts" / "analyze-service-index" / "backup.py").is_file()
+
+
+def test_the_backup_unit_is_separate_from_the_commit_unit():
+    """🔴 The commit unit runs with PrivateNetwork=true and a single writable
+    BindPath. Backing up needs the network and must NOT be folded into it:
+    adding network to that unit would destroy a containment control that took
+    several measured rounds to get right."""
+    src = _home_nix()
+    assert "systemd.user.services.analyze-service-index-backup" in src
+    assert "systemd.user.services.analyze-service-index-commit" in src
+    assert "systemd.user.timers.analyze-service-index-backup" in src
+
+
+def test_the_commit_unit_still_has_no_network():
+    """A regression guard on the OTHER unit: this change must not have loosened it."""
+    src = _home_nix()
+    commit_block = src.split("systemd.user.services.analyze-service-index-commit")[1]
+    commit_block = commit_block.split("systemd.user.services.analyze-service-index-backup")[0] \
+        if "systemd.user.services.analyze-service-index-backup" in commit_block else commit_block
+    commit_block = commit_block[:4000]
+    assert "PrivateNetwork = true;" in commit_block, (
+        "the commit unit lost PrivateNetwork — its no-exfiltration control")
+
+
+def test_the_backup_unit_mounts_the_store_READ_ONLY():
+    """Defence in depth for the read-only claim: even a bug in backup.py cannot
+    write the store, because the namespace does not offer it writable."""
+    src = _home_nix()
+    block = src.split("systemd.user.services.analyze-service-index-backup")[1][:6000]
+    assert "BindReadOnlyPaths" in block
+    assert "analyze-service-index" in block
+    assert "BindPaths" not in block.split("ExecStart")[0], (
+        "the backup unit binds a WRITABLE path — the store must be read-only to it")
+
+
+def test_the_backup_unit_puts_age_on_its_path():
+    src = _home_nix()
+    block = src.split("systemd.user.services.analyze-service-index-backup")[1][:6000]
+    assert "pkgs.age" in block, "age is not on the backup unit's PATH"
+
+
+def test_age_is_declared_as_a_package():
+    assert "age" in PKGS_NIX.read_text(encoding="utf-8").split(), (
+        "age is not in nix/pkgs/default.nix — it is not on PATH without it")
+
+
+def test_age_is_available_to_the_pytest_gate():
+    """🔴 A new hard test dependency that the gate does not provide turns this
+    whole file into an import error in the sandbox."""
+    assert "pkgs.age" in FLAKE_NIX.read_text(encoding="utf-8"), (
+        "age is missing from flake.nix gateTools — these tests would fail to "
+        "import inside `nix build .#checks.x86_64-linux.pytests`")
+
+
+def test_the_producer_reuses_the_mail_actions_minio_helper():
+    """One convention for reaching the tenant, not two. A second implementation
+    is one more thing to rotate and the copy nobody exercises is the broken one."""
+    src = SCRIPT.read_text(encoding="utf-8")
+    assert "from _minio import MinioArchive" in src
+    assert "mail-actions" in src
+    assert (SCRIPTS / "mail-actions" / "_minio.py").is_file()

--- a/scripts/tests/test_analyze_service_index_backup.py
+++ b/scripts/tests/test_analyze_service_index_backup.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -50,6 +51,7 @@ SCRIPT = SCRIPTS / "analyze-service-index" / "backup.py"
 HOME_NIX = ROOT / "nix" / "home.nix"
 FLAKE_NIX = ROOT / "flake.nix"
 PKGS_NIX = ROOT / "nix" / "pkgs" / "default.nix"
+SECRETS_MD = ROOT / "SECRETS.md"
 
 sys.path.insert(0, str(SCRIPTS / "analyze-service-index"))
 sys.path.insert(0, str(SCRIPTS))
@@ -222,6 +224,37 @@ def _manifest(root: Path) -> dict[str, tuple[int, int, str]]:
             st.st_size, st.st_mtime_ns,
             hashlib.sha256(p.read_bytes()).hexdigest(),
         )
+    return out
+
+
+def _bundle_ref_pairs(bundle: Path, work_dir: Path, store: Path) -> set[str]:
+    """The refs a BUNDLE declares, normalised to `_refs`'s "<refname> <oid>" form.
+
+    A TEST helper, deliberately not in the producer: `bundle_scope` compares the
+    restore against the SCOPE by ref name and has no use for the bundle header
+    (an object-level comparison against it was tried there and removed as
+    unreachable — see the note in `bundle_scope`). The tests still need it to
+    pin the `--mirror` decision, which is a production behaviour observed from
+    outside.
+
+    🔴 `git bundle list-heads` prints `<objectname> <refname>` — the REVERSE of
+    `for-each-ref --format=%(refname) %(objectname)`. Flipped here so the two
+    are comparable; getting it wrong would make every comparison mismatch, or
+    (if both sides were flipped) compare nothing. It also reports `HEAD`, which
+    `for-each-ref` never does, so non-`refs/` entries are dropped.
+    """
+    p = B._git_scratch(work_dir, "bundle", "list-heads", str(bundle), forbidden=store)
+    assert p.returncode == 0, f"git bundle list-heads rc={p.returncode}: {p.stderr}"
+    out = set()
+    for ln in p.stdout.splitlines():
+        parts = ln.strip().split(None, 1)
+        if len(parts) != 2:
+            continue
+        oid, name = parts
+        if not name.strip().startswith("refs/"):
+            continue
+        out.add(f"{name.strip()} {oid}")
+    assert out, f"{bundle} declares no refs/* head — a comparison against it is vacuous"
     return out
 
 
@@ -439,15 +472,178 @@ def test_the_scratch_git_helper_is_never_pointed_at_the_store(tmp_path, identity
         "scope's history in plaintext")
 
 
-@pytest.mark.parametrize("verb", ["config", "remote-add", "gc", "commit", "push", "fetch"])
-def test_git_refuses_a_write_subcommand(tmp_path, verb):
-    """NEGATIVE CONTROL, watched to fail with THIS guard's own message."""
+def test_the_scratch_git_helper_REFUSES_a_cwd_inside_the_store(tmp_path):
+    """🔴 The refusal `_git_scratch`'s docstring CLAIMED and did not implement.
+
+    Before this, the docstring said the helper "refuses to run anywhere near the
+    store" and there was no such check — a comment describing a guard that is
+    not there, which is worse than no guard because it stops the next person
+    looking. Watched to fail on this guard's own message, at the store root AND
+    at a scope inside it (a boundary and an interior point).
+    """
+    store = tmp_path / "store"
+    scope = _make_scope(store, "scope-alpha", {"e.md": "x"}, commits=1)
+    for cwd in (store, scope):
+        with pytest.raises(B.BackupError) as exc:
+            B._git_scratch(cwd, "clone", "--bare", str(tmp_path / "x.bundle"),
+                           str(tmp_path / "out.git"), forbidden=store)
+        assert "inside the /analyze-service index store" in str(exc.value), (
+            f"cwd={cwd} was refused by some OTHER guard: {exc.value}")
+
+
+def test_the_scratch_git_helper_ACCEPTS_a_cwd_outside_the_store(tmp_path):
+    """POSITIVE CONTROL for the refusal above: it is not simply always red."""
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "x"}, commits=1)
+    elsewhere = tmp_path / "scratch"
+    elsewhere.mkdir()
+    p = B._git_scratch(elsewhere, "rev-parse", "--git-dir", forbidden=store)
+    assert p.returncode != 0 and "not a git repository" in p.stderr.lower(), (
+        f"expected git itself to answer, not the guard: rc={p.returncode} "
+        f"{p.stderr!r}")
+
+
+def test_the_scratch_guard_cannot_be_INHERITED_BY_FORGETTING_IT():
+    """🔴 STRUCTURAL, not spelled: `forbidden` is required and keyword-only, so a
+    later call site that omits it is a TypeError at the call rather than a
+    silently unguarded write."""
+    import inspect
+    sig = inspect.signature(B._git_scratch)
+    p = sig.parameters["forbidden"]
+    assert p.kind is inspect.Parameter.KEYWORD_ONLY, p.kind
+    assert p.default is inspect.Parameter.empty, (
+        "`forbidden` has a default, so a call site can drop the guard without "
+        "any error — which is exactly how the unimplemented version read")
+
+
+@pytest.mark.parametrize("argv", [
+    ("config", "--local", "user.name", "x"),
+    ("gc", "--prune=all"),
+    ("commit", "--allow-empty", "-m", "x"),
+    ("push", "origin", "trunk"),
+    ("fetch", "origin"),
+    ("reflog", "expire", "--all"),
+])
+def test_git_refuses_a_write_subcommand(tmp_path, argv):
+    """NEGATIVE CONTROL, watched to fail with THIS guard's own message.
+
+    🔴 Every entry is a REAL git command line. The previous version parametrised
+    `"remote-add"`, which is not a git subcommand at all: it could only ever
+    prove that the allowlist rejects a string nobody would type, and it sat in
+    the list looking exactly like coverage of `git remote add` — the write this
+    file's own allowlist comment named as an example of what it refuses, and
+    which was in fact ALLOWED. See the subverb tests below.
+    """
     repo = _make_scope(tmp_path / "store", "scope-alpha", {"e.md": "x"}, commits=1)
     with pytest.raises(B.BackupError) as exc:
-        B._git(repo, verb, "whatever")
+        B._git(repo, *argv)
     assert "READ-ONLY to this script" in str(exc.value), (
-        f"{verb} was refused by some OTHER guard — this control is green for the "
-        f"wrong reason")
+        f"{argv[0]} was refused by some OTHER guard — this control is green for "
+        f"the wrong reason")
+
+
+def test_the_dispatcher_subverb_allowlist_is_pinned_exactly():
+    """An EXACT mapping. `remote` and `bundle` are dispatchers whose subverbs are
+    not all reads; widening either has to be a visible diff against this line."""
+    assert B._ALLOWED_SUBVERBS == {
+        "bundle": frozenset({"create", "verify"}),
+        "remote": frozenset({None}),
+    }
+    assert set(B._ALLOWED_SUBVERBS) <= B._READ_ONLY_SUBCOMMANDS, (
+        "a subverb policy names a verb the outer allowlist does not permit — it "
+        "can never be reached and reads as coverage while providing none")
+
+
+@pytest.mark.parametrize("argv,written", [
+    (("remote", "add", "exfil", "file:///dev/null"), "config"),
+    (("remote", "set-url", "origin", "file:///dev/null"), "config"),
+    (("remote", "rename", "origin", "other"), "config"),
+    (("bundle", "unbundle", "foreign.bundle"), "objects"),
+])
+def test_git_refuses_a_WRITING_SUBVERB_of_an_allowlisted_verb(tmp_path, argv, written):
+    """🔴 THE GAP: the verb reads, the SUBVERB writes.
+
+    `remote` and `bundle` are on the read-only allowlist because `git remote`
+    lists and `git bundle create|verify` read. `git remote add` writes
+    `.git/config`; `git bundle unbundle` writes a foreign packfile into the
+    object store. Both were rc=0 through `_git()` before this, against the only
+    copy of the data — while the allowlist's own comment named `git remote add`
+    as an example of what it refused.
+
+    Asserted on THIS guard's message (the verb guard has a different one), and
+    on the repository being byte-identical afterwards.
+    """
+    repo = _make_scope(tmp_path / "store", "scope-alpha", {"e.md": "x"}, commits=1)
+    before = _manifest(repo)
+    with pytest.raises(B.BackupError) as exc:
+        B._git(repo, *argv)
+    assert "is not a READ-ONLY mode of" in str(exc.value), (
+        f"`git {' '.join(argv)}` was refused by the VERB guard, not the subverb "
+        f"guard — this control would stay green with the subverb guard deleted: "
+        f"{exc.value}")
+    assert _manifest(repo) == before, f"the repository's {written} changed anyway"
+
+
+def test_the_subverb_refusal_is_REACHABLE_and_the_writes_are_REAL(tmp_path):
+    """🔴 POSITIVE CONTROL: without the guard these commands SUCCEED and MUTATE.
+
+    A refusal test proves nothing about the hazard unless the thing refused
+    would otherwise have happened. Run through raw git — the same command line,
+    the same repository shape — and watch `.git/config` gain a remote and the
+    object store gain a foreign pack. If this ever stops being true the guard
+    above is guarding nothing and should be re-argued, not kept.
+    """
+    repo = _make_scope(tmp_path / "store", "scope-alpha", {"e.md": "x"}, commits=1)
+    cfg = repo / ".git" / "config"
+
+    before = cfg.read_text(encoding="utf-8")
+    p = _git_run(repo, "remote", "add", "exfil", "file:///dev/null")
+    assert p.returncode == 0, f"raw `git remote add` failed: {p.stderr}"
+    after = cfg.read_text(encoding="utf-8")
+    assert after != before and 'remote "exfil"' in after, (
+        "raw `git remote add` did not change .git/config — the refusal above "
+        "refuses something that could not happen, and proves nothing")
+
+    donor = _make_scope(tmp_path / "elsewhere", "scope-donor", {"d.md": "y"}, commits=2)
+    foreign = tmp_path / "foreign.bundle"
+    b = _git_run(donor, "bundle", "create", str(foreign), "--all")
+    assert b.returncode == 0, b.stderr
+    objs_before = sorted(str(q) for q in (repo / ".git" / "objects").rglob("*"))
+    u = _git_run(repo, "bundle", "unbundle", str(foreign))
+    assert u.returncode == 0, f"raw `git bundle unbundle` failed: {u.stderr}"
+    objs_after = sorted(str(q) for q in (repo / ".git" / "objects").rglob("*"))
+    assert objs_after != objs_before, (
+        "raw `git bundle unbundle` wrote nothing into the object store — the "
+        "refusal above refuses something that could not happen")
+
+
+@pytest.mark.parametrize("argv", [
+    ("remote",),
+    ("remote", "-v"),
+    ("bundle", "verify", "x.bundle"),
+])
+def test_the_subverb_guard_still_ALLOWS_the_read_only_forms(tmp_path, argv):
+    """POSITIVE CONTROL for the subverb guard: it is not simply always red.
+
+    Each of these must reach git (whatever git then says about the arguments),
+    not the guard. Without this, tightening `_ALLOWED_SUBVERBS` to the empty set
+    would satisfy every negative control in this file and break the producer.
+    """
+    repo = _make_scope(tmp_path / "store", "scope-alpha", {"e.md": "x"}, commits=1)
+    p = B._git(repo, *argv)          # must NOT raise
+    assert isinstance(p, subprocess.CompletedProcess)
+
+
+def test_the_producer_still_reads_the_remote_list_through_the_guard(tmp_path):
+    """The one call site of the bare-verb form. `scope_remotes()` is what the
+    no-remote invariant test rests on, so a subverb policy that refused `git
+    remote` would make that invariant unmeasurable rather than false."""
+    repo = _make_scope(tmp_path / "store", "scope-alpha", {"e.md": "x"}, commits=1)
+    assert B.scope_remotes(repo) == []
+    assert _git_run(repo, "remote", "add", "origin", "file:///dev/null").returncode == 0
+    assert B.scope_remotes(repo) == ["origin"], (
+        "scope_remotes() cannot see a remote that IS there — the no-remote "
+        "invariant test would pass on a scope that had gained one")
 
 
 def test_the_git_environment_disables_optional_locks():
@@ -516,7 +712,8 @@ def test_a_corrupted_bundle_is_caught_by_the_restore_rehearsal(tmp_path):
     good.write_bytes(bytes(raw))
 
     c = B._git_scratch(work, "clone", "--bare", "--quiet",
-                       str(good), str(tmp_path / "rehearse.git"))
+                       str(good), str(tmp_path / "rehearse.git"),
+                       forbidden=tmp_path / "store")
     assert c.returncode != 0, (
         "a clone from a byte-flipped bundle SUCCEEDED — the restore rehearsal "
         "would not catch corruption and the whole verification story is vacuous")
@@ -632,6 +829,179 @@ def test_the_rehearsal_ACCEPTS_a_good_bundle(tmp_path):
     assert (tmp_path / "ok.bundle").stat().st_size > 0
 
 
+def test_a_COMMIT_LANDING_MID_REHEARSAL_does_not_condemn_a_GOOD_bundle(
+        tmp_path, monkeypatch):
+    """🔴 THE COMMITTER/BACKUP RACE — a good bundle reported as corrupt.
+
+    `analyze-service-index-commit` runs hourly and holds NO lock against this
+    daily job. The rehearsal window it raced with contains a full bare clone of
+    the scope, so it is not narrow. An earlier version read the scope's refs
+    AFTER `bundle create` returned and required the restore to match them: one
+    ordinary commit landing in that window moved `refs/heads/trunk`, the
+    comparison mismatched, and the run reported
+
+        "the bundle restores to a DIFFERENT set of refs than the scope holds"
+
+    — losing that day's backup for the scope and telling the operator their
+    archive was corrupt, while the bundle cloned cleanly.
+
+    Reproduced here by committing to the scope the instant `bundle create`
+    returns. RED at the parent of this fix, on that exact message; green now,
+    because the restore is compared against the BUNDLE'S OWN declared heads.
+    """
+    scope = _make_scope(tmp_path / "store", "scope-alpha", {"e.md": "x"}, commits=3)
+
+    def commit_now(_bundle: Path, repo: Path):
+        (repo / "e.md").write_text("the committer got there first\n", encoding="utf-8")
+        _git_run(repo, "add", "e.md")
+        r = _git_run(repo, "commit", "-q", "-m", "concurrent autocommit")
+        assert r.returncode == 0, r.stderr
+
+    _mangle_bundle_after_create(monkeypatch, commit_now)
+    B.bundle_scope(scope, tmp_path / "out.bundle", tmp_path / "work")   # must NOT raise
+    assert (tmp_path / "out.bundle").stat().st_size > 0
+
+
+def test_the_race_repro_ACTUALLY_MOVES_A_REF(tmp_path, monkeypatch):
+    """POSITIVE CONTROL for the test above: the injected commit must really move
+    `refs/heads/trunk` between `bundle create` and the comparison.
+
+    Without this, a hook that silently failed to commit would leave the race
+    test passing for the wrong reason — it would be asserting that an unchanged
+    scope produces a good bundle, which every other test here already says.
+    """
+    scope = _make_scope(tmp_path / "store", "scope-alpha", {"e.md": "x"}, commits=3)
+    fmt = "--format=%(refname) %(objectname)"
+    seen: dict[str, set] = {}
+
+    def commit_now(_bundle: Path, repo: Path):
+        seen["before"] = B._refs(B._git(repo, "for-each-ref", fmt))
+        (repo / "e.md").write_text("moved\n", encoding="utf-8")
+        _git_run(repo, "add", "e.md")
+        _git_run(repo, "commit", "-q", "-m", "concurrent autocommit")
+        seen["after"] = B._refs(B._git(repo, "for-each-ref", fmt))
+
+    _mangle_bundle_after_create(monkeypatch, commit_now)
+    B.bundle_scope(scope, tmp_path / "out.bundle", tmp_path / "work")
+    assert seen["before"] != seen["after"], (
+        "the injected commit did not move any ref — the race test above is not "
+        "exercising the race it claims to")
+    assert {ln.split(" ", 1)[0] for ln in seen["before"]} == \
+           {ln.split(" ", 1)[0] for ln in seen["after"]}, (
+        "the injected commit changed the set of ref NAMES; the completeness "
+        "guard would fire for a legitimate reason and this test would be "
+        "measuring that instead")
+
+
+def test_the_bundle_ref_reader_normalises_list_heads_output(tmp_path):
+    """VALIDATE THE INSTRUMENT — the two `--mirror` tests below read a bundle's
+    contents through `_bundle_ref_pairs`, so every claim they make is a claim
+    about this reader until it has been watched to work.
+
+    `git bundle list-heads` prints `<oid> <refname>`, the REVERSE of the
+    `for-each-ref` format used everywhere else, and it also reports `HEAD`,
+    which `for-each-ref` never does. A reader that did not flip the fields would
+    disagree with every bundle git has ever made; one that flipped both sides
+    would compare nothing at all.
+    """
+    scope = _make_scope(tmp_path / "store", "scope-alpha", {"e.md": "x"}, commits=2)
+    work = tmp_path / "work"
+    bundle = tmp_path / "ok.bundle"
+    B.bundle_scope(scope, bundle, work)
+
+    declared = _bundle_ref_pairs(bundle, work, tmp_path / "store")
+    fmt = "--format=%(refname) %(objectname)"
+    live = B._refs(B._git(scope, "for-each-ref", fmt))
+    assert declared, "list-heads produced NOTHING — the comparison is vacuous"
+    assert declared == live, f"declared={declared} live={live}"
+    for ln in declared:
+        name, oid = ln.split(" ", 1)
+        assert name.startswith("refs/"), f"fields are the wrong way round: {ln!r}"
+        assert re.fullmatch(r"[0-9a-f]{40,64}", oid), f"not an object id: {ln!r}"
+
+
+def _scope_with_a_non_branch_ref(tmp_path) -> Path:
+    """A scope carrying `refs/notes/commits` and one other non-branch ref.
+
+    Not exotic: `git notes` is an ordinary thing for a repository to acquire,
+    and `git bundle create --all` captures every ref regardless.
+    """
+    scope = _make_scope(tmp_path / "store", "scope-alpha", {"e.md": "x"}, commits=3)
+    head = _git_run(scope, "rev-parse", "HEAD").stdout.strip()
+    assert _git_run(scope, "notes", "add", "-m", "a note").returncode == 0
+    assert _git_run(scope, "update-ref", "refs/weird/thing", head).returncode == 0
+    return scope
+
+
+def test_a_BARE_rehearsal_silently_drops_every_non_branch_ref(tmp_path):
+    """🔴 THE MEASUREMENT BEHIND `--mirror`, pinned so nobody re-simplifies it.
+
+    `git clone --bare` uses the default `+refs/heads/*:refs/heads/*` refspec and
+    drops everything else WITHOUT SAYING SO. Measured 2026-08-22 from a bundle
+    created with `--all` that declared all three refs below:
+
+        --bare    restored refs/heads/trunk ONLY
+        --mirror  restored all three
+
+    Two separate defects, which is why this is pinned rather than trusted. A
+    `--bare` rehearsal never checks that the non-branch refs come back at all,
+    so it is not rehearsing the restore for them. And the comparison against the
+    bundle's declared heads would then mismatch on every single run — a
+    permanently-red gate on a disaster-recovery job, which trains everyone to
+    ignore it.
+    """
+    scope = _scope_with_a_non_branch_ref(tmp_path)
+    work = tmp_path / "work"
+    work.mkdir()
+    bundle = work / "b.bundle"
+    assert B._git(scope, "bundle", "create", str(bundle), "--all").returncode == 0
+
+    declared = {ln.split(" ", 1)[0] for ln in _bundle_ref_pairs(bundle, work, tmp_path / "store")}
+    assert declared == {"refs/heads/trunk", "refs/notes/commits", "refs/weird/thing"}, declared
+
+    fmt = "--format=%(refname) %(objectname)"
+    seen = {}
+    for mode in ("--bare", "--mirror"):
+        tgt = work / f"r{mode.strip('-')}.git"
+        c = B._git_scratch(work, "clone", mode, "--quiet", str(bundle), str(tgt),
+                           forbidden=tmp_path / "store")
+        assert c.returncode == 0, f"{mode}: {c.stderr}"
+        seen[mode] = {ln.split(" ", 1)[0] for ln in
+                      B._refs(B._git_scratch(tgt, "for-each-ref", fmt,
+                                             forbidden=tmp_path / "store"))}
+    assert seen["--bare"] == {"refs/heads/trunk"}, seen["--bare"]
+    assert seen["--mirror"] == declared, seen["--mirror"]
+
+
+def test_a_scope_with_a_NON_BRANCH_REF_backs_up_and_restores_INTACT(tmp_path, identity):
+    """🔴 REACHABILITY for the `got != declared` comparison, and the regression
+    guard for the `--bare` defect above.
+
+    This is the input that makes the guard fire: with a `--bare` rehearsal the
+    restore is missing two of the three refs the bundle declares, so the
+    comparison goes red — and it would go red on every future run too. With
+    `--mirror` the round trip is intact. Mutating `--mirror` back to `--bare` is
+    therefore killed HERE, by this test, on this guard's own message.
+    """
+    scope = _scope_with_a_non_branch_ref(tmp_path)
+    work = tmp_path / "work"
+    B.bundle_scope(scope, work / "ok.bundle", work)     # must NOT raise
+
+    declared = _bundle_ref_pairs(work / "ok.bundle", work, tmp_path / "store")
+    fmt = "--format=%(refname) %(objectname)"
+    live = B._refs(B._git(scope, "for-each-ref", fmt))
+    assert declared == live, (
+        f"the bundle does not carry the scope's non-branch refs: "
+        f"declared={sorted(declared)} live={sorted(live)}")
+
+    # The whole run, through the real producer, with the store byte-identical.
+    before = _manifest(scope)
+    up = FakeUploader()
+    _run_backup(tmp_path / "store", tmp_path / "work2", up, identity)
+    assert len(up.puts) == 1, up.puts
+    assert _manifest(scope) == before, "the store changed during the run"
+
+
 def test_a_bundle_missing_commits_fails_the_rehearsal(tmp_path):
     """A bundle that restores CLEANLY but INCOMPLETELY is the quiet failure:
     the clone succeeds, so only the ref/commit comparison can see it."""
@@ -651,15 +1021,18 @@ def test_a_bundle_missing_commits_fails_the_rehearsal(tmp_path):
 
     # POSITIVE CONTROL: it is a perfectly valid bundle. Both weaker checks pass.
     assert B._git(scope, "bundle", "verify", str(partial)).returncode == 0
-    c = B._git_scratch(work, "clone", "--bare", "--quiet", str(partial), str(work / "r.git"))
+    c = B._git_scratch(work, "clone", "--bare", "--quiet", str(partial),
+                       str(work / "r.git"), forbidden=tmp_path / "store")
     assert c.returncode == 0, "the partial bundle must clone fine, or this proves nothing"
-    got = B._git_scratch(work / "r.git", "rev-list", "--count", "--all").stdout.strip()
+    got = B._git_scratch(work / "r.git", "rev-list", "--count", "--all",
+                         forbidden=tmp_path / "store").stdout.strip()
     assert got == "1" and B.commit_count(scope) == 4
 
     # Only the ref/commit comparison can see the shortfall.
     fmt = "--format=%(refname) %(objectname)"
     want = B._refs(B._git(scope, "for-each-ref", fmt))
-    restored = B._refs(B._git_scratch(work / "r.git", "for-each-ref", fmt))
+    restored = B._refs(B._git_scratch(work / "r.git", "for-each-ref", fmt,
+                                      forbidden=tmp_path / "store"))
     assert restored != want, (
         "a bundle holding 1 of 4 commits restored the SAME ref set as the "
         "source — the comparison in bundle_scope() cannot detect a partial "
@@ -890,16 +1263,214 @@ def test_print_plan_does_not_overstate_what_bundle_verify_proves():
 
 
 # --------------------------------------------------------------------------- #
+# 4b. 🔴 the PLAINTEXT bundle — a full unencrypted copy of a confidential scope
+# --------------------------------------------------------------------------- #
+def test_the_PLAINTEXT_bundle_does_not_survive_a_successful_run(tmp_path, identity):
+    """🔴 The artifact the whole design exists to avoid leaving anywhere.
+
+    `git bundle create` writes the scope's entire history in the clear. It is
+    supposed to exist only between that call and `age`. It was never deleted on
+    any path — `PrivateTmp` cleaned up the default case under the unit, but the
+    PR's own documented smoke run (`--no-upload --work-dir X` against the REAL
+    store) has no namespace around it and left plaintext history on disk.
+    """
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "canary-plaintext"}, commits=2)
+    work = tmp_path / "work"
+    _run_backup(store, work, FakeUploader(), identity)
+
+    leftovers = sorted(p.name for p in work.iterdir() if p.name.endswith(".bundle"))
+    assert leftovers == [], f"plaintext bundle(s) left behind: {leftovers}"
+    for p in work.rglob("*"):
+        if p.is_file():
+            assert b"canary-plaintext" not in p.read_bytes(), (
+                f"{p} holds the scope's content in the clear")
+
+
+def test_the_PLAINTEXT_bundle_does_not_survive_a_FAILED_run(tmp_path, identity):
+    """🔴 THE PATH THAT MATTERS MOST, and the one a success-path unlink misses.
+
+    A failed encryption is exactly when a plaintext copy is most likely to be
+    left behind and least likely to be noticed. `age` is made to fail after the
+    bundle exists; the bundle must still be gone.
+    """
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "canary-plaintext"}, commits=2)
+    work = tmp_path / "work"
+
+    def boom(plain, cipher, recipient):
+        assert Path(plain).is_file(), "the bundle must exist, or this proves nothing"
+        raise B.BackupError("synthetic encryption failure")
+
+    real_encrypt = B.encrypt
+    B.encrypt = boom
+    try:
+        with pytest.raises(B.BackupError):
+            _run_backup(store, work, FakeUploader(), identity)
+    finally:
+        B.encrypt = real_encrypt
+
+    leftovers = sorted(p.name for p in work.iterdir() if p.name.endswith(".bundle"))
+    assert leftovers == [], f"a FAILED run left plaintext behind: {leftovers}"
+
+
+def test_artifacts_are_not_readable_by_anyone_else(tmp_path, identity):
+    """0600 files in a 0700 directory. Both were 0644/0755 under the operator's
+    umask, on a real disk, holding a client-confidential scope."""
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "x"}, commits=2)
+    work = tmp_path / "work"
+    up = FakeUploader()
+    _run_backup(store, work, up, identity)
+
+    assert (work.stat().st_mode & 0o077) == 0, (
+        f"the work dir is {oct(work.stat().st_mode & 0o777)}, not 0700")
+    ciphers = [p for p in work.iterdir() if p.name.endswith(".bundle.age")]
+    assert ciphers, "no ciphertext to check — this test measured nothing"
+    for c in ciphers:
+        assert (c.stat().st_mode & 0o077) == 0, (
+            f"{c.name} is {oct(c.stat().st_mode & 0o777)}, not 0600")
+
+
+def test_the_permission_check_can_SEE_a_loose_mode(tmp_path):
+    """POSITIVE CONTROL for the assertion above: a 0644 file must fail it.
+
+    Without this, a check written against a mode that the umask already
+    guarantees would report a tightening it never made.
+    """
+    d = tmp_path / "d"
+    d.mkdir(mode=0o755)
+    os.chmod(d, 0o755)
+    f = d / "loose"
+    f.write_text("x", encoding="utf-8")
+    os.chmod(f, 0o644)
+    assert (d.stat().st_mode & 0o077) != 0 and (f.stat().st_mode & 0o077) != 0, (
+        "the mode check cannot distinguish 0755/0644 from 0700/0600 — every "
+        "permission assertion in this file would be vacuous")
+
+
+def test_an_EXISTING_work_dir_is_tightened_too(tmp_path, identity):
+    """`mkdir(exist_ok=True)` does nothing to an existing directory's mode, and
+    with an explicit `--work-dir` the second run onwards is exactly that case."""
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "x"}, commits=1)
+    work = tmp_path / "work"
+    work.mkdir(mode=0o777)
+    os.chmod(work, 0o777)
+    assert (work.stat().st_mode & 0o077) != 0, "fixture is not loose; nothing to tighten"
+    _run_backup(store, work, FakeUploader(), identity)
+    assert (work.stat().st_mode & 0o077) == 0, (
+        f"a pre-existing work dir stayed {oct(work.stat().st_mode & 0o777)}")
+
+
+# --------------------------------------------------------------------------- #
+# 4c. 🔴 per-scope isolation — one scope failing must not abandon the others
+# --------------------------------------------------------------------------- #
+class _ExplodingUploader(FakeUploader):
+    """An uploader that raises a NON-BackupError, the way the real one does.
+
+    `uploader.put/list/remove` go through the minio client, which raises
+    `S3Error` and urllib3 connection errors. Neither is a BackupError, and the
+    per-scope handler used to catch only BackupError — so one scope hitting a
+    dead port-forward escaped the loop AND `run()`, abandoning every scope after
+    it in the alphabet while the comment above the handler said "one scope
+    failing must not stop the others".
+    """
+
+    def __init__(self, boom_on: str):
+        super().__init__()
+        self.boom_on = boom_on
+
+    def put(self, key, data):
+        if f"/{self.boom_on}/" in key:
+            raise ConnectionResetError("synthetic: the port-forward died")
+        super().put(key, data)
+
+
+def test_a_NON_BackupError_in_one_scope_does_not_abandon_the_others(tmp_path, identity):
+    """🔴 The isolation the comment claimed and the code did not provide."""
+    store = tmp_path / "store"
+    for n in ("scope-alpha", "scope-beta", "scope-gamma"):
+        _make_scope(store, n, {"e.md": n}, commits=2)
+    up = _ExplodingUploader(boom_on="scope-alpha")   # FIRST in sort order
+
+    with pytest.raises(B.BackupError) as exc:
+        _run_backup(store, tmp_path / "work", up, identity)
+
+    assert "1 of 3 scope(s) failed" in str(exc.value), (
+        f"the run did not report a partial failure: {exc.value}")
+    assert "ConnectionResetError" in str(exc.value), (
+        f"the failure's TYPE was dropped; for a non-BackupError it is most of "
+        f"the diagnosis: {exc.value}")
+    uploaded = sorted(k.split("/")[1] for k in up.puts)
+    assert uploaded == ["scope-beta", "scope-gamma"], (
+        f"scopes after the failing one were abandoned: {uploaded}. Alphabetical "
+        f"order puts scope-alpha first precisely so this is observable.")
+
+
+def test_the_exploding_uploader_control_raises_a_NON_BackupError():
+    """VALIDATE THE INSTRUMENT: if the fixture raised a BackupError the test
+    above would pass against the OLD handler and prove nothing."""
+    up = _ExplodingUploader(boom_on="s")
+    with pytest.raises(Exception) as exc:
+        up.put("h/s/k.age", b"x")
+    assert not isinstance(exc.value, B.BackupError), type(exc.value)
+
+
+def test_the_CLI_frames_a_NON_BackupError_instead_of_bare_tracebacking(
+        tmp_path, identity):
+    """`main()` caught only BackupError, so anything else reached the
+    interpreter's default handler: a traceback and no statement of what it means
+    for the backup. The traceback is kept — for these the stack IS the
+    diagnosis — and a sentence saying nothing was backed up is added."""
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "x"}, commits=1)
+    os.chmod(store, 0o000)
+    try:
+        # POSITIVE CONTROL: the fixture must really raise a non-BackupError, and
+        # from OUTSIDE the per-scope loop (which now catches everything itself,
+        # and would turn this into an ordinary BackupError).
+        with pytest.raises(PermissionError):
+            list(store.iterdir())
+        r = _cli(store, "--no-upload", "--work-dir", str(tmp_path / "work"),
+                 identity=identity)
+    finally:
+        os.chmod(store, 0o700)
+    assert r.returncode == 1, f"rc={r.returncode}\n{r.stdout}\n{r.stderr}"
+    assert "unexpected PermissionError" in r.stderr, (
+        f"the failure was not framed for the operator:\n{r.stderr}")
+    assert "Traceback" in r.stderr, (
+        f"the traceback was swallowed; for a non-BackupError it is the "
+        f"diagnosis:\n{r.stderr}")
+
+
+# --------------------------------------------------------------------------- #
 # 5. retention
 # --------------------------------------------------------------------------- #
 def test_retention_keeps_the_newest_and_prunes_the_rest():
+    """🔴 THE FIXTURE IS INSERTED OUT OF ORDER, ON PURPOSE.
+
+    `FakeUploader.list` returns keys in insertion order, and a real S3 listing
+    is not ordered either. `prune()`'s `sorted()` is what turns a listing into
+    chronology, and with a pre-sorted fixture a `sorted()` -> `list()` mutant
+    SURVIVES a fully green suite — the fixture can only ever produce the order
+    the assertion expects. Shuffled here so the sort is load-bearing.
+    """
     up = FakeUploader()
     prefix = "h/scope-alpha/"
-    for i in range(6):
+    for i in (3, 0, 5, 2, 4, 1):
         up.objects[f"{prefix}2026010{i}T000000Z.bundle.age"] = b"x"
+    assert up.list(prefix) != sorted(up.list(prefix)), (
+        "the fixture is already sorted — a sorted() -> list() mutant would "
+        "survive this test")
     newest = f"{prefix}20260105T000000Z.bundle.age"
     doomed = B.prune(up, prefix, keep=3, just_uploaded=newest)
     assert len(doomed) == 3
+    assert sorted(doomed) == [
+        f"{prefix}20260100T000000Z.bundle.age",
+        f"{prefix}20260101T000000Z.bundle.age",
+        f"{prefix}20260102T000000Z.bundle.age",
+    ], doomed
     assert sorted(up.objects) == sorted([
         f"{prefix}20260103T000000Z.bundle.age",
         f"{prefix}20260104T000000Z.bundle.age",
@@ -927,6 +1498,60 @@ def test_retention_refuses_when_the_listing_omits_the_new_object():
         B.prune(up, prefix, keep=1, just_uploaded=f"{prefix}NOT-THERE.bundle.age")
     assert "is not in the listing" in str(exc.value)
     assert up.removed == [], "it deleted objects before refusing"
+
+
+def test_retention_refuses_to_DELETE_THE_OBJECT_IT_JUST_UPLOADED():
+    """🔴 MEMBERSHIP IS NOT SURVIVAL, and only survival is the property wanted.
+
+    The membership refusal above asks whether the new object is SOMEWHERE in the
+    listing. It says nothing about whether it is in the set about to be deleted,
+    and there is a real way for it to be: lexical order is chronological order
+    only while the clock moves forward. An NTP correction, or a laptop RTC
+    restored after suspend, steps it BACKWARDS — today's key then sorts OLDEST.
+
+    Reproduced here with keys dated ahead of the "new" one. Before the fix this
+    run uploaded, verified, printed "verified", and deleted its own upload; the
+    bucket silently stopped advancing while the timer stayed green — every
+    future run doing the same. That is the false all-clear the whole file exists
+    to prevent, so it is refused rather than reordered around.
+    """
+    up = FakeUploader()
+    prefix = "h/scope-alpha/"
+    # The bucket already holds backups stamped AFTER the one this run just made.
+    for d in ("20260210", "20260211", "20260212"):
+        up.objects[f"{prefix}{d}T000000Z.bundle.age"] = b"old-but-newer-looking"
+    stale = f"{prefix}20260105T000000Z.bundle.age"      # the clock went backwards
+    up.objects[stale] = b"the object this run just uploaded"
+
+    with pytest.raises(B.BackupError) as exc:
+        B.prune(up, prefix, keep=3, just_uploaded=stale)
+    assert "DELETE THE OBJECT THIS RUN JUST UPLOADED" in str(exc.value), (
+        f"refused by some OTHER guard — this control would stay green with the "
+        f"survival check deleted: {exc.value}")
+    assert up.removed == [], "it deleted objects before refusing"
+    assert stale in up.objects, "the upload this run just made is gone"
+
+
+def test_the_self_deletion_repro_IS_REACHED_past_the_membership_guard():
+    """🔴 REACHABILITY: prove the earlier membership guard does not win first.
+
+    A mutation still passes when an earlier check always fires, so the guard
+    under test never executes. Here the just-uploaded key IS in the listing —
+    membership is satisfied — and it is nonetheless first in sorted order. This
+    asserts that shape directly, so the test above cannot be green because a
+    different guard spoke.
+    """
+    up = FakeUploader()
+    prefix = "h/scope-alpha/"
+    for d in ("20260210", "20260211", "20260212"):
+        up.objects[f"{prefix}{d}T000000Z.bundle.age"] = b"x"
+    stale = f"{prefix}20260105T000000Z.bundle.age"
+    up.objects[stale] = b"x"
+
+    keys = sorted(up.list(prefix))
+    assert stale in keys, "membership would fire first and the survival guard never runs"
+    assert keys[0] == stale, "the just-uploaded key does not sort oldest; no self-delete"
+    assert stale in keys[:-3], "the just-uploaded key is not in the doomed slice"
 
 
 @pytest.mark.parametrize("keep", [0, -1])
@@ -1026,6 +1651,306 @@ def _home_nix() -> str:
     return HOME_NIX.read_text(encoding="utf-8")
 
 
+_BACKUP_SERVICE = "systemd.user.services.analyze-service-index-backup"
+_BACKUP_TIMER = "systemd.user.timers.analyze-service-index-backup"
+_COMMIT_SERVICE = "systemd.user.services.analyze-service-index-commit"
+_COMMIT_TIMER = "systemd.user.timers.analyze-service-index-commit"
+
+
+def _strip_nix_comments(block: str) -> str:
+    """Drop whole-line `#` comments.
+
+    These blocks are heavily commented and several comments QUOTE directives
+    (`#   ProtectHome=read-only …`, `# BindPaths = [ … "-%h" ];`). A reader that
+    did not strip them would answer questions about the prose instead of the
+    configuration — and would do it silently.
+    """
+    return "\n".join(ln for ln in block.splitlines()
+                     if not ln.lstrip().startswith("#"))
+
+
+def _unit_block(start: str, end: str) -> str:
+    """The source of exactly one systemd unit, bounded at both ends.
+
+    Bounded at BOTH ends on purpose. The previous version of these tests took
+    `src.split(marker)[1][:6000]` — everything after the marker, truncated at a
+    byte count — so the window's contents depended on how long the comments
+    happened to be and could run into whatever unit came next.
+    """
+    src = _home_nix()
+    assert src.count(start) == 1, (
+        f"{start!r} appears {src.count(start)}x in nix/home.nix; this reader "
+        f"assumes exactly one and would otherwise slice an arbitrary one")
+    assert src.count(end) == 1, (
+        f"{end!r} appears {src.count(end)}x in nix/home.nix; the block below "
+        f"would be bounded at the wrong place")
+    body = src.split(start, 1)[1]
+    assert end in body, f"{end!r} does not follow {start!r} — cannot bound the block"
+    return _strip_nix_comments(body.split(end, 1)[0])
+
+
+def _backup_block() -> str:
+    return _unit_block(_BACKUP_SERVICE, _BACKUP_TIMER)
+
+
+def _commit_block() -> str:
+    return _unit_block(_COMMIT_SERVICE, _COMMIT_TIMER)
+
+
+# 🔴 A CLOSED VOCABULARY of the systemd directives that decide what a unit can
+# REACH. The assertion below compares a unit's intersection with this set
+# against an exact expected mapping, which is what makes three different
+# mutations one failure: a directive DELETED (key missing), a value FLIPPED
+# (value differs) and a loosening directive ADDED (extra key) all produce a
+# mapping that is not the expected one. An open "whatever the block contains"
+# reader could not see the third.
+_CONTAINMENT_VOCAB = frozenset({
+    "ProtectSystem", "ProtectHome", "PrivateTmp", "PrivateNetwork",
+    "PrivateDevices", "PrivateIPC", "PrivateUsers", "PrivateMounts",
+    "NoNewPrivileges", "InaccessiblePaths", "ReadWritePaths", "ReadOnlyPaths",
+    "BindPaths", "BindReadOnlyPaths", "TemporaryFileSystem", "RootDirectory",
+    "RootImage", "DynamicUser", "ProtectProc", "ProcSubset",
+    "RestrictNamespaces", "ProtectKernelTunables", "ProtectControlGroups",
+    "ProtectKernelModules", "ProtectKernelLogs", "ProtectClock",
+    "ProtectHostname", "RestrictAddressFamilies", "IPAddressDeny",
+})
+
+
+def _containment_directives(block: str) -> dict[str, str]:
+    """{directive: normalised value} for every `_CONTAINMENT_VOCAB` name present."""
+    import re
+    out: dict[str, str] = {}
+    for name in _CONTAINMENT_VOCAB:
+        m = re.search(rf"^\s*{name}\s*=\s*(.*?);\s*$", block, re.M | re.S)
+        if m:
+            out[name] = " ".join(m.group(1).split())
+    return out
+
+
+def _environment_entries(block: str) -> list[str]:
+    """The `Environment = [ … ];` entries of a unit, one per source line."""
+    import re
+    m = re.search(r"^\s*Environment\s*=\s*\[(.*?)^\s*\];\s*$", block, re.M | re.S)
+    assert m, "the unit has no `Environment = [ … ];` list"
+    out = []
+    for ln in m.group(1).splitlines():
+        ln = ln.strip()
+        if not ln:
+            continue
+        assert ln.startswith('"') and ln.endswith('"'), (
+            f"unparsed Environment entry {ln!r}: this reader takes one entry per "
+            f"line and would otherwise make claims about a string it did not "
+            f"understand")
+        out.append(ln[1:-1])
+    return out
+
+
+# 🔴 THE EXACT CONTAINMENT OF THE BACKUP UNIT. Every value here is load-bearing;
+# see the comment block above the unit in nix/home.nix for the systemd-run
+# measurement behind `ProtectHome` and for why the bind list is frozen.
+_EXPECTED_BACKUP_CONTAINMENT = {
+    "ProtectSystem": '"strict"',
+    "ProtectHome": '"tmpfs"',
+    "InaccessiblePaths": '[ "/dev/shm" "/dev/mqueue" ]',
+    "PrivateTmp": "true",
+    "NoNewPrivileges": "true",
+    "BindReadOnlyPaths": (
+        '[ "%h/workspace/devrc/scripts" '
+        '"-%h/.claude/analyze-service-index" '
+        '"-%h/workspace/homelab-talos/.secrets/age.key" '
+        '"-%h/workspace/homelab-talos/homelab-kubeconfig" '
+        '"-%h/.kube/homelab-nebula.yaml" ]'
+    ),
+}
+
+
+def test_the_home_nix_directive_reader_is_VALIDATED_before_it_is_believed():
+    """🔴 VALIDATE THE INSTRUMENT. Every assertion about nix/home.nix below is a
+    claim about this reader until the reader itself has been watched to work.
+
+    Positive control: it must see all three value shapes that occur (a quoted
+    scalar, a bare `true`, a multi-line list). Negative controls: a DELETED
+    directive must be observably absent and a CHANGED value observably
+    different — a reader that returned a hardcoded mapping, or one whose regex
+    never matched, would satisfy neither.
+    """
+    synth = '''
+      ProtectSystem = "strict";
+      ProtectHome = "tmpfs";
+      BindReadOnlyPaths = [
+        "a"
+        "b"
+      ];
+      PrivateTmp = true;
+      # ProtectHome = "read-only";   <- a comment, not configuration
+    '''
+    got = _containment_directives(_strip_nix_comments(synth))
+    assert got == {
+        "ProtectSystem": '"strict"',
+        "ProtectHome": '"tmpfs"',
+        "BindReadOnlyPaths": '[ "a" "b" ]',
+        "PrivateTmp": "true",
+    }, got
+
+    deleted = _containment_directives(
+        _strip_nix_comments(synth.replace('ProtectHome = "tmpfs";', "")))
+    assert "ProtectHome" not in deleted, (
+        "the reader reports a directive that is NOT in the source — every "
+        "'the unit has X' assertion below would be vacuous")
+
+    flipped = _containment_directives(
+        _strip_nix_comments(synth.replace('ProtectHome = "tmpfs";',
+                                          'ProtectHome = "read-only";')))
+    assert flipped["ProtectHome"] == '"read-only"', (
+        "the reader cannot see a directive's VALUE change — it would report "
+        "`tmpfs` for a unit that ships `read-only`")
+
+
+def test_the_unit_block_reader_separates_the_two_units():
+    """POSITIVE CONTROL on the block bounding, using the fact that the two units
+    are deliberately DIFFERENT.
+
+    The committer has `PrivateNetwork` and a WRITABLE `BindPaths`; the backup
+    unit has neither (it needs a network, and the store must be read-only to
+    it). If the bounding leaked one block into the other — or returned the whole
+    file — these disagreements would vanish and both units' assertions would go
+    green for the wrong reason.
+    """
+    b = _containment_directives(_backup_block())
+    c = _containment_directives(_commit_block())
+    assert c, "the committer block yielded NO directives — the reader walked nothing"
+    assert b, "the backup block yielded NO directives — the reader walked nothing"
+    assert "PrivateNetwork" in c and "PrivateNetwork" not in b, (
+        f"the two blocks are not being separated: PrivateNetwork in "
+        f"commit={'PrivateNetwork' in c} backup={'PrivateNetwork' in b}")
+    assert "BindPaths" in c and "BindPaths" not in b
+    assert c["BindReadOnlyPaths"] != b["BindReadOnlyPaths"]
+
+
+def test_the_backup_unit_pins_its_CONTAINMENT_directives_exactly():
+    """🔴 THE CONTAINMENT, PINNED AS AN EXACT MAPPING — the guard this suite
+    previously did not have.
+
+    Measured before this test existed: a mutant that DELETED `ProtectHome`,
+    repointed the store bind at a nonexistent decoy path, and widened the age
+    key bind to the whole `.secrets/` DIRECTORY passed all 64 tests. The only
+    assertion in the area required the substring "analyze-service-index" to
+    appear somewhere in the block — which the service's own NAME satisfies — and
+    nothing anywhere mentioned ProtectHome, ProtectSystem, PrivateTmp,
+    InaccessiblePaths or NoNewPrivileges at all.
+
+    🔴 This is a SEAM guard, not a component one: no test in this repo can run
+    systemd, so the suite can pin what the unit DECLARES and never that it
+    works. The measurements behind each value are in nix/home.nix beside the
+    directive, taken with `systemd-run --user`; this test is what stops them
+    drifting away from what ships.
+    """
+    got = _containment_directives(_backup_block())
+
+    for name, want in sorted(_EXPECTED_BACKUP_CONTAINMENT.items()):
+        assert name in got, (
+            f"the backup unit has NO `{name}` directive. Its containment is not "
+            f"defence in depth around backup.py — it IS the control, because "
+            f"this is the one unit here with a network. Expected {name} = {want};")
+        assert got[name] == want, (
+            f"the backup unit's `{name}` is `{got[name]}`, expected `{want}`.")
+
+    extra = {k: v for k, v in got.items() if k not in _EXPECTED_BACKUP_CONTAINMENT}
+    assert not extra, (
+        f"the backup unit gained containment directive(s) {sorted(extra)} that "
+        f"this test does not know about. Adding one without a `systemd-run "
+        f"--user` measurement is how a declared-but-ineffective hardening line "
+        f"ships (see the committer's comment on PrivateDevices/PrivateIPC). Add "
+        f"it to _EXPECTED_BACKUP_CONTAINMENT with the measurement in the same "
+        f"commit.")
+    assert got == _EXPECTED_BACKUP_CONTAINMENT
+
+
+def test_the_backup_unit_does_not_leave_HOME_READABLE():
+    """🔴 THE SPECIFIC HAZARD, NAMED, so a future `read-only` cannot slip past as
+    a plausible-looking value.
+
+    `ProtectHome=read-only` makes $HOME unwritable and leaves it fully READABLE,
+    which means the bind list confers nothing — it is a list of things already
+    visible. MEASURED 2026-08-22 with `systemd-run --user`, this unit's exact
+    directive set otherwise, probing readability from inside the namespace:
+
+        read-only  ~/.ssh/id_ed25519 READABLE, ~/.kube/config READABLE,
+                   ~/workspace/homelab-talos/.secrets/ listed 6 entries
+        tmpfs      ~/.ssh ABSENT, ~/.kube/config ABSENT,
+                   .secrets/ listed 1 entry — the bound key file
+
+    `read-only` is the plausible wrong answer here (it is even the tidier-
+    sounding one), so it gets its own assertion and its own sentence.
+    """
+    ph = _containment_directives(_backup_block()).get("ProtectHome")
+    assert ph == '"tmpfs"', (
+        f"the backup unit's ProtectHome is {ph!r}. Only `tmpfs` makes $HOME "
+        f"disappear; `read-only` leaves ~/.ssh, ~/.kube/config and every "
+        f"sibling of the age key in ~/workspace/homelab-talos/.secrets/ "
+        f"READABLE to a unit that has a network.")
+
+
+def test_the_backup_unit_binds_the_age_key_as_a_FILE_not_its_directory():
+    """The narrow bind is the whole reason the sibling cluster credentials in
+    `.secrets/` stay out of a networked unit's namespace. Widening it to the
+    directory is a one-token change that looks like a convenience."""
+    binds = _containment_directives(_backup_block())["BindReadOnlyPaths"]
+    assert '"-%h/workspace/homelab-talos/.secrets/age.key"' in binds, binds
+    assert '.secrets"' not in binds and '.secrets/"' not in binds, (
+        f"the backup unit binds the `.secrets` DIRECTORY, not just the age key: "
+        f"{binds}. That directory holds cluster credentials this job has no "
+        f"business seeing.")
+
+
+def test_the_backup_unit_pins_a_PER_HOST_key_prefix():
+    """🔴 `ASIB_HOST` IS THE ONLY THING SEPARATING THE TWO HOSTS' BACKUPS.
+
+    Measured: deleting this one Environment line leaves all 64 other tests
+    green, and `host_label()` then falls through to `socket.gethostname()` —
+    which is `nixos` on BOTH machines. The two stores are DIVERGENT content, so
+    a shared key prefix makes each host's retention pass evict the other's
+    backups: the backup becomes a second way to lose the data, visibly only as
+    archives going missing.
+    """
+    env = _environment_entries(_backup_block())
+    hosts = [e for e in env if e.startswith("ASIB_HOST=")]
+    assert len(hosts) == 1, (
+        f"the backup unit sets ASIB_HOST {len(hosts)}x (expected exactly once) "
+        f"in {env}. Without it both hosts label their objects `nixos` and "
+        f"overwrite each other under retention.")
+    value = hosts[0].split("=", 1)[1]
+    assert "%m" in value, (
+        f"ASIB_HOST={value!r} does not contain systemd's `%m` machine ID. A "
+        f"readable name alone is not enough: `isLaptop` is a backlight probe "
+        f"that fails OPEN, so an ACPI-only laptop would label itself "
+        f"`workbench` and collide silently.")
+    assert "isLaptop" in value, (
+        f"ASIB_HOST={value!r} carries no human-readable host name; %m alone is "
+        f"unreadable in a bucket listing.")
+
+
+def test_without_an_explicit_host_handle_the_two_hosts_COLLIDE():
+    """The consequence the test above prevents, measured rather than asserted.
+
+    POSITIVE CONTROL for it: with both handles unset the label is the bare
+    hostname, which is `nixos` on both machines — so the unit's Environment line
+    is doing real work, not decorating a value that was already distinct.
+    """
+    import re as _re
+    import socket as _socket
+    saved = {k: os.environ.pop(k, None) for k in ("ASIB_HOST", "ACTIVITY_HOST")}
+    try:
+        assert B.host_label() == _re.sub(
+            r"[^A-Za-z0-9._-]", "-", _socket.gethostname() or "unknown"), (
+            "host_label() no longer falls back to the hostname; the collision "
+            "this documents may have moved rather than been fixed")
+    finally:
+        for k, v in saved.items():
+            if v is not None:
+                os.environ[k] = v
+
+
 def test_the_unit_execstart_resolves_to_the_file_these_tests_exercise():
     import re
     m = re.search(r'ExecStart\s*=\s*"([^"]*backup\.py[^"]*)"', _home_nix())
@@ -1048,30 +1973,39 @@ def test_the_backup_unit_is_separate_from_the_commit_unit():
 
 def test_the_commit_unit_still_has_no_network():
     """A regression guard on the OTHER unit: this change must not have loosened it."""
-    src = _home_nix()
-    commit_block = src.split("systemd.user.services.analyze-service-index-commit")[1]
-    commit_block = commit_block.split("systemd.user.services.analyze-service-index-backup")[0] \
-        if "systemd.user.services.analyze-service-index-backup" in commit_block else commit_block
-    commit_block = commit_block[:4000]
-    assert "PrivateNetwork = true;" in commit_block, (
-        "the commit unit lost PrivateNetwork — its no-exfiltration control")
+    got = _containment_directives(_commit_block())
+    assert got.get("PrivateNetwork") == "true", (
+        f"the commit unit lost PrivateNetwork — its no-exfiltration control. "
+        f"Its containment reads {got}")
+    assert got.get("ProtectHome") == '"tmpfs"', (
+        f"the commit unit's ProtectHome is {got.get('ProtectHome')!r}; `tmpfs` "
+        f"is what makes its single BindPath the only part of $HOME it can see")
 
 
 def test_the_backup_unit_mounts_the_store_READ_ONLY():
     """Defence in depth for the read-only claim: even a bug in backup.py cannot
-    write the store, because the namespace does not offer it writable."""
-    src = _home_nix()
-    block = src.split("systemd.user.services.analyze-service-index-backup")[1][:6000]
-    assert "BindReadOnlyPaths" in block
-    assert "analyze-service-index" in block
-    assert "BindPaths" not in block.split("ExecStart")[0], (
-        "the backup unit binds a WRITABLE path — the store must be read-only to it")
+    write the store, because the namespace does not offer it writable.
+
+    🔴 This test used to assert that the substring "analyze-service-index"
+    appeared somewhere in the block — which the SERVICE'S OWN NAME satisfies, so
+    it held for a unit whose store bind pointed at a nonexistent decoy path. It
+    now names the REAL path and requires it in the read-only list specifically.
+    """
+    got = _containment_directives(_backup_block())
+    assert '"-%h/.claude/analyze-service-index"' in got["BindReadOnlyPaths"], (
+        f"the backup unit does not bind the real store path read-only; its "
+        f"BindReadOnlyPaths is {got['BindReadOnlyPaths']}. A bind pointing "
+        f"somewhere else leaves the unit backing up nothing, or backing up "
+        f"whatever is at the decoy path.")
+    assert "BindPaths" not in got, (
+        "the backup unit binds a WRITABLE path — the store must be read-only to "
+        "it. `BindPaths` is the committer's directive, not this one's.")
 
 
 def test_the_backup_unit_puts_age_on_its_path():
-    src = _home_nix()
-    block = src.split("systemd.user.services.analyze-service-index-backup")[1][:6000]
-    assert "pkgs.age" in block, "age is not on the backup unit's PATH"
+    path = [e for e in _environment_entries(_backup_block()) if e.startswith("PATH=")]
+    assert len(path) == 1, f"expected exactly one PATH entry, got {path}"
+    assert "pkgs.age" in path[0], f"age is not on the backup unit's PATH: {path[0]}"
 
 
 def test_age_is_declared_as_a_package():
@@ -1085,6 +2019,87 @@ def test_age_is_available_to_the_pytest_gate():
     assert "pkgs.age" in FLAKE_NIX.read_text(encoding="utf-8"), (
         "age is missing from flake.nix gateTools — these tests would fail to "
         "import inside `nix build .#checks.x86_64-linux.pytests`")
+
+
+# --------------------------------------------------------------------------- #
+# 8. 🔴 the documented RESTORE RECIPE — the only part of this a human executes
+# --------------------------------------------------------------------------- #
+def test_the_documented_restore_recipe_DROPS_THE_REMOTE_the_clone_adds(tmp_path):
+    """🔴 `git clone <bundle> <dir>` SETS `origin` TO THE BUNDLE PATH.
+
+    That breaks the `remote = none` invariant every scope README, `commit.sh`'s
+    PrivateNetwork unit and this feature's own `test_no_scope_gains_a_remote`
+    rest on — and it breaks it at the one moment a human is following written
+    instructions under pressure. The recipe must say to remove it.
+
+    POSITIVE CONTROL first: prove the clone really does add the remote, so the
+    documented step is fixing something that happens rather than reading as a
+    precaution nobody needs.
+    """
+    scope = _make_scope(tmp_path / "store", "scope-alpha", {"e.md": "x"}, commits=2)
+    bundle = tmp_path / "restore.bundle"
+    B.bundle_scope(scope, bundle, tmp_path / "work")
+
+    dest = tmp_path / "restored"
+    p = subprocess.run([GIT, "clone", str(bundle), str(dest)],
+                       capture_output=True, text=True, env=_git_env())
+    assert p.returncode == 0, p.stderr
+    assert _git_run(dest, "remote").stdout.split() == ["origin"], (
+        "a clone from a bundle did NOT gain a remote — the documented removal "
+        "step would be guarding nothing")
+
+    assert _git_run(dest, "remote", "remove", "origin").returncode == 0
+    assert _git_run(dest, "remote").stdout.strip() == "", (
+        "the documented remedy does not actually clear the remote")
+
+    doc = SECRETS_MD.read_text(encoding="utf-8")
+    assert "remote remove origin" in doc, (
+        "SECRETS.md's restore recipe leaves the restored scope with a remote "
+        "pointing at the bundle — the invariant the whole store is built on")
+
+
+def test_the_documented_object_key_matches_the_one_the_code_WRITES():
+    """The recipe named the artifact `<scope>-<stamp>.bundle.age`. The real key
+    is `<host>/<scope>/<stamp>.bundle.age` — a different shape, not just a
+    different spelling, and you cannot fetch an object by a name it does not
+    have. Pinned against `object_key()` rather than against a remembered
+    string."""
+    from datetime import datetime, timezone
+    key = B.object_key("workbench-abc", "scope-alpha",
+                       datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc))
+    assert key == "workbench-abc/scope-alpha/20260102T030405Z.bundle.age"
+
+    doc = SECRETS_MD.read_text(encoding="utf-8")
+    assert "<host>/<scope>/<UTC stamp>.bundle.age" in doc, (
+        "SECRETS.md does not state the real key shape")
+    assert "<scope>-<stamp>.bundle.age" not in doc, (
+        "SECRETS.md still names the artifact by a key that does not exist")
+
+
+def test_the_restore_recipe_tells_you_how_to_RETRIEVE_the_object():
+    """🔴 The recipe began at "you already have the .age file", which is the one
+    thing you will not have in the scenario it exists for: the local disk is
+    gone. It must name the bucket, the bridge, and a listing step."""
+    doc = SECRETS_MD.read_text(encoding="utf-8")
+    recipe = doc.split("**Restoring**", 1)[1].split("\n---", 1)[0]
+    for needle in ("list_objects", "get_object", "analyze-service-index-backups",
+                   "MinioArchive", "KUBECONFIG"):
+        assert needle in recipe, (
+            f"the restore recipe never mentions {needle!r} — it does not say "
+            f"how to get the object out of MinIO in the first place")
+
+
+def test_the_python_in_the_restore_recipe_is_SYNTACTICALLY_VALID():
+    """VALIDATE THE INSTRUCTION. A recipe nobody has run is a claim; the cheapest
+    part of it to check mechanically is that the python it embeds compiles."""
+    doc = SECRETS_MD.read_text(encoding="utf-8")
+    recipe = doc.split("**Restoring**", 1)[1].split("\n---", 1)[0]
+    snippets = re.findall(r'python3 -c "\n(.*?)\n"', recipe, re.S)
+    assert len(snippets) == 2, (
+        f"expected the two documented python3 -c snippets, found {len(snippets)}")
+    for i, s in enumerate(snippets):
+        # The doc escapes double quotes for the surrounding shell; undo that.
+        compile(s.replace('\\"', '"'), f"<SECRETS.md snippet {i}>", "exec")
 
 
 def test_the_producer_reuses_the_mail_actions_minio_helper():


### PR DESCRIPTION
## What this closes

`~/.claude/analyze-service-index/` is one git repo per scope. The hourly
autocommit (`commit.sh`) gives each of them local history — which defends against
exactly one failure mode: an agent's Write clobbering a file a previous run had
already committed.

Measured on the workbench: **10 scope repos, every one `remote = none`, and no
copy of any of them anywhere off this disk.** The history lives *inside* the
thing a disk failure or an `rm -rf` of the store root destroys. The content is
not re-derivable — it records gotchas, retracted theories and measurements true
at a moment. The other host's store is *divergent content*, not a backup.

Per scope, daily: `git bundle create --all` → verify → `age` → upload to the
homelab `minio-archive` tenant → read back and compare → prune to the last N.

## 🔴 The finding: `git bundle verify` does not detect corruption

The design said "`git bundle verify` the bundle before upload — an unverified
bundle is a claim, not a backup." Right about the principle, wrong about the
command. Measured on a 504-byte bundle with **one byte flipped mid-packfile**:

```
git bundle verify <corrupted>   ->  rc=0
<oid> HEAD
The bundle records a complete history.
```

It validates the **header and prerequisites**; it does not walk the pack. Bit
rot, a truncated write and a partial copy all pass it — while it prints
*"complete history"*. The same flip fails a clone at rc=128, `error: index-pack
died`.

A pipeline that stops at `verify` uploads corrupt archives under a green verdict,
which is worse than not checking at all: it manufactures confidence. So the real
check is a **restore rehearsal** — clone the bundle into a throwaway bare repo
(forcing `index-pack` to validate every object hash and the pack checksum), then
compare the restored ref set against the source. Same standard as the upload
read-back: the only evidence a backup is restorable is having restored it.

The weakness is pinned by a test that asserts verify's **rc=0**, so if a future
git tightens it, that test goes red and the rehearsal can be removed with
evidence rather than hope.

## Design as built

| decision | what and why |
|---|---|
| **producer** | local — the store is on local disk, so a k8s CronJob would have to invert the trust boundary to read `$HOME` |
| **key** | the **existing** SOPS age identity (`SOPS_AGE_KEY_FILE`), the same key every homelab `*.enc.yaml` uses. No new key minted. The **recipient is derived** from it at run time, never hardcoded — a hardcoded recipient can drift from the key the operator holds and produce archives that encrypt cleanly and decrypt never |
| **endpoint/creds** | reuses `scripts/mail-actions/_minio.py` wholesale — same `kubectl port-forward`, same `minio-archive-config` secret, same path-style client. A second convention for one endpoint is a defect |
| **timer** | a **sibling** unit, not an extension of `analyze-service-index-commit` (see below). Daily, not hourly |
| **kubeconfig** | resolved per host (workbench checkout → laptop nebula), because both stores need backing up |

### Why a sibling timer

The commit unit's containment — `PrivateNetwork = true`, `InaccessiblePaths` on
`/dev/shm`, both bind lists frozen at exactly one entry — **is** its
no-exfiltration control, arrived at over several measured rounds after three
earlier attempts to make exfiltration merely *detectable* were each evaded a new
way. Backing up needs a network by definition. Giving that unit a network is not
a small edit to it; it is deleting the property it was built to have — and for a
job on a completely different schedule. A regression test asserts the commit unit
still has `PrivateNetwork`.

Daily rather than hourly because the window this narrows is *"the disk died"*,
not the same-day write-then-clobber the committer handles.

### Not gated on `serverMode`

Same reasoning as the committer. Gating it out would leave the laptop's
divergent, equally unrecoverable store with no off-machine copy while the
workbench looked healthy — the exact silent gap this closes.

## Read-only-ness, proven

- every git call goes through one helper that **refuses any subcommand outside an
  allowlist** (`bundle`/`rev-list`/`remote`/`rev-parse`/`for-each-ref`), pinned as
  an **exact set**
- the unit mounts the store `BindReadOnlyPaths`, so a bug in the producer cannot
  reach the only copy of the data it protects
- the suite checksums a synthetic store (size + `mtime_ns` + sha256 per file)
  across a full run and requires **byte identity**, and requires every scope to
  still report **zero remotes** and an untouched `.git/config`

`mtime_ns` is in the fingerprint deliberately: a git read that refreshes
`.git/index` leaves content identical and moves the mtime, and a content-only
hash would call that "unchanged".

## Empty outcomes are loud

A store that exists with no scopes, a scope with zero commits, a bundle that
fails verification, an upload whose read-back disagrees, and a run that backed up
zero scopes **all fail**. A zero-commit scope fails the run *even beside healthy
ones* — a partial backup reported as success is the false all-clear this exists
to prevent.

The single exception is an **absent** store: a host that never ran
`/analyze-service` has nothing to lose, and failing there would make the timer a
permanently-red gate.

## Corrections the mutation sweep forced

Two claims this code made about itself that were not true:

- a commit-count comparison in the rehearsal **survived every mutation** — it is
  unreachable, because matching `(refname, objectname)` pairs pin the same
  reachable commit set by construction. Removed: a guard that cannot fail reads
  as coverage while providing none, which stops the next person looking.
- `GIT_OPTIONAL_LOCKS=0` was commented as *"the load-bearing one"*. Measured
  against a repo with a deliberately stale index: **none** of the allowlisted
  subcommands touches `.git/index` at either setting, while `git status` in the
  same probe **did** (positive control). Kept as defence in depth, comment
  corrected, and its test now states plainly that it is a spelling check.

## Testing

- **64 tests** in `scripts/tests/test_analyze_service_index_backup.py`, all
  fixtures synthetic
- the **round-trip restore drill** is the only test that proves the feature:
  synthetic store → bundle → verify → encrypt → upload boundary → decrypt →
  `git clone` from the bundle → restored entry set, entry **bytes**, commit count
  and HEAD all equal the source
- **18 mutants across three rounds, all killed**, each by a named test; swept
  under `PYTHONDONTWRITEBYTECODE=1` with a fresh tree copy per mutant, plus a
  negative control (unmutated tree green) and a positive control in the batch.
  Round 1 scored three guards SURVIVED — the clone-failure check, the ref
  comparison, and the (now removed) commit count — because the end-to-end control
  replaced the bundle with junk, which breaks the *header* so `bundle verify`
  rejected it and the rehearsal never ran. Corruption that **passes** verify is
  what reaches those guards.
- **real-store smoke run**, read-only and upload disabled: 10/10 scopes bundled,
  rehearsed and encrypted, 279,478 bytes of ciphertext, store fingerprint
  unchanged, zero remotes, no leftover rehearsal dirs, artifacts deleted

### 🔴 The full gate was NOT run

A repo-wide freeze is in effect — a test suite recently pushed ~63 fixture
commits over the real `origin/main`. `scripts/gate.sh`, `run-tests.sh` and
`nix build .#checks…` were all deliberately **not** run. What *was* run:

```
pytest scripts/tests/test_analyze_service_index_backup.py     -> 64 passed
pytest scripts/tests/test_analyze_service_index_commit.py     -> 88 passed
pytest scripts/tests/{test_no_captured_text,test_no_captured_markup,
       test_no_client_hostnames,test_no_public_ips,test_no_conflict_markers,
       test_doc_path_rot,test_ci_claim_matches_reality,
       test_devshell_satisfies_required_tools,
       test_run_tests_preconditions}.py                       -> 327 passed, 2 failed
```

Those 2 failures are **pre-existing and environmental** — they name a missing
`logrotate` on the ad-hoc `nix-shell` PATH and fail **identically on unmodified
`main` in the same shell** (control run). Not caused by this change.

`nix-instantiate --parse` is clean on `home.nix`, `pkgs/default.nix` and
`flake.nix`; `pkgs.age` and `python3Packages.minio` both resolve in the pinned
nixpkgs.

## Deploy notes

- `age` is added to `nix/pkgs/default.nix` (it was not on PATH) and to
  `flake.nix` `gateTools`, because the new suite resolves `age`/`age-keygen` at
  import and **raises rather than skips** — a skipped backup test reports safety
  it never measured
- **merged ≠ deployed**: the timer only exists after a `home-manager switch` /
  `ship.sh`
- the first real run will create the `analyze-service-index-backups` bucket
- `SECRETS.md` documents the identity, the restore command, and that **no new
  credential** is introduced

## Worth a second opinion

- **Scope names are plaintext in the object key** (`<host>/<scope>/<stamp>`).
  The *content* is ciphertext, but the bucket listing reveals which scopes exist.
  Given MinIO is the operator's own homelab — the same place the k8s secrets
  live — that seemed the right trade against making restore discovery opaque, but
  it is a deliberate choice worth confirming rather than a forced one.
- **Retention is count-based (last N), not age-based.** A scope that stops
  changing keeps N identical-ish bundles; a scope written heavily rotates faster
  in wall-clock terms. Fine for 10 small scopes, worth revisiting if the store
  grows.
- **Nothing verifies a backup is still restorable *after* upload.** The rehearsal
  happens pre-upload and the read-back confirms bytes landed, but nothing
  periodically pulls an object back down and restores it. That is the natural
  next loop, and it is the check that would catch a bucket policy or key problem
  before it matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
