### PR TITLE
fix(agent-ledger): de-flake the two ledger tests that asserted under a production deadline — plus a classification of the whole devrc-pytests red set

### DIFF
--- a/scripts/lib/agent_ledger.py
+++ b/scripts/lib/agent_ledger.py
@@ -145,6 +145,26 @@ DEFAULT_MAX_AGE = 7 * 86400
 # threshold `classify_status` uses.
 DEFAULT_THROTTLE = 30
 
+# How long a writer may wait for tmux to answer `display-message`. Deliberately
+# SHORT: both writers sit on an agent's hot path (`PostToolUse` for the Claude
+# hook, every opencode tool call for the CLI), so a wedged or restarting tmux
+# server must cost the agent ~nothing. Missing it is not an error — see
+# `filename_for`, which keys the record on the SESSION when the window id is
+# unknown precisely so this degradation stays lossless.
+#
+# 🔴 IT IS A CONSTANT HERE AND A PARAMETER EVERYWHERE ELSE, and that is the
+# whole point. A caller that needs the tmux answer to be RELIABLE rather than
+# CHEAP — a test asserting the pane-keyed filename, say — must be able to buy
+# more time, because otherwise its assertion silently depends on how loaded the
+# machine is. MEASURED 2026-08-24: this stub-tmux call takes 0.003s (p50) idle
+# and 0.197s worst at a 20x CPU stall (`systemd-run -p CPUQuota=5%`) on a
+# 24-core workbench — but the `devrc-ci` pytest leg runs in a container capped
+# at 4 CPUs / 8Gi beside ~15.8k other tests, several such pods to a 16-core
+# node, and `tekton/devrc-pytests` went red on exactly this: the CLI wrote
+# `opencode-s-oc-4.json` where the test expected `opencode-p77.json`
+# (devrc-ci-wwj4d). Reproduced end-to-end by making the stub sleep 2.5s.
+DEFAULT_TMUX_TIMEOUT_S = 2.0
+
 RUNTIMES = ("claude", "opencode", "clawgate")
 
 # `@41` -> `41`, matching the naming `tmux-task-hook.sh` used (`${WIN_ID//[@%]/}`).
@@ -628,7 +648,7 @@ def index_by_window(records) -> dict:
 # =========================================================================== #
 # TMUX + the CLI — the two IMPURE edges, both shared by every writer
 # =========================================================================== #
-def tmux_context(runner=None, pane=None):
+def tmux_context(runner=None, pane=None, timeout=None):
     """`(window_id, tmux_pid)` for this pane, or `(None, None)`.
 
     ONE tmux call for both fields: they come from the same server and asking twice
@@ -638,14 +658,19 @@ def tmux_context(runner=None, pane=None):
 
     TWO callers: the Claude hook and the `--write` CLI. It is here so there is
     one resolver rather than one per writer.
+
+    `timeout` is the seconds to allow tmux, defaulting to
+    `DEFAULT_TMUX_TIMEOUT_S` — read that constant for why the default is short
+    and why a caller must be able to raise it.
     """
     pane = os.environ.get("TMUX_PANE") if pane is None else pane
     if not pane:
         return None, None
+    budget = DEFAULT_TMUX_TIMEOUT_S if timeout is None else float(timeout)
     argv = ["tmux", "display-message", "-t", pane, "-p", "#{window_id}|#{pid}"]
     try:
         run = runner or (lambda a: subprocess.run(
-            a, capture_output=True, text=True, timeout=2.0))
+            a, capture_output=True, text=True, timeout=budget))
         proc = run(argv)
         if proc.returncode != 0:
             return None, None
@@ -679,11 +704,24 @@ def main(argv=None) -> int:
     p.add_argument("--session", required=True)
     p.add_argument("--transcript-path", default=None)
     p.add_argument("--throttle", type=float, default=DEFAULT_THROTTLE)
+    p.add_argument("--tmux-timeout", type=float, default=DEFAULT_TMUX_TIMEOUT_S,
+                   help="seconds to allow tmux to answer (default %(default)s). "
+                        "Raise it when the pane-keyed filename must be RELIABLE "
+                        "rather than cheap — see DEFAULT_TMUX_TIMEOUT_S.")
     p.add_argument("--prune", action="store_true",
                    help="also reap records past the retention window; the "
                         "caller does this on a session boundary, not per call")
     p.add_argument("--directory", default=LEDGER_DIR)
     args = p.parse_args(sys.argv[1:] if argv is None else list(argv))
