### PR TITLE
fix(guard): an unresolvable `-C` has TWO causes — stop reporting a literal path as a shell variable

### DIFF
--- a/scripts/claude-hooks/guard_core.py
+++ b/scripts/claude-hooks/guard_core.py
@@ -1962,6 +1962,50 @@ def _commit_to_main_reason(repo_dir):
     )
 
 
+def _unresolvable_dash_c_note(token):
+    """Explain WHY a `-C` target could not be resolved — branched on the CAUSE.
+
+    🔴 THERE ARE TWO CAUSES AND THEY NEED DIFFERENT ADVICE. This note used to
+    assert the variable one for BOTH, so an operator whose `-C` named a literal
+    path that simply did not exist yet was sent hunting for a shell variable that
+    appears nowhere in their command. Measured on the shipped guard:
+
+        git -C /tmp/no-such-dir-xyz123 commit -m x
+        -> "… it is a shell variable whose value the command text does not carry"
+
+    which is flatly wrong, and cost a session two rounds of misdirected debugging.
+
+    The literal-path cause is the non-obvious one, because it is a consequence of
+    WHEN this runs: the guard is a PreToolUse hook, so it parses the command TEXT
+    before any of that command executes. A block that creates a directory and
+    THEN runs `git -C <that-dir>` is therefore always judged against the cwd —
+    at parse time the target does not exist. The remedy is a different tool call,
+    not a different spelling, which is why sharing one message was expensive.
+
+    `$` is the discriminator: `_resolve_dir` runs `expandvars` first, so a handle
+    the hook's own environment carries (`$DEVRC`) resolves and never reaches here.
+    A token still holding a `$` is one the environment did not carry.
+
+    Message-only. The fallback to the cwd is deliberate and documented in
+    `_dash_c_dir` — it errs toward denying, and nothing here changes any verdict.
+    """
+    if "$" in token:
+        cause = ("it is a shell variable whose value the command text does not "
+                 "carry")
+        remedy = ("pass `-C` an ABSOLUTE path, or assign the variable in this "
+                  "same command so the value is visible")
+    else:
+        cause = ("no directory exists at that path; this guard runs BEFORE the "
+                 "command does, so a directory the command is about to CREATE "
+                 "does not exist yet when the command text is parsed")
+        remedy = ("create the directory in an EARLIER tool call so it exists by "
+                  "the time this command is parsed, or pass `-C` a path that "
+                  "already exists")
+    return (f"\n(The `-C {token}` in this command names a path this guard could "
+            f"not resolve — {cause} — so the caller's own directory was judged "
+            f"instead. If that is the wrong repo, {remedy}.)")
+
+
 @_wants_cwd
 def check_git_commit_to_main(cmd, cwd=None):
     """🔴 Never commit to main/master/trunk — the rule prose demonstrably failed to hold.
@@ -2059,12 +2103,7 @@ def check_git_commit_to_main(cmd, cwd=None):
             reason = _commit_to_main_reason(repo_dir)
             if reason:
                 if unresolved and repo_dir == eff_cwd:
-                    reason += (
-                        f"\n(The `-C {unresolved[0]}` in this command names a path this guard "
-                        f"could not resolve — it is a shell variable whose value the command "
-                        f"text does not carry — so the caller's own directory was judged "
-                        f"instead. If that is the wrong repo, pass `-C` an ABSOLUTE path, or "
-                        f"assign the variable in this same command so the value is visible.)")
+                    reason += _unresolvable_dash_c_note(unresolved[0])
                 elif not_worktrees and repo_dir == eff_cwd:
                     reason += (
                         f"\n(This command names `{not_worktrees[0]}` as its repo, but that path "

--- a/scripts/claude-hooks/tests/test_guard_core.py
+++ b/scripts/claude-hooks/tests/test_guard_core.py
@@ -2651,10 +2651,12 @@ def test_S6d_the_deny_explains_WHY_it_judged_the_cwd_instead(tmp_path):
     """Falling back to the cwd produces a deny naming a repo the user never wrote
     in the command — unreadable unless it says why. The two fallbacks have
     DIFFERENT causes and must not share one message: `unresolved` is a path the
