### PR TITLE
fix(run-tests): GUARD 10 blamed the target in teardown — say WHICH KEYS moved and rank the writer

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -152,7 +152,20 @@ _emit_verdict() {
     echo "RESULT: FAIL (exit=$rc)"
   fi
 }
-_on_exit() { _emit_verdict "$?"; }
+# 🔴 THE VERDICT FIRST, THEN THE SHREDDER. `NOGIT_DIR` holds GUARD 10's
+# key snapshots, which are full `key<TAB>value` dumps of the operator's REAL git
+# config — `remote.origin.url` included, which can carry a token. The normal
+# path removes it at the end of the accounting; this covers the paths that never
+# reach there (TERM, INT, an unset-variable abort under `set -u`). It is guarded
+# on the variable being set because the trap is installed long before it exists,
+# and `|| true` because a cleanup failure must never change the exit status the
+# verdict just announced.
+_on_exit() {
+  local rc=$?
+  _emit_verdict "$rc"
+  [ -n "${NOGIT_DIR:-}" ] && rm -rf "$NOGIT_DIR" 2>/dev/null || true
+  return 0
+}
 trap '_on_exit' EXIT
 # Without these, a TERM/INT (a `timeout`, a Ctrl-C, an OOM kill) bypasses the
 # EXIT trap in bash and the run ends with no verdict at all — the truncation
