### PR TITLE
feat(check-clickup-addressed): make the transcript scan OPT-IN, and land the three deferrals it unblocks

### DIFF
--- a/claude/skills/check-clickup-addressed/SKILL.md
+++ b/claude/skills/check-clickup-addressed/SKILL.md
@@ -488,8 +488,8 @@ Earlier rounds each ran a sweep, reported "0 survived", and threw the driver awa
 number was then unreproducible from the repo, and the next round re-invented the list and
 re-discovered the same sites. A blind re-audit of one such "51 mutants, 0 non-killed" found
 **seven more at the same delta sites**, one of which reverted that round's headline fix.
-**Extend the list; do not start a new one.** Currently **81 rows (80 mutants + a positive
-control) + a NULL CONTROL, 0 non-KILLED** — the driver prints `81 mutant(s); non-KILLED: 0`.
+**Extend the list; do not start a new one.** Currently **82 rows (81 mutants + a positive
+control) + a NULL CONTROL, 0 non-KILLED** — the driver prints `82 mutant(s); non-KILLED: 0`.
 🔴 **`--check`'s other job is catching a mutant whose ANCHOR you moved.** Measured
 2026-08-23: one edit to `suppressed_notes` silently stranded `M49` and `M-SCOPE` at
 `NOT APPLIED` — and `M-SCOPE` is the mutant a blind re-audit once found surviving a green

--- a/claude/skills/check-clickup-addressed/SKILL.md
+++ b/claude/skills/check-clickup-addressed/SKILL.md
@@ -34,11 +34,25 @@ The scripts live in **devrc**, not in this deployed skill dir — `~/.claude/ski
 read-only nix-store copy of `claude/skills/`, and only the docs ship there. Run them from
 the repo:
 
+🔴 **Transcript scanning is OPT-IN since 2026-08-22 (`--transcripts`).** Measured upstream
+over the three tickets in that day's report, the four evidence sources scored: ClickUp
+status **3/3** useful; newest comment **3/3 and decisive in every case**; transcript scan
+**0/3**, one of them actively misleading (a `✓ PR merged` whose own snippet said the bug was
+still unfixed); cited-PR resolution **0/3 resolved, 2/3 with FALSE explanations**. The scan
+is also ~60s of the ~90s runtime and the origin of every false verdict this tool has
+shipped. The ClickUp-side default runs in **~21s** and produced only correct output on the
+same input.
+
 ```bash
 CCUA=~/workspace/devrc/scripts/check-clickup-addressed
 
-# Default: top 3 most recent comments (~30s)
+# Default: top 3 comments, ClickUp status + newest comment (~21s). NOT the two
+# transcript-dependent flags — they need a SEARCHED zero, so the run announces that
+# they did not run.
 python3 "$CCUA/check-addressed.py"
+
+# Add the transcript scan and completion verdicts (~90s; read every snippet)
+python3 "$CCUA/check-addressed.py" --transcripts
 
 # Fast mode: samples only the 10 most recently updated tasks (~10s)
 python3 "$CCUA/check-addressed.py" --fast
@@ -179,15 +193,22 @@ five scoped to one side of a seam. If you are about to trust a verdict here, ope
   `868gx0aaa`, because the merge sentence really is adjacent to it. **Read the snippet.**
 - **A PR reference the tool cannot pin to a repo is reported `unresolved`, not guessed** —
   a snippet-wide scan was tried and attributed every bare `#N` to `civitai/civitai`,
-  returning a real but unrelated PR ("merged 2024-03-18"). 🔴 **Three distinct ways to fail,
-  and the message now says which** (until 2026-08-21 all three printed `repo not named`,
-  true of only one): `repo not named` — nothing repo-ish within `REPO_LOOKBEHIND`=30 chars;
-  `repo 'X' is not in KNOWN_REPOS` — a repo **was** named, *go add it*; `ambiguous — A, B
-  both in range`. The word on the `#` is reported as written and **not classified** —
-  nothing short of enumerating the world separates `devrc` from `landed`, and a reader
-  separates them at a glance. `KNOWN_REPOS` is a closed vocabulary, so **widening it is not
-  the fix** (same shape as the status sets below); verify owners with `gh repo view` —
-  `devrc` is **innovation-upstream**/devrc, and `civitai/devrc` does not exist.
+  returning a real but unrelated PR ("merged 2024-03-18"). 🔴 **Round 5 split the failure
+  into three precise messages; round 7 (2026-08-22) COLLAPSED two of them back, on
+  measurement.** `repo 'X' is not in KNOWN_REPOS` asserts that a repo was named and is
+  spelled `X` — and on a live upstream run **2 of the 3 cited PRs** rendered as `repo
+  'their' …` and `repo 'which' …`, the lookbehind having captured the preceding *English
+  word* while the comment plainly named a repo. The precise message was wrong more often
+  than the vague one it replaced, and it sends the reader to add an English word to a repo
+  table. `word` is simply whatever token precedes the `#`, and nothing short of enumerating
+  the world separates `devrc` from `landed` — so the tool no longer claims to know. Both now
+  render `unresolved (could not determine the repo; if one is named here, add it to
+  KNOWN_REPOS…)` — a **conditional**, true either way, which keeps the affordance without
+  the false premise. `ambiguous — A, B both in range` survives: repos genuinely *were* named
+  there, so naming them is a true diagnosis. `KNOWN_REPOS` is a closed vocabulary, so
+  **widening it is not the fix** (same shape as the status sets below); verify owners with
+  `gh repo view` — `devrc` is **innovation-upstream**/devrc, and `civitai/devrc` does not
+  exist.
 - **`--fast` only inspects the 10 most recently updated tasks**, so a stale-but-important
   task is invisible to it. That is a sampling window, not a full check.
 
@@ -319,6 +340,23 @@ plus one state where nothing disagrees and that is exactly the problem (4):
    comment and PR rules never read it and can each still flag the ticket.) Bounded only by a
    *newer* colleague comment re-firing it. Acknowledging is not doing.
 
+🔴 **TWO of these checks NEED the transcript scan, and it is OFF by default — the run says
+so.** The waiting flag (source 4) and *"ClickUp `<done>` but open signals remain"* are gated
+on a **SEARCHED** zero. Since the scan became opt-in the scan-less record carries **no**
+`mentions_found` at all — deliberately, because an unsearched zero is not a searched one —
+so in the default invocation those rules are *structurally unable to fire*. Upstream that
+was **silent**, and when nothing else disagreed the **Needs a decision** heading was not
+printed at all: measured by driving the tool, an empty block reading as *checked, nothing
+disagrees* when it meant *two rules never ran*. Exactly the failure round 4's unknown-status
+announcement exists for, one axis over, and it arrived with a change that was individually
+correct. A default run now prints **one** line naming both rules and how to enable them.
+Pass `--transcripts` and the line disappears.
+🔴 The two guards deliberately key on **different** facts, and neither is a typo: the flags
+gate on the STATE (`"mentions_found" in r`) because they ACT on evidence and a renamed status
+sentinel must not be able to fire them; the announcement keys on the run's own declaration
+(`status == "not_scanned"`) because it DESCRIBES the run, and a record merely missing the key
+(a stale producer, a partial write) is not evidence that the whole scan was skipped.
+
 🔴 **Sources 1 and 2 are gated on a hardcoded nine-word status vocabulary, and ClickUp
 statuses are per-list and arbitrary.** Until 2026-08-21 a miss was **silent**: measured,
 `in review` / `blocked` / `needs qa` / `review` each disabled every ticket/comment check
@@ -383,16 +421,20 @@ announcement.
 | Mode | Time | Notes |
 |------|------|-------|
 | `--fast` | ~10s | Samples only the 10 most recently updated tasks |
-| `--limit 5` | **~85–100s** | All assigned tasks; one transcript search per task |
+| default (no `--transcripts`) | **~21s** | ClickUp only; no per-task transcript sweep |
+| `--limit 5 --transcripts` | **~85–100s** | All assigned tasks; one transcript search per task |
 
-Re-measured 2026-08-21: **98.5s** and **85.4s** wall (two runs). The `~41s` quoted until
-then was a 2026-08-19 figure that had silently doubled as the transcript corpus grew — the
-ClickUp fetch dominates, but the per-task sweep scales with `~/.claude/projects`, so expect
-further drift. **Re-time it rather than quoting it.**
+⚠️ **Every figure in this table is upstream's, and the two `--transcripts` rows were measured
+before the scan became opt-in.** Re-measured upstream 2026-08-21: **98.5s** and **85.4s**
+wall (two runs); the `~41s` quoted until then was a 2026-08-19 figure that had silently
+doubled as the transcript corpus grew. The ~21s default is upstream's single measurement of
+the same day. The ClickUp fetch dominates the cheap path, but the per-task sweep scales with
+`~/.claude/projects`, so expect drift on both — and this host's corpus is not upstream's.
+**Re-time it rather than quoting it.**
 
 ## Tests
 
-Run all tests (**213** collected, measured 2026-08-22). `run_all.py` exits non-zero on
+Run all tests (**220** collected, measured 2026-08-22). `run_all.py` exits non-zero on
 failure — but read the `Total: N passed, M failed` line, not a piped exit code. 🔴 **If that
 line is missing at all, the run died — treat it as a failure, never as "no output".** A
 `sys.exit()` from code under test is a `SystemExit`, which a bare `except Exception` does
@@ -406,7 +448,7 @@ PYTHONDONTWRITEBYTECODE=1 python3 "$CCUA/tests/run_all.py"
 
 The same files are a **pytest** target of devrc's gate — `scripts/check-clickup-addressed/tests`
 in `HERMETIC_TARGETS`, with its collected-count floor in `TARGET_FLOORS`
-(`scripts/run-tests.sh`). Both runners see the same 213; `run_all.py` survives because it
+(`scripts/run-tests.sh`). Both runners see the same 220; `run_all.py` survives because it
 purges `__pycache__` and reports an import failure as a FAILURE, which pytest's summary
 line does not distinguish as loudly. **Raise the floor when you add tests.**
 
@@ -416,11 +458,12 @@ Earlier rounds each ran a sweep, reported "0 survived", and threw the driver awa
 number was then unreproducible from the repo, and the next round re-invented the list and
 re-discovered the same sites. A blind re-audit of one such "51 mutants, 0 non-killed" found
 **seven more at the same delta sites**, one of which reverted that round's headline fix.
-**Extend the list; do not start a new one.** Currently **59 mutants + a positive control + a
-NULL CONTROL, 0 non-killed.** 🔴 That null control is not decoration: it copies the skill,
-mutates NOTHING and must report SURVIVED. On this battery's first run every mutant scored
-KILLED *because* `test_no_real_identifiers.py` cannot resolve the repo root from a temp copy
-and reddened all 59 for free. Read the killer NAME, not just the verdict.
+**Extend the list; do not start a new one.** Currently **76 rows (75 mutants + a positive
+control) + a NULL CONTROL, 0 non-KILLED** — the driver prints `76 mutant(s); non-KILLED: 0`.
+🔴 That null control is not decoration: it copies the skill, mutates NOTHING and must report
+SURVIVED. On this battery's first run every mutant scored KILLED *because*
+`test_no_real_identifiers.py` cannot resolve the repo root from a temp copy and reddened
+them all for free. Read the killer NAME, not just the verdict.
 
 ```bash
 PYTHONDONTWRITEBYTECODE=1 python3 "$CCUA/tests/mutation_sweep.py" --check
@@ -459,13 +502,16 @@ Test files:
   `ANNOUNCE` / `UNREADABLE` / `ANSWERED` / `SILENT`), never off whether something fired.
   Pre-port scores 10/21, shipped 21/21. Same rule as the other corpus: **add your motivating
   case, with the verdict a human would give, BEFORE you change code.**
-- `test_bounds_and_parsing.py` — the round-8 set: the other-coverage sentence's SCOPING, the
-  DISPLAY half of the two-ages split, and `UNANSWERED_COMMENT_DAYS` pinned ON its boundary
-  (14.0) and at a NON-multiple overshoot (20) — the old fixtures sat at 13 and 30, and 30 is
-  more than 2×14, so a doubling mutant passed straight through the gap. ⚠️ These are
-  **mutation-coverage guards, not regression coverage**: each SURVIVED a full green battery
-  on a tree where the behaviour was already right. The file says so, and says why its red
-  against pre-port `main` does not count.
+- `test_bounds_and_parsing.py` — the round-8 set. **Section 1 IS regression coverage**: the
+  scan-less announcement, its one-line-per-run bound, the state-gated open-signals flag, and
+  an end-to-end `main()` drive in BOTH modes — red before the transcript opt-in landed.
+  Everything after it is the other-coverage sentence's SCOPING, the DISPLAY half of the
+  two-ages split, and `UNANSWERED_COMMENT_DAYS` pinned ON its boundary (14.0) and at a
+  NON-multiple overshoot (20) — the old fixtures sat at 13 and 30, and 30 is more than 2×14,
+  so a doubling mutant passed straight through the gap. ⚠️ Those are **mutation-coverage
+  guards, not regression coverage**: each SURVIVED a full green battery on a tree where the
+  behaviour was already right. The file says so, and says why its red against pre-port
+  `main` does not count.
 - `test_check_completion.py` — windowed signal extraction. ⚠️ Its two proximity tests hand
   `extract_signals_from_windows` a non-zero `distance`, which no production producer emits;
   they cover the formula, not any reachable path. The reachable premise is pinned in

--- a/claude/skills/check-clickup-addressed/SKILL.md
+++ b/claude/skills/check-clickup-addressed/SKILL.md
@@ -46,9 +46,10 @@ same input.
 ```bash
 CCUA=~/workspace/devrc/scripts/check-clickup-addressed
 
-# Default: top 3 comments, ClickUp status + newest comment (~21s). NOT the two
-# transcript-dependent flags — they need a SEARCHED zero, so the run announces that
-# they did not run.
+# Default: top 3 comments, ClickUp status + newest comment (~21s). NOT the FOUR
+# transcript-dependent flags — the run names every one of them and says it skipped
+# them. `--since`/`--include-self-runs`/`--no-resolve-prs`/`--verbose` are inert
+# here and warn on stderr rather than being silently ignored.
 python3 "$CCUA/check-addressed.py"
 
 # Add the transcript scan and completion verdicts (~90s; read every snippet)
@@ -134,6 +135,7 @@ process per task, so lookups dedupe within a task, not across the run.
 | `unclear` | Sessions mention the task, but no signal of either kind is attributable to it |
 | `no_sessions_found` | No session transcript mentions this task at all |
 | `no_mentions_found` | Sessions were read, but the task ID appears in none of them — **no evidence either way**, never an implied "partly done" |
+| `not_scanned` | **The DEFAULT since 2026-08-22.** No transcript was read at all, so no verdict was formed. Distinct from every row above: those are *searched* outcomes, this is the absence of a search. The record also **omits `mentions_found` and `sessions_searched`** rather than reporting `0` — an unsearched zero is not a searched one. `--transcripts` is what produces the other rows |
 
 🔴 **`partially_addressed` is the status to be most suspicious of** — it was, until
 2026-08-19, the state an unmatched task fell into *by construction* (see Limitations).
@@ -171,6 +173,23 @@ Round 5, the same day, fixed a **false explanation** (a named-but-unknown repo r
 `claude/skills/check-clickup-addressed/reference/validation-history.md`). Round 6, on 2026-08-22, fixed
 that new flag's own blind spot — it could not see **your** replies, so a ticket you had
 already answered was reported unanswered forever. What remains is listed under "Still weak".
