### PR TITLE
feat(hooks): deny a GitHub issue create whose body names no closing condition

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1366,6 +1366,54 @@ in
   home.file.".claude/hooks/clawgate-task-interview-guard.py" = {
     source = ../scripts/claude-hooks/clawgate-task-interview-guard.py;
   };
+  # 🔴 THE GH-ISSUE CLOSING-CONDITION GATE — the interview gate's twin on the
+  # OTHER board. That one makes a clawgate task say what "done" means; this one
+  # makes a GitHub issue say what ENDS it.
+  #
+  # PreToolUse(Bash): denies `gh issue create` (plus a `gh api …/issues` POST and
+  # a curl POST to the same path) whose body carries no `## Closing condition` /
+  # `## Acceptance criteria` heading WITH CONTENT UNDER IT. The rule it enforces
+  # is claude/RULES.md's "Out of scope" branch; the predicate's single definition
+  # is question 1 of claude/skills/clawgate/flows/task-authoring.md, which the
+  # block message points at rather than restating (that single-source claim is
+  # gated by scripts/tests/test_closing_condition_single_source.py).
+  #
+  # 🔴 WHY A HOOK AND NOT MORE PROSE — measured, two blind runs, private solo
+  # repos so the outward-facing half of the rule could not confound: an UNBRIEFED
+  # subagent filed 6 issues with 0 closing conditions; a BRIEFED one (same rule
+  # pasted verbatim into its prompt) filed 10 with 10. BOTH had the rule —
+  # subagents do receive RULES.md — so the failure is SALIENCE, not delivery, and
+  # PRINCIPLES.md answers that with a structural fix.
+  #
+  # 🔴 IT MUST NOT FIRE ON A MENTION. This one watches `gh`, the most-typed tool
+  # in these repos, so a block on a `grep`/`echo`/heredoc that merely QUOTES the
+  # command would train everyone to reach for the override — and a
+  # permanently-red gate is worse than no gate. Classification is argv-based, and
+  # a heredoc body attached to a text sink (cat/tee/echo/printf, not piped
+  # onward) is not read as commands. That sink list is an ALLOWLIST, so anything
+  # unrecognised keeps the body: over-block, never silent pass.
+  #
+  # 🔴 It also denies a create whose body it CANNOT SEE (a generator
+  # substitution, `--body-file -`, a missing file) — failing open there would
+  # make the gate walkable by changing the SHAPE of the call. Escape hatches, both
+  # deliberate and both tested: a body that already carries the heading passes
+  # SILENTLY, and `GH_ISSUE_NO_CLOSING_CONDITION=1` skips it for one call in ONE
+  # greppable spelling.
+  #
+  # 🔴 IT DOES NOT CHECK SEMANTICS, and its own message says so. In the briefed
+  # arm above all 10 issues carried the heading and MOST wrote the remedy under
+  # it rather than a condition that ends the object. This raises the floor from
+  # nothing to a filled-in section; it does not certify the content.
+  #
+  # 🔴 A NEW file, so it must be `git add`ed or the flake silently omits it and
+  # the switch succeeds with the hook absent — this repo's standing trap.
+  # Registered on PreToolUse(Bash) per-host by register-nudge-hook.py, which is
+  # also what pins its interpreter to an absolute /nix/store path (a bare
+  # `python3` there is `command not found` for ~1s of every switch, and a
+  # PreToolUse hook exiting 127 FAILS OPEN — PR #609).
+  home.file.".claude/hooks/gh-issue-closing-condition-guard.py" = {
+    source = ../scripts/claude-hooks/gh-issue-closing-condition-guard.py;
+  };
   # 🔴 THE BASE-CLONE STALENESS HOOK — the only hook here that fixes what the
   # agent READS rather than what it does.
   #

--- a/scripts/claude-hooks/gh-issue-closing-condition-guard.py
+++ b/scripts/claude-hooks/gh-issue-closing-condition-guard.py
@@ -60,6 +60,28 @@ COVERED (classified from a real argv, never from adjacency in the raw text):
                                       `-f`/`-F`/`--input` payload, which is what
                                       makes gh default to POST
   * `curl` POST to a `…/issues` URL path
+  * any of the three INSIDE A COMMAND SUBSTITUTION, quoted or not:
+    `URL="$(gh issue create …)"`, `echo "created: $(…)"`, `if [ -n "$(…)" ]`,
+    the backtick spelling, and nested ones. A substitution RUNS -- the quotes
+    only decide how its OUTPUT is word-split -- so capturing the new issue's URL,
+    the single most natural thing to write, is not a way past this gate. It was
+    until 2026-08-25: `guard_core._scan_raw` buffers a double-quoted region
+    verbatim, so `"$( … )"` survived as ONE argv token and the create inside was
+    never enumerated, while the same line WITHOUT the two quote characters
+    denied. `substitution_scopes` closes it inside this file; `guard_core` is
+    untouched. The override reaches these too, in command position inside the
+    substitution -- see `creating_invocations`.
+
+🔴 ONE EFFECTIVE BODY PER SOURCE. A create that names a body flag TWICE is judged
+on the value the tool actually sends, not on whichever one happened to carry the
+heading: `--body`/`-b` and `--body-file`/`-F` are last-wins with `--body-file`
+beating `--body` outright, a repeated `gh api` `body` field is a hard gh error,
+and curl MERGES repeated data options rather than replacing. Each rule is
+measured against the shipped tool and cited where it is implemented
+(`body_candidates`, `_api_body_fields`, `CURL_DATA_JOIN`). Aggregating them, as
+this file did until 2026-08-25, meant ~40 characters of stock text in a discarded
+argument bought a pass -- the same "spelled, not structural" failure the ANSI-C
+paragraph above refuses, arrived at from the other side.
 
 NOT COVERED, deliberately enumerated so this file cannot read as wider than it
 is (a guard that does that stops people looking -- RULES.md):
@@ -78,6 +100,21 @@ is (a guard that does that stops people looking -- RULES.md):
     after this fix round, and NOT fixed here: the peeler is `guard_core`'s and
     is shared with `bash-guard.py`, so widening it is its own change with its
     own blast radius. Recorded rather than left for someone to rediscover.
+  * 🔴 A CREATE INSIDE A BRACE GROUP OR A FUNCTION BODY, same mechanism, one
+    keyword further out: `{ gh issue create …; }` and
+    `f(){ gh issue create …; }; f` both ALLOW, because `guard_core._tokenise`
+    hands the segment to `shlex.split`, which has no idea `{` is a shell reserved
+    word, so argv[0] is the literal `{`. THE TWO PARSERS HERE DISAGREE ABOUT `{`
+    AND THIS FILE'S ONE IS RIGHT: `_CMD_KEEPERS` lists `{` and `}` precisely
+    because bash's `{` is a reserved word that leaves the NEXT word in command
+    position, which is why the override walk gets `{ GH_ISSUE_… =1 gh … ; }`
+    right. Fixing the enumeration means teaching the SHARED tokeniser the same
+    thing, and it would change what `bash-guard.py` sees on every call -- its own
+    change, its own blast radius. Measured 2026-08-25, unchanged by this round,
+    and pinned by test_a_brace_group_is_a_KNOWN_UNCOVERED_ROUTE so it cannot rot.
+    Note it is NOT reachable by simply wrapping a create in braces to hide it and
+    hoping: `{` must be followed by a space and the group by a `;` or newline, or
+    bash itself rejects the line.
   * `gh issue create --web` / `-w`, which does NOT post: gh opens the browser's
     new-issue form and exits, so the object is created by a human in a form this
     process cannot see. Structurally exempt, like `--help`; it is a one-flag way
@@ -97,6 +134,16 @@ test_a_body_quoting_a_heredoc_operator_is_a_KNOWN_FALSE_POSITIVE. The fix is to
 make the SCRUB quote-aware while body resolution stays blind; that is a change to
 the mechanism the mention-is-not-an-invocation requirement rests on and has not
 been made.
+
+🔴 AND ONE CONSEQUENCE OF READING SUBSTITUTIONS, recorded for the same reason: a
+DOUBLE-quoted body carrying an UNESCAPED backtick span or `$( … )` around a
+`gh issue create` now denies, where it used to pass. That is not a mention -- in
+`"…"` bash really does run what is between the backticks and splice its output
+into the body -- so the same line would have mangled the issue either way; the
+gate is telling you the quoting is wrong. SINGLE-quoted bodies (the spelling
+every correct example here uses) and backslash-escaped spans are untouched, and
+both are pinned. Cost: a body written with double quotes and raw markdown code spans
+denies, with a message that names the override.
 
 ONLY `create`. `gh issue comment|edit|close|reopen|list|view|status|develop`,
 `gh pr create`, and a GET of `…/issues` all pass untouched. This gate exists to
@@ -354,10 +401,32 @@ GH_API_VALUE_FLAGS = GH_API_FIELD_FLAGS + (
     "-t", "--template", "--cache", "-p", "--preview",
 )
 