+    # 🔴 FAIL CLOSED on a junk budget rather than falling back to the default.
+    # `--tmux-timeout 0` is not "no limit" — `subprocess.run(timeout=0)` expires
+    # immediately, so a typo would silently force the DEGRADED session-keyed
+    # path on every write while the CLI still exited 0. argparse's own exit
+    # code (2) is the right one: this is a bad invocation, not a failed write.
+    if not args.tmux_timeout > 0 or args.tmux_timeout == float("inf"):
+        p.error("--tmux-timeout must be a positive, finite number of seconds "
+                "(got %r); it bounds the tmux lookup, and a non-positive value "
+                "silently forces the session-keyed fallback" % args.tmux_timeout)
 
     try:
         pane = os.environ.get("TMUX_PANE") or None
@@ -694,7 +732,7 @@ def main(argv=None) -> int:
                                 pane_filename(args.runtime, pane))
             if is_throttled(path, args.session, args.throttle):
                 return 0
-        wid, pid = tmux_context(pane=pane or "")
+        wid, pid = tmux_context(pane=pane or "", timeout=args.tmux_timeout)
         rec = build_record(
             runtime=args.runtime, session_id=args.session,
             last_activity_ts=now_iso(), window_id=wid, pane_id=pane,

--- a/scripts/tests/test_agent_ledger.py
+++ b/scripts/tests/test_agent_ledger.py
@@ -651,7 +651,7 @@ def test_the_tie_break_resolves_on_the_record_read_FIRST():
 # =========================================================================== #
 # the --write CLI, and writer 2 (opencode)
 # =========================================================================== #
-def _stub_tmux(bindir, answer="@41|4025325"):
+def _stub_tmux(bindir, answer="@41|4025325", delay=None):
     """A stub `tmux` on PATH so the CLI can resolve a window hermetically.
 
     🔴 Without one the CLI takes the DEGRADED path — `$TMUX_PANE` set, tmux
@@ -660,21 +660,85 @@ def _stub_tmux(bindir, answer="@41|4025325"):
     job, and it is why a fixture that fakes only the pane tests the wrong path.
     Via `testlib.mockbin`, which owns the shebang (`#!/usr/bin/env bash` is dead
     in the nix sandbox).
+
+    `delay` seconds makes it answer SLOWLY. That is how the budget below is
+    exercised without waiting for the HOST to be slow — which is the very
+    dependency this file exists to stop having.
     """
+    body = "" if delay is None else "sleep %s\n" % delay
     return str(mockbin.write_exec(Path(str(bindir)) / "tmux",
-                                  "printf '%s\\n'\n" % answer))
+                                  body + "printf '%s\\n'\n" % answer))
 
 
-def _cli(*args, env=None, directory=None):
-    """Drive the REAL CLI as `ledger.js` does — argv, no shell."""
+# 🔴 THE BUDGETS THIS FILE ASSERTS UNDER, IN ONE PLACE, BECAUSE A TEST MUST NOT
+# INHERIT A PRODUCTION DEADLINE IT DOES NOT CONTROL.
+#
+# `AL.DEFAULT_TMUX_TIMEOUT_S` is 2.0s deliberately: both writers sit on an
+# agent's hot path, so a wedged tmux must cost ~nothing. That is right for
+# PRODUCTION and wrong for a test whose subject is "when tmux answers, the
+# record is pane-keyed" — under that default the assertion also, silently,
+# depends on the machine finishing a `/bin/sh` exec inside 2s.
+#
+# It does not, in the tier that gates a merge. MEASURED on `devrc-ci-wwj4d`
+# (2026-08-24): the CLI wrote `opencode-s-oc-4.json` where this file expects
+# `opencode-p77.json` — `filename_for`'s documented DEGRADED path, taken when
+# `tmux_context` returns (None, None). Reproduced end-to-end on the dev host by
+# giving the stub a 2.5s `sleep`: same signature, and the CLI still exits 0.
+# The `devrc-ci` pytest leg runs in a container capped at 4 CPUs / 8Gi beside
+# ~15.8k other tests, several such pods to a 16-core node.
+#
+# These are CEILINGS, not sleeps — a passing call returns in ~3ms, so a
+# generous number costs nothing and buys an assertion that measures the record
+# shape instead of the host's spare capacity. The stub call measured 0.003s at
+# p50 idle and 0.197s worst at a 20x CPU stall, so 60s is ~300x the worst
+# contended observation.
+_TMUX_BUDGET_S = 60.0
+#: The whole `--write` subprocess. Same disease, same treatment: it was 30s,
+#: which under the same stall would have turned the degraded-path failure into a
+#: `TimeoutExpired` — a different wrong answer, not a right one. Must exceed
+#: `_TMUX_BUDGET_S` or the inner budget is unreachable and this file would be
+#: asserting against the outer one.
+_CLI_BUDGET_S = 300.0
+
+
+def _cli(*args, env=None, directory=None, tmux_timeout=None):
+    """Drive the REAL CLI as `ledger.js` does — argv, no shell.
+
+    `tmux_timeout` is passed through as `--tmux-timeout`; pass
+    `_TMUX_BUDGET_S` from any test that asserts the PANE-keyed filename.
+    """
     e = dict(os.environ)
     e.pop("TMUX_PANE", None)
     e.update(env or {})
     argv = [sys.executable, _MODULE, "--write", *args]
