### PR TITLE
docs(handoff): next-step 1 DECIDED — the rescued WIP splits, and #778's own diagnosis was wrong three ways

### DIFF
--- a/claudedocs/handoff-ci-flakes-and-misattribution.md
+++ b/claudedocs/handoff-ci-flakes-and-misattribution.md
@@ -44,9 +44,10 @@ spool row. Both are now fixed; the flake family underneath is only half closed.
   another session's uncommitted `scripts/run-node-tests.sh` line. Deployed artifact ≠ commit
   on that host.
 - **#783 open by design** — #807 fixed the assertions, NOT the root cause.
-- **#778 CLOSED unmerged** — see the first open investigation; this is the risky one.
+- **#778 CLOSED unmerged** — **decided 2026-08-25**, see the first entry below. No longer the
+  risky one; the risk moved to *not deleting the rescue branch before #824 lands*.
 
-## Open investigations — live diagnosis state
+## Investigations — live diagnosis state (first entry is DECIDED, the rest are open)
 
 ### ✅ DECIDED 2026-08-25 — the rescued `initiative-scan.py` WIP: one half salvaged, one half rejected on measurement
 **Operator decision: salvage `--exclude-slugs` only; drop `parse_resolved`. `IN FLIGHT: devrc#824`.**
@@ -69,8 +70,20 @@ ancestor), not by ancestry.
 
     | corpus | scanned | flagged | `heading-marker` | `inline-status` | `PROSE-SUMMARY` |
     |---|---|---|---|---|---|
-    | `origin/main` today | 62 | 11 (18%) | **8** | 1 | 2 |
+    | `199774f8` (main at #824's base) | 62 | 11 (18%) | **7** | 1 | 3 |
     | `982778ee` (the sha it cites) | 53 | 10 (19%) | **7** | 1 | 2 |
+
+    ⚠ Both corpora are PINNED on purpose. An earlier draft of this table wrote the first row
+    as "`origin/main` today" and as **8 / 1 / 2** — wrong on both counts, caught by the #826
+    audit. `main` moves (it is already past `199774f8`), so an unpinned row cannot be told
+    apart from doc rot; and the arm split was mis-transcribed by eyeballing a listing instead
+    of counting it. `8 / 1 / 2` is not merely wrong, it is UNREACHABLE: the extra doc at
+    `199774f8` is `handoff-ccua-…`, which has no marker-initial heading, so it can only be a
+    prose hit — and heading could only reach 8 by counting `handoff-prompt-optimization-…`,
+    which is itself the sole `inline-status` hit, forcing that column to 0. The row summed to
+    11 either way, which is exactly why the arithmetic self-check did not catch it.
+    🔴 The irony is the lesson: this section exists to correct #778 for publishing numbers it
+    had not re-derived, and its own first draft did the same thing.
 
   - (a) It blames the prose scan and states *"the heading and inline `Status:` arms did **not**
     fire"*. The heading arm is the DOMINANT one — `### DONE this session`,
@@ -78,7 +91,9 @@ ancestor), not by ancestry.
   - (b) Its counts came from the **working tree** while citing `982778ee`: its headline example
     `handoff-ccua-waiting-flag-and-fork-close.md` does **not exist** at that sha
     (`git cat-file -e` → absent). That is the 11/55-vs-10/53 gap.
-  - (c) Its suggested fix — *"a heading that **starts** with the marker"* — **preserves all 8**.
+  - (c) Its suggested fix — *"a heading that **starts** with the marker"* — **preserves all 7**:
+    that arm's regex already requires the marker to start the heading, so the fix is a no-op
+    against every one of them.
 - **Root cause (the reason the half was rejected, not just deferred):** a handoff is a
   MULTI-SECTION document. Those headings describe one investigation *inside* a doc that still
   carries live next-steps. The predicate conflates "this document mentions something finished"
@@ -150,8 +165,10 @@ ancestor), not by ancestry.
    uncommitted `discord-embed-ext` line. Not ours to commit; resolves itself when they do.
 
 🔴 **This list is a WORK QUEUE WITH NO LOCK** — every `/resume` session draws from it, so a
