### PR TITLE
docs(ci): both Tekton legs are required now — two files still called a red check advisory

### DIFF
--- a/githooks/tests-on-push.sh
+++ b/githooks/tests-on-push.sh
@@ -291,11 +291,25 @@ fi
 # by the shellHook this hook relies on. The two exports are not redundant.
 # (The nodetests leg carries no marker and needs none: no DEVRC_GATE_ENV, no
 # exit 3 in its runner.)
-# Its red is advisory — `main`'s protection requires a review but NOT status
-# checks (`required_status_checks` -> 404, measured 2026-08-22) — which is why
-# this hook is still the only tier that blocks A PUSH. (Precisely: `main` also
-# requires 1 approving review, which blocks a MERGE — so "the only tier that
-# blocks" unqualified is wrong. The push is what this hook governs.)
+# 🔴 ITS RED IS NO LONGER ADVISORY — corrected in place, because the drift is the
+# lesson. This used to read: "Its red is advisory — `main`'s protection requires
+# a review but NOT status checks (`required_status_checks` -> 404, measured
+# 2026-08-22)". Measured 2026-08-23T22:55Z, protection requires BOTH legs:
+#     contexts: ["tekton/devrc-nodetests", "tekton/devrc-pytests"]
+#     strict: false, enforce_admins: true
+# so a red check on EITHER leg now BLOCKS a MERGE. An intermediate revision named
+# only `nodetests`; `pytests` was added the same day. Re-measure, do not restate:
+#   gh api repos/innovation-upstream/devrc/branches/main/protection/required_status_checks
+#
+# ⚠ The REVIEW half of the old sentence is UNRESOLVED and is deliberately left
+# unasserted here: the top-level protection object omits
+# `required_pull_request_reviews` entirely, while the sub-endpoint returns
+# `required_approving_review_count: 1`. Two API surfaces disagree and nobody has
+# settled which is authoritative — so this comment claims nothing about reviews.
+#
+# What survives unchanged: this hook is still the only tier that blocks A PUSH.
+# The Tekton gate blocks a MERGE, never a push, and the push is what this hook
+# governs — so the distinction the old parenthetical drew is still the right one.
 #
 # Verified in the other direction too: `fail` is only ever assigned 0 or 1 and the
 # script ends `exit "$fail"`, so a genuine pytest failure can never surface as 2

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -302,13 +302,22 @@ cd "$ROOT" || { echo "run-tests: cannot cd to ROOT=$ROOT" >&2; exit 3; }
 # nodetests leg exports no marker and needs none: its runner has no
 # DEVRC_GATE_ENV and no exit 3.)
 #
-# What that gate does NOT do is block a merge: `main`'s branch protection does
-# NOT require status checks — `required_status_checks` returns 404 (measured
-# 2026-08-22) — though it DOES require 1 approving review. So protection EXISTS
-# and a red check is still advisory; do not restate this as "there is no branch
-# protection", which is the wrong mechanism for the right conclusion.
+# 🔴 AND THAT CLAIM DRIFTED IN THE REASSURING DIRECTION — corrected in place,
+# because the drift is the lesson. It used to read: "What that gate does NOT do
+# is block a merge: `main`'s branch protection does NOT require status checks —
+# `required_status_checks` returns 404 (measured 2026-08-22)." True when written.
+# Measured 2026-08-23T22:55Z that endpoint returns BOTH legs:
+#     contexts: ["tekton/devrc-nodetests", "tekton/devrc-pytests"]
+#     strict: false, enforce_admins: true
+# So a red Tekton check on EITHER leg now BLOCKS the merge. An intermediate
+# revision of this comment said only `nodetests` was required and `pytests` was
+# not; `pytests` was added the same day, so do not restate that version either.
+# Re-measure rather than trusting this line:
+#   gh api repos/innovation-upstream/devrc/branches/main/protection/required_status_checks
+# Do not restate any of it as "there is no branch protection" — that was always
+# the wrong mechanism for the right conclusion, and the conclusion has flipped.
 # `test_ci_claim_matches_reality.py` cannot see any of this — its own scope note
