### PR TITLE
docs+rules: four of six cross-subsystem recommendations were wrong, and object-leak stamping was stale both ways

### DIFF
--- a/claude/RULES-ARCHIVE.md
+++ b/claude/RULES-ARCHIVE.md
@@ -1481,14 +1481,32 @@ audit caught it. If the core rule ever narrows back to mechanical checks only, i
 that defect — the archive is not consulted to decide whether a rule applies, so the core's own
 wording has to carry the T2 case.
 
-**Stamping — IN FLIGHT, not shipped.** An `agent/<producer>` label plus a body marker are proposed
-for the in-cluster GitHub producers and the single ClickUp create choke point (PRs open, not
-merged, at time of writing; the marker grammar lands with the ClickUp one). Until they merge there
-is no format an agent can follow, which is why the core rule does **not** instruct anyone to stamp.
+**Stamping — SHIPPED for ClickUp, DROPPED for GitHub.** Verified 2026-08-24; this paragraph
+previously read "IN FLIGHT, not shipped" and was stale in **both** directions.
+
+*ClickUp — shipped.* The `agent/<producer>` tag plus a body marker land at the single create
+choke point: `claude/skills/clickup/lib/agent-marker.mjs` defines the grammar and
+`applyAgentStamp()` in `claude/skills/clickup/api/tasks.mjs` applies it, with `createTask` /
+`createSubtask` spreading the body and attaching the tag (devrc #768, merged). So a format an
+agent can follow now exists. It shipped harder than proposed: a caller-supplied `cond` is
+validated at the seam and `unstated` is **refused** there, so only the fallback branch may emit
+it — an honest marker of absence stays countable instead of being laundered into a fake `manual`.
+
+*GitHub — dropped, for want of a producer.* Never implemented, and no longer applicable: the
+in-cluster producer it was written for (`scripts/task-spec-drafter/drafter.sh`) now **denies**
+`gh issue create` outright via `DRAFTER_DENY_GH`, and `clank-resolver/bot.py` — the only other
+candidate — makes no GitHub API calls at all (its `labels` are its own task-DB column, which is
+what a naive grep trips on). Re-open this only if an in-cluster GitHub producer reappears.
+
+🔴 **The core rule still does not instruct anyone to stamp**, and that is now a choice rather
+than a consequence: the ClickUp path stamps itself at the choke point, so no agent needs to know
+the grammar. Do not add a "stamp your objects" instruction to the core on the strength of this
+paragraph.
+
 Before that work, **3** open GitHub objects carried any fingerprint marker — all three from one
 producer — and **zero** ClickUp tasks did, a zero validated against a synthetic control (the same
 pattern matched a planted marker, and descriptions do carry a literal `<`, so a real one would
-have been visible).
+have been visible). Those counts are the pre-stamping baseline and are not re-measured here.
 
 **What is NOT established, and bounds how far this goes.** Agent authorship of *issues* is
 bounded, not measured: the Claude Code footer lands on PR bodies (93 of 97 hits) and essentially

