### PR TITLE
rescue(nix/system): two apply scripts existed on ONE disk, in no commit and no backup — and the reason nobody ran the nvidia one is FALSE

### DIFF
--- a/nix/system/apply-nvidia-kernel-7.2.sh
+++ b/nix/system/apply-nvidia-kernel-7.2.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Unbreak nixos-rebuild after the channel jumped to kernel 7.2.
+#
+#   Symptom: nvidia-open-595.45.04-7.2 fails with
+#            nv-linux.h:1730:10: fatal error: linux/of_gpio.h: No such file or directory
+#   Cause:   /etc/nixos/configuration.nix pins hardware.nvidia.package to
+#            nvidiaPackages.beta, which in the current channel is 595.45.04 —
+#            OLDER than stable/production (595.91.07). 595.45.04 includes
+#            <linux/of_gpio.h> unconditionally; kernel 7.2 no longer ships it.
+#   Fix:     move off the beta branch. 595.91.07 (production/stable) and
+#            610.57.04 (latest) both build against 7.2 and are prebuilt on
+#            cache.nixos.org — verified 2026-08-19 by building
+#            linuxPackages_latest.nvidiaPackages.{production,latest}.open
+#            against root's channel (kernel 7.2); both substituted, no compile.
+#
+# Run with:  sudo bash nix/system/apply-nvidia-kernel-7.2.sh
+# Or pick a different branch:
+#            sudo NVIDIA_BRANCH=latest bash nix/system/apply-nvidia-kernel-7.2.sh
+set -euo pipefail
+
+CFG="/etc/nixos/configuration.nix"
+BRANCH="${NVIDIA_BRANCH:-production}"
+
+case "$BRANCH" in
+  production|stable|latest|beta) ;;
+  *) echo "ERROR: NVIDIA_BRANCH must be one of production|stable|latest|beta (got '$BRANCH')" >&2; exit 2 ;;
+esac
+
+ACTIVE_RE='^[[:space:]]*package[[:space:]]*=[[:space:]]*config\.boot\.kernelPackages\.nvidiaPackages\.[a-z_0-9]+;'
+
+n=$(grep -cE "$ACTIVE_RE" "$CFG" || true)
+if [ "$n" -ne 1 ]; then
+  echo "ERROR: expected exactly 1 uncommented nvidiaPackages line in $CFG, found $n." >&2
+  echo "       Edit it by hand — this script will not guess which one to change." >&2
+  exit 1
+fi
+
+current=$(grep -oE "$ACTIVE_RE" "$CFG" | grep -oE '[a-z_0-9]+;$' | tr -d ';')
+if [ "$current" = "$BRANCH" ]; then
+  echo "Already on nvidiaPackages.$BRANCH — no config change needed."
+else
+  BAK="$CFG.bak-nvidia-$(date +%Y%m%d-%H%M%S)"
+  cp "$CFG" "$BAK"
+  sed -i -E "s|^([[:space:]]*package[[:space:]]*=[[:space:]]*config\.boot\.kernelPackages\.nvidiaPackages\.)[a-z_0-9]+;|\1${BRANCH};|" "$CFG"
+
+  now=$(grep -oE "$ACTIVE_RE" "$CFG" | grep -oE '[a-z_0-9]+;$' | tr -d ';')
+  if [ "$now" != "$BRANCH" ]; then
+    echo "ERROR: sed did not take (still '$now') — restoring $BAK" >&2
+    cp "$BAK" "$CFG"
+    exit 1
+  fi
+  echo "[1/2] hardware.nvidia.package: $current -> $BRANCH   (backup: $BAK)"
+fi
+
+echo "[2/2] Rebuilding..."
+nixos-rebuild switch
+
+echo
+echo "Done. The new driver only takes effect after a REBOOT (kernel module)."
+echo "Check after reboot:  nvidia-smi --query-gpu=driver_version --format=csv,noheader"
+echo "Roll back without rebooting into it:  nixos-rebuild switch --rollback"


### PR DESCRIPTION
rescue(nix/system): two apply scripts existed on ONE disk, in no commit and no backup — and the reason nobody ran the nvidia one is FALSE

`drift-check.sh` reports untracked files per host precisely because they are the
loss class nothing else catches: work sitting on one machine that no other host
and no backup has. Two have been sitting there — one for 17 days — and #728's
handoff already listed them as "stranded, unowned, untracked in the tree". Nobody
closed it. One `git clean`, one `git checkout` by a concurrent session, or one
disk failure and they are gone with no record they existed.

  nix/system/apply-nvidia-kernel-7.2.sh                     Aug 19, 2708 B
  nix/system/apply-nebula-443.sh.LOCAL-preserved-2026-08-02 Aug  6, 1302 B

Both committed here verbatim — byte-identical to the working-tree copies
(`cmp` clean), `bash -n` clean.

## 🔴 The nvidia script was NOT unrunnable, and that claim probably cost 17 days

`claudedocs/handoff-guards-and-gates.md` says of it: *"it is `chmod 644`, so it
cannot be run as written."* That is false, and it is the kind of false that stops
anyone trying.

The file's own header documents the invocation:

    Run with:  sudo bash nix/system/apply-nvidia-kernel-7.2.sh

`bash <file>` does not need the execute bit. Only direct exec does. Measured:

    mode 0644, `bash <file>`      -> rc 0, script runs
    mode 0644, direct exec        -> permission denied

And 644 is not even anomalous in this directory: `apply-freeze-instrumentation.sh`
is committed at `100644` today. Eleven siblings are 755, so this commit sets 755
for consistency — but consistency is the only reason, not runnability.

What that script actually does is unbreak `nixos-rebuild` on a host whose
`hardware.nvidia.package` pins `nvidiaPackages.beta`, which in the current channel
is 595.45.04 — OLDER than production (595.91.07) and containing an unconditional
`#include <linux/of_gpio.h>` that kernel 7.2 no longer ships. So a rebuild fails
with a compile error in `nv-linux.h`. The author verified both production and
latest build against 7.2 and substitute prebuilt from cache.nixos.org.

🔴 **Still staged, not applied** — it edits `/etc/nixos` and needs
`sudo bash nix/system/apply-nvidia-kernel-7.2.sh`, which Claude cannot run. This
PR only stops it evaporating.

## The nebula one is a preserved conflict artifact, kept deliberately

`apply-nebula-443.sh.LOCAL-preserved-2026-08-02` is the LOCAL side of a merge
someone resolved by hand on 2026-08-06, parked next to the committed
`apply-nebula-443.sh` (which is tracked, 755). Committing it does not make it
authoritative — it makes it recoverable and reviewable. If it turns out to carry
nothing the tracked version lacks, delete it in a follow-up with that stated;
deleting it while it exists only in one working tree is not a decision anyone can
review.

## Not fixed here

`NVIDIA_BRANCH="${NVIDIA_BRANCH:-production}"` is the same `${VAR:-default}` shape
#716 was about — set-but-empty resolves to the default. Benign in this case: the
default is a package branch name, not a filesystem path, so an empty value falls
back to something safe rather than to the operator's real clone. Noted so the next
reader does not have to re-derive that it is the same shape and a different risk.
