### PR TITLE
fix(opencode): narrow the recursive-rm globs — "*rm*-r*" ate ordinary read-only commands

### DIFF
--- a/scripts/opencode/opencode.jsonc
+++ b/scripts/opencode/opencode.jsonc
@@ -70,24 +70,48 @@
 // that fires too often on a mutation family is a far better failure than an
 // `ask` that never fires on the spelling an operator actually types.
 //
-// 🔴 ONE DELIBERATE EXCEPTION — the only rule ever narrowed AWAY from a
+// 🔴 TWO DELIBERATE EXCEPTIONS — the only rules ever narrowed AWAY from a
 // working infix form (several rules, e.g. `*chmod -R*`, `*dd if=*`, `*sudo *`,
 // were written binary-plus-literal-flag from the start; this is not a claim
-// that every other pattern is infix): the two `age` decrypt
-// rules are `*age -d*` / `*age --decrypt*` — leading-`*` but NOT infix. The
-// infix form `*age*-d*` matched any text with "age" followed LATER by "-d",
-// and "age" is a substring of package, packages, image, message, storage and
-// manage while "-d" covers -db-, --dir, --debug and --dry-run. Because
-// `opencode run` AUTO-REJECTS an ask rather than prompting, that over-match did
-// not "fire too often" — it KILLED runs on `ls packages/…-db-…` and
-// `grep … packages/…`. Measured 2026-08-21; two real dispatches died on it.
-// The trade is real and is NOT free: the narrowed rules know exactly one
-// argument order, so reordered spellings like `age -i k.txt -d f` now resolve
-// ALLOW, and guard_core.py has NO age/sops check to catch them. That gap is
-// pinned as a characterization test —
-// `test_age_glob_misses_these_reordered_decrypt_spellings` — so it stays
-// visible. Do NOT "restore consistency" by re-widening these to infix without
-// reading that test first.
+// that every other pattern is infix). Both were narrowed for the SAME measured
+// reason, one day apart, and the second is why this heading says TWO:
+//
+//   (a) the two `age` decrypt rules, `*age -d*` / `*age --decrypt*` —
+//       leading-`*` but NOT infix. The infix form `*age*-d*` matched any text
+//       with "age" followed LATER by "-d", and "age" is a substring of package,
+//       packages, image, message, storage and manage while "-d" covers -db-,
+//       --dir, --debug and --dry-run. Measured 2026-08-21; two real dispatches
+//       died on it, one on `grep`, one on `ls`.
+//
+//   (b) the two `rm` recursive rules, `*rm -r*` / `*rm --recursive*`. The infix
+//       form `*rm*-r*` was the identical defect: "rm" is a substring of format,
+//       terraform, firmware, confirm and platform, and "-r" covers --reverse,
+//       --refresh, --reporter, --repo and --recursive. Measured 2026-08-22:
+//       `git log --format=oneline --reverse`, `terraform plan -refresh=false`,
+//       `rg '…format…' src/ --replace ''` and `pnpm run format --reporter=…`
+//       all resolved ASK. The first three are pinned as MUST_ALLOW rows in
+//       test_opencode_config.py and were watched to FAIL before the narrowing.
+//       It needed a SECOND rule, not just a narrowing: "rm --recursive" does not
+//       contain the literal "rm -r", so dropping the inner `*` alone would have
+//       released an ordinary recursive delete that the guard layer does not
+//       backstop — measured by deleting that row: it drops to plain ALLOW.
+//
+// WHY THESE TWO AND NOT THE REST. Because `opencode run` AUTO-REJECTS an ask
+// rather than prompting, an over-match on a family an agent types CONSTANTLY
+// does not "fire too often" — it KILLS the run mid-task. That inverts the trade
+// argued above, but only for patterns whose binary name is a substring of
+// ordinary English/flag text. `kubectl`, `talosctl`, `sops`, `sudoedit` are not,
+// which is why they stay infix.
+//
+// THE TRADE IS REAL AND IS NOT FREE, in the same way for both: a narrowed rule
+// knows exactly one argument order, so `age -i k.txt -d f` and `rm -f -r <path>`
+// now resolve ALLOW. guard_core.py has NO age/sops check at all, and its `rm`
+// check has a deliberately narrow TARGET set that an ordinary project path never
+// reaches. Both gaps are pinned as characterization tests —
+// `test_age_glob_misses_these_reordered_decrypt_spellings` and
+// `test_rm_glob_misses_these_recursive_spellings` — so they stay visible. Do NOT
+// "restore consistency" by re-widening any of these four rules to infix without
+// reading those tests first.
 //
 // Other measured facts baked into this file (v1.18.18, EXCEPT where a bullet
 // says otherwise — the 2026-08-19 re-derivation could not reach three of them,
@@ -345,7 +369,21 @@
       // --- filesystem blast radius ---
       "*chmod -R*": "ask",
       "*chown -R*": "ask",
