### PR TITLE
fix(gate): GUARD 10 splits its protected set — the repo-local config has ~90 other writers (#730)

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -2078,8 +2078,29 @@ _nogit_protect "${XDG_CONFIG_HOME:-${HOME:-}/.config}/git/config"
 # the change is REPORTED (printed, counted, named, with the reason) and does not
 # fail. The proof is GUARD 9's own already-audited evidence — see
 # `_nogit_cotenancy_probe` below — not a second heuristic. With no proven
-# co-tenant it still fails, so the `core.bare = true` casualty stays covered on
-# a clean machine and in CI, which is where that damage happened.
+# co-tenant it still fails.
+#
+# 🔴 BE PRECISE ABOUT WHERE THAT REMAINING ENFORCEMENT ACTUALLY LIVES — an
+# earlier wording here claimed the `core.bare = true` casualty "stays covered on
+# a clean machine and in CI", and the CI half is FALSE. The nix tier builds from
+# `cp -r ${./.} src` (`flake.nix`), a store copy with NO `.git` — which is what
+# the parenthesis above already says — so `NOGIT_REPO_LOCAL` is EMPTY there and
+# there is nothing for this class to enforce, downgrade or not. And on the
+# operator's box co-tenancy is provable essentially always. So repo-local
+# enforcement really survives in exactly one place: an isolated, single-writer
+# clone — which nothing currently schedules. It is a floor for the machine that
+# has one writer, not a gate that runs on every merge. The GLOBAL class above is
+# unaffected and is enforced everywhere, including in the sandbox.
+#
+# 🔴 AND THE EVIDENCE HAS A BLIND SPOT WORTH NAMING, because it is the writer
+# this change exists to excuse. `live_cotenants` roots at a git dir and its
+# PARENT, so for a linked worktree the roots are `<common>/.git` and the MAIN
+# clone's work tree. A session sitting in a SIBLING worktree
+# (`…/devrc-<topic>/`) is outside both and is NOT counted — MEASURED, all 35
+# co-tenant hits on the operator's box were cwd=`…/devrc` itself, zero from any
+# sibling. Widening those roots would be the second heuristic #730 says not to
+# invent, so this is a documented limit, not a TODO: absence of evidence leaves
+# the guard ENFORCING, which is the safe direction.
 NOGIT_REPO_LOCAL=()
 NOGIT_REPO_GITDIR="$(git -C "$ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
 if [ -n "$NOGIT_REPO_GITDIR" ]; then
@@ -2113,7 +2134,10 @@ NOGIT_CONFIG="$NOGIT_DIR/gitconfig"
 NOGIT_SESSIONS_LOG="$NOGIT_DIR/sessions.log"
 NOGIT_CHANGED_LOG="$NOGIT_DIR/changed.log"
 NOGIT_EVIDENCE_LOG="$NOGIT_DIR/evidence.log"
-if ! : > "$NOGIT_CONFIG" || ! : > "$NOGIT_CHANGED_LOG"; then
+# 🔴 THE EVIDENCE LOG IS IN THIS CHECK, not just in the list above. It is the
+# only record of WHY anything was downgraded, there is no `set -e` here, and an
+# unwritable one would silently produce downgrades with no stated cause.
+if ! : > "$NOGIT_CONFIG" || ! : > "$NOGIT_CHANGED_LOG" || ! : > "$NOGIT_EVIDENCE_LOG"; then
   echo "run-tests: FATAL — could not create the git-isolation files under" >&2
   echo "  $NOGIT_DIR. Refusing to run: without them a test that calls" >&2
   echo "  'git config --global' rewrites the operator's ~/.gitconfig, and a" >&2
@@ -2234,42 +2258,80 @@ fi
 # else. (It is the same argument the runner already `cd`'d to.)
 #
 # 🔴 FAIL TOWARD ENFORCING. A probe that cannot run (no python, an import error,
-# a helper that raises, a repo it cannot resolve) must NEVER read as "another
-# writer was found" — that is a broken instrument silently switching the guard
-# off, which claude/RULES.md rates worse than no guard. Any non-zero exit, and
-# any empty git-dir set, comes back as `probe-failed` and the change is enforced
-# exactly as it was before this change existed.
+# a helper that raises, a repo it cannot resolve, a hang) must NEVER read as
+# "another writer was found" — that is a broken instrument silently switching
+# the guard off, which claude/RULES.md rates worse than no guard. Any non-zero
+# exit, any empty git-dir set, and any output that does not carry the token
+# below comes back as `probe-failed`/`none`, and the change is enforced exactly
+# as it was before this change existed.
+#
+# 🔴 THE TOKEN IS THE FIX FOR A MEASURED FAIL-OPEN. This used to decide `proven`
+# from `[ -s "$out" ]` — output PRESENCE, not content — while the probe inherits
+# the ambient `PYTHONPATH`. So ANY stdout on that path counted as evidence:
+# MEASURED with NO co-tenant present, a single `print()` added to
+# `scripts/testlib/__init__.py` produced `repo-local-reported=1` and downgraded
+# a genuinely attributable write, rendering the stray line as GUARD 9 evidence.
+# A package that chatters at import, a `.pth`, a `sitecustomize` — all reach it.
+# Now only lines the probe itself stamps are accepted, and `proven` requires at
+# least one ACCEPTED reason, so whitespace-only or unstamped stdout is `none`.
+NOGIT_EVIDENCE_TOKEN="DEVRC-NOGIT-EVIDENCE"
+# `timeout` keeps a hung probe from wedging the whole run — "fails toward
+# enforcing" says nothing about a `/proc` stat that never returns. Absent
+# `timeout` is not fatal: the probe runs bare, exactly as before.
+if command -v timeout >/dev/null 2>&1; then
+  NOGIT_PROBE_TIMEOUT=(timeout 60)
+else
+  NOGIT_PROBE_TIMEOUT=()
+fi
 NOGIT_EV_STATUS=""    # proven | none | probe-failed
 _nogit_cotenancy_probe() { # $1 = target -> sets NOGIT_EV_STATUS, logs the reason
-  local t="$1" out="$NOGIT_DIR/evidence.out" err="$NOGIT_DIR/evidence.err" rc=0
+  local t="$1" out="$NOGIT_DIR/evidence.out" err="$NOGIT_DIR/evidence.err"
+  local rc=0 n=0 line reason
   : > "$out"; : > "$err"
-  PYTHONPATH="$ROOT/scripts${PYTHONPATH:+:$PYTHONPATH}" python -c '
+  PYTHONPATH="$ROOT/scripts${PYTHONPATH:+:$PYTHONPATH}" \
+  ${NOGIT_PROBE_TIMEOUT[@]+"${NOGIT_PROBE_TIMEOUT[@]}"} python -c '
 import sys
 from pathlib import Path
 from testlib.gitenv import attribution_evidence, protected_git_dirs
-dirs = protected_git_dirs([Path(p) for p in sys.argv[1:]])
+token, starts = sys.argv[1], sys.argv[2:]
+dirs = protected_git_dirs([Path(p) for p in starts])
 if not dirs:
     # No repository resolved, yet a repo-local config just changed. The two
     # cannot both be true, so this is a broken probe, not an absence of writers.
     sys.exit(3)
 for reason in attribution_evidence(dirs):
-    print(reason)
-' "$ROOT" >"$out" 2>"$err" || rc=$?
+    reason = " ".join(str(reason).split())   # one line, so one accepted reason
+    if reason:
+        sys.stdout.write(f"{token}\t{reason}\n")
+' "$NOGIT_EVIDENCE_TOKEN" "$ROOT" >"$out" 2>"$err" || rc=$?
   if [ "$rc" -ne 0 ]; then
     NOGIT_EV_STATUS="probe-failed"
     printf '%s\t%s\t%s\n' "$t" "probe-failed" \
-      "the co-tenancy probe exited $rc, so no writer was PROVEN and this change is ENFORCED: $(tr '\n' ' ' < "$err" | cut -c1-300)" \
+      "the co-tenancy probe exited $rc (124 = timed out), so no writer was PROVEN and this change is ENFORCED: $(tr '\n' ' ' < "$err" | cut -c1-300)" \
       >> "$NOGIT_EVIDENCE_LOG"
-  elif [ -s "$out" ]; then
+    return 0
+  fi
+  # Only the probe's OWN stamped lines are evidence. Anything else on stdout
+  # belongs to somebody else's import and is not a fact about co-tenancy.
+  while IFS= read -r line; do
+    case "$line" in
+      "$NOGIT_EVIDENCE_TOKEN"$'\t'*) : ;;
+      *) continue ;;
+    esac
+    reason="${line#"$NOGIT_EVIDENCE_TOKEN"$'\t'}"
+    [ -n "$reason" ] || continue
+    n=$(( n + 1 ))
+    printf '%s\t%s\t%s\n' "$t" "proven" "$reason" >> "$NOGIT_EVIDENCE_LOG"
+  done < "$out"
+  # 🔴 SET *AFTER* THE LOOP, deliberately. Setting it before meant
+  # whitespace-only stdout produced `proven` with ZERO logged reasons — a
+  # downgrade whose stated cause was the empty string.
+  if [ "$n" -gt 0 ]; then
     NOGIT_EV_STATUS="proven"
-    while IFS= read -r line; do
-      [ -n "$line" ] || continue
-      printf '%s\t%s\t%s\n' "$t" "proven" "$line" >> "$NOGIT_EVIDENCE_LOG"
-    done < "$out"
   else
     NOGIT_EV_STATUS="none"
     printf '%s\t%s\t%s\n' "$t" "none" \
-      "no live process outside this run's own lineage is sitting inside the protected repository, so this change IS attributable to the target and is ENFORCED" \
+      "the co-tenancy probe returned no evidence, so this change IS attributable to the target and is ENFORCED" \
       >> "$NOGIT_EVIDENCE_LOG"
   fi
 }
@@ -3085,7 +3147,14 @@ for entry in ${NOGIT_SEEN[@]+"${NOGIT_SEEN[@]}"}; do
     # misdiagnosis for the repo-local one: it sent the reader to audit a target
     # that had done nothing (#730).
     if printf '%s' "$changed_names" | grep -q 'repo-local-enforced'; then
