### PR TITLE
fix(gate): raise the signal floor to 682 — main was RED, so every push was blocked

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1226,7 +1226,14 @@ TARGET_FLOORS=(
   # rots is silent: an anchor stops matching, the mutant never lands, and the
   # run prints ANCHOR-MISS, which reads like a hiccup rather than "this mutant
   # tested nothing". That has already happened here once.
-  "scripts/signal/tests|553"
+  # 2026-08-22: 717 tripped the ceiling at 691 with every test PASSING (716
+  # passed, 1 pinned skip) — the floor had fallen 164 behind, more than the
+  # 138 of slack the gate allows, so a whole suite could have vanished under it
+  # while the run stayed green. The gate printed "scripts/signal/tests|682" and
+  # that is what is below, copied not computed. Found by a run on an unrelated
+  # branch: this was already RED on origin/main, so it was blocking every push
+  # rather than only the change that noticed it.
+  "scripts/signal/tests|682"
   "scripts/initiatives/tests|745"
   "scripts/repo-cos/tests|315"
   "scripts/task-spec-drafter/tests|135"


### PR DESCRIPTION
`scripts/signal/tests` collects **717** with its floor still at **553** — 164 of slack against a documented ceiling of 138, so `run-tests.sh` fails:

```
run-tests: ERROR — scripts/signal/tests collected 717 tests but its floor is
only 553. That is more than 138 of slack: a whole suite could vanish under
this floor with the gate still green. Raise the TARGET_FLOORS entry to
"scripts/signal/tests|682"
```

**682 is copied verbatim from that message**, not computed here — the convention the surrounding comments establish and re-establish at 368, 444 and 553.

## Every test passes

`716 passed, 1 skipped` (the pinned `SIGNAL_PG_DSN` Postgres case). Nothing is broken; the floor simply fell behind the suite. That is exactly what the ceiling exists to catch — a floor 164 behind would let a whole suite vanish while the gate stayed green.

## This was already red on `main`

Not introduced by the branch that found it. **Control:** a clean `git worktree add --detach` of `origin/main` (`2d1ba0d7`) collects the same **717** against the same floor **553**. Since `run-tests.sh` exit 1 blocks, this was blocking **every** push to the repo.

It surfaced during unrelated work on #705, hence a separate one-line PR rather than folding it into the change that happened to notice it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)