### PR TITLE
fix(browser-bridge tests): a spool row is not yours because it is FIRST — select by op (#783)

### DIFF
--- a/scripts/browser-bridge/tests/conftest.py
+++ b/scripts/browser-bridge/tests/conftest.py
@@ -114,8 +114,24 @@ def _session_spool_backstop(tmp_path_factory):
 
 @pytest.fixture(autouse=True)
 def _isolate_activity_spool(tmp_path, monkeypatch):
-    """Narrow the spool to a PER-TEST temp dir, so no test can read another's
-    rows. Teardown restores to the session backstop above, never to ambient."""
+    """Narrow the spool to a PER-TEST temp dir. Teardown restores to the session
+    backstop above, never to ambient.
+
+    🔴 THIS DOES NOT GUARANTEE "no test can read another's rows", which is what
+    this docstring used to claim. `ACTIVITY_SPOOL_DIR` is a process-global env
+    var and this re-points it per test, so a thread still ALIVE from an earlier
+    test emits into whatever the CURRENT test's dir is. Measured 2026-08-24: a
+    neighbour's `{"op":"getHtml","outcome":"timeout"}` sat at position 0 of two
+    different tests' spools in CI, which made
+    `_wait_events(spool_dir, 1)[0]` return someone else's row and reddened two
+    PRs that cannot reach browser-bridge at all.
+
+    What this fixture actually gives you is a per-test dir, not a per-test
+    WRITER SET. Select rows by `op` (`_wait_ops`/`_wait_payload` in
+    `test_server.py`) rather than by position, and treat the isolation here as
+    narrowing the blast radius rather than closing it. Closing it properly means
+    joining every emitter thread at teardown, which is a bigger change than the
+    one that fixed the assertions."""
     monkeypatch.setenv("ACTIVITY_SPOOL_DIR", str(tmp_path / "activity-spool"))
     # Only reset the lazy emitter cache on an ALREADY-imported `server`. Several
     # modules here (test_skill_size, test_browser_agent_parse, …) never import

--- a/scripts/browser-bridge/tests/conftest.py
+++ b/scripts/browser-bridge/tests/conftest.py
@@ -39,9 +39,17 @@ shells out is covered too. (No test does today: nothing here spawns `server.py`,
 and neither the `browser` CLI nor `browser-agent` touches the spool at all.)
 
 TWO FIXTURES, TWO DIFFERENT HAZARDS — see each one's own docstring. The
-per-test one gives each test its own spool so tests cannot read each other's
-rows; the session-scoped backstop exists because the per-test one's TEARDOWN is
-itself a hole.
+per-test one gives each test its own spool DIRECTORY; the session-scoped
+backstop exists because the per-test one's TEARDOWN is itself a hole.
+
+🔴 A PER-TEST DIRECTORY IS NOT A PER-TEST WRITER SET, and this sentence used to
+claim it was ("so tests cannot read each other's rows"). `ACTIVITY_SPOOL_DIR` is
+process-global and re-pointed per test, so a thread still ALIVE from an earlier
+test emits into the CURRENT test's dir. Corrected in the same change that fixed
+the assertions it broke — see `_isolate_activity_spool` below for the
+measurement. The correction lived only on that fixture at first, leaving this
+paragraph contradicting it 70 lines higher in the same file; a reader who stops
+here would still get the false guarantee, which is the whole failure mode.
 
 `scripts/browser-bridge/tests/test_spool_isolation.py` is the regression guard,
 and it is a SEPARATE FILE on purpose: its first two tests are only meaningful as

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -124,8 +124,10 @@ def _wait_events(spool_dir, n=1, timeout=10.0, until=None) -> list:
     `{"event":"throttled","op":"tabs","reason":"rate_limited"}` is in that run's
     captured stderr — but only the `cmd` event had reached the spool inside the
     deadline, so the filter found nothing and the assertion failed as
-    `assert 0 == 1`, reading like a defect in rate limiting. 16 of the 52 call
-    sites in this module use a count this way. Pass `until=` whenever you are
+    `assert 0 == 1`, reading like a defect in rate limiting. A count is still
+    how MOST call sites here wait — see `_wait_ops` below for the positional
+    half of the same problem. (A previous revision quoted an exact site count;
+    it was stale within a day, twice. Counts in prose rot — measure it.) Pass `until=` whenever you are
     waiting for a SPECIFIC event; the count is only right when any N will do.
 
     🔴 AND A TIMEOUT IS NOW LOUD. This used to return a SHORT list silently, so
@@ -162,12 +164,23 @@ def _wait_events(spool_dir, n=1, timeout=10.0, until=None) -> list:
 
 def _payload_op(e) -> str | None:
     """The `op` inside a spooled event's payload, or None if it has no readable
-    one. Deliberately total: a row written by something other than the bridge
+    one.
+
+    Total by construction — a row written by something other than the bridge
     must not raise here, because the whole point of the helpers below is to walk
-    PAST such a row rather than trip on it."""
+    PAST such a row rather than trip on it.
+
+    🔴 `AttributeError` IS IN THE TUPLE ON PURPOSE, and the #807 audit is why:
+    an earlier version claimed to be total and was not. A payload that is valid
+    JSON but not an OBJECT — `null`, `123`, `"str"`, `[1,2]` — decodes fine and
+    then has no `.get`, so all four raised. Only malformed JSON, a missing
+    `payload` key and a `None` payload were actually covered. A non-bridge
+    writer emitting a scalar payload is exactly the named case, so the claim and
+    the code disagreed precisely where it mattered.
+    """
     try:
         return json.loads(e["payload"]).get("op")
-    except (KeyError, TypeError, ValueError):
+    except (KeyError, TypeError, ValueError, AttributeError):
         return None
 
 
@@ -183,15 +196,30 @@ def _wait_ops(spool_dir, op, n=1, **kw) -> list:
     `monkeypatch.setenv`. A thread still alive from an EARLIER test therefore
     emits into the CURRENT test's spool — so `[0]` is whichever row landed
     first, not whichever row this test caused. Seen in CI as
-    `assert 'getHtml' == 'frames'` and `assert 'getHtml' == 'type'`, both with a
-    pair of `{"event":"cmd_timeout","op":"getHtml"}` rows from a neighbour
-    sitting ahead of the test's own event. Neither PR could reach browser-bridge
+    `assert 'getHtml' == 'frames'` and `assert 'getHtml' == 'type'`. The visible
+    artifact was a pair of `{"event":"cmd_timeout","op":"getHtml"}` lines in the
+    failing test's captured STDERR — those are the server's structured log, NOT
+    spool rows; do not grep the spool for that string. The corresponding spool
+    payload reads `{"op":"getHtml", …, "outcome":"timeout"}`. The stderr is
+    still good evidence because capture is per-test-phase, so a neighbour's
+    timeout demonstrably fired inside the failing test's window. Neither PR could reach browser-bridge
     — one changed `scripts/run-tests.sh`, the other changed only a `.md`.
 
     This is the positional sibling of the COUNT problem `_wait_events`'s own
     docstring describes: that one waits for the wrong NUMBER, this one reads the
     wrong ROW. `until=` fixes both, and this wraps the idiom so each call site
     does not re-derive it.
+
+    🔴 WHAT THIS DOES **NOT** COVER — it narrows the class, it does not close it.
+    Discrimination is on `op` ALONE, so a neighbour emitting the SAME op is
+    still selected. The exposed shape is a caller asking for N rows of a common
+    op where their ORDER carries the signal — `_wait_ops(…, "tabs", 2)` below is
+    the one such site. Measured for the #807 audit: no current test leaves a
+    `tabs` command in flight to time out (the two candidates call
+    `registry.submit` directly and never reach `emit_cmd_event`), so today's
+    residual is far smaller than the `getHtml`-timeout shape that caused the
+    incident. If that ever changes, the rows already carry `session` and a
+    payload `sess_src`, which would discriminate further.
     """
     def _seen(evs):
         return len([e for e in evs if _payload_op(e) == op]) >= n
@@ -223,10 +251,11 @@ def test_a_neighbours_late_row_does_not_become_this_tests_event(telemetry):
     """
     spool_dir = telemetry
     spool_dir.mkdir(parents=True, exist_ok=True)
-    # A neighbour's late `cmd_timeout`, in the exact shape CI produced, written
-    # as a v1 spool line. The format lives in `_parse_spool_line` above; if it
-    # ever changes, this planting breaks LOUDLY (that reader asserts `v1`)
-    # rather than silently planting a row nothing can decode.
+    # A neighbour's late `cmd_timeout`, written as a v1 spool line. The format
+    # lives in `_parse_spool_line` above. Drift breaks this LOUDLY either way,
+    # but be precise about which guard catches what: a VERSION-TAG change trips
+    # that reader's `v1` assert, while a same-version KEY RENAME is caught by
+    # this test's own control below (verified by simulating both).
     foreign_payload = json.dumps({"op": "getHtml", "outcome": "timeout"})
     _log_file(spool_dir).write_text("\t".join([
         "v1", "source=browser-bridge", "kind=cmd",
@@ -3179,7 +3208,9 @@ def test_only_the_heartbeat_is_server_originated(telemetry):
     """
     spool_dir = telemetry
     S.emit_heartbeat_event(S.Registry())
-    e = _wait_events(spool_dir, 1)[0]
+    # Selected by op, then cross-checked against `kind` — selection is on the
+    # PAYLOAD op, so this assertion is not tautological.
+    e = _wait_ops(spool_dir, "heartbeat", 1)[0]
     assert e["kind"] == "heartbeat"
     assert "session" not in e, e
     p = json.loads(e["payload"])
@@ -5819,7 +5850,9 @@ def test_type_telemetry_no_typed_text(telemetry):
                      {"op": "type", "text": "SECRET_PROMPT_cafef00d"})
         assert st == 200
         # Selected by op, not by position: a neighbour's late row can sit at [0].
