### PR TITLE
feat(initiative-scan): --exclude-slugs, salvaged from a stranded WIP — explicit list only, never an inferred "this looks done"

### DIFF
--- a/scripts/session-analysis/initiative-scan.py
+++ b/scripts/session-analysis/initiative-scan.py
@@ -62,10 +62,12 @@ Usage:
            slug derived from the handoff filename — the slug shown on each row.
            EXPLICIT ONLY: the scan never infers that an initiative is finished, so
            nothing disappears from this report unless you name it here.
-           🔴 A slug is NOT repo-unique — it comes from the handoff filename, and two
-           repos can hold `handoff-<same-slug>-<date>.md`. One name therefore suppresses
-           the matching row in EVERY repo. Read the `SUPPRESSED N` count: N larger than
-           the number of slugs you passed means you hit more repos than you meant to.
+           🔴 A slug is NOT repo-unique. Doc-anchored rows take it from the handoff
+           filename and two repos can hold `handoff-<same-slug>-<date>.md`; session-only
+           rows derive it from the session title, so a suppressible slug need not
+           correspond to ANY file on disk. Either way one name suppresses the matching
+           row in EVERY repo. Read the `SUPPRESSED N` count: N larger than the number of
+           slugs you passed means you hit more repos than you meant to.
            Matching is exact and CASE-SENSITIVE: `Alpha` never matches `alpha`, and
            reports `SUPPRESSED 0` rather than erroring.
            A suppressed initiative takes its live tmux session out of the report with

--- a/scripts/session-analysis/initiative-scan.py
+++ b/scripts/session-analysis/initiative-scan.py
@@ -49,7 +49,7 @@ Populate the password from SOPS (homelab-talos trunk):
       sops -d --extract '["stringData"]["reader-password"]' /tmp/s.yaml); rm -f /tmp/s.yaml
 
 Usage:
-  initiative-scan.py [--days N] [--json] [--repo PATH] [--tmux]
+  initiative-scan.py [--days N] [--json] [--repo PATH] [--tmux] [--exclude-slugs S1,S2,...]
   --days   trailing window in days (default 5)
   --json   machine-readable output (the raw per-initiative data)
   --repo   restrict to a single repo path (default: auto-discover under ~/workspace)
@@ -57,6 +57,11 @@ Usage:
            claude pane title against the initiative slug/title, scoped by the pane's
            cwd→repo); also lists live claude sessions with no matched initiative.
            Best-effort: no tmux server -> initiatives simply show [no session].
+  --exclude-slugs  comma-separated initiative slugs to suppress from the report, e.g.
+           "observability-gaps-audit,evaluate-script-then-validate". Matches the base
+           slug derived from the handoff filename — the `[slug]` shown on each row.
+           EXPLICIT ONLY: the scan never infers that an initiative is finished, so
+           nothing disappears from this report unless you name it here.
 
 HONESTY NOTE: this measures ACTIVITY, RECENCY, and EFFORT (commits / sessions /
 telemetry events / handoff freshness) plus the human-written "Next steps" line —
