### PR TITLE
fix(browser-bridge): bound the screenshot fast path — a hung captureVisibleTab never reached the CDP fallthrough

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -1287,7 +1287,26 @@ Two changes close it:
    `OPS[cmd.op](cmd)` against `EXEC_OP_BUDGET_MS` (18s). `frames`/`screenshot`
    are deliberately **not** patched individually — one rule, one place, or the bug
    regenerates at the next op added (`targetTab()` alone is on the path of every
-   op). Every *other* await in the loop body is bounded too: the poll fetch
+   op).
+
+   🔴 **ONE DOCUMENTED EXCEPTION, and it is not a weakening of that rule.**
+   `screenshot`'s **fast path** carries its own `FAST_CAPTURE_BUDGET_MS` bound.
+   The choke point above can only *end* an op; it cannot make a hung sub-step
+   FALL THROUGH to a working alternative. `chrome.tabs.captureVisibleTab` can
+   hang rather than reject, and the fast path's `catch` — which exists precisely
+   to fall through to the CDP path — can only see a rejection, so the op burned
+   all 18s and failed on a tab CDP captures fine. A bound that converts "never
+   settles" into a rejection is the only shape that restores the fallthrough.
+   The rule still holds for *terminating* an op; it simply cannot express
+   "recover from this step". ⚠ Its cost is a real constraint, pinned by a test in
+   `tests/cdp_protocol.test.mjs`: whatever the fast path spends comes out of the
+   CDP attach-hang margin below, so `FAST_CAPTURE_BUDGET_MS + 16s <= 18s`.
+
+   ⚠ The predicted regeneration is already present: `open`'s
+   `await chrome.tabs.get(cmd.reuseTabId)` sits in a `catch` that promises a
+   fall-through it cannot deliver if that call hangs. Same class, not yet fixed.
+
+   Every *other* await in the loop body is bounded too: the poll fetch
    (`POLL_BUDGET_MS` 40s), the result POST (`RESULT_BUDGET_MS` 10s), and the
    `chrome.storage.local` reads in `config()`/`clearSuperseded()`
    (`STORAGE_BUDGET_MS` 5s) — the last of which runs on *every* healthy iteration,

--- a/scripts/browser-bridge/extension/build_id.js
+++ b/scripts/browser-bridge/extension/build_id.js
@@ -24,4 +24,4 @@
 //   * a hash computed in the worker over its own source — same disk read
 // The marker must be a LITERAL in a module the worker imported, so that it was
 // frozen into the loaded module graph at load time and travels with the code.
-export const BUILD_MARKER = "ef984e84cbb83651";
+export const BUILD_MARKER = "ab6f1a5082a3e8d6";

--- a/scripts/browser-bridge/extension/build_id.js
+++ b/scripts/browser-bridge/extension/build_id.js
@@ -24,4 +24,4 @@
 //   * a hash computed in the worker over its own source — same disk read
 // The marker must be a LITERAL in a module the worker imported, so that it was
 // frozen into the loaded module graph at load time and travels with the code.
-export const BUILD_MARKER = "4c35cce7fa6186a8";
+export const BUILD_MARKER = "790ffec959040e69";

--- a/scripts/browser-bridge/extension/build_id.js
+++ b/scripts/browser-bridge/extension/build_id.js
@@ -24,4 +24,4 @@
 //   * a hash computed in the worker over its own source — same disk read
 // The marker must be a LITERAL in a module the worker imported, so that it was
 // frozen into the loaded module graph at load time and travels with the code.
-export const BUILD_MARKER = "aefab9d551a8d058";
+export const BUILD_MARKER = "ef984e84cbb83651";

--- a/scripts/browser-bridge/extension/build_id.js
+++ b/scripts/browser-bridge/extension/build_id.js
@@ -24,4 +24,4 @@
 //   * a hash computed in the worker over its own source — same disk read
 // The marker must be a LITERAL in a module the worker imported, so that it was
 // frozen into the loaded module graph at load time and travels with the code.
-export const BUILD_MARKER = "ab6f1a5082a3e8d6";
+export const BUILD_MARKER = "4c35cce7fa6186a8";

--- a/scripts/browser-bridge/extension/build_id.js
+++ b/scripts/browser-bridge/extension/build_id.js
@@ -24,4 +24,4 @@
 //   * a hash computed in the worker over its own source — same disk read
 // The marker must be a LITERAL in a module the worker imported, so that it was
 // frozen into the loaded module graph at load time and travels with the code.
-export const BUILD_MARKER = "0d9194e9f92dd697";
+export const BUILD_MARKER = "aefab9d551a8d058";

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -1712,6 +1712,26 @@ export const STORAGE_BUDGET_MS = 5000;
 // the image" caveat is about --fullpage, a different clip). ⚠ That geometry
 // equality is n=1, at one zoom/deviceScaleFactor, and the fallthrough is now
 // ROUTINE rather than rare — so a divergence at non-100% zoom would be routine too.
+//
+// 🔴 WHAT THE NARROW BOUND COSTS. Stated rather than discovered later; none of it
+// is fatal, and no value satisfying the invariant above avoids (a):
+//   (a) The retry ladder is largely CUT OFF for the OTHER transient class it was
+//       built for — `image readback failed`, the GPU/paint race behind #181's
+//       spacing invariant. Attempt 2 starts at T+700ms and must finish inside the
+//       bound; attempt 3 needs >=2200ms and can NEVER run. (At 2000ms, the maximum
+//       the invariant allows, attempt 3 is still unreachable — this is structural,
+//       not a tuning error.) Such a capture now takes CDP instead of retrying.
+//   (b) A merely SLOW-but-successful capture in the 1.5-18s band now falls through
+//       where it previously succeeded, and CDP is not a universal substitute:
+//       chrome.debugger.attach fails on a tab that already has DevTools attached,
+//       which is a case where the fast path was the ONLY working path. Sacrificing
+//       that tail is the intent — but it is a real behaviour change, not free.
+//   (c) The abandoned ladder keeps firing captureVisibleTab in the background
+//       CONCURRENTLY with the CDP capture, consuming the ~2/sec quota. There is no
+//       abort primitive for captureVisibleTab (contrast the bounded fetch, which
+//       has a signal that tears the request down), so this cannot be fixed here.
+//       At 5000ms abandonment was rare; at 1500ms it is routine. Self-healing —
+//       the next op's own retry absorbs it.
 export const FAST_CAPTURE_BUDGET_MS = 1500;
 // A /poll blocks server-side for BROWSER_BRIDGE_POLL_TIMEOUT (default 25s) before
 // its 204. 40s leaves generous headroom for a slow loopback round-trip plus the

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -1722,9 +1722,8 @@ export const STORAGE_BUDGET_MS = 5000;
 //       built for — `image readback failed`, the GPU/paint race behind #181's
 //       spacing invariant. Attempt 2 starts at T+700ms and must finish inside the
 //       bound; attempt 3 needs >=2100ms (700·1 + 700·2; probed at 2106ms) and can