-      nogit_why="A repo-local one is a write to <git-common-dir>/config, which GIT_CONFIG_GLOBAL does not govern at all — and this run FOUND NO OTHER WRITER (no live process outside its own lineage sits in that repository), so it is attributable to this target. A global one reached the operator's file some other way: code that removes GIT_CONFIG_GLOBAL from its own environment."
+      # 🔴 STATE WHAT THE PROBE MEASURED, NOT AN INFERENCE FROM IT. This used to
+      # read "no live process outside its own lineage sits in that repository",
+      # which the probe cannot support: `live_cotenants` roots at the git dir
+      # and its PARENT, so a session in a SIBLING worktree is never counted.
+      # Telling a reader no other writer exists, when the writer this guard
+      # exists for is structurally invisible, is the same class of confident
+      # misdiagnosis #730 was filed about.
+      nogit_why="A repo-local one is a write to <git-common-dir>/config, which GIT_CONFIG_GLOBAL does not govern at all — and this run FOUND NO PROOF of another writer, so the change is attributed to this target. What was actually checked: no live process outside this run's own lineage had its cwd inside the git dir or its parent. That does NOT cover a session sitting in a SIBLING worktree of the same clone, which is invisible to this probe — if that is what wrote here, 'git reflog' and the file's mtime will say so. A global one reached the operator's file some other way: code that removes GIT_CONFIG_GLOBAL from its own environment."
     else
       nogit_why="GIT_CONFIG_GLOBAL redirects 'git config --global', so this reached them some other way — code that removes the variable from its own environment."
     fi
@@ -3140,8 +3209,15 @@ if [ -s "$NOGIT_EVIDENCE_LOG" ]; then
 fi
 
 if [ "${#nogit_problems[@]}" -gt 0 ]; then
+  # 🔴 THE BLOCK IS DELIMITED so a test can assert a path appears IN THE
+  # FAILURE, not merely somewhere in the run. MEASURED: without the end marker,
+  # `str(path) in out` was satisfied by the startup `present <path> [<class>]`
+  # listing, which prints unconditionally — suppressing the path here left the
+  # negative controls GREEN. Same shape as the reason assertion inside the
+  # downgrade block; the remedy just had not been applied here.
   echo "  ERROR: ${#nogit_problems[@]} GUARD 10 problem(s):" >&2
   for p in "${nogit_problems[@]}"; do echo "         $p" >&2; done
