### PR TITLE
clickup: `manual` must name a checker; a missing condition is recorded as missing — plus a task-hygiene flow

### DIFF
--- a/claude/skills/clickup/SKILL.md
+++ b/claude/skills/clickup/SKILL.md
@@ -84,10 +84,14 @@ node query.mjs edit-page <doc_id> <page_id> --file /tmp/page.md
   platform specifically**: the API token resolves to a HUMAN identity, so an agent-filed
   task is otherwise indistinguishable from a hand-typed one. Pass **`--cond`** to record
   what will close the task — from the enumerated allowlist `gh_pr_merged:<owner>/<repo>#<n>`,
-  `alert_cleared:<name>`, `cmd_exit_zero:<id>`, `metric_below:<id>`, `manual:<who>`. Anything
-  else is REJECTED at the CLI, not stored — **including a bare `manual`**, which names
-  nobody. Omitting `--cond` records `cond=unstated` and warns on stderr: an honest,
-  greppable marker of ABSENCE, so tasks filed with no closing condition stay countable
+  `alert_cleared:<name>`, `cmd_exit_zero:<id>`, `metric_below:<id>`, `manual:<who>`. It
+  works on **`create` and `subtask`** alike, and a batch plan takes the same value as a
+  `cond` key per task and per subtask (validated plan-wide *before* any task is created).
+  Anything else is REJECTED — **including a bare `manual`**, which names nobody, and
+  **including `unstated`**, which is what the code records when you named nothing and is
+  not something a caller may claim. Rejection happens at the create seam, not just at the
+  CLI. Omitting `--cond` records `cond=unstated` and warns on stderr: an honest, greppable
+  marker of ABSENCE, so tasks filed with no closing condition stay countable
   instead of reading as compliant. ⚠️ The tag is
   **best-effort** — ClickUp requires a tag to exist at the SPACE level first, and creating
   one is a workspace mutation this will not do silently, so a missing space tag warns on

--- a/claude/skills/clickup/SKILL.md
+++ b/claude/skills/clickup/SKILL.md
@@ -84,12 +84,26 @@ node query.mjs edit-page <doc_id> <page_id> --file /tmp/page.md
   platform specifically**: the API token resolves to a HUMAN identity, so an agent-filed
   task is otherwise indistinguishable from a hand-typed one. Pass **`--cond`** to record
   what will close the task — from the enumerated allowlist `gh_pr_merged:<owner>/<repo>#<n>`,
-  `alert_cleared:<name>`, `cmd_exit_zero:<id>`, `metric_below:<id>`, `manual`. Anything
-  else is REJECTED at the CLI, not stored; omitting it means `manual`. ⚠️ The tag is
+  `alert_cleared:<name>`, `cmd_exit_zero:<id>`, `metric_below:<id>`, `manual:<who>`. Anything
+  else is REJECTED at the CLI, not stored — **including a bare `manual`**, which names
+  nobody. Omitting `--cond` records `cond=unstated` and warns on stderr: an honest,
+  greppable marker of ABSENCE, so tasks filed with no closing condition stay countable
+  instead of reading as compliant. ⚠️ The tag is
   **best-effort** — ClickUp requires a tag to exist at the SPACE level first, and creating
   one is a workspace mutation this will not do silently, so a missing space tag warns on
   stderr and the task is still created with its marker. Opt out with `CLICKUP_AGENT_STAMP=0`
   when a human is genuinely the author.
+
+## Task hygiene — read it before you create or close one
+
+🔴 **Creating or closing a ClickUp task? `~/.claude/skills/clickup/flows/task-hygiene.md`.**
+Pre-verify before creating (7 of 8 inbound tickets dissolve on verification, so
+"already done / already exists" and creating NOTHING is a success); one completion
+comment with evidence **per acceptance criterion** plus an explicit NOT-verified list;
+and **do not mark complete when you derived the criteria yourself** — the API token is a
+HUMAN identity here, so an agent closing a ticket is indistinguishable from the human
+doing it. Two comments per task, never per turn. ⚠️ **Nothing enforces any of it** —
+there is no ClickUp hook; it is a convention, and the flow says so first.
 
 ## Going deeper — load ONE only when its trigger fires
 

--- a/claude/skills/clickup/api/tasks.mjs
+++ b/claude/skills/clickup/api/tasks.mjs
@@ -4,7 +4,9 @@
 
 import { apiRequest, apiRequestV3, fetchAllPages } from './client.mjs';
 import { getList } from './lists.mjs';
