### PR TITLE
skill(clawgate): task↔session threads shipped in #357 and the skill never learned they exist

### DIFF
--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -59,7 +59,7 @@ Memories: `clawgate-phase2` · `clawgate-phase3` · `clawgate-runbooks` ·
 | LAN URL (hook + UI) | `http://192.168.50.250:30302` (NodePort) — **OPEN, no auth**; machine endpoints still need the token |
 | Public / nebula URL | `https://clawgate.zacx.dev` behind **Authelia passkey** (portal `login.zacx.dev`); laptop `http://10.42.0.10:8109` (homelab gateway) |
 | Hook events | `PermissionRequest` (`CLAWGATE_REMOTE_APPROVAL=off`) + `Stop` (async, `CLAWGATE_SUGGEST=off`), both in `~/.claude/settings.json`, ON by default. 🔴 The `Stop` array also carries **two** unrelated hooks (`tmux/task-hook.sh`, `claude-notify.py`) — **preserve both** |
-| 🔴 Machine client | **`clawgatectl`** (devrc `nix/pkgs/tools/clawgatectl.nix`; on PATH after a switch). 🔴 **Built from a LOCAL working tree of homelab-talos, so it can be present but STALE** — a behind checkout ships a binary MISSING verbs that prints help and **exits 0** under a plausible version label. Closed both ways (devrc #536): the version derives from the compiled source, and `drift-check.sh` **rc 17** reports a stale source subtree per host; a checkout lacking `cmd/clawgatectl` gets no binary at all. **Exactly eight commands**: `health` · `agent ls` · `agent resolve <name> [--id]` · `task ls/get/create` · **`task status <id> <status>`** · **`task comment <id> --body …`** (the last two hit pre-existing routes — NO server release needed). Reads `clawgate.env` itself (no token in argv); JSON on stdout only; rc 0–8. **Every other route is still curl.** `task-api.md` |
+| 🔴 Machine client | **`clawgatectl`** (devrc `nix/pkgs/tools/clawgatectl.nix`; on PATH after a switch). 🔴 **Built from a LOCAL working tree of homelab-talos, so it can be present but STALE** — a behind checkout ships a binary MISSING verbs that prints help and **exits 0** under a plausible version label. JSON on stdout only; rc 0–8. **Every other route is still curl.** Commands, config, the staleness closure and the skew note: `task-api.md` |
 
 🔴 **clawgate has NO human auth of its own** (since 0.7.37): `requireSession` is a pass-through no-op,
 so **the LAN NodePort is fully unauthenticated** — including `DELETE /tasks/{id}` and 🔴 **`POST
@@ -145,14 +145,11 @@ create** — a load-bearing wire contract producers key their retry on.
 ⚠ **A task body may carry extension-picked element references** — never search the selector first
 (`element-references.md`).
 
-⚠ **Task ↔ session THREADS exist, but the query is ONE-WAY.** Since #357 (0.7.98) each task records
-which sessions touched it (`task_sessions`; roles `created` / `worked` / `read`) and `/ui/tasks`
-renders a `👥 N session(s)` chip. **There is NO task→sessions route** — `GET /api/tasks/{id}/sessions`
-404s and is absent from `routes.golden`; only the REVERSE lookup `GET /api/sessions/{id}/tasks` is
-callable, and `clawgatectl` has a subcommand for neither. So *"which sessions worked task N"* is
-answerable **only by reading the UI**. 🔴 Membership OVER-reports and never downgrades: a
-**400-rejected** PATCH still records `worked` (card #306), and a **subagent inherits the parent's
-session id**, so a subagent's mere read links the PARENT to a task nobody worked.
+⚠ **Task↔session threads (#357) are ONE-WAY.** `/ui/tasks` shows a `👥 N` chip, but
+`GET /api/tasks/{id}/sessions` **404s** — only the reverse `GET /api/sessions/{id}/tasks` is
+callable and `clawgatectl` has neither, so *"which sessions worked task N"* is **UI-only**.
+🔴 Membership OVER-reports and never downgrades: a 400-rejected PATCH still records `worked` (#306),
+and a subagent inherits the parent's session id. `task-api.md`
 
 **Writing/debugging a producer? Load `task-api.md`** — per-op semantics + status codes,
 409/immutability, the author allowlist, provenance, tag grammar, the route×auth inventory.

--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -145,6 +145,15 @@ create** — a load-bearing wire contract producers key their retry on.
 ⚠ **A task body may carry extension-picked element references** — never search the selector first
 (`element-references.md`).
 
+⚠ **Task ↔ session THREADS exist, but the query is ONE-WAY.** Since #357 (0.7.98) each task records
+which sessions touched it (`task_sessions`; roles `created` / `worked` / `read`) and `/ui/tasks`
+renders a `👥 N session(s)` chip. **There is NO task→sessions route** — `GET /api/tasks/{id}/sessions`
+404s and is absent from `routes.golden`; only the REVERSE lookup `GET /api/sessions/{id}/tasks` is
+callable, and `clawgatectl` has a subcommand for neither. So *"which sessions worked task N"* is
+answerable **only by reading the UI**. 🔴 Membership OVER-reports and never downgrades: a
+**400-rejected** PATCH still records `worked` (card #306), and a **subagent inherits the parent's
+session id**, so a subagent's mere read links the PARENT to a task nobody worked.
+
 **Writing/debugging a producer? Load `task-api.md`** — per-op semantics + status codes,
 409/immutability, the author allowlist, provenance, tag grammar, the route×auth inventory.
 

--- a/claude/skills/clawgate/reference/task-api.md
+++ b/claude/skills/clawgate/reference/task-api.md
@@ -335,6 +335,37 @@ directly above: a count re-derived against a live pin decays the moment the next
 `grep -vc '^#' routes.golden` (the file's first three lines are comments) and subtract anything
 committed after the live pin.
 
+### Task ↔ session threads (#357, 0.7.98) — the direction that EXISTS, and the one that does not
+
+The `task_sessions` table records which Claude Code sessions touched a task, with a role of
+`created` / `worked` / `read`, and `/ui/tasks` renders a `👥 N session(s)` chip with a deep link.
+🔴 **The link is written by the SERVER as a side effect of the request; there is no producer API for
+it,** and the query is asymmetric:
+
+| direction | surface | state |
+|---|---|---|
+| session → tasks | `GET /api/sessions/{id}/tasks` | ✅ callable (hook token), pinned in the golden |
+| task → sessions | *(none)* | 🔴 **no route.** `GET /api/tasks/{id}/sessions` returns **404** and appears nowhere in `routes.golden` |
+| either direction | `clawgatectl` | 🔴 **no subcommand** — not under `task`, not top-level |
+
+So *"which sessions worked task N"* — the question the feature was built to answer — is today
+answerable **only by reading `/ui/tasks`**. A machine consumer can ask the reverse question only.
+
+🔴 **Membership OVER-reports, and a role NEVER downgrades.** Two measured causes, both live:
+- a **400-rejected** `PATCH` still records the session as having `worked` the task: `noteTaskSession`
+  (defined in `internal/api/task_sessions.go`, called from the PATCH handler in
+  `internal/api/notes.go`) runs **before** the body/tag validation that rejects the request —
+  verified on trunk, the call precedes both `StatusBadRequest` returns in that handler. Card #306
+  carries three fix options;
+- a **subagent inherits the parent's `CLAUDE_CODE_SESSION_ID`**, so a subagent merely *reading* a
+  task links the **parent** session to work it never did.
+
+⚠ **No FK to `cc_sessions`, deliberately** — that table is swept at 14 days, and a cascading FK would
+silently empty every thread, making a task that HAD five sessions render identically to one that
+never had any. Link rows denormalise `project` / `cwd` / `host`; expect most rows to have no live
+detail link once their session is reaped. The cap is **advisory** and must never fail a request:
+evict oldest `read`, never `created`/`worked`; if nothing is evictable, skip and count.
+
 🔴 **The golden records PATTERNS ONLY — it is BLIND to auth.** By the time a handler reaches the
 mux it is already wrapped, so `requireHookToken(h)` and `requireSession(h)` are the same type and
 the gate cannot tell them apart. **A route silently moving between wrappers keeps that test green.**


### PR DESCRIPTION
Asked "did task-threads land and get integrated into the skill?" — the answer was **landed, not integrated**, so this closes the second half.

`clawgate/SKILL.md` had **zero** mentions of session threads. `reference/task-api.md` mentioned only the *reverse* route, and only as a note about whether it was callable — not as documentation of the feature.

## Measured against live 0.7.98 + trunk, not inferred

```
GET /api/sessions/{id}/tasks   -> 200   (pinned in routes.golden)
GET /api/tasks/{id}/sessions   -> 404   (absent from routes.golden entirely)
clawgatectl                    -> no subcommand for either direction
```

So the question the feature was built to answer — *"which sessions worked task N"* — is today answerable **only by reading `/ui/tasks`**. A machine consumer can ask the reverse question only.

That asymmetry is the thing most likely to cost someone an afternoon (I found it by guessing the obvious route and getting a 404), so it is now stated in both files instead of waiting to be rediscovered.

## Also documented: membership OVER-reports, and a role never downgrades

Both causes are live:

- **A 400-rejected `PATCH` still records `worked`.** Verified on trunk rather than copied from the handoff: `noteTaskSession(…, RoleWorked)` is called at `notes.go:786`, and **both** `StatusBadRequest` returns in that handler are at 803 and 815 — *after* it. ⚠️ The handoff cited `notes.go` for the function itself; it is **defined** in `task_sessions.go:122` and only *called* from `notes.go`. Corrected here.
- **A subagent inherits the parent's `CLAUDE_CODE_SESSION_ID`**, so a subagent merely *reading* a task links the **parent** session to work it never did.

Plus why there is deliberately **no FK to `cc_sessions`** (swept at 14d — a cascading FK would silently empty every thread, making a task that *had* five sessions render identically to one that never had any), and the advisory-cap semantics.

## Size

Deliberately asymmetric. **SKILL.md +779 B** — 8 lines: the feature, the one-way limit, the two over-report traps. **`reference/task-api.md` +2.0 KB**, which loads on demand.

#660 cut this SKILL.md 18,858 → 15,088 B two days ago and that intent is worth respecting. There is no automated size gate on it — `test_prune_skill_size.py` governs `prune-skill`, not this one (checked rather than assumed).

## Gate

`scripts/tests/test_skill_descriptions.py` + `test_skill_audit.py` — **105 passed**.

Not the full `run-tests.sh`: it refuses on this host with `FATAL — required tool(s) missing from PATH: logrotate`, by design rather than skipping silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)