### PR TITLE
fix(testlib): the skills-mapping check could not answer under CI load — give its budget a knob, not a bigger literal

### DIFF
--- a/scripts/testlib/skills_mapping.py
+++ b/scripts/testlib/skills_mapping.py
@@ -39,6 +39,7 @@ nix cannot evaluate FAILS loudly as "needs updating"; nothing passes silently.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -65,6 +66,39 @@ _FIX_IT = (
     "about a deployed file."
 )
 
+#: MEASURED, idle 24-core workbench: 0.02 s, and COLD == WARM (no nixpkgs
+#: import, nothing realised, so there is no cache to warm). Only CPU contention
+#: moves it, roughly with the oversubscription factor: 0.06 s at 1x, 0.26 s at
+#: 4x, 1.8 s at 10x. CI runs this in the `checks.pytests` sandbox beside ~15k
+#: tests where cgroup throttling stacks on that, and the old hardcoded 60 s was
+#: reached for real (devrc-ci-ztn92) — turning "cannot answer" into a red
+#: REQUIRED gate on unrelated PRs. 180 s is ~100x the worst measured contended
+#: run: a deadman, not a performance budget, so reaching it means WEDGED.
+_TIMEOUT_ENV = "DEVRC_SKILLS_MAPPING_TIMEOUT_S"
+_DEFAULT_TIMEOUT_S = 180.0
+
+
+def _budget() -> float | str:
+    """Seconds to allow, or a "cannot answer" reason when the override is junk.
+
+    🔴 A junk override must NOT fall back to the default. This knob can only
+    widen or narrow a safety check, so ignoring an unreadable one is how `…=0`
+    or a typo switches the check off while it still reads green.
+    """
+    raw = os.environ.get(_TIMEOUT_ENV)
+    if raw is None or not raw.strip():
+        return _DEFAULT_TIMEOUT_S
+    try:
+        seconds = float(raw)
+    except ValueError:
+        seconds = float("nan")
+    if not seconds > 0 or seconds == float("inf"):
+        return (
+            f"{_TIMEOUT_ENV}={raw!r} is not a positive, finite number of "
+            f"seconds, {_FIX_IT}"
+        )
+    return seconds
+
 
 def skills_mapping_problem(home_nix: Path | str) -> str | None:
     """A failure reason, or None when the mapping is declared and live."""
@@ -83,16 +117,23 @@ def skills_mapping_problem(home_nix: Path | str) -> str | None:
         return f"{shown} is not a file, {_FIX_IT}"
     if shutil.which("nix-instantiate") is None:
         return f"nix-instantiate is not on PATH, {_FIX_IT}"
+    budget = _budget()
+    if isinstance(budget, str):
+        return budget
     try:
         p = subprocess.run(
             ["nix-instantiate", "--eval", "--strict", "--json",
              "-E", _EXPR.replace("@PATH@", str(home_nix.resolve()))],
-            capture_output=True, text=True, timeout=60,
+            capture_output=True, text=True, timeout=budget,
         )
     except subprocess.TimeoutExpired:
-        # Measured runtime is ~0.02 s; a hang means the environment is wrong,
-        # which is a broken check, not a broken home.nix.
-        return f"nix-instantiate did not finish within 60s, {_FIX_IT}"
+        # Idle runtime is ~0.02 s (see _DEFAULT_TIMEOUT_S), so reaching this is
+        # a wedged environment — a broken check, not a broken home.nix.
+        return (
+            f"nix-instantiate did not finish within {budget:g}s, {_FIX_IT} "
+            f"If the host is merely slow rather than wedged, widen the budget "
+            f"with {_TIMEOUT_ENV}=<seconds> — do not shrink the check."
+        )
     if p.returncode != 0:
         return f"nix cannot evaluate {shown}, {_FIX_IT}\n{p.stderr.strip()[-600:]}"
     m = json.loads(p.stdout)

--- a/scripts/tests/test_skills_mapping_guard.py
+++ b/scripts/tests/test_skills_mapping_guard.py
@@ -20,15 +20,32 @@ lexical hole a regex over the raw text would have.
 """
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "scripts"))
 
-from testlib.skills_mapping import skills_mapping_problem  # noqa: E402
+from testlib import mockbin  # noqa: E402
+from testlib.skills_mapping import (  # noqa: E402
+    _DEFAULT_TIMEOUT_S,
+    _TIMEOUT_ENV,
+    assert_skills_mapping_declared,
+    skills_mapping_problem,
+)
 
 HOME_NIX = ROOT / "nix" / "home.nix"
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_override(monkeypatch):
+    """Every test states its own budget. An operator's exported value must not
+    decide what the rest of this file measures — the honouring of that value is
+    itself under test below, so leaking it in would make those cases circular."""
+    monkeypatch.delenv(_TIMEOUT_ENV, raising=False)
 
 # Every fixture is a home-manager module function, like the real file.
 REAL_SHAPE = """{ ... }:
@@ -216,7 +233,13 @@ def test_passing_the_files_TEXT_reads_as_a_broken_check(tmp_path):
 #: property it still got wrong, and was cut to ~4 KB by dropping that ambition.
 #: Without a gate that ceiling is a prose intention, and this file's own history
 #: shows prose intentions do not hold. Precedent: test_rules_size.py.
-MAX_MODULE_BYTES = 5_600
+#:
+#: Raised 5,600 -> 7,400 once, for `_budget()` + `_TIMEOUT_ENV` and the measured
+#: justification of the default. That allowance is SPENT: it bought the timeout
+#: knob and nothing else. It is not a general loosening, and it is not precedent
+#: for re-growing the source-resolution tracing named below -- that ambition is
+#: still forbidden at any byte count.
+MAX_MODULE_BYTES = 7_400
 
 
 def test_the_module_stays_under_its_ceiling():
@@ -231,6 +254,206 @@ def test_the_module_stays_under_its_ceiling():
         "the number. That half is verified against reality by ship.sh and\n"
         "drift-check.sh; re-deriving it from nix source is strictly worse."
     )
+
+
+# --------------------------------------------------------------------------
+# THE TIMEOUT BUDGET.
+#
+# The old hardcoded 60 s was REACHED in CI (devrc-ci-ztn92): the check could not
+# answer, said so correctly, and that correct answer was a red REQUIRED gate on
+# unrelated PRs. The budget is now `DEVRC_SKILLS_MAPPING_TIMEOUT_S`.
+#
+# 🔴 These cases must not depend on how long real nix takes -- that is the very
+# load-sensitivity being fixed, and pinning a test to it rebuilds the bug in the
+# harness. So they run against a STUB `nix-instantiate` that sleeps a known
+# duration and then emits the exact JSON the predicate parses. The stub is held
+# fixed and the OVERRIDE is varied, so the override is the only moving part.
+# --------------------------------------------------------------------------
+
+#: Whole seconds, so the stub needs nothing beyond POSIX `sleep`. Long enough
+#: that a narrow override cuts it off with room to spare, short enough that a
+#: generous override finishes it well inside the suite's patience.
+_STUB_SLEEP_S = 2
+
+_LIVE_MAPPING_JSON = (
+    '{"declared": true, "source": true, "enable": true, '
+    '"target": ".claude/skills"}'
+)
+
+
+def _stub_nix_instantiate(tmp_path, monkeypatch, sleep_s=_STUB_SLEEP_S):
+    """Put a slow-but-successful `nix-instantiate` at the front of PATH.
+
+    It answers "the mapping is live", so anything the predicate returns while
+    this is installed comes from the BUDGET, never from the fixture's content.
+    """
+    bindir = tmp_path / "stubbin"
+    bindir.mkdir()
+    stub = mockbin.write_exec(
+        bindir / "nix-instantiate",
+        f"sleep {sleep_s}\nprintf '%s' '{_LIVE_MAPPING_JSON}'\n",
+    )
+    monkeypatch.setenv("PATH", f"{bindir}{os.pathsep}{os.environ['PATH']}")
+    return stub
+
+
+def test_a_budget_narrower_than_the_call_cuts_it_off(tmp_path, monkeypatch):
+    """REGRESSION. Before the fix the env var did not exist: the 60 s literal
+    swallowed this stub whole and the predicate returned None -- a PASS. Red at
+    base, green at HEAD."""
+    _stub_nix_instantiate(tmp_path, monkeypatch)
+    monkeypatch.setenv(_TIMEOUT_ENV, "0.2")
+    problem = skills_mapping_problem(write(tmp_path, REAL_SHAPE))
+    assert problem is not None, (
+        f"{_TIMEOUT_ENV}=0.2 against a {_STUB_SLEEP_S}s call returned a PASS -- "
+        "the override is being ignored, so the budget is still hardcoded"
+    )
+    assert "did not finish" in problem, problem
+
+
+def test_a_budget_wider_than_the_call_lets_it_finish(tmp_path, monkeypatch):
+    """The paired control for the case above -- NOT regression coverage: the old
+    60 s default also cleared this stub, so it was green at base too.
+
+    Its job is to isolate the variable. Same stub, same fixture, only the
+    override's MAGNITUDE differs from the previous test, and the outcome
+    inverts. Without it, "0.2 fails" would be equally well explained by the
+    override merely being *present* rather than by its value being used.
+    """
+    _stub_nix_instantiate(tmp_path, monkeypatch)
+    monkeypatch.setenv(_TIMEOUT_ENV, "300")
+    assert skills_mapping_problem(write(tmp_path, REAL_SHAPE)) is None
+
+
+def test_the_timeout_message_names_the_knob_and_refuses_deletion(tmp_path, monkeypatch):
+    """REGRESSION. The pre-fix message named no knob, so the only actions it
+    suggested were "fix the check" or (against its own advice) delete it. A
+    maintainer hitting this in CI needs the third option spelled out."""
+    _stub_nix_instantiate(tmp_path, monkeypatch)
+    monkeypatch.setenv(_TIMEOUT_ENV, "0.2")
+    problem = skills_mapping_problem(write(tmp_path, REAL_SHAPE))
+    assert problem is not None
+    assert _TIMEOUT_ENV in problem, (
+        "the timeout message does not name the env var that widens it:\n" + problem
+    )
+    assert "do NOT delete it" in problem, problem
+
+
+def test_the_timeout_path_RAISES_rather_than_passing_or_skipping(tmp_path, monkeypatch):
+    """Fail-closed, measured at the CALLER's surface.
+
+    The four modules that consume this call `assert_skills_mapping_declared`,
+    not the predicate. "Could not answer" has to arrive there as a FAILURE --
+    not None, and emphatically not `pytest.skip`, which is how a check quietly
+    stops being one.
+    """
+    _stub_nix_instantiate(tmp_path, monkeypatch)
+    monkeypatch.setenv(_TIMEOUT_ENV, "0.2")
+    with pytest.raises(AssertionError) as excinfo:
+        assert_skills_mapping_declared(write(tmp_path, REAL_SHAPE))
+    assert "did not finish" in str(excinfo.value), excinfo.value
+
+
+@pytest.mark.parametrize("junk", ["abc", "0", "-5", "nan", "inf", "1e400", "5s"])
+def test_an_UNUSABLE_override_fails_closed_instead_of_falling_back(
+    tmp_path, monkeypatch, junk
+):
+    """REGRESSION, and the reason this knob is not just `int(os.environ[...])`.
+
+    A knob that silently reverts to its default when it cannot be read is a knob
+    that disables the check on a typo: `…=0` would otherwise mean "budget zero"
+    or "budget 180" depending on the parser, and nobody would be told which.
+    Every value here must land as "cannot answer", naming the value.
+    """
+    _stub_nix_instantiate(tmp_path, monkeypatch, sleep_s=0)
+    monkeypatch.setenv(_TIMEOUT_ENV, junk)
+    problem = skills_mapping_problem(write(tmp_path, REAL_SHAPE))
+    assert problem is not None, (
+        f"{_TIMEOUT_ENV}={junk!r} was accepted -- an unreadable budget silently "
+        "became the default, so a typo in this variable cannot be noticed"
+    )
+    assert _TIMEOUT_ENV in problem and repr(junk) in problem, problem
+    assert "do NOT delete it" in problem, problem
+
+
+@pytest.mark.parametrize("unset", ["", "   "])
+def test_an_EMPTY_override_means_the_default_not_an_error(tmp_path, monkeypatch, unset):
+    """An exported-but-empty variable is how a shell spells "I did not set
+    this". Treating it as junk would fail the gate on an empty export."""
+    _stub_nix_instantiate(tmp_path, monkeypatch, sleep_s=0)
+    monkeypatch.setenv(_TIMEOUT_ENV, unset)
+    assert skills_mapping_problem(write(tmp_path, REAL_SHAPE)) is None
+
+
+def test_the_default_budget_stays_far_above_the_MEASURED_cost():
+    """INVARIANT GUARD, not regression coverage -- a ratchet on a judgement call.
+
+    Measured on an idle 24-core workbench: 0.02 s, cold == warm. Under CPU
+    oversubscription it rises roughly linearly -- 0.06 s at 1x, 0.26 s at 4x,
+    1.8 s at 10x -- and CI stacks cgroup throttling on top of that inside the
+    `checks.pytests` sandbox, which is how 60 s was reached at all.
+
+    The floor below is deliberately well under the shipped default: this pins
+    the ORDER OF MAGNITUDE ("a deadman, not a performance budget"), and is not a
+    restatement of the constant. Lowering the default back toward the contended
+    measurements re-opens devrc-ci-ztn92.
+    """
+    assert _DEFAULT_TIMEOUT_S >= 120, (
+        f"the default budget is {_DEFAULT_TIMEOUT_S}s. The old 60 s literal was "
+        "REACHED in CI; anything near the contended measurements above makes "
+        "'the check could not answer' a routine red gate on unrelated PRs."
+    )
+
+
+# --------------------------------------------------------------------------
+# THE DISTINCTION THAT MAKES THIS CHECK WORTH HAVING.
+# --------------------------------------------------------------------------
+
+def test_cannot_answer_and_answer_is_no_stay_TELLABLE_APART(tmp_path, monkeypatch):
+    """INVARIANT GUARD -- true before this change too, and load-bearing for it.
+
+    "I could not answer" and "the answer is no" demand opposite responses: fix
+    the harness, versus fix nix/home.nix. The predicate keeps them separable by
+    appending `_FIX_IT` ("do NOT delete it") to every could-not-answer reason
+    and to NO answer-is-no reason. Adding the timeout knob added a new member to
+    each set, which is exactly when such a partition rots.
+
+    Pinned as a PARTITION over both sets rather than one example from each, so a
+    future reason cannot join the wrong side unnoticed.
+    """
+    stub_tmp = tmp_path / "stub"
+    stub_tmp.mkdir()
+
+    answer_is_no = {
+        "no mapping": skills_mapping_problem(write(tmp_path, NO_MAPPING)),
+        "no source": skills_mapping_problem(write(tmp_path, NO_SOURCE)),
+        "disabled": skills_mapping_problem(write(tmp_path, DISABLED)),
+        "redirected": skills_mapping_problem(write(tmp_path, REDIRECTED)),
+    }
+    cannot_answer = {
+        "absent file": skills_mapping_problem(tmp_path / "nope.nix"),
+        "unparseable": skills_mapping_problem(write(tmp_path, UNPARSEABLE)),
+    }
+
+    _stub_nix_instantiate(stub_tmp, monkeypatch)
+    monkeypatch.setenv(_TIMEOUT_ENV, "0.2")
+    cannot_answer["timed out"] = skills_mapping_problem(write(stub_tmp, REAL_SHAPE))
+    monkeypatch.setenv(_TIMEOUT_ENV, "junk")
+    cannot_answer["junk budget"] = skills_mapping_problem(write(stub_tmp, REAL_SHAPE))
+
+    for name, problem in {**answer_is_no, **cannot_answer}.items():
+        assert problem is not None, f"{name} produced a PASS"
+
+    for name, problem in cannot_answer.items():
+        assert "do NOT delete it" in problem, (
+            f"could-not-answer reason {name!r} is missing the fix-the-check "
+            f"marker, so it reads as a verdict on home.nix:\n{problem}"
+        )
+    for name, problem in answer_is_no.items():
+        assert "do NOT delete it" not in problem, (
+            f"answer-is-no reason {name!r} carries the fix-the-check marker, so "
+            f"a real broken deploy now reads as a broken harness:\n{problem}"
+        )
 
 
 def test_a_path_that_is_not_a_file_fails(tmp_path):


