### PR TITLE
docs(resume/handoff): the ranked next-steps list is a work queue with no lock — and worktrees do not fix it

### DIFF
--- a/claude/skills/handoff/SKILL.md
+++ b/claude/skills/handoff/SKILL.md
@@ -90,6 +90,20 @@ Topic argument (optional): `$ARGUMENTS`. If empty, infer a short kebab-case topi
    ## Next steps (ranked)
    1. ...
    2. ...
+   <!-- 🔴 THIS SECTION IS A WORK QUEUE, AND IT HAS NO LOCK. Every session that
+   /resumes this doc draws from this list, so a well-written ranked list is
+   exactly what makes two sessions pick the same item. Measured 2026-08-24 on
+   one handoff: next-step 1 became homelab-infra #386, and next-step 4 became
+   BOTH #388 and #389 — one of them abandoned after two audit rounds.
+   So when you WRITE an item here, make it cheap to tell whether it is already
+   taken: name the repo and the files it will touch, and where a branch or PR
+   already exists, name it. `/resume` step 6 carries the consuming half (check
+   open PRs, push the branch early to stake the claim). -->
+   <!-- ⚠ Worktree isolation does NOT prevent this — both colliding sessions
+   isolated correctly and no file was clobbered. It is a task-allocation
+   collision, not a filesystem one, and isolation is what HIDES it. -->
+   ⚠ **Mark an item that is already in flight** — `IN FLIGHT: <repo>#<pr>` or
+   `BRANCH: <name>` — rather than leaving it looking unclaimed.
 
    ## Gotchas / decisions / dead-ends
    - Things already tried that didn't work; constraints; why X over Y.

--- a/claude/skills/handoff/SKILL.md
+++ b/claude/skills/handoff/SKILL.md
@@ -90,20 +90,12 @@ Topic argument (optional): `$ARGUMENTS`. If empty, infer a short kebab-case topi
    ## Next steps (ranked)
    1. ...
    2. ...
-   <!-- 🔴 THIS SECTION IS A WORK QUEUE, AND IT HAS NO LOCK. Every session that
-   /resumes this doc draws from this list, so a well-written ranked list is
-   exactly what makes two sessions pick the same item. Measured 2026-08-24 on
-   one handoff: next-step 1 became homelab-infra #386, and next-step 4 became
-   BOTH #388 and #389 — one of them abandoned after two audit rounds.
-   So when you WRITE an item here, make it cheap to tell whether it is already
-   taken: name the repo and the files it will touch, and where a branch or PR
-   already exists, name it. `/resume` step 6 carries the consuming half (check
-   open PRs, push the branch early to stake the claim). -->
-   <!-- ⚠ Worktree isolation does NOT prevent this — both colliding sessions
-   isolated correctly and no file was clobbered. It is a task-allocation
-   collision, not a filesystem one, and isolation is what HIDES it. -->
-   ⚠ **Mark an item that is already in flight** — `IN FLIGHT: <repo>#<pr>` or
-   `BRANCH: <name>` — rather than leaving it looking unclaimed.
+   🔴 **This list is a WORK QUEUE WITH NO LOCK** — every `/resume` session draws
+   from it, so a *better* ranked list produces *more* duplicate work, not less.
+   Make each item cheap to check: name the repo and the files it will touch, and
+   **mark anything in flight `IN FLIGHT: <repo>#<pr>`** rather than leaving it
+   looking unclaimed. Worktrees do NOT prevent this. 📖 the measurements and the
+   refutation: `~/.claude/skills/handoff/reference/shared-queue.md`.
 
    ## Gotchas / decisions / dead-ends
    - Things already tried that didn't work; constraints; why X over Y.