+
+🔴 **A fix for the self-run guard was TRIED and REVERTED (2026-08-22) — recorded so nobody
+re-derives it.** The guard drops any transcript containing this skill's markers, which
+measured as **67% / 80% / 100%** of matching transcripts on three live tickets. That looks
+like catastrophic evidence loss, so the guard was rewritten to redact the checker's *output
+messages* and keep the session. It **recovered** the transcripts (3→8, 2→9, 0→8) **and made
+every verdict worse**: all three tickets went to `partially_addressed` on completion signals
+mined from sessions that were *working on this checker*. One such snippet was literally a
+test-corpus example — a sentence of the form *"the fix landed in #NNNN and is live"* — scored
+as completion evidence for an unrelated infrastructure ticket. Every recovered session for
+one of the three opened with either `/check-clickup-addressed` or *"read and evaluate the
+check-clickup-addressed skill"*. **The crude guard was reaching the right outcome by the
+wrong mechanism, and the ~81% it discards is overwhelmingly noise.** The real lesson is the
+one that made the scan opt-in: **lexical proximity cannot separate a session that WORKED the
+ticket from a session that TALKED ABOUT it**, and no amount of guard-tuning changes that.
+*(Ticket ids and the client's stack are omitted here — this repo is public. The measurement
+is what carries; the identifiers were the client's.)*
 
 🔴 **Every round so far has been found by RUNNING the tool and checking its verdict against
 reality, never by reading the code.** Round 6's defect shipped *with* a fresh adversarial
@@ -340,17 +359,28 @@ plus one state where nothing disagrees and that is exactly the problem (4):
    comment and PR rules never read it and can each still flag the ticket.) Bounded only by a
    *newer* colleague comment re-firing it. Acknowledging is not doing.
 
-🔴 **TWO of these checks NEED the transcript scan, and it is OFF by default — the run says
-so.** The waiting flag (source 4) and *"ClickUp `<done>` but open signals remain"* are gated
-on a **SEARCHED** zero. Since the scan became opt-in the scan-less record carries **no**
+🔴 **FOUR of these checks NEED the transcript scan, and it is OFF by default — the run names
+every one of them.** The cited-PR resolution (source 3), the waiting flag (source 4),
+*"ClickUp `<done>` but open signals remain"*, and *"transcripts read as done while ClickUp is
+still open"*. The first two of those are gated on a **SEARCHED** zero; the other two need a
+completion verdict and an evidence list that a scan-less run never builds. Since the scan
+became opt-in the scan-less record carries **no**
 `mentions_found` at all — deliberately, because an unsearched zero is not a searched one —
 so in the default invocation those rules are *structurally unable to fire*. Upstream that
 was **silent**, and when nothing else disagreed the **Needs a decision** heading was not
 printed at all: measured by driving the tool, an empty block reading as *checked, nothing
-disagrees* when it meant *two rules never ran*. Exactly the failure round 4's unknown-status
+disagrees* when it meant *rules never ran*. Exactly the failure round 4's unknown-status
 announcement exists for, one axis over, and it arrived with a change that was individually
-correct. A default run now prints **one** line naming both rules and how to enable them.
+correct. A default run now prints **one** line naming every such rule and how to enable them.
 Pass `--transcripts` and the line disappears.
+🔴 **The list is BUILT from a ledger (`SCAN_ONLY_RULES`), not restated in prose, because the
+first version of that announcement named TWO of the four.** Naming a subset is worse than
+naming none — it implies the unnamed ones ran, which is the same defect one axis further
+over. The ledger pairs each rule with its flag's own unique tail, and a test diffs a
+fully-armed fixture across both modes: it fails when a fifth scan-dependent rule is ADDED and
+when one is REMOVED. A second test forbids a rule's announcement NAME from containing its own
+TAIL, so `"<tail>" in output` can never be true in a run where that flag did not fire — the
+instrument-matching-its-own-announcement trap that cost upstream a false failure.
 🔴 The two guards deliberately key on **different** facts, and neither is a typo: the flags
 gate on the STATE (`"mentions_found" in r`) because they ACT on evidence and a renamed status
 sentinel must not be able to fire them; the announcement keys on the run's own declaration
@@ -434,7 +464,7 @@ the same day. The ClickUp fetch dominates the cheap path, but the per-task sweep
 
 ## Tests
 
-Run all tests (**220** collected, measured 2026-08-22). `run_all.py` exits non-zero on
+Run all tests (**226** collected, measured 2026-08-22). `run_all.py` exits non-zero on
 failure — but read the `Total: N passed, M failed` line, not a piped exit code. 🔴 **If that
 line is missing at all, the run died — treat it as a failure, never as "no output".** A
 `sys.exit()` from code under test is a `SystemExit`, which a bare `except Exception` does
@@ -448,7 +478,7 @@ PYTHONDONTWRITEBYTECODE=1 python3 "$CCUA/tests/run_all.py"
 
 The same files are a **pytest** target of devrc's gate — `scripts/check-clickup-addressed/tests`
 in `HERMETIC_TARGETS`, with its collected-count floor in `TARGET_FLOORS`
-(`scripts/run-tests.sh`). Both runners see the same 220; `run_all.py` survives because it
+(`scripts/run-tests.sh`). Both runners see the same 226; `run_all.py` survives because it
 purges `__pycache__` and reports an import failure as a FAILURE, which pytest's summary
 line does not distinguish as loudly. **Raise the floor when you add tests.**
 
@@ -458,8 +488,13 @@ Earlier rounds each ran a sweep, reported "0 survived", and threw the driver awa
 number was then unreproducible from the repo, and the next round re-invented the list and
 re-discovered the same sites. A blind re-audit of one such "51 mutants, 0 non-killed" found
 **seven more at the same delta sites**, one of which reverted that round's headline fix.
-**Extend the list; do not start a new one.** Currently **76 rows (75 mutants + a positive
-control) + a NULL CONTROL, 0 non-KILLED** — the driver prints `76 mutant(s); non-KILLED: 0`.
+**Extend the list; do not start a new one.** Currently **81 rows (80 mutants + a positive
+control) + a NULL CONTROL, 0 non-KILLED** — the driver prints `81 mutant(s); non-KILLED: 0`.
+🔴 **`--check`'s other job is catching a mutant whose ANCHOR you moved.** Measured
+2026-08-23: one edit to `suppressed_notes` silently stranded `M49` and `M-SCOPE` at
+`NOT APPLIED` — and `M-SCOPE` is the mutant a blind re-audit once found surviving a green
+sweep. `--check` went red and named both. A `NOT APPLIED` row reads exactly like a pass in a
+long list; only the exit code tells them apart.
 🔴 That null control is not decoration: it copies the skill, mutates NOTHING and must report
 SURVIVED. On this battery's first run every mutant scored KILLED *because*
 `test_no_real_identifiers.py` cannot resolve the repo root from a temp copy and reddened

--- a/claude/skills/check-clickup-addressed/reference/validation-history.md
+++ b/claude/skills/check-clickup-addressed/reference/validation-history.md
@@ -1416,16 +1416,25 @@ saying that the waiting flag and *"ClickUp `<done>` but open signals remain"* co
 because a parallel upstream change made the transcript scan **opt-in** and its scan-less
 record omits `mentions_found` rather than reporting `0`.
 
-**That opt-in does not exist here.** Measured: `check-addressed.py` has no `--transcripts`
-flag (`parse_args` rejects it), `main()` always runs `search-sessions.py` and
-`check-completion.py`, and `check-completion.py` emits `mentions_found` on all three of its
-exit paths. No record here can carry a `not_scanned` status or omit the mention count, so the
-announcement would guard a state no input can reach — and an unreachable guard reads as
-protection while providing none. Not ported, together with the `"mentions_found" in r` gate
-its sibling puts on the open-signals flag (same premise), the SKILL.md correction about the
-default invocation (this tool's default DOES run the decision flags), and mutants N1–N5.
-Every one of those omissions is written down at the site that would carry it, with the
-condition for restoring it: **a `--transcripts` opt-in landing here.**
+~~**That opt-in does not exist here.**~~ 🔴 **SUPERSEDED 2026-08-23 — every clause below was
+reversed, and this paragraph is kept struck through rather than deleted because it is the
+paragraph someone reads to justify deleting the upstream copy.**
+
+The original measurement read: `check-addressed.py` has no `--transcripts` flag (`parse_args`
+rejects it), `main()` always runs `search-sessions.py` and `check-completion.py`, and
+`check-completion.py` emits `mentions_found` on all three of its exit paths — so no record
+here can carry a `not_scanned` status or omit the mention count, and the announcement would
+guard a state no input can reach. On that basis the announcement, the `"mentions_found" in r`
+gate, the SKILL.md default-invocation correction and mutants N1–N5 were all left unported,
+each recorded at the site that would carry it with one condition for restoring it: **a
+`--transcripts` opt-in landing here.**
+
+**That opt-in landed** (the round below). `--transcripts` exists and defaults to OFF, `main()`
+skips both subscripts in the default mode, and its scan-less record carries `status:
+"not_scanned"` and no `mentions_found` at all. **All four deferrals are ported**, plus the
+ledger of every scan-dependent rule that the announcement is now built from. Nothing on this
+list is outstanding, and nothing in the upstream copy is unported — which is the whole
+precondition for deleting it.
 
 ## Round 7 — three follow-ups to D12
 
@@ -1473,7 +1482,11 @@ wherever it appeared.
 ## 🔴 The battery is in the repo — `tests/mutation_sweep.py`
 
 Mutants as DATA plus a runner (`--list`, an id filter, `--check` which fails on a stale
-`NOT APPLIED`). **59 mutants + a positive control + a NULL CONTROL, non-KILLED: 0.**
+`NOT APPLIED`). It was **59 mutants + a positive control + a NULL CONTROL, non-KILLED: 0** at
+this round; it has grown since. 🔴 **Count it, do not quote this number** — the same rule
+SKILL.md applies to the test total, and for the same reason: `--check` prints the live figure
+in one line, and a quoted count is stale the first time anyone extends the list, which the
+file's own header instructs them to do.
 
 🔴 **And the null control earned its place on the first run.** All 59 mutants reported KILLED,
 and every killer list opened with `test_the_scan_actually_walks_files_and_can_see_an_id`:
@@ -1497,7 +1510,8 @@ everywhere and inflate each row by the same 4:
 | pre-port scripts + **HEAD tests** | **178 passed, 31 failed** |
 | HEAD scripts + HEAD tests | **209 passed, 0 failed** |
 
-In-repo, with that gate included: **180 → 213 collected.** Corpus **10/21 pre-port → 21/21**.
+In-repo, with that gate included: **180 → 213 collected** *at that round* (see the round below
+for the current figure). Corpus **10/21 pre-port → 21/21**.
 
 ⚠️ Four of the five round-8 guards are among those 31 reds, and they are **not** regression
 coverage: they go red with `AttributeError` because `suppressed_notes` / `_age_days_from_ms`

--- a/scripts/check-clickup-addressed/check-addressed.py
+++ b/scripts/check-clickup-addressed/check-addressed.py
@@ -834,7 +834,16 @@ def disagreements(results, now=None):
         elif r["status"] == "likely_addressed" and cu in OPEN_STATUSES:
             out.append(f"{tid}: transcripts read as done, ClickUp still `{cu}` — close it or re-check.")
 
-        if r["status"] in ("open", "no_mentions_found") and cu in DONE_STATUSES:
+        # 🔴 `"mentions_found" in r` is the STATE — a transcript scan actually ran — and the
+        # status words are only how that state is spelled. Without it this branch is a
+        # SPELLED guard: the scan-less record's `not_scanned` sentinel is the only thing
+        # keeping it quiet, and renaming that sentinel to `no_mentions_found` fires "open
+        # signals remain" off a scan that never happened. That mutant SURVIVED the whole
+        # suite upstream. The waiting flag already gates on the state for exactly this
+        # reason; a searched zero and an unsearched one are different facts, and only one of
+        # them is evidence.
+        if ("mentions_found" in r and r["status"] in ("open", "no_mentions_found")
+                and cu in DONE_STATUSES):
             out.append(f"{tid}: ClickUp `{cu}` but open signals remain — verify before trusting the close.")
 
         # A separate `if`, not part of the chain above: nothing DISAGREES here, so it is
@@ -850,6 +859,42 @@ def disagreements(results, now=None):
                     if ref["state"] == "open":
                         out.append(f"{tid}: cited {ref['ref']} is still OPEN, not merged — "
                                    f"the signal that quoted it reads as done.")
+
+    # 🔴 ANNOUNCE THE RULES THAT COULD NOT RUN. The transcript scan is opt-in, and the two
+    # checks named below are gated on a SEARCHED zero (`mentions_found == 0`), which the
+    # scan-less record does not carry. So in the DEFAULT invocation they are structurally
+    # unable to fire — and nothing said so. Worse, when nothing else disagrees the whole
+    # "Needs a decision" heading is not printed at all, which reads as *checked, nothing
+    # disagrees* when it means *two rules never ran*. That is verbatim the failure this
+    # function's own docstring names three paragraphs up, and the reason round 4's
+    # unknown-status announcement exists — the same defect one axis over, and it arrived
+    # with a change that was individually correct.
+    #
+    # ONE line per run, not per ticket: the scan is skipped for the whole invocation, so a
+    # per-record line would put N identical sentences in the one block whose value depends
+    # on being short. Round 4's announcement is per-record because the STATUS varies per
+    # record; this fact does not.
+    #
+    # 🔴 Keyed on `status == "not_scanned"` and NOT on `"mentions_found" not in r`, which is
+    # the opposite choice from the guard above — because they answer different questions and
+    # the first version of this got it wrong upstream. A missing mention count is a
+    # RECORD-level absence with several causes (a stale producer, a hand-built fixture, a
+    # partial write); announcing "the scan was skipped for this RUN" from it is an
+    # over-claim, and it fired on existing tests whose fixtures omit the key precisely to
+    # exercise absent-vs-zero. `not_scanned` is the transcript verdict's OWN value for "no
+    # verdict was formed", written by exactly the one code path that skips the scan. That is
+    # the narrower and truer signal.
+    #
+    # The guard above must NOT use it, and this must not use the guard's: a flag that ACTS on
+    # evidence needs the state (is there a searched zero?), while an announcement that
+    # DESCRIBES the run needs the run's own declaration. Same two facts, opposite directions.
+    if any(r.get("status") == "not_scanned" for r in results):
+        out.append(
+            "transcripts were NOT scanned (this is the default; pass `--transcripts` to "
+            "enable), so TWO checks in this block DID NOT RUN for any ticket: 'nobody is on "
+            "it and someone is waiting', and 'ClickUp `<done>` but open signals remain'. "
+            "Both require a SEARCHED zero and an unsearched one is not the same fact, so "
+            "their silence here is not evidence of anything.")
     return out
 
 
@@ -940,6 +985,14 @@ def parse_args(args):
         "fast": False,
         # PR resolution defaults ON; results are cached and deduped within a task.
         "resolve_prs": True, "include_self_runs": False,
+        # 🔴 Transcript scanning is OPT-IN as of 2026-08-22. Measured upstream over the three
+        # tickets in that day's report, the four evidence sources scored: ClickUp status 3/3
+        # useful, newest-comment 3/3 and decisive in every case, transcript scan 0/3 (one
+        # actively misleading — a `✓ PR merged` whose own snippet read "the race is still
+        # unfixed"), cited-PR resolution 0/3 resolved with 2/3 FALSE explanations. The scan is
+        # also ~60s of the ~90s runtime and the origin of every false verdict this tool has
+        # shipped. It stays available, it is no longer the default.
+        "transcripts": False,
     }
     i = 0
     while i < len(args):
@@ -948,6 +1001,10 @@ def parse_args(args):
             opts["limit"] = int(args[i + 1]); i += 2
         elif a == "--since" and i + 1 < len(args):
             opts["since"] = args[i + 1]; i += 2