+  echo "  ---- end GUARD 10 problems ----" >&2
   fail=1
 fi
 rm -rf "$NOGIT_DIR"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -2019,6 +2019,9 @@ _spool_account() {
 #     fingerprinted before and after each target. That is what catches the
 #     residual hazard the exports cannot close — code that REMOVES
 #     GIT_CONFIG_GLOBAL from its own environment and drops back to $HOME.
+#     🔴 IT WATCHES TWO CLASSES AND ENFORCES THEM DIFFERENTLY (#730) — GLOBAL
+#     files always, the repo-local `<git-common-dir>/config` only while this run
+#     can still attribute a change to a target. See the class split below.
 #
 # 🔴 HOME IS DELIBERATELY NOT REASSIGNED. Several suites legitimately read
 # `~/.claude/...`, so a blanket HOME rewrite would break real tests and be
@@ -2052,8 +2055,44 @@ _nogit_protect "${XDG_CONFIG_HOME:-${HOME:-}/.config}/git/config"
 # is a REPO-LOCAL write — GIT_CONFIG_GLOBAL does not govern it at all. The
 # tripwire is the only thing that can see it. (Absent in the nix sandbox, which
 # builds from a store copy with no `.git`; that is reported, not assumed.)
+#
+# 🔴 BUT IT IS A DIFFERENT CLASS FROM THE OTHERS, AND #730 IS WHAT MEASURED IT.
+# The two files above are the OPERATOR'S: no concurrent worktree operation
+# writes `~/.gitconfig`, so a change there is still attributable to whatever was
+# running. `<git-common-dir>/config` is SHARED BY EVERY WORKTREE OF THE CLONE —
+# `git worktree add`, `git branch --track` and any `git config` in any of them
+# rewrite it. On the operator's box that clone carries ~90 worktrees and ~15
+# concurrent sessions, so it changes continuously and GUARD 10 blamed whichever
+# target happened to be running.
+#
+# MEASURED, same commit, two environments:
+#   isolated clone (own .git)  -> real-config-changed=0/3 everywhere, PASS
+#   shared clone (~90 wts)     -> .git/config CHANGED on 2 targets, FAIL,
+#                                 with failed=0: every test passed.
+# In that same shared run GUARD 9 (#720) independently PROVED co-tenancy and
+# downgraded itself to report mode. Two guards over an overlapping file set,
+# one of them attributing and one of them not.
+#
+# So the repo-local member is tracked SEPARATELY and enforced CONDITIONALLY: it
+# fails the run exactly as before UNLESS another writer is PROVEN, in which case
+# the change is REPORTED (printed, counted, named, with the reason) and does not
+# fail. The proof is GUARD 9's own already-audited evidence — see
+# `_nogit_cotenancy_probe` below — not a second heuristic. With no proven
+# co-tenant it still fails, so the `core.bare = true` casualty stays covered on
+# a clean machine and in CI, which is where that damage happened.
+NOGIT_REPO_LOCAL=()
 NOGIT_REPO_GITDIR="$(git -C "$ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
-[ -n "$NOGIT_REPO_GITDIR" ] && _nogit_protect "$NOGIT_REPO_GITDIR/config"
+if [ -n "$NOGIT_REPO_GITDIR" ]; then
+  _nogit_protect "$NOGIT_REPO_GITDIR/config"
+  NOGIT_REPO_LOCAL+=("$NOGIT_REPO_GITDIR/config")
+fi
+_nogit_is_repo_local() { # $1 = path -> 0 when it is the shared repo-local config
+  local p="$1" q
+  for q in ${NOGIT_REPO_LOCAL[@]+"${NOGIT_REPO_LOCAL[@]}"}; do
+    [ "$q" = "$p" ] && return 0
+  done
+  return 1
+}
 
 _nogit_fingerprint_of() { # $@ = paths -> one line each: "<sha256|ABSENT> <path>"
   local f
@@ -2073,6 +2112,7 @@ NOGIT_DIR="$(mktemp -d)"
 NOGIT_CONFIG="$NOGIT_DIR/gitconfig"
 NOGIT_SESSIONS_LOG="$NOGIT_DIR/sessions.log"
 NOGIT_CHANGED_LOG="$NOGIT_DIR/changed.log"
+NOGIT_EVIDENCE_LOG="$NOGIT_DIR/evidence.log"
 if ! : > "$NOGIT_CONFIG" || ! : > "$NOGIT_CHANGED_LOG"; then
   echo "run-tests: FATAL — could not create the git-isolation files under" >&2
   echo "  $NOGIT_DIR. Refusing to run: without them a test that calls" >&2
@@ -2165,11 +2205,76 @@ if [ "${#NOGIT_PROTECTED[@]}" -eq 0 ]; then
 else
   echo "  protected files: ${#NOGIT_PROTECTED[@]} (fingerprinted before/after every target)"
   for f in "${NOGIT_PROTECTED[@]}"; do
-    if [ -f "$f" ]; then echo "    present $f"; else echo "    absent  $f"; fi
+    # The CLASS is printed beside every path, at every site, because the two are
+    # enforced differently and a reader must never have to infer which is which.
+    if _nogit_is_repo_local "$f"; then
+      _nogit_cls="repo-local, enforcing unless another writer is PROVEN"
+    else
+      _nogit_cls="global, always enforcing"
+    fi
+    if [ -f "$f" ]; then echo "    present $f  [$_nogit_cls]"
+    else echo "    absent  $f  [$_nogit_cls]"; fi
   done
+  unset _nogit_cls
 fi
 
-# "<target>|<sess-from>|<sess-to>|<n-changed>|<control-delta>"
+# 🔴 THE EVIDENCE, BORROWED WHOLE FROM GUARD 9 — NOT A SECOND HEURISTIC.
+# `scripts/testlib/gitenv.py` already owns "can this session attribute a change
+# to a test?", it was audited for #683/#720, and it answers with POSITIVE
+# evidence: a live process, not one of our own ancestors, whose CWD sits inside
+# the work tree of a protected repository. That is the only question GUARD 10
+# needs, so it is asked THERE — one rule, one place. A bash re-implementation
+# would be a second policy that drifts from the first.
+#
+# `$ROOT` is passed EXPLICITLY rather than left to the default cwd discovery:
+# `protected_git_dirs()` also probes the module's own directory, which resolves
+# to whatever clone `scripts/testlib` lives in. That is right for GUARD 9's
+# in-process detector and wrong here — the question is about the repository
+# whose `<git-common-dir>/config` this runner is fingerprinting, and nothing
+# else. (It is the same argument the runner already `cd`'d to.)
+#
+# 🔴 FAIL TOWARD ENFORCING. A probe that cannot run (no python, an import error,
+# a helper that raises, a repo it cannot resolve) must NEVER read as "another
+# writer was found" — that is a broken instrument silently switching the guard
+# off, which claude/RULES.md rates worse than no guard. Any non-zero exit, and
+# any empty git-dir set, comes back as `probe-failed` and the change is enforced
+# exactly as it was before this change existed.
+NOGIT_EV_STATUS=""    # proven | none | probe-failed
+_nogit_cotenancy_probe() { # $1 = target -> sets NOGIT_EV_STATUS, logs the reason
+  local t="$1" out="$NOGIT_DIR/evidence.out" err="$NOGIT_DIR/evidence.err" rc=0
+  : > "$out"; : > "$err"
+  PYTHONPATH="$ROOT/scripts${PYTHONPATH:+:$PYTHONPATH}" python -c '
+import sys
+from pathlib import Path
+from testlib.gitenv import attribution_evidence, protected_git_dirs
+dirs = protected_git_dirs([Path(p) for p in sys.argv[1:]])
+if not dirs:
+    # No repository resolved, yet a repo-local config just changed. The two
+    # cannot both be true, so this is a broken probe, not an absence of writers.
+    sys.exit(3)
+for reason in attribution_evidence(dirs):
+    print(reason)
+' "$ROOT" >"$out" 2>"$err" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    NOGIT_EV_STATUS="probe-failed"
+    printf '%s\t%s\t%s\n' "$t" "probe-failed" \
+      "the co-tenancy probe exited $rc, so no writer was PROVEN and this change is ENFORCED: $(tr '\n' ' ' < "$err" | cut -c1-300)" \
+      >> "$NOGIT_EVIDENCE_LOG"
+  elif [ -s "$out" ]; then
+    NOGIT_EV_STATUS="proven"
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      printf '%s\t%s\t%s\n' "$t" "proven" "$line" >> "$NOGIT_EVIDENCE_LOG"
+    done < "$out"
+  else
+    NOGIT_EV_STATUS="none"
+    printf '%s\t%s\t%s\n' "$t" "none" \
+      "no live process outside this run's own lineage is sitting inside the protected repository, so this change IS attributable to the target and is ENFORCED" \
+      >> "$NOGIT_EVIDENCE_LOG"
+  fi
+}
+
+# "<target>|<sess-from>|<sess-to>|<n-enforced>|<control-delta>|<n-reported>"
 NOGIT_SEEN=()
 NOGIT_B_FP=""
 NOGIT_B_CTL=0
@@ -2186,18 +2291,44 @@ _nogit_mark_before() {
 }
 # $1 = target name. Every call MUST be preceded by the before-mark above, or the
 # range it records belongs to whatever ran previously.
+#
+# Two counters out, not one: ENFORCED changes (every global one, plus every
+# repo-local one this run could still attribute) and REPORTED ones (repo-local,
+# with another writer proven). A reported change is never dropped — it is
+# written to the changed log with its class, its reason is written to the
+# evidence log, and both are printed in the accounting below.
 _nogit_account() {
-  local t="$1" i n=0
-  local -a B A
+  local t="$1" i n=0 rep=0 path cls repo_hits=0 proven=0
+  local -a B A CHANGED=()
   mapfile -t B <<<"$NOGIT_B_FP"
   mapfile -t A <<<"$(_nogit_fingerprint)"
   for ((i = 0; i < ${#A[@]}; i++)); do
     if [ "${B[i]:-}" != "${A[i]}" ]; then
-      n=$(( n + 1 ))
-      printf '%s\t%s\n' "$t" "${A[i]#* }" >> "$NOGIT_CHANGED_LOG"
+      path="${A[i]#* }"
+      CHANGED+=("$path")
+      _nogit_is_repo_local "$path" && repo_hits=$(( repo_hits + 1 ))
     fi
   done
-  NOGIT_SEEN+=("$t|$(( NOGIT_B_S + 1 ))|$(_spool_lines "$NOGIT_SESSIONS_LOG")|$n|$(( $(_nogit_controls) - NOGIT_B_CTL ))")
+  # Asked once per target and only when it can change an outcome — the evidence
+  # is contemporaneous with the delta it explains, which is the whole point of
+  # asking it here rather than once at startup.
+  if [ "$repo_hits" -gt 0 ]; then
+    _nogit_cotenancy_probe "$t"
+    [ "$NOGIT_EV_STATUS" = "proven" ] && proven=1
+  fi
+  for path in ${CHANGED[@]+"${CHANGED[@]}"}; do
+    if _nogit_is_repo_local "$path"; then
+      if [ "$proven" -eq 1 ]; then
+        cls="repo-local-reported"; rep=$(( rep + 1 ))
+      else
+        cls="repo-local-enforced"; n=$(( n + 1 ))
+      fi
+    else
+      cls="global-enforced"; n=$(( n + 1 ))
+    fi
+    printf '%s\t%s\t%s\n' "$t" "$cls" "$path" >> "$NOGIT_CHANGED_LOG"
+  done
+  NOGIT_SEEN+=("$t|$(( NOGIT_B_S + 1 ))|$(_spool_lines "$NOGIT_SESSIONS_LOG")|$n|$(( $(_nogit_controls) - NOGIT_B_CTL ))|$rep")
 }
 
 # 🔴 THE ACKNOWLEDGEMENT LEDGER — "<target>|<reason>". A target listed here is
@@ -2899,8 +3030,12 @@ if [ "${#NOGIT_PROTECTED[@]}" -eq 0 ]; then
        "no .git in this tree). The controls carry this run; the tripwire watched nothing."
 else
   echo "    protected-files=${#NOGIT_PROTECTED[@]}  (fingerprinted before/after every target)"
+  echo "    classes=global:$(( ${#NOGIT_PROTECTED[@]} - ${#NOGIT_REPO_LOCAL[@]} ))" \
+       "(always enforcing)  repo-local:${#NOGIT_REPO_LOCAL[@]}" \
+       "(enforcing unless another writer is PROVEN — see #730)"
 fi
 nogit_problems=()
+nogit_reported_total=0
 for t in "${TARGETS[@]}"; do
   seen=0
   for entry in ${NOGIT_SEEN[@]+"${NOGIT_SEEN[@]}"}; do
@@ -2910,7 +3045,9 @@ for t in "${TARGETS[@]}"; do
 done
 
 for entry in ${NOGIT_SEEN[@]+"${NOGIT_SEEN[@]}"}; do
-  IFS='|' read -r gt gfrom gto gchanged gctl <<<"$entry"
+  IFS='|' read -r gt gfrom gto gchanged gctl greported <<<"$entry"
+  greported="${greported:-0}"
+  nogit_reported_total=$(( nogit_reported_total + greported ))
 
   gsess="$(_spool_slice "$NOGIT_SESSIONS_LOG" "$gfrom" "$gto")"
   markers=$(printf '%s\n' "$gsess" | grep -c "^$NOGIT_SESSION_MARKER" || true)
@@ -2928,15 +3065,31 @@ for entry in ${NOGIT_SEEN[@]+"${NOGIT_SEEN[@]}"}; do
   is_pytest=0
   for t in "${TARGETS[@]}"; do [ "$t" = "$gt" ] && is_pytest=1 && break; done
 
-  echo "    $gt  real-config-changed=$gchanged/${#NOGIT_PROTECTED[@]}  config-control=$gctl  protocol=${m_protocol:-n/a}  plugin=$markers"
+  # `repo-local-reported` is printed on EVERY line, including its zero. It is not
+  # a detector's zero — it is a count of deltas this run declined to attribute —
+  # and printing it always is what makes a non-zero one impossible to miss.
+  echo "    $gt  real-config-changed=$gchanged/${#NOGIT_PROTECTED[@]}  config-control=$gctl  protocol=${m_protocol:-n/a}  plugin=$markers  repo-local-reported=$greported"
 
   # 🔴 THE DAMAGE ITSELF. A protected file whose fingerprint moved is the
   # 2026-08-21 incident happening again: `~/.gitconfig` rewritten, or
   # `core.bare = true` written into a populated clone's `.git/config`.
+  #
+  # `$gchanged` counts only the ENFORCED classes. A repo-local delta with a
+  # proven external writer is in `$greported` instead and is rendered below,
+  # never here and never silently.
   if [ "$gchanged" -gt 0 ]; then
-    changed_names="$(grep -F "$(printf '%s\t' "$gt")" "$NOGIT_CHANGED_LOG" 2>/dev/null \
-      | cut -f2- | sed 's/^/             /' || true)"
-    nogit_problems+=("$gt  — CHANGED $gchanged of the operator's protected git config file(s) while it ran. GIT_CONFIG_GLOBAL redirects 'git config --global', so this reached them some other way (code that removes the variable from its own environment, or a repo-local write):"$'\n'"$changed_names")
+    changed_names="$(awk -F'\t' -v t="$gt" \
+      '$1 == t && $2 != "repo-local-reported" { printf "             %s  [%s]\n", $3, $2 }' \
+      "$NOGIT_CHANGED_LOG" 2>/dev/null || true)"
+    # The cause differs by class, and the old single sentence was a confident
+    # misdiagnosis for the repo-local one: it sent the reader to audit a target
+    # that had done nothing (#730).
+    if printf '%s' "$changed_names" | grep -q 'repo-local-enforced'; then
+      nogit_why="A repo-local one is a write to <git-common-dir>/config, which GIT_CONFIG_GLOBAL does not govern at all — and this run FOUND NO OTHER WRITER (no live process outside its own lineage sits in that repository), so it is attributable to this target. A global one reached the operator's file some other way: code that removes GIT_CONFIG_GLOBAL from its own environment."
+    else
+      nogit_why="GIT_CONFIG_GLOBAL redirects 'git config --global', so this reached them some other way — code that removes the variable from its own environment."
+    fi
+    nogit_problems+=("$gt  — CHANGED $gchanged of the operator's protected git config file(s) while it ran. $nogit_why"$'\n'"$changed_names")
   fi
 
   if [ "$is_pytest" -eq 1 ]; then
@@ -2959,6 +3112,32 @@ for entry in ${NOGIT_SEEN[@]+"${NOGIT_SEEN[@]}"}; do
     fi
   fi
 done
+
+# 🔴 A DOWNGRADE IS NOT A DROP. Everything this run declined to attribute is
+# rendered in full — the target, the file, its class, and the EVIDENCE that
+# licensed the downgrade, worded the way GUARD 9 words it. A guard that quietly
+# stopped failing would be indistinguishable from a guard that stopped looking;
+# these lines are the difference, and they are on stdout beside the counts.
+echo "    repo-local-reported-total=$nogit_reported_total  (deltas to <git-common-dir>/config this run could NOT attribute)"
+if [ "$nogit_reported_total" -gt 0 ]; then
+  echo "    ---- repo-local git config: REPORTED, not enforced (#730) ----"
+  awk -F'\t' '$2 == "repo-local-reported" { printf "      %s\n        changed: %s\n", $1, $3 }' \
+    "$NOGIT_CHANGED_LOG" 2>/dev/null || true
+  awk -F'\t' '$2 == "proven" { printf "      %s\n        cannot attribute: %s\n", $1, $3 }' \
+    "$NOGIT_EVIDENCE_LOG" 2>/dev/null || true
+  echo "      This file is the git COMMON dir's config, shared by every worktree of"
+  echo "      the clone; 'git worktree add', 'git branch --track' and any 'git config'"
+  echo "      in any of them rewrite it. GUARD 10's PREVENTION half is unaffected and"
+  echo "      still in force; only ATTRIBUTION is impossible here. Re-run in a clone"
+  echo "      with one writer to enforce it — an isolated clone still fails on this."
+fi
+# The same rendering for the two states that did NOT downgrade. A repo-local
+# delta that was enforced, or a probe that could not run, must say WHY beside
+# the failure it caused — otherwise the reader is back to guessing.
+if [ -s "$NOGIT_EVIDENCE_LOG" ]; then
+  awk -F'\t' '$2 == "none" || $2 == "probe-failed" { printf "    %s  evidence=%s: %s\n", $1, $2, $3 }' \
+    "$NOGIT_EVIDENCE_LOG" 2>/dev/null || true
+fi
 
 if [ "${#nogit_problems[@]}" -gt 0 ]; then
   echo "  ERROR: ${#nogit_problems[@]} GUARD 10 problem(s):" >&2

--- a/scripts/tests/test_nogit_isolation.py
+++ b/scripts/tests/test_nogit_isolation.py
@@ -61,6 +61,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -68,6 +69,11 @@ SCRIPTS = REPO_ROOT / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 from testlib import nogit_plugin  # noqa: E402
+# 🔴 The SAME helper the runner's evidence probe calls — imported, not restated.
+# A second copy of "is another process sitting in this repo?" would agree with
+# the first until the day one of them changed, and the control below would then
+# be asserting its own opinion instead of the guard's.
+from testlib.gitenv import live_cotenants  # noqa: E402
 from testlib.runner_patch import runner_with_targets, write_pytest_suite  # noqa: E402
 
 RUN_TESTS = SCRIPTS / "run-tests.sh"
@@ -735,3 +741,321 @@ def test_a_target_that_rewrites_the_home_config_is_named_and_red(tmp_path):
         f"the failure did not NAME the file that changed:\n{out}")
     # The positive control for the assertion above: the write really happened.
     assert "planted-by-a-test" in (home / ".gitconfig").read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 #730 — THE REPO-LOCAL CLASS, AND THE THREE DIRECTIONS THAT DEFINE IT
+# --------------------------------------------------------------------------- #
+# `NOGIT_PROTECTED` holds two classes of file and they are NOT the same claim:
+#
+#   GLOBAL      `~/.gitconfig`, `$XDG_CONFIG_HOME/git/config`, everything
+#               `git config --global --list --show-origin` names. Nothing a
+#               concurrent worktree operation does writes these, so a change is
+#               still attributable to whatever was running. Always enforcing.
+#   REPO-LOCAL  `<git-common-dir>/config`. Shared by EVERY worktree of the
+#               clone: `git worktree add`, `git branch --track` and any
+#               `git config` in any of them rewrite it. On the operator's box
+#               that is ~90 worktrees and ~15 concurrent sessions, so it moves
+#               continuously and GUARD 10 blamed whichever target was running.
+#
+# MEASURED, one commit, two environments (#730):
+#   isolated clone -> real-config-changed=0/3 on every target, PASS
+#   shared clone   -> .git/config CHANGED on 2 targets, FAIL, with failed=0
+# In that same shared run GUARD 9 PROVED co-tenancy and downgraded itself.
+#
+# WHAT IS REGRESSION COVERAGE HERE AND WHAT IS NOT. All four are RED at
+# `a0fb39c7`, but only ONE of them is red for a BEHAVIOURAL reason, and the
+# difference is the label:
+#   * `test_a_repo_local_change_is_REPORTED_when_a_cotenant_is_PROVEN` is THE
+#     regression test. At base, MEASURED: `real-config-changed=1/3`,
+#     `RESULT: FAIL (exit=1)` with `failed=0` — #730's shape exactly. GREEN at
+#     HEAD. This is the only one that may be counted as regression coverage.
+#   * `test_a_repo_local_change_still_FAILS_when_no_cotenant_is_proven` and
+#     `test_a_global_change_FAILS_even_with_a_cotenant_PROVEN` are NEGATIVE
+#     CONTROLS. The BEHAVIOUR they pin (the run must go red) is what base
+#     already did; they are red at base only because they also assert the new
+#     class WORDING. Do not read their base-red as regression coverage. Without
+#     them, "#730 is fixed" is satisfied by a patch that simply stops watching
+#     the file, or by one that lets co-tenancy suppress `~/.gitconfig` too.
+#   * `test_a_broken_evidence_probe_fails_TOWARD_enforcing` is a FAIL-SAFE guard
+#     on code that did not exist at base, so its base-red is structural (its
+#     mutation anchor is absent), not behavioural. Its branch is proved
+#     REACHABLE by the mutation that flips the probe's failure path to `proven`,
+#     which turns it red at HEAD.
+#
+# THE MEASUREMENT METHOD, and why it is sound: the runner is driven against a
+# SCRATCH ROOT — a directory whose top-level entries are symlinks to this repo
+# (so `$ROOT/scripts/...` resolves and the runner's own preconditions hold) but
+# which owns a FRESH `.git` of its own. The operator's real clone is never
+# written. Co-tenancy is then flipped with REAL evidence rather than a stub: a
+# live process whose cwd sits in that scratch root, which is exactly what
+# `testlib.gitenv.live_cotenants` looks for.
+_G10_PROBE_IMPORT = "from testlib.gitenv import attribution_evidence, protected_git_dirs"
+
+
+def _scratch_root(tmp_path: Path) -> Path:
+    """A repository of its own whose content is this repo, by symlink.
+
+    🔴 The point is the `.git`: `git init` here gives the runner a
+    `<git-common-dir>/config` that this test OWNS, so a planted repo-local write
+    is measured against a directory pytest created and never against the
+    operator's shared clone.
+    """
+    scratch = tmp_path / "scratch-root"
+    scratch.mkdir(parents=True, exist_ok=True)
+    for entry in REPO_ROOT.iterdir():
+        if entry.name == ".git":
+            continue
+        (scratch / entry.name).symlink_to(entry)
+    init = subprocess.run(["git", "init", "-q", str(scratch)],
+                          capture_output=True, text=True, timeout=120)
+    assert init.returncode == 0, f"could not init the scratch root:\n{init.stderr}"
+    assert (scratch / ".git" / "config").is_file(), (
+        "the scratch root has no repo-local config — the whole measurement "
+        "below would be about a file that does not exist")
+    return scratch
+
+
+def _runner_over(tmp_path: Path, scratch: Path, shell_tests: list[str]) -> Path:
+    target = tmp_path / "plain_tests"
+    write_pytest_suite(target, 2, prefix="test_plain")
+    return runner_with_targets(tmp_path, [str(target)], {str(target): 1},
+                               hook_tests=[], shell_tests=shell_tests)
+
+
+def _run_at(runner: Path, scratch: Path, tmp_path: Path) -> subprocess.CompletedProcess:
+    env = {**os.environ, **_unguarded_home(tmp_path)}
+    for k, v in list(env.items()):
+        if v is None:
+            del env[k]
+    return subprocess.run(["bash", str(runner), str(scratch)], capture_output=True,
+                          text=True, timeout=900, cwd=str(REPO_ROOT), env=env)
+
+
+class _cotenant:
+    """A REAL live process sitting in `root`, which is the evidence itself.
+
+    Not a stub and not a monkeypatch: `live_cotenants` scans `/proc` for a
+    process whose cwd is inside a protected repository and which is not one of
+    our own ancestors. A `sleep` started here is a sibling of the runner, so it
+    is precisely the thing that function exists to find.
+    """
+
+    def __init__(self, root: Path):
+        self.root = root
+        self.proc: subprocess.Popen | None = None
+
+    def __enter__(self):
+        self.proc = subprocess.Popen(["sleep", "900"], cwd=str(self.root),
+                                     stdout=subprocess.DEVNULL,
+                                     stderr=subprocess.DEVNULL)
+        # The positive control for the evidence itself: assert the helper the
+        # runner will call ACTUALLY sees it, before the run whose verdict
+        # depends on it. Without this a run that passed for some unrelated
+        # reason would be scored as "the downgrade worked".
+        for _ in range(50):
+            if live_cotenants([self.root / ".git"]):
+                return self
+            time.sleep(0.1)
+        raise AssertionError(
+            f"no co-tenant was visible in {self.root} after starting one — the "
+            "evidence this test depends on was never established")
+
+    def __exit__(self, *exc):
+        if self.proc is not None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=30)
+            except subprocess.TimeoutExpired:      # pragma: no cover - defensive
+                self.proc.kill()
+        return False
+
+
+# 🔴 NO SHEBANG, DELIBERATELY, AND NOT AN OVERSIGHT. `run-tests.sh`'s
+# SHELL_TESTS loop invokes each entry as `bash "$SHELL_TEST"`, so the shebang is
+# never consulted — and writing `#!/usr/bin/env bash` here would plant the exact
+# defect `test_runtime_shebangs.py` exists to catch: `/usr/bin/env` is present on
+# the dev host and ABSENT in the nix build sandbox, which is the tier that gates
+# merges. Measured: this file's first full-suite run was RED on that guard.
+def _plant_repo_local_write(scratch: Path) -> str:
+    name = "g10-write-repo-local.sh"
+    (scratch / name).write_text(
+        "set -euo pipefail\n"
+        f'git -C "{scratch}" config devrc-g10.planted yes\n',
+        encoding="utf-8")
+    return name
+
+
+def _plant_global_write(scratch: Path, home: Path) -> str:
+    name = "g10-write-global.sh"
+    (scratch / name).write_text(
+        "set -euo pipefail\n"
+        "env -u GIT_CONFIG_GLOBAL -u GIT_CONFIG_SYSTEM -u GIT_CONFIG_NOSYSTEM "
+        f'HOME="{home}" git config --global core.hooksPath /tmp/planted-by-a-test\n',
+        encoding="utf-8")
+    return name
+
+
+def test_a_repo_local_change_is_REPORTED_when_a_cotenant_is_PROVEN(tmp_path):
+    """🔴 THE REGRESSION TEST FOR #730. RED at a0fb39c7, GREEN at HEAD.
+
+    A target changes `<git-common-dir>/config` while another live process sits
+    in that repository. The change is real and is NOT dropped — it is counted,
+    named, and its reason is printed — but it does not fail the run, because
+    nothing in this environment can attribute it to the target.
+    """
+    scratch = _scratch_root(tmp_path)
+    name = _plant_repo_local_write(scratch)
+    runner = _runner_over(tmp_path, scratch, [name])
+
+    with _cotenant(scratch):
+        proc = _run_at(runner, scratch, tmp_path)
+    out = proc.stdout + proc.stderr
+
+    assert proc.returncode == 0, (
+        "a repo-local config change with a PROVEN external writer still failed "
+        f"the run — this is #730:\n{out}")
+    # The write really happened: without this the pass above is satisfied by
+    # nothing having changed at all.
+    assert "planted" in (scratch / ".git" / "config").read_text(encoding="utf-8"), (
+        "the planted repo-local write never landed, so this run proves nothing")
+    assert f"{name}  real-config-changed=0/" in out, (
+        f"the accounting did not record the change as non-enforcing:\n{out}")
+    assert "repo-local-reported=1" in out, (
+        f"the downgraded change was not COUNTED on the target's line:\n{out}")
+    assert "repo-local-reported-total=1" in out, (
+        f"the downgraded change is missing from the run's summary:\n{out}")
+
+    # 🔴 SCOPED TO GUARD 10's OWN BLOCK, and the mutation sweep is why.
+    # `cannot attribute: live processes are sitting inside …` is also printed by
+    # GUARD 9's per-target `gitenv(session)` lines, which fire here because that
+    # detector watches the repo `testlib` lives in — the operator's co-tenanted
+    # clone. Asserted against the whole output, the mutant that DELETES GUARD
+    # 10's reason logging SURVIVED a fully green suite: the neighbour's sentence
+    # satisfied the pin. The same applies to the file path, which the startup
+    # `protected files:` listing also prints. Both are read out of the reported
+    # block only.
+    head = "---- repo-local git config: REPORTED, not enforced (#730) ----"
+    tail = "This file is the git COMMON dir's config"
+    assert head in out, f"the downgrade block was never printed:\n{out}"
+    assert tail in out, f"the downgrade block is not delimited as expected:\n{out}"
+    block = out.split(head, 1)[1].split(tail, 1)[0]
+    assert name in block, (
+        f"the downgrade block did not NAME the target:\n{block}\n---\n{out}")
+    assert str(scratch / ".git" / "config") in block, (
+        f"the downgrade block did not NAME the file:\n{block}\n---\n{out}")
+    assert "cannot attribute: live processes are sitting inside" in block, (
+        f"the downgrade block did not state the REASON, as GUARD 9 does:"
+        f"\n{block}\n---\n{out}")
+
+
+def test_a_repo_local_change_still_FAILS_when_no_cotenant_is_proven(tmp_path):
+    """🔴 NEGATIVE CONTROL — NOT regression coverage.
+
+    The behaviour it pins (the run goes red) is what base already did; it is red
+    at base only over the new class wording. Counting that as regression
+    coverage would be a coverage claim nobody measured.
+
+    This is the half that matters. Without it, "#730 is fixed" is satisfied by a
+    patch that simply stops watching the repo-local file, and the `core.bare =
+    true` casualty that motivated protecting it would be uncovered on a clean
+    machine and in CI — which is exactly where it happened.
+    """
+    scratch = _scratch_root(tmp_path)
+    name = _plant_repo_local_write(scratch)
+    runner = _runner_over(tmp_path, scratch, [name])
+
+    assert not live_cotenants([scratch / ".git"]), (
+        "something is already sitting in this scratch root, so the 'no proven "
+        "writer' arm of this control does not hold")
+    proc = _run_at(runner, scratch, tmp_path)
+    out = proc.stdout + proc.stderr
+
+    assert proc.returncode != 0, (
+        f"an ATTRIBUTABLE repo-local config change produced a PASSING run:\n{out}")
+    assert "GUARD 10 problem" in out, (
+        f"the run failed, but not for the git-config reason:\n{out}")
+    assert "repo-local-enforced" in out, (
+        f"the failure did not classify the change as repo-local-ENFORCED:\n{out}")
+    assert "repo-local-reported-total=0" in out, (
+        f"nothing should have been downgraded in this run:\n{out}")
+    assert "FOUND NO OTHER WRITER" in out, (
+        f"the failure did not say WHY it was attributable:\n{out}")
+    assert str(scratch / ".git" / "config") in out, (
+        f"the failure did not NAME the file that changed:\n{out}")
+
+
+def test_a_global_change_FAILS_even_with_a_cotenant_PROVEN(tmp_path):
+    """🔴 NEGATIVE CONTROL on the CLASS BOUNDARY — NOT regression coverage.
+
+    Same label as the control above: base already failed this run, so its
+    base-red is about the new wording, not about behaviour.
+
+    Co-tenancy licenses a downgrade for the repo-local file and for NOTHING
+    else. `~/.gitconfig` is the 2026-08-21 incident's actual shape; a fix that
+    let proven co-tenancy suppress it would have removed the guard's teeth while
+    reading, in the output, exactly like the fix that keeps them.
+
+    Measured against a SCRATCH home, never the operator's.
+    """
+    scratch = _scratch_root(tmp_path)
+    home = tmp_path / "scratch-home"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".gitconfig").write_text("[user]\n\tname = pre-existing\n",
+                                     encoding="utf-8")
+    name = _plant_global_write(scratch, home)
+    runner = _runner_over(tmp_path, scratch, [name])
+
+    with _cotenant(scratch):
+        proc = _run_at(runner, scratch, tmp_path)
+    out = proc.stdout + proc.stderr
+
+    assert proc.returncode != 0, (
+        f"a GLOBAL config change was downgraded by co-tenancy:\n{out}")
+    assert "GUARD 10 problem" in out, (
+        f"the run failed, but not for the git-config reason:\n{out}")
+    assert "global-enforced" in out, (
+        f"the failure did not classify the change as GLOBAL:\n{out}")
+    assert str(home / ".gitconfig") in out, (
+        f"the failure did not NAME the file that changed:\n{out}")
+    # The positive control for the assertion above: the write really happened.
+    assert "planted-by-a-test" in (home / ".gitconfig").read_text(encoding="utf-8")
+
+
+def test_a_broken_evidence_probe_fails_TOWARD_enforcing(tmp_path):
+    """🔴 A BROKEN PROBE MUST NOT SILENTLY DISABLE THE GUARD.
+
+    The downgrade is licensed by evidence collected from `testlib.gitenv`. If
+    that collection cannot run — no python, an import error, a helper that
+    raises — the honest answer is "no writer was PROVEN", i.e. enforce. A probe
+    whose failure read as proof would be a guard switched off by a typo.
+
+    Its base-red is STRUCTURAL, not behavioural: base has no probe, so the
+    mutation anchor is simply absent. Its branch is proved REACHABLE by the
+    mutation that makes the failure path return `proven`, which turns it red.
+    """
+    scratch = _scratch_root(tmp_path)
+    name = _plant_repo_local_write(scratch)
+    runner = _runner_over(tmp_path, scratch, [name])
+
+    src = runner.read_text(encoding="utf-8")
+    assert src.count(_G10_PROBE_IMPORT) == 1, (
+        "expected exactly one live import in the evidence probe to break; "
+        "found a different number, so this mutation would not land")
+    runner.write_text(
+        src.replace(_G10_PROBE_IMPORT, "import testlib.no_such_module_g10"),
+        encoding="utf-8")
+    assert "no_such_module_g10" in runner.read_text(encoding="utf-8"), (
+        "the mutation did not land — a non-matching anchor scores a bogus pass")
+
+    with _cotenant(scratch):
+        proc = _run_at(runner, scratch, tmp_path)
+    out = proc.stdout + proc.stderr
+
+    assert proc.returncode != 0, (
+        "a BROKEN evidence probe downgraded a repo-local change — the guard was "
+        f"switched off by an import error:\n{out}")
+    assert "evidence=probe-failed" in out, (
+        f"the run failed, but not because the probe could not run:\n{out}")
+    assert "repo-local-reported-total=0" in out, (
+        f"a failed probe must downgrade NOTHING:\n{out}")

--- a/scripts/tests/test_nogit_isolation.py
+++ b/scripts/tests/test_nogit_isolation.py
@@ -108,6 +108,28 @@ EXPECTED_PLUGINS = {"testlib.nolaunch" + "_plugin",
 # --------------------------------------------------------------------------- #
 # Helpers
 # --------------------------------------------------------------------------- #
+def _guard10_failure_block(out: str) -> str:
+    """Just GUARD 10's `ERROR:` block, so a path assertion means what it says.
+
+    🔴 WHY THIS EXISTS, MEASURED. `assert str(path) in out` looks like "the
+    failure named the file" and is not: `run-tests.sh` prints
+    `present <path>  [<class>]` for EVERY protected file at startup,
+    unconditionally, whether or not anything fails. An audit mutant that
+    suppressed the path in GUARD 10's failure message left the negative controls
+    at `9 passed` — SURVIVED. The same shape as the reason assertion inside the
+    downgrade block, which had already been scoped for exactly this reason.
+
+    Returns "" when the block is absent, so a caller asserting into it fails
+    rather than silently searching an empty string it mistook for the run.
+    """
+    head = "ERROR:"
+    tail = "---- end GUARD 10 problems ----"
+    if "GUARD 10 problem(s):" not in out or tail not in out:
+        return ""
+    after = out.split("GUARD 10 problem(s):", 1)[1]
+    return head + after.split(tail, 1)[0]
+
+
 def _pytest_invocations(src: str) -> list[str]:
     """The lines that actually RUN pytest — not the ones that talk about it."""
     return [ln for ln in src.splitlines()
@@ -736,9 +758,15 @@ def test_a_target_that_rewrites_the_home_config_is_named_and_red(tmp_path):
         f"a planted write to the home git config produced a PASSING run:\n{out}")
     assert "GUARD 10 problem" in out, (
         f"the run failed, but not for the git-config reason:\n{out}")
-    assert str(target) in out, f"the failure did not NAME the target:\n{out}"
-    assert str(home / ".gitconfig") in out, (
-        f"the failure did not NAME the file that changed:\n{out}")
+    # 🔴 Read out of GUARD 10's FAILURE block, not the whole run — the startup
+    # `present <path>` listing satisfies a bare `in out` even when the failure
+    # names nothing (see `_guard10_failure_block`).
+    block = _guard10_failure_block(out)
+    assert block, f"GUARD 10's failure block was not printed at all:\n{out}"
+    assert str(target) in block, (
+        f"the failure did not NAME the target:\n{block}\n---\n{out}")
+    assert str(home / ".gitconfig") in block, (
+        f"the failure did not NAME the file that changed:\n{block}\n---\n{out}")
     # The positive control for the assertion above: the write really happened.
     assert "planted-by-a-test" in (home / ".gitconfig").read_text(encoding="utf-8")
 
@@ -921,10 +949,15 @@ def test_a_repo_local_change_is_REPORTED_when_a_cotenant_is_PROVEN(tmp_path):
         "the planted repo-local write never landed, so this run proves nothing")
     assert f"{name}  real-config-changed=0/" in out, (
         f"the accounting did not record the change as non-enforcing:\n{out}")
-    assert "repo-local-reported=1" in out, (
-        f"the downgraded change was not COUNTED on the target's line:\n{out}")
-    assert "repo-local-reported-total=1" in out, (
-        f"the downgraded change is missing from the run's summary:\n{out}")
+    # 🔴 TRAILING BOUNDARY PINNED. A bare `"repo-local-reported=1" in out` is a
+    # PREFIX match: it is equally satisfied by `=10` … `=19`, so a count that
+    # ran away by an order of magnitude reads as the expected 1.
+    assert re.search(r"repo-local-reported=1(?![0-9])", out), (
+        f"the downgraded change was not COUNTED as exactly 1 on the target's "
+        f"line:\n{out}")
+    assert re.search(r"repo-local-reported-total=1(?![0-9])", out), (
+        f"the downgraded change is missing from the run's summary, or the total "
+        f"is not exactly 1:\n{out}")
 
     # 🔴 SCOPED TO GUARD 10's OWN BLOCK, and the mutation sweep is why.
     # `cannot attribute: live processes are sitting inside …` is also printed by
@@ -979,10 +1012,18 @@ def test_a_repo_local_change_still_FAILS_when_no_cotenant_is_proven(tmp_path):
         f"the failure did not classify the change as repo-local-ENFORCED:\n{out}")
     assert "repo-local-reported-total=0" in out, (
         f"nothing should have been downgraded in this run:\n{out}")
-    assert "FOUND NO OTHER WRITER" in out, (
-        f"the failure did not say WHY it was attributable:\n{out}")
-    assert str(scratch / ".git" / "config") in out, (
-        f"the failure did not NAME the file that changed:\n{out}")
+    block = _guard10_failure_block(out)
+    assert block, f"GUARD 10's failure block was not printed at all:\n{out}"
+    assert "FOUND NO PROOF of another writer" in block, (
+        f"the failure did not say WHY it was attributable:\n{block}")
+    # 🔴 The message must not overstate the probe: it checks cwd against the git
+    # dir and its parent, so a SIBLING worktree is invisible. Saying "no other
+    # writer exists" would be the #730 misdiagnosis in a new place.
+    assert "SIBLING worktree" in block, (
+        f"the failure claimed more than the probe measured — the sibling-worktree "
+        f"blind spot is not named:\n{block}")
+    assert str(scratch / ".git" / "config") in block, (
+        f"the failure did not NAME the file that changed:\n{block}\n---\n{out}")
 
 
 def test_a_global_change_FAILS_even_with_a_cotenant_PROVEN(tmp_path):
@@ -1016,8 +1057,10 @@ def test_a_global_change_FAILS_even_with_a_cotenant_PROVEN(tmp_path):
         f"the run failed, but not for the git-config reason:\n{out}")
     assert "global-enforced" in out, (
         f"the failure did not classify the change as GLOBAL:\n{out}")
