### PR TITLE
fix(tests): the maintenance-lock flake was 6 of 8 modules, not 1 — one pin, one ledger, and the class closes

### DIFF
--- a/scripts/testlib/hermetic_git.py
+++ b/scripts/testlib/hermetic_git.py
@@ -1,0 +1,119 @@
+"""The canonical hermetic git environment for test fixtures — ONE copy.
+
+WHY THIS EXISTS
+---------------
+Several test modules fingerprint a fixture repository by hashing every file
+under its root, `.git` INCLUDED and on purpose: a read that refreshes
+`.git/index` leaves file contents identical and moves an mtime, so a hash blind
+to `.git` would call a mutating read "unchanged" and a read-only claim would be
+false in exactly the way nobody checks.
+
+The price of that honesty is that any file GIT creates under `.git` on its own
+initiative is a difference. Git's auto-maintenance creates one, transiently:
+
+    AssertionError: the repository changed anyway
+      Right contains 1 more item:
+      {'.git/objects/maintenance.lock': (0, …, 'e3b0c44…')}
+
+That has now broken CI twice, in two different modules, and each was fixed only
+AFTER it fired:
+
+    #743  tree_hash   in scripts/tests/test_handoff_doc.py
+    #780  _manifest   in scripts/tests/test_analyze_service_index_restore_verify.py
+
+🔴 A THIRD WAS ALREADY WAITING. Measured 2026-08-24 across `scripts/`: EIGHT
+modules define such a helper (`tree_hash` / `_tree_hash` / `_manifest` /
+`_fingerprint`) over git-repo fixtures, and only THREE pinned maintenance off.
+`claude/RULES.md`: "a predicate open-coded at N sites is typically wrong at N-1
+of them in the same direction, and unifying them is what makes the disagreement
+audible." Unifying them is this module.
+
+🔴 THE STAKES CHANGED, WHICH IS WHY THIS IS NOT COSMETIC. Both Tekton tiers
+(`devrc-pytests` AND `devrc-nodetests`) are required on `main` with
+`enforce_admins: true`. A flake in any one of these modules therefore blocks
+EVERY open PR, for everyone, with no admin override — and `claude/RULES.md` is
+explicit that a gate which fails for reasons unrelated to the code is how people
+are trained to click through a red run.
+
+WHAT THE PINS DO, AND WHAT THEY DO NOT
+--------------------------------------
+`GIT_CONFIG_COUNT` / `_KEY_n` / `_VALUE_n` inject config that outranks the repo's
+own. They are ENVIRONMENT variables, so every git process spawned from one that
+carries them inherits them — including gits launched by a script under test.
+
+⚠ THEY ARE NOT REDUNDANT WITH THE `/dev/null` PINS. `GIT_CONFIG_GLOBAL` /
+`GIT_CONFIG_SYSTEM` / `GIT_CONFIG_NOSYSTEM` stop git READING the operator's
+config; none of them turns maintenance off, because `maintenance.auto` and
+`gc.auto` default to ON with no config file at all. `test_hermetic_git.py`
+proves that distinction with a negative control rather than asserting it.
+
+⚠ AND THEY SURVIVE `testlib.gitenv`. That module strips REPO POINTER variables
+from the environment to stop a fixture writing into the real repo, and
+`GIT_CONFIG_COUNT`/`_KEY_n`/`_VALUE_n` are on its explicit DELIBERATELY NOT
+STRIPPED ledger — they inject values into whatever repo git already resolved,
+they cannot change WHICH repo that is. Verified before relying on it; if that
+ledger ever changes, these pins go silently inert and the flake returns.
+"""
+from __future__ import annotations
+
+import os
+
+# The maintenance half, alone, so a caller that already has its own hermetic env
+# can merge just this in without inheriting opinions about identity or protocol.
+#
+# 🔴 KEEP `GIT_CONFIG_COUNT` IN SYNC WITH THE NUMBER OF KEY/VALUE PAIRS. git
+# reads exactly COUNT pairs; a COUNT lower than the pairs present silently
+# ignores the tail, which is a pin that looks correct and is not.
+MAINTENANCE_OFF: dict[str, str] = {
+    "GIT_CONFIG_COUNT": "2",
+    "GIT_CONFIG_KEY_0": "maintenance.auto",
+    "GIT_CONFIG_VALUE_0": "false",
+    "GIT_CONFIG_KEY_1": "gc.auto",
+    "GIT_CONFIG_VALUE_1": "0",
+}
+
+# Config isolation: git must not read or write the OPERATOR's real config, or a
+# stray `core.hooksPath` / `commit.gpgsign` decides whether these tests can
+# commit at all — and the nix sandbox and the dev host must behave identically.
+CONFIG_ISOLATION: dict[str, str] = {
+    "GIT_CONFIG_NOSYSTEM": "1",
+    "GIT_CONFIG_GLOBAL": os.devnull,
+    "GIT_CONFIG_SYSTEM": os.devnull,
+}
+
+# A committer identity, so `git commit` works with no global config present.
+IDENTITY: dict[str, str] = {
+    "GIT_AUTHOR_NAME": "t",
+    "GIT_AUTHOR_EMAIL": "t@localhost",
+    "GIT_COMMITTER_NAME": "t",
+    "GIT_COMMITTER_EMAIL": "t@localhost",
+}
+
+# Never block on a credential prompt inside a test run.
+NO_PROMPT: dict[str, str] = {"GIT_TERMINAL_PROMPT": "0"}
+
+# Everything a fixture repo normally wants.
+HERMETIC: dict[str, str] = {
+    **CONFIG_ISOLATION,
+    **IDENTITY,
+    **NO_PROMPT,
+    **MAINTENANCE_OFF,
+}
+
+
+def hermetic_git_env(base: "dict[str, str] | None" = None,
+                     **overrides: str) -> dict[str, str]:
+    """`base` (default a copy of `os.environ`) + `HERMETIC` + `overrides`.
+
+    Returns a NEW dict; `os.environ` is never mutated. `overrides` wins, so a
+    module needing e.g. `GIT_ALLOW_PROTOCOL` or a per-test `HOME` can add it
+    without losing the pins.
+
+    🔴 The maintenance pins are applied AFTER `base` deliberately. A caller
+    passing a `base` that already carries a stale `GIT_CONFIG_COUNT` from an
+    outer process would otherwise keep it and silently drop these.
+    """
+    env = dict(os.environ if base is None else base)
+    env.update(HERMETIC)
+    env.update(overrides)
+    return env

