### PR TITLE
fix(i3): cutover laptop from /etc/i3.conf to home-manager config

### DIFF
--- a/claudedocs/handoff-i3-laptop-espanso-float.md
+++ b/claudedocs/handoff-i3-laptop-espanso-float.md
@@ -1,0 +1,43 @@
+---
+# Handoff: i3-laptop-espanso-float — 2026-08-24
+
+## Goal
+Fix espanso windows tiling instead of floating on the laptop. The espanso floating rule (`for_window [class="(?i)espanso"] floating enable` in `nix/i3/config.nix:70`) is inert on the laptop because the NixOS system config forces i3 to read from `/etc/i3.conf` instead of the home-manager managed `~/.config/i3/config`.
+
+## State now
+- Branch: `fix/i3-laptop-espanso-float` — pushed, PR #805 (open, mergeable)
+- Commit: `d03702b8` — adds `nix/system/apply-i3-to-hm.sh`, updates stale comments in `nix/graphical.nix`
+- No uncommitted changes
+- **NOT deployed yet** — the apply script must be run manually with sudo after merge
+
+## Root cause (observed)
+- `i3-msg -t get_version` → `loaded_config_file_name: /etc/i3/config`
+- `/etc/i3/config` is a symlink → `/etc/static/i3/config`, generated from `/etc/nixos/i3config.nix`
+- `/etc/nixos/i3config.nix` is a 166-line basic i3 config with NO espanso rule, NO rig-control float, NO i3status-rust
+- `/etc/nixos/configuration.nix` (line ~95, from backup) has:
+  ```nix
+  windowManager.i3.configFile = "/etc/i3.conf";
+  environment.etc."i3.conf".text = import ./i3config.nix;
+  environment.etc."i3blocks.conf".text = import ./i3blocks.nix;
+  ```
+- This forces `i3 -c /etc/i3.conf`, making `~/.config/i3/config` (home-manager) completely inert
+- `nix/graphical.nix:14-16` documents this exact problem but references a retired apply script
+
+## The fix
+`nix/system/apply-i3-to-hm.sh` removes the three offending lines from `/etc/nixos/configuration.nix` and runs `nixos-rebuild switch`. After rebuild, i3 reads from `~/.config/i3/config` (home-manager managed) where the espanso rule is already live.
+
+## Next steps (ranked)
+1. Merge PR #805 — it's open and mergeable
+2. Run `sudo bash nix/system/apply-i3-to-hm.sh` on the laptop
+3. Reload i3 (`Mod+Shift+r`) or log out/in
+4. Verify: `i3-msg -t get_version | jq .loaded_config_file_name` → expect `~/.config/i3/config`
+5. Open espanso search — confirm it floats
+
+## How to verify
+```bash
+# After apply script + rebuild:
+i3-msg -t get_version | jq .loaded_config_file_name
+# expect: ~/.config/i3/config
+
+# Open espanso (Ctrl+Space or whatever the trigger is) — window should float
+```

--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -12,8 +12,7 @@
 # The i3 config is written verbatim via xdg.configFile."i3/config".text (raw string
 # from ./i3/config.nix) rather than the HM i3 DSL — Zach hand-maintains it.
 # NOTE: writing ~/.config/i3/config is INERT until the system stops forcing
-# `i3 -c /etc/i3.conf` (that cutover is a separate sudo nixos-rebuild step,
-# staged in nix/system/apply-i3-to-hm.sh).
+# `i3 -c /etc/i3.conf` — run `sudo bash nix/system/apply-i3-to-hm.sh` to cutover.
 { config, pkgs, lib, isNixOS ? false, isLaptop ? false, ... }:
 
 let
@@ -412,7 +411,7 @@ lib.mkIf isNixOS {
     '');
   fonts.fontconfig.enable = true;
 
-  # i3 config — raw string. INERT until the system cutover stops forcing /etc/i3.conf.
+  # i3 config — raw string. INERT until the system cutover (apply-i3-to-hm.sh).
   xdg.configFile."i3/config".text = import ./i3/config.nix { inherit isLaptop; };
 
   # Host AirVPN block scripts (workbench-only), symlinked beside the generated TOML.