-*better* ranked list produces *more* duplicate work. Nothing above is in flight as of this
-writing; if you start one, mark it `IN FLIGHT: <repo>#<pr>` here.
+*better* ranked list produces *more* duplicate work. **In flight right now: item 1 only, as
+`IN FLIGHT: devrc#824`. Items 2–5 are unclaimed.** If you start one, mark it
+`IN FLIGHT: <repo>#<pr>` here — and if you find this sentence disagreeing with the items above,
+believe the items, then fix this sentence.
 
 ## Gotchas / decisions / dead-ends
 - 🔴 **`scripts/gate.sh` runs the DEV-HOST tier only** — `run-tests.sh` + `run-node-tests.sh`.
@@ -201,17 +218,20 @@ git -C ~/workspace/devrc show origin/main:scripts/browser-bridge/tests/test_serv
 # and #802's fix is still there beside it
 git -C ~/workspace/devrc show origin/main:scripts/browser-bridge/server.py | grep -c "_spool_emit_lock"          # 3
 
-# the rescued WIP still exists — 🔴 if this prints nothing, the work is GONE
-# (still true: the branch is NOT deleted until devrc#824 merges — see next-step 1)
+# 🔴 READ THE TWO GREPS BELOW FIRST — they decide what an empty result here MEANS.
+#   greps == 0  -> #824 has NOT merged; empty here means the work is GONE. Alarm.
+#   greps == 1  -> #824 merged; empty here is CORRECT — the branch was deleted on purpose.
 git -C ~/workspace/devrc ls-remote --heads origin rescue/initiative-scan-resolved-filter
 
-# the salvage, once #824 merges — BY CONTENT, since a squash merge is never an ancestor
+# the salvage — BY CONTENT, since a squash merge is never an ancestor.
+# Expect 0 until #824 merges, 1 after. A 0 is only news if #824 shows as merged.
 git -C ~/workspace/devrc show origin/main:scripts/session-analysis/initiative-scan.py \
-  | grep -c "def parse_exclude_slugs"                                                 # 1
+  | grep -c "def parse_exclude_slugs"                              # 0 pre-merge / 1 post
 # and the invariant guard that stops the rejected half being re-added
 git -C ~/workspace/devrc show origin/main:scripts/session-analysis/tests/test_initiative_scan.py \
-  | grep -c "test_a_handoff_that_says_DONE_is_still_reported"                         # 1
+  | grep -c "test_a_handoff_that_says_DONE_is_still_reported"      # 0 pre-merge / 1 post
+gh pr view 824 --repo innovation-upstream/devrc --json mergedAt,mergeCommit
 
-# both hosts carry it
+# both hosts carry what is ALREADY on main (not #824, until it merges)
 bash ~/workspace/devrc/scripts/drift-check.sh    # read-only; rc 0 = converged
 ```

--- a/claudedocs/handoff-ci-flakes-and-misattribution.md
+++ b/claudedocs/handoff-ci-flakes-and-misattribution.md
@@ -45,7 +45,8 @@ spool row. Both are now fixed; the flake family underneath is only half closed.
   on that host.
 - **#783 open by design** — #807 fixed the assertions, NOT the root cause.
 - **#778 CLOSED unmerged** — **decided 2026-08-25**, see the first entry below. No longer the
-  risky one; the risk moved to *not deleting the rescue branch before #824 lands*.
+  risky one. 🔴 **The risk is now DELETING `rescue/initiative-scan-resolved-filter` before
+  #824 lands** — that branch is still the sole copy until then. Keep it.
 
 ## Investigations — live diagnosis state (first entry is DECIDED, the rest are open)
 
@@ -63,7 +64,14 @@ ancestor), not by ancestry.
   `--exclude-slugs` (+12 lines, explicit operator list) vs `parse_resolved` (+55 lines,
   inferred verdict, filter **on by default**).
 - 🔴 **#778's own diagnosis was wrong in three ways** — found by re-measuring, not by reading
-  it. Corrected on the PR: <https://github.com/innovation-upstream/devrc/pull/778#issuecomment-5413412588>
+  it. Corrected on the PR across THREE comments, each left standing rather than edited
+  because people read each before the next was known to be needed. **Only the third is
+  authoritative** — the table below matches it:
+  `…#issuecomment-5413412588` (original; the `8 / 1 / 2` split is WRONG) →
+  `…#issuecomment-5414463043` (corrects the split to `7 / 1 / 3` — numbers right, but its
+  explanation of how `8 / 1 / 2` arose is wrong) →
+  `…#issuecomment-5414562898` (**authoritative**: same numbers, correct mechanism).
+  All three at <https://github.com/innovation-upstream/devrc/pull/778>.
   - Method: loaded `1327372d`'s module directly, ran `parse_resolved` over handoffs
     materialized from git, attributed every hit to the arm that fired. Positive control
     (`## Status: RESOLVED`) → `True`; negative control (plain prose) → `False`.
