### PR TITLE
chore(skills): six always-on descriptions paid for MECHANISM prose — and BOTH reads used to judge them were wrong (13,925 → 13,491 chars)

### DIFF
--- a/claude/skills/adoption-scan/SKILL.md
+++ b/claude/skills/adoption-scan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adoption-scan
-description: "Report which shipped productivity tools are actually USED and YIELDING results versus idle or DEAD — a deterministic adoption + impact report over activity.events. Use for \"is anyone using X\", \"which tools are dead\", \"did the tool catch anything\", or auditing whether a shipped tool stuck."
+description: "Report which shipped productivity tools are actually USED and YIELDING versus idle or DEAD. Use for \"is anyone using X\", \"which tools are dead\", \"did the tool catch anything\", or whether a shipped tool stuck."
 argument-hint: "[--days N] [--insight-days N] [--dead-days N] [--host H] [--json] — optional; defaults to --days 14 --insight-days 30"
 allowed-tools: Bash
 ---

--- a/claude/skills/gpu-operator-check/SKILL.md
+++ b/claude/skills/gpu-operator-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gpu-operator-check
-description: "Check the NVIDIA GPU Operator across the GPU-fleet clusters: deployed version and per-cluster overlays, the latest upstream release, and the breaking changes between them. Use for: the GPU operator version or upgrade path, a newer GPU operator release, a pre-upgrade risk review of the GPU fleet."
+description: "Check the NVIDIA GPU Operator across the GPU-fleet clusters: deployed vs latest upstream version, and the breaking changes between. Use for: the GPU operator version or upgrade path, a newer GPU operator release, a pre-upgrade risk review of the GPU fleet."
 argument-hint: "[current | latest | upgrade-plan] — defaults to the full analysis"
 allowed-tools: Bash, Read, Grep, Glob
 ---

--- a/claude/skills/session-audit/SKILL.md
+++ b/claude/skills/session-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-audit
-description: "Analyze recent Claude Code session transcripts for this repo, then propose (and optionally implement) improvements to CLAUDE.md, the skills, token efficiency and the permission allowlist. Use when the user wants to audit how Claude has been working in a repo and harden the setup for future sessions."
+description: "Audit this repo's recent Claude Code session transcripts and propose fixes to CLAUDE.md, the skills, token efficiency and the permission allowlist. Use for: audit how Claude has been working in this repo, harden the setup for future sessions."
 ---
 
 # /session-audit — Repo session retrospective

--- a/claude/skills/ux-sweep/SKILL.md
+++ b/claude/skills/ux-sweep/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ux-sweep
-description: "One-off first-impression UX sweep of ANY app or flow: a subagent clicks through it with Playwright, screenshots every view at 5 breakpoints, and judges it as a non-technical, easily-deterred user would. Use to sanity-check a UI before shipping or after a change, or for \"click through X and evaluate the UX\". Re-runnable naida/vetr harnesses -> `ux-audit-loops`."
+description: "One-off first-impression UX sweep of ANY app or flow, judged as a non-technical user would. Use for \"click through X and evaluate the UX\", or sanity-checking a UI before shipping. Re-runnable naida/vetr harnesses -> `ux-audit-loops`."
 argument-hint: "<app/flow> [url] — e.g. 'the vet signup and onboarding flow', 'the admin dashboard http://localhost:3000'"
 allowed-tools: Bash, Read, Agent
 ---

--- a/claude/skills/vetr-mailbox/SKILL.md
+++ b/claude/skills/vetr-mailbox/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vetr-mailbox
-description: "Send 1:1 personalized email AS zach@vetr.com via Workspace SMTP — bounded, rate-limited, deduped, and it INBOXES. Use for 1:1 vet-recruitment outreach to the Vetr waitlist and other genuinely personal founder email. NOT a bulk blaster — bulk owner campaigns belong on Omnisend."
+description: "Send 1:1 personalized email AS zach@vetr.com via Workspace SMTP. Use for vet-recruitment outreach to the Vetr waitlist and other genuinely personal founder email. NOT a bulk blaster — bulk owner campaigns belong on Omnisend."
 ---
 
 # vetr-mailbox — send AS zach@vetr.com (Workspace SMTP)

