### PR TITLE
fix(dl-router): retry SQLITE_BUSY in the store — a contended write was silently LOST (#349)

### DIFF
--- a/scripts/dl-router/store.py
+++ b/scripts/dl-router/store.py
@@ -6,8 +6,10 @@ confusing qBittorrent and media scanners.
 
 Concurrency: the sidecar is threaded (one thread per HTTP request) and the CLI
 runs out-of-process against the same file, so WAL + a busy timeout + one
-connection per thread is the required shape. Schema changes go through
-`MIGRATIONS`; `user_version` is the version marker.
+connection per thread is the required shape. That shape is necessary and NOT
+sufficient — see `Store._write` for the durability hole a busy timeout alone
+leaves open. Schema changes go through `MIGRATIONS`; `user_version` is the
+version marker.
 """
 from __future__ import annotations
 
@@ -19,6 +21,61 @@ from pathlib import Path
 from urllib.parse import urlsplit
 
 SCHEMA_VERSION = 6
+
+# --- SQLITE_BUSY retry ------------------------------------------------------ #
+#
+# `busy_timeout` bounds how long ONE statement waits for the write lock. When it
+# expires SQLite raises `OperationalError: database is locked` and the caller's
+# write is simply GONE — in the sidecar the thread serving that request dies and
+# the routing decision is never recorded. Measured on the pre-fix tree, 6
+# threads x 25 upserts against one file, expecting 150 rows:
+#
+#     busy_timeout=10.0    errors=0   rows=150
+#     busy_timeout=0.5     errors=1   rows=125   ROWS LOST
+#     busy_timeout=0.05    errors=5   rows=25    ROWS LOST
+#     busy_timeout=0.005   errors=5   rows=25    ROWS LOST
+#
+# Raising the default timeout is NOT the fix: it moves the threshold and leaves
+# the write lossy past it. Every mutating statement therefore goes through
+# `Store._write`, which retries the whole transaction while SQLite says BUSY.
+SQLITE_BUSY = 5
+SQLITE_LOCKED = 6
+
+# Total wall clock the retry loop may spend on one write. It bounds the RETRIES,
+# not a single statement's own busy wait — with the default 10s busy_timeout a
+# contended write blocks inside SQLite first and this only decides whether it
+# gets another go. Chosen against the alternative it replaces: the sidecar
+# previously answered fast and silently dropped the row.
+WRITE_DEADLINE = 30.0
+# Belt to the deadline's braces: caps churn when busy_timeout is tiny and each
+# attempt returns in microseconds.
+WRITE_ATTEMPTS = 64
+RETRY_BASE = 0.005      # first backoff, seconds
+RETRY_CAP = 0.2         # backoff ceiling, seconds
+
+
+def is_busy_error(exc: BaseException) -> bool:
+    """True ONLY for SQLITE_BUSY / SQLITE_LOCKED — the retryable failures.
+
+    Structural rather than a message match: `sqlite_errorcode` is what SQLite
+    itself set, and the low byte strips any extended-code suffix.
+
+    This predicate is the whole safety of the retry. A malformed statement, a
+    closed database, a missing table or a constraint violation is PERMANENT —
+    retrying it would turn an immediate traceback into a 30-second hang and then
+    the same traceback, while hiding the real error behind a timeout. Everything
+    that is not BUSY/LOCKED must propagate on the first attempt.
+    """
+    code = getattr(exc, "sqlite_errorcode", None)
+    if code is None:
+        # Only reachable on a pre-3.11 interpreter, which has no error code to
+        # read. The message is the last resort, and is deliberately NOT consulted
+        # when a code is available.
+        text = str(exc)
+        return ("database is locked" in text
+                or "database table is locked" in text)
+    return (int(code) & 0xFF) in (SQLITE_BUSY, SQLITE_LOCKED)
+
 
 MIGRATIONS = {
     1: [
@@ -244,10 +301,14 @@ def source_url_key(url) -> str:
 class Store:
     """Thread-safe SQLite wrapper (one connection per thread)."""
 
-    def __init__(self, path, *, clock=time.time, timeout: float = 10.0):
+    def __init__(self, path, *, clock=time.time, timeout: float = 10.0,
+                 write_deadline: float = WRITE_DEADLINE,
+                 write_attempts: int = WRITE_ATTEMPTS):
         self.path = Path(path)
         self._clock = clock
         self._timeout = timeout
+        self._write_deadline = float(write_deadline)
+        self._write_attempts = max(1, int(write_attempts))
         self._local = threading.local()
         if str(self.path) != ":memory:":
             self.path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -284,38 +345,88 @@ class Store:
         self._shared = None
         self._local.conn = None
 
+    # --- writes ------------------------------------------------------------- #
+    def _write(self, work):
+        """Run `work(conn)` as ONE transaction, retrying while SQLite is BUSY.
+
+        EVERY mutating statement in this class goes through here — one rule, one
+        place. `busy_timeout` is not durability: when it expires the write is
+        dropped and the calling thread dies with it, which is how 125 of 150
+        rows went missing in the measurement at the top of this file. A bounded
+        retry makes a contended write COMPLETE instead of vanishing.
+
+        Retrying the WHOLE transaction is safe because a BUSY failure commits
+        nothing and the rollback below discards any partial work — so the
+        non-idempotent parts (`hits = aliases.hits + 1`) still apply exactly
+        once. This is also why the retry lives here and not at the call sites:
+        the unit that must be re-run is the transaction, which only this method
+        owns.
+
+        Bounded on both axes, and ONLY for BUSY/LOCKED: any other
+        `OperationalError` propagates on the first attempt (see
+        `is_busy_error`). Exhausting the bounds re-raises the last BUSY error —
+        a lossy write must still be loud, never swallowed.
+        """
+        conn = self.conn
+        deadline = time.monotonic() + self._write_deadline
+        delay = RETRY_BASE
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                result = work(conn)
+                conn.commit()
+                return result
+            except sqlite3.OperationalError as exc:
+                if not is_busy_error(exc):
+                    raise
+                try:
+                    conn.rollback()
+                except sqlite3.Error:
+                    pass
+                left = deadline - time.monotonic()
+                if attempt >= self._write_attempts or left <= 0:
+                    raise
+                time.sleep(min(delay, left))
+                delay = min(delay * 2, RETRY_CAP)
+
     # --- schema ------------------------------------------------------------ #
     def _has_column(self, table: str, column: str) -> bool:
         return any(row[1] == column
                    for row in self.conn.execute(f"PRAGMA table_info({table})"))
 
-    def _run_migration_step(self, step) -> None:
+    def _run_migration_step(self, conn, step) -> None:
         """Apply one migration step. Every step must be RE-RUNNABLE.
 
         sqlite3 autocommits DDL, so there is no transaction wrapping a
         migration and a crash can leave it half-applied. Each statement is
-        therefore either `IF NOT EXISTS` or guarded here.
+        therefore either `IF NOT EXISTS` or guarded here. That same re-runnability
+        is what makes `_write`'s retry safe over a migration: a BUSY part-way
+        through simply replays the step list.
         """
         if isinstance(step, tuple):
             kind = step[0]
             if kind == "ADD_COLUMN_IF_MISSING":
                 _, table, column, decl = step
                 if not self._has_column(table, column):
-                    self.conn.execute(
+                    conn.execute(
                         f"ALTER TABLE {table} ADD COLUMN {column} {decl}")
                 return
             raise RuntimeError(f"unknown migration step: {kind}")
-        self.conn.execute(step)
+        conn.execute(step)
 
     def migrate(self) -> int:
-        conn = self.conn
-        cur = conn.execute("PRAGMA user_version")
+        # Retried like every other write: `server.py` constructs the Store
+        # unguarded, so a BUSY here is a `Restart=always` crash loop rather than
+        # one lost row.
+        cur = self.conn.execute("PRAGMA user_version")
         version = int(cur.fetchone()[0])
         for target in range(version + 1, SCHEMA_VERSION + 1):
-            for step in MIGRATIONS[target]:
-                self._run_migration_step(step)
-            conn.execute(f"PRAGMA user_version={target}")
-            conn.commit()
+            def _apply(conn, target=target):
+                for step in MIGRATIONS[target]:
+                    self._run_migration_step(conn, step)
+                conn.execute(f"PRAGMA user_version={target}")
+            self._write(_apply)
         return SCHEMA_VERSION
 
     def version(self) -> int:
@@ -334,7 +445,7 @@ class Store:
         re-derived from whatever the LATEST correction saw.
         """
         now = self._clock()
-        self.conn.execute(
+        self._write(lambda conn: conn.execute(
             """INSERT INTO aliases (key, site, dir, hits, created_at,
                                     updated_at, source, evidence)
                VALUES (?, ?, ?, 1, ?, ?, ?, ?)
@@ -345,8 +456,7 @@ class Store:
                  source = excluded.source,
                  evidence = excluded.evidence""",
             (key, site or "", dir_name, now, now, str(source or ""),
-             str(evidence or "")))
-        self.conn.commit()
+             str(evidence or ""))))
 
     def alias_rows(self) -> list:
         """Every alias with its provenance, most recently written first."""
@@ -372,20 +482,18 @@ class Store:
             "SELECT COUNT(*) AS n FROM aliases").fetchone()["n"])
 
     def delete_alias(self, key: str, site: str = "") -> None:
-        self.conn.execute("DELETE FROM aliases WHERE key=? AND site=?",
-                          (key, site or ""))
-        self.conn.commit()
+        self._write(lambda conn: conn.execute(
+            "DELETE FROM aliases WHERE key=? AND site=?", (key, site or "")))
 
     # --- labelled examples ------------------------------------------------- #
     def add_example(self, context: dict, chosen_dir: str, auto_dir=None,
                     created_new: bool = False) -> int:
-        cur = self.conn.execute(
+        cur = self._write(lambda conn: conn.execute(
             """INSERT INTO examples (ts, context, chosen_dir, auto_dir, created_new)
                VALUES (?, ?, ?, ?, ?)""",
             (self._clock(), json.dumps(context, ensure_ascii=False,
                                        separators=(",", ":")),
-             chosen_dir, auto_dir, 1 if created_new else 0))
-        self.conn.commit()
+             chosen_dir, auto_dir, 1 if created_new else 0)))
         return int(cur.lastrowid)
 
     def examples(self, limit: int = 100) -> list:
@@ -464,22 +572,26 @@ class Store:
         trains the operator to dismiss it.
         """
         now = self._clock()
-        cur = self.conn.execute(
-            """INSERT INTO screened (key, site, dir, source, why, hits,
-                                     first_ts, last_ts)
-               VALUES (?, ?, ?, ?, ?, 1, ?, ?)
-               ON CONFLICT(key, site, dir) DO UPDATE SET
-                 hits = screened.hits + 1,
-                 why = excluded.why,
-                 last_ts = excluded.last_ts""",
-            (key, site or "", dir_name, str(source or ""), str(why or ""),
-             now, now))
-        # `rowcount` is 1 for both branches, so ask the row itself.
-        row = self.conn.execute(
-            "SELECT hits FROM screened WHERE key=? AND site=? AND dir=?",
-            (key, site or "", dir_name)).fetchone()
-        self.conn.commit()
-        del cur
+
+        def _do(conn):
+            conn.execute(
+                """INSERT INTO screened (key, site, dir, source, why, hits,
+                                         first_ts, last_ts)
+                   VALUES (?, ?, ?, ?, ?, 1, ?, ?)
+                   ON CONFLICT(key, site, dir) DO UPDATE SET
+                     hits = screened.hits + 1,
+                     why = excluded.why,
+                     last_ts = excluded.last_ts""",
+                (key, site or "", dir_name, str(source or ""), str(why or ""),
+                 now, now))
+            # `rowcount` is 1 for both branches, so ask the row itself. Read
+            # inside the SAME transaction as the insert, so a retry re-reads the
+            # count it actually wrote.
+            return conn.execute(
+                "SELECT hits FROM screened WHERE key=? AND site=? AND dir=?",
+                (key, site or "", dir_name)).fetchone()
+
+        row = self._write(_do)
         return bool(row) and int(row["hits"]) == 1
 
     def screened_rows(self, limit: int = 200) -> list:
@@ -489,22 +601,20 @@ class Store:
         return [dict(r) for r in rows]
 
     def clear_screened(self, key: str, site: str = "") -> int:
-        cur = self.conn.execute("DELETE FROM screened WHERE key=? AND site=?",
-                                (key, site or ""))
-        self.conn.commit()
+        cur = self._write(lambda conn: conn.execute(
+            "DELETE FROM screened WHERE key=? AND site=?", (key, site or "")))
         return int(cur.rowcount)
 
     # --- directory kinds ---------------------------------------------------- #
     def set_dir_kind(self, name: str, kind: str, source: str = "") -> None:
-        self.conn.execute(
+        self._write(lambda conn: conn.execute(
             """INSERT INTO dir_kinds (name, kind, source, ts)
                VALUES (?, ?, ?, ?)
                ON CONFLICT(name) DO UPDATE SET
                  kind = excluded.kind,
                  source = excluded.source,
                  ts = excluded.ts""",
-            (str(name), str(kind), str(source or ""), self._clock()))
-        self.conn.commit()
+            (str(name), str(kind), str(source or ""), self._clock())))
 
     def dir_kind_map(self) -> dict:
         rows = self.conn.execute("SELECT name, kind FROM dir_kinds").fetchall()
@@ -514,15 +624,14 @@ class Store:
     def log_route(self, *, url="", site="", filename="", dir_name="",
                   confidence=0.0, reason="", auto=False, dup=None,
                   download_id="") -> int:
-        cur = self.conn.execute(
+        cur = self._write(lambda conn: conn.execute(
             """INSERT INTO routes (ts, url, site, filename, dir, confidence,
                                    reason, auto, dup, download_id)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (self._clock(), url, site, filename, dir_name, float(confidence),
              reason, 1 if auto else 0,
              json.dumps(dup, separators=(",", ":")) if dup else None,
-             str(download_id or "")))
-        self.conn.commit()
+             str(download_id or ""))))
         return int(cur.lastrowid)
 
     def route_for_download(self, download_id):
@@ -544,15 +653,14 @@ class Store:
     def record_routed_file(self, rel_path: str, download_id: str,
                            dir_name: str) -> None:
         """Remember that `rel_path` is a file this router created."""
-        self.conn.execute(
+        self._write(lambda conn: conn.execute(
             """INSERT INTO routed_files (rel_path, download_id, dir, ts)
                VALUES (?, ?, ?, ?)
                ON CONFLICT(rel_path) DO UPDATE SET
                  download_id = excluded.download_id,
                  dir = excluded.dir,
                  ts = excluded.ts""",
-            (rel_path, str(download_id or ""), dir_name, self._clock()))
-        self.conn.commit()
+            (rel_path, str(download_id or ""), dir_name, self._clock())))
 
     def routed_file(self, rel_path: str):
         row = self.conn.execute(
@@ -566,9 +674,8 @@ class Store:
         provenance for it."""
         row = self.routed_file(old_rel)
         download_id = row["download_id"] if row else ""
-        self.conn.execute("DELETE FROM routed_files WHERE rel_path=?",
-                          (old_rel,))
-        self.conn.commit()
+        self._write(lambda conn: conn.execute(
+            "DELETE FROM routed_files WHERE rel_path=?", (old_rel,)))
         self.record_routed_file(new_rel, download_id, dir_name)
 
     def forget_routed_file(self, rel_path: str) -> int:
@@ -579,9 +686,8 @@ class Store:
         short-circuits on exactly that claim, so a later file arriving at the
         same path would inherit a proof it never earned.
         """
-        cur = self.conn.execute("DELETE FROM routed_files WHERE rel_path=?",
-                                (rel_path,))
-        self.conn.commit()
+        cur = self._write(lambda conn: conn.execute(
+            "DELETE FROM routed_files WHERE rel_path=?", (rel_path,)))
         return int(cur.rowcount)
 
     def routed_file_count(self) -> int:
@@ -627,14 +733,13 @@ class Store:
         download_id = str(download_id or "")
         if not download_id:
             return False
-        cur = self.conn.execute(
+        cur = self._write(lambda conn: conn.execute(
             """INSERT INTO discards (download_id, rel_path, kept_rel,
                                      trash_rel, mode, ts)
                VALUES (?, ?, ?, ?, ?, ?)
                ON CONFLICT(download_id) DO NOTHING""",
             (download_id, str(rel_path), str(kept_rel or ""),
-             str(trash_rel or ""), str(mode or ""), self._clock()))
-        self.conn.commit()
+             str(trash_rel or ""), str(mode or ""), self._clock())))
         return int(cur.rowcount) == 1
 
     def set_discard_trash(self, download_id: str, trash_rel: str) -> int:
@@ -647,10 +752,9 @@ class Store:
         never delivered it. The uniquified `(N)` name in the trash is exactly
         what someone needs to undo a wrong discard.
         """
-        cur = self.conn.execute(
+        cur = self._write(lambda conn: conn.execute(
             "UPDATE discards SET trash_rel=? WHERE download_id=?",
-            (str(trash_rel or ""), str(download_id or "")))
-        self.conn.commit()
+            (str(trash_rel or ""), str(download_id or ""))))
         return int(cur.rowcount)
 
     def release_discard(self, download_id: str) -> int:
@@ -664,9 +768,9 @@ class Store:
         for that download AND leaves the table claiming a file was removed
         that is still on disk.
         """
-        cur = self.conn.execute("DELETE FROM discards WHERE download_id=?",
-                                (str(download_id or ""),))
-        self.conn.commit()
+        cur = self._write(lambda conn: conn.execute(
+            "DELETE FROM discards WHERE download_id=?",
+            (str(download_id or ""),)))
         return int(cur.rowcount)
 
     def recent_discards(self, limit: int = 50) -> list:
@@ -693,7 +797,7 @@ class Store:
         if not key:
             return ""
         now = self._clock()
-        self.conn.execute(
+        self._write(lambda conn: conn.execute(
             """INSERT INTO source_urls (url_key, url, site, dir, rel_path,
                                         download_id, hits, first_ts, last_ts)
                VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?)
@@ -711,8 +815,7 @@ class Store:
                                     THEN excluded.download_id
                                     ELSE source_urls.download_id END""",
             (key, str(url), str(site or ""), str(dir_name or ""),
-             str(rel_path or ""), str(download_id or ""), now, now))
-        self.conn.commit()
+             str(rel_path or ""), str(download_id or ""), now, now)))
         return key
 
     def source_url(self, url):
@@ -736,13 +839,12 @@ class Store:
         download_id = str(download_id or "")
         if not download_id:
             return 0
-        cur = self.conn.execute(
+        cur = self._write(lambda conn: conn.execute(
             """UPDATE source_urls SET dir=?, rel_path=CASE WHEN ?!='' THEN ?
                                                       ELSE rel_path END
                WHERE download_id=?""",
             (str(dir_name or ""), str(rel_path or ""), str(rel_path or ""),
-             download_id))
-        self.conn.commit()
+             download_id)))
         return int(cur.rowcount)
 
     def source_url_count(self) -> int:
@@ -753,12 +855,11 @@ class Store:
     def set_host_prior(self, site: str, dir_name: str) -> None:
         if not site:
             return
-        self.conn.execute(
+        self._write(lambda conn: conn.execute(
             """INSERT INTO host_prior (site, dir, ts) VALUES (?, ?, ?)
                ON CONFLICT(site) DO UPDATE SET
                  dir = excluded.dir, ts = excluded.ts""",
-            (site, dir_name, self._clock()))
-        self.conn.commit()
+            (site, dir_name, self._clock())))
 
     def host_prior(self, site: str):
         if not site:

--- a/scripts/dl-router/store.py
+++ b/scripts/dl-router/store.py
@@ -37,18 +37,27 @@ SCHEMA_VERSION = 6
 #
 # Raising the default timeout is NOT the fix: it moves the threshold and leaves
 # the write lossy past it. Every mutating statement therefore goes through
-# `Store._write`, which retries the whole transaction while SQLite says BUSY.
+# `Store._retry_busy` (via `_write`), which retries while SQLite says BUSY.
 SQLITE_BUSY = 5
 SQLITE_LOCKED = 6
 
