### PR TITLE
test(clickup+ccua): one TABLE for the awaiting predicate — the code consolidation is a regression, and here is why

### DIFF
--- a/claude/skills/clickup/SKILL.md
+++ b/claude/skills/clickup/SKILL.md
@@ -121,3 +121,6 @@ there is no ClickUp hook; it is a convention, and the flow says so first.
 - **CHANGING this skill** — where to edit so the change deploys, the nix-built
   `node_modules` + `npmDepsHash`, and the test suites →
   `~/.claude/skills/clickup/reference/maintaining.md`.
+- **"`check-clickup-addressed` re-derives `awaiting`'s predicate — consolidate them"**
+  → `~/.claude/skills/clickup/reference/awaiting-vs-ccua.md`. It cannot; the answer is
+  measured, not argued. Read it BEFORE proposing that ccua call `query.mjs awaiting`.

--- a/claude/skills/clickup/lib/awaiting.mjs
+++ b/claude/skills/clickup/lib/awaiting.mjs
@@ -29,6 +29,19 @@
  * Everything here is pure except `findAwaiting`, whose two effects (fetching
  * comments, sleeping) are injected, so the cap and pacing are testable without
  * a network.
+ *
+ * 🔴 THIS PREDICATE IS IMPLEMENTED TWICE, AND THAT IS DELIBERATE.
+ * `scripts/check-clickup-addressed/` derives the same fact across a seam
+ * (`recent-comments.py::latest_reply_ts_by` -> `check-addressed.py::
+ * _reply_answers_the_comment`), and it already shells out to this CLI — so
+ * "have ccua call `query.mjs awaiting`" looks obvious and is a REGRESSION. The
+ * decisive reason is one line below (`selectAwaiting` skips a task the owner
+ * answered last, which is exactly the population ccua's suppression note is
+ * built from); the rest, plus the three measured cross-language divergences,
+ * are in `reference/awaiting-vs-ccua.md`. The two implementations are pinned to
+ * ONE shared table — `test/awaiting-contract.fixtures.json`, read by
+ * `test/awaiting-contract.test.mjs` and by the Python half — so neither can
+ * drift silently. Read that file before changing anything here.
  */
 
 export const MS_PER_DAY = 86400000;

--- a/claude/skills/clickup/reference/awaiting-vs-ccua.md
+++ b/claude/skills/clickup/reference/awaiting-vs-ccua.md
@@ -1,0 +1,88 @@
+# `awaiting` vs `check-clickup-addressed` — why the predicate is not consolidated
+
+**The question this file answers, once:** the predicate *"the newest comment on this task
+is NOT the token owner's"* is implemented twice in this repo, in two languages.
+`scripts/check-clickup-addressed/` (ccua) already shells out to this CLI. So why doesn't
+it call `query.mjs awaiting` and stop re-deriving?
+
+**Because it would be a regression, and the specific losses are enumerated and tested.**
+Read this before proposing the consolidation again — the reasoning below is measured, and
+every claim in it is pinned by a test that goes red when it stops being true.
+
+## Where the two implementations actually are
+
+| side | file | shape |
+|---|---|---|
+| JS | `lib/awaiting.mjs :: isAwaiting()` | per TASK, a **boolean** |
+| PY | `recent-comments.py :: latest_reply_ts_by()` → `check-addressed.py :: _reply_answers_the_comment()` | per COMMENT, a **three-state** derived across a seam |
+
+⚠️ `recent-comments.py`'s author comparison (`str(c["user"]["id"]) != my_id`) is **not**
+the duplicate — that is a per-comment *authorship filter*, a different predicate. The
+duplicate is the pair in the table above, and the Python side is the **richer** one, which
+is why the consolidation direction that looks obvious is backwards.
+
+## The blockers
+
+Machine-readable in `test/awaiting-contract.fixtures.json` → `blockers`. In severity order:
+
+1. **Population (decisive).** `awaiting` emits a row *only* when the newest comment is not
+   the owner's. Every task the owner answered last is structurally absent — and that is
+   exactly the population `_waiting_verdict`'s **ANSWERED / suppression** branch is built
+   from, the branch carrying `BOT_IDENTITY_CAVEAT` ("an agent may have answered as you").
+   Feeding ccua from `awaiting` deletes that whole block with nothing failing.
+2. **Comment text.** `awaiting` rows carry no body at all. ccua's entire decision surface
+   is the text: the keep-open veto, the RESOLVED-reading-comment flag, `TEXT_CHARS`.
+3. **`my_latest_reply` / `my_latest_reply_ms`.** No equivalent exists. It is the fix for
+   the D12 seam defect, and its *absence* is itself a reported fact (`UNIDENTIFIED`). A
+   two-state boolean cannot carry a three-state field.
+4. **`task_priority`.** `awaiting` carries `status` but not `priority`.
+5. **Failure mode.** With an unresolvable owner id, `query.mjs awaiting` exits 1 and prints
+   nothing. ccua continues, warns on stderr, and *withholds* the key so the consumer takes
+   its announce-rather-than-decide branch. Exiting is right for a triage command and wrong
+   for a producer feeding a report.
+
+Blockers 2–4 could be added to `awaiting` at the cost of turning a triage command into a
+data dump. **Blocker 1 cannot** — it is the command's definition — and blocker 5 is a
+deliberate difference in kind.
+
+## What WAS consolidated: the table, not the code
+
+`test/awaiting-contract.fixtures.json` is the single definition of the *contract*, read by
+both suites:
+
+* `test/awaiting-contract.test.mjs` measures `isAwaiting()`;
+* `scripts/check-clickup-addressed/tests/test_awaiting_contract.py` measures the ccua
+  producer → consumer pipeline end to end.
+
+Neither copies the other's column, and **both** recompute the divergence ledger from the
+two columns and pin it as a set, so a divergence appearing *or* disappearing is red on
+both sides. Nothing else makes these two agree; do not delete the fixture to "simplify".
+
+## The three measured divergences
+
+Cross-language behaviour differences, found by writing the table — not previously known:
+
+* **`owner_reply_in_the_same_millisecond`** — two comments at the same instant. Python
+  resolves it by an explicit rule (`mine_ms >= theirs_ms`; a genuine tie counts as
+  answered). JS resolves it by **array order** — `newestComment()` keeps the first of an
+  equal pair — so reversing the list flips the verdict, and in the API's own order it
+  answers the *opposite* of Python.
+* **`the_owners_own_comment_has_an_unreadable_date`** — Python declines to claim
+  (`UNIDENTIFIED` → the key is withheld → the flag fires *with* a note that the check did
+  not run). JS returns a **confident `true`** over a thread it cannot rank. Same
+  direction, different confidence, and `isAwaiting()`'s return type cannot express it.
+* **`every_comment_has_an_unreadable_date`** — Python declines. JS's answer is a property
+  of the response order rather than of the thread.
+
+None is currently reachable in production — all 84 comments sampled when `awaiting` was
+written carried a `date`, and an exact-millisecond tie needs two writes in the same
+millisecond. They are **pinned rather than fixed**: changing `isAwaiting()`'s behaviour on
+an unobserved input is a live behaviour change to a shipped command bought with nothing.
+The order-dependence label is proved by reversing the list, not asserted.
+
+## If you are here to close a blocker
+
+Fine — but move the fixture and this file in the same commit, and say in the commit
+message which behaviour changed. The guards will tell you if you missed one: the JS half
+pins the exact `awaiting` row key set, and the Python half pins that ccua still emits each
+blocked field, so a blocker that is genuinely retired fails **both** sides at once.