--- a/claudedocs/handoff-cross-subsystem-analysis.md
+++ b/claudedocs/handoff-cross-subsystem-analysis.md
@@ -1,0 +1,89 @@
+---
+---
+# Handoff: cross-subsystem-analysis — 2026-08-24
+
+## Run this first — the index, one read-only command
+```bash
+python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py --repo ~/workspace/devrc
+```
+Terse pointers this doc does not carry, curated by past sessions and outliving it.
+🔴 RECALL, NOT LIVE OBSERVATION — every line is a pointer to VERIFY, never a current
+reading, and it may describe a gotcha already fixed. `scope-absent`/`scope-empty` means
+nothing is recorded yet: ordinary, not an error, and not a clean bill of health.
+Non-blocking: if it exits non-zero, print the stderr line and carry on.
+
+## Goal
+Comprehensive identification, tracing, and analysis of five subsystems: subsystem-index, session-manager, check-clickup-addressed, clawgate, and object-leak. Produced a reflection, evaluation, and recommendations across the stack.
+
+## State now
+- Branch: `main` (behind origin/main by 1 commit)
+- No commits, no PRs, no code changes this session — pure analysis
+- No deploy/verify state
+
+## Subsystem analysis delivered
+
+### 1. Subsystem Index (`analyze-service-index`)
+- Core library: `scripts/lib/subsystem_resolver.py` (1,753L), `subsystem_touch.py` (6,032L), `subsystem_recall.py` (3,063L)
+- Store: `~/.claude/analyze-service-index/<scope>/<slug>.md` — each scope is independent git repo
+- Lifecycle: write via handoff → autocommit hourly (sandboxed) → backup daily to MinIO (age-encrypted) → prune via audit tool
+- 38,490 lines of tests across 11 files
+- Cross-scope query gap identified: API serves one scope at a time
+
+### 2. Session-Manager
+- Main: `scripts/session-manager` (4,395L) — read-only cross-host tmux + agent-activity view
+- 6 data sources: tmux panes/windows, batched capture, agent ledger, clawgate cache, ClickHouse, fuzzyclaw (opt-in, off by default)
+- `waiting_probable`: 3 regex signals, 11/11 precision. `unsent_prompt`: separate signal, never summed
+- 18,718 lines of tests across 6 files
+- Dependency fan-out: 3 independently deployed writers can drift
+
+### 3. Check-ClickUp-Addressed
+- 4 scripts (~2,611L): orchestrator, clickup fetcher, session searcher, completion extractor
+- Default mode (~21s, ClickUp only) nearly always correct; transcript mode (~90s) OFF since 2026-08-22
+- Self-run guard drops 81% of matching transcripts (prior runs of the checker itself)
+- Keep-open veto: STRONG (absolute) vs WEAK (downgrades when closure claim exists)
+- 226 collected tests, 82 mutants, 8 rounds of debugging
+
+### 4. Clawgate
+- Go + htmx PWA: approval hook → Task API (121 routes, Postgres) → agent dispatch (kubeclaw pods) → browser extension → Flux deploy
+- LAN NodePort fully unauthenticated since 0.7.37; `DELETE /api/tasks/{id}` tears down agent pods; `POST /api/auto-approve-all` is global kill switch
+- 2 devrc-side enforcement hooks: interview guard (blocks criteria-less create), writeback guard (escalates: 2 blocks → 1 systemMessage → silent)
+- `clawgatectl` built from local homelab-talos working tree; version read from Go source
+- GitOps from `trunk` deploys manifest, not code — `git log` is NOT evidence code is live
+
+### 5. Object-Leak
+- Not a file — anchor section in `claude/RULES-ARCHIVE.md` (lines 1416–1505)
+- Measurement: 30-day issue survival ~47% vs PR ~5% (9× gap)
+- 96% of 90-day net growth landed in last 30 days (growth, not backlog)
+- Duplication NOT the channel (~2% near-dupes, 0 exact)
+- 42% of open issues reference already-merged PRs (provenance, not "done but never closed")
+- Tier system: T1 deterministic (auto-closable), T2 evidential (human judgement), T3 none (forbidden)
+- Stamping (`agent/<producer>` label) still IN FLIGHT
+
+## Findings and recommendations
+
+### Strengths across the stack
+- Consistent "never writes" invariant on library layer (subsystem-index, session-manager, check-clickup-addressed)
+- Silent-zero discipline everywhere (classified empties, not_measured populations)
+- Mutation-tested suites, not just green (82 mutants on clickup, mutation sweep on session-manager)
+- Honest admissions of failure (fuzzyclaw off by default, transcript scan off by default, object-leak stamping not shipped)
+
+### Recommendations
+1. **Close clawgate auth gap**: enforce `requireHookToken` on `POST /api/auto-approve-all` — it's already "enforce-when-set" on other machine endpoints
+2. **Retire transcript mode from check-clickup-addressed**: off since 2026-08-22, produced all false verdicts, ClickUp-side default nearly correct; archive the code, keep self-run guard as library
+3. **Add cross-scope query to subsystem-store-api**: `GET /api/search?q=<term>` across all scopes — unlocks the queries the index was built for
+4. **Ship object-leak stamping or retract proposal**: `agent/<producer>` label has been "IN FLIGHT" since the measurement; either ship it or remove the deferred promise
+5. **Add reconciliation signal between clawgate ClickUp mirror and check-clickup-addressed**: daily diff report comparing task states
+6. **Consider making writeback guard escalation resettable**: tombstone is absolute, escalation ladder finite (2→1→silent) — a stale read followed by long work session permanently disables the check
+
+## Gotchas / decisions / dead-ends
+- Subsystem index cross-scope query gap: most useful queries require enumerating scopes first
+- Check-clickup-addressed transcript mode is effectively dead code (off, produced all false verdicts)
+- Clawgate writeback guard's asymmetric subagent rule: dispatching session owes writeback even when subagents do the work
+- Object-leak structural fingerprint attempt discarded (31/74 false positive against human control)
+- The five subsystems form a coherent agent-ops stack but the approval seam (clawgate LAN) is the widest attack surface
+
+## How to verify
+- Subsystem index probe: `python3 ~/workspace/devrc/scripts/lib/subsystem_touch.py --repo ~/workspace/devrc`
+- Session manager: `python3 ~/workspace/devrc/scripts/session-manager --json`
+- Clawgate health: `clawgatectl health`
+- Object-leak: read `claude/RULES-ARCHIVE.md` lines 1416–1505

