### PR TITLE
feat(check-clickup-addressed): port upstream rounds 7+8 into the copy that actually runs

### DIFF
--- a/claude/skills/check-clickup-addressed/SKILL.md
+++ b/claude/skills/check-clickup-addressed/SKILL.md
@@ -47,9 +47,14 @@ is run straight out of the working tree — the edit is live immediately, and it
    status/priority, author, snippet + full `text`, and `my_latest_reply` — the date of *your*
    newest comment on that task, computed **before** your comments are dropped, because the
    consumer otherwise cannot tell an answered ticket from an abandoned one. That last key
-   is **omitted entirely** when the user id could not be resolved — absent means "the
-   check could not run", which is not the same fact as a present `null` ("I looked; you
-   never replied"). Both consumers branch on which.
+   is **omitted entirely** when the user id could not be resolved, or when a date on one of
+   *your* comments would not parse — absent means "the check could not run", which is not the
+   same fact as a present `null` ("I looked; you never replied"). Both consumers branch on
+   which. Beside the two display dates it also emits the raw epoch-ms they were formatted
+   from (`date_ms`, `my_latest_reply_ms`), because `format_date` throws the seconds away and
+   the "have I answered?" comparison then runs at minute resolution. Each is emitted **only
+   when it parses** — absent, never `0`, and `my_latest_reply_ms` is nested under
+   `my_latest_reply` so a precise instant can never outlive the reply it refines.
 2. **`search-sessions.py`** — searches `~/.claude/projects/**/*.jsonl` transcripts for
    sessions mentioning a task ID, ranks by hit count. Terms are **ANDed**, so it is run
    **once per task**, never with several tasks' terms in one query.
@@ -81,7 +86,7 @@ process per task, so lookups dedupe within a task, not across the run.
 
 | Script | Input | Output |
 |--------|-------|--------|
-| `recent-comments.py --limit N` | ClickUp API | `--json`: task_id, task_name, task_status, task_priority, date, author, snippet, text, and **`my_latest_reply` only when the user id resolved** — its ABSENCE is meaningful (the check could not run), so read with `in`, never `.get()`. The tabular printer emits a different, smaller set — task_id, task_name, date, author, snippet — which `check-completion.py` parses for field 0 only. |
+| `recent-comments.py --limit N` | ClickUp API | `--json`: task_id, task_name, task_status, task_priority, date, author, snippet, text, and **`my_latest_reply` only when the user id resolved AND every comment of yours could be ranked** — its ABSENCE is meaningful (the check could not run), so read with `in`, never `.get()`. Plus `date_ms` / `my_latest_reply_ms`, the raw epoch-ms behind the two display dates, each present only when it parsed. The tabular printer emits a different, smaller set — task_id, task_name, date, author, snippet — which `check-completion.py` parses for field 0 only. |
 | `search-sessions.py term1 [term2 ...]` | `~/.claude/projects/` | session_id, date, project, hits |
 | `check-completion.py --task ID` | session transcripts | status, completion signals, open items |
 | `check-addressed.py --limit N` | all of the above | unified report |
@@ -235,18 +240,65 @@ plus one state where nothing disagrees and that is exactly the problem (4):
    assumption, so the fix crosses the seam: the producer now emits `my_latest_reply` per task
    and the flag suppresses when your newest reply is **at or after** the comment. Compared,
    not counted — a reply *predating* the question does not answer it. An **absent**
-   `my_latest_reply` (stale producer, or a failed user-id lookup) fires but says the check
-   never ran, rather than silently deciding either way.
+   `my_latest_reply` (stale producer, a failed user-id lookup, or a date on one of YOUR
+   comments the producer could not read) fires but says the check never ran, rather than
+   silently deciding either way.
+   🔴 **Compared on the raw epoch-ms, not on the displayed minute** (2026-08-22, round 7).
+   `format_date` threw the seconds away before anything compared them, so a reply written
+   **20 seconds BEFORE** the question rendered identical to it and counted as an answer — a
+   waiting colleague dropped from the report. Whether a tie means "answered" was a judgement
+   call argued to opposite conclusions from the same evidence; the producer HAS the raw ms,
+   so it is now a question of fact and a tie means the same millisecond. `date_ms` /
+   `my_latest_reply_ms` ride beside the display fields and are used **only when BOTH are
+   present** — comparing one raw instant against a rounded one is worse than comparing two
+   rounded ones — otherwise the minute-age comparison is used unchanged. An unreadable date
+   yields an **absent** ms, never a `0`: zero is 1970, which would make every reply look
+   newer than every question.
+   🔴 **A SUPPRESSED flag now prints one line of its own, and that is where the bot-identity
+   caveat lives.** **ClickUp has no bot identity**: every comment posted through the `pk_`
+   token comes back authored as the token's owner whoever typed it, so *"you answered"* and
+   *"an agent answered as you"* are the **same observable** — an agent-posted comment sets
+   `my_latest_reply` and suppresses this flag. Suppression used to print nothing at all, so a
+   genuinely-waiting colleague left the report with no trace — and with the transcripts
+   finding nothing, the flag that would have caught it was the one being suppressed. The line
+   goes in its **own** block (`## Answered already — no action, but check who answered`),
+   never in **Needs a decision** — a "no action" line in the act-on-this block is how a block
+   stops being read — and the caveat leads that block **once**, not per line (199 chars ×
+   every line was ~11 KB in a `--limit 20` report, in the one block whose justification is
+   that volume kills a block). Each note keeps the caveat's *consequence*.
+   🔴 **The note is bounded, and it must be able to PROVE it is bounded.** It carries the same
+   recency window as the flag; the bound falls back to `date_ms` when the display date is
+   unreadable (otherwise a drifted `format_date` kills the bound for every record while the ms
+   path keeps deciding — measured: a 2019 ticket printed an unbounded note); and if NO bound
+   can be evaluated from either field the record falls through to the **flag** instead, since
+   an un-expirable "no action needed" line is exactly the permanent noise this is guarding
+   against, while a call to action should survive an unreadable date.
+   🔴 **The note states other coverage as a COMPUTED fact, never an assumed one.** It used to
+   assert that nothing else in the report named the ticket, *because* `mentions_found == 0` —
+   false in four reproduced shapes (unknown status / RESOLVED-reading comment / keep-open veto
+   / open cited PR, each printing a **Needs a decision** line about the same ticket directly
+   above it), and a non-sequitur besides: not one of those four rules reads `mentions_found`.
+   It now runs `disagreements([r])` on that ONE record and says what came back — `[r]`, not
+   the whole result list, or every note in the report inherits one ticket's flag.
    🔴 **The seam is crossed for TOP-LEVEL comments only.** `recent-comments.py` calls the CLI
    without `--threads`, and `/task/{id}/comment` returns top-level comments only — replies
    live behind `getThreadedComments`. So an answer you wrote *inside a comment thread* is
    still invisible and the ticket still reads as unanswered. Narrower than D12, same shape.
    (Verified 2026-08-22 that the two answers on `868gz0hhh` are top-level, so the motivating
    case really is fixed — but do not read that as the general case.)
+   🔴 **THIS FLAG HAS ITS OWN CORPUS — SCORE IT, DO NOT ARGUE FROM THE EXAMPLE.**
+   `tests/test_waiting_corpus.py` holds **21 labelled RECORDS** (pre-port 10/21, shipped
+   21/21). `test_corpus.py` cannot help here: it scores comment TEXT and this flag reads
+   FIELDS. Verdicts are read off the **claim** — "nobody has answered" vs "the check did not
+   run" vs "the date was unreadable" vs the suppression note vs silence — because "the flag
+   fired" is satisfied by four lines that tell a reader four different things.
    🔴 **New false-SILENCE direction, deliberately unbounded by transcripts:** reply *"I'll
