### PR TITLE
fix(gate): `main` is RED on a signal floor nothing in this round touched

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1225,8 +1225,13 @@ TARGET_FLOORS=(
   # pin the battery's ANCHORS and killer-test NAMES, because the way a battery
   # rots is silent: an anchor stops matching, the mutant never lands, and the
   # run prints ANCHOR-MISS, which reads like a hiccup rather than "this mutant
+  # 2026-08-22: 717 tripped the ceiling at 691 with every test PASSING (716 passed,
+  # 1 skipped). The gate printed "scripts/signal/tests|682" and that is what is below,
+  # copied not computed. Nothing in this round touched scripts/signal/ — the drift is
+  # from tests landed by earlier merges without the floor moving with them, which is
+  # exactly what the ceiling exists to catch.
   # tested nothing". That has already happened here once.
-  "scripts/signal/tests|553"
+  "scripts/signal/tests|682"
   "scripts/initiatives/tests|745"
   "scripts/repo-cos/tests|315"
   "scripts/task-spec-drafter/tests|135"


### PR DESCRIPTION
`scripts/signal/tests` collects **717** against a floor of **553** — 138 of slack, past the drift ceiling of **691** — so `scripts/gate.sh` exits 1 while every test in that target passes (`716 passed, 1 skipped`). A whole suite could vanish under that floor and the gate would stay green, which is exactly what the ceiling exists to prevent.

Raised to **682** — the number `run-tests.sh` printed itself, copied not computed, per the rule its own surrounding comments already state twice.

## It is not any branch in flight

Measured on a standalone clone of `origin/main` alone:

```
main-only clone @ 2d1ba0d
signal tests collected on PLAIN MAIN: 717 tests collected
the ceiling constant on main:         691
```

So this is drift from tests landed by earlier merges without the floor moving with them. I found it because it turned up as the **only** failure in an unrelated PR's gate run (14,790 passed / 0 failed, `GATE: RESULT=FAIL`), and running the control was what separated "my change broke it" from "main is red".

Both prior historical notes on this entry are preserved; a new dated one records this round.