--- a/nix/system/apply-i3-to-hm.sh
+++ b/nix/system/apply-i3-to-hm.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Cutover i3 from NixOS-managed /etc/i3.conf to home-manager ~/.config/i3/config
+#
+# The NixOS config forces `i3 -c /etc/i3.conf` via:
+#   windowManager.i3.configFile = "/etc/i3.conf";
+#   environment.etc."i3.conf".text = import ./i3config.nix;
+#
+# Home-manager writes ~/.config/i3/config (nix/graphical.nix) with the full
+# config including espanso floating, rig-control floats, i3status-rust, etc.
+# But i3 never reads it because the NixOS module passes -c explicitly.
+#
+# This script removes the NixOS-level i3 config and lets i3 fall back to its
+# default search path (~/.config/i3/config). Requires sudo nixos-rebuild.
+#
+#   sudo bash nix/system/apply-i3-to-hm.sh
+set -euo pipefail
+
+CFG=/etc/nixos/configuration.nix
+[[ $EUID -eq 0 ]] || { echo "must run as root (sudo bash $0)"; exit 1; }
+[[ -f $CFG ]] || { echo "missing $CFG"; exit 1; }
+
+BAK="$CFG.bak-i3-hm-$(date +%Y%m%d-%H%M%S)"
+cp -a "$CFG" "$BAK"
+echo "[0/4] backed up $CFG -> $BAK"
+
+restore_on_err() {
+  local rc=$?
+  echo "ERROR (rc=$rc) — restoring $CFG from $BAK" >&2
+  cp -a "$BAK" "$CFG"
+  exit "$rc"
+}
+trap restore_on_err ERR
+
+# ---- 1. Remove configFile = "/etc/i3.conf" from windowManager.i3 ----------
+if grep -q 'configFile.*=.*"/etc/i3.conf"' "$CFG"; then
+  sed -i '/configFile.*=.*"\/etc\/i3\.conf"/d' "$CFG"
+  grep -q 'configFile.*=.*"/etc/i3.conf"' "$CFG" && { echo "ERROR: configFile edit did not apply"; false; }
+  echo "[1/4] removed windowManager.i3.configFile"
+else
+  echo "[1/4] configFile already absent — skipping"
+fi
+
+# ---- 2. Remove environment.etc."i3.conf" (the system-level config text) ---
+if grep -q 'environment\.etc\."i3\.conf"' "$CFG"; then
+  # This is a multi-line attr: text = import ./i3config.nix; — remove the whole block.
+  # Match from the etc line through the closing semicolon.
+  sed -i '/environment\.etc\."i3\.conf"/,/;$/d' "$CFG"
+  grep -q 'environment\.etc\."i3\.conf"' "$CFG" && { echo "ERROR: i3.conf etc edit did not apply"; false; }
+  echo "[2/4] removed environment.etc.\"i3.conf\""
+else
+  echo "[2/4] environment.etc.\"i3.conf\" already absent — skipping"
+fi
+
+# ---- 3. Remove environment.etc."i3blocks.conf" (companion) ----------------
+if grep -q 'environment\.etc\."i3blocks\.conf"' "$CFG"; then
+  sed -i '/environment\.etc\."i3blocks\.conf"/,/;$/d' "$CFG"
+  echo "[3/4] removed environment.etc.\"i3blocks.conf\""
+else
+  echo "[3/4] environment.etc.\"i3blocks.conf\" already absent — skipping"
+fi
+
+# ---- 4. Validate ----------------------------------------------------------
+echo "[4/4] parsing $CFG ..."
+nix-instantiate --parse "$CFG" >/dev/null
+echo "[4/4] parse OK"
+
+trap - ERR
+
+echo
+echo "Review the diff before applying:"
+echo "    diff -u $BAK $CFG"
+echo
+
+if [[ -t 0 ]]; then
+  read -r -p "Run 'nixos-rebuild switch' now? [y/N] " ans || ans=n
+else
+  ans=n
+  echo "(non-interactive stdin — skipping the rebuild prompt)"
+fi
+
+if [[ ${ans:-n} =~ ^[Yy]$ ]]; then
+  if ! nixos-rebuild switch; then
+    echo
+    echo "nixos-rebuild FAILED. The config edits are still in place." >&2
+    echo "Rollback: cp -a $BAK $CFG && nixos-rebuild switch" >&2
+    exit 1
+  fi
+else
+  echo "Config edited and validated; nixos-rebuild NOT run. Run it when ready:"
+  echo "    sudo nixos-rebuild switch"
+fi
+
+echo
+echo "After rebuild, reload i3 (Mod+Shift+r) or log out/in."
+echo "Verify: i3-msg -t get_version | jq .loaded_config_file_name"
+echo "  expect: ~/.config/i3/config  (was /etc/i3/config)"
+echo
+echo "Rollback: cp -a $BAK $CFG && sudo nixos-rebuild switch"


### PR DESCRIPTION
The NixOS config forces `i3 -c /etc/i3.conf` via `windowManager.i3.configFile`, bypassing the home-manager managed `~/.config/i3/config`. The espanso floating rule (#488) and every i3 config change since #74 have been inert on the laptop.

This adds `nix/system/apply-i3-to-hm.sh` which removes the NixOS-level `configFile`, `i3.conf`, and `i3blocks.conf` entries and rebuilds. Also updates stale comments in `graphical.nix`.

**To apply on the laptop:**
```
sudo bash nix/system/apply-i3-to-hm.sh
```