### PR TITLE
fix(analyze-service-index): a leaked GIT_DIR aimed the BACKUP — the one with a network — at a foreign repo

### DIFF
--- a/scripts/analyze-service-index/backup.py
+++ b/scripts/analyze-service-index/backup.py
@@ -218,6 +218,14 @@ def _private_dir(d: Path) -> Path:
 # --------------------------------------------------------------------------- #
 # git — read-only by construction
 # --------------------------------------------------------------------------- #
+# 🔴 PROCESS-GLOBAL, AND DELIBERATELY NEVER RESET. `_git_env()` is rebuilt for
+# every git invocation, so without this the announcement below would print once
+# per call and bury the backup's own output. The consequence for TESTS is the
+# part worth naming: an in-process assertion on the announcement is
+# ORDER-DEPENDENT — whichever test runs first consumes the one line for that
+# name. So the behavioural pins on it (`test_the_leak_is_ANNOUNCED_…`,
+# `test_the_announcement_is_ONCE_PER_NAME_…`) drive a SUBPROCESS, where the set
+# starts empty by construction. A unit-level test must snapshot and restore it.
 _POINTERS_ANNOUNCED: set[str] = set()
 
 
@@ -303,6 +311,24 @@ def _git_env() -> dict:
     return env
 
 
+def _announcing_program() -> str:
+    """The program actually running, for the announcement's prefix.
+
+    🔴 NOT `PROG`. `_git_env()` is SHARED: `restore-verify.py` imports this
+    module and calls `_git_env()` / `_git_scratch` directly (it deliberately
+    reuses them rather than copying the guards). Hardcoding `PROG` therefore
+    announced a leak hit during a RESTORE VERIFICATION under the BACKUP's name,
+    sending whoever read the journal to the wrong program and the wrong unit.
+    `sys.argv[0]`'s basename distinguishes them without either program having to
+    register anything.
+    """
+    try:
+        name = Path(sys.argv[0]).name
+    except (IndexError, TypeError, ValueError):  # pragma: no cover - argv is a list
+        return PROG
+    return name or PROG
+
+
 def _announce_stripped_pointers(stripped: dict) -> None:
     """Say ONCE per variable that the caller's environment was aimed elsewhere.
 
@@ -311,18 +337,19 @@ def _announce_stripped_pointers(stripped: dict) -> None:
     and the strip fixes this program's behaviour without fixing theirs. Printing
     it makes the leak visible in the journal instead of only in a diff nobody
     reads. Once per name, because `_git_env()` is rebuilt for every invocation
-    and a per-call line would bury the backup's own output.
+    and a per-call line would bury the run's own output — see the note on
+    `_POINTERS_ANNOUNCED` for what that costs a test.
     """
     for name in sorted(stripped):
         if name in _POINTERS_ANNOUNCED:
             continue
         _POINTERS_ANNOUNCED.add(name)
         print(
-            f"{PROG}: STRIPPED {name}={stripped[name]!r} from the git "
-            f"environment. It decides WHICH repository a git command lands in "
-            f"and it OVERRIDES `git -C`; inherited here it would have aimed this "
-            f"backup at that repository and uploaded it. Fix the caller — "
-            f"nothing in this program's normal operation sets it.",
+            f"{_announcing_program()}: STRIPPED {name}={stripped[name]!r} from "
+            f"the git environment. It decides WHICH repository a git command "
+            f"lands in and it OVERRIDES `git -C`; inherited here it would have "
+            f"aimed this program at that repository. Fix the caller — nothing "
+            f"in normal operation sets it.",
             file=sys.stderr,
         )
 

--- a/scripts/analyze-service-index/backup.py
+++ b/scripts/analyze-service-index/backup.py
@@ -32,6 +32,22 @@ That read-only-ness is not asserted, it is measured: the test suite checksums a
 synthetic store before and after a full run and requires byte identity, and
 separately requires that every scope still reports zero remotes.
 
+🔴 READ-ONLY IS ONLY HALF THE QUESTION — THE OTHER HALF IS *WHICH REPOSITORY*
+------------------------------------------------------------------------------
+Every git call below is `git -C <scope> …`, and `-C` is the weakest possible
+claim about where a command lands: **GIT_DIR OVERRIDES IT**. MEASURED 2026-08-23
+(git 2.55.0) on the pre-fix tree, sole variable `GIT_DIR` pointed at a decoy
+repo, driving this CLI end to end under the unit's own environment shape:
+
+    control (no leak)  rc=0  bundle head: <sha> refs/heads/trunk
+    GIT_DIR=<decoy>    rc=0  bundle head: <sha> refs/heads/foreign-branch
+
+A perfectly read-only run, of the wrong repository, encrypted and uploaded
+off-box under a green timer. Being read-only is what makes it *worse*, not
+better: nothing looks damaged afterwards. `_git_env()` therefore strips the
+repo-pointer family before every invocation; see its docstring, and
+`testlib/gitenv.py` for the incident that established the mechanism.
+
 WHY age, WHEN MINIO IS SELF-HOSTED
 ----------------------------------
 🔴 The store is client-confidential and the scope READMEs say the content never
@@ -98,6 +114,36 @@ import tempfile
 import traceback
 from datetime import datetime, timezone
 from pathlib import Path
+
+# 🔴 THE REPO-POINTER LEDGER IS NOT SPELLED IN THIS FILE, ON PURPOSE.
+# `scripts/testlib/gitenv.py::REPO_POINTER_VARS` OWNS the set of environment
+# variables that decide WHICH repository a git command lands in. `commit.sh`
+# (the sibling program) has to re-spell it as a bash array because bash cannot
+# import; this file is Python and can use the owner directly, which is strictly
+# stronger — there is no copy to drift. claude/RULES.md → "One rule, one place".
+#
+# THE IMPORT IS A HARD FAILURE, NEVER A SILENT DEGRADE. A `try: … except
+# ImportError: POINTERS = ()` fallback would turn a missing ledger into a backup
+# that runs with the defect back in place and still reports success — the exact
+# false all-clear this whole file is built against. The unit mounts
+# `%h/workspace/devrc/scripts` read-only (nix/home.nix), so `testlib/` is on
+# disk beside this script in every environment that runs it; if it ever is not,
+# the run must stop and say so.
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+try:
+    from testlib.gitenv import REPO_POINTER_VARS, strip_repo_pointers  # noqa: E402
+except ImportError as _exc:  # pragma: no cover - a deployment fault, not a code path
+    raise ImportError(
+        f"analyze-service-index/backup.py cannot import the git repo-pointer "
+        f"ledger from {_SCRIPTS_DIR / 'testlib' / 'gitenv.py'} ({_exc}). That "
+        f"ledger is what stops a leaked GIT_DIR aiming this program — which has "
+        f"a network and uploads what it bundles off-box — at a FOREIGN "
+        f"repository. Refusing to run without it: a backup that silently drops "
+        f"the strip would bundle and upload somebody else's history under a "
+        f"green timer."
+    ) from _exc
 
 PROG = "analyze-service-index-backup"
 
@@ -172,10 +218,46 @@ def _private_dir(d: Path) -> Path:
 # --------------------------------------------------------------------------- #
 # git — read-only by construction
 # --------------------------------------------------------------------------- #
