### PR TITLE
clawgate: one definition of the closing condition, and stop hooks.md contradicting it

### DIFF
--- a/claude/skills/clawgate/flows/task-authoring.md
+++ b/claude/skills/clawgate/flows/task-authoring.md
@@ -67,15 +67,22 @@ Good uses of a question — roughly in order of value:
 1. **What does DONE look like?** (this is the acceptance criteria; if you get
    nothing else, get this)
 
-   🔴 **THIS IS THE ONE DEFINITION. `## Acceptance criteria` is where the CLOSING
-   CONDITION lives — they are one thing under two names, not two requirements.** It
-   must name either a mechanical check (a merged PR, a cleared alert, a command
-   exiting 0) or a human judgement over NAMED EVIDENCE ("X reads the transcript" —
-   never "someone will decide"). **If neither can be named, do not create the task
-   at all**: say so in your reply, and why. Everywhere else that mentions the
-   requirement — the core rule, the hook, `claude/skills/clawgate/reference/hooks.md` — points here rather
-   than restating it, because a predicate open-coded at N sites is wrong at N−1 of
-   them. Do not add a sixth phrasing.
+   🔴 **THIS IS THE OPERATIONAL DEFINITION. `## Acceptance criteria` is where the
+   CLOSING CONDITION lives — they are one thing under two names, not two
+   requirements.** It must name the condition **and who or what checks it**: either
+   a mechanical check (a merged PR, a cleared alert, a command exiting 0) or a human
+   judgement over NAMED EVIDENCE ("X reads the transcript" — never "someone will
+   decide"). **If neither can be named, do not create the task at all**: say so in
+   your reply, and why.
+
+   🔴 **`claude/RULES.md` states the RULE and deliberately restates the predicate in
+   full — do NOT "consolidate" it away.** `scripts/tests/test_rules_size.py` records
+   why (the condition, who checks it, the human-judgement case and the say-why
+   forcing function are each load-bearing; the first shipped draft lost one and
+   acquired a real defect), and **no test asserts that clause's text**, so deleting
+   it to reclaim bytes would be silent. What points HERE rather than restating is
+   the operational surface: the interview hook and
+   `~/.claude/skills/clawgate/reference/hooks.md`. Add no further phrasings.
 2. **Scope boundary** — the smallest version that is still worth doing vs the full
    one, offered as concrete options
 3. **A decision only Zach can make** — a user-facing micro-decision, a naming

--- a/claude/skills/clawgate/flows/task-authoring.md
+++ b/claude/skills/clawgate/flows/task-authoring.md
@@ -66,6 +66,16 @@ Good uses of a question — roughly in order of value:
 
 1. **What does DONE look like?** (this is the acceptance criteria; if you get
    nothing else, get this)
+
+   🔴 **THIS IS THE ONE DEFINITION. `## Acceptance criteria` is where the CLOSING
+   CONDITION lives — they are one thing under two names, not two requirements.** It
+   must name either a mechanical check (a merged PR, a cleared alert, a command
+   exiting 0) or a human judgement over NAMED EVIDENCE ("X reads the transcript" —
+   never "someone will decide"). **If neither can be named, do not create the task
+   at all**: say so in your reply, and why. Everywhere else that mentions the
+   requirement — the core rule, the hook, `claude/skills/clawgate/reference/hooks.md` — points here rather
+   than restating it, because a predicate open-coded at N sites is wrong at N−1 of
+   them. Do not add a sixth phrasing.
 2. **Scope boundary** — the smallest version that is still worth doing vs the full
    one, offered as concrete options
 3. **A decision only Zach can make** — a user-facing micro-decision, a naming

--- a/claude/skills/clawgate/reference/hooks.md
+++ b/claude/skills/clawgate/reference/hooks.md
@@ -124,7 +124,7 @@ worse, not better — and this hook is not that change.
 
 | trigger | reaches the phone? |
 |---|---|
-| Out of scope | **No** — semantic, produces no `PermissionRequest`. File a task **only if you can name its closing condition**; with none, say so in your reply instead of creating one (definition: `flows/task-authoring.md`, question 1 — the single source; do not restate it here). Note the criteria-less-create denial comes from a devrc PreToolUse hook, `clawgate-task-interview-guard.py`, NOT this one; and the criteria table in SKILL.md governs the final status on the LOCAL pickup path, which may set `complete` — it is the DISPATCHED devpod route that cannot, `taskstatus.go:79-81`. |
+| Out of scope | **No** — semantic, produces no `PermissionRequest`. File a task **only if you can name its closing condition**; with none, say so in your reply instead of creating one (definition: `~/.claude/skills/clawgate/flows/task-authoring.md`, question 1 — the single source; do not restate it here). Note the criteria-less-create denial comes from a devrc PreToolUse hook, `clawgate-task-interview-guard.py`, NOT this one; and the criteria table in SKILL.md governs the final status on the LOCAL pickup path, which may set `complete` — it is the DISPATCHED devpod route that cannot, `taskstatus.go:79-81`. |
 | Fork | **No.** A design fork raises no `PermissionRequest` at all; and even when one does surface, the return channel is binary — see the 🔴 above. Never route a Fork here. |
 | Outward-facing / irreversible | **Partially** — an allowlisted command never prompts, so it never reaches the phone at all. |
 | Named hazard | **No, and must not** — a named hazard's response is stage-it or hand-it-over, never solicit approval. |

--- a/claude/skills/clawgate/reference/hooks.md
+++ b/claude/skills/clawgate/reference/hooks.md
@@ -124,7 +124,7 @@ worse, not better — and this hook is not that change.
 
 | trigger | reaches the phone? |
 |---|---|
-| Out of scope | **No** — semantic, produces no `PermissionRequest`. File a task instead (`flows/task-authoring.md` — note the criteria-less-create denial comes from a devrc PreToolUse hook, `clawgate-task-interview-guard.py`, NOT this one; and the criteria table in SKILL.md governs the final status on the LOCAL pickup path, which may set `complete` — it is the DISPATCHED devpod route that cannot, `taskstatus.go:79-81`). |
+| Out of scope | **No** — semantic, produces no `PermissionRequest`. File a task **only if you can name its closing condition**; with none, say so in your reply instead of creating one (definition: `flows/task-authoring.md`, question 1 — the single source; do not restate it here). Note the criteria-less-create denial comes from a devrc PreToolUse hook, `clawgate-task-interview-guard.py`, NOT this one; and the criteria table in SKILL.md governs the final status on the LOCAL pickup path, which may set `complete` — it is the DISPATCHED devpod route that cannot, `taskstatus.go:79-81`. |
 | Fork | **No.** A design fork raises no `PermissionRequest` at all; and even when one does surface, the return channel is binary — see the 🔴 above. Never route a Fork here. |
 | Outward-facing / irreversible | **Partially** — an allowlisted command never prompts, so it never reaches the phone at all. |
 | Named hazard | **No, and must not** — a named hazard's response is stage-it or hand-it-over, never solicit approval. |

--- a/scripts/tests/test_closing_condition_single_source.py
+++ b/scripts/tests/test_closing_condition_single_source.py
@@ -1,0 +1,139 @@
+"""The closing-condition predicate must have exactly ONE definition.
+
+WHY THIS EXISTS
+---------------
+`claude/RULES.md` requires that a filed task name the closing condition that ends
+it. The clawgate hook enforces a `## Acceptance criteria` heading. The authoring
+flow asks "what does DONE look like". A re-audit of devrc #772 found the SAME
+predicate spelled five different ways across the tree, with none of the other four
+updated when the rule landed -- and RULES.md's own "One rule, one place" bullet
+warns that a predicate open-coded at N sites is typically wrong at N-1 of them.
+
+The consolidation deliberately does NOT rename `## Acceptance criteria`: that
+heading is the ENFORCED artifact (`scripts/claude-hooks/clawgate-task-interview-guard.py`
+matches it literally) and every existing task body carries it. Renaming it would
+break the gate and the corpus at once. What is single-sourced is the DEFINITION --
+question 1 of the authoring flow -- with every other site pointing at it.
+
+WHY THE ASSERTIONS LOOK BRITTLE
+-------------------------------
+The artifact under test is PROSE. RULES.md: "when the artifact under test IS prose,
+a guard on WORDS is walkable by REWORDING -- pin the WHOLE normalised string. A
+cosmetic reword then fails the test -- pay it, for a machine-readable claim."
+
+So these pin whole normalised sentences, not keywords. A reword SHOULD fail here;
+the fix is to update the constant below in the same commit, which is exactly the
+moment someone should notice they are about to create a sixth phrasing.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# The ONE place the predicate is defined. Everything else points here.
+CANONICAL = REPO_ROOT / "claude" / "skills" / "clawgate" / "flows" / "task-authoring.md"
+HOOKS_REF = REPO_ROOT / "claude" / "skills" / "clawgate" / "reference" / "hooks.md"
+
+# The distinctive sentence that marks the definition site. Must occur exactly once
+# in the whole tree -- that count IS the single-source claim.
+DEFINITION_MARK = "they are one thing under two names, not two requirements"
+
+# The conditional form the out-of-scope row must carry. The row previously read
+# "File a task instead" unconditionally, which is verbatim the instruction that
+# generated the leak the rule exists to stop.
+HOOKS_CONDITIONAL = "File a task **only if you can name its closing condition**"
+
+# The unconditional form that must NOT come back anywhere in the clawgate skill.
+BANNED_UNCONDITIONAL = "produces no `PermissionRequest`. File a task instead"
+
+SEARCH_ROOTS = (REPO_ROOT / "claude", REPO_ROOT / "scripts")
+SEARCH_SUFFIXES = {".md", ".py", ".mjs", ".js", ".sh"}
+
+
+def _normalise(text: str) -> str:
+    """Collapse whitespace so a line-wrap is not a false failure."""
+    return re.sub(r"\s+", " ", text)
+
+
+SELF = Path(__file__).resolve()
+
+
+def _corpus() -> dict[Path, str]:
+    """Every doc/script that could restate the predicate.
+
+    🔴 THIS MODULE EXCLUDES ITSELF. It necessarily quotes both the canonical
+    sentence and the banned one as constants, so without this it matches its own
+    source and reports itself as the violation -- a guard failing on its own
+    declaration rather than on the thing it guards. Verified: with the exclusion
+    removed, both relationship tests fail naming this file.
+    """
+    out = {}
+    for root in SEARCH_ROOTS:
+        for p in root.rglob("*"):
+            if p.is_file() and p.suffix in SEARCH_SUFFIXES and p.resolve() != SELF:
+                try:
+                    out[p] = _normalise(p.read_text(encoding="utf-8"))
+                except (UnicodeDecodeError, OSError):
+                    continue
+    return out
+
+
+def test_the_corpus_is_non_empty():
+    """Positive control: a zero-file corpus would make every test below vacuous."""
+    corpus = _corpus()
+    assert len(corpus) > 50, (
+        f"only {len(corpus)} files collected -- the search roots are probably wrong, "
+        "which would make every assertion in this module pass vacuously"
+    )
+
+
+def test_the_definition_exists_at_the_canonical_site():
+    assert CANONICAL.is_file(), f"canonical definition file is missing: {CANONICAL}"
+    assert DEFINITION_MARK in _normalise(CANONICAL.read_text(encoding="utf-8")), (
+        f"\n\nThe closing-condition definition is gone from its canonical home.\n"
+        f"  expected in: {CANONICAL.relative_to(REPO_ROOT)}\n"
+        f"  the sentence: {DEFINITION_MARK!r}\n"
+        f"If you reworded it, update DEFINITION_MARK in this module in the SAME commit."
+    )
+
+
+def test_the_definition_appears_exactly_once_in_the_tree():
+    """The single-source claim, asserted as a RELATIONSHIP.
+
+    Fails if the set GROWS (someone restated the predicate elsewhere) or SHRINKS
+    (the definition was deleted) -- both are real regressions.
+    """
+    hits = sorted(
+        p.relative_to(REPO_ROOT).as_posix()
+        for p, text in _corpus().items()
+        if DEFINITION_MARK in text
+    )
+    assert hits == [CANONICAL.relative_to(REPO_ROOT).as_posix()], (
+        f"\n\nThe closing-condition predicate must be DEFINED in exactly one place.\n"
+        f"  expected: [{CANONICAL.relative_to(REPO_ROOT).as_posix()}]\n"
+        f"  found:    {hits}\n"
+        f"A predicate open-coded at N sites is typically wrong at N-1 of them.\n"
+        f"Point at the definition instead of restating it."
+    )
+
+
+def test_the_out_of_scope_row_is_conditional():
+    text = _normalise(HOOKS_REF.read_text(encoding="utf-8"))
+    assert _normalise(HOOKS_CONDITIONAL) in text, (
+        f"\n\n{HOOKS_REF.relative_to(REPO_ROOT)} no longer states the out-of-scope "
+        f"case conditionally.\n  expected: {HOOKS_CONDITIONAL!r}\n"
+        f"An unconditional 'file a task' is the instruction that generates the leak."
+    )
+
+
+def test_the_unconditional_form_has_not_come_back():
+    offenders = sorted(
+        p.relative_to(REPO_ROOT).as_posix()
+        for p, text in _corpus().items()
+        if _normalise(BANNED_UNCONDITIONAL) in text
+    )
+    assert offenders == [], (
+        f"\n\nThe unconditional 'File a task instead' is back in: {offenders}\n"
+        f"Out-of-scope work is only filed when its closing condition can be named."
+    )

--- a/scripts/tests/test_closing_condition_single_source.py
+++ b/scripts/tests/test_closing_condition_single_source.py
@@ -21,9 +21,28 @@ The artifact under test is PROSE. RULES.md: "when the artifact under test IS pro
 a guard on WORDS is walkable by REWORDING -- pin the WHOLE normalised string. A
 cosmetic reword then fails the test -- pay it, for a machine-readable claim."
 
-So these pin whole normalised sentences, not keywords. A reword SHOULD fail here;
-the fix is to update the constant below in the same commit, which is exactly the
-moment someone should notice they are about to create a sixth phrasing.
+So these pin whole normalised sentences and one whole normalised table row, not
+keywords. A reword SHOULD fail here; the fix is to update the constant below in the
+same commit, which is exactly the moment someone should notice they are about to
+create a sixth phrasing.
+
+🔴 WHAT THIS MODULE DOES **NOT** ENFORCE -- read before trusting it as coverage
+------------------------------------------------------------------------------
+An audit of this PR found six ways to restate the predicate that stay green, and a
+guard that reads as wider than it is stops anyone looking. Precisely:
+
+1. **It pins ONE sentence, not the CONCEPT.** A semantically identical restatement
+   in different words is invisible. There is no known mechanical fix for that; the
+   prose instruction in task-authoring.md ("add no further phrasings") is the only
+   control, and it is a convention, not a gate.
+2. **It cannot see files outside SEARCH_ROOTS/SEARCH_SUFFIXES** -- `claudedocs/`,
+   `nix/`, `githooks/`, `cmd/`, and (inside the roots) extensionless executables,
+   `.html`, `.json`, `.txt`, `.toml`. Repo-root `CLAUDE.md` WAS invisible and is now
+   explicitly included, because it is the highest-traffic surface for exactly this
+   restatement.
+3. **`claude/RULES.md` is deliberately exempt** -- it restates the predicate on
+   purpose (see task-authoring.md question 1). Nothing here guards RULES.md's own
+   wording; that clause remains unguarded, which is recorded rather than fixed.
 """
 
 import re
@@ -39,16 +58,36 @@ HOOKS_REF = REPO_ROOT / "claude" / "skills" / "clawgate" / "reference" / "hooks.
 # in the whole tree -- that count IS the single-source claim.
 DEFINITION_MARK = "they are one thing under two names, not two requirements"
 
-# The conditional form the out-of-scope row must carry. The row previously read
-# "File a task instead" unconditionally, which is verbatim the instruction that
-# generated the leak the rule exists to stop.
-HOOKS_CONDITIONAL = "File a task **only if you can name its closing condition**"
+# 🔴 The WHOLE normalised out-of-scope row, not a prefix of it.
+#
+# A prefix assertion is satisfied by a row that states the condition and then
+# contradicts itself in its own tail ("...only if you can name its closing
+# condition; otherwise file a task instead") -- an audit mutant proved exactly that
+# passed when this pinned only the opening clause. Pinning the whole row is what
+# makes the guard structural rather than spelled. A cosmetic edit to this row will
+# fail here; update the constant in the same commit.
+HOOKS_ROW = (
+    "| Out of scope | **No** — semantic, produces no `PermissionRequest`. "
+    "File a task **only if you can name its closing condition**; with none, say so "
+    "in your reply instead of creating one "
+    "(definition: `~/.claude/skills/clawgate/flows/task-authoring.md`, question 1 — "
+    "the single source; do not restate it here). Note the criteria-less-create "
+    "denial comes from a devrc PreToolUse hook, `clawgate-task-interview-guard.py`, "
+    "NOT this one; and the criteria table in SKILL.md governs the final status on "
+    "the LOCAL pickup path, which may set `complete` — it is the DISPATCHED devpod "
+    "route that cannot, `taskstatus.go:79-81`. |"
+)
 
 # The unconditional form that must NOT come back anywhere in the clawgate skill.
 BANNED_UNCONDITIONAL = "produces no `PermissionRequest`. File a task instead"
 
 SEARCH_ROOTS = (REPO_ROOT / "claude", REPO_ROOT / "scripts")
 SEARCH_SUFFIXES = {".md", ".py", ".mjs", ".js", ".sh"}
+
+# Repo-root CLAUDE.md is not under either root but IS always-loaded project context
+# -- the single highest-traffic place a sixth phrasing would land. An audit mutant
+# that restated the predicate there survived until this was added.
+EXTRA_FILES = (REPO_ROOT / "CLAUDE.md",)
 
 
 def _normalise(text: str) -> str:
@@ -69,13 +108,20 @@ def _corpus() -> dict[Path, str]:
     removed, both relationship tests fail naming this file.
     """
     out = {}
-    for root in SEARCH_ROOTS:
-        for p in root.rglob("*"):
-            if p.is_file() and p.suffix in SEARCH_SUFFIXES and p.resolve() != SELF:
-                try:
-                    out[p] = _normalise(p.read_text(encoding="utf-8"))
-                except (UnicodeDecodeError, OSError):
-                    continue
+    candidates = [
+        p
+        for root in SEARCH_ROOTS
+        for p in root.rglob("*")
+        if p.is_file() and p.suffix in SEARCH_SUFFIXES
+    ]
+    candidates += [p for p in EXTRA_FILES if p.is_file()]
+    for p in candidates:
+        if p.resolve() == SELF:
+            continue
+        try:
+            out[p] = _normalise(p.read_text(encoding="utf-8"))
+        except (UnicodeDecodeError, OSError):
+            continue
     return out
 
 
@@ -98,18 +144,25 @@ def test_the_definition_exists_at_the_canonical_site():
     )
 
 
-def test_the_definition_appears_exactly_once_in_the_tree():
+def test_the_definition_sentence_occurs_exactly_once_in_the_scanned_corpus():
     """The single-source claim, asserted as a RELATIONSHIP.
 
     Fails if the set GROWS (someone restated the predicate elsewhere) or SHRINKS
     (the definition was deleted) -- both are real regressions.
+
+    🔴 Counts OCCURRENCES, not files. `x in text` is membership, so a SECOND copy
+    inside the canonical file itself passed green while this test's own name said
+    "exactly once" -- found by audit. The name and the assertion now agree.
+
+    Scope is the scanned corpus only; see the module docstring for what that
+    structurally cannot see.
     """
     hits = sorted(
-        p.relative_to(REPO_ROOT).as_posix()
+        f"{p.relative_to(REPO_ROOT).as_posix()} (x{text.count(DEFINITION_MARK)})"
         for p, text in _corpus().items()
-        if DEFINITION_MARK in text
+        if text.count(DEFINITION_MARK) > 0
     )
-    assert hits == [CANONICAL.relative_to(REPO_ROOT).as_posix()], (
+    assert hits == [f"{CANONICAL.relative_to(REPO_ROOT).as_posix()} (x1)"], (
         f"\n\nThe closing-condition predicate must be DEFINED in exactly one place.\n"
         f"  expected: [{CANONICAL.relative_to(REPO_ROOT).as_posix()}]\n"
         f"  found:    {hits}\n"
@@ -118,12 +171,21 @@ def test_the_definition_appears_exactly_once_in_the_tree():
     )
 
 
-def test_the_out_of_scope_row_is_conditional():
+def test_the_whole_out_of_scope_row_matches_byte_for_byte():
+    """Pins the ENTIRE normalised row, not its opening clause.
+
+    A prefix assertion is satisfied by a row that states the condition and then
+    contradicts itself in its own tail -- "...only if you can name its closing
+    condition; otherwise file a task instead" passed the prefix version. Found by
+    audit. Pinning the whole row is what makes this structural rather than spelled.
+    """
     text = _normalise(HOOKS_REF.read_text(encoding="utf-8"))
-    assert _normalise(HOOKS_CONDITIONAL) in text, (
-        f"\n\n{HOOKS_REF.relative_to(REPO_ROOT)} no longer states the out-of-scope "
-        f"case conditionally.\n  expected: {HOOKS_CONDITIONAL!r}\n"
-        f"An unconditional 'file a task' is the instruction that generates the leak."
+    assert _normalise(HOOKS_ROW) in text, (
+        f"\n\n{HOOKS_REF.relative_to(REPO_ROOT)}'s out-of-scope row no longer matches "
+        f"the pinned text.\n\n  expected (normalised):\n    {_normalise(HOOKS_ROW)}\n\n"
+        f"If you edited that row deliberately, update HOOKS_ROW in this module in the "
+        f"SAME commit -- and check the edit did not reintroduce an unconditional "
+        f"'file a task', which is the instruction that generates the leak."
     )
 
 


### PR DESCRIPTION
Two follow-ups from the #772 re-audit: 🟢-18 (a contradiction left in a loaded file) and 🟡-10 (one predicate, five spellings).

## 🟢-18 — `reference/hooks.md` contradicted the rule that just merged

Its out-of-scope row still said **"File a task instead"**, unconditionally. That is verbatim the instruction #772 exists to stop, sitting in a file agents actually load. Now conditional, and it points at the definition rather than restating it.

## 🟡-10 — one predicate, five spellings

The same requirement was spelled five ways — the core rule, the enforced `## Acceptance criteria` heading, the authoring flow's *"what does DONE look like"*, the ClickUp `--cond` allowlist, and #772's own new wording — with none updated when the rule landed. `RULES.md`'s **"One rule, one place"** warns that a predicate open-coded at N sites is typically wrong at N−1 of them.

**What is deliberately NOT consolidated:** the `## Acceptance criteria` heading is not renamed. It is the **enforced** artifact — `clawgate-task-interview-guard.py` matches it literally, and every existing task body carries it — so renaming would break the gate and the corpus at once.

**What is single-sourced:** the *definition*. Question 1 of `claude/skills/clawgate/flows/task-authoring.md` now states that the acceptance criteria **is** the closing condition, gives the mechanical-check and named-evidence forms, and states the do-not-create case. Every other site points there.

## The guard pins a relationship, not a keyword

`scripts/tests/test_closing_condition_single_source.py` asserts the definition sentence occurs **exactly once** across `claude/` and `scripts/` — failing if the set **grows** (someone restated it) or **shrinks** (it was deleted). Both are real regressions.

Per `RULES.md`, a prose guard on *words* is walkable by rewording, so these pin whole normalised strings. A cosmetic reword **should** fail here — that is the trade, and it fires at exactly the moment someone is about to mint a sixth phrasing.

The module **excludes itself** from the corpus. It necessarily quotes both the canonical and the banned sentence as constants, so without that it matched its own source and reported itself as the violation. Caught on first run.

## Matrix

| Check | Result |
|---|---|
| Guard at `origin/main` (pre-change) | **RED — 4 failed, 1 passed** |
| Guard at HEAD | **GREEN — 5 passed** |
| `test_doc_path_rot` | 76 passed |
| `run-tests.sh --check-floors` | PASS — new file lands in an existing target, no floor change |

The one test passing at base is the corpus positive control, correctly — it asserts the search roots aren't empty, which is not a claim about this change.

**Mutants**, all under `PYTHONDONTWRITEBYTECODE=1` (a same-length edit in the same second is otherwise invisible to CPython's bytecode cache and would score SURVIVED without executing). Each killed by its **named** test:

| Mutant | Killed by |
|---|---|
| M1 revert the row to unconditional | `test_the_out_of_scope_row_is_conditional` |
| M2 restate the definition in a 2nd file | `test_the_definition_appears_exactly_once_in_the_tree` |
| M3 delete it from its canonical home | `test_the_definition_exists_at_the_canonical_site` |
| M4 point the corpus at nothing | `test_the_corpus_is_non_empty` |
| M0 / M5 unmutated controls | 5 passed at both ends |

`test_doc_path_rot` also **caught a real error in this change** before I did: a bare `reference/hooks.md` sidecar ref, which resolves against the reader's cwd and is unopenable. Now repo-root-relative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
