### PR TITLE
feat(clickup): Phase 0 — stamp every agent-created ClickUp task as agent-created

### DIFF
--- a/claude/skills/clickup/SKILL.md
+++ b/claude/skills/clickup/SKILL.md
@@ -77,6 +77,19 @@ node query.mjs edit-page <doc_id> <page_id> --file /tmp/page.md
   `node query.mjs status id1,id2 "complete"`.
 - **Internal-API commands** (`inbox-*`, `doc-comments`) need a JWT in the account, not
   just a token — see setup below.
+- 🔴 **Every task this skill creates is STAMPED as agent-created, automatically.**
+  `create`, `create-subtask` and `batch-create` all route through one choke point, which
+  appends `<!-- claw:obj v=1 src=<producer>/<run-id> cond=<id> -->` to the description
+  and attaches the tag `agent/<producer>`. The tag is the load-bearing half **on this
+  platform specifically**: the API token resolves to a HUMAN identity, so an agent-filed
+  task is otherwise indistinguishable from a hand-typed one. Pass **`--cond`** to record
+  what will close the task — from the enumerated allowlist `gh_pr_merged:<owner>/<repo>#<n>`,
+  `alert_cleared:<name>`, `cmd_exit_zero:<id>`, `metric_below:<id>`, `manual`. Anything
+  else is REJECTED at the CLI, not stored; omitting it means `manual`. ⚠️ The tag is
+  **best-effort** — ClickUp requires a tag to exist at the SPACE level first, and creating
+  one is a workspace mutation this will not do silently, so a missing space tag warns on
+  stderr and the task is still created with its marker. Opt out with `CLICKUP_AGENT_STAMP=0`
+  when a human is genuinely the author.
 
 ## Going deeper — load ONE only when its trigger fires
 

--- a/claude/skills/clickup/api/tasks.mjs
+++ b/claude/skills/clickup/api/tasks.mjs
@@ -4,6 +4,7 @@
 
 import { apiRequest, apiRequestV3, fetchAllPages } from './client.mjs';
 import { getList } from './lists.mjs';
+import { agentIdentity, buildMarker, stampDescription } from '../lib/agent-marker.mjs';
 
 // Get task details
 export async function getTask(taskId, includeSubtasks = false) {
@@ -70,13 +71,98 @@ export async function updateTaskStatus(taskId, statusInput) {
   return { task: response, matchedStatus: match };
 }
 
+// ── Agent-object hygiene (Phase 0) ──────────────────────────────────────────
+//
+// 🔴 THE STAMP LIVES HERE, AT THE ONE CHOKE POINT, and that placement is the
+// point. Every ClickUp task this skill creates goes through createTask() —
+// `query.mjs create`, `query.mjs create-subtask`, and lib/batch-create.mjs's
+// whole fan-out. Stamping at the CALL SITES instead would regenerate the same
+// omission at each one, and a new caller would arrive unstamped by default.
+//
+// Two things get stamped, and they answer different questions:
+//   * the TAG `agent/<producer>` — "which objects did an agent create?",
+//     answerable through the API with no body parsing at all;
+//   * the MARKER in the description — "what closes this one?".
+//
+// On ClickUp the tag is the load-bearing half for a reason specific to this
+// platform: the API token resolves to a HUMAN identity, so creator-based
+// attribution is structurally impossible here. Without a tag there is no
+// queryable signal that an agent filed the task at all.
+//
+// ⚠️ TAGGING IS BEST-EFFORT AND CAN LEGITIMATELY FAIL. ClickUp requires a tag to
+// exist at the SPACE level before it can be attached to a task; creating one is
+// a workspace-level mutation this must not perform silently. So a missing space
+// tag warns on stderr and the task is still created, with the marker intact.
+// Create the `agent/<producer>` space tag once, per space, to turn the tag half
+// on. (lib/batch-create.mjs already treats its own tag failures this way.)
+//
+// Opt out with CLICKUP_AGENT_STAMP=0 or `{ agentStamp: false }` — for the case
+// where a human is driving the CLI by hand and the object genuinely is theirs.
+function agentStampEnabled(options) {
+  if (options.agentStamp === false) return false;
+  return process.env.CLICKUP_AGENT_STAMP !== '0';
+}
+
+// Split the caller's options into (a) the body ClickUp receives, marker folded
+// into the description, and (b) the tag to attach afterwards.
+//
+// EXPORTED for test/agent-marker.test.mjs. It is the entire stamping decision,
+// and it is pure — so the suite can assert what ClickUp would actually receive
+// without a network call or a module mock. createTask/createSubtask do nothing
+// with the result but spread it into the POST body and attach the tag.
+export function applyAgentStamp(options) {
+  const { agentStamp: _drop, agentFp, agentCond, ...rest } = options;
+  if (!agentStampEnabled(options)) return { body: rest, tag: null };
+  const id = agentIdentity();
+  const marker = buildMarker({
+    srcProducer: id.producer,
+    srcRunId: id.runId,
+    // A caller with a real machine-checkable condition passes one; a session
+    // filing a one-off gets `manual`, which is an honest "no machine closes
+    // this" rather than a fabricated condition nobody will evaluate.
+    cond: agentCond ?? id.cond,
+    // 🔴 fp is OMITTED unless the caller supplies one. A session-filed task has
+    // no stable claim tuple, and a fingerprint that changes every run defeats
+    // the dedupe it exists to provide — see lib/agent-marker.mjs.
+    fp: agentFp ?? null,
+    init: id.init,
+  });
+  // ClickUp renders `markdown_description` when present and ignores
+  // `description`; stamping only one of them would put the marker in the field
+  // the UI is not showing, or drop it entirely on a task that set neither.
+  const body = { ...rest };
+  if (typeof body.markdown_description === 'string' || typeof body.description !== 'string') {
+    body.markdown_description = stampDescription(body.markdown_description, marker);
+  } else {
+    body.description = stampDescription(body.description, marker);
+  }
+  return { body, tag: id.label };
+}
+
+async function attachAgentTag(taskId, tag) {
+  if (!tag || !taskId) return;
+  try {
+    await addTag(taskId, tag);
+  } catch (e) {
+    // Never fatal: the marker is already in the body, so the object is still
+    // identifiable. Loud on stderr because a silently untagged fleet is exactly
+    // the state Phase 0 exists to end.
+    process.stderr.write(
+      `Warning: could not attach agent tag "${tag}" to ${taskId}: ${e.message}\n` +
+      `  (ClickUp requires the tag to exist at the SPACE level first.)\n`,
+    );
+  }
+}
+
 // Create a new task in a list
 export async function createTask(listId, name, options = {}) {
-  const body = { name, ...options };
+  const { body: stamped, tag } = applyAgentStamp(options);
+  const body = { name, ...stamped };
   const response = await apiRequest(`/list/${listId}/task`, {
     method: 'POST',
     body: JSON.stringify(body),
   });
+  await attachAgentTag(response?.id, tag);
   return response;
 }
 
@@ -89,11 +175,13 @@ export async function createSubtask(parentTaskId, name, options = {}) {
     throw new Error('Could not determine list ID from parent task');
   }
 
-  const body = { name, parent: parentTaskId, ...options };
+  const { body: stamped, tag } = applyAgentStamp(options);
+  const body = { name, parent: parentTaskId, ...stamped };
   const response = await apiRequest(`/list/${listId}/task`, {
     method: 'POST',
     body: JSON.stringify(body),
   });
+  await attachAgentTag(response?.id, tag);
   return response;
 }
 

