### PR TITLE
feat(skills): tier the always-on skill listing — ledger, dry-run sync, rc 22 (mechanism only, switch NOT flipped)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,15 @@ there. Only what's specific to this repo, where a working tree is also a **deplo
   its absence a token fails the suite. It exists because the prose version was false for
   three days — `summary.age_sources` was read with no presence check, and a report
   missing it printed a `READY` byte-identical to a real one.
+  🔴 **rc 22 — a host's deployed `skillOverrides` disagree with `claude/skill-tiers.json`.**
+  A host with NO overrides prints **NOT ADOPTED and sets no rc**: the tier mechanism
+  shipped applied to zero hosts on purpose (nothing is being truncated today), and
+  counting an unapplied host as drift would have made this arm red on every run from
+  the day it landed. rc 22 is **adopted-then-drifted** only. It ranks just under rc 10
+  because a BEHIND host carries a stale ledger — ship it first, then re-run
+  `scripts/sync-skill-tiers.py`. The expectation is read through the ledger's own
+  parser, never a second sed; a ledger it cannot read prints COULD NOT MEASURE and
+  sets no rc, because an empty expectation would make every host look compliant.
 - **Recovering a diverged host** — preserve, verify, *then* move the pointer:
   `git branch <topic> HEAD && git push -u origin <topic>` on that host → confirm the shas are
   on origin **from a different host** → `git reset --keep origin/main` (`--keep` refuses
@@ -121,6 +130,7 @@ there. Only what's specific to this repo, where a working tree is also a **deplo
   does — something must NAME it, so give each one a router (a SKILL.md table row, and where it
   matters a hook that names the path in its message; see `clawgate/flows/task-authoring.md`).
 - 🔴 **The skill LISTING is a third always-on cost, and it fails SILENTLY.** Every skill's name + `description` (+ `when_to_use`) loads on **every session** under a budget of **1% of the context window** (per-entry cap 1,536 chars); on overflow Claude Code DROPS descriptions starting with the skills you invoke least — stripping the very trigger keywords that make a skill auto-fire, with no error. So a description is **routing surface, not documentation**: key use case first, then the literal phrases Zach says, then disambiguation from a sibling skill. Narrative goes in the body (0 until invoked). 🔴 **Measured 2026-08-23: the listing does NOT fit a 200k context and cannot be made to — it fits 1M.** The TOTAL is now ratcheted by `scripts/tests/test_skill_descriptions.py`, which owns the constants, the measurement, the break-even argument and the eviction playbook — **read them there, never restate them.** Any addition needs an eviction in the SAME commit; closing the remaining gap means retiring or merging skills, or disabling the cloudflare plugin (a quarter of the total, and not devrc's to edit). ⚠ `claude doctor` (the CLI) reports no listing cost; the interactive `/doctor` reportedly does — unverified.
+  🔴 **The cost is now per-skill opt-in, and ADDING A SKILL MEANS TIERING IT.** `claude/skill-tiers.json` assigns every skill tier A (full description) or tier B (`name-only`, ~12 chars, still `/name`-invocable, no routing prose). `scripts/tests/test_skill_tiers.py` pins it **two-way** — a skill with no entry, or an entry naming no skill, fails the suite — and owns the tier-A ratchet, the real charging formula and the playbook: **read them there, never restate them.** Tier by whether the skill must **AUTO-FIRE from a symptom Zach describes**, never by an invocation counter (`dl-router` runs as a live systemd service and `adoption-scan` has 20,494 tool events; Claude Code's counter says 0 for both). 🔴 **The ledger is applied to NO host by default** — `~/.claude/settings.json` is per-host and unmanaged, so `scripts/sync-skill-tiers.py` (dry-run unless `--apply`) is an operator act, and `drift-check.sh` reports an unapplied host as **NOT ADOPTED, not drift**. Full argument: `claudedocs/proposal-skill-listing-tiers.md`.
 - `.zshrc`, `.tmux.conf` etc. are read by the nix modules — read with offset/limit, they're large.
 
 ### Subsystems — operate each via its SKILL, not from here

--- a/claude/skill-tiers.json
+++ b/claude/skill-tiers.json
@@ -1,0 +1,120 @@
+{
+  "_doc": [
+    "THE SKILL-LISTING TIER LEDGER. devrc-owned; the single source of truth for",
+    "which skills spend always-on listing budget on a full description (tier A)",
+    "and which ship as `name-only` (tier B, ~12 chars, still /name-invocable and",
+    "still callable by the Skill tool -- what it loses is the ROUTING PROSE that",
+    "makes it fire from a described symptom).",
+    "",
+    "APPLIED BY `scripts/sync-skill-tiers.py`, which writes `skillOverrides` into",
+    "a host's ~/.claude/settings.json. It DEFAULTS TO DRY-RUN. This file being in",
+    "git says nothing about any host having it applied -- ~/.claude/settings.json",
+    "is per-host and unmanaged by design. `scripts/drift-check.sh` reports a host",
+    "whose deployed overrides disagree with this ledger (rc 22), and reports NOT",
+    "ADOPTED -- with no rc -- for a host that has never had it applied.",
+    "",
+    "THIS FILE IS NOT DEPLOYED ANYWHERE. `nix/home.nix` maps named paths under",
+    "claude/, not the directory, so nothing symlinks this into ~/.claude/.",
+    "",
+    "HOW TO TIER A SKILL -- the question is NOT how often it is used.",
+    "Ask: must this fire when Zach describes a SYMPTOM rather than naming the",
+    "tool? If yes it is A. If he reaches for it by name (or types /name), it is B.",
+    "Two skills here are LIVE with zero recorded skill invocations -- `dl-router`",
+    "runs as a systemd service and `adoption-scan` has 20,494 tool-invocation",
+    "events -- so the usage counter cannot decide this and is not consulted.",
+    "",
+    "THE TIE-BREAK, applied to the two entries below that were genuinely close:",
+    "tier B when a mis-route DEGRADES the answer; tier A when a mis-route takes a",
+    "WRONG ACTION. That is why `vetr-mailbox` is A despite 0 uses and being the",
+    "second-cheapest entry in the whole listing: name-only, an 'email them on my",
+    "behalf' prompt routes to `mailbox`, which claims the same phrase and sends",
+    "from a different account.",
+    "",
+    "THIS SET IS DELIBERATELY CONSERVATIVE. Measured 2026-08-24: the whole listing",
+    "is 20,708 chars against a 30,000 budget on claude-opus-5 @1M -- 0.69x, so",
+    "NOTHING is being truncated today. A wide tier B would cost real routing now",
+    "for a benefit ~1.8 months out. Flipping one skill is a one-line edit here;",
+    "the ratchet in scripts/tests/test_skill_tiers.py re-measures on every run.",
+    "",
+    "Every tier-B entry carries a one-line `why` so the call is auditable. Tier-A",
+    "entries carry none: A is the default, and a rationale for a default is noise."
+  ],
+  "skills": {
+    "activity": { "tier": "A" },
+    "adoption-scan": {
+      "tier": "B",
+      "why": "asked for by name ('is anyone using X', 'which tools are dead'); its 20,494 tool-invocation events are invisible to the skill counter, and no symptom routes here"
+    },
+    "analyze-service": { "tier": "A" },
+    "audit-pr": { "tier": "A" },
+    "auditloop": {
+      "tier": "B",
+      "why": "the trigger IS the product name (auditloop / auditloop.zacx.dev) -- there is no symptom phrasing for it"
+    },
+    "bar": { "tier": "A" },
+    "browser": { "tier": "A" },
+    "check-clickup-addressed": { "tier": "A" },
+    "clawgate": { "tier": "A" },
+    "clickup": { "tier": "A" },
+    "close-the-loop": {
+      "tier": "B",
+      "why": "a deliberate ritual Zach opens by name; nothing he says by accident should start it"
+    },
+    "devrc-dx": { "tier": "A" },
+    "dl-router": { "tier": "A" },
+    "espanso-audit": {
+      "tier": "B",
+      "why": "invoked as /espanso-audit; the skill name IS the phrase he types"
+    },
+    "find-session": { "tier": "A" },
+    "handoff": { "tier": "A" },
+    "i3": { "tier": "A" },
+    "initiative-scan": {
+      "tier": "B",
+      "why": "CLOSEST CALL in this ledger -- 'what's stalled' IS a symptom, but the mis-route lands on `initiatives` (the durable board), a degraded answer rather than a wrong action; flip to A the first time that costs anything"
+    },
+    "initiatives": { "tier": "A" },
+    "mailbox": { "tier": "A" },
+    "obs-read": { "tier": "A" },
+    "opencode": { "tier": "A" },
+    "prune-index": {
+      "tier": "B",
+      "why": "'prune the analyze-service index' -- named, not described; and the three prune-* siblings spend most of their prose disambiguating each other, which name-only makes moot"
+    },
+    "prune-memory": {
+      "tier": "B",
+      "why": "'prune memory' / MEMORY.md is named explicitly whenever this is wanted"
+    },
+    "prune-skill": {
+      "tier": "B",
+      "why": "'prune/shrink this skill' -- named, not described"
+    },
+    "repo-cos": {
+      "tier": "B",
+      "why": "a weekly ritual opened by name or as /repo-cos; the email that prompts it names it"
+    },
+    "resume": { "tier": "A" },
+    "session-manager": { "tier": "A" },
+    "sglang": {
+      "tier": "B",
+      "why": "named by the thing it operates (sglang / sglang-server); GPU-contention symptoms route to obs-read first anyway"
+    },
+    "signal": { "tier": "A" },
+    "standup": { "tier": "A" },
+    "subsystem-index": {
+      "tier": "B",
+      "why": "invoked BY `/handoff`, which names it in its own body; its own description says 'rarely run directly', so no symptom needs to route to it"
+    },
+    "tekton": { "tier": "A" },
+    "ux-audit-loops": {
+      "tier": "B",
+      "why": "named alongside its sibling `auditloop`; tiering BOTH keeps neither winning the other's prompts by default"
+    },
+    "verify-agent": {
+      "tier": "B",
+      "why": "CLOSE CALL -- run as a gate immediately after an agent reports done, and named when it is; flip to A if a 'done' claim ever gets believed because this did not fire"
+    },
+    "vetr-mailbox": { "tier": "A" },
+    "window-triage": { "tier": "A" }
+  }
+}

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -2632,7 +2632,7 @@ in
         # local_ipv4s identifies WHICH host this is (both report hostname `nixos`).
         # Without it detection returns "unknown" and the script exits 6.
         #
-        # 🔴 python3 AND tmux ARE FOR THE CHILD, NOT FOR drift-check.sh ITSELF.
+        # 🔴 tmux IS FOR THE CHILD; python3 IS NOW FOR BOTH.
         # The fuzzyclaw phase-2 gate execs `scripts/session-manager`, whose
         # shebang resolves `python3` from PATH and which shells out to `tmux
         # list-panes`. Under systemd there is none of the login shell's PATH, so
@@ -2640,6 +2640,12 @@ in
         # forever — from a unit that looks correct, which is the exact shape the
         # iproute2 note above records. Pinned by
         # `test_the_phase2_child_binaries_are_on_the_unit_path`.
+        # ⚠ This block used to say python3 was for the child ONLY. That stopped
+        # being true when the skill-tier arm (rc 22) landed: drift-check.sh now
+        # runs `python3 lib/skill_tier_facts.py` itself, in the driver, to read
+        # `claude/skill-tiers.json` through the ledger's own parser instead of a
+        # second sed. Without python3 that arm reports COULD NOT MEASURE — no rc,
+        # but also no coverage.
         "PATH=${lib.makeBinPath [ pkgs.git pkgs.openssh pkgs.iproute2 pkgs.bash pkgs.coreutils pkgs.gawk pkgs.gnused pkgs.gnugrep pkgs.python3 pkgs.tmux ]}"
         "HOME=%h"
       ];
@@ -2650,6 +2656,12 @@ in
         "${../scripts/drift-check.sh}"
         "${../scripts/lib/host-role.sh}"
         "${../scripts/lib/drift_phase2.py}"
+        # The rc-22 skill-tier arm: the reader, the parser it delegates to, and
+        # the ledger itself. The ledger is listed because a re-tiering changes
+        # what the unit would REPORT without any script changing at all.
+        "${../scripts/lib/skill_tier_facts.py}"
+        "${../scripts/lib/skill_tiers.py}"
+        "${../claude/skill-tiers.json}"
       ];
     };
   };

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -90,7 +90,8 @@
 # further down ("a new DRIFT code has nowhere to go but upward") points the next
 # one. So:
 #   * 19, 20 and 21 are RESERVED to ship.sh here and must not be taken as DRIFT
-#     codes — the next free code for this script is 22.
+#     codes. 22 is now TAKEN by this script (skillOverrides disagree with the
+#     tier ledger), so the next free code for this script is 23.
 #   * anything this script adds above 21 is reserved back the other way; ship.sh
 #     documents this in its own header for the same reason.
 #
@@ -144,6 +145,14 @@
 #       fire for it. 🔴 The gap rc 17 left: "we could not look" correctly set no
 #       code, and therefore escalated NEVER. See "UNMEASURED IS NOT FOREVER"
 #       below. Same ladder as rc 13, and it ranks just under it — see severity().
+#   22  DRIFT — a host's DEPLOYED `skillOverrides` disagree with devrc's skill-
+#       listing tier ledger (`claude/skill-tiers.json`), so the always-on skill
+#       listing on that host is not the one this repo describes. 🔴 A host with
+#       NO overrides at all is NOT ADOPTED and sets NO code — that is the state
+#       the mechanism shipped in, and calling it drift would have made this arm
+#       permanently red. rc 22 is adopted-then-drifted only. See "SKILL-LISTING
+#       TIERS" below. It ranks just under rc 10, because a BEHIND host carries a
+#       stale ledger and can produce this finding as a symptom.
 #   16  ACTIONABLE, not drift — the fuzzyclaw PHASE-2 GATE has OPENED: zero rows
 #       still take their `age_secs` from fuzzyclaw alone, so the readers can be
 #       removed. See "THE FUZZYCLAW PHASE-2 GATE" below. It is the LEAST severe
@@ -381,14 +390,16 @@
 # is reading a timer's output, so the single number it hands to systemd must be
 # the worst thing found, or an un-pushed workbench could hide behind a merely
 # behind laptop. Severity order (worst first):
-#     8 > 17 > 14 > 13 > 18 > 6 > 2 > 4 > 3 > 12 > 15 > 10 > 16
+#     8 > 17 > 14 > 13 > 18 > 6 > 2 > 4 > 3 > 12 > 15 > 10 > 22 > 16
 # 🔴 THAT ORDER IS THE severity() TABLE, NOT THE DIGITS — it never was monotonic
-# (14 outranks 13 outranks 18 outranks 6 outranks 4), and 17 is not "less severe
-# than 16" because it is larger. Every code below 16 that is still free (5, 7, 9, 11) is
+# (14 outranks 13 outranks 18 outranks 6 outranks 4), 17 is not "less severe
+# than 16" because it is larger, and 22 ranks second-LAST despite being the
+# largest digit here. Every code below 16 that is still free (5, 7, 9, 11) is
 # reserved to a ship.sh meaning this script does not take, so a new DRIFT code
 # has nowhere to go but upward; its rank is stated in severity() and here.
-# 🔴 UPWARD IS NOT EMPTY EITHER: ship.sh owns 19 (hosts-disagree) and 20
-# (superseded), so the next free DRIFT code is 22, not 19. See the reciprocal
+# 🔴 UPWARD IS NOT EMPTY EITHER: ship.sh owns 19 (hosts-disagree), 20
+# (superseded) and 21 (usage), and this script has now taken 22, so the next free
+# DRIFT code is 23, not 19. See the reciprocal
 # reservation under EXIT CODES above — that collision was one increment away.
 # (6 and 2 are both unreachable through this path today — the script exits each
 # directly, before any per-host leg runs — but the order is documented for every
@@ -448,6 +459,13 @@
 #                    gate is local-only, and every value sent over ssh is one
 #                    that has to be proved safe.
 #   DRIFT_PHASE2_TIMEOUT  seconds the phase-2 scan may take (default 60, integer)
+#   DRIFT_TIER_LEDGER  path to the skill-listing tier ledger (default: the
+#                    claude/skill-tiers.json beside this script's repo). Exists
+#                    so the suite can drive the rc-22 arm against a fixture
+#                    ledger; the default is the only correct value on a real
+#                    host. Deliberately NOT forwarded over ssh — the comparison
+#                    happens in the driver, and every value sent across that hop
+#                    is one that has to be proved safe.
 set -uo pipefail
 
 # --- Host identity: SOURCED, never copied (see header) ------------------------
@@ -622,6 +640,17 @@ severity() {
     # header for why un-pushed commits still outrank a broken deployment.
     15) echo 35 ;;
     10) echo 30 ;;