-import { agentIdentity, buildMarker, stampDescription, COND_UNSTATED } from '../lib/agent-marker.mjs';
+import {
+  agentIdentity, buildMarker, stampDescription, validateCond, MarkerError, COND_UNSTATED,
+} from '../lib/agent-marker.mjs';
 
 // Get task details
 export async function getTask(taskId, includeSubtasks = false) {
@@ -123,12 +125,25 @@ export function applyAgentStamp(options) {
   // marker of presence: `cond=unstated` is greppable, so "how many objects did we
   // file with no closing condition?" is a countable question, where a fake
   // `manual` simply hid the non-compliant object among the compliant ones.
-  const cond = agentCond ?? id.cond;
+  //
+  // 🔴 A CALLER'S cond IS VALIDATED HERE, WITH `unstated` REFUSED. This is the
+  // create seam — `query.mjs create`, `create-subtask`, batch-create and every
+  // programmatic import land on it — and until this validation existed only the
+  // CLI rejected `unstated`, so `applyAgentStamp({ agentCond: 'unstated' })`
+  // stamped it happily. `unstated` records that the CODE OBSERVED an absence;
+  // a caller who can assert it has converted an observation into a claim, and
+  // the count of `cond=unstated` objects stops measuring anything.
+  //
+  // Only the FALLBACK branch below may produce it, and it is the only branch
+  // that opts into buildMarker's `allowUnstated`.
+  const fromFallback = agentCond === undefined || agentCond === null;
+  const cond = fromFallback ? id.cond : validateCallerCond(agentCond);
   warnIfConditionUnstated(cond);
   const marker = buildMarker({
     srcProducer: id.producer,
     srcRunId: id.runId,
     cond,
+    allowUnstated: fromFallback,
     // 🔴 fp is OMITTED unless the caller supplies one. A session-filed task has
     // no stable claim tuple, and a fingerprint that changes every run defeats
     // the dedupe it exists to provide — see lib/agent-marker.mjs.
@@ -145,6 +160,25 @@ export function applyAgentStamp(options) {
     body.description = stampDescription(body.description, marker);
   }
   return { body, tag: id.label };
+}
+
+// Validate a CALLER-supplied cond, and say so in the message.
+//
+// 🔴 THE PREFIX IS LOAD-BEARING, and the reason is a mutation result. buildMarker
+// validates too, so removing this call changes NO behaviour a plain
+// `assert.throws(…, MarkerError)` can see — the mutant that deletes the seam's own
+// guard dies to buildMarker's instead, i.e. green for the wrong reason, and would
+// stay green with this guard gone. `claude/RULES.md`: "a mutant that dies for a
+// DIFFERENT guard's reason proves nothing about this one." Attributing the refusal
+// to the seam is what makes this guard's own assertion reachable — and it is also
+// the more useful error, because it names the OPTION the caller passed rather than
+// a grammar rule they never invoked directly.
+function validateCallerCond(agentCond) {
+  try {
+    return validateCond(agentCond);
+  } catch (e) {
+    throw new MarkerError(`agentCond rejected at the create seam: ${e.message}`);
+  }
 }
 
 // Loud on stderr, never fatal: the caller asked for a task and gets one. The

--- a/claude/skills/clickup/api/tasks.mjs
+++ b/claude/skills/clickup/api/tasks.mjs
@@ -4,7 +4,7 @@
 
 import { apiRequest, apiRequestV3, fetchAllPages } from './client.mjs';
 import { getList } from './lists.mjs';
-import { agentIdentity, buildMarker, stampDescription } from '../lib/agent-marker.mjs';
+import { agentIdentity, buildMarker, stampDescription, COND_UNSTATED } from '../lib/agent-marker.mjs';
 
 // Get task details
 export async function getTask(taskId, includeSubtasks = false) {
@@ -107,20 +107,28 @@ function agentStampEnabled(options) {
 // into the description, and (b) the tag to attach afterwards.
 //
 // EXPORTED for test/agent-marker.test.mjs. It is the entire stamping decision,
-// and it is pure — so the suite can assert what ClickUp would actually receive
-// without a network call or a module mock. createTask/createSubtask do nothing
-// with the result but spread it into the POST body and attach the tag.
+// and its ONLY side effect is the stderr warning below — so the suite can assert
+// what ClickUp would actually receive without a network call or a module mock.
+// createTask/createSubtask do nothing with the result but spread it into the
+// POST body and attach the tag.
 export function applyAgentStamp(options) {
   const { agentStamp: _drop, agentFp, agentCond, ...rest } = options;
   if (!agentStampEnabled(options)) return { body: rest, tag: null };
   const id = agentIdentity();
+  // A caller with a real closing condition passes one. A caller with none gets
+  // `unstated` — and is TOLD SO, loudly.
+  //
+  // 🔴 This used to default to `manual`, which stamped every conditionless task
+  // as though it had a condition. An honest marker of ABSENCE beats a dishonest
+  // marker of presence: `cond=unstated` is greppable, so "how many objects did we
+  // file with no closing condition?" is a countable question, where a fake
+  // `manual` simply hid the non-compliant object among the compliant ones.
+  const cond = agentCond ?? id.cond;
+  warnIfConditionUnstated(cond);
   const marker = buildMarker({
     srcProducer: id.producer,
     srcRunId: id.runId,
-    // A caller with a real machine-checkable condition passes one; a session
-    // filing a one-off gets `manual`, which is an honest "no machine closes
-    // this" rather than a fabricated condition nobody will evaluate.
-    cond: agentCond ?? id.cond,
+    cond,
     // 🔴 fp is OMITTED unless the caller supplies one. A session-filed task has
     // no stable claim tuple, and a fingerprint that changes every run defeats
     // the dedupe it exists to provide — see lib/agent-marker.mjs.
@@ -137,6 +145,19 @@ export function applyAgentStamp(options) {
     body.description = stampDescription(body.description, marker);
   }
   return { body, tag: id.label };
+}
+
+// Loud on stderr, never fatal: the caller asked for a task and gets one. The
+// warning is what makes the gap visible AT THE MOMENT it is created, instead of
+// only to whoever greps the corpus later.
+function warnIfConditionUnstated(cond) {
+  if (cond !== COND_UNSTATED) return;
+  process.stderr.write(
+    'Warning: filing this task with cond=unstated — no closing condition was named.\n'
+    + '  Pass --cond to say what closes it: gh_pr_merged:<owner>/<repo>#<n>, alert_cleared:<name>,\n'
+    + '  cmd_exit_zero:<id>, metric_below:<id>, or manual:<who> naming the human who checks it.\n'
+    + '  What counts as a closing condition: ~/.claude/skills/clawgate/flows/task-authoring.md, question 1.\n',
+  );
 }
 
 async function attachAgentTag(taskId, tag) {

--- a/claude/skills/clickup/flows/task-hygiene.md
+++ b/claude/skills/clickup/flows/task-hygiene.md
@@ -1,0 +1,129 @@
+# flow: ClickUp task hygiene — before you create, and before you close
+
+🔴 **NOTHING ENFORCES ANY OF THIS.** clawgate's equivalents
+(`~/.claude/skills/clawgate/flows/task-authoring.md`,
+`~/.claude/skills/clawgate/flows/task-pickup.md`) work because two PreToolUse/Stop
+hooks route to them and BLOCK. There is no ClickUp hook, no server check, and no
+gate anywhere in this skill that reads this file. It is a convention you follow or
+do not follow, and it is written down here so it can at least be *cited*.
+
+That warning is first because a doc that reads as a gate while providing none is
+worse than none — it stops anyone looking. Do not summarise this file elsewhere as
+"the ClickUp task gate". It is not one.
+
+---
+
+## 1. Before you CREATE — pre-verify, and expect to create nothing
+
+Every question you can answer yourself is one you must not spend on a human.
+Arrive with findings.
+
+| question | how you answer it |
+|---|---|
+| Is it already done? | `git log --oneline -20 -- <path>` in the owning repo; `gh pr list --search "<keyword>" --state all` |
+| Does a task already exist? | `node query.mjs search "<keyword>"` — **search before create**, every time. Duplicates on a team board are worse than on a private one: two people work them |
+| Is it deliberately off / suspended? | read the config or manifest — a suspended kustomization, an `enabled: false`, a commented-out timer. A task to "fix" something that is off ON PURPOSE is worse than no task |
+| Which repo / directory does it land in? | resolve it now; a ticket that does not say is a ticket someone has to come back to you about |
+| Is there a verifier already? | an existing test target, a gate script, an alert — cheaper than inventing one |
+
+**Reporting "already done" / "already exists" / "deliberately off" and creating
+NOTHING is the successful outcome.** Say so, with what you measured. It is not a
+failure to have produced no object.
+
+📊 **Why this is first, measured.** `scripts/task-spec-drafter/README.md` ran the
+unattended version of exactly this problem over a real batch of **8 inbound
+tickets: 1 was genuinely actionable.** The other 7 dissolved on verification —
+already done, stale, underspecified, or deliberately switched off. A naive
+title-only pass would have filed all 8, and one of its drafts would have crashed a
+deliberately-suspended service. Pre-verification is not diligence theatre; it is
+where 7 of 8 objects go away.
+
+**Name the closing condition, or do not file.** What counts as one — and who or
+what checks it — is defined at question 1 of
+`~/.claude/skills/clawgate/flows/task-authoring.md`. That is the single source; it
+is deliberately not restated here, and a guard
+(`scripts/tests/test_closing_condition_single_source.py`) fails if anyone restates
+it anywhere. If you can name neither a mechanical check nor a named human
+judgement over named evidence, say so in your reply instead of creating an object
+nobody can close.
+
+**Record it mechanically too**: pass `--cond` on create
+(`gh_pr_merged:<owner>/<repo>#<n>`, `alert_cleared:<name>`, `cmd_exit_zero:<id>`,
+`metric_below:<id>`, or `manual:<who>` naming the human who checks it). Omitting
+`--cond` is not fatal — it records `cond=unstated` and warns — but `unstated` is a
+recorded admission that you filed something nobody can close, and it is greppable
+precisely so those can be counted.
+
+**Body: keep it to Context + Acceptance criteria + Non-goals + Verifier.**
+
+- **Non-goals** — what a reader would plausibly do and should not. The cheapest
+  scope control there is.
+- **Verifier** — the exact command, test target or metric. "Read the diff" is not a
+  verifier.
+
+## 2. Before you CLOSE — the completion write-back
+
+**One completion comment, carrying evidence PER ACCEPTANCE CRITERION** — one line
+each, naming what proves it — **plus an explicit `NOT verified:` list**.
+
+> "All green" with no per-criterion mapping is not a completion report.
+
+📊 **Why, measured.** An entire skill exists solely to answer the question "was
+this actually done?" — `~/.claude/skills/check-clickup-addressed/SKILL.md` reads
+session transcripts because the tasks themselves do not say. On the tasks it could
+see it returned **0 addressed / 1 partially addressed / 2 not established.** A
+per-criterion mapping is what would have let that verdict be read off the task
+itself, instead of reconstructed from a transcript and still coming back
+"not established".
+
+The `NOT verified:` list is the load-bearing half. It is the only place the reader
+learns what you did *not* check, and omitting it converts an honest partial into a
+false completion.
+
+## 3. Before you set a status — the self-grading gate
+
+**If YOU derived the acceptance criteria rather than the author specifying them,
+you MUST NOT mark the task complete.** Report what you did, leave it for the
+author, and say plainly that the criteria were yours.
+
+Detector, not a judgement call: a heading matching `## Acceptance criteria`
+(case-insensitive) in the body the author wrote → **AUTHOR-SPECIFIED**. Anything
+else — including a body that merely *reads* like criteria — means you **DERIVED**
+them. Writing the criteria and grading them is one act, in either order.
+
+🔴 **The ClickUp-specific reason, and it inverts the intuition you may have brought
+from clawgate.** On clawgate a dispatched agent *structurally cannot* set
+`complete` (the agent route refuses it) and its comments are authored `claude-code`,
+a distinct identity from `user`. **On ClickUp the API token resolves to a HUMAN
+identity.** There is no bot identity, no separate author, and no status the token
+is forbidden. An agent closing a ticket is **indistinguishable from the human
+closing it**, in the UI and in the API. ClickUp has *weaker* structural protection
+than clawgate, and therefore needs this discipline **more**, not less — the place
+where the machine cannot stop you is exactly the place the convention has to hold.
+
+## 4. Comment budget — two per task, never per turn
+
+**Exactly two comments: one when you start, one when you finish.** ClickUp
+notifies every watcher on every comment, so per-turn self-reporting spams the whole
+team rather than one board owner. Per-turn chatter was measured as noise and
+removed once on clawgate; do not reintroduce it here, where the blast radius is
+other people's notifications.
+
+The pre-start comment is the point at which someone can object *before* the work
+rather than after: state the criteria (quoted verbatim, and labelled
+`DERIVED — not author-specified` if they are yours), the plan, the non-goals, and
+the assumptions that would change the work if wrong.
+
+---
+
+## Deliberately NOT ported from clawgate — do not re-add these
+
+- **The `in_progress` 409 ordering trap.** That is an artifact of clawgate's own
+  API (a task in progress refuses body PATCHes). ClickUp has no equivalent guard,
+  so the "flip status LAST" ordering rule has nothing to protect against here.
+- **Hard tag validation and reserved namespaces** (`runbook:`, `gate:`,
+  `initiative:`). clawgate 400s on an invalid tag; ClickUp tags are **Space-level
+  and must pre-exist**, so tagging here is best-effort — a missing space tag warns
+  on stderr and the task is still created. There is no closed namespace to police.
+- **The full 6-section body template.** Too heavy for a ticket other humans have to
+  read. Keep Non-goals and Verifier (section 1); drop the rest.

--- a/claude/skills/clickup/flows/task-hygiene.md
+++ b/claude/skills/clickup/flows/task-hygiene.md
@@ -47,12 +47,16 @@ it anywhere. If you can name neither a mechanical check nor a named human
 judgement over named evidence, say so in your reply instead of creating an object
 nobody can close.
 
-**Record it mechanically too**: pass `--cond` on create
+**Record it mechanically too**: pass `--cond` on `create` **or `subtask`**
 (`gh_pr_merged:<owner>/<repo>#<n>`, `alert_cleared:<name>`, `cmd_exit_zero:<id>`,
-`metric_below:<id>`, or `manual:<who>` naming the human who checks it). Omitting
-`--cond` is not fatal — it records `cond=unstated` and warns — but `unstated` is a
-recorded admission that you filed something nobody can close, and it is greppable
-precisely so those can be counted.
+`metric_below:<id>`, or `manual:<who>` naming the human who checks it); a batch
+plan takes the same value as a `cond` key per task and per subtask. Omitting it is
+not fatal — it records `cond=unstated` and warns — but `unstated` is a recorded
+admission that you filed something nobody can close, and it is greppable precisely
+so those can be counted. 🔴 **You cannot pass `unstated` yourself.** It is what the
+code writes when it OBSERVED that you named nothing; a caller able to assert it
+would turn that observation back into a claim, and the count would stop measuring
+anything. It is rejected at the create path, not only at the CLI.
 
 **Body: keep it to Context + Acceptance criteria + Non-goals + Verifier.**
 
@@ -70,11 +74,13 @@ each, naming what proves it — **plus an explicit `NOT verified:` list**.
 
 📊 **Why, measured.** An entire skill exists solely to answer the question "was
 this actually done?" — `~/.claude/skills/check-clickup-addressed/SKILL.md` reads
-session transcripts because the tasks themselves do not say. On the tasks it could
-see it returned **0 addressed / 1 partially addressed / 2 not established.** A
+session transcripts because the tasks themselves do not say. The one end-to-end
+run recorded in this repo — `claude/skills/check-clickup-addressed/reference/validation-history.md`,
+"End-to-end after round 3" (2026-08-20) — came back **0 addressed, 0 partial,
+0 open, 2 unclear**: it could establish nothing about either task it looked at. A
 per-criterion mapping is what would have let that verdict be read off the task
 itself, instead of reconstructed from a transcript and still coming back
-"not established".
+"unclear".
 
 The `NOT verified:` list is the load-bearing half. It is the only place the reader
 learns what you did *not* check, and omitting it converts an honest partial into a

--- a/claude/skills/clickup/lib/agent-marker.mjs
+++ b/claude/skills/clickup/lib/agent-marker.mjs
@@ -47,7 +47,7 @@ export const MARKER_VERSION = '1';
 //   alert_cleared:<alertname>        closes when that Prometheus alert stops firing
 //   cmd_exit_zero:<id>               closes when a registered command exits 0
 //   metric_below:<id>                closes when a registered metric drops below its bound
-//   manual                           the escape hatch — no machine check, takes NO arg
+//   manual:<who>                     no machine check — NAMES the human who checks it
 export const COND_KINDS = Object.freeze([
   'gh_pr_merged',
   'alert_cleared',
@@ -56,10 +56,19 @@ export const COND_KINDS = Object.freeze([
   'manual',
 ]);
 
-// The one kind that is complete on its own. Every OTHER kind REQUIRES an
-// argument: a bare `metric_below` names no metric and is exactly as unactionable
-// as the free text the allowlist exists to forbid.
-export const COND_KINDS_NO_ARG = Object.freeze(['manual']);
+// 🔴 `manual` REQUIRES an argument, and that is the whole point of it.
+// `claude/RULES.md` (proactivity gate, "Out of scope") allows a task to be filed
+// only when its closing condition can be NAMED, together with who or what checks
+// it — the definition lives at question 1 of
+// `~/.claude/skills/clawgate/flows/task-authoring.md`. A bare `manual` satisfies
+// neither half: it is not a machine check, and it names nobody. So it is exactly
+// as unactionable as the free text this allowlist exists to forbid, and it is
+// worse than free text because it READS as a recorded condition.
+//
+// `unstated` is the ONE kind that is complete on its own — see below. Every kind
+// a caller may pass takes an argument.
+export const COND_UNSTATED = 'unstated';
+export const COND_KINDS_NO_ARG = Object.freeze([COND_UNSTATED]);
 
 export const AGENT_LABEL_PREFIX = 'agent/';
 
@@ -92,23 +101,55 @@ export function labelFor(producer) {
   return AGENT_LABEL_PREFIX + producer;
 }
 
-export function validateCond(cond) {
+// Validate a condition string.
+//
+// 🔴 TWO OPT-INS, both narrow, both named — never a bare boolean:
+//
+//   allowUnstated    `unstated` is the value the MISSING-cond fallback produces
+//                    (agentIdentity / applyAgentStamp). buildMarker and
+//                    parseMarker must be able to handle it; a CALLER must never
+//                    be able to pass it, because "I have no condition" is a fact
+//                    the code observes, not a condition anyone may claim.
+//   allowBareManual  parse-side only, and it is a CROSS-LANGUAGE fact rather
+//                    than a legacy allowance: talos-infra's
+//                    `scripts/lib/agent_obj_marker.py` is the other half of this
+//                    one grammar and it still emits a bare `manual` (measured
+//                    2026-08-24). Rejecting that on the READ path would blind a
+//                    JS reconciler to every object the Python producers stamp —
+//                    which is the exact invisibility this whole marker exists to
+//                    end. So: this side REFUSES TO EMIT one and still READS one.
+//                    A bare `manual` parses with condArg === null, which is how a
+//                    consumer counts the ones that name nobody.
+export function validateCond(cond, { allowUnstated = false, allowBareManual = false } = {}) {
   if (typeof cond !== 'string' || cond === '') {
     throw new MarkerError('cond is required');
   }
   const i = cond.indexOf(':');
   const kind = i < 0 ? cond : cond.slice(0, i);
   const arg = i < 0 ? '' : cond.slice(i + 1);
+  if (kind === COND_UNSTATED) {
+    if (!allowUnstated) {
+      throw new MarkerError(
+        'cond "unstated" is produced only by the missing-cond fallback and is never accepted as input'
+        + ' — name a real condition instead, e.g. `manual:<who>`',
+      );
+    }
+    if (i >= 0) throw new MarkerError('cond kind "unstated" takes no argument');
+    return cond;
+  }
   if (!COND_KINDS.includes(kind)) {
     throw new MarkerError(
       `cond kind ${JSON.stringify(kind)} is not in the allowlist ${JSON.stringify([...COND_KINDS].sort())}`,
     );
   }
-  if (COND_KINDS_NO_ARG.includes(kind)) {
-    if (i >= 0) throw new MarkerError(`cond kind ${JSON.stringify(kind)} takes no argument`);
-    return cond;
-  }
   if (i < 0 || arg === '') {
+    if (kind === 'manual') {
+      if (i < 0 && allowBareManual) return cond;
+      throw new MarkerError(
+        'cond kind "manual" must NAME who checks it — write `manual:<who>` (e.g. `manual:zach`).'
+        + ' A bare `manual` names nobody, so it records a condition no one can act on.',
+      );
+    }
     throw new MarkerError(`cond kind ${JSON.stringify(kind)} requires an argument (\`${kind}:<arg>\`)`);
   }
   if (!COND_ARG_RE.test(arg)) {
@@ -145,7 +186,9 @@ export function buildMarker({ srcProducer, srcRunId, cond, fp = null, init = nul
   if (!RUN_ID_RE.test(srcRunId ?? '')) {
     throw new MarkerError(`invalid run-id ${JSON.stringify(srcRunId)} (want ${RUN_ID_RE})`);
   }
-  validateCond(cond);
+  // `unstated` is buildable because the fallback produces it; a bare `manual` is
+  // NOT, because this side must never emit a condition that names nobody.
+  validateCond(cond, { allowUnstated: true });
   const parts = [`v=${MARKER_VERSION}`];
   if (fp !== null && fp !== undefined) {
     if (!FP_RE.test(fp)) throw new MarkerError(`invalid fp ${JSON.stringify(fp)} (want 12 lowercase hex)`);
@@ -195,7 +238,9 @@ function parseFields(blob) {
   const runId = src.slice(si + 1);
   if (!PRODUCER_RE.test(producer) || !RUN_ID_RE.test(runId)) return null;
   try {
-    validateCond(cond);
+    // Read side: tolerant of both the fallback value and the Python
+    // implementation's bare `manual` — see validateCond's opt-in notes.
+    validateCond(cond, { allowUnstated: true, allowBareManual: true });
   } catch {
     return null;
   }
@@ -236,14 +281,22 @@ export function agentIdentity(env = process.env) {
     RUN_ID_RE,
     (s) => s.replace(/[^A-Za-z0-9._-]/g, '-').slice(0, 128),
   ) ?? 'unknown';
-  // 🔴 An unrecognised cond falls back to `manual`, NOT to silence. `manual` is
-  // an honest "no machine can close this"; dropping the marker entirely would
-  // make the object invisible again, which is the whole defect.
-  let cond = 'manual';
+  // 🔴 A missing or unrecognised cond falls back to `unstated`, NOT to silence
+  // and NOT to `manual`.
+  //
+  // It used to fall back to `manual`, and that was a DISHONEST marker of
+  // presence: every task filed without a condition came out stamped as though it
+  // had one, so a non-compliant object was indistinguishable from a compliant
+  // one and nothing could count them. `unstated` is an honest marker of ABSENCE
+  // — greppable, countable ("how many objects were filed with no condition?"),
+  // and impossible to mistake for a condition somebody will evaluate. Dropping
+  // the marker entirely is still not an option: that makes the object invisible
+  // again, which is the defect this whole file exists to close.
+  let cond = COND_UNSTATED;
   try {
     if (env.CLAW_AGENT_COND) cond = validateCond(env.CLAW_AGENT_COND);
   } catch {
-    cond = 'manual';
+    cond = COND_UNSTATED;
   }
   const init = sanitise(env.CLAW_AGENT_INIT, INIT_RE, (s) => s.toLowerCase().replace(/[^a-z0-9-]/g, '-')) ?? null;
   return { producer, runId, cond, init, label: AGENT_LABEL_PREFIX + producer };

--- a/claude/skills/clickup/lib/agent-marker.mjs
+++ b/claude/skills/clickup/lib/agent-marker.mjs
@@ -106,20 +106,29 @@ export function labelFor(producer) {
 // 🔴 TWO OPT-INS, both narrow, both named — never a bare boolean:
 //
 //   allowUnstated    `unstated` is the value the MISSING-cond fallback produces
-//                    (agentIdentity / applyAgentStamp). buildMarker and
-//                    parseMarker must be able to handle it; a CALLER must never
-//                    be able to pass it, because "I have no condition" is a fact
-//                    the code observes, not a condition anyone may claim.
-//   allowBareManual  parse-side only, and it is a CROSS-LANGUAGE fact rather
-//                    than a legacy allowance: talos-infra's
-//                    `scripts/lib/agent_obj_marker.py` is the other half of this
-//                    one grammar and it still emits a bare `manual` (measured
-//                    2026-08-24). Rejecting that on the READ path would blind a
-//                    JS reconciler to every object the Python producers stamp —
-//                    which is the exact invisibility this whole marker exists to
-//                    end. So: this side REFUSES TO EMIT one and still READS one.
-//                    A bare `manual` parses with condArg === null, which is how a
-//                    consumer counts the ones that name nobody.
+//                    (agentIdentity → applyAgentStamp). parseMarker must handle
+//                    it unconditionally (a reconciler has to READ what we stamp)
+//                    and buildMarker handles it only when the caller declares the
+//                    fallback. A CALLER must never be able to pass it, because
+//                    "I have no condition" is a fact the code observes, not a
+//                    condition anyone may claim — enforced at the create seam
+//                    (api/tasks.mjs `validateCallerCond`) and, one layer down, by
+//                    buildMarker's `allowUnstated: false` default.
+//   allowBareManual  parse-side only, and it is a LEGACY-CORPUS allowance:
+//                    objects stamped before the arity rule carry `cond=manual`
+//                    and are live right now. Rejecting that on the READ path
+//                    would make every one of them unparseable and therefore
+//                    invisible — the exact invisibility this marker exists to
+//                    end. So: REFUSE TO EMIT, STILL READ. A bare `manual` parses
+//                    with condArg === null, which is how a consumer counts the
+//                    ones that name nobody. `manual:` — a colon with an empty
+//                    argument — is NOT covered: that is malformed, not legacy.
+//                    🔴 The other half of this grammar,
+//                    `<talos-infra>/scripts/lib/agent_obj_marker.py`, takes the
+//                    SAME position (measured at commit `9e21058fc`, 2026-08-24) —
+//                    an earlier version of this comment said Python "still emits"
+//                    a bare `manual`, which stopped being true with
+//                    civitai/talos-infra#1286.
 export function validateCond(cond, { allowUnstated = false, allowBareManual = false } = {}) {
   if (typeof cond !== 'string' || cond === '') {
     throw new MarkerError('cond is required');

--- a/claude/skills/clickup/lib/agent-marker.mjs
+++ b/claude/skills/clickup/lib/agent-marker.mjs
@@ -179,16 +179,25 @@ function canonicalJson(value) {
   return JSON.stringify(value);
 }
 
-export function buildMarker({ srcProducer, srcRunId, cond, fp = null, init = null }) {
+// 🔴 `allowUnstated` DEFAULTS TO FALSE, and that default is the fix for a real
+// hole: this used to pass `{ allowUnstated: true }` unconditionally, so ANY
+// caller reaching buildMarker — or applyAgentStamp, createTask, create-subtask,
+// batch-create — could assert `cond=unstated` and have it stamped. Only the CLI
+// rejected it. `unstated` means the CODE OBSERVED AN ABSENCE; a caller able to
+// assert it converts an observation back into a claim, which destroys the
+// sentinel's only value (you can no longer count authorial omission, because
+// anyone can spell it). So the affordance is now opt-in AT THE CALL SITE, and
+// the only site that opts in is the missing-cond fallback in applyAgentStamp().
+export function buildMarker({ srcProducer, srcRunId, cond, fp = null, init = null, allowUnstated = false }) {
   if (!PRODUCER_RE.test(srcProducer ?? '')) {
     throw new MarkerError(`invalid producer ${JSON.stringify(srcProducer)} (want ${PRODUCER_RE})`);
   }
   if (!RUN_ID_RE.test(srcRunId ?? '')) {
     throw new MarkerError(`invalid run-id ${JSON.stringify(srcRunId)} (want ${RUN_ID_RE})`);
   }
-  // `unstated` is buildable because the fallback produces it; a bare `manual` is
-  // NOT, because this side must never emit a condition that names nobody.
-  validateCond(cond, { allowUnstated: true });
+  // A bare `manual` is never emittable — this side must not emit a condition
+  // that names nobody. `unstated` is emittable ONLY through the fallback path.
+  validateCond(cond, { allowUnstated });
   const parts = [`v=${MARKER_VERSION}`];
   if (fp !== null && fp !== undefined) {
     if (!FP_RE.test(fp)) throw new MarkerError(`invalid fp ${JSON.stringify(fp)} (want 12 lowercase hex)`);
@@ -292,14 +301,33 @@ export function agentIdentity(env = process.env) {
   // and impossible to mistake for a condition somebody will evaluate. Dropping
   // the marker entirely is still not an option: that makes the object invisible
   // again, which is the defect this whole file exists to close.
+  //
+  // 🔴 AND THE DEGRADATION IS ANNOUNCED WHERE IT HAPPENS. An operator who
+  // exported `CLAW_AGENT_COND=manual` (or any off-allowlist value) believes they
+  // named a condition; silently rewriting it to `unstated` makes them wrong in a
+  // way only a later grep could reveal, and the create-site warning alone says
+  // "no closing condition was named", which reads as false to someone who did
+  // set the variable. So the point of degradation says so, quoting the value and
+  // the reason it was refused.
   let cond = COND_UNSTATED;
   try {
     if (env.CLAW_AGENT_COND) cond = validateCond(env.CLAW_AGENT_COND);
-  } catch {
+  } catch (e) {
     cond = COND_UNSTATED;
+    warn(
+      `Warning: CLAW_AGENT_COND=${JSON.stringify(env.CLAW_AGENT_COND)} was REFUSED — ${e.message}\n`
+      + `  Recording cond=${COND_UNSTATED} instead. Export an allowlisted value, e.g.\n`
+      + '  CLAW_AGENT_COND=manual:zach, or pass --cond on the create.\n',
+    );
   }
   const init = sanitise(env.CLAW_AGENT_INIT, INIT_RE, (s) => s.toLowerCase().replace(/[^a-z0-9-]/g, '-')) ?? null;
   return { producer, runId, cond, init, label: AGENT_LABEL_PREFIX + producer };
+}
+
+// Single writer for this module's stderr, so a test can capture it the same way
+// it captures api/tasks.mjs's create-site warning.
+function warn(text) {
+  process.stderr.write(text);
 }
 
 function sanitise(raw, re, clean) {

--- a/claude/skills/clickup/lib/batch-create.mjs
+++ b/claude/skills/clickup/lib/batch-create.mjs
@@ -19,11 +19,12 @@
  *       "dueDate": "+7d",           // relative or absolute date
  *       "startDate": "today",
  *       "tags": ["architecture"],
+ *       "cond": "manual:zach",      // agent-object close-condition (see below)
  *       "listId": "900000000002",   // override default list
  *       "dependsOn": ["other-ref"], // must complete before this task starts
  *       "blocks": ["other-ref"],    // this task blocks other tasks
  *       "subtasks": [
- *         { "name": "Draft ERD", "assignee": "sam" },
+ *         { "name": "Draft ERD", "assignee": "sam", "cond": "manual:sam" },
  *         { "name": "Review ERD", "assignee": "riley" }
  *       ]
  *     }
@@ -33,6 +34,36 @@
 
 import { createTask, createSubtask, addDependency, setPriority, parseDateInput, setDueDate, setStartDate, assignTask, addTag } from '../api/tasks.mjs';
 import { findUser } from '../api/user.mjs';
+import { validateCond } from './agent-marker.mjs';
+
+/**
+ * Validate every `cond` in a plan BEFORE anything is created.
+ *
+ * 🔴 UP FRONT, not per task. A plan is a fan-out: validating lazily means task
+ * 17 of 20 throws with 16 objects already on the board and no rollback. The
+ * whole plan is a single authoring act, so it fails as one.
+ *
+ * Exported so the suite can assert the refusal without a network call.
+ * Returns the list of `<where>: <message>` problems; empty means the plan's
+ * conditions are all sayable.
+ */
+export function validatePlanConds(plan) {
+  const problems = [];
+  const check = (cond, where) => {
+    if (cond === undefined || cond === null) return; // omission is legal — it records `unstated`
+    try {
+      validateCond(cond);
+    } catch (e) {
+      problems.push(`${where}: ${e.message}`);
+    }
+  };
+  (plan.tasks || []).forEach((t, i) => {
+    const label = t.ref || t.name || `task[${i}]`;
+    check(t.cond, label);
+    (t.subtasks || []).forEach((s, j) => check(s.cond, `${label} > ${s.name || `subtask[${j}]`}`));
+  });
+  return problems;
+}
 
 /**
  * Execute a batch create plan.
@@ -47,6 +78,16 @@ export async function executeBatchCreate(plan, opts = {}) {
 
   if (tasks.length === 0) {
     return { created: [], errors: [], message: 'No tasks in plan' };
+  }
+
+  const condProblems = validatePlanConds(plan);
+  if (condProblems.length > 0) {
+    return {
+      created: [],
+      errors: condProblems.map((error) => ({ error })),
+      refMap: {},
+      message: `Plan rejected: ${condProblems.length} invalid cond value(s); nothing was created`,
+    };
   }
 
   // Phase 1: Create all tasks and map refs to real IDs
@@ -76,6 +117,11 @@ export async function executeBatchCreate(plan, opts = {}) {
       const createOpts = {};
       if (t.description) createOpts.markdown_description = t.description;
       if (t.status) createOpts.status = t.status;
+      // The close-condition for the agent-object marker createTask() stamps.
+      // Without this every batch-filed task is `cond=unstated` by construction,
+      // and a 20-task plan contributes 20 to a count that is supposed to measure
+      // authorial omission. Already validated above, plan-wide.
+      if (t.cond) createOpts.agentCond = t.cond;
       if (t.dueDate) {
         try {
           const date = parseDateInput(t.dueDate);
@@ -134,6 +180,8 @@ export async function executeBatchCreate(plan, opts = {}) {
             const subResult = await createSubtask(taskId, sub.name, {
               description: sub.description || undefined,
               status: sub.status || undefined,
+              // Same reason as the parent: a subtask is a stamped object too.
+              agentCond: sub.cond || undefined,
             });
             if (verbose) process.stderr.write(`  ↳ Subtask "${sub.name}" → ${subResult.id}\n`);
 

--- a/claude/skills/clickup/query.mjs
+++ b/claude/skills/clickup/query.mjs
@@ -210,6 +210,30 @@ contentArg = unescapeText(contentArg);
 descriptionArg = unescapeText(descriptionArg);
 arg2 = unescapeText(arg2);
 
+// Agent-object hygiene: fold --cond into a create's options, validated.
+//
+// 🔴 ONE PLACE, because there is more than one creating command. `create` and
+// `subtask` both stamp (api/tasks.mjs), so both must be able to NAME the closing
+// condition — a creator that structurally cannot is a creator whose objects are
+// all `cond=unstated` no matter how diligent the author, which turns the
+// `unstated` count from a measure of authorial omission into a measure of an
+// interface gap. Validated HERE so an off-allowlist value fails loudly at the
+// CLI instead of degrading somewhere deeper: a wrong condition that reads as
+// accepted is how an object ends up believed-tracked and actually immortal.
+// Omitting --cond is NOT an error: it records cond=unstated and warns.
+function withAgentCond(options) {
+  if (!condArg) return options;
+  try {
+    options.agentCond = validateCond(condArg);
+  } catch (e) {
+    console.error(`Error: ${e.message}`);
+    console.error(`Allowed --cond kinds: ${[...COND_KINDS].sort().join(', ')}`);
+    console.error('Every kind takes an argument; manual takes the NAME of who checks it.');
+    process.exit(1);
+  }
+  return options;
+}
+
 // --file overrides --content: read file contents as the content/text argument
 if (fileArg) {
   const filePath = resolve(fileArg);
@@ -338,14 +362,18 @@ Options:
   --attach     File path to upload as attachment (repeatable, for attach/comment)
   --page       Page ID for doc-reply (identifies which page the thread is on)
   --space      Space ID for create-doc (places doc in that space)
-  --cond       Close-condition for a task an agent files, from the enumerated
-               allowlist (gh_pr_merged:<owner>/<repo>#<n>, alert_cleared:<name>,
-               cmd_exit_zero:<id>, metric_below:<id>, manual:<who>). Recorded in
-               the task body so a later reconciler can close it. 'manual' MUST
-               name who checks it - a bare 'manual' names nobody and is REJECTED,
-               as is anything off-allowlist. Omitting --cond records
-               cond=unstated and warns on stderr, so a task filed with no
-               condition stays countable instead of looking compliant.
+  --cond       Close-condition for a task an agent files (create AND subtask),
+               from the enumerated allowlist (gh_pr_merged:<owner>/<repo>#<n>,
+               alert_cleared:<name>, cmd_exit_zero:<id>, metric_below:<id>,
+               manual:<who>). Recorded in the task body so a later reconciler
+               can close it. 'manual' MUST name who checks it - a bare 'manual'
+               names nobody and is REJECTED, as is anything off-allowlist.
+               'unstated' is REJECTED too: it is what the code records when you
+               named nothing, never something you may claim. Omitting --cond
+               records cond=unstated and warns on stderr, so a task filed with
+               no condition stays countable instead of looking compliant.
+               batch-create takes the same value per task as a 'cond' key (and
+               per subtask), validated before ANY task is created.
 
 Bulk Operations (comma-separated IDs):
   node query.mjs get id1,id2,id3              Fetch multiple tasks at once
@@ -1096,21 +1124,9 @@ async function main() {
           options.markdown_description = descriptionArg;
         }
         // Agent-object hygiene: an explicit close-condition for the marker
-        // createTask() stamps. Validated HERE so an off-allowlist value fails
-        // loudly at the CLI instead of silently degrading deep inside the stamp
-        // — a wrong condition that reads as accepted is how an object ends up
-        // believed-tracked and actually immortal. Omitting --cond entirely is
-        // NOT an error: it records cond=unstated and warns (api/tasks.mjs).
-        if (condArg) {
-          try {
-            options.agentCond = validateCond(condArg);
-          } catch (e) {
-            console.error(`Error: ${e.message}`);
-            console.error(`Allowed --cond kinds: ${[...COND_KINDS].sort().join(', ')}`);
-            console.error('Every kind takes an argument; manual takes the NAME of who checks it.');
-            process.exit(1);
-          }
-        }
+        // createTask() stamps. See withAgentCond() — one validator, both
+        // creating commands.
+        withAgentCond(options);
         if (dueArg) {
           const dueDate = parseDateInput(dueArg);
           options.due_date = dueDate.getTime();
@@ -1333,7 +1349,10 @@ async function main() {
           console.error('Usage: node query.mjs subtask <task> "Subtask title"');
           process.exit(1);
         }
-        const subtask = await createSubtask(taskId, arg2);
+        // A subtask is a created object like any other: it gets stamped, so it
+        // must be able to name what closes it. Without --cond here every
+        // subtask this CLI files is `cond=unstated` by construction.
+        const subtask = await createSubtask(taskId, arg2, withAgentCond({}));
         if (jsonOutput) {
           console.log(JSON.stringify(subtask, null, 2));
         } else {

--- a/claude/skills/clickup/query.mjs
+++ b/claude/skills/clickup/query.mjs
@@ -340,9 +340,12 @@ Options:
   --space      Space ID for create-doc (places doc in that space)
   --cond       Close-condition for a task an agent files, from the enumerated
                allowlist (gh_pr_merged:<owner>/<repo>#<n>, alert_cleared:<name>,
-               cmd_exit_zero:<id>, metric_below:<id>, manual). Recorded in the
-               task body so a later reconciler can close it. Defaults to
-               'manual'; anything off-allowlist is REJECTED, not stored.
+               cmd_exit_zero:<id>, metric_below:<id>, manual:<who>). Recorded in
+               the task body so a later reconciler can close it. 'manual' MUST
+               name who checks it - a bare 'manual' names nobody and is REJECTED,
+               as is anything off-allowlist. Omitting --cond records
+               cond=unstated and warns on stderr, so a task filed with no
+               condition stays countable instead of looking compliant.
 
 Bulk Operations (comma-separated IDs):
   node query.mjs get id1,id2,id3              Fetch multiple tasks at once
@@ -1094,15 +1097,17 @@ async function main() {
         }
         // Agent-object hygiene: an explicit close-condition for the marker
         // createTask() stamps. Validated HERE so an off-allowlist value fails
-        // loudly at the CLI instead of silently degrading to `manual` deep
-        // inside the stamp — a wrong condition that reads as accepted is how an
-        // object ends up believed-tracked and actually immortal.
+        // loudly at the CLI instead of silently degrading deep inside the stamp
+        // — a wrong condition that reads as accepted is how an object ends up
+        // believed-tracked and actually immortal. Omitting --cond entirely is
+        // NOT an error: it records cond=unstated and warns (api/tasks.mjs).
         if (condArg) {
           try {
             options.agentCond = validateCond(condArg);
           } catch (e) {
             console.error(`Error: ${e.message}`);
             console.error(`Allowed --cond kinds: ${[...COND_KINDS].sort().join(', ')}`);
+            console.error('Every kind takes an argument; manual takes the NAME of who checks it.');
             process.exit(1);
           }
         }

--- a/claude/skills/clickup/reference/maintaining.md
+++ b/claude/skills/clickup/reference/maintaining.md
@@ -56,10 +56,22 @@ Two gotchas worth keeping:
   shallow sort silently fingerprints two identical claims apart whenever a nested
   object's keys were built in a different order. Mutation-verified: only the
   nested vector catches it.
-- `agentIdentity()` **sanitises rather than trusts**, and an unusable
-  `CLAW_AGENT_COND` degrades to `manual`, never to silence. `manual` is an honest
-  "no machine closes this"; dropping the marker would make the object invisible
-  again, which is the whole defect.
+- `agentIdentity()` **sanitises rather than trusts**, and a missing or unusable
+  `CLAW_AGENT_COND` degrades to `unstated`, never to silence and never to
+  `manual`. `unstated` is an honest, greppable marker of ABSENCE — a fake `manual`
+  hid the non-compliant object among the compliant ones; dropping the marker
+  entirely would make the object invisible again, which is the whole defect.
+  A caller may not pass `unstated`: it is an observation the code makes, not a
+  condition anyone may claim.
+- 🔴 **This side and the Python side now DIVERGE on `manual`'s arity, deliberately
+  and only there.** Here `manual:<who>` is required and a bare `manual` is
+  refused; Python still accepts a bare `manual` and refuses `manual:zach`
+  (measured 2026-08-24 against `<talos-infra>/scripts/lib/agent_obj_marker.py` at
+  `origin/trunk`). So this side **refuses to emit** a bare `manual` and **still
+  parses** one — rejecting it on the read path would blind a JS reconciler to
+  every object the Python producers stamp. The divergence is enumerated and
+  asserted in `test/agent-marker.test.mjs` (`PYTHON_DIVERGENCE`); closing it means
+  making the same change in the Python module and moving those notes with it.
 
 ## Tests
 

--- a/claude/skills/clickup/reference/maintaining.md
+++ b/claude/skills/clickup/reference/maintaining.md
@@ -58,20 +58,41 @@ Two gotchas worth keeping:
   nested vector catches it.
 - `agentIdentity()` **sanitises rather than trusts**, and a missing or unusable
   `CLAW_AGENT_COND` degrades to `unstated`, never to silence and never to
-  `manual`. `unstated` is an honest, greppable marker of ABSENCE — a fake `manual`
-  hid the non-compliant object among the compliant ones; dropping the marker
-  entirely would make the object invisible again, which is the whole defect.
-  A caller may not pass `unstated`: it is an observation the code makes, not a
-  condition anyone may claim.
-- 🔴 **This side and the Python side now DIVERGE on `manual`'s arity, deliberately
-  and only there.** Here `manual:<who>` is required and a bare `manual` is
-  refused; Python still accepts a bare `manual` and refuses `manual:zach`
-  (measured 2026-08-24 against `<talos-infra>/scripts/lib/agent_obj_marker.py` at
-  `origin/trunk`). So this side **refuses to emit** a bare `manual` and **still
-  parses** one — rejecting it on the read path would blind a JS reconciler to
-  every object the Python producers stamp. The divergence is enumerated and
-  asserted in `test/agent-marker.test.mjs` (`PYTHON_DIVERGENCE`); closing it means
-  making the same change in the Python module and moving those notes with it.
+  `manual` — and the degradation now **warns at the point it happens**, quoting
+  the refused value. `unstated` is an honest, greppable marker of ABSENCE — a fake
+  `manual` hid the non-compliant object among the compliant ones; dropping the
+  marker entirely would make the object invisible again, which is the whole
+  defect.
+- 🔴 **`unstated` is PRODUCED, never ACCEPTED — and that is enforced at the create
+  seam, not only at the CLI.** `applyAgentStamp()` validates a caller's
+  `agentCond` with `unstated` refused, and `buildMarker`'s `allowUnstated` now
+  defaults to **false** so the only site that can emit one is the missing-cond
+  fallback. It used to pass `allowUnstated: true` unconditionally, which meant
+  `applyAgentStamp`, `createTask`, `createSubtask` and batch-create all accepted
+  `cond=unstated` from a caller while the docs and one test claimed they did not.
+  A caller who can assert `unstated` has converted an observation into a claim,
+  and the count stops measuring anything.
+- 🔴 **What the `unstated` count MEANS, and how it was nearly ruined.** It is
+  meant to measure **authorial omission**. That only holds while every creating
+  path can name a condition: `create-subtask` and batch-create originally could
+  not, so every subtask and every batch task was `unstated` by construction and a
+  20-task plan added 20. Both now take one (`--cond` on `subtask`; a `cond` key
+  per task and per subtask in a batch plan, validated plan-wide **before any task
+  is created**). **If you add another creating path, give it a cond option in the
+  same change** — a creator that structurally cannot name one silently reclassifies
+  an interface gap as authorial omission.
+- 🔴 **This side and the Python side DIVERGE in exactly ONE place: the
+  missing-cond FALLBACK.** JS has one (`agentIdentity` → `applyAgentStamp`), so JS
+  is the only half that ever EMITS `cond=unstated`; Python's `cond` is a required
+  positional and its `build_marker` validates with no opt-ins, so it cannot. Both
+  sides refuse to emit a bare `manual` and both still parse one; both refuse
+  `unstated` as input and both parse it. Measured 2026-08-24 against
+  `<talos-infra>/scripts/lib/agent_obj_marker.py` at commit `9e21058fc` (branch
+  `zach/marker-manual-names-checker`, PR civitai/talos-infra#1286, which merges
+  before this). The divergence is enumerated and asserted in
+  `test/agent-marker.test.mjs` (`PYTHON_DIVERGENCE`), which records that commit
+  and the sha256 of the file it was measured from; closing it means making the
+  same change in the Python module and moving those notes with it.
 
 ## Tests
 

--- a/claude/skills/clickup/test/agent-marker.test.mjs
+++ b/claude/skills/clickup/test/agent-marker.test.mjs
@@ -36,6 +36,7 @@ import {
   MARKER_VERSION,
   COND_KINDS,
   COND_KINDS_NO_ARG,
+  COND_UNSTATED,
   MarkerError,
   AGENT_LABEL_PREFIX,
   labelFor,
@@ -60,8 +61,8 @@ const QUERY_SRC = readFileSync(resolve(__dirname, '..', 'query.mjs'), 'utf8');
 // and it would agree with any drift.
 const VECTORS = Object.freeze({
   minimal: {
-    args: { srcProducer: 'capacity-sweep', srcRunId: 'sweep-29159872-abcde', cond: 'manual' },
-    marker: '<!-- claw:obj v=1 src=capacity-sweep/sweep-29159872-abcde cond=manual -->',
+    args: { srcProducer: 'capacity-sweep', srcRunId: 'sweep-29159872-abcde', cond: 'cmd_exit_zero:drift-check' },
+    marker: '<!-- claw:obj v=1 src=capacity-sweep/sweep-29159872-abcde cond=cmd_exit_zero:drift-check -->',
   },
   full: {
     args: {
@@ -81,6 +82,31 @@ const VECTORS = Object.freeze({
     [{ producer: 'reliability-sweep-advisor', claim: 'index-candidates' }, '633d2c372bd0'],
   ],
   condKinds: ['alert_cleared', 'cmd_exit_zero', 'gh_pr_merged', 'manual', 'metric_below'],
+  // A Python-produced marker carrying the bare `manual` this side no longer
+  // EMITS but must still READ. Generated 2026-08-24 from
+  // talos-infra scripts/lib/agent_obj_marker.py at origin/trunk.
+  pythonBareManual: '<!-- claw:obj v=1 src=capacity-sweep/run-1 cond=manual -->',
+});
+
+// 🔴 THE DIVERGENCE FROM PYTHON, ENUMERATED — because tier 2 above otherwise
+// reads as "these two agree", and as of this change they do not, in exactly two
+// places. Both were MEASURED against the Python module at
+// talos-infra origin/trunk on 2026-08-24, and the error strings are quoted:
+//
+//   1. bare `manual`  — Python ACCEPTS it (`validate_cond('manual') -> 'manual'`);
+//      this side refuses to emit one and still parses one. Python rejects
+//      `manual:zach` with "cond kind 'manual' takes no argument (got 'zach')".
+//   2. `unstated`     — JS only. Python: "cond kind 'unstated' is not in the
+//      allowlist [...]".
+//
+// Neither divergence changes the ALLOWLIST OF KINDS, which is why the pin below
+// still holds. Closing the divergence means making the same change in
+// `scripts/lib/agent_obj_marker.py` and moving these notes with it; until then
+// this block is the honest record, not a to-do nobody wrote down.
+const PYTHON_DIVERGENCE = Object.freeze({
+  jsRefusesToEmitBareManual: true,
+  jsStillParsesBareManual: true,
+  jsOnlyFallbackKind: COND_UNSTATED,
 });
 
 // ── Tier 1: unit ────────────────────────────────────────────────────────────
@@ -120,11 +146,84 @@ test('buildMarker: a cond kind that needs an argument is rejected bare', () => {
   }
 });
 
-test('buildMarker: `manual` rejects an argument', () => {
+// ── `manual` must NAME a checker ────────────────────────────────────────────
+// The rule: a task may be filed only when its closing condition can be named,
+// together with who or what checks it (definition: question 1 of
+// ~/.claude/skills/clawgate/flows/task-authoring.md). A bare `manual` names
+// nobody, so it recorded a condition that satisfied neither half of that.
+
+test('validateCond: `manual:<who>` is the valid form and is returned verbatim', () => {
+  assert.equal(validateCond('manual:zach'), 'manual:zach');
+  assert.equal(validateCond('manual:koen'), 'manual:koen');
+  assert.equal(validateCond('manual:support-rota'), 'manual:support-rota');
+});
+
+test('validateCond: a BARE `manual` is rejected, and the message says what to write instead', () => {
+  let err;
   assert.throws(
-    () => buildMarker({ srcProducer: 'p', srcRunId: 'r', cond: 'manual:because-i-said-so' }),
-    MarkerError,
+    () => validateCond('manual'),
+    (e) => { err = e; return e instanceof MarkerError; },
+    'a bare `manual` must not validate — it names nobody',
   );
+  // 🔴 Pin the REMEDY, not just the rejection. A rejection with no instruction
+  // is how a caller ends up deleting --cond altogether.
+  assert.match(err.message, /manual:<who>/,
+    `the rejection must tell the caller to write \`manual:<who>\`; got: ${err.message}`);
+  assert.match(err.message, /names nobody/,
+    `the rejection must say WHY; got: ${err.message}`);
+  // `manual:` with an empty argument is the same defect wearing a colon.
+  assert.throws(() => validateCond('manual:'), MarkerError);
+});
+
+test('buildMarker: refuses to EMIT a bare `manual`, and round-trips `manual:<who>`', () => {
+  assert.throws(() => buildMarker({ srcProducer: 'p', srcRunId: 'r', cond: 'manual' }), MarkerError);
+  const marker = buildMarker({ srcProducer: 'capacity-sweep', srcRunId: 'run-1', cond: 'manual:zach' });
+  assert.equal(marker, '<!-- claw:obj v=1 src=capacity-sweep/run-1 cond=manual:zach -->');
+  const got = parseMarker(`body text\n${marker}\ntrailing`);
+  assert.ok(got, 'a `manual:<who>` marker must parse');
+  assert.equal(got.cond, 'manual:zach');
+  assert.equal(got.condKind, 'manual');
+  assert.equal(got.condArg, 'zach', 'the CHECKER is the whole point — it must survive the round-trip');
+});
+
+test('validateCond: the other allowlisted kinds are unchanged', () => {
+  assert.equal(validateCond('gh_pr_merged:civitai/devrc#796'), 'gh_pr_merged:civitai/devrc#796');
+  assert.equal(validateCond('alert_cleared:KubeNodeNotReady'), 'alert_cleared:KubeNodeNotReady');
+  assert.equal(validateCond('cmd_exit_zero:drift-check'), 'cmd_exit_zero:drift-check');
+  assert.equal(validateCond('metric_below:capacity:node-disk-free'), 'metric_below:capacity:node-disk-free');
+  for (const bare of ['gh_pr_merged', 'alert_cleared', 'cmd_exit_zero', 'metric_below']) {
+    assert.throws(() => validateCond(bare), MarkerError, `bare ${bare} must still be rejected`);
+  }
+});
+
+// ── `unstated` is produced, never accepted ──────────────────────────────────
+
+test('validateCond: `unstated` is REJECTED as caller input', () => {
+  let err;
+  assert.throws(
+    () => validateCond(COND_UNSTATED),
+    (e) => { err = e; return e instanceof MarkerError; },
+    '`unstated` must not be passable by a caller — it is an observation, not a claim',
+  );
+  assert.match(err.message, /never accepted as input/,
+    `the rejection must say it is fallback-only; got: ${err.message}`);
+  // Nor with an argument, nor via the marker builder's caller-facing path.
+  assert.throws(() => validateCond('unstated:whatever'), MarkerError);
+  assert.throws(() => validateCond('unstated:whatever', { allowUnstated: true }), MarkerError);
+  // …and it is NOT in the allowlist a caller is shown.
+  assert.equal(COND_KINDS.includes(COND_UNSTATED), false,
+    '`unstated` must stay out of COND_KINDS — that list is the menu offered to callers');
+  assert.deepEqual([...COND_KINDS_NO_ARG], [COND_UNSTATED],
+    'the fallback kind is the ONLY kind that is complete without an argument');
+});
+
+test('buildMarker/parseMarker: `unstated` round-trips, because the fallback must be stampable', () => {
+  const marker = buildMarker({ srcProducer: 'claude-code', srcRunId: 'r', cond: COND_UNSTATED });
+  assert.equal(marker, '<!-- claw:obj v=1 src=claude-code/r cond=unstated -->');
+  const got = parseMarker(marker);
+  assert.ok(got, 'an `unstated` marker must be readable — that is what makes the gap COUNTABLE');
+  assert.equal(got.cond, COND_UNSTATED);
+  assert.equal(got.condArg, null);
 });
 
 test('buildMarker: a value that would break the HTML comment is rejected', () => {
@@ -132,15 +231,15 @@ test('buildMarker: a value that would break the HTML comment is rejected', () =>
     assert.throws(() => buildMarker({ srcProducer: 'p', srcRunId: 'r', cond }), MarkerError);
   }
   for (const bad of ['Capacity Sweep', 'cap sweep', '-lead', '', 'A']) {
-    assert.throws(() => buildMarker({ srcProducer: bad, srcRunId: 'r', cond: 'manual' }), MarkerError);
+    assert.throws(() => buildMarker({ srcProducer: bad, srcRunId: 'r', cond: 'manual:zach' }), MarkerError);
   }
   for (const bad of ['run 1', 'run>1', '']) {
-    assert.throws(() => buildMarker({ srcProducer: 'p', srcRunId: bad, cond: 'manual' }), MarkerError);
+    assert.throws(() => buildMarker({ srcProducer: 'p', srcRunId: bad, cond: 'manual:zach' }), MarkerError);
   }
 });
 
 test('buildMarker: invalid optional fields are rejected', () => {
-  const base = { srcProducer: 'p', srcRunId: 'r', cond: 'manual' };
+  const base = { srcProducer: 'p', srcRunId: 'r', cond: 'manual:zach' };
   assert.throws(() => buildMarker({ ...base, fp: 'deadbeef' }), MarkerError);      // too short
   assert.throws(() => buildMarker({ ...base, fp: '0123456789AB' }), MarkerError);  // uppercase
   assert.throws(() => buildMarker({ ...base, init: 'Not A Slug' }), MarkerError);
@@ -162,8 +261,8 @@ test('parseMarker: round-trip with the optional fields ABSENT', () => {
   const got = parseMarker(VECTORS.minimal.marker);
   assert.equal(got.fp, null);
   assert.equal(got.init, null);
-  assert.equal(got.condArg, null);
-  assert.equal(got.cond, 'manual');
+  assert.equal(got.cond, 'cmd_exit_zero:drift-check');
+  assert.equal(got.condArg, 'drift-check');
 });
 
 test('parseMarker: an absent marker is null, never a throw', () => {
@@ -216,6 +315,29 @@ test('CROSS-LANGUAGE: markers are byte-identical to the Python implementation', 
   assert.equal(buildMarker(VECTORS.full.args), VECTORS.full.marker);
 });
 
+test('CROSS-LANGUAGE: the divergence from Python is EXACTLY the enumerated set', () => {
+  // 🔴 Tier 2 otherwise reads as "these two implementations agree", and on the
+  // `manual` arity they now do not. An enumerated, asserted divergence is the
+  // honest form: unplanned drift still goes red, and the planned part is
+  // greppable rather than a comment nobody re-checks.
+  assert.equal(PYTHON_DIVERGENCE.jsRefusesToEmitBareManual, true);
+  assert.throws(() => buildMarker({ srcProducer: 'p', srcRunId: 'r', cond: 'manual' }), MarkerError,
+    'this side must NOT emit the bare `manual` Python still emits');
+
+  assert.equal(PYTHON_DIVERGENCE.jsStillParsesBareManual, true);
+  const legacy = parseMarker(VECTORS.pythonBareManual);
+  assert.ok(legacy,
+    'a Python-stamped bare `manual` MUST still parse — rejecting it on the READ path would blind '
+    + 'a JS reconciler to every object the Python producers stamp, which is the invisibility this '
+    + 'marker exists to end');
+  assert.equal(legacy.condKind, 'manual');
+  assert.equal(legacy.condArg, null, 'condArg === null is how a consumer counts the ones naming nobody');
+
+  assert.equal(PYTHON_DIVERGENCE.jsOnlyFallbackKind, COND_UNSTATED);
+  // The kind ALLOWLIST is unchanged, which is why the pin above still holds.
+  assert.deepEqual([...COND_KINDS].sort(), VECTORS.condKinds);
+});
+
 test('CROSS-LANGUAGE: fingerprints match Python json.dumps(sort_keys=True)', () => {
   // The nested case is the one that matters: JSON.stringify preserves insertion
   // order, so a SHALLOW key sort silently fingerprints two identical claims
@@ -231,7 +353,9 @@ test('agentIdentity: defaults are usable with an empty environment', () => {
   const id = agentIdentity({});
   assert.equal(id.producer, DEFAULT_PRODUCER);
   assert.equal(id.runId, 'unknown');
-  assert.equal(id.cond, 'manual');
+  // 🔴 NOT `manual`. A missing condition is recorded as MISSING.
+  assert.equal(id.cond, COND_UNSTATED,
+    'a caller who named no condition must not be stamped as though they had');
   assert.equal(id.init, null);
   assert.equal(id.label, `agent/${DEFAULT_PRODUCER}`);
   // The whole point: whatever the environment holds, the result must BUILD.
@@ -247,10 +371,10 @@ test('agentIdentity: a hostile environment still yields a buildable identity', (
   });
   assert.equal(id.producer, 'capacity-sweep--');
   assert.equal(id.runId, 'run-id-with-spaces-and-brackets');
-  // 🔴 Falls back to `manual`, NOT to silence. `manual` is an honest "no machine
-  // closes this"; dropping the marker would make the object invisible again,
-  // which is the entire defect Phase 0 addresses.
-  assert.equal(id.cond, 'manual');
+  // 🔴 Falls back to `unstated`, NOT to silence and NOT to `manual`. An honest
+  // marker of ABSENCE beats a dishonest marker of presence; dropping the marker
+  // would make the object invisible again, which is the defect Phase 0 addresses.
+  assert.equal(id.cond, COND_UNSTATED);
   assert.equal(id.init, 'some-slug');
   const marker = buildMarker({ srcProducer: id.producer, srcRunId: id.runId, cond: id.cond, init: id.init });
   assert.ok(parseMarker(marker), 'a sanitised identity must produce a PARSEABLE marker');
@@ -274,14 +398,50 @@ test('stampDescription: idempotent — an existing marker is never doubled', () 
 
 // ── Tier 3: the producer seam (behavioural) ─────────────────────────────────
 
+/** Run `fn` with process.stderr.write captured; returns [result, stderrText]. */
+function captureStderr(fn) {
+  const real = process.stderr.write;
+  let out = '';
+  process.stderr.write = (chunk) => { out += String(chunk); return true; };
+  try {
+    return [fn(), out];
+  } finally {
+    process.stderr.write = real;
+  }
+}
+
 test('SEAM: a plain create is stamped with a parseable marker and a tag', () => {
-  const { body, tag } = applyAgentStamp({});
+  const [{ body, tag }] = captureStderr(() => applyAgentStamp({}));
   const got = parseMarker(body.markdown_description);
   assert.ok(got, `no marker in ${JSON.stringify(body)}`);
-  assert.equal(got.cond, 'manual');
+  assert.equal(got.cond, COND_UNSTATED);
   assert.equal(got.fp, null, 'a session-filed one-off has no stable claim — fp must be OMITTED');
   assert.equal(tag, got.label);
   assert.equal(tag, `agent/${got.producer}`, 'the tag and src= must name the SAME producer');
+});
+
+test('SEAM: a create with NO condition warns LOUDLY on stderr and records cond=unstated', () => {
+  const [{ body }, err] = captureStderr(() => applyAgentStamp({}));
+  // The stamp itself must be honest…
+  assert.ok(body.markdown_description.includes('cond=unstated'),
+    `the marker must carry the greppable absence; got: ${body.markdown_description}`);
+  // …and the gap must be visible AT CREATE TIME, not only to a later grep.
+  assert.match(err, /cond=unstated/, `stderr must name the value it recorded; got: ${JSON.stringify(err)}`);
+  assert.match(err, /no closing condition was named/,
+    `stderr must say what is missing; got: ${JSON.stringify(err)}`);
+  assert.match(err, /manual:<who>/,
+    `stderr must name the remedy, including the human form; got: ${JSON.stringify(err)}`);
+});
+
+test('SEAM: a create WITH a condition is silent — the warning is not noise on every create', () => {
+  const [{ body }, err] = captureStderr(
+    () => applyAgentStamp({ agentCond: 'gh_pr_merged:civitai/devrc#796' }),
+  );
+  assert.ok(body.markdown_description.includes('cond=gh_pr_merged:civitai/devrc#796'));
+  assert.equal(err, '',
+    `a compliant create must not warn, or the warning stops being read; got: ${JSON.stringify(err)}`);
+  const [, errManual] = captureStderr(() => applyAgentStamp({ agentCond: 'manual:zach' }));
+  assert.equal(errManual, '', '`manual:<who>` names a checker and is therefore compliant');
 });
 
 test('SEAM: an existing markdown description keeps its content and gains the marker', () => {

--- a/claude/skills/clickup/test/agent-marker.test.mjs
+++ b/claude/skills/clickup/test/agent-marker.test.mjs
@@ -32,12 +32,10 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'fs';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
-
-import { createHash } from 'node:crypto';
-import { existsSync } from 'fs';
 
 import {
   MARKER_VERSION,
@@ -95,10 +93,12 @@ const VECTORS = Object.freeze({
     [{ producer: 'reliability-sweep-advisor', claim: 'index-candidates' }, '633d2c372bd0'],
   ],
   condKinds: ['alert_cleared', 'cmd_exit_zero', 'gh_pr_merged', 'manual', 'metric_below'],
-  // A Python-produced marker carrying the bare `manual` this side no longer
-  // EMITS but must still READ. Generated 2026-08-24 from
-  // talos-infra scripts/lib/agent_obj_marker.py at origin/trunk.
-  pythonBareManual: '<!-- claw:obj v=1 src=capacity-sweep/run-1 cond=manual -->',
+  // A LEGACY marker carrying the bare `manual` NEITHER side emits any more but
+  // both must still READ — objects stamped before the arity rule carry it and are
+  // live right now. (An earlier note called this "Python-produced": Python stopped
+  // emitting it in civitai/talos-infra#1286, which merges before this. The corpus,
+  // not the producer, is what keeps the read path open.)
+  legacyBareManual: '<!-- claw:obj v=1 src=capacity-sweep/run-1 cond=manual -->',
 });
 
 // ── The Python half: WHAT was measured, and FROM WHAT ───────────────────────
@@ -426,7 +426,7 @@ test('CROSS-LANGUAGE: bare `manual` — both sides refuse to EMIT it and both st
     `this side must not emit a bare \`manual\`; neither does ${PY}`);
 
   assert.equal(PYTHON_DIVERGENCE.bothStillParseBareManual, true);
-  const legacy = parseMarker(VECTORS.pythonBareManual);
+  const legacy = parseMarker(VECTORS.legacyBareManual);
   assert.ok(legacy,
     'a legacy bare `manual` MUST still parse — rejecting it on the READ path would blind '
     + 'a JS reconciler to every already-stamped object carrying one, which is the invisibility this '

--- a/claude/skills/clickup/test/agent-marker.test.mjs
+++ b/claude/skills/clickup/test/agent-marker.test.mjs
@@ -4,7 +4,7 @@
  * Gates for the `claw:obj` agent-object marker on the ClickUp side
  * (Phase 0 of agent-object hygiene). Hermetic — no credentials, no network.
  *
- * Four tiers, and the last two are the ones that could actually be missing:
+ * Five tiers, and the last three are the ones that could actually be missing:
  *
  *  1. UNIT — build/parse round-trip, the enumerated `cond` allowlist, malformed
  *     input, optional fields absent.
@@ -20,6 +20,10 @@
  *     close lives on the producer side, not in the helper.
  *  4. CHOKE POINT — the stamp is applied in ONE place, not per call site. A
  *     per-call-site stamp regenerates the same omission at every new caller.
+ *  5. PROSE — flows/task-hygiene.md's load-bearing sentences, pinned as WHOLE
+ *     NORMALISED STRINGS. 🔴 Its no-enforcement disclaimer was guarded by
+ *     nothing: flipping it into a false claim of enforcement went fully green.
+ *     A guard on WORDS is walkable by rewording, so this pins the paragraph.
  *
  * Usage:
  *   node test/agent-marker.test.mjs
@@ -31,6 +35,9 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
+
+import { createHash } from 'node:crypto';
+import { existsSync } from 'fs';
 
 import {
   MARKER_VERSION,
@@ -48,11 +55,17 @@ import {
   stampDescription,
   DEFAULT_PRODUCER,
 } from '../lib/agent-marker.mjs';
-import { applyAgentStamp } from '../api/tasks.mjs';
+import { applyAgentStamp, createTask } from '../api/tasks.mjs';
+import { validatePlanConds } from '../lib/batch-create.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TASKS_SRC = readFileSync(resolve(__dirname, '..', 'api', 'tasks.mjs'), 'utf8');
 const QUERY_SRC = readFileSync(resolve(__dirname, '..', 'query.mjs'), 'utf8');
+const MAINTAINING_SRC = readFileSync(resolve(__dirname, '..', 'reference', 'maintaining.md'), 'utf8');
+const HYGIENE_SRC = readFileSync(resolve(__dirname, '..', 'flows', 'task-hygiene.md'), 'utf8');
+
+/** Collapse whitespace so a line-wrap in prose is not a false failure. */
+const normalise = (s) => s.replace(/\s+/g, ' ').trim();
 
 // ── Tier 2: the cross-language pin ──────────────────────────────────────────
 // Every value here was produced by the PYTHON implementation
@@ -88,25 +101,63 @@ const VECTORS = Object.freeze({
   pythonBareManual: '<!-- claw:obj v=1 src=capacity-sweep/run-1 cond=manual -->',
 });
 
+// ── The Python half: WHAT was measured, and FROM WHAT ───────────────────────
+//
+// 🔴 A CROSS-LANGUAGE CLAIM MUST CARRY ITS OWN PROVENANCE, or it is a sentence
+// that was true once. The previous version of this block was three JS-side
+// booleans asserted against their own literals — self-referential, so Python-side
+// drift was structurally invisible AND the claims were already wrong by the time
+// they were read (they described the pre-#1286 Python). Nothing here can make a
+// hermetic JS suite READ Python, but it can make a stale claim TRACEABLE: the
+// exact file, the exact immutable commit, its sha256, and the date measured.
+const PYTHON_SIDE = Object.freeze({
+  repo: 'civitai/talos-infra',
+  path: 'scripts/lib/agent_obj_marker.py',
+  // An IMMUTABLE ref, deliberately — `origin/trunk` moves, so a claim pinned to
+  // it cannot be re-checked later and reads as current forever.
+  ref: '9e21058fc6a420bb89a4a0826d5163f9de10b622',
+  branch: 'zach/marker-manual-names-checker', // PR civitai/talos-infra#1286, merges BEFORE this
+  sha256: 'ea39f91abd3dc031a58b710fa930fe9404d54e8aac3e4403335feea169dbe4cb',
+  measuredOn: '2026-08-24',
+  // Re-measure with:
+  //   git -C <talos-infra> show <ref>:scripts/lib/agent_obj_marker.py
+  // or arm the staleness check below:
+  //   AGENT_OBJ_MARKER_PY=<talos-infra>/scripts/lib/agent_obj_marker.py node --test …
+  armEnv: 'AGENT_OBJ_MARKER_PY',
+});
+
 // 🔴 THE DIVERGENCE FROM PYTHON, ENUMERATED — because tier 2 above otherwise
-// reads as "these two agree", and as of this change they do not, in exactly two
-// places. Both were MEASURED against the Python module at
-// talos-infra origin/trunk on 2026-08-24, and the error strings are quoted:
+// reads as "these two implementations agree", and in ONE place they do not.
 //
-//   1. bare `manual`  — Python ACCEPTS it (`validate_cond('manual') -> 'manual'`);
-//      this side refuses to emit one and still parses one. Python rejects
-//      `manual:zach` with "cond kind 'manual' takes no argument (got 'zach')".
-//   2. `unstated`     — JS only. Python: "cond kind 'unstated' is not in the
-//      allowlist [...]".
+// AGREEMENTS (recorded, because "they agree" is a claim and this is its evidence):
+//   * bare `manual`  — BOTH refuse to emit it; BOTH still parse it. Python's
+//     `validate_cond('manual')` raises "cond kind 'manual' must NAME who checks
+//     it — write `manual:<who>`"; `validate_cond('manual', allow_bare_manual=True)`
+//     returns it, and `parse_marker` passes that opt-in.
+//   * `unstated`     — BOTH refuse it as caller input; BOTH parse it.
+//     Python: "cond %r records a MISSING condition and is never accepted as input".
+//   * the ALLOWLIST OF KINDS is identical, which is why the VECTORS pin holds.
 //
-// Neither divergence changes the ALLOWLIST OF KINDS, which is why the pin below
-// still holds. Closing the divergence means making the same change in
-// `scripts/lib/agent_obj_marker.py` and moving these notes with it; until then
-// this block is the honest record, not a to-do nobody wrote down.
+// THE ONE DIVERGENCE — the missing-cond FALLBACK:
+//   JS has one and Python does not. `agentIdentity()` observes an absent/unusable
+//   `CLAW_AGENT_COND` and yields `unstated`, which `applyAgentStamp()` then emits
+//   through the single `allowUnstated` call site. On the Python side `cond` is a
+//   REQUIRED POSITIONAL of `build_marker(src_producer, src_run_id, cond, …)` and
+//   `build_marker` calls `validate_cond(cond)` with NO opt-ins, so "no condition"
+//   is a TypeError at authoring time and `cond=unstated` is unemittable there.
+//   Consequence for a reconciler: every `cond=unstated` object in the corpus was
+//   stamped by THIS side.
+//
+// Closing the divergence means giving Python a fallback (or removing JS's) and
+// moving these notes with it. Until then this block is the honest record.
 const PYTHON_DIVERGENCE = Object.freeze({
-  jsRefusesToEmitBareManual: true,
-  jsStillParsesBareManual: true,
-  jsOnlyFallbackKind: COND_UNSTATED,
+  // Asserted BEHAVIOURALLY below — this half lives in this repo.
+  jsProducesUnstatedFromItsFallback: true,
+  // RECORDED from PYTHON_SIDE — not observable from here.
+  pythonCanEmitUnstated: false,
+  bothRefuseToEmitBareManual: true,
+  bothStillParseBareManual: true,
+  bothRejectUnstatedAsInput: true,
 });
 
 // ── Tier 1: unit ────────────────────────────────────────────────────────────
@@ -171,8 +222,30 @@ test('validateCond: a BARE `manual` is rejected, and the message says what to wr
     `the rejection must tell the caller to write \`manual:<who>\`; got: ${err.message}`);
   assert.match(err.message, /names nobody/,
     `the rejection must say WHY; got: ${err.message}`);
-  // `manual:` with an empty argument is the same defect wearing a colon.
-  assert.throws(() => validateCond('manual:'), MarkerError);
+  // `manual:` with an empty argument is the same defect wearing a colon — and it
+  // must fail for the SAME reason, not merely fail.
+  //
+  // 🔴 PINNING ONLY `MarkerError` HERE WAS A SURVIVING MUTANT (M18). Every
+  // rejection path in validateCond throws MarkerError, so a mutant that lets
+  // `manual:` fall through to the ARGUMENT charset check still throws — and the
+  // caller is then told their argument "contains whitespace or `>`" about an
+  // argument they never wrote. Same colour, wrong instruction. Assert the message.
+  let colonErr;
+  assert.throws(
+    () => validateCond('manual:'),
+    (e) => { colonErr = e; return e instanceof MarkerError; },
+  );
+  assert.match(colonErr.message, /must NAME who checks it/,
+    `\`manual:\` must be refused as an unnamed checker, not as a bad argument; got: ${colonErr.message}`);
+  assert.match(colonErr.message, /manual:<who>/,
+    `and it must still name the remedy; got: ${colonErr.message}`);
+  assert.doesNotMatch(colonErr.message, /whitespace/,
+    `\`manual:\` must NOT be re-routed to the argument-charset error; got: ${colonErr.message}`);
+  // The same value must be unbuildable, and for the same reason.
+  assert.throws(
+    () => buildMarker({ srcProducer: 'p', srcRunId: 'r', cond: 'manual:' }),
+    (e) => e instanceof MarkerError && /must NAME who checks it/.test(e.message),
+  );
 });
 
 test('buildMarker: refuses to EMIT a bare `manual`, and round-trips `manual:<who>`', () => {
@@ -198,16 +271,17 @@ test('validateCond: the other allowlisted kinds are unchanged', () => {
 
 // ── `unstated` is produced, never accepted ──────────────────────────────────
 
-test('validateCond: `unstated` is REJECTED as caller input', () => {
+test('validateCond: `unstated` is REJECTED by default, and accepted only under the named opt-in', () => {
   let err;
   assert.throws(
     () => validateCond(COND_UNSTATED),
     (e) => { err = e; return e instanceof MarkerError; },
-    '`unstated` must not be passable by a caller — it is an observation, not a claim',
+    '`unstated` must not validate by default — it is an observation, not a claim',
   );
   assert.match(err.message, /never accepted as input/,
     `the rejection must say it is fallback-only; got: ${err.message}`);
-  // Nor with an argument, nor via the marker builder's caller-facing path.
+  // The opt-in exists and is narrow: the value, not the value plus an argument.
+  assert.equal(validateCond(COND_UNSTATED, { allowUnstated: true }), COND_UNSTATED);
   assert.throws(() => validateCond('unstated:whatever'), MarkerError);
   assert.throws(() => validateCond('unstated:whatever', { allowUnstated: true }), MarkerError);
   // …and it is NOT in the allowlist a caller is shown.
@@ -217,8 +291,15 @@ test('validateCond: `unstated` is REJECTED as caller input', () => {
     'the fallback kind is the ONLY kind that is complete without an argument');
 });
 
-test('buildMarker/parseMarker: `unstated` round-trips, because the fallback must be stampable', () => {
-  const marker = buildMarker({ srcProducer: 'claude-code', srcRunId: 'r', cond: COND_UNSTATED });
+test('buildMarker: `unstated` is emittable ONLY under the explicit fallback opt-in', () => {
+  // 🔴 THE HOLE THIS CLOSES. buildMarker used to pass `allowUnstated: true`
+  // unconditionally, so `unstated` was emittable by anyone who could reach it —
+  // and via applyAgentStamp that was every create path. The default is now false;
+  // exactly one call site (the missing-cond fallback) opts in.
+  const args = { srcProducer: 'claude-code', srcRunId: 'r', cond: COND_UNSTATED };
+  assert.throws(() => buildMarker(args), MarkerError,
+    'buildMarker must NOT emit `unstated` for a caller that did not declare the fallback');
+  const marker = buildMarker({ ...args, allowUnstated: true });
   assert.equal(marker, '<!-- claw:obj v=1 src=claude-code/r cond=unstated -->');
   const got = parseMarker(marker);
   assert.ok(got, 'an `unstated` marker must be readable — that is what makes the gap COUNTABLE');
@@ -282,6 +363,12 @@ test('parseMarker: a MALFORMED marker reads as absent', () => {
     '<!-- claw:obj v=1 src=p cond=manual -->',           // src has no run-id
     '<!-- claw:obj v=1 src=p/r cond=whenever -->',       // cond off-allowlist
     '<!-- claw:obj v=1 src=p/r cond=metric_below -->',   // arg-less kind
+    // 🔴 A colon with no checker is MALFORMED, not legacy. The read-side
+    // `allowBareManual` opt-in covers the bare word only — objects stamped
+    // before the arity rule carry `cond=manual`, never `cond=manual:`. Widening
+    // the opt-in to "kind is manual" would silently make this parse. (The
+    // Python half's docstring says the same, in the same words.)
+    '<!-- claw:obj v=1 src=p/r cond=manual: -->',        // colon, no checker
     '<!-- claw:obj v=1 src=p/r cond=manual fp=xyz -->',  // fp not hex
     '<!-- claw:obj v=1 src=p/r cond=manual junk=1 -->',  // unknown field
     '<!-- claw:obj v=1 v=1 src=p/r cond=manual -->',     // repeated field
@@ -315,27 +402,83 @@ test('CROSS-LANGUAGE: markers are byte-identical to the Python implementation', 
   assert.equal(buildMarker(VECTORS.full.args), VECTORS.full.marker);
 });
 
-test('CROSS-LANGUAGE: the divergence from Python is EXACTLY the enumerated set', () => {
-  // 🔴 Tier 2 otherwise reads as "these two implementations agree", and on the
-  // `manual` arity they now do not. An enumerated, asserted divergence is the
-  // honest form: unplanned drift still goes red, and the planned part is
-  // greppable rather than a comment nobody re-checks.
-  assert.equal(PYTHON_DIVERGENCE.jsRefusesToEmitBareManual, true);
-  assert.throws(() => buildMarker({ srcProducer: 'p', srcRunId: 'r', cond: 'manual' }), MarkerError,
-    'this side must NOT emit the bare `manual` Python still emits');
+const PY = `${PYTHON_SIDE.repo} ${PYTHON_SIDE.path} @ ${PYTHON_SIDE.ref}`
+  + ` (branch ${PYTHON_SIDE.branch}, measured ${PYTHON_SIDE.measuredOn})`;
 
-  assert.equal(PYTHON_DIVERGENCE.jsStillParsesBareManual, true);
+test('CROSS-LANGUAGE: the ONE divergence is the missing-cond FALLBACK, and JS has it', () => {
+  // The half that lives in THIS repo is asserted for real, not recorded.
+  assert.equal(PYTHON_DIVERGENCE.jsProducesUnstatedFromItsFallback, true);
+  const [id, warned] = captureStderr(() => agentIdentity({}));
+  assert.equal(id.cond, COND_UNSTATED,
+    `JS's fallback must PRODUCE ${COND_UNSTATED} — that is the divergence from ${PY}`);
+  assert.equal(warned, '', 'an ABSENT CLAW_AGENT_COND is not a degradation and must not warn');
+  const [{ body }] = captureStderr(() => applyAgentStamp({}));
+  assert.ok(body.markdown_description.includes(`cond=${COND_UNSTATED}`),
+    `and it must reach a stamped marker — every cond=${COND_UNSTATED} object in the corpus came from `
+    + `this side, because ${PY} takes cond as a REQUIRED POSITIONAL and validates it with no opt-ins`);
+  // …and the recorded Python half says it cannot do the same.
+  assert.equal(PYTHON_DIVERGENCE.pythonCanEmitUnstated, false, `recorded from ${PY}`);
+});
+
+test('CROSS-LANGUAGE: bare `manual` — both sides refuse to EMIT it and both still PARSE it', () => {
+  assert.equal(PYTHON_DIVERGENCE.bothRefuseToEmitBareManual, true);
+  assert.throws(() => buildMarker({ srcProducer: 'p', srcRunId: 'r', cond: 'manual' }), MarkerError,
+    `this side must not emit a bare \`manual\`; neither does ${PY}`);
+
+  assert.equal(PYTHON_DIVERGENCE.bothStillParseBareManual, true);
   const legacy = parseMarker(VECTORS.pythonBareManual);
   assert.ok(legacy,
-    'a Python-stamped bare `manual` MUST still parse — rejecting it on the READ path would blind '
-    + 'a JS reconciler to every object the Python producers stamp, which is the invisibility this '
+    'a legacy bare `manual` MUST still parse — rejecting it on the READ path would blind '
+    + 'a JS reconciler to every already-stamped object carrying one, which is the invisibility this '
     + 'marker exists to end');
   assert.equal(legacy.condKind, 'manual');
   assert.equal(legacy.condArg, null, 'condArg === null is how a consumer counts the ones naming nobody');
 
-  assert.equal(PYTHON_DIVERGENCE.jsOnlyFallbackKind, COND_UNSTATED);
-  // The kind ALLOWLIST is unchanged, which is why the pin above still holds.
+  assert.equal(PYTHON_DIVERGENCE.bothRejectUnstatedAsInput, true);
+  assert.throws(() => validateCond(COND_UNSTATED), MarkerError, `as does ${PY}`);
+
+  // The kind ALLOWLIST is unchanged, which is why the VECTORS pin above holds.
   assert.deepEqual([...COND_KINDS].sort(), VECTORS.condKinds);
+});
+
+test('CROSS-LANGUAGE: the Python provenance is pinned to an IMMUTABLE ref and cited in the docs', () => {
+  // 🔴 A recorded cross-language claim decays. Nothing hermetic can read Python,
+  // so these are the two things that CAN be checked from here:
+  //   (a) the ref is a full commit sha, not a moving branch name — a claim pinned
+  //       to `origin/trunk` cannot be re-checked and reads as current forever;
+  //   (b) the SAME provenance appears in reference/maintaining.md, so the prose
+  //       record and the test record cannot drift apart silently.
+  assert.match(PYTHON_SIDE.ref, /^[0-9a-f]{40}$/, 'pin an immutable commit, never a branch ref');
+  assert.match(PYTHON_SIDE.sha256, /^[0-9a-f]{64}$/);
+  assert.match(PYTHON_SIDE.measuredOn, /^\d{4}-\d{2}-\d{2}$/);
+  const doc = normalise(MAINTAINING_SRC);
+  assert.ok(doc.includes(PYTHON_SIDE.ref.slice(0, 9)),
+    `reference/maintaining.md must cite the same commit (${PYTHON_SIDE.ref.slice(0, 9)}) this suite pins`);
+  assert.ok(doc.includes(PYTHON_SIDE.measuredOn),
+    `reference/maintaining.md must cite the same measurement date (${PYTHON_SIDE.measuredOn})`);
+  assert.ok(doc.includes(PYTHON_SIDE.path),
+    `reference/maintaining.md must name the same Python file (${PYTHON_SIDE.path})`);
+});
+
+test('CROSS-LANGUAGE: ARMED-ONLY — the recorded Python file still hashes to what was measured', () => {
+  // 🔴 UNARMED THIS TEST PROVES NOTHING, and saying so is the point: without the
+  // env var it asserts only that the guard is wired, so do not read a green run
+  // as evidence the Python side is unchanged. Arm it in a checkout:
+  //   AGENT_OBJ_MARKER_PY=<talos-infra>/scripts/lib/agent_obj_marker.py \
+  //     node --test test/agent-marker.test.mjs
+  // It is opt-in because a hermetic suite must not depend on another repo being
+  // present — that is a flaky gate, not a gate.
+  const p = process.env[PYTHON_SIDE.armEnv];
+  if (!p) {
+    assert.equal(typeof PYTHON_SIDE.sha256, 'string', 'unarmed: nothing was measured');
+    return;
+  }
+  assert.ok(existsSync(p), `${PYTHON_SIDE.armEnv}=${p} does not exist`);
+  const got = createHash('sha256').update(readFileSync(p)).digest('hex');
+  assert.equal(got, PYTHON_SIDE.sha256,
+    `\n${PYTHON_SIDE.path} has CHANGED since ${PY}.\n`
+    + '  Re-measure the divergence block above against the new content and update\n'
+    + '  PYTHON_SIDE (ref, sha256, measuredOn) and reference/maintaining.md together.');
 });
 
 test('CROSS-LANGUAGE: fingerprints match Python json.dumps(sort_keys=True)', () => {
@@ -358,17 +501,20 @@ test('agentIdentity: defaults are usable with an empty environment', () => {
     'a caller who named no condition must not be stamped as though they had');
   assert.equal(id.init, null);
   assert.equal(id.label, `agent/${DEFAULT_PRODUCER}`);
-  // The whole point: whatever the environment holds, the result must BUILD.
-  assert.ok(parseMarker(buildMarker({ srcProducer: id.producer, srcRunId: id.runId, cond: id.cond })));
+  // The whole point: whatever the environment holds, the result must BUILD —
+  // through the fallback opt-in, which is the ONLY path allowed to emit it.
+  assert.ok(parseMarker(buildMarker({
+    srcProducer: id.producer, srcRunId: id.runId, cond: id.cond, allowUnstated: true,
+  })));
 });
 
-test('agentIdentity: a hostile environment still yields a buildable identity', () => {
-  const id = agentIdentity({
+test('agentIdentity: a hostile environment still yields a buildable identity, and WARNS on the degradation', () => {
+  const [id, err] = captureStderr(() => agentIdentity({
     CLAW_AGENT_PRODUCER: 'Capacity Sweep!!',
     CLAW_AGENT_RUN_ID: 'run id/with spaces>and brackets',
     CLAW_AGENT_COND: 'whatever_i_feel_like',
     CLAW_AGENT_INIT: 'Some Slug',
-  });
+  }));
   assert.equal(id.producer, 'capacity-sweep--');
   assert.equal(id.runId, 'run-id-with-spaces-and-brackets');
   // 🔴 Falls back to `unstated`, NOT to silence and NOT to `manual`. An honest
@@ -376,15 +522,40 @@ test('agentIdentity: a hostile environment still yields a buildable identity', (
   // would make the object invisible again, which is the defect Phase 0 addresses.
   assert.equal(id.cond, COND_UNSTATED);
   assert.equal(id.init, 'some-slug');
-  const marker = buildMarker({ srcProducer: id.producer, srcRunId: id.runId, cond: id.cond, init: id.init });
+  // 🔴 …AND THE DEGRADATION IS ANNOUNCED WHERE IT HAPPENS. An operator who
+  // exported a value believes they named a condition; the create-site warning
+  // says "no closing condition was named", which reads as FALSE to them. This
+  // one quotes the value and the reason it was refused.
+  assert.match(err, /CLAW_AGENT_COND="whatever_i_feel_like" was REFUSED/,
+    `the degradation must quote the value it threw away; got: ${JSON.stringify(err)}`);
+  assert.match(err, /not in the allowlist/,
+    `the degradation must give the REASON, from validateCond; got: ${JSON.stringify(err)}`);
+  assert.match(err, new RegExp(`Recording cond=${COND_UNSTATED} instead`),
+    `the degradation must name what it recorded instead; got: ${JSON.stringify(err)}`);
+  const marker = buildMarker({
+    srcProducer: id.producer, srcRunId: id.runId, cond: id.cond, init: id.init, allowUnstated: true,
+  });
   assert.ok(parseMarker(marker), 'a sanitised identity must produce a PARSEABLE marker');
 });
 
-test('agentIdentity: an allowlisted CLAW_AGENT_COND is honoured verbatim', () => {
-  assert.equal(
-    agentIdentity({ CLAW_AGENT_COND: 'gh_pr_merged:civitai/talos-infra#1277' }).cond,
-    'gh_pr_merged:civitai/talos-infra#1277',
+test('agentIdentity: CLAW_AGENT_COND=manual is a DEGRADATION and says so', () => {
+  // The specific case the audit named: `manual` is no longer emittable, so this
+  // environment silently became `unstated`. Silently is the defect.
+  const [id, err] = captureStderr(() => agentIdentity({ CLAW_AGENT_COND: 'manual' }));
+  assert.equal(id.cond, COND_UNSTATED);
+  assert.match(err, /CLAW_AGENT_COND="manual" was REFUSED/, `got: ${JSON.stringify(err)}`);
+  assert.match(err, /must NAME who checks it/,
+    "the reason must be manual's own, not a generic one; got: " + JSON.stringify(err));
+  assert.match(err, /CLAW_AGENT_COND=manual:zach/,
+    `the warning must name the remedy; got: ${JSON.stringify(err)}`);
+});
+
+test('agentIdentity: an allowlisted CLAW_AGENT_COND is honoured verbatim, and silently', () => {
+  const [id, err] = captureStderr(
+    () => agentIdentity({ CLAW_AGENT_COND: 'gh_pr_merged:civitai/talos-infra#1277' }),
   );
+  assert.equal(id.cond, 'gh_pr_merged:civitai/talos-infra#1277');
+  assert.equal(err, '', `a valid value must not warn; got: ${JSON.stringify(err)}`);
 });
 
 test('stampDescription: idempotent — an existing marker is never doubled', () => {
@@ -442,6 +613,104 @@ test('SEAM: a create WITH a condition is silent — the warning is not noise on 
     `a compliant create must not warn, or the warning stops being read; got: ${JSON.stringify(err)}`);
   const [, errManual] = captureStderr(() => applyAgentStamp({ agentCond: 'manual:zach' }));
   assert.equal(errManual, '', '`manual:<who>` names a checker and is therefore compliant');
+});
+
+test('SEAM: a CALLER may not pass `unstated` — the create path REJECTS it', async () => {
+  // 🔴 THIS IS THE TEST THAT WAS MISSING, and its absence is why the claim was
+  // false for six months of call sites. The old test with this name only ever
+  // called validateCond() with default options — it never touched the create
+  // seam it was named after, while applyAgentStamp / createTask / createSubtask /
+  // batch-create all accepted `agentCond: 'unstated'` and stamped it.
+  //
+  // `unstated` means the CODE OBSERVED AN ABSENCE. A caller who can assert it has
+  // converted an observation back into a claim, and `cond=unstated` stops
+  // counting authorial omission.
+  let err;
+  assert.throws(
+    () => applyAgentStamp({ agentCond: COND_UNSTATED }),
+    (e) => { err = e; return e instanceof MarkerError; },
+    'applyAgentStamp must refuse a caller-supplied `unstated`',
+  );
+  assert.match(err.message, /never accepted as input/,
+    `the refusal must say it is fallback-only; got: ${err.message}`);
+  // 🔴 ATTRIBUTED TO THE SEAM, and that is not cosmetic. buildMarker validates
+  // too, so a mutant deleting the seam's own guard dies to buildMarker's instead
+  // — green for the wrong reason, and still green with this guard removed.
+  // Asserting WHICH guard refused is what makes this test about the seam.
+  // (Measured: without this assertion the seam-deletion mutant SURVIVED.)
+  assert.match(err.message, /agentCond rejected at the create seam/,
+    `the refusal must come from the seam's own guard; got: ${err.message}`);
+
+  // createTask is the real producer, and it validates BEFORE any network call —
+  // so this rejects hermetically, with no transport and no credentials.
+  await assert.rejects(
+    () => createTask('900000000001', 'a task', { agentCond: COND_UNSTATED }),
+    (e) => e instanceof MarkerError
+      && /agentCond rejected at the create seam/.test(e.message)
+      && /never accepted as input/.test(e.message),
+    'createTask must refuse it too — the CLI is not the only caller',
+  );
+
+  // The same seam still refuses everything else off-allowlist, including the
+  // bare `manual` this side will not emit.
+  for (const bad of ['manual', 'manual:', 'someone_looks_at_it', 'unstated:x']) {
+    assert.throws(() => applyAgentStamp({ agentCond: bad }), MarkerError, `should reject ${bad}`);
+  }
+  // …and a legitimate condition still goes through.
+  const [{ body }] = captureStderr(() => applyAgentStamp({ agentCond: 'manual:zach' }));
+  assert.equal(parseMarker(body.markdown_description).cond, 'manual:zach');
+});
+
+test('SEAM: createSubtask can NAME a condition — a subtask is a stamped object too', () => {
+  // 🔴 WHAT THIS PROTECTS IS THE MEANING OF THE COUNT. Until this landed,
+  // `create-subtask` and batch-create structurally could not supply a cond, so
+  // every subtask and every batch task was `unstated` BY CONSTRUCTION — and a
+  // 20-task plan added 20. The `unstated` count is supposed to measure authorial
+  // omission; an interface gap would have dominated it.
+  const [{ body }, err] = captureStderr(
+    () => applyAgentStamp({ parent: 'abc123', agentCond: 'cmd_exit_zero:drift-check' }),
+  );
+  assert.equal(parseMarker(body.markdown_description).cond, 'cmd_exit_zero:drift-check');
+  assert.equal(err, '', 'a subtask that named its condition must not warn');
+  // The CLI wires it: `subtask` routes through the same one validator as `create`.
+  assert.ok(QUERY_SRC.includes('createSubtask(taskId, arg2, withAgentCond({}))'),
+    'the subtask command must thread --cond through, or every CLI subtask is `unstated` by construction');
+  // 🔴 Match the CALL SHAPES, not the identifier: a bare `withAgentCond\(` count
+  // also matches the declaration AND the prose that points at it, so it reads 4
+  // on a perfectly correct tree. (The same trap is annotated twice in the CHOKE
+  // POINT test below; it is the third time in this file.)
+  assert.equal((QUERY_SRC.match(/function withAgentCond\(options\) \{/g) || []).length, 1,
+    'exactly one validator');
+  assert.equal((QUERY_SRC.match(/\bwithAgentCond\(options\);/g) || []).length, 1,
+    'the `create` command must route through it');
+  assert.equal((QUERY_SRC.match(/\bwithAgentCond\(\{\}\)/g) || []).length, 1,
+    'the `subtask` command must route through it');
+});
+
+test('SEAM: a batch plan\'s conds are validated BEFORE anything is created', () => {
+  // Positive control first: a plan whose conds are all sayable reports nothing.
+  assert.deepEqual(validatePlanConds({
+    tasks: [
+      { ref: 'a', name: 'A', cond: 'manual:zach', subtasks: [{ name: 's', cond: 'gh_pr_merged:civitai/devrc#803' }] },
+      { name: 'B' }, // omission is legal — it records `unstated`
+    ],
+  }), []);
+  // A caller-asserted `unstated` and an off-allowlist value are both refused, and
+  // the report NAMES which task, because a fan-out failure that says only "bad
+  // cond" is unactionable across 20 tasks.
+  const problems = validatePlanConds({
+    tasks: [
+      { ref: 'a', name: 'A', cond: COND_UNSTATED },
+      { name: 'B', cond: 'manual', subtasks: [{ name: 'sub', cond: 'whenever' }] },
+    ],
+  });
+  assert.equal(problems.length, 3, `expected one problem per bad cond; got ${JSON.stringify(problems)}`);
+  assert.match(problems[0], /^a: /);
+  assert.match(problems[0], /never accepted as input/);
+  assert.match(problems[1], /^B: /);
+  assert.match(problems[1], /must NAME who checks it/);
+  assert.match(problems[2], /^B > sub: /);
+  assert.match(problems[2], /not in the allowlist/);
 });
 
 test('SEAM: an existing markdown description keeps its content and gains the marker', () => {
@@ -523,6 +792,98 @@ test('CHOKE POINT: --cond is validated at the CLI, not silently downgraded', () 
   assert.ok(QUERY_SRC.includes('options.agentCond = validateCond(condArg)'),
     '--cond must be validated against the allowlist before it is stored');
   assert.ok(QUERY_SRC.includes('--cond'), '--cond must appear in showUsage()');
+});
+
+test('CHOKE POINT: a refused --cond prints the allowlist AND the arity rule', () => {
+  // 🔴 M23 SURVIVED BECAUSE THIS LINE WAS UNTESTED. The rejection is only useful
+  // if it says what to write instead — a bare "not in the allowlist" leaves the
+  // caller's most likely next move (drop --cond) unaddressed, and the `manual`
+  // arity rule is exactly the one they are most likely to have broken.
+  assert.ok(QUERY_SRC.includes('`Allowed --cond kinds: ${[...COND_KINDS].sort().join(\', \')}`'),
+    'the refusal must enumerate the allowlist from COND_KINDS, not a restated literal list');
+  assert.ok(
+    QUERY_SRC.includes(
+      "'Every kind takes an argument; manual takes the NAME of who checks it.'"),
+    'the refusal must state the arity rule verbatim — that is the half a caller gets wrong');
+  // One writer, so both creating commands print the same thing.
+  assert.equal((QUERY_SRC.match(/Every kind takes an argument/g) || []).length, 1,
+    'the hint must exist in exactly one place (withAgentCond), or the two creators can drift apart');
+});
+
+test('CHOKE POINT: batch-create validates the WHOLE plan before creating anything', () => {
+  const src = readFileSync(resolve(__dirname, '..', 'lib', 'batch-create.mjs'), 'utf8');
+  assert.ok(src.includes('const condProblems = validatePlanConds(plan);'),
+    'the plan-wide validation must run inside executeBatchCreate');
+  // Order is the whole point: validating lazily leaves 16 objects on the board
+  // when task 17 throws, and there is no rollback.
+  assert.ok(src.indexOf('validatePlanConds(plan)') < src.indexOf('await createTask('),
+    'the plan-wide cond check must precede the first create');
+  // 🔴 PIN THE WHOLE STATEMENT, GUARD INCLUDED. `src.includes('createOpts.agentCond
+  // = t.cond')` still matched after a mutant rewrote the guard to `if (false)` —
+  // measured, it SURVIVED. `executeBatchCreate` takes no injectable transport, so
+  // its wiring is covered structurally rather than behaviourally; a structural
+  // check that omits the condition is a check of the wrong half.
+  assert.ok(src.includes('      if (t.cond) createOpts.agentCond = t.cond;\n'),
+    'a batch task must be able to name its condition');
+  assert.ok(src.includes('              agentCond: sub.cond || undefined,\n'),
+    'so must a batch subtask');
+});
+
+// ── Tier 5: the prose the flow rests on ─────────────────────────────────────
+//
+// 🔴 THE ARTIFACT UNDER TEST IS PROSE, so this pins WHOLE NORMALISED SENTENCES,
+// not keywords — `claude/RULES.md`: a guard on words is walkable by rewording.
+// The pattern (and the reasoning behind pinning whole strings) is
+// `scripts/tests/test_closing_condition_single_source.py`. A cosmetic reword
+// SHOULD fail here; update the constant in the same commit, which is the moment
+// somebody should notice they are editing a load-bearing disclaimer.
+
+// The most load-bearing sentence in flows/task-hygiene.md. Flipping it to a
+// FALSE gate claim ("a PreToolUse hook blocks…") was a fully green mutant (M24):
+// nothing read this file. A doc that reads as a gate while providing none is
+// worse than none — it stops anyone looking.
+const HYGIENE_NO_ENFORCEMENT = normalise(`
+🔴 **NOTHING ENFORCES ANY OF THIS.** clawgate's equivalents
+(\`~/.claude/skills/clawgate/flows/task-authoring.md\`,
+\`~/.claude/skills/clawgate/flows/task-pickup.md\`) work because two PreToolUse/Stop
+hooks route to them and BLOCK. There is no ClickUp hook, no server check, and no
+gate anywhere in this skill that reads this file. It is a convention you follow or
+do not follow, and it is written down here so it can at least be *cited*.
+
+That warning is first because a doc that reads as a gate while providing none is
+worse than none — it stops anyone looking. Do not summarise this file elsewhere as
+"the ClickUp task gate". It is not one.
+`);
+
+test('PROSE: the hygiene flow still says NOTHING ENFORCES IT, in exactly those words', () => {
+  const doc = normalise(HYGIENE_SRC);
+  assert.ok(doc.includes(HYGIENE_NO_ENFORCEMENT),
+    '\n\nflows/task-hygiene.md\'s no-enforcement disclaimer no longer matches the pinned text.\n\n'
+    + `  expected (normalised):\n    ${HYGIENE_NO_ENFORCEMENT}\n\n`
+    + '  If you edited it deliberately, update HYGIENE_NO_ENFORCEMENT in the SAME commit —\n'
+    + '  and check the edit did not turn a disclaimer into a claim of enforcement that does\n'
+    + '  not exist. If a gate ever DOES land, this test is where you record that it did.');
+  // It must be FIRST — a disclaimer buried under the advice it qualifies is one
+  // most readers never reach.
+  const bodyStart = HYGIENE_SRC.indexOf('\n', HYGIENE_SRC.indexOf('# flow:'));
+  assert.ok(normalise(HYGIENE_SRC.slice(bodyStart, bodyStart + 400)).startsWith('🔴 **NOTHING ENFORCES ANY OF THIS.**'),
+    'the disclaimer must remain the first thing in the body');
+});
+
+test('PROSE: the measured figure in the hygiene flow cites a source in this repo', () => {
+  // 🔴 It used to quote "0 addressed / 1 partially addressed / 2 not established"
+  // as measured, with nothing to cite: that run happened in a session, not in the
+  // repo, and the in-repo record says something different. An uncitable number
+  // presented as measurement is the shape a claim takes just before it is wrong.
+  const doc = normalise(HYGIENE_SRC);
+  const cited = 'claude/skills/check-clickup-addressed/reference/validation-history.md';
+  assert.ok(doc.includes(cited), `the measured figure must cite ${cited}`);
+  assert.ok(doc.includes('**0 addressed, 0 partial, 0 open, 2 unclear**'),
+    'the figure quoted must be the one that record actually holds');
+  const record = normalise(readFileSync(
+    resolve(__dirname, '..', '..', 'check-clickup-addressed', 'reference', 'validation-history.md'), 'utf8'));
+  assert.ok(record.includes('Summary: 0 addressed, 0 partial, 0 open, 2 unclear'),
+    'and the cited record must still hold it — this is the half that goes stale');
 });
 
 test('CHOKE POINT: validateCond is importable by the CLI and rejects free text', () => {

--- a/scripts/run-node-tests.sh
+++ b/scripts/run-node-tests.sh
@@ -223,7 +223,16 @@ SUITES=(
   # missing-condition fallback (`cond=unstated`, warned on stderr at the create
   # site) — plus the enumerated JS/Python divergence those two introduce.
   # Floor 152 = 160 - min(50, max(1, 160/20)) = 160 - 8.
-  "claude/skills/clickup/test|5|152"
+  #
+  # 171 tests / 5 files measured 2026-08-24 (fix round on the same PR). The
+  # `unstated` sentinel was passable by any CALLER, not just the fallback that
+  # observes an absence — so the create seam now validates it, `create-subtask`
+  # and batch-create gained a way to name a condition at all, the JS/Python
+  # divergence block was rewritten to carry its own provenance, and
+  # flows/task-hygiene.md's no-enforcement disclaimer is pinned as prose (it was
+  # guarded by nothing; flipping it to a false gate claim went fully green).
+  # Floor 163 = 171 - min(50, max(1, 171/20)) = 171 - 8.
+  "claude/skills/clickup/test|5|163"
 )
 
 # --- discovery roots -----------------------------------------------------------

--- a/scripts/run-node-tests.sh
+++ b/scripts/run-node-tests.sh
@@ -217,7 +217,13 @@ SUITES=(
   # talos-infra's Python implementation (no byte-mirror can bridge the two, so
   # shared vectors are what keeps them from drifting), and the create-path seam.
   # Floor 145 = 152 - min(50, max(1, 152/20)) = 152 - 7.
-  "claude/skills/clickup/test|5|145"
+  #
+  # 160 tests / 5 files measured 2026-08-24: the `cond` guard grew a checker
+  # requirement (`manual:<who>`, bare `manual` rejected) and an honest
+  # missing-condition fallback (`cond=unstated`, warned on stderr at the create
+  # site) — plus the enumerated JS/Python divergence those two introduce.
+  # Floor 152 = 160 - min(50, max(1, 160/20)) = 160 - 8.
+  "claude/skills/clickup/test|5|152"
 )
 
 # --- discovery roots -----------------------------------------------------------


### PR DESCRIPTION
## Why

`claude/RULES.md` (proactivity gate, "Out of scope") permits filing a task only when its closing condition can be named together with who or what checks it — definition at question 1 of `claude/skills/clawgate/flows/task-authoring.md` (single source; `scripts/tests/test_closing_condition_single_source.py` fails if it is restated).

The ClickUp `claw:obj` marker contradicted that rule in two silent ways:

1. **`manual` took NO argument** — the one non-mechanical kind in the allowlist named **nobody**, so it satisfied neither half of the rule while reading as a recorded condition.
2. **Every create without `--cond` was stamped `cond=manual`** — a task with no closing condition, marked as though it had one. A dishonest marker of *presence*: it hides the non-compliant object among the compliant ones and makes "how many did we file with no condition?" unanswerable.

## Change 1 — the `cond` grammar

| | before | after |
|---|---|---|
| `manual` | valid, no argument | **rejected** — message names the remedy |
| `manual:zach` | rejected | **valid** — the checker survives the round-trip as `condArg` |
| no `--cond` | stamped `cond=manual` | stamped **`cond=unstated`** + a loud stderr warning at the create site |
| `unstated` as caller input | n/a | **rejected** — produced by the fallback only, never claimable |

- `claude/skills/clickup/lib/agent-marker.mjs:70` — `COND_UNSTATED`; `COND_KINDS_NO_ARG` now holds only it
- `claude/skills/clickup/lib/agent-marker.mjs:123,146` — `validateCond` and the `manual` branch
- `claude/skills/clickup/lib/agent-marker.mjs:295` — the fallback
- `claude/skills/clickup/api/tasks.mjs:126,153` — the effective cond + `warnIfConditionUnstated`
- `claude/skills/clickup/query.mjs:343` — `--cond` help (single quotes only; `node --check` run on every edited `.mjs`)

🔴 ~~**Deliberate divergence from the canonical Python implementation.** `<talos-infra>/scripts/lib/agent_obj_marker.py` still accepts a bare `manual` and rejects `manual:zach` (measured 2026-08-24 by running it).~~ **CORRECTED in the fix round below** — civitai/talos-infra#1286 (merges first) makes the Python side take the same position; the one surviving divergence is the missing-cond FALLBACK. So the read path stays tolerant: **this side refuses to EMIT a bare `manual` and still PARSES one** — rejecting it on the read path would blind a JS reconciler to every object the Python producers stamp, which is the exact invisibility the marker exists to end. The divergence is enumerated and asserted (`PYTHON_DIVERGENCE`), not left as a comment. Closing it means the same change in the Python module.

## Change 2 — `claude/skills/clickup/flows/task-hygiene.md`

Three things ported from clawgate, adapted, plus a short SKILL.md pointer:

- **Pre-verify before creating** — already done? already exists (search before create)? deliberately off? Reporting "already done" and creating NOTHING is the success case. Measured: 8 inbound tickets, **1** actionable.
- **The completion write-back** — one comment, evidence **per acceptance criterion**, plus an explicit `NOT verified:` list. ~~Measured: `check-clickup-addressed` returned 0 addressed / 1 partially / 2 not established.~~ **CORRECTED in the fix round below** — that figure had no citable source; the in-repo record says **0 addressed, 0 partial, 0 open, 2 unclear**.
- **The self-grading gate** — derived the criteria yourself ⇒ do not mark complete. The ClickUp-specific reason inverts the clawgate intuition: **the API token resolves to a HUMAN identity**, so an agent closing a ticket is indistinguishable from the human closing it. Weaker structural protection ⇒ needs the discipline *more*.

Plus two comments per task (never per turn), and a pointer to the closing-condition definition rather than a restatement.

🔴 **The doc says first that NOTHING ENFORCES IT** — there is no ClickUp hook, unlike clawgate's two — because a doc that reads as a gate while providing none stops anyone looking. It also records what was deliberately **not** ported (the `in_progress` 409 trap, hard tag validation / reserved namespaces, the 6-section body template).

## Verification

**Red/green matrix.** New cases run against `origin/main` (namespace-import shim there only, because `COND_UNSTATED` does not exist at base and a named import would collect zero tests): **11 RED**, each with its own message —

```
Missing expected exception: a bare `manual` must not validate — it names nobody
the rejection must say it is fallback-only; got: cond kind "unstated" is not in the allowlist [...]
the marker must carry the greppable absence; got: <!-- claw:obj v=1 src=claude-code/… cond=manual -->
a caller who named no condition must not be stamped as though they had
Missing expected exception (MarkerError): this side must NOT emit the bare `manual` Python still emits
```

At HEAD: **38/38 green** (suite total 152 → 160; floor raised 145 → 152 in `scripts/run-node-tests.sh`).

**Mutation table** — each mutant copied to its own tree, applied-ness verified by readback, control green first:

| mutant | applied | killed by |
|---|---|---|
| bare `manual` validates again | ✅ | `validateCond: a BARE manual is rejected…` (+2 others) |
| fallback back to `manual` | ✅ | `agentIdentity: defaults…`, both `SEAM` cases |
| stderr warning deleted | ✅ | `SEAM: a create with NO condition warns LOUDLY…` — *"stderr must name the value it recorded; got: \"\""* |
| `unstated` accepted as input | ✅ | ~~`validateCond: unstated is REJECTED as caller input`~~ — **that test never touched the create seam its name claimed; see fix round** |
| parse rejects Python's bare `manual` | ✅ | `CROSS-LANGUAGE: the divergence…` |
| build emits bare `manual` | ✅ | `buildMarker: refuses to EMIT a bare manual…` |
| **comment-only (negative control)** | ✅ | **SURVIVED** — the sweep can report SURVIVED |

**Suites.** `bash scripts/run-tests.sh --check-floors` → PASS. `bash scripts/run-node-tests.sh` → PASS (1187 tests). `scripts/tests` full run: **70 failed / 7814 passed at HEAD and 70 failed / 7814 passed at `origin/main`** — the failing sets are byte-identical in 69 of 70; the 70th is a different case inside `test_subsystem_store_api.py` on each run, and that file passes 272/272 in isolation at HEAD, i.e. a load flake in a file this PR does not touch.

---

## Fix round — 2026-08-24 (audit findings)

The audit found the PR "safe to merge, no 🔴", 19/22 mutants killed. Five things were wrong anyway; **two corrections above are struck through rather than quietly edited**, because both were claims this PR asserted as measured.

### 1. 🔴 `unstated` WAS passable by a caller — the row above was false for every path but the CLI

`buildMarker` passed `{ allowUnstated: true }` unconditionally and `applyAgentStamp` forwarded `agentCond` unvalidated, so `applyAgentStamp`, `createTask`, `createSubtask` and batch-create all accepted `cond=unstated`. The test **named** `unstated is REJECTED as caller input` only ever called `validateCond` with default options — it never touched the create seam it was named after, so the name claimed coverage the body did not provide.

- `claude/skills/clickup/api/tasks.mjs` — `applyAgentStamp` splits fallback from caller; `validateCallerCond()` validates a caller's cond and **attributes the refusal to the seam**. That attribution is load-bearing, not cosmetic: `buildMarker` validates too, so a mutant deleting the seam guard dies to the *other* guard and **SURVIVED** until the message was asserted (measured).
- `claude/skills/clickup/lib/agent-marker.mjs` — `buildMarker`'s `allowUnstated` now defaults to **false**; exactly one call site opts in.
- The test now exercises `applyAgentStamp` **and** `createTask` (which validates before any network call, so it rejects hermetically).

### 2. `PYTHON_DIVERGENCE` was self-referential — and its entries were already wrong

Three JS-side booleans asserted against their own literals; nothing read Python, so Python-side drift was structurally invisible. civitai/talos-infra#1286 (merges first) also made every entry wrong.

Rewritten for the post-#1286 world. The **one** surviving divergence is the **missing-cond fallback**: JS has one, so JS is the only half that ever emits `cond=unstated`; Python's `cond` is a required positional and its `build_marker` validates with no opt-ins. Both refuse to emit bare `manual`; both still parse it; both refuse `unstated` as input.

Made traceable rather than merely recorded: `PYTHON_SIDE` pins repo, path, an **immutable commit** (`9e21058fc`), its **sha256**, and the measurement date, asserted to be a 40-hex sha (not a moving ref) and **cross-checked against `reference/maintaining.md`** so prose and test cannot drift apart. Plus an **ARMED-ONLY** hash check (`AGENT_OBJ_MARKER_PY=<path>`) that goes red when the Python file changes.

**Judgement:** a runtime check that shells into another repo was rejected — a hermetic suite that depends on another checkout being present is a flaky gate, not a gate. **Unarmed, the hash check proves nothing, and the test says so in its own body.** What is always-on is the shape check and the doc cross-check.

### 3. An unsourced figure

~~`check-clickup-addressed` returned 0 addressed / 1 partially / 2 not established~~ — that came from a live session run, not from anything citable. Replaced with the figure the in-repo record actually holds, cited: `claude/skills/check-clickup-addressed/reference/validation-history.md`, "End-to-end after round 3" (2026-08-20) — **0 addressed, 0 partial, 0 open, 2 unclear**.

### 4. The three non-control survivors, closed

| survivor | why it survived | now killed by |
|---|---|---|
| `manual:` (colon, empty checker) | the test pinned only `MarkerError`; every path in `validateCond` throws that, so a mutant re-routing `manual:` to the argument-charset check ("contains whitespace or `>`" — about an argument nobody wrote) stayed green | `validateCond: a BARE manual is rejected…` now asserts the message, **and** `assert.doesNotMatch(/whitespace/)` |
| `query.mjs` CLI hint line | untested | `CHOKE POINT: a refused --cond prints the allowlist AND the arity rule` |
| `flows/task-hygiene.md` "🔴 NOTHING ENFORCES ANY OF THIS" | guarded by nothing — flipping it into a false claim of enforcement went fully green | `PROSE: the hygiene flow still says NOTHING ENFORCES IT…`, pinning the **whole normalised paragraph** (a reword inside it is a separate, killed mutant) |

### 5. `create-subtask` / batch-create could not name a condition — judged CHEAP, threaded

Every subtask and every batch task was `unstated` **by construction**, and a 20-task plan added 20 — an interface gap masquerading as authorial omission in the one number this feature exists to produce. Threading it cost ~40 lines, so it was threaded rather than documented-around:

- `--cond` now works on `subtask` (one validator, `withAgentCond()`, shared with `create`);
- a batch plan takes `cond` per task **and** per subtask, validated **plan-wide before any task is created** (`validatePlanConds`) — a lazy check leaves 16 objects on the board when task 17 throws, and there is no rollback;
- `reference/maintaining.md` records what the `unstated` count means and that a new creating path must ship with a cond option.

`CLAW_AGENT_COND=manual` also no longer degrades silently: the point of degradation warns, quoting the value and the reason.

### Verification (fix round)

**Node:** `bash scripts/run-node-tests.sh` → PASS, 1198 tests. clickup suite **160 → 171**; floor **152 → 163**.

**Red/green.** Reverting the five non-test source files to the pre-fix branch head (`9ae3e158`) and keeping the new tests: **7 RED**, named —

```
buildMarker: `unstated` is emittable ONLY under the explicit fallback opt-in
CROSS-LANGUAGE: the Python provenance is pinned to an IMMUTABLE ref and cited in the docs
agentIdentity: a hostile environment … and WARNS on the degradation
agentIdentity: CLAW_AGENT_COND=manual is a DEGRADATION and says so
SEAM: a CALLER may not pass `unstated` — the create path REJECTS it
SEAM: createSubtask can NAME a condition — a subtask is a stamped object too
PROSE: the measured figure in the hygiene flow cites a source in this repo
```

Reverting `lib/batch-create.mjs` as well cannot be measured per-test — `validatePlanConds` does not exist at base, so the module fails to link and the whole file reports one failure. That half's red/green is established by mutants M15–M20 instead.

🔴 **Three of the new tests are INVARIANT GUARDS, not regression tests, and are labelled as such**: `PROSE: … NOTHING ENFORCES IT`, `CHOKE POINT: a refused --cond prints…`, and the `manual:` message assertions all pass at `9ae3e158` — the behaviour was already right, it was simply unguarded. Their mutants (M24/M25, M22, M05) are what proves they are live.

**Mutation battery — 31 mutants, re-run in full after the fixes.** Every mutant verified applied by reading the file back (an anchor matching ≠1 time is reported `NOT-APPLIED`, never scored); verdicts read from counted TAP output, never an exit code.

| # | file | mutation | verdict | killed by |
|---|---|---|---|---|
| M01 | agent-marker.mjs | `allowUnstated` default → `true` | KILLED | `buildMarker: unstated is emittable ONLY under the explicit fallback opt-in` |
| M02 | agent-marker.mjs | `if (!allowUnstated)` → `if (false)` | KILLED | `validateCond: unstated is REJECTED by default…` |
| M03 | agent-marker.mjs | `unstated:<arg>` accepted | KILLED | `validateCond: unstated is REJECTED by default…` |
| M04 | agent-marker.mjs | `manual` refusal stops naming the remedy | KILLED | `validateCond: a BARE manual is rejected…` |
| M05 | agent-marker.mjs | **M18 of the audit** — `manual:` re-routes to the charset error | KILLED | `validateCond: a BARE manual is rejected…` |
| M06 | agent-marker.mjs | `manual:` accepted on the parse path as legacy | KILLED | `parseMarker: a MALFORMED marker reads as absent` |
| M07 | agent-marker.mjs | degradation warning deleted | KILLED | `agentIdentity: … WARNS on the degradation` |
| M08 | agent-marker.mjs | warning stops quoting the refused value | KILLED | `agentIdentity: … WARNS on the degradation` |
| M09 | agent-marker.mjs | a VALID `CLAW_AGENT_COND` discarded | KILLED | `agentIdentity: an allowlisted CLAW_AGENT_COND is honoured verbatim, and silently` |
| M10 | api/tasks.mjs | seam stops validating a caller's cond | KILLED | `SEAM: a CALLER may not pass unstated…` |
| M10b | api/tasks.mjs | `validateCallerCond` → pass-through | KILLED | `SEAM: a CALLER may not pass unstated…` |
| M10c | api/tasks.mjs | refusal no longer attributed to the seam | KILLED | `SEAM: a CALLER may not pass unstated…` |
| M11 | api/tasks.mjs | `fromFallback` → always `true` | KILLED | `SEAM: a create WITH a condition is silent` (+3) |
| **M12** | api/tasks.mjs | `allowUnstated: fromFallback` → `true` | **SURVIVED (declared)** | **redundant by design** — M10 already refuses `unstated` at the seam, so this argument is unreachable defence-in-depth. buildMarker's own default is what M01 tests. |
| M13 | api/tasks.mjs | create-site warning deleted | KILLED | `SEAM: a create with NO condition warns LOUDLY…` |
| M14 | api/tasks.mjs | warning inverted | KILLED | `SEAM: a create with NO condition warns LOUDLY…` |
| M15 | batch-create.mjs | a batch task cannot name its cond | KILLED | `CHOKE POINT: batch-create validates the WHOLE plan…` |
| M16 | batch-create.mjs | a batch SUBTASK cannot name its cond | KILLED | `CHOKE POINT: batch-create validates the WHOLE plan…` |
| M17 | batch-create.mjs | plan pre-flight stops running | KILLED | `CHOKE POINT: batch-create validates the WHOLE plan…` |
| M18 | batch-create.mjs | `validatePlanConds` accepts everything | KILLED | `SEAM: a batch plan's conds are validated BEFORE anything is created` |
| M19 | batch-create.mjs | subtask conds never validated | KILLED | `SEAM: a batch plan's conds…` |
| M20 | batch-create.mjs | a plan may assert `unstated` | KILLED | `SEAM: a batch plan's conds…` |
| M21 | query.mjs | `subtask` loses `--cond` | KILLED | `SEAM: createSubtask can NAME a condition…` |
| M22 | query.mjs | **M23 of the audit** — arity-rule hint reworded | KILLED | `CHOKE POINT: a refused --cond prints the allowlist AND the arity rule` |
| M23 | query.mjs | `--cond` stored unvalidated | KILLED | `CHOKE POINT: --cond is validated at the CLI…` |
| M24 | task-hygiene.md | **M24 of the audit** — disclaimer flipped to a false gate claim | KILLED | `PROSE: … NOTHING ENFORCES IT, in exactly those words` |
| M25 | task-hygiene.md | a REWORD inside the pinned paragraph | KILLED | `PROSE: … NOTHING ENFORCES IT…` |
| M26 | task-hygiene.md | the cited figure altered away from its source | KILLED | `PROSE: the measured figure … cites a source in this repo` |
| M27 | test file | Python pin → a MOVING ref | KILLED | `CROSS-LANGUAGE: the Python provenance is pinned to an IMMUTABLE ref…` |
| M28 | maintaining.md | doc provenance drifts from the suite's | KILLED | `CROSS-LANGUAGE: the Python provenance…` |
| **NC1** | agent-marker.mjs | **negative control** — comment-only reword | **SURVIVED (expected)** | — the battery can report SURVIVED |

**29 killed / 1 declared-redundant survivor / 1 negative control.** `unexpected: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