-    assert str(home / ".gitconfig") in out, (
-        f"the failure did not NAME the file that changed:\n{out}")
+    block = _guard10_failure_block(out)
+    assert block, f"GUARD 10's failure block was not printed at all:\n{out}"
+    assert str(home / ".gitconfig") in block, (
+        f"the failure did not NAME the file that changed:\n{block}\n---\n{out}")
     # The positive control for the assertion above: the write really happened.
     assert "planted-by-a-test" in (home / ".gitconfig").read_text(encoding="utf-8")
 
@@ -1057,5 +1100,197 @@ def test_a_broken_evidence_probe_fails_TOWARD_enforcing(tmp_path):
         f"switched off by an import error:\n{out}")
     assert "evidence=probe-failed" in out, (
         f"the run failed, but not because the probe could not run:\n{out}")
+    # Its two siblings pin this; without it "the run went red" is satisfied by
+    # the runner being red about anything at all.
+    assert "GUARD 10 problem" in out, (
+        f"the run failed, but not for the git-config reason:\n{out}")
     assert "repo-local-reported-total=0" in out, (
         f"a failed probe must downgrade NOTHING:\n{out}")
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE PROBE'S OUTPUT IS EVIDENCE ONLY IF THE PROBE WROTE IT
+# --------------------------------------------------------------------------- #
+# The downgrade used to be decided by `[ -s "$out" ]` — output PRESENCE. The
+# probe inherits the ambient `PYTHONPATH`, so ANY stdout on that path counted:
+# a package that prints at import, a `.pth`, a `sitecustomize`. Measured with NO
+# co-tenant present, a single `print()` in `scripts/testlib/__init__.py`
+# produced `repo-local-reported=1` and downgraded a genuinely attributable
+# write, rendering the stray line as GUARD 9 evidence. That is a downgrade
+# WITHOUT PROOF, which is the one thing this design promises cannot happen.
+#
+# Both tests below run with NO co-tenant, so the correct verdict is FAIL in
+# each; a PASS means the guard was switched off by somebody else's print().
+def _plant_chatty_import(tmp_path: Path, text: str) -> tuple[Path, Path]:
+    """A real `sitecustomize` on `PYTHONPATH` that writes `text` to stdout.
+
+    Injected via `PYTHONPATH`, never by editing this repo's `scripts/testlib/`:
+    the probe prepends `$ROOT/scripts` and KEEPS whatever it inherited, and that
+    inherited half is precisely the surface under test. `sitecustomize` is
+    imported by `site` at interpreter startup, so this is a genuine
+    print-at-import, not a stub of one.
+
+    🔴 SCOPED TO THE PROBE by `sys.argv`, deliberately. Printing from EVERY
+    python the runner starts would corrupt GUARD 8's captured
+    `SPOOL_TRAP_LOG` command substitution and abort the run `exit 2` — the test
+    would then be red for a NEIGHBOUR's reason while asserting this one's, which
+    is the failure mode this whole file exists to avoid.
+
+    Returns `(pythonpath_dir, witness)`. The witness is the positive control:
+    it proves the module actually loaded INSIDE the probe process, so a red
+    verdict cannot be scored as "the token worked" when nothing ever printed.
+    """
+    noisy = tmp_path / "noisy-pythonpath"
+    noisy.mkdir(parents=True, exist_ok=True)
+    witness = tmp_path / "noise-witness.txt"
+    (noisy / "sitecustomize.py").write_text(
+        "import os, sys\n"
+        "if any('DEVRC-NOGIT-EVIDENCE' in a for a in sys.argv):\n"
+        f"    open({str(witness)!r}, 'a').write('fired\\n')\n"
+        f"    sys.stdout.write({text!r})\n",
+        encoding="utf-8")
+    return noisy, witness
+
+
+def _run_at_with_env(runner: Path, scratch: Path, tmp_path: Path,
+                     extra: dict) -> subprocess.CompletedProcess:
+    env = {**os.environ, **_unguarded_home(tmp_path), **extra}
+    for k, v in list(env.items()):
+        if v is None:
+            del env[k]
+    return subprocess.run(["bash", str(runner), str(scratch)], capture_output=True,
+                          text=True, timeout=900, cwd=str(REPO_ROOT), env=env)
+
+
+def test_a_stray_print_on_the_probes_pythonpath_is_NOT_evidence(tmp_path):
+    """🔴 REGRESSION for the measured fail-open. Not a stub: a real module on a
+    real `PYTHONPATH`, printing at import, exactly as the audit reproduced it.
+
+    With no co-tenant, the repo-local write is attributable and MUST fail. If
+    the stray line is accepted as evidence, the run goes green instead.
+    """
+    scratch = _scratch_root(tmp_path)
+    name = _plant_repo_local_write(scratch)
+    runner = _runner_over(tmp_path, scratch, [name])
+    # The text is deliberately the EXACT wording GUARD 9 uses, so nothing but
+    # the token can distinguish it from real evidence.
+    noisy, witness = _plant_chatty_import(
+        tmp_path,
+        "live processes are sitting inside a protected repository (cwd), "
+        "and none of them is ours: 1:fake\n")
+
+    assert not live_cotenants([scratch / ".git"]), (
+        "something is already sitting in this scratch root, so the 'no proven "
+        "writer' premise of this test does not hold")
+    proc = _run_at_with_env(runner, scratch, tmp_path,
+                            {"PYTHONPATH": str(noisy)})
+    out = proc.stdout + proc.stderr
+
+    # 🔴 POSITIVE CONTROL FOR THE FIXTURE ITSELF — the noise really loaded
+    # inside the probe process. Without this, a run that went red because the
+    # module never imported would be scored as "the token rejected it".
+    assert witness.exists() and witness.read_text(encoding="utf-8").strip(), (
+        "the chatty sitecustomize never ran inside the probe, so this test "
+        f"measured nothing:\n{out}")
+    assert proc.returncode != 0, (
+        "a stray print() on the probe's PYTHONPATH was accepted as co-tenancy "
+        f"evidence and downgraded an ATTRIBUTABLE write:\n{out}")
+    assert "GUARD 10 problem" in out, (
+        f"the run failed, but not for the git-config reason:\n{out}")
+    assert "repo-local-reported-total=0" in out, (
+        f"an unstamped line must downgrade NOTHING:\n{out}")
+    assert "evidence=none" in out, (
+        f"the run did not record the probe as having returned no evidence:\n{out}")
+
+
+def test_whitespace_only_probe_stdout_is_NOT_evidence(tmp_path):
+    """🔴 The second half of the same site: `NOGIT_EV_STATUS` used to be set
+    BEFORE the loop that skips blank lines, so whitespace-only stdout produced
+    `proven` with ZERO logged reasons — a downgrade whose stated cause was the
+    empty string.
+    """
+    scratch = _scratch_root(tmp_path)
+    name = _plant_repo_local_write(scratch)
+    runner = _runner_over(tmp_path, scratch, [name])
+    noisy, witness = _plant_chatty_import(tmp_path, "   \n\t\n\n")
+
+    assert not live_cotenants([scratch / ".git"])
+    proc = _run_at_with_env(runner, scratch, tmp_path,
+                            {"PYTHONPATH": str(noisy)})
+    out = proc.stdout + proc.stderr
+
+    assert witness.exists() and witness.read_text(encoding="utf-8").strip(), (
+        f"the whitespace-emitting sitecustomize never ran in the probe:\n{out}")
+    assert proc.returncode != 0, (
+        f"whitespace-only probe stdout was accepted as evidence:\n{out}")
+    assert "GUARD 10 problem" in out, (
+        f"the run failed, but not for the git-config reason:\n{out}")
+    assert "repo-local-reported-total=0" in out, (
+        f"blank lines must downgrade NOTHING:\n{out}")
+    assert "evidence=none" in out, (
+        f"the run did not record the probe as having returned no evidence:\n{out}")
+
+
+def test_a_LINKED_WORKTREE_protects_the_COMMON_config(tmp_path):
+    """🔴 THE PRODUCTION SHAPE, which every other test here approximates.
+
+    #730 is about a clone with ~122 linked worktrees; the suite normally runs
+    from one of them, not from the main clone. In that shape
+    `rev-parse --git-common-dir` resolves to the MAIN clone's `.git`, so the
+    protected repo-local file is the SHARED config — the one with other writers
+    — and not anything under `.git/worktrees/<name>/`.
+
+    This pins that the classifier and the evidence probe agree about which file
+    that is. Without it, the whole class could be keyed on a path that only
+    exists in the non-worktree shape and every test here would still pass.
+    """
+    main = _scratch_root(tmp_path)
+    # A worktree needs a commit to check out.
+    for cmd in (["git", "-C", str(main), "commit", "-q", "--allow-empty",
+                 "-m", "base", "--no-gpg-sign"],):
+        done = subprocess.run(cmd, capture_output=True, text=True, timeout=120,
+                              env={**os.environ, "GIT_AUTHOR_NAME": "t",
+                                   "GIT_AUTHOR_EMAIL": "t@example.invalid",
+                                   "GIT_COMMITTER_NAME": "t",
+                                   "GIT_COMMITTER_EMAIL": "t@example.invalid"})
+        assert done.returncode == 0, f"could not seed the scratch repo:\n{done.stderr}"
+
+    linked = tmp_path / "linked-wt"
+    add = subprocess.run(["git", "-C", str(main), "worktree", "add", "--detach",
+                          "-q", str(linked)], capture_output=True, text=True,
+                         timeout=180)
+    assert add.returncode == 0, f"could not create the linked worktree:\n{add.stderr}"
+    # The runner needs `$ROOT/scripts` to resolve; the worktree holds only the
+    # (empty) commit, so the same symlink farm is laid over it.
+    for entry in REPO_ROOT.iterdir():
+        if entry.name == ".git" or (linked / entry.name).exists():
+            continue
+        (linked / entry.name).symlink_to(entry)
+
+    common = main / ".git" / "config"
+    writer = "g10-write-common.sh"
+    (linked / writer).write_text(
+        "set -euo pipefail\n"
+        f'git -C "{linked}" config devrc-g10.planted yes\n',
+        encoding="utf-8")
+    target = tmp_path / "plain_tests"
+    write_pytest_suite(target, 2, prefix="test_plain")
+    runner = runner_with_targets(tmp_path, [str(target)], {str(target): 1},
+                                 hook_tests=[], shell_tests=[writer])
+
+    with _cotenant(main):                      # the co-tenant sits in the MAIN tree
+        proc = _run_at(runner, linked, tmp_path)
+    out = proc.stdout + proc.stderr
+
+    # The write landed in the COMMON config, not in the worktree's own git dir.
+    assert "planted" in common.read_text(encoding="utf-8"), (
+        "the planted write did not reach the common config — this test's "
+        "premise about `git config` in a linked worktree is wrong")
+    assert f"present {common}  [repo-local" in out, (
+        f"the common config was not classified repo-local from a linked "
+        f"worktree:\n{out}")
+    assert proc.returncode == 0, (
+        f"a repo-local change in a LINKED WORKTREE, with a proven co-tenant in "
+        f"the main tree, still failed the run:\n{out}")
+    assert re.search(r"repo-local-reported-total=1(?![0-9])", out), (
+        f"the linked-worktree downgrade was not counted:\n{out}")