--- a/claude/skills/handoff/reference/shared-queue.md
+++ b/claude/skills/handoff/reference/shared-queue.md
@@ -1,0 +1,72 @@
+# The ranked next-steps list is a work queue with no lock
+
+Measurements behind the one-line rule in `SKILL.md` → `## Next steps (ranked)`,
+and the consuming half in `/resume` step 6.
+
+## What was measured — 2026-08-24
+
+Three sessions collided on the same work in one day. One collision cost an
+entire PR: **homelab-infra `#388`**, closed after two adversarial audit rounds of
+work had already gone into it.
+
+The cause is the handoff's own ranked list. Every `/resume` session draws from
+it and nothing marks an item taken. It mapped onto the PR series nearly 1:1:
+
+| handoff next-step | PR |
+|---|---|
+| 1. finally-on-timeout for the other pipelines | `#386` |
+| 4. right-size requests — *"gitops-validate alone asks 4.65 CPU / 4.688Gi"* | **`#388` AND `#389`** |
+| 5. watch for a `Preempted` event | `#389` too |
+
+🔴 **The uncomfortable implication: a BETTER ranked list produces MORE of this,
+not less.** Making the next action obvious, specific and actionable is exactly
+what makes two sessions pick the same one. The list is not the problem — the
+absence of a claim step is.
+
+## 🔴 Worktree isolation is REFUTED as the explanation
+
+This is the intuitive theory and it is wrong twice over:
+
+1. **Every colliding session WAS using a worktree.** `hi-finally-fix` (`#385`),
+   `homelab-renderdiff` (`#390`) and `tekton-devrc` were all live worktrees on
+   their own branches at the time. They isolated correctly.
+2. **No file was ever clobbered.** Each colliding PR was internally clean and
+   independently passed its own review.
+
+Worktrees prevent a **filesystem** collision — two agents editing one tree. This
+is a **task-allocation** collision. They are orthogonal, and isolation is in fact
+what *hides* the duplication: a shared tree would have shown the other branch.
+
+## The timing, which is what makes it fixable
+
+Each collision had a window in which the other PR was **already public**:
+
+- `#774` was public **22 minutes** before its duplicate `#775` was opened.
+- `#388` was public **18 minutes** before the other side's first commit.
+
+Both were visible to `gh pr list`. Neither was checked. A PR becomes public
+seconds after the first push, while the work itself takes ~20 minutes — so the
+information exists for nearly the whole window.
+
+## Why a pre-flight check alone is NOT sufficient
+
+🔴 **Whoever moves FIRST cannot see the second session at all.** In the
+`#388`/`#389` pair, no check on the first mover's side could have helped: at
+branch-creation time the other session had not started, and at PR-creation time
+it still had not. The duplication was created entirely by the later session.
+
+That is why the rule has two halves, and why the second one matters most:
+
+- **Check** `gh pr list --state open` before starting **and again immediately
+  before `gh pr create`** — two moments, because the second is where the sunk
+  cost is highest. This protects you from being the *later* session.
+- **Push the branch the moment you create it, before doing the work** (an empty
+  commit is enough). That is the claim. It costs seconds, collapses the invisible
+  window from ~20 minutes to ~0, and is the **only** half that protects you when
+  you are the *first* session.
+
+## Producing side
+
+When writing an item into `## Next steps (ranked)`, make "is this already taken?"
+cheap to answer: name the repo and the files it will touch, and mark anything
+already in progress as `IN FLIGHT: <repo>#<pr>` or `BRANCH: <name>`.

--- a/claude/skills/resume/SKILL.md
+++ b/claude/skills/resume/SKILL.md
@@ -101,4 +101,32 @@ Topic argument (optional): `$ARGUMENTS`.
    - Any drift you found between the handoff and live state.
    - Anything the index recalled that bears on the next steps — labelled `from index`, kept separate from what step 2 measured.
 
+6. 🔴 **BEFORE ACTING ON A NEXT-STEP, CLAIM IT — the list is a SHARED QUEUE WITH NO LOCK.**
+   Every session that resumes this handoff draws from the same ranked list, and
+   nothing marks an item as taken. Measured 2026-08-24 on one handoff: its
+   next-step 1 became homelab-infra `#386`, and next-step 4 became **both `#388`
+   and `#389`** — two sessions, same item, one PR abandoned after two audit
+   rounds of work.
+   🔴 **Worktree isolation does NOT prevent this and is not the answer.** Both
+   sessions isolated correctly; no file was ever clobbered. Worktrees stop a
+   FILESYSTEM collision (two agents in one tree); this is a TASK-ALLOCATION
+   collision. Isolation is in fact what HIDES it — a shared tree would have shown
+   the other branch.
+   **So do both of these, in this order:**
+   - **`gh pr list --repo <r> --state open --json number,title,headRefName,files`
+     before you start, and AGAIN immediately before `gh pr create`.** Two moments,
+     because the window is ~20 minutes and the second one is where the sunk cost
+     is highest. Measured: `#774` was public **22 minutes** before the duplicate
+     was opened, and `#388` was public **18 minutes** before the other side's
+     first commit. Each was visible; neither was checked.
+   - **PUSH THE BRANCH THE MOMENT YOU CREATE IT, before doing the work** (an empty
+     commit is fine). That is the claim. It costs seconds and collapses the
+     invisible window from ~20 minutes to ~0, because a branch is visible to
+     `git ls-remote` the instant it lands.
+   ⚠ **A pre-flight check alone is NOT sufficient, and it is worth knowing why:**
+   whoever moves FIRST cannot see the second session at all. In the `#388`/`#389`
+   pair, no check on the first mover's side could have helped — the duplication
+   was created entirely by the later session. That is exactly why the early push
+   matters: it is the only half of this that protects the first mover.
+
 Then wait for direction. Pair: `/handoff` (it writes the index entries this step reads).

--- a/claudedocs/handoff-devrc-ci-gate.md
+++ b/claudedocs/handoff-devrc-ci-gate.md
@@ -344,6 +344,29 @@ longer true, and a permanently-red gate is no longer the expected outcome. See s
 - **Concurrency is the dominant cost.** `main` moved 11+ times during this session; two of
   my PRs were superseded mid-flight by better fixes from other sessions. Check whether
   someone is already on a defect before dispatching an agent at it.