-# excludes Tekton — so do not read its green as agreement.
+# excludes Tekton AND branch protection — so do not read its green as agreement.
 # A new `exit` here must pick a side deliberately.
 # --- GUARD 1: tool precondition ------------------------------------------------
 # Every binary the suites `skipif` on. Absence must be an ERROR, never a skip.
@@ -382,10 +391,11 @@ if [ "${#missing_tools[@]}" -gt 0 ]; then
   # pre-push hook DEGRADED, and the push went through with ZERO tests run — while
   # the test that would have caught the typo never executed, because the runner
   # aborted before pytest started. That is "a suite stops running while the gate
-  # goes green" on the only tier that BLOCKS a push — a Tekton PR gate does now
-  # run (see the EXIT CODES block above), but its red is advisory — branch
-  # protection does not require status checks — so exit 3 here still let the
-  # push land. devrc#705.
+  # goes green" on the only tier that BLOCKS a push. A Tekton PR gate does now
+  # run (see the EXIT CODES block above), and since 2026-08-23 BOTH its legs are
+  # required status checks, so a red check blocks the MERGE — but it still does
+  # not block the PUSH, which is what this exit code governs. So exit 3 here let
+  # the push land exactly as described. devrc#705.
   #
   # The discriminator is whether we are IN a sanctioned gate env, which both the
   # devShell and checks.pytests announce with DEVRC_GATE_ENV=1:


### PR DESCRIPTION
## What

`#771` corrects five sites for this drift. It does **not** reach these two, which
carry the *older and more wrong* version of the claim — that `main` has no required
status checks at all:

- `scripts/run-tests.sh:305-311` — *"a red check is still advisory"*
- `scripts/run-tests.sh:385-388` — *"its red is advisory — branch protection does not require status checks"*
- `githooks/tests-on-push.sh:294-298` — *"`main`'s protection requires a review but NOT status checks"*

Verified against `#771`'s own head, not just `main`, so this is a genuine gap rather
than a merge-order artifact. No overlap with `#771`'s file set.

## Measurement

`2026-08-23T22:55Z`, three separate calls agreeing:

```json
{"strict": false,
 "contexts": ["tekton/devrc-nodetests", "tekton/devrc-pytests"],
 "checks": [{"context": "tekton/devrc-nodetests", "app_id": 4320115},
            {"context": "tekton/devrc-pytests",  "app_id": 4320115}]}
```

`enforce_admins: true`. A red check on **either** leg now blocks the merge.

Note the claim drifted **twice**: `404` (2026-08-22) → `nodetests` only (2026-08-23,
what the handoff recorded) → **both legs** (same day). The intermediate version is
called out in place so nobody re-derives it.

## Deliberately not asserted

The **review** half of the old sentence. The top-level protection object omits
`required_pull_request_reviews` entirely, while
`/protection/required_pull_request_reviews` returns `required_approving_review_count: 1`.
Two API surfaces disagree; I did not settle which is authoritative, so the comment now
claims nothing about reviews rather than picking one and being wrong a fourth time.

## Unchanged

This hook is still the only tier that blocks **a push**. The Tekton gate blocks a
*merge*, never a push — the push/merge distinction the old parenthetical drew is
still correct and is preserved.

## Verification

Comments only, no behaviour change.

- `bash -n` clean on both files
- `test_run_tests_preconditions.py` + `test_ci_claim_matches_reality.py` — **23 passed**
- Grepped `scripts/tests/` first: no test pins the corrected wording. The one adjacent
  docstring (`test_run_tests_preconditions.py:427`) is already in `#771`'s scope and is
  left alone to avoid conflicting with it.

`test_ci_claim_matches_reality.py` is hermetic (marker-based, no API) and its
`merge-gate: other` marker stays valid in both states — so it was never red for this,
and its green is not evidence for these comments either. Its own scope note says so.