### PR TITLE
feat(preflight): report the blind spot it structurally cannot scan — skill reference/ reads

### DIFF
--- a/scripts/opencode/lib/oc_permissions.py
+++ b/scripts/opencode/lib/oc_permissions.py
@@ -169,3 +169,27 @@ def base_bash_rules(config: dict | None = None) -> tuple:
 def effective_bash_action(command: str, config: dict | None = None) -> str:
     """The action opencode's PRIMARY agent resolves for one command node."""
     return resolve(base_bash_rules(config), command)
+
+
+def external_directory_rules(config: dict | None = None) -> tuple:
+    """The ORDERED (pattern, action) list for `permission.external_directory`.
+
+    🔴 TWO SHAPES, one code path. This key was a bare SCALAR (`"ask"`) until the
+    skills-tree carve-out made it a map, and both shapes are live in the wild —
+    an older checkout, another host, or a revert all produce the scalar. A caller
+    that assumes a dict raises `AttributeError` on it, which is a crash where a
+    verdict was wanted. A scalar is therefore modelled as a single `*` rule.
+
+    Same resolver as bash (LAST match wins, `ask` when nothing matches), because
+    two copies of a resolution loop disagree eventually and silently.
+    """
+    cfg = config if config is not None else load_config()
+    ed = cfg["permission"].get("external_directory", "ask")
+    if isinstance(ed, str):
+        return ((("*"), ed),)
+    return tuple(ed.items())
+
+
+def effective_external_directory_action(path: str, config: dict | None = None) -> str:
+    """The action opencode resolves for a read OUTSIDE the project directory."""
+    return resolve(external_directory_rules(config), path)

--- a/scripts/opencode/opencode-dispatch
+++ b/scripts/opencode/opencode-dispatch
@@ -69,6 +69,7 @@ for _p in (_HERE / "lib", _HERE.parent / "collector"):
         sys.path.insert(0, str(_p))
 
 import brief_scan  # noqa: E402
+import oc_permissions  # noqa: E402
 
 TOOL = "opencode-dispatch"
 
@@ -321,6 +322,53 @@ VERDICT_NOT_EXAMINED = ("  external paths    : NOT EXAMINED — no resolvable pa
                         "in the brief, and no attachments")
 VERDICT_CLEAN = "  external paths    : none — all {n} examined resolve under --dir"
 
+# 🔴 THE BLIND SPOT THIS SCAN STRUCTURALLY CANNOT SEE, STATED RATHER THAN LEFT
+# UNKNOWN.
+#
+# Every verdict above is about paths named in the BRIEF. But a skill the agent
+# loads carries pointers to its OWN `reference/` and `flows/` files, and those
+# live under ~/.config/opencode/skills — outside `--dir` for every dispatch, by
+# construction. MEASURED 2026-08-23: a dispatch loaded a skill, followed the
+# skill's own pointer, hit the `external_directory` auto-reject and the run DIED
+# mid-task — while preflight had correctly reported "external paths: NOT
+# EXAMINED", because the brief named nothing.
+#
+# So a clean preflight was never evidence that a run is safe from an
+# external-directory stall. This line closes that gap the only way a static scan
+# can: it does not try to guess which skills will load — it reports whether the
+# CONFIG would permit such a read at all, which is a fact it can actually check.
+SKILLS_DIR = Path.home() / ".config" / "opencode" / "skills"
+VERDICT_SKILL_REFS_OK = ("  skill reference/  : readable — external_directory "
+                         "allows {dir} (rule: {pattern})")
+VERDICT_SKILL_REFS_BLOCKED = (
+    "  skill reference/  : 🔴 NOT readable — external_directory resolves to "
+    "`{action}` for {dir}")
+
+
+def skill_reference_verdict(config: dict | None = None) -> str:
+    """One line: would the CONFIG permit a skill to read its own reference/ file?
+
+    🔴 It reports a CONFIG state, not a scan result, and that is the point — the
+    offending path comes from the skill, never from the brief, so no amount of
+    brief-scanning can reach it.
+
+    🔴 A failure to read the config returns an explicit COULD-NOT-DETERMINE line,
+    never the OK one. An unreadable config and a permissive config are different
+    facts, and defaulting to reassurance here would rebuild the exact "guard
+    whose description is wider than its implementation" this file already
+    corrected once.
+    """
+    probe = str(SKILLS_DIR / "any-skill" / "reference" / "any.md")
+    try:
+        rules = oc_permissions.external_directory_rules(config)
+        action, pattern = oc_permissions.resolve_with_rule(rules, probe)
+    except Exception as e:                      # unreadable / malformed config
+        return ("  skill reference/  : COULD NOT DETERMINE — "
+                f"{type(e).__name__}: {e}")
+    if action == "allow":
+        return VERDICT_SKILL_REFS_OK.format(dir=SKILLS_DIR, pattern=pattern)
+    return VERDICT_SKILL_REFS_BLOCKED.format(action=action, dir=SKILLS_DIR)
+
 
 def print_report(rep: dict) -> None:
     # 🔴 Always print what was EXAMINED beside what was found. A bare "0