--- a/scripts/dl-router/SKILL.md
+++ b/scripts/dl-router/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dl-router
-description: Operate the media download router — a loopback sidecar + Brave extension that files downloads by PAGE CONTEXT, not the filename. Fix a wrong route, add a site rule, run the backfill, restart/debug the sidecar or extension. Use for: the download router, dl-route, downloads landing in the wrong folder, auto-filing downloads, the download picker/toast, backfilling loose files.
+description: Operate the media download router — it files downloads by PAGE CONTEXT, not the filename. Use for: the download router, dl-route, downloads landing in the wrong folder, auto-filing downloads, the download picker/toast, a wrong route or a new site rule, backfilling loose files, the sidecar or extension.
 ---
 
 # dl-router

--- a/scripts/tests/test_skill_descriptions.py
+++ b/scripts/tests/test_skill_descriptions.py
@@ -38,7 +38,7 @@ decidable, and only those are asserted:
 WHY (4) EXISTS, AND WHAT IT DELIBERATELY DOES NOT CLAIM
 -------------------------------------------------------
 (2) is a PER-ENTRY cap; nothing measured the SUM, and the sum is what the 1%
-budget is spent against. Measured 2026-08-23 on the live workbench.
+budget is spent against. Re-measured 2026-08-23 on the live workbench.
 
 🔴 CHARS ARE THE UNIT HERE, and they are exact -- the token column is an
 ESTIMATE and is labelled as one. It was produced with `tiktoken` cl100k_base,
@@ -47,22 +47,32 @@ this host. Do not quote it as a Claude token count. It is carried only because
 it supplies the chars/token divisor, and the verdict below does not depend on
 that divisor being right:
 
-    devrc's 39 entries            14,792 chars   ~3,481 est. tok
-    the cloudflare plugin's 13      5,221 chars   ~1,132 est. tok  (NOT ours)
+    devrc's 39 entries            13,491 chars   ~3,109 est. tok
+    the cloudflare plugin's 13         0 chars        0 est. tok  (see below)
     ---------------------------------------------------------------
-    disk-readable total            20,013 chars   ~4,613 est. tok
-    implied divisor                              4.34 chars/token (estimate)
+    disk-readable total            13,491 chars   ~3,109 est. tok
+    divisor used                                 4.34 chars/token (estimate)
+
+The cloudflare plugin cost 5,221 chars of listing until it was removed from
+`enabledPlugins` in `~/.claude/settings.json`. 🔴 That file is PER-HOST and
+unmanaged by design (`CLAUDE.md` -> Git discipline), so the zero above is a
+measurement of THE WORKBENCH, not a devrc fact and not a claim about the laptop.
+Nothing in this repo can hold it there -- if the plugin comes back, so does the
+5,221, and no assertion here will notice. It is stated to explain the drop from
+20,013, not relied on.
 
 THE VERDICT IS TOKENIZER-INDEPENDENT, which is why it is stated as a break-even
 rather than as a token count. 1% of a 200,000-token context is 2,000 tokens, so
-fitting 20,013 exact chars into it requires a divisor of >10.0 chars/token. No
-tokenizer of natural language reaches half that -- real prose runs 3.5-4.5, and
-the estimate above lands mid-range at 4.34. So on a 200k context the listing is
-~2.3x over budget and CANNOT be re-tokenised into fitting: descriptions are
-being silently DROPPED today, starting with the skills invoked least. On a 1M
-context (10,000 tokens) the break-even runs the other way -- overflow would need
-a divisor BELOW 2.0 -- so it fits with room to spare. Built-in skills are not
-readable from disk and are ADDITIONAL, so 52 entries is a FLOOR, not the count.
+fitting 13,491 exact chars into it requires a divisor of >6.7 chars/token. No
+tokenizer of natural language reaches that -- real prose runs 3.5-4.5, and the
+estimate above lands mid-range at 4.34. So on a 200k context the listing is
+still ~1.6x over budget and CANNOT be re-tokenised into fitting: descriptions
+are being silently DROPPED today, starting with the skills invoked least. Two
+rounds of trimming have narrowed the overshoot (2.3x -> 1.6x) without closing
+it. On a 1M context (10,000 tokens) the break-even runs the other way --
+overflow would need a divisor BELOW 1.35 -- so it fits with room to spare.
+Built-in skills are not readable from disk and are ADDITIONAL, so 39 entries is
+a FLOOR, not the count.
 
 🔴 So this ceiling is NOT "the listing fits" -- it demonstrably does not on 200k,
 and a gate pinned at the real 200k budget would be permanently red, which
