### PR TITLE
fix(base-clone hook): a path DELETED upstream was reported FAILED forever and never removed

### DIFF
--- a/scripts/claude-hooks/base-clone-staleness.sh
+++ b/scripts/claude-hooks/base-clone-staleness.sh
@@ -55,7 +55,7 @@ BEHIND="$(git -C "$ROOT" rev-list --count "HEAD..$UP" 2>/dev/null || echo 0)"
 # just not listed.
 DIFFERING="$(git -C "$ROOT" diff --name-only "$UP" -- "${REFRESH_PATHS[@]}" 2>/dev/null || true)"
 
-refreshed=(); skipped=(); optout=(); failed=(); approved=()
+refreshed=(); skipped=(); optout=(); failed=(); approved=(); pruned=(); to_prune=()
 
 if [ -n "$DIFFERING" ]; then
   while IFS= read -r p; do
@@ -76,6 +76,7 @@ if [ -n "$DIFFERING" ]; then
     # idempotence test that re-runs without upstream moving in between -- the
     # second refresh only breaks once the file goes stale AGAIN.
     known=no
+    deleted=no
     if [ ! -e "$ROOT/$p" ]; then
       # NEW UPSTREAM: the path does not exist here at all, so there is no local
       # content to protect and the checkout below CREATES it.
@@ -90,16 +91,37 @@ if [ -n "$DIFFERING" ]; then
     elif ! cur="$(git -C "$ROOT" hash-object "$p" 2>/dev/null)" || [ -z "$cur" ]; then
       failed+=("$p")
       continue
-    elif [ "$cur" = "$(git -C "$ROOT" rev-parse "HEAD:$p" 2>/dev/null || echo none)" ]; then
-      known=yes
     else
-      while IFS= read -r c; do
-        [ -n "$c" ] || continue
-        if [ "$cur" = "$(git -C "$ROOT" rev-parse "$c:$p" 2>/dev/null || echo none)" ]; then
-          known=yes
-          break
-        fi
-      done < <(git -C "$ROOT" rev-list -n 100 "$UP" -- "$p" 2>/dev/null)
+      # DELETED UPSTREAM: present here, absent in $UP. `checkout $UP -- $p` cannot
+      # deliver a deletion -- the pathspec matches nothing there -- so both it and
+      # the retry fail and the path lands in FAILED, every session, forever. The
+      # file is then retained indefinitely and keeps loading into agent context.
+      #
+      # 🔴 This is the exact mirror of the ADDED-path bug fixed above, and it lands
+      # in the same wrong bucket. Measured 2026-08-24 on a datapacket-talos clone:
+      # `.claude/skills/check-clickup-addressed/` was removed upstream (the skill
+      # moved to devrc), and the clone went on serving a 437-line retired SKILL.md
+      # against the 562-line canonical one -- with .pytest_cache/ and __pycache__/
+      # underneath it, so it was being RUN from, not merely read. The hook reported
+      # those paths as FAILED on every session start and could never resolve them.
+      #
+      # Detected by ASKING UPSTREAM (`cat-file -e`), never by an exit code from a
+      # comparison: `git diff --quiet <ref> -- <p>` exits 0 when <p> is on neither
+      # side, which reads as a reassuring "same" for a file that is simply absent.
+      if ! git -C "$ROOT" cat-file -e "$UP:$p" 2>/dev/null; then
+        deleted=yes
+      fi
+      if [ "$cur" = "$(git -C "$ROOT" rev-parse "HEAD:$p" 2>/dev/null || echo none)" ]; then
+        known=yes
+      else
+        while IFS= read -r c; do
+          [ -n "$c" ] || continue
+          if [ "$cur" = "$(git -C "$ROOT" rev-parse "$c:$p" 2>/dev/null || echo none)" ]; then
+            known=yes
+            break
+          fi
+        done < <(git -C "$ROOT" rev-list -n 100 "$UP" -- "$p" 2>/dev/null)
+      fi
     fi
     if [ "$known" = no ]; then
       skipped+=("$p")
@@ -108,6 +130,11 @@ if [ -n "$DIFFERING" ]; then
 
     if [ "${BASE_CLONE_NO_REFRESH:-0}" = "1" ]; then
       optout+=("$p")
+      continue
+    fi
+
+    if [ "$deleted" = yes ]; then
+      to_prune+=("$p")
       continue
     fi
 
@@ -143,17 +170,51 @@ if [ "${#approved[@]}" -gt 0 ]; then
   fi
 fi
 