--- a/claude/skills/clickup/test/awaiting-contract.fixtures.json
+++ b/claude/skills/clickup/test/awaiting-contract.fixtures.json
@@ -1,0 +1,190 @@
+{
+  "_doc": [
+    "THE ONE TABLE. Two implementations of 'the newest comment on this task is NOT the",
+    "token owner's' live in this repo, in two languages, and NOTHING made them agree until",
+    "this file existed. It is read by BOTH suites:",
+    "",
+    "  JS  claude/skills/clickup/test/awaiting-contract.test.mjs",
+    "        -> measures claude/skills/clickup/lib/awaiting.mjs :: isAwaiting()",
+    "  PY  scripts/check-clickup-addressed/tests/test_awaiting_contract.py",
+    "        -> measures the ccua pipeline end to end: recent-comments.py::_collect (the",
+    "           producer, including latest_reply_ts_by + the UNIDENTIFIED sentinel) joined to",
+    "           check-addressed.py::build_newest_comment + _reply_answers_the_comment (the",
+    "           consumer that DERIVES the same predicate from what the producer reported).",
+    "",
+    "Each side MEASURES its own column rather than asserting it, so this table cannot lie",
+    "about either implementation; and each side recomputes `divergences` from the two columns",
+    "and pins it, so a divergence appearing OR disappearing is red on both sides.",
+    "",
+    "WHY THE TWO ARE NOT CONSOLIDATED: see `blockers` below and",
+    "claude/skills/clickup/reference/awaiting-vs-ccua.md. The short version is that",
+    "`query.mjs awaiting` cannot be ccua's producer, so a shared TABLE is the only single",
+    "definition available. Do not delete this file to 'simplify' — it is the consolidation.",
+    "",
+    "Every id, username and timestamp below is SYNTHETIC. This repo is public. Comment texts",
+    "are deliberately short, whitespace-free tokens: the authorship predicate never reads",
+    "them, ccua only requires them to be non-empty, and scripts/tests/test_no_captured_text.py",
+    "scans every string under a `comments` key."
+  ],
+
+  "owner_id": "9000001",
+  "colleague_id": "9000002",
+  "now_ms": 1755820800000,
+
+  "_timestamps": {
+    "early": "1755648000000  (now - 2d)",
+    "mid": "1755734400000  (now - 1d)",
+    "late": "1755777600000  (now - 12h)"
+  },
+
+  "_columns": {
+    "awaiting": "THE CONTRACT. true | false | \"undecidable\" — what is actually knowable from the comment list. \"undecidable\" means no implementation can honestly return a boolean; at least one side must therefore be non-boolean below.",
+    "js": "MEASURED from isAwaiting(). true | false | \"order-dependent\" (the answer flips when the comment array is reversed — asserted by reversing it, never merely labelled).",
+    "py": "MEASURED from the ccua producer+consumer pipeline. true | false | \"unverified\". \"unverified\" is the state awaiting.mjs has no way to return: the pipeline REFUSES to decide from the evidence, because the producer withheld `my_latest_reply` (the UNIDENTIFIED sentinel — the owner's own comments cannot be ranked, or the owner could not be identified at all) or because neither date resolution could be read. `_waiting_verdict` then surfaces the ticket with an explicit note that the check did not run, instead of claiming nobody answered.",
+    "_note_on_present_and_null": "`my_latest_reply: null` is NOT \"unverified\" — it is the positive claim \"I looked at every comment and none is mine\", so the newest comment is the colleague's and the verdict is a decided `true`. Present-and-null vs ABSENT is the distinction the whole ccua seam exists to protect, and reading them as one value is the false negative it was built against."
+  },
+
+  "cases": [
+    {
+      "name": "colleague_commented_last",
+      "why": "the ordinary match — someone else spoke after the owner did",
+      "comments": [
+        {"id": "c1", "user": {"id": "9000001", "username": "owner-synth"}, "date": "1755648000000", "comment": [{"text": "ack-alpha"}]},
+        {"id": "c2", "user": {"id": "9000002", "username": "colleague-synth"}, "date": "1755777600000", "comment": [{"text": "q-bravo"}]}
+      ],
+      "awaiting": true,
+      "js": true,
+      "py": true
+    },
+    {
+      "name": "owner_commented_last",
+      "why": "🔴 THE STRUCTURAL BLOCKER. `awaiting` DROPS this task entirely — that is its whole definition — while ccua still emits a record for the colleague's comment carrying `my_latest_reply_ms`, which is the ONLY input check-addressed.py's ANSWERED/suppression block has. Both halves are asserted, one per suite.",
+      "comments": [
+        {"id": "c3", "user": {"id": "9000002", "username": "colleague-synth"}, "date": "1755648000000", "comment": [{"text": "q-charlie"}]},
+        {"id": "c4", "user": {"id": "9000001", "username": "owner-synth"}, "date": "1755777600000", "comment": [{"text": "ack-delta"}]}
+      ],
+      "awaiting": false,
+      "js": false,
+      "py": false
+    },
+    {
+      "name": "only_a_colleague_has_commented",
+      "why": "no reply of the owner's exists at all — 'never answered', which is a different fact from 'could not look'",
+      "comments": [
+        {"id": "c5", "user": {"id": "9000002", "username": "colleague-synth"}, "date": "1755734400000", "comment": [{"text": "q-echo"}]}
+      ],
+      "awaiting": true,
+      "js": true,
+      "py": true
+    },
+    {
+      "name": "only_the_owner_has_commented",
+      "why": "nobody is waiting; ccua emits no row because it drops the owner's own comments",
+      "comments": [
+        {"id": "c6", "user": {"id": "9000001", "username": "owner-synth"}, "date": "1755734400000", "comment": [{"text": "note-foxtrot"}]}
+      ],
+      "awaiting": false,
+      "js": false,
+      "py": false
+    },
+    {
+      "name": "no_comments_at_all",
+      "why": "the empty list must not read as 'someone is waiting' on either side",
+      "comments": [],
+      "awaiting": false,
+      "js": false,
+      "py": false
+    },
+    {
+      "name": "owner_reply_in_the_same_millisecond",
+      "why": "🔴 DIVERGENCE, and on a REACHABLE input. There is no single newest comment, so the contract is undecidable. Python resolves it by an explicit documented rule (`mine_ms >= theirs_ms` — a genuine tie counts as answered; see _reply_answers_the_comment). JS resolves it by ARRAY ORDER: newestComment() keeps the first of an equal pair, so reversing the list flips the verdict — and in the API's own order it answers the OPPOSITE of Python.",
+      "comments": [
+        {"id": "c7", "user": {"id": "9000002", "username": "colleague-synth"}, "date": "1755734400000", "comment": [{"text": "q-golf"}]},
+        {"id": "c8", "user": {"id": "9000001", "username": "owner-synth"}, "date": "1755734400000", "comment": [{"text": "ack-hotel"}]}
+      ],
+      "awaiting": "undecidable",
+      "js": "order-dependent",
+      "py": false
+    },
+    {
+      "name": "the_newest_comment_has_no_author_id",
+      "why": "an unidentifiable COMMENT AUTHOR counts as someone else on both sides — a false positive costs one glance, a false negative hides the thing the check exists to find",
+      "comments": [
+        {"id": "c9", "user": {"id": "9000001", "username": "owner-synth"}, "date": "1755648000000", "comment": [{"text": "ack-india"}]},
+        {"id": "c10", "user": {}, "date": "1755777600000", "comment": [{"text": "q-juliett"}]}
+      ],
+      "awaiting": true,
+      "js": true,
+      "py": true
+    },
+    {
+      "name": "the_owners_own_comment_has_an_unreadable_date",
+      "why": "🔴 THE UNIDENTIFIED DISTINCTION, and the reason a consolidation onto the JS side would be LOSSY. One of the owner's comments cannot be dated, so which of the owner's comments is newest is UNKNOWABLE and Python says so (latest_reply_ts_by returns UNIDENTIFIED, build_record omits the key, and the flag announces that the check did not run). isAwaiting() has no third state: it sorts the undated comment oldest and returns a CONFIDENT true. Same direction, different confidence — and awaiting.mjs cannot express the difference.",
+      "comments": [
+        {"id": "c11", "user": {"id": "9000001", "username": "owner-synth"}, "date": "", "comment": [{"text": "ack-kilo"}]},
+        {"id": "c12", "user": {"id": "9000002", "username": "colleague-synth"}, "date": "1755777600000", "comment": [{"text": "q-lima"}]}
+      ],
+      "awaiting": "undecidable",
+      "js": true,
+      "py": "unverified"
+    },
+    {
+      "name": "every_comment_has_an_unreadable_date",
+      "why": "🔴 DIVERGENCE. Nothing can be ranked. Python declines to claim. isAwaiting() sorts every undated comment to -Infinity and keeps whichever the API happened to return first, so its answer is a property of the response order rather than of the thread.",
+      "comments": [
+        {"id": "c13", "user": {"id": "9000001", "username": "owner-synth"}, "date": "", "comment": [{"text": "ack-mike"}]},
+        {"id": "c14", "user": {"id": "9000002", "username": "colleague-synth"}, "date": "", "comment": [{"text": "q-november"}]}
+      ],
+      "awaiting": "undecidable",
+      "js": "order-dependent",
+      "py": "unverified"
+    }
+  ],
+
+  "divergences": [
+    "every_comment_has_an_unreadable_date",
+    "owner_reply_in_the_same_millisecond",
+    "the_owners_own_comment_has_an_unreadable_date"
+  ],
+
+  "awaiting_row_keys": [
+    "ageMs",
+    "commentCount",
+    "id",
+    "lastCommentAtMs",
+    "lastCommentBy",
+    "lastCommentById",
+    "list",
+    "name",
+    "status",
+    "url"
+  ],
+
+  "blockers": [
+    {
+      "kind": "population",
+      "field": "(the whole task)",
+      "why": "`awaiting` emits a row ONLY when the newest comment is not the owner's, so every task the owner answered last is structurally absent from its output. That is exactly the population check-addressed.py's ANSWERED note is built from — the note that carries BOT_IDENTITY_CAVEAT, i.e. the only place the report says 'an agent may have answered as you'. Asserted by the `owner_commented_last` case in both suites."
+    },
+    {
+      "kind": "field",
+      "field": "comment text",
+      "why": "`awaiting` rows carry no comment body at all (see `awaiting_row_keys`). ccua's whole decision surface is the text: the keep-open veto, the RESOLVED-reading-comment flag and the 4000-char TEXT_CHARS cap all read `text`."
+    },
+    {
+      "kind": "field",
+      "field": "my_latest_reply / my_latest_reply_ms",
+      "why": "no equivalent exists in awaiting.mjs. It is the fix for the D12 seam defect (a WAITING flag blind to the owner's own replies) and its ABSENCE is itself a reported fact — the UNIDENTIFIED sentinel. A two-state boolean cannot carry a three-state field."
+    },
+    {
+      "kind": "field",
+      "field": "task_priority",
+      "why": "`awaiting` carries `status` but not `priority`; check-addressed.py sets `clickup_priority` from it."
+    },
+    {
+      "kind": "failure-mode",
+      "field": "the owner's user id",
+      "why": "when the owner id cannot be resolved, `query.mjs awaiting` exits 1 and prints nothing. ccua CONTINUES with UNIDENTIFIED, warns on stderr, and disables every downstream 'have I already replied?' check by omitting the key. Exiting is right for a triage command and wrong for a producer feeding a report."
+    }
+  ]
+}

