### PR TITLE
fix(gate): GUARD 1 classifies by CAUSE — a REQUIRED_TOOLS typo turned the gate off

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -179,6 +179,14 @@
         name = "devrc-gate";
         packages = gateTools;
         shellHook = ''
+          # 🔴 Marks a SANCTIONED gate environment. run-tests.sh GUARD 1 uses it to
+          # tell a REPO defect from a CALLER defect: a REQUIRED_TOOLS entry missing
+          # while this is set means the repo asked for something `gateTools` does
+          # not supply (or the entry is a typo) — that BLOCKS. Missing while it is
+          # unset means the caller is simply not in the gate env — that degrades.
+          # Set in BOTH tiers (here and checks.pytests) or the sandbox would
+          # misclassify its own repo defects as environment faults.
+          export DEVRC_GATE_ENV=1
           echo "devrc: gate toolchain ready — bash scripts/run-tests.sh ." >&2
         '';
       };
@@ -329,6 +337,8 @@
             # sandbox (no /usr/bin/env). Rewrite shebangs to store paths so those
             # legitimately-hermetic tests can run. (Does NOT touch test logic.)
             patchShebangs src/scripts
+            # Same marker the devShell sets — see its shellHook for why.
+            export DEVRC_GATE_ENV=1
             export HOME="$TMPDIR/home"
             mkdir -p "$HOME"
             cd src

--- a/githooks/README.md
+++ b/githooks/README.md
@@ -78,7 +78,9 @@ Behaviour, all failing in the **safe direction**:
   redundant. (The `nodetests` leg carries no marker and needs none.)
   Its red is advisory (`main`'s protection requires a review but **not** status
   checks — `required_status_checks` → 404, measured 2026-08-22) — which is why
-  this hook remains the only tier that **blocks**.
+  this hook remains the only tier that blocks **a push**. (`main` also requires
+  1 approving review, which blocks a *merge* — so the unqualified "only tier
+  that blocks" would be wrong.)
 - **Escape hatch** — `DEVRC_SKIP_TESTS=1 git push …` skips the gate for one push
   regardless of mode (the flake check / CI still enforce the hermetic subset).
 

--- a/githooks/README.md
+++ b/githooks/README.md
@@ -54,12 +54,27 @@ Behaviour, all failing in the **safe direction**:
   - the hook's own `degrade()`, **before the runner is ever invoked** — this is
     the offline/substituter/devShell-build case;
   - the runner exiting **3**, for its own environment preconditions (GUARDs
-    1/1b/1c, a failed `cd $ROOT`, the spool `mkdir`).
+    1b/1c, a failed `cd $ROOT`, the spool `mkdir`, and GUARD 1 **only when run
+    outside a sanctioned gate env**).
 
   🔴 A REPO-CONTENT guard (runner exit **2** — target list, floor table,
   launcher stubs, spool wiring) **BLOCKS** even though zero tests ran: those are
-  defects in the repo, and this hook is the only automatic gate (no CI, no
-  branch protection). So: exit 1 blocks, exit 2 blocks, exit 3 degrades.
+  defects in the repo. So: exit 1 blocks, exit 2 blocks, exit 3 degrades.
+
+  🔴 **GUARD 1 is in both lists.** Its input `REQUIRED_TOOLS` is repo content,
+  but its usual failure is environmental — so since devrc#705 it classifies by
+  **cause**: `DEVRC_GATE_ENV=1` (set by the devShell's `shellHook` and by
+  `checks.pytests`) means the environment already supplies everything
+  `gateTools` declares, so a still-missing tool is a repo defect → **exit 2,
+  blocks**; unset means the caller simply isn't in the gate env → **exit 3,
+  degrades**. Before that, a typo in `REQUIRED_TOOLS` aborted with 3 and the
+  push went through with zero tests run.
+
+  🔴 A Tekton PR gate (`tekton/devrc-pytests`, `tekton/devrc-nodetests`) now
+  runs on PRs; the older "no CI" claim here was true when written and is not
+  now. It invokes the runner via `nix develop`, so the marker arms it too. With
+  no branch protection its red is advisory — which is why this hook remains the
+  only tier that **blocks**.
 - **Escape hatch** — `DEVRC_SKIP_TESTS=1 git push …` skips the gate for one push
   regardless of mode (the flake check / CI still enforce the hermetic subset).
 

--- a/githooks/README.md
+++ b/githooks/README.md
@@ -72,9 +72,13 @@ Behaviour, all failing in the **safe direction**:
 
   🔴 A Tekton PR gate (`tekton/devrc-pytests`, `tekton/devrc-nodetests`) now
   runs on PRs; the older "no CI" claim here was true when written and is not
-  now. It invokes the runner via `nix develop`, so the marker arms it too. With
-  no branch protection its red is advisory — which is why this hook remains the
-  only tier that **blocks**.
+  now. It runs `nix build .#checks.x86_64-linux.<leg>` and does **not** enter
+  the devShell, so it is armed by `checks.pytests`'s own `DEVRC_GATE_ENV`
+  export rather than the `shellHook` this hook uses — the two are not
+  redundant. (The `nodetests` leg carries no marker and needs none.)
+  Its red is advisory (`main`'s protection requires a review but **not** status
+  checks — `required_status_checks` → 404, measured 2026-08-22) — which is why
+  this hook remains the only tier that **blocks**.
 - **Escape hatch** — `DEVRC_SKIP_TESTS=1 git push …` skips the gate for one push
   regardless of mode (the flake check / CI still enforce the hermetic subset).
 

--- a/githooks/tests-on-push.sh
+++ b/githooks/tests-on-push.sh
@@ -252,7 +252,9 @@ fi
 # exit 3 in its runner.)
 # Its red is advisory — `main`'s protection requires a review but NOT status
 # checks (`required_status_checks` -> 404, measured 2026-08-22) — which is why
-# this hook is still the only tier that BLOCKS.
+# this hook is still the only tier that blocks A PUSH. (Precisely: `main` also
+# requires 1 approving review, which blocks a MERGE — so "the only tier that
+# blocks" unqualified is wrong. The push is what this hook governs.)
 #
 # Verified in the other direction too: `fail` is only ever assigned 0 or 1 and the
 # script ends `exit "$fail"`, so a genuine pytest failure can never surface as 2

--- a/githooks/tests-on-push.sh
+++ b/githooks/tests-on-push.sh
@@ -19,9 +19,15 @@
 #     the push. 🔴 TWO DISJOINT mechanisms, deliberately not conflated: THIS
 #     file's `degrade()` handles the env-can't-be-built case BEFORE the runner
 #     is invoked at all; the runner's own exit 3 covers its environment
-#     preconditions (GUARDs 1/1b/1c, a failed `cd $ROOT`, the spool `mkdir`).
+#     preconditions (GUARDs 1b/1c, a failed `cd $ROOT`, the spool `mkdir`, and
+#     GUARD 1 ONLY when run outside a sanctioned gate env).
 #     Saying "the runner signals this with exit 3" sent people looking for a
 #     runner message that was never printed.
+#     🔴 GUARD 1 is no longer purely environmental: its input REQUIRED_TOOLS is
+#     REPO CONTENT, so since devrc#705 it exits 2 (BLOCK) when DEVRC_GATE_ENV=1
+#     — i.e. the env already supplies everything `gateTools` declares and the
+#     tool is still missing, which means the repo asked for something nothing
+#     supplies. It is the one guard whose code depends on the CAUSE.
 #   * 🔴 REPO-CONTENT guards BLOCK even though zero tests ran. run-tests.sh exits
 #     2 when its target list, floor table, launcher stubs or spool wiring are
 #     wrong — defects in the REPO, whose own messages warn that silencing them is
@@ -217,18 +223,31 @@ if [ "$run_rc" -eq 0 ]; then
   exit 0
 fi
 