-# Total wall clock the retry loop may spend on one write. It bounds the RETRIES,
-# not a single statement's own busy wait — with the default 10s busy_timeout a
-# contended write blocks inside SQLite first and this only decides whether it
-# gets another go. Chosen against the alternative it replaces: the sidecar
-# previously answered fast and silently dropped the row.
+# Wall clock the retry LOOP may spend on one write.
+#
+# 🔴 It is NOT the worst-case call duration, and the difference is large. The
+# deadline is checked AFTER an attempt returns, so the last attempt can begin at
+# `deadline - ε` and then block a further `busy_timeout` inside SQLite. The real
+# ceiling is therefore about `WRITE_DEADLINE + timeout` — with the production
+# defaults (10s busy_timeout) that is ~40s, not ~30s. Measured against a held
+# lock at three points: deadline=1.0/timeout=2.0 -> 2.02s;
+# deadline=0.5/timeout=4.0 -> 4.28s; deadline=3.0/timeout=1.0 -> 3.07s.
+#
+# That matters to a caller with its own budget: `server.py` documents that the
+# extension's /discard timeout (240s) must exceed `DISCARD_VERIFY_TIMEOUT_S`
+# (180s), and store retries on the same request now eat into that headroom.
 WRITE_DEADLINE = 30.0
 # Belt to the deadline's braces: caps churn when busy_timeout is tiny and each
-# attempt returns in microseconds.
+# attempt returns in microseconds. Unreachable at the production busy_timeout
+# (~3 attempts fit in the deadline); it bounds the tiny-timeout case.
 WRITE_ATTEMPTS = 64
 RETRY_BASE = 0.005      # first backoff, seconds
 RETRY_CAP = 0.2         # backoff ceiling, seconds
@@ -58,7 +67,16 @@ def is_busy_error(exc: BaseException) -> bool:
     """True ONLY for SQLITE_BUSY / SQLITE_LOCKED — the retryable failures.
 
     Structural rather than a message match: `sqlite_errorcode` is what SQLite
-    itself set, and the low byte strips any extended-code suffix.
+    itself set.
+
+    🔴 The `& 0xFF` is load-bearing, not tidiness. An extended result code is
+    `primary | (sub << 8)`, and this interpreter DOES surface them — a WAL
+    read-then-write upgrade raises `517` (`SQLITE_BUSY_SNAPSHOT`), and
+    `SQLITE_BUSY_TIMEOUT` is `773`. Without the mask those compare unequal to 5
+    and a genuinely retryable failure would propagate as if it were permanent.
+    No `_write` body reads before writing today, so it is latent — which is
+    exactly why it needs a test rather than a comment
+    (`test_is_busy_error_masks_the_extended_code_suffix`).
 
     This predicate is the whole safety of the retry. A malformed statement, a
     closed database, a missing table or a constraint violation is PERMANENT —
@@ -308,7 +326,10 @@ class Store:
         self._clock = clock
         self._timeout = timeout
         self._write_deadline = float(write_deadline)
-        self._write_attempts = max(1, int(write_attempts))
+        # No `max(1, …)`: the bound is checked AFTER an attempt, so the first
+        # one always runs and 0 or a negative value already behaves as 1. A
+        # clamp here would read as a guard while changing nothing.
+        self._write_attempts = int(write_attempts)
         self._local = threading.local()
         if str(self.path) != ":memory:":
             self.path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -324,7 +345,15 @@ class Store:
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA busy_timeout=%d" % int(self._timeout * 1000))
         if str(self.path) != ":memory:":
-            conn.execute("PRAGMA journal_mode=WAL")
+            # THE ONE WRITE THAT CANNOT GO THROUGH `_write`: this runs while the
+            # connection is still being built, and `_write` reaches for
+            # `self.conn`, which would re-enter here. It is a real write —
+            # converting a delete-mode database to WAL takes the write lock and
+            # raises SQLITE_BUSY if another connection holds EXCLUSIVE — so it
+            # gets the same bounded retry applied directly. Narrow (only the
+            # one-time delete->WAL conversion) but it fails at CONSTRUCTION, and
+            # per `migrate` below that lands in a degrade nothing recovers from.
+            self._retry_busy(lambda: conn.execute("PRAGMA journal_mode=WAL"))
         conn.execute("PRAGMA foreign_keys=ON")
         return conn
 
@@ -346,54 +375,81 @@ class Store:
         self._local.conn = None
 
     # --- writes ------------------------------------------------------------- #
-    def _write(self, work):
-        """Run `work(conn)` as ONE transaction, retrying while SQLite is BUSY.
+    def _retry_busy(self, work, *, rollback=None):
+        """Run `work()`, retrying while SQLite says BUSY. THE retry, once.
 
-        EVERY mutating statement in this class goes through here — one rule, one
-        place. `busy_timeout` is not durability: when it expires the write is
-        dropped and the calling thread dies with it, which is how 125 of 150
-        rows went missing in the measurement at the top of this file. A bounded
-        retry makes a contended write COMPLETE instead of vanishing.
-
-        Retrying the WHOLE transaction is safe because a BUSY failure commits
-        nothing and the rollback below discards any partial work — so the
-        non-idempotent parts (`hits = aliases.hits + 1`) still apply exactly
-        once. This is also why the retry lives here and not at the call sites:
-        the unit that must be re-run is the transaction, which only this method
-        owns.
+        Separate from `_write` for one caller: `_connect` must retry the WAL
+        pragma, and cannot use `_write` because `_write` asks for `self.conn`
+        and would re-enter the connection it is still building. Everything else
+        goes through `_write`.
 
         Bounded on both axes, and ONLY for BUSY/LOCKED: any other
-        `OperationalError` propagates on the first attempt (see
-        `is_busy_error`). Exhausting the bounds re-raises the last BUSY error —
-        a lossy write must still be loud, never swallowed.
+        `OperationalError` propagates on the FIRST attempt (see
+        `is_busy_error`) — retrying a permanent error would hide it behind a
+        timeout. Exhausting the bounds re-raises the last BUSY error; a write
+        that cannot land must still be loud, never swallowed.
+
+        🔴 The deadline is checked AFTER an attempt, so this can outrun it by up
+        to one `busy_timeout`. See `WRITE_DEADLINE` for the real ceiling.
         """
-        conn = self.conn
         deadline = time.monotonic() + self._write_deadline
         delay = RETRY_BASE
         attempt = 0
         while True:
             attempt += 1
             try:
-                result = work(conn)
-                conn.commit()
-                return result
+                return work()
             except sqlite3.OperationalError as exc:
                 if not is_busy_error(exc):
                     raise
-                try:
-                    conn.rollback()
-                except sqlite3.Error:
-                    pass
+                if rollback is not None:
+                    try:
+                        rollback.rollback()
+                    except sqlite3.Error:
+                        pass
                 left = deadline - time.monotonic()
                 if attempt >= self._write_attempts or left <= 0:
                     raise
                 time.sleep(min(delay, left))
                 delay = min(delay * 2, RETRY_CAP)
 
+    def _write(self, work):
+        """Run `work(conn)` as ONE transaction, retrying while SQLite is BUSY.
+
+        Every mutating statement in this class goes through here — one rule, one
+        place — with the single, named exception of the WAL pragma in
+        `_connect`, which cannot (see `_retry_busy`). Both share one retry, and
+        `test_every_mutating_execute_is_routed_through_the_retry` pins that
+        ledger per `execute` call rather than per method.
+
+        `busy_timeout` is not durability: when it expires the write is dropped
+        and the calling thread dies with it, which is how 125 of 150 rows went
+        missing in the measurement at the top of this file. A bounded retry
+        makes a contended write COMPLETE instead of vanishing.
+
+        Retrying the WHOLE transaction is safe because a BUSY failure commits
+        nothing and the rollback discards any partial work — so the
+        non-idempotent parts (`hits = aliases.hits + 1`) still apply exactly
+        once. That is also why the retry lives here and not at the call sites:
+        the unit that must be re-run is the transaction, which only this method
+        owns.
+        """
+        conn = self.conn
+
+        def _commit():
+            result = work(conn)
+            conn.commit()
+            return result
+
+        return self._retry_busy(_commit, rollback=conn)
+
     # --- schema ------------------------------------------------------------ #
-    def _has_column(self, table: str, column: str) -> bool:
+    def _has_column(self, conn, table: str, column: str) -> bool:
+        # Takes its connection like `_run_migration_step`, its only caller: both
+        # run inside a `_write` transaction, and reaching for `self.conn` there
+        # would be a second handle on the same seam.
         return any(row[1] == column
-                   for row in self.conn.execute(f"PRAGMA table_info({table})"))
+                   for row in conn.execute(f"PRAGMA table_info({table})"))
 
     def _run_migration_step(self, conn, step) -> None:
         """Apply one migration step. Every step must be RE-RUNNABLE.
@@ -408,7 +464,7 @@ class Store:
             kind = step[0]
             if kind == "ADD_COLUMN_IF_MISSING":
                 _, table, column, decl = step
-                if not self._has_column(table, column):
+                if not self._has_column(conn, table, column):
                     conn.execute(
                         f"ALTER TABLE {table} ADD COLUMN {column} {decl}")
                 return
@@ -416,9 +472,15 @@ class Store:
         conn.execute(step)
 
     def migrate(self) -> int:
-        # Retried like every other write: `server.py` constructs the Store
-        # unguarded, so a BUSY here is a `Restart=always` crash loop rather than
-        # one lost row.
+        # Retried like every other write, and the reason is NOT a crash loop.
+        # `server.py:main()` wraps `App(cfg, …)` — which is where this runs — in
+        # `except Exception`, logs `startup_error`, and degrades to
+        # `App(blank, store=Store(":memory:"))`. So a BUSY here does not raise
+        # out of the process: main() returns 0, the unit stays `active`,
+        # `Restart=always` never fires, and the sidecar serves 503 from an
+        # in-memory store on every routing endpoint until a human restarts it.
+        # That is WORSE than a crash loop, because nothing self-heals and the
+        # unit looks healthy — which is what makes retrying here worth doing.
         cur = self.conn.execute("PRAGMA user_version")
         version = int(cur.fetchone()[0])
         for target in range(version + 1, SCHEMA_VERSION + 1):

--- a/scripts/dl-router/tests/test_dedupe.py
+++ b/scripts/dl-router/tests/test_dedupe.py
@@ -1102,7 +1102,11 @@ def test_running_the_v5_step_list_twice_is_a_no_op(tmp_path):
     store.record_source_url("https://example-site.test/a.mp4",
                             dir_name="Jane Doe")
     for step in MIGRATIONS[5]:
-        store._run_migration_step(step)
+        # `_run_migration_step` takes its connection explicitly now: `migrate`
+        # runs the whole step list inside one `Store._write` transaction so a
+        # SQLITE_BUSY during a migration is retried rather than crashing the
+        # sidecar on start-up.
+        store._run_migration_step(store.conn, step)
     assert store.source_url_count() == 1, "a re-run dropped the ledger"
     assert store.migrate() == SCHEMA_VERSION
     store.close()

--- a/scripts/dl-router/tests/test_store.py
+++ b/scripts/dl-router/tests/test_store.py
@@ -3,15 +3,18 @@ log. Uses temp SQLite files; no shared state between tests.
 """
 from __future__ import annotations
 
