### PR TITLE
fix(guard9): the detector blamed TESTS for a repository with 30 other writers, one env var still switched it off, and the PR body's root cause was FALSE (audit follow-ups on #683)

### DIFF
--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -47,9 +47,23 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 # environment, `GIT_DIR=…` here silently hands this repository's git dir to
 # every child, including `tests-on-push.sh` -> `run-tests.sh` -> pytest. GIT_DIR
 # OVERRIDES `-C`, so the whole devrc suite would then build its fixtures inside
-# THIS checkout: that is the 2026-08-21 incident, in which `refs/heads/main` was
-# rewritten with fixture commits and pushed. `scripts/testlib/gitenv.py` closes
-# it from the suite's side; this rename closes the route.
+# THIS checkout — the shape of the 2026-08-21 incident, in which
+# `refs/heads/main` was rewritten with fixture commits and pushed.
+#
+# 🔴 BUT THE PRECONDITION IN THE FIRST SENTENCE IS LOAD-BEARING AND #683's PR
+# BODY DROPPED IT, turning a hygiene fix into a false diagnosis that was then
+# relayed onward as established fact. **Measured on git 2.55.0, as a PAIR: a
+# `git push` from a `GIT_DIR`-free parent gives `pre-push` only `GIT_EXEC_PATH`
+# and `GIT_PREFIX` (plus the caller's own `GIT_AUTHOR_*`/`GIT_CONFIG_*`) — no
+# `GIT_DIR`; the same push with `GIT_DIR` exported by the caller passes it
+# straight through.** So pushing does not, on its own, hand `GIT_DIR` to
+# anything; the old line was a route only when some OUTER caller had already
+# exported that name. A live scan of the box found 46 processes carrying some
+# `GIT_*` variable and ZERO carrying `GIT_DIR` (13 unreadable).
+# 🔴 THE ROOT CAUSE OF THE INCIDENT — what exported `GIT_DIR` into that gate run
+# — REMAINS UNIDENTIFIED. This rename removes a real route and is worth keeping;
+# it is not the explanation. `scripts/testlib/gitenv.py` closes the mechanism
+# from the suite's side whatever set the variable, and
 # `scripts/tests/test_git_repo_isolation.py` asserts no shell script that can
 # reach the runner assigns to one of those names.
 HOOK_GIT_DIR="$(git rev-parse --git-dir 2>/dev/null || true)"

--- a/githooks/tests-on-push.sh
+++ b/githooks/tests-on-push.sh
@@ -45,6 +45,47 @@
 
 set -uo pipefail
 
+# --- GUARD 9: NO TEST MAY OPERATE ON THE REPO THE SUITE RUNS FROM -------------
+# 🔴 THE FOURTH ENTRY POINT, and it was missing until #683's audit found it.
+# This file matches `RUNNERS`' own description exactly — it resolves a repo root
+# with `rev-parse --show-toplevel` and then runs the suite — and it is the LAST
+# hop before `run-tests.sh` on the `git push` path, which is the path the
+# 2026-08-21 incident travelled. Without the clear here the resolution on the
+# next line is itself corruptible: with GIT_DIR set and no GIT_WORK_TREE, git
+# takes the CWD as the top of the work tree.
+#
+# The SET is owned by `scripts/testlib/gitenv.py::REPO_POINTER_VARS` (and
+# `CONTROL_VARS`); every spelling is pinned two-way, and the ordering against
+# the root line is pinned too, by `scripts/tests/test_git_repo_isolation.py`.
+# Spelled here rather than sourced for the reason in `scripts/run-tests.sh`'s
+# copy of this header — and doubly so here: this file is invoked by a GLOBAL git
+# hook from an arbitrary repository, so a sibling `lib/` is not something it can
+# assume exists.
+DEVRC_GIT_REPO_POINTERS=(
+  GIT_DIR                            # the repository itself; beats -C
+  GIT_WORK_TREE                      # the working tree
+  GIT_COMMON_DIR                     # where refs/config actually live
+  GIT_INDEX_FILE                     # the index a `git add` writes
+  GIT_OBJECT_DIRECTORY               # where new objects are written
+  GIT_ALTERNATE_OBJECT_DIRECTORIES   # extra object stores
+  GIT_NAMESPACE                      # the ref namespace refs land in
+  GIT_PREFIX                         # hook-injected pathspec prefix
+  GIT_GRAFT_FILE                     # repo-scoped grafts
+  GIT_SHALLOW_FILE                   # repo-scoped shallow list
+  GIT_CONFIG                         # legacy: the file `git config` WRITES
+)
+DEVRC_GITENV_CONTROL_VARS=(
+  DEVRC_GITENV_PROTECT               # which git dirs the detector watches
+  DEVRC_GITENV_MODE                  # enforce | report | auto
+)
+unset "${DEVRC_GIT_REPO_POINTERS[@]}"
+unset "${DEVRC_GITENV_CONTROL_VARS[@]}"
+
+# 🔴 `GIT_PREFIX` is on that list and git DOES export it to a pre-push hook
+# (measured, git 2.55.0: `GIT_EXEC_PATH` and `GIT_PREFIX` are exported to
+# `pre-push`; `GIT_DIR` is NOT). Nothing below reads it, and
+# clearing it before `rev-parse` is what keeps the resolution on the next line
+# a function of the CWD alone.
 REPO_ROOT="${1:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
 [ -n "$REPO_ROOT" ] || exit 0
 

--- a/scripts/browser-bridge/tests/conftest.py
+++ b/scripts/browser-bridge/tests/conftest.py
@@ -143,3 +143,33 @@ def _isolate_activity_spool(tmp_path, monkeypatch):
     # on it.
     monkeypatch.setattr(server, "_spool_emit_mod", None)
     monkeypatch.setattr(server, "_spool_emit_tried", False)
+
+
+# --- GUARD 9: the repository the suite RUNS FROM ----------------------------- #
+# 🔴 THE SECOND ENTRY POINT, and it belongs in EVERY test directory a bare
+# `pytest <dir>` can be pointed at. `scripts/run-tests.sh` loads the same module
+# with `-p testlib.gitenv_plugin` for every target, so this changes nothing
+# under the runner; it is what protects a hand-run `pytest`. #683's audit found
+# exactly ONE of seven conftests wired, and not the one `gitenv_plugin`'s own
+# rationale cites (`test_bash_guard.py::_mkrepo` and `test_guard_core.py`'s
+# module-scoped repos, which run during COLLECTION).
+# `test_git_repo_isolation.py::test_the_conftest_entry_points_are_a_pinned_ledger`
+# fails when a conftest under `scripts/` is added or removed, so the next one
+# cannot be forgotten — that is the "asserted ledger of every caller" shape
+# claude/RULES.md asks for, rather than a single pinned example.
+import sys as _guard9_sys  # noqa: E402
+from pathlib import Path as _Guard9Path  # noqa: E402
+
+for _guard9_parent in _Guard9Path(__file__).resolve().parents:
+    if (_guard9_parent / "testlib" / "gitenv_plugin.py").is_file():
+        if str(_guard9_parent) not in _guard9_sys.path:
+            _guard9_sys.path.insert(0, str(_guard9_parent))
+        break
+
+from testlib.gitenv_plugin import (  # noqa: E402,F401
+    _devrc_git_repo_isolation,
+    pytest_collection_finish,
+    pytest_configure,
+    pytest_runtest_logstart,
+    pytest_sessionfinish,
+)

--- a/scripts/claude-hooks/tests/conftest.py
+++ b/scripts/claude-hooks/tests/conftest.py
@@ -230,3 +230,33 @@ class _SystemExitIsACollectError(pytest.Module):
                 "'no tests ran' because that pair was indistinguishable from a "
                 "clean zero."
             ) from exc
+
+
+# --- GUARD 9: the repository the suite RUNS FROM ----------------------------- #
+# 🔴 THE SECOND ENTRY POINT, and it belongs in EVERY test directory a bare
+# `pytest <dir>` can be pointed at. `scripts/run-tests.sh` loads the same module
+# with `-p testlib.gitenv_plugin` for every target, so this changes nothing
+# under the runner; it is what protects a hand-run `pytest`. #683's audit found
+# exactly ONE of seven conftests wired, and not the one `gitenv_plugin`'s own
+# rationale cites (`test_bash_guard.py::_mkrepo` and `test_guard_core.py`'s
+# module-scoped repos, which run during COLLECTION).
+# `test_git_repo_isolation.py::test_the_conftest_entry_points_are_a_pinned_ledger`
+# fails when a conftest under `scripts/` is added or removed, so the next one
+# cannot be forgotten — that is the "asserted ledger of every caller" shape
+# claude/RULES.md asks for, rather than a single pinned example.
+import sys as _guard9_sys  # noqa: E402
+from pathlib import Path as _Guard9Path  # noqa: E402
+
+for _guard9_parent in _Guard9Path(__file__).resolve().parents:
+    if (_guard9_parent / "testlib" / "gitenv_plugin.py").is_file():
+        if str(_guard9_parent) not in _guard9_sys.path:
+            _guard9_sys.path.insert(0, str(_guard9_parent))
+        break
+
+from testlib.gitenv_plugin import (  # noqa: E402,F401
+    _devrc_git_repo_isolation,
+    pytest_collection_finish,
+    pytest_configure,
+    pytest_runtest_logstart,
+    pytest_sessionfinish,
+)

--- a/scripts/claude-hooks/tests/conftest.py
+++ b/scripts/claude-hooks/tests/conftest.py
@@ -253,10 +253,28 @@ for _guard9_parent in _Guard9Path(__file__).resolve().parents:
             _guard9_sys.path.insert(0, str(_guard9_parent))
         break
 
-from testlib.gitenv_plugin import (  # noqa: E402,F401
-    _devrc_git_repo_isolation,
-    pytest_collection_finish,
-    pytest_configure,
-    pytest_runtest_logstart,
-    pytest_sessionfinish,
-)
+# 🔴 THIS FILE IS DELIBERATELY COPIED OUT OF THE TREE.
+# `scripts/tests/test_hook_tests_dir_collects.py` `shutil.copy`s it into a tmp
+# dir, and a copy has no `scripts/` above it — the loop above finds nothing, so
+# the import below depends entirely on the copying harness putting `scripts/` on
+# PYTHONPATH. It does; this error exists so that if it ever stops, the failure
+# names the cause instead of reading as a broken repo. Same lesson as #683's
+# `runner_patch.py` finding: a copy cannot reach a sibling it was not copied
+# with. Do NOT "fix" this by deleting the import — that silently drops GUARD 9
+# for a bare `pytest scripts/claude-hooks/tests/...`.
+try:
+    from testlib.gitenv_plugin import (  # noqa: E402,F401
+        _devrc_git_repo_isolation,
+        pytest_collection_finish,
+        pytest_configure,
+        pytest_runtest_logstart,
+        pytest_sessionfinish,
+    )
+except ModuleNotFoundError as _guard9_exc:  # pragma: no cover - harness-only path
+    raise RuntimeError(
+        "GUARD 9's second entry point cannot import `testlib.gitenv_plugin` from "
+        f"{__file__}. In the real tree it is found by walking up to `scripts/`; "
+        "this looks like a COPY of the conftest, whose harness must export "
+        "PYTHONPATH=<repo>/scripts (see `_pytest` in "
+        "scripts/tests/test_hook_tests_dir_collects.py)."
+    ) from _guard9_exc

--- a/scripts/dl-router/tests/conftest.py
+++ b/scripts/dl-router/tests/conftest.py
@@ -177,3 +177,33 @@ def cfg(tmp_path, library, dirs_file):
                              state_dir=tmp_path / "state",
                              token_file=tmp_path / "token",
                              dirs_file=dirs_file)
+
+
+# --- GUARD 9: the repository the suite RUNS FROM ----------------------------- #
+# 🔴 THE SECOND ENTRY POINT, and it belongs in EVERY test directory a bare
+# `pytest <dir>` can be pointed at. `scripts/run-tests.sh` loads the same module
+# with `-p testlib.gitenv_plugin` for every target, so this changes nothing
+# under the runner; it is what protects a hand-run `pytest`. #683's audit found
+# exactly ONE of seven conftests wired, and not the one `gitenv_plugin`'s own
+# rationale cites (`test_bash_guard.py::_mkrepo` and `test_guard_core.py`'s
+# module-scoped repos, which run during COLLECTION).
+# `test_git_repo_isolation.py::test_the_conftest_entry_points_are_a_pinned_ledger`
+# fails when a conftest under `scripts/` is added or removed, so the next one
+# cannot be forgotten — that is the "asserted ledger of every caller" shape
+# claude/RULES.md asks for, rather than a single pinned example.
+import sys as _guard9_sys  # noqa: E402
+from pathlib import Path as _Guard9Path  # noqa: E402
+
+for _guard9_parent in _Guard9Path(__file__).resolve().parents:
+    if (_guard9_parent / "testlib" / "gitenv_plugin.py").is_file():
+        if str(_guard9_parent) not in _guard9_sys.path:
+            _guard9_sys.path.insert(0, str(_guard9_parent))
+        break
+
+from testlib.gitenv_plugin import (  # noqa: E402,F401
+    _devrc_git_repo_isolation,
+    pytest_collection_finish,
+    pytest_configure,
+    pytest_runtest_logstart,
+    pytest_sessionfinish,
+)

--- a/scripts/gate.sh
+++ b/scripts/gate.sh
@@ -117,7 +117,19 @@ DEVRC_GIT_REPO_POINTERS=(
   GIT_SHALLOW_FILE                   # repo-scoped shallow list
   GIT_CONFIG                         # legacy: the file `git config` WRITES
 )
+# 🔴 AND GUARD 9's OWN SEAMS. `DEVRC_GITENV_PROTECT` redirects the DETECTOR at a
+# different repository and `DEVRC_GITENV_MODE` decides whether it fails or
+# merely reports; #683's audit measured `DEVRC_GITENV_PROTECT=":"` producing
+# `protected-git-dirs=0` and a GREEN run over a real escape, and
+# `=/nonexistent/x` producing a marker line that asserted coverage it did not
+# have. One inherited variable defeating every layer is the bug this guard
+# exists for. Owned by `testlib/gitenv.py::CONTROL_VARS`, pinned two-way.
+DEVRC_GITENV_CONTROL_VARS=(
+  DEVRC_GITENV_PROTECT               # which git dirs the detector watches
+  DEVRC_GITENV_MODE                  # enforce | report | auto
+)
 unset "${DEVRC_GIT_REPO_POINTERS[@]}"
+unset "${DEVRC_GITENV_CONTROL_VARS[@]}"
 
 if [ -z "$ROOT" ]; then
   ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null || true)"

--- a/scripts/repo-cos/tests/conftest.py
+++ b/scripts/repo-cos/tests/conftest.py
@@ -31,3 +31,33 @@ def _no_live_initiatives_store(monkeypatch):
     except Exception:  # noqa: BLE001 - router unloadable here == no store read possible
         return
     monkeypatch.setattr(route, "load_current", lambda: [], raising=False)
+
+
+# --- GUARD 9: the repository the suite RUNS FROM ----------------------------- #
+# 🔴 THE SECOND ENTRY POINT, and it belongs in EVERY test directory a bare
+# `pytest <dir>` can be pointed at. `scripts/run-tests.sh` loads the same module
+# with `-p testlib.gitenv_plugin` for every target, so this changes nothing
+# under the runner; it is what protects a hand-run `pytest`. #683's audit found
+# exactly ONE of seven conftests wired, and not the one `gitenv_plugin`'s own
+# rationale cites (`test_bash_guard.py::_mkrepo` and `test_guard_core.py`'s
+# module-scoped repos, which run during COLLECTION).
+# `test_git_repo_isolation.py::test_the_conftest_entry_points_are_a_pinned_ledger`
+# fails when a conftest under `scripts/` is added or removed, so the next one
+# cannot be forgotten — that is the "asserted ledger of every caller" shape
+# claude/RULES.md asks for, rather than a single pinned example.
+import sys as _guard9_sys  # noqa: E402
+from pathlib import Path as _Guard9Path  # noqa: E402
+
+for _guard9_parent in _Guard9Path(__file__).resolve().parents:
+    if (_guard9_parent / "testlib" / "gitenv_plugin.py").is_file():
+        if str(_guard9_parent) not in _guard9_sys.path:
+            _guard9_sys.path.insert(0, str(_guard9_parent))
+        break
+
+from testlib.gitenv_plugin import (  # noqa: E402,F401
+    _devrc_git_repo_isolation,
+    pytest_collection_finish,
+    pytest_configure,
+    pytest_runtest_logstart,
+    pytest_sessionfinish,
+)

--- a/scripts/run-node-tests.sh
+++ b/scripts/run-node-tests.sh
@@ -139,7 +139,19 @@ DEVRC_GIT_REPO_POINTERS=(
   GIT_SHALLOW_FILE                   # repo-scoped shallow list
   GIT_CONFIG                         # legacy: the file `git config` WRITES
 )
+# 🔴 AND GUARD 9's OWN SEAMS. `DEVRC_GITENV_PROTECT` redirects the DETECTOR at a
+# different repository and `DEVRC_GITENV_MODE` decides whether it fails or
+# merely reports; #683's audit measured `DEVRC_GITENV_PROTECT=":"` producing
+# `protected-git-dirs=0` and a GREEN run over a real escape, and
+# `=/nonexistent/x` producing a marker line that asserted coverage it did not
+# have. One inherited variable defeating every layer is the bug this guard
+# exists for. Owned by `testlib/gitenv.py::CONTROL_VARS`, pinned two-way.
+DEVRC_GITENV_CONTROL_VARS=(
+  DEVRC_GITENV_PROTECT               # which git dirs the detector watches
+  DEVRC_GITENV_MODE                  # enforce | report | auto
+)
 unset "${DEVRC_GIT_REPO_POINTERS[@]}"
+unset "${DEVRC_GITENV_CONTROL_VARS[@]}"
 
 if [ -z "$ROOT" ]; then
   ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null || true)"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -236,7 +236,33 @@ DEVRC_GIT_REPO_POINTERS=(
   GIT_SHALLOW_FILE                   # repo-scoped shallow list
   GIT_CONFIG                         # legacy: the file `git config` WRITES
 )
+# 🔴 AND GUARD 9's OWN SEAMS, for the same reason and measured the same way.
+# `DEVRC_GITENV_PROTECT` redirects the DETECTOR at a different repository and
+# `DEVRC_GITENV_MODE` decides whether it fails or merely reports. #683's audit
+# measured the first: `DEVRC_GITENV_PROTECT=":"` gave `protected-git-dirs=0`
+# and a GREEN run while the escaping test really created its branch, and
+# `=/nonexistent/x` gave `protected-git-dirs=1` — a marker line asserting
+# healthy coverage — over the same real mutation. One inherited variable
+# defeating every layer is the bug this whole guard exists for; leaving one
+# inside the fix was not acceptable. `testlib/gitenv.py` now REFUSES an
+# unresolvable value, and no runner passes one down.
+DEVRC_GITENV_CONTROL_VARS=(
+  DEVRC_GITENV_PROTECT               # which git dirs the detector watches
+  DEVRC_GITENV_MODE                  # enforce | report | auto
+)
+# What was actually SET before we cleared it — reported below beside the
+# constant list, because "here is the list I would have cleared" and "here is
+# what was really in this environment" are different claims and only the second
+# one can tell you an incident is in progress.
+DEVRC_GITENV_FOUND=""
+for _devrc_gitenv_var in "${DEVRC_GIT_REPO_POINTERS[@]}" "${DEVRC_GITENV_CONTROL_VARS[@]}"; do
+  if [ -n "${!_devrc_gitenv_var+set}" ]; then
+    DEVRC_GITENV_FOUND="${DEVRC_GITENV_FOUND}${DEVRC_GITENV_FOUND:+,}${_devrc_gitenv_var}"
+  fi
+done
+unset _devrc_gitenv_var
 unset "${DEVRC_GIT_REPO_POINTERS[@]}"
+unset "${DEVRC_GITENV_CONTROL_VARS[@]}"
 
 if [ -z "$ROOT" ]; then
   ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null || true)"
@@ -1789,6 +1815,14 @@ SPOOL_SESSION_MARKER="spool(session)"
 SPOOL_CONTROL_SOURCE="devrc-spool-guard"
 SPOOL_CONTROL_OK="emitted"
 
+# 🔴 GUARD 9's marker, the same shape and pinned the same way against
+# `scripts/testlib/gitenv.py::SESSION_MARKER`. #683 declared this marker and
+# then never counted it, which left "this target loaded the detector and saw
+# nothing" indistinguishable from "this target never loaded the detector" — the
+# reassuring zero claude/RULES.md's positive-control rule is about. It is
+# counted per pytest target in `run_pytest`, and its absence is a FAILURE.
+GITENV_SESSION_MARKER="gitenv(session)"
+
 # Where the fallback lands, asked of `spool_emit` ITSELF with the variable
 # removed — never restated here. A second copy of the "…/activity/spool" layout
 # would agree with the first until the day the rule changed, and the trap would
@@ -1823,12 +1857,22 @@ echo "  fallback trap      =$SPOOL_TRAP_LOG"
 # The clearing itself happens at the TOP of this file (before ROOT is resolved —
 # see the GUARD 9 header there); this is only the announcement, printed here so
 # it sits beside GUARDS 7 and 8 where a reader looks for the run's isolation