-def _git_env() -> dict:
-    """Environment that makes git structurally incapable of writing to the repo.
+_POINTERS_ANNOUNCED: set[str] = set()
 
-    Each entry earns its place:
+
+def _git_env() -> dict:
+    """The environment every git invocation in this file runs under.
+
+    Two independent jobs, and the docstring used to claim only one of them while
+    naming neither correctly. It said this environment "makes git structurally
+    incapable of writing to the repo" — a claim WIDER than the code: nothing here
+    made git incapable of writing (the allowlist in `_git` and the unit's
+    `BindReadOnlyPaths` do that), and nothing here said anything about WHICH
+    repository git resolves, which was the half that was actually missing.
+
+    1. WHICH REPOSITORY — `strip_repo_pointers`, and it is the load-bearing one.
+       ------------------------------------------------------------------------
+       🔴 `git -C <scope>` is the WEAKEST possible claim about where a command
+       lands: **GIT_DIR OVERRIDES IT**. MEASURED 2026-08-23 (git 2.55.0) driving
+       the pre-fix CLI end to end against a decoy repo, sole variable `GIT_DIR`,
+       under the unit's own environment shape (`env -i` plus PATH/HOME):
+
+           control (no leak)  rc=0  bundle head: <sha> refs/heads/trunk
+           GIT_DIR=<decoy>    rc=0  bundle head: <sha> refs/heads/foreign-branch
+
+       The run printed a successful backup of a repository it was never pointed
+       at. This program has NO `PrivateNetwork`, `Wants=network-online.target`,
+       and uploads what it bundles to MinIO — so where the committer's version of
+       this defect (#721) corrupted local history, this one EXFILTRATES.
+
+       🔴 AND THE RESTORE REHEARSAL IN `bundle_scope` CANNOT CATCH IT. Its
+       `want_names` is read with `_git(scope, "for-each-ref")` — through the same
+       poisoned environment — so both sides of the comparison report the decoy's
+       refs and agree. That is a second sample of the unknown, not a control;
+       nothing downstream of it may be cited as covering this.
+
+       The SET is not chosen here — `testlib/gitenv.py::REPO_POINTER_VARS` owns
+       it (see the import banner at the top of this file).
+
+    2. WHICH CONFIG, AND NO PROMPTS — the four keys below.
+       ------------------------------------------------------------------------
+       These decide what git READS, not what it may write:
 
       GIT_OPTIONAL_LOCKS=0   DEFENCE IN DEPTH, and stated at the scope it was
                              measured. Some git reads (`git status` is the
@@ -195,8 +277,22 @@ def _git_env() -> dict:
       GIT_CONFIG_GLOBAL      no ~/.gitconfig — so the operator's own config can
       GIT_CONFIG_SYSTEM      neither change what we produce nor be written to.
       GIT_TERMINAL_PROMPT=0  never block a timer-driven run on a prompt.
+
+    🔴 EVERY git subprocess in this file takes its environment from HERE — `_git`
+    and `_git_scratch` both, pinned by
+    `test_every_git_invocation_takes_its_environment_from_git_env`. A future call
+    site that builds its own `dict(os.environ)` reintroduces the defect above and
+    that test is what fails.
     """
     env = dict(os.environ)
+    # 🔴 THE STRIP. Its ORDER relative to the `update` below is NOT load-bearing
+    # — the two sets are disjoint, and a mutation moving this call after the
+    # update was swept and SURVIVED, correctly. What matters is that it runs at
+    # all, and that it is handed `env` (the copy) rather than a throwaway: a
+    # mutant passing `dict(env)` leaves every pointer in place with the call
+    # still visibly there, and is killed by the parametrised regression test.
+    stripped = strip_repo_pointers(env)
+    _announce_stripped_pointers(stripped)
     env.update({
         "GIT_OPTIONAL_LOCKS": "0",
         "GIT_CONFIG_NOSYSTEM": "1",
@@ -205,6 +301,30 @@ def _git_env() -> dict:
         "GIT_TERMINAL_PROMPT": "0",
     })
     return env
+
+
+def _announce_stripped_pointers(stripped: dict) -> None:
+    """Say ONCE per variable that the caller's environment was aimed elsewhere.
+
+    Silence would be the wrong shape for this file: a run whose environment
+    carried `GIT_DIR=<somebody else's repo>` is a run whose *caller* is broken,
+    and the strip fixes this program's behaviour without fixing theirs. Printing
+    it makes the leak visible in the journal instead of only in a diff nobody
+    reads. Once per name, because `_git_env()` is rebuilt for every invocation
+    and a per-call line would bury the backup's own output.
+    """
+    for name in sorted(stripped):
+        if name in _POINTERS_ANNOUNCED:
+            continue
+        _POINTERS_ANNOUNCED.add(name)
+        print(
+            f"{PROG}: STRIPPED {name}={stripped[name]!r} from the git "
+            f"environment. It decides WHICH repository a git command lands in "
+            f"and it OVERRIDES `git -C`; inherited here it would have aimed this "
+            f"backup at that repository and uploaded it. Fix the caller — "
+            f"nothing in this program's normal operation sets it.",
+            file=sys.stderr,
+        )
 
 
 def _subverb(args: tuple[str, ...]) -> str | None:
@@ -291,6 +411,24 @@ def commit_count(scope: Path) -> int:
 
 
 def scope_remotes(scope: Path) -> list[str]:
+    """🔴 TEST-ONLY. THERE IS NO PRODUCTION CALL SITE, AND THAT IS DELIBERATE.
+
+    Nothing on the run path calls this. It exists so the test suite can assert
+    the no-remote invariant from OUTSIDE the code under test
+    (`test_no_scope_gains_a_remote`), and its dead-code status is pinned by
+    `test_scope_remotes_has_no_production_call_site` so this docstring cannot
+    quietly become false in either direction.
+
+    Say so here because the surrounding module docstring talks at length about
+    "WHY NO REMOTE", and a reader skimming for the control that ENFORCES it will
+    land on this function. It enforces nothing. What actually holds the invariant
+    on the run path is `_git`'s (verb, subverb) allowlist — `git remote add` is
+    refused there — plus the unit's `BindReadOnlyPaths`. A post-hoc check here
+    would in any case be an unreachable guard: this program has no code that
+    could add a remote, so a run-path assertion that none appeared could never
+    fail, and claude/RULES.md rates a guard that cannot fail as worse than none
+    because it reads as coverage while providing none.
+    """
     p = _git(scope, "remote")
     return [ln for ln in p.stdout.split("\n") if ln.strip()]
 

--- a/scripts/testlib/__init__.py
+++ b/scripts/testlib/__init__.py
@@ -10,4 +10,13 @@ Import it by putting `scripts/` on sys.path, e.g. from
 
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))  # scripts/
     from testlib import mockbin
+
+🔴 ONE MODULE HERE IS NOT TEST-ONLY: `gitenv.py`. `scripts/analyze-service-index/
+backup.py` — a systemd-timer program that encrypts and UPLOADS OFF-BOX, and
+`restore-verify.py` through it — imports `REPO_POINTER_VARS` /
+`strip_repo_pointers` at RUNTIME, and refuses to start if the import fails. So
+this package is on the deployed path (the unit mounts the whole `scripts/` tree
+read-only), and moving, renaming or making `gitenv.py` import anything heavier
+than the stdlib is a PRODUCTION change, not an internal test refactor. See that
+module's own header.
 """

--- a/scripts/testlib/gitenv.py
+++ b/scripts/testlib/gitenv.py
@@ -143,6 +143,22 @@ NOT here — widening a shared ledger on the strength of one consumer's defect
 changes GUARD 9 for every runner. Read this list as "cannot redirect git",
 never as "safe to inherit".
 
+🔴 THIS MODULE IS ON THE DEPLOYED PATH — IT IS NOT TEST-ONLY, DESPITE LIVING IN
+`testlib/`. `scripts/analyze-service-index/backup.py` imports `REPO_POINTER_VARS`
+and `strip_repo_pointers` from here AT RUNTIME, under a systemd timer, and
+`restore-verify.py` inherits that through it. Both encrypt and upload off-box, so
+the import is a HARD failure there rather than a degrade: a missing ledger stops
+the backup instead of silently running without the strip. Three consequences for
+anyone editing this file:
+
+  * keep it STDLIB-ONLY (today: `hashlib`, `os`, `pathlib`). The unit's python
+    env carries `minio` and nothing else; a pytest import here would break the
+    4:30am backup and nothing in the suite would notice.
+  * moving or renaming it is a PRODUCTION change. The unit reaches it only
+    because `BindReadOnlyPaths` mounts the whole `scripts/` tree.
+  * a name added to `REPO_POINTER_VARS` reaches that program with no edit there
+    — which is the point, and why it imports the object instead of copying it.
+
 🔴 FIFTH SPELLING, 2026-08-22. `scripts/analyze-service-index/commit.sh` also
 carries the array. It is not a runner — it resolves no ROOT and no test tier
 reaches it (systemd timer, operator shell) — but it is the one program here

--- a/scripts/tests/test_analyze_service_index_backup.py
+++ b/scripts/tests/test_analyze_service_index_backup.py
@@ -2566,14 +2566,27 @@ def test_every_git_invocation_takes_its_environment_from_git_env():
     """
     import ast
     tree = ast.parse(SCRIPT.read_text(encoding="utf-8"))
-    git_sites = [(node.lineno, _env_is_git_env(node))
-                 for node in ast.walk(tree) if _is_git_subprocess(node)]
+    classified = [_classify_subprocess(n) for n in ast.walk(tree)]
+    git_sites = [c for c in classified if c and c[1] == _KIND_GIT]
+    unknown = [c for c in classified if c and c[1] == _KIND_UNRECOGNISED]
 
     assert len(git_sites) >= 2, (
         f"the AST walk found {len(git_sites)} git subprocess site(s) in "
         f"{SCRIPT.name}; it should see at least `_git` and `_git_scratch`. A "
         f"walker that finds nothing would make this pass vacuously.")
-    bad = [ln for ln, ok in git_sites if not ok]
+
+    # 🔴 AN UNRECOGNISED SHAPE IS A FAILURE, NOT A PASS. `subprocess.run(argv)`
+    # or `subprocess.run([_GITBIN, …])` cannot be read statically, so the walker
+    # cannot say whether it is a git site — and "cannot say" must never render
+    # as compliant. Widen the classifier deliberately, or hoist the literal.
+    assert not unknown, (
+        f"{SCRIPT.name} has subprocess call(s) at line(s) "
+        f"{[ln for ln, _k, _ok in unknown]} whose argv[0] is not a literal, so "
+        f"this guard CANNOT tell whether they invoke git. It refuses to read "
+        f"that as compliant. Either spell argv[0] as a literal, or widen "
+        f"`_classify_subprocess` in the same commit.")
+
+    bad = [ln for ln, _k, ok in git_sites if not ok]
     assert not bad, (
         f"{SCRIPT.name} invokes git at line(s) {bad} with an environment that "
         f"did not come from `_git_env()`. That site does not get the "
@@ -2581,49 +2594,257 @@ def test_every_git_invocation_takes_its_environment_from_git_env():
         f"repository — the whole of clawgate #343.")
 
 
-def _is_git_subprocess(node) -> bool:
-    """`subprocess.run(["git", …], …)` — the shape both git helpers use."""
+_KIND_GIT = "git"
+_KIND_OTHER = "other"
+_KIND_UNRECOGNISED = "unrecognised"
+
+
+def _classify_subprocess(node):
+    """`(lineno, kind, env_ok)` for any `subprocess.*` call, else None.
+
+    🔴 WIDENED AFTER AN AUDIT MEASURED IT NARROWER THAN THE SENTENCE BESIDE IT.
+    The first version matched only `subprocess.run` whose argv[0] was the
+    literal `"git"`, while `backup.py`'s docstring told the next maintainer that
+    EVERY git subprocess in the file is pinned by this test. Two realistic
+    third-site shapes survived a fully green 139-test run:
+
+        subprocess.check_output(["git", "--version"], env=dict(os.environ))
+        subprocess.run([_GITBIN, ...], env=dict(os.environ))
+
+    Both are exactly the "third site added later" this guard exists for. So:
+
+      * ANY attribute on the `subprocess` module counts, not just `run` —
+        `check_output`, `check_call`, `call`, `Popen`, whatever arrives next.
+      * a non-literal argv, or a non-literal argv[0], is `_KIND_UNRECOGNISED`
+        and the caller FAILS on it. A guard that cannot read a call must not
+        report it as fine; that is the same "wider description than
+        implementation" defect one level up.
+      * `env=` is accepted as `_git_env()` or `<module>._git_env()`, because
+        `restore-verify.py` reaches it as `B._git_env()`.
+    """
     import ast
     if not isinstance(node, ast.Call):
-        return False
+        return None
     fn = node.func
-    if not (isinstance(fn, ast.Attribute) and fn.attr == "run"
+    if not (isinstance(fn, ast.Attribute)
             and isinstance(fn.value, ast.Name) and fn.value.id == "subprocess"):
-        return False
-    if not node.args or not isinstance(node.args[0], ast.List):
-        return False
-    elts = node.args[0].elts
-    first = elts[0] if elts else None
-    return isinstance(first, ast.Constant) and first.value == "git"
+        return None
+
+    env_ok = _env_is_git_env(node)
+    if not node.args:
+        return (node.lineno, _KIND_UNRECOGNISED, env_ok)
+    argv = node.args[0]
+    if not isinstance(argv, (ast.List, ast.Tuple)):
+        return (node.lineno, _KIND_UNRECOGNISED, env_ok)
+    if not argv.elts:
+        return (node.lineno, _KIND_UNRECOGNISED, env_ok)
+    first = argv.elts[0]
+    if not isinstance(first, ast.Constant) or not isinstance(first.value, str):
+        return (node.lineno, _KIND_UNRECOGNISED, env_ok)
+    kind = _KIND_GIT if Path(first.value).name == "git" else _KIND_OTHER
+    return (node.lineno, kind, env_ok)
 
 
 def _env_is_git_env(node) -> bool:
+    """`env=_git_env()` or `env=<module>._git_env()`."""
     import ast
     env = {k.arg: k.value for k in node.keywords}.get("env")
-    return (isinstance(env, ast.Call) and isinstance(env.func, ast.Name)
-            and env.func.id == "_git_env")
+    if not isinstance(env, ast.Call):
+        return False
+    f = env.func
+    if isinstance(f, ast.Name):
+        return f.id == "_git_env"
+    return isinstance(f, ast.Attribute) and f.attr == "_git_env"
+
+
+_SEAM_CONTROL_SRC = """
+import subprocess, os
+def _git_env():
+    return {}
+def compliant_run():
+    return subprocess.run(['git', 'status'], env=_git_env())
+def compliant_via_module():
+    return subprocess.run(['git', 'status'], env=B._git_env())
+def compliant_abs_path():
+    return subprocess.run(['/usr/bin/git', 'status'], env=_git_env())
+def offending_run():
+    return subprocess.run(['git', 'log'], env=dict(os.environ))
+def offending_check_output():
+    return subprocess.check_output(['git', '--version'], env=dict(os.environ))
+def offending_popen():
+    return subprocess.Popen(['git', 'fsck'], env=dict(os.environ))
+def not_git():
+    return subprocess.run(['age', '-e'], env=dict(os.environ))
+def unreadable_name():
+    return subprocess.run([_GITBIN, 'log'], env=dict(os.environ))
+def unreadable_argv(argv):
+    return subprocess.run(argv, env=dict(os.environ))
+"""
 
 
 def test_the_git_env_seam_guard_can_go_RED():
-    """Negative control for the walker above: hand it the pre-fix shape and
-    watch it refuse. Without this, "0 bad sites" is indistinguishable from a
-    walker wired to nothing — the reassuring zero RULES.md's positive-control
-    rule is about."""
+    """🔴 NEGATIVE CONTROL, REBUILT AFTER AN AUDIT WALKED THE OLD ONE.
+
+    The previous control fed exactly two shapes — a compliant `subprocess.run`
+    and an offending one — so it proved the walker could tell those two apart
+    and nothing else. An audit then measured two realistic third-site mutants
+    surviving a fully green run: `subprocess.check_output(["git", …])` and
+    `subprocess.run([_GITBIN, …])`. Both are now in the fixture, alongside the
+    module-qualified `env=B._git_env()` that `restore-verify.py` uses and an
+    absolute-path `argv[0]`.
+
+    The unreadable shapes must classify as UNRECOGNISED — not as compliant, and
+    not as non-git. That distinction is the whole point: "I cannot read this"
+    and "this is fine" must not produce the same verdict.
+    """
     import ast
-    tree = ast.parse(
-        "import subprocess, os\n"
-        "def _git_env():\n    return {}\n"
-        "def a():\n"
-        "    return subprocess.run(['git', 'status'], env=_git_env())\n"
-        "def b():\n"
-        "    return subprocess.run(['git', 'log'], env=dict(os.environ))\n"
-        "def c():\n"
-        "    return subprocess.run(['age', '-e'], env=dict(os.environ))\n"
-    )
-    verdicts = [_env_is_git_env(n) for n in ast.walk(tree) if _is_git_subprocess(n)]
-    assert verdicts == [True, False], (
-        f"the seam walker cannot tell the two git shapes apart, or counted the "
-        f"non-git `age` call: {verdicts}")
+    tree = ast.parse(_SEAM_CONTROL_SRC)
+    by_func = {}
+    for fn in [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)]:
+        for n in ast.walk(fn):
+            c = _classify_subprocess(n)
+            if c is not None:
+                by_func[fn.name] = (c[1], c[2])
+
+    assert by_func == {
+        "compliant_run": (_KIND_GIT, True),
+        "compliant_via_module": (_KIND_GIT, True),
+        "compliant_abs_path": (_KIND_GIT, True),
+        "offending_run": (_KIND_GIT, False),
+        "offending_check_output": (_KIND_GIT, False),
+        "offending_popen": (_KIND_GIT, False),
+        "not_git": (_KIND_OTHER, False),
+        "unreadable_name": (_KIND_UNRECOGNISED, False),
+        "unreadable_argv": (_KIND_UNRECOGNISED, False),
+    }, (
+        "the seam walker misclassified one of the shapes it exists to catch:\n"
+        f"{by_func}\n"
+        "Every `offending_*` must be (git, False) so the guard fails on it; "
+        "every `unreadable_*` must be UNRECOGNISED so the guard refuses rather "
+        "than passing it.")
+
+
+def _transplant(root: Path, with_ledger: bool) -> Path:
+    """A copy of `backup.py` at the same depth, with or without `testlib/`.
+
+    Same depth matters: the producer resolves the ledger as
+    `Path(__file__).resolve().parents[1] / "testlib"`, so the copy has to sit
+    one level under a scripts-like root for either outcome to mean anything.
+    """
+    area = root / "analyze-service-index"
+    area.mkdir(parents=True)
+    shutil.copy(SCRIPT, area / SCRIPT.name)
+    if with_ledger:
+        shutil.copytree(SCRIPTS / "testlib", root / "testlib")
+    return area / SCRIPT.name
+
+
+def _bare_env() -> dict:
+    """PATH and HOME only — no PYTHONPATH to smuggle the ledger back in."""
+    return {"PATH": os.environ["PATH"], "HOME": os.environ.get("HOME", "/tmp")}
+
+
+def test_a_MISSING_pointer_ledger_STOPS_the_program(tmp_path):
+    """🔴 THE ONE CLAIM NO OTHER TEST CAN SEE — measured, not asserted.
+
+    `backup.py`'s import banner says the ledger import is "A HARD FAILURE, NEVER
+    A SILENT DEGRADE". An audit measured that replacing the `raise` with
+
+        except ImportError:
+            REPO_POINTER_VARS = ()
+            def strip_repo_pointers(env=None): return {}
+
+    leaves the whole suite GREEN — 139/139. That degrade is precisely the
+    false all-clear this program exists to prevent: a backup that silently
+    re-acquires clawgate #343 and still reports success, on a daily timer,
+    uploading off-box. Every other test here runs where `testlib/` is present,
+    so none of them can distinguish the two.
+
+    So: transplant the producer somewhere the ledger is NOT, and require it to
+    refuse. Paired with `test_the_transplant_control_RUNS_when_the_ledger_is_
+    there`, without which "non-zero exit" could be any other cause.
+    """
+    script = _transplant(tmp_path / "noledger", with_ledger=False)
+    p = subprocess.run([sys.executable, str(script), "--print-plan"],
+                       capture_output=True, text=True, env=_bare_env())
+
+    assert p.returncode != 0, (
+        "backup.py STARTED with no repo-pointer ledger reachable. The import "
+        "degraded instead of raising, so this run has no strip at all and would "
+        "bundle and upload whatever a leaked GIT_DIR pointed it at — while "
+        f"reporting success.\nstdout:\n{p.stdout[-800:]}")
+    assert "cannot import the git repo-pointer ledger" in p.stderr, (
+        f"it failed, but not with the message that tells an operator WHY — so "
+        f"the failure is indistinguishable from an unrelated crash:\n"
+        f"{p.stderr[-1200:]}")
+
+
+def test_the_transplant_control_RUNS_when_the_ledger_is_there(tmp_path):
+    """The other half of the pair, and it is not optional.
+
+    A transplanted copy could exit non-zero for a dozen reasons that have
+    nothing to do with the ledger — a missing sibling, a bad path, an unrelated
+    import. Unless the SAME transplant with `testlib/` present exits 0, the test
+    above is measuring the transplant, not the guard.
+    """
+    script = _transplant(tmp_path / "withledger", with_ledger=True)
+    p = subprocess.run([sys.executable, str(script), "--print-plan"],
+                       capture_output=True, text=True, env=_bare_env())
+    assert p.returncode == 0, (
+        f"the transplant itself is broken, so the missing-ledger test above "
+        f"proves nothing:\nstderr:\n{p.stderr[-1200:]}")
+    assert "remote:    NONE" in p.stdout, p.stdout[:400]
+
+
+def test_the_announcement_is_ONCE_PER_NAME_not_once_per_git_call(leak_bed):
+    """🟢 The dedupe is a claim in the docstring, so it gets a pin.
+
+    A full run calls `_git_env()` many times per scope (`rev-list`, `bundle
+    create`, `bundle verify`, the rehearsal clone, `for-each-ref`), so a missing
+    `continue` turns one useful line into a wall that buries the backup's own
+    output. Measured across a SUBPROCESS boundary on purpose —
+    `_POINTERS_ANNOUNCED` is process-global and never reset, so an in-process
+    assertion would depend on which test ran first.
+    """
+    p = _run_isolated(leak_bed["store"], leak_bed["work"], leak_bed["home"],
+                      leak_bed["identity"],
+                      leak={"GIT_DIR": str(leak_bed["decoy"] / ".git")})
+    assert p.returncode == 0, p.stderr
+    n = p.stderr.count("STRIPPED GIT_DIR=")
+    assert n == 1, (
+        f"the leak was announced {n} times in one run; it must be once per "
+        f"variable. `_git_env()` is rebuilt for every git invocation, so a "
+        f"per-call line buries the run's own output.")
+
+
+def test_the_announcement_names_the_PROGRAM_THAT_IS_RUNNING(monkeypatch):
+    """🟢 `_git_env()` is SHARED — `restore-verify.py` calls it directly.
+
+    Hardcoding `PROG` announced a leak hit during a restore VERIFICATION under
+    the BACKUP's name, pointing whoever read the journal at the wrong program
+    and the wrong systemd unit.
+
+    Snapshot/restore `_POINTERS_ANNOUNCED` because it is process-global by
+    design; see its note in the producer.
+    """
+    saved = set(B._POINTERS_ANNOUNCED)
+    try:
+        B._POINTERS_ANNOUNCED.clear()
+        monkeypatch.setattr(sys, "argv", ["/somewhere/restore-verify.py", "--x"])
+        import io
+        import contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            B._announce_stripped_pointers({"GIT_DIR": "/tmp/foreign/x"})
+        out = buf.getvalue()
+        assert out.startswith("restore-verify.py: STRIPPED GIT_DIR="), (
+            f"the announcement does not name the running program: {out!r}")
+        assert B.PROG not in out, (
+            f"the announcement still hardcodes the BACKUP's name while "
+            f"restore-verify.py is what ran: {out!r}")
+    finally:
+        B._POINTERS_ANNOUNCED.clear()
+        B._POINTERS_ANNOUNCED.update(saved)
 
 
 def test_scope_remotes_has_no_production_call_site():
@@ -2634,17 +2855,47 @@ def test_scope_remotes_has_no_production_call_site():
     stops a future reader citing it as the control that ENFORCES the no-remote
     invariant when it enforces nothing. Wire it in and this goes red, which is
     the point: the docstring has to change in the same commit.
+
+    🔴 SCANS EVERY PRODUCTION MODULE IN THE DIRECTORY, not just `backup.py`.
+    An audit noted the first version parsed one file while the docstring it
+    protects makes an UNQUALIFIED claim ("there is no production call site").
+    `restore-verify.py` imports `backup` as `B`, so `B.scope_remotes(scope)`
+    there would be a production call the narrow version could not see — the
+    same "description wider than the implementation" defect the guard exists to
+    prevent, one level up. Both the bare name and any attribute access on it
+    count. Derived from the directory at scan time, so a third program is
+    covered the day it appears.
     """
     import ast
-    tree = ast.parse(SCRIPT.read_text(encoding="utf-8"))
-    defs = [n for n in ast.walk(tree)
-            if isinstance(n, ast.FunctionDef) and n.name == "scope_remotes"]
-    assert len(defs) == 1, f"expected exactly one definition, found {len(defs)}"
-    calls = [n.lineno for n in ast.walk(tree)
-             if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
-             and n.func.id == "scope_remotes"]
+    modules = sorted((SCRIPTS / "analyze-service-index").glob("*.py"))
+    assert len(modules) >= 2, (
+        f"the production-module sweep found {len(modules)} file(s) in "
+        f"scripts/analyze-service-index/; it must see at least backup.py and "
+        f"restore-verify.py, or this scan is vacuous: "
+        f"{[m.name for m in modules]}")
+    assert {m.name for m in modules} >= {"backup.py", "restore-verify.py"}, (
+        f"{[m.name for m in modules]} — the two known producers must both be in "
+        f"the swept set")
+
+    defs, calls = [], []
+    for mod in modules:
+        tree = ast.parse(mod.read_text(encoding="utf-8"))
+        for n in ast.walk(tree):
+            if isinstance(n, ast.FunctionDef) and n.name == "scope_remotes":
+                defs.append(f"{mod.name}:{n.lineno}")
+            if not isinstance(n, ast.Call):
+                continue
+            f = n.func
+            named = ((isinstance(f, ast.Name) and f.id == "scope_remotes")
+                     or (isinstance(f, ast.Attribute) and f.attr == "scope_remotes"))
+            if named:
+                calls.append(f"{mod.name}:{n.lineno}")
+
+    assert len(defs) == 1 and defs[0].startswith("backup.py:"), (
+        f"expected exactly one `scope_remotes` definition, in backup.py; "
+        f"found {defs}")
     assert not calls, (
-        f"scope_remotes() now HAS a production call site (line(s) {calls}). Its "
+        f"scope_remotes() now HAS a production call site ({calls}). Its "
         f"docstring says it has none and that no future reader may cite it as a "
         f"run-path control. Update that docstring in this commit — and note "
         f"that a post-hoc no-remote assertion on the run path would be "

--- a/scripts/tests/test_analyze_service_index_backup.py
+++ b/scripts/tests/test_analyze_service_index_backup.py
@@ -2109,3 +2109,604 @@ def test_the_producer_reuses_the_mail_actions_minio_helper():
     assert "from _minio import MinioArchive" in src
     assert "mail-actions" in src
     assert (SCRIPTS / "mail-actions" / "_minio.py").is_file()
+
+
+# --------------------------------------------------------------------------- #
+# 12. 🔴 WHICH REPOSITORY — a leaked git repo-pointer must not aim this
+#     program, which HAS A NETWORK, at a foreign repository (clawgate #343)
+# --------------------------------------------------------------------------- #
+#
+# THE MECHANISM. Every git call in backup.py is `git -C <scope> …`, and `-C` is
+# the weakest possible claim about where a command lands: GIT_DIR OVERRIDES IT.
+# The pre-fix `_git_env()` built from `dict(os.environ)` and added five config
+# keys, stripping none of the repo-pointer family.
+#
+# MEASURED 2026-08-23, git 2.55.0, driving the real CLI end to end
+# (`--no-upload --work-dir`) under the systemd unit's own environment SHAPE
+# (`env -i` plus PATH/HOME/SOPS_AGE_KEY_FILE/ASIB_HOST — NOT the operator's
+# shell, whose GIT_AUTHOR_* would fix a dimension the unit does not have), on
+# the pre-fix tree at d7d682f0. One variable at a time, exit code included:
+#
+#   VARIABLE                          rc   the BUNDLE declared        decoy
+#   ------------------------------------------------------------------------
+#   (control: no leak)                 0   refs/heads/trunk           identical
+#   GIT_DIR                            0   refs/heads/foreign-branch  identical  <- EXFILTRATION
+#   GIT_WORK_TREE                      0   refs/heads/trunk           identical
+#   GIT_COMMON_DIR                     1   (no bundle: rev-list 128)  identical
+#   GIT_INDEX_FILE                     0   refs/heads/trunk           identical
+#   GIT_OBJECT_DIRECTORY               1   (no bundle: rev-list 128)  identical
+#   GIT_ALTERNATE_OBJECT_DIRECTORIES   0   refs/heads/trunk           identical
+#   GIT_NAMESPACE                      0   refs/heads/trunk           identical
+#   GIT_PREFIX                         0   refs/heads/trunk           identical
+#   GIT_GRAFT_FILE                     0   refs/heads/trunk           identical
+#   GIT_SHALLOW_FILE                   0   refs/heads/trunk           identical
+#   GIT_CONFIG                         0   refs/heads/trunk           identical
+#
+# 🔴 EVERY ROW WAS RUN, exit code included. #721 shipped a table row claiming
+# `rc 0` where the truth was `rc 1`, because its probe exported GIT_AUTHOR_*.
+#
+# 🔴 READ THE SECOND COLUMN, NOT THE THIRD. The exfiltration signature is a
+# bundle full of the WRONG repository's refs while the foreign repo sits there
+# byte-identical — a read-only theft leaves nothing behind. A test that only
+# asserted "the decoy did not move" would have called the GIT_DIR row clean.
+#
+# 🔴 AND THE RESTORE REHEARSAL IN `bundle_scope` CANNOT CATCH IT: `want_names`
+# is read with `_git(scope, "for-each-ref")`, through the same poisoned
+# environment, so both sides report the decoy's refs and agree. rc=0, "verified".
+# That is a second sample of the unknown, not a control. Independently
+# re-measured here (card criterion 1) — the audit's two reported claims HOLD.
+#
+# The fix is the `strip_repo_pointers()` call in `_git_env()`, using the ledger
+# `testlib/gitenv.py` OWNS. Post-fix every row above is rc=0 / refs/heads/trunk,
+# including the two that used to fail outright.
+
+# 🔴 PARAMETRISED FROM THE LEDGER'S OWNER, NOT FROM `B`. Importing it here
+# rather than reading `B.REPO_POINTER_VARS` is what lets these tests COLLECT
+# against the pre-fix producer, where that attribute does not exist: parametrise
+# off `B` and the whole section dies at collection with an AttributeError, which
+# is red for an earlier check's reason and proves nothing about the guard
+# (claude/RULES.md → "prove it REACHABLE, not just breakable"). Whether the
+# producer uses this same object is a SEPARATE assertion, below.
+from testlib.gitenv import REPO_POINTER_VARS as _LEDGER  # noqa: E402
+
+_POINTER_VERDICTS: dict[str, str] = {
+    # name                             -> what the PRE-FIX tree did with it
+    "GIT_DIR": "spoofed: the bundle carried the DECOY's refs at rc=0",
+    "GIT_WORK_TREE": "no effect: the scope's own refs, rc=0",
+    "GIT_COMMON_DIR": "broke the run: rev-list rc=128, no bundle, rc=1",
+    "GIT_INDEX_FILE": "no effect: the scope's own refs, rc=0",
+    "GIT_OBJECT_DIRECTORY": "broke the run: rev-list rc=128, no bundle, rc=1",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES": "no effect: the scope's own refs, rc=0",
+    "GIT_NAMESPACE": "no effect: the scope's own refs, rc=0",
+    "GIT_PREFIX": "no effect: the scope's own refs, rc=0",
+    "GIT_GRAFT_FILE": "no effect: the scope's own refs, rc=0",
+    "GIT_SHALLOW_FILE": "no effect: the scope's own refs, rc=0",
+    "GIT_CONFIG": "no effect: the scope's own refs, rc=0",
+}
+
+# The pre-fix rows that are REGRESSION coverage rather than invariant guards:
+# these are the parametrisations watched RED at d7d682f0. The rest are labelled
+# invariant guards below and are NOT counted as regression coverage.
+_RED_AT_BASE_SECURITY = ("GIT_DIR",)
+_RED_AT_BASE_AVAILABILITY = ("GIT_COMMON_DIR", "GIT_OBJECT_DIRECTORY")
+
+
+def _leak_value(var: str, decoy: Path) -> str:
+    """A REALISTIC value for `var` that aims git at `decoy`.
+
+    Realistic, not a textbook fixture: each is what the variable would actually
+    hold if it had leaked out of a session working in that repository.
+    """
+    return {
+        "GIT_DIR": str(decoy / ".git"),
+        "GIT_WORK_TREE": str(decoy),
+        "GIT_COMMON_DIR": str(decoy / ".git"),
+        "GIT_INDEX_FILE": str(decoy / ".git" / "index"),
+        "GIT_OBJECT_DIRECTORY": str(decoy / ".git" / "objects"),
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES": str(decoy / ".git" / "objects"),
+        "GIT_NAMESPACE": "foreignns",
+        "GIT_PREFIX": "sub/",
+        "GIT_GRAFT_FILE": str(decoy / ".git" / "info" / "grafts"),
+        "GIT_SHALLOW_FILE": str(decoy / ".git" / "shallow"),
+        "GIT_CONFIG": str(decoy / ".git" / "config"),
+    }[var]
+
+
+def _git_dir_fingerprint(git_dir: Path) -> dict[str, str]:
+    """sha256 of EVERY file under a git dir — `objects/` INCLUDED.
+
+    🔴 `objects/` IS THE POINT. #721's foreign-repo fingerprint omitted it, and
+    that blindness produced a confident, wrong "harmless" verdict for
+    GIT_OBJECT_DIRECTORY — the variable that decides where NEW OBJECTS ARE
+    WRITTEN, i.e. the one whose whole damage class lives in the directory the
+    fingerprint could not see. Walking the entire git dir covers `objects/`,
+    `refs/`, `HEAD`, `config`, `logs/` and `index` by construction, and covers
+    whatever git grows next without anyone remembering to add it.
+    """
+    out: dict[str, str] = {}
+    for dirpath, _dirs, files in os.walk(git_dir):
+        for name in files:
+            p = Path(dirpath) / name
+            rel = p.relative_to(git_dir).as_posix()
+            try:
+                out[rel] = hashlib.sha256(p.read_bytes()).hexdigest()
+            except OSError as exc:  # unreadable is a CHANGE we must not hide
+                out[rel] = f"<unreadable {exc.__class__.__name__}>"
+    return out
+
+
+def test_the_foreign_fingerprint_covers_the_categories_it_CLAIMS(tmp_path):
+    """🔴 VALIDATE THE INSTRUMENT BEFORE READING ITS VERDICT.
+
+    A fingerprint helper that walked nothing would return `{}` and make every
+    byte-identity assertion below pass vacuously — and one that walked only refs
+    would report "harmless" for an object-store write, which is exactly the
+    blind spot this section exists to not repeat. So: it must SEE `objects/`,
+    `refs/`, `HEAD`, `config`, `logs/` and `index`, and it must MOVE when each
+    of those changes.
+    """
+    repo = _make_scope(tmp_path / "store", "probe", {"a.md": "x"})
+    git_dir = repo / ".git"
+
+    fp = _git_dir_fingerprint(git_dir)
+    assert fp, "the fingerprint walked nothing — every comparison below is vacuous"
+    for needed, why in (
+        ("objects/", "#721's blind spot: where GIT_OBJECT_DIRECTORY writes"),
+        ("refs/", "where a branch lands"),
+        ("HEAD", "which branch the repo is on"),
+        ("config", "the incident's config damage"),
+        ("logs/", "the reflog"),
+        ("index", "what a stage writes"),
+    ):
+        assert any(k == needed or k.startswith(needed) for k in fp), (
+            f"the fingerprint does not cover {needed!r} — {why}. Present: "
+            f"{sorted(fp)[:20]}")
+
+    def moved(before, after):
+        return sorted(k for k in set(before) | set(after)
+                      if before.get(k) != after.get(k))
+
+    # POSITIVE CONTROL, per category: watch the fingerprint move for each one.
+    before = _git_dir_fingerprint(git_dir)
+    (repo / "b.md").write_text("new\n", encoding="utf-8")
+    _git_run(repo, "add", "b.md")
+    _git_run(repo, "commit", "-q", "-m", "second")
+    delta = moved(before, _git_dir_fingerprint(git_dir))
+    assert any(k.startswith("objects/") for k in delta), (
+        f"a real commit wrote no object the fingerprint could see: {delta}")
+    assert any(k.startswith("refs/") or k == "packed-refs" for k in delta), delta
+    assert any(k.startswith("logs/") for k in delta), delta
+    assert "index" in delta, delta
+
+    before = _git_dir_fingerprint(git_dir)
+    _git_run(repo, "config", "user.name", "mutated")
+    assert "config" in moved(before, _git_dir_fingerprint(git_dir))
+
+    before = _git_dir_fingerprint(git_dir)
+    _git_run(repo, "symbolic-ref", "HEAD", "refs/heads/elsewhere")
+    assert "HEAD" in moved(before, _git_dir_fingerprint(git_dir))
+
+
+def _unit_shaped_env(home: Path, identity: Path) -> dict:
+    """The systemd unit's environment SHAPE, not the operator's shell.
+
+    🔴 `env -i` plus exactly what nix/home.nix sets: PATH, HOME, the age key
+    handle, ASIB_HOST. NOT `dict(os.environ)`. #721 shipped a measured table row
+    with the wrong exit code because its probe exported
+    GIT_AUTHOR_*/GIT_COMMITTER_*, fixing a dimension the unit does not have — a
+    probe built from the harness's own environment measures the harness.
+    """
+    return {
+        "PATH": os.environ["PATH"],
+        "HOME": str(home),
+        "SOPS_AGE_KEY_FILE": str(identity),
+        "ASIB_HOST": "synthetic-host",
+    }
+
+
+def _run_isolated(store: Path, work: Path, home: Path, identity: Path,
+                  leak: dict | None = None) -> subprocess.CompletedProcess:
+    env = _unit_shaped_env(home, identity)
+    env.update(leak or {})
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--store", str(store),
+         "--no-upload", "--work-dir", str(work)],
+        capture_output=True, text=True, env=env)
+
+
+def _bundle_heads_cleanly(bundle: Path, home: Path) -> list[str]:
+    """`git bundle list-heads`, read with an environment WITHOUT the leak.
+
+    🔴 The artifact must be inspected through a channel the leaked variable does
+    not touch. Reading it back through the same poisoned environment is the
+    mistake `bundle_scope`'s own cross-check makes — a second sample of the
+    unknown, which is why that check reports "verified" over a foreign bundle.
+    """
+    p = subprocess.run(
+        [GIT, "bundle", "list-heads", str(bundle)],
+        capture_output=True, text=True,
+        env={"PATH": os.environ["PATH"], "HOME": str(home)})
+    assert p.returncode == 0, f"git bundle list-heads rc={p.returncode}: {p.stderr}"
+    return [ln.strip() for ln in p.stdout.splitlines() if ln.strip()]
+
+
+@pytest.fixture()
+def leak_bed(tmp_path, identity):
+    """A scope to back up, a DECOY repository to try to steal, and a fake HOME."""
+    home = tmp_path / "home"
+    home.mkdir()
+    store = tmp_path / "store"
+    scope = _make_scope(store, "some-scope", {"NOTES.md": "scope content"})
+
+    decoy = tmp_path / "decoy"
+    decoy.mkdir()
+    subprocess.run([GIT, "init", "-q", "-b", "foreign-branch", str(decoy)],
+                   check=True, capture_output=True, env=_git_env())
+    (decoy / "SECRET.md").write_text("foreign secret content\n", encoding="utf-8")
+    _git_run(decoy, "add", "SECRET.md")
+    _git_run(decoy, "commit", "-q", "-m", "foreign secret commit")
+
+    return {"home": home, "store": store, "scope": scope, "decoy": decoy,
+            "work": tmp_path / "work", "identity": identity}
+
+
+def test_the_leak_bed_really_builds_two_DIFFERENT_repositories(leak_bed):
+    """Positive control for the fixture. If the decoy shared the scope's refs,
+    every "did the bundle carry the decoy's refs" assertion below would be
+    unable to tell the two apart and would pass no matter what."""
+    scope_refs = set(_git_run(leak_bed["scope"], "for-each-ref",
+                              "--format=%(refname)").stdout.split())
+    decoy_refs = set(_git_run(leak_bed["decoy"], "for-each-ref",
+                              "--format=%(refname)").stdout.split())
+    assert scope_refs == {"refs/heads/trunk"}, scope_refs
+    assert decoy_refs == {"refs/heads/foreign-branch"}, decoy_refs
+    assert scope_refs.isdisjoint(decoy_refs)
+
+
+def test_a_clean_run_bundles_the_SCOPE(leak_bed):
+    """The control the parametrised tests below are read against. Without it a
+    green row cannot distinguish "the strip worked" from "the run never produced
+    a bundle at all"."""
+    p = _run_isolated(leak_bed["store"], leak_bed["work"],
+                      leak_bed["home"], leak_bed["identity"])
+    assert p.returncode == 0, f"control run failed rc={p.returncode}: {p.stderr}"
+    cipher = leak_bed["work"] / "some-scope.bundle.age"
+    assert cipher.is_file(), "the control run produced no artifact"
+    plain = leak_bed["work"] / "readback.bundle"
+    d = _decrypt(cipher.read_bytes(), leak_bed["identity"], plain)
+    assert d.returncode == 0, d.stderr
+    heads = _bundle_heads_cleanly(plain, leak_bed["home"])
+    assert any("refs/heads/trunk" in h for h in heads), heads
+    assert not any("foreign" in h for h in heads), heads
+
+
+@pytest.mark.parametrize("var", _LEDGER)
+def test_a_leaked_pointer_cannot_aim_the_backup_at_a_FOREIGN_repository(leak_bed, var):
+    """🔴 THE REGRESSION TEST. Red at d7d682f0 for GIT_DIR; green at HEAD.
+
+    Two claims, and the second is the one a foreign-repo-unchanged assertion
+    alone would miss:
+
+      1. the DECOY is byte-identical afterwards, `objects/` INCLUDED, and
+      2. the BUNDLE — the thing that gets encrypted and UPLOADED OFF-BOX —
+         declares the SCOPE's refs and none of the decoy's.
+
+    Claim 2 is the exfiltration signature. On the pre-fix tree with GIT_DIR
+    leaked the run exited 0, the decoy was untouched, `bundle_scope`'s restore
+    rehearsal passed, and the artifact was a complete copy of the decoy.
+
+    Rows other than GIT_DIR / GIT_COMMON_DIR / GIT_OBJECT_DIRECTORY were already
+    green at d7d682f0 — see `_POINTER_VERDICTS`. Those parametrisations are
+    INVARIANT GUARDS, not regression coverage, and they are here because "no
+    effect on this program today" is a measurement with a date on it, not a
+    property.
+    """
+    before = _git_dir_fingerprint(leak_bed["decoy"] / ".git")
+
+    p = _run_isolated(leak_bed["store"], leak_bed["work"], leak_bed["home"],
+                      leak_bed["identity"],
+                      leak={var: _leak_value(var, leak_bed["decoy"])})
+
+    cipher = leak_bed["work"] / "some-scope.bundle.age"
+    if p.returncode != 0:
+        # "Refuses" is an acceptable outcome per the card — but it must not have
+        # left an artifact behind that something downstream could upload.
+        assert not cipher.is_file(), (
+            f"{var}: the run FAILED (rc={p.returncode}) but still left an "
+            f"encrypted artifact behind: {cipher}")
+    else:
+        assert cipher.is_file(), f"{var}: rc=0 but no artifact: {p.stdout}\n{p.stderr}"
+        plain = leak_bed["work"] / "readback.bundle"
+        d = _decrypt(cipher.read_bytes(), leak_bed["identity"], plain)
+        assert d.returncode == 0, f"{var}: could not decrypt the artifact: {d.stderr}"
+        heads = _bundle_heads_cleanly(plain, leak_bed["home"])
+        assert heads, f"{var}: the artifact declares no heads at all"
+        assert not any("foreign" in h for h in heads), (
+            f"🔴 {var} AIMED THE BACKUP AT THE DECOY. The artifact that gets "
+            f"encrypted and uploaded declares the FOREIGN repository's refs: "
+            f"{heads}. This program has no PrivateNetwork and uploads what it "
+            f"bundles to MinIO, so this is content exfiltration, not local "
+            f"corruption. `git -C <scope>` does not win against a repo pointer "
+            f"— `_git_env()` must strip "
+            f"`testlib/gitenv.py::REPO_POINTER_VARS`.")
+        assert any("refs/heads/trunk" in h for h in heads), (
+            f"{var}: the artifact does not carry the SCOPE's own branch: {heads}")
+
+    after = _git_dir_fingerprint(leak_bed["decoy"] / ".git")
+    moved = sorted(k for k in set(before) | set(after) if before.get(k) != after.get(k))
+    assert not moved, (
+        f"🔴 {var} let the backup WRITE INTO the foreign repository. Paths that "
+        f"changed under {leak_bed['decoy'] / '.git'} ({len(moved)}, of which "
+        f"{sum(1 for k in moved if k.startswith('objects/'))} under objects/): "
+        f"{moved[:20]}")
+
+
+@pytest.mark.parametrize("var", _LEDGER)
+def test_a_leaked_pointer_does_not_BREAK_the_backup(leak_bed, var):
+    """The availability half. Red at d7d682f0 for GIT_COMMON_DIR and
+    GIT_OBJECT_DIRECTORY (both `rev-list` rc=128, so the run exited 1).
+
+    Refusing is safe, but a backup that refuses is a backup that does not exist,
+    and this one runs unattended on a daily timer behind an `OnFailure` toast.
+    Stripping the pointers makes the run correct AND available; the card's
+    "refuses or operates on the scope" is the floor, this is the standard.
+    """
+    p = _run_isolated(leak_bed["store"], leak_bed["work"], leak_bed["home"],
+                      leak_bed["identity"],
+                      leak={var: _leak_value(var, leak_bed["decoy"])})
+    assert p.returncode == 0, (
+        f"{var} broke the backup (rc={p.returncode}). A leaked pointer must be "
+        f"neutralised, not survived-by-failing:\n{p.stderr[-1500:]}")
+    assert (leak_bed["work"] / "some-scope.bundle.age").is_file()
+
+
+def test_the_leak_is_ANNOUNCED_so_the_broken_caller_gets_fixed(leak_bed):
+    """The strip fixes THIS program; it does not fix whoever exported the
+    variable. Saying so in the journal is the only thing that does."""
+    p = _run_isolated(leak_bed["store"], leak_bed["work"], leak_bed["home"],
+                      leak_bed["identity"],
+                      leak={"GIT_DIR": str(leak_bed["decoy"] / ".git")})
+    assert p.returncode == 0, p.stderr
+    assert "STRIPPED GIT_DIR=" in p.stderr, (
+        f"the run neutralised a leaked GIT_DIR silently:\n{p.stderr}")
+
+
+def test_a_clean_run_announces_NOTHING(leak_bed):
+    """The other half of the pair. A message printed unconditionally is not a
+    signal, and would train the operator to ignore the one that matters."""
+    p = _run_isolated(leak_bed["store"], leak_bed["work"],
+                      leak_bed["home"], leak_bed["identity"])
+    assert p.returncode == 0, p.stderr
+    assert "STRIPPED" not in p.stderr, p.stderr
+
+
+# --------------------------------------------------------------------------- #
+# 12b. the LEDGER: one owner, no second spelling
+# --------------------------------------------------------------------------- #
+def test_the_producer_uses_the_SHARED_ledger_object_itself():
+    """🔴 ONE RULE, ONE PLACE — and here it can be an identity check.
+
+    `commit.sh` has to RE-SPELL the ledger as a bash array (bash cannot import)
+    and is pinned two-way by `test_git_repo_isolation.py`. backup.py is Python,
+    so it uses the owner's object directly: there is no copy, so there is
+    nothing to drift, and a name added to `testlib/gitenv.py` reaches this
+    program with no edit here at all.
+    """
+    from testlib import gitenv
+    assert getattr(B, "REPO_POINTER_VARS", None) is gitenv.REPO_POINTER_VARS, (
+        "backup.py is not using testlib/gitenv.py's ledger OBJECT. Either it "
+        "does not import it at all (the pre-fix shape: `_git_env()` built from "
+        "`dict(os.environ)` and stripped nothing), or it re-spells the names — "
+        "and a second spelling can drift from the owner, which is the failure "
+        "this pins.")
+    assert getattr(B, "strip_repo_pointers", None) is gitenv.strip_repo_pointers, (
+        "backup.py does not use the owner's `strip_repo_pointers`; a local "
+        "re-implementation is a second place for the fix to be wrong.")
+
+
+def test_the_measured_table_covers_every_ledger_name():
+    """Two-way pin. A name added to `REPO_POINTER_VARS` with no measured verdict
+    here is a name nobody ran against this program; a verdict for a name that
+    left the ledger is a claim about something no longer stripped."""
+    assert set(_POINTER_VERDICTS) == set(_LEDGER), (
+        f"the measured table and the ledger disagree:\n"
+        f"  measured but not on the ledger: "
+        f"{sorted(set(_POINTER_VERDICTS) - set(_LEDGER))}\n"
+        f"  on the ledger but never measured: "
+        f"{sorted(set(_LEDGER) - set(_POINTER_VERDICTS))}\n"
+        "Run it — do not infer the row. #721 shipped a row claiming rc 0 where "
+        "the truth was rc 1.")
+    for var in _RED_AT_BASE_SECURITY + _RED_AT_BASE_AVAILABILITY:
+        assert var in _LEDGER, var
+    # And every name must have a leak value, or its parametrisation is vacuous.
+    for var in _LEDGER:
+        assert _leak_value(var, Path("/nonexistent/decoy")), var
+
+
+def test_the_git_environment_strips_every_pointer_on_the_ledger(monkeypatch):
+    """The unit-level assertion the mutation sweep is read against.
+
+    Ledger-driven, so it grows and shrinks with `REPO_POINTER_VARS` instead of
+    pinning a hand-typed list that could quietly cover fewer names than the
+    docstring claims.
+    """
+    for name in _LEDGER:
+        monkeypatch.setenv(name, f"/tmp/foreign/{name}")
+    env = B._git_env()
+    still = sorted(n for n in _LEDGER if n in env)
+    assert not still, (
+        f"_git_env() passed {still} straight through to git. Each of these "
+        f"decides WHICH repository a command lands in and OVERRIDES `git -C`.")
+    # The config half must survive the strip — the two sets are disjoint.
+    assert env["GIT_OPTIONAL_LOCKS"] == "0"
+    assert env["GIT_CONFIG_NOSYSTEM"] == "1"
+    assert env["GIT_CONFIG_GLOBAL"] == os.devnull
+    assert env["GIT_CONFIG_SYSTEM"] == os.devnull
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
+
+
+def test_the_strip_does_not_mutate_the_CALLERS_environment(monkeypatch):
+    """`strip_repo_pointers()` mutates what it is handed. It is handed a COPY
+    here; handing it `os.environ` would make one `_git_env()` call silently
+    reshape the whole process, which is a behaviour change nobody asked for."""
+    monkeypatch.setenv("GIT_DIR", "/tmp/foreign/x")
+    B._git_env()
+    assert os.environ.get("GIT_DIR") == "/tmp/foreign/x"
+
+
+def test_every_git_invocation_takes_its_environment_from_git_env():
+    """🔴 A SEAM GUARD: it pins the RELATIONSHIP, not one function.
+
+    `_git` and `_git_scratch` are two separate `subprocess.run` sites and both
+    must inherit the strip. The failure this closes is a THIRD site added later
+    that builds `dict(os.environ)` itself — which is exactly the shape the bug
+    had. Walking the AST rather than grepping, because a grep for `_git_env`
+    would be satisfied by the two that already exist while a new one sat beside
+    them.
+    """
+    import ast
+    tree = ast.parse(SCRIPT.read_text(encoding="utf-8"))
+    git_sites = [(node.lineno, _env_is_git_env(node))
+                 for node in ast.walk(tree) if _is_git_subprocess(node)]
+
+    assert len(git_sites) >= 2, (
+        f"the AST walk found {len(git_sites)} git subprocess site(s) in "
+        f"{SCRIPT.name}; it should see at least `_git` and `_git_scratch`. A "
+        f"walker that finds nothing would make this pass vacuously.")
+    bad = [ln for ln, ok in git_sites if not ok]
+    assert not bad, (
+        f"{SCRIPT.name} invokes git at line(s) {bad} with an environment that "
+        f"did not come from `_git_env()`. That site does not get the "
+        f"repo-pointer strip, so a leaked GIT_DIR aims it at a foreign "
+        f"repository — the whole of clawgate #343.")
+
+
+def _is_git_subprocess(node) -> bool:
+    """`subprocess.run(["git", …], …)` — the shape both git helpers use."""
+    import ast
+    if not isinstance(node, ast.Call):
+        return False
+    fn = node.func
+    if not (isinstance(fn, ast.Attribute) and fn.attr == "run"
+            and isinstance(fn.value, ast.Name) and fn.value.id == "subprocess"):
+        return False
+    if not node.args or not isinstance(node.args[0], ast.List):
+        return False
+    elts = node.args[0].elts
+    first = elts[0] if elts else None
+    return isinstance(first, ast.Constant) and first.value == "git"
+
+
+def _env_is_git_env(node) -> bool:
+    import ast
+    env = {k.arg: k.value for k in node.keywords}.get("env")
+    return (isinstance(env, ast.Call) and isinstance(env.func, ast.Name)
+            and env.func.id == "_git_env")
+
+
+def test_the_git_env_seam_guard_can_go_RED():
+    """Negative control for the walker above: hand it the pre-fix shape and
+    watch it refuse. Without this, "0 bad sites" is indistinguishable from a
+    walker wired to nothing — the reassuring zero RULES.md's positive-control
+    rule is about."""
+    import ast
+    tree = ast.parse(
+        "import subprocess, os\n"
+        "def _git_env():\n    return {}\n"
+        "def a():\n"
+        "    return subprocess.run(['git', 'status'], env=_git_env())\n"
+        "def b():\n"
+        "    return subprocess.run(['git', 'log'], env=dict(os.environ))\n"
+        "def c():\n"
+        "    return subprocess.run(['age', '-e'], env=dict(os.environ))\n"
+    )
+    verdicts = [_env_is_git_env(n) for n in ast.walk(tree) if _is_git_subprocess(n)]
+    assert verdicts == [True, False], (
+        f"the seam walker cannot tell the two git shapes apart, or counted the "
+        f"non-git `age` call: {verdicts}")
+
+
+def test_scope_remotes_has_no_production_call_site():
+    """Card criterion 7, machine-checked in BOTH directions.
+
+    `scope_remotes()` is called by the test suite only. Its docstring says so;
+    this is what stops that sentence from quietly becoming false — and what
+    stops a future reader citing it as the control that ENFORCES the no-remote
+    invariant when it enforces nothing. Wire it in and this goes red, which is
+    the point: the docstring has to change in the same commit.
+    """
+    import ast
+    tree = ast.parse(SCRIPT.read_text(encoding="utf-8"))
+    defs = [n for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef) and n.name == "scope_remotes"]
+    assert len(defs) == 1, f"expected exactly one definition, found {len(defs)}"
+    calls = [n.lineno for n in ast.walk(tree)
+             if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+             and n.func.id == "scope_remotes"]
+    assert not calls, (
+        f"scope_remotes() now HAS a production call site (line(s) {calls}). Its "
+        f"docstring says it has none and that no future reader may cite it as a "
+        f"run-path control. Update that docstring in this commit — and note "
+        f"that a post-hoc no-remote assertion on the run path would be "
+        f"UNREACHABLE, since nothing in this program can add a remote.")
+    src = SCRIPT.read_text(encoding="utf-8")
+    assert "TEST-ONLY" in src and "NO PRODUCTION CALL SITE" in src, (
+        "the dead-code status is no longer stated where a reader lands")
+
+
+def test_the_unit_can_actually_reach_the_pointer_ledger_at_runtime():
+    """🔴 THE IMPORT IS A NEW RUNTIME DEPENDENCY, so the sandbox must contain it.
+
+    backup.py imports `testlib/gitenv.py`, and the unit runs under
+    `ProtectSystem=strict` + `ProtectHome=tmpfs` — the ledger is reachable ONLY
+    because `BindReadOnlyPaths` mounts the whole `scripts/` tree. If someone
+    narrows that mount to `scripts/analyze-service-index`, the import raises and
+    the backup stops. Loudly, by design — but this says so before it happens.
+    """
+    ledger = SCRIPTS / "testlib" / "gitenv.py"
+    assert ledger.is_file(), f"{ledger} is missing — backup.py imports it"
+    binds = _containment_directives(_backup_block())["BindReadOnlyPaths"]
+    assert '"%h/workspace/devrc/scripts"' in binds, (
+        f"the backup unit no longer mounts the whole `scripts/` tree: {binds}. "
+        f"backup.py imports its repo-pointer ledger from "
+        f"`scripts/testlib/gitenv.py`; without that mount the unit cannot even "
+        f"import, and the daily backup stops.")
+
+
+def test_the_docstring_no_longer_claims_more_than_the_code_does():
+    """Card criterion 6. The old wording — "makes git structurally incapable of
+    writing to the repo" — was wider than the check in two directions at once:
+    nothing in `_git_env()` made git incapable of writing (the allowlist and
+    `BindReadOnlyPaths` do that), and it said nothing at all about WHICH
+    repository git resolves, which was the half that was missing.
+
+    🔴 A BAN ON THE PHRASE WOULD BE THE WRONG GUARD TWICE OVER: the docstring
+    QUOTES the old claim in order to retract it (which is the useful thing to
+    do), and a word-ban is walkable by rewording anyway. So this pins the whole
+    normalised RETRACTION — claude/RULES.md → "when the artifact under test IS
+    prose, pin the WHOLE normalised string". A cosmetic reword fails this test;
+    that is the price of a machine-readable claim, and it is worth paying here
+    because the sentence is the only thing standing between a reader and a
+    guarantee the code does not provide.
+    """
+    doc = " ".join((B._git_env.__doc__ or "").split())
+    retraction = (
+        'It said this environment "makes git structurally incapable of writing '
+        'to the repo" — a claim WIDER than the code: nothing here made git '
+        'incapable of writing (the allowlist in `_git` and the unit\'s '
+        '`BindReadOnlyPaths` do that), and nothing here said anything about '
+        'WHICH repository git resolves, which was the half that was actually '
+        'missing.'
+    )
+    assert retraction in doc, (
+        "`_git_env`'s docstring no longer carries the retraction of its old, "
+        "over-wide claim verbatim. Either the claim came back un-retracted, or "
+        "the sentence was reworded — re-read the implementation against it and "
+        "update this pin in the same commit.\n\n"
+        f"docstring now reads:\n{doc[:1200]}")
+    assert "WHICH REPOSITORY — `strip_repo_pointers`" in doc, (
+        "`_git_env`'s docstring does not name repo resolution and the strip "
+        "that provides it, which is now the main thing the function does")
+    assert "GIT_DIR OVERRIDES IT" in doc, (
+        "the docstring no longer states WHY `-C` is not enough, which is the "
+        "fact the whole function turns on")