### PR DESCRIPTION
Closes #730.

`f340d52d` splits the class, `62dd53d8` fixes what the adversarial audit found in the first, `5cd5ee4d` merges current `main` in.

### 🔴 The merge-gating tier was red, and it was not this PR

`tekton/devrc-pytests` went **FAILURE** on `62dd53d8` — `failed=1`. I had run the full suite four times in the **devShell** and never seen it: the authoritative runner is `nix build .#checks.x86_64-linux.pytests`, whose source is a `/nix/store` copy with **no `.git`**, and my runs were structurally blind to that tier.

Reproduced locally before theorising, and the failing test was **`test_the_module_root_is_load_bearing`** in `scripts/tests/test_git_repo_isolation.py` — a GUARD 9 test this branch never touches (`git diff` over both my commits: empty for that file and for `gitenv.py`). Its assertion is `gitenv.py is not inside a git checkout`, which is a property of the sandbox, not of my change.

The control that settles it: `5a2a7b21` on `main`, *"the module-root guard asserted THIS checkout has a `.git` — the authoritative runner has none (#732)"*, landed **after** my base `a0fb39c7` and says the failure fired *"on every devrc-ci PipelineRun, on unrelated branches, for a reason no PR had touched."* Inherited, already fixed upstream.

Fixed here by **merging `origin/main`** (not rebasing — the audit references `f340d52d`/`62dd53d8` by SHA, and this needs no force-push). `main` also touched `scripts/run-tests.sh`, so I read the merged result rather than trusting a clean merge: its change is a `TARGET_FLOORS` re-pin, a different region from GUARD 10 entirely — no semantic conflict.