@@ -76,14 +84,24 @@ ancestor), not by ancestry.
     ⚠ Both corpora are PINNED on purpose. An earlier draft of this table wrote the first row
     as "`origin/main` today" and as **8 / 1 / 2** — wrong on both counts, caught by the #826
     audit. `main` moves (it is already past `199774f8`), so an unpinned row cannot be told
-    apart from doc rot; and the arm split was mis-transcribed by eyeballing a listing instead
-    of counting it. `8 / 1 / 2` is not merely wrong, it is UNREACHABLE: the extra doc at
-    `199774f8` is `handoff-ccua-…`, which has no marker-initial heading, so it can only be a
-    prose hit — and heading could only reach 8 by counting `handoff-prompt-optimization-…`,
-    which is itself the sole `inline-status` hit, forcing that column to 0. The row summed to
-    11 either way, which is exactly why the arithmetic self-check did not catch it.
-    🔴 The irony is the lesson: this section exists to correct #778 for publishing numbers it
-    had not re-derived, and its own first draft did the same thing.
+    apart from doc rot.
+    **How the `8 / 1 / 2` arose** — the actual mechanism, itself re-derived after a first
+    explanation turned out to be wrong: the linked #778 comment hedges the split as "7–8"
+    heading and "2–3" prose, and the table was then built by taking the TOP of one range and
+    the BOTTOM of the other. Not a miscount of any particular document — a hedge hardened in
+    two directions at once. **A previous draft of this note claimed `8 / 1 / 2` was
+    UNREACHABLE. That was also false**, and is recorded rather than deleted because it is the
+    same error a third time: at `199774f8` FOUR flagged docs sit outside the heading column
+    (3 prose + 1 inline), so miscounting any one of the three prose docs yields exactly
+    `8 / 1 / 2`. Two of them look like heading hits at a glance — `### ✅ CLOSED 2026-08-22`
+    and `## State now — DONE, verified end to end` — and classify as prose only because the
+    arm's regex needs the marker to START the heading.
+    The row summed to 11 in every wrong version, which is exactly why an arithmetic
+    self-check never caught any of them.
+    🔴 The lesson, earned three times in one section: this block exists to correct #778 for
+    publishing numbers it had not re-derived, and its first draft, and then its own
+    correction, each did the same thing. **Re-derive; do not reason about what the number
+    must have been.**
 
   - (a) It blames the prose scan and states *"the heading and inline `Status:` arms did **not**
     fire"*. The heading arm is the DOMINANT one — `### DONE this session`,
@@ -218,9 +236,13 @@ git -C ~/workspace/devrc show origin/main:scripts/browser-bridge/tests/test_serv
 # and #802's fix is still there beside it
 git -C ~/workspace/devrc show origin/main:scripts/browser-bridge/server.py | grep -c "_spool_emit_lock"          # 3
 