--- a/claude/skills/clickup/lib/agent-marker.mjs
+++ b/claude/skills/clickup/lib/agent-marker.mjs
@@ -1,0 +1,267 @@
+// Agent-object hygiene — the ONE definition of the `claw:obj` marker grammar
+// for the JS side (ClickUp task creation).
+//
+// Phase 0: make every object an agent creates SELF-IDENTIFYING, so a later
+// ledger + reconciler can find it and close it. Measured 2026-08-23 over a
+// complete enumeration of 741 open GitHub objects and 64,137 ClickUp tasks:
+// agent-created ISSUES leak (47.4% 30-day survival) while agent PRs do not
+// (5.2%), and on ClickUp the API token resolves to a HUMAN identity, so an
+// agent-filed task is currently indistinguishable from a hand-typed one. That
+// last part is why this exists here rather than only on the GitHub side.
+//
+//   <!-- claw:obj v=1 fp=<12hex> src=<producer>/<run-id> cond=<condition-id> init=<slug> -->
+//
+//   v     REQUIRED  grammar version. Always 1 in Phase 0.
+//   fp    OPTIONAL  12 lowercase hex — sha256 of a STABLE claim tuple. Emitted
+//                   only by a deterministic reconciler that owns one. A session
+//                   filing a one-off has NO stable claim: omit it rather than
+//                   invent one, because a fingerprint that changes every run
+//                   defeats the dedupe it exists to provide.
+//   src   REQUIRED  `<producer>/<run-id>`.
+//   cond  REQUIRED  the machine-checkable condition that CLOSES the object,
+//                   from the enumerated allowlist COND_KINDS below.
+//   init  OPTIONAL  initiatives slug.
+//
+// 🔴 THE ASYMMETRY IS DELIBERATE: buildMarker() THROWS on anything invalid, so a
+// producer cannot emit a marker a reconciler is unable to act on; parseMarker()
+// RETURNS null on anything malformed, so a reconciler sweeping bodies written by
+// humans and other tools cannot be crashed by one.
+//
+// 🔴 THIS IS A SECOND IMPLEMENTATION OF ONE GRAMMAR, and saying so is the honest
+// framing. The canonical Python module is talos-infra
+// `scripts/lib/agent_obj_marker.py`, byte-mirrored into the in-cluster
+// producers' ConfigMaps and drift-gated there. Python and JS cannot share a
+// byte-mirror, so what keeps THESE two in step is the shared VECTORS array in
+// test/agent-marker.test.mjs — the same literal strings the Python suite pins.
+// If you change the grammar, change it in both, and move the vectors together.
+
+import { createHash } from 'node:crypto';
+
+export const MARKER_VERSION = '1';
+
+// 🔴 ENUMERATED ALLOWLIST, not free text. Adding a kind is a deliberate act:
+// something downstream has to be able to EVALUATE it, so a kind with no
+// evaluator is a promise nobody keeps.
+//
+//   gh_pr_merged:<owner>/<repo>#<n>  closes when that PR is merged
+//   alert_cleared:<alertname>        closes when that Prometheus alert stops firing
+//   cmd_exit_zero:<id>               closes when a registered command exits 0
+//   metric_below:<id>                closes when a registered metric drops below its bound
+//   manual                           the escape hatch — no machine check, takes NO arg
+export const COND_KINDS = Object.freeze([
+  'gh_pr_merged',
+  'alert_cleared',
+  'cmd_exit_zero',
+  'metric_below',
+  'manual',
+]);
+
+// The one kind that is complete on its own. Every OTHER kind REQUIRES an
+// argument: a bare `metric_below` names no metric and is exactly as unactionable
+// as the free text the allowlist exists to forbid.
+export const COND_KINDS_NO_ARG = Object.freeze(['manual']);
+
+export const AGENT_LABEL_PREFIX = 'agent/';
+
+const PRODUCER_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+const RUN_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
+const INIT_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+const FP_RE = /^[0-9a-f]{12}$/;
+// A cond ARGUMENT may hold most printable ASCII (repo slugs, `#`, `:`, `/`) but
+// NEVER whitespace and never `>` — either would terminate or split the HTML
+// comment token stream this grammar rides on.
+const COND_ARG_RE = /^[!-=?-~]{1,200}$/;
+
+const MARKER_RE = /<!--\s*claw:obj\s+([^>]*?)\s*-->/g;
+const TOKEN_RE = /^([a-z]+)=(\S+)$/;
+
+export class MarkerError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'MarkerError';
+  }
+}
+
+// The ClickUp TAG / GitHub LABEL that makes this producer's objects queryable
+// without parsing a single body. That is the single highest-value half of
+// Phase 0 — 112 of the 120 agent-attributable open issues carried zero labels.
+export function labelFor(producer) {
+  if (!PRODUCER_RE.test(producer ?? '')) {
+    throw new MarkerError(`invalid producer ${JSON.stringify(producer)} (want ${PRODUCER_RE})`);
+  }
+  return AGENT_LABEL_PREFIX + producer;
+}
+
+export function validateCond(cond) {
+  if (typeof cond !== 'string' || cond === '') {
+    throw new MarkerError('cond is required');
+  }
+  const i = cond.indexOf(':');
+  const kind = i < 0 ? cond : cond.slice(0, i);
+  const arg = i < 0 ? '' : cond.slice(i + 1);
+  if (!COND_KINDS.includes(kind)) {
+    throw new MarkerError(
+      `cond kind ${JSON.stringify(kind)} is not in the allowlist ${JSON.stringify([...COND_KINDS].sort())}`,
+    );
+  }
+  if (COND_KINDS_NO_ARG.includes(kind)) {
+    if (i >= 0) throw new MarkerError(`cond kind ${JSON.stringify(kind)} takes no argument`);
+    return cond;
+  }
+  if (i < 0 || arg === '') {
+    throw new MarkerError(`cond kind ${JSON.stringify(kind)} requires an argument (\`${kind}:<arg>\`)`);
+  }
+  if (!COND_ARG_RE.test(arg)) {
+    throw new MarkerError(`cond argument ${JSON.stringify(arg)} contains whitespace or \`>\``);
+  }
+  return cond;
+}
+
+// sha256 of sorted-key compact JSON, first 12 hex. `claim` must be the STABLE
+// tuple identifying what the object asserts, and must NOT contain anything that
+// varies per run (a timestamp, a session id, a measured value).
+//
+// 🔴 Key-sorted RECURSIVELY, matching Python's json.dumps(sort_keys=True).
+// JSON.stringify preserves insertion order, so a shallow sort would make two
+// identical claims with differently-ordered NESTED objects fingerprint apart —
+// silently, as two objects instead of one.
+export function fingerprint(claim) {
+  return createHash('sha256').update(canonicalJson(claim), 'utf8').digest('hex').slice(0, 12);
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (value !== null && typeof value === 'object') {
+    const keys = Object.keys(value).sort();
+    return `{${keys.map((k) => `${JSON.stringify(k)}:${canonicalJson(value[k])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function buildMarker({ srcProducer, srcRunId, cond, fp = null, init = null }) {
+  if (!PRODUCER_RE.test(srcProducer ?? '')) {
+    throw new MarkerError(`invalid producer ${JSON.stringify(srcProducer)} (want ${PRODUCER_RE})`);
+  }
+  if (!RUN_ID_RE.test(srcRunId ?? '')) {
+    throw new MarkerError(`invalid run-id ${JSON.stringify(srcRunId)} (want ${RUN_ID_RE})`);
+  }
+  validateCond(cond);
+  const parts = [`v=${MARKER_VERSION}`];
+  if (fp !== null && fp !== undefined) {
+    if (!FP_RE.test(fp)) throw new MarkerError(`invalid fp ${JSON.stringify(fp)} (want 12 lowercase hex)`);
+    parts.push(`fp=${fp}`);
+  }
+  parts.push(`src=${srcProducer}/${srcRunId}`);
+  parts.push(`cond=${cond}`);
+  if (init !== null && init !== undefined) {
+    if (!INIT_RE.test(init)) throw new MarkerError(`invalid init slug ${JSON.stringify(init)} (want ${INIT_RE})`);
+    parts.push(`init=${init}`);
+  }
+  return `<!-- claw:obj ${parts.join(' ')} -->`;
+}
+
+// Returns the FIRST well-formed marker in `text` as an object, else null.
+// Never throws. A marker that is present but MALFORMED reads the same as absent
+// — deliberately, so a half-written marker cannot be acted on as if complete.
+export function parseMarker(text) {
+  if (typeof text !== 'string') return null;
+  MARKER_RE.lastIndex = 0;
+  let m;
+  while ((m = MARKER_RE.exec(text)) !== null) {
+    const parsed = parseFields(m[1]);
+    if (parsed) return parsed;
+  }
+  return null;
+}
+
+function parseFields(blob) {
+  const fields = new Map();
+  for (const tok of blob.split(/\s+/).filter(Boolean)) {
+    const tm = TOKEN_RE.exec(tok);
+    if (!tm) return null;
+    if (fields.has(tm[1])) return null; // a repeated key is ambiguous, not a preference
+    fields.set(tm[1], tm[2]);
+  }
+  for (const k of fields.keys()) {
+    if (!['v', 'fp', 'src', 'cond', 'init'].includes(k)) return null;
+  }
+  if (fields.get('v') !== MARKER_VERSION) return null;
+  const src = fields.get('src');
+  const cond = fields.get('cond');
+  if (!src || !cond) return null;
+  const si = src.indexOf('/');
+  if (si < 0) return null;
+  const producer = src.slice(0, si);
+  const runId = src.slice(si + 1);
+  if (!PRODUCER_RE.test(producer) || !RUN_ID_RE.test(runId)) return null;
+  try {
+    validateCond(cond);
+  } catch {
+    return null;
+  }
+  const fp = fields.has('fp') ? fields.get('fp') : null;
+  if (fp !== null && !FP_RE.test(fp)) return null;
+  const init = fields.has('init') ? fields.get('init') : null;
+  if (init !== null && !INIT_RE.test(init)) return null;
+  const ci = cond.indexOf(':');
+  return {
+    v: MARKER_VERSION,
+    fp,
+    src,
+    producer,
+    runId,
+    cond,
+    condKind: ci < 0 ? cond : cond.slice(0, ci),
+    condArg: ci < 0 ? null : cond.slice(ci + 1),
+    init,
+    label: AGENT_LABEL_PREFIX + producer,
+  };
+}
+
+// ── Who is filing this, and what closes it ──────────────────────────────────
+//
+// Resolved from the environment so a CronJob, a session and a one-off script all
+// stamp correctly without any of them restating the grammar.
+//
+// 🔴 SANITISED, NOT TRUSTED. buildMarker THROWS on a value outside its charset,
+// and a stray session id must never be able to abort a task the caller asked
+// for. An unusable value degrades to a valid default rather than an exception.
+export const DEFAULT_PRODUCER = 'claude-code';
+
+export function agentIdentity(env = process.env) {
+  const producer = sanitise(env.CLAW_AGENT_PRODUCER, PRODUCER_RE, (s) => s.toLowerCase().replace(/[^a-z0-9-]/g, '-'))
+    ?? DEFAULT_PRODUCER;
+  const runId = sanitise(
+    env.CLAW_AGENT_RUN_ID || env.CLAUDE_SESSION_ID || env.CLAUDE_CODE_SESSION_ID,
+    RUN_ID_RE,
+    (s) => s.replace(/[^A-Za-z0-9._-]/g, '-').slice(0, 128),
+  ) ?? 'unknown';
+  // 🔴 An unrecognised cond falls back to `manual`, NOT to silence. `manual` is
+  // an honest "no machine can close this"; dropping the marker entirely would
+  // make the object invisible again, which is the whole defect.
+  let cond = 'manual';
+  try {
+    if (env.CLAW_AGENT_COND) cond = validateCond(env.CLAW_AGENT_COND);
+  } catch {
+    cond = 'manual';
+  }
+  const init = sanitise(env.CLAW_AGENT_INIT, INIT_RE, (s) => s.toLowerCase().replace(/[^a-z0-9-]/g, '-')) ?? null;
+  return { producer, runId, cond, init, label: AGENT_LABEL_PREFIX + producer };
+}
+
+function sanitise(raw, re, clean) {
+  if (typeof raw !== 'string' || raw === '') return null;
+  if (re.test(raw)) return raw;
+  const fixed = clean(raw).replace(/^-+/, '');
+  return re.test(fixed) ? fixed : null;
+}
+
+// Append the marker to a task description, idempotently: a body that already
+// carries a well-formed marker is returned untouched, so a caller that pre-built
+// one (a deterministic reconciler with its own fp) keeps ITS marker rather than
+// getting a second, contradictory one.
+export function stampDescription(description, marker) {
+  const body = typeof description === 'string' ? description : '';
+  if (parseMarker(body)) return body;
+  return body === '' ? marker : `${body.replace(/\s+$/, '')}\n\n${marker}`;
+}

--- a/claude/skills/clickup/query.mjs
+++ b/claude/skills/clickup/query.mjs
@@ -84,6 +84,7 @@ import { uploadAttachment, uploadAttachments } from './api/attachments.mjs';
 
 // Lib imports
 import { executeBatchCreate } from './lib/batch-create.mjs';
+import { validateCond, COND_KINDS } from './lib/agent-marker.mjs';
 import { splitIds, isBulk, bulkExecute, formatBulkResults } from './lib/bulk.mjs';
 import { parseTaskId, parseListId, parseDocId, parsePageId, parseSpaceId } from './lib/parse.mjs';
 import {
@@ -112,6 +113,7 @@ let filterMe = false;
 let assigneeArg = null;
 let dueArg = null;
 let descriptionArg = null;
+let condArg = null;
 let contentArg = null;
 let nameArg = null;
 let parentArg = null;
@@ -147,6 +149,8 @@ for (let i = 0; i < args.length; i++) {
     dueArg = args[++i];
   } else if (arg === '--description' || arg === '--desc') {
     descriptionArg = args[++i];
+  } else if (arg === '--cond') {
+    condArg = args[++i];
   } else if (arg === '--content' || arg === '-c') {
     contentArg = args[++i];
   } else if (arg === '--file' || arg === '-f') {
@@ -334,6 +338,11 @@ Options:
   --attach     File path to upload as attachment (repeatable, for attach/comment)
   --page       Page ID for doc-reply (identifies which page the thread is on)
   --space      Space ID for create-doc (places doc in that space)
+  --cond       Close-condition for a task an agent files, from the enumerated
+               allowlist (gh_pr_merged:<owner>/<repo>#<n>, alert_cleared:<name>,
+               cmd_exit_zero:<id>, metric_below:<id>, manual). Recorded in the
+               task body so a later reconciler can close it. Defaults to
+               `manual`; anything off-allowlist is REJECTED, not stored.
 
 Bulk Operations (comma-separated IDs):
   node query.mjs get id1,id2,id3              Fetch multiple tasks at once
@@ -1082,6 +1091,20 @@ async function main() {
           // Note: Task descriptions use markdown_description (ClickUp parses),
           // while comments use JSON array format (we parse via markdownToClickUp)
           options.markdown_description = descriptionArg;
+        }
+        // Agent-object hygiene: an explicit close-condition for the marker
+        // createTask() stamps. Validated HERE so an off-allowlist value fails
+        // loudly at the CLI instead of silently degrading to `manual` deep
+        // inside the stamp — a wrong condition that reads as accepted is how an
+        // object ends up believed-tracked and actually immortal.
+        if (condArg) {
+          try {
+            options.agentCond = validateCond(condArg);
+          } catch (e) {
+            console.error(`Error: ${e.message}`);
+            console.error(`Allowed --cond kinds: ${[...COND_KINDS].sort().join(', ')}`);
+            process.exit(1);
+          }
         }
         if (dueArg) {
           const dueDate = parseDateInput(dueArg);

--- a/claude/skills/clickup/reference/maintaining.md
+++ b/claude/skills/clickup/reference/maintaining.md
@@ -32,6 +32,35 @@ All mutable state lives in `$XDG_STATE_HOME/clickup` (fallback
 `~/.local/state/clickup`), credentials included; a write next to the code is
 `EROFS`. Pinned by `test/state-paths.test.mjs`.
 
+## The agent-object stamp (`claw:obj`)
+
+`lib/agent-marker.mjs` is the ONE definition of the marker grammar on this side.
+`api/tasks.mjs` applies it in exactly one place — `applyAgentStamp()`, called by
+both `createTask` and `createSubtask`, which is every path that creates a ClickUp
+task here. **Do not stamp at a call site**: a per-call-site stamp regenerates the
+same omission at every new caller, which is the defect this replaced.
+
+🔴 **It is a SECOND implementation of one grammar.** The canonical one is Python,
+in another repo — `<talos-infra>/scripts/lib/agent_obj_marker.py` — byte-mirrored
+into the in-cluster CronJob producers and drift-gated there. Python and JS cannot share
+a byte-mirror, so what keeps these two in step is the `VECTORS` block in
+`test/agent-marker.test.mjs` — literal markers, fingerprints and the `cond`
+allowlist computed on the **Python** side and pinned here. **Change the grammar in
+both, and move the vectors with it.** Never regenerate the vectors from this file:
+a self-referential pin agrees with any drift.
+
+Two gotchas worth keeping:
+
+- `fingerprint()` sorts keys **recursively**, matching Python's
+  `json.dumps(sort_keys=True)`. `JSON.stringify` preserves insertion order, so a
+  shallow sort silently fingerprints two identical claims apart whenever a nested
+  object's keys were built in a different order. Mutation-verified: only the
+  nested vector catches it.
+- `agentIdentity()` **sanitises rather than trusts**, and an unusable
+  `CLAW_AGENT_COND` degrades to `manual`, never to silence. `manual` is an honest
+  "no machine closes this"; dropping the marker would make the object invisible
+  again, which is the whole defect.
+
 ## Tests
 
 The hermetic gates are `node:test` suites, run by devrc's node gate

--- a/claude/skills/clickup/test/agent-marker.test.mjs
+++ b/claude/skills/clickup/test/agent-marker.test.mjs
@@ -1,0 +1,371 @@
+#!/usr/bin/env node
+
+/**
+ * Gates for the `claw:obj` agent-object marker on the ClickUp side
+ * (Phase 0 of agent-object hygiene). Hermetic — no credentials, no network.
+ *
+ * Four tiers, and the last two are the ones that could actually be missing:
+ *
+ *  1. UNIT — build/parse round-trip, the enumerated `cond` allowlist, malformed
+ *     input, optional fields absent.
+ *  2. CROSS-LANGUAGE — this file and talos-infra's
+ *     `scripts/lib/agent_obj_marker.py` are two implementations of ONE grammar,
+ *     and no byte-mirror can bridge Python and JS. The VECTORS below are the
+ *     bridge: literal strings and fingerprints computed from the PYTHON side and
+ *     pinned here, so a change to one implementation goes red until the other
+ *     follows. Without this the two drift silently and a reconciler written
+ *     against one stops seeing objects stamped by the other.
+ *  3. SEAM — createTask/createSubtask actually stamp. 🔴 Tiers 1 and 2 can be
+ *     entirely green with the stamp wired to nothing; the leak Phase 0 exists to
+ *     close lives on the producer side, not in the helper.
+ *  4. CHOKE POINT — the stamp is applied in ONE place, not per call site. A
+ *     per-call-site stamp regenerates the same omission at every new caller.
+ *
+ * Usage:
+ *   node test/agent-marker.test.mjs
+ *   node --test test/agent-marker.test.mjs
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+import {
+  MARKER_VERSION,
+  COND_KINDS,
+  COND_KINDS_NO_ARG,
+  MarkerError,
+  AGENT_LABEL_PREFIX,
+  labelFor,
+  validateCond,
+  fingerprint,
+  buildMarker,
+  parseMarker,
+  agentIdentity,
+  stampDescription,
+  DEFAULT_PRODUCER,
+} from '../lib/agent-marker.mjs';
+import { applyAgentStamp } from '../api/tasks.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TASKS_SRC = readFileSync(resolve(__dirname, '..', 'api', 'tasks.mjs'), 'utf8');
+const QUERY_SRC = readFileSync(resolve(__dirname, '..', 'query.mjs'), 'utf8');
+
+// ── Tier 2: the cross-language pin ──────────────────────────────────────────
+// Every value here was produced by the PYTHON implementation
+// (talos-infra scripts/lib/agent_obj_marker.py) and pasted in. Do not
+// "regenerate" them from this file — that would make the pin self-referential
+// and it would agree with any drift.
+const VECTORS = Object.freeze({
+  minimal: {
+    args: { srcProducer: 'capacity-sweep', srcRunId: 'sweep-29159872-abcde', cond: 'manual' },
+    marker: '<!-- claw:obj v=1 src=capacity-sweep/sweep-29159872-abcde cond=manual -->',
+  },
+  full: {
+    args: {
+      srcProducer: 'capacity-sweep',
+      srcRunId: 'run-1',
+      cond: 'gh_pr_merged:civitai/talos-infra#1234',
+      fp: '0123456789ab',
+      init: 'agent-hygiene',
+    },
+    marker:
+      '<!-- claw:obj v=1 fp=0123456789ab src=capacity-sweep/run-1 '
+      + 'cond=gh_pr_merged:civitai/talos-infra#1234 init=agent-hygiene -->',
+  },
+  fingerprints: [
+    [{ producer: 'capacity-sweep', surface: 'node-disk-free' }, 'ffa496f6e083'],
+    [{ b: 1, a: { z: 2, y: [3, 'x'] } }, 'f71b983349d5'],
+    [{ producer: 'reliability-sweep-advisor', claim: 'index-candidates' }, '633d2c372bd0'],
+  ],
+  condKinds: ['alert_cleared', 'cmd_exit_zero', 'gh_pr_merged', 'manual', 'metric_below'],
+});
+
+// ── Tier 1: unit ────────────────────────────────────────────────────────────
+
+test('buildMarker: minimal marker omits the optional fields', () => {
+  const got = buildMarker(VECTORS.minimal.args);
+  assert.equal(got, VECTORS.minimal.marker);
+  assert.ok(!got.includes('fp='));
+  assert.ok(!got.includes('init='));
+});
+
+test('buildMarker: full marker emits fields in canonical order', () => {
+  assert.equal(buildMarker(VECTORS.full.args), VECTORS.full.marker);
+});
+
+test('buildMarker: every allowlisted cond kind builds', () => {
+  for (const kind of COND_KINDS) {
+    const cond = COND_KINDS_NO_ARG.includes(kind) ? kind : `${kind}:x`;
+    assert.ok(buildMarker({ srcProducer: 'p', srcRunId: 'r', cond }).includes(`cond=${cond}`));
+  }
+});
+
+test('buildMarker: a cond outside the allowlist is REJECTED', () => {
+  for (const cond of ['someone_looks_at_it', 'gh_pr_closed:civitai/x#1', '', 'MANUAL']) {
+    assert.throws(
+      () => buildMarker({ srcProducer: 'p', srcRunId: 'r', cond }),
+      MarkerError,
+      `should reject cond ${JSON.stringify(cond)}`,
+    );
+  }
+});
+
+test('buildMarker: a cond kind that needs an argument is rejected bare', () => {
+  for (const kind of COND_KINDS.filter((k) => !COND_KINDS_NO_ARG.includes(k))) {
+    assert.throws(() => buildMarker({ srcProducer: 'p', srcRunId: 'r', cond: kind }), MarkerError);
+    assert.throws(() => buildMarker({ srcProducer: 'p', srcRunId: 'r', cond: `${kind}:` }), MarkerError);
+  }
+});
+
+test('buildMarker: `manual` rejects an argument', () => {
+  assert.throws(
+    () => buildMarker({ srcProducer: 'p', srcRunId: 'r', cond: 'manual:because-i-said-so' }),
+    MarkerError,
+  );
+});
+
+test('buildMarker: a value that would break the HTML comment is rejected', () => {
+  for (const cond of ['metric_below:a b', 'metric_below:a>b']) {
+    assert.throws(() => buildMarker({ srcProducer: 'p', srcRunId: 'r', cond }), MarkerError);
+  }
+  for (const bad of ['Capacity Sweep', 'cap sweep', '-lead', '', 'A']) {
+    assert.throws(() => buildMarker({ srcProducer: bad, srcRunId: 'r', cond: 'manual' }), MarkerError);
+  }
+  for (const bad of ['run 1', 'run>1', '']) {
+    assert.throws(() => buildMarker({ srcProducer: 'p', srcRunId: bad, cond: 'manual' }), MarkerError);
+  }
+});
+
+test('buildMarker: invalid optional fields are rejected', () => {
+  const base = { srcProducer: 'p', srcRunId: 'r', cond: 'manual' };
+  assert.throws(() => buildMarker({ ...base, fp: 'deadbeef' }), MarkerError);      // too short
+  assert.throws(() => buildMarker({ ...base, fp: '0123456789AB' }), MarkerError);  // uppercase
+  assert.throws(() => buildMarker({ ...base, init: 'Not A Slug' }), MarkerError);
+});
+
+test('parseMarker: full round-trip', () => {
+  const got = parseMarker(`body\n${VECTORS.full.marker}\nmore`);
+  assert.equal(got.v, MARKER_VERSION);
+  assert.equal(got.fp, '0123456789ab');
+  assert.equal(got.producer, 'capacity-sweep');
+  assert.equal(got.runId, 'run-1');
+  assert.equal(got.condKind, 'gh_pr_merged');
+  assert.equal(got.condArg, 'civitai/talos-infra#1234');
+  assert.equal(got.init, 'agent-hygiene');
+  assert.equal(got.label, 'agent/capacity-sweep');
+});
+
+test('parseMarker: round-trip with the optional fields ABSENT', () => {
+  const got = parseMarker(VECTORS.minimal.marker);
+  assert.equal(got.fp, null);
+  assert.equal(got.init, null);
+  assert.equal(got.condArg, null);
+  assert.equal(got.cond, 'manual');
+});
+
+test('parseMarker: an absent marker is null, never a throw', () => {
+  for (const text of ['', 'no marker here', null, undefined, 42, '<!-- fp:capacity:x -->']) {
+    assert.equal(parseMarker(text), null);
+  }
+});
+
+test('parseMarker: a MALFORMED marker reads as absent', () => {
+  // Each is exactly one field away from valid. A half-written marker must not
+  // be actionable.
+  const bad = [
+    '<!-- claw:obj v=1 cond=manual -->',                 // no src
+    '<!-- claw:obj v=1 src=p/r -->',                     // no cond
+    '<!-- claw:obj src=p/r cond=manual -->',             // no v
+    '<!-- claw:obj v=2 src=p/r cond=manual -->',         // wrong version
+    '<!-- claw:obj v=1 src=p cond=manual -->',           // src has no run-id
+    '<!-- claw:obj v=1 src=p/r cond=whenever -->',       // cond off-allowlist
+    '<!-- claw:obj v=1 src=p/r cond=metric_below -->',   // arg-less kind
+    '<!-- claw:obj v=1 src=p/r cond=manual fp=xyz -->',  // fp not hex
+    '<!-- claw:obj v=1 src=p/r cond=manual junk=1 -->',  // unknown field
+    '<!-- claw:obj v=1 v=1 src=p/r cond=manual -->',     // repeated field
+    '<!-- claw:obj v=1 src=p/r cond=manual bare -->',    // non key=value token
+    '<!-- clawobj v=1 src=p/r cond=manual -->',          // wrong sentinel
+  ];
+  for (const b of bad) assert.equal(parseMarker(b), null, `should not parse: ${b}`);
+});
+
+test('parseMarker: a malformed marker does not shadow a later good one', () => {
+  const text = `<!-- claw:obj v=1 cond=manual -->\n${VECTORS.minimal.marker}`;
+  assert.equal(parseMarker(text).producer, 'capacity-sweep');
+});
+
+test('labelFor: reproduces capacity-sweep\'s existing live label exactly', () => {
+  assert.equal(labelFor('capacity-sweep'), 'agent/capacity-sweep');
+  assert.equal(AGENT_LABEL_PREFIX, 'agent/');
+  for (const bad of ['Capacity Sweep', '', '-x', 'A']) {
+    assert.throws(() => labelFor(bad), MarkerError);
+  }
+});
+
+// ── Tier 2: cross-language ──────────────────────────────────────────────────
+
+test('CROSS-LANGUAGE: the cond allowlist matches the Python implementation', () => {
+  assert.deepEqual([...COND_KINDS].sort(), VECTORS.condKinds);
+});
+
+test('CROSS-LANGUAGE: markers are byte-identical to the Python implementation', () => {
+  assert.equal(buildMarker(VECTORS.minimal.args), VECTORS.minimal.marker);
+  assert.equal(buildMarker(VECTORS.full.args), VECTORS.full.marker);
+});
+
+test('CROSS-LANGUAGE: fingerprints match Python json.dumps(sort_keys=True)', () => {
+  // The nested case is the one that matters: JSON.stringify preserves insertion
+  // order, so a SHALLOW key sort silently fingerprints two identical claims
+  // apart whenever a nested object's keys were built in a different order.
+  for (const [claim, expected] of VECTORS.fingerprints) {
+    assert.equal(fingerprint(claim), expected, `fingerprint drift for ${JSON.stringify(claim)}`);
+  }
+});
+
+// ── agentIdentity ───────────────────────────────────────────────────────────
+
+test('agentIdentity: defaults are usable with an empty environment', () => {
+  const id = agentIdentity({});
+  assert.equal(id.producer, DEFAULT_PRODUCER);
+  assert.equal(id.runId, 'unknown');
+  assert.equal(id.cond, 'manual');
+  assert.equal(id.init, null);
+  assert.equal(id.label, `agent/${DEFAULT_PRODUCER}`);
+  // The whole point: whatever the environment holds, the result must BUILD.
+  assert.ok(parseMarker(buildMarker({ srcProducer: id.producer, srcRunId: id.runId, cond: id.cond })));
+});
+
+test('agentIdentity: a hostile environment still yields a buildable identity', () => {
+  const id = agentIdentity({
+    CLAW_AGENT_PRODUCER: 'Capacity Sweep!!',
+    CLAW_AGENT_RUN_ID: 'run id/with spaces>and brackets',
+    CLAW_AGENT_COND: 'whatever_i_feel_like',
+    CLAW_AGENT_INIT: 'Some Slug',
+  });
+  assert.equal(id.producer, 'capacity-sweep--');
+  assert.equal(id.runId, 'run-id-with-spaces-and-brackets');
+  // 🔴 Falls back to `manual`, NOT to silence. `manual` is an honest "no machine
+  // closes this"; dropping the marker would make the object invisible again,
+  // which is the entire defect Phase 0 addresses.
+  assert.equal(id.cond, 'manual');
+  assert.equal(id.init, 'some-slug');
+  const marker = buildMarker({ srcProducer: id.producer, srcRunId: id.runId, cond: id.cond, init: id.init });
+  assert.ok(parseMarker(marker), 'a sanitised identity must produce a PARSEABLE marker');
+});
+
+test('agentIdentity: an allowlisted CLAW_AGENT_COND is honoured verbatim', () => {
+  assert.equal(
+    agentIdentity({ CLAW_AGENT_COND: 'gh_pr_merged:civitai/talos-infra#1277' }).cond,
+    'gh_pr_merged:civitai/talos-infra#1277',
+  );
+});
+
+test('stampDescription: idempotent — an existing marker is never doubled', () => {
+  const once = stampDescription('hello', VECTORS.minimal.marker);
+  assert.ok(once.includes(VECTORS.minimal.marker));
+  const twice = stampDescription(once, VECTORS.full.marker);
+  assert.equal(twice, once, 'a body that already carries a marker must be untouched');
+  assert.equal(stampDescription('', VECTORS.minimal.marker), VECTORS.minimal.marker);
+  assert.equal(stampDescription(undefined, VECTORS.minimal.marker), VECTORS.minimal.marker);
+});
+
+// ── Tier 3: the producer seam (behavioural) ─────────────────────────────────
+
+test('SEAM: a plain create is stamped with a parseable marker and a tag', () => {
+  const { body, tag } = applyAgentStamp({});
+  const got = parseMarker(body.markdown_description);
+  assert.ok(got, `no marker in ${JSON.stringify(body)}`);
+  assert.equal(got.cond, 'manual');
+  assert.equal(got.fp, null, 'a session-filed one-off has no stable claim — fp must be OMITTED');
+  assert.equal(tag, got.label);
+  assert.equal(tag, `agent/${got.producer}`, 'the tag and src= must name the SAME producer');
+});
+
+test('SEAM: an existing markdown description keeps its content and gains the marker', () => {
+  const { body } = applyAgentStamp({ markdown_description: '# Title\n\nSome body.' });
+  assert.ok(body.markdown_description.startsWith('# Title\n\nSome body.'));
+  assert.ok(parseMarker(body.markdown_description));
+});
+
+test('SEAM: a caller using the plain `description` field is stamped there', () => {
+  const { body } = applyAgentStamp({ description: 'plain text' });
+  assert.equal(body.markdown_description, undefined);
+  assert.ok(parseMarker(body.description));
+});
+
+test('SEAM: agentCond and agentFp reach the marker and are NOT sent to ClickUp', () => {
+  const fp = fingerprint({ producer: 'x', claim: 'y' });
+  const { body } = applyAgentStamp({
+    agentCond: 'gh_pr_merged:civitai/talos-infra#1277',
+    agentFp: fp,
+  });
+  const got = parseMarker(body.markdown_description);
+  assert.equal(got.condKind, 'gh_pr_merged');
+  assert.equal(got.condArg, 'civitai/talos-infra#1277');
+  assert.equal(got.fp, fp);
+  // 🔴 These are OUR options, not ClickUp's. Leaking them into the POST body
+  // would send unknown fields to the API on every single create.
+  for (const k of ['agentCond', 'agentFp', 'agentStamp']) {
+    assert.equal(k in body, false, `${k} must not be forwarded to ClickUp`);
+  }
+});
+
+test('SEAM: opt-out returns the caller\'s options untouched and no tag', () => {
+  const { body, tag } = applyAgentStamp({ agentStamp: false, markdown_description: 'raw' });
+  assert.equal(body.markdown_description, 'raw');
+  assert.equal(tag, null);
+  assert.equal('agentStamp' in body, false);
+});
+
+test('SEAM: CLICKUP_AGENT_STAMP=0 disables the stamp', () => {
+  const prev = process.env.CLICKUP_AGENT_STAMP;
+  process.env.CLICKUP_AGENT_STAMP = '0';
+  try {
+    const { body, tag } = applyAgentStamp({ markdown_description: 'raw' });
+    assert.equal(body.markdown_description, 'raw');
+    assert.equal(tag, null);
+  } finally {
+    if (prev === undefined) delete process.env.CLICKUP_AGENT_STAMP;
+    else process.env.CLICKUP_AGENT_STAMP = prev;
+  }
+});
+
+// ── Tier 4: the choke point ─────────────────────────────────────────────────
+
+test('CHOKE POINT: every ClickUp task-create call site stamps', () => {
+  // Both creators must route through applyAgentStamp + attachAgentTag. A new
+  // creator that POSTs to /list/<id>/task without them would be unstamped by
+  // default — which is how this defect class regenerates.
+  // 🔴 Match the POST, not the ENDPOINT. `/list/<id>/task` is also the GET that
+  // getTasksInList uses, so an endpoint-only count reads 3 and fails on a
+  // perfectly correct tree — which is exactly what this assertion did on its
+  // first run. A read is not a create.
+  const endpoints = TASKS_SRC.match(/`\/list\/\$\{listId\}\/task`/g) || [];
+  assert.ok(endpoints.length >= 2, 'positive control: the endpoint literal is findable at all');
+  const posts = TASKS_SRC.match(/`\/list\/\$\{listId\}\/task`,\s*\{\s*method: 'POST'/g) || [];
+  assert.equal(posts.length, 2, 'expected exactly 2 task-create POST sites (createTask, createSubtask)');
+  // 🔴 `applyAgentStamp(options)` alone matches its own DECLARATION too, so an
+  // unqualified count reads 3. Match the CALL shape — the destructure — not the
+  // identifier. (Same defect one line up, same session, twice.)
+  assert.equal(
+    (TASKS_SRC.match(/const \{ body: stamped, tag \} = applyAgentStamp\(options\);/g) || []).length, 2,
+    'both creators must route through the single stamping helper');
+  assert.equal(
+    (TASKS_SRC.match(/await attachAgentTag\(response\?\.id, tag\);/g) || []).length, 2,
+    'both creators must attach the agent tag');
+});
+
+test('CHOKE POINT: --cond is validated at the CLI, not silently downgraded', () => {
+  assert.ok(QUERY_SRC.includes("arg === '--cond'"), '--cond flag is not parsed');
+  assert.ok(QUERY_SRC.includes('options.agentCond = validateCond(condArg)'),
+    '--cond must be validated against the allowlist before it is stored');
+  assert.ok(QUERY_SRC.includes('--cond'), '--cond must appear in showUsage()');
+});
+
+test('CHOKE POINT: validateCond is importable by the CLI and rejects free text', () => {
+  assert.equal(validateCond('metric_below:capacity:node-disk-free'), 'metric_below:capacity:node-disk-free');
+  assert.throws(() => validateCond('when someone gets round to it'), MarkerError);
+});

--- a/scripts/run-node-tests.sh
+++ b/scripts/run-node-tests.sh
@@ -210,7 +210,14 @@ SUITES=(
   # 122 tests / 4 files measured 2026-08-21: test/awaiting.test.mjs, the gate for
   # the `awaiting` command (predicate, fan-out cap, pacing) and for the inbox
   # cursor loop. Floor 116 = 122 - min(50, max(1, 122/20)) = 122 - 6.
-  "claude/skills/clickup/test|4|116"
+  #
+  # 152 tests / 5 files measured 2026-08-23: test/agent-marker.test.mjs, the gate
+  # for the `claw:obj` agent-object marker (Phase 0 of agent-object hygiene) —
+  # the grammar, the enumerated `cond` allowlist, the CROSS-LANGUAGE pin against
+  # talos-infra's Python implementation (no byte-mirror can bridge the two, so
+  # shared vectors are what keeps them from drifting), and the create-path seam.
+  # Floor 145 = 152 - min(50, max(1, 152/20)) = 152 - 7.
+  "claude/skills/clickup/test|5|145"
 )
 
 # --- discovery roots -----------------------------------------------------------


### PR DESCRIPTION
feat(clickup): Phase 0 — stamp every agent-created ClickUp task as agent-created

Companion to talos-infra #1277, which does the same for the in-cluster GitHub
issue producers. This is the ClickUp half.

WHY THIS HALF EXISTS AT ALL, and it is a platform-specific reason: on ClickUp the
API token resolves to a HUMAN identity, so an agent-filed task is currently
indistinguishable from a hand-typed one. There is no creator-based attribution to
fall back on the way there is on GitHub. Measured 2026-08-23 across 64,137 ClickUp
tasks: nothing marks any of them as agent-authored.

Every task this skill creates is now stamped with two things:

  * the TAG `agent/<producer>` — answers "which objects did an agent create?"
    through the API with no body parsing;
  * a marker in the description — answers "what closes this one?":
      <!-- claw:obj v=1 fp=<12hex> src=<producer>/<run-id> cond=<id> init=<slug> -->

`cond` comes from an ENUMERATED ALLOWLIST (gh_pr_merged, alert_cleared,
cmd_exit_zero, metric_below, and `manual` as the escape hatch), settable per-task
with the new `--cond` flag and validated AT THE CLI so an off-allowlist value
fails loudly instead of silently degrading — a wrong condition that reads as
accepted is how an object ends up believed-tracked and actually immortal. `fp` is
OMITTED by default: a session filing a one-off has no stable claim tuple, and a
fingerprint that changes every run defeats the dedupe it exists to provide.

🔴 THE STAMP LIVES AT THE ONE CHOKE POINT — applyAgentStamp() in api/tasks.mjs,
called by createTask and createSubtask, which is every path that creates a
ClickUp task here (query.mjs create, create-subtask, and lib/batch-create.mjs's
whole fan-out). Stamping at the call sites would regenerate the same omission at
each one and leave every future caller unstamped by default.

⚠️ TAGGING IS BEST-EFFORT, deliberately. ClickUp requires a tag to exist at the
SPACE level before it can be attached, and creating one is a workspace-level
mutation this must not perform silently. A missing space tag warns on stderr and
the task is still created with its marker intact. Create the `agent/<producer>`
space tag once per space to turn the tag half on.

🔴 THIS IS A SECOND IMPLEMENTATION OF ONE GRAMMAR, and the commit says so rather
than pretending otherwise. The canonical definition is Python, in talos-infra,
byte-mirrored into the CronJob producers and drift-gated there. Python and JS
cannot share a byte-mirror, so what keeps the two in step is the VECTORS block in
test/agent-marker.test.mjs: literal markers, fingerprints and the cond allowlist
computed on the PYTHON side and pinned here. Never regenerate them from this file
— a self-referential pin agrees with any drift.

fingerprint() sorts keys RECURSIVELY to match Python's json.dumps(sort_keys=True).
JSON.stringify preserves insertion order, so a shallow sort silently fingerprints
two identical claims apart whenever a nested object's keys were built in a
different order. Only the nested vector can see that, and it was mutation-verified.

Tests: 30 new (152 total in the clickup suite, up from 122); the SUITES pin in
scripts/run-node-tests.sh moves to 5 files / floor 145.

Red/green matrix:
  * at origin/main with the helper copied in and applyAgentStamp stubbed to a
    no-op — i.e. "the library shipped, the producers wired to nothing", which is
    the isolation seam this suite exists for: 7 FAIL / 30, every SEAM and CHOKE
    POINT test red with its own message ("no marker in {}", "both creators must
    route through the single stamping helper", "--cond flag is not parsed"); the
    23 unit + cross-language tests pass, correctly, because the helper is present.
  * at HEAD: 30/30 green; full devrc node gate 1179/1179.
  * 7 mutants, each KILLED by its own named test: dropping metric_below from the
    allowlist, validateCond accepting anything, fingerprint falling back to bare
    JSON.stringify, our own agentCond/agentFp leaking into the ClickUp POST body,
    createSubtask losing attachAgentTag, agentIdentity not falling back to
    `manual` on an unusable CLAW_AGENT_COND, and --cond stored unvalidated.

Two instrument defects worth recording, both caught by the gates rather than by
reading: the choke-point count matched `/list/${listId}/task` including the GET
that getTasksInList uses (3, not 2), and `applyAgentStamp(options)` matched its
own DECLARATION as well as its two call sites. Both now match the POST and the
destructure respectively.

NOT in scope: no ledger, no reconciler, no auto-close. No ClickUp task was
created or modified — every test is hermetic.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