-# curl flags that carry a request body.
-CURL_DATA_FLAGS = (
+# curl flags that carry a request body, split by WHAT REPEATING ONE DOES.
+#
+# 🔴 curl DOES NOT TAKE THE LAST ONE. Measured against curl(1) as shipped here
+# (curl 8.17.0), because assuming the gh rule would have been wrong in the
+# direction that invents a body nobody sent:
+#   * `-d`/`--data`/`--data-raw`/`--data-ascii`/`--data-binary`/`--data-urlencode`
+#     — "If any of these options is used more than once on the same command line,
+#     the data pieces specified are merged with a separating &-symbol."
+#   * `--json` — "data pieces are concatenated to the previous before sending",
+#     with NO separator; curl's own example splits one JSON object across two
+#     `--json` arguments.
+#   * `-F`/`--form` and `-T`/`--upload-file` are not a mergeable text payload at
+#     all (multipart parts / a whole-file PUT), so no join models them.
+CURL_AMP_DATA_FLAGS = (
     "-d", "--data", "--data-raw", "--data-ascii", "--data-binary",
-    "--data-urlencode", "--json", "-F", "--form", "-T", "--upload-file",
+    "--data-urlencode",
+)
+CURL_CONCAT_DATA_FLAGS = ("--json",)
+CURL_OTHER_BODY_FLAGS = ("-F", "--form", "-T", "--upload-file")
+CURL_DATA_FLAGS = CURL_AMP_DATA_FLAGS + CURL_CONCAT_DATA_FLAGS + CURL_OTHER_BODY_FLAGS
+# The separator curl inserts between repeats of each family, or None for a family
+# whose repeats this gate will not model.
+CURL_DATA_JOIN = dict(
+    [(f, "&") for f in CURL_AMP_DATA_FLAGS]
+    + [(f, "") for f in CURL_CONCAT_DATA_FLAGS]
+    + [(f, None) for f in CURL_OTHER_BODY_FLAGS]
 )
 CURL_METHOD_FLAGS = ("-X", "--request")
 # curl flags that take a value we must not mistake for a URL or a body.
@@ -617,8 +686,43 @@ _SEPARATOR_CHARS = ";&|\n"
 _WORD_BREAK = " \t\r\n;&|()<>`"
 
 
-def _read_word(text, i, n):
-    """`(word, next index)` for the shell word starting at `i`."""
+def _substitution_end(text, i, n):
+    """`(inner start, inner end, next index)` for the substitution opening at `i`.
+
+    `$( … )` counts nesting; `` ` … ` `` ends at the next backtick. An opener with
+    no closer runs to the end of the text — the fail-CLOSED reading, so a
+    truncated substitution cannot hide the command inside it.
+    """
+    if text[i] == "`":
+        j = text.find("`", i + 1)
+        return (i + 1, n, n) if j == -1 else (i + 1, j, j + 1)
+    depth, j = 1, i + 2
+    while j < n and depth:
+        if text[j] == "(":
+            depth += 1
+        elif text[j] == ")":
+            depth -= 1
+        j += 1
+    return (i + 2, j - 1, j) if depth == 0 else (i + 2, n, n)
+
+
+def _read_word(text, i, n, subs=None):
+    """`(word, next index)` for the shell word starting at `i`.
+
+    🔴 `subs` COLLECTS SUBSTITUTIONS THIS WORD SWALLOWED, and without it half of
+    bypass A stayed open after the walk itself was fixed. A word is read whole,
+    quotes included, so `URL="$(gh issue create …)"` — one assignment word — was
+    consumed here in its entirety and `_shell_walk`'s own `$(` branch never saw
+    the opener at all: the create inside stayed invisible while the
+    otherwise-identical `echo "created: $(…)"` (whose argument STARTS with the
+    quote, so the main walk handles it) was found. Same for `--flag="$( … )"`.
+    A word can carry a command; recording it here is what makes the two agree.
+
+    Only a DOUBLE-quoted region is scanned: inside `'…'` a `$(` is literal text,
+    and at top level the word BREAKS at `$(` (and at a backtick, via
+    `_WORD_BREAK`) so the caller's own branch sees it — which is why nothing is
+    recorded twice.
+    """
     out, quote = [], None
     while i < n:
         c = text[i]
@@ -626,6 +730,13 @@ def _read_word(text, i, n):
             if c == "\\" and quote == '"' and i + 1 < n:
                 out.append(text[i + 1])
                 i += 2
+                continue
+            if quote == '"' and (c == "`" or (c == "$" and text[i + 1:i + 2] == "(")):
+                lo, hi, nxt = _substitution_end(text, i, n)
+                if subs is not None:
+                    subs.append(text[lo:hi])
+                out.append(text[i:nxt])
+                i = nxt
                 continue
             if c == quote:
                 quote = None
@@ -650,7 +761,8 @@ def _read_word(text, i, n):
 
 
 def _shell_walk(text):
-    """`(segments, override)` — one TEXT per top-level command segment.
+    """`(segments, override, substitutions)` — one TEXT per top-level command
+    segment, plus the INNER TEXT of every command substitution on the line.
 
     A segment is a TOP-LEVEL command, split on unquoted `;`/`&`/`|`/newline and
     on a subshell paren, with the bodies of the heredocs THAT COMMAND OPENED
@@ -681,12 +793,31 @@ def _shell_walk(text):
     COMMAND POSITION at substitution depth 0 — the assignment bash would actually
     put in `gh`'s environment. Inside `$( … )` or a backtick it is a different
     process's environment and does not count; inside a quote it is prose.
+
+    🔴 `substitutions` IS THE THIRD ELEMENT AND IT CLOSES A REAL BYPASS. This walk
+    already had to enter `$( … )` and `` ` … ` `` INSIDE A DOUBLE QUOTE to decide
+    the override correctly (see the `quote == '"'` branch), so it is the one
+    parser here that can see a command hidden there. `guard_core._scan_raw` cannot:
+    its `if quote:` branch buffers every byte of a double-quoted region verbatim,
+    so `"$( … )"` survives as ONE argv TOKEN and the command inside it is never
+    enumerated. `URL="$(gh issue create -t t -b 'nope')"` — the single most
+    natural way to capture the new issue's URL — therefore ALLOWED, while the
+    same line without the two quote characters DENIED. Collecting the inner text
+    here and enumerating it in `creating_invocations` is what makes the two agree.
+
+    The inner text is the RAW SLICE between the opener and its matching closer, so
+    a heredoc body that a command inside the substitution opened is inside it
+    (the walk steps OVER those bytes, but they are still between the two offsets)
+    and re-parses when the slice is walked again. An UNCLOSED substitution yields
+    the tail; that is the fail-CLOSED direction — a truncated `$(` must not hide
+    a create.
     """
     n = len(text)
     heres = heredocs(text)
     skip = {h.start: h.after for h in heres}
     spans, seg_lo = [], 0
-    stack = []            # (saved quote, closing char) per open substitution
+    subs = []             # inner text of every closed command substitution
+    stack = []            # (saved quote, closing char, inner start) per open one
     quote, at_cmd, override, i = None, True, False, 0
     while i < n:
         if i in skip:
@@ -714,11 +845,11 @@ def _shell_walk(text):
                 i += 2
                 continue
             if c == "$" and text[i + 1:i + 2] == "(":
-                stack.append((quote, ")"))
+                stack.append((quote, ")", i + 2))
                 quote, at_cmd, i = None, True, i + 2
                 continue
             if c == "`":
-                stack.append((quote, "`"))
+                stack.append((quote, "`", i + 1))
                 quote, at_cmd, i = None, True, i + 1
                 continue
             if c == '"':
@@ -730,16 +861,18 @@ def _shell_walk(text):
             i += 2
             continue
         if c == "$" and text[i + 1:i + 2] == "(":
-            stack.append((quote, ")"))
+            stack.append((quote, ")", i + 2))
             at_cmd, i = True, i + 2
             continue
         if stack and ((c == ")" and stack[-1][1] == ")")
                       or (c == "`" and stack[-1][1] == "`")):
-            quote = stack.pop()[0]
+            saved_quote, _closer, sub_lo = stack.pop()
+            subs.append(text[sub_lo:i])
+            quote = saved_quote
             at_cmd, i = False, i + 1
             continue
         if c == "`":
-            stack.append((quote, "`"))
+            stack.append((quote, "`", i + 1))
             at_cmd, i = True, i + 1
             continue
         if c in ("'", '"'):
@@ -759,7 +892,7 @@ def _shell_walk(text):
         if c.isspace():
             i += 1
             continue
-        word, j = _read_word(text, i, n)
+        word, j = _read_word(text, i, n, subs)
         if at_cmd and not stack:
             if _ASSIGN_WORD.match(word):
                 override = override or word == OVERRIDE_ASSIGNMENT
@@ -768,6 +901,21 @@ def _shell_walk(text):
         else:
             at_cmd = False
         i = max(j, i + 1)
+    # An opener with no closer: the rest of the line is its inner text. Fail
+    # CLOSED — a `$(` the walk never closed must not swallow a create silently.
+    #
+    # 🔴 NOT DEMONSTRATED BY ANY TEST, AND SAID SO RATHER THAN LEFT TO READ AS
+    # COVERAGE. Mutation-checked 2026-08-25 by emptying this loop: SURVIVED the
+    # whole suite, because `guard_core._scan_raw`'s own unterminated-quote
+    # recovery already re-reads the tail and exposes the create, so both
+    # unterminated shapes in
+    # test_an_unterminated_substitution_still_shows_the_create deny either way
+    # (they denied at the pre-fix hook too — an invariant guard, not regression
+    # coverage). It is kept because the two parsers recover by different routes
+    # and the cost of being wrong here is a create going unseen; it is NOT
+    # evidence that this file handles truncated input on its own.
+    for _saved, _closer, sub_lo in stack:
+        subs.append(text[sub_lo:n])
     spans.append((seg_lo, n))
     segments = []
     for lo, hi in spans:
@@ -782,7 +930,7 @@ def _shell_walk(text):
         bodies = [text[h.start:h.after]
                   for h in heres if lo <= h.op < hi and h.start >= hi]
         segments.append((head + "\n" + "".join(bodies)) if bodies else head)
-    return segments, override
+    return segments, override, subs
 
 
 def command_segments(text):
@@ -792,6 +940,31 @@ def command_segments(text):
     command opened — see `_shell_walk` for why that cannot be one slice.
     """
     return _shell_walk(text)[0]
+
+
+def substitution_scopes(text):
+    """Command-segment TEXTS from inside every `$( … )` / `` ` … ` `` on `text`.
+
+    🔴 A COMMAND SUBSTITUTION RUNS. That is the entire argument for reading it,
+    and it is why the shape this closes is not a "mention": bash forks a shell,
+    executes what is inside, and substitutes the output — so a `gh issue create`
+    there files an issue exactly as a bare one does. Quoting the substitution
+    changes only how the RESULT is word-split, never whether it executes.
+
+    The nesting is already handled by `_shell_walk`'s stack: an inner `$( … )`
+    closes first and is recorded on its own, an outer one is recorded whole, so
+    both are returned and nothing here needs to recurse.
+    """
+    out = []
+    for body in _shell_walk(text)[2]:
+        # No blank-body skip here on purpose: `command_segments` already drops a
+        # segment whose text is all whitespace, so one would be a `continue` that
+        # can never change an answer. It was written, mutation-checked, found to
+        # SURVIVE every case in the suite for exactly that reason, and deleted.
+        for seg in command_segments(body):
+            if seg not in out:
+                out.append(seg)
+    return out
 
 
 # --------------------------------------------------------------------------- #
@@ -973,7 +1146,13 @@ def is_gh_api_issue_create(argv):
 
 
 def _curl_parts(argv):
-    """(method, [url paths], [data values]) for a curl argv.
+    """(method, [url paths], [(data flag, data value), …]) for a curl argv.
+
+    🔴 THE DATA LIST CARRIES THE FLAG NAME, NOT JUST THE VALUE, because which
+    flag it was decides how curl MERGES repeats — see `CURL_DATA_JOIN`. Dropping
+    the name here is what made `-d <good> -d <bad>` readable as "some payload
+    carried the heading", when the bytes curl actually sends are the two values
+    joined by `&`.
 
     🔴 EVERY FLAG READ THROUGH `_match_flag`, NOT BY EXACT-TOKEN EQUALITY. This
     used to test `tok in CURL_DATA_FLAGS`, so `--request=POST`, `--data=…`,
@@ -995,7 +1174,7 @@ def _curl_parts(argv):
         hit = _match_flag(argv, i, CURL_DATA_FLAGS)
         if hit is not None:
             if hit[1] is not None:
-                data.append(hit[1])
+                data.append((hit[0], hit[1]))
             i = hit[2]
             continue
         hit = _match_flag(argv, i, ("--url",))
@@ -1078,6 +1257,10 @@ UNRESOLVED_STDIN = "the body is piped in on stdin, where a PreToolUse hook canno
 UNRESOLVED_UNREADABLE = "the body-file path could not be read"
 UNRESOLVED_NONE = "the command names no body this gate can read"
 UNRESOLVED_JSON = "the request payload is not JSON this gate can parse"
+UNRESOLVED_CURL_MERGE = (
+    "several curl body options are combined in a way this gate cannot reconstruct")
+UNRESOLVED_DUP_FIELD = (
+    "the body field is given more than once, which gh rejects outright")
 
 
 def _match_flag(argv, i, names):
@@ -1249,25 +1432,68 @@ def _resolve_json_payload(payloads):
     return [], (UNRESOLVED_JSON if failed else UNRESOLVED_NONE)
 
 
-def _resolve_curl_data(value, text, full=None):
-    """([body, …], reason-or-None) for one curl data argument."""
+def _curl_data_texts(value, text, full=None):
+    """([raw payload text, …], reason-or-None) for one curl data argument.
+
+    The texts are UNPARSED on purpose: repeats of a data flag are merged by curl
+    BEFORE anything is sent, so JSON-parsing a single argument would be parsing
+    something curl never transmits. `_resolve_curl_payload` does the merge and
+    hands the result to `_resolve_json_payload` exactly once.
+    """
     if value.startswith("@"):
         # 🔴 `-d @file` / `-d @-` still has to be JSON-PARSED afterwards.
         # Returning the file's raw bytes as a body candidate is a real defect: a
         # payload `{"body":"## Closing condition\n…"}` carries the heading only
         # as an ESCAPED \n, so the line-based detector never sees a heading and a
         # correctly-specified create is denied.
-        payloads, why = _resolve_file(value[1:], text, full)
+        return _resolve_file(value[1:], text, full)
+    payloads = heredoc_bodies(value) or ([] if opaque_value(value) else [value])
+    if not payloads:
+        outer = heredoc_bodies(text)
+        if not outer:
+            return [], UNRESOLVED_OPAQUE
+        payloads = outer
+    return payloads, None
+
+
+def _resolve_curl_payload(data, text, full=None):
+    """([body, …], reason-or-None) for the ONE payload this curl actually sends.
+
+    `data` is `[(flag, value), …]` in argv order — see `_curl_parts`.
+
+    🔴 curl MERGES REPEATED DATA OPTIONS; IT DOES NOT TAKE THE LAST ONE, and it
+    does not evaluate them independently either. Treating each argument as its
+    own candidate meant a create passed as soon as ANY of them carried the
+    heading, so ~40 characters of stock text in a `-d` curl never sends as its own
+    request bought a pass — the "spelled, not structural" failure this gate
+    refused to allow for ANSI-C decoding. The merge rule is per family and is
+    quoted from curl(1) at `CURL_DATA_JOIN`.
+
+    Two deliberate fail-CLOSED edges:
+      * mixed families (`-d` beside `--json`, or any `-F`/`-T`) have no single
+        join this gate can claim, so the payload is UNRESOLVED rather than
+        guessed;
+      * an argument that resolves to SEVERAL alternative texts (a value carrying
+        more than one heredoc) cannot be placed in a merge, so the same.
+    Both keep the single-argument path — the shape ~every real curl uses —
+    byte-for-byte what it was.
+    """
+    if len(data) == 1:
+        payloads, why = _curl_data_texts(data[0][1], text, full)
+        return ([], why) if why else _resolve_json_payload(payloads)
+    joins = {CURL_DATA_JOIN.get(flag) for flag, _ in data}
+    if len(joins) != 1 or None in joins:
+        return [], UNRESOLVED_CURL_MERGE
+    sep = joins.pop()
+    pieces = []
+    for _flag, value in data:
+        got, why = _curl_data_texts(value, text, full)
         if why:
             return [], why
-    else:
-        payloads = heredoc_bodies(value) or ([] if opaque_value(value) else [value])
-        if not payloads:
-            outer = heredoc_bodies(text)
-            if not outer:
-                return [], UNRESOLVED_OPAQUE
-            payloads = outer
-    return _resolve_json_payload(payloads)
+        if len(got) != 1:
+            return [], UNRESOLVED_CURL_MERGE
+        pieces.append(got[0])
+    return _resolve_json_payload([sep.join(pieces)])
 
 
 def _resolve_gh_api_field(value, text, at_file, full=None):
@@ -1292,18 +1518,86 @@ def _resolve_gh_api_field(value, text, at_file, full=None):
     return _resolve_inline(val, text)
 
 
+def _api_body_fields(argv):
+    """[(field value, is `-F`/`--field`), …] naming `body`, in gh's OWN order.
+
+    🔴 gh api PROCESSES EVERY `-f`/`--raw-field` FIRST, THEN EVERY
+    `-F`/`--field` — regardless of the order they were typed in — and REFUSES a
+    key it has already set. Read from `parseFields` in
+    `cli/cli@v2.97.0:pkg/cmd/api/fields.go`:
+
+        } else {
+            if _, exists := destMap[subkey]; exists {
+                return fmt.Errorf("unexpected override existing field under %q", subkey)
+            }
+            destMap[subkey] = value
+        }
+
+    Verified against the shipped binary (gh 2.97.0): `-f body=A -f body=B`,
+    `-f body=A -F body=B` and `-F body=A -f body=B` ALL exit with
+    `unexpected override existing field under "body"`, while the single-field
+    control `-f body=A` reaches the API. So a repeated body field is not
+    last-wins here the way `gh issue create --body` is — it is a hard error, and
+    the caller sees whichever of the two they wrote LAST no more than the first.
+    The ordering below matters only for the single-field case; it is gh's, so
+    this function cannot drift from it in the direction that reads the wrong one.
+    """
+    out = []
+    for at_file, flags in ((False, GH_API_RAW_FIELD_FLAGS),
+                           (True, GH_API_AT_FILE_FLAGS)):
+        for value in _flag_values(argv, flags):
+            key = value.split("=", 1)[0] if "=" in value else None
+            if key is not None and key.strip() == "body":
+                out.append((value, at_file))
+    return out
+
+
 def body_candidates(argv, text, route, full=None):
     """([every body text this gate could read], reason the rest were unreadable).
 
-    The reason is None when everything named was resolved. Aggregating rather
-    than picking ONE source is deliberate: a command may legitimately name a
-    body-file that a heredoc on the same line is about to write, and a candidate
-    is only ever used to let the command THROUGH.
+    The reason is None when everything named was resolved.
+
+    🔴 ONE EFFECTIVE BODY PER SOURCE, NOT EVERY BODY-SHAPED ARGUMENT ON THE LINE.
+    This used to aggregate every candidate and `evaluate` passed if ANY of them
+    carried the heading, so a SECOND body flag was a bypass:
+    `gh issue create --body '<a correct section>' --body 'nope'` allowed, while
+    `gh` sends only the LAST value and GitHub only ever renders that one. ~40
+    characters of stock text that never reach GitHub bought a pass — the
+    "spelled, not structural" failure the module docstring refuses to allow for
+    ANSI-C decoding, arrived at from the other side.
+
+    The rule is per source because the three tools genuinely disagree, and one
+    rule applied everywhere would be WRONG in the direction that false-denies:
+
+      * `gh issue create` registers `--body`/`-b` and `--body-file`/`-F` as pflag
+        `StringVarP`, so a REPEAT of either is last-wins (measured on gh 2.97.0:
+        `gh api --hostname aaa-first.invalid --hostname bbb-last.invalid …`
+        connects to `bbb-last.invalid`). Across the two flags `--body-file` wins
+        REGARDLESS OF ORDER: `create.go` assigns `opts.Body = string(b)` after
+        `--body` has already been bound, and the file is read even when `--body`
+        was given (measured: `--body 'aaa' --body-file /nonexistent/zz.md` fails
+        with `open /nonexistent/zz.md: no such file or directory`, never reaching
+        the API).
+      * `gh api` REJECTS a repeated `body` field outright — see `_api_body_fields`.
+      * `curl` MERGES repeated data options rather than replacing — see
+        `_resolve_curl_payload` and `CURL_DATA_JOIN`.
+
+    Aggregation WITHIN one source is still deliberate and is untouched: a single
+    `--body-file` may resolve to several candidate texts (a heredoc about to
+    write that path), and a candidate is only ever used to let the command
+    through.
+
+    🔴 A DELIBERATE OVER-BLOCK, RECORDED RATHER THAN HIDDEN: `--body '<good>'
+    --body-file <unreadable>` now denies as "cannot see the body". gh would ERROR
+    on that call, so nothing is created either way, and the alternative — reading
+    the `--body` gh discards — is the bypass this fixes.
 
     🔴 `text` IS THIS CREATE'S OWN COMMAND SEGMENT, NOT THE COMMAND LINE. That is
     the whole of the B2/B3 fix and it is a change of MEANING, not of degree —
-    aggregation across sources on ONE command is deliberate, aggregation across
-    COMMANDS was a bug. The segment carries the bodies of the heredocs this
+    aggregation across COMMANDS was a bug. (The sentence that stood here also
+    called aggregation across SOURCES on one command deliberate; the block above
+    is where that stopped being true, and the two lines were one edit apart on
+    purpose.) The segment carries the bodies of the heredocs this
     command's own text opened (attributed by the `<<` offset), so a
     `heredoc_bodies(text)` here reads this create's body and no other's, however
     the openers are interleaved on the line. `full` is threaded through for the
@@ -1322,25 +1616,36 @@ def body_candidates(argv, text, route, full=None):
 
     if route == "curl":
         _, _, data = _curl_parts(argv)
-        for value in data:
-            take(_resolve_curl_data(value, text, full))
+        if data:
+            take(_resolve_curl_payload(data, text, full))
     elif route == "gh-api":
-        for value in _flag_values(argv, GH_API_AT_FILE_FLAGS):
-            take(_resolve_gh_api_field(value, text, True, full))
-        for value in _flag_values(argv, GH_API_RAW_FIELD_FLAGS):
-            take(_resolve_gh_api_field(value, text, False))
-        for value in _flag_values(argv, ("--input",)):
+        fields = _api_body_fields(argv)
+        if len(fields) > 1:
+            take(([], UNRESOLVED_DUP_FIELD))
+        elif fields:
+            value, at_file = fields[0]
+            take(_resolve_gh_api_field(value, text, at_file, full))
+        # `--input` is a pflag `StringVar` in gh api, so a repeat is last-wins for
+        # the same reason `--body` is; only the last one names the request body.
+        inputs = _flag_values(argv, ("--input",))
+        if inputs:
+            value = inputs[-1]
             if value in STDIN_NAMES:
                 inner = heredoc_bodies(text)
                 take(_resolve_json_payload(inner) if inner else ([], UNRESOLVED_STDIN))
-                continue
-            payloads, why = _resolve_file(value, text, full)
-            take(([], why) if why else _resolve_json_payload(payloads))
+            else:
+                payloads, why = _resolve_file(value, text, full)
+                take(([], why) if why else _resolve_json_payload(payloads))
     else:
-        for value in _flag_values(argv, GH_ISSUE_BODY_FLAGS):
-            take(_resolve_inline(value, text))
-        for value in _flag_values(argv, GH_ISSUE_BODY_FILE_FLAGS):
-            take(_resolve_file(value, text, full))
+        # `--body-file` beats `--body` whatever the order, and within either flag
+        # the LAST spelling is the one gh binds. See this function's docstring for
+        # the measurement behind both halves.
+        files = _flag_values(argv, GH_ISSUE_BODY_FILE_FLAGS)
+        bodies = _flag_values(argv, GH_ISSUE_BODY_FLAGS)
+        if files:
+            take(_resolve_file(files[-1], text, full))
+        elif bodies:
+            take(_resolve_inline(bodies[-1], text))
 
     if not cands and reason is None:
         # No body argument this gate could read. A heredoc on THIS COMMAND is
@@ -1496,12 +1801,47 @@ def creating_invocations(text, guard_core):
     whole-text pass and keeps the OLD line-wide scope. That is deliberate: the
     backstop must not be able to turn a create that used to ALLOW into a deny,
     only to keep one from disappearing.
+
+    🔴 THE SUBSTITUTION PASS IS SECOND, AND IT IS DEDUPED AGAINST THE FIRST.
+    `guard_core` already lifts an UNQUOTED `$( … )` into its own segment, so
+    `echo $(gh issue create …)` is found by the first loop with its line-wide
+    scope; what the shared core cannot lift is a substitution inside a DOUBLE
+    QUOTE (its `if quote:` branch buffers the region verbatim), and that is the
+    set this loop adds. Skipping an argv the first loop already attributed keeps
+    the pass additive: nothing already seen is re-judged under a second, narrower
+    scope.
+
+    🔴 THE DEDUPE ITSELF IS A CONSERVATIVE CHOICE, NOT A TESTED ONE, and that is
+    recorded rather than dressed up. Mutation-checked 2026-08-25 by deleting the
+    `argv not in seen` clause: SURVIVED the whole suite. The hazard it is aimed at
+    — the same argv judged twice, the second time under a scope missing a heredoc
+    the first one carried, so a create that ALLOWED denies — was searched for and
+    NOT reproduced. It is kept because every duplicate can only make `evaluate`
+    stricter and the failure direction is a false deny; do not cite it as covered.
     """
     out, seen = [], []
     for scope in command_segments(text):
         for argv in guard_core.commands(scrub_inert_heredocs(scope)):
             route = _route(argv)
             if route and not is_exempt_invocation(argv, route):
+                out.append((argv, route, scope))
+                seen.append(argv)
+    for scope in substitution_scopes(text):
+        # 🔴 THE ESCAPE HATCH HAS TO REACH THE SHAPE THE HATCH IS FOR. A
+        # substitution runs in its own shell, so `GH_ISSUE_NO_CLOSING_CONDITION=1`
+        # in command position INSIDE it is the assignment bash puts in THAT `gh`'s
+        # environment — the override's documented spelling, "on the call itself".
+        # `override_requested` cannot see it: `_shell_walk` deliberately ignores
+        # an assignment at substitution depth > 0, which is right for the line
+        # (there it is a different process's environment) and wrong once the call
+        # inside is the thing being judged. Without this, the newly-covered shapes
+        # would be the only ones with no way out — and a gate nobody can get past
+        # is the one people switch off.
+        if _shell_walk(scope)[1]:
+            continue
+        for argv in guard_core.commands(scrub_inert_heredocs(scope)):
+            route = _route(argv)
+            if route and not is_exempt_invocation(argv, route) and argv not in seen:
                 out.append((argv, route, scope))
                 seen.append(argv)
     for argv in guard_core.commands(scrub_inert_heredocs(text)):

--- a/scripts/claude-hooks/gh-issue-closing-condition-guard.py
+++ b/scripts/claude-hooks/gh-issue-closing-condition-guard.py
@@ -715,7 +715,7 @@ def _shell_walk(text):
                 # `heredoc_bodies(span)` still finds it.
                 end = skip.get(i + 1) if c == "\n" else None
                 if end is not None:
-                    spans.append((seg_lo, i))
+                    spans.append((seg_lo, end))
                     seg_lo, i, at_cmd = end, end, True
                     continue
                 spans.append((seg_lo, i))

--- a/scripts/claude-hooks/gh-issue-closing-condition-guard.py
+++ b/scripts/claude-hooks/gh-issue-closing-condition-guard.py
@@ -1,0 +1,1112 @@
+#!/usr/bin/env python3
+"""PreToolUse(Bash) gate: no GitHub issue is CREATED without a closing condition.
+
+WHY THIS EXISTS
+---------------
+`claude/RULES.md` (Deterministic Over Prose -> the "Out of scope" branch) says an
+agent may file a work item only once it can name the CONDITION that ends it and
+who or what checks it; naming neither means saying so in the reply instead of
+minting an object nobody can close. The operational definition is question 1 of
+`claude/skills/clawgate/flows/task-authoring.md`, which is the SINGLE source --
+pinned by `scripts/tests/test_closing_condition_single_source.py`. Nothing here
+restates it; this file points at it.
+
+🔴 THE FAILURE THIS FIXES IS SALIENCE, NOT DELIVERY, AND THAT IS MEASURED.
+Two blind runs, same design, private solo repos so the outward-facing half of the
+rule could not confound:
+
+    unbriefed subagent   6 issues filed,  0 carrying a closing condition
+    briefed subagent    10 issues filed, 10 carrying one
+
+BOTH agents had the rule -- subagents receive RULES.md. (An earlier claim that
+they do not was a FALSE ZERO: a transcript does not record the system prompt, so
+grepping transcripts for the rule text could never have found it. Do not repeat
+that measurement.) So the prose arrives and does not fire, which is exactly the
+case PRINCIPLES.md answers with a structural fix rather than more prose. Same
+shape as `clawgate-task-interview-guard.py`, whose sibling rule sat in 🔴 prose
+and was skipped 2/2 until the hook made it structural.
+
+🔴 WHAT THIS GATE CAN AND CANNOT CHECK -- READ BEFORE TRUSTING IT AS COVERAGE
+----------------------------------------------------------------------------
+It checks that the body carries a level-2 heading (`## Closing condition` or its
+other name, `## Acceptance criteria`) WITH NON-EMPTY CONTENT UNDER IT. Whether
+that content is a genuine OBSERVABLE END-STATE, rather than a restatement of the
+fix, is **NOT machine-checkable and is not checked**. That caveat is measured,
+not defensive: in the briefed arm above all 10 issues carried the heading and
+MOST wrote the remedy under it instead of a condition that ends the object. So
+this gate raises the floor from "nothing" to "a filled-in section"; it does not
+certify the semantics, and a report that says otherwise is wrong.
+
+Both spellings are accepted on purpose. task-authoring.md question 1 treats the
+acceptance-criteria heading and the closing condition as one requirement under
+two names, and every clawgate task body already carries the second spelling --
+so accepting only the first would deny a correctly-specified body for using the
+house heading.
+
+One deliberate OVER-acceptance, recorded rather than hidden: a `--body` whose
+text contains the two characters `\n` is ALSO read with those decoded (see
+`escape_expanded`). `shlex` does not implement bash's `$'…'`, so an ANSI-C-quoted
+body arrives as one line beginning `$##` and would deny; and a plainly
+double-quoted `"…\n…"` really is one line to bash, which GitHub would render on
+one line too. Crediting both is a knowing trade: an author who typed `\n` between
+a heading and its content meant a newline, and denying them is the false positive
+that gets a gate routed around.
+
+ROUTES COVERED, AND THE ONES THAT ARE NOT
+-----------------------------------------
+COVERED (classified from a real argv, never from adjacency in the raw text):
+  * `gh issue create …`            -- the route agents actually use
+  * `gh api …/issues` as a POST    -- explicit `-X POST`/`--method POST`, or a
+                                      `-f`/`-F`/`--input` payload, which is what
+                                      makes gh default to POST
+  * `curl` POST to a `…/issues` URL path
+
+NOT COVERED, deliberately enumerated so this file cannot read as wider than it
+is (a guard that does that stops people looking -- RULES.md):
+  * any OTHER client: `python`/`requests`/`urllib`, `wget`, `httpie`/`http`,
+    `node`, a Go or Rust binary, or the GitHub MCP tools -- a PreToolUse(Bash)
+    hook only ever sees Claude Code's Bash tool
+  * `xargs gh issue create`, `ssh <host> gh issue create`, and argv assembled
+    from a variable (`$CMD issue create`) -- the command text does not carry it
+  * `gh issue create --web` / `-w`, which does NOT post: gh opens the browser's
+    new-issue form and exits, so the object is created by a human in a form this
+    process cannot see. Structurally exempt, like `--help`; it is a one-flag way
+    past this gate and is recorded as one rather than hidden.
+  * the GitHub web UI, the mobile app, and anything a systemd/cron process does
+  * `gh issue transfer`, `gh issue develop`, and issue creation as a side effect
+    of some other tool (a bot, a workflow, `gh workflow run`)
+  * the SEMANTIC question above: heading present and filled in is all it knows
+
+ONLY `create`. `gh issue comment|edit|close|reopen|list|view|status|develop`,
+`gh pr create`, and a GET of `…/issues` all pass untouched. This gate exists to
+stop an object being MINTED, not to tax every interaction with one.
+
+🔴 WHEN THE BODY CANNOT BE SEEN, THIS BLOCKS. IT DOES NOT PASS.
+`gh issue create --body "$(generate.sh)"` hands the gate an argument it cannot
+evaluate; `--body-file -` puts the body on a stdin no PreToolUse hook can read.
+Passing either through would make the guard walkable by changing the SHAPE of
+the call rather than its content -- the "spelled, not structural" failure
+RULES.md names. Both are denies, with a message that says how to make the body
+readable (write it to a file with the Write tool, then `--body-file <path>`).
+The cost is real and accepted.
+
+🔴 A MENTION IS NOT AN INVOCATION, AND THAT IS A FIRST-CLASS REQUIREMENT.
+`bash-guard.py` blocks a command line that merely QUOTES a banned shape, and its
+DESIGN NOTE defends that trade for irreversible actions. It is the wrong trade
+here: this gate fires on `gh`, the most-typed tool in these repos, and blocking
+a `grep`/`echo`/`rg` for the command string would train people to reach for the
+override -- a permanently-red gate is worse than no gate. So classification is
+argv-based (`grep 'gh issue create' f` has argv[0]=`grep`), and a heredoc body
+whose operator attaches to a KNOWN INERT SINK (`cat`/`tee`/`echo`/`printf`, not
+piped onward) is not read as commands. That sink list is an ALLOWLIST, so an
+unrecognised or unparseable attachment keeps the body -- the fail-CLOSED
+direction. A heredoc that really executes (`bash <<EOF`) keeps full coverage.
+
+THE OVERRIDE IS ONE SPELLING, ON PURPOSE
+----------------------------------------
+`GH_ISSUE_NO_CLOSING_CONDITION=1` -- as a command-position assignment on the call
+itself, or in the hook process's environment. Exactly the value `1`; `true`,
+`yes` and `0` do NOT override, because an override with several spellings is an
+override nobody can grep for. It is deliberately noisy in the transcript, which
+is the point: "when did we skip this" has to have an answer.
+
+I/O CONTRACT
+------------
+Reads PreToolUse JSON on stdin (`tool_name`, `tool_input.command`), prints
+`hookSpecificOutput.permissionDecision = "deny"` with a reason, exits 0. Exit 0
+with no output is ALLOW. Exit codes other than 2 are non-blocking for PreToolUse,
+so this file never relies on a non-zero status to mean anything.
+
+FAIL-CLOSED IS SCOPED, NOT GLOBAL
+---------------------------------
+`bash-guard.py` denies on ANY internal failure because every Bash call is in its
+scope. This hook is in scope for a much smaller family, so a blanket deny-on-
+crash would block `gh pr checks` on an unrelated bug. Instead: a crash (including
+a failed `guard_core` import) denies ONLY when the raw command text still looks
+like an issue create by a pure regex that cannot itself fail. Everything else
+exits 0. That fallback IS text-based, so on the crash path -- and only there -- a
+mere mention can be denied; the message names the override.
+"""
+import json
+import os
+import re
+import sys
+
+sys.dont_write_bytecode = True
+
+# --------------------------------------------------------------------------- #
+# Constants — every literal the tests pin lives here, spelled once.
+# --------------------------------------------------------------------------- #
+
+# The heading that satisfies the gate. Two accepted names, one requirement --
+# see the module docstring.
+#
+# 🔴 EXACTLY TWO HASHES, matching the clawgate gate's detector rather than
+# inventing a second convention. One pattern then finds every specified body in
+# either corpus, which is the whole value of a machine-readable claim; `###`
+# is blocked and the deny message says so.
+#
+# Up to three leading spaces is CommonMark's ATX-heading indent allowance; a
+# fourth makes it an indented code block, and a missing space after `##` makes it
+# not a heading at all. The `(?![^\W\d_])` stops `## Closing conditions of sale`
+# style run-ons from being rejected while `## Closing conditionality` — a
+# different word — is not silently credited.
+CLOSING_HEADING = re.compile(
+    r"^ {0,3}##[ \t]+(?:closing[ \t]+conditions?|acceptance[ \t]+criteria)"
+    r"(?![^\W\d_])[^\n]*$",
+    re.IGNORECASE,
+)
+
+# Any level-1 or level-2 ATX heading — what ENDS the section opened above.
+# A `###` does NOT end it: a sub-heading with content under it is content.
+SECTION_END = re.compile(r"^ {0,3}#{1,2}[ \t]")
+
+# A fenced code block opener/closer, CommonMark-ish: >=3 backticks or tildes,
+# indented at most 3 spaces.
+FENCE = re.compile(r"^ {0,3}(?P<char>`{3,}|~{3,})(?P<info>.*)$")
+
+OVERRIDE_ENV = "GH_ISSUE_NO_CLOSING_CONDITION"
+# One spelling. See the module docstring.
+OVERRIDE_VALUE = "1"
+# The assignment in COMMAND POSITION, or via `export`. Anchored on a command
+# boundary so the same bytes quoted inside an issue body do not silently disarm
+# the gate (a guard that can be turned off by QUOTING its own name is not a
+# guard).
+OVERRIDE_INLINE = re.compile(
+    r"(?:^|[\n;&|(){}`]|\$\()\s*(?:(?:then|else|do|!)\s+)*(?:export\s+)?"
+    + OVERRIDE_ENV + r"=" + OVERRIDE_VALUE + r"(?![\w.-])"
+)
+
+# Where the predicate is DEFINED. Both spellings are printed: the deployed path
+# is what the model can open right now, the repo path is what it edits. This gate
+# points at the definition and never restates it — see
+# scripts/tests/test_closing_condition_single_source.py.
+DEF_DEPLOYED = "~/.claude/skills/clawgate/flows/task-authoring.md"
+DEF_REPO = "devrc/claude/skills/clawgate/flows/task-authoring.md"
+
+# The pure-regex fallback classifier used ONLY on the crash path. It must never
+# raise and must never need a parse.
+CRASH_LOOKS_LIKE_CREATE = re.compile(r"\bissue\s+create\b|/issues(?![/\w])")
+
+# The cheap pre-filter. A command line naming neither of these cannot be an issue
+# create this gate covers, and returns before anything is imported or parsed.
+PREFILTER = re.compile(r"\bgh\b|\bcurl\b")
+
+# A body file larger than this is not an issue body; reading it would only be a
+# way to make a per-Bash-call hook slow. Treated as UNRESOLVED (i.e. blocked),
+# never as "no closing condition" — different facts, different messages.
+MAX_BODY_FILE_BYTES = 1024 * 1024
+
+# Shell constructs whose VALUE this process cannot know.
+#
+# 🔴 THE TWO PREDICATES ARE DIFFERENT ON PURPOSE, inherited from the clawgate
+# gate where collapsing them was a measured false positive: an issue body is
+# PROSE, so a lone `$VAR` inside it is text and only a command substitution (or a
+# value that is NOTHING BUT a variable reference) actually hides the content. A
+# body-FILE argument is a PATH, where any `$` at all makes the target unknowable.
+# A backtick is deliberately NOT a substitution marker for a body value: markdown
+# code spans are everywhere in an issue body.
+SUBSTITUTION = re.compile(r"\$\(")
+WHOLE_VARIABLE = re.compile(r"^\s*\$\{?[A-Za-z_][A-Za-z0-9_]*\}?\s*$")
+
+STDIN_NAMES = ("-", "/dev/stdin", "/proc/self/fd/0")
+
+
+def opaque_value(value):
+    """True when a `--body`-shaped argument hides its content."""
+    return bool(SUBSTITUTION.search(value) or WHOLE_VARIABLE.match(value))
+
+
+def opaque_path(value):
+    """True when a `--body-file`-shaped argument names an unknowable path."""
+    return "$" in value or "`" in value
+
+
+# Escapes an ANSI-C-quoted body (`--body $'…\n…'`) carries as two characters.
+_ANSI_C_ESCAPES = (("\\n", "\n"), ("\\r\\n", "\n"), ("\\t", "\t"))
+
+
+def escape_expanded(value):
+    """`value` with a surviving `$'…'` marker dropped and `\\n`/`\\t` decoded.
+
+    🔴 A FALSE-POSITIVE KILLER, AND IT MOVES IN THE ALLOW DIRECTION ONLY.
+    `shlex` — which the shared core tokenises with — does not implement bash's
+    ANSI-C quoting, so `--body $'## Closing condition\\nthe queue drains'` arrives
+    as the ONE line `$## Closing condition\\nthe queue drains`: the `$` defeats
+    the heading anchor and the escape keeps the content on the same line, so a
+    correctly-specified body DENIES. That is the shape that makes a gate get
+    routed around.
+
+    Used only as an EXTRA candidate beside the raw value, never as a replacement:
+    a candidate can only ever let a command through, so decoding cannot invent a
+    deny. It also cannot invent a pass that the operator did not write — a body
+    whose literal text is `## Closing condition\\n…` is one whose author meant a
+    newline.
+    """
+    out = value[1:] if value.startswith("$") else value
+    for esc, real in _ANSI_C_ESCAPES:
+        out = out.replace(esc, real)
+    return out
+
+
+def _inline_variants(value):
+    """The readings of one `--body` argument this gate will accept a heading in."""
+    expanded = escape_expanded(value)
+    return [value] if expanded == value else [value, expanded]
+
+
+# --------------------------------------------------------------------------- #
+# Flag tables — per ROUTE, because the same letter means different things.
+#
+# 🔴 `-F` IS TWO DIFFERENT FLAGS. On `gh issue create` it is `--body-file`; on
+# `gh api` it is `--raw-field`. One shared table would either read a raw field as
+# a file path or a file path as a field, and both directions produce a confident
+# wrong verdict. Hence separate tables, named after the route they belong to.
+# --------------------------------------------------------------------------- #
+GH_ISSUE_BODY_FLAGS = ("--body", "-b")
+GH_ISSUE_BODY_FILE_FLAGS = ("--body-file", "-F")
+# Every `gh issue create` flag that consumes a separate value token, plus the gh
+# globals that may precede the verb.
+GH_ISSUE_VALUE_FLAGS = GH_ISSUE_BODY_FLAGS + GH_ISSUE_BODY_FILE_FLAGS + (
+    "-a", "--assignee", "-l", "--label", "-m", "--milestone", "-p", "--project",
+    "-T", "--template", "-t", "--title", "-R", "--repo", "--editor",
+    "--hostname",
+)
+# gh api's own value-taking flags.
+GH_API_FIELD_FLAGS = ("-f", "--field", "-F", "--raw-field")
+GH_API_VALUE_FLAGS = GH_API_FIELD_FLAGS + (
+    "-X", "--method", "-H", "--header", "--input", "--hostname", "-q", "--jq",
+    "-t", "--template", "--cache", "-p", "--preview",
+)
+
+# curl flags that carry a request body.
+CURL_DATA_FLAGS = (
+    "-d", "--data", "--data-raw", "--data-ascii", "--data-binary",
+    "--data-urlencode", "--json", "-F", "--form", "-T", "--upload-file",
+)
+CURL_METHOD_FLAGS = ("-X", "--request")
+# curl flags that take a value we must not mistake for a URL or a body.
+CURL_VALUE_FLAGS = CURL_DATA_FLAGS + CURL_METHOD_FLAGS + (
+    "-H", "--header", "-o", "--output", "-u", "--user", "-A", "--user-agent",
+    "-e", "--referer", "-b", "--cookie", "-c", "--cookie-jar", "--url",
+    "--connect-timeout", "--max-time", "-m", "--retry", "--cacert", "--cert",
+    "--key", "--proxy", "-x", "--write-out", "-w",
+)
+
+# The ONE path suffix that CREATES an issue. `…/issues/<n>` is a read,
+# `…/issues/comments` is a comment — neither is in scope.
+CREATE_PATH_SUFFIX = "/issues"
+
+HELP_FLAGS = ("--help", "-h")
+# See the docstring: `--web` opens a browser form instead of posting.
+WEB_FLAGS = ("--web", "-w")
+
+
+# --------------------------------------------------------------------------- #
+# Heredocs
+# --------------------------------------------------------------------------- #
+# `(?<!<)` keeps a HERE-STRING (`<<<word`) out: it has no body and no terminator,
+# so reading one as a heredoc would swallow the rest of the command line as
+# "body text" and hand the gate prose it must not credit.
+_HEREDOC_OPEN = re.compile(
+    r"(?<!<)<<(?P<dash>-?)\s*(?P<tag>'[^']*'|\"[^\"]*\"|\\?[A-Za-z0-9_.-]+)")
+
+# Commands whose heredoc body is INERT TEXT rather than something to execute.
+# 🔴 An ALLOWLIST, and that is the safety argument: an attachment this table does
+# not recognise — `bash`, `sh`, `python3`, `xargs`, a variable, an unparseable
+# fragment, nothing at all — leaves the body in the command scan, so the failure
+# direction is over-blocking rather than a silent pass.
+INERT_HEREDOC_SINKS = frozenset({"cat", "tee", "echo", "printf"})
+# Anything on the operator's own line AFTER the tag that would send the sink's
+# output somewhere executable. `cat <<EOF | bash` is not inert.
+_PIPES_ONWARD = re.compile(r"[|&;]")
+# Separators that end the command the heredoc operator attaches to.
+_SEG_SPLIT = re.compile(r"\n|;|&&|\|\||\||&|\(|\)|`|\$\(")
+_ASSIGN_TOKEN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def _attached_command(text, operator_start):
+    """The command word the heredoc operator at `operator_start` attaches to.
+
+    Returns "" when it cannot be determined, which the caller reads as NOT inert.
+    """
+    head = _SEG_SPLIT.split(text[:operator_start])[-1]
+    for tok in head.split():
+        if _ASSIGN_TOKEN.match(tok):
+            continue
+        return os.path.basename(tok.strip("\"'"))
+    return ""
+
+
+def heredocs(text):
+    """Every heredoc in `text` as `(body, start, end, inert)`, in operator order.
+
+    🔴 DELIBERATELY QUOTE-BLIND for the BODY, unlike `guard_core._scan`. The
+    dominant real shape is
+
+        gh issue create --body "$(cat <<'EOF'
+        ## Closing condition
+        …
+        EOF
+        )"
+
+    where the operator sits INSIDE a double-quoted command substitution. A
+    quote-tracking scanner is right about what bash executes and wrong about what
+    this gate needs, which is "where is the prose". Being blind to quoting can
+    only ever surface MORE candidate body text, and a candidate is only ever used
+    to let a command THROUGH after the heading is found in it — so the blindness
+    cannot invent a pass that the text does not contain.
+
+    A body with no terminator line runs to end-of-text, which is bash's own
+    behaviour and the direction that keeps the text visible.
+    """
+    out, n = [], len(text)
+    # `cmd <<A <<B` opens TWO heredocs on ONE line, and bash reads their bodies
+    # back to back in the order the operators appear — B's body starts where A's
+    # terminator ended, not on the line after the command.
+    cursor, line_end, consumed = None, None, []
+    for m in _HEREDOC_OPEN.finditer(text):
+        # An operator that appears INSIDE a body already consumed is prose, not
+        # an operator. Without this, an issue body quoting `<<EOF` would mint a
+        # spurious body — and a spurious body is the one thing that could
+        # manufacture a false ALLOW.
+        if any(lo <= m.start() < hi for lo, hi in consumed):
+            continue
+        tag = m.group("tag")
+        if tag[:1] in ("'", '"'):
+            tag = tag[1:-1]
+        elif tag[:1] == "\\":
+            tag = tag[1:]
+        if not tag:
+            continue
+        strip_tabs = bool(m.group("dash"))
+        nl = text.find("\n", m.end())
+        if nl == -1:
+            continue
+        start = cursor if (line_end == nl and cursor is not None) else nl + 1
+        rest_of_line = text[m.end():nl]
+        line_end = nl
+        i, lines = start, []
+        # 🔴 TWO END OFFSETS, NOT ONE. `body_end` is where the TERMINATOR LINE
+        # begins; `after` is past it. Reporting `after` as the body's end made
+        # `scrub_inert_heredocs` blank the terminator too, so the downstream
+        # scanner saw an UNTERMINATED heredoc and swallowed the rest of the line —
+        # a correctly-specified create then denied with "no closing condition".
+        body_end = n
+        while i < n:
+            j = text.find("\n", i)
+            line = text[i:j] if j != -1 else text[i:]
+            nxt = (j + 1) if j != -1 else n
+            # 🔴 `<<-` strips leading TABS from the body lines as well as from
+            # the terminator. Stripping only the terminator leaves every body
+            # line carrying a tab, which turns `\t## Closing condition` into a
+            # four-space-indented code line and makes the heading invisible.
+            probe = line.lstrip("\t") if strip_tabs else line
+            if probe.rstrip("\r") == tag:
+                body_end = i
+                i = nxt
+                break
+            lines.append(probe)
+            i = nxt
+        consumed.append((start, i))
+        cursor = i
+        inert = (
+            _attached_command(text, m.start()) in INERT_HEREDOC_SINKS
+            and not _PIPES_ONWARD.search(rest_of_line)
+        )
+        out.append(("\n".join(lines), start, body_end, inert))
+    return out
+
+
+def heredoc_bodies(text):
+    """Every heredoc body, inert or not — the body-resolution view."""
+    return [h[0] for h in heredocs(text)]
+
+
+def scrub_inert_heredocs(text):
+    """`text` with INERT heredoc bodies blanked, for the INVOCATION scan only.
+
+    🔴 THIS IS NOT `guard_core`'s REVERTED `_strip_message_text()` HELPER, and
+    the difference is what makes it safe. That one decided which bytes of an
+    ARGUMENT were inert message text, using regexes over quoting it could not
+    parse, and three audit rounds each found a fresh shape where a genuinely
+    EXECUTING command was blanked. This one blanks nothing inside an argument: it
+    removes only a heredoc body whose operator attaches to a command in a
+    four-entry allowlist of text sinks, with nothing piping that sink's output
+    onward. Anything else — including anything it fails to parse — is kept.
+
+    The terminator line and the line structure are preserved (each body becomes
+    the same number of blank lines), so the downstream scanner still consumes the
+    heredoc exactly as it would have.
+
+    Body CONTENT is unaffected: `heredoc_bodies` reads the ORIGINAL text, so a
+    `--body "$(cat <<'EOF' … EOF)"` is still resolved from its heredoc.
+    """
+    spans = [(lo, hi) for _, lo, hi, inert in heredocs(text) if inert]
+    if not spans:
+        return text
+    out, prev = [], 0
+    for lo, hi in spans:
+        out.append(text[prev:lo])
+        out.append("\n" * text.count("\n", lo, hi))
+        prev = hi
+    out.append(text[prev:])
+    return "".join(out)
+
+
+# --------------------------------------------------------------------------- #
+# The closing-condition detector
+# --------------------------------------------------------------------------- #
+def _fence_states(body):
+    """`[(line, inside-a-fenced-code-block), …]` for `body`.
+
+    A fence DELIMITER line is reported as inside, so it can never be read as a
+    heading and never ends a section.
+    """
+    out = []
+    fence_char, fence_len = None, 0
+    for line in body.splitlines():
+        m = FENCE.match(line)
+        if m:
+            run = m.group("char")
+            if fence_char is None:
+                # An opening fence. Its info string may name a language; a
+                # CLOSING fence may not have one, which is why the state is
+                # tracked rather than toggled on every fence-looking line.
+                fence_char, fence_len = run[0], len(run)
+            elif run[0] == fence_char and len(run) >= fence_len and not m.group("info").strip():
+                fence_char, fence_len = None, 0
+            out.append((line, True))
+            continue
+        out.append((line, fence_char is not None))
+    return out
+
+
+def has_closing_condition(body):
+    """True iff `body` carries a real closing-condition heading WITH CONTENT.
+
+    🔴 TWO CONDITIONS, NOT ONE, AND THE SECOND IS WHY THIS IS NOT THE CLAWGATE
+    DETECTOR. A bare heading with nothing under it is the exact near-miss a model
+    produces when it pastes a template it did not fill in: the word is on the
+    page, the object still cannot be closed. So the section must hold at least
+    one non-blank line before the next `#`/`##` heading.
+
+    🔴 A HEADING INSIDE A FENCED CODE BLOCK DOES NOT COUNT. The template this
+    gate's own message prints is fenced; a draft that quotes the template while
+    forgetting to fill it in is exactly the near-miss this has to catch, and a
+    naive substring search passes it. Same class as RULES.md's "a field that
+    exists in a DTO is not a guard".
+
+    🔴 IT DOES NOT AND CANNOT CHECK THE SEMANTICS. See the module docstring: most
+    of a measured briefed-arm corpus wrote the REMEDY under this heading rather
+    than a condition that ends the issue, and every one of those passes here.
+    """
+    if not isinstance(body, str) or not body:
+        return False
+    lines = _fence_states(body)
+    for idx, (line, fenced) in enumerate(lines):
+        if fenced or not CLOSING_HEADING.match(line):
+            continue
+        for nxt, nxt_fenced in lines[idx + 1:]:
+            if not nxt_fenced and SECTION_END.match(nxt):
+                break
+            if nxt.strip():
+                return True
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# Command classification
+# --------------------------------------------------------------------------- #
+def _operands(argv, value_flags):
+    """argv's non-flag tokens, with each known value flag's value skipped."""
+    out, skip = [], False
+    for tok in argv[1:]:
+        if skip:
+            skip = False
+            continue
+        if tok.startswith("-") and tok != "-":
+            if tok in value_flags:
+                skip = True
+            continue
+        out.append(tok)
+    return out
+
+
+def _has_flag(argv, flags, value_flags):
+    """True when one of `flags` appears as a FLAG, not as some flag's value."""
+    skip = False
+    for tok in argv[1:]:
+        if skip:
+            skip = False
+            continue
+        if tok in value_flags:
+            skip = True
+            continue
+        if tok in flags:
+            return True
+    return False
+
+
+def _is_gh(argv):
+    return bool(argv) and os.path.basename(argv[0]) == "gh"
+
+
+def is_gh_issue_create(argv):
+    """True for a `gh … issue create …` argv.
+
+    Keyed on the OPERAND LIST rather than on argv[1:3], because a flag with a
+    value can precede the verb (`gh -R owner/x issue create`) and `issue` is also
+    a legal value of some other flag. Because the tokens come from a real lexer, a
+    quoted `"gh issue create"` is ONE token and never matches — the
+    mention-vs-invocation requirement.
+
+    🔴 THE VERB MUST BE THE FIRST TWO OPERANDS, NOT AN ADJACENT PAIR ANYWHERE.
+    The adjacency reading was written first and was a MEASURED false positive:
+    `gh pr list  # gh issue create needs a closing condition` tokenises with `#`
+    as an ordinary word (shlex does not strip shell comments), so `issue` and
+    `create` appear adjacent in the operand list and a trailing COMMENT was
+    classified as an invocation. gh takes no positional argument before the verb,
+    so the prefix reading is exact rather than merely narrower.
+    """
+    if not _is_gh(argv):
+        return False
+    ops = _operands(argv, GH_ISSUE_VALUE_FLAGS)
+    return ops[:2] == ["issue", "create"]
+
+
+def _url_path(token):
+    """The path component of a URL-ish token, or None."""
+    if "://" not in token:
+        return None
+    rest = token.split("://", 1)[1]
+    slash = rest.find("/")
+    path = rest[slash:] if slash != -1 else "/"
+    for sep in ("?", "#"):
+        cut = path.find(sep)
+        if cut != -1:
+            path = path[:cut]
+    return path.rstrip("/") or "/"
+
+
+def _api_path(token):
+    """Normalise a `gh api` endpoint operand to a leading-slash path."""
+    path = _url_path(token)
+    if path is None:
+        path = token.split("?", 1)[0].split("#", 1)[0]
+        if not path.startswith("/"):
+            path = "/" + path
+        path = path.rstrip("/") or "/"
+    return path
+
+
+def _creates_issue_path(path):
+    return path.endswith(CREATE_PATH_SUFFIX)
+
+
+def _flag_value(argv, names):
+    """The FIRST value of `--flag value` / `--flag=value`, or None."""
+    vals = _flag_values(argv, names)
+    return vals[0] if vals else None
+
+
+def is_gh_api_issue_create(argv):
+    """True for a `gh api …/issues` POST.
+
+    gh api defaults to GET, and to POST as soon as any field is supplied — so a
+    create is "explicit POST" OR "fields, no explicit method". An explicit
+    non-POST method is out of scope, and a plain `gh api repos/x/y/issues` is the
+    LIST endpoint.
+    """
+    if not _is_gh(argv):
+        return False
+    ops = _operands(argv, GH_API_VALUE_FLAGS)
+    if not ops or ops[0] != "api":
+        return False
+    if not any(_creates_issue_path(_api_path(o)) for o in ops[1:]):
+        return False
+    method = _flag_value(argv, ("-X", "--method"))
+    if method is not None:
+        return method.upper() == "POST"
+    return bool(_flag_values(argv, GH_API_FIELD_FLAGS)
+                or _flag_values(argv, ("--input",)))
+
+
+def _curl_parts(argv):
+    """(method, [url paths], [data values]) for a curl argv."""
+    method, paths, data = None, [], []
+    i = 1
+    while i < len(argv):
+        tok = argv[i]
+        if tok in CURL_METHOD_FLAGS and i + 1 < len(argv):
+            method = argv[i + 1].upper()
+            i += 2
+            continue
+        if tok in CURL_DATA_FLAGS and i + 1 < len(argv):
+            data.append(argv[i + 1])
+            i += 2
+            continue
+        if tok == "--url" and i + 1 < len(argv):
+            p = _url_path(argv[i + 1])
+            if p:
+                paths.append(p)
+            i += 2
+            continue
+        if tok in CURL_VALUE_FLAGS:
+            i += 2
+            continue
+        if not tok.startswith("-") or tok == "-":
+            p = _url_path(tok)
+            if p:
+                paths.append(p)
+        i += 1
+    return method, paths, data
+
+
+def is_curl_issue_create(argv):
+    """True for a curl that POSTs a NEW issue.
+
+    `…/issues/<n>` (a read) and `…/issues/comments` are out of scope by path, and
+    an explicit non-POST method is out of scope by method. A curl to the create
+    path with neither an explicit method nor any data flag is a GET of the issue
+    list — also out of scope.
+    """
+    if not argv or os.path.basename(argv[0]) != "curl":
+        return False
+    method, paths, data = _curl_parts(argv)
+    if not any(_creates_issue_path(p) for p in paths):
+        return False
+    if method is not None:
+        return method == "POST"
+    return bool(data)
+
+
+def is_exempt_invocation(argv):
+    """True for a create-shaped argv that STRUCTURALLY cannot post an issue.
+
+    🔴 Structural exemptions, not convenience ones, and both are recorded in the
+    docstring's uncovered-routes list rather than hidden:
+
+      * `--help`/`-h`, or a leading `help` operand — cobra prints usage and exits
+        WITHOUT calling the command, so the argv cannot reach the API. `--body`
+        alongside `--help` changes nothing: help still wins.
+      * `--web`/`-w` — gh opens the browser's new-issue form and exits. Nothing
+        is posted by this process; a human fills in a form this gate cannot see.
+
+    🔴 Scoped to `gh` BY NAME. `-w` is curl's `--write-out` and `-h` is not a
+    curl flag at all; curl posts the request regardless. Letting this predicate
+    answer for a curl create would hand every curl caller a one-word bypass —
+    the exact hole the clawgate gate's first `is_help_invocation` had.
+    """
+    if not _is_gh(argv):
+        return False
+    if _has_flag(argv, HELP_FLAGS + WEB_FLAGS, GH_ISSUE_VALUE_FLAGS):
+        return True
+    return _operands(argv, GH_ISSUE_VALUE_FLAGS)[:1] == ["help"]
+
+
+# --------------------------------------------------------------------------- #
+# Body resolution
+# --------------------------------------------------------------------------- #
+UNRESOLVED_OPAQUE = "the argument is a shell substitution this gate cannot evaluate"
+UNRESOLVED_STDIN = "the body is piped in on stdin, where a PreToolUse hook cannot read it"
+UNRESOLVED_UNREADABLE = "the body-file path could not be read"
+UNRESOLVED_NONE = "the command names no body this gate can read"
+UNRESOLVED_JSON = "the request payload is not JSON this gate can parse"
+
+
+def _flag_values(argv, names):
+    """Values of `--flag value` and `--flag=value`, in argv order."""
+    out, i = [], 1
+    while i < len(argv):
+        tok = argv[i]
+        if tok in names and i + 1 < len(argv):
+            out.append(argv[i + 1])
+            i += 2
+            continue
+        for name in names:
+            if tok.startswith(name + "="):
+                out.append(tok[len(name) + 1:])
+                break
+        i += 1
+    return out
+
+
+def _read_body_file(path):
+    path = os.path.expanduser(path)
+    if os.path.getsize(path) > MAX_BODY_FILE_BYTES:
+        raise ValueError("body file too large")
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        return f.read()
+
+
+def _resolve_inline(value, text):
+    """([body, …], reason-or-None) for a literal `--body` argument."""
+    inner = heredoc_bodies(value)
+    if inner:
+        # 🔴 THE ORIGINAL TEXT IS THE AUTHORITATIVE READING WHEN THE ARGUMENT
+        # ITSELF CARRIES A HEREDOC. `argv` comes from a copy of the command line
+        # whose inert heredoc bodies were blanked for the invocation scan, so
+        # `--body "$(cat <<'EOF' … EOF)"` — the shape this gate's own message
+        # recommends — resolves through `value` to a run of EMPTY lines and a
+        # correctly-specified create denied. `inner` survives only as the
+        # fallback for a value carrying a heredoc `text` somehow does not.
+        #
+        # 🔴 KNOWN LOOSENESS, recorded rather than hidden: `heredoc_bodies(text)`
+        # is every heredoc on the LINE, so a command line that both writes a
+        # well-specified heredoc elsewhere AND creates an issue whose own body is
+        # a different heredoc passes on the strength of the former. This is the
+        # same "aggregate the candidates" trade the clawgate gate makes, and it
+        # is reachable only when the create's own `--body` carries a heredoc
+        # operator — a plain `--body 'nope'` beside a good heredoc still DENIES
+        # (pinned by test_an_unrelated_heredoc_does_not_satisfy_a_create).
+        # An earlier version narrowed this to the all-blank case; a mutation
+        # sweep showed no test could tell the two apart, i.e. the narrowing was
+        # an unreachable guard reading as coverage. Removed rather than kept.
+        return (heredoc_bodies(text) or inner), None
+    # 🔴 AN EMPTY VALUE IS AN ARTIFACT OF THE PARSE, NOT A BODY. `guard_core`'s
+    # scanner LIFTS `$( … )` out of the segment it appears in, so
+    # `--body "$(cat <<'EOF' … EOF)"` — the shape the deny message itself
+    # recommends — arrives here as the empty string. Returning it as a readable
+    # body made a correctly-specified create deny with "no closing condition",
+    # which is both wrong and the most confusing possible message. Reporting
+    # NOTHING SEEN instead lets `body_candidates` fall through to the heredoc on
+    # the line, where the text actually is; if there is no heredoc either, the
+    # command still denies — as "cannot see the body", which is the true fact.
+    if not value.strip():
+        return [], None
+    # 🔴 Ordered so that a heading PRESENT IN THE LITERAL ARGUMENT always wins.
+    # `--body "## Closing condition\n… $(date)"` is readable enough: whatever the
+    # substitution expands to, the heading is in the bytes the operator typed.
+    # Consulting opacity first would report "cannot see the body" about a body
+    # that is right there.
+    variants = _inline_variants(value)
+    if any(has_closing_condition(v) for v in variants):
+        return variants, None
+    if opaque_value(value):
+        # Last chance: the operator may have opened the heredoc outside the
+        # quoted argument (`--body "$(cat <<EOF)"` splits across both shapes).
+        outer = heredoc_bodies(text)
+        if outer:
+            return outer, None
+        return [], UNRESOLVED_OPAQUE
+    return variants, None
+
+
+def _resolve_file(value, text):
+    """([body, …], reason-or-None) for a `--body-file` argument."""
+    if value in STDIN_NAMES:
+        # A body-file of `-` fed by a heredoc IS readable; fed by a pipe it is
+        # not.
+        inner = heredoc_bodies(text)
+        return (inner, None) if inner else ([], UNRESOLVED_STDIN)
+    if opaque_path(value):
+        return [], UNRESOLVED_OPAQUE
+    try:
+        return [_read_body_file(value)], None
+    except Exception:
+        # The file may be about to be written by a heredoc earlier on the same
+        # command line, which this gate CAN read.
+        inner = heredoc_bodies(text)
+        return (inner, None) if inner else ([], UNRESOLVED_UNREADABLE)
+
+
+def _resolve_json_payload(payloads):
+    """([body, …], reason-or-None) for JSON request payloads."""
+    bodies, failed = [], False
+    for payload in payloads:
+        try:
+            obj = json.loads(payload)
+        except Exception:
+            failed = True
+            continue
+        if isinstance(obj, dict) and isinstance(obj.get("body"), str):
+            bodies.append(obj["body"])
+        else:
+            failed = True
+    if bodies:
+        return bodies, None
+    return [], (UNRESOLVED_JSON if failed else UNRESOLVED_NONE)
+
+
+def _resolve_curl_data(value, text):
+    """([body, …], reason-or-None) for one curl data argument."""
+    if value.startswith("@"):
+        # 🔴 `-d @file` / `-d @-` still has to be JSON-PARSED afterwards.
+        # Returning the file's raw bytes as a body candidate is a real defect: a
+        # payload `{"body":"## Closing condition\n…"}` carries the heading only
+        # as an ESCAPED \n, so the line-based detector never sees a heading and a
+        # correctly-specified create is denied.
+        payloads, why = _resolve_file(value[1:], text)
+        if why:
+            return [], why
+    else:
+        payloads = heredoc_bodies(value) or ([] if opaque_value(value) else [value])
+        if not payloads:
+            outer = heredoc_bodies(text)
+            if not outer:
+                return [], UNRESOLVED_OPAQUE
+            payloads = outer
+    return _resolve_json_payload(payloads)
+
+
+def _resolve_gh_api_field(value, text):
+    """([body, …], reason-or-None) for one `gh api -f/-F` field argument.
+
+    Only a field literally named `body` is a body; `title=…` and `labels[]=…` are
+    not, and returning them would let a title carry the heading.
+    """
+    if "=" not in value:
+        return [], None
+    key, val = value.split("=", 1)
+    if key.strip() != "body":
+        return [], None
+    if val.startswith("@"):
+        return _resolve_file(val[1:], text)
+    return _resolve_inline(val, text)
+
+
+def body_candidates(argv, text, route):
+    """([every body text this gate could read], reason the rest were unreadable).
+
+    The reason is None when everything named was resolved. Aggregating rather
+    than picking ONE source is deliberate: a command may legitimately name a
+    body-file that a heredoc on the same line is about to write, and a candidate
+    is only ever used to let the command THROUGH.
+    """
+    cands, reason = [], None
+
+    def take(pair):
+        nonlocal reason
+        got, why = pair
+        cands.extend(got)
+        if why and reason is None:
+            reason = why
+
+    if route == "curl":
+        _, _, data = _curl_parts(argv)
+        for value in data:
+            take(_resolve_curl_data(value, text))
+    elif route == "gh-api":
+        for value in _flag_values(argv, GH_API_FIELD_FLAGS):
+            take(_resolve_gh_api_field(value, text))
+        for value in _flag_values(argv, ("--input",)):
+            if value in STDIN_NAMES:
+                inner = heredoc_bodies(text)
+                take(_resolve_json_payload(inner) if inner else ([], UNRESOLVED_STDIN))
+                continue
+            payloads, why = _resolve_file(value, text)
+            take(([], why) if why else _resolve_json_payload(payloads))
+    else:
+        for value in _flag_values(argv, GH_ISSUE_BODY_FLAGS):
+            take(_resolve_inline(value, text))
+        for value in _flag_values(argv, GH_ISSUE_BODY_FILE_FLAGS):
+            take(_resolve_file(value, text))
+
+    if not cands and reason is None:
+        # No body argument at all. The heredoc on the line, if any, is still the
+        # operator's body — and if there is none, the gate has seen nothing.
+        outer = heredoc_bodies(text)
+        if outer:
+            cands = outer
+        else:
+            reason = UNRESOLVED_NONE
+    return cands, reason
+
+
+# --------------------------------------------------------------------------- #
+# Messages
+# --------------------------------------------------------------------------- #
+_WHY = (
+    "Your RULES say a work item may only be filed once you can name the "
+    "condition that ENDS it and who or what checks it -- name neither and the "
+    "honest move is to say so in your reply rather than mint an object nobody "
+    "can close.\n"
+    "Definition (the single source -- point at it, do not restate it):\n"
+    "    " + DEF_DEPLOYED + "   -> question 1\n"
+    "    (repo: " + DEF_REPO + ")"
+)
+
+_HOW = (
+    "Put this in the body, filled in:\n"
+    "````\n"
+    "## Closing condition\n"
+    "<the observable end-state that ends this issue>\n"
+    "Checked by: <a command that exits 0 / a merged PR / a cleared alert / a "
+    "NAMED person reading NAMED evidence>\n"
+    "````\n"
+    "`## Acceptance criteria` is accepted as the same heading under its other "
+    "name."
+)
+
+_LIMIT = (
+    "What this gate checked: the heading is present, at level 2, outside a code "
+    "fence, with at least one non-blank line under it. It CANNOT check that what "
+    "you wrote is an observable end-state rather than a restatement of the fix -- "
+    "that is not machine-checkable, and in the run that motivated this gate most "
+    "bodies that cleared the heading still described the remedy. Passing here is "
+    "a floor, not a verdict."
+)
+
+_ESCAPES = (
+    "Escape hatches, both deliberate:\n"
+    "  * a body that already carries the heading passes this gate SILENTLY -- the "
+    "one-liner still works, it just has to say what ends the issue;\n"
+    "  * for this one call only, prefix it with " + OVERRIDE_ENV + "=" +
+    OVERRIDE_VALUE + " (greppable on purpose)."
+)
+
+
+def missing_text():
+    return (
+        "This creates a GitHub issue whose body names no closing condition.\n\n"
+        + _WHY + "\n\n" + _HOW + "\n\n"
+        "The heading must be a level-2 ATX heading -- `## Closing condition` or "
+        "`## Acceptance criteria` (case-insensitive, trailing text allowed) -- "
+        "and it must have CONTENT under it. `###`, bold text, a heading inside a "
+        "``` fence, and a heading with nothing beneath it all fail, because none "
+        "of them is a filled-in section.\n\n" + _LIMIT + "\n\n" + _ESCAPES
+    )
+
+
+def unseeable_text(reason):
+    return (
+        "This creates a GitHub issue, but this gate CANNOT SEE THE BODY (" +
+        reason + "), so it cannot check for a closing condition.\n\n"
+        "Blocking rather than passing it through, deliberately: a gate that fails "
+        "open on a body it cannot read is walkable by changing the SHAPE of the "
+        "call instead of its content -- a spelled guard, not a structural one "
+        "(RULES.md).\n\n"
+        "Hand the body over where the gate can read it:\n"
+        "    --body '<the full markdown>'\n"
+        "    --body-file <a real path>            (write it with the Write tool first)\n"
+        "    --body \"$(cat <<'EOF' … EOF)\"        (a heredoc IS readable)\n\n"
+        + _WHY + "\n\n" + _HOW + "\n\n" + _ESCAPES
+    )
+
+
+def crash_text(exc):
+    return (
+        "gh-issue-closing-condition-guard crashed while checking this command (" +
+        str(exc) + "). It looks like a GitHub issue create, so it is denied "
+        "rather than passed through unchecked.\n\n"
+        "This crash path classifies by RAW TEXT, so a command that only MENTIONS "
+        "`issue create` can land here even though the normal path would allow it. "
+        "Report it; the command text is what reproduces it. To proceed now, "
+        "prefix the call with " + OVERRIDE_ENV + "=" + OVERRIDE_VALUE + ".\n\n"
+        "The definition: " + DEF_DEPLOYED
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Decision
+# --------------------------------------------------------------------------- #
+def override_requested(text, env):
+    """True when the operator explicitly disarmed the gate.
+
+    Two channels, one spelling. The inline assignment is anchored on a command
+    boundary; the process environment is read exactly, so `=true` / `=0` / an
+    empty value are NOT overrides.
+    """
+    if env.get(OVERRIDE_ENV) == OVERRIDE_VALUE:
+        return True
+    return bool(OVERRIDE_INLINE.search(text))
+
+
+def _route(argv):
+    """Which covered route this argv is, or None."""
+    if is_gh_issue_create(argv):
+        return "gh-issue"
+    if is_gh_api_issue_create(argv):
+        return "gh-api"
+    if is_curl_issue_create(argv):
+        return "curl"
+    return None
+
+
+def creating_invocations(text, guard_core):
+    """[(argv, route), …] for every REAL issue create on this command line.
+
+    🔴 The scan runs over `scrub_inert_heredocs(text)`, not `text`. That is the
+    mention-vs-invocation requirement: a `cat > notes.md <<'EOF'` body that spells
+    out the command is documentation, and denying it would make this gate the
+    thing people route around. Body resolution still reads the ORIGINAL text.
+    """
+    out = []
+    for argv in guard_core.commands(scrub_inert_heredocs(text)):
+        route = _route(argv)
+        if route and not is_exempt_invocation(argv):
+            out.append((argv, route))
+    return out
+
+
+def evaluate(text, env, guard_core):
+    """The deny reason for this command line, or None to allow."""
+    if not PREFILTER.search(text):
+        return None
+    creates = creating_invocations(text, guard_core)
+    if not creates:
+        return None
+    if override_requested(text, env):
+        return None
+    # 🔴 Judged over ALL the creates on the line together. A line that files two
+    # issues, one specified and one not, must not pass on the strength of the
+    # good one — so the verdict is "every create had a closing condition", never
+    # "some body somewhere did".
+    worst = None
+    for argv, route in creates:
+        cands, reason = body_candidates(argv, text, route)
+        if any(has_closing_condition(c) for c in cands):
+            continue
+        if cands:
+            return missing_text()
+        worst = worst or unseeable_text(reason or UNRESOLVED_NONE)
+    return worst
+
+
+def deny(reason):
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }))
+    sys.exit(0)
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+    if not isinstance(data, dict) or data.get("tool_name") != "Bash":
+        sys.exit(0)
+    tool_input = data.get("tool_input")
+    cmd = tool_input.get("command", "") if isinstance(tool_input, dict) else ""
+    if not isinstance(cmd, str) or not cmd:
+        sys.exit(0)
+    # The pre-filter runs BEFORE the import so a session that never touches gh or
+    # curl pays one regex and an interpreter start, nothing else.
+    if not PREFILTER.search(cmd):
+        sys.exit(0)
+
+    # 🔴 BaseException, not Exception — the same widening bash-guard.py measured.
+    # A SystemExit or KeyboardInterrupt escaping here would exit non-zero, and for
+    # PreToolUse every non-2 status is a silent ALLOW.
+    try:
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        import guard_core
+        reason = evaluate(cmd, os.environ, guard_core)
+    except BaseException as exc:  # noqa: BLE001 - see above
+        if CRASH_LOOKS_LIKE_CREATE.search(cmd) and not override_requested(cmd, os.environ):
+            deny(crash_text(exc))
+        sys.exit(0)
+
+    if reason:
+        deny(reason)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/claude-hooks/gh-issue-closing-condition-guard.py
+++ b/scripts/claude-hooks/gh-issue-closing-condition-guard.py
@@ -119,8 +119,13 @@ watches -- rescued `--body-file -`, `--body "$(gen.sh)"`, an unreadable
 `--body-file`, an attached `-b…`, and a create with no body flag at all. It also
 made a line filing TWO issues pass on the strength of the FIRST one's heredoc.
 Body resolution is now scoped to the create's OWN command segment
