### PR TITLE
fix(analyze-service-index): a leaked GIT_DIR aimed the COMMITTER at a foreign repo — GUARD 9 stopped at the runners

### DIFF
--- a/scripts/analyze-service-index/commit.sh
+++ b/scripts/analyze-service-index/commit.sh
@@ -218,8 +218,9 @@ command -v git >/dev/null 2>&1 ||
 #
 # THE SET IS NOT CHOSEN HERE. `scripts/testlib/gitenv.py::REPO_POINTER_VARS` owns
 # it and test_git_repo_isolation.py pins this spelling against it in BOTH
-# directions, exactly as it does for the four other clearers. Every name below can make
-# git resolve a DIFFERENT repository, index or object store than the `-C` says.
+# directions, exactly as it does for the four other clearers. Every name below
+# can make git resolve a DIFFERENT repository, index or object store than the
+# `-C` says.
 #
 # UNCONDITIONAL: there is no workflow in which this unit should be aimed at a
 # repository by inherited environment.

--- a/scripts/analyze-service-index/commit.sh
+++ b/scripts/analyze-service-index/commit.sh
@@ -218,7 +218,7 @@ command -v git >/dev/null 2>&1 ||
 #
 # THE SET IS NOT CHOSEN HERE. `scripts/testlib/gitenv.py::REPO_POINTER_VARS` owns
 # it and test_git_repo_isolation.py pins this spelling against it in BOTH
-# directions, exactly as it does for the three runners. Every name below can make
+# directions, exactly as it does for the four other clearers. Every name below can make
 # git resolve a DIFFERENT repository, index or object store than the `-C` says.
 #
 # UNCONDITIONAL: there is no workflow in which this unit should be aimed at a

--- a/scripts/analyze-service-index/commit.sh
+++ b/scripts/analyze-service-index/commit.sh
@@ -221,12 +221,6 @@ command -v git >/dev/null 2>&1 ||
 # directions, exactly as it does for the three runners. Every name below can make
 # git resolve a DIFFERENT repository, index or object store than the `-C` says.
 #