-# summary. It reports the PAIR: the shell half cleared the pointers for EVERY
-# target including the non-pytest ones, and each pytest target additionally
-# loads the detector that names whichever test moves a ref.
+# summary.
+#
+# 🔴 IT REPORTS A REAL PAIR NOW. It used to print two CONSTANTS under the words
+# "the PAIR" — the ledger it would clear and the flag it would pass — neither of
+# which is a measurement, so the line read identically on a poisoned environment
+# and a clean one. `found-set` is what was actually in this environment when the
+# run started (the clearing itself happens at the TOP of this file, before ROOT
+# is resolved — see the GUARD 9 header there), and `none` there is the normal
+# case. A non-empty value on a machine nobody has instrumented is the single
+# most useful line in this output: it names the variable that would have
+# redirected the suite.
 echo "run-tests: git repo pointers cleared for this run (GUARD 9)"
-echo "  cleared     =${DEVRC_GIT_REPO_POINTERS[*]}"
-echo "  detector    =-p testlib.gitenv_plugin (per pytest target)"
+echo "  ledger      =${DEVRC_GIT_REPO_POINTERS[*]} ${DEVRC_GITENV_CONTROL_VARS[*]}"
+echo "  found-set   =${DEVRC_GITENV_FOUND:-none}"
+echo "  detector    =-p testlib.gitenv_plugin (per pytest target; its own"
+echo "               '$GITENV_SESSION_MARKER' line is counted per target below)"
 
 # "<target>|<sess-from>|<sess-to>|<trap-from>|<trap-to>|<iso-from>|<iso-to>" —
 # three line ranges per target, so every count below is attributed to the target