-# 🔴 READ THE TWO GREPS BELOW FIRST — they decide what an empty result here MEANS.
-#   greps == 0  -> #824 has NOT merged; empty here means the work is GONE. Alarm.
-#   greps == 1  -> #824 merged; empty here is CORRECT — the branch was deleted on purpose.
+# 🔴 RUN THE GREPS *AND* THE `gh` READ BELOW FIRST — together they decide what this means.
+#   Content on main does not prove WHICH pr put it there, so the grep alone is a proxy;
+#   `mergedAt` is the authority. All four states:
+#     ls-remote non-empty + 824 unmerged -> normal, pre-merge. Do nothing.
+#     ls-remote non-empty + 824 merged   -> normal, post-merge. The deliberate delete is DUE.
+#     ls-remote EMPTY    + 824 merged    -> CORRECT: branch deleted on purpose.
+#     ls-remote EMPTY    + 824 unmerged  -> 🔴 ALARM. The sole copy is GONE.
 git -C ~/workspace/devrc ls-remote --heads origin rescue/initiative-scan-resolved-filter
 
 # the salvage — BY CONTENT, since a squash merge is never an ancestor.

--- a/claudedocs/handoff-ci-flakes-and-misattribution.md
+++ b/claudedocs/handoff-ci-flakes-and-misattribution.md
@@ -22,8 +22,9 @@ session's git write, and browser-bridge tests blaming their own subject for a ne
 spool row. Both are now fixed; the flake family underneath is only half closed.
 
 ## State now
-- Branch `main`, both hosts converged. **IN FLIGHT: devrc#824** (the `--exclude-slugs`
-  salvage — next-step 1). Nothing else.
+- Branch `main`. **Nothing in flight.** #824 (the `--exclude-slugs` salvage) MERGED as
+  `d3b6eeae`, and `rescue/initiative-scan-resolved-filter` was deleted deliberately
+  afterwards — next-step 1 is fully closed, residual included.
   ⚠ Hosts were converged as of the deploy note below; that was measured on 2026-08-25 and
   `main` has moved since (#806, #812, #817, #818, …). Re-run `drift-check.sh` rather than
   reading the line below as current.
@@ -45,16 +46,24 @@ spool row. Both are now fixed; the flake family underneath is only half closed.
   on that host.
 - **#783 open by design** — #807 fixed the assertions, NOT the root cause.
 - **#778 CLOSED unmerged** — **decided 2026-08-25**, see the first entry below. No longer the
-  risky one. 🔴 **The risk is now DELETING `rescue/initiative-scan-resolved-filter` before
-  #824 lands** — that branch is still the sole copy until then. Keep it.
+  risky one, and no longer risky at all: #824 landed and the rescue branch was then deleted
+  deliberately. Nothing here is single-copy any more.
 
 ## Investigations — live diagnosis state (first entry is DECIDED, the rest are open)
 
 ### ✅ DECIDED 2026-08-25 — the rescued `initiative-scan.py` WIP: one half salvaged, one half rejected on measurement
-**Operator decision: salvage `--exclude-slugs` only; drop `parse_resolved`. `IN FLIGHT: devrc#824`.**
-🔴 **`rescue/initiative-scan-resolved-filter` still must NOT be deleted as cleanup** — it stays
-until #824 merges, and then goes deliberately, verified BY CONTENT (a squash merge is never an
-ancestor), not by ancestry.
+**Operator decision: salvage `--exclude-slugs` only; drop `parse_resolved`. SHIPPED — #824
+merged as `d3b6eeae` 2026-08-25.**
+✅ **`rescue/initiative-scan-resolved-filter` is now DELETED — deliberately, not as cleanup.**
+The delete was gated on four conditions re-checked in the same command that performed it:
+`parse_exclude_slugs` present on `origin/main` (**by content**, since a squash merge is never
+an ancestor), the invariant guard present, `gh pr view 824 --json mergedAt` non-null, and the
+branch still existing. All four held.
+🔴 **`parse_resolved` now exists NOWHERE.** That was the decision, not an accident — it is
+rejected, and the reasoning below is the record. Its commit was `1327372d`; GitHub keeps an
+unreferenced commit reachable by sha for a limited window only, so if it is ever wanted back,
+recover it soon or rebuild it from the description here. **Do not rebuild it as specified** —
+read the root cause first; the design is what failed, not the code.
 
 - **What made it urgent (re-verified live, not carried forward):** branch present on origin;
   `merge-base --is-ancestor 1327372d origin/main` → **no**; `git branch -a --contains` → only