+import ast
+import sqlite3
 import sys
 import threading
+import time
 from pathlib import Path
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from store import SCHEMA_VERSION, Store  # noqa: E402
+from store import SCHEMA_VERSION, Store, is_busy_error  # noqa: E402
 
 
 # --- schema ---------------------------------------------------------------- #
@@ -115,6 +118,283 @@ def test_concurrent_upserts_of_the_same_key_converge(tmp_path):
     row = st.conn.execute("SELECT hits FROM aliases WHERE key='shared'").fetchone()
     assert row["hits"] == 120
     st.close()
+
+
+# --- SQLITE_BUSY durability ------------------------------------------------- #
+#
+# The two tests above are the ones that FOUND this: they went red in CI with
+# `OperationalError: database is locked`, and the row counts said what that
+# error costs — a writer whose `busy_timeout` expires does not retry, so its
+# thread dies and every remaining write it owed is silently never made. On the
+# pre-fix store, 6 threads x 25 upserts with the busy_timeout dialled down lost
+# 25 rows at 0.5s and 125 rows at 0.05s and below.
+#
+# The tests below pin that as a CONTRACT rather than a race. They hold SQLite's
+# write lock from a second connection for a fixed span, so "the write was
+# blocked past its busy_timeout" is arranged, not hoped for.
+
+def _hold_write_lock(path, hold_seconds, acquired, released):
+    """Hold SQLite's write lock on `path` for `hold_seconds`, then let go.
+
+    `BEGIN IMMEDIATE` takes the write lock at once (rather than on first write),
+    which is what makes the block deterministic instead of timing-dependent.
+    `acquired` fires only once the lock is genuinely held, so the test never
+    races the blocker.
+    """
+    conn = sqlite3.connect(str(path), timeout=30.0)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        acquired.set()
+        time.sleep(hold_seconds)
+        conn.rollback()
+    finally:
+        conn.close()
+        released.set()
+
+
+def test_a_write_blocked_past_its_busy_timeout_still_lands(tmp_path):
+    """THE durability contract: a contended write COMPLETES, never vanishes.
+
+    busy_timeout is 20ms and the lock is held for 400ms — twenty times longer,
+    so the first attempt is guaranteed to raise SQLITE_BUSY. Pre-fix that error
+    reached the caller and the row was never written; the retry makes the write
+    wait for the lock and land.
+    """
+    path = tmp_path / "held.sqlite3"
+    st = Store(path, timeout=0.02)
+    acquired, released = threading.Event(), threading.Event()
+    blocker = threading.Thread(target=_hold_write_lock,
+                               args=(path, 0.4, acquired, released))
+    blocker.start()
+    try:
+        assert acquired.wait(10), "the blocker never took the write lock"
+        st.upsert_alias("contended", "Jane Doe")
+    finally:
+        blocker.join(30)
+    assert st.alias("contended") == "Jane Doe"
+    assert st.alias_count() == 1
+    st.close()
+
+
+def test_without_the_retry_that_same_write_is_lost(tmp_path):
+    """POSITIVE CONTROL for the test above — this harness CAN see the loss.
+
+    `write_attempts=1` is exactly the pre-fix code path: one attempt, no retry.
+    Same lock, same timeout, and the write is gone — so a green result in the
+    previous test is the retry working, not the contention failing to happen.
+    """
+    path = tmp_path / "held-no-retry.sqlite3"
+    st = Store(path, timeout=0.02, write_attempts=1)
+    acquired, released = threading.Event(), threading.Event()
+    blocker = threading.Thread(target=_hold_write_lock,
+                               args=(path, 0.4, acquired, released))
+    blocker.start()
+    try:
+        assert acquired.wait(10), "the blocker never took the write lock"
+        with pytest.raises(sqlite3.OperationalError) as excinfo:
+            st.upsert_alias("contended", "Jane Doe")
+    finally:
+        blocker.join(30)
+    assert "locked" in str(excinfo.value)
+    assert st.alias_count() == 0      # the row is GONE, not merely delayed
+    st.close()
+
+
+def test_six_writers_with_a_tiny_busy_timeout_still_land_every_row(tmp_path):
+    """The CI failure, reproduced by shrinking the timeout instead of the box.
+
+    Identical to `test_concurrent_writers_do_not_lose_rows` except that the
+    busy_timeout is 5ms rather than 10s. On the pre-fix store this failed 3/3
+    with 5 errors and 25 of 150 rows; the CI failure is the same shape with a
+    10-second threshold and an I/O-stalled node supplying the contention.
+    """
+    st = Store(tmp_path / "tiny-timeout.sqlite3", timeout=0.005)
+    errors = []
+
+    def writer(n):
+        try:
+            for i in range(25):
+                st.upsert_alias(f"key{n}-{i}", "Jane Doe")
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=writer, args=(n,)) for n in range(6)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert errors == []
+    assert st.alias_count() == 150
+    st.close()
+
+
+def test_a_permanent_error_propagates_instead_of_being_retried(store):
+    """🔴 The control that matters more than the happy path.
+
+    A retry that cannot tell BUSY from a real defect turns an immediate
+    traceback into a 30-second hang and then the same traceback — with the real
+    error dressed up as contention. `no such table` must come straight back.
+    """
+    # Without this the timing bound below could pass vacuously.
+    assert store._write_deadline >= 5.0
+    store._write(lambda conn: conn.execute("DROP TABLE aliases"))
+    started = time.monotonic()
+    with pytest.raises(sqlite3.OperationalError) as excinfo:
+        store.upsert_alias("jd", "Jane Doe")
+    elapsed = time.monotonic() - started
+    assert "no such table" in str(excinfo.value)
+    assert elapsed < 1.0, f"a permanent error was retried for {elapsed:.2f}s"
+
+
+def test_is_busy_error_reads_the_code_sqlite_set(store, tmp_path):
+    """Both branches of the predicate, against REAL sqlite3 exceptions.
+
+    Hand-built `OperationalError`s carry no `sqlite_errorcode`, so they would
+    exercise the pre-3.11 message fallback rather than the structural path this
+    interpreter actually takes.
+    """
+    with pytest.raises(sqlite3.OperationalError) as permanent:
+        store.conn.execute("SELECT * FROM no_such_table")
+    assert permanent.value.sqlite_errorcode == 1        # SQLITE_ERROR
+    assert is_busy_error(permanent.value) is False
+
+    path = tmp_path / "codes.sqlite3"
+    st = Store(path, timeout=0.02, write_attempts=1)
+    acquired, released = threading.Event(), threading.Event()
+    blocker = threading.Thread(target=_hold_write_lock,
+                               args=(path, 0.3, acquired, released))
+    blocker.start()
+    try:
+        assert acquired.wait(10), "the blocker never took the write lock"
+        with pytest.raises(sqlite3.OperationalError) as busy:
+            st.upsert_alias("k", "Jane Doe")
+    finally:
+        blocker.join(30)
+    assert busy.value.sqlite_errorcode == 5             # SQLITE_BUSY
+    assert is_busy_error(busy.value) is True
+    st.close()
+
+
+def test_an_exhausted_retry_re_raises_rather_than_going_quiet(tmp_path):
+    """A write that truly cannot land must still be LOUD.
+
+    The retry is bounded; the whole point is that it turns a *transient* block
+    into a completed write, not that it hides a permanent one. When the bounds
+    run out the last BUSY error is re-raised — swallowing it would recreate the
+    original bug with the error message removed as well as the row.
+    """
+    path = tmp_path / "never-free.sqlite3"
+    st = Store(path, timeout=0.01, write_deadline=0.1)
+    acquired, released = threading.Event(), threading.Event()
+    blocker = threading.Thread(target=_hold_write_lock,
+                               args=(path, 3.0, acquired, released))
+    blocker.start()
+    try:
+        assert acquired.wait(10), "the blocker never took the write lock"
+        started = time.monotonic()
+        with pytest.raises(sqlite3.OperationalError):
+            st.upsert_alias("doomed", "Jane Doe")
+        elapsed = time.monotonic() - started
+    finally:
+        blocker.join(30)
+    # Bounded on both sides: it kept retrying for roughly the deadline (so it
+    # did not give up on the first attempt), and it gave up well before the
+    # 3-second hold ended (so it is not simply waiting the blocker out).
+    assert 0.05 <= elapsed < 1.5, f"gave up after {elapsed:.3f}s"
+    assert st.alias_count() == 0
+    st.close()
+
+
+def test_write_attempts_bounds_the_number_of_attempts_made(tmp_path):
+    """`write_attempts=N` must mean exactly N attempts.
+
+    Counted rather than timed: an off-by-one here shows up as a few tens of
+    milliseconds, which no wall-clock assertion can separate from noise, and it
+    silently widens or narrows the bound the sidecar's write latency rests on.
+    The failures are real SQLITE_BUSY errors — the lock is genuinely held for
+    the whole test.
+    """
+    path = tmp_path / "count.sqlite3"
+    st = Store(path, timeout=0.01, write_deadline=30.0, write_attempts=3)
+    attempts = []
+
+    def work(conn):
+        attempts.append(1)
+        conn.execute("INSERT INTO host_prior (site, dir, ts) "
+                     "VALUES ('example-site.test', 'Jane Doe', 0)")
+
+    acquired, released = threading.Event(), threading.Event()
+    blocker = threading.Thread(target=_hold_write_lock,
+                               args=(path, 3.0, acquired, released))
+    blocker.start()
+    try:
+        assert acquired.wait(10), "the blocker never took the write lock"
+        with pytest.raises(sqlite3.OperationalError):
+            st._write(work)
+    finally:
+        blocker.join(30)
+    assert len(attempts) == 3
+    st.close()
+
+
+def test_a_retry_rolls_back_the_partial_transaction_first(store):
+    """A multi-statement write must not apply its first statement TWICE.
+
+    `record_screened` already does insert-then-read inside one transaction, and
+    a write with two INSERTs is one commit away. Without the rollback the first
+    statement's work survives into the retry and lands a second time — silent
+    duplication, which is the same class of damage as the lost row this whole
+    change is about, in the opposite direction.
+    """
+    class _Busy(sqlite3.OperationalError):
+        # A real BUSY as far as `is_busy_error` is concerned: it reads
+        # `sqlite_errorcode`, and a class attribute answers that. Arranging a
+        # genuine mid-transaction BUSY is not something a test can schedule.
+        sqlite_errorcode = 5
+
+    raised = []
+
+    def work(conn):
+        conn.execute("INSERT INTO routes (ts, dir) VALUES (1, 'Jane Doe')")
+        if not raised:
+            raised.append(1)
+            raise _Busy("database is locked")
+
+    store._write(work)
+    assert raised == [1], "the retry path was never exercised"
+    assert len(store.recent_routes()) == 1
+
+
+def test_every_mutating_method_routes_through_the_write_helper():
+    """One rule, one place — an asserted ledger, not a pinned example.
+
+    A new write method that does its own `conn.execute` + `commit()` would
+    reintroduce exactly this bug at one site while every other site stays
+    correct, and nothing else in the suite would notice. This fails when the
+    set of mutating methods GROWS past the set that goes through `_write`.
+    """
+    source = (Path(__file__).resolve().parent.parent / "store.py").read_text(
+        encoding="utf-8")
+    tree = ast.parse(source)
+    store_cls = next(node for node in tree.body
+                     if isinstance(node, ast.ClassDef) and node.name == "Store")
+    # `_write` IS the helper; `_run_migration_step` only ever runs inside one
+    # (see `migrate`), and takes its connection as an argument for that reason.
+    exempt = {"_write", "_run_migration_step"}
+    mutating = ("INSERT INTO", "UPDATE ", "DELETE FROM", "ALTER TABLE",
+                "DROP TABLE", "PRAGMA USER_VERSION=")
+    offenders = []
+    for node in store_cls.body:
+        if not isinstance(node, ast.FunctionDef) or node.name in exempt:
+            continue
+        body = ast.get_source_segment(source, node) or ""
+        statements = "".join(
+            n.value for n in ast.walk(ast.parse(body))
+            if isinstance(n, ast.Constant) and isinstance(n.value, str)).upper()
+        if any(kw in statements for kw in mutating) \
+                and "self._write(" not in body:
+            offenders.append(node.name)
+    assert offenders == []
 
 
 # --- examples + routes ----------------------------------------------------- #

