### PR TITLE
fix(browser-bridge): the #1 CI failure was a DROPPED telemetry row, not a slow one — the lazy emitter load raced itself

### DIFF
--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -972,13 +972,19 @@ _spool_emit_mod = None
 _spool_emit_tried = False
 # 🔴 THE LAZY LOAD RUNS ON A HANDLER THREAD, SO IT NEEDS A LOCK. ThreadingHTTPServer
 # gives every /cmd its own thread and each one emits after its response is sent, so
-# two commands in flight reach `_load_spool_emit` CONCURRENTLY — routinely, because
-# request N's emit fires exactly while request N+1 is being handled. Without this
-# lock the flag was published BEFORE the module: the loser thread read
-# `_spool_emit_tried is True`, was handed a still-None `_spool_emit_mod`, and
-# `emit_cmd_event` returned at its `if se is None` guard. That event was DROPPED —
-# not delayed, not retried, gone — for the whole life of the process on the losing
-# call, and the row simply never appears in activity.events.
+# request N's emit fires exactly while request N+1 is being handled: the handlers
+# OVERLAP routinely. Without this lock the flag was published BEFORE the module, so
+# any handler arriving during the FIRST import read `_spool_emit_tried is True`, was
+# handed a still-None `_spool_emit_mod`, and `emit_cmd_event` returned at its
+# `if se is None` guard. That event was DROPPED — not delayed, not retried, gone —
+# and its row never appears in activity.events.
+#
+# 🔴 SCOPE, because the overlap is routine and the LOSS is not: the window is the
+# FIRST import only, once per process. After it, `_spool_emit_tried` is latched and
+# every later emit takes the unlocked fast path. So the exposure is the handful of
+# commands concurrent with a server's first emit — real, and bounded. It is the
+# TEST suite that meets it constantly, because the `telemetry` fixture resets the
+# cache per test and re-arms the first import every time.
 #
 # MEASURED, not reasoned, and stated at the scope it was measured: two threads
 # reaching this function with the cache cold, 40 trials per point, on the 24-core

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -970,28 +970,76 @@ _SPOOL_EMIT_PATH = Path(
 )
 _spool_emit_mod = None
 _spool_emit_tried = False
