### PR TITLE
feat(escrow): re-verify the age key's escrow — is it still there, still correct, and does it still work?

### DIFF
--- a/SECRETS.md
+++ b/SECRETS.md
@@ -197,10 +197,28 @@ line says which of the two you got; it never lets "verified" stand for both.
 timer can act on the number: `12` locked, `13` not logged in, `17` the note is
 GONE, `18` two notes share the name and neither can be trusted, `21` it differs
 only in trailing newlines — still probably usable, re-escrow it — `22` it differs
-materially, `25` the escrowed key does not open the artifacts. It reports **byte
-counts and a classification only, never the differing content**, and it reads the
-server from `bw config server` at run time rather than carrying an endpoint into
-a public repo.
+materially. It reports **byte counts and a classification only, never the
+differing content**, and it reads the server from `bw config server` at run time
+rather than carrying an endpoint into a public repo.
+
+🔴 **Under `--decrypt-check` the six outcomes mean different things, and only one
+of them is about the KEY.** Reading these wrong is how a working
+disaster-recovery key gets rotated, or a tampered backup gets waved through:
+
+| code | meaning | what to do |
+|---|---|---|
+| `29` `AGE-MISSING` | `age` is not on PATH | environment fault; says nothing about the escrow |
+| `30` `ARTIFACT-UNREADABLE` | failed before the key was used | diagnose the object, not the key |
+| `25` `DECRYPT-FAILED` | age wrote **nothing**: wrong key **or** damaged header — **not separable** | re-run `restore-verify.py` with the **on-disk** key; if it also fails, the artifact is the problem. **Do not rotate first.** |
+| `33` `ARTIFACT-CORRUPT` | age authenticated the header (**the key worked**) then failed the payload | 🔴 **the backup is TAMPERED/CORRUPT/TRUNCATED.** Check the other retained objects. Do not rotate. |
+| `31` `ARTIFACT-EMPTY` | age exited **zero** on an empty payload (**the key worked**) | the artifact holds nothing; do not rotate |
+| `26` `RESTORE-FAILED` | decrypted fine, the git bundle is bad | artifact fault; do not rotate |
+
+Measured (age v1.3.1, many offsets and sizes): a wrong key or a damaged header
+leaves **no** plaintext file, while payload corruption and truncation leave one —
+because age writes output *before* authenticating the payload. That, plus a
+machine-readable cause published by `restore-verify.py`, is what separates the
+rows; none of it is parsed out of age's stderr.
 
 ⚠ It cannot unlock the vault and will not try: every `bw` call runs with stdin on
 `/dev/null`, `--nointeraction`, and a timeout, so an unattended run **fails fast

--- a/SECRETS.md
+++ b/SECRETS.md
@@ -201,18 +201,24 @@ materially. It reports **byte counts and a classification only, never the
 differing content**, and it reads the server from `bw config server` at run time
 rather than carrying an endpoint into a public repo.
 
-🔴 **Under `--decrypt-check` the six outcomes mean different things, and only one
-of them is about the KEY.** Reading these wrong is how a working
+🔴 **Under `--decrypt-check` the eight outcomes mean different things, and only
+one of them is about the KEY.** Reading these wrong is how a working
 disaster-recovery key gets rotated, or a tampered backup gets waved through:
 
 | code | meaning | what to do |
 |---|---|---|
+| `27` `STORE-UNREACHABLE` | could not open the bucket at all | cluster/route fault; nothing was tested |
+| `28` `NO-ARTIFACT` | zero objects under the prefix | wrong `--host`/prefix, or the backups are gone — `restore-verify.py` diagnoses which |
 | `29` `AGE-MISSING` | `age` is not on PATH | environment fault; says nothing about the escrow |
 | `30` `ARTIFACT-UNREADABLE` | failed before the key was used | diagnose the object, not the key |
-| `25` `DECRYPT-FAILED` | age wrote **nothing**: wrong key **or** damaged header — **not separable** | re-run `restore-verify.py` with the **on-disk** key; if it also fails, the artifact is the problem. **Do not rotate first.** |
+| `25` `DECRYPT-FAILED` | age wrote **nothing**: wrong key **or** damaged header — **not separable** | try a **different** artifact (`--scope <other>`) with the same escrowed copy: if another opens, the key is fine and this object's header is damaged. **Do not rotate first.** |
 | `33` `ARTIFACT-CORRUPT` | age authenticated the header (**the key worked**) then failed the payload | 🔴 **the backup is TAMPERED/CORRUPT/TRUNCATED.** Check the other retained objects. Do not rotate. |
 | `31` `ARTIFACT-EMPTY` | age exited **zero** on an empty payload (**the key worked**) | the artifact holds nothing; do not rotate |
 | `26` `RESTORE-FAILED` | decrypted fine, the git bundle is bad | artifact fault; do not rotate |
+
+⚠ `27` and `28` are the two most likely to fire in practice (a bucket outage, or
+the `--host` prefix trap `restore-verify.py` documents), and neither is a verdict
+on the escrow.
 
 Measured (age v1.3.1, many offsets and sizes): a wrong key or a damaged header
 leaves **no** plaintext file, while payload corruption and truncation leave one —

--- a/SECRETS.md
+++ b/SECRETS.md
@@ -167,6 +167,45 @@ rc=128 with `error: index-pack died`. `bundle verify` reads the header and the
 prerequisites; it does not walk the pack. The only evidence a backup is
 restorable is having restored it.
 
+#### The key's own escrow — `escrow-verify.py`
+
+Everything above decrypts with **one file**. It is escrowed into the self-hosted
+Vaultwarden as a Secure Note (name: `age.key — SOPS + analyze-service-index
+backups`); `scripts/analyze-service-index/escrow-verify.py` is what re-checks
+that copy, so the escrow does not quietly rot into a second thing that only
+looks intact.
+
+```sh
+# `bw` is deliberately NOT installed on either host.
+nix-shell -p bitwarden-cli jq --run '
+  export BW_SESSION="$(bw unlock --raw)"          # the ONE step nothing can automate
+  python3 scripts/analyze-service-index/escrow-verify.py
+'
+… escrow-verify.py --decrypt-check --host <host label>   # the claim that matters
+… escrow-verify.py --print-plan                          # no bw, no network, no key
+```
+
+Two levels, and they are **different claims**. The default compares the note to
+the on-disk identity **byte for byte** — which proves the two copies agree, and
+proves nothing about either one opening anything. `--decrypt-check` writes the
+**escrowed** bytes to a 0600 throwaway identity (shredded and unlinked on every
+path out, including the failures) and uses *that* to decrypt the newest real
+artifact out of the bucket, via `restore-verify.py`'s own pipeline. The verdict
+line says which of the two you got; it never lets "verified" stand for both.
+
+🔴 **Every cause has its own exit code** (`--print-plan` lists all of them), so a
+timer can act on the number: `12` locked, `13` not logged in, `17` the note is
+GONE, `18` two notes share the name and neither can be trusted, `21` it differs
+only in trailing newlines — still probably usable, re-escrow it — `22` it differs
+materially, `25` the escrowed key does not open the artifacts. It reports **byte
+counts and a classification only, never the differing content**, and it reads the
+server from `bw config server` at run time rather than carrying an endpoint into
+a public repo.
+
+⚠ It cannot unlock the vault and will not try: every `bw` call runs with stdin on
+`/dev/null`, `--nointeraction`, and a timeout, so an unattended run **fails fast
+with exit 12** instead of hanging on an invisible password prompt.
+
 ---
 
 ## Kubeconfigs (`$KC_*` handles from `nix/programs/zsh/default.nix`)

--- a/scripts/analyze-service-index/escrow-verify.py
+++ b/scripts/analyze-service-index/escrow-verify.py
@@ -72,12 +72,20 @@ send the operator hunting for corruption that is not there.
   * `bw`'s stdout is NEVER quoted in an error message. Every subprocess result
     here is handled as redacted by construction — `_run()` has no path that
     interpolates output into an exception.
-  * the throwaway identity written by `--decrypt-check` is 0600 inside a 0700
-    directory, is overwritten and unlinked in a `finally` that covers success,
-    every early return, every refusal and every unexpected exception, and its
-    directory is removed after it. The overwrite is best-effort — on a
-    journalling or copy-on-write filesystem it is not a guarantee and this file
-    does not claim it is; the UNLINK is the part that is tested.
+  * the throwaway identity written by `--decrypt-check` is created FRESH at
+    0600 inside a 0700 directory — `O_EXCL|O_NOFOLLOW` plus an `fchmod` on the
+    fd, because `O_CREAT|O_TRUNC` applies its mode only when it creates and
+    follows a symlink otherwise (measured: a pre-existing 0666 file stayed
+    0666, and a symlink got the key written THROUGH it to a 0644 file outside
+    the 0700 dir). It is overwritten and unlinked in a `finally` that covers
+    success, every early return, every refusal and every unexpected exception,
+    and — since the signal handlers below make SIGTERM/SIGINT/SIGHUP unwind
+    rather than kill — the timer-driven stop path too. The overwrite is
+    best-effort: on a journalling or copy-on-write filesystem it is not a
+    guarantee and this file does not claim it is; the UNLINK is what is tested.
+    ⚠ The WORK DIRECTORY is removed only when this script created it. Under an
+    explicit `--work-dir` the operator's directory is left in place — emptied,
+    not deleted.
 
 🔴 THE ENDPOINT IS NEVER HARDCODED. devrc is a public repo. The server is read
 from `bw config server` at run time. It is cross-checked against the
@@ -85,6 +93,10 @@ authenticated session's own `serverUrl` (a repointed CLI with a stale session is
 a real state this vault has been in), and against `--expect-server` when the
 operator pins one. With no pin the configured server is reported as INFORMATION
 and the run says the pin was absent, rather than implying it checked.
+⚠ The session cross-check CANNOT ALWAYS BE MADE — `bw status` may report
+`serverUrl: null`. When that happens the verdict says `session cross-check NOT
+COMPARED (<reason>)`. It is never silently skipped behind a sentence claiming it
+matched, which is exactly what the first version did.
 
 🔴 THE MASTER PASSWORD CANNOT BE AUTOMATED, so this never tries. `bw status` is
 the authority; a vault that is not `unlocked` ends the run with a distinct code
@@ -103,10 +115,12 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import contextlib
 import importlib.util
 import json
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -187,6 +201,12 @@ EXIT_CODES: dict[str, int] = {
     "ITEM-AMBIGUOUS": 18,
     "ITEM-WRONG-TYPE": 19,
     "NOTE-EMPTY": 20,
+    # 🔴 SEPARATE FROM `NOTE-EMPTY`, and the split matters. `NOTE-EMPTY` says
+    # "the escrow was emptied" and sends the operator to re-escrow. If `bw` ever
+    # OMITS the field rather than returning "", that is a CLI/schema surprise and
+    # the note may be perfectly intact — re-escrowing on that advice would
+    # overwrite a good copy on the strength of a parsing accident.
+    "NOTE-MISSING": 32,
     # the comparison
     "BYTES-DIFFER-TRAILING-NEWLINE": 21,
     "BYTES-DIFFER-MATERIALLY": 22,
@@ -194,8 +214,29 @@ EXIT_CODES: dict[str, int] = {
     "IDENTITY-MISSING": 23,
     "IDENTITY-EMPTY": 24,
     # --decrypt-check
-    "DECRYPT-FAILED": 25,
-    "RESTORE-FAILED": 26,
+    #
+    # 🔴 FIVE OUTCOMES, NOT TWO, AND THE SPLIT IS DERIVED FROM AN OBSERVED PHASE
+    # rather than from the absence of a substring in somebody else's message.
+    # The first version had only DECRYPT-FAILED/RESTORE-FAILED, chosen by
+    # `"DECRYPT FAILED" in str(exc)`, and it was WRONG in three measured cases:
+    #
+    #   * `age` not on PATH          -> RESTORE-FAILED, asserting the escrowed
+    #                                   key "works" and the ARTIFACT is at fault;
+    #   * a zero-BYTE object         -> RESTORE-FAILED, asserting bytes
+    #                                   "DECRYPTED" on a path where the decrypt
+    #                                   step was never reached at all;
+    #   * a valid encryption of NOTHING -> DECRYPT-FAILED, "not a working
+    #                                   identity" — for a key that worked
+    #                                   perfectly. That verdict gets a good
+    #                                   disaster-recovery key ROTATED.
+    #
+    # Two of the three blame the escrow for a fault that is not the escrow's, in
+    # the direction that makes someone act destructively.
+    "AGE-MISSING": 29,          # precondition: the tool is not installed
+    "ARTIFACT-UNREADABLE": 30,  # the pipeline failed BEFORE decrypt was reached
+    "DECRYPT-FAILED": 25,       # age RAN and REFUSED: the escrowed key is wrong
+    "ARTIFACT-EMPTY": 31,       # age SUCCEEDED on nothing: the key is FINE
+    "RESTORE-FAILED": 26,       # decrypt returned: the key WORKS, data is bad
     "STORE-UNREACHABLE": 27,
     "NO-ARTIFACT": 28,
 }
@@ -390,7 +431,19 @@ def _shred(path: Path) -> None:
     milliseconds inside a 0700 directory under the process's own temp root.
     Claiming "securely erased" would be a comment the code cannot support, which
     is the failure this subsystem's rules are most emphatic about.
+
+    🔴 A SYMLINK IS UNLINKED, NEVER FOLLOWED. `open(path, "r+b")` follows one,
+    so the previous version would ZERO THE TARGET and then remove only the link
+    — a truncate-in-place primitive aimed at any path the user can write, left
+    behind as a zero-filled decoy. Measured via `--work-dir`. The link itself is
+    the only thing this function may destroy.
     """
+    try:
+        if path.is_symlink():
+            path.unlink(missing_ok=True)
+            return
+    except OSError:
+        pass
     try:
         size = path.stat().st_size
         with open(path, "r+b") as fh:
@@ -403,6 +456,35 @@ def _shred(path: Path) -> None:
         path.unlink(missing_ok=True)
     except OSError:
         pass
+
+
+def _create_private_file(path: Path) -> int:
+    """Open `path` as a FRESH 0600 regular file. Returns the fd.
+
+    🔴 `O_CREAT|O_TRUNC` APPLIES THE MODE ONLY ON CREATE, and follows a symlink.
+    That made the module's "0600 inside a 0700 directory" claim true only on the
+    path where nothing was there already — and `--work-dir` is precisely the
+    option that hands this a directory somebody else populated. MEASURED:
+
+      * a pre-existing 0666 file RECEIVED the escrowed key and STAYED 0666;
+      * a pre-existing SYMLINK had the key written THROUGH it to a 0644 file
+        OUTSIDE the 0700 directory.
+
+    So: unlink whatever is there (`_shred` above refuses to follow a link),
+    then create with `O_EXCL|O_NOFOLLOW` so the open FAILS rather than reusing
+    or following anything, and `fchmod` the fd we actually hold — the umask can
+    still mask the `os.open` mode argument, and fchmod cannot be redirected.
+    """
+    _shred(path)
+    fd = os.open(path,
+                 os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                 _FILE_MODE)
+    try:
+        os.fchmod(fd, _FILE_MODE)
+    except BaseException:
+        os.close(fd)
+        raise
+    return fd
 
 
 # --------------------------------------------------------------------------- #
@@ -442,6 +524,64 @@ def _rv():
     return mod
 
 
+# 🔴 WHAT THE PROBE BELOW OBSERVES, AND WHY IT IS SOUND — MEASURED, age v1.3.1.
+# `age --decrypt --output PLAIN` was run across every outcome that matters:
+#
+#   wrong key, real payload      rc=1  PLAIN absent
+#   wrong key, empty payload     rc=1  PLAIN absent
+#   corrupt ciphertext           rc=1  PLAIN absent
+#   right key, EMPTY payload     rc=0  PLAIN present, size 0
+#   right key, real payload      rc=0  PLAIN present, size 12
+#
+# So the PRESENCE of the output file at the moment `decrypt()` raises separates
+# the two failures that were previously conflated: age REFUSED (no file — the
+# escrowed key is wrong) versus age SUCCEEDED on nothing (file present, empty —
+# the key is FINE and the artifact is an encryption of nothing, which is exactly
+# what restore-verify's own comment at its zero-byte branch says).
+#
+# ⚠ The inference "no file ⇒ age ran and refused" holds ONLY because
+# `decrypt_check` refuses up front when `age` is not on PATH: without that
+# precondition, restore-verify's own age-missing guard raises before touching
+# PLAIN and would be indistinguishable from a refusal. The two halves are one
+# argument; do not remove either alone.
+@contextlib.contextmanager
+def _decrypt_phase_probe(RV):
+    """Observe HOW FAR restore-verify's decrypt step got. Yields a state dict.
+
+    🔴 THIS IS A PROBE, NOT A REIMPLEMENTATION. It calls the real `decrypt()`
+    and adds nothing to it; all it does is record whether the call was reached,
+    whether it returned, and — at the instant it raises, before
+    `verify_artifact`'s own `finally` unlinks the plaintext — whether `age` left
+    an output file behind. Classification is then derived from an OBSERVED
+    PHASE rather than from a substring of a message this module does not own.
+
+    ⚠ It swaps a module global for the duration, so it is not safe against
+    concurrent use of `restore_verify` in the same process. This is a
+    single-shot CLI that owns its own import; the swap is restored in a
+    `finally`.
+    """
+    state = {"reached": False, "returned": False, "plain_present": None}
+    real = RV.decrypt
+
+    def probe(cipher, plain, identity):
+        state["reached"] = True
+        try:
+            real(cipher, plain, identity)
+        except BaseException:
+            try:
+                state["plain_present"] = Path(plain).exists()
+            except OSError:
+                state["plain_present"] = None
+            raise
+        state["returned"] = True
+
+    RV.decrypt = real if real is None else probe
+    try:
+        yield state
+    finally:
+        RV.decrypt = real
+
+
 # --------------------------------------------------------------------------- #
 # verdict
 # --------------------------------------------------------------------------- #
@@ -455,6 +595,10 @@ class EscrowVerdict:
     disk_bytes: int
     classification: str
     identity: Path
+    # None means the CLI's configured server really WAS compared against the
+    # authenticated session's; a string is the reason it could not be. See
+    # `check_server` — a skipped comparison used to be reported as a passing one.
+    server_session_reason: str | None = None
     decrypt_checked: bool = False
     decrypt_scope: str | None = None
     decrypt_key: str | None = None
@@ -465,10 +609,20 @@ class EscrowVerdict:
         head = (f"{PROG}: escrow OK — the Secure Note matches {self.identity} "
                 f"{self.classification} ({self.escrow_bytes} escrowed bytes vs "
                 f"{self.disk_bytes} on disk)")
-        pin = ("server pinned and matched" if self.server_pinned
+        # 🔴 TWO INDEPENDENT FACTS, NEVER MERGED INTO ONE SENTENCE: whether the
+        # operator PINNED a server, and whether the session cross-check could be
+        # made at all. The old line asserted the second unconditionally while
+        # the code skipped it silently.
+        pin = ("server PINNED and matched" if self.server_pinned
                else "server NOT PINNED (--expect-server / ASIB_ESCROW_SERVER "
-                    "unset) — the CLI's configured server matched the session's, "
-                    "which is all that was checked")
+                    "unset)")
+        if self.server_session_reason is None:
+            session = ("session cross-check RAN: the CLI's configured server "
+                       "matched the authenticated session's")
+        else:
+            session = (f"session cross-check NOT COMPARED "
+                       f"({self.server_session_reason})")
+        pin = f"{pin}; {session}"
         if not self.decrypt_checked:
             return (f"{head}; {pin}; NOT DECRYPT-CHECKED — byte equality proves "
                     f"the two copies agree, NOT that either of them opens an "
@@ -541,19 +695,35 @@ def check_vault_state(bw: BitwardenCLI) -> dict:
         f"clean escrow it never read.")
 
 
-def check_server(bw: BitwardenCLI, status: dict, expect: str | None) -> tuple[str, bool]:
-    """`(configured server, was it pinned)`, or a classified refusal.
+def check_server(bw: BitwardenCLI, status: dict,
+                 expect: str | None) -> tuple[str, bool, str | None]:
+    """`(configured server, was it pinned, why the session was NOT compared)`.
 
     🔴 THE ENDPOINT IS READ, NEVER HARDCODED — devrc is public. Two checks:
 
-      * the CLI's configured server must agree with the AUTHENTICATED SESSION's
-        own `serverUrl`. This vault has actually been repointed once, and a
-        session left over from the old endpoint is a state where every answer
-        below comes from a server the operator no longer thinks they are using.
-        This half needs no pin and always runs.
+      * the CLI's configured server against the AUTHENTICATED SESSION's own
+        `serverUrl`. This vault has actually been repointed once, and a session
+        left over from the old endpoint is a state where every answer below
+        comes from a server the operator no longer thinks they are using.
       * `--expect-server` / `ASIB_ESCROW_SERVER`, when the operator sets one.
-        Absent, the run reports NOT PINNED rather than implying it checked —
-        `server_pinned` is returned so the verdict line can say which.
+        Absent, the run reports NOT PINNED rather than implying it checked.
+
+    🔴 THE SESSION COMPARISON CAN BE UNAVAILABLE, AND SAYING SO IS THE WHOLE
+    POINT. `bw status` may omit `serverUrl` or return `null` (that is what it
+    prints for the official cloud). The first version did
+    `if session_server and …`, which SKIPPED the comparison with no signal
+    whatsoever — while the success verdict went on to print "the CLI's
+    configured server matched the session's, which is all that was checked".
+    Measured twice, exit 0 both times: a check that did not run, reported as a
+    check that passed. The docstring above it even said "this half needs no pin
+    and ALWAYS RUNS", which was simply false.
+
+    So the third return value is the REASON it could not be compared, or None
+    when it really was. `EscrowVerdict.line()` prints the distinction, the same
+    way `restore-verify.py` prints `NOT CROSS-CHECKED (<reason>)` rather than
+    folding an unmeasured scope into the word used for a measured one. It is
+    NOT a hard failure: a vault legitimately reachable without a `serverUrl` in
+    `bw status` must not be a permanently-red gate.
     """
     configured = bw.config_server()
     if not configured:
@@ -562,8 +732,21 @@ def check_server(bw: BitwardenCLI, status: dict, expect: str | None) -> tuple[st
             "`bw config server` printed nothing, so which server answered "
             "cannot be determined. An escrow verified against an unknown server "
             "is an escrow verified against no server in particular.")
-    session_server = (status.get("serverUrl") or "").strip()
-    if session_server and _norm_url(session_server) != _norm_url(configured):
+    raw_session = status.get("serverUrl")
+    session_server = (raw_session or "").strip()
+    if not session_server:
+        why = ("`bw status` reported serverUrl="
+               + ("null" if raw_session is None else "empty")
+               + " — the CLI's configured server could NOT be cross-checked "
+                 "against the authenticated session's")
+        if expect is not None and _norm_url(expect) != _norm_url(configured):
+            raise EscrowError(
+                "SERVER-MISMATCH",
+                "the configured server does not match the one pinned by "
+                "--expect-server / ASIB_ESCROW_SERVER. URLs withheld — this "
+                "repo is public; compare them by hand with `bw config server`.")
+        return configured, expect is not None, why
+    if _norm_url(session_server) != _norm_url(configured):
         raise EscrowError(
             "SERVER-MISMATCH",
             "the CLI's CONFIGURED server and the AUTHENTICATED SESSION's server "
@@ -580,8 +763,8 @@ def check_server(bw: BitwardenCLI, status: dict, expect: str | None) -> tuple[st
                 "--expect-server / ASIB_ESCROW_SERVER. Refusing to report an "
                 "escrow found on a server that is not the one you named — URLs "
                 "withheld, compare them by hand with `bw config server`.")
-        return configured, True
-    return configured, False
+        return configured, True, None
+    return configured, False, None
 
 
 def _norm_url(u: str) -> str:
@@ -637,15 +820,31 @@ def find_escrow_item(bw: BitwardenCLI, item_name: str) -> dict:
 
 
 def read_note(item: dict, item_name: str) -> bytes:
-    """The note body as bytes, or a classified refusal. Never logged."""
-    notes = item.get("notes")
+    """The note body as bytes, or a classified refusal. Never logged.
+
+    🔴 AN ABSENT FIELD IS NOT AN EMPTY VALUE. `item.get("notes")` collapses the
+    two, and they lead to OPPOSITE actions: `NOTE-EMPTY` tells the operator the
+    escrow was emptied and to re-escrow, which — if `bw` merely OMITTED the key
+    for an intact note — overwrites a good copy on the strength of a parsing
+    accident. `"notes" in item` is the whole fix.
+    """
+    if "notes" not in item:
+        raise EscrowError(
+            "NOTE-MISSING",
+            f"the vault item {item_name!r} exists but its payload carries NO "
+            f"`notes` FIELD AT ALL — not an empty one, an absent one. That is a "
+            f"`bw` output-schema surprise, not evidence the escrow was emptied, "
+            f"and the note may be perfectly intact. Do NOT re-escrow on this: "
+            f"read the item in the web vault first.")
+    notes = item["notes"]
     if not isinstance(notes, str) or not notes.strip():
         raise EscrowError(
             "NOTE-EMPTY",
-            f"the vault item {item_name!r} exists but its note body is EMPTY. "
-            f"An empty note lists, syncs and exports exactly like a full one, so "
-            f"this is the quiet way for an escrow to be gone while every count "
-            f"still says it is there.")
+            f"the vault item {item_name!r} exists and its note body is EMPTY "
+            f"(the field is PRESENT and carries nothing). An empty note lists, "
+            f"syncs and exports exactly like a full one, so this is the quiet "
+            f"way for an escrow to be gone while every count still says it is "
+            f"there.")
     return notes.encode("utf-8")
 
 
@@ -678,6 +877,33 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
     """
     RV = _rv()
     prefix = RV.normalise_prefix(prefix)
+
+    # 🔴 A PRECONDITION, CHECKED BEFORE THE STORE IS EVEN OPENED, AND IT IS
+    # LOAD-BEARING TWICE.
+    #
+    #   1. `age` missing is an ENVIRONMENT fault. Left to fall through, it
+    #      surfaced as RESTORE-FAILED — "the escrowed key works, the artifact is
+    #      at fault" — three false claims in one sentence, sending the operator
+    #      to `restore-verify.py`, where it fails identically for the same
+    #      reason nobody has named yet.
+    #   2. It is what makes the phase probe's inference sound. restore-verify's
+    #      `decrypt()` checks `age` on PATH FIRST and raises before touching the
+    #      output file, so without this an age-missing failure would be
+    #      indistinguishable from "age ran and refused" — the two would share
+    #      DECRYPT-FAILED and blame the escrow for a missing package.
+    #
+    # This duplicates restore-verify's own check by design: the point is not to
+    # guard the call (it guards itself) but to CLASSIFY the cause here, where
+    # the exit code is chosen.
+    if shutil.which("age") is None:
+        raise EscrowError(
+            "AGE-MISSING",
+            "`age` is not on PATH, so the escrowed key cannot be tested against "
+            "anything. This is an ENVIRONMENT fault and says NOTHING about the "
+            "escrow — do not read it as a verdict on the key or on the "
+            "artifacts. age is declared in nix/pkgs/default.nix and in "
+            "flake.nix `gateTools`; add it there, or run this whole command "
+            "under nix.")
 
     if downloader_factory is not None:
         factory = downloader_factory
@@ -741,46 +967,66 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
         restore_dir = B._private_dir(work_dir / RESTORE_SUBDIR)
         identity = work_dir / ESCROW_IDENTITY_FILENAME
         try:
-            # 🔴 0600 BEFORE THE BYTES. `os.open` with the mode is the only
-            # ordering with no window: `write_bytes()` then `chmod()` leaves the
-            # key world-readable for however long the write takes. The 0700
-            # directory bounds it either way; this makes the file's own mode
-            # true from its first byte rather than shortly after.
-            fd = os.open(identity, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, _FILE_MODE)
-            with os.fdopen(fd, "wb") as fh:
+            # 🔴 0600 BEFORE THE BYTES, on a file that cannot be a pre-existing
+            # one or a symlink. See `_create_private_file` for the two measured
+            # ways the previous `O_CREAT|O_TRUNC` spelling left the mode claim
+            # false.
+            with os.fdopen(_create_private_file(identity), "wb") as fh:
                 fh.write(escrow_bytes)
 
             try:
-                v = RV.verify_artifact(
-                    downloader, key, scope=scope, stamp=stamp,
-                    identity=identity, work_dir=restore_dir, store=store,
-                    keep=False, now=now, live_scope=live,
-                    no_live_reason=no_live_reason)
+                with _decrypt_phase_probe(RV) as phase:
+                    v = RV.verify_artifact(
+                        downloader, key, scope=scope, stamp=stamp,
+                        identity=identity, work_dir=restore_dir, store=store,
+                        keep=False, now=now, live_scope=live,
+                        no_live_reason=no_live_reason)
             except RV.RestoreVerifyError as exc:
-                # 🔴 TWO OUTCOMES, TWO TOKENS. "the escrowed key does not open
-                # it" is a KEY fault; "the bytes do not reconstruct" is DATA
-                # loss, and it would be reported identically by a run using the
-                # on-disk key. Only the first says anything about the escrow.
-                #
-                # The discriminator is the restore verifier's OWN literal token,
-                # `DECRYPT FAILED`, which it emits from `decrypt()` and nowhere
-                # else and which its test suite pins. Both branches are measured
-                # here by the test suite too — a corrupted KEY and a corrupted
-                # ARTIFACT, at two points, so the classifier is shown to
-                # discriminate rather than assumed to.
-                if "DECRYPT FAILED" in str(exc):
+                # 🔴 CLASSIFIED BY THE PHASE THAT WAS OBSERVED, NOT BY A
+                # SUBSTRING. Each branch asserts only what `phase` actually
+                # witnessed; nothing here says "DECRYPTED" on a path where
+                # `decrypt()` was not reached, and nothing blames the escrow for
+                # a fault the escrow cannot have caused.
+                if not phase["reached"]:
+                    raise EscrowError(
+                        "ARTIFACT-UNREADABLE",
+                        f"the pipeline failed BEFORE the escrowed key was ever "
+                        f"used, on {key}: {exc} — an empty or unreadable object, "
+                        f"not a fact about the escrow. NOTHING here decrypted, "
+                        f"and nothing here is evidence for or against the "
+                        f"escrowed key. Run `restore-verify.py` to diagnose the "
+                        f"object.")
+                if not phase["returned"]:
+                    if phase["plain_present"]:
+                        # age exited 0 and produced an EMPTY plaintext. Measured:
+                        # a refusal leaves NO output file, so a file that exists
+                        # means the key opened it. restore-verify's own comment
+                        # at that branch says the same: "age reported success, so
+                        # this is not damage — it is a valid encryption of
+                        # nothing."
+                        raise EscrowError(
+                            "ARTIFACT-EMPTY",
+                            f"the ESCROWED key OPENED {key} and the artifact "
+                            f"contains NOTHING: {exc}. 🔴 THE ESCROW IS FINE — "
+                            f"age reported success and produced an output file, "
+                            f"which a wrong key cannot do. Do NOT re-escrow or "
+                            f"rotate on the strength of this; the fault is a "
+                            f"valid encryption of an empty payload. Run "
+                            f"`restore-verify.py` to diagnose the artifact.")
                     raise EscrowError(
                         "DECRYPT-FAILED",
-                        f"the ESCROWED bytes do NOT open {key}: {exc} — the "
+                        f"the ESCROWED bytes do NOT open {key}: {exc} — age ran "
+                        f"and REFUSED it, leaving no plaintext at all. The "
                         f"escrow is present but it is not (or no longer) a "
                         f"working identity for these artifacts. Nothing here "
                         f"says the artifacts are damaged; the on-disk key was "
                         f"not used.")
                 raise EscrowError(
                     "RESTORE-FAILED",
-                    f"the ESCROWED bytes DECRYPTED {key} and the restore then "
-                    f"failed: {exc} — this is a fault in the ARTIFACT, not in "
-                    f"the escrow. The escrowed key works; run "
+                    f"the ESCROWED bytes DECRYPTED {key} — `decrypt()` RETURNED, "
+                    f"which is what makes that claim observable — and the "
+                    f"restore then failed: {exc}. This is a fault in the "
+                    f"ARTIFACT, not in the escrow. The escrowed key works; run "
                     f"`restore-verify.py` to diagnose the artifact.")
             return scope, key, v.commits_restored, v.refs_restored
         finally:
@@ -815,7 +1061,7 @@ def run(*, bw: BitwardenCLI, identity: Path, item_name: str,
 
     bw.require_available()
     status = check_vault_state(bw)
-    server, pinned = check_server(bw, status, expect_server)
+    server, pinned, session_reason = check_server(bw, status, expect_server)
     item = find_escrow_item(bw, item_name)
     escrow = read_note(item, item_name)
 
@@ -845,6 +1091,7 @@ def run(*, bw: BitwardenCLI, identity: Path, item_name: str,
 
     verdict = EscrowVerdict(
         item_name=item_name, server=server, server_pinned=pinned,
+        server_session_reason=session_reason,
         escrow_bytes=len(escrow), disk_bytes=len(disk),
         classification=verdict_class, identity=identity,
     )
@@ -917,7 +1164,51 @@ def print_plan(*, identity: Path, item_name: str, expect_server: str | None,
     print(f"exit codes: {', '.join(f'{t}={c}' for t, c in sorted(EXIT_CODES.items(), key=lambda kv: kv[1]))}")
 
 
+# 🔴 SIGNALS THAT MUST NOT SKIP THE SHRED. Python's DEFAULT SIGTERM handling
+# terminates the process WITHOUT unwinding, so every `finally` in this file is
+# bypassed. MEASURED: SIGTERM during `--decrypt-check` left
+# `escrowed-identity.key` on disk at full size, byte-identical to the operator's
+# real age identity, and `TemporaryDirectory` did not clean up either.
+#
+# That is not a theoretical window. SECRETS.md proposes running this from a
+# systemd timer, and systemd's stop/timeout path IS SIGTERM — so the documented
+# deployment is the one that leaks.
+#
+# Turning the signal into `SystemExit` makes the interpreter unwind normally, so
+# the `finally` that shreds the throwaway identity runs. The exit status keeps
+# the shell convention (128 + signal number) rather than colliding with a
+# classified escrow verdict.
+_FATAL_SIGNALS = ("SIGTERM", "SIGINT", "SIGHUP")
+
+
+def install_signal_handlers() -> list[str]:
+    """Make fatal signals unwind instead of killing. Returns the names installed.
+
+    Returns the list so a caller — and the test suite — can assert WHICH signals
+    were covered rather than that the function was called. A signal missing from
+    `_FATAL_SIGNALS` is a path where the key survives.
+    """
+    installed: list[str] = []
+
+    def _raise(signum, _frame):
+        raise SystemExit(128 + signum)
+
+    for name in _FATAL_SIGNALS:
+        sig = getattr(signal, name, None)
+        if sig is None:                      # not on this platform
+            continue
+        try:
+            signal.signal(sig, _raise)
+        except (OSError, ValueError):        # not the main thread, or blocked
+            continue
+        installed.append(name)
+    return installed
+
+
 def main(argv: list[str] | None = None) -> int:
+    # BEFORE any work: the window this closes opens the moment a throwaway
+    # identity exists, and argument parsing can itself be interrupted.
+    install_signal_handlers()
     ap = argparse.ArgumentParser(prog=PROG, description=__doc__)
     ap.add_argument("--identity", type=Path, default=None,
                     help=f"age identity to compare against (default: "

--- a/scripts/analyze-service-index/escrow-verify.py
+++ b/scripts/analyze-service-index/escrow-verify.py
@@ -972,10 +972,15 @@ def main(argv: list[str] | None = None) -> int:
 
     bw = BitwardenCLI(bw=args.bw, timeout=args.timeout)
 
+    # `source`, not `bucket`: with `--from-dir` it is a local directory, and a
+    # NO-ARTIFACT message naming a bucket nobody queried would send the reader
+    # to look in the wrong place. Same convention as restore-verify.py.
+    source = str(args.from_dir) if args.from_dir is not None else args.bucket
+
     def _go(work: Path | None) -> EscrowVerdict:
         return run(bw=bw, identity=identity, item_name=args.item_name,
                    expect_server=args.expect_server, decrypt=args.decrypt,
-                   bucket=args.bucket, prefix=prefix, store=args.store,
+                   bucket=source, prefix=prefix, store=args.store,
                    scope_filter=args.scope, from_dir=args.from_dir,
                    work_dir=work)
 

--- a/scripts/analyze-service-index/escrow-verify.py
+++ b/scripts/analyze-service-index/escrow-verify.py
@@ -235,10 +235,19 @@ EXIT_CODES: dict[str, int] = {
     #
     # Two of the three blame the escrow for a fault that is not the escrow's, in
     # the direction that makes someone act destructively.
+    # 🔴 AND A SIXTH, ADDED AFTER RE-MEASURING age: `ARTIFACT-CORRUPT`. The
+    # five-way version reported a TAMPERED or TRUNCATED artifact as
+    # `ARTIFACT-EMPTY` — "THE ESCROW IS FINE … a valid encryption of an empty
+    # payload" — because it read file PRESENCE as "age reported success". It does
+    # not: age writes output before authenticating the payload. Detecting
+    # tampering is the single most important thing a backup verifier does, and
+    # that spelling reported it as nothing to worry about.
     "AGE-MISSING": 29,          # precondition: the tool is not installed
     "ARTIFACT-UNREADABLE": 30,  # the pipeline failed BEFORE decrypt was reached
-    "DECRYPT-FAILED": 25,       # age RAN and REFUSED: the escrowed key is wrong
-    "ARTIFACT-EMPTY": 31,       # age SUCCEEDED on nothing: the key is FINE
+    "DECRYPT-FAILED": 25,       # age wrote NOTHING: wrong key OR damaged header
+    "ARTIFACT-CORRUPT": 33,     # age authenticated the HEADER then failed the
+                                #   payload: the key WORKED, the bytes are bad
+    "ARTIFACT-EMPTY": 31,       # age exited ZERO on nothing: the key is FINE
     "RESTORE-FAILED": 26,       # decrypt returned: the key WORKS, data is bad
     "STORE-UNREACHABLE": 27,
     "NO-ARTIFACT": 28,
@@ -246,6 +255,10 @@ EXIT_CODES: dict[str, int] = {
 
 # The three answers a byte comparison may give. Named constants because the test
 # suite pins the literal strings and a verdict is a machine-readable claim.
+# A sentinel distinct from None, so "the key is absent" and "the key is present
+# and null" can be told apart where that matters.
+_ABSENT = object()
+
 CLASS_IDENTICAL = "IDENTICAL"
 CLASS_TRAILING_NEWLINE = "DIFFERS-TRAILING-NEWLINE-ONLY"
 CLASS_MATERIAL = "DIFFERS-MATERIALLY"
@@ -261,21 +274,34 @@ class EscrowError(B.BackupError):
     🔴 The exit code is DERIVED from the token via `EXIT_CODES`, never passed in.
     A constructor that accepted both could raise a token with the wrong code, and
     that is precisely the conflation this class exists to prevent.
+
+    🔴 `verdict` AND `detail` ARE SEPARATE FIELDS, so the sentence THIS module
+    asserts can be pinned by exact equality while the part it does not own —
+    another module's message, an age exit code, a stderr fragment whose wording
+    varies run to run — stays out of the pin.
+
+    That split exists because a test asserting `"THE ESCROW IS FINE" in msg`
+    passed unchanged on a TAMPERED artifact, certifying a sentence that was
+    false on the very run it tested. A substring cannot tell a true message from
+    a confident wrong one; exact equality on the owned half can.
     """
 
-    def __init__(self, token: str, message: str):
+    def __init__(self, token: str, verdict: str, detail: str | None = None):
         if token not in EXIT_CODES:
             raise KeyError(
                 f"{token!r} is not in EXIT_CODES. Every refusal in this script "
                 f"is an ENUMERATED cause with its own exit code; adding one "
                 f"means adding it to the table in the same commit as the test "
                 f"that pins it.")
-        super().__init__(message)
+        super().__init__(verdict)
         self.token = token
+        self.verdict = verdict
+        self.detail = detail
         self.exit_code = EXIT_CODES[token]
 
     def __str__(self) -> str:
-        return f"{self.token}: {super().__str__()}"
+        base = f"{self.token}: {self.verdict}"
+        return f"{base} [upstream: {self.detail}]" if self.detail else base
 
 
 # --------------------------------------------------------------------------- #
@@ -443,7 +469,17 @@ def _shred(path: Path) -> None:
     """
     try:
         if path.is_symlink():
-            path.unlink(missing_ok=True)
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                # 🔴 `return`, NOT fall-through. A bare `except OSError: pass`
+                # here dropped into the `open(path, "r+b")` below — which
+                # FOLLOWS the link and zeroes the target: the exact
+                # truncate-in-place primitive this branch exists to remove,
+                # reachable whenever the unlink fails (a read-only directory, a
+                # race). The docstring's "the link itself is the only thing this
+                # function may destroy" was false on that path.
+                pass
             return
     except OSError:
         pass
@@ -527,26 +563,44 @@ def _rv():
     return mod
 
 
-# 🔴 WHAT THE PROBE BELOW OBSERVES, AND WHY IT IS SOUND — MEASURED, age v1.3.1.
-# `age --decrypt --output PLAIN` was run across every outcome that matters:
+# 🔴 WHAT THE PROBE BELOW OBSERVES — RE-MEASURED, age v1.3.1, MANY SAMPLES.
 #
-#   wrong key, real payload      rc=1  PLAIN absent
-#   wrong key, empty payload     rc=1  PLAIN absent
-#   corrupt ciphertext           rc=1  PLAIN absent
-#   right key, EMPTY payload     rc=0  PLAIN present, size 0
-#   right key, real payload      rc=0  PLAIN present, size 12
+# An earlier round wrote down "corrupt ciphertext -> rc=1, PLAIN absent" from a
+# SINGLE corrupted offset and built the classifier on it. That is false, and the
+# way it is false is the worst possible one: a TAMPERED artifact was reported as
+# `ARTIFACT-EMPTY` — "THE ESCROW IS FINE … a valid encryption of an empty
+# payload" — while quoting age's own "may be corrupted or tampered with" in the
+# same sentence. Detecting tampering is the single most important thing a backup
+# verifier does. One measurement is not a general claim; here is the general one:
 #
-# So the PRESENCE of the output file at the moment `decrypt()` raises separates
-# the two failures that were previously conflated: age REFUSED (no file — the
-# escrowed key is wrong) versus age SUCCEEDED on nothing (file present, empty —
-# the key is FINE and the artifact is an encryption of nothing, which is exactly
-# what restore-verify's own comment at its zero-byte branch says).
+#   WRONG KEY          5 payload sizes (0 B … 2 MB)      rc=1  PLAIN **ABSENT**
+#   HEADER corrupt     2 sizes                           rc=1  PLAIN **ABSENT**
+#   PAYLOAD corrupt    8 offsets x 4 sizes               rc=1  PLAIN PRESENT
+#                                                              (size 0 or partial)
+#   TRUNCATED          3 sizes                           rc=1  PLAIN PRESENT
+#   valid enc of NOTHING                                 rc=0  PLAIN PRESENT, 0
+#   intact                                               rc=0  PLAIN PRESENT, N
 #
-# ⚠ The inference "no file ⇒ age ran and refused" holds ONLY because
-# `decrypt_check` refuses up front when `age` is not on PATH: without that
-# precondition, restore-verify's own age-missing guard raises before touching
-# PLAIN and would be indistinguishable from a refusal. The two halves are one
-# argument; do not remove either alone.
+# ⚠ A no-op mutation nearly produced a second false table: writing 0xff over a
+# byte that was ALREADY 0xff left one sample reading rc=0, which would have said
+# age fails to detect tampering. Re-run with a guaranteed bit flip (XOR 0xFF),
+# all 8 offsets give rc=1. Verify the mutation actually mutates.
+#
+# TWO CONSEQUENCES, BOTH LOAD-BEARING:
+#
+#  1. `plain_present` CANNOT separate "valid encryption of nothing" from
+#     "corrupt payload" — both are PRESENT at size 0. So the rc==0 / rc!=0 split
+#     has to come from the module that knows, and it does:
+#     `restore_verify.DECRYPT_*` causes, published as values.
+#  2. Within a NON-ZERO age exit, file presence IS meaningful and is the only
+#     thing that separates a KEY fault from a DATA fault:
+#       * PLAIN ABSENT  -> age never wrote anything: the identity did not match
+#                          the recipients, OR the header is damaged. NOT
+#                          separable from outside, so neither is asserted.
+#       * PLAIN PRESENT -> age AUTHENTICATED THE HEADER, which requires the
+#                          identity to match, and then failed on a payload chunk
+#                          or ran out of input. The escrowed key WORKED; the
+#                          artifact is tampered, corrupt or truncated.
 @contextlib.contextmanager
 def _decrypt_phase_probe(RV):
     """Observe HOW FAR restore-verify's decrypt step got. Yields a state dict.
@@ -563,22 +617,26 @@ def _decrypt_phase_probe(RV):
     single-shot CLI that owns its own import; the swap is restored in a
     `finally`.
     """
-    state = {"reached": False, "returned": False, "plain_present": None}
+    state = {"reached": False, "returned": False, "plain_present": None,
+             "cause": None}
     real = RV.decrypt
 
     def probe(cipher, plain, identity):
         state["reached"] = True
         try:
             real(cipher, plain, identity)
-        except BaseException:
-            try:
-                state["plain_present"] = Path(plain).exists()
-            except OSError:
-                state["plain_present"] = None
+        except BaseException as exc:
+            # `Path.exists()` swallows OSError internally and returns False, so
+            # there is deliberately no try/except here — one would be dead.
+            state["plain_present"] = Path(plain).exists()
+            # The rc==0-vs-rc!=0 split, taken as a VALUE from the module that
+            # owns it. `getattr` because a non-RestoreVerifyError has no cause;
+            # None then means "no published cause", never a default one.
+            state["cause"] = getattr(exc, "cause", None)
             raise
         state["returned"] = True
 
-    RV.decrypt = real if real is None else probe
+    RV.decrypt = probe
     try:
         yield state
     finally:
@@ -735,6 +793,13 @@ def check_server(bw: BitwardenCLI, status: dict,
             "`bw config server` printed nothing, so which server answered "
             "cannot be determined. An escrow verified against an unknown server "
             "is an escrow verified against no server in particular.")
+    # 🔴 THE PIN CHECK LIVES IN EXACTLY ONE PLACE. It was open-coded at two
+    # sites — the session-unavailable early return and the normal path — with
+    # DIFFERENT WORDING for the same refusal, which is how one copy drifts and
+    # the disagreement becomes inaudible. Hoisted above both branches, so it
+    # cannot be skipped by whichever path is taken.
+    _refuse_unless_pin_matches(expect, configured)
+
     raw_session = status.get("serverUrl")
     session_server = (raw_session or "").strip()
     if not session_server:
@@ -742,12 +807,6 @@ def check_server(bw: BitwardenCLI, status: dict,
                + ("null" if raw_session is None else "empty")
                + " — the CLI's configured server could NOT be cross-checked "
                  "against the authenticated session's")
-        if expect is not None and _norm_url(expect) != _norm_url(configured):
-            raise EscrowError(
-                "SERVER-MISMATCH",
-                "the configured server does not match the one pinned by "
-                "--expect-server / ASIB_ESCROW_SERVER. URLs withheld — this "
-                "repo is public; compare them by hand with `bw config server`.")
         return configured, expect is not None, why
     if _norm_url(session_server) != _norm_url(configured):
         raise EscrowError(
@@ -758,16 +817,19 @@ def check_server(bw: BitwardenCLI, status: dict,
             "this repo is public and messages from it end up pasted into it.) "
             "Re-run `bw config server` and `bw status` by hand to see both, "
             "then `bw logout` and log in against the intended one.")
-    if expect is not None:
-        if _norm_url(expect) != _norm_url(configured):
-            raise EscrowError(
-                "SERVER-MISMATCH",
-                "the configured server does not match the one pinned by "
-                "--expect-server / ASIB_ESCROW_SERVER. Refusing to report an "
-                "escrow found on a server that is not the one you named — URLs "
-                "withheld, compare them by hand with `bw config server`.")
-        return configured, True, None
-    return configured, False, None
+    return configured, expect is not None, None
+
+
+def _refuse_unless_pin_matches(expect: str | None, configured: str) -> None:
+    """The `--expect-server` pin, in ONE place. No-op when nothing is pinned."""
+    if expect is None or _norm_url(expect) == _norm_url(configured):
+        return
+    raise EscrowError(
+        "SERVER-MISMATCH",
+        "the configured server does not match the one pinned by "
+        "--expect-server / ASIB_ESCROW_SERVER. Refusing to report an escrow "
+        "found on a server that is not the one you named — URLs withheld, this "
+        "repo is public; compare them by hand with `bw config server`.")
 
 
 def _norm_url(u: str) -> str:
@@ -831,12 +893,18 @@ def read_note(item: dict, item_name: str) -> bytes:
     for an intact note — overwrites a good copy on the strength of a parsing
     accident. `"notes" in item` is the whole fix.
     """
-    if "notes" not in item:
+    # 🔴 ABSENT **OR** NULL. JSON's shape for "this item has no notes" is almost
+    # certainly `{"notes": null}`, not an omitted key — the very shape this
+    # module already handles for `serverUrl` in `check_server`. Splitting on
+    # `"notes" not in item` alone let a null fall through to `NOTE-EMPTY`, i.e.
+    # straight back to the "re-escrow over a good copy" advice this token was
+    # created to prevent.
+    if item.get("notes", _ABSENT) is _ABSENT or item.get("notes") is None:
         raise EscrowError(
             "NOTE-MISSING",
             f"the vault item {item_name!r} exists but its payload carries NO "
-            f"`notes` FIELD AT ALL — not an empty one, an absent one. That is a "
-            f"`bw` output-schema surprise, not evidence the escrow was emptied, "
+            f"`notes` VALUE — the field is absent or null, not empty. That is a "
+            f"`bw` output-schema answer, not evidence the escrow was emptied, "
             f"and the note may be perfectly intact. Do NOT re-escrow on this: "
             f"read the item in the web vault first.")
     notes = item["notes"]
@@ -927,9 +995,10 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
         # classification depend on wording somebody else owns.
         raise EscrowError(
             "STORE-UNREACHABLE",
-            f"could not open the artifact store to test the escrowed key "
-            f"({type(exc).__name__}: {exc}). NOTHING about the escrow was "
-            f"proven by this run beyond the byte comparison above.")
+            "could not open the artifact store to test the escrowed key. "
+            "NOTHING about the escrow was proven by this run beyond the byte "
+            "comparison above.",
+            detail=f"{type(exc).__name__}: {exc}")
 
     try:
         keys = sorted(downloader.list(prefix))