--- a/scripts/dl-router/tests/test_store.py
+++ b/scripts/dl-router/tests/test_store.py
@@ -133,13 +133,15 @@ def test_concurrent_upserts_of_the_same_key_converge(tmp_path):
 # write lock from a second connection for a fixed span, so "the write was
 # blocked past its busy_timeout" is arranged, not hoped for.
 
-def _hold_write_lock(path, hold_seconds, acquired, released, stop=None):
+def _hold_write_lock(path, hold_seconds, acquired, released, stop=None, *,
+                     mode="IMMEDIATE"):
     """Hold SQLite's write lock on `path`, then let go.
 
     `BEGIN IMMEDIATE` takes the write lock at once (rather than on first write),
     which is what makes the block deterministic instead of timing-dependent.
     `acquired` fires only once the lock is genuinely held, so the test never
-    races the blocker.
+    races the blocker. `mode="EXCLUSIVE"` additionally locks out readers, which
+    is what a delete-mode database needs to block the WAL conversion.
 
     `stop` releases it EARLY. A test that only needs "the lock is held while I
     make this call" sets it as soon as the call returns, so the test costs what
@@ -149,7 +151,7 @@ def _hold_write_lock(path, hold_seconds, acquired, released, stop=None):
     """
     conn = sqlite3.connect(str(path), timeout=30.0)
     try:
-        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(f"BEGIN {mode}")
         acquired.set()
         if stop is None:
             time.sleep(hold_seconds)
@@ -299,6 +301,111 @@ def test_is_busy_error_reads_the_code_sqlite_set(store, tmp_path):
     st.close()
 
 
+def _seed_delete_mode_db(path):
+    """A database that is NOT yet in WAL, so opening it must CONVERT it."""
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("CREATE TABLE seeded (x)")
+        conn.commit()
+    finally:
+        conn.close()
+    assert _journal_mode(path) == "delete"
+
+
+def _journal_mode(path):
+    conn = sqlite3.connect(str(path))
+    try:
+        return conn.execute("PRAGMA journal_mode").fetchone()[0]
+    finally:
+        conn.close()
+
+
+def test_the_wal_conversion_at_connect_time_survives_a_held_lock(tmp_path):
+    """`_connect`'s WAL pragma is a WRITE, and it is the one that cannot use
+    `_write` — so it gets the retry directly. This is that claim, measured.
+
+    Converting a delete-mode database to WAL takes the write lock, so an
+    EXCLUSIVE holder makes it raise SQLITE_BUSY. It happens during `Store()`
+    construction, and `server.py:main()` catches everything there and degrades
+    to an in-memory store that serves 503 forever — the unit stays `active`, so
+    `Restart=always` never rescues it. A lost lock race at start-up is therefore
+    stickier than a lost row.
+    """
+    path = tmp_path / "delete-mode.sqlite3"
+    _seed_delete_mode_db(path)
+    acquired, released = threading.Event(), threading.Event()
+    blocker = threading.Thread(target=_hold_write_lock,
+                               args=(path, 0.4, acquired, released),
+                               kwargs={"mode": "EXCLUSIVE"})
+    blocker.start()
+    try:
+        assert acquired.wait(10), "the blocker never took the lock"
+        started = time.monotonic()
+        st = Store(path, timeout=0.02)
+        elapsed = time.monotonic() - started
+    finally:
+        blocker.join(60)
+    assert st.version() == SCHEMA_VERSION
+    assert _journal_mode(path) == "wal"
+    assert elapsed >= 0.3, f"the conversion was never blocked ({elapsed:.3f}s)"
+    st.close()
+
+
+def test_without_the_retry_the_wal_conversion_is_lost(tmp_path):
+    """POSITIVE CONTROL for the test above — the harness CAN see that failure.
+
+    `write_attempts=1` is the pre-fix shape. Measured: raises code 5 in ~0.02s
+    while the same construction with the retry takes ~0.54s and succeeds.
+    """
+    path = tmp_path / "delete-mode-no-retry.sqlite3"
+    _seed_delete_mode_db(path)
+    acquired, released, stop = (threading.Event(), threading.Event(),
+                                threading.Event())
+    blocker = threading.Thread(target=_hold_write_lock,
+                               args=(path, 30.0, acquired, released, stop),
+                               kwargs={"mode": "EXCLUSIVE"})
+    blocker.start()
+    try:
+        assert acquired.wait(10), "the blocker never took the lock"
+        with pytest.raises(sqlite3.OperationalError) as excinfo:
+            Store(path, timeout=0.02, write_attempts=1)
+    finally:
+        stop.set()
+        blocker.join(60)
+    assert excinfo.value.sqlite_errorcode == 5
+    assert _journal_mode(path) == "delete", "the conversion should not have run"
+
+
+def test_is_busy_error_masks_the_extended_code_suffix():
+    """🔴 The `& 0xFF` in `is_busy_error`, pinned.
+
+    SQLite's extended result codes are `primary | (sub << 8)`, and this
+    interpreter surfaces them: a WAL read-then-write upgrade raises `517`
+    (`SQLITE_BUSY_SNAPSHOT`). Without the mask those compare unequal to 5 and a
+    genuinely retryable failure propagates as if it were permanent — the write
+    is lost again, which is the whole bug.
+
+    Latent today (no `_write` body reads before writing), which is precisely why
+    it needs a test: a mutant that drops the mask passed the entire suite.
+    """
+    def busy(code):
+        return type("_Coded", (sqlite3.OperationalError,),
+                    {"sqlite_errorcode": code})("database is locked")
+
+    for code in (5,      # SQLITE_BUSY
+                 6,      # SQLITE_LOCKED
+                 261,    # SQLITE_BUSY_RECOVERY
+                 262,    # SQLITE_LOCKED_SHAREDCACHE
+                 517,    # SQLITE_BUSY_SNAPSHOT
+                 773):   # SQLITE_BUSY_TIMEOUT
+        assert is_busy_error(busy(code)) is True, code
+    for code in (1,      # SQLITE_ERROR
+                 11,     # SQLITE_CORRUPT
+                 267,    # SQLITE_CORRUPT_VTAB — an extended code that is NOT busy
+                 19):    # SQLITE_CONSTRAINT
+        assert is_busy_error(busy(code)) is False, code
+
+
 def test_an_exhausted_retry_re_raises_rather_than_going_quiet(tmp_path):
     """A write that truly cannot land must still be LOUD.
 
@@ -396,36 +503,180 @@ def test_a_retry_rolls_back_the_partial_transaction_first(store):
     assert len(store.recent_routes()) == 1
 
 
-def test_every_mutating_method_routes_through_the_write_helper():
-    """One rule, one place — an asserted ledger, not a pinned example.
+# --- the ledger: no write may bypass the retry ------------------------------ #
+#
+# An earlier version of this guard matched SQL by substring and asked, per
+# METHOD, whether the word `self._write(` appeared anywhere in it. Its docstring
+# claimed it "fails when the set of mutating methods grows", and two mutants
+# showed it did not: `INSERT OR REPLACE INTO` does not contain `INSERT INTO`, and
+# a raw `conn.execute` added BESIDE an existing `self._write(…)` in the same
+# method was exempted by the method-wide substring. Both survived a fully green
+# suite. So the check below is per `execute` CALL and classifies the statement by
+# its VERB, not by a phrase somebody could spell differently.
 
-    A new write method that does its own `conn.execute` + `commit()` would
-    reintroduce exactly this bug at one site while every other site stays
-    correct, and nothing else in the suite would notice. This fails when the
-    set of mutating methods GROWS past the set that goes through `_write`.
+# The retry helpers. A statement reached through either is routed.
+_RETRY_HELPERS = ("_write", "_retry_busy")
+
+# SQL verbs that change the database.
+_MUTATING_VERBS = {"INSERT", "REPLACE", "UPDATE", "DELETE", "ALTER", "DROP",
+                   "CREATE"}
+
+# PRAGMAs that configure THIS CONNECTION and never touch the file, so they
+# cannot take the write lock. An ENUMERATION, not a pattern: an unknown pragma
+# assignment counts as mutating, so this fails closed. `journal_mode=` is
+# deliberately absent — converting a database to WAL is a real write, and it is
+# the one statement that cannot go through `_write` (see `Store._connect`).
+_CONNECTION_SCOPED_PRAGMAS = {"busy_timeout", "foreign_keys"}
+
+
+def _sql_of(call):
+    """The literal SQL of an `execute(...)` call, or None if not analysable.
+
+    An f-string contributes its literal parts, which is enough to read the verb
+    — every f-string here interpolates an identifier, never the verb itself.
     """
