### PR TITLE
fix(browser-bridge tests): a COUNT stood in for "the event I want landed" — and the timeout returned short in silence

### DIFF
--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -112,16 +112,76 @@ def _read_events(spool_dir) -> list:
             if ln.strip()]
 
 
-def _wait_events(spool_dir, n=1, timeout=3.0) -> list:
-    """Poll the spool for >=n events (the emit runs off the critical path, after
-    the HTTP response, so it lands slightly after /cmd returns)."""
+def _wait_events(spool_dir, n=1, timeout=10.0, until=None) -> list:
+    """Poll the spool until `until(evs)` holds, or >=n events have landed.
+
+    The emit runs off the critical path, after the HTTP response, so it lands
+    slightly after /cmd returns — hence the poll rather than a bare read.
+
+    🔴 A COUNT IS A PROXY, AND `until=` EXISTS BECAUSE THE PROXY IS WRONG UNDER
+    LOAD. MEASURED in CI 2026-08-24 on `devrc-ci-dhsn6`: a throttling test asked
+    for `n=2` and filtered for the `throttled` event. The server HAD throttled —
+    `{"event":"throttled","op":"tabs","reason":"rate_limited"}` is in that run's
+    captured stderr — but only the `cmd` event had reached the spool inside the
+    deadline, so the filter found nothing and the assertion failed as
+    `assert 0 == 1`, reading like a defect in rate limiting. 16 of the 52 call
+    sites in this module use a count this way. Pass `until=` whenever you are
+    waiting for a SPECIFIC event; the count is only right when any N will do.
+
+    🔴 AND A TIMEOUT IS NOW LOUD. This used to return a SHORT list silently, so
+    every caller's next line — `[0]`, or a filter — failed with a message about
+    the assertion rather than about the wait. Nothing in this module treats a
+    short read as valid (checked before changing it), so a miss is always a bug
+    or a race, and it now says which.
+
+    The deadline is 10s, up from 3s: CI is far slower than a workstation (that
+    suite ran 244s there against ~35s locally), and 3s was tuned on the fast
+    machine. It is a ceiling, not a sleep — a passing wait still returns as soon
+    as the condition holds.
+    """
     deadline = time.time() + timeout
+    evs = []
     while time.time() < deadline:
         evs = _read_events(spool_dir)
-        if len(evs) >= n:
+        if until(evs) if until else len(evs) >= n:
             return evs
         time.sleep(0.02)
-    return _read_events(spool_dir)
+    evs = _read_events(spool_dir)
+    if until is not None:
+        assert until(evs), (
+            f"spool never satisfied the wait condition in {timeout}s; "
+            f"got {len(evs)} event(s): {evs}"
+        )
+    else:
+        assert len(evs) >= n, (
+            f"spool never reached {n} event(s) in {timeout}s; "
+            f"got {len(evs)}: {evs}"
+        )
+    return evs
+
+
+def test_wait_events_reports_a_timeout_instead_of_returning_short(tmp_path):
+    """🔴 NEGATIVE CONTROL on the harness. `_wait_events` used to return a SHORT
+    list silently on timeout, so the caller's next line failed with a message
+    about its own assertion rather than about the wait — which is how a CI race
+    read as `assert 0 == 1` in a rate-limiting test.
+
+    Uses a tiny timeout so the control costs no wall clock."""
+    with pytest.raises(AssertionError, match=r"never reached 2 event\(s\)"):
+        _wait_events(tmp_path, n=2, timeout=0.05)
+
+    with pytest.raises(AssertionError, match=r"never satisfied the wait condition"):
+        _wait_events(tmp_path, timeout=0.05, until=lambda evs: False)
+
+
+def test_wait_events_returns_as_soon_as_the_condition_holds(tmp_path):
+    """POSITIVE CONTROL: the raised deadline is a CEILING, not a sleep. Without
+    this, `timeout=10.0` could be silently turning every wait into a 10s pause
+    and the suite would still be green — just 50x slower."""
+    started = time.time()
+    got = _wait_events(tmp_path, timeout=30.0, until=lambda evs: True)
+    assert got == []
+    assert time.time() - started < 1.0, "the wait slept instead of returning early"
 
 
 # NOTE: `_isolate_activity_spool` — the autouse fixture that points
@@ -2558,7 +2618,13 @@ def test_the_throttle_path_carries_both_the_hash_and_the_join_key(telemetry):
         assert _wait_connected(srv, want=True)
         assert _cmd_sess(srv, {"op": "tabs"}, sid=JOINABLE_ID)[0] == 200
         assert _cmd_sess(srv, {"op": "tabs"}, sid=JOINABLE_ID)[0] == 429
