### PR TITLE
fix(clickup): query.mjs has not parsed since #768 — the whole CLI was dead

### DIFF
--- a/claude/skills/clickup/query.mjs
+++ b/claude/skills/clickup/query.mjs
@@ -342,7 +342,7 @@ Options:
                allowlist (gh_pr_merged:<owner>/<repo>#<n>, alert_cleared:<name>,
                cmd_exit_zero:<id>, metric_below:<id>, manual). Recorded in the
                task body so a later reconciler can close it. Defaults to
-               `manual`; anything off-allowlist is REJECTED, not stored.
+               'manual'; anything off-allowlist is REJECTED, not stored.
 
 Bulk Operations (comma-separated IDs):
   node query.mjs get id1,id2,id3              Fetch multiple tasks at once

--- a/scripts/tests/test_skill_mjs_parses.py
+++ b/scripts/tests/test_skill_mjs_parses.py
@@ -1,0 +1,83 @@
+"""Every `.mjs` under `claude/skills/` must PARSE.
+
+WHY THIS EXISTS
+---------------
+PR #768 shipped a `claude/skills/clickup/query.mjs` that did not parse. The
+ClickUp skill's entire CLI was dead on `main` -- every invocation died with
+`SyntaxError: missing ) after argument list` before running a single line.
+
+The cause is worth stating, because it is a whole class and not a typo: the
+help text is a TEMPLATE LITERAL (`console.error(`Usage: ...`)`), and the PR
+added a line containing a backtick-quoted word -- ``manual`` -- inside it. The
+inner backtick TERMINATED the literal early; everything after it re-parsed as
+code, and the error surfaced ~14 lines EARLIER than the edit, at an unrelated
+`${...}` on line 331. So the reported location did not point at the defect.
+
+🔴 WHY THE EXISTING GATES DID NOT CATCH IT. The devrc node suite passed 1,179
+tests on that PR. It runs the `.test.mjs` files; it never IMPORTS or parses
+`query.mjs`, because nothing tests the CLI entry point. A suite can be fully
+green and structurally blind to a file being syntactically invalid.
+
+WHY `node --check` AND NOT AN IMPORT
+------------------------------------
+Importing needs the package's dependencies resolved. In a bare git worktree
+there is no `node_modules`, so an import test fails with ERR_MODULE_NOT_FOUND
+for reasons that have nothing to do with the code -- measured while fixing this
+(`Cannot find package 'unified'`). `node --check` validates syntax with no
+dependency resolution at all, so it is green in a worktree, in CI, and on a
+deployed store path alike. It checks LESS than an import, and what it checks it
+checks everywhere.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SKILLS = REPO_ROOT / "claude" / "skills"
+
+# Floor, so an empty or mis-rooted glob cannot pass vacuously. There were far
+# more than this when the test was written; it is a tripwire, not a target.
+MIN_FILES = 10
+
+
+def _mjs_files() -> list[Path]:
+    return sorted(p for p in SKILLS.rglob("*.mjs") if p.is_file())
+
+
+def test_node_is_available():
+    """If node is absent every check below would skip and read as coverage."""
+    assert shutil.which("node"), (
+        "node is not on PATH, so the parse checks below cannot run. "
+        "This test exists so that reads as a FAILURE, never as a silent pass."
+    )
+
+
+def test_the_glob_finds_files():
+    """Positive control. A zero-length list makes the parametrised test vacuous."""
+    found = _mjs_files()
+    assert len(found) >= MIN_FILES, (
+        f"only {len(found)} .mjs files found under {SKILLS} (floor {MIN_FILES}) -- "
+        "the search root is probably wrong, which would make the parse check "
+        "pass while checking nothing"
+    )
+
+
+@pytest.mark.parametrize("path", _mjs_files(), ids=lambda p: p.name)
+def test_mjs_parses(path: Path):
+    proc = subprocess.run(
+        ["node", "--check", str(path)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, (
+        f"\n\n{path.relative_to(REPO_ROOT)} does not parse.\n\n"
+        f"{proc.stderr.strip()}\n\n"
+        "🔴 If the reported line looks unrelated to your edit, suspect an "
+        "unbalanced delimiter EARLIER in the file -- a backtick inside a "
+        "template literal is the way this has actually broken before, and it "
+        "reports the error well after the real cause."
+    )


### PR DESCRIPTION
🔴 **Live break, and I shipped it.** `claude/skills/clickup/query.mjs` has not parsed since #768 merged. Every `node query.mjs …` dies with `SyntaxError` before executing a line — the ClickUp skill's entire CLI has been unusable on `main`.

## Cause

#768 (agent-object stamping) added a `--cond` help entry containing a backtick-quoted word inside the help block. That block is a **template literal** — `` console.error(`Usage: … `) `` — so the inner backtick **terminated it early** and everything after re-parsed as code.

Attribution measured, not assumed:

| ref | `node --check query.mjs` |
|---|---|
| `3bbb5514^` (before #768) | **0** |
| `3bbb5514` (#768) | **1** |
| `origin/main` | **1** |

## 🔴 The error did not point at the defect

It surfaced at **line 331**, on an unrelated `${AWAITING_DEFAULTS.maxTasks}` — **14 lines earlier** than the edit that caused it, because after a premature close the next `${…}` is simply the first thing that cannot parse. Anyone diagnosing from the reported line would have looked in the wrong place entirely.

## Why nothing caught it

The devrc node suite **passed 1,179 tests** on #768. It runs the `.test.mjs` files and never imports or parses `query.mjs`, because nothing tests the CLI entry point. A fully green suite, structurally blind to a file being syntactically invalid.

## The guard

`scripts/tests/test_skill_mjs_parses.py` — `node --check` on every `.mjs` under `claude/skills/` (33 today), plus:

- a `MIN_FILES` floor, so a mis-rooted glob cannot pass vacuously;
- an explicit node-on-PATH test, so an absent toolchain reads as **FAILURE** rather than a silent skip.

**`node --check`, not an import.** Importing needs dependencies resolved, and a bare worktree has no `node_modules` — measured while fixing this, an import attempt dies with `Cannot find package 'unified'` for reasons unrelated to the code. `--check` validates syntax with no dependency resolution, so it is green in a worktree, in CI, and against a deployed store path alike. It checks *less*, and what it checks it checks everywhere.

## Matrix

| | Result |
|---|---|
| Guard at `origin/main` | **RED — 1 failed / 32 passed**, failing id `query.mjs` |
| Guard at HEAD | **GREEN — 33 passed** |

The guard catches the actual live bug it was written for, not a proxy for it.

The failure message tells the next reader that an unrelated-looking line number means an unbalanced delimiter earlier in the file — since that is now how this has actually broken once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