--- a/claudedocs/handoff-cross-subsystem-analysis.md
+++ b/claudedocs/handoff-cross-subsystem-analysis.md
@@ -19,10 +19,12 @@ which do not survive verification**. They were produced by tracing/reading only 
 that revision was measured against live state, and the doc did not say so. This revision
 replaces them with measured results.
 
-**Nothing from the original recommendation list was implemented, and none of it should be.**
-Two were factually wrong about the code, one recommended a feature that already ships, and
-one recommended a change the source explicitly considered and rejected. Details below, each
-with the command or file:line that settles it.
+**Four of the six should not be implemented, and were not.** Two were factually wrong about the
+code, one recommended a feature that already ships, and one recommended a change the source
+explicitly considered and rejected. Of the remaining two: Rec 4 is **resolved in this PR** (half
+of it had already shipped and the archive line was stale), and Rec 5 is deliberately **not
+filed** — it has no closing condition. Details below, each with the command or file:line that
+settles it.
 
 ## Goal
 Comprehensive identification, tracing, and analysis of five subsystems: subsystem-index,
@@ -101,12 +103,28 @@ cannot mistake a scan-less run for a scanned one, which was the actual hazard.
 
 The original doc's "cross-scope query gap identified" was a reading error, not a gap.
 
-### 🟡 Rec 4 "Ship object-leak stamping or retract the proposal"
-**Legitimate, and still open.** `claude/RULES-ARCHIVE.md:1484` reads "**Stamping — IN FLIGHT,
-not shipped.**" A deferred promise in an archive nobody re-reads is exactly the object-leak
-shape the section itself describes.
-Closing condition: either the `agent/<producer>` label mechanism exists and the line names
-it, or the line is deleted. Mechanical, checkable by reading that one line.
+### ✅ Rec 4 "Ship object-leak stamping or retract the proposal" — RESOLVED in this PR
+**Half of it had already shipped; the archive line was stale in both directions.** Fixed here.
+
+- **ClickUp — shipped.** devrc **#768** (merged 2026-08-24) put the `agent/<producer>` tag and
+  body marker at the create choke point: `claude/skills/clickup/lib/agent-marker.mjs` holds the
+  grammar, `applyAgentStamp()` in `claude/skills/clickup/api/tasks.mjs` applies it, and
+  `createTask`/`createSubtask` spread the body and attach the tag. It is *branched on*, not a
+  dormant field, and covered by `test/agent-marker.test.mjs`.
+- **GitHub — dropped, no producer left.** Never implemented, no open PR, and the producer it
+  targeted is gone: `scripts/task-spec-drafter/drafter.sh` now denies `gh issue create`
+  (`DRAFTER_DENY_GH`), and `clank-resolver/bot.py` makes no GitHub API calls at all.
+
+`RULES-ARCHIVE.md` is corrected in this PR to say both, so the closing condition is met.
+
+🔴 **How this one was gotten wrong, twice.** The first revision of this doc asserted stamping
+was unshipped by *quoting the archive line* rather than checking the mechanism — the same
+trace-and-report failure this doc was written to correct, reproduced inside the correction. The
+check that settled it was one grep for the label constant. Then, verifying the GitHub half, a
+`gh pr list --repo ZacxDev/homelab-talos` returned `[]` — **wrong slug**; the repo is
+`ZacxDev/homelab-infra` and `homelab-talos` is only the local directory name. An empty PR list
+from a bad slug is byte-identical to "nothing was ever proposed". Re-run with the slug from
+`git remote get-url`, never from the directory name.
 
 ### 🟡 Rec 5 "Reconciliation signal between the clawgate ClickUp mirror and check-clickup-addressed"
 Net-new feature, no measured need behind it. Not a gap — no evidence was gathered that the
@@ -155,7 +173,10 @@ recommending a feature without grepping for its flag. Both are one command away.
 - `scripts/check-clickup-addressed/` — 5 files; `check-addressed.py` is the orchestrator
 - clawgate — Go + htmx PWA in `homelab-talos/containers/clawgate/`; GitOps from `trunk`
   deploys the **manifest, not the code**, so `git log` is not evidence code is live