--- a/claude/skills/clickup/test/awaiting-contract.test.mjs
+++ b/claude/skills/clickup/test/awaiting-contract.test.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+
+/**
+ * The JS half of the CROSS-LANGUAGE contract for
+ * "the newest comment on this task is NOT the token owner's".
+ *
+ * 🔴 WHY THIS FILE EXISTS AT ALL. That predicate is implemented TWICE in this
+ * repo, in two languages:
+ *
+ *   * here, as `isAwaiting()` in `lib/awaiting.mjs` — the `awaiting` command;
+ *   * in `scripts/check-clickup-addressed/`, where `recent-comments.py` reports
+ *     the owner's newest reply and `check-addressed.py::_reply_answers_the_comment`
+ *     derives the same predicate from it.
+ *
+ * ccua already shells out to THIS CLI (`recent-comments.py` runs
+ * `node query.mjs my-tasks|comments|me`), so the obvious consolidation is for it
+ * to call `query.mjs awaiting` and stop re-deriving. It CANNOT — see the
+ * `blockers` array in the fixture and `reference/awaiting-vs-ccua.md`. The
+ * decisive one is asserted below rather than argued: `awaiting` structurally
+ * drops every task the owner answered last, and that is precisely the population
+ * check-addressed.py's suppression note is built from.
+ *
+ * So the single definition available is a shared TABLE, not shared code:
+ * `awaiting-contract.fixtures.json`, read by this file and by
+ * `scripts/check-clickup-addressed/tests/test_awaiting_contract.py`. Each side
+ * MEASURES its own column — neither copies the other's — and both recompute the
+ * divergence ledger from the two columns and pin it, so a divergence appearing
+ * OR disappearing is red on both sides.
+ *
+ * 🔴 THESE ARE SEAM / INVARIANT GUARDS, NOT REGRESSION COVERAGE. No defect is
+ * being fixed here; nothing below was red before this file existed because
+ * nothing below existed. Their evidence is the MUTATION matrix in the PR body:
+ * break either implementation's predicate and a named test here (or in the
+ * Python half) goes red with its own message.
+ *
+ * Every value in the fixture is SYNTHETIC. This repo is public.
+ *
+ * Usage:
+ *   node test/awaiting-contract.test.mjs
+ *   node --test test/awaiting-contract.test.mjs
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { isAwaiting, selectAwaiting } from '../lib/awaiting.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = resolve(__dirname, 'awaiting-contract.fixtures.json');
+const FIXTURE = JSON.parse(readFileSync(FIXTURE_PATH, 'utf8'));
+
+const OWNER = FIXTURE.owner_id;
+const CASES = FIXTURE.cases;
+const byName = (name) => {
+  const c = CASES.find((x) => x.name === name);
+  assert.ok(c, `fixture has no case named ${name} — the table and this file disagree`);
+  return c;
+};
+
+/**
+ * What `isAwaiting` yields for a case, in the fixture's own vocabulary.
+ *
+ * `order-dependent` is DERIVED, never trusted from the table: the list is
+ * reversed and the two answers compared. A label nobody can watch fire is
+ * indistinguishable from a label wired to nothing, and "the API's ordering
+ * decides the verdict" is the exact claim worth being able to watch.
+ */
+function measureJs(comments) {
+  const forward = isAwaiting(comments, OWNER);
+  const reversed = isAwaiting([...comments].reverse(), OWNER);
+  return forward === reversed ? forward : 'order-dependent';
+}
+
+// ── The measured column ──────────────────────────────────────────────────────
+
+for (const c of CASES) {
+  test(`CONTRACT[js]: ${c.name}`, () => {
+    assert.equal(measureJs(c.comments), c.js,
+      `the fixture records js=${JSON.stringify(c.js)} for ${c.name}, but isAwaiting() `
+      + `yields ${JSON.stringify(measureJs(c.comments))}. One of the two is wrong; the `
+      + 'implementation is the authority, so re-read it before editing the table.');
+  });
+}
+
+test('CONTRACT[js]: an "order-dependent" label is proven by REVERSING the list, not asserted', () => {
+  // The positive control for `measureJs`. Without it, every case could be
+  // labelled order-dependent and the label would mean nothing.
+  const flippy = CASES.filter((c) => c.js === 'order-dependent');
+  assert.ok(flippy.length > 0, 'no order-dependent case left in the table — if isAwaiting() '
+    + 'became order-independent that is a FIX, but this control and the fixture must move with it');
+  for (const c of flippy) {
+    const forward = isAwaiting(c.comments, OWNER);
+    const reversed = isAwaiting([...c.comments].reverse(), OWNER);
+    assert.notEqual(forward, reversed,
+      `${c.name} is labelled order-dependent but isAwaiting() returned ${forward} in BOTH `
+      + 'directions — the label is now false');
+  }
+});
+
+test('CONTRACT[js]: an "undecidable" contract row has a non-boolean on at least one side', () => {
+  // Otherwise the word is decoration: if both implementations answer a clean
+  // boolean, the fact WAS decidable and the table is lying about the spec.
+  for (const c of CASES.filter((x) => x.awaiting === 'undecidable')) {
+    assert.ok(typeof c.js !== 'boolean' || typeof c.py !== 'boolean',
+      `${c.name} is marked undecidable but both sides record a boolean `
+      + `(js=${c.js}, py=${c.py}) — then it is decidable and the contract column is wrong`);
+  }
+});
+
+test('CONTRACT[js]: where both sides answer a boolean, they equal the contract', () => {
+  const checked = [];
+  for (const c of CASES) {
+    if (typeof c.js !== 'boolean' || typeof c.py !== 'boolean') continue;
+    assert.equal(typeof c.awaiting, 'boolean',
+      `${c.name}: both implementations answer a boolean, so the contract must too`);
+    assert.equal(c.js, c.awaiting, `${c.name}: JS disagrees with the contract`);
+    assert.equal(c.py, c.awaiting, `${c.name}: Python disagrees with the contract`);
+    checked.push(c.name);
+  }
+  assert.ok(checked.length >= 5,
+    `only ${checked.length} case(s) exercised the agreement claim — a table whose cases are `
+    + 'nearly all divergent proves the two are equivalent nowhere');
+});
+
+// ── The divergence ledger, recomputed from the two columns ───────────────────
+
+test('CONTRACT[js]: the divergence ledger is exactly the set the two columns produce', () => {
+  // 🔴 Asserted as a SET that fails when it GROWS *or* SHRINKS. A ledger that
+  // only catches growth blesses a silent narrowing, and a divergence that
+  // disappears is a behaviour change on a live command.
+  const derived = CASES.filter((c) => c.js !== c.py).map((c) => c.name).sort();
+  const pinned = [...FIXTURE.divergences].sort();
+  assert.deepEqual(derived, pinned,
+    'the pinned `divergences` ledger no longer matches the table.\n'
+    + `  derived: ${JSON.stringify(derived)}\n`
+    + `  pinned:  ${JSON.stringify(pinned)}\n`
+    + 'If an implementation changed, update BOTH the case row and this ledger, and say in '
+    + 'the commit which behaviour moved.');
+});
+
+test('CONTRACT[js]: isAwaiting() cannot express the UNIDENTIFIED distinction', () => {
+  // The single most important row in the table: it is why a consolidation onto
+  // this side would be LOSSY, and it is a property of the RETURN TYPE, so it
+  // cannot be fixed by care inside the function.
+  const c = byName('the_owners_own_comment_has_an_unreadable_date');
+  assert.equal(c.py, 'unverified',
+    'the Python pipeline is supposed to decline to claim here (UNIDENTIFIED)');
+  assert.equal(typeof isAwaiting(c.comments, OWNER), 'boolean',
+    'isAwaiting() grew a third state — if that is deliberate, this guard and the fixture '
+    + 'both move, and ccua may finally be able to consume this command');
+  assert.equal(isAwaiting(c.comments, OWNER), true,
+    'and the boolean it returns is a CONFIDENT true over a thread it cannot rank');
+});
+
+// ── The structural blocker, asserted rather than argued ──────────────────────
+
+test('CONTRACT[js]: `awaiting` emits NO row for a task the owner answered last', () => {
+  // 🔴 This is the blocker. The rows dropped here are exactly the ones
+  // check-addressed.py's ANSWERED/suppression note is built from — the note
+  // that carries the bot-identity caveat. A consumer fed by this command would
+  // lose that whole block with nothing failing.
+  const c = byName('owner_commented_last');
+  const sel = selectAwaiting({
+    tasks: [{ id: 'T-SYNTH-1', name: 'synthetic task', url: 'https://example.invalid/t/1' }],
+    commentsByTaskId: new Map([['T-SYNTH-1', c.comments]]),
+    ownerUserId: OWNER,
+    now: FIXTURE.now_ms,
+  });
+  assert.equal(sel.rows.length, 0,
+    'selectAwaiting() now emits a row for a task the owner answered last. That would be a '
+    + 'change to the command\'s definition — and it would also retire blocker "population" '
+    + 'in the fixture, so move both.');
+  assert.equal(sel.withComments, 1,
+    'the task was examined and HAD comments — the zero above is a verdict, not an empty scan');
+});
+
+test('CONTRACT[js]: an `awaiting` row carries exactly these fields, and no comment body', () => {
+  // An exact key ledger rather than "does not contain `text`": a spelled guard
+  // on one absent word passes while the hazard exists under another spelling,
+  // and this ledger is what the `field` blockers are measured against.
+  const c = byName('colleague_commented_last');
+  const sel = selectAwaiting({
+    tasks: [{
+      id: 'T-SYNTH-2',
+      name: 'another synthetic task',
+      url: 'https://example.invalid/t/2',
+      list: { name: 'Synthetic List' },
+      status: { status: 'to do' },
+    }],
+    commentsByTaskId: new Map([['T-SYNTH-2', c.comments]]),
+    ownerUserId: OWNER,
+    now: FIXTURE.now_ms,
+  });
+  assert.equal(sel.rows.length, 1, 'the fixture\'s canonical matching case stopped matching');
+  assert.deepEqual(Object.keys(sel.rows[0]).sort(), [...FIXTURE.awaiting_row_keys].sort(),
+    'the `awaiting` row shape changed. Update `awaiting_row_keys` in the fixture AND re-read '
+    + 'the `blockers` entries — a new field may have retired one of them.');
+});
+
+test('CONTRACT[js]: every blocker carries a kind and a reason', () => {
+  // A blocker with no reason is a sentence that was true once. The Python half
+  // asserts the same over the same array, so neither reader can drift alone.
+  const KINDS = new Set(['population', 'field', 'failure-mode']);
+  assert.ok(FIXTURE.blockers.length >= 5,
+    'the blocker ledger shrank — if a blocker was genuinely closed, say which in the commit');
+  for (const b of FIXTURE.blockers) {
+    assert.ok(KINDS.has(b.kind), `unknown blocker kind ${JSON.stringify(b.kind)}`);
+    assert.ok(typeof b.field === 'string' && b.field.length > 0, `blocker ${b.kind} names no field`);
+    assert.ok(typeof b.why === 'string' && b.why.length > 40,
+      `blocker ${b.kind}/${b.field} carries no usable reason`);
+  }
+});

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -942,6 +942,22 @@ in
     source = ../claude/RULES.md;
     force = true;  # overwrite the pre-existing unmanaged file on first switch
   };