+# Deliver upstream DELETIONS. This is the only place the hook removes anything, and
+# it is deliberately the narrowest operation that can work:
+#   * `rm -f` on a single FILE, never `rm -r`, so a directory can never be destroyed
+#     even if a path were somehow wrong;
+#   * only paths git itself named, from a diff already restricted to REFRESH_PATHS;
+#   * only after the same recoverability test that protects an overwrite -- a local
+#     copy whose blob appears NOWHERE in upstream history is unique work and was
+#     already routed to `skipped` above, so it is never reached here;
+#   * `BASE_CLONE_NO_REFRESH=1` opts out of this exactly as it does a refresh.
+# 🔴 A `..` or absolute component would escape REFRESH_PATHS, so reject rather than
+# resolve it: git will not emit one, and if that ever changes this must fail loudly
+# rather than delete outside the tree.
+for p in "${to_prune[@]}"; do
+  case "$p" in
+    /*|*..*) failed+=("$p"); continue ;;
+  esac
+  if rm -f "$ROOT/$p" 2>/dev/null && [ ! -e "$ROOT/$p" ]; then
+    pruned+=("$p")
+    # `rmdir` removes ONLY empty directories, so this cannot destroy content. It
+    # stops a hollow `.claude/skills/<name>/` shell being left behind looking like
+    # a skill that is still installed.
+    d="$(dirname "$p")"
+    while [ "$d" != "." ] && [ "$d" != "/" ]; do
+      rmdir "$ROOT/$d" 2>/dev/null || break
+      d="$(dirname "$d")"
+    done
+  else
+    failed+=("$p")
+  fi
+done
+
 n_ref=${#refreshed[@]}; n_skip=${#skipped[@]}; n_opt=${#optout[@]}; n_fail=${#failed[@]}
+n_prune=${#pruned[@]}
 
 # Nothing to say when the clone is current. A banner that fires every time gets
 # ignored, which is the failure mode this hook exists to prevent.
-if [ "$BEHIND" -eq 0 ] && [ "$n_ref" -eq 0 ] && [ "$n_skip" -eq 0 ] && [ "$n_opt" -eq 0 ] && [ "$n_fail" -eq 0 ]; then
+if [ "$BEHIND" -eq 0 ] && [ "$n_ref" -eq 0 ] && [ "$n_skip" -eq 0 ] && [ "$n_opt" -eq 0 ] && [ "$n_fail" -eq 0 ] \
+   && [ "$n_prune" -eq 0 ]; then
   exit 0
 fi
 
 repo="$(basename "$ROOT")"
 msg="$repo is $BEHIND commit(s) behind $UP"
 [ "$n_ref" -gt 0 ] && msg="$msg | refreshed $n_ref context file(s)"
+[ "$n_prune" -gt 0 ] && msg="$msg | pruned $n_prune deleted upstream"
 [ "$n_skip" -gt 0 ] && msg="$msg | SKIPPED $n_skip (local edits)"
 [ "$n_opt" -gt 0 ] && msg="$msg | STALE $n_opt (refresh opted out)"
 [ "$n_fail" -gt 0 ] && msg="$msg | FAILED $n_fail"
@@ -166,6 +227,16 @@ if [ "$n_ref" -gt 0 ]; then
 - REFRESHED from $UP (these now match upstream, and will show as modified-vs-HEAD
   in git status -- that is this hook's doing, not stray WIP):
 $(printf '    %s\n' "${refreshed[@]}")"
+fi
+if [ "$n_prune" -gt 0 ]; then
+  ctx="$ctx
+- PRUNED: deleted upstream, so removed here too. Only the file was removed (never a
+  directory), only after confirming its content is recoverable from $UP's history,
+  and HEAD was not moved -- so these show as deleted-in-worktree in git status until
+  this clone's branch catches up. Nothing unique to this machine was touched.
+  If you were relying on one of these, it is GONE upstream on purpose -- find where
+  it moved rather than restoring it:
+$(printf '    %s\n' "${pruned[@]}")"
 fi
 if [ "$n_skip" -gt 0 ]; then
   ctx="$ctx

--- a/scripts/claude-hooks/base-clone-staleness.sh
+++ b/scripts/claude-hooks/base-clone-staleness.sh
@@ -116,9 +116,13 @@ if [ -n "$DIFFERING" ]; then
       # upstream NEVER HAD. So `deleted=yes` alone must never authorise a removal.
       #
       # The `HEAD:$p` shortcut below is what made that difference dangerous. For a
-      # REFRESH it is correct: matching HEAD means the file was never touched
-      # locally, so overwriting it with a newer upstream version loses nothing. For
-      # a PRUNE it proves only that the content is committed HERE -- which is
+      # REFRESH it is adequate: matching HEAD means there is no UNCOMMITTED local
+      # modification, so the content stays recoverable from HEAD after an overwrite.
+      # (Not "never touched locally" -- a locally COMMITTED CLAUDE.md does match HEAD
+      # and IS reverted in the worktree on every session start. Pre-existing, and
+      # recoverable, but do not restate the stronger claim: it is the exact reasoning
+      # that went wrong below.) For a PRUNE the shortcut proves only that the content
+      # is committed HERE -- and a removal is not recoverable from HEAD -- which is
       # exactly what a skill authored on this branch and not yet pushed looks like.
       # Left ungated it deleted: a locally-committed skill, a locally-committed
       # CLAUDE.md, and on a branch with no upstream (so `$UP` falls back to
@@ -212,7 +216,6 @@ fi
 for p in "${to_prune[@]:-}"; do
   [ -n "$p" ] || continue
   case "/$p/" in
-    /) failed+=("$p"); continue ;;
     */../*) failed+=("$p"); continue ;;
   esac
   case "$p" in
@@ -225,7 +228,11 @@ for p in "${to_prune[@]:-}"; do
     # destroy content -- an untracked sibling (build cache, local scratch) both
     # survives and stops the climb.
     #
-    # 🔴 Bounded at the REFRESH_PATHS roots. Unbounded it walked past its own scope:
+    # 🔴 Bounded at the REFRESH_PATHS roots by EXACT string compare, so a future
+    # entry must be spelled the way `dirname` yields it -- `.claude/skills`, not
+    # `.claude/skills/`. A future entry that is a NESTED FILE (`docs/AGENTS.md`)
+    # would bound at the file and leave its parent directory climbable; the current
+    # two-entry list has no such case. Unbounded it walked past its own scope:
     # on a repo whose only skill was deleted upstream it removed `.claude/skills`
     # AND `.claude` -- empty and harmless, but `.claude` is not a path this hook is
     # allowed to touch, and anything probing `[ -d .claude ]` would see it vanish.

--- a/scripts/claude-hooks/base-clone-staleness.sh
+++ b/scripts/claude-hooks/base-clone-staleness.sh
@@ -111,7 +111,26 @@ if [ -n "$DIFFERING" ]; then
       if ! git -C "$ROOT" cat-file -e "$UP:$p" 2>/dev/null; then
         deleted=yes
       fi
-      if [ "$cur" = "$(git -C "$ROOT" rev-parse "HEAD:$p" 2>/dev/null || echo none)" ]; then
+      # 🔴 `cat-file -e` answers "is this path ABSENT upstream", which is NOT the
+      # same question as "was it DELETED upstream" -- they differ for a path
+      # upstream NEVER HAD. So `deleted=yes` alone must never authorise a removal.
+      #
+      # The `HEAD:$p` shortcut below is what made that difference dangerous. For a
+      # REFRESH it is correct: matching HEAD means the file was never touched
+      # locally, so overwriting it with a newer upstream version loses nothing. For
+      # a PRUNE it proves only that the content is committed HERE -- which is
+      # exactly what a skill authored on this branch and not yet pushed looks like.
+      # Left ungated it deleted: a locally-committed skill, a locally-committed
+      # CLAUDE.md, and on a branch with no upstream (so `$UP` falls back to
+      # `origin/HEAD`) every `.claude/skills/**` file the branch adds -- re-deleting
+      # them on every session, while the report said "GONE upstream on purpose ...
+      # find where it moved rather than restoring it". Caught in review, 2026-08-24.
+      #
+      # So a prune must clear the HIGHER bar: the blob has to appear in $UP's own
+      # history FOR THIS PATH. A never-upstream path has no such history (the
+      # rev-list below yields nothing), so it stays `known=no` and is protected.
+      if [ "$deleted" = no ] \
+         && [ "$cur" = "$(git -C "$ROOT" rev-parse "HEAD:$p" 2>/dev/null || echo none)" ]; then
         known=yes
       else
         while IFS= read -r c; do
@@ -170,29 +189,53 @@ if [ "${#approved[@]}" -gt 0 ]; then
   fi
 fi
 
-# Deliver upstream DELETIONS. This is the only place the hook removes anything, and
-# it is deliberately the narrowest operation that can work:
-#   * `rm -f` on a single FILE, never `rm -r`, so a directory can never be destroyed
-#     even if a path were somehow wrong;
+# Deliver upstream DELETIONS. This is the only place the hook removes anything:
+#   * `rm -f` on a single FILE for the content itself, plus `rmdir` (empty
+#     directories ONLY, it refuses a non-empty one) to clear the shell left behind;
 #   * only paths git itself named, from a diff already restricted to REFRESH_PATHS;
-#   * only after the same recoverability test that protects an overwrite -- a local
-#     copy whose blob appears NOWHERE in upstream history is unique work and was
-#     already routed to `skipped` above, so it is never reached here;
+#   * only for a path whose blob appears in $UP's OWN history for that path, so a
+#     never-upstream or locally-authored file is routed to `skipped` above and is
+#     never reached here;
 #   * `BASE_CLONE_NO_REFRESH=1` opts out of this exactly as it does a refresh.
-# 🔴 A `..` or absolute component would escape REFRESH_PATHS, so reject rather than
-# resolve it: git will not emit one, and if that ever changes this must fail loudly
-# rather than delete outside the tree.
-for p in "${to_prune[@]}"; do
+#
+# ⚠️ Two of those are UNREACHABLE BACKSTOPS today, and are labelled rather than
+# claimed as tested: the `rm -f`-not-`rm -r` choice and the escape guard below both
+# survive mutation, because `hash-object` fatals on a directory (so one never
+# reaches here) and `git diff --name-only` never emits a `..` component. They are
+# defence in depth against a future change upstream of this loop, NOT pinned
+# behaviour. The `rmdir` bound IS pinned -- widening it to `rm -rf` is caught.
+#
+# 🔴 An absolute path or a `..` COMPONENT would escape REFRESH_PATHS, so reject
+# rather than resolve it. Match the component, not the substring: `*..*` also
+# rejects an ordinary filename like `v1..v2.md`, sending it to the FAILED bucket
+# forever -- the exact misclassification this whole change exists to remove.
+for p in "${to_prune[@]:-}"; do
+  [ -n "$p" ] || continue
+  case "/$p/" in
+    /) failed+=("$p"); continue ;;
+    */../*) failed+=("$p"); continue ;;
+  esac
   case "$p" in
-    /*|*..*) failed+=("$p"); continue ;;
+    /*) failed+=("$p"); continue ;;
   esac
   if rm -f "$ROOT/$p" 2>/dev/null && [ ! -e "$ROOT/$p" ]; then
     pruned+=("$p")
-    # `rmdir` removes ONLY empty directories, so this cannot destroy content. It
-    # stops a hollow `.claude/skills/<name>/` shell being left behind looking like
-    # a skill that is still installed.
+    # Clear the hollow `.claude/skills/<name>/` shell so a removed skill does not
+    # keep LOOKING installed. `rmdir` refuses a non-empty directory, so this cannot
+    # destroy content -- an untracked sibling (build cache, local scratch) both
+    # survives and stops the climb.
+    #
+    # 🔴 Bounded at the REFRESH_PATHS roots. Unbounded it walked past its own scope:
+    # on a repo whose only skill was deleted upstream it removed `.claude/skills`
+    # AND `.claude` -- empty and harmless, but `.claude` is not a path this hook is
+    # allowed to touch, and anything probing `[ -d .claude ]` would see it vanish.
     d="$(dirname "$p")"
     while [ "$d" != "." ] && [ "$d" != "/" ]; do
+      _bounded=no
+      for _r in "${REFRESH_PATHS[@]}"; do
+        [ "$d" = "$_r" ] && _bounded=yes && break
+      done
+      [ "$_bounded" = yes ] && break
       rmdir "$ROOT/$d" 2>/dev/null || break
       d="$(dirname "$d")"
     done
@@ -230,12 +273,13 @@ $(printf '    %s\n' "${refreshed[@]}")"
 fi
 if [ "$n_prune" -gt 0 ]; then
   ctx="$ctx
-- PRUNED: deleted upstream, so removed here too. Only the file was removed (never a
-  directory), only after confirming its content is recoverable from $UP's history,
-  and HEAD was not moved -- so these show as deleted-in-worktree in git status until
-  this clone's branch catches up. Nothing unique to this machine was touched.
-  If you were relying on one of these, it is GONE upstream on purpose -- find where
-  it moved rather than restoring it:
+- PRUNED: deleted upstream, so removed here too. Each file was removed only after
+  confirming that exact content appears in $UP's own history for that path, so
+  nothing authored locally was touched; a directory left empty by the removal is
+  then cleared with rmdir, which refuses a non-empty one. HEAD was NOT moved, so
+  these show as deleted-in-worktree in git status until this clone's branch catches
+  up. If you were relying on one of these, it is GONE upstream on purpose -- find
+  where it moved rather than restoring it:
 $(printf '    %s\n' "${pruned[@]}")"
 fi
 if [ "$n_skip" -gt 0 ]; then

--- a/scripts/tests/mutants-base-clone.sh
+++ b/scripts/tests/mutants-base-clone.sh
@@ -28,7 +28,14 @@ run() { # run <name> <expect: KILLED|SURVIVES> <sed-expr>
   local out fails
   out="$(HOOK="$m" bash "$SUITE" 2>&1 | tail -1)"
   fails="$(sed -n 's/.*FAIL \([0-9]*\)/\1/p' <<<"$out")"
-  local got="KILLED"; [ "${fails:-0}" -eq 0 ] && got="SURVIVES"
+  # 🔴 A suite that dies before printing its summary yields an EMPTY count, and
+  # `${fails:-0}` would score that as SURVIVES -- a harness crash reported as "the
+  # guard held". Say so instead of defaulting.
+  if [ -z "$fails" ]; then
+    printf '  %-34s 🔴 HARNESS BROKE — no summary line (got: %s)\n' "$name" "${out:-<no output>}"
+    return
+  fi
+  local got="KILLED"; [ "$fails" -eq 0 ] && got="SURVIVES"
   local mark="ok "; [ "$got" != "$expect" ] && mark="🔴 "
   printf '  %s%-32s %-9s (%s kills) expected %s\n' "$mark" "$name" "$got" "${fails:-?}" "$expect"
 }
@@ -58,4 +65,9 @@ printf '   `hash-object` fatals on a directory so one never reaches the prune, a
 printf '   `git diff --name-only` never emits a `..` component. These are defence in\n'
 printf '   depth against a future change UPSTREAM of the loop, not pinned behaviour.\n'
 run 'rm-f-to-rm-rf'            SURVIVES 's|rm -f "$ROOT/$p"|rm -rf "$ROOT/$p"|'
-run 'drop-absolute-path-guard' SURVIVES 's|/\*) failed+=("$p"); continue ;;|/*) : ;;|'
+# 🔴 ISOLATE THE MUTATION. The obvious pattern here --
+#   s|/\*) failed+=("$p"); continue ;;|...|
+# -- also matches the TAIL of the `*/../*)` arm, so it disables the `..`-component
+# guard at the same time and the SURVIVES verdict would be about two guards rather
+# than the one it names. Anchor to the line start so only the absolute-path arm moves.
+run 'drop-absolute-path-guard' SURVIVES 's|^    /\*) failed+=("$p"); continue ;;$|    /*) : ;;|'

--- a/scripts/tests/mutants-base-clone.sh
+++ b/scripts/tests/mutants-base-clone.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Mutation battery for base-clone-staleness.sh's prune path.
+#
+# Not run by CI -- it is an author/reviewer instrument, kept in-tree so the claim
+# "mutation-verified" can be re-derived instead of believed.
+#
+#   bash scripts/tests/mutants-base-clone.sh
+#
+# 🔴 Each mutant is DIFFED against the original before it is run. A `sed` that
+# silently fails to match reports the UNMUTATED file's behaviour, which reads as
+# "the guard held" -- the most flattering possible wrong answer. That happened once
+# during authoring (a `grep -c` verification printed 0 while the mutant plainly
+# ran), which is why the check here is a diff and not a pattern count.
+set -uo pipefail
+CDPATH=
+D="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+HOOKSRC="$D/../claude-hooks/base-clone-staleness.sh"
+SUITE="$D/test_base_clone_staleness.sh"
+T="$(mktemp -d /tmp/bcs-mut-XXXXXX)"; trap 'rm -rf "$T"' EXIT
+
+run() { # run <name> <expect: KILLED|SURVIVES> <sed-expr>
+  local name="$1" expect="$2" expr="$3" m="$T/$1.sh"
+  sed "$expr" "$HOOKSRC" > "$m"
+  if cmp -s "$HOOKSRC" "$m"; then
+    printf '  %-34s 🔴 MUTATION DID NOT APPLY — result would be meaningless\n' "$name"
+    return
+  fi
+  local out fails
+  out="$(HOOK="$m" bash "$SUITE" 2>&1 | tail -1)"
+  fails="$(sed -n 's/.*FAIL \([0-9]*\)/\1/p' <<<"$out")"
+  local got="KILLED"; [ "${fails:-0}" -eq 0 ] && got="SURVIVES"
+  local mark="ok "; [ "$got" != "$expect" ] && mark="🔴 "
+  printf '  %s%-32s %-9s (%s kills) expected %s\n' "$mark" "$name" "$got" "${fails:-?}" "$expect"
+}
+
+printf 'baseline: '; bash "$SUITE" 2>&1 | tail -1
+
+printf '\n== detection and containment (must be KILLED) ==\n'
+run 'drop-deletion-detection'  KILLED \
+  's|if ! git -C "$ROOT" cat-file -e "$UP:$p" 2>/dev/null; then|if false; then|'
+run 'ungate-HEAD-shortcut'     KILLED \
+  's|if \[ "$deleted" = no \] \\|if [ true ] \\|'
+run 'strip-unique-work-guard'  KILLED \
+  's|if \[ "$known" = no \]; then|if [ "$known" = no ] \&\& [ "$deleted" = no ]; then|'
+run 'unbound-rmdir-climb'      KILLED \
+  's|\[ "$_bounded" = yes \] \&\& break|:|'
+run 'rmdir-to-rm-rf'           KILLED \
+  's|rmdir "$ROOT/$d" 2>/dev/null|rm -rf "$ROOT/$d" 2>/dev/null|'
+run 'dotdot-substring-guard'   KILLED \
+  's|\*/\.\./\*) failed+=("$p"); continue ;;|*..*) failed+=("$p"); continue ;;|'
+run 'hoist-prune-above-optout' KILLED \
+  's|if \[ "${BASE_CLONE_NO_REFRESH:-0}" = "1" \]; then|if false; then|'
+run 'break-recoverability-scan' KILLED \
+  's|rev-list -n 100|rev-list -n 0|'
+
+printf '\n== unreachable-by-construction backstops (SURVIVES is EXPECTED, not a gap) ==\n'
+printf '   `hash-object` fatals on a directory so one never reaches the prune, and\n'
+printf '   `git diff --name-only` never emits a `..` component. These are defence in\n'
+printf '   depth against a future change UPSTREAM of the loop, not pinned behaviour.\n'
+run 'rm-f-to-rm-rf'            SURVIVES 's|rm -f "$ROOT/$p"|rm -rf "$ROOT/$p"|'
+run 'drop-absolute-path-guard' SURVIVES 's|/\*) failed+=("$p"); continue ;;|/*) : ;;|'