-   look next week"* and the flag is silenced for that comment even though `mentions_found ==
-   0` means no other rule covers the ticket either — which is the gap this flag was added to
-   fill. Bounded only by a *newer* colleague comment re-firing it. Acknowledging is not doing.
+   look next week"* and the flag is silenced for that comment even though the transcripts
+   showed no work — which is the gap this flag was added to fill. (Do NOT restate that as
+   *"`mentions_found == 0` means no other rule covers the ticket"*: that is a non-sequitur,
+   retracted 2026-08-22. A zero mention count says the TRANSCRIPTS are empty; the status,
+   comment and PR rules never read it and can each still flag the ticket.) Bounded only by a
+   *newer* colleague comment re-firing it. Acknowledging is not doing.
 
 🔴 **Sources 1 and 2 are gated on a hardcoded nine-word status vocabulary, and ClickUp
 statuses are per-list and arbitrary.** Until 2026-08-21 a miss was **silent**: measured,
@@ -321,7 +373,7 @@ further drift. **Re-time it rather than quoting it.**
 
 ## Tests
 
-Run all tests (**180** collected, measured 2026-08-22). `run_all.py` exits non-zero on
+Run all tests (**213** collected, measured 2026-08-22). `run_all.py` exits non-zero on
 failure — but read the `Total: N passed, M failed` line, not a piped exit code. 🔴 **If that
 line is missing at all, the run died — treat it as a failure, never as "no output".** A
 `sys.exit()` from code under test is a `SystemExit`, which a bare `except Exception` does
@@ -335,9 +387,25 @@ PYTHONDONTWRITEBYTECODE=1 python3 "$CCUA/tests/run_all.py"
 
 The same files are a **pytest** target of devrc's gate — `scripts/check-clickup-addressed/tests`
 in `HERMETIC_TARGETS`, with its collected-count floor in `TARGET_FLOORS`
-(`scripts/run-tests.sh`). Both runners see the same 180; `run_all.py` survives because it
+(`scripts/run-tests.sh`). Both runners see the same 213; `run_all.py` survives because it
 purges `__pycache__` and reports an import failure as a FAILURE, which pytest's summary
 line does not distinguish as loudly. **Raise the floor when you add tests.**
+
+🔴 **The mutation battery lives in the repo now**: `tests/mutation_sweep.py` holds every
+mutant as DATA plus a runner (`--list`, an id filter, `--check` to fail on a stale one).
+Earlier rounds each ran a sweep, reported "0 survived", and threw the driver away — the
+number was then unreproducible from the repo, and the next round re-invented the list and
+re-discovered the same sites. A blind re-audit of one such "51 mutants, 0 non-killed" found
+**seven more at the same delta sites**, one of which reverted that round's headline fix.
+**Extend the list; do not start a new one.** Currently **59 mutants + a positive control + a
+NULL CONTROL, 0 non-killed.** 🔴 That null control is not decoration: it copies the skill,
+mutates NOTHING and must report SURVIVED. On this battery's first run every mutant scored
+KILLED *because* `test_no_real_identifiers.py` cannot resolve the repo root from a temp copy
+and reddened all 59 for free. Read the killer NAME, not just the verdict.
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 python3 "$CCUA/tests/mutation_sweep.py" --check
+```
 
 Test files:
 - `test_attribution.py` — the 2026-08-19 regression set (cross-task attribution, the
@@ -360,7 +428,25 @@ Test files:
   **because a mutation sweep found the wiring uncovered** — `latest_reply_by` and
   `build_record` were each pinned in isolation while `_collect`, the only thing that joins
   them, was not, so `latest_reply_by([], my_id)` made the whole fix inert against a fully
-  green suite. Pin the SEAM, not only the parts.
+  green suite. Pin the SEAM, not only the parts. It also carries the round-7 set: the
+  `UNIDENTIFIED` sentinel for an unreadable date on one of YOUR comments, the raw-ms
+  comparison, and the suppression note — including
+  `test_main_actually_PRINTS_both_blocks_end_to_end`, which drives `main()` and reads STDOUT
+  because deleting its whole print loop left the suite green.
+- `test_waiting_corpus.py` — 🔴 **the second labelled corpus, 21 whole RECORDS.**
+  `test_corpus.py` scores comment TEXT; the waiting flag reads FIELDS, so none of those 49
+  cases can see it — and this flag had by then been argued from single anecdotes three
+  rounds running. Verdicts are read off the **claim** the report makes (`WAITING` /
+  `ANNOUNCE` / `UNREADABLE` / `ANSWERED` / `SILENT`), never off whether something fired.
+  Pre-port scores 10/21, shipped 21/21. Same rule as the other corpus: **add your motivating
+  case, with the verdict a human would give, BEFORE you change code.**
+- `test_bounds_and_parsing.py` — the round-8 set: the other-coverage sentence's SCOPING, the
+  DISPLAY half of the two-ages split, and `UNANSWERED_COMMENT_DAYS` pinned ON its boundary
+  (14.0) and at a NON-multiple overshoot (20) — the old fixtures sat at 13 and 30, and 30 is
+  more than 2×14, so a doubling mutant passed straight through the gap. ⚠️ These are
+  **mutation-coverage guards, not regression coverage**: each SURVIVED a full green battery
+  on a tree where the behaviour was already right. The file says so, and says why its red
+  against pre-port `main` does not count.
 - `test_check_completion.py` — windowed signal extraction. ⚠️ Its two proximity tests hand
   `extract_signals_from_windows` a non-zero `distance`, which no production producer emits;
   they cover the formula, not any reachable path. The reachable premise is pinned in

--- a/claude/skills/check-clickup-addressed/reference/validation-history.md
+++ b/claude/skills/check-clickup-addressed/reference/validation-history.md
@@ -1398,3 +1398,123 @@ not have in mind.**
 🔴 **And a false SURVIVED nearly shipped from the sweep's own harness**: the first sweep filtered
 runner output through a `grep -E` alternation that omitted the killing test's name, so a mutant
 that *was* caught printed nothing and scored SURVIVED. Read the whole failure list.
+
+---
+
+# Rounds 7 + 8 — ported from the upstream copy (2026-08-22)
+
+This skill was migrated out of a private client repo earlier the same day. Two rounds of work
+landed there AFTER the migration and are ported here. **It is a PORT, not a copy**: every real
+ClickUp id, real person's name and verbatim third-party comment body in the upstream hunks was
+replaced with a synthetic equivalent registered in `tests/test_no_real_identifiers.py`. This
+repo is PUBLIC; the upstream one is not.
+
+## What was NOT ported, and why
+
+Upstream round 8's headline finding is a **scan-less-run announcement**: one line per run
+saying that the waiting flag and *"ClickUp `<done>` but open signals remain"* could not fire,
+because a parallel upstream change made the transcript scan **opt-in** and its scan-less
+record omits `mentions_found` rather than reporting `0`.
+
+**That opt-in does not exist here.** Measured: `check-addressed.py` has no `--transcripts`
+flag (`parse_args` rejects it), `main()` always runs `search-sessions.py` and
+`check-completion.py`, and `check-completion.py` emits `mentions_found` on all three of its
+exit paths. No record here can carry a `not_scanned` status or omit the mention count, so the
+announcement would guard a state no input can reach — and an unreachable guard reads as
+protection while providing none. Not ported, together with the `"mentions_found" in r` gate
+its sibling puts on the open-signals flag (same premise), the SKILL.md correction about the
+default invocation (this tool's default DOES run the decision flags), and mutants N1–N5.
+Every one of those omissions is written down at the site that would carry it, with the
+condition for restoring it: **a `--transcripts` opt-in landing here.**
+
+## Round 7 — three follow-ups to D12
+
+* **F1 — an unreadable date on MY OWN comment restored the exact false positive D12 fixed.**
+  `latest_reply_by` skipped a comment of mine whose date would not parse. If that was my
+  NEWEST, it returned an OLDER reply of mine — or `None`, which is the POSITIVE claim *"I
+  looked; you never replied"*. `latest_reply_ts_by` now returns the `UNIDENTIFIED` sentinel,
+  `build_record` omits the key, and the consumer announces rather than deciding. It is ANY of
+  my comments, not "the newest": an unreadable date has no position in the ordering.
+* **F2 — the tie boundary was a judgement call and the data to settle it was being thrown
+  away.** Minute-resolution ages made a reply written **20 seconds BEFORE** the question
+  compare EQUAL to it and count as an answer — a waiting colleague dropped from the report.
+  `date_ms` / `my_latest_reply_ms` now ride beside the display fields, used **only when BOTH**
+  are present; an unreadable date yields an ABSENT ms, never a `0` (1970 makes every reply
+  look newer than every question).
+* **F3 — ClickUp has no bot identity, and the suppression path printed NOTHING.** Every
+  comment posted through a `pk_` token comes back authored as the token's owner, so *"you
+  answered"* and *"an agent answered as you"* are the same observable. `suppressed_notes`
+  emits one line per suppressed task into its own `## Answered already` block, with the
+  caveat leading the block once.
+* **The instrument**: `tests/test_waiting_corpus.py`, 21 labelled RECORDS. `test_corpus.py`
+  scores comment TEXT; this flag reads FIELDS, so all 49 of its cases are blind to it. The
+  verdict is read off the CLAIM, never off whether something fired.
+* Round 7b's audit fixes are folded in: the computed other-coverage sentence, the
+  display-vs-bound age split, the note requiring a bound that was actually EVALUATED, and
+  `report_blocks` being driven THROUGH `main()` rather than merely extracted.
+
+## Round 8 — three invariants the prose guaranteed and nothing pinned
+
+All three SURVIVED upstream's full battery. `tests/test_bounds_and_parsing.py` closes them:
+per-record `disagreements([r])` scoping, the DISPLAY half of the two-ages split, and
+`UNANSWERED_COMMENT_DAYS` pinned ON its boundary (14.0) and at a NON-multiple overshoot (20).
+🔴 **The reusable lesson is the third: 30 is more than 2×14, so a DOUBLING mutant passed
+straight through the gap between fixtures at 13 and 30.** A bound needs a case exactly on it
+and an overshoot that is not a multiple of the step.
+
+Also ported: `TypeError` added to `_age_days_from_ms`' except tuple (dropping the `_ms()` call
+at the caller is a one-token edit that let a string `date_ms` crash the whole report), and
+three comment corrections — the `OSError` blame in `_age_days_from_ms` (the exception is
+`ValueError`; the real mechanism is that `_epoch_ms` never range-checks), the "changes NO flag
+outcome" claim about moving the recency bound (it now changes exactly one case), and the
+retracted *"`mentions_found == 0` means no other rule covers the ticket"* non-sequitur
+wherever it appeared.
+
+## 🔴 The battery is in the repo — `tests/mutation_sweep.py`
+
+Mutants as DATA plus a runner (`--list`, an id filter, `--check` which fails on a stale
+`NOT APPLIED`). **59 mutants + a positive control + a NULL CONTROL, non-KILLED: 0.**
+
+🔴 **And the null control earned its place on the first run.** All 59 mutants reported KILLED,
+and every killer list opened with `test_the_scan_actually_walks_files_and_can_see_an_id`:
+`test_no_real_identifiers.py` resolves `<repo>/scripts` and `<repo>/claude` from `__file__`,
+which cannot exist inside the sweep's temp copy, so its four tests failed in **every** run and
+a mutant that changed nothing would have scored KILLED too. That is a fully green sweep
+proving nothing — the exact "dying to a different guard's assertion is a green you cannot
+spend" failure, hit by the file that warns about it. Fixed two ways: that gate is dropped from
+each mutant copy (no code mutant can ever be caught by a tree-hygiene check), and the sweep
+now runs an unmutated copy FIRST and aborts unless it reports SURVIVED.
+
+## Red at base / green at HEAD
+
+Measured with `test_no_real_identifiers.py` excluded from all three trees — it is a
+repo-hygiene gate that cannot resolve the repo from a temp copy, so it would fail identically
+everywhere and inflate each row by the same 4:
+
+| tree | result |
+|---|---|
+| pre-port scripts + pre-port tests (baseline) | **176 passed, 0 failed** |
+| pre-port scripts + **HEAD tests** | **178 passed, 31 failed** |
+| HEAD scripts + HEAD tests | **209 passed, 0 failed** |
+
+In-repo, with that gate included: **180 → 213 collected.** Corpus **10/21 pre-port → 21/21**.
+
+⚠️ Four of the five round-8 guards are among those 31 reds, and they are **not** regression
+coverage: they go red with `AttributeError` because `suppressed_notes` / `_age_days_from_ms`
+do not exist pre-port, not because pre-port got those cases wrong. The file says so at the
+top. Counting them would overstate the port's regression matrix by four.
+
+## 🔴 What was NOT verified
+
+**No live ClickUp run**, in any round of this line of work, upstream or here. Every claim
+above is measured against the suite, the corpus and the sweep. The bot-identity finding is
+carried over from an independent measurement in a sibling tool and was not re-measured.
+
+The **threaded-comment blind spot is unchanged**: `recent-comments.py` still fetches
+top-level comments only, so a reply written inside a comment thread is invisible to
+`my_latest_reply` and the ticket still reads as unanswered.
+
+Found and deliberately NOT fixed: `_collect` still sorts on the FORMATTED `date` string. That
+is lexicographically correct for `%Y-%m-%d %H:%M`, and `date_ms` now exists so the sort could
+read it — but it would change which comments the report samples, and nothing measured says
+the current order is wrong.

--- a/scripts/check-clickup-addressed/check-addressed.py
+++ b/scripts/check-clickup-addressed/check-addressed.py
@@ -347,7 +347,25 @@ def _comment_age_days(date_str, now):
 
     `recent-comments.py` formats these itself, so an unreadable one means that formatter
     changed — which must not silently turn into "not recent". None is propagated to the
-    caller and surfaced, never swallowed.
+    caller rather than coerced.
+
+    🔴 THE ROUND-5 GUARANTEE WAS NARROWED, DELIBERATELY, AND THIS SENTENCE IS THE RECORD OF
+    IT. It used to read "surfaced, never swallowed", and that is no longer true in one case:
+    when the display date is unreadable but `date_ms` dates the comment PAST the recency
+    bound, the record is now SILENT rather than flagged. Nobody decided that on purpose —
+    it fell out of `bound_age` — so it is decided here, in favour of the new behaviour:
+
+      * the guarantee's purpose was that a formatter drift must not silently turn a RECENT
+        comment into a stale one. When `date_ms` is readable the age is not unknown, and
+        surfacing "age unknown" over a comment we can date to the millisecond would be a
+        false claim of ignorance — the mirror of the defect the guarantee was written for.
+      * when NO field can date it, the flag still fires and still says the date was
+        unreadable. That is the case the guarantee was actually about, and it is intact.
+
+    ⚠️ The residual gap, stated rather than papered over: in that one narrowed case the
+    formatter drift itself now goes unannounced. It is not re-added to the decision block
+    because it would be an unbounded line about tool health in the one block whose value
+    depends on being short — the same trade round 5 made for the flag itself.
     """
     try:
         dt = datetime.strptime((date_str or "").strip(), COMMENT_DATE_FMT).replace(
@@ -357,8 +375,129 @@ def _comment_age_days(date_str, now):
     return (now - dt).total_seconds() / 86400.0
 
 
-def _waiting_on_a_human(r, now):
-    """A colleague asked something recently and NO work exists anywhere. Returns a flag or None.
+def _ms(value):
+    """A raw epoch-ms field as an int, or None if it is not one.
+
+    STRICTER than the producer's own `_epoch_ms`, on purpose: these two keys are written by
+    `recent-comments.py` as ints and by nothing else, so a string here means a producer that
+    drifted and the right answer is to fall back to the age comparison rather than to guess.
+
+    `bool` is excluded explicitly because `isinstance(True, int)` is True in Python and a
+    JSON `true` would otherwise compare as 1 ms — 1970 — making every reply look newer than
+    every question. ⚠️ BY-CONSTRUCTION, not an observed input: no producer writes a bool
+    here. It is kept because the failure it prevents is silent and wrong rather than loud,
+    and it is pinned directly at this function rather than through a record fixture.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value
+
+
+def _age_days_from_ms(ms, now):
+    """Age in days computed from a raw epoch-ms, or None if it is absent or out of range.
+
+    🔴 This exists so the RECENCY BOUND cannot go dead when the display date is unreadable.
+    The bound reads `_comment_age_days`, which parses the FORMATTED string — and the producer's
+    `format_date` falls back to `str(ts_ms)` for anything `datetime.fromtimestamp` refuses,
+    which includes an out-of-range epoch. 🔴 The mechanism is that `_epoch_ms` NEVER RANGE-CHECKS
+    at all: it is `int()` plus an except, so it accepts any integer, while `fromtimestamp`
+    raises **`ValueError`** ("year … is out of range") on the same value. (An earlier version of
+    this sentence blamed `OSError`, which `_epoch_ms` supposedly did not catch — wrong on both
+    halves: the exception is `ValueError`, and `_epoch_ms` catches `ValueError` too. The
+    `except` clause below is correctly wide; only the explanation was false, which is the worse
+    kind of error because it sends the next reader after the wrong divergence.) So a record
+    could carry a perfectly good `date_ms` beside an unformattable `date`: age unknown, bound
+    skipped, and the ms path still deciding the verdict. Measured while porting this round — a
+    2019 ticket printed a suppression note with no bound at all, permanently, because an
+    answered ticket never changes an input.
+
+    The exotic case matters less than the systemic one: if `format_date` ever drifts, the
+    bound goes dead for EVERY record while the ms path keeps deciding. A bound that silently
+    stops bounding is the failure this whole block was designed against.
+    """
+    if ms is None:
+        return None
+    try:
+        dt = datetime.fromtimestamp(ms / 1000, tz=timezone.utc)
+    # `TypeError` because `ms / 1000` is the first thing that touches the value: drop the
+    # `_ms()` call at the caller — a one-token edit that survived the suite — and a STRING
+    # `date_ms` from a drifted producer reaches this line and raises an exception that was
+    # not in this tuple, crashing the whole report. A robust parser is the right place for
+    # that, not a second type check at the call site: one rule, one place.
+    except (ValueError, TypeError, OSError, OverflowError):
+        return None
+    return (now - dt).total_seconds() / 86400.0
+
+
+# The waiting flag's two outcomes. `_waiting_verdict` returns one of these with its line, so
+# the report can put them in DIFFERENT blocks: WAITING is an instruction to act, ANSWERED is
+# a note about a check that ran and found nothing to do. Merging them would put a line that
+# needs no action into the one block the reader is told to act on.
+WAITING, ANSWERED = "waiting", "answered"
+
+# 🔴 ClickUp has NO bot identity. Measured independently 2026-08-22 in a sibling tool
+# implementing this same predicate: every comment posted through a `pk_` personal token comes
+# back authored as the token's OWNER, whoever actually typed it. So "the owner answered" and
+# "a machine answered on the owner's behalf" are the SAME observable — there is no field that
+# separates them, and no amount of care in this file can recover one.
+#
+# That matters here specifically because an agent-posted comment sets `my_latest_reply` and
+# therefore SUPPRESSES this flag. Suppression printed nothing at all, so a genuinely-waiting
+# colleague was dropped with no trace and the caveat had nowhere to live.
+#
+# Printed ONCE, as the block's first line, not per note. It is 199 characters and repeating it
+# on every line put ~11 KB of identical no-action text in a `--limit 20` report — and this
+# block's own justification is that VOLUME is how a block stops being read, so repeating the
+# caveat to make sure it is seen is self-defeating. Each note carries only its own consequence.
+BOT_IDENTITY_CAVEAT = (
+    "ClickUp has NO bot identity — every comment posted through the `pk_` token comes back "
+    "authored as you, whoever typed it — so \"you answered\" and \"an agent answered as you\" "
+    "are the same observable, and EVERY line below rests on that.")
+
+
+def _reply_answers_the_comment(nc, now):
+    """Did my newest reply land at or after the colleague's comment? True / False / None.
+
+    None means the question is UNDECIDABLE from this record — a malformed value on either
+    side — and the caller must not read that as either answer. Round 6's rule holds: never
+    silently drop a waiting human because a date would not parse.
+
+    🔴 TWO resolutions, and the raw one wins when it is available on BOTH sides. `date_ms`
+    and `my_latest_reply_ms` are the epoch-ms `recent-comments.py` formatted the display
+    dates FROM; the display dates are minute-resolution, so a reply written 20 seconds
+    BEFORE the question renders identical to it and the minute comparison calls it an
+    answer. That boundary was a judgement call argued in both directions (round 6 shipped "a
+    tie counts as answered" because the minute rendering makes ties common; a parallel review
+    argued the opposite from the same evidence). Comparing the ms retires the argument: the
+    tie is now a real tie — two comments in the same MILLISECOND — and the sub-minute cases
+    decide themselves on the fact.
+    `>=` rather than `>` is kept for that genuine tie, so this change can only ever move
+    sub-minute cases; it cannot flip the shape round 6 measured.
+
+    The age fallback is UNCHANGED and is not a legacy path: a record from a producer that
+    predates the ms fields, or one whose date would not parse, must still get the round-6
+    behaviour rather than losing suppression entirely — which would resurrect D12's false
+    positive on every such record.
+    """
+    mine_ms, theirs_ms = _ms(nc.get("my_latest_reply_ms")), _ms(nc.get("date_ms"))
+    if mine_ms is not None and theirs_ms is not None:
+        return mine_ms >= theirs_ms
+    mine = _comment_age_days(nc.get("my_latest_reply"), now)
+    theirs = _comment_age_days(nc.get("date"), now)
+    if mine is None or theirs is None:
+        return None
+    # Smaller age = more recent.
+    return mine <= theirs
+
+
+def _waiting_verdict(r, now):
+    """A colleague asked something recently and NO work exists anywhere. Returns (kind, line).
+
+    `kind` is WAITING (a human is waiting and nothing exists), ANSWERED (every condition
+    held EXCEPT that a reply of mine already answers it — reported, quietly, in its own
+    block) or None (nothing to say). One function, two outcomes, because the two verdicts
+    share every condition but the last: re-deriving the preconditions in a second function
+    is how a predicate ends up wrong at one of its sites.
 
     This is the highest-signal state the tool can reach and no existing rule produced it:
     nothing "disagrees" — the ticket is open, the transcripts are empty, and they agree.
@@ -405,38 +544,32 @@ def _waiting_on_a_human(r, now):
        `my_latest_reply` is a stale producer that never gathered the fact, so the flag
        fires but says the check did not run — the same treatment an unreadable date gets,
        and the reason it cannot be silently disabled by dropping one dict key.
+
+    🔴 And suppression is REPORTED (ANSWERED), because a suppressed flag printed NOTHING and
+    that is where the bot-identity caveat had to live. ClickUp cannot tell a comment I typed
+    from one an agent posted with my token (`BOT_IDENTITY_CAVEAT`), so condition 4 can be
+    satisfied by a machine — and the silent version of that is a waiting colleague dropped
+    with no trace at all. The note carries the SAME recency bound as the flag, so it cannot
+    become the permanent noise the bound exists to prevent.
     """
     # PRESENT and zero, not `get(..., 0)`. An absent key is a record that never reported a
     # mention count — inferring "no work exists anywhere", the strongest claim this flag
     # makes, from a field that is simply missing is the same mistake as reading a declared
     # field as a code path. Caught by an existing round-2 control whose fixture omits it.
     if r.get("mentions_found") != 0:
-        return None
+        return None, None
     cu = (r.get("clickup_status") or "").lower()
     if cu in DONE_STATUSES:
-        return None
+        return None, None
 
     nc = r.get("newest_comment") or {}
     if not (nc.get("snippet") or "").strip():
-        return None
+        return None, None
     # An ABSENT date and a MALFORMED one are different facts. Absent = no interaction to be
     # recent about, so there is nothing to claim. Malformed = recent-comments.py's own
     # formatter drifted, which must announce itself rather than quietly read as "stale".
     if not (nc.get("date") or "").strip():
-        return None
-
-    # Answered already? Compare instants, not existence. Equal counts as answered: ClickUp
-    # renders to the MINUTE, so a reply written in the same minute as the comment reads as
-    # equal, and a strict `>` would report it unanswered.
-    reply_unreported = "my_latest_reply" not in nc
-    if not reply_unreported:
-        mine = _comment_age_days(nc.get("my_latest_reply"), now)
-        theirs = _comment_age_days(nc.get("date"), now)
-        # Smaller age = more recent. A malformed value on either side falls through to the
-        # flag rather than suppressing it — never silently drop a waiting human because a
-        # date would not parse.
-        if mine is not None and theirs is not None and mine <= theirs:
-            return None
+        return None, None
 
     age = _comment_age_days(nc.get("date"), now)
     # 🔴 The recency bound runs BEFORE any reporting caveat, and the caveats COMPOSE rather
@@ -445,10 +578,66 @@ def _waiting_on_a_human(r, now):
     # backlog comment was flagged forever (the exact unbounded-noise failure the recency bound
     # exists to prevent) and an unreadable date stopped being surfaced. A condition that
     # returns its own string is a condition that silently owns every condition after it.
-    if age is not None and age > UNANSWERED_COMMENT_DAYS:
-        return None
+    #
+    # It now also runs before the ANSWERED branch, which is what bounds the suppression note.
+    # Moving it earlier changed no flag outcome AT THE TIME — a stale comment returned None at
+    # this line instead of at the answered branch, the same None — but a note that outlived
+    # the flag would be exactly the unbounded block the bound was chosen against.
+    #
+    # ⚠️ That "changes NO flag outcome" claim is no longer true and the correction is kept
+    # here rather than the sentence quietly deleted: `bound_age` (below) made this bound
+    # reachable on records whose display date is unreadable, and measured base-vs-HEAD it now
+    # changes exactly one — an unformattable `date` beside a valid 90-day-old `date_ms`
+    # printed a WAITING flag before and is SILENT now. That is the narrowing decided in
+    # `_comment_age_days`' docstring, and it is pinned by a corpus case rather than argued.
+    #
+    # 🔴 TWO ages, deliberately. `age` is what the report DISPLAYS and must stay `None` when
+    # the `date` field itself is unreadable — that is a fact about the producer's formatter and
+    # the head says so. `bound_age` is what the bound DECIDES on, and it falls back to the raw
+    # ms, because the ms path below will happily decide the verdict from `date_ms` while `age`
+    # is None: measured while porting, a 2019 ticket printed an unbounded suppression note.
+    # A decision and a display are different jobs and reading one field for both is what let
+    # the bound go dead. See `_age_days_from_ms`.
+    bound_age = age if age is not None else _age_days_from_ms(_ms(nc.get("date_ms")), now)
+    if bound_age is not None and bound_age > UNANSWERED_COMMENT_DAYS:
+        return None, None
 
     who = nc.get("author") or "someone"
+
+    # Answered already? Compare instants, not existence — and at millisecond resolution when
+    # the producer reported it. A malformed value on either side (`None` here) falls through
+    # to the flag rather than suppressing it: never silently drop a waiting human because a
+    # date would not parse.
+    reply_unreported = "my_latest_reply" not in nc
+    # 🔴 `bound_age is not None` is a condition of the NOTE, not of the flag, and the asymmetry
+    # is the point. A note is a "no action needed" line: if its recency bound could not be
+    # evaluated at all it can never expire, and a permanent no-action line is precisely the
+    # noise the bound exists to prevent — so the record falls through to the FLAG instead,
+    # which surfaces the unreadable date rather than silently suppressing a colleague.
+    #
+    # This is the tail of the bound fix above, and without it the fix is only half applied:
+    # `_age_days_from_ms` returning None (an out-of-range `date_ms`, which `_epoch_ms` accepts
+    # and `format_date` rejects) left the note unbounded by the same mechanism one layer down.
+    # It is also what makes that None DISTINGUISHABLE — with the note unguarded, returning
+    # `None` and returning `0` from that function produce identical output, so the honest
+    # value was doing no work and a mutant swapping it survived.
+    if (not reply_unreported and bound_age is not None
+            and _reply_answers_the_comment(nc, now) is True):
+        when = nc.get("my_latest_reply")
+        seen = f"{age:.0f}d ago" if age is not None else f"at {nc.get('date')!r} (unreadable)"
+        # 🔴 The line claims only what THIS check did. It used to add "nothing was printed
+        # above about this ticket, and `mentions_found` is 0 so no other rule covers it
+        # either" — false in four reproduced shapes (an unknown ClickUp status, a
+        # RESOLVED-reading comment, a keep-open veto, an open cited PR), each of which puts a
+        # line about the SAME ticket directly above this one. And the reason given was a
+        # non-sequitur on top of that: not one of those four rules reads `mentions_found`.
+        # Whether anything else covers the ticket is a fact `suppressed_notes` can COMPUTE, so
+        # it appends that sentence rather than this one asserting it.
+        return ANSWERED, (
+            f"{r['task_id']}: @{who} commented {seen} and a reply from you at {when} is not "
+            f"older, so the WAITING flag is SUPPRESSED. If that reply was an agent's, @{who} "
+            f"is still waiting for a human — read the thread before treating this as handled.")
+
     head = (f"{r['task_id']}: @{who} is WAITING — the ticket is `{cu or 'unknown status'}`, "
             f"and the task ID appears in NO transcript, so no work exists anywhere.")
     if age is None:
@@ -462,7 +651,100 @@ def _waiting_on_a_human(r, now):
         head += (" NOTE: your own replies were not reported by recent-comments.py, so whether "
                  "you already answered could not be checked — read the thread before treating "
                  "this as unanswered.")
-    return head
+    return WAITING, head
+
+
+def _waiting_on_a_human(r, now):
+    """The WAITING flag alone, or None. A thin view over `_waiting_verdict`.
+
+    Kept as its own name because it is what `disagreements` appends to the act-on-this block
+    and what four rounds of tests and mutants address. The ANSWERED verdict deliberately does
+    NOT come out of here: it would land in "Needs a decision", which is the one block a
+    reader is told to act on, and a line saying "no action needed" belongs somewhere else.
+    """
+    kind, line = _waiting_verdict(r, now)
+    return line if kind == WAITING else None
+
+
+def suppressed_notes(results, now=None):
+    """One line per task whose WAITING flag was suppressed by a reply of mine.
+
+    A SIBLING of `disagreements`, not part of it — its lines report a check that ran and
+    found nothing to do, which is a different kind of claim from a disagreement and belongs
+    in a different block of the report. Both call `_waiting_verdict`, so the preconditions
+    exist once.
+
+    🔴 It exists because the alternative is silence, and silence is what this whole skill
+    polices. A suppressed flag printed NOTHING, so the ticket vanished from the report
+    entirely — no line to carry `BOT_IDENTITY_CAVEAT`, and an agent-posted reply (which
+    ClickUp reports as mine, indistinguishably) dropped a genuinely-waiting colleague with
+    no trace. Bounded by the same recency window as the flag itself, inside
+    `_waiting_verdict`, so it cannot become permanent noise.
+
+    🔴 Each line ends with a COMPUTED statement of whether anything else in "Needs a decision"
+    names the same ticket, never an asserted one. The first version asserted that nothing did,
+    and four shapes were reproduced where a line about the same ticket sits directly above it —
+    an unknown ClickUp status, a RESOLVED-reading comment, a keep-open veto, an open cited PR.
+    Running `disagreements` on the single record is what makes the sentence true: the waiting
+    flag is suppressed for these records by definition, so whatever comes back is another
+    rule's line. One predicate, asked rather than assumed. 🔴 `[r]` and not `results` — the
+    sentence is about THIS ticket, and a mutant widening it to the whole report survived a
+    green suite because every fixture written for the sentence passed a single-record list.
+
+    The `BOT_IDENTITY_CAVEAT` is NOT repeated per line — `report_blocks` prints it once as the
+    block's first line. See the constant for why repeating it defeated its own purpose.
+    """
+    now = now or datetime.now(timezone.utc)
+    out = []
+    for r in results:
+        kind, line = _waiting_verdict(r, now)
+        if kind != ANSWERED:
+            continue
+        others = disagreements([r], now)
+        if others:
+            line += (" ⚠️  'Needs a decision' above ALSO carries a line about this ticket — "
+                     "this note is only about the waiting check.")
+        else:
+            line += (" No other flag names this ticket, so nothing else in this report is "
+                     "asking you to look at it.")
+        out.append(line)
+    return out
+
+
+DECISION_HEADING = "## Needs a decision"
+ANSWERED_HEADING = "## Answered already — no action, but check who answered"
+
+
+def report_blocks(results, now=None):
+    """The report's trailing blocks, as (heading, lines) in print order. Empty ones omitted.
+
+    Extracted from `main()` so the WIRING is testable. Both producers below are correct in
+    isolation and pinned in isolation, and a producer `main()` never calls is inert with a
+    fully green suite — this skill's own headline defect class, twice over already. 🔴 That
+    extraction is NOT the test: measured, replacing `main()`'s whole print loop with `pass`
+    left the suite green, so `test_main_actually_PRINTS_both_blocks_end_to_end` drives
+    `main()` and asserts on STDOUT. A function extracted to make a seam testable and then not
+    tested THROUGH has moved the seam rather than closed it.
+
+    🔴 TWO blocks, not one list. The suppression notes report a flag that DID NOT fire and
+    ask for no action; "Needs a decision" is the one block the reader is told to act on, and
+    diluting it is how a block stops being read. That reasoning is the same one that bounded
+    the waiting flag by recency in the first place.
+    """
+    now = now or datetime.now(timezone.utc)
+    blocks = []
+    flags = disagreements(results, now)
+    if flags:
+        blocks.append((DECISION_HEADING, [f"⚠️  {f}" for f in flags]))
+    notes = suppressed_notes(results, now)
+    if notes:
+        # The caveat leads the block ONCE. It applies to every line under it, it is 199
+        # characters, and repeating it per line put ~11 KB of identical text in a `--limit 20`
+        # report — in the one block whose whole justification is that volume is how a block
+        # stops being read.
+        blocks.append((ANSWERED_HEADING,
+                       [f"🔴 {BOT_IDENTITY_CAVEAT}"] + [f"ℹ️  {n}" for n in notes]))
+    return blocks
 
 
 def disagreements(results, now=None):
@@ -631,6 +913,15 @@ def build_newest_comment(meta):
     # must tell them apart — one is evidence, the other is a gap to announce.
     if "my_latest_reply" in meta:
         nc["my_latest_reply"] = meta["my_latest_reply"]
+    # The raw epoch-ms the two display dates were formatted from, carried across the same
+    # hand-off and by the same rule. Absent here means the producer could not read that date
+    # (or predates the fields), and `_reply_answers_the_comment` falls back to the
+    # minute-resolution ages — so DROPPING either key silently reverts the precision fix and
+    # nothing about the report looks different. Both are pinned by a test for that reason,
+    # the same way `text` and `my_latest_reply` are.
+    for key in ("date_ms", "my_latest_reply_ms"):
+        if key in meta:
+            nc[key] = meta[key]
     return nc
 
 
@@ -834,11 +1125,10 @@ def main():
                       if r["status"] in ("unclear", "no_sessions_found", "no_mentions_found"))
         print(f"## Summary: {addressed} addressed, {partial} partial, {open_count} open, {unclear} unclear")
 
-        flags = disagreements(results)
-        if flags:
-            print("\n## Needs a decision\n")
-            for f in flags:
-                print(f"⚠️  {f}")
+        for heading, lines in report_blocks(results):
+            print(f"\n{heading}\n")
+            for line in lines:
+                print(line)
 
 
 if __name__ == "__main__":

--- a/scripts/check-clickup-addressed/recent-comments.py
+++ b/scripts/check-clickup-addressed/recent-comments.py
@@ -127,13 +127,39 @@ TEXT_CHARS = 4000
 UNIDENTIFIED = object()
 
 
-def latest_reply_by(comments, my_id):
-    """Formatted date of the newest comment authored by `my_id`, or None if there is none.
+def _epoch_ms(value):
+    """ClickUp's raw millisecond timestamp as an int, or None if it cannot be read.
 
-    The loop below drops every comment of mine, which is right for a report about what
-    OTHER people said — and it is exactly why the downstream "nobody has answered" flag
-    was blind: the evidence that would refute it is removed before the flag ever runs.
-    This carries the one fact across that seam.
+    Tolerant of the string form because that is what the API returns (`"1755800000000"`).
+    The CONSUMER's parse is deliberately stricter — see `_ms` in check-addressed.py — because
+    it reads a field this file wrote, where anything but an int means a drifted producer.
+    """
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def latest_reply_ts_by(comments, my_id):
+    """Raw epoch-ms of the newest comment authored by `my_id`.
+
+    Three return values, and the third is the point:
+      * an int — my newest reply,
+      * `None` — I looked at every comment and none is mine ("you never replied"),
+      * `UNIDENTIFIED` — one of MY comments carries a date this function cannot read, so
+        which of my comments is newest is UNKNOWABLE.
+
+    🔴 That third case used to `continue`, and it restored the exact false positive round 6
+    fixed. An unreadable date on my NEWEST comment made the loop skip it and return either
+    an OLDER reply of mine or `None` — and `None` is the POSITIVE claim "I looked; you
+    never replied", so the waiting flag says "nobody has answered" about a ticket that was
+    answered. `UNIDENTIFIED`'s own comment above states that property; this is that
+    property defeated on a different input, which is why the sentinel is reused here rather
+    than a second, weaker signal being invented.
+
+    It is deliberately ANY of my comments, not "the newest one": an unreadable date has no
+    position in the ranking, so there is no way to establish that it is not the newest. The
+    conservative reading — we cannot rank my comments — is the only one that is true.
 
     Ranked on the raw epoch-ms, never on the formatted string: `format_date` falls back to
     `str(ts_ms)` for an unparseable value, so a max() over formatted dates can rank garbage
@@ -143,16 +169,40 @@ def latest_reply_by(comments, my_id):
     for c in comments:
         if str(c.get("user", {}).get("id", "")) != my_id:
             continue
-        try:
-            ts = int(c.get("date", ""))
-        except (ValueError, TypeError):
-            continue
+        ts = _epoch_ms(c.get("date", ""))
+        if ts is None:
+            return UNIDENTIFIED
         if best is None or ts > best:
             best = ts
-    return format_date(best) if best is not None else None
+    return best
 
 
-def build_record(tid, tname, task, comment, text, my_latest_reply):
+def _formatted_reply(ts):
+    """Display form of `latest_reply_ts_by`'s answer, passing both non-int states through.
+
+    One function rather than two parallel expressions: `_collect` needs the raw ms AND the
+    formatted string for the same reply, and deriving them at two sites is how they drift
+    apart. `format_date(UNIDENTIFIED)` would return the repr of an `object()` — a string,
+    truthy, and indistinguishable downstream from a real date.
+    """
+    if ts is None or ts is UNIDENTIFIED:
+        return ts
+    return format_date(ts)
+
+
+def latest_reply_by(comments, my_id):
+    """Formatted date of my newest comment, `None` if I never replied, `UNIDENTIFIED` if
+    my comments cannot be ranked. See `latest_reply_ts_by` for why the third state exists.
+
+    The loop there drops every comment that is not mine — the mirror of the filter in
+    `_collect`, which is right for a report about what OTHER people said and is exactly why
+    the downstream "nobody has answered" flag was blind: the evidence that would refute it
+    is removed before the flag ever runs. This carries the one fact across that seam.
+    """
+    return _formatted_reply(latest_reply_ts_by(comments, my_id))
+
+
+def build_record(tid, tname, task, comment, text, my_latest_reply, my_latest_reply_ms):
     """One comment row.
 
     A function, not an inline dict, so the `snippet`/`text` split is pinned by a test. Both
@@ -163,7 +213,10 @@ def build_record(tid, tname, task, comment, text, my_latest_reply):
 
     `my_latest_reply` is a REQUIRED positional argument rather than a defaulted one. A
     default would let a caller omit it and get the pre-fix behaviour silently; this way the
-    omission is a TypeError at the only call site.
+    omission is a TypeError at the only call site. `my_latest_reply_ms` is required for the
+    same reason and it is the stronger case: omitting it degrades silently to the
+    minute-resolution comparison, which is the pre-change behaviour and looks like a
+    working tool.
     """
     rec = {
         "task_id": tid,
@@ -178,6 +231,20 @@ def build_record(tid, tname, task, comment, text, my_latest_reply):
         "snippet": text[:SNIPPET_CHARS],
         "text": text[:TEXT_CHARS],
     }
+    # 🔴 The RAW millisecond, beside the display string it was formatted from — because
+    # `format_date` throws the seconds away and the consumer's "have I already answered
+    # this?" comparison then runs at MINUTE resolution, where a reply written 20 seconds
+    # BEFORE the question compares EQUAL to it. At minute resolution "equal counts as
+    # answered" is a judgement call that has been argued both ways; carrying the ms makes it
+    # a question of fact instead, and a tie a real tie.
+    #
+    # Emitted only when it PARSES. An unreadable date must not become a `0` (1970, so every
+    # reply looks newer) nor a `None` (a JSON null the consumer would have to special-case
+    # anyway) — it is ABSENT, and the consumer falls back to the age comparison it already
+    # had. Absent-vs-present is the same discipline `my_latest_reply` gets below.
+    date_ms = _epoch_ms(comment.get("date", ""))
+    if date_ms is not None:
+        rec["date_ms"] = date_ms
     # Present-and-null ("I looked; you never replied") is a different fact from absent
     # ("nobody could look"). The consumer branches on which, so the key is emitted for every
     # value EXCEPT the UNIDENTIFIED sentinel, whose whole purpose is to reach the absent
@@ -185,6 +252,14 @@ def build_record(tid, tname, task, comment, text, my_latest_reply):
     # confident false negative.
     if my_latest_reply is not UNIDENTIFIED:
         rec["my_latest_reply"] = my_latest_reply
+        # Nested, so the ms can never appear without the formatted date it refines: one is
+        # EVIDENCE (did the producer look?), the other is only PRECISION. The evidence
+        # distinction lives in `my_latest_reply` alone and is deliberately NOT duplicated
+        # here — two fields carrying the same fact is two chances to disagree — so this key
+        # is simply absent for "no reply" and for "unreadable", and its absence is never
+        # read as a claim about anything.
+        if isinstance(my_latest_reply_ms, int) and not isinstance(my_latest_reply_ms, bool):
+            rec["my_latest_reply_ms"] = my_latest_reply_ms
     return rec
 
 
@@ -210,9 +285,12 @@ def _collect(limit, fast, as_json):
         # see UNIDENTIFIED. Loud on stderr too: a report whose author id is missing cannot
         # tell your comments from anyone else's, and silence there reads as a normal run.
         if my_id:
-            my_reply = latest_reply_by(comments, my_id)
+            my_reply_ts = latest_reply_ts_by(comments, my_id)
         else:
-            my_reply = UNIDENTIFIED
+            my_reply_ts = UNIDENTIFIED
+        # The raw ms and its display string come from ONE lookup, so they cannot describe
+        # two different comments.
+        my_reply = _formatted_reply(my_reply_ts)
         for c in comments:
             user_id = str(c.get("user", {}).get("id", ""))
             if user_id == my_id:
@@ -220,7 +298,8 @@ def _collect(limit, fast, as_json):
             text = extract_text(c)
             if not text:
                 continue
-            results.append(build_record(tid, tname, task, c, text, my_reply))
+            results.append(
+                build_record(tid, tname, task, c, text, my_reply, my_reply_ts))
 
     # Sort newest first, take top N
     results.sort(key=lambda x: x["date"], reverse=True)

--- a/scripts/check-clickup-addressed/tests/mutation_sweep.py
+++ b/scripts/check-clickup-addressed/tests/mutation_sweep.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""The mutation battery for this skill's decision logic, as DATA plus a runner.
+
+    PYTHONDONTWRITEBYTECODE=1 python3 tests/mutation_sweep.py          # everything
+    PYTHONDONTWRITEBYTECODE=1 python3 tests/mutation_sweep.py M17 N7   # a subset
+    python3 tests/mutation_sweep.py --list                             # ids and notes
+
+🔴 WHY THIS IS IN THE REPO. Earlier rounds each ran a sweep, reported "N mutants, 0 survived",
+and threw the driver away. That number was then unreproducible from the repo — a reviewer had
+to take it on trust, and the next round re-invented a list from scratch and re-discovered the
+same sites. A blind re-audit of one such "51 mutants, 0 non-killed" spot-checked the delta and
+found SEVEN more at the same sites, including one (`M-SCOPE`) that reverted that round's
+headline fix. That is not a criticism of the sweep; it is the standing lesson: **a green sweep
+is a claim about the mutants somebody imagined**, so the list must be extendable rather than
+re-derived. Add to it; do not start a new one.
+
+HOW TO READ A RESULT
+  * `KILLED` names the test that failed. 🔴 **Read the name.** A mutant that dies to a
+    DIFFERENT guard's assertion is a green you cannot spend — it says nothing about the guard
+    you meant to exercise.
+  * `SURVIVED` is a hole. Not always in the code: three of one round's four survivors were
+    defects in the MUTANT or in a vacuous TEST. Establish which before writing code.
+  * `NOT APPLIED` means the pattern no longer matches — the code moved. It is NOT a pass, and
+    an unnoticed one reads exactly like one. `--check` fails the run if any mutant is stale.
+
+Each mutant runs against a FRESH copy of the skill (never `cp -a`: it preserves mtimes, and
+CPython validates a cached module on whole-second mtime + size, so a same-length edit inside
+the same second imports the ORIGINAL bytecode and scores SURVIVED without ever running).
+`run_all.py` purges `__pycache__` itself; `PYTHONDONTWRITEBYTECODE=1` is set on the child too.
+
+⚠️ LAYOUT. Upstream keeps the scripts in `<skill>/scripts/` and the suite in `<skill>/test/`;
+here the scripts sit at the skill root and the suite in `tests/`. `run_one` below is written
+against THIS layout — if you copy a mutant across, copy the paths too.
+
+⚠️ FIVE UPSTREAM MUTANTS ARE DELIBERATELY ABSENT (N1-N5). They cover a scan-less-run
+announcement and the `"mentions_found" in r` gate that goes with it, both of which exist
+because upstream made the transcript scan opt-in. This tool always scans — `check-completion.py`
+emits `mentions_found` on every exit path and nothing writes a `not_scanned` status — so those
+mutants would target code that is not here and score NOT APPLIED forever. Restore them in the
+same commit as any `--transcripts` opt-in.
+"""
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SKILL = Path(__file__).resolve().parent.parent
+RC = "recent-comments.py"
+CA = "check-addressed.py"
+
+# 🔴 REMOVED FROM EVERY MUTANT COPY, and this is the instrument's own correctness, not tidiness.
+# `test_no_real_identifiers.py` is a REPO-HYGIENE gate: it walks `<repo>/scripts/…` and
+# `<repo>/claude/skills/…` via `Path(__file__).resolve().parents[3]`, and asserts loudly when a
+# scan root is missing — correctly, since a scan that walks nothing is not a clean scan. Inside
+# the temp copy those roots do not exist, so all four of its tests fail on EVERY run.
+#
+# Measured on the first pass of this port: all 59 mutants reported KILLED, and each one's killer
+# list opened with `test_the_scan_actually_walks_files_and_can_see_an_id`. That is a
+# fully-green sweep in which a mutant changing NOTHING would also have scored KILLED — the exact
+# "dying to a different guard's assertion is a green you cannot spend" failure this file's own
+# HOW TO READ A RESULT section warns about, hit by the file that warns about it.
+#
+# No code mutant can ever be caught by this gate (it reads the tree, not the logic), so dropping
+# it costs no coverage. `NULL-CONTROL` below is what proves the removal was sufficient.
+EXCLUDED_FROM_MUTANT_RUNS = ("test_no_real_identifiers.py",)
+
+# (id, file, old, new, note). `old` must occur EXACTLY ONCE or the mutant is NOT APPLIED.
+MUTANTS = [
+    # ---------- round 7 change 1: the UNIDENTIFIED sentinel on an unreadable own date
+    ("M1", RC, "        if ts is None:\n            return UNIDENTIFIED",
+     "        if ts is None:\n            continue", "revert to round 6's `continue`"),
+    ("M2", RC, "        if best is None or ts > best:", "        if best is None or ts < best:",
+     "rank my OLDEST comment as newest"),
+    ("M3", RC, "        if best is None or ts > best:", "        if best is None:",
+     "first-wins instead of newest-wins"),
+    ("M4", RC, "    if ts is None or ts is UNIDENTIFIED:\n        return ts\n    return format_date(ts)",
+     "    return format_date(ts)", "format the sentinel into a date-looking string"),
+    ("M5", RC, "    if ts is None or ts is UNIDENTIFIED:", "    if ts is None:",
+     "pass None through but format the sentinel"),
+    ("M14", RC, "    except (ValueError, TypeError):\n        return None\n\n\ndef latest_reply_ts_by",
+     "    except (ValueError, TypeError):\n        return 0\n\n\ndef latest_reply_ts_by",
+     "unreadable epoch-ms becomes 1970 instead of absent"),
+
+    # ---------- round 7 change 2, producer side
+    ("M6", RC, '    if date_ms is not None:\n        rec["date_ms"] = date_ms',
+     '    if date_ms is not None:\n        pass', "drop the comment's raw ms"),
+    ("M7", RC, '    if date_ms is not None:\n        rec["date_ms"] = date_ms',
+     '    if True:\n        rec["date_ms"] = date_ms', "emit an absent ms as None"),
+    ("M8", RC, '    date_ms = _epoch_ms(comment.get("date", ""))',
+     '    date_ms = _epoch_ms(comment.get("date", "")) or 0', "emit an unreadable ms as 0"),
+    ("M9", RC, '        if isinstance(my_latest_reply_ms, int) and not isinstance(my_latest_reply_ms, bool):\n            rec["my_latest_reply_ms"] = my_latest_reply_ms',
+     '        if isinstance(my_latest_reply_ms, int) and not isinstance(my_latest_reply_ms, bool):\n            pass',
+     "drop my reply's raw ms"),
+    ("M10", RC, "        if isinstance(my_latest_reply_ms, int) and not isinstance(my_latest_reply_ms, bool):",
+     "        if my_latest_reply_ms is not None:", "accept a non-int ms"),
+    ("M11", RC, '        if isinstance(my_latest_reply_ms, int) and not isinstance(my_latest_reply_ms, bool):\n            rec["my_latest_reply_ms"] = my_latest_reply_ms\n    return rec',
+     '        pass\n    if isinstance(my_latest_reply_ms, int) and not isinstance(my_latest_reply_ms, bool):\n        rec["my_latest_reply_ms"] = my_latest_reply_ms\n    return rec',
+     "un-nest: an ms without the formatted date it refines"),
+    ("M12", RC, "            my_reply_ts = latest_reply_ts_by(comments, my_id)",
+     "            my_reply_ts = latest_reply_ts_by([], my_id)",
+     "compute the reply over an empty list (round 6's inert-fix shape)"),
+    ("M13", RC, "                build_record(tid, tname, task, c, text, my_reply, my_reply_ts))",
+     "                build_record(tid, tname, task, c, text, my_reply, None))",
+     "drop the ms at the _collect join"),
+
+    # ---------- round 7 change 2, consumer side
+    ("M15", CA, "    if isinstance(value, bool) or not isinstance(value, int):",
+     "    if not isinstance(value, int):", "`_ms` accepts a bool: a JSON `true` compares as 1ms"),
+    ("M17", CA, "        return mine_ms >= theirs_ms", "        return mine_ms > theirs_ms",
+     "a same-millisecond tie is no longer an answer"),
+    ("M18", CA, "        return mine_ms >= theirs_ms", "        return mine_ms <= theirs_ms",
+     "invert the ms comparison"),
+    ("M19", CA, "        return mine_ms >= theirs_ms", "        return True",
+     "any reported reply answers, at ms resolution"),
+    ("M20", CA, "    if mine_ms is not None and theirs_ms is not None:",
+     "    if mine_ms is not None or theirs_ms is not None:",
+     "compare a raw instant against a rounded one"),
+    ("M21", CA, "    if mine_ms is not None and theirs_ms is not None:\n        return mine_ms >= theirs_ms",
+     "    if False:\n        return mine_ms >= theirs_ms", "delete the ms branch"),
+    ("M22", CA, "    if mine is None or theirs is None:\n        return None\n    # Smaller age = more recent.\n    return mine <= theirs",
+     "    return None", "delete the age fallback"),
+    ("M23", CA, "    return mine <= theirs", "    return mine < theirs",
+     "round 6's own minute boundary, flipped"),
+
+    # ---------- round 7 change 3: the suppression note
+    ("M24", CA, "            and _reply_answers_the_comment(nc, now) is True):",
+     "            and _reply_answers_the_comment(nc, now) is not None):",
+     "undecidable counts as answered"),
+    ("M25", CA, "    if (not reply_unreported and bound_age is not None",
+     "    if (bound_age is not None", "drop the reported-vs-absent guard on the answered branch"),
+    ("M26", CA, "        return ANSWERED, (", "        return None, None or (",
+     "suppress silently again"),
+    ("M27", CA, "            f\"older, so the WAITING flag is SUPPRESSED. If that reply was an agent's, @{who} \"\n            f\"is still waiting for a human — read the thread before treating this as handled.\")",
+     "            f\"older, so the WAITING flag is SUPPRESSED.\")",
+     "drop the caveat's per-line consequence"),
+    ("M28", CA, "        if kind != ANSWERED:\n            continue", "        if kind != WAITING:\n            continue",
+     "wrong bind in suppressed_notes"),
+    ("M29", CA, "    now = now or datetime.now(timezone.utc)\n    out = []\n    for r in results:\n        kind, line = _waiting_verdict(r, now)\n        if kind != ANSWERED:",
+     "    now = now or datetime.now(timezone.utc)\n    out = []\n    for r in []:\n        kind, line = _waiting_verdict(r, now)\n        if kind != ANSWERED:",
+     "suppressed_notes over an empty list"),
+    ("M30", CA, "    kind, line = _waiting_verdict(r, now)\n    return line if kind == WAITING else None",
+     "    kind, line = _waiting_verdict(r, now)\n    return line", "notes leak into Needs a decision"),
+    ("M31", CA, "    return WAITING, head", "    return ANSWERED, head",
+     "route the waiting flag into the notes block"),
+    ("M32", CA, "    notes = suppressed_notes(results, now)\n    if notes:",
+     "    notes = suppressed_notes(results, now)\n    if False:", "drop the notes block"),
+    ("M33", CA, '    for key in ("date_ms", "my_latest_reply_ms"):', '    for key in ("date_ms",):',
+     "hand-off drops my reply's ms"),
+    ("M34", CA, '    for key in ("date_ms", "my_latest_reply_ms"):', '    for key in ("my_latest_reply_ms",):',
+     "hand-off drops the comment's ms"),
+    ("M35", CA, "    for key in (\"date_ms\", \"my_latest_reply_ms\"):\n        if key in meta:\n            nc[key] = meta[key]",
+     "    for key in (\"date_ms\", \"my_latest_reply_ms\"):\n        nc[key] = meta.get(key)",
+     "hand-off flattens absent into null"),
+    ("M36", CA, "MOVE_THE_RECENCY_BOUND", "", "move the recency bound AFTER the answered branch"),
+    ("M37", CA, "        blocks.append((DECISION_HEADING, [f\"⚠️  {f}\" for f in flags]))",
+     "        blocks.insert(99, (DECISION_HEADING, [f\"⚠️  {f}\" for f in flags]))\n"
+     "    notes = suppressed_notes(results, now)\n"
+     "    if notes:\n"
+     "        blocks.insert(0, (ANSWERED_HEADING, [f\"🔴 {BOT_IDENTITY_CAVEAT}\"] + [f\"ℹ️  {n}\" for n in notes]))",
+     "print the no-action block first"),
+    ("M38", CA, "        waiting = _waiting_on_a_human(r, now)\n        if waiting:",
+     "        waiting = _waiting_on_a_human(r, now)\n        if False:", "drop the waiting flag"),
+    ("M39", CA, "        seen = f\"{age:.0f}d ago\" if age is not None else f\"at {nc.get('date')!r} (unreadable)\"",
+     "        seen = f\"{age:.0f}d ago\"", "assume the note's age is always readable"),
+    ("M40", CA, "    if r.get(\"mentions_found\") != 0:\n        return None, None",
+     "    if r.get(\"mentions_found\", 0) != 0:\n        return None, None",
+     "absent mention count read as a reported zero"),
+
+    # ---------- round 7b: the audit fixes
+    #
+    # ⚠️ MEASURED WHILE PORTING, and worth knowing before you move a test: **M45 and M47 are
+    # killed by NOTHING in `test_own_reply_answers.py`.** Running each of the three files
+    # alone against those two mutants: the round-7 hand-written file goes 0 red, the corpus
+    # goes 4 red, and `test_bounds_and_parsing.py` goes 1 and 2 red respectively. Both mutants
+    # disable the `bound_age` fallback to the raw ms, and the only fixtures that combine an
+    # unreadable DISPLAY date with a usable `date_ms` live in the corpus and the round-8 file.
+    # All three ship together, so coverage is real — but delete either of those files and
+    # these two mutants survive a suite that still looks comprehensive.
+    ("M45", CA, "    bound_age = age if age is not None else _age_days_from_ms(_ms(nc.get(\"date_ms\")), now)",
+     "    bound_age = age", "recency bound dies when the display date is unreadable"),
+    ("M46", CA, "    except (ValueError, TypeError, OSError, OverflowError):\n        return None\n    return (now - dt).total_seconds() / 86400.0",
+     "    except (ValueError, TypeError, OSError, OverflowError):\n        return 0\n    return (now - dt).total_seconds() / 86400.0",
+     "an unusable raw ms reads as age 0 (always fresh)"),
+    ("M47", CA, "    if ms is None:\n        return None\n    try:\n        dt = datetime.fromtimestamp(ms / 1000, tz=timezone.utc)",
+     "    if True:\n        return None\n    try:\n        dt = datetime.fromtimestamp(ms / 1000, tz=timezone.utc)",
+     "the ms-based bound never answers"),
+    ("M48", CA, "        if others:\n            line +=", "        if not others:\n            line +=",
+     "invert the other-coverage branch"),
+    ("M49", CA, "        others = disagreements([r], now)", "        others = []",
+     "always claim the report is silent about the ticket"),
+    ("M50", CA, "                       [f\"🔴 {BOT_IDENTITY_CAVEAT}\"] + [f\"ℹ️  {n}\" for n in notes]))",
+     "                       [f\"ℹ️  {n}\" for n in notes]))", "drop the caveat preamble"),
+    ("M51", CA, "                       [f\"🔴 {BOT_IDENTITY_CAVEAT}\"] + [f\"ℹ️  {n}\" for n in notes]))",
+     "                       [f\"ℹ️  {n}\" for n in notes] + [f\"🔴 {BOT_IDENTITY_CAVEAT}\"]))",
+     "the caveat trails the block instead of leading it"),
+    ("M52", CA, "        for heading, lines in report_blocks(results):\n            print(f\"\\n{heading}\\n\")\n            for line in lines:\n                print(line)",
+     "        pass", "delete main()'s entire print loop"),
+    ("M53", CA, "        for heading, lines in report_blocks(results):",
+     "        for heading, lines in report_blocks(results)[:1]:", "print only the first block"),
+    ("M54", CA, "    flags = disagreements(results, now)", "    flags = disagreements(results)",
+     "report_blocks drops `now` on the flags producer"),
+    ("M55", CA, "    notes = suppressed_notes(results, now)", "    notes = suppressed_notes(results)",
+     "report_blocks drops `now` on the notes producer"),
+    ("M56", CA, "    if (not reply_unreported and bound_age is not None\n            and _reply_answers_the_comment(nc, now) is True):",
+     "    if (not reply_unreported\n            and _reply_answers_the_comment(nc, now) is True):",
+     "emit a note whose recency bound could not be evaluated at all"),
+
+    # ---------- round 8: the invariants nothing pinned. M-SCOPE is the one a blind re-audit
+    # found surviving a green sweep — it reverts round 7b's headline fix, and the guard
+    # written for that fix could not see it because every fixture passed a single-record list.
+    ("M-SCOPE", CA, "        others = disagreements([r], now)", "        others = disagreements(results, now)",
+     "the other-coverage sentence stops being scoped to its own ticket"),
+    ("N7", CA, "        seen = f\"{age:.0f}d ago\" if age is not None else f\"at {nc.get('date')!r} (unreadable)\"",
+     "        seen = f\"{bound_age:.0f}d ago\" if bound_age is not None else f\"at {nc.get('date')!r} (unreadable)\"",
+     "the NOTE displays an age derived from the raw ms"),
+    ("N8", CA, "    if age is None:\n        head += (f\" (comment date {nc.get('date')!r} was unreadable, so its age is unknown \"",
+     "    if bound_age is None:\n        head += (f\" (comment date {nc.get('date')!r} was unreadable, so its age is unknown \"",
+     "the FLAG head displays an age derived from the raw ms"),
+    ("N9", CA, "    if bound_age is not None and bound_age > UNANSWERED_COMMENT_DAYS:",
+     "    if bound_age is not None and bound_age >= UNANSWERED_COMMENT_DAYS:",
+     "the recency bound becomes inclusive"),
+    ("N10", CA, "UNANSWERED_COMMENT_DAYS = 14", "UNANSWERED_COMMENT_DAYS = 28",
+     "silently double the recency window"),
+    ("N11", CA, "    bound_age = age if age is not None else _age_days_from_ms(_ms(nc.get(\"date_ms\")), now)",
+     "    bound_age = age if age is not None else _age_days_from_ms(nc.get(\"date_ms\"), now)",
+     "drop the `_ms` type gate on the bound fallback"),
+    ("N12", CA, "    except (ValueError, TypeError, OSError, OverflowError):",
+     "    except (ValueError, OSError, OverflowError):",
+     "a string raw-ms raises an uncaught TypeError"),
+
+    # ---------- POSITIVE CONTROL. A mutant round 6 proved is caught; if this ever reports
+    # SURVIVED the harness is broken, not the code.
+    ("PC", CA, '    reply_unreported = "my_latest_reply" not in nc', "    reply_unreported = False",
+     "POSITIVE CONTROL — flatten absent vs reported"),
+]
+
+# M36 is a MOVE, not a substitution, so it is applied by hand below rather than by pattern.
+# The tuple above carries a sentinel `old` that never matches; `run` special-cases the id.
+_BOUND = ("    bound_age = age if age is not None else _age_days_from_ms(_ms(nc.get(\"date_ms\")), now)\n"
+          "    if bound_age is not None and bound_age > UNANSWERED_COMMENT_DAYS:\n"
+          "        return None, None\n")
+_AFTER_NOTE = ("            f\"is still waiting for a human — read the thread before treating "
+               "this as handled.\")\n")
+
+
+def _apply(body, mid, old, new):
+    """Return the mutated source, or None if the mutant no longer applies."""
+    if mid == "NULL-CONTROL":
+        return body
+    if mid == "M36":
+        if body.count(_BOUND) != 1 or body.count(_AFTER_NOTE) != 1:
+            return None
+        body = body.replace(_BOUND, "")
+        return body.replace(_AFTER_NOTE, _AFTER_NOTE + "\n" + _BOUND)
+    if body.count(old) != 1:
+        return None
+    return body.replace(old, new)
+
+
+def run_one(mid, fname, old, new, note, workdir):
+    dst = Path(workdir) / mid
+    shutil.copytree(SKILL, dst, ignore=shutil.ignore_patterns("__pycache__", ".pytest_cache"))
+    for name in EXCLUDED_FROM_MUTANT_RUNS:
+        (dst / "tests" / name).unlink(missing_ok=True)
+    target = dst / fname
+    mutated = _apply(target.read_text(), mid, old, new)
+    if mutated is None:
+        return "NOT APPLIED", []
+    target.write_text(mutated)
+    env = dict(os.environ, PYTHONDONTWRITEBYTECODE="1")
+    proc = subprocess.run([sys.executable, str(dst / "tests" / "run_all.py")],
+                          capture_output=True, text=True, env=env)
+    killers = re.findall(r"^  ✗ (\S+?):", proc.stdout, re.M)
+    total = re.search(r"Total: (\d+) passed, (\d+) failed", proc.stdout)
+    if not total:
+        # No verdict line at all is a DEAD RUN, never a pass — the runner's own docstring
+        # says so, and an absent line reads as empty output through any filter.
+        return "NO VERDICT", killers
+    return ("KILLED" if int(total.group(2)) else "SURVIVED"), killers
+
+
+def main(argv):
+    if "--list" in argv:
+        for mid, fname, _o, _n, note in MUTANTS:
+            print(f"{mid:8s} {fname:20s} {note}")
+        return 0
+    strict = "--check" in argv
+    wanted = [a for a in argv if not a.startswith("--")]
+    selected = [m for m in MUTANTS if not wanted or m[0] in wanted]
+    if wanted and len(selected) != len(set(wanted)):
+        print(f"unknown mutant id in {wanted}", file=sys.stderr)
+        return 2
+
+    bad = []
+    with tempfile.TemporaryDirectory(prefix="ccua-sweep-") as workdir:
+        # 🔴 NEGATIVE CONTROL ON THE HARNESS, run FIRST and fatal. It copies the skill and
+        # mutates NOTHING, so the only honest verdict is SURVIVED. A `KILLED` here means the
+        # suite is red inside the temp copy for a reason that has nothing to do with any
+        # mutant — and then every row below reads KILLED for free, which is a fully green
+        # sweep that proves nothing. That is not hypothetical: it is what the first run of
+        # this file did, because a repo-hygiene gate cannot resolve the repo from a copy.
+        # See EXCLUDED_FROM_MUTANT_RUNS.
+        verdict, killers = run_one("NULL-CONTROL", CA, "", "", "no mutation", workdir)
+        print(f"{'NULL-CTL':8s} {verdict:11s} no mutation — MUST be SURVIVED")
+        if verdict != "SURVIVED":
+            for k in killers[:5]:
+                print(f"          red without any mutation: {k}")
+            print("\nABORTED: the suite is not green inside a fresh copy, so every mutant "
+                  "below would score KILLED whatever it did. Fix the harness, not the code.",
+                  file=sys.stderr)
+            return 2
+
+        for mid, fname, old, new, note in selected:
+            verdict, killers = run_one(mid, fname, old, new, note, workdir)
+            if verdict != "KILLED":
+                bad.append((mid, verdict))
+            print(f"{mid:8s} {verdict:11s} {note}")
+            for k in killers[:3]:
+                print(f"          killed by: {k}")
+            if len(killers) > 3:
+                print(f"          ... and {len(killers) - 3} more")
+            sys.stdout.flush()
+
+    print(f"\n{len(selected)} mutant(s); non-KILLED: {len(bad)}")
+    for mid, verdict in bad:
+        print(f"  {mid}: {verdict}")
+    # `NOT APPLIED` fails under --check because a stale mutant is not a pass: the code moved
+    # out from under it, and nobody notices a verdict that looks like every other one.
+    return 1 if (bad and strict) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-clickup-addressed/tests/test_bounds_and_parsing.py
+++ b/scripts/check-clickup-addressed/tests/test_bounds_and_parsing.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Round 8 (2026-08-22). Three invariants the prose GUARANTEED and nothing pinned, plus the
+parser robustness a one-token mutant exposed.
+
+⚠️ THESE ARE MUTATION-COVERAGE GUARDS, NOT REGRESSION COVERAGE — and the label needs one
+extra sentence here that upstream did not need. Upstream these are literally green at its
+base, because its base already carries the round-7 code they cover. **Measured against THIS
+repo's pre-port `main`, four of the five below are RED** — with `AttributeError: module
+'check_addressed' has no attribute 'suppressed_notes' / '_age_days_from_ms'`. That red is the
+code being ABSENT, not the code being wrong: pre-port `main` never reaches these cases at all,
+so a red here is not evidence that anything was fixed. **Do not count them in the port's
+regression matrix.** What they are for is the mutants: each one below SURVIVED the full
+battery of the round that introduced the code it covers, on a tree where the behaviour was
+already correct.
+
+  * scoping — `disagreements([r], now)` -> `disagreements(results, now)` in `suppressed_notes`.
+    The guard written for that sentence only ever passed a single-record list, so it was
+    structurally blind to the very thing the sentence claims.
+  * the DISPLAY half of the two-ages split — reporting `bound_age` where `age` belongs
+    survived, so a record with an unreadable display date would print a confident "Nd ago"
+    derived from a field the formatter rejected. The decision half was well pinned; the
+    display half, which is the stated REASON for having two, was not.
+  * `UNANSWERED_COMMENT_DAYS` — `>` -> `>=` AND `> 14` -> `> 28` both survived, because the
+    fixtures sat at 13 and 30 and 30 is more than 2x the constant. 🔴 A fixture that
+    overshoots by a MULTIPLE of the step cannot see a doubling mutant. The cases below
+    overshoot deliberately (20) and include one exactly ON the boundary (14.0).
+
+🔴 NOT PORTED, deliberately: the upstream copy of this file opens with a scan-less-run
+ANNOUNCEMENT — one line per run saying that the two transcript-gated rules could not fire —
+because upstream made the transcript scan opt-in. This tool has no such flag: `main()` always
+runs search-sessions.py and check-completion.py, no record ever carries a `not_scanned`
+status, and `mentions_found` is always present. Porting the announcement would add a branch
+no input here can reach, and an unreachable guard reads as protection while providing none.
+The same goes for the `"mentions_found" in r` gate its sibling puts on the "open signals
+remain" flag: that gate exists to stop an UNSEARCHED zero firing it, and there is no
+unsearched zero here. If a `--transcripts` opt-in ever lands, both are required in the same
+commit.
+"""
+import importlib.util
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.parent
+spec = importlib.util.spec_from_file_location("check_addressed", SCRIPT_DIR / "check-addressed.py")
+check_addressed = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check_addressed)
+
+NOW = datetime(2026, 8, 22, 12, 0, tzinfo=timezone.utc)
+FMT = check_addressed.COMMENT_DATE_FMT
+
+
+def _fmt(dt):
+    return dt.strftime(FMT)
+
+
+def _ms(dt):
+    return int(dt.timestamp() * 1000)
+
+
+def _rec(tid="868gz0hhh", days=2, reply_days=None, status="to do", date_str=None, date_ms=True):
+    """A `task_status` record, carrying both the display strings and the raw epoch-ms."""
+    their = NOW - timedelta(days=days)
+    nc = {"date": date_str if date_str is not None else _fmt(their),
+          "author": "Robin Example", "snippet": "a question", "text": "a question"}
+    if date_ms:
+        nc["date_ms"] = _ms(their)
+    if reply_days is not None:
+        mine = NOW - timedelta(days=reply_days)
+        nc["my_latest_reply"] = _fmt(mine)
+        nc["my_latest_reply_ms"] = _ms(mine)
+    else:
+        nc["my_latest_reply"] = None
+    return {"task_id": tid, "status": "no_mentions_found", "sessions_searched": 1,
+            "mentions_found": 0, "clickup_status": status, "clickup_priority": "high",
+            "newest_comment": nc, "completion": [], "open": []}
+
+
+def _flags(*recs):
+    return check_addressed.disagreements(list(recs), now=NOW)
+
+
+def _waiting(*recs):
+    return [f for f in _flags(*recs) if "WAITING" in f]
+
+
+def _notes(*recs):
+    return check_addressed.suppressed_notes(list(recs), now=NOW)
+
+
+def test_the_other_coverage_sentence_is_scoped_to_ITS_OWN_ticket():
+    """MUTATION-COVERAGE GUARD (see the module docstring: red against pre-port `main` only
+    because the code is ABSENT there, so it is NOT regression coverage). 🔴 A SURVIVING MUTANT:
+    `disagreements([r], now)` -> `disagreements(results, now)`.
+
+    This is the crux of the finding that produced the sentence at all. Under the mutant, ONE
+    flagged ticket anywhere in the report makes EVERY suppression note claim that "'Needs a
+    decision' above ALSO carries a line about this ticket" — a false statement about a
+    different ticket, which is the same species of defect as the claim it replaced.
+
+    The guard written for it only ever passed a SINGLE-record list, so it could not observe
+    scoping at all; the only multi-record path never asserted the sentence. **A guard whose
+    fixture cannot express the failure is not narrower than its docstring — it is blind to it.**
+    """
+    flagged = _rec(tid="868gx0aaa", status="blocked")             # unknown status -> a flag
+    answered = _rec(tid="868gx0bbb", reply_days=0.5)              # answered, nothing else
+    notes = _notes(flagged, answered)
+    assert len(notes) == 1, f"expected one note (for the answered ticket only): {notes}"
+    assert "868gx0bbb" in notes[0], f"the note is about the wrong ticket: {notes[0]}"
+    assert "no other flag names this ticket" in notes[0].lower(), (
+        "the note claimed another block carries a line about ITS ticket, when the only flag "
+        f"in the report is about a DIFFERENT one: {notes[0]}")
+
+    # And the true direction, in the same report: a ticket that IS flagged elsewhere says so.
+    both = _rec(tid="868gx0aaa", status="blocked", reply_days=0.5)
+    notes = _notes(both, _rec(tid="868gx0zzz", reply_days=0.5))
+    by_tid = {n.split(":")[0]: n.lower() for n in notes}
+    assert "also carries a line about this ticket" in by_tid["868gx0aaa"], \
+        f"a ticket that IS flagged above did not say so: {by_tid['868gx0aaa']}"
+    assert "no other flag names this ticket" in by_tid["868gx0zzz"], \
+        f"a ticket flagged nowhere claimed it was: {by_tid['868gx0zzz']}"
+
+
+def test_the_DISPLAY_age_never_comes_from_the_raw_ms():
+    """MUTATION-COVERAGE GUARD (see the module docstring: red against pre-port `main` only
+    because the code is ABSENT there, so it is NOT regression coverage). 🔴 A SURVIVING MUTANT: report `bound_age`
+    where `age` belongs, in both report lines.
+
+    The two-ages split exists precisely so a DECISION can use the raw ms while the DISPLAY
+    stays honest about the `date` field the reader is looking at. Only the decision half was
+    pinned, so printing a confident "Commented 2d ago" over a date the formatter REJECTED
+    survived the suite — a number attributed to a field that never produced it.
+
+    The corpus cannot see this: `_verdict` classifies ANSWERED off the note's existence, not
+    its text, so both sides score identically there.
+    """
+    # the WAITING head
+    r = _rec(days=2, date_str="99999999999999999")
+    flags = _waiting(r)
+    assert flags, "the flag stopped firing on an unreadable display date"
+    assert "unreadable" in flags[0].lower(), \
+        f"the head did not admit the date field was unreadable: {flags[0]}"
+    assert "commented 2d ago" not in flags[0].lower(), (
+        "the head printed a confident age derived from `date_ms` while claiming to describe "
+        f"the `date` field the formatter rejected: {flags[0]}")
+
+    # the suppression note
+    note = _notes(_rec(days=2, reply_days=0.5, date_str="99999999999999999"))
+    assert len(note) == 1, f"expected one note: {note}"
+    assert "unreadable" in note[0].lower() and "2d ago" not in note[0].lower(), (
+        f"the note printed a raw-ms age as though the display date had produced it: {note[0]}")
+
+
+def test_the_recency_bound_is_pinned_ON_its_boundary_and_at_an_overshoot():
+    """MUTATION-COVERAGE GUARD (see the module docstring: red against pre-port `main` only
+    because the code is ABSENT there, so it is NOT regression coverage). 🔴 TWO SURVIVING MUTANTS at one constant:
+    `>` -> `>=`, and `> 14` -> `> 28`.
+
+    The old fixtures sat at 13 and 30 days. 13 cannot see `>=`; 30 is more than 2x14, so a
+    DOUBLING mutant passes straight through the gap between them. "The note is bounded by
+    recency" is the design argument for this entire block, and it could be silently widened
+    with a green suite.
+
+    Three points, chosen so no single mutation satisfies all of them: exactly ON the boundary
+    (14.0 -> fires, kills `>=`), just past it (14.5 -> silent), and an overshoot that is NOT a
+    multiple of the step (20 -> silent, kills `> 28`).
+    """
+    assert _waiting(_rec(days=14)), (
+        f"a comment exactly {check_addressed.UNANSWERED_COMMENT_DAYS}d old was treated as "
+        "stale — the bound is exclusive, and a comment ON the boundary is inside it")
+    assert _waiting(_rec(days=14.5)) == [], "a comment past the bound was still flagged"
+    assert _waiting(_rec(days=20)) == [], \
+        "a 20-day-old comment was flagged, so the bound is wider than it says it is"
+    # the note inherits the same bound, at the same three points
+    assert _notes(_rec(days=14, reply_days=13.9))
+    assert _notes(_rec(days=14.5, reply_days=14.4)) == []
+    assert _notes(_rec(days=20, reply_days=19)) == []
+
+
+def test_age_from_ms_survives_a_value_that_is_not_a_number():
+    """🔴 A SURVIVING MUTANT: drop the `_ms()` call in the `bound_age` fallback.
+
+    Under it a STRING `date_ms` from a drifted producer reaches `ms / 1000` and raises
+    `TypeError`, which was NOT in this function's except tuple — the whole report crashes on a
+    malformed field. `TypeError` is now caught here rather than at the call site: the parser is
+    the right place to be robust, one rule in one place.
+    """
+    assert check_addressed._age_days_from_ms("1755800000000", NOW) is None, \
+        "a string raw-ms crashed or was accepted as an instant"
+    assert check_addressed._age_days_from_ms(None, NOW) is None
+    assert check_addressed._age_days_from_ms(99999999999999999, NOW) is None, \
+        "an out-of-range epoch was accepted as an instant (fromtimestamp raises ValueError)"
+    real = check_addressed._age_days_from_ms(int((NOW - timedelta(days=3)).timestamp() * 1000), NOW)
+    assert real is not None and abs(real - 3.0) < 0.01, \
+        f"a usable epoch did not yield its age — positive control failed: {real}"
+
+
+def test_a_bool_raw_ms_does_not_date_the_comment_to_1970():
+    """⚠️ BY-CONSTRUCTION, and it is what makes `_ms()` load-bearing in the bound fallback.
+
+    `isinstance(True, int)` is True, so without `_ms` a JSON `true` divides to 0.001s — 1970 —
+    and the bound trips, silently dropping a recent comment. No producer writes a bool here;
+    the guard is kept because its failure is quiet and wrong rather than loud, and pinned at
+    the record level because that is where the fallback reads it.
+    """
+    r = _rec(days=2)
+    r["newest_comment"]["date"] = "99999999999999999"     # force the fallback
+    r["newest_comment"]["date_ms"] = True
+    assert _waiting(r), \
+        "a boolean raw-ms dated the comment to 1970 and the recency bound dropped it"

--- a/scripts/check-clickup-addressed/tests/test_own_reply_answers.py
+++ b/scripts/check-clickup-addressed/tests/test_own_reply_answers.py
@@ -88,6 +88,34 @@ def _waiting_flags(r):
     return [f for f in check_addressed.disagreements([r], now=NOW) if "WAITING" in f]
 
 
+def _collect_with(fake_comments, my_id, capture_stderr=None):
+    """Run the producer end to end over a stubbed ClickUp, returning the JSON rows.
+
+    A helper rather than a third copy of the same stubbing dance: three tests now drive
+    `_collect`, and a copied fixture is how two of them end up exercising different code
+    while reading identically. `my_id=None` is the failed-user-lookup case.
+    """
+    orig = (recent_comments.get_my_user_id, recent_comments.get_my_tasks,
+            recent_comments.get_comments)
+    try:
+        recent_comments.get_my_user_id = lambda: my_id
+        recent_comments.get_my_tasks = lambda: [{"id": "868gz0hhh", "name": "t"}]
+        recent_comments.get_comments = fake_comments
+        buf, err = io.StringIO(), io.StringIO()
+        real_out, real_err = sys.stdout, sys.stderr
+        sys.stdout, sys.stderr = buf, err
+        try:
+            recent_comments._collect(10, False, True)
+        finally:
+            sys.stdout, sys.stderr = real_out, real_err
+    finally:
+        (recent_comments.get_my_user_id, recent_comments.get_my_tasks,
+         recent_comments.get_comments) = orig
+    if capture_stderr is not None:
+        capture_stderr.append(err.getvalue())
+    return json.loads(buf.getvalue())
+
+
 # --------------------------------------------------------------------------- D12
 
 def test_my_own_later_reply_suppresses_the_waiting_flag():
@@ -209,14 +237,68 @@ def test_latest_reply_by_returns_none_when_i_never_commented():
         "reported a reply from me on a thread I never commented on"
 
 
-def test_latest_reply_by_ignores_an_unparseable_date():
-    """A malformed date must not win the max() and must not crash the fetch."""
+def test_an_unreadable_own_date_yields_UNIDENTIFIED_not_an_older_reply():
+    """🔴 ROUND 7. Red at base — base returns the OLDER reply and the flag says "answered".
+
+    This test replaces `test_latest_reply_by_ignores_an_unparseable_date`, which pinned the
+    `continue` that IS the defect. Its two claims survive: a malformed date must not win the
+    ranking, and it must not crash the fetch. What changed is the third, unstated one — that
+    skipping it is safe. It is not: if the unreadable date belongs to my NEWEST comment, the
+    loop returns an OLDER reply of mine (or `None` when it is my only one), and `None` is the
+    POSITIVE claim "I looked; you never replied". Round 6's own comment on `UNIDENTIFIED`
+    names that exact property as the one this seam exists to protect; an unreadable date
+    defeats it on a different input.
+
+    The sentinel is right and "skip it" is wrong because an unreadable date has NO POSITION in
+    the ranking — there is no evidence it is not the newest — so "which of my comments is
+    newest" is genuinely unknowable, not merely unknown for one row.
+    """
     comments = [
         {"user": {"id": "7"}, "date": "not-a-timestamp"},
         {"user": {"id": "7"}, "date": "1755800000000"},
     ]
-    assert recent_comments.latest_reply_by(comments, "7") == \
-        recent_comments.format_date("1755800000000")
+    got = recent_comments.latest_reply_by(comments, "7")
+    assert got is recent_comments.UNIDENTIFIED, (
+        "an unreadable date on one of MY comments was skipped and an older reply reported as "
+        f"my newest: {got!r}")
+    # The two claims the replaced test made, kept: garbage never wins, and no exception.
+    assert got != recent_comments.format_date("not-a-timestamp")
+
+
+def test_an_unreadable_own_date_reaches_the_ANNOUNCE_branch_end_to_end():
+    """The seam, not the part. The sentinel is worthless unless it survives to the consumer.
+
+    `build_record` omits the key for UNIDENTIFIED and `_waiting_on_a_human` then announces
+    rather than deciding — the same path a failed user-id lookup takes. Pinned end to end
+    because every link is individually correct at base and the fix is still inert if
+    `_collect` formats the sentinel into a string on the way past (`format_date` returns
+    `str(ts_ms)` for anything it cannot parse, which is truthy and looks like a date).
+    """
+    def fake_comments(_tid):
+        return [
+            {"user": {"id": "9", "username": "Robin Example"},
+             "date": "1755800000000", "comment": [{"text": "a question"}]},
+            {"user": {"id": "7", "username": "me"},
+             "date": "corrupted", "comment": [{"text": "my answer"}]},
+        ]
+
+    rows = _collect_with(fake_comments, my_id="7")
+    assert rows, "no rows emitted"
+    assert "my_latest_reply" not in rows[0], (
+        "an unrankable set of my own comments was reported as a definite reply date or as a "
+        f"definite absence of one: {rows[0]}")
+    assert "my_latest_reply_ms" not in rows[0], \
+        f"a raw ms was emitted without the formatted date it refines: {rows[0]}"
+
+    r = _rec()
+    r["newest_comment"] = dict(check_addressed.build_newest_comment(rows[0]),
+                               date=_at(2), author="Robin Example")
+    flags = _waiting_flags(r)
+    assert flags and "not reported" in " ".join(flags).lower(), (
+        f"the absent key did not reach the announce branch end-to-end: {flags}")
+    assert "nobody has answered" not in " ".join(flags).lower(), (
+        "claimed nobody answered while the evidence that would refute it was unreadable: "
+        f"{flags}")
 
 
 def test_build_record_carries_my_latest_reply():
@@ -226,9 +308,17 @@ def test_build_record_carries_my_latest_reply():
     """
     r = recent_comments.build_record(
         "868gz0hhh", "name", {}, {"user": {"username": "Robin Example"}, "date": "1755900000000"},
-        "some text", "2026-08-22 01:04")
+        "some text", "2026-08-22 01:04", 1755819840000)
     assert r.get("my_latest_reply") == "2026-08-22 01:04", \
         f"build_record dropped my_latest_reply, so the fix cannot reach the flag: {r}"
+    # ROUND 7: the raw ms beside it, for BOTH sides. Dropping either one is invisible in the
+    # report — the comparison silently falls back to minute resolution — so both are pinned
+    # here for the same reason `text` and `my_latest_reply` are.
+    assert r.get("my_latest_reply_ms") == 1755819840000, \
+        f"build_record dropped my reply's raw ms, so the sub-minute fix is inert: {r}"
+    assert r.get("date_ms") == 1755900000000, (
+        "build_record dropped the comment's own raw ms — comparing one raw instant against a "
+        f"minute-rounded one is worse than comparing two rounded ones: {r}")
 
 
 def test_build_record_EMITS_the_key_for_a_genuine_absence_of_replies():
@@ -249,11 +339,18 @@ def test_build_record_EMITS_the_key_for_a_genuine_absence_of_replies():
     """
     r = recent_comments.build_record(
         "868gz0hhh", "name", {}, {"user": {"username": "Robin Example"}, "date": "1755900000000"},
-        "some text", None)
+        "some text", None, None)
     assert "my_latest_reply" in r, (
         "a genuine 'no reply from me' lost the key, so the consumer will announce that the "
         f"check never ran instead of reporting that nobody answered: {r}")
     assert r["my_latest_reply"] is None, f"expected a reported null, got {r['my_latest_reply']!r}"
+    # ROUND 7. The ms is PRECISION, not evidence, and the two must not be confused: there is
+    # no reply, so there is no instant to refine, and the key is absent rather than null.
+    # `my_latest_reply` carries the absent-vs-null distinction ALONE — duplicating it into a
+    # second field is two chances for the record to contradict itself.
+    assert "my_latest_reply_ms" not in r, (
+        "a raw ms was invented for a reply that does not exist, giving the record two fields "
+        f"that can disagree about whether I replied: {r}")
 
 
 def test_collect_computes_the_reply_over_the_UNFILTERED_comment_list():
@@ -266,8 +363,6 @@ def test_collect_computes_the_reply_over_the_UNFILTERED_comment_list():
     here. That is this skill's own headline defect class: a seam no single-component test
     owns.
     """
-    calls = {}
-
     def fake_comments(_tid):
         return [
             {"user": {"id": "9", "username": "Robin Example"},
@@ -276,28 +371,20 @@ def test_collect_computes_the_reply_over_the_UNFILTERED_comment_list():
              "date": "1755900000000", "comment": [{"text": "my answer"}]},
         ]
 
-    orig = (recent_comments.get_my_user_id, recent_comments.get_my_tasks,
-            recent_comments.get_comments)
-    try:
-        recent_comments.get_my_user_id = lambda: "7"
-        recent_comments.get_my_tasks = lambda: [{"id": "868gz0hhh", "name": "t"}]
-        recent_comments.get_comments = fake_comments
-        buf = io.StringIO()
-        real_stdout, sys.stdout = sys.stdout, buf
-        try:
-            recent_comments._collect(10, False, True)
-        finally:
-            sys.stdout = real_stdout
-        calls = json.loads(buf.getvalue())
-    finally:
-        (recent_comments.get_my_user_id, recent_comments.get_my_tasks,
-         recent_comments.get_comments) = orig
+    calls = _collect_with(fake_comments, my_id="7")
 
     assert len(calls) == 1, f"expected only the colleague's comment to survive: {calls}"
     assert calls[0]["author"] == "Robin Example"
     assert calls[0]["my_latest_reply"] == recent_comments.format_date("1755900000000"), (
         "_collect did not report my reply — the reply must be computed over the FULL "
         f"comment list, before mine are discarded: {calls[0]}")
+    # ROUND 7: the same join for the raw ms, at the same seam. `_collect` is the only code
+    # that pairs the formatted date with its own ms; taking them from two lookups would let
+    # them describe two different comments, and nothing in the report would look wrong.
+    assert calls[0]["my_latest_reply_ms"] == 1755900000000, (
+        f"_collect reported my reply's date without the ms it was formatted from: {calls[0]}")
+    assert calls[0]["date_ms"] == 1755800000000, (
+        f"_collect reported the colleague's date without its own raw ms: {calls[0]}")
 
 
 def test_a_failed_user_lookup_omits_the_key_instead_of_claiming_no_reply():
@@ -314,30 +401,15 @@ def test_a_failed_user_lookup_omits_the_key_instead_of_claiming_no_reply():
         return [{"user": {"id": "9", "username": "Robin Example"},
                  "date": "1755800000000", "comment": [{"text": "a question"}]}]
 
-    orig = (recent_comments.get_my_user_id, recent_comments.get_my_tasks,
-            recent_comments.get_comments)
-    try:
-        recent_comments.get_my_user_id = lambda: None          # the failure under test
-        recent_comments.get_my_tasks = lambda: [{"id": "868gz0hhh", "name": "t"}]
-        recent_comments.get_comments = fake_comments
-        buf, err = io.StringIO(), io.StringIO()
-        real_out, real_err = sys.stdout, sys.stderr
-        sys.stdout, sys.stderr = buf, err
-        try:
-            recent_comments._collect(10, False, True)
-        finally:
-            sys.stdout, sys.stderr = real_out, real_err
-        rows = json.loads(buf.getvalue())
-    finally:
-        (recent_comments.get_my_user_id, recent_comments.get_my_tasks,
-         recent_comments.get_comments) = orig
+    errs = []
+    rows = _collect_with(fake_comments, my_id=None, capture_stderr=errs)   # the failure under test
 
     assert rows, "no rows emitted"
     assert "my_latest_reply" not in rows[0], (
         "a FAILED user lookup was reported as 'I looked; you never replied' — the key must be "
         f"absent so the consumer announces rather than decides: {rows[0]}")
-    assert "WARNING" in err.getvalue(), \
-        f"an unidentifiable user produced no warning on stderr: {err.getvalue()!r}"
+    assert "WARNING" in errs[0], \
+        f"an unidentifiable user produced no warning on stderr: {errs[0]!r}"
 
     # And the consumer must actually take the announce branch on that record.
     nc = check_addressed.build_newest_comment(rows[0])
@@ -402,3 +474,480 @@ def test_build_newest_comment_preserves_absent_vs_null():
     absent = check_addressed.build_newest_comment({"date": "d", "author": "a", "snippet": "s"})
     assert "my_latest_reply" not in absent, \
         "an unreported reply was invented as null, claiming the producer looked when it did not"
+
+
+# ======================================================================= ROUND 7
+# Three follow-ups to round 6, each building on its design rather than replacing it:
+#   1. an unreadable date on one of MY comments restored the false positive (above).
+#   2. the tie boundary was a judgement call; the producer HAS the raw ms and threw it away.
+#   3. suppression printed NOTHING, so the bot-identity caveat had nowhere to live.
+
+
+def _ms_at(seconds_after_epoch_ref):
+    """Epoch-ms for a fixed instant, so the sub-minute cases are exact, not clock-derived."""
+    return 1755819600000 + int(seconds_after_epoch_ref * 1000)
+
+
+def _sub_minute_rec(their_offset_s, my_offset_s):
+    """Two comments inside the SAME rendered minute, `their_offset_s` seconds apart.
+
+    Both `date` and `my_latest_reply` render to the identical minute string, so the round-6
+    comparison sees a tie whatever the real order was. The ms fields carry the real order.
+    """
+    base = _ms_at(0)
+    their_ms, my_ms = base + int(their_offset_s * 1000), base + int(my_offset_s * 1000)
+    rendered = recent_comments.format_date(base)
+    r = _rec(comment_days_ago=2)
+    r["newest_comment"].update({
+        "date": rendered, "my_latest_reply": rendered,
+        "date_ms": their_ms, "my_latest_reply_ms": my_ms,
+    })
+    # The recency bound reads the RENDERED date, so pin `now` relative to it rather than to
+    # NOW — otherwise the fixture ages out and every case below goes silent for the wrong
+    # reason. (A silent-for-the-wrong-reason fixture is the vacuous-green shape this file
+    # exists to police.)
+    return r
+
+
+def _flags_at(r, now):
+    return [f for f in check_addressed.disagreements([r], now=now) if "WAITING" in f]
+
+
+def _now_for(r):
+    return datetime.strptime(r["newest_comment"]["date"], "%Y-%m-%d %H:%M").replace(
+        tzinfo=timezone.utc) + timedelta(days=2)
+
+
+def test_a_reply_twenty_seconds_BEFORE_the_question_is_no_longer_read_as_an_answer():
+    """🔴 ROUND 7 REGRESSION. Red at base: base renders both to the same minute and suppresses.
+
+    This is the failure direction that costs something — a colleague's question dropped from
+    the report entirely because a reply I wrote 20 seconds EARLIER rounded onto it. Round 6
+    chose "equal counts as answered" deliberately and correctly for minute-resolution data;
+    the point here is that the data need not be minute-resolution. `recent-comments.py` has
+    the raw epoch-ms and `format_date` throws the seconds away before anything compares them.
+    """
+    r = _sub_minute_rec(their_offset_s=30, my_offset_s=10)
+    flags = _flags_at(r, _now_for(r))
+    assert flags, (
+        "a reply written 20 seconds BEFORE the question was counted as answering it — the "
+        "minute rendering made two different instants compare equal")
+
+
+def test_a_reply_forty_seconds_AFTER_the_question_still_suppresses():
+    """INVARIANT GUARD (green at base, for the wrong reason there).
+
+    The mirror of the case above, and the anti-widening control for it: at base this passes
+    because BOTH sides round to the same minute and a tie counts as answered — the right
+    answer from the wrong evidence. Here it passes on the fact. A mutant that inverts the ms
+    comparison flips exactly one of this pair, so the pair is what makes the direction
+    observable; either test alone is satisfied by `mine_ms <= theirs_ms`.
+    """
+    r = _sub_minute_rec(their_offset_s=10, my_offset_s=50)
+    assert _flags_at(r, _now_for(r)) == [], (
+        "a reply written 40 seconds AFTER the question did not suppress the flag")
+
+
+def test_a_tie_is_now_a_real_tie_at_the_MILLISECOND():
+    """The boundary itself. `>=` is kept, so an exact tie still counts as answered.
+
+    At minute resolution a "tie" was common and the choice was a judgement call argued in
+    both directions. At millisecond resolution a tie means two comments in the same
+    millisecond, which is a genuine simultaneity and not a rounding artefact — so keeping
+    `>=` cannot move any case round 6 measured, only the sub-minute ones.
+    """
+    r = _sub_minute_rec(their_offset_s=17, my_offset_s=17)
+    assert _flags_at(r, _now_for(r)) == [], \
+        "a reply in the same MILLISECOND as the comment was treated as not-an-answer"
+
+
+def test_a_record_with_no_ms_fields_falls_back_to_the_minute_ages_unchanged():
+    """INVARIANT GUARD (green at base). The fallback is not a legacy path.
+
+    A record from a producer that predates the ms fields — or one whose dates would not parse
+    — must keep round 6's behaviour exactly. Deleting the fallback instead of keeping it would
+    resurrect D12's false positive on every such record while every ms-carrying test stayed
+    green, which is the shape of a fix that only works on the fixtures it was written with.
+    """
+    assert _waiting_flags(_rec(comment_days_ago=2, reply_days_ago=0.46)) == [], \
+        "a record without the raw-ms fields lost suppression entirely"
+    assert _waiting_flags(_rec(comment_days_ago=1, reply_days_ago=5)), \
+        "a record without the raw-ms fields lost the older-reply-is-not-an-answer rule"
+
+
+def test_the_ms_comparison_requires_BOTH_sides_and_falls_back_otherwise():
+    """Comparing one raw instant against a minute-rounded one is worse than comparing two
+    rounded ones: it silently mixes resolutions and the error is invisible in the output.
+
+    So the raw path is taken only when BOTH sides are present. With one side present the
+    record must behave exactly like a record with neither — pinned in the direction that
+    matters, a reply 20s BEFORE the question, where the two paths disagree.
+    """
+    for drop in ("date_ms", "my_latest_reply_ms"):
+        r = _sub_minute_rec(their_offset_s=30, my_offset_s=10)
+        del r["newest_comment"][drop]
+        assert _flags_at(r, _now_for(r)) == [], (
+            f"with only {drop} missing the checker still used the raw ms of the other side, "
+            "comparing a raw instant against a rounded one")
+
+
+def test_ms_reads_ints_only_and_refuses_a_bool():
+    """Directly at the helper. ⚠️ The bool clause is BY-CONSTRUCTION, not an observed input.
+
+    `isinstance(True, int)` is True in Python, so a JSON `true` would otherwise be compared as
+    1 ms — 1970 — making every reply look newer than every question, silently. No producer
+    writes a bool here; the guard is kept because its failure is quiet and wrong rather than
+    loud, and it is pinned here rather than through a record fixture so nobody counts a
+    record-level test as covering it.
+    """
+    assert check_addressed._ms(1755800000000) == 1755800000000
+    assert check_addressed._ms(True) is None, "a JSON `true` was read as 1 millisecond"
+    assert check_addressed._ms("1755800000000") is None, (
+        "a STRING ms was accepted — the consumer's fields are machine-written ints, and a "
+        "string means a drifted producer whose right answer is the age fallback")
+    assert check_addressed._ms(None) is None
+
+
+def test_build_newest_comment_carries_both_raw_ms_fields_and_preserves_absence():
+    """The hand-off, both directions. Dropping either key is INVISIBLE in the report — the
+    comparison silently falls back to minute resolution and every existing test stays green —
+    which is the same way dropping `text` silently reverted the keep-open veto.
+    """
+    nc = check_addressed.build_newest_comment(
+        {"date": "d", "author": "a", "snippet": "s", "my_latest_reply": "m",
+         "date_ms": 111, "my_latest_reply_ms": 222})
+    assert nc.get("date_ms") == 111 and nc.get("my_latest_reply_ms") == 222, (
+        f"a raw ms was dropped at the hand-off, so the sub-minute fix is inert: {nc}")
+    bare = check_addressed.build_newest_comment({"date": "d", "author": "a", "snippet": "s"})
+    assert "date_ms" not in bare and "my_latest_reply_ms" not in bare, (
+        f"an unreported ms was invented, mixing a fabricated instant into the ordering: {bare}")
+
+
+# ------------------------------------------------------- the suppression note (change 3)
+
+def _notes(r, now=NOW):
+    return check_addressed.suppressed_notes([r], now=now)
+
+
+def test_a_suppressed_flag_emits_exactly_one_line_and_the_block_carries_the_caveat():
+    """🔴 ROUND 7 REGRESSION. Red at base: base emits NOTHING when it suppresses.
+
+    ClickUp has no bot identity — measured independently the same day in a sibling tool
+    implementing this same predicate. Every comment posted through the `pk_` token comes back
+    authored as the token's owner, so an AGENT's reply sets `my_latest_reply` and suppresses
+    this flag, and "the owner answered" and "a machine answered as the owner" are the same
+    observable. Suppression printed nothing at all, so the ticket left no trace in the report
+    and the caveat had nowhere to live: a genuinely-waiting colleague, dropped silently, and
+    with the transcripts empty the flag that would have caught it was the one being
+    suppressed. (NOT "`mentions_found == 0` means no other rule covers the ticket" — that
+    non-sequitur was retracted from the note itself; the status, comment and PR rules never
+    read the mention count and can each still flag the ticket.)
+    """
+    r = _rec(comment_days_ago=2, reply_days_ago=0.46)
+    notes = _notes(r)
+    assert len(notes) == 1, f"expected exactly one suppression note, got {notes}"
+    joined = notes[0].lower()
+    assert "868gz0hhh" in notes[0] and "robin example" in joined, \
+        f"the note does not identify the ticket and the person waiting: {notes[0]}"
+    assert "suppressed" in joined, \
+        f"the note does not say a flag was suppressed: {notes[0]}"
+    # The per-line CONSEQUENCE of the caveat stays on every line; the caveat itself is hoisted
+    # to the block. Asserted separately so hoisting cannot quietly take the consequence with
+    # it — a reader who skips the preamble must still see why this line is not "handled".
+    assert "if that reply was an agent's" in joined, \
+        f"the note dropped the consequence of the bot-identity caveat: {notes[0]}"
+
+    # ...and the CAVEAT is in the block, exactly ONCE. It is 199 chars; repeating it per line
+    # put ~11 KB of identical text in a `--limit 20` report, in the one block whose own
+    # justification is that volume is how a block stops being read.
+    lines = dict(check_addressed.report_blocks([r], now=NOW))[check_addressed.ANSWERED_HEADING]
+    carriers = [l for l in lines if "bot identity" in l.lower()]
+    assert len(carriers) == 1, \
+        f"the caveat appears {len(carriers)}x in the block; it must lead it exactly once: {lines}"
+    assert lines[0] is carriers[0], f"the caveat does not LEAD the block: {lines}"
+
+
+def test_the_suppression_note_never_lands_in_the_needs_a_decision_block():
+    """🔴 The whole point of a second block. "Needs a decision" is the one block the reader is
+    told to act on; a line saying "no action needed" belongs elsewhere, and the flag's own
+    recency bound was chosen on exactly this reasoning — a block that fills with lines nobody
+    must act on trains the reader to skip it.
+    """
+    r = _rec(comment_days_ago=2, reply_days_ago=0.46)
+    assert check_addressed.disagreements([r], now=NOW) == [], \
+        "the suppression note leaked into the act-on-this block"
+    blocks = dict(check_addressed.report_blocks([r], now=NOW))
+    assert check_addressed.ANSWERED_HEADING in blocks, \
+        f"the note never reached the report — a producer main() does not print is inert: {blocks}"
+    assert check_addressed.DECISION_HEADING not in blocks, \
+        f"an empty decision block was printed beside it: {blocks}"
+
+
+def test_a_waiting_ticket_produces_a_flag_and_NO_note():
+    """The two verdicts are mutually exclusive, in both directions. A mutant that emits the
+    note unconditionally would otherwise pass every assertion above.
+    """
+    r = _rec(comment_days_ago=2, reply_days_ago=None)
+    assert _waiting_flags(r), "the waiting flag stopped firing on an unanswered ticket"
+    assert _notes(r) == [], f"an unanswered ticket also produced a suppression note: {_notes(r)}"
+
+
+def test_the_note_obeys_the_SAME_recency_bound_as_the_flag_it_replaces():
+    """🔴 Otherwise the note is the permanent noise the bound exists to prevent — worse than
+    the flag, because an answered ticket never changes any input and would print forever.
+
+    Measured at both ends of the bound rather than at one: inside it a note, outside it
+    nothing at all (no flag AND no note). `UNANSWERED_COMMENT_DAYS` is 14. The bound's exact
+    VALUE and its exclusivity are pinned separately, in `test_bounds_and_parsing.py` — 13 and
+    30 cannot see `>=` or a doubling.
+    """
+    inside = _rec(comment_days_ago=13, reply_days_ago=12)
+    assert len(_notes(inside)) == 1, f"a note inside the recency window went missing: {inside}"
+    outside = _rec(comment_days_ago=30, reply_days_ago=29)
+    assert _notes(outside) == [], \
+        "a 30-day-old answered ticket still printed a note — unbounded by construction"
+    assert _waiting_flags(outside) == [], "the recency bound stopped bounding the flag itself"
+
+
+def test_the_note_is_bounded_to_one_line_per_task():
+    """Bounded volume is the property, not just bounded age: three suppressed tasks must give
+    three lines, not a per-comment firehose. The report already samples the N most recent
+    comments, so this composes with that cap rather than multiplying it.
+    """
+    recs = []
+    for tid in ("868gy0ddd", "868gy0eee", "868gy0fff"):
+        r = _rec(comment_days_ago=2, reply_days_ago=0.46)
+        r["task_id"] = tid
+        recs.append(r)
+    notes = check_addressed.suppressed_notes(recs, now=NOW)
+    assert len(notes) == 3, f"expected one line per suppressed task, got {len(notes)}: {notes}"
+    assert len({n.split(":")[0] for n in notes}) == 3, f"lines are not per-task: {notes}"
+
+
+def test_the_act_on_this_block_is_printed_BEFORE_the_no_action_block():
+    """Order is part of the claim, not cosmetics: the first block a reader meets should be
+    the one that asks for something. Membership alone is satisfied by printing the "no action
+    needed" lines first, which is how a reader learns that the report opens with noise.
+    """
+    waiting = _rec(comment_days_ago=2, reply_days_ago=None)
+    answered = _rec(comment_days_ago=2, reply_days_ago=0.46)
+    answered["task_id"] = "868gw0zzz"
+    headings = [h for h, _lines in check_addressed.report_blocks([waiting, answered], now=NOW)]
+    assert headings == [check_addressed.DECISION_HEADING, check_addressed.ANSWERED_HEADING], \
+        f"the report's trailing blocks are in the wrong order: {headings}"
+
+
+def test_main_actually_PRINTS_both_blocks_end_to_end():
+    """🔴 THE SEAM NOBODY OWNED, and it was wider than the extraction admitted.
+
+    Measured on this branch: replacing `main()`'s entire `for heading, lines in
+    report_blocks(results)` loop with `pass` left the whole suite green. The tool's whole
+    trailing output — both blocks, including the WAITING flag and four rounds of work behind
+    it — could be deleted with nothing going red. `report_blocks` was extracted with a
+    docstring claiming it existed "so the WIRING is testable"; extracting it moved the seam up
+    one level rather than closing it, which is this skill's headline defect class wearing the
+    fix for itself as a disguise.
+
+    So: drive `main()` with the ONLY subprocess seam (`run_script`) stubbed and assert on its
+    STDOUT. Two tasks, one waiting and one answered, so both blocks must appear.
+
+    ⚠️ Dates are relative to the WALL CLOCK, because `main()` has no `now` seam — that is the
+    honest shape of an end-to-end test here, and 2 days ago is inside the 14-day bound on
+    every day it can run.
+
+    ⚠️ NOT PORTED from the upstream copy: its second half drives `main()` with the transcript
+    scan OFF and asserts both blocks vanish. This tool has no such flag — `main()` always runs
+    search-sessions.py and check-completion.py — so that half would assert a state that cannot
+    occur here. If a `--transcripts` opt-in ever lands, restore it.
+    """
+    now = datetime.now(timezone.utc)
+    fmt = lambda dt: dt.strftime("%Y-%m-%d %H:%M")
+    ms = lambda dt: int(dt.timestamp() * 1000)
+    theirs, mine = now - timedelta(days=2), now - timedelta(hours=11)
+
+    comments = [
+        {"task_id": "868gz0hhh", "task_name": "unanswered", "task_status": "to do",
+         "task_priority": "high", "date": fmt(theirs), "author": "Robin Example",
+         "snippet": "a question nobody answered", "text": "a question nobody answered",
+         "date_ms": ms(theirs), "my_latest_reply": None},
+        {"task_id": "868gw0zzz", "task_name": "answered", "task_status": "to do",
+         "task_priority": "high", "date": fmt(theirs), "author": "Robin Example",
+         "snippet": "a question I answered", "text": "a question I answered",
+         "date_ms": ms(theirs), "my_latest_reply": fmt(mine), "my_latest_reply_ms": ms(mine)},
+    ]
+
+    def fake_run_script(name, *args):
+        if name == "recent-comments.py":
+            return json.dumps(comments), 0
+        if name == "search-sessions.py":
+            return json.dumps({"sessions": [], "self_runs_skipped": 0,
+                               "self_runs_skipped_ids": []}), 0
+        if name == "check-completion.py":
+            tid = args[args.index("--task") + 1]
+            return json.dumps([{"task_id": tid, "status": "no_mentions_found",
+                                "sessions_searched": 1, "mentions_found": 0,
+                                "completion": [], "open": []}]), 0
+        raise AssertionError(f"main() called an unexpected script: {name}")
+
+    def drive(*argv):
+        orig_run, orig_argv = check_addressed.run_script, sys.argv
+        buf, real_stdout = io.StringIO(), sys.stdout
+        try:
+            check_addressed.run_script = fake_run_script
+            sys.argv = ["check-addressed.py", *argv]
+            sys.stdout = buf
+            check_addressed.main()
+        finally:
+            sys.stdout = real_stdout
+            check_addressed.run_script, sys.argv = orig_run, orig_argv
+        return buf.getvalue()
+
+    out = drive()
+
+    assert check_addressed.DECISION_HEADING in out, \
+        f"main() printed no decision block at all:\n{out[-1500:]}"
+    assert check_addressed.ANSWERED_HEADING in out, \
+        f"main() printed no answered-already block at all:\n{out[-1500:]}"
+    assert "868gz0hhh" in out and "is WAITING" in out, \
+        "the waiting flag never reached stdout"
+    assert "868gw0zzz" in out and "SUPPRESSED" in out, \
+        "the suppression note never reached stdout"
+    assert "bot identity" in out.lower(), "the caveat never reached stdout"
+    # ORDER on the real output, not just in `report_blocks`' return value.
+    assert out.index(check_addressed.DECISION_HEADING) < out.index(check_addressed.ANSWERED_HEADING), \
+        "the no-action block was printed before the act-on-this block"
+
+
+def test_report_blocks_passes_its_now_through_to_BOTH_producers():
+    """A `now` that does not reach a producer silently becomes the WALL CLOCK.
+
+    🔴 This test is written against the wall clock on purpose, and the first version of it was
+    vacuous: it passed `now=2026-08-22`, which is the day the round was written, so dropping
+    the argument changed nothing and both `now`-dropping mutants SURVIVED. A seam test whose
+    two sides agree by coincidence is not a test — it is the agreement that has to be
+    impossible.
+
+    So the records are dated ~100 days in the PAST and `now` is set 2 days after them: honoured,
+    the comment is 2 days old and both blocks appear; ignored, it is ~100 days old, past
+    `UNANSWERED_COMMENT_DAYS`, and the report goes silent. Past, not future — a future comment
+    yields a NEGATIVE age, which does not trip an upper bound, so that direction agrees too.
+    """
+    stamp = datetime.now(timezone.utc) - timedelta(days=98)
+    fmt = lambda dt: dt.strftime("%Y-%m-%d %H:%M")
+
+    def rec(tid, reply):
+        nc = {"date": fmt(stamp - timedelta(days=2)), "author": "Robin Example",
+              "snippet": "q", "text": "q",
+              "my_latest_reply": fmt(stamp - timedelta(days=1)) if reply else None}
+        return {"task_id": tid, "status": "no_mentions_found", "sessions_searched": 1,
+                "mentions_found": 0, "clickup_status": "to do", "newest_comment": nc,
+                "completion": [], "open": []}
+
+    headings = [h for h, _l in check_addressed.report_blocks(
+        [rec("868gz0hhh", False), rec("868gw0zzz", True)], now=stamp)]
+    assert headings == [check_addressed.DECISION_HEADING, check_addressed.ANSWERED_HEADING], (
+        "a producer did not receive report_blocks' `now` and fell back to the wall clock, so "
+        f"the recency bound was applied against the wrong instant: {headings}")
+
+
+def test_a_note_whose_recency_bound_cannot_be_EVALUATED_is_not_printed_at_all():
+    """🔴 The tail of the bound fix. An unbounded no-action line is permanent noise.
+
+    `_epoch_ms` accepts any int; `format_date` rejects an out-of-range one. So a record can
+    carry a `date_ms` that decides the ms comparison while being unusable as an instant — no
+    display age, no ms age, no bound that can ever expire. Measured while porting: a note
+    printed over a comment whose date was `'-99999999999999999'`.
+
+    The flag is the safe fallback and the asymmetry is deliberate: a call to action should
+    survive an unreadable date (round 5 chose to SURFACE rather than assume stale), a "no
+    action needed" line should not. Without this the honest `return None` in
+    `_age_days_from_ms` is indistinguishable from a dishonest `return 0` — both leave the
+    bound unenforced — and a mutant swapping them survives a green suite.
+    """
+    r = _rec(comment_days_ago=2, reply_days_ago=1)
+    r["newest_comment"].update({
+        "date": "-99999999999999999", "date_ms": -99999999999999999,
+        "my_latest_reply": "2019-02-12 20:00", "my_latest_reply_ms": 1550000000000,
+    })
+    assert _notes(r) == [], (
+        "a suppression note was printed with a recency bound that can NEVER expire: "
+        f"{_notes(r)}")
+    flags = _waiting_flags(r)
+    assert flags and "unreadable" in " ".join(flags).lower(), (
+        "the record was dropped entirely instead of falling through to the flag that "
+        f"surfaces the unreadable date: {flags}")
+
+
+# ------------------- holes the mutation sweep opened, and the tests that close them
+
+def test_an_unreadable_comment_date_emits_NO_date_ms_rather_than_a_zero():
+    """🔴 A SURVIVING MUTANT: `_epoch_ms(...) or 0`, and it silently drops waiting humans.
+
+    Zero is 1970, so `mine_ms >= theirs_ms` is true for EVERY reply ever written and the flag
+    is suppressed on any ticket whose comment date the producer could not read. That is the
+    round-6 false positive's mirror — a colleague dropped from the report instead of nagged
+    about — and it survived the whole suite, because every ms fixture used a readable date.
+    An absent ms is not a zero and not a null; both of those are claims, and absence is not.
+    """
+    rec = recent_comments.build_record(
+        "868gz0hhh", "n", {}, {"user": {"username": "x"}, "date": "corrupted"},
+        "some text", "2026-08-22 01:04", 1755819840000)
+    assert "date_ms" not in rec, \
+        f"an unreadable comment date was reported as a definite instant: {rec.get('date_ms')!r}"
+
+    # The behavioural half: prove the absence REACHES the flag and keeps it firing. A guard
+    # nobody can watch fire is indistinguishable from one wired to nothing.
+    nc = check_addressed.build_newest_comment(dict(rec, date=_at(2)))
+    r = _rec()
+    r["newest_comment"] = dict(nc, date=_at(2), author="Robin Example",
+                               my_latest_reply=_at(5))     # my reply PREDATES the question
+    assert _waiting_flags(r), (
+        "a reply older than the question suppressed the flag because the comment's own "
+        "unreadable date had been reported as an instant")
+
+
+def test_build_record_refuses_a_raw_ms_that_is_not_an_int_and_never_orphans_one():
+    """Two invariants of the record shape, both ⚠️ BY-CONSTRUCTION under the real producer.
+
+    `latest_reply_ts_by` only ever returns an int, `None` or the sentinel, so neither arm is
+    reachable through `_collect` today. They are pinned rather than deleted because both
+    failures are SILENT — a string ms is quietly ignored by the consumer and an orphaned ms
+    is a fact about a reply the record does not claim exists — and because `build_record` is
+    called directly by four tests, which is enough of a surface to keep honest.
+    """
+    typed = recent_comments.build_record(
+        "868gz0hhh", "n", {}, {"user": {"username": "x"}, "date": "1755900000000"},
+        "some text", "2026-08-22 01:04", "1755819840000")
+    assert "my_latest_reply_ms" not in typed, (
+        "a STRING was emitted as a raw ms; the consumer reads ints only, so this is a field "
+        f"that exists, looks authoritative and is silently ignored: {typed}")
+
+    orphan = recent_comments.build_record(
+        "868gz0hhh", "n", {}, {"user": {"username": "x"}, "date": "1755900000000"},
+        "some text", recent_comments.UNIDENTIFIED, 1755819840000)
+    assert "my_latest_reply_ms" not in orphan and "my_latest_reply" not in orphan, (
+        "an ms outlived the formatted date it refines — the record now carries a precise "
+        f"instant for a reply it does not claim to have found: {orphan}")
+
+
+def test_a_raw_ms_without_its_formatted_date_does_not_decide_the_question():
+    """🔴 A SURVIVING MUTANT: dropping `not reply_unreported` from the answered branch.
+
+    `build_newest_comment` copies the two ms keys independently of `my_latest_reply`, so a
+    record carrying `my_latest_reply_ms` with NO `my_latest_reply` is reachable at the
+    consumer — a stale or hand-built meta is all it takes. Without the guard the ms alone
+    decides, and the report files an unanswered ticket under "answered already", quoting a
+    reply date of `None`.
+
+    The EVIDENCE field is `my_latest_reply` and the ms is only PRECISION: precision about a
+    fact nobody reported is not evidence, and the announce branch is the only honest answer.
+    """
+    r = _rec(comment_days_ago=2, reply_reported=False)
+    r["newest_comment"]["date_ms"] = 1755819600000
+    r["newest_comment"]["my_latest_reply_ms"] = 1755819900000     # "newer", but of what?
+    flags = _waiting_flags(r)
+    assert _notes(r) == [], \
+        f"an ms with no reply behind it was reported as an answer: {_notes(r)}"
+    assert flags and "not reported" in " ".join(flags).lower(), (
+        "a record whose reply was never reported did not reach the announce branch once a "
+        f"stray ms was present: {flags}")

--- a/scripts/check-clickup-addressed/tests/test_ported_hardening.py
+++ b/scripts/check-clickup-addressed/tests/test_ported_hardening.py
@@ -174,7 +174,7 @@ def test_comment_record_carries_full_text_and_a_truncated_snippet():
     long_text = "y" * 4200 + " do not close"
     rec = recent_comments.build_record(
         "868aaa111", "a task", {}, {"date": "1700000000000", "user": {"username": "x"}},
-        long_text, None)
+        long_text, None, None)
     assert len(rec["snippet"]) == 200, f"display snippet cap moved: {len(rec['snippet'])}"
     assert len(rec["text"]) == 4000, f"analysis cap moved: {len(rec['text'])}"
     assert rec["text"] == long_text[:4000]

--- a/scripts/check-clickup-addressed/tests/test_waiting_corpus.py
+++ b/scripts/check-clickup-addressed/tests/test_waiting_corpus.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""A LABELLED CORPUS OF RECORDS for the WAITING flag, and the score it must not fall below.
+
+🔴 Why a SECOND corpus. `test_corpus.py` scores COMMENT TEXT — it exists because eight rounds
+of the keep-open veto were argued one clever sentence at a time. The waiting flag reads none
+of that text: it reads FIELDS (`mentions_found`, `clickup_status`, `date`, `my_latest_reply`,
+and now two raw-ms fields), so every case in that corpus is blind to it. Three rounds of this
+flag have now been argued from single anecdotes — the live `868gz0hhh` false positive, then
+the tie boundary, argued to opposite conclusions from the SAME evidence by two parallel
+reviews. That is the pattern a scoreboard ended for the veto, and this is the same instrument
+pointed at the other half of the tool.
+
+**When you change the flag, run this first. Add the case that motivated your change, with the
+verdict a human reading the report would give, BEFORE you change any code.**
+
+🔴 THE VERDICT IS READ OFF THE CLAIM, NEVER OFF WHETHER SOMETHING FIRED. "The flag fired" is
+satisfied by four different lines that tell a reader four different things — that nobody has
+answered, that the own-reply check never ran, that the date was unreadable — and this skill's
+own audit found a guard asserting mere truthiness while its docstring claimed a relationship,
+which let a fix-reverting mutant survive a green suite. `_verdict` therefore classifies on the
+sentence the reader acts on.
+
+Every fixture here is SYNTHETIC — see `tests/test_no_real_identifiers.py`, the ledger gate
+this repo is public for. The SHAPES are what came from measurement: the live 868gz0hhh
+record, the round-6 fixtures, the disputed sub-minute boundary, and the ClickUp bot-identity
+finding of 2026-08-22.
+"""
+import importlib.util
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.parent
+spec = importlib.util.spec_from_file_location("check_addressed", SCRIPT_DIR / "check-addressed.py")
+check_addressed = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check_addressed)
+
+spec2 = importlib.util.spec_from_file_location("recent_comments", SCRIPT_DIR / "recent-comments.py")
+recent_comments = importlib.util.module_from_spec(spec2)
+spec2.loader.exec_module(recent_comments)
+
+NOW = datetime(2026, 8, 22, 12, 0, tzinfo=timezone.utc)
+SNIPPET = "Follow-up from the reporter, asking for a status update"
+
+# The four claims the report can make about one task, plus silence.
+WAITING = "WAITING"          # "…nobody has answered. Read it."
+ANNOUNCE = "ANNOUNCE"        # fired, but says the own-reply check did not run
+UNREADABLE = "UNREADABLE"    # fired, but says the comment date could not be read
+ANSWERED = "ANSWERED"        # suppressed, and SAID SO in the answered-already block
+SILENT = "SILENT"            # nothing printed about this task at all
+LABELS = (WAITING, ANNOUNCE, UNREADABLE, ANSWERED, SILENT)
+
+# Measured against the shipped implementation: 21/21, no known failures. Raising this is
+# progress; a change that lowers it is a regression however it reads. Against the pre-port
+# tree the same 21 cases score 10 — the eleven it fails are listed in
+# `claude/skills/check-clickup-addressed/reference/validation-history.md`, not here, because a
+# KNOWN_FAILURES set on a corpus that has none is an invitation to add one.
+MIN_SCORE = 21
+
+
+def _fmt(dt):
+    return dt.strftime(check_addressed.COMMENT_DATE_FMT)
+
+
+def _ms(dt):
+    return int(dt.timestamp() * 1000)
+
+
+def _rec(their, mine=None, reply_reported=True, with_ms=True, their_ms=True, mine_ms=True,
+         status="to do", mentions=0, date_str=None):
+    """One `task_status` record in the shape check-addressed.py builds from a live run.
+
+    `their` / `mine` are instants; the record carries the MINUTE-rendered strings the report
+    displays, plus the raw epoch-ms `recent-comments.py` formatted them from. The three ms
+    switches exist because the mixed case — one side raw, one side rounded — is a distinct
+    hazard from having neither, and a corpus that cannot express it cannot score it.
+    """
+    nc = {"date": date_str if date_str is not None else _fmt(their),
+          "author": "Robin Example", "snippet": SNIPPET, "text": SNIPPET}
+    if with_ms and their_ms:
+        nc["date_ms"] = _ms(their)
+    if reply_reported:
+        nc["my_latest_reply"] = _fmt(mine) if mine is not None else None
+        if with_ms and mine_ms and mine is not None:
+            nc["my_latest_reply_ms"] = _ms(mine)
+    r = {"task_id": "868gz0hhh", "status": "no_mentions_found", "sessions_searched": 1,
+         "clickup_status": status, "clickup_priority": "high",
+         "newest_comment": nc, "completion": [], "open": []}
+    if mentions is not None:
+        r["mentions_found"] = mentions
+    return r
+
+
+def _rec_via_producer(my_date_raw, their_ms_raw="1755819600000"):
+    """A record built by the REAL producer chain, not hand-written.
+
+    `latest_reply_ts_by` -> `build_record` -> `build_newest_comment`, so the case scores the
+    seam rather than one side of it. Used for the unreadable-own-date case, whose whole point
+    is what the PRODUCER emits: a hand-written record would encode the answer being tested.
+    """
+    comments = [
+        {"user": {"id": "9", "username": "Robin Example"}, "date": their_ms_raw},
+        {"user": {"id": "7", "username": "me"}, "date": my_date_raw},
+    ]
+    reply = recent_comments.latest_reply_by(comments, "7")
+    # BASE-COMPAT, for the same reason `_blocks` reaches for the notes producer with getattr:
+    # neither the ms argument nor `latest_reply_ts_by` exists on the pre-port tree, and a
+    # corpus that cannot be pointed at base can only ever describe the code it shipped with. A
+    # base that cannot build the case scores it as a FAILURE — which is the correct verdict
+    # for a base that cannot represent the fact, not a skip.
+    ts_fn = getattr(recent_comments, "latest_reply_ts_by", None)
+    reply_ts = ts_fn(comments, "7") if ts_fn else None
+    try:
+        meta = recent_comments.build_record(
+            "868gz0hhh", "t", {}, comments[0], SNIPPET, reply, reply_ts)
+    except TypeError:
+        meta = recent_comments.build_record(
+            "868gz0hhh", "t", {}, comments[0], SNIPPET, reply)
+    nc = check_addressed.build_newest_comment(meta)
+    # The producer's date is a fixed instant; re-render it against NOW so the case sits
+    # inside the recency window whatever day the suite runs on. The ms fields are left as
+    # the producer wrote them — they are only ever compared with each other.
+    nc["date"] = _fmt(NOW - timedelta(days=2))
+    return {"task_id": "868gz0hhh", "status": "no_mentions_found", "sessions_searched": 1,
+            "mentions_found": 0, "clickup_status": "to do", "clickup_priority": "high",
+            "newest_comment": nc, "completion": [], "open": []}
+
+
+def _with(r, **fields):
+    """Override `newest_comment` fields on a built record, for shapes `_rec` cannot express.
+
+    Kept deliberately blunt: a builder that grows a keyword for every one-off case stops being
+    readable, and a corpus whose fixtures are hard to read is a corpus nobody audits.
+    """
+    r["newest_comment"].update(fields)
+    return r
+
+
+D = timedelta(days=1)
+S = timedelta(seconds=1)
+THEIRS = NOW - 2 * D          # the colleague's comment, inside the 14-day window
+
+CORPUS = [
+    # --- A: the flag's own job. A human is waiting and nothing exists anywhere.
+    (WAITING, "reply_older_than_the_question",
+     _rec(their=NOW - D, mine=NOW - 5 * D)),
+    (WAITING, "producer_reported_no_reply_at_all",
+     _rec(their=THEIRS, mine=None)),
+    (WAITING, "sub_minute_reply_20s_BEFORE_the_question",
+     _rec(their=THEIRS + 30 * S, mine=THEIRS + 10 * S)),
+
+    # --- B: I answered. Suppressed, and the suppression is REPORTED — see BOT_IDENTITY.
+    (ANSWERED, "the_live_868gz0hhh_shape_reply_11h_later",
+     _rec(their=THEIRS, mine=NOW - timedelta(hours=11))),
+    (ANSWERED, "sub_minute_reply_40s_AFTER_the_question",
+     _rec(their=THEIRS + 10 * S, mine=THEIRS + 50 * S)),
+    (ANSWERED, "an_exact_tie_at_the_millisecond",
+     _rec(their=THEIRS + 17 * S, mine=THEIRS + 17 * S)),
+    (ANSWERED, "no_ms_fields_at_all_falls_back_to_minute_ages",
+     _rec(their=THEIRS, mine=NOW - timedelta(hours=11), with_ms=False)),
+    (ANSWERED, "only_THEIR_ms_present_must_not_mix_resolutions",
+     _rec(their=THEIRS + 30 * S, mine=THEIRS + 10 * S, mine_ms=False)),
+    (ANSWERED, "only_MY_ms_present_must_not_mix_resolutions",
+     _rec(their=THEIRS + 30 * S, mine=THEIRS + 10 * S, their_ms=False)),
+    (ANSWERED, "a_status_outside_the_vocabulary_still_gets_the_note",
+     _rec(their=THEIRS, mine=NOW - timedelta(hours=11), status="blocked")),
+    (ANSWERED, "an_unreadable_display_date_decided_on_the_raw_ms",
+     _rec(their=THEIRS + 10 * S, mine=THEIRS + 50 * S, date_str="2026-13-45 99:99")),
+
+    # --- C: the check could not run. Announce, never decide.
+    (ANNOUNCE, "my_latest_reply_field_absent_stale_producer",
+     _rec(their=THEIRS, reply_reported=False)),
+    (ANNOUNCE, "an_unreadable_date_on_MY_OWN_newest_comment",
+     _rec_via_producer(my_date_raw="corrupted")),
+    (UNREADABLE, "their_comment_date_unreadable_beside_a_reported_reply",
+     _rec(their=THEIRS, mine=NOW - D, with_ms=False, date_str="not-a-date")),
+    # 🔴 The ms decides "answered" but NO bound can be evaluated from either field, so the
+    # note would be permanent. It falls through to the flag instead: a call to action survives
+    # an unreadable date, a "no action needed" line does not.
+    (UNREADABLE, "a_raw_ms_unusable_as_an_instant_falls_through_to_the_flag",
+     _with(_rec(their=THEIRS + 10 * S, mine=THEIRS + 50 * S),
+           date="-99999999999999999", date_ms=-99999999999999999)),
+
+    # --- D: nothing to say. Every one of these is a bound, and a bound that stops bounding
+    # is how a block fills with lines nobody must act on.
+    (SILENT, "answered_but_the_comment_is_30_days_old",
+     _rec(their=NOW - 30 * D, mine=NOW - 29 * D)),
+    (SILENT, "unanswered_but_the_comment_is_90_days_old",
+     _rec(their=NOW - 90 * D, mine=None)),
+    (SILENT, "a_done_ticket_is_not_waiting_on_anyone",
+     _rec(their=THEIRS, mine=None, status="closed")),
+    (SILENT, "transcripts_mention_the_task_so_work_exists",
+     _rec(their=THEIRS, mine=None, mentions=4)),
+    (SILENT, "mentions_found_absent_is_not_a_reported_zero",
+     _rec(their=THEIRS, mine=None, mentions=None)),
+    # 🔴 The bound must not go dead because the DISPLAY date is unreadable. `format_date`
+    # falls back to `str(ts_ms)` for an out-of-range epoch, which `_epoch_ms` accepts because
+    # it never range-checks, so a record can carry a good `date_ms` beside an unformattable
+    # `date`: age unknown, bound skipped, and the ms path still deciding. Measured while
+    # porting as a 2019 ticket printing an unbounded note. The exotic input matters less than
+    # the systemic one — if `format_date` ever drifts, the bound dies for EVERY record.
+    (SILENT, "an_unformattable_display_date_over_a_90_day_old_raw_ms",
+     _rec(their=NOW - 90 * D, mine=NOW - 89 * D, date_str="99999999999999999")),
+]
+
+
+def _blocks(r):
+    """(flag lines, suppression notes) for one record.
+
+    `getattr` on the notes producer so this corpus RUNS against the pre-port tree, where it
+    does not exist — the red-at-base matrix is not optional here and a corpus that cannot be
+    pointed at base can only ever describe the code it shipped with. A missing producer scores
+    every ANSWERED case as a failure, which is the correct verdict, not a skip.
+    """
+    flags = [f for f in check_addressed.disagreements([r], now=NOW) if "WAITING" in f]
+    notes_fn = getattr(check_addressed, "suppressed_notes", None)
+    notes = notes_fn([r], now=NOW) if notes_fn else []
+    return flags, notes
+
+
+def _answered_block(r):
+    """The printed lines of the answered-already block, or [] where it does not exist.
+
+    The block is where the bot-identity caveat lives — once, leading it — so a guard that only
+    ever reads `suppressed_notes` cannot see whether the reader is given it at all. Same
+    `getattr` base-compat as `_blocks`, for the same reason.
+    """
+    fn = getattr(check_addressed, "report_blocks", None)
+    if not fn:
+        return []
+    return dict(fn([r], now=NOW)).get(check_addressed.ANSWERED_HEADING, [])
+
+
+def _verdict(r):
+    """The CLAIM the report makes about this record, as one of `LABELS`.
+
+    Precedence among the fired-flag labels is the strongest CAVEAT first, because the caveat
+    is what changes what the reader does: "the check did not run" outranks "the date was
+    unreadable" outranks the plain claim. They are near-disjoint by construction — the plain
+    claim is only appended when neither caveat applies — so precedence is documented rather
+    than relied upon.
+    """
+    flags, notes = _blocks(r)
+    if flags:
+        joined = " ".join(flags).lower()
+        if "not reported" in joined:
+            return ANNOUNCE
+        if "unreadable" in joined:
+            return UNREADABLE
+        if "nobody has answered" in joined:
+            return WAITING
+        return "?"
+    if notes:
+        return ANSWERED
+    return SILENT
+
+
+def test_the_waiting_corpus_score_has_not_regressed():
+    """The headline guard. Scores the real report over every labelled record."""
+    got = [(name, want, _verdict(r)) for want, name, r in CORPUS]
+    good = [n for n, want, g in got if g == want]
+    assert len(good) >= MIN_SCORE, (
+        f"waiting-flag corpus score fell to {len(good)}/{len(CORPUS)}, below the pinned "
+        f"{MIN_SCORE}. Failing: {[(n, w, g) for n, w, g in got if g != w]}")
+
+
+def test_no_case_that_needs_a_human_comes_out_SILENT():
+    """🔴 THE DIRECTION THAT COSTS SOMETHING. A waiting colleague dropped without a trace.
+
+    Silence is this flag's worst outcome and its most invisible: nothing about a ticket that
+    goes silent here appears anywhere in the report. (NOT because "`mentions_found == 0` means
+    no other rule covers the ticket" — that non-sequitur was retracted; the other rules never
+    read the mention count. It is because these fixtures carry nothing for those rules to fire
+    on, which is the ordinary shape and is exactly why this flag was added.) It is also the
+    direction change 3 exists for — suppression used to print nothing, so an agent-posted
+    reply (which ClickUp reports as mine, indistinguishably) removed the ticket from the
+    report with no line to say so.
+    """
+    for want, name, r in CORPUS:
+        if want in (WAITING, ANNOUNCE, UNREADABLE, ANSWERED):
+            assert _verdict(r) != SILENT, \
+                f"{name}: a task needing a human's eyes produced no output at all"
+
+
+def test_no_UNANSWERED_case_is_reported_as_ANSWERED():
+    """🔴 The mirror direction: claiming a question was answered when it was not.
+
+    This is D12 inverted — instead of nagging about an answered ticket, the report would
+    quietly file an unanswered one under "no action". `>=` on the raw ms is the boundary that
+    decides it, so the sub-minute cases are load-bearing here, not decoration.
+    """
+    for want, name, r in CORPUS:
+        if want in (WAITING, ANNOUNCE, UNREADABLE):
+            assert _verdict(r) != ANSWERED, \
+                f"{name}: an unanswered (or unknowable) question was reported as answered"
+
+
+def test_every_ANSWERED_case_reaches_the_reader_under_the_bot_identity_caveat():
+    """A suppression note without the caveat is a note that says the wrong thing confidently.
+
+    ClickUp has NO bot identity: a comment posted through the `pk_` token is authored as the
+    token's owner whoever typed it, so "you answered" and "an agent answered as you" are the
+    same observable and the note cannot claim the first. Asserting the caveat REACHES THE
+    READER, not that any particular string is in any particular line — the same lesson that
+    produced this file's verdict-on-the-claim rule. It leads the BLOCK once (repeating it per
+    line put ~11 KB of identical text in a `--limit 20` report); each line keeps its own
+    consequence, so a reader who skips the preamble still sees why this is not "handled".
+    """
+    for want, name, r in CORPUS:
+        if want != ANSWERED:
+            continue
+        _flags, notes = _blocks(r)
+        assert len(notes) == 1, f"{name}: expected exactly one note, got {notes}"
+        assert "if that reply was an agent's" in notes[0].lower(), \
+            f"{name}: the note asserts you answered without the consequence of the caveat"
+        lines = _answered_block(r)
+        carriers = [l for l in lines if "bot identity" in l.lower()]
+        assert len(carriers) == 1 and lines[0] is carriers[0], \
+            f"{name}: the caveat must lead the block exactly once, got {len(carriers)}x"
+
+
+def test_a_note_never_claims_the_report_is_silent_about_a_ticket_it_also_flags():
+    """🔴 A CLAIM THE CODE CONTRADICTED. The note used to assert that nothing else in the
+    report named the ticket, and *why*: `mentions_found == 0`. Both halves were wrong.
+
+    Four shapes put a "Needs a decision" line about the SAME ticket directly above the note —
+    an unknown ClickUp status, a RESOLVED-reading comment, a keep-open veto, an open cited PR
+    — and NOT ONE of those four rules reads `mentions_found`, so the stated reason was a
+    non-sequitur rather than an unlucky case. The corpus already contained one such shape
+    (`a_status_outside_the_vocabulary_still_gets_the_note`) and scored it green, because the
+    label reads the VERDICT and this was a defect in the line's prose.
+
+    So the claim is COMPUTED now, and this is the guard that can see it: for every case, what
+    the note says about other coverage must match what `disagreements` actually produced.
+    """
+    for want, name, r in CORPUS:
+        if want != ANSWERED:
+            continue
+        flags = check_addressed.disagreements([r], now=NOW)
+        note = _blocks(r)[1][0].lower()
+        if flags:
+            assert "also carries a line about this ticket" in note, (
+                f"{name}: the note claims the report is silent about a ticket that has "
+                f"{len(flags)} decision line(s) directly above it: {flags}")
+            assert "no other flag names this ticket" not in note, f"{name}: contradictory note"
+        else:
+            assert "no other flag names this ticket" in note, \
+                f"{name}: the note did not state that nothing else covers the ticket"
+
+
+def test_every_SILENT_case_is_silent_in_BOTH_blocks():
+    """A positive control on what SILENT means. A label that only checked the flag would pass
+    while the note block filled up with the very lines the recency bound exists to stop."""
+    for want, name, r in CORPUS:
+        if want != SILENT:
+            continue
+        flags, notes = _blocks(r)
+        assert not flags and not notes, f"{name}: expected nothing, got {flags} {notes}"
+
+
+def test_the_case_ledger_is_pinned_so_the_set_cannot_shrink():
+    """A LEDGER, the same instrument `test_corpus.py` uses. A corpus that can quietly lose a
+    case is a scoreboard that can be won by deleting the cases you fail — and every guard
+    above is only as wide as the set it iterates."""
+    names = [name for _w, name, _r in CORPUS]
+    assert len(names) == len(set(names)), f"duplicate case names: {names}"
+    assert len(CORPUS) == 21, (
+        f"corpus size changed to {len(CORPUS)}; update MIN_SCORE and this number together")
+    assert {w for w, _n, _r in CORPUS} == set(LABELS), (
+        "a label has no case, so every directional guard over it is vacuous — the corpus "
+        "must exercise all five outcomes")
+
+
+def test_the_verdict_reader_can_actually_tell_the_labels_apart():
+    """🔴 POSITIVE CONTROL ON THE INSTRUMENT. `_verdict` reads substrings out of prose; a
+    reword upstream could collapse two labels into one and every guard above would still be
+    green, because agreement between a broken reader and a broken report is invisible.
+
+    So: the labels the corpus actually produces must be five distinct values, and no case may
+    score `?` — the reader's own "I did not recognise this line" outcome.
+    """
+    produced = {_verdict(r) for _w, _n, r in CORPUS}
+    assert "?" not in produced, "a fired flag made a claim `_verdict` does not recognise"
+    assert produced == set(LABELS), (
+        f"the corpus produces only {sorted(produced)} — a reader that cannot distinguish the "
+        "outcomes scores agreement with itself")

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1426,7 +1426,19 @@ TARGET_FLOORS=(
   # four an adversarial audit of the migration produced — the documented `$CCUA/...`
   # invocation, the unmarked `--json` output, its end-to-end seam, and the
   # header/marker single-source pin.)
-  "scripts/check-clickup-addressed/tests|168"
+  #
+  # 2026-08-22, re-pinned when upstream rounds 7+8 were ported in: 213 collected,
+  # from this gate's own line `PASS scripts/check-clickup-addressed/tests
+  # (collected=213 passed=213 skipped=0 floor=168)`, again agreeing with
+  # tests/run_all.py (213 passed, 0 failed) — two runners, one number.
+  #   _suggested_floor 213 = 213 - min(50, max(1, 213/20 = 10)) = 213 - 10 = 203.
+  # 🔴 The gate did NOT force this: 213 is under the drift ceiling (floor 168 +
+  # max(60, 168/4) = 228), so it passed and printed no replacement number. Re-pinned
+  # anyway, because 45 tests of slack is most of what this port ADDED — the whole
+  # waiting corpus (8) plus the bounds/parsing set (5) plus the round-7 additions
+  # could have vanished with the gate still green, which is the exact staleness the
+  # header above says a per-target floor exists to prevent.
+  "scripts/check-clickup-addressed/tests|203"
   "scripts/claude-hooks/tests/test_guard_core.py|1260"
   # 2026-08-13, next-step-nudge.py's suite arrives as a NEW target: 78 collected on the
   # branch. Gate's own count through the gate's own rule:


### PR DESCRIPTION
Ports two rounds of upstream work on `check-clickup-addressed` that landed in the private
client repo **after** this skill was migrated here at 14:03 today, so the copy that actually
runs (`~/.claude/skills/check-clickup-addressed/` → `$DEVRC/scripts/check-clickup-addressed/`)
has been missing them all day.

Upstream #1238 was already carried across at 14:47 and is **not** re-ported — confirmed by
reading `recent-comments.py` (`UNIDENTIFIED`, `latest_reply_by`, `my_latest_reply`) before
starting.

🔴 **This is a PORT, not a copy.** The upstream hunks still carry real ClickUp ids, real
colleagues' names and verbatim third-party comment bodies; this repo is PUBLIC and was
scrubbed this morning (`ec4fc008`). Everything was re-synthesised as it was ported and every
value is on the existing ledger in `tests/test_no_real_identifiers.py` — **no new ledger
entries were needed.**

## Round 7 (upstream #1246, merged)

- an unreadable date on **one of YOUR OWN** comments returned an older reply, restoring the
  exact false positive #1238 fixed → `latest_reply_ts_by` returns the `UNIDENTIFIED` sentinel
- the answered/not-answered comparison ran at **minute** resolution, so a reply written 20
  seconds *before* the question counted as answering it → raw `date_ms` /
  `my_latest_reply_ms`, used only when **both** sides have them, with a minute-age fallback
- a **suppressed** flag printed nothing at all → its own `## Answered already` block, carrying
  the ClickUp-has-no-bot-identity caveat once at the top
- `report_blocks()` extracted from `main()` — and then actually driven THROUGH `main()`,
  because deleting the whole print loop left the suite green
- `tests/test_waiting_corpus.py`: 21 labelled **records** (the existing corpus scores comment
  TEXT; this flag reads FIELDS, so all 49 of its cases are blind to it)

## Round 8 (upstream #1253, open — content ported, PR to be closed unmerged)

- `tests/test_bounds_and_parsing.py`: three invariants the prose guaranteed and nothing
  pinned — per-record `disagreements([r])` scoping, the display-vs-bound age split, and
  `UNANSWERED_COMMENT_DAYS` pinned **on** its boundary (14.0) and at a non-multiple overshoot
  (20). The old fixtures sat at 13 and 30, and 30 is more than 2×14, so a doubling mutant
  walked straight through the gap.
- `TypeError` added to `_age_days_from_ms`' except tuple (a string `date_ms` crashed the whole
  report)
