### PR TITLE
skills: clickup and check-clickup-addressed now disambiguate each other (+ the sibling ledger could silently shrink)

### DIFF
--- a/claude/skills/check-clickup-addressed/SKILL.md
+++ b/claude/skills/check-clickup-addressed/SKILL.md
@@ -9,6 +9,25 @@ Deterministic check: given the N most recent comments not from you on your assig
 tasks, find the sessions that worked on those tasks, read the transcripts, and report
 what's done vs what's still open.
 
+## Run the cheap pass first — `clickup`'s `awaiting`
+
+🔴 **If the question is *which* tasks are waiting on you, this is the wrong tool.** The
+`clickup` skill answers that on its own, with no transcript reads:
+
+```bash
+node query.mjs awaiting        # from the clickup skill dir; --max bounds the fan-out
+```
+
+`awaiting` decides on ONE predicate — the newest comment on the task was not authored by
+the token owner — and sweeps the whole assigned queue in ~45s at one API request per
+task. It cannot tell you whether anything got *done*; that is the question this skill
+exists for, and answering it costs a transcript read per task.
+
+So: `awaiting` to get the list, this skill on the few entries that matter. The two are
+complementary, not alternatives, and the split is by QUESTION (which vs whether), not by
+speed. Running both does duplicate one ClickUp fan-out — step 1 below makes its own pass —
+which is cheap for a handful of tasks and wasteful across the whole queue.
+
 ## Quick start
 
 The scripts live in **devrc**, not in this deployed skill dir — `~/.claude/skills/` is a

--- a/claude/skills/clickup/SKILL.md
+++ b/claude/skills/clickup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clickup
-description: "Read and act on ClickUp tickets and docs from the CLI: a task by URL or bare id, its comments and threads, status / assignee / due date / priority, my-tasks, workspace search, create tasks and subtasks, read and edit doc pages, attachments. Use for: a pasted app.clickup.com/t/ link or a bare ClickUp id, my ClickUp tickets, what ClickUp has assigned to me, comment on / update / close a ticket, mark it in progress, set a due date, a ClickUp doc or page. This is the EXTERNAL ClickUp workspace — the self-hosted approval UI and ITS Tasks are `clawgate`, the durable cross-repo board is `initiatives`, and the email action-items queue is `mailbox`."
+description: "Read and act on ClickUp tickets and docs: its comments and threads, status / assignee / due date / priority, workspace search, create tasks and subtasks, read and edit doc pages, attachments. Use for: a pasted app.clickup.com/t/ link or a bare ClickUp id, my ClickUp tickets, what ClickUp has assigned to me, comment on / update / close a ticket, mark it in progress, set a due date, a ClickUp doc or page. This is the EXTERNAL ClickUp workspace — the self-hosted approval UI and ITS Tasks are `clawgate`, the durable cross-repo board is `initiatives`, the email action-items queue is `mailbox`, and verifying from session transcripts whether work on a task was actually done is `check-clickup-addressed`."
 ---
 
 # ClickUp
@@ -65,7 +65,10 @@ node query.mjs edit-page <doc_id> <page_id> --file /tmp/page.md
   owner's.** Comment-level `resolved` is not readable through the API and ClickUp has
   no bot identity, so "unresolved" is not computable and *anything* this token posts
   reads as the owner answering. It fans out one request per task — hence `--max`, and
-  hence the examined/matched/truncated counts it always prints.
+  hence the examined/matched/truncated counts it always prints. It is the cheap TRIAGE
+  half: it says WHICH tasks have someone else's comment last, never whether the work got
+  done. That verdict is the `check-clickup-addressed` skill, which reads the session
+  transcripts — run `awaiting` first, then hand it only the tasks that matter.
 - **`claim <task>`** links the current session to a task via the Session ID custom
   field, so work is resumable later. Non-obvious and easy to forget.
 - **`--account <name>`** targets a non-default identity on any command