-# 🔴 rc 3 is an ENVIRONMENT precondition abort (run-tests.sh GUARDs 1/1b/1c): by
-# construction ZERO tests ran, and the fault is in the CALLER, not the repo. This
-# file's header promises "Infra flakiness DEGRADES, never blocks", so it degrades.
+# 🔴 rc 3 is an ENVIRONMENT precondition abort (run-tests.sh GUARDs 1b/1c, a
+# failed `cd $ROOT`, the spool `mkdir`, and GUARD 1 when run outside a gate env):
+# by construction ZERO tests ran, and the fault is in the CALLER, not the repo.
+# This file's header promises "Infra flakiness DEGRADES, never blocks", so it
+# degrades.
 #
 # 🔴 rc 2 STILL BLOCKS, and the distinction is the whole point. A first version of
-# this degraded on rc 2 — but run-tests.sh has TEN abort sites and only six are
-# environmental; the rest are REPO-CONTENT guards (target list, floor table,
-# launcher stubs, spool wiring) whose own messages warn "do NOT delete the entry
-# to make this pass — that is how a suite stops running while the gate goes
-# green". Degrading on 2 produced exactly that, on the only tier that runs
-# automatically: this repo has no CI and no branch protection. The runner now
-# exits 3 for the environment cases so the two can be told apart.
+# this degraded on rc 2 — but run-tests.sh has ELEVEN abort sites, six `exit 3`
+# and five `exit 2`; the exit-2 ones are REPO-CONTENT guards (target list, floor
+# table, launcher stubs, spool wiring) whose own messages warn "do NOT delete the
+# entry to make this pass — that is how a suite stops running while the gate goes
+# green". Degrading on 2 produced exactly that, on the only tier that BLOCKS a
+# push. The runner exits 3 for the environment cases so the two can be told apart.
+#
+# 🔴 GUARD 1 appears in BOTH lists — since devrc#705 its code depends on the CAUSE
+# (DEVRC_GATE_ENV=1 -> repo defect -> 2; unset -> caller defect -> 3), because its
+# input REQUIRED_TOOLS is repo content while its usual failure is environmental.
+# So "which guard fired" no longer determines the code; do not re-derive the
+# mapping from the guard number alone.
+#
+# 🔴 A Tekton PR gate (`tekton/devrc-pytests`, `tekton/devrc-nodetests`) DOES now
+# run on PRs — the older "no CI" claim here was true when written and is not now.
+# It invokes the runner through `nix develop`, so it is armed by the same marker.
+# With no branch protection its red is advisory, which is why this hook is still
+# the only tier that BLOCKS.
 #
 # Verified in the other direction too: `fail` is only ever assigned 0 or 1 and the
 # script ends `exit "$fail"`, so a genuine pytest failure can never surface as 2

--- a/githooks/tests-on-push.sh
+++ b/githooks/tests-on-push.sh
@@ -245,9 +245,14 @@ fi
 #
 # 🔴 A Tekton PR gate (`tekton/devrc-pytests`, `tekton/devrc-nodetests`) DOES now
 # run on PRs — the older "no CI" claim here was true when written and is not now.
-# It invokes the runner through `nix develop`, so it is armed by the same marker.
-# With no branch protection its red is advisory, which is why this hook is still
-# the only tier that BLOCKS.
+# It runs `nix build .#checks.x86_64-linux.<leg>` and does NOT enter the
+# devShell, so it is armed by checks.pytests's OWN DEVRC_GATE_ENV export — not
+# by the shellHook this hook relies on. The two exports are not redundant.
+# (The nodetests leg carries no marker and needs none: no DEVRC_GATE_ENV, no
+# exit 3 in its runner.)
+# Its red is advisory — `main`'s protection requires a review but NOT status
+# checks (`required_status_checks` -> 404, measured 2026-08-22) — which is why
+# this hook is still the only tier that BLOCKS.
 #
 # Verified in the other direction too: `fail` is only ever assigned 0 or 1 and the
 # script ends `exit "$fail"`, so a genuine pytest failure can never surface as 2

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -267,8 +267,15 @@ cd "$ROOT" || { echo "run-tests: cannot cd to ROOT=$ROOT" >&2; exit 3; }
 # BLOCKS on 2. Collapsing them was a measured mistake — degrading on 2 turned
 # GUARD 5's and GUARD 3a's own warning ("do NOT delete the entry to make this
 # pass — that is how a suite stops running while the gate goes green") into
-# exactly that outcome, on the only tier that runs automatically: this repo has
-# no CI and no branch protection (pinned by test_ci_claim_matches_reality.py).
+# exactly that outcome, on the only tier that BLOCKS a push. 🔴 "The only tier
+# that RUNS" was true when this was written and is now FALSE: a Tekton PR gate
+# (`tekton/devrc-pytests`, `tekton/devrc-nodetests`) went live between #704 and
+# #714 — measured, #704 reports no checks and #714 reports both. It invokes
+# `nix develop --command bash scripts/run-tests.sh .`, so it IS armed by the
+# devShell's DEVRC_GATE_ENV export and needs no separate handling. What it does
+# NOT do is block a merge: there is still no branch protection, so a red check
+# is advisory. `test_ci_claim_matches_reality.py` cannot see this — its own
+# scope note excludes Tekton — so do not read its green as agreement.
 # A new `exit` here must pick a side deliberately.
 # --- GUARD 1: tool precondition ------------------------------------------------
 # Every binary the suites `skipif` on. Absence must be an ERROR, never a skip.
@@ -342,8 +349,9 @@ if [ "${#missing_tools[@]}" -gt 0 ]; then
   # pre-push hook DEGRADED, and the push went through with ZERO tests run — while
   # the test that would have caught the typo never executed, because the runner
   # aborted before pytest started. That is "a suite stops running while the gate
-  # goes green" on the only tier that runs automatically (no CI, no branch
-  # protection). devrc#705.
+  # goes green" on the only tier that BLOCKS a push — a Tekton PR gate does now
+  # run (see the EXIT CODES block above), but with no branch protection its red
+  # is advisory, so exit 3 here still let the push land. devrc#705.
   #
   # The discriminator is whether we are IN a sanctioned gate env, which both the
   # devShell and checks.pytests announce with DEVRC_GATE_ENV=1:
@@ -358,12 +366,34 @@ if [ "${#missing_tools[@]}" -gt 0 ]; then
   # (ripgrep->rg, util-linux->setsid, gnugrep->grep, nodejs->node), and this repo
   # has already been bitten by exactly that shape once (pyyaml->yaml, #704). A
   # table says nothing about the mapping it is missing.
+  #
+  # 🔴 The accepted value is EXACTLY "1" — not "any truthy value". A future tier
+  # writing `DEVRC_GATE_ENV=true` would fall through to the degrade arm. That is
+  # the fail-SAFE direction (a push blocks over a broken caller only if we get
+  # this wrong the other way), so it is a deliberate exact match, not an
+  # oversight: if you add a tier, export literally 1.
+  #
+  # 🔴 And the marker is a VARIABLE, so unlike the shellHook that sets it, it CAN
+  # be wrong about its environment: an operator who exports it by hand outside a
+  # gate env turns a genuine environment fault into a BLOCK whose message
+  # asserts the repo is broken. Manual paths only — every automated path
+  # re-enters `nix develop`, whose shellHook overwrites any inherited value
+  # (measured: DEVRC_GATE_ENV=0 nix develop … yields 1), so the hook tier cannot
+  # be weakened this way.
   if [ "${DEVRC_GATE_ENV:-0}" = "1" ]; then
     echo >&2
     echo "  🔴 This is a REPO defect, not an environment one: you are inside a" >&2
     echo "  sanctioned gate environment (DEVRC_GATE_ENV=1) and the tool is STILL" >&2
     echo "  missing, so REQUIRED_TOOLS names something flake.nix \`gateTools\`" >&2