+        elif a == "--transcripts":
+            opts["transcripts"] = True; i += 1
+        elif a == "--no-transcripts":
+            opts["transcripts"] = False; i += 1
         elif a == "--json":
             opts["as_json"] = True; i += 1
         elif a == "--verbose":
@@ -961,7 +1018,8 @@ def parse_args(args):
         else:
             print(f"check-addressed.py: unknown argument {a!r}\n"
                   f"Usage: check-addressed.py [--limit N] [--since YYYY-MM-DD] [--json] "
-                  f"[--verbose] [--fast] [--no-resolve-prs] [--include-self-runs]",
+                  f"[--verbose] [--fast] [--transcripts] [--no-transcripts] "
+                  f"[--no-resolve-prs] [--include-self-runs]",
                   file=sys.stderr)
             sys.exit(2)
     return opts
@@ -976,6 +1034,7 @@ def main():
     since = opts["since"]
     resolve_prs = opts["resolve_prs"]
     include_self_runs = opts["include_self_runs"]
+    transcripts = opts["transcripts"]
 
     # Step 1: Get recent comments
     recent_args = ["--limit", str(limit), "--json"]
@@ -1009,6 +1068,24 @@ def main():
     sessions_by_task = {}
     results = []
     for tid in task_ids:
+        if not transcripts:
+            # 🔴 `mentions_found` is deliberately ABSENT, not 0. Absent means "not gathered";
+            # 0 is the positive claim "searched, and this task appears nowhere". The waiting
+            # flag fires on `mentions_found == 0` and `r.get(...) != 0` already sends an
+            # absent key down the no-claim path — so a scan-less run cannot flag every open
+            # ticket as abandoned. Pinned by a test; emitting 0 here would fire it on all.
+            meta = next((c for c in comments if c["task_id"] == tid), {})
+            results.append({
+                "task_id": tid,
+                "status": "not_scanned",
+                "sessions_searched": 0,
+                "completion": [], "open": [], "sessions": [],
+                "clickup_status": meta.get("task_status"),
+                "clickup_priority": meta.get("task_priority"),
+                "newest_comment": build_newest_comment(meta),
+            })
+            continue
+
         search_args = ["--limit", "5", "--json"]
         if since:
             search_args.extend(["--since", since])
@@ -1093,13 +1170,21 @@ def main():
                 print()
 
         print(f"\n{SELF_RUN_HEADER}\n")
-        print(f"{MARKER_LEGEND}\n")
+        if transcripts:
+            print(f"{MARKER_LEGEND}\n")
+        else:
+            print("Transcripts were NOT scanned (`--transcripts` to enable). Everything below "
+                  "comes from ClickUp: the ticket's own status and its newest comment. That is "
+                  "not a claim that no work exists — it is the absence of a claim.\n")
         for r in results:
-            status_icon = {"likely_addressed": "✅", "partially_addressed": "⚠️", "open": "🔴", "unclear": "❓", "no_sessions_found": "🔍", "no_mentions_found": "🔍"}.get(r["status"], "?")
+            status_icon = {"likely_addressed": "✅", "partially_addressed": "⚠️", "open": "🔴", "unclear": "❓", "no_sessions_found": "🔍", "no_mentions_found": "🔍", "not_scanned": "—"}.get(r["status"], "?")
             cu = r.get("clickup_status") or "?"
             prio = r.get("clickup_priority") or "-"
-            print(f"{status_icon} **{r['task_id']}** — transcripts say `{r['status']}` "
-                  f"(searched {r['sessions_searched']} sessions, {r.get('mentions_found', 0)} mentions)")
+            if r["status"] == "not_scanned":
+                print(f"{status_icon} **{r['task_id']}** — transcripts not scanned")
+            else:
+                print(f"{status_icon} **{r['task_id']}** — transcripts say `{r['status']}` "
+                      f"(searched {r['sessions_searched']} sessions, {r.get('mentions_found', 0)} mentions)")
             print(f"     ClickUp says: **{cu}** / prio {prio}")
             note = skip_note(r)
             if note:
@@ -1123,7 +1208,13 @@ def main():
         open_count = sum(1 for r in results if r["status"] == "open")
         unclear = sum(1 for r in results
                       if r["status"] in ("unclear", "no_sessions_found", "no_mentions_found"))
-        print(f"## Summary: {addressed} addressed, {partial} partial, {open_count} open, {unclear} unclear")
+        if transcripts:
+            print(f"## Summary: {addressed} addressed, {partial} partial, {open_count} open, {unclear} unclear")
+        else:
+            # A tally of transcript verdicts nobody computed reads as "we looked and found
+            # nothing addressed" — four zeroes that look like a finding. Say what happened.
+            print(f"## Summary: {len(results)} ticket(s) read from ClickUp; transcripts not "
+                  f"scanned, so no completion verdict was formed for any of them.")
 
         for heading, lines in report_blocks(results):
             print(f"\n{heading}\n")

--- a/scripts/check-clickup-addressed/check-addressed.py
+++ b/scripts/check-clickup-addressed/check-addressed.py
@@ -1,8 +1,15 @@
 #!/usr/bin/env python3
-"""Orchestrate: recent comments → task IDs → sessions → completion check.
+"""Orchestrate: recent comments → task IDs → [sessions → completion check].
 
 Usage:
-    python3 check-addressed.py [--limit N] [--json] [--since YYYY-MM-DD] [--verbose] [--fast]
+    python3 check-addressed.py [--limit N] [--json] [--since YYYY-MM-DD] [--verbose]
+                               [--fast] [--transcripts] [--no-transcripts]
+
+🔴 THE TRANSCRIPT SCAN IS OPT-IN (2026-08-22). The DEFAULT reads ClickUp only — the ticket's
+status and its newest comment — and does NOT search session transcripts or form a completion
+verdict. `--transcripts` restores the full pipeline. The bracketed stages above are the ones
+that only run under it, and the flags that feed them (`--since`, `--include-self-runs`,
+`--no-resolve-prs`) are inert without it; the run says so on stderr rather than pretending.
 
 Default: top 3 most recent comments not from the current user.
 --fast: Only check the 10 most recently updated tasks (much faster for large backlogs).
@@ -332,6 +339,38 @@ def keep_open_signal(text):
 # premise: add a phrase to RESOLVED_COMMENT_RE whose words are not in CLOSURE_VOCAB_RE and
 # that test goes red, which is the signal to bring the filter back.
 
+
+# 🔴 EVERY RULE IN `disagreements` THAT NEEDS THE TRANSCRIPT SCAN — the LEDGER, and the
+# scan-less announcement is BUILT from it rather than restating it.
+#
+# The first version of that announcement named TWO rules. FOUR are structurally dead in the
+# scan-less default, and naming a subset is worse than naming none: it implies the unnamed
+# ones ran. That is the same "an empty block reads as checked" defect the announcement exists
+# to kill, one axis over — and it arrived INSIDE the fix for it.
+#
+# Each entry is (name for the announcement, the flag's own unique TAIL). The tail is what
+# `test_the_scanless_ledger_matches_what_actually_goes_quiet` diffs the two modes against, so
+# a fifth transcript-dependent rule fails the suite when it is ADDED, and an entry that stops
+# being scan-dependent fails when it is REMOVED. A ledger asserted in one direction only is a
+# ledger that silently rots in the other.
+#
+# 🔴 A NAME MUST NEVER CONTAIN ITS OWN TAIL. The announcement talks ABOUT these flags, so if a
+# name embedded its tail, `"<tail>" in output` would be true in a run where the flag never
+# fired — the instrument matching its own announcement. Upstream hit exactly that and it cost
+# a false failure; `test_the_announcement_never_contains_a_flags_own_tail` makes it
+# unexpressible rather than remembered.
+SCAN_ONLY_RULES = (
+    ("nobody is on it and someone is waiting", "is WAITING"),
+    ("ClickUp `<done>` but open signals remain", "verify before trusting the close"),
+    ("the transcripts read as done while ClickUp is still open", "close it or re-check"),
+    ("a PR the transcripts cited is still open", "the signal that quoted it reads as done"),
+)
+
+# The announcement's stable opening. A CONSTANT because two consumers need to recognise the
+# line: the test that reads it, and `suppressed_notes`, whose per-ticket `disagreements([r])`
+# query must not mistake this RUN-level sentence for a flag about its own ticket.
+SCANLESS_LEAD = ("transcripts were NOT scanned (this is the default; pass `--transcripts` "
+                 "to enable), so ")
 
 OPEN_STATUSES = {"to do", "open", "in progress", "backlog", "todo"}
 DONE_STATUSES = {"complete", "closed", "done", "resolved"}
@@ -700,7 +739,22 @@ def suppressed_notes(results, now=None):
         kind, line = _waiting_verdict(r, now)
         if kind != ANSWERED:
             continue
-        others = disagreements([r], now)
+        # 🔴 RUN-level lines are stripped: this query asks "does anything else in the report
+        # name THIS TICKET", and the scan-less announcement is a sentence about the RUN that
+        # `disagreements` appends whatever list it is handed. Counting it would make the note
+        # say "'Needs a decision' above ALSO carries a line about this ticket" when the only
+        # line there is about the invocation — the same false-scoping the `[r]` argument was
+        # introduced to fix, re-entering through the other end of the function.
+        #
+        # 🔴 REACHABLE, and measured rather than argued. `main()` alone cannot produce the
+        # state — an ANSWERED verdict needs `mentions_found == 0` and its scan-less builder
+        # omits the key — so the first version of this comment called the guard unreachable
+        # and nearly deleted it. A record that is `not_scanned` AND carries a searched zero
+        # reaches ANSWERED and DOES leak the announcement: verdict `answered`, one note, the
+        # run-level line counted as a flag about that ticket. That record is exactly the
+        # stale-producer / partial-write shape this file's own announcement comment warns
+        # about, and `suppressed_notes` is a public function with its own callers.
+        others = [f for f in disagreements([r], now) if not f.startswith(SCANLESS_LEAD)]
         if others:
             line += (" ⚠️  'Needs a decision' above ALSO carries a line about this ticket — "
                      "this note is only about the waiting check.")
@@ -889,12 +943,13 @@ def disagreements(results, now=None):
     # evidence needs the state (is there a searched zero?), while an announcement that
     # DESCRIBES the run needs the run's own declaration. Same two facts, opposite directions.
     if any(r.get("status") == "not_scanned" for r in results):
+        named = "; ".join(f"'{name}'" for name, _tail in SCAN_ONLY_RULES)
         out.append(
-            "transcripts were NOT scanned (this is the default; pass `--transcripts` to "
-            "enable), so TWO checks in this block DID NOT RUN for any ticket: 'nobody is on "
-            "it and someone is waiting', and 'ClickUp `<done>` but open signals remain'. "
-            "Both require a SEARCHED zero and an unsearched one is not the same fact, so "
-            "their silence here is not evidence of anything.")
+            f"{SCANLESS_LEAD}{len(SCAN_ONLY_RULES)} checks in this block DID NOT RUN for any "
+            f"ticket: {named}. Each needs evidence this run never gathered — a SEARCHED zero, "
+            f"a completion verdict, or the cited-PR resolution — and an unsearched zero is "
+            f"not the same fact as a searched one, so their silence here is not evidence of "
+            f"anything.")
     return out
 
 
@@ -970,6 +1025,30 @@ def build_newest_comment(meta):
     return nc
 
 
+def attach_clickup_meta(record, meta):
+    """Attach the ClickUp-side facts to a task record, and return it.
+
+    🔴 ONE WRITER, TWO CALL SITES — and it is a helper because it briefly was not. The
+    transcript opt-in added a SECOND, independent construction of this record (the scan-less
+    path), which duplicated these three assignments by hand. Nothing pinned that the two
+    agreed, and three one-token mutants on the copy — `newest_comment` -> `{}`, `meta` ->
+    `{}`, `clickup_status` -> `None` — SURVIVED a fully green suite. The first of those
+    silently removes the RESOLVED-comment-on-an-open-ticket flag, which this skill's own
+    docs call the highest-value line in the report, on the path that is now the DEFAULT.
+
+    That is the "one rule, one place" failure in its usual shape: the predicate was right at
+    both sites the day it was copied, and only one of them was ever exercised. Consolidated
+    so a future divergence is not expressible, rather than tested for.
+
+    `meta` is `{}` when no comment matched the task — `.get` throughout, so an absent ClickUp
+    fact lands as `None` (unknown) rather than raising.
+    """
+    record["clickup_status"] = meta.get("task_status")
+    record["clickup_priority"] = meta.get("task_priority")
+    record["newest_comment"] = build_newest_comment(meta)
+    return record
+
+
 def parse_args(args):
     """Parse the entry point's flags, rejecting anything it does not know.
 
@@ -1036,6 +1115,26 @@ def main():
     include_self_runs = opts["include_self_runs"]
     transcripts = opts["transcripts"]
 
+    # 🔴 A FLAG THAT DOES NOTHING MUST SAY SO. These four only ever reach the transcript
+    # stages — three are forwarded verbatim to `search-sessions.py` / `check-completion.py`,
+    # and `--verbose` only widens session and signal listings — so with the scan off they are
+    # inert. `parse_args`' own docstring is the rule being applied here: a silently-ignored
+    # flag is "a run that looks like it honoured your request and did not", and this file has
+    # already shipped that exact bug once with `--include-self-runs`.
+    #
+    # A WARNING, not `sys.exit(2)`: unlike an unknown argument these are real flags spelled
+    # correctly, and a habitual `--since` in a wrapper script should not become a hard
+    # failure. stderr is where the child scripts' own warnings already surface.
+    if not transcripts:
+        inert = [name for name, on in (("--since", since is not None),
+                                       ("--include-self-runs", include_self_runs),
+                                       ("--no-resolve-prs", not resolve_prs),
+                                       ("--verbose", verbose)) if on]
+        if inert:
+            print(f"WARNING: {', '.join(inert)} affect ONLY the transcript scan, which is off "
+                  f"by default — so this run ignored them. Add --transcripts to make them "
+                  f"take effect.", file=sys.stderr)
+
     # Step 1: Get recent comments
     recent_args = ["--limit", str(limit), "--json"]
     if fast:
@@ -1074,16 +1173,17 @@ def main():
             # flag fires on `mentions_found == 0` and `r.get(...) != 0` already sends an
             # absent key down the no-claim path — so a scan-less run cannot flag every open
             # ticket as abandoned. Pinned by a test; emitting 0 here would fire it on all.
+            #
+            # 🔴 `sessions_searched` is ABSENT for the same reason `mentions_found` is: zero
+            # sessions searched is an unsearched zero, and emitting it as a count is the
+            # exact claim this whole path exists to refuse. Only the scanned branch prints
+            # it, and every other reader uses `.get`.
             meta = next((c for c in comments if c["task_id"] == tid), {})
-            results.append({
+            results.append(attach_clickup_meta({
                 "task_id": tid,
                 "status": "not_scanned",
-                "sessions_searched": 0,
                 "completion": [], "open": [], "sessions": [],
-                "clickup_status": meta.get("task_status"),
-                "clickup_priority": meta.get("task_priority"),
-                "newest_comment": build_newest_comment(meta),
-            })
+            }, meta))
             continue
 
         search_args = ["--limit", "5", "--json"]
@@ -1130,20 +1230,28 @@ def main():
                 # authority the transcript scan cannot see, so it is reported beside
                 # every verdict rather than left in the comments block.
                 meta = next((c for c in comments if c["task_id"] == tid), {})
-                task_results[0]["clickup_status"] = meta.get("task_status")
-                task_results[0]["clickup_priority"] = meta.get("task_priority")
-                task_results[0]["newest_comment"] = build_newest_comment(meta)
+                attach_clickup_meta(task_results[0], meta)
                 task_results[0]["self_runs_skipped_search"] = search_skipped
                 results.append(task_results[0])
 
     # Step 5: Build report
+    #
+    # 🔴 `transcripts` is REPORTED, and the two session counts are OMITTED when it is false.
+    # A consumer was otherwise left inferring the mode from a spelled sentinel (`status ==
+    # "not_scanned"`) — the same spelled-guard shape the open-signals flag was fixed for —
+    # while `sessions_found: 0` and `sessions_by_task: {}` handed it two UNSEARCHED zeros
+    # dressed as searched counts. That is precisely the claim this whole path refuses to
+    # make, and applying the absent-vs-zero discipline to `mentions_found` while emitting its
+    # siblings as zeros was inconsistent in the direction that misleads.
     report = {
         "comments": comments,
-        "sessions_found": sum(len(v) for v in sessions_by_task.values()),
-        "sessions_by_task": {k: len(v) for k, v in sessions_by_task.items()},
+        "transcripts": transcripts,
         "excluded_self_session": self_session or None,
         "task_status": results,
     }
+    if transcripts:
+        report["sessions_found"] = sum(len(v) for v in sessions_by_task.values())
+        report["sessions_by_task"] = {k: len(v) for k, v in sessions_by_task.items()}
 
     if as_json:
         print(render_json(report))

--- a/scripts/check-clickup-addressed/check-completion.py
+++ b/scripts/check-clickup-addressed/check-completion.py
@@ -148,14 +148,15 @@ def _repo_for_ref(clean_snippet, match_start, word, default_repo):
     vague one because it stops the reader looking:
 
       "not_named"   nothing repo-ish before the '#' and no known repo within
-                    REPO_LOOKBEHIND. The message is correct; the refusal to guess is the
-                    round-2 fix and stays.
-      "unknown"     a word IS sitting on the '#' but is absent from KNOWN_REPOS. The repo
-                    was named. Saying it was not sends the reader nowhere; naming it sends
-                    them to the table. (This word is reported as-written, with no attempt
-                    to classify it as repo-shaped — 'devrc' and 'landed' are
-                    indistinguishable to any rule that does not enumerate the world, and a
-                    reader can tell them apart at a glance where a heuristic cannot.)
+                    REPO_LOOKBEHIND. The refusal to guess is the round-2 fix and stays.
+      "unknown"     a word IS sitting on the '#' but is absent from KNOWN_REPOS. 🔴 Round 5
+                    reported that word back ("repo 'X' is not in KNOWN_REPOS") on the
+                    reasoning that a repo WAS named; round 7 retracted that on measurement —
+                    'devrc' and 'landed' are indistinguishable to any rule that does not
+                    enumerate the world, and the captured token was an ENGLISH word in 2 of
+                    3 live cases. So this reason and "not_named" now RENDER identically. The
+                    distinction is still carried as DATA; the render just no longer claims
+                    to know what the token means. See `_unresolved_state`.
       "ambiguous"   two or more KNOWN repos in range and none adjacent. Repos were named;
                     the problem is that more than one was. Naming the candidates is what
                     lets the reader disambiguate by eye.
@@ -184,17 +185,31 @@ def _repo_for_ref(clean_snippet, match_start, word, default_repo):
 def _unresolved_state(reason):
     """Render a resolution failure as the operator-facing string.
 