### PR DESCRIPTION
Closes clawgate task **#343**. Sibling of #721, at strictly larger blast radius.

## The mechanism

`scripts/analyze-service-index/backup.py::_git_env()` built its environment from
`dict(os.environ)` and added exactly five config keys (`GIT_OPTIONAL_LOCKS`,
`GIT_CONFIG_NOSYSTEM`, `GIT_CONFIG_GLOBAL`, `GIT_CONFIG_SYSTEM`,
`GIT_TERMINAL_PROMPT`). It stripped **none** of the git repo-pointer family.

Every git call in the file is `git -C <scope> …`, and `-C` is the weakest
possible claim about where a command lands: **`GIT_DIR` overrides it.**

Why this is worse than the committer #721 fixed: the backup unit
(`nix/home.nix`) has **no `PrivateNetwork`**, `Wants=network-online.target`,
kubectl + minio on PATH, and it age-encrypts what it bundles and **uploads it
off-box to MinIO**. #721's defect corrupted local history. This one
**exfiltrates** — and because the run is genuinely read-only, nothing looks
damaged afterwards.

🔴 **The bundle-vs-restore cross-check inside `bundle_scope` cannot catch it.**
Its `want_names` is read with `_git(scope, "for-each-ref")` — through the same
poisoned environment — so both sides of the comparison report the decoy's refs
and agree. rc 0, "verified". A second sample of the unknown, not a control.
Nothing downstream of it may be cited as covering this.