-    echo "  does not supply. Fix the spelling, or add the package to gateTools." >&2
+    echo "  does not supply." >&2
+    echo >&2
+    echo "  FIX — the two files that must agree, and the name is in both:" >&2
+    echo "    * $ROOT/scripts/run-tests.sh   -> REQUIRED_TOOLS (the binary name)" >&2
+    echo "    * $ROOT/flake.nix              -> gateTools      (the nix package)" >&2
+    echo "  Correct the spelling in REQUIRED_TOOLS, or add the package that" >&2
+    echo "  provides it to gateTools. Note the two use DIFFERENT names for the" >&2
+    echo "  same tool (ripgrep provides rg, nodejs provides node)." >&2
+    echo >&2
     echo "  Exiting 2 so the pre-push hook BLOCKS rather than degrading." >&2
     exit 2
   fi

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -270,12 +270,19 @@ cd "$ROOT" || { echo "run-tests: cannot cd to ROOT=$ROOT" >&2; exit 3; }
 # exactly that outcome, on the only tier that BLOCKS a push. 🔴 "The only tier
 # that RUNS" was true when this was written and is now FALSE: a Tekton PR gate
 # (`tekton/devrc-pytests`, `tekton/devrc-nodetests`) went live between #704 and
-# #714 — measured, #704 reports no checks and #714 reports both. It invokes
-# `nix develop --command bash scripts/run-tests.sh .`, so it IS armed by the
-# devShell's DEVRC_GATE_ENV export and needs no separate handling. What it does
-# NOT do is block a merge: there is still no branch protection, so a red check
-# is advisory. `test_ci_claim_matches_reality.py` cannot see this — its own
-# scope note excludes Tekton — so do not read its green as agreement.
+# #714 — measured, #704 reports no checks and #714 reports both. It runs
+# `nix build .#checks.x86_64-linux.<leg>` — it does NOT enter the devShell — so
+# it is armed by checks.pytests's OWN export, not the shellHook's. (The
+# nodetests leg exports no marker and needs none: its runner has no
+# DEVRC_GATE_ENV and no exit 3.)
+#
+# What that gate does NOT do is block a merge: `main`'s branch protection does
+# NOT require status checks — `required_status_checks` returns 404 (measured
+# 2026-08-22) — though it DOES require 1 approving review. So protection EXISTS
+# and a red check is still advisory; do not restate this as "there is no branch
+# protection", which is the wrong mechanism for the right conclusion.
+# `test_ci_claim_matches_reality.py` cannot see any of this — its own scope note
+# excludes Tekton — so do not read its green as agreement.
 # A new `exit` here must pick a side deliberately.
 # --- GUARD 1: tool precondition ------------------------------------------------
 # Every binary the suites `skipif` on. Absence must be an ERROR, never a skip.
@@ -350,8 +357,9 @@ if [ "${#missing_tools[@]}" -gt 0 ]; then
   # the test that would have caught the typo never executed, because the runner
   # aborted before pytest started. That is "a suite stops running while the gate
   # goes green" on the only tier that BLOCKS a push — a Tekton PR gate does now
-  # run (see the EXIT CODES block above), but with no branch protection its red
-  # is advisory, so exit 3 here still let the push land. devrc#705.
+  # run (see the EXIT CODES block above), but its red is advisory — branch
+  # protection does not require status checks — so exit 3 here still let the
+  # push land. devrc#705.
   #
   # The discriminator is whether we are IN a sanctioned gate env, which both the
   # devShell and checks.pytests announce with DEVRC_GATE_ENV=1:
@@ -387,12 +395,15 @@ if [ "${#missing_tools[@]}" -gt 0 ]; then
     echo "  missing, so REQUIRED_TOOLS names something flake.nix \`gateTools\`" >&2
     echo "  does not supply." >&2
     echo >&2
-    echo "  FIX — the two files that must agree, and the name is in both:" >&2
-    echo "    * $ROOT/scripts/run-tests.sh   -> REQUIRED_TOOLS (the binary name)" >&2
-    echo "    * $ROOT/flake.nix              -> gateTools      (the nix package)" >&2
-    echo "  Correct the spelling in REQUIRED_TOOLS, or add the package that" >&2
-    echo "  provides it to gateTools. Note the two use DIFFERENT names for the" >&2
-    echo "  same tool (ripgrep provides rg, nodejs provides node)." >&2
+    echo "  FIX — two files must agree, but they name the tool DIFFERENTLY:" >&2
+    echo "    * $ROOT/scripts/run-tests.sh -> REQUIRED_TOOLS (the BINARY name)" >&2
+    echo "    * $ROOT/flake.nix            -> gateTools      (the NIX PACKAGE)" >&2
+    echo "  🔴 Do NOT expect to find the binary name in flake.nix — the package" >&2
+    echo "  that provides it is usually spelled differently (ripgrep provides" >&2
+    echo "  rg, nodejs provides node, util-linux provides setsid, gnugrep" >&2
+    echo "  provides grep). Finding no match there does NOT mean it is absent." >&2
+    echo "  So: correct the spelling in REQUIRED_TOOLS, or add the package that" >&2
+    echo "  PROVIDES the binary to gateTools." >&2
     echo >&2
     echo "  Exiting 2 so the pre-push hook BLOCKS rather than degrading." >&2
     exit 2

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -254,9 +254,15 @@ fi
 # starts, so unsetting it here is the one place that fixes it for all of them.
 unset CDPATH
 cd "$ROOT" || { echo "run-tests: cannot cd to ROOT=$ROOT" >&2; exit 3; }
-# 🔴 EXIT CODES: 3 = the ENVIRONMENT could not satisfy a precondition (this guard,
-# 1b, 1c). 2 = a REPO-CONTENT guard refused (target list, floor table, launcher
-# stubs, spool wiring). The distinction is load-bearing: `githooks/tests-on-push.sh`
+# 🔴 EXIT CODES: 3 = the ENVIRONMENT could not satisfy a precondition (GUARDs 1b
+# and 1c, a failed `cd $ROOT`, the spool `mkdir`, and GUARD 1 when run OUTSIDE a
+# sanctioned gate env). 2 = a REPO-CONTENT defect (target list, floor table,
+# launcher stubs, spool wiring — and GUARD 1 when DEVRC_GATE_ENV=1, because then
+# the missing tool is something the repo asked for and nothing supplies).
+# 🔴 NOTE GUARD 1 IS IN BOTH LISTS: it is the one guard whose code depends on the
+# CAUSE rather than on which guard fired, because its input (REQUIRED_TOOLS) is
+# repo content but its usual failure is environmental. The distinction is
+# load-bearing: `githooks/tests-on-push.sh`
 # DEGRADES on 3 (an env fault must not block a push over a broken caller) and
 # BLOCKS on 2. Collapsing them was a measured mistake — degrading on 2 turned
 # GUARD 5's and GUARD 3a's own warning ("do NOT delete the entry to make this
@@ -325,8 +331,51 @@ fi
 if [ "${#missing_tools[@]}" -gt 0 ]; then
   echo "run-tests: FATAL — required tool(s) missing from PATH: ${missing_tools[*]}" >&2
   echo "  The suites SKIP the tests that need these, so the run would go green while" >&2
