### PR TITLE
feat(check-clickup-addressed): migrate the skill out of datapacket-talos into devrc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ is preserved verbatim in `docs/LAYOUT.md` (not auto-loaded, and stale by design)
 | `scripts/initiatives/` | `initiatives` | durable cross-repo initiative ledger + viewer + router + assistant |
 | `scripts/mail-actions/` | `mailbox` | email-automation layer over the self-hosted inbox (**separate from activity telemetry**) |
 | `scripts/repo-cos/` | `repo-cos` | weekly repo "chief-of-staff" proposal digest + reply-driven exclusions |
+| `scripts/check-clickup-addressed/` | `check-clickup-addressed` | did the work on a ClickUp ticket actually happen — reads session transcripts for completion signals (migrated out of datapacket-talos 2026-08-22) |
 | `nix/i3/`, `nix/graphical.nix`, `scripts/bar-status-poll` | `bar` | i3 + i3status-rust bar, count blocks, dunst toasts |
 | `scripts/opencode/` | `opencode` | dispatch a task to the headless opencode agent (`opencode-dispatch`), + its config/agents/guard plugin |
 

--- a/claude/skills/check-clickup-addressed/SKILL.md
+++ b/claude/skills/check-clickup-addressed/SKILL.md
@@ -287,7 +287,7 @@ further drift. **Re-time it rather than quoting it.**
 
 ## Tests
 
-Run all tests (**156** collected, measured 2026-08-22). `run_all.py` exits non-zero on
+Run all tests (**157** collected, measured 2026-08-22). `run_all.py` exits non-zero on
 failure — but read the `Total: N passed, M failed` line, not a piped exit code. 🔴 **If that
 line is missing at all, the run died — treat it as a failure, never as "no output".** A
 `sys.exit()` from code under test is a `SystemExit`, which a bare `except Exception` does
@@ -301,7 +301,7 @@ PYTHONDONTWRITEBYTECODE=1 python3 "$CCUA/tests/run_all.py"
 
 The same files are a **pytest** target of devrc's gate — `scripts/check-clickup-addressed/tests`
 in `HERMETIC_TARGETS`, with its collected-count floor in `TARGET_FLOORS`
-(`scripts/run-tests.sh`). Both runners see the same 156; `run_all.py` survives because it
+(`scripts/run-tests.sh`). Both runners see the same 157; `run_all.py` survives because it
 purges `__pycache__` and reports an import failure as a FAILURE, which pytest's summary
 line does not distinguish as loudly. **Raise the floor when you add tests.**
 

--- a/claude/skills/check-clickup-addressed/SKILL.md
+++ b/claude/skills/check-clickup-addressed/SKILL.md
@@ -1,0 +1,329 @@
+---
+name: check-clickup-addressed
+description: Verify if ClickUp tasks were fully addressed by searching session transcripts for completion signals. Use when checking if recent work on assigned tasks is complete, or when asked to verify task completion status.
+---
+
+# /check-clickup-addressed — verify if ClickUp tasks were fully addressed
+
+Deterministic check: given the N most recent comments not from you on your assigned
+tasks, find the sessions that worked on those tasks, read the transcripts, and report
+what's done vs what's still open.
+
+## Quick start
+
+The scripts live in **devrc**, not in this deployed skill dir — `~/.claude/skills/` is a
+read-only nix-store copy of `claude/skills/`, and only the docs ship there. Run them from
+the repo:
+
+```bash
+CCUA=~/workspace/devrc/scripts/check-clickup-addressed
+
+# Default: top 3 most recent comments (~30s)
+python3 "$CCUA/check-addressed.py"
+
+# Fast mode: samples only the 10 most recently updated tasks (~10s)
+python3 "$CCUA/check-addressed.py" --fast
+
+# Top 5, JSON output
+python3 "$CCUA/check-addressed.py" --limit 5 --json
+
+# Only sessions since a date
+python3 "$CCUA/check-addressed.py" --since 2026-08-15
+
+# Verbose; skip the gh PR lookups
+python3 "$CCUA/check-addressed.py" --verbose --no-resolve-prs
+```
+
+🔴 **Editing this file needs a `home-manager switch`; editing the scripts does not.**
+`claude/skills/check-clickup-addressed/SKILL.md` + `reference/` deploy through nix, so a
+prose change is invisible to a session until the switch. `scripts/check-clickup-addressed/`
+is run straight out of the working tree — the edit is live immediately, and it is gated by
+`scripts/run-tests.sh` (target `scripts/check-clickup-addressed/tests`).
+
+## What it does (deterministic pipeline)
+
+1. **`recent-comments.py`** — queries ClickUp for all comments on your assigned tasks,
+   filters out your own, sorts by date, returns the top N with task ID/name/author/snippet.
+2. **`search-sessions.py`** — searches `~/.claude/projects/**/*.jsonl` transcripts for
+   sessions mentioning a task ID, ranks by hit count. Terms are **ANDed**, so it is run
+   **once per task**, never with several tasks' terms in one query.
+3. **`check-completion.py`** — for each task, reads the matched sessions' assistant text
+   and pattern-matches for completion signals (merged/shipped/verified) vs open signals
+   (still open/not yet done/needs action), **within ±2000 chars of a mention of that
+   task's ID, and only where that task is the nearest ID to the match**.
+4. **`check-addressed.py`** — orchestrates the above, produces a unified report.
+
+Both search and completion skip the **current session** (`$CLAUDE_CODE_SESSION_ID`),
+which necessarily mentions every task ID under test. Override with `--exclude-session ID`
+(repeatable) or, on `check-completion.py`, `--include-self`.
+
+🔴 **They also skip every PRIOR RUN of this checker** — recognised structurally by
+`scripts/check-clickup-addressed/_selfrun.py`, not by session id. A previous
+report prints each task ID directly beside `likely_addressed` / `✓ resolved` / `merged`,
+which is precisely the shape the proximity scorer rewards, so without this the tool reads
+yesterday's verdict back as today's evidence and re-confirms it forever. The report prints
+`(ignored N transcript(s) …)` when the guard fires; `--include-self-runs` disables it.
+
+## Individual scripts
+
+All scripts accept `--json` for machine-readable output. Two of them make network calls:
+`recent-comments.py` needs ClickUp credentials, and PR resolution shells out to `gh pr
+view` — **on by default in `check-addressed.py`** (`--no-resolve-prs` opts out), off by
+default in `check-completion.py` (`--resolve-prs` opts in). Only `search-sessions.py` is
+unconditionally hermetic. The PR cache is per-process and the orchestrator forks one
+process per task, so lookups dedupe within a task, not across the run.
+
+| Script | Input | Output |
+|--------|-------|--------|
+| `recent-comments.py --limit N` | ClickUp API | task_id, task_name, date, author, snippet |
+| `search-sessions.py term1 [term2 ...]` | `~/.claude/projects/` | session_id, date, project, hits |
+| `check-completion.py --task ID` | session transcripts | status, completion signals, open items |
+| `check-addressed.py --limit N` | all of the above | unified report |
+
+## Interpreting results
+
+| Status | Meaning |
+|--------|---------|
+| `likely_addressed` | Completion signals found, no open signals |
+| `partially_addressed` | Both completion and open signals — something shipped, something remains |
+| `open` | Only open signals found — work not completed |
+| `unclear` | Sessions mention the task, but no signal of either kind is attributable to it |
+| `no_sessions_found` | No session transcript mentions this task at all |
+| `no_mentions_found` | Sessions were read, but the task ID appears in none of them — **no evidence either way**, never an implied "partly done" |
+
+🔴 **`partially_addressed` is the status to be most suspicious of** — it was, until
+2026-08-19, the state an unmatched task fell into *by construction* (see Limitations).
+Check `mentions_found > 0` before believing any verdict, and read the snippets: a signal
+is attributed by lexical proximity, so it can be a real sentence about the right task
+that still says nothing about whether the ticket is done.
+
+## Completion signals detected
+
+- PR merged/landed/shipped (references like `#1234 merged`)
+- Verified on main/trunk
+- Fix shipped/deployed
+- Resolution markers
+
+## Open signals detected
+
+- Still open/pending/waiting
+- Left open (deliberately)
+- Not yet done/fixed/deployed
+- Premise refuted (scope changed)
+- Needs action/decision
+- Deployed ≠ verified
+
+## Limitations
+
+🔴 **This tool reports which words appeared near a task ID. It does not know whether the
+work is done.** Treat every verdict as a pointer to a transcript to read, never as an
+answer. Three structural false-positive generators were fixed on 2026-08-19, a fourth —
+the checker reading its own previous runs — on 2026-08-20, and on 2026-08-21 two **silent
+no-ops**: an unrecognised ClickUp status disabling every ticket/comment cross-check, and an
+inert proximity tier whose confidence marker printed the same symbol for every signal.
+Round 5, the same day, fixed a **false explanation** (a named-but-unknown repo reported as
+"repo not named"), the repaired marker never reaching the report, and the missing
+"nobody is on it and someone is waiting" flag (matrix in
+`claude/skills/check-clickup-addressed/reference/validation-history.md`); what remains is listed
+under "Still weak".
+
+- Session search is keyword-based, not semantic — a session that addressed the task
+  without ever writing its ID is invisible to this tool. **A `no_mentions_found` or
+  `unclear` verdict is not evidence that nothing was done.**
+- Completion detection is pattern-based — it catches common phrases ("merged", "shipped",
+  "verified on main") but may miss unusual phrasings.
+- The pipeline runs sequentially (ClickUp API → transcript search → pattern match), so
+  it's bounded by API latency for the comment fetch (~30s for 50 tasks).
+
+### Still weak (measured 2026-08-19, not fixed)
+
+- **A signal is attributed by lexical proximity, not by meaning.** Nearest-ID keeps a
+  neighbouring *task's* verdict out, but not a neighbouring *clause's*: ``#1065 … merged
+  08-16 (I confirmed). `868kr07fu` is u[nfixed]`` still scores as completion for
+  `868kr07fu`, because the merge sentence really is adjacent to it. **Read the snippet.**
+- **A PR reference the tool cannot pin to a repo is reported `unresolved`, not guessed** —
+  a snippet-wide scan was tried and attributed every bare `#N` to `civitai/civitai`,
+  returning a real but unrelated PR ("merged 2024-03-18"). 🔴 **Three distinct ways to fail,
+  and the message now says which** (until 2026-08-21 all three printed `repo not named`,
+  true of only one): `repo not named` — nothing repo-ish within `REPO_LOOKBEHIND`=30 chars;
+  `repo 'X' is not in KNOWN_REPOS` — a repo **was** named, *go add it*; `ambiguous — A, B
+  both in range`. The word on the `#` is reported as written and **not classified** —
+  nothing short of enumerating the world separates `devrc` from `landed`, and a reader
+  separates them at a glance. `KNOWN_REPOS` is a closed vocabulary, so **widening it is not
+  the fix** (same shape as the status sets below); verify owners with `gh repo view` —
+  `devrc` is **innovation-upstream**/devrc, and `civitai/devrc` does not exist.
+- **`--fast` only inspects the 10 most recently updated tasks**, so a stale-but-important
+  task is invisible to it. That is a sampling window, not a full check.
+
+### What the report now cross-checks for you
+
+Three independent sources, and the **Needs a decision** block fires on their disagreements —
+plus one state where nothing disagrees and that is exactly the problem (4):
+
+1. **ClickUp status + priority**, printed beside every verdict.
+2. **The ticket's newest comment** — usually the real record of what happened. A comment
+   reading "Resolved / recommend closing" over a ticket still at `to do` is flagged; that
+   exact case (`868kr07fu`, `to do`/urgent) is why the check exists. 🔴 **An explicit
+   refusal to close VETOES that flag**: on 2026-08-20 the alert-cycling sentence *"P95 > 5s …
+   fired and **resolved** repeatedly"* tripped the keyword on `868kr0799`, whose very next
+   words were *"Still live, do not close"* — the report told the operator to close it. The
+   reporter's own words outrank both the keyword scan and the transcripts.
+   🔴 **The veto has TWO TIERS** — an absolute one was wrong in *both* directions (round 8;
+   17-case before/after table in the validation doc). **STRONG** ("do not close", "still
+   live", "staying/remains open", "reopening") is about *this* ticket and is absolute. **WEAK**
+   ("still open", plus any *negated* closure claim) is as often about a PR, an alert or a
+   sibling ticket: it vetoes when it is the comment's only word on closure, and drops to
+   **"READ IT and decide"** when another clause carries an un-negated closure claim. Untiered,
+   *"Resolved… recommend closing. (The follow-up PR is still open but unrelated.)"* emitted
+   **do NOT close**.
+   🔴 **Negation is decided ONCE, scoped to the CLAUSE *and to word order*** (`closure_claims`)
+   — never per-word lookbehinds, which guard only the spellings they enumerate and lost this
+   twice on the abandoned branch. Untreated, `isn't`/`never`/`won't`/`not fully`/`unresolved`/
+   `cannot`/`far from` and *"I do not recommend closing"* all drew an affirmative **close it**
+   over a comment refusing exactly that. Contractions match by **shape** (`\w+n't`): any stem
+   list is already missing `won't` the day it is written.
+   🔴 **Commas ARE clause boundaries; parens are not; a negator negates only what FOLLOWS it.**
+   Each of those was wrong at least once, each wrong version shipped an affirmative wrong
+   instruction, and two blind audits found them. A trailing "no" reaching backwards turned
+   *"Resolved, no further action needed"* into **do NOT close** (12 of 12); a symptom's negator
+   reaching forward across a comma turned *"The alert wasn't firing, resolved by the rule fix"*
+   into **do NOT close** (10 of 10); parens stranding a negator turned *"This is not (yet)
+   resolved"* into **close it**.
+   🔴 **DO NOT ARGUE THE NEXT CHANGE FROM AN EXAMPLE — SCORE IT.**
+   `scripts/check-clickup-addressed/tests/test_corpus.py` holds 49 labelled comments,
+   every one from a measurement, and 8 recorded KNOWN FAILURES. Trunk scores 24/42 on the
+   original set, what shipped 38/42. Add your motivating case with the verdict a human would
+   give, *then* change code.
+   🔴 **AND AUDIT THE CORPUS ITSELF — it was blind to its own worst class.** All 18
+   negator/closure pairs in the first 42 put the negator FIRST, so a negator that FOLLOWS the
+   word it denies (*"The ticket says resolved but it isn't"* -> **close it**, on trunk and
+   now) appeared nowhere and the close-it guard could not fail on it. A mutant narrowing the
+   negation window to 30 chars kept the suite green AND the score unchanged while flipping
+   five refusals to "close it", because the corpus's cases all clustered under 27 chars.
+   **Ask which shapes your instrument structurally cannot see, and who wrote the labels.**
+3. **Cited PRs, resolved against GitHub** (`gh pr view`) rather than believed on sight. A
+   completion signal quoting a PR that is actually still **open** is flagged — on
+   2026-08-19 that shape was real (talos-infra #1073). Disable with `--no-resolve-prs`.
+4. **Nobody is on it and someone is waiting** — a not-done ticket + **zero** transcript
+   evidence (`mentions_found == 0`) + a comment from someone else within
+   `UNANSWERED_COMMENT_DAYS` (14). No rule produced this before 2026-08-21 because nothing
+   *disagrees*: ticket open, transcripts empty, and they agree. Measured live on
+   `868kuam02` (`to do`/high, colleague comment, 0 mentions) the block said nothing.
+   🔴 Bounded by **recency, not priority** — priority is a stale property of the *ticket*
+   and would re-fire on every unstarted backlog item forever, training the reader to skip
+   the block; recency is a property of the *interaction*, says a human is waiting **now**,
+   and self-clears. Fires whatever the status word reads (safe direction, like the veto).
+
+🔴 **Sources 1 and 2 are gated on a hardcoded nine-word status vocabulary, and ClickUp
+statuses are per-list and arbitrary.** Until 2026-08-21 a miss was **silent**: measured,
+`in review` / `blocked` / `needs qa` / `review` each disabled every ticket/comment check
+including the keep-open veto, and printed nothing — an empty **Needs a decision** block
+reads as *checked, nothing disagrees* when it means *not checked*. An unrecognised status
+now announces itself there and names the two sets to add it to. **Widening the sets is not
+the fix on its own** — it moves the silence to the next unknown word; keep the
+announcement.
+
+## Improvements over naive approach
+
+- **Windowed search**: only looks for signals within ±N characters of each task ID
+  mention, not across the entire session transcript
+- **Adjacency weighting (`[●]` / `[○]`)**: a signal whose own ±40-char snippet contains the
+  task ID (`[●]`) outranks one merely somewhere in the ±2000-char window (`[○]`). **`[○]` is
+  the one to distrust** — "same window" can mean a different paragraph about different work.
+  In the report it is a **second, bracketed column**: first glyph = `✓` completion / `○`
+  open (WHAT the signal says), bracketed = adjacency (HOW MUCH to trust it). Two orthogonal
+  facts, deliberately not merged — `○` already meant "open item" here. 🔴 **Inert until
+  2026-08-21, then invisible for a day**: first a `proximity > 0.5` tier ranked signals by a
+  `distance` the only production producer hardcodes to `0`, so everything scored ≥ 1.0 and
+  the marker printed `●` for every signal (tier deleted; verdicts unchanged on all six live
+  tasks); then the repaired marker was wired only into `check-completion.py`'s printer, not
+  into `check-addressed.py` — the entry point everyone runs — so it still reached no report.
+  **A marker nobody sees is the same no-op as one that cannot vary.** Live 2026-08-21:
+  `868ktvqf9` shows both values, `868kt8pfu` is all `[○]`.
+- **Deduplication**: same signal from multiple windows is only reported once
+- **Cross-task attribution guard**: a signal is kept only if the task under test is the
+  ClickUp ID lexically *nearest* to it. Without this, a triage table listing several
+  tasks reports every task's verdict as every other task's.
+- **Exact task-ID matching only**: a 6-character-prefix pass was removed on 2026-08-19 —
+  it matched neighbouring tasks sharing a prefix and never fired usefully, since ClickUp
+  always supplies the full ID.
+- **Self-exclusion**: the session running the check is skipped, so the tool cannot read
+  its own output back as evidence.
+- **Prior-run exclusion** (2026-08-20): every transcript that is a *run* of this checker is
+  skipped too, recognised by anchored markers rather than session id. The markers had to be
+  anchored. **Measured 2026-08-21 over the 735 transcripts these scripts actually walk**
+  (`CLAUDE_DIR.iterdir()` then `glob("*.jsonl")`, top level — *not* a recursive grep, which
+  also sees 4559 files under `<session>/subagents/` that are never opened): a bare
+  `check-clickup-addressed` matches **67 (9.1%)** because the skill catalog is injected into
+  every session, and a bare `/check-clickup-addressed` matches **24 (3.3%)** because it is a
+  substring of the skill's own path — against **4** for the real anchored markers. An earlier
+  "213 of ~250 / 32" came from the recursive walk and was wrong on both numerator and
+  denominator; the verdict survived re-measurement, the figures did not.
+  🔴 **These drift — 746/62/23 one day, 735/67/24 the next. Re-measure before quoting.**
+  Failure direction is deliberate: a false positive drops a session and degrades a verdict
+  to `unclear`; a false negative brings back a confident ✅ over a live ticket.
+- 🔴 **Self-classification creep, and it now has a REAL victim.** The markers appear in this
+  SKILL.md, so any session that loads the skill, reads this file, or reviews its diff becomes
+  a permanent self-run — and a session that both *did work* and *ran the checker* is dropped
+  from tomorrow's evidence. Measured 2026-08-21: **5 task IDs are visible only inside
+  dropped transcripts, and `868kt9qye` is a real ticket**, not a test fixture — its only
+  mentions sit in a work session that also ran the checker. An earlier note claiming "real
+  loss is currently zero" was true when written and is no longer. The drop lands in the safe
+  direction (→ `no_mentions_found`, i.e. *no evidence*, never a false ✅) but it lands on the
+  session most likely to contain the work. Nothing ages a marker out; the set only grows.
+  `--include-self-runs` is the escape hatch when you suspect this.
+
+## Performance
+
+| Mode | Time | Notes |
+|------|------|-------|
+| `--fast` | ~10s | Samples only the 10 most recently updated tasks |
+| `--limit 5` | **~85–100s** | All assigned tasks; one transcript search per task |
+
+Re-measured 2026-08-21: **98.5s** and **85.4s** wall (two runs). The `~41s` quoted until
+then was a 2026-08-19 figure that had silently doubled as the transcript corpus grew — the
+ClickUp fetch dominates, but the per-task sweep scales with `~/.claude/projects`, so expect
+further drift. **Re-time it rather than quoting it.**
+
+## Tests
+
+Run all tests (**156** collected, measured 2026-08-22). `run_all.py` exits non-zero on
+failure — but read the `Total: N passed, M failed` line, not a piped exit code. 🔴 **If that
+line is missing at all, the run died — treat it as a failure, never as "no output".** A
+`sys.exit()` from code under test is a `SystemExit`, which a bare `except Exception` does
+not catch; it used to escape the runner and kill every remaining test file silently (found
+by the round-4 mutation sweep, fixed in `run_all.py`).
+
+```bash
+CCUA=~/workspace/devrc/scripts/check-clickup-addressed
+PYTHONDONTWRITEBYTECODE=1 python3 "$CCUA/tests/run_all.py"
+```
+
+The same files are a **pytest** target of devrc's gate — `scripts/check-clickup-addressed/tests`
+in `HERMETIC_TARGETS`, with its collected-count floor in `TARGET_FLOORS`
+(`scripts/run-tests.sh`). Both runners see the same 156; `run_all.py` survives because it
+purges `__pycache__` and reports an import failure as a FAILURE, which pytest's summary
+line does not distinguish as loudly. **Raise the floor when you add tests.**
+
+Test files:
+- `test_attribution.py` — the 2026-08-19 regression set (cross-task attribution, the
+  `no_mentions_found` contract, self-exclusion, signal precision, PR-ref resolution,
+  ticket/comment disagreements) plus the 2026-08-20 set (D4 prior-run exclusion, the
+  keep-open veto). Read `claude/skills/check-clickup-addressed/reference/validation-history.md`
+  before changing any of it — several tests there are false-positive controls that pass at
+  base by construction and are labelled as such.
+- `test_status_and_tiers.py` — the 2026-08-21 round-4 set: the unknown-ClickUp-status blind
+  spot, the deleted proximity tier and the invariant guards that license deleting it, and
+  the entry point's flag parsing/forwarding.
+- `test_repo_vocab_and_waiting.py` — the round-5 set: the three distinct repo-resolution
+  failures (+ the `KNOWN_REPOS` owner ledger), the adjacency marker reaching the actual
+  report, and the waiting-on-a-human flag with its widening controls. 🔴
+  `test_an_unknown_clickup_status_does_not_disable_the_waiting_flag` asserts the **WAITING**
+  flag specifically: a bare `assert flags` was green for round 4's announcement instead, and
+  let a mutant rebuilding the D6 blind spot SURVIVE a fully green suite.
+- `test_check_completion.py` — windowed signal extraction. ⚠️ Its two proximity tests hand
+  `extract_signals_from_windows` a non-zero `distance`, which no production producer emits;
+  they cover the formula, not any reachable path. The reachable premise is pinned in
+  `test_status_and_tiers.py` instead.
+- `test_search_sessions.py` — session search, ranking, date filtering
+- `test_recent_comments.py` — ClickUp API parsing, filtering, sorting

--- a/claude/skills/check-clickup-addressed/SKILL.md
+++ b/claude/skills/check-clickup-addressed/SKILL.md
@@ -287,7 +287,7 @@ further drift. **Re-time it rather than quoting it.**
 
 ## Tests
 
-Run all tests (**157** collected, measured 2026-08-22). `run_all.py` exits non-zero on
+Run all tests (**161** collected, measured 2026-08-22). `run_all.py` exits non-zero on
 failure — but read the `Total: N passed, M failed` line, not a piped exit code. 🔴 **If that
 line is missing at all, the run died — treat it as a failure, never as "no output".** A
 `sys.exit()` from code under test is a `SystemExit`, which a bare `except Exception` does
@@ -301,7 +301,7 @@ PYTHONDONTWRITEBYTECODE=1 python3 "$CCUA/tests/run_all.py"
 
 The same files are a **pytest** target of devrc's gate — `scripts/check-clickup-addressed/tests`
 in `HERMETIC_TARGETS`, with its collected-count floor in `TARGET_FLOORS`
-(`scripts/run-tests.sh`). Both runners see the same 157; `run_all.py` survives because it
+(`scripts/run-tests.sh`). Both runners see the same 161; `run_all.py` survives because it
 purges `__pycache__` and reports an import failure as a FAILURE, which pytest's summary
 line does not distinguish as loudly. **Raise the floor when you add tests.**
 

--- a/claude/skills/check-clickup-addressed/SKILL.md
+++ b/claude/skills/check-clickup-addressed/SKILL.md
@@ -43,7 +43,13 @@ is run straight out of the working tree — the edit is live immediately, and it
 ## What it does (deterministic pipeline)
 
 1. **`recent-comments.py`** — queries ClickUp for all comments on your assigned tasks,
-   filters out your own, sorts by date, returns the top N with task ID/name/author/snippet.
+   filters out your own, sorts by date, returns the top N with task ID/name, ticket
+   status/priority, author, snippet + full `text`, and `my_latest_reply` — the date of *your*
+   newest comment on that task, computed **before** your comments are dropped, because the
+   consumer otherwise cannot tell an answered ticket from an abandoned one. That last key
+   is **omitted entirely** when the user id could not be resolved — absent means "the
+   check could not run", which is not the same fact as a present `null` ("I looked; you
+   never replied"). Both consumers branch on which.
 2. **`search-sessions.py`** — searches `~/.claude/projects/**/*.jsonl` transcripts for
    sessions mentioning a task ID, ranks by hit count. Terms are **ANDed**, so it is run
    **once per task**, never with several tasks' terms in one query.
@@ -75,7 +81,7 @@ process per task, so lookups dedupe within a task, not across the run.
 
 | Script | Input | Output |
 |--------|-------|--------|
-| `recent-comments.py --limit N` | ClickUp API | task_id, task_name, date, author, snippet |
+| `recent-comments.py --limit N` | ClickUp API | `--json`: task_id, task_name, task_status, task_priority, date, author, snippet, text, and **`my_latest_reply` only when the user id resolved** — its ABSENCE is meaningful (the check could not run), so read with `in`, never `.get()`. The tabular printer emits a different, smaller set — task_id, task_name, date, author, snippet — which `check-completion.py` parses for field 0 only. |
 | `search-sessions.py term1 [term2 ...]` | `~/.claude/projects/` | session_id, date, project, hits |
 | `check-completion.py --task ID` | session transcripts | status, completion signals, open items |
 | `check-addressed.py --limit N` | all of the above | unified report |
@@ -124,8 +130,14 @@ inert proximity tier whose confidence marker printed the same symbol for every s
 Round 5, the same day, fixed a **false explanation** (a named-but-unknown repo reported as
 "repo not named"), the repaired marker never reaching the report, and the missing
 "nobody is on it and someone is waiting" flag (matrix in
-`claude/skills/check-clickup-addressed/reference/validation-history.md`); what remains is listed
-under "Still weak".
+`claude/skills/check-clickup-addressed/reference/validation-history.md`). Round 6, on 2026-08-22, fixed
+that new flag's own blind spot — it could not see **your** replies, so a ticket you had
+already answered was reported unanswered forever. What remains is listed under "Still weak".
+
+🔴 **Every round so far has been found by RUNNING the tool and checking its verdict against
+reality, never by reading the code.** Round 6's defect shipped *with* a fresh adversarial
+test suite that had five controls on the very function that was wrong — all five green, all
+five scoped to one side of a seam. If you are about to trust a verdict here, open the ticket.
 
 - Session search is keyword-based, not semantic — a session that addressed the task
   without ever writing its ID is invisible to this tool. **A `no_mentions_found` or
@@ -213,6 +225,28 @@ plus one state where nothing disagrees and that is exactly the problem (4):
    and would re-fire on every unstarted backlog item forever, training the reader to skip
    the block; recency is a property of the *interaction*, says a human is waiting **now**,
    and self-clears. Fires whatever the status word reads (safe direction, like the veto).
+   🔴 **It could not see YOUR OWN replies until 2026-08-22, so an answered ticket stayed
+   flagged forever** — the unbounded noise the recency bound exists to prevent. Measured on
+   `868kuam02`: "Commented 2d ago; nobody has answered" over a ticket **two** sessions had
+   already answered, the later of them 11 h earlier, and acting on it duplicated an analysis
+   already in the thread. A **seam** defect, each side correct alone — `recent-comments.py`
+   drops your comments (right: the report is about what *others* said), and the flag concludes
+   nobody answered (right, given the only evidence it is handed). Neither can see the other's
+   assumption, so the fix crosses the seam: the producer now emits `my_latest_reply` per task
+   and the flag suppresses when your newest reply is **at or after** the comment. Compared,
+   not counted — a reply *predating* the question does not answer it. An **absent**
+   `my_latest_reply` (stale producer, or a failed user-id lookup) fires but says the check
+   never ran, rather than silently deciding either way.
+   🔴 **The seam is crossed for TOP-LEVEL comments only.** `recent-comments.py` calls the CLI
+   without `--threads`, and `/task/{id}/comment` returns top-level comments only — replies
+   live behind `getThreadedComments`. So an answer you wrote *inside a comment thread* is
+   still invisible and the ticket still reads as unanswered. Narrower than D12, same shape.
+   (Verified 2026-08-22 that the two answers on `868kuam02` are top-level, so the motivating
+   case really is fixed — but do not read that as the general case.)
+   🔴 **New false-SILENCE direction, deliberately unbounded by transcripts:** reply *"I'll
+   look next week"* and the flag is silenced for that comment even though `mentions_found ==
+   0` means no other rule covers the ticket either — which is the gap this flag was added to
+   fill. Bounded only by a *newer* colleague comment re-firing it. Acknowledging is not doing.
 
 🔴 **Sources 1 and 2 are gated on a hardcoded nine-word status vocabulary, and ClickUp
 statuses are per-list and arbitrary.** Until 2026-08-21 a miss was **silent**: measured,
@@ -287,7 +321,7 @@ further drift. **Re-time it rather than quoting it.**
 
 ## Tests
 
-Run all tests (**161** collected, measured 2026-08-22). `run_all.py` exits non-zero on
+Run all tests (**176** collected, measured 2026-08-22). `run_all.py` exits non-zero on
 failure — but read the `Total: N passed, M failed` line, not a piped exit code. 🔴 **If that
 line is missing at all, the run died — treat it as a failure, never as "no output".** A
 `sys.exit()` from code under test is a `SystemExit`, which a bare `except Exception` does
@@ -301,7 +335,7 @@ PYTHONDONTWRITEBYTECODE=1 python3 "$CCUA/tests/run_all.py"
 
 The same files are a **pytest** target of devrc's gate — `scripts/check-clickup-addressed/tests`
 in `HERMETIC_TARGETS`, with its collected-count floor in `TARGET_FLOORS`
-(`scripts/run-tests.sh`). Both runners see the same 161; `run_all.py` survives because it
+(`scripts/run-tests.sh`). Both runners see the same 176; `run_all.py` survives because it
 purges `__pycache__` and reports an import failure as a FAILURE, which pytest's summary
 line does not distinguish as loudly. **Raise the floor when you add tests.**
 
@@ -321,6 +355,12 @@ Test files:
   `test_an_unknown_clickup_status_does_not_disable_the_waiting_flag` asserts the **WAITING**
   flag specifically: a bare `assert flags` was green for round 4's announcement instead, and
   let a mutant rebuilding the D6 blind spot SURVIVE a fully green suite.
+- `test_own_reply_answers.py` — the round-6 set (D12): the waiting flag reading your own
+  replies. 🔴 `test_collect_computes_the_reply_over_the_UNFILTERED_comment_list` exists
+  **because a mutation sweep found the wiring uncovered** — `latest_reply_by` and
+  `build_record` were each pinned in isolation while `_collect`, the only thing that joins
+  them, was not, so `latest_reply_by([], my_id)` made the whole fix inert against a fully
+  green suite. Pin the SEAM, not only the parts.
 - `test_check_completion.py` — windowed signal extraction. ⚠️ Its two proximity tests hand
   `extract_signals_from_windows` a non-zero `distance`, which no production producer emits;
   they cover the formula, not any reachable path. The reachable premise is pinned in

--- a/claude/skills/check-clickup-addressed/reference/validation-history.md
+++ b/claude/skills/check-clickup-addressed/reference/validation-history.md
@@ -14,10 +14,33 @@ back to the D4 failure it was built to prevent — reading yesterday's report as
 evidence. Nothing errors when this happens; the report just stops printing
 `(ignored N transcript(s) …)`.
 
-Both spellings are now in `SELF_RUN_MARKERS` (transcripts written before the move still say
-the old one), the ledger in `test_the_devrc_invocation_path_is_a_self_run` /
-`EXPECTED_SELF_RUN_MARKERS` pins both, and the new test was watched RED on the migrated tree
-before the marker was added. Suite: 155 → 156.
+The old literal stays in `SELF_RUN_MARKERS` (transcripts written before the move still say
+it) and the new layout is matched by `NEW_LAYOUT_RE`. The test was watched RED on the
+migrated tree before the marker existed. Suite: 155 → 157.
+
+🔴 **And the obvious fix was measured WRONG, which is the more useful half.** The natural
+counterpart to the old marker is the directory, `scripts/check-clickup-addressed/`. That
+re-creates the exact defect this file already rejects the bare name for. devrc's `CLAUDE.md`
+carries a subsystem table mapping `scripts/<dir>/` to its owning skill, a project `CLAUDE.md`
+is injected into every session in that repo, and the gate prints a per-target line naming the
+same directory. Measured over the 761 transcripts these scripts actually walk:
+
+| candidate | transcripts matched | verdict |
+|---|---|---|
+| `check-clickup-addressed` (bare name) | 96 (12.6%) | unusable — the known one |
+| `scripts/repo-cos/` (sibling CLAUDE.md row, as a proxy) | 83 (10.9%) | what the directory spelling would cost |
+| `scripts/session-analysis/` (ditto) | 72 (9.5%) | ” |
+| `check-clickup-addressed/scripts/` (old marker) | 11 (1.4%) | ✅ anchored |
+| `scripts/check-clickup-addressed/[file].py` (shipped) | — | ✅ anchored: requires a FILE |
+
+So the marker requires a `.py` file immediately after the directory. A run matches; the
+CLAUDE.md row and the gate's `…/tests` line do not. `test_a_mention_of_the_scripts_DIRECTORY_
+is_not_a_self_run` uses both of those as REAL fixtures, and the directory-spelling mutant dies
+on that test alone — verified by substituting it and watching 1 failed / 156 passed.
+
+**Generalise:** the over-broad direction has no error and no test of its own unless you write
+one. Ask what OTHER document in the new repo spells your marker, and measure the candidate
+against the real corpus before shipping it.
 
 **Generalise:** a marker built out of a path is a claim about where the code lives. Moving
 the code invalidates it without touching it, and the tell is a guard that goes quiet rather

--- a/claude/skills/check-clickup-addressed/reference/validation-history.md
+++ b/claude/skills/check-clickup-addressed/reference/validation-history.md
@@ -5,14 +5,29 @@ scoped, gated by nothing) into devrc: docs at `claude/skills/check-clickup-addre
 code + suite at `scripts/check-clickup-addressed/`. It is now a global skill on both hosts
 and a registered target of `scripts/run-tests.sh`, which had never run it before.
 
-**The move broke a guard, silently, and that is the round's finding.** `_selfrun.py`'s
-anchored markers are PATH FRAGMENTS. One of them was `check-clickup-addressed/scripts/` —
-the talos layout. The devrc layout reverses those two segments
-(`scripts/check-clickup-addressed/`), so after the move no invocation matched, the prior-run
-guard would have stopped recognising its own runs, and the checker would have gone straight
-back to the D4 failure it was built to prevent — reading yesterday's report as today's
-evidence. Nothing errors when this happens; the report just stops printing
-`(ignored N transcript(s) …)`.
+**The move broke a marker, and an audit then corrected how much that mattered.**
+`_selfrun.py`'s anchored markers are PATH FRAGMENTS. One was `check-clickup-addressed/scripts/`
+— the talos layout. The devrc layout reverses those two segments, so after the move no
+invocation matched it.
+
+🔴 **The first write-up of this said the guard "went quiet". Measured, that was wrong, and the
+correction is the more useful fact.** The path markers catch the *invocation*; the report
+header `## Task Completion Status` catches the *output*, and every text-mode run prints it.
+Over the same 762 transcripts the exclusion set is **11 with or without** the path marker. So
+the ordinary path was never blind. Two genuinely broken shapes came out of the audit instead:
+
+1. **`--json` carried no marker at all.** The header lived on the text branch; `--json` printed
+   `json.dumps(report)`. A JSON report lists every task ID beside `likely_addressed` — the exact
+   shape the proximity scorer rewards — so that output, if captured, read back as evidence.
+   Fixed by `render_json()`, which emits the header as a `report_header` field.
+2. **The marker missed the invocation SKILL.md itself teaches.** The quick start is
+   `CCUA=…` then `python3 "$CCUA/check-addressed.py"`; the variable means the path adjacency
+   never appears in the transcript. A marker for a shape nobody types is not a marker. The
+   entry-point basenames are alternatives now — each measured in the anchored class
+   (1.3–1.6%), not the ~10% mention class.
+
+What the path markers uniquely cover, and why they stay: a run whose OUTPUT never reaches the
+transcript — piped to a file, `| jq`, truncated. Defence in depth, labelled as such.
 
 The old literal stays in `SELF_RUN_MARKERS` (transcripts written before the move still say
 it) and the new layout is matched by `NEW_LAYOUT_RE`. The test was watched RED on the

--- a/claude/skills/check-clickup-addressed/reference/validation-history.md
+++ b/claude/skills/check-clickup-addressed/reference/validation-history.md
@@ -1,0 +1,1244 @@
+# Migration to devrc — 2026-08-22
+
+The skill moved out of `datapacket-talos/.claude/skills/check-clickup-addressed/` (project-
+scoped, gated by nothing) into devrc: docs at `claude/skills/check-clickup-addressed/`,
+code + suite at `scripts/check-clickup-addressed/`. It is now a global skill on both hosts
+and a registered target of `scripts/run-tests.sh`, which had never run it before.
+
+**The move broke a guard, silently, and that is the round's finding.** `_selfrun.py`'s
+anchored markers are PATH FRAGMENTS. One of them was `check-clickup-addressed/scripts/` —
+the talos layout. The devrc layout reverses those two segments
+(`scripts/check-clickup-addressed/`), so after the move no invocation matched, the prior-run
+guard would have stopped recognising its own runs, and the checker would have gone straight
+back to the D4 failure it was built to prevent — reading yesterday's report as today's
+evidence. Nothing errors when this happens; the report just stops printing
+`(ignored N transcript(s) …)`.
+
+Both spellings are now in `SELF_RUN_MARKERS` (transcripts written before the move still say
+the old one), the ledger in `test_the_devrc_invocation_path_is_a_self_run` /
+`EXPECTED_SELF_RUN_MARKERS` pins both, and the new test was watched RED on the migrated tree
+before the marker was added. Suite: 155 → 156.
+
+**Generalise:** a marker built out of a path is a claim about where the code lives. Moving
+the code invalidates it without touching it, and the tell is a guard that goes quiet rather
+than a test that goes red.
+
+---
+
+# Validation record — 2026-08-19
+
+Three defects made this checker emit confident false verdicts. All three were found by
+reading the tool's own output against ClickUp ground truth, not by a failing test.
+
+## Defects
+
+**D1 — the fallback that manufactured `partially_addressed`.**
+`check-completion.py` fell back to a full-text scan of the whole corpus when a task ID
+appeared nowhere, scoring every signal at a hardcoded `proximity: 0.5`. The "close" tier
+requires `> 0.5`, so those results could never reach it and always fell through to
+`elif completion and open_items → "partially_addressed"`. Any unmatched task, in a corpus
+containing one `#N merged` and one `still running`, was labelled partially-addressed **by
+construction**, citing other tasks' work. Observed on `868kt8pfu`: 5 completion + 5 open
+signals, `mentions_found: 0`, every snippet about unrelated work. One of the five
+"completion" signals literally read *"PR #346 is still unmerged."*
+
+**D2 — ±2000-char windows bleed across a multi-task triage table.**
+Asking about `868krn3y1` returned `868kr07fu`'s merge at **proximity 1.5** — the task-ID
+boost fired because the *target's* ID also fell inside the 80-char snippet, making the
+misattributed signal the highest-confidence one in the report.
+
+**D3 — the tool read its own transcript.**
+`search-sessions.py` run against the four task IDs returned exactly one session: the one
+running the check, which mentions every task ID under test by construction.
+
+**D4 (found while fixing) — `sessions_found: 0` on every multi-task run.**
+`check-addressed.py` merged all task IDs plus four words from each task *name* into one
+≤8-term bag; `search_sessions` ANDs its terms, so the query demanded a single session
+mentioning four unrelated tasks. It always returned 0, `check-completion.py` silently fell
+back to its own per-task scan, and the report still printed `sessions_found: 0` —
+describing a search whose result nothing used.
+
+## Fixes
+
+- `check_task` returns **`no_mentions_found`** with empty signal lists; the full-text
+  fallback is deleted.
+- `extract_signals_from_windows` keeps a signal only when the task under test is the
+  ClickUp ID lexically nearest to it (`_nearest_task_id`).
+- `extract_text_windows` returns `(window, distance, mention_offset)` and matches the
+  **exact** ID only; the 6-char-prefix pass is removed, along with its `already_covered`
+  check (an `any()` over `range(len(text))` whose predicate ignored the loop variable).
+- `--exclude-session` on both scripts, defaulting to `$CLAUDE_CODE_SESSION_ID`.
+- `check-addressed.py` searches **per task** and reports `sessions_by_task`.
+
+## Red-at-base / green-at-HEAD
+
+Base = the pre-fix scripts, copied aside before editing. Suite: `python3 scripts/check-clickup-addressed/tests/run_all.py`.
+
+| Test | At base | At HEAD |
+|---|---|---|
+| `test_no_mentions_is_not_partially_addressed` | ✗ `got 'partially_addressed'` | ✓ |
+| `test_rival_task_signal_is_not_attributed_to_target` | ✗ (see note) | ✓ |
+| `test_own_signal_survives_the_attribution_guard` | ✗ (see note) | ✓ |
+| `test_nearest_task_id_picks_the_closer_of_two` | ✗ `no attribute '_nearest_task_id'` | ✓ |
+| `test_excluded_session_is_not_read` | ✗ `unexpected keyword 'exclude_sessions'` | ✓ |
+| `test_search_sessions_honours_exclude` | ✗ `unexpected keyword 'exclude_sessions'` | ✓ |
+| `test_windows_carry_their_mention_offset` | ✗ `expected 3, got 2` | ✓ |
+| `test_prefix_matching_does_not_invent_windows` | ✗ (window invented) | ✓ |
+| `test_no_mentions_positive_control` | ✓ | ✓ |
+
+**Note — two of those reds are weak.** The attribution tests fail at base on the tuple
+*shape* (`too many values to unpack`), not on the behaviour, so they died for the wrong
+reason. The behaviour was therefore proven separately against the baseline's own 2-tuple
+API: asking about `868krn3y1` over a two-row table returned
+`[PR merged] prox=1.5 | 868kr07fu | talos-infra #1065 merged 08-16 …`. That is the defect,
+measured at base.
+
+`test_no_mentions_positive_control` passes at base and is an **invariant guard**, not
+regression coverage: it exists so D1's fix cannot pass by returning nothing for everything.
+
+Full suite at HEAD: **45 passed, 0 failed, rc=0** — read by counting `✓`/`✗` lines, not
+from a piped exit code (`run_all.py | tail` reports *tail's* status; that misread happened
+once during this work).
+
+## Mutation sweep
+
+Each guard broken in a pristine copy; the suite must fail **by name**.
+`PYTHONDONTWRITEBYTECODE=1`, `__pycache__` excluded from the copy.
+
+| Mutant | Verdict | Killed by |
+|---|---|---|
+| IDENTITY (harness control) | OK — 45 passed | — |
+| M1 drop attribution guard | KILLED | `test_rival_task_signal_is_not_attributed_to_target` |
+| M2 `no_mentions_found` → `partially_addressed` | KILLED | `test_no_mentions_is_not_partially_addressed` |
+| M3 `check_task` ignores exclude list | KILLED | `test_excluded_session_is_not_read` |
+| M4 `search_sessions` ignores exclude | KILLED | `test_search_sessions_honours_exclude` |
+| M5 nearest → farthest | KILLED | `test_nearest_task_id_picks_the_closer_of_two` (+2 collateral) |
+| M6 prefix matching reinstated | KILLED | `test_prefix_matching_does_not_invent_windows` |
+
+The IDENTITY row is the harness's positive control: it proves the sweep can report
+"all pass", so a `SURVIVED` verdict would have been meaningful. Harness:
+`scratchpad/mutate.py` (session-local, not committed).
+
+## End-to-end: same four tasks, before and after
+
+Ground truth taken from each ticket's newest ClickUp comment and live status, plus
+`gh pr view` on every PR cited.
+
+| Task | Before | After | Ground truth |
+|---|---|---|---|
+| `868ktvqf9` | partially_addressed (5c/4o) | partially_addressed (5c/4o) | ✅ `in progress`; #4102 merged, headline defect open |
+| `868kt8pfu` | partially_addressed (5c/5o, **all false**) | **open** (0c/1o) | ✅ nothing shipped; blocked on `workflow` OAuth scope |
+| `868kr07fu` | partially_addressed (5c/3o, **all cross-task**) | **likely_addressed** (1c/0o) | ✅ *"Resolved … Recommend closing"* |
+| `868krn3y1` | partially_addressed (3c/3o, **all cross-task**) | **unclear** (0c/0o) | ✅ no work recorded since 08-15 |
+
+(These are the round-1 verdicts. Round 2 reads more text — user messages — so `868kr07fu`
+moves to `partially_addressed`; its resolved state is surfaced by the disagreement flag
+instead. See the round-2 section.)
+
+`sessions_found: 0` → `sessions_by_task: {868ktvqf9: 2, 868kt8pfu: 2, 868kr07fu: 4,
+868krn3y1: 2}`.
+
+🔴 **Honest residual:** `868kr07fu`'s single surviving signal is
+``#1065 … merged 08-16 (I confirmed). `868kr07fu` is u[nfixed]``. Nearest-ID attribution
+is now correct, but the sentence is about a *different repo's* PR and the clause it
+actually attaches to says **un**fixed. Right verdict, wrong reason. Lexical proximity
+cannot fix this; see "Still weak" in `SKILL.md`.
+
+---
+
+# Round 2 — 2026-08-19 (acting on the evaluation)
+
+Structural false positives were gone after round 1, but the tool still could not see the
+authority (the ticket) and believed every PR citation. Five changes:
+
+- **ClickUp status + priority + newest comment** carried through `recent-comments.py` into
+  every verdict line.
+- **`disagreements()`** cross-checks ticket status, newest comment, and transcripts.
+- **PR references resolved** via `gh pr view`, cached and deduped.
+- **`OPEN_PATTERNS` tightened** — "still running"/"still waiting" removed from the bare
+  alternation (100% noise in a real run) and kept only in a ticket-scoped pattern; a
+  `blocked on <permission|scope|token|…>` pattern added.
+- **Seam closed**: `check-completion.py` now reads user text too. `search-sessions.py`
+  always did, so a session selected on a user-only mention previously reported
+  `mentions_found: 0`, and a human writing "this is still broken" was invisible.
+- **`extract_signals()` deleted** — dead once the fallback went, with 3 tests exercising
+  unreachable code.
+
+## Behavioural red at base (round 2)
+
+Three round-2 tests fail at base only on the tuple shape, so the behaviour was measured
+directly against the pre-fix API:
+
+```
+BASE — process noise scored as TICKET-OPEN signals:
+  1 hit(s) <- the throwaway Postgres is still running on port 5543
+  1 hit(s) <- CI is still running rather than failing
+  1 hit(s) <- The mirror agent is still running; I'll report when
+BASE — user-message read?  no_sessions_found
+```
+
+## Suite and mutation
+
+**55 passed, 0 failed, rc=0** (read unpiped). **15/15 mutants KILLED, 0 survivors**,
+IDENTITY control clean.
+
+Two findings the sweep produced that review had not:
+
+- **M12 SURVIVED twice.** A markdown-stripping step (a `re.sub` over emphasis characters) had no
+  killing mutation. First response was to add the test it lacked
+  (`test_adjacency_breaks_a_repo_tie_through_markdown`); it survived again, because the
+  bounded lookbehind already saw past the emphasis. The step was **deleted** — it was
+  doing nothing. M12 now mutates `REPO_LOOKBEHIND` instead, and dies.
+- **M9 NO-APPLY** — the mutant still targeted a line an earlier refactor had removed, so
+  it was silently testing nothing. A mutation harness needs its own "did this even apply"
+  check; ours prints `NO-APPLY` and exits non-zero.
+
+## End-to-end after round 2
+
+The report now leads with the thing that actually needed a human:
+
+```
+## Needs a decision
+⚠️  868kr07fu: newest comment reads as RESOLVED but the ticket is still `to do`
+    — close it, or say why it stays open.
+```
+
+🔴 **A false positive introduced and caught in the same session.** The first repo-inference
+rule scanned the whole snippet for a known repo name. "civitai" appears in nearly every
+snippet in this corpus (org name, sibling repos, prose), so every bare `#N` resolved to
+`civitai/civitai` and reported real-but-unrelated PRs — including
+`civitai/civitai#1080: merged 2024-03-18`. Replaced with a 30-character lookbehind
+(`REPO_LOOKBEHIND`); pinned by `test_distant_repo_name_does_not_claim_a_bare_ref`. This is
+the hazard the code comments warn about, walked into while writing the warning.
+
+Runtime unchanged at ~41–45s for `--limit 5` (PR lookups are cached and deduped).
+
+---
+
+# Round 3 — 2026-08-20
+
+## D4: the checker read its OWN PREVIOUS RUNS
+
+Round 1 stopped the checker reading the transcript it was being written into
+(`$CLAUDE_CODE_SESSION_ID`). It did nothing about **yesterday's run**, which is the same
+defect one day later and strictly worse: a prior report prints each task ID directly beside
+`likely_addressed`, `✓ resolved` and `merged`, so it is not merely noise — it is the exact
+lexical shape the proximity scorer is built to reward, and it ranks first.
+
+Found by running the tool for real. Both tasks in the report scored `likely_addressed`; the
+only substantive session behind either verdict was the previous run (`acf5d5fb…`, 14 hits).
+The cited evidence was the tool's own caveat text and an unrelated `scripts/obs-read` path
+lesson. Removing that one session:
+
+| Task | Verdict citing the prior run | Verdict without it | Ground truth |
+|---|---|---|---|
+| `868kr0799` | ✅ `likely_addressed` | ❓ `unclear` (2 mentions) | ✅ open — comment reads *"Still live, do not close"* |
+| `868kuam02` | ✅ `likely_addressed` | 🔍 `no_mentions_found` (0 mentions) | ✅ untouched; two cover-image comments unanswered |
+
+Left alone this is self-reinforcing: each run writes the evidence the next run reads.
+
+## Marker selection — the numbers that ruled out the obvious choices
+
+Counted over `~/.claude/projects` (~250 transcripts) before anything was added:
+
+| Candidate marker | Transcripts matched | Verdict |
+|---|---|---|
+| `check-clickup-addressed` | 213¹ | unusable — the skill catalog is injected into every session |
+| `/check-clickup-addressed` | 32 | unusable — substring of the skill's own **path** |
+| `<command-name>/check-clickup-addressed</command-name>` | 2 | ✅ the slash invocations |
+| `check-clickup-addressed/scripts/` | 6 | ✅ pipeline runs + the sessions that BUILT the skill |
+| `## Task Completion Status` | 1 | ✅ the report header, for a pasted-output session |
+
+¹ 🔴 **These counts are WRONG and are kept only as the historical record.** They came from a recursive `grep` over `~/.claude/projects`, which walks `<session>/subagents/` and `tool-results/` — files these scripts never open. Re-measured 2026-08-21 over the population they actually walk (735 transcripts): bare name **67 (9.1%)**, bare slash form **24 (3.3%)**, real anchored markers **4**. The verdict survives; the figures did not. Current numbers live in `SKILL.md` and `scripts/check-clickup-addressed/_selfrun.py`.
+
+The `check-clickup-addressed/scripts/` marker also catches the skill's own build sessions,
+which is correct rather than incidental: their test fixtures hardcode real task IDs
+(`868krn3y1`, `868kr07fu`) next to mock completion text.
+
+Failure direction is deliberate. A false positive drops a session and degrades a verdict to
+`unclear`/`no_mentions_found` — which this skill already documents as *no evidence either
+way*. A false negative restores the confident-✅-over-a-live-ticket bug.
+
+## D5: "resolved" in a comment that says DO NOT CLOSE
+
+Round 2's headline feature — flag a ticket whose newest comment reads as resolved — fired
+on `868kr0799`, telling the operator to close it. The comment:
+
+> **Still live, do not close.** … MeiliSearch: P95 > 5s (Saturation Burst) fired and
+> **resolved** repeatedly, A=18.97 at 7:55
+
+"resolved" there describes an *alert cycling*. No keyword can separate those two senses, so
+an explicit refusal to close (`KEEP_OPEN_RE`) now **vetoes** the flag outright rather than
+being weighed against it — the flag is an instruction to a human, not a score.
+
+## Red-at-base / green-at-HEAD
+
+Base = the same tree with the guard neutered (`is_self_run` → `return False`;
+`keep_open` → `None`), which is exactly the pre-change program.
+
+| Test | At base | At HEAD |
+|---|---|---|
+| `test_prior_run_is_not_read_as_evidence` | ✗ `read back as evidence: 'likely_addressed'` | ✓ |
+| `test_search_sessions_drops_prior_runs` | ✗ `prior run leaked: ['prior-run', 'real-work']` | ✓ |
+| `test_each_self_run_marker_fires_on_its_own` | ✗ `marker never fires` | ✓ |
+| `test_skill_tool_invocation_is_a_self_run` | ✗ `Skill tool_use not recognised` | ✓ |
+| `test_keep_open_comment_vetoes_the_close_flag` | ✗ `told the operator to close a ticket whose comment says not to` | ✓ |
+| `test_prior_run_positive_control` | ✓ | ✓ |
+| `test_ordinary_work_session_is_still_read` | ✓ | ✓ |
+| `test_skill_catalog_mention_is_not_a_self_run` | ✓ | ✓ |
+| `test_self_run_marker_set_has_not_drifted` | ✓ | ✓ |
+| `test_keep_open_veto_does_not_silence_genuine_resolutions` | ✓ | ✓ |
+
+🔴 The last four are **false-positive controls, not regression coverage** — they pass at
+base by construction (base never flags anything as a self-run, so it trivially never
+mis-flags one). They earn their place under mutation, below, not here.
+
+## Mutation sweep
+
+| Mutant | Verdict | Killed by (own message) |
+|---|---|---|
+| BASELINE (guard neutered — harness control) | 4 red / 25 green | see table above |
+| M13 drop the `## Task Completion Status` marker | KILLED | `test_each_self_run_marker_fires_on_its_own` + the defect returns as `likely_addressed` |
+| M14 drop the `<command-name>…` marker | KILLED | `test_each_self_run_marker_fires_on_its_own`, `test_self_run_marker_set_has_not_drifted` |
+| M15 widen marker to bare `check-clickup-addressed` | KILLED | `test_skill_catalog_mention_is_not_a_self_run` (the over-broad direction) |
+| M16 `keep_open` → `None` | KILLED | `test_keep_open_comment_vetoes_the_close_flag` |
+
+M15 is the one that matters for the controls: it is the only mutant testing the *widening*
+direction, and it dies on a test that is green at base.
+
+🔴 **`test_each_self_run_marker_fires_on_its_own` iterates `EXPECTED_SELF_RUN_MARKERS`, a
+literal list in the test file — deliberately NOT `selfrun.SELF_RUN_MARKERS`.** Iterating the
+implementation's own tuple makes "delete a marker" pass vacuously: the deleted marker simply
+stops being tested. `test_self_run_marker_set_has_not_drifted` pins the tuple as a ledger, so
+the set cannot grow or shrink without a deliberate edit to the test.
+
+A marker escape also had to be fixed: the first `SELF_RUN_RE` matched only raw JSON
+(`"skill":"…"`), missing the backslash-escaped form a transcript uses when it quotes a call
+inside message text. Caught by the marker test, not by review.
+
+## End-to-end after round 3
+
+```
+❓ **868kr0799** — transcripts say `unclear` (searched 2 sessions, 2 mentions)
+     ClickUp says: **to do** / prio urgent
+🔍 **868kuam02** — transcripts say `no_mentions_found` (searched 1 sessions, 0 mentions)
+     (ignored 1 transcript(s) that are prior runs of this checker …)
+## Summary: 0 addressed, 0 partial, 0 open, 2 unclear
+```
+
+The skip count is printed rather than swallowed: a guard nobody can watch fire is
+indistinguishable from one wired to nothing.
+
+---
+
+# Round 4 — 2026-08-21
+
+Found by reading the code against its own documentation, not by a failing test. Both
+defects are **silent no-ops**: a feature the docs describe, that runs, and does nothing.
+
+## D6: an unrecognised ClickUp status disabled every ticket/comment cross-check
+
+`disagreements()` gates all three of its checks on `OPEN_STATUSES` / `DONE_STATUSES` — nine
+hardcoded words. ClickUp statuses are per-list and arbitrary. Measured at base:
+
+| `clickup_status` | flags emitted |
+|---|---|
+| `to do` | ✅ "newest comment reads as RESOLVED but the ticket is still `to do`" |
+| `open` | ✅ same |
+| `in review` | **[]** |
+| `blocked` | **[]** |
+| `needs qa` | **[]** |
+| `review` | **[]** |
+
+The keep-open veto — round 3's headline safety fix — is inside the same gate, so it was off
+too. Nothing was printed either way, and an empty **Needs a decision** block reads as
+*checked, nothing disagrees*.
+
+Fix: an unrecognised (or missing) status now emits a flag naming the status, saying the
+cross-check **DID NOT RUN**, and listing the two sets to add it to; an explicit "do not
+close" in the comment is surfaced regardless of status, since that direction is safe and it
+is the reporter's own instruction. 🔴 **Widening the sets is deliberately not the fix** — it
+only moves the silence to the next unknown word.
+
+## D7: the proximity tier was unreachable, and its confidence marker was a constant
+
+`proximity = 1.0/(1.0 + distance)`, ×1.5 when the task ID is inside the signal's own
+±40-char snippet. But `extract_text_windows` — the only producer of windows in production —
+hardcodes `distance = 0`:
+
+```
+windows.append((text[window_start:window_end], 0, pos - window_start))
+```
+
+So production proximity is only ever **1.0 or 1.5**, both above the `> 0.5` "close"
+threshold. Consequences, all measured:
+
+- `close_completion` was always `== completion` ⇒ the three branches behind the tier
+  (`elif completion and not open_items` …) were **unreachable**.
+- The `●` / `○` marker printed **`●` for every signal ever emitted**, including one 2000
+  characters from the mention. Confirmed on a live run of `868kr07fu`: every line `●`.
+- The two tests covering proximity (`test_proximity_scoring`,
+  `test_extract_signals_from_windows`) hand-build windows with `distance` 100 and 500 —
+  values production cannot produce. Green over a path that does not exist. One of them is
+  additionally wrapped in `if open_items:` and can pass vacuously.
+
+The tier is **vestigial**: the round-1 full-text fallback, deleted for D1, was the only
+thing that ever set a non-unit proximity (a hardcoded 0.5). Round 1 removed the fallback
+and left its scoring machinery behind.
+
+Fix: delete the tier (four branches remain); keep the ×1.5 weight, which is real and does
+vary, and rename what it means — `confidence_marker()` reports **adjacency**: `●` the task
+ID is inside this signal's own snippet, `○` merely somewhere in the ±2000-char window.
+
+**Verdict-neutrality was measured, not argued** — round-3 code vs round-4 code, same live
+corpus, same second:
+
+| Task | round 3 | round 4 |
+|---|---|---|
+| `868kr07fu` | partially_addressed 8/7/2c/1o | identical |
+| `868krn3y1` | unclear 5/6/0c/0o | identical |
+| `868ktvqf9` | partially_addressed 6/25/5c/5o | identical |
+| `868kt8pfu` | partially_addressed 4/29/3c/4o | identical |
+| `868kr0799` | unclear 5/2/0c/0o | identical |
+| `868kuam02` | no_mentions_found 1/0/0c/0o | identical |
+
+And the marker now discriminates: on `868kt8pfu` **all seven** signals are `○` — none of
+that evidence has the task ID in its own snippet, which is exactly what the operator needed
+to know and previously could not see.
+
+## D8 (bonus): `--include-self-runs` was documented on the entry point and never parsed
+
+`check-addressed.py`'s arg loop ended in `else: i += 1`, swallowing every unrecognised flag.
+Base behaviour, measured by capturing the argv handed to each sub-process:
+
+```
+recent-comments.py:  [--limit 3 --json]
+search-sessions.py:  [--limit 5 --json --exclude-session <id> <task>]
+check-completion.py: [--task <task> --json --exclude-session <id>]
+'--include-self-runs' forwarded anywhere?  False
+```
+
+The run completed and printed a normal report. Fix: `parse_args()` handles every flag and
+**exits 2 on an unknown one**, and the flag is forwarded to both sub-scripts.
+
+## Red-at-base / green-at-HEAD
+
+Base = the round-3 commit (`f5434a399`, pushed as `acf9eb0b9`).
+
+| Test | At base | At HEAD |
+|---|---|---|
+| `test_unknown_clickup_status_is_flagged_not_silently_skipped` | ✗ `status 'in review': cross-check silently skipped` | ✓ |
+| `test_missing_clickup_status_is_flagged_too` | ✗ `a missing ClickUp status silently skipped the cross-check` | ✓ |
+| `test_keep_open_is_surfaced_even_on_an_unknown_status` | ✗ `'do not close' never reached the operator: []` | ✓ |
+| `test_confidence_marker_distinguishes_adjacent_from_same_window` | ✗ (see note) | ✓ |
+| `test_include_self_runs_is_recognised_by_the_orchestrator` | ✗ (see note) | ✓ |
+| `test_include_self_runs_is_forwarded_to_both_subscripts` | ✗ (see note) | ✓ |
+| `test_known_flags_still_parse` / `test_unknown_flag_is_rejected_not_swallowed` | ✗ (see note) | ✓ |
+| `test_production_windows_are_all_distance_zero` | ✓ | ✓ |
+| `test_every_production_signal_scores_above_the_deleted_threshold` | ✓ | ✓ |
+| `test_deleting_the_tier_preserves_every_verdict` | ✓ | ✓ |
+| `test_known_open_status_still_flags_a_resolved_comment` | ✓ | ✓ |
+| `test_known_status_veto_still_wins` | ✓ | ✓ |
+| `test_agreeing_ticket_still_produces_no_flag` | ✓ | ✓ |
+| `test_self_run_guard_is_on_by_default` | ✓ | ✓ |
+
+🔴 **Note — five of those reds are weak**, exactly as in round 1: they fail at base on
+`AttributeError` (`no attribute 'confidence_marker'` / `'parse_args'`), i.e. on API shape,
+not behaviour. Both behaviours were therefore measured directly against the base program
+instead — the all-`●` live run for the marker, and the captured sub-process argv above for
+the flag. Those measurements are the evidence; the tests are the ratchet.
+
+The seven ✓-at-base rows are **INVARIANT GUARDS / false-positive controls**, not regression
+coverage. Two of them carry real weight anyway: `test_production_windows_are_all_distance_zero`
+is the premise that licenses D7's deletion (M25 proves it is live), and
+`test_self_run_guard_is_on_by_default` is the only test of the *widening* direction (M24).
+
+## Mutation sweep
+
+Pristine copy per mutant, `__pycache__` excluded, `PYTHONDONTWRITEBYTECODE=1` in the child.
+Harness reports `NO-APPLY` and fails when a mutant's target text is absent.
+
+| Mutant | Verdict | Killed by (own message) |
+|---|---|---|
+| IDENTITY (harness control) | OK — 80 passed | — |
+| M17 unknown-status branch never fires | KILLED | `test_unknown_clickup_status_is_flagged_not_silently_skipped` |
+| M18 keep-open not surfaced on unknown status | KILLED | `test_keep_open_is_surfaced_even_on_an_unknown_status` |
+| M19 marker threshold back to the dead `0.5` | KILLED | `test_confidence_marker_distinguishes_adjacent_from_same_window` |
+| M20 unknown flag swallowed again | KILLED | `test_unknown_flag_is_rejected_not_swallowed` |
+| M21 `--include-self-runs` not parsed | KILLED | `test_include_self_runs_is_recognised_by_the_orchestrator` |
+| M22 not forwarded to search-sessions | KILLED | `test_include_self_runs_is_forwarded_to_both_subscripts` |
+| M23 not forwarded to check-completion | KILLED | `test_include_self_runs_is_forwarded_to_both_subscripts` |
+| M24 forwarded UNCONDITIONALLY (widening) | KILLED | `test_self_run_guard_is_on_by_default` |
+| M25 producer emits a non-zero distance | KILLED | `test_production_windows_are_all_distance_zero` |
+
+M22 and M23 are separated deliberately: one test claims the flag reaches **both** stages, so
+each stage needs its own mutant or the claim is half-checked. Their kill messages differ
+(`reached: {'check-completion.py'}` vs `{'search-sessions.py'}`), which is what proves the
+test is not passing for the other stage's reason.
+
+🔴 **The sweep found a defect in the TEST HARNESS that no test could have.** M21 first came
+back `HARNESS ERROR — no total line`: `parse_args` calls `sys.exit(2)`, and `SystemExit` is
+a `BaseException`, so `run_all.py`'s `except Exception` did not catch it. It escaped the
+loop and killed the entire run — no remaining test files, no `Total:` line, and an exit code
+this skill's own docs tell you not to read. **A suite that dies prints nothing, which is not
+distinguishable from a suite that has nothing to say.** `run_all.py` now catches
+`SystemExit` and scores it as a failure naming the test; M21 then died by name.
+
+## Suite
+
+**80 passed, 0 failed** (counted, unpiped). Harness: `/tmp/ccua-mutate.py`, session-local,
+not committed.
+
+---
+
+# Round 5 — 2026-08-21
+
+Found by **running the tool for real** after round 4 shipped, not by reading it and not by a
+failing test — the suite was 80/0 green over every one of these. Round 4's own lesson,
+one layer up: the defects live where nothing was looking.
+
+## D9: `_repo_for_ref` has THREE failure modes and reported them all as one — the wrong one
+
+`_repo_for_ref` returns `None` in more than one situation and `annotate_pr_refs` rendered
+every one as `unresolved (repo not named)`. Measured live on the report's own output for
+`868ktvqf9`, snippet ``| **#4181**, **devrc #591** | merged, verified by content |``:
+
+```
+  ✓ PR merged: red **both inherited**; unaudited | | **#4181**, **devrc #591** | merged, verifi
+      ↳ #4181: unresolved (repo not named)
+      ↳ #591:  unresolved (repo not named)      <-- FALSE. the repo IS named.
+```
+
+The regex captured `word='devrc'` for the second one — the repo was named; `devrc` simply
+is not one of the six `KNOWN_REPOS` keys. Both PRs resolve by hand:
+`civitai/civitai#4181` **MERGED**, `innovation-upstream/devrc#591` **MERGED** (both
+`gh pr view`, 2026-08-20). So round 2's "is this cited PR actually still open?"
+cross-check — the whole point of the `gh` lookups — contributed **nothing** on the only
+task in the run that had completion signals, while reporting a cause that was wrong.
+
+Same closed-vocabulary silent-miss class as D6, but worse: **a wrong explanation stops the
+reader looking**, where an honest "I don't know this repo" sends them to add it.
+
+Fix, in three parts:
+
+1. `_repo_for_ref` returns `(repo, reason)` and `_unresolved_state` renders the reason —
+   `repo not named` (correct, and kept: the refusal to guess is the round-2 fix),
+   `repo 'X' is not in KNOWN_REPOS — add it`, and `ambiguous — A, B both in range`.
+   Resolution ORDER is byte-for-byte the pre-change control flow, so **no citation changes
+   repo**; only the text of a failure changes.
+2. `KNOWN_REPOS` gains the three hub repos it was missing —
+   `storage-resolver` → `civitai/storage-resolver`, `flipt-state` → `civitai/flipt-state`,
+   `devrc` → **`innovation-upstream/devrc`**. Every owner verified with
+   `gh repo view <owner>/<name>`; `civitai/devrc` **does not exist**, and the owner is
+   precisely the part a guess gets wrong.
+3. 🔴 **Widening the dict is explicitly not the fix**, and the code says so. It only moves
+   the silence to the next repo nobody thought of. The message is the durable half.
+
+The word on the `#` is reported **as written, unclassified**. Nothing short of enumerating
+the world separates `devrc` from `landed`, and a reader separates them at a glance where a
+heuristic cannot — so the honest output is "here is the word that sat on the `#`, and it is
+not in my table", noise included.
+
+## D10: round 4's own fix was half-delivered — the marker never reached the report
+
+Round 4 built `confidence_marker()` (`●` = the task ID is inside the signal's own ±40-char
+snippet, `○` = merely in the ±2000-char window) and wired it into **`check-completion.py`'s
+own printer only**. `check-addressed.py` — the entry point the Quick start tells you to
+run, and the only one anyone runs — never called it. Its `✓`/`○` mark
+completion-vs-open, not confidence.
+
+Base rendering, measured with the printer's own code over two signals that differ ONLY in
+adjacency:
+
+```
+  ✓ PR merged: ADJACENT     (proximity 1.5)
+  ✓ PR merged: FAR AWAY     (proximity 1.0)   <-- identical
+  ○ still open: ADJ         (proximity 1.5)
+  ○ still open: FAR         (proximity 1.0)   <-- identical
+```
+
+This is the "a guard's DESCRIPTION claims coverage wider than its implementation" defect,
+walked into **while fixing that defect class**. A marker nobody sees is the same no-op as a
+marker that cannot vary; round 4 fixed one half and left the other.
+
+Fix: `signal_line()` renders adjacency as a **second, bracketed column** —
+`✓ [●] …` / `○ [○] …` — because `○` already meant "open item" in the first column, and
+merging two orthogonal facts into one glyph makes the report unreadable rather than silent,
+which is not an improvement. `check-addressed.py` **imports** the marker from
+`check-completion.py` rather than re-deriving it; one threshold, one place. A legend is
+printed once per report.
+
+## D11: the highest-signal state in the tool produced no flag at all
+
+`disagreements()` emitted nothing for a task that is OPEN, has **zero** transcript
+evidence, and carries a recent comment from someone else. Measured live on `868kuam02`:
+`to do` / high, comment from @Ellie King 2026-08-20, `mentions_found: 0` — and the
+**Needs a decision** block said nothing about it.
+
+Every existing rule stayed quiet because **nothing disagrees**: the ticket is open, the
+transcripts are empty, and they agree with each other. But "a colleague asked you something
+and no work exists anywhere" is arguably the most actionable thing this tool can detect,
+and it is exactly the reassuring-nothing the whole skill exists to police.
+
+Fix: `_waiting_on_a_human()`, three conditions, and the **bounding choice matters more than
+the detection**:
+
+| Condition | Implementation | Why this shape |
+|---|---|---|
+| zero evidence | `r.get("mentions_found") != 0 → skip` | the STATE, not the word — `no_sessions_found` is the same zero, and a guard spelled against `no_mentions_found` passes while the hazard exists in the other's shape. **Present and zero**, never `get(…, 0)`: see the finding below. |
+| not done | `cu in DONE_STATUSES → skip` | deliberately NOT `cu in OPEN_STATUSES` — that would rebuild D6's blind spot, silently losing the flag on `in review` / `blocked`. Safe in either direction, like the keep-open veto. |
+| recent comment | `age > 14d → skip` | **recency, not priority** |
+
+🔴 **Why recency and not priority.** Priority is a property of the *ticket*: set once, often
+stale, and completely unchanged by anyone asking anything — so a priority bound would fire
+on every unstarted high-priority backlog item on every run, and a permanently-noisy block
+trains the reader to skip it (the same failure as a permanently-red gate). Recency is a
+property of the *interaction*: it says a human is waiting **now**, it self-clears as the
+comment ages so the flag's false-positive volume is bounded by construction, and it
+composes with the tool's own sampling — the report already takes the N most recent
+comments. The comment is guaranteed not to be the user's own; `recent-comments.py` drops
+every comment whose author id equals `me` before any of this runs.
+
+## Also fixed
+
+`SKILL.md` claimed `--limit 5` takes **~41s**. Re-measured 2026-08-21 over two runs:
+**98.5s** and **85.4s** wall. Corrected to ~85–100s, with a note to re-time rather than
+quote — the per-task transcript sweep scales with `~/.claude/projects`, so it will keep
+drifting.
+
+## Red-at-base / green-at-HEAD
+
+Base = `f736c0611` (round 4), extracted clean with `git archive` — **not** read from the
+primary clone. HEAD tests run against those pristine base scripts:
+**80 passed, 23 failed**. At HEAD: **103 passed, 0 failed**.
+
+| Test | At base | Strength |
+|---|---|---|
+| `test_a_named_but_unknown_repo_is_not_reported_as_unnamed` | ✗ `a NAMED repo was reported as unnamed — the message is false: 'unresolved (repo not named)'` | **strong** |
+| `test_the_unknown_repo_message_says_what_to_do` | ✗ `the message does not name the table to add the repo to` | **strong** |
+| `test_devrc_now_resolves_to_innovation_upstream` | ✗ `devrc #591 did not resolve to innovation-upstream/devrc: []` | **strong** |
+| `test_the_hub_repos_are_all_present_and_correctly_owned` | ✗ `KNOWN_REPOS drifted` (3 missing) | **strong** (ledger) |
+| `test_ambiguous_repos_are_named_rather_than_called_unnamed` | ✗ `ambiguity reported as absence` | **strong** |
+| `test_ambiguous_repo_stays_unresolved` (round-2 test, message updated) | ✗ `'unresolved (repo not named)'` | **strong** |
+| `test_distant_repo_name_does_not_claim_a_bare_ref` (round-2 test, message updated) | ✗ `the word on the '#' is not reported` | **strong** |
+| `test_both_marker_values_reach_a_real_report` | ✗ `live-shaped adjacent signal not marked ●: '  ✓ PR merged: ADJACENT'` | **strong** (through `main()`) |
+| `test_the_marker_legend_is_printed_in_the_report` | ✗ `no legend glyphs in the report` | **strong** (through `main()`) |
+| `test_disagreements_still_works_without_an_explicit_now` | ✗ `lost its default clock and stopped flagging a fresh comment` | **strong** (positional call) |
+| `test_report_lines_carry_the_adjacency_marker` | ✗ `no attribute 'signal_line'` | 🔴 **WEAK** |
+| `test_the_adjacency_marker_does_not_collide_with_the_open_glyph` | ✗ `no attribute 'signal_line'` | 🔴 **WEAK** |
+| `test_the_entry_point_agrees_with_check_completion_at_every_boundary` | ✗ `no attribute 'confidence_marker'` | 🔴 **WEAK** |
+| ×10 D11 tests | ✗ `disagreements() got an unexpected keyword argument 'now'` | 🔴 **WEAK** |
+| `test_a_genuinely_unnamed_ref_still_says_not_named` | ✓ | INVARIANT GUARD |
+| `test_an_unknown_repo_is_still_never_guessed` | ✓ | INVARIANT GUARD / widening control |
+| `test_a_stale_backlog_comment_does_not_fire` | ✓ | INVARIANT GUARD / widening control |
+| `test_evidence_in_the_transcripts_suppresses_the_flag` | ✓ | INVARIANT GUARD / widening control |
+| `test_a_closed_ticket_does_not_fire` | ✓ | INVARIANT GUARD / widening control |
+| `test_a_record_with_no_mention_count_does_not_fire` | ✓ | INVARIANT GUARD / widening control |
+| `test_a_record_with_no_comment_date_does_not_fire` | ✓ | INVARIANT GUARD / widening control |
+| `test_round_four_flags_all_still_fire` | ✗ (kwarg) | 🔴 WEAK; round-4 regression control |
+
+🔴 **Thirteen of those reds are WEAK** — they die at base on `AttributeError` /
+`TypeError` (API shape), not on behaviour, exactly as in rounds 1 and 4. Every one of the
+three behaviours was therefore **measured directly against the unmodified base program**
+instead, and those measurements are the evidence; the tests are the ratchet:
+
+```
+BASE annotate_pr_refs on the live snippet ->
+    {'ref': '#4181', 'state': 'unresolved (repo not named)'}
+    {'ref': '#591',  'state': 'unresolved (repo not named)'}   <-- regex captured word='devrc'
+
+BASE report rendering (printer code copied verbatim from check-addressed.py main()):
+    ✓ PR merged: ADJACENT (prox 1.5)   /   ✓ PR merged: FAR AWAY (prox 1.0)   <-- identical
+    ○ still open: ADJ     (prox 1.5)   /   ○ still open: FAR     (prox 1.0)   <-- identical
+
+BASE disagreements() for the live 868kuam02 shape -> []
+BASE live run's "Needs a decision" block -> one flag (868kr0799 keep-open), nothing about 868kuam02
+```
+
+The seven ✓-at-base rows are **false-positive controls, not regression coverage** — base
+flags nothing and resolves nothing, so it trivially never mis-flags. They earn their place
+under mutation (M29, M30, M36–M40), which is the only place a widening defect can die.
+
+## Mutation sweep
+
+Pristine copy per mutant, `__pycache__` excluded from the copy, `PYTHONDONTWRITEBYTECODE=1`
+in the child. **18/18 KILLED, 0 survivors.** Harness `/tmp/ccua-mutate5.py`, session-local,
+not committed.
+
+| Mutant | Verdict | Killed by (own message) |
+|---|---|---|
+| IDENTITY (harness control) | OK — 103 passed, 0 failed | — |
+| M26 `devrc` dropped from `KNOWN_REPOS` | KILLED | `test_devrc_now_resolves_to_innovation_upstream` — `did not resolve to innovation-upstream/devrc: []` |
+| M27 unknown-repo message reverts to the false "not named" | KILLED | `test_a_named_but_unknown_repo_is_not_reported_as_unnamed` — `a NAMED repo was reported as unnamed` |
+| M28 ambiguous message reverts to "not named" | KILLED | `test_ambiguous_repos_are_named_rather_than_called_unnamed` — `ambiguity reported as absence` |
+| **M29 WIDENING**: an unknown word is GUESSED under `civitai/` | KILLED | `test_distant_repo_name_does_not_claim_a_bare_ref` — `a distant repo name claimed a bare ref: [('civitai/landed', '1080')]` |
+| **M30 WIDENING**: the genuinely-unnamed case relabelled "unknown" | KILLED | `test_a_genuinely_unnamed_ref_still_says_not_named` — `the honest not-named case was relabelled` |
+| M31 report line drops the adjacency marker | KILLED | `test_report_lines_carry_the_adjacency_marker` — `adjacent signal is not marked ●: '  ✓ PR merged: ADJACENT'` |
+| M32 marker merged into the kind glyph (no brackets) | KILLED | `test_the_adjacency_marker_does_not_collide_with_the_open_glyph` — `the two ○ meanings are not separable` |
+| M33 legend never printed | KILLED | `test_the_marker_legend_is_printed_in_the_report` — `no legend glyphs in the report` |
+| M34 entry point re-implements the marker at the dead `0.5` | KILLED | `test_report_lines_carry_the_adjacency_marker` — `a same-window-only signal was marked ●: '  ✓ [●] PR merged: FAR AWAY'` |
+| M35 waiting flag never fires | KILLED | `test_an_unanswered_comment_with_zero_evidence_is_flagged` — `produced no flag: []` |
+| **M36 WIDENING**: waiting flag fires unconditionally | KILLED (9 red) | `test_no_flag_when_ticket_and_comment_agree` — `false disagreement raised: ['868krn3y1: @x is WAITING — unconditional']` |
+| M37 recency bound removed | KILLED | `test_a_stale_backlog_comment_does_not_fire` — `every unstarted backlog item with an old comment would be flagged forever` |
+| M38 evidence no longer suppresses the flag | KILLED | `test_evidence_in_the_transcripts_suppresses_the_flag` — `the flag fired over a task the transcripts actually discuss` |
+| M39 a DONE ticket reported as waiting | KILLED | `test_a_closed_ticket_does_not_fire` — `a closed ticket was reported as waiting` |
+| M40 mention count defaulted to zero when absent | KILLED | `test_a_record_with_no_mention_count_does_not_fire` — `a record that never reported a mention count was read as zero evidence` |
+| M41 an unreadable comment date is swallowed | KILLED | `test_an_unparseable_comment_date_is_surfaced_not_swallowed` — `silently disabled the flag` |
+| M42 D6 blind spot rebuilt: gated on `OPEN_STATUSES` | KILLED | `test_an_unknown_clickup_status_does_not_disable_the_waiting_flag` — `an unrecognised status silently disabled the waiting flag — D6 all over again` |
+| M43 zero-evidence gate spelled against one status word | KILLED | `test_no_sessions_found_is_the_same_zero_evidence_state` — `no_sessions_found is zero evidence too` |
+| NO-APPLY CONTROL (target text deliberately absent) | OK — harness refused, as designed | — |
+
+### 🔴 Two things the sweep found that review and a green suite did not
+
+**M42 SURVIVED the first sweep, over a 103/0 green suite.** The mutant rebuilds D6's exact
+blind spot — gating the new flag on `OPEN_STATUSES` instead of `not in DONE_STATUSES`, so
+`in review` silently loses it. `test_an_unknown_clickup_status_does_not_disable_the_waiting_flag`
+asserted only `assert flags` (non-empty), and `in review` **also** trips round 4's
+unknown-status announcement — so the test was **green for the other guard's reason** and
+stayed green with the thing it was written to protect deleted. Fixed by asserting the
+`WAITING` flag specifically, plus a positive control that round 4's announcement is *also*
+present, so it cannot pass by having quietly suppressed that one instead. This is the
+"a DIFFERENT guard's error kills your test" trap, and only the sweep could see it.
+
+**The first draft of the D11 flag fired on a round-2 control**, `test_no_flag_when_ticket_and_comment_agree`,
+whose fixture omits `mentions_found` entirely and has no comment date. The draft used
+`r.get("mentions_found", 0) != 0`, i.e. it inferred *"no work exists anywhere"* — the
+strongest claim the flag makes — from a key that was simply **absent**. Corrected to
+require the count be **present and zero**, and to treat an ABSENT comment date (no
+interaction) differently from a MALFORMED one (formatter drift, which announces itself).
+An existing false-positive control caught a real design error in a new feature; that is
+what they are for.
+
+## End-to-end: the same live run, before and after
+
+Same corpus, `--limit 5`, ~15 minutes apart.
+
+**Before** (`f736c0611`, 98.5s):
+```
+  ✓ PR merged: red **both inherited**; unaudited | | **#4181**, **devrc #591** | merged, verifi
+      ↳ #4181: unresolved (repo not named)
+      ↳ #591: unresolved (repo not named)
+  ○ still open: fact instead of reasoning about it.  ## Still open, unchanged  - **`868ktvqf9`**
+  ○ needs action: commands** (`inbox-*`, `doc-comments`) need a JWT in the account, not   just a t
+
+## Needs a decision
+⚠️  868kr0799: newest comment says "Still live" — do NOT close. …
+```
+
+**After** (85.4s):
+```
+Evidence lines: `✓` completion signal / `○` open signal · then `[●]` the task ID is inside
+that signal's own snippet, `[○]` merely somewhere in the same ±2000-char window — distrust `[○]`.
+
+  ✓ [●] PR merged: red **both inherited**; unaudited | | **#4181**, **devrc #591** | merged, verifi
+      ↳ #4181: unresolved (repo not named)
+      ↳ innovation-upstream/devrc#591: merged 2026-08-20
+  ○ [●] still open: fact instead of reasoning about it.  ## Still open, unchanged  - **`868ktvqf9`**
+  ○ [○] needs action: commands** (`inbox-*`, `doc-comments`) need a JWT in the account, not   just a t
+
+## Needs a decision
+⚠️  868kr0799: newest comment says "Still live" — do NOT close. …
+⚠️  868kuam02: @Ellie King is WAITING — the ticket is `to do`, and the task ID appears in NO
+    transcript, so no work exists anywhere. Commented 1d ago; nobody has answered. Read it.
+```
+
+Round 4 behaviour confirmed intact in the same run: the keep-open veto still fires on
+`868kr0799`, and the unknown-status announcement still fires (verified separately by
+direct call on `in review` / `blocked` / `needs qa` — the live run could not exercise it,
+because both real statuses that day were in the vocabulary).
+
+`#4181` correctly **stays** `repo not named`: nothing repo-ish sits within 30 characters of
+it. That is the one honest arm of the old message, and it is preserved.
+
+## Residual — honest
+
+- 🔴 **`#4181` is a real, resolvable PR (`civitai/civitai#4181`, merged) that this tool
+  still reports as unresolvable**, and it is right not to guess. A 4-digit number in this
+  corpus is *almost always* `civitai/civitai`, but "almost always" is what produced
+  `civitai/civitai#1080: merged 2024-03-18` in round 2. The message now at least tells the
+  reader the citation named no repo, rather than mislabelling why.
+- **Naming the word on the `#` is noisy by design.** `issue #45` reports
+  `repo 'issue' is not in KNOWN_REPOS`. Every alternative requires classifying which words
+  are repo-shaped, which means enumerating the world; a reader discards `'issue'` at a
+  glance and acts on `'devrc'`. Noisy-and-true beats quiet-and-false.
+- **The waiting flag cannot see whether you already replied in ClickUp.** It reads the
+  *newest* comment only, and `recent-comments.py` filters out your own — so a ticket where
+  you answered and the colleague then commented again looks identical to one you ignored.
+  The 14-day bound limits the damage; a real fix needs comment threading.
+- **`UNANSWERED_COMMENT_DAYS = 14` is a judgement, not a measurement.** It was not tuned
+  against a labelled set of "should have flagged" tickets, because none exists. It is
+  chosen to be shorter than a sprint and long enough to survive a week off.
+- The round-1 residual is unchanged: **a signal is attributed by lexical proximity, not by
+  meaning.** The new `[●]` marker makes the *attribution distance* visible, which is the
+  most a lexical tool can offer; it still cannot tell you the adjacent clause is about a
+  different thing.
+
+## Suite
+
+**103 passed, 0 failed** (counted from the `Total:` line, unpiped). Up from 80: 21 new
+tests in `test_repo_vocab_and_waiting.py`, plus two round-2 tests whose assertions were
+updated to the new message text (their behavioural claim — *nothing was resolved* — is
+unchanged and still asserted).
+
+---
+
+# Round 8 — 2026-08-21 (veto tiering, re-attempted fresh from trunk)
+
+The keep-open veto redesign that rounds 4–7 could not land, rebuilt from `origin/trunk`
+(`d11e67e87`) rather than cherry-picked from the abandoned branch `zach/ccua-self-run-guard`.
+Those rounds each fixed the previous round's regression, so the design converged while the
+diff carrying it did not; only the converged design is here.
+
+## The defect has TWO directions and one cause
+
+Trunk's veto is absolute. Measured with one instrument over 17 comments, on a `to do` ticket
+whose transcripts read `likely_addressed`:
+
+| Comment | trunk `d11e67e87` | round 8 |
+|---|---|---|
+| "Resolved on both counts, recommend closing. (The follow-up PR is still open but unrelated.)" | 🔴 do NOT close | READ IT |
+| "One review thread is not resolved on the PR, but the ticket itself is done. Recommend closing." | 🔴 do NOT close | READ IT |
+| "The alert fired and was not resolved automatically. Ticket work is done — recommend closing." | 🔴 do NOT close | READ IT |
+| "The fix landed in #1234 and is live. The follow-up PR is still open but unrelated." | 🔴 do NOT close | READ IT |
+| "The issue isn't resolved." | 🔴 **close it** | do NOT close |
+| "The issue is never resolved." | 🔴 **close it** | do NOT close |
+| "This won't be resolved until next sprint." | 🔴 **close it** | do NOT close |
+| "This is not fully resolved." | 🔴 **close it** | do NOT close |
+| "This is unresolved." | 🔴 close it or re-check¹ | do NOT close |
+| "I do not recommend closing this yet." | 🔴 **close it** | do NOT close |
+| "This is still open. I have not had time to look at it." | do NOT close | do NOT close |
+| "The issue is not resolved." | do NOT close | do NOT close |
+| "This is still open. I haven't done anything yet." | do NOT close | do NOT close |
+| "This is still open. The bug is not fixed." | do NOT close | do NOT close |
+| "This is still open — nothing has been merged." | do NOT close | do NOT close |
+| "Still live, do not close." | do NOT close | do NOT close |
+| "Resolved on both counts. Recommend closing." | close it | close it |
+
+9 rows move, 8 hold. **The second block is the dangerous one and it is live on trunk today**:
+six comments that refuse a close draw an affirmative instruction to close.
+
+¹ 🔴 **CORRECTED by audit — this row is the odd one out and the original wording overstated
+it.** `RESOLVED_COMMENT_RE` is `\bresolved\b`, and `unresolved` has no word boundary before
+`resolved`, so trunk's COMMENT flag never fires on it: at `transcript_status="unclear"` trunk
+emits **nothing at all**, and the "close it or re-check" above comes from the TRANSCRIPT
+branch. So it is **5 of 6** comments drawing the comment-level close-it, not 6 of 6 — the
+sixth draws an affirmative close instruction by a different mechanism. Same family as the
+probe bug below: the first rebuild fixed the READ/close-it confusion and left the
+comment-flag/transcript-flag confusion in place. **Every measurement in this table should be
+taken at `transcript_status="unclear"`, where the transcript branch cannot contribute.**
+
+🔴 **The instrument was wrong first.** The probe classified verdicts with
+`"READ" in v.upper()`, which matches `reads as RESOLVED` inside the close-it line — so it
+labelled the close-it flag as an ambiguity flag, in BOTH columns, silently. The table above
+was only readable after the labels were rebuilt from disjoint literals.
+
+## The fix: one mechanism, two consequences
+
+**Negation decided once, at clause level.** `closure_claims()` matches the closure vocabulary
+plainly, then asks whether the CLAUSE it sits in carries a negator. A new closure word
+inherits negation handling for free — the thing per-word lookbehinds could never do, and the
+reason rounds 6 and 7 each shipped a regression enumerating them. Contractions match by
+**shape** (`\w+n't`), not by a stem list: `won't` has the stem "wo", so any enumeration is
+incomplete when written. `unresolved` is handled as morphological negation.
+
+**Two tiers.** STRONG is an instruction about this ticket and stays absolute. WEAK is
+`still open` plus any negated closure claim; it vetoes when it is the comment's only word on
+closure, and downgrades to "READ IT and decide" only when another clause carries an
+un-negated closure claim. That is the round-5 lesson kept: *WEAK means ambiguous alongside a
+closure claim, never ignorable* — the plainest keep-open phrasing must still veto.
+
+Clause scope is load-bearing in **both** directions. Comment-wide scope lets one "not"
+silence every closure word and makes the ambiguous tier unreachable. 🔴 **The claim that
+followed here — "commas are not boundaries, because that would strand a negator away from its
+target" — was REFUTED by measurement in round 8c below; commas ARE boundaries and the
+interrupted-negation case is handled by a carry rule instead.** Parens are not boundaries.
+
+`CLOSURE_VOCAB_RE` (wide) is deliberately NOT merged into `RESOLVED_COMMENT_RE` (narrow):
+only the narrow one may instruct a human to close a live ticket, so widening it manufactures
+close-it flags, while widening the wide one can only add a veto or downgrade one to "read it".
+`test_widening_ambiguity_did_not_widen_the_close_it_trigger` is the control.
+
+## Red-at-base / green-at-HEAD
+
+**Of 27 new tests: 16 red at `origin/trunk` d11e67e87 for a BEHAVIOURAL reason, 3 red only
+structurally (`AttributeError` on symbols this change introduces — they could never have been
+red for a behavioural reason and are not regression coverage), 8 green at base. All 27 green
+at HEAD.** An earlier draft of this section said "13 of 19 red" without that split, which
+overstated regression coverage by 3. The 8 that pass
+at base are labelled INVARIANT GUARD or CONTROL in their docstrings and are counted as
+neither regression coverage nor evidence: they exist so the tiering cannot quietly eat
+behaviour trunk already had right (the close-it flag firing on a clean resolution, a lone weak
+refusal still vetoing, both tiers staying gated on an open status).
+
+🔴 **One of them was vacuous and passed for the wrong reason.** `test_strong_wins_the_quote_
+over_weak` asserted `"do not close" in j.lower()`, which the flag's own boilerplate `— do NOT
+close.` satisfies. It passed at base *while base quoted the WEAK phrase*, and would have
+passed with the tiers reversed. Rewritten to assert the quoted SPAN. This is the third round
+running that found a test asserting a substring the surrounding sentence also contains.
+
+## 🔴 The live run found what the table could not
+
+The 17-case table above is synthetic, and it was green when the tool was run for real against
+ClickUp — where it **downgraded a live keep-open**. `868ktt2ct`'s newest comment opens
+*"Status check during ClickUp triage 2026-08-21 — **staying open**, and mostly not verifiable
+from this repo"*, and its only closure vocabulary is one "shipped" describing a sub-item that
+landed in a **different repo**. The tier read that as ambiguity and emitted "READ IT and
+decide"; trunk's absolute veto had it right, by luck of a later "still open".
+
+`stay(s|ing) open` / `remains open` / `leaving it open` are now STRONG. They belong in the
+strong tier rather than the weak one for the reason round 6 used to demote `not resolved`,
+running the other way: those phrasings are **not this domain's vocabulary for anything else**
+— a PR or an alert is "open", never "staying open" — so a deliberate declaration about what
+happens to THIS ticket has no second reading.
+
+This is round 6's N1 in mirror image. There, the ambiguity vocabulary was too narrow against
+real prose and the weak tier was nearly inert; here the STRONG vocabulary was too narrow
+against real prose and a real refusal fell through it. **A vocabulary tested only against
+sentences its author wrote is a claim about the author.**
+
+## Mutation sweep — 18 mutants, all killed
+
+Controls first: **CONTROL-identity SURVIVED 141/0** (the harness can report a survivor);
+**CONTROL-positive KILLED**. A mutant whose anchor no longer applies, or whose substitution is
+a no-op, is scored a **FAILURE**, not a survivor.
+
+The first sweep left **3 survivors**, each a real gap rather than a missing assertion:
+
+| Survivor | What it exposed | Closed by |
+|---|---|---|
+| stripping `but\|however\|…` from the clause splitter | every ambiguous fixture *also* carried a sentence boundary doing the same work, so the conjunction boundary was never exercised | a fixture where the negator and the closure claim share one sentence |
+| dropping the negation filter on the close-it branch | it is the **IDENTITY** — unreachable, because every phrase `RESOLVED_COMMENT_RE` matches contains a `CLOSURE_VOCAB_RE` word, so a negated trigger is already vetoed one branch earlier | **deleted**, with `test_every_close_it_trigger_phrase_is_also_ambiguity_vocabulary` pinning the premise that licenses the deletion |
+| ambiguity reading the snippet instead of the full comment | the two windows differ deliberately and nothing pinned it | a fixture whose closure claim sits past the 200-char display truncation |
+
+🔴 **An unreachable guard reads as protection while providing none** — the same finding as
+round 7's A4, reached independently. It is deleted rather than tested, and what replaces it is
+a test of its PREMISE: add a phrase to `RESOLVED_COMMENT_RE` whose words are outside
+`CLOSURE_VOCAB_RE` and that test goes red, which is the signal to bring the filter back.
+
+The re-sweep kills all 18. The premise mutant was checked to kill the premise test **by its
+own assertion message**, not merely to make the suite red — 10 tests fail under it, and a
+mutant that dies to a neighbour's assertion is a green for the wrong reason.
+
+## Suite
+
+**141 passed, 0 failed**, up from 122 (`Total:` line, from a tree whose `__pycache__` was
+purged by `run_all.py` — the round-7 stale-bytecode trap). Verified live end-to-end against
+ClickUp, which is what caught the `868ktt2ct` downgrade above.
+
+## Residual risk
+
+- **`CLOSURE_VOCAB_RE` is a guess, like every vocabulary in this tool.** A comment that says
+  the work is finished in words outside it ("wrapped up", "sorted", "no longer an issue")
+  will not create ambiguity, so a weak refusal beside it still vetoes. That is the safe
+  direction and it is why the tier downgrades rather than flips.
+- **Clause splitting is punctuation-based, not a parser.** A comment written as one long
+  comma-spliced sentence collapses to a single clause and reads as fully negated if any
+  negator appears in it. Over-veto, not over-close.
+- **`no` is a negator.** "There is no regression. Resolved — recommend closing." works only
+  because the two sit in different sentences; written as one clause it would veto.
+- **The STRONG vocabulary is still an enumeration**, and the live run proved one round of
+  enumeration is not enough. Negation was moved to a shape rule precisely because enumerating
+  loses; the keep-open phrasings have no equivalent shape, so they stay a list — and the way
+  to find the next gap is to run the tool against real comments, not to add more fixtures.
+
+---
+
+# Round 8b — 2026-08-21 (blind audit of round 8, and the regression it caught)
+
+Round 8 was audited BLIND — the auditor was given the worktree and the tool's priority order,
+no conclusions. It confirmed the tiering idea and the deleted-identity-guard reasoning, and
+then found that **round 8's own fix had introduced a defect worse than the one it fixed.**
+🔴 That is the fifth consecutive round in this file where the previous round's fix shipped a
+regression. An audit fix RESETS the verification gate; budget for it.
+
+## 🔴 F1 — negation was clause-scoped but NOT order-scoped, and inverted plain resolutions
+
+`closure_claims()` asked `NEGATOR_RE.search(clause)` — position-independent — and commas are
+deliberately not clause boundaries. So any trailing `no` / `nothing` reached BACKWARDS:
+
+| comment (ticket `to do`) | trunk | round 8 | round 8b |
+|---|---|---|---|
+| "Resolved, no further action needed." | close it | 🔴 **do NOT close** | close it |
+| "Recommend closing, no further work planned." | close it | 🔴 **do NOT close** | close it |
+| "Confirmed resolved, no repro since Tuesday." | close it | 🔴 **do NOT close** | close it |
+| "This is done, nothing else outstanding." | close it | 🔴 **do NOT close** | close it |
+
+**12 of 12** ordinary "work is finished, nothing outstanding" comments regressed. The
+ambiguity tier could not rescue them — the whole comment is one clause, so `affirmed` is
+empty and the veto is absolute. Round 8 would have traded **4 wrongly-suppressed close-its
+for 12 wrongly-created vetoes**, which is a net loss on this tool's own priority.
+
+The wrong premise was written down, in round 8's own code comment: *"widening this one can
+only ever downgrade a veto to 'read it' or ADD A VETO. Both directions are the safe one."*
+Adding a veto over "Recommend closing, no objections" is not safe — it is an affirmative
+wrong instruction. **A "safe direction" argument is only as good as the enumeration of
+directions.** Fixed: a negator negates only closure words that FOLLOW it in the clause.
+
+## 🔴 F3 — `()` as a clause boundary was the exact defect the file forbids for commas
+
+`test_a_bare_comma_is_not_a_clause_boundary` exists because splitting on commas *"would
+strand `resolved` in a clause of its own and produce a close-it over a refusal"*. Parens did
+precisely that, one line away, and README asserted them as boundaries as though justified:
+
+| comment | round 8 | round 8b |
+|---|---|---|
+| "This is not (yet) resolved." | 🔴 **close it** | do NOT close |
+| "This is not (fully) resolved." | 🔴 **close it** | do NOT close |
+| "This is anything but resolved." | 🔴 **close it** | do NOT close |
+
+Removing the arm costs nothing: the round-8 paren fixture is already split by its full stop
+(pinned by `test_the_parenthesised_aside_is_still_read_for_ambiguity`). `anything but` needed
+BOTH a negator entry and a lookbehind in the splitter — neither half works alone.
+
+## 🔴 F5 — the guard on the highest-value flag was watching a DIFFERENT flag
+
+`test_the_close_it_flag_still_fires_on_a_clean_resolution` asserted `"close it" in j` at the
+helper's default `transcript_status="likely_addressed"`. The TRANSCRIPT branch emits
+`"— close it or re-check"`, whose boilerplate contains that substring. **Measured: replacing
+`RESOLVED_COMMENT_RE` with a never-matching pattern — deleting the comment-level close-it
+flag outright — left 17 of the 19 tests in the file GREEN.** The two that fired both assert
+on the regex object, not on behaviour.
+
+This is the **second** instance of this class inside round 8 alone (the first was
+`"do not close" in j.lower()` matching the flag's own boilerplate) and the third round
+running in this file. The author had even written the cure — one test passes
+`transcript_status="unclear"` specifically to avoid the interference — and did not
+generalise it. **Never assert a substring the surrounding sentence can also produce**, and
+when you find one instance, sweep the file for the rest.
+
+## The rest
+
+- **F4** — 144 of 672 generated keep-open × closure combinations downgrade to "READ IT".
+  Mostly by design; the exception is `the ticket is still open`, which passes the same
+  no-second-reading test that promoted `staying open` to STRONG (a PR is not "the ticket").
+  Promoted. The generic downgrades stand: "READ IT" is not an instruction to close.
+- **F2** — a negator found AFTER the closure word printed manufactured quotations
+  (`says "no … resolved"` for "Confirmed resolved, no repro since Tuesday"): words the
+  comment contains, in an order it never used. Order-scoped negation makes the elided form an
+  honest elision. Two mutants on that quoting guard had survived; one of them emptied the
+  span, which makes `if veto_phrase:` falsy and **silently drops the whole veto** — the tier
+  decision no longer depends on the phrase being truthy.
+- **F8** — `cannot`, `far from` and `anything but` negate without containing a negator word;
+  all three drew a close-it over a refusal. Added. Apostrophe-less `isnt`/`wont`/`cant`
+  remain unhandled: `\w+nt\b` also matches *important*, *went*, *current*, so the shape rule
+  does not extend there. Residual risk, stated rather than half-fixed.
+- **F9** — the em-dash clause arm and the unknown-status ambiguity output were both
+  load-bearing and pinned by nothing; deleting either left the suite green. Both now pinned.
+
+## Sweep
+
+**26 mutants, all killed.** CONTROL-identity SURVIVED 149/0; CONTROL-positive KILLED. Seven
+mutants went **NO-APPLY (stale anchor)** after the F1/F3 rewrites and were scored FAILURES,
+then re-anchored to the new code and re-run — a stale anchor reports SURVIVED-looking success
+for a mutation that never happened. The battery now covers every region the audit named.
+
+**149 passed, 0 failed** (was 141).
+
+🔴 **The honest reading of "18/18 killed" in round 8 above: it was a true claim about those
+18 mutants, and the audit's own 14-mutant sweep on the same code found 5 survivors.** A
+mutation sweep measures the mutants you imagined, and round 8's were shaped by the findings
+it had just fixed — exactly the correction round 5 already recorded, re-learned.
+
+
+---
+
+# Round 8c — 2026-08-21 (delta re-audit of the audit fixes, and the scoreboard that ended it)
+
+The round-8b fixes were audited BLIND again. The re-audit re-derived the 17-case table, the
+red-at-base split and the suite count exactly — and found that **8b's fix for F1 had shipped
+the MIRROR IMAGE of the defect it removed.** Seven consecutive rounds, seven fixes, seven new
+defects created by the previous fix.
+
+## 🔴 The mirror: order-scoping fixed one word order and left the other wide open
+
+8b made a negator negate only what FOLLOWS it, which fixed "Resolved, no further action
+needed". But in a bug ticket the dominant shape states the SYMPTOM — negated, because that is
+what a bug is — and then the RESOLUTION, in one comma-spliced sentence. With commas not a
+clause boundary, the symptom's negator reached the resolution:
+
+| comment | trunk | round 8b | round 8c |
+|---|---|---|---|
+| "Users cannot upload avatars, fixed in #4421 and deployed." | (silent) | 🔴 **do NOT close** | (silent) |
+| "The alert wasn't firing, resolved by the rule fix." | close it | 🔴 **do NOT close** | close it |
+| "The job did not run on Sunday, resolved — I re-ran it." | close it | 🔴 **do NOT close** | close it |
+| "Cannot reproduce this anymore, resolved." | close it | 🔴 **do NOT close** | close it |
+
+10 of 10. Round 8b had measured "12 of 12" in ONE order and shipped; the other order was
+never measured. Its own headline lesson — *"a safe-direction argument is only as good as its
+enumeration of directions"* — applied to itself and went unnoticed for exactly one round.
+
+## What actually ended it: a labelled corpus, not a better argument
+
+Eight rounds were argued one clever sentence at a time. Instead, every case from the round-8
+table, both audits and the live ticket was labelled with the verdict a human reading it would
+give, and every candidate was scored against the same set:
+
+| implementation | score |
+|---|---|
+| `origin/trunk` | **24 / 42** |
+| round 8b (commas not a boundary, order-scoped) | **28 / 42** |
+| commas ARE a boundary | 36 / 42 |
+| + drop `ticket\|task still open` from STRONG | 38 / 42 |
+| + carry a clause-TRAILING negator (shipped) | **39 / 42** |
+
+That table is now `scripts/check-clickup-addressed/tests/test_corpus.py`, with the score
+pinned, the three known failures held as a LEDGER so the set cannot silently grow, and a guard
+that no `VETO`-labelled case may ever produce a close-it. Its own controls were run: reverting
+commas-as-boundary drops it to 30/42 and it says so by name.
+
+## The other findings
+
+- **Commas ARE boundaries** — the round-8 rationale for excluding them ("This is not, in my
+  view, resolved must keep its negator") was true about one sentence and false about ticket
+  prose. That sentence is handled instead by a narrow **carry** rule: a clause that ENDS on
+  its negator is an interrupted negation and carries into the next clause. A clause ending in
+  anything else ("Users cannot upload avatars,") is a finished thought and carries nothing.
+- **`(?:ticket|task) (?:is |remains? )?still open` removed from STRONG.** Added one round
+  earlier on the argument that "only THIS object is *the ticket*" — false in ClickUp, where
+  comments reference siblings constantly ("the duplicate task is still open, closing this
+  one"). It hard-vetoed 4 of 4 such comments where the weak tier correctly said READ IT. This
+  is the round-8 motivating case with the noun changed, re-introduced by its own fix.
+- **Two guards no test distinguished**, both found by mutation: the positional filter (making
+  it position-independent left the suite green) and clearing `carry` on a consuming clause.
+  Both are now pinned. The positional filter is kept for a narrower reason than it was
+  written for — it never fabricates a reversed quotation — and the verdict it produces on
+  "Resolved and not verified in prod." is **wrong**, which is recorded rather than hidden.
+
+## Sweep and suite
+
+**30 mutants, all killed.** CONTROL-identity SURVIVED 156/0; CONTROL-positive KILLED. Stale
+anchors after each rewrite were scored FAILURES and re-anchored — three separate times across
+8b and 8c. **156 passed, 0 failed** (122 at the start of round 8).
+
+## 🔴 The lesson worth keeping
+
+Every round here produced a rule that was locally right and globally untested, and the
+review that caught it was always someone else's. The rules were not the problem — the
+**absence of a scoreboard** was. Score the corpus before and after; a candidate that reads
+worse but scores higher wins.
+
+
+---
+
+# Round 8d — 2026-08-21 (third blind audit: the corpus itself was audited)
+
+The third audit was pointed primarily at the **42 labels**, on the reasoning that the corpus
+had just become the authority for this subsystem — future rounds score against it — so a wrong
+LABEL is more dangerous than a wrong line of code: it steers every later round toward a wrong
+answer and nobody re-derives it. The author of the labels was also the author of the code.
+
+That was the right place to look.
+
+## 🔴 The corpus was structurally blind to the class that produces the WORST outcome
+
+Measured mechanically: across all 42 cases there were **18 negator→closure pairs and every
+one put the negator FIRST**. So a negator that FOLLOWS the closure word it denies appeared
+nowhere — and `test_no_new_case_fails_in_the_close_it_direction`, the file's declared 🔴
+guard, **could not fail on that class however bad it got**:
+
+| comment | trunk | shipped |
+|---|---|---|
+| "The ticket says resolved but it isn't." | close it | close it |
+| "This was marked resolved, but it is not." | close it | close it |
+| "Claimed resolved in standup, but it never was." | close it | close it |
+
+Not a regression — trunk is equally wrong — but it is the tool's worst outcome, and the
+corpus omitted its own worst class. **A guard that cannot fail on a shape nobody wrote down
+reads as coverage while providing none.** The class is now in `KNOWN_FAILURES`, counted
+rather than described, and the close-it guard exempts exactly those recorded cases and no
+others.
+
+🔴 **And a docstring asserted coverage that did not exist.** It said *"the corpus records the
+failing case rather than hiding it"* — `grep -c` returned **0** — and justified the design
+with *"its failure mode needs the writer to use 'and', where a comma or full stop is far more
+common"*, which is false on all six separators measured (`and` / `,` / `.` / `but` / `;` /
+`—`, every one drawing "close it"). Both corrected.
+
+## 🔴 `MIN_SCORE` was self-fulfilling: a mutant survives the whole suite and flips five refusals
+
+The audit's sharpest finding. Restricting a negator to closure words within 30 characters —
+touching no pinned regex — left **156 passed, 0 failed and the corpus still at 39/42**, while
+turning five plain refusals into "close it":
+
+    "This is not something I would describe as anywhere near resolved."   -> close it
+    "There is no evidence at all in the logs that this is resolved."      -> close it
+
+Because the largest negator→closure distance anywhere in the corpus was **27 characters**,
+the scoreboard actively *rewarded* shrinking the window. At a 19-character window the corpus
+test **passes at 41/42** and the ledger's own failure message instructs the next author to
+accept it and raise the bar behind it. A scoreboard is only as good as the spread of its
+cases; a corpus whose cases cluster on one axis silently rewards over-fitting that axis.
+
+## 🔴 The `carry` rule — written by round 8c — was a new regression, and is DELETED
+
+`carry` propagated a clause-trailing negator into the next clause. "Ends on a negator" does
+not distinguish an interrupted negation from how engineers write a clean status:
+
+| comment | trunk | with carry | now |
+|---|---|---|---|
+| "Downtime: none. Resolved and deployed." | close it | 🔴 **do NOT close** | close it |
+| "Impact: none, resolved by the rollback." | close it | 🔴 **do NOT close** | close it |
+| "Regressions found: none. Resolved." | close it | 🔴 **do NOT close** | close it |
+
+It also reintroduced the manufactured quotation `negated_phrase` exists to prevent —
+`says "none … Resolved"`, two words from different sentences — and was cleared only by a
+clause containing a closure word, so it survived arbitrarily many intervening clauses. It
+bought **one** corpus case and cost **seven** realistic close-its.
+
+Deleted. The case it was written for is now a stated KNOWN FAILURE. **Say what is not handled
+rather than half-handling it** — that is the second rule this round deleted rather than
+extended, and both deletions scored better than the rules they replaced.
+
+## Still open: six labels the audit disputes, and it is a PRODUCT decision, not a bug
+
+The audit disputes 11 labels, **11 of 11 in the direction that flatters the implementation** —
+one-directional, which is the corruption signature. The substantive six are every `READ` case,
+which it argues should be `CLOSE`:
+
+> "Fix merged. The duplicate task is still open, closing this one." — labelled READ. The
+> comment literally says *closing this one*.
+
+The argument is that the reporter explicitly **disclaims** the aside ("but unrelated",
+"tracked separately", "closing this one"), so a human wants "close it", and the corpus has
+encoded the implementation's inability to discount a disclaimed aside as though it were the
+preferred behaviour. If that is right, the ambiguity tier is much narrower than built.
+
+**Not resolved here, because it changes what the tool should DO, not whether it does it
+correctly.** But it was MEASURED, which settles the only question that blocked shipping —
+scored over all 49 cases, with the disputed labels flipped to CLOSE as the audit argues:
+
+| implementation | these labels | the audit's labels |
+|---|---|---|
+| `origin/trunk` | 27/49 | 24/49 |
+| **shipped (ambiguity tier)** | **41/49** | 34/49 |
+| variant: disclaimed aside -> close it | 37/49 | **38/49** |
+
+🔴 **The shipped code beats trunk under BOTH labellings** (41 vs 27, and 34 vs 24), so the
+dispute decides which of two improvements is better, not whether to ship one. That is why it
+did not block the merge, and why it should not be settled in a hurry.
+
+Two further measurements worth having before anyone re-opens it: the variant produces **zero
+collateral changes** — it moves only disputed cases, nothing else — and it still does NOT
+satisfy the audit on 2 of the 6, including its sharpest example. "Fix merged. The duplicate
+task is still open, closing this one." stays READ even with the tier removed, because
+`RESOLVED_COMMENT_RE` does not match a bare `closing`. So the audit's preferred behaviour is
+NOT reachable by deleting the tier; it needs the close-it trigger widened too, which is the
+one direction this file has repeatedly established as unsafe. Anyone taking this on should
+start there, not at the tier.
+
+Recorded for the human decision. The other five disputes are `not-VETO` labels
+that should be `CLOSE`; `not-VETO` passes on CLOSE, READ *or silence*, so it converts a miss
+into a pass — genuinely load-bearing in only 1 of its 6 cases.
+
+## Suite and corpus
+
+Corpus **49 cases** (42 + 4 negator-after + 3 carry controls), **41/49**, MIN_SCORE 41,
+8 recorded known failures. On the original 42, the score moves 39 → **38**: the one point the
+deleted carry rule was buying. **155 passed, 0 failed.**
+
+## 🔴 The lesson
+
+Round 8c concluded "a scoreboard ended it". One round later the scoreboard itself was the
+thing most in need of auditing — blind to its own worst class, and shaped so that over-fitting
+one axis scored *higher*. **A corpus is an instrument, and an instrument gets validated like
+any other: ask which shapes it structurally cannot see, and who wrote the labels.**

--- a/claude/skills/check-clickup-addressed/reference/validation-history.md
+++ b/claude/skills/check-clickup-addressed/reference/validation-history.md
@@ -1280,3 +1280,107 @@ Round 8c concluded "a scoreboard ended it". One round later the scoreboard itsel
 thing most in need of auditing — blind to its own worst class, and shaped so that over-fitting
 one axis scored *higher*. **A corpus is an instrument, and an instrument gets validated like
 any other: ask which shapes it structurally cannot see, and who wrote the labels.**
+
+---
+
+# Round 6 — D12: the waiting flag could not see the user's own replies (2026-08-22)
+
+**Found by running the tool and opening the ticket**, one day after round 5 shipped the flag.
+
+## What it printed, and what was true
+
+    868kuam02: @Ellie King is WAITING — … Commented 2d ago; nobody has answered. Read it.
+
+Two sessions had already answered her: 2026-08-21 13:52 and 2026-08-22 01:04 — the second
+**eleven hours** before the run. Acting on the flag re-derived an analysis already sitting in
+the thread. (The re-derivation was not worthless — it added a live measurement that closed an
+open question the 01:04 comment had explicitly named — but that was luck, not the tool's doing.)
+
+## Why five green controls did not catch it
+
+Round 5 shipped `_waiting_on_a_human` with five tests, including two anti-widening controls.
+All five were correct. **Every one of them was scoped to one side of a seam**, and the defect
+was the seam: `recent-comments.py` drops the user's own comments (correct — the report is about
+what *others* said), and the flag concludes nobody answered (correct, given the evidence it is
+handed). The function's own docstring even stated the filter as a *guarantee it relies on*:
+
+> The comment is guaranteed not to be the user's own: `recent-comments.py` drops every
+> comment whose author id equals `me` before any of this runs.
+
+True — and exactly why it was blind. The evidence that would refute the flag is removed
+upstream, so no care inside the function could recover it. **A guarantee you depend on is worth
+asking whether it also deletes your disconfirming evidence.**
+
+## Failure direction, and why this one mattered
+
+The recency bound was chosen (round 5) specifically because *"a permanently-noisy block is
+worse than no block — it trains the reader to skip it."* D12 defeated that reasoning: an
+answered ticket is flagged **forever**, because nothing about answering it ever changes the
+inputs the flag reads. The bound bounded the wrong axis.
+
+## The fix
+
+`recent-comments.py` emits `my_latest_reply` per task, computed over the **unfiltered** comment
+list; `_waiting_on_a_human` suppresses when it is at or after the comment. Three deliberate
+choices, each pinned by a mutant:
+
+| Choice | Mutant | Killed by |
+|---|---|---|
+| Compare instants, don't count replies | `if mine is not None:` | `test_a_reply_older_than_the_question_does_not_suppress` |
+| `<=`, not `<` (ClickUp renders to the minute) | `mine < theirs` | `test_a_same_minute_reply_counts_as_answered` |
+| Absent ≠ "no reply" — announce instead | `reply_unreported = False` | `test_an_unreported_reply_field_announces_instead_of_deciding` |
+
+## 🔴 The mutation sweep found a hole the tests did not
+
+`latest_reply_by([], my_id)` — computing the reply over an empty list, i.e. the whole fix
+inert — **SURVIVED a fully green suite.** `latest_reply_by` and `build_record` were each
+pinned in isolation; `_collect`, the only code that joins them, was covered by nothing.
+That is round 6's own defect class reappearing *inside the fix for it*, within the same hour.
+`test_collect_computes_the_reply_over_the_UNFILTERED_comment_list` closes it.
+
+Also worth recording, because it nearly produced a false SURVIVED: the first sweep filtered
+runner output with a `grep -E "^  ✗ test_(my_own_later|…)"` whose alternation did not include
+`test_build_newest_comment_…`, so a mutant that **was** killed printed nothing and scored
+SURVIVED. **Read the whole failure list; a filter is part of the instrument.**
+
+## Ordering bug introduced while fixing this
+
+The first version returned its own message from the unreported-reply branch, *before* the
+recency bound. That silently broke two existing guards at once — a 90-day-old backlog comment
+became flagged forever (the exact unbounded-noise failure round 5 designed against) and an
+unreadable date stopped being surfaced. Caught by the existing suite. **A condition that
+returns its own string owns every condition after it**; the caveats now compose into one head.
+
+## Suite
+
+**170 passed, 0 failed** (155 before this round). Corpus unchanged at 49 cases — D12 is not a
+comment-classification defect, so it adds no corpus rows.
+
+## Two adversarial audit rounds, and what they cost
+
+**Audit 1** found no deploy-blockers and independently reproduced every claim in the PR body,
+but produced **two surviving mutants inside the fix's own design property**:
+
+- `get_my_user_id()` returns `None` on auth expiry / a CLI output change, and `run_clickup`
+  never checks the subprocess return code. Every id comparison then failed, so the record
+  carried `my_latest_reply: null` — the POSITIVE claim "I looked; you never replied" — on the
+  one failure mode that should produce *absent*. Fixed with an `UNIDENTIFIED` sentinel.
+- `test_reported_absence_of_a_reply_still_flags` asserted truthiness while its docstring
+  claimed a relationship, so flattening absent and null survived a green 166/0 suite.
+
+**Audit 2 (delta)** confirmed all four fixes and found the fix round's own regression: the new
+conditional was pinned in the *omit* direction only, so `UNIDENTIFIED = None` — collapsing the
+two states from the producer side — survived. It also measured that the new stderr warning
+reached the operator **zero** times, because `run_script` captured child stderr and returned
+only stdout.
+
+🔴 **The recurring shape, now four rounds deep: introducing a distinction pins one side of it.**
+D12 itself, then the audit-1 fix, then the audit-2 fix each created a new branch and tested the
+branch they were thinking about. Two nearby mutants even died for the WRONG reason — `object()`
+is truthy and non-`None`, so they crashed in `json.dumps` rather than failing an assertion,
+which reads as coverage and is not. **When you add a branch, write the test for the arm you did
+not have in mind.**
+
+🔴 **And a false SURVIVED nearly shipped from the sweep's own harness**: the first sweep filtered
+runner output through a `grep -E` alternation that omitted the killing test's name, so a mutant
+that *was* caught printed nothing and scored SURVIVED. Read the whole failure list.

--- a/scripts/check-clickup-addressed/_selfrun.py
+++ b/scripts/check-clickup-addressed/_selfrun.py
@@ -39,15 +39,12 @@ SELF_RUN_MARKERS = (
     # catches the sessions that BUILT this skill, whose test fixtures hardcode real task
     # IDs (868krn3y1, 868kr07fu) next to mock completion text.
     #
-    # 🔴 TWO SPELLINGS BECAUSE THE MARKER IS A PATH AND THE CODE MOVED (2026-08-22). The
-    # first is the datapacket-talos layout `.claude/skills/check-clickup-addressed/scripts/`,
-    # kept because transcripts written before the migration still say it. The second is the
-    # devrc layout `scripts/check-clickup-addressed/…` — the SAME two segments, REVERSED, so
-    # neither string matches the other's path and dropping either blinds the guard to half
-    # the corpus. Both stay anchored: the always-injected skill catalog names
-    # `~/.claude/skills/check-clickup-addressed/SKILL.md`, which contains NEITHER.
+    # 🔴 THE MARKER IS A PATH AND THE CODE MOVED (2026-08-22): this literal is the
+    # datapacket-talos layout `.claude/skills/check-clickup-addressed/scripts/`, kept because
+    # transcripts written before the migration still say it. The devrc layout reverses those
+    # two segments, so it matches nothing here — it is handled by NEW_LAYOUT_RE below, which
+    # is a regex for a measured reason, not a stylistic one.
     "check-clickup-addressed/scripts/",
-    "scripts/check-clickup-addressed/",
     # The report header printed by check-addressed.py — catches a session that pasted the
     # output without running it.
     "## Task Completion Status",
@@ -59,6 +56,27 @@ SELF_RUN_MARKERS = (
 # (`\"skill\": \"...\"`) when a transcript quotes the call inside message text. The escaped
 # form is why this is not a plain string match — the first version missed it.
 SELF_RUN_RE = re.compile(r'\\?"skill\\?"\s*:\s*\\?"check-clickup-addressed\\?"')
+
+# The devrc layout, anchored on a SCRIPT FILE rather than on the directory.
+#
+# 🔴 THE DIRECTORY SPELLING WAS TRIED AND MEASURED UNUSABLE (2026-08-22). `scripts/check-
+# clickup-addressed/` reads like the obvious counterpart of the old marker, but devrc's
+# CLAUDE.md carries a subsystem table mapping `scripts/<dir>/` to its owning skill, and a
+# project CLAUDE.md is injected into every session in that repo. Measured over the 761
+# transcripts these scripts actually walk: the two sibling rows `scripts/repo-cos/` and
+# `scripts/session-analysis/` appear in **83 (10.9%)** and **72 (9.5%)** of them — the same
+# order as the bare name `check-clickup-addressed` at 96 (12.6%), which this file already
+# rejects as unusable. The gate's own per-target output (`… scripts/check-clickup-addressed/
+# tests`) is a second such source.
+#
+# Requiring a `.py` FILE immediately after the directory separates a run from a mention:
+#   matches      scripts/check-clickup-addressed/check-addressed.py     (an invocation)
+#   NO match     scripts/check-clickup-addressed/                       (CLAUDE.md's table)
+#   NO match     scripts/check-clickup-addressed/tests/test_corpus.py   (gate output — the
+#                                                                        slash breaks it)
+# SKILL.md still self-marks, deliberately, because it cites `…/_selfrun.py` — a loaded
+# SKILL.md means the skill fired, which IS a run.
+NEW_LAYOUT_RE = re.compile(r'check-clickup-addressed/[\w.-]+\.py')
 
 _cache = {}
 
@@ -77,7 +95,9 @@ def is_self_run(path):
     try:
         with open(key, errors="replace") as f:
             for line in f:
-                if any(m in line for m in SELF_RUN_MARKERS) or SELF_RUN_RE.search(line):
+                if (any(m in line for m in SELF_RUN_MARKERS)
+                        or SELF_RUN_RE.search(line)
+                        or NEW_LAYOUT_RE.search(line)):
                     hit = True
                     break
     except OSError:

--- a/scripts/check-clickup-addressed/_selfrun.py
+++ b/scripts/check-clickup-addressed/_selfrun.py
@@ -44,6 +44,16 @@ SELF_RUN_MARKERS = (
     # transcripts written before the migration still say it. The devrc layout reverses those
     # two segments, so it matches nothing here — it is handled by NEW_LAYOUT_RE below, which
     # is a regex for a measured reason, not a stylistic one.
+    #
+    # ⚠ HOW MUCH THE MOVE ACTUALLY BROKE — corrected after an audit, because the first version
+    # of this comment overstated it. The path markers catch the INVOCATION; the header below
+    # catches the OUTPUT, and every text-mode report prints it. Measured over the 762
+    # transcripts these scripts walk, the exclusion set is **11 with or without** the path
+    # marker — so the guard did NOT go blind on the ordinary path. The one shape that was
+    # genuinely uncovered is a `--json` run, whose output carried no marker at all until
+    # `render_json` was fixed the same day. The path markers remain worth keeping: they catch
+    # a run whose OUTPUT never reaches the transcript (piped to a file, `--json | jq`,
+    # truncated), which the header cannot. Defence in depth, correctly labelled.
     "check-clickup-addressed/scripts/",
     # The report header printed by check-addressed.py — catches a session that pasted the
     # output without running it.
@@ -76,7 +86,23 @@ SELF_RUN_RE = re.compile(r'\\?"skill\\?"\s*:\s*\\?"check-clickup-addressed\\?"')
 #                                                                        slash breaks it)
 # SKILL.md still self-marks, deliberately, because it cites `…/_selfrun.py` — a loaded
 # SKILL.md means the skill fired, which IS a run.
-NEW_LAYOUT_RE = re.compile(r'check-clickup-addressed/[\w.-]+\.py')
+#
+# 🔴 THE PATH FORM ALONE MISSES THE INVOCATION THIS SKILL'S OWN DOCS TEACH. SKILL.md's quick
+# start is `CCUA=~/workspace/devrc/scripts/check-clickup-addressed` then
+# `python3 "$CCUA/check-addressed.py"` — the variable means the adjacency never appears in the
+# transcript, and `cd <dir> && python3 check-addressed.py` breaks it the same way. A marker
+# that only matches the fully-spelled path is a marker for a shape nobody types. So the bare
+# entry-point BASENAMES are alternatives here. Measured 2026-08-22 over the 762 transcripts
+# these scripts walk, each is in the anchored class, not the ~10% mention class:
+#   check-addressed.py 12 (1.6%) · check-completion.py 10 (1.3%)
+#   search-sessions.py 10 (1.3%) · recent-comments.py  10 (1.3%)
+# for reference: the old path marker 11 (1.4%), the bare skill name 96 (12.6%, rejected).
+# The `-` spelling is what keeps them tight: the test modules are `test_check_completion.py`
+# with UNDERSCORES, so a pytest run naming them does not match.
+NEW_LAYOUT_RE = re.compile(
+    r'check-clickup-addressed/[\w.-]+\.py'
+    r'|(?:check-addressed|check-completion|search-sessions|recent-comments)\.py'
+)
 
 _cache = {}
 

--- a/scripts/check-clickup-addressed/_selfrun.py
+++ b/scripts/check-clickup-addressed/_selfrun.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Detect a transcript that is a RUN of this checker, not independent evidence about a task.
+
+Why this exists (2026-08-20). The pipeline already skipped `$CLAUDE_CODE_SESSION_ID`, so it
+could not read the transcript it was being written into. It could still read *yesterday's*
+run — and a prior run is the worst possible witness: it prints every task ID under test
+directly beside completion vocabulary ("likely_addressed", "✓ resolved", "merged"), which is
+exactly the shape the proximity scorer is built to reward.
+
+Measured that day: both tasks in the report scored `likely_addressed` on evidence that was
+100% a previous run's own output. Excluding it, they were `unclear` and `no_mentions_found`.
+One of them (868kr0799) carried a comment reading "Still live, do not close" — the tool told
+the operator to close it.
+
+The markers below must be ANCHORED. Measured **2026-08-21** over the population these
+scripts actually walk — `CLAUDE_DIR.iterdir()` then `glob("*.jsonl")`, top level only,
+**735 transcripts** on this box — a bare `check-clickup-addressed` matches **67 (9.1%)**,
+because the skill catalog is injected into every session's context; a bare
+`/check-clickup-addressed` matches **24 (3.3%)**, because it is a substring of the *path*
+`~/.claude/skills/check-clickup-addressed`. The real anchored markers match **4**. That is a
+~17x over-drop for the bare name and ~6x for the slash form — either is unusable.
+
+🔴 These figures DRIFT and are undated nowhere else: 746/62/23 on 2026-08-20 became
+735/67/24 on 2026-08-21. Treat them as a ratio and a date, not a constant — re-measure
+before quoting them anywhere.
+
+🔴 Measure over THAT population, not over `grep -r ~/.claude/projects`. A recursive grep also
+walks `<session>/subagents/*.jsonl` (4559 files) and `<session>/tool-results/*`, which these
+scripts never open — doing so gave 213 and 32 against a denominator of ~250, i.e. both
+numerator and denominator wrong, and made the rejected candidates look far worse than they
+are. The verdict survived re-measurement; the figures did not.
+"""
+import re
+
+SELF_RUN_MARKERS = (
+    # Slash invocation of the skill.
+    "<command-name>/check-clickup-addressed</command-name>",
+    # Any Bash call into the pipeline, and the SKILL.md body itself once loaded. Also
+    # catches the sessions that BUILT this skill, whose test fixtures hardcode real task
+    # IDs (868krn3y1, 868kr07fu) next to mock completion text.
+    #
+    # 🔴 TWO SPELLINGS BECAUSE THE MARKER IS A PATH AND THE CODE MOVED (2026-08-22). The
+    # first is the datapacket-talos layout `.claude/skills/check-clickup-addressed/scripts/`,
+    # kept because transcripts written before the migration still say it. The second is the
+    # devrc layout `scripts/check-clickup-addressed/…` — the SAME two segments, REVERSED, so
+    # neither string matches the other's path and dropping either blinds the guard to half
+    # the corpus. Both stay anchored: the always-injected skill catalog names
+    # `~/.claude/skills/check-clickup-addressed/SKILL.md`, which contains NEITHER.
+    "check-clickup-addressed/scripts/",
+    "scripts/check-clickup-addressed/",
+    # The report header printed by check-addressed.py — catches a session that pasted the
+    # output without running it.
+    "## Task Completion Status",
+)
+
+# Skill-tool invocation, e.g. {"skill": "check-clickup-addressed"}. A regex rather than a
+# literal because spacing varies by serializer, and because the pair appears in two forms:
+# raw JSON structure (`"skill":"..."`) when the Skill tool was called, and BACKSLASH-ESCAPED
+# (`\"skill\": \"...\"`) when a transcript quotes the call inside message text. The escaped
+# form is why this is not a plain string match — the first version missed it.
+SELF_RUN_RE = re.compile(r'\\?"skill\\?"\s*:\s*\\?"check-clickup-addressed\\?"')
+
+_cache = {}
+
+
+def is_self_run(path):
+    """True if `path` is a transcript of this checker running (or its output being quoted).
+
+    Scans raw JSONL lines rather than decoded message text: the markers live in tool_use
+    inputs and command wrappers, which the text-only readers in check-completion.py drop.
+    """
+    key = str(path)
+    if key in _cache:
+        return _cache[key]
+
+    hit = False
+    try:
+        with open(key, errors="replace") as f:
+            for line in f:
+                if any(m in line for m in SELF_RUN_MARKERS) or SELF_RUN_RE.search(line):
+                    hit = True
+                    break
+    except OSError:
+        # Deliberately NOT cached. A transient read error answers "not a self-run", which
+        # is the unsafe direction; caching it would pin that answer for the whole process
+        # and let a prior run be read as evidence on every later lookup.
+        return False
+
+    _cache[key] = hit
+    return hit

--- a/scripts/check-clickup-addressed/check-addressed.py
+++ b/scripts/check-clickup-addressed/check-addressed.py
@@ -47,6 +47,30 @@ MARKER_LEGEND = ("Evidence lines: `✓` completion signal / `○` open signal ·
                  "task ID is inside that signal's own snippet, `[○]` merely somewhere in "
                  "the same ±2000-char window — distrust `[○]`.")
 
+# The report header, and simultaneously a SELF-RUN MARKER — `_selfrun.py` matches this exact
+# literal, which is how a transcript that merely PASTED a report is recognised as a prior run.
+# It is defined once here and emitted by BOTH output branches (the JSON one carries it as the
+# `report_header` field); `tests/test_attribution.py` pins that both do. Changing the wording
+# without changing `SELF_RUN_MARKERS` silently unhooks the guard from every future report.
+SELF_RUN_HEADER = "## Task Completion Status"
+
+
+def render_json(report):
+    """Serialise the report for `--json`, CARRYING THE SELF-RUN MARKER.
+
+    🔴 A --json RUN MUST BE SELF-MARKING TOO. The text branch prints `SELF_RUN_HEADER`, which
+    `_selfrun.py` matches, so a transcript holding a pasted report is recognised as a prior
+    run. Until 2026-08-22 the JSON branch emitted `json.dumps(report)` and no marker at all —
+    so a `--json` invocation, whose output lists every task ID beside `likely_addressed` (the
+    exact shape the proximity scorer rewards), was invisible to the guard. Found by an
+    adversarial audit of the devrc migration, which RAN the script rather than reading it.
+
+    🔴 This is a FUNCTION so its test can exercise the real path. The first attempt asserted a
+    payload the test itself had built with the same dict-merge — it passed with the production
+    branch reverted, i.e. it tested nothing. A test may not re-implement the thing it checks.
+    """
+    return json.dumps({**report, "report_header": SELF_RUN_HEADER}, indent=2)
+
 
 def run_script(name, *args):
     script = SCRIPT_DIR / name
@@ -691,7 +715,7 @@ def main():
     }
 
     if as_json:
-        print(json.dumps(report, indent=2))
+        print(render_json(report))
     else:
         print(f"## Recent Comments ({len(comments)})\n")
         for c in comments:
@@ -714,7 +738,7 @@ def main():
                     print(f"  file: {s.get('file', '?')}")
                 print()
 
-        print(f"\n## Task Completion Status\n")
+        print(f"\n{SELF_RUN_HEADER}\n")
         print(f"{MARKER_LEGEND}\n")
         for r in results:
             status_icon = {"likely_addressed": "✅", "partially_addressed": "⚠️", "open": "🔴", "unclear": "❓", "no_sessions_found": "🔍", "no_mentions_found": "🔍"}.get(r["status"], "?")

--- a/scripts/check-clickup-addressed/check-addressed.py
+++ b/scripts/check-clickup-addressed/check-addressed.py
@@ -73,11 +73,23 @@ def render_json(report):
 
 
 def run_script(name, *args):
+    """Run a sibling script and return its stdout.
+
+    🔴 Child stderr is FORWARDED, not swallowed. `capture_output=True` captures both streams
+    and this function used to return only stdout, so anything a child wrote to stderr was
+    silently discarded — measured: `recent-comments.py`'s warning that it could not resolve
+    the ClickUp user id (and therefore cannot tell your comments from anyone else's) appeared
+    ZERO times in this entry point's output, on either stream. A warning nobody can see is
+    the same no-op as one that never fires, and this skill has shipped that shape twice
+    already. Forwarding costs nothing on the normal path: children are silent there.
+    """
     script = SCRIPT_DIR / name
     result = subprocess.run(
         [sys.executable, str(script), *args],
         capture_output=True, text=True, timeout=300
     )
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
     return result.stdout, result.returncode
 
 
@@ -376,6 +388,23 @@ def _waiting_on_a_human(r, now):
 
     The comment is guaranteed not to be the user's own: `recent-comments.py` drops every
     comment whose author id equals `me` before any of this runs.
+
+    🔴 That guarantee is also what made this flag BLIND until 2026-08-22, and it is a SEAM
+    defect — each side is correct alone. Dropping my own comments is right for a report
+    about what other people said; concluding "nobody has answered" from the surviving
+    comments is right given the only evidence handed over. Neither component can observe
+    the other's assumption, so no care inside this function could recover it. Measured on
+    868kuam02: the flag said "Commented 2d ago; nobody has answered" over a ticket TWO
+    sessions had already answered, the later of them eleven hours earlier — and acting on
+    it duplicated an analysis already sitting in the thread. The fix has to cross the seam,
+    so `recent-comments.py` now reports `my_latest_reply` and condition 4 reads it.
+
+    4. **I have not already answered it** — suppressed when my newest reply is at or after
+       the comment. Compared, not merely counted: a reply PREDATING the question does not
+       answer it, which is the ordinary shape on a long-running ticket. An ABSENT
+       `my_latest_reply` is a stale producer that never gathered the fact, so the flag
+       fires but says the check did not run — the same treatment an unreadable date gets,
+       and the reason it cannot be silently disabled by dropping one dict key.
     """
     # PRESENT and zero, not `get(..., 0)`. An absent key is a record that never reported a
     # mention count — inferring "no work exists anywhere", the strongest claim this flag
@@ -396,16 +425,44 @@ def _waiting_on_a_human(r, now):
     if not (nc.get("date") or "").strip():
         return None
 
+    # Answered already? Compare instants, not existence. Equal counts as answered: ClickUp
+    # renders to the MINUTE, so a reply written in the same minute as the comment reads as
+    # equal, and a strict `>` would report it unanswered.
+    reply_unreported = "my_latest_reply" not in nc
+    if not reply_unreported:
+        mine = _comment_age_days(nc.get("my_latest_reply"), now)
+        theirs = _comment_age_days(nc.get("date"), now)
+        # Smaller age = more recent. A malformed value on either side falls through to the
+        # flag rather than suppressing it — never silently drop a waiting human because a
+        # date would not parse.
+        if mine is not None and theirs is not None and mine <= theirs:
+            return None
+
     age = _comment_age_days(nc.get("date"), now)
+    # 🔴 The recency bound runs BEFORE any reporting caveat, and the caveats COMPOSE rather
+    # than each returning their own message. Written the other way round first, and it broke
+    # two existing guards at once: the unreported-reply branch returned early, so a 90-day-old
+    # backlog comment was flagged forever (the exact unbounded-noise failure the recency bound
+    # exists to prevent) and an unreadable date stopped being surfaced. A condition that
+    # returns its own string is a condition that silently owns every condition after it.
+    if age is not None and age > UNANSWERED_COMMENT_DAYS:
+        return None
+
     who = nc.get("author") or "someone"
     head = (f"{r['task_id']}: @{who} is WAITING — the ticket is `{cu or 'unknown status'}`, "
             f"and the task ID appears in NO transcript, so no work exists anywhere.")
     if age is None:
-        return (head + f" (comment date {nc.get('date')!r} was unreadable, so its age is "
-                       f"unknown — surfaced rather than assumed stale.)")
-    if age > UNANSWERED_COMMENT_DAYS:
-        return None
-    return head + f" Commented {age:.0f}d ago; nobody has answered. Read it."
+        head += (f" (comment date {nc.get('date')!r} was unreadable, so its age is unknown "
+                 f"— surfaced rather than assumed stale.)")
+    else:
+        head += f" Commented {age:.0f}d ago"
+        # Only claim nobody answered when that was actually checked.
+        head += "." if reply_unreported else "; nobody has answered. Read it."
+    if reply_unreported:
+        head += (" NOTE: your own replies were not reported by recent-comments.py, so whether "
+                 "you already answered could not be checked — read the thread before treating "
+                 "this as unanswered.")
+    return head
 
 
 def disagreements(results, now=None):
@@ -563,12 +620,18 @@ def build_newest_comment(meta):
     by a sentence reorder — the comment that motivated the veto is 196 characters and
     cleared the old cap by four.
     """
-    return {
+    nc = {
         "date": meta.get("date"),
         "author": meta.get("author"),
         "snippet": (meta.get("snippet") or "")[:200],
         "text": meta.get("text") or meta.get("snippet") or "",
     }
+    # Copied only when PRESENT. A `.get()` here would flatten "the producer reported no
+    # reply" and "the producer never reported" into the same None, and `_waiting_on_a_human`
+    # must tell them apart — one is evidence, the other is a gap to announce.
+    if "my_latest_reply" in meta:
+        nc["my_latest_reply"] = meta["my_latest_reply"]
+    return nc
 
 
 def parse_args(args):

--- a/scripts/check-clickup-addressed/check-addressed.py
+++ b/scripts/check-clickup-addressed/check-addressed.py
@@ -1,0 +1,758 @@
+#!/usr/bin/env python3
+"""Orchestrate: recent comments → task IDs → sessions → completion check.
+
+Usage:
+    python3 check-addressed.py [--limit N] [--json] [--since YYYY-MM-DD] [--verbose] [--fast]
+
+Default: top 3 most recent comments not from the current user.
+--fast: Only check the 10 most recently updated tasks (much faster for large backlogs).
+"""
+import importlib.util
+import json, os, re, subprocess, sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+
+# Import the sibling's marker rather than re-deriving it. The threshold and the two glyphs
+# are ONE rule; a second copy is a second thing to drift, and round 4 already lost a round
+# to a marker that existed in exactly one place and never reached the report (D10).
+_spec = importlib.util.spec_from_file_location(
+    "_check_completion", SCRIPT_DIR / "check-completion.py")
+_check_completion = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_check_completion)
+confidence_marker = _check_completion.confidence_marker
+
+
+def signal_line(kind_glyph, signal, verbose=False):
+    """Render one evidence line: kind glyph, then adjacency, then the signal.
+
+    🔴 Two orthogonal facts, two columns. `kind_glyph` is `✓` completion / `○` open — that
+    is WHAT the signal says. The bracketed marker is `●` the task ID is inside this
+    signal's own ±40-char snippet / `○` merely somewhere in the ±2000-char window — that is
+    HOW MUCH to trust the attribution, and `○` is the one to distrust.
+
+    They are kept in separate columns because `○` already meant "open item" here. Round 4
+    added `confidence_marker()` and wired it only into check-completion.py's own printer,
+    so the entry point everyone actually runs never showed adjacency at all: measured
+    2026-08-21, a proximity-1.5 signal and a proximity-1.0 signal rendered IDENTICALLY.
+    Merging the two facts into one glyph would have made the report unreadable instead of
+    silent, which is not an improvement — hence the brackets.
+    """
+    width = 120 if verbose else 80
+    return f"  {kind_glyph} [{confidence_marker(signal)}] {signal['signal']}: {signal['snippet'][:width]}"
+
+
+MARKER_LEGEND = ("Evidence lines: `✓` completion signal / `○` open signal · then `[●]` the "
+                 "task ID is inside that signal's own snippet, `[○]` merely somewhere in "
+                 "the same ±2000-char window — distrust `[○]`.")
+
+
+def run_script(name, *args):
+    script = SCRIPT_DIR / name
+    result = subprocess.run(
+        [sys.executable, str(script), *args],
+        capture_output=True, text=True, timeout=300
+    )
+    return result.stdout, result.returncode
+
+
+# A ticket whose newest comment declares the work done while the ticket itself is still
+# open. This is the single highest-value thing in the report and no transcript scan can
+# produce it: on 2026-08-19 `868kr07fu` sat at `to do` / urgent under a comment reading
+# "Resolved ... Recommend closing".
+RESOLVED_COMMENT_RE = re.compile(
+    r"\b(?:resolved|recommend closing|can be closed|both asks are (?:now )?closed|"
+    r"this is done|all (?:asks|items) (?:are )?closed)\b", re.IGNORECASE)
+
+# An explicit refusal to close. This VETOES the close-it flag rather than being weighed
+# against it, because that flag is an instruction to a human, not a score.
+#
+# Measured 2026-08-20 on 868kr0799, whose newest comment read: "Still live, do not close.
+# ... MeiliSearch: P95 > 5s (Saturation Burst) fired and resolved repeatedly". The word
+# "resolved" there describes an ALERT cycling, and the ticket sat at `to do`/urgent — so
+# the report told the operator to close a ticket whose reporter had just said, in the same
+# sentence, not to. A keyword cannot tell those two senses of "resolved" apart; an explicit
+# override can, and it is the reporter's own words doing the overriding.
+#
+# STRONG = an instruction about THIS ticket that no other reading survives. It is absolute.
+# 🔴 `stay(s|ing) open` / `remains open` / `leaving it open` are here because the LIVE
+# end-to-end run found them, not the 17-case table. On 2026-08-21 the real ticket
+# `868ktt2ct` opened with "Status check during ClickUp triage — **staying open**, and mostly
+# not verifiable from this repo", and its only closure vocabulary was one "shipped" about a
+# sub-item in another repo. The tier downgraded an unmistakable refusal to "READ IT" —
+# trunk's absolute veto had it right, by luck of "still open" appearing later in the comment.
+#
+# They are STRONG rather than WEAK because, unlike `still open` and `not resolved`, they are
+# not this domain's vocabulary for anything else: a PR or an alert is "open", never "staying
+# open". A deliberate declaration about what happens to THIS ticket has no second reading.
+STRONG_KEEP_OPEN_RE = re.compile(
+    r"\b(?:do ?n[o']?t close|keep (?:it |this )?open|still live|"
+    r"stay(?:s|ing)? open|remains? open|leav(?:e|ing) (?:it |this )?open|"
+    # 🔴 `(?:ticket|task) (?:is |remains? )?still open` was here and was REMOVED. It reads
+    # as naming THIS object — "a PR is open, but only this is *the ticket*" — and that
+    # premise is false in ClickUp, where comments reference sibling tickets constantly:
+    # "the upstream task is still open but that is tracked separately", "the duplicate task
+    # is still open, closing this one". Measured, it produced a hard veto on 4 of 4 such
+    # comments where the weak tier correctly said READ IT. Weak is the right tier for every
+    # "still open" — the ambiguity downgrade is what handles the ones about this ticket.
+    r"still (?:broken|happening|occurring|reproducing)|"
+    r"reopen(?:ing|ed)?|premature to close)\b", re.IGNORECASE)
+
+# WEAK = a refusal that is MOST OFTEN about something else in this tool's own domain. A
+# GitHub review thread is resolved/unresolved, Alertmanager says firing/resolved, and a
+# sibling PR is open or closed — so "still open" and "not resolved" are as likely to be
+# about a PR or an alert as about the ticket. Measured on trunk 2026-08-21: a comment
+# reading "Resolved on both counts, recommend closing. (The follow-up PR is still open but
+# unrelated.)" on a `to do` ticket emitted **do NOT close** — the veto suppressing exactly
+# the flag the reporter asked for.
+#
+# A weak phrase is NOT ignorable: alone in a comment it is the only statement about
+# closure, so it vetoes like a strong one. It downgrades only when the SAME comment also
+# carries an un-negated closure claim in another clause — then the comment genuinely says
+# both things and this tool refuses to instruct either way. That is the whole tier.
+WEAK_KEEP_OPEN_RE = re.compile(r"\bstill open\b", re.IGNORECASE)
+
+# Negation, decided ONCE, at clause level.
+#
+# Four rounds on the abandoned branch `zach/ccua-self-run-guard` tried per-word lookbehinds
+# and lost the same way twice: `(?<!not )(?<!not yet )resolved` guards exactly the two
+# spellings it names, so `isn't` / `never` / `won't` / `not fully` / `unresolved` all still
+# read as RESOLUTIONS and drew an affirmative "close it" over a comment saying the opposite.
+# Enumerating a class is the error; recognising its SHAPE is the fix. Contractions are
+# matched by shape (`\w+n't`) rather than by stem because a stem list misses `won't` —
+# whose stem is "wo", not "will" — and by construction cannot be completed.
+NEGATOR_RE = re.compile(
+    r"\b(?:not|never|no|none|nothing|nobody|without|unable|cannot|can not|"
+    # Idioms that negate what FOLLOWS them without containing a negator word. `anything but`
+    # also carries a lookbehind in CLAUSE_SPLIT_RE so the `but` does not split the phrase
+    # away from the word it negates — both halves are needed, and neither works alone.
+    r"far from|anything but|"
+    r"yet to|fails? to|failed to)\b"
+    r"|\b\w+n['’]t\b", re.IGNORECASE)
+
+# Morphological negation: a refusal wearing the closure word's own root, with no separate
+# negator anywhere in the clause for NEGATOR_RE to find.
+NEGATED_CLOSURE_WORD_RE = re.compile(
+    r"\bun(?:resolved|fixed|merged|addressed|deployed|shipped|done|closed)\b", re.IGNORECASE)
+
+# The WIDE closure vocabulary, used ONLY to decide ambiguity and to spot a negated closure
+# claim. Deliberately NOT merged into RESOLVED_COMMENT_RE: that regex TRIGGERS the close-it
+# instruction, so widening it manufactures close-it flags, whereas widening this one can
+# only ever downgrade a veto to "read it" or add a veto. Both directions are the safe one.
+# Real comments say landed / shipped / merged / deployed / fixed, and a tier that only
+# recognised the six phrasings of RESOLVED_COMMENT_RE would be close to inert on real prose.
+CLOSURE_VOCAB_RE = re.compile(
+    r"\b(?:resolved|fixed|done|merged|deployed|shipped|landed|completed?|closing|closed)\b",
+    re.IGNORECASE)
+
+# Clause boundaries.
+#
+# 🔴 COMMAS ARE BOUNDARIES, and getting this wrong twice is what makes it worth spelling out.
+# The reasoning that excluded them — "This is not, in my view, resolved must keep its negator
+# attached" — is true about that one sentence and false about ticket prose in general. The
+# dominant shape in a bug comment states the SYMPTOM (negated) and then the RESOLUTION, in
+# one comma-spliced sentence:
+#
+#     "Users cannot upload avatars, fixed in #4421 and deployed."
+#     "The alert wasn't firing, resolved by the rule fix."
+#     "The job did not run on Sunday, resolved — I re-ran it."
+#
+# With commas inside the clause, the symptom's negator reaches the resolution and vetoes it.
+# Measured against a 42-case labelled corpus built from two blind audits and one live ticket:
+# commas-not-a-boundary scored 28/42, commas-a-boundary 39/42. The interrupted-negation case
+# that motivated the exclusion is handled by the `carry` rule in `closure_claims` instead —
+# narrowly, by the shape that actually distinguishes it (the clause ENDS on its negator).
+#
+# Parens are NOT boundaries: "This is not (yet) resolved" would strand the closure word in a
+# clause of its own and draw an affirmative close-it over a refusal, which is the worst
+# outcome this tool has. The cost is a false veto when a parenthetical negates a different
+# noun ("The fix (not the workaround) is deployed") — an over-veto, and the safe direction.
+#
+# `but` carries lookbehinds so the "anything but resolved" idiom is not split apart into a
+# clause that reads as a plain resolution.
+CLAUSE_SPLIT_RE = re.compile(
+    r"[.,;!?\n]|[—–]|(?<!anything )(?<!nothing )(?<!everything )"
+    r"\b(?:but|however|although|though|whereas|while)\b",
+    re.IGNORECASE)
+
+def clauses(text):
+    """Split a comment into clauses. One place, so every caller scopes negation the same way."""
+    return [c for c in CLAUSE_SPLIT_RE.split(text or "") if c and c.strip()]
+
+
+def negated_phrase(clause, neg, m):
+    """What to QUOTE back for a negated closure claim.
+
+    The bare vocabulary word is not quotable: `newest comment says "resolved" — do NOT
+    close` states the opposite of the comment it is quoting, which is how an operator stops
+    trusting the line. Quote the negator through the word instead, so the reason the flag
+    fired is legible in the flag itself.
+
+    `neg` always PRECEDES `m` (see `closure_claims`), so the span is a real substring in the
+    comment's own word order and the elided form is an honest elision. An earlier version
+    allowed a negator found ANYWHERE in the clause, and printed manufactured quotations like
+    `"no … resolved"` for a comment reading "Confirmed resolved, no repro since Tuesday" —
+    words the comment contains, in an order it never used.
+    """
+    span = clause[neg.start():m.end()].strip()
+    if span and len(span) <= 80:
+        return span
+    return f"{neg.group(0)} … {m.group(0)}"
+
+
+def closure_claims(text):
+    """(affirmed, negated) closure claims, negation scoped to the clause AND to word order.
+
+    A single pass over CLOSURE_VOCAB_RE, so a word added to that vocabulary inherits the
+    negation handling for free — which is the thing per-word lookbehinds could never do.
+
+    🔴 A negator only negates closure words that FOLLOW it. Clause-wide, position-independent
+    negation was a regression worse than the bug this tier exists to fix: with commas
+    deliberately not a boundary, any trailing "no" / "nothing" reached backwards and inverted
+    a plain resolution. Measured by audit — 12 of 12 ordinary "work is finished, nothing
+    outstanding" comments flipped from **close it** to **do NOT close**, e.g.
+
+        "Resolved, no further action needed."      -> do NOT close
+        "Recommend closing, no further work planned." -> do NOT close
+
+    That is an affirmative wrong instruction, not a safe over-veto, and it would have traded
+    4 wrongly-suppressed close-its for 12 wrongly-created vetoes.
+    """
+    # 🔴 THERE IS NO CARRY ACROSS CLAUSES, and the deleted attempt is worth recording.
+    #
+    # A `carry` rule once propagated a clause-TRAILING negator into the next clause, to catch
+    # the one shape commas-as-boundaries loses: "This is not, in my view, resolved". It bought
+    # exactly that one corpus case and cost a whole class, because "ends on a negator" does not
+    # distinguish an interrupted negation from the way engineers actually write a clean status:
+    #
+    #     "Downtime: none. Resolved and deployed."      -> do NOT close   (trunk: close it)
+    #     "Impact: none, resolved by the rollback."     -> do NOT close   (trunk: close it)
+    #     "Regressions found: none. Resolved."          -> do NOT close   (trunk: close it)
+    #
+    # It also reintroduced the manufactured quotation `negated_phrase` exists to prevent —
+    # `says "none … Resolved"` over a comment whose two words come from different sentences —
+    # and it was cleared only by a clause containing a closure word, so it survived arbitrarily
+    # many intervening clauses. Suppressing a legitimate close-it is the second-worst thing
+    # this tool does, and one corpus point does not buy seven of them.
+    #
+    # The interrupted-negation shape is now a recorded KNOWN FAILURE in test_corpus.py rather
+    # than a rule. Say what is not handled; do not half-handle it.
+    affirmed, negated = [], []
+    for clause in clauses(text):
+        negators = list(NEGATOR_RE.finditer(clause))
+        for m in CLOSURE_VOCAB_RE.finditer(clause):
+            preceding = [n for n in negators if n.start() < m.start()]
+            if preceding:
+                # The NEAREST preceding negator, so the quoted span stays tight.
+                negated.append(negated_phrase(clause, preceding[-1], m))
+            else:
+                affirmed.append(m.group(0))
+        negated.extend(m.group(0) for m in NEGATED_CLOSURE_WORD_RE.finditer(clause))
+    return affirmed, negated
+
+
+def keep_open_signal(text):
+    """('strong'|'weak', phrase) or (None, None) — the reporter's refusal to close, tiered.
+
+    STRONG is checked first and wins outright: a comment carrying both must quote the
+    stronger phrase, or the tool would downgrade an explicit "do not close" on the strength
+    of an incidental "still open" elsewhere in the same comment.
+
+    A NEGATED closure claim is a weak keep-open signal in its own right, which is how
+    `not resolved`, `isn't resolved`, `never resolved`, `won't be resolved`, `not fully
+    resolved`, `unresolved` and `I do not recommend closing` all become one rule instead of
+    six enumerated spellings.
+    """
+    m = STRONG_KEEP_OPEN_RE.search(text or "")
+    if m:
+        return "strong", m.group(0)
+    m = WEAK_KEEP_OPEN_RE.search(text or "")
+    if m:
+        return "weak", m.group(0)
+    _affirmed, negated = closure_claims(text)
+    # `or m.group(0)`-style fallbacks are not enough here: an empty phrase makes
+    # `if veto_phrase:` in disagreements() falsy, which SILENTLY DROPS THE WHOLE VETO rather
+    # than printing a blank one. A mutant that emptied the quoted span survived the suite by
+    # deleting the flag, so the tier decision must never depend on the phrase being truthy.
+    for phrase in negated:
+        if phrase and phrase.strip():
+            return "weak", phrase.strip()
+    if negated:
+        return "weak", "a negated closure claim"
+    return None, None
+
+
+# 🔴 The close-it branch below deliberately carries NO negation filter of its own, and that
+# is a claim with a premise, not an oversight.
+#
+# One was written, and the mutation sweep scored it the IDENTITY: reverting it to a bare
+# `RESOLVED_COMMENT_RE.search()` changed no test and no behaviour. The branch is only
+# reached when `keep_open_signal` returned no tier at all, and every phrase
+# RESOLVED_COMMENT_RE can match contains a CLOSURE_VOCAB_RE word — so a negated close-it
+# trigger has ALREADY been recorded as a negated closure claim and vetoed one branch above.
+# An unreachable guard reads as protection while providing none, so it is deleted rather
+# than tested. `test_every_close_it_trigger_phrase_is_also_ambiguity_vocabulary` pins the
+# premise: add a phrase to RESOLVED_COMMENT_RE whose words are not in CLOSURE_VOCAB_RE and
+# that test goes red, which is the signal to bring the filter back.
+
+
+OPEN_STATUSES = {"to do", "open", "in progress", "backlog", "todo"}
+DONE_STATUSES = {"complete", "closed", "done", "resolved"}
+
+# How recent a comment has to be for "nobody has answered this" to be worth a human's
+# attention. See `_waiting_on_a_human` for why this is bounded by RECENCY and not priority.
+UNANSWERED_COMMENT_DAYS = 14
+COMMENT_DATE_FMT = "%Y-%m-%d %H:%M"
+
+
+def _comment_age_days(date_str, now):
+    """Age of a comment in days, or None if the date cannot be read.
+
+    `recent-comments.py` formats these itself, so an unreadable one means that formatter
+    changed — which must not silently turn into "not recent". None is propagated to the
+    caller and surfaced, never swallowed.
+    """
+    try:
+        dt = datetime.strptime((date_str or "").strip(), COMMENT_DATE_FMT).replace(
+            tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return None
+    return (now - dt).total_seconds() / 86400.0
+
+
+def _waiting_on_a_human(r, now):
+    """A colleague asked something recently and NO work exists anywhere. Returns a flag or None.
+
+    This is the highest-signal state the tool can reach and no existing rule produced it:
+    nothing "disagrees" — the ticket is open, the transcripts are empty, and they agree.
+    Measured live 2026-08-21 on `868kuam02` (`to do`/high, two unanswered comments from a
+    colleague, 0 mentions): the "Needs a decision" block said nothing at all.
+
+    Three conditions, and the bounding choice matters more than the detection:
+
+    1. **Zero transcript evidence** — gated on `mentions_found == 0`, the STATE, not on the
+       word `no_mentions_found`. `no_sessions_found` is the same zero and a guard spelled
+       against one word passes while the hazard exists in the other's shape. Once any
+       transcript mentions the task there IS evidence and the verdict branches own it.
+    2. **Not a done ticket** — deliberately `not in DONE_STATUSES` rather than
+       `in OPEN_STATUSES`. Gating on the open vocabulary would rebuild D6's blind spot:
+       an `in review` / `blocked` ticket would silently lose the flag. Like the keep-open
+       veto, this direction is safe whatever the status word reads. A DONE ticket with no
+       evidence is already covered by the "verify before trusting the close" flag, and
+       calling it "someone is waiting" would be false.
+    3. **A recent comment** — the flag is bounded by RECENCY, not priority. Priority is a
+       property of the TICKET: set once, frequently stale, and unchanged by anyone asking
+       anything, so a priority bound would fire on every unstarted high-priority backlog
+       item every single run — and a permanently-noisy block is worse than no block,
+       because it trains the reader to skip it. Recency is a property of the INTERACTION:
+       it says a human is waiting NOW, it self-clears as the comment ages, so the flag's
+       false-positive volume is bounded by construction, and it composes with the tool's
+       own sampling (the report already takes the N most recent comments).
+
+    The comment is guaranteed not to be the user's own: `recent-comments.py` drops every
+    comment whose author id equals `me` before any of this runs.
+    """
+    # PRESENT and zero, not `get(..., 0)`. An absent key is a record that never reported a
+    # mention count — inferring "no work exists anywhere", the strongest claim this flag
+    # makes, from a field that is simply missing is the same mistake as reading a declared
+    # field as a code path. Caught by an existing round-2 control whose fixture omits it.
+    if r.get("mentions_found") != 0:
+        return None
+    cu = (r.get("clickup_status") or "").lower()
+    if cu in DONE_STATUSES:
+        return None
+
+    nc = r.get("newest_comment") or {}
+    if not (nc.get("snippet") or "").strip():
+        return None
+    # An ABSENT date and a MALFORMED one are different facts. Absent = no interaction to be
+    # recent about, so there is nothing to claim. Malformed = recent-comments.py's own
+    # formatter drifted, which must announce itself rather than quietly read as "stale".
+    if not (nc.get("date") or "").strip():
+        return None
+
+    age = _comment_age_days(nc.get("date"), now)
+    who = nc.get("author") or "someone"
+    head = (f"{r['task_id']}: @{who} is WAITING — the ticket is `{cu or 'unknown status'}`, "
+            f"and the task ID appears in NO transcript, so no work exists anywhere.")
+    if age is None:
+        return (head + f" (comment date {nc.get('date')!r} was unreadable, so its age is "
+                       f"unknown — surfaced rather than assumed stale.)")
+    if age > UNANSWERED_COMMENT_DAYS:
+        return None
+    return head + f" Commented {age:.0f}d ago; nobody has answered. Read it."
+
+
+def disagreements(results, now=None):
+    """Cross-check the three independent sources: ticket status, newest comment, transcripts.
+
+    Every branch below is gated on the ClickUp status being one of the nine words above.
+    ClickUp statuses are per-list and arbitrary, so that vocabulary is a guess, and until
+    2026-08-21 a miss was SILENT: measured, 'in review' / 'blocked' / 'needs qa' / 'review'
+    each returned [] — the keep-open veto and the resolved-comment flag both disabled, with
+    no output saying so. An empty "Needs a decision" block then reads as "checked, nothing
+    disagrees" when it means "not checked at all", which is the reassuring-nothing this
+    whole skill exists to police. An unrecognised status is now announced instead.
+
+    Widening the two sets is NOT the fix on its own — it only moves the silence to the next
+    unrecognised word. The announcement is what makes a miss visible, so widen the sets when
+    a real status shows up in a flag AND keep the announcement.
+
+    `now` is a test seam so the recency bound in `_waiting_on_a_human` is deterministic; it
+    defaults to the wall clock and main() calls this with one argument.
+    """
+    now = now or datetime.now(timezone.utc)
+    out = []
+    for r in results:
+        tid = r["task_id"]
+        cu = (r.get("clickup_status") or "").lower()
+        nc = r.get("newest_comment") or {}
+        # 🔴 TWO WINDOWS, DELIBERATELY DIFFERENT, because the two regexes fail in opposite
+        # directions.
+        #
+        # The VETO reads the FULL comment: it is absolute, so a refusal to close that falls
+        # past a truncation boundary silently restores the "close it" instruction. The
+        # comment that motivated the veto is 196 characters and cleared the old 200-char cap
+        # by four — write the same sentences with the keep-open clause last and the veto
+        # misses it. Widening here can only ever SUPPRESS a flag, which is the safe way to
+        # be wrong about an instruction to a human.
+        #
+        # The RESOLVED trigger keeps the 200-char snippet. Feeding it the full 4000 chars
+        # widens the close-it trigger 20x in the UNSAFE direction: a long status comment
+        # whose only match is "the alert fired and resolved repeatedly" at character 600
+        # then produces "close it" on a live ticket — the exact alert-cycling sense of
+        # "resolved" this veto exists to neutralise, in a position where the veto cannot
+        # help because there is no refusal in the comment at all. Pinned in both directions
+        # by `test_widened_window_did_not_widen_the_close_it_trigger`.
+        veto_text = nc.get("text") or nc.get("snippet") or ""
+        comment = nc.get("snippet") or ""
+
+        tier, phrase = keep_open_signal(veto_text)
+        # The ambiguity decision reads the FULL comment while the close-it trigger below
+        # keeps the 200-char snippet. Widening THIS window can only downgrade a veto to
+        # "read it" or leave it standing — it can never produce a close-it — which is what
+        # makes the asymmetry safe in the same way the veto's own widened window is.
+        affirmed, _negated = closure_claims(veto_text)
+        # A weak refusal ALONGSIDE an un-negated closure claim in another clause: the
+        # comment says both things, so the tool states the conflict instead of instructing.
+        ambiguous = tier == "weak" and bool(affirmed)
+        veto_phrase = phrase if (tier and not ambiguous) else None
+        ambiguity_line = None
+        if ambiguous:
+            ambiguity_line = (
+                f"{tid}: newest comment carries BOTH a keep-open phrase (\"{phrase}\") and a "
+                f"closure claim (\"{affirmed[0]}\") in different clauses — READ IT and decide. "
+                f"A weak keep-open phrase is as often about a PR, an alert or a sibling "
+                f"ticket as about this one, so this checker will not instruct either way.")
+        known = cu in OPEN_STATUSES or cu in DONE_STATUSES
+
+        if not known:
+            shown = f"`{cu}`" if cu else "(none returned)"
+            out.append(f"{tid}: ClickUp status {shown} is outside this checker's vocabulary "
+                       f"{sorted(OPEN_STATUSES | DONE_STATUSES)} — the ticket/comment "
+                       f"cross-check DID NOT RUN for this task. Read the newest comment "
+                       f"yourself, and add the status to the right set in check-addressed.py.")
+            if veto_phrase:
+                # Safe in either direction and it is the reporter's own instruction, so it
+                # is surfaced whatever the status reads.
+                out.append(f"{tid}: newest comment says \"{veto_phrase}\" — do NOT close.")
+            elif ambiguity_line:
+                out.append(ambiguity_line)
+        elif veto_phrase and cu in OPEN_STATUSES:
+            # The reporter's own words outrank both the keyword scan and the transcripts.
+            out.append(f"{tid}: newest comment says \"{veto_phrase}\" — do NOT close. "
+                       f"Any 'resolved' wording in it is noise; the ticket is correctly `{cu}`.")
+        elif ambiguity_line and cu in OPEN_STATUSES:
+            out.append(ambiguity_line)
+        elif cu in OPEN_STATUSES and RESOLVED_COMMENT_RE.search(comment):
+            out.append(f"{tid}: newest comment reads as RESOLVED but the ticket is still "
+                       f"`{cu}` — close it, or say why it stays open.")
+        elif r["status"] == "likely_addressed" and cu in OPEN_STATUSES:
+            out.append(f"{tid}: transcripts read as done, ClickUp still `{cu}` — close it or re-check.")
+
+        if r["status"] in ("open", "no_mentions_found") and cu in DONE_STATUSES:
+            out.append(f"{tid}: ClickUp `{cu}` but open signals remain — verify before trusting the close.")
+
+        # A separate `if`, not part of the chain above: nothing DISAGREES here, so it is
+        # not a disagreement — it is the absence of anything at all where a human is
+        # waiting, and it composes with whatever else this task triggered.
+        waiting = _waiting_on_a_human(r, now)
+        if waiting:
+            out.append(waiting)
+
+        for kind in ("completion", "open"):
+            for s in r.get(kind, []):
+                for ref in s.get("pr_refs", []):
+                    if ref["state"] == "open":
+                        out.append(f"{tid}: cited {ref['ref']} is still OPEN, not merged — "
+                                   f"the signal that quoted it reads as done.")
+    return out
+
+
+def parse_search_payload(payload):
+    """Return (sessions, self_runs_skipped, skipped_ids) from search-sessions.py output.
+
+    That script now emits an OBJECT rather than a bare list, because the self-run drop was
+    otherwise INVISIBLE downstream: the caller saw only a shorter list and a smaller
+    "N found" header, which is indistinguishable from the sessions not existing.
+
+    The bare-list branch keeps a stale copy of search-sessions.py degrading to "no count"
+    rather than a TypeError mid-report. It exists for a failure nobody would otherwise
+    exercise, so it is pinned by a test rather than trusted.
+    """
+    if isinstance(payload, dict):
+        return (payload.get("sessions", []),
+                payload.get("self_runs_skipped", 0),
+                payload.get("self_runs_skipped_ids", []))
+    return payload, 0, []
+
+
+def skip_note(r):
+    """One line stating what the self-run guard dropped, or "" if it dropped nothing.
+
+    The two stages are reported SEPARATELY, never summed: when the search stage hands over
+    sessions the completion stage never rediscovers, but when search returns nothing,
+    completion falls back to its own corpus scan and a total would count the SAME
+    transcripts twice. Two labelled numbers cannot double-count; one total can.
+
+    A function rather than an inline print so the visibility claim is pinned by a test — a
+    guard nobody can watch fire is indistinguishable from one wired to nothing, and that
+    applies to the line announcing the guard as much as to the guard.
+    """
+    parts = []
+    if r.get("self_runs_skipped_search"):
+        parts.append(f"{r['self_runs_skipped_search']} at session-search")
+    if r.get("self_runs_skipped"):
+        parts.append(f"{r['self_runs_skipped']} at completion")
+    if not parts:
+        return ""
+    return (f"(ignored prior runs of this checker — {', '.join(parts)}; "
+            f"they quote every task ID beside 'merged')")
+
+
+def build_newest_comment(meta):
+    """Assemble the per-task comment record.
+
+    `snippet` is a 200-char DISPLAY truncation; `text` is the full comment and is what the
+    decision logic reads. Deciding on the truncation is how the keep-open veto gets defeated
+    by a sentence reorder — the comment that motivated the veto is 196 characters and
+    cleared the old cap by four.
+    """
+    return {
+        "date": meta.get("date"),
+        "author": meta.get("author"),
+        "snippet": (meta.get("snippet") or "")[:200],
+        "text": meta.get("text") or meta.get("snippet") or "",
+    }
+
+
+def parse_args(args):
+    """Parse the entry point's flags, rejecting anything it does not know.
+
+    This used to be an inline loop ending in `else: i += 1`, which SWALLOWED every
+    unrecognised flag. `--include-self-runs` — documented in SKILL.md as the escape hatch
+    that disables the prior-run guard — was never parsed and never forwarded, so passing it
+    to the command the Quick start tells you to run did nothing at all and the run reported
+    success. A silently-ignored flag is a run that looks like it honoured your request and
+    did not; exiting is the whole point.
+    """
+    opts = {
+        "limit": 3, "since": None, "as_json": False, "verbose": False,
+        "fast": False,
+        # PR resolution defaults ON; results are cached and deduped within a task.
+        "resolve_prs": True, "include_self_runs": False,
+    }
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a == "--limit" and i + 1 < len(args):
+            opts["limit"] = int(args[i + 1]); i += 2
+        elif a == "--since" and i + 1 < len(args):
+            opts["since"] = args[i + 1]; i += 2
+        elif a == "--json":
+            opts["as_json"] = True; i += 1
+        elif a == "--verbose":
+            opts["verbose"] = True; i += 1
+        elif a == "--fast":
+            opts["fast"] = True; i += 1
+        elif a == "--no-resolve-prs":
+            opts["resolve_prs"] = False; i += 1
+        elif a == "--include-self-runs":
+            opts["include_self_runs"] = True; i += 1
+        else:
+            print(f"check-addressed.py: unknown argument {a!r}\n"
+                  f"Usage: check-addressed.py [--limit N] [--since YYYY-MM-DD] [--json] "
+                  f"[--verbose] [--fast] [--no-resolve-prs] [--include-self-runs]",
+                  file=sys.stderr)
+            sys.exit(2)
+    return opts
+
+
+def main():
+    opts = parse_args(sys.argv[1:])
+    limit = opts["limit"]
+    as_json = opts["as_json"]
+    verbose = opts["verbose"]
+    fast = opts["fast"]
+    since = opts["since"]
+    resolve_prs = opts["resolve_prs"]
+    include_self_runs = opts["include_self_runs"]
+
+    # Step 1: Get recent comments
+    recent_args = ["--limit", str(limit), "--json"]
+    if fast:
+        recent_args.append("--fast")
+    out, rc = run_script("recent-comments.py", *recent_args)
+    if rc != 0:
+        print(f"Error fetching comments: {out}", file=sys.stderr)
+        sys.exit(1)
+
+    comments = json.loads(out)
+    if not comments:
+        print("No recent comments from others on assigned tasks.")
+        return
+
+    # Step 2: Extract unique task IDs
+    task_ids = list(dict.fromkeys(c["task_id"] for c in comments))
+
+    # Never read the transcript this check is itself being written into: every task ID
+    # under test appears there by construction, so it self-matches on all of them.
+    self_session = os.environ.get("CLAUDE_CODE_SESSION_ID", "")
+
+    # Step 3+4: Search sessions and check completion, PER TASK.
+    #
+    # This used to merge every task's ID plus four words from every task NAME into one
+    # <=8-term bag and issue a single search. search-sessions.py ANDs its terms, so the
+    # query asked for one session mentioning all four unrelated tasks at once — which
+    # never exists. It returned 0 sessions on every multi-task run, check-completion.py
+    # silently fell back to its own per-task scan, and the report still printed
+    # "sessions_found: 0" describing a search whose result nothing had used.
+    sessions_by_task = {}
+    results = []
+    for tid in task_ids:
+        search_args = ["--limit", "5", "--json"]
+        if since:
+            search_args.extend(["--since", since])
+        if self_session:
+            search_args.extend(["--exclude-session", self_session])
+        if include_self_runs:
+            search_args.append("--include-self-runs")
+        search_args.append(tid)
+
+        out, rc = run_script("search-sessions.py", *search_args)
+        sessions, search_skipped, skipped_ids = [], 0, []
+        if rc != 0:
+            print(f"Error searching sessions for {tid}: {out}", file=sys.stderr)
+        else:
+            sessions, search_skipped, skipped_ids = parse_search_payload(json.loads(out))
+        sessions_by_task[tid] = sessions
+
+        check_args = ["--task", tid, "--json"]
+        for s in sessions[:5]:
+            check_args.extend(["--session", s["session_id"]])
+        if self_session:
+            check_args.extend(["--exclude-session", self_session])
+        # The self-runs the SEARCH stage already dropped, so the completion stage cannot
+        # rediscover and re-count the same transcripts — without this the two stages'
+        # counts overlap and the report names one set of files twice.
+        for sid in skipped_ids:
+            check_args.extend(["--exclude-session", sid])
+        if include_self_runs:
+            check_args.append("--include-self-runs")
+        if resolve_prs:
+            check_args.append("--resolve-prs")
+
+        out, rc = run_script("check-completion.py", *check_args)
+        if rc == 0:
+            task_results = json.loads(out)
+            if task_results:
+                task_results[0]["sessions"] = [
+                    {"id": s["session_id"], "date": s["date"], "hits": s["hits"]}
+                    for s in sessions[:3]
+                ]
+                # The ticket's own state, carried through from ClickUp. It is the
+                # authority the transcript scan cannot see, so it is reported beside
+                # every verdict rather than left in the comments block.
+                meta = next((c for c in comments if c["task_id"] == tid), {})
+                task_results[0]["clickup_status"] = meta.get("task_status")
+                task_results[0]["clickup_priority"] = meta.get("task_priority")
+                task_results[0]["newest_comment"] = build_newest_comment(meta)
+                task_results[0]["self_runs_skipped_search"] = search_skipped
+                results.append(task_results[0])
+
+    # Step 5: Build report
+    report = {
+        "comments": comments,
+        "sessions_found": sum(len(v) for v in sessions_by_task.values()),
+        "sessions_by_task": {k: len(v) for k, v in sessions_by_task.items()},
+        "excluded_self_session": self_session or None,
+        "task_status": results,
+    }
+
+    if as_json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(f"## Recent Comments ({len(comments)})\n")
+        for c in comments:
+            print(f"- **{c['task_name'][:50]}** ({c['task_id']})")
+            print(f"  {c['date']} by @{c['author']}: {c['snippet'][:100]}")
+            print()
+
+        for tid, tsessions in sessions_by_task.items():
+            if not tsessions:
+                continue
+            print(f"\n## Matching Sessions for {tid} ({len(tsessions)} found)\n")
+            show = tsessions if verbose else tsessions[:3]
+            for s in show:
+                print(f"- [{s['date']}] {s['project']} — {s['hits']} hits")
+                print(f"  {s['opening'][:100]}")
+                print(f"  `claude --resume {s['session_id']}`")
+                if verbose:
+                    terms_str = ", ".join(f"{t}({c})" for t, c in s.get("term_hits", {}).items())
+                    print(f"  terms: {terms_str}")
+                    print(f"  file: {s.get('file', '?')}")
+                print()
+
+        print(f"\n## Task Completion Status\n")
+        print(f"{MARKER_LEGEND}\n")
+        for r in results:
+            status_icon = {"likely_addressed": "✅", "partially_addressed": "⚠️", "open": "🔴", "unclear": "❓", "no_sessions_found": "🔍", "no_mentions_found": "🔍"}.get(r["status"], "?")
+            cu = r.get("clickup_status") or "?"
+            prio = r.get("clickup_priority") or "-"
+            print(f"{status_icon} **{r['task_id']}** — transcripts say `{r['status']}` "
+                  f"(searched {r['sessions_searched']} sessions, {r.get('mentions_found', 0)} mentions)")
+            print(f"     ClickUp says: **{cu}** / prio {prio}")
+            note = skip_note(r)
+            if note:
+                print(f"     {note}")
+            nc = r.get("newest_comment") or {}
+            if nc.get("snippet"):
+                print(f"     newest comment [{nc.get('date')}] @{nc.get('author')}: {nc['snippet'][:110]}")
+
+            show_completion = r.get("completion", []) if verbose else r.get("completion", [])[:3]
+            show_open = r.get("open", []) if verbose else r.get("open", [])[:3]
+            for glyph, group in (("✓", show_completion), ("○", show_open)):
+                for s in group:
+                    print(signal_line(glyph, s, verbose))
+                    for ref in s.get("pr_refs", []):
+                        print(f"      ↳ {ref['ref']}: {ref['state']}")
+            print()
+
+        # Summary
+        addressed = sum(1 for r in results if r["status"] == "likely_addressed")
+        partial = sum(1 for r in results if r["status"] == "partially_addressed")
+        open_count = sum(1 for r in results if r["status"] == "open")
+        unclear = sum(1 for r in results
+                      if r["status"] in ("unclear", "no_sessions_found", "no_mentions_found"))
+        print(f"## Summary: {addressed} addressed, {partial} partial, {open_count} open, {unclear} unclear")
+
+        flags = disagreements(results)
+        if flags:
+            print("\n## Needs a decision\n")
+            for f in flags:
+                print(f"⚠️  {f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-clickup-addressed/check-completion.py
+++ b/scripts/check-clickup-addressed/check-completion.py
@@ -1,0 +1,591 @@
+#!/usr/bin/env python3
+"""Read session transcripts and extract completion signals for given task IDs.
+
+Usage:
+    python3 check-completion.py [--session SESSION_ID] [--task TASK_ID] [--json] [--window N]
+
+Without arguments: reads recent-comments.py output, finds sessions for each task,
+and checks completion status.
+
+Output: per-task summary with completion signals.
+
+The --window flag controls how many characters around each task ID mention to search
+for signals (default: 2000). Signals closer to the task ID mention are weighted higher.
+"""
+import json, os, re, sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _selfrun import is_self_run  # noqa: E402
+
+CLAUDE_DIR = Path.home() / ".claude" / "projects"
+
+# Shape of a ClickUp task ID in this workspace (e.g. 868ktvqf9). Used to detect when a
+# signal inside a task's text window actually belongs to a DIFFERENT task — the window is
+# ±window_size characters wide, so a triage table listing several tasks puts each task's
+# verdict inside every other task's window.
+# NOTE: if a workspace ever issues IDs that don't match this, the attribution guard
+# degrades to "no rival IDs visible" and keeps the signal — it fails OPEN, not closed.
+TASK_ID_RE = re.compile(r"\b868[a-z0-9]{6}\b", re.IGNORECASE)
+
+# Signals that indicate completion
+COMPLETION_PATTERNS = [
+    (r"#[0-9]+.*(?:merged|landed|shipped|deployed)", "PR merged"),
+    (r"(?:merged|landed|shipped|deployed).*#[0-9]+", "PR merged (alt)"),
+    (r"verified.*(?:by content|on (?:main|trunk))", "verified on main"),
+    (r"\bfix(?:ed)?\b.*(?:shipped|merged|deployed|landed)", "fix shipped"),
+    (r"\bresolv(?:ed|es)\b.*(?:by|via|through|in)", "resolved"),
+    (r"✅.*(?:merged|shipped|done|complete|fix)", "completion confirmed"),
+]
+
+# Signals that indicate work is still open.
+#
+# "still running" and "still waiting" used to sit in the first alternation. They are
+# overwhelmingly PROCESS state, not ticket state — measured 2026-08-19, every one of them
+# in a real run was noise ("the throwaway Postgres is still running on port 55432", "CI is
+# still running rather than failing", "the mirror agent is still running"). They are kept
+# only in the scoped pattern below, which requires a ticket-ish subject. Narrowing the
+# pattern is preferred to filtering the matches with a denylist of process nouns: the
+# denylist has to enumerate the world, the narrower pattern does not.
+OPEN_PATTERNS = [
+    (r"\bstill (?:open|pending|unresolved|outstanding|unfixed)\b", "still open"),
+    (r"\b(?:ticket|task|issue|it|this)\s+(?:is\s+)?still\s+(?:open|running|waiting|blocked|in progress)\b",
+     "still open (ticket-scoped)"),
+    (r"\bblocked (?:on|by)\b[^.]{0,45}?\b(?:decision|permission|scope|token|credential|review|human|answer|approval|access)\b",
+     "blocked on external"),
+    (r"\bleft open\b", "left open"),
+    (r"\bnot (?:yet )?(?:done|fixed|deployed|merged|resolved|shipped|complete)\b", "not yet done"),
+    (r"\bpremise (?:refuted|wrong|dead)\b", "premise refuted"),
+    (r"\bneeds? (?:a |its |to be |deciding|re-measure|your call)", "needs action"),
+    (r"\bopen issue\b", "open issue"),
+    (r"deployed ≠ verified", "deployed not verified"),
+    (r"\bnot (?:yet )?deployed\b", "not deployed yet"),
+]
+
+
+# Repos whose PRs get cited in these transcripts by bare name. A citation naming no repo
+# is reported UNRESOLVED rather than guessed — guessing produces a confident wrong state.
+#
+# 🔴 This is a CLOSED VOCABULARY, and widening it is NOT the fix on its own — exactly as
+# with the ClickUp status sets in check-addressed.py, adding entries only moves the silence
+# to the next repo nobody thought of. What makes the next miss visible is the MESSAGE:
+# a `#N` whose repo word is absent from this table now says so and names the word, rather
+# than claiming no repo was named. Measured 2026-08-21 on the live snippet
+# `| **#4181**, **devrc #591** | merged, verified by content |`: both refs came back
+# "unresolved (repo not named)" although the second one names its repo, so round 2's
+# is-this-PR-actually-open cross-check contributed nothing on the only task in the run with
+# completion signals — while reporting a cause that was false.
+#
+# Owners are verified with `gh repo view <owner>/<name>` before being added, never inferred
+# from the org that owns the neighbouring entries: `devrc` is innovation-upstream/devrc, and
+# civitai/devrc does not exist. The owner is precisely the part a guess gets wrong.
+KNOWN_REPOS = {
+    "talos-infra": "civitai/talos-infra",
+    "civitai": "civitai/civitai",
+    "civitai-orchestration": "civitai/civitai-orchestration",
+    "civitai-image-cacher": "civitai/civitai-image-cacher",
+    "civitai-spine-controller": "civitai/civitai-spine-controller",
+    "cli": "civitai/cli",
+    "storage-resolver": "civitai/storage-resolver",
+    "flipt-state": "civitai/flipt-state",
+    "devrc": "innovation-upstream/devrc",
+}
+# "talos-infra #1065", "civitai#4102", "#1100"
+PR_REF_RE = re.compile(r"(?:\b([a-z][a-z0-9-]{2,})\s*)?#(\d{2,6})\b", re.IGNORECASE)
+
+_pr_cache = {}
+
+
+def resolve_pr(repo, number):
+    """Ask GitHub what a cited PR actually is. Returns a short state string.
+
+    A '#1234 merged' signal is otherwise believed on sight — nothing checks the PR exists,
+    is merged, or belongs to this ticket. On 2026-08-19 this turned a cited-as-done item
+    into an open, unmerged PR (talos-infra #1073).
+    """
+    key = (repo, number)
+    if key in _pr_cache:
+        return _pr_cache[key]
+
+    import subprocess
+    try:
+        r = subprocess.run(
+            ["gh", "pr", "view", str(number), "--repo", repo, "--json", "state,mergedAt,title"],
+            capture_output=True, text=True, timeout=25,
+        )
+        if r.returncode != 0:
+            out = "not found"
+        else:
+            d = json.loads(r.stdout)
+            out = d.get("state", "?").lower()
+            if d.get("mergedAt"):
+                out += f" {d['mergedAt'][:10]}"
+    except (OSError, ValueError, subprocess.SubprocessError):
+        out = "lookup failed"
+
+    _pr_cache[key] = out
+    return out
+
+
+# How far back from a '#' to look for the repo it belongs to. Deliberately short.
+# A snippet-WIDE scan was tried first and was badly wrong: "civitai" appears in almost
+# every snippet here (org name, sibling repo names, prose), so every bare '#N' resolved
+# to civitai/civitai and reported a real but unrelated PR — one citation came back
+# "merged 2024-03-18". Same principle as the task-ID attribution guard: nearest wins,
+# and out of range means unknown rather than guessed.
+REPO_LOOKBEHIND = 30
+
+
+def _repo_for_ref(clean_snippet, match_start, word, default_repo):
+    """Resolve which repo a '#N' belongs to. Returns (repo_or_None, reason_or_None).
+
+    Returning None (-> "unresolved") is deliberate. Guessing yields a confident state for
+    the WRONG PR, which is worse than admitting the citation is ambiguous.
+
+    🔴 But there are THREE different ways to fail here, and until 2026-08-21 all three
+    rendered as the single string "unresolved (repo not named)" — which is TRUE of only one
+    of them. The other two are false explanations, and a false explanation is worse than a
+    vague one because it stops the reader looking:
+
+      "not_named"   nothing repo-ish before the '#' and no known repo within
+                    REPO_LOOKBEHIND. The message is correct; the refusal to guess is the
+                    round-2 fix and stays.
+      "unknown"     a word IS sitting on the '#' but is absent from KNOWN_REPOS. The repo
+                    was named. Saying it was not sends the reader nowhere; naming it sends
+                    them to the table. (This word is reported as-written, with no attempt
+                    to classify it as repo-shaped — 'devrc' and 'landed' are
+                    indistinguishable to any rule that does not enumerate the world, and a
+                    reader can tell them apart at a glance where a heuristic cannot.)
+      "ambiguous"   two or more KNOWN repos in range and none adjacent. Repos were named;
+                    the problem is that more than one was. Naming the candidates is what
+                    lets the reader disambiguate by eye.
+
+    The reason is data, not prose: annotate_pr_refs renders it. Resolution order matches
+    the pre-2026-08-21 control flow exactly, so no citation changes repo — only the text of
+    a failure changes, plus the three repos added to KNOWN_REPOS.
+    """
+    if word and word.lower() in KNOWN_REPOS:
+        return KNOWN_REPOS[word.lower()], None
+
+    back = clean_snippet[max(0, match_start - REPO_LOOKBEHIND):match_start]
+    named = {KNOWN_REPOS[k] for k in KNOWN_REPOS if re.search(rf"\b{re.escape(k)}\b", back, re.I)}
+    if len(named) == 1:
+        return next(iter(named)), None
+
+    if default_repo:
+        return default_repo, None
+    if len(named) > 1:
+        return None, ("ambiguous", sorted(named))
+    if word:
+        return None, ("unknown", word)
+    return None, ("not_named", None)
+
+
+def _unresolved_state(reason):
+    """Render a resolution failure as the operator-facing string.
+
+    Each variant says what is actually wrong AND what to do about it. The unknown-repo
+    variant names KNOWN_REPOS explicitly: D6's lesson is that the announcement, not the
+    widened vocabulary, is what makes the next miss visible.
+    """
+    kind, detail = reason
+    if kind == "unknown":
+        return (f"unresolved (repo {detail!r} is not in KNOWN_REPOS — add it to "
+                f"check-completion.py, owner verified, if it is a real repo)")
+    if kind == "ambiguous":
+        return f"unresolved (ambiguous — {', '.join(detail)} both in range, neither adjacent)"
+    return "unresolved (repo not named)"
+
+
+def annotate_pr_refs(signals, default_repo=None):
+    """Attach real PR state to any signal citing a PR number. Mutates and returns."""
+    for s in signals:
+        # No markdown stripping: the bounded lookbehind already sees past `**`/`` ` ``
+        # between a repo name and its '#'. A strip step was tried and every mutation of
+        # it survived the suite — it was doing nothing the lookbehind did not.
+        clean = s.get("snippet", "")
+        refs, seen = [], set()
+        for m in PR_REF_RE.finditer(clean):
+            word, num = m.group(1), m.group(2)
+            if num in seen:
+                continue
+            seen.add(num)
+            repo, reason = _repo_for_ref(clean, m.start(), word, default_repo)
+            if not repo:
+                refs.append({"ref": f"#{num}", "state": _unresolved_state(reason)})
+            else:
+                refs.append({"ref": f"{repo}#{num}", "state": resolve_pr(repo, num)})
+        if refs:
+            s["pr_refs"] = refs
+    return signals
+
+
+def session_path(session_id):
+    """Locate a session transcript by ID, or None."""
+    for project_dir in CLAUDE_DIR.iterdir():
+        if not project_dir.is_dir():
+            continue
+        path = project_dir / f"{session_id}.jsonl"
+        if path.exists():
+            return path
+    return None
+
+
+def load_session_text(session_id):
+    """Load all text from a session by ID."""
+    path = session_path(session_id)
+    return _read_session(path) if path else ""
+
+
+def _read_session(path):
+    """Read user AND assistant text from a transcript.
+
+    This used to read assistant text only, while search-sessions.py matched on user text
+    too — so a session could be selected on a user-only mention of the task and then
+    report `mentions_found: 0` when read here. It also meant a human writing "this is
+    still broken" was invisible to every verdict. The two stages now agree on what a
+    session contains.
+    """
+    texts = []
+    with open(path, errors="replace") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            obj = json.loads(line)
+            if obj.get("type") in ("assistant", "user"):
+                msg = obj.get("message", {})
+                if isinstance(msg, dict):
+                    content = msg.get("content", "")
+                else:
+                    content = str(msg)
+                if isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            texts.append(block.get("text", ""))
+                elif content:
+                    texts.append(str(content))
+    return "\n".join(texts)
+
+
+def extract_text_windows(text, task_id, window_size=2000):
+    """Extract text windows around each EXACT mention of task_id.
+
+    Returns list of (window_text, distance_from_mention, mention_offset) tuples, where
+    mention_offset is the index of the task ID *within that window* — the anchor the
+    attribution guard measures against.
+
+    Deliberately exact-match only. A 6-character-prefix match used to be added here at a
+    nominal distance of 100; it bought nothing (ClickUp always hands us the full ID) and
+    fed the window with neighbouring tasks that share a prefix.
+    """
+    windows = []
+    text_lower = text.lower()
+    task_lower = task_id.lower()
+
+    start = 0
+    while True:
+        pos = text_lower.find(task_lower, start)
+        if pos == -1:
+            break
+
+        window_start = max(0, pos - window_size)
+        window_end = min(len(text), pos + len(task_id) + window_size)
+        windows.append((text[window_start:window_end], 0, pos - window_start))
+
+        start = pos + len(task_id)
+
+    return windows
+
+
+def _nearest_task_id(window_text, match_start, match_end, task_id, mention_offset):
+    """Return the task ID lexically nearest to a matched signal, lowercased.
+
+    The window is anchored on `task_id` at `mention_offset`, but may contain other task
+    IDs. A signal belongs to whichever ID sits closest to it.
+    """
+    candidates = [(task_id.lower(), mention_offset)]
+    for m in TASK_ID_RE.finditer(window_text):
+        candidates.append((m.group(0).lower(), m.start()))
+
+    def gap(pos):
+        if pos < match_start:
+            return match_start - pos
+        if pos > match_end:
+            return pos - match_end
+        return 0
+
+    return min(candidates, key=lambda c: gap(c[1]))[0]
+
+
+def extract_signals_from_windows(windows, patterns, task_id=None):
+    """Find matching patterns in text windows, weighted by proximity.
+    
+    Returns list of (pattern_desc, matched_snippet, proximity_score) tuples.
+    If task_id is provided, signals that mention the task ID get a proximity boost.
+    """
+    signals = []
+    seen = set()  # Deduplicate by (pattern, snippet)
+
+    for window_text, distance, mention_offset in windows:
+        for pattern, desc in patterns:
+            for m in re.finditer(pattern, window_text, re.IGNORECASE):
+                # Attribution guard: a window is wide enough to swallow neighbouring
+                # tasks' verdicts. Keep the signal only if THIS task is the nearest ID.
+                if task_id and _nearest_task_id(
+                    window_text, m.start(), m.end(), task_id, mention_offset
+                ) != task_id.lower():
+                    continue
+
+                start = max(0, m.start() - 40)
+                end = min(len(window_text), m.end() + 40)
+                snippet = window_text[start:end].replace("\n", " ").strip()
+
+                # Deduplicate
+                key = (desc, snippet[:80])
+                if key in seen:
+                    continue
+                seen.add(key)
+
+                # Proximity score: closer = higher score
+                proximity_score = 1.0 / (1.0 + distance)
+
+                # Boost if snippet mentions the task ID
+                if task_id and task_id.lower() in snippet.lower():
+                    proximity_score *= 1.5
+
+                signals.append((desc, snippet, proximity_score))
+
+    # Sort by proximity score (highest first)
+    signals.sort(key=lambda x: x[2], reverse=True)
+    return signals
+
+
+# The score `extract_signals_from_windows` emits is an ADJACENCY weight, not a distance.
+# Production windows all carry distance 0, so the only thing that varies is the x1.5 boost
+# applied when the task ID falls inside the signal's own +/-40-char snippet. This threshold
+# sits between the two values production can emit, so the marker reports that — and only
+# that. It used to be `prox > 0.5`, which every production signal cleared, so the report
+# printed ● for a signal 2000 characters from the mention exactly as for an adjacent one.
+ADJACENCY_MARK = 1.25
+
+
+def confidence_marker(signal):
+    """● = the task ID is inside this signal's own snippet; ○ = merely in the same window.
+
+    ○ is the one to distrust: a +/-2000-char window is wide enough that "merely in the same
+    window" can mean a different paragraph about different work.
+    """
+    return "●" if signal.get("proximity", 0) >= ADJACENCY_MARK else "○"
+
+
+def check_task(task_id, session_ids=None, window_size=2000, exclude_sessions=None,
+               resolve_prs=False, include_self_runs=False):
+    """Check completion status for a task across sessions.
+
+    Uses windowed search: only looks for signals within ±window_size characters
+    of each task ID mention, and weights signals by proximity.
+
+    `exclude_sessions` drops named sessions before reading them — used to keep the check
+    from reading its OWN transcript, in which every task ID under test necessarily appears.
+
+    That covers the CURRENT run only. A PRIOR run of this checker is the same defect one
+    day later, and worse: its report prints each task ID beside "likely_addressed" / "✓
+    resolved" / "merged", so it scores as strong, close, on-topic evidence. Unless
+    `include_self_runs`, any transcript `_selfrun.is_self_run` recognises is dropped too.
+    """
+    excluded = {s for s in (exclude_sessions or []) if s}
+    self_runs_skipped = 0
+
+    if not session_ids:
+        # Search for the task ID in all sessions
+        session_ids, self_runs_skipped = _find_sessions_for_task(
+            task_id, excluded, include_self_runs)
+    else:
+        session_ids = [s for s in session_ids if s not in excluded]
+        if not include_self_runs:
+            kept = []
+            for sid in session_ids:
+                p = session_path(sid)
+                if p is not None and is_self_run(p):
+                    self_runs_skipped += 1
+                else:
+                    kept.append(sid)
+            session_ids = kept
+
+    all_text = ""
+    for sid in session_ids:
+        all_text += load_session_text(sid) + "\n"
+
+    if not all_text.strip():
+        return {
+            "task_id": task_id, "status": "no_sessions_found",
+            "sessions_searched": len(session_ids), "mentions_found": 0,
+            "self_runs_skipped": self_runs_skipped,
+            "completion": [], "open": [],
+        }
+
+    # Extract text windows around task ID mentions
+    windows = extract_text_windows(all_text, task_id, window_size)
+
+    if not windows:
+        # The task ID appears nowhere in the sessions we read, so nothing in them can be
+        # attributed to it. There used to be a full-text fallback here that scored every
+        # signal in the corpus at a hardcoded proximity of 0.5; because the "close" tier
+        # below requires > 0.5, its results could never reach it and always fell through
+        # to `completion and open_items` -> "partially_addressed". Any unmatched task in a
+        # corpus containing one "#N merged" and one "still running" was labelled
+        # partially-addressed by construction, citing other tasks' work as its evidence.
+        return {
+            "task_id": task_id, "status": "no_mentions_found",
+            "sessions_searched": len(session_ids), "mentions_found": 0,
+            "self_runs_skipped": self_runs_skipped,
+            "completion": [], "open": [],
+        }
+
+    completion = extract_signals_from_windows(windows, COMPLETION_PATTERNS, task_id)
+    open_items = extract_signals_from_windows(windows, OPEN_PATTERNS, task_id)
+
+    # Convert to output format, limit to top 5
+    completion = [{"signal": s, "snippet": n, "proximity": round(p, 2)} for s, n, p in completion[:5]]
+    open_items = [{"signal": s, "snippet": n, "proximity": round(p, 2)} for s, n, p in open_items[:5]]
+
+    if resolve_prs:
+        annotate_pr_refs(completion)
+        annotate_pr_refs(open_items)
+
+    # Status. A "close" tier keyed on `proximity > 0.5` used to sit in front of these four
+    # branches, with three further branches behind it. It was UNREACHABLE (2026-08-21):
+    # extract_text_windows is the only producer of windows in production and hardcodes
+    # distance 0, so proximity is 1.0 — or 1.5 with the adjacency boost — and nothing could
+    # ever land at or below 0.5. `close_completion` was therefore always == `completion`,
+    # the second tier was dead, and the ●/○ marker it fed printed ● for every signal ever
+    # emitted. It is vestigial from the full-text fallback deleted in round 1, which was
+    # the only thing that ever set a non-unit proximity (a hardcoded 0.5).
+    #
+    # Deleting it changes no verdict. The premise is pinned by
+    # test_production_windows_are_all_distance_zero and
+    # test_every_production_signal_scores_above_the_deleted_threshold — if a producer ever
+    # emits a non-zero distance, those go red and this tier needs rebuilding, because
+    # signals could then fall below the threshold it existed to catch.
+    if completion and not open_items:
+        status = "likely_addressed"
+    elif completion and open_items:
+        status = "partially_addressed"
+    elif open_items and not completion:
+        status = "open"
+    else:
+        status = "unclear"
+
+    return {
+        "task_id": task_id,
+        "status": status,
+        "sessions_searched": len(session_ids),
+        "mentions_found": len(windows),
+        "self_runs_skipped": self_runs_skipped,
+        "completion": completion,
+        "open": open_items,
+    }
+
+
+def _find_sessions_for_task(task_id, excluded=None, include_self_runs=False):
+    """Find session IDs that mention this task ID.
+
+    Returns (session_ids, self_runs_skipped). The count is reported rather than swallowed:
+    a guard nobody can see fire is indistinguishable from one wired to nothing.
+    """
+    excluded = excluded or set()
+    sessions = []
+    skipped = 0
+    for project_dir in CLAUDE_DIR.iterdir():
+        if not project_dir.is_dir():
+            continue
+        for path in project_dir.glob("*.jsonl"):
+            if path.stem in excluded:
+                continue
+            try:
+                with open(path, errors="replace") as f:
+                    for line in f:
+                        if task_id in line:
+                            if not include_self_runs and is_self_run(path):
+                                skipped += 1
+                            else:
+                                sessions.append(path.stem)
+                            break
+            except OSError:
+                continue
+    return sessions, skipped
+
+
+def main():
+    as_json = "--json" in sys.argv
+    task_ids = []
+    session_ids = []
+    window_size = 2000
+    # Default: never read the transcript we are currently writing. Every task ID under
+    # test appears in it by construction, so it is a guaranteed self-match.
+    exclude_sessions = [os.environ.get("CLAUDE_CODE_SESSION_ID", "")]
+    resolve_prs = False
+    include_self_runs = False
+
+    args = [a for a in sys.argv[1:] if a != "--json"]
+    i = 0
+    while i < len(args):
+        if args[i] == "--task" and i + 1 < len(args):
+            task_ids.append(args[i + 1]); i += 2
+        elif args[i] == "--session" and i + 1 < len(args):
+            session_ids.append(args[i + 1]); i += 2
+        elif args[i] == "--exclude-session" and i + 1 < len(args):
+            exclude_sessions.append(args[i + 1]); i += 2
+        elif args[i] == "--include-self":
+            # Debug escape hatch: read everything, this checker's own runs included.
+            exclude_sessions = []; include_self_runs = True; i += 1
+        elif args[i] == "--include-self-runs":
+            include_self_runs = True; i += 1
+        elif args[i] == "--resolve-prs":
+            resolve_prs = True; i += 1
+        elif args[i] == "--window" and i + 1 < len(args):
+            window_size = int(args[i + 1]); i += 2
+        else:
+            # Bare argument = task ID
+            task_ids.append(args[i]); i += 1
+
+    if not task_ids:
+        # Read from stdin (piped from recent-comments.py)
+        if not sys.stdin.isatty():
+            for line in sys.stdin:
+                parts = line.strip().split("\t")
+                if parts:
+                    task_ids.append(parts[0])
+        else:
+            print("Usage: check-completion.py --task TASK_ID [--session SESSION_ID] [--window N]", file=sys.stderr)
+            sys.exit(1)
+
+    results = []
+    for tid in task_ids:
+        result = check_task(
+            tid, session_ids if session_ids else None, window_size,
+            exclude_sessions=exclude_sessions, resolve_prs=resolve_prs,
+            include_self_runs=include_self_runs,
+        )
+        results.append(result)
+
+    if as_json:
+        print(json.dumps(results, indent=2))
+    else:
+        for r in results:
+            print(f"\n=== {r['task_id']} ===")
+            print(f"Status: {r['status']} (searched {r['sessions_searched']} sessions, found {r.get('mentions_found', '?')} mentions)")
+            if r.get("self_runs_skipped"):
+                print(f"  (skipped {r['self_runs_skipped']} transcript(s) that are runs of this checker)")
+            if r["completion"]:
+                print("Completion signals:  (● task ID is inside the snippet · ○ same window only)")
+                for s in r["completion"]:
+                    print(f"  {confidence_marker(s)} {s['signal']}: {s['snippet'][:100]}")
+            if r["open"]:
+                print("Open items:  (● task ID is inside the snippet · ○ same window only)")
+                for s in r["open"]:
+                    print(f"  {confidence_marker(s)} {s['signal']}: {s['snippet'][:100]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-clickup-addressed/recent-comments.py
+++ b/scripts/check-clickup-addressed/recent-comments.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Fetch recent comments on assigned ClickUp tasks, return task IDs + comment metadata.
+
+Usage:
+    python3 recent-comments.py [--limit N] [--json] [--fast]
+
+Output (default): one line per comment, tab-separated:
+    task_id\ttask_name\tcomment_date\tcomment_author\tcomment_snippet
+
+With --json: JSON array of objects.
+
+--fast: Only check the 10 most recently updated tasks (much faster for large backlogs).
+"""
+import subprocess, json, sys, os
+from datetime import datetime, timezone
+
+CLICKUP_DIR = os.environ.get(
+    "CLICKUP_DIR", os.path.expanduser("~/.config/opencode/skills/clickup")
+)
+
+
+def run_clickup(*args):
+    result = subprocess.run(
+        ["node", "query.mjs", *args],
+        capture_output=True, text=True, cwd=CLICKUP_DIR, timeout=120
+    )
+    return result.stdout
+
+
+def get_my_tasks():
+    raw = run_clickup("my-tasks", "--json")
+    lines = raw.split("\n")
+    try:
+        start = next(i for i, l in enumerate(lines) if l.strip().startswith("["))
+        return json.loads("\n".join(lines[start:]))
+    except (StopIteration, json.JSONDecodeError):
+        return []
+
+
+def get_comments(task_id):
+    raw = run_clickup("comments", task_id, "--json")
+    lines = raw.split("\n")
+    try:
+        start = next(i for i, l in enumerate(lines) if l.strip().startswith("["))
+        return json.loads("\n".join(lines[start:]))
+    except (StopIteration, json.JSONDecodeError):
+        return []
+
+
+def get_my_user_id():
+    raw = run_clickup("me")
+    for line in raw.split("\n"):
+        if line.startswith("ID:"):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def extract_text(comment_obj):
+    parts = []
+    for p in comment_obj.get("comment", []):
+        if isinstance(p, dict):
+            parts.append(p.get("text", ""))
+    return " ".join(parts).strip()
+
+
+def task_status(task):
+    """ClickUp returns status as {"status": "to do", ...} or occasionally a bare string."""
+    s = task.get("status")
+    if isinstance(s, dict):
+        return s.get("status")
+    return s
+
+
+def task_priority(task):
+    p = task.get("priority")
+    if isinstance(p, dict):
+        return p.get("priority")
+    return p
+
+
+def format_date(ts_ms):
+    try:
+        dt = datetime.fromtimestamp(int(ts_ms) / 1000, tz=timezone.utc)
+        return dt.strftime("%Y-%m-%d %H:%M")
+    except (ValueError, TypeError, OSError):
+        return str(ts_ms)
+
+
+def main():
+    limit = 3
+    as_json = False
+    fast = False
+    args = sys.argv[1:]
+    i = 0
+    while i < len(args):
+        if args[i] == "--limit" and i + 1 < len(args):
+            limit = int(args[i + 1]); i += 2
+        elif args[i] == "--json":
+            as_json = True; i += 1
+        elif args[i] == "--fast":
+            fast = True; i += 1
+        else:
+            i += 1
+
+    return _collect(limit, fast, as_json)
+
+
+# Display truncation for the report; `text` below is what DECISIONS read.
+SNIPPET_CHARS = 200
+# Generous cap on the analysed text. Not uncapped, because this rides in every report's
+# JSON — but 20x the display cap, because the keep-open veto is absolute and a refusal to
+# close that falls past a truncation boundary silently restores the "close it" instruction.
+# The comment that motivated the veto is 196 characters; it cleared the old 200-char cap by
+# four. See `claude/skills/check-clickup-addressed/reference/validation-history.md` round 4.
+TEXT_CHARS = 4000
+
+
+def build_record(tid, tname, task, comment, text):
+    """One comment row.
+
+    A function, not an inline dict, so the `snippet`/`text` split is pinned by a test. Both
+    ends of that split were tested independently while the JOIN was not — and dropping
+    `text` here silently reverts the whole fix, since the consumer falls back to `snippet`.
+    """
+    return {
+        "task_id": tid,
+        "task_name": tname,
+        # The ticket's OWN state is the authority on whether work is outstanding; the
+        # transcript scan downstream cannot see it. A ticket left at `to do` under a
+        # comment reading "Resolved, recommend closing" is invisible without these two.
+        "task_status": task_status(task),
+        "task_priority": task_priority(task),
+        "date": format_date(comment.get("date", "")),
+        "author": comment.get("user", {}).get("username", "?"),
+        "snippet": text[:SNIPPET_CHARS],
+        "text": text[:TEXT_CHARS],
+    }
+
+
+def _collect(limit, fast, as_json):
+    my_id = get_my_user_id()
+    tasks = get_my_tasks()
+
+    # In fast mode, only check the 10 most recently updated tasks
+    if fast and len(tasks) > 10:
+        tasks = tasks[:10]
+
+    results = []
+    for task in tasks:
+        tid = task["id"]
+        tname = task.get("name", tid)[:80]
+        comments = get_comments(tid)
+        for c in comments:
+            user_id = str(c.get("user", {}).get("id", ""))
+            if user_id == my_id:
+                continue
+            text = extract_text(c)
+            if not text:
+                continue
+            results.append(build_record(tid, tname, task, c, text))
+
+    # Sort newest first, take top N
+    results.sort(key=lambda x: x["date"], reverse=True)
+    results = results[:limit]
+
+    if as_json:
+        print(json.dumps(results, indent=2))
+    else:
+        for r in results:
+            print(f"{r['task_id']}\t{r['task_name']}\t{r['date']}\t@{r['author']}\t{r['snippet'][:120]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-clickup-addressed/recent-comments.py
+++ b/scripts/check-clickup-addressed/recent-comments.py
@@ -115,14 +115,57 @@ SNIPPET_CHARS = 200
 TEXT_CHARS = 4000
 
 
-def build_record(tid, tname, task, comment, text):
+# Sentinel for "we could not identify the user at all", which is NOT the same fact as "the
+# user has not replied". `get_my_user_id()` returns None whenever the ClickUp CLI prints no
+# `ID:` line — auth expiry, a network error, an output-format change — and `run_clickup` does
+# not check the subprocess return code, so this is silent. Without the sentinel the id
+# comparison below never matches, `latest_reply_by` returns None, and the record carries
+# `my_latest_reply: null`, which the consumer reads as the POSITIVE claim "I looked; you never
+# replied". That is the one design property this whole seam exists to protect, defeated on the
+# exact failure mode that produces it. `build_record` omits the key for this value, so the
+# consumer takes its announce-rather-than-decide branch.
+UNIDENTIFIED = object()
+
+
+def latest_reply_by(comments, my_id):
+    """Formatted date of the newest comment authored by `my_id`, or None if there is none.
+
+    The loop below drops every comment of mine, which is right for a report about what
+    OTHER people said — and it is exactly why the downstream "nobody has answered" flag
+    was blind: the evidence that would refute it is removed before the flag ever runs.
+    This carries the one fact across that seam.
+
+    Ranked on the raw epoch-ms, never on the formatted string: `format_date` falls back to
+    `str(ts_ms)` for an unparseable value, so a max() over formatted dates can rank garbage
+    above a real timestamp. Format the winner, not the candidates.
+    """
+    best = None
+    for c in comments:
+        if str(c.get("user", {}).get("id", "")) != my_id:
+            continue
+        try:
+            ts = int(c.get("date", ""))
+        except (ValueError, TypeError):
+            continue
+        if best is None or ts > best:
+            best = ts
+    return format_date(best) if best is not None else None
+
+
+def build_record(tid, tname, task, comment, text, my_latest_reply):
     """One comment row.
 
     A function, not an inline dict, so the `snippet`/`text` split is pinned by a test. Both
     ends of that split were tested independently while the JOIN was not — and dropping
     `text` here silently reverts the whole fix, since the consumer falls back to `snippet`.
+    The same is true of `my_latest_reply`: drop it and the waiting flag goes back to
+    reporting answered tickets as unanswered, with nothing failing.
+
+    `my_latest_reply` is a REQUIRED positional argument rather than a defaulted one. A
+    default would let a caller omit it and get the pre-fix behaviour silently; this way the
+    omission is a TypeError at the only call site.
     """
-    return {
+    rec = {
         "task_id": tid,
         "task_name": tname,
         # The ticket's OWN state is the authority on whether work is outstanding; the
@@ -135,10 +178,22 @@ def build_record(tid, tname, task, comment, text):
         "snippet": text[:SNIPPET_CHARS],
         "text": text[:TEXT_CHARS],
     }
+    # Present-and-null ("I looked; you never replied") is a different fact from absent
+    # ("nobody could look"). The consumer branches on which, so the key is emitted for every
+    # value EXCEPT the UNIDENTIFIED sentinel, whose whole purpose is to reach the absent
+    # branch. Emitting it unconditionally is what turned a failed user lookup into a
+    # confident false negative.
+    if my_latest_reply is not UNIDENTIFIED:
+        rec["my_latest_reply"] = my_latest_reply
+    return rec
 
 
 def _collect(limit, fast, as_json):
     my_id = get_my_user_id()
+    if not my_id:
+        print("recent-comments: WARNING — could not resolve your ClickUp user id, so your "
+              "own comments cannot be distinguished from anyone else's. Every downstream "
+              "'have I already replied?' check is disabled for this run.", file=sys.stderr)
     tasks = get_my_tasks()
 
     # In fast mode, only check the 10 most recently updated tasks
@@ -150,6 +205,14 @@ def _collect(limit, fast, as_json):
         tid = task["id"]
         tname = task.get("name", tid)[:80]
         comments = get_comments(tid)
+        # Computed over the FULL comment list, before the loop below discards mine. When the
+        # user could not be identified at all, the answer is UNKNOWN rather than "no reply" —
+        # see UNIDENTIFIED. Loud on stderr too: a report whose author id is missing cannot
+        # tell your comments from anyone else's, and silence there reads as a normal run.
+        if my_id:
+            my_reply = latest_reply_by(comments, my_id)
+        else:
+            my_reply = UNIDENTIFIED
         for c in comments:
             user_id = str(c.get("user", {}).get("id", ""))
             if user_id == my_id:
@@ -157,7 +220,7 @@ def _collect(limit, fast, as_json):
             text = extract_text(c)
             if not text:
                 continue
-            results.append(build_record(tid, tname, task, c, text))
+            results.append(build_record(tid, tname, task, c, text, my_reply))
 
     # Sort newest first, take top N
     results.sort(key=lambda x: x["date"], reverse=True)

--- a/scripts/check-clickup-addressed/search-sessions.py
+++ b/scripts/check-clickup-addressed/search-sessions.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Search Claude Code session transcripts for keywords, return ranked matches.
+
+Usage:
+    python3 search-sessions.py [--since YYYY-MM-DD] [--limit N] [--project SUBSTR] term1 [term2 ...]
+
+Output (default): one line per match, tab-separated:
+    session_id\tdate\tproject\thits\topening_snippet
+
+With --json: an OBJECT — {"sessions": [...], "self_runs_skipped": N,
+"self_runs_skipped_ids": [...]}. It was a bare array until 2026-08-21; the
+count has to travel with the results or the self-run drop is invisible to the
+caller, which sees only a shorter list.
+
+Terms are ANDed by default (session must match all). Add --any to OR them.
+"""
+import json, os, re, sys
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _selfrun import is_self_run  # noqa: E402
+
+CLAUDE_DIR = Path.home() / ".claude" / "projects"
+
+
+def load_session(path):
+    """Load a session JSONL, return list of (type, content) tuples."""
+    entries = []
+    with open(path, errors="replace") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            obj = json.loads(line)
+            etype = obj.get("type", "")
+            if etype in ("user", "assistant"):
+                msg = obj.get("message", {})
+                if isinstance(msg, dict):
+                    content = msg.get("content", "")
+                else:
+                    content = str(msg)
+                if isinstance(content, list):
+                    # Flatten assistant content blocks
+                    texts = []
+                    for block in content:
+                        if isinstance(block, dict):
+                            if block.get("type") == "text":
+                                texts.append(block.get("text", ""))
+                            elif block.get("type") == "tool_use":
+                                inp = block.get("input", {})
+                                if isinstance(inp, dict):
+                                    texts.append(json.dumps(inp))
+                    content = " ".join(texts)
+                if content:
+                    entries.append((etype, str(content)))
+            elif etype == "ai-title":
+                entries.append(("title", obj.get("aiTitle", "")))
+    return entries
+
+
+def search_sessions(terms, since=None, limit=10, project_substr=None, match_any=False,
+                    exclude_sessions=None, include_self_runs=False, stats=None):
+    """Rank sessions matching `terms`.
+
+    Runs of this checker are dropped by default: a prior run mentions every task ID it was
+    asked about, so it always ranks top (14 hits, on 2026-08-20) and reads as the session
+    that did the work. See `_selfrun.py`.
+
+    Pass `stats` (a dict) to learn how many were dropped — it gets `self_runs_skipped` and
+    `self_runs_skipped_ids`. The count is not returned in the result list because the drop
+    is otherwise INVISIBLE: the caller just sees a shorter list and a smaller "N found"
+    header, which is indistinguishable from the sessions not existing.
+    """
+    exclude = {s for s in (exclude_sessions or []) if s}
+    results = []
+    skipped_ids = []
+    for project_dir in CLAUDE_DIR.iterdir():
+        if not project_dir.is_dir():
+            continue
+        if project_substr and project_substr not in project_dir.name:
+            continue
+        for session_file in project_dir.glob("*.jsonl"):
+            if session_file.stem in exclude:
+                continue
+            mtime = datetime.fromtimestamp(session_file.stat().st_mtime)
+            if since and mtime < since:
+                continue
+            try:
+                entries = load_session(session_file)
+            except (json.JSONDecodeError, OSError):
+                continue
+
+            # Combine all text for matching
+            all_text = " ".join(content for _, content in entries)
+
+            # Count matches per term
+            term_hits = {}
+            for term in terms:
+                count = all_text.lower().count(term.lower())
+                if count > 0:
+                    term_hits[term] = count
+
+            if match_any:
+                matched = len(term_hits) > 0
+            else:
+                matched = len(term_hits) == len(terms)
+
+            if not matched:
+                continue
+
+            # Self-run check runs AFTER term matching, deliberately. It reads the file to
+            # EOF, and a non-matching file is discarded anyway, so testing it first only
+            # bought a full extra read of every transcript in the corpus: measured
+            # 5.6s -> 16.1s over 746 files, once PER TASK. Same result set, 2.8x the cost.
+            if not include_self_runs and is_self_run(session_file):
+                skipped_ids.append(session_file.stem)
+                continue
+
+            total_hits = sum(term_hits.values())
+
+            # Get opening message
+            opening = ""
+            for etype, content in entries:
+                if etype == "user" and content:
+                    opening = content[:150]
+                    break
+                elif etype == "title" and content:
+                    opening = f"[title] {content}"
+
+            # Get project name from dir
+            project = project_dir.name.replace("-home-zach-workspace-", "").replace("-", "/")
+
+            results.append({
+                "session_id": session_file.stem,
+                "date": mtime.strftime("%Y-%m-%d %H:%M"),
+                "project": project,
+                "hits": total_hits,
+                "term_hits": term_hits,
+                "opening": opening[:120],
+                "file": str(session_file),
+            })
+
+    if stats is not None:
+        stats["self_runs_skipped"] = len(skipped_ids)
+        stats["self_runs_skipped_ids"] = skipped_ids
+
+    results.sort(key=lambda x: (len(x["term_hits"]), x["hits"], x["date"]), reverse=True)
+    return results[:limit]
+
+
+def render_payload(results, stats):
+    """The `--json` document.
+
+    An OBJECT, not a bare list: the skip count has to travel with the results or the drop is
+    invisible to check-addressed.py, which then sees only a shorter list — indistinguishable
+    from the sessions not existing. A function so the emitted SHAPE is pinned by a test; the
+    consumer half (`parse_search_payload`) was tested while the producer half was not, so
+    reverting this to a bare list passed the whole suite.
+    """
+    return {"sessions": results, **stats}
+
+
+def main():
+    since_str = None
+    limit = 10
+    project = None
+    match_any = False
+    terms = []
+    exclude_sessions = []
+    include_self_runs = False
+
+    args = sys.argv[1:]
+    i = 0
+    while i < len(args):
+        if args[i] == "--since" and i + 1 < len(args):
+            since_str = args[i + 1]; i += 2
+        elif args[i] == "--limit" and i + 1 < len(args):
+            limit = int(args[i + 1]); i += 2
+        elif args[i] == "--project" and i + 1 < len(args):
+            project = args[i + 1]; i += 2
+        elif args[i] == "--exclude-session" and i + 1 < len(args):
+            exclude_sessions.append(args[i + 1]); i += 2
+        elif args[i] == "--include-self-runs":
+            include_self_runs = True; i += 1
+        elif args[i] == "--any":
+            match_any = True; i += 1
+        elif args[i] == "--json":
+            i += 1  # handled below
+        else:
+            terms.append(args[i]); i += 1
+
+    if not terms:
+        print("Usage: search-sessions.py [--since YYYY-MM-DD] [--limit N] term1 [term2 ...]", file=sys.stderr)
+        sys.exit(1)
+
+    since = None
+    if since_str:
+        since = datetime.strptime(since_str, "%Y-%m-%d")
+
+    as_json = "--json" in sys.argv
+
+    stats = {}
+    results = search_sessions(terms, since=since, limit=limit, project_substr=project,
+                              match_any=match_any, exclude_sessions=exclude_sessions,
+                              include_self_runs=include_self_runs, stats=stats)
+
+    if as_json:
+        print(json.dumps(render_payload(results, stats), indent=2))
+    else:
+        if stats.get("self_runs_skipped"):
+            print(f"(skipped {stats['self_runs_skipped']} transcript(s) that are runs of "
+                  f"this checker: {', '.join(stats['self_runs_skipped_ids'])})")
+            print()
+        for r in results:
+            terms_str = ", ".join(f"{t}({c})" for t, c in r["term_hits"].items())
+            print(f"{r['session_id']}\t{r['date']}\t{r['project']}\t{r['hits']} hits\t{terms_str}")
+            print(f"  opening: {r['opening']}")
+            print(f"  file: {r['file']}")
+            print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-clickup-addressed/tests/run_all.py
+++ b/scripts/check-clickup-addressed/tests/run_all.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Run all tests for check-clickup-addressed skill."""
+import shutil, sys
+from pathlib import Path
+
+TEST_DIR = Path(__file__).parent
+
+
+def run_test_file(test_file):
+    """Run a test file and return (passed, failed).
+
+    🔴 An IMPORT failure is counted as a FAILURE, not allowed to crash the run.
+
+    Until 2026-08-21 a module that failed to import raised straight out of `main()`: no
+    further test files ran, and — the part that actually did damage — **no `Total:` line was
+    printed at all**. Every reader of this suite, including this skill's own docs, is told to
+    read that line rather than an exit code. An absent line reads as nothing rather than as
+    failure, and through a `grep -E '✗|Total:'` filter it is literally empty output.
+
+    That is how a `_selfrun.py` with a SyntaxError was committed and pushed as "122 passed":
+    a stale `__pycache__/_selfrun.cpython-312.pyc` served the pre-edit bytecode for one run
+    (`PYTHONDONTWRITEBYTECODE=1` stops bytecode being WRITTEN, never READ), and when the
+    cache was gone the suite crashed instead of reporting. Both halves now fail loudly:
+    the count below, and the cache purge in `main()`.
+    """
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(test_file.stem, test_file)
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except BaseException as e:                      # SyntaxError, ImportError, SystemExit…
+        print(f"  ✗ {test_file.name}: FAILED TO IMPORT — {type(e).__name__}: {e}")
+        return 0, 1
+
+    tests = [v for k, v in vars(module).items() if k.startswith("test_")]
+    if not tests:
+        # A module that collects zero tests is indistinguishable from a passing one in the
+        # totals. Say so; a suite silently covering nothing is this skill's own headline bug.
+        print(f"  ✗ {test_file.name}: collected 0 tests")
+        return 0, 1
+    passed = 0
+    failed = 0
+    
+    for test in tests:
+        try:
+            test()
+            print(f"  ✓ {test.__name__}")
+            passed += 1
+        except SystemExit as e:
+            # SystemExit is a BaseException, so a bare `except Exception` does NOT catch it
+            # and it propagates out of main(), killing the whole run: no further test files,
+            # no "Total: N passed, M failed" line, and an exit code a reader is told
+            # elsewhere in this skill not to trust. Found by the round-4 mutation sweep,
+            # where a mutant made parse_args reject a flag a test passes it; the mutant
+            # scored HARNESS ERROR rather than KILLED. Any code under test that calls
+            # sys.exit() has this shape.
+            print(f"  ✗ {test.__name__}: SystemExit({e.code}) escaped the test")
+            failed += 1
+        except Exception as e:
+            print(f"  ✗ {test.__name__}: {e}")
+            failed += 1
+
+    return passed, failed
+
+
+def _purge_bytecode():
+    """Delete every `__pycache__` under the skill before importing anything.
+
+    🔴 `PYTHONDONTWRITEBYTECODE=1` prevents bytecode being WRITTEN. It does nothing about
+    bytecode being READ, and CPython validates a cached module on source mtime-in-whole-
+    SECONDS plus size — so an edit that lands in the same second as the last import and
+    happens not to change the size is invisible, and the ORIGINAL module is imported.
+
+    Measured 2026-08-21: a `_selfrun.py` edited into a SyntaxError imported cleanly from a
+    stale `.pyc` and the suite reported "122 passed, 0 failed". It was committed and pushed
+    on the strength of that line. The scripts here are edited constantly by mutation
+    batteries and by hand, which is exactly the workload the mtime heuristic mis-serves.
+    """
+    for cache in (TEST_DIR.parent).rglob("__pycache__"):
+        shutil.rmtree(cache, ignore_errors=True)
+
+
+def main():
+    _purge_bytecode()
+    test_files = sorted(TEST_DIR.glob("test_*.py"))
+
+    total_passed = 0
+    total_failed = 0
+
+    for test_file in test_files:
+        print(f"\n--- {test_file.name} ---")
+        passed, failed = run_test_file(test_file)
+        total_passed += passed
+        total_failed += failed
+    
+    print(f"\n{'='*40}")
+    print(f"Total: {total_passed} passed, {total_failed} failed")
+    
+    return 1 if total_failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-clickup-addressed/tests/test_attribution.py
+++ b/scripts/check-clickup-addressed/tests/test_attribution.py
@@ -1,0 +1,633 @@
+#!/usr/bin/env python3
+"""Regression tests for the three defects that made this checker report confident
+false positives (2026-08-19).
+
+Each test below was watched failing against the pre-fix scripts; the matrix is in
+`claude/skills/check-clickup-addressed/reference/validation-history.md`. Tests marked INVARIANT
+GUARD passed at base too and are labelled as such — they are controls, not coverage.
+
+  D1  a task ID that appears in NO session fell through to a full-text scan over the
+      whole corpus at a hardcoded proximity of 0.5, which the "close" tier (> 0.5) can
+      never accept, so every such task landed on "partially_addressed" citing other
+      tasks' signals.
+  D2  a +/-2000-char window swallows neighbouring rows of a multi-task triage table, so
+      one task's "#N merged" was reported as another task's completion signal.
+  D3  the checker read the transcript it was being written into, which mentions every
+      task ID under test by construction.
+"""
+import json, sys, tempfile
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import importlib.util
+spec = importlib.util.spec_from_file_location("check_completion", SCRIPT_DIR / "check-completion.py")
+check_completion = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check_completion)
+
+spec2 = importlib.util.spec_from_file_location("search_sessions", SCRIPT_DIR / "search-sessions.py")
+search_sessions = importlib.util.module_from_spec(spec2)
+spec2.loader.exec_module(search_sessions)
+
+spec3 = importlib.util.spec_from_file_location("check_addressed", SCRIPT_DIR / "check-addressed.py")
+check_addressed = importlib.util.module_from_spec(spec3)
+spec3.loader.exec_module(check_addressed)
+
+import _selfrun as selfrun  # noqa: E402  (SCRIPT_DIR is on sys.path above)
+
+TARGET = "868krn3y1"   # the task under test
+RIVAL = "868kr07fu"    # a different task whose verdict sits in the same window
+
+
+def _session(tmpdir, session_id, *texts):
+    """Write a mock session transcript and point CLAUDE_DIR at it."""
+    mock_dir = Path(tmpdir) / ".claude" / "projects" / "test-project"
+    mock_dir.mkdir(parents=True, exist_ok=True)
+    with open(mock_dir / f"{session_id}.jsonl", "w") as f:
+        for t in texts:
+            f.write(json.dumps(
+                {"type": "assistant", "message": {"content": [{"type": "text", "text": t}]}}
+            ) + "\n")
+    return mock_dir.parent
+
+
+# --------------------------------------------------------------------------- D1
+
+def test_no_mentions_is_not_partially_addressed():
+    """D1: a task mentioned nowhere must not borrow another task's signals.
+
+    Pre-fix this returned "partially_addressed" with 5 completion + 5 open signals, none
+    of which mentioned the task. The corpus below deliberately contains one completion
+    phrase and one open phrase so the old fallback had something to find.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _session(tmp, "s1", "PR #348 merged. The mirror agent is still running.")
+        orig, check_completion.CLAUDE_DIR = check_completion.CLAUDE_DIR, root
+        try:
+            r = check_completion.check_task("868kt8pfu", session_ids=["s1"])
+        finally:
+            check_completion.CLAUDE_DIR = orig
+
+    assert r["status"] == "no_mentions_found", \
+        f"unmentioned task must report no_mentions_found, got {r['status']!r}"
+    assert r["completion"] == [], f"must cite no completion signals, got {r['completion']}"
+    assert r["open"] == [], f"must cite no open signals, got {r['open']}"
+    assert r["mentions_found"] == 0
+
+
+def test_no_mentions_positive_control():
+    """Control for the test above: the SAME corpus, with the task ID present, must still
+    produce signals. Without this, D1's fix could pass by returning nothing for
+    everything."""
+    with tempfile.TemporaryDirectory() as tmp:
+        # NB: the open phrase here must be TICKET state. An earlier version of this
+        # fixture said "the mirror agent is still running", which the tightened
+        # OPEN_PATTERNS correctly no longer match — the control was asserting on noise.
+        root = _session(tmp, "s1", "868kt8pfu: PR #348 merged. The ticket is still open.")
+        orig, check_completion.CLAUDE_DIR = check_completion.CLAUDE_DIR, root
+        try:
+            r = check_completion.check_task("868kt8pfu", session_ids=["s1"])
+        finally:
+            check_completion.CLAUDE_DIR = orig
+
+    assert r["mentions_found"] == 1
+    assert r["completion"], "positive control found no completion signal — guard is inert"
+    assert r["open"], "positive control found no open signal — guard is inert"
+    assert r["status"] == "partially_addressed"
+
+
+# --------------------------------------------------------------------------- D2
+
+def test_rival_task_signal_is_not_attributed_to_target():
+    """D2: a signal sitting next to a DIFFERENT task's ID must not count for this one.
+
+    Shaped like the real triage table that produced the bug: two rows, each a task ID
+    followed by its own verdict. Asking about TARGET must not return RIVAL's merge.
+    """
+    window = (
+        f"| {RIVAL} | talos-infra #1065 merged 08-16, root cause fixed |\n"
+        f"| {TARGET} | no work recorded yet |\n"
+    )
+    offset = window.index(TARGET)
+    signals = check_completion.extract_signals_from_windows(
+        [(window, 0, offset)], check_completion.COMPLETION_PATTERNS, TARGET
+    )
+    assert signals == [], (
+        "a completion signal adjacent to a rival task ID was attributed to the target: "
+        f"{[s[1] for s in signals]}"
+    )
+
+
+def test_own_signal_survives_the_attribution_guard():
+    """Positive control for D2 — the guard must not simply drop everything. Same table
+    shape, but now we ask about the task the merge actually belongs to."""
+    window = (
+        f"| {RIVAL} | talos-infra #1065 merged 08-16, root cause fixed |\n"
+        f"| {TARGET} | no work recorded yet |\n"
+    )
+    offset = window.index(RIVAL)
+    signals = check_completion.extract_signals_from_windows(
+        [(window, 0, offset)], check_completion.COMPLETION_PATTERNS, RIVAL
+    )
+    assert signals, "the guard dropped a signal that genuinely belongs to this task"
+    assert any("1065" in s[1] for s in signals)
+
+
+def test_nearest_task_id_picks_the_closer_of_two():
+    """Unit-level check on the discriminator itself, at both ends: the same window, the
+    same two IDs, a signal placed near each in turn."""
+    w = f"{RIVAL} shipped it. Much later in the row, {TARGET} is untouched."
+    near_rival = w.index("shipped")
+    assert check_completion._nearest_task_id(w, near_rival, near_rival + 7, TARGET, w.index(TARGET)) == RIVAL
+    near_target = w.index("untouched")
+    assert check_completion._nearest_task_id(w, near_target, near_target + 9, TARGET, w.index(TARGET)) == TARGET
+
+
+# --------------------------------------------------------------------------- D3
+
+def test_excluded_session_is_not_read():
+    """D3: the check must be able to skip its own transcript."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _session(tmp, "self-sess", f"{TARGET} PR #999 merged and verified on main.")
+        orig, check_completion.CLAUDE_DIR = check_completion.CLAUDE_DIR, root
+        try:
+            included = check_completion.check_task(TARGET, session_ids=["self-sess"])
+            excluded = check_completion.check_task(
+                TARGET, session_ids=["self-sess"], exclude_sessions=["self-sess"]
+            )
+        finally:
+            check_completion.CLAUDE_DIR = orig
+
+    assert included["completion"], "positive control: the session should match when included"
+    assert excluded["status"] == "no_sessions_found", \
+        f"excluded session was still read, got {excluded['status']!r}"
+    assert excluded["completion"] == []
+
+
+def test_search_sessions_honours_exclude():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _session(tmp, "self-sess", f"working on {TARGET}")
+        orig, search_sessions.CLAUDE_DIR = search_sessions.CLAUDE_DIR, root
+        try:
+            found = search_sessions.search_sessions([TARGET])
+            hidden = search_sessions.search_sessions([TARGET], exclude_sessions=["self-sess"])
+        finally:
+            search_sessions.CLAUDE_DIR = orig
+
+    assert len(found) == 1, "positive control: the session must be findable when not excluded"
+    assert hidden == [], f"excluded session still returned: {hidden}"
+
+
+# --------------------------------------------------------------------------- shape
+
+def test_windows_carry_their_mention_offset():
+    """The attribution guard needs to know where in the window the task ID sits."""
+    text = f"padding {TARGET} trailing"
+    windows = check_completion.extract_text_windows(text, TARGET, window_size=50)
+    assert len(windows) == 1
+    win, dist, offset = windows[0]
+    assert win[offset:offset + len(TARGET)] == TARGET, \
+        "mention_offset does not point at the task ID inside the window"
+
+
+def test_prefix_matching_does_not_invent_windows():
+    """A different task sharing the first 6 characters must not create a window.
+
+    868kr07fu and 868kr0zzz share "868kr0"; the old prefix pass matched on that.
+    """
+    text = "868kr0zzz is a completely different task."
+    assert check_completion.extract_text_windows(text, RIVAL, window_size=50) == []
+
+
+# ----------------------------------------------------------------- signal precision
+
+def test_process_state_is_not_a_ticket_open_signal():
+    """"still running" about a process is not a statement about the ticket.
+
+    Every real-run match of the old bare `still (open|pending|waiting|running|needed)`
+    alternation was process state, not ticket state (measured 2026-08-19).
+    """
+    noise = [
+        "the throwaway Postgres is still running on port 55432",
+        "CI is still running rather than failing",
+        "The mirror agent is still running; I'll report when it lands",
+    ]
+    for text in noise:
+        window = f"{TARGET} {text}"
+        hits = check_completion.extract_signals_from_windows(
+            [(window, 0, 0)], check_completion.OPEN_PATTERNS, TARGET
+        )
+        assert hits == [], f"process noise scored as an open signal: {text!r} -> {hits}"
+
+
+def test_ticket_scoped_open_signal_still_fires():
+    """Positive control for the tightening: real ticket-state phrasing must survive."""
+    for text in ["this ticket is still open", "the task is still blocked", "still unresolved"]:
+        window = f"{TARGET} {text}"
+        hits = check_completion.extract_signals_from_windows(
+            [(window, 0, 0)], check_completion.OPEN_PATTERNS, TARGET
+        )
+        assert hits, f"real open signal was dropped by the tightening: {text!r}"
+
+
+def test_blocked_on_credential_is_detected():
+    """The 868kt8pfu shape: work finished, landing blocked on a permission."""
+    window = f"{TARGET} no PR was opened, blocked on the workflow scope for the token"
+    hits = check_completion.extract_signals_from_windows(
+        [(window, 0, 0)], check_completion.OPEN_PATTERNS, TARGET
+    )
+    assert any("blocked" in h[0] for h in hits), f"blocked-on-permission not detected: {hits}"
+
+
+# ----------------------------------------------------------------- PR resolution
+
+def test_pr_ref_without_a_repo_is_not_guessed():
+    sig = [{"signal": "PR merged", "snippet": "PR #1100 merged, verified by content"}]
+    check_completion.annotate_pr_refs(sig, default_repo=None)
+    assert sig[0]["pr_refs"] == [{"ref": "#1100", "state": "unresolved (repo not named)"}], \
+        f"a repo-less PR reference was guessed: {sig[0].get('pr_refs')}"
+
+
+def test_pr_ref_with_named_repo_resolves(monkeypatched=None):
+    """Uses a stubbed resolver so the test stays hermetic (no network)."""
+    calls = []
+    orig = check_completion.resolve_pr
+    check_completion.resolve_pr = lambda repo, num: calls.append((repo, num)) or "merged 2026-08-19"
+    try:
+        sig = [{"signal": "PR merged", "snippet": "talos-infra #1065 merged 08-16"}]
+        check_completion.annotate_pr_refs(sig)
+    finally:
+        check_completion.resolve_pr = orig
+    assert calls == [("civitai/talos-infra", "1065")], f"wrong repo resolved: {calls}"
+    assert sig[0]["pr_refs"][0]["state"] == "merged 2026-08-19"
+
+
+# ----------------------------------------------------------------- transcript seam
+
+def test_user_messages_are_read():
+    """search-sessions matches on user text; completion must read it too, or a session
+    selected on a user-only mention reports mentions_found: 0."""
+    with tempfile.TemporaryDirectory() as tmp:
+        mock_dir = Path(tmp) / ".claude" / "projects" / "p"
+        mock_dir.mkdir(parents=True)
+        with open(mock_dir / "u.jsonl", "w") as f:
+            f.write(json.dumps({"type": "user", "message": {"content":
+                    [{"type": "text", "text": f"{TARGET} is still unresolved"}]}}) + "\n")
+        orig, check_completion.CLAUDE_DIR = check_completion.CLAUDE_DIR, mock_dir.parent
+        try:
+            r = check_completion.check_task(TARGET, session_ids=["u"])
+        finally:
+            check_completion.CLAUDE_DIR = orig
+    assert r["mentions_found"] == 1, f"user-message mention was invisible: {r}"
+    assert r["status"] == "open", f"expected open, got {r['status']}"
+
+
+# ----------------------------------------------------------------- repo inference
+
+def test_repo_inferred_from_markdown_separated_name():
+    """Real snippets read `talos-infra **#1065` — emphasis between the repo and the '#'
+    left almost every reference unresolved before this."""
+    calls = []
+    orig = check_completion.resolve_pr
+    check_completion.resolve_pr = lambda repo, num: calls.append((repo, num)) or "merged"
+    try:
+        sig = [{"signal": "PR merged", "snippet": "while talos-infra **#1065 merged 08-16** (I confirmed)"}]
+        check_completion.annotate_pr_refs(sig)
+    finally:
+        check_completion.resolve_pr = orig
+    assert calls == [("civitai/talos-infra", "1065")], f"repo not inferred: {calls}"
+
+
+def test_adjacency_breaks_a_repo_tie_through_markdown():
+    """Two known repos named, but one is adjacent to the '#'. Adjacency must win.
+
+    This is the case that makes the markdown strip load-bearing: without it the emphasis
+    blocks the adjacency capture, both repos look equally plausible, and the reference
+    degrades to "unresolved". Found by a SURVIVED mutant, not by review.
+    """
+    calls = []
+    orig = check_completion.resolve_pr
+    check_completion.resolve_pr = lambda repo, num: calls.append((repo, num)) or "merged"
+    try:
+        sig = [{"signal": "PR merged", "snippet": "civitai lagged while talos-infra **#1065 merged"}]
+        check_completion.annotate_pr_refs(sig)
+    finally:
+        check_completion.resolve_pr = orig
+    assert calls == [("civitai/talos-infra", "1065")], \
+        f"adjacency did not break the tie (markdown strip inert?): {calls} {sig[0].get('pr_refs')}"
+
+
+def test_ambiguous_repo_stays_unresolved():
+    """Two known repos in range and NEITHER adjacent -> refuse to pick.
+
+    Note the fixture has a non-repo word ("saw") directly before the '#'. A repo written
+    immediately before the number is an explicit citation and deliberately outranks a
+    second repo mentioned nearby — this test is about the case where no such citation
+    exists, which is the only genuinely ambiguous one.
+    """
+    called = []
+    orig = check_completion.resolve_pr
+    check_completion.resolve_pr = lambda repo, num: called.append((repo, num)) or "merged"
+    try:
+        sig = [{"signal": "PR merged", "snippet": "civitai talos-infra saw #1065 merged"}]
+        check_completion.annotate_pr_refs(sig)
+    finally:
+        check_completion.resolve_pr = orig
+    assert called == [], f"ambiguous repo was resolved anyway: {called}"
+    # Round 5 (D9) changed the TEXT of this failure, not the behaviour: two repos WERE
+    # named here, so "repo not named" was a false explanation. Refusing to pick is what
+    # this test has always been about, and that is unchanged.
+    assert sig[0]["pr_refs"][0]["state"] == (
+        "unresolved (ambiguous — civitai/civitai, civitai/talos-infra both in range, "
+        "neither adjacent)"), f"ambiguous repo was guessed: {sig[0]['pr_refs']}"
+
+
+def test_distant_repo_name_does_not_claim_a_bare_ref():
+    """The false positive a snippet-wide scan produced (2026-08-19).
+
+    "civitai" appears in almost every snippet in this corpus, so a whole-snippet scan
+    attributed every bare '#N' to civitai/civitai and reported real-but-unrelated PRs —
+    one came back "merged 2024-03-18". A repo far from the '#' must not claim it.
+    """
+    called = []
+    orig = check_completion.resolve_pr
+    check_completion.resolve_pr = lambda repo, num: called.append((repo, num)) or "merged"
+    try:
+        sig = [{"signal": "PR merged", "snippet":
+                "civitai counted 8 NO EVIDENCE and 4 partial across the sweep; strongest landed #1080"}]
+        check_completion.annotate_pr_refs(sig)
+    finally:
+        check_completion.resolve_pr = orig
+    assert called == [], f"a distant repo name claimed a bare ref: {called}"
+    # Round 5 (D9): the word sitting on this '#' is "landed", which is reported as-written.
+    # No rule short of enumerating the world separates 'landed' from 'devrc', and a reader
+    # separates them at a glance — so the message names the word and refuses to classify
+    # it. What matters, and is unchanged, is that nothing was resolved.
+    assert sig[0]["pr_refs"][0]["state"].startswith("unresolved ("), \
+        f"a distant repo name claimed a bare ref: {sig[0]['pr_refs']}"
+    assert "'landed'" in sig[0]["pr_refs"][0]["state"], \
+        f"the word on the '#' is not reported: {sig[0]['pr_refs']}"
+
+
+# ----------------------------------------------------------------- disagreements
+
+def test_resolved_comment_on_open_ticket_is_flagged():
+    """The 868kr07fu shape: ticket `to do`/urgent, newest comment says "Resolved"."""
+    flags = check_addressed.disagreements([{
+        "task_id": "868kr07fu", "status": "partially_addressed",
+        "clickup_status": "to do",
+        "newest_comment": {"snippet": "Resolved. The 8/17 DR-SWEEP reads 0 missing. Recommend closing."},
+    }])
+    assert any("still" in f and "868kr07fu" in f for f in flags), \
+        f"resolved-comment-on-open-ticket not flagged: {flags}"
+
+
+def test_no_flag_when_ticket_and_comment_agree():
+    """Control: an open ticket with an open-sounding comment must NOT be flagged."""
+    flags = check_addressed.disagreements([{
+        "task_id": "868krn3y1", "status": "unclear", "clickup_status": "to do",
+        "newest_comment": {"snippet": "Escalating priority: this fired on three healthy branches."},
+    }])
+    assert flags == [], f"false disagreement raised: {flags}"
+
+
+def test_open_pr_cited_as_done_is_flagged():
+    """A completion signal quoting a PR that is actually still open."""
+    flags = check_addressed.disagreements([{
+        "task_id": "868kr07fu", "status": "likely_addressed", "clickup_status": "complete",
+        "newest_comment": {"snippet": ""},
+        "completion": [{"signal": "PR merged", "snippet": "addressed in #1073",
+                        "pr_refs": [{"ref": "civitai/talos-infra#1073", "state": "open"}]}],
+    }])
+    assert any("#1073" in f and "OPEN" in f for f in flags), f"open PR not flagged: {flags}"
+
+
+# The real 868kr0799 comment (2026-08-20), abridged. Contains BOTH an explicit refusal to
+# close and the word "resolved" in its alert-cycling sense.
+KEEP_OPEN_COMMENT = ("Still live, do not close. The 8/17 clean CAPACITY-SWEEP looks like a "
+                     "lucky snapshot. Grafana tonight (8/19): MeiliSearch: P95 > 5s "
+                     "(Saturation Burst) fired and resolved repeatedly, A=18.97 at 7:55")
+
+
+def test_keep_open_comment_vetoes_the_close_flag():
+    """A comment refusing closure must never produce a 'close it' instruction, however
+    much completion vocabulary it also contains."""
+    flags = check_addressed.disagreements([{
+        "task_id": "868kr0799", "status": "likely_addressed", "clickup_status": "to do",
+        "newest_comment": {"snippet": KEEP_OPEN_COMMENT},
+    }])
+    assert not any("close it" in f.lower() for f in flags), \
+        f"told the operator to close a ticket whose comment says not to: {flags}"
+    assert any("do NOT close" in f for f in flags), f"keep-open not surfaced: {flags}"
+
+
+def test_keep_open_veto_does_not_silence_genuine_resolutions():
+    """Positive control: the 868kr07fu shape must still be flagged for closing. Without
+    this the veto could pass by suppressing every close-it flag."""
+    flags = check_addressed.disagreements([{
+        "task_id": "868kr07fu", "status": "likely_addressed", "clickup_status": "to do",
+        "newest_comment": {"snippet": "Resolved on both counts. Recommend closing."},
+    }])
+    assert any("close it" in f for f in flags), f"genuine resolution no longer flagged: {flags}"
+
+
+# --------------------------------------------------------------------------- D4
+#
+# D4 (2026-08-20) the checker skipped its OWN transcript but not a PRIOR RUN's. A prior
+# run's report prints each task ID directly beside "likely_addressed" / "✓ resolved" /
+# "merged", which is the exact shape the proximity scorer rewards — so the tool read
+# yesterday's verdict back as today's evidence and re-confirmed it. On the day it was
+# found, both tasks in the report scored `likely_addressed` on nothing else; one carried a
+# comment reading "Still live, do not close".
+#
+# Every test below was watched RED against a baseline copy with `is_self_run` forced to
+# return False (that constant is exactly the pre-change program). Matrix in
+# claude/skills/check-clickup-addressed/reference/validation-history.md.
+
+# A prior run's report: the header check-addressed.py prints, plus a verdict line quoting
+# the task ID next to completion vocabulary.
+PRIOR_RUN_REPORT = (
+    "## Task Completion Status\n\n"
+    f"✅ **{TARGET}** — transcripts say `likely_addressed`\n"
+    f"  ✓ resolved: the fix shipped in #1065, merged and verified on trunk\n"
+)
+
+
+def test_prior_run_is_not_read_as_evidence():
+    """D4: a transcript that is a run of this checker must not supply signals."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _session(tmp, "prior-run", PRIOR_RUN_REPORT)
+        orig, check_completion.CLAUDE_DIR = check_completion.CLAUDE_DIR, root
+        try:
+            r = check_completion.check_task(TARGET, session_ids=["prior-run"])
+        finally:
+            check_completion.CLAUDE_DIR = orig
+
+    assert r["status"] != "likely_addressed", \
+        f"a prior run of this checker was read back as evidence: {r['status']!r}"
+    assert r["completion"] == [], f"cited a prior run's own output: {r['completion']}"
+    assert r["self_runs_skipped"] == 1, \
+        f"guard did not fire (self_runs_skipped={r.get('self_runs_skipped')!r})"
+
+
+def test_prior_run_positive_control():
+    """Control for the test above: the SAME fixture, guard disabled, MUST produce the bad
+    verdict. Without this the test could pass because the fixture is inert."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _session(tmp, "prior-run", PRIOR_RUN_REPORT)
+        orig, check_completion.CLAUDE_DIR = check_completion.CLAUDE_DIR, root
+        try:
+            r = check_completion.check_task(
+                TARGET, session_ids=["prior-run"], include_self_runs=True)
+        finally:
+            check_completion.CLAUDE_DIR = orig
+
+    assert r["status"] == "likely_addressed", \
+        f"fixture cannot reproduce the defect, so the guard test proves nothing: {r['status']!r}"
+    assert r["completion"], "fixture produced no completion signals"
+
+
+def test_ordinary_work_session_is_still_read():
+    """The markers must be anchored enough that real work survives them. Over-dropping
+    turns every verdict into `no_mentions_found`, which is quiet and useless."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _session(
+            tmp, "real-work",
+            f"Fixed the saturation bug for {TARGET}; the fix shipped in #1065, merged.")
+        orig, check_completion.CLAUDE_DIR = check_completion.CLAUDE_DIR, root
+        try:
+            r = check_completion.check_task(TARGET, session_ids=["real-work"])
+        finally:
+            check_completion.CLAUDE_DIR = orig
+
+    assert r["self_runs_skipped"] == 0, "an ordinary work session was mistaken for a self-run"
+    assert r["status"] == "likely_addressed", f"real evidence was dropped: {r['status']!r}"
+
+
+def test_skill_catalog_mention_is_not_a_self_run():
+    """The single most important false-positive control.
+
+    The skill catalog is injected into EVERY session, so a bare `check-clickup-addressed`
+    matched 213 of ~250 transcripts on this box, and `/check-clickup-addressed` matched 32
+    because it is a substring of the skill's own PATH. Either as a marker would blind the
+    tool to the whole corpus while still reporting confident verdicts.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _session(
+            tmp, "catalog-only",
+            "- check-clickup-addressed: Verify if ClickUp tasks were fully addressed.\n"
+            "Base directory: /home/zach/.claude/skills/check-clickup-addressed/SKILL.md\n"
+            f"{TARGET} still needs work.")
+        path = root / "test-project" / "catalog-only.jsonl"
+        assert not selfrun.is_self_run(path), \
+            "the skill catalog line / skill path was mistaken for a run of the checker"
+
+
+def test_the_devrc_invocation_path_is_a_self_run():
+    """🔴 THE MARKER IS A PATH, AND THE MIGRATION MOVED THE PATH (2026-08-22).
+
+    Until this repo, the pipeline lived at `.claude/skills/check-clickup-addressed/scripts/`
+    inside datapacket-talos, and the anchored marker was `check-clickup-addressed/scripts/`.
+    In devrc the identical call reads
+    `~/workspace/devrc/scripts/check-clickup-addressed/check-addressed.py` — the two segments
+    are REVERSED, so the old marker matches none of it. Nothing errors: the guard simply
+    stops recognising its own runs, and the checker goes back to reading yesterday's report
+    as today's evidence, which is the exact failure the guard was built for (see
+    `scripts/check-clickup-addressed/_selfrun.py`).
+
+    Watched RED before the marker was added: the assertion below failed on the migrated tree
+    with the marker tuple untouched.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _session(
+            tmp, "devrc-run",
+            "python3 ~/workspace/devrc/scripts/check-clickup-addressed/check-addressed.py --limit 3")
+        path = root / "test-project" / "devrc-run.jsonl"
+        assert selfrun.is_self_run(path), \
+            "the devrc invocation path was not recognised as a run of this checker"
+
+
+# Written out as LITERALS, deliberately not read from selfrun.SELF_RUN_MARKERS. Iterating
+# the implementation's own tuple would make "delete a marker" pass vacuously — the deleted
+# marker simply stops being tested. This is a ledger: it fails if the set shrinks (a marker
+# stopped working) AND if it grows (a new marker arrived unreviewed), so widening what counts
+# as a self-run has to be a deliberate edit here, where the false-positive cost is argued.
+EXPECTED_SELF_RUN_MARKERS = (
+    "<command-name>/check-clickup-addressed</command-name>",
+    "check-clickup-addressed/scripts/",     # the pre-2026-08-22 datapacket-talos layout
+    "scripts/check-clickup-addressed/",     # the devrc layout the scripts live in now
+    "## Task Completion Status",
+    '"skill": "check-clickup-addressed"',   # matched by SELF_RUN_RE, not the literal tuple
+)
+
+
+def test_each_self_run_marker_fires_on_its_own():
+    """Every marker must be independently load-bearing — a dead one is coverage that
+    reads as protection and provides none."""
+    with tempfile.TemporaryDirectory() as tmp:
+        for i, marker in enumerate(EXPECTED_SELF_RUN_MARKERS):
+            root = _session(tmp, f"m{i}", f"some text {marker} more text")
+            path = root / "test-project" / f"m{i}.jsonl"
+            assert selfrun.is_self_run(path), f"marker never fires: {marker!r}"
+
+
+def test_self_run_marker_set_has_not_drifted():
+    """Pin the literal tuple too, so an added marker cannot slip in untested. The tuple
+    holds four of the five; the fifth is the regex."""
+    assert tuple(selfrun.SELF_RUN_MARKERS) == EXPECTED_SELF_RUN_MARKERS[:4], (
+        f"self-run marker set changed: {selfrun.SELF_RUN_MARKERS!r}. Add the new marker to "
+        f"EXPECTED_SELF_RUN_MARKERS and prove it does not fire on the skill catalog."
+    )
+
+
+def test_skill_tool_invocation_is_a_self_run():
+    """The realistic shape of the regex marker: a Skill tool_use block, whose quotes are
+    raw JSON structure rather than escaped text. The marker test above writes its fixture
+    into message TEXT (escaped quotes); both forms must match, so both are exercised."""
+    with tempfile.TemporaryDirectory() as tmp:
+        mock_dir = Path(tmp) / ".claude" / "projects" / "test-project"
+        mock_dir.mkdir(parents=True)
+        path = mock_dir / "skilltool.jsonl"
+        with open(path, "w") as f:
+            f.write(json.dumps({
+                "type": "assistant",
+                "message": {"content": [{
+                    "type": "tool_use", "name": "Skill",
+                    "input": {"skill": "check-clickup-addressed"},
+                }]},
+            }) + "\n")
+        assert selfrun.is_self_run(path), "a Skill tool_use invocation was not recognised"
+
+
+def test_search_sessions_drops_prior_runs():
+    """The report lists 'Matching Sessions' from here; on 2026-08-20 a prior run topped
+    that list with 14 hits and read as the session that did the work."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _session(tmp, "prior-run", PRIOR_RUN_REPORT)
+        _session(tmp, "real-work", f"digging into {TARGET} today")
+        orig, search_sessions.CLAUDE_DIR = search_sessions.CLAUDE_DIR, root
+        try:
+            default = search_sessions.search_sessions([TARGET])
+            everything = search_sessions.search_sessions([TARGET], include_self_runs=True)
+        finally:
+            search_sessions.CLAUDE_DIR = orig
+
+    assert {r["session_id"] for r in default} == {"real-work"}, \
+        f"prior run leaked into the session list: {[r['session_id'] for r in default]}"
+    assert len(everything) == 2, "positive control: both sessions are findable when allowed"
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    passed = failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  ✓ {t.__name__}")
+            passed += 1
+        except Exception as e:
+            print(f"  ✗ {t.__name__}: {type(e).__name__}: {e}")
+            failed += 1
+    print(f"\n{passed} passed, {failed} failed")
+    sys.exit(1 if failed else 0)

--- a/scripts/check-clickup-addressed/tests/test_attribution.py
+++ b/scripts/check-clickup-addressed/tests/test_attribution.py
@@ -548,6 +548,33 @@ def test_the_devrc_invocation_path_is_a_self_run():
             "the devrc invocation path was not recognised as a run of this checker"
 
 
+def test_a_mention_of_the_scripts_DIRECTORY_is_not_a_self_run():
+    """🔴 THE NEGATIVE CONTROL THAT REJECTED THE OBVIOUS FIX, and the whole reason the devrc
+    marker is a regex requiring a `.py` FILE rather than the directory.
+
+    `scripts/check-clickup-addressed/` reads like the exact counterpart of the old marker.
+    It is unusable, for the same reason the bare name is: devrc's CLAUDE.md carries a table
+    mapping `scripts/<dir>/` to its owning skill, and a project CLAUDE.md is injected into
+    every session in that repo. Measured 2026-08-22 over the 761 transcripts these scripts
+    walk, the two sibling rows already in that table appear in 83 (10.9%) and 72 (9.5%) of
+    them — the same order as the bare name at 96 (12.6%), which this module rejects by name.
+    A ~10% over-drop of the corpus, silent, in the direction of trusting stale evidence.
+
+    Both fixtures below are REAL text: the CLAUDE.md row this migration added, and the gate's
+    own per-target line. Both contain the directory; neither is a run.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        for i, text in enumerate((
+            "| `scripts/check-clickup-addressed/` | `check-clickup-addressed` | did the work "
+            "on a ClickUp ticket actually happen |",
+            "  PASS  scripts/check-clickup-addressed/tests  (collected=157 passed=157 floor=149)",
+        )):
+            root = _session(tmp, f"dirmention{i}", f"{text}\n{TARGET} is still open.")
+            path = root / "test-project" / f"dirmention{i}.jsonl"
+            assert not selfrun.is_self_run(path), \
+                f"a mention of the scripts DIRECTORY was mistaken for a run: {text!r}"
+
+
 # Written out as LITERALS, deliberately not read from selfrun.SELF_RUN_MARKERS. Iterating
 # the implementation's own tuple would make "delete a marker" pass vacuously — the deleted
 # marker simply stops being tested. This is a ledger: it fails if the set shrinks (a marker
@@ -556,9 +583,9 @@ def test_the_devrc_invocation_path_is_a_self_run():
 EXPECTED_SELF_RUN_MARKERS = (
     "<command-name>/check-clickup-addressed</command-name>",
     "check-clickup-addressed/scripts/",     # the pre-2026-08-22 datapacket-talos layout
-    "scripts/check-clickup-addressed/",     # the devrc layout the scripts live in now
     "## Task Completion Status",
-    '"skill": "check-clickup-addressed"',   # matched by SELF_RUN_RE, not the literal tuple
+    '"skill": "check-clickup-addressed"',                       # SELF_RUN_RE
+    "scripts/check-clickup-addressed/check-addressed.py",       # NEW_LAYOUT_RE
 )
 
 
@@ -574,8 +601,8 @@ def test_each_self_run_marker_fires_on_its_own():
 
 def test_self_run_marker_set_has_not_drifted():
     """Pin the literal tuple too, so an added marker cannot slip in untested. The tuple
-    holds four of the five; the fifth is the regex."""
-    assert tuple(selfrun.SELF_RUN_MARKERS) == EXPECTED_SELF_RUN_MARKERS[:4], (
+    holds three of the five; the last two are regexes (SELF_RUN_RE, NEW_LAYOUT_RE)."""
+    assert tuple(selfrun.SELF_RUN_MARKERS) == EXPECTED_SELF_RUN_MARKERS[:3], (
         f"self-run marker set changed: {selfrun.SELF_RUN_MARKERS!r}. Add the new marker to "
         f"EXPECTED_SELF_RUN_MARKERS and prove it does not fire on the skill catalog."
     )

--- a/scripts/check-clickup-addressed/tests/test_attribution.py
+++ b/scripts/check-clickup-addressed/tests/test_attribution.py
@@ -15,7 +15,7 @@ GUARD passed at base too and are labelled as such — they are controls, not cov
   D3  the checker read the transcript it was being written into, which mentions every
       task ID under test by construction.
 """
-import json, sys, tempfile
+import contextlib, io, json, sys, tempfile
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).parent.parent
@@ -531,10 +531,12 @@ def test_the_devrc_invocation_path_is_a_self_run():
     inside datapacket-talos, and the anchored marker was `check-clickup-addressed/scripts/`.
     In devrc the identical call reads
     `~/workspace/devrc/scripts/check-clickup-addressed/check-addressed.py` — the two segments
-    are REVERSED, so the old marker matches none of it. Nothing errors: the guard simply
-    stops recognising its own runs, and the checker goes back to reading yesterday's report
-    as today's evidence, which is the exact failure the guard was built for (see
-    `scripts/check-clickup-addressed/_selfrun.py`).
+    are REVERSED, so the old marker matches none of it.
+
+    ⚠ SCOPE, corrected after an audit: this alone did NOT blind the guard. The report header
+    marker independently catches every text-mode run, and the exclusion set measured 11 either
+    way. What the path marker uniquely covers is a run whose OUTPUT never reaches the
+    transcript — piped to a file, `| jq`, truncated. Keep the claim that size.
 
     Watched RED before the marker was added: the assertion below failed on the migrated tree
     with the marker tuple untouched.
@@ -546,6 +548,111 @@ def test_the_devrc_invocation_path_is_a_self_run():
         path = root / "test-project" / "devrc-run.jsonl"
         assert selfrun.is_self_run(path), \
             "the devrc invocation path was not recognised as a run of this checker"
+
+
+def test_the_invocation_SKILL_MD_ACTUALLY_TEACHES_is_a_self_run():
+    """🔴 A MARKER FOR A SHAPE NOBODY TYPES IS NOT A MARKER.
+
+    The first cut of the devrc marker required the fully-spelled path
+    `scripts/check-clickup-addressed/check-addressed.py`. SKILL.md's own quick start teaches
+    `CCUA=~/workspace/devrc/scripts/check-clickup-addressed` and then
+    `python3 "$CCUA/check-addressed.py"` — the variable means that adjacency never reaches the
+    transcript, so the documented invocation was NOT recognised. Found by an adversarial audit
+    of the migration, which executed the fixture rather than reading the regex.
+
+    All three shapes below are real: the two the docs teach, and the `cd`-then-run a human
+    types. Each was watched RED before the basename alternatives were added.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        for i, cmd in enumerate((
+            'CCUA=~/workspace/devrc/scripts/check-clickup-addressed\n'
+            'python3 "$CCUA/check-addressed.py" --fast',
+            'python3 ~/workspace/devrc/scripts/check-clickup-addressed/check-addressed.py',
+            'cd ~/workspace/devrc/scripts/check-clickup-addressed && python3 check-addressed.py',
+        )):
+            root = _session(tmp, f"inv{i}", cmd)
+            path = root / "test-project" / f"inv{i}.jsonl"
+            assert selfrun.is_self_run(path), \
+                f"an invocation the docs teach was not recognised as a run: {cmd!r}"
+
+
+def test_a_json_run_carries_the_self_run_marker():
+    """🔴 THE ONE SHAPE THE MIGRATION LEFT UNCOVERED, found by the same audit.
+
+    `--json` printed only `json.dumps(report)`; the `## Task Completion Status` header that
+    makes every other report self-marking is on the text branch. So a JSON run — whose output
+    lists every task ID beside `likely_addressed`, the exact shape the proximity scorer
+    rewards — was invisible to the guard, and a session that captured one would have had it
+    read back as evidence.
+
+    🔴 This calls the PRODUCTION renderer. The first version of this test built the payload
+    itself with the same dict-merge the code uses, and so passed with the production branch
+    reverted — a mutant that removed the marker from `--json` output SURVIVED a green suite.
+    Deriving a test's expectation from a copy of the implementation is not a test.
+    """
+    payload = check_addressed.render_json({"task_status": [], "comments": []})
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _session(tmp, "jsonrun", payload)
+        path = root / "test-project" / "jsonrun.jsonl"
+        assert selfrun.is_self_run(path), "a --json report was not recognised as a run"
+    # The payload must still be valid JSON that carries the report through unharmed.
+    parsed = json.loads(payload)
+    assert parsed["task_status"] == [] and "report_header" in parsed
+
+
+def test_main_json_output_is_self_marking_END_TO_END():
+    """🔴 THE SEAM: `render_json` being right does not mean `main()` CALLS it.
+
+    Testing the renderer alone left a live mutant — swapping the `--json` branch back to a
+    bare `json.dumps(report)` kept the suite green, because every assertion was scoped to the
+    function and none to the call site. "Verified in isolation" is not verified.
+
+    So this drives the REAL `main()` with `run_script` stubbed, reads what it actually printed
+    to stdout, and requires `is_self_run` to recognise it. It is hermetic: no ClickUp, no
+    transcripts, no subprocess — the stub answers all three pipeline stages.
+    """
+    canned = {
+        "recent-comments.py": json.dumps([{
+            "task_id": TARGET, "task_name": "a ticket", "date": "2026-08-22 09:00",
+            "author": "someone", "snippet": "please look at this",
+            "task_status": "to do", "task_priority": "high",
+        }]),
+        "search-sessions.py": json.dumps([]),
+        "check-completion.py": json.dumps([{
+            "task_id": TARGET, "status": "no_mentions_found", "sessions_searched": 0,
+            "mentions_found": 0, "completion_signals": [], "open_signals": [],
+        }]),
+    }
+    orig_run, orig_argv = check_addressed.run_script, sys.argv
+    check_addressed.run_script = lambda name, *a: (canned[name], 0)
+    sys.argv = ["check-addressed.py", "--json"]
+    buf = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(buf):
+            check_addressed.main()
+    finally:
+        check_addressed.run_script, sys.argv = orig_run, orig_argv
+
+    printed = buf.getvalue()
+    assert printed.strip(), "main() printed nothing — the stub did not drive the pipeline"
+    json.loads(printed)                      # positive control: it really is the JSON branch
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _session(tmp, "e2ejson", printed)
+        path = root / "test-project" / "e2ejson.jsonl"
+        assert selfrun.is_self_run(path), (
+            "a real --json run of main() was not recognised as a run of this checker"
+        )
+
+
+def test_the_two_output_branches_share_one_header_literal():
+    """The text branch and the JSON branch must emit the SAME string, and it must be the one
+    `_selfrun.py` matches. Three copies of a literal is how a guard silently unhooks itself
+    from the thing it guards: reword the header for the humans, and every future report stops
+    being recognised, with nothing failing."""
+    assert check_addressed.SELF_RUN_HEADER in selfrun.SELF_RUN_MARKERS, (
+        "check-addressed.py's report header is not in _selfrun.py's marker set — a report "
+        "printed today would not be recognised as a prior run"
+    )
 
 
 def test_a_mention_of_the_scripts_DIRECTORY_is_not_a_self_run():

--- a/scripts/check-clickup-addressed/tests/test_check_completion.py
+++ b/scripts/check-clickup-addressed/tests/test_check_completion.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Tests for check-completion.py — windowed signal extraction."""
+import json, os, sys, tempfile, shutil
+from pathlib import Path
+
+# Add scripts dir to path and import the module
+SCRIPT_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+# Import the module by loading the file directly
+import importlib.util
+spec = importlib.util.spec_from_file_location("check_completion", SCRIPT_DIR / "check-completion.py")
+check_completion = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check_completion)
+
+
+def test_extract_text_windows_exact_match():
+    text = "Task 868ktvqf9 was fixed. PR #123 merged for 868ktvqf9. Later 868ktvqf9 was closed."
+    windows = check_completion.extract_text_windows(text, "868ktvqf9", window_size=50)
+    assert len(windows) == 3, f"Expected 3 windows, got {len(windows)}"
+    for window, dist, offset in windows:
+        assert window[offset:offset + 9] == "868ktvqf9"
+
+
+def test_extract_text_windows_no_match():
+    text = "No task ID here."
+    windows = check_completion.extract_text_windows(text, "868ktvqf9", window_size=50)
+    assert len(windows) == 0
+
+
+def test_extract_text_windows_partial_match():
+    text = "Task 868ktvqf9 done. Also 868ktv referenced."
+    windows = check_completion.extract_text_windows(text, "868ktvqf9", window_size=100)
+    # Should find exact match and partial match
+    assert len(windows) >= 1
+
+
+
+
+
+def test_extract_signals_from_windows():
+    windows = [
+        ("Task 868ktvqf9 fixed. PR #123 merged.", 0, 5),
+        ("Different task. Still open.", 100, 0),
+    ]
+    completion = check_completion.extract_signals_from_windows(windows, check_completion.COMPLETION_PATTERNS)
+    open_items = check_completion.extract_signals_from_windows(windows, check_completion.OPEN_PATTERNS)
+    assert len(completion) >= 1
+    # "Still open" is in the second window (distance=100), so it should have lower proximity
+    if open_items:
+        assert open_items[0][2] < 1.0, "Distant signals should have lower proximity"
+
+
+def test_check_task_status_likely_addressed():
+    """Task with completion signals near the mention, no open signals."""
+    # Create a mock session file
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mock_dir = Path(tmpdir) / ".claude" / "projects" / "test-project"
+        mock_dir.mkdir(parents=True)
+        
+        session_id = "test-session-123"
+        session_file = mock_dir / f"{session_id}.jsonl"
+        
+        # Create mock session with completion signals near task ID
+        mock_data = [
+            {"type": "assistant", "message": {"content": [
+                {"type": "text", "text": "Working on 868ktvqf9. PR #123 merged for this task. Verified on main."}
+            ]}}
+        ]
+        with open(session_file, "w") as f:
+            for entry in mock_data:
+                f.write(json.dumps(entry) + "\n")
+        
+        # Temporarily override CLAUDE_DIR
+        original_dir = check_completion.CLAUDE_DIR
+        check_completion.CLAUDE_DIR = Path(tmpdir) / ".claude" / "projects"
+        
+        try:
+            result = check_completion.check_task("868ktvqf9", session_ids=[session_id])
+            assert result["status"] == "likely_addressed", f"Expected likely_addressed, got {result['status']}"
+            assert len(result["completion"]) > 0, "Should find completion signals"
+        finally:
+            check_completion.CLAUDE_DIR = original_dir
+
+
+def test_check_task_status_no_sessions():
+    """Must be hermetic: with session_ids=[] this falls back to scanning every real
+    transcript under CLAUDE_DIR, including the one the test run is being written into,
+    which contains this test's own source. Point CLAUDE_DIR at an empty dir instead."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        empty = Path(tmpdir) / ".claude" / "projects"
+        empty.mkdir(parents=True)
+        original_dir = check_completion.CLAUDE_DIR
+        check_completion.CLAUDE_DIR = empty
+        try:
+            result = check_completion.check_task("nonexistent_task", session_ids=[])
+        finally:
+            check_completion.CLAUDE_DIR = original_dir
+
+    assert result["status"] == "no_sessions_found"
+    assert result["completion"] == []
+    assert result["open"] == []
+
+
+def test_proximity_scoring():
+    """Closer signals should have higher proximity scores.
+
+    ⚠️ NOT evidence about production. These windows are hand-built with distance 500;
+    `extract_text_windows` — the only producer outside these tests — hardcodes distance 0,
+    so this covers the formula, not any reachable path. Fixtures of exactly this shape are
+    what let the `proximity > 0.5` status tier look tested for two rounds while being
+    unreachable. The reachable premise is pinned by
+    test_production_windows_are_all_distance_zero in test_status_and_tiers.py.
+    """
+    windows = [
+        ("868ktvqf9 fixed. PR #123 merged.", 0, 0),  # Very close
+        ("868ktvqf9 elsewhere. PR #456 merged.", 500, 0),  # Far away
+    ]
+    completion = check_completion.extract_signals_from_windows(windows, check_completion.COMPLETION_PATTERNS)
+    if len(completion) >= 2:
+        # First signal should have higher proximity
+        assert completion[0][2] >= completion[1][2]
+
+
+def test_empty_text():
+    windows = check_completion.extract_text_windows("", "868ktvqf9")
+    assert len(windows) == 0
+
+
+def test_special_characters_in_task_id():
+    text = "Task 868kt-vqf9 with dash. And 868kt_vqf9 with underscore."
+    windows = check_completion.extract_text_windows(text, "868kt-vqf9", window_size=50)
+    assert len(windows) >= 1
+
+
+if __name__ == "__main__":
+    # Run all test functions
+    tests = [v for k, v in globals().items() if k.startswith("test_")]
+    passed = 0
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            print(f"  ✓ {test.__name__}")
+            passed += 1
+        except Exception as e:
+            print(f"  ✗ {test.__name__}: {e}")
+            failed += 1
+    print(f"\n{passed} passed, {failed} failed")
+    sys.exit(1 if failed else 0)

--- a/scripts/check-clickup-addressed/tests/test_corpus.py
+++ b/scripts/check-clickup-addressed/tests/test_corpus.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""A LABELLED CORPUS, and the score `disagreements()` must not fall below.
+
+🔴 Why this file exists. Eight rounds of this veto were argued from anecdotes — one clever
+sentence at a time, each fix breaking a shape the previous round had not thought of, five
+consecutive rounds shipping a regression. What ended that was scoring every candidate against
+the SAME labelled set: trunk 24/42, the first tiering attempt 28/42, the version that shipped
+39/42. "Better" became a number instead of an argument.
+
+Every case came from a MEASUREMENT — the round-8 table, two blind audits, and the real
+ClickUp comment on 868ktt2ct. None was invented to make a rule look good.
+
+**When you change the veto, run this first.** A candidate that scores lower is worse, however
+good its reasoning sounds. Add the case that motivated your change, with the verdict a human
+reading it would give, BEFORE you change any code.
+
+The three known failures are recorded here rather than hidden, and all three are over-vetoes
+— the safe direction. A newly-FAILING case in the `CLOSE`/`not-VETO` direction is the one that
+must never ship: that is the tool telling a human to close a ticket whose comment refuses.
+"""
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.parent
+spec = importlib.util.spec_from_file_location("check_addressed", SCRIPT_DIR / "check-addressed.py")
+check_addressed = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check_addressed)
+
+NOW = datetime(2026, 8, 21, 12, 0, tzinfo=timezone.utc)
+VETO, CLOSE, READ, NOTVETO = "VETO", "CLOSE", "READ", "not-VETO"
+
+# Measured 2026-08-21 against the shipped implementation. Raising this is progress; a change
+# that lowers it is a regression no matter how it reads.
+MIN_SCORE = 41
+
+CORPUS = [
+    # --- A: a refusal about THIS ticket. Must veto.
+    (VETO, "This is still open. I have not had time to look at it."),
+    (VETO, "The issue is not resolved."),
+    (VETO, "The issue isn't resolved."),
+    (VETO, "The issue is never resolved."),
+    (VETO, "This won't be resolved until next sprint."),
+    (VETO, "This is not fully resolved."),
+    (VETO, "This is unresolved."),
+    (VETO, "I do not recommend closing this yet."),
+    (VETO, "Still live, do not close."),
+    (VETO, "We cannot call this resolved."),
+    (VETO, "This is far from resolved."),
+    (VETO, "This is anything but resolved."),
+    (VETO, "This is still open. I haven't done anything yet."),
+    (VETO, "This is still open. The bug is not fixed."),
+    (VETO, "This is still open — nothing has been merged."),
+    (VETO, "This is not (yet) resolved."),
+    (VETO, "This is not, in my view, resolved."),   # known failure: see KNOWN_FAILURES
+    (VETO, "Status check during ClickUp triage — staying open, and mostly not verifiable "
+           "from this repo. Per the thread: R1 shipped via talos-infra #1093."),
+
+    # --- B: the work is finished. Must produce the close-it flag.
+    (CLOSE, "Resolved on both counts. Recommend closing."),
+    (CLOSE, "Resolved, no further action needed."),
+    (CLOSE, "Recommend closing, no further work planned."),
+    (CLOSE, "Confirmed resolved, no repro since Tuesday."),
+    (CLOSE, "There is no regression left. Resolved — recommend closing."),
+    (CLOSE, "The alert wasn't firing, resolved by the rule fix."),
+    (CLOSE, "Search returned no results for tag queries, resolved by the reindex."),
+    (CLOSE, "The job did not run on Sunday, resolved — I re-ran it."),
+    (CLOSE, "Cannot reproduce this anymore, resolved."),
+    (CLOSE, "No repro since the deploy, resolved."),
+    (CLOSE, "No further action needed, resolved."),
+    (CLOSE, "The root cause (never reproduced in staging) is resolved."),
+
+    # --- C: the comment genuinely says both. Must refuse to instruct.
+    (READ, "Resolved on both counts, recommend closing. (The follow-up PR is still open "
+           "but unrelated.)"),
+    (READ, "One review thread is not resolved on the PR, but the ticket itself is done. "
+           "Recommend closing."),
+    (READ, "The alert fired and was not resolved automatically. Ticket work is done — "
+           "recommend closing."),
+    (READ, "The fix landed in #1234 and is live. The follow-up PR is still open but unrelated."),
+    (READ, "Resolved on both counts, recommend closing. The upstream task is still open "
+           "but that is tracked separately."),
+    (READ, "Fix merged. The duplicate task is still open, closing this one."),
+
+    # --- A2: a negator that FOLLOWS the closure word it denies. 🔴 The corpus was blind to
+    # this class entirely — measured, all 18 negator/closure pairs in the original 42 put the
+    # negator FIRST — so `test_no_new_case_fails_in_the_close_it_direction` could not fail on
+    # it however bad it got. Every one is a KNOWN FAILURE drawing "close it" over a refusal,
+    # on trunk and here alike: it is the tool's worst outcome, unfixed, and now visible.
+    (VETO, "The ticket says resolved but it isn't."),
+    (VETO, "This was marked resolved, but it is not."),
+    (VETO, "Claimed resolved in standup, but it never was."),
+    (VETO, "Resolved and not verified in prod."),
+
+    # --- B2: a clean status line whose own clause ends in a negator. These are the cases the
+    # deleted `carry` rule broke, kept as controls so it cannot come back unnoticed.
+    (CLOSE, "Downtime: none. Resolved and deployed."),
+    (CLOSE, "Impact: none, resolved by the rollback."),
+    (CLOSE, "Regressions found: none. Resolved."),
+
+    # --- D: innocent prose. A veto here is a wrong instruction.
+    (NOTVETO, "The fix (not the workaround) is deployed."),
+    (NOTVETO, "We changed nothing but the config, and it is deployed."),
+    (NOTVETO, "Users cannot upload avatars, fixed in #4421 and deployed."),
+    (NOTVETO, "No objections to closing."),
+    (NOTVETO, "This is done, nothing else outstanding."),
+    (NOTVETO, "Nothing else outstanding, this is done."),
+]
+
+
+
+# Recorded failures, all over-vetoes (the safe direction). Listed so a fix that closes one is
+# visibly progress, and so nobody re-derives them as new discoveries.
+KNOWN_FAILURES = {
+    # A negator inside a parenthetical that qualifies a different noun. Over-veto (safe).
+    "The root cause (never reproduced in staging) is resolved.",
+    "The fix (not the workaround) is deployed.",
+    # "no" attaching to a noun rather than to the closure word. Over-veto (safe).
+    "No objections to closing.",
+    # 🔴 THE UNSAFE ONES. A negator that FOLLOWS the closure word it denies is not recognised
+    # at all, so these draw an affirmative "close it" over a comment that refuses — the worst
+    # thing this tool can do. TRUE ON TRUNK TOO; not a regression, and not fixed here. They
+    # are listed because a corpus that omits its own worst class is worse than no corpus:
+    # the close-it-direction guard below cannot fail on a shape nobody wrote down.
+    "The ticket says resolved but it isn't.",
+    "This was marked resolved, but it is not.",
+    "Claimed resolved in standup, but it never was.",
+    "Resolved and not verified in prod.",
+    # An interrupted negation — the one case commas-as-boundaries loses. A `carry` rule fixed
+    # exactly this and broke seven "Downtime: none. Resolved." shapes, so it was deleted and
+    # this went back to being a stated gap.
+    "This is not, in my view, resolved.",
+}
+
+
+def _verdict(comment):
+    r = {"task_id": "T", "status": "unclear", "clickup_status": "to do", "mentions_found": 3,
+         "newest_comment": {"snippet": comment[:200], "text": comment,
+                            "date": "2026-08-20 10:00", "author": "x"},
+         "completion": [], "open": []}
+    out = check_addressed.disagreements([r], now=NOW)
+    if not out:
+        return "(silent)"
+    j = " ".join(out)
+    for needle, name in (("do NOT close", VETO), ("READ IT and decide", READ),
+                         ("close it", CLOSE)):
+        if needle in j:
+            return name
+    return "?"
+
+
+def _ok(want, got):
+    return got != VETO if want == NOTVETO else got == want
+
+
+def test_the_corpus_score_has_not_regressed():
+    """The headline guard. Scores the real `disagreements()` over every labelled case."""
+    good = [c for want, c in CORPUS if _ok(want, _verdict(c))]
+    assert len(good) >= MIN_SCORE, (
+        f"corpus score fell to {len(good)}/{len(CORPUS)}, below the pinned {MIN_SCORE}. "
+        f"Newly failing: {sorted(set(c for _, c in CORPUS) - set(good) - KNOWN_FAILURES)}")
+
+
+def test_no_new_case_fails_in_the_close_it_direction():
+    """🔴 The direction that matters. A comment a human would read as a refusal must never
+    draw an affirmative close-it, and none of the recorded failures do."""
+    for want, c in CORPUS:
+        if want == VETO and c not in KNOWN_FAILURES:
+            got = _verdict(c)
+            assert got != CLOSE, \
+                f"told the operator to CLOSE a ticket whose comment refuses: {c!r}"
+
+
+def test_the_known_failures_are_still_exactly_these_three():
+    """A LEDGER, so the set cannot silently GROW — the same reason the regex patterns are
+    pinned as literals. If a fix closes one, delete it here and raise MIN_SCORE."""
+    failing = {c for want, c in CORPUS if not _ok(want, _verdict(c))}
+    assert failing == KNOWN_FAILURES, (
+        f"the known-failure set changed.\n  newly failing: {sorted(failing - KNOWN_FAILURES)}"
+        f"\n  now fixed (delete from KNOWN_FAILURES and raise MIN_SCORE): "
+        f"{sorted(KNOWN_FAILURES - failing)}")
+
+
+def test_every_label_is_one_of_the_four():
+    """Positive control on the corpus itself: a typo'd label would silently pass `_ok`."""
+    assert {w for w, _ in CORPUS} <= {VETO, CLOSE, READ, NOTVETO}
+    assert len(CORPUS) == 49, f"corpus size changed to {len(CORPUS)}; update MIN_SCORE too"

--- a/scripts/check-clickup-addressed/tests/test_own_reply_answers.py
+++ b/scripts/check-clickup-addressed/tests/test_own_reply_answers.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Round 6 (2026-08-22). D12 — the WAITING flag cannot see the user's OWN replies.
+
+MEASURED LIVE, and it cost real work. On 868kuam02 the report said:
+
+    @Ellie King is WAITING — the ticket is `to do`, and the task ID appears in NO
+    transcript, so no work exists anywhere. Commented 2d ago; nobody has answered.
+
+Two sessions had already answered her — 2026-08-21 13:52 and 2026-08-22 01:04, the
+second eleven hours before the run that printed that line. Acting on the flag
+duplicated an analysis that was already in the thread.
+
+The mechanism is a SEAM, not a logic bug, and each side is correct alone.
+`recent-comments.py` drops every comment authored by `me` — right, because the report
+is about what OTHER people said. `_waiting_on_a_human` then reads the newest surviving
+comment and concludes nobody answered — right, given the only evidence it is handed.
+Neither component can observe the other's assumption. `_waiting_on_a_human`'s own
+docstring states the filter as a GUARANTEE it relies on:
+
+    The comment is guaranteed not to be the user's own: `recent-comments.py` drops
+    every comment whose author id equals `me` before any of this runs.
+
+True, and precisely why the flag is blind: the evidence that would refute it is
+removed upstream, so no amount of care inside the function can recover it. The fix has
+to cross the seam — `recent-comments.py` must report the date of the user's newest
+reply per task, and the flag must branch on it.
+
+FAILURE DIRECTION. The old bug is a FALSE POSITIVE on the one block the report tells
+you to act on, and this function's own docstring argues that a permanently-noisy block
+is worse than no block because it trains the reader to skip it. An answered ticket
+never stops being flagged, so the noise is unbounded — exactly the property the
+recency bound was chosen to avoid.
+
+ABSENT IS NOT "NO REPLY". If `my_latest_reply` is missing entirely the producer never
+reported one, which is the pre-fix state. Treating that as "nobody replied" would keep
+the bug alive for any stale producer; treating it as "someone replied" would silently
+disable the flag if the field were ever dropped from `build_record` — this skill's own
+headline defect class. It announces instead, the same way an unreadable date does.
+
+Tests marked INVARIANT GUARD pass at base too — they are anti-widening controls, not
+regression coverage. A suppression that fires on ANY reply, regardless of when, would
+turn D12 into the mirror-image bug and must be killed by a test that is green at base.
+"""
+import importlib.util, io, json, sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+spec = importlib.util.spec_from_file_location("check_addressed", SCRIPT_DIR / "check-addressed.py")
+check_addressed = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check_addressed)
+
+spec2 = importlib.util.spec_from_file_location("recent_comments", SCRIPT_DIR / "recent-comments.py")
+recent_comments = importlib.util.module_from_spec(spec2)
+spec2.loader.exec_module(recent_comments)
+
+NOW = datetime(2026, 8, 22, 12, 0, tzinfo=timezone.utc)
+
+
+def _at(days_ago):
+    return (NOW - timedelta(days=days_ago)).strftime("%Y-%m-%d %H:%M")
+
+
+def _rec(comment_days_ago=2, reply_days_ago=None, reply_reported=True):
+    """The live 868kuam02 shape: open ticket, zero transcript evidence, colleague comment.
+
+    `reply_reported=False` omits the key entirely — the stale-producer case, which is a
+    different fact from "reported, and there is no reply" (`reply_days_ago=None`).
+    """
+    nc = {
+        "date": _at(comment_days_ago),
+        "author": "Ellie King",
+        "snippet": "Follow-up from the reporter, on why this looks pixelated",
+        "text": "Follow-up from the reporter, on why this looks pixelated",
+    }
+    if reply_reported:
+        nc["my_latest_reply"] = _at(reply_days_ago) if reply_days_ago is not None else None
+    return {
+        "task_id": "868kuam02", "status": "no_mentions_found", "sessions_searched": 1,
+        "mentions_found": 0, "clickup_status": "to do", "clickup_priority": "high",
+        "newest_comment": nc, "completion": [], "open": [],
+    }
+
+
+def _waiting_flags(r):
+    return [f for f in check_addressed.disagreements([r], now=NOW) if "WAITING" in f]
+
+
+# --------------------------------------------------------------------------- D12
+
+def test_my_own_later_reply_suppresses_the_waiting_flag():
+    """THE REGRESSION. Red at base: base emits WAITING over a ticket already answered.
+
+    The exact live shape — Ellie commented 2 days ago, I replied 11 hours ago. Nobody is
+    waiting on a first response, so the report must not send the reader to write one.
+    """
+    flags = _waiting_flags(_rec(comment_days_ago=2, reply_days_ago=0.46))
+    assert flags == [], (
+        "a ticket answered AFTER the colleague's comment was still reported as unanswered "
+        f"— the live 868kuam02 false positive: {flags}")
+
+
+def test_a_reply_older_than_the_question_does_not_suppress():
+    """INVARIANT GUARD (green at base) — anti-widening control for the fix above.
+
+    Kills the mutant that suppresses on the mere EXISTENCE of a reply. Answering on the
+    5th does not answer a question asked on the 21st, and that is the common shape on a
+    long-running ticket: an old reply of mine sits under a fresh question.
+    """
+    flags = _waiting_flags(_rec(comment_days_ago=1, reply_days_ago=5))
+    assert flags, (
+        "a reply PREDATING the colleague's comment suppressed the flag — existence of a "
+        "reply is not an answer to a later question")
+
+
+def test_reported_absence_of_a_reply_still_flags():
+    """INVARIANT GUARD (green at base). `my_latest_reply: None` is a positive statement.
+
+    The producer looked and found no reply from me. That is the state the flag exists for,
+    and it must survive the new branch.
+    """
+    flags = _waiting_flags(_rec(comment_days_ago=2, reply_days_ago=None))
+    assert flags, "an explicitly-reported absence of any reply from me suppressed the flag"
+    joined = " ".join(flags).lower()
+    # 🔴 Assert the RELATIONSHIP the docstring claims, not merely that something fired. A bare
+    # `assert flags` let the mutant `reply_unreported = nc.get("my_latest_reply") is None`
+    # — flattening absent and null, the single mutation this whole `in`/`not in` design exists
+    # to prevent — SURVIVE a fully green suite. Under it every genuinely-unanswered ticket
+    # loses "nobody has answered" and gains the FALSE line "your own replies were not
+    # reported". The producer side of the distinction was pinned; this consumer side was not.
+    assert "nobody has answered" in joined, (
+        "a reported null was not treated as evidence — the flag must state nobody answered, "
+        f"because the producer did look: {flags}")
+    assert "not reported" not in joined, (
+        f"a reported null was misreported as an ungathered fact: {flags}")
+
+
+def test_an_unreadable_comment_date_beside_a_reported_reply_still_flags():
+    """Covers `theirs is not None` at check-addressed.py — an untested guard at audit time.
+
+    The docstring there claims a malformed value on EITHER side falls through to the flag.
+    Only the `mine` side was exercised: no fixture combined a REPORTED `my_latest_reply` with
+    an UNREADABLE comment date, so deleting `theirs is not None` survived the whole suite and
+    would raise `TypeError: '<=' not supported between 'float' and 'NoneType'` on a real
+    record. A description claiming coverage the tests do not provide reads as coverage while
+    providing none.
+    """
+    r = _rec(comment_days_ago=2, reply_days_ago=1)
+    r["newest_comment"]["date"] = "not-a-date"
+    flags = _waiting_flags(r)
+    assert flags, "an unreadable comment date silently dropped a possibly-waiting human"
+    assert "unreadable" in " ".join(flags).lower(), \
+        f"the flag did not admit the comment date was unreadable: {flags}"
+
+
+def test_an_unreported_reply_field_announces_instead_of_deciding():
+    """A stale producer must not silently decide the question either way.
+
+    Absent means `recent-comments.py` never reported a reply date — the pre-fix state. The
+    flag still fires (a missed waiting human costs more than one noisy line, matching the
+    unreadable-date branch) but must SAY the check did not run, so a reader is not told
+    'nobody has answered' on evidence that was never gathered.
+    """
+    flags = _waiting_flags(_rec(comment_days_ago=2, reply_reported=False))
+    assert flags, "an unreported reply field silently disabled the flag"
+    joined = " ".join(flags).lower()
+    assert "own repl" in joined or "not reported" in joined or "could not" in joined, (
+        "the flag fired without disclosing that the own-reply check never ran, so an "
+        f"ungathered fact reads as a gathered one: {flags}")
+    assert "nobody has answered" not in joined, (
+        "the flag asserted 'nobody has answered' while the check that would establish it "
+        f"did not run: {flags}")
+
+
+def test_a_same_minute_reply_counts_as_answered():
+    """Boundary: equal timestamps. ClickUp formats to the MINUTE, so a reply written in
+    the same minute as the comment renders as equal, not later. A strict `>` would flag
+    it as unanswered. Measured at both ends rather than at one — the `>` vs `>=` choice
+    is exactly the mutation this pins.
+    """
+    assert _waiting_flags(_rec(comment_days_ago=2, reply_days_ago=2)) == [], \
+        "a reply in the same minute as the comment was treated as not-an-answer"
+
+
+# ------------------------------------------------- the seam, from the producer side
+
+def test_latest_reply_by_picks_my_newest_comment_by_timestamp():
+    """Ranked on the raw epoch-ms, not on the formatted string.
+
+    `format_date` falls back to `str(ts_ms)` for an unparseable value, so a max() over
+    formatted strings can rank garbage above a real date. The defining value is the
+    integer; formatting happens to the winner only.
+    """
+    comments = [
+        {"user": {"id": "7"}, "date": "1755000000000"},   # mine, older
+        {"user": {"id": "9"}, "date": "1755900000000"},   # someone else's, newest overall
+        {"user": {"id": "7"}, "date": "1755800000000"},   # mine, newest of mine
+    ]
+    got = recent_comments.latest_reply_by(comments, "7")
+    assert got == recent_comments.format_date("1755800000000"), \
+        f"did not select my newest comment: {got}"
+
+
+def test_latest_reply_by_returns_none_when_i_never_commented():
+    comments = [{"user": {"id": "9"}, "date": "1755900000000"}]
+    assert recent_comments.latest_reply_by(comments, "7") is None, \
+        "reported a reply from me on a thread I never commented on"
+
+
+def test_latest_reply_by_ignores_an_unparseable_date():
+    """A malformed date must not win the max() and must not crash the fetch."""
+    comments = [
+        {"user": {"id": "7"}, "date": "not-a-timestamp"},
+        {"user": {"id": "7"}, "date": "1755800000000"},
+    ]
+    assert recent_comments.latest_reply_by(comments, "7") == \
+        recent_comments.format_date("1755800000000")
+
+
+def test_build_record_carries_my_latest_reply():
+    """Pins the JOIN. Both ends of this seam are testable in isolation and the fix is
+    inert unless the field actually reaches the record — the same way dropping `text`
+    from this dict silently reverted the keep-open veto.
+    """
+    r = recent_comments.build_record(
+        "868kuam02", "name", {}, {"user": {"username": "Ellie King"}, "date": "1755900000000"},
+        "some text", "2026-08-22 01:04")
+    assert r.get("my_latest_reply") == "2026-08-22 01:04", \
+        f"build_record dropped my_latest_reply, so the fix cannot reach the flag: {r}"
+
+
+def test_build_record_EMITS_the_key_for_a_genuine_absence_of_replies():
+    """The other direction of the conditional, which the audit-round fix left unpinned.
+
+    `build_record` omits the key only for the UNIDENTIFIED sentinel. A genuine `None` — "I
+    looked; you never replied" — must still be EMITTED, because present-and-null is the
+    evidence the flag reads to say "nobody has answered". Before the sentinel the key was
+    emitted unconditionally, so this direction was structurally impossible and nothing
+    tested it; introducing the branch opened it. The mutant `UNIDENTIFIED = None` collapses
+    the two, degrading every genuinely-unanswered ticket to the false caveat "your own
+    replies were not reported", and it SURVIVED a green 168-test suite.
+
+    Note the trap this is written around: the neighbouring mutants `if my_latest_reply:` and
+    `if my_latest_reply is not None:` do die — but on `Object of type object is not JSON
+    serializable`, because `object()` is both truthy and non-None. They die for the WRONG
+    reason and prove nothing about the null direction. Only this assertion isolates it.
+    """
+    r = recent_comments.build_record(
+        "868kuam02", "name", {}, {"user": {"username": "Ellie King"}, "date": "1755900000000"},
+        "some text", None)
+    assert "my_latest_reply" in r, (
+        "a genuine 'no reply from me' lost the key, so the consumer will announce that the "
+        f"check never ran instead of reporting that nobody answered: {r}")
+    assert r["my_latest_reply"] is None, f"expected a reported null, got {r['my_latest_reply']!r}"
+
+
+def test_collect_computes_the_reply_over_the_UNFILTERED_comment_list():
+    """The wiring, not the parts. Added because a mutation sweep found nothing covered it.
+
+    `latest_reply_by` and `build_record` are both correct in isolation and both pinned
+    above, yet `_collect` could call the first with the wrong list — after the loop that
+    discards my comments, say — and the entire fix would be inert with a fully green
+    suite. Mutating the call to `latest_reply_by([], my_id)` SURVIVED every other test
+    here. That is this skill's own headline defect class: a seam no single-component test
+    owns.
+    """
+    calls = {}
+
+    def fake_comments(_tid):
+        return [
+            {"user": {"id": "9", "username": "Ellie King"},
+             "date": "1755800000000", "comment": [{"text": "a question"}]},
+            {"user": {"id": "7", "username": "me"},
+             "date": "1755900000000", "comment": [{"text": "my answer"}]},
+        ]
+
+    orig = (recent_comments.get_my_user_id, recent_comments.get_my_tasks,
+            recent_comments.get_comments)
+    try:
+        recent_comments.get_my_user_id = lambda: "7"
+        recent_comments.get_my_tasks = lambda: [{"id": "868kuam02", "name": "t"}]
+        recent_comments.get_comments = fake_comments
+        buf = io.StringIO()
+        real_stdout, sys.stdout = sys.stdout, buf
+        try:
+            recent_comments._collect(10, False, True)
+        finally:
+            sys.stdout = real_stdout
+        calls = json.loads(buf.getvalue())
+    finally:
+        (recent_comments.get_my_user_id, recent_comments.get_my_tasks,
+         recent_comments.get_comments) = orig
+
+    assert len(calls) == 1, f"expected only the colleague's comment to survive: {calls}"
+    assert calls[0]["author"] == "Ellie King"
+    assert calls[0]["my_latest_reply"] == recent_comments.format_date("1755900000000"), (
+        "_collect did not report my reply — the reply must be computed over the FULL "
+        f"comment list, before mine are discarded: {calls[0]}")
+
+
+def test_a_failed_user_lookup_omits_the_key_instead_of_claiming_no_reply():
+    """`get_my_user_id()` → None must reach the ANNOUNCE branch, never the evidence branch.
+
+    It returns None whenever the ClickUp CLI prints no `ID:` line — auth expiry, a network
+    error, an output-format change — and `run_clickup` does not check the subprocess return
+    code, so the failure is silent. Before the sentinel, no comment matched the id, so
+    `latest_reply_by` returned None and the record carried `my_latest_reply: null`, which the
+    consumer reads as the POSITIVE claim "I looked; you never replied". The one design
+    property this seam exists to protect, defeated on the exact failure mode that produces it.
+    """
+    def fake_comments(_tid):
+        return [{"user": {"id": "9", "username": "Ellie King"},
+                 "date": "1755800000000", "comment": [{"text": "a question"}]}]
+
+    orig = (recent_comments.get_my_user_id, recent_comments.get_my_tasks,
+            recent_comments.get_comments)
+    try:
+        recent_comments.get_my_user_id = lambda: None          # the failure under test
+        recent_comments.get_my_tasks = lambda: [{"id": "868kuam02", "name": "t"}]
+        recent_comments.get_comments = fake_comments
+        buf, err = io.StringIO(), io.StringIO()
+        real_out, real_err = sys.stdout, sys.stderr
+        sys.stdout, sys.stderr = buf, err
+        try:
+            recent_comments._collect(10, False, True)
+        finally:
+            sys.stdout, sys.stderr = real_out, real_err
+        rows = json.loads(buf.getvalue())
+    finally:
+        (recent_comments.get_my_user_id, recent_comments.get_my_tasks,
+         recent_comments.get_comments) = orig
+
+    assert rows, "no rows emitted"
+    assert "my_latest_reply" not in rows[0], (
+        "a FAILED user lookup was reported as 'I looked; you never replied' — the key must be "
+        f"absent so the consumer announces rather than decides: {rows[0]}")
+    assert "WARNING" in err.getvalue(), \
+        f"an unidentifiable user produced no warning on stderr: {err.getvalue()!r}"
+
+    # And the consumer must actually take the announce branch on that record.
+    nc = check_addressed.build_newest_comment(rows[0])
+    r = _rec()
+    r["newest_comment"] = dict(nc, date=_at(2), author="Ellie King")
+    flags = _waiting_flags(r)
+    assert flags and "not reported" in " ".join(flags).lower(), (
+        f"the absent key did not reach the announce branch end-to-end: {flags}")
+
+
+def test_run_script_forwards_child_stderr_to_the_operator():
+    """A warning the entry point swallows is the same no-op as one that never fires.
+
+    `run_script` uses `capture_output=True` and returned only stdout, so
+    `recent-comments.py`'s "could not resolve your ClickUp user id" warning reached the
+    operator ZERO times through the command everyone actually runs — measured by the audit.
+    Real subprocess, not a stub: the swallowing happened in the plumbing, so a test that
+    stubs the plumbing would pass over the bug.
+    """
+    import tempfile, subprocess as sp
+    with tempfile.TemporaryDirectory() as td:
+        child = Path(td) / "noisy.py"
+        child.write_text(
+            "import sys\n"
+            "print('REAL-STDOUT')\n"
+            "print('CHILD-WARNING-MARKER', file=sys.stderr)\n")
+        orig_dir = check_addressed.SCRIPT_DIR
+        try:
+            check_addressed.SCRIPT_DIR = Path(td)
+            err = io.StringIO()
+            real_err, sys.stderr = sys.stderr, err
+            try:
+                out, rc = check_addressed.run_script("noisy.py")
+            finally:
+                sys.stderr = real_err
+        finally:
+            check_addressed.SCRIPT_DIR = orig_dir
+
+    assert rc == 0 and "REAL-STDOUT" in out, f"stdout was disturbed: {out!r} rc={rc}"
+    assert "CHILD-WARNING-MARKER" in err.getvalue(), (
+        "child stderr was swallowed — a diagnostic the child emits cannot reach the person "
+        f"reading the report: {err.getvalue()!r}")
+    # ⚠️ BY-CONSTRUCTION INVARIANT, not coverage — labelled so nobody counts it twice.
+    # `run_script` returns `result.stdout`, so the child's stderr cannot appear in `out`
+    # whatever the forwarding does. Mutating the forward to write to the parent's STDOUT is
+    # caught by the assertion above (stderr goes empty), never by this one. Kept as a cheap
+    # tripwire for a future rewrite that merges the streams (`stderr=subprocess.STDOUT`).
+    assert "CHILD-WARNING-MARKER" not in out, \
+        "child stderr leaked into the stdout callers parse as data"
+
+
+def test_build_newest_comment_preserves_absent_vs_null():
+    """Absent and null are different facts and both must survive the hand-off.
+
+    JSON round-trips both, so the distinction is only lost if this function flattens it
+    with a `.get()`.
+    """
+    present = check_addressed.build_newest_comment(
+        {"date": "d", "author": "a", "snippet": "s", "my_latest_reply": None})
+    assert "my_latest_reply" in present, \
+        "a reported null reply was flattened to absent, losing 'the producer did look'"
+    absent = check_addressed.build_newest_comment({"date": "d", "author": "a", "snippet": "s"})
+    assert "my_latest_reply" not in absent, \
+        "an unreported reply was invented as null, claiming the producer looked when it did not"

--- a/scripts/check-clickup-addressed/tests/test_ported_hardening.py
+++ b/scripts/check-clickup-addressed/tests/test_ported_hardening.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Regression tests for the hardening ported from PR #1202 (2026-08-21).
+
+That PR ran seven audit rounds on a branch off an older trunk; trunk meanwhile grew its own
+parallel arc. Only the non-overlapping, non-controversial half was ported — the keep-open
+veto redesign was deliberately LEFT BEHIND, because every regression in that arc came from it
+(five rounds, five regressions, each created by the previous round's fix).
+
+What is here, and the mutant each test kills:
+
+  P1  search-sessions.py dropped self-runs with a bare `continue` — no count returned, none
+      printed. The caller saw a shorter list and a smaller "N found" header, which is
+      indistinguishable from the sessions not existing.
+  P2  `is_self_run` reads a transcript to EOF and ran BEFORE the mtime/`--since` filter, so
+      it re-read the whole corpus for an identical result set — once PER TASK. Measured over
+      746 files: 5.8s -> 16.6s, back to 6.0s once moved after term-matching.
+  P3  the keep-open veto decided on a 200-char DISPLAY truncation. The comment that motivated
+      the veto is 196 characters — it cleared the cap by four, so a sentence reorder restored
+      "close it".
+  P4  the search stage's skipped ids were not forwarded, so the completion stage rediscovered
+      and re-counted the same transcripts and the report named one set of files twice.
+  P5  a transcript read error was CACHED, pinning "not a self-run" for the whole process.
+  P6  the guard read every transcript with errors="replace" while the readers did not —
+      UnicodeDecodeError is a ValueError, which `except (JSONDecodeError, OSError)` misses.
+
+Red-at-base matrix, measured against pristine `origin/trunk`: **12 of these 16 fail there,
+4 pass.** The four that pass are INVARIANT GUARDS, not regression coverage, and are labelled
+as such — trunk already skips prior runs on the auto-discovery path (it shipped with that),
+so `test_auto_discovery_*`, `test_skip_count_is_pinned_when_evidence_survives` and
+`test_search_stage_skips_are_excluded_from_the_completion_stage` pin behaviour that is
+already correct. They earn their place by killing mutants, not by having been red.
+
+Two of the twelve are LIVE DEFECTS on trunk, not merely missing coverage:
+  * `test_readers_tolerate_undecodable_bytes` — trunk raises `UnicodeDecodeError` on a
+    transcript containing one invalid byte, which the callers do not catch.
+  * `test_keep_open_veto_reads_past_the_display_truncation` — trunk decides the veto on the
+    200-char snippet, so a refusal written after that boundary produces "close it". That is
+    the 868kr0799 shape with the clauses reordered.
+"""
+import contextlib, io, json, sys, tempfile
+from datetime import datetime
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import importlib.util
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, SCRIPT_DIR / filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+check_completion = _load("check_completion", "check-completion.py")
+search_sessions = _load("search_sessions", "search-sessions.py")
+check_addressed = _load("check_addressed", "check-addressed.py")
+recent_comments = _load("recent_comments", "recent-comments.py")
+import _selfrun as selfrun  # noqa: E402
+
+TARGET = "868krn3y1"
+PRIOR_RUN_REPORT = (
+    "## Task Completion Status\n\n"
+    f"✅ **{TARGET}** — transcripts say `likely_addressed`\n"
+    f"  ✓ resolved: the fix shipped in #1065, merged and verified on trunk\n"
+)
+
+
+def _session(tmpdir, session_id, *texts):
+    mock_dir = Path(tmpdir) / ".claude" / "projects" / "test-project"
+    mock_dir.mkdir(parents=True, exist_ok=True)
+    with open(mock_dir / f"{session_id}.jsonl", "w") as f:
+        for t in texts:
+            f.write(json.dumps(
+                {"type": "assistant", "message": {"content": [{"type": "text", "text": t}]}}
+            ) + "\n")
+    return mock_dir.parent
+
+
+# --------------------------------------------------------------------------- P1
+
+def test_search_sessions_reports_what_it_dropped():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _session(tmp, "prior-run-s", PRIOR_RUN_REPORT)
+        _session(tmp, "real-work-s", f"digging into {TARGET} today")
+        orig, search_sessions.CLAUDE_DIR = search_sessions.CLAUDE_DIR, root
+        stats = {}
+        try:
+            found = search_sessions.search_sessions([TARGET], stats=stats)
+        finally:
+            search_sessions.CLAUDE_DIR = orig
+
+    assert [r["session_id"] for r in found] == ["real-work-s"]
+    assert stats["self_runs_skipped"] == 1, f"drop went unreported: {stats}"
+    assert stats["self_runs_skipped_ids"] == ["prior-run-s"]
+
+
+def test_search_payload_is_an_object_and_round_trips_through_the_consumer():
+    """Producer and consumer asserted TOGETHER, so the two halves cannot drift apart —
+    reverting either alone passed the suite when only one side was pinned."""
+    payload = search_sessions.render_payload(
+        [{"session_id": "s1"}],
+        {"self_runs_skipped": 2, "self_runs_skipped_ids": ["p1", "p2"]})
+    assert isinstance(payload, dict), f"emitted a bare list: {payload!r}"
+    assert check_addressed.parse_search_payload(payload) == \
+        ([{"session_id": "s1"}], 2, ["p1", "p2"])
+
+
+def test_search_payload_tolerates_the_legacy_bare_list():
+    """Back-compat for a stale copy of search-sessions.py: degrade to "no count" rather
+    than a TypeError mid-report."""
+    assert check_addressed.parse_search_payload([{"session_id": "s1"}]) == \
+        ([{"session_id": "s1"}], 0, [])
+
+
+def test_skip_note_reports_both_stages_without_summing():
+    note = check_addressed.skip_note({"self_runs_skipped_search": 2, "self_runs_skipped": 3})
+    assert "2 at session-search" in note and "3 at completion" in note, note
+    assert "5" not in note, f"the two stages were summed, which double-counts: {note}"
+    assert check_addressed.skip_note({"self_runs_skipped_search": 0}) == "", \
+        "announced a drop that did not happen"
+
+
+# --------------------------------------------------------------------------- P2
+
+def test_self_run_check_runs_after_term_matching():
+    """`is_self_run` must never be handed a file that does not match the search terms.
+
+    Pinning only "after the date filter" is NOT enough and that gap shipped once:
+    `check-addressed.py` passes `--since` only when the operator supplies one, so the
+    DEFAULT path has no date filter at all and the whole corpus was re-read per task.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _session(tmp, "irrelevant", "a session about something else entirely")
+        _session(tmp, "relevant", f"working on {TARGET} today")
+        seen = []
+        real = search_sessions.is_self_run
+        search_sessions.is_self_run = lambda p: (seen.append(str(p)), real(p))[1]
+        orig, search_sessions.CLAUDE_DIR = search_sessions.CLAUDE_DIR, root
+        try:
+            search_sessions.search_sessions([TARGET])      # no `since` — the default path
+        finally:
+            search_sessions.CLAUDE_DIR = orig
+            search_sessions.is_self_run = real
+
+    assert [Path(p).stem for p in seen] == ["relevant"], \
+        (f"is_self_run was handed non-matching file(s) — it reads to EOF, so this is a "
+         f"full-corpus re-read per task: {[Path(p).stem for p in seen]}")
+
+
+def test_date_filter_still_precedes_the_self_run_check():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _session(tmp, "ancient", f"{TARGET} mentioned here")
+        seen = []
+        real = search_sessions.is_self_run
+        search_sessions.is_self_run = lambda p: (seen.append(str(p)), real(p))[1]
+        orig, search_sessions.CLAUDE_DIR = search_sessions.CLAUDE_DIR, root
+        try:
+            search_sessions.search_sessions([TARGET], since=datetime(2099, 1, 1))
+        finally:
+            search_sessions.CLAUDE_DIR = orig
+            search_sessions.is_self_run = real
+    assert seen == [], f"read {len(seen)} file(s) the date filter had already excluded"
+
+
+# --------------------------------------------------------------------------- P3
+
+def test_comment_record_carries_full_text_and_a_truncated_snippet():
+    """Literals, not the implementation's own constants — an expectation read from the
+    constant cannot see the constant change. Fixture exceeds BOTH caps, or narrowing the
+    analysis cap to a value above the fixture length is invisible too."""
+    long_text = "y" * 4200 + " do not close"
+    rec = recent_comments.build_record(
+        "868aaa111", "a task", {}, {"date": "1700000000000", "user": {"username": "x"}},
+        long_text)
+    assert len(rec["snippet"]) == 200, f"display snippet cap moved: {len(rec['snippet'])}"
+    assert len(rec["text"]) == 4000, f"analysis cap moved: {len(rec['text'])}"
+    assert rec["text"] == long_text[:4000]
+
+
+def test_newest_comment_carries_full_text_not_just_the_snippet():
+    long_text = "x" * 500 + " do not close"
+    nc = check_addressed.build_newest_comment({"snippet": long_text[:200], "text": long_text})
+    assert nc["text"] == long_text, "full comment text was not carried through"
+    assert len(nc["snippet"]) == 200, "display snippet should stay truncated"
+    assert check_addressed.build_newest_comment({"snippet": "short"})["text"] == "short"
+
+
+def test_keep_open_veto_reads_past_the_display_truncation():
+    """The behavioural half of P3, on trunk's own veto: a refusal written after the 200-char
+    boundary must still veto. Same sentences as the real 868kr0799 comment with the
+    keep-open clause LAST — idiomatic for a status update."""
+    padding = ("MeiliSearch: P95 > 5s (Saturation Burst) fired and resolved repeatedly, "
+               "A=18.97 at 7:55. The 8/17 clean CAPACITY-SWEEP looks like a lucky snapshot "
+               "and the numbers below all come from the same window, so read them together. ")
+    text = padding + "Still live, do not close."
+    assert len(text) > 200, "fixture must exceed the truncation to test anything"
+    flags = check_addressed.disagreements([{
+        "task_id": "868kr0799", "status": "likely_addressed", "clickup_status": "to do",
+        "mentions_found": 3, "newest_comment": {"snippet": text[:200], "text": text},
+    }])
+    assert not any("close it" in f.lower() for f in flags), \
+        f"keep-open clause past the truncation was missed: {flags}"
+    assert any("do NOT close" in f for f in flags), f"veto did not fire: {flags}"
+
+
+# --------------------------------------------------------------------------- P4
+
+def test_search_stage_skips_are_excluded_from_the_completion_stage():
+    """🔴 This test used to BUILD `args` in its own body and assert on its own construction —
+    it imported no production symbol and touched no code path, so deleting the forwarding
+    loop in `main()` left the suite green. Exactly the vacuous shape this suite exists to
+    catch, shipped inside a docstring claiming these tests kill mutants.
+
+    Now it drives the real behaviour end to end: `check_task` must not READ a session that
+    the search stage already dropped, and must not re-count it either.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _session(tmp, "prior-run-fwd", PRIOR_RUN_REPORT)
+        orig, check_completion.CLAUDE_DIR = check_completion.CLAUDE_DIR, root
+        try:
+            # No exclusion: the completion stage rediscovers the prior run and counts it,
+            # which is the double-count the forwarding prevents.
+            without = check_completion.check_task(TARGET)
+            # With the search stage's skip forwarded, it is excluded BEFORE the self-run
+            # check, so it is neither read nor counted a second time.
+            with_fwd = check_completion.check_task(
+                TARGET, exclude_sessions=["prior-run-fwd"])
+        finally:
+            check_completion.CLAUDE_DIR = orig
+
+    assert without["self_runs_skipped"] == 1, \
+        f"positive control: the completion stage should rediscover it: {without}"
+    assert with_fwd["self_runs_skipped"] == 0, \
+        (f"a search-stage skip was re-counted at the completion stage — the report would "
+         f"name one set of files twice: {with_fwd}")
+    assert with_fwd["status"] != "likely_addressed", \
+        f"the excluded prior run was still read as evidence: {with_fwd['status']!r}"
+
+
+def test_main_forwards_skips_and_reports_the_count():
+    """🔴 The JOIN inside `main()`, driven end to end with the three subprocesses stubbed.
+
+    Two mutants survived every earlier attempt at this, because each test exercised the two
+    ENDS and never the wiring: dropping the `--exclude-session` forwarding loop, and
+    hardcoding `self_runs_skipped_search = 0`, both left the suite green. Asserting on
+    `check_task(exclude_sessions=...)` proves the exclusion WORKS; it does not prove `main()`
+    passes it. The only thing that proves the join is running the join.
+    """
+    captured = {}
+
+    def fake_run_script(name, *args):
+        if name == "recent-comments.py":
+            return json.dumps([{
+                "task_id": "868aaa111", "task_name": "a task", "task_status": "to do",
+                "task_priority": "high", "date": "2026-08-21 10:00", "author": "someone",
+                "snippet": "Please take a look.", "text": "Please take a look.",
+            }]), 0
+        if name == "search-sessions.py":
+            captured["search"] = args
+            return json.dumps({"sessions": [], "self_runs_skipped": 2,
+                               "self_runs_skipped_ids": ["prior-a", "prior-b"]}), 0
+        if name == "check-completion.py":
+            captured["check"] = args
+            return json.dumps([{
+                "task_id": "868aaa111", "status": "unclear", "sessions_searched": 0,
+                "mentions_found": 1, "self_runs_skipped": 0, "completion": [], "open": [],
+            }]), 0
+        raise AssertionError(f"unexpected script {name}")
+
+    real_run, real_argv = check_addressed.run_script, sys.argv
+    check_addressed.run_script = fake_run_script
+    sys.argv = ["check-addressed.py", "--limit", "1", "--no-resolve-prs"]
+    out = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(out):
+            check_addressed.main()
+    finally:
+        check_addressed.run_script, sys.argv = real_run, real_argv
+
+    check_args = list(captured.get("check", ()))
+    for sid in ("prior-a", "prior-b"):
+        assert sid in check_args, \
+            f"search-stage skip {sid!r} was not forwarded to the completion stage: {check_args}"
+        assert check_args[check_args.index(sid) - 1] == "--exclude-session", (
+            f"{sid!r} is paired with {check_args[check_args.index(sid) - 1]!r} — a prior run "
+            f"is being fed INTO the completion stage: {check_args}")
+
+    report = out.getvalue()
+    assert "2 at session-search" in report, \
+        f"the search-stage drop never reached the report — it is invisible again:\n{report}"
+
+
+def test_orchestrator_carries_the_search_skip_count_into_the_record():
+    """The JOIN, which was the untested half: `skip_note` was pinned on a hand-built dict
+    and `parse_search_payload` on a hand-built payload, while the line in `main()` wiring one
+    to the other was not — hardcoding it to 0 left the suite green and silently returned the
+    search-stage drop to being invisible.
+
+    Asserted through the real consumer so producer and consumer cannot drift apart.
+    """
+    sessions, skipped, ids = check_addressed.parse_search_payload(
+        {"sessions": [], "self_runs_skipped": 2, "self_runs_skipped_ids": ["p1", "p2"]})
+    record = {"task_id": "868aaa111", "self_runs_skipped_search": skipped}
+    note = check_addressed.skip_note(record)
+    assert "2 at session-search" in note, \
+        f"the parsed search count did not reach the report line: {note!r}"
+    assert ids == ["p1", "p2"]
+
+
+def test_widened_window_did_not_widen_the_close_it_trigger():
+    """🔴 Reading the full comment is for the VETO only.
+
+    Feeding `RESOLVED_COMMENT_RE` the full 4000 chars widens the close-it trigger 20x in the
+    UNSAFE direction. Fixture: a long status comment on an open ticket whose only match is
+    the alert-cycling sense of "resolved", past the 200-char display boundary, with NO
+    keep-open clause anywhere — so the veto cannot rescue it.
+    """
+    padding = ("Weekly status. Throughput held flat across the window and the backlog drained "
+               "on schedule; nothing here needs a decision from anyone this week, and the "
+               "numbers below are all from the same 24h window so they can be read together. ")
+    text = padding + "MeiliSearch: P95 > 5s (Saturation Burst) fired and resolved repeatedly."
+    assert len(padding) > 200, "the trigger phrase must sit past the display truncation"
+
+    flags = check_addressed.disagreements([{
+        "task_id": "868zzz111", "status": "unclear", "clickup_status": "to do",
+        "mentions_found": 3, "newest_comment": {"snippet": text[:200], "text": text},
+    }])
+    assert not any("reads as RESOLVED" in f for f in flags), \
+        (f"an alert-cycling 'resolved' past the display window produced a close-it "
+         f"instruction on a live ticket: {flags}")
+
+
+def test_auto_discovery_skips_prior_runs_and_says_so():
+    """The production fallback: `check_task` with NO session_ids scans the corpus itself.
+    That branch is what `check-addressed.py` reaches whenever search returns 0 sessions —
+    which, now that search itself drops self-runs, is exactly the prior-run scenario."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _session(tmp, "prior-run-auto", PRIOR_RUN_REPORT)
+        orig, check_completion.CLAUDE_DIR = check_completion.CLAUDE_DIR, root
+        try:
+            r = check_completion.check_task(TARGET)          # no session_ids
+        finally:
+            check_completion.CLAUDE_DIR = orig
+    assert r["status"] != "likely_addressed", \
+        f"auto-discovery read a prior run back as evidence: {r['status']!r}"
+    assert r["self_runs_skipped"] == 1, f"skip counter not incremented: {r}"
+
+
+def test_auto_discovery_positive_control():
+    """Control: the same path must still FIND a real session, or the test above could pass
+    by discovering nothing at all."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _session(tmp, "real-work-auto", f"{TARGET}: the fix shipped in #1065, merged.")
+        orig, check_completion.CLAUDE_DIR = check_completion.CLAUDE_DIR, root
+        try:
+            r = check_completion.check_task(TARGET)
+        finally:
+            check_completion.CLAUDE_DIR = orig
+    assert r["status"] == "likely_addressed", f"auto-discovery found nothing: {r['status']!r}"
+    assert r["self_runs_skipped"] == 0
+
+
+def test_skip_count_is_pinned_when_evidence_survives():
+    """The case with the most at stake: a prior run WAS dropped and real evidence still
+    produced a verdict. Asserts 1, deliberately not 0 — a fixture whose expected value
+    equals a hardcoding mutant's literal cannot see that mutant."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _session(tmp, "prior-run-mix", PRIOR_RUN_REPORT)
+        _session(tmp, "real-work-mix", f"{TARGET}: the fix shipped in #1065, merged.")
+        orig, check_completion.CLAUDE_DIR = check_completion.CLAUDE_DIR, root
+        try:
+            r = check_completion.check_task(TARGET)
+        finally:
+            check_completion.CLAUDE_DIR = orig
+    assert r["status"] == "likely_addressed", f"real evidence lost: {r['status']!r}"
+    assert r["self_runs_skipped"] == 1, \
+        f"a dropped prior run went unreported alongside a verdict: {r['self_runs_skipped']!r}"
+
+
+# --------------------------------------------------------------------------- P5 / P6
+
+def test_unreadable_transcript_is_not_cached_as_safe():
+    """A read error answers "not a self-run", the unsafe direction. Caching it pins that
+    answer for the whole process and lets a prior run be read as evidence thereafter."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _session(tmp, "flaky", PRIOR_RUN_REPORT)
+        path = root / "test-project" / "flaky.jsonl"
+        selfrun._cache.pop(str(path), None)
+
+        import builtins
+        real_open, calls = builtins.open, {"n": 0}
+
+        def flaky_open(*a, **kw):
+            if a and str(a[0]) == str(path):
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    raise OSError("transient")
+            return real_open(*a, **kw)
+
+        builtins.open = flaky_open
+        try:
+            first = selfrun.is_self_run(path)
+            second = selfrun.is_self_run(path)
+        finally:
+            builtins.open = real_open
+
+    assert first is False, "positive control: the failed read should answer False"
+    assert second is True, "the read failure was cached, hiding a real self-run"
+
+
+def test_readers_tolerate_undecodable_bytes():
+    """The guard reads every transcript with errors="replace", so a file it tolerates must
+    not then crash a reader. There are FOUR readers — `_find_sessions_for_task` scans the
+    corpus on the DEFAULT path and is missed by any fixture that passes session_ids."""
+    with tempfile.TemporaryDirectory() as tmp:
+        mock_dir = Path(tmp) / ".claude" / "projects" / "test-project"
+        mock_dir.mkdir(parents=True)
+        # Invalid UTF-8 INSIDE a string value, so the JSON stays valid and only the DECODE
+        # fails. Appending garbage after the object tests a different, already-handled defect.
+        line = json.dumps(
+            {"type": "assistant", "message": {"content": [{"type": "text",
+             "text": f"{TARGET} MARKER the fix shipped in #1065, merged."}]}}).encode()
+        assert b"MARKER" in line
+        (mock_dir / "badbytes.jsonl").write_bytes(line.replace(b"MARKER", b"\xff\xfe") + b"\n")
+
+        root = mock_dir.parent
+        oc, check_completion.CLAUDE_DIR = check_completion.CLAUDE_DIR, root
+        os_, search_sessions.CLAUDE_DIR = search_sessions.CLAUDE_DIR, root
+        try:
+            explicit = check_completion.check_task(TARGET, session_ids=["badbytes"])
+            auto = check_completion.check_task(TARGET)
+            found = search_sessions.search_sessions([TARGET])
+        finally:
+            check_completion.CLAUDE_DIR = oc
+            search_sessions.CLAUDE_DIR = os_
+
+    assert explicit["status"] == "likely_addressed", \
+        f"undecodable bytes broke the explicit-session reader: {explicit['status']!r}"
+    assert auto["status"] == "likely_addressed", \
+        f"undecodable bytes broke the corpus-scan reader: {auto['status']!r}"
+    assert [s["session_id"] for s in found] == ["badbytes"], \
+        f"undecodable bytes broke the search reader: {found}"
+
+
+# --------------------------------------------------------------------------- producer
+
+def test_recent_comments_main_actually_collects():
+    """The `main()` -> `_collect()` delegation has no other coverage, and there are no
+    subprocess tests in this suite — so this is the only thing between the CLI and doing
+    nothing at all. The fixture uses `comment: [{"text": …}]`, the shape `extract_text`
+    actually reads; `comment_text` silently yields an empty payload and passes."""
+    calls = {}
+    real = (recent_comments.get_my_user_id, recent_comments.get_my_tasks,
+            recent_comments.get_comments)
+    recent_comments.get_my_user_id = lambda: "me"
+    recent_comments.get_my_tasks = lambda: [
+        {"id": "868aaa111", "name": "a task", "status": {"status": "to do"}}]
+    recent_comments.get_comments = lambda tid: (
+        calls.setdefault("tids", []).append(tid) or
+        [{"user": {"id": "999", "username": "someone"}, "date": "1700000000000",
+          "comment": [{"text": "This is still open."}]}])
+    argv, out = sys.argv, io.StringIO()
+    sys.argv = ["recent-comments.py", "--limit", "1", "--json"]
+    try:
+        with contextlib.redirect_stdout(out):
+            recent_comments.main()
+    finally:
+        sys.argv = argv
+        (recent_comments.get_my_user_id, recent_comments.get_my_tasks,
+         recent_comments.get_comments) = real
+
+    assert calls.get("tids") == ["868aaa111"], f"main() never collected: {calls}"
+    records = json.loads(out.getvalue())
+    assert len(records) == 1, f"the CLI emitted nothing: {records}"
+    assert records[0]["text"] == "This is still open."
+    assert records[0]["task_status"] == "to do", f"status not carried: {records[0]}"
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    passed = failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  ✓ {t.__name__}")
+            passed += 1
+        except Exception as e:
+            print(f"  ✗ {t.__name__}: {type(e).__name__}: {e}")
+            failed += 1
+    print(f"\n{passed} passed, {failed} failed")
+    sys.exit(1 if failed else 0)

--- a/scripts/check-clickup-addressed/tests/test_ported_hardening.py
+++ b/scripts/check-clickup-addressed/tests/test_ported_hardening.py
@@ -174,7 +174,7 @@ def test_comment_record_carries_full_text_and_a_truncated_snippet():
     long_text = "y" * 4200 + " do not close"
     rec = recent_comments.build_record(
         "868aaa111", "a task", {}, {"date": "1700000000000", "user": {"username": "x"}},
-        long_text)
+        long_text, None)
     assert len(rec["snippet"]) == 200, f"display snippet cap moved: {len(rec['snippet'])}"
     assert len(rec["text"]) == 4000, f"analysis cap moved: {len(rec['text'])}"
     assert rec["text"] == long_text[:4000]

--- a/scripts/check-clickup-addressed/tests/test_recent_comments.py
+++ b/scripts/check-clickup-addressed/tests/test_recent_comments.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Tests for recent-comments.py — ClickUp API integration."""
+import json, os, sys, tempfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# Import the module by loading the file directly
+SCRIPT_DIR = Path(__file__).parent.parent
+import importlib.util
+spec = importlib.util.spec_from_file_location("recent_comments", SCRIPT_DIR / "recent-comments.py")
+recent_comments = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(recent_comments)
+
+
+def test_extract_text():
+    """Test extracting text from comment object."""
+    comment = {"comment": [{"text": "Hello "}, {"text": "world"}]}
+    result = recent_comments.extract_text(comment)
+    # The function joins with space, so "Hello " + " " + "world" = "Hello  world"
+    assert "Hello" in result and "world" in result
+
+
+def test_extract_text_empty():
+    """Test extracting text from empty comment."""
+    comment = {"comment": []}
+    result = recent_comments.extract_text(comment)
+    assert result == ""
+
+
+def test_extract_text_nested():
+    """Test extracting text with nested objects."""
+    comment = {"comment": [{"text": "Hello"}, {"not_text": "ignored"}, {"text": "world"}]}
+    result = recent_comments.extract_text(comment)
+    assert "Hello" in result and "world" in result
+
+
+def test_format_date_valid():
+    """Test formatting a valid timestamp."""
+    # 2026-08-19 12:00:00 UTC (approximately)
+    ts_ms = 1787227200000
+    result = recent_comments.format_date(ts_ms)
+    # Just check it returns a string with the date
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+def test_format_date_invalid():
+    """Test formatting an invalid timestamp."""
+    result = recent_comments.format_date("invalid")
+    assert result == "invalid"
+
+
+def test_format_date_none():
+    """Test formatting None timestamp."""
+    result = recent_comments.format_date(None)
+    assert result == "None"
+
+
+def test_run_clickup_mock():
+    """Test run_clickup with mocked subprocess."""
+    mock_result = MagicMock()
+    mock_result.stdout = "User: Test User\nID: 12345"
+    
+    with patch("subprocess.run", return_value=mock_result) as mock_run:
+        result = recent_comments.run_clickup("me")
+        assert result == "User: Test User\nID: 12345"
+        mock_run.assert_called_once()
+
+
+def test_get_my_user_id():
+    """Test extracting user ID from output."""
+    with patch.object(recent_comments, "run_clickup", return_value="User: Test\nID: 12345\nEmail: test@test.com"):
+        result = recent_comments.get_my_user_id()
+        assert result == "12345"
+
+
+def test_get_my_user_id_not_found():
+    """Test when user ID is not in output."""
+    with patch.object(recent_comments, "run_clickup", return_value="User: Test\nNo ID here"):
+        result = recent_comments.get_my_user_id()
+        assert result is None
+
+
+def test_get_my_tasks_mock():
+    """Test get_my_tasks with mocked API response."""
+    mock_tasks = [{"id": "868ktvqf9", "name": "Test Task"}]
+    mock_output = "Scanned 19 spaces\n" + json.dumps(mock_tasks)
+    
+    with patch.object(recent_comments, "run_clickup", return_value=mock_output):
+        result = recent_comments.get_my_tasks()
+        assert len(result) == 1
+        assert result[0]["id"] == "868ktvqf9"
+
+
+def test_get_my_tasks_empty():
+    """Test get_my_tasks with empty response."""
+    with patch.object(recent_comments, "run_clickup", return_value="No tasks found"):
+        result = recent_comments.get_my_tasks()
+        assert len(result) == 0
+
+
+def test_get_comments_mock():
+    """Test get_comments with mocked API response."""
+    mock_comments = [{"id": "123", "comment": [{"text": "Test comment"}], "user": {"id": "999"}, "date": "1787227200000"}]
+    mock_output = json.dumps(mock_comments)
+    
+    with patch.object(recent_comments, "run_clickup", return_value=mock_output):
+        result = recent_comments.get_comments("868ktvqf9")
+        assert len(result) == 1
+        assert result[0]["id"] == "123"
+
+
+def test_filter_my_comments():
+    """Test that my own comments are filtered out."""
+    my_id = "81593871"
+    comments = [
+        {"id": "1", "comment": [{"text": "My comment"}], "user": {"id": "81593871"}, "date": "1787227200000"},
+        {"id": "2", "comment": [{"text": "Other comment"}], "user": {"id": "99999"}, "date": "1787227200000"},
+    ]
+    
+    # Simulate filtering logic
+    filtered = [c for c in comments if str(c.get("user", {}).get("id", "")) != my_id]
+    assert len(filtered) == 1
+    assert filtered[0]["id"] == "2"
+
+
+def test_sort_by_date():
+    """Test that comments are sorted by date (newest first)."""
+    comments = [
+        {"task_id": "1", "date": "2026-08-17 10:00"},
+        {"task_id": "2", "date": "2026-08-19 10:00"},
+        {"task_id": "3", "date": "2026-08-18 10:00"},
+    ]
+    
+    sorted_comments = sorted(comments, key=lambda x: x["date"], reverse=True)
+    assert sorted_comments[0]["task_id"] == "2"  # Aug 19
+    assert sorted_comments[1]["task_id"] == "3"  # Aug 18
+    assert sorted_comments[2]["task_id"] == "1"  # Aug 17
+
+
+def test_limit_results():
+    """Test that results are limited to N items."""
+    comments = [{"task_id": str(i)} for i in range(10)]
+    limited = comments[:3]
+    assert len(limited) == 3
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in globals().items() if k.startswith("test_")]
+    passed = 0
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            print(f"  ✓ {test.__name__}")
+            passed += 1
+        except Exception as e:
+            print(f"  ✗ {test.__name__}: {e}")
+            failed += 1
+    print(f"\n{passed} passed, {failed} failed")
+    sys.exit(1 if failed else 0)

--- a/scripts/check-clickup-addressed/tests/test_repo_vocab_and_waiting.py
+++ b/scripts/check-clickup-addressed/tests/test_repo_vocab_and_waiting.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""Round 5 (2026-08-21). Three defects found by RUNNING the tool, not by reading it.
+
+  D9   `_repo_for_ref` returns None in two different situations and `annotate_pr_refs`
+       renders both as "unresolved (repo not named)". When a repo IS named but is absent
+       from KNOWN_REPOS, that message is FALSE. Measured live on the snippet
+       `| **#4181**, **devrc #591** | merged, verified by content |`: the regex captured
+       word='devrc' — the repo was named — yet the report said it was not. Both PRs were
+       resolvable by hand (civitai/civitai#4181 MERGED, innovation-upstream/devrc#591
+       MERGED), so round 2's "is this cited PR actually still open?" cross-check
+       contributed NOTHING on the one task in the run that had completion signals, while
+       reporting a cause that was wrong. Same closed-vocabulary silent-miss class as D6,
+       but worse: a wrong explanation stops the reader looking, where an honest "I don't
+       know this repo" sends them to add it.
+
+  D10  round 4's `confidence_marker()` is used by check-completion.py's own printer and
+       NOT by check-addressed.py, the entry point everyone runs. That printer's `✓`/`○`
+       mark completion-vs-open, not confidence, so the adjacency signal never reached the
+       report. Measured at base: a signal at proximity 1.5 (task ID inside its own
+       snippet) and one at 1.0 (merely in the same ±2000-char window) rendered
+       identically. This is the "a guard's DESCRIPTION claims coverage wider than its
+       implementation" defect, walked into while fixing that defect class.
+
+  D11  `disagreements()` emitted nothing for a task that is OPEN, has ZERO transcript
+       evidence, and carries a recent comment from someone else. Measured live on
+       868kuam02: `to do`/high, @Ellie King 2026-08-20, 0 mentions — and the "Needs a
+       decision" block said nothing. Nothing "disagrees", so every existing rule stayed
+       quiet, but "a colleague asked you something and no work exists anywhere" is the
+       most actionable thing this tool can detect.
+
+Tests marked INVARIANT GUARD pass at base too. They are false-positive controls, not
+regression coverage; several of them exist only to kill a WIDENING mutant (a flag that
+fires on everything is as useless as one that fires on nothing).
+"""
+import importlib.util, io, json, sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+spec = importlib.util.spec_from_file_location("check_completion", SCRIPT_DIR / "check-completion.py")
+check_completion = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check_completion)
+
+spec2 = importlib.util.spec_from_file_location("check_addressed", SCRIPT_DIR / "check-addressed.py")
+check_addressed = importlib.util.module_from_spec(spec2)
+spec2.loader.exec_module(check_addressed)
+
+# The exact snippet the live run produced, verbatim from `check-addressed.py --limit 5`
+# on 2026-08-21 (task 868ktvqf9).
+LIVE_SNIPPET = "| **#4181**, **devrc #591** | merged, verified by content |"
+
+NOW = datetime(2026, 8, 21, 12, 0, tzinfo=timezone.utc)
+
+
+def _no_network():
+    """Swap the GitHub call for a recording stub. Returns (restore, calls)."""
+    calls = []
+    orig = check_completion.resolve_pr
+
+    def stub(repo, num):
+        calls.append((repo, num))
+        return "merged 2026-08-20"
+
+    check_completion.resolve_pr = stub
+
+    def restore():
+        check_completion.resolve_pr = orig
+
+    return restore, calls
+
+
+def _state(snippet, ref_num):
+    restore, _ = _no_network()
+    try:
+        sig = [{"signal": "PR merged", "snippet": snippet}]
+        check_completion.annotate_pr_refs(sig, default_repo=None)
+    finally:
+        restore()
+    for r in sig[0].get("pr_refs", []):
+        if r["ref"].endswith(f"#{ref_num}"):
+            return r["ref"], r["state"]
+    raise AssertionError(f"#{ref_num} produced no pr_ref at all: {sig[0].get('pr_refs')}")
+
+
+# --------------------------------------------------------------------------- D9
+
+def test_a_named_but_unknown_repo_is_not_reported_as_unnamed():
+    """The false message. `devrc` IS named; it is merely absent from KNOWN_REPOS.
+
+    At base both refs in this live snippet came back "unresolved (repo not named)".
+    """
+    ref, state = _state("| **#4181**, **notarepo-xyz #591** | merged |", "591")
+    assert "not named" not in state, \
+        f"a NAMED repo was reported as unnamed — the message is false: {state!r}"
+    assert "notarepo-xyz" in state, \
+        f"the unknown repo must be named so the reader can add it: {state!r}"
+
+
+def test_the_unknown_repo_message_says_what_to_do():
+    """An honest 'I don't know this repo' has to send the reader somewhere.
+
+    D6's lesson: widening the vocabulary is not the fix, the announcement is. A message
+    that names the gap without naming the table it is missing from is half a message.
+    """
+    _, state = _state("fix landed in notarepo-xyz #4242", "4242")
+    assert "KNOWN_REPOS" in state, \
+        f"the message does not name the table to add the repo to: {state!r}"
+
+
+def test_devrc_now_resolves_to_innovation_upstream():
+    """The live case. Verified with `gh repo view`: devrc is innovation-upstream/devrc,
+    NOT a civitai repo — the owner is the part a guess gets wrong."""
+    restore, calls = _no_network()
+    try:
+        sig = [{"signal": "PR merged", "snippet": LIVE_SNIPPET}]
+        check_completion.annotate_pr_refs(sig, default_repo=None)
+    finally:
+        restore()
+    assert ("innovation-upstream/devrc", "591") in calls, \
+        f"devrc #591 did not resolve to innovation-upstream/devrc: {calls}"
+
+
+def test_the_hub_repos_are_all_present_and_correctly_owned():
+    """A ledger, not a spot-check. Every owner verified with `gh repo view` 2026-08-21.
+
+    Pinned as an exact mapping so the table cannot silently gain a guessed owner — the
+    devrc case proves the owner is exactly what a guess gets wrong.
+    """
+    expected = {
+        "talos-infra": "civitai/talos-infra",
+        "civitai": "civitai/civitai",
+        "civitai-orchestration": "civitai/civitai-orchestration",
+        "civitai-image-cacher": "civitai/civitai-image-cacher",
+        "civitai-spine-controller": "civitai/civitai-spine-controller",
+        "cli": "civitai/cli",
+        "storage-resolver": "civitai/storage-resolver",
+        "flipt-state": "civitai/flipt-state",
+        "devrc": "innovation-upstream/devrc",
+    }
+    assert check_completion.KNOWN_REPOS == expected, \
+        ("KNOWN_REPOS drifted. Verify any new entry with `gh repo view <owner>/<name>` "
+         f"before adding it here.\n  got:      {check_completion.KNOWN_REPOS}\n"
+         f"  expected: {expected}")
+
+
+def test_a_genuinely_unnamed_ref_still_says_not_named():
+    """INVARIANT GUARD — passes at base. The refusal to guess is deliberate and stays.
+
+    `#4181` in the live snippet has no repo word before it and no known repo within
+    REPO_LOOKBEHIND. "repo not named" is the CORRECT message there, and the D9 fix must
+    not relabel it as an unknown-repo problem.
+    """
+    _, state = _state(LIVE_SNIPPET, "4181")
+    assert state == "unresolved (repo not named)", \
+        f"the honest not-named case was relabelled: {state!r}"
+
+
+def test_an_unknown_repo_is_still_never_guessed():
+    """INVARIANT GUARD / widening control — passes at base.
+
+    Naming the unknown repo must not become resolving it. Guessing an owner is the
+    round-2 failure (`civitai/civitai#1080: merged 2024-03-18`), and it is worse than
+    admitting ignorance.
+    """
+    restore, calls = _no_network()
+    try:
+        sig = [{"signal": "PR merged", "snippet": "notarepo-xyz #591 merged"}]
+        check_completion.annotate_pr_refs(sig, default_repo=None)
+    finally:
+        restore()
+    assert calls == [], f"an unknown repo name was guessed at and resolved: {calls}"
+
+
+def test_ambiguous_repos_are_named_rather_than_called_unnamed():
+    """Third arm of the same wrong message: two known repos in range, neither adjacent.
+
+    Repos WERE named there; the problem is that more than one was. Reporting that as
+    "repo not named" is the same false explanation in a different shape.
+    """
+    _, state = _state("civitai talos-infra saw #1065 merged", "1065")
+    assert "not named" not in state, f"ambiguity reported as absence: {state!r}"
+    assert "civitai/civitai" in state and "civitai/talos-infra" in state, \
+        f"the ambiguous candidates are not named: {state!r}"
+
+
+# --------------------------------------------------------------------------- D10
+
+def test_report_lines_carry_the_adjacency_marker():
+    """The entry point's report must show adjacency, not just completion-vs-open.
+
+    At base a proximity-1.5 signal and a proximity-1.0 signal rendered IDENTICALLY:
+        ✓ PR merged: ADJACENT ...
+        ✓ PR merged: FAR AWAY ...
+    """
+    adjacent = {"signal": "PR merged", "snippet": "ADJACENT", "proximity": 1.5}
+    far = {"signal": "PR merged", "snippet": "FAR AWAY", "proximity": 1.0}
+    line_a = check_addressed.signal_line("✓", adjacent, verbose=False)
+    line_f = check_addressed.signal_line("✓", far, verbose=False)
+    assert line_a != line_f, \
+        f"adjacent and same-window-only signals render identically: {line_a!r}"
+    assert "●" in line_a, f"adjacent signal is not marked ●: {line_a!r}"
+    assert "●" not in line_f, f"a same-window-only signal was marked ●: {line_f!r}"
+
+
+def test_the_adjacency_marker_does_not_collide_with_the_open_glyph():
+    """`○` already means 'open item' in the first column of this report.
+
+    Reusing one glyph for two orthogonal facts is how a marker becomes unreadable, so the
+    adjacency field must be visually separated from the completion/open glyph rather than
+    merged into it.
+    """
+    far_open = {"signal": "still open", "snippet": "FAR", "proximity": 1.0}
+    line = check_addressed.signal_line("○", far_open, verbose=False)
+    assert line.count("○") == 2, \
+        f"the two ○ meanings are not separable on this line: {line!r}"
+    assert "[○]" in line, \
+        f"the adjacency field is not delimited from the kind glyph: {line!r}"
+
+
+def test_the_entry_point_agrees_with_check_completion_at_every_boundary():
+    """One vocabulary, one threshold — asserted BEHAVIOURALLY, across the boundary.
+
+    Object identity cannot be asserted here: this test file loads check-completion.py with
+    its own `exec_module`, and check-addressed.py loads a second, independent instance, so
+    `is` compares two different function objects even when the import is correct. That
+    version of this test failed for a reason that had nothing to do with the code.
+
+    Behavioural equivalence is also the stronger claim: it catches the hazard that actually
+    matters — a re-implementation with a DIFFERENT threshold, which object identity would
+    catch only by accident. The sweep straddles ADJACENCY_MARK on both sides and lands
+    exactly ON it, since a boundary is where two copies of a rule diverge first.
+    """
+    mark = check_completion.ADJACENCY_MARK
+    for prox in (0.0, 0.5, 1.0, mark - 0.01, mark, mark + 0.01, 1.5, 99.0):
+        mine = check_addressed.confidence_marker({"proximity": prox})
+        theirs = check_completion.confidence_marker({"proximity": prox})
+        assert mine == theirs, \
+            f"the two markers disagree at proximity {prox}: {mine!r} vs {theirs!r}"
+    # Positive control: the sweep must actually see BOTH values, or agreement is vacuous.
+    seen = {check_addressed.confidence_marker({"proximity": p}) for p in (1.0, 1.5)}
+    assert seen == {"●", "○"}, f"the sweep never exercised both markers: {seen}"
+
+
+def test_the_marker_legend_is_printed_in_the_report():
+    """An unexplained glyph is a glyph nobody reads. The report must say what ● / ○ mean.
+
+    Driven through main() with stubbed sub-processes so this asserts what an operator
+    actually sees, not what a helper returns.
+    """
+    out = _run_main(["--no-resolve-prs"], completion=[
+        {"signal": "PR merged", "snippet": "x", "proximity": 1.5}])
+    assert "●" in out and "○" in out, f"no legend glyphs in the report:\n{out}"
+    assert "same" in out.lower() and "window" in out.lower(), \
+        f"the legend does not explain what ○ means:\n{out}"
+
+
+def _run_main(argv, completion=None, open_items=None, status="partially_addressed",
+              mentions=3, clickup_status="to do", comment="hi", comment_date=None,
+              task="868ktvqf9"):
+    """Drive check-addressed.main() with every sub-process stubbed. Returns stdout."""
+    def fake(name, *args):
+        if name == "recent-comments.py":
+            return json.dumps([{
+                "task_id": task, "task_name": "t", "task_status": clickup_status,
+                "task_priority": "high",
+                "date": comment_date or NOW.strftime("%Y-%m-%d %H:%M"),
+                "author": "colleague", "snippet": comment}]), 0
+        if name == "search-sessions.py":
+            return "[]", 0
+        return json.dumps([{
+            "task_id": task, "status": status, "sessions_searched": 1,
+            "mentions_found": mentions, "completion": completion or [],
+            "open": open_items or []}]), 0
+
+    orig_run, orig_argv, orig_stdout = check_addressed.run_script, sys.argv, sys.stdout
+    check_addressed.run_script = fake
+    sys.argv = ["check-addressed.py", *argv]
+    sys.stdout = io.StringIO()
+    try:
+        check_addressed.main()
+        return sys.stdout.getvalue()
+    finally:
+        check_addressed.run_script, sys.argv, sys.stdout = orig_run, orig_argv, orig_stdout
+
+
+def test_both_marker_values_reach_a_real_report():
+    """Positive control on BOTH values — a marker that can only print one symbol is the
+    exact defect round 4 fixed, reintroduced one layer up.
+
+    Mirrors the live distribution measured 2026-08-21: 868ktvqf9 carries proximity 1.5
+    AND 1.0 signals; 868kt8pfu carries only 1.0.
+    """
+    out = _run_main(["--no-resolve-prs"], completion=[
+        {"signal": "PR merged", "snippet": "ADJACENT", "proximity": 1.5},
+        {"signal": "PR merged", "snippet": "FAR AWAY", "proximity": 1.0}])
+    body = [l for l in out.splitlines() if "ADJACENT" in l or "FAR AWAY" in l]
+    assert len(body) == 2, f"both signals must be printed: {body}"
+    adj = next(l for l in body if "ADJACENT" in l)
+    far = next(l for l in body if "FAR AWAY" in l)
+    assert "[●]" in adj, f"live-shaped adjacent signal not marked ●: {adj!r}"
+    assert "[○]" in far, f"live-shaped distant signal not marked ○: {far!r}"
+
+
+# --------------------------------------------------------------------------- D11
+
+def _waiting(days_ago=1, status="to do", mentions=0, transcript="no_mentions_found"):
+    d = (NOW - timedelta(days=days_ago)).strftime("%Y-%m-%d %H:%M")
+    return {
+        "task_id": "868kuam02", "status": transcript, "sessions_searched": 1,
+        "mentions_found": mentions, "clickup_status": status, "clickup_priority": "high",
+        "newest_comment": {"date": d, "author": "Ellie King",
+                           "snippet": "Follow-up from the reporter, on why this looks pixelated"},
+        "completion": [], "open": [],
+    }
+
+
+def _flags(r):
+    return check_addressed.disagreements([r], now=NOW)
+
+
+def test_an_unanswered_comment_with_zero_evidence_is_flagged():
+    """The live 868kuam02 shape. At base: [].
+
+    An open ticket + zero transcript evidence anywhere + a recent comment from someone
+    else means a human asked and nobody has started. Nothing "disagrees", so every
+    existing rule stayed silent about the most actionable state in the report.
+    """
+    flags = _flags(_waiting())
+    waiting = [f for f in flags if "WAITING" in f]
+    assert waiting, f"an unanswered colleague comment over zero evidence produced no flag: {flags}"
+    joined = " ".join(waiting).lower()
+    assert "868kuam02" in joined, f"the flag does not name the task: {waiting}"
+    assert "ellie king" in joined, f"the flag does not name who is waiting: {waiting}"
+
+
+def test_no_sessions_found_is_the_same_zero_evidence_state():
+    """Gate on the STATE (mentions_found == 0), not on one status word.
+
+    `no_sessions_found` and `no_mentions_found` are both zero evidence. A guard spelled
+    against one word passes while the hazard exists in the other's shape.
+    """
+    assert any("WAITING" in f for f in _flags(_waiting(transcript="no_sessions_found"))), \
+        "no_sessions_found is zero evidence too, and was not flagged"
+
+
+def test_an_unknown_clickup_status_does_not_disable_the_waiting_flag():
+    """D6's lesson applied forward: this flag must not join the closed-vocabulary gate.
+
+    'a human is waiting and no work exists' is safe to surface whatever the status word
+    reads, exactly like the keep-open veto.
+
+    🔴 This assertion looks for the WAITING flag specifically, not merely for a non-empty
+    list. `in review` also trips round 4's unknown-status announcement, so the weaker
+    `assert flags` was GREEN FOR THE OTHER GUARD'S REASON: the M42 mutant (which rebuilds
+    exactly this blind spot by gating on OPEN_STATUSES) SURVIVED a fully green suite, and
+    only tightening the assertion killed it.
+    """
+    flags = _flags(_waiting(status="in review"))
+    assert any("WAITING" in f for f in flags), \
+        f"an unrecognised status silently disabled the waiting flag — D6 all over again: {flags}"
+    # Positive control on the OTHER guard: both flags must fire here, so this test cannot
+    # pass by having quietly suppressed round 4's announcement.
+    assert any("DID NOT RUN" in f for f in flags), \
+        f"the round-4 unknown-status announcement stopped firing: {flags}"
+
+
+# --- the widening direction: a flag that fires on everything is as useless as one that
+# --- fires on nothing. Each of these is green at base by construction (base flags
+# --- nothing), so they are controls; they earn their place under mutation.
+
+def test_a_stale_backlog_comment_does_not_fire():
+    """INVARIANT GUARD / widening control.
+
+    Bounded by RECENCY rather than priority. Priority is a property of the TICKET, set
+    once and often stale; recency is a property of the INTERACTION and says a human is
+    waiting NOW. A recency bound also self-clears, so the flag's false-positive volume is
+    bounded by construction — and a permanently-noisy block trains the reader to skip it.
+    """
+    assert _flags(_waiting(days_ago=90)) == [], \
+        "every unstarted backlog item with an old comment would be flagged forever"
+
+
+def test_evidence_in_the_transcripts_suppresses_the_flag():
+    """INVARIANT GUARD / widening control. The claim is 'no work exists ANYWHERE'.
+
+    Once a transcript mentions the task there IS evidence, and the existing verdict
+    branches own it.
+    """
+    assert _flags(_waiting(mentions=7, transcript="unclear")) == [], \
+        "the flag fired over a task the transcripts actually discuss"
+
+
+def test_a_closed_ticket_does_not_fire():
+    """INVARIANT GUARD / widening control. A done ticket with no transcript evidence is
+    already covered by the 'verify before trusting the close' flag; claiming someone is
+    waiting on it would be false."""
+    for f in _flags(_waiting(status="complete")):
+        assert "waiting" not in f.lower(), f"a closed ticket was reported as waiting: {f}"
+
+
+def test_a_record_with_no_mention_count_does_not_fire():
+    """INVARIANT GUARD / widening control — and the one a real fixture caught.
+
+    "no work exists ANYWHERE" is the strongest claim this flag makes. Deriving it from a
+    key that is simply ABSENT is the field-that-is-not-a-guard mistake inverted: the count
+    must be present and zero, never defaulted to zero. Found by round 2's
+    `test_no_flag_when_ticket_and_comment_agree`, whose fixture omits the key — the first
+    draft of this flag fired on it.
+    """
+    r = _waiting()
+    del r["mentions_found"]
+    assert _flags(r) == [], "a record that never reported a mention count was read as zero evidence"
+
+
+def test_a_record_with_no_comment_date_does_not_fire():
+    """INVARIANT GUARD / widening control. ABSENT and MALFORMED are different facts.
+
+    Absent means there is no interaction to be recent about. Only a date that is present
+    and unreadable indicates the formatter drifted, and only that one announces itself.
+    """
+    r = _waiting()
+    r["newest_comment"].pop("date")
+    assert _flags(r) == [], "a record with no comment date was treated as a fresh comment"
+
+
+def test_an_unparseable_comment_date_is_surfaced_not_swallowed():
+    """A date this checker cannot read must not silently become 'not recent'.
+
+    That is the reassuring-nothing this whole skill exists to police: an unparseable date
+    is unknown age, and a missed waiting human costs more than one noisy line.
+    """
+    r = _waiting()
+    r["newest_comment"]["date"] = "yesterday-ish"
+    flags = _flags(r)
+    assert flags, "an unparseable comment date silently disabled the flag"
+    assert any("date" in f.lower() for f in flags), \
+        f"the flag does not admit the date was unreadable: {flags}"
+
+
+def test_round_four_flags_all_still_fire():
+    """INVARIANT GUARD — the round-4 and round-3 behaviour must survive round 5."""
+    keep_open = {"task_id": "868kr0799", "status": "unclear", "mentions_found": 2,
+                 "clickup_status": "to do",
+                 "newest_comment": {"date": NOW.strftime("%Y-%m-%d %H:%M"),
+                                    "author": "Justin Maier",
+                                    "snippet": "Still live, do not close. P95 > 5s fired and resolved repeatedly."},
+                 "completion": [], "open": []}
+    joined = " ".join(check_addressed.disagreements([keep_open], now=NOW))
+    assert "do NOT close" in joined, f"the round-3 keep-open veto stopped firing: {joined}"
+    assert "close it, or say why" not in joined, f"veto lost its suppression: {joined}"
+
+    unknown = {"task_id": "868kzzzzz", "status": "likely_addressed", "mentions_found": 4,
+               "clickup_status": "in review",
+               "newest_comment": {"date": NOW.strftime("%Y-%m-%d %H:%M"),
+                                  "author": "x", "snippet": "Resolved. Recommend closing."},
+               "completion": [], "open": []}
+    joined = " ".join(check_addressed.disagreements([unknown], now=NOW)).lower()
+    assert "did not run" in joined, f"the round-4 unknown-status announcement was lost: {joined}"
+
+
+def test_disagreements_still_works_without_an_explicit_now():
+    """INVARIANT GUARD — `now` is a test seam, not a required argument. main() calls
+    disagreements(results) with one argument and must keep working."""
+    r = _waiting(days_ago=0)
+    r["newest_comment"]["date"] = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M")
+    assert check_addressed.disagreements([r]), \
+        "disagreements() lost its default clock and stopped flagging a fresh comment"
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    passed = failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  ✓ {t.__name__}")
+            passed += 1
+        except SystemExit as e:
+            print(f"  ✗ {t.__name__}: SystemExit({e.code}) escaped the test")
+            failed += 1
+        except Exception as e:
+            print(f"  ✗ {t.__name__}: {type(e).__name__}: {e}")
+            failed += 1
+    print(f"\n{passed} passed, {failed} failed")
+    sys.exit(1 if failed else 0)

--- a/scripts/check-clickup-addressed/tests/test_search_sessions.py
+++ b/scripts/check-clickup-addressed/tests/test_search_sessions.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Tests for search-sessions.py — session transcript search."""
+import json, os, sys, tempfile
+from pathlib import Path
+
+# Import the module by loading the file directly
+SCRIPT_DIR = Path(__file__).parent.parent
+import importlib.util
+spec = importlib.util.spec_from_file_location("search_sessions", SCRIPT_DIR / "search-sessions.py")
+search_sessions = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(search_sessions)
+
+
+def test_load_session_basic():
+    """Test loading a session with user and assistant messages."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+        f.write(json.dumps({"type": "user", "message": {"content": "Hello"}}) + "\n")
+        f.write(json.dumps({"type": "assistant", "message": {"content": [{"type": "text", "text": "Hi there"}]}}) + "\n")
+        f.write(json.dumps({"type": "ai-title", "aiTitle": "Test Session"}) + "\n")
+        f.flush()
+        
+        try:
+            entries = search_sessions.load_session(f.name)
+            assert len(entries) == 3
+            assert entries[0] == ("user", "Hello")
+            assert entries[1] == ("assistant", "Hi there")
+            assert entries[2] == ("title", "Test Session")
+        finally:
+            os.unlink(f.name)
+
+
+def test_load_session_empty():
+    """Test loading an empty session."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+        f.flush()
+        
+        try:
+            entries = search_sessions.load_session(f.name)
+            assert len(entries) == 0
+        finally:
+            os.unlink(f.name)
+
+
+def test_load_session_tool_use():
+    """Test loading a session with tool use blocks."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+        f.write(json.dumps({"type": "assistant", "message": {"content": [
+            {"type": "text", "text": "Let me check."},
+            {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}}
+        ]}}) + "\n")
+        f.flush()
+        
+        try:
+            entries = search_sessions.load_session(f.name)
+            assert len(entries) == 1
+            assert "Let me check." in entries[0][1]
+            assert "ls" in entries[0][1]  # Tool input should be included
+        finally:
+            os.unlink(f.name)
+
+
+def test_search_sessions_no_match():
+    """Test searching for terms that don't exist."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        projects_dir = Path(tmpdir) / "projects"
+        projects_dir.mkdir()
+        
+        # Create a mock session
+        session_dir = projects_dir / "test-project"
+        session_dir.mkdir()
+        session_file = session_dir / "session1.jsonl"
+        
+        with open(session_file, "w") as f:
+            f.write(json.dumps({"type": "assistant", "message": {"content": [{"type": "text", "text": "Hello world"}]}}) + "\n")
+        
+        # Override CLAUDE_DIR
+        original_dir = search_sessions.CLAUDE_DIR
+        search_sessions.CLAUDE_DIR = projects_dir
+        
+        try:
+            results = search_sessions.search_sessions(["nonexistent_term_xyz123"])
+            assert len(results) == 0
+        finally:
+            search_sessions.CLAUDE_DIR = original_dir
+
+
+def test_search_sessions_match():
+    """Test searching for terms that exist."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        projects_dir = Path(tmpdir) / "projects"
+        projects_dir.mkdir()
+        
+        # Create a mock session
+        session_dir = projects_dir / "test-project"
+        session_dir.mkdir()
+        session_file = session_dir / "session1.jsonl"
+        
+        with open(session_file, "w") as f:
+            f.write(json.dumps({"type": "assistant", "message": {"content": [{"type": "text", "text": "Task 868ktvqf9 was fixed. PR #123 merged."}]}}) + "\n")
+        
+        # Override CLAUDE_DIR
+        original_dir = search_sessions.CLAUDE_DIR
+        search_sessions.CLAUDE_DIR = projects_dir
+        
+        try:
+            results = search_sessions.search_sessions(["868ktvqf9"])
+            assert len(results) == 1
+            assert results[0]["session_id"] == "session1"
+            assert results[0]["hits"] >= 1
+        finally:
+            search_sessions.CLAUDE_DIR = original_dir
+
+
+def test_search_sessions_multiple_terms():
+    """Test searching with multiple terms (AND logic)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        projects_dir = Path(tmpdir) / "projects"
+        projects_dir.mkdir()
+        
+        # Create a mock session with both terms
+        session_dir = projects_dir / "test-project"
+        session_dir.mkdir()
+        session_file = session_dir / "session1.jsonl"
+        
+        with open(session_file, "w") as f:
+            f.write(json.dumps({"type": "assistant", "message": {"content": [{"type": "text", "text": "868ktvqf9 was fixed. Exit 0 confirmed."}]}}) + "\n")
+        
+        # Override CLAUDE_DIR
+        original_dir = search_sessions.CLAUDE_DIR
+        search_sessions.CLAUDE_DIR = projects_dir
+        
+        try:
+            # Should match (both terms present)
+            results = search_sessions.search_sessions(["868ktvqf9", "exit 0"])
+            assert len(results) == 1
+            
+            # Should not match (one term missing)
+            results = search_sessions.search_sessions(["868ktvqf9", "nonexistent"])
+            assert len(results) == 0
+        finally:
+            search_sessions.CLAUDE_DIR = original_dir
+
+
+def test_search_sessions_any_mode():
+    """Test searching with --any (OR logic)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        projects_dir = Path(tmpdir) / "projects"
+        projects_dir.mkdir()
+        
+        # Create a mock session with only one term
+        session_dir = projects_dir / "test-project"
+        session_dir.mkdir()
+        session_file = session_dir / "session1.jsonl"
+        
+        with open(session_file, "w") as f:
+            f.write(json.dumps({"type": "assistant", "message": {"content": [{"type": "text", "text": "868ktvqf9 was fixed."}]}}) + "\n")
+        
+        # Override CLAUDE_DIR
+        original_dir = search_sessions.CLAUDE_DIR
+        search_sessions.CLAUDE_DIR = projects_dir
+        
+        try:
+            # With match_any=True, should match even with only one term
+            results = search_sessions.search_sessions(["868ktvqf9", "nonexistent"], match_any=True)
+            assert len(results) == 1
+        finally:
+            search_sessions.CLAUDE_DIR = original_dir
+
+
+def test_search_sessions_ranking():
+    """Test that sessions are ranked by hit count."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        projects_dir = Path(tmpdir) / "projects"
+        projects_dir.mkdir()
+        
+        # Create two sessions with different hit counts
+        for i, hits in enumerate([(1, "low"), (3, "high")]):
+            session_dir = projects_dir / f"project-{i}"
+            session_dir.mkdir()
+            session_file = session_dir / f"session{i}.jsonl"
+            
+            text = "test_term " * hits[0]
+            with open(session_file, "w") as f:
+                f.write(json.dumps({"type": "assistant", "message": {"content": [{"type": "text", "text": text}]}}) + "\n")
+        
+        # Override CLAUDE_DIR
+        original_dir = search_sessions.CLAUDE_DIR
+        search_sessions.CLAUDE_DIR = projects_dir
+        
+        try:
+            results = search_sessions.search_sessions(["test_term"])
+            assert len(results) == 2
+            # Higher hit count should come first
+            assert results[0]["hits"] >= results[1]["hits"]
+        finally:
+            search_sessions.CLAUDE_DIR = original_dir
+
+
+def test_search_sessions_since_filter():
+    """Test filtering by date."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        projects_dir = Path(tmpdir) / "projects"
+        projects_dir.mkdir()
+        
+        # Create a mock session
+        session_dir = projects_dir / "test-project"
+        session_dir.mkdir()
+        session_file = session_dir / "session1.jsonl"
+        
+        with open(session_file, "w") as f:
+            f.write(json.dumps({"type": "assistant", "message": {"content": [{"type": "text", "text": "test_term"}]}}) + "\n")
+        
+        # Override CLAUDE_DIR
+        original_dir = search_sessions.CLAUDE_DIR
+        search_sessions.CLAUDE_DIR = projects_dir
+        
+        try:
+            from datetime import datetime, timedelta
+            # Should match (future date)
+            results = search_sessions.search_sessions(["test_term"], since=datetime.now() - timedelta(days=1))
+            assert len(results) == 1
+            
+            # Should not match (past date)
+            results = search_sessions.search_sessions(["test_term"], since=datetime.now() + timedelta(days=1))
+            assert len(results) == 0
+        finally:
+            search_sessions.CLAUDE_DIR = original_dir
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in globals().items() if k.startswith("test_")]
+    passed = 0
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            print(f"  ✓ {test.__name__}")
+            passed += 1
+        except Exception as e:
+            print(f"  ✗ {test.__name__}: {e}")
+            failed += 1
+    print(f"\n{passed} passed, {failed} failed")
+    sys.exit(1 if failed else 0)

--- a/scripts/check-clickup-addressed/tests/test_status_and_tiers.py
+++ b/scripts/check-clickup-addressed/tests/test_status_and_tiers.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Round 4 (2026-08-21). Two defects found by reading the code against its own docs.
+
+  D6  `disagreements()` gates every ticket/comment cross-check on a hardcoded five-word
+      status vocabulary. A ClickUp status outside it — "in review", "blocked", "needs qa"
+      — silently disables ALL of them, including the keep-open veto and the flagship
+      resolved-comment flag. The report then prints an empty "Needs a decision" block,
+      which reads as "no disagreement" when it means "not checked". Measured at base:
+      'to do' and 'open' flagged; 'in review', 'blocked', 'needs qa', 'review' returned [].
+
+  D7  the proximity tier was unreachable. `extract_text_windows` is the only producer of
+      windows in production and hardcodes distance 0, so every signal scored 1.0 (or 1.5
+      with the adjacency boost) and NOTHING could ever land at or below the 0.5 "close"
+      threshold. `close_completion` was therefore always == `completion`, the three
+      branches behind it were dead, and the ●/○ confidence marker always printed ●.
+      Vestigial from the full-text fallback deleted in round 1 — the only thing that ever
+      emitted a non-unit proximity (a hardcoded 0.5).
+
+Tests marked INVARIANT GUARD pass at base too. They are controls, not regression
+coverage; `test_production_windows_are_all_distance_zero` in particular is the premise
+that licenses D7's deletion, and goes red if a producer ever emits a non-zero distance.
+"""
+import io, json, sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import importlib.util
+
+spec = importlib.util.spec_from_file_location("check_completion", SCRIPT_DIR / "check-completion.py")
+check_completion = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check_completion)
+
+spec2 = importlib.util.spec_from_file_location("check_addressed", SCRIPT_DIR / "check-addressed.py")
+check_addressed = importlib.util.module_from_spec(spec2)
+spec2.loader.exec_module(check_addressed)
+
+TASK = "868kr07fu"
+RESOLVED_COMMENT = "Resolved. Recommend closing."
+KEEP_OPEN_COMMENT = "Still live, do not close. P95 > 5s fired and resolved repeatedly."
+
+
+def _result(status_word, comment, transcript_status="likely_addressed"):
+    return {
+        "task_id": TASK,
+        "status": transcript_status,
+        "clickup_status": status_word,
+        "newest_comment": {"snippet": comment},
+        "completion": [], "open": [],
+    }
+
+
+# --------------------------------------------------------------------------- D6
+
+def test_unknown_clickup_status_is_flagged_not_silently_skipped():
+    """A status outside the vocabulary must announce that the cross-check did NOT run.
+
+    At base this returns [] for every one of these, indistinguishable from "checked, and
+    the ticket agrees with the transcripts".
+    """
+    for unknown in ("in review", "blocked", "needs qa", "review", "won't do"):
+        flags = check_addressed.disagreements([_result(unknown, RESOLVED_COMMENT)])
+        assert flags, f"status {unknown!r}: cross-check silently skipped, no flag emitted"
+        joined = " ".join(flags).lower()
+        assert unknown in joined, f"status {unknown!r}: flag does not name the status: {flags}"
+        assert "did not run" in joined or "not check" in joined, \
+            f"status {unknown!r}: flag does not say the cross-check was skipped: {flags}"
+
+
+def test_missing_clickup_status_is_flagged_too():
+    """A task whose status ClickUp did not return is the same blind spot, not a pass."""
+    flags = check_addressed.disagreements([_result(None, RESOLVED_COMMENT)])
+    assert flags, "a missing ClickUp status silently skipped the cross-check"
+
+
+def test_keep_open_is_surfaced_even_on_an_unknown_status():
+    """The reporter's own 'do not close' is worth surfacing whatever the status reads.
+
+    The D5 veto only suppresses a flag, so on an unknown status it is moot — but the
+    instruction itself must still reach the operator.
+    """
+    flags = check_addressed.disagreements([_result("in review", KEEP_OPEN_COMMENT)])
+    joined = " ".join(flags).lower()
+    assert "do not close" in joined, \
+        f"'do not close' in the newest comment never reached the operator: {flags}"
+
+
+def test_known_open_status_still_flags_a_resolved_comment():
+    """INVARIANT GUARD — passes at base. The D6 fix must not swallow the round-2 flag."""
+    flags = check_addressed.disagreements([_result("to do", RESOLVED_COMMENT)])
+    assert any("reads as RESOLVED" in f for f in flags), f"round-2 flag lost: {flags}"
+
+
+def test_known_status_veto_still_wins():
+    """INVARIANT GUARD — passes at base. The D5 veto must survive the D6 fix."""
+    flags = check_addressed.disagreements([_result("to do", KEEP_OPEN_COMMENT)])
+    joined = " ".join(flags)
+    assert "do NOT close" in joined, f"veto lost: {flags}"
+    assert "close it, or say why" not in joined, \
+        f"told the operator to close a ticket whose comment says not to: {flags}"
+
+
+def test_agreeing_ticket_still_produces_no_flag():
+    """INVARIANT GUARD — passes at base. The D6 fix must not flag every task."""
+    r = _result("complete", "Confirmed fixed, thanks.", transcript_status="likely_addressed")
+    assert check_addressed.disagreements([r]) == []
+
+
+# --------------------------------------------------------------------------- D7
+
+def test_production_windows_are_all_distance_zero():
+    """INVARIANT GUARD — the premise that licensed deleting the proximity tier.
+
+    `extract_text_windows` is the ONLY producer of windows outside the tests. If it ever
+    emits a non-zero distance this goes red: re-read the deleted `proximity > 0.5` tier
+    in check_task() before trusting any verdict, because signals could then fall below
+    the threshold the deleted branches existed to catch.
+    """
+    text = ("prelude " * 400) + f" {TASK} fixed, PR #123 merged. " + ("tail " * 400)
+    windows = check_completion.extract_text_windows(text, TASK, window_size=2000)
+    assert windows, "positive control: the task ID is in the text, so a window must exist"
+    assert all(distance == 0 for _, distance, _ in windows), \
+        f"a producer emitted a non-zero distance: {[d for _, d, _ in windows]}"
+
+
+def test_every_production_signal_scores_above_the_deleted_threshold():
+    """INVARIANT GUARD — the second half of the same premise.
+
+    Distance 0 means proximity is 1.0, or 1.5 with the adjacency boost. Both exceed the
+    0.5 "close" threshold, so the tier keyed on it could never discriminate.
+    """
+    text = f"{TASK} PR #123 merged. " + ("filler " * 200) + " and #456 was shipped too"
+    windows = check_completion.extract_text_windows(text, TASK, window_size=2000)
+    signals = check_completion.extract_signals_from_windows(
+        windows, check_completion.COMPLETION_PATTERNS, TASK)
+    assert signals, "positive control: this text contains completion signals"
+    assert all(s[2] > 0.5 for s in signals), \
+        f"a production signal scored <= 0.5, the deleted tier mattered: {[s[2] for s in signals]}"
+
+
+def test_confidence_marker_distinguishes_adjacent_from_same_window():
+    """The ●/○ marker must report something that varies in production.
+
+    At base it is computed inline as `"●" if prox > 0.5 else "○"`, and production
+    proximity is only ever 1.0 or 1.5 — so it printed ● for every signal ever emitted,
+    including signals whose snippet is 2000 characters from the task ID. Verified live on
+    868kr07fu: every line was ●.
+    """
+    adjacent = {"proximity": 1.5}      # the task ID is inside the signal's own snippet
+    same_window_only = {"proximity": 1.0}  # merely somewhere in the +/-2000-char window
+    assert check_completion.confidence_marker(adjacent) == "●"
+    assert check_completion.confidence_marker(same_window_only) == "○", \
+        "the marker still cannot distinguish an adjacent signal from a distant one"
+
+
+def test_deleting_the_tier_preserves_every_verdict():
+    """The four surviving branches must produce the same four verdicts as before.
+
+    Built from real windows, not hand-made ones: fixtures that feed a distance production
+    cannot emit are what let the dead tier look tested for two rounds.
+    """
+    def verdict(text):
+        windows = check_completion.extract_text_windows(text, TASK, window_size=2000)
+        comp = check_completion.extract_signals_from_windows(
+            windows, check_completion.COMPLETION_PATTERNS, TASK)
+        opn = check_completion.extract_signals_from_windows(
+            windows, check_completion.OPEN_PATTERNS, TASK)
+        return bool(comp), bool(opn)
+
+    assert verdict(f"{TASK} PR #123 merged") == (True, False)
+    assert verdict(f"{TASK} is still open") == (False, True)
+    assert verdict(f"{TASK} PR #123 merged but the root cause is still open") == (True, True)
+    assert verdict(f"{TASK} we talked about it") == (False, False)
+
+
+# ------------------------------------------------------- orchestrator arg parsing
+
+def test_include_self_runs_is_recognised_by_the_orchestrator():
+    """SKILL.md documents this flag on the entry point; at base the parser drops it.
+
+    check-addressed.py's loop ends in `else: i += 1`, so an unrecognised flag is silently
+    swallowed and never forwarded to the sub-scripts. The documented escape hatch did
+    nothing at all when passed to the command the Quick start tells you to run.
+    """
+    opts = check_addressed.parse_args(["--include-self-runs"])
+    assert opts["include_self_runs"] is True
+
+
+def test_include_self_runs_is_forwarded_to_both_subscripts():
+    """Recognising the flag is not wiring it — assert the argv the sub-scripts receive.
+
+    Parsing and forwarding are two separate steps and only one of them is what the flag
+    means. A test that stops at parse_args would read as coverage of a flag that still did
+    nothing. Measured at base, the entry point handed the sub-scripts:
+        search-sessions.py:  [--limit 5 --json --exclude-session <id> <task>]
+        check-completion.py: [--task <task> --json --exclude-session <id>]
+    with '--include-self-runs' forwarded nowhere, and the run reported success.
+    """
+    calls = []
+
+    def fake(name, *args):
+        calls.append((name, list(args)))
+        if name == "recent-comments.py":
+            return json.dumps([{"task_id": TASK, "task_name": "t", "task_status": "to do",
+                                "task_priority": "urgent", "date": "2026-08-20 10:00",
+                                "author": "x", "snippet": "hi"}]), 0
+        if name == "search-sessions.py":
+            return "[]", 0
+        return json.dumps([{"task_id": TASK, "status": "unclear", "sessions_searched": 0,
+                            "mentions_found": 0, "completion": [], "open": []}]), 0
+
+    orig_run, orig_argv, orig_stdout = check_addressed.run_script, sys.argv, sys.stdout
+    check_addressed.run_script = fake
+    sys.argv = ["check-addressed.py", "--include-self-runs", "--no-resolve-prs"]
+    sys.stdout = io.StringIO()
+    try:
+        check_addressed.main()
+    finally:
+        check_addressed.run_script, sys.argv, sys.stdout = orig_run, orig_argv, orig_stdout
+
+    forwarded = {name for name, a in calls if "--include-self-runs" in a}
+    assert forwarded == {"search-sessions.py", "check-completion.py"}, \
+        f"flag not forwarded to both stages; reached: {forwarded or 'nothing'}"
+
+
+def test_self_run_guard_is_on_by_default():
+    """INVARIANT GUARD — the opposite direction: without the flag, nothing opts out.
+
+    Pairs with the test above so 'always forward' cannot pass as 'forward when asked'.
+    """
+    calls = []
+
+    def fake(name, *args):
+        calls.append((name, list(args)))
+        if name == "recent-comments.py":
+            return json.dumps([{"task_id": TASK, "task_name": "t", "task_status": "to do",
+                                "task_priority": "urgent", "date": "2026-08-20 10:00",
+                                "author": "x", "snippet": "hi"}]), 0
+        if name == "search-sessions.py":
+            return "[]", 0
+        return json.dumps([{"task_id": TASK, "status": "unclear", "sessions_searched": 0,
+                            "mentions_found": 0, "completion": [], "open": []}]), 0
+
+    orig_run, orig_argv, orig_stdout = check_addressed.run_script, sys.argv, sys.stdout
+    check_addressed.run_script = fake
+    sys.argv = ["check-addressed.py", "--no-resolve-prs"]
+    sys.stdout = io.StringIO()
+    try:
+        check_addressed.main()
+    finally:
+        check_addressed.run_script, sys.argv, sys.stdout = orig_run, orig_argv, orig_stdout
+
+    assert not any("--include-self-runs" in a for _, a in calls), \
+        "the prior-run guard was opted out of without anyone asking"
+
+
+def test_known_flags_still_parse():
+    """INVARIANT GUARD for the extraction — every flag main() used to read by hand."""
+    opts = check_addressed.parse_args(
+        ["--limit", "5", "--since", "2026-08-15", "--json", "--verbose",
+         "--fast", "--no-resolve-prs"])
+    assert opts["limit"] == 5
+    assert opts["since"] == "2026-08-15"
+    assert opts["as_json"] is True
+    assert opts["verbose"] is True
+    assert opts["fast"] is True
+    assert opts["resolve_prs"] is False
+
+
+def test_unknown_flag_is_rejected_not_swallowed():
+    """The class behind D7's doc drift: a typo'd or retired flag must not read as success.
+
+    A silently-ignored flag is the same reassuring-nothing this skill exists to police —
+    the run looks like it honoured your request and did not.
+    """
+    try:
+        check_addressed.parse_args(["--no-such-flag"])
+    except SystemExit:
+        return
+    raise AssertionError("an unknown flag was accepted and silently ignored")
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    passed = failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  ✓ {t.__name__}")
+            passed += 1
+        except SystemExit as e:
+            # Not an Exception — see the note in run_all.py; uncaught it kills the run.
+            print(f"  ✗ {t.__name__}: SystemExit({e.code}) escaped the test")
+            failed += 1
+        except Exception as e:
+            print(f"  ✗ {t.__name__}: {type(e).__name__}: {e}")
+            failed += 1
+    print(f"\n{passed} passed, {failed} failed")
+    sys.exit(1 if failed else 0)

--- a/scripts/check-clickup-addressed/tests/test_veto_tiers.py
+++ b/scripts/check-clickup-addressed/tests/test_veto_tiers.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+"""The keep-open veto's two tiers and its clause-scoped negation.
+
+Round 8 — 2026-08-21. Measured matrix over the 34 tests this round adds (30 here, 4 in
+`test_corpus.py`): **21 red at `origin/trunk` `d11e67e87` for a BEHAVIOURAL reason, 3 red only
+structurally** (`AttributeError` on symbols this change introduces — they could never have
+been behaviourally red, so they are NOT regression coverage), **10 green at base, all 34 green
+at HEAD.**
+
+Several of the 10 that pass at base are red against an INTERMEDIATE version of this change
+rather than against trunk — they pin regressions that two blind audits found in the FIX, not
+in trunk. Their docstrings say so. Trunk gets those cases right by having no clause machinery
+at all, which is not the same as being safe: it scores 24/42 on the labelled corpus, against
+39/42 for what ships here.
+
+🔴 **Before changing the veto, read `scripts/check-clickup-addressed/tests/test_corpus.py`
+and score your candidate.** Eight rounds of this were argued one clever sentence at a time and
+five shipped a regression. The scoreboard is what ended that.
+
+Three hazards this file has hit repeatedly, all worth re-reading before adding a test:
+
+1. **Do not claim RED AT BASE without running it at base** — two tests here claimed it and
+   did not have it.
+2. 🔴 **Do not assert a substring the surrounding sentence can also produce.** `flags()`
+   defaults to `transcript_status="likely_addressed"`, and the TRANSCRIPT branch emits
+   "— close it or re-check", so a bare `"close it" in j` is satisfied by a completely
+   different flag. Measured: deleting the comment-level close-it trigger outright once left
+   17 of 19 tests here GREEN. **Pass `transcript_status="unclear"` whenever you assert about
+   the comment flag**, and assert its own words (`reads as RESOLVED`).
+3. 🔴 **A mutant whose anchor no longer applies is a FAILURE, not a survivor.** Three separate
+   rewrites in this round left stale anchors in the battery, each of which would have read as
+   a passing mutation that never ran.
+
+The defect this round fixes has TWO directions and one cause. Trunk's veto is absolute, so a
+legitimate close-it is suppressed whenever the comment mentions an unrelated open PR, AND an
+affirmative CLOSE IT is emitted over a refusal spelled any way other than the two literals
+`KEEP_OPEN_RE` enumerates. The second direction is the dangerous one and is live on trunk.
+"""
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.parent
+spec = importlib.util.spec_from_file_location("check_addressed", SCRIPT_DIR / "check-addressed.py")
+check_addressed = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check_addressed)
+
+NOW = datetime(2026, 8, 21, 12, 0, tzinfo=timezone.utc)
+RECENT = "2026-08-20 10:00"
+
+
+def flags(comment, status="to do", transcript_status="likely_addressed"):
+    """Drive the real `disagreements()`. Full text AND snippet, as production supplies both."""
+    return check_addressed.disagreements([{
+        "task_id": "868test01", "status": transcript_status, "clickup_status": status,
+        "mentions_found": 3,
+        "newest_comment": {"snippet": comment[:200], "text": comment,
+                           "date": RECENT, "author": "colleague"},
+        "completion": [], "open": [],
+    }], now=NOW)
+
+
+def joined(comment, **kw):
+    return " ".join(flags(comment, **kw))
+
+
+# --------------------------------------------------------- direction 1: over-veto
+
+AMBIGUOUS_COMMENTS = [
+    "Resolved on both counts, recommend closing. (The follow-up PR is still open but unrelated.)",
+    "One review thread is not resolved on the PR, but the ticket itself is done. Recommend closing.",
+    "The alert fired and was not resolved automatically. Ticket work is done — recommend closing.",
+    "The fix landed in #1234 and is live. The follow-up PR is still open but unrelated.",
+]
+
+
+def test_a_weak_refusal_beside_a_closure_claim_stops_suppressing_the_close_it():
+    """RED AT BASE — all four emit an absolute `do NOT close` on trunk.
+
+    These are the shapes that made the veto expensive: `still open` and `not resolved` are
+    routinely about a PR, an alert or a sibling ticket, and the reporter is in the same
+    breath asking for the ticket to be closed.
+    """
+    for c in AMBIGUOUS_COMMENTS:
+        j = joined(c)
+        assert "do NOT close" not in j, f"a weak refusal still suppressed a close-it: {c!r} -> {j}"
+        assert "READ IT and decide" in j, f"no ambiguity flag emitted for {c!r}: {j}"
+
+
+def test_the_ambiguity_flag_names_both_halves():
+    """A flag that says "it is ambiguous" without saying WHICH two phrases collided sends the
+    reader back to re-read the whole comment, which is the work the tool is meant to do."""
+    j = joined(AMBIGUOUS_COMMENTS[0])
+    assert "still open" in j, f"the ambiguity flag does not name the keep-open phrase: {j}"
+    assert "Resolved" in j, f"the ambiguity flag does not name the closure claim: {j}"
+
+
+# --------------------------------------------------------- direction 2: under-veto
+
+NEGATED_REFUSALS = [
+    "The issue isn't resolved.",
+    "The issue is never resolved.",
+    "This won't be resolved until next sprint.",
+    "This is not fully resolved.",
+    "This is unresolved.",
+    "I do not recommend closing this yet.",
+]
+
+
+def test_a_negated_closure_claim_never_reads_as_a_resolution():
+    """RED AT BASE — all six draw an affirmative "close it" on trunk.
+
+    One rule replaces six spellings: the vocabulary is matched plainly, then the CLAUSE it
+    sits in is asked whether it carries a negator. Per-word lookbehinds guarded exactly the
+    two forms they named and lost this twice on the abandoned branch.
+    """
+    for c in NEGATED_REFUSALS:
+        j = joined(c)
+        assert "close it" not in j, f"told the operator to close a ticket refusing it: {c!r} -> {j}"
+        assert "do NOT close" in j, f"the refusal never reached the operator: {c!r} -> {j}"
+
+
+def test_contractions_are_matched_by_shape_not_by_a_stem_list():
+    """`won't` has the stem "wo", not "will" — so any list of contraction stems is already
+    incomplete when it is written. `\\w+n't` covers the class, including shan't/mightn't."""
+    for c in ("This shan't be resolved this quarter.",
+              "It mightn't be resolved before the freeze.",
+              "This won't be resolved until next sprint."):
+        assert "close it" not in joined(c), f"contraction not recognised as negation: {c!r}"
+
+
+def test_the_quoted_phrase_carries_its_own_negator():
+    """A veto reading `newest comment says "resolved" — do NOT close` quotes the comment as
+    saying the OPPOSITE of what fired the flag. That is how an operator learns to skip the
+    line, so the quoted span runs from the negator through the closure word.
+
+    `not resolved` alone would pass at base — trunk's regex carries that exact literal — so
+    the spellings trunk CANNOT produce are what make this red there.
+    """
+    for comment, want in (("The issue is not resolved.", '"not resolved"'),
+                          ("This won't be resolved until next sprint.", '"won\'t be resolved"'),
+                          ("Nothing has been merged.", '"Nothing has been merged"')):
+        j = joined(comment)
+        assert want in j, f"the flag does not quote the negator with its target: {j}"
+
+
+# --------------------------------------------------------- clause scope, both directions
+
+def test_a_trailing_negator_does_not_reach_BACKWARDS_and_invert_a_resolution():
+    """🔴 The regression the first blind audit caught, and it was worse than the bug this
+    round exists to fix.
+
+    RED against the intermediate version, GREEN at trunk (which has no clause machinery to
+    get this wrong) — so it is regression coverage for the FIX, not for trunk.
+
+    Negation was scoped to the clause but NOT to word order, and commas were not yet clause
+    boundaries, so any trailing "no" / "nothing" reached backwards over a plain
+    resolution: 12 of 12 ordinary "work is finished, nothing outstanding" comments flipped
+    from `close it` to `do NOT close`. That is an affirmative wrong instruction, not a safe
+    over-veto — it would have traded 4 wrongly-suppressed close-its for 12 wrongly-created
+    vetoes, on a tool whose whole priority is that its instructions are trustworthy.
+
+    A negator now negates only closure words that FOLLOW it in the clause.
+    """
+    for c in ("Resolved, no further action needed.",
+              "Recommend closing, no further work planned.",
+              "Confirmed resolved, no repro since Tuesday.",
+              "This is done, nothing else outstanding."):
+        j = joined(c, transcript_status="unclear")
+        assert "do NOT close" not in j, f"a trailing negator inverted a resolution: {c!r} -> {j}"
+        assert "reads as RESOLVED" in j, f"the close-it flag was lost for {c!r}: {j}"
+
+
+def test_the_quoted_phrase_is_a_real_substring_in_the_comments_own_word_order():
+    """A negator found AFTER the closure word produced manufactured quotations — the flag
+    printed `says "no … resolved"` for a comment reading "Confirmed resolved, no repro since
+    Tuesday", i.e. words the comment contains in an order it never used. With negation
+    positional the elided form is an honest elision. Nothing asserted on this output shape
+    before; two mutants on the quoting guard survived the suite."""
+    j = joined("The rollback is not (as far as I can tell) done.", transcript_status="unclear")
+    assert "do NOT close" in j, f"expected a veto: {j}"
+    quoted = j.split('says "', 1)[1].split('"', 1)[0]
+    assert quoted, "the veto quoted an EMPTY phrase — which makes the whole flag falsy"
+    src = "The rollback is not (as far as I can tell) done."
+    if " … " in quoted:
+        head, tail = quoted.split(" … ", 1)
+        assert src.index(head) < src.index(tail), \
+            f"the elided quote reverses the comment's word order: {quoted!r}"
+    else:
+        assert quoted in src, f"the flag quoted text the comment does not contain: {quoted!r}"
+
+
+def test_parentheses_do_not_strand_a_negator_from_its_target():
+    """🔴 RED AT BASE and at base-of-this-round: `()` used to be a clause boundary, which is
+    exactly what `test_a_bare_comma_is_not_a_clause_boundary` forbids for commas — the same
+    class, one line apart, unnoticed until audit. "This is not (yet) resolved" split into
+    ["This is not ", "yet", " resolved"] and drew an affirmative CLOSE IT over a refusal."""
+    for c in ("This is not (yet) resolved.",
+              "This is not (fully) resolved.",
+              "The rollback is not (as far as I can tell) done."):
+        j = joined(c, transcript_status="unclear")
+        assert "close it" not in j, f"a paren stranded the negator: {c!r} -> {j}"
+        assert "do NOT close" in j, f"the refusal never reached the operator: {c!r} -> {j}"
+
+
+def test_the_parenthesised_aside_is_still_read_for_ambiguity():
+    """CONTROL for the fix above — dropping `()` as a boundary must not cost the round-8
+    fixture its ambiguity, which it gets from the full stop that precedes the paren."""
+    j = joined(AMBIGUOUS_COMMENTS[0])
+    assert "READ IT and decide" in j, f"the paren fixture lost its ambiguity flag: {j}"
+
+
+def test_negators_that_are_not_spelled_with_a_negator_word():
+    """`cannot` has no apostrophe and no separate negator token; `far from` and `anything
+    but` negate what follows them idiomatically. All three drew a CLOSE IT over a refusal.
+
+    `anything but` needs BOTH halves of its handling — the negator entry AND the lookbehind
+    in CLAUSE_SPLIT_RE — because the `but` would otherwise split the phrase away from the
+    word it negates. Neither half works alone, which is why one behavioural case pins both.
+    """
+    for c in ("We cannot call this resolved.",
+              "This is far from resolved.",
+              "This is anything but resolved."):
+        j = joined(c, transcript_status="unclear")
+        assert "close it" not in j, f"unrecognised negation drew a close-it: {c!r} -> {j}"
+        assert "do NOT close" in j, f"no veto for {c!r}: {j}"
+
+
+def test_naming_a_ticket_beside_still_open_is_NOT_promoted_to_strong():
+    """🔴 The reverse of what an earlier round of this change asserted, and the reversal is
+    the finding.
+
+    `(?:ticket|task) (?:is |remains? )?still open` was briefly STRONG, on the argument that
+    "a PR is open, but only THIS object is *the ticket*, so there is no second reading".
+    That premise is false in ClickUp, where comments reference sibling tickets constantly.
+    Measured: it produced a hard veto on 4 of 4 comments where the weak tier had correctly
+    said READ IT — the round-8 motivating case with the noun changed.
+
+    Weak is the right tier for every "still open"; the ambiguity downgrade is what handles
+    the ones that are about this ticket.
+    """
+    for c in ("Resolved on both counts, recommend closing. The upstream task is still open "
+              "but that is tracked separately.",
+              "Fix merged. The duplicate task is still open, closing this one.",
+              "This is done and deployed. The parent ticket is still open; it covers the "
+              "rollout."):
+        j = joined(c)
+        assert "do NOT close" not in j, f"a SIBLING ticket's status vetoed this one: {c!r} -> {j}"
+        assert "READ IT and decide" in j, f"no ambiguity flag: {c!r} -> {j}"
+
+
+def test_the_unknown_status_branch_emits_the_ambiguity_flag_too():
+    """The unknown-status branch is reachable and had zero coverage — deleting its ambiguity
+    output left the suite green. An unrecognised ClickUp status already tells the reader to
+    read the comment; saying WHY it is ambiguous is the part that saves them the re-read."""
+    j = joined(AMBIGUOUS_COMMENTS[0], status="in review")
+    assert "DID NOT RUN" in j, f"the unknown-status announcement was lost: {j}"
+    assert "READ IT and decide" in j, \
+        f"an ambiguous comment on an unknown status said nothing about the conflict: {j}"
+
+
+def test_an_em_dash_is_a_clause_boundary():
+    """Load-bearing on real prose and pinned by nothing until audit — deleting the `[—–]` arm
+    left the suite green. Without it the negator reaches across the dash."""
+    j = joined("This is still open — the fix was merged and shipped last week.")
+    assert "READ IT and decide" in j, \
+        f"an em-dash clause boundary was not honoured: {j}"
+
+
+def test_negation_does_not_leak_across_clauses():
+    """INVARIANT GUARD — passes at base (trunk has no clause scope to leak across), and is
+    the control for the mechanism this round adds, not evidence for it.
+
+    Comment-wide negation scope would let a single "no" anywhere silence every closure word,
+    making the ambiguous tier unreachable and turning every such comment into a veto. Here
+    the negator belongs to a different sentence than the resolution, so the close-it stands.
+    Killed by the no-clause-splitting mutant, which is what makes it non-vacuous.
+
+    🔴 Asserts `reads as RESOLVED` under `transcript_status="unclear"`, NOT `"close it"` at
+    the default. The transcript branch emits "— close it or re-check", whose boilerplate
+    satisfies a bare `"close it" in j`, so the original assertion observed a DIFFERENT flag
+    than the one it names.
+    """
+    j = joined("There is no regression left. Resolved — recommend closing.",
+               transcript_status="unclear")
+    assert "reads as RESOLVED" in j, \
+        f"a negator in a different clause swallowed the resolution: {j}"
+    assert "do NOT close" not in j, f"negation leaked across a clause boundary: {j}"
+
+
+def test_a_coordinating_conjunction_IS_a_clause_boundary():
+    """The other half of clause scope, and the one every other fixture accidentally covered.
+
+    Found by a surviving mutant: stripping `but|however|…` from the splitter changed nothing,
+    because every ambiguous fixture also carried a sentence boundary that did the same work.
+    Here the negator and the closure claim share one sentence, so only the conjunction
+    separates them — without it the "not" reaches "done" and a legitimate close-it is vetoed.
+    """
+    j = joined("One review thread is not resolved but the ticket itself is done")
+    assert "READ IT and decide" in j, \
+        f"a negator leaked across a conjunction and suppressed the closure claim: {j}"
+
+
+def test_the_ambiguity_window_reads_the_full_comment_not_the_snippet():
+    """Also found by a surviving mutant: the ambiguity decision reads the FULL comment while
+    the close-it trigger keeps the 200-char snippet, and nothing pinned the difference.
+
+    A status comment that opens with an unrelated "still open" and asks for the close 600
+    characters later is the ordinary shape of a long update. Reading only the snippet vetoes
+    it — the exact suppression this round exists to remove.
+    """
+    padding = ("The follow-up PR is still open but unrelated. Throughput held flat across the "
+               "window and the backlog drained on schedule; the numbers below are all from the "
+               "same 24h window so they can be read together, and nothing else changed. ")
+    text = padding + "Both asks are now closed — recommend closing."
+    assert len(padding) > 200, "the closure claim must sit past the display truncation"
+    j = joined(text)
+    assert "do NOT close" not in j, \
+        f"a closure claim past the display window was invisible to the ambiguity tier: {j}"
+    assert "READ IT and decide" in j, f"no ambiguity flag: {j}"
+
+
+def test_every_close_it_trigger_phrase_is_also_ambiguity_vocabulary():
+    """🔴 THE PREMISE THAT LICENSES DELETING THE CLOSE-IT BRANCH'S NEGATION FILTER.
+
+    That filter was written, and the sweep scored it the identity. It is unreachable because
+    every phrase `RESOLVED_COMMENT_RE` matches also contains a `CLOSURE_VOCAB_RE` word, so a
+    NEGATED close-it trigger is already a negated closure claim and vetoes one branch earlier.
+
+    If that stops being true this goes red — and the filter must come back, because a
+    close-it trigger outside the ambiguity vocabulary would reach the close-it branch through
+    its own negation. The first assertion is the positive control: it fails if these fixtures
+    drift away from the regex they claim to enumerate.
+    """
+    for phrase in ("resolved", "recommend closing", "can be closed", "both asks are closed",
+                   "both asks are now closed", "this is done", "all asks are closed",
+                   "all items are closed"):
+        assert check_addressed.RESOLVED_COMMENT_RE.search(phrase), \
+            f"fixture drift: {phrase!r} no longer matches the close-it trigger at all"
+        assert check_addressed.CLOSURE_VOCAB_RE.search(phrase), \
+            (f"{phrase!r} triggers a close-it but is NOT ambiguity vocabulary, so its negated "
+             f"form reaches the close-it branch unguarded — restore the negation filter in "
+             f"disagreements()")
+
+
+def test_a_status_line_ending_in_a_negator_does_not_veto_the_next_sentence():
+    """🔴 The regression the THIRD blind audit caught, in the rule written by the second.
+
+    A `carry` rule propagated a clause-TRAILING negator into the following clause, to rescue
+    "This is not, in my view, resolved" after commas became boundaries. But "ends on a
+    negator" does not distinguish an interrupted negation from how engineers actually write a
+    clean status — `Downtime: none.` `Impact: none,` `Regressions found: none.` — so it
+    vetoed the resolution that followed, and reintroduced a manufactured quotation
+    (`says "none … Resolved"`, two words from different sentences).
+
+    It bought ONE corpus case and cost seven realistic close-its. Deleted; the case it was
+    written for is now a recorded KNOWN FAILURE in test_corpus.py. Say what is not handled
+    rather than half-handling it.
+    """
+    for c in ("Downtime: none. Resolved and deployed.",
+              "Impact: none, resolved by the rollback.",
+              "Regressions found: none. Resolved.",
+              "Blockers: none. Owner: me. Reviewed by Alice. Resolved — closing."):
+        j = joined(c, transcript_status="unclear")
+        assert "do NOT close" not in j, \
+            f"a status line ending in a negator vetoed its own resolution: {c!r} -> {j}"
+        assert "none …" not in j, f"manufactured quotation across two sentences: {j}"
+
+
+def test_the_symptom_then_resolution_shape_is_not_vetoed():
+    """🔴 THE DOMINANT SHAPE IN A BUG COMMENT, and the reason commas ARE clause boundaries.
+
+    A bug comment states the SYMPTOM — which is negated, because that is what a bug is —
+    and then the RESOLUTION, in one comma-spliced sentence. With commas inside the clause,
+    the symptom's negator reaches forward and vetoes the resolution. Measured: 10 of 10
+    realistic comments of this shape became false `do NOT close`.
+
+    This is the mirror of the trailing-negator regression above. Both were found by audit,
+    one round apart, and only measuring BOTH orders against a labelled corpus settled it:
+    commas-not-a-boundary scored 28/42, commas-a-boundary 39/42.
+    """
+    for c in ("Users cannot upload avatars, fixed in #4421 and deployed.",
+              "The alert wasn't firing, resolved by the rule fix.",
+              "Search returned no results for tag queries, resolved by the reindex.",
+              "The job did not run on Sunday, resolved — I re-ran it.",
+              "Cannot reproduce this anymore, resolved.",
+              "No repro since the deploy, resolved."):
+        j = joined(c, transcript_status="unclear")
+        assert "do NOT close" not in j, \
+            f"the symptom's negator vetoed its own resolution: {c!r} -> {j}"
+
+
+def test_a_negator_AFTER_the_closure_word_never_produces_a_reversed_quote():
+    """What the positional rule earns, and the only thing that distinguishes it.
+
+    Found by mutation: making negation position-independent again left the whole suite green,
+    because every fixture happened to put the negator first. It is not equivalent — it
+    reverses the quote. "Resolved and not verified in prod." has no comma, so both words sit
+    in one clause, and the position-independent version emits:
+
+        newest comment says "not … Resolved" — do NOT close
+
+    which is the manufactured-quotation defect: words the comment contains, in an order it
+    never used. The elision reads as the comment having said "not resolved", which it did not.
+
+    🔴 Stated residual, not a solved problem: the two orders disagree on the VERDICT here and
+    neither is right in general. Positional calls this "close it" (wrong — it is not
+    verified); position-independent calls it "do NOT close" but would call "Resolved and no
+    follow-up is planned" the same (also wrong). What the negator attaches to is not
+    recoverable from punctuation. Positional is kept for ONE reason only: it never fabricates
+    a quotation.
+
+    🔴 TWO CLAIMS THAT USED TO BE HERE WERE FALSE, and an audit measured both.
+    "Its failure mode needs the writer to use 'and', where a comma or full stop is far more
+    common" — no: the failure fires on every separator, `and` / `,` / `.` / `but` / `;` / `—`,
+    all six measured drawing "close it". And "the corpus records the failing case rather than
+    hiding it" — the corpus contained it zero times; the sentence asserted coverage that did
+    not exist, which is the thing that stops the next person looking. The whole class (a
+    negator FOLLOWING the closure word it denies) is now in `test_corpus.py`'s KNOWN_FAILURES,
+    where it is counted rather than described.
+    """
+    j = joined("Resolved and not verified in prod.", transcript_status="unclear")
+    assert "not … Resolved" not in j, f"the flag quoted the comment in reverse order: {j}"
+    assert "no … Resolved" not in j, f"the flag quoted the comment in reverse order: {j}"
+
+
+def test_a_weak_refusal_ALONE_still_vetoes():
+    """RED-ADJACENT: passes at base, and is the round-5 regression this design must not
+    repeat. WEAK means *ambiguous alongside a closure claim*, never *ignorable* — with no
+    closure claim in the comment the weak phrase is the only statement about closure, so
+    there is nothing for it to be ambiguous against.
+    """
+    for c in ("This is still open. I have not had time to look at it.",
+              "The issue is not resolved.",
+              "This is still open. I haven't done anything yet.",
+              "This is still open. The bug is not fixed.",
+              "This is still open — nothing has been merged."):
+        j = joined(c)
+        assert "do NOT close" in j, f"a lone weak refusal stopped vetoing: {c!r} -> {j}"
+        assert "READ IT and decide" not in j, \
+            f"a lone weak refusal was downgraded to ambiguous with nothing to be ambiguous " \
+            f"against: {c!r} -> {j}"
+
+
+def test_a_negated_done_word_does_not_fake_a_closure_claim():
+    """The mirror of the round-6 blind spot: only `resolved` carried negation handling there,
+    so `haven't done` / `not fixed` / `nothing merged` each faked the closure half of an
+    ambiguity and downgraded a legitimate veto. Covered above behaviourally; this pins the
+    unit so a vocabulary change cannot re-open it silently."""
+    affirmed, negated = check_addressed.closure_claims(
+        "This is still open. I haven't done anything, nothing has been merged, not fixed.")
+    assert affirmed == [], f"a negated done-word was counted as a closure claim: {affirmed}"
+    assert negated, "the negated done-words were not recorded at all"
+
+
+def test_strong_veto_is_absolute_even_beside_a_closure_claim():
+    """INVARIANT GUARD — passes at base, where the veto is absolute and nothing can downgrade
+    it. It exists because this round introduces the downgrade: STRONG is an instruction about
+    THIS ticket that no other reading survives, so a closure claim elsewhere in the comment
+    must not reach it."""
+    j = joined("Still live, do not close. The fix landed and the sibling ticket is done.")
+    assert "do NOT close" in j, f"an explicit 'do not close' was downgraded: {j}"
+    assert "READ IT and decide" not in j, f"a strong veto was treated as ambiguous: {j}"
+
+
+def test_a_declaration_that_the_ticket_STAYS_open_is_strong():
+    """🔴 REGRESSION FROM THE LIVE RUN, not from the table.
+
+    The real comment on `868ktt2ct` (2026-08-21) opens "Status check during ClickUp triage —
+    staying open, and mostly not verifiable from this repo", and its ONLY closure vocabulary
+    is one "shipped" describing a sub-item that landed in a different repo. The first version
+    of this round downgraded it to "READ IT and decide" — trunk's absolute veto had it right.
+
+    These phrasings are STRONG because they are not this domain's vocabulary for anything
+    else: a PR or an alert is "open", never "staying open". The synthetic 17-case table could
+    not have found this; only running the tool against real comments did.
+    """
+    real = ("Status check during ClickUp triage 2026-08-21 — staying open, and mostly not "
+            "verifiable from this repo. Per the comment thread: R1 (log_lock_waits=on) "
+            "shipped via talos-infra #1093, a separate repo. R2, the global lock_timeout "
+            "this task is named for, is still open and needs re-sizing.")
+    j = joined(real)
+    assert "do NOT close" in j, f"an explicit 'staying open' was downgraded: {j}"
+    assert "READ IT and decide" not in j, f"a deliberate keep-open read as ambiguous: {j}"
+
+    for c in ("This remains open until the follow-up lands.",
+              "Leaving it open for now.",
+              "This stays open until Q4."):
+        assert "do NOT close" in joined(c), f"not treated as a strong refusal: {c!r}"
+
+
+def test_strong_wins_the_quote_over_weak():
+    """A comment carrying both must quote the STRONGER phrase.
+
+    🔴 The first version of this test asserted `"do not close" in j.lower()`, which matches
+    the flag's OWN boilerplate `— do NOT close.` It therefore passed at base while base
+    quoted "still open", and would have passed with the tiers reversed. Assert the QUOTED
+    SPAN, not a substring that the surrounding sentence also contains.
+    """
+    j = joined("This is still open and the work is done. Do not close.")
+    assert '"Do not close"' in j, f"the strong phrase was not what got quoted: {j}"
+    assert '"still open"' not in j, f"the weak phrase outranked an explicit refusal: {j}"
+
+
+# --------------------------------------------------------- controls
+
+def test_widening_ambiguity_did_not_widen_the_close_it_trigger():
+    """CONTROL, in the direction that costs money.
+
+    `CLOSURE_VOCAB_RE` is wide (landed/shipped/deployed/…) and `RESOLVED_COMMENT_RE` is
+    narrow. Only the narrow one may INSTRUCT a human to close a live ticket; the wide one
+    exists solely to decide ambiguity. A comment made only of wide-vocabulary words must
+    therefore produce no close-it at all.
+    """
+    j = joined("The fix landed and shipped to prod yesterday.", transcript_status="unclear")
+    assert "close it" not in j, f"the ambiguity vocabulary manufactured a close-it flag: {j}"
+
+
+def test_the_close_it_flag_still_fires_on_a_clean_resolution():
+    """INVARIANT GUARD — passes at base. This flag is the single highest-value thing the tool
+    produces and the whole tiering exists to stop suppressing it; a change that also stops
+    EMITTING it has traded one silent failure for another.
+
+    🔴 THIS TEST WAS VACUOUS AND OBSERVED A DIFFERENT FLAG THAN ITS OWN NAME. It asserted
+    `"close it" in j` at the helper's default `transcript_status="likely_addressed"`, and the
+    TRANSCRIPT branch emits "— close it or re-check", whose boilerplate contains that exact
+    substring. Measured: deleting the comment-flag trigger outright (RESOLVED_COMMENT_RE
+    replaced with a never-matching pattern) left 17 of the 19 tests in this file GREEN.
+
+    So: `transcript_status="unclear"` — which makes the transcript branch unreachable — and
+    assert the comment flag's own words. This is the second instance of this class in this
+    file alone; the first was `"do not close" in j.lower()` matching the flag's own
+    boilerplate. **Never assert a substring the surrounding sentence can also produce.**
+    """
+    j = joined("Resolved on both counts. Recommend closing.", transcript_status="unclear")
+    assert "reads as RESOLVED" in j, f"the close-it flag was lost: {j}"
+    assert "close it, or say why it stays open" in j, f"the close-it flag was lost: {j}"
+    assert "do NOT close" not in j, f"a clean resolution was vetoed: {j}"
+
+
+def test_both_tiers_stay_gated_on_an_open_status():
+    """INVARIANT GUARD — a DONE ticket must never be told "do NOT close" or "read it and
+    decide"; there is nothing to decide about a ticket that is already closed. Dropping
+    either `cu in OPEN_STATUSES` guard is a mutant that reads as harmless."""
+    for c in ("Still live, do not close.",
+              "The issue is not resolved.",
+              AMBIGUOUS_COMMENTS[0]):
+        j = joined(c, status="complete")
+        assert "do NOT close" not in j, f"vetoed an already-closed ticket: {c!r} -> {j}"
+        assert "READ IT and decide" not in j, f"ambiguity flag on a closed ticket: {c!r} -> {j}"
+
+
+def test_regex_vocabularies_are_pinned_as_literals():
+    """🔴 The phrase ledger must see the set GROW, not only shrink.
+
+    Round 6's N3 mutant added `|done` to the veto regex — which vetoes every comment
+    containing the word "done", killing the close-it feature outright — and passed the whole
+    suite, because every other test asserts on behaviour it happens to sample. Pinning the
+    patterns means a widened vocabulary has to be a deliberate edit here too.
+    """
+    assert check_addressed.STRONG_KEEP_OPEN_RE.pattern == (
+        r"\b(?:do ?n[o']?t close|keep (?:it |this )?open|still live|"
+        r"stay(?:s|ing)? open|remains? open|leav(?:e|ing) (?:it |this )?open|"
+        r"still (?:broken|happening|occurring|reproducing)|"
+        r"reopen(?:ing|ed)?|premature to close)\b")
+    assert check_addressed.WEAK_KEEP_OPEN_RE.pattern == r"\bstill open\b"
+    assert check_addressed.CLOSURE_VOCAB_RE.pattern == (
+        r"\b(?:resolved|fixed|done|merged|deployed|shipped|landed|completed?|closing|closed)\b")
+    assert check_addressed.RESOLVED_COMMENT_RE.pattern == (
+        r"\b(?:resolved|recommend closing|can be closed|both asks are (?:now )?closed|"
+        r"this is done|all (?:asks|items) (?:are )?closed)\b")
+    # The two regexes that decide SCOPE. Both were widened by audit findings that a
+    # behavioural test alone would not have forced anyone to look at twice.
+    assert check_addressed.NEGATOR_RE.pattern == (
+        r"\b(?:not|never|no|none|nothing|nobody|without|unable|cannot|can not|"
+        r"far from|anything but|"
+        r"yet to|fails? to|failed to)\b"
+        r"|\b\w+n['’]t\b")
+    assert check_addressed.CLAUSE_SPLIT_RE.pattern == (
+        r"[.,;!?\n]|[—–]|(?<!anything )(?<!nothing )(?<!everything )"
+        r"\b(?:but|however|although|though|whereas|while)\b")

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1246,13 +1246,14 @@ TARGET_FLOORS=(
   "scripts/initiatives/tests|745"
   "scripts/repo-cos/tests|315"
   "scripts/task-spec-drafter/tests|135"
-  # 2026-08-22, check-clickup-addressed arrives as a NEW target: 156 collected on
-  # the branch, agreeing with what its own tests/run_all.py reports (156 passed,
+  # 2026-08-22, check-clickup-addressed arrives as a NEW target: 157 collected on
+  # the branch, agreeing with what its own tests/run_all.py reports (157 passed,
   # 0 failed) — two runners, one number. Gate's own rule on the gate's own count:
-  #   _suggested_floor 156 = 156 - min(50, max(1, 156/20 = 7)) = 156 - 7 = 149.
-  # (155 came over from datapacket-talos; the +1 is the marker-path regression
-  # test the migration itself needed — see _selfrun.py's two spellings.)
-  "scripts/check-clickup-addressed/tests|149"
+  #   _suggested_floor 157 = 157 - min(50, max(1, 157/20 = 7)) = 157 - 7 = 150.
+  # (155 came over from datapacket-talos; the +2 are the marker-path regression the
+  # migration itself created and the negative control that rejected the obvious fix
+  # — see the NEW_LAYOUT_RE block in _selfrun.py.)
+  "scripts/check-clickup-addressed/tests|150"
   "scripts/claude-hooks/tests/test_guard_core.py|1260"
   # 2026-08-13, next-step-nudge.py's suite arrives as a NEW target: 78 collected on the
   # branch. Gate's own count through the gate's own rule:

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1246,16 +1246,16 @@ TARGET_FLOORS=(
   "scripts/initiatives/tests|745"
   "scripts/repo-cos/tests|315"
   "scripts/task-spec-drafter/tests|135"
-  # 2026-08-22, check-clickup-addressed arrives as a NEW target: 161 collected on
-  # the branch, agreeing with what its own tests/run_all.py reports (161 passed,
+  # 2026-08-22, check-clickup-addressed arrives as a NEW target: 176 collected on
+  # the branch, agreeing with what its own tests/run_all.py reports (176 passed,
   # 0 failed) — two runners, one number. Gate's own rule on the gate's own count:
-  #   _suggested_floor 161 = 161 - min(50, max(1, 161/20 = 8)) = 161 - 8 = 153.
+  #   _suggested_floor 176 = 176 - min(50, max(1, 176/20 = 8)) = 176 - 8 = 168.
   # (155 came over from datapacket-talos; the +6 are the migration's own marker-path
   # regression, the negative control that rejected the obvious directory fix, and the
   # four an adversarial audit of the migration produced — the documented `$CCUA/...`
   # invocation, the unmarked `--json` output, its end-to-end seam, and the
   # header/marker single-source pin.)
-  "scripts/check-clickup-addressed/tests|153"
+  "scripts/check-clickup-addressed/tests|168"
   "scripts/claude-hooks/tests/test_guard_core.py|1260"
   # 2026-08-13, next-step-nudge.py's suite arrives as a NEW target: 78 collected on the
   # branch. Gate's own count through the gate's own rule:

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1246,14 +1246,16 @@ TARGET_FLOORS=(
   "scripts/initiatives/tests|745"
   "scripts/repo-cos/tests|315"
   "scripts/task-spec-drafter/tests|135"
-  # 2026-08-22, check-clickup-addressed arrives as a NEW target: 157 collected on
-  # the branch, agreeing with what its own tests/run_all.py reports (157 passed,
+  # 2026-08-22, check-clickup-addressed arrives as a NEW target: 161 collected on
+  # the branch, agreeing with what its own tests/run_all.py reports (161 passed,
   # 0 failed) — two runners, one number. Gate's own rule on the gate's own count:
-  #   _suggested_floor 157 = 157 - min(50, max(1, 157/20 = 7)) = 157 - 7 = 150.
-  # (155 came over from datapacket-talos; the +2 are the marker-path regression the
-  # migration itself created and the negative control that rejected the obvious fix
-  # — see the NEW_LAYOUT_RE block in _selfrun.py.)
-  "scripts/check-clickup-addressed/tests|150"
+  #   _suggested_floor 161 = 161 - min(50, max(1, 161/20 = 8)) = 161 - 8 = 153.
+  # (155 came over from datapacket-talos; the +6 are the migration's own marker-path
+  # regression, the negative control that rejected the obvious directory fix, and the
+  # four an adversarial audit of the migration produced — the documented `$CCUA/...`
+  # invocation, the unmarked `--json` output, its end-to-end seam, and the
+  # header/marker single-source pin.)
+  "scripts/check-clickup-addressed/tests|153"
   "scripts/claude-hooks/tests/test_guard_core.py|1260"
   # 2026-08-13, next-step-nudge.py's suite arrives as a NEW target: 78 collected on the
   # branch. Gate's own count through the gate's own rule:

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -438,6 +438,15 @@ HERMETIC_TARGETS=(
   scripts/initiatives/tests
   scripts/repo-cos/tests
   scripts/task-spec-drafter/tests
+  # Added 2026-08-22 with the check-clickup-addressed migration out of
+  # datapacket-talos, where no gate had ever run it — the suite was invoked by
+  # hand via its own tests/run_all.py. Hermetic by construction: every ClickUp
+  # call goes through a patched `subprocess.run`, and the transcript walkers get
+  # their CLAUDE_DIR reassigned to a tmp tree, so neither the network nor the
+  # real ~/.claude/projects is touched. run_all.py stays as the skill's own
+  # runner (it purges __pycache__ and scores an import failure as a FAILURE);
+  # pytest collects the same files.
+  scripts/check-clickup-addressed/tests
   # A FILE, not a dir, and deliberately so: scripts/claude-hooks/tests/ also
   # holds hand-rolled scripts that call main() at import and sys.exit(), which
   # pytest cannot collect. Naming the one pytest-collectable file keeps them
@@ -1237,6 +1246,13 @@ TARGET_FLOORS=(
   "scripts/initiatives/tests|745"
   "scripts/repo-cos/tests|315"
   "scripts/task-spec-drafter/tests|135"
+  # 2026-08-22, check-clickup-addressed arrives as a NEW target: 156 collected on
+  # the branch, agreeing with what its own tests/run_all.py reports (156 passed,
+  # 0 failed) — two runners, one number. Gate's own rule on the gate's own count:
+  #   _suggested_floor 156 = 156 - min(50, max(1, 156/20 = 7)) = 156 - 7 = 149.
+  # (155 came over from datapacket-talos; the +1 is the marker-path regression
+  # test the migration itself needed — see _selfrun.py's two spellings.)
+  "scripts/check-clickup-addressed/tests|149"
   "scripts/claude-hooks/tests/test_guard_core.py|1260"
   # 2026-08-13, next-step-nudge.py's suite arrives as a NEW target: 78 collected on the
   # branch. Gate's own count through the gate's own rule:


### PR DESCRIPTION
## What

Moves the `check-clickup-addressed` skill out of `datapacket-talos` (where it was
project-scoped to one client repo) into devrc:

| | from | to |
|---|---|---|
| skill body | `<datapacket-talos>/.claude/skills/check-clickup-addressed/SKILL.md` | `claude/skills/check-clickup-addressed/SKILL.md` |
| validation record | `.../README-validation.md` | `claude/skills/check-clickup-addressed/reference/validation-history.md` |
| pipeline | `.../scripts/*.py` | `scripts/check-clickup-addressed/*.py` |
| suite | `.../test/*.py` | `scripts/check-clickup-addressed/tests/*.py` |

The tool is about ClickUp tickets and `~/.claude/projects` transcripts — neither is a
talos concern. It is now a global skill on both hosts, and its **161** tests are a
registered `HERMETIC_TARGETS` entry of `scripts/run-tests.sh` (floor **153**). **No gate
had ever run this suite**; it was invoked by hand.

Layout follows the devrc majority (`session-analysis`, `repo-cos`, `signal`…) rather
than the clickup-skill shape, for one concrete reason: `githooks/tests-on-push.sh`
filters on `^(scripts/|flake\.nix|flake\.lock)$`, so a suite living under `claude/`
would not gate its own edits.

## The self-run guard: what the move broke, corrected

`_selfrun.py`'s markers are **path fragments**, and the two layouts spell the same two
segments in reverse order, so the old marker matched no invocation after the move.

🔴 **An earlier version of this PR said that made the guard "go quiet". Measured, that
was wrong**, and the correction is the more useful fact. The path markers catch the
*invocation*; the report header `## Task Completion Status` catches the *output*, and
every text-mode run prints it. Over the 762 transcripts these scripts actually walk, the
exclusion set is **11 with or without** the path marker. The ordinary path was never
blind. The path markers stay because they uniquely cover a run whose output never reaches
the transcript (piped to a file, `| jq`, truncated) — defence in depth, at that size.

An adversarial audit then found the shapes that *were* broken:

1. **The marker missed the invocation this skill's own SKILL.md teaches.** The quick start
   is `CCUA=…` then `python3 "$CCUA/check-addressed.py"` — the variable means the path
   adjacency never reaches the transcript, and `cd <dir> && python3 check-addressed.py`
   breaks it the same way. A marker for a shape nobody types is not a marker. The four
   entry-point basenames are alternatives now; each measured in the anchored class
   (check-addressed.py 12/1.6%, the others 10/1.3%) beside the old path marker (11/1.4%)
   and the rejected bare name (96/12.6%).
2. **A `--json` run carried no marker at all** — the header was on the text branch, so a
   JSON report, which lists every task ID beside `likely_addressed`, was invisible to the
   guard. `render_json()` now emits it as a field, and `SELF_RUN_HEADER` is one literal
   shared by both branches and pinned against `SELF_RUN_MARKERS`.

## The directory spelling was measured and rejected

The obvious counterpart to the old marker is `scripts/check-clickup-addressed/`. It
re-creates the defect `_selfrun.py` already rejects the bare name for: devrc's `CLAUDE.md`
maps `scripts/<dir>/` to its owning skill and is injected into every session in this repo
(this PR adds that row), and the gate prints a per-target line naming the same directory.

| candidate | matched | |
|---|---|---|
| `check-clickup-addressed` (bare name) | 96 (12.6%) | already rejected |
| `scripts/repo-cos/` (sibling CLAUDE.md row, proxy) | 83 (10.9%) | what the directory spelling costs |
| `scripts/session-analysis/` | 72 (9.5%) | ” |
| `check-clickup-addressed/scripts/` (old marker) | 11 (1.4%) | anchored |

So the marker requires a `.py` file. `test_a_mention_of_the_scripts_DIRECTORY_is_not_a_self_run`
uses the real `CLAUDE.md` row and the real gate line as fixtures.

## 🔴 A test in this PR was vacuous — the round's real lesson

The first `--json` test built the payload itself with the same dict-merge the code uses,
so the mutant that removed the marker **survived a green suite**. Calling the production
`render_json` killed it and left a **second** mutant alive: swapping the `--json` branch
back to a bare `json.dumps` was still green, because every assertion was scoped to the
function and none to the **call site**. `test_main_json_output_is_self_marking_END_TO_END`
now drives the real `main()` with `run_script` stubbed and asserts on what it printed.
Both mutants die, each naming its own test; the isolated-renderer test stays as the
narrower control.

## Verification

- Every new guard watched RED before its fix, and the mutation battery re-run after each
  fix round rather than only the last.
- **161** collected/passed under pytest **and** 161 passed / 0 failed under
  `tests/run_all.py` — two runners, one number. Floor 153 = `_suggested_floor(161)`.
- `--check-targets` / `--check-floors` PASS; the table has exactly one entry per list
  after the rebase.
- **End-to-end from the new path**: `check-addressed.py --fast --limit 2` reached ClickUp,
  produced a report, and reported 7 prior runs ignored — the guard firing on real data.
- Full hermetic gate: `scripts/check-clickup-addressed/tests` **PASS (161/161)**.
- Rebased onto current `main`, which carries the `signal/tests` floor fix (#708).

⚠️ **One unrelated failure in the last full-gate run, not from this branch**:
`scripts/browser-bridge/tests::test_wrapper_forces_tab…` hit its 60s hang-net during a run
concurrent with another dispatched agent. It passes at `origin/main` alone (0.31s) and the
whole 60-test browser-agent suite passes on this branch alone (19.28s); this branch touches
no browser-bridge file. Re-running the full gate on a quiet box before merge.

## Follow-ups (not in this PR)

- `datapacket-talos`: delete the old copy and mark its handoff superseded — held until this
  merges + `home-manager switch`, so the skill is never absent from both.
- A stale unmanaged copy at `~/.config/opencode/skills/check-clickup-addressed/` holds the
  old layout and is not nix-managed.
- `SKILL.md` is ~21 KB — a `/prune-skill` candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