## Reproduction — the reporter's probe, and mine

The reporter measured, sole variable `GIT_DIR`, calling `bundle_scope()`
directly against a decoy:

```
control (no leak): bundle heads -> 104462c0 refs/heads/trunk
GIT_DIR leaked:    bundle heads -> f05aab33 refs/heads/foreign/branch
                   bundle_scope: OK   <- no error, restore-verify PASSED
```

**Independently re-measured** (card criterion 1) — both reported claims HOLD.
Mine drove the **real CLI end to end** (`--no-upload --work-dir`), decrypted the
artifact with `age`, and read it with `git bundle list-heads` under an
environment **without** the leak. Built with the unit's actual environment shape
(`env -i` plus PATH / HOME / SOPS_AGE_KEY_FILE / ASIB_HOST), **not** my shell —
#721 shipped a table row with the wrong exit code because its probe exported
`GIT_AUTHOR_*`, fixing a dimension the unit does not have.

Every row was run, exit code included. Pre-fix tree (`backup.py` byte-identical
at d7d682f0 and c0cec452), git 2.55.0:

| variable | rc | the BUNDLE declared | decoy `.git` |
|---|---|---|---|
| (control: no leak) | 0 | `refs/heads/trunk` | identical |
| **GIT_DIR** | **0** | **`refs/heads/foreign-branch`** | identical |
| GIT_WORK_TREE | 0 | `refs/heads/trunk` | identical |
| GIT_COMMON_DIR | 1 | (no bundle: `rev-list` 128) | identical |
| GIT_INDEX_FILE | 0 | `refs/heads/trunk` | identical |
| GIT_OBJECT_DIRECTORY | 1 | (no bundle: `rev-list` 128) | identical |
| GIT_ALTERNATE_OBJECT_DIRECTORIES | 0 | `refs/heads/trunk` | identical |
| GIT_NAMESPACE | 0 | `refs/heads/trunk` | identical |
| GIT_PREFIX | 0 | `refs/heads/trunk` | identical |
| GIT_GRAFT_FILE | 0 | `refs/heads/trunk` | identical |
| GIT_SHALLOW_FILE | 0 | `refs/heads/trunk` | identical |
| GIT_CONFIG | 0 | `refs/heads/trunk` | identical |