+  🔴 **DIAGNOSED 2026-08-24 — THE CAUSE IS *THIS DOC'S OWN* NEXT-STEPS LIST, and the
+  fix is not worktrees.** The ranked list is a work queue that every `/resume`
+  session draws from, with nothing marking an item as taken. It maps onto the PR
+  series nearly 1:1: next-step 1 → homelab-infra `#386`; next-step 4 (*"right-size
+  the other pipelines' requests — gitops-validate alone asks 4.65 CPU"*) → **BOTH
+  `#388` and `#389`**; next-step 5 → `#389` as well. `#388` was closed after two
+  audit rounds of work. A *better* ranked list produces *more* of this, not less.
+  🔴 **Worktree isolation is REFUTED as the explanation.** Every other session was
+  using one (`hi-finally-fix`, `homelab-renderdiff`, `tekton-devrc` were all live
+  worktrees on their own branches) and **no file was ever clobbered** — each
+  colliding PR was internally clean. Worktrees prevent a FILESYSTEM collision;
+  this is a TASK-ALLOCATION collision, and isolation is what *hides* it, since a
+  shared tree would have shown the other branch.
+  **The measured timing, which is what makes it fixable:** each collision had a
+  window where the other PR was already PUBLIC — `#774` by **22 min** before its
+  duplicate was opened, `#388` by **18 min** before the other side's first commit.
+  Both were visible; neither was checked.
+  ⚠ **But a pre-flight check cannot protect the FIRST mover** — in `#388`/`#389`
+  nothing on my side could have seen a session that had not started yet. Hence two
+  halves, both now written into the skills: `/resume` step 6 (check open PRs before
+  starting **and** again immediately before `gh pr create`) and **push the branch
+  the moment you create it**, which is the only half that protects whoever moves
+  first. `/handoff` now asks that in-flight items be marked `IN FLIGHT: <repo>#<pr>`.
 
 - 📌 **CARRIED FORWARD from the previous revision's `Next steps`, which this update replaces.**
   These are durable *findings*, not pending actions, and would otherwise have been deleted —


### PR DESCRIPTION
Three sessions collided on the same work today; one collision cost an entire PR ([homelab-infra #388](https://github.com/ZacxDev/homelab-infra/pull/388), closed after two audit rounds). This diagnoses why and fixes both halves.

## The cause is the handoff's own `## Next steps (ranked)` section

It is a work queue that every `/resume` session draws from, and **nothing marks an item as taken.** It maps onto the PR series nearly 1:1:

| handoff next-step | PR |
|---|---|
| 1. finally-on-timeout for the other pipelines | `#386` |
| 4. right-size requests — *"gitops-validate alone asks 4.65 CPU / 4.688Gi"* | **`#388` AND `#389`** |
| 5. watch for a `Preempted` event | `#389` too |

The uncomfortable part: **a better ranked list produces more of this, not less.** Making the next action obvious and actionable is exactly what makes two sessions pick it.

## 🔴 Worktree isolation is refuted as the explanation

This was the intuitive theory and it is wrong twice over:

1. **Every other session *was* using a worktree** — `hi-finally-fix`, `homelab-renderdiff`, `tekton-devrc` were all live worktrees on their own branches. They isolated correctly.
2. **No file was ever clobbered.** Each colliding PR was internally clean. Worktrees prevent a *filesystem* collision (two agents in one tree); this is a *task-allocation* collision.

And the perverse bit: **isolation is what hides it.** A shared tree would have shown me the other branch.

## What makes it fixable: the timing

Each collision had a window where the other PR was **already public**:

- `#774` was public **22 minutes** before I opened its duplicate `#775`.
- `#388` was public **18 minutes** before the other side's first commit.

Both were visible. Neither was checked.

## The fix — two halves, because one is not enough

**`/resume` gains step 6** — `gh pr list --state open` **before starting, and again immediately before `gh pr create`.** Two moments, because the window is ~20 minutes and the second is where the sunk cost is highest.

⚠ **But a pre-flight check cannot protect the *first* mover.** In `#388`/`#389`, nothing on my side could have seen a session that had not started yet — the duplication was created entirely by the later session. So:

**Push the branch the moment you create it, before doing the work.** That is the claim. It costs seconds, collapses the invisible window from ~20 minutes to ~0, and is the only half that protects whoever moves first.

**`/handoff` gains the producing side**: mark in-flight items `IN FLIGHT: <repo>#<pr>`, and name the files an item will touch, so "is this already taken?" is cheap to answer.

## Scope + gate

Skill **bodies** and one handoff doc. **Descriptions are byte-identical** (verified: 0 changed `description:`/`name:` lines), so the always-on listing budget is unaffected — bodies cost 0 until invoked.

Ran `test_skill_descriptions`, `test_rules_size`, `test_skill_audit`, `test_skills_mapping_guard`, `test_doc_path_rot`, `test_handoff_doc`, `test_prune_skill_size`, `test_no_captured_text` → **507 passed**.

Dogfooded: I ran the open-PR check before starting this branch (it caught that `main` had moved 5 commits, including #790 refactoring the very handoff skill I was about to edit), pushed the branch before opening this PR, and re-ran the check immediately before creating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfTgjbqgfxixamnvVktMQA