### PR TITLE
fix(home): deploy RULES-ARCHIVE.md — every `→ archive:` pointer in RULES.md was a dead end

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -942,6 +942,22 @@ in
     source = ../claude/RULES.md;
     force = true;  # overwrite the pre-existing unmanaged file on first switch
   };
+  # 🔴 RULES.md is USELESS ON ITS OWN: it is dense with `→ archive: <anchor>`
+  # pointers into RULES-ARCHIVE.md — the evidence, dates and retracted theories
+  # behind each rule. Until 2026-08-24 the archive was deployed NOWHERE, so
+  # ~/.claude/RULES-ARCHIVE.md did not exist and every one of those pointers was
+  # a dead end for any agent without a devrc checkout. That is the "reads as
+  # coverage while providing none" shape RULES.md itself names: a pointer nobody
+  # can follow stops people looking, which is worse than no pointer.
+  #
+  # Costs nothing per session: unlike RULES.md this is NOT auto-loaded and NOT
+  # concatenated into opencode's AGENTS.md (that concat reads ../claude/RULES.md
+  # explicitly — see the opencode block below). It is paid only when an agent
+  # actually follows a pointer, which is exactly when it should be.
+  home.file.".claude/RULES-ARCHIVE.md" = {
+    source = ../claude/RULES-ARCHIVE.md;
+    force = true;
+  };
   home.file.".claude/PRINCIPLES.md" = {
     source = ../claude/PRINCIPLES.md;
     force = true;

--- a/scripts/tests/test_doc_path_rot.py
+++ b/scripts/tests/test_doc_path_rot.py
@@ -241,6 +241,7 @@ DEPLOYED_MAP: tuple[tuple[str, Path], ...] = (
     ("~/.claude/hooks/", REPO_ROOT / "scripts/claude-hooks"),
     ("~/.claude/skills/", REPO_ROOT / "claude/skills"),
     ("~/.claude/RULES.md", REPO_ROOT / "claude/RULES.md"),
+    ("~/.claude/RULES-ARCHIVE.md", REPO_ROOT / "claude/RULES-ARCHIVE.md"),
     ("~/.claude/PRINCIPLES.md", REPO_ROOT / "claude/PRINCIPLES.md"),
     # Not a deploy entry -- a spelling of this repo's own root that docs use.
     # Tilde-only on purpose: see the HERMETICITY note in the module docstring.


### PR DESCRIPTION
`claude/RULES.md` is dense with `→ archive: <anchor>` pointers into `RULES-ARCHIVE.md` — the evidence, dates and retracted theories behind each rule. **The archive was deployed nowhere.**

```
$ readlink -f ~/.claude/RULES-ARCHIVE.md
/home/zach/.claude/RULES-ARCHIVE.md      # the path itself — not a symlink, not present
$ grep -c … ~/.claude/RULES-ARCHIVE.md
ugrep: warning: No such file or directory
```

`nix/home.nix` had `home.file` entries for `RULES.md` and `PRINCIPLES.md` only. So for any agent without a devrc checkout, **every one of those pointers resolved to nothing** — the exact failure RULES.md names in its own words: a reference that reads as coverage while providing none is worse than none, because it stops anyone looking.

`CLAUDE.md` already *claimed* this was deployed — "`claude/` — `RULES.md` (+ `RULES-ARCHIVE.md`) … `nix/home.nix` symlinks these into `~/.claude/`". This makes that sentence true rather than editing the sentence to document the gap.

## Why this is free

Unlike `RULES.md`, the archive is **not auto-loaded** and **not** concatenated into opencode's `AGENTS.md` — verified: that concat reads `PRINCIPLES.md` + `RULES.md` + `opencode-addendum.md` explicitly (`home.nix:1415-1417`), so this entry does not touch it. RULES.md's own "NOT shipped to opencode" stays true. The archive is paid only when an agent actually follows a pointer, which is when it should be.

## Verification

- `nix-instantiate --parse nix/home.nix` → OK
- `mkOutOfStoreSymlink` paths unaffected — they resolve from `workspace = "${home}/workspace"` (`home.nix:5`), not the flake root, so building from a worktree cannot repoint them.
- Node tier: **1202 tests, 0 fail** across 4 suites (floor 1173).
- pytest tier: run under `nix develop` (the worktree has no flake env of its own — a bare `gate.sh` there exits 3 on the toolchain precondition, which is *not* a test failure).
- Post-merge: `home-manager switch` then re-check `readlink -f ~/.claude/RULES-ARCHIVE.md` terminates in `/nix/store` — merged ≠ deployed for every `home.file` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5zXWvD7jqNbANCbQyarZb
