### PR TITLE
docs(ci): both Tekton tiers are required now — five files still said one, or none

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,14 +148,15 @@ Repo-level facts that are NOT in any skill — they live here on purpose:
 - **Two always-on docs have enforced byte ceilings**, because both load on every session: `scripts/browser-bridge/SKILL.md` (gated by `scripts/browser-bridge/tests/test_skill_size.py`) and `claude/RULES.md` (gated by `scripts/tests/test_rules_size.py`). Each test OWNS its constants and prints an eviction playbook on failure — **read the numbers there, never restate them.** Any addition needs an eviction in the SAME commit.
 - **Run the gate with `scripts/gate.sh`** (`--tier pytest|node|both`, `--set hermetic|all`). It sends the full output to a LOG FILE and prints only a bounded summary, so there is no reason to pipe it — and **its exit status is authoritative**. It also cross-checks that status against the runners' own `RESULT:` line and exits **90 = could-not-vouch** when they disagree, when a run printed no verdict, or when `panic: test timed out` appears. 90 is not "the tests failed"; it means read the log.
 - **The runners' verdict line carries their exit code** (`RESULT: FAIL (exit=1)`), emitted from one writer behind an EXIT trap, so it survives a pipe and a killed run still says so. Historically the status was destroyed by `… | tail; echo "rc=$?"` — four agents reported `exit 0` over `RESULT: FAIL` on 2026-08-11 — which is why counting `PASSED`/`FAILED` lines used to be mandatory. Still a fine cross-check; no longer the only thing you can trust.
-- 🔴 **A MERGE IS NOW BLOCKED BY `tekton/devrc-nodetests`. `devrc-pytests` is NOT.** <!-- merge-gate: other -->
-  Since 2026-08-23 `required_status_checks.contexts = ["tekton/devrc-nodetests"]` on `main`,
-  with `enforce_admins: true`. Verified behaviourally, not from the setting: PRs with
-  nodetests `ERROR` or `PENDING` read `mergeStateStatus=BLOCKED`, green ones read `CLEAN`,
-  and a PR with pytests red but nodetests green reads `UNSTABLE` — mergeable. That split is
-  deliberate — and nodetests collects `*.test.mjs` ONLY, so a Python-only PR cannot fail
-  the required check at all. There is still no `.github/workflows`, so
-  the marker stays `other`.
+- 🔴 **A MERGE IS BLOCKED BY BOTH TIERS — `tekton/devrc-pytests` AND `tekton/devrc-nodetests`.** <!-- merge-gate: other -->
+  Measured 2026-08-23: `required_status_checks.contexts =
+  ["tekton/devrc-nodetests","tekton/devrc-pytests"]` on `main`, `enforce_admins: true`. A
+  Python-only change is now genuinely gated. ⚠ **It was not, earlier the same day** —
+  `contexts` held nodetests ALONE, which collects `*.test.mjs` ONLY, so a Python-only PR
+  could not fail it and read `UNSTABLE` (mergeable) with pytests red. **That observation is
+  OBSOLETE**; it reads `BLOCKED` today. Kept because a one-element `contexts` list reads as
+  "blocked" at a glance — check the LIST, not that the key exists. There is still no
+  `.github/workflows`, so the marker stays `other`.
   🔴 **`enforce_admins: true` is LIVE now** — it protected nothing while nothing was
   required. If Tekton is down or wedged, NOTHING merges and there is no admin override.
   The escape hatch, deliberately written down because you will want it under pressure:
@@ -179,7 +180,7 @@ Repo-level facts that are NOT in any skill — they live here on purpose:
   🔴 **`error` is not `failure`.** A check posted as `error` with `COULD NOT RUN: <leg>`
   means the gate stopped before that leg reported — a broken gate, not a bad change. Do not
   debug your diff against it.
-  🔴 **Before making a check REQUIRED, know this failure mode:** when a run hits
+  🔴 **Both checks are REQUIRED, so this failure mode is LIVE:** when a run hits
   `timeouts.tasks` the `finally` report task never runs, so **nothing is posted and the PR's
   checks stay `pending` forever** — measured on `devrc-ci-nnt6f` and `devrc-ci-9p6mf`,
   `childReferences` `[notify, gate]` only, still `pending` hours later. A required check in
@@ -223,9 +224,9 @@ Repo-level facts that are NOT in any skill — they live here on purpose:
   see (Tekton — which is why it reads `other` today — or an installed `githooks/` pre-push
   gate); `other` exists so the test can never force you to write a false `none`.
   🔴 **The marker records that something RUNS, never that it BLOCKS.** Those are different
-  facts, and the marker cannot tell them apart: it read `other` both while nothing blocked
-  (2026-08-22) and now that `tekton/devrc-nodetests` is required (2026-08-23) — the value
-  did not move, because what changed was branch protection, which this test cannot see.
+  facts, and the marker cannot tell them apart: it read `other` while nothing blocked
+  (2026-08-22), while one tier blocked, and now that both do (2026-08-23) — the value never
+  moved, because what changed each time was branch protection, which this test cannot see.
   So `other` never licenses "the merge is protected". Whether a run blocks is branch
   protection, which — along with Tekton and git hooks — is named above but NOT
   machine-checked from here. Re-verify by hand rather than trusting this paragraph's age:

--- a/claude/skills/tekton/SKILL.md
+++ b/claude/skills/tekton/SKILL.md
@@ -100,10 +100,12 @@ debugging, changing or copying a specific pipeline.
    `taskStart + timeout` while the budget is `runStart + tasks`, so an unbounded early task
    (devrc's `notify` inherited the cluster's 1h default) lets them cross and re-opens this.
 9. ⚠ **Gotcha 6 is scoped to `homelab-infra`, not to Tekton.** `innovation-upstream/devrc` is a
-   DIFFERENT repo on a plan where protection works, and since 2026-08-23 it requires
-   `tekton/devrc-nodetests` — verified behaviourally: nodetests `ERROR`/`PENDING` ⇒
-   `mergeStateStatus=BLOCKED`, `SUCCESS` ⇒ `CLEAN`, pytests red + nodetests green ⇒ `UNSTABLE`.
-   So on devrc a Tekton check **is** a gate. 🔴 `enforce_admins: true` there means a wedged
+   DIFFERENT repo on a plan where protection works, and since 2026-08-23 it requires **both**
+   `tekton/devrc-nodetests` and `tekton/devrc-pytests` (measured — re-measure, this moved
+   twice in one day). A required check `ERROR`/`PENDING` ⇒ `mergeStateStatus=BLOCKED`,
+   both `SUCCESS` ⇒ `CLEAN`. So on devrc a Tekton check **is** a gate — on either tier;
+   the earlier nodetests-only window let pytests-red PRs read `UNSTABLE` and merge.
+   🔴 `enforce_admins: true` there means a wedged
    Tekton blocks everyone with no override; the escape hatch is
    `gh api -X DELETE /repos/innovation-upstream/devrc/branches/main/protection/required_status_checks`.
 

--- a/githooks/README.md
+++ b/githooks/README.md
@@ -76,11 +76,12 @@ Behaviour, all failing in the **safe direction**:
   the devShell, so it is armed by `checks.pytests`'s own `DEVRC_GATE_ENV`
   export rather than the `shellHook` this hook uses — the two are not
   redundant. (The `nodetests` leg carries no marker and needs none.)
-  Its red is advisory (`main`'s protection requires a review but **not** status
-  checks — `required_status_checks` → 404, measured 2026-08-22) — which is why
-  this hook remains the only tier that blocks **a push**. (`main` also requires
-  1 approving review, which blocks a *merge* — so the unqualified "only tier
-  that blocks" would be wrong.)
+  Its red is **no longer advisory**: measured 2026-08-23, `main`'s
+  `required_status_checks.contexts` lists BOTH legs (`strict: false`,
+  `enforce_admins: true`), so either one red blocks a *merge*. This hook is
+  still the only tier that blocks **a push** — that qualifier is what keeps the
+  claim true; unqualified "only tier that blocks" was already wrong (`main`
+  requires 1 approving review too) and is now wrong twice over.
 - **Escape hatch** — `DEVRC_SKIP_TESTS=1 git push …` skips the gate for one push
   regardless of mode (the flake check / CI still enforce the hermetic subset).
 

--- a/scripts/tests/test_ci_claim_matches_reality.py
+++ b/scripts/tests/test_ci_claim_matches_reality.py
@@ -19,10 +19,16 @@ carry branch protection, and `statusCheckRollup` is non-empty. Still true: no
 used to continue: "the protection carries **no `required_status_checks`**:
 checks RUN, nothing BLOCKS", evidenced by #707 merging **28 minutes** after its
 `devrc-pytests` went RED and #711 two minutes after. **Measured FALSE on
-2026-08-23**: `required_status_checks.contexts` is `["tekton/devrc-nodetests"]`,
-`strict: false`, `enforce_admins: true` — a merge DOES block now. But on one
-tier of two, and the required one collects `*.test.mjs` ONLY, so a Python-only
-change cannot fail it. "Partially blocked" is the shape that reads as "blocked".
+2026-08-23**: `required_status_checks.contexts` is
+`["tekton/devrc-nodetests","tekton/devrc-pytests"]`, `strict: false`,
+`enforce_admins: true` — BOTH tiers block, so a Python-only change is gated too.
+
+⚠ It briefly listed nodetests ALONE (same day, corrected within the hour), and
+that one-element state is worth remembering rather than deleting: nodetests
+collects `*.test.mjs` ONLY, so a Python-only change could not fail the required
+check at all, yet the setting read as "protected". "Partially blocked" is the
+shape that reads as "blocked" — which is why the re-measure below says to read
+the LIST, not whether the key exists.
 
 The marker was `other` before that change and is `other` after, because it
 encodes what REPORTS, not what BLOCKS: something this test cannot see (Tekton)

--- a/scripts/tests/test_run_tests_preconditions.py
+++ b/scripts/tests/test_run_tests_preconditions.py
@@ -424,10 +424,12 @@ def test_the_hook_degrades_on_ENV_faults_and_BLOCKS_on_repo_content():
     spelling. (b) "The ONLY tier that runs automatically: no CI and no branch
     protection" -- a Tekton PR gate now runs (`tekton/devrc-pytests`,
     `tekton/devrc-nodetests`); measured, #704 reports no checks and #714 reports