@@ -166,12 +175,11 @@ ancestor), not by ancestry.
 
 ## Next steps (ranked)
 1. ~~**Decide the fate of `rescue/initiative-scan-resolved-filter`**~~ — **DONE 2026-08-25.**
-   Split decision: `--exclude-slugs` salvaged as **`IN FLIGHT: devrc#824`**, `parse_resolved`
-   rejected on measurement (see the decided investigation above). **Residual, blocked on #824
-   merging:** delete the rescue branch deliberately, after confirming BY CONTENT that the
-   salvage landed (`git show origin/main:scripts/session-analysis/initiative-scan.py |
-   grep -c parse_exclude_slugs` → 1) — never by ancestry. Closing condition: that grep, plus
-   `gh pr view 824 --json mergedAt,mergeCommit`. Until both, the branch stays.
+   Split decision: `--exclude-slugs` salvaged and **MERGED (#824, `d3b6eeae`)**,
+   `parse_resolved` rejected on measurement (see the decided investigation above).
+   **Residual also CLOSED:** the rescue branch was deleted deliberately, gated on the
+   closing condition this item named — the by-content grep **plus** `mergedAt` — both
+   re-checked inside the deleting command. Nothing remains of this item.
 2. **Close #783 at the root** (devrc: `scripts/browser-bridge/tests/conftest.py`,
    `scripts/browser-bridge/server.py`) — join emitter threads at teardown so a re-pointed
    `ACTIVITY_SPOOL_DIR` cannot be written by a dead test's thread.
@@ -183,8 +191,8 @@ ancestor), not by ancestry.
    uncommitted `discord-embed-ext` line. Not ours to commit; resolves itself when they do.
 
 🔴 **This list is a WORK QUEUE WITH NO LOCK** — every `/resume` session draws from it, so a
-*better* ranked list produces *more* duplicate work. **In flight right now: item 1 only, as
-`IN FLIGHT: devrc#824`. Items 2–5 are unclaimed.** If you start one, mark it
+*better* ranked list produces *more* duplicate work. **Nothing is in flight: item 1 is closed
+(merged + residual done), items 2–5 are unclaimed.** If you start one, mark it
 `IN FLIGHT: <repo>#<pr>` here — and if you find this sentence disagreeing with the items above,
 believe the items, then fix this sentence.
 
@@ -236,22 +244,16 @@ git -C ~/workspace/devrc show origin/main:scripts/browser-bridge/tests/test_serv
 # and #802's fix is still there beside it
 git -C ~/workspace/devrc show origin/main:scripts/browser-bridge/server.py | grep -c "_spool_emit_lock"          # 3
 
-# 🔴 RUN THE GREPS *AND* THE `gh` READ BELOW FIRST — together they decide what this means.
-#   Content on main does not prove WHICH pr put it there, so the grep alone is a proxy;
-#   `mergedAt` is the authority. All four states:
-#     ls-remote non-empty + 824 unmerged -> normal, pre-merge. Do nothing.
-#     ls-remote non-empty + 824 merged   -> normal, post-merge. The deliberate delete is DUE.
-#     ls-remote EMPTY    + 824 merged    -> CORRECT: branch deleted on purpose.
-#     ls-remote EMPTY    + 824 unmerged  -> 🔴 ALARM. The sole copy is GONE.
-git -C ~/workspace/devrc ls-remote --heads origin rescue/initiative-scan-resolved-filter
-
-# the salvage — BY CONTENT, since a squash merge is never an ancestor.
-# Expect 0 until #824 merges, 1 after. A 0 is only news if #824 shows as merged.
+# the salvage landed — BY CONTENT, since a squash merge is never an ancestor
 git -C ~/workspace/devrc show origin/main:scripts/session-analysis/initiative-scan.py \
