### PR TITLE
docs(merge-gate): name the mechanism — nodetests collects `*.test.mjs` ONLY

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,8 @@ Repo-level facts that are NOT in any skill — they live here on purpose:
   with `enforce_admins: true`. Verified behaviourally, not from the setting: PRs with
   nodetests `ERROR` or `PENDING` read `mergeStateStatus=BLOCKED`, green ones read `CLEAN`,
   and a PR with pytests red but nodetests green reads `UNSTABLE` — mergeable. That split is
-  deliberate: pytests reports, nodetests gates. There is still no `.github/workflows`, so
+  deliberate — and nodetests collects `*.test.mjs` ONLY, so a Python-only PR cannot fail
+  the required check at all. There is still no `.github/workflows`, so
   the marker stays `other`.
   🔴 **`enforce_admins: true` is LIVE now** — it protected nothing while nothing was
   required. If Tekton is down or wedged, NOTHING merges and there is no admin override.

--- a/scripts/tests/test_ci_claim_matches_reality.py
+++ b/scripts/tests/test_ci_claim_matches_reality.py
@@ -15,19 +15,30 @@ no ruleset, no Tekton trigger, and `statusCheckRollup` is empty on every PR."
 carry branch protection, and `statusCheckRollup` is non-empty. Still true: no
 `.github/workflows`, and no ruleset.
 
-None of that changed the marker to `github-actions`, because the protection
-carries **no `required_status_checks`**: checks RUN, nothing BLOCKS. Measured
-behaviourally, not inferred — #707 merged **28 minutes** after its
-`devrc-pytests` went RED, #711 two minutes after. The marker is `other` because
-something this test cannot see (Tekton) now reports; it would become
-`github-actions` only if a `pull_request` workflow appeared here.
+🔴 AND IT DRIFTED AGAIN, this time in the REASSURING direction. This paragraph
+used to continue: "the protection carries **no `required_status_checks`**:
+checks RUN, nothing BLOCKS", evidenced by #707 merging **28 minutes** after its
+`devrc-pytests` went RED and #711 two minutes after. **Measured FALSE on
+2026-08-23**: `required_status_checks.contexts` is `["tekton/devrc-nodetests"]`,
+`strict: false`, `enforce_admins: true` — a merge DOES block now. But on one
+tier of two, and the required one collects `*.test.mjs` ONLY, so a Python-only
+change cannot fail it. "Partially blocked" is the shape that reads as "blocked".
+
+The marker was `other` before that change and is `other` after, because it
+encodes what REPORTS, not what BLOCKS: something this test cannot see (Tekton)
+runs here, and it would become `github-actions` only if a `pull_request`
+workflow appeared. Branch protection is invisible to this test in BOTH states —
+see SCOPE below — so nothing in this file verifies the paragraph above, and a
+green run here is not evidence for it. Re-measure it.
 
 Re-measure both surfaces rather than quoting any of the above:
     gh api repos/innovation-upstream/devrc/branches/main/protection   # required_status_checks?
     gh api repos/innovation-upstream/devrc/rules/branches/main        # org+repo+enterprise rulesets
-On the first, an ABSENT key reads as clean unless you look for it by name; on
-the second the answer is an empty array. Positive-control the `[]` before
-believing it — the same call against a repo with rulesets returns non-empty.
+On the first the key is PRESENT today, so read the `contexts` LIST and `strict`,
+not merely whether the key exists — a one-element list is a PARTIAL gate, and an
+absent key would read as clean unless you looked for it by name. On the second
+the answer is an empty array. Positive-control the `[]` before believing it —
+the same call against a repo with rulesets returns non-empty.
 
 That is the worst shape a false claim can take. It lives in the always-loaded
 project instructions, it is reassuring, and it is exactly the sort of sentence


### PR DESCRIPTION
## What

One clause in `CLAUDE.md`, net **+72 bytes**:

```diff
-  deliberate: pytests reports, nodetests gates. There is still no `.github/workflows`, so
+  deliberate — and nodetests collects `*.test.mjs` ONLY, so a Python-only PR cannot fail
+  the required check at all. There is still no `.github/workflows`, so
```

## Why

The section already says the gate is real and partial — the bold headline reads
"**A MERGE IS NOW BLOCKED BY `tekton/devrc-nodetests`. `devrc-pytests` is NOT.**" — and
covers `enforce_admins: true` being live, the `gh api -X DELETE …` escape hatch, and
`strict: false` with "a green check is a claim about the PR's BRANCH, not about the tree
the merge creates."