### PR DESCRIPTION
## The defect

`scripts/testlib/skills_mapping.py` ran `nix-instantiate` with a hardcoded
`timeout=60`. In CI that was **reached** (`devrc-ci-ztn92`): the check correctly
reported *"I cannot answer this"*, and that correct answer turned
`tekton/devrc-pytests` red and blocked #667 and #658, which were otherwise clean.

The check is not at fault for failing — it is designed to fail closed. The
budget was.

## Measurements

Idle 24-core workbench, the real expression against `nix/home.nix`:

| condition | time |
|---|---|
| warm (5 runs) | 0.021 – 0.030 s |
| cold — fresh `HOME` + `XDG_CACHE_HOME` (3 runs) | 0.018 – 0.021 s |

**Cold == warm.** The expression imports no nixpkgs and realises nothing, so
there is no cache to warm; "cold start" is simply not a cost this call has. The
only variable that moves it is CPU contention, and it moves roughly with the
oversubscription factor:

| load (24 cores) | time |
|---|---|
| 24 spinners (1×) | 0.054 – 0.096 s |
| 96 spinners (4×) | 0.171 – 0.403 s |
| 240 spinners (10×) | 0.308 – 1.806 s |

60 s was ~500× the idle cost and *looked* generous. But CI runs this inside the
`checks.pytests` nix sandbox beside ~15k other tests, where cgroup throttling
stacks on plain CFS competition — and unlike the fair-share measurement above, a
quota can hard-stall a process for whole scheduling periods. A fixed 60 s was
never a safe distance from that.