-      "*rm*-r*": "ask",
+      // 🔴 NOT INFIX, ON PURPOSE — exception (b) in the header. `*rm*-r*` matched
+      // "rm" followed LATER by "-r" ANYWHERE in the command text — note the
+      // ORDER: the "rm" substring must come FIRST, so it took `git log
+      // --format=oneline --reverse` and `terraform plan -refresh=false` but not
+      // `grep -r 'format' src/`. That still auto-rejected ordinary read-only
+      // work wherever a format/terraform/firmware/confirm/platform token
+      // preceded a --reverse/--refresh/--reporter/--repo/--replace flag.
+      // BOTH ROWS ARE LOAD-BEARING and neither covers the other: "rm --recursive"
+      // does NOT contain the literal "rm -r", so deleting the second row releases
+      // `rm --recursive <path>` — which guard_core does not backstop on an
+      // ordinary path. Each is pinned individually in MUST_ASK.
+      // Known gap, pinned by test_rm_glob_misses_these_recursive_spellings:
+      // `-R` bundles and any flag placed BEFORE `-r` (`rm -f -r <path>`).
+      "*rm -r*": "ask",
+      "*rm --recursive*": "ask",
       // `dd` stays ANCHORED / operand-scoped on purpose: a leading-`*` `"*dd *"`
       // also matches `git add src/` (…"add "…), and gating every `git add` is
       // exactly the prompt fatigue that trains an operator to click through.

--- a/scripts/opencode/opencode.jsonc
+++ b/scripts/opencode/opencode.jsonc
@@ -100,14 +100,30 @@
 // rather than prompting, an over-match on a family an agent types CONSTANTLY
 // does not "fire too often" — it KILLS the run mid-task. That inverts the trade
 // argued above, but only for patterns whose binary name is a substring of
-// ordinary English/flag text. `kubectl`, `talosctl`, `sops`, `sudoedit` are not,
-// which is why they stay infix.
+// ordinary English/flag text. `kubectl` and `sops` are not, which is why they
+// stay infix. (`*talosctl*` and `*sudoedit*` are single-token wildcards with no
+// middle `*` at all — they are not infix rules and are not evidence either way.)
 //
-// THE TRADE IS REAL AND IS NOT FREE, in the same way for both: a narrowed rule
-// knows exactly one argument order, so `age -i k.txt -d f` and `rm -f -r <path>`
-// now resolve ALLOW. guard_core.py has NO age/sops check at all, and its `rm`
-// check has a deliberately narrow TARGET set that an ordinary project path never
-// reaches. Both gaps are pinned as characterization tests —
+// 🔴 THE TRADE IS REAL, IS NOT FREE, AND THE TARGET NEED NOT BE DISPOSABLE.
+// A narrowed rule knows exactly one argument order, so `age -i k.txt -d f` and
+// `rm -f -r <path>` now resolve ALLOW. State the `rm` cost at its WORST, not its
+// mildest — the examples in the tests use `/repo/build`, but nothing restricts
+// it to a build dir. MEASURED at both layers on this config:
+//     rm -f -r ~/.ssh                        ALLOW   (was ask before the narrowing)
+//     rm -f -r /etc/nixos                    ALLOW   (was ask)
+//     rm --force --recursive /var/lib/…      ALLOW   (was ask)
+//     rm /repo/build -rf                     ALLOW   (was ask — flags AFTER the operand)
+// 🔴 But read the counterfactual before treating the narrowing as the cause:
+// `rm -fr ~/.ssh`, `rm -Rf ~/.ssh` and `rm -R ~/.ssh` were ALREADY plain ALLOW
+// at both layers BEFORE this change (measured on `main`). So this glob was never
+// a control for that target — the narrowing WIDENS an already-open hole, it does
+// not open one. The honest summary is: layer 1 does not protect `$HOME` from a
+// recursive delete and never did; if you want that, it belongs in guard_core.py,
+// per this header's own rule about irreversible families.
+// guard_core.py has NO age/sops check at all, and its `rm`
+// check has a deliberately narrow TARGET set — `/`, `~`/`$HOME`, `.`/`..` and
+// top-level system dirs — that a SUBPATH like `~/.ssh` never reaches.
+// Both gaps are pinned as characterization tests —
 // `test_age_glob_misses_these_reordered_decrypt_spellings` and
 // `test_rm_glob_misses_these_recursive_spellings` — so they stay visible. Do NOT
 // "restore consistency" by re-widening any of these four rules to infix without
@@ -380,8 +396,13 @@
       // does NOT contain the literal "rm -r", so deleting the second row releases
       // `rm --recursive <path>` — which guard_core does not backstop on an
       // ordinary path. Each is pinned individually in MUST_ASK.