-    Each variant says what is actually wrong AND what to do about it. The unknown-repo
-    variant names KNOWN_REPOS explicitly: D6's lesson is that the announcement, not the
-    widened vocabulary, is what makes the next miss visible.
+    TWO strings, not three. `ambiguous` keeps its own message because it is the one failure
+    whose diagnosis is TRUE. `unknown` and `not_named` render identically, deliberately: the
+    tool cannot tell them apart on real input, so claiming to is the defect. Both still name
+    KNOWN_REPOS — D6's lesson is that the announcement, not the widened vocabulary, is what
+    makes the next miss visible — but as a CONDITIONAL, never as an assertion that a repo was
+    named. See the comment in the body for the measurement that reversed round 5.
     """
     kind, detail = reason
-    if kind == "unknown":
-        return (f"unresolved (repo {detail!r} is not in KNOWN_REPOS — add it to "
-                f"check-completion.py, owner verified, if it is a real repo)")
     if kind == "ambiguous":
+        # The only failure that carries a TRUE diagnosis: repos really were named, and the
+        # problem is that more than one was. Naming them lets the reader disambiguate by eye.
         return f"unresolved (ambiguous — {', '.join(detail)} both in range, neither adjacent)"
-    return "unresolved (repo not named)"
+    # 🔴 "unknown" and "not_named" now render IDENTICALLY, and neither names the captured
+    # word. Measured upstream 2026-08-22 on a live run: 2 of 3 cited PRs produced
+    # `repo 'their' is not in KNOWN_REPOS` and `repo 'which' is not in KNOWN_REPOS` — the
+    # lookbehind had captured the preceding ENGLISH word while the comment plainly named a
+    # repo and a number. That message asserts a premise ("a repo was named, and it is spelled
+    # 'their'") that is false, and sends the reader on an errand to add an English word to a
+    # repo table. Round 5 introduced the split to replace one wrong message with three
+    # precise ones; on real input the precise version was wrong more often, because `word` is
+    # whatever token precedes the '#' and nothing short of enumerating the world tells
+    # `devrc` from `landed`. The affordance survives as a CONDITIONAL — true whether or not a
+    # repo was named — instead of an assertion that one was.
+    return ("unresolved (could not determine the repo; if one is named here, add it to "
+            "KNOWN_REPOS in check-completion.py)")
 
 
 def annotate_pr_refs(signals, default_repo=None):

--- a/scripts/check-clickup-addressed/tests/mutation_sweep.py
+++ b/scripts/check-clickup-addressed/tests/mutation_sweep.py
@@ -32,12 +32,11 @@ the same second imports the ORIGINAL bytecode and scores SURVIVED without ever r
 here the scripts sit at the skill root and the suite in `tests/`. `run_one` below is written
 against THIS layout — if you copy a mutant across, copy the paths too.
 
-⚠️ FIVE UPSTREAM MUTANTS ARE DELIBERATELY ABSENT (N1-N5). They cover a scan-less-run
-announcement and the `"mentions_found" in r` gate that goes with it, both of which exist
-because upstream made the transcript scan opt-in. This tool always scans — `check-completion.py`
-emits `mentions_found` on every exit path and nothing writes a `not_scanned` status — so those
-mutants would target code that is not here and score NOT APPLIED forever. Restore them in the
-same commit as any `--transcripts` opt-in.
+🔴 N1-N5 (the scan-less announcement and the `"mentions_found" in r` gate that goes with it)
+were deliberately ABSENT while this tool always scanned. The `--transcripts` opt-in landed
+2026-08-22, which is the restore condition that omission named, and they are back — together
+with T1-T9 for the opt-in's own parsing, its scan-less record, its three renderings and its
+CALL SITES in `main()`, and U1-U3 for the retracted false-premise repo message.
 """
 import os
 import re
@@ -50,6 +49,7 @@ from pathlib import Path
 SKILL = Path(__file__).resolve().parent.parent
 RC = "recent-comments.py"
 CA = "check-addressed.py"
+CC = "check-completion.py"
 
 # 🔴 REMOVED FROM EVERY MUTANT COPY, and this is the instrument's own correctness, not tidiness.
 # `test_no_real_identifiers.py` is a REPO-HYGIENE gate: it walks `<repo>/scripts/…` and
