### PR TITLE
fix(escrow-verify): the advertised shell could not run its own command, and a mismatch never said WHAT chose the file

### DIFF
--- a/claudedocs/handoff-analyze-service-index-backup.md
+++ b/claudedocs/handoff-analyze-service-index-backup.md
@@ -344,15 +344,20 @@ not, which is why the same command behaved differently for the agent and the hum
 age identity file is the same size (fixed-width `# created:`, `# public key:` and key
 lines). Equal byte counts on both sides carry no information about whether the keys match.
 
-Public-key hashes, compared without printing key material — all four are distinct
-identities:
+Public-key hashes, compared without printing key material — all four are **distinct**
+identities. Three client checkouts carry their own key at a `…/.secrets/sops/age.key` path;
+they are not enumerated here (this repo is public) and which one it landed on does not
+change the conclusion:
 
 | identity | pubkey sha (first 16) |
 |---|---|
 | `homelab-talos/.secrets/age.key` (the real one) | `288c4d24cfdb5aa1` |
-| `civit/postgres-debezium-kafka-replication/.secrets/sops/age.key` | `7e3367f5a3a5d327` |
-| `civit/civitai-gpu-fleet/.secrets/sops/age.key` | `6643aa0a698317cf` |
-| `civit/datapacket-talos/.secrets/sops/age.key` | `8e6095ea38340cef` |
+| client checkout A | `7e3367f5a3a5d327` |
+| client checkout B | `6643aa0a698317cf` |
+| client checkout C | `8e6095ea38340cef` |
+
+Reproduce with `age-keygen -y <file> | sha256sum` — it prints the PUBLIC half only, so the
+comparison never handles secret material.
 
 **The on-disk homelab key is confirmed correct, independently of the vault.**
 `restore-verify.py --identity ~/workspace/homelab-talos/.secrets/age.key` → **rc=0**, all

--- a/claudedocs/handoff-analyze-service-index-backup.md
+++ b/claudedocs/handoff-analyze-service-index-backup.md
@@ -51,7 +51,11 @@ and close the one failure mode in it that is unrecoverable (no off-machine backu
    escrowed key still there, still byte-identical, and does it still *work*". Byte equality
    and working are different claims: `--decrypt-check` writes the **escrowed** bytes to a
    throwaway 0600 identity and decrypts a real artifact with them.
-   🔴 **Its unlocked path has never run.** See "The one link still untested".
+   🔴 **Its unlocked path ran once (2026-08-25) and did NOT settle the question** — it
+   compared against a client key an env var had redirected it to. The escrow's agreement
+   with the real `age.key` is **still unconfirmed since the 08-23 `cmp`**, and that older
+   claim is neither confirmed nor refuted by the 08-25 run. See "The one link still
+   untested" — and do not re-escrow on that run's advice.
 
 ### Verified live, end to end
 10 scopes, 201 commits compared, restored from the bucket → `age -d` → `git clone` →
@@ -271,11 +275,17 @@ systemctl --user list-timers analyze-service-index-backup.timer --all
 systemctl --user show analyze-service-index-backup.service -p Result
 
 # the escrow is still there, still correct, and still WORKS (needs the master password)
-nix-shell -p bitwarden-cli jq --run \
-  'export BW_SESSION="$(bw unlock --raw)"; python3 ~/workspace/devrc/scripts/analyze-service-index/escrow-verify.py --decrypt-check --host workbench-$(cat /etc/machine-id)'
+# 🔴 THE SHELL MUST CARRY minio AND THE IDENTITY MUST BE PINNED — see "The env
+# redirect" below. Both omissions cost a real run on 2026-08-25.
+nix-shell -p bitwarden-cli jq 'python3.withPackages(p:[p.minio])' --run \
+  'export BW_SESSION="$(bw unlock --raw)"; env -u SOPS_AGE_KEY_FILE -u ASIB_AGE_IDENTITY python3 ~/workspace/devrc/scripts/analyze-service-index/escrow-verify.py --decrypt-check --identity ~/workspace/homelab-talos/.secrets/age.key --host workbench-$(cat /etc/machine-id)'
 # no password to hand? this is still a real check — it must exit 12 VAULT-LOCKED,
-# promptly and without hanging, NOT sit waiting on an invisible prompt:
+# promptly and without hanging, NOT sit waiting on an invisible prompt.
+# MEASURED 2026-08-25: rc=12 in 2s.
 nix-shell -p bitwarden-cli jq --run 'python3 ~/workspace/devrc/scripts/analyze-service-index/escrow-verify.py'
+# and BEFORE spending a password, confirm which file the run will actually
+# compare against — no vault, no network:
+python3 ~/workspace/devrc/scripts/analyze-service-index/escrow-verify.py --print-plan
 
 # the index store's own verdict
 python3 ~/workspace/devrc/scripts/subsystem-audit.py
@@ -293,17 +303,69 @@ pgrep -f 'run-tests.sh|gate.sh' | while read -r p; do
 done   # none may equal ~/workspace/devrc/.git
 ```
 
-## The one link still untested — 🔴 THE ONLY THING BLOCKED ON A HUMAN
+## The one link still untested — 🔴 STILL THE ONLY THING BLOCKED ON A HUMAN
 
-**`escrow-verify.py`'s unlocked path has never run.** Everything above the vault boundary
-is synthetic: the real note fetch, the real byte comparison against the real `age.key`, and
-`--decrypt-check` against MinIO are covered only by an injected fake. One command with the
-master password exercises all three:
+**`escrow-verify.py`'s unlocked path has RUN ONCE, on 2026-08-25, and it did not settle
+the question** — it compared the escrow against the wrong file. Details in "The env
+redirect" below. So the claim below is unchanged: everything above the vault boundary is
+still synthetic — the real note fetch, the real byte comparison against the real `age.key`,
+and `--decrypt-check` against MinIO are covered only by an injected fake.
+
+🔴 **Do NOT re-escrow on the strength of that run.** What it proved is that the escrow
+differs from a **CivitAI client key**, which is not a fact about the escrow at all.
+
+The command below is the corrected one — it pins the identity and provisions `minio`.
+Both differences are load-bearing, and each was a separate failure on 2026-08-25:
 
 ```bash
-nix-shell -p bitwarden-cli jq --run \
-  'export BW_SESSION="$(bw unlock --raw)"; python3 ~/workspace/devrc/scripts/analyze-service-index/escrow-verify.py --decrypt-check --host workbench-$(cat /etc/machine-id)'
+nix-shell -p bitwarden-cli jq 'python3.withPackages(p:[p.minio])' --run \
+  'export BW_SESSION="$(bw unlock --raw)"; env -u SOPS_AGE_KEY_FILE -u ASIB_AGE_IDENTITY python3 ~/workspace/devrc/scripts/analyze-service-index/escrow-verify.py --decrypt-check --identity ~/workspace/homelab-talos/.secrets/age.key --host workbench-$(cat /etc/machine-id)'
 ```
+
+Validated to the vault boundary (`rc=12 VAULT-LOCKED` in 3s), so argv, `--identity`, the
+host label and the imports are all known-good; only the step the password opens is untried.
+
+### 🔴 The env redirect — what the 2026-08-25 run actually measured
+
+The run returned **`rc=22 BYTES-DIFFER-MATERIALLY`, "189 escrowed bytes vs 189 on disk"**,
+and its remedy said to re-escrow from the on-disk identity. Following that advice would
+have **overwritten a good escrow with a client's age key**. Two mechanisms fit that output
+and they demand opposite actions:
+
+- **A** — the escrow is stale/damaged → re-escrow.
+- **B** — the *on-disk* side was the wrong file → change nothing.
+
+**It was B, measured.** `resolve_identity()` reads `ASIB_AGE_IDENTITY` → `SOPS_AGE_KEY_FILE`
+→ the default. The command ran in an **interactive** shell (`!`/`.zshrc`), which had
+`SOPS_AGE_KEY_FILE` pointed into a **client repo**; the Bash tool's non-interactive zsh does
+not, which is why the same command behaved differently for the agent and the human.
+
+🔴 **"189 vs 189" is not corroboration — it is what two DIFFERENT keys look like.** Every
+age identity file is the same size (fixed-width `# created:`, `# public key:` and key
+lines). Equal byte counts on both sides carry no information about whether the keys match.
+
+Public-key hashes, compared without printing key material — all four are distinct
+identities:
+
+| identity | pubkey sha (first 16) |
+|---|---|
+| `homelab-talos/.secrets/age.key` (the real one) | `288c4d24cfdb5aa1` |
+| `civit/postgres-debezium-kafka-replication/.secrets/sops/age.key` | `7e3367f5a3a5d327` |
+| `civit/civitai-gpu-fleet/.secrets/sops/age.key` | `6643aa0a698317cf` |
+| `civit/datapacket-talos/.secrets/sops/age.key` | `8e6095ea38340cef` |
+
+**The on-disk homelab key is confirmed correct, independently of the vault.**
+`restore-verify.py --identity ~/workspace/homelab-talos/.secrets/age.key` → **rc=0**, all
+10 artifacts decrypted, 214 commits compared, `fsck OK`, 0 self-consistency-only, against
+artifacts stamped `20260824T094214Z` — the timer's own output. Two independent sources
+agree that path is the intended one: the systemd unit pins `SOPS_AGE_KEY_FILE` to it
+(`nix/home.nix:3312`), and it opens the bucket.
+
+**Both defects are fixed in this branch** (`fix/escrow-identity-provenance`): the advertised
+nix-shell is derived from a package ledger pinned against what the decrypt path imports, and
+a mismatch now names *what chose* the on-disk path — refusing to call the mismatch diagnosed
+when an env var did. `--print-plan` discloses a redirect before any password is spent.
+Matrix: both red at `a8089a51`, green at HEAD, demonstrated by execution.
 
 It also settles two assumptions **never measured against the real vault item**: that a
 Secure Note has `type == 2`, and that `notes` is present in `bw list items` output. A wrong
@@ -326,7 +388,9 @@ from the **web vault on another device** and paste it into a file — a path tha
 mangle whitespace. Worth doing once at leisure: open the note in the web vault, paste it
 into a scratch file, confirm 189 bytes / 3 lines.
 
-⚠ `bw` is **not installed** — run it as `nix-shell -p bitwarden-cli jq --run '…'`. Its
+⚠ `bw` is **not installed** — run it as `nix-shell -p bitwarden-cli jq --run '…'`, and add
+`'python3.withPackages(p:[p.minio])'` for `--decrypt-check`, which reaches MinIO through a
+**lazy** `minio` import and so dies mid-run, after the password, in a shell without it. Its
 server was repointed from the internal LAN name to the externally-trusted one
 (`bw config server` shows the current value; the old one survives as a historical
 `byServer` entry). The LAN endpoint serves a cert-manager **self-signed placeholder**

--- a/scripts/analyze-service-index/backup.py
+++ b/scripts/analyze-service-index/backup.py
@@ -463,17 +463,44 @@ def scope_remotes(scope: Path) -> list[str]:
 # --------------------------------------------------------------------------- #
 # age
 # --------------------------------------------------------------------------- #
-def resolve_identity() -> Path:
-    """Path to the operator's age identity file.
+# 🔴 THE RESOLUTION ORDER LIVES HERE ONCE, as data. `resolve_identity()`
+# delegates to `resolve_identity_with_source()` rather than repeating the loop:
+# a second copy of this order is a second thing to get wrong, and the two would
+# drift silently because both return a plausible path.
+IDENTITY_ENV_VARS = ("ASIB_AGE_IDENTITY", "SOPS_AGE_KEY_FILE")
+
+# What chose the identity, when nothing overrode it. A sentinel STRING rather
+# than None so every consumer formats one type, and so a message can never read
+# "chosen by None".
+IDENTITY_SOURCE_DEFAULT = "the built-in default"
+
+
+def resolve_identity_with_source() -> tuple[Path, str]:
+    """The operator's age identity file, AND what chose it.
 
     Order: ASIB_AGE_IDENTITY -> SOPS_AGE_KEY_FILE (the handle the homelab repos
     already use, per SECRETS.md) -> the default homelab-talos path.
+
+    🔴 THE SECOND ELEMENT IS NOT COSMETIC. `SOPS_AGE_KEY_FILE` is exported by
+    unrelated client work, and every age identity file is the SAME SIZE (fixed
+    -width `# created:`, `# public key:` and key lines), so a comparison against
+    the wrong one fails with two equal byte counts and looks exactly like a
+    damaged escrow. A consumer that reports only the PATH leaves the operator
+    unable to tell "your escrow is corrupt" from "you compared the wrong file" —
+    and the remedies are opposites. MEASURED 2026-08-25: that is precisely what
+    happened, and the advice a path-only message gave would have overwritten a
+    good escrow with an unrelated key.
     """
-    for var in ("ASIB_AGE_IDENTITY", "SOPS_AGE_KEY_FILE"):
+    for var in IDENTITY_ENV_VARS:
         v = os.environ.get(var)
         if v:
-            return Path(v)
-    return DEFAULT_IDENTITY
+            return Path(v), f"${var}"
+    return DEFAULT_IDENTITY, IDENTITY_SOURCE_DEFAULT
+
+
+def resolve_identity() -> Path:
+    """Path only. See `resolve_identity_with_source()` for the order."""
+    return resolve_identity_with_source()[0]
 
 
 def resolve_recipient(identity: Path) -> str:

--- a/scripts/analyze-service-index/backup.py
+++ b/scripts/analyze-service-index/backup.py
@@ -522,9 +522,16 @@ def same_identity_file(a: Path, b: Path) -> bool:
     """
     try:
         return a.expanduser().resolve() == b.expanduser().resolve()
-    except (OSError, RuntimeError):
-        # RuntimeError: a symlink loop. Fall back to the literal comparison
-        # rather than letting a path oddity crash a verifier.
+    except (OSError, ValueError, RuntimeError):
+        # 🔴 MEASURED on CPython 3.12: none of symlink loops, self-links,
+        # deep chains, ENAMETOOLONG, an unreadable parent or a deleted cwd
+        # raises here — `resolve(strict=False)` swallows them and returns a
+        # normalised path. So this is a BELT, not a live branch, and the
+        # earlier comment naming RuntimeError as "a symlink loop" was wrong
+        # about its own condition. `ValueError` (an embedded NUL) is the one
+        # that can actually escape, and is unreachable from argv or env.
+        # Falling back to the LITERAL comparison keeps the safe direction: two
+        # paths that are not textually equal stay "different", which warns.
         return a == b
 
 

