### PR TITLE
fix(gate): the signal floor had fallen 164 behind — a whole suite could vanish under it while the gate stayed green

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1226,7 +1226,20 @@ TARGET_FLOORS=(
   # rots is silent: an anchor stops matching, the mutant never lands, and the
   # run prints ANCHOR-MISS, which reads like a hiccup rather than "this mutant
   # tested nothing". That has already happened here once.
-  "scripts/signal/tests|553"
+  # 2026-08-22: 717 tripped the ceiling at 691 with every test PASSING (716 passed,
+  # 1 skipped — the pre-existing SIGNAL_PG_DSN skip, so EXPECTED_SKIPS is untouched).
+  # The gate printed "scripts/signal/tests|682" and that is what is below, copied not
+  # computed. 🔴 FIRST DRIFT CAUGHT BY THE TEKTON GATE RATHER THAN BY HAND — this is
+  # the devrc-pytests leg of devrc-ci-djm7n, the first PipelineRun the repo has ever
+  # had, and the drift ceiling was the ONLY thing it failed on. The floor had fallen
+  # 164 behind: a whole suite could have vanished under it while the gate stayed
+  # green. The 135 new tests since the last raise come from four merged PRs —
+  # the outbound group draft linked to a phantom contact instead of its GROUP (#686),
+  # the D3 send path that had never worked on real Postgres because COALESCE mixed
+  # uuid and text (#657), two liveness tests that waited on the CLOCK and lost the
+  # race (#628), and keeping the mutation battery in-repo after eight were written
+  # into scratchpads and thrown away (#606).
+  "scripts/signal/tests|682"
   "scripts/initiatives/tests|745"
   "scripts/repo-cos/tests|315"
   "scripts/task-spec-drafter/tests|135"


### PR DESCRIPTION
`scripts/signal/tests` collects **717**; its `TARGET_FLOORS` entry still said **553**. That is 164 of slack against a ceiling of 138 (floor × 0.25), so the drift check failed the run **with every single test passing** (716 passed, 1 skipped — the pre-existing `SIGNAL_PG_DSN` skip, so `EXPECTED_SKIPS` is untouched).

The replacement is **copied from the gate, not computed here**, per the rule this table documents:

```
run-tests: ERROR — scripts/signal/tests collected 717 tests but its floor is only 553.
  That is more than 138 of slack: a whole suite could vanish under this
  floor with the gate still green. Raise the TARGET_FLOORS entry to
  "scripts/signal/tests|682" — that number is this run's own count put through
  the documented rule, so it needs no measurement of its own.
```

## How this surfaced — it is the gate's first catch

This is the `devrc-pytests` leg of **`devrc-ci-djm7n`, the first Tekton PipelineRun this repo has ever had**. The gate went live and immediately caught a real staleness the hand-run process had missed. The drift ceiling was the **only** thing it failed on; `tekton/devrc-nodetests` passed **1119/1119**.

## It also corrects a stale belief

The handoff recorded `devrc-pytests` as unrequireable because "the nix sandbox does not exist in the pod, and all three levers are rejected by PodSecurity `baseline:latest`". **It does exist** — `seed-nix` exited 0 and **14,686 tests ran in-pod**. Once this lands, `devrc-pytests` should go green and the "cannot be required" verdict deserves re-testing over a few runs.

## Verification

Deliberately **not** run locally: devrc's test tier mutates real git repos, and running it from a worktree that shares the base clone's git dir is the failure recorded in the handoff (and in open PRs #673/#676/#683/#689). The authoritative check here is the Tekton gate itself, which runs `run-tests.sh` in an isolated pod — so this PR is verified by the very gate it fixes. If 682 is wrong, the gate prints the correct number and this is a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)