What it did **not** say is the mechanism, and that is the part that changes what you do.
"nodetests gates" reads as though the required check gives a Python change *some*
coverage. It gives **none**: `run-node-tests.sh` collects `*.test.mjs` exclusively — at
discovery (`for f in "$_root"/**/*.test.mjs`, line 254) and again per suite
(`FILES=("$dir"/*.test.mjs`, line 379) — so no `.py` file is executed by the only check
that can block a merge. A Python-only PR is the common case in this repo.

`git show origin/main:CLAUDE.md | grep -n 'test.mjs'` returns nothing, so this was not
stated anywhere in the file.

## Why so small

The clause **replaces** "pytests reports, nodetests gates" rather than being appended to
it. That phrase restated the bold headline one line above, so the mechanism costs almost
nothing over what it displaces. This file loads every session.

No enforced byte ceiling covers `CLAUDE.md` — `scripts/tests/test_rules_size.py` guards
`claude/RULES.md` (`MAX_BYTES = 40_300`) and `test_skill_size.py` guards
`scripts/browser-bridge/SKILL.md`. Kept minimal regardless.

## Measured, not inherited

Read twice, ~40 minutes apart, identical both times:

```
required_status_checks.contexts: ["tekton/devrc-nodetests"]
required_status_checks.strict:   false
enforce_admins.enabled:          true
rulesets:                        []          (and no .github/workflows)
```

Behaviourally: PRs #753–#756 read `mergeStateStatus=BLOCKED` on a `PENDING` nodetests.

Tier sizes measured directly, not copied:

| tier | required? | collects | suites/targets | tests |
|---|---|---|---|---|
| `tekton/devrc-nodetests` | **yes** | `*.test.mjs` only | 4 suites | 1,149 |
| `tekton/devrc-pytests` | no | pytest | 27 targets | floor sum 13,732 |

`scripts/browser-bridge/tests/` is the trap in miniature — one directory holding both
`.py` and `.test.mjs` files, of which only the `.mjs` half is required.

## Marker

`<!-- merge-gate: other -->` is **untouched** and still correct: Tekton is not GitHub
Actions, and the marker records that something RUNS, never that it BLOCKS. Still exactly
one marker (the other `merge-gate:` grep hit uses a Unicode ellipsis, which
`MARKER_RE`'s `[a-z0-9-]+` cannot match).

## Verification

`scripts/tests/test_ci_claim_matches_reality.py` + `scripts/tests/test_rules_size.py` —
**10 passed**.

Guard validated in both directions rather than trusted: mutating the marker to
`github-actions` makes it fail with **this** guard's own assertion
(`assert 'github-actions' in {'none', 'other'}` at
`test_claude_md_marker_matches_the_repo`), then restored and re-confirmed green by
checksum. No full gate run — this is a one-clause docs edit touching no executable code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Second commit: the guard's own docstring asserted the same false claim

`scripts/tests/test_ci_claim_matches_reality.py:19` still read:

> the protection carries **no `required_status_checks`**: checks RUN, nothing BLOCKS

Third instance of this drift, and the worst-placed: a false statement of the gate's
state inside **the guard whose entire job is to stop that claim from drifting**. The
next person to touch this test reads its docstring to learn what it is for, and would
have learned something false about whether merges are blocked.

Re-measured at the moment of writing:

```
required_status_checks.contexts: ["tekton/devrc-nodetests"]
required_status_checks.strict:   false
enforce_admins.enabled:          true
```

Rewritten in place, in this file's own established style of recording each drift
(the same way lines 9–16 record the previous one). The old sentence now appears only
inside quotation marks as the thing measured false.

Kept deliberately narrow, per the rule that a docstring must not advertise coverage
the code does not provide:

- The paragraph does **not** claim this test verifies any of it. It states that branch
  protection is invisible to this test in **both** states, points at the existing SCOPE
  section that already spells that out, and says a green run here is not evidence for
  the paragraph.
- The adjacent re-measure recipe said "an ABSENT key reads as clean unless you look for
  it by name" — true as advice, misleading as a picture of today. It now says the key is
  **PRESENT**, so read the `contexts` LIST and `strict` (a one-element list is a partial
  gate), while keeping the absent-key warning for the state it describes.

Comments only; no behaviour change. SCOPE section verified unchanged and still accurate.

## Tests (both commits)

`test_ci_claim_matches_reality.py` + `test_rules_size.py` — **10 passed**, re-run after
the docstring change. No full gate: docs/comment-only, no executable code touched.