--- a/scripts/tests/test_base_clone_staleness.sh
+++ b/scripts/tests/test_base_clone_staleness.sh
@@ -22,7 +22,18 @@
 # documented mutation control:
 #
 #   sed 's/rev-list -n 100/rev-list -n 0/' scripts/claude-hooks/base-clone-staleness.sh > /tmp/m.sh
-#   HOOK=/tmp/m.sh bash scripts/tests/test_base_clone_staleness.sh   # must report FAIL 1
+#   HOOK=/tmp/m.sh bash scripts/tests/test_base_clone_staleness.sh   # must report FAIL 5
+#
+# ⚠️ That count was FAIL 1 until case 9 was added (2026-08-24). Breaking the
+# recoverability scan also strands the prune cases, which depend on phase 1 having
+# refreshed the file first. The kills are: case 2 "second refresh landed v3", and
+# four in case 9/9c. If you add cases, RE-RUN this control and update the number --
+# a stale expected count makes the next reader distrust a working harness.
+# A second mutant, aimed at the prune specifically (must report FAIL 5, all in 9/9c):
+#   sed 's/if ! git -C "$ROOT" cat-file -e "$UP:$p" 2>\/dev\/null; then/if false; then/' \
+#     scripts/claude-hooks/base-clone-staleness.sh > /tmp/mA.sh
+# 🔴 Confirm the sed ACTUALLY matched before believing a red -- a mutation that
+# silently fails to apply reports the unmutated hook's result.
 #
 # 🔴 HOOK defaults to the REPO copy, resolved relative to THIS FILE — never to a
 # deployed per-host path under ~/.claude/. A default pointing at the deployed