+    # 22 (a host's deployed skillOverrides disagree with the devrc tier ledger)
+    # ranks BELOW 10 and above 16, and the digit says nothing about that either.
+    #   BELOW 10, because a host that is BEHIND has not received the ledger yet:
+    #   a stale checkout can PRODUCE this finding as a symptom, so the code that
+    #   names the cause must outrank the one that names the effect. Shipping the
+    #   host is also the first thing to try.
+    #   ABOVE 16, because 16 is not a fault at all. This one is a real
+    #   divergence: the always-on skill listing on that host is not the listing
+    #   the repo describes, which degrades routing silently and in exactly the
+    #   way the tier mechanism exists to control.
+    22) echo 25 ;;
     # 16 is the FLOOR of the owned codes, deliberately. It is not a fault at all
     # — it says an optional cleanup became possible — so it must never outrank a
     # host that is behind, let alone one with un-pushed commits. Being last also
@@ -970,11 +999,46 @@ if [ "$eplug" != UNEVALUATED ] && [ "$eplug" != NONE ] && [ "$iplug" != UNEVALUA
   fi
 fi
 
+# --- skillOverrides: the SKILL-LISTING TIER LEDGER, AS DEPLOYED ---------------
+# 🔴 Reported as a FACT only. The verdict is NOT a property of this host — it is
+# the difference between this host and a ledger that lives in a repo, so it is
+# computed in the driver (see "SKILL-LISTING TIERS" below) where the ledger can
+# be read by its own parser instead of by a second sed.
+#
+# Three states, and they must never print the same way:
+#   NONE         the key is absent — the ledger has never been APPLIED here.
+#                Not drift: this is the state the mechanism shipped in.
+#   EMPTY        the key exists and holds nothing.
+#   UNEVALUATED  settings.json unreadable, or the extractor matched nothing.
+#
+# 🔴 THE RANGE END IS `^  [}"]`, NOT `^  }`. A minified-away or one-line
+# `"skillOverrides": {},` still matches the range START (the pattern is a
+# substring match), and with `^  }` as the end the range would run on through
+# every following key and harvest their 4-space entries as overrides. Ending at
+# the next TOP-LEVEL line — a closing brace or the next key — bounds it either
+# way, and an empty harvest reports EMPTY rather than a clean-looking NONE.
+#
+# Values are printed, unlike the key-name-only rule above: an override value is
+# one of `on` / `name-only` / `user-invocable-only` / `off`, which is an enum,
+# not a secret. Nothing here reads a permission rule, a hook command or a token.
+sover="UNEVALUATED"
+if [ -r "$set_file" ]; then
+  if [ -n "$(sed -n '"'"'/^  "skillOverrides":/p'"'"' "$set_file")" ]; then
+    solist="$(sed -n '"'"'/^  "skillOverrides": {/,/^  [}"]/p'"'"' "$set_file")"
+    solist="$(printf "%s\n" "$solist" | sed -n '"'"'s/^    "\([^"]*\)": *"\([^"]*\)".*/\1=\2/p'"'"')"
+    sover="$(norm_set "$solist")"
+    [ -n "$sover" ] || sover="EMPTY"
+  else
+    sover="NONE"
+  fi
+fi
+
 # FACT lines are the machine-readable half — the driver diffs them ACROSS hosts,
 # which is the only place a key-set difference can be seen at all.
 echo "[$label] FACT settings-keys $skeys"
 echo "[$label] FACT enabled-plugins $eplug"
 echo "[$label] FACT installed-plugins $iplug"
+echo "[$label] FACT skill-overrides $sover"
 echo "[$label] PARITY-RC=$p_rc"
 '
 
@@ -1727,6 +1791,119 @@ else
 fi
 echo
 
+# ── SKILL-LISTING TIERS (rc 22) ───────────────────────────────────────────────
+# 🔴 WHAT THIS MEASURES. Every skill's name + description loads on EVERY session
+# under a budget of 1% of the context window, IN CHARACTERS. `skillOverrides` in
+# settings.json makes that cost per-skill opt-in, and `claude/skill-tiers.json`
+# is devrc's ledger of which skills spend it. That ledger is in git;
+# ~/.claude/settings.json is per-host and unmanaged, so nothing keeps them
+# together except this arm and `scripts/sync-skill-tiers.py`.
+#
+# 🔴 THIS IS NOT A CROSS-HOST COMPARISON. Both hosts can agree perfectly and both
+# be wrong; the reference is the ledger, not the other machine. So each host is
+# reported against the ledger on its own, and a run that reaches only one host
+# still says something true about that one.
+#
+# 🔴 "NO OVERRIDES AT ALL" IS **NOT** DRIFT, AND THAT IS THE WHOLE DESIGN.
+# The mechanism shipped with the ledger applied to NO host — deliberately:
+# measured 2026-08-24, the listing was 20,708 chars against a 30,000-char budget
+# on claude-opus-5 @1M (0.69x), so nothing is being truncated and a wide tier B
+# would cost real routing today for a benefit ~1.8 months out. If an unapplied
+# host counted as drift, this code would be red on every run from the moment it
+# landed — and `claude/RULES.md` is explicit that a permanently-red gate is worse
+# than no gate, because it trains everyone to click through. So a host with no
+# `skillOverrides` key prints NOT ADOPTED, every run, with NO rc. rc 22 fires
+# only once a host HAS been given overrides and they have since disagreed:
+# adopted-then-drifted, which is the hazard a ledger in git can actually own.
+#
+# 🔴 THE EXPECTATION IS READ BY THE LEDGER'S OWN PARSER, never by a second sed.
+# `lib/skill_tier_facts.py` projects it through `lib/skill_tiers.py` — the same
+# module `sync-skill-tiers.py` writes from — so the checker and the writer cannot
+# disagree about what the ledger says. A reader that cannot produce an
+# expectation prints COULD NOT MEASURE and sets no rc: an empty expectation would
+# make every host look compliant, in silence, which is the reassuring zero this
+# whole subsystem exists to refuse.
+_drift_tier_py="$_drift_dir/lib/skill_tier_facts.py"
+
+tier_report() { # tier_report <role> <that host's fact> <wanted name=value list> <wanted count>
+  local ROLE="$1" FACT="$2" WANT="$3" NW="$4"
+  local X N V MISSING="" WRONG="" EXTRA=""
+  if [ -z "$FACT" ]; then
+    echo "[tiers] $ROLE: NOT REPORTED — that host produced no skill-overrides fact."
+    echo "[tiers]   Not reached (--no-local/--no-remote, or unreachable), or its stream was cut"
+    echo "[tiers]   short before the FACT lines. NOT a match — nothing was compared for this host."
+    return 0
+  fi
+  if [ "$FACT" = UNEVALUATED ]; then
+    echo "[tiers] $ROLE: NOT EVALUATED — settings.json unreadable or unparseable there (see its line above)."
+    echo "[tiers]   This is not 'it matches the ledger'. Nothing was compared for this host."
+    return 0
+  fi
+  if [ "$NW" = 0 ]; then
+    echo "[tiers] $ROLE: nothing to compare — the ledger asks for 0 overrides (every skill is tier A)."
+    return 0
+  fi
+  if [ "$FACT" = NONE ] || [ "$FACT" = EMPTY ]; then
+    echo "[tiers] $ROLE: NOT ADOPTED — no skillOverrides deployed, so none of the ledger's $NW tier-B entries apply."
+    echo "[tiers]   This is the state the mechanism SHIPPED in, not drift — applying it is an"
+    echo "[tiers]   operator act on a per-host file. Apply it there with:"
+    echo "[tiers]     scripts/sync-skill-tiers.py            # dry-run, prints the exact diff"
+    echo "[tiers]     scripts/sync-skill-tiers.py --apply    # writes"
+    return 0
+  fi
+  for X in $WANT; do
+    N="${X%%=*}"
+    V="${X#*=}"
+    case " $FACT " in
+      *" $N=$V "*) ;;
+      *" $N="*) WRONG="$WRONG $X" ;;
+      *) MISSING="$MISSING $X" ;;
+    esac
+  done
+  for X in $FACT; do
+    N="${X%%=*}"
+    case " $WANT " in
+      *" $N="*) ;;
+      *) EXTRA="$EXTRA $X" ;;
+    esac
+  done
+  if [ -n "$MISSING" ] || [ -n "$WRONG" ] || [ -n "$EXTRA" ]; then
+    echo "[tiers] 🔴 DRIFT — $ROLE has skillOverrides that disagree with claude/skill-tiers.json:"
+    [ -n "$MISSING" ] && echo "[tiers]   in the ledger, NOT on the host:$MISSING"
+    [ -n "$WRONG" ] && echo "[tiers]   on the host with a DIFFERENT value than the ledger asks for:$WRONG"
+    [ -n "$EXTRA" ] && echo "[tiers]   on the host, NOT in the ledger (hand-edited, or a retired skill):$EXTRA"
+    echo "[tiers]   The always-on skill listing on that host is not the one this repo describes."
+    echo "[tiers]   fix (on that host): scripts/sync-skill-tiers.py   (dry-run; --apply to write)"
+    echo "[tiers]   If the host is also reported BEHIND above, ship it FIRST — a stale checkout"
+    echo "[tiers]   carries a stale ledger, and this finding is then a symptom of that one."
+    note_rc 22
+  else
+    echo "[tiers] $ROLE: matches the ledger ($NW tier-B override(s) deployed as asked)."
+  fi
+}
+
+echo "=== skill-listing tiers (deployed skillOverrides vs claude/skill-tiers.json) ==="
+if [ ! -r "$_drift_tier_py" ]; then
+  echo "[tiers] COULD NOT MEASURE — cannot read $_drift_tier_py."
+  echo "[tiers]   This is NOT 'the hosts match the ledger'. No rc is set."
+else
+  T_RAW="$(python3 "$_drift_tier_py" "${DRIFT_TIER_LEDGER:-}" 2>/dev/null)"
+  T_TOKEN="${T_RAW%% *}"
+  if [ "$T_TOKEN" != ok ]; then
+    echo "[tiers] COULD NOT MEASURE — the ledger reader produced no usable expectation."
+    echo "[tiers]   An empty expectation would make every host look compliant, in silence."
+    echo "[tiers]   This is NOT 'the hosts match the ledger'. No rc is set."
+  else
+    T_WANT="${T_RAW#ok}"
+    T_WANT="${T_WANT# }"
+    T_NW="$(printf '%s' "$T_WANT" | wc -w)"
+    echo "[tiers] ledger asks for $T_NW name-only override(s); every other skill keeps its description."
+    tier_report "$LOCAL_ROLE" "$(fact_of "$LOCAL_OUT" skill-overrides)" "$T_WANT" "$T_NW"
+    tier_report "$REMOTE_ROLE" "$(fact_of "$REMOTE_OUT" skill-overrides)" "$T_WANT" "$T_NW"
+  fi
+fi
+echo
+
 # ── CROSS-HOST SOURCE-REPO COMPARISON ─────────────────────────────────────────
 # 🔴 INFORMATION ONLY — it sets no exit code, and that is a decision, not an
 # omission. Whether a given source-repo HEAD is WRONG has a defined answer and it
@@ -2043,6 +2220,9 @@ if [ "$rc" != 0 ]; then
   echo "  rc18=a built-source scope has been UNMEASURABLE for N consecutive runs on that host"
   echo "       (no upstream / fetch failing), so rc17 cannot fire for it. repo ABSENT never"
   echo "       escalates. (ranks just under rc13 — same 'could not look' class, smaller scope)"
+  echo "  rc22=a host's deployed skillOverrides disagree with claude/skill-tiers.json. A host"
+  echo "       with NO overrides is NOT ADOPTED, never rc22 — that is the shipped state."
+  echo "       (ranks just under rc10 — a behind host carries a stale ledger; ship it first)"
 fi
 [ -n "$UNCHECKED" ] && echo "drift-check: NOT checked: $UNCHECKED"
 exit "$rc"

