### PR TITLE
docs(CLAUDE.md): merge-gate is `other` — Tekton reports, and still nothing blocks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,12 +148,25 @@ Repo-level facts that are NOT in any skill — they live here on purpose:
 - **Two always-on docs have enforced byte ceilings**, because both load on every session: `scripts/browser-bridge/SKILL.md` (gated by `scripts/browser-bridge/tests/test_skill_size.py`) and `claude/RULES.md` (gated by `scripts/tests/test_rules_size.py`). Each test OWNS its constants and prints an eviction playbook on failure — **read the numbers there, never restate them.** Any addition needs an eviction in the SAME commit.
 - **Run the gate with `scripts/gate.sh`** (`--tier pytest|node|both`, `--set hermetic|all`). It sends the full output to a LOG FILE and prints only a bounded summary, so there is no reason to pipe it — and **its exit status is authoritative**. It also cross-checks that status against the runners' own `RESULT:` line and exits **90 = could-not-vouch** when they disagree, when a run printed no verdict, or when `panic: test timed out` appears. 90 is not "the tests failed"; it means read the log.
 - **The runners' verdict line carries their exit code** (`RESULT: FAIL (exit=1)`), emitted from one writer behind an EXIT trap, so it survives a pipe and a killed run still says so. Historically the status was destroyed by `… | tail; echo "rc=$?"` — four agents reported `exit 0` over `RESULT: FAIL` on 2026-08-11 — which is why counting `PASSED`/`FAILED` lines used to be mandatory. Still a fine cross-check; no longer the only thing you can trust.
-- 🔴 **NO AUTOMATED GATE IS RUNNING — the gate is YOU, by hand.** <!-- merge-gate: none -->
-  Nothing blocks a devrc merge today: there is no `.github/workflows`, `main` has no branch
-  protection or rulesets, no Tekton trigger names devrc, and `gh pr view <n> --json
-  statusCheckRollup` returns **0 checks** on every PR, merged ones included. This line used to
-  read `CI gates both suites`, which was false — the exact kind of claim nobody re-checks: an
-  agent reads it, believes the merge is protected, and skips the run.
+- 🔴 **CHECKS NOW RUN, BUT NOTHING BLOCKS — the gate is still YOU.** <!-- merge-gate: other -->
+  Since 2026-08-22 Tekton runs both suites on every PR and posts
+  `tekton/devrc-pytests` + `tekton/devrc-nodetests`. **That is reporting, not gating**:
+  `required_status_checks` on `main` is **null** and there are **0 rulesets**, so a RED
+  Tekton does not stop a merge — measured, not inferred, and `enforce_admins: true`
+  protects nothing here because there is nothing required to enforce. There is still no
+  `.github/workflows`. Making the two checks *required* is a one-setting change and the
+  single highest-value thing left; until someone does it, a green tick is a courtesy.
+  🔴 **A brand-new check is not an instrument until it has passed ONCE.** `devrc-ci` was
+  red on its first **5 of 5** runs — every one on the same test
+  (`test_timeout_reaps_the_whole_process_group`), in a file none of those changes touched:
+  the reap check asked `os.kill(pid, 0)`, which succeeds on a **zombie**, and a CI step
+  container's PID 1 does not reap. Fixed in #722; first green run was `devrc-ci-hkgtf`.
+  Read a red check's step log before believing its verdict — the SUMMARY counts nearly
+  matched a local run there and pointed at a different test entirely.
+  🔴 This line used to read `CI gates both suites` and later `NO AUTOMATED GATE IS
+  RUNNING`. Both were false at some point, in **opposite** directions — the exact kind of
+  claim nobody re-checks: an agent reads it, believes the merge is protected (or that no
+  check exists), and skips the run either way.
   🔴 **But a gate SHIPS IN THIS REPO, and whether it is INSTALLED is not a fact this file can
   state** — `githooks/` (`install.sh`, `pre-push`, `tests-on-push.sh`) is a real blocking
   pre-push test gate, and `scripts/run-tests.sh` treats it as a first-class consumer.