@@ -104,6 +115,16 @@ advance() { # advance <name> <claude-body> [newfile-relpath]
     git -C "$a" add "$newfile"
   fi
   git -C "$a" "${GIT_ID[@]}" commit -qm "advance $body"
+  git -C "$a" push -q origin fixture
+}
+
+# Remove a path upstream. The path must already exist there, and the work clone
+# must already have received it -- otherwise the case is vacuous (there is nothing
+# on disk for the prune to act on), which is why case 9 asserts that first.
+advance_delete() { # advance_delete <name> <relpath>
+  local a="$TMP/$1-author"
+  git -C "$a" rm -q "$2"
+  git -C "$a" "${GIT_ID[@]}" commit -qm "delete $2"
   git -C "$a" push -q origin fixture
 }
 
@@ -223,6 +244,98 @@ OUT=$(run_hook "$W")
 check "parses as JSON"        "$(jq -e . <<<"$OUT" >/dev/null 2>&1 && echo yes || echo no)" "yes"
 check "carries systemMessage" "$(jq -r 'has("systemMessage")' <<<"$OUT" 2>/dev/null)" "true"
 check "hookEventName correct" "$(jq -r '.hookSpecificOutput.hookEventName' <<<"$OUT" 2>/dev/null)" "SessionStart"
