### PR TITLE
claude-hooks: register base-clone-staleness.sh — it shipped to both hosts and fired on one

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1260,16 +1260,22 @@ in
   # absent from the upstream branch's recent history, and reports what it
   # touched. `BASE_CLONE_NO_REFRESH=1` makes it report-only.
   #
-  # Registration in ~/.claude/settings.json stays PER-HOST and unmanaged, exactly
-  # like bash-guard.py above: register-nudge-hook.py deliberately does NOT own
-  # it. That is structural, not an omission — the registrar's managed-command
-  # surface recognises `<python> <path>.py` commands only, and its whole rewrite
-  # half exists to normalise a python INTERPRETER token to an absolute /nix/store
-  # path. This hook is bash, so there is no interpreter hazard to fix and nothing
-  # for the registrar to match; teaching that shared component a second
-  # interpreter would widen a load-bearing surface for no benefit. Consequence,
-  # the same known gap bash-guard.py has: on any host where the entry has not
-  # been added by hand, the switch delivers the script and the hook is INERT.
+  # 🔴 REGISTERED BY register-nudge-hook.py since 2026-08-23 — this comment used to
+  # say the opposite, and the opposite was a shipped gap. It reasoned that the
+  # registrar recognises `<python> <path>.py` only, that a bash hook has no
+  # interpreter hazard to fix, and concluded that teaching it a second interpreter
+  # "would widen a load-bearing surface for no benefit". The first two clauses are
+  # still true; the conclusion did not follow. The benefit is not interpreter
+  # pinning — it is REGISTRATION, and the stated consequence was the #452 shape
+  # verbatim: on the second host the switch delivers the script, reports success,
+  # and the hook sits INERT with nothing on screen to say so. Measured: it fired on
+  # exactly one host, the one where the entry had been hand-added.
+  #
+  # What the registrar gained is an IDENTITY recogniser (`hook_script_of`) sitting
+  # beside the interpreter one, not a widened rewrite surface. The rewrite pass
+  # still keys on the python-only `managed_match`, because normalising this
+  # command's first token to a python path would make every session start a
+  # SyntaxError. See MANAGED_SHELL_HOOK_SCRIPTS in that script.
   #
   # 🔴 A NEW file, so it must be `git add`ed or the flake silently omits it and
   # the switch still succeeds with the hook absent — this repo's standing trap
@@ -1281,8 +1287,10 @@ in
   # never been hand-placed. MEASURED 2026-08-22 before the first switch that
   # deploys it — `ls -la ~/.claude/hooks/` shows 14 entries on this host, ALL
   # /nix/store symlinks, no regular files, and no base-clone-staleness.sh among
-  # them. The live copy being replaced lives in ~/.claude/local-hooks/, a
-  # different directory this attribute does not write to. If a foreign file ever
+  # them. The live copy being replaced lived in ~/.claude/local-hooks/, a
+  # different directory this attribute never wrote to; it was kept as the rollback
+  # path until the hook was observed to fire from here, and deleted 2026-08-23
+  # once it had been. If a foreign file ever
   # does appear at this path the switch fails LOUDLY ("would be clobbered")
   # rather than silently leaving it unmanaged — add it to dropStaleClaudeHooks
   # then.

--- a/scripts/claude-hooks/register-nudge-hook.py
+++ b/scripts/claude-hooks/register-nudge-hook.py
@@ -92,6 +92,12 @@ Registers (APPEND surface):
     notifier — a best-effort side-effect hook, appended alongside any existing
     Stop/clawgate-stop/tmux hooks).
   * Stop: next-step-nudge.py
+  * SessionStart: base-clone-staleness.sh — THE ONLY NON-PYTHON HOOK REGISTERED
+    HERE, and the reason there are two recognisers below. It refreshes CLAUDE.md
+    and .claude/skills/** in the repo at cwd from that repo's upstream branch,
+    because those two surfaces load into agent context FROM THE WORKING TREE, so
+    a base clone that has fallen behind serves stale, authoritative-looking
+    instructions with nothing on screen to indicate it.
   * SessionStart / UserPromptSubmit / PostToolUse / Stop: agent-ledger-hook.py
   * PostToolUse / Stop: clawgate-writeback-guard.py (the hook that makes the clawgate
     task write-back non-optional — PostToolUse watches for a read of a specific task
@@ -217,6 +223,41 @@ MANAGED_HOOK_SCRIPTS = frozenset({
     "shell-env-nudge.py",
 })
 
+# --------------------------------------------------------------------------- #
+# THE SHELL-HOOK LEDGER — a SEPARATE set, and the separation is the whole design.
+#
+# 🔴 MANAGED_HOOK_SCRIPTS above is the REWRITE surface's ledger: "scripts whose
+# INTERPRETER TOKEN this script may replace with an absolute /nix/store python".
+# A bash hook has no business there. Adding `base-clone-staleness.sh` to that set
+# would hand it to `normalized_command`, which rewrites the first token
+# unconditionally — turning the hook's leading `bash` into an absolute python,
+# i.e. a SyntaxError on every session start. The recogniser's third condition
+# (basename starts with `python`) is what stands between those two facts, so it
+# is never relaxed.
+#
+# 🔴 The path is deliberately NOT spelled with its hooks-dir prefix anywhere in
+# this comment. test_registrar_activation.py parses this file for that exact
+# pattern and reads every hit as a REGISTRATION — the warning above the command
+# tables says so — and a prefixed path in prose is therefore a phantom
+# registration that keeps the delivery-seam test green after the real table
+# entry is gone. Measured: with this comment written the long way, deleting the
+# SessionStart registration outright left that suite fully green.
+#
+# This set feeds only the IDENTITY question — "which hook script does this command
+# invoke", used by the append and de-dup surfaces. Identity is about WHICH SCRIPT;
+# the rewrite is about WHICH INTERPRETER. They were one function while every hook
+# was python; a non-python hook is what forces them apart.
+#
+# 🔴 It must be non-empty for the append pass to be safe: a command this script
+# WRITES but cannot READ BACK is re-appended on every run — measured on the
+# python side at 14 -> 27 -> 40 commands over three runs, +13 every time, silent
+# and unbounded. `with_bash` re-proves that round-trip for the strings actually
+# written, exactly as `with_python` does.
+# --------------------------------------------------------------------------- #
+MANAGED_SHELL_HOOK_SCRIPTS = frozenset({
+    "base-clone-staleness.sh",
+})
+
 HOOK_LIBRARY_MODULES = frozenset({"agent_ledger.py", "bg_command_capture.py",
                                   "guard_core.py"})
 
@@ -271,8 +312,68 @@ def managed_match(cmd):
 
 
 def managed_script_of(cmd):
-    """The devrc-managed hook script this command invokes, or None."""
+    """The devrc-managed hook script this command invokes, or None.
+
+    🔴 PYTHON ONLY, and every caller that keys on it is making a claim about the
+    INTERPRETER, not about identity. For "which hook script is this", use
+    `hook_script_of` — see MANAGED_SHELL_HOOK_SCRIPTS for why the two are
+    separate functions.
+    """
     m = managed_match(cmd)
+    return None if m is None else m.group("base")
+
+
+# <bash> <hooks-dir><basename.sh>[ <args>] — the shell mirror of _MANAGED_CMD_RE,
+# anchored identically so a leading env assignment or any other prefix does not
+# match. The interpreter condition is `bash` rather than `python*`; it is checked
+# in `shell_match` for the same reason its sibling checks it, so that a
+# hypothetical `python3 <hooks-dir>x.sh` is not mistaken for one of ours.
+_SHELL_CMD_RE = re.compile(
+    r"^(?P<interp>\S+)[ \t]+(?:%s)(?P<base>[A-Za-z0-9_.+-]+\.sh)(?=$|[ \t])"
+    % "|".join(re.escape(p) for p in HOOK_DIR_PREFIXES)
+)
+
+
+def shell_match(cmd):
+    """The regex match for a devrc-managed SHELL hook invocation, or None.
+
+    Same three conservative conditions as `managed_match`, with `bash` in place of
+    `python*`. Deliberately does NOT accept `sh`, `zsh` or a bare `./path`: the
+    hook is a bash script (it uses arrays and `[[`), home.nix's activation and the
+    tables below both spell it `bash`, and widening the accepted spellings here
+    would let this script claim ownership of an entry somebody else wrote
+    differently on purpose.
+    """
+    if not isinstance(cmd, str):
+        return None
+    m = _SHELL_CMD_RE.match(cmd)
+    if not m:
+        return None
+    if m.group("base") not in MANAGED_SHELL_HOOK_SCRIPTS:
+        return None
+    if os.path.basename(m.group("interp")) != "bash":
+        return None
+    return m
+
+
+def hook_script_of(cmd):
+    """THE IDENTITY RECOGNISER — which managed hook script this command invokes.
+
+    🔴 The union of the python and shell recognisers, and the single answer to
+    "is this hook already registered on this event". Every append-surface
+    membership test and the whole de-dup identity key go through here, so the two
+    surfaces cannot disagree about what "already registered" means — the same
+    property `registered_scripts` documents for the cross-spelling case, now
+    holding across interpreters too.
+
+    NOT used by the rewrite pass. `normalized_command` keys on `managed_match`
+    alone, because rewriting the interpreter of a bash hook to a python one is
+    precisely the damage MANAGED_SHELL_HOOK_SCRIPTS exists to prevent.
+    """
+    base = managed_script_of(cmd)
+    if base is not None:
+        return base
+    m = shell_match(cmd)
     return None if m is None else m.group("base")
 
 
@@ -282,8 +383,12 @@ def bare_managed_command(cmd):
     The de-dup surface removes only these. `<interp> <path> --flag` names the same
     script but is a DIFFERENT configuration — somebody typed those arguments — and
     deleting it would be this script overwriting a decision it did not make.
+
+    Covers BOTH interpreters, because the de-dup surface it serves keys on
+    `hook_script_of`. A shell hook registered with an argument is somebody's
+    configuration in exactly the way a python one is.
     """
-    m = managed_match(cmd)
+    m = managed_match(cmd) or shell_match(cmd)
     return m is not None and m.end() == len(cmd)
 
 
@@ -416,6 +521,35 @@ def with_python(path):
     return cmd
 
 
+def with_bash(path):
+    """Build a SHELL hook command for the append tables — same round-trip proof.
+
+    🔴 `bash` is spelled bare and PATH-resolved, unlike the python interpreter,
+    and that asymmetry is deliberate rather than an oversight:
+
+      * the python pinning exists to close a specific window — during ~1s of every
+        home-manager switch the intermediate profile generation has no `python3`
+        on PATH, so a hook firing then dies with `command not found`, and
+        bash-guard FAILS OPEN when it does. `bash` is not on that profile; it
+        comes from the system, so the window does not exist for it.
+      * settings.json is read by the CLI, which runs hook commands through a
+        shell — a shell that, by definition, already exists.
+      * and this hook is a SessionStart reporter with no verdict: if it somehow
+        failed to launch, the cost is a missing banner, not a guard that fails
+        open.
+
+    Pinning it would also mean writing a /nix/store bash path that a
+    `home-manager rollback` would leave dangling, which is a live hazard the
+    de-dup surface exists to recover from. Bare is the safer end of that trade.
+    """
+    cmd = "bash " + path
+    if hook_script_of(cmd) is None:
+        raise AssertionError(
+            "register-nudge-hook.py would write a shell command its own recogniser "
+            "does not recognise, so every run would re-append it: %r" % cmd)
+    return cmd
+
+
 # --------------------------------------------------------------------------- #
 # THE APPEND SURFACE: the command tables. Unchanged in width — only the
 # interpreter half of each string moved.
@@ -485,8 +619,19 @@ PRE_BASH_CMDS = [
 ]
 
 # Hooks registered on exactly one event each: {event: [command, ...]}.
+#
+# 🔴 The SessionStart entry is the first NON-PYTHON registration this script makes.
+# It is appended in the bare `{"type","command"}` shape like every other — NOT with
+# a `timeout` — even though the host that pioneered this hook by hand carries
+# `timeout: 20`. Two reasons, both load-bearing: `removable_duplicate` treats any
+# extra hook-level key as somebody else's configuration, so a timeout this script
+# wrote would be a duplicate it could never heal after a rollback; and that
+# hand-placed entry is exactly what the append surface must LEAVE ALONE. It does —
+# `registered_scripts` keys on the script, so the richer entry counts as registered
+# and nothing is added beside it.
 SINGLE_EVENT_CMDS = {
     "Stop": [with_python("~/.claude/hooks/next-step-nudge.py")],
+    "SessionStart": [with_bash("~/.claude/hooks/base-clone-staleness.sh")],
 }
 
 # 🔴 THE OWNERSHIP BOUNDARY OF THE DE-DUP SURFACE, derived from the tables above
@@ -496,10 +641,17 @@ SINGLE_EVENT_CMDS = {
 # a doubled bash-guard entry came from something else and is not this script's to
 # remove. It is reported instead — see the end of the de-dup pass.
 REGISTERED_SCRIPTS = frozenset(
-    managed_script_of(c)
+    hook_script_of(c)
     for c in POST_BASH_CMDS + PRE_BASH_CMDS + [NOTIFY_CMD, LEDGER_CMD, WRITEBACK_CMD]
     + [c for cmds in SINGLE_EVENT_CMDS.values() for c in cmds]
 )
+
+# 🔴 A None in there would mean a table command the recogniser cannot read back —
+# the unbounded re-append defect — reaching the ownership boundary as a wildcard
+# that matches every unrecognised entry. `with_python`/`with_bash` each raise on
+# their own output, so this is a second, cheaper net across the COMBINED set.
+assert None not in REGISTERED_SCRIPTS, (
+    "a command table entry is unreadable by this script's own identity recogniser")
 
 with open(SETTINGS) as f:
     data = json.load(f)
@@ -511,7 +663,11 @@ deduped = []
 
 
 def registered_scripts(event_arrays):
-    """Which MANAGED hook scripts an event's entry list already invokes.
+    """Which managed hook scripts an event's entry list already invokes.
+
+    Keyed on `hook_script_of`, so a shell hook counts as registered exactly the
+    way a python one does — see MANAGED_SHELL_HOOK_SCRIPTS for why identity and
+    interpreter are two questions.
 
     🔴 The append surface keys on the SCRIPT, not on the exact command string.
     Exact-string keying was already fragile — a host spelling the hooks dir
@@ -527,7 +683,7 @@ def registered_scripts(event_arrays):
     silently duplicated. That is the right failure — the append surface never
     rewrites what it does not own.
     """
-    found = {managed_script_of(h.get("command"))
+    found = {hook_script_of(h.get("command"))
              for entry in event_arrays for h in entry.get("hooks", [])}
     found.discard(None)
     return found
@@ -667,7 +823,7 @@ def entry_identity_list(entry, event):
             scope = ("<non-str matcher>", repr(scope))
     else:
         scope = None
-    ids = [(scope, managed_script_of(h.get("command")))
+    ids = [(scope, hook_script_of(h.get("command")))
            for h in _entry_hook_dicts(entry)]
     return [i for i in ids if i[1] is not None]
 
@@ -725,7 +881,7 @@ def removable_duplicate(entry):
         return False
     if not bare_managed_command(h.get("command")):
         return False
-    return managed_script_of(h.get("command")) in REGISTERED_SCRIPTS
+    return hook_script_of(h.get("command")) in REGISTERED_SCRIPTS
 
 
 # --- PASS 1: heal a file an OLDER registrar double-registered ----------------
@@ -877,7 +1033,7 @@ for _event in sorted(hooks):
 pre = hooks.setdefault("PreToolUse", [])
 pre_registered = registered_scripts(pre)
 for cmd in PRE_BASH_CMDS:
-    if managed_script_of(cmd) in pre_registered:
+    if hook_script_of(cmd) in pre_registered:
         continue
     pre.append({"matcher": "Bash", "hooks": [{"type": "command", "command": cmd}]})
     added.append("PreToolUse(Bash): " + cmd)
@@ -886,7 +1042,7 @@ for cmd in PRE_BASH_CMDS:
 post = hooks.setdefault("PostToolUse", [])
 post_registered = registered_scripts(post)
 for cmd in POST_BASH_CMDS:
-    if managed_script_of(cmd) in post_registered:
+    if hook_script_of(cmd) in post_registered:
         continue
     post.append({"matcher": "Bash", "hooks": [{"type": "command", "command": cmd}]})
     added.append("PostToolUse(Bash): " + cmd)
@@ -896,7 +1052,7 @@ for cmd in POST_BASH_CMDS:
 # a tmux Stop hook) — only add claude-notify where it's missing.
 for event in NOTIFY_EVENTS:
     arr = hooks.setdefault(event, [])
-    if managed_script_of(NOTIFY_CMD) in registered_scripts(arr):
+    if hook_script_of(NOTIFY_CMD) in registered_scripts(arr):
         continue
     arr.append({"hooks": [{"type": "command", "command": NOTIFY_CMD}]})
     added.append("%s: %s" % (event, NOTIFY_CMD))
@@ -910,7 +1066,7 @@ for event in NOTIFY_EVENTS:
 # misconfiguration; `tests/test_register_nudge_hook.py` pins the shape it writes.
 for event in LEDGER_EVENTS:
     arr = hooks.setdefault(event, [])
-    if managed_script_of(LEDGER_CMD) in registered_scripts(arr):
+    if hook_script_of(LEDGER_CMD) in registered_scripts(arr):
         continue
     arr.append({"hooks": [{"type": "command", "command": LEDGER_CMD}]})
     added.append("%s: %s" % (event, LEDGER_CMD))
@@ -922,7 +1078,7 @@ for event in LEDGER_EVENTS:
 # consecutive blocks per task — well inside the CLI's own cap of 8.
 for event in WRITEBACK_EVENTS:
     arr = hooks.setdefault(event, [])
-    if managed_script_of(WRITEBACK_CMD) in registered_scripts(arr):
+    if hook_script_of(WRITEBACK_CMD) in registered_scripts(arr):
         continue
     arr.append({"hooks": [{"type": "command", "command": WRITEBACK_CMD}]})
     added.append("%s: %s" % (event, WRITEBACK_CMD))
@@ -932,7 +1088,7 @@ for event, cmds in SINGLE_EVENT_CMDS.items():
     arr = hooks.setdefault(event, [])
     present = registered_scripts(arr)
     for cmd in cmds:
-        if managed_script_of(cmd) in present:
+        if hook_script_of(cmd) in present:
             continue
         arr.append({"hooks": [{"type": "command", "command": cmd}]})
         added.append("%s: %s" % (event, cmd))

--- a/scripts/claude-hooks/tests/test_register_nudge_hook.py
+++ b/scripts/claude-hooks/tests/test_register_nudge_hook.py
@@ -114,6 +114,14 @@ CLAWGATE_STOP = "/home/zach/.claude/clawgate-stop-hook.sh"
 SEARCH_NUDGE = PY + " ~/.claude/hooks/search-tool-nudge.py"
 NEXT_STEP = PY + " ~/.claude/hooks/next-step-nudge.py"
 TMUX_STOP = "~/.config/tmux/task-hook.sh"
+# 🔴 THE ONE MANAGED COMMAND WITH NO PYTHON IN IT — see scenario 18. It is spelled
+# with a bare `bash` on purpose, and several assertions below that used to read
+# "every command names the pinned interpreter" now have to say "every PYTHON
+# command", because this one legitimately does not and must never be made to.
+# Excluding it is not a weakening: scenario 18 asserts the exclusion positively
+# (the interpreter stays `bash`), so a mutant that dropped the shell hook from the
+# tables would go red there rather than quietly satisfying a widened `all()` here.
+BCS = "bash ~/.claude/hooks/base-clone-staleness.sh"
 LEDGER = PY + " ~/.claude/hooks/agent-ledger-hook.py"
 WRITEBACK = PY + " ~/.claude/hooks/clawgate-writeback-guard.py"
 INTERVIEW = PY + " ~/.claude/hooks/clawgate-task-interview-guard.py"
@@ -476,8 +484,14 @@ with tempfile.TemporaryDirectory() as tmp:
           and matchers_for(d3, "PostToolUse", "/search-tool-nudge.py") == ["Bash"])
     # Every command this run wrote carries the pinned absolute interpreter — no
     # bare `python3` survives anywhere in the file it produced.
-    check("9: every managed command it wrote names the absolute interpreter",
-          all(c.startswith(PY + " ") for c in all_cmds if c != TMUX_STOP))
+    check("9: every managed PYTHON command it wrote names the absolute interpreter",
+          all(c.startswith(PY + " ")
+              for c in all_cmds if c not in (TMUX_STOP, BCS)))
+    # Anti-vacuity for the exclusion just added: the shell hook really is in
+    # this file, so the filter is removing something rather than describing an
+    # empty case, and it is NOT carrying a python interpreter.
+    check("9: ...and the one non-python managed command is present and bash-run",
+          all_cmds.count(BCS) == 1)
 
 # --- 10. THE RECOGNISER IS CONSERVATIVE -------------------------------------
 # 🔴 Each command below names a MANAGED hook script under the hooks dir and must
@@ -566,8 +580,13 @@ with tempfile.TemporaryDirectory() as tmp:
     with open(settings) as f:
         d5 = json.load(f)
     every = [c for ev in d5.get("hooks", {}) for c in cmds(d5, ev)]
-    check("11: every command now names the BUMPED interpreter",
-          every and all(c.startswith(PY2 + " ") for c in every))
+    check("11: every PYTHON command now names the BUMPED interpreter",
+          every and all(c.startswith(PY2 + " ") for c in every if c != BCS))
+    # 🔴 The shell hook must NOT have been bumped -- an interpreter bump that
+    # reached it would have rewritten `bash` to a python path and broken every
+    # session start. Asserted here because this is the scenario that bumps.
+    check("11: the shell hook was NOT bumped -- it still runs under bash",
+          every.count(BCS) == 1)
     check("11: not one command still names the old interpreter",
           not any(c.startswith(PY + " ") for c in every))
     # Anti-vacuity: the file still holds the hooks it held before, in the same
@@ -729,7 +748,8 @@ with tempfile.TemporaryDirectory() as tmp:
     check("12: the matchered Stop duplicate was removed, keeping the FIRST copy",
           entries(d12, "Stop").count((None, NEXT_STEP)) == 1
           and ("Bash", NEXT_STEP) not in entries(d12, "Stop"))
-    check("12: SessionStart healed", entries(d12, "SessionStart") == [(None, LEDGER)])
+    check("12: SessionStart healed, and the shell hook appended after it",
+          entries(d12, "SessionStart") == [(None, LEDGER), (None, BCS)])
     check("12: UserPromptSubmit healed",
           entries(d12, "UserPromptSubmit") == [(None, NOTIFY), (None, LEDGER)])
     check("12: SubagentStop healed", entries(d12, "SubagentStop") == [(None, NOTIFY)])
@@ -884,14 +904,21 @@ for hostile, why, hostile_cwd, expected_reason in HOSTILE_OVERRIDES:
         # commands than it did. The literal stays a literal — `a == b == c` is
         # satisfied by a run that appends nothing at all, which is the unbounded-
         # growth guard's own failure mode inverted.
-        check(tag + ": three consecutive runs hold exactly 18 hook commands",
-              counts == [18, 18, 18])
+        # 18 -> 19: base-clone-staleness.sh joined SINGLE_EVENT_CMDS on
+        # SessionStart, so one converged run holds one more command.
+        check(tag + ": three consecutive runs hold exactly 19 hook commands",
+              counts == [19, 19, 19])
         with open(settings) as f:
             d13 = json.load(f)
         written = [c for ev in d13.get("hooks", {}) for c in cmds(d13, ev)
-                   if c != TMUX_STOP]
-        check(tag + ": every hook command names the resolved fallback instead",
+                   if c not in (TMUX_STOP, BCS)]
+        check(tag + ": every PYTHON hook command names the resolved fallback instead",
               written and all(c.startswith(RESOLVED + " ") for c in written))
+        # The hostile override must not have reached the shell hook either --
+        # it has no python token to poison, and it must still be exactly one.
+        check(tag + ": the shell hook survived the hostile override untouched",
+              [c for ev in d13.get("hooks", {}) for c in cmds(d13, ev)
+               if "base-clone-staleness.sh" in c] == [BCS])
         # By PREFIX, not substring: the resolved fallback is itself a path ending
         # in `python3`, so a substring test would report the relative override as
         # "reached" purely because the honest answer contains its spelling.
@@ -1225,6 +1252,132 @@ with tempfile.TemporaryDirectory() as tmp:
     check("17: the second run reports no change", "no change" in p17b.stdout)
     check("17: the healed file is BYTE-IDENTICAL after a second run",
           open(settings, "rb").read() == healed17)
+
+# --- 18. THE SHELL HOOK: REGISTERED, NEVER REWRITTEN, NEVER RE-APPENDED -------
+# 🔴 base-clone-staleness.sh is the first NON-PYTHON hook this script registers,
+# and it walks straight at the two defects the python side already paid for:
+#
+#   * THE UNBOUNDED RE-APPEND. The append surface asks "is this script already
+#     registered" through a recogniser. While that recogniser was python-only it
+#     could not read a `bash …` command back — including one it had just written
+#     — so every run would append another copy. Measured on the python side at
+#     14 -> 27 -> 40 over three runs. (c) below is what makes that visible: it is
+#     the assertion that goes red if `hook_script_of` ever loses its shell half.
+#   * THE REWRITE THAT DESTROYS IT. `normalized_command` replaces the FIRST token
+#     with an absolute python. Applied here it produces
+#     `<python> ~/.claude/hooks/base-clone-staleness.sh`, i.e. a SyntaxError on
+#     every single session start. (b) pins that the rewrite pass does not see it.
+#
+# The fixture is EMPTY of SessionStart entries so the append is a real creation,
+# not a preservation — an append bug is invisible on a populated event.
+with tempfile.TemporaryDirectory() as tmp:
+    home = os.path.join(tmp, "home")
+    os.makedirs(os.path.join(home, ".claude"))
+    settings = os.path.join(home, ".claude", "settings.json")
+    with open(settings, "w") as f:
+        json.dump({"hooks": {}}, f, indent=2)
+
+    env = dict(os.environ)
+    env["HOME"] = home
+    env["DEVRC_HOOK_PYTHON"] = PY
+
+    p18 = run(env)
+    check("18: run exits 0", p18.returncode == 0)
+    with open(settings) as f:
+        d18 = json.load(f)
+
+    ss = cmds(d18, "SessionStart")
+
+    # (a) IT IS REGISTERED AT ALL — the gap this scenario exists to close. Before
+    #     this change the switch delivered the script and registered nothing, so
+    #     the hook fired only on the one host where the entry was hand-added.
+    check("18: the shell hook is registered on SessionStart", BCS in ss)
+    check("18: exactly once", ss.count(BCS) == 1)
+
+    # POSITIVE CONTROL: SessionStart is an event the python side also writes to,
+    # so a run that appended nothing at all cannot be what makes (a) green.
+    check("18: POSITIVE CONTROL — the python hook landed on the same event too",
+          LEDGER in ss)
+
+    # (b) THE REWRITE PASS DOES NOT TOUCH IT. Asserted on the string, because the
+    #     damage is exactly a substituted first token.
+    check("18: the interpreter is still `bash`, NOT the pinned python",
+          [c for c in ss if "base-clone-staleness.sh" in c] == [BCS])
+    check("18: no SessionStart command pairs a python interpreter with a .sh",
+          not any(c.endswith(".sh") and c.startswith(PY) for c in ss))
+    check("18: ...and the run did not report it as pinned",
+          "base-clone-staleness.sh" not in "".join(
+              ln for ln in p18.stdout.splitlines() if ln.startswith("  ~ ")))
+
+    # (c) THE FIXED POINT — the re-append defect, measured over a second run.
+    after18 = open(settings, "rb").read()
+    p18b = run(env)
+    check("18: the second run reports no change", "no change" in p18b.stdout)
+    check("18: the file is BYTE-IDENTICAL after a second run",
+          open(settings, "rb").read() == after18)
+    with open(settings) as f:
+        check("18: still exactly one shell-hook registration after re-running",
+              cmds(json.load(f), "SessionStart").count(BCS) == 1)
+
+# --- 18b. THE HAND-PLACED ENTRY THIS SCRIPT MUST LEAVE ALONE ------------------
+# 🔴 The host that pioneered the hook carries it with `timeout: 20` and a
+# `statusMessage`, added by hand. Both are keys this script never writes, so it
+# must neither duplicate the registration nor strip the keys — `removable_duplicate`
+# reads any extra hook-level key as somebody else's configuration. A second, BARE
+# copy is added alongside to prove the de-dup identity covers shell hooks too:
+# without it the bare duplicate survives and the hook fires twice per session.
+HANDPLACED = {"hooks": {"SessionStart": [
+    {"hooks": [{"type": "command", "command": BCS,
+                "timeout": 20, "statusMessage": "Checking base-clone staleness..."}]},
+    {"hooks": [{"type": "command", "command": BCS}]},
+]}}
+
+with tempfile.TemporaryDirectory() as tmp:
+    home = os.path.join(tmp, "home")
+    os.makedirs(os.path.join(home, ".claude"))
+    settings = os.path.join(home, ".claude", "settings.json")
+    with open(settings, "w") as f:
+        json.dump(HANDPLACED, f, indent=2)
+
+    env = dict(os.environ)
+    env["HOME"] = home
+    env["DEVRC_HOOK_PYTHON"] = PY
+
+    p18c = run(env)
+    check("18b: run exits 0", p18c.returncode == 0)
+    with open(settings) as f:
+        d18c = json.load(f)
+
+    ss_hooks = [h for e in d18c["hooks"]["SessionStart"] for h in e["hooks"]
+                if "base-clone-staleness.sh" in h.get("command", "")]
+
+    # ⚠ AN INVARIANT GUARD, labelled honestly — NOT regression coverage, and it
+    # was demoted to this label after being mutation-tested rather than assumed.
+    # TWO independent barriers stand in front of it, so no small mutant reaches
+    # it: `_MANAGED_CMD_RE` is anchored on `\.py`, so a `.sh` command cannot match
+    # the python recogniser however the ledgers are edited; and the rewrite pass
+    # raises rather than writing a product it cannot read back. Both mutants that
+    # SHOULD have reached it — widening `normalized_command` to `shell_match`,
+    # with and without adding the `.sh` to MANAGED_HOOK_SCRIPTS — died on that
+    # raise, which is the right failure but a different one.
+    #
+    # It stays because it states the consequence in one line, and the assertion
+    # BELOW it is the one that actually caught both mutants (the file keeps two
+    # unhealed copies when the registrar aborts mid-run).
+    check("18b: the rewrite pass did NOT swap `bash` for a python interpreter",
+          not any(c.endswith(".sh") and c.startswith(PY)
+                  for c in cmds(d18c, "SessionStart")))
+    check("18b: ...and the command is verbatim the one the tables write",
+          [c for c in cmds(d18c, "SessionStart")
+           if "base-clone-staleness.sh" in c] == [BCS])
+
+    check("18b: the bare duplicate is healed away", len(ss_hooks) == 1)
+    check("18b: ...and the survivor is the FIRST entry, keys intact",
+          ss_hooks[:1] == [{"type": "command", "command": BCS, "timeout": 20,
+                            "statusMessage": "Checking base-clone staleness..."}])
+    check("18b: no THIRD copy was appended beside the hand-placed one",
+          cmds(d18c, "SessionStart").count(BCS) == 1)
+
 
 with open(SCRIPT) as f:
     src = f.read()

--- a/scripts/claude-hooks/tests/test_registrar_activation.py
+++ b/scripts/claude-hooks/tests/test_registrar_activation.py
@@ -444,7 +444,13 @@ def test_with_no_arguments_it_looks_for_the_registrar_under_home(tmp_path):
 # 3. WIRING — section 1 passes with home.nix untouched; that IS the shipped bug
 # --------------------------------------------------------------------------- #
 
-HOOK_CMD_RE = re.compile(r"~/\.claude/hooks/([A-Za-z0-9_.-]+\.py)")
+# 🔴 `.py|.sh`, not `.py`. This pattern IS the coverage of
+# test_home_nix_deploys_every_hook_the_registrar_registers below, and while it
+# was python-only that test's sentence ("every hook the registrar registers")
+# was wider than its implementation: the first non-python registration would
+# have been invisible to it and shipped undelivered, which is the exact bug the
+# test exists to catch, walked past by the guard meant to stop it.
+HOOK_CMD_RE = re.compile(r"~/\.claude/hooks/([A-Za-z0-9_.-]+\.(?:py|sh))")
 HOME_FILE_RE = re.compile(r'home\.file\."\.claude/hooks/([^"]+)"')
 
 
@@ -469,6 +475,11 @@ def test_the_parsers_find_something_positive_control():
     assert "next-step-nudge.py" in registers, registers
     assert len(deploys) >= 5, deploys
     assert "bash-guard.py" in deploys, deploys
+    # The `.sh` half of HOOK_CMD_RE, controlled separately: a pattern that had
+    # silently lost its shell alternation would still satisfy every assertion
+    # above, and the two tests below would go back to being python-only while
+    # still reading as "every hook".
+    assert "base-clone-staleness.sh" in registers, registers
 
 
 def test_home_nix_deploys_every_hook_the_registrar_registers():
@@ -548,6 +559,52 @@ def test_the_managed_hook_set_is_pinned_two_way_against_home_nix():
     )
 
 
+def test_the_shell_hook_set_is_pinned_two_way_against_home_nix():
+    """🔴 The SHELL ledger, pinned the same way its python sibling above is.
+
+    Separate test rather than a widened one, because the two sets answer
+    different questions and the sibling's `.py` filter is what keeps the rewrite
+    surface honest: MANAGED_HOOK_SCRIPTS means "whose INTERPRETER this script
+    rewrites", and a bash hook must never be in it — normalising that command's
+    first token to a python path turns every session start into a SyntaxError.
+
+    Fails when a `.claude/hooks/*.sh` entry lands in home.nix that nobody has
+    decided about, and when the registrant's set names one home.nix does not
+    deliver.
+    """
+    deployed = {n for n in home_nix_deploys() if n.endswith(".sh")}
+    shell = set(registrar_literal("MANAGED_SHELL_HOOK_SCRIPTS"))
+
+    # Positive control: both sides non-empty, so an equality of two empty sets
+    # can never be what makes this green.
+    assert deployed, "no .claude/hooks/*.sh home.file entry found in nix/home.nix"
+    assert shell, "MANAGED_SHELL_HOOK_SCRIPTS is empty"
+
+    assert deployed == shell, (
+        "nix/home.nix's .claude/hooks/*.sh set no longer matches the registrant's "
+        "shell ledger. Unaccounted (deployed, not managed): %r. Stale (claimed, "
+        "not deployed): %r."
+        % (sorted(deployed - shell), sorted(shell - deployed))
+    )
+
+
+def test_the_two_ledgers_are_disjoint_and_the_shell_one_is_never_rewritten():
+    """🔴 THE SEAM, pinned as a relationship rather than as two component facts.
+
+    A `.sh` name reaching MANAGED_HOOK_SCRIPTS would hand it to the interpreter
+    rewrite; a `.py` name in the shell set would put a python hook behind a
+    `bash` recogniser. Both sets can be individually well-formed and this can
+    still be wrong, which is why it is asserted about the PAIR.
+    """
+    managed = set(registrar_literal("MANAGED_HOOK_SCRIPTS"))
+    shell = set(registrar_literal("MANAGED_SHELL_HOOK_SCRIPTS"))
+
+    assert managed and shell                                    # positive control
+    assert managed & shell == set(), sorted(managed & shell)
+    assert all(n.endswith(".py") for n in managed), sorted(managed)
+    assert all(n.endswith(".sh") for n in shell), sorted(shell)
+
+
 def test_the_two_exclusions_are_explicit_and_justified():
     """🔴 The exclusions must be a DECISION, not an accident of omission.
 
@@ -569,12 +626,31 @@ def test_the_two_exclusions_are_explicit_and_justified():
         "a module excluded as a never-invoked library IS in the command tables: "
         + repr(sorted(libraries & registrar_registers()))
     )
-    # ...and every hook the registrant registers must be one it will also keep
-    # pinned, or the append surface would write a command the rewrite surface
-    # refuses to maintain.
-    assert registrar_registers() <= managed, (
-        "registered but not in the managed set, so its interpreter would never "
-        "be re-pinned: " + repr(sorted(registrar_registers() - managed))
+    # ...and every hook the registrant registers must be accounted for by ONE of
+    # the two ledgers, or the append surface would write a command no recogniser
+    # can read back — the unbounded re-append defect.
+    #
+    # 🔴 This used to read `<= managed` alone, and its stated reason ("its
+    # interpreter would never be re-pinned") is why: while every hook was python,
+    # "registered" and "interpreter-managed" were the same set. They are not the
+    # same question, and a shell hook is the case that separates them — it has no
+    # python token to re-pin, so demanding its presence in `managed` would demand
+    # exactly the rewrite that breaks it. The exhaustiveness is unchanged: a hook
+    # in NEITHER ledger still fails here.
+    shell = set(registrar_literal("MANAGED_SHELL_HOOK_SCRIPTS"))
+    unaccounted = registrar_registers() - (managed | shell)
+    assert unaccounted == set(), (
+        "registered but in neither ledger, so nothing maintains it and this "
+        "script cannot read its own command back: " + repr(sorted(unaccounted))
+    )
+    # And the python ledger is still exhaustive over the PYTHON registrations —
+    # the original claim, kept at its own width rather than dissolved into the
+    # union above, which would pass if a .py hook drifted into the shell set.
+    assert {n for n in registrar_registers() if n.endswith(".py")} <= managed, (
+        "a python hook is registered but not interpreter-managed, so it would "
+        "never be re-pinned: "
+        + repr(sorted({n for n in registrar_registers() if n.endswith(".py")}
+                      - managed))
     )
 
 


### PR DESCRIPTION
## What

`base-clone-staleness.sh` shipped to both hosts via `home.file` and fired on **exactly one** — the one where the `settings.json` entry had been added by hand. `register-nudge-hook.py` did not know it existed.

## Why the old reasoning looked sound

`nix/home.nix` explained the omission, and every clause before its conclusion is true:

> the registrar's managed-command surface recognises `<python> <path>.py` commands only, and its whole rewrite half exists to normalise a python INTERPRETER token to an absolute /nix/store path. This hook is bash, so there is no interpreter hazard to fix and nothing for the registrar to match; teaching that shared component a second interpreter would widen a load-bearing surface for no benefit.

The conclusion does not follow. **The benefit was never interpreter pinning — it was registration.** The comment even wrote down its own consequence:

> on any host where the entry has not been added by hand, the switch delivers the script and the hook is INERT.

That is the #452 shape verbatim, which is the failure this script exists to prevent. The analogy to `bash-guard.py` fails too: bash-guard is excluded on **provenance** (hand-placed on both hosts before the registrar existed, so ownership is unprovable), not on interpreter. This hook has no such history.

## How

An **identity** recogniser beside the interpreter one — not a wider rewrite surface.

- **`MANAGED_SHELL_HOOK_SCRIPTS`** — a deliberately separate ledger. Putting the `.sh` in `MANAGED_HOOK_SCRIPTS` would hand it to `normalized_command`, which replaces the first token unconditionally: the hook's leading `bash` becomes a python path, i.e. a `SyntaxError` on every session start.
- **`hook_script_of()`** = python recogniser ∪ `bash <hooks-dir><name>.sh`. All append-membership tests and the de-dup identity key go through it, so the surfaces cannot disagree about "already registered". **The rewrite pass still keys on the python-only `managed_match`.** Identity is *which script*; the rewrite is *which interpreter* — one function only because every hook used to be python.
- **`with_bash()`** re-proves the round-trip for the strings actually written. A command written but not readable back is re-appended every run — measured on the python side at 14 → 27 → 40.

`bash` stays bare rather than store-pinned: the 127 window is a property of the python-carrying profile generation, the CLI runs hook commands through a shell that by definition exists, and a pinned bash path would dangle after a `home-manager rollback`.

The entry is appended in the bare `{type,command}` shape, so the hand-placed entry carrying `timeout: 20` is left alone, and this script's own appends stay removable by its de-dup pass.

## Coverage — mutation-validated, not assumed

| Mutant | Killed by | Reason confirmed |
|---|---|---|
| `registered_scripts()` loses its shell half | scenario 18 fixed-point (3 assertions) | `run exits 0` still passes, so the re-append defect is what was observed — not a crash |
| SessionStart entry deleted from the tables | scenario 18 + activation positive control | both |
| `normalized_command` widened to `shell_match` | 18b | registrar aborts rather than writing a mangled command |
| `HOOK_CMD_RE` loses `.sh` | activation positive control | parser blindness |
| `home.file` entry renamed | `test_home_nix_deploys_every_hook_the_registrar_registers` + the new two-way shell pin | registered-but-undelivered |

**One defect found by the sweep and fixed:** writing the hooks-dir-prefixed path into a **comment** made the delivery-seam parser read a phantom registration — so deleting the real table entry left that suite fully green. The registrar's own comment warns about exactly this. An audit for it is now part of the sweep.

`HOOK_CMD_RE` widened to `(?:py|sh)`: while python-only, `test_home_nix_deploys_every_hook_the_registrar_registers` claimed *"every hook the registrar registers"* but structurally could not see a non-python one — the guard meant to catch this bug class would have walked past it.

The 18b interpreter assertion is labelled an **invariant guard**, not regression coverage: `_MANAGED_CMD_RE` is anchored on `\.py` and the rewrite pass raises on a product it cannot read back, so both mutants that should have reached it died on that raise instead.

## Tests

- `test_register_nudge_hook.py` — all passed (scenarios 18 + 18b new; 9/11/12/13 updated for the one extra command, count 18 → 19)
- `test_registrar_activation.py` — 26 passed (2 new tests)
- `test_base_clone_staleness.sh` — 24/24
- Full `scripts/run-tests.sh` — `RESULT: PASS`, three times (standalone, and as the pre-push gate on two attempts)

## Note for whoever pushes next

The pre-push gate takes ~25 min, during which git's SSH connection to GitHub sits idle and **gets dropped** — the push then dies with SIGPIPE (rc 141) after the gate reports ✅. Worse, `git push … | tail` reports *tail's* status, so it reads as success while nothing lands. Push with keepalives:

```bash
GIT_SSH_COMMAND="ssh -o ServerAliveInterval=20 -o ServerAliveCountMax=200" git push -u origin <branch>
```

and verify with `git ls-remote --heads origin | grep <branch>`, never the exit code of a pipeline.