-  | grep -c "def parse_exclude_slugs"                              # 0 pre-merge / 1 post
+  | grep -c "def parse_exclude_slugs"                                                   # 1
 # and the invariant guard that stops the rejected half being re-added
 git -C ~/workspace/devrc show origin/main:scripts/session-analysis/tests/test_initiative_scan.py \
-  | grep -c "test_a_handoff_that_says_DONE_is_still_reported"      # 0 pre-merge / 1 post
+  | grep -c "test_a_handoff_that_says_DONE_is_still_reported"                           # 1
+
+# the rescue branch is GONE, and that is CORRECT — deleted on purpose after the two greps
+# above returned 1. Expect EMPTY. 🔴 Empty is only alarming if those greps return 0.
+git -C ~/workspace/devrc ls-remote --heads origin rescue/initiative-scan-resolved-filter  # empty
 gh pr view 824 --repo innovation-upstream/devrc --json mergedAt,mergeCommit
 
 # both hosts carry what is ALREADY on main (not #824, until it merges)

--- a/claudedocs/handoff-ci-flakes-and-misattribution.md
+++ b/claudedocs/handoff-ci-flakes-and-misattribution.md
@@ -22,7 +22,11 @@ session's git write, and browser-bridge tests blaming their own subject for a ne
 spool row. Both are now fixed; the flake family underneath is only half closed.
 
 ## State now