-  echo "  testing less. This is a MISSING ENVIRONMENT, not a code failure — nothing" >&2
-  echo "  in the repo is broken and no test has run yet." >&2
+  echo "  testing less. No test has run yet." >&2
+  echo >&2
+  echo "  Do NOT drop entries from REQUIRED_TOOLS to make this pass — each one is" >&2
+  echo "  justified in the comment block directly above it." >&2
+  # 🔴 CLASSIFY BY CAUSE, NOT BY SITE. This guard reads REQUIRED_TOOLS, which is
+  # REPO CONTENT — so "GUARD 1 fired" does not by itself mean the environment is
+  # at fault, and treating it as environmental let a typo turn the gate off.
+  # MEASURED: `logrotatee` planted in REQUIRED_TOOLS aborted with rc 3, the
+  # pre-push hook DEGRADED, and the push went through with ZERO tests run — while
+  # the test that would have caught the typo never executed, because the runner
+  # aborted before pytest started. That is "a suite stops running while the gate
+  # goes green" on the only tier that runs automatically (no CI, no branch
+  # protection). devrc#705.
+  #
+  # The discriminator is whether we are IN a sanctioned gate env, which both the
+  # devShell and checks.pytests announce with DEVRC_GATE_ENV=1:
+  #   * set   -> the env supplies everything `gateTools` declares, so a still-
+  #              missing entry means the REPO asked for something nothing
+  #              supplies (a typo, or a gateTools omission). Repo defect: BLOCK.
+  #   * unset -> the caller is not in the gate env. Caller defect: degrade, and
+  #              the FATAL above tells them how to get in.
+  #
+  # 🔴 Deliberately NOT "is the binary declared in gateTools", which was the first
+  # design: that needs a hand-maintained nixpkgs-attr -> binary-name table
+  # (ripgrep->rg, util-linux->setsid, gnugrep->grep, nodejs->node), and this repo
+  # has already been bitten by exactly that shape once (pyyaml->yaml, #704). A
+  # table says nothing about the mapping it is missing.
+  if [ "${DEVRC_GATE_ENV:-0}" = "1" ]; then
+    echo >&2
+    echo "  🔴 This is a REPO defect, not an environment one: you are inside a" >&2
+    echo "  sanctioned gate environment (DEVRC_GATE_ENV=1) and the tool is STILL" >&2
+    echo "  missing, so REQUIRED_TOOLS names something flake.nix \`gateTools\`" >&2
+    echo "  does not supply. Fix the spelling, or add the package to gateTools." >&2
+    echo "  Exiting 2 so the pre-push hook BLOCKS rather than degrading." >&2
+    exit 2
+  fi
+  # The other arm. 🔴 Everything below is TRUE ONLY HERE — it says the repo is
+  # fine and tells you to enter the dev shell, and both are wrong advice for a
+  # caller who is already IN one. That is why it moved out of the shared header:
+  # it was printed unconditionally, so the exit-2 arm this change adds would have
+  # told a contributor with a REQUIRED_TOOLS typo that "nothing in the repo is
+  # broken" and to go re-run in the shell they were already standing in.
+  echo >&2
+  echo "  This is a MISSING ENVIRONMENT, not a code failure — nothing in the" >&2
+  echo "  repo is broken." >&2
   echo >&2
   echo "  FIX — enter the repo's own dev shell, which carries exactly this list," >&2
   echo "  and re-run from there:" >&2
@@ -337,9 +386,6 @@ if [ "${#missing_tools[@]}" -gt 0 ]; then
   echo "  you like). That shell is built from the SAME flake.nix \`gateTools\` list" >&2
   echo "  as the \`nix flake check\` gate, so it cannot drift out of satisfying this" >&2
   echo "  precondition." >&2
-  echo >&2
-  echo "  Do NOT drop entries from REQUIRED_TOOLS to make this pass — each one is" >&2
-  echo "  justified in the comment block directly above it." >&2
   exit 3
 fi
 

--- a/scripts/tests/test_devshell_satisfies_required_tools.py
+++ b/scripts/tests/test_devshell_satisfies_required_tools.py
@@ -489,10 +489,37 @@ def test_both_sanctioned_gate_envs_export_the_marker():
     src = _uncommented_flake()
     MARKER = "DEVRC_GATE_ENV=1"
 
-    # --- half 1: the devShell's shellHook (the pre-push tier's environment) ---
+    # 🔴 BOTH WINDOWS ARE STRUCTURALLY BOUNDED, AND PROVEN DISJOINT.
+    # The first version bounded half 1 with a FIXED SLICE, src[shell_at:+800].
+    # Measured, that ran 538 chars PAST the devShell block and INTO the pytests
+    # derivation: the windows were (2458,3258) and (2720,5620). A single marker
+    # landing in the overlap satisfied BOTH assertions, so a flake.nix with
+    # NEITHER tier armed could pass -- the exact vacuity this test exists to
+    # prevent, reintroduced by the fix for it. The 800 was only ever "safe" by
+    # however much comment text happened to separate the two blocks, which is
+    # the least stable content in the file.
     shell_at = src.find("shellHook")
+    py_at = src.find("pytests =")
+    node_at = src.find("nodetests =", py_at) if py_at != -1 else -1
     assert shell_at != -1, "no shellHook in flake.nix"
