### PR TITLE
fix(clawgate skill): "which sessions worked task N" is NOT UI-only — correct both docs, and make the pickup flow use it

### DIFF
--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -145,11 +145,11 @@ create** — a load-bearing wire contract producers key their retry on.
 ⚠ **A task body may carry extension-picked element references** — never search the selector first
 (`element-references.md`).
 
-⚠ **Task↔session threads (#357) are ONE-WAY.** `/ui/tasks` shows a `👥 N` chip, but
-`GET /api/tasks/{id}/sessions` **404s** — only the reverse `GET /api/sessions/{id}/tasks` is
-callable and `clawgatectl` has neither, so *"which sessions worked task N"* is **UI-only**.
-🔴 Membership OVER-reports and never downgrades: a 400-rejected PATCH still records `worked` (#306),
-and a subagent inherits the parent's session id. `task-api.md`
+⚠ **Task↔session threads (#357).** `GET /api/tasks/{id}/sessions` **404s BY DESIGN** (pinned by
+`TestNoForwardSessionsSubRoute`) — the thread is EMBEDDED on task reads. So
+`clawgatectl task get N | jq .sessions` answers *"which sessions worked task N"*; NOT UI-only.
+🔴 Membership OVER-reports: a subagent inherits the parent's id, and a mere READ links you.
+(#306's rejected-PATCH link is FIXED, live 0.7.99.) `task-api.md`
 
 **Writing/debugging a producer? Load `task-api.md`** — per-op semantics + status codes,
 409/immutability, the author allowlist, provenance, tag grammar, the route×auth inventory.

--- a/claude/skills/clawgate/flows/task-pickup.md
+++ b/claude/skills/clawgate/flows/task-pickup.md
@@ -19,8 +19,11 @@ flow was opened. Everything else about the pickup is here.
 Route-level cites: `task-api.md` → "Notifications".
 
 ```bash
-clawgatectl task get <id>            # 1. READ — body + comments are BOTH already here
+clawgatectl task get <id>            # 1. READ — body, comments AND sessions are ALL already here
                                      #    (no /comments GET exists; it is 405)
+#  1b. WHO ALREADY TOUCHED IT — free, the read above already returned it:
+#      jq '.sessions[] | select(.role=="worked" or .role=="created")'
+#      A `worked` link from ANOTHER session => say so before doing the work again.
 #  2. EVALUATE and report to Zach. Do NOT flip status yet — see the ordering trap below.
 #  3a. On "local dispatch": settle the acceptance criteria (detector below).
 clawgatectl task comment <id> --body "$(cat <<'EOF'
@@ -38,6 +41,26 @@ clawgatectl task status <id> in_progress          # 3c. THEN flip, and work
 clawgatectl task comment <id> --body "…"          # 5. ONE completion comment (shape below)
 clawgatectl task status <id> ready_for_review     # 6. …or `complete` — see the gate
 ```
+
+**Step 1b — has someone already done this?** The `sessions` array is the task's thread: which
+Claude Code sessions touched it, and how. It arrives **in the step-1 response**, so this check
+costs no extra call and creates no extra link. Two cards (#193, #194) were dispatched and paid for
+twice; this is the cheapest thing that catches that before you start.
+
+🔴 **Filter on `role`. Membership alone means nothing** — a *mere read* links a session, and a
+subagent links its PARENT. Only `worked` / `created` are claims about work.
+
+| what you see | what it means | what to do |
+|---|---|---|
+| `worked` by another session | someone did real work already | **Say so before starting.** Check the comments for their write-back; it may be finished and un-flipped |
+| `created` only | the card was filed, not worked | normal — proceed |
+| only `read` links | nobody worked it | proceed |
+| your OWN id as `worked` | you already worked it this session | you are probably re-entering; re-read your own comment first |
+
+⚠ **Never read "no `read` link" as "nobody looked".** The thread cap evicts oldest `read` first and
+**never** `created`/`worked` — so `worked` is durable evidence while a missing `read` may just have
+been evicted. ⚠ `detailAvailable: false` is the majority state; a `sessionId` usually will not
+resolve to a transcript. Full semantics: `reference/task-api.md` → "Task ↔ session threads".
 
 **Acceptance-criteria detector — deterministic, not a judgement call.** A heading matching
 `## Acceptance criteria` (case-insensitive) → **AUTHOR-SPECIFIED**. Anything else — including a body

--- a/claude/skills/clawgate/flows/task-pickup.md
+++ b/claude/skills/clawgate/flows/task-pickup.md
@@ -60,7 +60,8 @@ subagent links its PARENT. Only `worked` / `created` are claims about work.
 ⚠ **Never read "no `read` link" as "nobody looked".** The thread cap evicts oldest `read` first and
 **never** `created`/`worked` — so `worked` is durable evidence while a missing `read` may just have
 been evicted. ⚠ `detailAvailable: false` is the majority state; a `sessionId` usually will not
-resolve to a transcript. Full semantics: `reference/task-api.md` → "Task ↔ session threads".
+resolve to a transcript. Full semantics:
+`~/.claude/skills/clawgate/reference/task-api.md` → "Task ↔ session threads".
 
 **Acceptance-criteria detector — deterministic, not a judgement call.** A heading matching
 `## Acceptance criteria` (case-insensitive) → **AUTHOR-SPECIFIED**. Anything else — including a body

--- a/claude/skills/clawgate/reference/task-api.md
+++ b/claude/skills/clawgate/reference/task-api.md
@@ -335,30 +335,56 @@ directly above: a count re-derived against a live pin decays the moment the next
 `grep -vc '^#' routes.golden` (the file's first three lines are comments) and subtract anything
 committed after the live pin.
 
-### Task ↔ session threads (#357, 0.7.98) — the direction that EXISTS, and the one that does not
+### Task ↔ session threads (#357, 0.7.98) — BOTH directions are machine-readable
 
 The `task_sessions` table records which Claude Code sessions touched a task, with a role of
 `created` / `worked` / `read`, and `/ui/tasks` renders a `👥 N session(s)` chip with a deep link.
 🔴 **The link is written by the SERVER as a side effect of the request; there is no producer API for
-it,** and the query is asymmetric:
+it** — you cannot create, edit or delete a link.
+
+🔴 **RETRACTED 2026-08-24: this section used to say the task→sessions direction had "no route",
+`clawgatectl` had "no subcommand", and the question was answerable "only by reading `/ui/tasks`".
+The CONCLUSION was wrong** — measured live against `0.7.99` on 11 tasks. The sub-route genuinely
+404s, but the thread is **EMBEDDED on every task read**, so the CLI has always been able to answer:
+
+```bash
+clawgatectl task get N | jq '.sessions[] | select(.role=="worked")'
+# {"sessionId":"55810ec6-…","role":"worked","host":"nixos",
+#  "firstSeenAt":"…","lastSeenAt":"…","detailAvailable":false}
+```
 
 | direction | surface | state |
 |---|---|---|
 | session → tasks | `GET /api/sessions/{id}/tasks` | ✅ callable (hook token), pinned in the golden |
-| task → sessions | *(none)* | 🔴 **no route.** `GET /api/tasks/{id}/sessions` returns **404** and appears nowhere in `routes.golden` |
-| either direction | `clawgatectl` | 🔴 **no subcommand** — not under `task`, not top-level |
+| task → sessions | `GET /api/tasks/{id}` → **`sessions[]`** | ✅ **embedded on the task read**, list and single. Pinned by `task_sessions_test.go` ("response embeds the link it just made") |
+| task → sessions | `GET /api/tasks/{id}/sessions` | 🔴 **404 BY DESIGN — do not "fix" it.** `TestNoForwardSessionsSubRoute` pins 404/405 because the codebase embeds a task's children rather than keep a second contract in sync. Correctly absent from `routes.golden` |
+| either direction | `clawgatectl` | ✅ `task get` (embed, above) · reverse is still curl |
 
-So *"which sessions worked task N"* — the question the feature was built to answer — is today
-answerable **only by reading `/ui/tasks`**. A machine consumer can ask the reverse question only.
+🔴 **The lesson that cost this file three days of being wrong:** "the sub-route 404s" and "the data
+is unreachable" are different claims, and the second does not follow from the first. A handoff doc
+queued *"build the forward direction"* as ranked work on the strength of this table. One
+`clawgatectl task get` would have retired it.
 
-🔴 **Membership OVER-reports, and a role NEVER downgrades.** Two measured causes, both live:
-- a **400-rejected** `PATCH` still records the session as having `worked` the task: `noteTaskSession`
-  (defined in `internal/api/task_sessions.go`, called from the PATCH handler in
-  `internal/api/notes.go`) runs **before** the body/tag validation that rejects the request —
-  verified on trunk, the call precedes both `StatusBadRequest` returns in that handler. Card #306
-  carries three fix options;
-- a **subagent inherits the parent's `CLAUDE_CODE_SESSION_ID`**, so a subagent merely *reading* a
-  task links the **parent** session to work it never did.
+#### Reading a thread WITHOUT being fooled by it
+
+**Filter on `role`, never on membership.** Presence in a thread does not mean the session did work:
+
+- 🔴 **A mere READ links you.** `task get` records a `read` link for your own session — so
+  *querying a thread changes it*. Checking task 337 took it from 2 sessions to 3. An agent polling
+  the board inflates every thread it touches.
+- 🔴 **A subagent inherits the parent's `CLAUDE_CODE_SESSION_ID`**, so a subagent merely reading a
+  task links the **parent** session to work it never did. Give a dispatched agent its own.
+- ✅ **FIXED in 0.7.99** (#306 / PR #391): a **400-rejected** `PATCH` used to record `worked`
+  permanently. It now records **no link at all** — not even `read`, deliberately, since the weaker
+  role would manufacture membership out of a refused attempt. Verified live against Postgres.
+
+**Trust `worked`/`created`; never infer from the absence of `read`.** The cap is asymmetric —
+it evicts oldest `read` first and **never** `created`/`worked` — so a `worked` link is durable
+evidence, while a missing `read` may simply have been evicted. This asymmetry is what makes the
+query answerable at all.
+
+⚠ **Expect `detailAvailable: false` on most rows** (16 of 17 live rows when measured) — see the
+`cc_sessions` note below. A `sessionId` usually will NOT resolve to a transcript.
 
 ⚠ **No FK to `cc_sessions`, deliberately** — that table is swept at 14 days, and a cascading FK would
 silently empty every thread, making a task that HAD five sessions render identically to one that


### PR DESCRIPTION
## What

The skill claimed task↔session threads were effectively **one-way** — that `GET /api/tasks/{id}/sessions` 404s, that `clawgatectl` had no subcommand either way, and that *"which sessions worked task N"* was answerable **only from `/ui/tasks`**.

Measured live against `0.7.99` on 11 tasks (threads of 0, 1 and 2 sessions): **only the 404 is true.**

```console
$ clawgatectl task get 337 | jq '.sessions[] | select(.role=="worked")'
{ "sessionId": "55810ec6-…", "role": "worked", "host": "nixos", "lastSeenAt": "2026-08-24T03:41:59Z" }
```

`GET /api/tasks/{id}` **embeds** the thread, so the CLI has always been able to answer. The 404 is a **design decision**, pinned by `TestNoForwardSessionsSubRoute`: the codebase embeds a task's children rather than keep a second contract in sync.

> "the sub-route 404s" and "the data is unreachable" are different claims, and the second does not follow from the first.

That inference had **"build the forward direction"** queued as ranked next work in a handoff doc. Building it would have broken the test that exists to prevent it, to add a route duplicating data already on the wire.

## Two commits, because the first fix was incomplete

| commit | file | why |
|---|---|---|
| `9b9b41c5` | `SKILL.md` | the summary claim |
| `090e7e63` | `reference/task-api.md` | **the same false claim, in more detail** — a table row reading "no route" + "no subcommand" + "only by reading `/ui/tasks`". This is the file an agent loads when working the Task API, so the first commit reached the wrong half of the readership. One rule, one place. |
| `090e7e63` | `flows/task-pickup.md` | the behavioural half — see below |

## Making agents actually use it

`task-pickup.md` now checks the thread at **step 1b**:

```bash
jq '.sessions[] | select(.role=="worked" or .role=="created")'
```

**This costs nothing.** Step 1 of the flow already runs `clawgatectl task get`, and that response already carries `sessions` — the field was on the wire and being ignored. Cards **#193** and **#194** were dispatched and paid for twice, which a `worked` link from another session would have caught before the work started.

## The two traps that make a naive read wrong

Both files now carry these, because the recipe alone is the least useful part:

- **Filter on `role`, never membership.** A *mere read* links you — so querying a thread changes it (checking task 337 took it from 2 sessions to 3) — and a **subagent links its PARENT**.
- **Trust `worked`/`created`; never infer from a missing `read`.** The cap evicts oldest `read` first and **never** `created`/`worked`. So `worked` is durable evidence while an absent `read` may just have been evicted. That asymmetry is what makes the query trustworthy at all.
- `detailAvailable: false` is the majority state (16 of 17 live rows) — a `sessionId` usually will not resolve to a transcript.

Also corrected: #306 is no longer one of *"two measured causes, both live"* of over-reporting — it is **fixed and live in `0.7.99`**.

## Gates

- `310 passed` — interview guard, including the `SKILL.md` byte ceiling (untouched at **15074**, net −10 from the first commit; the addition is paid for by tightening the same paragraph, per the skill's own eviction rule)
- `59 passed` — `test_prune_skill_size` + `test_skills_mapping_guard`
- The ceiling gate was **negative-controlled**: padding `SKILL.md` by 30 bytes turns `test_the_skill_did_not_grow` red, confirming it resolves to the file this PR edits rather than passing vacuously
- Neither `task-api.md` nor `task-pickup.md` carries a size gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)