@@ -123,16 +133,19 @@ PER_ENTRY_CAP_CHARS = 1_536
 MIN_LISTING_ENTRIES = 30
 
 # 🔴 THE RATCHET. devrc's listing entries summed to 14,792 chars at
-# 99b2636f; this PR's trims took it to 13,925 without dropping a trigger phrase
-# or a disambiguation clause. The ceiling sits ~250 chars above that measurement
-# -- deliberately less than one average entry (13,925 / 39 = 357), so a NEW skill
+# 99b2636f; #749's trims took it to 13,925, and the six description shrinks in
+# this commit take it to 13,491 -- none of them dropping a trigger phrase or a
+# disambiguation clause. The ceiling sits ~250 chars above that measurement
+# -- deliberately less than one average entry (13,491 / 39 = 345), so a NEW skill
 # cannot be added without an eviction in the SAME commit. That is the same rule
 # `claude/RULES.md` and `scripts/browser-bridge/tests/test_skill_size.py` already
 # apply to the other two always-on documents.
 #
-# LOWER it when you cut; do NOT raise it to make a new description fit. The
+# LOWER it when you cut; do NOT raise it to make a new description fit. A ceiling
+# left at the previous, larger number licenses exactly the regrowth this constant
+# exists to catch, so re-pinning it is part of the cut, not follow-up work. The
 # eviction playbook is printed by the failing assertion below.
-LISTING_TOTAL_CEILING_CHARS = 14_175
+LISTING_TOTAL_CEILING_CHARS = 13_741
 
 # The skills deployed by `mkOutOfStoreSymlink` from `scripts/` instead of by the
 # recursive `claude/skills` mapping (`nix/home.nix`). They are listing entries