+
+# ---------------------------------------------------------------------------
+say "9. a path DELETED upstream is pruned here, not reported FAILED forever"
+# Defect (2026-08-24): `checkout $UP -- $p` cannot deliver a deletion -- the
+# pathspec matches nothing in $UP -- so the batch AND the per-file retry both
+# failed and the path landed in FAILED on every session start, forever, while the
+# file stayed on disk and kept loading into agent context. Exact mirror of the
+# ADDED-path bug in case 1, and the same wrong bucket.
+# Real instance: .claude/skills/check-clickup-addressed/ was removed from
+# talos-infra (it moved to devrc); the clone went on serving a 437-line retired
+# SKILL.md against the 562-line canonical one.
+W=$(mkfixture t9)
+advance t9 "CLAUDE v2" ".claude/skills/doomed/SKILL.md"
+git -C "$W" fetch -q origin fixture
+run_hook "$W" >/dev/null 2>&1                      # phase 1: the clone receives it
+pre "doomed skill exists before the delete" \
+    "$([ -e "$W/.claude/skills/doomed/SKILL.md" ] && echo yes || echo no)" "yes" && {
+  advance_delete t9 ".claude/skills/doomed/SKILL.md"
+  git -C "$W" fetch -q origin fixture
+  OUT=$(run_hook "$W")
+  vecho "$OUT"
+  check "deleted-upstream file is GONE locally" \
+        "$([ -e "$W/.claude/skills/doomed/SKILL.md" ] && echo yes || echo no)" "no"
+  check "reported as pruned, NOT failed" \
+        "$(jq -r '.systemMessage' <<<"$OUT" 2>/dev/null | grep -c 'pruned 1 deleted upstream')" "1"
+  check "no FAILED bucket for it" \
+        "$(jq -r '.systemMessage' <<<"$OUT" 2>/dev/null | grep -c 'FAILED')" "0"
+  # The emptied skill dir must not be left behind looking installed.
+  check "emptied skill dir cleaned up" \
+        "$([ -d "$W/.claude/skills/doomed" ] && echo yes || echo no)" "no"
+  # ...but a directory that still holds content must survive. `rmdir` refuses a
+  # non-empty dir, which is exactly why the cleanup uses it rather than `rm -r`.
+  check "sibling skill dir untouched" \
+        "$([ -e "$W/.claude/skills/demo/SKILL.md" ] && echo yes || echo no)" "yes"
+}
+
+say "9b. a deleted path holding UNIQUE LOCAL work is NOT pruned"
+# The prune must inherit the same protection as an overwrite. A local edit whose
+# blob appears NOWHERE in upstream history is unique human work; deleting it
+# would be strictly worse than the bug being fixed.
+#
+# ⚠️ HONEST LABEL: this is NOT regression coverage for the FAILED-bucket defect --
+# it passes on pre-change code too, because there the file survived by never being
+# pruned at all. It guards the NEW capability instead, and it is a killing guard
+# for it: mutating `if [ "$known" = no ]` to `[ "$known" = no ] && [ "$deleted" = no ]`
+# deletes the file and takes all three assertions red. Reachable, and it fires for
+# its own reason.
+W=$(mkfixture t9b)
+advance t9b "CLAUDE v2" ".claude/skills/precious/SKILL.md"
+git -C "$W" fetch -q origin fixture
+run_hook "$W" >/dev/null 2>&1
+printf 'HAND-WRITTEN LOCAL NOTES NOBODY ELSE HAS\n' > "$W/.claude/skills/precious/SKILL.md"
+pre "local edit is genuinely unrecoverable" \
+    "$(git -C "$W" rev-list --all --objects 2>/dev/null | grep -c "$(blob "$W" .claude/skills/precious/SKILL.md)")" "0" && {
+  advance_delete t9b ".claude/skills/precious/SKILL.md"
+  git -C "$W" fetch -q origin fixture
+  OUT=$(run_hook "$W")
+  vecho "$OUT"
+  check "unique local work SURVIVES the prune" \
+        "$([ -e "$W/.claude/skills/precious/SKILL.md" ] && echo yes || echo no)" "yes"
+  check "content is still the local edit" \
+        "$(cat "$W/.claude/skills/precious/SKILL.md")" "HAND-WRITTEN LOCAL NOTES NOBODY ELSE HAS"
+  check "reported as SKIPPED, not pruned" \
+        "$(jq -r '.systemMessage' <<<"$OUT" 2>/dev/null | grep -c 'SKIPPED')" "1"
+}
+
+say "9c. BASE_CLONE_NO_REFRESH=1 does not prune either (with a positive control)"
+# Report-only must mean report-only for deletions too, or the opt-out silently
+# stops protecting the one operation that cannot be undone by a re-run.
+#
+# ⚠️ HONEST LABEL: the two opt-out assertions are INVARIANT guards -- they pass on
+# pre-change code, where nothing was pruned under any flag. The POSITIVE CONTROL at
+# the end is the only real regression assertion in this case, and it is why the
+# other two are not vacuous: without it, "the file is still there" is the same
+# observation whether the opt-out works or the prune is simply broken.
+W=$(mkfixture t9c)
+advance t9c "CLAUDE v2" ".claude/skills/optout/SKILL.md"
+git -C "$W" fetch -q origin fixture
+run_hook "$W" >/dev/null 2>&1
+advance_delete t9c ".claude/skills/optout/SKILL.md"
+git -C "$W" fetch -q origin fixture
+OUT=$(run_hook "$W" BASE_CLONE_NO_REFRESH=1)
+vecho "$OUT"
+check "opt-out: file untouched" \
+      "$([ -e "$W/.claude/skills/optout/SKILL.md" ] && echo yes || echo no)" "yes"
+check "opt-out: no false 'pruned' claim" \
+      "$(jq -r '.systemMessage' <<<"$OUT" 2>/dev/null | grep -c 'pruned')" "0"
+# 🔴 Without this control the case above passes even if the prune never worked at
+# all -- "the file is still there" is the SAME observation as a broken feature.
+OUT=$(run_hook "$W")
+check "POSITIVE CONTROL: prunes without the flag" \
+      "$([ -e "$W/.claude/skills/optout/SKILL.md" ] && echo yes || echo no)" "no"
 
 printf '\n=====================================\n'
 printf 'PASS %d   FAIL %d\n' "$PASS" "$FAIL"