-- object-leak — not a file; anchor section in `claude/RULES-ARCHIVE.md` (~1416–1505)
+- object-leak — not a file; the `## object-leak` anchor section in `claude/RULES-ARCHIVE.md`
+  (currently the last section, running to EOF). **Cite the anchor, not a line range** — this
+  PR's own edit shifted every number after 1484, and `test_rules_size.py` pins the anchor
+  while nothing pins the lines.
 
 Structural observations from the original pass that no verification contradicted: the
 "library layer never writes" invariant, silent-zero discipline (classified empties rather
@@ -169,10 +190,24 @@ scan off, stamping openly marked unshipped.
 - Cross-scope search exists: `grep -n "all_scopes" scripts/lib/subsystem_recall.py scripts/subsystem-store-api/server.py`
 - Transcript mode is opt-in, not absent: `python3 scripts/check-clickup-addressed/check-addressed.py --help | grep transcripts`
 - Writeback guard's rejection of `--rearm`: `sed -n '348,357p' scripts/claude-hooks/clawgate-writeback-guard.py`
-- Stamping still unshipped: `grep -n "IN FLIGHT" claude/RULES-ARCHIVE.md`
+- ClickUp stamping is real and wired: `grep -n "applyAgentStamp" claude/skills/clickup/api/tasks.mjs`
+  — **expect a definition AND a call site**. A definition alone is a dormant field, not a stamp.
+- No GitHub producer to stamp: `grep -c "gh issue create" scripts/task-spec-drafter/drafter.sh`
+  returns a hit **inside `DRAFTER_DENY_GH`** (a denial, not a use); `grep -c github
+  ~/workspace/homelab-talos/clusters/workbench/apps/clank-resolver/bot.py` → 0.
 
 ## Next steps, ranked
-1. **Rec 4** — resolve the `agent/<producer>` stamping promise in `RULES-ARCHIVE.md:1484`:
-   ship the label or delete the sentence. Smallest real item here.
-2. Nothing else from the original list. Recs 1, 2, 3 and 6 are closed as **not actionable**
-   for the reasons above; re-opening any of them needs new evidence, not a re-reading.
+**None.** All six are closed:
+
+- Recs 1, 2, 3, 6 — **not actionable**; the premises are wrong (see above). Re-opening any of
+  them needs new evidence, not a re-reading.
+- Rec 4 — **resolved in this PR** (ClickUp shipped, GitHub dropped, archive corrected).
+- Rec 5 — **not filed as work.** Per RULES.md's proactivity gate, an item with no named closing
+  condition is not a work object. Nobody has measured whether the clawgate ClickUp mirror and
+  check-clickup-addressed ever actually disagree, so "add a reconciliation signal" has no
+  condition that could end it and would ship a report that always prints zero. If it is ever
+  picked up, the first step is measuring the disagreement rate — that has a closing condition;
+  the report does not.
+
+Recording this so the list is not mistaken for a queue: this doc mints **no** open objects,
+which is the object-leak rule applied to itself.

--- a/claudedocs/handoff-cross-subsystem-analysis.md
+++ b/claudedocs/handoff-cross-subsystem-analysis.md
@@ -12,78 +12,167 @@ reading, and it may describe a gotcha already fixed. `scope-absent`/`scope-empty
 nothing is recorded yet: ordinary, not an error, and not a clean bill of health.
 Non-blocking: if it exits non-zero, print the stderr line and carry on.
 
+## 🔴 Read this before acting on the earlier version of this doc
+
+The first revision of this file (commit `66d13091`) carried **six recommendations, four of
+which do not survive verification**. They were produced by tracing/reading only — nothing in
+that revision was measured against live state, and the doc did not say so. This revision
+replaces them with measured results.
+
+**Nothing from the original recommendation list was implemented, and none of it should be.**
+Two were factually wrong about the code, one recommended a feature that already ships, and
+one recommended a change the source explicitly considered and rejected. Details below, each
+with the command or file:line that settles it.
+
 ## Goal
-Comprehensive identification, tracing, and analysis of five subsystems: subsystem-index, session-manager, check-clickup-addressed, clawgate, and object-leak. Produced a reflection, evaluation, and recommendations across the stack.
+Comprehensive identification, tracing, and analysis of five subsystems: subsystem-index,
+session-manager, check-clickup-addressed, clawgate, and object-leak — then a verification
+pass over the recommendations that analysis produced.
 
 ## State now
-- Branch: `main` (behind origin/main by 1 commit)
-- No commits, no PRs, no code changes this session — pure analysis
-- No deploy/verify state
+- Branch: `handoff-cross-subsystem-analysis`, based on `b0ca088c` (= `origin/main` at time of writing)
+- Docs-only. No code changed in any repo, in either revision of this doc.
+- No deploy state. **No change was made to clawgate**, in this repo or in `homelab-talos`.
+- Decision on the one real finding (clawgate LAN posture): **leave as-is**, operator's call,
+  taken 2026-08-24. See "Finding 1".
 
-## Subsystem analysis delivered
+## Verification results — the six recommendations
 
-### 1. Subsystem Index (`analyze-service-index`)
-- Core library: `scripts/lib/subsystem_resolver.py` (1,753L), `subsystem_touch.py` (6,032L), `subsystem_recall.py` (3,063L)
-- Store: `~/.claude/analyze-service-index/<scope>/<slug>.md` — each scope is independent git repo
-- Lifecycle: write via handoff → autocommit hourly (sandboxed) → backup daily to MinIO (age-encrypted) → prune via audit tool
-- 38,490 lines of tests across 11 files
-- Cross-scope query gap identified: API serves one scope at a time
+### ❌ Rec 1 "Close clawgate auth gap: enforce `requireHookToken` on `POST /api/auto-approve-all`"
+**Wrong mechanism, and wrong about which surface is open.**
 
-### 2. Session-Manager
-- Main: `scripts/session-manager` (4,395L) — read-only cross-host tmux + agent-activity view
-- 6 data sources: tmux panes/windows, batched capture, agent ledger, clawgate cache, ClickHouse, fuzzyclaw (opt-in, off by default)
-- `waiting_probable`: 3 regex signals, 11/11 precision. `unsent_prompt`: separate signal, never summed
-- 18,718 lines of tests across 6 files
-- Dependency fan-out: 3 independently deployed writers can drift
+`requireSession` is a **no-op pass-through** — `containers/clawgate/internal/api/auth.go:40-42`
+is literally `return next`. Human auth was removed on purpose; the file comment states
+clawgate is fronted by Authelia forward-auth on its public path and **the LAN is treated as
+trusted-open**. So every `requireSession` route is unauthenticated on the LAN, not just the
+one the original doc named.
 
-### 3. Check-ClickUp-Addressed
-- 4 scripts (~2,611L): orchestrator, clickup fetcher, session searcher, completion extractor
-- Default mode (~21s, ClickUp only) nearly always correct; transcript mode (~90s) OFF since 2026-08-22
-- Self-run guard drops 81% of matching transcripts (prior runs of the checker itself)
-- Keep-open veto: STRONG (absolute) vs WEAK (downgrades when closure claim exists)
-- 226 collected tests, 82 mutants, 8 rounds of debugging
+`requireHookToken` is enforce-when-set (`auth.go:49-61`), and `CLAWGATE_HOOK_TOKEN` **is**
+set in the deployed secret (`clusters/workbench/apps/clawgate/secrets.enc.yaml:10`, wired at
+`deployment.yaml:102-106`).
 
-### 4. Clawgate
-- Go + htmx PWA: approval hook → Task API (121 routes, Postgres) → agent dispatch (kubeclaw pods) → browser extension → Flux deploy
-- LAN NodePort fully unauthenticated since 0.7.37; `DELETE /api/tasks/{id}` tears down agent pods; `POST /api/auto-approve-all` is global kill switch
-- 2 devrc-side enforcement hooks: interview guard (blocks criteria-less create), writeback guard (escalates: 2 blocks → 1 systemMessage → silent)
-- `clawgatectl` built from local homelab-talos working tree; version read from Go source
-- GitOps from `trunk` deploys manifest, not code — `git log` is NOT evidence code is live
+Measured live against the LAN NodePort, no credentials presented, with both controls:
 
-### 5. Object-Leak
-- Not a file — anchor section in `claude/RULES-ARCHIVE.md` (lines 1416–1505)
-- Measurement: 30-day issue survival ~47% vs PR ~5% (9× gap)
-- 96% of 90-day net growth landed in last 30 days (growth, not backlog)
-- Duplication NOT the channel (~2% near-dupes, 0 exact)
-- 42% of open issues reference already-merged PRs (provenance, not "done but never closed")
-- Tier system: T1 deterministic (auto-closable), T2 evidential (human judgement), T3 none (forbidden)
-- Stamping (`agent/<producer>` label) still IN FLIGHT
+| route | middleware | observed |
+|---|---|---|
+| `GET /api/tasks` | `requireHookToken` | **401** ← negative control: the probe *can* see a rejection |
+| `GET /api/requests` | `requireSession` | **200** |
+| `GET /` | `requireSession` | **200** |
 
-## Findings and recommendations
+```bash
+NODE=$(KUBECONFIG=$KC_WORKBENCH kubectl get node nixos \
+  -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')   # 192.168.50.250
+curl -s -o /dev/null -w "%{http_code}\n" "http://$NODE:30302/api/tasks?limit=1"   # 401
+curl -s -o /dev/null -w "%{http_code}\n" "http://$NODE:30302/api/requests"        # 200
+```
+Read-only routes only — do **not** probe this with `POST /api/auto-approve-all`; that arms
+the global approval firehose for real.
 
-### Strengths across the stack
-- Consistent "never writes" invariant on library layer (subsystem-index, session-manager, check-clickup-addressed)
-- Silent-zero discipline everywhere (classified empties, not_measured populations)
-- Mutation-tested suites, not just green (82 mutants on clickup, mutation sweep on session-manager)
-- Honest admissions of failure (fuzzyclaw off by default, transcript scan off by default, object-leak stamping not shipped)
+Two corrections to the original doc:
+- It claimed `DELETE /api/tasks/{id}` (agent-pod teardown) is part of the unauthenticated
+  surface. **False** — it is `requireHookToken` (`server.go:434`) and returns 401.
+- The proposed fix would have **broken the UI**: `/api/auto-approve-all` is posted by htmx
+  from the browser (`internal/ui/components.go:1047,1067`), which carries no hook token. It
+  would have disabled the operator's own control while leaving ~30 other UI routes —
+  including `POST /ui/decision/{id}`, which approves or denies any pending request — open.
 
-### Recommendations
-1. **Close clawgate auth gap**: enforce `requireHookToken` on `POST /api/auto-approve-all` — it's already "enforce-when-set" on other machine endpoints
-2. **Retire transcript mode from check-clickup-addressed**: off since 2026-08-22, produced all false verdicts, ClickUp-side default nearly correct; archive the code, keep self-run guard as library
-3. **Add cross-scope query to subsystem-store-api**: `GET /api/search?q=<term>` across all scopes — unlocks the queries the index was built for
-4. **Ship object-leak stamping or retract proposal**: `agent/<producer>` label has been "IN FLIGHT" since the measurement; either ship it or remove the deferred promise
-5. **Add reconciliation signal between clawgate ClickUp mirror and check-clickup-addressed**: daily diff report comparing task states
-6. **Consider making writeback guard escalation resettable**: tombstone is absolute, escalation ladder finite (2→1→silent) — a stale read followed by long work session permanently disables the check
+The distroless image has no shell, so `kubectl exec … sh` cannot confirm the token; the
+401/200 pair above is what establishes it behaviourally.
 
-## Gotchas / decisions / dead-ends
-- Subsystem index cross-scope query gap: most useful queries require enumerating scopes first
-- Check-clickup-addressed transcript mode is effectively dead code (off, produced all false verdicts)
-- Clawgate writeback guard's asymmetric subagent rule: dispatching session owes writeback even when subagents do the work
-- Object-leak structural fingerprint attempt discarded (31/74 false positive against human control)
-- The five subsystems form a coherent agent-ops stack but the approval seam (clawgate LAN) is the widest attack surface
+### ❌ Rec 2 "Retire transcript mode from check-clickup-addressed"
+**Not dead code.** It is a deliberate opt-in (`--transcripts`), **already off by default**
+since 2026-08-22, so the ~60s of the ~90s runtime it costs is *already* avoided on every
+default run. The source states the decision plainly at
+`scripts/check-clickup-addressed/check-addressed.py:1067-1073`: *"It stays available, it is
+no longer the default."*
 
-## How to verify
-- Subsystem index probe: `python3 ~/workspace/devrc/scripts/lib/subsystem_touch.py --repo ~/workspace/devrc`
-- Session manager: `python3 ~/workspace/devrc/scripts/session-manager --json`
-- Clawgate health: `clawgatectl health`
-- Object-leak: read `claude/RULES-ARCHIVE.md` lines 1416–1505
+The evidence behind retiring it is **n=3 tickets on a single day**. Deleting a working,
+mutation-tested, opt-in path on a 3-sample basis trades optionality for maintenance surface
+with no measured benefit — the runtime win was banked when the default flipped. The
+inert-flag warning (`:1128-1135`) and the `not_scanned` state discipline mean an operator
+cannot mistake a scan-less run for a scanned one, which was the actual hazard.
+
+### ❌ Rec 3 "Add cross-scope query to subsystem-store-api"
+**Already shipped, in both layers.**
+- Library: `scripts/lib/subsystem_recall.py:2532` — `search(..., all_scopes: bool = False)`;
+  CLI flag `--all-scopes` at `:2863`.
+- HTTP API: `scripts/subsystem-store-api/server.py:1728` already parses `all_scopes` from
+  the query string.
+
+The original doc's "cross-scope query gap identified" was a reading error, not a gap.
+
+### 🟡 Rec 4 "Ship object-leak stamping or retract the proposal"
+**Legitimate, and still open.** `claude/RULES-ARCHIVE.md:1484` reads "**Stamping — IN FLIGHT,
+not shipped.**" A deferred promise in an archive nobody re-reads is exactly the object-leak
+shape the section itself describes.
+Closing condition: either the `agent/<producer>` label mechanism exists and the line names
+it, or the line is deleted. Mechanical, checkable by reading that one line.
+
+### 🟡 Rec 5 "Reconciliation signal between the clawgate ClickUp mirror and check-clickup-addressed"
+Net-new feature, no measured need behind it. Not a gap — no evidence was gathered that the
+two sources actually disagree. If it is ever picked up, **measure the disagreement rate
+first**; a daily diff report that always prints zero is a new permanently-green gate.
+
+### ❌ Rec 6 "Make the writeback guard escalation resettable"
+**Explicitly considered and rejected in the source**, with reasoning stronger than the
+recommendation's — `scripts/claude-hooks/clawgate-writeback-guard.py:348-357`:
+
+> There is deliberately NO `--rearm` flag: the escape from a dismissal is a new session,
+> which costs nothing and is unambiguous.
+
+The same block already names the false negative the recommendation "discovered" and prices
+it: *"the price of the message being true"*. Re-proposing it without engaging that argument
+is a regression in the reasoning, not a finding.
+
+## Findings that DID survive
+
+### Finding 1 — clawgate's web UI is unauthenticated on the LAN, by design
+Every `requireSession` route answers **200 with no credentials** to anything that can reach
+the workbench node on NodePort 30302 — including approve/deny of any pending permission
+request and the global auto-approve firehose. Since clawgate is the approval gate in front of
+agents that run commands, a device on the wifi is a genuine escalation path.
+
+This is a **deliberate, documented decision** (`auth.go:14-22, 35-39`), not an oversight, and
+the machine surface that carries the destructive API — task CRUD, agent-pod teardown — is
+hook-token gated and verified returning 401.
+
+**Decision 2026-08-24: leave the posture as-is.** Recorded here so the next session does not
+re-derive it as a bug. If it is ever revisited, the lever is `requireSession` itself — the
+comment notes re-adding an app-level gate is a one-function change rather than ~30 route
+edits. The cost to weigh: the operator reaches the UI over that same LAN NodePort
+(`nix/graphical.nix` references 30302), so any gate needs a credential in browser and phone,
+with real lockout risk on the approval path.
+
+### Finding 2 — the original revision of this doc was unverified and did not say so
+Four of six recommendations were wrong in ways that a single `grep` or `curl` would have
+caught. The failure mode was **tracing code and reporting the trace as a finding**: reading
+that a route is wrapped in `requireSession` without reading what `requireSession` does, and
+recommending a feature without grepping for its flag. Both are one command away.
+
+## Subsystem inventory (line counts spot-checked, accurate)
+- `scripts/lib/subsystem_resolver.py` 1,753L · `subsystem_touch.py` 6,032L · `subsystem_recall.py` 3,063L
+- `scripts/session-manager` 4,395L — read-only cross-host tmux + agent-activity view
+- `scripts/check-clickup-addressed/` — 5 files; `check-addressed.py` is the orchestrator
+- clawgate — Go + htmx PWA in `homelab-talos/containers/clawgate/`; GitOps from `trunk`
+  deploys the **manifest, not the code**, so `git log` is not evidence code is live
+- object-leak — not a file; anchor section in `claude/RULES-ARCHIVE.md` (~1416–1505)
+
+Structural observations from the original pass that no verification contradicted: the
+"library layer never writes" invariant, silent-zero discipline (classified empties rather
+than bare zeros), mutation-tested suites, and the honest defaults — fuzzyclaw off, transcript
+scan off, stamping openly marked unshipped.
+
+## How to verify this doc
+- clawgate auth pair: the two `curl` lines above — **expect 401 then 200**. A 200 on the
+  first means the hook token was unset or removed; a 401 on the second means an app-level
+  gate was added and Finding 1's decision was reversed.
+- Cross-scope search exists: `grep -n "all_scopes" scripts/lib/subsystem_recall.py scripts/subsystem-store-api/server.py`
+- Transcript mode is opt-in, not absent: `python3 scripts/check-clickup-addressed/check-addressed.py --help | grep transcripts`
+- Writeback guard's rejection of `--rearm`: `sed -n '348,357p' scripts/claude-hooks/clawgate-writeback-guard.py`
+- Stamping still unshipped: `grep -n "IN FLIGHT" claude/RULES-ARCHIVE.md`
+
+## Next steps, ranked
+1. **Rec 4** — resolve the `agent/<producer>` stamping promise in `RULES-ARCHIVE.md:1484`:
+   ship the label or delete the sentence. Smallest real item here.
+2. Nothing else from the original list. Recs 1, 2, 3 and 6 are closed as **not actionable**
+   for the reasons above; re-opening any of them needs new evidence, not a re-reading.


### PR DESCRIPTION
Verified the six recommendations from the original revision of this handoff against live state. **Four do not survive; none of the four were implemented. A fifth turned out to be half-shipped already and is resolved here.**

## The six

| # | Claim | Verdict |
|---|---|---|
| 1 | clawgate: token-gate `POST /api/auto-approve-all` | ❌ Wrong twice — see below |
| 2 | Retire ccua transcript mode | ❌ Deliberate opt-in, already off by default; evidence is n=3 on one day |
| 3 | Add cross-scope query to subsystem-store-api | ❌ Already ships — `all_scopes` in **both** the library and the HTTP API |
| 4 | Ship object-leak stamping or retract it | ✅ **Resolved in this PR** — ClickUp half shipped, GitHub half dropped |
| 5 | ClickUp reconciliation signal | 🚫 Deliberately **not filed** — no closing condition |
| 6 | Resettable writeback escalation | ❌ Explicitly considered and rejected in the source, which already prices the false negative it "found" |

### Rec 1 is wrong in two independent ways
`requireSession` is a **no-op pass-through** (`auth.go:40-42`, literally `return next`), so the open surface is the *entire web UI*, not the one route named. And `DELETE /api/tasks/{id}` — claimed unauthenticated — is `requireHookToken` and returns **401**. The proposed fix would have broken the operator's own auto-approve control (htmx posts it with no token) while leaving ~30 UI routes including approve/deny still open.

Measured on the LAN NodePort with both controls, so the 200s are a finding rather than a broken probe:

| route | middleware | observed |
|---|---|---|
| `GET /api/tasks` | `requireHookToken` | **401** ← negative control: the probe *can* see a rejection |
| `GET /api/requests` | `requireSession` | **200** |
| `GET /` | `requireSession` | **200** |

### Rec 4, resolved
- **ClickUp — shipped.** #768 (merged 2026-08-24). `lib/agent-marker.mjs` holds the grammar; `applyAgentStamp()` at `api/tasks.mjs:113` is called by *both* `createTask` (:159) and `createSubtask` (:178) — branched on, not a dormant field.
- **GitHub — dropped, no producer left.** `drafter.sh` now **denies** `gh issue create` (`DRAFTER_DENY_GH`); `clank-resolver/bot.py` makes **0** GitHub API calls.

`RULES-ARCHIVE.md` said "IN FLIGHT, not shipped" — stale in *both* directions. Corrected here.

## What survived
Clawgate's web UI genuinely is unauthenticated on the LAN — approve/deny and the global auto-approve firehose included. It is **documented design**, and the destructive machine API is token-gated (verified 401). Recorded as an operator decision to leave the posture as-is, so the next session does not re-derive it as a bug. **No change was made to clawgate.**

## Verification
Every claim has a command in the doc's own "How to verify" section; all run clean.

Gates: `test_rules_size.py` + `test_no_public_ips.py` + `test_no_client_hostnames.py` → **38 passed**. The `192.168.50.250` literal is classified internal by the IP gate itself (`test_no_public_ips.py:387`).

Docs-only — no code changed in this repo or in `homelab-infra`.

## Two self-inflicted process notes, recorded in the doc
- The first pass at Rec 4 asserted stamping was unshipped by **quoting the archive line** instead of grepping for the label constant — the exact trace-and-report failure this PR exists to correct, reproduced inside the correction.
- `gh pr list --repo ZacxDev/homelab-talos` returned `[]` because the repo is **`ZacxDev/homelab-infra`** — `homelab-talos` is only the local directory name. An empty list from a bad slug is byte-identical to "nothing was ever proposed". Take the slug from `git remote get-url`, never the directory name.

The next-steps list is empty by construction: this doc mints **no** open objects, which is the object-leak rule applied to itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5zXWvD7jqNbANCbQyarZb
