### PR TITLE
docs(ci): `gate.sh` and `nix build .#checks` are two TIERS, not two spellings — the "or" cost a required check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,11 +206,22 @@ Repo-level facts that are NOT in any skill — they live here on purpose:
   agent-worktree creation, is NOT a devrc setting, and `git config --local --get
   core.hooksPath` per clone is the only answer.
   **Until then: run the gate yourself before you merge, and say which command you ran.**
-  `nix build .#checks.x86_64-linux.pytests` / `.#checks.x86_64-linux.nodetests` (or
-  `scripts/gate.sh`) are authoritative — they assert collected-test FLOORS and parse structured
-  output rather than reading an exit code, because `node --test <dir>` silently yields a bogus
-  `# tests 1` and a pytest suite can collect 0 with a zero exit. Gate on the MERGED tree, not
-  the PR branch.
+  Both of these assert collected-test FLOORS and parse structured output rather than reading
+  an exit code, because `node --test <dir>` silently yields a bogus `# tests 1` and a pytest
+  suite can collect 0 with a zero exit. Gate on the MERGED tree, not the PR branch.
+  🔴 **BUT THEY ARE TWO DIFFERENT TIERS, NOT TWO SPELLINGS OF ONE — this line used to join
+  them with "or", and that word cost a required check.** `scripts/gate.sh` runs
+  `scripts/run-tests.sh` + `scripts/run-node-tests.sh` **on the dev host** (see its
+  `PYTEST_RUNNER`/`NODE_RUNNER`); it does **not** invoke `nix build` at all.
+  `nix build .#checks.x86_64-linux.{pytests,nodetests}` builds from a `cp -r ${./.}` **store
+  copy with NO `.git`**, and that is the tier **Tekton runs and the merge is gated on**.
+  Measured 2026-08-23 on #773: four consecutive `GATE: RESULT=PASS` runs, then
+  `tekton/devrc-pytests` red — the sandbox tier had never been run. The dev-host tier is also
+  structurally blind to anything keyed on the repo being a git checkout: GUARD 10's
+  `NOGIT_REPO_LOCAL` is EMPTY in the sandbox, so its whole repo-local class evaluates
+  differently there. **Run BOTH before you claim a merge is safe, and name the tier and the
+  base sha in the claim** — "the gate passed" is true of one run, one tier, one base, and
+  reads as a property of the change.
   🔴 **The `<!-- merge-gate: … -->` marker above is LOAD-BEARING, not decoration.**
   `scripts/tests/test_ci_claim_matches_reality.py` parses it and fails when it disagrees with
   the repo. **Reword this prose freely — but keep a sentence on the marker's line and do not


### PR DESCRIPTION
## The line, and the word that broke it

`CLAUDE.md` read:

> `nix build .#checks.x86_64-linux.pytests` / `.#checks.x86_64-linux.nodetests` **(or `scripts/gate.sh`)** are authoritative

That "or" says the two are interchangeable. They are not — they are the **two tiers** this same file elsewhere insists must both be green, and the parenthesis quietly licensed running only one.

- **`scripts/gate.sh`** runs `scripts/run-tests.sh` + `scripts/run-node-tests.sh` **on the dev host** (its `PYTEST_RUNNER` / `NODE_RUNNER`). It never invokes `nix build`.
- **`nix build .#checks…`** builds from a `cp -r ${./.}` **store copy with no `.git`** — and that is the tier **Tekton runs**, i.e. the one the merge is gated on.

## Measured cost

On #773: **four consecutive `GATE: RESULT=PASS` runs** were reported as though they covered the merge, then `tekton/devrc-pytests` came back red. The sandbox tier had never been run once.

## Why it is not merely "two environments"

The dev-host tier is **structurally blind** to anything keyed on the repo being a git checkout. GUARD 10's `NOGIT_REPO_LOCAL` is **empty** in the sandbox (no `.git`), so its entire repo-local class evaluates differently there — measured in the same PR: `real-config-changed=0/2`, `repo-local-reported-total=0`, versus a live repo-local delta on the dev host. A change to that guard is exactly the change whose sandbox behaviour you cannot infer from the dev host.

## The other half: name the tier and the base

Added, because a green is read as a property of the *change* when it is a property of *one run, one tier, one base*. `main` moved **seven times** during #773, and the first merged-tree gate was stale before it finished.

## Blast radius

Prose only, inside the existing merge-gate block. The `<!-- merge-gate: other -->` marker is untouched and still the only one; its line still says something to a human. `test_ci_claim_matches_reality.py` and `test_rules_size.py` both pass.

Verified in **both** tiers before asking for the merge — which is the point of the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpMxc3NpzvbcP4ZUWh8pe4