-    assert MARKER in src[shell_at:shell_at + 800], (
+    assert py_at != -1, "no `pytests =` derivation in flake.nix"
+    assert node_at != -1, "no `nodetests =` after pytests to bound the window"
+    # The ordering assumption, made explicit rather than left implicit in a
+    # slice: devShells is declared BEFORE checks. If that ever flips, this fails
+    # loudly here instead of silently producing an empty or inverted window.
+    assert shell_at < py_at, (
+        f"expected the devShell ({shell_at}) to be declared before the checks "
+        f"block ({py_at}); the window bounds below assume it."
+    )
+    dev_win, pyt_win = (shell_at, py_at), (py_at, node_at)
+    # TRIPWIRE: the whole point is that each half is pinned SEPARATELY.
+    assert dev_win[1] <= pyt_win[0], (
+        f"the two windows overlap ({dev_win} vs {pyt_win}) — a single marker in "
+        "the overlap would satisfy both assertions, so neither half is pinned."
+    )
+
+    # --- half 1: the devShell's shellHook (the pre-push tier's environment) ---
+    assert MARKER in src[dev_win[0]:dev_win[1]], (
         "the devShell's shellHook does not export DEVRC_GATE_ENV=1, so a "
         "contributor running the gate from `nix develop` -- which is how the "
         "pre-push hook invokes it -- gets the ENVIRONMENT diagnosis for a REPO "
@@ -500,15 +527,20 @@ def test_both_sanctioned_gate_envs_export_the_marker():
     )
 
     # --- half 2: the checks.pytests derivation (the hermetic/CI tier) ---
-    # Bounded by the NEXT derivation so this window cannot drift into it. Both
-    # anchors are assignments: the bare word "nodetests" also appears in a
-    # comment inside the pytests block, and slicing on that truncated the window
-    # to before the export while writing this.
-    py_at = src.find("pytests =")
-    assert py_at != -1, "no `pytests =` derivation in flake.nix"
-    node_at = src.find("nodetests =", py_at)
-    assert node_at != -1, "no `nodetests =` after pytests to bound the window"
-    assert MARKER in src[py_at:node_at], (
+    # 🔴 This is the export the TEKTON PR GATE runs on. That pipeline does
+    # `nix build .#checks.x86_64-linux.pytests` -- it does NOT enter the
+    # devShell -- so half 1 does not cover CI and this half is not redundant
+    # with it. (`checks.nodetests` exports no marker and needs none: its runner
+    # has no DEVRC_GATE_ENV and no exit 3 at all.)
+    #
+    # The anchors are both ASSIGNMENTS (`nodetests =`, not the bare word). In
+    # THIS code path that is belt-and-braces rather than load-bearing, because
+    # `_uncommented_flake` has already removed the comment that contains the
+    # bare word -- stripped, both spellings resolve to the same offset. It
+    # matters when reading the RAW file, where the bare word appears ~7.7k
+    # chars earlier and truncates the window to before the export. Keep the
+    # assignment form so the anchor is right in both views.
+    assert MARKER in src[pyt_win[0]:pyt_win[1]], (
         "the checks.pytests derivation does not export DEVRC_GATE_ENV=1, so the "
         "hermetic tier misclassifies its OWN repo defects as environment "
         "faults. Asserted as its own window, not as a count: a total is "

--- a/scripts/tests/test_devshell_satisfies_required_tools.py
+++ b/scripts/tests/test_devshell_satisfies_required_tools.py
@@ -412,6 +412,19 @@ def test_guard1_classifies_by_cause_not_by_site(
     (stub / "bash").symlink_to(bash)
     home = tmp_path_factory.mktemp("home-cause")
 
+    # 🔴 This REPLACES PATH, so it falls under test_no_real_launchers.py's
+    # PINNED_PATH_CLOBBERS ledger, whose justification works by ENUMERATING the
+    # clobbering dir's contents and whose closing line is that the fixture
+    # "ASSERTS the one-entry contents itself, so this justification is a live
+    # invariant rather than prose that can rot". The ledger's needle matches
+    # BOTH stub dirs in this file, so it cannot tell them apart -- without the
+    # same assertion here, the justification is prose again for this site.
+    assert sorted(p.name for p in stub.iterdir()) == ["bash"], (
+        "the stub PATH dir must hold exactly one entry (a bash symlink); it "
+        f"holds {sorted(p.name for p in stub.iterdir())}. PINNED_PATH_CLOBBERS "
+        "justifies this clobber by enumerating those contents."
+    )
+
     # An explicit env dict, so the ambient DEVRC_GATE_ENV cannot leak in and
     # decide the arm for us. That matters: this suite normally runs INSIDE the
     # dev shell, where the marker IS set, so inheriting it would collapse both
@@ -451,12 +464,22 @@ def test_guard1_classifies_by_cause_not_by_site(
 def test_both_sanctioned_gate_envs_export_the_marker():
     """The two tiers that satisfy REQUIRED_TOOLS must both announce themselves.
 
-    🔴 SILENT-FAILURE DIRECTION. If only the devShell exports it, `nix flake
-    check` misclassifies its OWN repo defects as environment faults; if only
-    checks.pytests does, the pre-push tier -- the only one that runs
-    automatically here, since this repo has no CI and no branch protection --
-    goes back to degrading on a typo. Neither shows up as a failure anywhere:
-    the runner still exits, just with the code that lets the push through.
+    🔴 SILENT-FAILURE DIRECTION, and the two halves are NOT symmetric.
+    If only checks.pytests exports it, the pre-push tier goes back to degrading
+    on a typo, and nothing anywhere reports it: the runner still exits, just
+    with the code that lets the push through. That half is genuinely silent.
+    If only the devShell exports it, `nix flake check` misclassifies its own
+    repo defects as environment faults -- but flake.nix fails the derivation on
+    ANY non-zero rc, so that half changes the DIAGNOSIS, not the verdict.
+    Both are worth pinning; only the first is invisible.
+
+    🔴 ASSERT ONE WINDOW PER HALF, never a total. A `count() >= 2` is satisfied
+    by any second occurrence, so it passes while one tier has BOTH exports and
+    the other has none -- measured: delete the checks.pytests export, duplicate
+    the devShell one, and a version of this test that checked only the total
+    plus the shellHook window went green. That is this repo's "a guard's
+    DESCRIPTION claims coverage the implementation does not provide" shape, in
+    the very test written to close a coverage gap.
 
     Reads flake.nix as SOURCE, with the same limitation the seam tests above
     document -- it can see the export is WRITTEN and not commented out, not that
@@ -464,19 +487,30 @@ def test_both_sanctioned_gate_envs_export_the_marker():
     the commented-out case fail rather than pass.
     """
     src = _uncommented_flake()
-    hits = src.count("DEVRC_GATE_ENV=1")
-    assert hits >= 2, (
-        f"DEVRC_GATE_ENV=1 is exported {hits} time(s) in flake.nix; both the "
-        "devShell shellHook AND checks.pytests must set it. GUARD 1 uses it to "
-        "tell a REPO defect from a CALLER defect, so a tier that does not set "
-        "it silently degrades instead of blocking (devrc#705)."
-    )
-    # ...and specifically in the devShell, not twice in the sandbox check.
+    MARKER = "DEVRC_GATE_ENV=1"
+
+    # --- half 1: the devShell's shellHook (the pre-push tier's environment) ---
     shell_at = src.find("shellHook")
     assert shell_at != -1, "no shellHook in flake.nix"
-    tail = src[shell_at:shell_at + 800]
-    assert "DEVRC_GATE_ENV=1" in tail, (
+    assert MARKER in src[shell_at:shell_at + 800], (
         "the devShell's shellHook does not export DEVRC_GATE_ENV=1, so a "
-        "contributor running the gate from `nix develop` gets the "
-        "ENVIRONMENT diagnosis for a REPO defect and the hook degrades."
+        "contributor running the gate from `nix develop` -- which is how the "
+        "pre-push hook invokes it -- gets the ENVIRONMENT diagnosis for a REPO "
+        "defect, and the hook DEGRADES instead of blocking (devrc#705)."
+    )
+
+    # --- half 2: the checks.pytests derivation (the hermetic/CI tier) ---
+    # Bounded by the NEXT derivation so this window cannot drift into it. Both
+    # anchors are assignments: the bare word "nodetests" also appears in a
+    # comment inside the pytests block, and slicing on that truncated the window
+    # to before the export while writing this.
+    py_at = src.find("pytests =")
+    assert py_at != -1, "no `pytests =` derivation in flake.nix"
+    node_at = src.find("nodetests =", py_at)
+    assert node_at != -1, "no `nodetests =` after pytests to bound the window"
+    assert MARKER in src[py_at:node_at], (
+        "the checks.pytests derivation does not export DEVRC_GATE_ENV=1, so the "
+        "hermetic tier misclassifies its OWN repo defects as environment "
+        "faults. Asserted as its own window, not as a count: a total is "
+        "satisfied by two exports in the devShell and none here."
     )

--- a/scripts/tests/test_devshell_satisfies_required_tools.py
+++ b/scripts/tests/test_devshell_satisfies_required_tools.py
@@ -370,3 +370,113 @@ def test_every_required_tool_is_justified_in_the_comment_block():
         f"REQUIRED_TOOLS entries with no justification in the comment block "
         f"above them: {unjustified}. The FATAL promises the reader one."
     )
+
+
+# ---------------------------------------------------------------------------
+# GUARD 1 CLASSIFIES BY CAUSE (devrc#705)
+#
+# GUARD 1 reads REQUIRED_TOOLS, which is REPO CONTENT, but exited 3 for every
+# cause -- so `githooks/tests-on-push.sh` DEGRADED on a typo there and the push
+# went through with zero tests run. Measured before the fix: `logrotatee` in
+# REQUIRED_TOOLS -> rc 3 -> push allowed. The test that would have caught the
+# typo never ran, because the runner aborts at GUARD 1 before pytest starts.
+#
+# The discriminator is DEVRC_GATE_ENV=1, exported by BOTH sanctioned gate
+# environments. The two tests below pin the two halves, and BOTH are needed:
+# the behavioural one proves the runner branches on the marker, and the seam one
+# proves something still SETS it. Drop the export from flake.nix and the
+# behavioural test still passes while the gate silently reverts to
+# always-degrade -- the exact silent direction this issue was filed about.
+
+
+@pytest.mark.parametrize(
+    "marker,expect_rc,must_say,must_not_say",
+    [
+        # In a sanctioned gate env the toolchain supplies everything gateTools
+        # declares, so a STILL-missing entry means the repo asked for something
+        # nothing supplies. Repo defect -> 2 -> the hook BLOCKS.
+        ("1", 2, "REPO defect", "not a code failure"),
+        # Outside one, the caller simply is not in the gate env. Caller defect
+        # -> 3 -> the hook degrades, and the FATAL says how to get in.
+        (None, 3, "not a code failure", "REPO defect"),
+    ],
+    ids=["inside-gate-env-BLOCKS", "outside-gate-env-degrades"],
+)
+def test_guard1_classifies_by_cause_not_by_site(
+    tmp_path_factory, marker, expect_rc, must_say, must_not_say
+):
+    """Same missing tool, two causes, two exit codes -- driven, not parsed."""
+    bash = shutil.which("bash")
+    assert bash, "bash is not on PATH; this suite cannot drive the runner"
+    stub = tmp_path_factory.mktemp("only-bash-cause")
+    (stub / "bash").symlink_to(bash)
+    home = tmp_path_factory.mktemp("home-cause")
+
+    # An explicit env dict, so the ambient DEVRC_GATE_ENV cannot leak in and
+    # decide the arm for us. That matters: this suite normally runs INSIDE the
+    # dev shell, where the marker IS set, so inheriting it would collapse both
+    # parametrisations onto the same arm and the pair would agree vacuously.
+    env = {"PATH": str(stub), "HOME": str(home)}
+    if marker is not None:
+        env["DEVRC_GATE_ENV"] = marker
+
+    proc = subprocess.run(
+        [bash, str(RUN_TESTS), str(REPO_ROOT)],
+        env=env, capture_output=True, text=True, timeout=120,
+    )
+    out = proc.stdout + proc.stderr
+
+    # POSITIVE CONTROL -- without it, an abort from some OTHER guard that
+    # happened to share the expected code would read as a pass.
+    assert "required tool(s) missing from PATH" in out, (
+        "GUARD 1 is not what fired, so this measures the wrong guard.\n"
+        f"exit={proc.returncode}\n{out[-3000:]}"
+    )
+    assert proc.returncode == expect_rc, (
+        f"DEVRC_GATE_ENV={marker!r} should classify as exit {expect_rc}, got "
+        f"{proc.returncode}. Exit 3 DEGRADES the pre-push hook; exit 2 blocks "
+        f"it.\n{out[-3000:]}"
+    )
+    # The wording must match the classification. A correct code under the wrong
+    # diagnosis is its own defect: the environment arm tells the reader "nothing
+    # in the repo is broken" and to go enter the dev shell, which is actively
+    # wrong advice for someone who is already inside one.
+    assert must_say in out, f"expected {must_say!r} in the FATAL:\n{out[-3000:]}"
+    assert must_not_say not in out, (
+        f"the FATAL carries {must_not_say!r}, which belongs to the OTHER arm — "
+        f"the diagnosis contradicts the exit code.\n{out[-3000:]}"
+    )
+
+
+def test_both_sanctioned_gate_envs_export_the_marker():
+    """The two tiers that satisfy REQUIRED_TOOLS must both announce themselves.
+
+    🔴 SILENT-FAILURE DIRECTION. If only the devShell exports it, `nix flake
+    check` misclassifies its OWN repo defects as environment faults; if only
+    checks.pytests does, the pre-push tier -- the only one that runs
+    automatically here, since this repo has no CI and no branch protection --
+    goes back to degrading on a typo. Neither shows up as a failure anywhere:
+    the runner still exits, just with the code that lets the push through.
+
+    Reads flake.nix as SOURCE, with the same limitation the seam tests above
+    document -- it can see the export is WRITTEN and not commented out, not that
+    nix evaluates it into the environment. `_uncommented_flake` is what makes
+    the commented-out case fail rather than pass.
+    """
+    src = _uncommented_flake()
+    hits = src.count("DEVRC_GATE_ENV=1")
+    assert hits >= 2, (
+        f"DEVRC_GATE_ENV=1 is exported {hits} time(s) in flake.nix; both the "
+        "devShell shellHook AND checks.pytests must set it. GUARD 1 uses it to "
+        "tell a REPO defect from a CALLER defect, so a tier that does not set "
+        "it silently degrades instead of blocking (devrc#705)."
+    )
+    # ...and specifically in the devShell, not twice in the sandbox check.
+    shell_at = src.find("shellHook")
+    assert shell_at != -1, "no shellHook in flake.nix"
+    tail = src[shell_at:shell_at + 800]
+    assert "DEVRC_GATE_ENV=1" in tail, (
+        "the devShell's shellHook does not export DEVRC_GATE_ENV=1, so a "
+        "contributor running the gate from `nix develop` gets the "
+        "ENVIRONMENT diagnosis for a REPO defect and the hook degrades."
+    )

--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -951,8 +951,11 @@ PINNED_PATH_CLOBBERS = {
         "measured the intended case: two tiers, opposite blind spots"),
     "test_devshell_satisfies_required_tools.py": (
         '{"PATH"' + ': str(stub)',
-        "the SECOND clobber justified by ENUMERATION rather than emptiness, and "
-        "the stronger case of the two. 🔴 This needle now matches TWO sites in "
+        "a clobber justified by ENUMERATION rather than emptiness, and the "
+        "strongest of those. (It used to say \"the SECOND … of the two\": there "
+        "are THREE enumeration-justified entries, and next to the \"TWO sites\" "
+        "below the ordinal read as if it counted those instead.) 🔴 This needle "
+        "now matches TWO sites in "
         "that file — the `emitted_fatal` fixture (`only-bash`) and "
         "`test_guard1_classifies_by_cause_not_by_site` (`only-bash-cause`) — so "
         "it cannot tell them apart; BOTH carry the one-entry assertion, which "

--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -952,9 +952,13 @@ PINNED_PATH_CLOBBERS = {
     "test_devshell_satisfies_required_tools.py": (
         '{"PATH"' + ': str(stub)',
         "the SECOND clobber justified by ENUMERATION rather than emptiness, and "
-        "the stronger case of the two: the replacement directory is created by "
-        "the fixture itself two lines above the clobber "
-        "(`tmp_path_factory.mktemp(\"only-bash\")`, then one "
+        "the stronger case of the two. 🔴 This needle now matches TWO sites in "
+        "that file — the `emitted_fatal` fixture (`only-bash`) and "
+        "`test_guard1_classifies_by_cause_not_by_site` (`only-bash-cause`) — so "
+        "it cannot tell them apart; BOTH carry the one-entry assertion, which "
+        "is what keeps this justification live for each. In both, the "
+        "replacement directory is created by the test itself near the clobber "
+        "(`tmp_path_factory.mktemp(...)`, then one "
         "`(stub / \"bash\").symlink_to(bash)`), so its contents are not merely "
         "audited but CONSTRUCTED — it holds exactly one entry, a bash symlink, "
         "and nothing else can appear in a freshly-minted tmp dir. No "

--- a/scripts/tests/test_run_tests_preconditions.py
+++ b/scripts/tests/test_run_tests_preconditions.py
@@ -410,13 +410,28 @@ def test_guard1c_dep_list_matches_the_flake_interpreter():
 def test_the_hook_degrades_on_ENV_faults_and_BLOCKS_on_repo_content():
     """🔴 The exit-code split, and the reason it exists.
 
-    A first version of the pre-push hook degraded on rc 2. `run-tests.sh` has TEN abort
-    sites and only six are environmental; the rest are REPO-CONTENT
-    guards -- the target list, the floor table, the launcher stubs, the spool
-    wiring -- whose own messages warn "do NOT delete the entry to make this pass
-    -- that is how a suite stops running while the gate goes green". Degrading on
-    2 produced precisely that, on the ONLY tier that runs automatically: this repo
-    has no CI and no branch protection (pinned by test_ci_claim_matches_reality).
+    A first version of the pre-push hook degraded on rc 2. `run-tests.sh` has
+    ELEVEN abort sites -- six `exit 3` and five `exit 2`; the exit-2 ones are
+    REPO-CONTENT guards -- the target list, the floor table, the launcher stubs,
+    the spool wiring -- whose own messages warn "do NOT delete the entry to make
+    this pass -- that is how a suite stops running while the gate goes green".
+    Degrading on 2 produced precisely that, on the only tier that BLOCKS a push.
+
+    🔴 Two corrections, both because the claims above went stale and were still
+    being cited. (a) The census said "TEN abort sites, only six environmental",
+    which is both the wrong total and a 6/4 split against the true 6/5; a
+    line-anchored `^\\s*exit 3$` misses the inline `cd "$ROOT" || { ...; exit 3; }`
+    spelling. (b) "The ONLY tier that runs automatically: no CI and no branch
+    protection" -- a Tekton PR gate now runs (`tekton/devrc-pytests`,
+    `tekton/devrc-nodetests`); measured, #704 reports no checks and #714 reports
+    both. Its red is advisory -- `main`'s protection requires a review but NOT
+    status checks (`required_status_checks` -> 404, measured 2026-08-22) -- so
+    the accurate claim is "the only tier that BLOCKS", not "the only tier that
+    runs", and NOT "there is no branch protection".
+
+    🔴 GUARD 1 is now in BOTH lists: since devrc#705 it classifies by CAUSE
+    (DEVRC_GATE_ENV=1 -> repo defect -> 2; unset -> caller defect -> 3), so the
+    exit code no longer follows from which guard fired.
 
     So the runner now exits 3 for environment faults, and this asserts BOTH sides
     -- the hook degrading on 3 is worthless if it also degrades on 2.


### PR DESCRIPTION
Closes #705.

## The defect

`run-tests.sh` classified its aborts by **site**, not by **cause**. GUARD 1 was an environment precondition (`exit 3`, which `githooks/tests-on-push.sh` degrades on) — but one of its inputs, `REQUIRED_TOOLS`, is **repo content**. A typo there turned the gate off.

Measured, before the fix — plant `logrotatee` in `REQUIRED_TOOLS` and drive the runner exactly as the hook does:

```
nix develop <repo> --command bash <repo>/scripts/run-tests.sh --set all <repo>
  -> rc=3   ->   hook DEGRADES   ->   push allowed, ZERO tests run
```

The test that would have caught the typo never runs, because the runner aborts at GUARD 1 before pytest starts. This repo has **no branch protection**, so the pre-push hook is the only tier that *blocks*. (A Tekton PR gate does now run — see the round-2 correction below — but with no branch protection its red is advisory.)

## The fix

Both sanctioned gate environments now export `DEVRC_GATE_ENV=1` — the devShell's `shellHook` and `checks.pytests` — and GUARD 1 branches on it:

| `DEVRC_GATE_ENV` | means | exit | hook |
|---|---|---|---|
| `1` | the env supplies everything `gateTools` declares, so a still-missing entry is something **the repo asked for and nothing supplies** | **2** | **BLOCKS** |
| unset | the caller is simply not in the gate env | **3** | degrades |

Same missing tool, two causes, two codes.

### Why not the fix the issue suggested

#705 proposed exiting 2 when the missing binary is *not declared in `gateTools`*. That needs a hand-maintained **nixpkgs-attr → binary-name** table (`ripgrep`→`rg`, `util-linux`→`setsid`, `gnugrep`→`grep`, `nodejs`→`node`), and #704's audit already caught this repo on exactly that shape with `pyyaml`→`yaml`. A table says nothing about the mapping it is missing. A marker the environment sets cannot drift out of describing that environment.

## A claim this change falsified

The FATAL said, unconditionally:

> This is a MISSING ENVIRONMENT, not a code failure — nothing in the repo is broken

…and told the reader to go enter the dev shell. Both are **wrong advice in the new arm** — you are already in one, and the repo *is* broken. The diagnosis moved below the branch and is now per-arm. The two sentences tests pin ("go green while", "Do NOT drop entries from REQUIRED_TOOLS") stay in the shared header, where they are true either way.

## Tests

Two, and **both are load-bearing in different directions**:

- `test_guard1_classifies_by_cause_not_by_site` — parametrized, drives the real runner with an explicit env dict (so the ambient marker cannot collapse both arms onto one), asserts the exit code **and** that the wording matches the classification, with a positive control that GUARD 1 is what fired.
- `test_both_sanctioned_gate_envs_export_the_marker` — the silent direction. Drop the export from flake.nix and the behavioural test *still passes* while the gate reverts to always-degrade.

### Mutation — 4 killed, each for its own assertion's reason, each with proof it landed

| mutant | result |
|---|---|
| branch disabled (`if false`) | inside-gate arm fails on returncode; **outside arm still passes** (arms are independent) |
| env arm reworded to "REPO defect" | outside arm fails on the wording assertion |
| devShell export **commented out** | seam test fails on the count — while the **raw substring count is still 2**, so a naive count would have passed |
| export **moved** (devShell → pytests twice) | seam test fails on the shellHook assertion, total still 2 (not redundant with the count) |

Two further attempts **asserted and failed closed** on a wrong anchor — `"          export"` (10 spaces) is a substring of the 12-space line — so no bogus "passed" entered the record.

## Verification

**End-to-end through the real hook, not per-component.** "The runner returns 2" and "the hook blocks on 2" are two isolated facts; the seam is what the issue is about. With `logrotatee` planted and driven through `githooks/tests-on-push.sh`:

```
HOOK rc=2
RESULT: FAIL (exit=2)
pre-push: ❌ devrc test suite FAILED (rc=2) — push BLOCKED.
```

Before this change, that exact input produced rc=3 → degrade → **push allowed, zero tests run**. Negative control: the same invocation on the unmutated tree runs the full suite and returns 0.
- Full suite through the real hook, and the hermetic tier (`checks.pytests`) rebuilt, since this PR modifies that derivation.
- `scripts/tests` — the target this PR's two new tests land in — **PASS, collected=7006, floor 6459**. Suite-wide: `passed=14690 skipped=2 failed=0`.

### One red in that run, and it is not this PR's

`FAIL scripts/signal/tests (collected=717 above drift ceiling 691, floor 553)` — **zero failing tests**, a floor that had fallen 164 behind. Control: a clean `worktree add --detach` of `origin/main` (2d1ba0d7) collects the same **717** with the same floor, so it was **already red on main** and blocking every push. Fixed separately, since it is unrelated to this change and holding up everyone.

## 🔴 The premise needs a caveat: the hook is NOT INSTALLED on this host

#705 argues this matters because the pre-push hook is the only tier that runs unattended. Measured while verifying this PR — **it currently runs for nobody on this machine**:

- `git config --global core.hooksPath` → **empty**; the same locally.
- `devrc/.git/hooks/` contains **only `.sample` files** — no `pre-push`.
- A real `git push` of the #708 branch printed **no `pre-push:` line at all** and was completely ungated.

So today the classification this PR fixes has no effect here until someone runs `githooks/install.sh`. That is a **deployment gap, not a reason to hold this change** — the semantics have to be right before the gate is switched on, and every measurement above drives the worker directly. Flagged rather than fixed, because installing a **global** `core.hooksPath` touches every repo on the box and is the operator's call.

## Still open, deliberately not in scope

There is still **no gate on the per-site classification itself** for guards *other* than GUARD 1 — `test_the_hook_degrades_on_ENV_faults_and_BLOCKS_on_repo_content` asserts only that *some* `exit 2` and *some* `exit 3` exist, so a future repo-content guard written as `exit 3` has no guard. #705's closing note raises it; it wants its own change.


---

# Round 2 — adversarial audit applied

Round-1 audit: **no 🔴, safe to merge**, four 🟡. All fixed in `3cd02dae`. Each finding was **reproduced here before being accepted** — and one of them corrected me.

**1. The seam test claimed both halves and pinned one.** `count(MARKER) >= 2` plus a devShell window passes with *both* exports in the devShell and *none* in `checks.pytests`. Reproduced: the marker sat at `flake.nix:181-182` with the sandbox tier unarmed, and the test went green. That is this repo's "a guard's description claims coverage the implementation does not provide" shape — inside the very test written to close a coverage gap; my own mutation round walked the *move* in only one direction. Now **one bounded window per half, no total**, verified both ways (drop pytests → fails at the pytests window, line 511; drop devShell → fails at the devShell window, line 495).

Same docstring: *"Neither shows up as a failure anywhere"* was **false** for the pytests half — `flake.nix` fails that derivation on any non-zero rc, so it changes the diagnosis, not the verdict. Only the devShell half is genuinely silent. They are no longer described as symmetric.

**2. The "no CI" premise is stale — and I restated it in new 🔴 comments.** Measured: `tekton/devrc-pytests` + `tekton/devrc-nodetests` run on #714; **#704 reports no checks**, so the gate went live between them. The accurate claim is "the only tier that **blocks**". Good news for this PR: that pipeline invokes the runner via `nix develop`, so it is **armed by the devShell export** — not a third unarmed tier. Corrected in `run-tests.sh` (both sites), the hook and the README. `test_ci_claim_matches_reality.py` structurally cannot see this (its scope note excludes Tekton), so its green is not agreement.

**3. Three stale exit-code claims in the consumer**, updated: `tests-on-push.sh:22`, `:220`, `githooks/README.md`. GUARD 1 is now named in **both** lists everywhere, since the split turns on cause rather than site.

🔴 The census in that comment ("TEN abort sites, six environmental") was stale too — and **re-deriving it corrected me, not the audit**: my anchored `^\s*exit 3$` counted 10 and missed the inline `cd "$ROOT" || { …; exit 3; }`. True count is **11** (six `exit 3`, five `exit 2`), which is what the audit said. A pattern that cannot see a second spelling returns a confident wrong number.

**4. The new PATH clobber sat outside its ledger's justification.** `PINNED_PATH_CLOBBERS` justifies this file's clobber by *enumerating* the stub dir and closes "the fixture ASSERTS the one-entry contents itself, so this justification is a live invariant rather than prose that can rot". The new test made a **second** stub dir without that assertion, and the ledger's needle matches both. Assertion copied.

🟢 Also: the accepted marker value is exactly `1` (a future `=true` would degrade — fail-safe, now stated); the marker is a *variable* and so, unlike the shellHook, **can** be wrong about its environment if exported by hand (manual paths only — every automated path re-enters `nix develop`, whose shellHook overwrites an inherited value; measured `DEVRC_GATE_ENV=0` in → `1` out); and the exit-2 arm now names the two files that must agree, matching the exit-3 arm's copy-pasteable remedy.

## Verification note — why the final green is from an isolated clone

The full suite **cannot currently go green in `~/workspace/devrc`**, for a reason unrelated to this PR: the `gitenv_plugin` guard from #683 attributes *any* concurrent git write in the shared clone to whichever test is running. A URL-routing test was reported as having created branch `mk3`. Filed as **#719**.

Attribution established three ways:
1. **Content** — the mutations are other sessions' branch names (`docs/merge-gate-marker-tekton`, committed by another session minutes earlier); the blamed tests cannot produce them.
2. **Control** — clean `origin/main` (`754bd218`) hits the same violations on a target this PR does not touch: `991 passed, 2 errors`. **Main is equally affected.**
3. **Isolation** — this exact tree in a separate clone (own `.git`, no concurrent writers): **`collected=14827 passed=14825 skipped=2 failed=0`, `RESULT: PASS (exit=0)`**.


---

# Round 3 — delta re-audit applied (`51a76c9c`)

Delta audit of round 2: **no 🔴, "safe to merge"**, seven findings. Six fixed; one deliberately left to another PR. **Two caught claims round 2 itself introduced** — which is why the delta gets re-audited.

**🔴 F5 — round 2's fix reintroduced the vacuity it closed.** Round 2 split the seam test into "one window per half", but only half 2 was structurally bounded; half 1 kept the pre-existing fixed slice `src[shell_at : shell_at + 800]`, which runs **538 chars past the devShell block and into the pytests derivation**. Measured on the stripped source: `(2458,3258)` vs `(2720,5620)`. A single marker in the overlap satisfied **both** assertions, so a `flake.nix` with **neither tier armed** could pass. The `800` was only ever "safe" by however much *comment* text separated the blocks — the least stable content in the file.

Both windows are now bounded by structure (`shellHook`..`pytests =`, `pytests =`..`nodetests =`), the block ordering is asserted rather than assumed, and a **disjointness tripwire** fails if they ever overlap again. Mutation: one marker planted inside the old overlap with **both** real exports deleted — previously **PASSED**, now **FAILS** on the devShell window's own assertion.

**🟡 F1 — the Tekton comment stated the wrong mechanism, in the direction that invites deleting the export.** Round 2 said the gate "invokes the runner through `nix develop`". It does not — the pipeline runs `nix build .#checks.x86_64-linux.<leg>` (`nix develop` appears zero times in the pipeline definition). So CI is armed by **`checks.pytests`'s own export**, and the devShell's does not cover it. The wrong mechanism makes that export look redundant — the belief that makes deleting it look safe, inverting the exact distinction the seam test protects. Also corrected: the `nodetests` leg is not "armed by the same marker" — it exports none and needs none.

**🔴 The same shape a third time, found while verifying F3: "no branch protection" is FALSE.** `main` **has** branch protection — `enforce_admins` on, force-push and deletion blocked, 1 approving review required. What it lacks is **`required_status_checks`** (API returns 404). So the conclusion ("a red check is advisory; this hook is the only tier that blocks") is right and the stated reason was wrong — the third right-conclusion-wrong-mechanism defect in two rounds, in a PR whose whole subject is classifying by cause. Corrected at all five sites, each naming `required_status_checks`, dated, with an explicit "do not restate this as 'there is no branch protection'".

**🟡 F2 — the stale-claim sweep missed a site because the phrase WRAPPED.** `test_run_tests_preconditions.py` carried both corrected claims; `grep "abort sites"` missed it because the text is split as `TEN abort
    sites`. A line-oriented search cannot see a claim spanning a line break — **the same blind spot that produced the wrong census** (a line-anchored `^\s*exit 3$` missing the inline `cd "$ROOT" || { …; exit 3; }`).

**🟡 F4** — the exit-2 remedy contradicted itself one sentence later ("the name is in both", then "the two use DIFFERENT names"). Rewritten to lead with the mismatch and state that finding no match in `flake.nix` does **not** mean the tool is absent. **🟢 F6/F7** — anchor justification true of the raw file but false of the code path it annotates; ledger prose describing one of the two sites its needle now matches.

**Not fixed here, deliberately: F3** (CLAUDE.md's "NO AUTOMATED GATE IS RUNNING" + `test_ci_claim_matches_reality.py`'s scope note). **PR #718 from another session already rewrites exactly those two files** — verified against its diff. Touching them here would conflict with work in review.

Full suite, isolated clone at this tip: `collected=14827 passed=14825 skipped=2 failed=0`, `RESULT: PASS (exit=0)`.


---

# Round 4 — CLEAN, and a note on the red CI check

Delta re-audit of `51a76c9c`: **no 🔴, no 🟡** — verdict **safe to merge**. The convergence pattern broke: round 3 fixed round 2's defect *without* introducing one, and all three of its replacement factual claims verified true independently (including the pre-push half of the Tekton correction, which it asserted without being asked). Round 3's window fix confirmed correct: `dev_win=(2458,2720)`, `pyt_win=(2720,5620)` — half-open and sharing an endpoint, so no single marker can satisfy both. Nine-mutant battery, each landing-verified; the round-2 regression case (`M3`) is **PASSED → FAILED** across the two test files.

Two of the four 🟢 taken in `94842ac4` (both touched text this PR wrote): "the only tier that BLOCKS" had lost its object at two of five sites — `main` also requires 1 approving review, which blocks a *merge*, so the unqualified form is wrong; and a `PINNED_PATH_CLOBBERS` ordinal that read as counting the wrong "two". Two 🟢 deliberately left: a ~40-char window slack that needs a deliberately planted live marker to reach, and a pre-existing docstring untouched by this PR.

## The red `tekton/devrc-pytests` check is not this PR's — filed as #725

Attributed rather than assumed:

- **Failing test identified:** `test_timeout_reaps_the_whole_process_group` — a 35s process-group reaping test. Its own self-check clears the machine (spawn probe 0.23s against a 0.80s stall threshold), so it is not simple CI load.
- **Reproduced on a byte-identical tree:** the sha was amended with **no content change** (`tree df30cf25` before and after) and CI failed identically — `failed=1` both times.
- **Green locally on the same derivation:** `nix build .#checks.x86_64-linux.pytests` **built (not cached) and passed**; the full suite in an isolated clone is `collected=14827 passed=14825 skipped=2 failed=0`.
- **Control — branches WITHOUT this change fail the same way:** #718 (docs-only, `CLAUDE.md` + one test file) and #715 both report the identical single failure.

Also surfaced there: the `pytests` step exits **0** even when `nix build` fails (the `| tee` masking its own pipeline comments warn about — the `verdict` step is the net that catches it), and the gate pod is GC'd, so after the fact the failing test is unrecoverable from the check. Identifying it required force-pushing an identical tree and tailing the live pod.

The check is **advisory** — `main` has branch protection but no `required_status_checks` — so this does not merge *through* an enforcing gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