🔴 **Read the third column, not the fourth.** The exfiltration signature is a
bundle full of the wrong repository's refs while the foreign repo sits
byte-identical. A foreign-repo-unchanged assertion alone calls the `GIT_DIR` row
clean.

Post-fix, every row is rc 0 / `refs/heads/trunk`, decoy identical — including
the two that previously failed outright.

## The fix

`_git_env()` calls `testlib/gitenv.py::strip_repo_pointers()`.

**Not a re-spelling.** `commit.sh` has to copy the ledger into a bash array
because bash cannot import; `backup.py` is Python and imports the owner's
object, so there is nothing to drift — pinned by an identity assertion
(`B.REPO_POINTER_VARS is gitenv.REPO_POINTER_VARS`). A name added to
`testlib/gitenv.py` reaches this program with no edit here.

The import is a **hard failure**: a `except ImportError: POINTERS = ()` fallback
would turn a missing ledger into a backup running with the defect back in place
and still reporting success — the exact false all-clear this file is built
against. The unit mounts `%h/workspace/devrc/scripts` read-only, so `testlib/`
is reachable; a test pins that mount so narrowing it goes red here rather than
at 04:30 on a timer.

**Both git call sites fixed, and pinned.** `_git` and `_git_scratch` are the only
two `subprocess.run(["git", …])` sites and both take `env=_git_env()`.
`test_every_git_invocation_takes_its_environment_from_git_env` walks the AST and
fails on a third site that builds its own environment — with its own negative
control (`test_the_git_env_seam_guard_can_go_RED`) so "0 bad sites" is not a
walker wired to nothing. `_git_scratch`'s `forbidden` guard is untouched; the
strip composes with it (nothing about which repo `-C` names changes the
cwd-is-not-the-store refusal).

