### PR TITLE
claude-hooks: track the base-clone staleness hook + its suite, and deploy the script via home-manager

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1239,6 +1239,62 @@ in
   home.file.".claude/hooks/clawgate-task-interview-guard.py" = {
     source = ../scripts/claude-hooks/clawgate-task-interview-guard.py;
   };
+  # 🔴 THE BASE-CLONE STALENESS HOOK — the only hook here that fixes what the
+  # agent READS rather than what it does.
+  #
+  # Why it exists: when all work happens in throwaway worktrees + PRs, a base
+  # clone is never written to and silently falls behind. That is harmless for
+  # WRITES — `git worktree add <path> origin/<branch>` resolves the REMOTE
+  # tracking ref, so a clone 700 commits behind still yields a current worktree —
+  # but it is dangerous for READS: `CLAUDE.md` and `.claude/skills/**` load into
+  # agent context FROM THE WORKING TREE, so a stale clone serves stale,
+  # authoritative-looking instructions with nothing on screen to indicate it.
+  # Measured 2026-08-21 in the datapacket-talos hub: every dispatch-hub clone was
+  # behind (talos 33 commits, civitai-orchestration 53, civitai 18), and one of
+  # them served a skill whose retention figure had been corrected upstream five
+  # days earlier — a whole session was framed on the corrected-away claim.
+  #
+  # On SessionStart it fetches the cwd repo's upstream and `git checkout
+  # <upstream> --`s ONLY those two paths. It does NOT move HEAD (that would need
+  # a clean tree and would move the branch), never overwrites content that is
+  # absent from the upstream branch's recent history, and reports what it
+  # touched. `BASE_CLONE_NO_REFRESH=1` makes it report-only.
+  #
+  # Registration in ~/.claude/settings.json stays PER-HOST and unmanaged, exactly
+  # like bash-guard.py above: register-nudge-hook.py deliberately does NOT own
+  # it. That is structural, not an omission — the registrar's managed-command
+  # surface recognises `<python> <path>.py` commands only, and its whole rewrite
+  # half exists to normalise a python INTERPRETER token to an absolute /nix/store
+  # path. This hook is bash, so there is no interpreter hazard to fix and nothing
+  # for the registrar to match; teaching that shared component a second
+  # interpreter would widen a load-bearing surface for no benefit. Consequence,
+  # the same known gap bash-guard.py has: on any host where the entry has not
+  # been added by hand, the switch delivers the script and the hook is INERT.
+  #
+  # 🔴 A NEW file, so it must be `git add`ed or the flake silently omits it and
+  # the switch still succeeds with the hook absent — this repo's standing trap
+  # (the #452 shape, called out twice above).
+  #
+  # No `force = true` and no `dropStaleClaudeHooks` entry, for the reason the
+  # register-nudge-hook.py block below records verbatim: that treatment exists
+  # only to displace a PRE-EXISTING hand-placed regular file, and this path has
+  # never been hand-placed. MEASURED 2026-08-22 before the first switch that
+  # deploys it — `ls -la ~/.claude/hooks/` shows 14 entries on this host, ALL
+  # /nix/store symlinks, no regular files, and no base-clone-staleness.sh among
+  # them. The live copy being replaced lives in ~/.claude/local-hooks/, a
+  # different directory this attribute does not write to. If a foreign file ever
+  # does appear at this path the switch fails LOUDLY ("would be clobbered")
+  # rather than silently leaving it unmanaged — add it to dropStaleClaudeHooks
+  # then.
+  #
+  # Its regression suite is `scripts/tests/test_base_clone_staleness.sh`, run by
+  # `scripts/run-tests.sh` as a SHELL_TESTS target (24 assertions / 8 cases,
+  # offline synthetic fixtures). Every case there is a defect that actually
+  # shipped; run it before changing this script.
+  home.file.".claude/hooks/base-clone-staleness.sh" = {
+    source = ../scripts/claude-hooks/base-clone-staleness.sh;
+    executable = true;
+  };
 
   # 🔴 THE REGISTRAR ITSELF — the hook that makes the hooks above DO anything.
   # settings.json is per-host and unmanaged (permissions/allowlists), so a hook