+    if not call.args:
+        return ""
+    node = call.args[0]
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        return "".join(p.value for p in node.values
+                       if isinstance(p, ast.Constant)
+                       and isinstance(p.value, str))
+    if isinstance(node, ast.BinOp):        # "PRAGMA busy_timeout=%d" % ...
+        return _sql_of(ast.Call(func=call.func, args=[node.left], keywords=[]))
+    return None
+
+
+def _is_mutating(sql):
+    """True if this statement can take the write lock. None (unreadable) → True.
+
+    Failing closed on an unreadable statement is the point: a write assembled at
+    runtime is exactly the one nobody can eyeball.
+    """
+    if sql is None:
+        return True
+    head = " ".join(sql.split()).upper()
+    if not head:
+        return False
+    if head.startswith("PRAGMA "):
+        target = head[len("PRAGMA "):].split("(")[0]
+        if "=" not in target:
+            return False                   # a query: PRAGMA user_version
+        return target.split("=")[0].strip().lower() \
+            not in _CONNECTION_SCOPED_PRAGMAS
+    return head.split(" ", 1)[0] in _MUTATING_VERBS
+
+
+def _routed_node_ids(func):
+    """Every AST node reached through a retry helper inside `func`.
+
+    Covers both shapes in use: a lambda written inline in the call, and a nested
+    `def` handed over by name (`self._write(_apply)`).
+    """
+    routed, handed = set(), set()
+    for node in ast.walk(func):
+        if not (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in _RETRY_HELPERS):
+            continue
+        for arg in list(node.args) + [kw.value for kw in node.keywords]:
+            if isinstance(arg, ast.Name):
+                handed.add(arg.id)
+            routed.update(id(n) for n in ast.walk(arg))
+    for node in ast.walk(func):
+        if isinstance(node, ast.FunctionDef) and node.name in handed:
+            routed.update(id(n) for n in ast.walk(node))
+    return routed
+
+
+def _store_class():
     source = (Path(__file__).resolve().parent.parent / "store.py").read_text(
         encoding="utf-8")
     tree = ast.parse(source)
-    store_cls = next(node for node in tree.body
-                     if isinstance(node, ast.ClassDef) and node.name == "Store")
-    # `_write` IS the helper; `_run_migration_step` only ever runs inside one
-    # (see `migrate`), and takes its connection as an argument for that reason.
-    exempt = {"_write", "_run_migration_step"}
-    mutating = ("INSERT INTO", "UPDATE ", "DELETE FROM", "ALTER TABLE",
-                "DROP TABLE", "PRAGMA USER_VERSION=")
+    return next(node for node in tree.body
+                if isinstance(node, ast.ClassDef) and node.name == "Store")
+
+
+def test_every_mutating_execute_is_routed_through_the_retry():
+    """One rule, one place — an asserted ledger, checked per `execute` call.
+
+    A write that does its own `conn.execute` + `commit()` reintroduces exactly
+    this bug at one site while every other site stays correct, and nothing else
+    in the suite would notice. This fails when such a site APPEARS — including
+    beside a correct one in the same method, and including a verb spelled
+    differently (`INSERT OR REPLACE`, `REPLACE INTO`, `CREATE INDEX`).
+    """
+    store_cls = _store_class()
+    # `_retry_busy` IS the helper. `_run_migration_step` executes SQL it is
+    # handed and cannot classify it — exempt, but see the next test, which pins
+    # that every call to it is itself routed.
+    exempt = {"_retry_busy", "_run_migration_step"}
     offenders = []
-    for node in store_cls.body:
-        if not isinstance(node, ast.FunctionDef) or node.name in exempt:
+    for func in store_cls.body:
+        if not isinstance(func, ast.FunctionDef) or func.name in exempt:
             continue
-        body = ast.get_source_segment(source, node) or ""
-        statements = "".join(
-            n.value for n in ast.walk(ast.parse(body))
-            if isinstance(n, ast.Constant) and isinstance(n.value, str)).upper()
-        if any(kw in statements for kw in mutating) \
-                and "self._write(" not in body:
-            offenders.append(node.name)
+        routed = _routed_node_ids(func)
+        for node in ast.walk(func):
+            if not (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "execute"):
+                continue
+            sql = _sql_of(node)
+            if _is_mutating(sql) and id(node) not in routed:
+                offenders.append(
+                    f"{func.name}:{node.lineno} {(sql or '<dynamic>')[:60]!r}")
     assert offenders == []
+
+
+def test_the_migration_step_runners_exemption_is_earned():
+    """`_run_migration_step` is exempt only because its CALLERS are routed.
+
+    Without this, the exemption above is a hole the size of the whole migration
+    path: anything could call it outside a transaction and the ledger would
+    still read green.
+    """
+    store_cls = _store_class()
+    unrouted = []
+    for func in store_cls.body:
+        if not isinstance(func, ast.FunctionDef):
+            continue
+        routed = _routed_node_ids(func)
+        for node in ast.walk(func):
+            if (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "_run_migration_step"
+                    and id(node) not in routed):
+                unrouted.append(f"{func.name}:{node.lineno}")
+    assert unrouted == []
+
+
+def test_the_ledger_classifier_reads_verbs_not_phrases():
+    """The classifier itself, against the spellings that walked the old guard.
+
+    A guard on words is walkable by rewording; these are the exact rewordings
+    two surviving mutants used, plus the reads that must stay unflagged.
+    """
+    for sql in ("INSERT INTO aliases (key) VALUES (?)",
+                "INSERT OR REPLACE INTO aliases (key) VALUES (?)",
+                "REPLACE INTO aliases (key) VALUES (?)",
+                "  update   aliases\n   SET dir = ?",
+                "DELETE FROM aliases WHERE key=?",
+                "CREATE INDEX IF NOT EXISTS aliases_dir ON aliases(dir)",
+                "ALTER TABLE aliases ADD COLUMN x TEXT",
+                "PRAGMA user_version = 6",
+                "PRAGMA journal_mode=WAL"):
+        assert _is_mutating(sql) is True, sql
+    for sql in ("SELECT * FROM aliases",
+                "PRAGMA user_version",
+                "PRAGMA table_info(aliases)",
+                "PRAGMA busy_timeout=10000",
+                "PRAGMA foreign_keys=ON"):
+        assert _is_mutating(sql) is False, sql
+    # Unreadable SQL fails CLOSED — a write assembled at runtime is the one
+    # nobody can eyeball, so it must be routed like any other.
+    assert _is_mutating(None) is True
 
 
 # --- examples + routes ----------------------------------------------------- #

--- a/scripts/dl-router/tests/test_store.py
+++ b/scripts/dl-router/tests/test_store.py
@@ -133,19 +133,28 @@ def test_concurrent_upserts_of_the_same_key_converge(tmp_path):
 # write lock from a second connection for a fixed span, so "the write was
 # blocked past its busy_timeout" is arranged, not hoped for.
 
-def _hold_write_lock(path, hold_seconds, acquired, released):
-    """Hold SQLite's write lock on `path` for `hold_seconds`, then let go.
+def _hold_write_lock(path, hold_seconds, acquired, released, stop=None):
+    """Hold SQLite's write lock on `path`, then let go.
 
     `BEGIN IMMEDIATE` takes the write lock at once (rather than on first write),
     which is what makes the block deterministic instead of timing-dependent.
     `acquired` fires only once the lock is genuinely held, so the test never
     races the blocker.
+
+    `stop` releases it EARLY. A test that only needs "the lock is held while I
+    make this call" sets it as soon as the call returns, so the test costs what
+    the call costs rather than `hold_seconds`; `hold_seconds` then serves as the
+    upper bound that keeps a broken run from hanging. A test that needs the lock
+    to free itself on a schedule passes no `stop` and gets the timed release.
     """
     conn = sqlite3.connect(str(path), timeout=30.0)
     try:
         conn.execute("BEGIN IMMEDIATE")
         acquired.set()
-        time.sleep(hold_seconds)
+        if stop is None:
+            time.sleep(hold_seconds)
+        else:
+            stop.wait(hold_seconds)
         conn.rollback()
     finally:
         conn.close()
@@ -168,11 +177,17 @@ def test_a_write_blocked_past_its_busy_timeout_still_lands(tmp_path):
     blocker.start()
     try:
         assert acquired.wait(10), "the blocker never took the write lock"
+        started = time.monotonic()
         st.upsert_alias("contended", "Jane Doe")
+        elapsed = time.monotonic() - started
     finally:
-        blocker.join(30)
+        blocker.join(60)
     assert st.alias("contended") == "Jane Doe"
     assert st.alias_count() == 1
+    # The write really did wait for the lock rather than sailing through before
+    # the blocker got there — otherwise this is a plain write test wearing a
+    # concurrency name. Only a lower bound: load can only make it larger.
+    assert elapsed >= 0.3, f"the write was never actually blocked ({elapsed:.3f}s)"
     st.close()
 
 
@@ -185,16 +200,18 @@ def test_without_the_retry_that_same_write_is_lost(tmp_path):
     """
     path = tmp_path / "held-no-retry.sqlite3"
     st = Store(path, timeout=0.02, write_attempts=1)
-    acquired, released = threading.Event(), threading.Event()
+    acquired, released, stop = (threading.Event(), threading.Event(),
+                                threading.Event())
     blocker = threading.Thread(target=_hold_write_lock,
-                               args=(path, 0.4, acquired, released))
+                               args=(path, 30.0, acquired, released, stop))
     blocker.start()
     try:
         assert acquired.wait(10), "the blocker never took the write lock"
         with pytest.raises(sqlite3.OperationalError) as excinfo:
             st.upsert_alias("contended", "Jane Doe")
     finally:
-        blocker.join(30)
+        stop.set()
+        blocker.join(60)
     assert "locked" in str(excinfo.value)
     assert st.alias_count() == 0      # the row is GONE, not merely delayed
     st.close()