**The merged tree passes the authoritative gate**, run locally:

```
  TOTAL collected=15198  passed=15196  skipped=2  failed=0  (floor: 13732 = sum of 27 per-target floors)
    classes=global:2 (always enforcing)  repo-local:0 (enforcing unless another writer is PROVEN — see #730)
    repo-local-reported-total=0
RESULT: PASS (exit=0)
```

🔴 Note `repo-local:0` — that is **audit finding 4 confirmed live**: the sandbox has no `.git`, so this class is empty there and has nothing to enforce. The corrected comment says exactly that; the number now proves it.

## What was wrong

#720 gave **GUARD 9** attribution machinery so it stops blaming tests for a repository with other writers. **GUARD 10** watched an overlapping file set with **no attribution at all**, and failed the suite for the same reason — in the same run in which GUARD 9 had already *proven* co-tenancy and downgraded itself. Every test passed; the run was red purely on GUARD 10.

`NOGIT_PROTECTED` mixed two things that are not the same claim:

| class | files | who else writes them |
|---|---|---|
| **GLOBAL** | `~/.gitconfig`, `$XDG_CONFIG_HOME/git/config`, everything `git config --global --list --show-origin` names | nobody — a change is still attributable |
| **REPO-LOCAL** | `<git-common-dir>/config` | **every worktree of the clone**: `git worktree add`, `git branch --track`, any `git config` |