@@ -2266,7 +2271,8 @@ def build_report(days: int, repos: list[str] | None = None,
                  client=None, projects_root: str = PROJECTS_ROOT,
                  now: float | None = None, include_tmux: bool = False,
                  panes: list[dict] | None = None,
-                 gh_ok: bool | None = None) -> dict:
+                 gh_ok: bool | None = None,
+                 exclude_slugs: set[str] | None = None) -> dict:
     """Fuse the three sources into a ranked, per-repo report dict.
 
     `client` may be None (telemetry skipped). `repos` None -> auto-discover from the
@@ -2358,6 +2364,22 @@ def build_report(days: int, repos: list[str] | None = None,
     initiatives = [i for i in initiatives
                    if i.get("last_touch") is not None and i["last_touch"] >= cutoff]
 
+    # Operator-supplied suppression. Deliberately the ONLY way a row leaves this report
+    # for a reason other than the `--days` window: an earlier WIP (PR #778) inferred
+    # "resolved" from markers in the handoff text and, measured over the real corpus,
+    # flagged 11 of 62 docs — 8 of them on section headings like `### DONE this session`
+    # inside handoffs that carried live next-steps. A scan whose whole job is answering
+    # "what am I working on" must not hide a row on a guess, so this list is explicit.
+    # A suppressed row must stay AUDIBLE: report the slugs asked for and the number
+    # actually removed separately, so `--exclude-slugs typo` reads as "0 suppressed"
+    # rather than looking identical to a run that had nothing to suppress.
+    excluded_slugs = sorted(exclude_slugs) if exclude_slugs else []
+    excluded_count = 0
+    if exclude_slugs:
+        kept = [i for i in initiatives if i.get("slug") not in exclude_slugs]
+        excluded_count = len(initiatives) - len(kept)
+        initiatives = kept
+
     initiatives = sort_initiatives(initiatives)
 
     # Sets aren't JSON-serializable and the renderer wants a stable order.
@@ -2381,6 +2403,10 @@ def build_report(days: int, repos: list[str] | None = None,
     return {
         "days": days,
         "telemetry_available": telemetry_available,
+        # What the operator asked to hide, and how many rows that actually removed.
+        # Both, because they can disagree — a misspelled slug suppresses nothing.
+        "excluded_slugs": excluded_slugs,
+        "excluded_count": excluded_count,
         # Says which zeroes are MEASURED and which are "not wired up here":
         # False means every `open_prs: []` / `merged_prs: 0` in this report is
         # an absence of data, not an absence of PRs.
@@ -2435,6 +2461,11 @@ def render(report: dict, now: float | None = None) -> str:
                "its momentum + next step. Momentum = recency of touch, NOT % done.")
     out.append(f"   Showing only initiatives touched in the last {days}d "
                "(or with a live tmux session); widen --days to resurface older/stalled work.")
+    # Say it out loud. A hidden row that nobody knows is hidden is how this report
+    # starts lying about what is in flight.
+    if report.get("excluded_slugs"):
+        out.append(f"   --exclude-slugs SUPPRESSED {report.get('excluded_count', 0)} "
+                   f"initiative(s); asked for: {', '.join(report['excluded_slugs'])}")
 
     repo_names = sorted(report["by_repo"].keys()) or report.get("repos", [])
     for repo in repo_names:
@@ -2537,7 +2568,24 @@ def parse_args(argv=None) -> argparse.Namespace:
     p.add_argument("--repo", default=None, help="restrict to a single repo path")
     p.add_argument("--tmux", action="store_true",
                    help="link each initiative to the live tmux session(s) hosting it")
+    p.add_argument("--exclude-slugs", default=None,
+                   help="comma-separated initiative slugs to suppress from the report")
     return p.parse_args(argv)
+
+
+def parse_exclude_slugs(raw: str | None) -> set[str] | None:
+    """Split a `--exclude-slugs` value into a slug set, or None if it names nothing.
+
+    Strips whitespace and drops empty tokens, so `"a, b"`, `"a,b,"` and `"a , b"` all
+    give `{"a", "b"}` — a bare `.split(",")` would yield `" b"` and `""`, which match
+    no slug and would silently suppress nothing while looking like they did. A value
+    that is all separators (`","`, `"  "`) returns None: nothing was named.
+    """
+    if not raw:
+        return None
+    slugs = {tok.strip() for tok in raw.split(",")}
+    slugs.discard("")
+    return slugs or None
 
 
 def main(argv=None) -> int:
@@ -2566,7 +2614,8 @@ def main(argv=None) -> int:
     except RuntimeError:
         client = None  # telemetry optional — degrade gracefully
 
-    report = build_report(a.days, repos=repos, client=client, include_tmux=a.tmux)
+    report = build_report(a.days, repos=repos, client=client, include_tmux=a.tmux,
+                          exclude_slugs=parse_exclude_slugs(a.exclude_slugs))
 
     if a.json:
         print(json.dumps(report, indent=2, default=str))

--- a/scripts/session-analysis/initiative-scan.py
+++ b/scripts/session-analysis/initiative-scan.py
@@ -59,9 +59,18 @@ Usage:
            Best-effort: no tmux server -> initiatives simply show [no session].
   --exclude-slugs  comma-separated initiative slugs to suppress from the report, e.g.
            "observability-gaps-audit,evaluate-script-then-validate". Matches the base
-           slug derived from the handoff filename — the `[slug]` shown on each row.
+           slug derived from the handoff filename — the slug shown on each row.
            EXPLICIT ONLY: the scan never infers that an initiative is finished, so
            nothing disappears from this report unless you name it here.
+           🔴 A slug is NOT repo-unique — it comes from the handoff filename, and two
+           repos can hold `handoff-<same-slug>-<date>.md`. One name therefore suppresses
+           the matching row in EVERY repo. Read the `SUPPRESSED N` count: N larger than
+           the number of slugs you passed means you hit more repos than you meant to.
+           Matching is exact and CASE-SENSITIVE: `Alpha` never matches `alpha`, and
+           reports `SUPPRESSED 0` rather than erroring.
+           A suppressed initiative takes its live tmux session out of the report with
+           it — it does NOT reappear under "no matched initiative". The header says how
+           many suppressed rows held a live session so that loss is never silent.
 
 HONESTY NOTE: this measures ACTIVITY, RECENCY, and EFFORT (commits / sessions /
 telemetry events / handoff freshness) plus the human-written "Next steps" line —
@@ -2281,6 +2290,10 @@ def build_report(days: int, repos: list[str] | None = None,
     read (for tests / reproducibility). `gh_ok` overrides the `gh_available()` probe
     the same way — a test that stubs `gh_open_prs` must state which world it is in,
     rather than letting the report's honesty flag depend on the host running it.
+    `exclude_slugs` suppresses initiatives by EXACT slug — operator-supplied only, never
+    inferred; None and an empty set both mean "no filter". Applied after the `--days`
+    window, so `excluded_count` counts rows removed from what would otherwise be shown.
+    Slugs are not repo-unique, so one name can remove a row from several repos.
     """
     now_epoch = now if now is not None else time.time()
 
@@ -2367,17 +2380,27 @@ def build_report(days: int, repos: list[str] | None = None,
     # Operator-supplied suppression. Deliberately the ONLY way a row leaves this report
     # for a reason other than the `--days` window: an earlier WIP (PR #778) inferred
     # "resolved" from markers in the handoff text and, measured over the real corpus,
-    # flagged 11 of 62 docs — 8 of them on section headings like `### DONE this session`
-    # inside handoffs that carried live next-steps. A scan whose whole job is answering
-    # "what am I working on" must not hide a row on a guess, so this list is explicit.
+    # flagged 11 of 62 docs at 199774f8 — 7 of them on section headings like
+    # `### DONE this session` inside handoffs that carried live next-steps. A scan whose
+    # whole job is answering "what am I working on" must not hide a row on a guess, so
+    # this list is explicit.
     # A suppressed row must stay AUDIBLE: report the slugs asked for and the number
     # actually removed separately, so `--exclude-slugs typo` reads as "0 suppressed"
     # rather than looking identical to a run that had nothing to suppress.
+    # Deliberately placed AFTER the `--days` window filter: `excluded_count` then means
+    # "rows removed from what you WOULD have seen", not "rows removed from all of history".
     excluded_slugs = sorted(exclude_slugs) if exclude_slugs else []
     excluded_count = 0
+    excluded_live = 0
     if exclude_slugs:
         kept = [i for i in initiatives if i.get("slug") not in exclude_slugs]
-        excluded_count = len(initiatives) - len(kept)
+        dropped = [i for i in initiatives if i.get("slug") in exclude_slugs]
+        excluded_count = len(dropped)
+        # A suppressed initiative takes its LIVE tmux pane out of the report with it —
+        # it is not re-surfaced under `tmux_unmatched`, which is computed earlier. So the
+        # one thing the operator must not silently lose ("which session is X in") gets
+        # counted and announced separately from the row count.
+        excluded_live = sum(1 for i in dropped if i.get("tmux_sessions"))
         initiatives = kept
 
     initiatives = sort_initiatives(initiatives)
@@ -2407,6 +2430,9 @@ def build_report(days: int, repos: list[str] | None = None,
         # Both, because they can disagree — a misspelled slug suppresses nothing.
         "excluded_slugs": excluded_slugs,
         "excluded_count": excluded_count,
+        # Of the suppressed rows, how many held a LIVE tmux session. Separate because
+        # losing a live pane is a different kind of loss from hiding a stale row.
+        "excluded_live": excluded_live,
         # Says which zeroes are MEASURED and which are "not wired up here":
         # False means every `open_prs: []` / `merged_prs: 0` in this report is
         # an absence of data, not an absence of PRs.
@@ -2464,8 +2490,11 @@ def render(report: dict, now: float | None = None) -> str:
     # Say it out loud. A hidden row that nobody knows is hidden is how this report
     # starts lying about what is in flight.
     if report.get("excluded_slugs"):
+        live = report.get("excluded_live", 0)
         out.append(f"   --exclude-slugs SUPPRESSED {report.get('excluded_count', 0)} "
-                   f"initiative(s); asked for: {', '.join(report['excluded_slugs'])}")
+                   f"initiative(s)"
+                   + (f", {live} with a LIVE session" if live else "")
+                   + f"; asked for: {', '.join(report['excluded_slugs'])}")
 
     repo_names = sorted(report["by_repo"].keys()) or report.get("repos", [])
     for repo in repo_names:

--- a/scripts/session-analysis/tests/test_initiative_scan.py
+++ b/scripts/session-analysis/tests/test_initiative_scan.py
@@ -2995,14 +2995,21 @@ def test_excluded_slugs_render_in_a_deterministic_order(tmp_path, monkeypatch):
     # Kills the mutant `sorted(exclude_slugs)` -> `list(exclude_slugs)`. Every earlier
     # test used a single-element set, where iteration order cannot vary. Set ordering is
     # salted per process, so the mutant produces output that differs BETWEEN RUNS.
+    #
+    # SIX slugs, not three. A 3-element set comes out already-sorted about 1 time in 6,
+    # so the mutant SURVIVED this test on 3 of 20 PYTHONHASHSEED values — a guard that
+    # only fires ~85% of the time. Six gives 1/720. The count is the guard's strength,
+    # so do not trim this list.
     import calendar
     now = float(calendar.timegm((2026, 7, 5, 0, 0, 0, 0, 0, 0)))
     repo = _two_initiative_repo(tmp_path, monkeypatch, now)
 
+    slugs = {"zulu", "alpha", "mike", "delta", "oscar", "bravo"}
     report = isc.build_report(14, repos=[str(repo)], client=None, now=now,
-                              exclude_slugs={"zulu", "alpha", "mike"})
-    assert report["excluded_slugs"] == ["alpha", "mike", "zulu"]        # sorted, not set order
-    assert "asked for: alpha, mike, zulu" in isc.render(report, now=now)
+                              exclude_slugs=slugs)
+    assert report["excluded_slugs"] == ["alpha", "bravo", "delta", "mike", "oscar", "zulu"]
+    assert ("asked for: alpha, bravo, delta, mike, oscar, zulu"
+            in isc.render(report, now=now))
 
 
 def test_suppression_runs_AFTER_the_days_window_so_the_count_means_rows_you_would_have_seen(
@@ -3115,10 +3122,32 @@ def test_suppressing_an_initiative_that_holds_a_LIVE_session_says_so(tmp_path, m
                             include_tmux=True, panes=panes, exclude_slugs={"alpha"})
     assert gone["excluded_count"] == 1
     assert gone["excluded_live"] == 1
+    # Pin the WHOLE normalised line, not a substring. A substring match leaves the
+    # separator punctuation unconstrained — dropping the comma, swapping in a semicolon
+    # and doubling the space all survived it. A cosmetic reword then fails this test;
+    # that is the trade for a machine-readable claim.
     out = isc.render(gone, now=now)
-    assert "1 with a LIVE session" in out
+    assert ("   --exclude-slugs SUPPRESSED 1 initiative(s), 1 with a LIVE session; "
+            "asked for: alpha") in out.splitlines()
     # Negative control: suppressing a row with NO live pane must not claim one.
     quiet = isc.build_report(14, repos=[str(repo)], client=None, now=now,
                              include_tmux=True, panes=panes, exclude_slugs={"beta"})
     assert quiet["excluded_count"] == 1 and quiet["excluded_live"] == 0
     assert "LIVE session" not in isc.render(quiet, now=now)
+
+    # `excluded_live` counts ROWS, not PANES. With one fixture pane the two are equal, so
+    # `sum(1 for ...)` -> `sum(len(...) for ...)` is invisible. Give the suppressed row
+    # TWO panes: rows stays 1, panes would read 2.
+    two_panes = panes + [{"session": "9", "window": "2", "title": "Alpha groundwork",
+                          "cwd": str(repo), "pane_id": "%2"}]
+    multi = isc.build_report(14, repos=[str(repo)], client=None, now=now,
+                             include_tmux=True, panes=two_panes)
+    live_rows = [i for i in multi["by_repo"][str(repo)] if i.get("tmux_sessions")]
+    assert len(live_rows) == 1 and len(live_rows[0]["tmux_sessions"]) == 2, (
+        f"fixture did not attach two panes to one row: {live_rows}")
+
+    multi_gone = isc.build_report(14, repos=[str(repo)], client=None, now=now,
+                                  include_tmux=True, panes=two_panes,
+                                  exclude_slugs={"alpha"})
+    assert multi_gone["excluded_count"] == 1
+    assert multi_gone["excluded_live"] == 1          # ROWS — 2 would mean it counted panes

--- a/scripts/session-analysis/tests/test_initiative_scan.py
+++ b/scripts/session-analysis/tests/test_initiative_scan.py
@@ -2961,3 +2961,164 @@ def test_a_handoff_that_says_DONE_is_still_reported(tmp_path, monkeypatch):
     # And no resolution verdict is computed or emitted anywhere in the payload.
     assert not hasattr(isc, "parse_resolved")
     assert all("resolved" not in i for i in report["by_repo"][str(repo)])
+
+
+# --------------------------------------------------------------------------- #
+# --exclude-slugs, round 2: the four mutants the first battery let through.
+# Found by the #824 pre-merge audit, not by the green suite. Each test below
+# names the mutant it kills so a future reader knows what it is FOR.
+# --------------------------------------------------------------------------- #
+def test_render_prints_the_REMOVED_count_not_the_REQUESTED_count(tmp_path, monkeypatch):
+    # Kills the mutant `render`: excluded_count -> len(excluded_slugs).
+    # The first render test only ever passed a slug that MATCHED, so request-size and
+    # real-count were both 1 and could not disagree — the mutant survived a green suite.
+    # The typo case was asserted on the report dict but never through render(), which is
+    # the surface the operator actually reads. Fixture makes the two numbers DIFFER.
+    import calendar
+    now = float(calendar.timegm((2026, 7, 5, 0, 0, 0, 0, 0, 0)))
+    repo = _two_initiative_repo(tmp_path, monkeypatch, now)
+
+    # Two slugs requested, ONE of them real -> requested=2, removed=1. Any implementation
+    # that prints the request size says 2 here.
+    out = isc.render(isc.build_report(14, repos=[str(repo)], client=None, now=now,
+                                      exclude_slugs={"alpha", "no-such-slug"}), now=now)
+    assert "SUPPRESSED 1 initiative(s)" in out
+    assert "SUPPRESSED 2 initiative(s)" not in out
+
+    # And the all-typo case, through render() rather than the dict.
+    typo = isc.render(isc.build_report(14, repos=[str(repo)], client=None, now=now,
+                                       exclude_slugs={"alhpa"}), now=now)
+    assert "SUPPRESSED 0 initiative(s); asked for: alhpa" in typo
+
+
+def test_excluded_slugs_render_in_a_deterministic_order(tmp_path, monkeypatch):
+    # Kills the mutant `sorted(exclude_slugs)` -> `list(exclude_slugs)`. Every earlier
+    # test used a single-element set, where iteration order cannot vary. Set ordering is
+    # salted per process, so the mutant produces output that differs BETWEEN RUNS.
+    import calendar
+    now = float(calendar.timegm((2026, 7, 5, 0, 0, 0, 0, 0, 0)))
+    repo = _two_initiative_repo(tmp_path, monkeypatch, now)
+
+    report = isc.build_report(14, repos=[str(repo)], client=None, now=now,
+                              exclude_slugs={"zulu", "alpha", "mike"})
+    assert report["excluded_slugs"] == ["alpha", "mike", "zulu"]        # sorted, not set order
+    assert "asked for: alpha, mike, zulu" in isc.render(report, now=now)
+
+
+def test_suppression_runs_AFTER_the_days_window_so_the_count_means_rows_you_would_have_seen(
+        tmp_path, monkeypatch):
+    # Kills the mutant that relocates the suppression block ABOVE the `--days` cutoff.
+    # `stale` is outside a 4d window, so the window already removed it: excluding it must
+    # report 0, not 1. Filtering first would count it and inflate the number the operator
+    # reads. Bounds overshoot the step deliberately (19d vs a 4d window) so the fixture
+    # cannot land exactly on the boundary and make the assertion unreachable.
+    import calendar
+    now = float(calendar.timegm((2026, 7, 5, 0, 0, 0, 0, 0, 0)))
+    repo = tmp_path / "r"
+    (repo / "claudedocs").mkdir(parents=True)
+    (repo / "claudedocs" / "handoff-fresh-2026-07-04.md").write_text(
+        "# Handoff: fresh\n## Next steps\n1. go\n")
+    (repo / "claudedocs" / "handoff-stale-2026-06-16.md").write_text(
+        "# Handoff: stale\n## Next steps\n1. go\n")
+    _stub_no_external_io(monkeypatch)
+    monkeypatch.setattr(isc, "worktree_canonical_map", lambda repos: {})
+    fresh = _sess("Fresh feature build", session_id="sf", cwd=str(repo),
+                  last_user_ts=now - isc.DAY, n_turns=10)
+    stale = _sess("Stale cleanup task", session_id="ss", cwd=str(repo),
+                  last_user_ts=now - 19 * isc.DAY, n_turns=10)
+    monkeypatch.setattr(isc, "collect_session_records", lambda root, d, n=5: [fresh, stale])
+
+    windowed_out = isc.build_report(4, repos=[str(repo)], client=None, now=now,
+                                    exclude_slugs={"stale"})
+    assert windowed_out["excluded_count"] == 0          # the WINDOW removed it, not us
+    assert {i["slug"] for i in windowed_out["by_repo"][str(repo)]} == {"fresh"}
+
+    # Control: widen the window and the same slug IS ours to remove -> 1.
+    in_window = isc.build_report(30, repos=[str(repo)], client=None, now=now,
+                                 exclude_slugs={"stale"})
+    assert in_window["excluded_count"] == 1
+    assert {i["slug"] for i in in_window["by_repo"][str(repo)]} == {"fresh"}
+
+
+def test_render_tolerates_a_report_predating_the_exclude_keys(tmp_path, monkeypatch):
+    # Kills the mutant `report.get("excluded_slugs")` -> `report["excluded_slugs"]`.
+    # `--json` output is written to disk and re-read by other tooling, so a report dict
+    # produced before these keys existed must still render instead of raising KeyError.
+    import calendar
+    now = float(calendar.timegm((2026, 7, 5, 0, 0, 0, 0, 0, 0)))
+    repo = _two_initiative_repo(tmp_path, monkeypatch, now)
+    legacy = isc.build_report(14, repos=[str(repo)], client=None, now=now)
+    for key in ("excluded_slugs", "excluded_count", "excluded_live"):
+        legacy.pop(key)
+
+    out = isc.render(legacy, now=now)                   # must not raise
+    assert "SUPPRESSED" not in out
+    assert "alpha" in out and "beta" in out
+
+
+def test_one_slug_suppresses_that_row_in_EVERY_repo(tmp_path, monkeypatch):
+    # Pins the documented cross-repo behaviour (module docstring): a slug comes from the
+    # handoff FILENAME and is not repo-unique, so `--exclude-slugs clawgate` removes the
+    # row from every repo that has one. Asserted so the surprise is a contract, not a
+    # discovery — and so `excluded_count` (2 for one requested slug) stays the tell.
+    import calendar
+    now = float(calendar.timegm((2026, 7, 5, 0, 0, 0, 0, 0, 0)))
+    repos = []
+    sessions = []
+    for name in ("r1", "r2"):
+        repo = tmp_path / name
+        (repo / "claudedocs").mkdir(parents=True)
+        (repo / "claudedocs" / "handoff-alpha-2026-07-04.md").write_text(
+            "# Handoff: alpha\n## Next steps\n1. go\n")
+        (repo / "claudedocs" / f"handoff-only-{name}-2026-07-04.md").write_text(
+            f"# Handoff: only {name}\n## Next steps\n1. go\n")
+        repos.append(str(repo))
+        sessions.append(_sess("Alpha groundwork", session_id=f"sa-{name}",
+                              cwd=str(repo), last_user_ts=now - isc.DAY, n_turns=10))
+        sessions.append(_sess(f"Only {name} groundwork", session_id=f"so-{name}",
+                              cwd=str(repo), last_user_ts=now - isc.DAY, n_turns=10))
+    _stub_no_external_io(monkeypatch)
+    monkeypatch.setattr(isc, "worktree_canonical_map", lambda repos_: {})
+    monkeypatch.setattr(isc, "collect_session_records", lambda root, d, n=5: sessions)
+
+    before = isc.build_report(14, repos=repos, client=None, now=now)
+    assert all("alpha" in {i["slug"] for i in before["by_repo"][r]} for r in repos)
+
+    after = isc.build_report(14, repos=repos, client=None, now=now,
+                             exclude_slugs={"alpha"})
+    assert all("alpha" not in {i["slug"] for i in after["by_repo"][r]} for r in repos)
+    # ONE slug requested, TWO rows gone across two repos — that gap is the warning.
+    assert after["excluded_count"] == 2
+    assert after["excluded_slugs"] == ["alpha"]
+    # The per-repo rows that were NOT named survive in both repos.
+    assert {i["slug"] for i in after["by_repo"][repos[0]]} == {"only-r1"}
+    assert {i["slug"] for i in after["by_repo"][repos[1]]} == {"only-r2"}
+
+
+def test_suppressing_an_initiative_that_holds_a_LIVE_session_says_so(tmp_path, monkeypatch):
+    # A suppressed row takes its live tmux pane with it and is NOT re-surfaced under
+    # `tmux_unmatched` (that is computed earlier). Losing sight of a live session is a
+    # different, worse loss than hiding a stale row, so it is counted and announced.
+    import calendar
+    now = float(calendar.timegm((2026, 7, 5, 0, 0, 0, 0, 0, 0)))
+    repo = _two_initiative_repo(tmp_path, monkeypatch, now)
+    panes = [{"session": "9", "window": "1", "title": "Alpha groundwork",
+              "cwd": str(repo), "pane_id": "%1"}]
+
+    kept = isc.build_report(14, repos=[str(repo)], client=None, now=now,
+                            include_tmux=True, panes=panes)
+    assert kept["excluded_live"] == 0
+    live_slugs = {i["slug"] for i in kept["by_repo"][str(repo)] if i.get("tmux_sessions")}
+    assert live_slugs == {"alpha"}, f"fixture did not attach a live pane: {live_slugs}"
+
+    gone = isc.build_report(14, repos=[str(repo)], client=None, now=now,
+                            include_tmux=True, panes=panes, exclude_slugs={"alpha"})
+    assert gone["excluded_count"] == 1
+    assert gone["excluded_live"] == 1
+    out = isc.render(gone, now=now)
+    assert "1 with a LIVE session" in out
+    # Negative control: suppressing a row with NO live pane must not claim one.
+    quiet = isc.build_report(14, repos=[str(repo)], client=None, now=now,
+                             include_tmux=True, panes=panes, exclude_slugs={"beta"})
+    assert quiet["excluded_count"] == 1 and quiet["excluded_live"] == 0
+    assert "LIVE session" not in isc.render(quiet, now=now)

--- a/scripts/session-analysis/tests/test_initiative_scan.py
+++ b/scripts/session-analysis/tests/test_initiative_scan.py
@@ -2828,3 +2828,136 @@ def test_build_report_source_distribution_has_no_pure_doc(tmp_path, monkeypatch)
     assert "doc" not in sources
     assert "orphan-doc" not in slugs                      # unanchored handoff dropped
     assert "mail-automation" in slugs                     # anchored handoff survives as both
+
+
+# --------------------------------------------------------------------------- #
+# --exclude-slugs — operator-supplied suppression, and the inference it REFUSES
+#
+# History: PR #778 rescued a WIP that paired this flag with a `parse_resolved()`
+# that INFERRED "this initiative is finished" from markers in the handoff text,
+# filtering on by default. Measured over the real corpus it flagged 11 of 62
+# handoffs, 8 of them on section headings (`### DONE this session`) inside docs
+# that carried live next-steps. Only the explicit-list half was salvaged.
+# --------------------------------------------------------------------------- #
+def test_parse_exclude_slugs_strips_whitespace_and_empty_tokens():
+    # REGRESSION: the rescued WIP did a bare `set(raw.split(","))`, so `"a, b"` gave
+    # `{"a", " b"}` — ` b` matches no slug, and the run suppressed one initiative while
+    # reading as if it had suppressed two. Red on the pre-change expression.
+    assert isc.parse_exclude_slugs("a,b") == {"a", "b"}
+    assert isc.parse_exclude_slugs("a, b") == {"a", "b"}
+    assert isc.parse_exclude_slugs("  a ,  b  ") == {"a", "b"}
+    assert isc.parse_exclude_slugs("a,b,") == {"a", "b"}
+    assert isc.parse_exclude_slugs("a,,b") == {"a", "b"}
+
+
+def test_parse_exclude_slugs_returns_none_when_nothing_is_named():
+    # None/empty/all-separator values must be indistinguishable from "flag not passed",
+    # so build_report takes the no-filter path rather than filtering against an empty set.
+    assert isc.parse_exclude_slugs(None) is None
+    assert isc.parse_exclude_slugs("") is None
+    assert isc.parse_exclude_slugs(",") is None
+    assert isc.parse_exclude_slugs("  ,  ") is None
+
+
+def _two_initiative_repo(tmp_path, monkeypatch, now):
+    """A hermetic repo with two session-anchored initiatives: `alpha` and `beta`."""
+    repo = tmp_path / "r"
+    (repo / "claudedocs").mkdir(parents=True)
+    (repo / "claudedocs" / "handoff-alpha-2026-07-04.md").write_text(
+        "# Handoff: alpha\n## Next steps\n1. go\n")
+    (repo / "claudedocs" / "handoff-beta-2026-07-04.md").write_text(
+        "# Handoff: beta\n## Next steps\n1. go\n")
+    _stub_no_external_io(monkeypatch)
+    monkeypatch.setattr(isc, "worktree_canonical_map", lambda repos: {})
+    a = _sess("Alpha groundwork", session_id="sa", cwd=str(repo),
+              last_user_ts=now - isc.DAY, n_turns=10)
+    b = _sess("Beta groundwork", session_id="sb", cwd=str(repo),
+              last_user_ts=now - isc.DAY, n_turns=10)
+    monkeypatch.setattr(isc, "collect_session_records", lambda root, d, n=5: [a, b])
+    return repo
+
+
+def test_build_report_exclude_slugs_suppresses_only_the_named_row(tmp_path, monkeypatch):
+    import calendar
+    now = float(calendar.timegm((2026, 7, 5, 0, 0, 0, 0, 0, 0)))
+    repo = _two_initiative_repo(tmp_path, monkeypatch, now)
+
+    # Negative control FIRST: with no filter, both rows are present. Without this the
+    # assertion below would also pass if `alpha` had never been built at all.
+    unfiltered = isc.build_report(14, repos=[str(repo)], client=None, now=now)
+    assert {i["slug"] for i in unfiltered["by_repo"][str(repo)]} == {"alpha", "beta"}
+    assert unfiltered["excluded_slugs"] == []
+    assert unfiltered["excluded_count"] == 0
+
+    filtered = isc.build_report(14, repos=[str(repo)], client=None, now=now,
+                                exclude_slugs={"alpha"})
+    assert {i["slug"] for i in filtered["by_repo"][str(repo)]} == {"beta"}
+    assert filtered["excluded_slugs"] == ["alpha"]
+    assert filtered["excluded_count"] == 1
+
+
+def test_build_report_exclude_slugs_reports_zero_when_the_slug_matches_nothing(
+        tmp_path, monkeypatch):
+    # A misspelled slug must be AUDIBLE: `excluded_slugs` still names what was asked for
+    # while `excluded_count` stays 0. Reporting only the request would make a typo look
+    # identical to a successful suppression.
+    import calendar
+    now = float(calendar.timegm((2026, 7, 5, 0, 0, 0, 0, 0, 0)))
+    repo = _two_initiative_repo(tmp_path, monkeypatch, now)
+
+    report = isc.build_report(14, repos=[str(repo)], client=None, now=now,
+                              exclude_slugs={"alhpa"})   # typo, on purpose
+    assert {i["slug"] for i in report["by_repo"][str(repo)]} == {"alpha", "beta"}
+    assert report["excluded_slugs"] == ["alhpa"]
+    assert report["excluded_count"] == 0
+
+
+def test_render_announces_suppression_and_stays_silent_otherwise(tmp_path, monkeypatch):
+    import calendar
+    now = float(calendar.timegm((2026, 7, 5, 0, 0, 0, 0, 0, 0)))
+    repo = _two_initiative_repo(tmp_path, monkeypatch, now)
+
+    quiet = isc.render(isc.build_report(14, repos=[str(repo)], client=None, now=now),
+                       now=now)
+    assert "SUPPRESSED" not in quiet
+
+    loud = isc.render(isc.build_report(14, repos=[str(repo)], client=None, now=now,
+                                       exclude_slugs={"alpha"}), now=now)
+    assert "--exclude-slugs SUPPRESSED 1 initiative(s); asked for: alpha" in loud
+
+
+def test_a_handoff_that_says_DONE_is_still_reported(tmp_path, monkeypatch):
+    # INVARIANT GUARD, not regression coverage — the inferring filter was never merged,
+    # so this pins a property `main` already has rather than a bug it once had. It exists
+    # to make re-adding that inference fail loudly: every string below is a real shape
+    # from the corpus that the rescued `parse_resolved()` flagged as resolved, in a doc
+    # that carries live next-steps. Slugs are unique per marker so a failure NAMES the one
+    # that leaked. Suppression is by explicit slug only; nothing else may hide a row.
+    import calendar
+    now = float(calendar.timegm((2026, 7, 5, 0, 0, 0, 0, 0, 0)))
+    markers = {
+        "alfa":    "### DONE this session\nshipped the thing\n",
+        "bravo":   "## RESOLVED 2026-06-20 — the producer was THE TEST SUITE\ntrail\n",
+        "charlie": "## CLOSED: the guard fail-open (#395)\nfixed\n",
+        "delta":   "**Status: DONE, merged, deployed to BOTH hosts.**\n",
+        "echo":    "### ARCHIVED — superseded\nsee elsewhere\n",
+        "foxtrot": "It closed — and then kept going, which is why this is still open.\n",
+    }
+    repo = tmp_path / "r"
+    (repo / "claudedocs").mkdir(parents=True)
+    for slug, body in markers.items():
+        (repo / "claudedocs" / f"handoff-{slug}-2026-07-04.md").write_text(
+            f"# Handoff: {slug}\n\n## Summary\n{body}\n## Next steps\n1. still to do\n")
+    _stub_no_external_io(monkeypatch)
+    monkeypatch.setattr(isc, "worktree_canonical_map", lambda repos: {})
+    sessions = [_sess(f"{slug.capitalize()} groundwork", session_id=f"s-{slug}",
+                      cwd=str(repo), last_user_ts=now - isc.DAY, n_turns=10)
+                for slug in markers]
+    monkeypatch.setattr(isc, "collect_session_records", lambda root, d, n=5: sessions)
+
+    report = isc.build_report(14, repos=[str(repo)], client=None, now=now)
+    assert {i["slug"] for i in report["by_repo"][str(repo)]} == set(markers)
+    assert report["excluded_count"] == 0
+    # And no resolution verdict is computed or emitted anywhere in the payload.
+    assert not hasattr(isc, "parse_resolved")
+    assert all("resolved" not in i for i in report["by_repo"][str(repo)])


### PR DESCRIPTION
Salvages the usable half of `rescue/initiative-scan-resolved-filter` @ `1327372d` — the sole surviving copy of a WIP whose PR (#778) was closed with no comment. That branch paired two independent features; this takes one and deliberately drops the other. Correction posted to #778: https://github.com/innovation-upstream/devrc/pull/778#issuecomment-5413412588

## What lands

`--exclude-slugs a,b` suppresses named initiatives from the report.

The report carries `excluded_slugs` (what was **asked for**) and `excluded_count` (how many rows that **actually removed**) as separate fields, and `render()` announces both. A misspelled slug prints `SUPPRESSED 0 initiative(s); asked for: <typo>` rather than looking identical to a run that suppressed something. A suppressed row nobody knows is suppressed is how this report would start lying about what is in flight.

## What is deliberately dropped — measured, not reviewed

The WIP also added `parse_resolved()`, which **inferred** that an initiative was finished from `RESOLVED|DONE|COMPLETED|CLOSED|ARCHIVED` markers in its handoff, and filtered those out **by default**.

Re-measured by loading `1327372d`'s module directly and running it over handoffs materialized from git (positive control `## Status: RESOLVED` → `True`, negative control plain prose → `False`):

| corpus | scanned | flagged resolved | `heading-marker` | `inline-status` | `PROSE-SUMMARY` |
|---|---|---|---|---|---|
| `199774f8` (this PR's base) | 62 | 11 (18%) | **7** | 1 | 3 |
| `982778ee` (the sha #778 cites) | 53 | 10 (19%) | **7** | 1 | 2 |

#778's body blames the free-text summary scan — *"the heading and inline `Status:` arms did **not** fire; only the prose scan did"*. That is wrong, and was wrong at the sha it cited. The heading arm dominates:

```
### DONE this session
### RESOLVED: the clawgate stuck detector HAS now fired on a real wedge
## CLOSED: the commit-to-main guard fail-open (#395 + #396)
```

So its suggested fix — *"a heading that **starts** with the marker"* — preserves every one of them: that arm's regex already requires a marker-initial heading, so the fix is a no-op against all 7.

> ⚠ **Corrected after the pre-merge audit.** The first version of this table said **8 / 1 / 2** for the base row. The measurement is **7 / 1 / 3** — I read arm labels off a printed listing instead of counting them, which is the same defect this PR criticises #778 for. How it arose: the #778 correction comment hedges the split as "7–8" heading and "2–3" prose, and this table was built by taking the top of one range and the bottom of the other. (A first attempt to explain it claimed `8/1/2` was *unreachable* — that was wrong too, and is noted here rather than quietly dropped: four flagged docs sit outside the heading column, so miscounting any one prose doc reaches it.) The row summed to 11 in every wrong version, which is why the obvious self-check never caught any of them. The substance is unchanged — the heading arm still dominates, 7 vs 3.

**Root cause:** a handoff is a multi-section document. Those headings describe one investigation *inside* a doc that still carries live next-steps. The predicate conflates "this document mentions something finished" with "this initiative is finished", and that signal does not exist in the corpus at the granularity it needs. A report whose entire job is answering *"what am I working on"* must not hide a row on a guess — so suppression is explicit-only.

Also fixed: the WIP's `set(raw.split(","))` never stripped, so `"a, b"` yielded `" b"`, matching no slug. It suppressed one of two while reading as if it had done both.

## Verification

**Dev-host tier**, base `199774f8` — `scripts/gate.sh --tier both --set all` → `GATE: RESULT=PASS exit=0`, both runners' own verdict lines agreeing (`pytest exit=0`, `node exit=0`; node 1219 tests over floor 1189). `scripts/session-analysis/tests` on its own: 482 passed, 2 skipped.

**Sandbox tier**, base `199774f8` — `nix build .#checks.x86_64-linux.{pytests,nodetests}`, the tier Tekton gates on. It builds from a `cp -r` store copy with **no `.git`**, so it is a genuinely different run from the above, not a second spelling of it. Both derivations produced output paths (`rc=0`; a derivation yields one only on success), and their retained build logs carry real counts rather than a vacuous pass:

```
devrc-pytests    TOTAL collected=15843 passed=15841 skipped=2 failed=0  (floor: 13753 = sum of 27 per-target floors)
devrc-nodetests  TOTAL suites=4 files=36 tests=1219 pass=1219 fail=0 skipped=0  (floor: 1189)
both: RESULT: PASS (exit=0)
```

Both are claims about **this branch** at base `199774f8`, not about the tree the merge creates — `strict` is false on this repo's protection.

**Mutation sweep** — 5 mutants, each applied and parse-verified in isolation under `PYTHONDONTWRITEBYTECODE=1`, each **killed by its own test**, not a neighbour's:

| mutant | victim | result |
|---|---|---|
| `wip-bare-split` — the WIP's literal expression | whitespace test | KILLED → genuine **regression** coverage |
| `no-filter` | suppression test | KILLED |
| `count-is-request-size` | typo test | KILLED |
| `silent-render` | render test | KILLED |
| `reinstate-inferred-resolution` | DONE-still-reported test | KILLED |

The last mutant re-adds the inferring filter **without** defining `parse_resolved`, so the *behavioural* assertion is what kills it rather than the `hasattr` check — otherwise that test would be green for the wrong reason.

**Live CLI**, 14d window against this repo:

```
41 rows → 39 with --exclude-slugs 'agent-limit-restored-with, dispatch-recommendations'
```

(note the space — the WIP's bug) both named rows gone, a third retained. Typo case renders `SUPPRESSED 0 initiative(s); asked for: no-such-slug`.

`test_a_handoff_that_says_DONE_is_still_reported` is labelled in-source as an **invariant guard, not regression coverage** — the inferring filter never merged, so it pins a property `main` already has. It exists to make re-adding that inference fail loudly.

## After this merges

`rescue/initiative-scan-resolved-filter` can be deleted **deliberately** — its usable content is here and its rejected half is documented above and on #778. Until then it stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