@@ -235,15 +252,20 @@ def test_a_permanent_error_propagates_instead_of_being_retried(store):
     traceback into a 30-second hang and then the same traceback — with the real
     error dressed up as contention. `no such table` must come straight back.
     """
-    # Without this the timing bound below could pass vacuously.
-    assert store._write_deadline >= 5.0
+    # Without this the timing bound below could pass vacuously: the claim is
+    # "it returned in a fraction of the retry budget", which needs a budget.
+    assert store._write_deadline >= 15.0
     store._write(lambda conn: conn.execute("DROP TABLE aliases"))
     started = time.monotonic()
     with pytest.raises(sqlite3.OperationalError) as excinfo:
         store.upsert_alias("jd", "Jane Doe")
     elapsed = time.monotonic() - started
     assert "no such table" in str(excinfo.value)
-    assert elapsed < 1.0, f"a permanent error was retried for {elapsed:.2f}s"
+    # A fifth of the budget, so a contended CI node cannot turn "returned at
+    # once" into a failure while a genuine retry (which would take the FULL
+    # budget) still cannot slip under it.
+    assert elapsed < store._write_deadline / 5, \
+        f"a permanent error was retried for {elapsed:.2f}s"
 
 
 def test_is_busy_error_reads_the_code_sqlite_set(store, tmp_path):
@@ -260,16 +282,18 @@ def test_is_busy_error_reads_the_code_sqlite_set(store, tmp_path):
 
     path = tmp_path / "codes.sqlite3"
     st = Store(path, timeout=0.02, write_attempts=1)
-    acquired, released = threading.Event(), threading.Event()
+    acquired, released, stop = (threading.Event(), threading.Event(),
+                                threading.Event())
     blocker = threading.Thread(target=_hold_write_lock,
-                               args=(path, 0.3, acquired, released))
+                               args=(path, 30.0, acquired, released, stop))
     blocker.start()
     try:
         assert acquired.wait(10), "the blocker never took the write lock"
         with pytest.raises(sqlite3.OperationalError) as busy:
             st.upsert_alias("k", "Jane Doe")
     finally:
-        blocker.join(30)
+        stop.set()
+        blocker.join(60)
     assert busy.value.sqlite_errorcode == 5             # SQLITE_BUSY
     assert is_busy_error(busy.value) is True
     st.close()
@@ -285,9 +309,12 @@ def test_an_exhausted_retry_re_raises_rather_than_going_quiet(tmp_path):
     """
     path = tmp_path / "never-free.sqlite3"
     st = Store(path, timeout=0.01, write_deadline=0.1)
-    acquired, released = threading.Event(), threading.Event()
+    acquired, released, stop = (threading.Event(), threading.Event(),
+                                threading.Event())
+    # The lock is held until this test lets go, so "it gave up" cannot be the
+    # lock quietly freeing itself. 60s is the hang-guard, never the schedule.
     blocker = threading.Thread(target=_hold_write_lock,
-                               args=(path, 3.0, acquired, released))
+                               args=(path, 60.0, acquired, released, stop))
     blocker.start()
     try:
         assert acquired.wait(10), "the blocker never took the write lock"
@@ -296,11 +323,13 @@ def test_an_exhausted_retry_re_raises_rather_than_going_quiet(tmp_path):
             st.upsert_alias("doomed", "Jane Doe")
         elapsed = time.monotonic() - started
     finally:
-        blocker.join(30)
-    # Bounded on both sides: it kept retrying for roughly the deadline (so it
-    # did not give up on the first attempt), and it gave up well before the
-    # 3-second hold ended (so it is not simply waiting the blocker out).
-    assert 0.05 <= elapsed < 1.5, f"gave up after {elapsed:.3f}s"
+        stop.set()
+        blocker.join(60)
+    # It kept retrying for roughly the deadline rather than giving up on the
+    # first attempt. There is no upper bound here on purpose: the lock was still
+    # held when the call returned, which is the fact that matters, and any upper
+    # bound would be an assertion about how loaded the machine is.
+    assert elapsed >= 0.05, f"gave up after {elapsed:.3f}s — no retry happened"
     assert st.alias_count() == 0
     st.close()
 
@@ -323,16 +352,18 @@ def test_write_attempts_bounds_the_number_of_attempts_made(tmp_path):
         conn.execute("INSERT INTO host_prior (site, dir, ts) "
                      "VALUES ('example-site.test', 'Jane Doe', 0)")
 
-    acquired, released = threading.Event(), threading.Event()
+    acquired, released, stop = (threading.Event(), threading.Event(),
+                                threading.Event())
     blocker = threading.Thread(target=_hold_write_lock,
-                               args=(path, 3.0, acquired, released))
+                               args=(path, 60.0, acquired, released, stop))
     blocker.start()
     try:
         assert acquired.wait(10), "the blocker never took the write lock"
         with pytest.raises(sqlite3.OperationalError):
             st._write(work)
     finally:
-        blocker.join(30)
+        stop.set()
+        blocker.join(60)
     assert len(attempts) == 3
     st.close()
 


### PR DESCRIPTION
Closes clawgate task **#349** — filed as "flaky test", reframed by its own comment as a
**durability bug the flaky test was reporting**. This fixes the store, not the test.

## The mechanism

`Store.upsert_alias` — and every other write in `store.py` — executed its statement
directly and committed. `busy_timeout` bounds how long **one** statement waits for the
write lock; when it expires SQLite raises `OperationalError: database is locked` and the
caller's write is **gone**. In `test_concurrent_writers_do_not_lose_rows` that kills the
writer thread and every remaining upsert it owed is never made. In the sidecar it kills the
thread serving the request and the routing decision is never recorded.

`sqlite3.connect(timeout=10.0)`, `PRAGMA busy_timeout=10000` and `PRAGMA journal_mode=WAL`
were already in place. This was never missing configuration — it was a missing **retry**.

The fix is one retry core, `Store._retry_busy`, bounded by `write_deadline=30.0s` **and**
`write_attempts=64`. `Store._write(work)` wraps it to run `work(conn)` plus its commit as
one transaction; **all 17 mutating methods go through `_write`**, and the one statement
that cannot — `PRAGMA journal_mode=WAL` in `_connect`, which runs while the connection is
still being built — calls `_retry_busy` directly. Retrying the whole transaction is safe
because a BUSY failure commits nothing and the helper rolls back first, so
`hits = aliases.hits + 1` still applies exactly once.

`migrate` is retried too, and **not** because an uncaught BUSY there is a crash loop —
`server.py:main()` catches everything around `App(cfg, …)` and degrades to
`Store(":memory:")`, so the process returns 0, the unit stays `active`, `Restart=always`
never fires, and the sidecar serves 503 from an in-memory store until a human intervenes.
That is worse than a crash loop, because nothing self-heals.

Only BUSY/LOCKED is retried, read **structurally** from `sqlite_errorcode` rather than by
matching the message. Anything else propagates on the first attempt. Exhausting the bounds
re-raises the last BUSY error — a write that truly cannot land must still be loud.

🔴 **The default `busy_timeout` is unchanged.** Raising it moves the threshold and leaves
the write lossy past it, which is the "papering over" the card warned about aimed one layer
down.

## Before / after — the busy_timeout sweep

Six threads x 25 upserts against one `Store`, expecting 150 rows, 3 reps per value. Driven
directly rather than through pytest.

| busy_timeout | BEFORE (errors / rows) | AFTER (errors / rows) |
|---|---|---|
| 10.0   | 0 / 150 | 0 / 150 |
| 0.5    | 1 / **125** ROWS LOST | 0 / 150 |
| 0.05   | 5 / **25** ROWS LOST (one rep 42) | 0 / 150 |
| 0.005  | 5 / **25** ROWS LOST | 0 / 150 |
| 0.001  | 5 / **25** ROWS LOST | 0 / 150 |

Before: 12 of 15 reps lost rows. After: 15 of 15 reps at 150 rows, 0 errors, including the
aggressive values where the pre-fix store lost 125 of 150.

## Red / green matrix

`test_concurrent_writers_do_not_lose_rows` is **untouched** — it still asserts
`errors == []` and `alias_count() == 150`. Broken deliberately (retry removed **and** the
default `busy_timeout` dialled to CI-like contention), it goes red with **its own
assertion**, at its own line:

```
>       assert errors == []
E       AssertionError: assert [OperationalE...e is locked')] == []
E         Left contains 5 more items, first extra item: OperationalError('database is locked')
scripts/dl-router/tests/test_store.py:100: AssertionError
```

That is the same shape as the CI failure quoted on the card.

| | pre-fix store | post-fix store |
|---|---|---|
| `test_concurrent_writers_do_not_lose_rows` (unchanged) | RED with its own assertion | green |
| `test_six_writers_with_a_tiny_busy_timeout_still_land_every_row` (new) | RED | green |
| `test_a_write_blocked_past_its_busy_timeout_still_lands` (new) | RED | green |
| whole module | — | 25 passed |

Fourteen tests added, all deterministic: they arrange the block with `BEGIN IMMEDIATE`
(or `EXCLUSIVE`, for the delete→WAL conversion) from a second connection rather than hoping
for a race, and release it on an event so the test costs what the call costs. Module
runtime ~7s; `scripts/dl-router/tests` 991 → 1005 collected.

## Audit round — five 🟡s, all closed

A blind audit found no 🔴 and called it safe to merge, with five 🟡s. Three of them changed
what is actually **enforced**, so they are worth naming:

1. **The comment justifying `migrate`'s retry was FALSE** — it claimed a `Restart=always`
   crash loop. Reproduced: with `migrate()` raising code 5, `main()` returns **0**. The real
   behaviour is the sticky in-memory degrade described above. Comment and PR body corrected;
   the finding strengthens the fix and invalidated only its stated reason.
2. **The `& 0xFF` mask was load-bearing and unasserted** — a mutant removing it passed the
   entire suite. This interpreter surfaces extended codes, so `517 SQLITE_BUSY_SNAPSHOT`
   would have propagated as permanent and lost the row again. Now pinned on
   `5/6/261/262/517/773 → True` and `1/11/19/267 → False`.
3. **The ledger guard was narrower than its docstring** — the recurring class. It matched
   SQL by substring and asked *per method* whether `self._write(` appeared anywhere. Two
   mutants walked it: a bypass spelled `INSERT OR REPLACE INTO`, and a raw `execute` +
   `commit()` added **beside** a correct `_write` in the same method. It now classifies by
   SQL **verb** and checks **per `execute` call**, resolving both inline lambdas and nested
   defs handed over by name. `_run_migration_step`'s exemption is no longer asserted but
   **earned** — a second test pins that every call to it is itself routed.