Its message was also a confident misdiagnosis, sending the reader to audit a target that had done nothing.

## What changed

* **GLOBAL stays fully enforcing**, including when co-tenancy *is* proven. That is the 2026-08-21 incident's actual shape.
* **REPO-LOCAL is enforcing unless another writer is PROVEN.** With proof the change is **REPORTED**: counted per target (`repo-local-reported=N`), counted per run (`repo-local-reported-total=N`), and rendered with the file and the evidence sentence. Without proof it still **fails**.
* **The proof is GUARD 9's own already-audited evidence**, called via `testlib.gitenv.attribution_evidence()` / `protected_git_dirs()` — one rule, one place. `$ROOT` is passed explicitly, because `protected_git_dirs()` also probes the module's own directory, which is the wrong repository to ask about here.
* **A broken probe fails toward enforcing**, and now that includes a *hang* (the probe is wrapped in `timeout`).
* 🔴 **Evidence is authenticated.** The probe stamps each reason `DEVRC-NOGIT-EVIDENCE\t<reason>`; only stamped lines count, and `proven` needs ≥1 accepted reason. See the audit section — this replaced a measured fail-open.

## Two-environment verification

Both run the FULL suite (`--set all`) at `62dd53d8`. They answer different questions.

### 1. Isolated clone — *does enforcement survive?*

```
    present /home/zach/.config/git/config  [global, always enforcing]
    absent  /home/zach/.gitconfig          [global, always enforcing]
    present /tmp/g10-iso2/.git/config      [repo-local, enforcing unless another writer is PROVEN]
  TOTAL collected=15159  passed=15157  skipped=2  failed=0  (floor: 13697 = sum of 27 per-target floors)
    classes=global:2 (always enforcing)  repo-local:1 (enforcing unless another writer is PROVEN — see #730)
    repo-local-reported-total=0
RESULT: PASS (exit=0)
```

**34 of 34** accounting lines `real-config-changed=0/3`; `repo-local-reported=1..9` appears **0** times; GUARD 10 problems **0**. Enforcement intact, nothing downgraded.

### 2. Shared clone — *is the false red gone?*

🔴 **This run exercised the downgrade organically**, which the earlier round could not (its window happened to contain no external write, and the PR said so). Two targets saw the shared config move underneath them:

```
    present /home/zach/workspace/devrc/.git/config  [repo-local, enforcing unless another writer is PROVEN]
    scripts/signal/tests       real-config-changed=0/3 … repo-local-reported=1
    scripts/initiatives/tests  real-config-changed=0/3 … repo-local-reported=1
    repo-local-reported-total=2
    ---- repo-local git config: REPORTED, not enforced (#730) ----
      scripts/signal/tests
        changed: /home/zach/workspace/devrc/.git/config
      scripts/signal/tests
        cannot attribute: live processes are sitting inside a protected repository (cwd),
        and none of them is ours: 25746:zsh, 25748:tmux: client, 67653:zsh, …
  TOTAL collected=15159  passed=15157  skipped=2  failed=0
RESULT: PASS (exit=0)
```