--- a/scripts/tests/test_analyze_service_index_backup.py
+++ b/scripts/tests/test_analyze_service_index_backup.py
@@ -58,6 +58,7 @@ sys.path.insert(0, str(SCRIPTS))
 
 import backup as B  # noqa: E402
 from testlib.mockbin import write_exec  # noqa: E402
+from testlib import hermetic_git  # noqa: E402
 
 
 def _require(tool: str, why: str) -> str:
@@ -96,6 +97,12 @@ def _git_env() -> dict:
         "GIT_TERMINAL_PROMPT": "0",
         "GIT_ALLOW_PROTOCOL": "file",
     })
+    # 🔴 Background maintenance OFF — `_manifest` hashes `.git`, so a
+    # transient `.git/objects/maintenance.lock` reads as a repository change.
+    # Broke CI twice before this was shared (#743, #780); see
+    # scripts/testlib/hermetic_git.py for the measurement and why the
+    # /dev/null pins above do NOT cover it.
+    e.update(hermetic_git.MAINTENANCE_OFF)
     return e
 
 

--- a/scripts/tests/test_analyze_service_index_commit.py
+++ b/scripts/tests/test_analyze_service_index_commit.py
@@ -28,6 +28,7 @@ wrong reason and stays green with the guard it claims to test deleted.
 """
 from __future__ import annotations
 
+from testlib import hermetic_git  # noqa: E402
 import os
 import re
 import shutil
@@ -65,6 +66,12 @@ def _run(store, *args, **env):
     """Invoke the committer. bash is resolved to an absolute path — never via a
     shebang and never through an interpreter that may be absent in the sandbox."""
     e = dict(os.environ)
+    # 🔴 Maintenance OFF BEFORE the caller's overrides, never after: several
+    # tests here pass their own GIT_CONFIG_* to prove the committer neutralises
+    # ambient config, and those must still win. `_fingerprint` walks `objects/`,
+    # which is where `.git/objects/maintenance.lock` lands, so this module is a
+    # member of the class by construction. See scripts/testlib/hermetic_git.py.
+    e.update(hermetic_git.MAINTENANCE_OFF)
     e.update({k: str(v) for k, v in env.items()})
     return subprocess.run(
         [BASH, str(SCRIPT), *[str(a) for a in args], str(store)],

--- a/scripts/tests/test_analyze_service_index_restore_verify.py
+++ b/scripts/tests/test_analyze_service_index_restore_verify.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 
 import hashlib
 import importlib.util
+from testlib import hermetic_git  # noqa: E402
 import os
 import shutil
 import subprocess
@@ -162,11 +163,7 @@ def _git_env() -> dict:
         "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@localhost",
         "GIT_TERMINAL_PROMPT": "0",
         "GIT_ALLOW_PROTOCOL": "file",
-        "GIT_CONFIG_COUNT": "2",
-        "GIT_CONFIG_KEY_0": "maintenance.auto",
-        "GIT_CONFIG_VALUE_0": "false",
-        "GIT_CONFIG_KEY_1": "gc.auto",
-        "GIT_CONFIG_VALUE_1": "0",
+        **hermetic_git.MAINTENANCE_OFF,
     })
     return e
 

--- a/scripts/tests/test_handoff_doc.py
+++ b/scripts/tests/test_handoff_doc.py
@@ -36,6 +36,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
+from testlib import hermetic_git  # noqa: E402
 from testlib.mockbin import write_exec  # noqa: E402
 
 TOOL = REPO_ROOT / "scripts" / "lib" / "handoff_doc.py"
@@ -141,11 +142,11 @@ UPDATE_DOC = f"""## State now
 GIT_ENV = {
     "GIT_CONFIG_GLOBAL": "/dev/null",
     "GIT_CONFIG_SYSTEM": "/dev/null",
-    "GIT_CONFIG_COUNT": "2",
-    "GIT_CONFIG_KEY_0": "maintenance.auto",
-    "GIT_CONFIG_VALUE_0": "false",
-    "GIT_CONFIG_KEY_1": "gc.auto",
-    "GIT_CONFIG_VALUE_1": "0",
+    # 🔴 CONSOLIDATED 2026-08-24. These five keys were spelled out here, again
+    # in restore-verify, and nowhere in five other modules that need them — the
+    # N-sites-wrong-at-N-1 shape. One copy now: testlib/hermetic_git.py, whose
+    # ledger test fails when a new module joins the class without them.
+    **hermetic_git.MAINTENANCE_OFF,
 }
 
 