-# ⚠ GIT_CEILING_DIRECTORIES is deliberately NOT here, and that is measured, not
-# assumed: it can only make the upward discovery walk STOP EARLY (rc 128, "not a
-# git repository"), never point at another one. In this script that maps to
-# state 0, i.e. `git init` inside the scope — the safe direction. See the
-# "DELIBERATELY NOT STRIPPED" list in gitenv.py.
-#
 # UNCONDITIONAL: there is no workflow in which this unit should be aimed at a
 # repository by inherited environment.
 DEVRC_GIT_REPO_POINTERS=(
@@ -248,6 +242,51 @@ DEVRC_GIT_REPO_POINTERS=(
 # fails test_every_unplaceable_git_token_is_pinned_prose — which is the right
 # outcome for that test, and a wording constraint here rather than a pin there.
 unset "${DEVRC_GIT_REPO_POINTERS[@]}"
+
+# --- 🔴 AND TWO MORE THAT ARE THIS SCRIPT'S PROBLEM ALONE -----------------------
+# These are NOT on GUARD 9's shared ledger and must not be added to it. GUARD 9's
+# remit is "which repository does a command LAND in", and neither of these can
+# redirect one — which is exactly why they are invisible to it, and exactly why
+# they still break THIS script. A ledger is only as wide as the question it asks.
+#
+# MEASURED 2026-08-22 (git 2.55.0), each on its own against a decoy:
+#
+#   GIT_CEILING_DIRECTORIES — it stops the upward discovery walk EARLY. It cannot
+#     point git at another repo (with a ceiling naming an UNRELATED repo,
+#     `rev-parse --show-toplevel` still returns the enclosing one). But stopping
+#     the walk is precisely how `scope_repo_state` is made to answer 0 instead of
+#     2, and 0 means BOOTSTRAP. A scope genuinely nested inside a foreign
+#     checkout went from
+#         rc=1  "scope inner: not its own repo — it sits inside <foreign>. Refusing…"
+#     to
+#         rc=0  "scope inner: initialised a new repository … ok — 1 scope(s) processed"
+#     with a `.git` planted INSIDE somebody else's working tree. Nothing lands in
+#     foreign HISTORY, so this is not the exfiltration shape — but the refusal
+#     that test_a_leaked_pointer_does_not_defeat_the_nested_scope_refusal calls
+#     "THE GUARD'S REAL JOB" is silently converted into its opposite, and the run
+#     still prints ok. An earlier version of this comment called that "the safe
+#     direction" and stopped there; that was true about exfiltration and
+#     misleading about everything else.
+#
+#   GIT_TEMPLATE_DIR — the ENVIRONMENT twin of `init.templateDir`, which the
+#     GIT_CONFIG block below already pins off. Neutralising the config route and
+#     leaving the env route open is the asymmetry worth naming: `GIT_CONFIG_GLOBAL
+#     =/dev/null` does not touch a variable. MEASURED: a template
+#     `hooks/post-commit` IS copied into the repository this script bootstraps and
+#     PERSISTS there. It did not fire, because GIT_CONFIG_KEY_0 redirects
+#     core.hooksPath — so this is a planted-but-dormant payload, armed the moment
+#     anyone runs git in that scope by hand, which is exactly what an operator
+#     does to inspect a backup.
+#
+# Kept in a SEPARATE array on purpose: `DEVRC_GIT_REPO_POINTERS` above is pinned
+# two-way against `testlib/gitenv.py::REPO_POINTER_VARS`, so quietly widening it
+# here would break that pin — and widening the shared ledger would change GUARD 9
+# for every runner on the strength of a defect that is local to this script.
+ASI_LOCAL_GIT_POINTERS=(
+  GIT_CEILING_DIRECTORIES            # stops discovery early -> refusal becomes bootstrap
+  GIT_TEMPLATE_DIR                   # env twin of init.templateDir; plants files in the new repo
+)
+unset "${ASI_LOCAL_GIT_POINTERS[@]}"
 
 # --- 🔴 NEUTRALISE AMBIENT GIT CONFIG ------------------------------------------
 # This block exists because the no-exfiltration guarantee was bypassable WITHOUT

--- a/scripts/analyze-service-index/commit.sh
+++ b/scripts/analyze-service-index/commit.sh
@@ -192,6 +192,63 @@ ASI_NO_INIT="${ASI_NO_INIT:-0}"
 command -v git >/dev/null 2>&1 ||
   die "the version-control binary is not on PATH — refusing to report success"
 
+# --- 🔴 NEUTRALISE THE AMBIENT REPO POINTERS ------------------------------------
+# WHICH repository, before WHICH config. Everything below this line reaches git
+# as `git -C "$scope" …`, and `-C` is the weakest possible claim about where a
+# command lands: GIT_DIR OVERRIDES IT.
+#
+# MEASURED 2026-08-22 against a throwaway decoy repo with a linked worktree, on
+# git 2.55.0, running THIS script unchanged:
+#
+#     GIT_DIR=<decoy>/.git/worktrees/wt  commit.sh <store>
+#       -> scope_repo_state: `git -C "$scope" rev-parse --show-toplevel` honours
+#          GIT_DIR and takes the CWD as the work tree, so it returns "$scope"
+#          ITSELF -> state 1, "it IS its own repo".
+#       -> that skips BOTH the `git init` bootstrap AND the "not its own repo"
+#          refusal, and every later `git -C "$scope" add/commit` writes into the
+#          DECOY's gitdir, index and branch. The decoy's `decoy/target` moved to
+#          `autocommit: 3 change(s) in the some-scope analyze-service index`
+#          while this script printed "committed <sha>" and exited 0.
+#
+# That is the 2026-08-21 incident's mechanism (scripts/testlib/gitenv.py) arriving
+# at the one program in this repo whose whole job is to COMMIT. `run-tests.sh`,
+# `run-node-tests.sh` and `gate.sh` already strip these for the test tiers; this
+# is the same strip AT THE WRITER, so a caller that never goes through a runner —
+# a systemd unit, an operator's shell, a future script — cannot spoof it either.
+#
+# THE SET IS NOT CHOSEN HERE. `scripts/testlib/gitenv.py::REPO_POINTER_VARS` owns
+# it and test_git_repo_isolation.py pins this spelling against it in BOTH
+# directions, exactly as it does for the three runners. Every name below can make
+# git resolve a DIFFERENT repository, index or object store than the `-C` says.
+#
+# ⚠ GIT_CEILING_DIRECTORIES is deliberately NOT here, and that is measured, not
+# assumed: it can only make the upward discovery walk STOP EARLY (rc 128, "not a
+# git repository"), never point at another one. In this script that maps to
+# state 0, i.e. `git init` inside the scope — the safe direction. See the
+# "DELIBERATELY NOT STRIPPED" list in gitenv.py.
+#
+# UNCONDITIONAL: there is no workflow in which this unit should be aimed at a
+# repository by inherited environment.
+DEVRC_GIT_REPO_POINTERS=(
+  GIT_DIR                            # the repository itself; beats -C
+  GIT_WORK_TREE                      # the working tree
+  GIT_COMMON_DIR                     # where refs/config actually live
+  GIT_INDEX_FILE                     # the index that staging writes
+  GIT_OBJECT_DIRECTORY               # where new objects are written
+  GIT_ALTERNATE_OBJECT_DIRECTORIES   # extra object stores
+  GIT_NAMESPACE                      # the ref namespace refs land in
+  GIT_PREFIX                         # hook-injected pathspec prefix
+  GIT_GRAFT_FILE                     # repo-scoped grafts
+  GIT_SHALLOW_FILE                   # repo-scoped shallow list
+  GIT_CONFIG                         # legacy: the config file a write lands in
+)
+# ⚠ The trailing comments above deliberately avoid the word this file's own
+# ledger test scans for. `_script_code_lines` strips comment-ONLY lines, so a
+# trailing comment naming a subcommand reads as an unplaceable call site and
+# fails test_every_unplaceable_git_token_is_pinned_prose — which is the right
+# outcome for that test, and a wording constraint here rather than a pin there.
+unset "${DEVRC_GIT_REPO_POINTERS[@]}"
+
 # --- 🔴 NEUTRALISE AMBIENT GIT CONFIG ------------------------------------------
 # This block exists because the no-exfiltration guarantee was bypassable WITHOUT
 # TOUCHING THIS FILE. MEASURED 2026-08-06 (git 2.55.0), end to end:
@@ -434,6 +491,15 @@ capture() {
 # repo instead — committing client-sensitive content into somebody else's
 # history. Compare the discovered toplevel against the scope and refuse on a
 # mismatch. Echoes: 1 = own repo, 0 = no repo, 2 = inside a DIFFERENT repo.
+#
+# 🔴 THIS FUNCTION IS THE SPOOFABLE ONE, and the thing that makes it honest is
+# NOT in this function: it is the DEVRC_GIT_REPO_POINTERS `unset` at the top of
+# the file. An inherited GIT_DIR makes the `rev-parse` below answer "$scope"
+# whatever the truth is, which reports state 1 — its own repo — for a scope that
+# is a bare directory sitting inside somebody else's checkout, so BOTH the
+# bootstrap and the state-2 refusal are skipped and the commits land in the
+# foreign repo. Do not move that `unset`, and do not add a caller that re-sets a
+# pointer between it and here.
 scope_repo_state() {
   local scope="$1" top
   top="$(git -C "$scope" rev-parse --show-toplevel 2>/dev/null)"

--- a/scripts/testlib/gitenv.py
+++ b/scripts/testlib/gitenv.py
@@ -121,6 +121,23 @@ re-derive it:
   * `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_n` / `GIT_CONFIG_VALUE_n` — they
     inject config VALUES into whatever repo git already resolved. Same reason.
   * `GIT_AUTHOR_*` / `GIT_COMMITTER_*` — identity, not location.
+  * `GIT_CEILING_DIRECTORIES` — it can only make the upward discovery walk STOP
+    EARLY, never point at a different repository. MEASURED (git 2.55.0): with a
+    ceiling above a scope nested in a repo, `git -C <scope> rev-parse
+    --show-toplevel` exits 128 "not a git repository"; with the ceiling naming
+    an UNRELATED repo it returns the enclosing one unchanged. Failing to
+    discover is the safe direction — in `analyze-service-index/commit.sh` it
+    reads as "no repo", i.e. `init` inside the scope. Listed because the name
+    looks like it belongs and the absence of a reason reads as an oversight.
+
+🔴 FOURTH SPELLING, 2026-08-22. `scripts/analyze-service-index/commit.sh` also
+carries the array. It is not a runner — it resolves no ROOT and no test tier
+reaches it (systemd timer, operator shell) — but it is the one program here
+whose job is to COMMIT, and on the pre-fix tree a leaked `GIT_DIR` made its
+`scope_repo_state` report "this scope IS its own repo" for a bare directory,
+skipping both the bootstrap and the nested-repo refusal and putting
+`autocommit: N change(s) in the some-scope analyze-service index` on a foreign
+branch. `test_git_repo_isolation.py::POINTER_CLEARERS` pins it like the rest.
 """
 from __future__ import annotations
 

--- a/scripts/testlib/gitenv.py
+++ b/scripts/testlib/gitenv.py
@@ -51,14 +51,16 @@ written into the clone's config are the tests' OWN correct values. The tests
 computed the right thing and git wrote it into the wrong repository.
 
 WHAT THIS MODULE OWNS. `REPO_POINTER_VARS` below is the ONE owner of the set.
-It is re-spelled as a bash array at the top of `run-tests.sh`,
-`run-node-tests.sh`, `gate.sh` and `githooks/tests-on-push.sh` — each BEFORE
-that script resolves its own ROOT — and `scripts/tests/test_git_repo_isolation.py`
-pins every spelling against this tuple in both directions, plus the ordering.
-Four shell copies rather than one sourced file because `testlib/runner_patch.py`
-writes a patched COPY of `run-tests.sh` into a tmp dir that ~15 tests drive, and
-a copy cannot source a sibling `lib/` that was never copied with it (measured:
-the sourced version turned all fifteen into a FATAL):
+It is re-spelled as a bash array at the top of FIVE shell files:
+`run-tests.sh`, `run-node-tests.sh`, `gate.sh` and `githooks/tests-on-push.sh` —
+each BEFORE that script resolves its own ROOT — and
+`analyze-service-index/commit.sh`, which resolves no ROOT at all (see FIFTH
+SPELLING below). `scripts/tests/test_git_repo_isolation.py` pins every spelling
+against this tuple in both directions, and pins the ORDERING for the four that
+resolve a ROOT. Copies rather than one sourced file because
+`testlib/runner_patch.py` writes a patched COPY of `run-tests.sh` into a tmp dir
+that ~15 tests drive, and a copy cannot source a sibling `lib/` that was never
+copied with it (measured: the sourced version turned all fifteen into a FATAL):
 
   1. `REPO_POINTER_VARS` — the environment variables that decide WHICH
      repository a git command lands in. Stripping them is the FIX.
@@ -125,12 +127,23 @@ re-derive it:
     EARLY, never point at a different repository. MEASURED (git 2.55.0): with a
     ceiling above a scope nested in a repo, `git -C <scope> rev-parse
     --show-toplevel` exits 128 "not a git repository"; with the ceiling naming
-    an UNRELATED repo it returns the enclosing one unchanged. Failing to
-    discover is the safe direction — in `analyze-service-index/commit.sh` it
-    reads as "no repo", i.e. `init` inside the scope. Listed because the name
-    looks like it belongs and the absence of a reason reads as an oversight.
+    an UNRELATED repo it returns the enclosing one unchanged.
+  * `GIT_TEMPLATE_DIR` — it seeds the contents of a repo `git init` CREATES; it
+    does not choose which repo a command lands in.
 
-🔴 FOURTH SPELLING, 2026-08-22. `scripts/analyze-service-index/commit.sh` also
+🔴 BUT "NOT ON THIS LEDGER" IS NOT "HARMLESS", AND THE TWO ABOVE PROVE IT. This
+ledger answers exactly one question — WHICH REPOSITORY DOES A COMMAND LAND IN —
+and a variable that cannot redirect is invisible to it while still being able to
+wreck a consumer. Both were measured doing so in
+`analyze-service-index/commit.sh` on 2026-08-22: a ceiling turns its nested-repo
+REFUSAL into a silent `git init` inside somebody else's checkout, and a template
+dir plants a `hooks/post-commit` into the repo it bootstraps. That script
+therefore strips them in its OWN array (`ASI_LOCAL_GIT_POINTERS`), deliberately
+NOT here — widening a shared ledger on the strength of one consumer's defect
+changes GUARD 9 for every runner. Read this list as "cannot redirect git",
+never as "safe to inherit".
+
+🔴 FIFTH SPELLING, 2026-08-22. `scripts/analyze-service-index/commit.sh` also
 carries the array. It is not a runner — it resolves no ROOT and no test tier
 reaches it (systemd timer, operator shell) — but it is the one program here
 whose job is to COMMIT, and on the pre-fix tree a leaked `GIT_DIR` made its
@@ -138,6 +151,7 @@ whose job is to COMMIT, and on the pre-fix tree a leaked `GIT_DIR` made its
 skipping both the bootstrap and the nested-repo refusal and putting
 `autocommit: N change(s) in the some-scope analyze-service index` on a foreign
 branch. `test_git_repo_isolation.py::POINTER_CLEARERS` pins it like the rest.
+
 """
 from __future__ import annotations
 
@@ -148,15 +162,16 @@ from pathlib import Path
 # --------------------------------------------------------------------------- #
 # 1. THE LEDGER: what redirects git at a repository
 # --------------------------------------------------------------------------- #
-# 🔴 ORDERED and EXACT. Each of the four shell entry points spells the same
-# names in a `DEVRC_GIT_REPO_POINTERS` array — they have to, because the
-# non-pytest targets (HOOK_TESTS, SHELL_TESTS, the node tier) never load a
-# pytest plugin, and because an inherited GIT_DIR corrupts each runner's ROOT
-# resolution before any Python runs. `test_git_repo_isolation.py::
-# test_the_shell_and_python_pointer_ledgers_agree` is parametrised over all
-# four and fails if any diverges from this tuple in EITHER direction. Adding a
-# name here without adding it there would leave those targets unprotected while
-# this file's docstring claimed otherwise.
+# 🔴 ORDERED and EXACT. Each of the FIVE shell files above spells the same names
+# in a `DEVRC_GIT_REPO_POINTERS` array — the four runners have to, because the
+# non-pytest targets (HOOK_TESTS, SHELL_TESTS, the node tier) never load a pytest
+# plugin, and because an inherited GIT_DIR corrupts each runner's ROOT resolution
+# before any Python runs; `commit.sh` has to because no test tier reaches it at
+# all. `test_git_repo_isolation.py::test_the_shell_and_python_pointer_ledgers_
+# agree` is parametrised over all FIVE (`POINTER_CLEARERS`) and fails if any
+# diverges from this tuple in EITHER direction. Adding a name here without adding
+# it there would leave those targets unprotected while this docstring claimed
+# otherwise.
 REPO_POINTER_VARS: tuple[str, ...] = (
     "GIT_DIR",                            # the repository itself; beats -C
     "GIT_WORK_TREE",                      # the working tree

--- a/scripts/tests/test_analyze_service_index_commit.py
+++ b/scripts/tests/test_analyze_service_index_commit.py
@@ -2438,7 +2438,7 @@ def test_the_bind_list_parser_sees_an_appended_entry():
 # That is BOTH hazards at once — client-identifying content into a foreign
 # repository AND a backup that does not exist while the unit prints ok — and it
 # never self-heals, because every later run repeats it. It is arguably the worst
-# of the five, and the false comment was instructing the next maintainer not to
+# of the six, and the false comment was instructing the next maintainer not to
 # cover it. `_fingerprint` now walks `objects/`; see its docstring.
 #
 # 🔴 ALL ELEVEN LEDGER NAMES ARE MEASURED, not six of them with the rest left to
@@ -2447,12 +2447,19 @@ def test_the_bind_list_parser_sees_an_appended_entry():
 # shape as the GIT_OBJECT_DIRECTORY correction above, one level up. Each was run
 # ALONE against the pre-fix script with the WIDENED fingerprint:
 #
+# 🔴 AND WITH NO GIT IDENTITY IN THE ENVIRONMENT, which is how the unit actually
+# runs (a systemd timer has no GIT_AUTHOR_*/GIT_COMMITTER_*). The first version
+# of this table was measured with them exported and recorded `GIT_CONFIG rc=0`;
+# that number was an artifact of the probe FIXING a dimension the unit does not
+# have. Re-measured both ways — identity in env flips GIT_CONFIG from rc 1 to
+# rc 0 and nothing else — so the honest column is the one without it.
+#
 #   variable                          rc   foreign repo moved?
-#   GIT_DIR                            0   YES  (both the worktree and main gitdir)
+#   GIT_DIR                            0   YES  silent: no own repo, commits land foreign
 #   GIT_COMMON_DIR                     0   YES  config
 #   GIT_INDEX_FILE                     0   YES  index
 #   GIT_OBJECT_DIRECTORY               0   YES  objects + an unusable backup
-#   GIT_CONFIG                         0   YES  config  <-- found BY this sweep
+#   GIT_CONFIG                         1   YES  config AND a loud failure  <-- see below
 #   GIT_WORK_TREE                      1   no — the run FAILED instead
 #   GIT_ALTERNATE_OBJECT_DIRECTORIES   0   no
 #   GIT_NAMESPACE                      0   no
@@ -2464,13 +2471,27 @@ def test_the_bind_list_parser_sees_an_appended_entry():
 # six others are NOT, and that is the honest label: they are on the ledger
 # because they redirect git in general, but a test over them here would be an
 # invariant guard wearing a regression test's name. Post-fix, all eleven leave
-# the foreign repo byte-identical and the scope backed up correctly.
+# the foreign repo byte-identical and the scope backed up correctly, rc 0.
 #
-# GIT_CONFIG is the one this sweep turned up: it makes the per-repo
-# `commit.gpgsign false` pin write into the FOREIGN repository's config
-# (`+[commit]\n\tgpgsign = false` measured in the decoy) — configuration damage
-# to somebody else's checkout, the same class as the `core.hooksPath` and
-# `remote.origin.url` writes in the 2026-08-21 incident.
+# 🔴 THE rc COLUMN IS A DISCRIMINATOR, NOT DECORATION — it is the whole reason
+# GIT_WORK_TREE sits in the excluded half ("the run FAILED rather than misdirect
+# it"). So GIT_CONFIG's rc matters: it is a THIRD shape, not a copy of either
+# neighbour.
+#
+#   GIT_DIR        rc 0  foreign write, silent — the script reports ok
+#   GIT_WORK_TREE  rc 1  loud failure, nothing foreign touched
+#   GIT_CONFIG     rc 1  loud failure AND a foreign write AND no usable backup
+#
+# MEASURED for GIT_CONFIG against the pre-fix script: the per-repo
+# `commit.gpgsign false` pin AND the identity seeding both land in the FOREIGN
+# repository's config (`+[commit]\n\tgpgsign = false` in the decoy), after which
+# the scope's own commit cannot resolve an author —
+#     "seeded a local commit identity (analyze-service index …)"
+#     "git commit failed (rc=128): Author identity unknown"
+# so the scope IS bootstrapped, the foreign config IS rewritten, and the backup
+# is still not made. Configuration damage to somebody else's checkout is the
+# same class as the `core.hooksPath` / `remote.origin.url` writes in the
+# 2026-08-21 incident; the loud exit is what stops it being the silent one.
 #
 # ⚠ AND TWO THAT ARE NOT ON THE SHARED LEDGER AT ALL, covered separately below:
 # GIT_CEILING_DIRECTORIES and GIT_TEMPLATE_DIR cannot redirect git, so GUARD 9
@@ -2574,6 +2595,69 @@ def _fingerprint(dirs):
 
 _SPOOF_SHAPES = ("GIT_DIR_worktree", "GIT_DIR_main", "GIT_INDEX_FILE",
                  "GIT_COMMON_DIR", "GIT_OBJECT_DIRECTORY", "GIT_CONFIG")
+
+#: The ledger names each parametrised case above actually leaks. Spelled
+#: separately from `_SPOOF_SHAPES` because two cases share `GIT_DIR`.
+_SHAPES_COVER = {
+    "GIT_DIR", "GIT_INDEX_FILE", "GIT_COMMON_DIR", "GIT_OBJECT_DIRECTORY",
+    "GIT_CONFIG",
+}
+
+#: Measured NOT to damage the foreign repo on their own, with their reason. This
+#: is the other half of the eleven, enumerated rather than implied — see
+#: `test_the_measured_table_covers_every_ledger_name`.
+_SHAPES_EXCLUDED = {
+    "GIT_WORK_TREE": "rc 1 — the pre-fix run FAILED rather than misdirect it",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES": "foreign repo byte-identical",
+    "GIT_NAMESPACE": "foreign repo byte-identical",
+    "GIT_PREFIX": "foreign repo byte-identical",
+    "GIT_GRAFT_FILE": "foreign repo byte-identical",
+    "GIT_SHALLOW_FILE": "foreign repo byte-identical",
+}
+
+
+def test_the_measured_table_covers_every_ledger_name():
+    """🔴 THE TABLE ABOVE SAYS "ALL ELEVEN" — MAKE THAT ENFORCED, NOT ASSERTED.
+
+    A twelfth name added to `REPO_POINTER_VARS` is forced into `commit.sh`'s
+    array by `test_the_shell_and_python_pointer_ledgers_agree`, so the FIX would
+    cover it automatically. Nothing forces it into this file, though: the
+    sentence "all eleven ledger names are measured" would silently become false
+    and a damage class would go untried — which is precisely the unstated-scope
+    defect this section already had to correct twice.
+
+    So pin it BOTH WAYS. Growing fails (a new name must be measured and then
+    either parametrised or excluded with a reason); shrinking fails too (a name
+    that leaves the ledger must leave this file deliberately, not linger as a
+    case testing something the guard no longer claims).
+
+    Same shape as `test_POINTER_CLEARERS_is_every_file_that_declares_the_array`
+    one file over — this was a consistency gap, not a missing idea.
+    """
+    from testlib.gitenv import REPO_POINTER_VARS
+
+    ledger = set(REPO_POINTER_VARS)
+    accounted = _SHAPES_COVER | set(_SHAPES_EXCLUDED)
+
+    assert not (_SHAPES_COVER & set(_SHAPES_EXCLUDED)), (
+        "a name is both parametrised and excluded: "
+        f"{sorted(_SHAPES_COVER & set(_SHAPES_EXCLUDED))}")
+    assert accounted == ledger, (
+        "the measured table disagrees with REPO_POINTER_VARS:\n"
+        f"  on the ledger, NOT measured here: {sorted(ledger - accounted)}\n"
+        f"  measured here, NOT on the ledger: {sorted(accounted - ledger)}\n"
+        "Measure the new name against the PRE-FIX script and then either add it "
+        "to _SHAPES_COVER with a parametrised case, or to _SHAPES_EXCLUDED with "
+        "the reason it is harmless alone. Do not just edit this set.")
+
+    # Every covered name must actually be leaked by some case — otherwise the
+    # set could claim coverage that `_spoof_env` never produces.
+    leaked = set()
+    for shape in _SPOOF_SHAPES:
+        leaked |= set(_spoof_env(shape, Path("/w"), Path("/w/.git/worktrees/wt")))
+    assert leaked == _SHAPES_COVER, (
+        "_SHAPES_COVER does not match what the parametrised cases actually "
+        f"export:\n  claimed: {sorted(_SHAPES_COVER)}\n  exported: {sorted(leaked)}")
 
 
 def _spoof_env(shape, work, gitdir):

--- a/scripts/tests/test_analyze_service_index_commit.py
+++ b/scripts/tests/test_analyze_service_index_commit.py
@@ -35,6 +35,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS = ROOT / "scripts"
 SCRIPT = SCRIPTS / "analyze-service-index" / "commit.sh"
@@ -2391,3 +2393,204 @@ def test_the_bind_list_parser_sees_an_appended_entry():
         "test_the_bind_lists_are_pinned_by_exact_contents is vacuous")
     assert empty == [], "an EMPTY list must read as empty, not as missing"
     assert absent is None, "a MISSING directive must read as None, not as empty"
+
+
+# --------------------------------------------------------------------------- #
+# 9. 🔴 THE REPO POINTERS — commit.sh must not be aimable by ENVIRONMENT
+# --------------------------------------------------------------------------- #
+# Every git call in this script is `git -C "$scope" …`, and `-C` is the weakest
+# possible claim about where a command lands. GIT_DIR overrides it.
+#
+# WHY IT MATTERS HERE AND NOT ONLY IN THE TEST HARNESS. `scripts/run-tests.sh`,
+# `run-node-tests.sh` and `gate.sh` already strip the pointers for the test tiers
+# (GUARD 9, scripts/testlib/gitenv.py). commit.sh is reached by none of them: it
+# runs from a systemd timer and from an operator's shell, and it is the one
+# program in this repo whose JOB is to commit. Its own strip is what makes the
+# refusal non-spoofable independently of who called it.
+#
+# 🔴 THE SHAPES BELOW ARE MEASURED, NOT IMAGINED. Each was run against the
+# PRE-FIX script with a decoy repo and a linked worktree, and each moved the
+# foreign repository:
+#
+#   GIT_DIR=<worktree gitdir>  refs/heads/decoy/target, config, index, logs/HEAD
+#   GIT_DIR=<main gitdir>      refs/heads/decoy/base,   config, index, logs/HEAD
+#   GIT_INDEX_FILE             the foreign worktree's index, overwritten
+#   GIT_COMMON_DIR             the foreign config (the identity seeding)
+#
+# DELIBERATELY NOT PARAMETRISED OVER, and measured too, so nobody adds them
+# believing they are regression coverage: GIT_OBJECT_DIRECTORY and GIT_NAMESPACE
+# alone left the foreign repo byte-identical on the pre-fix tree, and
+# GIT_WORK_TREE alone made the pre-fix run FAIL (rc 1) rather than misdirect it.
+# They are on the ledger because they redirect git in general; a test over them
+# here would be an invariant guard wearing a regression test's name.
+from testlib.gitenv import (  # noqa: E402
+    common_dir_of,
+    diff_snapshots,
+    resolve_git_dir,
+    snapshot,
+)
+
+
+def _decoy_repo_with_worktree(tmp_path):
+    """A foreign repo + a LINKED worktree on its own branch.
+
+    The linked worktree is the wild shape: `git push` from one exports
+    GIT_DIR=<repo>/.git/worktrees/<name> into the pre-push hook's environment
+    (MEASURED, git 2.55.0 — a push from the MAIN checkout exports no GIT_DIR),
+    which is how the variable reaches a suite, and from there anything the suite
+    runs.
+    """
+    work = tmp_path / "decoy" / "work"
+    work.mkdir(parents=True)
+    env = dict(os.environ)
+    env.update({"GIT_AUTHOR_NAME": "decoy", "GIT_AUTHOR_EMAIL": "d@example.invalid",
+                "GIT_COMMITTER_NAME": "decoy", "GIT_COMMITTER_EMAIL": "d@example.invalid"})
+    subprocess.run(["git", "init", "-q", "-b", "decoy/base", str(work)],
+                   check=True, capture_output=True, env=env)
+    (work / "real-file.txt").write_text("real\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(work), "add", "real-file.txt"],
+                   check=True, capture_output=True, env=env)
+    subprocess.run(["git", "-C", str(work), "commit", "-qm",
+                    "decoy: the real commit that must survive"],
+                   check=True, capture_output=True, env=env)
+    wt = tmp_path / "decoy" / "wt"
+    subprocess.run(["git", "-C", str(work), "worktree", "add", str(wt),
+                    "-b", "decoy/target", "-q"],
+                   check=True, capture_output=True, env=env)
+    gitdir = work / ".git" / "worktrees" / "wt"
+    assert gitdir.is_dir(), f"no linked-worktree gitdir at {gitdir}"
+    return work, wt, gitdir
+
+
+def _foreign_git_dirs(wt):
+    """The per-worktree gitdir AND the common dir where refs/config really live.
+
+    Watching only the per-worktree dir would miss every ref and config write —
+    two of the four measured damage shapes.
+    """
+    git_dir = resolve_git_dir(wt)
+    assert git_dir is not None, f"could not resolve a git dir for {wt}"
+    common = common_dir_of(git_dir)
+    assert common is not None, (
+        f"{wt} reported no common dir; the fingerprint would be blind to "
+        "exactly the refs and config the pre-fix script rewrote")
+    return [git_dir, common]
+
+
+def _fingerprint(dirs):
+    """`index` is INCLUDED here, unlike gitenv.snapshot's default use against the
+    HOST repo. The racy-refresh objection that keeps it out there does not apply
+    to a decoy nothing else reads between two snapshots, and an overwritten
+    index is one of the four measured damage shapes."""
+    return snapshot(dirs, extra_files=[d / "index" for d in dirs])
+
+
+_SPOOF_SHAPES = ("GIT_DIR_worktree", "GIT_DIR_main", "GIT_INDEX_FILE", "GIT_COMMON_DIR")
+
+
+def _spoof_env(shape, work, gitdir):
+    return {
+        "GIT_DIR_worktree": {"GIT_DIR": str(gitdir)},
+        "GIT_DIR_main": {"GIT_DIR": str(work / ".git")},
+        "GIT_INDEX_FILE": {"GIT_INDEX_FILE": str(gitdir / "index")},
+        "GIT_COMMON_DIR": {"GIT_COMMON_DIR": str(work / ".git")},
+    }[shape]
+
+
+@pytest.mark.parametrize("shape", _SPOOF_SHAPES)
+def test_a_leaked_repo_pointer_cannot_aim_the_committer_at_a_foreign_repo(tmp_path, shape):
+    """🔴 THE REGRESSION. Red on the pre-fix tree for all four shapes.
+
+    The assertion is the RELATIONSHIP — the foreign repository is byte-identical
+    afterwards — not that a particular sentence was printed. A message can be
+    reworded; a moved ref cannot be talked out of.
+
+    And the scope is asserted to have become its OWN repo with its OWN commit,
+    because "the foreign repo did not move" is equally true of a script that did
+    nothing at all.
+    """
+    work, wt, gitdir = _decoy_repo_with_worktree(tmp_path)
+    dirs = _foreign_git_dirs(wt)
+    before = _fingerprint(dirs)
+
+    store = _seed(tmp_path)
+    p = _run(store, **_spoof_env(shape, work, gitdir))
+
+    deltas = diff_snapshots(before, _fingerprint(dirs))
+    assert deltas == [], (
+        f"a leaked {shape} aimed commit.sh at the foreign repository:\n"
+        + "\n".join(deltas)
+        + f"\n\nscript said:\n{p.stdout}\n{p.stderr}")
+    assert p.returncode == 0, f"the run should still succeed normally:\n{p.stderr}"
+    assert (store / "some-scope" / ".git").is_dir(), (
+        "the scope did not become its own repo, so this test would pass just as "
+        f"well if the script had done nothing:\n{p.stdout}\n{p.stderr}")
+    assert _commits(store / "some-scope") == 1, (
+        f"the scope has no commit of its own:\n{p.stdout}\n{p.stderr}")
+
+
+def test_the_foreign_repo_fixture_would_actually_record_a_write(tmp_path):
+    """🔴 POSITIVE CONTROL. The four assertions above are ZEROES — "nothing
+    moved" — and a zero is indistinguishable from a fingerprint wired to nothing.
+
+    So do the damaging thing on purpose, with the same fixture and the same
+    variable, and watch the number move. This is the mechanism itself: `git -C`
+    at a directory that is NOT a repo, with GIT_DIR inherited, commits to the
+    foreign branch instead of erroring.
+    """
+    work, wt, gitdir = _decoy_repo_with_worktree(tmp_path)
+    dirs = _foreign_git_dirs(wt)
+    before = _fingerprint(dirs)
+
+    notarepo = tmp_path / "notarepo"
+    notarepo.mkdir()
+    env = dict(os.environ)
+    env.update({"GIT_DIR": str(gitdir),
+                "GIT_AUTHOR_NAME": "probe", "GIT_AUTHOR_EMAIL": "p@example.invalid",
+                "GIT_COMMITTER_NAME": "probe", "GIT_COMMITTER_EMAIL": "p@example.invalid"})
+    p = subprocess.run(["git", "-C", str(notarepo), "commit", "-q", "--allow-empty",
+                        "-m", "control: the write the guard must prevent"],
+                       capture_output=True, text=True, env=env)
+    assert p.returncode == 0, (
+        "git refused the spoof, so the mechanism this section guards against no "
+        f"longer exists on this git — every zero above is unfalsifiable:\n{p.stderr}")
+
+    deltas = diff_snapshots(before, _fingerprint(dirs))
+    assert deltas, (
+        "the foreign repo was written to and the fingerprint saw NOTHING — the "
+        "detector every assertion above relies on is not wired up")
+    assert any("refs/heads/decoy/target" in d for d in deltas), (
+        "the branch write was invisible to the fingerprint:\n" + "\n".join(deltas))
+
+
+def test_a_leaked_pointer_does_not_defeat_the_nested_scope_refusal(tmp_path):
+    """🔴 THE GUARD'S REAL JOB MUST SURVIVE THE FIX.
+
+    `scope_repo_state` exists to refuse a scope that sits INSIDE somebody else's
+    checkout. On the pre-fix tree a leaked GIT_DIR made such a scope report state
+    1 — "it IS its own repo" — so the refusal never fired. A fix that merely
+    stopped the foreign WRITE while leaving the state wrong would still commit
+    client-sensitive content into the enclosing repo.
+
+    So: nested scope AND a leaked pointer, and the refusal must still be the
+    outcome, asserted by its own message.
+    """
+    work, wt, gitdir = _decoy_repo_with_worktree(tmp_path)
+    dirs = _foreign_git_dirs(wt)
+    before = _fingerprint(dirs)
+
+    store = tmp_path / "parentstore"
+    (store / "inner").mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", "-b", "trunk", str(store)],
+                   check=True, capture_output=True)
+    (store / "inner" / "thing.md").write_text("x\n", encoding="utf-8")
+
+    p = _run(store, GIT_DIR=str(gitdir))
+    assert p.returncode != 0, (
+        f"a scope nested in a foreign repo was NOT refused:\n{p.stdout}\n{p.stderr}")
+    assert "not its own repo" in p.stderr, (
+        f"the run failed, but not for the nesting reason:\n{p.stderr}")
+    assert not (store / "inner" / ".git").exists(), (
+        "the nested scope was bootstrapped into its own repo instead of refused")
+    assert diff_snapshots(before, _fingerprint(dirs)) == [], (
+        "the decoy repository moved while the nested scope was being refused")

--- a/scripts/tests/test_analyze_service_index_commit.py
+++ b/scripts/tests/test_analyze_service_index_commit.py
@@ -2417,6 +2417,7 @@ def test_the_bind_list_parser_sees_an_appended_entry():
 #   GIT_INDEX_FILE             the foreign worktree's index, overwritten
 #   GIT_COMMON_DIR             the foreign config (the identity seeding)
 #   GIT_OBJECT_DIRECTORY       the foreign OBJECT STORE — see below
+#   GIT_CONFIG                 the foreign repo's config (the gpgsign pin)
 #
 # 🔴 A CORRECTION, AND THE REASON IT WAS WRONG. An earlier revision of this
 # comment said GIT_OBJECT_DIRECTORY "alone left the foreign repo byte-identical
@@ -2440,12 +2441,36 @@ def test_the_bind_list_parser_sees_an_appended_entry():
 # of the five, and the false comment was instructing the next maintainer not to
 # cover it. `_fingerprint` now walks `objects/`; see its docstring.
 #
-# DELIBERATELY NOT PARAMETRISED OVER, and re-measured with the WIDENED
-# fingerprint so this claim is not the previous one's mistake again:
-# GIT_NAMESPACE alone left the foreign repo byte-identical on the pre-fix tree,
-# and GIT_WORK_TREE alone made the pre-fix run FAIL (rc 1) rather than misdirect
-# it. They are on the ledger because they redirect git in general; a test over
-# them here would be an invariant guard wearing a regression test's name.
+# 🔴 ALL ELEVEN LEDGER NAMES ARE MEASURED, not six of them with the rest left to
+# inference. An earlier revision listed only the damaging ones and read as
+# exhaustive while five names had never been tried — the same unstated-scope
+# shape as the GIT_OBJECT_DIRECTORY correction above, one level up. Each was run
+# ALONE against the pre-fix script with the WIDENED fingerprint:
+#
+#   variable                          rc   foreign repo moved?
+#   GIT_DIR                            0   YES  (both the worktree and main gitdir)
+#   GIT_COMMON_DIR                     0   YES  config
+#   GIT_INDEX_FILE                     0   YES  index
+#   GIT_OBJECT_DIRECTORY               0   YES  objects + an unusable backup
+#   GIT_CONFIG                         0   YES  config  <-- found BY this sweep
+#   GIT_WORK_TREE                      1   no — the run FAILED instead
+#   GIT_ALTERNATE_OBJECT_DIRECTORIES   0   no
+#   GIT_NAMESPACE                      0   no
+#   GIT_PREFIX                         0   no
+#   GIT_GRAFT_FILE                     0   no
+#   GIT_SHALLOW_FILE                   0   no
+#
+# The five YES names are parametrised below (six cases — GIT_DIR gets two). The
+# six others are NOT, and that is the honest label: they are on the ledger
+# because they redirect git in general, but a test over them here would be an
+# invariant guard wearing a regression test's name. Post-fix, all eleven leave
+# the foreign repo byte-identical and the scope backed up correctly.
+#
+# GIT_CONFIG is the one this sweep turned up: it makes the per-repo
+# `commit.gpgsign false` pin write into the FOREIGN repository's config
+# (`+[commit]\n\tgpgsign = false` measured in the decoy) — configuration damage
+# to somebody else's checkout, the same class as the `core.hooksPath` and
+# `remote.origin.url` writes in the 2026-08-21 incident.
 #
 # ⚠ AND TWO THAT ARE NOT ON THE SHARED LEDGER AT ALL, covered separately below:
 # GIT_CEILING_DIRECTORIES and GIT_TEMPLATE_DIR cannot redirect git, so GUARD 9
@@ -2494,7 +2519,7 @@ def _foreign_git_dirs(wt):
     """The per-worktree gitdir AND the common dir where refs/config really live.
 
     Watching only the per-worktree dir would miss every ref and config write —
-    two of the four measured damage shapes.
+    three of the measured damage shapes (config, refs, index).
     """
     git_dir = resolve_git_dir(wt)
     assert git_dir is not None, f"could not resolve a git dir for {wt}"
@@ -2548,7 +2573,7 @@ def _fingerprint(dirs):
 
 
 _SPOOF_SHAPES = ("GIT_DIR_worktree", "GIT_DIR_main", "GIT_INDEX_FILE",
-                 "GIT_COMMON_DIR", "GIT_OBJECT_DIRECTORY")
+                 "GIT_COMMON_DIR", "GIT_OBJECT_DIRECTORY", "GIT_CONFIG")
 
 
 def _spoof_env(shape, work, gitdir):
@@ -2558,12 +2583,13 @@ def _spoof_env(shape, work, gitdir):
         "GIT_INDEX_FILE": {"GIT_INDEX_FILE": str(gitdir / "index")},
         "GIT_COMMON_DIR": {"GIT_COMMON_DIR": str(work / ".git")},
         "GIT_OBJECT_DIRECTORY": {"GIT_OBJECT_DIRECTORY": str(work / ".git" / "objects")},
+        "GIT_CONFIG": {"GIT_CONFIG": str(work / ".git" / "config")},
     }[shape]
 
 
 @pytest.mark.parametrize("shape", _SPOOF_SHAPES)
 def test_a_leaked_repo_pointer_cannot_aim_the_committer_at_a_foreign_repo(tmp_path, shape):
-    """🔴 THE REGRESSION. Red on the pre-fix tree for all FIVE shapes.
+    """🔴 THE REGRESSION. Red on the pre-fix tree for all SIX cases.
 
     TWO independent claims, because GIT_OBJECT_DIRECTORY broke both at once and
     either one alone would have passed it:
@@ -2627,7 +2653,7 @@ def test_a_leaked_repo_pointer_cannot_aim_the_committer_at_a_foreign_repo(tmp_pa
 
 
 def test_the_foreign_repo_fixture_would_actually_record_a_write(tmp_path):
-    """🔴 POSITIVE CONTROL. The four assertions above are ZEROES — "nothing
+    """🔴 POSITIVE CONTROL. The six assertions above are ZEROES — "nothing
     moved" — and a zero is indistinguishable from a fingerprint wired to nothing.
 
     So do the damaging thing on purpose, with the same fixture and the same
@@ -2658,6 +2684,23 @@ def test_the_foreign_repo_fixture_would_actually_record_a_write(tmp_path):
         "detector every assertion above relies on is not wired up")
     assert any("refs/heads/decoy/target" in d for d in deltas), (
         "the branch write was invisible to the fingerprint:\n" + "\n".join(deltas))
+    # 🔴 THE `objects/` COMPONENT, PINNED BY A DELTA ONLY IT CAN SEE.
+    #
+    # Without this line the component added in this very round is itself
+    # unpinned: `_objects_files` could `return []` unconditionally and this
+    # control stays green, because the ref delta above already satisfies
+    # `assert deltas`. That is one level up from the defect this section exists
+    # to correct — a silent empty from the instrument reading as a clean repo —
+    # and it is the treatment this file's own docstring promises for every
+    # fingerprint entry: a mutation ONLY that entry can observe.
+    #
+    # MEASURED: with `_objects_files` stubbed to `[]`, the suite was 99 passed /
+    # 0 red before this assertion existed.
+    assert any("/objects/" in d for d in deltas), (
+        "the commit's OBJECTS were invisible to the fingerprint — `_fingerprint` "
+        "is not watching `objects/`, so the GIT_OBJECT_DIRECTORY shape above "
+        "would report a clean repo while the store's content sat in it:\n"
+        + "\n".join(deltas))
 
 
 def test_a_leaked_pointer_does_not_defeat_the_nested_scope_refusal(tmp_path):

--- a/scripts/tests/test_analyze_service_index_commit.py
+++ b/scripts/tests/test_analyze_service_index_commit.py
@@ -2409,20 +2409,48 @@ def test_the_bind_list_parser_sees_an_appended_entry():
 # refusal non-spoofable independently of who called it.
 #
 # 🔴 THE SHAPES BELOW ARE MEASURED, NOT IMAGINED. Each was run against the
-# PRE-FIX script with a decoy repo and a linked worktree, and each moved the
+# PRE-FIX script with a decoy repo and a linked worktree, and each damaged the
 # foreign repository:
 #
 #   GIT_DIR=<worktree gitdir>  refs/heads/decoy/target, config, index, logs/HEAD
 #   GIT_DIR=<main gitdir>      refs/heads/decoy/base,   config, index, logs/HEAD
 #   GIT_INDEX_FILE             the foreign worktree's index, overwritten
 #   GIT_COMMON_DIR             the foreign config (the identity seeding)
+#   GIT_OBJECT_DIRECTORY       the foreign OBJECT STORE — see below
 #
-# DELIBERATELY NOT PARAMETRISED OVER, and measured too, so nobody adds them
-# believing they are regression coverage: GIT_OBJECT_DIRECTORY and GIT_NAMESPACE
-# alone left the foreign repo byte-identical on the pre-fix tree, and
-# GIT_WORK_TREE alone made the pre-fix run FAIL (rc 1) rather than misdirect it.
-# They are on the ledger because they redirect git in general; a test over them
-# here would be an invariant guard wearing a regression test's name.
+# 🔴 A CORRECTION, AND THE REASON IT WAS WRONG. An earlier revision of this
+# comment said GIT_OBJECT_DIRECTORY "alone left the foreign repo byte-identical
+# on the pre-fix tree", and that a test over it "would be an invariant guard
+# wearing a regression test's name". BOTH SENTENCES WERE FALSE, and they were
+# false because `_fingerprint` below did not watch `objects/` — the instrument
+# returned a zero and the zero was written up as a fact about the repository
+# (claude/RULES.md → "a reassuring zero is indistinguishable from a harness wired
+# to nothing"). RE-MEASURED against the pre-fix script:
+#
+#     GIT_OBJECT_DIRECTORY=<decoy>/.git/objects  commit.sh <store>
+#       -> "committed 9b8a9f2 — 1 change(s)" / "ok — 1 scope(s) processed", rc 0
+#       -> foreign loose objects 3 -> 6, and one of the three new ones is a BLOB
+#          holding the store's own index content
+#       -> the scope's `.git` EXISTS but its `objects/` is EMPTY, so
+#          `git -C <scope> log` -> "fatal: not a git repository"
+#
+# That is BOTH hazards at once — client-identifying content into a foreign
+# repository AND a backup that does not exist while the unit prints ok — and it
+# never self-heals, because every later run repeats it. It is arguably the worst
+# of the five, and the false comment was instructing the next maintainer not to
+# cover it. `_fingerprint` now walks `objects/`; see its docstring.
+#
+# DELIBERATELY NOT PARAMETRISED OVER, and re-measured with the WIDENED
+# fingerprint so this claim is not the previous one's mistake again:
+# GIT_NAMESPACE alone left the foreign repo byte-identical on the pre-fix tree,
+# and GIT_WORK_TREE alone made the pre-fix run FAIL (rc 1) rather than misdirect
+# it. They are on the ledger because they redirect git in general; a test over
+# them here would be an invariant guard wearing a regression test's name.
+#
+# ⚠ AND TWO THAT ARE NOT ON THE SHARED LEDGER AT ALL, covered separately below:
+# GIT_CEILING_DIRECTORIES and GIT_TEMPLATE_DIR cannot redirect git, so GUARD 9
+# does not strip them — but both were measured breaking THIS script, and
+# commit.sh strips them in its own `ASI_LOCAL_GIT_POINTERS` array.
 from testlib.gitenv import (  # noqa: E402
     common_dir_of,
     diff_snapshots,
@@ -2477,15 +2505,50 @@ def _foreign_git_dirs(wt):
     return [git_dir, common]
 
 
+def _objects_files(dirs):
+    """Every file under each git dir's `objects/` — loose objects AND packs.
+
+    🔴 THIS IS THE HALF THAT WAS MISSING, and its absence is why the first
+    revision of this section asserted something false about GIT_OBJECT_DIRECTORY.
+    `gitenv.snapshot` watches `config/HEAD/packed-refs/ORIG_HEAD/logs/HEAD` and
+    `refs/**` — the right set for the HOST-repo detector, where object churn is
+    noisy and harmless — so a write that lands ONLY in `objects/` produced a
+    clean report. Against a decoy that nothing else touches, `objects/` is both
+    quiet and exactly where content exfiltration shows up.
+    """
+    out = []
+    for d in dirs:
+        root = d / "objects"
+        if not root.is_dir():
+            continue
+        for dirpath, _dirnames, filenames in os.walk(root):
+            for name in filenames:
+                out.append(Path(dirpath) / name)
+    return out
+
+
 def _fingerprint(dirs):
-    """`index` is INCLUDED here, unlike gitenv.snapshot's default use against the
-    HOST repo. The racy-refresh objection that keeps it out there does not apply
-    to a decoy nothing else reads between two snapshots, and an overwritten
-    index is one of the four measured damage shapes."""
-    return snapshot(dirs, extra_files=[d / "index" for d in dirs])
+    """The foreign repository's content, as wide as the damage can be.
+
+    Beyond `gitenv.snapshot`'s default set, two additions, each because a
+    measured shape lands there and nowhere else:
+
+      * `index`   — GIT_INDEX_FILE overwrites it. Excluded from the HOST-repo
+                    fingerprint because a plain `git status` rewrites it as a
+                    racy-timestamp refresh; that objection does not apply to a
+                    decoy nothing else reads between two snapshots.
+      * `objects/`— GIT_OBJECT_DIRECTORY writes the store's own blobs there and
+                    touches nothing else. See `_objects_files`.
+
+    🔴 Keep this WIDER than the narrowest thing that could fail, not equal to it.
+    The claim these tests make is "the foreign repository is untouched"; a
+    fingerprint narrower than that claim reads as coverage while providing none.
+    """
+    return snapshot(dirs, extra_files=[d / "index" for d in dirs] + _objects_files(dirs))
 
 
-_SPOOF_SHAPES = ("GIT_DIR_worktree", "GIT_DIR_main", "GIT_INDEX_FILE", "GIT_COMMON_DIR")
+_SPOOF_SHAPES = ("GIT_DIR_worktree", "GIT_DIR_main", "GIT_INDEX_FILE",
+                 "GIT_COMMON_DIR", "GIT_OBJECT_DIRECTORY")
 
 
 def _spoof_env(shape, work, gitdir):
@@ -2494,20 +2557,28 @@ def _spoof_env(shape, work, gitdir):
         "GIT_DIR_main": {"GIT_DIR": str(work / ".git")},
         "GIT_INDEX_FILE": {"GIT_INDEX_FILE": str(gitdir / "index")},
         "GIT_COMMON_DIR": {"GIT_COMMON_DIR": str(work / ".git")},
+        "GIT_OBJECT_DIRECTORY": {"GIT_OBJECT_DIRECTORY": str(work / ".git" / "objects")},
     }[shape]
 
 
 @pytest.mark.parametrize("shape", _SPOOF_SHAPES)
 def test_a_leaked_repo_pointer_cannot_aim_the_committer_at_a_foreign_repo(tmp_path, shape):
-    """🔴 THE REGRESSION. Red on the pre-fix tree for all four shapes.
+    """🔴 THE REGRESSION. Red on the pre-fix tree for all FIVE shapes.
 
-    The assertion is the RELATIONSHIP — the foreign repository is byte-identical
-    afterwards — not that a particular sentence was printed. A message can be
-    reworded; a moved ref cannot be talked out of.
+    TWO independent claims, because GIT_OBJECT_DIRECTORY broke both at once and
+    either one alone would have passed it:
 
-    And the scope is asserted to have become its OWN repo with its OWN commit,
-    because "the foreign repo did not move" is equally true of a script that did
-    nothing at all.
+      1. the foreign repository is untouched — asserted as the RELATIONSHIP, a
+         `_fingerprint` equality over refs + HEAD + config + logs + index +
+         `objects/`, not "a particular sentence was printed". A message can be
+         reworded; a written object cannot be talked out of.
+      2. the BACKUP ACTUALLY EXISTS — the scope is its own repo, with its own
+         commit, and that commit is READABLE. Under a leaked
+         GIT_OBJECT_DIRECTORY the pre-fix script created a `.git` whose
+         `objects/` was empty, so `git log` in the scope said "fatal: not a git
+         repository" while the unit printed ok. "The foreign repo did not move"
+         is equally true of a script that did nothing, and "a .git exists" is
+         equally true of a backup that cannot be read.
     """
     work, wt, gitdir = _decoy_repo_with_worktree(tmp_path)
     dirs = _foreign_git_dirs(wt)
@@ -2527,6 +2598,32 @@ def test_a_leaked_repo_pointer_cannot_aim_the_committer_at_a_foreign_repo(tmp_pa
         f"well if the script had done nothing:\n{p.stdout}\n{p.stderr}")
     assert _commits(store / "some-scope") == 1, (
         f"the scope has no commit of its own:\n{p.stdout}\n{p.stderr}")
+    # 🔴 READABLE, not merely present: the objects backing that commit must be in
+    # the SCOPE's own store.
+    #
+    # ⚠ MEASURED, and stated because the honest version is less flattering: these
+    # two assertions kill NO mutant that `_commits(...) == 1` above does not
+    # already kill. Breaking GIT_OBJECT_DIRECTORY's strip with them deleted still
+    # fails, on "the scope has no commit of its own". They stay because they NAME
+    # the second hazard where a reader will look for it — but they are
+    # defence-in-depth, not independent coverage, and counting them as coverage
+    # would be the same error as the comment this section had to correct.
+    #
+    # The `objects/` half of `_fingerprint` is a different story and IS
+    # load-bearing: with the wide fingerprint the mutant dies on "aimed commit.sh
+    # at the foreign repository" (the exfiltration claim); with `objects/` removed
+    # the same mutant dies on "no commit of its own" instead — still red, but for
+    # the OTHER claim, leaving the leak itself unobserved. A test that goes red
+    # for the wrong reason is how a hazard stays invisible.
+    log = _git(store / "some-scope", "log", "--oneline")
+    assert log.returncode == 0 and log.stdout.strip(), (
+        f"the scope's repository exists but cannot be read back — the backup does "
+        f"not exist while the script printed ok:\n{log.stdout}{log.stderr}\n"
+        f"{p.stdout}{p.stderr}")
+    blobs = _git(store / "some-scope", "cat-file", "--batch-check", "--batch-all-objects")
+    assert blobs.returncode == 0 and blobs.stdout.strip(), (
+        f"the scope's object store is EMPTY — its commit's content went "
+        f"somewhere else:\n{blobs.stdout}{blobs.stderr}")
 
 
 def test_the_foreign_repo_fixture_would_actually_record_a_write(tmp_path):
@@ -2594,3 +2691,139 @@ def test_a_leaked_pointer_does_not_defeat_the_nested_scope_refusal(tmp_path):
         "the nested scope was bootstrapped into its own repo instead of refused")
     assert diff_snapshots(before, _fingerprint(dirs)) == [], (
         "the decoy repository moved while the nested scope was being refused")
+
+
+# --------------------------------------------------------------------------- #
+# 9b. 🔴 THE TWO THAT ARE **NOT** ON GUARD 9's LEDGER
+# --------------------------------------------------------------------------- #
+# Neither variable can redirect git at a different repository, so neither is on
+# `REPO_POINTER_VARS` and neither ever will be — GUARD 9 answers one question and
+# this is not it. Both were nonetheless measured breaking THIS script, which is
+# the whole lesson: "not on the ledger" means "cannot redirect", never "safe to
+# inherit". commit.sh strips them in `ASI_LOCAL_GIT_POINTERS`.
+
+
+def test_an_inherited_ceiling_does_not_turn_the_nested_refusal_into_a_bootstrap(tmp_path):
+    """🔴 GIT_CEILING_DIRECTORIES. Red on the pre-fix tree.
+
+    It stops the upward discovery walk early, which is exactly how
+    `scope_repo_state` is made to answer 0 ("no repo") instead of 2 ("inside a
+    DIFFERENT repo") — and 0 means BOOTSTRAP. MEASURED against the pre-fix
+    script, a scope genuinely nested in a foreign checkout went from
+
+        rc=1  "scope inner: not its own repo — it sits inside <foreign>. Refusing…"
+    to
+        rc=0  "scope inner: initialised a new repository … ok — 1 scope(s) processed"
+
+    planting a `.git` inside somebody else's working tree. No client content
+    reaches foreign HISTORY, so this is not the exfiltration shape — and that is
+    precisely why an earlier comment waved it through as "the safe direction".
+    The refusal the test above calls THE GUARD'S REAL JOB was being converted
+    into its opposite, silently, with the run still printing ok.
+    """
+    store = tmp_path / "parentstore"
+    (store / "inner").mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", "-b", "trunk", str(store)],
+                   check=True, capture_output=True)
+    (store / "inner" / "thing.md").write_text("x\n", encoding="utf-8")
+
+    p = _run(store, GIT_CEILING_DIRECTORIES=str(store))
+
+    assert p.returncode != 0, (
+        "an inherited ceiling turned the nested-scope REFUSAL into a silent "
+        f"bootstrap:\n{p.stdout}\n{p.stderr}")
+    assert "not its own repo" in p.stderr, (
+        f"the run failed, but not for the nesting reason:\n{p.stderr}")
+    assert not (store / "inner" / ".git").exists(), (
+        "a .git was planted inside the foreign checkout instead of refusing")
+
+
+def test_the_ceiling_fixture_would_actually_hide_the_enclosing_repo(tmp_path):
+    """🔴 POSITIVE CONTROL for the ceiling. The assertion above is "still
+    refused", which is ALSO what a fixture whose ceiling does nothing produces —
+    a nested scope is refused with or without the variable. So prove the variable
+    bites: with the ceiling set, raw `rev-parse` must fail to find the enclosing
+    repo it finds without it.
+    """
+    store = tmp_path / "parentstore"
+    (store / "inner").mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", "-b", "trunk", str(store)],
+                   check=True, capture_output=True)
+
+    clean = {k: v for k, v in os.environ.items() if k != "GIT_CEILING_DIRECTORIES"}
+    found = subprocess.run(
+        ["git", "-C", str(store / "inner"), "rev-parse", "--show-toplevel"],
+        capture_output=True, text=True, env=clean)
+    assert found.returncode == 0 and found.stdout.strip(), (
+        f"the fixture's enclosing repo is not discoverable at all:\n{found.stderr}")
+
+    ceilinged = dict(clean)
+    ceilinged["GIT_CEILING_DIRECTORIES"] = str(store)
+    hidden = subprocess.run(
+        ["git", "-C", str(store / "inner"), "rev-parse", "--show-toplevel"],
+        capture_output=True, text=True, env=ceilinged)
+    assert hidden.returncode != 0, (
+        "GIT_CEILING_DIRECTORIES did not hide the enclosing repo on this git, so "
+        f"the test above is not measuring what it claims:\n{hidden.stdout}")
+
+
+def test_an_inherited_template_dir_plants_nothing_in_the_bootstrapped_repo(tmp_path):
+    """🔴 GIT_TEMPLATE_DIR. Red on the pre-fix tree.
+
+    This is the ENVIRONMENT twin of `init.templateDir`, which commit.sh's
+    GIT_CONFIG block already pins off — neutralising the config route while
+    leaving the env route open is the asymmetry: `GIT_CONFIG_GLOBAL=/dev/null`
+    does not touch a variable.
+
+    MEASURED against the pre-fix script: a template `hooks/post-commit` IS copied
+    into the repository this script bootstraps and PERSISTS there. It did not
+    FIRE, because `GIT_CONFIG_KEY_0=core.hooksPath` redirects hooks to an empty
+    dir — so the guard asserted here is about the PLANT, not the execution. A
+    dormant payload in the operator's backup is armed the moment anyone runs git
+    in that scope by hand, which is exactly what one does to inspect a backup.
+    """
+    tpl = tmp_path / "tpl"
+    (tpl / "hooks").mkdir(parents=True)
+    # 🔴 `write_exec`, not a hand-written shebang: test_runtime_shebangs.py fails
+    # any test that spells one itself, and it caught this file twice.
+    write_exec(tpl / "hooks" / "post-commit", "exit 0\n")
+    (tpl / "planted-marker").write_text("planted\n", encoding="utf-8")
+
+    store = _seed(tmp_path)
+    p = _run(store, GIT_TEMPLATE_DIR=str(tpl))
+    assert p.returncode == 0, f"the run should still succeed:\n{p.stderr}"
+
+    scope_git = store / "some-scope" / ".git"
+    assert scope_git.is_dir(), f"no repo was bootstrapped:\n{p.stdout}\n{p.stderr}"
+    assert not (scope_git / "hooks" / "post-commit").exists(), (
+        "an inherited GIT_TEMPLATE_DIR planted a post-commit hook inside the "
+        "repository this unit created. It is dormant only while core.hooksPath "
+        "stays redirected — that is one config change away from executing.")
+    assert not (scope_git / "planted-marker").exists(), (
+        "an inherited GIT_TEMPLATE_DIR seeded arbitrary files into the "
+        "bootstrapped repository")
+
+
+def test_the_template_fixture_would_actually_plant(tmp_path):
+    """🔴 POSITIVE CONTROL for the template. Two `assert not ...exists()` above
+    are absences, and an absence is what a template dir git never read also
+    produces. So run a plain `git init` with the SAME fixture and watch the files
+    arrive."""
+    tpl = tmp_path / "tpl"
+    (tpl / "hooks").mkdir(parents=True)
+    # 🔴 `write_exec`, not a hand-written shebang: test_runtime_shebangs.py fails
+    # any test that spells one itself, and it caught this file twice.
+    write_exec(tpl / "hooks" / "post-commit", "exit 0\n")
+    (tpl / "planted-marker").write_text("planted\n", encoding="utf-8")
+
+    target = tmp_path / "plain"
+    env = dict(os.environ)
+    env["GIT_TEMPLATE_DIR"] = str(tpl)
+    r = subprocess.run(["git", "init", "-q", str(target)],
+                       capture_output=True, text=True, env=env)
+    assert r.returncode == 0, r.stderr
+    assert (target / ".git" / "hooks" / "post-commit").is_file(), (
+        "GIT_TEMPLATE_DIR did not plant a hook even on a bare `git init`, so the "
+        "test above proves nothing about commit.sh")
+    assert (target / ".git" / "planted-marker").is_file(), (
+        "GIT_TEMPLATE_DIR did not seed the marker file")

--- a/scripts/tests/test_git_repo_isolation.py
+++ b/scripts/tests/test_git_repo_isolation.py
@@ -95,6 +95,25 @@ RUNNERS = (SCRIPTS / "run-tests.sh",
            SCRIPTS / "gate.sh",
            ROOT / "githooks" / "tests-on-push.sh")
 
+# 🔴 THE WRITER, added 2026-08-22. `analyze-service-index/commit.sh` is the one
+# program in this repo whose job is to `git commit`, and it is NOT a runner: it
+# resolves no ROOT, and it runs from a systemd timer and from an operator's
+# shell, neither of which passes through anything in RUNNERS. It carries the
+# same `unset` for the same reason and is pinned to the same owner — MEASURED on
+# the pre-fix tree, `GIT_DIR=<decoy>/.git/worktrees/wt commit.sh <store>` put an
+# `autocommit: N change(s) in the some-scope analyze-service index` commit on the
+# decoy's branch and exited 0, which is the 2026-08-21 incident's damage arriving
+# by a route no test tier covers.
+#
+# It is kept OUT of `RUNNERS` deliberately rather than folded in: the ordering
+# test below is about the ROOT resolution these three share and commit.sh has
+# none, so a single list would have to weaken that assertion to accommodate it.
+COMMIT_SH = SCRIPTS / "analyze-service-index" / "commit.sh"
+
+# Every file that carries a `DEVRC_GIT_REPO_POINTERS` spelling. The ledger pins
+# below run over ALL of them; only the ROOT-ordering pin is runner-specific.
+POINTER_CLEARERS = (*RUNNERS, COMMIT_SH)
+
 sys.path.insert(0, str(SCRIPTS))
 
 from testlib import gitenv, gitenv_plugin, mockbin  # noqa: E402
@@ -111,6 +130,7 @@ from testlib.gitenv import (  # noqa: E402
     SESSION_MARKER,
     VIOLATION_TOKEN,
     GitEnvConfigError,
+    common_dir_of,
     diff_snapshots,
     live_cotenants,
     protected_git_dirs,
@@ -121,6 +141,16 @@ from testlib.gitenv import (  # noqa: E402
     snapshot,
     strip_repo_pointers,
 )
+
+# 🔴 NOT a shebang and NOT a bare "bash". Section 6 drives run-tests.sh as a
+# subprocess; an unnarrowed `shutil.which` result would surface as a TypeError
+# from inside subprocess, naming the wrong cause.
+_BASH = shutil.which("bash")
+if _BASH is None:  # pragma: no cover - the gate puts bash on PATH
+    raise RuntimeError(
+        "bash is not on PATH. It is in run-tests.sh's REQUIRED_TOOLS and in the "
+        "flake's pytests check — add it there rather than skipping these tests.")
+BASH: str = _BASH
 
 # 🔴 NOT a skipif. `git` is in run-tests.sh's REQUIRED_TOOLS and in the flake's
 # pytests check, so its absence is an ERROR: a skipped isolation test reports a
@@ -189,13 +219,32 @@ def _mkrepo(path: Path, branch: str = "main") -> Path:
 def test_every_file_the_ledgers_read_exists():
     """Every ledger assertion below reads one of these. If one moved, the
     assertion would parse an empty string and pass while measuring nothing."""
-    for path in (RUN_TESTS, CONFTEST, *RUNNERS):
+    for path in (RUN_TESTS, CONFTEST, *POINTER_CLEARERS):
         assert path.is_file(), f"{path} missing — the ledger tests are vacuous"
 
 
 # --------------------------------------------------------------------------- #
 # 1. THE LEDGERS — one owner (gitenv.py), four spellings, pinned both ways
 # --------------------------------------------------------------------------- #
+def _unset_line_number(text: str, array: str) -> int:
+    """The 1-based line that RUNS `unset "${<array>[@]}"`, or -1.
+
+    🔴 EXACT MATCH ON A STRIPPED LINE, never `in text`. A substring test is
+    satisfied by `# unset "${DEVRC_GIT_REPO_POINTERS[@]}"` — commenting the guard
+    out leaves every word on the page, so the pin stays green while the guard
+    stops executing. claude/RULES.md's spelled-guard shape, and it was live here:
+    `_clear_line` below did the exact match but ran only over `RUNNERS`, so
+    `commit.sh` — which has no ROOT resolution to fall back on — was covered only
+    by the substring version. MEASURED: commenting `commit.sh`'s unset out killed
+    0 tests before this change and 9 after.
+    """
+    statement = f'unset "${{{array}[@]}}"'
+    for i, line in enumerate(text.splitlines(), 1):
+        if line.strip() == statement:
+            return i
+    return -1
+
+
 def _shell_array(runner: Path, array: str) -> list[str]:
     """The names in `runner`'s `<array>=( … )` literal, comments stripped."""
     text = runner.read_text(encoding="utf-8")
@@ -205,9 +254,11 @@ def _shell_array(runner: Path, array: str) -> list[str]:
         "protects the NON-pytest targets (HOOK_TESTS, SHELL_TESTS, the node "
         "tier) and what keeps ROOT resolvable at all under an inherited GIT_DIR."
     )
-    assert f'unset "${{{array}[@]}}"' in text, (
-        f"{runner.name} declares {array} but never unsets it. 🔴 A declaration "
-        "is not a code path (claude/RULES.md)."
+    assert _unset_line_number(text, array) > 0, (
+        f"{runner.name} declares {array} but never runs the unset as a LIVE "
+        "statement — it is absent, or commented out. 🔴 A declaration is not a "
+        "code path (claude/RULES.md), and neither is a comment that reads like "
+        "one."
     )
     names: list[str] = []
     for line in m.group(1).splitlines():
@@ -221,12 +272,17 @@ def _shell_unset_names(runner: Path) -> list[str]:
     return _shell_array(runner, "DEVRC_GIT_REPO_POINTERS")
 
 
-@pytest.mark.parametrize("runner", RUNNERS, ids=lambda p: p.name)
+@pytest.mark.parametrize("runner", POINTER_CLEARERS, ids=lambda p: p.name)
 def test_the_shell_and_python_pointer_ledgers_agree(runner):
-    """🔴 BOTH DIRECTIONS, for EVERY runner. A name in Python and not in a
+    """🔴 BOTH DIRECTIONS, for EVERY spelling. A name in Python and not in a
     runner leaves that runner's non-pytest targets exposed and its ROOT
     resolvable only by luck; a name in a runner and not in Python leaves a bare
-    `pytest` exposed. Either way the guard claims coverage it does not have."""
+    `pytest` exposed. Either way the guard claims coverage it does not have.
+
+    `commit.sh` is in this list for a different reason from the three runners:
+    nothing there resolves a ROOT, but it is the file that COMMITS, so a name
+    missing from its copy is a repository somebody else's content can land in.
+    """
     shell = _shell_unset_names(runner)
     python = list(REPO_POINTER_VARS)
     assert sorted(shell) == sorted(python), (
@@ -272,7 +328,7 @@ def test_GIT_DIR_is_on_every_ledger():
     """The one that actually happened. Pinned by name so a future prune of the
     list cannot quietly drop the variable the incident was made of."""
     assert "GIT_DIR" in REPO_POINTER_VARS
-    for runner in RUNNERS:
+    for runner in POINTER_CLEARERS:
         assert "GIT_DIR" in _shell_unset_names(runner), runner.name
 
 
@@ -312,10 +368,10 @@ def _root_line(text: str) -> int:
 
 
 def _clear_line(text: str) -> int:
-    for i, line in enumerate(text.splitlines(), 1):
-        if line.strip() == 'unset "${DEVRC_GIT_REPO_POINTERS[@]}"':
-            return i
-    return -1
+    # ONE implementation of "is the unset live?", shared with the ledger pin —
+    # they disagreed once (exact here, substring there) and the weaker one was
+    # the only thing covering `commit.sh`.
+    return _unset_line_number(text, "DEVRC_GIT_REPO_POINTERS")
 
 
 @pytest.mark.parametrize("runner", RUNNERS, ids=lambda p: p.name)
@@ -1639,3 +1695,206 @@ def test_with_no_guard_dir_an_override_is_protected_exactly_as_before(
     monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(target))
     monkeypatch.delenv("DEVRC_TEST_GIT_GUARD_DIR", raising=False)
     assert global_config_paths() == [target]
+# --------------------------------------------------------------------------- #
+# 6. 🔴 run-tests.sh's SHELL half, measured END TO END rather than read
+# --------------------------------------------------------------------------- #
+# Everything in section 1 reads the runner's TEXT: the array agrees with the
+# owner, the `unset` line exists, it precedes the ROOT block. All three are
+# satisfied by a file that never runs — reading as coverage while providing none
+# is the shape claude/RULES.md rates worse than no guard at all.
+#
+# So this pair drives the real `run-tests.sh` (via the shared patched copy that
+# ~15 other suites use) with GIT_DIR poisoned, and asks a NON-PYTEST target what
+# it actually received. The non-pytest tier is the point: HOOK_TESTS and
+# SHELL_TESTS load no plugin, so the shell `unset` is their ONLY protection —
+# testing the pytest tier here would measure `testlib/gitenv_plugin` a second
+# time and report it as evidence about the shell.
+#
+# The probe's damaging step is the incident's own shape: `git -C <dir>` where
+# <dir> is NOT a repository. Clean, that is an error. With GIT_DIR inherited it
+# is a commit on somebody else's branch.
+# 🔴 NO SHEBANG, deliberately. run-tests.sh invokes a SHELL_TESTS entry as
+# `bash "$SHELL_TEST"`, so one would be decorative — and test_runtime_shebangs.py
+# fails any test that writes its own (it caught this file's first draft).
+_SHELL_PROBE = '''\
+# Written by test_git_repo_isolation.py into a tmp dir; never part of the repo.
+set -u
+report="__REPORT__"
+: > "$report"
+echo "GIT_DIR=${GIT_DIR-<unset>}" >> "$report"
+echo "GIT_INDEX_FILE=${GIT_INDEX_FILE-<unset>}" >> "$report"
+export GIT_AUTHOR_NAME=probe GIT_AUTHOR_EMAIL=probe@example.invalid
+export GIT_COMMITTER_NAME=probe GIT_COMMITTER_EMAIL=probe@example.invalid
+git -C "__NOTAREPO__" commit -q --allow-empty -m "probe: fixture-shaped commit" \\
+  >> "$report" 2>&1
+echo "commit_rc=$?" >> "$report"
+# Always 0: a red SHELL_TESTS verdict would fail the run for a reason that is
+# not the subject, and an ambiguous red cannot tell the two halves apart.
+exit 0
+'''
+
+_UNSET_LINE = 'unset "${DEVRC_GIT_REPO_POINTERS[@]}"'
+
+
+def _decoy_git_dirs(wt: Path) -> list[Path]:
+    """The decoy's per-worktree gitdir AND the common dir refs really live in.
+
+    Fingerprinting only the per-worktree dir would miss every ref and config
+    write — the exact blind spot `common_dir_of` exists to close.
+    """
+    git_dir = resolve_git_dir(wt)
+    assert git_dir is not None, f"could not resolve a git dir for {wt}"
+    out = [git_dir]
+    common = common_dir_of(git_dir)
+    if common is not None:
+        out.append(common)
+    assert len(out) == 2, (
+        f"the decoy worktree reported no common dir ({git_dir}); the fingerprint "
+        "would then be blind to exactly the refs the incident moved")
+    return out
+
+
+def _decoy_with_worktree(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """A repo, a LINKED worktree on its own branch, and that worktree's gitdir.
+
+    The linked-worktree shape is not decoration: `git push` from a linked
+    worktree is what exports GIT_DIR=<repo>/.git/worktrees/<name> into a pre-push
+    hook, which is the route from a push to `run-tests.sh` (githooks/pre-push ->
+    tests-on-push.sh -> run-tests.sh). MEASURED on git 2.55.0: a push from the
+    MAIN checkout exports no GIT_DIR at all.
+    """
+    work = _mkrepo(tmp_path / "decoy" / "work", branch="decoy/base")
+    wt = tmp_path / "decoy" / "wt"
+    assert _git(work, "worktree", "add", str(wt), "-b", "decoy/target", "-q").returncode == 0
+    gitdir = work / ".git" / "worktrees" / "wt"
+    assert gitdir.is_dir(), f"no linked-worktree gitdir at {gitdir}"
+    return work, wt, gitdir
+
+
+def _drive_runner(tmp_path: Path, *, keep_unset: bool) -> dict:
+    """Run a patched copy of run-tests.sh with GIT_DIR poisoned; report facts.
+
+    `keep_unset=False` deletes GUARD 9's `unset` line from the COPY — one
+    mutation, in the copy only, so the two halves differ by exactly the line
+    under test (claude/RULES.md → "ISOLATE THE MUTATION").
+    """
+    from testlib.runner_patch import runner_with_targets, write_pytest_suite
+
+    work, wt, gitdir = _decoy_with_worktree(tmp_path)
+    before = _git(wt, "rev-parse", "HEAD").stdout.strip()
+    assert before, "the decoy worktree has no HEAD — the fixture is broken"
+    protected = _decoy_git_dirs(wt)
+    # `index` is included here and excluded from the host-repo fingerprint for
+    # the same reason: this decoy is read by nobody else between the two
+    # snapshots, and the wild damage overwrote the real index.
+    baseline = snapshot(protected, extra_files=[d / "index" for d in protected])
+
+    notarepo = tmp_path / "notarepo"
+    notarepo.mkdir()
+    report = tmp_path / "probe-report.txt"
+    probe = tmp_path / "probe.sh"
+    probe.write_text(
+        _SHELL_PROBE.replace("__REPORT__", str(report))
+                    .replace("__NOTAREPO__", str(notarepo)),
+        encoding="utf-8")
+
+    target = tmp_path / "trivial_tests"
+    write_pytest_suite(target, 1, prefix="test_trivial")
+    runner = runner_with_targets(tmp_path, [str(target)], {str(target): 1},
+                                 hook_tests=[], shell_tests=[str(probe)])
+    if not keep_unset:
+        src = runner.read_text(encoding="utf-8")
+        assert src.count(_UNSET_LINE) == 1, (
+            "the copied runner does not contain exactly one GUARD 9 `unset` "
+            f"line, so the mutation cannot be placed: found {src.count(_UNSET_LINE)}")
+        runner.write_text(src.replace(_UNSET_LINE, "# MUTANT: unset removed"),
+                          encoding="utf-8")
+
+    # 🔴 The OUTER gate's guard bookkeeping is REMOVED from the child, the same
+    # way `test_activity_spool_isolation._clean_home` does it. A nested runner
+    # that inherits `DEVRC_TEST_LAUNCH_STUB_DIR` / `ACTIVITY_SPOOL_DIR` /
+    # `XDG_STATE_HOME` / `DEVRC_TEST_SPOOL_GUARD_DIR` shares the log files whose
+    # per-target line counts GUARD 7 and GUARD 8 slice up, and a nested run's
+    # lines landing in the outer run's slice misattributes both. Removed rather
+    # than pointed elsewhere: each is re-derived by the child from scratch.
+    env = _env(GIT_DIR=str(gitdir), HOME=str(tmp_path / "home"))
+    for leaked in ("DEVRC_TEST_LAUNCH_STUB_DIR", "DEVRC_TEST_SPOOL_GUARD_DIR",
+                   "ACTIVITY_SPOOL_DIR", "XDG_STATE_HOME",
+                   "DEVRC_TEST_SPOOL_IN_SESSION"):
+        env.pop(leaked, None)
+    (tmp_path / "home").mkdir(exist_ok=True)
+    # ROOT is passed EXPLICITLY. Without it the runner resolves its own root with
+    # `rev-parse --show-toplevel`, which under a poisoned GIT_DIR yields
+    # `<repo>/scripts` and exits 127 before any target runs — the mutated half
+    # would then die for a reason that is not the subject.
+    proc = subprocess.run([BASH, str(runner), str(ROOT)],
+                          capture_output=True, text=True, env=env, cwd=str(tmp_path))
+    return {
+        "proc": proc,
+        "report": report.read_text(encoding="utf-8") if report.is_file() else None,
+        "before": before,
+        "after": _git(wt, "rev-parse", "HEAD").stdout.strip(),
+        "work": work,
+        "wt": wt,
+        "deltas": diff_snapshots(
+            baseline,
+            snapshot(protected, extra_files=[d / "index" for d in protected])),
+    }
+
+
+def test_without_the_unset_the_runner_hands_a_foreign_repo_to_a_shell_target(tmp_path):
+    """🔴 THE RED HALF — and the REACHABILITY proof for the pair.
+
+    A `run-tests.sh` whose GUARD 9 line is deleted passes GIT_DIR straight
+    through to a SHELL_TESTS script, whose `git -C <not-a-repo> commit` then
+    lands on the decoy's branch. If this ever stops reproducing, the green half
+    below stops being evidence about anything.
+    """
+    r = _drive_runner(tmp_path, keep_unset=False)
+    assert r["report"] is not None, (
+        "the shell probe never ran, so this control measured nothing:\n"
+        f"{r['proc'].stdout[-3000:]}\n{r['proc'].stderr[-3000:]}")
+    assert "GIT_DIR=<unset>" not in r["report"], (
+        f"the mutated runner stripped GIT_DIR anyway — the mutation did not "
+        f"land:\n{r['report']}")
+    assert r["after"] != r["before"], (
+        "the decoy branch did NOT move even with the guard removed. Either the "
+        "probe is wired to nothing or git no longer honours GIT_DIR over -C; "
+        f"either way the green half proves nothing.\nreport:\n{r['report']}")
+    log = _git(r["wt"], "log", "--oneline").stdout
+    assert "probe: fixture-shaped commit" in log, (
+        f"the decoy moved, but not for the probe's reason:\n{log}")
+    assert r["deltas"], (
+        "HEAD moved but the fingerprint saw nothing — the detector used by the "
+        "green half is wired to nothing")
+
+
+def test_the_runner_strips_the_pointers_before_a_non_pytest_target_runs(tmp_path):
+    """🔴 THE GREEN HALF. Identical fixture, identical env, unmutated runner.
+
+    Asserts the RELATIONSHIP — the foreign repository is byte-identical
+    afterwards — not that some string was printed. The probe's own commit is
+    asserted to have FAILED, because "the decoy did not move" is equally true of
+    a probe that never executed; the report file's content is what tells the two
+    apart.
+    """
+    r = _drive_runner(tmp_path, keep_unset=True)
+    assert r["report"] is not None, (
+        "the shell probe never ran, so nothing here was measured:\n"
+        f"{r['proc'].stdout[-3000:]}\n{r['proc'].stderr[-3000:]}")
+    assert "GIT_DIR=<unset>" in r["report"], (
+        f"run-tests.sh handed GIT_DIR to a SHELL_TESTS target:\n{r['report']}")
+    assert "GIT_INDEX_FILE=<unset>" in r["report"], r["report"]
+    assert "commit_rc=0" not in r["report"], (
+        "the probe's `git -C <not-a-repo> commit` SUCCEEDED. With the pointers "
+        f"stripped it has no repository to write to and must fail:\n{r['report']}")
+    assert r["after"] == r["before"], (
+        f"the foreign worktree branch moved: {r['before']} -> {r['after']}\n"
+        f"{r['report']}")
+    # 🔴 THE WHOLE REPOSITORY, not just the one ref the probe aimed at. HEAD is
+    # the damage this probe happens to cause; the incident also rewrote config,
+    # created and deleted branches, and overwrote the index. Asserting the
+    # fingerprint pins "the foreign repo is untouched", which is the claim.
+    assert r["deltas"] == [], (
+        "the foreign repository changed even though its HEAD did not:\n"
+        + "\n".join(r["deltas"]))

--- a/scripts/tests/test_git_repo_isolation.py
+++ b/scripts/tests/test_git_repo_isolation.py
@@ -32,11 +32,15 @@ name. The rename is hygiene, not a diagnosis.
 HOW THIS FILE IS BUILT, and why each layer is not redundant with the next:
 
   1. LEDGERS. The variable lists are owned once in Python (`testlib/gitenv.py`)
-     and re-spelled in each of the four shell entry points — they need them
-     because HOOK_TESTS, SHELL_TESTS and the node tier never load a pytest
-     plugin, and because an inherited GIT_DIR breaks ROOT resolution before any
-     Python runs. Pinned in BOTH directions for every spelling: a set that only
+     and re-spelled in each of the FIVE shell files that clear them
+     (`POINTER_CLEARERS`) — the four entry points need them because HOOK_TESTS,
+     SHELL_TESTS and the node tier never load a pytest plugin, and because an
+     inherited GIT_DIR breaks ROOT resolution before any Python runs;
+     `analyze-service-index/commit.sh` needs them because no test tier reaches
+     it at all. Pinned in BOTH directions for every spelling: a set that only
      grows on one side is a guard that protects twelve targets and not five.
+     The FILE LIST is pinned against a `git ls-files` sweep too, so a sixth
+     clearer added later cannot sit unpinned.
   2. ENTRY POINTS, as a LEDGER rather than an example. Every `conftest.py`
      under `scripts/` must re-export the plugin's hooks, and the SET is pinned,
      so adding a test directory cannot silently leave a bare `pytest <dir>`
@@ -324,6 +328,28 @@ def test_the_shell_ledger_has_no_duplicates(runner):
         assert len(names) == len(set(names)), f"duplicates in {runner.name}:{array}: {names}"
 
 
+def test_the_committers_ledger_has_no_duplicates():
+    """🔴 `commit.sh` is checked SEPARATELY, and deliberately not folded into the
+    parametrised test above.
+
+    That one requires BOTH arrays, and `DEVRC_GITENV_CONTROL_VARS` names the
+    DETECTOR's own seams (`DEVRC_GITENV_PROTECT`, `DEVRC_GITENV_MODE`) — which
+    exist only inside a test harness. `commit.sh` is not one; it is a systemd
+    unit that commits. Adding that array there to satisfy a parametrisation
+    would be cargo-culting a guard into a program it cannot apply to, and would
+    make the pin read as coverage of something that was never at risk.
+    """
+    names = _shell_array(COMMIT_SH, "DEVRC_GIT_REPO_POINTERS")
+    assert len(names) == len(set(names)), f"duplicates in commit.sh: {names}"
+    local = _shell_array(COMMIT_SH, "ASI_LOCAL_GIT_POINTERS")
+    assert len(local) == len(set(local)), f"duplicates in ASI_LOCAL_GIT_POINTERS: {local}"
+    overlap = set(names) & set(local)
+    assert not overlap, (
+        f"{sorted(overlap)} is in BOTH of commit.sh's arrays. The local array is "
+        "for variables the SHARED ledger deliberately does not carry; a name in "
+        "both means one of the two lists is lying about its scope.")
+
+
 def test_GIT_DIR_is_on_every_ledger():
     """The one that actually happened. Pinned by name so a future prune of the
     list cannot quietly drop the variable the incident was made of."""
@@ -347,6 +373,63 @@ def test_the_runner_and_python_session_markers_agree():
         "positive control that is never read is the reassuring zero itself: "
         "'loaded and saw nothing' and 'never loaded' print identically."
     )
+def test_POINTER_CLEARERS_is_every_file_that_declares_the_array():
+    """🔴 THE FILE LIST IS DERIVED, NOT TRUSTED — both directions.
+
+    `POINTER_CLEARERS` is hand-maintained. Every pin above is parametrised over
+    it, so a FIFTH file that grows a `DEVRC_GIT_REPO_POINTERS` array is silently
+    unpinned: its copy could drift from the owner, or spell `unset` wrong, and
+    nothing here would notice. That is the "a count of DECLARATIONS is not a
+    count of INSTANCES" shape.
+
+    So sweep the tracked tree and require the sets to be EQUAL. Growing fails
+    (a new clearer must be pinned); shrinking fails too (a clearer that lost its
+    array must be removed here deliberately, not discovered later).
+
+    Mirrors the precedent in `drift-check.sh`, whose covered package set is
+    derived from `nix/pkgs/` at scan time and pinned two-way.
+    """
+    tracked = subprocess.run(["git", "-C", str(ROOT), "ls-files", "-z"],
+                             capture_output=True, text=True)
+    assert tracked.returncode == 0, f"git ls-files failed: {tracked.stderr}"
+    names = [n for n in tracked.stdout.split("\0") if n]
+    assert len(names) > 100, (
+        f"the tracked-file sweep found only {len(names)} files — it is not "
+        "walking the repo, so its agreement below would be vacuous")
+
+    found: set[Path] = set()
+    for rel in names:
+        p = ROOT / rel
+        if p.suffix not in (".sh", "") or not p.is_file():
+            continue
+        try:
+            text = p.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if "DEVRC_GIT_REPO_POINTERS=(" in text:
+            found.add(p)
+
+    declared = set(POINTER_CLEARERS)
+    assert found == declared, (
+        "POINTER_CLEARERS disagrees with the files that actually declare the "
+        "array:\n"
+        f"  declares it but NOT pinned: {sorted(str(p.relative_to(ROOT)) for p in found - declared)}\n"
+        f"  pinned but does NOT declare it: {sorted(str(p.relative_to(ROOT)) for p in declared - found)}\n"
+        "Add or remove it here in the same commit — every ledger pin above is "
+        "parametrised over this tuple, so an unlisted clearer is an unchecked one."
+    )
+
+
+def test_the_clearer_sweep_can_actually_find_one():
+    """🔴 POSITIVE CONTROL for the sweep. `found == declared` is also what a
+    walker that matched NOTHING produces on an empty `POINTER_CLEARERS` — and
+    more to the point, a typo'd marker string would make the sweep return an
+    empty set that silently agreed with nothing. Prove it matches a real file."""
+    text = (SCRIPTS / "run-tests.sh").read_text(encoding="utf-8")
+    assert "DEVRC_GIT_REPO_POINTERS=(" in text, (
+        "the marker the sweep greps for is not in run-tests.sh — the sweep is "
+        "looking for a string that no longer exists, so it can only ever "
+        "return an empty set")
 
 
 def _root_line(text: str) -> int:

--- a/scripts/tests/test_git_repo_isolation.py
+++ b/scripts/tests/test_git_repo_isolation.py
@@ -87,7 +87,7 @@ CONFTEST = SCRIPTS / "tests" / "conftest.py"
 # the `git push` path — the path the incident travelled — and resolves
 # `REPO_ROOT` with exactly the vulnerable expression.
 #
-# 🔴 FOUR SPELLINGS RATHER THAN ONE SOURCED FILE, and the reason is measured,
+# 🔴 FIVE SPELLINGS RATHER THAN ONE SOURCED FILE, and the reason is measured,
 # not aesthetic: `testlib/runner_patch.py` writes a patched COPY of
 # `run-tests.sh` into a tmp dir and about fifteen tests drive that copy. A copy
 # cannot source a sibling `lib/` that was never copied with it — the first
@@ -110,7 +110,7 @@ RUNNERS = (SCRIPTS / "run-tests.sh",
 # by a route no test tier covers.
 #
 # It is kept OUT of `RUNNERS` deliberately rather than folded in: the ordering
-# test below is about the ROOT resolution these three share and commit.sh has
+# test below is about the ROOT resolution those four share and commit.sh has
 # none, so a single list would have to weaken that assertion to accommodate it.
 COMMIT_SH = SCRIPTS / "analyze-service-index" / "commit.sh"
 
@@ -145,6 +145,13 @@ from testlib.gitenv import (  # noqa: E402
     snapshot,
     strip_repo_pointers,
 )
+
+# 🔴 IMPORTED, not re-implemented. `repo_files` prefers `git ls-files` and falls
+# back to a filesystem walk when there is no `.git` — which is exactly the nix
+# build sandbox, where `checks.pytests` runs off `cp -r ${./.} src`.
+# `captured_text_scan.py` carries a "ONE RULE, ONE PLACE … a third copy of it
+# would be a third place for that trap to come back" banner over this helper.
+from testlib.public_ip_scan import repo_files  # noqa: E402
 
 # 🔴 NOT a shebang and NOT a bare "bash". Section 6 drives run-tests.sh as a
 # subprocess; an unnarrowed `shutil.which` result would surface as a TypeError
@@ -228,7 +235,7 @@ def test_every_file_the_ledgers_read_exists():
 
 
 # --------------------------------------------------------------------------- #
-# 1. THE LEDGERS — one owner (gitenv.py), four spellings, pinned both ways
+# 1. THE LEDGERS — one owner (gitenv.py), five spellings, pinned both ways
 # --------------------------------------------------------------------------- #
 def _unset_line_number(text: str, array: str) -> int:
     """The 1-based line that RUNS `unset "${<array>[@]}"`, or -1.
@@ -283,7 +290,7 @@ def test_the_shell_and_python_pointer_ledgers_agree(runner):
     resolvable only by luck; a name in a runner and not in Python leaves a bare
     `pytest` exposed. Either way the guard claims coverage it does not have.
 
-    `commit.sh` is in this list for a different reason from the three runners:
+    `commit.sh` is in this list for a different reason from the four runners:
     nothing there resolves a ROOT, but it is the file that COMMITS, so a name
     missing from its copy is a repository somebody else's content can land in.
     """
@@ -373,41 +380,79 @@ def test_the_runner_and_python_session_markers_agree():
         "positive control that is never read is the reassuring zero itself: "
         "'loaded and saw nothing' and 'never loaded' print identically."
     )
+
+
+# 🔴 ASSEMBLED, never spelled literally. If this module's own text contained the
+# array-opening string, the sweep below would match THIS FILE the moment anyone
+# widened its suffix filter — a red for a reason that has nothing to do with the
+# guard. Assembling it makes self-exclusion a property of the MARKER rather than
+# an accident of the filter, so the filter is free to say only what it means:
+# WHERE a bash array can live.
+#
+# Which is why the sentence above describes the string instead of quoting it.
+# The first draft of this very comment spelled it out and put the literal right
+# back into the file — `test_this_file_never_spells_the_marker_literally` below
+# pins that, because a comment is a claim like any other.
+_ARRAY_MARKER = "DEVRC_GIT_REPO_POINTERS" + "=("
+
+
+def _could_hold_a_shell_array(path: Path) -> bool:
+    """SCOPE ONLY — which files could carry a bash array at all.
+
+    `.sh`, or extensionless (the `githooks/` hooks). This is deliberately NOT
+    doing double duty as self-exclusion; see `_ARRAY_MARKER`.
+    """
+    return path.suffix in (".sh", "")
+
+
 def test_POINTER_CLEARERS_is_every_file_that_declares_the_array():
     """🔴 THE FILE LIST IS DERIVED, NOT TRUSTED — both directions.
 
     `POINTER_CLEARERS` is hand-maintained. Every pin above is parametrised over
-    it, so a FIFTH file that grows a `DEVRC_GIT_REPO_POINTERS` array is silently
-    unpinned: its copy could drift from the owner, or spell `unset` wrong, and
-    nothing here would notice. That is the "a count of DECLARATIONS is not a
-    count of INSTANCES" shape.
+    it, so a SIXTH file that grows the array is silently unpinned: its copy could
+    drift from the owner, or spell `unset` wrong, and nothing here would notice.
+    That is the "a count of DECLARATIONS is not a count of INSTANCES" shape.
 
-    So sweep the tracked tree and require the sets to be EQUAL. Growing fails
-    (a new clearer must be pinned); shrinking fails too (a clearer that lost its
-    array must be removed here deliberately, not discovered later).
+    So sweep the tree and require the sets to be EQUAL. Growing fails (a new
+    clearer must be pinned); shrinking fails too (a clearer that lost its array
+    must be removed here deliberately, not discovered later).
 
-    Mirrors the precedent in `drift-check.sh`, whose covered package set is
-    derived from `nix/pkgs/` at scan time and pinned two-way.
+    🔴 THE SWEEP MUST WORK IN BOTH TIERS, and the first version did not. It ran a
+    bare `git ls-files` and asserted rc 0 — but `flake.nix` builds
+    `checks.pytests` from `cp -r ${./.} src`, which has NO `.git`, so the
+    authoritative hermetic tier died `fatal: not a git repository … assert 128
+    == 0`. The dev-host `--set all` run could not see it: RULES.md's two-tiers
+    rule, exactly as written.
+
+    The repo already owns the fix and it is an IMPORT, not a new helper:
+    `testlib.public_ip_scan.repo_files` prefers `git ls-files` and falls back to
+    a filesystem walk in the sandbox. `captured_text_scan.py` carries a "ONE
+    RULE, ONE PLACE — a third copy of it would be a third place for that trap to
+    come back" banner over the same helper; a hand-rolled fallback here would
+    have been that third copy.
     """
-    tracked = subprocess.run(["git", "-C", str(ROOT), "ls-files", "-z"],
-                             capture_output=True, text=True)
-    assert tracked.returncode == 0, f"git ls-files failed: {tracked.stderr}"
-    names = [n for n in tracked.stdout.split("\0") if n]
+    names = repo_files(ROOT)
+    # A fallback that silently returned nothing would make `found == declared`
+    # true by vacuum — the empty-result-reads-as-clean failure this whole PR is
+    # about. Floor first, agreement second.
     assert len(names) > 100, (
-        f"the tracked-file sweep found only {len(names)} files — it is not "
-        "walking the repo, so its agreement below would be vacuous")
+        f"the repo-file sweep found only {len(names)} files under {ROOT} — it is "
+        "not walking the repo, so the agreement below would be vacuous")
+    shell = [p for p in names if _could_hold_a_shell_array(p)]
+    assert len(shell) > 10, (
+        f"the sweep saw {len(shell)} shell files — the walk is not reaching "
+        "`scripts/` or `githooks/`, where every clearer lives")
 
     found: set[Path] = set()
-    for rel in names:
-        p = ROOT / rel
-        if p.suffix not in (".sh", "") or not p.is_file():
+    for path in shell:
+        if not path.is_file():
             continue
         try:
-            text = p.read_text(encoding="utf-8")
+            text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        if "DEVRC_GIT_REPO_POINTERS=(" in text:
-            found.add(p)
+        if _ARRAY_MARKER in text:
+            found.add(path)
 
     declared = set(POINTER_CLEARERS)
     assert found == declared, (
@@ -420,16 +465,57 @@ def test_POINTER_CLEARERS_is_every_file_that_declares_the_array():
     )
 
 
+def test_this_file_never_spells_the_marker_literally():
+    """🔴 SELF-EXCLUSION MUST STAY A PROPERTY OF THE MARKER, not of the filter.
+
+    `_could_hold_a_shell_array` currently admits only `.sh` and extensionless
+    files, so this `.py` module is out of scope anyway — today. The moment
+    someone widens that filter (to catch a clearer in a `.bash` file, say), any
+    literal occurrence of the array-opening string in THIS file makes the sweep
+    match itself and go red for a reason unrelated to the guard.
+
+    Measured: the first draft of the comment above defeated the assembly by
+    quoting the very string it was explaining.
+    """
+    src = Path(__file__).read_text(encoding="utf-8")
+    assert src.count(_ARRAY_MARKER) == 0, (
+        f"this file spells the array marker literally {src.count(_ARRAY_MARKER)} "
+        "time(s). Assemble it, or describe it in prose without quoting it — "
+        "otherwise widening `_could_hold_a_shell_array` makes the sweep match "
+        "itself.")
+
+
 def test_the_clearer_sweep_can_actually_find_one():
-    """🔴 POSITIVE CONTROL for the sweep. `found == declared` is also what a
-    walker that matched NOTHING produces on an empty `POINTER_CLEARERS` — and
-    more to the point, a typo'd marker string would make the sweep return an
-    empty set that silently agreed with nothing. Prove it matches a real file."""
+    """🔴 POSITIVE CONTROL for the sweep, and it must hold IN BOTH TIERS.
+
+    `found == declared` is also what a walker that matched NOTHING produces
+    against an empty `POINTER_CLEARERS`, and a typo'd marker would make the
+    sweep return an empty set that silently agreed with nothing.
+
+    Everything below is filesystem-only — no `git` — so it measures the same
+    thing inside the nix sandbox, where the sweep now takes its fallback path.
+    """
+    # 1. the marker really is in a real clearer, read off disk
     text = (SCRIPTS / "run-tests.sh").read_text(encoding="utf-8")
-    assert "DEVRC_GIT_REPO_POINTERS=(" in text, (
+    assert _ARRAY_MARKER in text, (
         "the marker the sweep greps for is not in run-tests.sh — the sweep is "
         "looking for a string that no longer exists, so it can only ever "
         "return an empty set")
+
+    # 2. the file-list source itself is non-empty and reaches shell files
+    names = repo_files(ROOT)
+    assert len(names) > 100, f"repo_files({ROOT}) returned {len(names)} files"
+    assert any(_could_hold_a_shell_array(p) and p.name == "run-tests.sh"
+               for p in names), (
+        "repo_files did not return run-tests.sh, so the sweep cannot have "
+        "matched it — in this tier the sweep is wired to nothing")
+
+    # 3. and the scope filter admits every shape a clearer takes: a `.sh` file
+    #    and an extensionless githooks hook.
+    assert _could_hold_a_shell_array(Path("x/run-tests.sh"))
+    assert _could_hold_a_shell_array(Path("githooks/tests-on-push"))
+    assert not _could_hold_a_shell_array(Path("x/test_thing.py"))
+
 
 
 def _root_line(text: str) -> int:
@@ -1280,6 +1366,10 @@ def test_the_module_root_is_load_bearing(tmp_path, monkeypatch):
     outside = tmp_path / "not-a-repo"
     outside.mkdir()
     monkeypatch.chdir(outside)
+    assert resolve_git_dir(Path.cwd()) is None, (
+        "the tmp cwd resolved to a repository, so this test could pass via the "
+        "cwd root and would not kill the mutant it exists for")
+
     dirs = protected_git_dirs()
     home_git_dir = resolve_git_dir(home)
     assert home_git_dir is not None, "the fixture repo has no git dir (test rig issue)"
@@ -1287,6 +1377,45 @@ def test_the_module_root_is_load_bearing(tmp_path, monkeypatch):
         "the module's own repository was not discovered from a cwd outside any "
         "repository — dropping Path(__file__) from `starts` would be "
         f"invisible.\nfound: {dirs}")
+
+
+def test_the_module_root_pin_does_not_depend_on_this_tree_being_a_checkout():
+    """🔴 THE REGRESSION GUARD FOR THE FIX ABOVE, and it is not a tautology.
+
+    The bug was an environmental assumption hiding inside a behavioural test, and
+    the only reason it survived review is that nobody ran the tier that lacks the
+    environment. So assert the property directly: the module-root pin must build
+    its own repository and must not interrogate the ambient one.
+
+    🔴 CODE ONLY, docstrings and comments STRIPPED. The first version of this
+    guard grepped the raw source and matched the PROSE in the test above — which
+    quotes the old failure message on purpose — so it failed on a correct tree.
+    `_root_line` in this same file carries the identical warning: a parser that
+    cannot tell code from prose is measuring the wrong thing.
+    """
+    import ast
+
+    src = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    fn = next(n for n in tree.body
+              if isinstance(n, ast.FunctionDef)
+              and n.name == "test_the_module_root_is_load_bearing")
+    body = fn.body[1:] if ast.get_docstring(fn) is not None else fn.body
+    code = "\n".join(ast.get_source_segment(src, stmt) or "" for stmt in body)
+    assert code.strip(), "could not extract the pinned test's code"
+
+    assert 'monkeypatch.setattr(gitenv, "__file__"' in code, (
+        "test_the_module_root_is_load_bearing no longer rebinds the module root, "
+        "so it is measuring the ambient tree again — which is exactly what made "
+        f"the nix sandbox permanently red.\ncode was:\n{code}")
+    assert "_mkrepo(" in code, (
+        "the pinned test no longer builds its own repository, so it depends on "
+        "the ambient tree being a checkout")
+    residual = code.replace('monkeypatch.setattr(gitenv, "__file__"', "")
+    assert "gitenv.__file__" not in residual, (
+        "the pinned test reads the REAL module location again. That is the "
+        "environmental assumption which is false by construction in the nix "
+        "sandbox (`cp -r ${./.} src`, no .git)")
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tests/test_git_repo_isolation.py
+++ b/scripts/tests/test_git_repo_isolation.py
@@ -151,7 +151,7 @@ from testlib.gitenv import (  # noqa: E402
 # build sandbox, where `checks.pytests` runs off `cp -r ${./.} src`.
 # `captured_text_scan.py` carries a "ONE RULE, ONE PLACE … a third copy of it
 # would be a third place for that trap to come back" banner over this helper.
-from testlib.public_ip_scan import repo_files  # noqa: E402
+from testlib.public_ip_scan import _is_skipped, repo_files  # noqa: E402
 
 # 🔴 NOT a shebang and NOT a bare "bash". Section 6 drives run-tests.sh as a
 # subprocess; an unnarrowed `shutil.which` result would surface as a TypeError
@@ -405,6 +405,30 @@ def _could_hold_a_shell_array(path: Path) -> bool:
     return path.suffix in (".sh", "")
 
 
+def _sweep_candidates() -> list[Path]:
+    """The files the clearer sweep looks at, filtered the way this repo's other
+    `repo_files` consumers filter theirs.
+
+    🔴 `_is_skipped` is RE-APPLIED after `repo_files`, for the reason
+    `captured_text_scan._candidates` and `public_ip_scan.scan_repo` both spell
+    out: `repo_files` only filters on the FILESYSTEM-WALK tier, so on the
+    `git ls-files` tier a tracked path under a skip dir comes back. MEASURED
+    zero such paths today — this closes a DIVERGENCE between the two tiers, not
+    a live miss, and a divergence here would surface as a red in one tier only,
+    which is the shape this whole PR keeps being about.
+
+    ⚠ MEASURED, and stated because the honest version is less flattering:
+    deleting the `_is_skipped` call kills NO test. There are no tracked files
+    under a `SKIP_DIRS` name today, so nothing can observe its absence. It is
+    defence-in-depth and consistency with the two established `repo_files`
+    consumers — NOT coverage, and it must not be counted as any. The same
+    labelling as the "backup is readable" assertions in
+    `test_analyze_service_index_commit.py`.
+    """
+    return [p for p in repo_files(ROOT)
+            if _could_hold_a_shell_array(p) and not _is_skipped(p, ROOT)]
+
+
 def test_POINTER_CLEARERS_is_every_file_that_declares_the_array():
     """🔴 THE FILE LIST IS DERIVED, NOT TRUSTED — both directions.
 
@@ -438,7 +462,7 @@ def test_POINTER_CLEARERS_is_every_file_that_declares_the_array():
     assert len(names) > 100, (
         f"the repo-file sweep found only {len(names)} files under {ROOT} — it is "
         "not walking the repo, so the agreement below would be vacuous")
-    shell = [p for p in names if _could_hold_a_shell_array(p)]
+    shell = _sweep_candidates()
     assert len(shell) > 10, (
         f"the sweep saw {len(shell)} shell files — the walk is not reaching "
         "`scripts/` or `githooks/`, where every clearer lives")
@@ -515,7 +539,6 @@ def test_the_clearer_sweep_can_actually_find_one():
     assert _could_hold_a_shell_array(Path("x/run-tests.sh"))
     assert _could_hold_a_shell_array(Path("githooks/tests-on-push"))
     assert not _could_hold_a_shell_array(Path("x/test_thing.py"))
-
 
 
 def _root_line(text: str) -> int:


### PR DESCRIPTION
## What this is

`analyze-service-index/commit.sh` — the one program in this repo whose job is to
`git commit` — could be aimed at a **foreign repository by environment**. A
leaked `GIT_DIR` made its `scope_repo_state()` report "this scope IS its own
repo" for a bare directory, which skipped **both** the `git init` bootstrap and
the "not its own repo — refusing to commit" guard, and every subsequent
`git -C "$scope" add/commit` wrote into the foreign gitdir, index and branch.

## 🔴 The HERMETIC tier — mine was broken, and `main`'s was too

`nix build .#checks.x86_64-linux.pytests` is the **authoritative** tier. It was
**RED on `main`** from the moment #720 merged, and I measured that myself rather
than taking it on report — no pipe near the build, status captured on the next
line:

| tree | verdict | failures |
|---|---|---|
| `main` `b8f1e996` | `RESULT: FAIL (exit=1)` | **1** — `test_the_module_root_is_load_bearing`: *"gitenv.py is not inside a git checkout"* (#720's) |
| this PR `f75bcbdb` | `RESULT: FAIL (exit=1)` | **2** — #720's, **plus mine** |

Both had the **same root cause**: a test assuming a git checkout, in a sandbox
`flake.nix` builds from `cp -r ${./.} src` with no `.git`. RULES.md's two-tiers
rule exactly as written — the dev-host `--set all` run passed throughout and is
structurally unable to see this.

### Mine

`test_POINTER_CLEARERS_is_every_file_that_declares_the_array`, added in round 2,
ran a bare `git ls-files` and asserted rc 0 → `fatal: not a git repository …
assert 128 == 0`.

The repo already owned the fix, and it is an **import, not a new helper**:
`testlib.public_ip_scan.repo_files` prefers `git ls-files` and falls back to a
filesystem walk. `captured_text_scan.py` carries a *"ONE RULE, ONE PLACE — a
third copy of it would be a third place for that trap to come back"* banner over
it; a hand-rolled fallback here would have been that third copy. Measured, both
tiers, identical answer:

```
with .git   : repo_files=1012  shell candidates=121  clearers found=5
without .git: repo_files=1012  shell candidates=121  clearers found=5
              (githooks/tests-on-push.sh, analyze-service-index/commit.sh,
               gate.sh, run-node-tests.sh, run-tests.sh)
```

⚠ An earlier revision of this PR reported `1005 / 1006` here — a one-file gap
that was **my probe, not the tiers**. That no-`.git` tree was an older commit
*and* I had copied a pre-fix copy of the test file into it for the red-before
control (+1). Re-measured on a clean `git archive` of this HEAD the two tiers are
**byte-identical**, and `git status --untracked-files=all` on this worktree is
empty. Leaving the wrong numbers on record next to the right ones would be the
same defect this PR keeps correcting.

The sweep also re-applies `_is_skipped` after `repo_files`, matching
`captured_text_scan._candidates` and `public_ip_scan.scan_repo`, which document
why: `repo_files` filters only on the filesystem-walk tier, so on the
`git ls-files` tier a tracked path under a skip dir comes back. ⚠ Measured and
labelled as such in the code: deleting that call kills **no** test — there are no
such paths today. Defence-in-depth and cross-tier consistency, **not** coverage.

A fallback that silently returned nothing would make `found == declared` true by
vacuum — the empty-result-reads-as-clean failure this whole PR is about — so the
sweep now floors the file count **and** the shell-candidate count before
comparing sets, and its positive control is filesystem-only so it measures the
same thing in the sandbox.

### #720's — and `main` fixed it first

I fixed `test_the_module_root_is_load_bearing` here too, because it is the same
root cause, two hundred lines away, in a file this PR already touches — fixing
one and leaving its twin is the "one rule, one place" violation the repo's own
banner warns about, and a permanently-red gate is what RULES.md rates worse than
no gate.

Then the rebase onto `df8d0319` brought **`main`'s own fix**, reached
independently and by the same route (rebind `gitenv.__file__`, build a repo with
`_mkrepo`). **This PR keeps `main`'s implementation and drops mine** — theirs is
canonical and there is no reason to carry two. So this PR no longer claims that
fix; credit belongs upstream.

What it does keep is the part `main` does not have:
`test_the_module_root_pin_does_not_depend_on_this_tree_being_a_checkout`, which
pins the property by AST — **code only, docstrings stripped**, because its own
first version grepped raw source and matched the prose that quotes the old
failure message, the "parser that cannot tell code from prose" trap `_root_line`
warns about ten lines away. Mutation-checked against `main`'s implementation, in
both tiers:

| mutation of `protected_git_dirs`' `starts` | with `.git` | without `.git` |
|---|---|---|
| `[Path.cwd()]` only | `test_the_module_root_is_load_bearing` RED | RED |
| `[Path(__file__)…]` only | `test_the_cwd_root_is_load_bearing` RED | RED |

Before either fix, the old version could not run at all in the sandbox, so the
`starts=[cwd]` mutant was **unobservable** in the authoritative tier.

## 🔴 CORRECTIONS — two claims this PR made that were WRONG, left visible

Round 1 shipped a comment about `GIT_OBJECT_DIRECTORY` that was **measurably
false**. An adversarial audit found it; I reproduced it independently before
changing anything. Round 1's text said, verbatim:

> GIT_OBJECT_DIRECTORY and GIT_NAMESPACE alone left the foreign repo
> byte-identical on the pre-fix tree … a test over them here would be an
> invariant guard wearing a regression test's name.

Both halves of that were wrong about `GIT_OBJECT_DIRECTORY`. Re-measured against
the pre-fix script:

```
GIT_OBJECT_DIRECTORY=<decoy>/.git/objects  commit.sh <store>
  -> "committed 9b8a9f2 — 1 change(s)" / "ok — 1 scope(s) processed"   rc=0
  -> foreign loose objects 3 -> 6; one of the three new ones is a blob
     holding the store's own index content
  -> the scope's .git EXISTS but its objects/ is EMPTY, so
     `git -C <scope> log` -> "fatal: not a git repository"
```

Both hazards at once — client-identifying content into a foreign repository AND
a backup that does not exist while the unit prints ok — and it never self-heals,
because every later run repeats it.

**Why I got it wrong, which matters more than the row.** `_fingerprint` watched
`config/HEAD/packed-refs/ORIG_HEAD/logs/HEAD`, `refs/**` and `index` — and was
structurally blind to `objects/`. The instrument returned a zero and I wrote the
zero up as a fact about the repository: `claude/RULES.md`'s positive-control trap,
committed verbatim into a comment that then told the next maintainer *not* to
cover the most damaging shape. The docstring claiming "the foreign repository is
byte-identical afterwards" had the same defect — a coverage claim wider than the
check under it.

**The second correction is the same shape, one level up.** Round 2's replacement
comment listed the damaging names and read as exhaustive while **five of the
eleven ledger names had never been tried at all**. So I measured all eleven, and
one of the untried ones — **`GIT_CONFIG`** — turned out to be a sixth damaging
shape: it makes commit.sh's per-repo `commit.gpgsign false` pin write into the
**foreign** repository's config (`+[commit]\n\tgpgsign = false`, measured in the
decoy). That is configuration damage to somebody else's checkout, the same class
as the `core.hooksPath` and `remote.origin.url` writes in the 2026-08-21 incident.
It is now a parametrised case, and the full eleven-name table is in the test.

Neither correction was ever a deploy risk — the fix covered both from the start
(measured at HEAD: foreign objects `3 → 3`, foreign config unchanged, scope
commits to its own readable repo). The defect was the claim.

## 🔴 First, what CONTRADICTS the brief I was given

The brief described this as a two-layer bug and asked me to build Layer 1
(scrub the git environment in `scripts/run-tests.sh`). **Layer 1 already exists
on `origin/main` and works.** It is GUARD 9 — `scripts/testlib/gitenv.py`
(`REPO_POINTER_VARS`, an 11-name ledger), re-spelled in `run-tests.sh`,
`run-node-tests.sh` and `gate.sh`, plus `testlib/gitenv_plugin` loaded on every
pytest target and re-exported from `scripts/tests/conftest.py`. It landed with
the 2026-08-21 incident.

I re-verified rather than assuming, exactly as the brief asked:

```
$ nix develop <wt> --command python -m pytest scripts/tests/test_analyze_service_index_commit.py -q
88 passed in 4.55s        decoy base 543279d  target 543279d   (unmoved)

$ GIT_DIR=<decoy>/.git/worktrees/wt nix develop <wt> --command python -m pytest ... -q
88 passed in 4.29s        decoy base 543279d  target 543279d   (unmoved)
```

`GIT_DIR` **did** survive `nix develop` (`nix develop <wt> --command env | grep
^GIT` printed it), so the leak route in the brief is real — GUARD 9 simply
already closes it for the suite.

**Layer 2 is genuinely open, and I reproduced it.** Running `commit.sh`
directly, with a decoy repo + linked worktree, on the tree at `e9e9045c` (and re-confirmed against `4dd14e68`):

```
BEFORE  base=0eff903  target=0eff903
--- commit.sh rc=0
analyze-service-index-commit: scope some-scope: committed 69bae35 — 3 change(s)
analyze-service-index-commit: ok — 1 scope(s) processed
AFTER   base=0eff903  target=69bae35        <-- the foreign branch MOVED
69bae35 autocommit: 3 change(s) in the some-scope analyze-service index
0eff903 decoy: the real commit that must survive
--- scope .git present? --- False           <-- never bootstrapped its own repo
```

That is the wild damage signature from #322, arriving by a route **no test tier
covers**: `commit.sh` runs from a systemd timer and from an operator's shell,
never through a runner.

After the fix, same fixture, same variable:

```
BEFORE  base=3753827  target=3753827
analyze-service-index-commit: scope some-scope: initialised a new repository (branch trunk, no remote)
analyze-service-index-commit: scope some-scope: committed 7af90af — 2 change(s)
AFTER   base=3753827  target=3753827        <-- unmoved
--- scope .git present? --- True            <-- committed to its OWN repo
```

## The mechanism

Every git call in `commit.sh` is `git -C "$scope" …`, and `-C` is the weakest
possible claim about where a command lands. With `GIT_DIR` set and no
`GIT_WORK_TREE`, git honours `GIT_DIR` and takes the **CWD** as the work tree, so
`git -C "$scope" rev-parse --show-toplevel` returns `$scope` itself. The
`realpath` comparison then matches → state 1 → both guards bypassed.

## Which variables actually spoof it — all eleven measured, not six

Each run ALONE against the pre-fix script, with the **widened** fingerprint
(refs + HEAD + config + logs + index + `objects/`) and **no git identity in the
environment** — which is how the unit actually runs, since a systemd timer has
no `GIT_AUTHOR_*`:

| variable (alone) | rc | foreign repo moved? | what happens |
|---|---|---|---|
| `GIT_DIR` = worktree gitdir | 0 | **yes** | `refs/heads/decoy/target`, `config`, `index`, `logs/HEAD` — **silently**, script reports ok |
| `GIT_DIR` = main gitdir | 0 | **yes** | `refs/heads/decoy/base`, `config`, `index`, `logs/HEAD` |
| `GIT_INDEX_FILE` | 0 | **yes** | the foreign worktree's `index`, overwritten |
| `GIT_COMMON_DIR` | 0 | **yes** | the foreign `config` (identity seeding) |
| `GIT_OBJECT_DIRECTORY` | 0 | **yes** | the store's content as a blob in the foreign object store; scope `.git` with an EMPTY `objects/`, so `git log` says "fatal: not a git repository" |
| `GIT_CONFIG` | **1** | **yes** | the foreign `config` — **and** the run fails loudly, **and** no usable backup |
| `GIT_WORK_TREE` | 1 | no | the run **failed** rather than misdirect |
| `GIT_ALTERNATE_OBJECT_DIRECTORIES` | 0 | no | — |
| `GIT_NAMESPACE` | 0 | no | — |
| `GIT_PREFIX` | 0 | no | — |
| `GIT_GRAFT_FILE` | 0 | no | — |
| `GIT_SHALLOW_FILE` | 0 | no | — |

### 🔴 A correction to this table's own rc column

Round 3 recorded `GIT_CONFIG` as `rc 0`. **That number was false**, and it was
false in a way that inverted the row's meaning: the rc column is this table's
*discriminator* — it is the stated reason `GIT_WORK_TREE` sits in the excluded
half. A `0` claims silent misdirection where the truth is a loud failure:

```
GIT_CONFIG leaked → rc=1
  "seeded a local commit identity (analyze-service index …)"
  "git commit failed (rc=128): Author identity unknown"
```

The identity seeding *also* lands in the foreign config, so the scope's own
commit can no longer resolve an author. Three genuinely distinct shapes:

| | rc | foreign write | outcome |
|---|---|---|---|
| `GIT_DIR` | 0 | yes | silent — the script reports ok |
| `GIT_WORK_TREE` | 1 | no | loud failure, nothing foreign touched |
| `GIT_CONFIG` | 1 | **yes** | loud failure **and** a foreign write **and** no backup |

**Why I recorded 0:** my probe exported `GIT_AUTHOR_*`/`GIT_COMMITTER_*` into the
environment `commit.sh` ran under. The unit has no such variables, so the probe
had *fixed a dimension the unit does not have* — RULES.md's "one measurement is
not a general claim; name the points you measured". I re-ran it **both ways** to
bound the claim: identity-in-env flips `GIT_CONFIG` from rc 1 to rc 0 and changes
**nothing else** in the eleven-name table. The damage claim and the
parametrisation were always right; only the number was wrong.

### The table is now enforced, not asserted

"All eleven ledger names are measured" was prose. A twelfth name in
`REPO_POINTER_VARS` is forced into `commit.sh`'s array by the existing
ledger-agreement test — so the *fix* would cover it — but nothing forced it into
this table, so the sentence would quietly become false and a damage class would
go untried. That is the unstated-scope defect this section already had to correct
twice.

`test_the_measured_table_covers_every_ledger_name` pins
`_SHAPES_COVER | _SHAPES_EXCLUDED` against `REPO_POINTER_VARS` — failing when the
set **grows** or **shrinks**, refusing a name in both halves, and requiring every
claimed name to be one `_spoof_env` actually exports. All four assertions shown
reachable by mutants aimed only at them:

| mutant | result |
|---|---|
| a 12th ledger name | RED — *"the measured table disagrees with REPO_POINTER_VARS"* |
| a name leaves the ledger | RED — same message |
| a name in both halves | RED — *"a name is both parametrised and excluded"* |
| a case dropped, set kept | RED — plus that shape's own case |

## The fix

**`scripts/analyze-service-index/commit.sh`** — the same
`DEVRC_GIT_REPO_POINTERS` array + `unset`, placed before its first git call
(beside the existing ambient-config neutralisation, "WHICH repository, before
WHICH config"). Unconditional: there is no workflow in which this unit should be
aimed at a repository by inherited environment.

The set is **not chosen there**. `testlib/gitenv.py::REPO_POINTER_VARS` remains
the single owner, and `test_git_repo_isolation.py` now pins `commit.sh`'s
spelling against it in both directions via a new `POINTER_CLEARERS` tuple —
the same treatment the three runners already get. `commit.sh` is kept OUT of
`RUNNERS` on purpose: the ROOT-ordering pin is about a `rev-parse
--show-toplevel` line `commit.sh` does not have, and folding it in would have
meant weakening that assertion.

### Two variables that are **not** on GUARD 9's ledger, and never will be

Round 1 said `GIT_CEILING_DIRECTORIES` was safe to inherit because it "can only
make discovery stop early — the safe direction". True about exfiltration,
misleading about everything else. Re-measured:

```
nested scope, no ceiling  -> rc=1  "scope inner: not its own repo — it sits inside <foreign>. Refusing…"
nested scope, ceiling set -> rc=0  "scope inner: initialised a new repository … ok — 1 scope(s) processed"
                                   ...and a .git planted INSIDE the foreign checkout
```

Stopping the walk is exactly how `scope_repo_state` is made to answer 0 ("no
repo") instead of 2 ("inside a DIFFERENT repo") — and 0 means **bootstrap**. The
refusal that this PR's own test calls *THE GUARD'S REAL JOB* was being converted
into its opposite, silently, with the run still printing ok.

`GIT_TEMPLATE_DIR` is the same family, found by asking why it was on neither
list. It is the **environment twin** of `init.templateDir`, which `commit.sh`
already pins off by config — neutralising the config route while leaving the env
route open is the asymmetry, because `GIT_CONFIG_GLOBAL=/dev/null` does not touch
a variable. Measured: a template `hooks/post-commit` **is** copied into the repo
this script bootstraps and persists there. It does not *fire*, because
`GIT_CONFIG_KEY_0=core.hooksPath` redirects hooks — a planted-but-dormant
payload, armed the moment anyone runs git in that scope by hand, which is exactly
what an operator does to inspect a backup.

**Where they are stripped, and why not on the shared ledger.** Both go in a
separate, `commit.sh`-local `ASI_LOCAL_GIT_POINTERS` array. Neither can redirect
git at a different repository, so neither belongs in `REPO_POINTER_VARS` — that
tuple answers one question and this is not it. Widening it would change GUARD 9
for every runner on the strength of one consumer's defect, and would collide with
open PR #720, which is rewriting `gitenv.py` concurrently. `gitenv.py`'s
"DELIBERATELY NOT STRIPPED" list now carries both names **plus the general
lesson**: read that list as "cannot redirect git", never as "safe to inherit".

### `githooks/tests-on-push.sh` — I changed my mind, and left it alone

It was the obvious belt-and-braces spot and the brief asked me to decide with
evidence. The leak route is real: a push from a **linked worktree** exports
`GIT_DIR=<repo>/.git/worktrees/<name>` into the hook; a push from the main
checkout exports only `GIT_EDITOR`/`GIT_EXEC_PATH`/`GIT_PREFIX`.

I first wrote a comment there arguing it did **not** need the scrub (run-tests.sh
clears the ledger as its first act, and this file's own git calls are read-only
reads that are *supposed* to be about the repository being pushed). Then I
found **open PR #720**, which adds the array to that exact file with a better
argument than mine — `GIT_PREFIX` *is* exported to `pre-push`, and the
`rev-parse --show-toplevel` on the next line should be a function of the CWD
alone.

So I reverted my change to that file. Shipping a comment saying "deliberately
NOT scrubbed" would have **auto-merged cleanly** into a file that scrubs — a
semantic conflict nothing would catch. The reasoning lives here instead, where
it cannot rot. `githooks/tests-on-push.sh` is byte-identical to `origin/main` in
this branch.

## Rebases — `main` moved ten times under this PR

| base | what landed | conflict | resolution |
|---|---|---|---|
| `e9e9045c` | — | — | original |
| `4dd14e68` | #673 (GUARD 10, `nogit_plugin`) | 1 file | both sides appended a section; kept both |
| `dc25debf` | #722, #723, #724 | none | clean |
| `b8f1e996` | **#720 merged** (GUARD 9 audit follow-ups, ~2,000 lines) | 2 files, 8 hunks | see below |
| `a689441f` | #731, #733 | none | clean |
| `df8d0319` | #706 — which included `main`'s own fix for `test_the_module_root_is_load_bearing` | 1 file, 3 hunks | kept **main's** implementation, dropped mine, kept my companion pin |
| `99b2636f` | #730/#734 (GUARD 10 protected-set split) | none | clean |
| `a662b48b` | #738 | none | clean |
| `64960b98` | #726, #742 (RULES + clawgate skill) | none | clean |
| `69ab990a` | #747 (check-clickup-addressed) | none | clean |

`rerere` was **disabled for every one** (`git -c rerere.enabled=false`) —
CLAUDE.md records it silently replaying a resolution from a different merge in
this repo before.

### The #720 merge, and what it changed about this PR

#720 restructured the same guard, and two of its decisions land directly on
mine:

* **It added `githooks/tests-on-push.sh` as a spelling of the array** — the file
  I had argued did not need one and then reverted my change to. Its argument is
  the one I said was better: `GIT_PREFIX` *is* exported to `pre-push`, so the
  `rev-parse` on the next line should be a function of the CWD alone. With
  `commit.sh` there are now **five** spellings, and the docstrings, the
  "FIFTH SPELLING" heading and the counts are updated to say so.
* **It introduced a second array, `DEVRC_GITENV_CONTROL_VARS`** (the detector's
  own seams, `DEVRC_GITENV_PROTECT` / `DEVRC_GITENV_MODE`), and made
  `test_the_shell_ledger_has_no_duplicates` require **both** arrays. `commit.sh`
  is a systemd unit, not a test harness, so those seams mean nothing there.
  Rather than cargo-cult an empty array in to satisfy a parametrisation, that
  test stays over `RUNNERS` and `commit.sh` gets its own
  `test_the_committers_ledger_has_no_duplicates` — which also asserts the two
  commit.sh arrays do not **overlap**, since a name in both would mean one of
  them is lying about its scope.

**My `_unset_line_number` hardening got wider, not narrower.** #720's
`_shell_array` still used `f'unset "${{{array}[@]}}"' in text` — the same
substring test — and now over **two** arrays across **four** files. The
generalised exact-line version replaces it for all of them, and `_clear_line`
delegates to it so there is one implementation of "is the unset live?".

**#720 also fixed the thing I reported from round 1.** Concurrent writers in the
shared clone no longer fail the run: GUARD 9 now detects live co-tenant
processes and downgrades to `gitenv(observed) … CANNOT SAY WHO DID IT`, printing
`attributed-violations=0 unattributed-observations=N`. My round-1 finding is
closed by their change, not mine.

## Test coverage

### Red/green matrix — every claim measured, `PYTHONDONTWRITEBYTECODE=1`

Base = `origin/main`, extracted with `git archive` into a pristine tree so
nothing could touch a real repo. Re-measured from scratch at every base `main`
moved to — `e9e9045c`, `4dd14e68`, `dc25debf` — with identical results.

| test | at base | at HEAD |
|---|---|---|
| `…cannot_aim_the_committer_at_a_foreign_repo[GIT_DIR_worktree]` | **RED** | green |
| `…cannot_aim_the_committer_at_a_foreign_repo[GIT_DIR_main]` | **RED** | green |
| `…cannot_aim_the_committer_at_a_foreign_repo[GIT_INDEX_FILE]` | **RED** | green |
| `…cannot_aim_the_committer_at_a_foreign_repo[GIT_COMMON_DIR]` | **RED** | green |
| `…cannot_aim_the_committer_at_a_foreign_repo[GIT_OBJECT_DIRECTORY]` | **RED** | green |
| `…cannot_aim_the_committer_at_a_foreign_repo[GIT_CONFIG]` | **RED** | green |
| `test_a_leaked_pointer_does_not_defeat_the_nested_scope_refusal` | **RED** | green |
| `test_an_inherited_ceiling_does_not_turn_the_nested_refusal_into_a_bootstrap` | **RED** | green |
| `test_an_inherited_template_dir_plants_nothing_in_the_bootstrapped_repo` | **RED** | green |
| `test_the_shell_and_python_pointer_ledgers_agree[commit.sh]` | **RED** | green |
| `test_the_shell_ledger_has_no_duplicates[commit.sh]` → `test_the_committers_ledger_has_no_duplicates` | **RED** | green |
| `test_GIT_DIR_is_on_every_ledger` | **RED** | green |
| `test_POINTER_CLEARERS_is_every_file_that_declares_the_array` | **RED** | green |
| `test_the_foreign_repo_fixture_would_actually_record_a_write` | green | green |
| `test_the_ceiling_fixture_would_actually_hide_the_enclosing_repo` | green | green |
| `test_the_template_fixture_would_actually_plant` | green | green |
| `test_the_clearer_sweep_can_actually_find_one` | green | green |
| `test_this_file_never_spells_the_marker_literally` **(round 3)** | green | green |
| `test_the_module_root_pin_does_not_depend_on_this_tree_being_a_checkout` | green | green |
| `test_the_measured_table_covers_every_ledger_name` **(round 4)** | green | green |
| `test_the_runner_strips_the_pointers_before_a_non_pytest_target_runs` | green | green |
| `test_without_the_unset_the_runner_hands_a_foreign_repo_to_a_shell_target` | green | green |

**13 red at base, all green at HEAD** (re-measured against `origin/main` again
this round). The nine green-at-both are green *by design* and are not counted as regression coverage: five are positive controls
(they must be green at both ends or the zeroes they back are unfalsifiable), one
pins the round-3 hermetic fix, one is an invariant guard over the ledger/table
agreement (round 4), and two cover Layer 1, which already exists on `main`.

🔴 **Separately, the two hermetic-tier fixes have their own matrix, because
`--set all` cannot see them at all** — measured by running the pre-fix and
post-fix files against a tree built with `git archive` and no `.git`:

| test | pre-fix, no `.git` | post-fix, no `.git` |
|---|---|---|
| `test_POINTER_CLEARERS_is_every_file_that_declares_the_array` | **RED** — `fatal: not a git repository … assert 128 == 0` | green |
| `test_the_module_root_is_load_bearing` (#720's) | **RED** — *"gitenv.py is not inside a git checkout"* | green — **by `main`'s fix**, not this PR's |

### What the regression tests assert

The **relationship**, not a spelling: the foreign repository is **byte-identical**
afterwards — `refs/`, `HEAD`, `packed-refs`, `ORIG_HEAD`, `logs/HEAD`, `config`
**and `index`**, across both the per-worktree gitdir and its common dir, via
`gitenv.snapshot`/`diff_snapshots`. A message can be reworded; a moved ref
cannot. Each also asserts the scope became its **own** repo with its **own**
commit, because "the foreign repo did not move" is equally true of a script that
did nothing.

The nested-scope test is the one that pins the guard's *real job*: a fix that
merely stopped the foreign write while leaving the state wrong would still commit
client-sensitive content into an enclosing repo. On the pre-fix tree that scope
was **not refused** — it was committed.

### The harness half, measured rather than read

Every existing GUARD 9 pin on `run-tests.sh` reads its **text** (the array agrees
with the owner, the `unset` line exists, it precedes ROOT). All three are
satisfied by a file that never runs. The new pair drives the **real**
`run-tests.sh` (through the shared `runner_patch` copy) with `GIT_DIR` poisoned
and asks a **`SHELL_TESTS`** target what it actually received — the non-pytest
tier on purpose, since it loads no plugin and the shell `unset` is its only
protection. Testing the pytest tier there would have measured
`testlib/gitenv_plugin` a second time and reported it as evidence about the
shell.

### Mutation results — full battery, re-run on the rebased tree

One mutant at a time, restored from a `cp` copy and **md5-verified between
each**. `PYTHONDONTWRITEBYTECODE=1` throughout. Baseline (unmutated): **0 red** —
the positive control that the battery is not simply failing everything.

| # | mutation | tests that went red |
|---|---|---|
| A | `commit.sh`: delete the SHARED `unset` | **10** — all 6 cases + nested-scope + 3 ledger pins |
| B | `commit.sh`: drop `GIT_DIR` only | **8**; the other four shapes stayed **green** |
| C | `commit.sh`: drop `GIT_INDEX_FILE` only | **2** — that shape + 1 ledger pin |
| E | `commit.sh`: drop `GIT_OBJECT_DIRECTORY` only | **2** — that shape + 1 ledger pin |
| L | `commit.sh`: drop `GIT_CONFIG` only **(new)** | **2** — that shape + 1 ledger pin |
| F | `commit.sh`: delete the LOCAL `unset` | **3** — ceiling, template, commit.sh ledger pin |
| G | `commit.sh`: drop `GIT_CEILING_DIRECTORIES` only | **1** — the ceiling test alone |
| H | `commit.sh`: drop `GIT_TEMPLATE_DIR` only | **1** — the template test alone |
| J | `commit.sh`: **comment out** the shared `unset` | **10** — same as A. Was **0** before round 2 |
| D | `run-tests.sh`: delete its `unset` | **6** — including the harness pair, each with its own assertion |
| I | narrow `_fingerprint` (drop `objects/`) | **1** — *was a SURVIVOR in round 2; the N2 fix is what kills it* |
| N | `_objects_files` returns `[]` **(new)** | **1** — the component added in round 2 is now pinned |
| K | drop `commit.sh` from `POINTER_CLEARERS` | **1** — the derivation test |
| O | `starts = [Path.cwd()]` **(new)** | **1** — `test_the_module_root_is_load_bearing`, in **both** tiers |
| P | `starts = [Path(__file__)…]` **(new)** | **1** — `test_the_cwd_root_is_load_bearing`, in **both** tiers |

B/C/E/G/H/L are the isolation control: each shape is observed by its own
assertion, not by copies of one.

Round 4 added four more, aimed only at the new ledger/table pin — a 12th name, a
removed name, a name in both halves, and a dropped case — each red with that
pin's own message. Full battery re-run on the rebased tree: baseline **0 red**,
every mutant killed.

#### Mutant I no longer survives — and that is the point of N2

In round 2 this mutant survived: narrowing `_fingerprint` back killed nothing,
because the ref delta already satisfied `assert deltas` in the fixture control.
The audit sharpened it — stubbing `_objects_files` to `[]` left **99 passed, 0
red** — which is the round-2 defect one level up: a silent empty from the
instrument this round *added*, reading as a clean repo. The control now asserts
`any("/objects/" in d ...)`, so both **I** and the new **N** go red.

The round-2 discriminating control still stands and is why the component is kept
wide rather than merely present: with the wide fingerprint the
`GIT_OBJECT_DIRECTORY` mutant dies on *"aimed commit.sh at the foreign
repository"*; with `objects/` removed it dies on *"no commit of its own"* — still
red, but for the **other** claim, leaving the leak unobserved.

My two "backup is readable" assertions remain labelled **defence-in-depth, not
coverage**: they kill no mutant that the pre-existing `_commits(...) == 1` does
not already kill, and the test says so. Counting them as coverage would be the
same error this PR keeps correcting.

#### Mutant J — the pin was walkable by commenting the guard out

The audit's point, confirmed: `_shell_unset_names` tested
`'unset "${DEVRC_GIT_REPO_POINTERS[@]}"' in text`, a **substring** test that
`# unset "${DEVRC_GIT_REPO_POINTERS[@]}"` satisfies. The ordering pin's
`_clear_line` did an exact stripped-line match — but it runs only over the
`RUNNERS`, so `commit.sh`, the one file with no ROOT resolution to fall back on,
was covered only by the weak version. Both now share one `_unset_line_number`,
and mutant J goes from **0 red to 10**. #720 later grew a second array
(`DEVRC_GITENV_CONTROL_VARS`) with the same substring test, so the generalised
version now covers two arrays across five files.

## Gate — BOTH tiers, both reported

devrc has checks but nothing blocks (`required_status_checks` is null), so the
gate is still a human. Both tiers were run on the exact commit this PR proposes,
in a **fresh clone** (see the finding below for why that matters), and **neither
verdict was read through a pipe** — output to a file, status captured on the very
next line, because `cmd | tail; echo $?` yields `tail`'s status.

```
clone = <scratch>/gcC
HEAD  = 24f1415649bc869611165bbb0dcedbdb5f2107f0   (= origin/main 69ab990a + 4 commits)
dirty = 0 file(s)
start = 2026-08-23T13:02:13-05:00
end   = 2026-08-23T13:37:15-05:00
CLONE REFS: UNCHANGED during the run
```

**TIER 1 — dev host, `bash scripts/run-tests.sh <clone> --set all`**

```
RESULT: all good
  TOTAL collected=15270  passed=15268  skipped=2  failed=0  (floor: 13732 = sum of 27 per-target floors)
RESULT: PASS (exit=0)
RUNNER_EXIT=0
```

**TIER 2 — authoritative, `nix build .#checks.x86_64-linux.pytests`**

```
devrc-pytests> RESULT: all good
devrc-pytests>   TOTAL collected=15270  passed=15268  skipped=2  failed=0  (floor: 13732 = sum of 27 per-target floors)
devrc-pytests> RESULT: PASS (exit=0)
NIX_BUILD_EXIT=0
```

Both tiers agree on the counts, which is the point: before this PR the
authoritative tier could not run two of these tests at all. Both verdicts are for
the exact HEAD this PR proposes, with no rebase since.

**TIER 3 — `nix build .#checks.x86_64-linux.nodetests`**

```
devrc-nodetests>   TOTAL suites=4 files=34 tests=1149 pass=1149 fail=0 skipped=0  (floor: 1126)
devrc-nodetests> RESULT: PASS (exit=0)
NIX_BUILD_EXIT=0
```

🔴 **The node tier is here because devrc now has a REAL blocking gate, and that
changed under this PR.** At every earlier measurement
`repos/…/branches/main/protection` returned `required_status_checks: null` — the
premise behind `CLAUDE.md`'s "run the gate yourself before you merge". Measured
after the final push:

```
required_status_checks.contexts = ["tekton/devrc-nodetests"]
```

So `tekton/devrc-nodetests` is now **required**, the PR reports
`mergeStateStatus: BLOCKED` until Tekton reports on the head, and the blocking
tier was the one tier this PR had never run. It is green locally on this exact
commit. (`CLAUDE.md`'s `<!-- merge-gate: other -->` marker already covers this —
"something this test cannot see starts gating (Tekton …)" — so no marker change
is needed.)

No floor needed changing: `TARGET_FLOORS` entries are lower bounds and this PR
only adds tests.

### ⚠ A second observation: `core.hooksPath` flipped mid-PR, repo-LOCALLY

At every measurement across the first four rounds — each taken immediately
before a push, never cached — `core.hooksPath` was unset in all three scopes.
Measured again just before the final push:

```
local:  /home/zach/workspace/devrc/githooks
global: <unset>
system: <unset>
```

That is exactly the shape `CLAUDE.md` records as volatile and **not** a devrc
setting ("`install.sh` sets the key `--global`, and a local one wins — observed
pointing at `.git/hooks` on 08-20 and at `githooks/` on 08-21; it correlates
with agent-worktree creation"). Nothing in this session set it.

It matters here because the live `githooks/pre-push` → `tests-on-push.sh` path
runs the suite **inside the worktree it is pushing**, which is the #322 shape:
a push that hung and came back with the branch rewritten. So the final push used
the documented escape hatch `DEVRC_SKIP_TESTS=1` — **not** `--no-verify`, which
would have skipped the whole hook — on the strength of having just run *both*
tiers by hand on this exact tree, and the branch was re-checked afterwards.

Re-measure it yourself before your own push rather than trusting this paragraph;
that is the entire point of the CLAUDE.md note.

### ⚠ A finding: you cannot gate honestly from a worktree of a BUSY clone

My first three full runs, all from the agent worktree, reported `failed=3`,
`failed=3`, `failed=3` — every one of them a GUARD 9 **detector** error at
teardown, blamed on whichever test happened to be running. Six different tests
across the three runs, none of which my change touches. The detector was right
and the attribution was necessarily arbitrary: it fingerprints the **shared**
common dir, and other people were writing to it. A before/after `show-ref` diff
around one run names them:

```
refs/heads/fix/pre-push-gitdir-leak       e9e9045c -> 182f41ad   (mine — I committed mid-run)
refs/heads/zach/exit-code-by-cause        3cd02dae -> 51a76c9c   (another session)
refs/remotes/origin/fix/guard9-audit-followups  (appeared)       (another session)
```

and the reflog confirms the writers:

```
refs/remotes/origin/fix/repo-path-set-but-empty@{15:58:14}: update by push
refs/heads/feat/migrate-check-clickup-addressed@{14:47:04}: commit: fix(check-clickup-addressed): …
```

So the authoritative runs above were done from a **fresh `git clone` of the
branch** into a scratch dir. GUARD 9 stays fully armed — it just watches a git
dir nobody else writes to — and a before/after `show-ref` proves the window was
quiet. Both clone runs came back `failed=0`, `RESULT: PASS (exit=0)`, zero
violations. That is the difference between "my change is fine" and "the box was
quiet", and it is worth doing rather than arguing.

Separately, my **first** full run reported `scripts/tests intercepted=0 plugin=0`
for GUARD 7 and GUARD 8. It did **not** reproduce: two later full runs and a
pristine-`origin/main` control all reported the identical `intercepted=71
systemctl-reads=2 plugin=1` / `spool-rows=4 control=1 plugin=1`. I could not
identify a mechanism and am reporting it as measured-once-and-not-reproduced
rather than explained.

## Also in this round

* **`GIT_CONFIG`'s rc corrected** and the three shapes disambiguated — see the
  table's own correction above.
* **The measured table is pinned to `REPO_POINTER_VARS`**, both directions, so
  "all eleven are measured" is enforced rather than asserted.
* **`_is_skipped` re-applied after `repo_files`**, matching the two established
  consumers — labelled in the code as defence-in-depth, since no mutant can
  observe it today.
* **The two-tier file counts on record are corrected** to the clean measurement
  (1012/1012, 121/121), with the old numbers explained rather than deleted.
* **The `objects/` fingerprint component is pinned by a delta only it can see.**
* **The sweep marker is assembled, not spelled** — and
  `test_this_file_never_spells_the_marker_literally` pins that, because the first
  draft of the comment *explaining* it put the literal straight back.
* **Stale counts corrected** — eight across four rounds, several authored by this
  PR, most of them made false when #720 added a fourth runner mid-flight.
* **`POINTER_CLEARERS` is derived, not trusted** — asserted equal to a
  `repo_files` sweep, both directions, with a positive control that holds in the
  sandbox too.
* Cosmetics: the `E303` a previous round's `E302` fix overshot into, and an
  87-char line in `commit.sh`.

## Deliberately NOT in this PR

`scripts/analyze-service-index/backup.py` builds its git environment from
`dict(os.environ)` and does not strip the pointers — and that unit **has
network**. Real, pre-existing, untouched by this PR, and being filed separately
rather than grown into this one.

## Not claimed

* I did **not** exercise the real `git push` → `githooks/pre-push` →
  `tests-on-push.sh` path end to end; `core.hooksPath` was unset everywhere at
  every point I measured it. The GIT_DIR export from a linked worktree, and
  `nix develop`'s preservation of it, were measured directly.
* The systemd-timer path for `commit.sh` was not exercised under systemd; the
  script was run directly with the same environment the timer would give it.