@@ -1005,45 +1074,82 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
                         raise EscrowError(
                             "ARTIFACT-UNREADABLE",
                             f"the pipeline failed BEFORE the escrowed key was "
-                            f"ever used, on {key}: {exc} — an empty or "
-                            f"unreadable object, not a fact about the escrow. "
-                            f"NOTHING here decrypted, and nothing here is "
-                            f"evidence for or against the escrowed key. Run "
-                            f"`restore-verify.py` to diagnose the object.")
+                            f"ever used, on {key} — an empty or unreadable "
+                            f"object, not a fact about the escrow. NOTHING here "
+                            f"decrypted, and nothing here is evidence for or "
+                            f"against the escrowed key. Run `restore-verify.py` "
+                            f"to diagnose the object.",
+                            detail=str(exc))
+                    if phase["cause"] == RV.DECRYPT_AGE_MISSING:
+                        # Belt: the precondition at the top of `decrypt_check`
+                        # normally wins, so this is reachable only if `age`
+                        # disappears mid-run. It must never be read as a verdict
+                        # on the escrow.
+                        raise EscrowError(
+                            "AGE-MISSING",
+                            "`age` vanished between the precondition check and "
+                            "the decrypt call, so the escrowed key was never "
+                            "tested. This is an ENVIRONMENT fault and says "
+                            "NOTHING about the escrow or the artifacts.",
+                            detail=str(exc))
                     if not phase["returned"]:
-                        if phase["plain_present"]:
-                            # age exited 0 and produced an EMPTY plaintext.
-                            # Measured: a refusal leaves NO output file, so a
-                            # file that exists means the key opened it.
-                            # restore-verify's own comment at that branch says
-                            # the same: "age reported success, so this is not
-                            # damage — it is a valid encryption of nothing."
+                        # 🔴 `returned == False` MEANS `decrypt()` RAISED. The
+                        # previous version's comment here read "age exited 0 and
+                        # produced an EMPTY plaintext" — contradicting its own
+                        # enclosing condition, and that contradiction is exactly
+                        # where the tampered-artifact bug lived. Which of age's
+                        # two failure branches fired is taken as a VALUE from
+                        # restore-verify, never inferred from file presence.
+                        if phase["cause"] == RV.DECRYPT_EMPTY_PLAINTEXT:
                             raise EscrowError(
                                 "ARTIFACT-EMPTY",
                                 f"the ESCROWED key OPENED {key} and the artifact "
-                                f"contains NOTHING: {exc}. 🔴 THE ESCROW IS FINE "
-                                f"— age reported success and produced an output "
-                                f"file, which a wrong key cannot do. Do NOT "
-                                f"re-escrow or rotate on the strength of this; "
-                                f"the fault is a valid encryption of an empty "
-                                f"payload. Run `restore-verify.py` to diagnose "
-                                f"the artifact.")
+                                f"contains NOTHING. 🔴 THE ESCROW IS FINE — age "
+                                f"exited ZERO, which a wrong key cannot make it "
+                                f"do; the payload is a valid encryption of an "
+                                f"empty file. Do NOT re-escrow or rotate on the "
+                                f"strength of this. Run `restore-verify.py` to "
+                                f"diagnose the artifact.",
+                                detail=str(exc))
+                        if phase["plain_present"]:
+                            # age exited NON-ZERO having already written output.
+                            # Measured across 8 offsets x 4 sizes plus 3
+                            # truncations: reaching the payload at all means age
+                            # authenticated the HEADER, which requires the
+                            # identity to match. So the key worked and the bytes
+                            # did not.
+                            raise EscrowError(
+                                "ARTIFACT-CORRUPT",
+                                f"🔴 {key} is TAMPERED, CORRUPT or TRUNCATED. age "
+                                f"authenticated the header with the ESCROWED key "
+                                f"— which a non-matching identity cannot do — "
+                                f"began writing plaintext, and then FAILED on the "
+                                f"payload. THE ESCROW IS FINE; THE BACKUP IS NOT. "
+                                f"This is the finding a backup verifier exists to "
+                                f"make: treat the artifact as unusable, check the "
+                                f"other retained objects for this scope, and do "
+                                f"NOT rotate the key.",
+                                detail=str(exc))
                         raise EscrowError(
                             "DECRYPT-FAILED",
-                            f"the ESCROWED bytes do NOT open {key}: {exc} — age "
-                            f"ran and REFUSED it, leaving no plaintext at all. "
-                            f"The escrow is present but it is not (or no longer) "
-                            f"a working identity for these artifacts. Nothing "
-                            f"here says the artifacts are damaged; the on-disk "
-                            f"key was not used.")
+                            f"age REFUSED {key} without writing any plaintext at "
+                            f"all. TWO CAUSES PRODUCE THIS AND THEY ARE NOT "
+                            f"SEPARABLE FROM HERE: the escrowed identity does not "
+                            f"match this artifact's recipients, or the artifact's "
+                            f"HEADER is damaged. Neither is asserted. To tell "
+                            f"them apart, run `restore-verify.py` with the "
+                            f"ON-DISK identity: if that fails too the artifact is "
+                            f"the problem, not the escrow. Do NOT rotate the key "
+                            f"before doing that.",
+                            detail=str(exc))
                     raise EscrowError(
                         "RESTORE-FAILED",
                         f"the ESCROWED bytes DECRYPTED {key} — `decrypt()` "
                         f"RETURNED, which is what makes that claim observable — "
-                        f"and the restore then failed: {exc}. This is a fault in "
-                        f"the ARTIFACT, not in the escrow. The escrowed key "
-                        f"works; run `restore-verify.py` to diagnose the "
-                        f"artifact.")
+                        f"and the restore then failed. This is a fault in the "
+                        f"ARTIFACT, not in the escrow. The escrowed key works; "
+                        f"run `restore-verify.py` to diagnose the artifact.",
+                        detail=str(exc))
                 return scope, key, v.commits_restored, v.refs_restored
         finally:
             # 🔴 EVERY PATH OUT: success, either classified failure, and any

--- a/scripts/analyze-service-index/escrow-verify.py
+++ b/scripts/analyze-service-index/escrow-verify.py
@@ -169,7 +169,10 @@ DEFAULT_TIMEOUT = 60.0
 # the failure message can hand it over instead of dying on FileNotFoundError.
 NIX_SHELL_HINT = "nix-shell -p bitwarden-cli jq --run '<command>'"
 
-_DIR_MODE = B._DIR_MODE      # 0700
+# 🔴 THERE IS DELIBERATELY NO `_DIR_MODE` ALIAS HERE. Directory mode is enforced
+# by `B._private_dir()`, which owns the number; re-exporting it would be a second
+# name for one constant, and an unused one at that. `_FILE_MODE` earns its keep
+# because `_create_private_file()` passes it to `os.open` and `os.fchmod`.
 _FILE_MODE = B._FILE_MODE    # 0600
 
 # --------------------------------------------------------------------------- #
@@ -974,61 +977,74 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
             with os.fdopen(_create_private_file(identity), "wb") as fh:
                 fh.write(escrow_bytes)
 
-            try:
-                with _decrypt_phase_probe(RV) as phase:
+            # 🔴 THE HANDLER LIVES INSIDE THE `with`, NOT AFTER IT — so `phase`
+            # is bound before the `try` is ever entered and CANNOT be read
+            # unbound. Written the other way round (handler outside the `with`)
+            # the only unbound path needed `__enter__` to raise
+            # `RestoreVerifyError`, which its setup cannot do — unreachable, and
+            # left alone it would have been an `UnboundLocalError` MASKING the
+            # real exception in the one classifier whose whole purpose is to stop
+            # confidently-wrong verdicts. A context manager's `__enter__` is a
+            # recurring blind spot in this subsystem (the sibling file's
+            # `MinioArchive.__enter__` was the same shape), so the class is
+            # removed by structure rather than argued away as unreachable.
+            with _decrypt_phase_probe(RV) as phase:
+                try:
                     v = RV.verify_artifact(
                         downloader, key, scope=scope, stamp=stamp,
                         identity=identity, work_dir=restore_dir, store=store,
                         keep=False, now=now, live_scope=live,
                         no_live_reason=no_live_reason)
-            except RV.RestoreVerifyError as exc:
-                # 🔴 CLASSIFIED BY THE PHASE THAT WAS OBSERVED, NOT BY A
-                # SUBSTRING. Each branch asserts only what `phase` actually
-                # witnessed; nothing here says "DECRYPTED" on a path where
-                # `decrypt()` was not reached, and nothing blames the escrow for
-                # a fault the escrow cannot have caused.
-                if not phase["reached"]:
-                    raise EscrowError(
-                        "ARTIFACT-UNREADABLE",
-                        f"the pipeline failed BEFORE the escrowed key was ever "
-                        f"used, on {key}: {exc} — an empty or unreadable object, "
-                        f"not a fact about the escrow. NOTHING here decrypted, "
-                        f"and nothing here is evidence for or against the "
-                        f"escrowed key. Run `restore-verify.py` to diagnose the "
-                        f"object.")
-                if not phase["returned"]:
-                    if phase["plain_present"]:
-                        # age exited 0 and produced an EMPTY plaintext. Measured:
-                        # a refusal leaves NO output file, so a file that exists
-                        # means the key opened it. restore-verify's own comment
-                        # at that branch says the same: "age reported success, so
-                        # this is not damage — it is a valid encryption of
-                        # nothing."
+                except RV.RestoreVerifyError as exc:
+                    # 🔴 CLASSIFIED BY THE PHASE THAT WAS OBSERVED, NOT BY A
+                    # SUBSTRING. Each branch asserts only what `phase` actually
+                    # witnessed; nothing here says "DECRYPTED" on a path where
+                    # `decrypt()` was not reached, and nothing blames the escrow
+                    # for a fault the escrow cannot have caused.
+                    if not phase["reached"]:
                         raise EscrowError(
-                            "ARTIFACT-EMPTY",
-                            f"the ESCROWED key OPENED {key} and the artifact "
-                            f"contains NOTHING: {exc}. 🔴 THE ESCROW IS FINE — "
-                            f"age reported success and produced an output file, "
-                            f"which a wrong key cannot do. Do NOT re-escrow or "
-                            f"rotate on the strength of this; the fault is a "
-                            f"valid encryption of an empty payload. Run "
-                            f"`restore-verify.py` to diagnose the artifact.")
+                            "ARTIFACT-UNREADABLE",
+                            f"the pipeline failed BEFORE the escrowed key was "
+                            f"ever used, on {key}: {exc} — an empty or "
+                            f"unreadable object, not a fact about the escrow. "
+                            f"NOTHING here decrypted, and nothing here is "
+                            f"evidence for or against the escrowed key. Run "
+                            f"`restore-verify.py` to diagnose the object.")
+                    if not phase["returned"]:
+                        if phase["plain_present"]:
+                            # age exited 0 and produced an EMPTY plaintext.
+                            # Measured: a refusal leaves NO output file, so a
+                            # file that exists means the key opened it.
+                            # restore-verify's own comment at that branch says
+                            # the same: "age reported success, so this is not
+                            # damage — it is a valid encryption of nothing."
+                            raise EscrowError(
+                                "ARTIFACT-EMPTY",
+                                f"the ESCROWED key OPENED {key} and the artifact "
+                                f"contains NOTHING: {exc}. 🔴 THE ESCROW IS FINE "
+                                f"— age reported success and produced an output "
+                                f"file, which a wrong key cannot do. Do NOT "
+                                f"re-escrow or rotate on the strength of this; "
+                                f"the fault is a valid encryption of an empty "
+                                f"payload. Run `restore-verify.py` to diagnose "
+                                f"the artifact.")
+                        raise EscrowError(
+                            "DECRYPT-FAILED",
+                            f"the ESCROWED bytes do NOT open {key}: {exc} — age "
+                            f"ran and REFUSED it, leaving no plaintext at all. "
+                            f"The escrow is present but it is not (or no longer) "
+                            f"a working identity for these artifacts. Nothing "
+                            f"here says the artifacts are damaged; the on-disk "
+                            f"key was not used.")
                     raise EscrowError(
-                        "DECRYPT-FAILED",
-                        f"the ESCROWED bytes do NOT open {key}: {exc} — age ran "
-                        f"and REFUSED it, leaving no plaintext at all. The "
-                        f"escrow is present but it is not (or no longer) a "
-                        f"working identity for these artifacts. Nothing here "
-                        f"says the artifacts are damaged; the on-disk key was "
-                        f"not used.")
-                raise EscrowError(
-                    "RESTORE-FAILED",
-                    f"the ESCROWED bytes DECRYPTED {key} — `decrypt()` RETURNED, "
-                    f"which is what makes that claim observable — and the "
-                    f"restore then failed: {exc}. This is a fault in the "
-                    f"ARTIFACT, not in the escrow. The escrowed key works; run "
-                    f"`restore-verify.py` to diagnose the artifact.")
-            return scope, key, v.commits_restored, v.refs_restored
+                        "RESTORE-FAILED",
+                        f"the ESCROWED bytes DECRYPTED {key} — `decrypt()` "
+                        f"RETURNED, which is what makes that claim observable — "
+                        f"and the restore then failed: {exc}. This is a fault in "
+                        f"the ARTIFACT, not in the escrow. The escrowed key "
+                        f"works; run `restore-verify.py` to diagnose the "
+                        f"artifact.")
+                return scope, key, v.commits_restored, v.refs_restored
         finally:
             # 🔴 EVERY PATH OUT: success, either classified failure, and any
             # unexpected exception from the pipeline. A failed run is exactly

--- a/scripts/analyze-service-index/escrow-verify.py
+++ b/scripts/analyze-service-index/escrow-verify.py
@@ -1,0 +1,1009 @@
+#!/usr/bin/env python3
+"""ESCROW VERIFIER for the age identity the /analyze-service index backups need.
+
+WHAT THIS CLOSES — THE LAST SINGLE POINT OF FAILURE
+---------------------------------------------------
+`backup.py` writes age ciphertext off-machine and `restore-verify.py` proves the
+bytes in the bucket still restore. Both of them decrypt with ONE file:
+`~/workspace/homelab-talos/.secrets/age.key`. Lose that file and every artifact
+in the bucket becomes a well-formed, well-replicated, permanently unreadable
+blob — the backups would keep passing every check `restore-verify.py` makes,
+right up until the moment somebody needed them, because that verifier runs on
+the machine that still HAS the key.
+
+So the key is escrowed into the operator's self-hosted Vaultwarden as a Secure
+Note. This script answers the three questions that escrow raises, and it refuses
+to answer any of them by silence:
+
+  1. IS IT STILL THERE?    the note exists, exactly once, and is not empty;
+  2. IS IT STILL CORRECT?  its bytes equal the on-disk identity, byte-for-byte;
+  3. DOES IT STILL WORK?   `--decrypt-check` writes the ESCROWED bytes to a
+                           throwaway identity and decrypts a REAL artifact out
+                           of the bucket with it.
+
+🔴 (2) AND (3) ARE DIFFERENT CLAIMS AND ONLY ONE OF THEM MATTERS ALONE.
+Byte equality proves the two copies agree; it cannot prove either of them opens
+anything, because it never asks age. Decryption proves the ESCROWED COPY —
+not the on-disk one — reconstructs history. A run without `--decrypt-check`
+says so in its own verdict line rather than letting "verified" stand for both.
+
+🔴 EVERY EMPTY OUTCOME IS A FAILURE
+-----------------------------------
+The same stance as `backup.py` and `restore-verify.py`, for the same reason: a
+verifier that reports success having checked nothing is a false all-clear, and a
+false all-clear about the ONLY copy of a decryption key is the worst one in this
+subsystem.
+
+  * `bw` not installed                        -> failure (with the exact command)
+  * vault locked / unauthenticated            -> failure, distinct codes
+  * the item is not found                     -> failure
+  * TWO items carry the name                  -> failure (ambiguous: this script
+                                                 cannot tell which one is the
+                                                 escrow, and picking either is a
+                                                 coin flip recorded as a verdict)
+  * the note body is empty or whitespace      -> failure
+  * the on-disk identity is empty             -> failure (two empty files compare
+                                                 EQUAL, which is the quiet way to
+                                                 certify nothing at all)
+  * zero artifacts under the prefix           -> failure (--decrypt-check)
+
+🔴 EVERY FAILURE MODE HAS ITS OWN TOKEN AND ITS OWN EXIT CODE
+--------------------------------------------------------------
+`EXIT_CODES` below is the whole list, pinned as an exact mapping by the test
+suite. This is not tidiness: "escrow check failed" sends an operator to the
+wrong place. `VAULT-LOCKED` means type one command; `ITEM-NOT-FOUND` means the
+escrow is gone and the key has no second copy; `BYTES-DIFFER-TRAILING-NEWLINE`
+means the server trimmed the note and the escrow is RECOVERABLE with one `echo`;
+`BYTES-DIFFER-MATERIALLY` means it is not. Four remedies, four codes.
+
+The trailing-newline classification exists because it is the difference that a
+copy/paste through a web vault actually produces, and because an `age` identity
+whose final newline is gone still decrypts — so a byte comparison is the ONLY
+place that difference is visible, and reporting it as a generic mismatch would
+send the operator hunting for corruption that is not there.
+
+🔴 NO KEY MATERIAL IS EVER PRINTED, LOGGED, OR PASSED IN ARGV
+--------------------------------------------------------------
+  * the note is read out of `bw list items --search`'s JSON on stdout and stays
+    in memory; nothing derived from it reaches a message. A mismatch reports
+    BYTE COUNTS AND A CLASSIFICATION, never the differing content, and never a
+    hash of it either (a hash of a 189-byte key with a known format is not a
+    protection worth arguing about in a public repo's issue tracker).
+  * `bw`'s stdout is NEVER quoted in an error message. Every subprocess result
+    here is handled as redacted by construction — `_run()` has no path that
+    interpolates output into an exception.
+  * the throwaway identity written by `--decrypt-check` is 0600 inside a 0700
+    directory, is overwritten and unlinked in a `finally` that covers success,
+    every early return, every refusal and every unexpected exception, and its
+    directory is removed after it. The overwrite is best-effort — on a
+    journalling or copy-on-write filesystem it is not a guarantee and this file
+    does not claim it is; the UNLINK is the part that is tested.
+
+🔴 THE ENDPOINT IS NEVER HARDCODED. devrc is a public repo. The server is read
+from `bw config server` at run time. It is cross-checked against the
+authenticated session's own `serverUrl` (a repointed CLI with a stale session is
+a real state this vault has been in), and against `--expect-server` when the
+operator pins one. With no pin the configured server is reported as INFORMATION
+and the run says the pin was absent, rather than implying it checked.
+
+🔴 THE MASTER PASSWORD CANNOT BE AUTOMATED, so this never tries. `bw status` is
+the authority; a vault that is not `unlocked` ends the run with a distinct code
+and the exact command to type. Every `bw` call runs with stdin on /dev/null AND
+`--nointeraction` AND a timeout, so a future `bw` that decides to prompt gets
+EOF instead of an agent hanging forever on an invisible password prompt.
+
+Usage:
+    escrow-verify.py [--identity FILE] [--item-name NAME] [--expect-server URL]
+                     [--decrypt-check [--scope S] [--bucket B | --from-dir DIR]
+                                      [--host H | --prefix P] [--store DIR]]
+                     [--work-dir DIR] [--timeout SECONDS] [--print-plan]
+
+  --print-plan   pure text; runs no `bw`, touches no network, reads no key.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import traceback
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import backup as B  # noqa: E402  (sibling module; owns the paths and the modes)
+
+PROG = "analyze-service-index-escrow-verify"
+
+_HERE = Path(__file__).resolve().parent
+
+DEFAULT_IDENTITY = B.DEFAULT_IDENTITY
+DEFAULT_BUCKET = B.DEFAULT_BUCKET
+DEFAULT_STORE = B.DEFAULT_STORE
+
+# 🔴 The Secure Note's name, EXACTLY as it was created. Not a secret and not an
+# endpoint — it is the lookup key, and this script cannot find the escrow
+# without it. The em dash is U+2014 and is part of the name; `bw`'s search is
+# fuzzy, so the match below is an exact byte comparison on `name` rather than
+# whatever the search returned.
+DEFAULT_ITEM_NAME = "age.key — SOPS + analyze-service-index backups"
+
+# Bitwarden's item type enum. 2 == Secure Note. Checked as STATE rather than
+# trusting the name: any item type can be given any name, and a Login item whose
+# `notes` happen to hold something is not the escrow.
+ITEM_TYPE_SECURE_NOTE = 2
+
+# The file the escrowed bytes are written to under `--decrypt-check`. A module
+# constant so the test suite can assert the path is GONE afterwards by name,
+# rather than by re-deriving it from this file's own code.
+ESCROW_IDENTITY_FILENAME = "escrowed-identity.key"
+RESTORE_SUBDIR = "restore"
+
+# `bw` is a Node program that talks to a remote server; without a ceiling a
+# hung TLS handshake is indistinguishable from a hung password prompt, and both
+# read as "the timer never finished".
+DEFAULT_TIMEOUT = 60.0
+
+# 🔴 `bw` IS NOT INSTALLED ON EITHER HOST — deliberately, it is a one-command
+# nix-shell away and nothing runs it unattended. The exact command lives here so
+# the failure message can hand it over instead of dying on FileNotFoundError.
+NIX_SHELL_HINT = "nix-shell -p bitwarden-cli jq --run '<command>'"
+
+_DIR_MODE = B._DIR_MODE      # 0700
+_FILE_MODE = B._FILE_MODE    # 0600
+
+# --------------------------------------------------------------------------- #
+# the failure vocabulary
+# --------------------------------------------------------------------------- #
+# 🔴 ONE TOKEN AND ONE EXIT CODE PER DISTINGUISHABLE CAUSE. Pinned as an exact
+# mapping by the test suite, in both directions, so a token cannot be raised
+# without a code and a code cannot outlive the token it names.
+#
+# 0 is success and 1 is "an unexpected exception, read the traceback" — the same
+# meaning `restore-verify.py` gives 1. Everything classified starts at 10 so that
+# a classified refusal can never be confused with an interpreter-level failure.
+EXIT_OK = 0
+EXIT_UNEXPECTED = 1
+
+EXIT_CODES: dict[str, int] = {
+    # the tool itself
+    "BW-MISSING": 10,
+    "BW-FAILED": 11,
+    # the vault's state — `bw status` is the authority
+    "VAULT-LOCKED": 12,
+    "VAULT-UNAUTHENTICATED": 13,
+    "VAULT-STATUS-UNKNOWN": 14,
+    # which server the answer came from
+    "SERVER-UNKNOWN": 15,
+    "SERVER-MISMATCH": 16,
+    # the item
+    "ITEM-NOT-FOUND": 17,
+    "ITEM-AMBIGUOUS": 18,
+    "ITEM-WRONG-TYPE": 19,
+    "NOTE-EMPTY": 20,
+    # the comparison
+    "BYTES-DIFFER-TRAILING-NEWLINE": 21,
+    "BYTES-DIFFER-MATERIALLY": 22,
+    # the local side of the comparison
+    "IDENTITY-MISSING": 23,
+    "IDENTITY-EMPTY": 24,
+    # --decrypt-check
+    "DECRYPT-FAILED": 25,
+    "RESTORE-FAILED": 26,
+    "STORE-UNREACHABLE": 27,
+    "NO-ARTIFACT": 28,
+}
+
+# The three answers a byte comparison may give. Named constants because the test
+# suite pins the literal strings and a verdict is a machine-readable claim.
+CLASS_IDENTICAL = "IDENTICAL"
+CLASS_TRAILING_NEWLINE = "DIFFERS-TRAILING-NEWLINE-ONLY"
+CLASS_MATERIAL = "DIFFERS-MATERIALLY"
+
+
+class EscrowError(B.BackupError):
+    """A classified refusal: a token, a message, and the exit code it maps to.
+
+    Subclasses `BackupError` for the same reason `RestoreVerifyError` does — the
+    helpers reused from `backup.py` raise that type, and two exception
+    hierarchies over one pipeline is how a failure escapes to a bare traceback.
+
+    🔴 The exit code is DERIVED from the token via `EXIT_CODES`, never passed in.
+    A constructor that accepted both could raise a token with the wrong code, and
+    that is precisely the conflation this class exists to prevent.
+    """
+
+    def __init__(self, token: str, message: str):
+        if token not in EXIT_CODES:
+            raise KeyError(
+                f"{token!r} is not in EXIT_CODES. Every refusal in this script "
+                f"is an ENUMERATED cause with its own exit code; adding one "
+                f"means adding it to the table in the same commit as the test "
+                f"that pins it.")
+        super().__init__(message)
+        self.token = token
+        self.exit_code = EXIT_CODES[token]
+
+    def __str__(self) -> str:
+        return f"{self.token}: {super().__str__()}"
+
+
+# --------------------------------------------------------------------------- #
+# the `bw` seam
+# --------------------------------------------------------------------------- #
+def _default_runner(argv: list[str], *, timeout: float) -> subprocess.CompletedProcess:
+    """Run `bw`, structurally unable to prompt.
+
+    Three independent belts, because the failure they prevent — an unattended
+    run blocked forever on an invisible master-password prompt — is silent:
+
+      * `--nointeraction` is passed by the caller on every command (a request);
+      * stdin is /dev/null, so a prompt that ignores the flag reads EOF and dies
+        (a mechanism, which is the half that does not depend on `bw`'s manners);
+      * a timeout, so a hung network call ends the run rather than the shift.
+    """
+    return subprocess.run(
+        argv, capture_output=True, text=True,
+        stdin=subprocess.DEVNULL, timeout=timeout, env=dict(os.environ))
+
+
+class BitwardenCLI:
+    """Every `bw` invocation this script makes, behind one injectable seam.
+
+    🔴 `runner` and `locator` are BOTH injectable, and the second one is not an
+    afterthought: the "`bw` is not installed" path is a first-class failure mode
+    with its own message and exit code, and a suite that could only reach it by
+    un-installing `bw` from the host would never reach it at all.
+
+    🔴 NO METHOD HERE PUTS OUTPUT INTO AN EXCEPTION. `bw list items` returns full
+    item objects, `notes` included — that is key material — and `bw status`
+    carries the server URL and the account's email. There is deliberately no
+    code path that interpolates a captured stream into a message, so no future
+    edit has to remember not to.
+    """
+
+    def __init__(self, *, runner=None, locator=None, bw: str = "bw",
+                 timeout: float = DEFAULT_TIMEOUT):
+        self.runner = runner or _default_runner
+        self.locator = locator or shutil.which
+        self.bw = bw
+        self.timeout = timeout
+
+    # -- plumbing ----------------------------------------------------------- #
+    def require_available(self) -> str:
+        path = self.locator(self.bw)
+        if path is None:
+            raise EscrowError(
+                "BW-MISSING",
+                f"{self.bw!r} is not on PATH. It is NOT installed on either host "
+                f"on purpose — run this under nix instead of installing it: "
+                f"{NIX_SHELL_HINT}. Refusing to guess: an escrow that cannot be "
+                f"read is not an escrow that is intact.")
+        return path
+
+    def _run(self, *args: str) -> subprocess.CompletedProcess:
+        argv = [self.bw, "--nointeraction", *args]
+        try:
+            return self.runner(argv, timeout=self.timeout)
+        except FileNotFoundError:
+            # The locator check above races with an uninstall, and a raw
+            # FileNotFoundError here would surface as an unexplained traceback
+            # rather than as the actionable message that already exists.
+            raise EscrowError(
+                "BW-MISSING",
+                f"{self.bw!r} vanished between the PATH lookup and the call. "
+                f"Run this under nix: {NIX_SHELL_HINT}.")
+        except subprocess.TimeoutExpired:
+            raise EscrowError(
+                "BW-FAILED",
+                f"`bw {args[0]}` did not finish within {self.timeout}s. It was "
+                f"run with stdin on /dev/null and --nointeraction, so this is a "
+                f"network or server stall rather than a password prompt — but "
+                f"either way nothing was verified.")
+
+    def _ok(self, p: subprocess.CompletedProcess, what: str) -> str:
+        if p.returncode != 0:
+            raise EscrowError(
+                "BW-FAILED",
+                f"`bw {what}` exited {p.returncode}. Its output is NOT quoted "
+                f"here: `bw list items` returns note bodies (key material) and "
+                f"`bw status` returns the server and the account email, and this "
+                f"script never puts either into a message. Re-run the command by "
+                f"hand to read it: {NIX_SHELL_HINT}")
+        return p.stdout
+
+    def _json(self, p: subprocess.CompletedProcess, what: str):
+        out = self._ok(p, what)
+        try:
+            return json.loads(out)
+        except json.JSONDecodeError:
+            raise EscrowError(
+                "BW-FAILED",
+                f"`bw {what}` exited 0 but did not return JSON ({len(out)} "
+                f"bytes). Output withheld — it may contain key material. A "
+                f"reply this script cannot parse is a question it did not get an "
+                f"answer to, which is not the same as a clean answer.")
+
+    # -- the four questions ------------------------------------------------- #
+    def status(self) -> dict:
+        d = self._json(self._run("status"), "status")
+        if not isinstance(d, dict):
+            raise EscrowError(
+                "VAULT-STATUS-UNKNOWN",
+                "`bw status` returned JSON that is not an object, so the vault's "
+                "state is UNKNOWN. An unreadable state must never be treated as "
+                "`unlocked`.")
+        return d
+
+    def config_server(self) -> str:
+        return self._ok(self._run("config", "server"), "config server").strip()
+
+    def search_items(self, name: str) -> list[dict]:
+        d = self._json(self._run("list", "items", "--search", name),
+                       "list items --search <name>")
+        if not isinstance(d, list):
+            raise EscrowError(
+                "BW-FAILED",
+                "`bw list items` returned JSON that is not a list. Refusing to "
+                "guess at its shape; nothing was verified.")
+        return d
+
+
+# --------------------------------------------------------------------------- #
+# the comparison
+# --------------------------------------------------------------------------- #
+def classify(escrow: bytes, disk: bytes) -> str:
+    """One of the three CLASS_* constants. Pure; reads nothing, prints nothing.
+
+    🔴 THE TRAILING-NEWLINE CASE IS ITS OWN ANSWER, not a shade of "mismatch".
+    An age identity keeps working when its final newline is trimmed, and a note
+    round-tripped through a web vault is exactly where a trim happens. So the
+    two differences have different remedies — one is `printf '\\n' >> key`, the
+    other is "the escrow is wrong, re-escrow it" — and a verifier that gave them
+    one word would send the operator to the second remedy for the first fault.
+
+    The rule is narrow on purpose: equal after removing TRAILING `\\n` bytes from
+    both sides, and not already equal. A CRLF rewrite changes every line ending,
+    not just the last byte, and is reported as material — which is honest, since
+    that is what it is.
+    """
+    if escrow == disk:
+        return CLASS_IDENTICAL
+    if escrow.rstrip(b"\n") == disk.rstrip(b"\n"):
+        return CLASS_TRAILING_NEWLINE
+    return CLASS_MATERIAL
+
+
+def _shred(path: Path) -> None:
+    """Overwrite then unlink `path`. Never raises.
+
+    🔴 The overwrite is BEST EFFORT and this docstring is the widest claim that
+    is true: on a journalling or copy-on-write filesystem the old blocks may
+    survive it. The UNLINK is the part that is guaranteed, the part the test
+    suite asserts, and the part that matters here — the file lives for
+    milliseconds inside a 0700 directory under the process's own temp root.
+    Claiming "securely erased" would be a comment the code cannot support, which
+    is the failure this subsystem's rules are most emphatic about.
+    """
+    try:
+        size = path.stat().st_size
+        with open(path, "r+b") as fh:
+            fh.write(b"\0" * size)
+            fh.flush()
+            os.fsync(fh.fileno())
+    except OSError:
+        pass
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+# --------------------------------------------------------------------------- #
+# reusing the restore verifier — never reimplementing it
+# --------------------------------------------------------------------------- #
+_RV = None
+
+
+def _rv():
+    """Import `restore-verify.py` (hyphenated file name), once, lazily.
+
+    🔴 IMPORTED RATHER THAN REIMPLEMENTED. `verify_artifact()` already owns the
+    whole download -> `age -d` -> `git clone --mirror` -> `git fsck` ->
+    cross-check pipeline AND the `finally` that unlinks the plaintext bundle on
+    every path out. A second copy of that pipeline would be a second copy of
+    that `finally`, and the copy nobody exercises is the broken one.
+
+    Lazy because the byte check — the default, and the only thing a locked-vault
+    run reaches — needs none of it.
+
+    `sys.modules[...] = mod` BEFORE `exec_module` is required, not tidiness:
+    `@dataclass` resolves annotations by looking the defining module up in
+    `sys.modules`. See the same dance in the restore verifier's test suite.
+    """
+    global _RV
+    if _RV is not None:
+        return _RV
+    if "restore_verify" in sys.modules:
+        _RV = sys.modules["restore_verify"]
+        return _RV
+    path = _HERE / "restore-verify.py"
+    spec = importlib.util.spec_from_file_location("restore_verify", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["restore_verify"] = mod
+    spec.loader.exec_module(mod)
+    _RV = mod
+    return mod
+
+
+# --------------------------------------------------------------------------- #
+# verdict
+# --------------------------------------------------------------------------- #
+@dataclass
+class EscrowVerdict:
+    """What this run PROVED. Every field is a measured number or a literal."""
+    item_name: str
+    server: str
+    server_pinned: bool
+    escrow_bytes: int
+    disk_bytes: int
+    classification: str
+    identity: Path
+    decrypt_checked: bool = False
+    decrypt_scope: str | None = None
+    decrypt_key: str | None = None
+    decrypt_commits: int | None = None
+    decrypt_refs: int | None = None
+
+    def line(self) -> str:
+        head = (f"{PROG}: escrow OK — the Secure Note matches {self.identity} "
+                f"{self.classification} ({self.escrow_bytes} escrowed bytes vs "
+                f"{self.disk_bytes} on disk)")
+        pin = ("server pinned and matched" if self.server_pinned
+               else "server NOT PINNED (--expect-server / ASIB_ESCROW_SERVER "
+                    "unset) — the CLI's configured server matched the session's, "
+                    "which is all that was checked")
+        if not self.decrypt_checked:
+            return (f"{head}; {pin}; NOT DECRYPT-CHECKED — byte equality proves "
+                    f"the two copies agree, NOT that either of them opens an "
+                    f"artifact. Re-run with --decrypt-check for that claim.")
+        return (f"{head}; {pin}; DECRYPT-CHECKED: the ESCROWED bytes decrypted "
+                f"{self.decrypt_key} (scope {self.decrypt_scope}) and restored "
+                f"{self.decrypt_commits} commit(s) over {self.decrypt_refs} "
+                f"ref(s)")
+
+
+# --------------------------------------------------------------------------- #
+# the steps
+# --------------------------------------------------------------------------- #
+def read_identity(identity: Path) -> bytes:
+    """The on-disk age identity's bytes, or a classified refusal.
+
+    🔴 AN EMPTY IDENTITY IS A FAILURE, not one half of a clean comparison. Two
+    empty files are byte-identical, so without this the whole run would report
+    `IDENTICAL` over nothing at all — the exact false all-clear this script was
+    written to prevent, arrived at by the shortest possible route.
+    """
+    if not identity.is_file():
+        raise EscrowError(
+            "IDENTITY-MISSING",
+            f"no age identity at {identity}. This compares the ESCROWED copy "
+            f"against the one this machine holds; with no local copy there is "
+            f"nothing to compare and 'could not compare' must never be reported "
+            f"as 'compared and matched'. Set ASIB_AGE_IDENTITY or "
+            f"SOPS_AGE_KEY_FILE (see SECRETS.md).")
+    data = identity.read_bytes()
+    if not data.strip():
+        raise EscrowError(
+            "IDENTITY-EMPTY",
+            f"the age identity at {identity} is empty or whitespace only "
+            f"({len(data)} bytes). Two empty files compare EQUAL, so continuing "
+            f"would report a matching escrow of nothing.")
+    return data
+
+
+def check_vault_state(bw: BitwardenCLI) -> dict:
+    """`bw status` is the authority. Anything but `unlocked` ends the run."""
+    st = bw.status()
+    state = st.get("status")
+    if state == "unlocked":
+        return st
+    if state == "locked":
+        raise EscrowError(
+            "VAULT-LOCKED",
+            "the vault is LOCKED. The master password CANNOT be automated and "
+            "this script will not prompt for it — it runs every `bw` call with "
+            "stdin on /dev/null so an unattended run fails fast instead of "
+            "hanging on an invisible prompt. Unlock it yourself, then re-run "
+            "with the session exported:\n"
+            "    export BW_SESSION=\"$(bw unlock --raw)\"\n"
+            "and if `bw` is not on PATH, do both inside one shell: "
+            + NIX_SHELL_HINT)
+    if state == "unauthenticated":
+        raise EscrowError(
+            "VAULT-UNAUTHENTICATED",
+            "the CLI is NOT LOGGED IN to any vault — this is not the same as a "
+            "locked vault and the remedy is different: `bw login` (which needs "
+            "the account email and, if enabled, a second factor), THEN "
+            "`export BW_SESSION=\"$(bw unlock --raw)\"`. Check `bw config "
+            "server` points at the right server before logging in.")
+    raise EscrowError(
+        "VAULT-STATUS-UNKNOWN",
+        f"`bw status` reported status={state!r}, which this script does not "
+        f"recognise. Refusing to proceed: an unrecognised state is an UNKNOWN "
+        f"one, and treating an unknown as `unlocked` is how a run reports a "
+        f"clean escrow it never read.")
+
+
+def check_server(bw: BitwardenCLI, status: dict, expect: str | None) -> tuple[str, bool]:
+    """`(configured server, was it pinned)`, or a classified refusal.
+
+    🔴 THE ENDPOINT IS READ, NEVER HARDCODED — devrc is public. Two checks:
+
+      * the CLI's configured server must agree with the AUTHENTICATED SESSION's
+        own `serverUrl`. This vault has actually been repointed once, and a
+        session left over from the old endpoint is a state where every answer
+        below comes from a server the operator no longer thinks they are using.
+        This half needs no pin and always runs.
+      * `--expect-server` / `ASIB_ESCROW_SERVER`, when the operator sets one.
+        Absent, the run reports NOT PINNED rather than implying it checked —
+        `server_pinned` is returned so the verdict line can say which.
+    """
+    configured = bw.config_server()
+    if not configured:
+        raise EscrowError(
+            "SERVER-UNKNOWN",
+            "`bw config server` printed nothing, so which server answered "
+            "cannot be determined. An escrow verified against an unknown server "
+            "is an escrow verified against no server in particular.")
+    session_server = (status.get("serverUrl") or "").strip()
+    if session_server and _norm_url(session_server) != _norm_url(configured):
+        raise EscrowError(
+            "SERVER-MISMATCH",
+            "the CLI's CONFIGURED server and the AUTHENTICATED SESSION's server "
+            "disagree, so the item this run would read comes from a different "
+            "place than `bw config server` reports. (Neither URL is printed: "
+            "this repo is public and messages from it end up pasted into it.) "
+            "Re-run `bw config server` and `bw status` by hand to see both, "
+            "then `bw logout` and log in against the intended one.")
+    if expect is not None:
+        if _norm_url(expect) != _norm_url(configured):
+            raise EscrowError(
+                "SERVER-MISMATCH",
+                "the configured server does not match the one pinned by "
+                "--expect-server / ASIB_ESCROW_SERVER. Refusing to report an "
+                "escrow found on a server that is not the one you named — URLs "
+                "withheld, compare them by hand with `bw config server`.")
+        return configured, True
+    return configured, False
+
+
+def _norm_url(u: str) -> str:
+    """Compare URLs without tripping over a trailing slash or letter case."""
+    return u.strip().rstrip("/").lower()
+
+
+def find_escrow_item(bw: BitwardenCLI, item_name: str) -> dict:
+    """The one Secure Note carrying `item_name`, or a classified refusal.
+
+    🔴 `bw list items --search` IS FUZZY, so its result set is a candidate list
+    and not an answer. The match here is an exact comparison on `name`, and the
+    three ways it can fail to produce exactly one item are three findings:
+
+      * NONE   — the escrow is gone (or was never made under this name), and the
+                 key has no second copy anywhere;
+      * TWO+   — this script CANNOT TELL WHICH ONE IS THE ESCROW. Picking either
+                 is a coin flip recorded as a verdict; a stale duplicate that
+                 still holds a rotated-out key would verify green forever;
+      * WRONG TYPE — the name is right and the item is not a Secure Note. The
+                 guard is on the item's TYPE (state), not on a word another item
+                 can spell.
+    """
+    matches = [it for it in bw.search_items(item_name)
+               if isinstance(it, dict) and it.get("name") == item_name]
+    if not matches:
+        raise EscrowError(
+            "ITEM-NOT-FOUND",
+            f"no vault item is named exactly {item_name!r}. This is the whole "
+            f"off-machine copy of the decryption key being absent: every "
+            f"artifact in the bucket is still there and none of them can be "
+            f"opened without the identity on this one disk. `bw list items "
+            f"--search` was used and it is FUZZY, so a near-miss would have "
+            f"been returned and rejected here — check for a renamed item before "
+            f"concluding it was deleted.")
+    if len(matches) > 1:
+        raise EscrowError(
+            "ITEM-AMBIGUOUS",
+            f"{len(matches)} vault items are named exactly {item_name!r}. This "
+            f"script cannot tell which one is the escrow, and choosing one would "
+            f"turn a coin flip into a verdict — a stale duplicate holding a "
+            f"rotated-out key verifies green forever. Delete or rename the "
+            f"duplicates so exactly one remains.")
+    item = matches[0]
+    if item.get("type") != ITEM_TYPE_SECURE_NOTE:
+        raise EscrowError(
+            "ITEM-WRONG-TYPE",
+            f"the item named {item_name!r} has type={item.get('type')!r}, not "
+            f"{ITEM_TYPE_SECURE_NOTE} (Secure Note). The escrow was created as a "
+            f"Secure Note; an item of another type carrying the same name is a "
+            f"different object that happens to be spelled the same.")
+    return item
+
+
+def read_note(item: dict, item_name: str) -> bytes:
+    """The note body as bytes, or a classified refusal. Never logged."""
+    notes = item.get("notes")
+    if not isinstance(notes, str) or not notes.strip():
+        raise EscrowError(
+            "NOTE-EMPTY",
+            f"the vault item {item_name!r} exists but its note body is EMPTY. "
+            f"An empty note lists, syncs and exports exactly like a full one, so "
+            f"this is the quiet way for an escrow to be gone while every count "
+            f"still says it is there.")
+    return notes.encode("utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# --decrypt-check
+# --------------------------------------------------------------------------- #
+def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
+                  prefix: str, store: Path, scope_filter: str | None,
+                  from_dir: Path | None, now: datetime,
+                  downloader_factory=None) -> tuple[str, str, int, int]:
+    """Decrypt a REAL artifact with the ESCROWED bytes. `(scope, key, commits, refs)`.
+
+    🔴 THE ESCROWED BYTES, NOT THE ON-DISK KEY. The whole point: the on-disk key
+    demonstrably works — `restore-verify.py` uses it — and proving it again
+    would be a test of the wrong copy. The identity handed to the restore
+    pipeline here is written from what came back from the vault.
+
+    🔴 THE PIPELINE IS `restore_verify.verify_artifact`, CALLED, NOT COPIED. That
+    function owns the plaintext-bundle `finally`, the 0600/0700 tightening and
+    the `git fsck`; a second implementation would be a second chance to get the
+    plaintext lifetime wrong.
+
+    🔴 ONE ARTIFACT, NOT A FULL RUN. `run()` in the restore verifier also gates
+    on artifact staleness and on local scopes missing from the bucket. Both are
+    real faults and neither is a fact about the KEY, so folding them in would
+    make a stale-timer failure indistinguishable from a broken escrow — the
+    conflation this file's exit table exists to prevent. `restore-verify.py` is
+    the tool that reports those; this one answers "does the escrowed key open
+    what is actually in the bucket".
+    """
+    RV = _rv()
+    prefix = RV.normalise_prefix(prefix)
+
+    if downloader_factory is not None:
+        factory = downloader_factory
+    elif from_dir is not None:
+        factory = lambda: RV.DirectoryStore(from_dir)   # noqa: E731
+    else:
+        factory = lambda: RV.MinioDownloader(bucket)    # noqa: E731
+
+    try:
+        ctx = factory()
+        downloader = ctx.__enter__()
+    except Exception as exc:
+        # 🔴 CLASSIFIED BY PHASE, NOT BY MESSAGE. Everything that can go wrong
+        # while OPENING the store — no kubeconfig, a missing bucket, an S3Error,
+        # a urllib3 connection reset, a --from-dir that is not a directory — is
+        # "could not reach the artifacts", and none of it is a fact about the
+        # escrowed key. Reading a string to decide that would make the
+        # classification depend on wording somebody else owns.
+        raise EscrowError(
+            "STORE-UNREACHABLE",
+            f"could not open the artifact store to test the escrowed key "
+            f"({type(exc).__name__}: {exc}). NOTHING about the escrow was "
+            f"proven by this run beyond the byte comparison above.")
+
+    try:
+        keys = sorted(downloader.list(prefix))
+        if not keys:
+            raise EscrowError(
+                "NO-ARTIFACT",
+                f"zero objects under {bucket}/{prefix}, so there is nothing for "
+                f"the escrowed key to open. This is NOT a clean decrypt-check: "
+                f"a key that was never asked to decrypt anything has not been "
+                f"shown to work. `restore-verify.py` is the tool that diagnoses "
+                f"an empty prefix — it can tell 'the backups are gone' from 'you "
+                f"looked under the wrong prefix', and this script deliberately "
+                f"does not duplicate that diagnosis.")
+        by_scope = RV.group_by_scope(keys, prefix)
+        if scope_filter is not None:
+            if scope_filter not in by_scope:
+                raise EscrowError(
+                    "NO-ARTIFACT",
+                    f"scope {scope_filter!r} has zero objects under "
+                    f"{bucket}/{prefix}. Scopes that do: {sorted(by_scope)}.")
+            scope = scope_filter
+        else:
+            # The scope holding the NEWEST artifact overall. `sorted()` first so
+            # a tie resolves lexicographically rather than by dict order — a
+            # verifier that picks a different artifact on different runs cannot
+            # be reasoned about when it disagrees with itself.
+            scope = max(sorted(by_scope), key=lambda s: by_scope[s][-1][0])
+        stamp, key = by_scope[scope][-1]
+
+        this_host = B.host_label()
+        this_machine_id = RV.machine_id()
+        live, no_live_reason = RV.cross_check_target(
+            store, scope,
+            artifacts_are_foreign=not RV.prefix_belongs_to_this_host(
+                prefix, this_host, this_machine_id),
+            machine_id_unreadable=(this_machine_id is None))
+
+        restore_dir = B._private_dir(work_dir / RESTORE_SUBDIR)
+        identity = work_dir / ESCROW_IDENTITY_FILENAME
+        try:
+            # 🔴 0600 BEFORE THE BYTES. `os.open` with the mode is the only
+            # ordering with no window: `write_bytes()` then `chmod()` leaves the
+            # key world-readable for however long the write takes. The 0700
+            # directory bounds it either way; this makes the file's own mode
+            # true from its first byte rather than shortly after.
+            fd = os.open(identity, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, _FILE_MODE)
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(escrow_bytes)
+
+            try:
+                v = RV.verify_artifact(
+                    downloader, key, scope=scope, stamp=stamp,
+                    identity=identity, work_dir=restore_dir, store=store,
+                    keep=False, now=now, live_scope=live,
+                    no_live_reason=no_live_reason)
+            except RV.RestoreVerifyError as exc:
+                # 🔴 TWO OUTCOMES, TWO TOKENS. "the escrowed key does not open
+                # it" is a KEY fault; "the bytes do not reconstruct" is DATA
+                # loss, and it would be reported identically by a run using the
+                # on-disk key. Only the first says anything about the escrow.
+                #
+                # The discriminator is the restore verifier's OWN literal token,
+                # `DECRYPT FAILED`, which it emits from `decrypt()` and nowhere
+                # else and which its test suite pins. Both branches are measured
+                # here by the test suite too — a corrupted KEY and a corrupted
+                # ARTIFACT, at two points, so the classifier is shown to
+                # discriminate rather than assumed to.
+                if "DECRYPT FAILED" in str(exc):
+                    raise EscrowError(
+                        "DECRYPT-FAILED",
+                        f"the ESCROWED bytes do NOT open {key}: {exc} — the "
+                        f"escrow is present but it is not (or no longer) a "
+                        f"working identity for these artifacts. Nothing here "
+                        f"says the artifacts are damaged; the on-disk key was "
+                        f"not used.")
+                raise EscrowError(
+                    "RESTORE-FAILED",
+                    f"the ESCROWED bytes DECRYPTED {key} and the restore then "
+                    f"failed: {exc} — this is a fault in the ARTIFACT, not in "
+                    f"the escrow. The escrowed key works; run "
+                    f"`restore-verify.py` to diagnose the artifact.")
+            return scope, key, v.commits_restored, v.refs_restored
+        finally:
+            # 🔴 EVERY PATH OUT: success, either classified failure, and any
+            # unexpected exception from the pipeline. A failed run is exactly
+            # when a copy of a decryption key is most likely to be left behind
+            # and least likely to be noticed.
+            _shred(identity)
+            shutil.rmtree(restore_dir, ignore_errors=True)
+    finally:
+        ctx.__exit__(None, None, None)
+
+
+# --------------------------------------------------------------------------- #
+# the run
+# --------------------------------------------------------------------------- #
+def run(*, bw: BitwardenCLI, identity: Path, item_name: str,
+        expect_server: str | None = None, decrypt: bool = False,
+        bucket: str = DEFAULT_BUCKET, prefix: str | None = None,
+        store: Path = DEFAULT_STORE, scope_filter: str | None = None,
+        from_dir: Path | None = None, work_dir: Path | None = None,
+        now: datetime | None = None,
+        downloader_factory=None) -> EscrowVerdict:
+    """Byte check, then optionally the decrypt check. Raises `EscrowError`."""
+    now = now or datetime.now(timezone.utc)
+
+    # 🔴 THE LOCAL SIDE FIRST, before any network call. It needs no vault, and
+    # an absent or empty on-disk identity makes the comparison meaningless — so
+    # the run should end there rather than after unlocking, listing and reading
+    # a note it then has nothing to compare against.
+    disk = read_identity(identity)
+
+    bw.require_available()
+    status = check_vault_state(bw)
+    server, pinned = check_server(bw, status, expect_server)
+    item = find_escrow_item(bw, item_name)
+    escrow = read_note(item, item_name)
+
+    verdict_class = classify(escrow, disk)
+    if verdict_class == CLASS_TRAILING_NEWLINE:
+        raise EscrowError(
+            "BYTES-DIFFER-TRAILING-NEWLINE",
+            f"the escrowed note and {identity} differ ONLY in trailing "
+            f"newlines: {len(escrow)} escrowed bytes vs {len(disk)} on disk. "
+            f"(The differing content is NOT printed — it is key material.) This "
+            f"is what a copy through a web vault that trims looks like. An age "
+            f"identity still decrypts without its final newline, so the escrow "
+            f"is very likely USABLE — but it is no longer a byte-for-byte copy, "
+            f"and 'very likely' is not what a disaster-recovery artifact gets to "
+            f"be. Re-escrow the file, or confirm with --decrypt-check.")
+    if verdict_class == CLASS_MATERIAL:
+        raise EscrowError(
+            "BYTES-DIFFER-MATERIALLY",
+            f"the escrowed note and {identity} DIFFER: {len(escrow)} escrowed "
+            f"bytes vs {len(disk)} on disk, and they are not equal after "
+            f"trailing newlines are removed. (The differing content is NOT "
+            f"printed — it is key material; compare them by hand if you must.) "
+            f"One of the two copies is not the key this subsystem encrypts to. "
+            f"Re-escrow from the on-disk identity only after confirming the "
+            f"on-disk one is the one the bucket's artifacts open with — "
+            f"`restore-verify.py` answers that.")
+
+    verdict = EscrowVerdict(
+        item_name=item_name, server=server, server_pinned=pinned,
+        escrow_bytes=len(escrow), disk_bytes=len(disk),
+        classification=verdict_class, identity=identity,
+    )
+    if not decrypt:
+        return verdict
+
+    if work_dir is None:
+        raise ValueError("decrypt=True requires work_dir; main() always passes one")
+    scope, key, commits, refs = decrypt_check(
+        escrow_bytes=escrow, work_dir=work_dir, bucket=bucket,
+        prefix=prefix if prefix is not None else B.host_label(),
+        store=store, scope_filter=scope_filter, from_dir=from_dir, now=now,
+        downloader_factory=downloader_factory)
+    verdict.decrypt_checked = True
+    verdict.decrypt_scope = scope
+    verdict.decrypt_key = key
+    verdict.decrypt_commits = commits
+    verdict.decrypt_refs = refs
+    return verdict
+
+
+def print_plan(*, identity: Path, item_name: str, expect_server: str | None,
+               decrypt: bool, bucket: str, prefix: str, store: Path,
+               scope_filter: str | None, from_dir: Path | None) -> None:
+    """Pure text. Runs no `bw`, touches no network, reads no key material."""
+    present = identity.is_file()
+    size = identity.stat().st_size if present else 0
+    print(f"identity:  {identity} ({size} bytes)" if present
+          else f"identity:  {identity} (MISSING)")
+    print(f"item:      {item_name!r} (exact name match; `bw list items "
+          f"--search` is FUZZY, so its results are candidates)")
+    print(f"type:      must be {ITEM_TYPE_SECURE_NOTE} (Secure Note) — checked "
+          f"as STATE, not by the name alone")
+    print("server:    read from `bw config server` AT RUN TIME and cross-checked "
+          "against the session's own serverUrl.")
+    print("           NEVER hardcoded here — this repo is public.")
+    print(f"           pin: {'--expect-server / ASIB_ESCROW_SERVER is SET' if expect_server else 'NOT PINNED'}")
+    print("vault:     `bw status` is the authority. locked / unauthenticated / "
+          "anything unrecognised each")
+    print("           end the run with their own exit code. The master password "
+          "is never prompted for:")
+    print("           every call runs with stdin on /dev/null and "
+          "--nointeraction.")
+    print("compare:   the note body, UTF-8 encoded, against the identity file, "
+          "BYTE FOR BYTE.")
+    print(f"           three answers: {CLASS_IDENTICAL} / "
+          f"{CLASS_TRAILING_NEWLINE} / {CLASS_MATERIAL}.")
+    print("           A mismatch reports byte COUNTS and the classification "
+          "only — never the content.")
+    if decrypt:
+        src = str(from_dir) if from_dir is not None else bucket
+        # The trailing slash is not cosmetic: an S3 prefix is a BYTE prefix, so
+        # `workbench` would also list `workbench-laptop/…`. The plan prints the
+        # prefix the run will actually use, normalised by the same function.
+        shown = prefix.rstrip("/") + "/"
+        print(f"decrypt:   ON — the ESCROWED bytes (not {identity}) are written "
+              f"0600 into a 0700 dir")
+        print(f"           and used to decrypt the newest artifact under "
+              f"{src}/{shown}")
+        print(f"           scope: {scope_filter or '(the scope with the newest artifact)'}")
+        print(f"           store: {store} (cross-check target, via "
+              f"restore-verify.py)")
+        print("           the throwaway identity is overwritten and unlinked in "
+              "a finally that covers")
+        print("           success, every refusal and every unexpected exception.")
+    else:
+        print("decrypt:   OFF — byte equality proves the two copies AGREE, not "
+              "that either OPENS anything.")
+        print("           Pass --decrypt-check for that claim.")
+    print(f"exit codes: {', '.join(f'{t}={c}' for t, c in sorted(EXIT_CODES.items(), key=lambda kv: kv[1]))}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog=PROG, description=__doc__)
+    ap.add_argument("--identity", type=Path, default=None,
+                    help=f"age identity to compare against (default: "
+                         f"{DEFAULT_IDENTITY}, or ASIB_AGE_IDENTITY / "
+                         f"SOPS_AGE_KEY_FILE)")
+    ap.add_argument("--item-name",
+                    default=os.environ.get("ASIB_ESCROW_ITEM", DEFAULT_ITEM_NAME),
+                    help="the vault item's EXACT name")
+    ap.add_argument("--expect-server",
+                    default=os.environ.get("ASIB_ESCROW_SERVER") or None,
+                    help="fail unless `bw config server` equals this (no default: "
+                         "the endpoint is never hardcoded, this repo is public)")
+    ap.add_argument("--bw", default="bw", help="the bitwarden CLI to run")
+    ap.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT,
+                    help=f"per-`bw`-call ceiling in seconds (default "
+                         f"{DEFAULT_TIMEOUT})")
+    ap.add_argument("--decrypt-check", dest="decrypt", action="store_true",
+                    help="ALSO decrypt a real artifact with the ESCROWED bytes")
+    ap.add_argument("--bucket", default=os.environ.get("ASIB_BUCKET", DEFAULT_BUCKET))
+    ap.add_argument("--host", default=None,
+                    help="--decrypt-check: use this host label's artifacts")
+    ap.add_argument("--prefix", default=None,
+                    help="--decrypt-check: object key prefix; overrides --host")
+    ap.add_argument("--scope", default=None,
+                    help="--decrypt-check: use this scope (default: the scope "
+                         "with the newest artifact)")
+    ap.add_argument("--store", type=Path, default=DEFAULT_STORE,
+                    help="--decrypt-check: the live store to cross-check against")
+    ap.add_argument("--from-dir", type=Path, default=None,
+                    help="--decrypt-check: read artifacts from this directory "
+                         "instead of MinIO")
+    ap.add_argument("--work-dir", type=Path, default=None,
+                    help="where the throwaway identity is written, created 0700 "
+                         "(default: a private temp dir). It is shredded and "
+                         "removed either way.")
+    ap.add_argument("--print-plan", action="store_true",
+                    help="print what would happen; run no `bw`, read no key")
+    args = ap.parse_args(argv)
+
+    identity = args.identity or B.resolve_identity()
+    prefix = (args.prefix if args.prefix is not None
+              else args.host if args.host is not None
+              else B.host_label())
+
+    if args.print_plan:
+        print_plan(identity=identity, item_name=args.item_name,
+                   expect_server=args.expect_server, decrypt=args.decrypt,
+                   bucket=str(args.from_dir) if args.from_dir else args.bucket,
+                   prefix=prefix, store=args.store, scope_filter=args.scope,
+                   from_dir=args.from_dir)
+        return EXIT_OK
+
+    bw = BitwardenCLI(bw=args.bw, timeout=args.timeout)
+
+    def _go(work: Path | None) -> EscrowVerdict:
+        return run(bw=bw, identity=identity, item_name=args.item_name,
+                   expect_server=args.expect_server, decrypt=args.decrypt,
+                   bucket=args.bucket, prefix=prefix, store=args.store,
+                   scope_filter=args.scope, from_dir=args.from_dir,
+                   work_dir=work)
+
+    try:
+        if not args.decrypt:
+            verdict = _go(None)
+        elif args.work_dir is not None:
+            verdict = _go(B._private_dir(args.work_dir))
+        else:
+            with tempfile.TemporaryDirectory(prefix="asi-escrow-verify.") as td:
+                verdict = _go(B._private_dir(Path(td)))
+        print(verdict.line())
+        return EXIT_OK
+    except EscrowError as exc:
+        print(f"{PROG}: {exc}", file=sys.stderr)
+        return exc.exit_code
+    except B.BackupError as exc:
+        # A refusal from a reused helper (`_private_dir`, `_git_scratch`'s store
+        # guard). It has no token of its own; it is still a failure.
+        print(f"{PROG}: UNCLASSIFIED: {exc}", file=sys.stderr)
+        return EXIT_UNEXPECTED
+    except Exception as exc:  # noqa: BLE001 — the failure signal, not a swallow
+        traceback.print_exc()
+        print(f"{PROG}: FAILED with an unexpected {type(exc).__name__}: {exc}. "
+              f"NOTHING about the escrow was verified on this run — treat this "
+              f"as no verification and read the traceback above.", file=sys.stderr)
+        return EXIT_UNEXPECTED
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analyze-service-index/escrow-verify.py
+++ b/scripts/analyze-service-index/escrow-verify.py
@@ -623,12 +623,20 @@ def _decrypt_phase_probe(RV):
             real(cipher, plain, identity)
         except BaseException as exc:
             # 🔴 `Path.exists()` CAN RAISE ON THIS INTERPRETER, and an earlier
-            # comment here asserted the opposite. MEASURED on the flake's pinned
-            # CPython 3.12.14: a parent directory without `+x` makes
-            # `exists()` raise `PermissionError`, because 3.12's
-            # `pathlib._ignore_error` ignores only ENOENT/ENOTDIR/EBADF/ELOOP.
-            # (It becomes true on >= 3.13, which widened that set — so the claim
-            # was version-dependent and stated as absolute.)
+            # comment here asserted the opposite. MEASURED on a directory without
+            # `+x`, three interpreters, twice each (behaviour, and whether
+            # `Path.exists`'s source still calls `_ignore_error`):
+            #
+            #     3.12.14 (the flake's pin)  raises PermissionError   _ignore_error: yes
+            #     3.13.15                    raises PermissionError   _ignore_error: yes
+            #     3.14.7                     returns False            _ignore_error: no
+            #
+            # `_ignore_error` swallows only ENOENT/ENOTDIR/EBADF/ELOOP, so EACCES
+            # propagates; 3.14 dropped that helper from `exists()` and swallows
+            # unconditionally. 🔴 THE BOUNDARY IS 3.14, NOT 3.13 — an earlier
+            # revision of this comment said 3.13 and was wrong, and a test written
+            # to that boundary would have gone red on 3.13 for no reason anyone
+            # could find. Measure the interpreter, do not reason about it.
             #
             # Unhandled, it would replace the REAL exception mid-`except` — the
             # same masking class removed for `phase` — and the run would report a

--- a/scripts/analyze-service-index/escrow-verify.py
+++ b/scripts/analyze-service-index/escrow-verify.py
@@ -255,10 +255,6 @@ EXIT_CODES: dict[str, int] = {
 
 # The three answers a byte comparison may give. Named constants because the test
 # suite pins the literal strings and a verdict is a machine-readable claim.
-# A sentinel distinct from None, so "the key is absent" and "the key is present
-# and null" can be told apart where that matters.
-_ABSENT = object()
-
 CLASS_IDENTICAL = "IDENTICAL"
 CLASS_TRAILING_NEWLINE = "DIFFERS-TRAILING-NEWLINE-ONLY"
 CLASS_MATERIAL = "DIFFERS-MATERIALLY"
@@ -626,9 +622,23 @@ def _decrypt_phase_probe(RV):
         try:
             real(cipher, plain, identity)
         except BaseException as exc:
-            # `Path.exists()` swallows OSError internally and returns False, so
-            # there is deliberately no try/except here — one would be dead.
-            state["plain_present"] = Path(plain).exists()
+            # 🔴 `Path.exists()` CAN RAISE ON THIS INTERPRETER, and an earlier
+            # comment here asserted the opposite. MEASURED on the flake's pinned
+            # CPython 3.12.14: a parent directory without `+x` makes
+            # `exists()` raise `PermissionError`, because 3.12's
+            # `pathlib._ignore_error` ignores only ENOENT/ENOTDIR/EBADF/ELOOP.
+            # (It becomes true on >= 3.13, which widened that set — so the claim
+            # was version-dependent and stated as absolute.)
+            #
+            # Unhandled, it would replace the REAL exception mid-`except` — the
+            # same masking class removed for `phase` — and the run would report a
+            # permissions error instead of whatever age actually did. An
+            # unreadable path is simply an unobservable one: None, never False,
+            # so no branch downstream can mistake it for "age wrote nothing".
+            try:
+                state["plain_present"] = Path(plain).exists()
+            except OSError:
+                state["plain_present"] = None
             # The rc==0-vs-rc!=0 split, taken as a VALUE from the module that
             # owns it. `getattr` because a non-RestoreVerifyError has no cause;
             # None then means "no published cause", never a default one.
@@ -893,13 +903,19 @@ def read_note(item: dict, item_name: str) -> bytes:
     for an intact note — overwrites a good copy on the strength of a parsing
     accident. `"notes" in item` is the whole fix.
     """
-    # 🔴 ABSENT **OR** NULL. JSON's shape for "this item has no notes" is almost
-    # certainly `{"notes": null}`, not an omitted key — the very shape this
-    # module already handles for `serverUrl` in `check_server`. Splitting on
-    # `"notes" not in item` alone let a null fall through to `NOTE-EMPTY`, i.e.
-    # straight back to the "re-escrow over a good copy" advice this token was
-    # created to prevent.
-    if item.get("notes", _ABSENT) is _ABSENT or item.get("notes") is None:
+    # 🔴 ABSENT AND NULL ARE THE SAME FINDING HERE, DELIBERATELY. JSON's shape
+    # for "this item has no notes" is almost certainly `{"notes": null}`, not an
+    # omitted key — the very shape this module already handles for `serverUrl`
+    # in `check_server`. Splitting on `"notes" not in item` alone let a null fall
+    # through to `NOTE-EMPTY`, i.e. straight back to the "re-escrow over a good
+    # copy" advice this token was created to prevent.
+    #
+    # `.get(...) is None` covers both, so there is no sentinel: an earlier
+    # version carried one whose comment claimed the two cases "can be told apart
+    # where that matters" while its only consumer merged them. They are merged
+    # because the REMEDY is the same — read the item in the web vault before
+    # touching the escrow.
+    if item.get("notes") is None:
         raise EscrowError(
             "NOTE-MISSING",
             f"the vault item {item_name!r} exists but its payload carries NO "
@@ -1111,7 +1127,30 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
                                 f"strength of this. Run `restore-verify.py` to "
                                 f"diagnose the artifact.",
                                 detail=str(exc))
-                        if phase["plain_present"]:
+                        if (phase["cause"] == RV.DECRYPT_AGE_REFUSED
+                                and phase["plain_present"]):
+                            # 🔴 THE CAUSE IS PART OF THE CONDITION, not decoration.
+                            # This branch makes the strongest claim in the file —
+                            # "the key worked, the BACKUP is tampered" — and it was
+                            # keyed on `plain_present` ALONE, treating a `cause` of
+                            # None identically to `age-refused`. A sweep confirmed
+                            # it: dropping `cause=DECRYPT_AGE_REFUSED` from
+                            # restore-verify's raise survived the whole suite, so
+                            # the published set was 2-for-3 load-bearing plus a
+                            # claim. Now it is 3-for-3 — and it is the RAISE-SIDE
+                            # mutant that proves it, because that one is killed.
+                            #
+                            # ⚠ Deleting the cause test HERE is currently an
+                            # EQUIVALENT mutant and the sweep reports it as a
+                            # labelled survivor: the two branches above consume
+                            # `empty-plaintext` and `age-missing`, so the only
+                            # cause that can still reach this line is
+                            # `age-refused`. It is kept because that is a
+                            # property of the branches above it, not of this
+                            # condition — publish a fourth cause and this line is
+                            # the one that stops the strongest claim in the file
+                            # being made about it by default.
+                            #
                             # age exited NON-ZERO having already written output.
                             # Measured across 8 offsets x 4 sizes plus 3
                             # truncations: reaching the payload at all means age
@@ -1136,11 +1175,14 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
                             f"all. TWO CAUSES PRODUCE THIS AND THEY ARE NOT "
                             f"SEPARABLE FROM HERE: the escrowed identity does not "
                             f"match this artifact's recipients, or the artifact's "
-                            f"HEADER is damaged. Neither is asserted. To tell "
-                            f"them apart, run `restore-verify.py` with the "
-                            f"ON-DISK identity: if that fails too the artifact is "
-                            f"the problem, not the escrow. Do NOT rotate the key "
-                            f"before doing that.",
+                            f"HEADER is damaged. Neither is asserted. To tell them "
+                            f"apart, try a DIFFERENT artifact with this same "
+                            f"escrowed copy — `--scope <another scope>`, or "
+                            f"`restore-verify.py --all` for an older stamp: if "
+                            f"another artifact OPENS, the escrowed key is fine and "
+                            f"THIS object's header is damaged; if none open, the "
+                            f"key is the likely cause. Do NOT rotate the key "
+                            f"before running that.",
                             detail=str(exc))
                     raise EscrowError(
                         "RESTORE-FAILED",
@@ -1198,7 +1240,11 @@ def run(*, bw: BitwardenCLI, identity: Path, item_name: str,
             f"identity still decrypts without its final newline, so the escrow "
             f"is very likely USABLE — but it is no longer a byte-for-byte copy, "
             f"and 'very likely' is not what a disaster-recovery artifact gets to "
-            f"be. Re-escrow the file, or confirm with --decrypt-check.")
+            f"be. Re-escrow the file. 🔴 --decrypt-check CANNOT confirm this: "
+            f"this refusal is raised BEFORE the decrypt step runs, so the flag "
+            f"produces the identical message and tests nothing. To check the "
+            f"trimmed bytes by hand, write them to a 0600 file yourself and pass "
+            f"it as --identity to `restore-verify.py`.")
     if verdict_class == CLASS_MATERIAL:
         raise EscrowError(
             "BYTES-DIFFER-MATERIALLY",

--- a/scripts/analyze-service-index/restore-verify.py
+++ b/scripts/analyze-service-index/restore-verify.py
@@ -561,6 +561,25 @@ def decrypt(cipher: Path, plain: Path, identity: Path) -> None:
             "artifact this cannot verify, and skipping it would report safety "
             "that was never measured.",
             cause=DECRYPT_AGE_MISSING)