-        evs = _wait_events(spool_dir, 2)
+        # 🔴 `until=` not `n=2`: the count was a proxy for "the throttled event
+        # landed", and CI proved the proxy wrong (see `_wait_events`).
+        def _has_throttle(evs):
+            return any(json.loads(e["payload"]).get("outcome") == "throttled"
+                       for e in evs)
+
+        evs = _wait_events(spool_dir, until=_has_throttle)
         thr = [e for e in evs
                if json.loads(e["payload"]).get("outcome") == "throttled"]
         assert len(thr) == 1, evs


### PR DESCRIPTION
fix(browser-bridge tests): a COUNT was standing in for "the event I want landed" — and the timeout returned short in silence

Third CI flake blocking a REQUIRED check today, and the run's own log contained
the proof it was not a code defect.

MEASURED on `devrc-ci-dhsn6` (PR #790, a branch touching nothing in
browser-bridge):

    scripts/browser-bridge/tests/test_server.py:2564
    assert len(thr) == 1
    E  assert 0 == 1  +  where 0 = len([])

That reads as "rate limiting stopped emitting a throttle event". It did not.
The same run's captured stderr:

    {"ts":…,"event":"throttled","op":"tabs","key":"fake-1","reason":"rate_limited"}

The server throttled. The test asked `_wait_events(spool_dir, 2)` — wait for TWO
events — then filtered for the throttled one. Only the `cmd` event had reached
the spool inside the 3 s deadline, so the filter found nothing.

🔴 THE COUNT IS A PROXY FOR "THE EVENT I WANT HAS LANDED", AND THE PROXY IS WRONG
UNDER LOAD. 16 of the 52 `_wait_events` call sites in this module use a count
that way. The emit runs off the critical path — the helper's own docstring says
so — so which of N events arrives first is a race the count cannot express.

🔴 AND THE TIMEOUT WAS SILENT, WHICH IS WHY THIS LOOKED LIKE A CODE DEFECT. On
expiry `_wait_events` returned a SHORT list and said nothing, so the failure
surfaced one line later as the caller's own assertion — a message about rate
limiting, not about a wait that never completed. A harness that fails as its
CALLER is how a race gets debugged as a bug.

WHAT LANDED

- `until=` predicate: wait for the SPECIFIC event, not for "N of anything". Used
  at the failing site; available to the other 15 (not converted here — this file
  holds 407 tests and a blanket rewrite is a bigger blast radius than the flake).
- The timeout now ASSERTS, naming what it got and what it wanted. This reaches
  all 52 sites without touching one of them.
- Deadline 3 s -> 10 s, from measurement rather than taste: that suite runs 244 s
  in CI against ~35 s locally, so 3 s was tuned on the fast machine. It is a
  CEILING, not a sleep.

🔴 THE SHARED-BEHAVIOUR CHANGE WAS VERIFIED, NOT REASONED. Before making the
timeout loud I checked no call site treats a short read as valid, then ran the
whole module: 407 passed. Nothing depended on the silence.

HARNESS CONTROLS, because `claude/RULES.md` says validate the instrument:

    M0  pristine                          2 passed
    M1  timeout returns short silently    FAILED test_wait_events_reports_a_timeout_…
        (i.e. the original bug restored)
    M2  `until=` ignored, count proxy     FAILED test_wait_events_returns_as_soon_as_…
        used instead                      — and took 30.88 s vs 0.19 s
    restored                              2 passed

M2's timing is the finding worth keeping: without that control, raising the
deadline to 10 s could silently turn every wait into a 10 s sleep and the suite
would still be GREEN, just 50x slower. The control proves the deadline is a
ceiling.

⚠ This cannot be shown red-then-green: the failure is a RACE. What is
demonstrated is the mechanism, the battery above, and the CI run that caught it.

⚠ FOLLOW-UP NOT DONE HERE: 15 remaining count-as-proxy sites. They are latent
instances of exactly this shape and should move to `until=`; doing it in this PR
would mean rewriting a 407-test file to fix a one-line flake.

Verified: `gate.sh --tier both --set hermetic` under `nix develop` on this tree —
GATE: RESULT=PASS exit=0; pytest collected=15656 passed=15654 skipped=2 failed=0,
27 targets above floor, no target reporting FAIL; node suites=4 tests=1179
pass=1179 fail=0.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