-      // Known gap, pinned by test_rm_glob_misses_these_recursive_spellings:
-      // `-R` bundles and any flag placed BEFORE `-r` (`rm -f -r <path>`).
+      // Known gap, pinned by test_rm_glob_misses_these_recursive_spellings, in
+      // THREE classes: `-R` bundles (pre-existing), any flag placed BEFORE `-r`
+      // (`rm -f -r <path>`, opened here), and flags placed AFTER the operand
+      // (`rm <path> -rf`, opened here — GNU rm permutes options, so it works).
+      // 🔴 And the target is not restricted to a build dir: `rm -f -r ~/.ssh` is
+      // ALLOW at both layers. See the header for the counterfactual — `rm -fr
+      // ~/.ssh` was already ALLOW before this change, so layer 1 never gated it.
       "*rm -r*": "ask",
       "*rm --recursive*": "ask",
       // `dd` stays ANCHORED / operand-scoped on purpose: a leading-`*` `"*dd *"`

--- a/scripts/opencode/opencode.jsonc
+++ b/scripts/opencode/opencode.jsonc
@@ -101,8 +101,10 @@
 // does not "fire too often" — it KILLS the run mid-task. That inverts the trade
 // argued above, but only for patterns whose binary name is a substring of
 // ordinary English/flag text. `kubectl` and `sops` are not, which is why they
-// stay infix. (`*talosctl*` and `*sudoedit*` are single-token wildcards with no
-// middle `*` at all — they are not infix rules and are not evidence either way.)
+// stay infix. (The *rules named* `*talosctl*` and `*sudoedit*` are single-token
+// wildcards with no middle `*` at all, so they are not evidence either way —
+// but do not read that as "there is no infix talosctl rule": `*talosctl*reset*`
+// in the deny block below is one.)
 //
 // 🔴 THE TRADE IS REAL, IS NOT FREE, AND THE TARGET NEED NOT BE DISPOSABLE.
 // A narrowed rule knows exactly one argument order, so `age -i k.txt -d f` and
@@ -116,10 +118,14 @@
 // 🔴 But read the counterfactual before treating the narrowing as the cause:
 // `rm -fr ~/.ssh`, `rm -Rf ~/.ssh` and `rm -R ~/.ssh` were ALREADY plain ALLOW
 // at both layers BEFORE this change (measured on `main`). So this glob was never
-// a control for that target — the narrowing WIDENS an already-open hole, it does
-// not open one. The honest summary is: layer 1 does not protect `$HOME` from a
-// recursive delete and never did; if you want that, it belongs in guard_core.py,
-// per this header's own rule about irreversible families.
+// a RELIABLE control for that target — three ordinary spellings already walked
+// around it — and the narrowing WIDENS an already-open hole rather than opening
+// one. Do not overstate that in either direction: the old glob DID gate
+// `rm -f -r ~/.ssh` (it is `ask` on `main`, per the table above), so this is a
+// partial control being made weaker, not a no-op being blamed. The honest
+// summary is: layer 1 does not reliably protect `$HOME` from a recursive delete
+// and never did; if you want that, it belongs in guard_core.py, per this
+// header's own rule about irreversible families.
 // guard_core.py has NO age/sops check at all, and its `rm`
 // check has a deliberately narrow TARGET set — `/`, `~`/`$HOME`, `.`/`..` and
 // top-level system dirs — that a SUBPATH like `~/.ssh` never reaches.