+    if tmux_timeout is not None:
+        argv += ["--tmux-timeout", str(tmux_timeout)]
     if directory:
         argv += ["--directory", str(directory)]
-    return subprocess.run(argv, capture_output=True, text=True, timeout=30,
-                          env=e)
+    return subprocess.run(argv, capture_output=True, text=True,
+                          timeout=_CLI_BUDGET_S, env=e)
+
+
+def _assert_pane_keyed(directory, expected):
+    """The stub answered and the record is PANE-keyed — said in one sentence.
+
+    🔴 DIAGNOSIS, NOT COVERAGE. Without it the degraded path surfaces as
+    `FileNotFoundError: …/opencode-p77.json` or as a list-vs-list diff of two
+    strings that differ mid-name, both of which read as "the CLI wrote nothing"
+    / "the naming is wrong" rather than as "tmux did not answer in time". That
+    misreading is what made this class expensive: `devrc-ci-wwj4d` was
+    diagnosed from the filename, not from the deadline.
+    """
+    names = sorted(n for n in os.listdir(str(directory)) if n.endswith(".json"))
+    degraded = [n for n in names if "-s-" in n]
+    assert expected in names, (
+        f"expected the PANE-keyed record {expected!r}, got {names}. "
+        + (f"{degraded} is `filename_for`'s DEGRADED path: $TMUX_PANE was set "
+           f"but `tmux_context` returned (None, None), i.e. the stub tmux did "
+           f"not answer inside --tmux-timeout. That is the record shape doing "
+           f"its job — raise the budget, do not relax the assertion."
+           if degraded else
+           "no session-keyed record either, so this is not the tmux deadline."))
 
 
 def test_the_CLI_writes_a_record_a_runtime_that_cannot_IMPORT_us_can_reach(
@@ -727,13 +791,14 @@ def test_the_CLI_throttles_on_a_repeat_from_the_SAME_session(tmp_path):
     env = {"TMUX_PANE": "%77",
            "PATH": "%s:%s" % (bindir, os.environ["PATH"])}
     first = _cli("--runtime", "opencode", "--session", "oc-3", env=env,
-                 directory=tmp_path)
+                 directory=tmp_path, tmux_timeout=_TMUX_BUDGET_S)
     assert first.returncode == 0
     path = os.path.join(str(tmp_path), "opencode-p77.json")
+    _assert_pane_keyed(tmp_path, "opencode-p77.json")
     before = os.stat(path)
 
     second = _cli("--runtime", "opencode", "--session", "oc-3", env=env,
-                  directory=tmp_path)
+                  directory=tmp_path, tmux_timeout=_TMUX_BUDGET_S)
     assert second.returncode == 0
     after = os.stat(path)
 