- three comment corrections, including `_age_days_from_ms` blaming `OSError` when the
  exception is `ValueError` and the real mechanism is that `_epoch_ms` never range-checks
- `tests/mutation_sweep.py` — the battery as committed data plus a runner

### 🔴 The scan-less announcement was NOT ported — it is unreachable here

Upstream #1253's headline finding announces that two rules could not fire because a parallel
upstream change made the transcript scan **opt-in**. Measured here before deciding:
`check-addressed.py` has no `--transcripts` flag (`parse_args` rejects unknown args and
exits 2), `main()` always runs `search-sessions.py` and `check-completion.py`, and
`check-completion.py` writes `mentions_found` on all three of its exit paths. Nothing can
produce a `not_scanned` status or a record without a mention count, so the announcement would
guard a state no input can reach. Also skipped for the same reason: the `"mentions_found" in
r` gate on the open-signals flag, the SKILL.md line correction (this tool's default *does*
run the decision flags), and mutants N1–N5. Every omission is recorded at the site that would
carry it, with the restore condition named: **a `--transcripts` opt-in landing here.**

## 🔴 The mutation battery caught its own harness first

The first full run reported all 59 mutants KILLED — and every killer list opened with
`test_the_scan_actually_walks_files_and_can_see_an_id`. `test_no_real_identifiers.py`
resolves `<repo>/scripts` and `<repo>/claude` from `__file__` and asserts loudly when a scan
root is missing (correctly), which it always is inside the sweep's temp copy. All four of its
tests failed in **every** run, so a mutant changing nothing would also have scored KILLED.
A fully green sweep proving nothing — the exact "dying to a different guard's assertion is a
green you cannot spend" failure, hit by the file that warns about it.