--- a/scripts/tests/test_base_clone_staleness.sh
+++ b/scripts/tests/test_base_clone_staleness.sh
@@ -21,19 +21,25 @@
 # have never watched fail is a claim about your shell, not about the code. The
 # documented mutation control:
 #
-#   sed 's/rev-list -n 100/rev-list -n 0/' scripts/claude-hooks/base-clone-staleness.sh > /tmp/m.sh
-#   HOOK=/tmp/m.sh bash scripts/tests/test_base_clone_staleness.sh   # must report FAIL 5
+#   bash scripts/tests/mutants-base-clone.sh
 #
-# ⚠️ That count was FAIL 1 until case 9 was added (2026-08-24). Breaking the
-# recoverability scan also strands the prune cases, which depend on phase 1 having
-# refreshed the file first. The kills are: case 2 "second refresh landed v3", and
-# four in case 9/9c. If you add cases, RE-RUN this control and update the number --
-# a stale expected count makes the next reader distrust a working harness.
-# A second mutant, aimed at the prune specifically (must report FAIL 5, all in 9/9c):
-#   sed 's/if ! git -C "$ROOT" cat-file -e "$UP:$p" 2>\/dev\/null; then/if false; then/' \
-#     scripts/claude-hooks/base-clone-staleness.sh > /tmp/mA.sh
-# 🔴 Confirm the sed ACTUALLY matched before believing a red -- a mutation that
-# silently fails to apply reports the unmutated hook's result.
+# That is the battery, in-tree, with each mutant's EXPECTED verdict beside it so a
+# regression in the suite's own strength is visible rather than inferred. It also
+# diffs every mutant against the original before running it: a `sed` that silently
+# fails to match reports the UNMUTATED file's behaviour, which reads as "the guard
+# held" -- the most flattering possible wrong answer, and one that actually happened
+# during authoring.
+#
+# ⚠️ This comment used to hardcode "must report FAIL 1", then "FAIL 5". Both went
+# stale within a day as cases were added, and a stale expected count makes the next
+# reader distrust a working harness. Do not reintroduce a number here -- the battery
+# owns the expectations.
+#
+# 🔴 Two mutants are expected to SURVIVE, and the battery says so out loud: `rm -f`
+# -> `rm -rf` on the file, and dropping the absolute-path guard. Both are
+# unreachable by construction today. Labelling them beats pretending they are
+# pinned -- and note that bounding the rmdir climb once took `rmdir` -> `rm -rf`
+# OFF the board silently, which is why case 9g exists.
 #
 # 🔴 HOOK defaults to the REPO copy, resolved relative to THIS FILE — never to a
 # deployed per-host path under ~/.claude/. A default pointing at the deployed