+# 🔴 THE LAZY LOAD RUNS ON A HANDLER THREAD, SO IT NEEDS A LOCK. ThreadingHTTPServer
+# gives every /cmd its own thread and each one emits after its response is sent, so
+# two commands in flight reach `_load_spool_emit` CONCURRENTLY — routinely, because
+# request N's emit fires exactly while request N+1 is being handled. Without this
+# lock the flag was published BEFORE the module: the loser thread read
+# `_spool_emit_tried is True`, was handed a still-None `_spool_emit_mod`, and
+# `emit_cmd_event` returned at its `if se is None` guard. That event was DROPPED —
+# not delayed, not retried, gone — for the whole life of the process on the losing
+# call, and the row simply never appears in activity.events.
+#
+# MEASURED, not reasoned, and stated at the scope it was measured: two threads
+# reaching this function with the cache cold, 40 trials per point, on the 24-core
+# workbench at load average ~42-49 (i.e. loaded, not idle — the CI-like end of
+# the range; the idle end was not measured). Events lost, before -> after:
+#
+#     stagger 0ms      35/40 -> 0/40
+#     stagger 0.5ms      1/40 -> 0/40
+#     stagger 2ms        0/40 -> 0/40
+#
+# So the window is the import's own duration, under 2ms here — which is why this
+# is rare on a workstation and ~10% of runs in a CI step container, where every
+# thread switch is slower. It surfaced as the #1 CI failure: the throttle test's
+# `throttled` row never landing while the server's own stderr proved it HAD
+# throttled. Raising that test's deadline 3s -> 10s could not help, because
+# nothing was ever going to arrive.
+_spool_emit_lock = threading.Lock()
 
 
 def _load_spool_emit():
     """Import the activity spool emitter by absolute path, once. Returns the
     module or None (best-effort — a missing/broken emitter just disables
-    telemetry, never raises)."""
+    telemetry, never raises).
+
+    THREAD-SAFE, and it has to be — see `_spool_emit_lock` above. Two orderings
+    carry the whole contract:
+      * `_spool_emit_tried` is set LAST, after `_spool_emit_mod` is published, so
+        the unlocked fast path can never observe "tried" with the module still
+        missing. (CPython's GIL makes the two global stores non-reorderable.)
+      * the double check inside the lock is what stops the second thread redoing
+        an import the first already finished.
+
+    BEST-EFFORT IS PRESERVED, with one honest caveat: a concurrent caller now
+    BLOCKS for the duration of one small stdlib-only file import instead of
+    silently losing its event. That cannot delay a command — every emit call site
+    runs after `_send` — and it happens at most once per process.
+
+    🔴 The lock is NOT re-entrant: nothing the loaded module imports may call back
+    into this function. spool_emit.py imports stdlib only; keep it that way.
+    """
     global _spool_emit_mod, _spool_emit_tried
     if _spool_emit_tried:
         return _spool_emit_mod
-    _spool_emit_tried = True
-    try:
-        import importlib.util
-        spec = importlib.util.spec_from_file_location(
-            "browser_bridge_spool_emit", str(_SPOOL_EMIT_PATH))
-        if spec is None or spec.loader is None:
-            return None
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
+    with _spool_emit_lock:
+        if _spool_emit_tried:
+            return _spool_emit_mod
+        mod = None
+        try:
+            import importlib.util
+            spec = importlib.util.spec_from_file_location(
+                "browser_bridge_spool_emit", str(_SPOOL_EMIT_PATH))
+            if spec is not None and spec.loader is not None:
+                candidate = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(candidate)
+                mod = candidate
+        except Exception:  # noqa: BLE001 — telemetry is strictly best-effort.
+            mod = None
         _spool_emit_mod = mod
-    except Exception:  # noqa: BLE001 — telemetry is strictly best-effort.
-        _spool_emit_mod = None
-    return _spool_emit_mod
+        # LAST. See the ordering contract in the docstring.
+        _spool_emit_tried = True
+        return _spool_emit_mod
 
 
 def _domain_from_result(result) -> str:

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -118,15 +118,25 @@ def _wait_events(spool_dir, n=1, timeout=10.0, until=None) -> list:
     The emit runs off the critical path, after the HTTP response, so it lands
     slightly after /cmd returns — hence the poll rather than a bare read.
 
-    🔴 A COUNT IS A PROXY, AND `until=` EXISTS BECAUSE THE PROXY IS WRONG UNDER
-    LOAD. MEASURED in CI 2026-08-24 on `devrc-ci-dhsn6`: a throttling test asked
-    for `n=2` and filtered for the `throttled` event. The server HAD throttled —
-    `{"event":"throttled","op":"tabs","reason":"rate_limited"}` is in that run's
-    captured stderr — but only the `cmd` event had reached the spool inside the
-    deadline, so the filter found nothing and the assertion failed as
-    `assert 0 == 1`, reading like a defect in rate limiting. 16 of the 52 call
-    sites in this module use a count this way. Pass `until=` whenever you are
-    waiting for a SPECIFIC event; the count is only right when any N will do.
+    🔴 THE FLAKE THIS WAS BUILT FOR WAS NOT A WAIT PROBLEM AT ALL — DO NOT REACH
+    FOR THE DEADLINE. The throttling test that failed on 3 of the 29 `devrc-ci`
+    runs after 2026-08-24 was losing its `throttled` row to a DATA RACE in
+    server.py's lazy emitter load: two /cmd handler threads reached
+    `_load_spool_emit` together, the flag was published before the module, and
+    the loser was handed None and dropped its event. DROPPED, not delayed — no
+    deadline could ever have recovered it, and raising this one 3s -> 10s did
+    not. Fixed at the root (`_spool_emit_lock`, and the ordering the flag is
+    published in); pinned by
+    `test_a_second_command_emitting_during_the_emitter_load_still_spools`.
+
+    So `until=` and the loud timeout below are still worth having, but for the
+    ORDINARY reason — a count is a proxy for "the event I want landed", and the
+    proxy is only exact when any N will do. Measured over the 56 call sites here:
+    43 pass n=1 after a single command (exact, not a proxy), 4 pass `until=`, and
+    9 pass n>=2. Of those 9, all but one either wait for the earlier event before
+    issuing the next request or assert something order-independent; the exception
+    is the `absent, empty = _wait_events(spool_dir, 2)` unpack, which does depend
+    on file order. Pass `until=` whenever you are waiting for a SPECIFIC event.
 
     🔴 AND A TIMEOUT IS NOW LOUD. This used to return a SHORT list silently, so
     every caller's next line — `[0]`, or a filter — failed with a message about
@@ -2618,8 +2628,11 @@ def test_the_throttle_path_carries_both_the_hash_and_the_join_key(telemetry):
         assert _wait_connected(srv, want=True)
         assert _cmd_sess(srv, {"op": "tabs"}, sid=JOINABLE_ID)[0] == 200
         assert _cmd_sess(srv, {"op": "tabs"}, sid=JOINABLE_ID)[0] == 429
-        # 🔴 `until=` not `n=2`: the count was a proxy for "the throttled event
-        # landed", and CI proved the proxy wrong (see `_wait_events`).
+        # `until=` not `n=2` — the count is a proxy for "the throttled event
+        # landed". 🔴 But the CI failure this test kept producing was NOT a slow
+        # wait: the row was being DROPPED by the emitter-load race (see
+        # `_wait_events` and server.py's `_spool_emit_lock`). Do not widen the
+        # deadline if this reds again — read the spool for what is MISSING.
         def _has_throttle(evs):
             return any(json.loads(e["payload"]).get("outcome") == "throttled"
                        for e in evs)
@@ -2632,6 +2645,164 @@ def test_the_throttle_path_carries_both_the_hash_and_the_join_key(telemetry):
         assert p["sess"] == hashlib.sha256(JOINABLE_ID.encode()).hexdigest()[:8]
         assert p["sess_src"] == "claude"
         assert thr[0]["session"] == JOINABLE_UUID
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# --------------------------------------------------------------------------- #
+# The lazy emitter load is CONCURRENT — see server.py's `_spool_emit_lock`.
+# --------------------------------------------------------------------------- #
+def _gated_emitter(tmp_path):
+    """A copy of the REAL spool emitter whose IMPORT blocks until released.
+
+    Returns `(path, release, counts)`. The gate is APPENDED to the genuine
+    `spool_emit.py` source — so `emit` behaves identically, and so the real file's
+    `from __future__` line keeps its mandatory first-statement position. It
+    records one character per import in `counts` and then blocks. That turns
+    "another caller arrives while the emitter is still loading" from a scheduling
+    accident into an ORDER THE TEST CHOOSES, which is the only way to pin this
+    without a wall-clock dependency.
+
+    The wait is capped so a regression can never hang the suite: it gives up and
+    lets the import finish, and the assertion (not a timeout) is what reports.
+    """
+    go = tmp_path / "emitter-go"
+    counts = tmp_path / "emitter-imports"
+    src = SPOOL_EMIT_PY.read_text(encoding="utf-8") + (
+        "\n\n# --- test gate (appended by _gated_emitter) ---\n"
+        "import time as _t\n"
+        f"with open({str(counts)!r}, 'a') as _f:\n"
+        "    _f.write('x')\n"
+        f"_gate = Path({str(go)!r})\n"
+        "_deadline = _t.time() + 30\n"
+        "while not _gate.exists() and _t.time() < _deadline:\n"
+        "    _t.sleep(0.005)\n"
+    )
+    path = tmp_path / "gated_spool_emit.py"
+    path.write_text(src, encoding="utf-8")
+    return path, (lambda: go.write_text("go", encoding="utf-8")), counts
+
+
+def test_the_emitter_load_publishes_the_module_before_it_claims_to_have_tried(
+        telemetry, tmp_path, monkeypatch):
+    """🔴 THE ORDERING CONTRACT, and the root cause of the #1 CI failure.
+
+    `_load_spool_emit`'s unlocked fast path is `if _spool_emit_tried: return
+    _spool_emit_mod`. It used to set `_spool_emit_tried = True` BEFORE running the
+    import, so for the whole duration of that import a second caller read
+    "already tried" and was handed a still-`None` module — and `emit_cmd_event`
+    returned at its `if se is None` guard. The event was DROPPED, permanently.
+    Not delayed: no deadline could ever have recovered it.
+
+    That is not a rare interleave. Every /cmd emits AFTER its response is sent,
+    so request N's load overlaps request N+1's handler by construction. A probe
+    of two threads reaching the cold function together lost the event in 35 of 40
+    trials at zero stagger and 1 of 40 at a 0.5ms stagger (24-core workbench,
+    load average ~42-49); 0 of 40 at every point after the fix. The full paired
+    numbers are in server.py beside `_spool_emit_lock`.
+
+    Pinned as STATE, not as a word: while the import is provably in flight,
+    `_spool_emit_tried` must still be False.
+    """
+    emitter, release, counts = _gated_emitter(tmp_path)
+    monkeypatch.setattr(S, "_SPOOL_EMIT_PATH", emitter)
+    monkeypatch.setattr(S, "_spool_emit_mod", None)
+    monkeypatch.setattr(S, "_spool_emit_tried", False)
+
+    got = {}
+    t = threading.Thread(target=lambda: got.update(mod=S._load_spool_emit()))
+    t.start()
+    try:
+        # Deterministic handshake: the counts file is written by the gate at the
+        # END of the module body, immediately before it blocks — so its existence
+        # proves the loader is inside exec_module and has NOT returned.
+        assert _wait_until(counts.exists, timeout=30), (
+            "the gated import never started")
+        assert S._spool_emit_tried is False, (
+            "`_spool_emit_tried` was published while `_spool_emit_mod` is still "
+            f"{S._spool_emit_mod!r} — a concurrent caller reading the fast path "
+            "here is handed None and silently drops its event")
+    finally:
+        release()
+        t.join(timeout=30)
+    assert not t.is_alive()
+    assert got["mod"] is not None
+    assert S._spool_emit_tried is True and S._spool_emit_mod is got["mod"]
+
+
+def test_a_second_command_emitting_during_the_emitter_load_still_spools(
+        telemetry, tmp_path, monkeypatch):
+    """🔴 THE CI FAILURE ITSELF, made deterministic.
+
+    `test_the_throttle_path_carries_both_the_hash_and_the_join_key` failed on 3
+    of the 29 `devrc-ci` runs after 2026-08-24 — the single most frequent red in
+    that window — always the same way: the `throttled` row absent from the spool
+    while the server's captured stderr proved it HAD throttled. The two /cmd
+    handler threads were racing the lazy emitter load, and the loser's event was
+    dropped.
+
+    Here the race is SCHEDULED rather than hoped for: the emitter's import blocks,
+    and the second command is not issued until the first command's load is
+    provably in flight and the second's emit is provably inside the loader. So
+    this is red at the pre-fix ordering EVERY run, not one in ten.
+
+    Note what is NOT weakened: the wait is the same `until=_has_throttle`, and the
+    row must still carry its payload. A fix that made this pass by asserting less
+    would be worse than the flake.
+    """
+    spool_dir = telemetry
+    emitter, release, counts = _gated_emitter(tmp_path)
+    monkeypatch.setattr(S, "_SPOOL_EMIT_PATH", emitter)
+    monkeypatch.setattr(S, "_spool_emit_mod", None)
+    monkeypatch.setattr(S, "_spool_emit_tried", False)
+
+    real_load = S._load_spool_emit
+    entered = threading.Semaphore(0)
+
+    def _counting_load():
+        # Recorded BEFORE the call so "the second emitter has reached the loader"
+        # is observable from the test thread. The RESULT still comes from the
+        # real function — this wrapper orchestrates, it never answers.
+        entered.release()
+        return real_load()
+
+    monkeypatch.setattr(S, "_load_spool_emit", _counting_load)
+
+    reg = S.Registry(rate_per_sec=0.001, burst=1, max_queue=1000)
+    srv, _ = _serve(registry=reg)
+    ext = FakeExtension(srv)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=JOINABLE_ID)[0] == 200
+        # The ok-command's emit is the one that performs the load. Wait until it
+        # is inside the (blocked) import before provoking the throttle.
+        assert entered.acquire(timeout=30), "the first emit never reached the loader"
+        assert _wait_until(counts.exists, timeout=30), (
+            "the gated import never started")
+
+        assert _cmd_sess(srv, {"op": "tabs"}, sid=JOINABLE_ID)[0] == 429
+        assert entered.acquire(timeout=30), "the throttled emit never reached the loader"
+    finally:
+        release()
+
+    def _has_throttle(evs):
+        return any(json.loads(e["payload"]).get("outcome") == "throttled"
+                   for e in evs)
+
+    try:
+        evs = _wait_events(spool_dir, until=_has_throttle)
+        thr = [e for e in evs
+               if json.loads(e["payload"]).get("outcome") == "throttled"]
+        assert len(thr) == 1, evs
+        p = json.loads(thr[0]["payload"])
+        assert p["sess"] == hashlib.sha256(JOINABLE_ID.encode()).hexdigest()[:8]
+        assert thr[0]["session"] == JOINABLE_UUID
+        # ONCE-ONLY under a race is the lock's own job — the ordering alone would
+        # let the second caller redo the import.
+        assert counts.read_text() == "x", (
+            f"the emitter was imported {len(counts.read_text())} times under a "
+            "concurrent first load; `_spool_emit_lock` is not holding")
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
 

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -131,12 +131,29 @@ def _wait_events(spool_dir, n=1, timeout=10.0, until=None) -> list:
 
     So `until=` and the loud timeout below are still worth having, but for the
     ORDINARY reason — a count is a proxy for "the event I want landed", and the
-    proxy is only exact when any N will do. Measured over the 56 call sites here:
-    43 pass n=1 after a single command (exact, not a proxy), 4 pass `until=`, and
-    9 pass n>=2. Of those 9, all but one either wait for the earlier event before
-    issuing the next request or assert something order-independent; the exception
-    is the `absent, empty = _wait_events(spool_dir, 2)` unpack, which does depend
-    on file order. Pass `until=` whenever you are waiting for a SPECIFIC event.
+    proxy is only exact when any N will do.
+
+    DERIVED BY AST OVER THIS FILE, not by grep, and the difference was a real
+    error: a line-oriented regex for the count reads the POSITIONAL form and
+    misses the KEYWORD one, so `_wait_events(tmp_path, n=2, …)` was silently
+    filed under n=1 while its sibling on the next line (`until=lambda evs:
+    False`) was filed under `until=` — one function, one test, two buckets, and
+    a total that still added to 56. Rule used, stated because it is a judgement
+    call: bucket by what the call ASKS FOR, and **`_wait_events`' own control
+    tests are classified like every other site — no self-test exemption**, since
+    exempting one of a pair and not the other is what produced the wrong number.
+
+        56 total  =  42 n=1  +  4 until=  +  10 n>=2
+
+    n=1 after a single command is exact, not a proxy. Of the 10 n>=2, one is this
+    harness's own negative control below (it asserts the timeout fires; no real
+    events are involved). Of the 9 remaining real waits, 8 are order-safe —
+    either they wait for the earlier event before issuing the next request, so
+    file order is pinned structurally, or they assert something
+    order-independent. The exception is the `absent, empty =
+    _wait_events(spool_dir, 2)` unpack, which does depend on file order.
+
+    Pass `until=` whenever you are waiting for a SPECIFIC event.
 
     🔴 AND A TIMEOUT IS NOW LOUD. This used to return a SHORT list silently, so
     every caller's next line — `[0]`, or a filter — failed with a message about
@@ -2231,6 +2248,49 @@ def test_load_spool_emit_missing_path_returns_none(monkeypatch, tmp_path):
     monkeypatch.setattr(S, "_spool_emit_mod", None)
     monkeypatch.setattr(S, "_spool_emit_tried", False)
     assert S._load_spool_emit() is None
+    # 🔴 "TRIED" MEANS TRIED, NOT "SUCCEEDED". The flag must be set even on the
+    # failure path — see the behavioural guard below for what goes wrong if a
+    # later edit tucks it into the success branch.
+    assert S._spool_emit_tried is True, (
+        "a FAILED import left `_spool_emit_tried` False, so the next emit will "
+        "retry it — under `_spool_emit_lock`, on every request")
+
+
+def test_a_failed_emitter_import_is_never_retried(monkeypatch, tmp_path):
+    """🔴 THE FAILURE PATH LATCHES — and without this nothing said so.
+
+    `_spool_emit_tried` is set unconditionally, so an emitter that cannot be
+    imported disables telemetry once and stays disabled. That is the documented
+    supported configuration: "collector not checked out -> telemetry simply off".
+
+    UNPINNED UNTIL NOW, and measured: the mutant `_spool_emit_tried = mod is not
+    None` — tucking the flag into the success branch — SURVIVED all 785 tests in
+    this directory. Under it every single emit re-attempts a failing import, and
+    since this PR each of those attempts serializes on `_spool_emit_lock`. That
+    makes a lock added to stop dropped events strictly WORSE than no lock, on a
+    configuration the code says it supports, with no test to say so.
+
+    Pinned BEHAVIOURALLY — the number of import ATTEMPTS — not by reading the
+    flag, because the flag is the proxy and the retry is the harm.
+    """
+    attempts = tmp_path / "import-attempts"
+    emitter = tmp_path / "broken_spool_emit.py"
+    emitter.write_text(
+        f"with open({str(attempts)!r}, 'a') as _f:\n"
+        "    _f.write('x')\n"
+        "raise RuntimeError('emitter is broken')\n",
+        encoding="utf-8")
+    monkeypatch.setattr(S, "_SPOOL_EMIT_PATH", emitter)
+    monkeypatch.setattr(S, "_spool_emit_mod", None)
+    monkeypatch.setattr(S, "_spool_emit_tried", False)
+
+    assert S._load_spool_emit() is None
+    assert attempts.read_text() == "x", "positive control: the import never ran"
+    for _ in range(3):
+        assert S._load_spool_emit() is None
+    assert attempts.read_text() == "x", (
+        f"the broken emitter was imported {len(attempts.read_text())} times — a "
+        "failed import must latch, not retry on every emit")
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/collector/keylog/spool_emit.py
+++ b/scripts/collector/keylog/spool_emit.py
@@ -15,6 +15,18 @@ daemon (`collector.parse_line`) ships the records unchanged:
     the caller omits them — mirroring the bash `emit`.
   * Append is a single newline-terminated `write`, opened O_APPEND, so
     concurrent writers do not interleave for sub-PIPE_BUF lines.
+
+🔴 KEEP THE IMPORTS AT MODULE SCOPE STDLIB-ONLY, AND KEEP THIS BODY CHEAP.
+This is a constraint imposed by a CONSUMER in another directory, so nothing here
+would otherwise hint at it: browser-bridge's `server.py` imports this file lazily
+from a request-handler thread, holding a global lock across `exec_module` (see
+`_spool_emit_lock` there). That lock is what stops a concurrent handler being
+handed a half-loaded module and silently dropping its telemetry row — and its
+worst-case hold time is exactly however long THIS file takes to import. A heavy
+import here, or one that reaches back into `server` and re-enters
+`_load_spool_emit`, turns that into a stall or a deadlock. Unenforced by a test
+on purpose (low reachability, and a test would be more machinery than the risk);
+this note is the enforcement.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## The target

`test_the_throttle_path_carries_both_the_hash_and_the_join_key` was the single
most frequent CI red: **3 of the 6 genuine verdict failures** across the 29
completed `devrc-ci` runs since 2026-08-24 — ~10% of all runs, the same
magnitude as all preemption combined, and blocking unrelated PRs behind a
required gate.

## Diagnosis: DROPPED, not delayed

Established, not inferred. The event never arrives at all — so no deadline could
ever have recovered it, which is why #791 (`9f8d5824`: a real `until=` condition,
a loud timeout, 3s → 10s) was necessary but not sufficient. Run `devrc-ci-pgpd8`
failed on revision `184e88cf`, which already contained it.

`server.py:_load_spool_emit()` publishes its *flag* before its *module*:

```python
_spool_emit_tried = True      # published FIRST
...
spec.loader.exec_module(mod)  # real work, real time
_spool_emit_mod = mod         # published LAST
```

`ThreadingHTTPServer` gives every `/cmd` its own thread, and every emit runs
**after** `_send`. So request N's import overlaps request N+1's handler **by
construction** — not by bad luck. The loser reads `_spool_emit_tried is True`,
is handed a still-`None` `_spool_emit_mod`, and `emit_cmd_event` returns at its
`if se is None:` guard. The row never reaches the spool.

That matches every observed symptom: the spool holding only the `cmd` event
after a full 10s, while the server's own captured stderr proves it *had*
throttled (`{"event":"throttled","op":"tabs","reason":"rate_limited"}`).

### Measured, paired, at the same load

24-core workbench, load average ~42-49 (loaded, not idle — the CI-like end of
the range; the idle end was not measured). 40 trials per point, two threads
reaching the cold function together. **Events lost, before → after:**

| stagger | before | after |
|---|---|---|
| 0 ms | **35/40** | 0/40 |
| 0.5 ms | 1/40 | 0/40 |
| 2 ms | 0/40 | 0/40 |

The window is the import's own duration — under 2 ms here. That is why it is
rare on a workstation and ~10% of runs in a CI step container, where every
thread switch is slower.

## The fix: deterministic, not a bigger number

A module-level lock, plus the ordering the unlocked fast path depends on —
`_spool_emit_tried` set **last**, after the module is published, so a concurrent
reader can never observe "tried" with the module still missing.

Considered and rejected: raising the deadline again (cannot work — nothing
arrives); pre-warming the load in the test (would green the suite while leaving
a real production bug where a throttled row silently vanishes from
`activity.events`).

The best-effort contract is preserved, with one honest caveat recorded in the
docstring: a concurrent caller now **blocks** for one small stdlib-only import
instead of silently losing its event. No command is delayed — every emit call
site already runs after the response is sent — and it happens at most once per
process.

## Tests — red at `2f6928df`, green at HEAD

Both are deterministic, with **no wall-clock dependency**: the emitter's import
is gated by the test, so the race is *scheduled* rather than hoped for.

- `test_the_emitter_load_publishes_the_module_before_it_claims_to_have_tried` —
  pins the ordering as **state**: while the import is provably in flight,
  `_spool_emit_tried` must still be `False`.
- `test_a_second_command_emitting_during_the_emitter_load_still_spools` —
  reproduces the CI failure itself. At the pre-fix ordering it fails with the
  **exact CI signature**: one `cmd` event in the spool, `throttled` absent, and
  the `throttled` line present in captured stderr.

**The assertions are unchanged from the original test.** `len(thr) == 1` and the
`sess` / `session` checks are still there; nothing was weakened.

## Mutation sweep

Run under `PYTHONDONTWRITEBYTECODE=1`, with a positive control. Each mutant is
the narrowest expression that can be wrong, and each dies with **its own guard's
message** (verified separately, not just "a test failed"):

Re-swept after the audit fix (a fix resets the gate), each mutant against the
**whole** browser-bridge suite — no `-k` slice, so a `SURVIVED` verdict cannot be
an artefact of a filter that excluded the killing test.

| mutant | verdict | killed by |
|---|---|---|
| flag published before module (the original bug) | KILLED | ordering assertion + the end-to-end test |
| lock removed (ordering kept) | KILLED | `'xx' == 'x'` — the once-only counter |
| inner double-check removed | KILLED | same |
| `_spool_emit_tried = mod is not None` (**M9**) | KILLED *(was SURVIVED)* | `"imported 4 times"` — 1 + 3 retries |
| `_load_spool_emit` returns `None` always (**positive control**) | KILLED | 4 telemetry tests |

The lock and the ordering are **separately** load-bearing, and separately
pinned: the ordering alone stops the drop, but would let a second caller redo
the import.

### The M9 finding (second commit)

An audit found that `_spool_emit_tried = mod is not None` — tucking the flag into
the success branch — **survived all 785 tests**. Reproduced independently before
fixing. The code was already correct; the property was simply unpinned, and it
matters *because* of the lock this PR adds: under that mutant every emit
re-attempts a failing import and each attempt now serializes on
`_spool_emit_lock`, turning a fix for dropped events into a per-request stall —
on the configuration the code documents as supported ("collector not checked out
→ telemetry simply off"), with no test to say so.

Pinned **behaviourally**, by counting import *attempts*, because the flag is the
proxy and the retry is the harm; plus a one-line structural echo on the existing
missing-path test. Both kill M9 with their own message.

## Call-site survey

`_wait_events`' docstring recorded the wrong diagnosis and would have sent the
next reader to widen the deadline again — corrected here. Its "16 of the 52 call
sites" figure is replaced with a measurement of all **56**, re-derived **by AST**
after the audit caught my first split being wrong:

> **56 = 42 `n=1` + 4 `until=` + 10 `n>=2`**   (not 43/4/9)

The total was right for the wrong reason. A line-oriented regex reads the
*positional* count and misses the *keyword* one, so
`_wait_events(tmp_path, n=2, timeout=0.05)` was filed under `n=1` while its
sibling on the very next line (`until=lambda evs: False`) was filed under
`until=` — one function, one test, two buckets. The classification rule is now
stated in the docstring, including that the harness's own control tests get **no
self-test exemption**: exempting one of a pair and not the other is exactly what
produced the wrong number.

`n=1` after a single command is exact, not a proxy. Of the 10 `n>=2`, one is the
harness's own negative control (no real events involved). Of the 9 remaining
real waits, 8 are order-safe. The one exception —
`absent, empty = _wait_events(spool_dir, 2)` — carries a genuine positional-order
dependency. It is **named, not swept**: a different mechanism from this bug,
never observed firing. No sweeping rewrite.

## Gate

`nix develop <worktree> --command bash scripts/gate.sh --tier both`, run twice —
the second time on the **exact committed tree** at `6e871228` (tree `05463f90`).
Both: **`GATE: RESULT=PASS exit=0`**.

The follow-up commit `d8c55282` is one test plus comments, so the full gate was
**not** re-run for it; `browser-bridge` + `collector/keylog` were:
**871 passed / 0 failed**.

- pytest: 15,811 collected · 15,809 passed · 2 skipped · **0 failed**
  (`scripts/browser-bridge/tests` 785/785)
- node: PASS (`scripts/browser-bridge/tests` 498/498)
- GUARD 8 `spool-rows=0 fallback-leaked=0 control=1`; GUARD 10
  `real-config-changed=0/3 config-control=1` — positive controls fired, nothing
  "never accounted", no second writer.

⚠ Two caveats on scope, both mine to state rather than imply:

1. `gate.sh` is the **dev-host** tier. The tier Tekton gates on is
   `nix build .#checks.x86_64-linux.{pytests,nodetests}`, which builds from a
   store copy with **no `.git`** — not run here.
2. This is a claim about **this branch**, not about the tree its merge creates.
   `strict` is false on `main`, so gating the merged tree is still a manual step.

Note: the first Tekton run on this PR posted **`ERROR` / `COULD NOT RUN`** on
both legs — per `CLAUDE.md` that is the gate stopping before a leg reported, i.e.
a broken gate rather than a verdict on this diff. Deliberately **not** re-run:
re-rolling a flaky required check until it goes green is the exact failure mode
this PR exists to reduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