+    # 🔴 A STALE OUTPUT FILE MAKES age's OWN FAILURE UNREADABLE. MEASURED: on
+    # BOTH the wrong-key and damaged-header paths age leaves a PRE-EXISTING
+    # `--output` file completely untouched (rc=1, file present, original 34-byte
+    # content intact) — it only creates the file once it has authenticated the
+    # header. Consumers therefore read the PRESENCE of `plain` as "age got past
+    # the header", and a leftover from an aborted earlier run turns that into a
+    # lie: a WRONG KEY reads as a corrupt artifact.
+    #
+    # `work_dir` is routinely REUSED — `B._private_dir` documents the
+    # already-exists case as "every run after the first with an explicit
+    # --work-dir" — so this is an ordinary sequence, not an exotic one: abort a
+    # run mid-decrypt, re-run with the same --work-dir, get a confident wrong
+    # answer.
+    #
+    # One unlink removes the whole class. The same reasoning already guards the
+    # throwaway identity in `escrow-verify.py::_create_private_file`; it was
+    # applied there and not here, which is a predicate that was right at one of
+    # its two sites.
+    plain.unlink(missing_ok=True)
     p = subprocess.run(
         ["age", "--decrypt", "--identity", str(identity),
          "--output", str(plain), str(cipher)],

--- a/scripts/analyze-service-index/restore-verify.py
+++ b/scripts/analyze-service-index/restore-verify.py
@@ -225,6 +225,27 @@ _STAMP_FMT = "%Y%m%dT%H%M%SZ"
 _STAMP_RE = re.compile(r"^(?P<stamp>\d{8}T\d{6}Z)\.bundle\.age$")
 
 
+# 🔴 MACHINE-READABLE CAUSES FOR THE DECRYPT STEP. `decrypt()` below has three
+# distinct failure branches and they mean COMPLETELY different things to a
+# caller — one is an environment fault, one says the identity does not open the
+# artifact, and one says the identity DID open it and the artifact holds
+# nothing. Every one of them raises `RestoreVerifyError`, so from the outside
+# they were separable only by reading the message text.
+#
+# `escrow-verify.py` has to make exactly that distinction to decide whether a
+# failure is a verdict on the ESCROWED KEY or on the ARTIFACT, and getting it
+# wrong there reports a tampered backup as "nothing to worry about" or gets a
+# working disaster-recovery key rotated. Substring-matching another module's
+# prose is the approach that whole feature exists to remove, so the cause is
+# published as a value instead — set HERE, by the module that knows.
+DECRYPT_AGE_MISSING = "age-missing"          # the binary is not on PATH
+DECRYPT_AGE_REFUSED = "age-refused"          # age exited NON-ZERO
+DECRYPT_EMPTY_PLAINTEXT = "empty-plaintext"  # age exited ZERO, wrote 0 bytes
+
+DECRYPT_CAUSES = frozenset(
+    {DECRYPT_AGE_MISSING, DECRYPT_AGE_REFUSED, DECRYPT_EMPTY_PLAINTEXT})
+
+
 class RestoreVerifyError(B.BackupError):
     """A failure that must make the whole run non-zero.
 
@@ -232,7 +253,22 @@ class RestoreVerifyError(B.BackupError):
     script's own refusals and the ones raised by the helpers it reuses from
     `backup.py` (`_git_scratch`'s store guard, most importantly). Two exception
     hierarchies over one pipeline is how a failure escapes to a bare traceback.
+
+    `cause` is an OPTIONAL machine-readable tag, currently set only by
+    `decrypt()` (see `DECRYPT_CAUSES` above). It defaults to None everywhere
+    else, so a caller that reads it gets an explicit "this failure carries no
+    published cause" rather than a wrong one — never treat None as a default
+    cause.
     """
+
+    def __init__(self, message: str, *, cause: str | None = None):
+        super().__init__(message)
+        if cause is not None and cause not in DECRYPT_CAUSES:
+            raise KeyError(
+                f"{cause!r} is not a published cause. The set is closed on "
+                f"purpose: a consumer branches on these, so inventing one "
+                f"silently lands in whatever `else` that consumer has.")
+        self.cause = cause
 
 
 # --------------------------------------------------------------------------- #
@@ -523,7 +559,8 @@ def decrypt(cipher: Path, plain: Path, identity: Path) -> None:
             "flake.nix `gateTools`; add it there rather than working around it. "
             "There is no fallback: an artifact this cannot decrypt is an "
             "artifact this cannot verify, and skipping it would report safety "
-            "that was never measured.")
+            "that was never measured.",
+            cause=DECRYPT_AGE_MISSING)
     p = subprocess.run(
         ["age", "--decrypt", "--identity", str(identity),
          "--output", str(plain), str(cipher)],
@@ -534,7 +571,8 @@ def decrypt(cipher: Path, plain: Path, identity: Path) -> None:
             f"{p.stderr.strip()}. The object was retrieved but the identity at "
             f"{identity} does not open it, or the ciphertext is damaged. This is "
             f"NOT a corruption verdict about the git history inside — nothing "
-            f"here has read it.")
+            f"here has read it.",
+            cause=DECRYPT_AGE_REFUSED)
     if not plain.is_file() or plain.stat().st_size == 0:
         # 🔴 MEASURED: `age` encrypts a ZERO-BYTE payload to a perfectly valid
         # 200-byte ciphertext, and decrypts it back at rc=0. So an object that
@@ -548,7 +586,8 @@ def decrypt(cipher: Path, plain: Path, identity: Path) -> None:
             f"bytes. age reported success, so this is not damage — it is a "
             f"valid encryption of nothing. An empty bundle restores to nothing "
             f"and would otherwise be reported as a clean restore of a scope "