@@ -336,6 +342,120 @@ check "opt-out: no false 'pruned' claim" \
 OUT=$(run_hook "$W")
 check "POSITIVE CONTROL: prunes without the flag" \
       "$([ -e "$W/.claude/skills/optout/SKILL.md" ] && echo yes || echo no)" "no"
+
+say "9d. a path the LOCAL branch ADDED (never upstream) is NEVER pruned"
+# 🔴 The defect this case exists for shipped in the first cut of the prune and was
+# caught in review. `cat-file -e "$UP:$p"` answers "is this ABSENT upstream", not
+# "was it DELETED upstream" -- and those differ for a path upstream never had.
+# Combined with the `cur = HEAD:$p` recoverability shortcut (correct for a refresh,
+# where matching HEAD means untouched-locally; WRONG for a prune, where it means
+# only "committed here"), a skill authored on this branch and not yet pushed was
+# deleted -- and re-deleted every session, while the report said it was "GONE
+# upstream on purpose ... find where it moved rather than restoring it".
+#
+# 🔴 EVERY other case 9 fixture reaches the absent-upstream state via
+# `advance_delete`, so all of them are indistinguishable to `cat-file -e` and the
+# suite was STRUCTURALLY BLIND to this. The fixture below is the only one that
+# creates the path locally and never pushes it, which is what makes it able to see.
+W=$(mkfixture t9d)
+mkdir -p "$W/.claude/skills/homegrown"
+printf 'authored here, never pushed\n' > "$W/.claude/skills/homegrown/SKILL.md"
+git -C "$W" add .claude/skills/homegrown/SKILL.md
+git -C "$W" "${GIT_ID[@]}" commit -qm "local-only skill"
+advance t9d "CLAUDE v2"        # upstream moves for an unrelated reason
+git -C "$W" fetch -q origin fixture
+pre "local-only skill is absent upstream" \
+    "$(git -C "$W" cat-file -e "origin/fixture:.claude/skills/homegrown/SKILL.md" 2>/dev/null && echo yes || echo no)" "no" && {
+  OUT=$(run_hook "$W")
+  vecho "$OUT"
+  check "locally-authored skill SURVIVES" \
+        "$([ -e "$W/.claude/skills/homegrown/SKILL.md" ] && echo yes || echo no)" "yes"
+  check "content untouched" \
+        "$(cat "$W/.claude/skills/homegrown/SKILL.md" 2>/dev/null)" "authored here, never pushed"
+  check "not reported as pruned" \
+        "$(jq -r '.systemMessage' <<<"$OUT" 2>/dev/null | grep -c 'pruned')" "0"
+  # ...and it must stay gone-proof across repeated session starts, which is how the
+  # original defect presented: restoring the file just got it deleted again.
+  run_hook "$W" >/dev/null 2>&1; run_hook "$W" >/dev/null 2>&1
+  check "still present after 3 session starts" \
+        "$([ -e "$W/.claude/skills/homegrown/SKILL.md" ] && echo yes || echo no)" "yes"
+}
+
+say "9e. the rmdir climb stops at the REFRESH_PATHS root"
+# Unbounded, the climb walked out of its own scope: with the only skill deleted
+# upstream it removed `.claude/skills` AND `.claude`. Empty and harmless, but
+# `.claude` is not a path this hook may touch.
+#
+# ⚠️ FIXTURE TRAP, hit while writing this: deleting the `demo` skill only in the
+# WORK TREE does not empty `.claude/skills` -- `demo` is still upstream, so the same
+# hook run REFRESHES it straight back, the directory stays non-empty, the climb
+# stops one level early and the case PASSES on the broken hook for the wrong
+# reason. Every skill must be deleted UPSTREAM, and the precondition below asserts
+# the directory really is empty before the two root checks mean anything.
+W=$(mkfixture t9e)
+advance t9e "CLAUDE v2" ".claude/skills/solo/SKILL.md"
+git -C "$W" fetch -q origin fixture
+run_hook "$W" >/dev/null 2>&1
+advance_delete t9e ".claude/skills/solo/SKILL.md"
+advance_delete t9e ".claude/skills/demo/SKILL.md"
+git -C "$W" fetch -q origin fixture
+run_hook "$W" >/dev/null 2>&1
+pre "skills tree really is empty of files" \
+    "$(find "$W/.claude/skills" -type f 2>/dev/null | wc -l)" "0" && {
+  check "emptied skill dir removed"    "$([ -d "$W/.claude/skills/solo" ] && echo yes || echo no)" "no"
+  check ".claude/skills root survives" "$([ -d "$W/.claude/skills" ] && echo yes || echo no)" "yes"
+  check ".claude survives"             "$([ -d "$W/.claude" ] && echo yes || echo no)" "yes"
+}
+
+say "9g. an UNTRACKED sibling is never deleted, and it stops the directory cleanup"
+# The prune removes tracked files git named; it must never touch untracked local
+# content (build cache, scratch notes). `rmdir` is what enforces that -- it refuses
+# a non-empty directory -- and this is the case that PINS the choice.
+#
+# 🔴 This case exists because bounding the climb at the REFRESH_PATHS root (9e)
+# SILENTLY REMOVED the coverage that used to kill `rmdir` -> `rm -rf`: with the
+# bound in place that mutant can no longer reach a sibling SKILL dir, so it
+# survived a fully green suite. A fix round taking a mutant off the board is
+# exactly the regression an audit round is for. The distinguishing case has to sit
+# INSIDE the bound -- an untracked file in the pruned skill's own directory.
+#
+# It is also the real-world shape: on the clone that motivated this change the
+# retired skill dir held .pytest_cache/ and __pycache__/, which correctly survived.
+W=$(mkfixture t9g)
+advance t9g "CLAUDE v2" ".claude/skills/withjunk/SKILL.md"
+git -C "$W" fetch -q origin fixture
+run_hook "$W" >/dev/null 2>&1
+printf 'local scratch, never committed\n' > "$W/.claude/skills/withjunk/NOTES.local"
+advance_delete t9g ".claude/skills/withjunk/SKILL.md"
+git -C "$W" fetch -q origin fixture
+pre "untracked sibling is genuinely untracked" \
+    "$(git -C "$W" status --porcelain --untracked-files=all -- .claude/skills/withjunk/NOTES.local | cut -c1-2)" "??" && {
+  OUT=$(run_hook "$W")
+  vecho "$OUT"
+  check "tracked file pruned"          "$([ -e "$W/.claude/skills/withjunk/SKILL.md" ] && echo yes || echo no)" "no"
+  check "UNTRACKED sibling SURVIVES"   "$([ -e "$W/.claude/skills/withjunk/NOTES.local" ] && echo yes || echo no)" "yes"
+  check "its content is intact"        "$(cat "$W/.claude/skills/withjunk/NOTES.local" 2>/dev/null)" "local scratch, never committed"
+  check "non-empty dir NOT removed"    "$([ -d "$W/.claude/skills/withjunk" ] && echo yes || echo no)" "yes"
+}
+
+say "9f. a filename containing '..' is not misclassified as an escape attempt"
+# `*..*` as a substring match rejects an ordinary `v1..v2.md`, sending it to the
+# FAILED bucket forever -- the exact misclassification this change exists to fix.
+# Only a `..` COMPONENT can escape.
+W=$(mkfixture t9f)
+advance t9f "CLAUDE v2" ".claude/skills/dotty/v1..v2.md"
+git -C "$W" fetch -q origin fixture
+run_hook "$W" >/dev/null 2>&1
+pre "dotted file arrived" "$([ -e "$W/.claude/skills/dotty/v1..v2.md" ] && echo yes || echo no)" "yes" && {
+  advance_delete t9f ".claude/skills/dotty/v1..v2.md"
+  git -C "$W" fetch -q origin fixture
+  OUT=$(run_hook "$W")
+  vecho "$OUT"
+  check "dotted filename pruned, not FAILED" \
+        "$([ -e "$W/.claude/skills/dotty/v1..v2.md" ] && echo yes || echo no)" "no"
+  check "no FAILED bucket for a dotted name" \
+        "$(jq -r '.systemMessage' <<<"$OUT" 2>/dev/null | grep -c 'FAILED')" "0"
+}
 
 printf '\n=====================================\n'
 printf 'PASS %d   FAIL %d\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## The defect