-//       NEVER run. (At 2000ms, the maximum
-//       the invariant allows, attempt 3 is still unreachable — this is structural,
-//       not a tuning error.) Such a capture now takes CDP instead of retrying.
+//       NEVER run. (At 2000ms — the maximum the invariant allows — attempt 3 is
+//       still unreachable, so this is structural, not a tuning error.) Such a capture now takes CDP instead of retrying.
 //   (b) A merely SLOW-but-successful capture in the 1.5-18s band now falls through
 //       where it previously succeeded, and CDP is not a universal substitute:
 //       chrome.debugger.attach fails on a tab that already has DevTools attached,

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -1696,8 +1696,11 @@ export const STORAGE_BUDGET_MS = 5000;
 // comment describes. Raising this constant, CDP_ATTACH_TIMEOUT_MS or
 // CDP_COMMAND_TIMEOUT_MS without re-deriving the sum fails that test.
 //
-// 1500ms clears a healthy capture (measured 192-1365ms) and cuts the pathological
-// hang off ~16.5s before the op would have died outright.
+// 1500ms clears the ORDINARY healthy-capture band (control arm n=3: 292-1365ms;
+// arm A n=2: ~280ms) and cuts the pathological hang off ~16.5s before the op
+// would have died outright. ⚠ NOT "clears a healthy capture" — the same run
+// recorded a healthy capture at 17.97s (arm A′, noted above). Sacrificing that
+// 1.5-18s tail to CDP is the POINT of the bound, not an oversight.
 //
 // 🔴 DELIBERATE CONSEQUENCE, corrected from an earlier draft that claimed the
 // opposite: a genuine QUOTA STORM now falls through to CDP rather than riding out
@@ -1718,7 +1721,8 @@ export const STORAGE_BUDGET_MS = 5000;
 //   (a) The retry ladder is largely CUT OFF for the OTHER transient class it was
 //       built for — `image readback failed`, the GPU/paint race behind #181's
 //       spacing invariant. Attempt 2 starts at T+700ms and must finish inside the
-//       bound; attempt 3 needs >=2200ms and can NEVER run. (At 2000ms, the maximum
+//       bound; attempt 3 needs >=2100ms (700·1 + 700·2; probed at 2106ms) and can
+//       NEVER run. (At 2000ms, the maximum
 //       the invariant allows, attempt 3 is still unreachable — this is structural,
 //       not a tuning error.) Such a capture now takes CDP instead of retrying.
 //   (b) A merely SLOW-but-successful capture in the 1.5-18s band now falls through

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -1651,6 +1651,34 @@ export const EXEC_OP_BUDGET_MS = 18000;
 // `frames`/`screenshot` ever did. Bounded so "every await in the loop body is
 // bounded" is literally true rather than nearly true.
 export const STORAGE_BUDGET_MS = 5000;
