### PR TITLE
fix(tests): the module-root guard asserted THIS checkout has a .git — the authoritative runner has none

### DIFF
--- a/scripts/tests/test_git_repo_isolation.py
+++ b/scripts/tests/test_git_repo_isolation.py
@@ -1113,18 +1113,41 @@ def test_the_cwd_root_is_load_bearing(tmp_path, monkeypatch):
 def test_the_module_root_is_load_bearing(tmp_path, monkeypatch):
     """Kills the `starts = [Path.cwd()]` mutant. Every nested control in this
     file runs pytest with `cwd` in a tmp dir that is not a repository at all; so
-    does any `pytest` launched from `/tmp`. This repo is then protected only by
-    the module root."""
+    does any `pytest` launched from `/tmp`. The module root is what protects a
+    repo then.
+
+    🔴 This must NOT depend on THIS checkout having a `.git`. It used to assert
+    exactly that (`gitenv.py is not inside a git checkout`) and the assertion
+    fired — not as a bug in the guard, but because the AUTHORITATIVE runner is
+    `nix build .#checks.x86_64-linux.pytests`, whose source is a `/nix/store`
+    path with no `.git` at all. So the suite passed on a dev host and failed in
+    the one environment that gates a merge, on every branch, for reasons no PR
+    had touched. Reproduce it in one line: `rm .git` from a copy of the tree and
+    run this test.
+
+    The rule under test is "the module's own directory is consulted", which does
+    not need the real repo. `protected_git_dirs` reads `Path(__file__)` — a
+    module global resolved at CALL time — so pointing `gitenv.__file__` at a
+    repository this test CONSTRUCTS exercises the real default `starts` (no
+    `starts=` argument is passed) while owning both roots outright.
+    """
     monkeypatch.delenv(PROTECT_ENV, raising=False)
+    # The module's home is a repo we control, so the assertion is about the
+    # discovery RULE and not about how this file happens to be checked out.
+    home = _mkrepo(tmp_path / "module-home")
+    monkeypatch.setattr(gitenv, "__file__", str(home / "gitenv.py"))
+    # ...and cwd is deliberately in no repository, so the cwd root finds nothing
+    # and ONLY the module root can supply the answer.
     outside = tmp_path / "not-a-repo"
     outside.mkdir()
     monkeypatch.chdir(outside)
     dirs = protected_git_dirs()
-    devrc_git_dir = resolve_git_dir(Path(gitenv.__file__).resolve().parent)
-    assert devrc_git_dir is not None, "gitenv.py is not inside a git checkout"
-    assert devrc_git_dir in dirs, (
-        "this checkout was not discovered from a cwd outside any repository — "
-        f"dropping Path(__file__) from `starts` would be invisible.\nfound: {dirs}")
+    home_git_dir = resolve_git_dir(home)
+    assert home_git_dir is not None, "the fixture repo has no git dir (test rig issue)"
+    assert home_git_dir in dirs, (
+        "the module's own repository was not discovered from a cwd outside any "
+        "repository — dropping Path(__file__) from `starts` would be "
+        f"invisible.\nfound: {dirs}")
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
`test_the_module_root_is_load_bearing` fails on **every** `devrc-ci` PipelineRun, on unrelated branches, for a reason no PR touched:

```
AssertionError: gitenv.py is not inside a git checkout
```

Measured on 3 revisions across different branches (`cacd03a7`, `632aa4de`, `806fc724`). It is the **sole** pytests failure — `collected=15152 passed=15149 skipped=2 failed=1`.

## Not a bug in the guard

The authoritative runner is `nix build .#checks.x86_64-linux.pytests`, whose source is a `/nix/store` path with **no `.git`**. So `resolve_git_dir(Path(gitenv.__file__).parent)` returns `None` and the test dies on its own precondition. It passes on a dev host and fails in the one environment that gates a merge.

Reproduce in one line, before changing anything — `rm .git` from a copy of the tree and run it. Same assertion, verbatim.

## The fix

The rule under test — "the module's own directory is consulted" — never needed the real repo. `protected_git_dirs` reads `Path(__file__)`, a **module global resolved at CALL time**, so the test now points `gitenv.__file__` at a repository it constructs. That exercises the real default `starts` (no `starts=` argument is passed) while owning both roots: cwd is deliberately in no repository, so **only** the module root can supply the answer.

## 🔴 The mutant is still killed — and now in both environments

This test exists to kill `starts = [Path.cwd()]`. A fix that made it vacuous would be worse than the bug, so that was verified explicitly, under `PYTHONDONTWRITEBYTECODE=1`:

```
MUTANT applied: dropped Path(__file__) from starts
rc=1
E  AssertionError: the module's own repository was not discovered from a cwd
   outside any repository — dropping Path(__file__) from `starts` would be invisible.
```

It fails with **its own** assertion, not another guard's. And this is a **strict improvement**: before this change the mutant *survived* in the nix sandbox, because the test could never reach its own assertion there.

## Verification

| check | result |
|---|---|
| file, WITH `.git` | 104 passed |
| file, WITHOUT `.git` (CI condition) | 104 passed |
| mutation (drop `Path(__file__)`) | killed, own assertion |
| **`nix build .#checks.x86_64-linux.pytests`** | **`RESULT: PASS (exit=0)`** — `collected=15152 passed=15150 skipped=2 failed=0` |

The authoritative run is the one that matters here: the whole defect is that targeted runs missed it.

⚠ **Scope note on the reproduction:** a `rm .git` copy is a valid repro of *this* failure but is **not** a faithful model of the nix sandbox — the whole `scripts/tests` dir shows 41 failures under it while the real CI run shows exactly 1. Do not read a main-wide failure count off that copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)