`git checkout $UP -- $p` **cannot deliver a deletion** — the pathspec matches nothing in `$UP`, so the batch *and* the per-file retry both fail and the path lands in the `FAILED` bucket on every session start, forever, while the file stays on disk and keeps loading into agent context.

This is the exact mirror of the ADDED-path bug already fixed in this file (`hash-object` fatals on a missing file → empty result classified `FAILED`). Same wrong bucket, opposite direction.

## Measured on a real clone

`.claude/skills/check-clickup-addressed/` was removed from talos-infra (the skill moved to devrc). A datapacket-talos clone went on serving a **437-line retired `SKILL.md`** against the **562-line canonical** one — with `.pytest_cache/` and `__pycache__/` underneath it, so it was being **run from**, not merely read.

Same clone, before and after:

| | systemMessage | files |
|---|---|---|
| pre-change | `193 commit(s) behind \| refreshed 1 context file(s) \| FAILED 19` | 25 retained |
| post-change | `193 commit(s) behind \| pruned 19 deleted upstream` | 19 removed |

## Why this is safe

This is the only place the hook removes anything, so it is deliberately the narrowest operation that can work:

- `rm -f` on a single **file**, never `rm -r` — a directory cannot be destroyed even if a path were somehow wrong
- only paths **git itself named**, from a diff already restricted to `REFRESH_PATHS`, with `/*` and `*..*` rejected rather than resolved
- only after the **same recoverability test that protects an overwrite** — a copy whose blob appears nowhere in upstream history is unique local work and is routed to `skipped` before it can reach the prune
- `BASE_CLONE_NO_REFRESH=1` opts out of pruning exactly as it does a refresh
- emptied directories are cleaned with `rmdir`, which **refuses a non-empty dir**, so the cleanup cannot remove content

Detection asks upstream (`cat-file -e`) rather than branching on a comparison's exit code — `git diff --quiet <ref> -- <p>` exits 0 when `<p>` is on **neither** side, which reads as a reassuring "same" for a file that is simply absent.

**Known and deliberate limit:** untracked siblings (build cache, local scratch) are never touched, so a pruned skill dir still holding e.g. `__pycache__` survives as an inert empty shell. Deleting untracked files is a much bigger hammer and could destroy local work.

## Tests: 24 → 35, watched to fail first

| | result |
|---|---|
| red at `origin/main` | **FAIL 5**, including `no FAILED bucket for it (got '1')` — which independently confirms the diagnosis |
| green at HEAD | **PASS 35 / FAIL 0** |

Mutation-checked rather than assumed:

- drop the `cat-file -e` detection → **5 kills**, all in 9/9c
- strip the unique-work protection from the prune path (`[ "$known" = no ]` → `&& [ "$deleted" = no ]`) → **3 kills in 9b, file genuinely deleted** — so 9b is reachable and fires for its own reason

### Honest labels

9b and the two 9c opt-out assertions are **not** regression coverage for the `FAILED`-bucket defect — they pass on pre-change code, where the file survived by never being pruned at all. They guard the **new capability**. 9c's positive control is what stops the opt-out case being vacuous, since *"the file is still there"* is otherwise the same observation whether the opt-out works or the prune is simply broken.

The suite header's documented mutation control is updated from `FAIL 1` to `FAIL 5`: breaking the recoverability scan now also strands the prune cases, which depend on phase 1 having refreshed the file first. A stale expected count makes the next reader distrust a working harness.

## Deploy note

The live hook is a `home.file` copy — `readlink -f ~/.claude/hooks/base-clone-staleness.sh` terminates in `/nix/store/…`. **Editing the repo does nothing until a home-manager switch.**

Two unrelated doc-rot findings while tracing this, not fixed here:
- talos-infra `CLAUDE.md` points at `~/.claude/local-hooks/base-clone-staleness.sh`; the real registration in `settings.json` is `~/.claude/hooks/…`
- it also says the regression suite "sits beside the hook"; it is at `scripts/tests/test_base_clone_staleness.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