-(`command_spans`), so a heredoc opened by a different command on the same line is
-not a candidate. Two deliberate consequences, recorded rather than hidden:
+(`command_segments`), and a heredoc is attributed to the command whose text
+holds its `<<` operator — never to whichever command the newline before its body
+happened to end. That distinction is the whole claim: when two commands on ONE
+physical line each open a heredoc, bash queues the bodies in operator order, so
+"the body after this command's newline" names the OTHER command's body. A
+heredoc opened by a different command is not a candidate. Two deliberate
+consequences, recorded rather than hidden:
   * an unreadable `--body-file <path>` is still rescued by a heredoc that WRITES
     THAT EXACT PATH, wherever on the line it sits -- `cat > p.md <<'EOF' … EOF &&
     gh issue create --body-file p.md` is a correctly-specified create and must
@@ -417,7 +422,9 @@ def _attached_command(text, operator_start):
 # `start`  where the body begins; `body_end` where the TERMINATOR LINE begins
 # `after`  past the terminator line — what a scan must skip to leave the body
 # `op`     the offset of the `<<` itself, which is what attributes a heredoc to
-#          the COMMAND that opened it (see `command_spans`)
+#          the COMMAND that opened it (see `_shell_walk`/`command_segments`) —
+#          the body's own position cannot, since several commands on one line
+#          queue their bodies back to back after the LAST of them
 _Heredoc = collections.namedtuple(
     "_Heredoc", "body start body_end inert op after head rest")
 
@@ -643,12 +650,32 @@ def _read_word(text, i, n):
 
 
 def _shell_walk(text):
-    """`(spans, override)` — top-level command spans, and the override verdict.
+    """`(segments, override)` — one TEXT per top-level command segment.
 