-        assert _wait_payload(spool_dir, "type")["op"] == "type"
+        # No `== "type"` assertion here — selecting on op then asserting it is
+        # tautological; `_wait_ops` already raises if no `type` row lands.
+        _wait_payload(spool_dir, "type")
         raw = _log_file(spool_dir).read_text()
         assert "SECRET_PROMPT" not in raw, "typed text leaked into telemetry"
     finally:
@@ -8635,7 +8668,13 @@ def test_heartbeat_is_not_counted_as_operator_usage(telemetry):
 
     spool_dir = telemetry
     S.emit_heartbeat_event(_FakeRegistry())
-    e = _wait_events(spool_dir, 1)[0]
+    # 🔴 SELECTED BY OP, and this site is why the #807 audit called it urgent.
+    # With positional indexing a neighbour's `kind="cmd"` row at [0] failed this
+    # with "the heartbeat is being counted as operator usage by adoption-scan" —
+    # a confident, FALSE diagnosis about a seam that is fine. That is strictly
+    # worse than the failure that prompted the fix (`'getHtml' == 'frames'`),
+    # which at least names its own confusion.
+    e = _wait_ops(spool_dir, "heartbeat", 1)[0]
     assert e["kind"] not in counted_kinds, \
         ("the heartbeat is being counted as operator usage by adoption-scan — "
          f"emitted kind={e['kind']!r}, counted={counted_kinds}")

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -149,13 +149,16 @@ def _wait_events(spool_dir, n=1, timeout=10.0, until=None) -> list:
     moved every bucket and a stale count is what the rule above exists to
     prevent. The 7 op-selected calls are `_wait_ops`/`_wait_payload`.
 
