### PR TITLE
fix(tekton skill): the kubeconfig is in homelab-talos, not homelab-infra

### DIFF
--- a/claude/skills/tekton/SKILL.md
+++ b/claude/skills/tekton/SKILL.md
@@ -77,7 +77,14 @@ debugging, changing or copying a specific pipeline.
   EventListener, PipelineRuns).
 - GitOps via **Flux**, repo **`ZacxDev/homelab-infra`** branch **`trunk`**, under
   `clusters/homelab/apps/tekton-pipelines/`.
-- Kubeconfig: `~/workspace/homelab-infra/homelab-kubeconfig`.
+- Kubeconfig: `~/workspace/homelab-talos/homelab-kubeconfig` (handle: `$KC_HOMELAB`).
+  🔴 **`homelab-talos`, NOT `homelab-infra`** — the line above names the GitOps *repo*
+  (`homelab-infra`), and this file used to reuse that name for the *kubeconfig*, giving a
+  path that does not exist on disk. `kubectl` then falls back to `localhost:8080` and every
+  read dies with `connection refused` — an error that names a port appearing nowhere in the
+  skill, so it reads as a cluster outage rather than a bad path. Measured 2026-08-23 while
+  debugging the devrc gate. Six sibling skills (`signal`, `activity`, `mailbox`, `sglang`,
+  `standup`) all spell `homelab-talos`; this was the only file that did not.
 
 ## GitHub App — `tekton-homelab`
 


### PR DESCRIPTION
`claude/skills/tekton/SKILL.md:80` pointed at `~/workspace/homelab-infra/homelab-kubeconfig`. **That file does not exist.** The real one is `~/workspace/homelab-talos/homelab-kubeconfig` (handle `$KC_HOMELAB`).

### Why the wrong name got there
The bullet directly above correctly names the GitOps **repo** as `homelab-infra`. Line 80 reused that name for the **kubeconfig location**. Two different things, adjacent lines, one name.

### Why it is worth a commit rather than a silent edit
With `KUBECONFIG` pointing at a missing file, kubectl falls back to `localhost:8080` and every read fails with `connection refused` — on a port that appears **nowhere in the skill**. So the symptom reads as a cluster or API-server outage, not a bad path. A skill loads as authoritative guidance, so this sends the reader to diagnose the wrong system.

Hit 2026-08-23 while investigating why the devrc gate legs were reporting `COULD NOT RUN`.

### Scope
Six sibling skills (`signal`, `activity`, `mailbox`, `sglang`, `standup`) already spell `homelab-talos`. This was the **only** file in `claude/` carrying the dead path, so the convention was already established and this line was simply wrong.

### Verified
- the corrected path exists on disk, and was used successfully for every kubectl read in the investigation that found this
- `grep` confirms no occurrence of the dead path remains under `claude/`

### Note on CI
The devrc gate is currently unreliable — five PipelineRuns in the last hour died with `InternalError: pods "…-gate-pod" not found`, in simultaneous batches, across unrelated branches. If this PR's checks come back `COULD NOT RUN`, that is the same platform issue and not a signal about this change. Docs-only, no code paths touched.