--- a/scripts/tests/test_skill_descriptions.py
+++ b/scripts/tests/test_skill_descriptions.py
@@ -33,12 +33,23 @@ decidable, and only those are asserted:
   3. `clickup` names its disambiguating siblings, AND each name it uses is a
      skill that actually exists.
 
-(3) is a RELATIONSHIP, not a word: renaming or deleting `clawgate`,
-`initiatives` or `mailbox` turns it red, so the disambiguation cannot rot into a
-pointer at nothing. The DECLARED gap: the sibling ledger below is a judgement
-call and is checked in one direction only -- a name in it must exist and must be
-named, but nothing here can know that a FOURTH task-shaped skill has appeared.
-Add it here when one does.
+(3) is a RELATIONSHIP, not a word: renaming or deleting any ledgered sibling
+turns it red, so the disambiguation cannot rot into a pointer at nothing. The
+DECLARED gap: the sibling ledger below is a judgement call and is checked in one
+direction only -- a name in it must exist and must be named, but nothing here can
+know that a FIFTH task-shaped skill has appeared. Add it here when one does.
+
+A FOURTH did, which is why that sentence now reads FIFTH.
+`check-clickup-addressed` was migrated into devrc after this gate was written,
+and it is the most confusable sibling yet: it works the SAME ClickUp tasks and
+asks the opposite question -- not "what is on this ticket" but "was the work
+actually done", answered by reading session transcripts. The overlap has a cheap
+half and an expensive half, and only the expensive half is a listing entry:
+`node query.mjs awaiting` (in `clickup`) is the ~45s triage pass answering WHICH
+tasks have someone else's comment last, and `check-clickup-addressed` is the
+transcript-reading verdict on WHETHER each is done. `awaiting` is a CLI command,
+not a skill, so it costs the listing nothing and must NOT be added to the ledger
+below -- every key there is asserted to be a real skill directory.
 
 NOT asserted: a minimum description length. Measured when this was written, the
 defect was 175 chars and the next-shortest entry was 181 (`espanso-audit`), so
@@ -88,6 +99,10 @@ CLICKUP_SIBLINGS = {
     "clawgate": "the self-hosted approval UI, which has its own Tasks",
     "initiatives": "the durable cross-repo initiative board",
     "mailbox": "the email action-items queue",
+    "check-clickup-addressed": (
+        "verifies from session transcripts whether work on a ClickUp task was "
+        "actually completed -- the same tasks, the opposite question"
+    ),
 }
 
 # The disambiguating sentence, pinned WHOLE and built from the sibling names.