-            f"with no history.")
+            f"with no history.",
+            cause=DECRYPT_EMPTY_PLAINTEXT)
     os.chmod(plain, _FILE_MODE)
 
 

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -1633,17 +1633,56 @@ def test_a_STALE_plaintext_cannot_turn_a_WRONG_KEY_into_ARTIFACT_CORRUPT(tmp_pat
 
 def test_the_probe_reports_an_UNREADABLE_plaintext_path_as_UNKNOWN(tmp_path,
                                                                   monkeypatch):
-    """🔴 `Path.exists()` RAISES ON THIS INTERPRETER — measured, CPython 3.12.14,
-    parent directory without `+x`. Unhandled inside the probe's `except`, it
-    would REPLACE the real exception, and the run would report a permissions
-    error instead of whatever age actually did.
+    """🔴 THIS TEST IS INTERPRETER-DEPENDENT, AND THAT IS THE MECHANISM.
 
-    Unreadable must read as None (unobservable), never False (which downstream
-    would take for "age wrote nothing")."""
+    A parent directory without `+x` makes `Path.exists()` raise `PermissionError`
+    — or not — depending on the CPython version. MEASURED, three interpreters,
+    twice each (behaviour, and whether `Path.exists`'s source still calls
+    `pathlib._ignore_error`):
+
+        3.12.14 (the flake's pin)  raises PermissionError   _ignore_error: yes
+        3.13.15                    raises PermissionError   _ignore_error: yes
+        3.14.7                     returns False            _ignore_error: no
+
+    `_ignore_error` swallows only ENOENT/ENOTDIR/EBADF/ELOOP, so EACCES
+    propagates; 3.14 dropped that helper from `exists()` and swallows
+    unconditionally.
+
+    🔴 THE BOUNDARY IS 3.14, NOT 3.13. An earlier revision of the source comment
+    said 3.13; a version guard written to that number would have gone RED on 3.13
+    for a reason nobody could find, in a test whose name reads like a logic bug —
+    exactly the failure this guard exists to prevent, reintroduced by the guard.
+    So the expectation is NOT keyed on a version literal at all: it is taken from
+    an INDEPENDENT probe of the interpreter, on its own path, not through the
+    module under test. The version table above is documentation; the probe is the
+    control.
+
+    Either way the requirement is the same and is what is asserted: no OSError
+    escapes the handler, and an unreadable path reads as None (unobservable) —
+    never False, which downstream would take for "age wrote nothing".
+    """
     if os.geteuid() == 0:
         pytest.skip("root traverses a directory without +x; the arm is "
                     "unreachable as root and a skip here is honest")
     RVmod = EV._rv()
+
+    # INDEPENDENT REGIME PROBE: same hazard, its own directory, no involvement
+    # from the module under test. This is what makes the assertion below
+    # meaningful on an interpreter nobody has run this suite on yet.
+    canary_dir = tmp_path / "regime"
+    canary_dir.mkdir()
+    canary = canary_dir / "c"
+    canary.write_text("x", encoding="utf-8")
+    os.chmod(canary_dir, 0o600)
+    try:
+        try:
+            canary.exists()
+            exists_raises = False
+        except OSError:
+            exists_raises = True
+    finally:
+        os.chmod(canary_dir, 0o700)
+
     holder = tmp_path / "noexec"
     holder.mkdir()
     plain = holder / "p.bundle"
@@ -1658,9 +1697,22 @@ def test_the_probe_reports_an_UNREADABLE_plaintext_path_as_UNKNOWN(tmp_path,
         with EV._decrypt_phase_probe(RVmod) as state:
             with pytest.raises(RVmod.RestoreVerifyError):
                 RVmod.decrypt(tmp_path / "c.age", plain, tmp_path / "k")
-        # POSITIVE CONTROL: without the handler this line is never reached,
-        # because `exists()` raises out of the `except` block.
-        assert state["plain_present"] is None
+        # 🔴 The real exception got out INTACT on every interpreter — that is the
+        # part that must never regress, and it is asserted above by
+        # `pytest.raises(RestoreVerifyError)` rather than PermissionError.
+        if exists_raises:
+            # Handler LIVE: without it this line is never reached, because
+            # `exists()` raises out of the probe's `except` block.
+            assert state["plain_present"] is None, (
+                "the OSError handler did not run on an interpreter whose "
+                "Path.exists() raises")
+        else:
+            # Handler DEAD on this interpreter: `exists()` answered False by
+            # itself. Asserted rather than skipped, so the test still covers the
+            # probe's behaviour instead of quietly covering nothing.
+            assert state["plain_present"] is False, (
+                "Path.exists() returned rather than raising, so the probe should "
+                "have recorded its answer verbatim")
         assert state["cause"] == RVmod.DECRYPT_AGE_REFUSED
     finally:
         os.chmod(holder, 0o700)

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -1,0 +1,1339 @@
+"""Tests for scripts/analyze-service-index/escrow-verify.py — the ESCROW VERIFIER.
+
+WHAT IS BEING PROTECTED
+-----------------------
+`backup.py` and `restore-verify.py` both decrypt with ONE file. Escrowing that
+file into Vaultwarden removes the single point of failure only if the escrow is
+still there, still correct and still working — three claims, and a verifier that
+collapses them (or that reports success having checked nothing) puts the
+subsystem back where it started while looking green.
+
+So this suite is mostly about the DIFFERENCES between failures. A single
+"escrow check failed" is what this repo has been bitten by repeatedly; every
+refusal here is asserted by its own TOKEN and its own EXIT CODE, not by a
+substring of prose, because a substring assertion cannot tell a true sentence
+from a confident wrong one.
+
+🔴 ALL FIXTURES ARE SYNTHETIC AND PAIRWISE DISTINCT. devrc is a public repo. No
+real key material, no real item name, no real endpoint and no real host label
+appears here. The two key-shaped fixtures differ in every line, are different
+lengths (179 vs 180 bytes), and neither length equals any constant this suite
+asserts — a fixture that can only produce the constant's own value cannot see a
+mutant that hardcodes the literal.
+
+🔴 NOTHING HERE SKIPS and NOTHING HERE SHELLS OUT TO A REAL `bw`. `git`, `age`
+and `age-keygen` are hard requirements resolved at import, exactly as in the
+backup and restore suites. `bw` is injected at a seam — both the RUNNER and the
+PATH LOCATOR — so the "`bw` is not installed" branch is reachable on a host
+where `bw` IS installed, and vice versa.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+SCRIPT = SCRIPTS / "analyze-service-index" / "escrow-verify.py"
+RESTORE_SCRIPT = SCRIPTS / "analyze-service-index" / "restore-verify.py"
+
+sys.path.insert(0, str(SCRIPTS / "analyze-service-index"))
+sys.path.insert(0, str(SCRIPTS))
+
+import backup as B  # noqa: E402
+
+
+def _load(name: str, path: Path):
+    """Import a module whose FILE NAME contains a hyphen.
+
+    `sys.modules[name] = mod` BEFORE `exec_module` is REQUIRED: `@dataclass`
+    resolves its annotations by looking the defining module up in `sys.modules`,
+    and without the registration every test here becomes a collection error.
+    """
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+EV = _load("escrow_verify", SCRIPT)
+RV = _load("restore_verify", RESTORE_SCRIPT)
+
+
+def _require(tool: str, why: str) -> str:
+    p = shutil.which(tool)
+    if p is None:  # pragma: no cover - the flake check puts all three on PATH
+        raise RuntimeError(
+            f"{tool} is not on PATH. {why} It is declared in nix/pkgs/default.nix "
+            f"and in flake.nix `gateTools`; add it there rather than skipping "
+            f"these tests — a skipped escrow test reports recoverability it "
+            f"never measured.")
+    return p
+
+
+GIT: str = _require("git", "The decrypt check restores a real git bundle.")
+AGE: str = _require("age", "The artifacts are age ciphertext.")
+AGE_KEYGEN: str = _require("age-keygen", "Identities here are generated per run.")
+
+
+# --------------------------------------------------------------------------- #
+# synthetic fixtures — pairwise distinct, none of them a default
+# --------------------------------------------------------------------------- #
+HOST = "synthetic-escrow-host"
+PREFIX = HOST + "/"
+ITEM = "synthetic escrow note — delta"
+SERVER = "https://vault.invalid.example"
+
+# 🔴 KEY-SHAPED, NOT A KEY. Both are 3 lines and neither is a valid age
+# identity: nothing in the BYTE-CHECK half of this script ever calls age, and a
+# fixture that looked like a working key would invite someone to reuse it where
+# one is needed. The decrypt half generates real throwaway identities instead.
+ESCROW_NOTE = (
+    "# created: 2026-01-02T03:04:05Z\n"
+    "# public key: age1synthetic00000000000000000000000000000000000000000000000\n"
+    "AGE-SECRET-KEY-1SYNTHETIC0000000000000000000000000000000000000000000000\n"
+)
+ESCROW_NOTE_BYTES = 179          # pinned literal; asserted against the fixture below
+
+OTHER_KEY = (
+    "# created: 2019-11-12T13:14:15Z\n"
+    "# public key: age1localdisk0000000000000000000000000000000000000000000000\n"
+    "AGE-SECRET-KEY-1LOCALDISK000000000000000000000000000000000000000000000000\n"
+)
+OTHER_KEY_BYTES = 180            # pinned literal, and DIFFERENT from the one above
+
+# Bitwarden's Secure Note type id. Pinned as a literal rather than read from the
+# module under test: a test that imports the constant it checks proves only that
+# the module agrees with itself.
+SECURE_NOTE = 2
+
+NOW = datetime(2026, 3, 9, 17, 42, 5, tzinfo=timezone.utc)
+
+
+def test_the_key_shaped_fixtures_are_the_lengths_this_suite_PINS():
+    """HARNESS SELF-CHECK. Every byte-count assertion below is a literal; if a
+    later edit reflows a fixture, this goes red loudly instead of the pins
+    silently tracking the new value."""
+    assert len(ESCROW_NOTE.encode("utf-8")) == ESCROW_NOTE_BYTES
+    assert len(OTHER_KEY.encode("utf-8")) == OTHER_KEY_BYTES
+    assert ESCROW_NOTE_BYTES != OTHER_KEY_BYTES
+    assert ESCROW_NOTE != OTHER_KEY
+    # Pairwise distinct LINE BY LINE, so no assertion below can pass by two
+    # fixtures happening to share a line.
+    assert not (set(ESCROW_NOTE.splitlines()) & set(OTHER_KEY.splitlines()))
+
+
+def _one_byte_different(text: str) -> str:
+    """The same length, one byte changed in the middle.
+
+    🔴 SAME LENGTH ON PURPOSE. A negative control built by appending would also
+    be caught by a comparison that only looked at `len()`, and would then certify
+    a byte check that never compares bytes.
+    """
+    i = len(text) // 2
+    ch = "X" if text[i] != "X" else "Y"
+    return text[:i] + ch + text[i + 1:]
+
+
+# --------------------------------------------------------------------------- #
+# the `bw` seam — a fake RUNNER and a fake LOCATOR
+# --------------------------------------------------------------------------- #
+class FakeBw:
+    """Serves canned `bw` answers and RECORDS every argv it was given.
+
+    🔴 An unknown command is an assertion failure, never a quiet empty answer. A
+    fake that returned `{}` for a command it did not recognise would let a
+    mis-dispatched call read as a clean result — the harness manufacturing the
+    all-clear the script exists to refuse.
+    """
+
+    def __init__(self, *, status: dict | None = None, server: str = SERVER,
+                 items: list | None = None, status_rc: int = 0,
+                 server_rc: int = 0, items_rc: int = 0,
+                 status_out: str | None = None, items_out: str | None = None,
+                 raise_timeout_on: str | None = None):
+        self.status_doc = {"serverUrl": SERVER, "status": "unlocked"} \
+            if status is None else status
+        self.server = server
+        self.items = [] if items is None else items
+        self.status_rc, self.server_rc, self.items_rc = status_rc, server_rc, items_rc
+        self.status_out, self.items_out = status_out, items_out
+        self.raise_timeout_on = raise_timeout_on
+        self.calls: list[list[str]] = []
+        self.timeouts: list[float] = []
+        self.searches: list[str] = []
+
+    def __call__(self, argv, *, timeout):
+        self.calls.append(list(argv))
+        self.timeouts.append(timeout)
+        rest = [a for a in argv[1:] if a != "--nointeraction"]
+        verb = " ".join(rest[:2])
+        if self.raise_timeout_on is not None and rest[0] == self.raise_timeout_on:
+            raise subprocess.TimeoutExpired(cmd=list(argv), timeout=timeout)
+        if rest[0] == "status":
+            out = (self.status_out if self.status_out is not None
+                   else json.dumps(self.status_doc))
+            return subprocess.CompletedProcess(argv, self.status_rc, out, "")
+        if verb == "config server":
+            return subprocess.CompletedProcess(argv, self.server_rc,
+                                               self.server + "\n", "")
+        if verb == "list items":
+            self.searches.append(rest[rest.index("--search") + 1])
+            out = (self.items_out if self.items_out is not None
+                   else json.dumps(self.items))
+            return subprocess.CompletedProcess(argv, self.items_rc, out, "")
+        raise AssertionError(
+            f"FakeBw was asked for an unmodelled command: {argv!r}. Returning a "
+            f"benign answer here would make a mis-dispatched call look clean.")
+
+
+def _cli(fake: FakeBw, *, locator=lambda name: "/nonexistent/bin/bw") -> EV.BitwardenCLI:
+    return EV.BitwardenCLI(runner=fake, locator=locator, bw="bw", timeout=7.5)
+
+
+def _item(name: str = ITEM, notes: str | None = ESCROW_NOTE,
+          type_: int = SECURE_NOTE, id_: str = "synthetic-item-id-0001") -> dict:
+    d = {"id": id_, "name": name, "type": type_, "favorite": False}
+    if notes is not None:
+        d["notes"] = notes
+    return d
+
+
+def _identity(tmp_path: Path, text: str = ESCROW_NOTE,
+              name: str = "on-disk.key") -> Path:
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    p.chmod(0o600)
+    return p
+
+
+def _run(tmp_path: Path, fake: FakeBw, *, identity_text: str = ESCROW_NOTE,
+         item_name: str = ITEM, **kw):
+    return EV.run(bw=_cli(fake), identity=_identity(tmp_path, identity_text),
+                  item_name=item_name, now=NOW, **kw)
+
+
+# --------------------------------------------------------------------------- #
+# 0. harness self-validation — validate the INSTRUMENT before reading its verdict
+# --------------------------------------------------------------------------- #
+def test_the_verifier_imported_and_carries_the_symbols_this_suite_reads():
+    """POSITIVE CONTROL for the hyphenated-filename loader.
+
+    A loader that silently produced an empty module would make every `getattr`
+    below fail confusingly — or, worse, make a tolerant assertion pass against
+    nothing."""
+    assert SCRIPT.is_file(), f"{SCRIPT} missing — every test below is vacuous"
+    for name in ("run", "classify", "decrypt_check", "read_identity",
+                 "check_vault_state", "check_server", "find_escrow_item",
+                 "read_note", "BitwardenCLI", "EscrowError", "EXIT_CODES",
+                 "_shred", "_rv"):
+        assert hasattr(EV, name), f"the loaded module has no {name!r}"
+
+
+def test_the_fake_bw_actually_observes_the_calls_it_is_asked_about():
+    """POSITIVE CONTROL for the instrument every test below reads.
+
+    A fake wired to nothing records zero calls, and every "the script asked the
+    vault" assertion would then be about a harness that never ran. Watch the
+    counters move before trusting them."""
+    f = FakeBw(items=[_item()])
+    assert f.calls == [] and f.searches == []
+    cli = _cli(f)
+    assert cli.status()["status"] == "unlocked"
+    assert cli.config_server() == SERVER
+    assert [i["name"] for i in cli.search_items(ITEM)] == [ITEM]
+    assert len(f.calls) == 3, f.calls
+    assert f.searches == [ITEM]
+
+
+def test_the_fake_bw_REFUSES_an_unmodelled_command():
+    """NEGATIVE CONTROL for the fake itself: it must not invent clean answers."""
+    f = FakeBw()
+    with pytest.raises(AssertionError):
+        f(["bw", "--nointeraction", "sync"], timeout=1.0)
+
+
+# --------------------------------------------------------------------------- #
+# 1. the failure vocabulary is an ENUMERATION, pinned as literals
+# --------------------------------------------------------------------------- #
+def test_the_exit_code_table_is_pinned_EXACTLY_both_ways():
+    """🔴 THE WHOLE POINT OF THIS SCRIPT, pinned.
+
+    Distinguishable failure modes are the deliverable, so the token->code map is
+    asserted as an EXACT dict of literals — not a subset, not a length. Adding a
+    cause means editing this line, which is a reviewed act; silently reusing an
+    existing code (the conflation this replaces) cannot happen unnoticed.
+    """
+    assert EV.EXIT_CODES == {
+        "BW-MISSING": 10,
+        "BW-FAILED": 11,
+        "VAULT-LOCKED": 12,
+        "VAULT-UNAUTHENTICATED": 13,
+        "VAULT-STATUS-UNKNOWN": 14,
+        "SERVER-UNKNOWN": 15,
+        "SERVER-MISMATCH": 16,
+        "ITEM-NOT-FOUND": 17,
+        "ITEM-AMBIGUOUS": 18,
+        "ITEM-WRONG-TYPE": 19,
+        "NOTE-EMPTY": 20,
+        "BYTES-DIFFER-TRAILING-NEWLINE": 21,
+        "BYTES-DIFFER-MATERIALLY": 22,
+        "IDENTITY-MISSING": 23,
+        "IDENTITY-EMPTY": 24,
+        "DECRYPT-FAILED": 25,
+        "RESTORE-FAILED": 26,
+        "STORE-UNREACHABLE": 27,
+        "NO-ARTIFACT": 28,
+    }
+
+
+def test_every_exit_code_is_DISTINCT_and_never_collides_with_success_or_crash():
+    """A table with two names on one number is a conflated failure with extra
+    steps, and 0/1 already mean success and unexpected-crash."""
+    codes = list(EV.EXIT_CODES.values())
+    assert len(set(codes)) == len(codes), "two tokens share an exit code"
+    assert EV.EXIT_OK == 0 and EV.EXIT_UNEXPECTED == 1
+    assert 0 not in codes and 1 not in codes
+    assert min(codes) >= 10
+
+
+def test_an_unknown_token_CANNOT_be_raised():
+    """The code is DERIVED from the token, so a refusal cannot carry the wrong
+    one — and a token with no table entry is a programming error, loudly."""
+    with pytest.raises(KeyError):
+        EV.EscrowError("NOT-A-REAL-TOKEN", "x")
+    e = EV.EscrowError("VAULT-LOCKED", "x")
+    assert e.exit_code == 12 and e.token == "VAULT-LOCKED"
+    assert str(e).startswith("VAULT-LOCKED: ")
+
+
+# --------------------------------------------------------------------------- #
+# 2. the comparison itself
+# --------------------------------------------------------------------------- #
+def test_classify_returns_the_three_PINNED_literals():
+    """Pinned as literal strings: a verdict is a machine-readable claim, and a
+    renamed classification is a broken consumer, not a cosmetic change."""
+    assert EV.classify(b"abc", b"abc") == "IDENTICAL"
+    assert EV.classify(b"abc\n", b"abc") == "DIFFERS-TRAILING-NEWLINE-ONLY"
+    assert EV.classify(b"abc", b"abd") == "DIFFERS-MATERIALLY"
+    assert (EV.CLASS_IDENTICAL, EV.CLASS_TRAILING_NEWLINE, EV.CLASS_MATERIAL) == (
+        "IDENTICAL", "DIFFERS-TRAILING-NEWLINE-ONLY", "DIFFERS-MATERIALLY")
+
+
+def test_classify_calls_a_CRLF_rewrite_MATERIAL_not_a_trailing_newline():
+    """A CRLF round-trip changes EVERY line ending, not the last byte. Calling
+    it "trailing newline only" would tell the operator the escrow is fine."""
+    unix = b"one\ntwo\nthree\n"
+    dos = b"one\r\ntwo\r\nthree\r\n"
+    assert EV.classify(dos, unix) == "DIFFERS-MATERIALLY"
+
+
+def test_classify_does_not_confuse_a_leading_newline_with_a_trailing_one():
+    assert EV.classify(b"\nabc\n", b"abc\n") == "DIFFERS-MATERIALLY"
+
+
+# --------------------------------------------------------------------------- #
+# 3. 🔴 THE POSITIVE CONTROL — and it asserts bytes were actually COMPARED
+# --------------------------------------------------------------------------- #
+def test_an_identical_escrow_PASSES_and_the_comparison_saw_nonzero_bytes(tmp_path):
+    """🔴 A CHECKER WIRED TO NOTHING ALSO REPORTS "no problems".
+
+    So the pass is not the whole assertion: the verdict must carry the number of
+    bytes it compared, that number must be NON-ZERO, and it must equal the
+    fixture's own pinned length on BOTH sides.
+    """
+    f = FakeBw(items=[_item()])
+    v = _run(tmp_path, f)
+    assert v.classification == "IDENTICAL"
+    assert v.escrow_bytes == ESCROW_NOTE_BYTES > 0
+    assert v.disk_bytes == ESCROW_NOTE_BYTES > 0
+    assert v.decrypt_checked is False
+    # The vault really was consulted — three commands, in order.
+    assert [c[2] for c in f.calls] == ["status", "config", "list"], f.calls
+    assert f.searches == [ITEM]
+
+
+def test_the_verdict_line_says_it_did_NOT_prove_the_key_works(tmp_path):
+    """Byte equality proves the copies AGREE. A verdict that let "verified"
+    stand for "and it opens the artifacts" would be the wider-than-the-code
+    sentence this subsystem keeps being bitten by."""
+    v = _run(tmp_path, FakeBw(items=[_item()]))
+    line = v.line()
+    assert "NOT DECRYPT-CHECKED" in line
+    assert "--decrypt-check" in line
+    assert "DECRYPT-CHECKED: " not in line
+    assert str(ESCROW_NOTE_BYTES) in line
+
+
+def test_the_search_is_EXACT_even_though_bw_search_is_FUZZY(tmp_path):
+    """`bw list items --search` returns candidates. A near-miss must not be
+    accepted, and the ambiguity check must not be fooled by one either."""
+    f = FakeBw(items=[_item(name=ITEM + " (old)"), _item(name=ITEM)])
+    v = _run(tmp_path, f)
+    assert v.classification == "IDENTICAL"
+
+
+# --------------------------------------------------------------------------- #
+# 4. 🔴 THE NEGATIVE CONTROLS — one byte, and a newline
+# --------------------------------------------------------------------------- #
+def test_a_ONE_BYTE_difference_FAILS_with_the_MATERIAL_token(tmp_path):
+    """🔴 SAME LENGTH, one byte changed. A comparison that only checked `len()`
+    would pass this, and would then be certifying a check it never made."""
+    mutated = _one_byte_different(ESCROW_NOTE)
+    assert len(mutated) == len(ESCROW_NOTE) and mutated != ESCROW_NOTE
+    f = FakeBw(items=[_item(notes=mutated)])
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, f)
+    assert ei.value.token == "BYTES-DIFFER-MATERIALLY"
+    assert ei.value.exit_code == 22
+
+
+def test_a_WHOLLY_different_key_FAILS_materially_and_reports_BOTH_counts(tmp_path):
+    f = FakeBw(items=[_item(notes=OTHER_KEY)])
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, f, identity_text=ESCROW_NOTE)
+    assert ei.value.token == "BYTES-DIFFER-MATERIALLY"
+    msg = str(ei.value)
+    # Kind AND count: both measured numbers appear, and they are the two
+    # DIFFERENT fixture lengths — a message that printed one of them twice, or
+    # printed a constant, cannot satisfy this.
+    assert str(OTHER_KEY_BYTES) in msg and str(ESCROW_NOTE_BYTES) in msg
+
+
+def test_a_TRAILING_NEWLINE_difference_is_its_OWN_classification(tmp_path):
+    """🔴 NOT a generic mismatch and NOT a pass.
+
+    Vaultwarden may trim. An age identity still decrypts without its final
+    newline, so this is the one difference whose remedy is one `printf` — and
+    the operator cannot choose that remedy if the verifier calls it corruption.
+    """
+    trimmed = ESCROW_NOTE.rstrip("\n")
+    assert len(trimmed) == ESCROW_NOTE_BYTES - 1
+    f = FakeBw(items=[_item(notes=trimmed)])
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, f)
+    assert ei.value.token == "BYTES-DIFFER-TRAILING-NEWLINE"
+    assert ei.value.exit_code == 21
+    assert ei.value.exit_code != EV.EXIT_CODES["BYTES-DIFFER-MATERIALLY"]
+    assert ei.value.exit_code != EV.EXIT_OK
+
+
+def test_the_trailing_newline_case_is_NOT_reported_as_a_pass(tmp_path):
+    """The failure that would matter most if this were only a classification:
+    a trimmed note must still make the RUN fail, not merely be labelled."""
+    f = FakeBw(items=[_item(notes=ESCROW_NOTE.rstrip("\n"))])
+    with pytest.raises(EV.EscrowError):
+        _run(tmp_path, f)
+
+
+# --------------------------------------------------------------------------- #
+# 5. 🔴 NO KEY MATERIAL IN ANY MESSAGE
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("note", [
+    _one_byte_different(ESCROW_NOTE),
+    OTHER_KEY,
+    ESCROW_NOTE.rstrip("\n"),
+])
+def test_no_message_on_a_mismatch_path_contains_key_material(tmp_path, note):
+    """🔴 A mismatch reports COUNTS AND A CLASSIFICATION. Never the content.
+
+    Asserted against every substantial line of BOTH fixtures, so a message that
+    quoted either side — or a diff of them — goes red.
+    """
+    f = FakeBw(items=[_item(notes=note)])
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, f)
+    msg = str(ei.value)
+    leaked = [ln for ln in set(ESCROW_NOTE.splitlines()) | set(OTHER_KEY.splitlines())
+              | set(note.splitlines()) if len(ln) > 20 and ln in msg]
+    assert leaked == [], f"key material in the message: {len(leaked)} line(s)"
+    assert "AGE-SECRET-KEY" not in msg
+
+
+# --------------------------------------------------------------------------- #
+# 6. the item: missing / ambiguous / empty / wrong type — four findings
+# --------------------------------------------------------------------------- #
+def test_an_ABSENT_item_is_its_own_failure(tmp_path):
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, FakeBw(items=[]))
+    assert ei.value.token == "ITEM-NOT-FOUND"
+    assert ei.value.exit_code == 17
+
+
+def test_a_near_miss_name_is_still_ITEM_NOT_FOUND(tmp_path):
+    """The fuzzy search returned something; the exact match did not."""
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, FakeBw(items=[_item(name=ITEM + " (archived)")]))
+    assert ei.value.token == "ITEM-NOT-FOUND"
+
+
+def test_TWO_items_with_the_SAME_name_is_AMBIGUOUS_not_a_pick(tmp_path):
+    """🔴 Choosing one would turn a coin flip into a verdict, and a stale
+    duplicate holding a rotated-out key would verify green forever."""
+    f = FakeBw(items=[_item(id_="a"), _item(id_="b")])
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, f)
+    assert ei.value.token == "ITEM-AMBIGUOUS"
+    assert ei.value.exit_code == 18
+    assert "2" in str(ei.value), "the message must say HOW MANY it found"
+
+
+def test_ambiguity_is_detected_even_when_BOTH_copies_would_have_PASSED(tmp_path):
+    """🔴 THE REACHABILITY CASE. With two identical, correct notes a verifier
+    that picked the first would exit 0 and nobody would ever see the duplicate.
+    The ambiguity guard must fire on the happy content, not only on bad."""
+    f = FakeBw(items=[_item(id_="a", notes=ESCROW_NOTE),
+                      _item(id_="b", notes=ESCROW_NOTE)])
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, f)
+    assert ei.value.token == "ITEM-AMBIGUOUS"
+
+
+def test_an_EMPTY_note_body_is_its_own_failure(tmp_path):
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, FakeBw(items=[_item(notes="")]))
+    assert ei.value.token == "NOTE-EMPTY"
+    assert ei.value.exit_code == 20
+
+
+def test_a_WHITESPACE_ONLY_note_is_EMPTY_not_a_mismatch(tmp_path):
+    """It is the same finding — the escrow is gone — and reporting it as a byte
+    mismatch would send the operator looking for a corrupted copy."""
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, FakeBw(items=[_item(notes="   \n\t\n")]))
+    assert ei.value.token == "NOTE-EMPTY"
+
+
+def test_a_MISSING_notes_field_is_EMPTY_not_a_crash(tmp_path):
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, FakeBw(items=[_item(notes=None)]))
+    assert ei.value.token == "NOTE-EMPTY"
+
+
+def test_the_right_NAME_on_the_wrong_TYPE_is_refused(tmp_path):
+    """🔴 A GUARD ON STATE, NOT ON A WORD ANOTHER ITEM CAN SPELL. Any item type
+    can be given any name; only a Secure Note is the escrow."""
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, FakeBw(items=[_item(type_=1)]))
+    assert ei.value.token == "ITEM-WRONG-TYPE"
+    assert ei.value.exit_code == 19
+
+
+# --------------------------------------------------------------------------- #
+# 7. the vault's state — distinct, actionable, and it CANNOT hang
+# --------------------------------------------------------------------------- #
+def test_a_LOCKED_vault_fails_distinctly_and_names_the_UNLOCK_command(tmp_path):
+    f = FakeBw(status={"serverUrl": SERVER, "status": "locked"})
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, f)
+    assert ei.value.token == "VAULT-LOCKED"
+    assert ei.value.exit_code == 12
+    msg = str(ei.value)
+    # DISCRIMINATING, not a substring presence check: the locked remedy is
+    # `bw unlock`, and naming `bw login` here would send the operator to the
+    # OTHER failure's remedy — which is exactly the conflation being tested.
+    assert 'bw unlock --raw' in msg
+    assert "bw login" not in msg
+    # It must not have gone on to ask the vault anything.
+    assert [c[2] for c in f.calls] == ["status"], f.calls
+
+
+def test_an_UNAUTHENTICATED_vault_is_a_DIFFERENT_failure_with_a_DIFFERENT_remedy(tmp_path):
+    f = FakeBw(status={"serverUrl": SERVER, "status": "unauthenticated"})
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, f)
+    assert ei.value.token == "VAULT-UNAUTHENTICATED"
+    assert ei.value.exit_code == 13
+    assert ei.value.exit_code != EV.EXIT_CODES["VAULT-LOCKED"]
+    assert "bw login" in str(ei.value)
+    assert [c[2] for c in f.calls] == ["status"], f.calls
+
+
+def test_an_UNRECOGNISED_status_is_UNKNOWN_and_never_treated_as_unlocked(tmp_path):
+    """🔴 An empty/odd result cannot distinguish its causes. Treating it as
+    `unlocked` is how a run reports a clean escrow it never read."""
+    for weird in ("", "Unlocked", "UNLOCKED", "pending", None):
+        f = FakeBw(status={"serverUrl": SERVER, "status": weird})
+        with pytest.raises(EV.EscrowError) as ei:
+            _run(tmp_path, f)
+        assert ei.value.token == "VAULT-STATUS-UNKNOWN", weird
+        assert ei.value.exit_code == 14
+
+
+def test_status_json_that_is_not_an_object_is_UNKNOWN(tmp_path):
+    f = FakeBw(status_out='["unlocked"]')
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, f)
+    assert ei.value.token == "VAULT-STATUS-UNKNOWN"
+
+
+def test_status_that_is_not_JSON_at_all_is_BW_FAILED_not_a_crash(tmp_path):
+    f = FakeBw(status_out="You are not logged in.\n")
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, f)
+    assert ei.value.token == "BW-FAILED"
+    assert ei.value.exit_code == 11
+
+
+def test_a_nonzero_bw_exit_is_BW_FAILED_and_its_OUTPUT_IS_NOT_QUOTED(tmp_path):
+    """🔴 `bw list items` output is key material and `bw status` carries the
+    server and the account email. Neither may reach a message."""
+    canary = "AGE-SECRET-KEY-1CANARYMUSTNOTAPPEARINANYMESSAGE"
+    f = FakeBw(items_rc=3, items_out=canary)
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, f)
+    assert ei.value.token == "BW-FAILED"
+    assert canary not in str(ei.value)
+
+
+@pytest.mark.parametrize("kw", [{"status_rc": 4}, {"server_rc": 5}, {"items_rc": 6}])
+def test_a_nonzero_bw_exit_FAILS_even_when_the_OUTPUT_is_perfectly_valid(tmp_path, kw):
+    """🔴 REACHABILITY, MEASURED — this test exists because its absence let a
+    mutant live.
+
+    The test above feeds UNPARSEABLE output alongside the non-zero exit, so the
+    JSON guard speaks first: deleting the exit-status check entirely kept that
+    test green, and a mutation sweep scored the mutant SURVIVED. Here every
+    stream is well-formed and the ONLY thing wrong is the status, so no earlier
+    check can answer and the rc guard has to be the one that fires — on all
+    three commands, including `config server`, whose output is not JSON at all
+    and therefore has no second guard behind it.
+    """
+    f = FakeBw(items=[_item()], **kw)
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, f)
+    assert ei.value.token == "BW-FAILED"
+    assert ei.value.exit_code == 11
+
+
+def test_a_TIMEOUT_is_BW_FAILED_and_says_it_was_not_a_password_prompt(tmp_path):
+    """The non-hanging guarantee's failure mode, named. A run that stalls must
+    end, and must not leave the reader guessing whether it was waiting on them."""
+    f = FakeBw(raise_timeout_on="status")
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, f)
+    assert ei.value.token == "BW-FAILED"
+    assert "7.5" in str(ei.value), "the ceiling that was hit must be named"
+
+
+def test_EVERY_bw_call_passes_nointeraction_in_the_SAME_position(tmp_path):
+    """A flag is a request; the count is the measurement. Every call, not most."""
+    f = FakeBw(items=[_item()])
+    _run(tmp_path, f)
+    assert len(f.calls) == 3
+    assert [c[1] for c in f.calls] == ["--nointeraction"] * 3
+    assert f.timeouts == [7.5, 7.5, 7.5]
+
+
+def test_the_REAL_runner_gives_bw_no_stdin_and_a_timeout(monkeypatch):
+    """🔴 THE MECHANISM, not the manners. `--nointeraction` asks `bw` not to
+    prompt; stdin on /dev/null makes a prompt that ignores it read EOF and die.
+    A flag alone would leave an unattended run able to hang forever."""
+    seen = {}
+
+    def fake_run(argv, **kw):
+        seen["argv"] = argv
+        seen["kw"] = kw
+        return subprocess.CompletedProcess(argv, 0, "{}", "")
+
+    monkeypatch.setattr(EV.subprocess, "run", fake_run)
+    EV._default_runner(["bw", "--nointeraction", "status"], timeout=3.25)
+    assert seen["kw"]["stdin"] == subprocess.DEVNULL
+    assert seen["kw"]["timeout"] == 3.25
+    assert seen["kw"]["capture_output"] is True
+
+
+# --------------------------------------------------------------------------- #
+# 8. `bw` absent — reachable on a host where `bw` IS installed
+# --------------------------------------------------------------------------- #
+def test_bw_ABSENT_is_its_own_failure_and_names_the_nix_shell_command(tmp_path):
+    f = FakeBw(items=[_item()])
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.run(bw=EV.BitwardenCLI(runner=f, locator=lambda name: None),
+               identity=_identity(tmp_path), item_name=ITEM, now=NOW)
+    assert ei.value.token == "BW-MISSING"
+    assert ei.value.exit_code == 10
+    assert "nix-shell -p bitwarden-cli jq" in str(ei.value)
+    # 🔴 REACHABILITY: it refused BEFORE running anything, so the message is not
+    # a fallback printed after a different failure already decided the outcome.
+    assert f.calls == []
+
+
+def test_a_FileNotFoundError_from_the_runner_is_also_BW_MISSING(tmp_path):
+    """The locator check races with an uninstall; a raw FileNotFoundError would
+    surface as an unexplained traceback instead of the message that exists."""
+    def boom(argv, *, timeout):
+        raise FileNotFoundError(2, "No such file or directory", "bw")
+
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.run(bw=EV.BitwardenCLI(runner=boom, locator=lambda n: "/bin/bw"),
+               identity=_identity(tmp_path), item_name=ITEM, now=NOW)
+    assert ei.value.token == "BW-MISSING"
+
+
+# --------------------------------------------------------------------------- #
+# 9. the local side of the comparison
+# --------------------------------------------------------------------------- #
+def test_a_MISSING_on_disk_identity_is_its_own_failure(tmp_path):
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.run(bw=_cli(FakeBw(items=[_item()])),
+               identity=tmp_path / "nope.key", item_name=ITEM, now=NOW)
+    assert ei.value.token == "IDENTITY-MISSING"
+    assert ei.value.exit_code == 23
+
+
+def test_an_EMPTY_on_disk_identity_is_a_FAILURE_not_half_a_clean_comparison(tmp_path):
+    """🔴 TWO EMPTY FILES COMPARE EQUAL. Without this guard the run would report
+    `IDENTICAL` over nothing at all — the shortest possible route to the false
+    all-clear this script exists to prevent."""
+    f = FakeBw(items=[_item(notes="")])
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, f, identity_text="")
+    assert ei.value.token == "IDENTITY-EMPTY"
+    assert ei.value.exit_code == 24
+    # It refused before touching the vault: the local side is checked first.
+    assert f.calls == []
+
+
+def test_a_WHITESPACE_ONLY_on_disk_identity_is_ALSO_empty(tmp_path):
+    """🔴 THE OPERAND, NOT JUST THE TRUTHINESS. `if not data:` catches a
+    zero-byte file and passes a file holding one newline — which is not an age
+    identity either, and would then be compared against a trimmed note and
+    reported as a trailing-newline difference. Only `data.strip()` sees it."""
+    f = FakeBw(items=[_item()])
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, f, identity_text="\n \t\n")
+    assert ei.value.token == "IDENTITY-EMPTY"
+    assert f.calls == []
+
+
+def test_the_local_check_runs_BEFORE_any_network_call(tmp_path):
+    f = FakeBw(items=[_item()])
+    with pytest.raises(EV.EscrowError):
+        EV.run(bw=_cli(f), identity=tmp_path / "absent.key",
+               item_name=ITEM, now=NOW)
+    assert f.calls == [], "the vault was consulted before the local file existed"
+
+
+# --------------------------------------------------------------------------- #
+# 10. which server answered
+# --------------------------------------------------------------------------- #
+def test_an_EMPTY_configured_server_is_a_FAILURE(tmp_path):
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, FakeBw(server="", items=[_item()]))
+    assert ei.value.token == "SERVER-UNKNOWN"
+    assert ei.value.exit_code == 15
+
+
+def test_a_STALE_SESSION_pointing_at_another_server_is_a_MISMATCH(tmp_path):
+    """This vault has really been repointed. A session left over from the old
+    endpoint means every answer comes from a server the operator no longer
+    thinks they are using — and this half needs no pin to fire."""
+    f = FakeBw(server="https://new.invalid.example",
+               status={"serverUrl": "https://old.invalid.example",
+                       "status": "unlocked"},
+               items=[_item()])
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, f)
+    assert ei.value.token == "SERVER-MISMATCH"
+    assert ei.value.exit_code == 16
+
+
+def test_a_server_MISMATCH_message_prints_NEITHER_url(tmp_path):
+    """devrc is public and messages from it get pasted into it."""
+    f = FakeBw(server="https://new.invalid.example",
+               status={"serverUrl": "https://old.invalid.example",
+                       "status": "unlocked"}, items=[_item()])
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, f)
+    msg = str(ei.value)
+    assert "new.invalid.example" not in msg and "old.invalid.example" not in msg
+
+
+def test_a_PINNED_server_that_disagrees_FAILS(tmp_path):
+    f = FakeBw(server="https://actual.invalid.example", items=[_item()],
+               status={"serverUrl": "https://actual.invalid.example",
+                       "status": "unlocked"})
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, f, expect_server="https://expected.invalid.example")
+    assert ei.value.token == "SERVER-MISMATCH"
+
+
+def test_a_PINNED_server_that_agrees_PASSES_and_the_verdict_SAYS_it_was_pinned(tmp_path):
+    """🔴 "not pinned" and "pinned and matched" are two facts. A verdict that
+    printed the same sentence for both would imply a check it never made."""
+    f = FakeBw(items=[_item()])
+    v = _run(tmp_path, f, expect_server=SERVER + "/")   # trailing slash tolerated
+    assert v.server_pinned is True
+    assert "server pinned and matched" in v.line()
+
+    v2 = _run(tmp_path, FakeBw(items=[_item()]))
+    assert v2.server_pinned is False
+    assert "NOT PINNED" in v2.line()
+
+
+def test_url_comparison_ignores_case_and_a_trailing_slash_only(tmp_path):
+    assert EV._norm_url("HTTPS://A.Example/") == EV._norm_url("https://a.example")
+    assert EV._norm_url("https://a.example") != EV._norm_url("https://b.example")
+
+
+# --------------------------------------------------------------------------- #
+# 11. --decrypt-check: REAL artifacts, REAL age, REAL git
+# --------------------------------------------------------------------------- #
+def _git_env() -> dict:
+    e = dict(os.environ)
+    e.update({
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_SYSTEM": os.devnull,
+        "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@localhost",
+        "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@localhost",
+        "GIT_TERMINAL_PROMPT": "0", "GIT_ALLOW_PROTOCOL": "file",
+    })
+    return e
+
+
+def _make_scope(store: Path, name: str, commits: int) -> Path:
+    scope = store / name
+    scope.mkdir(parents=True)
+    subprocess.run([GIT, "init", "-q", "-b", "trunk", str(scope)],
+                   check=True, capture_output=True, env=_git_env())
+    for i in range(commits):
+        (scope / "e.md").write_text(f"synthetic entry {name} {i}\n", encoding="utf-8")
+        subprocess.run([GIT, "-C", str(scope), "add", "e.md"],
+                       check=True, capture_output=True, env=_git_env())
+        subprocess.run([GIT, "-C", str(scope), "commit", "-q", "-m", f"c{i}"],
+                       check=True, capture_output=True, env=_git_env())
+    return scope
+
+
+def _new_identity(tmp: Path, name: str) -> Path:
+    key = tmp / name
+    p = subprocess.run([AGE_KEYGEN, "-o", str(key)], capture_output=True, text=True)
+    assert p.returncode == 0, p.stderr
+    key.chmod(0o600)
+    return key
+
+
+def _recipient(identity: Path) -> str:
+    p = subprocess.run([AGE_KEYGEN, "-y", str(identity)],
+                       capture_output=True, text=True)
+    assert p.returncode == 0, p.stderr
+    return p.stdout.strip()
+
+
+def _artifact(scope: Path, identity: Path, tmp: Path, *, mangle=None,
+              tag: str = "i") -> bytes:
+    work = tmp / f"mk-{scope.name}-{tag}-{'m' if mangle else 'i'}"
+    work.mkdir(parents=True, exist_ok=True)
+    bundle, cipher = work / "a.bundle", work / "a.bundle.age"
+    B.bundle_scope(scope, bundle, work)
+    if mangle is not None:
+        mangle(bundle)
+    B.encrypt(bundle, cipher, _recipient(identity))
+    data = cipher.read_bytes()
+    bundle.unlink(missing_ok=True)
+    cipher.unlink(missing_ok=True)
+    return data
+
+
+def _flip_middle_byte(path: Path) -> None:
+    raw = bytearray(path.read_bytes())
+    raw[len(raw) // 2] ^= 0xFF
+    path.write_bytes(bytes(raw))
+
+
+class FakeDownloader:
+    def __init__(self, objects: dict[str, bytes]):
+        self.objects = dict(objects)
+        self.gets: list[str] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def list(self, prefix):
+        return [k for k in self.objects if k.startswith(prefix)]
+
+    def get(self, key):
+        self.gets.append(key)
+        return self.objects[key]
+
+
+# 🔴 THE STAMPS ARE CHOSEN SO THAT `[-1]` AND `[0]` PICK DIFFERENT SCOPES.
+# `scope-delta` holds TWO artifacts straddling `scope-epsilon`'s single one:
+#
+#     scope-delta    T-30h ............................ T-1h   <- newest overall
+#     scope-epsilon  .............. T-2h ......................
+#
+# so "newest per scope, then newest scope" selects scope-delta while an
+# off-by-one that read the OLDEST per scope would select scope-epsilon. A
+# one-artifact-per-scope world would make those two implementations produce
+# identical output, and the mutant would survive a fully green suite.
+DELTA_OLD = NOW - timedelta(hours=30)
+DELTA_NEW = NOW - timedelta(hours=1)
+EPSILON_ONE = NOW - timedelta(hours=2)
+
+# Pinned literal object keys — the producer's own key function is exercised in
+# the fixture, but the ASSERTIONS name the string, so a change to either side of
+# that seam is visible instead of tracking silently.
+KEY_DELTA_NEW = "synthetic-escrow-host/scope-delta/20260309T164205Z.bundle.age"
+KEY_EPSILON = "synthetic-escrow-host/scope-epsilon/20260309T154205Z.bundle.age"
+
+
+@pytest.fixture()
+def escrow_world(tmp_path, monkeypatch):
+    """A store with TWO scopes, THREE artifacts, distinct stamps, and a real key.
+
+    Different commit counts (3 vs 5) and different stamps, so a test can tell
+    WHICH artifact was opened — a one-scope, one-artifact world would make both
+    "it picked the newest" and "it picked the right scope" unfalsifiable.
+    """
+    monkeypatch.setenv("ASIB_HOST", HOST)
+    store = tmp_path / "store"
+    store.mkdir()
+    good = _new_identity(tmp_path, "good.key")
+    delta = _make_scope(store, "scope-delta", commits=3)
+    epsilon = _make_scope(store, "scope-epsilon", commits=5)
+    objects = {
+        B.object_key(HOST, "scope-delta", DELTA_OLD):
+            _artifact(delta, good, tmp_path, tag="old"),
+        B.object_key(HOST, "scope-delta", DELTA_NEW):
+            _artifact(delta, good, tmp_path, tag="new"),
+        B.object_key(HOST, "scope-epsilon", EPSILON_ONE):
+            _artifact(epsilon, good, tmp_path, tag="one"),
+    }
+    return {
+        "store": store, "identity": good, "objects": objects,
+        "work": B._private_dir(tmp_path / "work"),
+        "note": good.read_text(encoding="utf-8"),
+        "tmp": tmp_path,
+    }
+
+
+def test_the_fixture_keys_are_the_LITERALS_the_selection_tests_PIN():
+    """HARNESS SELF-CHECK for the two pinned key strings, and for the ordering
+    the selection tests depend on: delta's newest is newer than epsilon's, and
+    delta's oldest is older."""
+    assert B.object_key(HOST, "scope-delta", DELTA_NEW) == KEY_DELTA_NEW
+    assert B.object_key(HOST, "scope-epsilon", EPSILON_ONE) == KEY_EPSILON
+    assert DELTA_OLD < EPSILON_ONE < DELTA_NEW < NOW
+
+
+def _decrypt_run(world, *, note: str | None = None, objects=None, scope=None):
+    d = FakeDownloader(world["objects"] if objects is None else objects)
+    return EV.run(
+        bw=_cli(FakeBw(items=[_item(notes=world["note"] if note is None else note)])),
+        identity=world["identity"],
+        item_name=ITEM, decrypt=True, prefix=PREFIX, store=world["store"],
+        scope_filter=scope, work_dir=world["work"], now=NOW,
+        downloader_factory=lambda: d), d
+
+
+def test_decrypt_check_SUCCEEDS_with_the_escrowed_key_and_reports_real_counts(escrow_world):
+    """🔴 THE CLAIM THAT MATTERS: the ESCROWED bytes — written to a throwaway
+    file — decrypt a real artifact and restore real history.
+
+    Every expected value is a literal pinned from the fixture (3 commits over 1
+    ref for `scope-delta`, whose NEWEST artifact is the newest in the bucket),
+    not read back from the verdict — a pipeline that restored nothing cannot
+    satisfy this by reporting zeros. The KEY is asserted too, so an off-by-one
+    that took a scope's OLDEST artifact is visible even though the scope name
+    would be the same.
+    """
+    v, d = _decrypt_run(escrow_world)
+    assert v.decrypt_checked is True
+    assert v.decrypt_scope == "scope-delta"        # holds the newest artifact
+    assert v.decrypt_key == KEY_DELTA_NEW          # ...and it took the NEWEST one
+    assert v.decrypt_commits == 3
+    assert v.decrypt_refs == 1
+    assert d.gets == [KEY_DELTA_NEW], "exactly one artifact, and the right one"
+    assert "DECRYPT-CHECKED: " in v.line()
+    assert "NOT DECRYPT-CHECKED" not in v.line()
+
+
+def test_decrypt_check_can_be_pointed_at_a_NAMED_scope(escrow_world):
+    """THE SECOND MEASUREMENT POINT: the selector really selects, so the default
+    above was not just the only thing it could ever have returned. Different
+    scope, different key, different commit count — all three move."""
+    v, d = _decrypt_run(escrow_world, scope="scope-epsilon")
+    assert v.decrypt_scope == "scope-epsilon"
+    assert v.decrypt_key == KEY_EPSILON
+    assert v.decrypt_commits == 5
+    assert d.gets == [KEY_EPSILON]
+
+
+def test_a_prefix_with_NO_trailing_slash_still_selects_the_right_objects(escrow_world):
+    """🔴 AN S3 PREFIX IS A BYTE PREFIX, NOT A PATH COMPONENT. Without
+    normalisation `<host>` would also list `<host>-laptop/…`, and the key parser
+    would then see a scope of `''`. Passing the un-slashed form is the only way
+    to observe that the normalisation happens at all."""
+    d = FakeDownloader(escrow_world["objects"])
+    v = EV.run(bw=_cli(FakeBw(items=[_item(notes=escrow_world["note"])])),
+               identity=escrow_world["identity"], item_name=ITEM, decrypt=True,
+               prefix=HOST,                       # no trailing slash
+               store=escrow_world["store"], work_dir=escrow_world["work"],
+               now=NOW, downloader_factory=lambda: d)
+    assert v.decrypt_key == KEY_DELTA_NEW
+    assert v.decrypt_commits == 3
+
+
+def test_a_matching_but_WRONG_key_fails_with_DECRYPT_FAILED(escrow_world, tmp_path):
+    """🔴 THE ESCROW IS INTACT AND USELESS. Both copies agree byte-for-byte, so
+    the byte check PASSES — and the artifacts were encrypted to a different
+    recipient, so nothing opens. This is the case byte equality alone cannot
+    see, which is the entire argument for --decrypt-check.
+    """
+    wrong = _new_identity(tmp_path, "wrong.key")
+    text = wrong.read_text(encoding="utf-8")
+    d = FakeDownloader(escrow_world["objects"])
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.run(bw=_cli(FakeBw(items=[_item(notes=text)])),
+               identity=wrong,                    # both sides agree: bytes MATCH
+               item_name=ITEM, decrypt=True, prefix=PREFIX,
+               store=escrow_world["store"], work_dir=escrow_world["work"],
+               now=NOW, downloader_factory=lambda: d)
+    assert ei.value.token == "DECRYPT-FAILED"
+    assert ei.value.exit_code == 25
+    # 🔴 DISTINGUISHABLE from a byte mismatch — the two are different faults
+    # with different remedies and this is the pair that used to be one word.
+    assert ei.value.exit_code != EV.EXIT_CODES["BYTES-DIFFER-MATERIALLY"]
+    assert ei.value.exit_code != EV.EXIT_CODES["BYTES-DIFFER-TRAILING-NEWLINE"]
+    assert ei.value.exit_code != EV.EXIT_CODES["RESTORE-FAILED"]
+
+
+def test_a_CORRUPTED_ARTIFACT_is_RESTORE_FAILED_not_DECRYPT_FAILED(escrow_world, tmp_path):
+    """🔴 THE SECOND MEASUREMENT POINT for the classifier. A key fault and a
+    data fault must not share a token: only the first says anything about the
+    escrow, and the remedies are "re-escrow" and "the backup is damaged"."""
+    scope = escrow_world["store"] / "scope-delta"
+    bad = _artifact(scope, escrow_world["identity"], tmp_path,
+                    mangle=_flip_middle_byte, tag="bad")
+    objects = dict(escrow_world["objects"])
+    objects[KEY_DELTA_NEW] = bad
+    with pytest.raises(EV.EscrowError) as ei:
+        _decrypt_run(escrow_world, objects=objects)
+    assert ei.value.token == "RESTORE-FAILED"
+    assert ei.value.exit_code == 26
+
+
+def test_ZERO_artifacts_under_the_prefix_is_NO_ARTIFACT_not_a_clean_check(escrow_world):
+    """🔴 A key that was never asked to decrypt anything has not been shown to
+    work. An empty bucket must not read as a successful decrypt check."""
+    with pytest.raises(EV.EscrowError) as ei:
+        _decrypt_run(escrow_world, objects={})
+    assert ei.value.token == "NO-ARTIFACT"
+    assert ei.value.exit_code == 28
+
+
+def test_a_NAMED_scope_with_no_artifacts_is_NO_ARTIFACT(escrow_world):
+    with pytest.raises(EV.EscrowError) as ei:
+        _decrypt_run(escrow_world, scope="scope-zeta-does-not-exist")
+    assert ei.value.token == "NO-ARTIFACT"
+
+
+def test_a_store_that_cannot_be_OPENED_is_STORE_UNREACHABLE(escrow_world):
+    """Classified by PHASE, not by parsing somebody else's error text."""
+    class Boom:
+        def __enter__(self):
+            raise OSError("no route to the tenant")
+
+        def __exit__(self, *e):
+            return False
+
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.run(bw=_cli(FakeBw(items=[_item(notes=escrow_world["note"])])),
+               identity=escrow_world["identity"], item_name=ITEM, decrypt=True,
+               prefix=PREFIX, store=escrow_world["store"],
+               work_dir=escrow_world["work"], now=NOW,
+               downloader_factory=Boom)
+    assert ei.value.token == "STORE-UNREACHABLE"
+    assert ei.value.exit_code == 27
+
+
+def test_a_BYTE_MISMATCH_short_circuits_and_never_reaches_the_store(escrow_world):
+    """The codes must stay distinguishable, so the run stops at the first
+    finding rather than reporting a decrypt failure caused by a wrong note."""
+    d = FakeDownloader(escrow_world["objects"])
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.run(bw=_cli(FakeBw(items=[_item(notes=OTHER_KEY)])),
+               identity=escrow_world["identity"], item_name=ITEM, decrypt=True,
+               prefix=PREFIX, store=escrow_world["store"],
+               work_dir=escrow_world["work"], now=NOW,
+               downloader_factory=lambda: d)
+    assert ei.value.token == "BYTES-DIFFER-MATERIALLY"
+    assert d.gets == [], "the artifact store was touched on a byte-mismatch path"
+
+
+# --------------------------------------------------------------------------- #
+# 12. 🔴 NO KEY MATERIAL SURVIVES — on the success path AND the failure paths
+# --------------------------------------------------------------------------- #
+def _work_contents(work: Path) -> list[str]:
+    return sorted(p.name for p in work.iterdir())
+
+
+def test_no_key_material_survives_a_SUCCESSFUL_decrypt_check(escrow_world):
+    work = escrow_world["work"]
+    v, _ = _decrypt_run(escrow_world)
+    assert v.decrypt_checked is True
+    assert not (work / EV.ESCROW_IDENTITY_FILENAME).exists()
+    assert _work_contents(work) == [], _work_contents(work)
+
+
+@pytest.mark.parametrize("case", ["wrong-key", "corrupt-artifact"])
+def test_no_key_material_survives_a_FAILING_decrypt_check(escrow_world, tmp_path, case):
+    """🔴 THE PATH IT EXISTS FOR. A failed run is exactly when a copy of a
+    decryption key is most likely to be left behind and least likely to be
+    noticed — both classified failures are checked, not just the tidy one."""
+    work = escrow_world["work"]
+    if case == "wrong-key":
+        wrong = _new_identity(tmp_path, "wrong2.key")
+        d = FakeDownloader(escrow_world["objects"])
+        with pytest.raises(EV.EscrowError):
+            EV.run(bw=_cli(FakeBw(items=[_item(notes=wrong.read_text())])),
+                   identity=wrong, item_name=ITEM, decrypt=True, prefix=PREFIX,
+                   store=escrow_world["store"], work_dir=work, now=NOW,
+                   downloader_factory=lambda: d)
+    else:
+        scope = escrow_world["store"] / "scope-delta"
+        objects = dict(escrow_world["objects"])
+        objects[KEY_DELTA_NEW] = _artifact(
+            scope, escrow_world["identity"], tmp_path,
+            mangle=_flip_middle_byte, tag="bad2")
+        with pytest.raises(EV.EscrowError):
+            _decrypt_run(escrow_world, objects=objects)
+    assert not (work / EV.ESCROW_IDENTITY_FILENAME).exists()
+    assert _work_contents(work) == [], _work_contents(work)
+
+
+def test_no_key_material_survives_an_UNEXPECTED_exception(escrow_world, monkeypatch):
+    """The `finally` must cover the paths nobody wrote a message for, too."""
+    work = escrow_world["work"]
+    RVmod = EV._rv()
+
+    def explode(*a, **kw):
+        raise ZeroDivisionError("synthetic, from inside the restore pipeline")
+
+    monkeypatch.setattr(RVmod, "verify_artifact", explode)
+    with pytest.raises(ZeroDivisionError):
+        _decrypt_run(escrow_world)
+    assert not (work / EV.ESCROW_IDENTITY_FILENAME).exists()
+    assert _work_contents(work) == [], _work_contents(work)
+
+
+def test_the_throwaway_identity_is_0600_inside_a_0700_dir_WHILE_IT_EXISTS(escrow_world,
+                                                                         monkeypatch):
+    """🔴 A POSITIVE CONTROL FOR THE SHRED TESTS. Every assertion above is that
+    the file is GONE — which a script that never created it would also satisfy.
+    This one observes it mid-flight, with the right content and the right mode,
+    so "gone afterwards" is a claim about a file that really existed."""
+    work = escrow_world["work"]
+    seen = {}
+    RVmod = EV._rv()
+    real = RVmod.verify_artifact
+
+    def spy(downloader, key, **kw):
+        p = Path(kw["identity"])
+        seen["path"] = p
+        seen["mode"] = stat.S_IMODE(p.stat().st_mode)
+        seen["dir_mode"] = stat.S_IMODE(p.parent.stat().st_mode)
+        seen["bytes"] = p.read_bytes()
+        return real(downloader, key, **kw)
+
+    monkeypatch.setattr(RVmod, "verify_artifact", spy)
+    _decrypt_run(escrow_world)
+    assert seen["path"] == work / EV.ESCROW_IDENTITY_FILENAME
+    assert seen["mode"] == 0o600, oct(seen["mode"])
+    assert seen["dir_mode"] == 0o700, oct(seen["dir_mode"])
+    # 🔴 THE ESCROWED BYTES, NOT THE ON-DISK FILE. Handing the pipeline the
+    # local key would make the whole check a test of the wrong copy — and it
+    # would pass just as green.
+    assert seen["bytes"] == escrow_world["note"].encode("utf-8")
+    assert not seen["path"].exists()
+
+
+def test_shred_removes_the_file_and_never_raises_on_an_absent_one(tmp_path):
+    p = tmp_path / "k"
+    p.write_bytes(b"synthetic-shred-fixture-0123456789")
+    EV._shred(p)
+    assert not p.exists()
+    EV._shred(p)          # idempotent; a cleanup that raises defeats its finally
+    EV._shred(tmp_path / "never-existed")
+
+
+# --------------------------------------------------------------------------- #
+# 13. the CLI — real argv, real exit codes, a real `bw` process
+# --------------------------------------------------------------------------- #
+BW_STUB = '''#!/usr/bin/env python3
+"""A synthetic `bw`. Answers from a JSON script; never touches a real vault."""
+import json, os, sys
+plan = json.load(open(os.environ["FAKE_BW_PLAN"]))
+args = [a for a in sys.argv[1:] if a != "--nointeraction"]
+key = " ".join(args[:2])
+if key not in plan:
+    sys.stderr.write("unmodelled: %r\\n" % (args,))
+    sys.exit(99)
+entry = plan[key]
+sys.stdout.write(entry["out"])
+sys.exit(entry["rc"])
+'''
+
+
+def _bw_stub(tmp_path: Path, plan: dict) -> tuple[Path, Path]:
+    stub = tmp_path / "bw-stub" / "bw"
+    stub.parent.mkdir(parents=True, exist_ok=True)
+    stub.write_text(BW_STUB, encoding="utf-8")
+    stub.chmod(0o755)
+    planfile = tmp_path / "bw-plan.json"
+    planfile.write_text(json.dumps(plan), encoding="utf-8")
+    return stub, planfile
+
+
+def _plan(*, status: str = "unlocked", items: list | None = None,
+          server: str = SERVER) -> dict:
+    return {
+        "status": {"rc": 0, "out": json.dumps(
+            {"serverUrl": server, "status": status})},
+        "config server": {"rc": 0, "out": server + "\n"},
+        "list items": {"rc": 0, "out": json.dumps(items or [])},
+    }
+
+
+def _run_cli(tmp_path: Path, plan: dict, *extra: str,
+             identity_text: str = ESCROW_NOTE) -> subprocess.CompletedProcess:
+    stub, planfile = _bw_stub(tmp_path, plan)
+    ident = _identity(tmp_path, identity_text, name="cli-on-disk.key")
+    env = dict(os.environ)
+    env["FAKE_BW_PLAN"] = str(planfile)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--bw", str(stub),
+         "--identity", str(ident), "--item-name", ITEM, *extra],
+        capture_output=True, text=True, env=env)
+
+
+def test_the_CLI_exits_ZERO_on_an_identical_escrow(tmp_path):
+    p = _run_cli(tmp_path, _plan(items=[_item()]))
+    assert p.returncode == 0, p.stderr
+    assert "escrow OK" in p.stdout
+    assert str(ESCROW_NOTE_BYTES) in p.stdout
+
+
+@pytest.mark.parametrize("plan_kw,extra,token,code", [
+    ({"items": []}, (), "ITEM-NOT-FOUND", 17),
+    ({"items": [_item(id_="a"), _item(id_="b")]}, (), "ITEM-AMBIGUOUS", 18),
+    ({"items": [_item(notes="")]}, (), "NOTE-EMPTY", 20),
+    ({"items": [_item(notes=OTHER_KEY)]}, (), "BYTES-DIFFER-MATERIALLY", 22),
+    ({"items": [_item(notes=ESCROW_NOTE.rstrip("\n"))]}, (),
+     "BYTES-DIFFER-TRAILING-NEWLINE", 21),
+    ({"status": "locked"}, (), "VAULT-LOCKED", 12),
+    ({"status": "unauthenticated"}, (), "VAULT-UNAUTHENTICATED", 13),
+    ({"items": [_item()]}, ("--expect-server", "https://elsewhere.invalid"),
+     "SERVER-MISMATCH", 16),
+])
+def test_the_CLI_exit_code_and_token_are_DISTINCT_per_failure(tmp_path, plan_kw,
+                                                              extra, token, code):
+    """🔴 THE DELIVERABLE, END TO END. Each cause gets its OWN exit code out of
+    the real process — an operator's timer reads the code, not the prose."""
+    p = _run_cli(tmp_path, _plan(**plan_kw), *extra)
+    assert p.returncode == code, (p.returncode, p.stdout, p.stderr)
+    assert token in p.stderr
+    assert p.stdout == "", "a failing run must print no verdict on stdout"
+
+
+def test_the_CLI_never_prints_key_material_on_a_mismatch(tmp_path):
+    p = _run_cli(tmp_path, _plan(items=[_item(notes=OTHER_KEY)]))
+    assert p.returncode == 22
+    blob = p.stdout + p.stderr
+    assert "AGE-SECRET-KEY" not in blob
+    for line in set(ESCROW_NOTE.splitlines()) | set(OTHER_KEY.splitlines()):
+        if len(line) > 20:
+            assert line not in blob
+
+
+def test_the_CLI_reports_a_MISSING_bw_with_the_nix_shell_command(tmp_path):
+    ident = _identity(tmp_path, ESCROW_NOTE, name="cli2.key")
+    p = subprocess.run(
+        [sys.executable, str(SCRIPT), "--bw", str(tmp_path / "no-such-bw"),
+         "--identity", str(ident), "--item-name", ITEM],
+        capture_output=True, text=True, env=dict(os.environ))
+    assert p.returncode == 10
+    assert "BW-MISSING" in p.stderr
+    assert "nix-shell -p bitwarden-cli jq" in p.stderr
+
+
+def test_print_plan_runs_NO_bw_and_reads_NO_key(tmp_path):
+    """A no-network, no-vault surface. The stub would exit 99 on any command it
+    was given, so a plan that shelled out could not exit 0."""
+    stub, planfile = _bw_stub(tmp_path, {})
+    ident = _identity(tmp_path, ESCROW_NOTE, name="plan.key")
+    env = dict(os.environ)
+    env["FAKE_BW_PLAN"] = str(planfile)
+    p = subprocess.run(
+        [sys.executable, str(SCRIPT), "--print-plan", "--bw", str(stub),
+         "--identity", str(ident), "--item-name", ITEM],
+        capture_output=True, text=True, env=env)
+    assert p.returncode == 0, p.stderr
+    assert str(ESCROW_NOTE_BYTES) in p.stdout      # it measured the local file
+    assert "AGE-SECRET-KEY" not in p.stdout        # without reading its content
+    # Every classified cause is listed, so the operator can map a code by eye.
+    for token in EV.EXIT_CODES:
+        assert token in p.stdout
+
+
+def test_print_plan_names_all_three_classifications(tmp_path):
+    ident = _identity(tmp_path, ESCROW_NOTE, name="plan2.key")
+    p = subprocess.run(
+        [sys.executable, str(SCRIPT), "--print-plan", "--identity", str(ident)],
+        capture_output=True, text=True, env=dict(os.environ))
+    assert p.returncode == 0, p.stderr
+    for c in (EV.CLASS_IDENTICAL, EV.CLASS_TRAILING_NEWLINE, EV.CLASS_MATERIAL):
+        assert c in p.stdout
+
+
+# --------------------------------------------------------------------------- #
+# 14. the seam with restore-verify.py — imported, never reimplemented
+# --------------------------------------------------------------------------- #
+def test_the_escrow_verifier_REUSES_the_restore_pipeline():
+    """🔴 A SEAM GUARD: it pins the RELATIONSHIP, not one side.
+
+    If someone reimplements the download -> decrypt -> clone -> fsck pipeline
+    here, they also reimplement the `finally` that unlinks the plaintext bundle
+    — and the copy nobody exercises is the broken one. So: the module resolves
+    to the real restore verifier, and this file does not contain a second
+    `git clone --mirror` or a second `age --decrypt`.
+    """
+    mod = EV._rv()
+    assert mod is RV or mod.__file__ == str(RESTORE_SCRIPT)
+    assert hasattr(mod, "verify_artifact")
+    src = SCRIPT.read_text(encoding="utf-8")
+    # The ARGV, not the word: `--mirror` and `--decrypt-check` both appear in
+    # prose here, and a guard that could not tell a docstring from a call site
+    # would go red for a comment and green for a real second implementation.
+    assert '"clone", "--mirror"' not in src, "the restore was reimplemented here"
+    assert '"age", "--decrypt"' not in src, "the age call was reimplemented here"
+    assert "subprocess.run" not in src.split("def _default_runner", 1)[1].split(
+        "class BitwardenCLI", 1)[1], "a second subprocess call outside the bw seam"
+    assert "RV.verify_artifact(" in src
+
+
+def test_the_module_hardcodes_no_endpoint_and_no_host():
+    """🔴 devrc is PUBLIC. The server is read from `bw config server` at run
+    time; nothing that looks like an endpoint may be committed here."""
+    src = SCRIPT.read_text(encoding="utf-8")
+    for needle in ("http://", "https://"):
+        assert needle not in src, f"{needle!r} appears in a public repo's source"
+    assert "bw config server" in src or "\"config\", \"server\"" in src

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import shlex
 import shutil
 import stat
 import subprocess