@@ -350,6 +398,8 @@ def print_report(rep: dict) -> None:
         print(VERDICT_NOT_EXAMINED)
     else:
         print(VERDICT_CLEAN.format(n=examined))
+
+    print(skill_reference_verdict())
 
     # 🔴 UNMEASURED is its own category and is never folded into either verdict
     # above — the same discipline drift-check applies to `absent`/`fetch failed`.

--- a/scripts/opencode/tests/test_dispatch.py
+++ b/scripts/opencode/tests/test_dispatch.py
@@ -404,6 +404,68 @@ def test_the_verdict_constants_match_the_sentences_pinned_here():
     assert D.VERDICT_CLEAN.format(n=2) == LINE_CLEAN_2
 
 
+# --------------------------------------------------------------------------- #
+# The skill-reference blind spot.
+#
+# 🔴 Every verdict above is about paths named in the BRIEF. A skill the agent
+# loads points at its OWN reference/ files, which live outside --dir for every
+# dispatch — so preflight can report "NOT EXAMINED" truthfully while a run is
+# about to die on an external_directory auto-reject. MEASURED 2026-08-23: that
+# is exactly what happened, and preflight was clean at the time.
+#
+# Same literal-sentence discipline as above: written out, not imported.
+# --------------------------------------------------------------------------- #
+_SKILLS = str(D.SKILLS_DIR)
+LINE_REFS_OK = ("  skill reference/  : readable — external_directory allows "
+                f"{_SKILLS} (rule: {_SKILLS}/**)")
+LINE_REFS_BLOCKED = ("  skill reference/  : 🔴 NOT readable — external_directory "
+                     f"resolves to `ask` for {_SKILLS}")
+
+_CFG_MAP_ALLOWED = {"permission": {"external_directory": {"*": "ask",
+                                                          f"{_SKILLS}/**": "allow"}}}
+
+
+def test_the_skill_reference_sentences_match_the_literals_pinned_here():
+    """Two-way pin, for the same reason as the block above."""
+    assert D.skill_reference_verdict(_CFG_MAP_ALLOWED) == LINE_REFS_OK
+    assert D.skill_reference_verdict(
+        {"permission": {"external_directory": "ask"}}) == LINE_REFS_BLOCKED
+
+
+def test_a_SCALAR_ask_reports_BLOCKED_and_does_not_crash():
+    """🔴 THE REGRESSION. `external_directory` was a bare scalar `"ask"` until the
+    skills carve-out made it a map, and that scalar is the shape that killed a
+    real dispatch. Two things are asserted, not one:
+
+    * it reports BLOCKED — so this line would have caught the incident BEFORE it
+      happened, rather than after;
+    * it does not raise. A caller assuming a dict hits `AttributeError` on a
+      scalar, which is a crash where a verdict was wanted — and the scalar is
+      still what a revert, an older checkout or another host produces.
+    """
+    out = D.skill_reference_verdict({"permission": {"external_directory": "ask"}})
+    assert "NOT readable" in out and "ask" in out
+
+
+def test_an_absent_key_is_BLOCKED_because_opencodes_fallback_is_ask():
+    """No key at all resolves to opencode's own fallback, which is `ask` — not
+    to a permissive default. Pinned so a future refactor cannot quietly invert
+    the safe direction."""
+    assert "NOT readable" in D.skill_reference_verdict({"permission": {}})
+
+
+def test_an_unreadable_config_says_COULD_NOT_DETERMINE_never_readable():
+    """🔴 An unreadable config and a permissive one are DIFFERENT FACTS.
+
+    Defaulting to the reassuring sentence here would rebuild precisely the
+    "description wider than the implementation" bug that produced
+    `VERDICT_NOT_EXAMINED` in the first place.
+    """
+    out = D.skill_reference_verdict({})          # no "permission" key at all
+    assert "COULD NOT DETERMINE" in out
+    assert "readable — external_directory allows" not in out
+
+
 def test_an_empty_scan_says_NOT_EXAMINED_not_an_all_clear(tmp_path):
     """🔴 THE finding. The report used to print
     'external paths : none — every path is under --dir' UNCONDITIONALLY, right


### PR DESCRIPTION
The half of #761 that was never done. #761 fixed the **permission** so a skill can read its own `reference/` files; preflight still could not **tell you** when such a read would stall.

## The gap

Measured 2026-08-23: a dispatch loaded a skill, followed the skill's **own pointer** to `reference/task-api.md`, hit the `external_directory` auto-reject, and the run **died mid-task** — while preflight had truthfully reported:

```
external paths    : NOT EXAMINED — no resolvable path in the brief, and no attachments
```

Every verdict preflight emits is about paths named in the **brief**. The offending path came from the **skill**. No amount of brief-scanning reaches it, so a clean preflight was never evidence a run is safe from an external-directory stall.

## What it does

It does *not* try to guess which skills will load — it reports whether the **config** would permit such a read at all, which is a fact a static scan can actually check:

```
skill reference/  : readable — external_directory allows <dir> (rule: <glob>)
skill reference/  : 🔴 NOT readable — external_directory resolves to `ask` for <dir>
skill reference/  : COULD NOT DETERMINE — <error>
```

🔴 **`COULD NOT DETERMINE` is a third outcome on purpose.** An unreadable config and a permissive config are different facts; returning the reassuring sentence on error would rebuild the exact *"description wider than the implementation"* bug that produced `VERDICT_NOT_EXAMINED` in the first place.

`external_directory_rules()` handles **both shapes** — the key was a bare scalar (`"ask"`) until the skills carve-out made it a map, and the scalar is still what a revert, an older checkout, or another host produces. A caller assuming a dict raises `AttributeError` on it: a crash where a verdict was wanted. Resolution reuses `resolve_with_rule` rather than adding a second resolution loop.

## Would it have caught the incident?

**Yes.** With the pre-#761 scalar `"ask"`, the line reads `🔴 NOT readable` — *before* dispatch, rather than after the run dies. Pinned as a regression test.

## Mutation battery — all applied-verified

| mutant | result |
|---|---|
| reword the OK sentence | 🔴 KILLED |
| unreadable config → claim OK (**false all-clear**) | 🔴 KILLED |
| drop the scalar branch (crash on the old shape) | 🔴 KILLED |
| invert the `action == "allow"` check | 🔴 KILLED |
| unmutated | 🟢 SURVIVED |

🔴 **The first run of that battery reported the inversion as SURVIVED** — because the battery itself passed `-k`, and the filter excluded the very tests that kill it. A filter that excludes the killing test manufactures a false SURVIVED. Re-run unfiltered it fails 3 tests; the battery now runs without `-k` and says why in a comment.

Verdict sentences are pinned as whole literals **written out** in the test file rather than imported — the same discipline the existing verdict block documents, and for the same reason.

`scripts/opencode/tests/test_dispatch.py` + `scripts/tests/test_opencode_config.py`: **721 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)