**Announced, once per name.** The strip fixes this program; it does not fix
whoever exported the variable. A leaked pointer prints `STRIPPED <NAME>=<value>`
to stderr so it lands in the journal.

**Docstring (criterion 6).** The old wording claimed this environment "makes git
structurally incapable of writing to the repo" — wider than the check in two
directions at once: nothing in `_git_env()` made git incapable of writing (the
allowlist and `BindReadOnlyPaths` do), and it said nothing about which
repository git resolves, which was the missing half. Rewritten, and the
retraction is pinned as a whole normalised string rather than a word-ban (a
word-ban would have been walkable by rewording, and would have forbidden the
useful act of quoting the old claim in order to retract it).

**`scope_remotes()` (criterion 7): marked dead, not wired in.** Documented
`TEST-ONLY — THERE IS NO PRODUCTION CALL SITE`, machine-checked in both
directions by `test_scope_remotes_has_no_production_call_site`. It is not wired
in on purpose: nothing in this program can add a remote, so a run-path
assertion that none appeared could never fail — an unreachable guard that reads
as coverage while providing none. What actually holds the invariant is `_git`'s
(verb, subverb) allowlist and the unit's `BindReadOnlyPaths`.

## Second-order: `restore-verify.py` inherits the fix for free

`scripts/analyze-service-index/restore-verify.py` imports this module as `B` and
has exactly one git site — `subprocess.run([...], env=B._git_env())` — while its
`_scratch()` delegates to `B._git_scratch`. It **clones bundles**, so it was
equally exposed to a leaked `GIT_DIR` and is now equally protected, with no
change of its own.