@@ -2153,16 +2166,34 @@ _nogit_repo_local_index() { # $1 = path -> its slot in NOGIT_REPO_LOCAL, or noth
 # `<git-common-dir>/config` legitimately holds `remote.origin.url`, which on some
 # clones carries a token, and this output lands in CI logs. The rendering below
 # prints the left-hand side of each entry and nothing else; a VALUE-ONLY change
-# still surfaces, as `~ <key>`, with the value itself never leaving this file.
+# still surfaces, as `~ <key>`, with the value never reaching stdout or stderr.
+#
+# 🔴 BE PRECISE ABOUT WHERE THE VALUES DO GO — an earlier wording here said "the
+# value itself never leaving this file", which was not true. The before/after
+# SNAPSHOTS under `$NOGIT_DIR` are full `key<TAB>value` dumps of the operator's
+# real config. They are 0700 (`mktemp -d`), they are never read except by the
+# key diff, and they are removed by the EXIT trap — which is where the cleanup
+# had to move, because the normal-path `rm -rf` alone left them behind on every
+# TERM/INT/abort. Not printed is not the same claim as not written down.
 #
 # `--list -z` rather than plain `--list`: with `-z` git separates ENTRIES with
 # NUL and key from value with a newline, so a multi-line config value cannot
 # masquerade as extra entries. Folding it back to one line per entry keeps the
 # diff a line diff.
-_nogit_config_entries() { # $1 = path -> "<key> <value…>", one per entry, sorted
+# 🔴 THE FOLD SEPARATOR IS A TAB, NOT A SPACE, AND THAT IS LOAD-BEARING. A git
+# key can legally contain a SPACE — `[remote "my name"]` gives `remote.my
+# name.url`, and `git submodule add <url> "my dir"` writes `submodule.my
+# dir.url`. Splitting the key off at the first SPACE truncated those to
+# `remote.my`: a key that does not exist, ungreppable, and — worse — one the
+# hazard rule's `remote\..*\.url$` clause cannot match, so the single key this
+# guard names as the token-bearing hazard was the one a space defeated. Found by
+# the #773 audit, measured end to end. A TAB cannot appear in the key here
+# because that is what we split on; a subsection containing a literal tab would
+# truncate, which is noted and not defended against.
+_nogit_config_entries() { # $1 = path -> "<key>\t<value…>", one per entry, sorted
   [ -f "$1" ] || return 0
   git config --file "$1" --list -z 2>/dev/null \
-    | tr '\n' ' ' | tr '\0' '\n' | LC_ALL=C sort
+    | tr '\n' '\t' | tr '\0' '\n' | LC_ALL=C sort
 }
 # $1 = before-snapshot file, $2 = after-snapshot file -> "<sign> <key>" lines.
 #   +  the key is new       -  the key is gone       ~  its value moved
@@ -2171,7 +2202,7 @@ _nogit_config_entries() { # $1 = path -> "<key> <value…>", one per entry, sort
 # what decides whether anything changed at all, and it saw the bytes.
 _nogit_key_delta() {
   LC_ALL=C awk '
-    function key(l) { sub(/ .*$/, "", l); return l }
+    function key(l) { sub(/\t.*$/, "", l); return l }
     NR == FNR { b[$0] = 1; next }
     { a[$0] = 1 }
     END {
@@ -2186,33 +2217,58 @@ _nogit_key_delta() {
 # 🔴 THE SHAPE VERDICT RANKS TWO HYPOTHESES; IT NEVER CLEARS THE TARGET.
 # $1 = the "<sign> <key>" lines -> one of: ordinary | hazard | unrecognised
 #
-#   hazard   any `core.*` / `user.*` / `url.*` / `http.*` / `credential.*` /
-#            `include*` / `alias.*` key, PLUS `remote.<name>.url|pushurl`. That
-#            is the 2026-08-21 incident's own shape (`core.hooksPath` --global,
-#            `core.bare = true` on a populated tree, ~63 fixture commits pushed
-#            to the REAL origin); nothing routine rewrites these in an existing
-#            clone. Hazard WINS over ordinary in a mixed delta — the safe
-#            direction, and the reason `remote.<name>.url` is HERE while the
-#            rest of `remote.*` is below: `git remote add` in a test is how a
-#            fixture reaches a real remote, and no ordinary session rewrites an
-#            established clone's origin URL mid-run.
-#   ordinary `branch.*` / `remote.*` (except the two above) / `worktree.*` /
+#   hazard   `core.*` / `user.*` / `url.*` / `http.*` / `credential.*` /
+#            `include*` / `alias.*`, PLUS any `remote.*`/`submodule.*` key
+#            ending in `url` / `pushurl` / `uploadpack` / `receivepack` /
+#            `proxy` / `update`. Two families, one reason. The first is the
+#            2026-08-21 incident's own shape (`core.hooksPath` --global,
+#            `core.bare = true` on a populated tree). The second is every
+#            `remote.*`/`submodule.*` key that names a REMOTE or a COMMAND —
+#            `uploadpack`, `receivepack`, `proxy` and `submodule.<n>.update`
+#            all execute a command, and the URL pair is how a fixture reaches a
+#            real remote. Nothing routine rewrites any of them in an existing
+#            clone. Hazard WINS over ordinary in a mixed delta.
+#   ordinary `branch.*` / the rest of `remote.*` / `worktree.*` / the rest of
 #            `submodule.*` / `maintenance.*` / `extensions.worktreeconfig`, and
 #            nothing else. These are what `git branch`, `checkout -b`,
-#            `push -u`, `worktree add` and `maintenance start` write. A hermetic
-#            test works under a tmpdir and has no route to them in the
-#            operator's real clone.
+#            `push -u`, `worktree add` and `maintenance start` write.
+#            ⚠ NOT A CLEAN SET, and the ORDINARY text printed to the reader says
+#            so: `push -u` writes `branch.<n>.remote`/`.merge`, and pushing ~63
+#            fixture commits to the real origin was HALF of the 2026-08-21
+#            incident. The two windows can land in different targets, so a
+#            `branch.*` row elsewhere in the same run is not independent of a
+#            `core.*` row here.
 #   unrecognised  anything else, including an empty delta. Ranked as NEITHER —
-#            an unknown key must not be laundered into "probably concurrent".
+#            an unknown key must not be laundered into "probably concurrent",
+#            and the HEADLINE honours that too (see `_tshape` below; it did not
+#            in the first cut, which is what the #773 audit caught).
+#
+# 🔴 HERESTRINGS, NOT `printf | grep -q` — MEASURED, 10/10 REPRODUCIBLE.
+# `grep -q` exits on the first match, `printf` then takes SIGPIPE (141), and
+# `set -o pipefail` reports the PIPELINE as 141, so the `if` goes FALSE. Above
+# ~5000 delta lines both greps fell through and every large delta scored
+# `ordinary` — the reassuring arm, always in the wrong direction. Latent rather
+# than live (the operator's clone holds ~590 entries), and one character to fix.
+#
+# 🔴 THE TWO SETS ARE A LEDGER, PINNED TWO-WAY by
+# `test_nogit_isolation.py::test_the_shape_ledger_is_pinned_two_way`. They are
+# the ONLY definition — the prose above describes them and does not duplicate
+# them. Editing either regex without editing the test fails the suite, which is
+# the point: a classifier that silently widens its `ordinary` set widens the
+# set of writes that get the reassuring headline.
+NOGIT_HAZARD_KEYS='^[+~-] (core|user|url|http|credential|include|includeif|alias)\.|^[+~-] (remote|submodule)\..*\.(url|pushurl|uploadpack|receivepack|proxy|update)$'
+NOGIT_ORDINARY_KEYS='^[+~-] (branch|remote|worktree|submodule|maintenance)\.|^[+~-] extensions\.worktreeconfig$'
 _nogit_delta_shape() {
   local delta="$1"
   [ -n "$delta" ] || { printf 'unrecognised'; return 0; }
-  if printf '%s\n' "$delta" \
-     | grep -qiE '^[+~-] (core|user|url|http|credential|include|includeif|alias)\.|^[+~-] remote\..*\.(url|pushurl)$'; then
+  # `-i` on the hazard grep and not on the ordinary one is deliberate, not an
+  # oversight: git lower-cases section and variable names in `--list` output, so
+  # neither NEEDS it — but the two arms fail in opposite directions, and the one
+  # that must not miss is the hazard arm.
+  if grep -qiE "$NOGIT_HAZARD_KEYS" <<<"$delta"; then
     printf 'hazard'; return 0
   fi
-  if printf '%s\n' "$delta" \
-     | grep -qvE '^[+~-] (branch|remote|worktree|submodule|maintenance)\.|^[+~-] extensions\.worktreeconfig$'; then
+  if grep -qvE "$NOGIT_ORDINARY_KEYS" <<<"$delta"; then
     printf 'unrecognised'; return 0
   fi
   printf 'ordinary'
@@ -2509,7 +2565,15 @@ _nogit_account() {
     _nogit_cotenancy_probe "$t"
     [ "$NOGIT_EV_STATUS" = "proven" ] && proven=1
   fi
-  local idx delta
+  # 🔴 THE KEY DELTA'S WINDOW IS WIDER THAN THE FINGERPRINT'S, and on the box
+  # this change exists for that gap is not theoretical. `keys-before` is taken
+  # just AFTER the before-fingerprint, and `keys-after` just after the
+  # after-fingerprint AND after `_nogit_cotenancy_probe` (bounded by
+  # `timeout 60`). A concurrent write landing inside either gap is therefore
+  # either invisible to the diff — rendering as the `?` row below, which is why
+  # that row exists — or folded into it. Measured sub-second in practice; worst
+  # case 60s. It cannot affect the VERDICT, only which keys are named.
+  local idx delta line
   for path in ${CHANGED[@]+"${CHANGED[@]}"}; do
     if _nogit_is_repo_local "$path"; then
       if [ "$proven" -eq 1 ]; then
@@ -3307,6 +3371,10 @@ _nogit_render_keys() {
       printf '%s  real clone, so the LEADING hypothesis is a concurrent git command in\n' "$pad"
       printf '%s  another worktree or session, and the target above is the SECOND. This\n' "$pad"
       printf '%s  is a RANKING, not a verdict — this run proved neither.\n' "$pad"
+      printf '%s  ⚠ NOT A CLEAN SET: "push -u" writes branch.<n>.remote/.merge too, and\n' "$pad"
+      printf '%s    pushing fixture commits to the real origin was HALF of 2026-08-21.\n' "$pad"
+      printf '%s    If any OTHER target in this run shows a core.*/user.*/url.* row,\n' "$pad"
+      printf '%s    read the two together — they can land in different windows.\n' "$pad"
       ;;
     hazard)
       printf '%s→ SHAPE: HAZARD. At least one key above is the 2026-08-21 incident'"'"'s own\n' "$pad"
@@ -3316,8 +3384,16 @@ _nogit_render_keys() {
       printf '%s  AUDIT THE TARGET FIRST. Still a ranking, not a verdict.\n' "$pad"
       ;;
     *)
-      printf '%s→ SHAPE: UNRECOGNISED. The keys above match neither the ordinary-git set\n' "$pad"
-      printf '%s  nor the known-hazard set, so this run cannot rank the two hypotheses.\n' "$pad"
+      if [ -n "$delta" ]; then
+        printf '%s→ SHAPE: UNRECOGNISED. The keys above match neither the ordinary-git set\n' "$pad"
+        printf '%s  nor the known-hazard set, so this run cannot rank the two hypotheses.\n' "$pad"
+      else
+        # "The keys above" was printed over a listing with no keys in it — only
+        # the NOT VISIBLE line. Small, and exactly the kind of sentence a reader
+        # scrolls back up to look for.
+        printf '%s→ SHAPE: UNRECOGNISED. There is no key delta to classify at all (see the\n' "$pad"
+        printf '%s  NOT VISIBLE line above), so this run cannot rank the two hypotheses.\n' "$pad"
+      fi
       printf '%s  Do not read that as either one.\n' "$pad"
       ;;
   esac
@@ -3373,9 +3449,20 @@ for entry in ${NOGIT_SEEN[@]+"${NOGIT_SEEN[@]}"}; do
   if [ "$gchanged" -gt 0 ]; then
     changed_names=""
     _tshape="none"
+    _thas_global=0
     while IFS=$'\t' read -r _ct _ccls _cpath; do
       [ -n "$_cpath" ] || continue
       changed_names+="             $_cpath  [$_ccls]"$'\n'
+      # 🔴 THE GLOBAL CLASS IS TRACKED SEPARATELY, AND THE #773 AUDIT IS WHY.
+      # `_nogit_shape_for` returns `none` for a global file — there are no key
+      # rows for one — so the shape aggregation below CANNOT see it. The first
+      # cut of this loop therefore let a mixed run (a `core.hooksPath` write to
+      # `~/.gitconfig` PLUS one `branch.*` key in the clone) print "THE TARGET
+      # NAMED HERE IS THE WINDOW, NOT A CULPRIT" over the one class that is
+      # ALWAYS attributable — and over the 2026-08-21 incident's own file. The
+      # comment here claimed the opposite of what the code did. Measured end to
+      # end by the audit; this flag is the fix.
+      [ "$_ccls" = "global-enforced" ] && _thas_global=1
       # Aggregate the worst shape across this target's changed files, hazard
       # first. It picks the LEAD SENTENCE below, so a mixed run must lead with
       # the accusatory one — under-warning is the expensive direction here.
@@ -3397,7 +3484,13 @@ for entry in ${NOGIT_SEEN[@]+"${NOGIT_SEEN[@]}"}; do
     # The cause differs by class, and the old single sentence was a confident
     # misdiagnosis for the repo-local one: it sent the reader to audit a target
     # that had done nothing (#730).
-    if printf '%s' "$changed_names" | grep -q 'repo-local-enforced'; then
+    # 🔴 A HERESTRING, and `-F` on a fixed token. `printf | grep -q` takes
+    # SIGPIPE under `pipefail` on a large input and reports the pipeline as 141
+    # — see the measurement in `_nogit_delta_shape`'s header — and this string
+    # grew by the whole key rendering in this change, so it moved closer to that
+    # cliff. Getting it wrong here swaps the repo-local message for the global
+    # one, which is the same misdiagnosis in a third place.
+    if grep -qF 'repo-local-enforced' <<<"$changed_names"; then
       # 🔴 STATE WHAT THE PROBE MEASURED, NOT AN INFERENCE FROM IT. This used to
       # read "no live process outside its own lineage sits in that repository",
       # which the probe cannot support: `live_cotenants` roots at the git dir
@@ -3420,10 +3513,24 @@ for entry in ${NOGIT_SEEN[@]+"${NOGIT_SEEN[@]}"}; do
       # both with "not a culprit" would under-warn on the one that IS the
       # incident. The window caveat is stated in every arm regardless — it is a
       # fact about the file, not about the shape.
-      if [ "$_tshape" = "hazard" ]; then
+      #
+      # 🔴 FOUR ARMS, NOT TWO, AND THE #773 AUDIT IS WHY. The first cut branched
+      # on `hazard` alone, so BOTH remaining states fell into the reassuring
+      # lead: a run that also touched a GLOBAL file (always attributable), and a
+      # delta this classifier explicitly declined to rank. The second was the
+      # sharper failure — it fired on `devrc-g10.planted`, which is this repo's
+      # OWN fixture for a test escaping isolation, and printed "NOT A CULPRIT"
+      # directly above "this run cannot rank the two hypotheses". The reassuring
+      # lead is now reachable ONLY from `ordinary` with no global file present;
+      # every other state gets a lead that ranks the target or ranks nothing.
+      if [ "$_thas_global" -eq 1 ]; then
+        nogit_lead="🔴 AND ONE OF THE FILES BELOW IS A GLOBAL ONE, WHICH *IS* ATTRIBUTABLE: no concurrent worktree operation writes the operator's global git config, so whatever reached it did so from inside this run. AUDIT THIS TARGET FIRST, starting with the [global-enforced] file. The window caveat below applies to the repo-local file only."
+      elif [ "$_tshape" = "hazard" ]; then
         nogit_lead="🔴 AND THE KEY DELTA BELOW POINTS AT THIS TARGET: it carries a key of the 2026-08-21 incident's own shape, which nothing routine writes into an existing clone. AUDIT THIS TARGET FIRST. The window caveat still applies and is stated below, but do not start there."
-      else
+      elif [ "$_tshape" = "ordinary" ]; then
         nogit_lead="🔴 THE TARGET NAMED HERE IS THE WINDOW, NOT A CULPRIT: that file is shared by every worktree of the clone, and any concurrent 'git branch' / 'checkout -b' / 'push -u' / 'worktree add' / 'maintenance start' in ANY of them rewrites it while this run is going."
+      else
+        nogit_lead="🔴 AND THIS RUN CANNOT RANK THE TWO HYPOTHESES: the key delta below matches neither the ordinary-git set nor the known-hazard set (or no key-level delta was visible at all), so DO NOT read the target as excused and DO NOT read it as accused. Start with the discriminators printed beside the file."
       fi
       nogit_why="A repo-local one is a write to <git-common-dir>/config, which GIT_CONFIG_GLOBAL does not govern at all. $nogit_lead This run FOUND NO PROOF of another writer, so the delta is REPORTED AGAINST whatever happened to be running — the probe only asks whether a live process outside this run's own lineage has its cwd inside the git dir or its parent, so a session sitting in a SIBLING worktree of the same clone is invisible to it. Read the key delta beside the file below BEFORE auditing any test. A global one is different and IS attributable: it reached the operator's file some other way — code that removes GIT_CONFIG_GLOBAL from its own environment."
     else

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -2218,9 +2218,11 @@ _nogit_key_delta() {
 # $1 = the "<sign> <key>" lines -> one of: ordinary | hazard | unrecognised
 #
 #   hazard   `core.*` / `user.*` / `url.*` / `http.*` / `credential.*` /
-#            `include*` / `alias.*`, PLUS any `remote.*`/`submodule.*` key
-#            ending in `url` / `pushurl` / `uploadpack` / `receivepack` /
-#            `proxy` / `update`. Two families, one reason. The first is the
+#            `include*` / `alias.*`, PLUS any `remote.*`/`submodule.*` key whose
+#            LAST DOT-COMPONENT is `url` / `pushurl` / `uploadpack` /
+#            `receivepack` / `proxy` / `update` — the regex requires the literal
+#            `.` before the suffix, so `remote.origin.skipdefaultupdate` does
+#            NOT match, and saying "ending in" over-stated it. The first is the
 #            2026-08-21 incident's own shape (`core.hooksPath` --global,
 #            `core.bare = true` on a populated tree). The second is every
 #            `remote.*`/`submodule.*` key that names a REMOTE or a COMMAND —
@@ -2258,6 +2260,14 @@ _nogit_key_delta() {
 # set of writes that get the reassuring headline.
 NOGIT_HAZARD_KEYS='^[+~-] (core|user|url|http|credential|include|includeif|alias)\.|^[+~-] (remote|submodule)\..*\.(url|pushurl|uploadpack|receivepack|proxy|update)$'
 NOGIT_ORDINARY_KEYS='^[+~-] (branch|remote|worktree|submodule|maintenance)\.|^[+~-] extensions\.worktreeconfig$'
+# 🔴 THE READER-FACING RENDERING OF THE HAZARD SET — THE ONLY ONE. The message
+# below used to retype this list, and the #773 delta re-audit caught it still
+# naming the pre-widening families while the regex matched more: a
+# `remote.origin.uploadpack` finding was explained as "core.* / user.* / url.*
+# / …", none of which it is. `test_the_shape_ledger_is_pinned_two_way` pins this
+# string AND checks every family it names really occurs in the regex, so the two
+# cannot drift apart again in the direction that bit us.
+NOGIT_HAZARD_FAMILIES='core.* / user.* / url.* / http.* / credential.* / include* / alias.*, or any remote.*/submodule.* key whose last component is url / pushurl / uploadpack / receivepack / proxy / update'
 _nogit_delta_shape() {
   local delta="$1"
   [ -n "$delta" ] || { printf 'unrecognised'; return 0; }
@@ -3377,11 +3387,22 @@ _nogit_render_keys() {
       printf '%s    read the two together — they can land in different windows.\n' "$pad"
       ;;
     hazard)
-      printf '%s→ SHAPE: HAZARD. At least one key above is the 2026-08-21 incident'"'"'s own\n' "$pad"
-      printf '%s  shape (core.* / user.* / url.* / http.* / credential.* / include* /\n' "$pad"
-      printf '%s  alias.*). Nothing routine rewrites those in an existing clone, so the\n' "$pad"
-      printf '%s  LEADING hypothesis is a test in the target above escaping isolation.\n' "$pad"
+      # 🔴 THE FAMILY LIST IS READ FROM THE LEDGER, NOT RETYPED HERE. The delta
+      # re-audit of #773 found this sentence still enumerating the OLD set after
+      # the regex had widened: a `remote.origin.uploadpack` finding printed
+      # "(core.* / user.* / url.* / …)", naming none of the families the key
+      # actually belongs to. That is the prose-contradicts-code defect this
+      # whole branch exists to close, re-instated by its own fix round — so the
+      # duplication is gone rather than corrected.
+      printf '%s→ SHAPE: HAZARD. At least one key above is in the set this guard treats\n' "$pad"
+      printf '%s  as hazardous: %s.\n' "$pad" "$NOGIT_HAZARD_FAMILIES"
+      printf '%s  Nothing routine rewrites those in an existing clone, so the LEADING\n' "$pad"
+      printf '%s  hypothesis is a test in the target above escaping isolation.\n' "$pad"
       printf '%s  AUDIT THE TARGET FIRST. Still a ranking, not a verdict.\n' "$pad"
+      printf '%s  ⚠ ONE EXCEPTION WORTH CHECKING FIRST: `git submodule init` and\n' "$pad"
+      printf '%s    `git submodule update --init` write submodule.<n>.url and .update\n' "$pad"
+      printf '%s    into this same shared config, routinely. If the key above is one of\n' "$pad"
+      printf '%s    those and this repo has submodules, look there before any test.\n' "$pad"
       ;;
     *)
       if [ -n "$delta" ]; then
@@ -3526,7 +3547,7 @@ for entry in ${NOGIT_SEEN[@]+"${NOGIT_SEEN[@]}"}; do
       if [ "$_thas_global" -eq 1 ]; then
         nogit_lead="🔴 AND ONE OF THE FILES BELOW IS A GLOBAL ONE, WHICH *IS* ATTRIBUTABLE: no concurrent worktree operation writes the operator's global git config, so whatever reached it did so from inside this run. AUDIT THIS TARGET FIRST, starting with the [global-enforced] file. The window caveat below applies to the repo-local file only."
       elif [ "$_tshape" = "hazard" ]; then
-        nogit_lead="🔴 AND THE KEY DELTA BELOW POINTS AT THIS TARGET: it carries a key of the 2026-08-21 incident's own shape, which nothing routine writes into an existing clone. AUDIT THIS TARGET FIRST. The window caveat still applies and is stated below, but do not start there."
+        nogit_lead="🔴 AND THE KEY DELTA BELOW POINTS AT THIS TARGET: it carries a key from the set this guard treats as hazardous — the per-file line below names WHICH, and the set it belongs to. Nothing routine writes those into an existing clone. AUDIT THIS TARGET FIRST. The window caveat still applies and is stated below, but do not start there."
       elif [ "$_tshape" = "ordinary" ]; then
         nogit_lead="🔴 THE TARGET NAMED HERE IS THE WINDOW, NOT A CULPRIT: that file is shared by every worktree of the clone, and any concurrent 'git branch' / 'checkout -b' / 'push -u' / 'worktree add' / 'maintenance start' in ANY of them rewrites it while this run is going."
       else

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -2126,6 +2126,108 @@ _nogit_is_repo_local() { # $1 = path -> 0 when it is the shared repo-local confi
   done
   return 1
 }
+_nogit_repo_local_index() { # $1 = path -> its slot in NOGIT_REPO_LOCAL, or nothing
+  local p="$1" i
+  for ((i = 0; i < ${#NOGIT_REPO_LOCAL[@]}; i++)); do
+    [ "${NOGIT_REPO_LOCAL[i]}" = "$p" ] && { printf '%s' "$i"; return 0; }
+  done
+  return 1
+}
+
+# --- WHAT MOVED, BY KEY NAME ---------------------------------------------------
+# 🔴 THIS IS THE FIX FOR AN ATTRIBUTION MESSAGE, NOT A NEW DETECTOR. The verdict
+# is unchanged: an unattributable repo-local delta still FAILS exactly as before.
+# What changed is that the failure now says WHICH KEYS moved, because that is the
+# one thing that separates the two hypotheses and the guard already had it.
+#
+# MEASURED 2026-08-23: on the operator's box GUARD 10 flagged
+# `<devrc>/.git/config` four separate times in one day and each time the message
+# named whichever target was in teardown. Every one of those writes was a
+# concurrent `git branch` / `worktree add` in the shared clone. The cost was a
+# four-run experiment by one agent and a diagnosis pass by the operator — all of
+# it spent auditing tests that had done nothing. `branch.<name>.remote` appearing
+# in the operator's real clone and a fixture write escaping a tmpdir are
+# STRUCTURALLY different events; the old sentence rendered them identically.
+#
+# 🔴 KEY NAMES ONLY, NEVER VALUES — and that is a hard requirement, not tidiness.
+# `<git-common-dir>/config` legitimately holds `remote.origin.url`, which on some
+# clones carries a token, and this output lands in CI logs. The rendering below
+# prints the left-hand side of each entry and nothing else; a VALUE-ONLY change
+# still surfaces, as `~ <key>`, with the value itself never leaving this file.
+#
+# `--list -z` rather than plain `--list`: with `-z` git separates ENTRIES with
+# NUL and key from value with a newline, so a multi-line config value cannot
+# masquerade as extra entries. Folding it back to one line per entry keeps the
+# diff a line diff.
+_nogit_config_entries() { # $1 = path -> "<key> <value…>", one per entry, sorted
+  [ -f "$1" ] || return 0
+  git config --file "$1" --list -z 2>/dev/null \
+    | tr '\n' ' ' | tr '\0' '\n' | LC_ALL=C sort
+}
+# $1 = before-snapshot file, $2 = after-snapshot file -> "<sign> <key>" lines.
+#   +  the key is new       -  the key is gone       ~  its value moved
+# Set semantics: two identical entries collapse to one, so a duplicated line is
+# invisible here. That is a limit of the RENDERING; the sha256 tripwire above is
+# what decides whether anything changed at all, and it saw the bytes.
+_nogit_key_delta() {
+  LC_ALL=C awk '
+    function key(l) { sub(/ .*$/, "", l); return l }
+    NR == FNR { b[$0] = 1; next }
+    { a[$0] = 1 }
+    END {
+      for (l in b) if (!(l in a)) rm[key(l)] = 1
+      for (l in a) if (!(l in b)) ad[key(l)] = 1
+      for (k in rm) if (k in ad) { ch[k] = 1; delete rm[k]; delete ad[k] }
+      for (k in ch) print "~ " k
+      for (k in ad) print "+ " k
+      for (k in rm) print "- " k
+    }' "$1" "$2" 2>/dev/null | LC_ALL=C sort -k2 -k1
+}
+# 🔴 THE SHAPE VERDICT RANKS TWO HYPOTHESES; IT NEVER CLEARS THE TARGET.
+# $1 = the "<sign> <key>" lines -> one of: ordinary | hazard | unrecognised
+#
+#   hazard   any `core.*` / `user.*` / `url.*` / `http.*` / `credential.*` /
+#            `include*` / `alias.*` key, PLUS `remote.<name>.url|pushurl`. That
+#            is the 2026-08-21 incident's own shape (`core.hooksPath` --global,
+#            `core.bare = true` on a populated tree, ~63 fixture commits pushed
+#            to the REAL origin); nothing routine rewrites these in an existing
+#            clone. Hazard WINS over ordinary in a mixed delta — the safe
+#            direction, and the reason `remote.<name>.url` is HERE while the
+#            rest of `remote.*` is below: `git remote add` in a test is how a
+#            fixture reaches a real remote, and no ordinary session rewrites an
+#            established clone's origin URL mid-run.
+#   ordinary `branch.*` / `remote.*` (except the two above) / `worktree.*` /
+#            `submodule.*` / `maintenance.*` / `extensions.worktreeconfig`, and
+#            nothing else. These are what `git branch`, `checkout -b`,
+#            `push -u`, `worktree add` and `maintenance start` write. A hermetic
+#            test works under a tmpdir and has no route to them in the
+#            operator's real clone.
+#   unrecognised  anything else, including an empty delta. Ranked as NEITHER —
+#            an unknown key must not be laundered into "probably concurrent".
+_nogit_delta_shape() {
+  local delta="$1"
+  [ -n "$delta" ] || { printf 'unrecognised'; return 0; }
+  if printf '%s\n' "$delta" \
+     | grep -qiE '^[+~-] (core|user|url|http|credential|include|includeif|alias)\.|^[+~-] remote\..*\.(url|pushurl)$'; then
+    printf 'hazard'; return 0
+  fi
+  if printf '%s\n' "$delta" \
+     | grep -qvE '^[+~-] (branch|remote|worktree|submodule|maintenance)\.|^[+~-] extensions\.worktreeconfig$'; then
+    printf 'unrecognised'; return 0
+  fi
+  printf 'ordinary'
+}
+# $1 = target, $2 = path -> the shape of THAT file's delta, or `none` when this
+# run recorded no key rows for the pair (the GLOBAL class). One reader for the
+# rows, used by the renderer and by the headline, so the two cannot disagree.
+_nogit_shape_for() {
+  local rows delta
+  rows="$(awk -F'\t' -v t="$1" -v p="$2" '$1 == t && $2 == p { print $3 }' \
+          "$NOGIT_KEYS_LOG" 2>/dev/null || true)"
+  [ -n "$rows" ] || { printf 'none'; return 0; }
+  delta="$(printf '%s\n' "$rows" | grep -v '^? ' || true)"
+  _nogit_delta_shape "$delta"
+}
 
 _nogit_fingerprint_of() { # $@ = paths -> one line each: "<sha256|ABSENT> <path>"
   local f
@@ -2146,10 +2248,16 @@ NOGIT_CONFIG="$NOGIT_DIR/gitconfig"
 NOGIT_SESSIONS_LOG="$NOGIT_DIR/sessions.log"
 NOGIT_CHANGED_LOG="$NOGIT_DIR/changed.log"
 NOGIT_EVIDENCE_LOG="$NOGIT_DIR/evidence.log"
+NOGIT_KEYS_LOG="$NOGIT_DIR/keydelta.log"
 # 🔴 THE EVIDENCE LOG IS IN THIS CHECK, not just in the list above. It is the
 # only record of WHY anything was downgraded, there is no `set -e` here, and an
-# unwritable one would silently produce downgrades with no stated cause.
-if ! : > "$NOGIT_CONFIG" || ! : > "$NOGIT_CHANGED_LOG" || ! : > "$NOGIT_EVIDENCE_LOG"; then
+# unwritable one would silently produce downgrades with no stated cause. The
+# key-delta log is in it for the same reason one step further on: an unwritable
+# one would produce a failure message with an EMPTY "keys that moved" list, and an
+# empty list reads as "nothing identifiable moved" — a claim about the file when
+# it is really a claim about this directory.
+if ! : > "$NOGIT_CONFIG" || ! : > "$NOGIT_CHANGED_LOG" || ! : > "$NOGIT_EVIDENCE_LOG" \
+   || ! : > "$NOGIT_KEYS_LOG"; then
   echo "run-tests: FATAL — could not create the git-isolation files under" >&2
   echo "  $NOGIT_DIR. Refusing to run: without them a test that calls" >&2
   echo "  'git config --global' rewrites the operator's ~/.gitconfig, and a" >&2
@@ -2362,6 +2470,17 @@ _nogit_mark_before() {
   NOGIT_B_FP="$(_nogit_fingerprint)"
   NOGIT_B_CTL="$(_nogit_controls)"
   NOGIT_B_S="$(_spool_lines "$NOGIT_SESSIONS_LOG")"
+  # The key snapshot is taken for EVERY target, unconditionally, because the
+  # question it answers only exists once a delta has already happened — by then
+  # the "before" is gone. Absent or unreadable file -> an empty snapshot, which
+  # the delta renders as "every key is new"; that is honest and visible, and it
+  # is why the reason for an empty delta is stated rather than left blank.
+  local i p
+  for ((i = 0; i < ${#NOGIT_REPO_LOCAL[@]}; i++)); do
+    p="${NOGIT_REPO_LOCAL[i]}"
+    _nogit_config_entries "$p" > "$NOGIT_DIR/keys-before.$i" 2>/dev/null \
+      || : > "$NOGIT_DIR/keys-before.$i"
+  done
 }
 # $1 = target name. Every call MUST be preceded by the before-mark above, or the
 # range it records belongs to whatever ran previously.
@@ -2390,12 +2509,34 @@ _nogit_account() {
     _nogit_cotenancy_probe "$t"
     [ "$NOGIT_EV_STATUS" = "proven" ] && proven=1
   fi
+  local idx delta
   for path in ${CHANGED[@]+"${CHANGED[@]}"}; do
     if _nogit_is_repo_local "$path"; then
       if [ "$proven" -eq 1 ]; then
         cls="repo-local-reported"; rep=$(( rep + 1 ))
       else
         cls="repo-local-enforced"; n=$(( n + 1 ))
+      fi
+      # 🔴 RECORDED FOR BOTH OUTCOMES. A downgraded delta gets the same key
+      # listing as an enforced one: the reader's question ("who wrote this?") is
+      # identical, and only the verdict differs.
+      if idx="$(_nogit_repo_local_index "$path")"; then
+        _nogit_config_entries "$path" > "$NOGIT_DIR/keys-after.$idx" 2>/dev/null \
+          || : > "$NOGIT_DIR/keys-after.$idx"
+        delta="$(_nogit_key_delta "$NOGIT_DIR/keys-before.$idx" "$NOGIT_DIR/keys-after.$idx")"
+        if [ -n "$delta" ]; then
+          while IFS= read -r line; do
+            [ -n "$line" ] || continue
+            printf '%s\t%s\t%s\n' "$t" "$path" "$line" >> "$NOGIT_KEYS_LOG"
+          done <<<"$delta"
+        else
+          # 🔴 NEVER AN EMPTY LIST. The bytes moved — the tripwire is what said
+          # so — and no key-level delta was visible, which is a DIFFERENT fact
+          # from "nothing moved" and must not render as one.
+          printf '%s\t%s\t%s\n' "$t" "$path" \
+            "? the file's bytes changed but no key-level delta was visible: a comment, whitespace, key reordering, a duplicated entry, or 'git config --file' could not parse it" \
+            >> "$NOGIT_KEYS_LOG"
+        fi
       fi
     else
       cls="global-enforced"; n=$(( n + 1 ))
@@ -3124,6 +3265,68 @@ else
        "(always enforcing)  repo-local:${#NOGIT_REPO_LOCAL[@]}" \
        "(enforcing unless another writer is PROVEN — see #730)"
 fi
+# 🔴 THE DISCRIMINATOR, RENDERED BESIDE THE FILE IT DESCRIBES.
+# $1 = target, $2 = changed path, $3 = indent. Prints nothing for a file this run
+# recorded no key rows for — today that is exactly the GLOBAL class.
+#
+# 🔴 THAT IS A DELIBERATE SCOPE LIMIT, NOT COVERAGE. The misattribution this
+# rendering fixes was repo-local: a global file has no concurrent writer to
+# confuse it with, so its one-line "reached the operator's file some other way"
+# is not wrong the way the repo-local sentence was. It is still LESS informative
+# than it could be — a `core.hooksPath` landing in `~/.gitconfig` would be worth
+# naming — so read the silence here as "not extended yet", never as "the global
+# class has nothing to say".
+#
+# Never prints an empty "keys that moved" list: `_nogit_account` writes a `?` row
+# with its reason when the bytes moved and no key delta was visible, and that row
+# is rendered as the reason. An empty list would read as "nothing identifiable
+# moved", which is a claim about the FILE; the truth would be a claim about the
+# PARSE.
+_nogit_render_keys() {
+  local t="$1" p="$2" pad="$3" rows delta unk shape
+  rows="$(awk -F'\t' -v t="$t" -v p="$p" '$1 == t && $2 == p { print $3 }' \
+          "$NOGIT_KEYS_LOG" 2>/dev/null || true)"
+  [ -n "$rows" ] || return 0
+  unk="$(printf '%s\n' "$rows" | grep '^? ' || true)"
+  delta="$(printf '%s\n' "$rows" | grep -v '^? ' || true)"
+  printf '%skeys that moved in this file (NAMES ONLY — values are never printed,\n' "$pad"
+  printf '%sbecause remote.<name>.url can carry a token and this lands in CI logs):\n' "$pad"
+  if [ -n "$delta" ]; then
+    printf '%s\n' "$delta" | sed "s|^|$pad  |"
+  fi
+  if [ -n "$unk" ]; then
+    printf '%s\n' "$unk" | sed "s|^? |$pad  NOT VISIBLE — |"
+  fi
+  shape="$(_nogit_shape_for "$t" "$p")"
+  case "$shape" in
+    ordinary)
+      printf '%s→ SHAPE: ORDINARY GIT. Every key above is one that "git branch",\n' "$pad"
+      printf '%s  "checkout -b", "push -u", "worktree add", "remote add" or\n' "$pad"
+      printf '%s  "maintenance start" writes into the SHARED config of a clone. A\n' "$pad"
+      printf '%s  hermetic test works under a tmpdir and has no route to the operator'"'"'s\n' "$pad"
+      printf '%s  real clone, so the LEADING hypothesis is a concurrent git command in\n' "$pad"
+      printf '%s  another worktree or session, and the target above is the SECOND. This\n' "$pad"
+      printf '%s  is a RANKING, not a verdict — this run proved neither.\n' "$pad"
+      ;;
+    hazard)
+      printf '%s→ SHAPE: HAZARD. At least one key above is the 2026-08-21 incident'"'"'s own\n' "$pad"
+      printf '%s  shape (core.* / user.* / url.* / http.* / credential.* / include* /\n' "$pad"
+      printf '%s  alias.*). Nothing routine rewrites those in an existing clone, so the\n' "$pad"
+      printf '%s  LEADING hypothesis is a test in the target above escaping isolation.\n' "$pad"
+      printf '%s  AUDIT THE TARGET FIRST. Still a ranking, not a verdict.\n' "$pad"
+      ;;
+    *)
+      printf '%s→ SHAPE: UNRECOGNISED. The keys above match neither the ordinary-git set\n' "$pad"
+      printf '%s  nor the known-hazard set, so this run cannot rank the two hypotheses.\n' "$pad"
+      printf '%s  Do not read that as either one.\n' "$pad"
+      ;;
+  esac
+  printf '%sDiscriminate before auditing any test, cheapest first:\n' "$pad"
+  printf '%s  stat -c '"'"'%%y %%n'"'"' %s\n' "$pad" "$p"
+  printf '%s  git -C %s worktree list      # a SIBLING worktree the probe cannot see\n' "$pad" "$ROOT"
+  printf '%s  git -C %s reflog --date=iso | head -20\n' "$pad" "$ROOT"
+}
+
 nogit_problems=()
 nogit_reported_total=0
 for t in "${TARGETS[@]}"; do
@@ -3168,9 +3371,29 @@ for entry in ${NOGIT_SEEN[@]+"${NOGIT_SEEN[@]}"}; do
   # proven external writer is in `$greported` instead and is rendered below,
   # never here and never silently.
   if [ "$gchanged" -gt 0 ]; then
-    changed_names="$(awk -F'\t' -v t="$gt" \
-      '$1 == t && $2 != "repo-local-reported" { printf "             %s  [%s]\n", $3, $2 }' \
-      "$NOGIT_CHANGED_LOG" 2>/dev/null || true)"
+    changed_names=""
+    _tshape="none"
+    while IFS=$'\t' read -r _ct _ccls _cpath; do
+      [ -n "$_cpath" ] || continue
+      changed_names+="             $_cpath  [$_ccls]"$'\n'
+      # Aggregate the worst shape across this target's changed files, hazard
+      # first. It picks the LEAD SENTENCE below, so a mixed run must lead with
+      # the accusatory one — under-warning is the expensive direction here.
+      case "$(_nogit_shape_for "$gt" "$_cpath")" in
+        hazard)       _tshape="hazard" ;;
+        unrecognised) if [ "$_tshape" != "hazard" ]; then _tshape="unrecognised"; fi ;;
+        ordinary)     if [ "$_tshape" = "none" ];   then _tshape="ordinary"; fi ;;
+      esac
+      # 🔴 THE KEY LISTING GOES *WITH THE FILE*, not in the prose above it. A
+      # run can carry more than one changed file, and a reader who has to pair
+      # a floating key list with a path by eye is back to guessing.
+      _kb="$(_nogit_render_keys "$gt" "$_cpath" "               ")"
+      [ -n "$_kb" ] && changed_names+="$_kb"$'\n'
+    done < <(awk -F'\t' -v t="$gt" \
+      '$1 == t && $2 != "repo-local-reported" { print }' \
+      "$NOGIT_CHANGED_LOG" 2>/dev/null || true)
+    changed_names="${changed_names%$'\n'}"
+    unset _ct _ccls _cpath _kb
     # The cause differs by class, and the old single sentence was a confident
     # misdiagnosis for the repo-local one: it sent the reader to audit a target
     # that had done nothing (#730).
@@ -3182,11 +3405,31 @@ for entry in ${NOGIT_SEEN[@]+"${NOGIT_SEEN[@]}"}; do
       # Telling a reader no other writer exists, when the writer this guard
       # exists for is structurally invisible, is the same class of confident
       # misdiagnosis #730 was filed about.
-      nogit_why="A repo-local one is a write to <git-common-dir>/config, which GIT_CONFIG_GLOBAL does not govern at all — and this run FOUND NO PROOF of another writer, so the change is attributed to this target. What was actually checked: no live process outside this run's own lineage had its cwd inside the git dir or its parent. That does NOT cover a session sitting in a SIBLING worktree of the same clone, which is invisible to this probe — if that is what wrote here, 'git reflog' and the file's mtime will say so. A global one reached the operator's file some other way: code that removes GIT_CONFIG_GLOBAL from its own environment."
+      #
+      # 🔴 AND THE SENTENCE THAT FOLLOWED IT WAS THE SAME MISTAKE ONE STEP ON.
+      # It read "so the change is attributed to this target" — a VERDICT, from a
+      # probe that had just been described as blind to the likeliest writer.
+      # MEASURED 2026-08-23: four such failures in one day on the operator's box,
+      # every one of them a concurrent `git branch`/`worktree add` in the shared
+      # clone, every one of them reported against whichever target was in
+      # teardown. The window is now stated as a WINDOW, both hypotheses are named
+      # in the order the key delta supports, and the discriminators are printed
+      # beside the file. The VERDICT is unchanged — this still fails the run.
+      # The LEAD SENTENCE follows the key delta, because a `core.hooksPath` write
+      # and a `branch.<name>.remote` write are not the same event and leading
+      # both with "not a culprit" would under-warn on the one that IS the
+      # incident. The window caveat is stated in every arm regardless — it is a
+      # fact about the file, not about the shape.
+      if [ "$_tshape" = "hazard" ]; then
+        nogit_lead="🔴 AND THE KEY DELTA BELOW POINTS AT THIS TARGET: it carries a key of the 2026-08-21 incident's own shape, which nothing routine writes into an existing clone. AUDIT THIS TARGET FIRST. The window caveat still applies and is stated below, but do not start there."
+      else
+        nogit_lead="🔴 THE TARGET NAMED HERE IS THE WINDOW, NOT A CULPRIT: that file is shared by every worktree of the clone, and any concurrent 'git branch' / 'checkout -b' / 'push -u' / 'worktree add' / 'maintenance start' in ANY of them rewrites it while this run is going."
+      fi
+      nogit_why="A repo-local one is a write to <git-common-dir>/config, which GIT_CONFIG_GLOBAL does not govern at all. $nogit_lead This run FOUND NO PROOF of another writer, so the delta is REPORTED AGAINST whatever happened to be running — the probe only asks whether a live process outside this run's own lineage has its cwd inside the git dir or its parent, so a session sitting in a SIBLING worktree of the same clone is invisible to it. Read the key delta beside the file below BEFORE auditing any test. A global one is different and IS attributable: it reached the operator's file some other way — code that removes GIT_CONFIG_GLOBAL from its own environment."
     else
       nogit_why="GIT_CONFIG_GLOBAL redirects 'git config --global', so this reached them some other way — code that removes the variable from its own environment."
     fi
-    nogit_problems+=("$gt  — CHANGED $gchanged of the operator's protected git config file(s) while it ran. $nogit_why"$'\n'"$changed_names")
+    nogit_problems+=("$gt  — 🔴 $gchanged of the operator's protected git config file(s) changed DURING this target's window. $nogit_why"$'\n'"$changed_names")
   fi
 
   if [ "$is_pytest" -eq 1 ]; then
@@ -3218,8 +3461,16 @@ done
 echo "    repo-local-reported-total=$nogit_reported_total  (deltas to <git-common-dir>/config this run could NOT attribute)"
 if [ "$nogit_reported_total" -gt 0 ]; then
   echo "    ---- repo-local git config: REPORTED, not enforced (#730) ----"
-  awk -F'\t' '$2 == "repo-local-reported" { printf "      %s\n        changed: %s\n", $1, $3 }' \
-    "$NOGIT_CHANGED_LOG" 2>/dev/null || true
+  # The same key listing the ENFORCED arm gets. A downgrade answers "this run
+  # will not fail you for it"; it does not answer "who wrote it", which is the
+  # question the reader actually has, and the rows are already recorded.
+  while IFS=$'\t' read -r _rt _rcls _rpath; do
+    [ -n "$_rpath" ] || continue
+    printf '      %s\n        changed: %s\n' "$_rt" "$_rpath"
+    _nogit_render_keys "$_rt" "$_rpath" "          "
+  done < <(awk -F'\t' '$2 == "repo-local-reported" { print }' \
+    "$NOGIT_CHANGED_LOG" 2>/dev/null || true)
+  unset _rt _rcls _rpath
   awk -F'\t' '$2 == "proven" { printf "      %s\n        cannot attribute: %s\n", $1, $3 }' \
     "$NOGIT_EVIDENCE_LOG" 2>/dev/null || true
   echo "      This file is the git COMMON dir's config, shared by every worktree of"

--- a/scripts/tests/test_nogit_isolation.py
+++ b/scripts/tests/test_nogit_isolation.py
@@ -1026,6 +1026,226 @@ def test_a_repo_local_change_still_FAILS_when_no_cotenant_is_proven(tmp_path):
         f"the failure did not NAME the file that changed:\n{block}\n---\n{out}")
 
 
+# --------------------------------------------------------------------------- #
+# 🔴 THE ATTRIBUTION MESSAGE — WHAT MOVED, AND WHICH HYPOTHESIS IT SUPPORTS
+# --------------------------------------------------------------------------- #
+# MEASURED 2026-08-23 on the operator's box: GUARD 10 flagged `<devrc>/.git/config`
+# FOUR separate times in one day and each time the message named whichever target
+# was in teardown ("…so the change is attributed to this target"). Every one of
+# those writes was a concurrent `git branch` / `worktree add` in the shared clone.
+# Cost: a four-run experiment by one agent and a diagnosis pass by the operator,
+# all of it auditing tests that had done nothing.
+#
+# The DETECTION is deliberately unchanged — an unattributable repo-local delta
+# still fails the run, and the controls below pin that in both directions. What
+# these tests pin is the MESSAGE: the key names that moved, and a ranking that
+# follows them rather than always landing on the target.
+#
+# WHAT IS REGRESSION COVERAGE HERE AND WHAT IS NOT:
+#   * `test_an_ORDINARY_git_delta_does_not_blame_the_target` is THE regression
+#     test. Base prints the accusatory sentence and no key delta at all.
+#   * the HAZARD, VALUE and NOT-VISIBLE tests are NEGATIVE CONTROLS on the
+#     ranking, the redaction and the empty list. They are red at base only
+#     because base emits none of this; the behaviour they defend is "the fix did
+#     not overshoot into always excusing the target", "a config VALUE is never
+#     printed", and "an unobservable delta says so instead of rendering blank".
+
+def _plant_repo_local_keys(scratch: Path, *pairs: tuple[str, str]) -> str:
+    """A shell target that writes specific KEYS into the scratch clone's config.
+
+    Same no-shebang convention as `_plant_repo_local_write` above, and for the
+    same reason: `run-tests.sh` invokes SHELL_TESTS as `bash "$SHELL_TEST"`.
+    """
+    name = "g10-write-keys.sh"
+    body = "set -euo pipefail\n" + "".join(
+        f'git -C "{scratch}" config {k} {v}\n' for k, v in pairs)
+    (scratch / name).write_text(body, encoding="utf-8")
+    return name
+
+
+def test_an_ORDINARY_git_delta_does_not_blame_the_target(tmp_path):
+    """🔴 THE REGRESSION TEST for the four misattributions of 2026-08-23.
+
+    `branch.<name>.remote` / `.merge` appearing in a clone's SHARED config is
+    what `git branch --track`, `checkout -b --track` and `push -u` write. The
+    run must still FAIL — that is the guard's job and it is unchanged — but the
+    message must name the keys and rank the concurrent writer FIRST, instead of
+    telling the reader the target did it.
+    """
+    scratch = _scratch_root(tmp_path)
+    name = _plant_repo_local_keys(
+        scratch,
+        ("branch.topic-x.remote", "origin"),
+        ("branch.topic-x.merge", "refs/heads/topic-x"))
+    runner = _runner_over(tmp_path, scratch, [name])
+
+    assert not live_cotenants([scratch / ".git"]), (
+        "something is already sitting in this scratch root, so this run would "
+        "take the DOWNGRADE arm and measure a different message")
+    proc = _run_at(runner, scratch, tmp_path)
+    out = proc.stdout + proc.stderr
+
+    # 🔴 THE DETECTION IS UNCHANGED. Without this the whole fix is satisfied by
+    # a patch that simply stops failing, which is the outcome the message was
+    # annoying enough to tempt someone into.
+    assert proc.returncode != 0, (
+        f"the run PASSED — the message fix silently disarmed the guard:\n{out}")
+
+    block = _guard10_failure_block(out)
+    assert block, f"GUARD 10's failure block was not printed at all:\n{out}"
+    # The sentence that was wrong four times. Its absence is the fix.
+    assert "attributed to this target" not in block, (
+        f"the failure still hands the reader a VERDICT it cannot support:\n{block}")
+    assert "WINDOW, NOT A CULPRIT" in block, (
+        f"the failure did not say the target is the window rather than the "
+        f"writer:\n{block}")
+    # 🔴 The keys themselves, in GUARD 10's block — not merely somewhere in the
+    # run. Same reason `_guard10_failure_block` exists.
+    assert "+ branch.topic-x.remote" in block, (
+        f"the failure did not name the key that moved:\n{block}")
+    assert "+ branch.topic-x.merge" in block, (
+        f"the failure named only one of the two keys that moved:\n{block}")
+    assert "SHAPE: ORDINARY GIT" in block, (
+        f"the failure did not classify the delta's shape:\n{block}")
+    assert "LEADING hypothesis is a concurrent git command" in block, (
+        f"the failure did not rank the concurrent writer first:\n{block}")
+    # A ranking, never a clearance — the probe proved nothing either way.
+    assert "RANKING, not a verdict" in block, (
+        f"the failure presented its ranking as a finding:\n{block}")
+    assert "worktree list" in block, (
+        f"the failure did not hand over the discriminator for the blind spot it "
+        f"just admitted to:\n{block}")
+
+
+def test_a_HAZARD_shaped_delta_still_points_at_the_target(tmp_path):
+    """🔴 NEGATIVE CONTROL ON THE RANKING — the fix must not overshoot.
+
+    `core.hooksPath` written into a clone's config is the 2026-08-21 incident
+    itself. If the new wording led with "the target is the window, not a
+    culprit" here it would have traded one confident misdiagnosis for its
+    mirror image, and the guard's whole reason for existing reads as noise.
+    """
+    scratch = _scratch_root(tmp_path)
+    name = _plant_repo_local_keys(
+        scratch, ("core.hooksPath", "/tmp/planted-by-a-test"))
+    runner = _runner_over(tmp_path, scratch, [name])
+
+    proc = _run_at(runner, scratch, tmp_path)
+    out = proc.stdout + proc.stderr
+    assert proc.returncode != 0, (
+        f"a core.hooksPath write into the clone's config PASSED:\n{out}")
+
+    block = _guard10_failure_block(out)
+    assert block, f"GUARD 10's failure block was not printed at all:\n{out}"
+    # git lower-cases key names in `--list`; pin what is actually printed.
+    assert "+ core.hookspath" in block, (
+        f"the failure did not name the key that moved:\n{block}")
+    assert "SHAPE: HAZARD" in block, (
+        f"the incident's own key shape was not classified as a hazard:\n{block}")
+    assert "AUDIT THIS TARGET FIRST" in block, (
+        f"the failure did not send the reader to the target:\n{block}")
+    assert "WINDOW, NOT A CULPRIT" not in block, (
+        f"the failure led with the concurrent-writer excuse on a delta that is "
+        f"the 2026-08-21 incident's own shape:\n{block}")
+
+
+def test_the_key_delta_never_prints_a_config_VALUE(tmp_path):
+    """🔴 NEGATIVE CONTROL ON REDACTION, with its positive control beside it.
+
+    `<git-common-dir>/config` holds `remote.<name>.url`, which on some clones
+    carries a token, and this output lands in CI logs. The rendering prints key
+    NAMES only — so a value-only change must still surface (positive control:
+    the key name appears, marked `~`) while the value must not appear ANYWHERE
+    in the run's output, not merely outside GUARD 10's block.
+    """
+    scratch = _scratch_root(tmp_path)
+    secret = "s3cr3t-token-that-must-never-be-printed"
+    seed = subprocess.run(
+        ["git", "-C", str(scratch), "config", "remote.origin.url",
+         "https://example.invalid/before"],
+        capture_output=True, text=True, timeout=120)
+    assert seed.returncode == 0, f"could not seed the remote URL:\n{seed.stderr}"
+    name = _plant_repo_local_keys(
+        scratch, ("remote.origin.url", f"https://example.invalid/{secret}"))
+    runner = _runner_over(tmp_path, scratch, [name])
+
+    proc = _run_at(runner, scratch, tmp_path)
+    out = proc.stdout + proc.stderr
+
+    # Positive control: the write really landed, so a clean output below is
+    # about the RENDERING and not about a write that never happened.
+    assert secret in (scratch / ".git" / "config").read_text(encoding="utf-8"), (
+        "the planted value never reached the config — this run proves nothing")
+    block = _guard10_failure_block(out)
+    assert block, f"GUARD 10's failure block was not printed at all:\n{out}"
+    assert "~ remote.origin.url" in block, (
+        f"a VALUE-only change did not surface as a moved key:\n{block}")
+    assert secret not in out, (
+        "a git config VALUE was printed into the run's output")
+
+
+def test_bytes_that_move_with_no_key_delta_SAY_SO(tmp_path):
+    """🔴 AN EMPTY LIST WOULD BE A CLAIM ABOUT THE FILE, NOT THE PARSE.
+
+    A comment appended to `.git/config` moves the bytes the tripwire hashes and
+    changes nothing `git config --list` reports. Rendering that as an empty
+    "keys that moved" list reads as "nothing identifiable changed" — which is
+    the same shape of confident silence this whole fix exists to remove.
+    """
+    scratch = _scratch_root(tmp_path)
+    name = "g10-comment.sh"
+    (scratch / name).write_text(
+        "set -euo pipefail\n"
+        f'printf "\\t# planted by a test\\n" >> "{scratch}/.git/config"\n',
+        encoding="utf-8")
+    runner = _runner_over(tmp_path, scratch, [name])
+
+    proc = _run_at(runner, scratch, tmp_path)
+    out = proc.stdout + proc.stderr
+    assert proc.returncode != 0, (
+        f"a byte-level change to the clone's config PASSED:\n{out}")
+
+    block = _guard10_failure_block(out)
+    assert block, f"GUARD 10's failure block was not printed at all:\n{out}"
+    assert "NOT VISIBLE" in block, (
+        f"a delta with no visible keys rendered as an empty list:\n{block}")
+    assert "no key-level delta was visible" in block, (
+        f"the failure did not say WHY the key list is empty:\n{block}")
+    assert "SHAPE: UNRECOGNISED" in block, (
+        f"an unobservable delta was ranked instead of declared unrankable:"
+        f"\n{block}")
+
+
+def test_the_DOWNGRADED_block_also_carries_the_key_delta(tmp_path):
+    """The reader's question is the same whether the run failed or not.
+
+    A downgrade answers "this will not fail you"; it does not answer "who wrote
+    it". The rows are already recorded, so withholding them here would leave the
+    #730 arm — the common one on the operator's box — as uninformative as the
+    message this change replaced.
+    """
+    scratch = _scratch_root(tmp_path)
+    name = _plant_repo_local_keys(scratch, ("branch.topic-y.remote", "origin"))
+    runner = _runner_over(tmp_path, scratch, [name])
+
+    with _cotenant(scratch):
+        proc = _run_at(runner, scratch, tmp_path)
+    out = proc.stdout + proc.stderr
+    assert proc.returncode == 0, (
+        f"a repo-local change with a PROVEN external writer failed the run — "
+        f"this test is measuring the wrong arm:\n{out}")
+
+    head = "---- repo-local git config: REPORTED, not enforced (#730) ----"
+    tail = "This file is the git COMMON dir's config"
+    assert head in out and tail in out, (
+        f"the downgrade block was not printed as expected:\n{out}")
+    block = out.split(head, 1)[1].split(tail, 1)[0]
+    assert "+ branch.topic-y.remote" in block, (
+        f"the downgrade block did not say WHICH key moved:\n{block}")
+    assert "SHAPE: ORDINARY GIT" in block, (
+        f"the downgrade block did not classify the delta's shape:\n{block}")
+
+
 def test_a_global_change_FAILS_even_with_a_cotenant_PROVEN(tmp_path):
     """🔴 NEGATIVE CONTROL on the CLASS BOUNDARY — NOT regression coverage.
 

--- a/scripts/tests/test_nogit_isolation.py
+++ b/scripts/tests/test_nogit_isolation.py
@@ -1539,6 +1539,96 @@ def test_a_LARGE_unrecognised_delta_is_not_flattened_to_ORDINARY(tmp_path):
         f"the headline ranked a delta of unknown keys:\n{block[:2000]}")
 
 
+def test_the_hazard_message_NAMES_the_family_the_key_belongs_to(tmp_path):
+    """🔴 THE PROSE-CONTRADICTS-CODE BUG, RE-INSTATED BY THE FIX ROUND ITSELF.
+
+    After the hazard regex widened to cover `remote.*.uploadpack` and friends,
+    the sentence the operator READS still enumerated the pre-widening families,
+    so a real finding was explained by a list that excluded it. The ledger test
+    pins the string; this pins that the string is what actually gets PRINTED
+    beside the key — a ledger nobody renders is still a ledger nobody reads.
+    """
+    scratch = _scratch_root(tmp_path)
+    name = _plant_repo_local_keys(
+        scratch, ("remote.origin.uploadpack", "/tmp/planted-uploadpack"))
+    runner = _runner_over(tmp_path, scratch, [name])
+
+    proc = _run_at(runner, scratch, tmp_path)
+    out = proc.stdout + proc.stderr
+    block = _guard10_failure_block(out)
+    assert block, f"GUARD 10's failure block was not printed at all:\n{out}"
+    assert "SHAPE: HAZARD" in block, f"the key was not ranked hazard:\n{block}"
+    assert "uploadpack" in block.split("SHAPE: HAZARD", 1)[1], (
+        f"the HAZARD explanation does not name the family the key that "
+        f"triggered it belongs to — the reader is handed a list that excludes "
+        f"their own finding:\n{block}")
+    # The routine writer of the one hazard key an ordinary git command produces.
+    assert "git submodule init" in block, (
+        f"the hazard arm does not name the routine writer of "
+        f"submodule.<n>.url/.update, so a submodule-bearing repo gets "
+        f"'AUDIT THIS TARGET FIRST' with no way to discriminate:\n{block}")
+
+
+def test_an_ABORTED_run_still_shreds_the_config_snapshots(tmp_path):
+    """🔴 THE SNAPSHOTS HOLD REAL CONFIG VALUES; A KILLED RUN USED TO KEEP THEM.
+
+    `$NOGIT_DIR/keys-{before,after}.N` are full `key<TAB>value` dumps of the
+    operator's real `<git-common-dir>/config` — `remote.origin.url` included.
+    Cleanup lived only on the normal path, so every TERM/INT/abort left them on
+    disk. Moving it into the EXIT trap fixed that, and the delta re-audit then
+    showed the fix was UNPINNED: deleting the `rm -rf` left the whole file
+    green. A guard nobody can break is a guard nobody is testing.
+
+    🔴 THE MATRIX, STATED SO THE LABEL IS NOT INFERRED. RED at `a7499d67`
+    (measured: the dir "survived a TERM"), GREEN at `089883d8` — because the
+    trap fix already landed there. So against 089883d8 this is MUTATION
+    coverage for an unpinned fix, not regression coverage; it is regression
+    coverage only relative to a7499d67.
+
+    Also asserts the verdict still prints and rc is still 143 — the cleanup runs
+    AFTER `_emit_verdict` precisely so it cannot swallow either.
+    """
+    scratch = _scratch_root(tmp_path)
+    name = _plant_repo_local_keys(scratch, ("branch.topic-abort.remote", "origin"))
+    runner = _runner_over(tmp_path, scratch, [name])
+
+    env = {**os.environ, **_unguarded_home(tmp_path)}
+    for k, v in list(env.items()):
+        if v is None:
+            del env[k]
+    proc = subprocess.Popen(["bash", str(runner), str(scratch)],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                            text=True, cwd=str(REPO_ROOT), env=env)
+    nogit_dir = None
+    assert proc.stdout is not None
+    captured = []
+    for line in proc.stdout:                      # read until the dir is named
+        captured.append(line)
+        if "GIT_CONFIG_GLOBAL=" in line:
+            nogit_dir = Path(line.split("GIT_CONFIG_GLOBAL=", 1)[1].strip()).parent
+            break
+    assert nogit_dir is not None, (
+        "the runner never announced its isolated config, so this test never "
+        "learned which directory to watch:\n" + "".join(captured))
+    # Positive control: the thing we are about to assert is GONE must first be
+    # THERE. Without it a passing test is indistinguishable from watching a
+    # directory that was never created.
+    assert nogit_dir.is_dir(), f"{nogit_dir} does not exist to begin with"
+
+    proc.terminate()
+    rest = proc.stdout.read()
+    proc.wait(timeout=120)
+    out = "".join(captured) + rest
+
+    assert not nogit_dir.exists(), (
+        f"{nogit_dir} survived a TERM. It holds key<TAB>value dumps of the "
+        f"operator's real git config:\n{sorted(p.name for p in nogit_dir.iterdir())}")
+    assert "RESULT: FAIL (exit=143)" in out, (
+        f"the cleanup ran but the verdict did not survive it:\n{out[-1500:]}")
+    assert proc.returncode == 143, (
+        f"the EXIT trap changed the process status: {proc.returncode}")
+
+
 def test_the_shape_ledger_is_pinned_two_way():
     """🔴 THE CLASSIFIER'S TWO SETS ARE A LEDGER, not prose plus a regex.
 
@@ -1574,6 +1664,33 @@ def test_the_shape_ledger_is_pinned_two_way():
         r"|^[+~-] extensions\.worktreeconfig$"
     ), ("the ORDINARY key set moved. Every key it gains gets the reassuring "
         "headline. Update this ledger in the SAME commit.")
+
+    # 🔴 THE READER-FACING RENDERING IS PART OF THE LEDGER, and the #773 delta
+    # re-audit is why. The hazard message used to RETYPE the family list, and
+    # after the regex widened it still named the pre-widening set: a
+    # `remote.origin.uploadpack` finding was explained as "core.* / user.* /
+    # url.* / …", none of which it is. Prose contradicting the code it describes
+    # is the defect class this whole branch exists to close.
+    families = _assignment("NOGIT_HAZARD_FAMILIES")
+    assert families == (
+        "core.* / user.* / url.* / http.* / credential.* / include* / alias.*, "
+        "or any remote.*/submodule.* key whose last component is url / pushurl "
+        "/ uploadpack / receivepack / proxy / update"
+    ), ("the hazard set's READER-FACING rendering moved. It is what the operator "
+        "is shown when a run fails; keep it in step with NOGIT_HAZARD_KEYS.")
+
+    # And the half that catches real drift rather than an edit to this file:
+    # every family the prose NAMES must actually occur in the regex. A widened
+    # regex with a stale sentence passes the literal pin above (nobody touched
+    # the sentence) and fails here only if the sentence names something the
+    # regex dropped — so this is the direction that decays silently.
+    connectives = {"or", "any", "key", "whose", "last", "component", "is"}
+    named = {w for w in re.findall(r"[a-z]+", families)} - connectives
+    missing = sorted(w for w in named if w not in _assignment("NOGIT_HAZARD_KEYS"))
+    assert not missing, (
+        f"NOGIT_HAZARD_FAMILIES names {missing}, which NOGIT_HAZARD_KEYS does "
+        f"not match. The operator is being told this guard catches a key family "
+        f"it does not catch.")
 
 
 def test_a_global_change_FAILS_even_with_a_cotenant_PROVEN(tmp_path):

--- a/scripts/tests/test_nogit_isolation.py
+++ b/scripts/tests/test_nogit_isolation.py
@@ -58,11 +58,14 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
 import time
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS = REPO_ROOT / "scripts"
@@ -1055,10 +1058,17 @@ def _plant_repo_local_keys(scratch: Path, *pairs: tuple[str, str]) -> str:
 
     Same no-shebang convention as `_plant_repo_local_write` above, and for the
     same reason: `run-tests.sh` invokes SHELL_TESTS as `bash "$SHELL_TEST"`.
+
+    🔴 BOTH SIDES GO THROUGH `shlex.quote`. They were interpolated bare, which
+    was correct for the values in use and silently wrong for anything carrying
+    a space, a glob or a `!` — the planter would then write something other
+    than what its caller asked for and the test would pass or fail for a reason
+    nobody could see. `submodule.<n>.update = !cmd` is exactly such a value.
     """
     name = "g10-write-keys.sh"
     body = "set -euo pipefail\n" + "".join(
-        f'git -C "{scratch}" config {k} {v}\n' for k, v in pairs)
+        f'git -C {shlex.quote(str(scratch))} config {shlex.quote(k)} '
+        f'{shlex.quote(v)}\n' for k, v in pairs)
     (scratch / name).write_text(body, encoding="utf-8")
     return name
 
@@ -1244,6 +1254,326 @@ def test_the_DOWNGRADED_block_also_carries_the_key_delta(tmp_path):
         f"the downgrade block did not say WHICH key moved:\n{block}")
     assert "SHAPE: ORDINARY GIT" in block, (
         f"the downgrade block did not classify the delta's shape:\n{block}")
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE #773 AUDIT ROUND — the reassuring lead was reachable from three states
+# --------------------------------------------------------------------------- #
+# The first cut of the lead selection branched on `hazard` alone, so BOTH other
+# states fell through to "THE TARGET NAMED HERE IS THE WINDOW, NOT A CULPRIT":
+#
+#   * a MIXED run, where a GLOBAL file also changed. `_nogit_shape_for` returns
+#     `none` for a global file — there are no key rows for one — so the shape
+#     aggregation structurally could not see it, and the one class that is
+#     ALWAYS attributable got the excuse. The comment above the loop claimed the
+#     opposite of what the code did.
+#   * an UNRECOGNISED delta, which the classifier's own header says must be
+#     "ranked as NEITHER". It fired on `devrc-g10.planted` — this file's own
+#     fixture for a test escaping isolation — printing "NOT A CULPRIT" directly
+#     above "this run cannot rank the two hypotheses".
+#
+# The audit's mutation sweep also found two advertised arms unpinned: deleting
+# the whole `remote.*.url|pushurl` hazard clause SURVIVED, and flipping the
+# `unrecognised` fall-through to `ordinary` SURVIVED. Both are covered below.
+
+def test_a_MIXED_global_and_repo_local_delta_leads_with_the_GLOBAL_class(tmp_path):
+    """🔴 REGRESSION for #773's first audit finding. RED at a7499d67.
+
+    A target that writes `core.hooksPath` into a scratch `~/.gitconfig` AND one
+    `branch.*` key into the clone. The global write is attributable by
+    construction — no concurrent worktree operation touches the operator's
+    global config — so the lead must send the reader at the target, not excuse
+    it. Before this round the very same run led with NOT A CULPRIT.
+    """
+    scratch = _scratch_root(tmp_path)
+    home = tmp_path / "scratch-home"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".gitconfig").write_text("[user]\n\tname = before\n", encoding="utf-8")
+    name = "g10-mixed.sh"
+    (scratch / name).write_text(
+        "set -euo pipefail\n"
+        f'git -C "{scratch}" config branch.topic-m.remote origin\n'
+        "env -u GIT_CONFIG_GLOBAL -u GIT_CONFIG_SYSTEM -u GIT_CONFIG_NOSYSTEM "
+        f'HOME="{home}" git config --global core.hooksPath /tmp/planted-by-a-test\n',
+        encoding="utf-8")
+    runner = _runner_over(tmp_path, scratch, [name])
+
+    env = {**os.environ, **_unguarded_home(tmp_path), "HOME": str(home)}
+    for k, v in list(env.items()):
+        if v is None:
+            del env[k]
+    proc = subprocess.run(["bash", str(runner), str(scratch)], capture_output=True,
+                          text=True, timeout=900, cwd=str(REPO_ROOT), env=env)
+    out = proc.stdout + proc.stderr
+    assert proc.returncode != 0, f"a mixed global + repo-local run PASSED:\n{out}"
+
+    block = _guard10_failure_block(out)
+    assert block, f"GUARD 10's failure block was not printed at all:\n{out}"
+    # Positive control: BOTH classes really are in this failure. Without it a
+    # green here could just mean the global write never landed.
+    assert "global-enforced" in block, (
+        f"the global write never reached the failure — this run is not the "
+        f"mixed case it claims to measure:\n{block}")
+    assert "repo-local-enforced" in block, (
+        f"the repo-local write never reached the failure:\n{block}")
+    assert "GLOBAL ONE, WHICH *IS* ATTRIBUTABLE" in block, (
+        f"the mixed run did not lead with the attributable class:\n{block}")
+    assert "AUDIT THIS TARGET FIRST" in block, (
+        f"the mixed run did not send the reader at the target:\n{block}")
+    assert "WINDOW, NOT A CULPRIT" not in block, (
+        f"the mixed run excused the target while the operator's GLOBAL config "
+        f"was being rewritten — this is #773's first audit finding:\n{block}")
+
+
+def test_an_UNRECOGNISED_delta_is_ranked_as_NEITHER_in_the_HEADLINE(tmp_path):
+    """🔴 REGRESSION for #773's second audit finding. RED at a7499d67.
+
+    `_nogit_delta_shape`'s header says an unknown key "must not be laundered
+    into 'probably concurrent'". The per-file line honoured that; the HEADLINE
+    did not, so the two contradicted each other on the same screen — and the
+    key that triggers it here is `devrc-g10.planted`, this file's own model of a
+    fixture write escaping isolation.
+    """
+    scratch = _scratch_root(tmp_path)
+    name = _plant_repo_local_write(scratch)          # writes devrc-g10.planted
+    runner = _runner_over(tmp_path, scratch, [name])
+
+    proc = _run_at(runner, scratch, tmp_path)
+    out = proc.stdout + proc.stderr
+    assert proc.returncode != 0, f"an unrecognised repo-local delta PASSED:\n{out}"
+
+    block = _guard10_failure_block(out)
+    assert block, f"GUARD 10's failure block was not printed at all:\n{out}"
+    assert "+ devrc-g10.planted" in block, (
+        f"the failure did not name the key that moved:\n{block}")
+    assert "SHAPE: UNRECOGNISED" in block, (
+        f"an unknown key was classified rather than declined:\n{block}")
+    assert "CANNOT RANK THE TWO HYPOTHESES" in block, (
+        f"the headline ranked a delta the classifier declined to rank:\n{block}")
+    assert "WINDOW, NOT A CULPRIT" not in block, (
+        f"the headline handed the reader the reassuring lead over an "
+        f"unrecognised key — this is #773's second audit finding:\n{block}")
+
+
+@pytest.mark.parametrize("key,value", [
+    ("remote.origin.url", "https://example.invalid/x"),
+    ("remote.origin.pushurl", "https://example.invalid/y"),
+    ("remote.origin.uploadpack", "/tmp/planted-uploadpack"),
+    ("remote.origin.receivepack", "/tmp/planted-receivepack"),
+    ("submodule.mod.update", "!/tmp/planted-update"),
+])
+def test_remote_and_submodule_COMMAND_and_URL_keys_rank_HAZARD(tmp_path, key, value):
+    """🔴 THE ARM THE AUDIT'S SWEEP FOUND UNPINNED — one case per key.
+
+    🔴 THE PARAMS SPLIT INTO TWO DIFFERENT CLAIMS AND THE LABEL MATTERS.
+    MEASURED at a7499d67: `url` and `pushurl` PASS there, the other three FAIL.
+
+      * `uploadpack`, `receivepack`, `submodule.<n>.update` are REGRESSION
+        coverage. They ranked ORDINARY at a7499d67 — the reassuring arm — while
+        being exactly the arbitrary-command-execution keys a test escaping
+        isolation would write. `remote.*` was an unanchored prefix.
+      * `url` and `pushurl` are MUTATION coverage, NOT regression coverage. The
+        hazard clause already covered them; deleting it whole nonetheless
+        SURVIVED the previous round's suite, because the only test that wrote
+        such a key asserted the key name and the redaction and never the shape.
+        Counting these two as regression coverage would be a coverage claim
+        nobody measured.
+
+    Parametrized so a single surviving key cannot hide behind its siblings.
+    """
+    scratch = _scratch_root(tmp_path)
+    name = _plant_repo_local_keys(scratch, (key, value))
+    runner = _runner_over(tmp_path, scratch, [name])
+
+    proc = _run_at(runner, scratch, tmp_path)
+    out = proc.stdout + proc.stderr
+    assert proc.returncode != 0, f"a {key} write PASSED:\n{out}"
+
+    block = _guard10_failure_block(out)
+    assert block, f"GUARD 10's failure block was not printed at all:\n{out}"
+    assert f"+ {key}" in block, (
+        f"the failure did not name {key}:\n{block}")
+    assert "SHAPE: HAZARD" in block, (
+        f"{key} was not ranked as a hazard — it names a remote or executes a "
+        f"command, and nothing routine writes it into an existing clone:\n{block}")
+    assert "WINDOW, NOT A CULPRIT" not in block, (
+        f"{key} got the reassuring lead:\n{block}")
+
+
+def test_a_key_with_a_SPACE_survives_the_fold_and_still_ranks_HAZARD(tmp_path):
+    """🔴 A git key can contain a SPACE, and the fold used to eat it.
+
+    `[remote "my name"]` is legal — `git config 'remote.my name.url' <u>` exits
+    0 — and `git submodule add <url> "my dir"` produces the same shape. Folding
+    the `--list -z` output on a SPACE truncated the key to `remote.my`: a key
+    that does not exist, ungreppable, and one the `remote\\..*\\.url$` hazard
+    clause cannot match. The single key this guard names as the token-bearing
+    hazard was the one a space defeated.
+    """
+    scratch = _scratch_root(tmp_path)
+    name = "g10-spacekey.sh"
+    (scratch / name).write_text(
+        "set -euo pipefail\n"
+        f"git -C \"{scratch}\" config 'remote.my name.url' "
+        "'https://example.invalid/spaced'\n",
+        encoding="utf-8")
+    runner = _runner_over(tmp_path, scratch, [name])
+
+    proc = _run_at(runner, scratch, tmp_path)
+    out = proc.stdout + proc.stderr
+    # Positive control: git really accepted the spaced subsection, so a pass
+    # below is about the fold and not about a write that never happened.
+    assert "my name" in (scratch / ".git" / "config").read_text(encoding="utf-8"), (
+        "git did not write the spaced subsection — this run proves nothing")
+    assert proc.returncode != 0, f"a spaced-key write PASSED:\n{out}"
+
+    block = _guard10_failure_block(out)
+    assert block, f"GUARD 10's failure block was not printed at all:\n{out}"
+    assert "+ remote.my name.url" in block, (
+        f"the key was truncated at its space instead of printed whole:\n{block}")
+    assert "SHAPE: HAZARD" in block, (
+        f"a spaced remote URL key escaped the hazard rule:\n{block}")
+
+
+def test_a_LARGE_delta_still_reaches_the_hazard_arm(tmp_path):
+    """🔴 SIGPIPE + `set -o pipefail` silently sent every large delta to the
+    REASSURING arm. RED at a7499d67.
+
+    `printf '%s\\n' "$delta" | grep -q …`: `grep -q` exits on the first match,
+    `printf` then takes SIGPIPE (141), and `pipefail` reports the PIPELINE as
+    141 — so the `if` goes FALSE even though the pattern matched. Both greps
+    fell through and `_nogit_delta_shape` returned `ordinary`. The audit
+    measured the cliff between 5001 lines (still correct) and 8001 (wrong),
+    reproducible 10/10; herestrings remove the pipeline entirely.
+
+    🔴 THE HAZARD KEY MUST SORT EARLY, and getting that wrong is how this test
+    first shipped green at base while proving nothing. `_nogit_key_delta` ends
+    in `sort -k2`, so a `core.*` key lands AFTER 15000 `bigsect.*` lines —
+    `grep -q` then reads almost the whole input, never exits early, and the
+    SIGPIPE never happens. Measured: that version PASSED at a7499d67. The key
+    here is `alias.*` — also in the hazard set, and it sorts before everything
+    else in the fixture, so `grep -q` matches on the first line and abandons
+    ~300 KB of unread input. That is the shape the bug needs.
+    """
+    scratch = _scratch_root(tmp_path)
+    name = "g10-bigdelta.sh"
+    cfg = scratch / ".git" / "config"
+    (scratch / name).write_text(
+        "set -euo pipefail\n"
+        f'cfg={shlex.quote(str(cfg))}\n'
+        '{ echo "[alias]"; echo "\tplantedcmd = !/tmp/planted-by-a-test"\n'
+        '  echo "[bigsect]"\n'
+        '  i=0; while [ "$i" -lt 15000 ]; do echo "\tkey$i = v$i"; i=$((i+1)); done\n'
+        '} >> "$cfg"\n',
+        encoding="utf-8")
+    runner = _runner_over(tmp_path, scratch, [name])
+
+    proc = _run_at(runner, scratch, tmp_path)
+    out = proc.stdout + proc.stderr
+    # Positive control: the delta really is past the cliff, so a pass below is
+    # about the pipeline and not about a fixture that stayed small.
+    entries = cfg.read_text(encoding="utf-8").count("key")
+    assert entries >= 15000, (
+        f"the fixture only produced {entries} keys — too small to reach the "
+        f"measured SIGPIPE cliff, so this run proves nothing")
+    assert proc.returncode != 0, f"a 15000-key config delta PASSED:\n{out[-3000:]}"
+
+    block = _guard10_failure_block(out)
+    assert block, f"GUARD 10's failure block was not printed at all:\n{out[-3000:]}"
+    assert "+ alias.plantedcmd" in block, (
+        f"the hazard key was not listed among the 15000:\n{block[:2000]}")
+    assert "SHAPE: HAZARD" in block, (
+        f"an alias.* write at the head of a large delta was ranked as "
+        f"something other than a hazard — SIGPIPE swallowed the match:"
+        f"\n{block[:2000]}")
+    assert "WINDOW, NOT A CULPRIT" not in block, (
+        f"a large delta carrying an alias.* command got the reassuring lead:"
+        f"\n{block[:2000]}")
+
+
+def test_a_LARGE_unrecognised_delta_is_not_flattened_to_ORDINARY(tmp_path):
+    """🔴 THE MIRROR OF THE TEST ABOVE, AND THE SWEEP IS WHY IT EXISTS.
+
+    `_nogit_delta_shape` has TWO `grep -q` calls and the test above only reaches
+    the first. Mutating the SECOND back to `printf | grep -q` SURVIVED a fully
+    green run: nothing exercised a large delta that gets PAST the hazard arm.
+
+    That path is the more dangerous one. `grep -qv ORDINARY` matches on the
+    first non-ordinary line, `printf` takes SIGPIPE, `pipefail` reports 141, the
+    `if` goes false and the function falls through to `ordinary` — so a delta of
+    15000 keys the classifier does not recognise would be announced as ordinary
+    git activity with the target ranked SECOND. Unknown keys laundered into the
+    reassuring arm, in bulk.
+
+    `aaasect.*` is neither ordinary nor hazard and sorts first, so the `-qv`
+    match happens on line one and abandons the rest.
+    """
+    scratch = _scratch_root(tmp_path)
+    name = "g10-bigunknown.sh"
+    cfg = scratch / ".git" / "config"
+    (scratch / name).write_text(
+        "set -euo pipefail\n"
+        f'cfg={shlex.quote(str(cfg))}\n'
+        '{ echo "[aaasect]"\n'
+        '  i=0; while [ "$i" -lt 15000 ]; do echo "\tkey$i = v$i"; i=$((i+1)); done\n'
+        '} >> "$cfg"\n',
+        encoding="utf-8")
+    runner = _runner_over(tmp_path, scratch, [name])
+
+    proc = _run_at(runner, scratch, tmp_path)
+    out = proc.stdout + proc.stderr
+    entries = cfg.read_text(encoding="utf-8").count("key")
+    assert entries >= 15000, (
+        f"the fixture only produced {entries} keys — too small to reach the "
+        f"measured SIGPIPE cliff, so this run proves nothing")
+    assert proc.returncode != 0, f"a 15000-key config delta PASSED:\n{out[-3000:]}"
+
+    block = _guard10_failure_block(out)
+    assert block, f"GUARD 10's failure block was not printed at all:\n{out[-3000:]}"
+    assert "+ aaasect.key0" in block, (
+        f"the unknown keys were not listed:\n{block[:2000]}")
+    assert "SHAPE: UNRECOGNISED" in block, (
+        f"15000 unknown keys were classified as something the runner claims to "
+        f"recognise — the ordinary grep's match was swallowed:\n{block[:2000]}")
+    assert "CANNOT RANK THE TWO HYPOTHESES" in block, (
+        f"the headline ranked a delta of unknown keys:\n{block[:2000]}")
+
+
+def test_the_shape_ledger_is_pinned_two_way():
+    """🔴 THE CLASSIFIER'S TWO SETS ARE A LEDGER, not prose plus a regex.
+
+    Same shape this repo already uses for `EXPECTED_PLUGINS`, `TARGET_FLOORS`
+    and drift-check's phase-2 reason tokens. The sets decide which writes get
+    the reassuring headline, so silently widening `ordinary` — or narrowing
+    `hazard` — must fail the suite, not merely change a message nobody reads
+    until the next incident.
+
+    Both directions: a token added to the runner and not here fails, and a
+    token removed from the runner while still listed here fails.
+    """
+    src = RUN_TESTS.read_text(encoding="utf-8")
+
+    def _assignment(name: str) -> str:
+        m = re.search(rf"^{name}='([^']*)'$", src, re.M)
+        assert m, (
+            f"{name} is not a single-quoted one-line assignment in "
+            f"run-tests.sh any more — this ledger cannot read it, so it is "
+            f"pinning nothing. Re-point it or restore the shape.")
+        return m.group(1)
+
+    assert _assignment("NOGIT_HAZARD_KEYS") == (
+        r"^[+~-] (core|user|url|http|credential|include|includeif|alias)\."
+        r"|^[+~-] (remote|submodule)\..*\.(url|pushurl|uploadpack|receivepack|proxy|update)$"
+    ), ("the HAZARD key set moved. Every key it drops starts getting the "
+        "'concurrent writer is the leading hypothesis' headline instead of "
+        "'AUDIT THIS TARGET FIRST'. Update this ledger in the SAME commit, and "
+        "add a behavioural case for the new key.")
+
+    assert _assignment("NOGIT_ORDINARY_KEYS") == (
+        r"^[+~-] (branch|remote|worktree|submodule|maintenance)\."
+        r"|^[+~-] extensions\.worktreeconfig$"
+    ), ("the ORDINARY key set moved. Every key it gains gets the reassuring "
+        "headline. Update this ledger in the SAME commit.")
 
 
 def test_a_global_change_FAILS_even_with_a_cotenant_PROVEN(tmp_path):


### PR DESCRIPTION
## The defect

`GUARD 10` flagged `<devrc>/.git/config` changing mid-run **four separate times today** and each message named whichever target was in teardown:

> `…this run FOUND NO PROOF of another writer, so the change is attributed to this target.`

Every one of those writes was a concurrent `git branch` / `worktree add` in the shared clone. Cost: a four-run experiment by one agent and a diagnosis pass by the operator, all of it auditing tests that had done nothing.

That clause is a **verdict**, issued by a probe the same paragraph then admits is structurally blind to the likeliest writer (`live_cotenants` roots at the git dir and its PARENT, so a session in a **sibling worktree** is never counted). #730 fixed the half that overstated the probe; the clause after it repeated the mistake one step on.

## The fix — the message, not the detection

An unattributable repo-local delta **still fails the run**; a proven co-tenant still downgrades it; the global class is untouched. What changed is that the guard now prints what it already had:

- **the key names that moved** in `<git-common-dir>/config` across the target's window (`+` new, `-` gone, `~` value moved), diffed from a per-target snapshot;
- **a shape ranking** — `ORDINARY GIT` (`branch.`/`remote.`/`worktree.`/`submodule.`/`maintenance.`) ranks a concurrent command first, target second; `HAZARD` (`core.`/`user.`/`url.`/`http.`/`credential.`/`include*`/`alias.` + `remote.<n>.url|pushurl` — the 2026-08-21 incident's own shape) ranks the target first and says **AUDIT THIS TARGET FIRST**; anything else is `UNRECOGNISED`, ranked as neither. Every arm says it is a **ranking, not a verdict**;
- **the discriminators**, beside the file: mtime, `git worktree list` for the blind spot the message just admitted to, and `git reflog`.

**Key names only, never values** — hard requirement: that file holds `remote.<name>.url`, which can carry a token, and this output lands in CI logs. A value-only change still surfaces, as `~ <key>`.

**No empty list.** Bytes that move with no visible key delta print `NOT VISIBLE — <reason>`; an empty list would be a claim about the FILE when the truth is a claim about the PARSE.

**Deliberate scope limit, flagged in the source** so its silence is not read as coverage: the GLOBAL class gets no key listing. Its one-line explanation was never the wrong one — a global file has no concurrent writer to confuse it with.

### Before / after, same command shape

```
BEFORE  g10-write-repo-local.sh  — CHANGED 1 of the operator's protected git config
        file(s) while it ran. … FOUND NO PROOF of another writer, so the change is
        attributed to this target. …
             /…/scratch-root/.git/config  [repo-local-enforced]

AFTER   scripts/dl-router/tests
          changed: /home/zach/workspace/devrc/.git/config
            keys that moved in this file (NAMES ONLY — values are never printed …):
              + branch.zach/t3-closing-condition.merge
              + branch.zach/t3-closing-condition.remote
            → SHAPE: ORDINARY GIT. … the LEADING hypothesis is a concurrent git
              command in another worktree or session, and the target above is the
              SECOND. This is a RANKING, not a verdict — this run proved neither.
            Discriminate before auditing any test, cheapest first: …
```

The AFTER is not a fixture — it is **the gate run for this PR**, on the operator's box, catching a concurrent session creating a tracking branch mid-run. (Those two took the downgraded arm; the rendering is shared with the enforcing arm that fired four times today.)

## Verification

- **5 new tests, RED at `origin/main` f2ed88c7, GREEN at HEAD** — the accusatory sentence, the key names, the shape, redaction, the NOT-VISIBLE arm, the downgraded block's rendering.
- **6 mutants, isolated, each killed by its own test**, with an unmutated **null control that SURVIVED** (5 passed): hazard lead reverted to the window wording; `key()` stops trimming the value (leak); the `?` row dropped; shape pinned to `ordinary`; the downgrade block stops rendering keys; the old sentence restored.
- `scripts/gate.sh --tier both --set all` → **`GATE: RESULT=PASS exit=0`** — pytest 15469 collected / 0 failed, node 1149 / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpMxc3NpzvbcP4ZUWh8pe4

---

# Round 2 — the adversarial audit (`a7499d67..089883d8`)

The audit returned **two 🔴s, both the PR's own thesis failing in its own terms.** The lead sentence branched on `hazard` alone, so every other state fell through to the reassuring "THE TARGET NAMED HERE IS THE WINDOW, NOT A CULPRIT":

- **Mixed global + repo-local.** `_nogit_shape_for` returns `none` for a global file — there are no key rows for one — so the shape aggregation was *structurally unable* to see it, and the one class that is **always attributable** got the excuse, over `~/.gitconfig`. The comment above the loop asserted the opposite of what the code did.
- **`unrecognised` laundered into that same lead**, contradicting the classifier's own "ranked as NEITHER" — and firing on `devrc-g10.planted`, this repo's own fixture for a test escaping isolation.

There are now **four arms**; the reassuring one is reachable only from `ordinary` with no global file present.

Also from that round: a git key can contain a **space** (`[remote "my name"]`), and folding on a space truncated it to `remote.my` — unmatchable by the `remote\..*\.url$` clause, so the one key named as the token-bearing hazard was the one a space defeated (fold is now a TAB); `remote.<n>.uploadpack`/`receivepack`/`proxy` and `submodule.<n>.update` ranked ORDINARY despite being arbitrary-command-execution keys; **SIGPIPE + `pipefail`** made `printf | grep -q` report 141 so every large delta scored `ordinary` (independently reproduced before fixing — pipe wrong **10/10** at 8001+ lines, herestring **0/10**); the key sets became a two-way ledger; `$NOGIT_DIR` cleanup moved into the EXIT trap.

# Round 3 — the delta re-audit (`089883d8..7a9ecf85`)

Returned **no 🔴 and "safe to merge"**. Three 🟡s fixed anyway, because the first is this branch's own defect class reappearing inside the fix for it:

- **The hazard message still enumerated the pre-widening families.** Round 2 widened the regex and updated the classifier *header* but not the sentence the operator reads, so an `uploadpack` finding was explained as "core.\* / user.\* / url.\* / …" — naming none of the families it belongs to. Fixed by **deleting the duplication**: the list is now read from the ledger at print time, so there is no second copy to drift. The ledger test pins the rendered string *and* checks every family it names occurs in the regex.
- **`submodule.<n>.url` is written by routine `git submodule init`** — the widened set would re-create #730's complaint at a new key. Kept hazardous (under-warning is the direction that cost four misattributions), but the arm now names `git submodule init` as the first thing to check.
- **The EXIT-trap cleanup was unpinned** — deleting the `rm -rf` left all 42 tests green. Now covered end to end under SIGTERM, asserting the verdict still prints and rc is still 143.

## Verification across all three rounds

- **Red/green matrices stated per test**, including the ones that are *not* regression coverage: `remote.origin.url`/`pushurl` are green at base by design (mutation coverage for a clause that survived deletion), and the SIGTERM test is green at `089883d8` because the trap fix landed there.
- **16 mutants total**, each verified to apply and parse, each killed by its intended test; null controls survived every round. Two rounds needed rebuilding: the first produced three **void** mutants (one that did not parse and killed everything for the wrong reason, one whose anchor never matched, one that applied half), and `R5b` **SURVIVED** on the honest re-run — the ordinary grep's herestring was unpinned, which is why a mirror test exists for it.
- 🔴 **One test was wrong before it was right.** The first large-delta fixture used `core.hooksPath`, which `sort -k2` places *after* 15000 filler lines, so `grep -q` never exits early and no SIGPIPE occurs — it **passed at base**, a green-at-base test mislabelled as regression coverage. The hazard key is now `alias.*`, which sorts first.
- **Merged-tree gate** on `integ/g10-773` rebuilt against `7c17b87f` (which includes #777, the only commit since to touch `run-tests.sh` — its hunks are CI-claim comments at ~302/~391, disjoint from GUARD 10): **`GATE: RESULT=PASS exit=0`**, pytest 15484 / 0 failed, node 1149 / 0 failed.
- **Three independent live catches** across three gate runs on the operator's box — `branch.zach/t3-closing-condition`, `branch.integ/handoff-764` + `branch.zach/tekton-pruner-and-burst-facts`, and a *deletion* of `branch.zach/ci-claims-both-tiers` — every one a concurrent session, every one now legible instead of pointed at a test.

## Known limits, stated rather than implied

Two other guards (`:3100`, `:3144`) carry the same `printf | grep -q` shape, unreachable today because their inputs are single short lines. The ledger's `re.search` pins the *first* assignment of each name. A config value containing a literal TAB now collides in the snapshot where a space used to — rarer, and it renders as the honest `?` row. The key delta measures a slightly wider window than the fingerprint that triggers it; it can change which keys are named, never the verdict.