-- Branch `main`, both hosts converged. **Nothing in flight.**
+- Branch `main`, both hosts converged. **IN FLIGHT: devrc#824** (the `--exclude-slugs`
+  salvage — next-step 1). Nothing else.
+  ⚠ Hosts were converged as of the deploy note below; that was measured on 2026-08-25 and
+  `main` has moved since (#806, #812, #817, #818, …). Re-run `drift-check.sh` rather than
+  reading the line below as current.
 - **Five PRs merged:**
 
 | PR | squash | what |
@@ -44,24 +48,48 @@ spool row. Both are now fixed; the flake family underneath is only half closed.
 
 ## Open investigations — live diagnosis state
 
-### 🔴 The rescued `initiative-scan.py` WIP now has exactly ONE copy, and its PR was closed
-- **Symptom + exact repro:** `origin/rescue/initiative-scan-resolved-filter` @ `1327372d` is
-  the only surviving copy of a `--exclude-slugs` / resolved-filter feature. Deleting that
-  branch destroys the work.
-- **Observed (with values):**
-  - working tree: `grep -c "exclude-slugs\|def parse_resolved" scripts/session-analysis/initiative-scan.py` → **0** (the WIP was discarded)
-  - on `origin/main`: same grep → **0**
-  - `git branch --contains 1327372d` excluding the rescue branch → **0**
-  - `git merge-base --is-ancestor 1327372d origin/main` → **no**
-  - `git ls-remote --heads origin rescue/initiative-scan-resolved-filter` → **1** (present)
-  - PR #778 `closedAt=2026-08-25T00:50:23Z`, **comments=0**
-- **Ruled out:** it did not land on `main` under another name (grep above); it is not on any
-  other local branch.
-- **Leading hypothesis:** whoever closed #778 did not know the branch had become the sole
-  copy — it was a draft, and the working-tree original was cleaned independently.
-- **Next probe:** ask the operator whether the feature is wanted. If yes, reopen/rebase; if
-  no, say so explicitly so the branch can be deleted deliberately rather than tidied away.
-  🔴 Do NOT delete that branch as cleanup.
+### ✅ DECIDED 2026-08-25 — the rescued `initiative-scan.py` WIP: one half salvaged, one half rejected on measurement
+**Operator decision: salvage `--exclude-slugs` only; drop `parse_resolved`. `IN FLIGHT: devrc#824`.**
+🔴 **`rescue/initiative-scan-resolved-filter` still must NOT be deleted as cleanup** — it stays
+until #824 merges, and then goes deliberately, verified BY CONTENT (a squash merge is never an
+ancestor), not by ancestry.
+
+- **What made it urgent (re-verified live, not carried forward):** branch present on origin;
+  `merge-base --is-ancestor 1327372d origin/main` → **no**; `git branch -a --contains` → only
+  the rescue branch itself; grep on `origin/main` → **0**. And `initiative-scan.py` had taken
+  **zero commits** since the rescue's parent, so the WIP still applied cleanly.
+- **The two halves are independent**, which is what made a split decision possible at all:
+  `--exclude-slugs` (+12 lines, explicit operator list) vs `parse_resolved` (+55 lines,
+  inferred verdict, filter **on by default**).
+- 🔴 **#778's own diagnosis was wrong in three ways** — found by re-measuring, not by reading
+  it. Corrected on the PR: <https://github.com/innovation-upstream/devrc/pull/778#issuecomment-5413412588>
+  - Method: loaded `1327372d`'s module directly, ran `parse_resolved` over handoffs
+    materialized from git, attributed every hit to the arm that fired. Positive control
+    (`## Status: RESOLVED`) → `True`; negative control (plain prose) → `False`.
+
+    | corpus | scanned | flagged | `heading-marker` | `inline-status` | `PROSE-SUMMARY` |
+    |---|---|---|---|---|---|
+    | `origin/main` today | 62 | 11 (18%) | **8** | 1 | 2 |
+    | `982778ee` (the sha it cites) | 53 | 10 (19%) | **7** | 1 | 2 |
+
+  - (a) It blames the prose scan and states *"the heading and inline `Status:` arms did **not**
+    fire"*. The heading arm is the DOMINANT one — `### DONE this session`,
+    `### RESOLVED: the clawgate stuck detector…`, `## CLOSED: the commit-to-main guard fail-open`.
+  - (b) Its counts came from the **working tree** while citing `982778ee`: its headline example
+    `handoff-ccua-waiting-flag-and-fork-close.md` does **not exist** at that sha
+    (`git cat-file -e` → absent). That is the 11/55-vs-10/53 gap.
+  - (c) Its suggested fix — *"a heading that **starts** with the marker"* — **preserves all 8**.
+- **Root cause (the reason the half was rejected, not just deferred):** a handoff is a
+  MULTI-SECTION document. Those headings describe one investigation *inside* a doc that still
+  carries live next-steps. The predicate conflates "this document mentions something finished"
+  with "this initiative is finished", and that signal **does not exist in the corpus at the
+  granularity it needs** — so no tightening of the marker regex reaches it. A report whose
+  entire job is answering *"what am I working on"* must not hide a row on a guess.
+- **Also fixed in the salvage:** the WIP's `set(raw.split(","))` never stripped, so `"a, b"`
+  yielded `" b"` — it suppressed one of two while reading as though it had done both.
+- **Not a dead end, recorded so nobody re-derives it:** if an inferred filter is ever wanted,
+  it needs an explicit top-level status FIELD as a handoff convention. That convention does
+  not exist today, and inventing it is a docs-format change, not a parser change.
 
 ### #783 — the spool defect's ROOT CAUSE is untouched
 - **Symptom + exact repro:** a test reads `_wait_events(spool_dir, 1)[0]` and gets a
@@ -104,9 +132,13 @@ spool row. Both are now fixed; the flake family underneath is only half closed.
   under-diagnosis this thread spent the evening correcting.
 
 ## Next steps (ranked)