@@ -2262,6 +2306,26 @@ run_pytest() {
   _spool_account "$d"
   _nogit_account "$d"
   cat "$log"
+
+  # --- GUARD 9's POSITIVE CONTROL, per target -------------------------------
+  # The detector announces itself once per pytest session. Counting it is the
+  # only thing that separates "GUARD 9 ran and this repository did not move"
+  # from "GUARD 9 was never loaded here" — two states with byte-identical
+  # output otherwise, and the second is what #399 and #614 both shipped.
+  # `>= 1` rather than `== 1`: a target whose conftest ALSO re-exports the hooks
+  # legitimately prints it twice (two plugin registrations of the same module's
+  # functions), and that is coverage, not a defect.
+  local gitenv_markers
+  gitenv_markers="$(grep -ac "^$GITENV_SESSION_MARKER" "$log" || true)"
+  if [ "${gitenv_markers:-0}" -lt 1 ]; then
+    echo "run-tests: FATAL — GUARD 9's detector never announced itself for $d." >&2
+    echo "  Expected at least one '$GITENV_SESSION_MARKER …' line. Its absence means" >&2
+    echo "  the target ran WITHOUT the git-repo isolation detector, so a clean" >&2
+    echo "  result there is a claim about nothing. Check that '-p testlib.gitenv_plugin'" >&2
+    echo "  is still on this runner's pytest line." >&2
+    RESULTS+=("FAIL  $d (GUARD 9 marker absent)")
+    fail=1
+  fi
 
   # GUARD 4: parse pytest's summary line. `-q` emits it undecorated, e.g.
   #   "660 passed, 123 skipped in 15.10s"   /   "1 failed, 2 passed in 0.1s"

--- a/scripts/session-analysis/session_insight/tests/conftest.py
+++ b/scripts/session-analysis/session_insight/tests/conftest.py
@@ -7,3 +7,33 @@ from pathlib import Path
 _PKG = Path(__file__).resolve().parent.parent   # scripts/session-analysis/session_insight
 if str(_PKG) not in sys.path:
     sys.path.insert(0, str(_PKG))
+
+
+# --- GUARD 9: the repository the suite RUNS FROM ----------------------------- #
+# 🔴 THE SECOND ENTRY POINT, and it belongs in EVERY test directory a bare
+# `pytest <dir>` can be pointed at. `scripts/run-tests.sh` loads the same module
+# with `-p testlib.gitenv_plugin` for every target, so this changes nothing
+# under the runner; it is what protects a hand-run `pytest`. #683's audit found
+# exactly ONE of seven conftests wired, and not the one `gitenv_plugin`'s own
+# rationale cites (`test_bash_guard.py::_mkrepo` and `test_guard_core.py`'s
+# module-scoped repos, which run during COLLECTION).
+# `test_git_repo_isolation.py::test_the_conftest_entry_points_are_a_pinned_ledger`
+# fails when a conftest under `scripts/` is added or removed, so the next one
+# cannot be forgotten — that is the "asserted ledger of every caller" shape
+# claude/RULES.md asks for, rather than a single pinned example.
+import sys as _guard9_sys  # noqa: E402
+from pathlib import Path as _Guard9Path  # noqa: E402
+
+for _guard9_parent in _Guard9Path(__file__).resolve().parents:
+    if (_guard9_parent / "testlib" / "gitenv_plugin.py").is_file():
+        if str(_guard9_parent) not in _guard9_sys.path:
+            _guard9_sys.path.insert(0, str(_guard9_parent))
+        break
+
+from testlib.gitenv_plugin import (  # noqa: E402,F401
+    _devrc_git_repo_isolation,
+    pytest_collection_finish,
+    pytest_configure,
+    pytest_runtest_logstart,
+    pytest_sessionfinish,
+)

--- a/scripts/signal/tests/conftest.py
+++ b/scripts/signal/tests/conftest.py
@@ -108,3 +108,33 @@ def _no_live_network(monkeypatch):
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", guard)
+
+
+# --- GUARD 9: the repository the suite RUNS FROM ----------------------------- #
+# 🔴 THE SECOND ENTRY POINT, and it belongs in EVERY test directory a bare
+# `pytest <dir>` can be pointed at. `scripts/run-tests.sh` loads the same module
+# with `-p testlib.gitenv_plugin` for every target, so this changes nothing
+# under the runner; it is what protects a hand-run `pytest`. #683's audit found
+# exactly ONE of seven conftests wired, and not the one `gitenv_plugin`'s own
+# rationale cites (`test_bash_guard.py::_mkrepo` and `test_guard_core.py`'s
+# module-scoped repos, which run during COLLECTION).
+# `test_git_repo_isolation.py::test_the_conftest_entry_points_are_a_pinned_ledger`
+# fails when a conftest under `scripts/` is added or removed, so the next one
+# cannot be forgotten — that is the "asserted ledger of every caller" shape
+# claude/RULES.md asks for, rather than a single pinned example.
+import sys as _guard9_sys  # noqa: E402
+from pathlib import Path as _Guard9Path  # noqa: E402
+
+for _guard9_parent in _Guard9Path(__file__).resolve().parents:
+    if (_guard9_parent / "testlib" / "gitenv_plugin.py").is_file():
+        if str(_guard9_parent) not in _guard9_sys.path:
+            _guard9_sys.path.insert(0, str(_guard9_parent))
+        break
+
+from testlib.gitenv_plugin import (  # noqa: E402,F401
+    _devrc_git_repo_isolation,
+    pytest_collection_finish,
+    pytest_configure,
+    pytest_runtest_logstart,
+    pytest_sessionfinish,
+)

--- a/scripts/testlib/gitenv.py
+++ b/scripts/testlib/gitenv.py
@@ -27,31 +27,90 @@ repo already knew this: `scripts/claude-hooks/guard_core.py` judges a
 `GIT_DIR=` prefix IN ADDITION to a resolving `-C` for exactly this reason
 ("even though `GIT_DIR` OVERRIDES the working directory"). The knowledge lived
 in the hook that polices the OPERATOR's commands and nowhere in the harness
-that runs 7,000 of our own.
+that runs 14,000 of our own.
 
-And the fixture VALUES are the tell that identifies the mechanism rather than
-merely being consistent with it: the tmpdir paths written into the clone's
-config are the tests' OWN correct values. The tests computed the right thing
-and git wrote it into the wrong repository.
+🔴 WHAT WAS **NOT** ESTABLISHED, and the correction matters because it was
+relayed onward as fact. #683's body claimed `githooks/pre-push` handing down
+`GIT_DIR` explained why *pushing* triggered the corruption. **Measured on git
+2.55.0, as a PAIR: a `git push` from a `GIT_DIR`-free parent gives `pre-push`
+only `GIT_EXEC_PATH` and `GIT_PREFIX` (plus the caller's own `GIT_AUTHOR_*` /
+`GIT_CONFIG_*`) — NO `GIT_DIR`; the same push with `GIT_DIR` exported by the
+caller passes it straight through.** The old `GIT_DIR=…` line in that
+hook was a route only if some OUTER caller had already exported the name (bash
+keeps an already-exported name exported across a reassignment); the hook's own
+comment stated that precondition correctly and the PR body dropped it. A live
+scan of the box found 46 processes carrying some `GIT_*` variable and **0**
+carrying `GIT_DIR` (13 unreadable). **THE ROOT CAUSE — what exported `GIT_DIR`
+into that gate run — IS STILL UNKNOWN.** The rename is correct hygiene and the
+strip below closes the mechanism whatever set it; neither identifies the
+setter. Do not cite the pre-push rename as the diagnosis.
+
+And the fixture VALUES are the tell that identifies the MECHANISM (an inherited
+`GIT_DIR`) rather than merely being consistent with it: the tmpdir paths
+written into the clone's config are the tests' OWN correct values. The tests
+computed the right thing and git wrote it into the wrong repository.
 
 WHAT THIS MODULE OWNS. `REPO_POINTER_VARS` below is the ONE owner of the set.
 It is re-spelled as a bash array at the top of `run-tests.sh`,
-`run-node-tests.sh` and `gate.sh` — each BEFORE that script resolves its own
-ROOT — and `scripts/tests/test_git_repo_isolation.py` pins every spelling
-against this tuple in both directions, plus the ordering. Three shell copies
-rather than one sourced file because `testlib/runner_patch.py` writes a patched
-COPY of `run-tests.sh` into a tmp dir that ~15 tests drive, and a copy cannot
-source a sibling `lib/` that was never copied with it (measured: the sourced
-version turned all fifteen into a FATAL):
+`run-node-tests.sh`, `gate.sh` and `githooks/tests-on-push.sh` — each BEFORE
+that script resolves its own ROOT — and `scripts/tests/test_git_repo_isolation.py`
+pins every spelling against this tuple in both directions, plus the ordering.
+Four shell copies rather than one sourced file because `testlib/runner_patch.py`
+writes a patched COPY of `run-tests.sh` into a tmp dir that ~15 tests drive, and
+a copy cannot source a sibling `lib/` that was never copied with it (measured:
+the sourced version turned all fifteen into a FATAL):
 
   1. `REPO_POINTER_VARS` — the environment variables that decide WHICH
      repository a git command lands in. Stripping them is the FIX.
-  2. `protected_git_dirs()` / `snapshot()` / `diff_snapshots()` — the
-     DETECTOR: a content fingerprint of the host repo's refs, HEAD and config
-     that `gitenv_plugin` compares around every test, so the NEXT escape —
-     by any mechanism, in any test, including one nobody has thought of — is
-     attributed to the test that caused it instead of being found days later
-     on the remote.
+  2. `CONTROL_VARS` — this guard's OWN seams. They are on the runners' unset
+     list for the same reason as the pointers: an inherited
+     `DEVRC_GITENV_PROTECT` used to redirect the whole detector, silently, with
+     the marker line still reporting a healthy `protected-git-dirs=1`.
+  3. `protected_git_dirs()` / `snapshot()` / `diff_snapshots()` — the
+     DETECTOR: a content fingerprint of the host repo's ref VALUES, HEAD and
+     config that `gitenv_plugin` compares around every test, so the NEXT escape
+     — by any mechanism, in any test — is attributed to the test that caused it
+     instead of being found days later on the remote.
+  4. `attribution_evidence()` / `MODE_*` — 🔴 the ANSWER TO "WHO ELSE WRITES
+     HERE". See "ATTRIBUTION" below; it is the difference between a guard and a
+     permanently-red gate.
+
+🔴 ATTRIBUTION — why the detector has two modes, measured 2026-08-22.
+
+The detector watches a repository it does not own. On the operator's box that
+clone has **dozens of concurrent writers**: during one 40-minute audit it gained
+two branches, lost one, and fast-forwarded `main` twice, and the `drift-check`
+systemd timer runs `git fetch origin` against it four times a day (whose
+`gc --auto` used to emit *hundreds* of `DELETED refs/…` lines under a banner
+saying the incident had recurred). A guard that fires on that, and asserts "test
+X MUTATED a git repository" at maximum confidence, is worse than no guard:
+claude/RULES.md rates a permanently-red gate as one that trains everyone to
+click through, and during an incident it actively misdirects.
+
+Three independent changes, all mechanical, none a reword:
+
+  a. THE FINGERPRINT IS REF **VALUES**, NOT REF **FILES**. `packed-refs` and
+     the loose `refs/` tree are parsed into one name -> object-id map, so
+     `git gc` / `git pack-refs` — which move every loose ref into `packed-refs`
+     while changing nothing about the repository's state — produce EXACTLY ZERO
+     deltas. That is the single loudest false-positive class, removed
+     structurally rather than filtered. `logs/HEAD` is gone for the same
+     reason: it is a pure derivative (every state it witnesses is also
+     witnessed by HEAD or the ref map) that `gc`'s reflog expiry rewrites on
+     its own.
+  b. POSITIVE EVIDENCE OF ANOTHER WRITER DOWNGRADES THE SESSION. Two probes,
+     both facts rather than inferences: live processes whose CWD sits inside a
+     protected work tree and are not our own ancestors (`live_cotenants`), and
+     a delta observed in a window when NO test body was running (the plugin's
+     idle probe, plus a settle re-read taken at the moment of any delta). Once
+     either fires, this repository is *known* to have another writer,
+     attribution is *known* to be impossible, and the detector reports instead
+     of failing — loudly, with the full delta and a session-end count.
+  c. THE VIOLATION MESSAGE LEADS WITH "ANOTHER PROCESS WROTE HERE". It used to
+     lead with the incident. See `violation_message`.
+
+Prevention (the strip) is untouched by any of this and does not depend on the
+mode. Report mode weakens ATTRIBUTION, never the fix.
 
 DELIBERATELY NOT STRIPPED, and the reason, so the next reader does not have to
 re-derive it:
@@ -72,13 +131,13 @@ from pathlib import Path
 # --------------------------------------------------------------------------- #
 # 1. THE LEDGER: what redirects git at a repository
 # --------------------------------------------------------------------------- #
-# 🔴 ORDERED and EXACT. Each of the three shell runners spells the same names
-# in a `DEVRC_GIT_REPO_POINTERS` array — they have to, because the non-pytest
-# targets (HOOK_TESTS, SHELL_TESTS, the node tier) never load a pytest plugin,
-# and because an inherited GIT_DIR corrupts each runner's ROOT resolution before
-# any Python runs. `test_git_repo_isolation.py::
+# 🔴 ORDERED and EXACT. Each of the four shell entry points spells the same
+# names in a `DEVRC_GIT_REPO_POINTERS` array — they have to, because the
+# non-pytest targets (HOOK_TESTS, SHELL_TESTS, the node tier) never load a
+# pytest plugin, and because an inherited GIT_DIR corrupts each runner's ROOT
+# resolution before any Python runs. `test_git_repo_isolation.py::
 # test_the_shell_and_python_pointer_ledgers_agree` is parametrised over all
-# three and fails if any diverges from this tuple in EITHER direction. Adding a
+# four and fails if any diverges from this tuple in EITHER direction. Adding a
 # name here without adding it there would leave those targets unprotected while
 # this file's docstring claimed otherwise.
 REPO_POINTER_VARS: tuple[str, ...] = (
@@ -95,24 +154,64 @@ REPO_POINTER_VARS: tuple[str, ...] = (
     "GIT_CONFIG",                         # legacy: the file `git config` WRITES
 )
 
-# The marker the plugin prints once per pytest session. `run-tests.sh` does not
-# count it today, but it is the only way to tell "this target loaded GUARD 9 and
-# saw nothing" apart from "this target never loaded GUARD 9" — the reassuring
-# zero that RULES.md's positive-control rule is about. Spelled on both sides of
-# a process boundary, so it is pinned by the test file.
-SESSION_MARKER = "gitenv(session)"
-
-# The token every violation message carries. Asserted verbatim by the
-# reachability control, so a control cannot pass off a DIFFERENT guard's error
-# as this one's.
-VIOLATION_TOKEN = "DEVRC-GITENV-VIOLATION"
-
-# TEST SEAM. A colon-separated list of git dirs to protect INSTEAD of the
+# TEST SEAM. A `os.pathsep`-separated list of git dirs to protect INSTEAD of the
 # discovered host repo. It exists so the controls in test_git_repo_isolation.py
 # can drive a nested pytest against a throwaway repo and watch this guard go
 # red — a guard nobody has watched fail proves nothing. It is a seam for tests,
 # not a supported way to run the suite.
+#
+# 🔴 AND IT IS VALIDATED, LOUDLY. Measured on #683's version: `PROTECT=":"` gave
+# `protected-git-dirs=0` and a GREEN run while the escaping test really created
+# its branch, and `PROTECT=/nonexistent/x` gave `protected-git-dirs=1` — a
+# marker line reporting healthy coverage — and a GREEN run over the same real
+# mutation. One inherited variable defeated the entire detection half, inside
+# the fix for one inherited variable defeating everything. `resolve_protect_env`
+# now raises rather than degrading, and the runners unset it (CONTROL_VARS).
 PROTECT_ENV = "DEVRC_GITENV_PROTECT"
+
+# TEST SEAM. Forces the detector's mode instead of deciding it from evidence.
+# The nested controls pin it so their verdict cannot depend on how busy the
+# host repository happens to be while the suite runs.
+MODE_ENV = "DEVRC_GITENV_MODE"
+
+MODE_ENFORCE = "enforce"   # a delta FAILS the test it was observed under
+MODE_REPORT = "report"     # a delta is printed in full; nothing fails
+MODE_AUTO = "auto"         # enforce until another writer is PROVEN (default)
+MODES = (MODE_AUTO, MODE_ENFORCE, MODE_REPORT)
+
+# 🔴 This guard's OWN environment seams, on the runners' unset list beside
+# REPO_POINTER_VARS and pinned two-way by the same test. Finding B of #683's
+# audit: no runner cleared PROTECT_ENV, so a single inherited value silently
+# redirected every layer of the detector.
+CONTROL_VARS: tuple[str, ...] = (PROTECT_ENV, MODE_ENV)
+
+# The marker the plugin prints once per pytest session, and `run-tests.sh`
+# COUNTS it per target: it is the only way to tell "this target loaded GUARD 9
+# and saw nothing" apart from "this target never loaded GUARD 9" — the
+# reassuring zero that RULES.md's positive-control rule is about. Spelled on
+# both sides of a process boundary, so it is pinned by the test file.
+SESSION_MARKER = "gitenv(session)"
+
+# Printed instead of failing, in report mode. Deliberately does NOT carry
+# VIOLATION_TOKEN: a control that asserts the token must not be satisfiable by
+# an unattributed observation.
+OBSERVED_MARKER = "gitenv(observed)"
+
+# Printed once, when another writer is PROVEN and the session downgrades.
+FOREIGN_MARKER = "gitenv(foreign-writer)"
+
+# The token every ATTRIBUTED violation message carries. Asserted verbatim by the
+# reachability control, so a control cannot pass off a DIFFERENT guard's error
+# as this one's.
+VIOLATION_TOKEN = "DEVRC-GITENV-VIOLATION"
+
+
+class GitEnvConfigError(RuntimeError):
+    """A GUARD 9 seam was set to something that cannot be honoured.
+
+    Raised, never degraded-around: the failure mode this replaces is a green run
+    under a marker line that claimed coverage the detector did not have.
+    """
 
 
 def strip_repo_pointers(env: "dict[str, str] | os._Environ | None" = None) -> "dict[str, str]":
@@ -131,6 +230,25 @@ def strip_repo_pointers(env: "dict[str, str] | os._Environ | None" = None) -> "d
             removed[name] = target[name]
             del target[name]
     return removed
+
+
+def requested_mode(env: "dict[str, str] | os._Environ | None" = None) -> str:
+    """`MODE_ENV`, validated. An unknown value RAISES rather than defaulting.
+
+    Defaulting on a typo is how `DEVRC_GITENV_MODE=enfore` would silently buy a
+    report-only session that reads as enforcement.
+    """
+    target = os.environ if env is None else env
+    if MODE_ENV not in target:
+        return MODE_AUTO
+    raw = target[MODE_ENV].strip()
+    if raw not in MODES:
+        raise GitEnvConfigError(
+            f"{MODE_ENV}={target[MODE_ENV]!r} is not one of {MODES}. GUARD 9 will "
+            "not guess: an unrecognised mode would silently buy a report-only "
+            "session that reads as enforcement."
+        )
+    return raw
 
 
 # --------------------------------------------------------------------------- #
@@ -177,6 +295,14 @@ def common_dir_of(git_dir: Path) -> "Path | None":
     `git_dir/commondir` holds the path (usually `../..`). Without this, a suite
     running inside a worktree would fingerprint the per-worktree HEAD and miss
     every ref and config write, which all land in the common dir.
+
+    🔴 It is also, by construction, the dir SHARED with every sibling worktree
+    and therefore with every sibling agent (claude/RULES.md → "a worktree
+    isolates a working DIRECTORY only"). Watching it is right — an escape lands
+    there — but it is precisely the case where attribution is impossible, which
+    is what `attribution_evidence()` and report mode exist for. The answer is
+    not to stop watching; it is to stop *asserting* when another writer is
+    proven.
     """
     marker = git_dir / "commondir"
     if not marker.is_file():
@@ -240,19 +366,94 @@ def global_config_paths() -> "list[Path]":
     return [ov]
 
 
+def _looks_like_a_git_dir(path: Path) -> bool:
+    """`path` is a directory git would accept as a repository.
+
+    `HEAD` plus one of `refs`/`objects` — the same shape `git rev-parse` uses.
+    Deliberately not "the directory exists": `/nonexistent/x` and `/tmp` are
+    both things a mis-set seam has actually pointed at.
+    """
+    if not path.is_dir():
+        return False
+    return (path / "HEAD").is_file() and (
+        (path / "refs").is_dir() or (path / "objects").is_dir())
+
+
+def resolve_protect_env(env: "dict[str, str] | os._Environ | None" = None) -> "list[Path] | None":
+    """`PROTECT_ENV`, validated. `None` when unset — anything else is honoured
+    exactly or RAISES.
+
+    🔴 THE FAILURE THIS REPLACES was silent and reassuring, both directions
+    measured on #683's code with the same escaping test:
+
+        PROTECT=<real>/.git   -> protected-git-dirs=1, RED  (correct)
+        PROTECT=":"           -> protected-git-dirs=0, GREEN, branch created
+        PROTECT=/nonexistent/x-> protected-git-dirs=1, GREEN, branch created
+
+    The third is the worst: the marker line asserted coverage over a path that
+    cannot hold a repository. An unresolvable seam is now a LOUD failure, never
+    a green with a marker.
+    """
+    target = os.environ if env is None else env
+    if PROTECT_ENV not in target:
+        return None
+    raw = target[PROTECT_ENV]
+    entries = [p for p in raw.split(os.pathsep) if p.strip()]
+    if not entries:
+        raise GitEnvConfigError(
+            f"{PROTECT_ENV}={raw!r} is set but names no path. GUARD 9 will not "
+            "fall back to discovery: on #683's code that spelling produced "
+            "`protected-git-dirs=0` and a GREEN run over a real escape. Unset "
+            "the variable to get discovery, or give it a git dir."
+        )
+    resolved: list[Path] = []
+    bad: list[str] = []
+    for entry in entries:
+        path = Path(entry.strip())
+        try:
+            path = path.resolve()
+        except OSError:
+            bad.append(f"{entry} (cannot resolve)")
+            continue
+        if not _looks_like_a_git_dir(path):
+            bad.append(f"{entry} (not a git dir: needs HEAD + refs/ or objects/)")
+            continue
+        if path not in resolved:
+            resolved.append(path)
+    if bad:
+        raise GitEnvConfigError(
+            f"{PROTECT_ENV} names {len(bad)} path(s) GUARD 9 cannot protect:\n  "
+            + "\n  ".join(bad)
+            + "\n\nThis is a hard failure by design. A detector pointed at a "
+              "path that cannot hold a repository reports `protected-git-dirs="
+              f"{len(entries)}` and stays green through any amount of damage — "
+              "measured, on the version this replaces."
+        )
+    return resolved
+
+
 def protected_git_dirs(starts: "list[Path] | None" = None) -> "list[Path]":
     """Every git dir the suite must leave byte-identical.
 
-    Two roots by default and both are needed: the CWD (what `run-tests.sh` cd's
-    to, and what a bare `pytest` inherits) and this file's own location (which
-    survives a runner invoked from somewhere else entirely). A worktree
-    contributes its common dir as well.
+    Two roots by default and BOTH are load-bearing — pinned by
+    `test_the_cwd_root_is_load_bearing` and `test_the_module_root_is_load_bearing`,
+    which is what a bare "both are needed" comment was not:
 
-    `DEVRC_GITENV_PROTECT` replaces the discovery entirely — see PROTECT_ENV.
+      * `Path.cwd()` — what `run-tests.sh` cd's to and what a bare `pytest`
+        inherits. It is the ONLY root when the runner is invoked from a
+        different repository than the one holding this file.
+      * this file's own directory — which survives a `cwd` that is not in any
+        repository at all (a tmp rootdir; every nested control in the test file
+        runs that way).
+
+    A worktree contributes its common dir as well.
+
+    `PROTECT_ENV` replaces the discovery entirely, and is VALIDATED — see
+    `resolve_protect_env`.
     """
-    override = os.environ.get(PROTECT_ENV)
-    if override:
-        return [Path(p) for p in override.split(os.pathsep) if p]
+    override = resolve_protect_env()
+    if override is not None:
+        return override
 
     if starts is None:
         starts = [Path.cwd(), Path(__file__).resolve().parent]
@@ -268,17 +469,31 @@ def protected_git_dirs(starts: "list[Path] | None" = None) -> "list[Path]":
     return found
 
 
-# The per-git-dir files whose content IS the repository's identity for our
-# purposes. `index` is deliberately absent: a plain `git status` rewrites it as
-# a racy-timestamp refresh, and a detector that reds on a READ is a
-# permanently-red gate (claude/RULES.md), which trains everyone to ignore it.
-# Every damage class from the incident lands in one of these instead —
-# commits/branch creates/deletes and HEAD moves in `refs/`+`HEAD`+`packed-refs`,
-# and `core.bare`/`user.*`/`core.hooksPath`/`remote.origin.url` in `config`.
-_GIT_DIR_FILES = ("config", "HEAD", "packed-refs", "ORIG_HEAD", "logs/HEAD")
-_GIT_DIR_TREES = ("refs",)
+# The per-git-dir files whose CONTENT is part of the repository's identity, on
+# top of the ref VALUE map below. `index` is deliberately absent: a plain
+# `git status` rewrites it as a racy-timestamp refresh, and a detector that reds
+# on a READ is a permanently-red gate (claude/RULES.md).
+#
+# 🔴 EVERY ENTRY HERE IS PINNED BY A MUTATION THAT ONLY IT CAN SEE
+# (`test_every_fingerprint_component_is_load_bearing`) — finding C of #683's
+# audit was that dropping `HEAD`, `packed-refs`, or `ORIG_HEAD`+`logs/HEAD`
+# each survived a fully green suite:
+#   * `config`    — `git config user.name T` (the incident's config damage)
+#   * `HEAD`      — `git symbolic-ref HEAD refs/heads/other` (the incident
+#                   repointed HEAD at `trunk`); moves HEAD and no ref
+#   * `ORIG_HEAD` — `git reset -q HEAD`; moves nothing else
+#
+# `logs/HEAD` was REMOVED rather than pinned. It is a pure derivative — every
+# state it can witness is also witnessed by `HEAD` or the ref map — and `git gc`
+# rewrites it on its own during reflog expiry (measured), i.e. it contributed
+# false positives and no unique coverage. `packed-refs` was likewise removed as
+# a hashed FILE and folded into `_ref_values`, where it belongs: see below.
+_GIT_DIR_FILES = ("config", "HEAD", "ORIG_HEAD")
 
 _LABEL_MISSING = "<absent>"
+
+_REF_KEY = "::ref::"
+_FILE_KEY = "::file::"
 
 
 def _digest(path: Path) -> str:
@@ -294,28 +509,72 @@ def _digest(path: Path) -> str:
         return f"<unreadable: {exc.__class__.__name__}>"
 
 
+def ref_values(git_dir: Path) -> "dict[str, str]":
+    """`refs/…` -> object id, from `packed-refs` AND the loose tree, loose wins.
+
+    🔴 VALUES, NOT FILES, and this is the single biggest false-positive
+    reduction in GUARD 9. Hashing the loose `refs/` tree made `git gc` and
+    `git pack-refs` — which move every loose ref into `packed-refs` and change
+    nothing about what the repository CONTAINS — emit one `DELETED` line per
+    branch: on the operator's clone, hundreds of them, under a banner claiming
+    the 2026-08-21 incident had recurred. `drift-check.sh` runs `git fetch` on a
+    6-hourly timer against exactly that clone and `fetch` triggers `gc --auto`
+    (its own comment says so), so that was not a hypothetical.
+
+    Reading the packed side is also what makes the incident's WORST act visible
+    at all: `refs/heads/main` was DELETED, and on a repo whose refs have been
+    packed that deletion is a `packed-refs` rewrite with no loose file anywhere.
+    """
+    refs: dict[str, str] = {}
+
+    packed = git_dir / "packed-refs"
+    try:
+        text = packed.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        text = ""
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("^"):
+            continue
+        parts = line.split(None, 1)
+        if len(parts) == 2:
+            refs[parts[1].strip()] = parts[0]
+
+    root = git_dir / "refs"
+    if root.is_dir():
+        for dirpath, _dirnames, filenames in os.walk(root):
+            for name in filenames:
+                if name.endswith(".lock"):
+                    # A transient write-in-progress, not a ref. Hashing it makes
+                    # the detector race with any concurrent git.
+                    continue
+                p = Path(dirpath) / name
+                try:
+                    rel = p.relative_to(git_dir).as_posix()
+                except ValueError:  # pragma: no cover - os.walk stays under root
+                    continue
+                try:
+                    refs[rel] = p.read_text(encoding="utf-8", errors="replace").strip()
+                except OSError as exc:
+                    refs[rel] = f"<unreadable: {exc.__class__.__name__}>"
+    return refs
+
+
 def snapshot(git_dirs: "list[Path]", extra_files: "list[Path] | None" = None) -> "dict[str, str]":
     """A content fingerprint of every protected repository.
 
     Content hashes rather than `stat`: an mtime is a claim about WHEN, and two
-    writes inside one timestamp tick would report SAME. The set is small (five
-    files plus the loose refs per repo), so exactness is affordable.
+    writes inside one timestamp tick would report SAME. The set is small (three
+    files plus the resolved refs per repo), so exactness is affordable.
     """
     out: dict[str, str] = {}
     for git_dir in git_dirs:
         for rel in _GIT_DIR_FILES:
-            out[f"{git_dir}/{rel}"] = _digest(git_dir / rel)
-        for tree in _GIT_DIR_TREES:
-            root = git_dir / tree
-            if not root.is_dir():
-                out[f"{git_dir}/{tree}/"] = _LABEL_MISSING
-                continue
-            for dirpath, _dirnames, filenames in os.walk(root):
-                for name in filenames:
-                    p = Path(dirpath) / name
-                    out[str(p)] = _digest(p)
+            out[f"{git_dir}{_FILE_KEY}{rel}"] = _digest(git_dir / rel)
+        for name, value in ref_values(git_dir).items():
+            out[f"{git_dir}{_REF_KEY}{name}"] = value
     for path in extra_files or []:
-        out[str(path)] = _digest(path)
+        out[f"{path}{_FILE_KEY}"] = _digest(path)
     return out
 
 
@@ -336,34 +595,186 @@ def diff_snapshots(before: "dict[str, str]", after: "dict[str, str]") -> "list[s
     return lines
 
 
-def violation_message(where: str, deltas: "list[str]", git_dirs: "list[Path]") -> str:
-    """The one place a GUARD 9 failure is worded.
+# --------------------------------------------------------------------------- #
+# 3. ATTRIBUTION: is this repository ours to blame a test for?
+# --------------------------------------------------------------------------- #
+def _own_process_lineage() -> "set[int]":
+    """This process and its ancestors, so the co-tenant probe never counts us.
 
-    Carries `VIOLATION_TOKEN` so a control can assert THIS guard fired and not a
-    neighbour's error (claude/RULES.md → "prove it REACHABLE"), and names the
-    remediation, because the reader is about to conclude the harness is flaky.
+    Read from `/proc/<pid>/stat` field 4 (PPid). A sibling agent is NOT an
+    ancestor, which is the whole point — that is the case we must be able to
+    see.
     """
+    lineage: set[int] = set()
+    pid = os.getpid()
+    for _ in range(64):  # a lineage longer than this is a loop, not a tree
+        if pid <= 0 or pid in lineage:
+            break
+        lineage.add(pid)
+        try:
+            stat = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8", errors="replace")
+            # comm can contain spaces and parentheses; PPid is the field after
+            # the final ')'.
+            after = stat[stat.rindex(")") + 1:].split()
+            pid = int(after[1])
+        except (OSError, ValueError, IndexError):
+            break
+    return lineage
+
+
+def live_cotenants(git_dirs: "list[Path]") -> "list[str]":
+    """Live processes, not our own ancestors, sitting inside a protected repo.
+
+    POSITIVE EVIDENCE, not a heuristic: if another process's CWD is inside the
+    work tree of a repository we are about to fingerprint, that repository has
+    another user and any delta we see is unattributable. On the operator's box
+    this is the normal state — 30+ Claude sessions were live in that one clone
+    while #683 was being audited.
+
+    Returns `pid:comm` strings (bounded), empty when there is no such evidence.
+    An unreadable `/proc` yields an empty list: absence of evidence leaves the
+    detector in ENFORCE mode, which is the direction that keeps the guard sharp.
+    """
+    roots: list[Path] = []
+    for git_dir in git_dirs:
+        # The work tree is the git dir's parent for a normal `.git`; also accept
+        # the git dir itself so a bare repo is covered.
+        for candidate in (git_dir.parent, git_dir):
+            if candidate not in roots:
+                roots.append(candidate)
+    if not roots:
+        return []
+
+    proc = Path("/proc")
+    if not proc.is_dir():
+        return []
+    mine = _own_process_lineage()
+    found: list[str] = []
+    try:
+        entries = list(proc.iterdir())
+    except OSError:
+        return []
+    for entry in entries:
+        if not entry.name.isdigit():
+            continue
+        pid = int(entry.name)
+        if pid in mine:
+            continue
+        try:
+            cwd = (entry / "cwd").resolve()
+        except OSError:
+            continue  # 13 of them were unreadable on the audited box; not evidence
+        for root in roots:
+            try:
+                cwd.relative_to(root)
+            except ValueError:
+                continue
+            try:
+                comm = (entry / "comm").read_text(encoding="utf-8", errors="replace").strip()
+            except OSError:
+                comm = "?"
+            found.append(f"{pid}:{comm}")
+            break
+        if len(found) >= 8:  # a count of 8 and a count of 300 mean the same thing
+            break
+    return found
+
+
+def attribution_evidence(git_dirs: "list[Path]") -> "list[str]":
+    """Reasons this session cannot attribute a delta to a test. Empty == it can.
+
+    Kept separate from the probes themselves so the plugin can add reasons it
+    learns LATER (a delta in an idle window, a settle re-read that moved again)
+    to the same list and word them the same way.
+    """
+    reasons: list[str] = []
+    cotenants = live_cotenants(git_dirs)
+    if cotenants:
+        reasons.append(
+            "live processes are sitting inside a protected repository "
+            f"(cwd), and none of them is ours: {', '.join(cotenants)}"
+        )
+    return reasons
+
+
+# --------------------------------------------------------------------------- #
+# 4. WORDING
+# --------------------------------------------------------------------------- #
+def _preamble(git_dirs: "list[Path]", deltas: "list[str]") -> str:
     listed = "\n".join(f"    {d}" for d in git_dirs) or "    (none discovered)"
     return (
-        f"{VIOLATION_TOKEN}: {where} MUTATED a git repository that is not its own tmpdir.\n"
-        "\n"
         "Protected git dir(s):\n"
         f"{listed}\n"
         "\n"
         "What moved:\n" + "\n".join(deltas) + "\n"
+    )
+
+
+def observation_message(where: str, deltas: "list[str]", git_dirs: "list[Path]",
+                        reasons: "list[str]") -> str:
+    """Report mode's wording. 🔴 Deliberately WITHOUT `VIOLATION_TOKEN`.
+
+    A control that asserts the token must not be satisfiable by an observation
+    nobody could attribute — otherwise the reachability proof degrades into
+    "something printed something".
+    """
+    why = "\n".join(f"    - {r}" for r in reasons) or "    - (none recorded)"
+    return (
+        f"{OBSERVED_MARKER}: a protected git repository changed during "
+        f"{where}, and GUARD 9 CANNOT SAY WHO DID IT.\n"
         "\n"
-        "🔴 This is the 2026-08-21 incident's shape. On that day a gate run rewrote\n"
-        "`refs/heads/main` with fixture commits, deleted the branch, rewrote\n"
-        "`core.hooksPath` and `remote.origin.url`, and pushed fixture refs to the\n"
-        "production remote. The fixtures were NOT sloppy — they all passed\n"
-        "`-C <tmp_path>`; an inherited GIT_DIR simply overrides `-C`.\n"
+        f"{_preamble(git_dirs, deltas)}"
+        "\n"
+        "Why this is a report and not a failure:\n"
+        f"{why}\n"
+        "\n"
+        "GUARD 9's PREVENTION half (the `REPO_POINTER_VARS` strip) is unaffected "
+        "and still in force; only ATTRIBUTION is impossible here. If you expected "
+        "this repository to have exactly one writer, that expectation is the bug — "
+        f"re-run where it holds, or pin `{MODE_ENV}={MODE_ENFORCE}`."
+    )
+
+
+def violation_message(where: str, deltas: "list[str]", git_dirs: "list[Path]") -> str:
+    """The one place an ATTRIBUTED GUARD 9 failure is worded.
+
+    Carries `VIOLATION_TOKEN` so a control can assert THIS guard fired and not a
+    neighbour's error (claude/RULES.md → "prove it REACHABLE"), and names the
+    remediation, because the reader is about to conclude the harness is flaky.
+
+    🔴 HYPOTHESIS 1 IS "SOMETHING ELSE WROTE HERE", and the order is the fix.
+    The first version led with the incident, so a `git branch` run by any of the
+    dozens of concurrent sessions on the operator's box produced *"test X
+    MUTATED a git repository that is not its own tmpdir … This is the
+    2026-08-21 incident's shape"* — maximum confidence, wrong subject. This
+    message is only reached when the co-tenant probe, the idle probe and a
+    settle re-read ALL found no other writer, and it says so, because the reader
+    needs to know which of those to distrust.
+    """
+    return (
+        f"{VIOLATION_TOKEN}: a protected git repository changed during {where}.\n"
+        "\n"
+        f"{_preamble(git_dirs, deltas)}"
         "\n"
         "Check, in this order:\n"
-        f"  1. Was one of {', '.join(REPO_POINTER_VARS[:4])}… set in the environment?\n"
+        "  1. 🔴 DID SOMETHING ELSE WRITE TO THIS REPOSITORY? By far the most\n"
+        "     common cause, and the one GUARD 9 cannot see from inside: another\n"
+        "     agent session, an editor, a `git fetch` timer (`drift-check` runs\n"
+        "     one 4x/day), a `gc`. This message is only printed when no process\n"
+        "     was found sitting in the repo, the delta held still across a\n"
+        "     re-read, and nothing moved while no test was running — but all\n"
+        "     three are ABSENCE of evidence. `git reflog` dates the change and\n"
+        "     names the operation.\n"
+        f"  2. Was one of {', '.join(REPO_POINTER_VARS[:4])}… set in the environment?\n"
         "     `scripts/testlib/gitenv.py` strips them; something re-set one AFTER\n"
         "     the plugin loaded (a monkeypatch.setenv, a conftest, a wrapper).\n"
-        "  2. Does the failing test run git with a path it did not build under\n"
-        "     `tmp_path` — e.g. a repo root derived from `__file__`?\n"
-        "  3. Restore this checkout before doing anything else: `git reflog` is the\n"
-        "     one-command diagnosis for a branch that looks like it moved backwards."
+        "  3. Does the failing test run git with a path it did not build under\n"
+        "     `tmp_path` — e.g. a repo root derived from `__file__`? That is the\n"
+        "     one escape the strip cannot close.\n"
+        "  4. If 2 or 3 holds, this is the 2026-08-21 incident's shape: a gate run\n"
+        "     rewrote `refs/heads/main` with fixture commits, deleted the branch,\n"
+        "     rewrote `core.hooksPath` and `remote.origin.url`, and pushed fixture\n"
+        "     refs to the production remote. The fixtures were NOT sloppy — they\n"
+        "     all passed `-C <tmp_path>`; an inherited GIT_DIR overrides `-C`.\n"
+        "     Restore this checkout before doing anything else."
     )

--- a/scripts/testlib/gitenv_plugin.py
+++ b/scripts/testlib/gitenv_plugin.py
@@ -3,17 +3,19 @@
 Loaded two ways, exactly like `nolaunch_plugin` and `spool_plugin`:
 
   * `scripts/run-tests.sh` puts `-p testlib.gitenv_plugin` on the ONE pytest
-    line every target goes through, so all seventeen get it rather than the one
+    line every target goes through, so all of them get it rather than the one
     directory that happens to have a conftest.
-  * `scripts/tests/conftest.py` imports it, so a bare `pytest scripts/tests`
-    outside the runner is protected too — by the same module, not a second copy.
+  * a conftest in each test directory that builds real git repositories imports
+    it, so a bare `pytest <dir>` outside the runner is protected too — by the
+    same module, not a second copy. The ledger of those conftests is pinned by
+    `test_the_conftest_entry_points_are_a_pinned_ledger`.
 
 Two layers, and they answer different questions:
 
   LAYER 1 — SANITISE (prevention), a second time and deliberately so. The
   shell side already cleared these at the top of whichever runner started this
-  process, before it resolved its ROOT; this repeats it for a BARE `pytest` that never
-  went through a runner. Strips `REPO_POINTER_VARS` from `os.environ`
+  process, before it resolved its ROOT; this repeats it for a BARE `pytest` that
+  never went through a runner. Strips `REPO_POINTER_VARS` from `os.environ`
   at IMPORT time, before pytest collects anything. Import time matters: several
   suites build real git repos at MODULE scope (`test_bash_guard.py::_mkrepo`,
   `test_guard_core.py`'s module-scoped cwd fixtures), which run during
@@ -28,86 +30,251 @@ Two layers, and they answer different questions:
 
 🔴 The strip runs at import, NOT in `pytest_configure`, and that ordering is
 load-bearing rather than stylistic — see above.
+
+🔴 LAYER 2 HAS TWO MODES, AND THE REASON IS MEASURED (#683 audit, finding A).
+The detector watches a repository it does not own; on the operator's box that
+clone has dozens of concurrent writers. Blaming a test for their writes, in a
+message that leads with "This is the 2026-08-21 incident's shape", is a
+permanently-red gate that misdirects during the very incident it names. So the
+detector now looks for POSITIVE EVIDENCE of another writer, from three
+independent probes, and downgrades to reporting when it finds any:
+
+  * `live_cotenants()` at import — a live process, not one of our ancestors,
+    whose CWD is inside a protected work tree.
+  * THE IDLE PROBE — a delta observed between `pytest_runtest_logfinish` and
+    the next `pytest_runtest_logstart`. Nothing of the test protocol runs in
+    that window (setup, call and teardown all sit between logstart and
+    logfinish), so a change there was made by somebody else. This is the one
+    airtight probe of the three.
+  * THE SETTLE RE-READ — on any delta, the fingerprint is taken again
+    immediately and again after `SETTLE_SECONDS`, with no test running. A repo
+    that keeps moving has another writer.
+
+Report mode prints the FULL delta under `OBSERVED_MARKER` and counts it into
+the session-end summary; it never fails a test, and it deliberately does not
+carry `VIOLATION_TOKEN`. Prevention (layer 1) is untouched by the mode.
 """
 from __future__ import annotations
 
 import os
+import time
 
 import pytest
 
 from testlib.gitenv import (  # noqa: F401  (re-exported for tests)
+    CONTROL_VARS,
+    FOREIGN_MARKER,
+    MODE_AUTO,
+    MODE_ENFORCE,
+    MODE_ENV,
+    MODE_REPORT,
+    OBSERVED_MARKER,
     PROTECT_ENV,
     REPO_POINTER_VARS,
     SESSION_MARKER,
     VIOLATION_TOKEN,
+    attribution_evidence,
     diff_snapshots,
     global_config_paths,
+    observation_message,
     protected_git_dirs,
+    requested_mode,
     snapshot,
     strip_repo_pointers,
     violation_message,
 )
 
+# How long to wait before the second settle re-read. Paid ONLY when a delta was
+# seen, which on a healthy run is never — so this is not a per-test cost.
+SETTLE_SECONDS = 0.25
+
 # --- LAYER 1, at import ------------------------------------------------------ #
 STRIPPED: dict[str, str] = strip_repo_pointers()
 
 # --- LAYER 2's state --------------------------------------------------------- #
+# Both of these RAISE on a malformed seam rather than degrading to a green run
+# under a reassuring marker line (gitenv.GitEnvConfigError; see finding B).
 _GIT_DIRS = protected_git_dirs()
+_MODE = requested_mode()
 _EXTRA = global_config_paths()
+
+# Reasons attribution is impossible. Seeded from the import-time probe and
+# appended to when the idle probe or a settle re-read proves another writer.
+_UNATTRIBUTABLE: list[str] = attribution_evidence(_GIT_DIRS)
+
+_OBSERVED = 0      # deltas reported without attribution
+_VIOLATIONS = 0    # deltas attributed to a test (enforce mode only)
 
 
 def _take() -> "dict[str, str]":
     return snapshot(_GIT_DIRS, _EXTRA)
 
 
-# 🔴 ARMED AT IMPORT, not in `pytest_configure`. `pytest_configure` is an
-# INITIALISATION hook: pytest calls it for plugins given with `-p` and for the
-# rootdir conftest, but NOT for a conftest loaded later during collection. The
-# conftest entry point (`scripts/tests/conftest.py`) is exactly that case, so a
-# baseline taken only in `pytest_configure` would be an empty dict there and the
-# first `_check` would report every protected file as CREATED. Taking it here
-# makes both entry points identical, and `pytest_configure` merely re-arms it
-# and prints the marker.
+# 🔴 ARMED AT IMPORT, not in `pytest_configure`. Damage done while a module is
+# being imported during collection has to be measured against a baseline that
+# predates the import. `pytest_configure` merely re-arms it and prints the
+# marker.
 _BASELINE: dict[str, str] = _take()
 
 
-def _check(where: str) -> None:
-    """Compare against the baseline and FAIL LOUDLY on any delta.
+_CONFIG = None  # set in pytest_configure; used only to bypass output capture
 
-    The baseline is re-armed after a violation is reported, deliberately: the
-    next test is not responsible for damage this one did, and a guard that
-    re-reports the same delta for every remaining test buries the attribution
-    it exists to provide.
+
+def _say(text: str) -> None:
+    """Print OUTSIDE pytest's output capture.
+
+    🔴 MEASURED, and it is the difference between a report and a swallowed one:
+    a delta is normally detected in the autouse fixture's teardown, and pytest
+    discards captured output for a test that PASSED — which report mode's tests
+    do, by design. A plain `print` there produced `unattributed-observations=1`
+    in the session summary and not one word about what actually moved. The
+    capture manager is asked to stand down for the duration, exactly as pytest's
+    own live-log and warning plugins do; if it is unavailable (a bare
+    `pytest -p no:capture`, another plugin), the print still happens.
+    """
+    manager = None
+    if _CONFIG is not None:
+        manager = _CONFIG.pluginmanager.getplugin("capturemanager")
+    if manager is None:
+        print(text)
+        return
+    with manager.global_and_fixture_disabled():
+        print(text)
+
+
+def _effective_mode() -> str:
+    if _MODE != MODE_AUTO:
+        return _MODE
+    return MODE_REPORT if _UNATTRIBUTABLE else MODE_ENFORCE
+
+
+def _mark_foreign(reason: str) -> None:
+    """Record PROVEN evidence of another writer and announce the downgrade once."""
+    global _UNATTRIBUTABLE
+    was_attributable = not _UNATTRIBUTABLE
+    _UNATTRIBUTABLE.append(reason)
+    if was_attributable:
+        _say(f"{FOREIGN_MARKER} {reason}\n"
+             f"{FOREIGN_MARKER} GUARD 9 can no longer attribute a change in a "
+             "protected repository to a test; it will REPORT deltas instead of "
+             "failing on them. The pointer strip (prevention) is unaffected.")
+
+
+def _report(where: str, deltas: "list[str]", *, in_a_test: bool = True) -> None:
+    """Fail or report, according to the mode.
+
+    🔴 `in_a_test=False` is not cosmetic. `pytest.fail` raised from
+    `pytest_collection_finish` or `pytest_sessionfinish` is an exception thrown
+    from a HOOK, which pytest reports as `INTERNALERROR>` and exits 3 with
+    **zero tests run** — measured on #683's code, where one neighbouring
+    `git branch` landing during collection aborted the entire suite that way.
+    `pytest.exit` is the supported route: same non-zero exit, same message,
+    reported as a decision instead of a crash.
+    """
+    global _OBSERVED, _VIOLATIONS
+    if _effective_mode() == MODE_ENFORCE:
+        _VIOLATIONS += 1
+        message = violation_message(where, deltas, _GIT_DIRS)
+        if in_a_test:
+            pytest.fail(message, pytrace=False)
+        _say(message)
+        pytest.exit(f"{VIOLATION_TOKEN}: see the message above ({where}).",
+                    returncode=1)
+    _OBSERVED += 1
+    _say(observation_message(where, deltas, _GIT_DIRS, _UNATTRIBUTABLE))
+
+
+def _check(where: str, *, in_a_test: bool = True) -> None:
+    """Compare against the baseline and act on any delta.
+
+    🔴 THE BASELINE IS RE-ARMED ON EVERY CALL, not only after a violation. With
+    a rolling baseline that only moved on failure, the window a delta could have
+    arrived in was the WHOLE SESSION, so the first test to finish after any
+    change — a concurrent agent's `git branch` included — wore it. Re-arming
+    every time makes the window one test.
+
+    🔴 AND THE DELTA IS RE-READ BEFORE ANYTHING IS ASSERTED. Twice: immediately,
+    and again after `SETTLE_SECONDS`. No test body is running during either, so
+    a repository that moves again has, provably, another writer.
     """
     global _BASELINE
-    if not _GIT_DIRS and not _EXTRA:
-        return
     after = _take()
     deltas = diff_snapshots(_BASELINE, after)
     if not deltas:
+        _BASELINE = after
         return
+
+    # 🔴 THE SETTLE COSTS NOTHING ONCE THE ANSWER IS KNOWN. Its only job is to
+    # DISCOVER a co-writer; if one has already been proven, re-reading buys
+    # nothing and the sleep is per-delta. Measured: a 40-test run against a
+    # repository being written every 40ms took 12.2s with the settle applied
+    # unconditionally and 2.3s with this guard — the same verdict either way.
+    if _effective_mode() == MODE_ENFORCE:
+        for label, pause in (("an immediate re-read", 0.0),
+                             (f"a {SETTLE_SECONDS}s settle", SETTLE_SECONDS)):
+            if pause:
+                time.sleep(pause)
+            again = _take()
+            if diff_snapshots(after, again):
+                _mark_foreign(
+                    f"the repository changed AGAIN during {label}, while no test was "
+                    "running — something outside this pytest session is writing to it"
+                )
+            after = again
+    deltas = diff_snapshots(_BASELINE, after)
     _BASELINE = after
-    pytest.fail(violation_message(where, deltas, _GIT_DIRS), pytrace=False)
+    if not deltas:  # everything settled back to the baseline
+        return
+    _report(where, deltas, in_a_test=in_a_test)
 
 
 def pytest_configure(config):
-    global _BASELINE
+    global _BASELINE, _CONFIG
+    _CONFIG = config
     _BASELINE = _take()
-    # ONE marker line per pytest session. A target that never prints it is a
-    # target this guard never loaded in, and "no marker" is otherwise
-    # indistinguishable from "loaded, saw nothing" — the reassuring zero
-    # claude/RULES.md's positive-control rule is about. It also reports the
-    # PAIR: what was stripped, and how many repos are being watched.
+    # ONE marker line per pytest session, and `run-tests.sh` COUNTS it per
+    # target: a target that never prints it is a target this guard never loaded
+    # in, and "no marker" is otherwise indistinguishable from "loaded, saw
+    # nothing" — the reassuring zero claude/RULES.md's positive-control rule is
+    # about. It reports the PAIR: what was stripped, how many repos are watched,
+    # and — because a count alone cannot say whether the count is trustworthy —
+    # the mode and why.
     stripped = ",".join(sorted(STRIPPED)) or "none"
-    watching = len(_GIT_DIRS)
-    print(f"{SESSION_MARKER} stripped={stripped} protected-git-dirs={watching}")
+    print(f"{SESSION_MARKER} stripped={stripped} "
+          f"protected-git-dirs={len(_GIT_DIRS)} "
+          f"mode={_effective_mode()}({_MODE}) "
+          f"unattributable={len(_UNATTRIBUTABLE)}")
+    for reason in _UNATTRIBUTABLE:
+        print(f"{SESSION_MARKER}   cannot attribute: {reason}")
 
 
 def pytest_collection_finish(session):
     # Module-scope repo building happens HERE, not inside a test, so a check
     # that only ran per-test would attribute import-time damage to whichever
     # test happened to run first — or miss it entirely in a collect-only run.
-    _check("collection (a module-level fixture, at import)")
+    _check("collection (a module-level fixture, at import)", in_a_test=False)
+
+
+def pytest_runtest_logstart(nodeid, location):
+    """🔴 THE IDLE PROBE — the one airtight "it wasn't us" measurement.
+
+    Setup, call and teardown all happen between `logstart` and `logfinish`, so
+    the window between the previous test's `logfinish` and this `logstart` runs
+    no test code at all. A delta observed here was written by another process,
+    full stop — and that PROVES this repository has a co-writer for the rest of
+    the session.
+    """
+    global _BASELINE
+    after = _take()
+    deltas = diff_snapshots(_BASELINE, after)
+    _BASELINE = after
+    if not deltas:
+        return
+    _mark_foreign(
+        "a protected repository changed BETWEEN tests, when no test body, "
+        "fixture or teardown was running"
+    )
+    _report(f"the idle window before `{nodeid}`", deltas, in_a_test=False)
 
 
 @pytest.fixture(autouse=True)
@@ -117,9 +284,8 @@ def _devrc_git_repo_isolation(request):
 
 
 def pytest_sessionfinish(session, exitstatus):
-    _check("session teardown (after the last test)")
-
-
-def _os_environ_is_clean() -> bool:
-    """Exposed for the controls: nothing re-set a pointer after the strip."""
-    return not any(name in os.environ for name in REPO_POINTER_VARS)
+    _check("session teardown (after the last test)", in_a_test=False)
+    if _OBSERVED or _VIOLATIONS:
+        print(f"{SESSION_MARKER} summary: attributed-violations={_VIOLATIONS} "
+              f"unattributed-observations={_OBSERVED} "
+              f"mode={_effective_mode()}({_MODE})")

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -55,14 +55,20 @@ from testlib.spool_plugin import no_real_activity_spool  # noqa: E402,F401
 #
 # 🔴 The names are imported INTO THIS CONFTEST'S NAMESPACE, which is what
 # registers them — pytest reads hooks and fixtures off the conftest module
-# object. `pytest_configure` is deliberately NOT among them: it is an
-# initialisation hook and pytest does not call it for a conftest loaded during
-# collection, so importing it would look like coverage while providing none.
-# The plugin arms its baseline at IMPORT for exactly that reason, so this entry
-# point loses nothing but the marker line.
+# object.
+#
+# 🔴 `pytest_configure` IS AMONG THEM, and the comment that used to sit here
+# saying it could not be was FALSE. It claimed pytest does not call
+# `pytest_configure` for a conftest loaded during collection, which cost this
+# entry point its marker line — the run's only evidence the guard loaded at all.
+# Measured on pytest 9.1.1: a `pytest_configure` in the collected directory's
+# conftest IS called. (`scripts/tests` is also this invocation's rootdir, so it
+# was never the "loaded later" case the claim described in the first place.)
 from testlib.gitenv_plugin import (  # noqa: E402,F401
     _devrc_git_repo_isolation,
     pytest_collection_finish,
+    pytest_configure,
+    pytest_runtest_logstart,
     pytest_sessionfinish,
 )
 

--- a/scripts/tests/test_git_repo_isolation.py
+++ b/scripts/tests/test_git_repo_isolation.py
@@ -97,7 +97,7 @@ RUNNERS = (SCRIPTS / "run-tests.sh",
 
 sys.path.insert(0, str(SCRIPTS))
 
-from testlib import gitenv, gitenv_plugin  # noqa: E402
+from testlib import gitenv, gitenv_plugin, mockbin  # noqa: E402
 from testlib.gitenv import (  # noqa: E402
     CONTROL_VARS,
     FOREIGN_MARKER,
@@ -494,6 +494,12 @@ _SHELL_ROOTS = ("githooks", "scripts", "nix")
 _SHELL_SUFFIXES = {".sh", ".bash", ".zsh", ".nix"}
 _SKIP_DIRS = {".git", "node_modules", "__pycache__", "result", "dist", "build",
               ".direnv", ".pytest_cache"}
+# 🔴 Spelled from character codes, not as a literal. `testlib/shebang_scan.py`
+# treats a quote followed by those two bytes as a test writing its own
+# shebang, and it is right to — it cannot tell a WRITE from a READ, and the
+# false negative it exists to prevent cost two days of red sandbox. Same
+# spelling trick that module uses on itself.
+_HASHBANG = (chr(35) + chr(33)).encode()
 _SHEBANG = re.compile(rb"\b(ba|z|da|k)?sh\b")
 
 _KEYWORDS = re.compile(r"^(?:export|readonly|local|declare|typeset)(?:\s+-\w+)*\s+")
@@ -528,7 +534,7 @@ def _shell_files() -> list[Path]:
                     head = p.open("rb").readline(200)
                 except OSError:
                     continue
-                if head.startswith(b"#!") and _SHEBANG.search(head):
+                if head.startswith(_HASHBANG) and _SHEBANG.search(head):
                     out.append(p)
     return out
 
@@ -797,12 +803,14 @@ def test_git_push_does_not_export_GIT_DIR_to_pre_push(tmp_path):
     assert _git(work, "remote", "add", "origin", str(bare), env=base).returncode == 0
 
     seen = tmp_path / "hookenv.txt"
-    hook = work / ".git" / "hooks" / "pre-push"
-    hook.write_text(
-        "#!/usr/bin/env bash\n"
+    # 🔴 `mockbin.write_exec` OWNS THE SHEBANG. Writing one here would give
+    # the hook `/usr/bin/env`, which `test_runtime_shebangs.py` fails on — a
+    # guard measured to matter: two files that wrote their own put 27 tests
+    # red in the nix sandbox for two days. The body is POSIX sh.
+    hook = mockbin.write_exec(
+        work / ".git" / "hooks" / "pre-push",
         f"env | grep -E '^GIT' | sort > {seen}\n"
-        "cat >/dev/null\nexit 0\n", encoding="utf-8")
-    hook.chmod(0o755)
+        "cat >/dev/null\nexit 0\n")
 
     assert _git(work, "push", "-q", "origin", "main", env=base).returncode == 0
     names = {ln.split("=", 1)[0] for ln in seen.read_text(encoding="utf-8").splitlines()}

--- a/scripts/tests/test_git_repo_isolation.py
+++ b/scripts/tests/test_git_repo_isolation.py
@@ -22,24 +22,40 @@ and a plugin rather than a patch in fourteen test files. The tmpdir
 paths written into the real config are the tell: the tests computed the RIGHT
 value and git wrote it into the WRONG repository.
 
+🔴 WHAT IS **NOT** KNOWN, stated here because #683's body asserted it and it was
+relayed onward: nothing has identified WHAT exported `GIT_DIR` into that run.
+`git push` does not hand `GIT_DIR` to `pre-push` (measured, git 2.55.0 — see
+`test_git_push_does_not_export_GIT_DIR_to_pre_push`), so the hook's old
+`GIT_DIR=` line was a route only when an outer caller had already exported the
+name. The rename is hygiene, not a diagnosis.
+
 HOW THIS FILE IS BUILT, and why each layer is not redundant with the next:
 
-  1. LEDGERS. The variable list is owned once in Python (`testlib/gitenv.py`)
-     and re-spelled in each of the three shell runners — they need it because
-     HOOK_TESTS, SHELL_TESTS and the node tier never load a pytest plugin, and
-     because an inherited GIT_DIR breaks ROOT resolution before any Python runs.
-     Pinned in BOTH directions for every spelling: a set that only grows on one
-     side is a guard that protects twelve targets and not five.
-  2. THE DETECTOR, as a unit. Does `snapshot` actually MOVE when a ref moves?
-     Reported as a pair with a no-op control, never as a bare zero.
-  3. 🔴 THE INCIDENT ITSELF, as a nested-pytest control pair. One run WITHOUT
+  1. LEDGERS. The variable lists are owned once in Python (`testlib/gitenv.py`)
+     and re-spelled in each of the four shell entry points — they need them
+     because HOOK_TESTS, SHELL_TESTS and the node tier never load a pytest
+     plugin, and because an inherited GIT_DIR breaks ROOT resolution before any
+     Python runs. Pinned in BOTH directions for every spelling: a set that only
+     grows on one side is a guard that protects twelve targets and not five.
+  2. ENTRY POINTS, as a LEDGER rather than an example. Every `conftest.py`
+     under `scripts/` must re-export the plugin's hooks, and the SET is pinned,
+     so adding a test directory cannot silently leave a bare `pytest <dir>`
+     unguarded. #683 wired exactly one of seven — and not the one the plugin's
+     own rationale cites.
+  3. THE FINGERPRINT'S CONTENT, component by component. Each entry is pinned by
+     a mutation that ONLY it can see, because "the detector noticed something"
+     is satisfied by any surviving component: five semantic mutants survived
+     #683's fully green suite.
+  4. 🔴 THE INCIDENT ITSELF, as a nested-pytest control pair. One run WITHOUT
      the plugin reproduces the damage (a fixture-shaped `git -C <tmp>` writing
-     a branch into the ambient repo); one run WITH it does not. A guard nobody
-     has watched fail proves nothing, and a fix nobody has watched CHANGE the
-     outcome proves nothing either.
-  4. REACHABILITY. The violation is asserted by `VIOLATION_TOKEN` — this
+     a branch into the ambient repo); one run WITH it does not.
+  5. REACHABILITY. The violation is asserted by `VIOLATION_TOKEN` — this
      guard's own marker — so a control cannot pass because a DIFFERENT check
      errored first (claude/RULES.md → "prove it REACHABLE, not just breakable").
+  6. 🔴 ATTRIBUTION. The detector watches a repository with other writers on it.
+     Both directions are pinned: a change made while no test was running must
+     NOT be blamed on a test (and must downgrade the session), and a real escape
+     must still be caught and named.
 """
 from __future__ import annotations
 
@@ -57,31 +73,51 @@ SCRIPTS = ROOT / "scripts"
 RUN_TESTS = SCRIPTS / "run-tests.sh"
 CONFTEST = SCRIPTS / "tests" / "conftest.py"
 
-# Every entry point that resolves a ROOT with `git rev-parse --show-toplevel`
-# and then runs tests. All three carry GUARD 9's `unset`, and all three must run
-# it BEFORE that line — see test_every_runner_clears_BEFORE_it_resolves_its_root.
+# Every entry point that resolves a repo root with
+# `git rev-parse --show-toplevel` and then runs tests. All four carry GUARD 9's
+# `unset`, and all four must run it BEFORE that line — see
+# test_every_runner_clears_BEFORE_it_resolves_its_root.
 #
-# 🔴 THREE SPELLINGS RATHER THAN ONE SOURCED FILE, and the reason is measured,
+# 🔴 `githooks/tests-on-push.sh` IS ONE OF THEM and #683 left it out, while this
+# very docstring described it. It sits between `pre-push` and `run-tests.sh` on
+# the `git push` path — the path the incident travelled — and resolves
+# `REPO_ROOT` with exactly the vulnerable expression.
+#
+# 🔴 FOUR SPELLINGS RATHER THAN ONE SOURCED FILE, and the reason is measured,
 # not aesthetic: `testlib/runner_patch.py` writes a patched COPY of
 # `run-tests.sh` into a tmp dir and about fifteen tests drive that copy. A copy
 # cannot source a sibling `lib/` that was never copied with it — the first
 # version of this guard did exactly that and turned those fifteen red with
-# `run-tests: FATAL — cannot source lib/git-repo-pointers.sh`. So the SET is
-# owned once, in `testlib/gitenv.py`, and every spelling is pinned to it here.
+# `run-tests: FATAL — cannot source lib/git-repo-pointers.sh`. So the SETS are
+# owned once, in `testlib/gitenv.py`, and every spelling is pinned to them here.
 RUNNERS = (SCRIPTS / "run-tests.sh",
            SCRIPTS / "run-node-tests.sh",
-           SCRIPTS / "gate.sh")
+           SCRIPTS / "gate.sh",
+           ROOT / "githooks" / "tests-on-push.sh")
 
 sys.path.insert(0, str(SCRIPTS))
 
+from testlib import gitenv, gitenv_plugin  # noqa: E402
 from testlib.gitenv import (  # noqa: E402
+    CONTROL_VARS,
+    FOREIGN_MARKER,
+    MODE_ENFORCE,
+    MODE_ENV,
+    MODE_REPORT,
+    OBSERVED_MARKER,
     PROTECT_ENV,
     global_config_paths,
     REPO_POINTER_VARS,
+    SESSION_MARKER,
     VIOLATION_TOKEN,
+    GitEnvConfigError,
     diff_snapshots,
+    live_cotenants,
     protected_git_dirs,
+    ref_values,
+    requested_mode,
     resolve_git_dir,
+    resolve_protect_env,
     snapshot,
     strip_repo_pointers,
 )
@@ -95,6 +131,22 @@ if shutil.which("git") is None:  # pragma: no cover - the gate puts git on PATH
         "git is not on PATH. Add it to REQUIRED_TOOLS in scripts/run-tests.sh "
         "and to the pytests check in flake.nix rather than skipping these tests."
     )
+
+def _require_proc() -> None:
+    """🔴 NOT a skip, for the same reason `git` above is not a skipif.
+
+    `live_cotenants` returns `[]` where `/proc` is unreadable, and `[]` is what
+    puts the detector in ENFORCE mode — so a SKIPPED co-tenant test reports a
+    safety property it never measured, on the exact hosts where the probe is
+    silently inert. Both devrc hosts are NixOS and the hermetic gate runs in a
+    Linux sandbox, so this is an ERROR, not an environment excuse.
+    """
+    assert Path("/proc").is_dir(), (
+        "/proc is missing, so GUARD 9's co-tenant probe cannot work and every "
+        "session would run in ENFORCE mode with no evidence. Port "
+        "`live_cotenants` to this platform rather than skipping the control."
+    )
+
 
 _GIT_ENV = {
     "GIT_CONFIG_SYSTEM": "/dev/null",
@@ -144,23 +196,17 @@ def test_every_file_the_ledgers_read_exists():
 # --------------------------------------------------------------------------- #
 # 1. THE LEDGERS — one owner (gitenv.py), four spellings, pinned both ways
 # --------------------------------------------------------------------------- #
-def _shell_unset_names(runner: Path) -> list[str]:
-    """The names `runner`'s GUARD 9 block actually clears.
-
-    Read out of the ARRAY LITERAL, comments stripped, and the array is then
-    required to be what the `unset` line expands — so a runner that keeps the
-    array for show and unsets something else cannot pass.
-    """
+def _shell_array(runner: Path, array: str) -> list[str]:
+    """The names in `runner`'s `<array>=( … )` literal, comments stripped."""
     text = runner.read_text(encoding="utf-8")
-    m = re.search(r"^DEVRC_GIT_REPO_POINTERS=\(\n(.*?)^\)$", text, re.M | re.S)
+    m = re.search(rf"^{array}=\(\n(.*?)^\)$", text, re.M | re.S)
     assert m, (
-        f"no DEVRC_GIT_REPO_POINTERS array in {runner.name}. GUARD 9's shell half "
-        "is what protects the NON-pytest targets (HOOK_TESTS, SHELL_TESTS, the "
-        "node tier) and what keeps ROOT resolvable at all under an inherited "
-        "GIT_DIR."
+        f"no {array} array in {runner.name}. GUARD 9's shell half is what "
+        "protects the NON-pytest targets (HOOK_TESTS, SHELL_TESTS, the node "
+        "tier) and what keeps ROOT resolvable at all under an inherited GIT_DIR."
     )
-    assert 'unset "${DEVRC_GIT_REPO_POINTERS[@]}"' in text, (
-        f"{runner.name} declares the array but never unsets it. 🔴 A declaration "
+    assert f'unset "${{{array}[@]}}"' in text, (
+        f"{runner.name} declares {array} but never unsets it. 🔴 A declaration "
         "is not a code path (claude/RULES.md)."
     )
     names: list[str] = []
@@ -169,6 +215,10 @@ def _shell_unset_names(runner: Path) -> list[str]:
         if line:
             names.extend(line.split())
     return names
+
+
+def _shell_unset_names(runner: Path) -> list[str]:
+    return _shell_array(runner, "DEVRC_GIT_REPO_POINTERS")
 
 
 @pytest.mark.parametrize("runner", RUNNERS, ids=lambda p: p.name)
@@ -188,10 +238,34 @@ def test_the_shell_and_python_pointer_ledgers_agree(runner):
 
 
 @pytest.mark.parametrize("runner", RUNNERS, ids=lambda p: p.name)
+def test_the_shell_and_python_CONTROL_ledgers_agree(runner):
+    """🔴 GUARD 9's OWN SEAMS ARE ON THE UNSET LIST TOO — finding B of #683's
+    audit, and the sharpest one, because the fix reintroduced its own bug.
+
+    `DEVRC_GITENV_PROTECT` redirects the whole detector and no runner cleared
+    it. Measured on that code, same escaping test, three spellings:
+
+        <real>/.git      -> protected-git-dirs=1, RED with the guard's token
+        ":"              -> protected-git-dirs=0, GREEN, branch really created
+        /nonexistent/x   -> protected-git-dirs=1, GREEN, branch really created
+
+    One inherited environment variable defeating every layer is the incident
+    this guard exists for; leaving one inside the guard was not acceptable.
+    """
+    shell = _shell_array(runner, "DEVRC_GITENV_CONTROL_VARS")
+    assert sorted(shell) == sorted(CONTROL_VARS), (
+        f"GUARD 9's control-var ledgers disagree between {runner.name} and "
+        f"gitenv.py.\n  only in {runner.name}: {sorted(set(shell) - set(CONTROL_VARS))}"
+        f"\n  only in gitenv.py    : {sorted(set(CONTROL_VARS) - set(shell))}"
+    )
+
+
+@pytest.mark.parametrize("runner", RUNNERS, ids=lambda p: p.name)
 def test_the_shell_ledger_has_no_duplicates(runner):
     """A duplicated name reads as a longer list than it is."""
-    shell = _shell_unset_names(runner)
-    assert len(shell) == len(set(shell)), f"duplicates in {runner.name}: {shell}"
+    for array in ("DEVRC_GIT_REPO_POINTERS", "DEVRC_GITENV_CONTROL_VARS"):
+        names = _shell_array(runner, array)
+        assert len(names) == len(set(names)), f"duplicates in {runner.name}:{array}: {names}"
 
 
 def test_GIT_DIR_is_on_every_ledger():
@@ -202,14 +276,31 @@ def test_GIT_DIR_is_on_every_ledger():
         assert "GIT_DIR" in _shell_unset_names(runner), runner.name
 
 
-def _root_line(text: str) -> int:
-    """The line that ASSIGNS ROOT from `rev-parse --show-toplevel`.
+def test_the_runner_and_python_session_markers_agree():
+    """`run-tests.sh` COUNTS the plugin's marker per target, so the token is
+    spelled on both sides of a process boundary — pinned both ways, exactly like
+    `SPOOL_SESSION_MARKER`. A rename on one side alone would make the count
+    match nothing and report a clean run."""
+    text = RUN_TESTS.read_text(encoding="utf-8")
+    m = re.search(r'^GITENV_SESSION_MARKER="([^"]+)"$', text, re.M)
+    assert m, "run-tests.sh no longer spells GITENV_SESSION_MARKER"
+    assert m.group(1) == SESSION_MARKER, (
+        f"run-tests.sh says {m.group(1)!r}, gitenv.py says {SESSION_MARKER!r}")
+    assert f'grep -ac "^$GITENV_SESSION_MARKER"' in text, (
+        "run-tests.sh declares the marker but never counts it. 🔴 A declared "
+        "positive control that is never read is the reassuring zero itself: "
+        "'loaded and saw nothing' and 'never loaded' print identically."
+    )
 
-    🔴 Comment lines are skipped, and `ROOT=` is required on the line. The first
-    version matched any mention of the phrase and therefore matched GUARD 9's
-    own explanatory COMMENT — which sits above the assignment, so all three
-    runners reported "clears AFTER ROOT" while being correctly ordered. A
-    parser that cannot tell code from prose is measuring the wrong thing.
+
+def _root_line(text: str) -> int:
+    """The line that ASSIGNS a repo root from `rev-parse --show-toplevel`.
+
+    🔴 Comment lines are skipped, and an assignment (`…ROOT=`) is required on
+    the line. The first version matched any mention of the phrase and therefore
+    matched GUARD 9's own explanatory COMMENT — which sits above the assignment,
+    so all runners reported "clears AFTER ROOT" while being correctly ordered.
+    A parser that cannot tell code from prose is measuring the wrong thing.
     """
     for i, line in enumerate(text.splitlines(), 1):
         stripped = line.strip()
@@ -232,10 +323,10 @@ def test_every_runner_clears_BEFORE_it_resolves_its_root(runner):
     """🔴 ORDER, not merely presence — and this is a MEASURED requirement, not a
     tidiness preference.
 
-    All three runners resolve their root with
-    `git -C "$(dirname "$0")" rev-parse --show-toplevel`. With GIT_DIR set and
-    no GIT_WORK_TREE, git takes the CWD as the top of the work tree, so that
-    returns `<repo>/scripts`; the runner then looks for
+    All four entry points resolve a root with
+    `git … rev-parse --show-toplevel`. With GIT_DIR set and no GIT_WORK_TREE,
+    git takes the CWD as the top of the work tree, so that returns
+    `<repo>/scripts`; the runner then looks for
     `<repo>/scripts/scripts/run-tests.sh` and exits 127 having produced NO
     verdict line. Found by running the gate end-to-end with a poisoned GIT_DIR —
     the first placement of this guard was *after* the ROOT block and the whole
@@ -251,16 +342,21 @@ def test_every_runner_clears_BEFORE_it_resolves_its_root(runner):
     assert root > 0, f"{runner.name} has no `rev-parse --show-toplevel` line to order against"
     assert clear < root, (
         f"{runner.name} clears the git repo pointers at line {clear}, AFTER it "
-        f"resolves ROOT at line {root}. An inherited GIT_DIR then makes ROOT "
-        f"`<repo>/scripts` and the run dies exit 127 with no verdict."
+        f"resolves its root at line {root}. An inherited GIT_DIR then makes that "
+        f"root `<repo>/scripts` and the run dies exit 127 with no verdict."
     )
 
 
 def test_every_pytest_target_gets_the_detector():
     """`-p testlib.gitenv_plugin` must sit on the ONE pytest line, beside GUARD
     7's and GUARD 8's. `scripts/run-tests.sh` runs one pytest process per target
-    and there are seventeen of them; a plugin registered from a conftest reaches
-    one directory (that is #399's and #614's measured failure, twice)."""
+    and there are two dozen of them; a plugin registered from a conftest reaches
+    one directory (that is #399's and #614's measured failure, twice).
+
+    🔴 The target COUNT is deliberately not written down here. #683 said
+    "seventeen" while `--check-targets` listed 25 — a number nobody re-derives
+    is a claim that rots, and the assertion never depended on it.
+    """
     text = re.sub(r"\\\n\s*", " ", RUN_TESTS.read_text(encoding="utf-8"))
     pytest_lines = [ln for ln in text.splitlines()
                     if "python -m pytest" in ln and "$d" in ln]
@@ -272,9 +368,57 @@ def test_every_pytest_target_gets_the_detector():
         )
 
 
-def test_the_scripts_tests_conftest_is_the_second_entry_point():
-    """A bare `pytest scripts/tests` outside the runner must get the same guard
-    — by the same module, not a second copy of the logic.
+# --------------------------------------------------------------------------- #
+# 1b. THE SECOND ENTRY POINT — a LEDGER of conftests, not one example
+# --------------------------------------------------------------------------- #
+# 🔴 #683 wired ONE of seven, and not the one `gitenv_plugin`'s own rationale
+# cites: `scripts/claude-hooks/tests/` holds `test_bash_guard.py::_mkrepo` and
+# `test_guard_core.py`'s module-scoped repos, which build real git repositories
+# during COLLECTION. Pinning one example is a guard that cannot notice the other
+# six, or the eighth. claude/RULES.md → "an asserted ledger of every writer,
+# failing when the set GROWS *or* SHRINKS".
+_PINNED_CONFTESTS = (
+    "scripts/browser-bridge/tests/conftest.py",
+    "scripts/claude-hooks/tests/conftest.py",
+    "scripts/dl-router/tests/conftest.py",
+    "scripts/repo-cos/tests/conftest.py",
+    "scripts/session-analysis/session_insight/tests/conftest.py",
+    "scripts/signal/tests/conftest.py",
+    "scripts/tests/conftest.py",
+)
+
+# What pytest actually acts on. A conftest that re-exports these IS a second
+# entry point; one that merely mentions the module's name is not.
+_ENTRY_POINT_ATTRS = ("_devrc_git_repo_isolation", "pytest_collection_finish",
+                      "pytest_configure", "pytest_runtest_logstart",
+                      "pytest_sessionfinish")
+
+
+def _discovered_conftests() -> tuple[str, ...]:
+    return tuple(sorted(p.relative_to(ROOT).as_posix()
+                        for p in SCRIPTS.rglob("conftest.py")
+                        if "__pycache__" not in p.parts))
+
+
+def test_the_conftest_entry_points_are_a_pinned_ledger():
+    """🔴 FAILS WHEN THE SET GROWS *OR* SHRINKS. A new test directory arrives
+    with a new conftest; without this, it silently joins the population of
+    directories a bare `pytest <dir>` can poison."""
+    found = _discovered_conftests()
+    assert found == _PINNED_CONFTESTS, (
+        "the set of conftests under scripts/ changed.\n"
+        f"  new     : {sorted(set(found) - set(_PINNED_CONFTESTS))}\n"
+        f"  removed : {sorted(set(_PINNED_CONFTESTS) - set(found))}\n"
+        "Add GUARD 9's second-entry-point block to any new one (copy it from "
+        "scripts/tests/conftest.py) and update _PINNED_CONFTESTS in the same "
+        "commit."
+    )
+
+
+@pytest.mark.parametrize("rel", _PINNED_CONFTESTS)
+def test_every_conftest_is_a_second_entry_point(rel):
+    """A bare `pytest <dir>` outside the runner must get the same guard — by the
+    same module, not a second copy of the logic.
 
     🔴 STRUCTURAL, NOT SPELLED. The first version of this test grepped the
     conftest for the strings `testlib.gitenv_plugin` and
@@ -285,21 +429,45 @@ def test_the_scripts_tests_conftest_is_the_second_entry_point():
     """
     import importlib.util
 
-    from testlib import gitenv_plugin
-
-    spec = importlib.util.spec_from_file_location("_devrc_conftest_probe", CONFTEST)
+    path = ROOT / rel
+    spec = importlib.util.spec_from_file_location(
+        f"_devrc_conftest_probe_{abs(hash(rel))}", path)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    for attr in ("_devrc_git_repo_isolation", "pytest_collection_finish",
-                 "pytest_sessionfinish"):
+    for attr in _ENTRY_POINT_ATTRS:
         got = getattr(module, attr, None)
         assert got is getattr(gitenv_plugin, attr), (
-            f"scripts/tests/conftest.py does not re-export `{attr}` from "
-            "testlib.gitenv_plugin, so a bare `pytest scripts/tests` runs "
-            f"without that half of GUARD 9 (found: {got!r})"
+            f"{rel} does not re-export `{attr}` from testlib.gitenv_plugin, so "
+            f"a bare `pytest {Path(rel).parent}` runs without that half of "
+            f"GUARD 9 (found: {got!r})"
         )
+
+
+def test_pytest_configure_IS_called_for_a_collected_directorys_conftest(tmp_path):
+    """🔴 THE CLAIM THIS REPLACES WAS FALSE AND COST REAL COVERAGE.
+
+    `scripts/tests/conftest.py` carried a comment asserting pytest does not call
+    `pytest_configure` for a conftest loaded during collection, and therefore
+    deliberately did NOT re-export it — which cost the second entry point the
+    session marker, i.e. the run's only evidence the guard loaded at all.
+    Measured here rather than asserted: it IS called.
+    """
+    d = tmp_path / "probe"
+    d.mkdir()
+    (d / "conftest.py").write_text(
+        'def pytest_configure(config):\n'
+        '    print("CONFTEST_CONFIGURE_RAN")\n', encoding="utf-8")
+    (d / "test_probe.py").write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", str(d), "-q", "-s", "-p", "no:cacheprovider",
+         "--no-header"],
+        capture_output=True, text=True, env=_env(), cwd=str(d))
+    assert "CONFTEST_CONFIGURE_RAN" in proc.stdout, (
+        "pytest_configure was NOT called for a collected directory's conftest — "
+        "the comment this test replaces would then have been right, and "
+        f"scripts/tests/conftest.py must stop importing it.\n{proc.stdout}")
 
 
 # --------------------------------------------------------------------------- #
@@ -308,56 +476,353 @@ def test_the_scripts_tests_conftest_is_the_second_entry_point():
 # `githooks/pre-push` did exactly this: `GIT_DIR="$(git rev-parse --git-dir)"`.
 # In bash, assigning to an ALREADY-EXPORTED name keeps it exported, so that line
 # hands this repository's git dir to `tests-on-push.sh` -> `run-tests.sh` ->
-# pytest whenever a caller has GIT_DIR in the environment. A concrete route from
-# `git push` to the incident, and invisible to every test that existed.
-_SHELL_SCRIPTS = ("githooks", "scripts")
+# pytest whenever a caller has GIT_DIR in the environment.
+#
+# 🔴 THE SCAN CLAIMED MORE THAN IT DID, BOTH WAYS (finding E of #683's audit).
+# It walked `*.sh` plus extensionless files whose PARENT was literally named
+# `githooks`, so it missed twelve extensionless bash scripts under `scripts/`,
+# everything under `nix/` — where an `envExtra`/`shellHook` export would poison
+# every shell this operator opens, the likeliest real source of all — and
+# `githooks/<subdir>/*`. Its regex missed `declare -x`, `typeset -x`,
+# `readonly`, a second statement on a line (`foo; GIT_DIR=…`), and
+# `export GIT_DIR` with NO `=`, which is precisely the already-exported-name
+# mechanism the whole rationale rests on. And it FALSE-POSITIVED on the harmless
+# `GIT_INDEX_FILE=$t git add …` command-prefix idiom, which does not export
+# anything.
+_SHELL_ROOTS = ("githooks", "scripts", "nix")
+_SHELL_SUFFIXES = {".sh", ".bash", ".zsh", ".nix"}
+_SKIP_DIRS = {".git", "node_modules", "__pycache__", "result", "dist", "build",
+              ".direnv", ".pytest_cache"}
+_SHEBANG = re.compile(rb"\b(ba|z|da|k)?sh\b")
+
+_KEYWORDS = re.compile(r"^(?:export|readonly|local|declare|typeset)(?:\s+-\w+)*\s+")
+_POINTER_NAMES = "|".join(REPO_POINTER_VARS)
+_ASSIGN = re.compile(r"^(" + _POINTER_NAMES + r")=")
+_BARE = re.compile(r"^(" + _POINTER_NAMES + r")(?:\[[^\]]*\])?$")
+# For `.nix`, where the shell lives inside a nix string literal on one line
+# (`envExtra = "export GIT_DIR=/x";`) the shell tokeniser sees one quoted blob.
+# An EXPORT keyword is the only shape that can poison a child from there — a
+# bare assignment in `envExtra` writes an unexported `.zshenv` line — so this is
+# a narrow raw-text pattern, not a second general parser.
+_NIX_EXPORT = re.compile(
+    r"(?:export|declare\s+-x|typeset\s+-x)\s+(" + _POINTER_NAMES + r")\b")
 
 
 def _shell_files() -> list[Path]:
     out: list[Path] = []
-    for rel in _SHELL_SCRIPTS:
+    for rel in _SHELL_ROOTS:
         base = ROOT / rel
         if not base.is_dir():
             continue
         for p in sorted(base.rglob("*")):
-            if not p.is_file():
+            if any(part in _SKIP_DIRS for part in p.relative_to(ROOT).parts):
                 continue
-            if p.suffix == ".sh" or (p.parent.name == "githooks" and p.suffix == ""):
+            if p.is_symlink() or not p.is_file():
+                continue
+            if p.suffix in _SHELL_SUFFIXES:
                 out.append(p)
+                continue
+            if p.suffix == "":
+                try:
+                    head = p.open("rb").readline(200)
+                except OSError:
+                    continue
+                if head.startswith(b"#!") and _SHEBANG.search(head):
+                    out.append(p)
     return out
 
 
+def _strip_comment(line: str) -> str:
+    """Drop a trailing `#` comment, respecting quotes. Cutting too eagerly can
+    only cause a MISS, never a false positive, so ambiguity is resolved toward
+    keeping text."""
+    out: list[str] = []
+    quote: str | None = None
+    i = 0
+    while i < len(line):
+        c = line[i]
+        if quote:
+            if c == quote:
+                quote = None
+            elif c == "\\" and quote == '"':
+                out.append(c)
+                i += 1
+                if i < len(line):
+                    out.append(line[i])
+                    i += 1
+                continue
+        elif c in "'\"":
+            quote = c
+        elif c == "#" and (not out or out[-1].isspace()):
+            break
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def _statements(line: str) -> list[str]:
+    """Split a line into shell statements on unquoted `;`, `&&`, `||`, `|`."""
+    parts: list[str] = []
+    buf: list[str] = []
+    quote: str | None = None
+    depth = 0
+    i = 0
+    while i < len(line):
+        c = line[i]
+        if quote:
+            buf.append(c)
+            if c == quote:
+                quote = None
+            i += 1
+            continue
+        if c in "'\"":
+            quote = c
+            buf.append(c)
+            i += 1
+            continue
+        if line.startswith("$(", i) or line.startswith("${", i):
+            depth += 1
+            buf.append(line[i:i + 2])
+            i += 2
+            continue
+        if c in ")}" and depth:
+            depth -= 1
+            buf.append(c)
+            i += 1
+            continue
+        if depth == 0 and c in ";&|":
+            parts.append("".join(buf))
+            buf = []
+            while i < len(line) and line[i] in ";&|":
+                i += 1
+            continue
+        buf.append(c)
+        i += 1
+    parts.append("".join(buf))
+
+    out: list[str] = []
+    for part in parts:
+        part = part.strip()
+        for kw in ("then ", "do ", "else ", "{ ", "( "):
+            while part.startswith(kw):
+                part = part[len(kw):].strip()
+        if part:
+            out.append(part)
+    return out
+
+
+def _is_a_command_prefix(rest: str) -> bool:
+    """`NAME=value cmd …` scopes the assignment to that ONE command.
+
+    It does not export anything and cannot reach the runner, so flagging it was
+    a false positive — and this idiom is used deliberately in this repo
+    (`GIT_INDEX_FILE=$t git add …`).
+    """
+    quote: str | None = None
+    depth = 0
+    i = 0
+    while i < len(rest):
+        c = rest[i]
+        if quote:
+            if c == quote:
+                quote = None
+            i += 1
+            continue
+        if c in "'\"":
+            quote = c
+            i += 1
+            continue
+        if rest.startswith("$(", i) or rest.startswith("${", i):
+            depth += 1
+            i += 2
+            continue
+        if c in ")}" and depth:
+            depth -= 1
+            i += 1
+            continue
+        if depth == 0 and c.isspace():
+            return rest[i:].strip() != ""
+        i += 1
+    return False
+
+
+def pointer_assignments(text: str, *, nix: bool = False) -> list[tuple[int, str, str]]:
+    """`(line, variable, statement)` for every shape that EXPORTS a repo pointer."""
+    hits: list[tuple[int, str, str]] = []
+    for lineno, raw in enumerate(text.splitlines(), 1):
+        line = _strip_comment(raw)
+        if not line.strip():
+            continue
+        for stmt in _statements(line):
+            keyword = _KEYWORDS.match(stmt)
+            body = stmt[keyword.end():].strip() if keyword else stmt
+            assign = _ASSIGN.match(body)
+            if assign:
+                if keyword is None and _is_a_command_prefix(body[assign.end():]):
+                    continue
+                hits.append((lineno, assign.group(1), stmt))
+                continue
+            first = body.split()[0] if body.split() else ""
+            if keyword and _BARE.match(first):
+                hits.append((lineno, first, stmt))
+        if nix:
+            for m in _NIX_EXPORT.finditer(line):
+                if not any(h[0] == lineno and h[1] == m.group(1) for h in hits):
+                    hits.append((lineno, m.group(1), line.strip()))
+    return hits
+
+
 def test_the_shell_scan_sees_files_at_all():
-    """The positive control for the scan below. A zero from a walker that
-    matched nothing is indistinguishable from a clean repo."""
+    """The positive control for the walker. A zero from a walker that matched
+    nothing is indistinguishable from a clean repo — and #683's walker really
+    did miss whole classes it claimed to cover."""
     files = _shell_files()
-    assert len(files) >= 10, f"the shell-script walk found only {len(files)} files"
-    assert any(p.name == "pre-push" for p in files), (
+    rels = {p.relative_to(ROOT).as_posix() for p in files}
+    assert len(files) >= 50, f"the shell-script walk found only {len(files)} files"
+    assert "githooks/pre-push" in rels, (
         "githooks/pre-push is not in the scanned set — it is the file this "
-        "check exists for."
-    )
+        "check exists for.")
+    assert "githooks/tests-on-push.sh" in rels
+    assert any(r.startswith("nix/") for r in rels), (
+        "nothing under nix/ is scanned. An `envExtra`/`shellHook` export lands "
+        "in every shell the operator opens, which makes it the likeliest real "
+        "source of an ambient GIT_DIR — and #683's scan could not see it.")
+    extensionless = [r for r in rels if "." not in Path(r).name]
+    assert len(extensionless) >= 5, (
+        "the walk found almost no extensionless scripts; #683's version keyed "
+        f"on the parent directory's NAME and missed twelve of them: {sorted(extensionless)}")
+
+
+@pytest.mark.parametrize("snippet", [
+    'GIT_DIR="$(git rev-parse --git-dir)"',
+    'export GIT_DIR=/x',
+    'export GIT_DIR',                        # 🔴 no `=`: THE mechanism
+    '  export   GIT_COMMON_DIR',
+    'declare -x GIT_DIR=/x',
+    'typeset -x GIT_WORK_TREE=/x',
+    'readonly GIT_INDEX_FILE=/x',
+    'local GIT_NAMESPACE=/x',
+    'foo; GIT_DIR=/x',
+    'cd /elsewhere && GIT_DIR=/x',
+    'if true; then GIT_DIR=/x; fi',
+])
+def test_the_pointer_scan_catches_every_export_shape(snippet):
+    """🔴 THE NEGATIVE CONTROL FOR THE SCANNER ITSELF (claude/RULES.md →
+    "validate the INSTRUMENT before you read its verdict"). Every one of these
+    was invisible to #683's regex, which anchored on `^[ \\t]*(export )?NAME=`.
+    A scanner that cannot go red on the mechanism its own rationale names is
+    reporting a fact about the scanner."""
+    assert pointer_assignments(snippet), f"the scan did not flag: {snippet!r}"
+
+
+@pytest.mark.parametrize("snippet", [
+    'GIT_INDEX_FILE="$t" git add -- f.txt',  # command-scoped prefix: harmless
+    'GIT_INDEX_FILE=$t git add x',
+    '# GIT_DIR="$(git rev-parse --git-dir)"',
+    '  GIT_DIR                            # inside an array literal',
+    'unset "${DEVRC_GIT_REPO_POINTERS[@]}"',
+    'echo "${GIT_DIR:-none}"',
+    'HOOK_GIT_DIR="$(git rev-parse --git-dir)"',
+    'GIT_DIR_SOMETHING=/x',
+    'GIT_CONFIG_GLOBAL=/x',                  # deliberately NOT a repo pointer
+])
+def test_the_pointer_scan_does_not_flag_harmless_shapes(snippet):
+    """The other half of the pair. A scanner that flags the command-prefix
+    idiom is a permanently-red gate over code that is correct — and this repo
+    uses that idiom on purpose."""
+    assert not pointer_assignments(snippet), (
+        f"the scan false-positived on: {snippet!r} -> {pointer_assignments(snippet)}")
+
+
+def test_the_nix_scan_catches_an_export_inside_a_one_line_nix_string():
+    """`programs.zsh.envExtra = "export GIT_DIR=…";` is shell inside a nix
+    string literal, on one line. The general shell tokeniser sees one quoted
+    blob, so `.nix` gets one extra narrow pattern."""
+    src = '  programs.zsh.envExtra = "export GIT_DIR=/x";\n'
+    assert not pointer_assignments(src), "sanity: the shell parser alone cannot see it"
+    assert pointer_assignments(src, nix=True), "the nix pattern missed it"
 
 
 def test_no_shell_script_that_can_reach_the_runner_assigns_a_git_repo_pointer():
-    pattern = re.compile(
-        r"^[ \t]*(?:export[ \t]+)?(" + "|".join(REPO_POINTER_VARS) + r")=", re.M)
     offenders: list[str] = []
     for path in _shell_files():
         try:
             text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        for m in pattern.finditer(text):
-            line = text[:m.start()].count("\n") + 1
-            offenders.append(f"{path.relative_to(ROOT)}:{line}: {m.group(1)}=")
+        for lineno, name, stmt in pointer_assignments(text, nix=path.suffix == ".nix"):
+            offenders.append(f"{path.relative_to(ROOT)}:{lineno}: {name}  ({stmt[:80]})")
     assert not offenders, (
-        "a shell script assigns to a git repo-pointer variable:\n  "
+        "a shell script assigns to (or exports) a git repo-pointer variable:\n  "
         + "\n  ".join(offenders)
         + "\n\nIn bash an assignment to an already-exported name STAYS exported, "
-          "so this hands a repository to every child process — including the test "
+          "and `export NAME` with no `=` exports whatever it already holds — so "
+          "this hands a repository to every child process, including the test "
           "runner, whose fixtures then build themselves inside it. Rename the "
           "variable (githooks/pre-push uses HOOK_GIT_DIR)."
     )
+
+
+def test_git_push_does_not_export_GIT_DIR_to_pre_push(tmp_path):
+    """🔴 THE CORRECTION, MEASURED, AS A PAIR — #683's body and commit message
+    both stated that `githooks/pre-push` handing down `GIT_DIR` explained why
+    *pushing* triggered the corruption, and that claim was relayed to another
+    session as established fact before it was checked.
+
+    A `git push` from a GIT_DIR-free parent gives `pre-push` only
+    `GIT_EXEC_PATH` and `GIT_PREFIX` (plus the caller's own identity/config
+    vars). The rename remains correct hygiene — an outer caller's exported
+    `GIT_DIR` really does survive a reassignment — but it is NOT the diagnosis,
+    and the root cause of the incident is still unknown.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    gitconfig = home / "gitconfig"
+    gitconfig.write_text("[user]\n\tname = g9\n\temail = g9@example.invalid\n",
+                         encoding="utf-8")
+    base = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    base.update(_GIT_ENV)
+    base["GIT_CONFIG_GLOBAL"] = str(gitconfig)
+
+    bare = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(bare)], check=True,
+                   capture_output=True, env=base)
+    work = tmp_path / "work"
+    subprocess.run(["git", "init", "-q", "-b", "main", str(work)], check=True,
+                   capture_output=True, env=base)
+    (work / "f.txt").write_text("x\n", encoding="utf-8")
+    assert _git(work, "add", "f.txt", env=base).returncode == 0
+    assert _git(work, "commit", "-qm", "c1", env=base).returncode == 0
+    assert _git(work, "remote", "add", "origin", str(bare), env=base).returncode == 0
+
+    seen = tmp_path / "hookenv.txt"
+    hook = work / ".git" / "hooks" / "pre-push"
+    hook.write_text(
+        "#!/usr/bin/env bash\n"
+        f"env | grep -E '^GIT' | sort > {seen}\n"
+        "cat >/dev/null\nexit 0\n", encoding="utf-8")
+    hook.chmod(0o755)
+
+    assert _git(work, "push", "-q", "origin", "main", env=base).returncode == 0
+    names = {ln.split("=", 1)[0] for ln in seen.read_text(encoding="utf-8").splitlines()}
+    assert "GIT_EXEC_PATH" in names, f"the hook did not run as expected: {names}"
+    assert "GIT_DIR" not in names, (
+        "`git push` DID export GIT_DIR to pre-push on this git version — the "
+        "correction in gitenv.py's header and githooks/pre-push is now wrong "
+        f"and must be rewritten.\nsaw: {sorted(names)}")
+
+    # The other half: an outer caller's export DOES survive, which is what makes
+    # the rename worth keeping.
+    poisoned = dict(base)
+    poisoned["GIT_DIR"] = str(work / ".git")
+    (work / "f.txt").write_text("y\n", encoding="utf-8")
+    assert _git(work, "add", "f.txt", env=base).returncode == 0
+    assert _git(work, "commit", "-qm", "c2", env=base).returncode == 0
+    assert _git(work, "push", "-q", "origin", "main", env=poisoned).returncode == 0
+    names = {ln.split("=", 1)[0] for ln in seen.read_text(encoding="utf-8").splitlines()}
+    assert "GIT_DIR" in names, (
+        "an exported GIT_DIR did NOT reach pre-push, so the rename protects "
+        f"nothing and should be reconsidered.\nsaw: {sorted(names)}")
 
 
 # --------------------------------------------------------------------------- #
@@ -399,6 +864,64 @@ def test_the_live_environment_is_already_clean_under_this_guard():
 
 
 # --------------------------------------------------------------------------- #
+# 3b. 🔴 THE SEAMS REFUSE A VALUE THEY CANNOT HONOUR (finding B)
+# --------------------------------------------------------------------------- #
+def test_an_unset_protect_seam_means_discovery():
+    assert resolve_protect_env({}) is None
+
+
+def test_a_real_git_dir_on_the_protect_seam_is_honoured(tmp_path):
+    repo = _mkrepo(tmp_path / "repo")
+    got = resolve_protect_env({PROTECT_ENV: str(repo / ".git")})
+    assert got == [(repo / ".git").resolve()]
+
+
+@pytest.mark.parametrize("value,because", [
+    (":", "splits to NOTHING — measured `protected-git-dirs=0` and a GREEN run "
+          "over a real escape"),
+    ("", "set but empty"),
+    ("   ", "whitespace only"),
+])
+def test_a_protect_seam_that_names_no_path_is_a_LOUD_failure(value, because):
+    with pytest.raises(GitEnvConfigError) as excinfo:
+        resolve_protect_env({PROTECT_ENV: value})
+    assert PROTECT_ENV in str(excinfo.value), because
+
+
+def test_a_protect_seam_naming_an_unresolvable_path_is_a_LOUD_failure(tmp_path):
+    """🔴 THE WORST OF THE THREE. On #683's code this produced
+    `protected-git-dirs=1` — a marker line asserting healthy coverage — while
+    the detector watched a path that cannot hold a repository and the escaping
+    test really created its branch. A guard is allowed to fail; it is not
+    allowed to report coverage it does not have."""
+    for bad in (str(tmp_path / "nonexistent" / "x"), str(tmp_path)):
+        with pytest.raises(GitEnvConfigError) as excinfo:
+            resolve_protect_env({PROTECT_ENV: bad})
+        assert "not a git dir" in str(excinfo.value) or "cannot resolve" in str(excinfo.value)
+
+
+def test_a_protect_seam_with_one_good_and_one_bad_path_still_fails(tmp_path):
+    """Partial credit is how a detector ends up watching half of what its marker
+    line claims."""
+    repo = _mkrepo(tmp_path / "repo")
+    with pytest.raises(GitEnvConfigError):
+        resolve_protect_env(
+            {PROTECT_ENV: os.pathsep.join([str(repo / ".git"), "/nonexistent/x"])})
+
+
+@pytest.mark.parametrize("value", ["enfore", "ENFORCE ", "1", "yes", "off"])
+def test_an_unknown_mode_is_a_LOUD_failure(value):
+    with pytest.raises(GitEnvConfigError):
+        requested_mode({MODE_ENV: value})
+
+
+def test_the_known_modes_round_trip():
+    assert requested_mode({}) == "auto"
+    for mode in ("auto", "enforce", "report"):
+        assert requested_mode({MODE_ENV: mode}) == mode
+
+
+# --------------------------------------------------------------------------- #
 # 4. THE DETECTOR, as a unit — it must MOVE, and it must stay still
 # --------------------------------------------------------------------------- #
 def test_the_detector_observes_nothing_when_nothing_happens(tmp_path):
@@ -416,13 +939,19 @@ def test_the_detector_observes_nothing_when_nothing_happens(tmp_path):
     (("config", "user.name", "T"), "config"),
     (("config", "core.hooksPath", "/tmp/elsewhere"), "config"),
     (("remote", "add", "origin", "/tmp/nowhere.git"), "config"),
+    # 🔴 A REAL HEAD-MOVE ROW. #683's docstring claimed one ("HEAD moves … lands
+    # in one of these") and every row was a ref-create or a config write; the
+    # incident repointed HEAD at `trunk`, and `symbolic-ref` is that, with no
+    # ref of its own moving.
+    (("symbolic-ref", "HEAD", "refs/heads/other"), "HEAD"),
 ])
 def test_the_detector_moves_for_every_damage_class_from_the_incident(
         tmp_path, mutation, expect):
     """🔴 REPORTED BESIDE THE NO-OP CONTROL ABOVE. Each row is a shape that was
-    actually found in the operator's clone: a branch create, a HEAD move, a
+    actually found in the operator's clone: a branch create, a HEAD repoint, a
     `user.name`, a `core.hooksPath`, a rewritten remote URL."""
     repo = _mkrepo(tmp_path / "repo")
+    assert _git(repo, "branch", "-q", "other").returncode == 0
     git_dir = resolve_git_dir(repo)
     before = snapshot([git_dir])
     assert _git(repo, *mutation).returncode == 0
@@ -430,6 +959,93 @@ def test_the_detector_moves_for_every_damage_class_from_the_incident(
     assert deltas, f"the detector did not see `git {' '.join(mutation)}`"
     assert any(expect in d for d in deltas), (
         f"expected a delta naming {expect!r}, got:\n" + "\n".join(deltas))
+
+
+# --------------------------------------------------------------------------- #
+# 4b. 🔴 EVERY FINGERPRINT COMPONENT IS LOAD-BEARING (finding C)
+# --------------------------------------------------------------------------- #
+# #683 mutation-swept the PLUMBING and not the CONTENT, and five semantic
+# mutants survived a fully green suite: dropping `HEAD`, dropping `packed-refs`,
+# dropping `ORIG_HEAD`+`logs/HEAD`, and reducing `starts` to either root alone.
+# "The detector noticed something" is satisfied by ANY surviving component, so
+# each row below is a mutation that ONLY the named component can see — measured
+# with `git` itself, not asserted.
+_COMPONENT_ROWS = (
+    # (component, setup, mutation, must-appear-in-a-delta)
+    ("config", (), ("config", "user.name", "T"), "config"),
+    ("HEAD", (("branch", "-q", "other"),), ("symbolic-ref", "HEAD", "refs/heads/other"), "HEAD"),
+    ("ORIG_HEAD", (), ("reset", "-q", "HEAD"), "ORIG_HEAD"),
+    ("refs (loose)", (), ("branch", "-q", "side"), "refs/heads/side"),
+    # 🔴 THE INCIDENT'S WORST ACT, on a repo whose refs are PACKED — which is
+    # every repo `git gc` has touched. #683 never packed refs in any fixture, so
+    # deleting `packed-refs` from the fingerprint survived while
+    # `DELETED refs/heads/main` is exactly what happened.
+    ("refs (packed)", (("branch", "-q", "doomed"), ("pack-refs", "--all")),
+     ("branch", "-q", "-D", "doomed"), "refs/heads/doomed"),
+)
+
+
+@pytest.mark.parametrize("component,setup,mutation,expect",
+                         _COMPONENT_ROWS, ids=[r[0] for r in _COMPONENT_ROWS])
+def test_every_fingerprint_component_is_load_bearing(
+        tmp_path, component, setup, mutation, expect):
+    """🔴 ISOLATED: the delta must name THIS component and nothing else, so the
+    row dies when this component is dropped and cannot be kept alive by a
+    neighbour (claude/RULES.md → "a mutant that dies for the wrong reason proves
+    nothing about the guard")."""
+    repo = _mkrepo(tmp_path / "repo")
+    for cmd in setup:
+        assert _git(repo, *cmd).returncode == 0, cmd
+    git_dir = resolve_git_dir(repo)
+    before = snapshot([git_dir])
+    assert _git(repo, *mutation).returncode == 0, mutation
+    deltas = diff_snapshots(before, snapshot([git_dir]))
+    assert deltas, (
+        f"nothing in the fingerprint moved for `git {' '.join(mutation)}` — the "
+        f"{component} component is not being read at all")
+    assert all(expect in d for d in deltas), (
+        f"the {component} row is not isolated: some delta does not name "
+        f"{expect!r}, so dropping {component} could still leave this test "
+        "green.\n" + "\n".join(deltas))
+
+
+def test_repacking_refs_is_NOT_reported_as_damage(tmp_path):
+    """🔴 THE FALSE-POSITIVE CLASS THAT MADE THIS A PERMANENTLY-RED GATE.
+
+    `git gc` / `git pack-refs` move every loose ref into `packed-refs`. The
+    repository's CONTENT is unchanged; #683's fingerprint hashed the loose ref
+    FILES, so it emitted one `DELETED refs/…` line per branch — on the
+    operator's clone, hundreds — under a banner announcing the incident had
+    recurred. `drift-check.sh` runs `git fetch` against that clone on a 6-hourly
+    systemd timer and its own comment records that `fetch` triggers `gc --auto`,
+    so this fired on a schedule.
+    """
+    repo = _mkrepo(tmp_path / "repo")
+    for name in ("a", "b", "c", "d", "e"):
+        assert _git(repo, "branch", "-q", name).returncode == 0
+    git_dir = resolve_git_dir(repo)
+    before = snapshot([git_dir])
+    assert _git(repo, "pack-refs", "--all").returncode == 0
+    assert (git_dir / "packed-refs").is_file(), "the fixture did not actually pack"
+    assert not (git_dir / "refs" / "heads" / "a").exists(), "loose ref survived the pack"
+    assert diff_snapshots(before, snapshot([git_dir])) == [], (
+        "packing refs was reported as damage — the fingerprint is reading ref "
+        "FILES rather than ref VALUES")
+    # …and the values really were read, not merely skipped.
+    assert ref_values(git_dir)["refs/heads/a"], "packed refs are invisible to ref_values"
+
+
+def test_gc_is_not_reported_as_damage(tmp_path):
+    """The same claim end-to-end, through the command that actually runs on the
+    timer."""
+    repo = _mkrepo(tmp_path / "repo")
+    for name in ("a", "b", "c"):
+        assert _git(repo, "branch", "-q", name).returncode == 0
+    git_dir = resolve_git_dir(repo)
+    before = snapshot([git_dir])
+    assert _git(repo, "gc", "-q", "--prune=now").returncode == 0
+    assert diff_snapshots(before, snapshot([git_dir])) == [], (
+        "`git gc` was reported as damage")
 
 
 def test_the_detector_sees_a_branch_DELETION(tmp_path):
@@ -464,6 +1080,81 @@ def test_the_detector_covers_a_WORKTREE_via_its_common_dir(tmp_path):
     assert any("made-from-the-worktree" in d for d in deltas), (
         "a ref created from a worktree was invisible — the common dir is not "
         "being watched:\n" + "\n".join(deltas))
+
+
+# --------------------------------------------------------------------------- #
+# 4c. 🔴 BOTH DISCOVERY ROOTS ARE LOAD-BEARING (finding C)
+# --------------------------------------------------------------------------- #
+# `protected_git_dirs` starts from `[Path.cwd(), Path(__file__).parent]` under a
+# comment reading "both are needed". That was a necessity claim with zero
+# coverage: reducing the list to EITHER root alone survived the whole suite.
+def test_the_cwd_root_is_load_bearing(tmp_path, monkeypatch):
+    """Kills the `starts = [Path(__file__)]` mutant. A runner invoked from a
+    DIFFERENT repository than the one holding gitenv.py — a nested checkout, a
+    worktree, `pytest` run from anywhere — is protected only by the cwd root."""
+    monkeypatch.delenv(PROTECT_ENV, raising=False)
+    other = _mkrepo(tmp_path / "elsewhere")
+    monkeypatch.chdir(other)
+    dirs = protected_git_dirs()
+    assert (other / ".git").resolve() in dirs, (
+        "the repository the suite is RUNNING IN was not discovered — dropping "
+        f"Path.cwd() from `starts` would be invisible.\nfound: {dirs}")
+
+
+def test_the_module_root_is_load_bearing(tmp_path, monkeypatch):
+    """Kills the `starts = [Path.cwd()]` mutant. Every nested control in this
+    file runs pytest with `cwd` in a tmp dir that is not a repository at all; so
+    does any `pytest` launched from `/tmp`. This repo is then protected only by
+    the module root."""
+    monkeypatch.delenv(PROTECT_ENV, raising=False)
+    outside = tmp_path / "not-a-repo"
+    outside.mkdir()
+    monkeypatch.chdir(outside)
+    dirs = protected_git_dirs()
+    devrc_git_dir = resolve_git_dir(Path(gitenv.__file__).resolve().parent)
+    assert devrc_git_dir is not None, "gitenv.py is not inside a git checkout"
+    assert devrc_git_dir in dirs, (
+        "this checkout was not discovered from a cwd outside any repository — "
+        f"dropping Path(__file__) from `starts` would be invisible.\nfound: {dirs}")
+
+
+# --------------------------------------------------------------------------- #
+# 4d. 🔴 THE CO-TENANT PROBE (finding A)
+# --------------------------------------------------------------------------- #
+def test_live_cotenants_sees_another_process_in_the_repo(tmp_path):
+    """The POSITIVE control. Without it, an empty co-tenant list is
+    indistinguishable from a probe wired to nothing — and an empty list is what
+    puts the detector in ENFORCE mode."""
+    _require_proc()
+    repo = _mkrepo(tmp_path / "repo")
+    git_dir = resolve_git_dir(repo)
+    assert live_cotenants([git_dir]) == [], "a brand-new tmp repo already has tenants?"
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"],
+                            cwd=str(repo), stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL)
+    try:
+        # The child's cwd is set by Popen before exec, so it is already visible.
+        found = live_cotenants([git_dir])
+        assert any(f.startswith(f"{proc.pid}:") for f in found), (
+            f"the co-tenant probe missed a live process in the repo: {found}")
+    finally:
+        proc.kill()
+        proc.wait(timeout=10)
+    assert live_cotenants([git_dir]) == [], (
+        "the probe still reports a tenant after it exited — it is not reading "
+        "live state")
+
+
+def test_live_cotenants_does_not_count_this_process(tmp_path, monkeypatch):
+    """We are always inside the repository we are watching. A probe that counted
+    itself would put every session in report mode, i.e. disable the detector
+    everywhere — the opposite failure to the one being fixed."""
+    _require_proc()
+    repo = _mkrepo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+    git_dir = resolve_git_dir(repo)
+    assert live_cotenants([git_dir]) == [], (
+        "the probe counted our own process (or an ancestor) as a co-tenant")
 
 
 # --------------------------------------------------------------------------- #
@@ -503,6 +1194,14 @@ def test_writes_where_it_should_not():
 _INNOCENT_TEST = '''
 def test_touches_nothing():
     assert 1 + 1 == 2
+
+
+def test_touches_nothing_either():
+    assert 2 + 2 == 4
+
+
+def test_still_nothing():
+    assert 3 + 3 == 6
 '''
 
 _IMPORT_TIME_MUTATOR = '''
@@ -520,11 +1219,34 @@ def test_placeholder():
     assert True
 '''
 
+# 🔴 A WRITER THAT RUNS WHEN NO TEST IS RUNNING. `pytest_runtest_logfinish` fires
+# after a test's setup, call AND teardown are complete and before the next
+# test's `logstart` — the window the idle probe watches. This is a DETERMINISTIC
+# stand-in for the dozens of concurrent sessions on the operator's box: same
+# observable (the repository moved while no test body was executing), no timing
+# race.
+_CONCURRENT_WRITER_CONFTEST = '''
+import os
+import subprocess
 
-def _nested_pytest(tmp_path, body: str, *, plugin: bool, env_extra: dict) -> subprocess.CompletedProcess:
+_n = [0]
+
+
+def pytest_runtest_logfinish(nodeid, location):
+    _n[0] += 1
+    subprocess.run(["git", "-C", os.environ["GUARD9_TARGET_REPO"],
+                    "branch", "-q", f"someone-elses-branch-{_n[0]}"],
+                   check=True, capture_output=True)
+'''
+
+
+def _nested_pytest(tmp_path, body: str, *, plugin: bool, env_extra: dict,
+                   conftest: str = "") -> subprocess.CompletedProcess:
     rootdir = tmp_path / "nested"
     rootdir.mkdir(exist_ok=True)
     (rootdir / "test_nested.py").write_text(body, encoding="utf-8")
+    if conftest:
+        (rootdir / "conftest.py").write_text(conftest, encoding="utf-8")
     argv = [sys.executable, "-m", "pytest", str(rootdir / "test_nested.py"),
             "-q", "-p", "no:cacheprovider"]
     if plugin:
@@ -575,7 +1297,7 @@ def test_with_GUARD_9_the_same_fixture_leaves_the_ambient_repo_alone(tmp_path):
     # standing evidence is the nested run's own green plus the marker below.
     assert "1 passed" in proc.stdout, (
         f"the fixture did not actually run to completion:\n{proc.stdout}")
-    assert "gitenv(session)" in proc.stdout, (
+    assert SESSION_MARKER in proc.stdout, (
         "the guard did not announce itself; this run may not have loaded it at "
         f"all:\n{proc.stdout}"
     )
@@ -585,11 +1307,18 @@ def test_the_detector_fails_the_test_that_moved_a_ref(tmp_path):
     """🔴 REACHABILITY, not merely breakability. The nested test writes by
     ABSOLUTE PATH, so the environment strip is bypassed and the ONLY thing that
     can go red is the detector. Asserted by this guard's own token, so a failure
-    from some neighbouring check cannot be scored as a kill."""
+    from some neighbouring check cannot be scored as a kill.
+
+    `MODE_ENV` is pinned to `enforce` so the verdict cannot depend on how busy
+    the host happens to be while the suite runs — under `auto` a co-tenant in
+    the *outer* checkout would (correctly) downgrade this run and the control
+    would measure the mode, not the detector.
+    """
     ambient = _mkrepo(tmp_path / "ambient")
     proc = _nested_pytest(
         tmp_path, _ABSOLUTE_PATH_MUTATOR, plugin=True,
         env_extra={PROTECT_ENV: str(ambient / ".git"),
+                   MODE_ENV: MODE_ENFORCE,
                    "GUARD9_TARGET_REPO": str(ambient)})
     out = proc.stdout + proc.stderr
     assert proc.returncode != 0, f"the detector stayed green on a real escape:\n{out}"
@@ -608,11 +1337,12 @@ def test_the_detector_is_silent_on_a_test_that_touches_nothing(tmp_path):
     ambient = _mkrepo(tmp_path / "ambient")
     proc = _nested_pytest(
         tmp_path, _INNOCENT_TEST, plugin=True,
-        env_extra={PROTECT_ENV: str(ambient / ".git")})
+        env_extra={PROTECT_ENV: str(ambient / ".git"), MODE_ENV: MODE_ENFORCE})
     out = proc.stdout + proc.stderr
     assert proc.returncode == 0, f"a harmless test was failed by GUARD 9:\n{out}"
     assert VIOLATION_TOKEN not in out, out
-    assert "1 passed" in out, out
+    assert OBSERVED_MARKER not in out, out
+    assert "3 passed" in out, out
 
 
 def test_the_detector_catches_damage_done_at_IMPORT_time(tmp_path):
@@ -623,6 +1353,7 @@ def test_the_detector_catches_damage_done_at_IMPORT_time(tmp_path):
     proc = _nested_pytest(
         tmp_path, _IMPORT_TIME_MUTATOR, plugin=True,
         env_extra={PROTECT_ENV: str(ambient / ".git"),
+                   MODE_ENV: MODE_ENFORCE,
                    "GUARD9_TARGET_REPO": str(ambient)})
     out = proc.stdout + proc.stderr
     assert proc.returncode != 0, f"import-time damage went unnoticed:\n{out}"
@@ -630,18 +1361,190 @@ def test_the_detector_catches_damage_done_at_IMPORT_time(tmp_path):
     assert "escaped-at-import" in out, out
     assert "collection" in out, (
         f"the violation was not attributed to collection:\n{out}")
+    # 🔴 AND IT MUST NOT BE AN INTERNALERROR. `pytest.fail` raised from a HOOK
+    # crashes pytest: exit 3, zero tests run, the message buried under
+    # `INTERNALERROR>`. Measured on #683's code — a NEIGHBOUR's `git branch`
+    # landing during collection took the whole suite down that way, which is
+    # both a false positive and a total outage. `pytest.exit` reports the same
+    # verdict as a decision.
+    assert "INTERNALERROR" not in out, (
+        "a session-level violation crashed pytest instead of exiting cleanly:\n"
+        f"{out}")
+    assert proc.returncode == 1, (
+        f"expected a clean exit 1, got {proc.returncode} (3 = internal error)")
 
 
-def test_the_violation_message_names_the_remediation(tmp_path):
-    """A red gate whose message does not say what to do gets clicked through."""
+def test_the_violation_message_leads_with_the_other_writer_hypothesis(tmp_path):
+    """🔴 A red gate whose message does not say what to do gets clicked through
+    — and one whose FIRST sentence names the wrong cause is worse than that: it
+    misdirects during an incident.
+
+    #683's message opened *"test X MUTATED a git repository that is not its own
+    tmpdir … This is the 2026-08-21 incident's shape"*, at maximum confidence,
+    for any write by any of the dozens of concurrent sessions on that box. The
+    ordering is pinned, not just the presence of the words.
+    """
     ambient = _mkrepo(tmp_path / "ambient")
     proc = _nested_pytest(
         tmp_path, _ABSOLUTE_PATH_MUTATOR, plugin=True,
         env_extra={PROTECT_ENV: str(ambient / ".git"),
+                   MODE_ENV: MODE_ENFORCE,
                    "GUARD9_TARGET_REPO": str(ambient)})
     out = proc.stdout + proc.stderr
     assert "git reflog" in out, f"no recovery instruction in the failure:\n{out}"
     assert "GIT_DIR" in out, f"the failure does not name the known mechanism:\n{out}"
+    other = out.find("DID SOMETHING ELSE WRITE TO THIS REPOSITORY")
+    incident = out.find("2026-08-21")
+    assert other != -1, f"the other-writer hypothesis is not in the message:\n{out}"
+    assert incident != -1, f"the incident is no longer described at all:\n{out}"
+    assert other < incident, (
+        "the message still leads with the incident rather than with the most "
+        f"common cause:\n{out}")
+
+
+# --------------------------------------------------------------------------- #
+# 6. 🔴 ATTRIBUTION: a concurrent writer must not be blamed on a test
+# --------------------------------------------------------------------------- #
+def test_a_write_in_the_idle_window_is_NOT_blamed_on_a_test(tmp_path):
+    """🔴 THE FINDING-A REGRESSION TEST, and the reason #683 could not ship.
+
+    Measured on that code: an innocent nested test plus a background
+    `git branch` in the protected repo produced *"test
+    'test_d.py::test_innocent_one' MUTATED a git repository that is not its own
+    tmpdir … This is the 2026-08-21 incident's shape."* — a fail, naming an
+    innocent test, asserting the incident.
+
+    Here the write happens in `pytest_runtest_logfinish`, i.e. after a test's
+    setup/call/teardown are all complete and before the next test's `logstart`.
+    Nothing of the test protocol runs in that window, so the change is provably
+    not any test's — and the detector says so instead of failing.
+    """
+    ambient = _mkrepo(tmp_path / "ambient")
+    proc = _nested_pytest(
+        tmp_path, _INNOCENT_TEST, plugin=True,
+        conftest=_CONCURRENT_WRITER_CONFTEST,
+        env_extra={PROTECT_ENV: str(ambient / ".git"),
+                   "GUARD9_TARGET_REPO": str(ambient)})
+    out = proc.stdout + proc.stderr
+    assert "3 passed" in out, f"an innocent test was failed by a foreign write:\n{out}"
+    assert proc.returncode == 0, out
+    assert VIOLATION_TOKEN not in out, (
+        "a concurrent writer was still reported as a GUARD 9 violation — the "
+        f"exact permanently-red gate this replaces:\n{out}")
+    # 🔴 AND IT IS NOT SILENT. Downgrading to a quiet pass would trade a false
+    # positive for a blind spot; the delta is printed in full, with the reason.
+    assert FOREIGN_MARKER in out, (
+        f"the session never announced that it could not attribute:\n{out}")
+    assert OBSERVED_MARKER in out, (
+        f"the delta was swallowed instead of reported:\n{out}")
+    assert "someone-elses-branch" in out, (
+        f"the report does not name what moved:\n{out}")
+    assert "unattributed-observations=" in out, (
+        f"no session-end summary of what went unattributed:\n{out}")
+
+
+def test_the_same_run_without_the_foreign_writer_stays_fully_silent(tmp_path):
+    """The control for the test above: identical body and identical mode, minus
+    the writer. Without it, "no violation" would be satisfied by a detector that
+    had simply stopped working."""
+    ambient = _mkrepo(tmp_path / "ambient")
+    proc = _nested_pytest(
+        tmp_path, _INNOCENT_TEST, plugin=True,
+        env_extra={PROTECT_ENV: str(ambient / ".git"),
+                   "GUARD9_TARGET_REPO": str(ambient)})
+    out = proc.stdout + proc.stderr
+    assert proc.returncode == 0, out
+    assert "3 passed" in out, out
+    assert FOREIGN_MARKER not in out, (
+        f"a quiet repository was declared to have another writer:\n{out}")
+    assert OBSERVED_MARKER not in out, out
+
+
+def test_a_real_escape_is_still_reported_when_attribution_is_impossible(tmp_path):
+    """🔴 REPORT MODE IS NOT A BLIND SPOT. The same absolute-path escape, with
+    the mode pinned to `report`: it must still be seen and named, with the token
+    ABSENT so a reachability control cannot be satisfied by an unattributed
+    observation."""
+    ambient = _mkrepo(tmp_path / "ambient")
+    proc = _nested_pytest(
+        tmp_path, _ABSOLUTE_PATH_MUTATOR, plugin=True,
+        env_extra={PROTECT_ENV: str(ambient / ".git"),
+                   MODE_ENV: MODE_REPORT,
+                   "GUARD9_TARGET_REPO": str(ambient)})
+    out = proc.stdout + proc.stderr
+    assert proc.returncode == 0, f"report mode failed the run:\n{out}"
+    assert OBSERVED_MARKER in out, f"report mode saw nothing:\n{out}"
+    assert "escaped-branch" in out, f"report mode did not name the ref:\n{out}"
+    assert VIOLATION_TOKEN not in out, (
+        "report mode emitted the violation token, so a control asserting that "
+        f"token can pass without any attribution:\n{out}")
+
+
+def test_the_marker_line_reports_the_mode_and_why(tmp_path):
+    """The marker is the run's only evidence the guard loaded. A count of
+    protected dirs without the MODE is a number whose meaning changed: `mode=
+    report` and `mode=enforce` are different guarantees, and #683's marker
+    reported neither."""
+    ambient = _mkrepo(tmp_path / "ambient")
+    proc = _nested_pytest(
+        tmp_path, _INNOCENT_TEST, plugin=True,
+        env_extra={PROTECT_ENV: str(ambient / ".git"), MODE_ENV: MODE_ENFORCE})
+    line = next((ln for ln in proc.stdout.splitlines() if ln.startswith(SESSION_MARKER)), "")
+    assert line, f"no marker line at all:\n{proc.stdout}"
+    assert "protected-git-dirs=1" in line, line
+    assert f"mode={MODE_ENFORCE}" in line, line
+    assert "unattributable=0" in line, line
+
+
+# --------------------------------------------------------------------------- #
+# 6b. THE SETTLE RE-READ, as a unit
+# --------------------------------------------------------------------------- #
+def test_a_repo_that_keeps_moving_is_declared_foreign_before_anything_fails(monkeypatch):
+    """🔴 "RE-READ BEFORE YOU FAIL." Driven at the unit level because the
+    behaviour under test is a TIMING one — a repository still being written
+    while we look at it — and a real concurrent writer would make this test a
+    race. The snapshots are a fixed sequence, so the outcome is deterministic.
+
+    A different value each time means the repo never settles; the plugin must
+    conclude "another writer" and REPORT, not `pytest.fail`.
+    """
+    reads = iter([{"k": "1"}, {"k": "2"}, {"k": "3"}, {"k": "4"}, {"k": "5"}])
+    monkeypatch.setattr(gitenv_plugin, "_take", lambda: next(reads))
+    monkeypatch.setattr(gitenv_plugin, "SETTLE_SECONDS", 0.0)
+    monkeypatch.setattr(gitenv_plugin, "_BASELINE", {"k": "0"})
+    monkeypatch.setattr(gitenv_plugin, "_UNATTRIBUTABLE", [])
+    monkeypatch.setattr(gitenv_plugin, "_MODE", "auto")
+    monkeypatch.setattr(gitenv_plugin, "_OBSERVED", 0)
+    monkeypatch.setattr(gitenv_plugin, "_VIOLATIONS", 0)
+
+    gitenv_plugin._check("a unit-level probe")     # must NOT raise Failed
+
+    assert gitenv_plugin._UNATTRIBUTABLE, "a repo that never settled was still attributed"
+    assert gitenv_plugin._OBSERVED == 1
+    assert gitenv_plugin._VIOLATIONS == 0
+
+
+def test_a_repo_that_settles_is_still_attributed(monkeypatch):
+    """The control. If "keeps moving" were the only path, the settle re-read
+    would have disabled enforcement outright rather than narrowed it."""
+    reads = iter([{"k": "1"}, {"k": "1"}, {"k": "1"}])
+    monkeypatch.setattr(gitenv_plugin, "_take", lambda: next(reads))
+    monkeypatch.setattr(gitenv_plugin, "SETTLE_SECONDS", 0.0)
+    monkeypatch.setattr(gitenv_plugin, "_BASELINE", {"k": "0"})
+    monkeypatch.setattr(gitenv_plugin, "_UNATTRIBUTABLE", [])
+    monkeypatch.setattr(gitenv_plugin, "_MODE", "auto")
+    monkeypatch.setattr(gitenv_plugin, "_OBSERVED", 0)
+    monkeypatch.setattr(gitenv_plugin, "_VIOLATIONS", 0)
+
+    # 🔴 `pytest.fail.Exception` (i.e. `_pytest.outcomes.Failed`) derives from
+    # BaseException, so `pytest.raises(Exception)` does NOT catch it — it would
+    # let the failure through and report this control as red for the wrong
+    # reason.
+    with pytest.raises(pytest.fail.Exception) as excinfo:
+        gitenv_plugin._check("a unit-level probe")
+    assert VIOLATION_TOKEN in str(excinfo.value)
+    assert not gitenv_plugin._UNATTRIBUTABLE
+    assert gitenv_plugin._VIOLATIONS == 1
 
 
 # --- the seam with GUARD 10 (`testlib/nogit_plugin.py`) ----------------------

--- a/scripts/tests/test_git_repo_isolation.py
+++ b/scripts/tests/test_git_repo_isolation.py
@@ -354,8 +354,9 @@ def test_every_pytest_target_gets_the_detector():
     one directory (that is #399's and #614's measured failure, twice).
 
     🔴 The target COUNT is deliberately not written down here. #683 said
-    "seventeen" while `--check-targets` listed 25 — a number nobody re-derives
-    is a claim that rots, and the assertion never depended on it.
+    "seventeen" while `--check-targets` listed 25 at the time of the audit and
+    26 today — a number nobody re-derives is a claim that rots, and the
+    assertion below never depended on it.
     """
     text = re.sub(r"\\\n\s*", " ", RUN_TESTS.read_text(encoding="utf-8"))
     pytest_lines = [ln for ln in text.splitlines()

--- a/scripts/tests/test_hook_tests_dir_collects.py
+++ b/scripts/tests/test_hook_tests_dir_collects.py
@@ -33,6 +33,7 @@ WHAT EACH TEST HERE IS (labelled, because "it passes" is not a category):
         hand-maintained lists. Nothing made those agree. This fails when the
         sets GROW or SHRINK on either side.
 """
+import os
 import re
 import shutil
 import subprocess
@@ -48,12 +49,24 @@ CONFTEST = HOOK_TESTS_DIR / "conftest.py"
 
 
 def _pytest(*args, cwd=None):
+    # 🔴 `scripts/` ON PYTHONPATH, EXPLICITLY. Several tests below `shutil.copy`
+    # CONFTEST into a tmp dir, and that conftest is a second entry point for
+    # GUARD 9 — it imports `testlib.gitenv_plugin`. In the real tree it finds
+    # `scripts/` by walking up from its own location; a COPY has nothing above
+    # it, so the copying harness has to supply what the location supplied.
+    # Without this the copy tests are GREEN under `run-tests.sh` (which exports
+    # PYTHONPATH) and RED under a bare `pytest scripts/tests` — a suite green in
+    # one tier and broken in the other, which claude/RULES.md rates as moving
+    # the bug rather than removing it. Measured, both tiers, before fixing it.
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT / "scripts") + os.pathsep + env.get("PYTHONPATH", "")
     return subprocess.run(
         [sys.executable, "-m", "pytest", "-p", "no:cacheprovider", *args],
         cwd=str(cwd or REPO_ROOT),
         capture_output=True,
         text=True,
         timeout=600,
+        env=env,
     )
 
 


### PR DESCRIPTION
> 🔄 **Rebased 2026-08-22 onto `6546acdc` (#722), and RE-MEASURED there — a rebase resets the verification gate.**
> One textual conflict, in `scripts/tests/test_git_repo_isolation.py` (add/add: #673 appended its
> GUARD-10-seam section at the same place this branch appended finding A's attribution section).
> Resolved by keeping BOTH, in order — this branch's continuation of
> `test_the_violation_message_leads_with_the_other_writer_hypothesis` first (its trailing
> `assert other < incident` block), then #673's seam section, which is self-contained.
> `scripts/run-tests.sh`, `scripts/testlib/gitenv.py` and `scripts/tests/conftest.py` auto-merged
> and were read region-by-region: #673's `global_config_paths()` scratch-redirect exemption, its
> GUARD 10 shell block and its `nogit_plugin` import all survive intact beside this branch's
> `CONTROL_VARS` unset, `found-set` marker and `pytest_configure` import. The merged run announces
> both guards (`GUARD 9 … found-set=none` then `GUARD 10 …`), which is the seam working.
> **Every number below is re-measured on the rebased tree, not carried over.**

Follow-up to **#683** (merged as `dfd2d203` while this audit was in flight, so the fixes land as their own PR rather than as edits to that branch). Six findings, in the order they block.

---

## 🔴 A — the detector could not tell an escape from a neighbour, and asserted the former at maximum confidence

The protected clone has **dozens of concurrent writers**. During one 40-minute audit it gained two branches, lost one and fast-forwarded `main` twice; `drift-check.sh` runs `git fetch` against it on a 6-hourly systemd timer, and `fetch` triggers `gc --auto` (its own comment says so), which repacks refs. #683's fingerprint hashed the loose ref *files*, so a repack emitted **one `DELETED refs/…` line per branch** under a banner reading *"This is the 2026-08-21 incident's shape."*

**Re-measured on the rebased tree** (40 innocent tests, each doing 50 ms of real
work so the suite spans a realistic ~2.5 s window, under a separate process writing a branch into
the watched repo every 40 ms plus `pack-refs --all` every 10th write; three runs each side; both
sides driven by the SAME harness, only `PYTHONPATH` differs):

| | before (`main`@`6546acdc`, still unfixed) | after (this branch, rebased) |
|---|---|---|
| run 1 | `40 passed, 40 errors` · exit 1 | `40 passed` · exit 0 |
| run 2 | `40 passed, 38 errors` · exit 1 | `40 passed` · exit 0 |
| run 3 | `40 passed, 40 errors` · exit 1 | `40 passed` · exit 0 |
| violation messages | 80 / 76 / 80 | **0 / 0 / 0** |
| innocent tests the run FAILED | 40 / 38 / 40 | **0 / 0 / 0** |
| deltas reported with the reason (`unattributed-observations=`) | — (no such output) | 40 / 41 / 41 |
| **false-positive rate** | **118/120 = 98.3 %** | **0/120 = 0 %** |
| wall time | 2.30 / 2.37 / 2.30 s | 2.58 / 2.60 / 2.74 s |

🔴 **A false positive is counted as an innocent test the run FAILED, not one merely NAMED in the
output.** Report mode deliberately PRINTS the delta together with the test window it landed in —
that is the non-silent behaviour this finding asked for — so scoring "named in the output" would
have recorded the fix as the bug (it reads 40/40 on the fixed code, with zero failures).

🔴 **The exit-3 outage still reproduces on `main`, intermittently.** An earlier batch of the same
measurement, same code, gave `INTERNALERROR`, exit 3, **ZERO tests ran** on 1 of 3 runs — a
neighbouring `git branch` landing during COLLECTION. On the rebased tree: 0 of 6 runs.

**Positive control for this harness** (RULES.md — a reassuring zero is indistinguishable from an
instrument wired to nothing): with the neighbour writer REMOVED and one test that really does
write to the watched repo, the same harness reports `exit=1, 1 error, 1 violation message,
marker protected-git-dirs=1` on BOTH the before and after trees. The zero above is a measurement,
not a silence.

The exit-3 rows are their own finding: `pytest.fail` raised from `pytest_collection_finish` is an exception thrown from a *hook*, so one neighbouring `git branch` landing during collection **took the whole suite down** with the message buried under `INTERNALERROR>`.

Four mechanical changes, none of them a reword:

1. **The fingerprint is ref VALUES, not ref FILES.** `packed-refs` and the loose `refs/` tree are parsed into one `name -> oid` map, so `git gc` / `git pack-refs` produce **exactly zero** deltas (pinned by `test_repacking_refs_is_NOT_reported_as_damage` and `test_gc_is_not_reported_as_damage`). `logs/HEAD` is dropped for the same reason — a pure derivative that `gc`'s reflog expiry rewrites on its own.
2. **Positive evidence of another writer downgrades the session to reporting.** Three probes, all facts rather than inferences: live processes whose CWD is inside a protected work tree and are not our ancestors (`live_cotenants`); a delta observed between `pytest_runtest_logfinish` and the next `logstart`, a window in which no setup, call or teardown runs; and a settle re-read taken at the moment of any delta. Report mode prints the **whole delta** with the reason and counts it at session end — it is not a quiet pass — and deliberately omits `VIOLATION_TOKEN` so a reachability control cannot be satisfied by an unattributed observation.
3. **The baseline re-arms on every check**, so a delta's blame window is one test rather than the whole session.
4. **The message leads with "DID SOMETHING ELSE WRITE TO THIS REPOSITORY?"** and states that the three probes finding nothing is an *absence* of evidence. Ordering is pinned, not just the words.

Session-level violations now exit via `pytest.exit` — same non-zero exit, same message, reported as a decision instead of a crash.

The shared **common dir** is still watched (an escape from a worktree lands there, and worktree isolation is this repo's standing default) — the mode logic is what handles the sibling-agent case, generically.

🔴 **The residual, measured rather than argued.** One case still fails: a **single** external write, by a process that does not *reside* in the repository, landing inside one test's window. It happened to me during the first gate run of this branch — I ran `git commit` in the clone while the gate was mid-flight, and two suites errored with

```
DEVRC-GITENV-VIOLATION: … changed during test `…::test_the_etag_still_changes…`
  CHANGED  …/.git::ref::refs/heads/fix/guard9-audit-followups  0686dc78 -> 1c8be33e
```

which is the detector working: a real mutation, named to the ref and the commit. (Those two shas are PRE-rebase and no longer exist on the branch; the observation stands, the object names do not.) The message's **first** hypothesis ("did something else write to this repository?") is the correct one, and the second gate run — same tree, nobody touching it — is clean. This case is not closable from inside the process; what changed is that it is now the *residual* rather than the *normal* outcome.

## 🔴 B — `DEVRC_GITENV_PROTECT` was a one-variable defeat of the entire detector, inside the fix for one variable defeating everything

**Re-measured on the rebased tree**, all four spellings, same escaping test (a nested pytest whose
only test writes a branch into a real repo by ABSOLUTE path, so the environment strip cannot stop
it). `mutated` is read back off the repo afterwards, not inferred from the exit code:

| `DEVRC_GITENV_PROTECT` | before (`main`@`6546acdc`) | after (this branch, rebased) |
|---|---|---|
| `<real>/.git` | **RED** exit 1, token present, `protected-git-dirs=1` | **RED** exit 1, token present, `protected-git-dirs=1 mode=enforce` *(unchanged)* |
| `":"` | **GREEN** exit 0, `protected-git-dirs=0`, **repo really mutated** | **RED** exit 1, `GitEnvConfigError: … is set but names no path`, **repo untouched** |
| `/nonexistent/x` | **GREEN** exit 0, `protected-git-dirs=1` — a marker asserting coverage over a path that cannot hold a repository — **repo really mutated** | **RED** exit 1, `GitEnvConfigError`, **repo untouched** |
| `""` | **GREEN** exit 0, `protected-git-dirs=0`, **repo really mutated** | **RED** exit 1, `GitEnvConfigError`, **repo untouched** |

The error text names the failure mode it replaces rather than just refusing: *"A detector pointed
at a path that cannot hold a repository reports `protected-git-dirs=1` and stays green through any
amount of damage."*

`resolve_protect_env` and `requested_mode` now raise `GitEnvConfigError` at plugin import (so the run aborts before any test can mutate anything), and `CONTROL_VARS` puts both seams on all four runners' unset list, pinned two-way.

## 🟡 C — the fingerprint's CONTENT is swept now, not just its plumbing

Five semantic mutants survived #683's green suite. Each component is now pinned by a mutation that **only it** can see, with the delta required to name *only* that component:

| component | mutation | notes |
|---|---|---|
| `config` | `git config user.name T` | |
| `HEAD` | `git symbolic-ref HEAD refs/heads/other` | the **HEAD-move row** two docstrings claimed and no row provided; the incident repointed `HEAD` at `trunk` |
| `ORIG_HEAD` | `git reset -q HEAD` | moves nothing else |
| refs (loose) | `git branch side` | |
| refs (**packed**) | `pack-refs --all` then `branch -D` | the incident's `DELETED refs/heads/main` on any repo `gc` has touched — no #683 fixture ever packed |

Plus both discovery roots: `test_the_cwd_root_is_load_bearing` (cwd in another repo) and `test_the_module_root_is_load_bearing` (cwd in no repo) kill the two `starts` mutants that a bare "both are needed" comment did not.

**Swept, on an isolated copy, under `PYTHONDONTWRITEBYTECODE=1` with `__pycache__` cleared between mutants** (baseline 101 passed, post-restore 101 passed):

| mutant | verdict | killed by |
|---|---|---|
| drop `HEAD` | killed | `…[HEAD]` — *the detector did not see `git symbolic-ref HEAD refs/heads/other`* |
| drop `ORIG_HEAD` | killed | `…[ORIG_HEAD]` — *nothing moved for `git reset -q HEAD`* |
| stop reading `packed-refs` | killed | `…[refs (packed)]` — *nothing moved for `git branch -q -D doomed`* |
| `starts = [Path(__file__)]` | killed | `test_the_cwd_root_is_load_bearing` |
| `starts = [Path.cwd()]` | killed | `test_the_module_root_is_load_bearing` |
| re-introduce loose-ref-FILE hashing | killed | `test_repacking_refs_is_NOT_reported_as_damage` |
| **positive control** — drop the token from the message | killed | `test_the_detector_fails_the_test_that_moved_a_ref` — *"failed, but not with GUARD 9's message"* |
| **no-op control** — *rename* `VIOLATION_TOKEN` | **survives, correctly** | see below |

🔴 The no-op control is worth stating rather than hiding: **renaming `VIOLATION_TOKEN` is semantically a no-op and a sweep must score it as a survivor**, because the assertion imports the same constant the message is built from — both sides move together. That is the "fixture value can only ever equal the constant" shape claude/RULES.md warns about, and it is *fine here* (the token exists to distinguish this guard from a neighbour's error, which a rename does not change) — but a sweep that used the rename as its positive control would have reported a broken batch as a clean one. That is exactly what the first run of this sweep did, before the control was replaced with one that removes the token from the **message**.

## 🟡 D — the second entry point covered 1 conftest of 7

…and not the one `gitenv_plugin`'s own rationale cites: `scripts/claude-hooks/tests/`, home to `test_bash_guard.py::_mkrepo` and `test_guard_core.py`'s module-scoped repos. All seven are wired, and the **set** is pinned (`test_the_conftest_entry_points_are_a_pinned_ledger`) so it fails when a conftest is added *or* removed.

## 🟡 E — the shell scan claimed more than it did, both ways

Missed: twelve extensionless scripts under `scripts/`, **everything under `nix/`** (an `envExtra`/`shellHook` export poisons every shell the operator opens — the likeliest real source), and `githooks/<subdir>/*`. Its regex missed `declare -x`, `typeset -x`, `readonly`, `foo; GIT_DIR=…`, `cd x && GIT_DIR=…` and **`export GIT_DIR` with no `=`** — which *is* the already-exported-name mechanism the whole rationale rests on. It false-positived on the harmless `GIT_INDEX_FILE=$t git add …` command-prefix idiom.

Replaced with a small shell tokeniser carrying **11 positive and 9 negative controls**, plus one narrow `.nix` pattern for shell inside a one-line nix string.

| | before | after |
|---|---|---|
| files scanned | 47 | **100** |
| extensionless scripts | 1 | **13** |
| files under `nix/` | 0 | **41** |

`githooks/tests-on-push.sh` — which matched `RUNNERS`' own docstring ("resolves a root … and then runs tests") and carried no strip — is now the fourth runner, with the array, the unset, and the ordering all pinned.

## 🟡 (found while fixing D) the 7th conftest was green in one tier and red in the other

`scripts/claude-hooks/tests/conftest.py` is deliberately `shutil.copy`d into a tmp dir by `test_hook_tests_dir_collects.py`. Wiring GUARD 9 into it made the copy import `testlib.gitenv_plugin`, which it resolves by walking **up** to `scripts/` — and a copy has nothing above it:

```
with PYTHONPATH=<repo>/scripts   11 passed        (what run-tests.sh exports)
without PYTHONPATH                3 failed, 8 passed — ModuleNotFoundError: No module named 'testlib'
```

The authoritative tier was the one that hid it, so it would have merged. The harness now exports `PYTHONPATH` for every subprocess it launches, and the copied conftest carries a **named** error saying exactly why, instead of a bare `ModuleNotFoundError` that reads as a broken repo. 112 passed in both tiers after.

## 🔴 F — a false claim, corrected

#683's body and commit message stated that `githooks/pre-push` handing down `GIT_DIR` explained why *pushing* triggered the corruption. **Measured here as a pair** (git 2.55.0, `test_git_push_does_not_export_GIT_DIR_to_pre_push`): a push from a `GIT_DIR`-free parent gives `pre-push` only `GIT_EXEC_PATH` and `GIT_PREFIX` — **no `GIT_DIR`**; the same push with `GIT_DIR` exported by the caller passes it straight through. So the rename is real hygiene and is **not** the diagnosis.

🔴 **The root cause of the 2026-08-21 incident remains unidentified.** A live scan found 46 processes carrying some `GIT_*` variable and **0** carrying `GIT_DIR`. Said plainly in `gitenv.py`'s header, in `githooks/pre-push`, and in the test file — and both halves of the measurement are a test, so the claim cannot rot silently.

## 🟢 Nits

- `scripts/tests/conftest.py` stated a **false pytest fact** (measured on pytest 9.1.1: `pytest_configure` **is** called for a collected directory's conftest), which cost the second entry point its marker line for no reason. Now imported — and the claim is a test.
- `SESSION_MARKER` was declared and never counted. `run-tests.sh` now **counts it per pytest target and FAILS when it is absent**, which is what makes it a positive control rather than a declaration; the token is pinned two-way like `SPOOL_SESSION_MARKER`.
- GUARD 9's "reports the PAIR" block printed two constants. It now prints `found-set` — what was really in the environment when the run started.
- The stale "seventeen targets" is removed rather than restated; `--check-targets` lists 26 hermetic today and the assertion never depended on the number.
- Dead `_os_environ_is_clean` and the unreachable `not _GIT_DIRS and not _EXTRA` branch are gone.

---

## Gate

Run from a **standalone clone with `origin` removed** — devrc's test tier mutates whatever repo it
runs from, and a contained clone with a live push path is not contained. Exact command:

```
env -C <clone> TMPDIR=<scratch> PYTHONDONTWRITEBYTECODE=1 nix develop . --command bash scripts/gate.sh
```

**On the rebased tree (base `6546acdc`):**

```
GATE: RESULT=PASS exit=0
  PASS  pytest  exit=0  verdict='RESULT: PASS (exit=0)'
    TOTAL collected=15120  passed=15118  skipped=2  failed=0   (floor: 13697 = sum of 27 per-target floors)
  PASS  node    exit=0  verdict='RESULT: PASS (exit=0)'
    TOTAL suites=4 files=34 tests=1149 pass=1149 fail=0 skipped=0   (floor: 1126)
```

0 `FAIL` lines, 0 `panic: test timed out`, and the two skips are the two pinned `EXPECTED_SKIPS`
(`signal` needs a real Postgres; `repo-cos`'s live-store drift check is opt-in) — GUARD 9 adds
none of its own. `scripts/browser-bridge/tests` is **781/781**, i.e.
`test_timeout_reaps_the_whole_process_group` passes locally including #722's additions.

GUARD 9's new per-target positive control fired on every pytest target: **42 `gitenv(session)`
marker lines**, 0 `GUARD 9 marker absent` FATALs. The run announces both guards side by side,
which is the merged-tree seam #673's own regression note is about:

```
run-tests: git repo pointers cleared for this run (GUARD 9)
  ledger      =GIT_DIR … GIT_CONFIG DEVRC_GITENV_PROTECT DEVRC_GITENV_MODE
  found-set   =none
  detector    =-p testlib.gitenv_plugin (per pytest target; its own
               'gitenv(session)' line is counted per target below)
run-tests: git isolated for this run (GUARD 10)
```

An earlier full gate on the same branch rebased onto `4dd14e68` (the previous `main`) was also
`GATE: RESULT=PASS exit=0`, `collected=15118 passed=15116 skipped=2 failed=0`; the only tree
difference between the two is #722's own edit to `scripts/browser-bridge/tests/test_browser_agent.py`,
which this branch does not touch.

`/home/zach/workspace/devrc` was **read only** (`show-ref`, `config --local --list`, `git clone`,
`cp .envrc`) and never written. Its refs and local config did move during this session — two
`branch.fix/reap-check-zombie.*` config entries and ~10 ref lines — from OTHER live sessions;
one of them was observed running `python -m pytest scripts/tests` with `cwd=/home/zach/workspace/devrc`,
i.e. the exact co-tenancy finding A is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