@@ -104,7 +119,9 @@ CLICKUP_SIBLINGS = {
 CLICKUP_DISAMBIGUATION = (
     "This is the EXTERNAL ClickUp workspace — the self-hosted approval UI and "
     "ITS Tasks are `clawgate`, the durable cross-repo board is `initiatives`, "
-    "and the email action-items queue is `mailbox`."
+    "the email action-items queue is `mailbox`, and verifying from session "
+    "transcripts whether work on a task was actually done is "
+    "`check-clickup-addressed`."
 )
 
 
@@ -348,7 +365,7 @@ def test_control_a_passing_mention_of_every_sibling_still_fails_the_pin():
     disambiguate from none of them. A per-name substring check passes this."""
     walked = (
         "Interact with ClickUp tasks and documents. See also clawgate, "
-        "initiatives and mailbox."
+        "initiatives, mailbox and check-clickup-addressed."
     )
     for sibling in CLICKUP_SIBLINGS:
         assert sibling in walked, "fixture broken: it must name every sibling"

--- a/scripts/tests/test_skill_descriptions.py
+++ b/scripts/tests/test_skill_descriptions.py
@@ -113,9 +113,10 @@ CLICKUP_SIBLINGS = {
 #
 # 🔴 Deliberately not a per-name substring check. `claude/RULES.md`: "When the
 # artifact under test IS prose, a guard on WORDS is walkable by REWORDING -- pin
-# the WHOLE normalised string." A description could name all three siblings in
-# passing ("see also clawgate, initiatives, mailbox") and satisfy a word check
-# while telling the router nothing about which one owns which case. The stated
+# the WHOLE normalised string." A description could name EVERY sibling in
+# passing ("see also clawgate, initiatives, mailbox and check-clickup-addressed")
+# and satisfy a word check while telling the router nothing about which one owns
+# which case -- that exact walk is a control below. The stated
 # cost, accepted: a cosmetic reword of this ONE sentence fails this test. The
 # routing keywords in the rest of the description are deliberately left free to
 # change -- rigidifying those would make the gate fight the very tuning it exists

--- a/scripts/tests/test_skill_descriptions.py
+++ b/scripts/tests/test_skill_descriptions.py
@@ -31,13 +31,16 @@ decidable, and only those are asserted:
   2. no entry breaches the per-entry cap -- past it the description is truncated
      or dropped silently;
   3. `clickup` names its disambiguating siblings, AND each name it uses is a
-     skill that actually exists.
+     skill that actually exists, AND the ledger of them cannot drift from the
+     sentence in EITHER direction.
 
 (3) is a RELATIONSHIP, not a word: renaming or deleting any ledgered sibling
 turns it red, so the disambiguation cannot rot into a pointer at nothing. The
-DECLARED gap: the sibling ledger below is a judgement call and is checked in one
-direction only -- a name in it must exist and must be named, but nothing here can
-know that a FIFTH task-shaped skill has appeared. Add it here when one does.
+DECLARED gap: the sibling ledger below is a judgement call. It is pinned EQUAL to
+the sentence, so it can no longer silently shrink (that hole was real, and is
+measured in the docstring of the test that closes it), and every name in it must
+resolve to a real skill -- but nothing here can know that a FIFTH task-shaped
+skill has appeared. Add it here when one does.
 
 A FOURTH did, which is why that sentence now reads FIFTH.
 `check-clickup-addressed` was migrated into devrc after this gate was written,
@@ -62,6 +65,7 @@ from __future__ import annotations
 
 import importlib.machinery
 import importlib.util
+import re
 from pathlib import Path
 
 import pytest
@@ -246,6 +250,33 @@ def test_no_listing_entry_breaches_the_per_entry_cap():
     )
 
 
+def test_the_sibling_ledger_and_the_pinned_sentence_name_the_SAME_skills():
+    """🔴 Two-way, so the ledger cannot silently SHRINK.
+
+    Everything else here that iterates siblings iterates the LEDGER, so deleting
+    an entry deletes its assertions along with it: the gate keeps passing while
+    checking strictly less than its docstring claims -- a guard reading as
+    coverage while providing none (`claude/RULES.md`). MEASURED, not reasoned:
+    dropping `check-clickup-addressed` from CLICKUP_SIBLINGS left this whole
+    module GREEN at 14 passed -- one quieter parametrised case than before, and
+    no failure anywhere.
+
+    Pinning the two sets EQUAL fails in both directions -- a name added to the
+    sentence without a ledger entry (so its skill is never proved to exist), and
+    a ledger entry deleted while the sentence still routes at it.
+    """
+    named = set(re.findall(r"`([a-z0-9][a-z0-9-]*)`", CLICKUP_DISAMBIGUATION))
+    assert named == set(CLICKUP_SIBLINGS), (
+        "the pinned disambiguation sentence and CLICKUP_SIBLINGS have drifted "
+        "apart.\n  named in the sentence but not in the ledger (so nothing "
+        f"proves the skill exists): {sorted(named - set(CLICKUP_SIBLINGS))}"
+        "\n  in the ledger but not named in the sentence (so the ledger "
+        "describes routing the listing does not carry): "
+        f"{sorted(set(CLICKUP_SIBLINGS) - named)}"
+        "\nUpdate both, plus clickup's description, in the same commit."
+    )
+
+
 @pytest.mark.parametrize("sibling", sorted(CLICKUP_SIBLINGS))
 def test_each_clickup_sibling_is_a_real_skill(sibling):
     """The disambiguation must point at something that EXISTS. A renamed or
@@ -271,13 +302,6 @@ def test_clickup_disambiguates_from_its_task_shaped_siblings():
     entries = {name: desc for _, name, desc in _entries()}
     assert "clickup" in entries, "the clickup skill is not in the listing at all"
     normalised = " ".join(entries["clickup"].split())
-
-    for sibling in sorted(CLICKUP_SIBLINGS):
-        assert sibling in CLICKUP_DISAMBIGUATION, (
-            f"`{sibling}` is in the sibling ledger but the pinned "
-            "disambiguation sentence does not mention it -- the ledger and the "
-            "pin have drifted apart, so this gate is checking less than it says."
-        )
 
     assert normalised.count(CLICKUP_DISAMBIGUATION) == 1, (
         "clickup's description no longer carries its disambiguation sentence "


### PR DESCRIPTION
`check-clickup-addressed` (migrated in #709) and `clickup` (whose CLI gained `awaiting` in #675) work the **same ClickUp tasks** and ask **opposite questions** — and neither named the other. They are complementary halves of one workflow:

| | question | how | cost |
|---|---|---|---|
| `clickup`'s `node query.mjs awaiting` | **WHICH** tasks have someone else's comment last | one API request per task | ~45s, no transcript reads |
| `check-clickup-addressed` | **WHETHER** the work was actually done | reads the session transcripts | a transcript read per task |

## (1) The listing direction — `clickup` gains a fourth sibling

`clickup`'s description is the only always-on surface either skill has, so the skill↔skill disambiguation goes there. Its pinned sentence now names `check-clickup-addressed` and says what it owns. `scripts/tests/test_skill_descriptions.py` moves with it: the `CLICKUP_SIBLINGS` ledger, the whole-sentence `CLICKUP_DISAMBIGUATION` pin, and the walkable-mention control fixture.

**Before → after (name + description, the unit the per-entry cap applies to):**

```
655 -> 712 chars   (+57, +8.7%)
```

The new clause costs ~105 chars, so three genuine dedupes were taken in the same description to hold it down — `from the CLI` (mechanism, not a phrase anyone types), `a task by URL or bare id` and `my-tasks`, all three already carried verbatim by the `Use for:` trigger phrases a few words later in the same string. No routing keyword was lost.

⚠️ This does make `clickup` the **longest** entry in the listing (it was second, behind `session-manager` at 685). Flagged rather than hidden — see the budget section for why 57 chars is not what matters here.

## (2) The reverse direction — in the BODY, deliberately

`check-clickup-addressed`'s SKILL.md gains a "Run the cheap pass first" section, and `clickup`'s own `awaiting` bullet closes the loop.

**Why body and not description:** the thing `check-clickup-addressed` must point at is `node query.mjs awaiting` — a CLI command *inside* the `clickup` skill, **not a listing entry**. It can never compete for a prompt in the listing, so no listing-level disambiguation can be needed for it, and the guidance is only actionable once this skill has already been invoked. A body costs 0 until then; a description is paid every session. Its description is untouched at 236 chars.

## A real hole found while mutation-checking

Every sibling assertion in the gate iterates **the ledger**, so deleting an entry deletes its own assertions along with it. Measured, not reasoned: dropping `check-clickup-addressed` from `CLICKUP_SIBLINGS` left the whole module **green at 14 passed, no failure** — the gate would have kept passing while checking strictly less than its docstring claimed.

Closed by `test_the_sibling_ledger_and_the_pinned_sentence_name_the_SAME_skills`, which pins the set of skill names backticked in the sentence **equal** to the ledger's keys, so it fails whether the set grows or shrinks. The now-subsumed one-directional loop is deleted rather than left as a dead assertion.

## Verification

Rebased onto `ec4fc008` (`main` moved 3 commits mid-task, one of them #731 touching `check-clickup-addressed`); clean rebase, and everything below was re-run **after** it.

**Red at base, green at HEAD** — the new test module against `origin/main`'s description:

```
red   at origin/main (ec4fc008) : 1 failed, 15 passed
        FAILED test_clickup_disambiguates_from_its_task_shaped_siblings
        its own message: "no longer carries its disambiguation sentence exactly once as written"
green at HEAD (3b3522a5)        : 16 passed
```

**Mutations** — all under `PYTHONDONTWRITEBYTECODE=1`, each red with *that test's own* message, not a collateral error:

| mutation | result |
|---|---|
| drop `check-clickup-addressed` from `CLICKUP_SIBLINGS` | RED — `test_the_sibling_ledger_and_the_pinned_sentence_name_the_SAME_skills` |
| drop it from `clickup`'s description | RED — `test_clickup_disambiguates_from_its_task_shaped_siblings` |
| rename `claude/skills/check-clickup-addressed/` | RED — `test_each_clickup_sibling_is_a_real_skill[check-clickup-addressed]` |

Tree restored clean after each; baseline re-confirmed at 16 passed.

**Full gate:** `nix develop . --command bash scripts/gate.sh`

```
pytest  collected=15158  passed=15156  skipped=2  failed=0   (floor 13697)
node    files=34  tests=1149  pass=1149  fail=0  skipped=0   (floor 1126)
GATE: RESULT=PASS exit=0
```

## Budget re-measurement

**Char counts are exact. Token counts are an explicitly-labelled ESTIMATE** — Claude Code's tokenizer is not public, and the only tokenizer available here is `tiktoken cl100k_base`, which is **OpenAI's**, not Claude's. It is a proxy, quoted as such; the divisor it implies is **4.22 chars/token**.

| scope | entries | name+desc chars (exact) | est. tokens (cl100k proxy) |
|---|---|---|---|
| devrc-managed, this branch | 38 | 14,326 | ~3,437 |
| live `~/.claude/skills` (deployed) | 39 | 14,735 | ~3,544 |
| `cloudflare` plugin (enabled) | 13 | 5,221 | ~1,156 |
| **live total measurable** | **52** | **19,956** | **~4,700** |

Top 5 this branch: `clickup` 712 · `session-manager` 685 · `window-triage` 620 · `prune-index` 599 · `signal` 516.

### Verdict — and it does not depend on the tokenizer

Rather than lean on a proxy count, here is the **break-even divisor**: how many chars-per-token it would take for the listing to fit each budget.

* **1% of 200k ≈ 2,000 tokens — DOES NOT FIT, and did not before this PR.** devrc's 38 entries alone (14,326 chars) would need **>7.16 chars/token** to fit; the measurable live listing (19,956 chars) would need **>9.98**. No plausible tokenizer is near either — real text runs ~3.5–4.5. The verdict holds for any divisor in that range, so the wrong-tokenizer risk does not touch it. On the proxy count devrc alone is ~1.7× over and the live listing ~2.35× over.
* **1% of 1M ≈ 10,000 tokens — FITS, comfortably.** The measurable live listing would have to average **under 2.0 chars/token** to overflow, which no tokenizer does.

Also note the measurable total is a **floor**, not the whole listing: built-in skills (`dataviz`, `artifact-*`, `code-review`, …, ~16 entries) are not readable from disk and are additional.

So on a 200k-context session descriptions are already being dropped silently, and this PR's **+57 chars (~14 est. tokens, 0.4% of devrc's listing)** does not move that verdict in either direction. Worth its own piece of work; deliberately not attempted here.

**Incidental finding, unrelated to this PR:** `~/.claude/skills/opencode` on the workbench is a **real directory, not a nix symlink** (`readlink -f` resolves to itself), and there is no `claude/skills/opencode/` in the repo. It is an unmanaged, hand-placed skill costing listing budget every session on this host only — and it is exactly the pre-existing-foreign-file shape that blocks a `home.file` switch. Not touched here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