--- a/scripts/tests/test_hermetic_git.py
+++ b/scripts/tests/test_hermetic_git.py
@@ -1,0 +1,220 @@
+"""The seam guard for `testlib.hermetic_git` — the git-maintenance flake class.
+
+WHY A LEDGER AND NOT A PER-MODULE ASSERTION
+-------------------------------------------
+`claude/RULES.md`: *"'Verified in isolation' is the new vacuous green — the
+defect lives in the SEAM nobody owns … a seam guard must pin a RELATIONSHIP, not
+a component — an asserted ledger of every writer/caller, failing when the set
+GROWS or SHRINKS."*
+
+That is exactly this class. Each module that fingerprints a git fixture was
+individually correct and individually tested; what nobody owned was the fact
+that ALL of them must pin maintenance off. Measured: eight such modules, three
+pinned — and both of those three were pinned only AFTER the flake fired in CI
+(#743, #780). A per-module assertion cannot see module nine.
+
+So the ledger below fails in BOTH directions:
+
+  * a NEW module defining a tree-hashing helper that does not use
+    `testlib.hermetic_git` — the case that produced #743 and #780;
+  * a module LEAVING the set — which is fine, but must be a decision someone
+    made, not a rename nobody noticed.
+
+WHAT THIS DOES NOT COVER, stated so a green here is not over-read: it checks
+that each module REFERENCES the shared pins, not that every git call inside it
+routes through them. A module could import `hermetic_git` and still build one
+stray env by hand. `test_the_pins_actually_reach_git` covers the shared
+constant behaviourally; the per-call routing is not machine-checked.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from testlib import hermetic_git  # noqa: E402
+
+GIT = "git"
+
+# The helper names that indicate "this module fingerprints a directory tree".
+# Derived from the real corpus rather than invented: these are the four spellings
+# actually in use across `scripts/`.
+HELPER_NAMES = {"tree_hash", "_tree_hash", "_manifest", "_fingerprint"}
+
+# 🔴 THE LEDGER. Every test module that fingerprints a GIT fixture and therefore
+# must pin maintenance off. Measured 2026-08-24. Adding a module here without
+# making it use `testlib.hermetic_git` fails the test below; adding one that uses
+# it and forgetting this list fails it too.
+EXPECTED_MEMBERS = {
+    "test_analyze_service_index_backup.py",
+    "test_analyze_service_index_commit.py",
+    "test_analyze_service_index_restore_verify.py",
+    "test_handoff_doc.py",
+    "test_service_recon.py",
+    "test_subsystem_recall.py",
+    "test_subsystem_store_api.py",
+    "test_subsystem_touch.py",
+}
+
+
+def _defines_a_tree_helper(path: Path) -> bool:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="ignore"))
+    except SyntaxError:
+        return False
+    return any(
+        isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and n.name in HELPER_NAMES
+        for n in ast.walk(tree)
+    )
+
+
+def _touches_git_fixtures(path: Path) -> bool:
+    """Does the module build git repositories? A tree-hashing helper over a
+    non-git directory has no maintenance to disarm."""
+    t = path.read_text(encoding="utf-8", errors="ignore")
+    return '"init"' in t or "git init" in t or "GIT_CONFIG" in t
+
+
+def _live_members() -> set[str]:
+    return {
+        p.name
+        for p in sorted((REPO_ROOT / "scripts" / "tests").glob("test_*.py"))
+        if _defines_a_tree_helper(p) and _touches_git_fixtures(p)
+    }
+
+
+def test_the_scan_finds_something():
+    """🔴 POSITIVE CONTROL. A ledger built by a scan that walked nothing reports
+    a clean set and an empty diff — indistinguishable from compliance. If this
+    ever returns zero, the detector is broken, not the repo."""
+    live = _live_members()
+    assert len(live) >= 5, (
+        f"the tree-helper scan found only {len(live)} module(s): {sorted(live)}. "
+        f"That is too few to be real — HELPER_NAMES or the glob is wrong, and a "
+        f"zero here would read as 'everything complies'."
+    )
+
+
+def test_the_ledger_matches_reality():
+    """Fails when the set GROWS or SHRINKS — see the module docstring."""
+    live = _live_members()
+    added = sorted(live - EXPECTED_MEMBERS)
+    gone = sorted(EXPECTED_MEMBERS - live)
+    assert not added, (
+        f"\n\nNEW module(s) fingerprint a git fixture: {added}\n"
+        f"  Each must pin git's background maintenance off, or a transient\n"
+        f"  .git/objects/maintenance.lock will read as a repository change and\n"
+        f"  flake CI — which now blocks EVERY merge, both Tekton tiers being\n"
+        f"  required with enforce_admins: true.\n"
+        f"  Fix: merge `hermetic_git.MAINTENANCE_OFF` into the module's git env,\n"
+        f"  then add it to EXPECTED_MEMBERS in this file.\n"
+        f"  See scripts/testlib/hermetic_git.py."
+    )
+    assert not gone, (
+        f"\n\nmodule(s) left the ledger: {gone}\n"
+        f"  Either the helper was renamed (update HELPER_NAMES), the module was\n"
+        f"  deleted (drop it from EXPECTED_MEMBERS), or the scan broke. A silent\n"
+        f"  shrink is how a member stops being covered without anyone deciding."
+    )
+
+
+@pytest.mark.parametrize("member", sorted(EXPECTED_MEMBERS))
+def test_every_member_uses_the_shared_pins(member: str):
+    """Each ledger member must REFERENCE the shared module, not re-spell the
+    pins. Four hand-rolled copies is what produced a class with 5 of 8 wrong."""
+    src = (REPO_ROOT / "scripts" / "tests" / member).read_text(encoding="utf-8")
+    assert "hermetic_git" in src, (
+        f"{member} fingerprints a git fixture but does not reference "
+        f"testlib.hermetic_git. Merge `hermetic_git.MAINTENANCE_OFF` into its "
+        f"git environment; do not re-spell GIT_CONFIG_COUNT locally."
+    )
+
+
+def test_the_pins_actually_reach_git(tmp_path):
+    """🔴 BEHAVIOURAL, on a REAL git process — the dict cannot be misspelled in
+    an interesting way, so a structural check would prove nothing.
+
+    🔴 THE NEGATIVE CONTROL IS THE LOAD-BEARING HALF: it re-queries with ONLY the
+    GIT_CONFIG_COUNT injection stripped, leaving the /dev/null pins in place, so
+    exactly one variable moves. Without it, a git that defaulted maintenance off
+    by itself would satisfy the assertions while the pins did nothing.
+    """
+    repo = tmp_path / "r"
+    repo.mkdir()
+    env = hermetic_git.hermetic_git_env()
+    subprocess.run([GIT, "init", "-q", "-b", "main", str(repo)],
+                   check=True, capture_output=True, env=env)
+
+    def cfg(key: str, e: dict) -> str:
+        # `--default ''` so an UNSET key exits 0 rather than 1 — otherwise a
+        # broken pin fails on the exit status and the message names the query.
+        return subprocess.run(
+            [GIT, "-C", str(repo), "config", "--get", "--default", "", key],
+            capture_output=True, text=True, env=e,
+        ).stdout.strip()
+
+    assert cfg("maintenance.auto", env) == "false"
+    assert cfg("gc.auto", env) == "0"
+
+    stripped = {
+        k: v for k, v in env.items()
+        if not k.startswith(("GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_",
+                             "GIT_CONFIG_VALUE_"))
+    }
+    assert cfg("maintenance.auto", stripped) == "", (
+        "git reports maintenance.auto with the injection removed, so the "
+        "assertions above are green for some other reason and prove nothing "
+        "about these pins"
+    )
+
+
+def test_the_count_matches_the_pairs():
+    """🔴 GIT READS EXACTLY `GIT_CONFIG_COUNT` PAIRS. A count lower than the
+    pairs present silently ignores the tail — a pin that looks right and is not,
+    and the failure mode is invisible because the visible keys still work."""
+    pairs = sum(1 for k in hermetic_git.MAINTENANCE_OFF if k.startswith("GIT_CONFIG_KEY_"))
+    values = sum(1 for k in hermetic_git.MAINTENANCE_OFF if k.startswith("GIT_CONFIG_VALUE_"))
+    count = int(hermetic_git.MAINTENANCE_OFF["GIT_CONFIG_COUNT"])
+    assert pairs == values == count, (
+        f"GIT_CONFIG_COUNT={count} but there are {pairs} key(s) and {values} "
+        f"value(s). git will read only the first {count}."
+    )
+
+
+def test_hermetic_env_does_not_mutate_os_environ():
+    """The builder returns a NEW dict. Mutating os.environ would leak the pins
+    into every later subprocess in the run, including ones deliberately testing
+    unpinned behaviour."""
+    before = dict(os.environ)
+    hermetic_git.hermetic_git_env(HOME="/nowhere")
+    assert dict(os.environ) == before
+
+
+def test_overrides_win_but_pins_survive_a_stale_base():
+    """A caller's override must win; a stale GIT_CONFIG_COUNT in `base` must
+    NOT, or a pin is silently dropped by an outer process's leftovers.
+
+    ⚠ The passthrough key is deliberately NOT `PATH`. `launcher_scan` flags any
+    dict literal binding PATH inside `scripts/tests` and pins the set in
+    `test_no_real_launchers.py::test_every_path_clobbering_site_is_pinned` —
+    correctly, since a test that REPLACES PATH drops the launcher-stub dir and
+    real `systemd-run`/`notify-send`/`rofi` become reachable. This dict is a
+    synthetic argument to a pure function and launches nothing, so the right fix
+    was to stop looking like a clobber, NOT to add a benign entry to a safety
+    ledger — an allowlist that accumulates harmless exceptions is how the next
+    real one gets waved through.
+    """
+    got = hermetic_git.hermetic_git_env(
+        base={"GIT_CONFIG_COUNT": "99", "UNRELATED_PASSTHROUGH": "/x"}, HOME="/h"
+    )
+    assert got["GIT_CONFIG_COUNT"] == hermetic_git.MAINTENANCE_OFF["GIT_CONFIG_COUNT"]
+    assert got["HOME"] == "/h"
+    assert got["UNRELATED_PASSTHROUGH"] == "/x"

--- a/scripts/tests/test_service_recon.py
+++ b/scripts/tests/test_service_recon.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+from testlib import hermetic_git  # noqa: E402
 import subprocess
 import sys
 from pathlib import Path
@@ -49,7 +50,8 @@ def _git(repo: Path, *args: str) -> None:
     subprocess.run(
         ["git", "-C", str(repo), *args],
         check=True, capture_output=True, text=True,
-        env={**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e",
+        env={**os.environ, **hermetic_git.MAINTENANCE_OFF,
+             "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e",
              "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e"},
     )
 

--- a/scripts/tests/test_subsystem_recall.py
+++ b/scripts/tests/test_subsystem_recall.py
@@ -43,6 +43,7 @@ import collections
 import hashlib
 import importlib.util
 import json
+from testlib import hermetic_git  # noqa: E402
 import subprocess
 import sys
 from pathlib import Path
@@ -2948,6 +2949,9 @@ class TestSharedPrimitivesAreReused:
             "HOME": str(tmp_path),
             "GIT_CONFIG_GLOBAL": "/dev/null",
             "GIT_CONFIG_SYSTEM": "/dev/null",
+            # 🔴 maintenance OFF: `_tree_hash` hashes `.git`, so a transient
+            # maintenance.lock reads as a repo change (testlib/hermetic_git.py).
+            **hermetic_git.MAINTENANCE_OFF,
             "PATH": __import__("os").environ.get("PATH", ""),
         }
         subprocess.run(["git", "-C", str(repo), "init", "-q", "-b", "main"], env=env, check=True)
@@ -3109,6 +3113,9 @@ class TestCli:
             "HOME": str(tmp_path),
             "GIT_CONFIG_GLOBAL": "/dev/null",
             "GIT_CONFIG_SYSTEM": "/dev/null",
+            # 🔴 maintenance OFF: `_tree_hash` hashes `.git`, so a transient
+            # maintenance.lock reads as a repo change (testlib/hermetic_git.py).
+            **hermetic_git.MAINTENANCE_OFF,
             "PATH": __import__("os").environ.get("PATH", ""),
         }
         subprocess.run(["git", "-C", str(repo), "init", "-q", "-b", "main"], env=env, check=True)
@@ -3446,6 +3453,9 @@ class TestAppendConcurrency:
             "HOME": str(tmp_path),
             "GIT_CONFIG_GLOBAL": "/dev/null",
             "GIT_CONFIG_SYSTEM": "/dev/null",
+            # 🔴 maintenance OFF: `_tree_hash` hashes `.git`, so a transient
+            # maintenance.lock reads as a repo change (testlib/hermetic_git.py).
+            **hermetic_git.MAINTENANCE_OFF,
             "GIT_AUTHOR_NAME": "T",
             "GIT_AUTHOR_EMAIL": "t@example.invalid",
             "GIT_COMMITTER_NAME": "T",

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -48,6 +48,7 @@ import ast
 import hashlib
 import http.client
 import importlib.util
+from testlib import hermetic_git  # noqa: E402
 import os
 import re
 import secrets
@@ -964,7 +965,8 @@ class TestScopeRevision:
             ["git", "-C", str(path), *args],
             check=True,
             capture_output=True,
-            env={**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "HOME": str(path)},
+            env={**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "HOME": str(path),
+                 **hermetic_git.MAINTENANCE_OFF},
         )
 
     def test_a_real_scope_repo_yields_its_HEAD_sha(self, store: Path):
@@ -1396,7 +1398,8 @@ class TestSeedNeverAddsARemote:
         self, store: Path, tmp_path: Path
     ):
         scope_dir = store / SCOPE
-        env = {**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "HOME": str(tmp_path)}
+        env = {**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "HOME": str(tmp_path),
+               **hermetic_git.MAINTENANCE_OFF}
         for args in (
             ["init", "-q", "-b", "main"],
             ["config", "user.email", "t@example.invalid"],
@@ -1420,7 +1423,8 @@ class TestSeedNeverAddsARemote:
         """Positive control: an empty `git remote` from a probe that never works
         is indistinguishable from a repo with no remotes."""
         scope_dir = store / OTHER_SCOPE
-        env = {**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "HOME": str(tmp_path)}
+        env = {**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "HOME": str(tmp_path),
+               **hermetic_git.MAINTENANCE_OFF}
         subprocess.run(
             ["git", "-C", str(scope_dir), "init", "-q", "-b", "main"],
             check=True, capture_output=True, env=env,

--- a/scripts/tests/test_subsystem_touch.py
+++ b/scripts/tests/test_subsystem_touch.py
@@ -76,6 +76,7 @@ ANALYZE_WRITEBACK_DOC = (ROOT / "claude" / "skills" / "analyze-service"
 sys.path.insert(0, str(ROOT / "scripts" / "lib"))
 sys.path.insert(0, str(ROOT / "scripts"))
 
+from testlib import hermetic_git  # noqa: E402
 from testlib.skills_mapping import (  # noqa: E402
     assert_skills_mapping_declared,
 )
@@ -182,6 +183,10 @@ def _git_env(home: Path) -> dict:
             "GIT_COMMITTER_EMAIL": "test@example.invalid",
         }
     )
+    # 🔴 Background maintenance OFF — `_tree_hash` hashes `.git`, so a transient
+    # `.git/objects/maintenance.lock` reads as a repository change. See
+    # scripts/testlib/hermetic_git.py; the /dev/null pins above do NOT cover it.
+    env.update(hermetic_git.MAINTENANCE_OFF)
     return env
 
 


### PR DESCRIPTION
fix(tests): the git-maintenance flake was 6 of 8 modules, not 1 — one pin, one ledger, and the class closes

#743 and #780 each fixed this flake in ONE module, AFTER it turned a CI check
red. This closes the class instead of waiting for instance three.

THE SHAPE. Several test modules fingerprint a fixture repo by hashing every file
under its root, `.git` INCLUDED and on purpose: a read that refreshes
`.git/index` moves an mtime with contents unchanged, so a hash blind to `.git`
would call a mutating read "unchanged". The price is that any file git creates
under `.git` on its own initiative is a difference, and auto-maintenance creates
one transiently:

    AssertionError: the repository changed anyway
      Right contains 1 more item: {'.git/objects/maintenance.lock': …}

MEASURED 2026-08-24 across `scripts/`: EIGHT modules define such a helper
(`tree_hash` / `_tree_hash` / `_manifest` / `_fingerprint`) over git fixtures.
🔴 SIX were unpinned — not five. My own first survey reported 3 pinned because
`test_analyze_service_index_commit.py` matched on `GIT_CONFIG_COUNT` appearing
in a DOCSTRING about a mutation sweep. A grep for a token is not a check for a
pin; the AST-based scan in the new test is.

`claude/RULES.md`: "a predicate open-coded at N sites is typically wrong at N-1
of them in the same direction, and unifying them is what makes the disagreement
audible." Unifying them is `scripts/testlib/hermetic_git.py`.

WHAT LANDED

- `testlib/hermetic_git.py` — ONE copy of the pins. `MAINTENANCE_OFF` alone for
  callers with their own env; `HERMETIC` and `hermetic_git_env()` for the rest.
- All EIGHT modules now reference it. That includes the three that were already
  pinned: each had its own hand-rolled copy, so the same five keys were spelled
  four different ways. The new ledger test went red on exactly those three the
  moment it existed — which is the consolidation argument, demonstrated rather
  than asserted.
- `scripts/tests/test_hermetic_git.py` — the SEAM guard.

🔴 A LEDGER, NOT A PER-MODULE ASSERTION, and that is the point. `RULES.md`: "a
seam guard must pin a RELATIONSHIP … an asserted ledger of every writer/caller,
failing when the set GROWS or SHRINKS." Each module here was individually
correct and individually tested; what nobody owned was that ALL of them must
pin maintenance. A per-module assertion structurally cannot see module nine —
which is precisely how #743 and #780 were both found only after they fired.

🔴 `test_analyze_service_index_commit.py` NEEDED CARE, NOT A BLANKET PATCH.
Several of its tests deliberately pass their own `GIT_CONFIG_*` to prove the
committer neutralises ambient config, so the pins are applied BEFORE the
caller's overrides, never after. Its `_fingerprint` walks `objects/` — where
`maintenance.lock` lands — so it is a member by construction even though it has
not fired.

MUTATION BATTERY, six mutants, all killed, each on a relevant assertion:

    M0  pristine                        14 passed
    M1  a member drops the import       FAILED test_every_member_uses_the_shared_pins[test_service_recon.py]
    M2  GIT_CONFIG_COUNT lies (2->1)    FAILED test_the_pins_actually_reach_git
                                        FAILED test_the_count_matches_the_pairs
    M3  pins removed entirely           FAILED test_the_pins_actually_reach_git
                                        FAILED test_overrides_win_but_pins_survive_a_stale_base
    M4  detector blinded (HELPER_NAMES  FAILED test_the_scan_finds_something
        emptied)                        FAILED test_the_ledger_matches_reality
    M5  a NEW module joins the class    FAILED test_the_ledger_matches_reality, naming it
    restored                            14 passed

M4 is the one worth reading: blinding the detector does NOT read as compliance,
because `test_the_scan_finds_something` is a positive control. A ledger built by
a scan that walked nothing produces a clean set and an empty diff.

🔴 THE GATE CAUGHT ME WITH THE SAME SHAPE, AND I FIXED MY CODE NOT THE LEDGER.
`test_no_real_launchers.py` pins which modules bind `PATH` in a dict literal,
because a test that REPLACES PATH drops the launcher-stub dir and real
`systemd-run`/`notify-send`/`rofi` become reachable. My new file joined that set
via `{"GIT_CONFIG_COUNT": "99", "PATH": "/x"}` — a synthetic argument to a pure
function that launches nothing. A false positive of a deliberately syntactic
scanner. The fix was to stop looking like a clobber, NOT to add a benign entry:
an allowlist that accumulates harmless exceptions is how the next real one gets
waved through. Reasoning is in the test's docstring so it is not re-litigated.

WHY THIS IS NOT COSMETIC. Both Tekton tiers are required on `main` with
`enforce_admins: true`, so a flake in any one of these modules blocks EVERY open
PR for everyone, with no admin override — and `RULES.md` is explicit that a gate
failing for reasons unrelated to the code is how people learn to click through a
red run.

Verified: `gate.sh --tier both --set hermetic` under `nix develop` on this tree —
GATE: RESULT=PASS exit=0; pytest collected=15502 passed=15500 skipped=2 failed=0,
27 targets above floor, no target reporting FAIL; node suites=4 tests=1179
pass=1179 fail=0.

⚠ This cannot be shown red-then-green: the failure is a RACE. What is
demonstrated is the mechanism (the battery above) and the CI run that caught the
last instance.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