@@ -365,7 +378,7 @@ def test_the_listing_total_does_not_regrow_past_its_ratchet():
     """🔴 The SUM, which the per-entry cap above structurally cannot see.
 
     39 entries each comfortably under the 1,536-char per-entry cap still overrun
-    the 1%-of-context budget by ~2.3x on a 200k window -- so the per-entry check
+    the 1%-of-context budget by ~1.6x on a 200k window -- so the per-entry check
     can be green while descriptions are being dropped. See this module's
     docstring for the measurement and for why this is a ratchet rather than a
     gate on the real budget.


### PR DESCRIPTION
## What

Six always-on skill descriptions were nominated for retirement on one read — **zero Skill-tool invocations**. This PR verifies that on three independent reads, finds the nomination **wrong in both directions**, and shrinks all six instead of retiring any.

**13,925 → 13,491 chars** across 39 entries (−434). The ratchet in `scripts/tests/test_skill_descriptions.py` is re-pinned **14,175 → 13,741**.

## Read 1 — Skill-tool + slash invocations

Corpus: 5,619 transcripts, 1.86M lines, `2026-06-23 … 2026-08-23`. **Every zero is reported beside a positive control on the identical query shape.**

| skill | `Skill()` | `/slash` | sessions |
|---|---|---|---|
| ux-sweep | 0 | 0 | 0 |
| gpu-operator-check | 0 | 0 | 0 |
| session-audit | 0 | 0 | 0 |
| adoption-scan | 0 | 0 | 0 |
| vetr-mailbox | 0 | 0 | 0 |
| dl-router | 0 | 0 | 0 |
| **control** `audit-pr` | **364** | **10** | 300 |
| **control** `browser` | **91** | 0 | 53 |
| **control** `handoff` | **47** | **279** | 267 |
| **control** `clickup` | **36** | **17** | 44 |
| **control** `session-manager` | **3** | 0 | 3 |

**A second, independent instrument agrees.** `activity.events` `source=claude kind=command`, `2026-05-09 … 2026-08-23`, 1,051 rows: all six **0**; controls `handoff` **326**, `clickup` **32**, `browser` **9**. (`audit-pr` OOM'd ClickHouse — **UNMEASURED**, not a zero.)

## Read 2 — prompt mentions: the rescue that isn't

Raw counts look like residual demand, and `dl-router`'s were previously read that way:

| skill | raw mentions | classified META | genuine demand |
|---|---|---|---|
| ux-sweep | 5 | 5 | **0** (full population read) |
| gpu-operator-check | 4 | 4 | **0** (full population read) |
| session-audit | 7 | 7 | **0** (full population read) |
| vetr-mailbox | 10 | 10 | **0** (full population read) |
| adoption-scan | 31 | 31 | **0** (13 sampled by hand) |
| dl-router | 107 | 107 | **0** (8 of 47 sampled by hand) |

Classifying all 164 mentions kills the reading. They are **devrc's own skill-infrastructure work** — skill audits, the commands→skills migration, `test_doc_path_rot` gates, `nix/home.nix` deploy ledgers, and this task's own briefing — naming each skill as a **file**. Not one is a user asking a skill to do its job.

🔴 **Scope of that classification, stated exactly.** An automated path/extension classifier put 60 of `dl-router`'s 107 in the META bucket mechanically. The remaining 47 were **not** all read — I read a sample of 8, and every one was the same artifact in prose rather than in path form (`"the four mkOutOfStoreSymlink exceptions (browser, dl-router, …)"`, `"dl-router 991/991"`). For `ux-sweep`, `gpu-operator-check`, `session-audit` and `vetr-mailbox` the sample **is** the full population (5/4/7/10), so those four zeroes are complete; `adoption-scan`'s 13 and `dl-router`'s 47 are sampled, not exhaustive.

**A repo that gates on its own skill paths mentions every skill constantly — which is exactly how a dead listing entry reads as alive.**

🔴 **This is a third defect in the tip-off list, opposite in sign to the two I was warned about.** `dl-router`'s "33 prompt mentions → residual demand, flagged and then listed for folding anyway" was not under-weighted evidence; it was not evidence.

## Read 3 — is the machinery invoked directly, bypassing the skill?

This is the read that actually separates the six.

| skill | finding |
|---|---|
| **adoption-scan** | 🟢 **LIVE.** Re-ran `adoption-scan.py --days 90` here: 20,494 tool-invocation events, 1,044 slash-commands, 9 tracked tools. The skill is a thin wrapper over a CLI agents call directly. |
| **dl-router** | 🟢 **LIVE.** `dl-router.service` = `active/running`; most recent download filed **2026-08-20**; 17 routed files / 34 routes / 17 source URLs in its store. |
| **vetr-mailbox** | `send.py` present, but **no send log and no credential file** — the one-time setup was never completed, so it has never sent. |
| **session-audit** | `~/.claude/tools/session-audit.py` exists (mtime 2026-06-14) and was invoked **0** times in the corpus. |
| **ux-sweep**, **gpu-operator-check** | no local backing script; nothing to bypass. |
| interactive shell — `source=zsh kind=command`, 90d, n=3,882 | all six **0**; controls `handoff` **19**, `clickup` **1**, `git` **25**. A thin stream: Zach works via agents, not an interactive shell. |

### Conclusions that changed the plan

- **`adoption-scan` and `dl-router` are alive** — confirmed independently of the tip-off. `dl-router` is **not** folded into `browser`: folding would delete routing surface for a subsystem that routed a file three days ago.
- **Nothing is rescued by demand.** Genuine demand is zero for all six.
- **Nothing is deleted either.** Deletion needs *no capability worth keeping* **and** no demand. Each of the six holds a real capability, so the first conjunct fails for all of them. `vetr-mailbox` was never a deletion candidate — it sends founder email on a real business identity, and a zero on a campaign-driven tool is a season, not a verdict.

## What changed — option (a), shrink, for all six

Mechanism and implementation prose out; **every trigger phrase and every disambiguation clause kept**.

| skill | before | after | saved |
|---|---|---|---|
| ux-sweep | 372 | 243 | 129 (35%) |
| adoption-scan | 308 | 227 | 81 (26%) |
| dl-router | 385 | 312 | 73 (19%) |
| session-audit | 313 | 255 | 58 (19%) |
| vetr-mailbox | 289 | 236 | 53 (18%) |
| gpu-operator-check | 314 | 274 | 40 (13%) |
| **total** | **1,981** | **1,547** | **434** |

Two deliberate non-cuts:

- **`dl-router` gains two triggers.** Its deleted verb-sentence carried "a wrong route", "add a site rule" and "the sidecar or extension"; those moved into the `Use for:` list rather than being dropped.
- **`vetr-mailbox` keeps "NOT a bulk blaster — bulk owner campaigns belong on Omnisend."** That clause guards the primary business mailbox against a mis-route. It is routing surface, not narrative.

## The ratchet, re-pinned and watched to fail

`LISTING_TOTAL_CEILING_CHARS` **14,175 → 13,741** (measurement + 250, less than one average entry of 345, so a new skill still cannot be added without an eviction in the same commit).

- **Red at `081838cc`** (the merge base) with only the re-pinned module applied to an otherwise-pristine tree: `AssertionError: assert 13925 <= 13741` — **2 failed, 19 passed**.
- **Green at HEAD** — **21 passed**.

The module docstring's measurement block is re-derived rather than left asserting a number the tree no longer has: 13,491 chars, a **>6.7 chars/token** break-even against the 2,000-token budget, ~1.6× over on 200k.

It also no longer leans on the cloudflare plugin's absence. Those 5,221 chars are gone because the plugin left `enabledPlugins` in `~/.claude/settings.json` — **a per-host, unmanaged file**. The docstring now states that zero as a workbench measurement, not a devrc fact: nothing in this repo can hold it there, and no assertion here would notice it coming back.

## 🔴 Budget verdict — this does NOT close the gap

| | chars | × the ~8,680-char budget (1% of 200k @ 4.34 c/tok) |
|---|---|---|
| before | 13,925 | 1.60× |
| after | **13,491** | **1.56×** |

**It still does not fit.** Descriptions are still being dropped silently today, starting with the skills invoked least. Closing it needs roughly **4,800 more chars** — skills genuinely **retired or merged**.

On the evidence above the retirement shortlist is **`ux-sweep`, `gpu-operator-check`, `session-audit`**: zero on all three reads, kept here only because each holds a real capability. Retiring all three would recover 772 chars — still not enough on its own. That is an operator call, not something this PR or a test can make.

## 🔴 Deploying this — the five and the one behave differently

Merging does **not** shrink the listing. Measured on the workbench with `readlink -f`:

```
adoption-scan  -> /nix/store/0dgm8pk…-devrc-claude-skills/adoption-scan/SKILL.md
vetr-mailbox   -> /nix/store/0dgm8pk…-devrc-claude-skills/vetr-mailbox/SKILL.md
ux-sweep       -> /nix/store/0dgm8pk…-devrc-claude-skills/ux-sweep/SKILL.md
dl-router      -> /home/zach/workspace/devrc/scripts/dl-router/SKILL.md
```

- The five under `claude/skills/` are **`home.file` copies in `/nix/store`** → they need `scripts/ship.sh` (or a `home-manager switch`) before the shrink is live. `git pull` alone changes nothing.
- `dl-router` is an **`mkOutOfStoreSymlink` onto the base clone's working tree** → its description goes live as soon as the base clone's file changes, with no switch.

So after merge: **merge → pull → `ship.sh`**, and a new session to reload the listing. Verifying the listing size without the switch measures the old artifact for five of the six.

## Verification

- `nix develop . --command bash scripts/gate.sh` — result posted as a comment below.
- Red/green matrix for the re-pinned ratchet as above.
- No path changed, so `test_doc_path_rot.py` is unaffected; the `OUT_OF_TREE_SKILLS` ↔ `nix/home.nix` seam ledger and the `CLICKUP_SIBLINGS` pin are untouched and green.
- No file added or deleted, so nothing needs `git add`ing for the flake to see it.
- `TARGET_FLOORS` in `scripts/run-tests.sh` untouched.

Do **not** merge without reading the gate result. `main` has a required `tekton/devrc-nodetests` check, so this will sit `BLOCKED` until that reports — that is the gate working, not a failure.