-    guard could not turn into a directory (a shell variable), this one is a path
-    that resolved fine and simply is not a repo. Asserted on the STATE (the named
-    path appears, and the not-a-worktree wording) rather than on any single word
-    another branch could also spell.
+    guard could not turn into a directory (a shell variable it could not expand,
+    or a literal path that does not exist yet — themselves two causes with two
+    messages, pinned in S6e/S6f/S6g), this one is a path that resolved fine and
+    simply is not a repo. Asserted on the STATE (the named path appears, and the
+    not-a-worktree wording) rather than on any single word another branch could
+    also spell.
     """
     cwd = _mkrepo(tmp_path / "cwd-trunk", branch="trunk")
     plain = tmp_path / "just-a-directory"
@@ -2665,6 +2667,98 @@ def test_S6d_the_deny_explains_WHY_it_judged_the_cwd_instead(tmp_path):
     assert "not a git worktree" in reason
     # …and it must NOT claim the path was unresolvable — that is the other cause.
     assert "could not resolve" not in reason
+
+
+# --- S6e/f/g. 🔴 THE TWO CAUSES OF AN UNRESOLVABLE `-C` ---------------------- #
+#
+# The note appended for an unresolvable `-C` is PROSE, and a guard on words is
+# walkable by rewording — so these pin the WHOLE normalised note string, not the
+# presence of a keyword. A cosmetic reword costs a test update here; that is the
+# deliberate trade for a machine-checkable claim about what the operator is told.
+
+def _tail_note(reason):
+    """The parenthetical the check appends, normalised to one whitespace run.
+
+    The note is appended as a single `\\n(...)` segment carrying no newlines of
+    its own, so it is exactly the last line of the reason.
+    """
+    assert reason is not None
+    return " ".join(reason.splitlines()[-1].split())
+
+
+def test_S6e_an_unresolvable_LITERAL_path_is_NOT_reported_as_a_variable(tmp_path):
+    """🔴 THE REGRESSION. A `-C` naming a literal path that does not exist yet was
+    reported as "a shell variable whose value the command text does not carry" —
+    flatly wrong, and it sent a session hunting for a variable its command never
+    contained, for two rounds.
+
+    The real cause is WHEN this runs: PreToolUse parses the command TEXT before
+    the command executes, so a directory the block is about to CREATE does not
+    exist at parse time. The remedy is therefore a different TOOL CALL, not a
+    different spelling — which is why the two causes could not share one message.
+    """
+    cwd = _mkrepo(tmp_path / "cwd-trunk", branch="trunk")
+    missing = tmp_path / "not-created-yet"          # deliberately never mkdir'd
+    assert not missing.exists()
+    reason = gc.check_git_commit_to_main(f"git -C {missing} commit -m x", str(cwd))
+    assert _tail_note(reason) == (
+        f"(The `-C {missing}` in this command names a path this guard could not "
+        f"resolve — no directory exists at that path; this guard runs BEFORE "
+        f"the command does, so a directory the command is about to CREATE does "
+        f"not exist yet when the command text is parsed — so the caller's own "
+        f"directory was judged instead. If that is the wrong repo, create the "
+        f"directory in an EARLIER tool call so it exists by the time this "
+        f"command is parsed, or pass `-C` a path that already exists.)")
+
+
+def test_S6f_an_unresolvable_VARIABLE_still_reports_the_variable_cause(
+        tmp_path, monkeypatch):
+    """An INVARIANT GUARD, not regression coverage: this wording is correct today
+    and is left byte-identical by the S6e fix. It is here so a later edit cannot
+    "fix" the literal-path message by flattening both branches back into one —
+    the failure mode that would make S6e pass while re-breaking this half.
+
+    Green on both sides of the fix, by construction. Do not count it as evidence
+    the fix works; S6e and S6g carry that.
+    """
+    monkeypatch.delenv(_UNSET_HANDLE, raising=False)
+    cwd = _mkrepo(tmp_path / "cwd-trunk", branch="trunk")
+    reason = gc.check_git_commit_to_main(
+        f"git -C ${_UNSET_HANDLE}/work commit -m x", str(cwd))
+    assert _tail_note(reason) == (
+        f"(The `-C ${_UNSET_HANDLE}/work` in this command names a path this "
+        f"guard could not resolve — it is a shell variable whose value the "
+        f"command text does not carry — so the caller's own directory was "
+        f"judged instead. If that is the wrong repo, pass `-C` an ABSOLUTE "
+        f"path, or assign the variable in this same command so the value is "
+        f"visible.)")
+
+
+def test_S6g_the_two_unresolvable_causes_do_not_share_a_message(
+        tmp_path, monkeypatch):
+    """The RELATIONSHIP between the two notes, which neither one alone pins.
+
+    Compared with the `-C` TOKEN substituted out, so the difference this asserts
+    is the explanation itself and not merely the path echoed back — pre-fix the
+    two notes are identical once the token is removed, which is the whole defect.
+    """
+    monkeypatch.delenv(_UNSET_HANDLE, raising=False)
+    cwd = _mkrepo(tmp_path / "cwd-trunk", branch="trunk")
+    missing = tmp_path / "not-created-yet"
+    var = f"${_UNSET_HANDLE}/work"
+
+    lit_note = _tail_note(gc.check_git_commit_to_main(
+        f"git -C {missing} commit -m x", str(cwd))).replace(str(missing), "<T>")
+    var_note = _tail_note(gc.check_git_commit_to_main(
+        f"git -C {var} commit -m x", str(cwd))).replace(var, "<T>")
+
+    assert lit_note != var_note, (
+        "both causes produced the same explanation once the path was removed — "
+        "the literal-path case is being reported as a shell variable again")
+    # …and each names ITS OWN cause, not the other's.
+    assert "shell variable" in var_note
+    assert "shell variable" not in lit_note
+    assert "does not exist yet" in lit_note
 
 
 def test_S6c_failing_closed_does_not_block_a_harmless_cwd(tmp_path):


### PR DESCRIPTION
## The defect

When a Bash command carries `git -C <path>` and the guard cannot resolve `<path>`, it falls back to judging the command against the session's cwd and appends a note explaining why. **That fallback is deliberate, documented in `_dash_c_dir`, and unchanged here.** Only the note was wrong: it hardcoded one cause for both of the two causes that reach it.

Measured on `origin/main`, cwd on `main`:

```
git -C /tmp/no-such-dir-xyz123 commit -m x
-> (The `-C /tmp/no-such-dir-xyz123` in this command names a path this guard could not
    resolve — it is a shell variable whose value the command text does not carry — so the
    caller's own directory was judged instead. If that is the wrong repo, pass `-C` an
    ABSOLUTE path, or assign the variable in this same command so the value is visible.)
```

There is no variable in that command. The real cause is **when** the guard runs: it is a `PreToolUse` hook, so it parses the command **text** before any of that command executes. A block that creates a directory and *then* runs `git -C <that-dir>` in the **same** block is therefore always judged against the cwd — at parse time the target does not exist. The remedy is a different **tool call**, not a different spelling, which is exactly why the two causes could not share one message. This cost a previous session two rounds of misdirected debugging, hunting for a variable that appeared nowhere in its command.

## The fix

`_unresolvable_dash_c_note(token)` branches on whether the unresolved token still holds a `$`, and keeps the actionable half of the message in **both** branches.

`$` is the correct discriminator: `_resolve_dir` runs `expandvars` first, so a handle the hook's own environment *does* carry (`$DEVRC`) resolves and never reaches this note. Verified as a control — `git -C $DEVRC commit` → resolves to `/home/zach/workspace/devrc`, `unresolved=[]`.

New literal-path message:

```
(The `-C <path>` in this command names a path this guard could not resolve — no directory
 exists at that path; this guard runs BEFORE the command does, so a directory the command
 is about to CREATE does not exist yet when the command text is parsed — so the caller's
 own directory was judged instead. If that is the wrong repo, create the directory in an
 EARLIER tool call so it exists by the time this command is parsed, or pass `-C` a path
 that already exists.)
```

The shell-variable message is **byte-identical** to before.

## Message-only — proven, not asserted

A differential harness loaded the pre- and post-change modules side by side and compared `evaluate()`'s **verdict** (deny vs allow) over 18 commands × 3 cwds × both policies:

```
compared 108 (policy x cwd x cmd) verdict pairs; changed = 0
positive control (harness can detect a verdict difference): True
literal-path message changed: True
variable message UNCHANGED:   True
```

The positive control is there because a bare `changed = 0` is indistinguishable from a harness wired to nothing. `POLICIES`, the fallback-to-cwd behaviour, and every allow/deny verdict are untouched.

## Reproduction, before and after

`_dash_c_dir` resolution is **identical** on both sides — only the message moved:

| `-C` argument | resolved | `unresolved` |
|---|---|---|
| `/tmp` | `/tmp` | `[]` |
| `/home/zach/workspace/civit/cli` | itself | `[]` |
| `/tmp/no-such-dir-xyz123` | *falls back to cwd* | `['/tmp/no-such-dir-xyz123']` |
| `$SOMEVAR/work` | *falls back to cwd* | `['$SOMEVAR/work']` |

## Test coverage — red/green matrix

The note is **prose**, and a guard on words is walkable by rewording, so S6e/S6f pin the **whole normalised note string** rather than a keyword. A cosmetic reword will now cost a test update; that is the intended trade for a machine-checkable claim about what the operator is told.

For the red run, `guard_core.py` was restored **byte-identical to `origin/main`** by file copy (never `git stash` in this repo — `refs/stash` is repo-global across all ~23 live worktrees), with the new tests in place:

| test | at `origin/main` | at HEAD | kind |
|---|---|---|---|
| `S6e_an_unresolvable_LITERAL_path_is_NOT_reported_as_a_variable` | **FAIL** | PASS | the regression |
| `S6g_the_two_unresolvable_causes_do_not_share_a_message` | **FAIL** | PASS | the relationship |
| `S6f_an_unresolvable_VARIABLE_still_reports_the_variable_cause` | PASS | PASS | **invariant guard** |

S6f is labelled an invariant guard in its own docstring rather than counted as regression coverage — it is green on both sides *by construction*, and that is precisely what proves the two messages were not simply rewritten together. S6g compares the two notes with the `-C` token substituted out, so it asserts the *explanation* differs and not merely the path echoed back; pre-fix the two are identical once the token is removed, which is the whole defect.

```
# red
git show origin/main:scripts/claude-hooks/guard_core.py > guard_core.py   # in the worktree
pytest tests/test_guard_core.py -k "S6e or S6f or S6g" -p no:randomly -q
-> 2 failed, 1 passed

# green
pytest tests/test_guard_core.py -k "S6e or S6f or S6g" -p no:randomly -q
-> 3 passed
```

## Suites run

- `scripts/claude-hooks/tests/` — **2358 passed** (includes `test_guard_core.py` at 1452 and the `bash-guard.py` adapter)
- `scripts/tests/test_opencode_engine.py` + `scripts/opencode/tests/` — **121 passed**

`bash-guard.py` needed no change — the message genuinely lives in `guard_core.py`, which is the only file in the repo containing this string. No opencode-side test asserts on this message. Both `POLICIES` entries include `_CLAUDE_CODE_CHECKS`, so both harnesses get the improved wording from the one implementation.

## 🔴 Inert until a `home-manager switch`

`~/.config/opencode/guard_core.py` is a symlink into `/nix/store`, so **the deployed copy does not change until the operator runs `home-manager switch`**. No switch was run as part of this change. It is intended to ride along with the switch already pending for the merged #741.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StvwRsCqGBPX4fhpR1ibqZ