That is #730's scenario exactly — **at `a0fb39c7` this is `FAIL (exit=1)` with `failed=0`** — and it is now green, with the change visible, counted and explained rather than dropped. GUARD 9 printed `mode=report(auto)` on all 53 of its lines, as expected (#720 working).

### 3. Three-arm rig, re-derived at `62dd53d8`

The three-arm matrix in the PR comment was measured at `f340d52d`, i.e. before the evidence token changed how `proven` is decided; citing it for this head would be a claim about superseded code. Re-run in a throwaway clone (`/tmp/g10-e2e2`) with a background writer stamping the clone's **own** `.git/config` every 0.2s:

| arm | ref | co-tenancy | GUARD 10 | verdict |
|---|---|---|---|---|
| base | `a0fb39c7` | proven (`326406:sleep`) | `real-config-changed=1/3`, 1 problem block | **FAIL (exit=1)** |
| head | `62dd53d8` | proven (`327951:sleep`) | `real-config-changed=0/3`, `repo-local-reported-total=1` | **PASS (exit=0)** |
| **neg-control** | `62dd53d8` | **none** (`[]`) | `real-config-changed=1/3`, `repo-local-reported=0`, 2 problem blocks | **FAIL (exit=1)** |

Every arm carries the rig's own positive control — the config sha is asserted to have **moved** (`f819e2ac -> e1cf638c` / `-> 025bb468` / `-> 4d7f9fd8`), because a byte-identical rewrite moves no fingerprint and would score a vacuous PASS.

## Red-at-base matrix

Measured by checking out `a0fb39c7` into a worktree, copying **only** the new test file in, and running there.

| test | at `a0fb39c7` | at HEAD | label |
|---|---|---|---|
| `test_a_repo_local_change_is_REPORTED_when_a_cotenant_is_PROVEN` | **RED — behavioural** | GREEN | 🔴 **regression coverage** |
| `test_a_repo_local_change_still_FAILS_when_no_cotenant_is_proven` | RED — wording only | GREEN | negative control, *not* regression coverage |
| `test_a_global_change_FAILS_even_with_a_cotenant_PROVEN` | RED — wording only | GREEN | negative control, *not* regression coverage |
| `test_a_broken_evidence_probe_fails_TOWARD_enforcing` | RED — structural (anchor absent) | GREEN | fail-safe guard; reachability via M4 |
| `test_a_stray_print_on_the_probes_pythonpath_is_NOT_evidence` | n/a (code absent) | GREEN | 🔴 regression for the audit's fail-open; reachability via M10/M11 |
| `test_whitespace_only_probe_stdout_is_NOT_evidence` | n/a | GREEN | same site, second half |
| `test_a_LINKED_WORKTREE_protects_the_COMMON_config` | n/a | GREEN | the production shape |

Only the first is red for a *behavioural* reason, and it is the only one counted as regression coverage for the split. Measured at base: `real-config-changed=1/3`, `RESULT: FAIL (exit=1)`, `failed=0`. The two controls are red at base only over the new class wording; reading that as regression coverage would be a claim nobody measured.

## Mutation table

12 mutants against `scripts/run-tests.sh`, scored over the whole GUARD 10 suite. **Every mutant proven to have LANDED** — a unique marker grepped out of the *written* file and printed (M12 is a deletion, proven by 0 remaining occurrences) — before scoring; pristine sha256 re-asserted after each restore; each mutant's **killing assertion text captured**, not assumed.

**Control, unmutated: 26 passed, 0 failed.**

| # | mutation | landed | verdict | killing assertion |
|---|---|---|---|---|
| M1 | every file is repo-local (**class SWAP**) | `return 0  # MUTANT_M1` | KILLED ×2 | *a GLOBAL config change was downgraded by co-tenancy* |
| M2 | no file is repo-local (**guard deleted**) | `return 1  # MUTANT_M2` | KILLED ×6 | *…still failed the run — this is #730* |
| M3 | evidence probe **always-true** | `NOGIT_EV_STATUS="proven"; return 0` | KILLED ×5 | *an ATTRIBUTABLE repo-local config change produced a PASSING run* |
| M4 | a **failed** probe reads as proven | `NOGIT_EV_STATUS="proven"  # MUTANT_M4` | KILLED ×1 | *a BROKEN evidence probe downgraded a repo-local change* |
| M5 | downgrade condition **inverted** | `[ "$NOGIT_EV_STATUS" != "proven" ] …` | KILLED ×6 | *…this is #730* / *…produced a PASSING run* |
| M6 | downgrade not **counted** | `cls="repo-local-reported"  # MUTANT_M6` | KILLED ×2 | *not COUNTED as exactly 1 on the target's line* |
| M7 | the **reason** is never logged | `:  # MUTANT_M7` | KILLED ×1 | *the downgrade block did not state the REASON* |
| M8 | the downgrade **block** is never printed | `if false; then  # MUTANT_M8` | KILLED ×1 | *the downgrade block was never printed* |
| **M9** | the failure **suppresses the path** *(audit 1)* | `# MUTANT_M9` | KILLED ×3 | *the failure did not NAME the file that changed* |
| **M10** | `proven` by **presence**, not token *(audit 2a)* | `if [ -s "$out" ]; then  # MUTANT_M10` | KILLED ×2 | *a stray print() … was accepted as co-tenancy evidence* |
| **M11** | any **unstamped** line accepted *(audit 2b)* | `*) : ;;  # MUTANT_M11` | KILLED ×2 | *…accepted as evidence* / *whitespace-only probe stdout…* |
| **M12** | message drops the **SIBLING caveat** *(audit 3)* | DELETED (0 occurrences remain) | KILLED ×1 | *the failure claimed more than the probe measured* |

M9, M10 and M11 are the audit's own mutants; **each SURVIVED before `62dd53d8`**.

*Honest note on attribution:* under M2 and M3 the two probe tests die on their own **fixture control** (*"the sitecustomize never ran inside the probe"*) — the probe is never reached, so they correctly report they measured nothing rather than passing vacuously. Their intended mutants are M10/M11, which they kill by the intended assertion.

## What the audit found, and what it changed

1. 🔴 **`proven` was decided by output PRESENCE**, and the probe inherits the ambient `PYTHONPATH` — so **any** stdout counted as co-tenancy evidence. Measured with **no co-tenant**: a single `print()` gave `repo-local-reported=1` and downgraded a genuinely attributable write, rendering the stray line as GUARD 9 evidence. Fixed with the stamped token + an accepted-reason count. Second half of the same site: `NOGIT_EV_STATUS` was set *before* the blank-line-skipping loop, so whitespace-only stdout gave `proven` with zero logged reasons.
2. **Both negative controls' "did the failure NAME the file?" assertions were vacuous** — the startup listing prints every protected path unconditionally, so an audit mutant suppressing the path in the failure left them at `9 passed`. The `ERROR:` block now has an end marker and `_guard10_failure_block()` slices it; applied to all three name-the-file assertions including the pre-existing one.
3. **The failure message overstated the probe.** `live_cotenants` roots at the git dir and its parent, so a **sibling worktree** — the writer this PR exists to excuse — is invisible. Measured live: all 35 co-tenant hits were cwd=`…/devrc` itself, zero from any sibling. Roots deliberately **not** widened; the message and header now state what was checked and name the blind spot.
4. **"and in CI" was false.** The nix tier builds from a store copy with no `.git`, so `NOGIT_REPO_LOCAL` is empty there. Repo-local enforcement survives only in an isolated single-writer clone, which nothing schedules. Stated plainly. GLOBAL is unaffected and enforced everywhere.

Plus: probe `timeout`; `NOGIT_EVIDENCE_LOG` added to the creatability preflight; `"GUARD 10 problem"` asserted in the fail-safe test; trailing boundaries pinned on `repo-local-reported=1` / `-total=1` (they prefix-matched `=10`…`=19`).

## Accepted, deliberately not changed

* 🟢5 **`real-config-changed=` field name** — it now counts only *enforced* changes. Documented at the site, and the paired `repo-local-reported=` is pinned on the same line, so a reader gets both numbers together. Renaming a long-standing field is a bigger blast radius than the confusion it removes.
* 🟢6 **The two-list rendering is unpaired** (changed files and reasons are printed as separate awk passes). Cosmetic; both lists are keyed by target and a reader joins them by name.
* 🟢11 **Linked-worktree shape** — the auditor confirmed both resolvers agree live. Turned out cheap after all, so it is now covered by `test_a_LINKED_WORKTREE_protects_the_COMMON_config` rather than accepted.
* 🟢12 **The negative control depends on an environmental absence** (no process may sit in the scratch root). It fails safe: a stray co-tenant makes the control fail loudly, never pass vacuously, and it asserts `not live_cotenants(...)` up front so the premise is checked rather than assumed.

## Test method

The runner is driven against a **scratch root** — top-level symlinks to this repo so its preconditions hold, but a **fresh `.git` of its own** — so planted writes are measured against a directory pytest created and the operator's clone is never written. Co-tenancy is flipped with **real evidence**: a live process whose cwd sits in that root, with `_cotenant.__enter__` asserting `live_cotenants` actually sees it before the run whose verdict depends on it.

The stray-print fixture is a real `sitecustomize` on a real `PYTHONPATH`, **scoped to the probe by `sys.argv`** — printing from every python would corrupt GUARD 8's captured `SPOOL_TRAP_LOG` and abort the run, i.e. red for a *neighbour's* reason — plus a witness file proving it loaded inside the probe.

## Not verified / limits

* The evidence inherits `live_cotenants`' roots (a git dir and its parent), so a session in a **sibling worktree** is not counted. Documented in code, named in the failure message, and deliberately not widened. Absence of evidence leaves the guard **enforcing**.
* The probe is asked per target and only when a repo-local delta was observed, so a run with no delta never calls it; its failure path is exercised by the test and the mutation, not by a normal run.
* **Repo-local enforcement does not run anywhere scheduled** — see audit finding 4. It is a floor for a single-writer machine, not a merge gate. GLOBAL is enforced everywhere.
* Every number here is from local runs named above, plus the Tekton gate on the PR itself.
* 🔴 **Four full devShell runs did not see a red merge-gating tier.** The two-tier blindness is called out above; the merged tree is now verified in *both* (devShell full suite, and `nix build .#checks…pytests`). Treat any future "the suite is green" claim on this repo as tier-scoped until both are named.