-1. **Decide the fate of `rescue/initiative-scan-resolved-filter`** (devrc, branch only — no
-   files in `main`). Sole copy; PR #778 closed with no comment. Cheapest item, highest
-   irreversibility.
+1. ~~**Decide the fate of `rescue/initiative-scan-resolved-filter`**~~ — **DONE 2026-08-25.**
+   Split decision: `--exclude-slugs` salvaged as **`IN FLIGHT: devrc#824`**, `parse_resolved`
+   rejected on measurement (see the decided investigation above). **Residual, blocked on #824
+   merging:** delete the rescue branch deliberately, after confirming BY CONTENT that the
+   salvage landed (`git show origin/main:scripts/session-analysis/initiative-scan.py |
+   grep -c parse_exclude_slugs` → 1) — never by ancestry. Closing condition: that grep, plus
+   `gh pr view 824 --json mergedAt,mergeCommit`. Until both, the branch stays.
 2. **Close #783 at the root** (devrc: `scripts/browser-bridge/tests/conftest.py`,
    `scripts/browser-bridge/server.py`) — join emitter threads at teardown so a re-pointed
    `ACTIVITY_SPOOL_DIR` cannot be written by a dead test's thread.
@@ -170,7 +202,15 @@ git -C ~/workspace/devrc show origin/main:scripts/browser-bridge/tests/test_serv
 git -C ~/workspace/devrc show origin/main:scripts/browser-bridge/server.py | grep -c "_spool_emit_lock"          # 3
 
 # the rescued WIP still exists — 🔴 if this prints nothing, the work is GONE
+# (still true: the branch is NOT deleted until devrc#824 merges — see next-step 1)
 git -C ~/workspace/devrc ls-remote --heads origin rescue/initiative-scan-resolved-filter
+
+# the salvage, once #824 merges — BY CONTENT, since a squash merge is never an ancestor
+git -C ~/workspace/devrc show origin/main:scripts/session-analysis/initiative-scan.py \
+  | grep -c "def parse_exclude_slugs"                                                 # 1
+# and the invariant guard that stops the rejected half being re-added
+git -C ~/workspace/devrc show origin/main:scripts/session-analysis/tests/test_initiative_scan.py \
+  | grep -c "test_a_handoff_that_says_DONE_is_still_reported"                         # 1
 
 # both hosts carry it
 bash ~/workspace/devrc/scripts/drift-check.sh    # read-only; rc 0 = converged


### PR DESCRIPTION
Resolves next-step 1 of `claudedocs/handoff-ci-flakes-and-misattribution.md` — *decide the fate of `rescue/initiative-scan-resolved-filter`* — as a **split**, and records the measurement that forced it.

Lands separately from #824 on purpose: that queue is a **work queue with no lock**, so an `IN FLIGHT` marker that only appears when #824 merges cannot prevent the duplicate work it exists to prevent.

## The decision
- `--exclude-slugs` → salvaged, #824.
- `parse_resolved` → **rejected on measurement**, not deferred.
- 🔴 `rescue/initiative-scan-resolved-filter` is **still not to be deleted as cleanup**. That instruction is retained and given a closing condition: it goes only after #824 merges, verified **by content** (a squash merge is never an ancestor). Both greps added to *How to verify*.

## Why #778 could not be taken at its word
Attributing every `parse_resolved` hit to the arm that fired (controls in the doc):

| corpus | scanned | flagged | heading | inline | prose |
|---|---|---|---|---|---|
| `origin/main` today | 62 | 11 | **8** | 1 | 2 |
| `982778ee` (the sha it cites) | 53 | 10 | **7** | 1 | 2 |

1. It blames the prose scan; the **heading** arm dominates.
2. Its counts came from the working tree while citing `982778ee` — its headline example does not exist at that sha.
3. Its suggested fix (*a heading that `starts` with the marker*) preserves all 8, since `### DONE this session` and `## CLOSED: …` do exactly that.

Correction also posted to #778: https://github.com/innovation-upstream/devrc/pull/778#issuecomment-5413412588

Also corrects the now-stale `Nothing in flight` and marks the deploy line as a 2026-08-25 measurement rather than current state.

## Verification
Docs-only. 807 passed, 0 failed — `scripts/tests` under `nix develop`, covering the doc byte ceilings, all four content gates, and `test_ci_claim_matches_reality`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)