--- a/scripts/lib/skill_tier_facts.py
+++ b/scripts/lib/skill_tier_facts.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Project the skill-listing tier ledger into one machine-readable line.
+
+`scripts/drift-check.sh` needs to know what `skillOverrides` the ledger asks a
+host to carry. It could sed the JSON — and that is exactly the trap
+`claude/RULES.md` names under "PARSING output makes its FORMAT a dependency you
+did not pin": a pattern that stops matching returns a confident empty set, and an
+empty expectation makes every host look compliant, in silence.
+
+So the ledger is read by the ONE parser that owns it (`lib/skill_tiers.py`, the
+same one `sync-skill-tiers.py` writes from), and this prints:
+
+    ok name=value name=value ...      # sorted; `ok` alone means the ledger
+                                      # asks for no overrides at all
+    err <token>                       # on stderr, exit 1 — the caller reports
+                                      # COULD NOT MEASURE and sets no rc
+
+Optional argv[1] overrides the ledger path, so the suite can drive every branch
+against a fixture instead of the live file.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+def main(argv) -> int:
+    try:
+        import skill_tiers
+    except Exception:
+        print("err reader-unimportable", file=sys.stderr)
+        return 1
+    path = Path(argv[1]) if len(argv) > 1 and argv[1] else skill_tiers.LEDGER_PATH
+    try:
+        ledger = skill_tiers.load_ledger(path)
+    except FileNotFoundError:
+        print("err ledger-absent", file=sys.stderr)
+        return 1
+    except ValueError:
+        print("err ledger-malformed", file=sys.stderr)
+        return 1
+    except OSError:
+        print("err ledger-unreadable", file=sys.stderr)
+        return 1
+    want = skill_tiers.expected_overrides(ledger)
+    print(" ".join(["ok"] + [f"{n}={v}" for n, v in sorted(want.items())]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/lib/skill_tiers.py
+++ b/scripts/lib/skill_tiers.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""The skill-listing TIER LEDGER, read once and shared by everything that needs it.
+
+`claude/skill-tiers.json` assigns every shipped skill to tier A (a full
+description in the always-on listing) or tier B (`name-only` -- roughly 12 chars,
+still `/name`-invocable and still callable by the Skill tool, but with no routing
+prose, so it no longer fires from a described symptom).
+
+Three consumers read it and they must not disagree:
+
+  * `scripts/sync-skill-tiers.py`   applies it to a host's ~/.claude/settings.json
+  * `scripts/drift-check.sh`        reports a host that has drifted from it
+  * `scripts/tests/test_skill_tiers.py`  pins it two-way against the shipped tree
+
+so the parsing, the discovery and the cost formula live HERE, once.
+`claude/RULES.md` -> "One rule, one place": a predicate open-coded at N sites is
+typically wrong at N-1 of them, in the same direction.
+
+🔴 THE COST FORMULA IS THE REAL ONE, NOT THE GATE'S.
+`scripts/tests/test_skill_descriptions.py` deliberately measures the SMALLER
+number -- `len(name) + len(desc)` -- and its docstring explains why that ratchet
+is left alone. What Claude Code actually charges, decompiled from the shipped
+binary (see `claudedocs/proposal-skill-listing-tiers.md` section 1), is
+
+    entry:      "- " + name + ": " + description   ->  len(name) + 4 + min(len(desc), 1536)
+    name-only:  "- " + name                        ->  len(name) + 2
+    total:      sum(entries) + (n - 1)             ->  newline-joined
+
+i.e. the older measure undercounts by exactly `5n - 1`. THIS module uses the real
+formula; the two numbers are supposed to differ, and neither is a bug.
+
+🔴 A RATIO WITHOUT ITS MODEL IS MEANINGLESS. The budget is
+`floor(contextWindow * zx(model) * 0.01)` CHARACTERS, and `zx` is 4 for the 14
+models up to 4.6 and **3 for claude-opus-5 and newer** -- 6,000 at 200k and
+30,000 at 1M on this session's model, not 8,000 / 40,000. Never quote one bare
+multiple of "the budget".
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LEDGER_PATH = REPO_ROOT / "claude" / "skill-tiers.json"
+SKILLS_DIR = REPO_ROOT / "claude" / "skills"
+HOME_NIX = REPO_ROOT / "nix" / "home.nix"
+
+# The upstream per-entry ceiling. Not a devrc choice.
+PER_ENTRY_CAP_CHARS = 1_536
+
+# What a tier-B entry becomes in `skillOverrides`.
+#
+# 🔴 NOT `user-invocable-only` and NOT `off`. Those two remove the skill from the
+# model's reach entirely (cost 0, hidden from the listing); `name-only` keeps the
+# NAME in the listing and keeps the Skill tool able to call it. Tiering is a
+# routing decision, never a disabling one -- if a skill should be off, delete it.
+TIER_B_OVERRIDE_VALUE = "name-only"
+
+# The values Claude Code's resolver understands. An unknown string is not a
+# no-op that we would notice: it falls through to the default, silently.
+VALID_OVERRIDE_VALUES = ("on", "name-only", "user-invocable-only", "off")
+
+VALID_TIERS = ("A", "B")
+
+# Skills deployed by `mkOutOfStoreSymlink` from `scripts/`, not by the recursive
+# `claude/skills` mapping. They are listing entries like any other.
+#
+# 🔴 DERIVED FROM nix/home.nix, never hand-listed here. The equivalent list in
+# `test_skill_descriptions.py` fell a whole entry behind once (`opencode` went
+# unmeasured while every check stayed green); deriving it means a fourth one is
+# covered the day it is added. `test_skill_tiers.py` pins this discovery against
+# that module's, so the two cannot silently disagree either.
+HOME_NIX_SKILL_SOURCE = re.compile(
+    r'home\.file\."\.claude/skills/[^"]+/SKILL\.md"\.source\s*=\s*'
+    r'config\.lib\.file\.mkOutOfStoreSymlink\s*"\$\{workspace\}/devrc/([^"]+)"',
+)
+
+
+def _load_parser():
+    """The repo's OWN frontmatter reader -- the one that builds the deployed
+    opencode command listing. A second regex here would be free to disagree with
+    what actually ships, and disagreement (not absence) is what makes a gate lie.
+    """
+    path = REPO_ROOT / "scripts" / "opencode" / "generate-commands.py"
+    loader = importlib.machinery.SourceFileLoader("_gen_commands_tiers", str(path))
+    spec = importlib.util.spec_from_loader("_gen_commands_tiers", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod.parse_skill
+
+
+def skill_md_paths() -> list[Path]:
+    """Every SKILL.md that becomes a listing entry, in-tree and out."""
+    found = sorted(SKILLS_DIR.glob("*/SKILL.md"))
+    nix = HOME_NIX.read_text(encoding="utf-8")
+    out_of_tree = sorted(HOME_NIX_SKILL_SOURCE.findall(nix))
+    if not out_of_tree:
+        raise RuntimeError(
+            f"the mkOutOfStoreSymlink pattern matched NOTHING in {HOME_NIX}. An "
+            "empty match set is not evidence of an empty ledger -- the deploy "
+            "idiom has changed shape. Re-derive HOME_NIX_SKILL_SOURCE rather "
+            "than letting this return a short list."
+        )
+    for rel in out_of_tree:
+        p = REPO_ROOT / rel
+        if not p.is_file():
+            raise RuntimeError(
+                f"nix/home.nix deploys {rel} as a ~/.claude/skills entry, but "
+                f"{p} does not exist."
+            )
+        found.append(p)
+    return found
+
+
+def shipped_skills() -> dict[str, tuple[str, str]]:
+    """name -> (repo-relative path, description) for every listing entry.
+
+    A SKILL.md the parser rejects is REPORTED by `unparseable()`, not silently
+    dropped -- upstream drops such a skill from the listing entirely, which is
+    the loud version of the same failure.
+    """
+    parse_skill = _load_parser()
+    out: dict[str, tuple[str, str]] = {}
+    for path in skill_md_paths():
+        parsed = parse_skill(path)
+        if parsed is None:
+            continue
+        out[parsed["name"]] = (str(path.relative_to(REPO_ROOT)), parsed["description"])
+    return out
+
+
+def unparseable() -> list[str]:
+    parse_skill = _load_parser()
+    return [str(p.relative_to(REPO_ROOT)) for p in skill_md_paths()
+            if parse_skill(p) is None]
+
+
+def load_ledger(path: Path | None = None) -> dict[str, dict]:
+    """name -> {"tier": "A"|"B", "why": str}. Raises on a malformed ledger.
+
+    Refusing to parse is the right failure: every consumer of this ledger takes
+    an ACTION from it (writing settings.json, calling a host drifted), and a
+    partially-read ledger produces a confident wrong one.
+    """
+    path = path or LEDGER_PATH
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or not isinstance(data.get("skills"), dict):
+        raise ValueError(f"{path}: expected a top-level object with a `skills` object")
+    skills = data["skills"]
+    if not skills:
+        raise ValueError(
+            f"{path}: the `skills` object is EMPTY. An empty ledger satisfies "
+            "every per-entry check in silence -- it is not a clean ledger."
+        )
+    for name, entry in skills.items():
+        if not isinstance(entry, dict):
+            raise ValueError(f"{path}: entry for `{name}` is not an object")
+        tier = entry.get("tier")
+        if tier not in VALID_TIERS:
+            raise ValueError(
+                f"{path}: `{name}` has tier {tier!r}; expected one of {VALID_TIERS}"
+            )
+        if tier == "B" and not str(entry.get("why", "")).strip():
+            raise ValueError(
+                f"{path}: `{name}` is tier B with no `why`. Every tier-B call is "
+                "a routing decision someone has to be able to audit; a tier-A "
+                "entry needs none because A is the default."
+            )
+    return skills
+
+
+def tier_of(ledger: dict[str, dict], name: str) -> str:
+    return ledger[name]["tier"]
+
+
+def tier_b_names(ledger: dict[str, dict]) -> list[str]:
+    return sorted(n for n, e in ledger.items() if e["tier"] == "B")
+
+
+def tier_a_names(ledger: dict[str, dict]) -> list[str]:
+    return sorted(n for n, e in ledger.items() if e["tier"] == "A")
+
+
+def expected_overrides(ledger: dict[str, dict]) -> dict[str, str]:
+    """The `skillOverrides` map this ledger asks a host to carry.
+
+    Tier A is deliberately ABSENT rather than written as `"on"`: `on` is already
+    the default, so emitting it would add a line per skill that says nothing, and
+    would make every tier-A flip a settings.json write instead of a no-op.
+    """
+    return {n: TIER_B_OVERRIDE_VALUE for n in tier_b_names(ledger)}
+
+
+def reconcile(ledger: dict[str, dict], skills: dict[str, tuple[str, str]]):
+    """-> (untiered, phantom). THE two-way pin, in one place.
+
+    `untiered`: a shipped skill with no ledger entry -- it silently keeps a full
+    description, so the mechanism stops covering the tree as the tree grows.
+    `phantom`:  a ledger entry naming no shipped skill -- a dead override that
+    can never be observed, pointing at a skill that was renamed or retired.
+    """
+    untiered = sorted(set(skills) - set(ledger))
+    phantom = sorted(set(ledger) - set(skills))
+    return untiered, phantom
+
+
+# --- cost, with the REAL formula --------------------------------------------- #
+
+def entry_chars(name: str, description: str) -> int:
+    """`"- " + name + ": " + description`, capped per-entry."""
+    return len(name) + 4 + min(len(description), PER_ENTRY_CAP_CHARS)
+
+
+def name_only_chars(name: str) -> int:
+    """`"- " + name`."""
+    return len(name) + 2
+
+
+def _joined(costs: list[int]) -> int:
+    """Newline-joined: the separators are `n - 1`, and an empty block costs 0."""
+    return sum(costs) + max(0, len(costs) - 1) if costs else 0
+
+
+def tier_a_chars(ledger: dict[str, dict], skills: dict[str, tuple[str, str]]) -> int:
+    """What the tier-A block costs, every session. The ratchet's subject."""
+    return _joined([entry_chars(n, skills[n][1])
+                    for n in tier_a_names(ledger) if n in skills])
+
+
+def tier_b_chars(ledger: dict[str, dict], skills: dict[str, tuple[str, str]]) -> int:
+    return _joined([name_only_chars(n) for n in tier_b_names(ledger) if n in skills])
+
+
+def devrc_listing_chars(ledger: dict[str, dict],
+                        skills: dict[str, tuple[str, str]]) -> int:
+    """devrc's whole contribution under this ledger -- A full, B name-only, one
+    separator between every pair. Reported as INFORMATION beside the ratchet:
+    the listing also carries non-devrc entries this repo cannot see, so this is
+    a floor on the listing and never the listing."""
+    costs = []
+    for name in sorted(skills):
+        if name in ledger and ledger[name]["tier"] == "B":
+            costs.append(name_only_chars(name))
+        else:
+            costs.append(entry_chars(name, skills[name][1]))
+    return _joined(costs)
+
+
+def costliest(ledger: dict[str, dict], skills: dict[str, tuple[str, str]],
+              n: int = 10) -> list[tuple[str, int]]:
+    """The tier-A entries to consider demoting first, largest first."""
+    return sorted(((name, entry_chars(name, skills[name][1]))
+                   for name in tier_a_names(ledger) if name in skills),
+                  key=lambda pair: (-pair[1], pair[0]))[:n]

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -171,14 +171,14 @@
 # 🔴 THE LADDER IS SHARED WITH scripts/drift-check.sh, RECIPROCALLY. That script
 # is the passive deadman for the same fleet and deliberately uses the same
 # vocabulary, so a number must not mean two things across the pair. It owns
-# 10, 14, 15, 16, 17 and 18 — DRIFT meanings this script does not take — and
-# reserves them here; this script owns 5, 7, 9, 11, 19 and 20 and they are
+# 10, 14, 15, 16, 17, 18 and 22 — DRIFT meanings this script does not take — and
+# reserves them here; this script owns 5, 7, 9, 11, 19, 20 and 21 and they are
 # reserved there. Its header says "a new DRIFT code has nowhere to go but
 # upward", which points the next one at 19 unless the reservation is written
-# down on both sides: so the next free code for THIS script is 22, and so is the
+# down on both sides: so the next free code for THIS script is 23, and so is the
 # next free code for that one.
 #
-# RESERVED-TO-DRIFT-CHECK: 10 14 15 16 17 18
+# RESERVED-TO-DRIFT-CHECK: 10 14 15 16 17 18 22
 #
 # That line is a LEDGER, machine-read, not a comment: it must equal exactly the
 # set of codes drift-check.sh can return and this script cannot, so it fails when

--- a/scripts/sync-skill-tiers.py
+++ b/scripts/sync-skill-tiers.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Apply the devrc skill-listing TIER LEDGER to a host's ~/.claude/settings.json.
+
+WHAT THIS IS FOR
+----------------
+Every skill's `name` + `description` loads on EVERY session, under a budget of
+1% of the context window measured IN CHARACTERS. Over budget, Claude Code
+silently strips descriptions starting with the skills invoked least -- taking
+with them the very trigger keywords that make a skill auto-fire.
+
+`skillOverrides` in settings.json makes that cost per-skill opt-in. A skill set
+to `name-only` costs ~12 chars instead of ~350, stays `/name`-invocable and stays
+callable by the Skill tool; what it loses is the ROUTING PROSE that makes it fire
+from a described symptom. `claude/skill-tiers.json` is the ledger of that call,
+one line per skill, with a rationale on every tier-B entry.
+
+🔴 IT DEFAULTS TO DRY-RUN. Nothing is written without `--apply`. Applying the
+ledger is an operator act on a per-host, unmanaged file -- not something that
+happens as a side effect of a merge or a switch.
+
+WHY A SCRIPT AND NOT A NIX MODULE
+---------------------------------
+The same reason `scripts/sync-claude-permissions.py` is one, and it is stated in
+`nix/home.nix` twice: `~/.claude/settings.json` is per-host and deliberately
+UNMANAGED, and Claude Code itself rewrites it every time a permission prompt is
+answered. Anything nix owned here would be clobbered on the next "allow", or
+would clobber the operator's own answers.
+
+🔴 THE MERGE ORDER MAKES THIS FILE THE WEAKEST SCOPE
+----------------------------------------------------
+Settings merge user -> project -> local -> flag -> policy, later wins, per-key
+deep merge. `~/.claude/settings.json` is the LOWEST-precedence ordinary scope, so
+a `skillOverrides` entry in any project's `.claude/settings.json` or
+`.claude/settings.local.json` silently beats this ledger for that skill, in that
+repo, with no error anywhere. This script cannot fix that -- those files are not
+devrc's -- so it goes looking for them and says so LOUDLY. A warning here is the
+only thing standing between "the ledger is applied" and "the ledger is applied
+except where it is not".
+
+🔴 A PLUGIN SKILL CAN NEVER BE TIERED
+-------------------------------------
+The override resolver hard-returns `"on"` for `source === "plugin"` before it
+looks at `skillOverrides` at all, so an entry naming a plugin skill is DEAD
+CONFIG that reads as coverage. devrc's own skills load as `source:
+"userSettings"`, and this ledger is pinned two-way against devrc's own tree
+(`reconcile` below, and `scripts/tests/test_skill_tiers.py`), so a plugin name
+cannot get an entry without failing as a phantom. The plugin scan below is belt
+and braces on top of that structural guarantee, not the guarantee itself.
+
+WHAT IT WRITES
+--------------
+Strictly additive within one key. It merges the ledger's tier-B entries into
+`skillOverrides`, never clobbering the key, never removing or rewriting an entry
+it did not put there, and never touching any other key. Tier A is written as
+ABSENCE, not as `"on"` -- `on` is already the default, so emitting it would add a
+line per skill that says nothing and turn every tier-A flip into a write.
+
+An existing entry whose value DISAGREES with the ledger is reported and left
+alone unless `--force-value` is passed: a hand-set `off` is somebody's decision,
+and quietly promoting it to `name-only` would re-enable a skill they hid.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+import skill_tiers  # noqa: E402
+
+DEFAULT_SETTINGS = Path.home() / ".claude" / "settings.json"
+DEFAULT_PROJECT_ROOTS = (Path.home() / "workspace",)
+CLAUDE_JSON = Path.home() / ".claude.json"
+PLUGINS_DIR = Path.home() / ".claude" / "plugins"
+
+
+# --------------------------------------------------------------------------- #
+# The scopes that can beat this one
+# --------------------------------------------------------------------------- #
+
+def _project_dirs(roots, claude_json: Path | None) -> list[Path]:
+    """Every directory that could hold a project-scope settings file.
+
+    Two independent sources, unioned rather than chosen between, because each
+    misses cases the other sees: the roots glob finds a checkout Claude Code has
+    never opened, and `~/.claude.json`'s `projects` keys find one that lives
+    outside every root.
+
+    🔴 `claude_json` is a PARAMETER, not the module constant read directly. The
+    live file names the operator's real checkouts, so a hardcoded read makes this
+    function unable to be driven against a fixture -- and the control that proves
+    the scan can see an overriding project would then be measuring the operator's
+    machine instead of its own fixture. Pass `None` to consult only `roots`.
+    """
+    found: set[Path] = set()
+    for root in roots:
+        try:
+            if not root.is_dir():
+                continue
+            children = sorted(root.iterdir())
+        except OSError:
+            continue
+        for child in children:
+            try:
+                if child.is_dir():
+                    found.add(child)
+            except OSError:
+                # 🔴 `is_dir()` STATS, and a stat can be REFUSED. Measured on the
+                # first live run with `--project-root /tmp`: systemd's
+                # `systemd-private-*` directories are mode 700 and owned by root,
+                # so the scan died with a traceback partway through -- after
+                # printing the ledger summary, which reads as a completed run.
+                # A directory this process cannot see is a gap in coverage, not a
+                # reason to abort; the FILE COUNT the caller prints is what makes
+                # the gap visible.
+                continue
+    if claude_json is not None:
+        try:
+            data = json.loads(claude_json.read_text(encoding="utf-8"))
+            for key in (data.get("projects") or {}):
+                found.add(Path(key))
+        except (OSError, ValueError, AttributeError):
+            # Absent or unreadable is a FACT about coverage, reported by the
+            # caller -- never folded into "no overriding projects found".
+            pass
+    return sorted(found)
+
+
+def overriding_scopes(names, roots,
+                      claude_json: Path | None = None
+                      ) -> tuple[list[tuple[Path, str, str]], int]:
+    """-> ([(file, skill, value)], number of settings files actually READ).
+
+    🔴 The count is returned with the findings and printed beside them. An empty
+    finding list from a scan that opened zero files is indistinguishable from a
+    clean sweep, and is exactly how a check wired to nothing reads as a pass.
+    """
+    hits: list[tuple[Path, str, str]] = []
+    read = 0
+    wanted = set(names)
+    for proj in _project_dirs(roots, claude_json):
+        for leaf in ("settings.json", "settings.local.json"):
+            path = proj / ".claude" / leaf
+            try:
+                if not path.is_file():
+                    continue
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                # Same reasoning as `_project_dirs`: an unreadable or unparseable
+                # project settings file is a gap in coverage, visible in the file
+                # count, and never a reason to abort the whole run.
+                continue
+            read += 1
+            over = data.get("skillOverrides")
+            if not isinstance(over, dict):
+                continue
+            for name, value in sorted(over.items()):
+                if name in wanted:
+                    hits.append((path, name, str(value)))
+    return hits, read
+
+
+def plugin_skill_names() -> set[str]:
+    """Skill names provided by installed plugins, best effort.
+
+    Absence is not evidence of none -- see the caller, which says which.
+    """
+    names: set[str] = set()
+    if not PLUGINS_DIR.is_dir():
+        return names
+    for skill_md in PLUGINS_DIR.glob("**/skills/*/SKILL.md"):
+        names.add(skill_md.parent.name)
+    return names
+
+
+# --------------------------------------------------------------------------- #
+
+def merge(existing: dict, wanted: dict, force_value: bool):
+    """-> (merged, added, conflicting, foreign).
+
+    added:       entries this run would write
+    conflicting: present with a DIFFERENT value (left alone unless --force-value)
+    foreign:     present in the file for a skill this ledger does not tier
+    """
+    merged = dict(existing)
+    added, conflicting = [], []
+    for name, value in sorted(wanted.items()):
+        current = existing.get(name)
+        if current is None:
+            merged[name] = value
+            added.append((name, value))
+        elif str(current) != value:
+            conflicting.append((name, str(current), value))
+            if force_value:
+                merged[name] = value
+    foreign = sorted(n for n in existing if n not in wanted)
+    return merged, added, conflicting, foreign
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--settings", type=Path, default=DEFAULT_SETTINGS,
+                    help="settings.json to update (default: ~/.claude/settings.json)")
+    ap.add_argument("--apply", action="store_true",
+                    help="actually write. WITHOUT THIS NOTHING IS WRITTEN.")
+    ap.add_argument("--force-value", action="store_true",
+                    help="overwrite an existing entry whose value disagrees with "
+                         "the ledger (default: report it and leave it alone)")
+    ap.add_argument("--project-root", type=Path, action="append", default=None,
+                    help="directory whose immediate children are scanned for "
+                         "project-scope settings that would beat this file "
+                         "(repeatable; default: ~/workspace)")
+    args = ap.parse_args(argv)
+    roots = args.project_root or list(DEFAULT_PROJECT_ROOTS)
+
+    # --- 1. the ledger must agree with the shipped tree, both ways ------------
+    try:
+        ledger = skill_tiers.load_ledger()
+    except (OSError, ValueError) as exc:
+        print(f"REFUSING TO WRITE — {skill_tiers.LEDGER_PATH} is unusable: {exc}",
+              file=sys.stderr)
+        return 2
+    try:
+        skills = skill_tiers.shipped_skills()
+    except RuntimeError as exc:
+        print(f"REFUSING TO WRITE — cannot enumerate the shipped skills: {exc}",
+              file=sys.stderr)
+        return 2
+
+    broken = skill_tiers.unparseable()
+    if broken:
+        print("REFUSING TO WRITE — these SKILL.md files have no readable "
+              f"frontmatter, so they are not in the listing at all: {broken}",
+              file=sys.stderr)
+        return 2
+
+    untiered, phantom = skill_tiers.reconcile(ledger, skills)
+    if untiered or phantom:
+        print("REFUSING TO WRITE — the ledger and the shipped skills disagree.",
+              file=sys.stderr)
+        for n in untiered:
+            print(f"  shipped but NOT tiered: {n}  ({skills[n][0]})", file=sys.stderr)
+        for n in phantom:
+            print(f"  tiered but NOT shipped: {n}  (renamed? retired? a plugin "
+                  "skill, which can never be tiered?)", file=sys.stderr)
+        print("  Add or remove the entry in claude/skill-tiers.json. Flipping a "
+              "skill is one line.", file=sys.stderr)
+        return 2
+
+    wanted = skill_tiers.expected_overrides(ledger)
+    a_names = skill_tiers.tier_a_names(ledger)
+    print(f"ledger: {len(a_names)} tier A (full description), "
+          f"{len(wanted)} tier B (name-only), {len(skills)} skills total")
+    print(f"  tier A costs {skill_tiers.tier_a_chars(ledger, skills):,} chars; "
+          f"devrc's whole listing under this ledger, "
+          f"{skill_tiers.devrc_listing_chars(ledger, skills):,} chars "
+          "(a FLOOR on the listing — the non-devrc entries are real and this "
+          "repo cannot see them)")
+
+    # --- 2. a plugin name in the ledger is dead config ------------------------
+    plugin_names = plugin_skill_names()
+    if plugin_names:
+        collide = sorted(set(ledger) & plugin_names)
+        print(f"  plugin skills: {len(plugin_names)} found under {PLUGINS_DIR}, "
+              f"{len(collide)} colliding with a ledger entry")
+        if collide:
+            print(f"  ⚠ these ledger entries share a name with a PLUGIN skill: "
+                  f"{collide}. The resolver hard-returns \"on\" for a plugin "
+                  "skill, so such an override never takes effect.", file=sys.stderr)
+    else:
+        print(f"  plugin skills: NOT SCANNED — {PLUGINS_DIR} is absent or empty "
+              "(so this run cannot say a ledger entry is not a dead plugin "
+              "override; the two-way pin above is what actually prevents it)")
+
+    # --- 3. the scopes that silently beat this one ----------------------------
+    hits, files_read = overriding_scopes(wanted, roots, CLAUDE_JSON)
+    known = "yes" if CLAUDE_JSON.is_file() else "NOT READABLE"
+    print(f"  project/local scopes examined: {files_read} settings file(s) under "
+          f"{[str(r) for r in roots]}; ~/.claude.json's project list: {known}")
+    if hits:
+        print("  🔴 THESE SCOPES BEAT THIS FILE. Settings merge user -> project "
+              "-> local, later wins, per-key: for each skill below, the ledger "
+              "is OVERRULED inside that project.", file=sys.stderr)
+        for path, name, value in hits:
+            print(f"     {path}: {name} = {value}", file=sys.stderr)
+        print("     Fix them THERE, or accept that the ledger does not hold in "
+              "those repos.", file=sys.stderr)
+
+    # --- 4. the write ---------------------------------------------------------
+    path = args.settings
+    if not path.exists():
+        print(f"{path} does not exist — nothing to merge into.", file=sys.stderr)
+        print("  Claude Code writes this file on first run; start it once, then "
+              "re-run this script.", file=sys.stderr)
+        return 3
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (ValueError, OSError) as exc:
+        print(f"{path} is not readable JSON ({exc}) — refusing to touch it.",
+              file=sys.stderr)
+        return 4
+    if not isinstance(data, dict):
+        print(f"{path} is not a JSON object — refusing to touch it.", file=sys.stderr)
+        return 4
+    existing = data.get("skillOverrides")
+    if existing is None:
+        existing = {}
+    if not isinstance(existing, dict):
+        print(f"{path}: `skillOverrides` is not an object — refusing to touch it.",
+              file=sys.stderr)
+        return 4
+
+    merged, added, conflicting, foreign = merge(existing, wanted, args.force_value)
+    print(f"{path}: {len(existing)} existing override(s), {len(added)} to add.")
+    for name, value in added:
+        why = ledger[name].get("why", "")
+        print(f"  + {name}: {value}" + (f"   — {why}" if why else ""))
+    for name, current, value in conflicting:
+        verb = "OVERWRITING" if args.force_value else "LEAVING ALONE"
+        print(f"  ! {name}: file says {current!r}, ledger says {value!r} "
+              f"— {verb}" + ("" if args.force_value else " (--force-value to change)"))
+    for name in foreign:
+        print(f"  = {name}: {existing[name]!r} — not tiered by the ledger, untouched")
+
+    if merged == existing:
+        print("  nothing to do — already in sync.")
+        return 0
+    if not args.apply:
+        print("  DRY RUN — nothing written. Re-run with --apply to write.")
+        return 0
+
+    data["skillOverrides"] = merged
+    backup = path.with_name(path.name + ".bak-" + time.strftime("%Y%m%dT%H%M%S"))
+    shutil.copy2(path, backup)
+    body = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".settings-", suffix=".json")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(body)
+        os.chmod(tmp, path.stat().st_mode & 0o7777)
+        os.replace(tmp, path)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+    print(f"  wrote {path} ({len(merged)} override(s)). Backup: {backup}")
+    print("  🔴 Claude Code reads settings.json at STARTUP — restart any running "
+          "session before expecting the listing to change.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -4751,3 +4751,286 @@ def test_the_two_rc_ladders_reserve_each_others_codes():
             f"code. The two ladders now reach {max(ship_codes | drift_codes)}, so "
             f"'nowhere to go but upward' points at a number that is already taken."
         )
+
+
+# --------------------------------------------------------------------------- #
+# SKILL-LISTING TIERS (rc 22)
+#
+# `claude/skill-tiers.json` decides which skills spend always-on listing budget
+# on a full description and which ship as `name-only`. That ledger is in git;
+# `~/.claude/settings.json` is per-host and unmanaged, so nothing keeps them
+# together except this arm and `scripts/sync-skill-tiers.py`.
+#
+# 🔴 THE DESIGN DECISION THESE TESTS EXIST TO PIN: a host with NO skillOverrides
+# is NOT ADOPTED, not drift, and sets NO rc. The mechanism shipped applied to
+# zero hosts — deliberately, because nothing is being truncated today — so
+# counting an unapplied host as drift would have made this code RED ON EVERY RUN
+# from the moment it landed, and `claude/RULES.md` is explicit that a
+# permanently-red gate is worse than no gate. rc 22 fires only on
+# adopted-then-drifted.
+#
+# The comparison is NOT cross-host: both machines can agree perfectly and both be
+# wrong. The reference is the ledger.
+# --------------------------------------------------------------------------- #
+
+TIER_LEDGER_FIXTURE = {
+    "skills": {
+        "alpha": {"tier": "B", "why": "a fixture rationale, long enough to pass"},
+        "beta": {"tier": "B", "why": "a second fixture rationale, also long"},
+        "gamma": {"tier": "A"},
+    }
+}
+TIER_WANT = {"alpha": "name-only", "beta": "name-only"}
+
+
+def _tier_ledger(tmp_path, body=None):
+    p = tmp_path / "skill-tiers.json"
+    p.write_text(json.dumps(body if body is not None else TIER_LEDGER_FIXTURE,
+                            indent=2), encoding="utf-8")
+    return p
+
+
+def _settings_with(home, overrides, extra=None):
+    """Write a fixture ~/.claude/settings.json in the SHAPE Claude Code writes:
+    2-space top-level keys, 4-space entries, `json.dumps(indent=2)`. The
+    extractor under test is a sed with a format dependency, so a fixture built
+    any other way would be testing a format nobody ships."""
+    claude = home / ".claude"
+    claude.mkdir(parents=True, exist_ok=True)
+    body = {"theme": "dark"}
+    if overrides is not None:
+        body["skillOverrides"] = overrides
+    body.update(extra or {})
+    (claude / "settings.json").write_text(
+        json.dumps(body, indent=2) + "\n", encoding="utf-8")
+
+
+def _tiers_block(out):
+    """Just the [tiers] lines, so an assertion cannot be satisfied by a word
+    that appears in some other arm's output."""
+    return "\n".join(ln for ln in out.splitlines() if ln.startswith("[tiers]"))
+
+
+def _tier_check(fleet, ledger, *args, **env):
+    return fleet.check("--no-remote", *args,
+                       DRIFT_TIER_LEDGER=str(ledger), **env)
+
+
+def test_a_host_with_no_skill_overrides_is_NOT_ADOPTED_not_drift(fleet, tmp_path):
+    """🔴 THE PERMANENTLY-RED-GATE GUARD, and the shipped state of the fleet.
+
+    Neither host had skillOverrides when this landed. If that counted as drift
+    the deadman would fail on every run forever, training the operator to click
+    through the one alert that has to keep its meaning.
+    """
+    fleet.catch_up()
+    _settings_with(fleet.home, None)
+    rc, out = _tier_check(fleet, _tier_ledger(tmp_path))
+    block = _tiers_block(out)
+    assert rc == 0, f"an unadopted host was reported as drift (rc {rc})\n{out}"
+    assert "NOT ADOPTED" in block, block
+    assert "DRIFT" not in block, block
+    assert "sync-skill-tiers.py --apply" in block, "no fix is offered\n" + block
+    assert "matches the ledger" not in block, (
+        "an unadopted host must not read as compliant\n" + block
+    )
+
+
+def test_a_host_matching_the_ledger_is_green(fleet, tmp_path):
+    """🔴 POSITIVE CONTROL. Report this ALONGSIDE the reds below: a green from an
+    arm wired to nothing looks exactly like this one, so the compliant case must
+    be shown to produce the AFFIRMATIVE line and not merely the absence of a
+    complaint."""
+    fleet.catch_up()
+    _settings_with(fleet.home, dict(TIER_WANT))
+    rc, out = _tier_check(fleet, _tier_ledger(tmp_path))
+    block = _tiers_block(out)
+    assert rc == 0, out
+    assert "matches the ledger (2 tier-B override(s) deployed as asked)" in block, block
+    assert "NOT ADOPTED" not in block, block
+
+
+def test_a_missing_ledger_entry_on_an_adopted_host_is_rc22(fleet, tmp_path):
+    """NEGATIVE CONTROL 1: the ledger gained an entry and nobody re-applied it.
+    Isolated — the host carries a VALID override for the other skill, so this can
+    only fail on the one that is absent."""
+    fleet.catch_up()
+    _settings_with(fleet.home, {"alpha": "name-only"})
+    rc, out = _tier_check(fleet, _tier_ledger(tmp_path))
+    block = _tiers_block(out)
+    assert rc == 22, f"expected rc 22, got {rc}\n{out}"
+    assert "in the ledger, NOT on the host: beta=name-only" in block, block
+    assert "alpha" not in block.split("NOT on the host:")[1].splitlines()[0], block
+
+
+def test_a_wrong_override_value_is_rc22(fleet, tmp_path):
+    """NEGATIVE CONTROL 2: the skill IS overridden, at a value the ledger does
+    not ask for. Reported as its own category — `off` hides the skill entirely,
+    which is a different fault from a missing entry and must not read the same."""
+    fleet.catch_up()
+    _settings_with(fleet.home, {"alpha": "off", "beta": "name-only"})
+    rc, out = _tier_check(fleet, _tier_ledger(tmp_path))
+    block = _tiers_block(out)
+    assert rc == 22, out
+    assert "DIFFERENT value than the ledger asks for: alpha=name-only" in block, block
+    assert "NOT on the host" not in block, block
+
+
+def test_an_override_the_ledger_does_not_name_is_rc22(fleet, tmp_path):
+    """NEGATIVE CONTROL 3: a hand-edit, or an override left behind by a retired
+    skill. The ledger is the reference in BOTH directions or it is not a
+    ledger."""
+    fleet.catch_up()
+    _settings_with(fleet.home, dict(TIER_WANT, delta="off"))
+    rc, out = _tier_check(fleet, _tier_ledger(tmp_path))
+    block = _tiers_block(out)
+    assert rc == 22, out
+    assert "NOT in the ledger (hand-edited, or a retired skill): delta=off" in block, block
+
+
+def test_rc22_names_the_fix_and_the_ordering_against_a_behind_host(fleet, tmp_path):
+    """A host reported BEHIND carries a STALE ledger, so this finding can be a
+    symptom of that one. The output has to say which to do first, or an operator
+    re-applies a ledger that is about to change under them."""
+    fleet.catch_up()
+    _settings_with(fleet.home, {"alpha": "name-only"})
+    _, out = _tier_check(fleet, _tier_ledger(tmp_path))
+    block = _tiers_block(out)
+    assert "sync-skill-tiers.py" in block, block
+    assert "ship it FIRST" in block, block
+
+
+def test_an_unusable_ledger_is_COULD_NOT_MEASURE_and_sets_no_rc(fleet, tmp_path):
+    """🔴 The reassuring zero this arm refuses. An unreadable ledger yields an
+    EMPTY expectation, and an empty expectation makes every host look compliant.
+    It must print COULD NOT MEASURE, set no rc, and never say `matches`."""
+    fleet.catch_up()
+    _settings_with(fleet.home, dict(TIER_WANT))
+    rc, out = _tier_check(fleet, tmp_path / "no-such-ledger.json")
+    block = _tiers_block(out)
+    assert rc == 0, out
+    assert "COULD NOT MEASURE" in block, block
+    assert "matches the ledger" not in block, block
+    assert "NOT ADOPTED" not in block, block
+
+    bad = tmp_path / "broken.json"
+    bad.write_text("{ not json", encoding="utf-8")
+    rc, out = _tier_check(fleet, bad)
+    assert rc == 0, out
+    assert "COULD NOT MEASURE" in _tiers_block(out), out
+
+
+def test_a_host_that_did_not_report_the_fact_is_not_reported_as_matching(
+        fleet, tmp_path):
+    """A host that produced no fact must never print like one that matches.
+
+    🔴 The reason is NOT "the far side runs an older drift-check.sh" — it cannot.
+    `PAYLOAD` is composed HERE and piped to `bash -s`, so the remote always runs
+    THIS script's payload. The real causes are a host that was not reached and a
+    stream cut short before the FACT lines, and the stub is the second shape: a
+    remote that answers cleanly, reports the earlier facts, and stops.
+    """
+    fleet.catch_up()
+    _settings_with(fleet.home, dict(TIER_WANT))
+    fleet.stub_ssh(0, stdout=("[laptop] clean\n"
+                              "[laptop] FACT settings-keys theme\n"
+                              "[laptop] PARITY-RC=0"))
+    rc, out = fleet.check(DRIFT_TIER_LEDGER=str(_tier_ledger(tmp_path)))
+    block = _tiers_block(out)
+    assert "laptop: NOT REPORTED" in block, block
+    assert "laptop: matches the ledger" not in block, block
+
+
+def test_the_ledger_the_arm_defaults_to_is_the_repos_own(fleet):
+    """With no override the arm reads `claude/skill-tiers.json` beside the script
+    — the copy that ships WITH this checker, so the two cannot be a version
+    apart. Measured through the live ledger's real tier-B count."""
+    fleet.catch_up()
+    _settings_with(fleet.home, None)
+    rc, out = fleet.check("--no-remote")
+    block = _tiers_block(out)
+    n = len(json.loads((REPO_ROOT / "claude" / "skill-tiers.json").read_text()
+                       )["skills"])
+    n_b = sum(1 for e in json.loads(
+        (REPO_ROOT / "claude" / "skill-tiers.json").read_text()
+    )["skills"].values() if e["tier"] == "B")
+    assert n >= 30, f"the live ledger has only {n} entries — is it being read?"
+    assert f"ledger asks for {n_b} name-only override(s)" in block, block
+
+
+# --- the EXTRACTOR, driven directly ---------------------------------------- #
+
+def _parity_fact(home, name="skill-overrides"):
+    """Run the real PARITY payload against a fixture $HOME and return one fact."""
+    proc = subprocess.run(
+        ["bash", "-c", _payload_literal("PARITY")],
+        capture_output=True, text=True,
+        env={"HOME": str(home), "PATH": os.environ.get("PATH", ""),
+             "DRIFT_LABEL": "fx", "DRIFT_PARITY_ROOTS": "no/such/dir"},
+    )
+    m = re.search(r"^\[fx\] FACT %s (.*)$" % re.escape(name), proc.stdout, re.M)
+    assert m, f"no `{name}` fact in the payload output:\n{proc.stdout}{proc.stderr}"
+    return m.group(1).strip()
+
+
+def test_the_extractor_can_actually_see_overrides(tmp_path):
+    """🔴 POSITIVE CONTROL FOR THE EXTRACTOR. Every other assertion about this
+    fact is a NONE / EMPTY / mismatch, and a sed that matches nothing produces
+    those too. It has to be shown reading real values out of the real shape."""
+    home = tmp_path / "h"
+    _settings_with(home, {"zeta": "name-only", "alpha": "off"})
+    assert _parity_fact(home) == "alpha=off zeta=name-only"
+
+
+def test_an_absent_key_is_NONE_and_an_unreadable_file_is_UNEVALUATED(tmp_path):
+    """Three states that must never collapse into one another."""
+    home = tmp_path / "h"
+    _settings_with(home, None)
+    assert _parity_fact(home) == "NONE"
+
+    empty = tmp_path / "e"
+    (empty / ".claude").mkdir(parents=True)
+    assert _parity_fact(empty) == "UNEVALUATED"
+
+
+def test_an_empty_overrides_object_does_not_swallow_the_following_key(tmp_path):
+    """🔴 ISOLATED MUTATION GUARD on the sed RANGE END, and the reason it is
+    `^  [}"]` rather than `^  }`.
+
+    `"skillOverrides": {},` on ONE line still matches the range START (the
+    pattern is an unanchored substring), so with `^  }` as the end the range runs
+    on through every FOLLOWING key and harvests their 4-space entries as
+    overrides. The fixture puts a nested object with entries of exactly that
+    shape immediately after, so a widened range would report them — and reporting
+    them would then be diffed against the ledger and called drift on a host that
+    has no overrides at all.
+    """
+    home = tmp_path / "h"
+    _settings_with(home, {}, extra={"statusLine": {"padStart": "yes",
+                                                   "command": "bar-status"}})
+    fact = _parity_fact(home)
+    assert fact == "EMPTY", fact
+    assert "padStart" not in fact and "command" not in fact, fact
+
+
+def test_a_populated_block_followed_by_another_key_stops_at_the_brace(tmp_path):
+    """The other side of the same boundary: a REAL multi-line block followed by
+    another object key must yield exactly its own entries. Without this, an
+    over-tight range end would pass the test above by matching nothing at all."""
+    home = tmp_path / "h"
+    _settings_with(home, {"alpha": "name-only", "beta": "off"},
+                   extra={"statusLine": {"command": "bar-status"}})
+    assert _parity_fact(home) == "alpha=name-only beta=off"
+
+
+def test_the_extractor_reports_only_the_enum_values_it_finds(tmp_path):
+    """The override VALUES are printed, unlike the key-name-only rule the rest of
+    this payload follows for settings.json — they are an enum, not a secret. This
+    pins that nothing ELSE from the file rides along: the fixture's other keys
+    carry values that would be a leak if they appeared."""
+    home = tmp_path / "h"
+    _settings_with(home, {"alpha": "name-only"},
+                   extra={"apiKeyHelper": "SECRET-DO-NOT-PRINT"})
+    fact = _parity_fact(home)
+    assert fact == "alpha=name-only"
+    assert "SECRET" not in fact

--- a/scripts/tests/test_skill_descriptions.py
+++ b/scripts/tests/test_skill_descriptions.py
@@ -78,22 +78,32 @@ Entry cost, from the binary: `"- " + name + ": " + description`, i.e.
 **name + 4 + min(len(desc), 1536)**; a name-only entry costs `name + 2`; the
 entries are newline-joined, so the total carries a further **(n - 1)**.
 
-    devrc's 36 entries, as this module measures  12,679 chars
-    + 4 per entry (144) + 35 separators             179 chars
+    devrc's 37 entries, as this module measures  12,861 chars
+    + 4 per entry (148) + 36 separators             184 chars
     ---------------------------------------------------------
-    what Claude Code actually charges            12,858 chars
+    what Claude Code actually charges            13,045 chars
 
-      vs a claude-3.x..4.6 200k budget (8,000)      1.61x over
-      vs a claude-opus-5   200k budget (6,000)      2.14x over
+      vs a claude-3.x..4.6 200k budget (8,000)      1.63x over
+      vs a claude-opus-5   200k budget (6,000)      2.17x over
       vs either 1M budget (40,000 / 30,000)         fits, with room
 
+⚠ RE-MEASURED at 37 entries. This block read 36 / 12,679 / 12,858 until
+`subsystem-index` landed in #790, AFTER #785 wrote those numbers -- so the
+figures were stale within a day and nothing said so. `test_skill_tiers.py` now
+pins its own copies of the same measurements against the live tree for exactly
+that reason; the numbers here are still prose, so re-derive rather than trust
+them (`listing_total_chars(_entries())` is the one this module owns).
+
 🔴 THIS MODULE DELIBERATELY MEASURES THE SMALLER NUMBER. `listing_total_chars`
-sums `len(name) + len(desc)` and so UNDERCOUNTS the real charge by 179 chars at
-36 entries (the per-entry 4 plus the separators; the general form is 5n - 1).
+sums `len(name) + len(desc)` and so UNDERCOUNTS the real charge by 184 chars at
+37 entries (the per-entry 4 plus the separators; the general form is 5n - 1 --
+quote the FORM, not the figure, which is what went stale above).
 That is the conservative direction -- the gate can only ever be stricter than
-reality -- and it is left alone ON PURPOSE: re-pointing the ratchet at the real
-formula belongs with the tiering work, not with a retirement. Do not "fix" it
-here without moving the ceiling in the same commit.
+reality -- and it is left alone ON PURPOSE: the tiering work in
+`test_skill_tiers.py` measures with the REAL formula, and having the two modules
+disagree by exactly 5n - 1 is the intended arrangement, pinned there by
+`test_the_real_formula_exceeds_the_older_gate_measure_by_5n_minus_1`. Do not
+"fix" it here without moving the ceiling in the same commit.
 
 ⚠ Two overrides sit ABOVE all of this. `SLASH_COMMAND_TOOL_CHAR_BUDGET`
 short-circuits the whole computation before the fraction or the context window
@@ -108,7 +118,8 @@ this gate from what Claude Code actually charges. No devrc skill defines
 `when_to_use`, so the `description - when_to_use` concatenation contributes
 nothing today either.
 
-The 36 is down from 39: `ux-sweep`, `gpu-operator-check` and `session-audit`
+The 37 is 39 minus three retirements plus one addition. `ux-sweep`,
+`gpu-operator-check` and `session-audit`
 were RETIRED on 2026-08-23 after measuring near-zero use of each -- no direct
 script/service use and no genuine prompt demand across 5,582 transcript files.
 Claude Code's own `skillUsage` counter recorded 0 for `ux-sweep` and
@@ -116,7 +127,7 @@ Claude Code's own `skillUsage` counter recorded 0 for `ux-sweep` and
 fired 2026-05-30. That is the eviction the playbook below asks for, and it is
 why the total moved without any description being trimmed.
 
-The 12,679 counts devrc's entries ONLY. The cloudflare plugin cost a further
+The 12,861 counts devrc's entries ONLY. The cloudflare plugin cost a further
 5,221 chars of listing until it was removed from `enabledPlugins` in
 `~/.claude/settings.json`, and it currently contributes nothing. 🔴 That file is
 PER-HOST and unmanaged by design (`CLAUDE.md` -> Git discipline), so that zero
@@ -139,17 +150,21 @@ SEPARATE `"builtin"` arm -- `init`, `statusline`, `security-review`,
 skills are not protected either. So the earlier claim in this docstring that
 built-in skills are merely "ADDITIONAL" had the direction wrong twice: bundled
 entries are SENIOR (they spend the budget first and never lose their
-descriptions, so devrc's 36 compete for the remainder), while builtin and plugin
+descriptions, so devrc's 37 compete for the remainder), while builtin and plugin
 entries are ordinary competitors like devrc's own.
 
-devrc's 36 entries are therefore a FLOOR on the listing, never the count: the
+devrc's 37 entries are therefore a FLOOR on the listing, never the count: the
 non-devrc entries are real, they are not readable from this repo, and no
 assertion here can see them.
 
-Two rounds of trimming plus one retirement round have narrowed devrc's share
+Two rounds of trimming plus one retirement round narrowed devrc's share
 (14,792 -> 13,925 -> 13,491 -> 12,679 as measured here) without ever closing the
 200k gap -- and retiring three whole unused skills bought only 812 chars, which
-is the honest measurement of how far this approach goes.
+is the honest measurement of how far this approach goes. ONE ADDITION
+(`subsystem-index`, #790) then put 182 of that back, taking the measure to
+12,861: the trimming approach is not merely slow, it is reversed by a single
+new skill. That is the argument the tier ledger exists to answer -- see
+`claude/skill-tiers.json` and `scripts/tests/test_skill_tiers.py`.
 
 🔴 So this ceiling is NOT "the listing fits" -- it demonstrably does not on 200k,
 and a gate pinned at the real 200k budget would be permanently red, which
@@ -202,7 +217,7 @@ SKILLS_DIR = REPO_ROOT / "claude" / "skills"
 # to make a description fit; cut the description.
 PER_ENTRY_CAP_CHARS = 1_536
 
-# Vacuity floor on the scan itself. 36 entries were measured at the time this
+# Vacuity floor on the scan itself. 37 entries were measured at the time this
 # gate was written; a glob that silently matches nothing would otherwise report a
 # clean sweep of an empty set -- the "reassuring zero" `claude/RULES.md` names.
 # Set below the measurement so adding or retiring a skill does not red the gate,
@@ -214,13 +229,28 @@ MIN_LISTING_ENTRIES = 30
 # 13,491 -- none of them dropping a trigger phrase or a disambiguation clause --
 # and retiring the three effectively-unused skills (`ux-sweep`,
 # `gpu-operator-check`, `session-audit` -- 0/0/1 recorded invocations, see the
-# docstring; plus ux-audit-loops' now-dangling pointer at the first) takes
-# it to 12,679 across 36 entries. The ceiling sits ~250 chars above that
-# measurement -- deliberately less than one average entry (12,679 / 36 = 352),
-# so a NEW skill cannot be added without an eviction in the SAME commit. That is
-# the same rule `claude/RULES.md` and
-# `scripts/browser-bridge/tests/test_skill_size.py` already apply to the other
-# two always-on documents.
+# docstring; plus ux-audit-loops' now-dangling pointer at the first) took
+# it to 12,679 across 36 entries, which is where this ceiling was set.
+#
+# 🔴 THE MEASURE IS NOW 12,861 ACROSS 37 ENTRIES, SO HEADROOM IS 68 -- NOT ~250.
+# `subsystem-index` (#790) arrived at 182 chars as this module measures and slid
+# straight through, because 182 < 250. That is not a bug in this constant; it is
+# the constant's actual contract, and the sentence that used to sit here --
+# "so a NEW skill cannot be added without an eviction in the SAME commit" --
+# CLAIMED COVERAGE THIS CODE DOES NOT PROVIDE. `claude/RULES.md` calls that worse
+# than no guard, because reading as coverage is what stops anyone looking.
+#
+# What it really does: headroom is set below the MEAN entry (12,679 / 36 = 352 at
+# the time), so it forces the eviction conversation for a TYPICAL new skill and
+# lets a small one through until the accumulated slack is gone. At 68 chars the
+# slack IS gone: the next addition of ANY size reds this gate. Do not read that
+# as the guard having tightened -- it is the same guard, at the end of its rope.
+#
+# 🔴 DO NOT "re-pin to the current measurement plus 250" -- that would RAISE this
+# number, which is the one thing the paragraph below forbids. Leave it at 12_929.
+# The structural answer to a listing that keeps regrowing is the tier ledger
+# (`claude/skill-tiers.json`, gated by `scripts/tests/test_skill_tiers.py`):
+# demote a skill to `name-only` and its entry stops being charged here at all.
 #
 # LOWER it when you cut; do NOT raise it to make a new description fit. A ceiling
 # left at the previous, larger number licenses exactly the regrowth this constant
@@ -458,7 +488,7 @@ def test_the_out_of_tree_ledger_matches_nix_home():
 def test_the_listing_total_does_not_regrow_past_its_ratchet():
     """🔴 The SUM, which the per-entry cap above structurally cannot see.
 
-    36 entries each comfortably under the 1,536-char per-entry cap still overrun
+    37 entries each comfortably under the 1,536-char per-entry cap still overrun
     the listing budget on a 200k window -- 1.61x on a claude-3.x..4.6 model,
     2.14x on claude-opus-5, because the budget's chars-per-token multiplier is
     model-dependent (4 vs 3). So the per-entry check can be green while
@@ -668,18 +698,23 @@ def test_control_the_total_ratchet_can_go_red():
     live_total = listing_total_chars(entries)
     assert live_total <= LISTING_TOTAL_CEILING_CHARS, "live tree already red"
 
-    # A new entry the size of the current mean. It must be enough on its own to
-    # breach the ceiling -- if it is not, the ratchet has been left so slack that
-    # a whole skill can be added for free, which is the failure mode it exists
-    # to prevent.
+    # A new entry the size of the current MEAN. It must be enough on its own to
+    # breach the ceiling -- if it is not, the ratchet has been left slack enough
+    # to absorb a typical whole skill unnoticed.
+    #
+    # 🔴 THIS PROVES NOTHING ABOUT A SMALL ENTRY, and that is not a hypothetical
+    # gap: `subsystem-index` (#790) was 182 chars and landed inside ~250 of
+    # headroom with no eviction, which is how headroom reached 68. The fixture is
+    # the mean ON PURPOSE -- building it from the smallest possible entry would
+    # grade a property this ceiling does not have and would be permanently red.
     mean = live_total // len(entries)
     newcomer = ("fixture/SKILL.md", "a-new-skill", "x" * (mean - len("a-new-skill")))
     assert entry_chars(newcomer[1], newcomer[2]) == mean
     assert listing_total_chars(entries + [newcomer]) > LISTING_TOTAL_CEILING_CHARS, (
         f"the ceiling has {LISTING_TOTAL_CEILING_CHARS - live_total} chars of "
         f"headroom, enough to absorb a whole {mean}-char entry unnoticed. "
-        "Re-tighten LISTING_TOTAL_CEILING_CHARS to the current measurement plus "
-        "less than one average entry."
+        "Cut descriptions, retire a skill, or demote one to tier B in "
+        "claude/skill-tiers.json -- do NOT raise LISTING_TOTAL_CEILING_CHARS."
     )
 
 

--- a/scripts/tests/test_skill_tiers.py
+++ b/scripts/tests/test_skill_tiers.py
@@ -64,21 +64,55 @@ import skill_tiers  # noqa: E402
 FACTS_READER = REPO_ROOT / "scripts" / "lib" / "skill_tier_facts.py"
 SYNC_SCRIPT = REPO_ROOT / "scripts" / "sync-skill-tiers.py"
 
-# Vacuity floor on the discovery itself. 36 entries were measured when this gate
+# Vacuity floor on the discovery itself. 37 entries were measured when this gate
 # was written; every assertion here is otherwise satisfied by an empty tree.
 MIN_SKILLS = 30
+
+# --------------------------------------------------------------------------- #
+# THE MEASUREMENT, PINNED
+#
+# 🔴 Every figure below is RECOMPUTED from the live tree by
+# `test_the_quoted_measurements_match_the_live_tree`, which prints the exact
+# replacement values when one drifts. They are quoted in the source so a reviewer
+# can see the ceiling was set from a real measurement rather than chosen — and
+# pinned so that audit trail cannot rot into a lie.
+#
+# This is deliberate friction: ADDING OR RETIRING A SKILL REDS THIS TEST, and the
+# fix is to copy the printed numbers. That is the point. The three transcribed
+# figures this replaced were each wrong within a day of being written — one was a
+# 36-entry total quoted in a 37-entry tree, and one contradicted the number the
+# same change reported to its reviewer.
+# --------------------------------------------------------------------------- #
+MEASURED_ENTRIES = 37
+MEASURED_TIER_A_ENTRIES = 24
+MEASURED_TIER_A_CHARS = 8_946
+# devrc's whole listing under the ledger (tier A in full, tier B name-only).
+MEASURED_UNDER_LEDGER_CHARS = 9_138
+# ...and what the same 37 entries would cost with every skill tier A. The
+# difference is what the ledger buys: 3,907 chars.
+MEASURED_ALL_TIER_A_CHARS = 13_045
 
 # 🔴 THE TIER-A RATCHET, in the REAL formula: the tier-A block cost
 # `sum(len(name) + 4 + min(len(desc), 1536)) + (n - 1)`.
 #
-# Measured at the commit that introduced the ledger: 24 tier-A entries, 8,946
-# chars (devrc's whole listing under the ledger is 9,120, down from 12,858 with
-# every skill tier A). The ceiling sits 254 chars above that — deliberately less
-# than one average tier-A entry (8,946 / 24 = 372) — so a NEW tier-A skill cannot
-# be added without an eviction or a demotion in the SAME commit. That is the rule
-# `claude/RULES.md`, `test_skill_descriptions.py` and
-# `scripts/browser-bridge/tests/test_skill_size.py` already apply to the other
-# always-on documents.
+# The ceiling sits 254 chars above MEASURED_TIER_A_CHARS — less than the MEAN
+# tier-A entry, which is 8,946 / 24 = 372.8.
+#
+# 🔴 READ WHAT THAT DOES AND DOES NOT BUY. A headroom below the mean bounds an
+# AVERAGE entry. It does NOT stop every addition, and the difference is not
+# academic:
+#   * a new tier-A skill whose entry is under 254 chars lands with NO eviction,
+#     and entries that small exist today — `handoff` is 205 and `audit-pr` 215;
+#   * the sibling ceiling in `test_skill_descriptions.py` has ALREADY been walked
+#     this way. `subsystem-index` arrived in #790 at 182 chars as that module
+#     measures, slipped inside its ~250 of headroom with no eviction, and took
+#     that headroom to 68.
+# So the honest claim is: this ceiling forces the eviction conversation for a
+# TYPICAL new skill, and a small one gets through until the accumulated slack
+# runs out. It is a ratchet on regrowth, not a per-addition gate. Do not restate
+# it as "a NEW skill cannot be added without an eviction" — that sentence claims
+# coverage this code does not provide, which `claude/RULES.md` calls worse than
+# no guard because it stops anyone looking.
 #
 # LOWER it when you cut; do NOT raise it to make a new description fit. Demoting
 # one skill to tier B in claude/skill-tiers.json is a ONE-LINE edit and is the
@@ -245,6 +279,50 @@ def test_the_symptom_routed_skills_stay_tier_a(ledger, skills, name):
     )
 
 
+def test_the_quoted_measurements_match_the_live_tree(ledger, skills):
+    """🔴 THE FIGURES IN THIS MODULE'S SOURCE ARE PINNED, NOT TRANSCRIBED.
+
+    A ceiling is only auditable if the reader can see what it was set from, so the
+    measurement is quoted at the top of this file. A quoted number nobody can
+    re-derive is exactly how the previous version shipped THREE wrong figures in
+    one comment — a 36-entry total quoted in a 37-entry tree, and a saving that
+    contradicted the number the same change reported to its reviewer.
+
+    This asserts each against the live computation and prints the replacements, in
+    the idiom `run-tests.sh` uses for its floors: resolve a drift by copying what
+    the failure says, never by arithmetic.
+    """
+    live = {
+        "MEASURED_ENTRIES": len(skills),
+        "MEASURED_TIER_A_ENTRIES": len(skill_tiers.tier_a_names(ledger)),
+        "MEASURED_TIER_A_CHARS": skill_tiers.tier_a_chars(ledger, skills),
+        "MEASURED_UNDER_LEDGER_CHARS": skill_tiers.devrc_listing_chars(ledger, skills),
+        "MEASURED_ALL_TIER_A_CHARS": skill_tiers.devrc_listing_chars(
+            {name: {"tier": "A"} for name in skills}, skills),
+    }
+    quoted = {
+        "MEASURED_ENTRIES": MEASURED_ENTRIES,
+        "MEASURED_TIER_A_ENTRIES": MEASURED_TIER_A_ENTRIES,
+        "MEASURED_TIER_A_CHARS": MEASURED_TIER_A_CHARS,
+        "MEASURED_UNDER_LEDGER_CHARS": MEASURED_UNDER_LEDGER_CHARS,
+        "MEASURED_ALL_TIER_A_CHARS": MEASURED_ALL_TIER_A_CHARS,
+    }
+    assert quoted == live, (
+        "the measurements quoted at the top of this module no longer describe the "
+        "tree. Copy these values in — do NOT recompute them by hand, and do not "
+        "adjust TIER_A_CEILING_CHARS to match unless you are deliberately "
+        "re-pinning the ratchet (raising it pays the saving back):\n"
+        + "\n".join(f"    {k} = {v:_}" for k, v in live.items())
+        + f"\n  the ledger saves {live['MEASURED_ALL_TIER_A_CHARS'] - live['MEASURED_UNDER_LEDGER_CHARS']:,} "
+        f"chars across {live['MEASURED_ENTRIES']} entries; the mean tier-A entry is "
+        f"{live['MEASURED_TIER_A_CHARS'] / live['MEASURED_TIER_A_ENTRIES']:.1f}, "
+        f"and TIER_A_CEILING_CHARS leaves "
+        f"{TIER_A_CEILING_CHARS - live['MEASURED_TIER_A_CHARS']} of headroom.\n"
+        "  🔴 Headroom below the mean bounds an AVERAGE entry, not every entry — "
+        "see the comment on TIER_A_CEILING_CHARS before claiming otherwise."
+    )
+
+
 def test_the_tier_a_cost_does_not_regrow_past_its_ratchet(ledger, skills):
     """🔴 THE RATCHET, in the REAL charging formula.
 
@@ -382,9 +460,17 @@ def test_control_the_tier_a_ratchet_can_go_red(ledger, skills):
     new tier-A skill — not a synthetic wall of text — because "someone adds a
     skill" is exactly how this ceiling gets breached.
 
-    It doubles as the headroom check: if one average entry does NOT breach it,
-    the ratchet has been left slack enough to absorb a whole skill unnoticed,
-    which is the failure mode it exists to prevent.
+    It doubles as the headroom check: if one MEAN-SIZED entry does not breach it,
+    the ratchet has been left slack enough to absorb a typical whole skill
+    unnoticed.
+
+    🔴 IT PROVES NOTHING ABOUT A SMALL ENTRY, and that gap is real rather than
+    theoretical — a tier-A skill under the current 254 chars of headroom lands
+    with no eviction, which is exactly how the sibling ceiling in
+    `test_skill_descriptions.py` went from ~250 of headroom to 68 when
+    `subsystem-index` arrived. The fixture is the mean deliberately: a control
+    built from the smallest possible entry would grade a property this ceiling
+    does not have.
     """
     live = skill_tiers.tier_a_chars(ledger, skills)
     assert live <= TIER_A_CEILING_CHARS, "live tree already red"

--- a/scripts/tests/test_skill_tiers.py
+++ b/scripts/tests/test_skill_tiers.py
@@ -1,0 +1,742 @@
+"""Gate on the SKILL-LISTING TIER LEDGER — `claude/skill-tiers.json`.
+
+WHAT THE MECHANISM IS
+---------------------
+Every skill's `name` + `description` loads on EVERY session under a budget of 1%
+of the context window, measured IN CHARACTERS. `skillOverrides` in
+settings.json makes that cost per-skill opt-in: a skill set to `name-only` costs
+`len(name) + 2` instead of `len(name) + 4 + len(desc)`, stays `/name`-invocable
+and stays callable by the Skill tool. What it loses is the ROUTING PROSE that
+makes it fire from a described symptom.
+
+`claude/skill-tiers.json` is devrc's ledger of that call, `scripts/
+sync-skill-tiers.py` applies it to a host, and `scripts/drift-check.sh` reports
+a host that has drifted from it (rc 22). This module gates the ledger itself.
+
+🔴 THE ONE PROPERTY THAT MAKES IT SCALE is the two-way pin below: every shipped
+skill has exactly one ledger entry and every ledger entry names a shipped skill.
+Without it the mechanism silently stops covering the tree the moment a skill is
+added — a new skill would just keep a full description and nothing would say so,
+which is precisely how a guard reads as coverage while providing none.
+
+WHY THE COST FORMULA HERE IS NOT THE ONE IN test_skill_descriptions.py
+---------------------------------------------------------------------
+That module deliberately measures the SMALLER number, `len(name) + len(desc)`,
+and its docstring says why it is left alone. What Claude Code actually charges,
+decompiled from the shipped binary (`claudedocs/proposal-skill-listing-tiers.md`
+section 1), is `len(name) + 4 + min(len(desc), 1536)` per entry plus one newline
+between entries — so the older measure undercounts by exactly `5n - 1`. That
+relationship is PINNED below rather than described, because it is the only thing
+keeping the two numbers legible as "two measures of one listing" rather than as
+a disagreement.
+
+🔴 A RATIO WITHOUT ITS MODEL IS MEANINGLESS, so this module quotes none. The
+budget is `floor(contextWindow * zx(model) * 0.01)` characters and `zx` is 4 for
+the 14 models up to 4.6 and **3 for claude-opus-5 and newer** — 6,000 at 200k and
+30,000 at 1M on this session's model, not 8,000 / 40,000. The ceiling below is a
+RATCHET on the number devrc controls, not a gate on any budget.
+
+WHY THE LEDGER IS DELIBERATELY CONSERVATIVE, AND WHY A TEST SAYS SO
+-------------------------------------------------------------------
+Measured 2026-08-24: the whole listing was 20,708 chars against a 30,000 budget
+on claude-opus-5 @1M — 0.69x. NOTHING is being truncated today. A wide tier B
+would trade real routing now for headroom ~1.8 months out, so the shipped tier B
+is small and every entry carries a rationale. `test_the_split_stays_conservative`
+pins that as a property, not as a paragraph nobody re-reads.
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "tests"))
+
+import skill_tiers  # noqa: E402
+
+FACTS_READER = REPO_ROOT / "scripts" / "lib" / "skill_tier_facts.py"
+SYNC_SCRIPT = REPO_ROOT / "scripts" / "sync-skill-tiers.py"
+
+# Vacuity floor on the discovery itself. 36 entries were measured when this gate
+# was written; every assertion here is otherwise satisfied by an empty tree.
+MIN_SKILLS = 30
+
+# 🔴 THE TIER-A RATCHET, in the REAL formula: the tier-A block cost
+# `sum(len(name) + 4 + min(len(desc), 1536)) + (n - 1)`.
+#
+# Measured at the commit that introduced the ledger: 24 tier-A entries, 8,946
+# chars (devrc's whole listing under the ledger is 9,120, down from 12,858 with
+# every skill tier A). The ceiling sits 254 chars above that — deliberately less
+# than one average tier-A entry (8,946 / 24 = 372) — so a NEW tier-A skill cannot
+# be added without an eviction or a demotion in the SAME commit. That is the rule
+# `claude/RULES.md`, `test_skill_descriptions.py` and
+# `scripts/browser-bridge/tests/test_skill_size.py` already apply to the other
+# always-on documents.
+#
+# LOWER it when you cut; do NOT raise it to make a new description fit. Demoting
+# one skill to tier B in claude/skill-tiers.json is a ONE-LINE edit and is the
+# intended move. The playbook is printed by the failing assertion below.
+TIER_A_CEILING_CHARS = 9_200
+
+# 🔴 Skills that must NEVER be tier B, pinned as a RELATIONSHIP rather than left
+# to review. Each one fires from a SYMPTOM Zach describes rather than from its own
+# name, so name-only would silently delete the only thing that routes it:
+#
+#   dl-router   "downloads are landing in the wrong folder" — and it looks dead
+#               to Claude Code's usage counter while running as a live systemd
+#               service, which is exactly how it would get demoted by mistake.
+#   browser     "look at the page I have open"
+#   clickup     a pasted app.clickup.com link, with four confusable siblings
+#   mailbox     "email someone on my behalf"
+#   vetr-mailbox  the OTHER side of that prompt. Name-only, "email them on my
+#               behalf" routes to `mailbox` and sends from a different account:
+#               a mis-route that takes a WRONG ACTION, not one that degrades an
+#               answer. That distinction is the ledger's stated tie-break.
+#   session-manager  "is anything waiting on me"
+#   obs-read    "is it actually zero or did my query miss"
+#
+# This is not a restatement of the ledger — it is the subset whose tier is a
+# safety property, and it fails if any of them is ever flipped.
+MUST_AUTO_FIRE = (
+    "dl-router", "browser", "clickup", "mailbox", "vetr-mailbox",
+    "session-manager", "obs-read",
+)
+
+
+@pytest.fixture(scope="module")
+def ledger():
+    return skill_tiers.load_ledger()
+
+
+@pytest.fixture(scope="module")
+def skills():
+    return skill_tiers.shipped_skills()
+
+
+# --------------------------------------------------------------------------- #
+# The live tree
+# --------------------------------------------------------------------------- #
+
+def test_the_scan_finds_the_skills_at_all(skills):
+    """POSITIVE CONTROL on discovery. Every other assertion in this module is a
+    reassuring ZERO, and a zero from a scan that walked nothing is
+    indistinguishable from a clean sweep."""
+    assert len(skills) >= MIN_SKILLS, (
+        f"only {len(skills)} shipped skills found, below the {MIN_SKILLS} "
+        "vacuity floor. Every check here would otherwise pass over an "
+        "almost-empty set. Fix the discovery path in scripts/lib/skill_tiers.py."
+    )
+
+
+def test_every_shipped_skill_has_exactly_one_ledger_entry(ledger, skills):
+    """🔴 THE TWO-WAY PIN. The property that makes this mechanism scale.
+
+    Fails when the set GROWS (a skill is added and nobody tiered it, so it
+    silently keeps a full description) and when it SHRINKS (a ledger entry names
+    a skill that was renamed or retired, so the override is dead config nobody
+    can observe). Adding a skill is therefore a deliberate tiering decision, in
+    the same commit, forever.
+    """
+    untiered, phantom = skill_tiers.reconcile(ledger, skills)
+    assert not untiered and not phantom, (
+        "claude/skill-tiers.json and the shipped skills disagree.\n"
+        f"  shipped but NOT tiered (keeps a full description in silence): {untiered}\n"
+        f"  tiered but NOT shipped (a dead override): {phantom}\n"
+        "\nAdd or remove the entry in claude/skill-tiers.json, in THIS commit.\n"
+        '  tier A: {"tier": "A"}                       — keeps its description\n'
+        '  tier B: {"tier": "B", "why": "<one line>"}  — name-only\n'
+        "Choose by whether the skill must AUTO-FIRE from a symptom Zach "
+        "describes, never by how often it has been invoked: `dl-router` runs as "
+        "a live systemd service and `adoption-scan` has 20,494 tool-invocation "
+        "events, and Claude Code's counter reports 0 skill invocations for both."
+    )
+
+
+def test_the_two_discovery_paths_agree(skills):
+    """🔴 SEAM GUARD. Two modules find the listing entries independently.
+
+    `skill_tiers.skill_md_paths` DERIVES the out-of-tree skills from
+    nix/home.nix; `test_skill_descriptions.OUT_OF_TREE_SKILLS` is a hand-kept
+    list of the same files (which fell a whole entry behind once, leaving
+    `opencode` unmeasured while every check stayed green). Each is verified
+    against nix/home.nix on its own; nothing checked them against EACH OTHER, and
+    a defect in the seam is invisible to both.
+    """
+    import test_skill_descriptions as tsd
+    other = {name for _, name, _ in tsd._entries()}
+    assert set(skills) == other, (
+        "the two discovery paths disagree about which skills are listing "
+        "entries.\n"
+        f"  only skill_tiers sees: {sorted(set(skills) - other)}\n"
+        f"  only test_skill_descriptions sees: {sorted(other - set(skills))}\n"
+        "One of them is measuring less than it claims. Fix the one that is "
+        "wrong — do not relax this."
+    )
+
+
+def test_every_tier_b_entry_carries_a_rationale(ledger):
+    """A tier-B call is a routing decision someone has to be able to audit.
+
+    `load_ledger` refuses a rationale-less tier-B entry, so this asserts the
+    LIVE ledger reaches that bar rather than that the parser exists.
+    """
+    thin = sorted(n for n in skill_tiers.tier_b_names(ledger)
+                  if len(str(ledger[n]["why"]).strip()) < 20)
+    assert not thin, (
+        f"these tier-B entries have a `why` too short to audit: {thin}. Say what "
+        "Zach types to reach the skill, or why no symptom routes to it."
+    )
+    assert all("why" not in ledger[n] for n in skill_tiers.tier_a_names(ledger)), (
+        "a tier-A entry carries a `why`. A is the DEFAULT — a rationale for a "
+        "default is noise that makes the tier-B rationales harder to find."
+    )
+
+
+def test_only_tier_b_gets_an_override_and_it_is_name_only(ledger):
+    """🔴 The projection is `name-only`, never `off` or `user-invocable-only`.
+
+    Those two REMOVE the skill from the model's reach. Tiering is a routing
+    decision and must never become a disabling one — if a skill should be off,
+    delete it. Tier A is written as ABSENCE rather than `"on"`: `on` is already
+    the default, so emitting it would add a line per skill that says nothing.
+    """
+    want = skill_tiers.expected_overrides(ledger)
+    assert set(want) == set(skill_tiers.tier_b_names(ledger))
+    assert set(want.values()) == {"name-only"}, sorted(set(want.values()))
+    assert "name-only" in skill_tiers.VALID_OVERRIDE_VALUES
+    for name in skill_tiers.tier_a_names(ledger):
+        assert name not in want, f"tier-A skill {name} got an override"
+
+
+def test_the_split_stays_conservative(ledger, skills):
+    """🔴 The ledger shipped SMALL on purpose, and that is a property, not prose.
+
+    Nothing is being truncated today (measured: 20,708 chars against a 30,000
+    budget on claude-opus-5 @1M). A wide tier B would delete real routing now for
+    headroom ~1.8 months out. If a future change wants a majority of skills
+    name-only, that is a deliberate decision and this assertion is where it gets
+    argued — not a thing that happens one entry at a time.
+    """
+    b = skill_tiers.tier_b_names(ledger)
+    assert len(b) * 2 < len(skills), (
+        f"{len(b)} of {len(skills)} skills are tier B — a majority-name-only "
+        "listing. That is a strategy change, not an increment: argue it here, "
+        "and re-read the runway argument in "
+        "claudedocs/proposal-skill-listing-tiers.md section 3 first."
+    )
+
+
+@pytest.mark.parametrize("name", MUST_AUTO_FIRE)
+def test_the_symptom_routed_skills_stay_tier_a(ledger, skills, name):
+    """Each of these fires from something Zach DESCRIBES, not from its own name.
+    See MUST_AUTO_FIRE for the per-skill reason."""
+    assert name in skills, f"{name} is not a shipped skill any more"
+    assert skill_tiers.tier_of(ledger, name) == "A", (
+        f"`{name}` was demoted to tier B. It routes from a SYMPTOM, not from its "
+        "name, so name-only deletes the only thing that reaches it. See "
+        "MUST_AUTO_FIRE in this module for why this one is on the list."
+    )
+
+
+def test_the_tier_a_cost_does_not_regrow_past_its_ratchet(ledger, skills):
+    """🔴 THE RATCHET, in the REAL charging formula.
+
+    The per-entry cap that `test_skill_descriptions.py` gates is a PER-ENTRY
+    limit; nothing there measures what tier A costs as a block, and tier A is the
+    part of the listing devrc still pays for on every session.
+    """
+    total = skill_tiers.tier_a_chars(ledger, skills)
+    a = skill_tiers.tier_a_names(ledger)
+    assert total <= TIER_A_CEILING_CHARS, (
+        f"tier A costs {total:,} chars across {len(a)} entries, over the "
+        f"{TIER_A_CEILING_CHARS:,}-char ratchet by {total - TIER_A_CEILING_CHARS:,}.\n"
+        "This loads on EVERY session and overflows SILENTLY — Claude Code drops "
+        "descriptions starting with the skills invoked least, taking their "
+        "trigger keywords with them, with no error.\n"
+        "\nPLAYBOOK — do these in order, in THIS commit:\n"
+        "  1. DEMOTE a tier-A skill that Zach reaches for BY NAME. One line in "
+        "claude/skill-tiers.json: {\"tier\": \"B\", \"why\": \"…\"}. This is the "
+        "move the mechanism exists for and it costs ~350 chars each.\n"
+        "  2. Cut mechanism prose out of the costliest descriptions below. A "
+        "description is ROUTING SURFACE; how it works belongs in the body, which "
+        "costs 0 until the skill is invoked.\n"
+        "  3. Do NOT drop a trigger phrase or a disambiguation clause to fit — "
+        "that trades a silent overflow for a silent mis-route.\n"
+        "  4. Do NOT raise TIER_A_CEILING_CHARS. Raising it pays the cost back "
+        "and is what this constant exists to prevent.\n"
+        "\ncostliest tier-A entries now:\n"
+        + "\n".join(f"  {n:26} {c:,} chars"
+                    for n, c in skill_tiers.costliest(ledger, skills))
+    )
+
+
+def test_the_ledger_json_is_readable_by_a_human_reviewer():
+    """The file is data, but it is also the artefact a reviewer reads. Its `_doc`
+    must survive, because everything explaining the tie-break lives there."""
+    data = json.loads(skill_tiers.LEDGER_PATH.read_text(encoding="utf-8"))
+    doc = data.get("_doc")
+    assert isinstance(doc, list) and len(" ".join(doc)) > 400, (
+        "claude/skill-tiers.json lost its `_doc`. That block carries the "
+        "auto-fire question, the mis-route tie-break and the measurement that "
+        "makes the conservative split defensible."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The FACTS READER — the projection drift-check.sh consumes
+# --------------------------------------------------------------------------- #
+
+def _reader(*args):
+    return subprocess.run([sys.executable, str(FACTS_READER), *args],
+                          capture_output=True, text=True)
+
+
+def test_the_facts_reader_projects_the_live_ledger(ledger):
+    proc = _reader()
+    assert proc.returncode == 0, proc.stderr
+    tokens = proc.stdout.split()
+    assert tokens[0] == "ok"
+    assert set(tokens[1:]) == {f"{n}=name-only"
+                               for n in skill_tiers.tier_b_names(ledger)}
+
+
+@pytest.mark.parametrize("body,expect", [
+    (None, "err ledger-absent"),
+    ("{ not json", "err ledger-malformed"),
+    ('{"skills": {}}', "err ledger-malformed"),
+    ('{"skills": {"x": {"tier": "Q"}}}', "err ledger-malformed"),
+    ('{"skills": {"x": {"tier": "B"}}}', "err ledger-malformed"),
+])
+def test_control_the_facts_reader_errs_rather_than_projecting_nothing(
+        tmp_path, body, expect):
+    """🔴 NEGATIVE CONTROL, and the one that matters most for the drift arm.
+
+    An empty expectation makes EVERY host look compliant, in silence. So each way
+    the ledger can be unusable must produce `err <token>` and a non-zero exit —
+    never a bare `ok` with no names. The fixtures are the real failure shapes: a
+    missing file, unparseable JSON, an empty ledger, a bad tier, and a tier-B
+    entry with no rationale.
+    """
+    path = tmp_path / "ledger.json"
+    if body is not None:
+        path.write_text(body, encoding="utf-8")
+    proc = _reader(str(path))
+    assert proc.returncode == 1, proc.stdout
+    assert proc.stderr.strip() == expect, proc.stderr
+    assert proc.stdout.strip() == "", (
+        "the reader printed an expectation while reporting an error — a "
+        "consumer that reads stdout would treat it as authoritative"
+    )
+
+
+def test_control_the_facts_reader_can_project_a_fixture(tmp_path):
+    """POSITIVE CONTROL for the same path: the reader is shown to emit a NON-EMPTY
+    projection from a ledger it has never seen, so the `err` results above are
+    not simply "it can never succeed"."""
+    path = tmp_path / "ledger.json"
+    path.write_text(json.dumps({"skills": {
+        "aaa": {"tier": "B", "why": "a fixture rationale long enough to pass"},
+        "bbb": {"tier": "A"},
+        "ccc": {"tier": "B", "why": "a second fixture rationale, also long"},
+    }}), encoding="utf-8")
+    proc = _reader(str(path))
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.split() == ["ok", "aaa=name-only", "ccc=name-only"]
+
+
+# --------------------------------------------------------------------------- #
+# CONTROLS on the two-way pin and the cost model
+# --------------------------------------------------------------------------- #
+
+def test_control_the_two_way_pin_detects_an_untiered_skill(ledger, skills):
+    """POSITIVE CONTROL, direction 1. Isolated mutation: ONE extra shipped skill,
+    the ledger untouched."""
+    mutated = dict(skills)
+    mutated["a-brand-new-skill"] = ("claude/skills/a-brand-new-skill/SKILL.md", "x")
+    untiered, phantom = skill_tiers.reconcile(ledger, mutated)
+    assert untiered == ["a-brand-new-skill"], untiered
+    assert phantom == [], phantom
+
+
+def test_control_the_two_way_pin_detects_a_ledger_entry_pointing_at_nothing(
+        ledger, skills):
+    """POSITIVE CONTROL, direction 2. Isolated the other way: ONE extra ledger
+    entry, the tree untouched. Both directions are needed — a pin that only
+    catches growth keeps passing while a rename leaves a dead override behind."""
+    mutated = dict(ledger)
+    mutated["a-retired-skill"] = {"tier": "B", "why": "a fixture rationale here"}
+    untiered, phantom = skill_tiers.reconcile(mutated, skills)
+    assert phantom == ["a-retired-skill"], phantom
+    assert untiered == [], untiered
+
+
+def test_control_the_tier_a_ratchet_can_go_red(ledger, skills):
+    """🔴 NEGATIVE CONTROL, built from the REAL tree plus ONE realistically-sized
+    new tier-A skill — not a synthetic wall of text — because "someone adds a
+    skill" is exactly how this ceiling gets breached.
+
+    It doubles as the headroom check: if one average entry does NOT breach it,
+    the ratchet has been left slack enough to absorb a whole skill unnoticed,
+    which is the failure mode it exists to prevent.
+    """
+    live = skill_tiers.tier_a_chars(ledger, skills)
+    assert live <= TIER_A_CEILING_CHARS, "live tree already red"
+
+    n_a = len(skill_tiers.tier_a_names(ledger))
+    mean = live // n_a
+    name = "a-new-skill"
+    mutated_skills = dict(skills)
+    mutated_skills[name] = ("fixture/SKILL.md", "x" * (mean - len(name) - 4))
+    mutated_ledger = dict(ledger)
+    mutated_ledger[name] = {"tier": "A"}
+    assert skill_tiers.entry_chars(name, mutated_skills[name][1]) == mean
+    grown = skill_tiers.tier_a_chars(mutated_ledger, mutated_skills)
+    assert grown > TIER_A_CEILING_CHARS, (
+        f"the ceiling has {TIER_A_CEILING_CHARS - live} chars of headroom, "
+        f"enough to absorb a whole {mean}-char tier-A entry unnoticed. "
+        "Re-tighten TIER_A_CEILING_CHARS to the current measurement plus less "
+        "than one average entry."
+    )
+
+
+def test_control_demoting_one_skill_moves_the_number(ledger, skills):
+    """🔴 ISOLATED MUTATION on the tier itself, and the claim the whole mechanism
+    rests on: flipping ONE entry to tier B must drop the tier-A cost by that
+    entry's full description.
+
+    Without this, a `tier_a_chars` that ignored the tier and summed every skill
+    would satisfy every other assertion here.
+    """
+    victim = "clickup"
+    assert skill_tiers.tier_of(ledger, victim) == "A"
+    before = skill_tiers.tier_a_chars(ledger, skills)
+    mutated = dict(ledger)
+    mutated[victim] = {"tier": "B", "why": "a fixture rationale, long enough"}
+    after = skill_tiers.tier_a_chars(mutated, skills)
+    # One entry leaves the block, so its cost AND its separator go with it.
+    expected = before - skill_tiers.entry_chars(victim, skills[victim][1]) - 1
+    assert after == expected, (before, after, expected)
+    # ...and it reappears in the tier-B block at the name-only price.
+    assert (skill_tiers.tier_b_chars(mutated, skills)
+            - skill_tiers.tier_b_chars(ledger, skills)
+            == skill_tiers.name_only_chars(victim) + 1)
+
+
+def test_the_real_formula_exceeds_the_older_gate_measure_by_5n_minus_1(skills):
+    """🔴 PINS THE RELATIONSHIP between the two measures of one listing.
+
+    `test_skill_descriptions.listing_total_chars` sums `len(name) + len(desc)`;
+    the real charge adds 4 per entry plus one separator between entries. The
+    difference is therefore exactly `5n - 1`, and that identity is what makes the
+    two numbers legible as two measures rather than as a disagreement. It holds
+    only while no description exceeds the per-entry cap, which is asserted first
+    rather than assumed.
+    """
+    import test_skill_descriptions as tsd
+    entries = tsd._entries()
+    assert all(len(d) <= skill_tiers.PER_ENTRY_CAP_CHARS for _, _, d in entries)
+    n = len(entries)
+    all_tier_a = {name: {"tier": "A"} for name in skills}
+    real = skill_tiers.devrc_listing_chars(all_tier_a, skills)
+    assert real - tsd.listing_total_chars(entries) == 5 * n - 1, (
+        f"the two measures differ by {real - tsd.listing_total_chars(entries)}, "
+        f"not the {5 * n - 1} the decompiled formula predicts at {n} entries. "
+        "One of them has changed shape."
+    )
+
+
+def test_control_entry_chars_caps_at_the_per_entry_cap():
+    """Boundary, both sides. A description AT the cap is charged in full; one
+    over it is charged the cap, because upstream truncates rather than growing."""
+    cap = skill_tiers.PER_ENTRY_CAP_CHARS
+    assert skill_tiers.entry_chars("ab", "x" * cap) == 2 + 4 + cap
+    assert skill_tiers.entry_chars("ab", "x" * (cap + 5000)) == 2 + 4 + cap
+    assert skill_tiers.entry_chars("ab", "x" * (cap - 1)) == 2 + 4 + cap - 1
+
+
+def test_control_the_block_costs_are_sums_not_maxima():
+    """ISOLATED mutation guard. Fixture values are pairwise distinct AND distinct
+    from every constant this module names (1536, 9200, 4, 2), so a mutant that
+    returns `max(...)`, the entry count, or a hardcoded constant lands on a
+    different answer. The bounds deliberately overshoot rather than sitting on a
+    multiple of the +4/+2 step."""
+    fx_skills = {
+        "aa": ("a/SKILL.md", "x" * 301),
+        "bbb": ("b/SKILL.md", "x" * 503),
+        "cccc": ("c/SKILL.md", "x" * 707),
+    }
+    a_only = {"aa": {"tier": "A"}, "bbb": {"tier": "A"}, "cccc": {"tier": "A"}}
+    # 2+4+301 + 3+4+503 + 4+4+707 = 307 + 510 + 719 = 1536... deliberately NOT:
+    assert skill_tiers.entry_chars("aa", fx_skills["aa"][1]) == 307
+    assert skill_tiers.entry_chars("bbb", fx_skills["bbb"][1]) == 510
+    assert skill_tiers.entry_chars("cccc", fx_skills["cccc"][1]) == 715
+    assert skill_tiers.tier_a_chars(a_only, fx_skills) == 307 + 510 + 715 + 2
+
+    b_only = {n: {"tier": "B", "why": "fixture rationale long enough here"}
+              for n in fx_skills}
+    assert skill_tiers.tier_b_chars(b_only, fx_skills) == 4 + 5 + 6 + 2
+    assert skill_tiers.tier_a_chars(b_only, fx_skills) == 0
+    assert skill_tiers.tier_b_chars(a_only, fx_skills) == 0
+
+
+def test_control_a_malformed_ledger_is_refused_in_process(tmp_path):
+    """The parser's own negative controls, graded through `load_ledger` so a
+    mutation there moves a verdict here."""
+    def w(obj):
+        p = tmp_path / "l.json"
+        p.write_text(json.dumps(obj), encoding="utf-8")
+        return p
+
+    with pytest.raises(ValueError, match="skills"):
+        skill_tiers.load_ledger(w({"nope": {}}))
+    with pytest.raises(ValueError, match="EMPTY"):
+        skill_tiers.load_ledger(w({"skills": {}}))
+    with pytest.raises(ValueError, match="tier"):
+        skill_tiers.load_ledger(w({"skills": {"x": {"tier": "C"}}}))
+    with pytest.raises(ValueError, match="why"):
+        skill_tiers.load_ledger(w({"skills": {"x": {"tier": "B"}}}))
+    with pytest.raises(ValueError, match="not an object"):
+        skill_tiers.load_ledger(w({"skills": {"x": "B"}}))
+    # ...and a well-formed one is accepted, so the above are not vacuous.
+    ok = skill_tiers.load_ledger(w({"skills": {
+        "x": {"tier": "B", "why": "a rationale long enough to be auditable"},
+        "y": {"tier": "A"},
+    }}))
+    assert skill_tiers.tier_b_names(ok) == ["x"]
+
+
+# --------------------------------------------------------------------------- #
+# scripts/sync-skill-tiers.py
+# --------------------------------------------------------------------------- #
+
+def _sync_module():
+    loader = importlib.machinery.SourceFileLoader("_sync_skill_tiers",
+                                                  str(SYNC_SCRIPT))
+    spec = importlib.util.spec_from_loader("_sync_skill_tiers", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+sync = _sync_module()
+
+
+@pytest.fixture(autouse=True)
+def _no_reading_the_operators_machine(tmp_path, monkeypatch):
+    """🔴 HERMETICITY SEAM. `main()` consults `~/.claude.json` (the operator's real
+    project list) and `~/.claude/plugins` by default. Left alone, these tests
+    would walk the operator's own checkouts — and the control that proves the
+    project scan CAN see an overriding entry would be measuring their machine
+    rather than its own fixture. Both are pointed at paths that do not exist;
+    the plugin scan is exercised against a fixture tree of its own below.
+    """
+    monkeypatch.setattr(sync, "CLAUDE_JSON", tmp_path / "no-claude.json")
+    monkeypatch.setattr(sync, "PLUGINS_DIR", tmp_path / "no-plugins")
+
+
+def test_plugin_skill_names_reads_a_plugin_tree(tmp_path, monkeypatch):
+    """POSITIVE CONTROL for the dead-config warning. The resolver hard-returns
+    `"on"` for a plugin skill, so a ledger entry naming one would never take
+    effect — the scan that notices has to be shown able to see a plugin skill at
+    all, or its silence means nothing."""
+    monkeypatch.setattr(sync, "PLUGINS_DIR", tmp_path)
+    p = tmp_path / "marketplace" / "somepack" / "skills" / "dataviz"
+    p.mkdir(parents=True)
+    (p / "SKILL.md").write_text("---\nname: dataviz\n---\n", encoding="utf-8")
+    assert sync.plugin_skill_names() == {"dataviz"}
+    monkeypatch.setattr(sync, "PLUGINS_DIR", tmp_path / "gone")
+    assert sync.plugin_skill_names() == set()
+
+
+def _settings(tmp_path, body):
+    p = tmp_path / "settings.json"
+    p.write_text(json.dumps(body, indent=2) + "\n", encoding="utf-8")
+    return p
+
+
+def _run_sync(path, tmp_path, *extra):
+    """Never without --settings and --project-root. The default settings path is
+    the OPERATOR'S LIVE FILE, and the default project root is their real
+    workspace; a test that omits either is a test that writes to, or walks, the
+    machine it is running on."""
+    empty = tmp_path / "no-projects"
+    empty.mkdir(exist_ok=True)
+    return sync.main(["--settings", str(path), "--project-root", str(empty), *extra])
+
+
+def test_the_sync_script_defaults_to_dry_run(tmp_path, capsys):
+    """🔴 THE SAFETY PROPERTY. Applying the ledger is an operator act on a
+    per-host, unmanaged file — it must never be a side effect of running the
+    tool. Graded on the FILE BYTES, not on the absence of a message."""
+    path = _settings(tmp_path, {"theme": "dark"})
+    before = path.read_bytes()
+    assert _run_sync(path, tmp_path) == 0
+    assert path.read_bytes() == before, "a default run WROTE to settings.json"
+    out = capsys.readouterr().out
+    assert "DRY RUN" in out and "--apply" in out, out
+
+
+def test_the_sync_script_writes_only_under_apply(tmp_path, ledger, capsys):
+    path = _settings(tmp_path, {"theme": "dark", "permissions": {"allow": ["Bash(ls:*)"]}})
+    assert _run_sync(path, tmp_path, "--apply") == 0
+    capsys.readouterr()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["skillOverrides"] == skill_tiers.expected_overrides(ledger)
+    # Every other key survives byte-for-byte in value.
+    assert data["theme"] == "dark"
+    assert data["permissions"] == {"allow": ["Bash(ls:*)"]}
+    # ...and it is idempotent.
+    assert _run_sync(path, tmp_path, "--apply") == 0
+    assert "already in sync" in capsys.readouterr().out
+
+
+def test_the_sync_script_merges_into_an_existing_key_rather_than_clobbering(
+        tmp_path, ledger, capsys):
+    """A host may already carry overrides this ledger says nothing about —
+    a hand-set `off` on a bundled skill, say. Wiping the key would silently
+    re-enable it."""
+    path = _settings(tmp_path, {"skillOverrides": {"dataviz": "off"}})
+    assert _run_sync(path, tmp_path, "--apply") == 0
+    out = capsys.readouterr().out
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["skillOverrides"]["dataviz"] == "off", "an untiered entry was lost"
+    for name in skill_tiers.tier_b_names(ledger):
+        assert data["skillOverrides"][name] == "name-only"
+    assert "not tiered by the ledger, untouched" in out, out
+
+
+def test_the_sync_script_leaves_a_conflicting_value_alone_unless_forced(
+        tmp_path, ledger, capsys):
+    """A hand-set value for a TIERED skill is somebody's decision. Quietly
+    promoting an `off` to `name-only` would re-enable a skill they hid."""
+    victim = skill_tiers.tier_b_names(ledger)[0]
+    path = _settings(tmp_path, {"skillOverrides": {victim: "off"}})
+    assert _run_sync(path, tmp_path, "--apply") == 0
+    out = capsys.readouterr().out
+    assert json.loads(path.read_text())["skillOverrides"][victim] == "off", out
+    assert "LEAVING ALONE" in out, out
+
+    assert _run_sync(path, tmp_path, "--apply", "--force-value") == 0
+    out = capsys.readouterr().out
+    assert json.loads(path.read_text())["skillOverrides"][victim] == "name-only"
+    assert "OVERWRITING" in out, out
+
+
+def test_the_sync_script_refuses_a_settings_file_it_cannot_understand(tmp_path):
+    bad = tmp_path / "settings.json"
+    bad.write_text("{ not json", encoding="utf-8")
+    assert _run_sync(bad, tmp_path) == 4
+    bad.write_text(json.dumps({"skillOverrides": ["a", "list"]}), encoding="utf-8")
+    assert _run_sync(bad, tmp_path) == 4
+    assert _run_sync(tmp_path / "absent.json", tmp_path) == 3
+
+
+def test_the_sync_script_refuses_when_the_ledger_and_the_tree_disagree(
+        tmp_path, monkeypatch, ledger):
+    """🔴 NEGATIVE CONTROL on the refusal. Two-way, and each direction on its own.
+
+    Isolated mutation: only the ledger moves; the tree, the settings file and the
+    flags are untouched, so the exit 2 can only come from the reconciliation.
+    """
+    path = _settings(tmp_path, {"theme": "dark"})
+    before = path.read_bytes()
+
+    phantom = dict(ledger)
+    phantom["not-a-real-skill"] = {"tier": "B", "why": "a fixture rationale here"}
+    monkeypatch.setattr(sync.skill_tiers, "load_ledger", lambda *a, **k: phantom)
+    assert _run_sync(path, tmp_path, "--apply") == 2
+    assert path.read_bytes() == before, "it wrote despite refusing"
+
+    short = {n: e for n, e in ledger.items() if n != "clickup"}
+    monkeypatch.setattr(sync.skill_tiers, "load_ledger", lambda *a, **k: short)
+    assert _run_sync(path, tmp_path, "--apply") == 2
+    assert path.read_bytes() == before
+
+    # ...and with the real ledger restored it proceeds, so the two refusals above
+    # are not simply "this fixture never works".
+    monkeypatch.undo()
+    assert _run_sync(path, tmp_path, "--apply") == 0
+
+
+def test_control_the_project_scope_scan_can_actually_see_an_override(tmp_path):
+    """🔴 POSITIVE CONTROL, and the reason the live run's reassuring zero is
+    quotable at all.
+
+    `~/.claude/settings.json` is the LOWEST-precedence ordinary scope: settings
+    merge user -> project -> local, later wins, per-key. A `skillOverrides` entry
+    in any project's own settings BEATS the ledger there, silently. The scan that
+    looks for those reports a count, and a count from a scan wired to nothing is
+    indistinguishable from a clean fleet — so it is shown here finding one.
+    """
+    root = tmp_path / "workspace"
+    proj = root / "some-repo" / ".claude"
+    proj.mkdir(parents=True)
+    (proj / "settings.json").write_text(
+        json.dumps({"skillOverrides": {"prune-index": "off"}}), encoding="utf-8")
+    (proj / "settings.local.json").write_text(
+        json.dumps({"skillOverrides": {"sglang": "on"}}), encoding="utf-8")
+    # A project with no overrides at all, so "files read" exceeds "hits".
+    quiet = root / "quiet-repo" / ".claude"
+    quiet.mkdir(parents=True)
+    (quiet / "settings.json").write_text(json.dumps({"theme": "dark"}),
+                                         encoding="utf-8")
+
+    hits, read = sync.overriding_scopes({"prune-index", "sglang"}, [root])
+    assert read == 3, f"the scan opened {read} files, not the 3 it was given"
+    assert sorted((p.name, n, v) for p, n, v in hits) == [
+        ("settings.json", "prune-index", "off"),
+        ("settings.local.json", "sglang", "on"),
+    ], hits
+
+    # NEGATIVE half of the same control: a name the ledger does not tier is not
+    # reported, so the scan is matching the ledger rather than any override.
+    hits2, read2 = sync.overriding_scopes({"handoff"}, [root])
+    assert read2 == 3 and hits2 == [], hits2
+
+
+def test_the_project_scan_survives_a_directory_it_cannot_stat(tmp_path):
+    """🔴 RED-AT-BASE, kept as a test rather than as a line in a commit message.
+
+    The FIRST live run of this script died with a `PermissionError` traceback
+    from `Path.is_dir()` — `/tmp` holds root-owned mode-700
+    `systemd-private-*` directories, and the scan walked into one. It died AFTER
+    printing the ledger summary, so the output up to that point read like a
+    completed run.
+
+    The fixture reproduces it exactly: an unreadable project directory beside a
+    readable one that DOES carry an overriding entry, so this cannot pass by the
+    scan degrading to finding nothing.
+    """
+    root = tmp_path / "workspace"
+    blind = root / "unreadable"
+    blind.mkdir(parents=True)
+    (blind / ".claude").mkdir()
+    blind.chmod(0o000)
+    good = root / "visible" / ".claude"
+    good.mkdir(parents=True)
+    (good / "settings.json").write_text(
+        json.dumps({"skillOverrides": {"sglang": "off"}}), encoding="utf-8")
+    try:
+        hits, read = sync.overriding_scopes({"sglang"}, [root])
+    finally:
+        blind.chmod(0o700)
+    assert read == 1, f"the readable project was not scanned: read={read}"
+    assert [(p.name, n, v) for p, n, v in hits] == [
+        ("settings.json", "sglang", "off")], hits
+
+
+def test_control_the_project_scan_reports_zero_files_when_there_are_none(tmp_path):
+    """The other side: an empty root yields `read == 0`, which the caller prints
+    beside the findings so "no overriding scopes" and "nothing was looked at"
+    can never read the same way."""
+    root = tmp_path / "empty"
+    root.mkdir()
+    hits, read = sync.overriding_scopes({"prune-index"}, [root])
+    assert (hits, read) == ([], 0)


### PR DESCRIPTION
Implements the mechanism `claudedocs/proposal-skill-listing-tiers.md` recommends. **It lands the tooling; it does not flip the switch.**

## What lands

| | |
|---|---|
| `claude/skill-tiers.json` | the ledger — every skill is tier A (full description) or tier B (`name-only`), every tier-B entry carries a one-line rationale |
| `scripts/sync-skill-tiers.py` | applies it to a host. **Defaults to dry-run**; `--apply` writes |
| `scripts/lib/skill_tiers.py` | the one parser + discovery + the real cost formula, shared by all three consumers |
| `scripts/lib/skill_tier_facts.py` | projects the ledger for `drift-check.sh` — so the checker and the writer cannot disagree about what the ledger says |
| `scripts/drift-check.sh` | **rc 22** — a host whose deployed `skillOverrides` disagree with the ledger |
| `scripts/tests/test_skill_tiers.py` | the two-way pin, the tier-A ratchet, the controls (40 tests) |
| `scripts/tests/test_drift_check.py` | +14 tests for the new arm |

## The split

**24 tier A / 13 tier B of 37 skills.** Tier A costs **8,946 chars** in the real charging formula (`len(name) + 4 + min(len(desc), 1536)`, `+ (n-1)` separators). devrc's whole listing under the ledger is **9,138**, down from **12,858** with every skill tier A.

Tier B: `adoption-scan`, `auditloop`, `close-the-loop`, `espanso-audit`, `initiative-scan`, `prune-index`, `prune-memory`, `prune-skill`, `repo-cos`, `sglang`, `subsystem-index`, `ux-audit-loops`, `verify-agent`.

**One change from the proposed starting set:** `vetr-mailbox` is **tier A**, not B. The ledger's stated tie-break is *tier B when a mis-route degrades the answer, tier A when it takes a wrong action* — name-only, "email them on my behalf" routes to `mailbox`, which claims the same phrase and sends from a different account. It is also the second-cheapest entry in the listing, so demoting it buys almost nothing. `initiative-scan` and `verify-agent` are flagged in the ledger as the two closest calls, with what would make them flip.

`dl-router` stays tier A as briefed — its value *is* auto-firing on "downloads landing in the wrong folder", and it looks dead to Claude Code's counter while running as a live systemd service.

## 🔴 Three decisions worth reviewing

**1. The switch is not flipped.** Nothing is applied to any host. Measured 2026-08-24: the whole listing is 20,708 chars against a 30,000-char budget on `claude-opus-5` @1M — **0.69×, nothing is being truncated**. A wide tier B would cost real routing now for headroom ~1.8 months out. `~/.claude/settings.json`, `~/.claude.json` and everything under `~/.claude/` are untouched on both hosts.

**2. An unapplied host is `NOT ADOPTED`, not drift, and sets no rc.** Both hosts had no `skillOverrides` when this landed. Counting that as drift would have made rc 22 **red on every run forever** — and a permanently-red gate is worse than no gate. rc 22 fires only on *adopted-then-drifted*.

**3. rc 22 was derived, not chosen.** `test_the_two_rc_ladders_reserve_each_others_codes` printed:

```
drift-check.sh's header does not publish 23 as the next free code.
The two ladders now reach 22, so 'nowhere to go but upward' points at a number that is already taken.

ship.sh reserves [10, 14, 15, 16, 17, 18] to drift-check.sh, but drift-check.sh alone
can return [10, 14, 15, 16, 17, 18, 22]. A code missing from that ledger is a code
ship.sh may take next.
```

Both headers and both `RESERVED-TO-*` ledger lines updated to match. `severity()` ranks 22 **just under rc 10**: a BEHIND host carries a stale ledger and can produce this finding as a symptom, so the code naming the cause outranks the one naming the effect.

## Two things that were red at base

* **The two-way pin earned itself before this was pushed.** Rebasing onto #790 made it RED on `subsystem-index` — a skill that had landed on `main` an hour earlier with no ledger entry. That is the mechanism working. It is now tier B (invoked *by* `/handoff`, which names it; its own description says "rarely run directly").
* **The project-scope scan died on its first live run.** `Path.is_dir()` raised `PermissionError` on `/tmp`'s root-owned mode-700 `systemd-private-*` directories — *after* the ledger summary had printed, so the output read like a completed run. An unreadable directory is now a gap in coverage (visible in the printed file count), never an abort. `test_the_project_scan_survives_a_directory_it_cannot_stat` keeps that shape.

## Verification

**Mutation sweep: 16 of 16 killed**, under `PYTHONDONTWRITEBYTECODE=1` with `__pycache__` cleared between mutants — both directions of the two-way pin, the sed range end, `note_rc 22`, the wrong-value and extra-override branches, the dry-run default, the `settings.local.json` leg of the project scan, the `+4` and the separators in the cost formula, `name-only` vs `off`, and the facts reader erring rather than projecting an empty expectation.

**The harness itself was negative-controlled**: an inert comment reword was fed through the same pipeline and reported `SURVIVED`. A sweep that reports KILLED for everything is indistinguishable from one whose selectors are broken.

Named controls in the suite:

* positive — the extractor is shown reading real values out of the real settings.json shape; the project scan is shown finding an overriding project entry (its live `0 hits over 56 files` is only quotable because of this); a compliant host is shown printing the affirmative line, not merely the absence of a complaint.
* negative — each of the three drift categories has its own rc-22 test; each way the ledger can be unusable produces `err <token>` and never a bare `ok`.
* isolated mutation — `test_control_demoting_one_skill_moves_the_number` pins that flipping ONE entry drops tier A by exactly that entry's cost plus its separator; without it a `tier_a_chars` that ignored the tier would satisfy everything else.
* the `5n − 1` identity between this module's real formula and `test_skill_descriptions.listing_total_chars` is pinned, so the two numbers stay legible as two measures of one listing rather than as a disagreement.

`LISTING_TOTAL_CEILING_CHARS` and `listing_total_chars` in `test_skill_descriptions.py` are untouched, per that module's docstring.

## nix

`python3` on the `drift-check` unit PATH was documented as being **for the child only**. That is now false — the driver runs `lib/skill_tier_facts.py` itself — so the comment is corrected rather than left to mislead. The reader, the parser and the ledger are added to `X-Restart-Triggers`; the ledger is there because a re-tiering changes what the unit reports with no script changing at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