4. **The worst-case bound was understated.** The deadline is checked *after* an attempt, so
   the last one can begin at `deadline − ε` and block a further `busy_timeout`. Measured at
   three points: `deadline=1.0/timeout=2.0 → 2.02s`; `0.5/4.0 → 4.28s`; `3.0/1.0 → 3.07s`.
   With production defaults the ceiling is **~40s, not ~30s** — documented, including that it
   eats into the /discard headroom `server.py` documents.
5. **`PRAGMA journal_mode=WAL` in `_connect` bypassed the retry**, contradicting the "EVERY
   mutating statement" wording. It is a real write and it cannot use `_write` (which would
   re-enter the connection it is building), so the retry core was split out as `_retry_busy`
   and `_connect` calls it directly. Measured with a held EXCLUSIVE lock: **retry off →
   raises code 5 in 0.021s; retry on → completes in 0.538s with `journal_mode=wal`.**

Also taken: dropped `max(1, int(write_attempts))` (dead — the bound is checked after an
attempt, so it never changed behaviour while reading as a guard), and `_has_column` now
takes its connection like its only caller.

## Mutation results — 17 of 18 killed

Re-run and widened after the audit fixes, since **an audit fix resets the verification
gate**. Every mutant below is traced to the named test that killed it.

| mutant | kind | verdict |
|---|---|---|
| M14 drop the `& 0xFF` mask | non-deletion | **KILLED** — `test_is_busy_error_masks_the_extended_code_suffix` |
| M16 partial bypass beside a correct `_write` | ledger | **KILLED** — `test_every_mutating_execute_is_routed_through_the_retry` |
| M17 bypass spelled `INSERT OR REPLACE INTO` | ledger | **KILLED** — same |
| M17b bypass spelled `REPLACE INTO` | ledger | **KILLED** — same |
| M17c bypass spelled `CREATE INDEX` | ledger | **KILLED** — same |
| M18 `_connect` stops retrying the WAL conversion | non-deletion | **KILLED** — `test_the_wal_conversion_at_connect_time_survives_a_held_lock` |
| M19 `_run_migration_step` called outside a transaction | ledger | **KILLED** — `test_the_migration_step_runners_exemption_is_earned` |
| M20 `_retry_busy` skips the rollback for `_write` | non-deletion | **KILLED** — `test_a_retry_rolls_back_the_partial_transaction_first` |

The original ten, unchanged:

`PYTHONDONTWRITEBYTECODE=1`, `__pycache__` cleared between mutants, positive control in the
batch.

| mutant | kind | verdict |
|---|---|---|
| retry disabled (`WRITE_ATTEMPTS=1`) | positive control | **KILLED** |
| pre-fix store: retry removed + CI-like `busy_timeout` | deletion | **KILLED** — by the untouched flagship test |
| swallow the BUSY, return without re-executing | non-deletion | **KILLED** |
| never re-raise once the bounds are exhausted | non-deletion | **KILLED** |
| off-by-one on the attempt bound (`>=` → `>`) | non-deletion | **KILLED** |
| `is_busy_error` returns True for everything | non-deletion | **KILLED** |
| `is_busy_error` returns False for everything | non-deletion | **KILLED** |
| drop the rollback between attempts | non-deletion | **KILLED** |
| backoff jumps straight to the cap | non-deletion | **SURVIVED** |
| a new write method that bypasses `_write` | ledger | **KILLED** |

The two survivors from the first round were real coverage gaps and both got a test:
`test_write_attempts_bounds_the_number_of_attempts_made` (counts attempts, because an
off-by-one is tens of milliseconds and no wall-clock assertion can see it) and
`test_a_retry_rolls_back_the_partial_transaction_first` (a two-statement write must not
apply its first statement twice).

**The one remaining survivor is accepted, not overlooked.** `delay = RETRY_CAP` changes how
long a contended write sleeps between attempts and nothing else — no durability assertion
in the suite can distinguish it, and pinning a backoff schedule would be a test of a
latency knob. The audit instrumented it independently: peak attempts **10/64 with 6
writers, 31/64 with 32**, so the cap is not near being reached either way.

## 🔴 Negative control — a permanent error still propagates

`test_a_permanent_error_propagates_instead_of_being_retried`: with `aliases` dropped,
`upsert_alias` raises `no such table: aliases` in well under a fifth of the 30-second retry
budget, and the test pins `_write_deadline >= 15.0` so that bound cannot pass vacuously.
`test_is_busy_error_reads_the_code_sqlite_set` pins both branches against **real** sqlite3
exceptions: `sqlite_errorcode == 1` (SQLITE_ERROR) → not retryable,
`sqlite_errorcode == 5` (SQLITE_BUSY, from a genuinely held lock) → retryable. Both
`is_busy_error` mutants die on these.

## Gates

**Gated sha `5e084336`**, rebased onto `origin/main` = `b20b7835`;
`git merge-base --is-ancestor origin/main HEAD` returns 0, and
`git diff --stat origin/main..HEAD` is exactly the three files in this PR — so this is the
**merged** tree, not just the branch.

```
dev host     nix develop . --command bash ./scripts/run-tests.sh . --set all
             RESULT: PASS (exit=0)
             TOTAL collected=15823  passed=15821  skipped=2  failed=0  (floor: 13732)

nix sandbox  nix build .#checks.x86_64-linux.pytests
             RESULT: PASS (exit=0)
             TOTAL collected=15823  passed=15821  skipped=2  failed=0  (floor: 13732)

nix sandbox  nix build .#checks.x86_64-linux.nodetests
             RESULT: PASS (exit=0)
             TOTAL suites=4 files=35 tests=1202 pass=1202 fail=0 skipped=0  (floor: 1173)
```

The node totals moved between the last two rounds (1179/floor 1155 → 1202/floor 1173)
because the intervening `main` commits changed `scripts/run-node-tests.sh` and the clickup
suites. That is the argument for re-gating rather than transferring an older green: the
node runner itself was in the delta.

No floor needed bumping — the added tests raise `scripts/dl-router/tests` from 991 to 1005
against a floor of 942.

### Three gate rounds, and what each round's red actually was

1. **Round 1 was RED on a real breakage of mine.** Making `migrate` run its step list inside
   a `_write` transaction changed `_run_migration_step` to take its connection explicitly,
   and `test_dedupe.py::test_running_the_v5_step_list_twice_is_a_no_op` calls it directly.
   My search for callers was `grep … | head -30` and the truncation dropped exactly that
   row. Both pytest tiers caught it. That round was also nearly misreported green: the
   background wrapper `…; echo "EXIT=$?"` exits 0 whatever the build did, so the harness
   reported "exit code 0" over a failed derivation — the verdict came from the `RESULT:`
   line, as it must.
2. **Round 2 was RED on the dev-host tier only**, in
   `browser_agent::test_malformed_then_blocked_after_one_retry` — a 60s hang-net on a
   subprocess, with three gates sharing the box. Not taken on trust: the file passes 62/62
   in isolation on this tree, the same target is green in the hermetic tier, and
   `browser-bridge` contains **zero** references to `dl-router` — there is no import path by
   which this change could reach it.
3. **Rounds 3 and 4 ran the dev-host tier alone on a quiet box: green both times.**

`origin/main` moved twice mid-gate (`2f6928df` → `5bd00189` → `b20b7835`), each time caught
by re-measuring rather than trusting the earlier ancestry check. Rebased and re-gated from
scratch both times rather than reporting a stale base — worth it the second time, since
that delta contained `scripts/run-node-tests.sh`.

🔴 **`main` moves faster than a gate round completes** (~20 min each way), so this is a
claim about `5e084336` on top of `b20b7835`, not a standing property. Re-check ancestry
before merging.

## Impact on the running sidecar

- **No connection, pragma or isolation change.** `journal_mode`, `busy_timeout`,
  `foreign_keys`, `check_same_thread` and the one-connection-per-thread shape are all
  byte-identical. The only behavioural difference is what happens *after* SQLite says BUSY.
- `dl-router.service` builds `Store(cfg.db_path, clock=clock)`, so it takes the new
  defaults. **Worst-case write latency under sustained contention goes from ~10s to ~30s**
  — after which it still raises. That is the trade being made: previously it answered
  quickly and dropped the row.
- Deploying it needs `home-manager switch` + `systemctl --user restart dl-router`; the unit
  runs from a `/nix/store` copy, so a merge alone changes nothing.

## Stated unmeasured

- **Production frequency is NOT measured.** `upsert_alias` has two non-test callers —
  `server.py:549` (the live sidecar's `write()` helper) and `backfill.py:205/229` — and
  neither retried. The path was unprotected and the failure mode is proven; how concurrent
  the sidecar actually is has not been measured, so nothing here claims this fires in
  normal operation.
- **The CI trigger is not reproduced directly.** Unloaded: 0 failures in 6 runs. Under 20
  CPU burners on 24 cores: 0 failures in 6 runs. In WAL mode a 10-second lock wait means an
  I/O stall, not a busy CPU, and no disk storm was recreated. The busy_timeout sweep
  establishes the mechanism without needing one — **a green CPU-loaded run is not evidence
  here.**
- **Not verified against the live sidecar's own database.** All measurements are on temp
  SQLite files.
- **The 30s deadline and 64-attempt cap are choices, not measurements.** Nothing measured
  says 30s is the right ceiling for an HTTP handler; both are constructor arguments if it
  needs lowering. The audit instrumented the cap as far from binding (peak 10/64 at 6
  writers, 31/64 at 32), but that is a claim about those two load points only.
- **The `& 0xFF` mask is pinned by test but has no live witness.** No `_write` body reads
  before writing today, so `517 SQLITE_BUSY_SNAPSHOT` has never actually been observed from
  this store — the test uses synthetic codes. The mask is correct-by-construction and now
  guarded; it is not confirmed against a real occurrence.
- **`move_routed_file` is still two transactions**, so the window in which neither path has
  a ledger row widens with the retry (~10s → ~40s). It fails closed — a missing row denies
  provenance rather than granting it — so there is no safety consequence, but the window is
  real and unmeasured in production.
- **The `:memory:` rollback caveat.** On the shared in-memory connection a retry's
  `rollback()` can discard another thread's uncommitted work. Confined to tests and the
  degraded-startup store, neither of which has concurrent writers; not fixed.