Two things to say plainly rather than leave unsaid:

- It has **no seam guard of its own**. `backup.py`'s guard is scoped by its own
  sentence ("every git subprocess **in this file**"), which is exactly as wide as
  the check — but nothing stops a future `dict(os.environ)` git site being added
  to `restore-verify.py`. **Out of scope here**, named so it is not mistaken for
  covered.
- The announcement's program name was fixed *because* of this sharing: a leak hit
  during a restore verification used to be announced under the backup's name.

## Measured and NOT stripped — no local array is warranted

#721 needed `ASI_LOCAL_GIT_POINTERS` for two variables GUARD 9 deliberately does
not carry. Measured against `backup.py` (same decoy harness, same environment
shape), each on its own — **all no-ops here**, rc 0, scope's own refs, decoy
identical:

- `GIT_CEILING_DIRECTORIES` — it wrecked `commit.sh` by turning a nested-repo
  refusal into a bootstrap. `backup.py` never runs `git init`, and
  `discover_scopes()` decides "is this a scope" in **pure Python**
  (`(child / ".git").exists()`), so nothing here depends on git's upward
  discovery walk.
- `GIT_TEMPLATE_DIR` — it plants files into a repo `git init` creates.
  `backup.py` creates only the rehearsal clone, which is `rmtree`'d on every
  path out; a hostile template's `post-checkout` did not fire and nothing
  survived the run.
- `GIT_CONFIG_COUNT`/`KEY_0`/`VALUE_0` injecting `core.hooksPath` — beaten by
  the `-c core.hooksPath=/dev/null` both helpers already pass. Marker file never
  created.

## Red/green matrix

Base = **c0cec452** (its `backup.py` is byte-identical to d7d682f0, the sha the
card was written against). Head = **ec43c038**. New tests run against the base
tree's producer with the new test file; parametrised off `testlib/gitenv.py`'s
ledger rather than `backup.py`'s attribute, so the section **collects** at base
and each test fails on **its own** assertion instead of an AttributeError at
collection.

**RED at base → GREEN at head (regression coverage, 8):**