+// 🔴 THE `screenshot` FAST PATH NEEDS ITS OWN, MUCH SMALLER BOUND — because
+// `chrome.tabs.captureVisibleTab` can HANG rather than reject, and a hang is
+// invisible to the `catch` that is supposed to fall through to CDP.
+//
+// The fast path's own comment promises "any failure there falls through to the
+// CDP path". That was only ever true of a REJECTION: captureWithRetry awaits the
+// call, so a promise that never settles never reaches the catch, and the op dies
+// at EXEC_OP_BUDGET_MS instead of taking the CDP path that would have worked.
+//
+// Measured 2026-08-24 (app-capture arc, an active tab on a non-visible
+// workspace): 3/3 `op_timeout:screenshot` pinned at 18.07-18.11s — the ceiling,
+// not a natural error latency — while the SAME tab captured fine via CDP 3/3 in
+// 381-3084ms once it was no longer its window's active tab. One arm returned via
+// captureVisibleTab at 17.97s, i.e. it can eventually settle; it is far too slow,
+// not permanently stuck. Occlusion is NOT the discriminator: the hang reproduces
+// with nothing drawn on top. Record:
+// <datapacket-talos>/claudedocs/app-capture-occlusion-refutation-2026-08-24.md
+//
+// 5s is chosen to sit ABOVE the legitimate retry ladder and far BELOW the op
+// ceiling: captureWithRetry can legitimately spend CAPTURE_MAX_ATTEMPTS(3) tries
+// spaced by max(CAPTURE_RETRY_BASE_MS(700)·attempt, CAPTURE_QUOTA_WAIT_MS(1000))
+// = 1000 + 1400 ≈ 2.4s of backoff on a real quota hit, plus the calls themselves
+// (healthy captures measured 192-1365ms). So a quota storm still RETRIES rather
+// than being pushed onto CDP, while the pathological hang is cut off ~13s before
+// the op would have failed outright. Falling through costs a debugger banner and
+// returns the SAME image: both paths measured identical 1709x1314 geometry (the
+// "CDP changes the image" caveat is about --fullpage, which is a different clip).
+export const FAST_CAPTURE_BUDGET_MS = 5000;
 // A /poll blocks server-side for BROWSER_BRIDGE_POLL_TIMEOUT (default 25s) before
 // its 204. 40s leaves generous headroom for a slow loopback round-trip plus the
 // activeTabSnapshot() that precedes the fetch, while still being a bound.

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -1630,6 +1630,13 @@ export function promiseWithTimeout(promise, ms, label, timers = {},
 //     `cdp_timeout:<method>`). Anyone lowering EXEC_OP_BUDGET_MS below 16s, or
 //     raising CDP_ATTACH_TIMEOUT_MS / CDP_COMMAND_TIMEOUT_MS, converts the
 //     attach case into a generic `op_timeout` — re-measure before touching either.
+//     🔴 A THIRD WAY TO SPEND THAT MARGIN, and it is not on this line's face:
+//     `screenshot`'s fast path can now burn FAST_CAPTURE_BUDGET_MS *before* the
+//     CDP path even starts, so on a fallthrough the real figure is
+//     1500 + 16000 = 17500 and the headroom is **500ms, not 2000ms**. That sum is
+//     pinned by a test (cdp_protocol.test.mjs) rather than by this comment,
+//     because the first draft of that constant was 5000 — which made it 21000,
+//     silently over this bound, and green under every other test in the repo.
 // Known cost: a slow-but-SUCCESSFUL CDP op in the 18–20s band is now killed at 18s
 // where it previously had until the server's 20s. That band was already mostly
 // lost to the server, so the trade is small and deliberate.
@@ -1669,16 +1676,43 @@ export const STORAGE_BUDGET_MS = 5000;
 // with nothing drawn on top. Record:
 // <datapacket-talos>/claudedocs/app-capture-occlusion-refutation-2026-08-24.md
 //
-// 5s is chosen to sit ABOVE the legitimate retry ladder and far BELOW the op
-// ceiling: captureWithRetry can legitimately spend CAPTURE_MAX_ATTEMPTS(3) tries
-// spaced by max(CAPTURE_RETRY_BASE_MS(700)·attempt, CAPTURE_QUOTA_WAIT_MS(1000))
-// = 1000 + 1400 ≈ 2.4s of backoff on a real quota hit, plus the calls themselves
-// (healthy captures measured 192-1365ms). So a quota storm still RETRIES rather
-// than being pushed onto CDP, while the pathological hang is cut off ~13s before
-// the op would have failed outright. Falling through costs a debugger banner and
-// returns the SAME image: both paths measured identical 1709x1314 geometry (the
-// "CDP changes the image" caveat is about --fullpage, which is a different clip).
-export const FAST_CAPTURE_BUDGET_MS = 5000;
+// 🔴 THE CEILING ON THIS NUMBER IS THE CDP FALLTHROUGH'S OWN BUDGET, NOT TASTE.
+// Whatever the fast path spends is spent BEFORE the CDP path starts, and it comes
+// straight out of the attach-hang margin documented at EXEC_OP_BUDGET_MS above: a
+// hung attach costs CDP_ATTACH_TIMEOUT_MS(8s) + an awaited safeDetach bounded by
+// CDP_COMMAND_TIMEOUT_MS(8s) = 16s, and that comment explicitly warns that
+// leaving it under 16s "converts the attach case into a generic op_timeout".
+// So the invariant is:
+//
+//     FAST_CAPTURE_BUDGET_MS + CDP_ATTACH_TIMEOUT_MS + CDP_COMMAND_TIMEOUT_MS
+//         <= EXEC_OP_BUDGET_MS
+//     1500 + 8000 + 8000 = 17500 <= 18000
+//
+// It is PINNED BY A TEST (cdp_protocol.test.mjs), not by this comment — an
+// earlier draft of this constant was 5000, which silently blew the sum to 21000
+// and would have mislabelled a post-fallthrough attach hang as `op_timeout`,
+// destroying the very phase attribution `fast_capture_timeout` exists to give.
+// ⚠ Be honest about what is left: 500ms of headroom, DOWN from the 2000ms that
+// comment describes. Raising this constant, CDP_ATTACH_TIMEOUT_MS or
+// CDP_COMMAND_TIMEOUT_MS without re-deriving the sum fails that test.
+//
+// 1500ms clears a healthy capture (measured 192-1365ms) and cuts the pathological
+// hang off ~16.5s before the op would have died outright.
+//
+// 🔴 DELIBERATE CONSEQUENCE, corrected from an earlier draft that claimed the
+// opposite: a genuine QUOTA STORM now falls through to CDP rather than riding out
+// the retry ladder. captureWithRetry can legitimately spend CAPTURE_MAX_ATTEMPTS(3)
+// tries spaced by max(CAPTURE_RETRY_BASE_MS(700)·attempt, CAPTURE_QUOTA_WAIT_MS
+// (1000)) = 1000 + 1400 = 2400ms of backoff PLUS the calls themselves — up to
+// ~6.5s at the top of the measured band, i.e. over this bound at any plausible
+// value that also satisfies the invariant above. That is the right trade rather
+// than a regression: CDP has NO captureVisibleTab quota, so the fallthrough is
+// exactly what a quota storm wants. It costs a debugger banner and returns the
+// SAME image — both paths measured identical 1709x1314 geometry (the "CDP changes
+// the image" caveat is about --fullpage, a different clip). ⚠ That geometry
+// equality is n=1, at one zoom/deviceScaleFactor, and the fallthrough is now
+// ROUTINE rather than rare — so a divergence at non-100% zoom would be routine too.
+export const FAST_CAPTURE_BUDGET_MS = 1500;
 // A /poll blocks server-side for BROWSER_BRIDGE_POLL_TIMEOUT (default 25s) before
 // its 204. 40s leaves generous headroom for a slow loopback round-trip plus the
 // activeTabSnapshot() that precedes the fetch, while still being a bound.

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -1008,7 +1008,19 @@ const OPS = {
           loopTiming().fastCaptureMs, "screenshot.fast", {},
           "fast_capture_timeout");
         return { url: tab.url, dataUrl, via: "captureVisibleTab" };
-      } catch (e) { /* fall through to the CDP path (works off-screen) */ }
+      } catch (e) {
+        // 🔴 LEAVE A TRACE — a silently swallowed `e` makes this path invisible.
+        // Nothing else distinguishes "the fast path was bounded out" from "the
+        // tab was not active" or "--fullpage", so without this breadcrumb there
+        // is NO way to tell in production whether FAST_CAPTURE_BUDGET_MS is set
+        // anywhere near right, and the constant's justification stays a
+        // laboratory argument forever. Same rolling slot as execute()'s
+        // breadcrumbs, so it cannot grow. Fire-and-forget, like every other one.
+        breadcrumb("screenshot", (cmd && cmd.id) || null,
+                   String((e && e.message) || e).startsWith("fast_capture_timeout")
+                     ? "fast_timeout" : "fast_failed");
+        /* fall through to the CDP path (works off-screen) */
+      }
     }
     const dataUrl = await withCdp(tab.id, tab.url, async (send) => {
       const params = { format: "png" };

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -1000,7 +1000,8 @@ const OPS = {
       // CDP path would have captured fine. Measured 2026-08-24: 3/3 timeouts
       // pinned at 18.07-18.11s here vs 3/3 CDP successes in 381-3084ms.
       // The bound turns "never settles" into a rejection, which is the ONLY
-      // shape this catch can see. See FAST_CAPTURE_BUDGET_MS for the 5s choice.
+      // shape this catch can see. See FAST_CAPTURE_BUDGET_MS for the 1500ms choice
+      // and, more importantly, for the budget invariant that CAPS it.
       try {
         const dataUrl = await promiseWithTimeout(
           captureWithRetry(() =>
@@ -1009,16 +1010,24 @@ const OPS = {
           "fast_capture_timeout");
         return { url: tab.url, dataUrl, via: "captureVisibleTab" };
       } catch (e) {
-        // 🔴 LEAVE A TRACE — a silently swallowed `e` makes this path invisible.
+        // Leave a trace — a silently swallowed `e` makes this path invisible.
         // Nothing else distinguishes "the fast path was bounded out" from "the
-        // tab was not active" or "--fullpage", so without this breadcrumb there
-        // is NO way to tell in production whether FAST_CAPTURE_BUDGET_MS is set
-        // anywhere near right, and the constant's justification stays a
-        // laboratory argument forever. Same rolling slot as execute()'s
+        // tab was not active" or "--fullpage". Same rolling slot as execute()'s
         // breadcrumbs, so it cannot grow. Fire-and-forget, like every other one.
+        //
+        // 🔴 BE HONEST ABOUT WHAT THIS BUYS, because an earlier draft of this
+        // comment claimed production measurement it does not deliver: the slot
+        // is SINGLE and execute() overwrites it with `done` as soon as the CDP
+        // fallthrough succeeds — the normal outcome. Measured write sequence
+        // with a hung fast path: ["start", "screenshot_fast_timeout", "done"],
+        // final slot `done`. So this crumb survives only when the op ALSO wedges
+        // in CDP or the worker dies mid-capture; there, it is strictly more
+        // informative than a bare `start`. It is NOT an answer to "is 1500ms the
+        // right number in production" — that needs a separate counter key that
+        // execute() does not clobber, deliberately not added here.
         breadcrumb("screenshot", (cmd && cmd.id) || null,
                    String((e && e.message) || e).startsWith("fast_capture_timeout")
-                     ? "fast_timeout" : "fast_failed");
+                     ? "screenshot_fast_timeout" : "screenshot_fast_failed");
         /* fall through to the CDP path (works off-screen) */
       }
     }
@@ -1512,7 +1521,7 @@ function loopTiming() {
     storageMs: t.storageMs == null ? STORAGE_BUDGET_MS : t.storageMs,
     // The `screenshot` fast path's own bound — see FAST_CAPTURE_BUDGET_MS. It is
     // NOT a loop budget, but it lives here so a unit test can drive a 20ms bound
-    // through the same injection point instead of waiting 5 real seconds.
+    // through the same injection point instead of waiting 1500 real ms.
     fastCaptureMs: t.fastCaptureMs == null
       ? FAST_CAPTURE_BUDGET_MS : t.fastCaptureMs,
   };
@@ -1534,6 +1543,13 @@ function breadcrumb(op, id, phase) {
 }
 
 // execute — THE choke point where every op is bounded.
+//
+// 🔴 ONE DOCUMENTED EXCEPTION EXISTS — see README "one rule, one place" and
+// FAST_CAPTURE_BUDGET_MS. `screenshot`'s FAST PATH carries its own bound, because
+// this choke point can only END an op; it cannot make a hung sub-step FALL
+// THROUGH to a working alternative, and `captureVisibleTab` hangs rather than
+// rejecting. That is a different job from the one below, not a weakening of it.
+// The paragraph that follows is still the rule for TERMINATING an op.
 //
 // The bound lives here and NOWHERE else on purpose. Patching `frames` and
 // `screenshot` individually (the two ops the journal caught wedging) would fix
@@ -1826,8 +1842,15 @@ if (!(typeof globalThis !== "undefined" && globalThis.BROWSER_BRIDGE_NO_AUTOSTAR
 // `emulationState` is exported for TESTS only — it is the sticky-emulation Map, and
 // asserting "close cleared it" / "a vanished tab dropped it" requires seeing it.
 // Nothing in production reads it from outside this module.
+// `loopTiming` is exported for TESTS only — it is the seam between the protocol.js
+// budget constants and the code that actually reads them. Pinning the CONSTANT is
+// not the same claim as pinning that production USES it: a re-audit mutated this
+// function's `fastCaptureMs` default to a literal 600000 and the whole 501-test
+// suite stayed green, because the relationship test reads the constant while the
+// behavioural tests inject an override. Exporting it lets one assertion close that
+// gap without a 1.5s timing test.
 export { execute, OPS, ALLOWED_OPS, cdpAttached, loop, emulationState,
-         documentEmulation };
+         documentEmulation, loopTiming };
 
 // A read/reset window onto the loop's private liveness state, for tests.
 export const loopState = {

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -50,7 +50,7 @@ import {
   // body is raced against a wall-clock budget (see protocol.js for why and for
   // the CDP < exec < server-cmd_timeout ordering).
   promiseWithTimeout, EXEC_OP_BUDGET_MS, POLL_BUDGET_MS, RESULT_BUDGET_MS,
-  LOOP_STALL_MS, STORAGE_BUDGET_MS,
+  LOOP_STALL_MS, STORAGE_BUDGET_MS, FAST_CAPTURE_BUDGET_MS,
   // `emulate` op: device emulation (viewport/touch/UA+UA-CH/media/geo/tz) that is
   // STICKY per tab because CDP overrides die at detach — see the EMULATION section
   // in protocol.js for the central problem and the safety property it buys.
@@ -973,7 +973,8 @@ const OPS = {
   // it fixes the captureVisibleTab "can only grab the foreground tab" limitation,
   // and lets two profiles each screenshot their own tab). A FAST path keeps the
   // cheap, banner-free captureVisibleTab for a tab that IS already visible (and not
-  // --fullpage); any failure there falls through to the CDP path. `--fullpage`
+  // --fullpage); any failure there — INCLUDING A HANG, which is why the fast path
+  // carries its own bound — falls through to the CDP path. `--fullpage`
   // captures the whole scrollable document (CDP only). Attach is REFUSED on a
   // privileged tab (assertCdpAttachable inside withCdp) before any attach.
   //
@@ -992,9 +993,20 @@ const OPS = {
     if (tab.active && !fullpage && !emulated) {
       // Fast path — no debugger attach/banner. Chrome throttles captureVisibleTab to
       // ~2/sec; captureWithRetry spaces the (rare) retry ≥ the quota window.
+      // 🔴 BOUNDED, because captureVisibleTab can HANG instead of rejecting, and
+      // a hang is invisible to the catch below. Unbounded, this `await` simply
+      // never returned and the op died at EXEC_OP_BUDGET_MS (18s) — so the
+      // fall-through this catch promises never happened, on exactly the tab the
+      // CDP path would have captured fine. Measured 2026-08-24: 3/3 timeouts
+      // pinned at 18.07-18.11s here vs 3/3 CDP successes in 381-3084ms.
+      // The bound turns "never settles" into a rejection, which is the ONLY
+      // shape this catch can see. See FAST_CAPTURE_BUDGET_MS for the 5s choice.
       try {
-        const dataUrl = await captureWithRetry(() =>
-          chrome.tabs.captureVisibleTab(tab.windowId, { format: "png" }));
+        const dataUrl = await promiseWithTimeout(
+          captureWithRetry(() =>
+            chrome.tabs.captureVisibleTab(tab.windowId, { format: "png" })),
+          loopTiming().fastCaptureMs, "screenshot.fast", {},
+          "fast_capture_timeout");
         return { url: tab.url, dataUrl, via: "captureVisibleTab" };
       } catch (e) { /* fall through to the CDP path (works off-screen) */ }
     }
@@ -1486,6 +1498,11 @@ function loopTiming() {
     resultMs: t.resultMs == null ? RESULT_BUDGET_MS : t.resultMs,
     stallMs: t.stallMs == null ? LOOP_STALL_MS : t.stallMs,
     storageMs: t.storageMs == null ? STORAGE_BUDGET_MS : t.storageMs,
+    // The `screenshot` fast path's own bound — see FAST_CAPTURE_BUDGET_MS. It is
+    // NOT a loop budget, but it lives here so a unit test can drive a 20ms bound
+    // through the same injection point instead of waiting 5 real seconds.
+    fastCaptureMs: t.fastCaptureMs == null
+      ? FAST_CAPTURE_BUDGET_MS : t.fastCaptureMs,
   };
 }
 

--- a/scripts/browser-bridge/tests/cdp_protocol.test.mjs
+++ b/scripts/browser-bridge/tests/cdp_protocol.test.mjs
@@ -213,8 +213,13 @@ test("fullPageClip uses the css content size for a full-document capture", () =>
 // the op SETTLES and control returns to the poll loop.
 
 test("timeout budgets are chosen well under the 20s server cmd_timeout", () => {
+  // EXEC_OP_BUDGET_MS belongs here too, and its absence was load-bearing: it is
+  // the right-hand side of the fast-path inequality below, so relaxing IT is the
+  // easiest way to satisfy that test — and a mutant raising it to 25000 (past the
+  // server's own 20s cmd_timeout, after which the envelope can never reach the
+  // caller at all) survived the entire suite.
   for (const ms of [CDP_ATTACH_TIMEOUT_MS, CDP_COMMAND_TIMEOUT_MS, CDP_OP_BUDGET_MS,
-                    FAST_CAPTURE_BUDGET_MS]) {
+                    FAST_CAPTURE_BUDGET_MS, EXEC_OP_BUDGET_MS]) {
     assert.ok(ms > 0 && ms < 20000, `budget ${ms} must be >0 and < the 20s server timeout`);
   }
 });
@@ -242,10 +247,21 @@ test("fast-path bound leaves the CDP fallthrough its full attach-hang budget", (
     `${FAST_CAPTURE_BUDGET_MS + attachHangCost}ms must fit the ${EXEC_OP_BUDGET_MS}ms ` +
     `op ceiling, or a post-fallthrough attach hang reports op_timeout instead of ` +
     `cdp_timeout:attach`);
-  // And it must still clear a healthy capture (measured 192-1365ms), or the bound
-  // pushes ordinary successes onto CDP and the fast path stops being a fast path.
+  // And it must still clear the ORDINARY healthy-capture band, or the bound pushes
+  // routine successes onto CDP and the fast path stops being a fast path.
+  //
+  // 🔴 THE BAND, NOT "THE SLOWEST" — an earlier version of this assertion said
+  // "must exceed the slowest measured healthy capture", which is FALSE and was the
+  // kind of false claim a test is worst at carrying, because the next person tuning
+  // this constant reasons from it. The same measurement run recorded a SUCCESSFUL
+  // capture at 17,970ms (arm A′). The slowest healthy capture is ~18s, not 1365ms.
+  // 1365ms is the top of the ORDINARY band (control arm, n=3: 292-1365ms; arm A,
+  // n=2: ~280ms). Sacrificing the 1.5-18s tail to CDP is the POINT of the bound,
+  // not a side effect. (The 292 figure also corrects a transcription error: the
+  // "192" previously quoted here came from a different 2026-08-19 measurement.)
   assert.ok(FAST_CAPTURE_BUDGET_MS > 1365,
-            "bound must exceed the slowest measured healthy capture");
+            "bound must exceed the ordinary healthy-capture band (292-1365ms), or "
+            + "routine successes fall through to CDP");
 });
 
 test("promiseWithTimeout: a hung promise rejects with cdp_timeout:<label> (settles, not hangs)", async () => {

--- a/scripts/browser-bridge/tests/cdp_protocol.test.mjs
+++ b/scripts/browser-bridge/tests/cdp_protocol.test.mjs
@@ -213,11 +213,22 @@ test("fullPageClip uses the css content size for a full-document capture", () =>
 // the op SETTLES and control returns to the poll loop.
 
 test("timeout budgets are chosen well under the 20s server cmd_timeout", () => {
-  // EXEC_OP_BUDGET_MS belongs here too, and its absence was load-bearing: it is
-  // the right-hand side of the fast-path inequality below, so relaxing IT is the
-  // easiest way to satisfy that test — and a mutant raising it to 25000 (past the
-  // server's own 20s cmd_timeout, after which the envelope can never reach the
-  // caller at all) survived the entire suite.
+  // EXEC_OP_BUDGET_MS is included because it is the right-hand side of the
+  // fast-path inequality below, so it belongs in the same class bound.
+  //
+  // 🔴 CORRECTION, and it is this PR's own defect class for the third time: an
+  // earlier version of this comment claimed a mutant raising EXEC_OP_BUDGET_MS to
+  // 25000 "survived the entire suite". THAT IS FALSE, and it was written in as
+  // measured fact on an auditor's say-so without being re-run. Measured directly:
+  // it is pinned EXACTLY, twice, and both pins predate this PR —
+  // `tests/emulation.test.mjs:342` ("BUDGET: the step count is bounded by a
+  // CONSTANT") fails `25000 !== 18000`, and `test_server.py`'s
+  // test_exec_budget_matches_the_extension pins it across the language boundary.
+  // It survives only when cdp_protocol.test.mjs is run ALONE, which is what that
+  // claim was really measuring. So this entry adds the CLASS bound (< 20s) that a
+  // single-file run cannot mislead about; it does not close a hole, because there
+  // was none. Re-verify a mutation result before quoting it — including one an
+  // auditor hands you.
   for (const ms of [CDP_ATTACH_TIMEOUT_MS, CDP_COMMAND_TIMEOUT_MS, CDP_OP_BUDGET_MS,
                     FAST_CAPTURE_BUDGET_MS, EXEC_OP_BUDGET_MS]) {
     assert.ok(ms > 0 && ms < 20000, `budget ${ms} must be >0 and < the 20s server timeout`);

--- a/scripts/browser-bridge/tests/cdp_protocol.test.mjs
+++ b/scripts/browser-bridge/tests/cdp_protocol.test.mjs
@@ -16,6 +16,7 @@ import {
   elementRectExpression, focusExpression, fullPageClip,
   promiseWithTimeout, assertTabCdpReady, TAB_DISCARDED_MESSAGE,
   CDP_ATTACH_TIMEOUT_MS, CDP_COMMAND_TIMEOUT_MS, CDP_OP_BUDGET_MS,
+  FAST_CAPTURE_BUDGET_MS, EXEC_OP_BUDGET_MS,
   matchCdpFrameId, pickOopifSessionId, evalValueOrThrow,
 } from "../extension/protocol.js";
 
@@ -212,9 +213,39 @@ test("fullPageClip uses the css content size for a full-document capture", () =>
 // the op SETTLES and control returns to the poll loop.
 
 test("timeout budgets are chosen well under the 20s server cmd_timeout", () => {
-  for (const ms of [CDP_ATTACH_TIMEOUT_MS, CDP_COMMAND_TIMEOUT_MS, CDP_OP_BUDGET_MS]) {
+  for (const ms of [CDP_ATTACH_TIMEOUT_MS, CDP_COMMAND_TIMEOUT_MS, CDP_OP_BUDGET_MS,
+                    FAST_CAPTURE_BUDGET_MS]) {
     assert.ok(ms > 0 && ms < 20000, `budget ${ms} must be >0 and < the 20s server timeout`);
   }
+});
+
+// 🔴 THE `screenshot` FAST-PATH BOUND IS ONLY SAFE RELATIVE TO WHAT FOLLOWS IT.
+//
+// Whatever the fast path spends is spent BEFORE the CDP fallthrough begins, and
+// it comes out of the attach-hang margin that EXEC_OP_BUDGET_MS's own comment
+// calls THIN: a hung attach costs CDP_ATTACH_TIMEOUT_MS + an awaited safeDetach
+// bounded by CDP_COMMAND_TIMEOUT_MS = 16s against the 18s op ceiling, and that
+// comment warns that dropping below 16s "converts the attach case into a generic
+// op_timeout" — i.e. destroys the phase attribution the whole timeout scheme
+// exists to provide.
+//
+// This is pinned as a RELATIONSHIP, in the style of wake.test.mjs, because the
+// failure mode is changing ONE of these four numbers without re-deriving the sum.
+// The first draft of FAST_CAPTURE_BUDGET_MS was 5000, which makes this 21000 —
+// over the ceiling, and green under every other test in this repo.
+test("fast-path bound leaves the CDP fallthrough its full attach-hang budget", () => {
+  const attachHangCost = CDP_ATTACH_TIMEOUT_MS + CDP_COMMAND_TIMEOUT_MS;
+  assert.equal(attachHangCost, 16000, "the documented attach-hang cost moved — re-derive");
+  assert.ok(
+    FAST_CAPTURE_BUDGET_MS + attachHangCost <= EXEC_OP_BUDGET_MS,
+    `fast path (${FAST_CAPTURE_BUDGET_MS}ms) + attach-hang (${attachHangCost}ms) = ` +
+    `${FAST_CAPTURE_BUDGET_MS + attachHangCost}ms must fit the ${EXEC_OP_BUDGET_MS}ms ` +
+    `op ceiling, or a post-fallthrough attach hang reports op_timeout instead of ` +
+    `cdp_timeout:attach`);
+  // And it must still clear a healthy capture (measured 192-1365ms), or the bound
+  // pushes ordinary successes onto CDP and the fast path stops being a fast path.
+  assert.ok(FAST_CAPTURE_BUDGET_MS > 1365,
+            "bound must exceed the slowest measured healthy capture");
 });
 
 test("promiseWithTimeout: a hung promise rejects with cdp_timeout:<label> (settles, not hangs)", async () => {

--- a/scripts/browser-bridge/tests/service_worker.test.mjs
+++ b/scripts/browser-bridge/tests/service_worker.test.mjs
@@ -318,8 +318,11 @@ test("screenshot fast path: a HUNG captureVisibleTab falls through to CDP",
   // 1000ms, so any run reaching this point is necessarily under it. An earlier
   // `Date.now() - started < 1000` could therefore only ever fire as a 1-2ms
   // boundary flake — a guard that cannot fail for its stated reason is worse than
-  // none, because it reads as coverage. The bound's real magnitude is pinned in
-  // the production-wiring test below.)
+  // none, because it reads as coverage. The bound's magnitude is not pinned
+  // anywhere — it is BOUNDED, from both sides: `> 1365` and the `FAST + 16s <=
+  // 18s` sum invariant, both in cdp_protocol.test.mjs. The wiring test below pins
+  // the WIRE, not the value. Saying "pinned" of either would be a fourth loose
+  // claim in a PR whose whole history is loose claims.)
 });
 
 // 🔴 PINNING THE CONSTANT IS NOT PINNING THAT PRODUCTION USES IT.
@@ -349,6 +352,15 @@ test("loop budgets are wired to their constants, not to literals", async () => {
       storageMs: STORAGE_BUDGET_MS,
       fastCaptureMs: FAST_CAPTURE_BUDGET_MS,
     };
+    // 🔴 THE GUARD IS ONLY AS GOOD AS THE VALUES BEING DISTINCT. If two budgets
+    // ever hold the SAME number, swapping their wires passes every assertion
+    // below — the collapsed-fixture trap, where a fixture cannot express the
+    // difference it exists to detect. They are pairwise distinct today
+    // (1500/5000/10000/18000/40000/180000); this keeps it that way rather than
+    // leaving it to luck, and fails loudly on the day someone picks a duplicate.
+    assert.equal(new Set(Object.values(wired)).size, Object.keys(wired).length,
+                 "two budgets share a value — a swapped wire would be undetectable; "
+                 + "give them distinct values or assert the swap directly");
     const actual = loopTiming();
     assert.deepEqual(Object.keys(actual).sort(), Object.keys(wired).sort(),
                      "a budget was added or removed — wire it to a constant here");

--- a/scripts/browser-bridge/tests/service_worker.test.mjs
+++ b/scripts/browser-bridge/tests/service_worker.test.mjs
@@ -81,7 +81,9 @@ globalThis.chrome = {
 };
 
 const { OPS, loopTiming } = await import("../extension/service_worker.js");
-const { FAST_CAPTURE_BUDGET_MS } = await import("../extension/protocol.js");
+const { FAST_CAPTURE_BUDGET_MS, EXEC_OP_BUDGET_MS, POLL_BUDGET_MS,
+        RESULT_BUDGET_MS, LOOP_STALL_MS, STORAGE_BUDGET_MS }
+  = await import("../extension/protocol.js");
 
 function lastExec() { return state.calls.executeScript[state.calls.executeScript.length - 1]; }
 
@@ -289,7 +291,6 @@ test("screenshot fast path: a HUNG captureVisibleTab falls through to CDP",
   globalThis.BROWSER_BRIDGE_LOOP_TIMING = { ...(realTiming || {}), fastCaptureMs: 20 };
   chrome.tabs.captureVisibleTab = () => new Promise(() => {});   // never settles
   state.tab.active = true;                                        // → fast path
-  const started = Date.now();
   // 🔴 RACE IT HERE rather than leaning on `{ timeout }` alone, so a regression is
   // counted as a FAILURE and not as a CANCELLATION. node scores a timed-out test
   // `cancelled`, leaving `fail` at 0 — so a gate that greps the fail count reads
@@ -319,7 +320,6 @@ test("screenshot fast path: a HUNG captureVisibleTab falls through to CDP",
   // boundary flake — a guard that cannot fail for its stated reason is worse than
   // none, because it reads as coverage. The bound's real magnitude is pinned in
   // the production-wiring test below.)
-  void started;
 });
 
 // 🔴 PINNING THE CONSTANT IS NOT PINNING THAT PRODUCTION USES IT.
@@ -330,13 +330,33 @@ test("screenshot fast path: a HUNG captureVisibleTab falls through to CDP",
 // FAST_CAPTURE_BUDGET_MS to a literal 600000 left ALL 501 tests green, i.e. the
 // original surviving mutant was still alive, just spelled one level down. This is
 // the seam assertion; it must run with NO override active.
-test("fast-path bound is wired to the constant, not to a literal", async () => {
+// 🔴 ALL SIX WIRES, not just the one this PR touched. Pinning only fastCaptureMs
+// left the SAME seam open on every other budget — and on the most important one:
+// mutating `execMs`'s default from EXEC_OP_BUDGET_MS to a literal 999999 left the
+// whole 502-test suite GREEN, i.e. the choke-point op budget could be silently
+// disconnected from its constant while every test that pins the CONSTANT's value
+// still passed. A per-field loop makes adding a 7th budget fail here until it is
+// wired, rather than silently going unpinned like these five did.
+test("loop budgets are wired to their constants, not to literals", async () => {
   const realTiming = globalThis.BROWSER_BRIDGE_LOOP_TIMING;
   delete globalThis.BROWSER_BRIDGE_LOOP_TIMING;
   try {
-    assert.equal(loopTiming().fastCaptureMs, FAST_CAPTURE_BUDGET_MS,
-                 "production must read FAST_CAPTURE_BUDGET_MS, so the budget "
-                 + "invariant in cdp_protocol.test.mjs actually governs runtime");
+    const wired = {
+      execMs: EXEC_OP_BUDGET_MS,
+      pollMs: POLL_BUDGET_MS,
+      resultMs: RESULT_BUDGET_MS,
+      stallMs: LOOP_STALL_MS,
+      storageMs: STORAGE_BUDGET_MS,
+      fastCaptureMs: FAST_CAPTURE_BUDGET_MS,
+    };
+    const actual = loopTiming();
+    assert.deepEqual(Object.keys(actual).sort(), Object.keys(wired).sort(),
+                     "a budget was added or removed — wire it to a constant here");
+    for (const [field, constant] of Object.entries(wired)) {
+      assert.equal(actual[field], constant,
+                   `loopTiming().${field} must read its protocol.js constant, or the `
+                   + `value assertions elsewhere do not govern runtime`);
+    }
   } finally {
     if (realTiming === undefined) delete globalThis.BROWSER_BRIDGE_LOOP_TIMING;
     else globalThis.BROWSER_BRIDGE_LOOP_TIMING = realTiming;

--- a/scripts/browser-bridge/tests/service_worker.test.mjs
+++ b/scripts/browser-bridge/tests/service_worker.test.mjs
@@ -254,35 +254,67 @@ test("screenshot STILL uses the chrome.debugger (CDP) path — not regressed to 
 // on a tab CDP would have captured in well under a second. Measured 2026-08-24,
 // 3/3 `op_timeout:screenshot` at 18.07-18.11s vs 3/3 CDP successes 381-3084ms.
 //
-// RED WITHOUT THE FIX: with the bound removed this test does not fail with an
-// assertion, it HANGS until the runner's own timeout kills it — which is exactly
-// the production symptom, so the test is a faithful reproduction rather than a
-// restatement of the patch.
-test("screenshot fast path: a HUNG captureVisibleTab falls through to CDP", async () => {
+// RED WITHOUT THE FIX — and it must be red as a FAILURE, never as a hang.
+//
+// 🔴 THE `{ timeout }` IS LOAD-BEARING, NOT HYGIENE. With the bound reverted and
+// no per-test timeout, this file does not fail — it WEDGES: measured, the runner
+// never exits (still running at 200s), prints NO summary, reports `not ok` = 0
+// and `# fail` = 0, and the 12 tests declared after this one NEVER RUN. So the
+// regression this test exists to catch would read as CLEAN to any gate that
+// counts failures, while silently blinding the back half of the file. A hang is
+// the one failure shape a green-suite check cannot distinguish from success.
+// With the timeout it fails with an attributable message and the file completes.
+// 🔴 CLEANUP IS `t.after`, NOT `finally`, AND THAT IS THE SECOND HALF OF THE FIX.
+// A `finally` around the await does NOT run when the test times out — the await
+// never settles, so the block is never reached. Measured with the bound reverted:
+// the hung stub and `tab.active = true` LEAKED into the following tests, hanging
+// the healthy-fast-path control too, and the file still died at the runner's own
+// timeout with `fail=0, cancelled=2` and 10 tests never run — i.e. still the
+// count-blind shape this timeout was added to remove. `t.after` runs even on a
+// timed-out test, so exactly ONE test fails and the other 22 still execute.
+test("screenshot fast path: a HUNG captureVisibleTab falls through to CDP",
+     { timeout: 2000 }, async (t) => {
   resetCalls();
   const realCapture = chrome.tabs.captureVisibleTab;
   const realTiming = globalThis.BROWSER_BRIDGE_LOOP_TIMING;
-  // 20ms bound instead of the real 5s, via the same injection point the loop
-  // budgets already use.
-  globalThis.BROWSER_BRIDGE_LOOP_TIMING = { ...(realTiming || {}), fastCaptureMs: 20 };
-  chrome.tabs.captureVisibleTab = () => new Promise(() => {});   // never settles
-  state.tab.active = true;                                        // → fast path
-  try {
-    const started = Date.now();
-    const out = await OPS.screenshot({ tabId: TAB_ID });
-    assert.equal(out.via, "cdp", "a hung fast path must fall through to CDP");
-    assert.match(out.dataUrl, /^data:image\/png;base64,/);
-    assert.ok(state.calls.debugger.includes("Page.captureScreenshot"),
-              "the CDP path actually ran");
-    assert.ok(state.calls.debugger.includes("detach"), "always detaches");
-    // Bounded, not merely eventual: nowhere near the 18s op ceiling.
-    assert.ok(Date.now() - started < 5000,
-              "must be cut off by the fast-path bound, not by the op budget");
-  } finally {
+  t.after(() => {
     chrome.tabs.captureVisibleTab = realCapture;
     globalThis.BROWSER_BRIDGE_LOOP_TIMING = realTiming;
     state.tab.active = false;
-  }
+  });
+  // 20ms bound instead of the real 1500ms, via the same injection point the loop
+  // budgets already use. The production VALUE is pinned separately, in
+  // cdp_protocol.test.mjs — this test covers the mechanism, not the number.
+  globalThis.BROWSER_BRIDGE_LOOP_TIMING = { ...(realTiming || {}), fastCaptureMs: 20 };
+  chrome.tabs.captureVisibleTab = () => new Promise(() => {});   // never settles
+  state.tab.active = true;                                        // → fast path
+  const started = Date.now();
+  // 🔴 RACE IT HERE rather than leaning on `{ timeout }` alone, so a regression is
+  // counted as a FAILURE and not as a CANCELLATION. node scores a timed-out test
+  // `cancelled`, leaving `fail` at 0 — so a gate that greps the fail count reads
+  // a regression as clean, which is the same count-blindness in a smaller shape.
+  // Racing it makes the regression an ordinary assertion failure with a message
+  // that names the cause. The `{ timeout: 2000 }` above stays as the backstop for
+  // anything that hangs OUTSIDE this race.
+  let hangTimer;
+  const out = await Promise.race([
+    OPS.screenshot({ tabId: TAB_ID }),
+    new Promise((_, reject) => {
+      hangTimer = setTimeout(
+        () => reject(new Error("screenshot did not settle within 1s: the fast path "
+                               + "is unbounded, so a hung captureVisibleTab never "
+                               + "reaches the catch that falls through to CDP")),
+        1000);
+    }),
+  ]).finally(() => clearTimeout(hangTimer));
+  assert.equal(out.via, "cdp", "a hung fast path must fall through to CDP");
+  assert.match(out.dataUrl, /^data:image\/png;base64,/);
+  assert.ok(state.calls.debugger.includes("Page.captureScreenshot"),
+            "the CDP path actually ran");
+  assert.ok(state.calls.debugger.includes("detach"), "always detaches");
+  // Bounded, not merely eventual: nowhere near the 18s op ceiling.
+  assert.ok(Date.now() - started < 1000,
+            "must be cut off by the fast-path bound, not by the op budget");
 });
 
 // ATTRIBUTION CONTROL for the test above: the bound must not simply push every

--- a/scripts/browser-bridge/tests/service_worker.test.mjs
+++ b/scripts/browser-bridge/tests/service_worker.test.mjs
@@ -246,6 +246,62 @@ test("screenshot STILL uses the chrome.debugger (CDP) path — not regressed to 
 });
 
 // --------------------------------------------------------------------------- //
+// 🔴 THE FAST PATH MUST SURVIVE A HANG, NOT ONLY A REJECTION.
+//
+// `chrome.tabs.captureVisibleTab` can simply never settle. Before the fast-path
+// bound, the `catch` that is supposed to fall through to CDP could not see that:
+// the await never returned, and the whole op died at EXEC_OP_BUDGET_MS (18s) —
+// on a tab CDP would have captured in well under a second. Measured 2026-08-24,
+// 3/3 `op_timeout:screenshot` at 18.07-18.11s vs 3/3 CDP successes 381-3084ms.
+//
+// RED WITHOUT THE FIX: with the bound removed this test does not fail with an
+// assertion, it HANGS until the runner's own timeout kills it — which is exactly
+// the production symptom, so the test is a faithful reproduction rather than a
+// restatement of the patch.
+test("screenshot fast path: a HUNG captureVisibleTab falls through to CDP", async () => {
+  resetCalls();
+  const realCapture = chrome.tabs.captureVisibleTab;
+  const realTiming = globalThis.BROWSER_BRIDGE_LOOP_TIMING;
+  // 20ms bound instead of the real 5s, via the same injection point the loop
+  // budgets already use.
+  globalThis.BROWSER_BRIDGE_LOOP_TIMING = { ...(realTiming || {}), fastCaptureMs: 20 };
+  chrome.tabs.captureVisibleTab = () => new Promise(() => {});   // never settles
+  state.tab.active = true;                                        // → fast path
+  try {
+    const started = Date.now();
+    const out = await OPS.screenshot({ tabId: TAB_ID });
+    assert.equal(out.via, "cdp", "a hung fast path must fall through to CDP");
+    assert.match(out.dataUrl, /^data:image\/png;base64,/);
+    assert.ok(state.calls.debugger.includes("Page.captureScreenshot"),
+              "the CDP path actually ran");
+    assert.ok(state.calls.debugger.includes("detach"), "always detaches");
+    // Bounded, not merely eventual: nowhere near the 18s op ceiling.
+    assert.ok(Date.now() - started < 5000,
+              "must be cut off by the fast-path bound, not by the op budget");
+  } finally {
+    chrome.tabs.captureVisibleTab = realCapture;
+    globalThis.BROWSER_BRIDGE_LOOP_TIMING = realTiming;
+    state.tab.active = false;
+  }
+});
+
+// ATTRIBUTION CONTROL for the test above: the bound must not simply push every
+// capture onto CDP. A healthy fast path is still the fast path — otherwise the
+// test above would pass just as well with the fast path deleted outright, and
+// would be recording coverage it does not have.
+test("screenshot fast path: a HEALTHY captureVisibleTab is still used", async () => {
+  resetCalls();
+  state.tab.active = true;
+  try {
+    const out = await OPS.screenshot({ tabId: TAB_ID });
+    assert.equal(out.via, "captureVisibleTab", "healthy fast path must NOT go to CDP");
+    assert.equal(state.calls.debugger.length, 0, "no debugger attach on the fast path");
+  } finally {
+    state.tab.active = false;
+  }
+});
+
+// --------------------------------------------------------------------------- //
 // `activate` op: foreground the tab (tabs.update{active} + windows.update{focused})
 // then bounded wait-for-load. Wiring only — the wait LOGIC is unit-tested in
 // protocol.test.mjs. No CDP/debugger, no executeScript, no new permission.

--- a/scripts/browser-bridge/tests/service_worker.test.mjs
+++ b/scripts/browser-bridge/tests/service_worker.test.mjs
@@ -80,7 +80,8 @@ globalThis.chrome = {
   alarms: { create() {}, onAlarm: { addListener() {} } },
 };
 
-const { OPS } = await import("../extension/service_worker.js");
+const { OPS, loopTiming } = await import("../extension/service_worker.js");
+const { FAST_CAPTURE_BUDGET_MS } = await import("../extension/protocol.js");
 
 function lastExec() { return state.calls.executeScript[state.calls.executeScript.length - 1]; }
 
@@ -312,9 +313,34 @@ test("screenshot fast path: a HUNG captureVisibleTab falls through to CDP",
   assert.ok(state.calls.debugger.includes("Page.captureScreenshot"),
             "the CDP path actually ran");
   assert.ok(state.calls.debugger.includes("detach"), "always detaches");
-  // Bounded, not merely eventual: nowhere near the 18s op ceiling.
-  assert.ok(Date.now() - started < 1000,
-            "must be cut off by the fast-path bound, not by the op budget");
+  // (No elapsed-time assertion here: the Promise.race above already rejects at
+  // 1000ms, so any run reaching this point is necessarily under it. An earlier
+  // `Date.now() - started < 1000` could therefore only ever fire as a 1-2ms
+  // boundary flake — a guard that cannot fail for its stated reason is worse than
+  // none, because it reads as coverage. The bound's real magnitude is pinned in
+  // the production-wiring test below.)
+  void started;
+});
+
+// 🔴 PINNING THE CONSTANT IS NOT PINNING THAT PRODUCTION USES IT.
+//
+// The test above injects `fastCaptureMs: 20`, and cdp_protocol.test.mjs asserts
+// the CONSTANT's value — so between them, nothing checked the wire connecting the
+// two. Measured by a re-audit: mutating loopTiming()'s default from
+// FAST_CAPTURE_BUDGET_MS to a literal 600000 left ALL 501 tests green, i.e. the
+// original surviving mutant was still alive, just spelled one level down. This is
+// the seam assertion; it must run with NO override active.
+test("fast-path bound is wired to the constant, not to a literal", async () => {
+  const realTiming = globalThis.BROWSER_BRIDGE_LOOP_TIMING;
+  delete globalThis.BROWSER_BRIDGE_LOOP_TIMING;
+  try {
+    assert.equal(loopTiming().fastCaptureMs, FAST_CAPTURE_BUDGET_MS,
+                 "production must read FAST_CAPTURE_BUDGET_MS, so the budget "
+                 + "invariant in cdp_protocol.test.mjs actually governs runtime");
+  } finally {
+    if (realTiming === undefined) delete globalThis.BROWSER_BRIDGE_LOOP_TIMING;
+    else globalThis.BROWSER_BRIDGE_LOOP_TIMING = realTiming;
+  }
 });
 
 // ATTRIBUTION CONTROL for the test above: the bound must not simply push every


### PR DESCRIPTION
## The defect

`screenshot` takes a fast path (`chrome.tabs.captureVisibleTab`) when the tab is its window's active tab, guarded by a `catch` whose comment promises *"any failure there falls through to the CDP path"*.

That was only ever true of a **rejection**. `captureWithRetry` awaits the call, so a promise that **never settles** never reaches the catch — the op burned the whole `EXEC_OP_BUDGET_MS` (18 s) and returned `op_timeout:screenshot`, on exactly the tab the CDP path captures fine.

## Measurement (2026-08-24, app-capture arc)

An active tab on a non-visible workspace:

| path | n | result |
|---|---|---|
| fast (`captureVisibleTab`) | 3 | `op_timeout` **pinned at 18.07–18.11 s** — the ceiling, not a natural error latency |
| CDP (same tab, backgrounded) | 3 | **ok**, 381–3084 ms, identical **1709×1314** geometry |

One arm *did* return via `captureVisibleTab` at **17.97 s** — so it is far too slow, not permanently stuck.

🔴 **Occlusion is not the discriminator**, which is what sent the earlier diagnosis wrong: the hang reproduces with the window merely on a non-visible workspace and **nothing drawn on top** — the same state that had succeeded 3/3 at ~292 ms twenty minutes earlier.

## The fix

Bound the fast path at `FAST_CAPTURE_BUDGET_MS` (5 s) and let the existing catch do its job. The bound turns "never settles" into a rejection, which is the only shape that catch can see.

5 s sits **above** the legitimate retry ladder (a real quota hit spends ~2.4 s of backoff across `CAPTURE_MAX_ATTEMPTS`, so a quota storm still *retries* rather than being pushed onto CDP) and far **below** the 18 s op ceiling. Falling through costs a debugger banner and returns the same image — the "CDP changes the image" caveat is about `--fullpage`, a different clip.

## Tests

- a **hung** `captureVisibleTab` must fall through to CDP;
- an **attribution control** that a *healthy* one is still used — without it the test would pass just as well with the fast path deleted outright.

**Red at base**, verified by reverting the bound: the test does not fail with an assertion, it **hangs** — killed at 30 s with `pass 0 / cancelled 1` and *"Promise resolution is still pending"*. That is the production symptom itself, so the test reproduces the defect rather than restating the patch. Green at HEAD.

Full suite: **500 mjs + 783 python, all passing**. `build_id.js` regenerated because the extension source changed (its own gate caught that and named the command).

## Not verified live

🔴 The deployed extension at `~/.local/share/browser-bridge-ext` still runs the old build. This needs a deploy + Brave reload, then `browser ping` to confirm buildMarker `aefab9d551a8d058` is the **running** code. Reproducing the hang on demand is intermittent, so live confirmation is opportunistic.

Record: `<datapacket-talos>/claudedocs/app-capture-occlusion-refutation-2026-08-24.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