@@ -761,11 +826,97 @@ def test_TWO_RUNTIMES_in_one_pane_do_not_overwrite_each_other(tmp_path):
     env = {"TMUX_PANE": "%77",
            "PATH": "%s:%s" % (bindir, os.environ["PATH"])}
     _cli("--runtime", "opencode", "--session", "oc-4", env=env,
-         directory=tmp_path)
+         directory=tmp_path, tmux_timeout=_TMUX_BUDGET_S)
+    _assert_pane_keyed(tmp_path, "opencode-p77.json")
     AL.write_record(rec(runtime="claude", pane_id="%77", session_id="cl-4"),
                     directory=str(tmp_path))
     assert sorted(n for n in os.listdir(tmp_path) if n.endswith(".json")) == [
         "claude-p77.json", "opencode-p77.json"]
+
+
+# --------------------------------------------------------------------------- #
+# `--tmux-timeout` — the budget the two tests above assert under
+# --------------------------------------------------------------------------- #
+def _slow_tmux_env(tmp_path, delay):
+    """A stub tmux that answers only after `delay` seconds, plus the env."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    _stub_tmux(bindir, delay=delay)
+    return {"TMUX_PANE": "%77",
+            "PATH": "%s:%s" % (bindir, os.environ["PATH"])}
+
+
+def test_the_tmux_budget_is_what_decides_pane_keyed_vs_session_keyed(tmp_path):
+    """🔴 THE REGRESSION GUARD FOR `devrc-ci-wwj4d`, and its own control.
+
+    One stub, slower than `AL.DEFAULT_TMUX_TIMEOUT_S`, run twice with the ONLY
+    difference being the budget. Asserting both arms in one test is deliberate:
+    the wide arm alone would pass just as well if `--tmux-timeout` were ignored
+    and something else had made the call fast, and the narrow arm alone proves
+    nothing about the fix. Together they say the budget — not the flag's mere
+    presence, and not the host's spare capacity — decides the record shape.
+
+    RED at base for the wide arm: `--tmux-timeout` did not exist, so argparse
+    exits 2 and no record is written at all.
+    """
+    delay = AL.DEFAULT_TMUX_TIMEOUT_S + 0.5
+    wide, narrow = tmp_path / "wide", tmp_path / "narrow"
+    wide.mkdir(); narrow.mkdir()
+
+    env = _slow_tmux_env(tmp_path, delay)
+    # WIDE — the budget covers the slow answer, so the window resolves.
+    got = _cli("--runtime", "opencode", "--session", "oc-slow", env=env,
+               directory=wide, tmux_timeout=_TMUX_BUDGET_S)
+    assert got.returncode == 0, got.stderr
+    _assert_pane_keyed(wide, "opencode-p77.json")
+
+    # NARROW — same stub, same everything, a budget it cannot meet. The write
+    # still SUCCEEDS; it just lands in the session-keyed file. That losslessness
+    # is the property `filename_for` exists for, so pin it here rather than
+    # only asserting the absence of the pane file.
+    got = _cli("--runtime", "opencode", "--session", "oc-slow", env=env,
+               directory=narrow, tmux_timeout=delay / 4)
+    assert got.returncode == 0, got.stderr
+    assert sorted(os.listdir(str(narrow))) == ["opencode-s-oc-slow.json"], (
+        "a budget shorter than the stub's own delay must produce the DEGRADED "
+        "session-keyed record; if it produced the pane-keyed one, "
+        "--tmux-timeout is not reaching `subprocess.run`")
+
+
+@pytest.mark.parametrize("junk", ["0", "-1", "nan", "inf"])
+def test_a_junk_tmux_timeout_FAILS_CLOSED_rather_than_silently_degrading(
+        tmp_path, junk):
+    """🔴 A knob that ignores what it cannot read is a knob that switches the
+    check off on a typo. `subprocess.run(timeout=0)` expires immediately, so
+    `--tmux-timeout 0` would force the degraded path on EVERY write while the
+    CLI still exited 0 — the failure this whole change exists to make visible,
+    reintroduced as a silent default.
+
+    🔴 The assertion is on the MESSAGE, not on the exit code. At base an
+    unrecognised `--tmux-timeout` also exits 2 writing nothing, so an exit-code
+    assertion would be green for the wrong reason on a tree with no fix in it.
+    """
+    proc = _cli("--runtime", "opencode", "--session", "oc-junk",
+                directory=tmp_path, tmux_timeout=junk)
+    assert proc.returncode != 0
+    assert "--tmux-timeout must be a positive, finite number" in proc.stderr, (
+        f"expected the budget validator to reject {junk!r}; got:\n{proc.stderr}")
+    assert os.listdir(str(tmp_path)) == []
+
+
+def test_the_CLI_default_budget_IS_the_module_constant(tmp_path):
+    """INVARIANT GUARD, labelled as one — not regression coverage.
+
+    Two spellings of one budget is how the hook and the CLI end up disagreeing
+    about how long tmux gets. Read out of `--help` so it measures the parser's
+    real default rather than re-reading the constant this file already imported.
+    """
+    out = subprocess.run(
+        [sys.executable, _MODULE, "--write", "--runtime", "x", "--session", "y",
+         "--help"], capture_output=True, text=True, timeout=_CLI_BUDGET_S).stdout
+    assert "default %s" % AL.DEFAULT_TMUX_TIMEOUT_S in " ".join(out.split()), (
+        f"--tmux-timeout's default has drifted from DEFAULT_TMUX_TIMEOUT_S="
+        f"{AL.DEFAULT_TMUX_TIMEOUT_S}:\n{out}")
 
 
 def test_a_cross_runtime_conflict_NAMES_THE_RUNTIMES():


### PR DESCRIPTION
Closes two of the eight tests in the flaky set that has kept `tekton/devrc-pytests`
effectively red for ~41h. **It does not close the set** — read "What this does NOT
fix" before treating the gate as healed.

## First: the set is not ONE bug, and 27 of the 65 failures are not test failures at all

Classified every completed `devrc-ci` gate TaskRun in the cluster (169) by which
step died and with what code, rather than by the PipelineRun's `Failed`:

| outcome | n | what it means |
|---|---|---|
| GREEN | 104 | |
| **REAL TEST FAILURE** (`pytests` 0, `nodetests` 0, `verdict` 1) | **27** | a test genuinely went red |
| **a test step KILLED** | **27** | 25 × `step-pytests` 255, 1 × `step-nodetests` 255, 1 × `137` (OOMKilled). The step never reported. |
| clone died / `TaskRunTimeout` / no steps | 11 | |

65 failures, matching the count this work started from. So the "flaky test set"
is really two populations. The KILLED half is
concurrency-driven — 25 of 27 occurred with ≥4 other gate TaskRuns overlapping —
and the reason is in the Task, not in any test:

```
step-pytests   requests: cpu 1,    memory 2Gi
               limits:   cpu 4,    memory 8Gi
```

Measured here, a full `nix build .#checks.x86_64-linux.pytests` peaked at
**4.8 GiB `memory.current`** in the nix-daemon cgroup over 1066s — but
**`memory.stat anon` stayed around 0.3 GiB**, so that figure is dominated by
*reclaimable page cache*. Stated precisely, because it changes the conclusion:
page cache does count against a container's memory limit and does drive reclaim
stalls, but it is not by itself an OOM story. I did **not** establish what kills
the 255 runs — one sibling is a confirmed `137`, the other 25 exited 255, and
Tekton reports 255 for "the container terminated abnormally" without saying why.

What *is* measured is the packing. `talos-xr6-r7p`, the node these land on, is
**already committed to cpu limits 252% and memory limits 230%** of capacity
(16 cores / 32 GiB; 19.6 GiB of memory *requests* alone). A step that requests
1 CPU while wanting far more, on a node overcommitted 2.5× on CPU limits, is
CFS-throttled hard — and that is the amplifier under everything below.

**That is an infra change to the `devrc-ci-gate` Task in homelab-talos, not to
this repo, and it is the single largest contributor. Flagging, not doing** —
it is outward-facing and moves every CI run at once. Suggested direction: raise
`requests` toward the limits so the scheduler stops overcommitting, and/or cap
concurrent devrc-ci runs. Before changing numbers, capture `kubectl get pod
<gate-pod> -o json | jq .status.containerStatuses` on a fresh 255 — that says
`OOMKilled` vs `Evicted` vs `Error` and settles what to raise.

The 27 REAL TEST FAILURES are ~1 failing test out of ~15,500 each, spread across
8 distinct tests, and they do **not** correlate cleanly with concurrency (4 of
them happened with ≤1 overlapping run). They are separate genuine races and
deadlines that a slow container makes likely — a shared *amplifier*, not a
shared *bug*. Three already have owners; this PR takes a fourth.

## What this PR fixes

`test_the_CLI_throttles_on_a_repeat_from_the_SAME_session` and
`test_TWO_RUNTIMES_in_one_pane_do_not_overwrite_each_other` both assert that the
`--write` CLI produces a **pane-keyed** record — and that outcome silently
depends on the machine finishing a `/bin/sh` exec inside `tmux_context`'s
hardcoded `timeout=2.0`. Miss it and `filename_for` correctly falls back to a
**session-keyed** name; the write still succeeds and the CLI still exits 0. Only
the tests go red.

`devrc-ci-wwj4d`:

```
line 733  FileNotFoundError: .../pytest-0/test_the_CLI_throttles_on_a_re0/opencode-p77.json
line 767  AssertionError: assert ['claude-p77....-s-oc-4.json'] == ['claude-p77....ode-p77.json']
```

**Reproduced with the deadline as the only variable.** Pristine `3ee79cc5` copy
of the module, tests untouched, `timeout=2.0` → `0.001`: both tests fail, at the
same two line numbers, with byte-identical messages including
`opencode-s-oc-4.json`. The same shrink applied to **this** commit is green,
because the tests now name their own budget. Module and tests restored
byte-identical afterwards (sha256 verified); no `git stash` was used.

The change: `tmux_context` grows a `timeout=` parameter, the literal becomes
`DEFAULT_TMUX_TIMEOUT_S = 2.0`, and the CLI grows `--tmux-timeout`. **The
production default is unchanged and deliberately short** — both writers sit on
an agent's hot path and the degradation is lossless by design. The Claude hook
passes no timeout and is unaffected. A junk budget fails **closed** (`p.error`,
exit 2): `subprocess.run(timeout=0)` expires immediately, so `--tmux-timeout 0`
would force the degraded path on every write while still exiting 0.

## Verification

| tier | tree | result |
|---|---|---|
| dev host, `pytest scripts/tests` (the only target touched) | this branch | **7890 passed, 0 failed**, 720s |
| nix sandbox, `nix build .#checks.x86_64-linux.pytests` | `3ee79cc5` (baseline, before this change) | **PASS** — collected=15809, failed=0, 1066s |
| nix sandbox, same command | this branch (`2ae5a20e`) | **FAIL — on a test this diff cannot touch.** collected=**15815** (+6 = exactly the new guards), passed=15812, failed=1: `test_live_cotenants_does_not_count_this_process`. All 8 agent-ledger tests passed. See "a ninth flake" below. |

I have NOT run `scripts/gate.sh` end-to-end; I ran the one target the change
touches on the dev host, and the whole suite in the sandbox tier. Branch base is
`3ee79cc5`; `origin/main` has since moved to `efd59d3d` (#797, #805) and neither
touches `scripts/lib/agent_ledger.py` or `scripts/tests/test_agent_ledger.py`,
so the merged tree is textually and semantically disjoint from this change.

Red→green:

* the 6 new guards + the 2 originals: **8 failed** against a pristine `3ee79cc5`
  module, **59 passed** at HEAD.
* deadline-shrink probe: **RED at base with the CI signature, GREEN at HEAD**
  under the identical mutation.
* `test_a_junk_tmux_timeout_FAILS_CLOSED...` asserts the **message**, not the
  exit code — at base an unrecognised `--tmux-timeout` also exits 2 writing
  nothing, so an exit-code assertion would have been green for the wrong reason.
* the wide/narrow arms live in ONE test on purpose: the wide arm alone would pass
  just as well if the flag were ignored; the narrow arm alone proves nothing
  about the fix.
* `test_the_CLI_default_budget_IS_the_module_constant` is labelled an **invariant
  guard**, not regression coverage.

## What I could NOT verify

**The CI-side stall.** On a 24-core workbench the stub tmux call takes 0.003s
(p50) idle and peaks at **0.197s** under a 20× CPU stall (`systemd-run --user
--scope -p CPUQuota=5%`; positive control — a fixed burn goes 2.83s → 13.33s, so
the quota demonstrably bites). Neither 5× CPU oversubscription (120 spinners) nor
a 30%/10%/5% quota turned either test red on this host. So I proved the *causal
path* (a tmux answer later than the budget produces exactly the CI signature) and
that the fix removes the dependency — but **not** what makes the CI container
that slow. Memory pressure inside the 8Gi cgroup is the leading hypothesis given
the 25 kills beside it; it is a hypothesis, not a measurement.

## What this does NOT fix

| test | status |
|---|---|
| `test_the_pinned_docs_are_the_DEPLOYED_ones` | **already fixed** — this is the `nix-instantiate` 60s timeout of #796 (that PR names `devrc-ci-ztn92`, the run it failed on). Merged. |
| `test_concurrent_writers_do_not_lose_rows` | **#801** — missing SQLITE_BUSY retry. Same family (a contended write losing a race), different subsystem. Untouched. |
| `test_the_throttle_path_carries_both_the_hash_and_the_join_key` | **#802** — `_load_spool_emit` publishes its flag before its module, so a concurrent `/cmd` reads "tried" with the module still `None` and the event is **dropped**. Untouched. |
| `test_an_absent_origin_header_is_not_the_same_as_an_empty_one` | **same mechanism as #802**, and in the same file. It waits on `_wait_events(spool_dir, 2)` through the same emitter; one dropped event fails it identically. Flagging rather than editing, to avoid colliding with #802 — **whoever merges #802 should re-check this one rather than assume it is covered.** |
| `test_no_unallowlisted_public_ip_literal_is_committed` | **UNDIAGNOSED.** No wall-clock dependency in the sandbox tier (no `.git` there, so the `git ls-files` 60s path is not taken and it falls back to a walk). Could equally have been a *correct* red on a branch that added an IP literal. |
| `test_the_module_root_is_load_bearing` | **UNDIAGNOSED.** Its only nondeterminism is `_mkrepo`'s three `git` subprocesses (no timeouts, `check=True`). Could also have been a correct red. |

### A NINTH flake, caught by running the authoritative tier

`test_live_cotenants_does_not_count_this_process`
(`scripts/tests/test_git_repo_isolation.py:1479`) — **the same file as
`test_the_module_root_is_load_bearing`**, which is how it is relevant. It was not
in the reported set of eight. It went red in my sandbox run at this branch while
the *same tier on the baseline* was green 45 minutes earlier, and my diff cannot
reach it:

```
E  AssertionError: the probe counted our own process (or an ancestor) as a co-tenant
E  assert ['55705:git'] == []
```

Narrowed, **not established**: `live_cotenants` skips only our **ancestors**, and
skips zombies implicitly (it resolves `/proc/<pid>/cwd`, a dangling link for a
zombie). All three of `_mkrepo`'s `subprocess.run` calls wait and reap. So the
survivor must be something git **detached** — and the only thing git detaches is
`git commit`'s `run_auto_maintenance()`, since `gc.autoDetach` defaults to true.

I could not confirm that: 0/25 reproductions on the dev host at idle, under 96
spinners, and under `CPUQuota=5%`, with auto-maintenance on and off. A /proc
watcher I wrote to catch the detached process **failed its own positive control**
— it never saw even the `git commit` process — so its zeros are not evidence and
I am not quoting them as one.

Suggested, in order: (1) make `live_cotenants` record `cmdline` and `ppid`
alongside `pid:comm`, so the next occurrence identifies the process instead of
requiring this guesswork; (2) if it is auto-maintenance, `gc.auto=0` +
`maintenance.auto=false` + `gc.autoDetach=false` in that file's `_GIT_ENV` kills
it at the source. **Deliberately not done here** — I have watched it fail once
and cannot re-run it, so I cannot show a fix green, and a plausible fix I cannot
falsify is exactly how this set got to nine.

The two undiagnosed ones need the failing run's log, which I could not recover:
the pods are GC'd, and the GitHub commit status is capped at 140 chars and
predates the `FAILING: <test>` field, so 26 of the 27 runs only report a count.
**If either recurs, capture `nix log` from the pod before it is collected.**

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NsRe3TW5xbSgzkqB7Catv