| test | base failure |
|---|---|
| `test_a_leaked_pointer_cannot_aim_the_backup_at_a_FOREIGN_repository[GIT_DIR]` | `🔴 GIT_DIR AIMED THE BACKUP AT THE DECOY … declares the FOREIGN repository's refs: ['… refs/heads/foreign-branch', '… HEAD']` |
| `test_a_leaked_pointer_does_not_BREAK_the_backup[GIT_COMMON_DIR]` | `broke the backup (rc=1)` |
| `test_a_leaked_pointer_does_not_BREAK_the_backup[GIT_OBJECT_DIRECTORY]` | `broke the backup (rc=1)` |
| `test_the_git_environment_strips_every_pointer_on_the_ledger` | `_git_env() passed [all 11] straight through to git` |
| `test_the_producer_uses_the_SHARED_ledger_object_itself` | producer does not import the ledger object |
| `test_the_leak_is_ANNOUNCED_so_the_broken_caller_gets_fixed` | `the run neutralised a leaked GIT_DIR silently` |
| `test_scope_remotes_has_no_production_call_site` | dead-code status not stated |
| `test_the_docstring_no_longer_claims_more_than_the_code_does` | over-wide claim un-retracted |

**GREEN at base — labelled INVARIANT GUARDS in the source, not counted as
regression coverage:** the other 10 parametrisations of
`…_FOREIGN_repository`, the other 9 of `…_does_not_BREAK_…`,
`test_the_strip_does_not_mutate_the_CALLERS_environment`,
`test_every_git_invocation_takes_its_environment_from_git_env`, and the
instrument/positive controls (`test_the_foreign_fingerprint_covers_the_
categories_it_CLAIMS`, `test_the_leak_bed_really_builds_two_DIFFERENT_
repositories`, `test_a_clean_run_bundles_the_SCOPE`,
`test_a_clean_run_announces_NOTHING`, `test_the_git_env_seam_guard_can_go_RED`,
`test_the_measured_table_covers_every_ledger_name`).

🔴 **The foreign-repo fingerprint includes `objects/`.** #721's did not, and that
blindness produced a confident, wrong "harmless" verdict for
`GIT_OBJECT_DIRECTORY` — the variable whose whole damage class lives in the
directory the fingerprint could not see. It walks the entire git dir, so
`objects/`, `refs/`, `HEAD`, `config`, `logs/` and `index` are covered by
construction, and it is **instrument-validated**: a test asserts each of those
six categories is present AND watches the fingerprint move for each one
(a commit → `objects/` + `refs/` + `logs/` + `index`; `git config user.name` →
`config`; `git symbolic-ref HEAD` → `HEAD`).

## Audit round 2 — two guards were narrower than their own descriptions

A blind audit returned no 🔴 and two 🟡, both the same class. Both are fixed in
this PR's second commit, and both were **measured surviving a fully green
139-test run** before the fix.

**🟡 1 — the seam guard was narrower than the sentence beside it.** It matched
only `subprocess.run` whose argv[0] was the literal `"git"`, while `backup.py`
told the next maintainer that *every* git subprocess in the file is pinned by it.
Two realistic third-site shapes were invisible to it:

```
subprocess.check_output(["git", "--version"], env=dict(os.environ))
subprocess.run([_GITBIN, ...],               env=dict(os.environ))
```

Now: any attribute on the `subprocess` module; `env=_git_env()` **or**
`env=<module>._git_env()` (restore-verify.py reaches it as `B._git_env()`); an
absolute argv[0] resolved by basename; and a **non-literal argv or argv[0] is
`UNRECOGNISED`, which FAILS** — "I cannot read this" must never render as "this
is fine". The negative control went from 2 shapes to 9 and pins the full
classification table, not just a pass/fail pair.

**🟡 2 — "hard failure, never a silent degrade" was the one new claim no test
could see.** Replacing the ledger import's `raise` with
`except ImportError: REPO_POINTER_VARS = (); strip_repo_pointers = <no-op>` left
the suite **139/139 green**. That is the exact false all-clear this program
exists to prevent. Now measured by transplanting `backup.py` to a tree with no
`testlib/` and requiring a non-zero exit with the explanatory message —
**paired** with a control running the same transplant *with* the ledger and
requiring exit 0, without which "non-zero" could be any other cause.

**🟢 also addressed:** the announcement no longer hardcodes `PROG` (a leak during
a *restore verification* was announced under the backup's name — `sys.argv[0]`'s
basename now); the once-per-name dedupe is pinned behaviourally across a
subprocess boundary; `_POINTERS_ANNOUNCED` is documented as process-global and
never reset, with what that costs an in-process assertion; the `scope_remotes`
dead-code pin now sweeps **every** production module in the directory (derived at
scan time) and counts attribute access, because its docstring makes an
unqualified claim; and `testlib/__init__.py` + `gitenv.py` now state they are **on
the deployed path** — a timer-driven program imports the ledger at runtime, so
keep it stdlib-only and treat a relocation as a production change.

The audit also independently reproduced all 11 table rows including exit codes,
the 8-row red/green matrix, the M5 disjointness argument, and the
no-local-array conclusion (it additionally tried a `GIT_CONFIG_COUNT`-injected
`core.alternateRefsCommand` — also inert), and **upgraded the sandbox caveat from
"as written" to measured on both hosts**, with a negative control: narrowing the
mount to `analyze-service-index` gives `ModuleNotFoundError`, and the live
deployed units have mounted the whole `scripts/` tree since #703, so there is no
merge-before-switch window.

## Mutation results

Re-run **in full** — a fix round resets the verification gate. Swept against the
fixed tree under `PYTHONDONTWRITEBYTECODE=1`, `__pycache__` deleted between
mutants (a same-length edit inside one second is invisible to CPython's
mtime-in-whole-seconds cache and would score SURVIVED without ever executing).

| mutant | verdict | killed by (own assertion) |
|---|---|---|
| **M0 positive control** — `GIT_OPTIONAL_LOCKS` -> `"1"` | KILLED | `test_the_git_environment_disables_optional_locks` — a *different*, pre-existing test, so the batch is proven able to go red |
| M1 — strip line DELETED | KILLED | `…_FOREIGN_repository[GIT_DIR]` on `🔴 GIT_DIR AIMED THE BACKUP AT THE DECOY`, + 3 more |
| **M2 — NON-DELETION: call COMMENTED OUT, text left in file** | KILLED | 5 tests, own assertions |
| M3 — hand-rolled loop covering the ledger **except `GIT_DIR`** | KILLED | `…_FOREIGN_repository[GIT_DIR]`; the unit test reports exactly `['GIT_DIR']` |
| **M4 — NON-DELETION: `strip_repo_pointers(dict(env))`** — call present, strips a throwaway | KILLED | `…_FOREIGN_repository[GIT_DIR]` + 2 |
| M5 — strip moved AFTER the config `update` | **SURVIVED**, expected | sets are disjoint; the source comment says order is not load-bearing, and this is what makes that true rather than asserted |
| **M6 — third git site via `subprocess.check_output`** | KILLED | `test_every_git_invocation_takes_its_environment_from_git_env`: *"invokes git at line(s) [149] with an environment that did not come from `_git_env()`"* |
| **M7 — third git site with non-literal argv[0] (`_GITBIN`)** | KILLED | same test, UNRECOGNISED branch: *"whose argv[0] is not a literal … refuses to read that as compliant"* |
| **M8 — ledger import DEGRADES instead of raising** | KILLED | `test_a_MISSING_pointer_ledger_STOPS_the_program` |
| **M9 — once-per-name `continue` removed** | KILLED | `test_the_announcement_is_ONCE_PER_NAME_…`: announced **6 times** in one run |
| **M10 — announcement prefix back to hardcoded `PROG`** | KILLED | `test_the_announcement_names_the_PROGRAM_THAT_IS_RUNNING` |

M6-M10 are the five mutants that survived the previous round's suite; each is now
killed by its own named test on its own assertion.

The pins that could have been walked by M2 are deliberately **not** text
matches: the ledger pin is an object-identity check and the seam guard is an AST
walk, so a commented-out call satisfies neither by spelling.

## Gates — all three, on the merged tree

Gated sha **ec43c038** (both commits), with
`git merge-base --is-ancestor origin/main HEAD` **true** at `origin/main` =
**f2ed88c7**, re-confirmed at the moment of push — so the branch tree *is* the
merged tree. Run from an **isolated clone** in a scratch dir, not a worktree of
the shared checkout, so GUARD 9's attribution is not degraded by sibling agents.
Every exit status captured directly, never through a pipe.

```
Gate 1 - dev-host runner, full set
  nix develop <clone> --command bash <clone>/scripts/run-tests.sh <clone> --set all
  RESULT: PASS (exit=0)
  TOTAL collected=15504  passed=15502  skipped=2  failed=0  (floor: 13732 = sum of 27 per-target floors)
  captured status: RUNTESTS_EXIT=0

Gate 2 - hermetic pytests
  nix build <clone>#checks.x86_64-linux.pytests --no-link --print-build-logs
  RESULT: PASS (exit=0)
  TOTAL collected=15504  passed=15502  skipped=2  failed=0  (floor: 13732)
  captured status: PYTESTS_NIX_EXIT=0

Gate 3 - hermetic nodetests  (the REQUIRED status check, tekton/devrc-nodetests)
  nix build <clone>#checks.x86_64-linux.nodetests --no-link --print-build-logs
  RESULT: PASS (exit=0)
  TOTAL suites=4 files=34 tests=1149 pass=1149 fail=0 skipped=0  (floor: 1126)
  captured status: NODETESTS_NIX_EXIT=0

scripts/tests (the target holding this PR's tests), both pytest tiers agree:
  PASS  scripts/tests  (collected=7587 passed=7587 skipped=0 floor=6459)
  No per-target floor drifted; the gate printed no replacement number.
  The 2 skips are the pinned pair (Postgres-only signal test; opt-in repo-cos
  live drift check).
```

`core.hooksPath` was **unset** at the moment of the push (re-measured then, not
earlier — it has flipped twice today), so no pre-push hook ran. Pushed with the
documented `DEVRC_SKIP_TESTS=1` escape hatch rather than `--no-verify`; branch
verified afterwards as two clean commits with no `autocommit` fixture commits.

## Not verified / explicitly unmeasured

- **Gating the merged tree is a claim with a timestamp.** `strict` is deliberately
  false on this repo's branch protection, so a green required check is a claim
  about the branch, not the tree the merge creates. `origin/main` was `f2ed88c7`
  when this round's gate started AND when it was pushed — re-checked at both
  points — so the gated tree is the merged tree as of then. If `main` moves before
  you merge, that claim ages.
- **Not run against the real store or the real MinIO tenant.** No live backup
  run, no upload, no `restore-verify.py`. Everything above is synthetic scopes,
  a real `age` round trip, and a faked/absent upload boundary.
- **The systemd unit was not started.** The import-reachability claim is checked
  against the unit's `BindReadOnlyPaths` **as written in `nix/home.nix`**, not by
  running the unit under its sandbox. A `home-manager switch` has not been done.
- **`GIT_OBJECT_DIRECTORY` pointed at a decoy's own object store**, which is the
  single-variable case. A *combined* leak that keeps the scope readable while
  redirecting writes (e.g. `GIT_OBJECT_DIRECTORY` + `GIT_ALTERNATE_OBJECT_
  DIRECTORIES`) was **not** measured on the pre-fix tree; post-fix both are
  stripped, so it cannot arise.
- The bundle's *contents* are asserted by ref name and by the absence of any
  decoy ref, not by walking every object in it.