--- a/scripts/analyze-service-index/backup.py
+++ b/scripts/analyze-service-index/backup.py
@@ -503,6 +503,31 @@ def resolve_identity() -> Path:
     return resolve_identity_with_source()[0]
 
 
+def same_identity_file(a: Path, b: Path) -> bool:
+    """Do two identity paths name the SAME FILE?
+
+    🔴 THE DISCRIMINATING STATE IS THE FILE, NOT WHAT NAMED IT. A caller that
+    asks "was an environment variable set?" gets the wrong answer twice over:
+    the deployed backup unit sets `SOPS_AGE_KEY_FILE` to the default path
+    (`nix/home.nix`), so the env var is set and nothing is redirected; and an
+    explicit `--identity` can point AT the default, which no environment
+    redirected at all. Branching on the mechanism made both of those read as
+    "NOT the default" — a confident wrong claim, and a permanently-red warning
+    on the subsystem's own normal configuration.
+
+    Symlinks are resolved, so a default path that is a link to the file an env
+    var names is correctly judged the SAME file. `resolve()` is non-strict, so
+    a path that does not exist compares by its normalised form rather than
+    raising — an absent identity is a separate, already-classified failure.
+    """
+    try:
+        return a.expanduser().resolve() == b.expanduser().resolve()
+    except (OSError, RuntimeError):
+        # RuntimeError: a symlink loop. Fall back to the literal comparison
+        # rather than letting a path oddity crash a verifier.
+        return a == b
+
+
 def resolve_recipient(identity: Path) -> str:
     """The age recipient to encrypt to, DERIVED from the identity we can decrypt with.
 

--- a/scripts/analyze-service-index/escrow-verify.py
+++ b/scripts/analyze-service-index/escrow-verify.py
@@ -179,8 +179,8 @@ DEFAULT_TIMEOUT = 60.0
 #
 # So the packages are a LEDGER and the hint is DERIVED from it. The ledger is
 # pinned against the modules the decrypt path imports by
-# `test_escrow_verify.py`, so the advertised shell and the code's actual
-# dependencies cannot drift apart silently.
+# `scripts/tests/test_analyze_service_index_escrow_verify.py`, so the advertised
+# shell and the code's actual dependencies cannot drift apart silently.
 NIX_SHELL_PACKAGES: tuple[str, ...] = (
     "bitwarden-cli",                       # `bw` itself
     "jq",                                  # the documented pipeline around it

--- a/scripts/analyze-service-index/escrow-verify.py
+++ b/scripts/analyze-service-index/escrow-verify.py
@@ -1286,6 +1286,22 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
 NON_DEFAULT_NOTE = "  <- NOT the default identity"
 
 
+def _undo_advice(identity_source: str) -> str:
+    """How to re-run against the default, phrased for THIS kind of source.
+
+    🔴 `env -u` is only meaningful for an ENVIRONMENT VARIABLE. The sources are
+    a closed set of shapes, and one combination is self-contradictory — the
+    built-in default paired with a path that is not the default — so it gets
+    generic advice rather than a sentence telling the operator to unset
+    something called "the built-in default".
+    """
+    if identity_source.startswith("$"):
+        return (f"Re-run with `env -u {identity_source.lstrip('$')} …` to "
+                f"compare against the default first.")
+    return (f"Re-run against {B.DEFAULT_IDENTITY} to compare against the "
+            f"default first.")
+
+
 def provenance_clauses(identity: Path, identity_source: str | None
                        ) -> tuple[str, str]:
     """`(chose, redirect)` — what to say about WHICH FILE was compared.
@@ -1340,8 +1356,7 @@ def provenance_clauses(identity: Path, identity_source: str | None
             f"both sides is what comparing two DIFFERENT keys looks like, not "
             f"evidence they are the same key. Re-escrowing now would overwrite a "
             f"possibly-good escrow with whatever {identity_source} happens to "
-            f"point at. Re-run with `env -u {identity_source.lstrip('$')} …` to "
-            f"compare against the default first.")
+            f"point at. {_undo_advice(identity_source)}")
     return chose, redirect
 
 

--- a/scripts/analyze-service-index/escrow-verify.py
+++ b/scripts/analyze-service-index/escrow-verify.py
@@ -1346,6 +1346,21 @@ def provenance_clauses(identity: Path, identity_source: str | None
             f"are the same key. Re-run against {B.DEFAULT_IDENTITY} before "
             f"concluding anything, and do NOT re-escrow from the file you just "
             f"named.")