## The change

`DEVRC_SKILLS_MAPPING_TIMEOUT_S`, defaulting to **180 s** — ~100× the worst
contended measurement. The ratio is the point, not the number: this is a
deadman, so reaching it should mean **wedged**, not merely **busy**. Worst case
stays bounded (4 call sites × 180 s = 12 min, well inside `gate.sh`'s own
3600 s).

### What deliberately did not change

Both properties are what made this a *visible failure* rather than a silent
pass, and both are now pinned by tests rather than by prose:

* **It still fails closed.** A timeout is a failure — never a skip, never a
  pass — and still reaches the caller as an `AssertionError`.
* **"I could not answer" stays distinguishable from "the answer is no."** Every
  could-not-answer reason carries the do-NOT-delete guidance; no answer-is-no
  reason does. The two new reasons join the correct side, and this is pinned as
  a **partition over both sets**, not one example from each.

A **junk override fails closed** rather than reverting to the default. That is
why this is not `int(os.environ[...])`: a knob that silently ignores what it
cannot read is a knob that disables the check on a typo, and `…=0` must not be
able to switch off a safety check while it still reads green. The timeout
message now names the knob, so "widen it" is spelled out beside "fix it" and
"do not delete it".

## Red / green matrix

Probed against a pristine `fb0b8417` copy of the module, importing only
`skills_mapping_problem` so a missing symbol could not stand in for a real
failure:

| property | base | HEAD | kind |
|---|---|---|---|
| narrow override is honoured | 🔴 RED | 🟢 GREEN | regression |
| timeout message names the knob | 🔴 RED | 🟢 GREEN | regression |
| junk override fails closed | 🔴 RED | 🟢 GREEN | regression |
| wide override still passes | 🟢 GREEN | 🟢 GREEN | **paired control** — isolates the variable, *not* regression coverage |

Two further tests are labelled **invariant guards** in-source, not counted as
regression coverage: the default-budget floor (a ratchet on a judgement call)
and the could-not-answer / answer-is-no partition (true before this change too).

## Mutation sweep

9 mutants, `PYTHONDONTWRITEBYTECODE=1` with `__pycache__` purged between each,
module restored and **sha256-verified** after every mutant:
**9 caught, 0 survivors.**

Includes a known-caught positive control (predicate always returns `None` → 19
killers), and one deliberately **over-strict** mutant recorded as such rather
than counted as evidence the fail-closed guard works — it kills the *control*
test, which is the tell that it is not a fail-open hole wearing a disabling
mutant's name. The three most precise mutants (knob name dropped, default
lowered to 60, zero accepted as a budget) are each killed by **exactly one**
test — their own guard's assertion.

## Gate

| tier | verdict |
|---|---|
| `nix build .#checks.x86_64-linux.pytests` (sandbox — what Tekton gates on) | rc 0 |
| `nix build .#checks.x86_64-linux.nodetests` (sandbox) | rc 0 |
| `scripts/gate.sh --tier both` (dev host) | `GATE: RESULT=PASS exit=0` |

Dev-host counts: pytest `collected=15776 passed=15774 skipped=2 failed=0`
(floor 13732); node `tests=1179 pass=1179 fail=0` (floor 1155). GUARD 8/10 clean
— `config-control=1`, no "never accounted".

The first full gate run caught this branch writing its own `#!` shebang in the
test stub; that is now routed through `testlib.mockbin.write_exec`, which is
what `test_runtime_shebangs.py` asks for.

## Sibling timeout survey

`scripts/testlib/` + `scripts/tests/` were swept for the same shape. **Nothing
else was changed** — `skills_mapping.py` was the only shared predicate whose
subprocess timeout is *fatal and unrecoverable*:

* `client_host_scan.py:203`, `public_ip_scan.py:208` — `timeout=60` on
  `git ls-files`, but inside `except subprocess.SubprocessError: pass`, which
  degrades to an equivalent `rglob` walk. Different shape: a timeout there fails
  no test. ⚠ Worth a separate look though — it means heavy load can silently
  switch these security scans' file-enumeration strategy, and "both tiers see
  the same set" is asserted in the docstring rather than measured.
* `mockbin.py:96` — `timeout=10` on `sh -c 'printf {a,b}'`. Same fail-loud
  family, but already ~4 orders of magnitude of headroom over the work, and it
  is a capability probe, not a correctness gate.
* `nogit_plugin.py:199` — already parameterised (`timeout: int = 30`) and
  already fails closed through its `control=`/`protocol=` fields. Closest
  genuine sibling in *risk* (it is the source of GUARD 8/10's `config-control`),
  but not the same one-line shape.

Everything else in that grep is an ordinary per-test subprocess whose timeout is
just a test failure.

## Not merged

Left open deliberately, as asked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