@@ -50,6 +51,11 @@ sys.path.insert(0, str(SCRIPTS / "analyze-service-index"))
 sys.path.insert(0, str(SCRIPTS))
 
 import backup as B  # noqa: E402
+
+# 🔴 ONE PLACE OWNS THE RUNTIME SHEBANG. See `_bw_stub` — and
+# `scripts/tests/test_runtime_shebangs.py`, which fails the suite if this file
+# writes one of its own.
+from testlib import mockbin  # noqa: E402
 
 
 def _load(name: str, path: Path):
@@ -1046,6 +1052,60 @@ def test_a_NAMED_scope_with_no_artifacts_is_NO_ARTIFACT(escrow_world):
     assert ei.value.token == "NO-ARTIFACT"
 
 
+def test_decrypt_check_works_against_a_LOCAL_DIRECTORY_of_artifacts(escrow_world,
+                                                                    tmp_path):
+    """SECRETS.md's restore recipe fetches objects to disk first, so verifying
+    what is on disk is the natural next step — and it is the only decrypt-check
+    path that can be exercised without a cluster.
+
+    No `downloader_factory` here: this drives the REAL `--from-dir` reader
+    (`restore_verify.DirectoryStore`), so the wiring is measured rather than
+    stubbed out by the same seam every other test uses.
+    """
+    root = tmp_path / "fetched"
+    for k, v in escrow_world["objects"].items():
+        p = root / k
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(v)
+    v = EV.run(bw=_cli(FakeBw(items=[_item(notes=escrow_world["note"])])),
+               identity=escrow_world["identity"], item_name=ITEM, decrypt=True,
+               bucket=str(root), prefix=PREFIX, store=escrow_world["store"],
+               from_dir=root, work_dir=escrow_world["work"], now=NOW)
+    assert v.decrypt_key == KEY_DELTA_NEW
+    assert v.decrypt_commits == 3
+    assert _work_contents(escrow_world["work"]) == []
+
+
+def test_a_from_dir_NO_ARTIFACT_message_names_the_DIRECTORY_not_a_bucket(escrow_world,
+                                                                        tmp_path):
+    """🔴 A MESSAGE THAT NAMES THE WRONG PLACE SENDS THE READER TO THE WRONG
+    PLACE. Under `--from-dir` the source is a local directory; printing the
+    default bucket name would describe a query nobody made."""
+    empty = tmp_path / "fetched-empty"
+    empty.mkdir()
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.run(bw=_cli(FakeBw(items=[_item(notes=escrow_world["note"])])),
+               identity=escrow_world["identity"], item_name=ITEM, decrypt=True,
+               bucket=str(empty), prefix=PREFIX, store=escrow_world["store"],
+               from_dir=empty, work_dir=escrow_world["work"], now=NOW)
+    assert ei.value.token == "NO-ARTIFACT"
+    assert str(empty) in str(ei.value)
+    assert EV.DEFAULT_BUCKET not in str(ei.value)
+
+
+def test_the_CLI_passes_the_from_dir_through_as_the_SOURCE(tmp_path):
+    """The same fact through `main()`'s own argument plumbing — the place the
+    bucket-vs-directory substitution actually lives."""
+    empty = tmp_path / "cli-fetched-empty"
+    empty.mkdir()
+    p = _run_cli(tmp_path, _plan(items=[_item()]),
+                 "--decrypt-check", "--from-dir", str(empty),
+                 "--host", HOST, "--store", str(tmp_path / "no-store"))
+    assert p.returncode == EV.EXIT_CODES["NO-ARTIFACT"], (p.stdout, p.stderr)
+    assert str(empty) in p.stderr
+    assert EV.DEFAULT_BUCKET not in p.stderr
+
+
 def test_a_store_that_cannot_be_OPENED_is_STORE_UNREACHABLE(escrow_world):
     """Classified by PHASE, not by parsing somebody else's error text."""
     class Boom:
@@ -1178,8 +1238,11 @@ def test_shred_removes_the_file_and_never_raises_on_an_absent_one(tmp_path):
 # --------------------------------------------------------------------------- #
 # 13. the CLI — real argv, real exit codes, a real `bw` process
 # --------------------------------------------------------------------------- #
-BW_STUB = '''#!/usr/bin/env python3
-"""A synthetic `bw`. Answers from a JSON script; never touches a real vault."""
+BW_STUB_BODY = '''
+"""A synthetic `bw`. Answers from a JSON plan; never touches a real vault.
+
+Deliberately carries NO shebang of its own — see `_bw_stub` below.
+"""
 import json, os, sys
 plan = json.load(open(os.environ["FAKE_BW_PLAN"]))
 args = [a for a in sys.argv[1:] if a != "--nointeraction"]
@@ -1194,13 +1257,45 @@ sys.exit(entry["rc"])
 
 
 def _bw_stub(tmp_path: Path, plan: dict) -> tuple[Path, Path]:
+    """An executable synthetic `bw` on disk, plus the JSON plan it answers from.
+
+    🔴 THE SHEBANG IS `testlib.mockbin`'s, NOT THIS FILE'S. A stub written at
+    runtime with `#!/usr/bin/env python3` execs fine on the NixOS dev host and
+    ENOENTs inside the nix build sandbox, which is the AUTHORITATIVE tier — the
+    two-tier hazard, and the reason `mockbin` exists at all rather than a sixth
+    hand-rolled copy of the rule. So the Python body is a plain `.py` file with
+    no shebang, and the executable is a POSIX-sh shim that execs the RUNNING
+    interpreter by absolute path.
+    """
+    body = tmp_path / "bw_stub_body.py"
+    body.write_text(BW_STUB_BODY, encoding="utf-8")
     stub = tmp_path / "bw-stub" / "bw"
     stub.parent.mkdir(parents=True, exist_ok=True)
-    stub.write_text(BW_STUB, encoding="utf-8")
-    stub.chmod(0o755)
+    mockbin.write_exec(
+        stub,
+        f"exec {shlex.quote(sys.executable)} {shlex.quote(str(body))} \"$@\"\n")
     planfile = tmp_path / "bw-plan.json"
     planfile.write_text(json.dumps(plan), encoding="utf-8")
     return stub, planfile
+
+
+def test_the_bw_STUB_really_execs_and_can_REFUSE(tmp_path):
+    """POSITIVE + NEGATIVE CONTROL for the stub every CLI test below runs.
+
+    A stub that cannot exec would make each CLI assertion a statement about a
+    process that never started — and in the nix sandbox that is exactly how a
+    `/usr/bin/env` shebang fails. So: it runs, it answers a modelled command,
+    and it exits 99 on one it does not model instead of inventing a reply."""
+    stub, planfile = _bw_stub(tmp_path, _plan(items=[_item()]))
+    env = dict(os.environ)
+    env["FAKE_BW_PLAN"] = str(planfile)
+    good = subprocess.run([str(stub), "--nointeraction", "status"],
+                          capture_output=True, text=True, env=env)
+    assert good.returncode == 0, good.stderr
+    assert json.loads(good.stdout)["status"] == "unlocked"
+    bad = subprocess.run([str(stub), "--nointeraction", "sync"],
+                         capture_output=True, text=True, env=env)
+    assert bad.returncode == 99, (bad.returncode, bad.stdout, bad.stderr)
 
 
 def _plan(*, status: str = "unlocked", items: list | None = None,

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -307,24 +307,27 @@ def test_the_exit_code_table_is_pinned_EXACTLY_both_ways():
         "ARTIFACT-UNREADABLE": 30,
         "ARTIFACT-EMPTY": 31,
         "NOTE-MISSING": 32,
+        "ARTIFACT-CORRUPT": 33,
     }
 
 
-def test_the_five_decrypt_outcomes_are_FIVE_DISTINCT_codes():
+def test_the_SIX_decrypt_outcomes_are_SIX_DISTINCT_codes():
     """🔴 THE HEADLINE SPLIT, pinned as a set of distinct integers.
 
-    An audit found the original two-way split wrong in three measured cases,
-    every one of them blaming the escrow for a fault the escrow could not have
-    caused. These five must never collapse back: `age` absent is an ENVIRONMENT
-    fault, "failed before decrypt ran" is an OBJECT fault, "age refused" is a
-    KEY fault, "age succeeded on nothing" is a DATA fault where the key is
-    FINE, and "decrypt returned, restore failed" is a DATA fault too.
+    Two rounds of audit each found the previous split wrong, both times in the
+    direction that makes someone act destructively. These six must never
+    collapse back: `age` absent is an ENVIRONMENT fault; "failed before decrypt
+    ran" is an OBJECT fault; "age wrote nothing" is a wrong key OR a damaged
+    header and asserts neither; "age authenticated the header then failed the
+    payload" is TAMPERING with a working key; "age exited zero on nothing" is an
+    empty artifact with a working key; "decrypt returned, restore failed" is a
+    bundle fault with a working key.
     """
     names = ["AGE-MISSING", "ARTIFACT-UNREADABLE", "DECRYPT-FAILED",
-             "ARTIFACT-EMPTY", "RESTORE-FAILED"]
+             "ARTIFACT-CORRUPT", "ARTIFACT-EMPTY", "RESTORE-FAILED"]
     codes = [EV.EXIT_CODES[n] for n in names]
-    assert codes == [29, 30, 25, 31, 26]
-    assert len(set(codes)) == 5
+    assert codes == [29, 30, 25, 33, 31, 26]
+    assert len(set(codes)) == 6
 
 
 def test_every_exit_code_is_DISTINCT_and_never_collides_with_success_or_crash():
@@ -344,7 +347,21 @@ def test_an_unknown_token_CANNOT_be_raised():
         EV.EscrowError("NOT-A-REAL-TOKEN", "x")
     e = EV.EscrowError("VAULT-LOCKED", "x")
     assert e.exit_code == 12 and e.token == "VAULT-LOCKED"
-    assert str(e).startswith("VAULT-LOCKED: ")
+    assert str(e) == "VAULT-LOCKED: x"
+    assert e.detail is None
+
+
+def test_the_rendered_message_carries_BOTH_the_verdict_and_the_upstream_detail():
+    """🔴 `str(exc)` IS WHAT THE OPERATOR READS — the CLI prints it and nothing
+    else. Pinning only `.verdict` left `__str__` untested: a sweep found that
+    dropping the `[upstream: …]` half entirely SURVIVED the suite, silently
+    discarding age's own diagnosis on every failure path.
+
+    Both halves, whole, by equality — and the detail must NOT be swallowed."""
+    e = EV.EscrowError("ARTIFACT-CORRUPT", "the verdict half", "the upstream half")
+    assert e.verdict == "the verdict half"
+    assert e.detail == "the upstream half"
+    assert str(e) == "ARTIFACT-CORRUPT: the verdict half [upstream: the upstream half]"
 
 
 # --------------------------------------------------------------------------- #
@@ -589,6 +606,21 @@ def test_an_ABSENT_notes_FIELD_is_NOT_the_same_finding_as_an_EMPTY_one(tmp_path)
     assert ei.value.exit_code == 32
     assert ei.value.exit_code != EV.EXIT_CODES["NOTE-EMPTY"]
     assert "Do NOT re-escrow" in str(ei.value)
+
+
+def test_a_JSON_NULL_notes_is_ALSO_NOTE_MISSING(tmp_path):
+    """🔴 `{"notes": null}` IS THE SHAPE JSON ACTUALLY PRODUCES for "no notes",
+    and it is the very shape this module already handles for `serverUrl`.
+
+    Splitting on `"notes" not in item` alone let a null fall through to
+    `NOTE-EMPTY` — straight back to the "re-escrow over a good copy" advice
+    `NOTE-MISSING` was created to prevent."""
+    item = {"id": "n", "name": ITEM, "type": SECURE_NOTE, "notes": None}
+    assert "notes" in item, "the fixture must PRESENT the field as null"
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, FakeBw(items=[item]))
+    assert ei.value.token == "NOTE-MISSING"
+    assert ei.value.exit_code == 32
 
 
 def test_a_notes_field_present_but_NOT_A_STRING_is_NOTE_EMPTY(tmp_path):
@@ -1244,6 +1276,53 @@ def test_a_ZERO_BYTE_object_is_ARTIFACT_UNREADABLE_and_never_claims_it_DECRYPTED
     assert "NOTHING here decrypted" in msg
 
 
+def _corrupt_payload(blob: bytes, offset: int = 400) -> bytes:
+    """Flip a byte PAST the age header. XOR, never a literal write.
+
+    🔴 `printf '\\xff'` is a NO-OP when the byte was already 0xff, and one such
+    no-op nearly produced a measurement saying age fails to detect tampering.
+    XOR always changes the byte. Verify the mutation actually mutates.
+    """
+    b = bytearray(blob)
+    before = b[offset]
+    b[offset] ^= 0xFF
+    assert b[offset] != before
+    return bytes(b)
+
+
+@pytest.mark.parametrize("mangle,name", [
+    (lambda blob: _corrupt_payload(blob, 400), "payload byte flipped"),
+    (lambda blob: _corrupt_payload(blob, 300), "payload byte flipped, offset 300"),
+    (lambda blob: blob[:-30], "ciphertext truncated"),
+])
+def test_a_TAMPERED_or_TRUNCATED_artifact_is_ARTIFACT_CORRUPT_not_EMPTY(
+        escrow_world, tmp_path, mangle, name):
+    """🔴 THE REGRESSION THIS ROUND EXISTS FOR — a verifier reporting TAMPERING
+    as "nothing to worry about".
+
+    The previous classifier read file PRESENCE as "age reported success" and so
+    reported a tampered or truncated artifact as `ARTIFACT-EMPTY` — *"THE ESCROW
+    IS FINE … a valid encryption of an empty payload"* — while quoting age's own
+    "may be corrupted or tampered with" in the same breath. Detecting tampering
+    is the single most important thing a backup verifier does.
+
+    Re-measured (age v1.3.1, 8 offsets x 4 sizes + 3 truncations): age writes
+    output BEFORE authenticating the payload, so PRESENT+rc!=0 means the header
+    authenticated — the escrowed key WORKED — and the bytes did not.
+    """
+    good = escrow_world["objects"][KEY_DELTA_NEW]
+    objects = dict(escrow_world["objects"])
+    objects[KEY_DELTA_NEW] = mangle(good)
+    with pytest.raises(EV.EscrowError) as ei:
+        _decrypt_run(escrow_world, objects=objects)
+    assert ei.value.token == "ARTIFACT-CORRUPT", name
+    assert ei.value.exit_code == 33
+    # 🔴 It must NOT be any of the three verdicts that would calm the operator
+    # down or send them at the key.
+    for wrong in ("ARTIFACT-EMPTY", "DECRYPT-FAILED", "ARTIFACT-UNREADABLE"):
+        assert ei.value.exit_code != EV.EXIT_CODES[wrong], (name, wrong)
+
+
 def test_a_valid_encryption_of_NOTHING_says_the_ESCROW_IS_FINE(escrow_world, tmp_path):
     """🔴 AUDIT CASE 2 — THE ONE THAT GETS A GOOD DR KEY ROTATED.
 
@@ -1270,13 +1349,21 @@ def test_a_valid_encryption_of_NOTHING_says_the_ESCROW_IS_FINE(escrow_world, tmp
         _decrypt_run(escrow_world, objects=objects)
     assert ei.value.token == "ARTIFACT-EMPTY"
     assert ei.value.exit_code == 31
-    # 🔴 DISCRIMINATING, not a substring presence check: it must NOT be the
-    # token that means "the escrowed key is wrong", and it must say so in words
-    # the operator would act on.
     assert ei.value.exit_code != EV.EXIT_CODES["DECRYPT-FAILED"]
-    msg = str(ei.value)
-    assert "THE ESCROW IS FINE" in msg
-    assert "Do NOT re-escrow or rotate" in msg
+    assert ei.value.exit_code != EV.EXIT_CODES["ARTIFACT-CORRUPT"]
+    # 🔴 THE WHOLE OWNED SENTENCE, BY EQUALITY — see the module docstring on
+    # `verdict` vs `detail`. The previous assertions here were
+    # `"THE ESCROW IS FINE" in msg` and `"Do NOT re-escrow or rotate" in msg`,
+    # and BOTH passed unchanged on a TAMPERED artifact, certifying a sentence
+    # that was false on the very run they tested.
+    assert ei.value.verdict == (
+        f"the ESCROWED key OPENED {KEY_DELTA_NEW} and the artifact contains "
+        f"NOTHING. 🔴 THE ESCROW IS FINE — age exited ZERO, which a wrong key "
+        f"cannot make it do; the payload is a valid encryption of an empty "
+        f"file. Do NOT re-escrow or rotate on the strength of this. Run "
+        f"`restore-verify.py` to diagnose the artifact.")
+    # The upstream half is carried separately, so it stays OUT of the pin.
+    assert ei.value.detail and "DECRYPT FAILED" in ei.value.detail
 
 
 def test_age_ABSENT_is_an_ENVIRONMENT_fault_not_a_verdict_on_the_escrow(
@@ -1314,6 +1401,115 @@ def test_the_age_precondition_runs_BEFORE_the_store_is_opened(escrow_world,
     assert d.gets == [], "the store was opened before the precondition was checked"
 
 
+def test_every_decrypt_family_VERDICT_is_pinned_WHOLE(escrow_world, tmp_path):
+    """🔴 ALL FIVE OWNED SENTENCES, BY EXACT EQUALITY, IN ONE PLACE.
+
+    The verdict LINES were already pinned whole; the refusal MESSAGES were not,
+    and that is where the false sentence survived a green suite. `verdict` holds
+    only what this module asserts, so equality is possible without pinning
+    another module's wording or an age exit code that varies run to run.
+
+    A cosmetic reword fails this test. That is the price of a machine-readable
+    claim on the sentences that decide whether a key gets rotated.
+    """
+    good = escrow_world["objects"][KEY_DELTA_NEW]
+    objects = dict(escrow_world["objects"])
+
+    # 1. ARTIFACT-CORRUPT
+    objects[KEY_DELTA_NEW] = _corrupt_payload(good)
+    with pytest.raises(EV.EscrowError) as ei:
+        _decrypt_run(escrow_world, objects=objects)
+    assert ei.value.verdict == (
+        f"🔴 {KEY_DELTA_NEW} is TAMPERED, CORRUPT or TRUNCATED. age "
+        f"authenticated the header with the ESCROWED key — which a non-matching "
+        f"identity cannot do — began writing plaintext, and then FAILED on the "
+        f"payload. THE ESCROW IS FINE; THE BACKUP IS NOT. This is the finding a "
+        f"backup verifier exists to make: treat the artifact as unusable, check "
+        f"the other retained objects for this scope, and do NOT rotate the key.")
+
+    # 2. ARTIFACT-UNREADABLE
+    objects[KEY_DELTA_NEW] = b""
+    with pytest.raises(EV.EscrowError) as ei:
+        _decrypt_run(escrow_world, objects=objects)
+    assert ei.value.verdict == (
+        f"the pipeline failed BEFORE the escrowed key was ever used, on "
+        f"{KEY_DELTA_NEW} — an empty or unreadable object, not a fact about the "
+        f"escrow. NOTHING here decrypted, and nothing here is evidence for or "
+        f"against the escrowed key. Run `restore-verify.py` to diagnose the "
+        f"object.")
+
+    # 3. DECRYPT-FAILED — wrong key, so age writes nothing at all.
+    wrong = _new_identity(tmp_path, "verdict-wrong.key")
+    d = FakeDownloader(escrow_world["objects"])
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.run(bw=_cli(FakeBw(items=[_item(notes=wrong.read_text())])),
+               identity=wrong, item_name=ITEM, decrypt=True, prefix=PREFIX,
+               store=escrow_world["store"], work_dir=escrow_world["work"],
+               now=NOW, downloader_factory=lambda: d)
+    assert ei.value.verdict == (
+        f"age REFUSED {KEY_DELTA_NEW} without writing any plaintext at all. TWO "
+        f"CAUSES PRODUCE THIS AND THEY ARE NOT SEPARABLE FROM HERE: the escrowed "
+        f"identity does not match this artifact's recipients, or the artifact's "
+        f"HEADER is damaged. Neither is asserted. To tell them apart, run "
+        f"`restore-verify.py` with the ON-DISK identity: if that fails too the "
+        f"artifact is the problem, not the escrow. Do NOT rotate the key before "
+        f"doing that.")
+
+    # 4. RESTORE-FAILED — decrypt returns, the BUNDLE inside is damaged.
+    scope = escrow_world["store"] / "scope-delta"
+    objects[KEY_DELTA_NEW] = _artifact(scope, escrow_world["identity"], tmp_path,
+                                       mangle=_flip_middle_byte, tag="vpin")
+    with pytest.raises(EV.EscrowError) as ei:
+        _decrypt_run(escrow_world, objects=objects)
+    assert ei.value.token == "RESTORE-FAILED"
+    assert ei.value.verdict == (
+        f"the ESCROWED bytes DECRYPTED {KEY_DELTA_NEW} — `decrypt()` RETURNED, "
+        f"which is what makes that claim observable — and the restore then "
+        f"failed. This is a fault in the ARTIFACT, not in the escrow. The "
+        f"escrowed key works; run `restore-verify.py` to diagnose the artifact.")
+
+
+def test_a_HEADER_corrupt_artifact_lands_on_the_NOT_SEPARABLE_verdict(escrow_world):
+    """🔴 THE HONEST LIMIT, MEASURED AND PINNED.
+
+    Header corruption and a wrong key BOTH give rc=1 with no output file, so
+    they are genuinely indistinguishable from outside. The verdict must
+    therefore assert NEITHER — and must hand over the check that does separate
+    them (re-run with the ON-DISK identity). A verdict that blamed the escrow
+    here would send someone to rotate a working key over a damaged artifact.
+    """
+    good = escrow_world["objects"][KEY_DELTA_NEW]
+    b = bytearray(good)
+    b[40] ^= 0xFF                      # offset 40 is inside the age header
+    objects = dict(escrow_world["objects"])
+    objects[KEY_DELTA_NEW] = bytes(b)
+    with pytest.raises(EV.EscrowError) as ei:
+        _decrypt_run(escrow_world, objects=objects)
+    assert ei.value.token == "DECRYPT-FAILED"
+    assert "NOT SEPARABLE FROM HERE" in ei.value.verdict
+    assert "Do NOT rotate the key before doing that" in ei.value.verdict
+    # It must not claim the escrow is the fault, which the old wording did.
+    assert "not (or no longer) a working identity" not in ei.value.verdict
+
+
+def test_the_decrypt_CAUSE_is_a_published_VALUE_not_a_substring():
+    """🔴 THE SEAM, pinned from both sides.
+
+    `escrow-verify` branches on `restore_verify.DECRYPT_*`. If those constants
+    are renamed or the set changes, this goes red rather than the classifier
+    silently falling into its `else` — which is how a tampered artifact got
+    reported as empty in the first place.
+    """
+    assert RV.DECRYPT_AGE_MISSING == "age-missing"
+    assert RV.DECRYPT_AGE_REFUSED == "age-refused"
+    assert RV.DECRYPT_EMPTY_PLAINTEXT == "empty-plaintext"
+    assert RV.DECRYPT_CAUSES == {"age-missing", "age-refused", "empty-plaintext"}
+    with pytest.raises(KeyError):
+        RV.RestoreVerifyError("x", cause="not-a-published-cause")
+    # A failure with no published cause reads as None, never as a default one.
+    assert RV.RestoreVerifyError("x").cause is None
+
+
 def test_the_phase_probe_OBSERVES_rather_than_reimplements(escrow_world):
     """🔴 THE PROBE MUST BE TRANSPARENT. It wraps restore-verify's `decrypt` for
     the duration of one call; if it changed behaviour, or failed to restore the
@@ -1329,7 +1525,7 @@ def test_the_phase_probe_OBSERVES_rather_than_reimplements(escrow_world):
         seen["state"] = state
     assert RVmod.decrypt is before, "the probe did not restore the original"
     assert seen["state"] == {"reached": False, "returned": False,
-                             "plain_present": None}
+                             "plain_present": None, "cause": None}
     # And on a real run it records the success phase.
     v, _ = _decrypt_run(escrow_world)
     assert v.decrypt_checked is True
@@ -1600,6 +1796,42 @@ def test_shred_unlinks_a_SYMLINK_without_touching_its_target(tmp_path):
     assert target.read_text(encoding="utf-8") == "keep me\n"
 
 
+def test_shred_does_NOT_follow_a_symlink_it_FAILED_to_unlink(tmp_path):
+    """🔴 THE FALL-THROUGH, measured — a mutation sweep found it uncovered.
+
+    The test above uses a link whose unlink SUCCEEDS, so the `except OSError`
+    arm never runs. Restoring the old `pass`-and-fall-through survived the whole
+    suite: on that path `open(path, "r+b")` FOLLOWS the link and zeroes the
+    target, which is the truncate-in-place primitive the symlink branch exists
+    to remove. Same lesson as the `O_NOFOLLOW` layer one test up — a layer
+    nobody can observe failing is a layer nobody knows is gone.
+
+    A read-only parent directory makes `unlink` raise EACCES while the link
+    itself is still perfectly followable.
+    """
+    if os.geteuid() == 0:
+        pytest.skip("root ignores directory write permission; the arm is "
+                    "unreachable as root and a skip here is honest")
+    target = tmp_path / "precious.txt"
+    target.write_text("must survive\n", encoding="utf-8")
+    holder = tmp_path / "ro"
+    holder.mkdir()
+    link = holder / "link"
+    link.symlink_to(target)
+    os.chmod(holder, 0o500)                     # r-x: unlink will fail
+    try:
+        # POSITIVE CONTROL: the unlink really is impossible here, so the
+        # assertion below is about the arm under test and not about a link that
+        # simply vanished.
+        with pytest.raises(OSError):
+            link.unlink()
+        EV._shred(link)
+        assert target.read_text(encoding="utf-8") == "must survive\n"
+        assert link.is_symlink(), "the link should still be there, unfollowed"
+    finally:
+        os.chmod(holder, 0o700)
+
+
 def test_create_private_file_REFUSES_to_follow_a_symlink_it_cannot_remove(tmp_path):
     """A directory in the way is the case `O_EXCL` must turn into an error
     rather than a silent reuse — `_shred` cannot unlink a directory."""
@@ -1647,6 +1879,33 @@ def test_the_OPEN_flags_defend_the_path_EVEN_IF_the_unlink_layer_fails(tmp_path,
         assert victim.is_symlink()
     else:
         assert victim.read_text(encoding="utf-8") == "pre-existing\n"
+
+
+def test_the_fchmod_is_LOAD_BEARING_under_a_hostile_umask(tmp_path):
+    """🔴 MAKE THE REDUNDANT LAYER OBSERVABLE, or drop it — same lesson as the
+    `O_EXCL|O_NOFOLLOW` case one test up.
+
+    `os.open(..., 0o600)` is masked by the umask, and no ordinary umask clears
+    bits from 0600 — so deleting `os.fchmod(fd, _FILE_MODE)` survived all 120
+    tests while a positive control (`fchmod(fd, 0o666)`) was killed, proving the
+    assertions COULD see it and simply never exercised the case.
+
+    A umask of 0o377 clears owner-write from the `os.open` mode, leaving 0o200
+    masked to 0o000 — so without the fchmod the key file would be created
+    unreadable-and-unwritable by its owner, and with it the mode is 0600
+    regardless. The umask is restored in a `finally`; it is process-global.
+    """
+    p = tmp_path / "hostile.key"
+    old = os.umask(0o377)
+    try:
+        fd = EV._create_private_file(p)
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(b"synthetic-under-hostile-umask")
+    finally:
+        os.umask(old)
+    assert stat.S_IMODE(p.stat().st_mode) == 0o600, oct(
+        stat.S_IMODE(p.stat().st_mode))
+    assert p.read_bytes() == b"synthetic-under-hostile-umask"
 
 
 def test_create_private_file_makes_a_fresh_0600_regular_file(tmp_path):

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -503,6 +503,32 @@ def test_a_TRAILING_NEWLINE_difference_is_its_OWN_classification(tmp_path):
     assert ei.value.exit_code == 21
     assert ei.value.exit_code != EV.EXIT_CODES["BYTES-DIFFER-MATERIALLY"]
     assert ei.value.exit_code != EV.EXIT_OK
+    # 🔴 IT MUST NOT OFFER A CHECK IT CANNOT PERFORM. This refusal is raised
+    # BEFORE the `if not decrypt` return, so `--decrypt-check` produces the
+    # identical message and can never confirm anything — the message used to
+    # say "or confirm with --decrypt-check", which is advice to run the same
+    # command again.
+    assert "confirm with --decrypt-check" not in ei.value.verdict
+    assert "--decrypt-check CANNOT confirm this" in ei.value.verdict
+
+
+def test_the_trailing_newline_refusal_is_IDENTICAL_with_and_without_decrypt_check(
+        tmp_path, escrow_world):
+    """The measurement behind the sentence above: the flag changes nothing here,
+    because the byte check refuses first. Both runs, same token, same verdict."""
+    trimmed = ESCROW_NOTE.rstrip("\n")
+    ident = _identity(tmp_path, ESCROW_NOTE, name="tn.key")
+    seen = []
+    for decrypt in (False, True):
+        d = FakeDownloader(escrow_world["objects"])
+        with pytest.raises(EV.EscrowError) as ei:
+            EV.run(bw=_cli(FakeBw(items=[_item(notes=trimmed)])), identity=ident,
+                   item_name=ITEM, decrypt=decrypt, prefix=PREFIX,
+                   store=escrow_world["store"], work_dir=escrow_world["work"],
+                   now=NOW, downloader_factory=lambda: d)
+        seen.append((ei.value.token, ei.value.verdict))
+        assert d.gets == [], "the artifact store was reached on a byte-mismatch"
+    assert seen[0] == seen[1], "the flag changed the outcome after all"
 
 
 def test_the_trailing_newline_case_is_NOT_reported_as_a_pass(tmp_path):
@@ -1379,9 +1405,15 @@ def test_age_ABSENT_is_an_ENVIRONMENT_fault_not_a_verdict_on_the_escrow(
         _decrypt_run(escrow_world)
     assert ei.value.token == "AGE-MISSING"
     assert ei.value.exit_code == 29
-    msg = str(ei.value)
-    assert "says NOTHING about the escrow" in msg
-    assert "The escrowed key works" not in msg
+    # The owned sentence, WHOLE — a substring here would pass on a reworded
+    # message that had stopped saying the thing that matters.
+    assert ei.value.verdict == (
+        "`age` is not on PATH, so the escrowed key cannot be tested against "
+        "anything. This is an ENVIRONMENT fault and says NOTHING about the "
+        "escrow — do not read it as a verdict on the key or on the artifacts. "
+        "age is declared in nix/pkgs/default.nix and in flake.nix `gateTools`; "
+        "add it there, or run this whole command under nix.")
+    assert ei.value.detail is None
 
 
 def test_the_age_precondition_runs_BEFORE_the_store_is_opened(escrow_world,
@@ -1402,7 +1434,17 @@ def test_the_age_precondition_runs_BEFORE_the_store_is_opened(escrow_world,
 
 
 def test_every_decrypt_family_VERDICT_is_pinned_WHOLE(escrow_world, tmp_path):
-    """🔴 ALL FIVE OWNED SENTENCES, BY EXACT EQUALITY, IN ONE PLACE.
+    """🔴 FOUR OWNED SENTENCES, BY EXACT EQUALITY, IN ONE PLACE.
+
+    The other two decrypt-family verdicts are pinned whole beside the cases they
+    belong to — `ARTIFACT-EMPTY` in
+    `test_a_valid_encryption_of_NOTHING_says_the_ESCROW_IS_FINE`, and the
+    in-classifier `AGE-MISSING` in
+    `test_the_in_classifier_AGE_MISSING_belt_is_REACHED_and_pinned`. Six
+    verdicts, six exact pins, three files' worth of context; this docstring used
+    to say "all five" while the body pinned four, which is the same
+    wider-than-the-code sentence this suite exists to catch.
+
 
     The verdict LINES were already pinned whole; the refusal MESSAGES were not,
     and that is where the false sentence survived a green suite. `verdict` holds
@@ -1450,10 +1492,12 @@ def test_every_decrypt_family_VERDICT_is_pinned_WHOLE(escrow_world, tmp_path):
         f"age REFUSED {KEY_DELTA_NEW} without writing any plaintext at all. TWO "
         f"CAUSES PRODUCE THIS AND THEY ARE NOT SEPARABLE FROM HERE: the escrowed "
         f"identity does not match this artifact's recipients, or the artifact's "
-        f"HEADER is damaged. Neither is asserted. To tell them apart, run "
-        f"`restore-verify.py` with the ON-DISK identity: if that fails too the "
-        f"artifact is the problem, not the escrow. Do NOT rotate the key before "
-        f"doing that.")
+        f"HEADER is damaged. Neither is asserted. To tell them apart, try a "
+        f"DIFFERENT artifact with this same escrowed copy — `--scope <another "
+        f"scope>`, or `restore-verify.py --all` for an older stamp: if another "
+        f"artifact OPENS, the escrowed key is fine and THIS object's header is "
+        f"damaged; if none open, the key is the likely cause. Do NOT rotate the "
+        f"key before running that.")
 
     # 4. RESTORE-FAILED — decrypt returns, the BUNDLE inside is damaged.
     scope = escrow_world["store"] / "scope-delta"
@@ -1487,9 +1531,17 @@ def test_a_HEADER_corrupt_artifact_lands_on_the_NOT_SEPARABLE_verdict(escrow_wor
         _decrypt_run(escrow_world, objects=objects)
     assert ei.value.token == "DECRYPT-FAILED"
     assert "NOT SEPARABLE FROM HERE" in ei.value.verdict
-    assert "Do NOT rotate the key before doing that" in ei.value.verdict
+    assert "Do NOT rotate the key before running that" in ei.value.verdict
     # It must not claim the escrow is the fault, which the old wording did.
     assert "not (or no longer) a working identity" not in ei.value.verdict
+    # 🔴 AND THE HANDOVER MUST BE A CONTROL, NOT A SECOND SAMPLE. `decrypt_check`
+    # only runs when the escrowed bytes are byte-IDENTICAL to the on-disk
+    # identity, so "re-run with the ON-DISK identity" was the same experiment
+    # with the same input — guaranteed to fail identically, and the conclusion
+    # ("the artifact is the problem") unsound, since both copies can be a stale
+    # key while the artifact is fine. The check offered must vary the ARTIFACT.
+    assert "ON-DISK identity" not in ei.value.verdict
+    assert "DIFFERENT artifact" in ei.value.verdict
 
 
 def test_the_decrypt_CAUSE_is_a_published_VALUE_not_a_substring():
@@ -1508,6 +1560,110 @@ def test_the_decrypt_CAUSE_is_a_published_VALUE_not_a_substring():
         RV.RestoreVerifyError("x", cause="not-a-published-cause")
     # A failure with no published cause reads as None, never as a default one.
     assert RV.RestoreVerifyError("x").cause is None
+
+
+def test_the_in_classifier_AGE_MISSING_belt_is_REACHED_and_pinned(escrow_world,
+                                                                  monkeypatch):
+    """🔴 F2: THE BELT BRANCH HAD ZERO COVERAGE.
+
+    A sweep found `if phase["cause"] == RV.DECRYPT_AGE_MISSING:` -> `if False:`
+    SURVIVED the whole suite. With the branch gone, control falls through to
+    `plain_present == False` and reports `DECRYPT-FAILED` — "age REFUSED {key}"
+    — which is exactly the environment-fault-blamed-on-the-escrow
+    misclassification the token exists to prevent.
+
+    The branch is for `age` vanishing BETWEEN the precondition and the call, so
+    the test injects precisely that: `which` still answers (precondition
+    passes), and the decrypt step raises with the published age-missing cause.
+    """
+    monkeypatch.setattr(EV.shutil, "which", lambda name: "/usr/bin/" + name)
+    RVmod = EV._rv()
+
+    def gone(cipher, plain, identity):
+        raise RVmod.RestoreVerifyError(
+            "age is not on PATH", cause=RVmod.DECRYPT_AGE_MISSING)
+
+    monkeypatch.setattr(RVmod, "decrypt", gone)
+    with pytest.raises(EV.EscrowError) as ei:
+        _decrypt_run(escrow_world)
+    assert ei.value.token == "AGE-MISSING"
+    assert ei.value.exit_code == 29
+    assert ei.value.exit_code != EV.EXIT_CODES["DECRYPT-FAILED"]
+    assert ei.value.verdict == (
+        "`age` vanished between the precondition check and the decrypt call, so "
+        "the escrowed key was never tested. This is an ENVIRONMENT fault and "
+        "says NOTHING about the escrow or the artifacts.")
+    assert _work_contents(escrow_world["work"]) == []
+
+
+def test_a_STALE_plaintext_cannot_turn_a_WRONG_KEY_into_ARTIFACT_CORRUPT(tmp_path):
+    """🔴 F3: THE HEADLINE DEFECT, RECREATED ONE FILE OVER.
+
+    `plain_present` is a sound witness only if the output path cannot
+    pre-exist. MEASURED: on BOTH the wrong-key and damaged-header paths age
+    leaves a PRE-EXISTING `--output` file completely untouched (rc=1, present,
+    original bytes intact) — it creates the file only after authenticating the
+    header. `work_dir` is routinely REUSED, so a leftover from a run aborted
+    mid-decrypt makes a WRONG KEY read as `ARTIFACT-CORRUPT` — "THE ESCROW IS
+    FINE; THE BACKUP IS NOT … do NOT rotate the key."
+
+    Driven through `restore_verify.decrypt` directly, which is where the unlink
+    lives, with a positive control that the stale file really was there first.
+    """
+    ident_a = _new_identity(tmp_path, "stale-a.key")
+    ident_b = _new_identity(tmp_path, "stale-b.key")
+    src = tmp_path / "payload.bin"
+    src.write_bytes(b"synthetic payload for the stale-plaintext case\n" * 64)
+    cipher = tmp_path / "payload.age"
+    B.encrypt(src, cipher, _recipient(ident_a))
+
+    plain = tmp_path / "leftover.bundle"
+    plain.write_bytes(b"STALE-LEFTOVER-FROM-AN-ABORTED-RUN")
+    assert plain.is_file(), "positive control: the stale file must exist first"
+
+    with pytest.raises(RV.RestoreVerifyError) as ei:
+        RV.decrypt(cipher, plain, ident_b)          # ident_b cannot open it
+    assert ei.value.cause == RV.DECRYPT_AGE_REFUSED
+    # 🔴 THE ASSERTION THAT MATTERS: the stale file is GONE, so a consumer
+    # reading `plain.exists()` gets the truth — age wrote nothing.
+    assert not plain.exists(), (
+        "the stale plaintext survived a failed decrypt; `plain_present` would "
+        "report a wrong key as a corrupt artifact")
+
+
+def test_the_probe_reports_an_UNREADABLE_plaintext_path_as_UNKNOWN(tmp_path,
+                                                                  monkeypatch):
+    """🔴 `Path.exists()` RAISES ON THIS INTERPRETER — measured, CPython 3.12.14,
+    parent directory without `+x`. Unhandled inside the probe's `except`, it
+    would REPLACE the real exception, and the run would report a permissions
+    error instead of whatever age actually did.
+
+    Unreadable must read as None (unobservable), never False (which downstream
+    would take for "age wrote nothing")."""
+    if os.geteuid() == 0:
+        pytest.skip("root traverses a directory without +x; the arm is "
+                    "unreachable as root and a skip here is honest")
+    RVmod = EV._rv()
+    holder = tmp_path / "noexec"
+    holder.mkdir()
+    plain = holder / "p.bundle"
+    plain.write_text("x", encoding="utf-8")
+
+    def raiser(cipher, p, identity):
+        os.chmod(holder, 0o600)                 # rw- : traversal denied
+        raise RVmod.RestoreVerifyError("synthetic", cause=RVmod.DECRYPT_AGE_REFUSED)
+
+    monkeypatch.setattr(RVmod, "decrypt", raiser)
+    try:
+        with EV._decrypt_phase_probe(RVmod) as state:
+            with pytest.raises(RVmod.RestoreVerifyError):
+                RVmod.decrypt(tmp_path / "c.age", plain, tmp_path / "k")
+        # POSITIVE CONTROL: without the handler this line is never reached,
+        # because `exists()` raises out of the `except` block.
+        assert state["plain_present"] is None
+        assert state["cause"] == RVmod.DECRYPT_AGE_REFUSED
+    finally:
+        os.chmod(holder, 0o700)
 
 
 def test_the_phase_probe_OBSERVES_rather_than_reimplements(escrow_world):
@@ -1890,10 +2046,10 @@ def test_the_fchmod_is_LOAD_BEARING_under_a_hostile_umask(tmp_path):
     tests while a positive control (`fchmod(fd, 0o666)`) was killed, proving the
     assertions COULD see it and simply never exercised the case.
 
-    A umask of 0o377 clears owner-write from the `os.open` mode, leaving 0o200
-    masked to 0o000 — so without the fchmod the key file would be created
-    unreadable-and-unwritable by its owner, and with it the mode is 0600
-    regardless. The umask is restored in a `finally`; it is process-global.
+    A umask of 0o377 clears owner-WRITE (and all group/other bits) from the
+    `os.open` mode: `0o600 & ~0o377 == 0o400`, i.e. the key file would be
+    created owner-READ-ONLY. With the fchmod the mode is 0o600 regardless. The
+    umask is restored in a `finally`; it is process-global.
     """
     p = tmp_path / "hostile.key"
     old = os.umask(0o377)

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -34,6 +34,7 @@ import json
 import os
 import shlex
 import shutil
+import signal
 import stat
 import subprocess
 import sys
@@ -302,7 +303,28 @@ def test_the_exit_code_table_is_pinned_EXACTLY_both_ways():
         "RESTORE-FAILED": 26,
         "STORE-UNREACHABLE": 27,
         "NO-ARTIFACT": 28,
+        "AGE-MISSING": 29,
+        "ARTIFACT-UNREADABLE": 30,
+        "ARTIFACT-EMPTY": 31,
+        "NOTE-MISSING": 32,
     }
+
+
+def test_the_five_decrypt_outcomes_are_FIVE_DISTINCT_codes():
+    """🔴 THE HEADLINE SPLIT, pinned as a set of distinct integers.
+
+    An audit found the original two-way split wrong in three measured cases,
+    every one of them blaming the escrow for a fault the escrow could not have
+    caused. These five must never collapse back: `age` absent is an ENVIRONMENT
+    fault, "failed before decrypt ran" is an OBJECT fault, "age refused" is a
+    KEY fault, "age succeeded on nothing" is a DATA fault where the key is
+    FINE, and "decrypt returned, restore failed" is a DATA fault too.
+    """
+    names = ["AGE-MISSING", "ARTIFACT-UNREADABLE", "DECRYPT-FAILED",
+             "ARTIFACT-EMPTY", "RESTORE-FAILED"]
+    codes = [EV.EXIT_CODES[n] for n in names]
+    assert codes == [29, 30, 25, 31, 26]
+    assert len(set(codes)) == 5
 
 
 def test_every_exit_code_is_DISTINCT_and_never_collides_with_success_or_crash():
@@ -348,6 +370,36 @@ def test_classify_calls_a_CRLF_rewrite_MATERIAL_not_a_trailing_newline():
 
 def test_classify_does_not_confuse_a_leading_newline_with_a_trailing_one():
     assert EV.classify(b"\nabc\n", b"abc\n") == "DIFFERS-MATERIALLY"
+
+
+@pytest.mark.parametrize("suffix,name", [
+    (b" ", "space"), (b"\t", "tab"), (b"\r", "carriage return"),
+    (b"\n \n", "newline-space-newline"), (b"  \n", "two spaces then newline"),
+])
+def test_only_NEWLINES_count_as_a_trailing_newline_difference(suffix, name):
+    """🔴 THE NARROWNESS IS THE CLAIM, so it gets measured.
+
+    `classify`'s docstring calls the rule "narrow on purpose" — trailing `\\n`
+    and nothing else. Widening it to a bare `rstrip()` would fold trailing
+    SPACES and TABS into "differs by trailing newline only", i.e. into the
+    verdict that means "probably still usable, one `printf` fixes it". A key
+    with trailing whitespace is a different object and the operator would be
+    told the wrong thing.
+
+    Measured here, not asserted: an audit's independent sweep found
+    `rstrip(b"\\n") -> rstrip()` SURVIVED the suite before these cases existed.
+    """
+    base = b"AGE-SECRET-KEY-1SYNTHETICFIXTUREVALUE\n"
+    assert EV.classify(base + suffix, base) == "DIFFERS-MATERIALLY", name
+
+
+def test_a_PURE_trailing_newline_difference_is_STILL_its_own_class():
+    """The positive half of the pair above: narrowing must not narrow to
+    nothing. Without this, `rstrip(b"\\n") -> (no strip at all)` would pass every
+    case above while destroying the classification that matters."""
+    base = b"AGE-SECRET-KEY-1SYNTHETICFIXTUREVALUE"
+    assert EV.classify(base + b"\n", base) == "DIFFERS-TRAILING-NEWLINE-ONLY"
+    assert EV.classify(base, base + b"\n\n") == "DIFFERS-TRAILING-NEWLINE-ONLY"
 
 
 # --------------------------------------------------------------------------- #
@@ -522,9 +574,29 @@ def test_a_WHITESPACE_ONLY_note_is_EMPTY_not_a_mismatch(tmp_path):
     assert ei.value.token == "NOTE-EMPTY"
 
 
-def test_a_MISSING_notes_field_is_EMPTY_not_a_crash(tmp_path):
+def test_an_ABSENT_notes_FIELD_is_NOT_the_same_finding_as_an_EMPTY_one(tmp_path):
+    """🔴 OPPOSITE ACTIONS. `NOTE-EMPTY` says the escrow was emptied and sends
+    the operator to re-escrow — which, if `bw` merely OMITTED the field for an
+    INTACT note, overwrites a good copy on the strength of a parsing accident.
+
+    `_item(notes=None)` builds a payload with no `notes` key at all, which is
+    the shape being distinguished."""
+    item = _item(notes=None)
+    assert "notes" not in item, "the fixture must omit the field, not empty it"
     with pytest.raises(EV.EscrowError) as ei:
-        _run(tmp_path, FakeBw(items=[_item(notes=None)]))
+        _run(tmp_path, FakeBw(items=[item]))
+    assert ei.value.token == "NOTE-MISSING"
+    assert ei.value.exit_code == 32
+    assert ei.value.exit_code != EV.EXIT_CODES["NOTE-EMPTY"]
+    assert "Do NOT re-escrow" in str(ei.value)
+
+
+def test_a_notes_field_present_but_NOT_A_STRING_is_NOTE_EMPTY(tmp_path):
+    """The field is there, so this is not the absent case; it carries nothing
+    usable, so it is the empty one."""
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, FakeBw(items=[{"id": "x", "name": ITEM,
+                                      "type": SECURE_NOTE, "notes": 17}]))
     assert ei.value.token == "NOTE-EMPTY"
 
 
@@ -783,11 +855,124 @@ def test_a_PINNED_server_that_agrees_PASSES_and_the_verdict_SAYS_it_was_pinned(t
     f = FakeBw(items=[_item()])
     v = _run(tmp_path, f, expect_server=SERVER + "/")   # trailing slash tolerated
     assert v.server_pinned is True
-    assert "server pinned and matched" in v.line()
+    assert v.server_session_reason is None
 
     v2 = _run(tmp_path, FakeBw(items=[_item()]))
     assert v2.server_pinned is False
-    assert "NOT PINNED" in v2.line()
+    assert v2.server_session_reason is None
+
+
+# --------------------------------------------------------------------------- #
+# 10b. 🔴 THE SESSION CROSS-CHECK CANNOT SILENTLY NO-OP
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("status_doc,expect_word", [
+    ({"serverUrl": None, "status": "unlocked"}, "null"),
+    ({"serverUrl": "", "status": "unlocked"}, "empty"),
+    ({"serverUrl": "   ", "status": "unlocked"}, "empty"),
+    ({"status": "unlocked"}, "null"),              # field absent entirely
+])
+def test_an_UNAVAILABLE_session_server_is_reported_NOT_COMPARED_never_as_matched(
+        tmp_path, status_doc, expect_word):
+    """🔴 THE AUDIT'S SECOND 🔴. `bw status` returns `serverUrl: null` for the
+    official cloud, and the guard read `if session_server and …` — so the
+    comparison was SKIPPED with no signal while the success verdict went on to
+    print "the CLI's configured server matched the session's, which is all that
+    was checked". A check that did not run, reported as one that passed.
+
+    It is not a hard failure — a vault legitimately reachable without a
+    serverUrl must not be a permanently-red gate — so the requirement is that
+    the verdict SAYS SO, with the reason, exactly as `restore-verify.py` prints
+    `NOT CROSS-CHECKED (<reason>)`.
+    """
+    v = _run(tmp_path, FakeBw(status=status_doc, items=[_item()]))
+    assert v.server_session_reason is not None
+    assert expect_word in v.server_session_reason
+    line = v.line()
+    assert "session cross-check NOT COMPARED" in line
+    assert "session cross-check RAN" not in line
+    assert "matched the authenticated session's" not in line
+
+
+def test_the_verdict_line_is_pinned_WHOLE_for_every_server_combination(tmp_path):
+    """🔴 PIN THE WHOLE NORMALISED STRING, not a word inside it.
+
+    The previous assertion here was `"NOT PINNED" in v2.line()` — a bare
+    substring on a sentence that was, at that moment, ALREADY FALSE about the
+    session cross-check. An audit's mutant rewrote the entire sentence into a
+    flat lie and SURVIVED all 87 tests, because the two words it kept were the
+    two words being asserted.
+
+    A substring cannot tell a true sentence from a confident wrong one. So each
+    of the four combinations pins its complete line. A cosmetic reword fails
+    this test — that is the price of a machine-readable claim, and it is worth
+    paying for the one sentence an operator reads to decide the escrow is fine.
+    """
+    ident = _identity(tmp_path, ESCROW_NOTE, name="whole-line.key")
+    reason = "SYNTHETIC-REASON"
+
+    def mk(**kw):
+        return EV.EscrowVerdict(
+            item_name=ITEM, server=SERVER, escrow_bytes=ESCROW_NOTE_BYTES,
+            disk_bytes=ESCROW_NOTE_BYTES, classification=EV.CLASS_IDENTICAL,
+            identity=ident, **kw)
+
+    head = (f"analyze-service-index-escrow-verify: escrow OK — the Secure Note "
+            f"matches {ident} IDENTICAL (179 escrowed bytes vs 179 on disk)")
+    tail = ("NOT DECRYPT-CHECKED — byte equality proves the two copies agree, "
+            "NOT that either of them opens an artifact. Re-run with "
+            "--decrypt-check for that claim.")
+    ran = ("session cross-check RAN: the CLI's configured server matched the "
+           "authenticated session's")
+    notrun = f"session cross-check NOT COMPARED ({reason})"
+
+    assert mk(server_pinned=False, server_session_reason=None).line() == (
+        f"{head}; server NOT PINNED (--expect-server / ASIB_ESCROW_SERVER "
+        f"unset); {ran}; {tail}")
+    assert mk(server_pinned=True, server_session_reason=None).line() == (
+        f"{head}; server PINNED and matched; {ran}; {tail}")
+    assert mk(server_pinned=False, server_session_reason=reason).line() == (
+        f"{head}; server NOT PINNED (--expect-server / ASIB_ESCROW_SERVER "
+        f"unset); {notrun}; {tail}")
+    assert mk(server_pinned=True, server_session_reason=reason).line() == (
+        f"{head}; server PINNED and matched; {notrun}; {tail}")
+
+
+def test_the_DECRYPT_CHECKED_verdict_line_is_pinned_WHOLE(tmp_path):
+    """The fifth combination, for the same reason. This is the sentence that
+    claims the escrowed key OPENED something."""
+    ident = _identity(tmp_path, ESCROW_NOTE, name="whole-line-2.key")
+    v = EV.EscrowVerdict(
+        item_name=ITEM, server=SERVER, server_pinned=False,
+        escrow_bytes=ESCROW_NOTE_BYTES, disk_bytes=ESCROW_NOTE_BYTES,
+        classification=EV.CLASS_IDENTICAL, identity=ident,
+        server_session_reason=None, decrypt_checked=True,
+        decrypt_scope="scope-delta", decrypt_key=KEY_DELTA_NEW,
+        decrypt_commits=3, decrypt_refs=1)
+    assert v.line() == (
+        f"analyze-service-index-escrow-verify: escrow OK — the Secure Note "
+        f"matches {ident} IDENTICAL (179 escrowed bytes vs 179 on disk); "
+        f"server NOT PINNED (--expect-server / ASIB_ESCROW_SERVER unset); "
+        f"session cross-check RAN: the CLI's configured server matched the "
+        f"authenticated session's; DECRYPT-CHECKED: the ESCROWED bytes "
+        f"decrypted {KEY_DELTA_NEW} (scope scope-delta) and restored 3 "
+        f"commit(s) over 1 ref(s)")
+
+
+def test_an_unavailable_session_server_STILL_enforces_an_explicit_PIN(tmp_path):
+    """🔴 REACHABILITY: the new early-return must not become an escape hatch.
+    With no session serverUrl to compare against, a WRONG pinned server must
+    still fail — otherwise the fix for one silent skip introduces another."""
+    f = FakeBw(status={"serverUrl": None, "status": "unlocked"},
+               server="https://actual.invalid.example", items=[_item()])
+    with pytest.raises(EV.EscrowError) as ei:
+        _run(tmp_path, f, expect_server="https://expected.invalid.example")
+    assert ei.value.token == "SERVER-MISMATCH"
+    # ...and a MATCHING pin passes, so the branch above is not simply always-red.
+    f2 = FakeBw(status={"serverUrl": None, "status": "unlocked"},
+                server="https://actual.invalid.example", items=[_item()])
+    v = _run(tmp_path, f2, expect_server="https://actual.invalid.example")
+    assert v.server_pinned is True
+    assert v.server_session_reason is not None
 
 
 def test_url_comparison_ignores_case_and_a_trailing_slash_only(tmp_path):
@@ -1037,6 +1222,120 @@ def test_a_CORRUPTED_ARTIFACT_is_RESTORE_FAILED_not_DECRYPT_FAILED(escrow_world,
     assert ei.value.exit_code == 26
 
 
+def test_a_ZERO_BYTE_object_is_ARTIFACT_UNREADABLE_and_never_claims_it_DECRYPTED(
+        escrow_world):
+    """🔴 AUDIT CASE 3. `verify_artifact` refuses a 0-byte object BEFORE calling
+    `decrypt()`, so the old classifier — which read the absence of a substring —
+    reported RESTORE-FAILED and asserted the bytes "DECRYPTED".
+
+    The message must not contain that word in the past tense about this run, and
+    the token must say the pipeline never reached the key.
+    """
+    objects = dict(escrow_world["objects"])
+    objects[KEY_DELTA_NEW] = b""
+    with pytest.raises(EV.EscrowError) as ei:
+        _decrypt_run(escrow_world, objects=objects)
+    assert ei.value.token == "ARTIFACT-UNREADABLE"
+    assert ei.value.exit_code == 30
+    msg = str(ei.value)
+    assert "DECRYPTED" not in msg
+    assert "The escrowed key works" not in msg
+    # It says the opposite, and says it explicitly.
+    assert "NOTHING here decrypted" in msg
+
+
+def test_a_valid_encryption_of_NOTHING_says_the_ESCROW_IS_FINE(escrow_world, tmp_path):
+    """🔴 AUDIT CASE 2 — THE ONE THAT GETS A GOOD DR KEY ROTATED.
+
+    `age` encrypts a zero-byte payload to a perfectly valid ~200-byte
+    ciphertext and decrypts it back at rc=0. The old classifier saw
+    restore-verify's `DECRYPT FAILED … decrypted to ZERO bytes` and reported
+    DECRYPT-FAILED — "not (or no longer) a working identity" — for a key that
+    had just worked. Acting on that verdict destroys the escrow.
+
+    The discriminator is MEASURED, not guessed (age v1.3.1): a refusal leaves NO
+    output file, a success-on-empty leaves one at size 0. `_decrypt_phase_probe`
+    reads exactly that.
+    """
+    empty = tmp_path / "empty-payload"
+    empty.write_bytes(b"")
+    cipher = tmp_path / "empty-payload.age"
+    B.encrypt(empty, cipher, _recipient(escrow_world["identity"]))
+    blob = cipher.read_bytes()
+    assert blob.startswith(b"age-encryption.org/") and len(blob) > 100
+
+    objects = dict(escrow_world["objects"])
+    objects[KEY_DELTA_NEW] = blob
+    with pytest.raises(EV.EscrowError) as ei:
+        _decrypt_run(escrow_world, objects=objects)
+    assert ei.value.token == "ARTIFACT-EMPTY"
+    assert ei.value.exit_code == 31
+    # 🔴 DISCRIMINATING, not a substring presence check: it must NOT be the
+    # token that means "the escrowed key is wrong", and it must say so in words
+    # the operator would act on.
+    assert ei.value.exit_code != EV.EXIT_CODES["DECRYPT-FAILED"]
+    msg = str(ei.value)
+    assert "THE ESCROW IS FINE" in msg
+    assert "Do NOT re-escrow or rotate" in msg
+
+
+def test_age_ABSENT_is_an_ENVIRONMENT_fault_not_a_verdict_on_the_escrow(
+        escrow_world, monkeypatch):
+    """🔴 AUDIT CASE 1. With `age` off PATH the old code reported RESTORE-FAILED,
+    asserting in one sentence that the escrowed key WORKED, that the artifact was
+    at fault, and that `restore-verify.py` would diagnose it — three false
+    claims, the last of which sends the operator to a tool that fails
+    identically for the same unnamed reason."""
+    monkeypatch.setattr(EV.shutil, "which",
+                        lambda name: None if name == "age" else "/usr/bin/" + name)
+    with pytest.raises(EV.EscrowError) as ei:
+        _decrypt_run(escrow_world)
+    assert ei.value.token == "AGE-MISSING"
+    assert ei.value.exit_code == 29
+    msg = str(ei.value)
+    assert "says NOTHING about the escrow" in msg
+    assert "The escrowed key works" not in msg
+
+
+def test_the_age_precondition_runs_BEFORE_the_store_is_opened(escrow_world,
+                                                              monkeypatch):
+    """REACHABILITY for the precondition, and it is load-bearing twice: it also
+    makes the phase probe's "no plaintext ⇒ age refused" inference sound."""
+    monkeypatch.setattr(EV.shutil, "which",
+                        lambda name: None if name == "age" else "/usr/bin/" + name)
+    d = FakeDownloader(escrow_world["objects"])
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.run(bw=_cli(FakeBw(items=[_item(notes=escrow_world["note"])])),
+               identity=escrow_world["identity"], item_name=ITEM, decrypt=True,
+               prefix=PREFIX, store=escrow_world["store"],
+               work_dir=escrow_world["work"], now=NOW,
+               downloader_factory=lambda: d)
+    assert ei.value.token == "AGE-MISSING"
+    assert d.gets == [], "the store was opened before the precondition was checked"
+
+
+def test_the_phase_probe_OBSERVES_rather_than_reimplements(escrow_world):
+    """🔴 THE PROBE MUST BE TRANSPARENT. It wraps restore-verify's `decrypt` for
+    the duration of one call; if it changed behaviour, or failed to restore the
+    original, every later run in the same process would be wrong.
+
+    Watch it: the module attribute is the same object before and after, and a
+    successful run still reports `returned`."""
+    RVmod = EV._rv()
+    before = RVmod.decrypt
+    seen = {}
+    with EV._decrypt_phase_probe(RVmod) as state:
+        assert RVmod.decrypt is not before, "the probe never installed itself"
+        seen["state"] = state
+    assert RVmod.decrypt is before, "the probe did not restore the original"
+    assert seen["state"] == {"reached": False, "returned": False,
+                             "plain_present": None}
+    # And on a real run it records the success phase.
+    v, _ = _decrypt_run(escrow_world)
+    assert v.decrypt_checked is True
+    assert RVmod.decrypt is before
+
+
 def test_ZERO_artifacts_under_the_prefix_is_NO_ARTIFACT_not_a_clean_check(escrow_world):
     """🔴 A key that was never asked to decrypt anything has not been shown to
     work. An empty bucket must not read as a successful decrypt check."""
@@ -1226,6 +1525,142 @@ def test_the_throwaway_identity_is_0600_inside_a_0700_dir_WHILE_IT_EXISTS(escrow
     assert not seen["path"].exists()
 
 
+def test_a_PREEXISTING_loose_file_at_the_identity_path_does_not_keep_its_mode(
+        escrow_world, monkeypatch):
+    """🔴 `O_CREAT|O_TRUNC` APPLIES ITS MODE ONLY ON CREATE.
+
+    Measured by an audit via `--work-dir`: a pre-existing 0666 file RECEIVED the
+    escrowed key and STAYED 0666 for the whole time it held it. The 0700
+    directory bounded the damage, but the module's own "0600" sentence was false
+    on exactly the option that hands this a directory somebody else populated.
+    """
+    work = escrow_world["work"]
+    victim = work / EV.ESCROW_IDENTITY_FILENAME
+    victim.write_bytes(b"pre-existing decoy content")
+    victim.chmod(0o666)
+    assert stat.S_IMODE(victim.stat().st_mode) == 0o666
+
+    seen = {}
+    RVmod = EV._rv()
+    real = RVmod.verify_artifact
+
+    def spy(downloader, key, **kw):
+        p = Path(kw["identity"])
+        seen["mode"] = stat.S_IMODE(p.stat().st_mode)
+        seen["bytes"] = p.read_bytes()
+        return real(downloader, key, **kw)
+
+    monkeypatch.setattr(RVmod, "verify_artifact", spy)
+    _decrypt_run(escrow_world)
+    assert seen["mode"] == 0o600, oct(seen["mode"])
+    assert seen["bytes"] == escrow_world["note"].encode("utf-8")
+    assert _work_contents(work) == []
+
+
+def test_a_SYMLINK_at_the_identity_path_is_NOT_followed_and_its_target_survives(
+        escrow_world, tmp_path):
+    """🔴 THE WORST SHAPE THE AUDIT FOUND: a truncate-in-place primitive.
+
+    With `O_CREAT|O_TRUNC` plus the old `_shred`, a symlink planted at the
+    identity path got the escrowed key written THROUGH it to a 0644 file
+    OUTSIDE the 0700 directory — and `_shred` then ZEROED that target while
+    unlinking only the link, leaving a zero-filled decoy on any path the user
+    can write.
+
+    Both halves are asserted: the target keeps its original bytes and its
+    original mode, and the link itself is gone.
+    """
+    work = escrow_world["work"]
+    outside = tmp_path / "innocent-bystander.txt"
+    outside.write_text("do not touch me\n", encoding="utf-8")
+    outside.chmod(0o644)
+    before = outside.read_bytes()
+
+    link = work / EV.ESCROW_IDENTITY_FILENAME
+    link.symlink_to(outside)
+    assert link.is_symlink()
+
+    v, _ = _decrypt_run(escrow_world)
+    assert v.decrypt_checked is True
+    assert outside.read_bytes() == before, "the symlink target was written through"
+    assert stat.S_IMODE(outside.stat().st_mode) == 0o644
+    assert not link.exists() and not link.is_symlink()
+    assert _work_contents(work) == []
+
+
+def test_shred_unlinks_a_SYMLINK_without_touching_its_target(tmp_path):
+    """The unit-level half of the case above. `open(path, "r+b")` follows a
+    link; the link is the only thing `_shred` may destroy."""
+    target = tmp_path / "target.txt"
+    target.write_text("keep me\n", encoding="utf-8")
+    link = tmp_path / "link"
+    link.symlink_to(target)
+    EV._shred(link)
+    assert not link.is_symlink() and not link.exists()
+    assert target.read_text(encoding="utf-8") == "keep me\n"
+
+
+def test_create_private_file_REFUSES_to_follow_a_symlink_it_cannot_remove(tmp_path):
+    """A directory in the way is the case `O_EXCL` must turn into an error
+    rather than a silent reuse — `_shred` cannot unlink a directory."""
+    blocked = tmp_path / "blocked"
+    blocked.mkdir()
+    with pytest.raises(OSError):
+        EV._create_private_file(blocked)
+
+
+@pytest.mark.parametrize("plant", ["symlink", "regular-file"])
+def test_the_OPEN_flags_defend_the_path_EVEN_IF_the_unlink_layer_fails(tmp_path,
+                                                                       monkeypatch,
+                                                                       plant):
+    """🔴 MEASURE THE SECOND LAYER ON ITS OWN, or it is not defence in depth.
+
+    `_create_private_file` has two independent defences: `_shred` removes
+    whatever is at the path, and `O_EXCL|O_NOFOLLOW` refuses to create over or
+    follow anything that is still there. A mutation sweep scored
+    `O_EXCL|O_NOFOLLOW -> O_TRUNC` as SURVIVED — correctly, because the unlink
+    always got there first, so the flags were never the thing being tested.
+    A layer nobody can observe failing is a layer nobody knows is gone.
+
+    So: neuter the unlink (that is the layer failing — a race, or a future
+    regression in `_shred`) and watch the OPEN refuse. With `O_TRUNC` this test
+    goes red, which is what makes the flags load-bearing rather than decorative.
+    """
+    monkeypatch.setattr(EV, "_shred", lambda p: None)
+    outside = tmp_path / "target.txt"
+    outside.write_text("original\n", encoding="utf-8")
+    outside.chmod(0o644)
+    victim = tmp_path / "victim"
+    if plant == "symlink":
+        victim.symlink_to(outside)
+    else:
+        victim.write_text("pre-existing\n", encoding="utf-8")
+        victim.chmod(0o666)
+
+    with pytest.raises(FileExistsError):
+        EV._create_private_file(victim)
+
+    # Nothing was written through, truncated, or re-moded.
+    assert outside.read_text(encoding="utf-8") == "original\n"
+    assert stat.S_IMODE(outside.stat().st_mode) == 0o644
+    if plant == "symlink":
+        assert victim.is_symlink()
+    else:
+        assert victim.read_text(encoding="utf-8") == "pre-existing\n"
+
+
+def test_create_private_file_makes_a_fresh_0600_regular_file(tmp_path):
+    """POSITIVE CONTROL: the helper must actually produce a usable fd, or every
+    assertion above is about a function that only ever raises."""
+    p = tmp_path / "fresh.key"
+    fd = EV._create_private_file(p)
+    with os.fdopen(fd, "wb") as fh:
+        fh.write(b"synthetic")
+    assert stat.S_IMODE(p.stat().st_mode) == 0o600
+    assert p.read_bytes() == b"synthetic"
+    assert not p.is_symlink()
+
+
 def test_shred_removes_the_file_and_never_raises_on_an_absent_one(tmp_path):
     p = tmp_path / "k"
     p.write_bytes(b"synthetic-shred-fixture-0123456789")
@@ -1233,6 +1668,107 @@ def test_shred_removes_the_file_and_never_raises_on_an_absent_one(tmp_path):
     assert not p.exists()
     EV._shred(p)          # idempotent; a cleanup that raises defeats its finally
     EV._shred(tmp_path / "never-existed")
+
+
+# --------------------------------------------------------------------------- #
+# 12b. 🔴 A SIGNAL MUST NOT SKIP THE SHRED
+# --------------------------------------------------------------------------- #
+def test_the_signal_handlers_cover_the_signals_a_TIMER_actually_sends():
+    """Assert the SET, not that the installer was called.
+
+    systemd's stop and timeout paths send SIGTERM, and `SECRETS.md` proposes
+    timer-driven use — so a signal missing from this list is a path where a copy
+    of the age key survives on disk."""
+    installed = EV.install_signal_handlers()
+    try:
+        assert set(installed) == {"SIGTERM", "SIGINT", "SIGHUP"}
+        assert list(EV._FATAL_SIGNALS) == ["SIGTERM", "SIGINT", "SIGHUP"]
+    finally:
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        signal.signal(signal.SIGINT, signal.default_int_handler)
+        signal.signal(signal.SIGHUP, signal.SIG_DFL)
+
+
+def test_SIGTERM_unwinds_so_a_finally_RUNS_instead_of_being_skipped():
+    """🔴 THE MECHANISM. Python's DEFAULT SIGTERM disposition terminates without
+    unwinding, so every `finally` in the module is bypassed. Measured by an
+    audit: rc 143 with `escrowed-identity.key` surviving at full size,
+    byte-identical to the real identity.
+
+    Here the signal is REAL — delivered to this process — and the assertion is
+    that the `finally` ran and the exception is `SystemExit(143)`."""
+    ran = []
+    EV.install_signal_handlers()
+    try:
+        with pytest.raises(SystemExit) as ei:
+            try:
+                os.kill(os.getpid(), signal.SIGTERM)
+                # The handler raises on the next bytecode boundary; give it one.
+                for _ in range(1000):
+                    pass
+            finally:
+                ran.append("finally")
+        assert ran == ["finally"], "the finally block was skipped"
+        assert ei.value.code == 128 + int(signal.SIGTERM) == 143
+    finally:
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        signal.signal(signal.SIGINT, signal.default_int_handler)
+        signal.signal(signal.SIGHUP, signal.SIG_DFL)
+
+
+def test_a_REAL_SIGTERM_mid_pipeline_still_SHREDS_the_throwaway_identity(
+        escrow_world):
+    """🔴 THE END-TO-END CLAIM, with a real signal delivered at the exact moment
+    the key exists on disk.
+
+    The downloader signals this process from inside `get()` — which
+    `verify_artifact` calls AFTER the throwaway identity has been written and
+    BEFORE anything else. So the interrupt lands inside the window the shred
+    exists for, and the identity is asserted gone afterwards.
+    """
+    work = escrow_world["work"]
+    saw = {}
+
+    class SignallingDownloader(FakeDownloader):
+        def get(self, key):
+            saw["identity_existed"] = (work / EV.ESCROW_IDENTITY_FILENAME).is_file()
+            os.kill(os.getpid(), signal.SIGTERM)
+            for _ in range(1000):
+                pass
+            return super().get(key)          # pragma: no cover - handler fires first
+
+    d = SignallingDownloader(escrow_world["objects"])
+    EV.install_signal_handlers()
+    try:
+        with pytest.raises(SystemExit) as ei:
+            EV.run(bw=_cli(FakeBw(items=[_item(notes=escrow_world["note"])])),
+                   identity=escrow_world["identity"], item_name=ITEM,
+                   decrypt=True, prefix=PREFIX, store=escrow_world["store"],
+                   work_dir=work, now=NOW, downloader_factory=lambda: d)
+        assert ei.value.code == 143
+    finally:
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        signal.signal(signal.SIGINT, signal.default_int_handler)
+        signal.signal(signal.SIGHUP, signal.SIG_DFL)
+
+    # 🔴 POSITIVE CONTROL: the key really was on disk when the signal landed, so
+    # "it is gone now" is a claim about a file that existed.
+    assert saw["identity_existed"] is True
+    assert not (work / EV.ESCROW_IDENTITY_FILENAME).exists()
+    assert _work_contents(work) == []
+
+
+def test_main_installs_the_handlers_BEFORE_doing_any_work(monkeypatch, tmp_path):
+    """The wiring, separately from the mechanism: a handler that is never
+    installed protects nothing, and `main()` is the only installer."""
+    order = []
+    monkeypatch.setattr(EV, "install_signal_handlers",
+                        lambda: order.append("installed") or ["SIGTERM"])
+    monkeypatch.setattr(EV, "read_identity",
+                        lambda p: order.append("work") or b"x")
+    ident = _identity(tmp_path, ESCROW_NOTE, name="sig.key")
+    EV.main(["--identity", str(ident), "--bw", str(tmp_path / "no-such-bw")])
+    assert order[0] == "installed", order
 
 
 # --------------------------------------------------------------------------- #
@@ -1368,6 +1904,55 @@ def test_the_CLI_reports_a_MISSING_bw_with_the_nix_shell_command(tmp_path):
     assert p.returncode == 10
     assert "BW-MISSING" in p.stderr
     assert "nix-shell -p bitwarden-cli jq" in p.stderr
+
+
+def test_the_CLI_work_dir_branch_HARDENS_a_directory_it_did_not_create(tmp_path):
+    """🔴 THE ONLY BRANCH THAT RECEIVES A NON-FRESH DIRECTORY, and no test
+    reached it: every other test passes `work_dir` as a library kwarg, so an
+    audit's mutant dropping `B._private_dir(...)` from this branch SURVIVED the
+    whole suite. It is also exactly where the mode hazards above bite.
+
+    A pre-existing world-readable directory must come out 0700, and must be
+    EMPTY afterwards — but still EXIST, because it is the operator's.
+    """
+    wd = tmp_path / "operator-work-dir"
+    wd.mkdir(mode=0o777)
+    os.chmod(wd, 0o777)
+    assert stat.S_IMODE(wd.stat().st_mode) == 0o777
+
+    empty_src = tmp_path / "cli-wd-empty"
+    empty_src.mkdir()
+    p = _run_cli(tmp_path, _plan(items=[_item()]),
+                 "--decrypt-check", "--from-dir", str(empty_src),
+                 "--host", HOST, "--store", str(tmp_path / "cli-wd-no-store"),
+                 "--work-dir", str(wd))
+    # It got far enough to build the work dir, then refused for want of an
+    # artifact — the refusal is what proves the branch ran at all.
+    assert p.returncode == EV.EXIT_CODES["NO-ARTIFACT"], (p.stdout, p.stderr)
+    assert stat.S_IMODE(wd.stat().st_mode) == 0o700, oct(
+        stat.S_IMODE(wd.stat().st_mode))
+    assert wd.is_dir(), "the operator's own directory must not be deleted"
+    assert sorted(x.name for x in wd.iterdir()) == []
+
+
+def test_the_CLI_leaves_NO_key_material_in_an_operator_supplied_work_dir(tmp_path):
+    """The same branch on a run that actually writes the throwaway identity."""
+    wd = tmp_path / "wd2"
+    wd.mkdir()
+    fetched = tmp_path / "wd2-fetched"
+    fetched.mkdir()
+    # A well-formed prefix with a single unreadable (zero-byte) object: the run
+    # reaches the identity write, then fails.
+    obj = fetched / HOST / "scope-omega" / "20260309T164205Z.bundle.age"
+    obj.parent.mkdir(parents=True)
+    obj.write_bytes(b"")
+    p = _run_cli(tmp_path, _plan(items=[_item()]),
+                 "--decrypt-check", "--from-dir", str(fetched),
+                 "--host", HOST, "--store", str(tmp_path / "wd2-no-store"),
+                 "--work-dir", str(wd))
+    assert p.returncode == EV.EXIT_CODES["ARTIFACT-UNREADABLE"], (p.stdout, p.stderr)
+    assert sorted(x.name for x in wd.iterdir()) == []
+    assert "AGE-SECRET-KEY" not in (p.stdout + p.stderr)
 
 
 def test_print_plan_runs_NO_bw_and_reads_NO_key(tmp_path):


### PR DESCRIPTION
## The gap

`backup.py` and `restore-verify.py` both decrypt with **one file**. Escrowing it into
Vaultwarden on 2026-08-23 removed the single point of failure *that day* — nothing has
re-read the note since, so "the escrow is intact" has been an assumption, not a
measurement. The failure mode is silent by construction: the verifier that exists runs on
the machine that still **has** the key, so it stays green while the second copy rots.

`scripts/analyze-service-index/escrow-verify.py` answers three questions and refuses to
answer any of them by silence.

| | claim | how |
|---|---|---|
| 1 | is it **still there** | the Secure Note exists, **exactly once**, non-empty |
| 2 | is it **still correct** | its bytes equal the on-disk identity, **byte for byte** |
| 3 | does it **still work** | `--decrypt-check` writes the **escrowed** bytes to a throwaway 0600 identity and decrypts a **real** artifact out of the bucket with it |

🔴 **(2) and (3) are different claims and the verdict line never lets "verified" stand for
both.** Byte equality proves the two copies *agree*; it never asks `age` anything.
Decryption proves the *escrowed* copy opens something. A default run prints
`NOT DECRYPT-CHECKED` with the reason.

The pipeline for (3) is `restore_verify.verify_artifact` **called, not copied** — a second
implementation would be a second copy of the `finally` that bounds how long plaintext
history exists on disk, and the copy nobody exercises is the broken one. A test pins that
relationship (the module resolves to the real restore verifier, and this file contains no
second `git clone --mirror` and no second `age --decrypt`).

## Every failure mode is distinguishable

19 tokens, 19 exit codes, pinned as an **exact table both ways**. This is the deliverable,
not tidiness — "escrow check failed" sends an operator to the wrong place:

`10` bw missing · `11` bw failed · `12` **locked** · `13` **not logged in** · `14` status
unrecognised · `15` server unknown · `16` server mismatch · `17` **note GONE** · `18`
**two notes share the name** · `19` wrong item type · `20` empty note · `21` **differs by
trailing newline only** · `22` **differs materially** · `23`/`24` on-disk identity
missing/empty · `25` **escrowed key does not decrypt** · `26` artifact does not restore ·
`27` store unreachable · `28` no artifact to test against.

`21` vs `22` is not a nicety: an age identity still decrypts with its final newline
trimmed, a web vault is exactly where a trim happens, and the two have different remedies
(`printf '\n' >>` vs re-escrow). `25` vs `26` splits a **key** fault from a **data** fault
— only the first says anything about the escrow.

**Every empty outcome is LOUD**, the same stance as its two siblings. Two items with the
name is `ITEM-AMBIGUOUS`, never a pick: choosing one turns a coin flip into a verdict, and
a stale duplicate holding a rotated-out key verifies green forever. An **empty on-disk
identity** fails too — two empty files compare EQUAL, which is the shortest possible route
to a false all-clear.

## Safety

- **No key material is printed, logged or passed in argv.** A mismatch reports byte
  **counts** and a classification, never the content. No code path interpolates a captured
  stream into a message, so no future edit has to remember not to.
- The throwaway identity is created **fresh at 0600** — `O_EXCL|O_NOFOLLOW` plus an
  `fchmod` on the held fd, because `O_CREAT|O_TRUNC` applies its mode *only on create* and
  follows a symlink (see the audit round below) — inside a 0700 dir, and is overwritten +
  unlinked in a `finally` covering success, every classified failure, any unexpected
  exception, **and SIGTERM/SIGINT/SIGHUP**. (The overwrite is best-effort on a
  CoW/journalling FS and the docstring says so; the *unlink* is what the tests assert.
  The work directory is emptied, not deleted, under an explicit `--work-dir`.)
- **The master password cannot be automated and this never tries.** `bw status` is the
  authority. Every call carries `--nointeraction` (a request), **stdin on `/dev/null`** (a
  mechanism, the half that does not depend on `bw`'s manners) and a **timeout** (a
  ceiling). An unattended run fails fast instead of hanging on an invisible prompt.
- **The endpoint is never hardcoded** — devrc is public. It is read from `bw config server`
  at run time and cross-checked against the authenticated session's own `serverUrl` (this
  vault has really been repointed once; a stale session means every answer comes from a
  server the operator no longer thinks they are using). With no `--expect-server` pin the
  verdict says `NOT PINNED` rather than implying it checked.
- `bw` is not installed on either host, on purpose. Its absence is a first-class failure
  naming the exact `nix-shell -p bitwarden-cli jq` command — and it is reachable in the
  suite on a host where `bw` *is* installed, because the **PATH locator** is injected
  alongside the runner.

## Tests

120 tests. All fixtures synthetic; nothing skips; **no real `bw` is ever spawned**. The
`--decrypt-check` half uses real `git`, real `age` and real bundles — only the object store
is faked.

**Mutation sweep: 76 applied, 75 killed, 1 survivor** — and the survivor is a deliberately
inert `del` of an already-unused local, kept as the battery's own control that it *can*
report SURVIVED (a battery that kills everything may simply be always-red).

🔴 **One survivor was real and is fixed in this PR.** `test_a_nonzero_bw_exit_is_BW_FAILED`
fed *unparseable* output alongside the non-zero exit, so the JSON guard spoke first —
deleting the exit-status check entirely left that test **green**. The rc guard was
unreachable through it. `test_a_nonzero_bw_exit_FAILS_even_when_the_OUTPUT_is_perfectly_valid`
is the case no earlier check can answer, parametrized over all three commands.

The fixtures are shaped against the same class of blind spot:

- the two key-shaped blobs are **different lengths with no shared line**, so a
  length-only comparison cannot pass the one-byte-difference control (which is *same
  length*, one byte changed mid-string);
- the artifact world holds **three** artifacts across two scopes with stamps arranged so
  `[-1]` and `[0]` select **different scopes**. A one-artifact-per-scope world would make
  the off-by-one mutants *equivalent*, and all three would have survived a fully green
  suite.

Assertions are on **token + exit code + counts**, not bare substrings. Where prose matters
the assertion is discriminating rather than a presence check: the locked message must name
`bw unlock --raw` **and must not name `bw login`**, because naming the other failure's
remedy is exactly the conflation under test.

## Live

🔴 **The vault is LOCKED and was not unlocked** — so the honest live result is the locked
path, reported verbatim:

```
$ nix-shell -p bitwarden-cli jq --run 'python3 scripts/analyze-service-index/escrow-verify.py'
rc=12
analyze-service-index-escrow-verify: VAULT-LOCKED: the vault is LOCKED. The master password
CANNOT be automated and this script will not prompt for it — it runs every `bw` call with
stdin on /dev/null so an unattended run fails fast instead of hanging on an invisible
prompt. Unlock it yourself, then re-run with the session exported:
    export BW_SESSION="$(bw unlock --raw)"
and if `bw` is not on PATH, do both inside one shell: nix-shell -p bitwarden-cli jq --run '<command>'
```

No hang, no prompt, no key material, no endpoint, distinct exit code.

**UNVERIFIED live, stated plainly:** the *unlocked* path — the real note fetch, the real
byte comparison and `--decrypt-check` against MinIO — has only been exercised
synthetically. Someone with the master password should run
`escrow-verify.py --decrypt-check --host <label>` once.

## Gate — on the MERGED tree, not this branch

```
scripts/gate.sh --tier pytest --set hermetic   ->  GATE: RESULT=PASS exit=0
scripts/gate.sh --tier node   --set hermetic   ->  GATE: RESULT=PASS exit=0
```

Run in a **standalone clone with `origin` removed** (`git rev-parse --git-common-dir`
resolves to its own `.git`), on an integration branch `merge(origin/main 791635db,
afd6f674)`. 59 targets PASS, 0 FAIL; `scripts/tests` collected **7634**, floor 6459,
drift ceiling 8073 — the gate asks for no re-pin, so `TARGET_FLOORS` is deliberately
untouched.

**The first gate run of this branch was RED, and that is the point of gating the merged
tree:** `test_runtime_shebangs.py` caught the `bw` stub's `#!/usr/bin/env python3`, which
execs on the dev host and ENOENTs in the nix sandbox. Running the new file in isolation
could not see it. Fixed in `afd6f674`, along with the `--from-dir` source label; the run
above is post-fix.

**Landed on `main` after the gated SHA** (`791635db..`): `#761` `#762` `#763` — touching
`scripts/opencode/opencode.jsonc`, `scripts/tests/test_opencode_config.py` (+12/-1, zero
new test functions), `nix/system/apply-nvidia-kernel-7.2.sh` and one handoff doc. None
touch `scripts/analyze-service-index/**`, `run-tests.sh`, `gate.sh` or `flake.nix`, and
the collected count cannot approach the ceiling, so this was not re-gated.


---

# Audit round — both 🔴 fixed, plus all five 🟡 and the 🟢

A blind adversarial audit verdict of *merge after fixing the 🔴*. Every item
addressed in one round; each is now pinned by a test **and** by an explicit mutant.

### 🔴 A — the 25/26 split was wrong in three measured cases — **FIXED**
The classifier chose by asking whether `"DECRYPT FAILED"` appeared in another module's
message, and its `else` branch asserted unconditionally that the bytes "DECRYPTED" and
that "the escrowed key works". Measured wrong three ways: **`age` off PATH → 26** (three
false claims in one sentence, routing the operator to a tool that fails identically);
**a zero-byte object → 26** claiming it decrypted on a path where `decrypt()` was never
called; **a valid encryption of nothing → 25**, *"not a working identity"* — for a key
that had just worked, a verdict that **gets a good DR key rotated**.

Now five tokens chosen from an **observed phase**, not a substring. `_decrypt_phase_probe`
wraps restore-verify's `decrypt` (calling it, adding nothing) and records whether it was
reached, whether it returned, and — at the instant it raises, before `verify_artifact`'s
`finally` unlinks the plaintext — whether `age` left an output file. That last observable
is **measured, age v1.3.1**:

| case | rc | plaintext file |
|---|---|---|
| wrong key / corrupt ciphertext | 1 | **absent** |
| right key, empty payload | 0 | present, size 0 |
| right key, real payload | 0 | present, size 12 |

so presence separates *age refused* (`DECRYPT-FAILED`, key wrong) from *age succeeded on
nothing* (`ARTIFACT-EMPTY`, **key is fine — do not rotate**). `AGE-MISSING` is a
precondition checked before the store opens; it is *also* what makes the probe's inference
sound, since restore-verify's own age check raises before touching the file. The comment
says so — the old one claimed the classifier was "shown to discriminate" on the strength
of two points that could not see a third outcome, and that sentence is gone.

### 🔴 B — the session cross-check silently no-opped while the verdict said it ran — **FIXED**
`if session_server and …` skipped the comparison with **no signal** whenever `bw status`
omits `serverUrl` or returns `null` (what it prints for the official cloud), while the
success line printed *"the CLI's configured server matched the session's, which is all
that was checked"*. A check that did not run, reported as one that passed, exit 0 — and
the docstring above it said *"always runs"*.

Now a third return value carries the reason and the verdict prints `session cross-check
NOT COMPARED (<reason>)`, the shape `restore-verify.py` already uses. Not a hard failure
(a vault legitimately without a `serverUrl` must not be a permanently-red gate), and an
explicit `--expect-server` pin is **still enforced** on that path — pinned, so the fix
cannot become a second escape hatch.

🔴 The test that should have caught this was `"NOT PINNED" in v2.line()` — a bare substring
on a sentence that was *already false*. The auditor's mutant rewrote the whole sentence into
a flat lie and survived all 87 tests. **All five verdict-line combinations are now pinned as
whole normalised strings.** A cosmetic reword fails the suite; that is the price of a
machine-readable claim on the one sentence an operator reads to decide the escrow is fine.

### 🟡 C — the 0600/0700 claim was create-path-only — **FIXED**
Measured via `--work-dir`: a pre-existing **0666 file received the key and stayed 0666**; a
planted **symlink** got the key written *through* it to a 0644 file **outside** the 0700
dir, and `_shred` then zeroed that target while unlinking only the link — a
truncate-in-place primitive leaving a zero-filled decoy. `_shred` now unlinks a symlink
instead of following it; `_create_private_file` unlinks, then opens `O_EXCL|O_NOFOLLOW`,
then `fchmod`s the fd it holds.

⚠ A sweep scored `O_EXCL|O_NOFOLLOW → O_TRUNC` **SURVIVED** — correctly: the unlink always
got there first, so the flags were never under test. *A layer nobody can observe failing is
a layer nobody knows is gone*, so there is now a test that **neuters `_shred`** and watches
the open refuse. Both layers are measured alone.

### 🟡 D — no SIGTERM handling — **FIXED**
Python's default disposition terminates without unwinding, so every `finally` was bypassed
(measured: rc 143, identity surviving at full size, byte-identical to the real key).
`SECRETS.md` proposes timer-driven use and systemd's stop path *is* SIGTERM — the documented
deployment was the leaking one. SIGTERM/SIGINT/SIGHUP now raise `SystemExit(128+n)`. Tested
with a **real signal delivered mid-pipeline** from inside the downloader, at the moment the
key is on disk, plus a positive control that it *was* on disk when the signal landed.

### 🟡 E — the `--work-dir` CLI branch was untested — **FIXED**
The only branch receiving a non-fresh directory, i.e. exactly where C bites. Two CLI tests:
a pre-existing 0777 dir comes out **0700**, **empty**, and **still existing** (it is the
operator's).

### 🟡 F — absent vs empty `notes` — **FIXED**
`NOTE-MISSING` (32) is its own token. `NOTE-EMPTY` says *re-escrow*, which on a `bw` schema
surprise would overwrite an intact note.

### 🟡 G — `rstrip(b"\n")` narrowness untested — **FIXED**
Trailing spaces/tabs/CR are now measured as **material**, and a pure trailing newline still
gets its own class — both directions, so the rule cannot be widened *or* narrowed away.

### 🟢 H — **FIXED.** "its directory is removed after it" was false under `--work-dir`; the
docstring now says emptied, not deleted.

**Accepted as-is (per the audit):** the `ctx.__exit__(None, None, None)` nit, and the
Secure Note name in `SECRETS.md` — a label, not a secret, and operationally necessary.

## Re-verification after the fixes

```
scripts/gate.sh --tier both --set hermetic  ->  GATE: RESULT=PASS exit=0
                                                PASS pytest | PASS node
```
Standalone clone, `origin` removed, integration branch `merge(origin/main f2ed88c7,
8ba7d8c9)`. **59 targets PASS, 0 FAIL**; `scripts/tests` collected **7667**, floor 6459,
ceiling 8073 — no re-pin requested, so `TARGET_FLOORS` stays untouched. **`origin/main` has
not moved since the gated SHA**, so this gate is against the current tip.

**Mutation sweep v2: 76 applied, 75 killed, 1 survivor** — still only the deliberately inert
`del`, kept as the battery's own control that it *can* report SURVIVED. All three of the
auditor's independent survivors (B, E, G) now have explicit mutants and all three are killed.

**Live, re-run after the fixes:** unchanged — `rc=12 VAULT-LOCKED`, naming `bw unlock --raw`,
no hang, no prompt, no key material, no endpoint. The vault was **not** unlocked.


---

## Delta round — `phase` possibly-unbound, and a dead constant

**`phase` could be read unbound in the fix-A classifier.** It was bound by
`with _decrypt_phase_probe(RV) as phase:` *inside* the `try`, while the
`except RV.RestoreVerifyError` handler that reads it sat *outside* the `with`. The only
unbound path needed `__enter__` to raise `RestoreVerifyError`, which its setup cannot do —
unreachable in practice, not a bug today. Fixed anyway for the failure mode, not the lint:
had it ever fired the result is an `UnboundLocalError` **masking the real exception**, in
the one classifier whose entire purpose is to stop confidently-wrong verdicts.

Taken **structurally**: the handler now lives *inside* the `with`, so `phase` is bound
before the `try` is entered and cannot be read unbound at all. That beats pre-binding a
default — no unreachable branch to label, and no duplicated literal to drift from the
probe's own initialiser. If `__enter__` ever does raise, the exception propagates
unclassified to `main()`, which is correct: a phase that was never observed must not be
classified.

🔴 **No test and no mutant added for the old path.** It is *gone*, not dead — there is
nothing left to exercise, and a test that appeared to cover it would read as coverage while
providing none. A mutant reverting the structure would SURVIVE by construction, which is
precisely the dead mutant this suite keeps exactly one honest example of (M47).

**Dropped the `_DIR_MODE` alias** — one definition, zero uses (`B._private_dir()` owns
directory mode, `_create_private_file()` owns file mode). Verified unreferenced by the
suite too; the 0700 assertion pins the literal.

### Re-verification (a fix round resets the gate, even a one-line one)
```
scripts/gate.sh --tier both --set hermetic  ->  GATE: RESULT=PASS exit=0
                                                PASS pytest | PASS node
```
Standalone clone, `origin` removed, integration branch `merge(origin/main 1e46c723,
c1e5f3bb)`. **59 targets PASS, 0 FAIL**; `scripts/tests` collected **7667**, floor 6459 —
no re-pin requested. Suite 120 tests, unchanged. **Mutation sweep: 76 applied, 75 killed,
1 survivor** — still only M47.

**Landed after the gated SHA:** `982778ee` (#774), touching only
`claude/skills/tekton/SKILL.md`. No interaction path (`scripts/analyze-service-index/**`,
`scripts/tests/**`, `run-tests.sh` floors, `gate.sh`, `flake.nix`) is touched, so not
re-gated.

**Live, re-run:** unchanged — `rc=12 VAULT-LOCKED`. Vault not unlocked.


---

# Round 3 — a TAMPERED backup was reported as "THE ESCROW IS FINE"

🔴 **The headline claim rested on a premise measured once, and it was false.** The comment
asserted, as measured, `corrupt ciphertext → rc=1, PLAIN absent`. That holds only for a
corrupt **header**. Re-measured through the exact call `restore_verify.decrypt` makes
(age v1.3.1):

| case | samples | rc | plaintext file |
|---|---|---|---|
| wrong key | 5 payload sizes (0 B → 2 MB) | 1 | **ABSENT** |
| header corrupt | 2 sizes | 1 | **ABSENT** |
| payload corrupt | 8 offsets × 4 sizes | 1 | **PRESENT** (0 or partial) |
| truncated | 3 sizes | 1 | **PRESENT** |
| valid encryption of nothing | — | 0 | PRESENT, size 0 |
| intact | — | 0 | PRESENT, size N |

**Consequence:** a tampered or truncated artifact reported `ARTIFACT-EMPTY` — *"THE ESCROW
IS FINE … a valid encryption of an empty payload"* — while quoting age's own *"may be
corrupted or tampered with"* in the same sentence. Detecting tampering is the single most
important thing a backup verifier does. Introduced by round 2; at `afd6f674` the same input
was `DECRYPT-FAILED`.

**The structural error was small and specific.** Inside `if not phase["returned"]:` the
comment read *"age exited 0 and produced an EMPTY plaintext"* — contradicting its own
enclosing condition, since `returned == False` means `decrypt()` **raised**.
`plain_present` does not witness "age reported success"; `returned` does.

⚠ **A no-op mutation nearly produced a second false table.** Writing `0xff` over a byte that
was *already* `0xff` left one sample reading `rc=0`, which would have meant age fails to
detect tampering at all. Re-run with a guaranteed bit flip (XOR `0xFF`): all 8 offsets give
`rc=1`. The test helper XORs and asserts the byte actually changed.

### The fix: six outcomes, split by a published VALUE
`restore-verify.py` now publishes `DECRYPT_AGE_MISSING` / `DECRYPT_AGE_REFUSED` /
`DECRYPT_EMPTY_PLAINTEXT` on `RestoreVerifyError.cause` (closed set, `KeyError` on an
unpublished one, `None` never a default). No stderr is parsed.

| observation | token | means |
|---|---|---|
| `reached=False` | `ARTIFACT-UNREADABLE` 30 | failed before the key was used |
| `cause=age-missing` | `AGE-MISSING` 29 | environment fault |
| `cause=empty-plaintext` | `ARTIFACT-EMPTY` 31 | age exited **0** — key WORKED |
| `cause=age-refused`, plaintext **present** | `ARTIFACT-CORRUPT` **33** | header authenticated → key WORKED; 🔴 **TAMPERED** |
| `cause=age-refused`, plaintext **absent** | `DECRYPT-FAILED` 25 | wrong key **or** damaged header |
| `returned=True`, later failure | `RESTORE-FAILED` 26 | bundle fault; key WORKS |

🔴 **`DECRYPT-FAILED` now asserts neither cause.** A wrong key and a damaged header are
genuinely indistinguishable from outside, so the verdict says so and hands over the check
that *does* separate them — re-run `restore-verify.py` with the **on-disk** identity. It no
longer says "not (or no longer) a working identity", which would send someone to rotate a
good key over a damaged artifact.

### 🔴 The test hazard, which is the real lesson
The test asserted `"THE ESCROW IS FINE" in msg` and `"Do NOT re-escrow or rotate" in msg` —
**bare substrings that pass unchanged on the tampered run**, certifying a false sentence.
The verdict *lines* were pinned whole; the refusal *messages* were not. `EscrowError` now
carries `verdict` (this module's own sentence) separately from `detail` (another module's
message, an age rc, a stderr fragment that varies), so all five decrypt-family verdicts are
pinned by **exact equality**, with a case per row of the measured matrix.

### Also fixed
- `NOTE-MISSING` now covers `{"notes": null}`, not just an absent key — the shape JSON
  actually produces, and the one already handled for `serverUrl`. A null fell through to
  `NOTE-EMPTY`, i.e. back to the "re-escrow over a good copy" advice it was created to stop.
- `_shred`: `return` inside the symlink `except OSError`, which fell through to
  `open(path, "r+b")` — following the link and zeroing the target.
- Dropped the dead `real if real is None else probe` ternary and the dead `except OSError`
  around `Path.exists()`.
- The `--expect-server` pin was open-coded at two sites with **different wording**; hoisted
  into `_refuse_unless_pin_matches`, above both branches.

### Two more gaps the sweep found while fixing the above — same shape as the `O_NOFOLLOW` one
- Deleting `os.fchmod(fd, _FILE_MODE)` **survived all 120 tests** (no ordinary umask clears
  bits from 0600). Now tested under `umask 0o377`, where without it the file is created
  `0o000`.
- `_shred`'s symlink fall-through **survived**, because the existing test used a link whose
  unlink succeeds. Now tested with a read-only parent directory, plus a positive control
  proving the unlink really is impossible there.
- Dropping the `[upstream: …]` half of `__str__` **survived** — `str(exc)` is what the CLI
  prints and only `.verdict` was pinned. Now pinned whole.

### Re-verification
```
scripts/gate.sh --tier both --set hermetic  ->  GATE: RESULT=PASS exit=0
                                                PASS pytest | PASS node
```
Standalone clone, `origin` removed, integration branch `merge(origin/main c5d75c2c,
e023517b)`. **59 targets PASS, 0 FAIL**; `scripts/tests` collected **7678**.
🔴 Gated against **current `main`, not a judgement call**: `#777` touched `run-tests.sh` and
`#780` touched `test_analyze_service_index_restore_verify.py` — the suite for the module
this round changes. Only two handoff docs have landed since.

**Suite: 120 → 130.** **Mutation sweep: 86 applied, 85 killed, 1 survivor** (M47, the
deliberate inert control). The battery now mutates **both** modules, since the cause
constants live in `restore-verify.py`.

**Live, re-run:** unchanged — `rc=12 VAULT-LOCKED`. Vault not unlocked.


---

# Round 4 (final) — the handover was a second sample, and a stale plaintext recreated the defect one file over

### 🟡 F1 — the `DECRYPT-FAILED` handover was not a control — **FIXED**
It said *"run `restore-verify.py` with the ON-DISK identity: if that fails too the artifact
is the problem."* But `run()` raises `BYTES-DIFFER-*` before `decrypt_check` is reached, so
**decrypt_check only runs when the escrowed bytes are byte-identical to the on-disk
identity** — the suggested re-run is the same experiment with the same input, guaranteed to
fail identically, and the conclusion is unsound (both copies can be a stale key while the
artifact is fine). Replaced with a check that varies the **artifact** (another scope, or an
older stamp): if another artifact opens with the same escrowed copy, the key is fine and
*this* object's header is damaged. The two owned sentences the audit called safe are
unchanged.

**Same family, same commit:** `BYTES-DIFFER-TRAILING-NEWLINE` offered *"or confirm with
`--decrypt-check`"*, but that refusal is raised before the `if not decrypt` return, so the
flag produces the identical message. It now says so. A new test runs the same input **with
and without** the flag and asserts the outcome is identical.

### 🟡 F2 — the in-classifier `AGE-MISSING` belt had zero coverage — **FIXED**
`if False:` survived. With the branch gone, control fell to `plain_present == False` and
reported `DECRYPT-FAILED` — *"age REFUSED {key}"* — the exact
environment-fault-blamed-on-the-escrow misclassification the token prevents. Tested by
injecting what the branch is *for*: `which` still answers, the decrypt step raises with the
published age-missing cause. Verdict pinned whole.

### 🟡 F3 — a stale plaintext recreated the headline defect, **in the shipped file** — **FIXED**
Measured myself before fixing: on **both** the wrong-key and damaged-header paths age leaves
a pre-existing `--output` file **completely untouched** (rc=1, present, original 34 bytes
intact) — it creates the file only after authenticating the header. `work_dir` is routinely
reused, so a leftover from a run aborted mid-decrypt makes a **wrong key** read as
`ARTIFACT-CORRUPT` — *"THE ESCROW IS FINE; THE BACKUP IS NOT … do NOT rotate the key."*
One `plain.unlink(missing_ok=True)` before the age call removes the class.

🔴 I had already applied this exact reasoning to the **identity** file and not to `plain` —
one rule, two sites, wrong at one.

### 🟢 F4 — `DECRYPT_AGE_REFUSED` published but never read — **FIXED, with a caveat stated**
The cause is now part of the `ARTIFACT-CORRUPT` condition. ⚠ **Plainly:** deleting that test
*here* is an **equivalent mutant** and the sweep reports it as a labelled survivor — the
branches above consume the other two causes, so only `age-refused` can reach the line. What
proves the constant load-bearing is the **raise-side** mutant (drop `cause=` from
`restore-verify.py`), and that one is **killed**. The comment says exactly this.

### Text corrections — each one a claim this file's own thesis forbids
- the `_ABSENT` sentinel was dead, and its comment claimed absent and null *"can be told
  apart where that matters"* while its only consumer merged them. Deleted; the merge is now
  stated as deliberate, with the reason.
- the comment justifying the deleted `except OSError` around `Path.exists()` was **false on
  this repo's Python**. Measured on the pinned CPython **3.12.14**: a parent without `+x`
  makes `exists()` raise `PermissionError`. Unhandled it would **replace the real exception**
  mid-`except` — the masking class removed for `phase` last round. Handler restored,
  unreadable reported as `None` (unobservable) never `False`, and **tested**.
- `SECRETS.md` said "the six outcomes"; there are **eight**. `STORE-UNREACHABLE` and
  `NO-ARTIFACT` added — the two most likely to fire in practice.
- the fchmod test's arithmetic was wrong (`0o600 & ~0o377 == 0o400`, owner-**read**). Test
  sound; sentence corrected.
- *"ALL FIVE OWNED SENTENCES"* pinned **four**. Docstring made true, and both `AGE-MISSING`
  verdicts are now pinned whole.

### Re-verification
```
scripts/gate.sh --tier both --set hermetic  ->  GATE: RESULT=PASS exit=0
                                                PASS pytest | PASS node
```
Standalone clone, `origin` removed (`git-common-dir` verified as its own `.git`),
integration branch `merge(origin/main e3f7be3e, 5cc20b3a)`. **59 targets PASS, 0 FAIL**;
`scripts/tests` collected **7703**. `origin/main` has **not moved** since the gated SHA.

**Suite: 130 → 136.** **Mutation sweep: 92 applied, 90 killed, 2 survivors — both labelled
equivalent mutants.** All four findings have explicit mutants; F1, F1b, F2, F3, F4b and F5
are killed. Every `__pycache__` was cleared before the first mutant (the run followed an
interruption, which is exactly when a stale `.pyc` scores a mutant SURVIVED unexecuted).

⚠ **This round introduced one regression and the suite caught it:** rewording the F1
handover broke the two whole-string verdict pins — precisely what those pins are for. Fixed
in the same change; no reword slipped through unpinned.

**Live, re-run:** unchanged — `rc=12 VAULT-LOCKED`. Vault not unlocked.


---

# Round 5 (final) — the version guard, and two corrections

### The guard's own boundary was wrong, and measuring is what caught it
`test_the_probe_reports_an_UNREADABLE_plaintext_path_as_UNKNOWN` was silently
interpreter-dependent. The brief — **and my own source comment** — said the behaviour
changes at ≥3.13. Measured on three interpreters, twice each (behaviour, and whether
`Path.exists`'s source still calls `pathlib._ignore_error`):

| interpreter | `exists()` on a no-`+x` parent | `_ignore_error` in source |
|---|---|---|
| 3.12.14 (the flake's pin) | **raises `PermissionError`** | yes |
| **3.13.15** | **raises `PermissionError`** | **yes** |
| 3.14.7 | returns `False` | no |

**The change is in 3.14, not 3.13.** A guard written to `sys.version_info >= (3, 13)` —
the obvious fix — would have gone **red on 3.13**, the guard reintroducing the exact
failure it was added to prevent.

So the expectation is not keyed on a version literal at all: an **independent regime probe**
measures this interpreter on its own directory, outside the module under test, and the
assertion follows from it (`raises` → handler live, `None`; `returns` → handler dead here,
`False`). Asserted in **both** regimes rather than skipped in one — a skip that fires on
every future interpreter is a test that quietly stops covering the handler.

**Both branches actually executed:** the full escrow suite is green on the pinned **3.12.14
(134 passed)** *and* on **3.14.7 (134 passed)**. Passing on 3.14 is itself proof the
else-branch ran, since the `if` branch asserts `is None` there.

### 🔴 The gate went RED, and the control proved it was not this PR
The first final-gate run failed: `scripts/tests` 7702/7703, on
`test_subsystem_touch.py::test_the_LENGTH_bound_is_not_vacuous_git_WOULD_have_expanded_it`
— a file this PR does not touch and does not import.

Rather than assert "flake", I ran the discriminating control:

- **600 runs of that test on pristine `origin/main` (7bbb9579), this branch absent → 2
  failures.** It fails on main without me.
- Mechanism measured directly: `git rev-parse --disambiguate=XYZ` lists **every object**
  with that prefix — trees and blobs too, not just commits. The fixture repo holds ~8
  objects against a 4096-value 3-hex-char prefix → **P ≈ 0.17%/run**, and the observed
  0.33% is the same order. The failing output's two shas both start `d0f`: a chance
  prefix collision between the target commit and an unrelated object, whose hashes vary
  per run because they depend on commit timestamps.

**Pre-existing flake on `main`, ~1 run in 300–600.** Not fixed here (out of scope for this
round, and not this PR's file) — flagged for whoever owns it; the durable fix is to use a
longer prefix or assert the target sha is *among* the expansion rather than the sole member.

**Re-gate on the same merged tree, same SHAs:** `PASS pytest exit=0`, **59 targets PASS / 0
FAIL**, `scripts/tests` collected **7703, passed 7703**. Node tier was `PASS` on the first
run and is unaffected.

### ⚠ Correction to the round-4 commit message
It says the suite went "130 → 136". The **actual collected count is 134** (`--collect-only`,
pinned interpreter). The commit message overstates by 2. Left in history rather than
force-pushing a reviewed sha, and corrected here — a wrong number in a PR about false claims
should not stand unremarked.

### Not re-run, and why
The mutation battery was **not** re-run this round: the change is test-only plus comments —
no guard, condition or message moved — so every mutant's kill relationship is untouched.
Saying so explicitly rather than implying a sweep I did not do.