+    elif not identity_source.startswith("$"):
+        # 🔴 NEITHER a flag NOR an environment variable. Reachable only through
+        # `run()`'s keyword API (the CLI pairs the default sentinel exclusively
+        # with DEFAULT_IDENTITY), but it RENDERS, and the first version said
+        # "the built-in default redirected the on-disk path away from …" — the
+        # same self-contradiction `_undo_advice` exists to prevent, one
+        # sentence earlier. Neutral wording that is true of any source.
+        redirect = (
+            f" 🔴 READ THIS BEFORE RE-ESCROWING: the on-disk path is not "
+            f"{B.DEFAULT_IDENTITY}, so a mismatch here is at least as likely to "
+            f"mean you compared the WRONG FILE as it is to mean the escrow is "
+            f"damaged — and the two remedies are opposites. Every age identity "
+            f"file is the same size, so equal byte counts on both sides is what "
+            f"comparing two DIFFERENT keys looks like, not evidence they are the "
+            f"same key. {_undo_advice(identity_source)}")
     else:
         redirect = (
             f" 🔴 READ THIS BEFORE RE-ESCROWING: {identity_source} redirected the "

--- a/scripts/analyze-service-index/escrow-verify.py
+++ b/scripts/analyze-service-index/escrow-verify.py
@@ -167,7 +167,40 @@ DEFAULT_TIMEOUT = 60.0
 # 🔴 `bw` IS NOT INSTALLED ON EITHER HOST — deliberately, it is a one-command
 # nix-shell away and nothing runs it unattended. The exact command lives here so
 # the failure message can hand it over instead of dying on FileNotFoundError.
-NIX_SHELL_HINT = "nix-shell -p bitwarden-cli jq --run '<command>'"
+#
+# 🔴 THE ADVERTISED SHELL MUST BE ABLE TO RUN THE COMMAND IT ADVERTISES.
+# MEASURED 2026-08-25: this hint provisioned `bitwarden-cli jq` ONLY, while
+# `--decrypt-check` reaches MinIO through `backup.MinioUploader`, whose `minio`
+# import is LAZY (inside the method, not at module import). So the advertised
+# shell parsed, started, unlocked the vault, and THEN died with
+# `ModuleNotFoundError: No module named 'minio'` — after the operator had
+# already typed the master password. A hint that cannot complete its own
+# invocation is worse than no hint: it is followed.
+#
+# So the packages are a LEDGER and the hint is DERIVED from it. The ledger is
+# pinned against the modules the decrypt path imports by
+# `test_escrow_verify.py`, so the advertised shell and the code's actual
+# dependencies cannot drift apart silently.
+NIX_SHELL_PACKAGES: tuple[str, ...] = (
+    "bitwarden-cli",                       # `bw` itself
+    "jq",                                  # the documented pipeline around it
+    "python3.withPackages(p:[p.minio])",   # --decrypt-check reaches the bucket
+)
+
+# The third-party Python modules the `--decrypt-check` path imports, named here
+# so the ledger above can be checked against them mechanically rather than by
+# someone remembering. `minio` is imported lazily by `backup.MinioUploader`.
+DECRYPT_PYTHON_MODULES: tuple[str, ...] = ("minio",)
+
+
+def _quote_nix_package(pkg: str) -> str:
+    """Shell-quote a `-p` argument that is a nix EXPRESSION, not a bare name."""
+    return f"'{pkg}'" if any(c in pkg for c in "()[]: ") else pkg
+
+
+NIX_SHELL_HINT = ("nix-shell -p "
+                  + " ".join(_quote_nix_package(p) for p in NIX_SHELL_PACKAGES)
+                  + " --run '<command>'")
 
 # 🔴 THERE IS DELIBERATELY NO `_DIR_MODE` ALIAS HERE. Directory mode is enforced
 # by `B._private_dir()`, which owns the number; re-exporting it would be a second
@@ -1216,6 +1249,7 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
 # the run
 # --------------------------------------------------------------------------- #
 def run(*, bw: BitwardenCLI, identity: Path, item_name: str,
+        identity_source: str | None = None,
         expect_server: str | None = None, decrypt: bool = False,
         bucket: str = DEFAULT_BUCKET, prefix: str | None = None,
         store: Path = DEFAULT_STORE, scope_filter: str | None = None,
@@ -1237,6 +1271,32 @@ def run(*, bw: BitwardenCLI, identity: Path, item_name: str,
     item = find_escrow_item(bw, item_name)
     escrow = read_note(item, item_name)
 
+    # 🔴 WHAT CHOSE THE ON-DISK FILE, stated in the mismatch messages below.
+    # Three branches, and the middle one is the whole point: an identity chosen
+    # by an environment variable is one an unrelated shell can redirect, so a
+    # mismatch is at least as likely to be a WRONG-FILE comparison as a damaged
+    # escrow. `None` means no caller stated a source — the messages then say
+    # NOTHING about provenance rather than asserting a default they cannot know.
+    if identity_source is None:
+        chose = ""
+        redirect = ""
+    elif identity_source == B.IDENTITY_SOURCE_DEFAULT:
+        chose = f" The on-disk path was chosen by {identity_source}."
+        redirect = ""
+    else:
+        chose = f" The on-disk path was chosen by {identity_source}, NOT by the default."
+        redirect = (
+            f" 🔴 READ THIS BEFORE RE-ESCROWING: because {identity_source} chose "
+            f"the on-disk path, a mismatch here is at least as likely to mean you "
+            f"compared the WRONG FILE as it is to mean the escrow is damaged — and "
+            f"the two remedies are opposites. Every age identity file is the same "
+            f"size, so equal byte counts on both sides is what comparing two "
+            f"DIFFERENT keys looks like, not evidence they are the same key. "
+            f"Re-escrowing now would overwrite a possibly-good escrow with "
+            f"whatever {identity_source} happens to point at. Re-run with "
+            f"--identity {B.DEFAULT_IDENTITY} to compare against the default "
+            f"first.")
+
     verdict_class = classify(escrow, disk)
     if verdict_class == CLASS_TRAILING_NEWLINE:
         raise EscrowError(
@@ -1248,7 +1308,7 @@ def run(*, bw: BitwardenCLI, identity: Path, item_name: str,
             f"identity still decrypts without its final newline, so the escrow "
             f"is very likely USABLE — but it is no longer a byte-for-byte copy, "
             f"and 'very likely' is not what a disaster-recovery artifact gets to "
-            f"be. Re-escrow the file. 🔴 --decrypt-check CANNOT confirm this: "
+            f"be.{chose} Re-escrow the file. 🔴 --decrypt-check CANNOT confirm this: "
             f"this refusal is raised BEFORE the decrypt step runs, so the flag "
             f"produces the identical message and tests nothing. To check the "
             f"trimmed bytes by hand, write them to a 0600 file yourself and pass "
@@ -1260,10 +1320,10 @@ def run(*, bw: BitwardenCLI, identity: Path, item_name: str,
             f"bytes vs {len(disk)} on disk, and they are not equal after "
             f"trailing newlines are removed. (The differing content is NOT "
             f"printed — it is key material; compare them by hand if you must.) "
-            f"One of the two copies is not the key this subsystem encrypts to. "
-            f"Re-escrow from the on-disk identity only after confirming the "
-            f"on-disk one is the one the bucket's artifacts open with — "
-            f"`restore-verify.py` answers that.")
+            f"One of the two copies is not the key this subsystem encrypts to."
+            f"{chose} Re-escrow from the on-disk identity only after confirming "
+            f"the on-disk one is the one the bucket's artifacts open with — "
+            f"`restore-verify.py` answers that.{redirect}")
 
     verdict = EscrowVerdict(
         item_name=item_name, server=server, server_pinned=pinned,
@@ -1291,12 +1351,20 @@ def run(*, bw: BitwardenCLI, identity: Path, item_name: str,
 
 def print_plan(*, identity: Path, item_name: str, expect_server: str | None,
                decrypt: bool, bucket: str, prefix: str, store: Path,
-               scope_filter: str | None, from_dir: Path | None) -> None:
+               scope_filter: str | None, from_dir: Path | None,
+               identity_source: str | None = None) -> None:
     """Pure text. Runs no `bw`, touches no network, reads no key material."""
     present = identity.is_file()
     size = identity.stat().st_size if present else 0
     print(f"identity:  {identity} ({size} bytes)" if present
           else f"identity:  {identity} (MISSING)")
+    # 🔴 The SIZE above cannot discriminate: every age identity file is the same
+    # size, so a redirected path looks identical here to the right one. The
+    # source is the only field on this line that can tell them apart.
+    if identity_source is not None:
+        note = ("" if identity_source == B.IDENTITY_SOURCE_DEFAULT else
+                "  <- NOT the default; an unrelated shell can set this")
+        print(f"chosen by: {identity_source}{note}")
     print(f"item:      {item_name!r} (exact name match; `bw list items "
           f"--search` is FUZZY, so its results are candidates)")
     print(f"type:      must be {ITEM_TYPE_SECURE_NOTE} (Secure Note) — checked "
@@ -1424,13 +1492,20 @@ def main(argv: list[str] | None = None) -> int:
                     help="print what would happen; run no `bw`, read no key")
     args = ap.parse_args(argv)
 
-    identity = args.identity or B.resolve_identity()
+    # 🔴 RESOLVE THE PATH AND WHAT CHOSE IT TOGETHER. An explicit --identity is
+    # its own source: it is the one choice the operator definitely made on
+    # purpose, so it must not be reported as an environment redirect.
+    if args.identity is not None:
+        identity, identity_source = args.identity, "the --identity flag"
+    else:
+        identity, identity_source = B.resolve_identity_with_source()
     prefix = (args.prefix if args.prefix is not None
               else args.host if args.host is not None
               else B.host_label())
 
     if args.print_plan:
-        print_plan(identity=identity, item_name=args.item_name,
+        print_plan(identity=identity, identity_source=identity_source,
+                   item_name=args.item_name,
                    expect_server=args.expect_server, decrypt=args.decrypt,
                    bucket=str(args.from_dir) if args.from_dir else args.bucket,
                    prefix=prefix, store=args.store, scope_filter=args.scope,
@@ -1446,6 +1521,7 @@ def main(argv: list[str] | None = None) -> int:
 
     def _go(work: Path | None) -> EscrowVerdict:
         return run(bw=bw, identity=identity, item_name=args.item_name,
+                   identity_source=identity_source,
                    expect_server=args.expect_server, decrypt=args.decrypt,
                    bucket=source, prefix=prefix, store=args.store,
                    scope_filter=args.scope, from_dir=args.from_dir,

--- a/scripts/analyze-service-index/escrow-verify.py
+++ b/scripts/analyze-service-index/escrow-verify.py
@@ -119,6 +119,7 @@ import contextlib
 import importlib.util
 import json
 import os
+import shlex
 import shutil
 import signal
 import subprocess
@@ -152,6 +153,13 @@ DEFAULT_ITEM_NAME = "age.key — SOPS + analyze-service-index backups"
 # trusting the name: any item type can be given any name, and a Login item whose
 # `notes` happen to hold something is not the escrow.
 ITEM_TYPE_SECURE_NOTE = 2
+
+# What `main()` reports when the operator passed `--identity` explicitly. A
+# named constant because `provenance_clauses()` BRANCHES on it: a flag is a
+# deliberate act, and wording it like an environment redirect sends the reader
+# chasing a variable they never set — and told them to re-run with the very
+# flag they had just used.
+IDENTITY_SOURCE_FLAG = "the --identity flag"
 
 # The file the escrowed bytes are written to under `--decrypt-check`. A module
 # constant so the test suite can assert the path is GONE afterwards by name,
@@ -194,8 +202,16 @@ DECRYPT_PYTHON_MODULES: tuple[str, ...] = ("minio",)
 
 
 def _quote_nix_package(pkg: str) -> str:
-    """Shell-quote a `-p` argument that is a nix EXPRESSION, not a bare name."""
-    return f"'{pkg}'" if any(c in pkg for c in "()[]: ") else pkg
+    """Shell-quote a `-p` argument that is a nix EXPRESSION, not a bare name.
+
+    🔴 `shlex.quote`, NOT a hand-rolled rule. The first revision tested for a
+    trigger set of metacharacters and wrapped in single quotes without escaping
+    any embedded quote — correct for today's two entries and wrong for the
+    first entry that contains a `'` or a `$`. `shlex.quote` leaves a bare name
+    bare and is correct for every input, which is the whole point of a hint the
+    operator pastes into a shell.
+    """
+    return shlex.quote(pkg)
 
 
 NIX_SHELL_HINT = ("nix-shell -p "
@@ -717,10 +733,23 @@ class EscrowVerdict:
     decrypt_commits: int | None = None
     decrypt_refs: int | None = None
 
+    # What chose `identity`, when a caller stated it. 🔴 DISCLOSED ON THE
+    # SUCCESS LINE TOO: "escrow OK — the Secure Note matches <path>" is exactly
+    # where a comparison against a file nobody intended is least likely to be
+    # questioned, and this module's stated stance is that a false all-clear is
+    # the worst outcome in this subsystem.
+    identity_source: str | None = None
+
     def line(self) -> str:
         head = (f"{PROG}: escrow OK — the Secure Note matches {self.identity} "
                 f"{self.classification} ({self.escrow_bytes} escrowed bytes vs "
                 f"{self.disk_bytes} on disk)")
+        if (self.identity_source is not None
+                and not B.same_identity_file(self.identity, B.DEFAULT_IDENTITY)):
+            head += (f" 🔴 NOTE: that is NOT the default identity — it was "
+                     f"chosen by {self.identity_source}, so this 'matches' is a "
+                     f"claim about that file, not about "
+                     f"{B.DEFAULT_IDENTITY}")
         # 🔴 TWO INDEPENDENT FACTS, NEVER MERGED INTO ONE SENTENCE: whether the
         # operator PINNED a server, and whether the session cross-check could be
         # made at all. The old line asserted the second unconditionally while
@@ -1246,6 +1275,77 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
 
 
 # --------------------------------------------------------------------------- #
+# provenance
+# --------------------------------------------------------------------------- #
+# The exact sentence `--print-plan` prints when the on-disk file is NOT the
+# default. A module constant so the test suite can pin it WHOLE: a guard that
+# asserts only the fragment "NOT the default" is satisfied by any other
+# sentence containing it, including a false one — which is how the first
+# revision of this feature shipped a line claiming an `--identity` flag could
+# be "set by an unrelated shell".
+NON_DEFAULT_NOTE = "  <- NOT the default identity"
+
+
+def provenance_clauses(identity: Path, identity_source: str | None
+                       ) -> tuple[str, str]:
+    """`(chose, redirect)` — what to say about WHICH FILE was compared.
+
+    🔴 THE TRIGGER IS THE FILE, NEVER THE MECHANISM. Both of the first
+    revision's branches were wrong, and both printed a confident FALSE
+    sentence on an ordinary invocation:
+
+      * `--identity <the default path>` — the documented recommended command —
+        was reported as "NOT by the default", and warned that "an unrelated
+        shell can set this" about a COMMAND-LINE FLAG.
+      * `SOPS_AGE_KEY_FILE=<the default path>` is what the deployed backup unit
+        itself sets, so the warning fired on the subsystem's own normal
+        configuration — a permanently-red warning, which trains a reader to
+        skip the one sentence that matters when it is finally true.
+
+    So: `redirect` is emitted only when the resolved file genuinely differs
+    from `DEFAULT_IDENTITY`, and the source name is carried as INFORMATION.
+    A source of `None` means no caller stated one — nothing is claimed about
+    provenance rather than a default being invented for them.
+    """
+    if identity_source is None:
+        return "", ""
+
+    if B.same_identity_file(identity, B.DEFAULT_IDENTITY):
+        # Named by anything at all — env var, flag or the built-in default —
+        # it is still the default FILE, so there is nothing to warn about.
+        return f" The on-disk path is the default identity, named by {identity_source}.", ""
+
+    chose = (f" The on-disk path is NOT the default identity; it was chosen by "
+             f"{identity_source}.")
+
+    if identity_source == IDENTITY_SOURCE_FLAG:
+        # A flag is a deliberate act by the person reading this message. Say
+        # what was compared, without implying something redirected them.
+        redirect = (
+            f" 🔴 READ THIS BEFORE RE-ESCROWING: you pointed --identity at a file "
+            f"that is NOT the identity this subsystem encrypts to, so this "
+            f"mismatch says nothing about whether the escrow is intact. Every age "
+            f"identity file is the same size, so equal byte counts on both sides "
+            f"is what comparing two DIFFERENT keys looks like, not evidence they "
+            f"are the same key. Re-run against {B.DEFAULT_IDENTITY} before "
+            f"concluding anything, and do NOT re-escrow from the file you just "
+            f"named.")
+    else:
+        redirect = (
+            f" 🔴 READ THIS BEFORE RE-ESCROWING: {identity_source} redirected the "
+            f"on-disk path away from {B.DEFAULT_IDENTITY}, so a mismatch here is "
+            f"at least as likely to mean you compared the WRONG FILE as it is to "
+            f"mean the escrow is damaged — and the two remedies are opposites. "
+            f"Every age identity file is the same size, so equal byte counts on "
+            f"both sides is what comparing two DIFFERENT keys looks like, not "
+            f"evidence they are the same key. Re-escrowing now would overwrite a "
+            f"possibly-good escrow with whatever {identity_source} happens to "
+            f"point at. Re-run with `env -u {identity_source.lstrip('$')} …` to "
+            f"compare against the default first.")
+    return chose, redirect
+
+
+# --------------------------------------------------------------------------- #
 # the run
 # --------------------------------------------------------------------------- #
 def run(*, bw: BitwardenCLI, identity: Path, item_name: str,
@@ -1271,31 +1371,7 @@ def run(*, bw: BitwardenCLI, identity: Path, item_name: str,
     item = find_escrow_item(bw, item_name)
     escrow = read_note(item, item_name)
 
-    # 🔴 WHAT CHOSE THE ON-DISK FILE, stated in the mismatch messages below.
-    # Three branches, and the middle one is the whole point: an identity chosen
-    # by an environment variable is one an unrelated shell can redirect, so a
-    # mismatch is at least as likely to be a WRONG-FILE comparison as a damaged
-    # escrow. `None` means no caller stated a source — the messages then say
-    # NOTHING about provenance rather than asserting a default they cannot know.
-    if identity_source is None:
-        chose = ""
-        redirect = ""
-    elif identity_source == B.IDENTITY_SOURCE_DEFAULT:
-        chose = f" The on-disk path was chosen by {identity_source}."
-        redirect = ""
-    else:
-        chose = f" The on-disk path was chosen by {identity_source}, NOT by the default."
-        redirect = (
-            f" 🔴 READ THIS BEFORE RE-ESCROWING: because {identity_source} chose "
-            f"the on-disk path, a mismatch here is at least as likely to mean you "
-            f"compared the WRONG FILE as it is to mean the escrow is damaged — and "
-            f"the two remedies are opposites. Every age identity file is the same "
-            f"size, so equal byte counts on both sides is what comparing two "
-            f"DIFFERENT keys looks like, not evidence they are the same key. "
-            f"Re-escrowing now would overwrite a possibly-good escrow with "
-            f"whatever {identity_source} happens to point at. Re-run with "
-            f"--identity {B.DEFAULT_IDENTITY} to compare against the default "
-            f"first.")
+    chose, redirect = provenance_clauses(identity, identity_source)
 
     verdict_class = classify(escrow, disk)
     if verdict_class == CLASS_TRAILING_NEWLINE:
@@ -1320,16 +1396,22 @@ def run(*, bw: BitwardenCLI, identity: Path, item_name: str,
             f"bytes vs {len(disk)} on disk, and they are not equal after "
             f"trailing newlines are removed. (The differing content is NOT "
             f"printed — it is key material; compare them by hand if you must.) "
+            # 🔴 ORDER IS LOAD-BEARING: the refusal comes BEFORE the remedy.
+            # The first revision appended it after "Re-escrow from the on-disk
+            # identity…", so the operator read the dangerous instruction first
+            # and the reason not to follow it second.
             f"One of the two copies is not the key this subsystem encrypts to."
-            f"{chose} Re-escrow from the on-disk identity only after confirming "
-            f"the on-disk one is the one the bucket's artifacts open with — "
-            f"`restore-verify.py` answers that.{redirect}")
+            f"{chose}{redirect} Re-escrow from the on-disk identity only after "
+            f"confirming the on-disk one is the one the bucket's artifacts open "
+            f"with — `restore-verify.py` answers that (pass it the SAME "
+            f"--identity you used here, or it will resolve its own).")
 
     verdict = EscrowVerdict(
         item_name=item_name, server=server, server_pinned=pinned,
         server_session_reason=session_reason,
         escrow_bytes=len(escrow), disk_bytes=len(disk),
         classification=verdict_class, identity=identity,
+        identity_source=identity_source,
     )
     if not decrypt:
         return verdict
@@ -1359,11 +1441,14 @@ def print_plan(*, identity: Path, item_name: str, expect_server: str | None,
     print(f"identity:  {identity} ({size} bytes)" if present
           else f"identity:  {identity} (MISSING)")
     # 🔴 The SIZE above cannot discriminate: every age identity file is the same
-    # size, so a redirected path looks identical here to the right one. The
-    # source is the only field on this line that can tell them apart.
+    # size, so a different key looks identical here to the right one. Whether
+    # the file IS the default is the only thing on this line that separates
+    # them — and it is asked of the FILE, never of what named it, so that
+    # `--identity <the default>` and the deployed unit's own
+    # `SOPS_AGE_KEY_FILE=<the default>` are both correctly silent.
     if identity_source is not None:
-        note = ("" if identity_source == B.IDENTITY_SOURCE_DEFAULT else
-                "  <- NOT the default; an unrelated shell can set this")
+        note = ("" if B.same_identity_file(identity, B.DEFAULT_IDENTITY)
+                else NON_DEFAULT_NOTE)
         print(f"chosen by: {identity_source}{note}")
     print(f"item:      {item_name!r} (exact name match; `bw list items "
           f"--search` is FUZZY, so its results are candidates)")
@@ -1496,7 +1581,7 @@ def main(argv: list[str] | None = None) -> int:
     # its own source: it is the one choice the operator definitely made on
     # purpose, so it must not be reported as an environment redirect.
     if args.identity is not None:
-        identity, identity_source = args.identity, "the --identity flag"
+        identity, identity_source = args.identity, IDENTITY_SOURCE_FLAG
     else:
         identity, identity_source = B.resolve_identity_with_source()
     prefix = (args.prefix if args.prefix is not None

--- a/scripts/analyze-service-index/restore-verify.py
+++ b/scripts/analyze-service-index/restore-verify.py
@@ -544,6 +544,22 @@ class ArtifactVerdict:
 # --------------------------------------------------------------------------- #
 # the verification of ONE artifact
 # --------------------------------------------------------------------------- #
+def _identity_note(identity: Path) -> str:
+    """" (NOT the default identity...)" when the file is not DEFAULT_IDENTITY.
+
+    🔴 A DECRYPT FAILURE HAS TWO MECHANISMS — wrong key, or damaged ciphertext —
+    and the message below names both. A THIRD is invisible without this note:
+    the identity was silently redirected by an environment variable, so the
+    "wrong key" arm is not a fact about the escrow or the artifact at all.
+    Asked of the FILE, never of what named it: the deployed backup unit exports
+    SOPS_AGE_KEY_FILE=<the default path>, which redirects nothing.
+    """
+    if B.same_identity_file(identity, B.DEFAULT_IDENTITY):
+        return ""
+    return (" (which is NOT the default identity — check ASIB_AGE_IDENTITY / "
+            "SOPS_AGE_KEY_FILE before concluding the key is wrong)")
+
+
 def decrypt(cipher: Path, plain: Path, identity: Path) -> None:
     """`age -d -i <identity>`. A failure here is a DECRYPT failure, and says so.
 
@@ -588,7 +604,8 @@ def decrypt(cipher: Path, plain: Path, identity: Path) -> None:
         raise RestoreVerifyError(
             f"DECRYPT FAILED for {cipher.name} (age rc={p.returncode}): "
             f"{p.stderr.strip()}. The object was retrieved but the identity at "
-            f"{identity} does not open it, or the ciphertext is damaged. This is "
+            f"{identity}{_identity_note(identity)} does not open it, or the ciphertext "
+            f"is damaged. This is "
             f"NOT a corruption verdict about the git history inside — nothing "
             f"here has read it.",
             cause=DECRYPT_AGE_REFUSED)
@@ -1347,7 +1364,7 @@ def summarise(verdicts: list[ArtifactVerdict]) -> str:
 
 def print_plan(*, bucket: str, prefix: str, store: Path, identity: Path,
                scope_filter: str | None, verify_all: bool,
-               max_lag_days: float) -> None:
+               max_lag_days: float, identity_source: str | None = None) -> None:
     """Pure text. Reads the local store; touches neither the network nor the key."""
     prefix = normalise_prefix(prefix)
     # `source`, not `bucket`: with `--from-dir` it is a local directory, and a
@@ -1357,6 +1374,13 @@ def print_plan(*, bucket: str, prefix: str, store: Path, identity: Path,
     print(f"prefix:    {prefix}")
     print(f"store:     {store}")
     print(f"identity:  {identity} ({'present' if identity.is_file() else 'MISSING'})")
+    # Every age identity file is the same size, so the line above cannot tell a
+    # redirected key from the right one. Asked of the FILE, never of what named
+    # it: the deployed unit exports SOPS_AGE_KEY_FILE=<the default>.
+    if identity_source is not None:
+        note = ("" if B.same_identity_file(identity, B.DEFAULT_IDENTITY)
+                else "  <- NOT the default identity")
+        print(f"chosen by: {identity_source}{note}")
     mid = machine_id()
     ours = prefix_belongs_to_this_host(prefix, B.host_label(), mid)
     print(f"host:      {B.host_label()} (machine-id "
@@ -1447,7 +1471,16 @@ def main(argv: list[str] | None = None) -> int:
                     help="print what would happen; touch neither network nor key")
     args = ap.parse_args(argv)
 
-    identity = args.identity or B.resolve_identity()
+    # 🔴 RESOLVE THE PATH AND WHAT CHOSE IT TOGETHER — the same seam
+    # escrow-verify.py closes. This tool is where escrow-verify's mismatch
+    # message SENDS the operator ("restore-verify.py answers that"), so if it
+    # silently resolves its own identity through the same env vars, the
+    # handover lands on the redirected key too and the second opinion is a
+    # second sample of the first mistake.
+    if args.identity is not None:
+        identity, identity_source = args.identity, "the --identity flag"
+    else:
+        identity, identity_source = B.resolve_identity_with_source()
     if args.prefix is not None:
         prefix, explicit = args.prefix, True
     elif args.host is not None:
@@ -1467,6 +1500,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if args.print_plan:
             print_plan(bucket=bucket, prefix=prefix, store=args.store,
+                       identity_source=identity_source,
                        identity=identity, scope_filter=args.scope,
                        verify_all=args.verify_all, max_lag_days=args.max_lag_days)
             return 0

--- a/scripts/analyze-service-index/restore-verify.py
+++ b/scripts/analyze-service-index/restore-verify.py
@@ -556,8 +556,15 @@ def _identity_note(identity: Path) -> str:
     """
     if B.same_identity_file(identity, B.DEFAULT_IDENTITY):
         return ""
-    return (" (which is NOT the default identity — check ASIB_AGE_IDENTITY / "
-            "SOPS_AGE_KEY_FILE before concluding the key is wrong)")
+    # 🔴 NAMES ALL THREE WAYS AN IDENTITY GETS CHOSEN, because this function
+    # is given the PATH and cannot know which one was used. Naming only the two
+    # environment variables told an operator who had passed `--identity` to go
+    # check two variables that had no effect on their run — and escrow-verify's
+    # mismatch message now explicitly hands over with "pass it the SAME
+    # --identity you used here", so that is the likely path, not a rare one.
+    return (" (which is NOT the default identity — it came from --identity, "
+            "ASIB_AGE_IDENTITY or SOPS_AGE_KEY_FILE; check which before "
+            "concluding the key is wrong)")
 
 
 def decrypt(cipher: Path, plain: Path, identity: Path) -> None:

--- a/scripts/tests/test_analyze_service_index_backup.py
+++ b/scripts/tests/test_analyze_service_index_backup.py
@@ -2968,3 +2968,40 @@ def test_the_docstring_no_longer_claims_more_than_the_code_does():
     assert "GIT_DIR OVERRIDES IT" in doc, (
         "the docstring no longer states WHY `-C` is not enough, which is the "
         "fact the whole function turns on")
+
+
+def test_the_units_SOPS_AGE_KEY_FILE_is_the_SAME_FILE_as_DEFAULT_IDENTITY():
+    """🔴 THE ARBITER OF EVERY "NOT the default identity" WARNING, PINNED TO THE
+    THING IT CLAIMS TO BE ABOUT.
+
+    `escrow-verify.py` and `restore-verify.py` now decide whether to warn by
+    comparing the resolved identity against `B.DEFAULT_IDENTITY`, and one of
+    those messages asserts the stronger claim that a non-matching file is "NOT
+    the identity this subsystem encrypts to". What the subsystem actually
+    encrypts to is whatever the BACKUP UNIT exports — `nix/home.nix`'s
+    `SOPS_AGE_KEY_FILE=…`, read by `backup.resolve_identity()` at run time.
+
+    Nothing compared those two. If home.nix drifts, one of two silent failures
+    follows, both with a fully green suite:
+      * the unit encrypts to a key the verifiers call "not the default", which
+        is the permanently-red warning this feature was fixed to remove; or
+      * "the default" quietly stops being the key the unit uses, so a genuine
+        redirect goes unwarned.
+
+    `%h` is systemd's home specifier; it is expanded to the running user's home,
+    which is what `Path.home()` gives this test.
+    """
+    block = _backup_block()
+    entries = _environment_entries(block)
+    keyed = [e for e in entries if e.startswith("SOPS_AGE_KEY_FILE=")]
+    assert len(keyed) == 1, (
+        f"expected exactly one SOPS_AGE_KEY_FILE entry, got {keyed!r} — the "
+        f"verifiers' notion of 'the default identity' is derived from it")
+    raw = keyed[0].split("=", 1)[1]
+    assert raw.startswith("%h/"), (
+        f"{raw!r} does not start with systemd's %h specifier; this test can "
+        f"only expand that form and must not guess at another")
+    unit_path = Path.home() / raw[len("%h/"):]
+    assert B.same_identity_file(unit_path, B.DEFAULT_IDENTITY), (
+        f"the backup unit encrypts to {unit_path}, but the verifiers treat "
+        f"{B.DEFAULT_IDENTITY} as the default identity. One of the two moved.")

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -2659,6 +2659,19 @@ def test_same_identity_file_asks_about_the_FILE_not_the_spelling(tmp_path):
     assert B.same_identity_file(real, Path(str(tmp_path) + "/./real.key"))
     assert B.same_identity_file(real, link), "a symlink to the file is the file"
     assert not B.same_identity_file(real, other)
+    # `~` must expand: argparse does NOT expanduser, so a quoted
+    # `--identity '~/...'` arrives literally and would otherwise never match.
+    home = Path.home()
+    assert B.same_identity_file(Path("~"), home)
+    assert not B.same_identity_file(Path("~"), home / "definitely-not-here")
+    # 🔴 THE EXCEPTION BELT, MADE REACHABLE. An embedded NUL is the one input
+    # that actually raises out of `resolve()` (ValueError, measured — symlink
+    # loops, deep chains and unreadable parents all return normally on 3.12).
+    # Without this the fallback was dead code and mutating it to the UNSAFE
+    # `return True` — which would silence the warning for every path — survived
+    # the whole suite.
+    assert not B.same_identity_file(Path("a\x00b"), real)
+    assert not B.same_identity_file(real, Path("a\x00b"))
     # a path that does not exist must compare, not raise
     assert not B.same_identity_file(real, tmp_path / "absent.key")
     assert B.same_identity_file(tmp_path / "absent.key", tmp_path / "absent.key")
@@ -2744,9 +2757,19 @@ def test_the_refusal_comes_BEFORE_the_remedy_it_argues_against(escrow_world):
     assert warn < remedy, "the warning trails the remedy it argues against"
 
 
-def test_a_mismatch_on_the_DEFAULT_file_carries_no_warning(escrow_world):
-    msg = _mismatch_verdict(escrow_world, B.IDENTITY_SOURCE_DEFAULT,
-                            identity=B.DEFAULT_IDENTITY)
+def test_a_mismatch_on_the_DEFAULT_file_carries_no_warning(escrow_world,
+                                                            monkeypatch):
+    """🔴 HERMETIC — the default is MONKEYPATCHED onto the fixture's own key.
+
+    The first version passed the REAL `B.DEFAULT_IDENTITY` into `run()`, which
+    READS that file. It therefore passed only on a machine holding the
+    operator's age key; anywhere else `run()` raised IDENTITY-MISSING before
+    reaching the comparison, and it turned the merge-gating nix sandbox tier
+    RED while the dev-host tier stayed green. Reproduce any such test with
+    `env HOME=<empty dir>` — that is the whole difference.
+    """
+    monkeypatch.setattr(B, "DEFAULT_IDENTITY", escrow_world["identity"])
+    msg = _mismatch_verdict(escrow_world, B.IDENTITY_SOURCE_DEFAULT)
     assert "READ THIS BEFORE RE-ESCROWING" not in msg
     assert "restore-verify.py" in msg
 
@@ -2859,3 +2882,32 @@ def test_the_SUCCESS_line_discloses_a_non_default_identity(escrow_world):
         disk_bytes=1, classification=EV.CLASS_IDENTICAL,
         identity=B.DEFAULT_IDENTITY, identity_source="$SOPS_AGE_KEY_FILE")
     assert "NOT the default identity" not in d.line()
+
+
+
+def test_the_SUCCESS_line_from_a_REAL_run_discloses_a_non_default_identity(
+        escrow_world, monkeypatch):
+    """🔴 THE SEAM, not the dataclass. The sibling test constructs
+    `EscrowVerdict` directly, so deleting `identity_source=identity_source`
+    from `run()`'s construction left the whole disclosure INERT on the only
+    path that produces it, with the suite fully green."""
+    monkeypatch.setattr(B, "DEFAULT_IDENTITY", Path("/srv/not-this-one.key"))
+    v = EV.run(bw=_cli(FakeBw(items=[_item(notes=escrow_world["note"])])),
+               identity=escrow_world["identity"], item_name=ITEM,
+               identity_source="$SOPS_AGE_KEY_FILE",
+               store=escrow_world["store"], now=NOW)
+    line = v.line()
+    assert "escrow OK" in line
+    assert "NOT the default identity" in line
+    assert "$SOPS_AGE_KEY_FILE" in line
+
+
+def test_the_undo_advice_matches_the_KIND_of_source():
+    """`env -u` is meaningless for a flag, and nonsense for the built-in
+    default — which can pair with a non-default path only through `run()`'s
+    keyword API, but renders a sentence either way."""
+    assert "env -u SOPS_AGE_KEY_FILE" in EV._undo_advice("$SOPS_AGE_KEY_FILE")
+    for src in (EV.IDENTITY_SOURCE_FLAG, B.IDENTITY_SOURCE_DEFAULT):
+        advice = EV._undo_advice(src)
+        assert "env -u" not in advice, advice
+        assert str(B.DEFAULT_IDENTITY) in advice

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -2926,12 +2926,43 @@ def test_no_source_renders_a_SELF_CONTRADICTING_refusal():
                 EV.IDENTITY_SOURCE_FLAG, B.IDENTITY_SOURCE_DEFAULT):
         chose, redirect = EV.provenance_clauses(Path("/srv/elsewhere.key"), src)
         assert redirect, src
+        # 🔴 POSITIVE CONTENT PINS, not only word-ABSENCES. The first version of
+        # this loop asserted three forbidden words and nothing else, and an
+        # INVERTED SAFETY CLAIM — "a mismatch here certainly means the escrow is
+        # DAMAGED and you should re-escrow at once", the exact opposite of this
+        # PR's advice — passed the whole suite using none of those words. A
+        # guard on WORDS is walkable by REWORDING; these say what must be TRUE.
+        assert "READ THIS BEFORE RE-ESCROWING" in redirect, (src, redirect)
+        assert str(B.DEFAULT_IDENTITY) in redirect, (src, redirect)
+        assert "same size" in redirect, (src, redirect)
         # only an ENV VAR can have "redirected" anything
         if not src.startswith("$"):
             assert "redirected" not in redirect, (src, redirect)
             assert "env -u" not in redirect, (src, redirect)
         # and nothing may claim a flag is settable by a shell
         assert "unrelated shell" not in redirect, (src, redirect)
+
+
+def test_the_NEUTRAL_arms_refusal_is_pinned_as_a_WHOLE_STRING():
+    """🔴 THE ARM THAT HAD NO POSITIVE PIN AT ALL, pinned whole.
+
+    Its two siblings each carry positive content assertions; this one carried
+    only word-absences, which is how an inverted safety instruction survived.
+    When the artifact under test IS prose, the guard is the whole normalised
+    string — a cosmetic reword then fails this test, and that is the trade
+    being made deliberately for a machine-readable claim about key material.
+    """
+    _, redirect = EV.provenance_clauses(Path("/srv/elsewhere.key"),
+                                        B.IDENTITY_SOURCE_DEFAULT)
+    d = B.DEFAULT_IDENTITY
+    assert redirect == (
+        f" 🔴 READ THIS BEFORE RE-ESCROWING: the on-disk path is not {d}, so a "
+        f"mismatch here is at least as likely to mean you compared the WRONG "
+        f"FILE as it is to mean the escrow is damaged — and the two remedies "
+        f"are opposites. Every age identity file is the same size, so equal "
+        f"byte counts on both sides is what comparing two DIFFERENT keys looks "
+        f"like, not evidence they are the same key. Re-run against {d} to "
+        f"compare against the default first.")
 
 
 def test_the_undo_advice_matches_the_KIND_of_source():

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -2487,28 +2487,40 @@ def test_the_module_hardcodes_no_endpoint_and_no_host():
 
 
 # --------------------------------------------------------------------------- #
-# 15. 🔴 THE ADVERTISED SHELL, AND WHAT CHOSE THE ON-DISK IDENTITY
+# 15. 🔴 THE ADVERTISED SHELL, AND WHICH FILE WAS ACTUALLY COMPARED
 #
-# Both halves are regressions from ONE live run, 2026-08-25, in which the
-# operator typed the master password and got a confident wrong answer:
+# Regressions from a live run on 2026-08-25 in which the operator typed the
+# master password and got a confident wrong answer, and from the adversarial
+# audit of the first attempt to fix it — which shipped a NEW confident wrong
+# sentence in the very line added to prevent one:
 #
-#   * the hint advertised `nix-shell -p bitwarden-cli jq`, and `--decrypt-check`
-#     then died `ModuleNotFoundError: No module named 'minio'` — AFTER the
-#     password had been spent. A hint that cannot run its own invocation is
-#     worse than none, because it is followed.
-#   * `SOPS_AGE_KEY_FILE`, exported by unrelated client work, redirected the
-#     on-disk side of the comparison to a DIFFERENT age key. Every age identity
-#     file is the same size, so the mismatch reported equal byte counts and read
-#     as a damaged escrow. The remedy it printed — "re-escrow from the on-disk
-#     identity" — would have overwritten a good escrow with an unrelated key.
+#   * the hint advertised `nix-shell -p bitwarden-cli jq`, and --decrypt-check
+#     then died `ModuleNotFoundError: No module named 'minio'` AFTER the
+#     password had been spent.
+#   * `SOPS_AGE_KEY_FILE`, exported by unrelated work, redirected the on-disk
+#     side to a DIFFERENT age key. Every age identity file is the same size, so
+#     the mismatch reported equal byte counts and read as a damaged escrow. Its
+#     remedy would have overwritten a good escrow with an unrelated key.
+#   * the FIRST FIX then branched on WHAT NAMED the file instead of WHICH FILE
+#     it was, so `--identity <the default>` (the documented command!) and the
+#     deployed unit's own `SOPS_AGE_KEY_FILE=<the default>` both printed
+#     "NOT the default" — and told the reader an `--identity` FLAG could be
+#     "set by an unrelated shell".
+#
+# 🔴 THE SENTENCES ARE PINNED WHOLE. A guard asserting the fragment "NOT the
+# default" passed unchanged on that false line. When the artifact under test is
+# prose, a substring cannot tell a true message from a confident wrong one.
 # --------------------------------------------------------------------------- #
 def test_the_advertised_nix_shell_provisions_every_module_the_decrypt_path_IMPORTS():
     """🔴 The RELATIONSHIP, not either side alone: every module the decrypt path
     needs must be provisioned by the shell the failure messages hand over.
 
     Scope, stated so nobody reads more coverage into this than it has: it pins
-    LEDGER -> HINT. It cannot DISCOVER a newly-added third-party import on its
-    own; the companion test below ties the ledger to backup.py's import site.
+    LEDGER -> HINT. It cannot DISCOVER a newly-added third-party import; the
+    companion test below ties the ledger to the import site that creates the
+    need. Neither covers NON-Python tools (`age`, `kubectl`, `git`) — those
+    resolve from the ambient profile because `nix-shell -p` is impure, and
+    `--pure` or a fresh host would break them with no guard watching.
     """
     assert EV.DECRYPT_PYTHON_MODULES, "an empty ledger would pass vacuously"
     for mod in EV.DECRYPT_PYTHON_MODULES:
@@ -2520,55 +2532,86 @@ def test_the_advertised_nix_shell_provisions_every_module_the_decrypt_path_IMPOR
             f"hint is what the operator actually copies")
 
 
-def test_the_decrypt_module_ledger_names_backup_pys_LAZY_minio_import():
-    """The ledger's one entry, tied to the code that creates the need.
+def test_the_decrypt_module_ledger_names_the_REAL_third_party_import_site():
+    """🔴 THE SITE THAT CREATES THE NEED, not the local shim that re-exports it.
 
-    `minio` is imported INSIDE `MinioUploader`, not at module scope, which is
-    exactly why the missing package survived every import-time check and only
-    surfaced mid-run against the real bucket.
+    The first revision asserted `from _minio import MinioArchive` in backup.py.
+    `_minio` is devrc's OWN module (`scripts/mail-actions/_minio.py`); the
+    third-party dependency is the `from minio import Minio` INSIDE it. Pinning
+    the shim meant swapping that module to another SDK would leave both tests
+    green while the advertised shell was wrong again — the same hazard in a
+    different shape.
     """
-    src = Path(B.__file__).read_text(encoding="utf-8")
-    assert "from _minio import MinioArchive" in src, (
-        "backup.py's lazy minio import moved — re-derive DECRYPT_PYTHON_MODULES")
+    shim = SCRIPT.parent.parent / "mail-actions" / "_minio.py"
+    assert shim.is_file(), f"the shim moved: {shim}"
+    assert "from minio import Minio" in shim.read_text(encoding="utf-8"), (
+        "the third-party minio import moved — re-derive DECRYPT_PYTHON_MODULES "
+        "from wherever it lives now")
     assert "minio" in EV.DECRYPT_PYTHON_MODULES
+    # and backup.py must still route through that shim, or the chain is broken
+    assert "from _minio import MinioArchive" in Path(B.__file__).read_text(
+        encoding="utf-8")
 
 
-def test_the_hint_quotes_nix_EXPRESSION_packages_and_leaves_bare_names_bare():
-    """An unquoted `python3.withPackages(p:[p.minio])` is a syntax error in the
-    operator's shell — parentheses and brackets are metacharacters. Pinned by
-    parsing the hint the way a shell would, not by eyeballing the string."""
-    words = shlex.split(EV.NIX_SHELL_HINT)
-    assert words[0] == "nix-shell"
-    assert words[1] == "-p"
-    # shlex removes the quoting, so the expression must survive as ONE word.
-    assert "python3.withPackages(p:[p.minio])" in words
-    assert "bitwarden-cli" in words
-    # ...and a bare name must NOT have been needlessly quoted into the string.
-    assert "'bitwarden-cli'" not in EV.NIX_SHELL_HINT
+def test_the_rendered_hint_is_accepted_by_a_REAL_SHELL():
+    """🔴 THE NEGATIVE CONTROL THAT THE FIRST REVISION LACKED.
+
+    That version asserted the quoting via `shlex.split`, which does NOT treat
+    `(`/`)`/`[`/`]` as metacharacters — so deleting the quoting entirely left
+    the suite fully green while the advertised command became a bash syntax
+    error. `bash -n` is the instrument that can actually see it.
+
+    Both halves are asserted: the real hint PARSES, and an unquoted rendering
+    of the same packages does NOT. Without the second half this test could pass
+    against a `bash -n` that accepts anything.
+    """
+    if shutil.which("bash") is None:
+        pytest.fail("bash is required to validate the hint this module hands out")
+    cmd = EV.NIX_SHELL_HINT.replace("<command>", "true")
+    ok = subprocess.run(["bash", "-n", "-c", cmd], capture_output=True, text=True)
+    assert ok.returncode == 0, (
+        f"the advertised hint is not valid shell: {ok.stderr.strip()}")
+
+    unquoted = ("nix-shell -p " + " ".join(EV.NIX_SHELL_PACKAGES)
+                + " --run 'true'")
+    bad = subprocess.run(["bash", "-n", "-c", unquoted], capture_output=True,
+                         text=True)
+    assert bad.returncode != 0, (
+        "the positive control did not fire: an UNQUOTED package list was "
+        "accepted by `bash -n`, so this test cannot see missing quoting")
 
 
+def test_the_hint_carries_its_run_clause_and_quotes_only_what_needs_it():
+    """The `--run '<command>'` half is what makes the hint copy-pasteable;
+    deleting it survived the first revision's guards."""
+    assert EV.NIX_SHELL_HINT.endswith(" --run '<command>'")
+    assert EV.NIX_SHELL_HINT.startswith("nix-shell -p ")
+    assert "'python3.withPackages(p:[p.minio])'" in EV.NIX_SHELL_HINT
+    assert "'bitwarden-cli'" not in EV.NIX_SHELL_HINT, "a bare name was quoted"
+
+
+# --------------------------------------------------------------------------- #
+# 15b. resolution order + the SAME-FILE predicate
+# --------------------------------------------------------------------------- #
 @pytest.mark.parametrize("env,expect_path,expect_source", [
     ({}, None, B.IDENTITY_SOURCE_DEFAULT),
     ({"SOPS_AGE_KEY_FILE": "/srv/sops-chosen.key"},
      "/srv/sops-chosen.key", "$SOPS_AGE_KEY_FILE"),
     ({"ASIB_AGE_IDENTITY": "/srv/asib-chosen.key"},
      "/srv/asib-chosen.key", "$ASIB_AGE_IDENTITY"),
-    # both set: ASIB wins, and the SOURCE must say so rather than naming the
-    # loser. A fixture whose two paths were equal could not see that swap.
     ({"ASIB_AGE_IDENTITY": "/srv/asib-chosen.key",
       "SOPS_AGE_KEY_FILE": "/srv/sops-chosen.key"},
      "/srv/asib-chosen.key", "$ASIB_AGE_IDENTITY"),
+    # an EMPTY env var is not a choice — it must fall through, not resolve to
+    # Path(""). `if v:` vs `if v is not None:` is invisible without this row.
+    ({"SOPS_AGE_KEY_FILE": ""}, None, B.IDENTITY_SOURCE_DEFAULT),
+    ({"ASIB_AGE_IDENTITY": "", "SOPS_AGE_KEY_FILE": "/srv/sops-chosen.key"},
+     "/srv/sops-chosen.key", "$SOPS_AGE_KEY_FILE"),
 ])
 def test_resolve_identity_with_source_NAMES_what_chose_the_path(
         monkeypatch, env, expect_path, expect_source):
-    """🔴 The path alone cannot discriminate — every age identity file is the
-    same size, so a redirected path looks exactly like the right one. The
-    source is the only thing that separates 'your escrow is corrupt' from 'you
-    compared the wrong file', and those remedies are opposites.
-
-    The three fixture paths are pairwise distinct AND distinct from
-    DEFAULT_IDENTITY, so a mutant that returns any constant is visible.
-    """
+    """The three fixture paths are pairwise distinct AND distinct from
+    DEFAULT_IDENTITY, so a mutant returning any constant is visible."""
     for var in B.IDENTITY_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
     for k, v in env.items():
@@ -2578,120 +2621,241 @@ def test_resolve_identity_with_source_NAMES_what_chose_the_path(
     expected = B.DEFAULT_IDENTITY if expect_path is None else Path(expect_path)
     assert path == expected
     assert source == expect_source
-    # the two-return helper and the one-return one must never disagree
     assert B.resolve_identity() == path
 
 
-def test_the_env_var_ORDER_is_declared_once_and_the_default_is_not_a_path():
+def test_the_env_var_ORDER_is_declared_once_and_the_sentinels_are_PINNED():
     """`resolve_identity()` delegates rather than repeating the loop: two copies
-    of a precedence order drift silently, because both return a plausible path."""
+    of a precedence order drift silently, because both return a plausible path.
+
+    The two source sentinels are pinned as WHOLE strings — they are printed to
+    the operator, and `provenance_clauses` BRANCHES on the flag one.
+    """
     assert B.IDENTITY_ENV_VARS == ("ASIB_AGE_IDENTITY", "SOPS_AGE_KEY_FILE")
     src = Path(B.__file__).read_text(encoding="utf-8")
     body = src.split("def resolve_identity(", 1)[1].split("\ndef ", 1)[0]
     assert "resolve_identity_with_source" in body, (
         "resolve_identity() re-implements the order instead of delegating")
     assert "os.environ" not in body, "a SECOND copy of the env order"
-    # the sentinel is a sentence, never a path — a message must not read
-    # "chosen by None" or "chosen by /some/path" where a source belongs.
-    assert isinstance(B.IDENTITY_SOURCE_DEFAULT, str)
-    assert "/" not in B.IDENTITY_SOURCE_DEFAULT
+    assert B.IDENTITY_SOURCE_DEFAULT == "the built-in default"
+    assert EV.IDENTITY_SOURCE_FLAG == "the --identity flag"
 
 
-def _mismatch_verdict(escrow_world, source):
-    """A BYTES-DIFFER-MATERIALLY run with a stated (or unstated) source."""
+def test_same_identity_file_asks_about_the_FILE_not_the_spelling(tmp_path):
+    """🔴 THE PREDICATE THE WHOLE FEATURE TURNS ON.
+
+    Equal-but-differently-spelled paths are the SAME file (that is the deployed
+    config: the unit exports SOPS_AGE_KEY_FILE=<the default>). A symlink to it
+    is also the same file. Two genuinely different files are not.
+    """
+    real = tmp_path / "real.key"
+    real.write_text("an identity file's contents", encoding="utf-8")
+    other = tmp_path / "other.key"
+    other.write_text("different", encoding="utf-8")
+    link = tmp_path / "link.key"
+    link.symlink_to(real)
+
+    assert B.same_identity_file(real, real)
+    assert B.same_identity_file(real, Path(str(tmp_path) + "/./real.key"))
+    assert B.same_identity_file(real, link), "a symlink to the file is the file"
+    assert not B.same_identity_file(real, other)
+    # a path that does not exist must compare, not raise
+    assert not B.same_identity_file(real, tmp_path / "absent.key")
+    assert B.same_identity_file(tmp_path / "absent.key", tmp_path / "absent.key")
+
+
+# --------------------------------------------------------------------------- #
+# 15c. 🔴 THE MESSAGES — pinned WHOLE, and the warning must DISCRIMINATE
+# --------------------------------------------------------------------------- #
+ELSEWHERE = Path("/srv/not-the-default.key")
+
+
+def test_the_default_FILE_never_triggers_a_warning_however_it_was_NAMED():
+    """🔴 THE AUDIT'S BLOCKING FINDING, both halves.
+
+    `--identity <the default>` is the command the handoff doc RECOMMENDS, and
+    `SOPS_AGE_KEY_FILE=<the default>` is what the deployed backup unit sets
+    (nix/home.nix). Branching on the mechanism made BOTH print "NOT the
+    default" — the second being a permanently-red warning on the subsystem's
+    own normal configuration, which trains a reader to skip it.
+    """
+    for source in (EV.IDENTITY_SOURCE_FLAG, "$SOPS_AGE_KEY_FILE",
+                   "$ASIB_AGE_IDENTITY", B.IDENTITY_SOURCE_DEFAULT):
+        chose, redirect = EV.provenance_clauses(B.DEFAULT_IDENTITY, source)
+        assert redirect == "", f"a warning fired on the DEFAULT file via {source}"
+        assert chose == (f" The on-disk path is the default identity, named by "
+                         f"{source}.")
+        assert "NOT the default" not in chose
+
+
+def test_an_UNSTATED_source_asserts_NOTHING_about_provenance():
+    """The honest branch: a caller that states no source must not have one
+    invented for it — neither for the default nor against it."""
+    for path in (B.DEFAULT_IDENTITY, ELSEWHERE):
+        assert EV.provenance_clauses(path, None) == ("", "")
+
+
+def test_an_ENV_REDIRECT_to_a_DIFFERENT_file_refuses_to_call_it_diagnosed():
+    chose, redirect = EV.provenance_clauses(ELSEWHERE, "$SOPS_AGE_KEY_FILE")
+    assert chose == (" The on-disk path is NOT the default identity; it was "
+                     "chosen by $SOPS_AGE_KEY_FILE.")
+    assert redirect.startswith(" 🔴 READ THIS BEFORE RE-ESCROWING: "
+                               "$SOPS_AGE_KEY_FILE redirected the on-disk path")
+    assert "WRONG FILE" in redirect
+    assert "same size" in redirect
+    # it must hand over a command that actually UNDOES the redirect...
+    assert "env -u SOPS_AGE_KEY_FILE" in redirect
+    # ...and must NOT tell them to re-run with the thing they already did
+    assert "--identity" not in redirect
+
+
+def test_an_EXPLICIT_FLAG_to_a_DIFFERENT_file_does_not_blame_a_shell():
+    """🔴 A flag is a deliberate act. The first revision told the operator an
+    `--identity` flag could be 'set by an unrelated shell', and advised them to
+    'Re-run with --identity <default>' — which, for someone who had just passed
+    --identity, is advice to repeat what they just did."""
+    chose, redirect = EV.provenance_clauses(ELSEWHERE, EV.IDENTITY_SOURCE_FLAG)
+    assert chose == (" The on-disk path is NOT the default identity; it was "
+                     "chosen by the --identity flag.")
+    assert "unrelated shell" not in redirect
+    assert "redirected" not in redirect
+    assert "you pointed --identity at a file" in redirect
+    assert str(B.DEFAULT_IDENTITY) in redirect
+    assert "do NOT re-escrow" in redirect
+
+
+def _mismatch_verdict(escrow_world, source, identity=None):
     with pytest.raises(EV.EscrowError) as ei:
         EV.run(bw=_cli(FakeBw(items=[_item(notes=OTHER_KEY)])),
-               identity=escrow_world["identity"], item_name=ITEM,
+               identity=identity or escrow_world["identity"], item_name=ITEM,
                identity_source=source, store=escrow_world["store"], now=NOW)
     assert ei.value.token == "BYTES-DIFFER-MATERIALLY"
     return ei.value.verdict
 
 
-def test_a_mismatch_on_an_ENV_CHOSEN_identity_warns_BEFORE_the_remedy(escrow_world):
-    """🔴 THE REGRESSION. The old message named only the resolved PATH, so a
-    redirected comparison read as a damaged escrow and the advice it gave —
-    re-escrow from the on-disk identity — would have destroyed a good escrow."""
+def test_the_refusal_comes_BEFORE_the_remedy_it_argues_against(escrow_world):
+    """🔴 ORDER, not mere presence. The first revision appended the warning
+    AFTER 'Re-escrow from the on-disk identity…', so the reader met the
+    dangerous instruction first. A substring test could not see that, and the
+    PR body claimed the opposite of what the code did."""
     msg = _mismatch_verdict(escrow_world, "$SOPS_AGE_KEY_FILE")
-    assert "$SOPS_AGE_KEY_FILE" in msg, "the message does not name what redirected it"
-    assert "READ THIS BEFORE RE-ESCROWING" in msg
-    assert "WRONG FILE" in msg
-    # the size-is-not-evidence fact, which is why the mismatch is ambiguous
-    assert "same size" in msg
-    # it must still route the operator to the tool that can actually decide
-    assert "restore-verify.py" in msg
+    warn = msg.index("READ THIS BEFORE RE-ESCROWING")
+    remedy = msg.index("Re-escrow from the on-disk identity")
+    assert warn < remedy, "the warning trails the remedy it argues against"
 
 
-def test_a_mismatch_on_the_DEFAULT_identity_does_NOT_carry_the_redirect_warning(
-        escrow_world):
-    """The warning must DISCRIMINATE. If it printed unconditionally it would be
-    noise on the one path where the on-disk file really is the expected one, and
-    a reader would learn to skip it."""
-    msg = _mismatch_verdict(escrow_world, B.IDENTITY_SOURCE_DEFAULT)
-    assert B.IDENTITY_SOURCE_DEFAULT in msg
+def test_a_mismatch_on_the_DEFAULT_file_carries_no_warning(escrow_world):
+    msg = _mismatch_verdict(escrow_world, B.IDENTITY_SOURCE_DEFAULT,
+                            identity=B.DEFAULT_IDENTITY)
     assert "READ THIS BEFORE RE-ESCROWING" not in msg
-    assert "$SOPS_AGE_KEY_FILE" not in msg
     assert "restore-verify.py" in msg
 
 
-def test_a_mismatch_with_NO_stated_source_asserts_NOTHING_about_provenance(
-        escrow_world):
-    """🔴 The honest third branch. A caller that states no source must not have
-    a default INVENTED for it: 'chosen by the built-in default' on a run that
-    never checked is the same class of confident wrong sentence this whole
-    module exists to prevent."""
-    msg = _mismatch_verdict(escrow_world, None)
-    assert "chosen by" not in msg
-    assert "READ THIS BEFORE RE-ESCROWING" not in msg
-    assert B.IDENTITY_SOURCE_DEFAULT not in msg
-    assert "restore-verify.py" in msg
+def test_the_TRAILING_NEWLINE_arm_also_states_which_file_it_compared(
+        escrow_world, tmp_path):
+    """That arm gained the provenance clause but had ZERO coverage — dropping
+    it there survived the first revision's suite."""
+    ident = tmp_path / "trailing.key"
+    ident.write_text(escrow_world["identity"].read_text(encoding="utf-8"),
+                     encoding="utf-8")
+    note = ident.read_text(encoding="utf-8").rstrip("\n")
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.run(bw=_cli(FakeBw(items=[_item(notes=note)])), identity=ident,
+               item_name=ITEM, identity_source="$SOPS_AGE_KEY_FILE",
+               store=escrow_world["store"], now=NOW)
+    assert ei.value.token == "BYTES-DIFFER-TRAILING-NEWLINE"
+    assert "is NOT the default identity" in ei.value.verdict
 
 
-def test_print_plan_discloses_an_ENV_REDIRECT_before_any_password_is_spent(
-        monkeypatch, capsys, tmp_path):
-    """🔴 EXERCISES main()'s OWN derivation. The suite is otherwise hermetic —
-    every other test injects the identity — so main()'s resolution is exactly
-    the code that was never covered when this failed live.
+def test_run_and_print_plan_DEFAULT_to_claiming_nothing():
+    """🔴 Both defaults were mutable to the DEFAULT sentinel invisibly, because
+    every test passes the argument explicitly. That mutation would invent a
+    provenance claim for callers that never made one."""
+    import inspect
+    for fn in (EV.run, EV.print_plan):
+        assert inspect.signature(fn).parameters["identity_source"].default is None
 
-    `--print-plan` runs no `bw` and touches no network, so this is the check an
-    operator can make BEFORE typing a master password.
+
+# --------------------------------------------------------------------------- #
+# 15d. main()'s OWN derivation — the suite is otherwise hermetic here
+# --------------------------------------------------------------------------- #
+def _plan_out(capsys, argv):
+    """Run `--print-plan` in-process and return stdout.
+
+    NOT named `_plan` — this module already has a `_plan()` that builds a fake
+    `bw` script's behaviour plan, and shadowing it broke 14 CLI tests.
     """
+    assert EV.main(["--print-plan", *argv]) == EV.EXIT_OK
+    return capsys.readouterr().out
+
+
+def test_print_plan_flags_a_REDIRECT_to_a_different_file(monkeypatch, capsys,
+                                                         tmp_path):
     key = tmp_path / "redirected.key"
     key.write_text(OTHER_KEY, encoding="utf-8")
     for var in B.IDENTITY_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("SOPS_AGE_KEY_FILE", str(key))
-
-    assert EV.main(["--print-plan"]) == EV.EXIT_OK
-    out = capsys.readouterr().out
-    assert "chosen by: $SOPS_AGE_KEY_FILE" in out
-    assert "NOT the default" in out
+    out = _plan_out(capsys, [])
+    assert f"chosen by: $SOPS_AGE_KEY_FILE{EV.NON_DEFAULT_NOTE}" in out
     assert str(key) in out
 
 
-def test_print_plan_on_the_DEFAULT_identity_does_not_cry_redirect(
-        monkeypatch, capsys):
-    """The negative control for the test above: a clean environment must not
-    print a warning, or the warning stops meaning anything."""
+@pytest.mark.parametrize("argv,env,expect_source", [
+    ([], {}, B.IDENTITY_SOURCE_DEFAULT),
+    # 🔴 the deployed configuration: the unit exports the DEFAULT path
+    ([], {"SOPS_AGE_KEY_FILE": None}, "$SOPS_AGE_KEY_FILE"),
+    # 🔴 the command the handoff doc recommends
+    (["--identity", None], {}, EV.IDENTITY_SOURCE_FLAG),
+])
+def test_print_plan_is_SILENT_when_the_file_is_the_default(
+        monkeypatch, capsys, argv, env, expect_source):
+    """🔴 Both of the audit's blocking reproductions, as tests. `None` in the
+    fixtures is substituted with DEFAULT_IDENTITY so the row cannot drift from
+    the constant it is about."""
     for var in B.IDENTITY_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
-    assert EV.main(["--print-plan"]) == EV.EXIT_OK
-    out = capsys.readouterr().out
-    assert f"chosen by: {B.IDENTITY_SOURCE_DEFAULT}" in out
+    for k in env:
+        monkeypatch.setenv(k, str(B.DEFAULT_IDENTITY))
+    argv = [str(B.DEFAULT_IDENTITY) if a is None else a for a in argv]
+    out = _plan_out(capsys, argv)
+    assert f"chosen by: {expect_source}" in out
+    assert EV.NON_DEFAULT_NOTE not in out, (
+        "a warning fired for the DEFAULT identity file")
     assert "NOT the default" not in out
 
 
-def test_an_explicit_identity_FLAG_is_reported_as_the_operators_own_choice(
-        monkeypatch, capsys, tmp_path):
-    """--identity is the one choice the operator definitely made deliberately.
-    Reporting it as an environment redirect would send them chasing a variable
-    they never set — and it must WIN over a set env var, not merely coexist."""
+def test_an_explicit_flag_WINS_over_a_set_env_var(monkeypatch, capsys, tmp_path):
     key = tmp_path / "explicit.key"
     key.write_text(OTHER_KEY, encoding="utf-8")
     monkeypatch.setenv("SOPS_AGE_KEY_FILE", "/srv/should-have-been-overridden.key")
-
-    assert EV.main(["--print-plan", "--identity", str(key)]) == EV.EXIT_OK
-    out = capsys.readouterr().out
-    assert "chosen by: the --identity flag" in out
+    out = _plan_out(capsys, ["--identity", str(key)])
+    assert f"chosen by: {EV.IDENTITY_SOURCE_FLAG}" in out
     assert "$SOPS_AGE_KEY_FILE" not in out
     assert "should-have-been-overridden" not in out
     assert str(key) in out
+
+
+def test_the_non_default_note_is_pinned_WHOLE():
+    """🔴 The first revision asserted only the fragment 'NOT the default', and
+    that fragment was present in a sentence claiming a command-line flag could
+    be set by an unrelated shell. Pin the whole string."""
+    assert EV.NON_DEFAULT_NOTE == "  <- NOT the default identity"
+    assert "shell" not in EV.NON_DEFAULT_NOTE
+
+
+def test_the_SUCCESS_line_discloses_a_non_default_identity(escrow_world):
+    """🔴 'escrow OK — the Secure Note matches <path>' is where an undisclosed
+    comparison against the wrong file is LEAST likely to be questioned."""
+    v = EV.EscrowVerdict(
+        item_name=ITEM, server="s", server_pinned=True, escrow_bytes=1,
+        disk_bytes=1, classification=EV.CLASS_IDENTICAL, identity=ELSEWHERE,
+        identity_source="$SOPS_AGE_KEY_FILE")
+    assert "NOT the default identity" in v.line()
+    assert "$SOPS_AGE_KEY_FILE" in v.line()
+
+    d = EV.EscrowVerdict(
+        item_name=ITEM, server="s", server_pinned=True, escrow_bytes=1,
+        disk_bytes=1, classification=EV.CLASS_IDENTICAL,
+        identity=B.DEFAULT_IDENTITY, identity_source="$SOPS_AGE_KEY_FILE")
+    assert "NOT the default identity" not in d.line()

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -2484,3 +2484,214 @@ def test_the_module_hardcodes_no_endpoint_and_no_host():
     for needle in ("http://", "https://"):
         assert needle not in src, f"{needle!r} appears in a public repo's source"
     assert "bw config server" in src or "\"config\", \"server\"" in src
+
+
+# --------------------------------------------------------------------------- #
+# 15. 🔴 THE ADVERTISED SHELL, AND WHAT CHOSE THE ON-DISK IDENTITY
+#
+# Both halves are regressions from ONE live run, 2026-08-25, in which the
+# operator typed the master password and got a confident wrong answer:
+#
+#   * the hint advertised `nix-shell -p bitwarden-cli jq`, and `--decrypt-check`
+#     then died `ModuleNotFoundError: No module named 'minio'` — AFTER the
+#     password had been spent. A hint that cannot run its own invocation is
+#     worse than none, because it is followed.
+#   * `SOPS_AGE_KEY_FILE`, exported by unrelated client work, redirected the
+#     on-disk side of the comparison to a DIFFERENT age key. Every age identity
+#     file is the same size, so the mismatch reported equal byte counts and read
+#     as a damaged escrow. The remedy it printed — "re-escrow from the on-disk
+#     identity" — would have overwritten a good escrow with an unrelated key.
+# --------------------------------------------------------------------------- #
+def test_the_advertised_nix_shell_provisions_every_module_the_decrypt_path_IMPORTS():
+    """🔴 The RELATIONSHIP, not either side alone: every module the decrypt path
+    needs must be provisioned by the shell the failure messages hand over.
+
+    Scope, stated so nobody reads more coverage into this than it has: it pins
+    LEDGER -> HINT. It cannot DISCOVER a newly-added third-party import on its
+    own; the companion test below ties the ledger to backup.py's import site.
+    """
+    assert EV.DECRYPT_PYTHON_MODULES, "an empty ledger would pass vacuously"
+    for mod in EV.DECRYPT_PYTHON_MODULES:
+        assert any(f"p.{mod}" in pkg for pkg in EV.NIX_SHELL_PACKAGES), (
+            f"{mod!r} is imported by --decrypt-check but no advertised package "
+            f"provides it: {EV.NIX_SHELL_PACKAGES}")
+        assert f"p.{mod}" in EV.NIX_SHELL_HINT, (
+            f"{mod!r} is in the ledger but the RENDERED hint omits it — the "
+            f"hint is what the operator actually copies")
+
+
+def test_the_decrypt_module_ledger_names_backup_pys_LAZY_minio_import():
+    """The ledger's one entry, tied to the code that creates the need.
+
+    `minio` is imported INSIDE `MinioUploader`, not at module scope, which is
+    exactly why the missing package survived every import-time check and only
+    surfaced mid-run against the real bucket.
+    """
+    src = Path(B.__file__).read_text(encoding="utf-8")
+    assert "from _minio import MinioArchive" in src, (
+        "backup.py's lazy minio import moved — re-derive DECRYPT_PYTHON_MODULES")
+    assert "minio" in EV.DECRYPT_PYTHON_MODULES
+
+
+def test_the_hint_quotes_nix_EXPRESSION_packages_and_leaves_bare_names_bare():
+    """An unquoted `python3.withPackages(p:[p.minio])` is a syntax error in the
+    operator's shell — parentheses and brackets are metacharacters. Pinned by
+    parsing the hint the way a shell would, not by eyeballing the string."""
+    words = shlex.split(EV.NIX_SHELL_HINT)
+    assert words[0] == "nix-shell"
+    assert words[1] == "-p"
+    # shlex removes the quoting, so the expression must survive as ONE word.
+    assert "python3.withPackages(p:[p.minio])" in words
+    assert "bitwarden-cli" in words
+    # ...and a bare name must NOT have been needlessly quoted into the string.
+    assert "'bitwarden-cli'" not in EV.NIX_SHELL_HINT
+
+
+@pytest.mark.parametrize("env,expect_path,expect_source", [
+    ({}, None, B.IDENTITY_SOURCE_DEFAULT),
+    ({"SOPS_AGE_KEY_FILE": "/srv/sops-chosen.key"},
+     "/srv/sops-chosen.key", "$SOPS_AGE_KEY_FILE"),
+    ({"ASIB_AGE_IDENTITY": "/srv/asib-chosen.key"},
+     "/srv/asib-chosen.key", "$ASIB_AGE_IDENTITY"),
+    # both set: ASIB wins, and the SOURCE must say so rather than naming the
+    # loser. A fixture whose two paths were equal could not see that swap.
+    ({"ASIB_AGE_IDENTITY": "/srv/asib-chosen.key",
+      "SOPS_AGE_KEY_FILE": "/srv/sops-chosen.key"},
+     "/srv/asib-chosen.key", "$ASIB_AGE_IDENTITY"),
+])
+def test_resolve_identity_with_source_NAMES_what_chose_the_path(
+        monkeypatch, env, expect_path, expect_source):
+    """🔴 The path alone cannot discriminate — every age identity file is the
+    same size, so a redirected path looks exactly like the right one. The
+    source is the only thing that separates 'your escrow is corrupt' from 'you
+    compared the wrong file', and those remedies are opposites.
+
+    The three fixture paths are pairwise distinct AND distinct from
+    DEFAULT_IDENTITY, so a mutant that returns any constant is visible.
+    """
+    for var in B.IDENTITY_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+
+    path, source = B.resolve_identity_with_source()
+    expected = B.DEFAULT_IDENTITY if expect_path is None else Path(expect_path)
+    assert path == expected
+    assert source == expect_source
+    # the two-return helper and the one-return one must never disagree
+    assert B.resolve_identity() == path
+
+
+def test_the_env_var_ORDER_is_declared_once_and_the_default_is_not_a_path():
+    """`resolve_identity()` delegates rather than repeating the loop: two copies
+    of a precedence order drift silently, because both return a plausible path."""
+    assert B.IDENTITY_ENV_VARS == ("ASIB_AGE_IDENTITY", "SOPS_AGE_KEY_FILE")
+    src = Path(B.__file__).read_text(encoding="utf-8")
+    body = src.split("def resolve_identity(", 1)[1].split("\ndef ", 1)[0]
+    assert "resolve_identity_with_source" in body, (
+        "resolve_identity() re-implements the order instead of delegating")
+    assert "os.environ" not in body, "a SECOND copy of the env order"
+    # the sentinel is a sentence, never a path — a message must not read
+    # "chosen by None" or "chosen by /some/path" where a source belongs.
+    assert isinstance(B.IDENTITY_SOURCE_DEFAULT, str)
+    assert "/" not in B.IDENTITY_SOURCE_DEFAULT
+
+
+def _mismatch_verdict(escrow_world, source):
+    """A BYTES-DIFFER-MATERIALLY run with a stated (or unstated) source."""
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.run(bw=_cli(FakeBw(items=[_item(notes=OTHER_KEY)])),
+               identity=escrow_world["identity"], item_name=ITEM,
+               identity_source=source, store=escrow_world["store"], now=NOW)
+    assert ei.value.token == "BYTES-DIFFER-MATERIALLY"
+    return ei.value.verdict
+
+
+def test_a_mismatch_on_an_ENV_CHOSEN_identity_warns_BEFORE_the_remedy(escrow_world):
+    """🔴 THE REGRESSION. The old message named only the resolved PATH, so a
+    redirected comparison read as a damaged escrow and the advice it gave —
+    re-escrow from the on-disk identity — would have destroyed a good escrow."""
+    msg = _mismatch_verdict(escrow_world, "$SOPS_AGE_KEY_FILE")
+    assert "$SOPS_AGE_KEY_FILE" in msg, "the message does not name what redirected it"
+    assert "READ THIS BEFORE RE-ESCROWING" in msg
+    assert "WRONG FILE" in msg
+    # the size-is-not-evidence fact, which is why the mismatch is ambiguous
+    assert "same size" in msg
+    # it must still route the operator to the tool that can actually decide
+    assert "restore-verify.py" in msg
+
+
+def test_a_mismatch_on_the_DEFAULT_identity_does_NOT_carry_the_redirect_warning(
+        escrow_world):
+    """The warning must DISCRIMINATE. If it printed unconditionally it would be
+    noise on the one path where the on-disk file really is the expected one, and
+    a reader would learn to skip it."""
+    msg = _mismatch_verdict(escrow_world, B.IDENTITY_SOURCE_DEFAULT)
+    assert B.IDENTITY_SOURCE_DEFAULT in msg
+    assert "READ THIS BEFORE RE-ESCROWING" not in msg
+    assert "$SOPS_AGE_KEY_FILE" not in msg
+    assert "restore-verify.py" in msg
+
+
+def test_a_mismatch_with_NO_stated_source_asserts_NOTHING_about_provenance(
+        escrow_world):
+    """🔴 The honest third branch. A caller that states no source must not have
+    a default INVENTED for it: 'chosen by the built-in default' on a run that
+    never checked is the same class of confident wrong sentence this whole
+    module exists to prevent."""
+    msg = _mismatch_verdict(escrow_world, None)
+    assert "chosen by" not in msg
+    assert "READ THIS BEFORE RE-ESCROWING" not in msg
+    assert B.IDENTITY_SOURCE_DEFAULT not in msg
+    assert "restore-verify.py" in msg
+
+
+def test_print_plan_discloses_an_ENV_REDIRECT_before_any_password_is_spent(
+        monkeypatch, capsys, tmp_path):
+    """🔴 EXERCISES main()'s OWN derivation. The suite is otherwise hermetic —
+    every other test injects the identity — so main()'s resolution is exactly
+    the code that was never covered when this failed live.
+
+    `--print-plan` runs no `bw` and touches no network, so this is the check an
+    operator can make BEFORE typing a master password.
+    """
+    key = tmp_path / "redirected.key"
+    key.write_text(OTHER_KEY, encoding="utf-8")
+    for var in B.IDENTITY_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("SOPS_AGE_KEY_FILE", str(key))
+
+    assert EV.main(["--print-plan"]) == EV.EXIT_OK
+    out = capsys.readouterr().out
+    assert "chosen by: $SOPS_AGE_KEY_FILE" in out
+    assert "NOT the default" in out
+    assert str(key) in out
+
+
+def test_print_plan_on_the_DEFAULT_identity_does_not_cry_redirect(
+        monkeypatch, capsys):
+    """The negative control for the test above: a clean environment must not
+    print a warning, or the warning stops meaning anything."""
+    for var in B.IDENTITY_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    assert EV.main(["--print-plan"]) == EV.EXIT_OK
+    out = capsys.readouterr().out
+    assert f"chosen by: {B.IDENTITY_SOURCE_DEFAULT}" in out
+    assert "NOT the default" not in out
+
+
+def test_an_explicit_identity_FLAG_is_reported_as_the_operators_own_choice(
+        monkeypatch, capsys, tmp_path):
+    """--identity is the one choice the operator definitely made deliberately.
+    Reporting it as an environment redirect would send them chasing a variable
+    they never set — and it must WIN over a set env var, not merely coexist."""
+    key = tmp_path / "explicit.key"
+    key.write_text(OTHER_KEY, encoding="utf-8")
+    monkeypatch.setenv("SOPS_AGE_KEY_FILE", "/srv/should-have-been-overridden.key")
+
+    assert EV.main(["--print-plan", "--identity", str(key)]) == EV.EXIT_OK
+    out = capsys.readouterr().out
+    assert "chosen by: the --identity flag" in out
+    assert "$SOPS_AGE_KEY_FILE" not in out
+    assert "should-have-been-overridden" not in out
+    assert str(key) in out

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -2662,14 +2662,25 @@ def test_same_identity_file_asks_about_the_FILE_not_the_spelling(tmp_path):
     # `~` must expand: argparse does NOT expanduser, so a quoted
     # `--identity '~/...'` arrives literally and would otherwise never match.
     home = Path.home()
+    # BOTH sides — dropping `.expanduser()` from `b` alone survived a guard
+    # that only ever put `~` in position `a`. The NUL assertions below are
+    # symmetric; this one was not, and the asymmetry was an oversight.
     assert B.same_identity_file(Path("~"), home)
+    assert B.same_identity_file(home, Path("~"))
     assert not B.same_identity_file(Path("~"), home / "definitely-not-here")
+    assert not B.same_identity_file(home / "definitely-not-here", Path("~"))
     # 🔴 THE EXCEPTION BELT, MADE REACHABLE. An embedded NUL is the one input
     # that actually raises out of `resolve()` (ValueError, measured — symlink
     # loops, deep chains and unreadable parents all return normally on 3.12).
     # Without this the fallback was dead code and mutating it to the UNSAFE
     # `return True` — which would silence the warning for every path — survived
     # the whole suite.
+    # 🔴 THE PRECONDITION, ASSERTED. Without this the pair below pins only the
+    # OUTCOME: on a runtime whose `resolve()` stopped raising, the belt would
+    # silently become dead code again and the unsafe `return True` mutant would
+    # pass. Measured raising on 3.12 and 3.13; this says so the day it changes.
+    with pytest.raises(ValueError):
+        Path("a\x00b").expanduser().resolve()
     assert not B.same_identity_file(Path("a\x00b"), real)
     assert not B.same_identity_file(real, Path("a\x00b"))
     # a path that does not exist must compare, not raise
@@ -2900,6 +2911,27 @@ def test_the_SUCCESS_line_from_a_REAL_run_discloses_a_non_default_identity(
     assert "escrow OK" in line
     assert "NOT the default identity" in line
     assert "$SOPS_AGE_KEY_FILE" in line
+
+
+def test_no_source_renders_a_SELF_CONTRADICTING_refusal():
+    """🔴 RENDERS THE WHOLE PARAGRAPH, not just the helper.
+
+    `_undo_advice()` fixed the last sentence; the FIRST one still read "the
+    built-in default redirected the on-disk path away from …" — the same class
+    of nonsense, one sentence earlier. A test that calls the helper in
+    isolation structurally cannot see that, which is why this one renders
+    `provenance_clauses` instead.
+    """
+    for src in ("$SOPS_AGE_KEY_FILE", "$ASIB_AGE_IDENTITY",
+                EV.IDENTITY_SOURCE_FLAG, B.IDENTITY_SOURCE_DEFAULT):
+        chose, redirect = EV.provenance_clauses(Path("/srv/elsewhere.key"), src)
+        assert redirect, src
+        # only an ENV VAR can have "redirected" anything
+        if not src.startswith("$"):
+            assert "redirected" not in redirect, (src, redirect)
+            assert "env -u" not in redirect, (src, redirect)
+        # and nothing may claim a flag is settable by a shell
+        assert "unrelated shell" not in redirect, (src, redirect)
 
 
 def test_the_undo_advice_matches_the_KIND_of_source():

--- a/scripts/tests/test_analyze_service_index_restore_verify.py
+++ b/scripts/tests/test_analyze_service_index_restore_verify.py
@@ -3057,6 +3057,13 @@ def test_the_identity_note_asks_about_the_FILE_not_the_env(tmp_path):
     assert RV._identity_note(B.DEFAULT_IDENTITY) == ""
     note = RV._identity_note(tmp_path / "somewhere-else.key")
     assert "NOT the default identity" in note
+    # 🔴 ALL THREE SOURCES. Asserting only the two env vars let the message be
+    # reverted to exactly the wording the previous round rejected — an operator
+    # who used `--identity` sent to check two variables that had no effect on
+    # their run — with the whole suite green. `--identity` is the word this
+    # guard exists for, and it is the likely path: escrow-verify's mismatch
+    # message explicitly says "pass it the SAME --identity you used here".
+    assert "--identity" in note, note
     assert "ASIB_AGE_IDENTITY" in note and "SOPS_AGE_KEY_FILE" in note
 
 

--- a/scripts/tests/test_analyze_service_index_restore_verify.py
+++ b/scripts/tests/test_analyze_service_index_restore_verify.py
@@ -3039,3 +3039,46 @@ def test_the_PRODUCER_points_at_the_verifier_for_the_downstream_half():
         "backup.py's --print-plan never mentions restore-verify.py, so nothing "
         "the operator reads says the uploaded object is verified separately — "
         "or that it is verified at all")
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 WHICH IDENTITY DID IT ACTUALLY USE — the seam with escrow-verify.py
+#
+# escrow-verify.py's mismatch message SENDS the operator here ("restore-verify.py
+# answers that"). If this tool silently resolves its own identity through the
+# same environment variables, the handover lands on the same redirected key and
+# the second opinion is a second sample of the first mistake — a control that
+# shares the step under suspicion is not a control.
+# --------------------------------------------------------------------------- #
+def test_the_identity_note_asks_about_the_FILE_not_the_env(tmp_path):
+    """The deployed backup unit exports SOPS_AGE_KEY_FILE=<the default path>,
+    so "an env var is set" is TRUE on the normal configuration and must not
+    produce a warning. Only a genuinely different file may."""
+    assert RV._identity_note(B.DEFAULT_IDENTITY) == ""
+    note = RV._identity_note(tmp_path / "somewhere-else.key")
+    assert "NOT the default identity" in note
+    assert "ASIB_AGE_IDENTITY" in note and "SOPS_AGE_KEY_FILE" in note
+
+
+def test_the_DECRYPT_FAILED_message_names_a_redirect_as_a_THIRD_mechanism():
+    """That message enumerates two mechanisms — wrong key, damaged ciphertext.
+    A redirected identity is a third, and without it the 'wrong key' arm reads
+    as a fact about the escrow or the artifact when it is neither."""
+    src = SCRIPT.read_text(encoding="utf-8")
+    assert "_identity_note(identity)" in src, (
+        "the DECRYPT FAILED message no longer states which identity it used")
+
+
+def test_print_plan_discloses_a_REDIRECTED_identity(tmp_path, identity):
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "x"}, commits=1)
+    # `_cli` supplies the identity through ASIB_AGE_IDENTITY, so this also
+    # exercises the env arm — the one that caused the incident.
+    r = _cli("--print-plan", "--store", str(store), identity=identity)
+    assert "chosen by: $ASIB_AGE_IDENTITY" in r.stdout, r.stdout
+    # the fixture identity is a throwaway key, never the operator's default
+    assert "NOT the default identity" in r.stdout, r.stdout
+
+    # ...and the explicit-flag arm reports itself as the flag, not as an env var
+    r2 = _cli("--print-plan", "--store", str(store), "--identity", str(identity))
+    assert "chosen by: the --identity flag" in r2.stdout, r2.stdout

--- a/scripts/tests/test_analyze_service_index_restore_verify.py
+++ b/scripts/tests/test_analyze_service_index_restore_verify.py
@@ -3082,3 +3082,39 @@ def test_print_plan_discloses_a_REDIRECTED_identity(tmp_path, identity):
     # ...and the explicit-flag arm reports itself as the flag, not as an env var
     r2 = _cli("--print-plan", "--store", str(store), "--identity", str(identity))
     assert "chosen by: the --identity flag" in r2.stdout, r2.stdout
+
+
+def test_restore_print_plan_is_SILENT_for_the_DEFAULT_identity(
+        tmp_path, monkeypatch, capsys):
+    """🔴 THE NEGATIVE CONTROL. Without it, mutating this tool's trigger to warn
+    UNCONDITIONALLY leaves the whole suite green — i.e. the sibling of the exact
+    permanently-red-warning bug that was just fixed in escrow-verify.py could be
+    reintroduced here undetected. The positive case alone cannot see it.
+
+    Hermetic: the default is monkeypatched onto a tmp file, so this never reads
+    the operator's real key (a test that did turned the sandbox tier red).
+    """
+    key = tmp_path / "the-default.key"
+    key.write_text("an identity file's contents", encoding="utf-8")
+    monkeypatch.setattr(B, "DEFAULT_IDENTITY", key)
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "x"}, commits=1)
+
+    RV.print_plan(bucket="a-bucket", prefix="a-host/", store=store,
+                  identity=key, scope_filter=None, verify_all=False,
+                  max_lag_days=1.0, identity_source="$SOPS_AGE_KEY_FILE")
+    out = capsys.readouterr().out
+    assert "chosen by: $SOPS_AGE_KEY_FILE" in out, out
+    assert "NOT the default identity" not in out, (
+        "restore-verify warned about the DEFAULT identity — the same "
+        "permanently-red warning that was just removed from escrow-verify")
+
+    # ...and the positive case, so this pair discriminates rather than just
+    # asserting silence (a print_plan that printed nothing would pass alone).
+    other = tmp_path / "somewhere-else.key"
+    other.write_text("different", encoding="utf-8")
+    RV.print_plan(bucket="a-bucket", prefix="a-host/", store=store,
+                  identity=other, scope_filter=None, verify_all=False,
+                  max_lag_days=1.0, identity_source="$SOPS_AGE_KEY_FILE")
+    out2 = capsys.readouterr().out
+    assert "NOT the default identity" in out2, out2


### PR DESCRIPTION
Three defects, all surfaced by one live run on 2026-08-25 in which the operator spent a master password and got a **confident wrong answer** — plus a fourth found by the adversarial audit of the first attempt to fix it. None is a logic bug; all are claims the code made that it had not earned.

> ⚠️ **This body was rewritten after the audit.** Its first version made two false claims of its own — see the correction comment on this PR. The table of sources listed three entries when there are four, and it said the refusal "leads" when the code appended it *after* the remedy. Both are now true of the code; they were not when first written.

## 1. The advertised shell could not run its own command

`escrow-verify.py`'s failure messages hand the operator an exact `nix-shell` command. It provisioned `bitwarden-cli jq` only — but `--decrypt-check` reaches MinIO through `backup.MinioUploader`, whose `minio` import is **lazy** (inside the method, not at module scope).

So the advertised shell parsed, started, unlocked the vault, and *then* died:

```
ModuleNotFoundError: No module named 'minio'
```

— after the password had been spent. The lazy import is why this survived every import-time check and only appeared mid-run against the real bucket. A hint that cannot complete its own invocation is worse than no hint, because it is followed.

**Fix:** the packages are a ledger (`NIX_SHELL_PACKAGES`) and the hint is *derived* from it, pinned against `DECRYPT_PYTHON_MODULES`. Quoting is `shlex.quote`, and the guard runs the rendered hint through **`bash -n`** with an unquoted positive control — the first version asserted via `shlex.split`, which does not treat parens as metacharacters, so deleting the quoting entirely left the suite green while the advertised command became a bash syntax error.

## 2. A mismatch never said which file it compared

The run returned `rc=22 BYTES-DIFFER-MATERIALLY`, *"189 escrowed bytes vs 189 on disk"*, and advised re-escrowing from the on-disk identity. **Following that advice would have overwritten a good escrow with an unrelated third party's age key.**

`resolve_identity()` reads `ASIB_AGE_IDENTITY` → `SOPS_AGE_KEY_FILE` → the default. `SOPS_AGE_KEY_FILE` was exported by unrelated work and had redirected the on-disk side to a different key. The message named the resolved *path* but never said anything had chosen it.

🔴 **"189 vs 189" is not corroboration — it is what two DIFFERENT keys look like.** Every age identity file is the same size (fixed-width `# created:`, `# public key:` and key lines), so equal byte counts carry no information about whether the keys match. That is what made the wrong reading so plausible.

## 3. 🔴 The first fix asked the WRONG QUESTION — and printed two false sentences

Found by audit, reproduced live before fixing. The first revision branched on **what named the file** rather than **which file it was**:

```
$ escrow-verify.py --print-plan --identity ~/workspace/homelab-talos/.secrets/age.key
chosen by: the --identity flag  <- NOT the default; an unrelated shell can set this
```

That path **is** the default, and **no shell can set a command-line flag**. Worse, it was the command this PR's own handoff doc recommends. The same false line fired for `SOPS_AGE_KEY_FILE=<the default path>` — which is exactly what the deployed backup unit exports (`nix/home.nix`) — making it a **permanently-red warning on the subsystem's own normal configuration**, the precise thing that trains a reader to skip the sentence when it finally matters.

**Fix:** `B.same_identity_file()` (symlink-resolving, non-strict) is the trigger; the source is carried as *information*. Four sources, and the warning must discriminate:

| resolved file | stated source | message |
|---|---|---|
| **is** the default | any of the four | names the source, **no** warning |
| not the default | an env var | names it + refusal + `env -u <VAR>` to undo the redirect |
| not the default | `--identity` | its own wording — a flag is a deliberate act, so no "unrelated shell", and it does **not** advise re-running with the flag they just used |
| any | none stated | asserts **nothing** — no default is invented for a caller that never checked |

The refusal now genuinely precedes the remedy it argues against. `--print-plan` discloses a redirect before any password is spent, and the **success** line discloses one too — "escrow OK — matches `<path>`" is where an undisclosed wrong-file comparison is least likely to be questioned.

## 4. The sibling tool had the same blind spot

The mismatch message routes the operator to `restore-verify.py` — which resolved its own identity through the same env vars, so the handover would land on the same redirected key. A control that shares the step under suspicion is not a control. It now discloses provenance in `--print-plan` and names a redirect as a third mechanism in its `DECRYPT FAILED` message (which previously enumerated only "wrong key or damaged ciphertext").

## Verification

**Red at base `a8089a51`, green at HEAD — by execution**, not by the new tests' collection error:

| defect | base | HEAD |
|---|---|---|
| advertised hint | `nix-shell -p bitwarden-cli jq --run '<command>'` | `… jq 'python3.withPackages(p:[p.minio])' --run …` |
| `--print-plan` under a real redirect | path only, no disclosure | `chosen by: $SOPS_AGE_KEY_FILE  <- NOT the default identity` |
| `--identity <the default>` | *(first fix)* falsely "NOT the default" | `chosen by: the --identity flag`, no warning |
| `SOPS_AGE_KEY_FILE=<the default>` | *(first fix)* falsely "NOT the default" | `chosen by: $SOPS_AGE_KEY_FILE`, no warning |

**Mutation sweep — 10 semantic mutants, not deletions**, `PYTHONDONTWRITEBYTECODE=1` (the repo's documented stale-bytecode trap), each asserting its own edit applied so a no-op cannot score as a kill: **10/10 KILLED**, including the original bug deliberately reintroduced and a positive control. All seven survivors the audit reported are now caught.

Both gate tiers on the head under review (`93f77813`), run separately because they are different environments, and read from output rather than exit codes:

| tier | pytest | node |
|---|---|---|
| dev host — `scripts/gate.sh --tier both --set all` | 15,871 passed / 0 failed (floor 13,753) | 1,219 / 0 |
| nix sandbox — `nix build .#checks.x86_64-linux.{pytests,nodetests}` | 15,871 passed / 0 failed | 1,219 / 0 |

🔴 **They disagreed one commit earlier, and that is the point.** At `6225610a` the dev-host tier was green at 15,865 while the sandbox tier was **RED** — one test in 27 targets, which read the operator's real age key and so passed only on the machine that has it. `env HOME=<empty dir>` reproduces that whole class in ~20s without a nix build.

## Review rounds

Three adversarial rounds; each of the first two found a real defect in the previous round's fix.

| round | verdict | what it caught |
|---|---|---|
| 1 | needs rework | the first provenance fix branched on **what named** the identity, not **which file** it was, and printed two false sentences — one on the command this PR's own doc recommends. Plus 7 mutation survivors. |
| 2 | merge after fixing 🔴 | the round-1 fix shipped an environment-dependent test that turned the merge-gating tier red; the success-line disclosure was inert-able with a green suite; nothing pinned `DEFAULT_IDENTITY` to what the backup unit actually exports. |
| 3 | safe to merge, no 🔴 | the round-2 fix was **unguarded** — reverting `restore-verify`'s note to the wording round 2 rejected left all 450 tests green. An unguarded fix is a comment, not a guarantee. |
| 4 | safe to merge, no 🔴 | one 🟢: the neutral refusal arm had only word-**absence** assertions, so an **inverted safety claim** ("this certainly means the escrow is DAMAGED, re-escrow at once") using none of the forbidden words passed 451/451. Fixed anyway — pinned whole. |

Three instrument failures were caught during this work, each of which would have produced a confident false result — recorded because none is visible in the diff:

- a mutation sweep that copied only `scripts/`, so the unmutated baseline failed 19 tests and every mutant "died" for that reason — a clean 5/5 measuring nothing;
- a sandbox copied with `rsync -a` carrying **valid** `__pycache__`, so it executed bytecode from the original tree and code mutants scored SURVIVED. 🔴 `PYTHONDONTWRITEBYTECODE=1` does **not** prevent this — it stops writing, not reading;
- a background-task notification reporting **"exit code 0"** for a build that failed, because a trailing `echo` owned the pipeline's status.

Every sweep here now runs an unmutated baseline first and requires it GREEN, asserts no `.pyc` reached the sandbox, and includes a no-op control that must SURVIVE — so a harness that reddens everything is distinguishable from real coverage.

Detail: **round 3's first mutation sweep was invalid** — it copied only `scripts/`, so the unmutated baseline failed 19 tests and all five mutants "died" for that reason, reporting a clean 5/5 that measured nothing. Corrected, the baseline returns 450 passed and each mutant dies with exactly one failure.

## Out of scope

Whether the escrowed note matches the real `age.key` is **still unconfirmed** — the 08-25 run neither confirmed nor refuted the 08-23 `cmp`, because it compared against the wrong file. The on-disk homelab key *is* confirmed as the one the bucket opens (`restore-verify.py` → rc=0, 10 artifacts, 214 commits, timer-produced).

Not covered by any guard here: the **non-Python** tools the decrypt path needs (`age`, `kubectl`, `git`) resolve from the ambient profile because `nix-shell -p` is impure. `--pure`, a root shell, or a fresh host would reproduce the same class of failure with nothing watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