-    both. Its red is advisory -- `main`'s protection requires a review but NOT
-    status checks (`required_status_checks` -> 404, measured 2026-08-22) -- so
-    the accurate claim is "the only tier that BLOCKS", not "the only tier that
-    runs", and NOT "there is no branch protection".
+    both. Its red is NOT advisory any more: measured 2026-08-23, `main`'s
+    `required_status_checks.contexts` lists BOTH legs, so either red blocks a
+    MERGE. This hook is still the only tier that blocks a PUSH -- so the
+    accurate claim is "the only tier that blocks a push", not "the only tier
+    that runs", not "the only tier that blocks", and NOT "there is no branch
+    protection".
 
     🔴 GUARD 1 is now in BOTH lists: since devrc#705 it classifies by CAUSE
     (DEVRC_GATE_ENV=1 -> repo defect -> 2; unset -> caller defect -> 3), so the


### PR DESCRIPTION
## What changed upstream

Branch protection on `main` was changed to require **both** Tekton checks. Re-measured
independently at the start of this work:

```
$ gh api repos/innovation-upstream/devrc/branches/main/protection \
    --jq '{required_status_checks, enforce_admins}'

required_status_checks.contexts = ["tekton/devrc-nodetests","tekton/devrc-pytests"]
strict          = false
enforce_admins  = true
```

A Python-only change is now genuinely gated. It was not, earlier the same day.

## Why five files, not two

The setting moved twice in one day — nothing required → `nodetests` only → both — and
five places were left asserting one of the two dead states. Two were flagged; three more
turned up carrying the same claim:

| file | said | now |
|---|---|---|
| `CLAUDE.md` (always loaded) | blocked by nodetests, "`devrc-pytests` is NOT" | both tiers |
| `scripts/tests/test_ci_claim_matches_reality.py` docstring | `contexts` = one element | both |
| `claude/skills/tekton/SKILL.md` gotcha 9 | requires `devrc-nodetests` | both |
| `githooks/README.md` | `required_status_checks` → 404, Tekton red is advisory | not advisory |
| `scripts/tests/test_run_tests_preconditions.py` docstring | same 404 claim | not advisory |

The last two were already false **before** today's change (they pinned a 2026-08-22
measurement) and are now false twice over.

## Judgement calls

- **The one-tier window is recorded, not deleted.** `nodetests` collects `*.test.mjs`
  only, so a one-element `contexts` list reads as "blocked" while a Python-only PR
  cannot fail it. That is why the standing advice is to read the **list**, not whether
  the key exists. Follows this file's existing convention of correcting in place and
  saying what was measured false and when.
- **The behavioural `UNSTABLE` evidence is marked OBSOLETE**, not left standing — the
  same PR reads `BLOCKED` today.
- **`strict: false` is unchanged and still documented with its consequence**: a green
  required check ran against the PR branch, not the merged tree, so gating the merged
  tree by hand stays load-bearing.
- **"Before making a check REQUIRED, know this failure mode"** was retimed — a required
  check wedged `pending` forever is now a **live** hazard, not a prospective one.
- **The `githooks` "only tier that blocks a push"** qualifier is called out explicitly,
  since it is the word that keeps that sentence true now that a merge blocks too.

## Marker

Value stays `other` — Tekton is not GitHub Actions, and the marker records what **runs**,
never what **blocks**. Branch protection is invisible to this test in every state, so
nothing here verifies the protection values above; they were measured by hand.

```
$ grep -cE '<!-- *merge-gate: *(none|github-actions|other) *-->' CLAUDE.md
1
```
(A bare `grep -c 'merge-gate:'` returns 2 — the prose *about* the marker matches too.)

## Verification

- `test_ci_claim_matches_reality.py` + `test_rules_size.py` + `test_run_tests_preconditions.py`
  → **28 passed**, run under `nix develop`. Re-run after a trim, still 28.
- `CLAUDE.md` 28,800 → 28,910 bytes (**+110, +0.38%**) for four corrected claims.
  No ceiling test covers `CLAUDE.md`; `test_rules_size.py` guards `claude/RULES.md` and is green.
- Docs and comments only — no behaviour change, so no full gate run.
- Pushed `--no-verify` after re-measuring `core.hooksPath` (unset at push time, but it is
  volatile). Post-push integrity: same sha, same tree, clean worktree, **0** `autocommit:` commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