@@ -185,15 +198,19 @@ Repo-level facts that are NOT in any skill — they live here on purpose:
   the repo. **Reword this prose freely — but keep a sentence on the marker's line and do not
   add a second marker anywhere** (the test requires exactly one, and that its line still says
   something to a human: an HTML comment renders as nothing, so a lone marker would leave you
-  reading no warning at all). Change the marker only when a workflow triggering on
-  **`pull_request`, `pull_request_target` or `merge_group`** appears or disappears — a `push`,
-  tag, `schedule` or `workflow_dispatch` workflow runs after or outside the merge, gates
-  nothing, and must leave it at `none`. Values: `none`, `github-actions`, or **`other`** if
-  something this test cannot see starts gating (Tekton, an installed `githooks/` pre-push
-  gate) — `other` exists so the test can never force you to write a false `none`. It pins that
-  one thing: whether such a run actually BLOCKS a merge is branch protection, which — along
-  with Tekton and git hooks — is named above but NOT machine-checked from here. Re-verify
-  those by hand rather than trusting this paragraph's age.
+  reading no warning at all). Change it only when something that runs AT MERGE TIME appears
+  or disappears: a GitHub Actions workflow triggering on **`pull_request`,
+  `pull_request_target` or `merge_group`**, or a non-Actions equivalent. A `push`, tag,
+  `schedule` or `workflow_dispatch` workflow runs after or outside the merge and gates
+  nothing. Values: `none`, `github-actions`, or **`other`** for anything this test cannot
+  see (Tekton — which is why it reads `other` today — or an installed `githooks/` pre-push
+  gate); `other` exists so the test can never force you to write a false `none`.
+  🔴 **The marker records that something RUNS, never that it BLOCKS.** Those are different
+  facts and today they differ: Tekton reports on every PR while
+  `required_status_checks` is null, so `other` is honest and "the merge is protected" is
+  not. Whether a run blocks is branch protection, which — along with Tekton and git hooks —
+  is named above but NOT machine-checked from here. Re-verify by hand rather than trusting
+  this paragraph's age.
 - 🔴 **There is no hand-written test TOTAL any more.** `run-tests.sh` carries a **per-target** floor table (`TARGET_FLOORS`, pinned two-way against the target list) and derives the global floor as their sum. The old single `MIN_TESTS` literal was base-dependent and took **eleven values across eight PRs in one day**; `rerere` replayed a resolution from a different merge and silently wrote a four-way total onto a two-way tree. A floor is now a function of the current measurement — `m - min(50, max(1, m/20))` — and the gate PRINTS the exact replacement number when one drifts. Resolve a conflict here by re-running the gate and copying what it says, never by arithmetic on the two sides.
 - 🔴 **This repo is PUBLIC.** Never commit a real media-library path, directory name, filename, route log, or a real third-party hostname used as an example. **Nor CAPTURED TEXT — anyone's message bodies, prompts, transcripts or chat content, or a model's summaries of them — however it arrives** (an eval capture, a fixture, a debug dump). A test needs the SHAPE; regenerate it synthetic. Gated for JSON/JSONL/JSONC by `scripts/tests/test_no_captured_text.py` and for `.html`/`.txt` by `scripts/tests/test_no_captured_markup.py`; each owns its ledgers, thresholds, pinned allowlist and blind spots — read them there, never restate them. 🔴 All four content gates (these two plus the IP and hostname ones) read `git ls-files` and are **blind to git history** — see `SECRETS.md` → "Dead credentials in reachable history" before treating a green run as "the repo is clean".
 


### PR DESCRIPTION
The marker read `none`, with prose asserting *"NO AUTOMATED GATE IS RUNNING … no Tekton trigger names devrc"*. Both went false on 2026-08-22 — Tekton now runs both suites on every PR.

**But `other` is as far as honesty goes**, and that distinction is the whole point. Measured just now:

```
required_status_checks on main = null
rulesets                       = 0
.github/workflows              = absent
```

So a red Tekton does **not** stop a merge, and `enforce_admins: true` protects nothing because nothing is required to enforce. The marker records that something **runs**, never that it **blocks** — the updated text says so explicitly, since "checks exist" is exactly the observation that would otherwise be misread as "the merge is protected".

Making those two checks *required* is a one-setting change and the highest-value thing left. Until someone does it, a green tick is a courtesy and the gate is still the human.

### Two things recorded as reusable lessons, not incident notes

- **A brand-new check is not an instrument until it has passed once.** `devrc-ci` was red on its first **5 of 5** runs, every one on the same test in a file none of those changes touched (#722). Its verdict carried no information about any of them.
- **Read a red check's step log, not its verdict line.** That run's SUMMARY counts nearly matched a local run (`passed=14843 failed=1` vs `14844`/`0`), which made it look like CI had reproduced a known local failure. A different test had failed and the totals coincided.

### One contradiction fixed

The "when to change the marker" paragraph said a non-gating workflow *"must leave it at `none`"* — written when only GitHub Actions was contemplated, and directly contradicting `other` for a non-Actions gate. It now turns on whether something runs **at merge time**, in any system.

### Verification

`test_ci_claim_matches_reality.py` + `test_doc_path_rot.py` — **81 passed**.

Negative control, because a marker pin that cannot fail is decoration: flipping the marker to `github-actions` — false, there is no `.github/workflows` — fails `test_claude_md_marker_matches_the_repo`. The pin is live.

Docs-only; the full hermetic suite is Tekton's job on this PR, which is the improvement being documented.