+  # 🔴 RULES.md is USELESS ON ITS OWN: it is dense with `→ archive: <anchor>`
+  # pointers into RULES-ARCHIVE.md — the evidence, dates and retracted theories
+  # behind each rule. Until 2026-08-24 the archive was deployed NOWHERE, so
+  # ~/.claude/RULES-ARCHIVE.md did not exist and every one of those pointers was
+  # a dead end for any agent without a devrc checkout. That is the "reads as
+  # coverage while providing none" shape RULES.md itself names: a pointer nobody
+  # can follow stops people looking, which is worse than no pointer.
+  #
+  # Costs nothing per session: unlike RULES.md this is NOT auto-loaded and NOT
+  # concatenated into opencode's AGENTS.md (that concat reads ../claude/RULES.md
+  # explicitly — see the opencode block below). It is paid only when an agent
+  # actually follows a pointer, which is exactly when it should be.
+  home.file.".claude/RULES-ARCHIVE.md" = {
+    source = ../claude/RULES-ARCHIVE.md;
+    force = true;
+  };
   home.file.".claude/PRINCIPLES.md" = {
     source = ../claude/PRINCIPLES.md;
     force = true;

--- a/scripts/check-clickup-addressed/recent-comments.py
+++ b/scripts/check-clickup-addressed/recent-comments.py
@@ -10,6 +10,17 @@ Output (default): one line per comment, tab-separated:
 With --json: JSON array of objects.
 
 --fast: Only check the 10 most recently updated tasks (much faster for large backlogs).
+
+🔴 THIS FILE SHELLS OUT TO THE CLICKUP SKILL'S CLI (`node query.mjs`, below), AND THAT CLI
+NOW HAS AN `awaiting` COMMAND ANSWERING A PREDICATE THIS PIPELINE ALSO DERIVES. Do NOT
+replace the derivation with a call to it: `awaiting` emits a row only when the newest
+comment is not the owner's, so every task the owner answered last is structurally absent —
+exactly the population `check-addressed.py`'s ANSWERED/suppression note is built from — and
+it carries no comment text, no priority, no `my_latest_reply`, and no way to express the
+`UNIDENTIFIED` sentinel below. The full ledger, the three measured cross-language
+divergences, and the shared table that keeps the two implementations pinned to one
+contract: `claude/skills/clickup/reference/awaiting-vs-ccua.md` and
+`tests/test_awaiting_contract.py`.
 """
 import subprocess, json, sys, os
 from datetime import datetime, timezone

--- a/scripts/check-clickup-addressed/tests/test_awaiting_contract.py
+++ b/scripts/check-clickup-addressed/tests/test_awaiting_contract.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""The PYTHON half of the cross-language contract for
+"the newest comment on this task is NOT the token owner's".
+
+🔴 WHY THIS FILE EXISTS. That predicate is implemented TWICE in this repo, in two
+languages, and nothing made the two agree until this file and its JS sibling existed:
+
+  * `claude/skills/clickup/lib/awaiting.mjs::isAwaiting` — the `awaiting` command,
+    whose own header calls this "the ONLY predicate this API can answer";
+  * HERE, decomposed across the ccua seam: `recent-comments.py::_collect` reports the
+    owner's newest reply (`latest_reply_ts_by`, with the `UNIDENTIFIED` sentinel), and
+    `check-addressed.py::_reply_answers_the_comment` derives the same predicate from it.
+
+ccua ALREADY shells out to that CLI — `recent-comments.py` runs `node query.mjs
+my-tasks|comments|me` — so the obvious consolidation is to call `query.mjs awaiting` and
+stop re-deriving. **It cannot**, and the reasons are enumerated in the fixture's
+`blockers` array and in `claude/skills/clickup/reference/awaiting-vs-ccua.md`. The
+decisive one is asserted below rather than argued: `awaiting` emits a row only when the
+newest comment is NOT the owner's, so every task the owner answered last is structurally
+absent from it — and that is exactly the population `_waiting_verdict`'s ANSWERED branch
+is built from, the branch that carries `BOT_IDENTITY_CAVEAT`.
+
+So the single definition available is a shared TABLE, not shared code:
+`claude/skills/clickup/test/awaiting-contract.fixtures.json`. Each side MEASURES its own
+column rather than copying the other's, and BOTH recompute the divergence ledger from the
+two columns and pin it — so a divergence appearing or disappearing is red on both sides.
+
+🔴 THESE ARE SEAM / INVARIANT GUARDS, NOT REGRESSION COVERAGE. No defect is fixed here;
+nothing below was red before this file existed because nothing below existed. Their
+evidence is the MUTATION matrix in the PR body: break either implementation's predicate
+and a named test here (or in the JS half) goes red with its own message.
+
+Every value in the fixture is SYNTHETIC. This repo is public.
+"""
+import importlib.util
+import io
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.parent
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_PATH = (REPO_ROOT / "claude" / "skills" / "clickup" / "test"
+                / "awaiting-contract.fixtures.json")
+
+sys.path.insert(0, str(SCRIPT_DIR))
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, SCRIPT_DIR / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+check_addressed = _load("check_addressed", "check-addressed.py")
+recent_comments = _load("recent_comments", "recent-comments.py")
+
+# 🔴 Read, never regenerated from this side. A table a test writes is a table that agrees
+# with any drift; the point of the file is that the OTHER language reads the same bytes.
+FIXTURE = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+OWNER = FIXTURE["owner_id"]
+CASES = FIXTURE["cases"]
+NOW = datetime.fromtimestamp(FIXTURE["now_ms"] / 1000, tz=timezone.utc)
+
+UNVERIFIED = "unverified"
+
+
+def _case(name):
+    for c in CASES:
+        if c["name"] == name:
+            return c
+    raise AssertionError(f"fixture has no case named {name!r} — the table and this file disagree")
+
+
+def _collect_rows(comments, my_id=OWNER):
+    """Run the REAL producer end to end over a stubbed ClickUp, returning its JSON rows.
+
+    `_collect` is driven rather than its parts called directly: the D12 fix lives in the
+    JOIN (the reply is computed over the UNFILTERED comment list, before the loop that
+    drops the owner's own comments), and calling `latest_reply_ts_by` by hand would test
+    both ends of that join while leaving the join itself unwitnessed.
+    """
+    orig = (recent_comments.get_my_user_id, recent_comments.get_my_tasks,
+            recent_comments.get_comments)
+    try:
+        recent_comments.get_my_user_id = lambda: my_id
+        recent_comments.get_my_tasks = lambda: [{
+            "id": "T-SYNTH-1", "name": "synthetic task",
+            "status": {"status": "to do"}, "priority": {"priority": "normal"},
+        }]
+        recent_comments.get_comments = lambda _tid: comments
+        buf, err = io.StringIO(), io.StringIO()
+        real_out, real_err = sys.stdout, sys.stderr
+        sys.stdout, sys.stderr = buf, err
+        try:
+            recent_comments._collect(10, False, True)
+        finally:
+            sys.stdout, sys.stderr = real_out, real_err
+    finally:
+        (recent_comments.get_my_user_id, recent_comments.get_my_tasks,
+         recent_comments.get_comments) = orig
+    return json.loads(buf.getvalue())
+
+
+def measure_py(comments):
+    """What the ccua PIPELINE answers, in the fixture's vocabulary.
+
+    Producer -> consumer, both real. Four branches, and the ORDER of the middle two is the
+    whole point of the seam:
+
+      * no row at all              -> False. Every comment was the owner's (or there were
+                                      none), so nobody is waiting. `_waiting_verdict`
+                                      returns at its `snippet` check.
+      * `my_latest_reply` ABSENT   -> UNVERIFIED. The producer withheld it: the UNIDENTIFIED
+                                      sentinel, i.e. the owner's own comments cannot be
+                                      ranked or the owner could not be identified at all.
+                                      `_waiting_verdict` surfaces the ticket WITH a note
+                                      saying the check did not run.
+      * `my_latest_reply` is None  -> True. PRESENT-and-null is the positive claim "I looked
+                                      at every comment and none is mine". That is a DECIDED
+                                      fact, not an absence — reading it as unverified is
+                                      exactly the conflation the sentinel was built to
+                                      prevent, in the opposite direction.
+                                      🔴 MEASURED, not assumed: `_reply_answers_the_comment`
+                                      returns None here (there is no date to compare), and
+                                      an earlier draft of this helper therefore scored the
+                                      case UNVERIFIED. `_waiting_verdict` gets it right by
+                                      falling through `is True` to the flag; this helper has
+                                      to make the same distinction explicitly.
+      * otherwise                  -> not answered.
+    """
+    rows = _collect_rows(comments)
+    if not rows:
+        return False
+    # `_collect` sorts newest-first and there is one task, so row 0 is the newest comment
+    # that is not the owner's — the record `attach_clickup_meta` would hand the consumer.
+    nc = check_addressed.build_newest_comment(rows[0])
+    if "my_latest_reply" not in nc:
+        return UNVERIFIED
+    if nc["my_latest_reply"] is None:
+        return True
+    answered = check_addressed._reply_answers_the_comment(nc, NOW)
+    if answered is None:
+        return UNVERIFIED
+    return not answered
+
+
+# --------------------------------------------------------------------------- the column
+
+def test_the_python_column_is_measured_case_by_case():
+    """Every row of the shared table, against the real producer+consumer pipeline."""
+    wrong = []
+    for c in CASES:
+        got = measure_py(c["comments"])
+        if got != c["py"]:
+            wrong.append(f"{c['name']}: fixture says py={c['py']!r}, pipeline yields {got!r}")
+    assert wrong == [], (
+        "the shared contract table no longer describes this side.\n  " + "\n  ".join(wrong)
+        + "\nThe implementation is the authority — re-read it before editing the table, and "
+        "say in the commit which behaviour moved.")
+
+
+def test_the_divergence_ledger_is_exactly_what_the_two_columns_produce():
+    """🔴 Recomputed HERE too, from the same two columns the JS half reads.
+
+    Asserted as a SET that fails when it GROWS *or* SHRINKS. A ledger that only catches
+    growth blesses a silent narrowing, and a divergence disappearing is a behaviour change
+    on a live command that nobody asked for.
+    """
+    derived = sorted(c["name"] for c in CASES if c["js"] != c["py"])
+    pinned = sorted(FIXTURE["divergences"])
+    assert derived == pinned, (
+        f"pinned divergences {pinned} != derived {derived}. Update BOTH the case row and "
+        "the ledger, in the same commit.")
+
+
+def test_the_two_implementations_agree_wherever_both_answer_a_boolean():
+    """The AGREEMENT half. Without it the table only records disagreement."""
+    checked = []
+    for c in CASES:
+        if not isinstance(c["js"], bool) or not isinstance(c["py"], bool):
+            continue
+        assert isinstance(c["awaiting"], bool), (
+            f"{c['name']}: both implementations answer a boolean, so the contract must too")
+        assert c["js"] == c["awaiting"], f"{c['name']}: JS disagrees with the contract"
+        assert c["py"] == c["awaiting"], f"{c['name']}: Python disagrees with the contract"
+        checked.append(c["name"])
+    assert len(checked) >= 5, (
+        f"only {len(checked)} case(s) exercised the agreement claim — a table whose cases are "
+        "nearly all divergent proves the two are equivalent nowhere")
+
+
+# ------------------------------------------------------- the UNIDENTIFIED distinction
+
+def test_UNIDENTIFIED_survives_the_contract_and_the_JS_side_cannot_express_it():
+    """🔴 THE FIELD THAT BLOCKS A CONSOLIDATION ONTO awaiting.mjs.
+
+    One of the owner's comments cannot be dated, so which of the owner's comments is
+    newest is UNKNOWABLE. This side says so — `latest_reply_ts_by` returns UNIDENTIFIED,
+    `build_record` omits the key, and `_waiting_verdict` fires the flag WITH a note saying
+    the check did not run. `isAwaiting()` has no third state and returns a confident
+    `true` (pinned on the JS side).
+
+    Driven end to end, not asserted about `latest_reply_ts_by` alone: the fact that
+    matters is the key being ABSENT from the record the consumer receives, and that is a
+    property of the join, not of the ranking function.
+    """
+    c = _case("the_owners_own_comment_has_an_unreadable_date")
+    rows = _collect_rows(c["comments"])
+    assert len(rows) == 1, f"the producer stopped reporting the colleague's comment: {rows}"
+    assert "my_latest_reply" not in rows[0], (
+        "the producer emitted `my_latest_reply` over a thread it cannot rank. Present-and-null "
+        "is the POSITIVE claim 'I looked; you never replied' — the exact false negative the "
+        f"UNIDENTIFIED sentinel exists to prevent: {rows[0]}")
+    assert "my_latest_reply_ms" not in rows[0], (
+        "the ms refinement appeared without the display date it refines")
+    assert measure_py(c["comments"]) == UNVERIFIED
+    assert c["js"] is True, (
+        "the fixture records that isAwaiting() answers a confident boolean here; if that "
+        "changed, the JS half is where it is measured and this claim moves with it")
+
+    # 🔴 UNVERIFIED must be OBSERVABLE in the report, not merely a value this helper
+    # computes. A state nobody can watch reach the output is indistinguishable from a state
+    # wired to nothing — and the whole claim being made about awaiting.mjs is that IT has no
+    # way to say this. Drive the real consumer and read what it prints.
+    record = {
+        "task_id": "T-SYNTH-1", "status": "no_mentions_found", "sessions_searched": 1,
+        "mentions_found": 0, "completion": [], "open": [],
+    }
+    check_addressed.attach_clickup_meta(record, rows[0])
+    kind, line = check_addressed._waiting_verdict(record, NOW)
+    assert kind == check_addressed.WAITING, (
+        f"the ticket was not surfaced at all when the owner's replies could not be ranked: "
+        f"{kind!r} / {line!r}")
+    assert "could not be checked" in line, (
+        "the flag fired but claimed nothing about the check that did not run — that is the "
+        f"confident false negative the sentinel exists to prevent: {line!r}")
+
+
+def test_a_failed_user_lookup_is_UNVERIFIED_and_not_a_verdict():
+    """The other arm of the same sentinel: the owner could not be identified AT ALL.
+
+    `query.mjs awaiting` exits 1 here and prints nothing (fixture blocker `failure-mode`).
+    ccua continues, warns on stderr, and withholds the key — so the pipeline declines to
+    claim rather than reporting an answered ticket as unanswered.
+    """
+    c = _case("colleague_commented_last")
+    rows = _collect_rows(c["comments"], my_id=None)
+    assert rows, "the producer reported nothing at all when the user id was unresolvable"
+    for r in rows:
+        assert "my_latest_reply" not in r, (
+            f"a failed user lookup produced a positive 'you never replied' claim: {r}")
+
+
+# ----------------------------------------------------- the structural blocker, asserted
+
+def test_the_population_awaiting_DROPS_is_the_one_the_suppression_note_needs():
+    """🔴 THE BLOCKER, from this side.
+
+    `awaiting` emits no row for a task the owner answered last (asserted in the JS half).
+    ccua DOES — and the record it emits carries `my_latest_reply_ms`, which is the only
+    input `_waiting_verdict`'s ANSWERED branch has. Feeding ccua from `awaiting` would
+    delete that whole block, and nothing in either suite would have failed.
+    """
+    c = _case("owner_commented_last")
+    rows = _collect_rows(c["comments"])
+    assert len(rows) == 1, (
+        "ccua must still report the colleague's comment on a task the owner answered last — "
+        f"that record is what the suppression note is built from: {rows}")
+    row = rows[0]
+    assert isinstance(row.get("my_latest_reply_ms"), int), (
+        f"the record carries no raw reply ms, so the ANSWERED branch cannot decide: {row}")
+    assert isinstance(row.get("date_ms"), int), (
+        f"the record carries no raw comment ms to compare against: {row}")
+
+    # And the consumer actually reaches ANSWERED on it — a structural check would
+    # type-check past a wrong argument, so the behaviour is exercised too.
+    nc = check_addressed.build_newest_comment(row)
+    assert check_addressed._reply_answers_the_comment(nc, NOW) is True, (
+        "the owner's reply is not older than the colleague's comment, so the consumer must "
+        "read this as answered")
+
+
+def test_the_fields_awaiting_cannot_carry_are_the_fields_this_producer_emits():
+    """The `field` blockers, measured rather than listed.
+
+    The JS half pins the exact key set an `awaiting` row carries. Here we pin that the
+    ccua record genuinely carries each blocked field, so the two ledgers describe one real
+    gap. A blocker naming a field nobody emits would be a sentence, not a gap.
+    """
+    c = _case("colleague_commented_last")
+    row = _collect_rows(c["comments"])[0]
+    for key in ("text", "task_priority", "my_latest_reply", "my_latest_reply_ms"):
+        assert key in row, (
+            f"the ccua record no longer carries {key!r}, which the fixture lists as a blocker. "
+            "Either the producer regressed or a blocker was genuinely closed — say which.")
+    awaiting_keys = set(FIXTURE["awaiting_row_keys"])
+    for key in ("text", "snippet", "task_priority", "my_latest_reply", "my_latest_reply_ms"):
+        assert key not in awaiting_keys, (
+            f"an `awaiting` row now carries {key!r} — that retires a blocker, so re-read "
+            "reference/awaiting-vs-ccua.md and the fixture before assuming it is still true.")
+
+
+def test_every_blocker_carries_a_kind_and_a_reason():
+    """The same claim the JS half makes over the same array, so neither reader drifts alone."""
+    kinds = {"population", "field", "failure-mode"}
+    assert len(FIXTURE["blockers"]) >= 5, (
+        "the blocker ledger shrank — if a blocker was genuinely closed, say which in the commit")
+    for b in FIXTURE["blockers"]:
+        assert b["kind"] in kinds, f"unknown blocker kind {b['kind']!r}"
+        assert b["field"], f"blocker {b['kind']} names no field"
+        assert len(b["why"]) > 40, f"blocker {b['kind']}/{b['field']} carries no usable reason"
+
+
+def test_the_fixture_is_reachable_from_this_suite_at_all():
+    """A POSITIVE CONTROL on the path, not a formality.
+
+    Every assertion above is vacuous if the fixture resolves to nothing — and the two
+    suites reach it from different roots, so a move that keeps the JS half green can leave
+    this one reading an empty table. The counts are the witness that it was read.
+    """
+    assert FIXTURE_PATH.is_file(), f"shared contract fixture missing at {FIXTURE_PATH}"
+    assert len(CASES) >= 9, f"the shared table collapsed to {len(CASES)} case(s)"
+    assert OWNER and FIXTURE["colleague_id"] != OWNER

--- a/scripts/run-node-tests.sh
+++ b/scripts/run-node-tests.sh
@@ -232,7 +232,18 @@ SUITES=(
   # flows/task-hygiene.md's no-enforcement disclaimer is pinned as prose (it was
   # guarded by nothing; flipping it to a false gate claim went fully green).
   # Floor 163 = 171 - min(50, max(1, 171/20)) = 171 - 8.
-  "claude/skills/clickup/test|5|163"
+  #
+  # 188 tests / 6 files measured 2026-08-24: test/awaiting-contract.test.mjs, the JS
+  # half of the CROSS-LANGUAGE contract for "the newest comment is not the token
+  # owner's". That predicate is implemented twice — here as `isAwaiting()`, and in
+  # scripts/check-clickup-addressed/ derived across a seam — and nothing made the two
+  # agree. Both suites now read ONE shared table
+  # (test/awaiting-contract.fixtures.json) and each MEASURES its own column, so a
+  # divergence appearing or disappearing is red on both sides. It also pins the
+  # structural blocker that makes a consolidation impossible: `awaiting` emits no row
+  # for a task the owner answered last. FILE COUNT MOVES 5 -> 6.
+  # Floor 179 = 188 - min(50, max(1, 188/20)) = 188 - 9.
+  "claude/skills/clickup/test|6|179"
 )
 
 # --- discovery roots -----------------------------------------------------------

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1461,7 +1461,19 @@ TARGET_FLOORS=(
   # waiting corpus (8) plus the bounds/parsing set (5) plus the round-7 additions
   # could have vanished with the gate still green, which is the exact staleness the
   # header above says a per-target floor exists to prevent.
-  "scripts/check-clickup-addressed/tests|203"
+  #
+  # 2026-08-24, +22 for tests/test_awaiting_contract.py — the PYTHON half of the
+  # cross-language contract for "the newest comment is not the token owner's". That
+  # predicate is implemented twice, here (recent-comments.py -> check-addressed.py,
+  # across the D12 seam) and as `isAwaiting()` in claude/skills/clickup/lib/awaiting.mjs,
+  # and nothing made the two agree. Both suites now read ONE shared table
+  # (claude/skills/clickup/test/awaiting-contract.fixtures.json) and each MEASURES its
+  # own column. 235 collected, agreeing with tests/run_all.py — two runners, one number.
+  #   _suggested_floor 235 = 235 - min(50, max(1, 235/20 = 11)) = 235 - 11 = 224.
+  # 🔴 Again NOT forced by the gate (235 is under the drift ceiling), and re-pinned for
+  # the same reason as the line above: leaving 32 tests of slack lets this whole file
+  # vanish with the gate still green, and its own subject is a guard against silence.
+  "scripts/check-clickup-addressed/tests|224"
   "scripts/claude-hooks/tests/test_guard_core.py|1260"
   # 2026-08-13, next-step-nudge.py's suite arrives as a NEW target: 78 collected on the
   # branch. Gate's own count through the gate's own rule:

--- a/scripts/tests/test_doc_path_rot.py
+++ b/scripts/tests/test_doc_path_rot.py
@@ -241,6 +241,7 @@ DEPLOYED_MAP: tuple[tuple[str, Path], ...] = (
     ("~/.claude/hooks/", REPO_ROOT / "scripts/claude-hooks"),
     ("~/.claude/skills/", REPO_ROOT / "claude/skills"),
     ("~/.claude/RULES.md", REPO_ROOT / "claude/RULES.md"),
+    ("~/.claude/RULES-ARCHIVE.md", REPO_ROOT / "claude/RULES-ARCHIVE.md"),
     ("~/.claude/PRINCIPLES.md", REPO_ROOT / "claude/PRINCIPLES.md"),
     # Not a deploy entry -- a spelling of this repo's own root that docs use.
     # Tilde-only on purpose: see the HERMETICITY note in the module docstring.


### PR DESCRIPTION
## The task, and the answer

The predicate **"the newest comment on this task is NOT the token owner's"** is implemented twice, in two languages. `scripts/check-clickup-addressed/` (ccua) *already* shells out to the CLI that owns the JS copy (`recent-comments.py:24` runs `node query.mjs`, `cwd=CLICKUP_DIR`). So the obvious consolidation is: have ccua call `query.mjs awaiting` and stop re-deriving.

**It cannot. Consolidating the code would be a regression, and this PR ships the measurement rather than the argument.**

🔴 **No production behaviour changes.** The diff is a shared fixture, two test files, one reference doc, three pointer comments, and two floor-table bumps.

## What the investigation found

**1. The brief's cited duplicate is not the duplicate.** `recent-comments.py:170` (`str(c["user"]["id"]) != my_id`) is a per-comment *authorship filter* — a different predicate. The real second implementation is `check-addressed.py::_reply_answers_the_comment` fed by `recent-comments.py::latest_reply_ts_by`, and it is the **richer** of the two: three states plus an absent-key state, against `isAwaiting()`'s bare boolean. The proposed consolidation direction is backwards.

**2. The decisive blocker is structural, not a missing field.** `awaiting` emits a row *only* when the newest comment is not the owner's — so **every task the owner answered last is absent by definition**. That is exactly the population `_waiting_verdict`'s ANSWERED/suppression branch is built from: the branch carrying `BOT_IDENTITY_CAVEAT` ("an agent may have answered as you"). Feeding ccua from `awaiting` deletes that whole block, and nothing in either suite would have failed. Asserted from both sides (`selectAwaiting` yields 0 rows; ccua still yields a record with `my_latest_reply_ms` and the consumer reaches ANSWERED on it).

**3. Four further blockers**, enumerated machine-readably in the fixture: comment **text** (ccua's entire decision surface — keep-open veto, RESOLVED-comment flag, `TEXT_CHARS`); **`my_latest_reply{,_ms}`**; **`task_priority`**; and the **failure mode** — `query.mjs awaiting` exits 1 on an unresolvable owner id, where ccua continues, warns on stderr, and *withholds* the key so the consumer takes its announce-rather-than-decide branch.

**4. The `UNIDENTIFIED` distinction does not survive a move to `awaiting.mjs`.** It is a property of the **return type**, so no amount of care inside `isAwaiting()` could recover it. Given a thread it cannot rank, Python declines to claim and the flag says the check did not run; JS returns a confident `true`.

Blockers 3 could be added at the cost of turning a triage command into a data dump. Blocker 2 cannot — it is the command's definition.

## What *was* consolidated: the contract, not the code

`claude/skills/clickup/test/awaiting-contract.fixtures.json` — one shared, synthetic table read by **both** suites:

| suite | measures |
|---|---|
| `claude/skills/clickup/test/awaiting-contract.test.mjs` | `lib/awaiting.mjs::isAwaiting()` |
| `scripts/check-clickup-addressed/tests/test_awaiting_contract.py` | the ccua producer → consumer pipeline, end to end |

Neither side copies the other's column — **each measures its own**, so the table cannot lie about either implementation. Both recompute the divergence ledger from the two columns and pin it **as a set that fails when it grows *or* shrinks**. This is the only thing that makes the two agree; the reference doc says so, so it does not get deleted as "an unused fixture".

## Three cross-language divergences, previously unknown

Found by writing the table:

- **`owner_reply_in_the_same_millisecond`** — Python resolves an exact tie by an explicit documented rule (`mine_ms >= theirs_ms`, a tie counts as answered). JS resolves it by **array order** (`newestComment()` keeps the first of an equal pair), so reversing the list flips the verdict — and in the API's own order it answers the **opposite** of Python.
- **`the_owners_own_comment_has_an_unreadable_date`** — Python declines to claim (UNIDENTIFIED); JS returns a confident `true` over a thread it cannot rank.
- **`every_comment_has_an_unreadable_date`** — Python declines; JS's answer is a property of the response order rather than of the thread.

**Pinned, not fixed.** None is reachable today — all 84 comments sampled when `awaiting` was written carried a `date`, and a tie needs two writes in the same millisecond. Changing a shipped command's behaviour on an unobserved input buys nothing and is a live behaviour change; the order-dependence label is *proved by reversing the list*, never asserted.

## Test evidence

🔴 **These are seam / invariant guards, NOT regression coverage.** No defect is fixed here, so "red at base" would be vacuous — nothing below existed at base. The honest evidence is a mutation sweep.

**9 mutants, 9 KILLED**, each by a named test with its own message. Run under `PYTHONDONTWRITEBYTECODE=1` with `__pycache__` purged between mutants, a **green baseline as the positive control**, and sha256 restore verification on all three mutated files afterwards (all `OK`).

| # | file | mutation | killed by |
|---|---|---|---|
| M1 | `awaiting.mjs` | `isAwaiting`: unknown author → `false` | `the_newest_comment_has_no_author_id` |
| M2 | `awaiting.mjs` | `isAwaiting`: `!==` → `===` | 8 tests incl. both blocker guards |
| M3 | `awaiting.mjs` | `newestComment`: undated sorts `Infinity` | `the_owners_own_comment_has_an_unreadable_date`, the UNIDENTIFIED guard |
| M4 | `awaiting.mjs` | `selectAwaiting`: drop the `isAwaiting` filter | `emits NO row for a task the owner answered last` |
| M5 | `awaiting.mjs` | add `text` to the row | `an awaiting row carries exactly these fields` |
| M6 | `recent-comments.py` | `return UNIDENTIFIED` → `continue` | column test + UNIDENTIFIED guard |
| M7 | `recent-comments.py` | emit `my_latest_reply` unconditionally | column test + both sentinel guards |
| M8 | `check-addressed.py` | `mine_ms >= theirs_ms` → `>` | column test (the tie case moves) |
| M9 | `recent-comments.py` | stop dropping the owner's own comments | both blocker guards |

A note on how the table itself was validated: the Python column was **written from the spec and then corrected by the measurement** — the first draft scored `only_a_colleague_has_commented` as decidable-`true` and the pipeline returned `unverified`, because `_reply_answers_the_comment` returns `None` when there is no reply date to compare. That is present-and-null (`"I looked; you never replied"`) versus absent (`"nobody could look"`), the exact distinction the ccua seam exists to protect. The helper now makes it explicitly, and the discovery is recorded in its docstring. That red run is also the suite's organic negative control.

## Gate verdicts — both tiers, named

Base sha: `324693fd`.

- **dev-host tier** (`nix develop --impure --command bash scripts/gate.sh --tier both`): `GATE: RESULT=PASS exit=0` — `PASS pytest exit=0`, `PASS node exit=0`.
- **nix sandbox tier — nodetests** (`nix build .#checks.x86_64-linux.nodetests`): exit 0, `RESULT: PASS (exit=0)`, `claude/skills/clickup/test (files=6 tests=188 pass=188 skipped=0 floor=179)`.
- **nix sandbox tier — pytests** (`nix build .#checks.x86_64-linux.pytests`): see the comment below.

(The first `gate.sh` attempt outside the dev shell exited 3 on `FATAL — required tool(s) missing from PATH: logrotate` — a missing environment, not a code failure. Re-run inside `nix develop`, as the runner's own message instructs.)

## Floors

Both raised deliberately rather than left with slack, per the per-target header's own rule:

- `run-node-tests.sh`: `claude/skills/clickup/test` `5|163` → **`6|179`** (188 measured; file count moves 5→6).
- `run-tests.sh`: `scripts/check-clickup-addressed/tests` `203` → **`224`** (235 measured, agreeing with `tests/run_all.py` — two runners, one number).

Neither was forced by the gate; both were re-pinned because leaving the slack lets these files vanish while the gate stays green, which is the staleness a per-target floor exists to prevent.

## Read this before re-proposing the consolidation

`claude/skills/clickup/reference/awaiting-vs-ccua.md`, routed from `SKILL.md`, and pointed at from the header of **both** implementations — so neither can be read in isolation and the question does not get re-derived from scratch a third time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