-    n=1 after a single command is exact, not a proxy. Of the 10 n>=2, one is this
+    n=1 after a single command is exact, not a proxy. Of the 9 n>=2, one is this
     harness's own negative control below (it asserts the timeout fires; no real
-    events are involved). Of the 9 remaining real waits, 8 are order-safe —
-    either they wait for the earlier event before issuing the next request, so
-    file order is pinned structurally, or they assert something
-    order-independent. The exception is the `absent, empty =
-    _wait_events(spool_dir, 2)` unpack, which does depend on file order.
+    events are involved). All 8 remaining real waits are order-safe — either
+    they wait for the earlier event before issuing the next request, so file
+    order is pinned structurally, or they assert something order-independent.
+
+    (Both numbers moved by one: the single order-DEPENDENT site this paragraph
+    used to name — the `absent, empty = _wait_events(spool_dir, 2)` unpack — is
+    the one #807 migrated, so it is no longer an n>=2 `_wait_events` call and no
+    longer the exception. Re-checked, not assumed.)
 
     Pass `until=` whenever you are waiting for a SPECIFIC event.
 

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -160,6 +160,105 @@ def _wait_events(spool_dir, n=1, timeout=10.0, until=None) -> list:
     return evs
 
 
+def _payload_op(e) -> str | None:
+    """The `op` inside a spooled event's payload, or None if it has no readable
+    one. Deliberately total: a row written by something other than the bridge
+    must not raise here, because the whole point of the helpers below is to walk
+    PAST such a row rather than trip on it."""
+    try:
+        return json.loads(e["payload"]).get("op")
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _wait_ops(spool_dir, op, n=1, **kw) -> list:
+    """The first `n` spooled events whose payload op is `op`, waiting for them.
+
+    🔴 USE THIS INSTEAD OF `_wait_events(spool_dir, n)[i]` WHENEVER YOU WANT A
+    SPECIFIC OP — indexing by POSITION assumes every row in the spool is yours,
+    and that assumption is false.
+
+    MEASURED 2026-08-24. `ACTIVITY_SPOOL_DIR` is a process-global env var that
+    `conftest._isolate_activity_spool` re-points per test with
+    `monkeypatch.setenv`. A thread still alive from an EARLIER test therefore
+    emits into the CURRENT test's spool — so `[0]` is whichever row landed
+    first, not whichever row this test caused. Seen in CI as
+    `assert 'getHtml' == 'frames'` and `assert 'getHtml' == 'type'`, both with a
+    pair of `{"event":"cmd_timeout","op":"getHtml"}` rows from a neighbour
+    sitting ahead of the test's own event. Neither PR could reach browser-bridge
+    — one changed `scripts/run-tests.sh`, the other changed only a `.md`.
+
+    This is the positional sibling of the COUNT problem `_wait_events`'s own
+    docstring describes: that one waits for the wrong NUMBER, this one reads the
+    wrong ROW. `until=` fixes both, and this wraps the idiom so each call site
+    does not re-derive it.
+    """
+    def _seen(evs):
+        return len([e for e in evs if _payload_op(e) == op]) >= n
+    evs = _wait_events(spool_dir, until=_seen, **kw)
+    return [e for e in evs if _payload_op(e) == op][:n]
+
+
+def _wait_payload(spool_dir, op, **kw) -> dict:
+    """The decoded payload of the first spooled event whose op is `op`."""
+    return json.loads(_wait_ops(spool_dir, op, 1, **kw)[0]["payload"])
+
+
+def test_a_neighbours_late_row_does_not_become_this_tests_event(telemetry):
+    """🔴 REGRESSION for the CI flake that blocked two unrelated PRs.
+
+    `ACTIVITY_SPOOL_DIR` is a process-global env var re-pointed per test, so a
+    thread still alive from an EARLIER test emits into THIS test's spool. Then
+    `_wait_events(spool_dir, 1)[0]` returns the neighbour's row and the test
+    asserts against someone else's op.
+
+    Observed twice in CI, on diffs that cannot reach browser-bridge:
+    `assert 'getHtml' == 'frames'` (#773, a change to `scripts/run-tests.sh`)
+    and `assert 'getHtml' == 'type'` (#770, a change to one `.md` file).
+
+    The foreign row is planted directly rather than raced into place: the defect
+    is "a row this test did not cause is sitting in the spool", and how it got
+    there is the neighbour's business. Planting it makes the test deterministic
+    instead of load-dependent — the whole complaint about the original.
+    """
+    spool_dir = telemetry
+    spool_dir.mkdir(parents=True, exist_ok=True)
+    # A neighbour's late `cmd_timeout`, in the exact shape CI produced, written
+    # as a v1 spool line. The format lives in `_parse_spool_line` above; if it
+    # ever changes, this planting breaks LOUDLY (that reader asserts `v1`)
+    # rather than silently planting a row nothing can decode.
+    foreign_payload = json.dumps({"op": "getHtml", "outcome": "timeout"})
+    _log_file(spool_dir).write_text("\t".join([
+        "v1", "source=browser-bridge", "kind=cmd",
+        "b64:payload=" + base64.b64encode(foreign_payload.encode()).decode(),
+    ]) + "\n")
+
+    srv, _ = _serve()
+    ext = FakeExtension(srv, executor=lambda c: {"url": "https://civitai.com/",
+                                                 "frames": []})
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        assert _req(srv, "POST", "/cmd", {"op": "frames"})[0] == 200
+
+        # THE FIX: selected by op, so the neighbour is walked past.
+        assert _wait_payload(spool_dir, "frames")["op"] == "frames"
+
+        # 🔴 THE CONTROL, in the same test so it cannot rot separately: the OLD
+        # idiom really does pick the wrong row here. Without this the assertion
+        # above would pass just as happily if the spool held only our own event,
+        # and the test would be pinning nothing.
+        evs = _wait_events(spool_dir, 1)
+        assert _payload_op(evs[0]) == "getHtml", (
+            "the planted neighbour row is not at position 0, so this test is "
+            "not reproducing the flake it claims to cover")
+        assert len(evs) >= 2, (
+            "this test's own event never landed — the control is measuring an "
+            "empty spool, not a contested one")
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
 def test_wait_events_reports_a_timeout_instead_of_returning_short(tmp_path):
     """🔴 NEGATIVE CONTROL on the harness. `_wait_events` used to return a SHORT
     list silently on timeout, so the caller's next line failed with a message
@@ -3053,7 +3152,9 @@ def test_an_absent_origin_header_is_not_the_same_as_an_empty_one(telemetry):
         assert _wait_connected(srv, want=True)
         assert _cmd_sess(srv, {"op": "tabs"}, sid=LEAKED_ID)[0] == 200
         assert _cmd_sess(srv, {"op": "tabs"}, sid=LEAKED_ID, origin="")[0] == 200
-        absent, empty = _wait_events(spool_dir, 2)
+        # Both rows are `tabs`, so ORDER between them is the signal and must be
+        # preserved — but a neighbour's row must not be counted as one of them.
+        absent, empty = _wait_ops(spool_dir, "tabs", 2)
         assert absent["session"] == LEAKED_UUID, absent
         assert "origin" not in json.loads(absent["payload"])
         assert "session" not in empty, empty
@@ -5693,9 +5794,8 @@ def test_frames_telemetry_metadata_only(telemetry):
         assert st == 200
         # round-trip sanity: the caller DOES get the frame list back.
         assert body["result"]["data"]["frames"][1]["frameId"] == "F1"
-        e = _wait_events(spool_dir, 1)[0]
-        p = json.loads(e["payload"])
-        assert p["op"] == "frames"
+        # Selected by op, not by position: a neighbour's late row can sit at [0].
+        p = _wait_payload(spool_dir, "frames")
         assert p["outcome"] == "ok"
         assert p["domain"] == "civitai.com"       # bare TOP-LEVEL domain only
         raw = _log_file(spool_dir).read_text()
@@ -5718,8 +5818,8 @@ def test_type_telemetry_no_typed_text(telemetry):
         st, _ = _req(srv, "POST", "/cmd",
                      {"op": "type", "text": "SECRET_PROMPT_cafef00d"})
         assert st == 200
-        e = _wait_events(spool_dir, 1)[0]
-        assert json.loads(e["payload"])["op"] == "type"
+        # Selected by op, not by position: a neighbour's late row can sit at [0].
+        assert _wait_payload(spool_dir, "type")["op"] == "type"
         raw = _log_file(spool_dir).read_text()
         assert "SECRET_PROMPT" not in raw, "typed text leaked into telemetry"
     finally:


### PR DESCRIPTION
Closes the assertion half of #783.

## Measured in CI, twice, on diffs that cannot reach browser-bridge

| PR | diff | failure |
|---|---|---|
| **#773** | `scripts/run-tests.sh` | `assert 'getHtml' == 'frames'` |
| **#770** | one `.md` file | `assert 'getHtml' == 'type'` |

Both with a pair of `{"event":"cmd_timeout","op":"getHtml"}` rows from a neighbour sitting **ahead** of the test's own event. **#770 is still blocked by it.**

## Root cause — and it is not the assertion style

`ACTIVITY_SPOOL_DIR` is a **process-global env var** that `conftest._isolate_activity_spool` re-points per test via `monkeypatch.setenv`. A thread still **alive** from an earlier test therefore emits into the **current** test's spool.

So the fixture gives a per-test **directory**, not a per-test **writer set** — and its docstring claimed *"no test can read another's rows"*, which is false exactly when a neighbour is late. That claim is corrected here; a comment that wrong is what stops the next reader looking.

## The fix — one rule, one place

`_wait_ops(spool_dir, op, n)` / `_wait_payload(spool_dir, op)` wait for and return the first N events whose payload op matches, so a foreign row is walked **past** rather than indexed **into**.

This is the positional sibling of the **count** problem `_wait_events`'s own docstring already describes: that one waits for the wrong *number*, this one reads the wrong *row*. Both are `until=`.

Migrated the three sites that have actually failed:

- `test_frames_telemetry_metadata_only` → `_wait_payload(…, "frames")`
- `test_type_telemetry_no_typed_text` → `_wait_payload(…, "type")`
- `test_an_absent_origin_header_is_not_the_same_as_an_empty_one` → `_wait_ops(…, "tabs", 2)`. Both rows there are `tabs` and their **order** is the signal, so order is preserved; only foreign rows are excluded.

`test_the_throttle_path_…` was already migrated by the earlier round that added `until=`.

## Verification — read the second bullet, it bounds the claim

- **`test_a_neighbours_late_row_does_not_become_this_tests_event`** plants a neighbour's row as a v1 spool line, then asserts the fix finds the test's **own** event. It carries its **control in the same body**: the old idiom must return `getHtml`, and the spool must hold ≥2 rows — otherwise the test is measuring an uncontested spool and pinning nothing. Planted rather than raced on purpose: the defect is *"a row this test did not cause is present"*, and planting makes it deterministic instead of load-dependent, which was the whole complaint about the original.
- 🔴 **The three call-site migrations are NOT individually pinned.** Mutating the helper back to positional indexing kills the new test and leaves all three of them **green** — nothing plants a foreign row in their bodies. Only the **helper's** behaviour is covered. Stated rather than implied.
- Full `scripts/browser-bridge/tests`: **784 passed**.

## Not done, counted rather than hand-waved

**47** further call sites in this module still take a count and index by position. Each is a latent instance of the same defect, safe only while no neighbour is late. Migrating them is mechanical and belongs in its own change.

Closing the root cause *properly* means joining every emitter thread at teardown so the global env var cannot be re-pointed out from under a live writer. That is larger than this, and #783 should stay open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpMxc3NpzvbcP4ZUWh8pe4