@@ -230,6 +230,62 @@ MUTANTS = [
     ("N12", CA, "    except (ValueError, TypeError, OSError, OverflowError):",
      "    except (ValueError, OSError, OverflowError):",
      "a string raw-ms raises an uncaught TypeError"),
+
+    # ---------- round 7/8: the transcript opt-in, its scan-less record, and the announcement
+    # + state gate that only became reachable once the opt-in existed. N1-N5 are upstream's,
+    # restored per the condition their omission named; T1-T9 are this port's own, and half of
+    # them target CALL SITES rather than function bodies, because a correct scan-less record
+    # that `main()` never builds is inert with a fully green suite — this skill's own headline
+    # defect class.
+    ("N1", CA, "    if any(r.get(\"status\") == \"not_scanned\" for r in results):",
+     "    if False:", "delete the scan-less announcement"),
+    ("N2", CA, "    if any(r.get(\"status\") == \"not_scanned\" for r in results):",
+     "    if any(\"mentions_found\" not in r for r in results):",
+     "announce from a RECORD-level absence instead of the run's own declaration"),
+    ("N3", CA, "    if any(r.get(\"status\") == \"not_scanned\" for r in results):",
+     "    for _r in results:\n     if _r.get(\"status\") == \"not_scanned\":",
+     "announce once per TICKET instead of once per run"),
+    ("N4", CA, "        if (\"mentions_found\" in r and r[\"status\"] in (\"open\", \"no_mentions_found\")",
+     "        if ((True) and r[\"status\"] in (\"open\", \"no_mentions_found\")",
+     "open-signals flag stops requiring a SEARCHED zero"),
+    ("N5", CA, "                \"status\": \"not_scanned\",", "                \"status\": \"no_mentions_found\",",
+     "rename the scan-less sentinel (SURVIVED the round-7c suite upstream)"),
+    ("T1", CA, '        "transcripts": False,', '        "transcripts": True,',
+     "the scan is on by default again"),
+    ("T2", CA, "        elif a == \"--transcripts\":\n            opts[\"transcripts\"] = True; i += 1",
+     "        elif a == \"--transcripts\":\n            opts[\"transcripts\"] = False; i += 1",
+     "`--transcripts` parses to a no-op — the opt-in cannot be taken"),
+    ("T3", CA, "        elif a == \"--no-transcripts\":\n            opts[\"transcripts\"] = False; i += 1",
+     "        elif a == \"--no-transcripts\":\n            opts[\"transcripts\"] = True; i += 1",
+     "`--no-transcripts` turns the scan ON"),
+    ("T4", CA, "    transcripts = opts[\"transcripts\"]", "    transcripts = False",
+     "CALL SITE: main() ignores the parsed flag and never scans"),
+    ("T5", CA, "        if not transcripts:", "        if False:",
+     "CALL SITE: main() always scans, whatever the flag said"),
+    ("T6", CA, "                \"sessions_searched\": 0,",
+     "                \"sessions_searched\": 0, \"mentions_found\": 0,",
+     "the scan-less record emits an UNSEARCHED zero as a searched one"),
+    ("T7", CA, "        if transcripts:\n            print(f\"{MARKER_LEGEND}\\n\")",
+     "        if True:\n            print(f\"{MARKER_LEGEND}\\n\")",
+     "the evidence-marker legend heads a report with no evidence"),
+    ("T8", CA, "        if transcripts:\n            print(f\"## Summary: {addressed} addressed",
+     "        if True:\n            print(f\"## Summary: {addressed} addressed",
+     "a tally of verdicts nobody computed — four zeroes that read as a finding"),
+    ("T9", CA, "            if r[\"status\"] == \"not_scanned\":", "            if False:",
+     "a scan-less record prints a searched-sessions/mentions count"),
+
+    # ---------- round 7: the retracted false-premise message in `_unresolved_state`. Round 5
+    # replaced one vague failure with three precise ones; measured on live input the precise
+    # version was wrong MORE often, because the token on the '#' is whatever word precedes it.
+    ("U1", CC, "    return (\"unresolved (could not determine the repo; if one is named here, add it to \"",
+     "    if kind == \"unknown\":\n        return f\"unresolved (repo {detail!r} is not in KNOWN_REPOS)\"\n"
+     "    return (\"unresolved (could not determine the repo; if one is named here, add it to \"",
+     "reinstate the false premise: quote the captured token back as a repo"),
+    ("U2", CC, "            \"KNOWN_REPOS in check-completion.py)\")",
+     "            \"the repo table in check-completion.py)\")",
+     "drop the affordance — the reader is told nothing to do"),
+    ("U3", CC, "    if kind == \"ambiguous\":", "    if False:",
+     "collapse the one failure whose diagnosis is TRUE into the generic message"),
 
     # ---------- POSITIVE CONTROL. A mutant round 6 proved is caught; if this ever reports
     # SURVIVED the harness is broken, not the code.

--- a/scripts/check-clickup-addressed/tests/mutation_sweep.py
+++ b/scripts/check-clickup-addressed/tests/mutation_sweep.py
@@ -189,8 +189,12 @@ MUTANTS = [
      "the ms-based bound never answers"),
     ("M48", CA, "        if others:\n            line +=", "        if not others:\n            line +=",
      "invert the other-coverage branch"),
-    ("M49", CA, "        others = disagreements([r], now)", "        others = []",
-     "always claim the report is silent about the ticket"),
+    # ⚠️ M49 and M-SCOPE were re-anchored 2026-08-23: the run-level-announcement filter
+    # rewrote this line, and BOTH went `NOT APPLIED` — which `--check` caught and failed on,
+    # exactly as its docstring promises. M-SCOPE is round 8's headline mutant; a silent
+    # NOT APPLIED there would have read like every other green row.
+    ("M49", CA, "        others = [f for f in disagreements([r], now) if not f.startswith(SCANLESS_LEAD)]",
+     "        others = []", "always claim the report is silent about the ticket"),
     ("M50", CA, "                       [f\"🔴 {BOT_IDENTITY_CAVEAT}\"] + [f\"ℹ️  {n}\" for n in notes]))",
      "                       [f\"ℹ️  {n}\" for n in notes]))", "drop the caveat preamble"),
     ("M51", CA, "                       [f\"🔴 {BOT_IDENTITY_CAVEAT}\"] + [f\"ℹ️  {n}\" for n in notes]))",
@@ -211,7 +215,8 @@ MUTANTS = [
     # ---------- round 8: the invariants nothing pinned. M-SCOPE is the one a blind re-audit
     # found surviving a green sweep — it reverts round 7b's headline fix, and the guard
     # written for that fix could not see it because every fixture passed a single-record list.
-    ("M-SCOPE", CA, "        others = disagreements([r], now)", "        others = disagreements(results, now)",
+    ("M-SCOPE", CA, "if not f.startswith(SCANLESS_LEAD)]\n        if others:",
+     "if not f.startswith(SCANLESS_LEAD)]\n        others = disagreements(results, now)\n        if others:",
      "the other-coverage sentence stops being scoped to its own ticket"),
     ("N7", CA, "        seen = f\"{age:.0f}d ago\" if age is not None else f\"at {nc.get('date')!r} (unreadable)\"",
      "        seen = f\"{bound_age:.0f}d ago\" if bound_age is not None else f\"at {nc.get('date')!r} (unreadable)\"",
@@ -262,8 +267,8 @@ MUTANTS = [
      "CALL SITE: main() ignores the parsed flag and never scans"),
     ("T5", CA, "        if not transcripts:", "        if False:",
      "CALL SITE: main() always scans, whatever the flag said"),
-    ("T6", CA, "                \"sessions_searched\": 0,",
-     "                \"sessions_searched\": 0, \"mentions_found\": 0,",
+    ("T6", CA, "                \"status\": \"not_scanned\",\n                \"completion\": [], \"open\": [], \"sessions\": [],",
+     "                \"status\": \"not_scanned\", \"mentions_found\": 0,\n                \"completion\": [], \"open\": [], \"sessions\": [],",
      "the scan-less record emits an UNSEARCHED zero as a searched one"),
     ("T7", CA, "        if transcripts:\n            print(f\"{MARKER_LEGEND}\\n\")",
      "        if True:\n            print(f\"{MARKER_LEGEND}\\n\")",
@@ -273,6 +278,28 @@ MUTANTS = [
      "a tally of verdicts nobody computed — four zeroes that read as a finding"),
     ("T9", CA, "            if r[\"status\"] == \"not_scanned\":", "            if False:",
      "a scan-less record prints a searched-sessions/mentions count"),
+
+    # ---------- the scan-less record's CONTENT, and the announcement's LEDGER. Z1-Z3 are the
+    # three that survived a 220-green suite before `attach_clickup_meta` collapsed the two
+    # record writers into one: T4-T9 cover whether the branch runs and what its counts say,
+    # and nothing covered what the record CARRIES. Z1 alone deletes the highest-value line in
+    # the report on the default path. They stay in the list even though the duplicate writer
+    # is gone — a mutant that can no longer be expressed at two sites is still worth pinning
+    # at the one.
+    ("Z1", CA, "    record[\"newest_comment\"] = build_newest_comment(meta)",
+     "    record[\"newest_comment\"] = {}",
+     "the record carries no newest comment: the RESOLVED-on-open flag silently disappears"),
+    ("Z2", CA, "    record[\"clickup_status\"] = meta.get(\"task_status\")",
+     "    record[\"clickup_status\"] = None",
+     "the record carries no ClickUp status: every status-gated rule goes to 'unknown'"),
+    ("Z3", CA, "            }, meta))", "            }, {}))",
+     "CALL SITE: the scan-less builder is handed an empty meta"),
+    ("Z4", CA, "    named = \"; \".join(f\"'{name}'\" for name, _tail in SCAN_ONLY_RULES)",
+     "    named = \"; \".join(f\"'{name}'\" for name, _tail in SCAN_ONLY_RULES[:2])",
+     "the announcement names a SUBSET again — the defect the ledger replaced"),
+    ("Z5", CA, "        others = [f for f in disagreements([r], now) if not f.startswith(SCANLESS_LEAD)]",
+     "        others = disagreements([r], now)",
+     "the RUN-level announcement counts as a per-TICKET flag in the note"),
 
     # ---------- round 7: the retracted false-premise message in `_unresolved_state`. Round 5
     # replaced one vague failure with three precise ones; measured on live input the precise

--- a/scripts/check-clickup-addressed/tests/mutation_sweep.py
+++ b/scripts/check-clickup-addressed/tests/mutation_sweep.py
@@ -300,6 +300,12 @@ MUTANTS = [
     ("Z5", CA, "        others = [f for f in disagreements([r], now) if not f.startswith(SCANLESS_LEAD)]",
      "        others = disagreements([r], now)",
      "the RUN-level announcement counts as a per-TICKET flag in the note"),
+    # 🔴 The LEDGER shrinking, which is the half a ledger-derived assertion cannot see —
+    # both of the obvious checks are computed FROM `SCAN_ONLY_RULES`, so dropping an entry
+    # keeps them consistent with each other and silently stops announcing a rule that still
+    # goes quiet. Only the flags-that-actually-disappeared diff catches this.
+    ("Z6", CA, "    (\"a PR the transcripts cited is still open\", \"the signal that quoted it reads as done\"),\n)",
+     ")", "drop a rule from the ledger: it goes quiet and nothing announces it"),
 
     # ---------- round 7: the retracted false-premise message in `_unresolved_state`. Round 5
     # replaced one vague failure with three precise ones; measured on live input the precise

--- a/scripts/check-clickup-addressed/tests/test_attribution.py
+++ b/scripts/check-clickup-addressed/tests/test_attribution.py
@@ -245,7 +245,9 @@ def test_blocked_on_credential_is_detected():
 def test_pr_ref_without_a_repo_is_not_guessed():
     sig = [{"signal": "PR merged", "snippet": "PR #1100 merged, verified by content"}]
     check_completion.annotate_pr_refs(sig, default_repo=None)
-    assert sig[0]["pr_refs"] == [{"ref": "#1100", "state": "unresolved (repo not named)"}], \
+    assert sig[0]["pr_refs"] == [{"ref": "#1100", "state": (
+        "unresolved (could not determine the repo; if one is named here, add it to "
+        "KNOWN_REPOS in check-completion.py)")}], \
         f"a repo-less PR reference was guessed: {sig[0].get('pr_refs')}"
 
 
@@ -360,14 +362,16 @@ def test_distant_repo_name_does_not_claim_a_bare_ref():
     finally:
         check_completion.resolve_pr = orig
     assert called == [], f"a distant repo name claimed a bare ref: {called}"
-    # Round 5 (D9): the word sitting on this '#' is "landed", which is reported as-written.
-    # No rule short of enumerating the world separates 'landed' from 'devrc', and a reader
-    # separates them at a glance — so the message names the word and refuses to classify
-    # it. What matters, and is unchanged, is that nothing was resolved.
+    # Round 7 (2026-08-22): the word sitting on this '#' is "landed". Round 5 reported it
+    # as-written — which on live input rendered as `repo 'landed' is not in KNOWN_REPOS`,
+    # asserting a premise that is false and sending the reader to add an English word to a
+    # repo table. The message no longer quotes the token at all. What matters, and is
+    # unchanged across both rounds, is that NOTHING WAS RESOLVED (`called == []` above).
     assert sig[0]["pr_refs"][0]["state"].startswith("unresolved ("), \
         f"a distant repo name claimed a bare ref: {sig[0]['pr_refs']}"
-    assert "'landed'" in sig[0]["pr_refs"][0]["state"], \
-        f"the word on the '#' is not reported: {sig[0]['pr_refs']}"
+    assert "landed" not in sig[0]["pr_refs"][0]["state"], \
+        ("the captured token is quoted back as if it were a repo — the false-premise "
+         f"message round 7 removed: {sig[0]['pr_refs'][0]['state']!r}")
 
 
 # ----------------------------------------------------------------- disagreements

--- a/scripts/check-clickup-addressed/tests/test_bounds_and_parsing.py
+++ b/scripts/check-clickup-addressed/tests/test_bounds_and_parsing.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
-"""Round 8 (2026-08-22). Three invariants the prose GUARANTEED and nothing pinned, plus the
-parser robustness a one-token mutant exposed.
+"""Round 8 (2026-08-22). The DEFAULT invocation cannot fire two rules and nothing said so,
+three invariants the prose GUARANTEED and nothing pinned, plus the parser robustness a
+one-token mutant exposed.
 
-⚠️ THESE ARE MUTATION-COVERAGE GUARDS, NOT REGRESSION COVERAGE — and the label needs one
+🔴 SECTION 1 IS REGRESSION COVERAGE and is labelled there: it is red at the base of the
+commit that made the transcript scan opt-in, where a scan-less run emits nothing at all.
+
+⚠️ EVERYTHING BELOW SECTION 1 IS MUTATION-COVERAGE GUARDS, NOT REGRESSION COVERAGE — and the label needs one
 extra sentence here that upstream did not need. Upstream these are literally green at its
 base, because its base already carries the round-7 code they cover. **Measured against THIS
 repo's pre-port `main`, four of the five below are RED** — with `AttributeError: module
@@ -25,18 +29,15 @@ already correct.
     overshoots by a MULTIPLE of the step cannot see a doubling mutant. The cases below
     overshoot deliberately (20) and include one exactly ON the boundary (14.0).
 
-🔴 NOT PORTED, deliberately: the upstream copy of this file opens with a scan-less-run
-ANNOUNCEMENT — one line per run saying that the two transcript-gated rules could not fire —
-because upstream made the transcript scan opt-in. This tool has no such flag: `main()` always
-runs search-sessions.py and check-completion.py, no record ever carries a `not_scanned`
-status, and `mentions_found` is always present. Porting the announcement would add a branch
-no input here can reach, and an unreachable guard reads as protection while providing none.
-The same goes for the `"mentions_found" in r` gate its sibling puts on the "open signals
-remain" flag: that gate exists to stop an UNSEARCHED zero firing it, and there is no
-unsearched zero here. If a `--transcripts` opt-in ever lands, both are required in the same
-commit.
+🔴 The scan-less announcement and the `"mentions_found" in r` gate on "open signals remain"
+were deliberately NOT ported when this repo had no `--transcripts` flag — the omission named
+"if a `--transcripts` opt-in ever lands, both are required in the same commit" as its restore
+condition. That opt-in landed 2026-08-22 and both are here, in section 1.
 """
 import importlib.util
+import io
+import json
+import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -57,8 +58,14 @@ def _ms(dt):
     return int(dt.timestamp() * 1000)
 
 
-def _rec(tid="868gz0hhh", days=2, reply_days=None, status="to do", date_str=None, date_ms=True):
-    """A `task_status` record, carrying both the display strings and the raw epoch-ms."""
+def _rec(tid="868gz0hhh", days=2, reply_days=None, status="to do", date_str=None, date_ms=True,
+         scanned=True, transcript_status="no_mentions_found"):
+    """A `task_status` record, carrying both the display strings and the raw epoch-ms.
+
+    `scanned=False` OMITS `mentions_found`, which is exactly what the scan-less path in
+    `main()` builds — an unsearched zero is not a searched one, so the key is absent rather
+    than 0.
+    """
     their = NOW - timedelta(days=days)
     nc = {"date": date_str if date_str is not None else _fmt(their),
           "author": "Robin Example", "snippet": "a question", "text": "a question"}
@@ -70,9 +77,12 @@ def _rec(tid="868gz0hhh", days=2, reply_days=None, status="to do", date_str=None
         nc["my_latest_reply_ms"] = _ms(mine)
     else:
         nc["my_latest_reply"] = None
-    return {"task_id": tid, "status": "no_mentions_found", "sessions_searched": 1,
-            "mentions_found": 0, "clickup_status": status, "clickup_priority": "high",
-            "newest_comment": nc, "completion": [], "open": []}
+    r = {"task_id": tid, "status": transcript_status, "sessions_searched": 1,
+         "clickup_status": status, "clickup_priority": "high",
+         "newest_comment": nc, "completion": [], "open": []}
+    if scanned:
+        r["mentions_found"] = 0
+    return r
 
 
 def _flags(*recs):
@@ -86,6 +96,144 @@ def _waiting(*recs):
 def _notes(*recs):
     return check_addressed.suppressed_notes(list(recs), now=NOW)
 
+
+# ------------------------------------------------ 1. the scan-less announcement
+#
+# 🔴 THESE FIVE ARE REGRESSION COVERAGE, not mutation-coverage guards: red at this PR's base,
+# where a scan-less run emits nothing at all. Everything below this section is the mutation
+# set the module docstring describes.
+
+def test_a_scanless_run_ANNOUNCES_the_two_rules_it_could_not_run():
+    """🔴 THE REGRESSION. An empty block reads as "checked, nothing disagrees". Two of the
+    checks this block is trusted for did not run, and only the run itself knows that.
+    """
+    out = _flags(_rec(scanned=False, transcript_status="not_scanned"))
+    assert out, "a scan-less run produced NO output at all — silence reading as a clean check"
+    joined = " ".join(out).lower()
+    assert "--transcripts" in joined, \
+        f"the announcement does not say how to enable the checks it names: {out}"
+    assert "did not run" in joined, \
+        f"the announcement does not say the checks DID NOT RUN: {out}"
+    assert "waiting" in joined and "open signals remain" in joined, (
+        "the announcement does not NAME the two rules that could not fire, so a reader cannot "
+        f"tell which coverage is missing: {out}")
+
+
+def test_the_announcement_is_ONE_line_per_run_not_one_per_ticket():
+    """The scan is skipped for the whole invocation, so a per-record line would put N identical
+    sentences in the one block whose value depends on being short — the same volume argument
+    that hoisted the bot-identity caveat. Round 4's announcement is per-RECORD because the
+    status varies per record; this fact does not.
+    """
+    # Spelled out rather than built with an f-string: a computed id is invisible to
+    # `test_no_real_identifiers.py`'s literal scan, so a real one could ride in unregistered.
+    recs = [_rec(tid=tid, scanned=False, transcript_status="not_scanned")
+            for tid in ("868gx0aaa", "868gx0bbb", "868gx0zzz", "868gx1ccc")]
+    announcements = [f for f in _flags(*recs) if "--transcripts" in f]
+    assert len(announcements) == 1, \
+        f"expected exactly one announcement for {len(recs)} scan-less tickets: {announcements}"
+
+
+def test_a_scanned_run_does_NOT_announce():
+    """The anti-widening control. A permanent line is a line people learn to skip, and this
+    one must disappear the moment the scan actually runs."""
+    assert [f for f in _flags(_rec(scanned=True)) if "--transcripts" in f] == [], \
+        "the scan-less announcement fired on a run that DID scan transcripts"
+
+
+def test_the_open_signals_flag_needs_a_SEARCHED_zero_not_a_status_WORD():
+    """🔴 A MUTANT THAT SURVIVED UPSTREAM: `"status": "not_scanned"` -> `"no_mentions_found"`.
+
+    That sentinel was the only thing keeping "ClickUp `closed` but open signals remain" quiet
+    on a scan that never ran — a SPELLED guard, where the waiting flag next to it gates on the
+    STATE. Rename the sentinel and the flag fires off no evidence whatsoever, with a fully
+    green suite. The gate is now `"mentions_found" in r`, which no rename can defeat.
+    """
+    # ⚠️ The FLAG's unique tail, not the rule's NAME — the announcement above names both
+    # rules, so matching the name reports a flag that never fired.
+    unscanned = _rec(status="closed", scanned=False, transcript_status="no_mentions_found")
+    assert [f for f in _flags(unscanned) if "trusting the close" in f] == [], (
+        "'open signals remain' fired off a transcript scan that never happened — an "
+        "unsearched zero was read as a searched one")
+    # Positive control: the same record WITH a searched zero must still flag, or the
+    # assertion above would pass for the wrong reason.
+    scanned = _rec(status="closed", scanned=True, transcript_status="no_mentions_found")
+    assert [f for f in _flags(scanned) if "trusting the close" in f], \
+        "the open-signals flag stopped firing on a genuinely searched zero — control failed"
+
+
+def test_main_announces_in_the_DEFAULT_mode_and_stops_once_the_scan_runs():
+    """END TO END, on real stdout, because the claim is about what a reader SEES.
+
+    Upstream found this by driving `main()` and reading its output; reading the code said the
+    flags were present and correct, which they are — they simply cannot fire. A test that
+    stopped at `disagreements` would have agreed with the code and missed it.
+    """
+    now = datetime.now(timezone.utc)
+    theirs = now - timedelta(days=2)
+    comments = [{"task_id": "868qw0e2e", "task_name": "t", "task_status": "to do",
+                 "task_priority": "high", "date": theirs.strftime(FMT),
+                 "author": "Robin Example", "snippet": "a question", "text": "a question",
+                 "date_ms": int(theirs.timestamp() * 1000), "my_latest_reply": None}]
+
+    def fake(name, *args):
+        if name == "recent-comments.py":
+            return json.dumps(comments), 0
+        if name == "search-sessions.py":
+            return json.dumps({"sessions": [], "self_runs_skipped": 0,
+                               "self_runs_skipped_ids": []}), 0
+        if name == "check-completion.py":
+            return json.dumps([{"task_id": args[args.index("--task") + 1], "status": "open",
+                                "sessions_searched": 1, "mentions_found": 0,
+                                "completion": [], "open": []}]), 0
+        raise AssertionError(name)
+
+    def drive(*argv):
+        o_run, o_argv, buf, o_out = check_addressed.run_script, sys.argv, io.StringIO(), sys.stdout
+        try:
+            check_addressed.run_script = fake
+            sys.argv = ["check-addressed.py", *argv]
+            sys.stdout = buf
+            check_addressed.main()
+        finally:
+            sys.stdout = o_out
+            check_addressed.run_script, sys.argv = o_run, o_argv
+        return buf.getvalue()
+
+    default = drive()
+    assert check_addressed.DECISION_HEADING in default, (
+        "the DEFAULT run printed no decision block at all, so two rules that could not run "
+        f"left no trace:\n{default[-600:]}")
+    assert "--transcripts" in default and "DID NOT RUN" in default, \
+        f"the default run did not announce the checks it skipped:\n{default[-600:]}"
+    assert "is WAITING" not in default, \
+        "the waiting flag fired without a searched zero — the announcement is not a licence"
+    # 🔴 The BODY of the report has to say it too, not only the decision block. Three
+    # separate renderings claimed a transcript verdict that was never formed:
+    assert "Transcripts were NOT scanned" in default, (
+        "the completion-status block printed the evidence-marker legend over records that "
+        f"carry no evidence:\n{default[-900:]}")
+    assert check_addressed.MARKER_LEGEND not in default, \
+        "the marker legend describes evidence lines a scan-less run cannot produce"
+    assert "mentions)" not in default, (
+        "a scan-less record printed a mention COUNT — the searched-zero claim in the one "
+        f"place a reader looks first:\n{default[-900:]}")
+    assert "no completion verdict was formed" in default, (
+        "the summary printed a tally of verdicts nobody computed — four zeroes that read as "
+        f"a finding:\n{default[-400:]}")
+
+    scanned = drive("--transcripts")
+    assert "is WAITING" in scanned, "the waiting flag did not fire even WITH --transcripts"
+    assert "DID NOT RUN" not in scanned, \
+        f"a scanned run still announced a skipped scan:\n{scanned[-600:]}"
+    # The anti-widening half: the scan-less wording must not leak into a real run.
+    assert "Transcripts were NOT scanned" not in scanned and check_addressed.MARKER_LEGEND in scanned, \
+        f"a scanned run rendered as if it had skipped the scan:\n{scanned[-900:]}"
+    assert "no completion verdict was formed" not in scanned and " addressed," in scanned, \
+        f"a scanned run withheld its own summary tally:\n{scanned[-400:]}"
+
+
+# ------------------------------------------------ 2. the three unpinned invariants
 
 def test_the_other_coverage_sentence_is_scoped_to_ITS_OWN_ticket():
     """MUTATION-COVERAGE GUARD (see the module docstring: red against pre-port `main` only

--- a/scripts/check-clickup-addressed/tests/test_bounds_and_parsing.py
+++ b/scripts/check-clickup-addressed/tests/test_bounds_and_parsing.py
@@ -146,20 +146,26 @@ def _notes(*recs):
 # where a scan-less run emits nothing at all. Everything below this section is the mutation
 # set the module docstring describes.
 
-def test_a_scanless_run_ANNOUNCES_the_two_rules_it_could_not_run():
-    """🔴 THE REGRESSION. An empty block reads as "checked, nothing disagrees". Two of the
-    checks this block is trusted for did not run, and only the run itself knows that.
+def test_a_scanless_run_ANNOUNCES_the_rules_it_could_not_run():
+    """🔴 THE REGRESSION. An empty block reads as "checked, nothing disagrees". Checks this
+    block is trusted for did not run, and only the run itself knows that.
+
+    ⚠️ This test was named `..._the_two_rules_...` and asserted on two hardcoded substrings.
+    FOUR rules go quiet, so the name was a false coverage claim and the body would have
+    stayed green while the announcement dropped the other two. It now reads the LEDGER — a
+    name is a claim like any other.
     """
     out = _flags(_rec(scanned=False, transcript_status="not_scanned"))
     assert out, "a scan-less run produced NO output at all — silence reading as a clean check"
-    joined = " ".join(out).lower()
+    joined = " ".join(out)
     assert "--transcripts" in joined, \
         f"the announcement does not say how to enable the checks it names: {out}"
-    assert "did not run" in joined, \
+    assert "DID NOT RUN" in joined, \
         f"the announcement does not say the checks DID NOT RUN: {out}"
-    assert "waiting" in joined and "open signals remain" in joined, (
-        "the announcement does not NAME the two rules that could not fire, so a reader cannot "
-        f"tell which coverage is missing: {out}")
+    missing = [n for n, _t in check_addressed.SCAN_ONLY_RULES if n not in joined]
+    assert not missing, (
+        "the announcement does not NAME every rule that could not fire, so a reader cannot "
+        f"tell which coverage is missing: {missing}")
 
 
 def test_the_scanless_ledger_matches_what_actually_goes_quiet():
@@ -188,6 +194,19 @@ def test_the_scanless_ledger_matches_what_actually_goes_quiet():
              if any(tail in f for f in _flags(quiet))}
     assert after == set(), \
         f"a ledger rule still fired on a record with no transcript evidence: {sorted(after)}"
+
+    # 🔴 THE *GROWS* DIRECTION, and it is the half that is easy to fake. Both sets above are
+    # derived FROM the ledger, so a fifth scan-dependent rule added to `disagreements` and
+    # not to the ledger would be invisible to them — a two-way claim that is really one-way.
+    # So: take the flags that ACTUALLY disappear between the two modes, and require every one
+    # of them to be a ledger entry. A new rule that goes quiet now fails here, naming itself.
+    quiet_flags = set(_flags(quiet))
+    disappeared = [f for f in _flags(scanned) if f not in quiet_flags]
+    unledgered = [f for f in disappeared
+                  if not any(tail in f for _n, tail in check_addressed.SCAN_ONLY_RULES)]
+    assert not unledgered, (
+        "a rule goes quiet without the transcript scan and is NOT in SCAN_ONLY_RULES, so the "
+        f"announcement does not name it and a reader is told the coverage ran: {unledgered}")
 
     named = " ".join(f for f in _flags(quiet) if f.startswith(check_addressed.SCANLESS_LEAD))
     for name, _tail in check_addressed.SCAN_ONLY_RULES:

--- a/scripts/check-clickup-addressed/tests/test_bounds_and_parsing.py
+++ b/scripts/check-clickup-addressed/tests/test_bounds_and_parsing.py
@@ -85,7 +85,50 @@ def _rec(tid="868gz0hhh", days=2, reply_days=None, status="to do", date_str=None
     return r
 
 
+def _armed(scanned=True):
+    """One record arming EVERY rule in `SCAN_ONLY_RULES` at once.
+
+    THREE records, not one, and the split is forced rather than stylistic: "open signals
+    remain" needs a DONE ClickUp status, while both "transcripts read as done" and the
+    waiting flag need an OPEN one, so no single record can arm all four. They are returned
+    together and fed to ONE `disagreements` call, which is what the ledger diff requires —
+    per-rule fixtures would let one silently stop arming without the set changing size.
+
+    ⚠️ The assertion that this fixture arms everything is IN the test, not here: a fixture
+    that quietly stopped arming a rule would otherwise make the whole guard vacuous, and it
+    already caught itself once (the waiting flag, missing on the first attempt).
+    """
+    their = NOW - timedelta(days=2)
+    nc = {"date": _fmt(their), "date_ms": _ms(their), "author": "Robin Example",
+          "snippet": "a question", "text": "a question", "my_latest_reply": None}
+    cited = [{"signal": "PR merged", "snippet": "shipped in #4242",
+              "pr_refs": [{"ref": "someorg/somerepo#4242", "state": "open"}]}]
+    done = {"task_id": "868gy0ddd", "status": "open", "clickup_status": "closed",
+            "clickup_priority": "high", "newest_comment": nc,
+            "completion": cited, "open": []}
+    still_open = {"task_id": "868gy0eee", "status": "likely_addressed",
+                  "clickup_status": "to do", "clickup_priority": "high",
+                  "newest_comment": nc, "completion": [], "open": []}
+    waiting = {"task_id": "868gy0fff", "status": "no_mentions_found",
+               "clickup_status": "to do", "clickup_priority": "high",
+               "newest_comment": nc, "completion": [], "open": []}
+    recs = (done, still_open, waiting)
+    if scanned:
+        done["mentions_found"] = 0
+        still_open["mentions_found"] = 3
+        waiting["mentions_found"] = 0
+    else:
+        # Exactly what the scan-less builder produces: no mention count, no verdict, and no
+        # evidence lists for the cited-PR loop to walk.
+        for r in recs:
+            r["status"] = "not_scanned"
+            r["completion"] = []
+    return recs
+
+
 def _flags(*recs):
+    if recs and isinstance(recs[0], tuple):
+        recs = recs[0]
     return check_addressed.disagreements(list(recs), now=NOW)
 
 
@@ -117,6 +160,87 @@ def test_a_scanless_run_ANNOUNCES_the_two_rules_it_could_not_run():
     assert "waiting" in joined and "open signals remain" in joined, (
         "the announcement does not NAME the two rules that could not fire, so a reader cannot "
         f"tell which coverage is missing: {out}")
+
+
+def test_the_scanless_ledger_matches_what_actually_goes_quiet():
+    """🔴 THE RELATIONSHIP GUARD, and the reason the first announcement was wrong.
+
+    It named TWO rules. FOUR go quiet in the scan-less default — the two gated on a SEARCHED
+    zero, plus "transcripts read as done" (whose `likely_addressed` status a scan-less record
+    can never hold) and the cited-PR loop (whose `completion`/`open` lists are empty). Naming
+    a SUBSET is worse than naming none: it implies the unnamed ones ran, which is the same
+    "an empty block reads as checked" defect the announcement exists to kill.
+
+    So this does not check the WORDS. It arms every rule on one record, runs `disagreements`
+    in both modes, and diffs. Whatever falls out of the scanned run must be exactly the
+    ledger — failing when a fifth transcript-dependent rule is ADDED and when one is REMOVED,
+    because a ledger asserted in one direction rots silently in the other.
+    """
+    scanned = _armed(scanned=True)
+    quiet = _armed(scanned=False)
+    before = {tail for _n, tail in check_addressed.SCAN_ONLY_RULES
+              if any(tail in f for f in _flags(scanned))}
+    assert before == {t for _n, t in check_addressed.SCAN_ONLY_RULES}, (
+        "the fixture did not arm every ledger rule, so this test cannot see one going quiet "
+        f"— it proves nothing until it does. Armed: {sorted(before)}")
+
+    after = {tail for _n, tail in check_addressed.SCAN_ONLY_RULES
+             if any(tail in f for f in _flags(quiet))}
+    assert after == set(), \
+        f"a ledger rule still fired on a record with no transcript evidence: {sorted(after)}"
+
+    named = " ".join(f for f in _flags(quiet) if f.startswith(check_addressed.SCANLESS_LEAD))
+    for name, _tail in check_addressed.SCAN_ONLY_RULES:
+        assert name in named, \
+            f"rule {name!r} goes quiet in the default run and the announcement does not name it"
+
+
+def test_the_announcement_never_contains_a_flags_own_tail():
+    """🔴 INSTRUMENT SAFETY, made unexpressible rather than remembered.
+
+    The announcement talks ABOUT these flags. If a rule's announcement NAME embedded that
+    rule's unique TAIL, then `"<tail>" in output` — the obvious check, and the one three
+    tests above use — would be TRUE in a run where the flag never fired. Upstream hit exactly
+    this and it cost a false failure; it could as easily have cost a false pass.
+    """
+    for name, tail in check_addressed.SCAN_ONLY_RULES:
+        assert tail not in name, (
+            f"the announcement name {name!r} contains its own flag tail {tail!r}, so every "
+            "substring check for that flag is now ambiguous")
+
+
+def test_the_run_level_announcement_is_not_counted_as_a_flag_about_ONE_ticket():
+    """🔴 The `[r]` scoping fix, re-entered from the other end of `disagreements`.
+
+    The note's closing sentence is computed by asking `disagreements([r])` what else names
+    THIS ticket. The scan-less announcement is a sentence about the RUN, appended to whatever
+    list the function is handed — so counted, it makes the note say "'Needs a decision' above
+    ALSO carries a line about this ticket" when the only line there is about the invocation.
+
+    ⚠️ REACHABILITY WAS MEASURED, not assumed, and the first reading was wrong. `main()`
+    cannot build this record (its scan-less path omits `mentions_found`, so the verdict can
+    never be ANSWERED) — which nearly got the guard deleted as unreachable. But a record that
+    is `not_scanned` AND carries a searched zero — a stale producer, a partial write, the
+    exact shape the announcement's own comment names — reaches ANSWERED and leaks the line.
+    """
+    their = NOW - timedelta(days=2)
+    mine = NOW - timedelta(hours=6)
+    r = {"task_id": "868gz0hhh", "status": "not_scanned", "mentions_found": 0,
+         "clickup_status": "to do", "clickup_priority": "high",
+         "completion": [], "open": [],
+         "newest_comment": {"date": _fmt(their), "date_ms": _ms(their),
+                            "author": "Robin Example", "snippet": "q", "text": "q",
+                            "my_latest_reply": _fmt(mine), "my_latest_reply_ms": _ms(mine)}}
+
+    # Positive control on the fixture: it must actually reach the note, or this proves nothing.
+    notes = _notes(r)
+    assert len(notes) == 1, f"the fixture never reached the suppression note: {notes}"
+    assert any(f.startswith(check_addressed.SCANLESS_LEAD) for f in _flags(r)), \
+        "the fixture does not produce the run-level announcement, so nothing could leak"
+
+    assert "no other flag names this ticket" in notes[0].lower(), (
+        "the run-level scan-less announcement was counted as a per-ticket flag, so the note "
+        f"claims another block names this ticket when none does: {notes[0]}")
 
 
 def test_the_announcement_is_ONE_line_per_run_not_one_per_ticket():
@@ -231,6 +355,141 @@ def test_main_announces_in_the_DEFAULT_mode_and_stops_once_the_scan_runs():
         f"a scanned run rendered as if it had skipped the scan:\n{scanned[-900:]}"
     assert "no completion verdict was formed" not in scanned and " addressed," in scanned, \
         f"a scanned run withheld its own summary tally:\n{scanned[-400:]}"
+
+
+def test_the_DEFAULT_run_still_carries_the_comment_derived_evidence():
+    """🔴 THE COVERAGE HOLE THAT LET THREE CALL-SITE MUTANTS LIVE.
+
+    Every other default-mode drive uses a NEUTRAL comment, so no comment- or status-derived
+    rule was exercised in default mode anywhere — and three one-token mutants on the
+    scan-less record's CONTENT (`newest_comment` -> `{}`, `meta` -> `{}`, `clickup_status`
+    -> `None`) survived a fully green suite. The first silently deletes the RESOLVED-comment-
+    on-an-open-ticket flag, which this skill's docs call the highest-value line in the report,
+    on what is now the DEFAULT path.
+
+    T4-T9 cover whether the scan-less BRANCH runs and what its count fields say. This covers
+    what the record actually CARRIES, end to end, on stdout — the ClickUp evidence is the
+    only evidence the default mode has, so a record that drops it has nothing left.
+    """
+    now = datetime.now(timezone.utc)
+    theirs = now - timedelta(days=1)
+    comments = [{"task_id": "868qw0e2e", "task_name": "t", "task_status": "to do",
+                 "task_priority": "urgent", "date": theirs.strftime(FMT),
+                 "author": "Robin Example",
+                 "snippet": "this is fixed and shipped, resolved on our side",
+                 "text": "this is fixed and shipped, resolved on our side",
+                 "date_ms": int(theirs.timestamp() * 1000), "my_latest_reply": None}]
+
+    def fake(name, *a):
+        if name == "recent-comments.py":
+            return json.dumps(comments), 0
+        raise AssertionError("a scan-less run must not call " + name)
+
+    o_run, o_argv, buf, o_out = check_addressed.run_script, sys.argv, io.StringIO(), sys.stdout
+    try:
+        check_addressed.run_script = fake
+        sys.argv = ["check-addressed.py"]
+        sys.stdout = buf
+        check_addressed.main()
+    finally:
+        sys.stdout = o_out
+        check_addressed.run_script, sys.argv = o_run, o_argv
+    out = buf.getvalue()
+
+    assert "reads as RESOLVED but the ticket is still" in out, (
+        "the DEFAULT run lost the resolved-comment-on-an-open-ticket flag — the scan-less "
+        f"record is not carrying its ClickUp evidence:\n{out[-900:]}")
+    assert "868qw0e2e" in out and "to do" in out, \
+        f"the scan-less record dropped the ticket's own status:\n{out[-900:]}"
+    assert "urgent" in out, f"the scan-less record dropped the priority:\n{out[-900:]}"
+    assert "resolved on our side" in out, \
+        f"the scan-less record dropped the newest comment itself:\n{out[-900:]}"
+
+
+def test_a_scanless_json_run_omits_UNSEARCHED_session_counts_and_declares_the_mode():
+    """The absent-vs-zero discipline applied to `mentions_found`' SIBLINGS.
+
+    `sessions_found: 0` / `sessions_by_task: {}` / `sessions_searched: 0` are unsearched
+    zeros — the exact claim this path refuses to make — and a consumer was left inferring the
+    mode from a spelled sentinel. `transcripts` is now stated outright.
+    """
+    comments = [{"task_id": "868qw0e2e", "task_name": "t", "task_status": "to do",
+                 "task_priority": "high", "date": "2026-08-21 09:00",
+                 "author": "Robin Example", "snippet": "q", "text": "q"}]
+
+    def fake(name, *a):
+        if name == "recent-comments.py":
+            return json.dumps(comments), 0
+        raise AssertionError(name)
+
+    def drive(*argv):
+        o_run, o_argv, buf, o_out = check_addressed.run_script, sys.argv, io.StringIO(), sys.stdout
+        try:
+            check_addressed.run_script = fake
+            sys.argv = ["check-addressed.py", "--json", *argv]
+            sys.stdout = buf
+            check_addressed.main()
+        finally:
+            sys.stdout = o_out
+            check_addressed.run_script, sys.argv = o_run, o_argv
+        return json.loads(buf.getvalue())
+
+    p = drive()
+    assert p["transcripts"] is False, \
+        "a --json consumer cannot tell the mode without parsing a spelled status sentinel"
+    assert "sessions_found" not in p and "sessions_by_task" not in p, (
+        "an UNSEARCHED zero was emitted as a session count — the claim this path exists to "
+        f"refuse: {{k: p[k] for k in ('sessions_found', 'sessions_by_task') if k in p}}")
+    assert "sessions_searched" not in p["task_status"][0], \
+        f"the record emitted an unsearched session count: {p['task_status'][0]}"
+    assert "mentions_found" not in p["task_status"][0], \
+        "the mention count regressed to a reported zero"
+
+
+def test_flags_that_only_feed_the_scan_WARN_when_the_scan_is_off():
+    """`parse_args`' own rule, applied one level up: a silently-ignored flag is a run that
+    looks like it honoured your request and did not. This file already shipped that bug once
+    with `--include-self-runs`, which was parsed by nothing and forwarded nowhere.
+    """
+    comments = [{"task_id": "868qw0e2e", "task_name": "t", "task_status": "to do",
+                 "task_priority": "high", "date": "2026-08-21 09:00",
+                 "author": "Robin Example", "snippet": "q", "text": "q"}]
+
+    def fake(name, *a):
+        if name == "recent-comments.py":
+            return json.dumps(comments), 0
+        if name == "search-sessions.py":
+            return json.dumps({"sessions": [], "self_runs_skipped": 0,
+                               "self_runs_skipped_ids": []}), 0
+        return json.dumps([{"task_id": "868qw0e2e", "status": "no_mentions_found",
+                            "sessions_searched": 1, "mentions_found": 0,
+                            "completion": [], "open": []}]), 0
+
+    def drive(argv):
+        o_run, o_argv, o_out, o_err = (check_addressed.run_script, sys.argv,
+                                       sys.stdout, sys.stderr)
+        err = io.StringIO()
+        try:
+            check_addressed.run_script = fake
+            sys.argv = ["check-addressed.py", *argv]
+            sys.stdout, sys.stderr = io.StringIO(), err
+            check_addressed.main()
+        finally:
+            sys.stdout, sys.stderr = o_out, o_err
+            check_addressed.run_script, sys.argv = o_run, o_argv
+        return err.getvalue()
+
+    warned = drive(["--since", "2026-08-01", "--include-self-runs"])
+    assert "WARNING" in warned and "--since" in warned and "--include-self-runs" in warned, \
+        f"inert flags were accepted in silence: {warned!r}"
+
+    # Anti-widening controls in BOTH directions — a warning that always fires is noise, and
+    # one that fires when the flags DO work is a lie about the run.
+    assert drive([]) == "", \
+        "a bare default run warned about flags nobody passed"
+    with_scan = drive(["--transcripts", "--since", "2026-08-01", "--include-self-runs"])
+    assert "WARNING" not in with_scan, \
+        f"the flags were honoured and the run still called them ignored: {with_scan!r}"
 
 
 # ------------------------------------------------ 2. the three unpinned invariants

--- a/scripts/check-clickup-addressed/tests/test_no_real_identifiers.py
+++ b/scripts/check-clickup-addressed/tests/test_no_real_identifiers.py
@@ -54,11 +54,16 @@ SEPARATED_ID_RE = re.compile(r"\b868[a-z0-9]{2}[-_][a-z0-9]{4}\b")
 #   868gx1ccc                          shares five with that group
 #   868gy0ddd / 868gy0eee / 868gy0fff              a second family
 #   868gz0hhh / 868gw0zzz / 868aaa111 / 868zzz111 / 868test01   isolated fixtures
+#   868qw0e2e                          the scan-less end-to-end drive in
+#                                      test_bounds_and_parsing.py; invented, and deliberately
+#                                      NOT sharing a prefix with any window fixture so it
+#                                      cannot perturb the prefix-matching tests
 ALLOWED_TASK_IDS = frozenset({
     "868gx0aaa", "868gx0bbb", "868gx0zzz", "868gx1ccc",
     "868gy0ddd", "868gy0eee", "868gy0fff",
     "868gz0hhh", "868gw0zzz",
     "868aaa111", "868zzz111", "868test01",
+    "868qw0e2e",
 })
 ALLOWED_SEPARATED_IDS = frozenset({"868gy-0ddd", "868gy_0ddd"})
 

--- a/scripts/check-clickup-addressed/tests/test_own_reply_answers.py
+++ b/scripts/check-clickup-addressed/tests/test_own_reply_answers.py
@@ -755,10 +755,11 @@ def test_main_actually_PRINTS_both_blocks_end_to_end():
     honest shape of an end-to-end test here, and 2 days ago is inside the 14-day bound on
     every day it can run.
 
-    ⚠️ NOT PORTED from the upstream copy: its second half drives `main()` with the transcript
-    scan OFF and asserts both blocks vanish. This tool has no such flag — `main()` always runs
-    search-sessions.py and check-completion.py — so that half would assert a state that cannot
-    occur here. If a `--transcripts` opt-in ever lands, restore it.
+    🔴 The second half drives `main()` with the scan OFF (the DEFAULT since the 2026-08-22
+    opt-in port) and asserts that both transcript-dependent verdicts go quiet while the
+    decision heading still appears, carrying the announcement that they could not run. It was
+    deliberately not ported when this repo had no `--transcripts` flag; that flag now exists,
+    which is the restore condition the omission named.
     """
     now = datetime.now(timezone.utc)
     fmt = lambda dt: dt.strftime("%Y-%m-%d %H:%M")
@@ -802,7 +803,7 @@ def test_main_actually_PRINTS_both_blocks_end_to_end():
             check_addressed.run_script, sys.argv = orig_run, orig_argv
         return buf.getvalue()
 
-    out = drive()
+    out = drive("--transcripts")
 
     assert check_addressed.DECISION_HEADING in out, \
         f"main() printed no decision block at all:\n{out[-1500:]}"
@@ -816,6 +817,28 @@ def test_main_actually_PRINTS_both_blocks_end_to_end():
     # ORDER on the real output, not just in `report_blocks`' return value.
     assert out.index(check_addressed.DECISION_HEADING) < out.index(check_addressed.ANSWERED_HEADING), \
         "the no-action block was printed before the act-on-this block"
+
+    # 🔴 THE SAME SEAM IN THE DEFAULT MODE, restored now that `--transcripts` exists. The
+    # scan-less record omits `mentions_found`, so both transcript-dependent verdicts must go
+    # quiet — and the suppression note inherits that gate for free, which is a claim about the
+    # two changes TOGETHER and so is asserted here rather than assumed from either side.
+    scanless = drive()
+    # ⚠️ Match the FLAG's own unique tail, never the rule's NAME: the scan-less announcement
+    # NAMES both rules it could not run, so `"open signals remain" in out` is TRUE in a run
+    # where the flag never fired. An instrument that matches the announcement instead of the
+    # thing announced reports a false positive, and upstream's did.
+    assert "is WAITING" not in scanless and "verify before trusting the close" not in scanless, (
+        "a run that never scanned transcripts still emitted a transcript-dependent flag — an "
+        f"unsearched zero was read as a searched one:\n{scanless[-800:]}")
+    # The heading IS printed, carrying the announcement that those two rules could not run.
+    # An absent heading was the defect — it read as "checked, nothing disagrees" when it
+    # meant "two rules never ran".
+    assert check_addressed.DECISION_HEADING in scanless and "DID NOT RUN" in scanless, (
+        "the scan-less run left no trace of the two checks it could not perform:"
+        f"\n{scanless[-800:]}")
+    assert check_addressed.ANSWERED_HEADING not in scanless, (
+        "a run that never scanned transcripts emitted suppression notes, which would be "
+        f"reporting on a waiting check that never ran:\n{scanless[-800:]}")
 
 
 def test_report_blocks_passes_its_now_through_to_BOTH_producers():
@@ -951,3 +974,39 @@ def test_a_raw_ms_without_its_formatted_date_does_not_decide_the_question():
     assert flags and "not reported" in " ".join(flags).lower(), (
         "a record whose reply was never reported did not reach the announce branch once a "
         f"stray ms was present: {flags}")
+
+
+# ------------------------------------------- transcripts opt-in (2026-08-22, round 7)
+
+def test_a_scanless_run_does_not_flag_every_open_ticket_as_abandoned():
+    """🔴 The failure mode that makes `--transcripts` opt-in dangerous if done carelessly.
+
+    The waiting flag fires on `mentions_found == 0`. When the transcript scan does not run,
+    every task trivially has zero mentions — so emitting `mentions_found: 0` would fire
+    "nobody is on it and someone is waiting" on EVERY open ticket with a recent comment,
+    turning the one high-signal block in the report into pure noise. The scan-less record
+    therefore OMITS the key: absent means "not gathered", 0 means "searched and found none".
+    Same absent-vs-null discipline as `my_latest_reply`, and the third time this distinction
+    has been load-bearing in this file.
+    """
+    r = _rec(comment_days_ago=1)          # open ticket, recent colleague comment, no reply
+    r.pop("mentions_found", None)         # exactly what the scan-less path builds
+    r["status"] = "not_scanned"
+    assert _waiting_flags(r) == [], (
+        "a run that never scanned transcripts claimed no work exists anywhere — the flag "
+        f"must require a SEARCHED zero, not an unsearched one: {_waiting_flags(r)}")
+
+    # Positive control: the same record WITH a searched zero must still flag, or the
+    # assertion above would pass for the wrong reason (a flag that never fires at all).
+    r["mentions_found"] = 0
+    r["status"] = "no_mentions_found"
+    assert _waiting_flags(r), \
+        "the waiting flag stopped firing on a genuinely searched zero — control failed"
+
+
+def test_transcripts_flag_parses_both_ways():
+    """The flag has to be readable in both directions or the default cannot be overridden."""
+    assert check_addressed.parse_args([])["transcripts"] is False, \
+        "transcript scanning is opt-in; the default must be off"
+    assert check_addressed.parse_args(["--transcripts"])["transcripts"] is True
+    assert check_addressed.parse_args(["--transcripts", "--no-transcripts"])["transcripts"] is False

--- a/scripts/check-clickup-addressed/tests/test_ported_hardening.py
+++ b/scripts/check-clickup-addressed/tests/test_ported_hardening.py
@@ -272,7 +272,7 @@ def test_main_forwards_skips_and_reports_the_count():
 
     real_run, real_argv = check_addressed.run_script, sys.argv
     check_addressed.run_script = fake_run_script
-    sys.argv = ["check-addressed.py", "--limit", "1", "--no-resolve-prs"]
+    sys.argv = ["check-addressed.py", "--transcripts", "--limit", "1", "--no-resolve-prs"]
     out = io.StringIO()
     try:
         with contextlib.redirect_stdout(out):

--- a/scripts/check-clickup-addressed/tests/test_repo_vocab_and_waiting.py
+++ b/scripts/check-clickup-addressed/tests/test_repo_vocab_and_waiting.py
@@ -86,16 +86,23 @@ def _state(snippet, ref_num):
 
 # --------------------------------------------------------------------------- D9
 
-def test_a_named_but_unknown_repo_is_not_reported_as_unnamed():
-    """The false message. `devrc` IS named; it is merely absent from KNOWN_REPOS.
+def test_an_unknown_token_is_not_asserted_to_be_a_repo():
+    """The false message. `notarepo-xyz` IS on the '#'; it is merely absent from KNOWN_REPOS.
 
-    At base both refs in this live snippet came back "unresolved (repo not named)".
+    At base both refs in this snippet came back "unresolved (repo not named)".
     """
     ref, state = _state("| **#4181**, **notarepo-xyz #591** | merged |", "591")
-    assert "not named" not in state, \
-        f"a NAMED repo was reported as unnamed — the message is false: {state!r}"
-    assert "notarepo-xyz" in state, \
-        f"the unknown repo must be named so the reader can add it: {state!r}"
+    # 🔴 ROUND 7 REVERSES ROUND 5's REMEDY, on measurement. Round 5 made this case say
+    # `repo 'notarepo-xyz' is not in KNOWN_REPOS`. On a live run upstream, 2 of 3 cited PRs
+    # rendered that way with the captured token being an ENGLISH WORD ('their', 'which')
+    # while the comment plainly named a repo — so the "precise" message was wrong more often
+    # than the vague one it replaced. `word` is simply whatever precedes the '#', and nothing
+    # short of enumerating the world tells `devrc` from `landed`. The message must therefore
+    # NOT assert that a repo was named.
+    assert "notarepo-xyz" not in state, \
+        f"the captured token is asserted to be a repo — the false premise: {state!r}"
+    assert "KNOWN_REPOS" in state, \
+        f"the affordance was dropped entirely; keep it as a CONDITIONAL: {state!r}"
 
 
 def test_the_unknown_repo_message_says_what_to_do():
@@ -145,16 +152,19 @@ def test_the_hub_repos_are_all_present_and_correctly_owned():
          f"  expected: {expected}")
 
 
-def test_a_genuinely_unnamed_ref_still_says_not_named():
-    """INVARIANT GUARD — passes at base. The refusal to guess is deliberate and stays.
+def test_an_unnamed_ref_renders_the_same_could_not_determine_message():
+    """INVARIANT GUARD — the refusal to guess is deliberate and stays.
 
-    `#4181` in the live snippet has no repo word before it and no known repo within
-    REPO_LOOKBEHIND. "repo not named" is the CORRECT message there, and the D9 fix must
-    not relabel it as an unknown-repo problem.
+    `#4181` in the snippet has no repo word before it and no known repo within
+    REPO_LOOKBEHIND.
     """
     _, state = _state(LIVE_SNIPPET, "4181")
-    assert state == "unresolved (repo not named)", \
-        f"the honest not-named case was relabelled: {state!r}"
+    # Round 7: this and the unknown-token case now render IDENTICALLY, deliberately — the
+    # tool cannot tell them apart on real input, so claiming to is the defect. What must
+    # survive is the refusal to GUESS a repo.
+    assert state == ("unresolved (could not determine the repo; if one is named here, add it "
+                     "to KNOWN_REPOS in check-completion.py)"), \
+        f"the honest could-not-determine case was relabelled: {state!r}"
 
 
 def test_an_unknown_repo_is_still_never_guessed():
@@ -276,7 +286,12 @@ def _run_main(argv, completion=None, open_items=None, status="partially_addresse
 
     orig_run, orig_argv, orig_stdout = check_addressed.run_script, sys.argv, sys.stdout
     check_addressed.run_script = fake
-    sys.argv = ["check-addressed.py", *argv]
+    # `--transcripts` FIRST and unconditionally: every caller of this helper is asserting on
+    # a transcript-derived verdict, and the scan is opt-in since the 2026-08-22 port. Without
+    # it `main()` never calls `check-completion.py` at all and `status`/`mentions` below are
+    # simply not in the record — the tests would pass or fail for reasons unrelated to what
+    # they assert.
+    sys.argv = ["check-addressed.py", "--transcripts", *argv]
     sys.stdout = io.StringIO()
     try:
         check_addressed.main()

--- a/scripts/check-clickup-addressed/tests/test_status_and_tiers.py
+++ b/scripts/check-clickup-addressed/tests/test_status_and_tiers.py
@@ -212,7 +212,7 @@ def test_include_self_runs_is_forwarded_to_both_subscripts():
 
     orig_run, orig_argv, orig_stdout = check_addressed.run_script, sys.argv, sys.stdout
     check_addressed.run_script = fake
-    sys.argv = ["check-addressed.py", "--include-self-runs", "--no-resolve-prs"]
+    sys.argv = ["check-addressed.py", "--transcripts", "--include-self-runs", "--no-resolve-prs"]
     sys.stdout = io.StringIO()
     try:
         check_addressed.main()
@@ -244,7 +244,7 @@ def test_self_run_guard_is_on_by_default():
 
     orig_run, orig_argv, orig_stdout = check_addressed.run_script, sys.argv, sys.stdout
     check_addressed.run_script = fake
-    sys.argv = ["check-addressed.py", "--no-resolve-prs"]
+    sys.argv = ["check-addressed.py", "--transcripts", "--no-resolve-prs"]
     sys.stdout = io.StringIO()
     try:
         check_addressed.main()


### PR DESCRIPTION
Closes the last of the delta between devrc's copy of `check-clickup-addressed` and the
retired copy in the client repo. **After this, that copy can be deleted with nothing
stranded.** Three commits: the port, an audit-fix round, then a self-audit of that fix.

## 🔴 The delta list was wrong by one — and it warned that it would be

Re-derived rather than trusted, as its own source doc says to:

```
git log --oneline 1c4418011..origin/trunk -- .claude/skills/check-clickup-addressed/
05fe90cc7  (#1246)  ported in #739
05b1e4f4a  (#1249)  "already present in devrc"  ← NOT TRUE
ed1c004e7  (#1247)  the transcript opt-in
```

`check-completion.py:_unresolved_state` still carried round 5's `unresolved (repo 'X' is not
in KNOWN_REPOS — …)` **verbatim**. #1249 was unported and would have been stranded. It is here.

## What landed

**1. `--transcripts` (upstream #1247).** Scored upstream over three tickets: ClickUp status
3/3 useful, newest comment 3/3 and decisive every time, transcript scan **0/3** with one
actively misleading, cited-PR resolution **0/3** with 2/3 false explanations. ~60s of the ~90s
runtime, and the origin of every false verdict this tool has shipped. Not deleted —
`--transcripts` runs it unchanged. The scan-less record **omits** `mentions_found` rather than
reporting `0`; emitting `0` would fire *"nobody is on it and someone is waiting"* on every
open ticket.

**2. The three deferrals #739 recorded** (upstream #1253), on the restore condition they named.

**3. Upstream #1249** — `unknown` and `not_named` now render identically, as a conditional
that keeps the affordance without the false premise.

**4. Upstream's tried-and-reverted NEGATIVE RESULT** (`ed1c004e7`), which had zero hits
anywhere in devrc and was one deletion away from being lost: the self-run guard rewrite that
recovered transcripts 3→8 / 2→9 / 0→8 **and made every verdict worse**, and the conclusion
that the ~81% it discards is overwhelmingly noise. Client ticket ids and stack omitted — this
repo is public, and the measurement is what carries.

## The audit round (second commit)

Four blockers, all real at `b99baa47`, all verified against the diff before acting:

**🔴1 — the announcement named TWO rules; FOUR go quiet.** Besides the two named,
`elif r["status"] == "likely_addressed"` (a scan-less status is always `not_scanned`) and the
cited-PR loop (reads `completion`/`open`, both `[]`) are equally dead. **Naming a subset is
worse than naming none** — it implies the rest ran, the same defect one axis over, arriving
inside the fix for it. The list is now BUILT from a ledger (`SCAN_ONLY_RULES`) and pinned by a
test that arms every rule, diffs both modes, and fails when the set **grows or shrinks**. A
second test forbids a rule's announcement NAME from containing its own flag TAIL, so
`"<tail>" in output` can never be true in a run where the flag did not fire — the
instrument-matches-its-own-announcement trap, made unexpressible. `SKILL.md`'s dropped source
3 restored.

**🔴2 — three call-site mutants on the record's CONTENT survived a 220-green suite.** Fixed
above the symptom: the scan-less builder was a **second independent writer** of a record whose
other writer sat 50 lines away, with nothing pinning that they agreed. `attach_clickup_meta()`
makes them one, so the divergence is no longer expressible. Coverage hole closed too — every
default-mode drive used a NEUTRAL comment, so no comment- or status-derived rule was exercised
in default mode anywhere.

**🔴3 — the port ledger stated the opposite of the tree.** `reference/validation-history.md`
still asserted, as a measurement, that no `--transcripts` flag exists and no record can carry
`not_scanned`. It is the file someone reads to justify deleting the upstream copy, so the old
text is struck through and kept, with the reversal recorded.

**🔴4 — see "What landed" above.**

🟡 also: the four flags that are inert in default mode now **warn on stderr** (`parse_args`'
own rule — this file shipped that bug once already); `--json` declares `"transcripts": false`
and **omits** `sessions_found` / `sessions_by_task` / `sessions_searched`, which were
unsearched zeros dressed as counts; the run-level announcement no longer counts as a
per-ticket flag in `suppressed_notes`; `not_scanned` documented in the status table; module
docstring corrected.

🔴 **On that last one, reachability was MEASURED, and the first reading was wrong.** `main()`
cannot build the leaking record, which nearly got the guard deleted as unreachable — but a
`not_scanned` record carrying a searched zero (a stale producer, a partial write) *does* reach
ANSWERED and leak the line. Probed before deciding; the guard stays and `Z5` kills it.

## Verification — full battery, both rounds

| tree | result |
|---|---|
| base, its own tests | **213 passed, 0 failed** |
| base scripts + HEAD tests | **205 passed, 21 failed** |
| HEAD | **226 passed, 0 failed** |

Of the 21: **13 behavioural**, 2 ABSENCE reds (`SCAN_ONLY_RULES` does not exist at base — the
code missing, not wrong), 6 `SystemExit(2)` harness reds from tests whose argv gained
`--transcripts`. **Only the 13 are regression coverage**; the other 8 are not counted.

### Mutation sweep — `82 mutant(s); non-KILLED: 0`, `NULL-CTL SURVIVED`

| id | mutation | killed by |
|---|---|---|
| N1 | delete the scan-less announcement | `test_a_scanless_run_ANNOUNCES_the_rules_it_could_not_run` |
| N2 | announce from a RECORD-level absence | `test_no_flag_when_ticket_and_comment_agree` |
| N3 | announce once per TICKET | `test_the_announcement_is_ONE_line_per_run_not_one_per_ticket` |
| N4 | open-signals flag stops needing a SEARCHED zero | `test_the_open_signals_flag_needs_a_SEARCHED_zero_not_a_status_WORD` |
| N5 | rename the `not_scanned` sentinel | `test_main_announces_in_the_DEFAULT_mode_and_stops_once_the_scan_runs` |
| T1 | scan on by default again | `test_main_announces_in_the_DEFAULT_mode_and_stops_once_the_scan_runs` |
| T2 | `--transcripts` parses to a no-op | `test_main_announces_in_the_DEFAULT_mode_and_stops_once_the_scan_runs` |
| T3 | `--no-transcripts` turns the scan ON | `test_transcripts_flag_parses_both_ways` |
| T4 | **call site**: `main()` ignores the parsed flag | `test_main_announces_in_the_DEFAULT_mode_and_stops_once_the_scan_runs` |
| T5 | **call site**: `main()` always scans | `test_main_announces_in_the_DEFAULT_mode_and_stops_once_the_scan_runs` |
| T6 | record emits an UNSEARCHED zero as searched | `test_a_scanless_json_run_omits_UNSEARCHED_session_counts_and_declares_the_mode` |
| T7 | evidence legend heads a report with no evidence | `test_main_announces_in_the_DEFAULT_mode_and_stops_once_the_scan_runs` |
| T8 | tally of verdicts nobody computed | `test_main_announces_in_the_DEFAULT_mode_and_stops_once_the_scan_runs` |
| T9 | scan-less record prints a mention count | `test_the_DEFAULT_run_still_carries_the_comment_derived_evidence` |
| **Z1** | record carries no newest comment — the RESOLVED-on-open flag silently vanishes | `test_the_DEFAULT_run_still_carries_the_comment_derived_evidence` |
| **Z2** | record carries no ClickUp status | `test_the_DEFAULT_run_still_carries_the_comment_derived_evidence` |
| **Z3** | **call site**: scan-less builder handed an empty meta | `test_the_DEFAULT_run_still_carries_the_comment_derived_evidence` |
| **Z4** | the announcement names a SUBSET again | `test_the_scanless_ledger_matches_what_actually_goes_quiet` |
| **Z5** | run-level announcement counted as a per-TICKET flag | `test_the_run_level_announcement_is_not_counted_as_a_flag_about_ONE_ticket` |
| **Z6** | drop a rule from the LEDGER — it goes quiet and nothing announces it | `test_the_scanless_ledger_matches_what_actually_goes_quiet` |
| U1 | reinstate the false premise (quote the token as a repo) | `test_an_unknown_token_is_not_asserted_to_be_a_repo` |
| U2 | drop the affordance | `test_the_unknown_repo_message_says_what_to_do` |
| U3 | collapse the one TRUE diagnosis (`ambiguous`) | `test_ambiguous_repos_are_named_rather_than_called_unnamed` |
| M49 | always claim the report is silent about the ticket | `test_the_other_coverage_sentence_is_scoped_to_ITS_OWN_ticket` |
| M-SCOPE | the other-coverage sentence loses its scoping | `test_the_other_coverage_sentence_is_scoped_to_ITS_OWN_ticket` |
| PC | positive control | `test_an_unreported_reply_field_announces_instead_of_deciding` |
| NULL | **no mutation — SURVIVED**, as it must | — |

🔴 **`--check` caught something first, and it was mine.** The `suppressed_notes` edit moved
the line `M49` and `M-SCOPE` anchor on; both went `NOT APPLIED` and `--check` exited 1 naming
them. **`M-SCOPE` is the mutant a blind re-audit once found surviving a fully green sweep.** A
`NOT APPLIED` row reads exactly like a pass in an 81-row list — only the exit code separates
them. Both re-anchored and re-verified KILLED by their intended guards.

### The rendered report, default mode

```
## Task Completion Status

Transcripts were NOT scanned (`--transcripts` to enable). Everything below comes from ClickUp:
the ticket's own status and its newest comment. That is not a claim that no work exists — it is
the absence of a claim.

— **868qw0e2e** — transcripts not scanned
     ClickUp says: **to do** / prio high
     newest comment [2026-08-21 06:55] @Robin Example: any update on this?

## Summary: 1 ticket(s) read from ClickUp; transcripts not scanned, so no completion verdict
was formed for any of them.

## Needs a decision

⚠️  transcripts were NOT scanned (this is the default; pass `--transcripts` to enable), so 4
checks in this block DID NOT RUN for any ticket: 'nobody is on it and someone is waiting';
'ClickUp `<done>` but open signals remain'; 'the transcripts read as done while ClickUp is
still open'; 'a PR the transcripts cited is still open'. Each needs evidence this run never
gathered — a SEARCHED zero, a completion verdict, or the cited-PR resolution — and an
unsearched zero is not the same fact as a searched one, so their silence here is not evidence
of anything.
```

Under `--transcripts` the announcement is gone, the marker legend and the `0 addressed, 0
partial, 1 open, 0 unclear` tally are back, and the WAITING flag fires. `--json` in default
mode: valid, still carries `report_header: ## Task Completion Status` (so `_selfrun.py` still
recognises a run), `transcripts: false`, and no `mentions_found` / `sessions_searched` /
`sessions_found`.

### Hygiene and gates

- Nothing copied blind. Every fixture value synthesised; the one new task id is registered in
  `tests/test_no_real_identifiers.py`; the multi-record fixture uses spelled-out ids because a
  computed id is invisible to that gate's literal scan. **Positive control re-run after adding
  fixtures** — a planted real-shaped id and real-looking author are both named by file.
- `_selfrun.py` markers: the report header is unchanged and printed in BOTH modes. Re-ran all
  19 marker/self-run/header tests by name — green.
- **Hermetic tier**: `GATE: RESULT=PASS exit=0`; target `collected=226 passed=226 floor=203`.
- **Sandbox-inclusive tier**: `GATE: RESULT=PASS exit=0`; same target 226/226;
  `TOTAL collected=15204 passed=15202 skipped=2 failed=0`. ⚠️ This tier FAILED on the
  previous run of this branch with a GUARD 10 report that `devrc/.git/config` changed
  mid-run; it passes now with no change to that area, confirming concurrent-writer noise
  rather than this branch.
- **`TARGET_FLOORS` unchanged** — the gate printed no floor-drift line, and the rule is to copy
  the number it prints rather than compute one.

## The self-audit round (third commit)

Two findings from checking my own claims, not from anything failing:

- **the ledger guard was ONE-way while described as two-way.** Both its sets were computed
  FROM `SCAN_ONLY_RULES`, so a fifth scan-dependent rule added to the code and not the ledger
  was invisible. It now also diffs the flags that *actually* disappear between modes and
  requires each to be a ledger entry. Shown red by `Z6`, and shown to fail on **that**
  assertion rather than an earlier one.
- **`test_a_scanless_run_ANNOUNCES_the_two_rules_it_could_not_run`** — the name said TWO and
  the body asserted two hardcoded substrings while FOUR rules go quiet: the same false-coverage
  claim the previous commit fixed in the announcement, left sitting in the test that checks it.
  Renamed, body reads the ledger. Measured consequence: `Z4` is now killed by this test as well
  as by the ledger guard, where before only the ledger guard caught it.

## ⚠️ What this did NOT verify

**No live ClickUp run.** Both rendered outputs come from driving `main()` with its subprocess
seam stubbed — which is what makes the seam visible at all, since reading the code says the
flags are present and correct, and they are. They simply cannot fire.

## 🔴 Unrelated finding

`core.hooksPath` was unset everywhere at 01:00 and, with no action from here, was set
**repo-locally** to `<repo>/githooks` by 01:22 — the third observation of the volatility
`CLAUDE.md` documents, correlating in time with a GUARD 10 report that
`/home/zach/workspace/devrc/.git/config` changed mid-run. `install.sh` sets the key
`--global`, so something else writes the `--local` one. Pushes used `--no-verify` (the gate
having been run by hand) with the #322 post-check: sha, tree and status unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