--- a/scripts/tests/test_opencode_config.py
+++ b/scripts/tests/test_opencode_config.py
@@ -779,6 +779,12 @@ MUST_ALLOW = [
     # Third row deliberately mirrors `rg 'storage' src/ --debug` above: same
     # binary, different substring pair. `rg --replace` rewrites only the OUTPUT,
     # never a file, so this list stays honestly read-only.
+    # 🔴 Honest caveat on the `terraform` row, since this list's HEADER is itself
+    # a claim: `terraform plan` is read-only w.r.t. infrastructure, but it does
+    # take a STATE LOCK and can write a plan file with `-out`. It is pinned here
+    # because it is the measured witness from the narrowing, not because it is
+    # side-effect-free. If that ever matters, swap it for another token ending in
+    # a non-adjacent "rm" — the rule under test is the substring, not terraform.
     "git log --format=oneline --reverse",
     "terraform plan -refresh=false",
     "rg 'formatBytes' src/ --replace ''",
@@ -1505,21 +1511,44 @@ def test_rm_glob_misses_these_recursive_spellings():
     Their intersection is a recursive delete of a project directory written with
     `-R`, `-Rf` or `-fr`: ALLOW at both layers, no prompt.
 
-    🔴 THE LAST THREE ROWS ARE NEWLY OPEN, and they are the price of the
-    2026-08-22 narrowing. `"*rm*-r*"` matched "rm" followed LATER by "-r"
-    anywhere in the text, so it DID hold `rm -f -r <path>` — at the cost of
-    auto-rejecting `git log --format=… --reverse`, `terraform plan
-    -refresh=false` and any other text where a format/terraform/firmware/
-    confirm/platform token PRECEDES a `-r` flag (see the three MUST_ALLOW rows
-    added with this change; the order matters — `grep -r 'format' src/` was
-    never matched, because there the "rm" comes second). Requiring the literal
-    "rm -r"
-    removes that false-positive class and gives up every spelling that puts
-    another flag first. This is the same trade, and the same shape of loss, as
+    🔴 THE LAST SIX ROWS ARE NEWLY OPEN, and they are the price of the
+    2026-08-22 narrowing. They fall in TWO classes, both of which `"*rm*-r*"`
+    used to hold:
+      * a flag placed BEFORE `-r`   — `rm -f -r <p>`, `rm -v -r <p>`,
+        `rm --force --recursive <p>`;
+      * flags placed AFTER the operand — `rm <p> -r`, `rm <p> -rf`,
+        `rm <p> --recursive`. GNU `rm` permutes options, so these really run.
+
+    The old glob matched "rm" followed LATER by "-r" anywhere in the text, which
+    covered both classes — at the cost of auto-rejecting `git log --format=…
+    --reverse`, `terraform plan -refresh=false` and other text where a
+    format/terraform/firmware/confirm/platform token PRECEDES a `-r` flag (see
+    the three MUST_ALLOW rows added with this change; the order matters —
+    `grep -r 'format' src/` was never matched, because there the "rm" comes
+    second).
+
+    Requiring the literal "rm -r" NARROWS that false-positive class — it does
+    not remove it. MEASURED, still `ask` on this config: `ls src/form -r`,
+    `terraform -refresh=false plan`, `./scripts/perform -r x`,
+    `docker run --rm -r foo`. What survives is any token ENDING in "rm"
+    immediately followed by a `-r` flag; what goes away is the much larger
+    non-adjacent class, which is where every measured dead run came from.
+    This is the same trade, and the same shape of loss, as
     `test_age_glob_misses_these_reordered_decrypt_spellings` records for `age`.
 
+    🔴 THE TARGET IS NOT RESTRICTED TO A BUILD DIRECTORY. The rows below use
+    `/repo/build` for readability, but the globs are target-blind: `rm -f -r
+    ~/.ssh` and `rm -f -r /etc/nixos` are ALLOW at both layers too. Before
+    reading that as this change's doing, note the counterfactual — `rm -fr
+    ~/.ssh`, `rm -Rf ~/.ssh` and `rm -R ~/.ssh` were ALREADY plain ALLOW on
+    `main`. Layer 1 does not protect `$HOME` from a recursive delete and never
+    did; this change WIDENS that hole rather than opening it. Closing it
+    properly is a guard_core change, per opencode.jsonc's own header.
+
     NOT closed here, deliberately. Widening the glob is whack-a-mole — `-R`
-    needs its own rule, then `-fR`, then `-vr`, then `-f -r`; and a candidate
+    needs its own rule, then `-fR`, then `-vr`, then `-f -r`, and NONE of them
+    reaches the target-first class at all (`rm <p> -rf` has no "rm -" prefix to
+    match); and a candidate
     that looked like it generalised (`"*rm*-*r*"`) matched `rm -R /repo/build`
     only because the PATH contains an "r", so it fails on `rm -R /x`. Re-widening
     to `"*rm*-r*"` closes three of these rows and reopens the auto-reject class
@@ -1533,8 +1562,12 @@ def test_rm_glob_misses_these_recursive_spellings():
     CLOSED: delete that row from here and add the command to MUST_ASK.
     """
     for cmd in ["rm -R /repo/build", "rm -Rf /repo/build", "rm -fr /repo/build",
+                # flag BEFORE -r — opened by the 2026-08-22 narrowing
                 "rm -f -r /repo/build", "rm -v -r /repo/build",
-                "rm --force --recursive /repo/build"]:
+                "rm --force --recursive /repo/build",
+                # flags AFTER the operand — also opened by it; GNU rm permutes
+                "rm /repo/build -r", "rm /repo/build -rf",
+                "rm /repo/build --recursive"]:
         assert layered_verdict(cmd, None) == "allow", (
             f"{cmd!r} no longer resolves 'allow'. If you closed this gap, move "
             f"it into MUST_ASK and delete it here — do not relax the assertion."

--- a/scripts/tests/test_opencode_config.py
+++ b/scripts/tests/test_opencode_config.py
@@ -742,6 +742,11 @@ GUARD_BACKSTOPPED_DENIES = {
 
 # Read-only, high-frequency. If these start prompting, the operator is trained
 # to click through — which is how the prompts that matter stop working.
+# 🔴 "Read-only" is the CONTRACT, not a proven property of every row: the
+# `terraform plan` row below is deliberately admitted with a documented caveat
+# (it takes a state lock). Read that comment before adding a row — an unflagged
+# non-read-only entry makes this header a false claim, which is the defect class
+# this file exists to catch.
 MUST_ALLOW = [
     "ls -la",
     "kubectl get pods -A",
@@ -1528,11 +1533,21 @@ def test_rm_glob_misses_these_recursive_spellings():
     second).
 
     Requiring the literal "rm -r" NARROWS that false-positive class — it does
-    not remove it. MEASURED, still `ask` on this config: `ls src/form -r`,
-    `terraform -refresh=false plan`, `./scripts/perform -r x`,
-    `docker run --rm -r foo`. What survives is any token ENDING in "rm"
-    immediately followed by a `-r` flag; what goes away is the much larger
-    non-adjacent class, which is where every measured dead run came from.
+    not remove it. State the residual EXACTLY, because a loose paraphrase is
+    wrong in both directions: what survives is any text CONTAINING the literal
+    substring `"rm -r"` or `"rm --recursive"`. Both halves matter, and an earlier
+    draft of this docstring named only the first.
+      * via `"*rm -r*"`  — a token ending in "rm" directly before a `-r` flag:
+        `ls src/form -r`, `terraform -refresh=false plan`,
+        `./scripts/perform -r x`, `docker run --rm -r foo`   (all still `ask`)
+      * via `"*rm --recursive*"` — its own class, and NOT illustrated by any row
+        above: `pnpm --filter form --recursive build`,
+        `npm run build:form --recursive`, `terraform --recursive x`
+        (all still `ask` — real dead runs under `opencode run`)
+    Do NOT read it as "a token ending in rm before any recursive-ish flag": the
+    match is a literal substring, so `perform -R x` and `perform --recurse x`
+    resolve ALLOW. What goes away is the much larger non-adjacent class, which is
+    where every measured dead run came from.
     This is the same trade, and the same shape of loss, as
     `test_age_glob_misses_these_reordered_decrypt_spellings` records for `age`.
 
@@ -1551,7 +1566,8 @@ def test_rm_glob_misses_these_recursive_spellings():
     match); and a candidate
     that looked like it generalised (`"*rm*-*r*"`) matched `rm -R /repo/build`
     only because the PATH contains an "r", so it fails on `rm -R /x`. Re-widening
-    to `"*rm*-r*"` closes three of these rows and reopens the auto-reject class
+    to `"*rm*-r*"` closes six of these rows (measured — rows 4-9; only `-R`,
+    `-Rf` and `-fr` stay open) and reopens the auto-reject class
     the narrowing was made to remove — that trade was already measured and
     rejected. The structural fix is to widen guard_core's target set, which its
     own docstring records as an operator decision needing a measurement of how

--- a/scripts/tests/test_opencode_config.py
+++ b/scripts/tests/test_opencode_config.py
@@ -37,7 +37,9 @@ WHAT IS UNDER TEST (see scripts/opencode/README.md for the measurements):
      fully green** — 17 of them real holes where a realistic command dropped to
      plain `allow` at BOTH layers (`*git*commit*`, `*kubectl*drain*`,
      `*helm*upgrade*`, all four mutating `systemctl` verbs, the anchored
-     `sudo*`, `*rm*-r*`, …). The aggregate `len(asks) >= 40` floor could not see
+     `sudo*`, `*rm*-r*` (the recursive-`rm` rule, spelled infix at that ref and
+     narrowed to `*rm -r*` + `*rm --recursive*` on 2026-08-22), …). The
+     aggregate `len(asks) >= 40` floor could not see
      it: deleting exactly ten ask rules left exactly 40 and reported
      480 passed, 0 failed while ten dangerous families ran unprompted.
      `test_every_ask_rule_is_individually_pinned` and its deny twin turn that
@@ -612,13 +614,18 @@ MUST_ASK = [
     # check_rm_rf_critical deliberately does NOT fire here (its fatal-target set
     # is `/`, `~`/`$HOME`, `.`/`..` and the top-level system dirs only — see
     # test_guard_core_catches_recursive_rm_without_the_force_flag below), so
-    # this glob is the only thing gating these two SPELLINGS.
-    # 🔴 NOT the family: the glob is spelled, and `-R`, `-Rf` and `-fr` all
-    # resolve ALLOW today. That live gap is pinned, deliberately, by
+    # these globs are the only thing gating these two SPELLINGS.
+    # 🔴 TWO ROWS, TWO RULES, NEITHER REDUNDANT. Since the 2026-08-22 narrowing
+    # of `*rm*-r*` to `*rm -r*`, the long spelling is held by its OWN rule:
+    # "rm --recursive" does not contain the literal "rm -r", so each row below
+    # is the sole decider for exactly one rule.
+    # 🔴 NOT the family: the globs are spelled, so `-R`, `-Rf`, `-fr` AND any
+    # flag placed before `-r` (`rm -f -r <path>`) all resolve ALLOW today. That
+    # live gap is pinned, deliberately, by
     # test_rm_glob_misses_these_recursive_spellings below — do not read this
     # pair as "recursive delete is covered".
-    "rm -r /repo/build",                                         # *rm*-r*
-    "rm --recursive /repo/node_modules",                         # *rm*-r*
+    "rm -r /repo/build",                                         # *rm -r*
+    "rm --recursive /repo/node_modules",                         # *rm --recursive*
     # A leading `dd` with neither an `if=` nor an `of=` operand — the one shape
     # the operand-scoped `*dd if=*`/`*dd of=*` rules structurally cannot see.
     # Stated honestly: this spelling is the least dangerous of the dd family
@@ -760,6 +767,21 @@ MUST_ALLOW = [
     "ls packages/civitai-db-schema/src/",
     "grep -n REPLICATION_LAG_DELAY packages/civitai-db/src/lag.test.ts",
     "rg 'storage' src/ --debug",
+    # 🔴 THE SAME REGRESSION, SAME CLASS, ONE DAY LATER — measured 2026-08-22.
+    # `"*rm*-r*"` had a `*` BETWEEN "rm" and "-r", so it matched any command text
+    # containing "rm" followed LATER by "-r". "rm" is a substring of format,
+    # terraform, firmware, confirm and platform; "-r" covers --reverse,
+    # --refresh, --reporter, --repo and --recursive. All three below resolved
+    # ASK on the primary agent before the narrowing — watched to fail — and
+    # `opencode run` auto-rejects an ask, so each one kills a run mid-task.
+    # The fix is `"*rm -r*"` (drop the inner `*`) plus a second rule
+    # `"*rm --recursive*"`, because the long spelling does not contain "rm -r".
+    # Third row deliberately mirrors `rg 'storage' src/ --debug` above: same
+    # binary, different substring pair. `rg --replace` rewrites only the OUTPUT,
+    # never a file, so this list stays honestly read-only.
+    "git log --format=oneline --reverse",
+    "terraform plan -refresh=false",
+    "rg 'formatBytes' src/ --replace ''",
 ]
 
 # Every agent that ships, plus the implicit primary. `None` == no agent block.
@@ -988,9 +1010,10 @@ def test_all_asks_precede_all_denies():
     """
     items = list(load_config()["permission"]["bash"].items())[1:]
     asks = [k for k, v in items if v == "ask"]
-    assert len(asks) == 51, (
-        f"{len(asks)} `ask` rules in the bash block, pinned at 51 (50 after the "
-        f"1fb8c2b restoration, +1 for `*sudoedit*`). This is `==`, not `>=`, on "
+    assert len(asks) == 52, (
+        f"{len(asks)} `ask` rules in the bash block, pinned at 52 (50 after the "
+        f"1fb8c2b restoration, +1 for `*sudoedit*`, +1 for `*rm --recursive*` "
+        f"when `*rm*-r*` was narrowed to `*rm -r*`). This is `==`, not `>=`, on "
         f"purpose — see the docstring: a one-sided floor lets the cushion regrow "
         f"silently until it is the same slack that let ten dangerous families be "
         f"deleted with the gate green.\n"
@@ -1454,7 +1477,8 @@ def test_guard_core_catches_recursive_rm_without_the_force_flag():
 
     The complement is the part that IS regression coverage, and it lives in
     MUST_ASK: an ordinary recursive delete (`rm -r /repo/build`) is deliberately
-    NOT in the guard's fatal-target set, so the `*rm*-r*` glob is its only gate.
+    NOT in the guard's fatal-target set, so the `*rm -r*` / `*rm --recursive*`
+    globs are its only gate.
     """
     for cmd in ["rm -r /", "rm --recursive /", "rm -R /", "rm -r $HOME",
                 "rm --recursive $HOME", "rm -r ~", "rm -r .", "rm -r /etc",
@@ -1475,23 +1499,42 @@ def test_rm_glob_misses_these_recursive_spellings():
       * guard_core's flag test is STRUCTURAL (`--recursive`, or any short bundle
         containing r/R), but its TARGET set is deliberately narrow — `/`, `~`,
         `.`/`..`, top-level system dirs — so an ordinary path never reaches it;
-      * the `"*rm*-r*"` glob covers any target but is SPELLED, and knows exactly
-        one flag spelling.
+      * the `"*rm -r*"` / `"*rm --recursive*"` globs cover any target but are
+        SPELLED, and know exactly two flag spellings, each with the flag
+        IMMEDIATELY after the binary.
     Their intersection is a recursive delete of a project directory written with
     `-R`, `-Rf` or `-fr`: ALLOW at both layers, no prompt.
 
+    🔴 THE LAST THREE ROWS ARE NEWLY OPEN, and they are the price of the
+    2026-08-22 narrowing. `"*rm*-r*"` matched "rm" followed LATER by "-r"
+    anywhere in the text, so it DID hold `rm -f -r <path>` — at the cost of
+    auto-rejecting `git log --format=… --reverse`, `terraform plan
+    -refresh=false` and any other text where a format/terraform/firmware/
+    confirm/platform token PRECEDES a `-r` flag (see the three MUST_ALLOW rows
+    added with this change; the order matters — `grep -r 'format' src/` was
+    never matched, because there the "rm" comes second). Requiring the literal
+    "rm -r"
+    removes that false-positive class and gives up every spelling that puts
+    another flag first. This is the same trade, and the same shape of loss, as
+    `test_age_glob_misses_these_reordered_decrypt_spellings` records for `age`.
+
     NOT closed here, deliberately. Widening the glob is whack-a-mole — `-R`
-    needs its own rule, then `-fR`, then `-vr`; and a candidate that looked like
-    it generalised (`"*rm*-*r*"`) matched `rm -R /repo/build` only because the
-    PATH contains an "r", so it fails on `rm -R /x`. The structural fix is to
-    widen guard_core's target set, which its own docstring records as an
-    operator decision needing a measurement of how often it would fire on real
-    sessions — not a change to smuggle into a test-coverage PR.
+    needs its own rule, then `-fR`, then `-vr`, then `-f -r`; and a candidate
+    that looked like it generalised (`"*rm*-*r*"`) matched `rm -R /repo/build`
+    only because the PATH contains an "r", so it fails on `rm -R /x`. Re-widening
+    to `"*rm*-r*"` closes three of these rows and reopens the auto-reject class
+    the narrowing was made to remove — that trade was already measured and
+    rejected. The structural fix is to widen guard_core's target set, which its
+    own docstring records as an operator decision needing a measurement of how
+    often it would fire on real sessions — not a change to smuggle into a
+    test-coverage PR.
 
     🔴 If this test FAILS because a verdict became `ask`/`deny`, the gap was
     CLOSED: delete that row from here and add the command to MUST_ASK.
     """
-    for cmd in ["rm -R /repo/build", "rm -Rf /repo/build", "rm -fr /repo/build"]:
+    for cmd in ["rm -R /repo/build", "rm -Rf /repo/build", "rm -fr /repo/build",
+                "rm -f -r /repo/build", "rm -v -r /repo/build",
+                "rm --force --recursive /repo/build"]:
         assert layered_verdict(cmd, None) == "allow", (
             f"{cmd!r} no longer resolves 'allow'. If you closed this gap, move "
             f"it into MUST_ASK and delete it here — do not relax the assertion."

--- a/scripts/tests/test_opencode_engine.py
+++ b/scripts/tests/test_opencode_engine.py
@@ -136,7 +136,10 @@ TOOLS_NIX = ROOT / "nix" / "pkgs" / "tools" / "default.nix"
 #   * the DEPRECATED-key list — a config-SCHEMA claim about keys this repo does
 #     not set, which the resolved dumps cannot see.
 #   * the k8s "index 74 after all 30 global rules" incident record, whose counts
-#     describe a tree that no longer exists (65 global bash rules today), so no
+#     describe a tree that no longer exists (66 global bash rules today — it was
+#     65 until `*rm --recursive*` was added alongside the `*rm -r*` narrowing;
+#     this is a PRESENT-TENSE count, so re-derive it when you change the block,
+#     do not carry it), so no
 #     fresh measurement could confirm that sentence. The STRUCTURAL claim under
 #     it — agent rules are appended AFTER the whole global block — IS re-derived,
 #     by the engine-vs-model conformance tests below.


### PR DESCRIPTION
Closes the defect #695 named as **"STILL OPEN, same defect class, deliberately not fixed here"** in its own commit message.

## The defect

`"*rm*-r*"` has a `*` **between** "rm" and "-r", so it matches any bash command whose text contains "rm" followed *later* by "-r". Neither half is rare — "rm" is a substring of **fo*rm*at, terrafo*rm*, fi*rm*ware, confi*rm*, platfo*rm***, and "-r" covers `--reverse`, `--refresh`, `--reporter`, `--repo`, `--replace`, `--recursive`.

`opencode run` **auto-rejects** an `ask` rather than prompting, so a match does not cost a prompt — it kills the run mid-task. Measured against this config on 2026-08-22:

| command | old `*rm*-r*` |
|---|---|
| `git log --format=oneline --reverse` | **ask** → auto-reject → run dead |
| `terraform plan -refresh=false` | **ask** |
| `rg 'formatBytes' src/ --replace ''` | **ask** |
| `pnpm run format --reporter=verbose` | **ask** |

Confirmed live, not just in the file: `opencode debug agent build` on the running v1.18.18 engine resolves `"*rm*-r*"` today.

## 🔴 It is not a one-character fix

Dropping the inner `*` requires the literal `"rm -r"` — and **`"rm --recursive"` does not contain `"rm -r"`**. The narrowing alone would have released `rm --recursive <path>` on an ordinary project path, which `guard_core` does **not** backstop (its fatal-target set is `/`, `~`/`$HOME`, `.`/`..` and top-level system dirs only).

Measured by deleting that row: `rm --recursive /repo/node_modules` drops to **plain `allow` at both layers**.

So this ships **two** rules — `"*rm -r*"` and `"*rm --recursive*"` — each pinned individually in `MUST_ASK`, each proven sole-decider for its own row. The leading `*` stays on both and still gates `/nix/store/…/bin/rm -r <path>` and `FOO=1 rm -r <path>`.

| | old `*rm*-r*` | `*rm -r*` | `*rm --recursive*` |
|---|---|---|---|
| `git log --format=oneline --reverse` | ask | allow | allow |
| `rm -r /repo/build` | ask | **ask** | allow |
| `rm --recursive /repo/node_modules` | ask | allow | **ask** |

## The cost, pinned rather than implied

The narrowed rules know exactly one argument order, so every spelling that puts another flag first loses its gate. `rm -f -r <path>`, `rm -v -r <path>` and `rm --force --recursive <path>` were held by the infix form and are `allow` at both layers now.

They are added to the existing `test_rm_glob_misses_these_recursive_spellings` characterization test (which already pinned `-R`/`-Rf`/`-fr`), with the docstring naming **which three rows this change opened** and why re-widening is not the answer. That test asserts today's wrong answer on purpose and tells the next reader to move a row into `MUST_ASK` rather than relax the assertion.

`guard_core`'s `rm` target set is **deliberately not touched** — widening it is the structural fix, and its own docstring records that as an operator decision needing a real-session measurement. Not smuggled in here.

## Header carve-out

"ONE DELIBERATE EXCEPTION" becomes **two**, restructured as (a) `age` and (b) `rm`, with the shared reason stated once: auto-reject makes over-match *fatal*, not noisy — but only for patterns whose binary name is a substring of ordinary English/flag text, which is why `kubectl`/`talosctl`/`sops`/`sudoedit` stay infix. Without this the next reader "restores consistency" and walks straight back into the outage, which is exactly what the `age` carve-out exists to prevent.

## One measured caveat written into the comments

**The order matters.** The "rm" substring had to come *first*, so `grep -r 'format' src/` was **never** matched by the old glob. A comment claiming the rule ate "anything with rm and -r" would send the next reader hunting a false-positive class that does not exist.

## Controls (each mutation watched to fail, for its own reason)

- infix glob restored → the 3 new `MUST_ALLOW` rows go **red** (5 failed / 635 passed; the other two are the ask-count pin and the characterization test's 3 new rows)
- `"*rm --recursive*"` deleted → `rm --recursive …` goes plain `allow` (4 failed)
- `"*rm -r*"` deleted → `rm -r …` goes plain `allow` (5 failed)
- pattern matrix re-measured with `wildcard_match` after catching that my first probe had its **arguments reversed** and returned an all-`False` table — the reassuring zero this repo's rules warn about

`len(asks)` pinned 51 → 52 in the same commit, as its own failure message instructs.

## Test status — read this before trusting the gate

`scripts/tests`: **7293 passed**. Full run: **`TOTAL collected=15161 passed=15159 skipped=2 failed=0`**.

The runner nonetheless printed `RESULT: FAIL (exit=1)`, from **GUARD 10** — `/home/zach/workspace/devrc/.git/config` changed mid-run, on `scripts/tests` **and `scripts/browser-bridge/tests`**.

I attribute that to cross-session contamination, by mechanism and reach rather than by a controlled comparison:

- that file is the **shared common git config** of a clone with **20+ worktrees**;
- **five other devrc suites were running concurrently** on the box, one of them from a worktree *of this same clone*, so its branch operations write that exact file;
- it fired on `browser-bridge/tests`, which this diff cannot reach — the diff is an opencode permission glob and its own test file;
- zero tests failed.

**I have not run the base-commit control**, and could not get a clean one while other sessions' runs were contending — a re-run would be a second sample of the same contamination, not a control. Treat the GUARD 10 verdict as unsettled, not as green.

## Not live on merge

`~/.config/opencode/opencode.jsonc` resolves into `/nix/store` (a `home.file` copy, not an out-of-store symlink), so merging changes nothing in the running engine. Needs `home-manager switch`, then re-verify with `opencode debug agent build | grep -a '"\*rm'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHQprhyDCEjtL3uPVWnjsD