-    `spans` are `[lo, hi)` slices of `text`, one per TOP-LEVEL command segment,
-    split on unquoted `;`/`&`/`|`/newline and on a subshell paren. A heredoc's
-    body is kept INSIDE the span of the command that opened it, because that is
-    exactly the relationship body resolution needs.
+    A segment is a TOP-LEVEL command, split on unquoted `;`/`&`/`|`/newline and
+    on a subshell paren, with the bodies of the heredocs THAT COMMAND OPENED
+    appended to it.
+
+    🔴 A SEGMENT IS NOT A `[lo, hi)` SLICE, AND CANNOT BE. A heredoc body sits
+    physically after the newline that ends the command line, and when SEVERAL
+    commands on one line each open one, bash queues the bodies back to back in
+    OPERATOR order — so the second command's command text and the second
+    command's body are separated by the FIRST command's body. One contiguous
+    slice cannot name that set. Returning a slice is what reopened B2: the span
+    was widened to the first queued body's end, which swallowed the EARLIER
+    command's body while the opener's own body fell outside every span.
+
+    Attribution is therefore by `_Heredoc.op` — the offset of the `<<` itself,
+    which is inside the command text of the command that opened it — and never
+    by which command the newline happened to terminate. A body already contained
+    in the command text (a heredoc opened INSIDE a `$( … )`, whose body is not
+    past the segment's end) is not appended a second time; appending it would put
+    the body's bytes in the invocation scan twice.
+
+    The reassembled text is `<command text> + "\\n" + <its bodies, in operator
+    order>`, which re-parses: the joiner restores the newline the split consumed,
+    so `heredocs()` reading a segment finds each operator's body exactly where
+    bash would.
 
     `override` is True only for a bare `GH_ISSUE_NO_CLOSING_CONDITION=1` word in
     COMMAND POSITION at substitution depth 0 — the assignment bash would actually
@@ -656,14 +683,24 @@ def _shell_walk(text):
     process's environment and does not count; inside a quote it is prose.
     """
     n = len(text)
-    skip = {}
-    for h in heredocs(text):
-        skip[h.start] = h.after
+    heres = heredocs(text)
+    skip = {h.start: h.after for h in heres}
     spans, seg_lo = [], 0
     stack = []            # (saved quote, closing char) per open substitution
     quote, at_cmd, override, i = None, True, False, 0
     while i < n:
         if i in skip:
+            # 🔴 A BODY IS DATA, NOT COMMAND TEXT. Stepping over it keeps its
+            # stray quotes out of the quote state — and keeps its bytes out of
+            # whichever segment is currently open. When the pending segment has
+            # nothing in it yet the body starts exactly where the segment does
+            # (a body always follows the newline that ended the opening command,
+            # or the previous body's terminator), so the segment begins AFTER it.
+            # `at_cmd` is deliberately untouched: the separator that opened this
+            # segment already set it, and the first word after the body really is
+            # in command position — that is the `VAR=1 gh …`-after-a-heredoc path.
+            if not text[seg_lo:i].strip():
+                seg_lo = skip[i]
             i = skip[i]
             continue
         c = text[i]
@@ -710,14 +747,11 @@ def _shell_walk(text):
             continue
         if c in _SEPARATOR_CHARS or (not stack and c in "()"):
             if not stack:
-                # 🔴 A newline that OPENS a heredoc body ends the command, but
-                # the body belongs to it: the span runs past the terminator so
-                # `heredoc_bodies(span)` still finds it.
-                end = skip.get(i + 1) if c == "\n" else None
-                if end is not None:
-                    spans.append((seg_lo, end))
-                    seg_lo, i, at_cmd = end, end, True
-                    continue
+                # The separator ends the COMMAND TEXT here, full stop. Any
+                # heredoc body it opened is re-attached below, by operator
+                # offset — never by "whatever body starts at i + 1", which is the
+                # FIRST queued body on the line and belongs to the EARLIEST
+                # opener, not to the command this newline is ending.
                 spans.append((seg_lo, i))
                 seg_lo = i + 1
             at_cmd, i = True, i + 1
@@ -735,11 +769,28 @@ def _shell_walk(text):
             at_cmd = False
         i = max(j, i + 1)
     spans.append((seg_lo, n))
-    return [(lo, hi) for lo, hi in spans if text[lo:hi].strip()], override
+    segments = []
+    for lo, hi in spans:
+        head = text[lo:hi]
+        if not head.strip():
+            continue
+        # `h.start >= hi` is what says "this body sits PAST the command text" —
+        # i.e. it was queued for a later line. A heredoc opened inside a
+        # `$( … )` has its body within `[lo, hi)` already and must not be
+        # duplicated: a second copy would put its bytes through the invocation
+        # scan twice, and a body that spells a create would then be counted.
+        bodies = [text[h.start:h.after]
+                  for h in heres if lo <= h.op < hi and h.start >= hi]
+        segments.append((head + "\n" + "".join(bodies)) if bodies else head)
+    return segments, override
 
 
-def command_spans(text):
-    """The `[lo, hi)` slice of every top-level command segment in `text`."""
+def command_segments(text):
+    """The reassembled TEXT of every top-level command segment in `text`.
+
+    Each segment is its command text followed by the bodies of the heredocs that
+    command opened — see `_shell_walk` for why that cannot be one slice.
+    """
     return _shell_walk(text)[0]
 
 
@@ -1119,8 +1170,9 @@ def _resolve_inline(value, text):
         #
         # 🔴 THE "KNOWN LOOSENESS" ABOVE IS NOW CLOSED, and this comment is kept
         # only so nobody re-derives it: `text` here is the create's OWN command
-        # segment, not the whole line, so a well-specified heredoc belonging to a
-        # different command is not in it.
+        # segment — its words plus the bodies of the heredocs whose `<<` it
+        # spells — not the whole line, so a well-specified heredoc belonging to a
+        # different command is not in it, on a preceding line OR on this one.
         return (heredoc_bodies(text) or inner), None
     # 🔴 AN EMPTY VALUE IS AN ARTIFACT OF THE PARSE, NOT A BODY. `guard_core`'s
     # scanner LIFTS `$( … )` out of the segment it appears in, so
@@ -1251,9 +1303,12 @@ def body_candidates(argv, text, route, full=None):
     🔴 `text` IS THIS CREATE'S OWN COMMAND SEGMENT, NOT THE COMMAND LINE. That is
     the whole of the B2/B3 fix and it is a change of MEANING, not of degree —
     aggregation across sources on ONE command is deliberate, aggregation across
-    COMMANDS was a bug. `full` is threaded through for the single place that
-    still legitimately looks line-wide: a heredoc writing an as-yet-unwritten
-    `--body-file` path.
+    COMMANDS was a bug. The segment carries the bodies of the heredocs this
+    command's own text opened (attributed by the `<<` offset), so a
+    `heredoc_bodies(text)` here reads this create's body and no other's, however
+    the openers are interleaved on the line. `full` is threaded through for the
+    single place that still legitimately looks line-wide: a heredoc writing an
+    as-yet-unwritten `--body-file` path.
     """
     full = text if full is None else full
     cands, reason = [], None
@@ -1429,9 +1484,12 @@ def creating_invocations(text, guard_core):
 
     🔴 `scope` IS THE THIRD ELEMENT AND THE POINT OF THIS FUNCTION NOW. Each
     create is enumerated inside its OWN top-level command segment and carries
-    that segment's text, so `body_candidates` cannot reach a heredoc a different
-    command opened. Two creates on one line therefore get two different scopes,
-    which is what stops the first one's good body answering for the second.
+    that segment's REASSEMBLED text — the command's words plus the bodies of the
+    heredocs IT opened, attributed by operator offset — so `body_candidates`
+    cannot reach a heredoc a different command opened, even when both openers
+    share one physical line and bash queues their bodies back to back. Two
+    creates on one line therefore get two different scopes, which is what stops
+    the first one's good body answering for the second.
 
     A create the segmentation does not attribute — malformed quoting, a shape the
     walk and the shared core read differently — is still enumerated by a
@@ -1440,8 +1498,7 @@ def creating_invocations(text, guard_core):
     only to keep one from disappearing.
     """
     out, seen = [], []
-    for lo, hi in command_spans(text):
-        scope = text[lo:hi]
+    for scope in command_segments(text):
         for argv in guard_core.commands(scrub_inert_heredocs(scope)):
             route = _route(argv)
             if route and not is_exempt_invocation(argv, route):

--- a/scripts/claude-hooks/gh-issue-closing-condition-guard.py
+++ b/scripts/claude-hooks/gh-issue-closing-condition-guard.py
@@ -43,14 +43,14 @@ two names, and every clawgate task body already carries the second spelling --
 so accepting only the first would deny a correctly-specified body for using the
 house heading.
 
-One deliberate OVER-acceptance, recorded rather than hidden: a `--body` whose
-text contains the two characters `\n` is ALSO read with those decoded (see
-`escape_expanded`). `shlex` does not implement bash's `$'…'`, so an ANSI-C-quoted
-body arrives as one line beginning `$##` and would deny; and a plainly
-double-quoted `"…\n…"` really is one line to bash, which GitHub would render on
-one line too. Crediting both is a knowing trade: an author who typed `\n` between
-a heading and its content meant a newline, and denying them is the false positive
-that gets a gate routed around.
+One NARROW decode, and its boundary is the point: a `--body` value that ARRIVES
+ANSI-C-QUOTED (`$'…\n…'`, which `shlex` does not implement, so it reaches this
+gate as one line beginning `$##`) is ALSO read with `\n`/`\t` decoded — see
+`escape_expanded`. A plainly double-quoted `"…\n…"` is NOT decoded: bash leaves
+those two characters literal, GitHub renders the body on one line, and there is
+no heading on that page. Crediting it would have made this gate passable by
+appending ~30 characters that produce nothing, which is a spelled guard, not a
+structural one. The `$` prefix is the discriminator and it is exact.
 
 ROUTES COVERED, AND THE ONES THAT ARE NOT
 -----------------------------------------
@@ -68,6 +68,16 @@ is (a guard that does that stops people looking -- RULES.md):
     hook only ever sees Claude Code's Bash tool
   * `xargs gh issue create`, `ssh <host> gh issue create`, and argv assembled
     from a variable (`$CMD issue create`) -- the command text does not carry it
+  * 🔴 A CREATE PRECEDED BY A SHELL KEYWORD, i.e. inside a compound statement:
+    `if …; then gh issue create …; fi`, `while …; do gh issue create …; done`,
+    and the bare `then`/`do`/`else`/`!` prefixes. `guard_core._peel_variants`
+    peels wrappers (`sudo`, `timeout`, `nohup`) and `VAR=` assignments but not
+    keywords, so argv[0] is `then` and the argv is not a `gh` at all.
+    `time`/`command`/`exec`/`eval` DO reach the gate; those four are not
+    keywords in the peeler's sense. Measured 2026-08-25, identical before and
+    after this fix round, and NOT fixed here: the peeler is `guard_core`'s and
+    is shared with `bash-guard.py`, so widening it is its own change with its
+    own blast radius. Recorded rather than left for someone to rediscover.
   * `gh issue create --web` / `-w`, which does NOT post: gh opens the browser's
     new-issue form and exits, so the object is created by a human in a form this
     process cannot see. Structurally exempt, like `--help`; it is a one-flag way
@@ -76,6 +86,17 @@ is (a guard that does that stops people looking -- RULES.md):
   * `gh issue transfer`, `gh issue develop`, and issue creation as a side effect
     of some other tool (a bot, a workflow, `gh workflow run`)
   * the SEMANTIC question above: heading present and filled in is all it knows
+
+🔴 ONE KNOWN FALSE POSITIVE, recorded because a limit nobody wrote down is a
+limit nobody can fix: a body that QUOTES a heredoc operator inside a code fence
+(`## Closing condition … ```cat <<'EOF' > x``` `) denies. `heredocs` is
+quote-blind on purpose, `scrub_inert_heredocs` therefore blanks bytes that sit
+inside the quoted argument, the argument's quote no longer balances and the
+fallback tokeniser hands `--body` a fragment. Pinned by
+test_a_body_quoting_a_heredoc_operator_is_a_KNOWN_FALSE_POSITIVE. The fix is to
+make the SCRUB quote-aware while body resolution stays blind; that is a change to
+the mechanism the mention-is-not-an-invocation requirement rests on and has not
+been made.
 
 ONLY `create`. `gh issue comment|edit|close|reopen|list|view|status|develop`,
 `gh pr create`, and a GET of `…/issues` all pass untouched. This gate exists to
@@ -89,6 +110,24 @@ the call rather than its content -- the "spelled, not structural" failure
 RULES.md names. Both are denies, with a message that says how to make the body
 readable (write it to a file with the Write tool, then `--body-file <path>`).
 The cost is real and accepted.
+
+🔴 AND A HEREDOC ONLY EVER ANSWERS FOR THE COMMAND IT FEEDS. This claim used to
+be false in a way that voided the paragraph above: every fallback resolved
+`heredoc_bodies(<the whole command line>)`, so ONE unrelated
+`cat > /tmp/plan.md <<'EOF' … EOF` -- the ordinary agent workflow this gate
+watches -- rescued `--body-file -`, `--body "$(gen.sh)"`, an unreadable
+`--body-file`, an attached `-b…`, and a create with no body flag at all. It also
+made a line filing TWO issues pass on the strength of the FIRST one's heredoc.
+Body resolution is now scoped to the create's OWN command segment
+(`command_spans`), so a heredoc opened by a different command on the same line is
+not a candidate. Two deliberate consequences, recorded rather than hidden:
+  * an unreadable `--body-file <path>` is still rescued by a heredoc that WRITES
+    THAT EXACT PATH, wherever on the line it sits -- `cat > p.md <<'EOF' … EOF &&
+    gh issue create --body-file p.md` is a correctly-specified create and must
+    not deny. The match is on the path, not on adjacency.
+  * `cat <<'EOF' … EOF | gh issue create --body-file -` DENIES. The pipe puts the
+    heredoc in a different segment, and no cheap parse ties one command's stdin
+    to another command's heredoc. Use `--body "$(cat <<'EOF' … EOF)"`.
 
 🔴 A MENTION IS NOT AN INVOCATION, AND THAT IS A FIRST-CLASS REQUIREMENT.
 `bash-guard.py` blocks a command line that merely QUOTES a banned shape, and its
@@ -110,6 +149,17 @@ itself, or in the hook process's environment. Exactly the value `1`; `true`,
 override nobody can grep for. It is deliberately noisy in the transcript, which
 is the point: "when did we skip this" has to have an answer.
 
+🔴 IT IS DECIDED BY A QUOTE-AWARE WALK, NEVER BY A REGEX OVER THE RAW TEXT. The
+first version matched an anchored regex against the whole command line, and its
+anchor class included `\n`, `;` and a backtick -- every one of which occurs
+INSIDE an ordinary issue body. So a body that merely MENTIONED the override
+string on its own line, or after a semicolon, or in a markdown code span,
+disarmed the gate silently; and this gate's own deny message TELLS the reader
+that string, so an issue about this guard turned it off. `_shell_walk` now
+credits an assignment only at a real command position, outside every quote, and
+at substitution depth 0 -- a `` `VAR=1` `` inside a body is a substitution whose
+assignment cannot reach `gh`'s environment anyway.
+
 I/O CONTRACT
 ------------
 Reads PreToolUse JSON on stdin (`tool_name`, `tool_input.command`), prints
@@ -127,6 +177,7 @@ like an issue create by a pure regex that cannot itself fail. Everything else
 exits 0. That fallback IS text-based, so on the crash path -- and only there -- a
 mere mention can be denied; the message names the override.
 """
+import collections
 import json
 import os
 import re
@@ -168,14 +219,11 @@ FENCE = re.compile(r"^ {0,3}(?P<char>`{3,}|~{3,})(?P<info>.*)$")
 OVERRIDE_ENV = "GH_ISSUE_NO_CLOSING_CONDITION"
 # One spelling. See the module docstring.
 OVERRIDE_VALUE = "1"
-# The assignment in COMMAND POSITION, or via `export`. Anchored on a command
-# boundary so the same bytes quoted inside an issue body do not silently disarm
-# the gate (a guard that can be turned off by QUOTING its own name is not a
-# guard).
-OVERRIDE_INLINE = re.compile(
-    r"(?:^|[\n;&|(){}`]|\$\()\s*(?:(?:then|else|do|!)\s+)*(?:export\s+)?"
-    + OVERRIDE_ENV + r"=" + OVERRIDE_VALUE + r"(?![\w.-])"
-)
+# 🔴 THE WHOLE TOKEN, COMPARED EXACTLY. There is no regex over the raw command
+# text any more: `_shell_walk` finds command-position words and this is the one
+# it accepts. `…=1x`, `…_EXTRA=1` and `…=true` are different strings and do not
+# override; the same bytes inside a quoted issue body are never a command word.
+OVERRIDE_ASSIGNMENT = OVERRIDE_ENV + "=" + OVERRIDE_VALUE
 
 # Where the predicate is DEFINED. Both spellings are printed: the deployed path
 # is what the model can open right now, the repo path is what it edits. This gate
@@ -239,11 +287,18 @@ def escape_expanded(value):
 
     Used only as an EXTRA candidate beside the raw value, never as a replacement:
     a candidate can only ever let a command through, so decoding cannot invent a
-    deny. It also cannot invent a pass that the operator did not write — a body
-    whose literal text is `## Closing condition\\n…` is one whose author meant a
-    newline.
+    deny.
+
+    🔴 GATED ON THE `$` PREFIX, AND THAT GATE IS THE FIX, NOT A DETAIL. Decoding
+    unconditionally meant ANY body passed by appending
+    `\\n## Closing condition\\ndone` — about thirty characters that bash leaves
+    literal, so the issue GitHub renders carries no heading at all. Only a value
+    that really arrived ANSI-C-quoted is decoded; a double-quoted `"…\\n…"` is
+    one line to bash and is judged as one line here.
     """
-    out = value[1:] if value.startswith("$") else value
+    if not value.startswith("$"):
+        return value
+    out = value[1:]
     for esc, real in _ANSI_C_ESCAPES:
         out = out.replace(esc, real)
     return out
@@ -267,13 +322,28 @@ GH_ISSUE_BODY_FLAGS = ("--body", "-b")
 GH_ISSUE_BODY_FILE_FLAGS = ("--body-file", "-F")
 # Every `gh issue create` flag that consumes a separate value token, plus the gh
 # globals that may precede the verb.
+#
+# 🔴 DERIVED FROM `gh issue create --help` ON gh 2.97.0, AND WRONG IN BOTH
+# DIRECTIONS BEFORE THAT. A value-taking flag MISSING here puts its value in the
+# operand list, which defeats the `ops[:2] == ["issue", "create"]` prefix test
+# whenever the flag precedes the verb — `--type`, `--parent`, `--blocked-by`,
+# `--blocking` and `--recover` were all missing, i.e. five one-flag bypasses.
+# A BOOLEAN flag listed here eats the following token instead: `--editor`
+# (`-e`, a boolean) was listed and would swallow whatever came next.
 GH_ISSUE_VALUE_FLAGS = GH_ISSUE_BODY_FLAGS + GH_ISSUE_BODY_FILE_FLAGS + (
     "-a", "--assignee", "-l", "--label", "-m", "--milestone", "-p", "--project",
-    "-T", "--template", "-t", "--title", "-R", "--repo", "--editor",
-    "--hostname",
+    "-T", "--template", "-t", "--title", "-R", "--repo", "--hostname",
+    "--type", "--parent", "--blocked-by", "--blocking", "--recover",
 )
 # gh api's own value-taking flags.
-GH_API_FIELD_FLAGS = ("-f", "--field", "-F", "--raw-field")
+#
+# 🔴 `-F` IS `--field` AND `-f` IS `--raw-field`, NOT THE OTHER WAY ROUND. The
+# pairing was inverted here, which matters because gh documents the `@<path>`
+# read-from-file form as a `--field` (`-F`) feature ONLY. See
+# `_resolve_gh_api_field`.
+GH_API_AT_FILE_FLAGS = ("-F", "--field")
+GH_API_RAW_FIELD_FLAGS = ("-f", "--raw-field")
+GH_API_FIELD_FLAGS = GH_API_AT_FILE_FLAGS + GH_API_RAW_FIELD_FLAGS
 GH_API_VALUE_FLAGS = GH_API_FIELD_FLAGS + (
     "-X", "--method", "-H", "--header", "--input", "--hostname", "-q", "--jq",
     "-t", "--template", "--cache", "-p", "--preview",
@@ -319,7 +389,12 @@ _HEREDOC_OPEN = re.compile(
 INERT_HEREDOC_SINKS = frozenset({"cat", "tee", "echo", "printf"})
 # Anything on the operator's own line AFTER the tag that would send the sink's
 # output somewhere executable. `cat <<EOF | bash` is not inert.
-_PIPES_ONWARD = re.compile(r"[|&;]")
+#
+# 🔴 A PROCESS SUBSTITUTION IS AN EXECUTION TOO. `cat <<'EOF' > >(bash)` really
+# runs the body; with only `[|&;]` here it scored INERT and the body was blanked
+# out of the invocation scan — a one-redirect bypass. `>(` and `<(` are both
+# spelled out because the class is "the sink's bytes reach a shell", not "a pipe".
+_PIPES_ONWARD = re.compile(r"[|&;]|[<>]\(")
 # Separators that end the command the heredoc operator attaches to.
 _SEG_SPLIT = re.compile(r"\n|;|&&|\|\||\||&|\(|\)|`|\$\(")
 _ASSIGN_TOKEN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
@@ -338,8 +413,17 @@ def _attached_command(text, operator_start):
     return ""
 
 
+# `body`   the text between the operator's line and the terminator
+# `start`  where the body begins; `body_end` where the TERMINATOR LINE begins
+# `after`  past the terminator line — what a scan must skip to leave the body
+# `op`     the offset of the `<<` itself, which is what attributes a heredoc to
+#          the COMMAND that opened it (see `command_spans`)
+_Heredoc = collections.namedtuple(
+    "_Heredoc", "body start body_end inert op after head rest")
+
+
 def heredocs(text):
-    """Every heredoc in `text` as `(body, start, end, inert)`, in operator order.
+    """Every heredoc in `text` as a `_Heredoc`, in operator order.
 
     🔴 DELIBERATELY QUOTE-BLIND for the BODY, unlike `guard_core._scan`. The
     dominant real shape is
@@ -410,17 +494,59 @@ def heredocs(text):
             i = nxt
         consumed.append((start, i))
         cursor = i
+        head = _SEG_SPLIT.split(text[:m.start()])[-1]
         inert = (
             _attached_command(text, m.start()) in INERT_HEREDOC_SINKS
             and not _PIPES_ONWARD.search(rest_of_line)
         )
-        out.append(("\n".join(lines), start, body_end, inert))
+        out.append(_Heredoc("\n".join(lines), start, body_end, inert,
+                            m.start(), i, head, rest_of_line))
     return out
 
 
 def heredoc_bodies(text):
     """Every heredoc body, inert or not — the body-resolution view."""
-    return [h[0] for h in heredocs(text)]
+    return [h.body for h in heredocs(text)]
+
+
+# A redirection or a `tee` argument naming the file a heredoc is about to write.
+_REDIR = re.compile(r"^\d*>>?$")
+
+
+def heredoc_bodies_writing(text, path):
+    """Bodies of the heredocs on this line whose own command WRITES `path`.
+
+    🔴 THE ATTRIBUTION THAT REPLACED "any heredoc anywhere on the line". An
+    unreadable `--body-file p.md` is legitimately rescued by
+    `cat > p.md <<'EOF' … EOF` earlier on the line — the file does not exist yet
+    when a PreToolUse hook runs, and denying that shape denies a correctly
+    specified create. Matching on the PATH rather than on adjacency is what keeps
+    an UNRELATED heredoc from doing the same job.
+    """
+    want = os.path.abspath(os.path.expanduser(path))
+    out = []
+    for h in heredocs(text):
+        toks = (h.head + " " + h.rest).split()
+        is_tee = bool(toks) and os.path.basename(toks[0].strip("\"'")) == "tee"
+        targets, redir = [], False
+        for tok in toks[1:] if is_tee else toks:
+            bare = tok.strip("\"'")
+            if _REDIR.match(bare):
+                redir = True
+                continue
+            if bare.startswith(">"):
+                targets.append(bare.lstrip(">"))
+                continue
+            if redir:
+                targets.append(bare)
+                redir = False
+                continue
+            if is_tee and not bare.startswith("-"):
+                targets.append(bare)
+        if any(t and os.path.abspath(os.path.expanduser(t.strip("\"'"))) == want
+               for t in targets):
+            out.append(h.body)
+    return out
 
 
 def scrub_inert_heredocs(text):
@@ -442,7 +568,7 @@ def scrub_inert_heredocs(text):
     Body CONTENT is unaffected: `heredoc_bodies` reads the ORIGINAL text, so a
     `--body "$(cat <<'EOF' … EOF)"` is still resolved from its heredoc.
     """
-    spans = [(lo, hi) for _, lo, hi, inert in heredocs(text) if inert]
+    spans = [(h.start, h.body_end) for h in heredocs(text) if h.inert]
     if not spans:
         return text
     out, prev = [], 0
@@ -452,6 +578,169 @@ def scrub_inert_heredocs(text):
         prev = hi
     out.append(text[prev:])
     return "".join(out)
+
+
+# --------------------------------------------------------------------------- #
+# A quote-aware walk of the command line
+#
+# 🔴 THE ONE THING A REGEX OVER RAW TEXT CANNOT DO IS TELL A COMMAND FROM PROSE,
+# and both of the defects this exists to fix were exactly that mistake:
+#
+#   * the override was matched by a regex whose "command boundary" class held
+#     `\n`, `;` and a backtick — all of which appear inside an ordinary issue
+#     body, so quoting the override string in a body disarmed the gate;
+#   * every body-resolution fallback read `heredoc_bodies(<the whole line>)`, so
+#     a heredoc belonging to some OTHER command answered for a create.
+#
+# One walk answers both. It tracks single quotes, double quotes, backslash
+# escapes, `$( … )` and backtick substitution depth, and it steps OVER heredoc
+# bodies (whose bytes are data, not command text, and whose stray quotes would
+# otherwise corrupt the state for everything after them).
+# --------------------------------------------------------------------------- #
+# Words that leave the NEXT word still in command position.
+_CMD_KEEPERS = frozenset({"!", "then", "else", "elif", "do", "time", "command",
+                          "{", "}", "nohup"})
+# Words after which further `NAME=value` words are still assignments.
+_ASSIGN_INTRODUCERS = frozenset({"export", "env", "declare", "local",
+                                 "readonly", "typeset"})
+_ASSIGN_WORD = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+_SEPARATOR_CHARS = ";&|\n"
+# A word ends at whitespace, at a separator, at a redirection, or at the start of
+# a substitution. Quotes are consumed as part of the word so `'a b'` stays one.
+_WORD_BREAK = " \t\r\n;&|()<>`"
+
+
+def _read_word(text, i, n):
+    """`(word, next index)` for the shell word starting at `i`."""
+    out, quote = [], None
+    while i < n:
+        c = text[i]
+        if quote:
+            if c == "\\" and quote == '"' and i + 1 < n:
+                out.append(text[i + 1])
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+                i += 1
+                continue
+            out.append(c)
+            i += 1
+            continue
+        if c in ("'", '"'):
+            quote = c
+            i += 1
+            continue
+        if c == "\\" and i + 1 < n:
+            out.append(text[i + 1])
+            i += 2
+            continue
+        if c in _WORD_BREAK or (c == "$" and text[i + 1:i + 2] == "("):
+            break
+        out.append(c)
+        i += 1
+    return "".join(out), i
+
+
+def _shell_walk(text):
+    """`(spans, override)` — top-level command spans, and the override verdict.
+
+    `spans` are `[lo, hi)` slices of `text`, one per TOP-LEVEL command segment,
+    split on unquoted `;`/`&`/`|`/newline and on a subshell paren. A heredoc's
+    body is kept INSIDE the span of the command that opened it, because that is
+    exactly the relationship body resolution needs.
+
+    `override` is True only for a bare `GH_ISSUE_NO_CLOSING_CONDITION=1` word in
+    COMMAND POSITION at substitution depth 0 — the assignment bash would actually
+    put in `gh`'s environment. Inside `$( … )` or a backtick it is a different
+    process's environment and does not count; inside a quote it is prose.
+    """
+    n = len(text)
+    skip = {}
+    for h in heredocs(text):
+        skip[h.start] = h.after
+    spans, seg_lo = [], 0
+    stack = []            # (saved quote, closing char) per open substitution
+    quote, at_cmd, override, i = None, True, False, 0
+    while i < n:
+        if i in skip:
+            i = skip[i]
+            continue
+        c = text[i]
+        if quote == "'":
+            if c == "'":
+                quote = None
+            i += 1
+            continue
+        if quote == '"':
+            if c == "\\" and i + 1 < n:
+                i += 2
+                continue
+            if c == "$" and text[i + 1:i + 2] == "(":
+                stack.append((quote, ")"))
+                quote, at_cmd, i = None, True, i + 2
+                continue
+            if c == "`":
+                stack.append((quote, "`"))
+                quote, at_cmd, i = None, True, i + 1
+                continue
+            if c == '"':
+                quote = None
+            i += 1
+            continue
+        if c == "\\" and i + 1 < n:
+            at_cmd = False
+            i += 2
+            continue
+        if c == "$" and text[i + 1:i + 2] == "(":
+            stack.append((quote, ")"))
+            at_cmd, i = True, i + 2
+            continue
+        if stack and ((c == ")" and stack[-1][1] == ")")
+                      or (c == "`" and stack[-1][1] == "`")):
+            quote = stack.pop()[0]
+            at_cmd, i = False, i + 1
+            continue
+        if c == "`":
+            stack.append((quote, "`"))
+            at_cmd, i = True, i + 1
+            continue
+        if c in ("'", '"'):
+            quote, at_cmd, i = c, False, i + 1
+            continue
+        if c in _SEPARATOR_CHARS or (not stack and c in "()"):
+            if not stack:
+                # 🔴 A newline that OPENS a heredoc body ends the command, but
+                # the body belongs to it: the span runs past the terminator so
+                # `heredoc_bodies(span)` still finds it.
+                end = skip.get(i + 1) if c == "\n" else None
+                if end is not None:
+                    spans.append((seg_lo, i))
+                    seg_lo, i, at_cmd = end, end, True
+                    continue
+                spans.append((seg_lo, i))
+                seg_lo = i + 1
+            at_cmd, i = True, i + 1
+            continue
+        if c.isspace():
+            i += 1
+            continue
+        word, j = _read_word(text, i, n)
+        if at_cmd and not stack:
+            if _ASSIGN_WORD.match(word):
+                override = override or word == OVERRIDE_ASSIGNMENT
+            elif word not in _ASSIGN_INTRODUCERS and word not in _CMD_KEEPERS:
+                at_cmd = False
+        else:
+            at_cmd = False
+        i = max(j, i + 1)
+    spans.append((seg_lo, n))
+    return [(lo, hi) for lo, hi in spans if text[lo:hi].strip()], override
+
+
+def command_spans(text):
+    """The `[lo, hi)` slice of every top-level command segment in `text`."""
+    return _shell_walk(text)[0]
 
 
 # --------------------------------------------------------------------------- #
@@ -633,27 +922,41 @@ def is_gh_api_issue_create(argv):
 
 
 def _curl_parts(argv):
-    """(method, [url paths], [data values]) for a curl argv."""
+    """(method, [url paths], [data values]) for a curl argv.
+
+    🔴 EVERY FLAG READ THROUGH `_match_flag`, NOT BY EXACT-TOKEN EQUALITY. This
+    used to test `tok in CURL_DATA_FLAGS`, so `--request=POST`, `--data=…`,
+    `--data-raw=…`, `--json=…` and `--url=…` matched NOTHING: the call was not
+    even classified as a create, and the gate never ran on it. The order below is
+    load-bearing — the specific tables are consulted before the catch-all
+    `CURL_VALUE_FLAGS`, which is a superset of both.
+    """
     method, paths, data = None, [], []
     i = 1
     while i < len(argv):
         tok = argv[i]
-        if tok in CURL_METHOD_FLAGS and i + 1 < len(argv):
-            method = argv[i + 1].upper()
-            i += 2
+        hit = _match_flag(argv, i, CURL_METHOD_FLAGS)
+        if hit is not None:
+            if hit[1] is not None:
+                method = hit[1].upper()
+            i = hit[2]
             continue
-        if tok in CURL_DATA_FLAGS and i + 1 < len(argv):
-            data.append(argv[i + 1])
-            i += 2
+        hit = _match_flag(argv, i, CURL_DATA_FLAGS)
+        if hit is not None:
+            if hit[1] is not None:
+                data.append(hit[1])
+            i = hit[2]
             continue
-        if tok == "--url" and i + 1 < len(argv):
-            p = _url_path(argv[i + 1])
+        hit = _match_flag(argv, i, ("--url",))
+        if hit is not None:
+            p = _url_path(hit[1]) if hit[1] else None
             if p:
                 paths.append(p)
-            i += 2
+            i = hit[2]
             continue
-        if tok in CURL_VALUE_FLAGS:
-            i += 2
+        hit = _match_flag(argv, i, CURL_VALUE_FLAGS)
+        if hit is not None:
+            i = hit[2]
             continue
         if not tok.startswith("-") or tok == "-":
             p = _url_path(tok)
@@ -681,7 +984,7 @@ def is_curl_issue_create(argv):
     return bool(data)
 
 
-def is_exempt_invocation(argv):
+def is_exempt_invocation(argv, route="gh-issue"):
     """True for a create-shaped argv that STRUCTURALLY cannot post an issue.
 
     🔴 Structural exemptions, not convenience ones, and both are recorded in the
@@ -697,12 +1000,23 @@ def is_exempt_invocation(argv):
     curl flag at all; curl posts the request regardless. Letting this predicate
     answer for a curl create would hand every curl caller a one-word bypass —
     the exact hole the clawgate gate's first `is_help_invocation` had.
+
+    🔴 AND SCOPED BY ROUTE, because `gh issue create` and `gh api` do not share a
+    flag table. Judging a `gh api` argv against the ISSUE table left gh api's own
+    value flags (`-q`, `--jq`, `-H`, `--cache`, `--input`) unskipped, so a VALUE
+    that happened to be `-h` or `-w` — a jq expression, a header — exempted the
+    create. `route` is already known at the only call site.
     """
     if not _is_gh(argv):
         return False
-    if _has_flag(argv, HELP_FLAGS + WEB_FLAGS, GH_ISSUE_VALUE_FLAGS):
+    api = route == "gh-api"
+    value_flags = GH_API_VALUE_FLAGS if api else GH_ISSUE_VALUE_FLAGS
+    # `--web` is a `gh issue create` flag; `gh api` has no such thing, and `-w`
+    # there is not a flag at all.
+    exempting = HELP_FLAGS if api else HELP_FLAGS + WEB_FLAGS
+    if _has_flag(argv, exempting, value_flags):
         return True
-    return _operands(argv, GH_ISSUE_VALUE_FLAGS)[:1] == ["help"]
+    return _operands(argv, value_flags)[:1] == ["help"]
 
 
 # --------------------------------------------------------------------------- #
@@ -715,20 +1029,49 @@ UNRESOLVED_NONE = "the command names no body this gate can read"
 UNRESOLVED_JSON = "the request payload is not JSON this gate can parse"
 
 
+def _match_flag(argv, i, names):
+    """`(name, value, next index)` when `argv[i]` carries one of `names`' values.
+
+    🔴 ALL THREE SPELLINGS THE REAL TOOLS ACCEPT, because a flag table that knows
+    only one of them is a table with holes in the other two. `--flag value` is
+    obvious; `--flag=value` was already handled here and NOT in `_curl_parts`, so
+    `--request=POST --data=…` was not classified as a create at all; and an
+    ATTACHED short flag (`-b<body>`, `-F<path>`, `-XPOST`, `-d<payload>` — every
+    one of them valid) was handled nowhere, so a CORRECTLY specified
+    `gh issue create -b'## Closing condition …'` denied with "CANNOT SEE THE
+    BODY", the most confusing message this gate can print.
+
+    🔴 NO `--` EXCLUSION IS NEEDED HERE, AND ONE WAS DELETED FOR SAYING
+    OTHERWISE. The first draft carried `and not tok.startswith("--")` with a
+    comment claiming it stopped `--data-raw` being read as `-d` + a value. It
+    cannot: `name[1] != "-"` already means a token beginning `--` can never
+    satisfy `tok.startswith(name)`. A mutation sweep found the clause SURVIVED
+    every test because it is provably unreachable — a guard that reads as
+    coverage while providing none, which is worse than no guard.
+    """
+    tok = argv[i]
+    if tok in names:
+        return (tok, argv[i + 1], i + 2) if i + 1 < len(argv) else (tok, None, i + 1)
+    for name in names:
+        if tok.startswith(name + "="):
+            return name, tok[len(name) + 1:], i + 1
+        if (len(name) == 2 and name[0] == "-" and name[1] != "-"
+                and len(tok) > 2 and tok.startswith(name)):
+            return name, tok[len(name):], i + 1
+    return None
+
+
 def _flag_values(argv, names):
-    """Values of `--flag value` and `--flag=value`, in argv order."""
+    """Values of every spelling of `names` in `argv`, in argv order."""
     out, i = [], 1
     while i < len(argv):
-        tok = argv[i]
-        if tok in names and i + 1 < len(argv):
-            out.append(argv[i + 1])
-            i += 2
+        hit = _match_flag(argv, i, names)
+        if hit is None:
+            i += 1
             continue
-        for name in names:
-            if tok.startswith(name + "="):
-                out.append(tok[len(name) + 1:])
-                break
-        i += 1
+        _, value, i = hit
+        if value is not None:
+            out.append(value)
     return out
 
 
@@ -742,6 +1085,16 @@ def _read_body_file(path):
 
 def _resolve_inline(value, text):
     """([body, …], reason-or-None) for a literal `--body` argument."""
+    # 🔴 ONE ORDERING RULE, APPLIED ONCE: a heading PRESENT IN THE LITERAL
+    # ARGUMENT always wins. It was stated below for the opacity branch and NOT
+    # for this one, so a correctly specified body that merely QUOTES a heredoc —
+    # `## Closing condition … ```cat <<'EOF' > x``` `, i.e. any issue documenting
+    # a shell snippet — was resolved through the quoted heredoc instead of its
+    # own text and denied. `heredocs` is deliberately quote-blind, so it cannot
+    # tell a documented operator from a real one; the operator's own bytes can.
+    variants = _inline_variants(value)
+    if any(has_closing_condition(v) for v in variants):
+        return variants, None
     inner = heredoc_bodies(value)
     if inner:
         # 🔴 THE ORIGINAL TEXT IS THE AUTHORITATIVE READING WHEN THE ARGUMENT
@@ -763,6 +1116,11 @@ def _resolve_inline(value, text):
         # An earlier version narrowed this to the all-blank case; a mutation
         # sweep showed no test could tell the two apart, i.e. the narrowing was
         # an unreachable guard reading as coverage. Removed rather than kept.
+        #
+        # 🔴 THE "KNOWN LOOSENESS" ABOVE IS NOW CLOSED, and this comment is kept
+        # only so nobody re-derives it: `text` here is the create's OWN command
+        # segment, not the whole line, so a well-specified heredoc belonging to a
+        # different command is not in it.
         return (heredoc_bodies(text) or inner), None
     # 🔴 AN EMPTY VALUE IS AN ARTIFACT OF THE PARSE, NOT A BODY. `guard_core`'s
     # scanner LIFTS `$( … )` out of the segment it appears in, so
@@ -775,29 +1133,37 @@ def _resolve_inline(value, text):
     # command still denies — as "cannot see the body", which is the true fact.
     if not value.strip():
         return [], None
-    # 🔴 Ordered so that a heading PRESENT IN THE LITERAL ARGUMENT always wins.
-    # `--body "## Closing condition\n… $(date)"` is readable enough: whatever the
-    # substitution expands to, the heading is in the bytes the operator typed.
-    # Consulting opacity first would report "cannot see the body" about a body
-    # that is right there.
-    variants = _inline_variants(value)
-    if any(has_closing_condition(v) for v in variants):
-        return variants, None
+    # The literal-heading test that would sit here has been hoisted to the TOP of
+    # this function — see the note there. `--body "## Closing condition\n…
+    # $(date)"` is readable enough: whatever the substitution expands to, the
+    # heading is in the bytes the operator typed, so consulting opacity first
+    # would report "cannot see the body" about a body that is right there.
     if opaque_value(value):
         # Last chance: the operator may have opened the heredoc outside the
         # quoted argument (`--body "$(cat <<EOF)"` splits across both shapes).
-        outer = heredoc_bodies(text)
-        if outer:
-            return outer, None
+        #
+        # 🔴 GATED ON THE ARGUMENT ITSELF NAMING A HEREDOC. Without the `<<`
+        # test this branch rescued `--body "$(gen.sh)"` — the exact shape the
+        # docstring promises to BLOCK — from any heredoc that happened to be in
+        # scope. A substitution that opens no heredoc has nothing here to read.
+        if "<<" in value:
+            outer = heredoc_bodies(text)
+            if outer:
+                return outer, None
         return [], UNRESOLVED_OPAQUE
     return variants, None
 
 
-def _resolve_file(value, text):
-    """([body, …], reason-or-None) for a `--body-file` argument."""
+def _resolve_file(value, text, full=None):
+    """([body, …], reason-or-None) for a `--body-file` argument.
+
+    `text` is the create's OWN command segment; `full` is the whole command line,
+    used ONLY for the path-matched write-rescue below.
+    """
+    full = text if full is None else full
     if value in STDIN_NAMES:
-        # A body-file of `-` fed by a heredoc IS readable; fed by a pipe it is
-        # not.
+        # A body-file of `-` fed by a heredoc on THIS command IS readable; fed by
+        # a pipe, or by some other command's heredoc, it is not.
         inner = heredoc_bodies(text)
         return (inner, None) if inner else ([], UNRESOLVED_STDIN)
     if opaque_path(value):
@@ -806,8 +1172,10 @@ def _resolve_file(value, text):
         return [_read_body_file(value)], None
     except Exception:
         # The file may be about to be written by a heredoc earlier on the same
-        # command line, which this gate CAN read.
-        inner = heredoc_bodies(text)
+        # command line, which this gate CAN read — but ONLY a heredoc that writes
+        # THIS path. Accepting any heredoc anywhere let an unrelated
+        # `cat > /tmp/plan.md <<'EOF'` answer for an unreadable `--body-file`.
+        inner = heredoc_bodies_writing(full, value)
         return (inner, None) if inner else ([], UNRESOLVED_UNREADABLE)
 
 
@@ -829,7 +1197,7 @@ def _resolve_json_payload(payloads):
     return [], (UNRESOLVED_JSON if failed else UNRESOLVED_NONE)
 
 
-def _resolve_curl_data(value, text):
+def _resolve_curl_data(value, text, full=None):
     """([body, …], reason-or-None) for one curl data argument."""
     if value.startswith("@"):
         # 🔴 `-d @file` / `-d @-` still has to be JSON-PARSED afterwards.
@@ -837,7 +1205,7 @@ def _resolve_curl_data(value, text):
         # payload `{"body":"## Closing condition\n…"}` carries the heading only
         # as an ESCAPED \n, so the line-based detector never sees a heading and a
         # correctly-specified create is denied.
-        payloads, why = _resolve_file(value[1:], text)
+        payloads, why = _resolve_file(value[1:], text, full)
         if why:
             return [], why
     else:
@@ -850,30 +1218,44 @@ def _resolve_curl_data(value, text):
     return _resolve_json_payload(payloads)
 
 
-def _resolve_gh_api_field(value, text):
-    """([body, …], reason-or-None) for one `gh api -f/-F` field argument.
+def _resolve_gh_api_field(value, text, at_file, full=None):
+    """([body, …], reason-or-None) for one `gh api -F/-f` field argument.
 
     Only a field literally named `body` is a body; `title=…` and `labels[]=…` are
     not, and returning them would let a title carry the heading.
+
+    🔴 `@` IS A `-F`/`--field` FEATURE ONLY — `at_file` carries that, and it is
+    two bugs in one place. Applying `@`-file semantics to `-f`/`--raw-field` (a)
+    read a file gh would have sent verbatim, and (b) denied a legitimate body
+    that merely STARTS with an @mention — an ordinary way to open an issue — as
+    an unreadable path.
     """
     if "=" not in value:
         return [], None
     key, val = value.split("=", 1)
     if key.strip() != "body":
         return [], None
-    if val.startswith("@"):
-        return _resolve_file(val[1:], text)
+    if at_file and val.startswith("@"):
+        return _resolve_file(val[1:], text, full)
     return _resolve_inline(val, text)
 
 
-def body_candidates(argv, text, route):
+def body_candidates(argv, text, route, full=None):
     """([every body text this gate could read], reason the rest were unreadable).
 
     The reason is None when everything named was resolved. Aggregating rather
     than picking ONE source is deliberate: a command may legitimately name a
     body-file that a heredoc on the same line is about to write, and a candidate
     is only ever used to let the command THROUGH.
+
+    🔴 `text` IS THIS CREATE'S OWN COMMAND SEGMENT, NOT THE COMMAND LINE. That is
+    the whole of the B2/B3 fix and it is a change of MEANING, not of degree —
+    aggregation across sources on ONE command is deliberate, aggregation across
+    COMMANDS was a bug. `full` is threaded through for the single place that
+    still legitimately looks line-wide: a heredoc writing an as-yet-unwritten
+    `--body-file` path.
     """
+    full = text if full is None else full
     cands, reason = [], None
 
     def take(pair):
@@ -886,26 +1268,31 @@ def body_candidates(argv, text, route):
     if route == "curl":
         _, _, data = _curl_parts(argv)
         for value in data:
-            take(_resolve_curl_data(value, text))
+            take(_resolve_curl_data(value, text, full))
     elif route == "gh-api":
-        for value in _flag_values(argv, GH_API_FIELD_FLAGS):
-            take(_resolve_gh_api_field(value, text))
+        for value in _flag_values(argv, GH_API_AT_FILE_FLAGS):
+            take(_resolve_gh_api_field(value, text, True, full))
+        for value in _flag_values(argv, GH_API_RAW_FIELD_FLAGS):
+            take(_resolve_gh_api_field(value, text, False))
         for value in _flag_values(argv, ("--input",)):
             if value in STDIN_NAMES:
                 inner = heredoc_bodies(text)
                 take(_resolve_json_payload(inner) if inner else ([], UNRESOLVED_STDIN))
                 continue
-            payloads, why = _resolve_file(value, text)
+            payloads, why = _resolve_file(value, text, full)
             take(([], why) if why else _resolve_json_payload(payloads))
     else:
         for value in _flag_values(argv, GH_ISSUE_BODY_FLAGS):
             take(_resolve_inline(value, text))
         for value in _flag_values(argv, GH_ISSUE_BODY_FILE_FLAGS):
-            take(_resolve_file(value, text))
+            take(_resolve_file(value, text, full))
 
     if not cands and reason is None:
-        # No body argument at all. The heredoc on the line, if any, is still the
-        # operator's body — and if there is none, the gate has seen nothing.
+        # No body argument this gate could read. A heredoc on THIS COMMAND is
+        # still the operator's body — that is how the shape the deny message
+        # itself recommends, `--body "$(cat <<'EOF' … EOF)"`, resolves, since the
+        # shared core lifts the substitution and the argument arrives empty. If
+        # this command opened no heredoc, the gate has seen nothing.
         outer = heredoc_bodies(text)
         if outer:
             cands = outer
@@ -1004,13 +1391,21 @@ def crash_text(exc):
 def override_requested(text, env):
     """True when the operator explicitly disarmed the gate.
 
-    Two channels, one spelling. The inline assignment is anchored on a command
-    boundary; the process environment is read exactly, so `=true` / `=0` / an
-    empty value are NOT overrides.
+    Two channels, one spelling. The inline assignment is found by a quote-aware
+    walk (see `_shell_walk`), never by a regex over raw text; the process
+    environment is read exactly, so `=true` / `=0` / an empty value are NOT
+    overrides.
+
+    🔴 A FAILURE HERE FAILS CLOSED. This is also called from the crash path, and
+    an exception escaping it would leave the hook exiting non-zero — a silent
+    ALLOW for PreToolUse. "Could not tell" means "not overridden".
     """
     if env.get(OVERRIDE_ENV) == OVERRIDE_VALUE:
         return True
-    return bool(OVERRIDE_INLINE.search(text))
+    try:
+        return _shell_walk(text)[1]
+    except BaseException:  # noqa: BLE001 - see above
+        return False
 
 
 def _route(argv):
@@ -1025,18 +1420,37 @@ def _route(argv):
 
 
 def creating_invocations(text, guard_core):
-    """[(argv, route), …] for every REAL issue create on this command line.
+    """[(argv, route, scope), …] for every REAL issue create on this line.
 
-    🔴 The scan runs over `scrub_inert_heredocs(text)`, not `text`. That is the
+    🔴 The scan runs over `scrub_inert_heredocs(…)`, not the raw text. That is the
     mention-vs-invocation requirement: a `cat > notes.md <<'EOF'` body that spells
     out the command is documentation, and denying it would make this gate the
     thing people route around. Body resolution still reads the ORIGINAL text.
+
+    🔴 `scope` IS THE THIRD ELEMENT AND THE POINT OF THIS FUNCTION NOW. Each
+    create is enumerated inside its OWN top-level command segment and carries
+    that segment's text, so `body_candidates` cannot reach a heredoc a different
+    command opened. Two creates on one line therefore get two different scopes,
+    which is what stops the first one's good body answering for the second.
+
+    A create the segmentation does not attribute — malformed quoting, a shape the
+    walk and the shared core read differently — is still enumerated by a
+    whole-text pass and keeps the OLD line-wide scope. That is deliberate: the
+    backstop must not be able to turn a create that used to ALLOW into a deny,
+    only to keep one from disappearing.
     """
-    out = []
+    out, seen = [], []
+    for lo, hi in command_spans(text):
+        scope = text[lo:hi]
+        for argv in guard_core.commands(scrub_inert_heredocs(scope)):
+            route = _route(argv)
+            if route and not is_exempt_invocation(argv, route):
+                out.append((argv, route, scope))
+                seen.append(argv)
     for argv in guard_core.commands(scrub_inert_heredocs(text)):
         route = _route(argv)
-        if route and not is_exempt_invocation(argv):
-            out.append((argv, route))
+        if route and not is_exempt_invocation(argv, route) and argv not in seen:
+            out.append((argv, route, text))
     return out
 
 
@@ -1054,8 +1468,8 @@ def evaluate(text, env, guard_core):
     # good one — so the verdict is "every create had a closing condition", never
     # "some body somewhere did".
     worst = None
-    for argv, route in creates:
-        cands, reason = body_candidates(argv, text, route)
+    for argv, route, scope in creates:
+        cands, reason = body_candidates(argv, scope, route, text)
         if any(has_closing_condition(c) for c in cands):
             continue
         if cands:

--- a/scripts/claude-hooks/register-nudge-hook.py
+++ b/scripts/claude-hooks/register-nudge-hook.py
@@ -218,6 +218,7 @@ MANAGED_HOOK_SCRIPTS = frozenset({
     "claude-notify.py",
     "clawgate-task-interview-guard.py",
     "clawgate-writeback-guard.py",
+    "gh-issue-closing-condition-guard.py",
     "next-step-nudge.py",
     "search-tool-nudge.py",
     "shell-env-nudge.py",
@@ -616,6 +617,15 @@ PRE_BASH_CMDS = [
     # Registering it does not widen what PreToolUse can REFUSE — only what it
     # observes.
     with_python("~/.claude/hooks/bg-command-capture.py"),
+    # 🔴 THE THIRD PreToolUse entry, and — unlike the one above — the SECOND that
+    # can REFUSE. It denies a `gh issue create` whose body names no closing
+    # condition, the RULES.md rule whose failure mode was measured to be SALIENCE
+    # rather than delivery (6 issues / 0 conditions unbriefed vs 10 / 10 briefed,
+    # with BOTH agents holding the rule). Registered here rather than left to a
+    # hand edit for the #452 reason its neighbours record: a hook that ships
+    # unregistered reports a successful switch and sits INERT with nothing on
+    # screen to say so.
+    with_python("~/.claude/hooks/gh-issue-closing-condition-guard.py"),
 ]
 
 # Hooks registered on exactly one event each: {event: [command, ...]}.

--- a/scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py
+++ b/scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py
@@ -1270,8 +1270,15 @@ def test_the_override_inside_a_heredoc_body_does_not_disarm_the_gate():
 
 def test_the_override_inside_a_substitution_does_not_disarm_the_gate():
     """🔴 An assignment inside `$( … )` sets a SUBSHELL's environment, so it can
-    never reach the `gh` process this gate is judging. Crediting it would be the
-    backtick hole under a second spelling."""
+    never reach a `gh` process OUTSIDE that subshell. Crediting it would be the
+    backtick hole under a second spelling.
+
+    🔴 READ THE SCOPE, NOT THE SPELLING — the create here is a DIFFERENT command
+    from the substitution, which is what makes the assignment unable to reach it.
+    An assignment in command position inside the substitution that CONTAINS the
+    create is the documented override for that call and does disarm it; see
+    test_the_override_reaches_a_create_inside_a_substitution. The two are not in
+    tension and the difference is which shell runs the `gh`."""
     cmd = ("echo \"$(" + OVERRIDE_ON + " true)\" && " +
            CREATE + " -t t --body " + q(NO_CC))
     assert MISSING_MARK in (ev(cmd) or "")
@@ -1647,3 +1654,452 @@ def test_a_body_quoting_a_heredoc_operator_is_a_KNOWN_FALSE_POSITIVE():
     it an ALLOW assertion and move the case into REALISTIC_ALLOWS."""
     body = CC + "\n```\ncat <<'EOF' > x\nEOF\n```"
     assert MISSING_MARK in (ev(CREATE + " -t t --body " + q(body)) or "")
+
+
+# =========================================================================== #
+# 14. 🔴 BYPASS A — A CREATE INSIDE A COMMAND SUBSTITUTION.
+#
+# `URL="$(gh issue create …)"` — capturing the new issue's URL, the single most
+# natural line an agent writes here — ALLOWED until 2026-08-25, while the SAME
+# line without the two quote characters denied. The whole difference was two
+# bytes: `guard_core._scan_raw` buffers a double-quoted region verbatim, so
+# `"$( … )"` survived as one argv TOKEN and the create inside was never
+# enumerated. A substitution RUNS; the quotes decide only how its OUTPUT is
+# word-split.
+#
+# Every case here is driven as a shape a person would really type, and the ALLOW
+# twin of each is asserted beside it — a fix that denies the quoted form by
+# denying every quoted form would pass a DENY-only table.
+# =========================================================================== #
+SUBSTITUTION_HIDDEN_CREATES = [
+    'URL="$(' + CREATE + " -t t -b " + q(NO_CC) + ')"',
+    'export URL="$(' + CREATE + " -t t -b " + q(NO_CC) + ')"',
+    'echo "created: $(' + CREATE + " -t t -b " + q(NO_CC) + ')"',
+    'printf "%s" "$(' + CREATE + " -t t -b " + q(NO_CC) + ')"',
+    'if [ -n "$(' + CREATE + " -t t -b " + q(NO_CC) + ')" ]; then echo y; fi',
+    'jq --arg u "$(' + CREATE + " -t t -b " + q(NO_CC) + ')" .',
+    'URL="`' + CREATE + " -t t -b " + q(NO_CC) + '`"',
+    'echo "$(' + CREATE + " -t t -b " + q(NO_CC) + ')" | tee /dev/null',
+    CREATE + " -t a --body " + q(CC) + ' && URL="$(' + CREATE + " -t b -b " + q(NO_CC) + ')"',
+    # 🔴 A NESTED `( … )` AHEAD OF THE CREATE. The substitution's own extent has
+    # to be found by COUNTING parens: stop at the first `)` and the slice ends
+    # before `gh` is ever reached, so the create disappears and the line allows.
+    # The nesting is deliberately BEFORE the create, and the outer `$(` is inside
+    # a word, which is the only path that reaches `_substitution_end`.
+    'URL="$(cd $(dirname /tmp/x) && ' + CREATE + " -t t -b " + q(NO_CC) + ')"',
+]
+
+SUBSTITUTION_SPECIFIED_CREATES = [
+    'URL="$(' + CREATE + " -t t --body " + q(CC) + ')"',
+    'export URL="$(' + CREATE + " -t t --body " + q(AC) + ')"',
+    'echo "created: $(' + CREATE + " -t t --body " + q(CC) + ')"',
+    'if [ -n "$(' + CREATE + " -t t --body " + q(AC) + ')" ]; then echo y; fi',
+    'URL="`' + CREATE + " -t t --body " + q(CC) + '`"',
+    CREATE + " -t a --body " + q(CC) + ' && URL="$(' + CREATE + " -t b -b " + q(AC) + ')"',
+]
+
+
+@pytest.mark.parametrize("cmd", SUBSTITUTION_HIDDEN_CREATES)
+def test_a_create_inside_a_quoted_substitution_is_judged(cmd):
+    assert MISSING_MARK in (ev(cmd) or ""), cmd
+
+
+@pytest.mark.parametrize("cmd", SUBSTITUTION_HIDDEN_CREATES[:4])
+def test_a_create_inside_a_quoted_substitution_is_judged_through_the_real_process(cmd):
+    assert MISSING_MARK in deny_reason(cmd)
+
+
+@pytest.mark.parametrize("cmd", SUBSTITUTION_SPECIFIED_CREATES)
+def test_a_specified_create_inside_a_substitution_still_passes(cmd):
+    """The ALLOW twin of every case above. Without this the section could be
+    satisfied by a change that denies any command line containing `$(`."""
+    assert ev(cmd) is None, cmd
+
+
+@pytest.mark.parametrize("cmd", [
+    "echo $(" + CREATE + " -t t -b " + q(NO_CC) + ")",
+    "X=$(" + CREATE + " -t t -b " + q(NO_CC) + ")",
+    "X=`" + CREATE + " -t t -b " + q(NO_CC) + "`",
+    # 🔴 NESTED SUBSTITUTIONS BELONG HERE, NOT IN THE TABLE ABOVE — measured, they
+    # denied at the pre-fix hook too. The inner `"` CLOSES the outer one for
+    # `guard_core`'s scanner, so the inner `$(` is briefly unquoted and gets
+    # lifted by accident. Counting them as regression coverage would have been a
+    # vacuous guard; they are a control instead.
+    'echo "$(printf %s "$(' + CREATE + " -t t -b " + q(NO_CC) + ')")"',
+    'URL="$(echo "$(' + CREATE + " -t t -b " + q(NO_CC) + ')")"',
+])
+def test_an_unquoted_substitution_create_is_judged_INVARIANT(cmd):
+    """🔴 AN INVARIANT GUARD, NOT REGRESSION COVERAGE — green at the pre-fix hook
+    too. `guard_core` already lifts an UNQUOTED `$( … )`, so these always denied;
+    they are here as the CONTROL that names the variable, because the entire
+    difference between this table and the one above is two quote characters."""
+    assert MISSING_MARK in (ev(cmd) or ""), cmd
+
+
+@pytest.mark.parametrize("cmd", [
+    # single quotes: `$(` and a backtick are literal text, not a substitution
+    CREATE + " -t t --body " + q(CC + '\nrepro: URL="$(gh issue create -t x -b y)"'),
+    CREATE + " -t t --body " + q(CC + "\nrun `gh issue create` by hand"),
+    "grep -n '$(gh issue create -t t -b nope)' notes.md",
+    # a substitution that runs something inert
+    'echo "today is $(date)" && ' + CREATE + " -t t --body " + q(CC),
+    'N="$(gh api repos/o/r/issues --jq \'length\')"',
+    # a double-quoted body whose backtick spans are ESCAPED is not a substitution
+    CREATE + ' -t t --body "## Closing condition\nrun \\`gh issue create\\` by hand\n'
+             'Checked by: a reviewer"',
+    # 🔴 THE ATTACHED SPELLINGS, WHICH ARE THE ONLY ONES THAT REACH `_read_word`.
+    # A body written as a SEPARATE argument starts with the quote, so the walk's
+    # own quote branch handles it and `_read_word` never sees it — meaning a
+    # `_read_word` that scanned single quotes as well as double would look
+    # harmless on every case above and false-deny only here. `--body=` and `-b`
+    # attached are both in REALISTIC_ALLOWS, so this is an ordinary spelling.
+    CREATE + " -t t --body=" + q(CC + '\nrepro: URL="$(gh issue create -t x -b y)"'),
+    CREATE + " -t t -b" + q(CC + "\nrun `gh issue create -t x -b y` by hand"),
+])
+def test_reading_substitutions_does_not_fire_on_prose(cmd):
+    """🔴 THE FALSE-POSITIVE HALF, and the reason the fix is in the WALK rather
+    than in a regex for `$(`. A create NAMED inside a single-quoted body is text
+    bash never executes, and must stay allowed."""
+    assert ev(cmd) is None, cmd
+
+
+def test_a_double_quoted_body_with_a_RAW_backtick_span_denies_KNOWN_CONSEQUENCE():
+    """🔴 PINNED AS A COST, NOT HIDDEN — this ALLOWED before 2026-08-25.
+
+    In `"…"` an unescaped backtick span really is command substitution: bash runs
+    what is inside and splices the output into the body, so this line was never
+    going to file the issue the author wrote. Denying it is the correct reading of
+    bash, not a mention being punished — but it IS a behaviour change on a shape
+    that looks like documentation, so it is recorded here. Every correct example
+    in this file single-quotes its body, which is untouched."""
+    cmd = (CREATE + ' -t t --body "## Closing condition\n'
+           'run `gh issue create -b x` by hand\nChecked by: a reviewer"')
+    assert MISSING_MARK in (ev(cmd) or "")
+
+
+@pytest.mark.parametrize("cmd,allowed", [
+    # in command position INSIDE the substitution — the call the gate is judging
+    ('URL="$(' + OVERRIDE_ON + " " + CREATE + " -t t -b " + q(NO_CC) + ')"', True),
+    # on the line, ahead of the assignment
+    (OVERRIDE_ON + ' URL="$(' + CREATE + " -t t -b " + q(NO_CC) + ')"', True),
+    # near-miss spellings are NOT the override
+    ('URL="$(' + OVERRIDE + "=true " + CREATE + " -t t -b " + q(NO_CC) + ')"', False),
+    ('URL="$(' + OVERRIDE + "=0 " + CREATE + " -t t -b " + q(NO_CC) + ')"', False),
+    # the override MENTIONED in the body inside the substitution is prose
+    ('URL="$(' + CREATE + " -t t -b " + q("nope; " + OVERRIDE_ON) + ')"', False),
+    # two hidden creates, only one overridden — the other still has to answer
+    ('A="$(' + OVERRIDE_ON + " " + CREATE + " -t a -b " + q(NO_CC) + ')"; '
+     'B="$(' + CREATE + " -t b -b " + q(NO_CC) + ')"', False),
+])
+def test_the_override_reaches_a_create_inside_a_substitution(cmd, allowed):
+    """🔴 A GATE WITH NO WAY PAST IT GETS SWITCHED OFF. Widening what the gate
+    SEES has to widen where the documented escape hatch WORKS, or the newly
+    covered shapes would be the only ones with no out. The near-misses are here
+    because an override with several spellings is one nobody can grep for."""
+    got = ev(cmd)
+    assert (got is None) is allowed, (cmd, got)
+
+
+@pytest.mark.parametrize("cmd", [
+    # opened inside a WORD — `_read_word`'s scanner runs off the end
+    'URL="$(' + CREATE + " -t t -b " + q(NO_CC),
+    # opened at top level after a quote — the walk's own stack is left open
+    'echo "$(' + CREATE + " -t t -b " + q(NO_CC),
+])
+def test_an_unterminated_substitution_still_shows_the_create(cmd):
+    """🔴 FAIL-CLOSED ON MALFORMED INPUT. bash would reject an unterminated
+    `$(`, so there is no "correct" reading to preserve — but a truncated opener
+    must not be a way to make the create invisible, which is the only direction a
+    guard may err in. Both entry points into the substitution scan have their own
+    unterminated case because they run off the end in different places."""
+    assert MISSING_MARK in (ev(cmd) or ""), cmd
+
+
+def test_the_substitution_tables_are_not_empty():
+    assert len(SUBSTITUTION_HIDDEN_CREATES) >= 10
+    assert len(SUBSTITUTION_SPECIFIED_CREATES) >= 6
+
+
+def test_control_the_specified_fixtures_carry_REAL_newlines():
+    """🔴 A FIXTURE-HYGIENE CONTROL, because the failure it catches reads as a
+    CODE regression. This gate deliberately denies a body whose `\\n` arrived as
+    the two literal characters — bash leaves them literal in `"…"`, GitHub renders
+    the body on one line, and there is no heading on that page. So a fixture
+    written with a literal backslash-n where a real newline was meant turns a
+    CORRECT deny into what looks like a false positive, and the next person
+    "fixes" working code. Assert the bytes rather than trusting the source."""
+    for cmd in SUBSTITUTION_SPECIFIED_CREATES:
+        assert "## Closing condition\n" in cmd or "## Acceptance criteria\n" in cmd, cmd
+        assert "\\n" not in cmd, cmd
+    # and the scratch dir is per-run, not a fixed name in a shared /tmp
+    assert SCRATCH.startswith(tempfile.gettempdir())
+    assert os.path.basename(SCRATCH).startswith("ghccg-test-")
+    assert len(os.path.basename(SCRATCH)) > len("ghccg-test-")
+
+
+# =========================================================================== #
+# 15. 🔴 BYPASS B — ONE EFFECTIVE BODY PER SOURCE.
+#
+# The gate used to aggregate every body-shaped argument and pass if ANY of them
+# carried the heading, so a SECOND body flag was a bypass: ~40 characters of
+# stock text in an argument the tool DISCARDS bought a pass. That is the
+# "spelled, not structural" failure the module docstring refuses to allow for
+# ANSI-C decoding, reached from the other side.
+#
+# 🔴 THE RULE IS PER SOURCE BECAUSE THE THREE TOOLS GENUINELY DISAGREE, and each
+# expectation below is a MEASURED fact about the shipped tool, not a guess:
+#   * gh 2.97.0 `issue create` binds `--body`/`-b` and `--body-file`/`-F` with
+#     pflag `StringVarP` — last occurrence wins (probed with
+#     `gh api --hostname aaa-first.invalid --hostname bbb-last.invalid`, which
+#     connects to bbb-last) — and `create.go` assigns `opts.Body` from the file
+#     AFTER `--body` is bound, so `--body-file` wins whatever the order (probed:
+#     `--body 'aaa' --body-file /nonexistent/zz.md` dies on the file read and
+#     never reaches the API);
+#   * gh 2.97.0 `api` REFUSES a repeated field: `-f body=A -f body=B`,
+#     `-f body=A -F body=B` and `-F body=A -f body=B` all exit with
+#     `unexpected override existing field under "body"`, while the single-field
+#     control `-f body=A` reaches the API;
+#   * curl 8.17.0 MERGES repeated data options — `-d` and its siblings with a
+#     separating `&`, `--json` by plain concatenation — it does not take the last.
+# A rule copied from one tool to the others would be wrong in the direction that
+# false-denies, so each is asserted separately.
+# =========================================================================== #
+REASON_JSON = "the request payload is not JSON this gate can parse"
+REASON_DUP_FIELD = "the body field is given more than once, which gh rejects outright"
+REASON_CURL_MERGE = (
+    "several curl body options are combined in a way this gate cannot reconstruct")
+
+
+@pytest.mark.parametrize("cmd", [
+    CREATE + " -t t --body " + q(CC) + " --body " + q(NO_CC),
+    CREATE + " -t t -b " + q(CC) + " -b " + q(NO_CC),
+    CREATE + " -t t -b " + q(AC) + " --body " + q(NO_CC),
+    CREATE + " -t t --body=" + q(CC) + " -b" + q(NO_CC),
+    CREATE + " -t t --body " + q(CC) + " --body " + q(AC) + " --body " + q(NO_CC),
+])
+def test_only_the_LAST_body_flag_answers_for_a_gh_issue_create(cmd):
+    """pflag last-wins: the earlier value is bound and then overwritten, so it
+    never reaches GitHub and cannot buy a pass."""
+    assert MISSING_MARK in (ev(cmd) or ""), cmd
+
+
+@pytest.mark.parametrize("cmd", [
+    CREATE + " -t t --body " + q(NO_CC) + " --body " + q(CC),
+    CREATE + " -t t -b " + q(NO_CC) + " -b " + q(AC),
+    CREATE + " -t t --body " + q(NO_CC) + " --body=" + q(CC),
+])
+def test_the_LAST_body_flag_being_correct_still_passes(cmd):
+    """The other half of last-wins — the rule is a direction, not a deny."""
+    assert ev(cmd) is None, cmd
+
+
+def test_a_body_file_beats_a_body_flag_whatever_the_order():
+    """`create.go` assigns `opts.Body = string(b)` after `--body` is bound, so the
+    FILE is what GitHub renders even when `--body` was written second."""
+    good = scratch("bfile-good.md")
+    bad = scratch("bfile-bad.md")
+    with open(good, "w") as f:
+        f.write(CC + "\n")
+    with open(bad, "w") as f:
+        f.write(NO_CC + "\n")
+    # the file wins even though --body came first and was correct
+    assert MISSING_MARK in (ev(CREATE + " -t t --body " + q(CC) +
+                               " --body-file " + bad) or "")
+    # …and even though --body came second and was correct
+    assert MISSING_MARK in (ev(CREATE + " -t t --body-file " + bad +
+                               " --body " + q(CC)) or "")
+    # the mirror image: a correct FILE rescues an incorrect --body
+    assert ev(CREATE + " -t t --body " + q(NO_CC) + " --body-file " + good) is None
+    assert ev(CREATE + " -t t --body-file " + good + " --body " + q(NO_CC)) is None
+    # and repeats of --body-file are last-wins like any other pflag StringVar
+    assert MISSING_MARK in (ev(CREATE + " -t t --body-file " + good +
+                               " --body-file " + bad) or "")
+    assert ev(CREATE + " -t t --body-file " + bad + " --body-file " + good) is None
+
+
+def test_a_correct_body_beside_an_UNREADABLE_body_file_cannot_see_the_body():
+    """🔴 A DELIBERATE OVER-BLOCK, ASSERTED SO IT IS NOT A SURPRISE. gh reads the
+    file regardless of `--body` and ERRORS when it cannot, so the call creates
+    nothing either way; reading the `--body` gh discards is the bypass. The
+    verdict must be the CANNOT-SEE one, not "no closing condition" — they are
+    different facts."""
+    missing = scratch("bfile-does-not-exist.md")
+    assert not os.path.exists(missing)
+    reason = ev(CREATE + " -t t --body " + q(CC) + " --body-file " + missing) or ""
+    assert UNSEEABLE_MARK in reason
+    assert REASON_UNREADABLE in reason
+
+
+@pytest.mark.parametrize("cmd", [
+    "gh api repos/o/r/issues -f title=t -f body=" + q(CC) + " -f body=" + q(NO_CC),
+    "gh api repos/o/r/issues -f body=" + q(NO_CC) + " -f body=" + q(CC),
+    "gh api repos/o/r/issues -F body=" + q(CC) + " -f body=" + q(NO_CC),
+    "gh api repos/o/r/issues -f body=" + q(NO_CC) + " -F body=" + q(CC),
+    "gh api -X POST repos/o/r/issues --field body=" + q(CC) +
+    " --raw-field body=" + q(NO_CC),
+])
+def test_a_repeated_gh_api_body_field_is_reported_as_unseeable(cmd):
+    """gh REJECTS it outright, so there is no body to check — and saying "no
+    closing condition" about a call gh will not run would be a wrong fact."""
+    reason = ev(cmd) or ""
+    assert UNSEEABLE_MARK in reason, cmd
+    assert REASON_DUP_FIELD in reason, cmd
+
+
+@pytest.mark.parametrize("cmd", [
+    "gh api repos/o/r/issues -f title=t -f body=" + q(CC),
+    "gh api -X POST repos/o/r/issues -F body=" + q(AC),
+    # two DIFFERENT keys are not a repeat — gh accepts them and so must this
+    "gh api repos/o/r/issues -f title=t -f labels=bug -f body=" + q(CC),
+    "gh api repos/o/r/issues -f title=t -F body=" + q(AC),
+    # `body[]=` is gh's ARRAY syntax, which APPENDS rather than colliding
+    "gh api repos/o/r/issues -f 'body[]=x' -f 'body[]=y' -f body=" + q(CC),
+])
+def test_a_single_gh_api_body_field_is_unaffected(cmd):
+    assert ev(cmd) is None, cmd
+
+
+CURL_URL = "https://api.github.com/repos/o/r/issues"
+
+
+@pytest.mark.parametrize("cmd", [
+    "curl -X POST " + CURL_URL + " -d " + q(json.dumps({"title": "t", "body": CC})) +
+    " -d " + q(json.dumps({"body": NO_CC})),
+    "curl -X POST " + CURL_URL + " -d " + q(json.dumps({"body": NO_CC})) +
+    " -d " + q(json.dumps({"body": CC})),
+    "curl -X POST " + CURL_URL + " --data " + q(json.dumps({"body": CC})) +
+    " --data-raw " + q(json.dumps({"body": NO_CC})),
+])
+def test_repeated_curl_data_is_MERGED_not_taken_one_at_a_time(cmd):
+    """curl(1): "If any of these options is used more than once on the same
+    command line, the data pieces specified are merged with a separating
+    &-symbol." Two JSON objects joined by `&` are not JSON, so the gate cannot
+    read a body — which is the true fact, and GitHub would reject the request
+    for the same reason."""
+    reason = ev(cmd) or ""
+    assert UNSEEABLE_MARK in reason, cmd
+    assert REASON_JSON in reason, cmd
+
+
+# 🔴 SPLIT AT A STRUCTURAL POSITION, NOT AN ARBITRARY OFFSET. The pair below is
+# the control that separates the two curl families, and it only works if the two
+# joins give DIFFERENT answers: `"".join` must produce valid JSON and `"&".join`
+# must not. An earlier version of these fixtures split `json.dumps(...)` at
+# character 12 — INSIDE the title's string literal — so an inserted `&` landed
+# harmlessly in a value and BOTH joins parsed. The mutants that swap one family's
+# separator for the other's survived a fully green suite on exactly that.
+JSON_HEAD = '{"title":"t",'
+JSON_TAIL = '"body":' + json.dumps(CC) + "}"
+
+
+def test_a_split_curl_json_payload_is_CONCATENATED_and_readable():
+    """🔴 THE RULE MUST BE PER FAMILY, AND THIS IS THE CASE THAT PROVES IT. curl
+    documents `--json` as concatenating with NO separator — its own man page
+    example splits one object across two `--json` arguments — so applying the `&`
+    rule here would DENY a correct call. It denied at the pre-fix hook for a
+    different reason (each half parsed alone, neither is JSON); it must allow
+    now."""
+    assert json.loads(JSON_HEAD + JSON_TAIL)["body"] == CC   # the fixture is real
+    assert ev("curl -X POST " + CURL_URL + " --json " + q(JSON_HEAD) +
+              " --json " + q(JSON_TAIL)) is None
+
+
+def test_a_split_curl_DATA_payload_is_AMP_merged_and_therefore_unreadable():
+    """The mirror of the case above, and the other half of the control: the SAME
+    two halves under `-d` are joined with `&`, which is not JSON, so the gate
+    cannot read a body and GitHub would reject the request for the same reason.
+    A rule that gave `-d` the `--json` treatment would ALLOW this."""
+    reason = ev("curl -X POST " + CURL_URL + " -d " + q(JSON_HEAD) +
+                " -d " + q(JSON_TAIL)) or ""
+    assert UNSEEABLE_MARK in reason
+    assert REASON_JSON in reason
+
+
+def test_a_curl_data_argument_carrying_TWO_heredocs_is_unmergeable():
+    """🔴 THE NARROW EDGE OF THE MERGE, ASSERTED BECAUSE IT IS REACHABLE. One
+    `-d` whose substitution opens two heredocs resolves to TWO candidate texts;
+    there is no single string to put in the merge, so the payload is UNRESOLVED
+    rather than silently built from the first. Without that check the gate would
+    merge the FIRST body and quietly ignore the second — reading a payload curl
+    never sends."""
+    cmd = ("curl -X POST " + CURL_URL + " -d \"$(cat <<'A'\n" +
+           json.dumps({"body": CC}) + "\nA\ncat <<'B'\n" +
+           json.dumps({"body": NO_CC}) + "\nB\n)\" -d " + q('{"title":"t"}'))
+    reason = ev(cmd) or ""
+    assert UNSEEABLE_MARK in reason
+    assert REASON_CURL_MERGE in reason
+
+
+@pytest.mark.parametrize("cmd", [
+    # `-d` (&-merged) beside `--json` (concatenated): no single join models it
+    "curl -X POST " + CURL_URL + " -d " + q('{"a":1}') + " --json " +
+    q(json.dumps({"body": CC})),
+    # multipart parts are not a mergeable text payload at all
+    "curl -X POST " + CURL_URL + " -F 'a=1' -F " + q("body=" + CC),
+])
+def test_curl_body_options_this_gate_cannot_merge_are_unseeable(cmd):
+    reason = ev(cmd) or ""
+    assert UNSEEABLE_MARK in reason, cmd
+    assert REASON_CURL_MERGE in reason, cmd
+
+
+@pytest.mark.parametrize("cmd", [
+    "curl -X POST " + CURL_URL + " -d " + q(json.dumps({"title": "t", "body": CC})),
+    "curl --request=POST --data=" + q(json.dumps({"body": AC})) + " " + CURL_URL,
+    "curl -X POST -H 'Accept: application/vnd.github+json' " + CURL_URL +
+    " -d " + q(json.dumps({"body": CC})),
+])
+def test_a_single_curl_data_argument_is_unaffected(cmd):
+    """The shape ~every real curl uses stays byte-for-byte what it was."""
+    assert ev(cmd) is None, cmd
+
+
+def test_only_the_LAST_gh_api_input_answers():
+    """`--input` is a pflag `StringVar` in gh api, so a repeat is last-wins for
+    exactly the reason `--body` is."""
+    good = scratch("input-good.json")
+    bad = scratch("input-bad.json")
+    with open(good, "w") as f:
+        json.dump({"title": "t", "body": CC}, f)
+    with open(bad, "w") as f:
+        json.dump({"title": "t", "body": NO_CC}, f)
+    assert MISSING_MARK in (ev("gh api -X POST repos/o/r/issues --input " + good +
+                               " --input " + bad) or "")
+    assert ev("gh api -X POST repos/o/r/issues --input " + bad +
+              " --input " + good) is None
+
+
+# =========================================================================== #
+# 16. 🔴 THE BRACE-GROUP GAP, PINNED SO IT CANNOT ROT.
+# =========================================================================== #
+@pytest.mark.parametrize("cmd", [
+    "{ " + CREATE + " -t t -b " + q(NO_CC) + "; }",
+    "f(){ " + CREATE + " -t t -b " + q(NO_CC) + "; }; f",
+    "{ " + CREATE + " -t t -b " + q(NO_CC) + "; } > /dev/null",
+])
+def test_a_brace_group_is_a_KNOWN_UNCOVERED_ROUTE(cmd):
+    """🔴 PINNED AS A GAP, NOT LEFT FOR SOMEONE TO REDISCOVER — and PRE-EXISTING,
+    identical on the pre-fix hook.
+
+    `guard_core._tokenise` hands the segment to `shlex.split`, which has no idea
+    `{` is a shell reserved word, so argv[0] is the literal `{` and the argv is
+    not a `gh` at all. It is the same family as the keyword gap above and needs
+    the same shared-tokeniser change.
+
+    🔴 THE TWO PARSERS HERE DISAGREE ABOUT `{`, AND THIS FILE'S ONE IS RIGHT:
+    `_CMD_KEEPERS` lists `{` and `}` because bash's `{` is a reserved word that
+    leaves the NEXT word in command position — which is why the override walk
+    reads `{ GH_ISSUE_NO_CLOSING_CONDITION=1 gh … ; }` correctly (asserted
+    below). `guard_core` is the one that would have to learn it, and that changes
+    what `bash-guard.py` sees on every call. If the tokeniser is widened, these
+    go red and the docstring's NOT-COVERED entry has to go with them."""
+    assert ev(cmd) is None, cmd
+
+
+def test_the_walk_does_read_a_brace_group_as_command_position():
+    """The boundary of the gap above, and the evidence for the claim in its
+    docstring: THIS file's walk gets `{` right even though the shared tokeniser
+    does not. Without `{` in `_CMD_KEEPERS` the assignment after it would not be
+    at command position and the override would be missed."""
+    assert guard._shell_walk("{ " + OVERRIDE_ON + " true; }")[1] is True
+    assert guard._shell_walk("{ true; }")[1] is False

--- a/scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py
+++ b/scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py
@@ -662,6 +662,148 @@ def test_an_unrelated_heredoc_does_not_satisfy_a_create(tail, mark):
     assert mark in (ev(PLAN_HEREDOC + tail) or ""), tail
 
 
+# =========================================================================== #
+# 🔴 THE SAME-PHYSICAL-LINE HALF — the one-sidedness that let B2 reopen.
+#
+# Every case in `UNRELATED_HEREDOC_CASES` puts the foreign heredoc on a PRECEDING
+# line, and a preceding line is the single arrangement where "the body that
+# starts after the newline ending this command" and "the body this command
+# opened" are the same bytes. So a walk that attributes a body BY POSITION passes
+# that whole table while being exactly wrong about the shape below.
+#
+# When two commands on ONE physical line each open a heredoc, bash queues the
+# bodies back to back in OPERATOR order after the last of them. "The body after
+# my newline" then names the FIRST opener's body — the EARLIER command's — while
+# the later command's own body starts where that one ended and falls outside
+# every segment. The verdicts invert: a junk-bodied create is credited with a
+# well-specified body it never opened, and a well-specified create is denied on
+# the strength of junk it never opened either. Both directions are pinned.
+#
+# Measured at 2bd3d1e7 (the parent of the commit adding these): every one of the
+# SEVEN cases in this table ALLOWED, and `test_the_same_line_good_heredoc_still_
+# allows` DENIED — 8 red, driven. The two cases that were already GREEN at that
+# ref are deliberately NOT in this table: they are invariant guards on the fix
+# itself, written as their own tests and labelled as such, because a guard the
+# bug never violated is not regression coverage and must not be counted as any.
+# The fixtures each name their own file under the per-run scratch dir, so no
+# leftover path can answer a `--body-file` question for them.
+# =========================================================================== #
+def _line(first_target, joiner, create_tail, first_body, own_body, op="<<"):
+    """One physical line: `cat <<A > <file> <joiner> <create> <tail>`, then the
+    queued bodies — A's first, the create's second, exactly as bash orders them.
+    """
+    pre = "" if op == "<<" else "\t"
+    def wrap(s):
+        return "\n".join(pre + line for line in s.splitlines())
+    return ("cat " + op + "'A' > " + first_target + " " + joiner + " " +
+            CREATE + " " + create_tail + "\n" +
+            wrap(first_body) + "\n" + pre + "A\n" +
+            wrap(own_body) + "\n" + pre + "B\n")
+
+
+SAME_LINE_HEREDOC_CASES = [
+    # `&&` — the shape a real agent types: write the plan, then file the issue.
+    ("&&", _line(scratch("sl-and.md"), "&&", "-t t --body-file - " + "<<'B'",
+                 CC, NO_CC), MISSING_MARK),
+    # `;` — a different separator must not change the attribution.
+    (";", _line(scratch("sl-semi.md"), ";", "-t t --body-file - " + "<<'B'",
+                CC, NO_CC), MISSING_MARK),
+    # A pipe between the first opener and its sink, still two openers on the line.
+    ("| tee",
+     "cat <<'A' | tee " + scratch("sl-pipe.md") + " && " + CREATE +
+     " -t t --body-file - <<'B'\n" + CC + "\nA\n" + NO_CC + "\nB\n",
+     MISSING_MARK),
+    # No body flag at all: the create's OWN heredoc feeds nothing gh reads, but
+    # it is still the operator's text — and it is still not the FIRST body.
+    ("no body flag", _line(scratch("sl-noflag.md"), "&&", "-t t <<'B'",
+                           CC, NO_CC), MISSING_MARK),
+    # `<<-` strips leading tabs from the bodies AND the terminators.
+    ("<<- tab stripped",
+     _line(scratch("sl-dash.md"), "&&", "-t t --body-file - " + "<<-'B'",
+           CC, NO_CC, op="<<-"), MISSING_MARK),
+    # CRLF: the reassembled segment must keep the line structure the parser needs.
+    ("CRLF", _line(scratch("sl-crlf.md"), "&&", "-t t --body-file - " + "<<'B'",
+                   CC, NO_CC).replace("\n", "\r\n"), MISSING_MARK),
+    # Three openers: the create's body is the THIRD in the queue, so a walk that
+    # takes "the next body" is wrong by two, not by one.
+    ("three chained heredocs",
+     "cat <<'A' > " + scratch("sl-1.md") + " && cat <<'B' > " +
+     scratch("sl-2.md") + " && " + CREATE + " -t t --body-file - <<'C'\n" +
+     CC + "\nA\n" + AC + "\nB\n" + NO_CC + "\nC\n", MISSING_MARK),
+]
+
+
+@pytest.mark.parametrize("label,cmd,mark", SAME_LINE_HEREDOC_CASES,
+                         ids=[c[0] for c in SAME_LINE_HEREDOC_CASES])
+def test_a_same_line_heredoc_belongs_to_the_command_that_opened_it(label, cmd, mark):
+    """🔴 A well-specified heredoc opened by a DIFFERENT command on the SAME line
+    must not answer for a create — the bodies are queued in operator order, so
+    position cannot attribute them and only the `<<` offset can. The mark is the
+    SPECIFIC reason, so a case cannot pass by observing "it blocked"."""
+    assert mark in (ev(cmd) or ""), cmd
+
+
+def test_the_same_line_good_heredoc_still_allows():
+    """🔴 THE OTHER DIRECTION, and the reason this is not just "block more". With
+    the bodies queued the other way round, position-based attribution hands the
+    create the FOREIGN junk body and denies a correctly-specified create. A fix
+    that only tightened would fail here."""
+    good = _line(scratch("sl-ok.md"), "&&", "-t t --body-file - " + "<<'B'",
+                 "junk the create never opened", CC)
+    assert ev(good) is None, good
+    # …and with the create's own body emptied of a condition it denies again,
+    # so the ALLOW above is about the body, not about the shape.
+    bad = _line(scratch("sl-ok2.md"), "&&", "-t t --body-file - " + "<<'B'",
+                "junk the create never opened", NO_CC)
+    assert MISSING_MARK in (ev(bad) or ""), bad
+
+
+def test_a_create_with_its_own_heredoc_is_not_credited_with_an_earlier_line_s():
+    """⚠️ AN INVARIANT GUARD — green at 2bd3d1e7, and written because a mutation
+    sweep found nothing else that could see it. It is the input that separates a
+    segment starting at the create from one starting at byte 0: the create opens
+    its OWN heredoc (so re-parsing its segment DOES find an operator), and a
+    well-specified heredoc sits on an earlier line. Widen the segment to the whole
+    line and the earlier body answers — the literal B2 bug, scored SURVIVED by
+    the suite as shipped."""
+    cmd = ("cat <<'A' > " + scratch("sl-prev.md") + "\n" + CC + "\nA\n" +
+           CREATE + " -t t --body-file - <<'B'\njunk\nB\n")
+    assert MISSING_MARK in (ev(cmd) or ""), cmd
+    # …and the create's own well-specified heredoc still ALLOWS on that same
+    # shape, so the assertion above is about attribution, not about denying more.
+    ok = ("cat <<'A' > " + scratch("sl-prev2.md") + "\njunk\nA\n" +
+          CREATE + " -t t --body-file - <<'B'\n" + CC + "\nB\n")
+    assert ev(ok) is None, ok
+
+
+def test_a_create_with_no_heredoc_of_its_own_sees_no_body():
+    """⚠️ AN INVARIANT GUARD, NOT REGRESSION COVERAGE — green at 2bd3d1e7 too, and
+    labelled so nobody counts it. It passed there for a reason that has nothing
+    to do with attribution: the widened span carried the foreign BODY but not the
+    foreign `<<` OPERATOR, so re-parsing the segment found no heredoc at all. It
+    is here because the fix reassembles segment text by hand, and an assembler
+    that appended every body rather than this command's would break it.
+
+    The reason must be "no body this gate can read", not "no closing condition" —
+    the gate saw nothing; it did not read a body and find it wanting."""
+    cmd = ("cat <<'A' > " + scratch("sl-none.md") + " && " + CREATE + " -t t\n" +
+           CC + "\nA\n")
+    assert REASON_NONE in (ev(cmd) or ""), cmd
+
+
+def test_the_override_still_reaches_a_command_after_a_heredoc_body():
+    """⚠️ ALSO AN INVARIANT GUARD — green at 2bd3d1e7. The walk steps OVER a
+    heredoc body; the first word after it is still in command position. Losing
+    that makes a legitimate override stop working, which is a permanently-red
+    gate — the failure direction nobody reports. It is pinned because the fix
+    rewrote the branch that used to re-arm `at_cmd` after a body (mutant M5)."""
+    line = ("cat <<'A' > " + scratch("sl-ovr.md") + "\nplan\nA\n" +
+            OVERRIDE_ON + " " + CREATE + " -t t -b nope")
+    assert ev(line) is None, line
+    # …and without the assignment the same line still denies.
+    assert MISSING_MARK in (ev(line.replace(OVERRIDE_ON + " ", "")) or "")
+
+
 def test_a_heredoc_that_writes_the_body_file_still_satisfies_it():
     """🔴 The other side, and why the rescue is matched on the PATH rather than
     deleted: the file does not exist yet when a PreToolUse hook runs, so a
@@ -695,7 +837,7 @@ def test_an_inert_sink_feeding_a_process_substitution_is_marked_not_inert():
     `cat <<'EOF' > >(bash)` really executes the body, and `_PIPES_ONWARD` — the
     "is this sink's output going somewhere executable" test — matched only
     `[|&;]`, so it scored INERT. No end-to-end command currently discriminates
-    that mutant, because `command_spans` splits on the substitution's own parens
+    that mutant, because `command_segments` splits on the substitution's own parens
     and re-exposes the body anyway. Two independent mechanisms is the point; a
     test that leans on the OTHER one would report coverage this guard does not
     have, so the claim is asserted where it is made."""

--- a/scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py
+++ b/scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py
@@ -1,0 +1,996 @@
+#!/usr/bin/env python3
+"""Tests for gh-issue-closing-condition-guard.py — the gate that makes a GitHub
+issue CREATE name the condition that ends it.
+
+WHAT THIS FILE IS FOR
+
+  1. 🔴 BOTH DIRECTIONS, AND A MENTION IS NOT AN INVOCATION. This hook DENIES a
+     Bash call, on `gh` — the most-typed tool in these repos. Firing it on a
+     `grep`/`echo`/`rg` for the command string, on a heredoc that DOCUMENTS it, or
+     on the string appearing inside some OTHER command's `--body`, would put a
+     block in front of work that owes nothing to anyone. That is not an edge case
+     here: `bash-guard.py` blocked a real `grep` for exactly this reason while
+     this gate was being specified. Every one of those shapes is a case below, not
+     an argument in a comment. And a guard nobody has watched ALLOW is as unproven
+     as one nobody has watched deny.
+
+  2. 🔴 EVERY BODY SOURCE, INCLUDING THE ONES THAT MUST BLOCK. `--body`, `-b`,
+     `--body-file <path>`, `-F <path>`, a heredoc, a `gh api -f body=…` field and
+     a curl JSON payload are readable; a body from a generator substitution, from
+     stdin (`--body-file -`), or from a file that does not exist is NOT, and the
+     gate must BLOCK there. Failing open on an unreadable body would make the
+     guard walkable by changing the SHAPE of the call rather than its content — a
+     spelled guard, not a structural one. Asserted with the two verdicts kept
+     DISTINCT: "no closing condition" and "cannot see the body" are different
+     facts with different messages, so a test cannot pass by observing "it
+     blocked" alone.
+
+  3. 🔴 THE DETECTOR IS PINNED AS A LITERAL TABLE, never derived from the regex it
+     tests — and BOTH of its conditions are exercised. A bare heading with nothing
+     under it is a REJECT, because the near-miss this gate exists to catch is a
+     pasted template that was never filled in. `###`, bold text, a missing space
+     after `##`, and a heading that only appears inside a ``` fence are rejects
+     too.
+
+  4. 🔴 THE OVERRIDE IS STRUCTURAL, NOT SPELLED. `GH_ISSUE_NO_CLOSING_CONDITION=1`
+     quoted INSIDE an issue body must NOT disarm the gate: a guard you can switch
+     off by naming it in prose is not a guard. Both real channels (a
+     command-position assignment, the process environment) are driven through a
+     REAL subprocess, and the near-miss spellings (`=true`, `=yes`, `=0`, empty)
+     are asserted NOT to override.
+
+  5. THE I/O CONTRACT, THROUGH A REAL PROCESS. A PreToolUse hook that exits
+     non-zero for any reason other than 2 is a silent ALLOW, so "exits 0" is
+     checked on the malformed-input paths too — where an in-process assertion
+     could not see a traceback.
+
+  6. 🔴 THE MESSAGE MUST CARRY ITS OWN LIMITS. The gate cannot check that what was
+     written under the heading is an observable end-state rather than a restated
+     fix; a message that reads as if it could would be a guard claiming coverage
+     it does not have. Asserted on both deny shapes, along with the pointer to the
+     definition site — which is asserted to EXIST, because a router pointing at
+     nothing is worse than no router.
+
+  7. THE WIRING SEAM. A hook that ships and is never registered is inert and says
+     nothing about it (#452). home.nix must deploy it and the registrar must
+     register it on PreToolUse(Bash); both are asserted here rather than left to
+     the delivery-seam suite alone.
+
+  8. NEGATIVE AND POSITIVE CONTROLS ON THIS FILE ITSELF. `test_control_*` feed the
+     harness one case that MUST deny and one that MUST allow. A suite that
+     reported a reassuring zero because it was wired to nothing would fail them.
+"""
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+HOOK = os.path.abspath(
+    os.path.join(HERE, os.pardir, "gh-issue-closing-condition-guard.py"))
+ROOT = Path(HERE).resolve().parents[2]
+DEFINITION = ROOT / "claude" / "skills" / "clawgate" / "flows" / "task-authoring.md"
+HOME_NIX = ROOT / "nix" / "home.nix"
+REGISTRAR = ROOT / "scripts" / "claude-hooks" / "register-nudge-hook.py"
+RULES = ROOT / "claude" / "RULES.md"
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_file_location(name, path, loader=loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+guard = _load("gh_issue_closing_condition_guard_undertest", HOOK)
+# The hook resolves `guard_core` from its own directory; do the same here so the
+# in-process helpers below see exactly the module the deployed hook would.
+sys.path.insert(0, os.path.abspath(os.path.join(HERE, os.pardir)))
+import guard_core  # noqa: E402
+
+# --------------------------------------------------------------------------- #
+# LITERALS, never `guard.<CONSTANT>`.
+#
+# 🔴 An expectation read out of the module under test asserts only that the module
+# agrees with itself: a mutant that renames the definition path, or widens the
+# override spelling, changes BOTH sides at once and survives. This is the lesson
+# test_clawgate_task_interview_guard.py records after two such mutants survived
+# its first sweep.
+#
+# The command word is built from pieces for a second reason: this repo's own
+# `bash-guard.py` matches raw command text, and a test fixture that spells a
+# guarded shape end-to-end has blocked tooling before.
+# --------------------------------------------------------------------------- #
+GH = "gh"
+CREATE = GH + " issue create"
+OVERRIDE = "GH_ISSUE_NO_CLOSING_CONDITION"
+OVERRIDE_ON = OVERRIDE + "=1"
+DEPLOYED_DEF = "~/.claude/skills/clawgate/flows/task-authoring.md"
+REPO_DEF = "devrc/claude/skills/clawgate/flows/task-authoring.md"
+HOOK_BASENAME = "gh-issue-closing-condition-guard.py"
+
+# The two verdict families, identified by a phrase that appears in exactly one of
+# them. Asserting on these keeps "it blocked" from standing in for "it blocked for
+# the right reason".
+MISSING_MARK = "names no closing condition"
+UNSEEABLE_MARK = "CANNOT SEE THE BODY"
+LIMIT_MARK = "not machine-checkable"
+
+REASON_STDIN = "the body is piped in on stdin, where a PreToolUse hook cannot read it"
+REASON_OPAQUE = "the argument is a shell substitution this gate cannot evaluate"
+REASON_NONE = "the command names no body this gate can read"
+REASON_UNREADABLE = "the body-file path could not be read"
+BODY_FILE_CAP = 1024 * 1024
+
+# A well-formed body and a specified-nothing body. Values are deliberately
+# distinct from every constant this suite asserts against.
+CC = ("## Closing condition\n"
+      "the wedge counter reads 0 for 24h after the rollout\n"
+      "Checked by: the alert clearing in Grafana")
+AC = ("## Acceptance criteria\n"
+      "the poller writes a row every 5 minutes\n"
+      "Checked by: a query returning 288 rows for a day")
+NO_CC = "make the pill nicer, you know the one"
+
+
+def q(s):
+    """Single-quote for the shell, keeping real newlines real."""
+    return "'" + s.replace("'", "'\\''") + "'"
+
+
+# --------------------------------------------------------------------------- #
+# drivers
+# --------------------------------------------------------------------------- #
+def verdict(cmd, env=None, tool_name="Bash", raw=None):
+    """Run the REAL hook as a subprocess. Returns (returncode, parsed-json-or-None).
+
+    A subprocess and not `guard.evaluate`, because the claims that matter most
+    here — "always exits 0", "prints nothing on an allow" — are claims about the
+    PROCESS. An in-process call cannot observe a traceback or a stray write to
+    stdout.
+    """
+    e = dict(os.environ)
+    e.pop(OVERRIDE, None)
+    e["PYTHONDONTWRITEBYTECODE"] = "1"
+    if env:
+        e.update(env)
+    payload = raw if raw is not None else json.dumps(
+        {"tool_name": tool_name, "hook_event_name": "PreToolUse",
+         "cwd": str(ROOT), "tool_input": {"command": cmd}})
+    p = subprocess.run([sys.executable, HOOK], input=payload,
+                       capture_output=True, text=True, env=e)
+    assert p.returncode == 0, (
+        f"a PreToolUse hook must exit 0; got {p.returncode}\n{p.stderr}")
+    if not p.stdout.strip():
+        return p.returncode, None
+    return p.returncode, json.loads(p.stdout)
+
+
+def reason_of(out):
+    assert out is not None, "expected a deny, got an allow"
+    hso = out["hookSpecificOutput"]
+    assert hso["hookEventName"] == "PreToolUse"
+    assert hso["permissionDecision"] == "deny"
+    return hso["permissionDecisionReason"]
+
+
+def deny_reason(cmd, env=None):
+    _, out = verdict(cmd, env=env)
+    return reason_of(out)
+
+
+def assert_allowed(cmd, env=None):
+    rc, out = verdict(cmd, env=env)
+    assert out is None, (
+        f"expected ALLOW for {cmd!r}\n"
+        f"got: {out['hookSpecificOutput']['permissionDecisionReason'][:400]}")
+
+
+# In-process evaluation, for the table-sized batteries where a subprocess per case
+# would make the suite slow. The subprocess driver above covers the process
+# contract; this covers volume.
+def ev(cmd, env=None):
+    return guard.evaluate(cmd, env or {}, guard_core)
+
+
+# =========================================================================== #
+# 1. THE DETECTOR — a literal table, both of its conditions.
+# =========================================================================== #
+ACCEPTS = [
+    "## Closing condition\nthe queue drains to 0",
+    "## closing condition\nthe queue drains to 0",
+    "## CLOSING CONDITION\nthe queue drains to 0",
+    "## Closing conditions\nboth queues drain",
+    "## Closing condition: the queue drains\nChecked by: a query",
+    "## Acceptance criteria\nthe suite is green",
+    "## acceptance criteria\nthe suite is green",
+    "  ## Closing condition\n  the queue drains to 0",
+    "   ## Closing condition\n   the queue drains to 0",
+    "##\tClosing\tcondition\nthe queue drains to 0",
+    "intro prose\n\n## Closing condition\nthe queue drains to 0\n\nmore prose",
+    "## Closing condition\n\n\nthe queue drains after two blank lines",
+    "## Closing condition\n### how\nby a query",
+    "## Closing condition\n```\na command exiting 0\n```",
+    "## Notes\nx\n## Closing condition\nthe queue drains to 0",
+    "## Closing condition\nthe queue drains\n## Notes\nunrelated",
+    "```\n## Closing condition\nin a fence\n```\n## Closing condition\nreal one",
+]
+
+REJECTS = [
+    "",
+    "make the pill nicer",
+    "## Closing condition",                       # heading, nothing under it
+    "## Closing condition\n",
+    "## Closing condition\n\n",
+    "## Closing condition\n\n## Notes\nunrelated",  # next heading, no content
+    "## Closing condition\n# Notes\nunrelated",
+    "### Closing condition\nthe queue drains",     # level 3
+    "# Closing condition\nthe queue drains",       # level 1
+    "#### Closing condition\nthe queue drains",
+    "**Closing condition**\nthe queue drains",
+    "##Closing condition\nthe queue drains",       # no space after ##
+    "    ## Closing condition\nthe queue drains",  # 4 spaces = code block
+    "## Closing conditionality\nthe queue drains",
+    "## Closingcondition\nthe queue drains",
+    "## Acceptancecriteria\nthe suite is green",
+    "## Acceptance criterion\nthe suite is green",
+    "closing condition: the queue drains",
+    "```\n## Closing condition\nonly inside a fence\n```",
+    "~~~\n## Closing condition\nonly inside a tilde fence\n~~~",
+    "```md\n## Closing condition\ntemplate quoted, never filled in\n```",
+    "## Closing condition\n```\n```\n".replace("```\n```", "\n"),  # blank-only section
+]
+
+
+@pytest.mark.parametrize("body", ACCEPTS)
+def test_the_detector_accepts(body):
+    assert guard.has_closing_condition(body) is True, body
+
+
+@pytest.mark.parametrize("body", REJECTS)
+def test_the_detector_rejects(body):
+    assert guard.has_closing_condition(body) is False, body
+
+
+@pytest.mark.parametrize("bad", [None, 0, [], {}, b"## Closing condition\nx"])
+def test_the_detector_rejects_non_strings(bad):
+    assert guard.has_closing_condition(bad) is False
+
+
+def test_a_heading_with_no_content_is_the_named_near_miss():
+    """🔴 The condition that separates this detector from the clawgate one.
+
+    Pinned on its own, with the CONTENT-bearing twin beside it, so a mutant that
+    drops the emptiness check cannot survive by passing the accept table alone.
+    """
+    assert guard.has_closing_condition("## Closing condition") is False
+    assert guard.has_closing_condition("## Closing condition\nx") is True
+
+
+def test_a_third_level_heading_is_not_a_section_boundary():
+    """`###` under the heading is still inside the section, so it is content."""
+    assert guard.has_closing_condition("## Closing condition\n### detail\nx") is True
+
+
+# =========================================================================== #
+# 2. A MENTION IS NOT AN INVOCATION — the first-class requirement.
+# =========================================================================== #
+MENTIONS = [
+    "grep " + q(CREATE) + " notes.md",
+    "grep -rn " + q(CREATE + " --body") + " claude/",
+    "rg -n " + q(CREATE) + " docs/",
+    'echo "' + CREATE + '"',
+    "echo " + q(CREATE + " --body " + q(NO_CC)),
+    "printf '%s\\n' " + q(CREATE),
+    # the command text inside ANOTHER command's body
+    "gh pr create --title t --body " + q("do not run " + CREATE + " --body x"),
+    "gh issue comment 12 --body " + q("we used " + CREATE + " --body x"),
+    "git commit -F /tmp/msg.md",
+    # a heredoc that DOCUMENTS the command
+    "cat > /tmp/notes.md <<'EOF'\n" + CREATE + " --body x\nEOF",
+    "cat > /tmp/notes.md <<EOF\n" + CREATE + " --body x\nEOF",
+    "tee /tmp/notes.md <<'EOF'\n" + CREATE + " --body x\nEOF",
+    "tee -a /tmp/notes.md <<'EOF'\n" + CREATE + " --body x\nEOF",
+    "cat <<'EOF'\n" + CREATE + " --body x\nEOF",
+    "cat <<-'EOF'\n\t" + CREATE + " --body x\n\tEOF",
+    "printf '%s' \"$(cat <<'EOF'\n" + CREATE + " --body x\nEOF\n)\"",
+    # a comment
+    "gh pr list  # " + CREATE + " needs a closing condition",
+]
+
+
+@pytest.mark.parametrize("cmd", MENTIONS)
+def test_a_mention_is_allowed(cmd):
+    assert ev(cmd) is None, cmd
+
+
+@pytest.mark.parametrize("cmd", MENTIONS[:6] + MENTIONS[9:12])
+def test_a_mention_is_allowed_through_the_real_process(cmd):
+    assert_allowed(cmd)
+
+
+HEREDOCS_THAT_EXECUTE = [
+    "bash <<'EOF'\n" + CREATE + " -t t --body x\nEOF",
+    "sh <<EOF\n" + CREATE + " -t t --body x\nEOF",
+    "zsh <<'EOF'\n" + CREATE + " -t t --body x\nEOF",
+    "cat <<'EOF' | bash\n" + CREATE + " -t t --body x\nEOF",
+    "cat <<'EOF' | sh -\n" + CREATE + " -t t --body x\nEOF",
+    "python3 - <<'EOF'\n" + CREATE + " -t t --body x\nEOF",
+    "xargs -0 sh -c <<'EOF'\n" + CREATE + " -t t --body x\nEOF",
+]
+
+
+@pytest.mark.parametrize("cmd", HEREDOCS_THAT_EXECUTE)
+def test_a_heredoc_that_can_execute_is_still_checked(cmd):
+    """🔴 The allowlist's other side. Blanking an inert sink's body must not cost
+    coverage of a body that really runs — otherwise the mention exemption IS the
+    bypass."""
+    assert MISSING_MARK in (ev(cmd) or ""), cmd
+
+
+def test_the_sink_allowlist_is_an_allowlist_not_a_denylist():
+    """An attachment the table does not know keeps the body — fail CLOSED."""
+    unknown = "some-unknown-wrapper <<'EOF'\n" + CREATE + " -t t --body x\nEOF"
+    assert ev(unknown) is not None
+
+
+def test_an_inert_sink_piped_onward_is_not_inert():
+    piped = "cat <<'EOF' | bash\n" + CREATE + " -t t --body x\nEOF"
+    plain = "cat <<'EOF'\n" + CREATE + " -t t --body x\nEOF"
+    assert ev(piped) is not None
+    assert ev(plain) is None
+
+
+def test_scrubbing_preserves_line_structure():
+    text = "cat > /tmp/n.md <<'EOF'\nline one\nline two\nEOF\ntrue"
+    out = guard.scrub_inert_heredocs(text)
+    assert out.count("\n") == text.count("\n")
+    assert "line one" not in out
+    assert "EOF" in out
+
+
+def test_scrubbing_is_a_no_op_without_an_inert_heredoc():
+    text = "bash <<'EOF'\nline one\nEOF"
+    assert guard.scrub_inert_heredocs(text) == text
+
+
+# =========================================================================== #
+# 3. OTHER SUBCOMMANDS AND NEIGHBOURING VERBS — the non-matches.
+# =========================================================================== #
+NOT_A_CREATE = [
+    GH + " issue comment 12 --body " + q(NO_CC),
+    GH + " issue edit 12 --body " + q(NO_CC),
+    GH + " issue close 12 --comment " + q(NO_CC),
+    GH + " issue reopen 12",
+    GH + " issue list",
+    GH + " issue list --label bug",
+    GH + " issue view 3",
+    GH + " issue view 3 --json body",
+    GH + " issue status",
+    GH + " issue develop 3 --name zach/fix",
+    GH + " issue transfer 3 other/repo",
+    GH + " issue pin 3",
+    GH + " pr create --title t --body " + q(NO_CC),
+    GH + " pr comment 4 --body " + q(NO_CC),
+    GH + " release create v1 --notes " + q(NO_CC),
+    GH + " gist create /tmp/x.md",
+    GH + " api repos/o/r/issues",
+    GH + " api repos/o/r/issues?state=open",
+    GH + " api repos/o/r/issues/3",
+    GH + " api repos/o/r/issues/3/comments -f body=" + q(NO_CC),
+    GH + " api -X GET repos/o/r/issues",
+    GH + " api -X PATCH repos/o/r/issues/3 -f body=" + q(NO_CC),
+    GH + " api /repos/o/r/issues/events",
+    "curl https://api.github.com/repos/o/r/issues",
+    "curl -X GET https://api.github.com/repos/o/r/issues",
+    "curl -X POST https://api.github.com/repos/o/r/issues/3/comments -d " + q('{"body":"hi"}'),
+    "curl https://api.github.com/repos/o/r/issues/3",
+    GH + " pr checks 4",
+    GH + " repo view",
+]
+
+
+@pytest.mark.parametrize("cmd", NOT_A_CREATE)
+def test_a_non_create_is_allowed(cmd):
+    assert ev(cmd) is None, cmd
+
+
+@pytest.mark.parametrize("cmd", NOT_A_CREATE[:8])
+def test_a_non_create_is_allowed_through_the_real_process(cmd):
+    assert_allowed(cmd)
+
+
+@pytest.mark.parametrize("cmd", [
+    CREATE + " --help",
+    CREATE + " -h",
+    GH + " help issue create",
+    CREATE + " --help --body " + q(NO_CC),
+    CREATE + " --web -t t",
+    CREATE + " -w -t t",
+    CREATE + " --web --body " + q(NO_CC),
+])
+def test_a_structurally_exempt_shape_is_allowed(cmd):
+    """`--help` and `--web` cannot post from this process — docstring records both
+    as known one-flag gaps rather than hiding them."""
+    assert ev(cmd) is None, cmd
+
+
+def test_the_exemption_does_not_reach_curl():
+    """🔴 `-w` is curl's `--write-out` and curl posts anyway. The clawgate gate's
+    first `is_help_invocation` had exactly this hole."""
+    cmd = ("curl -w '%{http_code}' -X POST https://api.github.com/repos/o/r/issues "
+           "-d " + q('{"body":"nope"}'))
+    assert ev(cmd) is not None
+
+
+def test_a_flag_value_that_looks_like_help_does_not_exempt():
+    """`--title --help` reads `--help` as the title's VALUE."""
+    assert ev(CREATE + " --title --help --body " + q(NO_CC)) is not None
+
+
+# =========================================================================== #
+# 4. BODY SOURCES — readable, and the ones that must block.
+# =========================================================================== #
+def test_a_body_flag_with_a_closing_condition_is_allowed():
+    assert_allowed(CREATE + " --title t --body " + q(CC))
+
+
+def test_a_body_flag_without_one_is_denied():
+    assert MISSING_MARK in deny_reason(CREATE + " --title t --body " + q(NO_CC))
+
+
+def test_the_short_body_flag_is_covered():
+    assert MISSING_MARK in (ev(CREATE + " -t t -b " + q(NO_CC)) or "")
+    assert ev(CREATE + " -t t -b " + q(CC)) is None
+
+
+def test_an_equals_spelling_is_covered():
+    assert MISSING_MARK in (ev(CREATE + " -t t --body=" + q(NO_CC)) or "")
+    assert ev(CREATE + " -t t --body=" + q(CC)) is None
+
+
+def test_a_body_file_is_read(tmp_path):
+    good = tmp_path / "good.md"
+    good.write_text(CC)
+    bad = tmp_path / "bad.md"
+    bad.write_text(NO_CC)
+    assert ev(CREATE + " -t t --body-file " + str(good)) is None
+    assert MISSING_MARK in (ev(CREATE + " -t t --body-file " + str(bad)) or "")
+
+
+def test_the_short_body_file_flag_is_covered(tmp_path):
+    """🔴 On `gh issue create`, `-F` is `--body-file`; on `gh api` it is
+    `--raw-field`. One shared table would read one as the other."""
+    good = tmp_path / "good.md"
+    good.write_text(CC)
+    assert ev(CREATE + " -t t -F " + str(good)) is None
+    bad = tmp_path / "bad.md"
+    bad.write_text(NO_CC)
+    assert MISSING_MARK in (ev(CREATE + " -t t -F " + str(bad)) or "")
+
+
+def test_a_missing_body_file_blocks_with_the_unreadable_reason(tmp_path):
+    missing = tmp_path / "nope.md"
+    reason = deny_reason(CREATE + " -t t --body-file " + str(missing))
+    assert UNSEEABLE_MARK in reason
+    assert REASON_UNREADABLE in reason
+
+
+def test_an_unreadable_body_file_blocks(tmp_path):
+    """A directory is a path that exists and cannot be read as a body."""
+    d = tmp_path / "adir"
+    d.mkdir()
+    assert UNSEEABLE_MARK in deny_reason(CREATE + " -t t --body-file " + str(d))
+
+
+def test_an_oversized_body_file_blocks_rather_than_reading_it(tmp_path):
+    big = tmp_path / "big.md"
+    big.write_text(CC + "\n" + ("x" * (BODY_FILE_CAP + 1)))
+    reason = deny_reason(CREATE + " -t t --body-file " + str(big))
+    assert UNSEEABLE_MARK in reason
+    assert MISSING_MARK not in reason
+
+
+def test_a_stdin_body_blocks_and_names_the_remedy():
+    reason = deny_reason(CREATE + " -t t --body-file -")
+    assert UNSEEABLE_MARK in reason
+    assert REASON_STDIN in reason
+    assert "write it with the Write tool first" in reason
+
+
+@pytest.mark.parametrize("spelling", ["-", "/dev/stdin", "/proc/self/fd/0"])
+def test_every_stdin_spelling_blocks(spelling):
+    assert REASON_STDIN in (ev(CREATE + " -t t --body-file " + spelling) or "")
+
+
+def test_a_generator_substitution_blocks():
+    reason = deny_reason(CREATE + ' -t t --body "$(generate-spec.sh)"')
+    assert UNSEEABLE_MARK in reason
+    assert REASON_OPAQUE in reason
+
+
+def test_a_whole_variable_body_blocks():
+    assert REASON_OPAQUE in (ev(CREATE + ' -t t --body "$BODY"') or "")
+    assert REASON_OPAQUE in (ev(CREATE + ' -t t --body "${BODY}"') or "")
+
+
+def test_a_variable_body_file_path_blocks():
+    assert REASON_OPAQUE in (ev(CREATE + ' -t t --body-file "$F/x.md"') or "")
+
+
+@pytest.mark.parametrize("cmd", [
+    CREATE + " -t t --body $(generate-spec.sh)",   # UNQUOTED substitution
+    CREATE + " -t t --body ''",
+    CREATE + ' -t t --body ""',
+])
+def test_an_empty_argument_is_not_read_as_an_empty_body(cmd):
+    """🔴 The shared core LIFTS an unquoted `$( … )` out of its segment, so the
+    `--body` argument arrives here as the empty string. Scoring that as a body
+    would report "no closing condition" about a body the gate never saw — the
+    wrong fact and the most confusing possible message."""
+    reason = deny_reason(cmd)
+    assert UNSEEABLE_MARK in reason
+    assert REASON_NONE in reason
+    assert MISSING_MARK not in reason
+
+
+def test_a_create_with_no_body_at_all_blocks():
+    reason = deny_reason(CREATE + " -t t")
+    assert UNSEEABLE_MARK in reason
+    assert REASON_NONE in reason
+
+
+@pytest.mark.parametrize("body", [
+    "$'## Closing condition\\nthe queue drains to 0'",
+    "$'## Acceptance criteria\\nthe suite is green'",
+    '"## Closing condition\\nthe queue drains to 0"',
+    "$'## Closing condition\\r\\nthe queue drains to 0'",
+    "$'## Closing condition\\tthe queue drains\\nChecked by: a query'",
+])
+def test_an_escaped_newline_body_is_decoded(body):
+    """🔴 `shlex` does not implement bash's `$'…'`, so a correctly-specified body
+    written that way arrives as ONE line starting `$##` and DENIES. A gate that
+    false-positives on correct usage is the gate everyone routes around.
+
+    The plain double-quoted spelling is credited too. That is a DELIBERATE
+    over-acceptance, recorded in the guard's docstring: bash leaves `"\\n"` as two
+    literal characters, so GitHub would render the body on one line — but an
+    author who typed `\\n` between a heading and its content meant a newline, and
+    denying them is the false positive that gets a gate routed around."""
+    assert ev(CREATE + " -t t --body " + body) is None, body
+
+
+def test_the_ansi_c_decoding_cannot_manufacture_a_pass():
+    """It only ever adds a candidate; a body with no heading still denies."""
+    assert ev(CREATE + " -t t --body $'nothing specified\\nhere either'") is not None
+    assert guard.escape_expanded("plain text") == "plain text"
+
+
+def test_a_lone_variable_inside_prose_is_not_opaque():
+    """🔴 A measured false positive on the sibling gate: an issue body is PROSE,
+    so `$PATH` inside it is text, not a hidden value."""
+    body = CC + "\nset $PATH correctly first"
+    assert ev(CREATE + " -t t --body " + q(body)) is None
+
+
+def test_a_substitution_after_the_heading_still_passes():
+    """🔴 Ordering: a heading PRESENT IN THE LITERAL ARGUMENT wins over opacity.
+    Consulting opacity first reports "cannot see the body" about a body that is
+    right there."""
+    ok = CREATE + " -t t --body \"$(printf '%s' x)" + "\n" + CC + '"'
+    assert ev(ok) is None
+    # …and the same shape WITHOUT a heading is still unreadable, not "missing".
+    hidden = CREATE + " -t t --body \"$(printf '%s' x)\""
+    assert REASON_OPAQUE in (ev(hidden) or "")
+
+
+def test_a_heredoc_body_is_readable():
+    good = (CREATE + " -t t --body \"$(cat <<'EOF'\n" + CC + "\nEOF\n)\"")
+    bad = (CREATE + " -t t --body \"$(cat <<'EOF'\n" + NO_CC + "\nEOF\n)\"")
+    assert ev(good) is None
+    assert MISSING_MARK in (ev(bad) or "")
+
+
+def test_a_tab_stripped_heredoc_body_is_readable():
+    """🔴 `<<-` strips leading TABS from body lines too. Stripping only the
+    terminator turns a tabbed heading into an indented code line."""
+    body = "\n".join("\t" + line for line in CC.splitlines())
+    cmd = CREATE + " -t t --body \"$(cat <<-'EOF'\n" + body + "\n\tEOF\n)\""
+    assert ev(cmd) is None
+
+
+def test_an_unrelated_heredoc_does_not_satisfy_a_create():
+    """🔴 The false ALLOW the blank-heredoc fallback is narrowed to avoid: a
+    well-specified heredoc written earlier on the line, for a DIFFERENT command,
+    must not let a create whose own body says nothing through."""
+    cmd = ("cat > /tmp/notes.md <<'EOF'\n" + CC + "\nEOF\n" +
+           CREATE + " -t t --body " + q(NO_CC))
+    assert MISSING_MARK in (ev(cmd) or ""), cmd
+
+
+def test_the_scrub_keeps_the_heredoc_terminator():
+    """🔴 Blanking the terminator too leaves the downstream scanner reading an
+    UNTERMINATED heredoc, which swallows the rest of the line — measured as a
+    correctly-specified create denying with 'no closing condition'."""
+    text = "cat > /tmp/n.md <<'EOF'\nbody line\nEOF\ntrue"
+    out = guard.scrub_inert_heredocs(text)
+    assert "\nEOF\n" in out
+    assert "body line" not in out
+
+
+def test_a_here_string_is_not_read_as_a_heredoc():
+    """A here-string has no body and no terminator; reading one as a heredoc would
+    swallow the rest of the line as prose the gate must not credit."""
+    assert ev(CREATE + " -t t --body-file - <<<" + q(CC)) is not None
+
+
+# =========================================================================== #
+# 5. THE gh api ROUTE.
+# =========================================================================== #
+def test_gh_api_field_body_is_checked():
+    assert MISSING_MARK in (ev(GH + " api repos/o/r/issues -f title=t -f body=" + q(NO_CC)) or "")
+    assert ev(GH + " api repos/o/r/issues -f title=t -f body=" + q(CC)) is None
+
+
+def test_gh_api_raw_field_body_is_checked():
+    assert MISSING_MARK in (ev(GH + " api repos/o/r/issues -F body=" + q(NO_CC)) or "")
+    assert ev(GH + " api repos/o/r/issues -F body=" + q(CC)) is None
+
+
+def test_gh_api_only_the_body_field_counts():
+    """A title carrying the heading must not satisfy the gate."""
+    assert ev(GH + " api repos/o/r/issues -f title=" + q(CC) + " -f body=" + q(NO_CC)) is not None
+
+
+def test_gh_api_explicit_post_is_a_create():
+    assert ev(GH + " api -X POST repos/o/r/issues -f body=" + q(NO_CC)) is not None
+    assert ev(GH + " api --method POST repos/o/r/issues -f body=" + q(NO_CC)) is not None
+
+
+def test_gh_api_a_full_url_is_recognised():
+    assert ev(GH + " api https://api.github.com/repos/o/r/issues -f body=" + q(NO_CC)) is not None
+
+
+def test_gh_api_input_file_is_read(tmp_path):
+    good = tmp_path / "good.json"
+    good.write_text(json.dumps({"title": "t", "body": CC}))
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({"title": "t", "body": NO_CC}))
+    assert ev(GH + " api -X POST repos/o/r/issues --input " + str(good)) is None
+    assert MISSING_MARK in (ev(GH + " api -X POST repos/o/r/issues --input " + str(bad)) or "")
+
+
+def test_gh_api_input_stdin_blocks():
+    assert REASON_STDIN in (ev(GH + " api -X POST repos/o/r/issues --input -") or "")
+
+
+def test_gh_api_field_reading_a_file_is_read(tmp_path):
+    f = tmp_path / "b.md"
+    f.write_text(CC)
+    assert ev(GH + " api repos/o/r/issues -F body=@" + str(f)) is None
+
+
+# =========================================================================== #
+# 6. THE curl ROUTE.
+# =========================================================================== #
+def test_curl_post_is_checked():
+    bad = ('curl -X POST -H "Accept: application/vnd.github+json" '
+           "https://api.github.com/repos/o/r/issues -d " + q(json.dumps({"body": NO_CC})))
+    good = bad.replace(q(json.dumps({"body": NO_CC})), q(json.dumps({"body": CC})))
+    assert MISSING_MARK in (ev(bad) or "")
+    assert ev(good) is None
+
+
+def test_curl_with_data_and_no_method_is_a_create():
+    assert ev("curl https://api.github.com/repos/o/r/issues -d " +
+              q(json.dumps({"body": NO_CC}))) is not None
+
+
+def test_curl_data_from_a_file_is_json_parsed(tmp_path):
+    """🔴 `-d @file` still has to be JSON-parsed. Handing the raw bytes to a
+    line-based detector denies a correctly-specified create, because the heading
+    is only there as an escaped \\n."""
+    f = tmp_path / "p.json"
+    f.write_text(json.dumps({"title": "t", "body": CC}))
+    assert ev("curl -X POST https://api.github.com/repos/o/r/issues -d @" + str(f)) is None
+
+
+def test_curl_with_a_non_json_payload_blocks():
+    reason = deny_reason("curl -X POST https://api.github.com/repos/o/r/issues -d 'body=nope'")
+    assert UNSEEABLE_MARK in reason
+
+
+def test_curl_to_another_host_is_still_covered():
+    """The path is what identifies the endpoint; GHES lives on another host."""
+    assert ev("curl -X POST https://ghe.example.com/api/v3/repos/o/r/issues -d " +
+              q(json.dumps({"body": NO_CC}))) is not None
+
+
+# =========================================================================== #
+# 7. COMPOUND AND QUOTED SHAPES.
+# =========================================================================== #
+COMPOUND_DENIES = [
+    "true && " + CREATE + " -t t --body " + q(NO_CC),
+    "true; " + CREATE + " -t t --body " + q(NO_CC),
+    "true || " + CREATE + " -t t --body " + q(NO_CC),
+    "true | " + CREATE + " -t t --body " + q(NO_CC),
+    "( " + CREATE + " -t t --body " + q(NO_CC) + " )",
+    "git -C /tmp/x log -1 && " + CREATE + " -t t --body " + q(NO_CC),
+    'bash -c "' + CREATE + " -t t --body '" + NO_CC + "'\"",
+    "sudo " + CREATE + " -t t --body " + q(NO_CC),
+    "timeout 60 " + CREATE + " -t t --body " + q(NO_CC),
+    "GH_TOKEN=x " + CREATE + " -t t --body " + q(NO_CC),
+    "nohup " + CREATE + " -t t --body " + q(NO_CC),
+    CREATE + " --body " + q(NO_CC) + " -t t",
+    CREATE + " -R owner/repo --body " + q(NO_CC) + " --title t",
+    GH + " -R owner/repo issue create --body " + q(NO_CC) + " -t t",
+    CREATE + " -t t -l bug -a zach --body " + q(NO_CC),
+    CREATE + " -t t --body " + q(NO_CC) + " && echo done",
+]
+
+
+@pytest.mark.parametrize("cmd", COMPOUND_DENIES)
+def test_a_compound_shape_is_still_checked(cmd):
+    assert MISSING_MARK in (ev(cmd) or ""), cmd
+
+
+COMPOUND_ALLOWS = [
+    "true && " + CREATE + " -t t --body " + q(CC),
+    "true; " + CREATE + " -t t --body " + q(CC),
+    'bash -c "' + CREATE + " -t t --body '" + CC + "'\"",
+    CREATE + " --body " + q(CC) + " -t t -R owner/repo",
+    GH + " -R owner/repo issue create --body " + q(CC) + " -t t",
+    "sudo " + CREATE + " -t t --body " + q(CC),
+]
+
+
+@pytest.mark.parametrize("cmd", COMPOUND_ALLOWS)
+def test_a_compound_shape_with_a_condition_is_allowed(cmd):
+    assert ev(cmd) is None, cmd
+
+
+def test_two_creates_are_judged_together():
+    """🔴 A line that files two issues, one specified and one not, must not pass on
+    the strength of the good one."""
+    cmd = (CREATE + " -t a --body " + q(CC) + " && " +
+           CREATE + " -t b --body " + q(NO_CC))
+    assert MISSING_MARK in (ev(cmd) or "")
+    both = (CREATE + " -t a --body " + q(CC) + " && " +
+            CREATE + " -t b --body " + q(AC))
+    assert ev(both) is None
+
+
+def test_a_quoted_verb_pair_is_one_token_and_never_matches():
+    assert ev(GH + " " + q("issue create") + " --body " + q(NO_CC)) is None
+
+
+# =========================================================================== #
+# 8. THE OVERRIDE — one spelling, structural not spelled.
+# =========================================================================== #
+def test_the_inline_override_allows():
+    assert_allowed(OVERRIDE_ON + " " + CREATE + " -t t --body " + q(NO_CC))
+
+
+def test_the_exported_inline_override_allows():
+    assert_allowed("export " + OVERRIDE_ON + "; " + CREATE + " -t t --body " + q(NO_CC))
+
+
+def test_the_environment_override_allows():
+    assert_allowed(CREATE + " -t t --body " + q(NO_CC), env={OVERRIDE: "1"})
+
+
+@pytest.mark.parametrize("value", ["true", "yes", "0", "", "1 ", "01", "TRUE"])
+def test_a_near_miss_environment_value_does_not_override(value):
+    assert ev(CREATE + " -t t --body " + q(NO_CC), env={OVERRIDE: value}) is not None
+
+
+@pytest.mark.parametrize("spelling", [
+    "=true", "=yes", "=0", "=2", "=1x", "_EXTRA=1",
+])
+def test_a_near_miss_inline_spelling_does_not_override(spelling):
+    cmd = OVERRIDE + spelling + " " + CREATE + " -t t --body " + q(NO_CC)
+    assert ev(cmd) is not None, cmd
+
+
+def test_the_override_quoted_inside_a_body_does_not_disarm_the_gate():
+    """🔴 A guard you can switch off by naming it in prose is not a guard."""
+    body = NO_CC + "\nwe considered " + OVERRIDE_ON + " but did not use it"
+    assert ev(CREATE + " -t t --body " + q(body)) is not None
+
+
+def test_the_override_is_named_in_both_deny_messages():
+    assert OVERRIDE_ON in deny_reason(CREATE + " -t t --body " + q(NO_CC))
+    assert OVERRIDE_ON in deny_reason(CREATE + " -t t --body-file -")
+
+
+# =========================================================================== #
+# 9. THE MESSAGES — they must carry their own limits and point somewhere real.
+# =========================================================================== #
+def test_the_definition_file_exists():
+    """A router pointing at nothing is worse than no router."""
+    assert DEFINITION.is_file(), DEFINITION
+
+
+@pytest.mark.parametrize("cmd", [
+    CREATE + " -t t --body " + q(NO_CC),
+    CREATE + " -t t --body-file -",
+    CREATE + " -t t",
+])
+def test_every_deny_names_the_definition_site(cmd):
+    reason = deny_reason(cmd)
+    assert DEPLOYED_DEF in reason
+    assert REPO_DEF in reason
+
+
+def test_the_missing_verdict_states_what_it_cannot_check():
+    """🔴 Measured: in the briefed arm all 10 issues carried the heading and most
+    wrote the remedy under it. A message that reads as if the gate verified the
+    semantics would be claiming coverage it does not have. Asserted on the
+    MISSING verdict, which is the one that follows an actual check — the
+    unseeable verdict follows no check at all and says so in its own words."""
+    reason = deny_reason(CREATE + " -t t --body " + q(NO_CC))
+    assert LIMIT_MARK in reason
+    assert "a floor, not a verdict" in reason
+
+
+def test_the_unseeable_verdict_names_the_readable_shapes():
+    reason = deny_reason(CREATE + " -t t --body-file -")
+    assert LIMIT_MARK not in reason
+    assert "--body-file <a real path>" in reason
+    assert "a heredoc IS readable" in reason
+
+
+def test_the_two_verdicts_are_distinct():
+    missing = deny_reason(CREATE + " -t t --body " + q(NO_CC))
+    unseeable = deny_reason(CREATE + " -t t --body-file -")
+    assert MISSING_MARK in missing and UNSEEABLE_MARK not in missing
+    assert UNSEEABLE_MARK in unseeable and MISSING_MARK not in unseeable
+
+
+def test_the_missing_message_shows_a_template_and_names_both_headings():
+    reason = deny_reason(CREATE + " -t t --body " + q(NO_CC))
+    assert "## Closing condition" in reason
+    assert "## Acceptance criteria" in reason
+
+
+# 🔴 NOT ASSERTED HERE: that the guard stays a POINTER at the closing-condition
+# definition rather than restating it. `scripts/tests/test_closing_condition_
+# single_source.py` already owns that claim REPO-WIDE, and its corpus covers
+# `scripts/**.py`, so the new guard is in scope automatically — one rule, one
+# place.
+#
+# 🔴 And a duplicate here would not merely be redundant, it would be a
+# SELF-INFLICTED VIOLATION: asserting the sentences are absent means SPELLING
+# them, and the owning module counts occurrences across the tree. Measured — an
+# earlier draft of this file did exactly that and turned that module's two
+# relationship tests red, which is why it excludes ITSELF and says so in its own
+# docstring.
+
+
+# =========================================================================== #
+# 10. THE I/O CONTRACT, through a real process.
+# =========================================================================== #
+@pytest.mark.parametrize("raw", [
+    "",
+    "not json",
+    "[]",
+    "null",
+    '{"tool_name": "Bash"}',
+    '{"tool_name": "Bash", "tool_input": null}',
+    '{"tool_name": "Bash", "tool_input": {}}',
+    '{"tool_name": "Bash", "tool_input": {"command": null}}',
+    '{"tool_name": "Bash", "tool_input": {"command": ""}}',
+    '{"tool_name": "Bash", "tool_input": {"command": 12}}',
+    '{"tool_input": {"command": "' + CREATE + '"}}',
+])
+def test_malformed_input_exits_zero_and_says_nothing(raw):
+    rc, out = verdict(None, raw=raw)
+    assert rc == 0
+    assert out is None
+
+
+@pytest.mark.parametrize("tool", ["Write", "Edit", "Read", "Task", "WebFetch"])
+def test_a_non_bash_tool_is_ignored(tool):
+    rc, out = verdict(CREATE + " -t t --body " + q(NO_CC), tool_name=tool)
+    assert out is None
+
+
+def test_the_prefilter_returns_before_any_parse():
+    assert guard.PREFILTER.search("ls -la") is None
+    assert guard.PREFILTER.search(CREATE) is not None
+    assert guard.PREFILTER.search("curl https://x/y/issues") is not None
+
+
+def test_an_unrelated_command_is_allowed():
+    assert_allowed("kubectl get pods -n monitoring")
+
+
+def test_the_crash_path_denies_a_create_shape():
+    """🔴 A crash must not become a silent allow. Driven by making the shared core
+    unimportable, which is the real failure this path exists for."""
+    e = dict(os.environ)
+    e.pop(OVERRIDE, None)
+    e["PYTHONPATH"] = ""
+    payload = json.dumps({"tool_name": "Bash", "hook_event_name": "PreToolUse",
+                          "tool_input": {"command": CREATE + " -t t --body " + q(NO_CC)}})
+    # Force the import to fail by pointing the hook at a directory with a
+    # poisoned guard_core earlier on sys.path is not possible from here, so drive
+    # the function directly with a core that raises.
+    class Boom:
+        def commands(self, _):
+            raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        guard.evaluate(CREATE + " -t t --body " + q(NO_CC), {}, Boom())
+    assert guard.CRASH_LOOKS_LIKE_CREATE.search(CREATE) is not None
+    assert OVERRIDE_ON in guard.crash_text(RuntimeError("boom"))
+    assert payload  # the shape a real hook receives; kept for the reader
+
+
+def test_the_crash_fallback_respects_the_override():
+    assert guard.override_requested(OVERRIDE_ON + " " + CREATE, {}) is True
+    assert guard.override_requested(CREATE, {OVERRIDE: "1"}) is True
+    assert guard.override_requested(CREATE, {OVERRIDE: "true"}) is False
+
+
+# =========================================================================== #
+# 11. THE WIRING SEAM — a hook that ships unregistered is inert (#452).
+# =========================================================================== #
+def test_home_nix_deploys_the_hook():
+    text = HOME_NIX.read_text(encoding="utf-8")
+    assert '.claude/hooks/' + HOOK_BASENAME + '"' in text, (
+        "nix/home.nix has no home.file entry for the guard, so a switch would "
+        "report success with the hook absent")
+
+
+def test_the_registrar_registers_it_on_pretooluse_bash():
+    text = REGISTRAR.read_text(encoding="utf-8")
+    assert '"' + HOOK_BASENAME + '"' in text, (
+        "the guard is not in MANAGED_HOOK_SCRIPTS, so its interpreter is never "
+        "pinned to an absolute store path")
+    marker = '~/.claude/hooks/' + HOOK_BASENAME
+    assert marker in text, "the guard is in no command table"
+    pre = text.split("PRE_BASH_CMDS", 1)
+    assert len(pre) == 2, "PRE_BASH_CMDS is gone from the registrar"
+    tail = pre[1].split("SINGLE_EVENT_CMDS", 1)[0]
+    assert marker in tail, (
+        "the guard is registered somewhere, but not on PreToolUse(Bash) — it "
+        "would never see a command")
+
+
+def test_the_rule_this_gate_enforces_still_exists():
+    """The gate is downstream of a rule; if the rule is gone the gate is orphaned."""
+    text = RULES.read_text(encoding="utf-8")
+    assert "CLOSING CONDITION" in text
+
+
+# =========================================================================== #
+# 12. CONTROLS ON THIS FILE ITSELF.
+# =========================================================================== #
+def test_control_a_case_that_must_deny():
+    """Positive control: if this passes as an allow, the harness is wired to
+    nothing and every assertion above is vacuous."""
+    rc, out = verdict(CREATE + " --title t --body " + q(NO_CC))
+    assert out is not None, "the harness observed no deny on a case that must deny"
+    assert rc == 0
+
+
+def test_control_a_case_that_must_allow():
+    """Negative control: a guard nobody has watched ALLOW is as unproven as one
+    nobody has watched deny."""
+    rc, out = verdict(CREATE + " --title t --body " + q(CC))
+    assert out is None, "the harness observed a deny on a case that must allow"
+    assert rc == 0
+
+
+def test_control_the_detector_table_is_non_empty():
+    assert len(ACCEPTS) >= 15
+    assert len(REJECTS) >= 15
+    assert len(MENTIONS) >= 12
+    assert len(NOT_A_CREATE) >= 25

--- a/scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py
+++ b/scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py
@@ -66,6 +66,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -144,16 +145,34 @@ def q(s):
     return "'" + s.replace("'", "'\\''") + "'"
 
 
+# 🔴 A FRESH, EMPTY DIRECTORY — NOT A HARD-CODED `/tmp/…` NAME. Several cases
+# below assert a verdict that depends on a body-file path NOT existing
+# (`REASON_UNREADABLE`) or on one that a heredoc is about to write. A literal
+# `/tmp/x.md` makes those a claim about this machine's `/tmp`: a leftover file
+# from an earlier debugging session silently flips the verdict, and the test
+# reports green or red for a reason that has nothing to do with the code.
+# Module-scoped rather than `tmp_path` because the module-level command TABLES
+# need it at import time.
+SCRATCH = tempfile.mkdtemp(prefix="ghccg-test-")
+
+
+def scratch(name):
+    return os.path.join(SCRATCH, name)
+
+
 # --------------------------------------------------------------------------- #
 # drivers
 # --------------------------------------------------------------------------- #
-def verdict(cmd, env=None, tool_name="Bash", raw=None):
+def verdict(cmd, env=None, tool_name="Bash", raw=None, hook=None):
     """Run the REAL hook as a subprocess. Returns (returncode, parsed-json-or-None).
 
     A subprocess and not `guard.evaluate`, because the claims that matter most
     here — "always exits 0", "prints nothing on an allow" — are claims about the
     PROCESS. An in-process call cannot observe a traceback or a stray write to
     stdout.
+
+    `hook` points the run at a COPY of the hook, which is how the crash-path
+    tests drive a real import failure.
     """
     e = dict(os.environ)
     e.pop(OVERRIDE, None)
@@ -163,7 +182,7 @@ def verdict(cmd, env=None, tool_name="Bash", raw=None):
     payload = raw if raw is not None else json.dumps(
         {"tool_name": tool_name, "hook_event_name": "PreToolUse",
          "cwd": str(ROOT), "tool_input": {"command": cmd}})
-    p = subprocess.run([sys.executable, HOOK], input=payload,
+    p = subprocess.run([sys.executable, hook or HOOK], input=payload,
                        capture_output=True, text=True, env=e)
     assert p.returncode == 0, (
         f"a PreToolUse hook must exit 0; got {p.returncode}\n{p.stderr}")
@@ -549,27 +568,38 @@ def test_a_create_with_no_body_at_all_blocks():
 @pytest.mark.parametrize("body", [
     "$'## Closing condition\\nthe queue drains to 0'",
     "$'## Acceptance criteria\\nthe suite is green'",
-    '"## Closing condition\\nthe queue drains to 0"',
     "$'## Closing condition\\r\\nthe queue drains to 0'",
     "$'## Closing condition\\tthe queue drains\\nChecked by: a query'",
 ])
-def test_an_escaped_newline_body_is_decoded(body):
+def test_an_ansi_c_quoted_body_is_decoded(body):
     """🔴 `shlex` does not implement bash's `$'…'`, so a correctly-specified body
     written that way arrives as ONE line starting `$##` and DENIES. A gate that
-    false-positives on correct usage is the gate everyone routes around.
-
-    The plain double-quoted spelling is credited too. That is a DELIBERATE
-    over-acceptance, recorded in the guard's docstring: bash leaves `"\\n"` as two
-    literal characters, so GitHub would render the body on one line — but an
-    author who typed `\\n` between a heading and its content meant a newline, and
-    denying them is the false positive that gets a gate routed around."""
+    false-positives on correct usage is the gate everyone routes around."""
     assert ev(CREATE + " -t t --body " + body) is None, body
+
+
+@pytest.mark.parametrize("body", [
+    '"' + NO_CC + '\\n## Closing condition\\nit is done"',
+    '"## Closing condition\\nthe queue drains to 0"',
+    "'" + NO_CC + "\\n## Acceptance criteria\\nshipped'",
+])
+def test_a_literal_backslash_n_body_is_not_decoded(body):
+    """🔴 THE DECODE IS GATED ON `$`, AND THAT GATE IS A GUARD, NOT A DETAIL.
+
+    Decoding unconditionally let ANY body pass by appending about thirty
+    characters: bash leaves `"\\n"` as two literal characters, so the issue
+    GitHub renders carries no heading on any line. This was recorded in the
+    guard's docstring as a "deliberate over-acceptance"; it was a bypass, and the
+    docstring now says the opposite because the code does."""
+    assert MISSING_MARK in (ev(CREATE + " -t t --body " + body) or ""), body
 
 
 def test_the_ansi_c_decoding_cannot_manufacture_a_pass():
     """It only ever adds a candidate; a body with no heading still denies."""
     assert ev(CREATE + " -t t --body $'nothing specified\\nhere either'") is not None
     assert guard.escape_expanded("plain text") == "plain text"
+    assert guard.escape_expanded("a\\nb") == "a\\nb"
+    assert guard.escape_expanded("$a\\nb") == "a\nb"
 
 
 def test_a_lone_variable_inside_prose_is_not_opaque():
@@ -605,13 +635,85 @@ def test_a_tab_stripped_heredoc_body_is_readable():
     assert ev(cmd) is None
 
 
-def test_an_unrelated_heredoc_does_not_satisfy_a_create():
-    """🔴 The false ALLOW the blank-heredoc fallback is narrowed to avoid: a
-    well-specified heredoc written earlier on the line, for a DIFFERENT command,
-    must not let a create whose own body says nothing through."""
-    cmd = ("cat > /tmp/notes.md <<'EOF'\n" + CC + "\nEOF\n" +
-           CREATE + " -t t --body " + q(NO_CC))
-    assert MISSING_MARK in (ev(cmd) or ""), cmd
+# 🔴 THE SHAPE THAT RESCUED EVERY UNSEEABLE BODY. One `cat > /tmp/plan.md
+# <<'EOF' … EOF` — the ordinary agent workflow this gate watches — sat on the
+# same line, and EVERY fallback read `heredoc_bodies(<the whole line>)`. The
+# original test pinned only `--body '<no condition>'`, which is the one shape
+# that already worked; the five below all ALLOWED, in direct contradiction of
+# the docstring's headline "WHEN THE BODY CANNOT BE SEEN, THIS BLOCKS".
+PLAN_HEREDOC = "cat > " + scratch("notes.md") + " <<'EOF'\n" + CC + "\nEOF\n"
+
+UNRELATED_HEREDOC_CASES = [
+    (CREATE + " -t t --body " + q(NO_CC), MISSING_MARK),
+    (CREATE + " -t t --body-file -", REASON_STDIN),
+    (CREATE + ' -t t --body "$(generate-spec.sh)"', REASON_OPAQUE),
+    (CREATE + " -t t", REASON_NONE),
+    (CREATE + " -t t -b" + NO_CC.replace(" ", "-"), MISSING_MARK),
+    (CREATE + " -t t --body-file " + scratch("no-such-file.md"), REASON_UNREADABLE),
+]
+
+
+@pytest.mark.parametrize("tail,mark", UNRELATED_HEREDOC_CASES)
+def test_an_unrelated_heredoc_does_not_satisfy_a_create(tail, mark):
+    """🔴 A well-specified heredoc written earlier on the line, for a DIFFERENT
+    command, must not answer for a create — whatever the reason the create's own
+    body is unreadable. The mark asserted is the SPECIFIC reason, so a case
+    cannot pass by observing "it blocked"."""
+    assert mark in (ev(PLAN_HEREDOC + tail) or ""), tail
+
+
+def test_a_heredoc_that_writes_the_body_file_still_satisfies_it():
+    """🔴 The other side, and why the rescue is matched on the PATH rather than
+    deleted: the file does not exist yet when a PreToolUse hook runs, so a
+    correctly specified create would otherwise deny."""
+    target = scratch("body.md")
+    good = ("cat > " + target + " <<'EOF'\n" + CC + "\nEOF\n" +
+            CREATE + " -t t --body-file " + target)
+    assert ev(good) is None
+    # …and the same line whose heredoc writes some OTHER path does not.
+    other = ("cat > " + scratch("elsewhere.md") + " <<'EOF'\n" + CC + "\nEOF\n" +
+             CREATE + " -t t --body-file " + target)
+    assert REASON_UNREADABLE in (ev(other) or "")
+
+
+def test_an_opaque_body_is_not_rescued_by_a_heredoc_it_does_not_name():
+    """🔴 REACHABLE ONLY WHEN THE HEREDOC IS ON THE CREATE'S OWN COMMAND, which is
+    why the segment-scoping cases above could not see this guard at all — a
+    mutation sweep scored it SURVIVED. `gh` reads stdin for the body ONLY with
+    `--body-file -`, so a bare heredoc here feeds nothing; crediting it would let
+    `--body "$(gen.sh)"` — the shape the docstring promises to block — pass."""
+    cmd = (CREATE + " -t t --body \"$(generate-spec.sh)\" <<'EOF'\n" + CC + "\nEOF")
+    assert REASON_OPAQUE in (ev(cmd) or "")
+    # …while an argument that really DOES open the heredoc still resolves.
+    ok = CREATE + " -t t --body \"$(cat <<'EOF'\n" + CC + "\nEOF\n)\""
+    assert ev(ok) is None
+
+
+def test_an_inert_sink_feeding_a_process_substitution_is_marked_not_inert():
+    """🔴 PINNED AT THE FUNCTION, AND HERE IS WHY THAT IS THE HONEST PLACE.
+
+    `cat <<'EOF' > >(bash)` really executes the body, and `_PIPES_ONWARD` — the
+    "is this sink's output going somewhere executable" test — matched only
+    `[|&;]`, so it scored INERT. No end-to-end command currently discriminates
+    that mutant, because `command_spans` splits on the substitution's own parens
+    and re-exposes the body anyway. Two independent mechanisms is the point; a
+    test that leans on the OTHER one would report coverage this guard does not
+    have, so the claim is asserted where it is made."""
+    for sink in ("> >(bash)", "> >(sh -)", "< <(bash)"):
+        text = "cat <<'EOF' " + sink + "\n" + CREATE + " -t t --body x\nEOF"
+        got = guard.heredocs(text)
+        assert len(got) == 1, text
+        assert got[0].inert is False, text
+    plain = "cat <<'EOF' > " + scratch("n.md") + "\n" + CREATE + " -t t --body x\nEOF"
+    assert guard.heredocs(plain)[0].inert is True
+
+
+def test_a_body_file_dash_is_fed_only_by_its_own_commands_heredoc():
+    own = CREATE + " -t t --body-file - <<'EOF'\n" + CC + "\nEOF"
+    assert ev(own) is None
+    foreign = ("cat <<'EOF'\n" + CC + "\nEOF\n" +
+               CREATE + " -t t --body-file -")
+    assert REASON_STDIN in (ev(foreign) or "")
 
 
 def test_the_scrub_keeps_the_heredoc_terminator():
@@ -626,8 +728,40 @@ def test_the_scrub_keeps_the_heredoc_terminator():
 
 def test_a_here_string_is_not_read_as_a_heredoc():
     """A here-string has no body and no terminator; reading one as a heredoc would
-    swallow the rest of the line as prose the gate must not credit."""
-    assert ev(CREATE + " -t t --body-file - <<<" + q(CC)) is not None
+    swallow the rest of the line as prose the gate must not credit.
+
+    🔴 THE OLD VERSION OF THIS TEST PASSED WITH OR WITHOUT THE `(?<!<)` IT IS
+    NAMED FOR — it asserted only "something blocked", and deleting the protection
+    changed the REASON, not the verdict. Both halves below move when it goes: the
+    parse yields a body, and the create's verdict flips from "cannot see the
+    body" to "no closing condition" (about a body it invented)."""
+    swallowed = "wc -l <<<word\n" + CC + "\nword\n"
+    assert guard.heredoc_bodies(swallowed) == [], (
+        "`<<<word` was read as a heredoc opening tag `word`")
+    assert REASON_STDIN in (ev(CREATE + " -t t --body-file - <<<" + q(CC)) or "")
+
+
+def test_an_unparseable_heredoc_attachment_is_not_read_as_inert():
+    """🔴 `_attached_command`'s `""` fallback is the ALLOWLIST's fail-CLOSED half,
+    and it was untested: flipping the fallback to `"cat"` — i.e. treating an
+    unrecognisable attachment as a text sink — left all 251 tests green. It is
+    reachable whenever the operator opens the segment or is preceded only by an
+    assignment."""
+    assert guard._attached_command("<<'EOF'\nx\nEOF", 0) == ""
+    assert guard._attached_command("V=1 <<'EOF'\nx\nEOF", 4) == ""
+    for cmd in ("true | <<'EOF'\n" + CREATE + " -t t --body x\nEOF",
+                "V=1 <<'EOF'\n" + CREATE + " -t t --body x\nEOF"):
+        assert MISSING_MARK in (ev(cmd) or ""), cmd
+
+
+def test_a_process_substitution_sink_does_not_hide_a_create():
+    """The end-to-end half of the claim above: a body that really executes stays
+    in the invocation scan, while an ordinary file redirect does not."""
+    for cmd in ("cat <<'EOF' > >(bash)\n" + CREATE + " -t t --body x\nEOF",
+                "cat <<'EOF' > >(sh -)\n" + CREATE + " -t t --body x\nEOF"):
+        assert MISSING_MARK in (ev(cmd) or ""), cmd
+    assert ev("cat <<'EOF' > " + scratch("n.md") + "\n" + CREATE +
+              " -t t --body x\nEOF") is None
 
 
 # =========================================================================== #
@@ -755,6 +889,11 @@ def test_a_compound_shape_with_a_condition_is_allowed(cmd):
     assert ev(cmd) is None, cmd
 
 
+def _hd(body, tag="EOF"):
+    """The `--body "$(cat <<'TAG' … TAG)"` spelling the deny message recommends."""
+    return " --body \"$(cat <<'" + tag + "'\n" + body + "\n" + tag + "\n)\""
+
+
 def test_two_creates_are_judged_together():
     """🔴 A line that files two issues, one specified and one not, must not pass on
     the strength of the good one."""
@@ -764,6 +903,159 @@ def test_two_creates_are_judged_together():
     both = (CREATE + " -t a --body " + q(CC) + " && " +
             CREATE + " -t b --body " + q(AC))
     assert ev(both) is None
+
+
+@pytest.mark.parametrize("sep", [" && ", " ; ", "\n", " || "])
+def test_two_creates_in_the_heredoc_spelling_are_judged_separately(sep):
+    """🔴 THE SPELLING THIS GATE'S OWN `_HOW` MESSAGE RECOMMENDS, USED TWICE.
+
+    The plain `--body '…'` pinning above is the case that already worked. In the
+    heredoc spelling the shared core LIFTS the `$( … )`, so create #2's `--body`
+    arrives EMPTY, the no-body fallback fired, and it was handed BOTH heredocs on
+    the line — so the first issue's closing condition let the second through.
+    Each create now resolves inside its own command segment."""
+    bad = CREATE + " -t a" + _hd(CC) + sep + CREATE + " -t b" + _hd(NO_CC, "EOF2")
+    assert MISSING_MARK in (ev(bad) or ""), bad
+    # the FIRST one unspecified is caught too — not just the last
+    other = CREATE + " -t a" + _hd(NO_CC) + sep + CREATE + " -t b" + _hd(CC, "EOF2")
+    assert MISSING_MARK in (ev(other) or ""), other
+    good = CREATE + " -t a" + _hd(CC) + sep + CREATE + " -t b" + _hd(AC, "EOF2")
+    assert ev(good) is None, good
+
+
+def test_two_creates_in_the_heredoc_spelling_deny_through_the_real_process():
+    bad = (CREATE + " -t a" + _hd(CC) + " && " +
+           CREATE + " -t b" + _hd(NO_CC, "EOF2"))
+    assert MISSING_MARK in deny_reason(bad)
+
+
+# =========================================================================== #
+# 7b. FLAG TABLES — every spelling the real tools accept.
+#
+# 🔴 A FLAG TABLE IS A CLAIM ABOUT ANOTHER PROGRAM, so these are checked against
+# `gh issue create --help` / `gh api --help` / curl(1) on gh 2.97.0, not against
+# what the guard believes.
+# =========================================================================== #
+@pytest.mark.parametrize("flag", ["--type", "--parent", "--blocked-by",
+                                  "--blocking", "--recover"])
+def test_a_value_taking_gh_flag_before_the_verb_does_not_hide_the_create(flag):
+    """🔴 A value-taking flag MISSING from the table leaves its value in the
+    operand list, which breaks the `["issue", "create"]` PREFIX test — one flag,
+    one bypass. All five of these were missing."""
+    cmd = GH + " " + flag + " somevalue issue create -t t --body " + q(NO_CC)
+    assert MISSING_MARK in (ev(cmd) or ""), cmd
+
+
+@pytest.mark.parametrize("flag", ["--type Bug", "--parent 100",
+                                  "--blocked-by 200", "--blocking 300",
+                                  "--recover /tmp/r-821.json", "--editor",
+                                  "-e"])
+def test_a_real_gh_issue_create_flag_does_not_break_a_good_body(flag):
+    assert ev(CREATE + " -t t " + flag + " --body " + q(CC)) is None, flag
+
+
+def test_a_boolean_gh_flag_does_not_eat_the_next_token():
+    """🔴 `--editor` (`-e`) is BOOLEAN in gh; listing it as value-taking made it
+    swallow whatever followed.
+
+    The third assertion is the one that DISCRIMINATES, and it took a mutation
+    sweep to find: with `--editor` back in the value table the first two still
+    deny, because `_flag_values` looks the body flag up independently of the
+    table. What actually breaks is a flag whose presence is read through the
+    table — `--web`, which makes the call structurally exempt. Swallowed, the
+    create denies, i.e. a correct call is blocked."""
+    assert MISSING_MARK in (ev(CREATE + " --editor --body " + q(NO_CC)) or "")
+    assert MISSING_MARK in (ev(CREATE + " -e --body " + q(NO_CC)) or "")
+    assert ev(CREATE + " --editor --web -t t") is None
+
+
+@pytest.mark.parametrize("cmd", [
+    CREATE + " -t t -b" + q(CC),
+    CREATE + " -t t -b" + q(AC),
+])
+def test_an_attached_short_body_flag_is_read(cmd):
+    """🔴 gh accepts `-b<body>` and `-F<path>`. Reading neither meant a CORRECTLY
+    specified create denied with "CANNOT SEE THE BODY" — the most confusing
+    message this gate can print, and the kind that gets a gate switched off."""
+    assert ev(cmd) is None, cmd
+
+
+def test_an_attached_short_body_flag_without_a_condition_denies():
+    reason = deny_reason(CREATE + " -t t -b" + q(NO_CC))
+    assert MISSING_MARK in reason
+    assert UNSEEABLE_MARK not in reason
+
+
+def test_an_attached_short_body_file_flag_is_read(tmp_path):
+    good = tmp_path / "good.md"
+    good.write_text(CC)
+    assert ev(CREATE + " -t t -F" + str(good)) is None
+    bad = tmp_path / "bad.md"
+    bad.write_text(NO_CC)
+    assert MISSING_MARK in (ev(CREATE + " -t t -F" + str(bad)) or "")
+
+
+CURL_ATTACHED = [
+    "curl --request=POST --data=" + q(json.dumps({"body": NO_CC})) +
+    " https://api.github.com/repos/o/r/issues",
+    "curl --url=https://api.github.com/repos/o/r/issues --data-raw=" +
+    q(json.dumps({"body": NO_CC})),
+    "curl -X POST https://api.github.com/repos/o/r/issues --json=" +
+    q(json.dumps({"body": NO_CC})),
+    "curl -XPOST https://api.github.com/repos/o/r/issues -d" +
+    q(json.dumps({"body": NO_CC})),
+    "curl --request POST --data-binary=" + q(json.dumps({"body": NO_CC})) +
+    " https://api.github.com/repos/o/r/issues",
+]
+
+
+@pytest.mark.parametrize("cmd", CURL_ATTACHED)
+def test_a_curl_name_equals_value_flag_is_still_classified(cmd):
+    """🔴 `_curl_parts` matched method/data/url flags as EXACT TOKENS, so
+    `--request=POST --data=…` was not classified as a create AT ALL — the gate
+    never ran, rather than running and passing."""
+    assert MISSING_MARK in (ev(cmd) or ""), cmd
+
+
+@pytest.mark.parametrize("cmd", [c.replace(json.dumps({"body": NO_CC}),
+                                           json.dumps({"body": CC}))
+                                 for c in CURL_ATTACHED])
+def test_a_curl_name_equals_value_flag_with_a_condition_is_allowed(cmd):
+    assert ev(cmd) is None, cmd
+
+
+@pytest.mark.parametrize("pair", ["-q -h", "--jq -w", "-H -h", "--cache -w",
+                                  "-t -h"])
+def test_a_gh_api_flag_value_that_looks_like_help_does_not_exempt(pair):
+    """🔴 `is_exempt_invocation` judged a `gh api` argv against the ISSUE flag
+    table, so gh api's OWN value flags were not skipped and a VALUE equal to
+    `-h`/`-w` exempted the create."""
+    cmd = GH + " api -X POST repos/o/r/issues " + pair + " -f body=" + q(NO_CC)
+    assert MISSING_MARK in (ev(cmd) or ""), cmd
+
+
+def test_gh_api_help_is_still_exempt():
+    assert ev(GH + " api --help repos/o/r/issues -f body=" + q(NO_CC)) is None
+
+
+def test_the_at_file_form_belongs_to_field_not_raw_field(tmp_path):
+    """🔴 gh documents `@<path>` as a `-F`/`--field` feature ONLY. Applying it to
+    `-f`/`--raw-field` read a file gh would send verbatim, AND denied a body that
+    merely opens with an @mention as an unreadable path."""
+    f = tmp_path / "b.md"
+    f.write_text(CC)
+    assert ev(GH + " api repos/o/r/issues -F body=@" + str(f)) is None
+    assert ev(GH + " api repos/o/r/issues --field body=@" + str(f)) is None
+    # `-f` sends the bytes, so the body IS `@<path>` and names no condition.
+    assert MISSING_MARK in (ev(GH + " api repos/o/r/issues -f body=@" + str(f)) or "")
+
+
+def test_a_body_opening_with_an_at_mention_is_read_as_a_body():
+    body = "@zach please pick this up\n\n" + CC
+    assert ev(GH + " api repos/o/r/issues -f body=" + q(body)) is None
+    assert ev(GH + " api repos/o/r/issues --raw-field body=" + q(body)) is None
+    assert MISSING_MARK in (
+        ev(GH + " api repos/o/r/issues -f body=" + q("@zach have a look")) or "")
 
 
 def test_a_quoted_verb_pair_is_one_token_and_never_matches():
@@ -798,10 +1090,64 @@ def test_a_near_miss_inline_spelling_does_not_override(spelling):
     assert ev(cmd) is not None, cmd
 
 
-def test_the_override_quoted_inside_a_body_does_not_disarm_the_gate():
+# 🔴 EVERY PLACE THE OVERRIDE STRING CAN SIT INSIDE A BODY, not just the one
+# that happened to work. The shipped regex anchored on `[\n;&|(){}`]`, so a
+# newline, a semicolon or a backtick INSIDE A QUOTED BODY read as a command
+# boundary and disarmed the gate. Only the mid-line case was pinned, which is
+# precisely the case the broken regex got right — a mutant narrowing the anchor
+# to `^` survived all 251 tests. The gate's own deny message names this string,
+# so an issue ABOUT this guard is the shape that walked it.
+OVERRIDE_IN_PROSE = [
+    NO_CC + "\nwe considered " + OVERRIDE_ON + " but did not use it",   # mid-line
+    NO_CC + "\n" + OVERRIDE_ON + "\nis the escape hatch",               # own line
+    NO_CC + " ; " + OVERRIDE_ON + " was considered",                    # after `;`
+    NO_CC + " `" + OVERRIDE_ON + "` in a code span",                    # backtick
+    NO_CC + " (" + OVERRIDE_ON + ") in parens",
+    NO_CC + " | " + OVERRIDE_ON + " after a pipe character",
+    NO_CC + " & " + OVERRIDE_ON + " after an ampersand",
+    "## Notes\n" + OVERRIDE_ON + "\n## Nothing else",
+]
+
+
+@pytest.mark.parametrize("body", OVERRIDE_IN_PROSE)
+def test_the_override_quoted_inside_a_body_does_not_disarm_the_gate(body):
     """🔴 A guard you can switch off by naming it in prose is not a guard."""
-    body = NO_CC + "\nwe considered " + OVERRIDE_ON + " but did not use it"
-    assert ev(CREATE + " -t t --body " + q(body)) is not None
+    assert MISSING_MARK in (ev(CREATE + " -t t --body " + q(body)) or ""), body
+
+
+@pytest.mark.parametrize("body", OVERRIDE_IN_PROSE[:4])
+def test_the_override_in_prose_does_not_disarm_the_real_process(body):
+    assert deny_reason(CREATE + " -t t --body " + q(body))
+
+
+def test_the_override_inside_a_heredoc_body_does_not_disarm_the_gate():
+    cmd = (CREATE + " -t t --body \"$(cat <<'EOF'\n" + NO_CC + "\n" +
+           OVERRIDE_ON + "\nEOF\n)\"")
+    assert MISSING_MARK in (ev(cmd) or "")
+
+
+def test_the_override_inside_a_substitution_does_not_disarm_the_gate():
+    """🔴 An assignment inside `$( … )` sets a SUBSHELL's environment, so it can
+    never reach the `gh` process this gate is judging. Crediting it would be the
+    backtick hole under a second spelling."""
+    cmd = ("echo \"$(" + OVERRIDE_ON + " true)\" && " +
+           CREATE + " -t t --body " + q(NO_CC))
+    assert MISSING_MARK in (ev(cmd) or "")
+
+
+@pytest.mark.parametrize("cmd", [
+    OVERRIDE_ON + " " + CREATE + " -t t --body " + q(NO_CC),
+    "export " + OVERRIDE_ON + "; " + CREATE + " -t t --body " + q(NO_CC),
+    "true && " + OVERRIDE_ON + " " + CREATE + " -t t --body " + q(NO_CC),
+    "true; " + OVERRIDE_ON + " " + CREATE + " -t t --body " + q(NO_CC),
+    OVERRIDE_ON + " GH_TOKEN=x " + CREATE + " -t t --body " + q(NO_CC),
+    "GH_TOKEN=x " + OVERRIDE_ON + " " + CREATE + " -t t --body " + q(NO_CC),
+])
+def test_a_real_command_position_override_still_works(cmd):
+    """🔴 The other half. Tightening the override until the documented escape
+    hatch stops working would make this a permanently-red gate, which is worse
+    than no gate."""
+    assert ev(cmd) is None, cmd
 
 
 def test_the_override_is_named_in_both_deny_messages():
@@ -911,26 +1257,59 @@ def test_an_unrelated_command_is_allowed():
     assert_allowed("kubectl get pods -n monitoring")
 
 
-def test_the_crash_path_denies_a_create_shape():
-    """🔴 A crash must not become a silent allow. Driven by making the shared core
-    unimportable, which is the real failure this path exists for."""
-    e = dict(os.environ)
-    e.pop(OVERRIDE, None)
-    e["PYTHONPATH"] = ""
-    payload = json.dumps({"tool_name": "Bash", "hook_event_name": "PreToolUse",
-                          "tool_input": {"command": CREATE + " -t t --body " + q(NO_CC)}})
-    # Force the import to fail by pointing the hook at a directory with a
-    # poisoned guard_core earlier on sys.path is not possible from here, so drive
-    # the function directly with a core that raises.
-    class Boom:
-        def commands(self, _):
-            raise RuntimeError("boom")
+POISON = "poisoned-core-8f21"
 
-    with pytest.raises(RuntimeError):
-        guard.evaluate(CREATE + " -t t --body " + q(NO_CC), {}, Boom())
-    assert guard.CRASH_LOOKS_LIKE_CREATE.search(CREATE) is not None
-    assert OVERRIDE_ON in guard.crash_text(RuntimeError("boom"))
-    assert payload  # the shape a real hook receives; kept for the reader
+
+def _poisoned_hook(tmp_path):
+    """A COPY of the hook beside a `guard_core.py` that raises on import.
+
+    The hook puts its OWN directory first on `sys.path` before importing the
+    shared core, so this copy imports the poison and never the real module.
+    """
+    sandbox = tmp_path / "hooks"
+    sandbox.mkdir()
+    copy = sandbox / HOOK_BASENAME
+    copy.write_text(Path(HOOK).read_text(encoding="utf-8"), encoding="utf-8")
+    (sandbox / "guard_core.py").write_text(
+        "raise RuntimeError(" + repr(POISON) + ")\n", encoding="utf-8")
+    return str(copy)
+
+
+def test_the_crash_path_denies_a_create_shape(tmp_path):
+    """🔴 A crash must not become a silent allow — DRIVEN, not asserted around.
+
+    This test used to run neither `main()` nor the crash path: it asserted
+    `pytest.raises` on a local stub, a `re.search`, a substring of `crash_text`,
+    and `assert payload` (truthiness of a non-empty JSON string, vacuous). An
+    `if False:` mutant on the crash branch survived the WHOLE suite, so the
+    fail-closed backstop for the entire hook was unexercised. Its own comment
+    claimed driving a real import failure "is not possible from here"; it is —
+    copy the hook next to a `guard_core.py` that raises, and run the process.
+    """
+    rc, out = verdict(CREATE + " -t t --body " + q(NO_CC),
+                      hook=_poisoned_hook(tmp_path))
+    reason = reason_of(out)
+    assert rc == 0
+    assert "crashed while checking this command" in reason
+    assert POISON in reason, "the crash message must carry the real exception"
+    assert OVERRIDE_ON in reason
+
+
+def test_the_crash_path_still_allows_a_non_create(tmp_path):
+    """🔴 The negative control for the test above. A blanket deny-on-crash would
+    block `gh pr checks` on an unrelated bug, which is why the fallback is scoped
+    by a pure regex — and a test that only ever watches it DENY cannot tell a
+    scoped fallback from a blanket one."""
+    rc, out = verdict("gh pr checks 4", hook=_poisoned_hook(tmp_path))
+    assert rc == 0
+    assert out is None
+
+
+def test_the_crash_path_respects_the_override(tmp_path):
+    rc, out = verdict(OVERRIDE_ON + " " + CREATE + " -t t --body " + q(NO_CC),
+                      hook=_poisoned_hook(tmp_path))
+    assert rc == 0
+    assert out is None
 
 
 def test_the_crash_fallback_respects_the_override():
@@ -965,9 +1344,20 @@ def test_the_registrar_registers_it_on_pretooluse_bash():
 
 
 def test_the_rule_this_gate_enforces_still_exists():
-    """The gate is downstream of a rule; if the rule is gone the gate is orphaned."""
-    text = RULES.read_text(encoding="utf-8")
-    assert "CLOSING CONDITION" in text
+    """The gate is downstream of a rule; if the rule is gone the gate is orphaned.
+
+    🔴 A TWO-WORD SUBSTRING ANYWHERE IN THE FILE WAS TOO WEAK: any other bullet
+    mentioning the phrase satisfied it, so the test could not tell "the rule
+    exists" from "the words exist". Pinned instead as a RELATIONSHIP — the
+    requirement lives in the proactivity gate's `Out of scope` branch, and names
+    BOTH halves (what ends the item, and who or what checks it), which is exactly
+    what this hook asks a body to carry."""
+    text = " ".join(RULES.read_text(encoding="utf-8").split())
+    assert "Out of scope" in text, "the proactivity gate's branch is gone"
+    branch = text.split("Out of scope", 1)[1].split("**Fork**", 1)[0]
+    assert "CLOSING CONDITION that ends it and who or what checks it" in branch, (
+        "the Out-of-scope branch no longer requires a closing condition; this "
+        "gate is enforcing a rule that has moved or been dropped")
 
 
 # =========================================================================== #
@@ -994,3 +1384,124 @@ def test_control_the_detector_table_is_non_empty():
     assert len(REJECTS) >= 15
     assert len(MENTIONS) >= 12
     assert len(NOT_A_CREATE) >= 25
+    assert len(REALISTIC_ALLOWS) >= 30
+    assert len(OVERRIDE_IN_PROSE) >= 6
+
+
+# =========================================================================== #
+# 13. 🔴 THE ALLOW DIRECTION, AS ONE BATTERY.
+#
+# The tightenings this file's newer cases pin all move in the DENY direction, and
+# a gate that starts false-positiving gets switched off — at which point it
+# protects nothing. This is the standing regression set for the other half: every
+# entry is a shape a person or an agent would really type, and every one of them
+# must pass SILENTLY. It is deliberately redundant with the sections above,
+# because a battery you can run as one name is a battery that actually gets run
+# after a fix round.
+# =========================================================================== #
+REALISTIC_ALLOWS = [
+    # the plain spellings
+    CREATE + " --title t --body " + q(CC),
+    CREATE + " -t t -b " + q(AC),
+    CREATE + " -t t --body=" + q(CC),
+    CREATE + " -t t -b" + q(CC),
+    CREATE + " -t t --body " + q(CC + "\n\n## Notes\ncontext, links, a repro"),
+    CREATE + " -t t --body " + q("## Summary\nprose first\n\n" + CC),
+    CREATE + " -t t --body $'## Closing condition\\nthe queue drains to 0'",
+    # the heredoc spellings the deny message recommends
+    CREATE + " -t t --body \"$(cat <<'EOF'\n" + CC + "\nEOF\n)\"",
+    CREATE + " -t t --body \"$(cat <<'EOF'\n" + AC + "\nEOF\n)\"",
+    CREATE + " -t t --body-file - <<'EOF'\n" + CC + "\nEOF",
+    "cat > " + scratch("allow.md") + " <<'EOF'\n" + CC + "\nEOF\n" +
+    CREATE + " -t t --body-file " + scratch("allow.md"),
+    # bodies that carry shell-ish prose
+    CREATE + " -t t --body " + q(CC + "\nrun `make test` and set $PATH first"),
+    CREATE + " -t t --body " + q(CC + "\nsee `gh issue list; gh pr list`"),
+    CREATE + " -t t --body " + q(CC + "\n```\nkubectl get pods -n monitoring\n```"),
+    CREATE + " -t t --body " + q(CC + "\ncost is $5 & rising | fast"),
+    CREATE + " -t t --body " + q("## Acceptance criteria\n- [ ] a\n- [ ] b"),
+    # flags around the body
+    CREATE + " -t t -l bug -a zach -m sprint-3 --body " + q(CC),
+    CREATE + " -t t --type Bug --parent 100 --body " + q(CC),
+    CREATE + " -t t --blocked-by 200,201 --blocking 300 --body " + q(CC),
+    CREATE + " -R owner/repo -t t --body " + q(CC),
+    GH + " -R owner/repo issue create -t t --body " + q(CC),
+    CREATE + " -t t --project Roadmap -T bug-report --body " + q(CC),
+    # compounds and wrappers
+    "true && " + CREATE + " -t t --body " + q(CC),
+    "git -C /tmp/x log -1 && " + CREATE + " -t t --body " + q(CC),
+    'bash -c "' + CREATE + " -t t --body '" + CC + "'\"",
+    "sudo " + CREATE + " -t t --body " + q(CC),
+    "timeout 60 " + CREATE + " -t t --body " + q(CC),
+    "GH_TOKEN=x " + CREATE + " -t t --body " + q(CC),
+    CREATE + " -t a --body " + q(CC) + " && " + CREATE + " -t b --body " + q(AC),
+    # the API routes
+    GH + " api repos/o/r/issues -f title=t -f body=" + q(CC),
+    GH + " api -X POST repos/o/r/issues -F body=" + q(AC),
+    "curl -X POST -H 'Accept: application/vnd.github+json' "
+    "https://api.github.com/repos/o/r/issues -d " + q(json.dumps({"body": CC})),
+    "curl --request=POST --data=" + q(json.dumps({"body": AC})) +
+    " https://api.github.com/repos/o/r/issues",
+    # the documented escape hatches
+    OVERRIDE_ON + " " + CREATE + " -t t --body " + q(NO_CC),
+    CREATE + " --web -t t",
+    CREATE + " --help",
+]
+
+
+@pytest.mark.parametrize("cmd", REALISTIC_ALLOWS)
+def test_a_realistic_correct_call_is_allowed(cmd):
+    assert ev(cmd) is None, cmd
+
+
+@pytest.mark.parametrize("cmd", REALISTIC_ALLOWS[:12])
+def test_a_realistic_correct_call_is_allowed_through_the_real_process(cmd):
+    assert_allowed(cmd)
+
+
+@pytest.mark.parametrize("cmd", [
+    "then " + CREATE + " -t t --body " + q(NO_CC),
+    "do " + CREATE + " -t t --body " + q(NO_CC),
+    "else " + CREATE + " -t t --body " + q(NO_CC),
+    "if true; then " + CREATE + " -t t --body " + q(NO_CC) + "; fi",
+    "while read x; do " + CREATE + " -t t --body " + q(NO_CC) + "; done",
+])
+def test_a_shell_keyword_prefix_is_a_KNOWN_UNCOVERED_ROUTE(cmd):
+    """🔴 PINNED AS A GAP, NOT LEFT FOR SOMEONE TO REDISCOVER — and PRE-EXISTING,
+    identical on the pre-fix hook.
+
+    `guard_core._peel_variants` peels wrappers and `VAR=` assignments but not
+    shell keywords, so a create inside a compound statement has argv[0] == `then`
+    and is not classified as `gh` at all. Fixing it means widening the shared
+    peeler, which `bash-guard.py` also depends on — its own change, its own blast
+    radius. This is the docstring's NOT-COVERED entry made machine-readable, so
+    the claim cannot rot: if the peeler is widened, these go red and the
+    docstring entry has to go with them."""
+    assert ev(cmd) is None, cmd
+
+
+@pytest.mark.parametrize("word", ["time", "command", "exec", "eval"])
+def test_a_non_keyword_prefix_does_still_reach_the_gate(word):
+    """The boundary of the gap above — asserted, because a NOT-COVERED entry that
+    over-claims is as misleading as one that under-claims."""
+    assert MISSING_MARK in (ev(word + " " + CREATE + " -t t --body " + q(NO_CC)) or "")
+
+
+def test_a_body_quoting_a_heredoc_operator_is_a_KNOWN_FALSE_POSITIVE():
+    """🔴 PINNED AS A LIMIT, NOT LEFT INVISIBLE — and it is PRE-EXISTING, byte for
+    byte identical on the pre-fix hook.
+
+    `heredocs()` is deliberately quote-BLIND (it has to find body prose inside a
+    `"$(cat <<'EOF' … )"`), so a `<<'EOF'` written inside a fenced code block in
+    an issue body looks like a real operator. `scrub_inert_heredocs` then blanks
+    those bytes for the invocation scan, which unbalances the argument's quote,
+    and the fallback tokeniser hands `--body` a fragment. The create denies with
+    "no closing condition" about a body that has one.
+
+    Fixing it means teaching the SCRUB about quoting while leaving body
+    resolution blind — a change to the mechanism the whole mention-is-not-an-
+    invocation requirement rests on, so it is recorded here rather than smuggled
+    into a fix round for something else. If you fix it, this test goes red: make
+    it an ALLOW assertion and move the case into REALISTIC_ALLOWS."""
+    body = CC + "\n```\ncat <<'EOF' > x\nEOF\n```"
+    assert MISSING_MARK in (ev(CREATE + " -t t --body " + q(body)) or "")

--- a/scripts/claude-hooks/tests/test_on_disk_artifact_names.py
+++ b/scripts/claude-hooks/tests/test_on_disk_artifact_names.py
@@ -528,6 +528,13 @@ OWNS_NO_ON_DISK_STATE = {
                                  # the one hook here that is deliberately memoryless:
                                  # a per-session "already asked" counter would let a
                                  # second create in the same turn through unchecked.
+    "gh-issue-closing-condition-guard.py",  # stateless for the same reason as its
+                                 # twin above: the verdict is a pure function of the
+                                 # command text plus any --body-file it READS. It
+                                 # writes nothing and keeps no throttle, deliberately
+                                 # — a per-session "already asked" counter would let
+                                 # a second create in the same turn through
+                                 # unchecked.
     "bash-guard.py",             # thin wrapper over guard_core.py
     "bg-command-capture.py",     # delegates every path to lib/bg_command_capture.py,
                                  # exactly as agent-ledger-hook.py does. Its names

--- a/scripts/claude-hooks/tests/test_register_nudge_hook.py
+++ b/scripts/claude-hooks/tests/test_register_nudge_hook.py
@@ -131,6 +131,10 @@ BASH_GUARD = PY + " ~/.claude/hooks/bash-guard.py"
 # It is instrumentation: no permissionDecision, no stdout, exit 0 always, so it
 # widens what PreToolUse OBSERVES and not what it can refuse.
 BG_CAPTURE = PY + " ~/.claude/hooks/bg-command-capture.py"
+# The gh-issue closing-condition gate — the THIRD entry PRE_BASH_CMDS owns, and
+# the second in it that can REFUSE a command. It denies a `gh issue create` whose
+# body names no closing condition.
+GH_ISSUE = PY + " ~/.claude/hooks/gh-issue-closing-condition-guard.py"
 
 # The pre-migration spellings, i.e. what is on both hosts right now.
 OLD_BASH_GUARD = "python3 ~/.claude/hooks/bash-guard.py"
@@ -289,13 +293,16 @@ with tempfile.TemporaryDirectory() as tmp:
     # owns — asserted by identity, not by a count, so "gained an entry" cannot be
     # confused with "gained the right entry". Before PRE_BASH_CMDS existed this
     # read `len(pre_entries) == 3`; PreToolUse was rewrite-only then.
-    check("6: PreToolUse gained exactly TWO entries, and they are the two the "
-          "append table owns — the interview guard and the capture log",
-          len(pre_entries) == 5
+    check("6: PreToolUse gained exactly THREE entries, and they are the three "
+          "the append table owns — the interview guard, the capture log and the "
+          "gh-issue closing-condition gate",
+          len(pre_entries) == 6
           and pre_entries[3]["hooks"][0]["command"] == INTERVIEW
           and pre_entries[3].get("matcher") == "Bash"
           and pre_entries[4]["hooks"][0]["command"] == BG_CAPTURE
-          and pre_entries[4].get("matcher") == "Bash")
+          and pre_entries[4].get("matcher") == "Bash"
+          and pre_entries[5]["hooks"][0]["command"] == GH_ISSUE
+          and pre_entries[5].get("matcher") == "Bash")
     check("6: the three pre-existing PreToolUse entries kept their positions",
           [e["hooks"][0]["command"] for e in pre_entries[:3]]
           == [FOREIGN_ELSEWHERE, BASH_GUARD, FOREIGN_UNMANAGED_HOOK])
@@ -312,13 +319,15 @@ with tempfile.TemporaryDirectory() as tmp:
     check("7: the two foreign .sh Stop hooks are untouched",
           TMUX_STOP in stop and CLAWGATE_STOP in stop)
     check("7: PreToolUse is the three commands it started with (one rewritten) "
-          "plus the two the append table owns",
+          "plus the three the append table owns",
           pre == [FOREIGN_ELSEWHERE, BASH_GUARD, FOREIGN_UNMANAGED_HOOK,
-                  INTERVIEW, BG_CAPTURE])
+                  INTERVIEW, BG_CAPTURE, GH_ISSUE])
     check("7: the interview guard is registered exactly once",
           pre.count(INTERVIEW) == 1)
     check("7: the capture log is registered exactly once",
           pre.count(BG_CAPTURE) == 1)
+    check("7: the gh-issue closing-condition gate is registered exactly once",
+          pre.count(GH_ISSUE) == 1)
 
     check("2: both PostToolUse nudges preserved",
           any(c.endswith("/audit-pr-nudge.py") for c in cmds(d, "PostToolUse"))
@@ -530,9 +539,9 @@ with tempfile.TemporaryDirectory() as tmp:
         d4 = json.load(f)
     check("10: every unrecognised command came back BYTE-IDENTICAL, in place",
           cmds(d4, "PreToolUse")[:len(UNRECOGNISED)] == UNRECOGNISED)
-    check("10: ...and the ONLY things added to PreToolUse are the two the append "
-          "table owns",
-          cmds(d4, "PreToolUse") == UNRECOGNISED + [INTERVIEW, BG_CAPTURE])
+    check("10: ...and the ONLY things added to PreToolUse are the three the "
+          "append table owns",
+          cmds(d4, "PreToolUse") == UNRECOGNISED + [INTERVIEW, BG_CAPTURE, GH_ISSUE])
     # Anti-vacuity: this run DID rewrite/append elsewhere in the same file, so
     # the check above is about the recogniser and not about a run that no-oped.
     check("10: ...while the run did its normal work on the same file",
@@ -757,7 +766,8 @@ with tempfile.TemporaryDirectory() as tmp:
     # removed. Its registration belongs to the host.
     check("12: the doubled bash-guard entry is PINNED but NOT deleted",
           entries(d12, "PreToolUse") == [("Bash", BASH_GUARD), ("Bash", BASH_GUARD),
-                                         ("Bash", INTERVIEW), ("Bash", BG_CAPTURE)])
+                                         ("Bash", INTERVIEW), ("Bash", BG_CAPTURE),
+                                         ("Bash", GH_ISSUE)])
     # The first bash-guard entry keeps both keys this script knows nothing about.
     check("12: the surviving bash-guard entry kept its foreign keys",
           d12["hooks"]["PreToolUse"][0].get("description")
@@ -906,8 +916,9 @@ for hostile, why, hostile_cwd, expected_reason in HOSTILE_OVERRIDES:
         # growth guard's own failure mode inverted.
         # 18 -> 19: base-clone-staleness.sh joined SINGLE_EVENT_CMDS on
         # SessionStart, so one converged run holds one more command.
-        check(tag + ": three consecutive runs hold exactly 19 hook commands",
-              counts == [19, 19, 19])
+        # 19 -> 20: gh-issue-closing-condition-guard.py joined PRE_BASH_CMDS.
+        check(tag + ": three consecutive runs hold exactly 20 hook commands",
+              counts == [20, 20, 20])
         with open(settings) as f:
             d13 = json.load(f)
         written = [c for ev in d13.get("hooks", {}) for c in cmds(d13, ev)
@@ -960,7 +971,8 @@ with tempfile.TemporaryDirectory() as tmp:
     with open(settings) as f:
         d14 = json.load(f)
     check("14: every unpinnable command came back BYTE-IDENTICAL",
-          cmds(d14, "PreToolUse") == UNPINNABLE + SILENT + [INTERVIEW, BG_CAPTURE])
+          cmds(d14, "PreToolUse") == UNPINNABLE + SILENT + [INTERVIEW, BG_CAPTURE,
+                                                            GH_ISSUE])
     check("14: exactly one warning per unpinnable command, and no more",
           p14.stderr.count("is not in the form this script can pin") == 5)
     for c in UNPINNABLE:

--- a/scripts/claude-hooks/tests/test_registrar_activation.py
+++ b/scripts/claude-hooks/tests/test_registrar_activation.py
@@ -93,6 +93,7 @@ WRITEBACK = HOOK_PY + " ~/.claude/hooks/clawgate-writeback-guard.py"
 INTERVIEW = HOOK_PY + " ~/.claude/hooks/clawgate-task-interview-guard.py"
 BASH_GUARD = HOOK_PY + " ~/.claude/hooks/bash-guard.py"
 BG_CAPTURE = HOOK_PY + " ~/.claude/hooks/bg-command-capture.py"
+GH_ISSUE = HOOK_PY + " ~/.claude/hooks/gh-issue-closing-condition-guard.py"
 CLAWGATE_STOP = "/home/zach/.claude/clawgate-stop-hook.sh"
 TMUX_STOP = "~/.config/tmux/task-hook.sh"
 
@@ -252,10 +253,14 @@ def test_unrelated_settings_content_is_untouched(tmp_path):
     # task interview guard, and the backgrounded-command capture log (868ktvqf9),
     # which is INSTRUMENTATION — it emits no permissionDecision and cannot refuse a
     # command, so its presence here widens what PreToolUse OBSERVES and not what it
-    # can block. Asserted as a whole-list equality, IN ORDER, so a fourth entry or a
-    # doubled bash-guard fails it — the strictness is the point, and is why adding a
-    # PreToolUse hook has to come through this line.
-    assert pre == [BASH_GUARD, INTERVIEW, BG_CAPTURE], pre
+    # can block. Asserted as a whole-list equality, IN ORDER, so an unexpected entry
+    # or a doubled bash-guard fails it — the strictness is the point, and is why
+    # adding a PreToolUse hook has to come through this line.
+    #
+    # 2026-08-25: GH_ISSUE joins them — the fourth entry and the THIRD that can
+    # refuse, denying a `gh issue create` whose body names no closing condition. It
+    # came through this line, as intended.
+    assert pre == [BASH_GUARD, INTERVIEW, BG_CAPTURE, GH_ISSUE], pre
 
 
 def test_a_settings_file_that_already_has_the_nudge_is_left_byte_identical(tmp_path):

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1715,7 +1715,20 @@ TARGET_FLOORS=(
   # heredoc operator — which pin the docstring's NOT-COVERED entries so the
   # claims cannot rot silently.
   #   _suggested_floor 383 = 383 - min(50, max(1, 383/20 = 19)) = 383 - 19 = 364.
-  "scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py|364"
+  #
+  # 2026-08-25, the same-physical-line heredoc attribution fix (B2 reopened by
+  # 2bd3d1e7): 383 -> 394 collected, 0 skipped. +11 = a 7-case table for two
+  # heredoc openers on ONE line (`&&`, `;`, `| tee`, no body flag, `<<-`, CRLF,
+  # three chained), each watched RED at 2bd3d1e7 and green here; the ALLOW-
+  # direction case on that same shape (also red at 2bd3d1e7); and three INVARIANT
+  # guards, labelled as such in the file because they were green at that ref and
+  # are not regression coverage — they exist because the mutation sweep found
+  # nothing else that could see the literal B2 mutant or the override-after-a-
+  # heredoc path. That sweep, run under PYTHONDONTWRITEBYTECODE=1 in a per-mutant
+  # copy of the tree, killed 6/6 real mutants with the positive control also
+  # killed. ZERO new skips, so EXPECTED_SKIPS is untouched.
+  #   _suggested_floor 394 = 394 - min(50, max(1, 394/20 = 19)) = 394 - 19 = 375.
+  "scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py|375"
   # 2026-08-18, the on-disk artifact-name registry arrives as a NEW target: 13
   # collected. Deliberately small — one test per module whose names it pins, plus the
   # two-sided classification guard that fails when a hook module appears or vanishes.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -682,6 +682,17 @@ HERMETIC_TARGETS=(
   # load-bearing half, so they are gated here rather than left to the ungated
   # hand-rolled scripts beside it.
   scripts/claude-hooks/tests/test_clawgate_task_interview_guard.py
+  # Same reason again — a FILE, not the directory. The interview gate's twin on
+  # the OTHER board: this one denies a `gh issue create` whose body names no
+  # closing condition, and — deliberately — one whose body it cannot read at all.
+  # It is the third hook here that can BLOCK and it fires PreToolUse on EVERY Bash
+  # call, on `gh`, the most-typed tool in these repos. Its NON-matches are the
+  # load-bearing half and then some: a `grep`/`echo`/`rg` for the command string,
+  # a heredoc that documents it, `issue comment|edit|close|list|view`, a `gh api`
+  # GET and a curl to `…/issues/<n>/comments` must all pass, or the gate becomes
+  # the thing everyone routes around. Gated here rather than left to the ungated
+  # hand-rolled scripts beside it.
+  scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py
   # Same reason again — a FILE, not the directory. This one gates a CROSS-MODULE
   # class rather than any single hook: the on-disk names every hook's cache is made
   # of. Fifteen of them could be renamed with zero test movement, because writer and
@@ -1677,6 +1688,19 @@ TARGET_FLOORS=(
   # ZERO new skips, so EXPECTED_SKIPS is untouched. If this line conflicts with a
   # sibling branch, re-run the gate on the MERGED tree and copy what it prints.
   "scripts/claude-hooks/tests/test_clawgate_task_interview_guard.py|285"
+  # 2026-08-25, the gh-issue closing-condition gate arrives as a NEW target: 251
+  # collected, 0 skipped, measured on this branch. Gate's own rule applied to the
+  # gate's own count:
+  #   _suggested_floor 251 = 251 - min(50, max(1, 251/20 = 12)) = 251 - 12 = 239.
+  # The suite is deliberately weighted toward the ALLOW direction — 17 detector
+  # accepts, 18 mention shapes, 30 non-create verbs — because this hook can block
+  # and it watches `gh`. A 32-mutant sweep run under PYTHONDONTWRITEBYTECODE=1,
+  # each edit verified applied by reading the file back, killed 31/31 real
+  # mutants; the comment-only negative control survived, which is what proves the
+  # sweep can report SURVIVED at all. ZERO new skips, so EXPECTED_SKIPS is
+  # untouched. If this line conflicts with a sibling branch, re-run the gate on
+  # the MERGED tree and copy what it prints.
+  "scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py|239"
   # 2026-08-18, the on-disk artifact-name registry arrives as a NEW target: 13
   # collected. Deliberately small — one test per module whose names it pins, plus the
   # two-sided classification guard that fails when a hook module appears or vanishes.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1700,7 +1700,22 @@ TARGET_FLOORS=(
   # sweep can report SURVIVED at all. ZERO new skips, so EXPECTED_SKIPS is
   # untouched. If this line conflicts with a sibling branch, re-run the gate on
   # the MERGED tree and copy what it prints.
-  "scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py|239"
+  #
+  # 2026-08-25, the audit fix round on the same branch: 251 -> 383 collected, 0
+  # skipped. +132 because the audit found three 🔴 bypasses whose PINNING TESTS
+  # each asserted only the one shape that already worked — the override quoted in
+  # a body (only mid-line was pinned, and only mid-line worked), an unrelated
+  # heredoc rescuing an unseeable body (only `--body '<no condition>'` was pinned,
+  # five other shapes ALLOWED), and two creates on a line (only the plain `--body`
+  # spelling was pinned, the heredoc spelling passed). Each is now a table. The
+  # rest is the ALLOW-direction regression battery (36 realistic correct calls,
+  # asserted to pass silently) plus the crash-path tests, which previously ran
+  # neither `main()` nor the crash branch at all.
+  # Plus two KNOWN-GAP tables — a shell-keyword prefix and a body quoting a
+  # heredoc operator — which pin the docstring's NOT-COVERED entries so the
+  # claims cannot rot silently.
+  #   _suggested_floor 383 = 383 - min(50, max(1, 383/20 = 19)) = 383 - 19 = 364.
+  "scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py|364"
   # 2026-08-18, the on-disk artifact-name registry arrives as a NEW target: 13
   # collected. Deliberately small — one test per module whose names it pins, plus the
   # two-sided classification guard that fails when a hook module appears or vanishes.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1728,7 +1728,26 @@ TARGET_FLOORS=(
   # copy of the tree, killed 6/6 real mutants with the positive control also
   # killed. ZERO new skips, so EXPECTED_SKIPS is untouched.
   #   _suggested_floor 394 = 394 - min(50, max(1, 394/20 = 19)) = 394 - 19 = 375.
-  "scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py|375"
+  #
+  # 2026-08-25, bypasses A and B closed: 394 -> 474 collected, 0 skipped. +80.
+  #   A — a create inside a COMMAND SUBSTITUTION. `URL="$(gh issue create …)"`
+  #   allowed while the same line without the two quote characters denied, because
+  #   `guard_core._scan_raw` buffers a double-quoted region verbatim. 39 of the 79
+  #   were watched RED at c8d60161 and green here; the other 41 are INVARIANT
+  #   guards, labelled as such in the file — the ALLOW twin of every hidden-create
+  #   case, the single-quoted-prose battery, the unquoted/nested controls that
+  #   name the variable, and the brace-group gap pinned as a gap.
+  #   B — ONE EFFECTIVE BODY PER SOURCE, each rule measured against the shipped
+  #   tool: pflag last-wins with `--body-file` beating `--body` on gh 2.97.0, a
+  #   repeated `gh api` body field rejected outright, curl 8.17.0 MERGING repeated
+  #   data options (`&` for the `-d` family, plain concatenation for `--json`).
+  #   The mutation sweep — per-mutant tree copy, PYTHONDONTWRITEBYTECODE=1 —
+  #   killed 24/24 real mutants each by its OWN target test, positive control
+  #   (OVERRIDE_VALUE 1->2) also killed; two probe mutants SURVIVED and are
+  #   recorded as not-covered in the hook's own comments rather than counted.
+  #   ZERO new skips, so EXPECTED_SKIPS is untouched.
+  #   _suggested_floor 474 = 474 - min(50, max(1, 474/20 = 23)) = 474 - 23 = 451.
+  "scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py|451"
   # 2026-08-18, the on-disk artifact-name registry arrives as a NEW target: 13
   # collected. Deliberately small — one test per module whose names it pins, plus the
   # two-sided classification guard that fails when a hook module appears or vanishes.


### PR DESCRIPTION
## Why

`claude/RULES.md`'s "Out of scope" branch says a work item may only be filed once its **closing condition** and *who or what checks it* can be named; name neither and the honest move is to say so in the reply rather than mint an object nobody can close.

Two blind runs, same design, private solo repos so the outward-facing half of the rule could not confound:

| arm | issues filed | with a closing condition |
|---|---|---|
| unbriefed subagent | 6 | **0** |
| briefed subagent (same rule pasted verbatim) | 10 | **10** |

🔴 **Both agents held the rule** — subagents do receive `RULES.md`. (The earlier claim that they don't was a *false zero*: a transcript does not record the system prompt, so grepping transcripts for the rule text could never have found it.) The failure is **salience, not delivery**, which PRINCIPLES.md answers with a structural fix rather than more prose — the same arc `clawgate-task-interview-guard.py` already ran for its sibling rule.

## What this is

A `PreToolUse(Bash)` hook, modelled on `clawgate-task-interview-guard.py`: same module-docstring style, same fail-closed-on-an-unreadable-body stance, same one-spelling override, same delivery wiring.

### Routes covered

- `gh issue create …`
- `gh api …/issues` as a POST (explicit `-X POST`, or a `-f`/`-F`/`--input` payload, which is what makes gh default to POST)
- `curl` POST to a `…/issues` URL path

### Routes NOT covered — enumerated, not implied

- any other client: `python`/`requests`, `wget`, `httpie`, `node`, a compiled binary, the GitHub MCP tools — a `PreToolUse(Bash)` hook only ever sees Claude Code's Bash tool
- `xargs`-wrapped, `ssh <host> …`, and argv assembled from a variable
- **`gh issue create --web` / `-w`** — gh opens the browser's new-issue form and posts nothing, so the argv structurally cannot create. Exempt like `--help`, and recorded as a one-flag gap rather than hidden.
- the web UI, the mobile app, anything a systemd/cron process does
- 🔴 **the semantics.** It checks that a level-2 `## Closing condition` / `## Acceptance criteria` heading exists outside a code fence **with content under it**. Whether that content is an observable end-state rather than a restated fix is *not machine-checkable*: in the briefed arm above **all 10** issues had the heading and **most wrote the remedy under it**. The deny message says this in its own words — a guard that reads wider than it is stops people looking.

Only `create`. `comment` / `edit` / `close` / `reopen` / `list` / `view` / `status` / `develop` / `transfer`, `gh pr create`, a `gh api` GET and a curl to `…/issues/<n>/comments` all pass untouched.

### A mention is not an invocation

First-class requirement, not an edge case: this gate watches `gh`, and blocking a `grep`/`echo`/`rg`/heredoc that merely *quotes* the command would train everyone to reach for the override — a permanently-red gate is worse than no gate. So classification is **argv-based**, and a heredoc body attached to a text sink (`cat`/`tee`/`echo`/`printf`, not piped onward) is not read as commands. That sink list is an **allowlist**, so anything unrecognised keeps the body — over-block rather than silent pass — and `bash <<EOF` keeps full coverage.

### Fail-closed on an unreadable body

A generator substitution, `--body-file -` (stdin, which no PreToolUse hook can read → deny naming the remedy), a missing/unreadable/oversized file. Failing open there would make the guard walkable by changing the **shape** of the call rather than its content.

### One escape hatch, one spelling

`GH_ISSUE_NO_CLOSING_CONDITION=1` — command-position assignment or process env. `=true` / `=yes` / `=0` / empty do **not** work, and the spelling quoted inside a body does not disarm it.

## Is it live?

**It will be, on the next `home-manager switch`** — wired the same way every other guard here is: a `home.file` entry in `nix/home.nix` plus a `PRE_BASH_CMDS` entry in `register-nudge-hook.py`. Leaving it unregistered would reproduce #452 (ships, switch reports success, sits inert). Four ledger tests own those sets and each had to be updated by hand, which is what they are for.

Reverting is a one-line removal from `PRE_BASH_CMDS`.

## Validation

**Red/green matrix** (251 tests):

| tree | result |
|---|---|
| `origin/main`, guard file genuinely absent | **1 collection ERROR, 0 tests run** — the module cannot be imported, so this proves nothing about the tests |
| `origin/main` + a null stand-in encoding the pre-change behaviour (no gate, everything allowed) | **209 failed, 42 passed** — including `test_control_a_case_that_must_deny` |
| HEAD | **251 passed** |

The stand-in is what makes the red half meaningful; the absent-file run is reported as an error, not as a pass or a failure.

**Mutation sweep** — 32 mutants, `PYTHONDONTWRITEBYTECODE=1`, `__pycache__` deleted between mutants, **every edit verified applied by reading the file back**: 31/31 real mutants killed, comment-only negative control **SURVIVED** (which is what proves the sweep can report SURVIVED at all). Two survivors in the first sweep were real findings: one was an unreachable narrowing reading as coverage — deleted rather than kept — and the other a missing test for the unquoted-substitution body shape.

**End-to-end** through a realistic `PreToolUse` payload on stdin: deny / allow / allow-a-mention all as expected, exit 0 and empty stdout on the allows.

**Gates**: `scripts/run-tests.sh --check-floors` → PASS (new floor 239 for 251 collected, by the gate's own rule). `scripts/claude-hooks/tests/` → 2612 passed. `scripts/tests` failure set is **byte-identical** to `origin/main`'s (68 pre-existing, outside the nix devshell; none attributable here).

## Deliberately not done

- `claude/RULES.md` is untouched — the rule already exists; this enforces it.
- No issues filed for anything found.
- The closing-condition predicate is **pointed at**, never restated: the single source stays question 1 of `claude/skills/clawgate/flows/task-authoring.md`, and `scripts/tests/test_closing_condition_single_source.py` already covers the new file repo-wide, so this suite does not duplicate that claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Audit rounds since the original description (2026-08-25)

The description above documents the first commit. Three further rounds landed, and
one of them exists because the PR head was **red while every signal said green**.

### The measurement that started it

The prior session recorded "383 passed / 0 failed" for head `6e7aa7a3`. That was read
off a **dirty working tree**. Measured at the commit, in a clean checkout:

| tree | result |
|---|---|
| `6e7aa7a3` — what was actually on the PR | **380 passed, 3 FAILED** |
| the dirty tree it was measured in | 383 passed, 0 failed |

`6e7aa7a3` had shipped the B2 heredoc-scoping **tests without the implementation**.
A correct `gh issue create -t t --body-file - <<'EOF' … EOF` denied with *CANNOT SEE
THE BODY*. Both CI legs went green over it, because CI had not yet run on that head.

### Round 1 — the create's own heredoc (`2bd3d1e7`)

One line in `_shell_walk`: the segment span closed at the newline instead of at the
heredoc terminator, so the body fell into no span at all. The comment three lines
above already said the span "runs past the terminator so `heredoc_bodies(span)` still
finds it"; the code did not do it.

### Round 2 — that fix REOPENED B2 (`deee9f47`)

Found by an adversarial delta re-audit, confirmed by driving the real hook. When two
commands on one physical line each open a heredoc, bash queues the bodies in operator
order, so `skip.get(i + 1)` returns the **earlier** command's body. The create's span
swallowed the foreign body and its own was skipped entirely — exactly inverted:

```
cat <<'A' > plan.md && gh issue create -t t --body-file - <<'B'
## Closing condition
the alert clears for 24h
Checked by: the Grafana alert going green
A
make the pill nicer, you know the one
B
```
ALLOWed, while the body gh actually receives on stdin is `make the pill nicer, you
know the one`. Seven shapes were affected (`&&`, `;`, `| tee`, no body flag, `<<-`,
CRLF, three chained heredocs).

Fixed by attributing each heredoc to the segment containing its `<<` **offset** —
`_Heredoc.op`, the field whose own comment already said it "is what attributes a
heredoc to the COMMAND that opened it" and which `_shell_walk` had never read.
`command_spans` became `command_segments` returning reassembled text, because a
single `[lo, hi)` slice cannot express the answer when the bodies interleave.

### Round 3 — two more confirmed bypasses (`d84835f6`)

**A. A create inside a quoted command substitution was invisible.**
`URL="$(gh issue create -t t -b 'no closing condition')"` → ALLOW, while the same
line without the two quote characters → DENY. This is the single most natural shape
an agent writes (capture the issue URL). `guard_core.py` is **untouched**; the fix is
in the hook, in `_shell_walk` and in `_read_word` — the latter swallowed
`URL="$( … )"` whole as one assignment word, so the walk's `$(` branch never saw the
opener. The override widened with the coverage: an override in command position
*inside* the substitution now disarms that call, or the newly-covered shapes would be
the only ones with no way out.

**B. A duplicate body flag defeated the gate.** The gate aggregated candidates and
passed if **any** carried the heading, so ~40 characters of stock text bought a pass
on a body that never reaches GitHub. Now one effective body per source, each rule
**measured against the shipped tool** rather than assumed:

- `gh issue create` — `--body`/`-b` and `--body-file`/`-F` are pflag `StringVarP`, so
  a repeat is last-wins, and `--body-file` beats `--body` regardless of order.
- `gh api` — **not** last-wins: a repeated `body` field is a hard error
  (`unexpected override existing field under "body"`), so it is reported as unseeable.
- `curl` — **merges** rather than replacing: `&` for the `-d` family, plain
  concatenation for `--json`. Applying gh's rule here would have created false denials.

**C. Documented, not fixed.** `{ gh issue create …; }` and a function body still
ALLOW. Both are now in the docstring's NOT-COVERED enumeration and pinned by a test,
so the day the behaviour changes, someone is told.

### Verification

- Focused suite **251 → 474**, 0 skipped. Full repo gate `RESULT: PASS`, 16309 passed
  / 0 failed, both tiers.
- Every new regression test **watched RED at its own base ref** and green here;
  anything already green at that ref is labelled an *invariant guard* in the file and
  is not counted as regression coverage.
- Mutation sweeps run in per-mutant tree copies under `PYTHONDONTWRITEBYTECODE=1`,
  each mutant confirmed applied by reading the file back, each scored by **which**
  test failed rather than by an exit code, and each batch carrying a positive control
  that must die and a comment-only control that must survive.
- Three clauses probed and found **not distinguished by any test**. They are kept for
  their fail-closed direction and say so in their own comments rather than reading as
  covered.

### Known limits, stated rather than implied

- The gh/curl precedence rules come from probing the shipped binaries against invalid
  targets plus reading `cli/cli` v2.97.0 — no real issue was created to observe which
  body lands, since that would mint exactly the object this gate exists to prevent.
- `nix/home.nix` copies this hook into `/nix/store`, so **merging does not deploy it**.
  It takes effect on the next `home-manager switch`, and the thing to verify afterwards
  is the deployed copy (`readlink -f`), not the checkout.