Fixed two ways, both in `mutation_sweep.py`: the hygiene gate is dropped from each mutant copy
(no code mutant can ever be caught by a tree-walking check), and a **NULL CONTROL** now runs
first — it copies the skill, mutates nothing, and the run **aborts** unless it reports
SURVIVED.

## Verification

| tree | result |
|---|---|
| pre-port scripts + pre-port tests | **176 passed, 0 failed** |
| pre-port scripts + **HEAD tests** | **178 passed, 31 failed** |
| HEAD scripts + HEAD tests | **209 passed, 0 failed** |

(`test_no_real_identifiers.py` excluded from all three — it cannot resolve the repo from a
temp copy, so it would fail identically in every row. In-repo, with it included: **180 → 213
collected.**)

Waiting-flag corpus: **10/21 pre-port → 21/21**.

Mutation battery: **59 mutants + a positive control + a null control, non-KILLED: 0.**

⚠️ Four of the 31 reds are round-8 guards going red with `AttributeError` because
`suppressed_notes` / `_age_days_from_ms` do not exist pre-port — that is the code being
ABSENT, not wrong. They are **mutation-coverage guards, not regression coverage**, and the
file says so at the top. Counting them would overstate the matrix by four.

`_selfrun.py` was not touched, but its markers are path fragments and the two layouts spell
the same segments in reverse order, so all eight marker tests were re-run **by name** and are
green: `test_skill_catalog_mention_is_not_a_self_run`,
`test_the_devrc_invocation_path_is_a_self_run`,
`test_the_invocation_SKILL_MD_ACTUALLY_TEACHES_is_a_self_run`,
`test_a_json_run_carries_the_self_run_marker`,
`test_a_mention_of_the_scripts_DIRECTORY_is_not_a_self_run`,
`test_each_self_run_marker_fires_on_its_own`,
`test_self_run_marker_set_has_not_drifted`, `test_skill_tool_invocation_is_a_self_run`.

**No live ClickUp run**, in any round of this work upstream or here. Every claim above is
measured against the suite, the corpus and the sweep.

## Found and deliberately not fixed

- `_collect` still sorts on the FORMATTED `date` string. Lexicographically correct for
  `%Y-%m-%d %H:%M`, and `date_ms` now exists so the sort could read it — but changing it
  changes which comments the report samples, and nothing measured says the current order is
  wrong.
- The **threaded-comment blind spot** is unchanged: `recent-comments.py` fetches top-level
  comments only, so an answer written inside a comment thread is still invisible to
  `my_latest_reply`.
