### PR TITLE
docs(handoff): the *rm*-r* narrowing — two rules, not one character, and a pre-push gate that cannot pass

### DIFF
--- a/claudedocs/handoff-opencode-rm-glob-narrowing.md
+++ b/claudedocs/handoff-opencode-rm-glob-narrowing.md
@@ -1,0 +1,186 @@
+# Handoff: opencode-rm-glob-narrowing — 2026-08-23
+
+## Run this first — the index, one read-only command
+
+```bash
+python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py --repo devrc
+```
+
+Terse pointers this doc does not carry, curated by past sessions and outliving it.
+🔴 RECALL, NOT LIVE OBSERVATION — every line is a pointer to VERIFY, never a current
+reading, and it may describe a gotcha already fixed. `scope-absent`/`scope-empty` means
+nothing is recorded yet: ordinary, not an error, and not a clean bill of health.
+Non-blocking: if it exits non-zero, print the stderr line and carry on.
+
+> **No `clawgate-task:` field on purpose.** `clawgate_handoff.sh resolve` exited **5**
+> (nothing resolved). An unknown session id answers `200` with an empty array, so that
+> result cannot distinguish "this session touched no task" from "the id is wrong". Per
+> the skill: no field written, and no task created to fill it.
+
+## Goal
+
+Close the `"*rm*-r*"` opencode permission glob — the same one-character defect #695 fixed
+for `age`, and which #695's own commit message flagged as *"STILL OPEN, same defect class,
+deliberately not fixed here"*.
+
+## State now
+
+- **Branch / PR:** `zach/opencode-rm-glob-narrow` → **[PR #744](https://github.com/innovation-upstream/devrc/pull/744)**,
+  `OPEN / MERGEABLE / CLEAN`, based on `main` @ `99b2636f`. Three commits:
+
+  | sha | what |
+  |---|---|
+  | `a08ac952` | the narrowing: `"*rm*-r*"` → `"*rm -r*"` + `"*rm --recursive*"` |
+  | `20988f91` | audit round — disclosure fixes, target-first class pinned |
+  | `360b54cf` | delta round — two sentences the audit round itself falsified |
+
+- **CI: GREEN on the head `360b54cf`** — `tekton/devrc-pytests` 15,199 passed / 0 failed
+  (floor 13,732), `tekton/devrc-nodetests` 1,149 pass / 0 fail (floor 1,126).
+- **Two adversarial audits ran**, the second re-auditing the first's fixes. Verdict:
+  **safe to merge, no 🔴**. A public correction comment is on the PR
+  ([#issuecomment-5384694287](https://github.com/innovation-upstream/devrc/pull/744#issuecomment-5384694287)) —
+  the original PR body understated the change's cost and was corrected in a comment rather
+  than silently edited.
+- **NOT merged, NOT live.** `main` requires an approving review. And merging alone changes
+  nothing in the running engine — see "How to verify".
+- Worktrees still on disk: `/tmp/wt-devrc-rmglob` (the PR branch, keep until merge) and
+  `/tmp/wt-devrc-handoff` (this doc).
+
+### What the change actually is
+
+`"*rm*-r*"` had a `*` **between** "rm" and "-r", matching any command text containing "rm"
+followed *later* by "-r". "rm" is a substring of fo**rm**at, terrafo**rm**, fi**rm**ware,
+confi**rm**, platfo**rm**; "-r" covers `--reverse`, `--refresh`, `--reporter`, `--repo`,
+`--replace`, `--recursive`. `opencode run` **auto-rejects** an ask, so a match killed the
+run mid-task rather than costing a prompt.
+
+🔴 **It is not the one-character fix the queueing handoff described.** `"rm --recursive"`
+does not contain the literal `"rm -r"`, so dropping the inner `*` alone would have released
+`rm --recursive <path>` — measured, plain `allow` at both layers. Hence **two** rules, each
+pinned individually in `MUST_ASK`, each proven sole-decider for its own row.
+
+## Open investigations — live diagnosis state
+
+### 🔴 The devrc pre-push gate CANNOT pass a push — confirmed, reproducible, unfixed
+
+- **Symptom + exact repro:** any `git push` from a devrc checkout with `core.hooksPath`
+  set runs the full suite (~20 min), the suite **passes**, and then the push dies with
+  `PUSH_RC=141` (SIGPIPE). Nothing lands. Repro: `git -C <devrc-worktree> push origin HEAD:<branch>`
+  and read the tail of the output.
+- **Observed (with values):** two independent attempts, identical signature.
+  Both logged `RESULT: PASS (exit=0)` with `TOTAL collected=15201 passed=15199 skipped=2
+  failed=0`, then `pre-push: ✅ devrc test suite passed.`, then `PUSH_RC=141`, with the
+  remote ref unmoved. **The cause is named in the log at line 21**, moments after the hook
+  starts:
+
+  ```
+  Connection to github.com closed by remote host.
+  ```
+
+- **Ruled out:** an undrained hook stdin — `githooks/pre-push:41` does
+  `STDIN_DATA="$(cat || true)"`, so git's ref lines are consumed. Also ruled out that it is
+  a test failure: the gate reports PASS both times, and CI independently passes the same tree.
+- **Leading hypothesis — now effectively confirmed by that log line:** git opens the SSH
+  transport to the remote *before* invoking `pre-push`; the hook then runs for ~20 minutes;
+  GitHub closes the idle connection; git finally writes the pack to a dead socket → SIGPIPE.
+- **Consequence, which is the point:** the gate does not block bad pushes, it blocks **all**
+  pushes, so the only workflow that works is `DEVRC_SKIP_TESTS=1`. That is the
+  "permanently-red gate trains everyone to click through" failure mode. It plausibly explains
+  why global `core.hooksPath` was **unset** when first measured this session (someone had
+  already given up on it) and repo-local was set partway through by another session.
+- **Next probe:** confirm the timeout attribution and pick a fix shape:
+
+  ```bash
+  GIT_TRACE=1 GIT_TRACE_PACKET=1 git -C /tmp/wt-devrc-rmglob push origin HEAD:refs/heads/tmp-probe 2>&1 | tail -40
+  ```
+
+  Fix shapes: move the suite **out** of the hook (run it before `git push`, gate on a
+  recorded PASS), or make the hook fast (changed-files-scoped subset), or have the hook
+  re-establish the connection. `githooks/tests-on-push.sh` already supports
+  `TESTS_ON_PUSH=shadow`.
+
+### 🟡 `guard_core` does not protect `$HOME` subpaths from a recursive delete
+
+- **Symptom + exact repro:** an unattended opencode agent can recursively delete a home or
+  system subdirectory with no friction at either layer.
+- **Observed (with values):** `layered_verdict` on the PR head — `rm -f -r ~/.ssh`,
+  `rm -f -r /etc/nixos`, `rm -f -r $HOME/workspace`, `rm --force --recursive /var/lib/postgresql`
+  all **allow**. 🔴 **And on `main`, BEFORE this PR:** `rm -fr ~/.ssh`, `rm -Rf ~/.ssh`,
+  `rm -R ~/.ssh` are **already allow**. `guard_core.py:988-1003` — fatal-target set is
+  exactly `/`, `~`/`$HOME`, `.`/`..` and 17 top-level dirs, so a **subpath** never reaches it.
+- **Ruled out:** that this PR opened the hole. It **widens** an already-open one (adding the
+  flag-before-`-r` and flags-after-operand classes). Both halves are written into the config
+  header and the characterization test, because either alone misleads.
+- **Leading hypothesis:** the glob layer is documented as *friction*, not control
+  (`opencode.jsonc` header), so the correct home for this is the argv-aware parser.
+  `check_rm_rf_critical` already parses flags structurally at `guard_core.py:1024-1028`;
+  what is narrow is the **target set**.
+- **Next probe:** before widening, measure how often it would fire on legitimate work —
+  that is the reason the PR deferred it, and its own docstring records it as an operator
+  decision. Count recursive `rm` invocations under `$HOME` in real session transcripts, then
+  extend `_RM_FATAL_DIRS` to `$HOME/**` and re-run `test_guard_core.py` (1,449 tests).
+
+## Next steps (ranked)
+
+1. **Review and merge PR #744.** Needs one approving review; I am the author. Note
+   `27fa67f9` — a merge is now blocked by `tekton/devrc-nodetests`, which is green here.
+2. **`home-manager switch`, then verify against the real engine.** Until then the change is
+   inert. See "How to verify".
+3. **`git -C $DEVRC worktree remove --force /tmp/wt-devrc-rmglob`** once merged.
+4. **Fix the pre-push gate** (investigation 1). It is currently unpassable, and every push
+   from this repo requires the bypass flag.
+5. **`guard_core` `$HOME`-subpath widening** (investigation 2), as its own PR with its own
+   measurement.
+
+## Gotchas / decisions / dead-ends
+
+- 🔴 **`DEVRC_SKIP_TESTS=1` was used for both pushes on this branch.** Justified — the gate
+  had just passed on the byte-identical tree each time, and CI passed independently — but it
+  **is** a bypass and should not be read as "the gate was satisfied". See investigation 1.
+- 🔴 **The GUARD 10 red was a stale runner, not contamination.** A full-suite run on the
+  pre-rebase tree reported `TOTAL … failed=0` with `RESULT: FAIL (exit=1)` from GUARD 10
+  naming `devrc/.git/config`. I spent a while attributing it to concurrent sessions. The real
+  answer: the branch was **5 commits behind `main`**, and `99b2636f` (#730) fixes exactly
+  that guard. **Check whether the base moved before diagnosing a guard failure.**
+- **`wildcard_match(text, pattern)` takes TEXT FIRST.** Reversing the arguments returns an
+  all-`False` table — a reassuring zero that looks like "nothing matches".
+- 🔴 **`pgrep -f '<pattern>'` in a wait loop matches the loop's own command line.** A
+  `until ! pgrep -f 'run-tests.sh --set all /tmp/wt-devrc-rmglob'` spun forever and a Monitor
+  armed on the same pattern timed out instead of firing. Both instruments were broken the
+  same way; the only real signal came from reading the log.
+- **A trailing `echo "EXIT=$?"` makes the harness report exit 0** regardless. The runner's
+  own `RESULT:`/`PUSH_RC=` line is the authority.
+- **Decision — land with disclosure, defer the structural fix.** Options weighed:
+  (a) land + fix disclosure ✅ chosen; (b) add `*rm -f -r*`-style rules — rejected, unbounded
+  *and* blind to the flags-after-operand class (there is no `rm -` prefix to match);
+  (c) widen `guard_core` — right fix, needs its own measurement; (d) drop the PR — rejected,
+  the false-positive class is real.
+- **Not accepted from the delta re-audit:** it reported the infix control fails **6** tests
+  naming two ledger tests. Measured on this tree it fails exactly **5** (3 `MUST_ALLOW` rows,
+  the ask-count pin, the characterization test) and neither ledger test is among them.
+  Recorded in `360b54cf` rather than deferred to.
+- **Both audits caught real defects in my own prose**, which is the class this PR is about:
+  the audit round falsified a sentence two lines from one it had just corrected
+  ("closes three of these rows" → six), and its replacement characterisation was wrong in
+  both directions (missed that `"*rm --recursive*"` carries its own surviving false-positive
+  class — `pnpm --filter form --recursive build` is still `ask`).
+
+## How to verify
+
+```bash
+# 1. the two rules are on the PR head, and the infix form is gone
+git -C /home/zach/workspace/devrc show 360b54cf:scripts/opencode/opencode.jsonc | grep -n '"\*rm'
+
+# 2. the fast, deterministic gate (both targets)
+cd /tmp/wt-devrc-rmglob && PYTHONDONTWRITEBYTECODE=1 \
+  python3 -m pytest scripts/tests/test_opencode_config.py scripts/opencode/tests -q   # 736 passed
+
+# 3. the control — re-widening to the infix form must fail exactly 5 tests by name
+#    (edit "*rm -r*"+"*rm --recursive*" back to a single "*rm*-r*", re-run, then restore)
+
+# 4. 🔴 LIVE, and the one that actually matters — merging changes NOTHING until a switch.
+#    ~/.config/opencode/opencode.jsonc resolves into /nix/store (a home.file copy).
+readlink -f ~/.config/opencode/opencode.jsonc          # -> /nix/store/...-hm_opencode.jsonc
+# after `home-manager switch`:
+opencode debug agent build --pure | grep -a '"\*rm'    # want "*rm -r*" + "*rm --recursive*", NO "*rm*-r*"
+```


### PR DESCRIPTION
Handoff for **#744**, plus the two open investigations that PR surfaced.

## Why a doc and not just the PR

The handoff that queued this work described it as *"one character, test pattern already exists"*. It is not. `"rm --recursive"` does not contain the literal `"rm -r"`, so dropping the inner `*` alone **releases** `rm --recursive <path>` — measured, plain `allow` at both layers, because `guard_core`'s fatal-target set never reaches an ordinary project path. Anyone picking this up from the one-line description ships that hole.

## Two investigations, with live diagnosis state

🔴 **The devrc pre-push gate cannot pass a push.** Measured twice: the suite runs ~20 min, reports `RESULT: PASS (exit=0)` / 15,199 passed, then the push dies `PUSH_RC=141` (SIGPIPE) and the remote ref does not move. The cause is named in the log at line 21:

```
Connection to github.com closed by remote host.
```

git opens the SSH transport **before** invoking `pre-push`; GitHub drops the idle connection while the suite runs; the pack write hits a dead socket. The gate therefore blocks *every* push rather than a bad one, and `DEVRC_SKIP_TESTS=1` is the only workflow that lands anything — the "permanently-red gate trains everyone to click through" shape. The doc carries the `GIT_TRACE` probe to confirm it and three fix shapes.

🟡 **`guard_core` does not protect `$HOME` subpaths from a recursive delete** — and did not before #744 either: `rm -fr ~/.ssh`, `rm -Rf ~/.ssh`, `rm -R ~/.ssh` are already `allow` on `main`. Both halves are recorded, because either alone misleads: the first overstates #744's culpability, the second reads as an excuse.

## Also captured

The GUARD 10 red that cost this session real time was a **stale runner**, not cross-session contamination — the branch was 5 commits behind `main` and `99b2636f` (#730) fixes exactly that guard. Check whether the base moved before diagnosing a guard failure.

Plus the instrument traps hit along the way: `wildcard_match(text, pattern)` takes text first (reversing it returns an all-`False` table that reads as "nothing matches"); a `pgrep -f` wait loop matches its own command line and spins forever; a trailing `echo "EXIT=$?"` makes the harness report exit 0 regardless.

## Notes

- **No `clawgate-task:` field** — `clawgate_handoff.sh resolve` exited 5 (nothing resolved), which cannot distinguish "touched no task" from "wrong session id". No task was created to fill it.
- Kept on its own branch so #744 stays a focused change.
- Pushed with `DEVRC_SKIP_TESTS=1`, for the reason documented in the doc itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHQprhyDCEjtL3uPVWnjsD