--- a/scripts/claude-hooks/base-clone-staleness.sh
+++ b/scripts/claude-hooks/base-clone-staleness.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# SessionStart: keep the context-loading files in THIS clone fresh, and report
+# anything that could not be refreshed.
+#
+# Why this exists: when all work happens in throwaway worktrees + PRs, the base
+# clone is never written to and silently falls behind. That is harmless for
+# WRITES -- `git worktree add <path> origin/<branch>` resolves the remote-tracking
+# ref, so a clone 700 commits behind still produces a current worktree -- but it
+# is dangerous for READS: CLAUDE.md and .claude/skills/** load into the agent's
+# context FROM THE WORKING TREE, so a stale clone serves stale,
+# authoritative-looking instructions with nothing to indicate it.
+#
+# What it does NOT do: move HEAD. `merge --ff-only` would need a clean tree and
+# would move the branch; refreshing specific paths needs neither and cannot
+# conflict. It also never overwrites a path you have locally modified -- those are
+# reported and skipped.
+#
+# Side effect, by design: a refreshed path shows as modified-vs-HEAD in
+# `git status` until the clone's branch catches up. That is inherent to fixing
+# reads without moving HEAD; the report below names every path it touched so the
+# dirt has a documented cause.
+#
+# Opt out of the write half with BASE_CLONE_NO_REFRESH=1 (report only).
+
+set -uo pipefail
+
+# Paths whose CONTENT is loaded into agent context from the working tree.
+REFRESH_PATHS=(CLAUDE.md .claude/skills)
+
+# Guard the VALUE, not just the cd: an empty ROOT sails past `cd "$ROOT" || exit`
+# on bash <= 5.2, where `cd ""` is a no-op returning 0.
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -n "$ROOT" ] && [ -d "$ROOT" ] || exit 0
+
+# Only the primary clone can go stale in the way that matters. In a linked
+# worktree .git is a FILE holding "gitdir: ..."; in the primary clone it is a dir.
+[ -d "$ROOT/.git" ] || exit 0
+
+# Prefer the checked-out branch's own upstream; fall back to origin's default HEAD.
+UP="$(git -C "$ROOT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
+if [ -z "$UP" ]; then
+  UP="$(git -C "$ROOT" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+fi
+[ -n "$UP" ] || exit 0
+
+# Bounded: a hung network must not wedge session start.
+timeout 12 git -C "$ROOT" fetch --quiet "${UP%%/*}" "${UP#*/}" >/dev/null 2>&1 || true
+
+BEHIND="$(git -C "$ROOT" rev-list --count "HEAD..$UP" 2>/dev/null || echo 0)"
+[ -n "$BEHIND" ] || BEHIND=0
+
+# List DIFFERING PATHS, never branch on an exit code: `git diff --quiet <ref> -- <p>`
+# exits 0 when <p> exists on NEITHER side, which reads as a reassuring "same" for a
+# file that is simply absent. --name-only reports content, so an absent file is
+# just not listed.
+DIFFERING="$(git -C "$ROOT" diff --name-only "$UP" -- "${REFRESH_PATHS[@]}" 2>/dev/null || true)"
+
+refreshed=(); skipped=(); optout=(); failed=(); approved=()
+
+if [ -n "$DIFFERING" ]; then
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+
+    # NEVER clobber real local work. The right question is not "does this differ
+    # from HEAD" but "is this content RECOVERABLE" -- i.e. does the working copy's
+    # exact blob already exist in the upstream branch's history for this path? If
+    # it does, it is either HEAD's own content (never touched) or the output of an
+    # earlier refresh, so overwriting destroys nothing. If the content appears
+    # NOWHERE in that history it is unique human work and must be protected.
+    #
+    # 🔴 The obvious guard -- "differs from HEAD => local edit" -- is WRONG, and it
+    # made this hook SELF-BLOCKING: `git checkout <ref> -- <path>` writes the index
+    # too, so every path the hook fixed then differed from HEAD forever after and
+    # was skipped on every subsequent run. The feature worked exactly once per file
+    # and then silently stopped. Measured 2026-08-21, and invisible to an
+    # idempotence test that re-runs without upstream moving in between -- the
+    # second refresh only breaks once the file goes stale AGAIN.
+    known=no
+    if [ ! -e "$ROOT/$p" ]; then
+      # NEW UPSTREAM: the path does not exist here at all, so there is no local
+      # content to protect and the checkout below CREATES it.
+      # 🔴 This case used to fall through to hash-object, which FATALS on a missing
+      # file; the empty result was then classified FAILED. Net effect: a stale
+      # clone never received a newly-added skill, and the report called it an
+      # error rather than "this skill is missing here". Measured 2026-08-21 —
+      # the whole FAILED bucket was exactly the files `git diff --name-status
+      # HEAD origin/trunk` marks `A`.
+      known=yes
+      cur=""
+    elif ! cur="$(git -C "$ROOT" hash-object "$p" 2>/dev/null)" || [ -z "$cur" ]; then
+      failed+=("$p")
+      continue
+    elif [ "$cur" = "$(git -C "$ROOT" rev-parse "HEAD:$p" 2>/dev/null || echo none)" ]; then
+      known=yes
+    else
+      while IFS= read -r c; do
+        [ -n "$c" ] || continue
+        if [ "$cur" = "$(git -C "$ROOT" rev-parse "$c:$p" 2>/dev/null || echo none)" ]; then
+          known=yes
+          break
+        fi
+      done < <(git -C "$ROOT" rev-list -n 100 "$UP" -- "$p" 2>/dev/null)
+    fi
+    if [ "$known" = no ]; then
+      skipped+=("$p")
+      continue
+    fi
+
+    if [ "${BASE_CLONE_NO_REFRESH:-0}" = "1" ]; then
+      optout+=("$p")
+      continue
+    fi
+
+    approved+=("$p")
+  done <<<"$DIFFERING"
+fi
+
+# ONE checkout for the whole approved batch — one .git/index.lock acquisition per
+# run instead of one per file.
+#
+# 🔴 Per-file checkout made this hook hostile to itself under concurrency. Two
+# sessions starting together each took the lock ~25 times, so they collided
+# repeatedly and reported FAILED 12 / FAILED 12 — and an immediate per-file retry
+# barely moved it (7/6), because the contention is SUSTAINED for the length of
+# both runs, not a narrow window. Measured 2026-08-21. Batching collapses the
+# collision surface to a single acquisition; the retry then covers the rare
+# genuine overlap.
+if [ "${#approved[@]}" -gt 0 ]; then
+  if git -C "$ROOT" checkout "$UP" -- "${approved[@]}" >/dev/null 2>&1 \
+     || git -C "$ROOT" checkout "$UP" -- "${approved[@]}" >/dev/null 2>&1; then
+    refreshed=("${approved[@]}")
+  else
+    # Batch failed: fall back to per-path so ONE bad path stays attributable
+    # instead of condemning the whole set.
+    for p in "${approved[@]}"; do
+      if git -C "$ROOT" checkout "$UP" -- "$p" >/dev/null 2>&1 \
+         || git -C "$ROOT" checkout "$UP" -- "$p" >/dev/null 2>&1; then
+        refreshed+=("$p")
+      else
+        failed+=("$p")
+      fi
+    done
+  fi
+fi
+
+n_ref=${#refreshed[@]}; n_skip=${#skipped[@]}; n_opt=${#optout[@]}; n_fail=${#failed[@]}
+
+# Nothing to say when the clone is current. A banner that fires every time gets
+# ignored, which is the failure mode this hook exists to prevent.
+if [ "$BEHIND" -eq 0 ] && [ "$n_ref" -eq 0 ] && [ "$n_skip" -eq 0 ] && [ "$n_opt" -eq 0 ] && [ "$n_fail" -eq 0 ]; then
+  exit 0
+fi
+
+repo="$(basename "$ROOT")"
+msg="$repo is $BEHIND commit(s) behind $UP"
+[ "$n_ref" -gt 0 ] && msg="$msg | refreshed $n_ref context file(s)"
+[ "$n_skip" -gt 0 ] && msg="$msg | SKIPPED $n_skip (local edits)"
+[ "$n_opt" -gt 0 ] && msg="$msg | STALE $n_opt (refresh opted out)"
+[ "$n_fail" -gt 0 ] && msg="$msg | FAILED $n_fail"
+
+ctx="Base-clone sync (working tree vs $UP):
+- behind by $BEHIND commit(s); HEAD was NOT moved."
+
+if [ "$n_ref" -gt 0 ]; then
+  ctx="$ctx
+- REFRESHED from $UP (these now match upstream, and will show as modified-vs-HEAD
+  in git status -- that is this hook's doing, not stray WIP):
+$(printf '    %s\n' "${refreshed[@]}")"
+fi
+if [ "$n_skip" -gt 0 ]; then
+  ctx="$ctx
+- STALE AND NOT REFRESHED: the working copy holds content found nowhere in the
+  recent history of $UP, so it is treated as unique local work and left alone.
+  What you read from these may be out of date:
+$(printf '    %s\n' "${skipped[@]}")"
+fi
+if [ "$n_opt" -gt 0 ]; then
+  ctx="$ctx
+- STALE, not refreshed because BASE_CLONE_NO_REFRESH=1 is set (report-only mode).
+  What you read from these may be out of date:
+$(printf '    %s\n' "${optout[@]}")"
+fi
+if [ "$n_fail" -gt 0 ]; then
+  ctx="$ctx
+- FAILED to refresh even after a retry. The usual cause is another session
+  starting at the same moment and holding .git/index.lock, which is transient and
+  self-heals on the next session; a path that keeps failing is a real problem:
+$(printf '    %s\n' "${failed[@]}")"
+fi
+
+ctx="$ctx
+
+Only CLAUDE.md and .claude/skills/** are synced; the rest of this tree is still
+$BEHIND commit(s) behind. Before relying on any OTHER doc claim that is
+load-bearing in a plan -- a limit, a retention figure, an arming state, a 'this is
+impossible' -- read it from the ref: git show $UP:<path>
+Worktrees are unaffected: they are created from $UP directly."
+
+jq -nc --arg m "$msg" --arg c "$ctx" \
+  '{systemMessage: $m, hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $c}}'

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -2571,9 +2571,25 @@ done
 # cases passed FOR THE WRONG REASON. It asserts the pure extraction helpers that
 # the DRIFT block's whole PR-reconciliation rests on; an unrun suite is a guard
 # that reports no failures.
+#
+# `test_base_clone_staleness.sh` is here from birth rather than being found
+# ungated later, which is the only difference between it and the two above. It
+# covers `scripts/claude-hooks/base-clone-staleness.sh`, a SessionStart hook that
+# WRITES to a clone's working tree (`git checkout <upstream> -- CLAUDE.md
+# .claude/skills/`), so an unrun suite here is an unguarded write path, not just
+# an unmeasured helper. Hermetic: its fixtures are local bare repos under a
+# mktemp dir — no network, no real remote, and every commit carries its identity
+# via `git -c user.email=…`, so it needs nothing from the operator's gitconfig
+# and stays inside GUARD 10's isolation.
+#
+# 🔴 Its HOOK default resolves the hook RELATIVE TO THE SUITE (../claude-hooks/),
+# not a deployed ~/.claude/ path. That is what makes this gate grade the tracked
+# file; a default pointing at a per-host copy would be green about something that
+# is not in the commit. Do not "simplify" it back.
 SHELL_TESTS=(
   "scripts/tests/test_release_wrapper.sh"
   "scripts/tests/test_resume_state.sh"
+  "scripts/tests/test_base_clone_staleness.sh"
 )
 for SHELL_TEST in "${SHELL_TESTS[@]}"; do
   if [ ! -f "$SHELL_TEST" ]; then

--- a/scripts/tests/test_base_clone_staleness.sh
+++ b/scripts/tests/test_base_clone_staleness.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Regression suite for base-clone-staleness.sh.
+#
+# Every case here corresponds to a defect that actually shipped, or to a fixture
+# mistake that produced a confident FALSE PASS. Read the comments before deleting
+# a case — several look redundant and are not.
+#
+# Fixtures are synthetic (a local bare "remote" + clones), so the suite is
+# offline, deterministic, and every blob is known. It deliberately does NOT clone
+# the real repo: the first version of these tests did, and two of them passed
+# vacuously because the fixture's own origin fed the hook a baseline that moved.
+#
+#   bash scripts/tests/test_base_clone_staleness.sh        run
+#   bash scripts/tests/test_base_clone_staleness.sh -v     show hook output per case
+#
+# Also run by `scripts/run-tests.sh` as a SHELL_TESTS target — a suite nothing
+# invokes is a guard that reports no failures.
+#
+# 🔴 Validate the harness itself before trusting a green run: break the hook on
+# purpose (e.g. make the guard always skip) and confirm cases go RED. A suite you
+# have never watched fail is a claim about your shell, not about the code. The
+# documented mutation control:
+#
+#   sed 's/rev-list -n 100/rev-list -n 0/' scripts/claude-hooks/base-clone-staleness.sh > /tmp/m.sh
+#   HOOK=/tmp/m.sh bash scripts/tests/test_base_clone_staleness.sh   # must report FAIL 1
+#
+# 🔴 HOOK defaults to the REPO copy, resolved relative to THIS FILE — never to a
+# deployed per-host path under ~/.claude/. A default pointing at the deployed
+# copy makes the tracked suite grade an UNTRACKED file: the gate goes green
+# against something that is not in the commit, and stays green after the tracked
+# hook is edited. The `HOOK=` override is deliberate and load-bearing — the
+# mutation control above depends on it.
+
+set -uo pipefail
+
+# 🔴 `CDPATH=` first: with CDPATH set in the caller's environment `cd <dir>`
+# PRINTS the resolved directory, so `$(cd … && pwd)` yields a TWO-LINE value and
+# HOOK below becomes an unopenable path. `run-tests.sh` unsets it for its
+# children, but this suite is also run by hand — and this exact trap already cost
+# this repo a red gate whose message pointed at the wrong thing entirely
+# (test_release_wrapper.sh; see the CDPATH comment in run-tests.sh).
+CDPATH=
+_SUITE_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+HOOK="${HOOK:-$_SUITE_DIR/../claude-hooks/base-clone-staleness.sh}"
+if [ ! -f "$HOOK" ]; then
+  printf 'test_base_clone_staleness: hook not found at %s\n' "$HOOK" >&2
+  exit 2
+fi
+VERBOSE=0; [ "${1:-}" = "-v" ] && VERBOSE=1
+TMP="$(mktemp -d /tmp/bcs-test-XXXXXX)"
+PASS=0; FAIL=0
+GIT_ID=(-c user.email=t@test -c user.name=test -c commit.gpgsign=false)
+
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+ok()   { PASS=$((PASS+1)); printf '  PASS  %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; }
+check(){ if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (got '$2', want '$3')"; fi; }
+
+# Assert a precondition. A precondition that does not hold makes the case
+# VACUOUS, not passing -- this is what turned two earlier tests green while
+# measuring nothing.
+pre() { if [ "$2" != "$3" ]; then bad "PRECONDITION $1 (got '$2', want '$3') -- case is vacuous"; return 1; fi; return 0; }
+
+run_hook() { # run_hook <dir> [env assignments...]
+  local d="$1"; shift
+  echo '{}' | env -C "$d" "$@" bash "$HOOK" 2>&1
+}
+
+blob()   { git -C "$1" hash-object "$2" 2>/dev/null; }
+upblob() { git -C "$1" rev-parse "origin/fixture:$2" 2>/dev/null; }
+
+# ---------------------------------------------------------------------------
+# Fixture: a bare remote, a "primary clone" (work), and a second clone (author)
+# used to advance upstream. Branch is `fixture`, never main/master.
+# ---------------------------------------------------------------------------
+mkfixture() { # mkfixture <name> -> echoes the work dir
+  local n="$1" r="$TMP/$1-remote.git" w="$TMP/$1-work" a="$TMP/$1-author"
+  git init -q --bare "$r"
+  git clone -q "$r" "$w" 2>/dev/null
+  git -C "$w" checkout -q -b fixture
+  mkdir -p "$w/.claude/skills/demo"
+  printf 'CLAUDE v1\n' > "$w/CLAUDE.md"
+  printf 'demo skill v1\n' > "$w/.claude/skills/demo/SKILL.md"
+  git -C "$w" add CLAUDE.md .claude/skills/demo/SKILL.md
+  git -C "$w" "${GIT_ID[@]}" commit -qm c1
+  git -C "$w" push -q origin fixture
+  git -C "$w" branch -q --set-upstream-to=origin/fixture fixture
+  git clone -q -b fixture "$r" "$a" 2>/dev/null
+  echo "$w"
+}
+
+# Advance upstream by one commit. Pass the CLAUDE.md body; optionally create a
+# brand-new skill file (the case that used to be misreported as FAILED).
+advance() { # advance <name> <claude-body> [newfile-relpath]
+  local n="$1" body="$2" newfile="${3:-}" a="$TMP/$1-author"
+  printf '%s\n' "$body" > "$a/CLAUDE.md"
+  printf '%s\n' "$body-skill" > "$a/.claude/skills/demo/SKILL.md"
+  git -C "$a" add CLAUDE.md .claude/skills/demo/SKILL.md
+  if [ -n "$newfile" ]; then
+    mkdir -p "$a/$(dirname "$newfile")"
+    printf 'brand new upstream file\n' > "$a/$newfile"
+    git -C "$a" add "$newfile"
+  fi
+  git -C "$a" "${GIT_ID[@]}" commit -qm "advance $body"
+  git -C "$a" push -q origin fixture
+}
+
+say() { printf '\n== %s\n' "$1"; }
+vecho() { [ "$VERBOSE" = 1 ] && printf '     | %s\n' "$1"; return 0; }
+
+# ---------------------------------------------------------------------------
+say "1. refreshes a stale context file, and CREATES one that is new upstream"
+# Defect: `git hash-object` fatals on a path missing locally, and the empty
+# result was classified FAILED -- so a newly-added upstream skill was never
+# created in a stale clone, and the report called it an error.
+W=$(mkfixture t1)
+advance t1 "CLAUDE v2" ".claude/skills/newskill/SKILL.md"
+git -C "$W" fetch -q origin fixture
+pre "CLAUDE.md is stale" "$(blob "$W" CLAUDE.md)" "$(git -C "$W" rev-parse HEAD:CLAUDE.md)" && {
+  pre "new file absent locally" "$([ -e "$W/.claude/skills/newskill/SKILL.md" ] && echo yes || echo no)" "no" && {
+    OUT=$(run_hook "$W"); vecho "$OUT"
+    check "stale CLAUDE.md refreshed to upstream" "$(blob "$W" CLAUDE.md)" "$(upblob "$W" CLAUDE.md)"
+    check "new upstream file created"             "$([ -e "$W/.claude/skills/newskill/SKILL.md" ] && echo yes || echo no)" "yes"
+    check "new file has upstream content"         "$(blob "$W" .claude/skills/newskill/SKILL.md)" "$(upblob "$W" .claude/skills/newskill/SKILL.md)"
+    check "no FAILED bucket"                      "$(grep -c 'FAILED' <<<"$OUT")" "0"
+  }
+}
+
+# ---------------------------------------------------------------------------
+say "2. refreshes AGAIN after upstream moves a second time"
+# 🔴 The self-blocking defect. `git checkout <ref> -- <path>` writes the INDEX
+# too, so after one refresh the path differs from HEAD forever; a guard keyed on
+# "differs from HEAD" then skipped it on every later run and the hook worked
+# exactly once per file. An idempotence test CANNOT see this -- re-running with
+# nothing new upstream is a no-op either way. Upstream must move between runs.
+W=$(mkfixture t2)
+advance t2 "CLAUDE v2"; git -C "$W" fetch -q origin fixture
+run_hook "$W" >/dev/null
+V2=$(blob "$W" CLAUDE.md)
+pre "first refresh landed v2" "$V2" "$(upblob "$W" CLAUDE.md)" && {
+  pre "path now differs from HEAD (the trap)" "$(git -C "$W" diff --name-only HEAD -- CLAUDE.md)" "CLAUDE.md" && {
+    advance t2 "CLAUDE v3"; git -C "$W" fetch -q origin fixture
+    pre "v3 differs from v2" "$([ "$(upblob "$W" CLAUDE.md)" != "$V2" ] && echo yes || echo no)" "yes" && {
+      OUT=$(run_hook "$W"); vecho "$OUT"
+      check "second refresh landed v3" "$(blob "$W" CLAUDE.md)" "$(upblob "$W" CLAUDE.md)"
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+say "3. NEVER clobbers unique local work"
+W=$(mkfixture t3)
+advance t3 "CLAUDE v2"; git -C "$W" fetch -q origin fixture
+printf 'UNIQUE-LOCAL-SENTINEL-do-not-destroy\n' >> "$W/.claude/skills/demo/SKILL.md"
+BEFORE=$(blob "$W" .claude/skills/demo/SKILL.md)
+pre "sentinel content is not upstream's" "$([ "$BEFORE" != "$(upblob "$W" .claude/skills/demo/SKILL.md)" ] && echo yes || echo no)" "yes" && {
+  OUT=$(run_hook "$W"); vecho "$OUT"
+  check "local edit preserved"      "$(blob "$W" .claude/skills/demo/SKILL.md)" "$BEFORE"
+  check "sentinel text intact"      "$(grep -c 'UNIQUE-LOCAL-SENTINEL' "$W/.claude/skills/demo/SKILL.md")" "1"
+  check "reported as skipped"       "$(grep -c 'SKIPPED' <<<"$OUT")" "1"
+  check "CLAUDE.md still refreshed" "$(blob "$W" CLAUDE.md)" "$(upblob "$W" CLAUDE.md)"
+}
+
+# ---------------------------------------------------------------------------
+say "4. a locally DELETED context file is restored"
+# Flip side of the protection rule: absent locally == nothing to protect. Worth
+# pinning because it surprises people -- deleting a skill only in the primary
+# clone does nothing durable.
+W=$(mkfixture t4)
+advance t4 "CLAUDE v2"; git -C "$W" fetch -q origin fixture
+rm -f "$W/.claude/skills/demo/SKILL.md"
+pre "file is gone" "$([ -e "$W/.claude/skills/demo/SKILL.md" ] && echo yes || echo no)" "no" && {
+  OUT=$(run_hook "$W"); vecho "$OUT"
+  check "deleted file restored" "$([ -e "$W/.claude/skills/demo/SKILL.md" ] && echo yes || echo no)" "yes"
+}
+
+# ---------------------------------------------------------------------------
+say "5. BASE_CLONE_NO_REFRESH=1 writes nothing (with a positive control)"
+# A "no write" result is meaningless unless the same fixture DOES write without
+# the flag -- otherwise a hook wired to nothing passes this case.
+W=$(mkfixture t5)
+advance t5 "CLAUDE v2"; git -C "$W" fetch -q origin fixture
+B0=$(blob "$W" CLAUDE.md)
+OUT=$(run_hook "$W" BASE_CLONE_NO_REFRESH=1); vecho "$OUT"
+check "opt-out: file untouched"    "$(blob "$W" CLAUDE.md)" "$B0"
+check "opt-out: reason is accurate" "$(grep -c 'opted out' <<<"$OUT")" "1"
+check "opt-out: no false 'local edits' claim" "$(grep -c 'local edits' <<<"$OUT")" "0"
+OUT=$(run_hook "$W")
+check "POSITIVE CONTROL: writes without the flag" "$(blob "$W" CLAUDE.md)" "$(upblob "$W" CLAUDE.md)"
+
+# ---------------------------------------------------------------------------
+say "6. stays silent where it must"
+W=$(mkfixture t6)
+check "current clone -> no output" "$(run_hook "$W" | wc -c)" "0"
+git -C "$W" worktree add -q --detach "$TMP/t6-wt" HEAD 2>/dev/null
+check "linked worktree -> no output" "$(run_hook "$TMP/t6-wt" | wc -c)" "0"
+mkdir -p "$TMP/not-a-repo"
+check "non-repo -> no output" "$(run_hook "$TMP/not-a-repo" | wc -c)" "0"
+
+# ---------------------------------------------------------------------------
+say "7. concurrent session starts do not corrupt or wedge the clone"
+# Per-file checkout took .git/index.lock once per file, so two simultaneous runs
+# collided repeatedly (measured FAILED 12/12; a per-file retry barely helped --
+# the contention is sustained, not a narrow window). The refresh is now ONE
+# batched checkout. This case pins the invariants, not the failure count, which
+# is inherently racy.
+W=$(mkfixture t7)
+advance t7 "CLAUDE v2" ".claude/skills/another/SKILL.md"
+git -C "$W" fetch -q origin fixture
+( run_hook "$W" >/dev/null 2>&1 ) & ( run_hook "$W" >/dev/null 2>&1 ) & wait
+check "no index.lock left behind" "$([ -e "$W/.git/index.lock" ] && echo yes || echo no)" "no"
+check "repo still usable"         "$(git -C "$W" status --short >/dev/null 2>&1 && echo yes || echo no)" "yes"
+check "CLAUDE.md ended correct"   "$(blob "$W" CLAUDE.md)" "$(upblob "$W" CLAUDE.md)"
+check "new file ended present"    "$([ -e "$W/.claude/skills/another/SKILL.md" ] && echo yes || echo no)" "yes"
+
+# ---------------------------------------------------------------------------
+say "8. output is valid JSON with the SessionStart contract"
+W=$(mkfixture t8)
+advance t8 "CLAUDE v2"; git -C "$W" fetch -q origin fixture
+OUT=$(run_hook "$W")
+check "parses as JSON"        "$(jq -e . <<<"$OUT" >/dev/null 2>&1 && echo yes || echo no)" "yes"
+check "carries systemMessage" "$(jq -r 'has("systemMessage")' <<<"$OUT" 2>/dev/null)" "true"
+check "hookEventName correct" "$(jq -r '.hookSpecificOutput.hookEventName' <<<"$OUT" 2>/dev/null)" "SessionStart"
+
+printf '\n=====================================\n'
+printf 'PASS %d   FAIL %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/tests/test_no_real_launchers_all_targets.py
+++ b/scripts/tests/test_no_real_launchers_all_targets.py
@@ -191,9 +191,17 @@ def test_the_non_pytest_targets_are_covered_and_named():
     # split between "fails" and "passes because the helper returns false for
     # every input". It touches no launcher and no spool — it sources
     # resume-state.sh and asserts pure extraction helpers on fixture strings.
+    # Third entry: `test_base_clone_staleness.sh`, registered when the suite
+    # LANDED rather than after being found ungated — the only difference between
+    # it and the two above. It touches no launcher: it drives
+    # `scripts/claude-hooks/base-clone-staleness.sh` against local bare-repo
+    # fixtures under a mktemp dir, and every fixture commit carries its identity
+    # via `git -c user.email=…`, so it reaches no real remote and needs nothing
+    # from the operator's gitconfig.
     assert shells == [
         "scripts/tests/test_release_wrapper.sh",
         "scripts/tests/test_resume_state.sh",
+        "scripts/tests/test_base_clone_staleness.sh",
     ], shells
     for rel in hooks + shells:
         assert (REPO_ROOT / rel).is_file(), f"{rel} is listed but does not exist"


### PR DESCRIPTION
Two files existed only as untracked, per-host copies in `~/.claude/local-hooks/` — present on exactly one machine, in no commit, covered by no gate. This lands them and deploys the script via home-manager.

## Why the hook exists

When all work happens in throwaway worktrees + PRs, a base clone is never written to and silently falls behind. That is harmless for **writes** — `git worktree add <path> origin/<branch>` resolves the *remote* ref, so a clone 700 commits behind still yields a current worktree — but dangerous for **reads**: `CLAUDE.md` and `.claude/skills/**` load into agent context *from the working tree*, so a stale clone serves stale, authoritative-looking instructions with nothing on screen to indicate it.

On `SessionStart` it fetches the cwd repo's upstream and `git checkout <upstream> --`s **only** those two paths. It does not move HEAD, never overwrites content that is absent from the upstream branch's recent history, and emits a one-line JSON `systemMessage` naming what it touched. `BASE_CLONE_NO_REFRESH=1` makes it report-only.

## What changed

| Path | |
|---|---|
| `scripts/claude-hooks/base-clone-staleness.sh` | the hook, **byte-identical** to the per-host copy (8940 bytes, `cmp` clean). Header prose preserved verbatim — each 🔴 block records a defect that actually shipped. |
| `scripts/tests/test_base_clone_staleness.sh` | its suite: 24 assertions / 8 cases, offline synthetic fixtures. Renamed hyphens → `test_*.sh` to match the two bash suites already there. |
| `scripts/run-tests.sh` | registered as a third `SHELL_TESTS` target. |
| `scripts/tests/test_no_real_launchers_all_targets.py` | `SHELL_TESTS` is a pinned ledger asserted exactly both ways — the new entry is added there with its rationale rather than silently widening the list. |
| `nix/home.nix` | `home.file.".claude/hooks/base-clone-staleness.sh"`, `executable = true`. |

### The one edit that is not a copy

🔴 The suite's `HOOK` default previously resolved to the script's own directory — i.e. the **deployed per-host copy**. Tracked unchanged, that would have made this gate grade an **untracked** file: green about something not in the commit, and *still* green after the tracked hook was edited. It now resolves `../claude-hooks/` relative to the suite's own location, with a not-found guard. The `HOOK=` override is kept — the mutation control depends on it. `CDPATH=` is set before the `$(cd … && pwd)`: with `CDPATH` set, `cd` prints the resolved dir and the value returns two lines long — the exact trap that already produced a red gate with a misleading message in `test_release_wrapper.sh`.

### Registration stays per-host, deliberately

`register-nudge-hook.py` does **not** own this. That is structural, not an omission: the registrar's managed-command surface recognises `<python> <path>.py` commands only, and its whole rewrite half exists to normalise a python interpreter token to an absolute `/nix/store` path. This hook is bash — no interpreter hazard to fix, nothing to match, and teaching that shared component a second interpreter would widen a load-bearing surface for no benefit. Same known gap `bash-guard.py` has.

No `force = true` / `dropStaleClaudeHooks`, per the precedent the `register-nudge-hook.py` block records verbatim — that treatment exists only to displace a pre-existing **hand-placed regular file**. Measured before the first switch: `ls -la ~/.claude/hooks/` shows 14 entries, all `/nix/store` symlinks, no regular files, no `base-clone-staleness.sh`. The copy being replaced lives in `~/.claude/local-hooks/`, which this attribute never writes to.

## Verification — pairs, not lone greens

- Suite from the **repo** copy: `PASS 24  FAIL 0`
- Mutation control (`rev-list -n 100` → `-n 0`) via `HOOK=`: `PASS 23  FAIL 1`
- 🔴 The control covering *this PR's* edit: mutating the worktree hook **in place with no `HOOK` override** → `PASS 23  FAIL 1`, and `PASS 24  FAIL 0` once restored. That is what proves the new default is bound to the repo copy rather than a per-host path; the green alone could not show it.
- Hostile `CDPATH=/tmp`: `PASS 24  FAIL 0`
- **The shipped runner executes it** — `=== script scripts/tests/test_base_clone_staleness.sh ===` → `PASS … (script)`, with GUARD 7/8/10 accounting it: `intercepted=0`, `spool-rows=0`, `real-config-changed=0/3` (reaches no launcher, touches none of the operator's git config).
- `nix build .#homeConfigurations.zach.activationPackage` (`--impure`; the config's pre-existing out-of-store `/home` symlinks forbid pure eval): builds, and the hook is **in the closure** at `.claude/hooks/base-clone-staleness.sh`, mode `r-xr-xr-x`, byte-identical to the committed copy — with a negative control confirming `cmp` can tell the files apart.
- `test_no_real_launchers_all_targets.py` + `test_runtime_shebangs.py`: 24 passed.

## 🔴 Post-merge operator steps this PR deliberately does NOT do

**Order is load-bearing — reversing 1 and 2 leaves the hook inert.**

1. `home-manager switch` — lands `~/.claude/hooks/base-clone-staleness.sh`.
2. **Verify that path exists**, *then* repoint the `SessionStart` entry in `~/.claude/settings.json` from `bash /home/zach/.claude/local-hooks/base-clone-staleness.sh` to the new `~/.claude/hooks/` path.
3. Start a fresh session and confirm the one-line staleness banner still appears.
4. **Only then** delete the two files in `~/.claude/local-hooks/`.

On any **other** host the switch delivers the script but **no** `settings.json` entry, so it is inert there until registered by hand — the same known gap `bash-guard.py` has.
