### PR TITLE
docs(tekton): pushing N branches is ONE blast-radius action — node-pinning makes them serialise, and the kills land on other people's PRs

### DIFF
--- a/claude/skills/tekton/SKILL.md
+++ b/claude/skills/tekton/SKILL.md
@@ -39,6 +39,24 @@ debugging, changing or copying a specific pipeline.
    walk-gate **cold 3m04s → warm 1m15s** (~1m50s saved) — the old "~2–15 min cold" figure was
    **wrong** (cache.nixos.org is fast here; cold ≈ 3 min). Tradeoff: if `talos-xr6-r7p` is
    down, runs Pend.
+   🔴 **AND PUSHING N BRANCHES IS NOT N INDEPENDENT ACTIONS — IT IS ONE BLAST-RADIUS ACTION.**
+   Node-pinning means every run lands on `talos-xr6-r7p`, so a burst of pushes stacks full
+   pipeline runs onto one node with **no concurrency control** (the known-open issue below).
+   Measured 2026-08-23: five branches pushed in quick succession took that node to 77% CPU
+   requests / 237% limits with 424 Completed + 97 Error pods resident, the cluster began
+   emitting `ExceededNodeResources: Insufficient resources to schedule pod`, and steps were
+   **killed with exit 255**. The rate moved **2/54 (4%) → 8/34 (24%)**. It is not your branch:
+   **anyone else's PR checks in that window die too.** Push, wait for the queue to drain, push.
+   🔴 **`exited with code 255` is the CONGESTION signature, and it names whichever step was
+   running** — it appeared in `step-clone` AND `step-pytests` in the same burst, which reads as
+   two unrelated bugs and is one. The check then posts `NOT RUN: <leg> — the gate stopped
+   before this leg reported`: **a broken gate, not a bad change — do not debug your diff
+   against it.** The tell that it is congestion rather than code: it heals when the queue
+   drains, and a code cause does not.
+   🔴 **Do NOT measure a flake rate from inside a burst you are causing.** That mistake was
+   made here and written into a handoff as a property of the CI tier before it was caught —
+   `claude/RULES.md` → *"a control that SHARES the step you doubt"*. Take the baseline from a
+   window with no pushes of your own in it.
 4. **Placeholder imagePullSecret breaks ALL pulls.** A `harbor-cred` dockerconfigjson with a
    non-base64 `auth` placeholder makes every pod fail image pull ("illegal base64 data").
    **Do NOT attach a placeholder imagePullSecret** to the pipeline SA — public images


### PR DESCRIPTION
docs(tekton): pushing N branches is ONE blast-radius action — node-pinning makes them serialise, and the kills land on other people's PRs

The skill already records that every run is pinned to `talos-xr6-r7p` (gotcha 3)
and that there is no concurrency control (a known-open issue). What it did not
record is the consequence for whoever pushes, which cost a wrong diagnosis and a
wrong number in a handoff before it was caught.

Measured 2026-08-23. Five branches pushed in quick succession put five full
pipeline runs on that one node — 77% CPU requests / 237% limits, 424 Completed
and 97 Error pods resident — and the cluster began emitting
`ExceededNodeResources: Insufficient resources to schedule pod`. Steps were then
killed with exit 255:

                        gate runs   steps killed with exit 255
  before the burst          54          2   (4%)
  during / after it         34          8   (24%)

Three things now written down:

1. **A burst is a blast-radius action.** It is not your branch that suffers —
   anyone else's PR checks in that window die too. Push, let the queue drain,
   push.

2. **`exited with code 255` is the congestion signature and it names whichever
   step was running.** It appeared in `step-clone` AND `step-pytests` in the same
   burst, which reads as two unrelated bugs and is one. The check then posts
   `NOT RUN: <leg> — the gate stopped before this leg reported`: a broken gate,
   not a bad change. The tell is that it heals when the queue drains, and a code
   cause does not.

3. **Do not measure a flake rate from inside a burst you are causing.** That is
   exactly what happened here — the 24% figure was written into a handoff as a
   property of the CI tier and had to be retracted. RULES.md calls it: "a control
   that SHARES the step you doubt". Take the baseline from a window with no
   pushes of your own in it.

Body-only change to an existing gotcha rather than a new entry, because it is the
same root cause as the node-pinning already documented there; splitting it would
put one mechanism in two places.

63 skill/doc gate tests pass (descriptions, rules size, conflict markers, client
hostnames, public IPs).
