### PR TITLE
fix(pre-push): the root cause was NOT unidentified — git exports GIT_DIR from a LINKED WORKTREE

### DIFF
--- a/claudedocs/handoff-gitdir-leak-and-ci-gates.md
+++ b/claudedocs/handoff-gitdir-leak-and-ci-gates.md
@@ -71,8 +71,13 @@ a cross-repo ref as `PR owner/repo#N`; it can only do that if the doc gave it th
   (`autocommit: N change(s) in the some-scope analyze-service index`), the real commit gone,
   the index wrecked, working files surviving on disk.
 - **Observed (with values):** mechanism proven at the unit level and reproduced end-to-end
-  against a decoy. git 2.55.0 exports `GIT_DIR` into a pre-push hook **only from a linked
-  worktree** (main checkout → `GIT_EDITOR`/`GIT_EXEC_PATH`/`GIT_PREFIX` only). With it set,
+  against a decoy. git 2.55.0 exports `GIT_DIR` into a pre-push hook from a **linked
+  worktree** but not from a main checkout (which gets
+  `GIT_EDITOR`/`GIT_EXEC_PATH`/`GIT_PREFIX` only). ⚠ **This line said "ONLY from a linked
+  worktree" and that word was wrong** — measured 2026-08-25, `--separate-git-dir` clones,
+  submodules (`<super>/.git/modules/<sub>`) and bare repos (a RELATIVE `.`) export it too, so
+  "not a worktree" is NO evidence that `GIT_DIR` is unset. The correction matters here
+  specifically because `githooks/pre-push` now routes readers to this doc. With it set,
   `git -C "$scope" rev-parse --show-toplevel` returns `$scope` itself → `scope_repo_state`
   reports "its own repo" → the nesting guard is skipped. Decoy went `2320f0a → 8c952fe`,
   HEAD tree `a.md`/`alpha.md`/`beta.md`.

--- a/claudedocs/handoff-skill-listing-budget.md
+++ b/claudedocs/handoff-skill-listing-budget.md
@@ -24,8 +24,12 @@
 > - The gate's own measure undercounts the real charge by **`5n − 1`**, not by a fixed number.
 >
 > **Everything under "Next steps" below is DONE**: the three skills were retired (#785), the
-> analysis landed (#784), and the tier mechanism shipped unadopted (#792). The `GIT_DIR`
-> investigation below was NOT revisited and its status is unchanged.
+> analysis landed (#784), and the tier mechanism shipped unadopted (#792).
+> - ✅ **UPDATE 2026-08-25: the `GIT_DIR` investigation below WAS revisited, and its central
+>   open question is ANSWERED** — git itself exports `GIT_DIR` into `pre-push` on a push from a
+>   linked worktree, which is what the 2026-08-21 incident was. This sentence used to say the
+>   investigation "was NOT revisited and its status is unchanged". The unattributed
+>   `scripts/tests` writer noted there is a SEPARATE question and remains open.
 
 
 > No `clawgate-task:` front matter: `clawgate_handoff.sh resolve` returned **NOTHING RESOLVED
@@ -127,7 +131,7 @@ first time. `CLAUDE.md`'s `<!-- merge-gate: -->` marker correctly reads `other`.
   # reaches ~1.47x — still over. Decide the product question first.
   ```
 
-### The test tier still mutates the repo it runs from — root cause UNIDENTIFIED
+### The test tier still mutates the repo it runs from — the GIT_DIR SETTER is identified (2026-08-25); the unattributed writer is not
 - **Symptom + exact repro:** running devrc's pytest tier writes into the git repo it runs from —
   refs, `.git/config`, `HEAD`. On 2026-08-21 it force-overwrote **`main` on the public GitHub
   remote** with ~63 fixture commits authored `T <t@example.com>`, set `core.bare=true` on the
@@ -141,9 +145,22 @@ first time. `CLAUDE.md`'s `<!-- merge-gate: -->` marker correctly reads `other`.
     clone's config.
   - Before/after on the same two test files with a poisoned `GIT_DIR`: **165 passed / 230 ERRORS**
     → **395 passed / 0 errors**, refs + config byte-identical after.
-  - 🔴 **Who exported `GIT_DIR` is still unknown.** Live scan reported as a pair:
-    **46 processes carry some `GIT_*`, 0 carry `GIT_DIR`**, 13 unreadable (UNMEASURED). No
-    tracked file assigns one.
+  - ✅ **ANSWERED 2026-08-25 — `git` itself, on a push from a linked worktree.** This bullet
+    read "🔴 Who exported `GIT_DIR` is still unknown" and the heading above still says
+    UNIDENTIFIED; both are superseded. Measured on git 2.55.0, parent scrubbed of every
+    `GIT_*` name, reproduced on two independent rigs: a push from a **main checkout** exports
+    `GIT_EXEC_PATH`/`GIT_PREFIX` and no `GIT_DIR`, while a push from a **linked worktree**
+    exports `GIT_DIR=<repo>/.git/worktrees/<name>`. Also true of `--separate-git-dir`,
+    submodules (`<super>/.git/modules/<sub>`) and bare repos (a relative `.`). No outer caller
+    is required, and the 2026-08-21 incident was a push from a linked worktree.
+  - ⚠ **The live scan is not counter-evidence and should not be read as narrowing it.**
+    "46 processes carry some `GIT_*`, 0 carry `GIT_DIR`", 13 unreadable, no tracked file
+    assigns one — all true, and all about AMBIENT processes. git sets this variable only for
+    the duration of the hook, where no process scan could ever observe it. The pair was
+    sound; the inference from it was not.
+  - Pinned by `scripts/tests/test_git_repo_isolation.py::test_git_exports_GIT_DIR_to_pre_push_from_a_worktree_but_not_a_main_checkout`.
+    ⚠ Still open: this names the SETTER. The unattributed `scripts/tests` writer in the bullet
+    below is a separate question and is NOT closed by it.
   - Still observed AFTER the guards: a PASS → FAIL → PASS sequence on an **identical tree** in an
     **isolated standalone clone**, the FAIL being GUARD 10 catching `scripts/tests` writing to
     that clone's `.git/config`, `0 failed` tests. Writer unattributed.

--- a/claudedocs/handoff-test-tier-hardening.md
+++ b/claudedocs/handoff-test-tier-hardening.md
@@ -397,11 +397,44 @@ newest fixture-shaped reflog entry: 14:42:12 "commit: seed"   ← no recurrence 
   ```
 - **Recommendation on record, and it is SPLIT — do not read it as "merge #683":** #683's **prevention** half is correct and independently verified (guard at `run-tests.sh:235` / `run-node-tests.sh:142` / `gate.sh:120`, each immediately above its own `ROOT=`, nothing git-related executing before it). That half stops the measured mechanism and is worth landing. Its **detection** half is *not* stronger than #689 on the axis that produced #689's fourteen bypasses — two measured defects below. Continue #689 only if someone takes the per-verb positional-repo problem knowingly. Salvage from #689 regardless: the armed-vector battery with **live-axis arms**, the per-target `control=plugin:N inherited:N` accounting, and the fail-open checks.
 
-### 🔴 THE ROOT CAUSE OF THE RECURRENCE IS STILL UNIDENTIFIED — do not close this
+### ✅ THE ROOT CAUSE OF THE RECURRENCE IS IDENTIFIED (2026-08-25) — this heading used to say it was not
 
-- **RETRACTED:** *"`githooks/pre-push` assigns to the exported name `GIT_DIR`, so it hands the base clone's git dir down to `run-tests.sh` → pytest"* was relayed to me as established and is **wrong as stated**. Measured on git 2.55.0: **`git push` exports `GIT_EXEC_PATH`, `GIT_PREFIX=""` and `GIT_EDITOR` to `pre-push` — NOT `GIT_DIR`.** The rename in #683 is a route **only if an outer caller had already exported `GIT_DIR`**; `githooks/pre-push:44-48` states that precondition, and the PR body/commit message drop it. Good hygiene, not the explanation.
-- **Live scan, reported as a pair:** **46 processes carry some `GIT_*` var, 0 carry `GIT_DIR`** (13 unreadable ⇒ unmeasured, not zero). No tracked file assigns one.
-- So *why pushing appeared to trigger corruption* is open. Nothing found so far protects `homelab-talos` or any other repo's tooling either.
+🔴 **The retraction below is itself now partly retracted, and this is the fifth
+place the same false generalisation was found. A `RETRACTED:` banner carries
+extra authority, which is exactly why a wrong one is expensive.**
+
+- **What was measured, and is still true:** on git 2.55.0, a `git push` **from a
+  MAIN CHECKOUT** exports `GIT_EXEC_PATH`, `GIT_PREFIX` and `GIT_EDITOR` to
+  `pre-push` — not `GIT_DIR`. The rename in #683 is a route only if an outer
+  caller had already exported the name. That much stands.
+- 🔴 **What was WRONG: the generalisation to every push.** Both points were
+  measured on the same side of the dimension that decides the answer — which
+  checkout the push came from. Measured 2026-08-25, git 2.55.0, parent scrubbed
+  of every `GIT_*` name, reproduced independently on a second rig:
+
+  | push origin | `GIT_DIR` in `pre-push` |
+  |---|---|
+  | main checkout | *none* |
+  | **linked worktree** | `<repo>/.git/worktrees/<name>` |
+  | `--separate-git-dir` | `<separate gitdir>` |
+  | submodule | `<super>/.git/modules/<sub>` |
+  | bare repo | `.` *(relative!)* |
+
+  **git itself exports it. No outer caller is required** — and the incident was a
+  `git push -u origin <branch>` **from a linked worktree**. That is the answer to
+  "why pushing appeared to trigger corruption".
+- **The live scan is not counter-evidence.** "46 processes carry some `GIT_*`,
+  0 carry `GIT_DIR`" is a fact about ambient processes; git sets this variable
+  *for the duration of the hook*, where no scan would ever see it.
+- Pinned by `scripts/tests/test_git_repo_isolation.py::test_git_exports_GIT_DIR_to_pre_push_from_a_worktree_but_not_a_main_checkout`.
+  Since worktree isolation is the standing default for file-modifying agents,
+  this is the ORDINARY path — so the `REPO_POINTER_VARS` strip is load-bearing,
+  not belt-and-braces. Do not weaken it on the strength of the first bullet.
+- ⚠ **Still open:** this identifies what SETS `GIT_DIR` on a push. It does not
+  complete the end-to-end walk `pre-push` → `tests-on-push.sh` → the suite for
+  the incident itself, which `claudedocs/handoff-gitdir-leak-and-ci-gates.md`
+  still lists as never exercised. And nothing here protects `homelab-talos` or
+  any other repo's tooling.
 
 ### 🔴 #683's DETECTION half — two measured defects (its prevention half is sound)
 

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -52,8 +52,10 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 #
 # 🔴 BUT THE PRECONDITION IN THE FIRST SENTENCE IS LOAD-BEARING AND #683's PR
 # BODY DROPPED IT, turning a hygiene fix into a false diagnosis that was then
-# relayed onward as established fact. Measured on git 2.55.0, as a PAIR: a
-# `git push` from a `GIT_DIR`-free parent gives `pre-push` only `GIT_EXEC_PATH`
+# relayed onward as established fact. ⚠ READ TO THE END OF THIS BLOCK BEFORE
+# ACTING ON THE NEXT SENTENCE — it is true only of a push from a MAIN CHECKOUT,
+# and the qualifier arrives a few lines down. Measured on git 2.55.0, as a PAIR:
+# a `git push` from a `GIT_DIR`-free parent gives `pre-push` only `GIT_EXEC_PATH`
 # and `GIT_PREFIX` (plus the caller's own `GIT_AUTHOR_*`/`GIT_CONFIG_*`) — no
 # `GIT_DIR`; the same push with `GIT_DIR` exported by the caller passes it
 # straight through. A live scan of the box found 46 processes carrying some

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -65,16 +65,28 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 # for the same reason: the pair was measured at ONE point on a dimension that
 # changes the answer — WHICH CHECKOUT THE PUSH CAME FROM.
 #
-# MEASURED 2026-08-25, git 2.55.0, parent explicitly scrubbed
-# (`env -u GIT_DIR -u GIT_WORK_TREE`), reproduced twice, both directions:
+# MEASURED 2026-08-25, git 2.55.0, parent explicitly scrubbed of every `GIT_*`
+# name, reproduced twice and independently re-derived on a separate rig:
 #
-#     push from the MAIN checkout    -> GIT_EXEC_PATH only.        no GIT_DIR
+#     push from the MAIN checkout    -> GIT_EXEC_PATH, GIT_PREFIX. no GIT_DIR
 #     push from a LINKED WORKTREE    -> GIT_DIR=<repo>/.git/worktrees/<name>
 #
 # **git ITSELF exports `GIT_DIR` into `pre-push` when the push originates from a
-# linked worktree. No outer caller is required.** That is the missing root
-# cause, and it matches the incident report exactly: clawgate#322 was a
-# `git push -u origin <branch>` FROM A LINKED WORKTREE.
+# linked worktree. No outer caller is required.** It matches the incident report
+# exactly: clawgate#322 was a `git push -u origin <branch>` FROM A LINKED
+# WORKTREE.
+#
+# ⚠ A WORKTREE IS NOT THE ONLY SHAPE, and saying "only" here would repeat this
+# block's own mistake at a narrower radius. Also measured as exporting
+# `GIT_DIR`: `--separate-git-dir` clones, submodules
+# (`<super>/.git/modules/<sub>`), and bare repos (a RELATIVE `.`). The list is
+# open — treat "this is not a worktree" as NO evidence that `GIT_DIR` is unset.
+#
+# ⚠ SCOPE OF THE CLAIM: this identifies what sets `GIT_DIR` on a push, which is
+# the question this block called unidentified. It does NOT complete the
+# end-to-end walk of `pre-push` -> `tests-on-push.sh` -> the suite for the
+# incident itself — `claudedocs/handoff-gitdir-leak-and-ci-gates.md` still lists
+# that leg as never exercised, and it remains outstanding.
 #
 # Why it does damage: `GIT_DIR` OVERRIDES `-C`, so a child asking
 # `git -C <scope> rev-parse --show-toplevel` about a PLAIN, NON-REPO directory
@@ -88,9 +100,10 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 # not just when some exotic caller misbehaves. Do not weaken it on the grounds
 # that "pushing cannot set GIT_DIR" — from a worktree, it can and does.
 # Pinned by `scripts/tests/test_git_repo_isolation.py::
-# test_git_exports_GIT_DIR_to_pre_push_only_from_a_linked_worktree`, which is a
-# CANARY on git's behaviour: if a future git stops doing this the test fails and
-# tells you the precondition changed, rather than letting this comment rot.
+# test_git_exports_GIT_DIR_to_pre_push_from_a_worktree_but_not_a_main_checkout`,
+# which is a CANARY on git's behaviour: if a future git stops doing this the
+# test fails and tells you the precondition moved, rather than letting this
+# comment rot into the same false generalisation it replaced.
 #
 # `scripts/testlib/gitenv.py` closes the mechanism from the suite's side
 # whatever set the variable, and `scripts/tests/test_git_repo_isolation.py`

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -52,20 +52,50 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 #
 # 🔴 BUT THE PRECONDITION IN THE FIRST SENTENCE IS LOAD-BEARING AND #683's PR
 # BODY DROPPED IT, turning a hygiene fix into a false diagnosis that was then
-# relayed onward as established fact. **Measured on git 2.55.0, as a PAIR: a
+# relayed onward as established fact. Measured on git 2.55.0, as a PAIR: a
 # `git push` from a `GIT_DIR`-free parent gives `pre-push` only `GIT_EXEC_PATH`
 # and `GIT_PREFIX` (plus the caller's own `GIT_AUTHOR_*`/`GIT_CONFIG_*`) — no
 # `GIT_DIR`; the same push with `GIT_DIR` exported by the caller passes it
-# straight through.** So pushing does not, on its own, hand `GIT_DIR` to
-# anything; the old line was a route only when some OUTER caller had already
-# exported that name. A live scan of the box found 46 processes carrying some
+# straight through. A live scan of the box found 46 processes carrying some
 # `GIT_*` variable and ZERO carrying `GIT_DIR` (13 unreadable).
-# 🔴 THE ROOT CAUSE OF THE INCIDENT — what exported `GIT_DIR` into that gate run
-# — REMAINS UNIDENTIFIED. This rename removes a real route and is worth keeping;
-# it is not the explanation. `scripts/testlib/gitenv.py` closes the mechanism
-# from the suite's side whatever set the variable, and
-# `scripts/tests/test_git_repo_isolation.py` asserts no shell script that can
-# reach the runner assigns to one of those names.
+#
+# 🔴 THAT PAIR IS TRUE AND ITS GENERALISATION WAS FALSE. This block used to
+# conclude "**so pushing does not, on its own, hand `GIT_DIR` to anything**" and
+# that "THE ROOT CAUSE OF THE INCIDENT REMAINS UNIDENTIFIED". Both were wrong,
+# for the same reason: the pair was measured at ONE point on a dimension that
+# changes the answer — WHICH CHECKOUT THE PUSH CAME FROM.
+#
+# MEASURED 2026-08-25, git 2.55.0, parent explicitly scrubbed
+# (`env -u GIT_DIR -u GIT_WORK_TREE`), reproduced twice, both directions:
+#
+#     push from the MAIN checkout    -> GIT_EXEC_PATH only.        no GIT_DIR
+#     push from a LINKED WORKTREE    -> GIT_DIR=<repo>/.git/worktrees/<name>
+#
+# **git ITSELF exports `GIT_DIR` into `pre-push` when the push originates from a
+# linked worktree. No outer caller is required.** That is the missing root
+# cause, and it matches the incident report exactly: clawgate#322 was a
+# `git push -u origin <branch>` FROM A LINKED WORKTREE.
+#
+# Why it does damage: `GIT_DIR` OVERRIDES `-C`, so a child asking
+# `git -C <scope> rev-parse --show-toplevel` about a PLAIN, NON-REPO directory
+# gets <scope> ITSELF back instead of the repo enclosing it. Measured on the
+# same day: clean env -> `<repoA>`; with `GIT_DIR` leaked -> `<repoA>/nested/scope`.
+# A nesting guard asking "is this its own repo?" therefore gets YES for a
+# directory that is not a repo at all, skips, and the write lands in the FOREIGN
+# repository `GIT_DIR` names. Unsetting the pointer set restores `<repoA>`.
+#
+# 🔴 SO THE STRIP IN `tests-on-push.sh` IS LOAD-BEARING ON THE ORDINARY PATH,
+# not just when some exotic caller misbehaves. Do not weaken it on the grounds
+# that "pushing cannot set GIT_DIR" — from a worktree, it can and does.
+# Pinned by `scripts/tests/test_git_repo_isolation.py::
+# test_git_exports_GIT_DIR_to_pre_push_only_from_a_linked_worktree`, which is a
+# CANARY on git's behaviour: if a future git stops doing this the test fails and
+# tells you the precondition changed, rather than letting this comment rot.
+#
+# `scripts/testlib/gitenv.py` closes the mechanism from the suite's side
+# whatever set the variable, and `scripts/tests/test_git_repo_isolation.py`
+# also asserts no shell script that can reach the runner assigns to one of
+# those names.
 HOOK_GIT_DIR="$(git rev-parse --git-dir 2>/dev/null || true)"
 SELF="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 

--- a/githooks/tests-on-push.sh
+++ b/githooks/tests-on-push.sh
@@ -89,9 +89,25 @@ unset "${DEVRC_GITENV_CONTROL_VARS[@]}"
 
 # 🔴 `GIT_PREFIX` is on that list and git DOES export it to a pre-push hook
 # (measured, git 2.55.0: `GIT_EXEC_PATH` and `GIT_PREFIX` are exported to
-# `pre-push`; `GIT_DIR` is NOT). Nothing below reads it, and
+# `pre-push` from a MAIN CHECKOUT). Nothing below reads it, and
 # clearing it before `rev-parse` is what keeps the resolution on the next line
 # a function of the CWD alone.
+#
+# 🔴 THAT PARENTHESIS USED TO END "`GIT_DIR` is NOT", FULL STOP — THREE LINES
+# ABOVE THE STRIP IT WOULD TALK YOU OUT OF. It is true only of a push from a
+# main checkout. Measured 2026-08-25, git 2.55.0, parent scrubbed:
+#
+#     push from a MAIN checkout   -> GIT_EXEC_PATH, GIT_PREFIX.  no GIT_DIR
+#     push from a LINKED WORKTREE -> GIT_DIR=<repo>/.git/worktrees/<name>
+#
+# git exports it ITSELF from a worktree — and `--separate-git-dir`, submodules
+# and bare repos do it too, so "not a worktree" is no evidence either. Since
+# worktree isolation is the standing default for file-modifying agents here,
+# that is the ORDINARY path, not an exotic one.
+# **So do not prune `GIT_DIR` from `DEVRC_GIT_REPO_POINTERS` above on the
+# strength of this parenthesis.** Pinned by `scripts/tests/
+# test_git_repo_isolation.py::test_git_exports_GIT_DIR_to_pre_push_from_a_
+# worktree_but_not_a_main_checkout`.
 REPO_ROOT="${1:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
 [ -n "$REPO_ROOT" ] || exit 0
 

--- a/scripts/testlib/gitenv.py
+++ b/scripts/testlib/gitenv.py
@@ -40,10 +40,25 @@ hook was a route only if some OUTER caller had already exported the name (bash
 keeps an already-exported name exported across a reassignment); the hook's own
 comment stated that precondition correctly and the PR body dropped it. A live
 scan of the box found 46 processes carrying some `GIT_*` variable and **0**
-carrying `GIT_DIR` (13 unreadable). **THE ROOT CAUSE — what exported `GIT_DIR`
-into that gate run — IS STILL UNKNOWN.** The rename is correct hygiene and the
-strip below closes the mechanism whatever set it; neither identifies the
-setter. Do not cite the pre-push rename as the diagnosis.
+carrying `GIT_DIR` (13 unreadable).
+
+🔴 **THE ROOT CAUSE IS NO LONGER UNKNOWN, AND THIS PARAGRAPH USED TO SAY IT
+WAS.** The pair above is true and its generalisation was not: both points were
+measured from a MAIN CHECKOUT. Measured 2026-08-25, git 2.55.0, parent scrubbed
+of every `GIT_*` name, reproduced independently:
+
+    push from a MAIN checkout    -> GIT_EXEC_PATH, GIT_PREFIX.  no GIT_DIR
+    push from a LINKED WORKTREE  -> GIT_DIR=<repo>/.git/worktrees/<name>
+
+**git itself exports it from a linked worktree; no outer caller is required**,
+and clawgate#322 was a push from a linked worktree. Other shapes do it too —
+`--separate-git-dir`, submodules (`<super>/.git/modules/<sub>`) and bare repos
+(a RELATIVE `.`) — so "not a worktree" is no evidence that `GIT_DIR` is unset.
+Pinned by `test_git_exports_GIT_DIR_to_pre_push_from_a_worktree_but_not_a_main
+_checkout`. So the strip below is load-bearing on the ORDINARY path, not only
+against a misbehaving outer caller: do not weaken it on the belief that pushing
+cannot set `GIT_DIR`. The pre-push rename is still correct hygiene and still
+not, by itself, the diagnosis.
 
 And the fixture VALUES are the tell that identifies the MECHANISM (an inherited
 `GIT_DIR`) rather than merely being consistent with it: the tmpdir paths

--- a/scripts/tests/test_git_repo_isolation.py
+++ b/scripts/tests/test_git_repo_isolation.py
@@ -2133,3 +2133,111 @@ def test_the_runner_strips_the_pointers_before_a_non_pytest_target_runs(tmp_path
     assert r["deltas"] == [], (
         "the foreign repository changed even though its HEAD did not:\n"
         + "\n".join(r["deltas"]))
+
+
+# --------------------------------------------------------------------------- #
+# 9. THE PRECONDITION ITSELF — a canary on git, not on devrc
+# --------------------------------------------------------------------------- #
+def test_git_exports_GIT_DIR_to_pre_push_only_from_a_linked_worktree(tmp_path):
+    """🔴 WHY GUARD 9's STRIP IS LOAD-BEARING ON THE ORDINARY PATH.
+
+    `githooks/pre-push` used to conclude that "pushing does not, on its own,
+    hand `GIT_DIR` to anything", and that the 2026-08-21 incident's root cause
+    "REMAINS UNIDENTIFIED". The measurement behind that was real but taken at
+    ONE point on a dimension that changes the answer: which checkout the push
+    came from. Measured 2026-08-25 on git 2.55.0 with the parent scrubbed:
+
+        push from the MAIN checkout -> GIT_EXEC_PATH only, no GIT_DIR
+        push from a LINKED WORKTREE -> GIT_DIR=<repo>/.git/worktrees/<name>
+
+    git itself exports it. No outer caller is needed — and clawgate#322 was a
+    push from a linked worktree, which is the match.
+
+    🔴 THIS IS A CANARY ON GIT'S BEHAVIOUR, NOT A TEST OF OUR CODE. It exists so
+    that if a future git stops exporting `GIT_DIR` here, someone is TOLD the
+    precondition moved, instead of the comment quietly rotting into the same
+    false generalisation it replaced. If it fails because git changed: update
+    the comment in `githooks/pre-push`, and do NOT weaken the strip on the
+    strength of one version's behaviour.
+
+    Both arms are asserted. The main-checkout arm is the control: without it a
+    hook that never ran, or a recorder that never wrote, would look identical to
+    "git does not export it".
+    """
+    repo = _mkrepo(tmp_path / "repo")
+    bare = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(bare)],
+                   check=True, capture_output=True, env=_env())
+    assert _git(repo, "remote", "add", "origin", str(bare)).returncode == 0
+    assert _git(repo, "push", "-q", "origin", "main").returncode == 0
+
+    hooks = tmp_path / "hooks"
+    hooks.mkdir()
+    # Every line goes INTO the file. An earlier version of this probe printed to
+    # stdout, so the file the assertions read was always empty and the probe
+    # reported "not exported" no matter what git did.
+    (hooks / "pre-push").write_text(
+        "#!/usr/bin/env bash\n"
+        'out="${PROBE_OUT:-/dev/null}"\n'
+        ': > "$out"\n'
+        'for v in GIT_DIR GIT_EXEC_PATH; do\n'
+        '  if [ -n "${!v:-}" ]; then printf "%s=%s\\n" "$v" "${!v}" >> "$out"; fi\n'
+        'done\n'
+        "exit 0\n",
+        encoding="utf-8")
+    (hooks / "pre-push").chmod(0o755)
+    assert _git(repo, "config", "--local", "core.hooksPath", str(hooks)).returncode == 0
+
+    def push_from(cwd: Path, branch: str, tag: str) -> str:
+        out = tmp_path / f"env-{tag}.txt"
+        env = _env(PROBE_OUT=str(out))
+        # Scrub the pointer names from the PARENT, so anything recorded was put
+        # there by git and not inherited from this test process.
+        for name in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE",
+                     "GIT_COMMON_DIR", "GIT_OBJECT_DIRECTORY"):
+            env.pop(name, None)
+        subprocess.run(["git", "-C", str(cwd), "push", "-q", "origin", branch],
+                       capture_output=True, text=True, env=env)
+        return out.read_text(encoding="utf-8") if out.exists() else ""
+
+    # --- arm 1: the MAIN checkout ------------------------------------------
+    assert _git(repo, "checkout", "-q", "-b", "from-main").returncode == 0
+    (repo / "b.txt").write_text("b\n", encoding="utf-8")
+    assert _git(repo, "add", "b.txt").returncode == 0
+    assert _git(repo, "commit", "-qm", "b").returncode == 0
+    main_env = push_from(repo, "from-main", "main")
+
+    # --- arm 2: a LINKED WORKTREE ------------------------------------------
+    wt = tmp_path / "wt"
+    assert _git(repo, "worktree", "add", "-q", str(wt), "-b", "from-wt",
+                "main").returncode == 0
+    (wt / "c.txt").write_text("c\n", encoding="utf-8")
+    assert _git(wt, "add", "c.txt").returncode == 0
+    assert _git(wt, "commit", "-qm", "c").returncode == 0
+    wt_env = push_from(wt, "from-wt", "wt")
+
+    # 🔴 POSITIVE CONTROL FIRST. git exports GIT_EXEC_PATH to hooks
+    # unconditionally, so if it is missing the hook never ran or never wrote,
+    # and an absent GIT_DIR below would prove nothing at all.
+    for tag, text in (("main-checkout", main_env), ("linked-worktree", wt_env)):
+        assert "GIT_EXEC_PATH=" in text, (
+            f"the {tag} probe recorded no GIT_EXEC_PATH, so the hook did not run "
+            f"or did not write. Nothing in this test was measured.\ngot: {text!r}")
+
+    assert "GIT_DIR=" not in main_env, (
+        "git exported GIT_DIR to pre-push from the MAIN checkout. The asymmetry "
+        "this test pins has changed; re-measure and update the comment in "
+        f"githooks/pre-push.\ngot: {main_env!r}")
+
+    assert "GIT_DIR=" in wt_env, (
+        "git did NOT export GIT_DIR to pre-push from a LINKED WORKTREE. That is "
+        "the precondition behind GUARD 9's strip and behind the clawgate#322 "
+        "diagnosis. If git genuinely changed, update the root-cause comment in "
+        "githooks/pre-push — do NOT weaken the strip on one version's "
+        f"behaviour.\ngot: {wt_env!r}")
+
+    # Name it precisely: it points at the WORKTREE's gitdir, which is why a
+    # `-C` lookup elsewhere resolves into this repo rather than the target.
+    assert "/worktrees/" in wt_env, (
+        "GIT_DIR was exported but does not point at a linked worktree's gitdir; "
+        f"the mechanism may differ from the one documented.\ngot: {wt_env!r}")

--- a/scripts/tests/test_git_repo_isolation.py
+++ b/scripts/tests/test_git_repo_isolation.py
@@ -1018,17 +1018,25 @@ def test_no_shell_script_that_can_reach_the_runner_assigns_a_git_repo_pointer():
     )
 
 
-def test_git_push_does_not_export_GIT_DIR_to_pre_push(tmp_path):
+def test_git_push_from_a_MAIN_CHECKOUT_does_not_export_GIT_DIR_to_pre_push(tmp_path):
     """🔴 THE CORRECTION, MEASURED, AS A PAIR — #683's body and commit message
     both stated that `githooks/pre-push` handing down `GIT_DIR` explained why
     *pushing* triggered the corruption, and that claim was relayed to another
     session as established fact before it was checked.
 
-    A `git push` from a GIT_DIR-free parent gives `pre-push` only
-    `GIT_EXEC_PATH` and `GIT_PREFIX` (plus the caller's own identity/config
-    vars). The rename remains correct hygiene — an outer caller's exported
-    `GIT_DIR` really does survive a reassignment — but it is NOT the diagnosis,
-    and the root cause of the incident is still unknown.
+    A `git push` **from a main checkout** with a GIT_DIR-free parent gives
+    `pre-push` only `GIT_EXEC_PATH` and `GIT_PREFIX` (plus the caller's own
+    identity/config vars). The rename remains correct hygiene — an outer
+    caller's exported `GIT_DIR` really does survive a reassignment.
+
+    🔴 THE SCOPE WORD IN THIS NAME IS LOAD-BEARING, AND IT WAS MISSING. This
+    test used to be called `test_git_push_does_not_export_GIT_DIR_to_pre_push`
+    and its docstring ended "the root cause of the incident is still unknown".
+    The measurement was right; the unqualified name generalised it to every
+    push. It is false for a push from a LINKED WORKTREE, where git exports
+    `GIT_DIR` on its own — see
+    `test_git_exports_GIT_DIR_to_pre_push_from_a_worktree_but_not_a_main_checkout`
+    below, which identifies the root cause this docstring called unknown.
     """
     home = tmp_path / "home"
     home.mkdir()
@@ -2138,106 +2146,132 @@ def test_the_runner_strips_the_pointers_before_a_non_pytest_target_runs(tmp_path
 # --------------------------------------------------------------------------- #
 # 9. THE PRECONDITION ITSELF — a canary on git, not on devrc
 # --------------------------------------------------------------------------- #
-def test_git_exports_GIT_DIR_to_pre_push_only_from_a_linked_worktree(tmp_path):
+def test_git_exports_GIT_DIR_to_pre_push_from_a_worktree_but_not_a_main_checkout(
+        tmp_path):
     """🔴 WHY GUARD 9's STRIP IS LOAD-BEARING ON THE ORDINARY PATH.
 
-    `githooks/pre-push` used to conclude that "pushing does not, on its own,
-    hand `GIT_DIR` to anything", and that the 2026-08-21 incident's root cause
-    "REMAINS UNIDENTIFIED". The measurement behind that was real but taken at
-    ONE point on a dimension that changes the answer: which checkout the push
-    came from. Measured 2026-08-25 on git 2.55.0 with the parent scrubbed:
+    The sibling test above measures the MAIN-CHECKOUT arm and finds no
+    `GIT_DIR`. That result is correct and this test does not contradict it —
+    what it corrects is the GENERALISATION once drawn from it, that "pushing
+    does not, on its own, hand GIT_DIR to anything" and that the 2026-08-21
+    incident's root cause was unidentified. Both were wrong, because the
+    measurement was taken at one point on a dimension that changes the answer:
+    WHICH CHECKOUT THE PUSH CAME FROM.
 
-        push from the MAIN checkout -> GIT_EXEC_PATH only, no GIT_DIR
+    Measured 2026-08-25, git 2.55.0, parent scrubbed of every `GIT_*` name:
+
+        push from the MAIN checkout -> GIT_EXEC_PATH, GIT_PREFIX.  no GIT_DIR
         push from a LINKED WORKTREE -> GIT_DIR=<repo>/.git/worktrees/<name>
 
-    git itself exports it. No outer caller is needed — and clawgate#322 was a
-    push from a linked worktree, which is the match.
+    git itself exports it; no outer caller is required. clawgate#322 was a push
+    from a linked worktree, which is the match.
 
-    🔴 THIS IS A CANARY ON GIT'S BEHAVIOUR, NOT A TEST OF OUR CODE. It exists so
-    that if a future git stops exporting `GIT_DIR` here, someone is TOLD the
-    precondition moved, instead of the comment quietly rotting into the same
-    false generalisation it replaced. If it fails because git changed: update
-    the comment in `githooks/pre-push`, and do NOT weaken the strip on the
-    strength of one version's behaviour.
+    ⚠ A WORKTREE IS NOT THE ONLY SHAPE THAT DOES THIS, and an earlier version of
+    this test said "only" in its own name. Also measured as exporting `GIT_DIR`:
+    `--separate-git-dir` clones, submodules (`<super>/.git/modules/<sub>`), and
+    bare repos (which export a RELATIVE `.`). The list is open; treat "not a
+    worktree" as no evidence that `GIT_DIR` is unset.
 
-    Both arms are asserted. The main-checkout arm is the control: without it a
-    hook that never ran, or a recorder that never wrote, would look identical to
-    "git does not export it".
+    🔴 THIS IS A CANARY ON GIT'S BEHAVIOUR, NOT A TEST OF OUR CODE. If a future
+    git stops exporting this, the test fails and tells you the precondition
+    moved — instead of the comment rotting into the same false generalisation it
+    replaced. Do NOT weaken the strip on one version's behaviour.
     """
-    repo = _mkrepo(tmp_path / "repo")
-    bare = tmp_path / "origin.git"
-    subprocess.run(["git", "init", "-q", "--bare", str(bare)],
-                   check=True, capture_output=True, env=_env())
-    assert _git(repo, "remote", "add", "origin", str(bare)).returncode == 0
-    assert _git(repo, "push", "-q", "origin", "main").returncode == 0
+    # Same isolation as the sibling: no inherited GIT_* names, and a pinned
+    # global config so the operator's own `core.hooksPath` cannot reach in.
+    gitconfig = tmp_path / "gitconfig"
+    gitconfig.write_text("[user]\n\tname = g9\n\temail = g9@example.invalid\n",
+                         encoding="utf-8")
+    base = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    base.update(_GIT_ENV)
+    base["GIT_CONFIG_GLOBAL"] = str(gitconfig)
 
+    bare = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(bare)], check=True,
+                   capture_output=True, env=base)
+    work = tmp_path / "work"
+    work.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main", str(work)], check=True,
+                   capture_output=True, env=base)
+    (work / "f.txt").write_text("base\n", encoding="utf-8")
+    assert _git(work, "add", "f.txt", env=base).returncode == 0
+    assert _git(work, "commit", "-qm", "base", env=base).returncode == 0
+    assert _git(work, "remote", "add", "origin", str(bare), env=base).returncode == 0
+    assert _git(work, "push", "-q", "origin", "main", env=base).returncode == 0
+
+    # 🔴 `mockbin.write_exec` OWNS THE SHEBANG — writing `#!/usr/bin/env bash`
+    # here would (a) fail `test_runtime_shebangs.py` and (b) be unrunnable in
+    # the nix sandbox, where `/usr/bin/env` does not exist. Both were measured
+    # on this very test. The body is POSIX sh for the same reason: `${!v}` is a
+    # bash-ism and `mockbin.SH` is `/bin/sh`.
+    main_seen = tmp_path / "env-main.txt"
+    wt_seen = tmp_path / "env-wt.txt"
     hooks = tmp_path / "hooks"
     hooks.mkdir()
-    # Every line goes INTO the file. An earlier version of this probe printed to
-    # stdout, so the file the assertions read was always empty and the probe
-    # reported "not exported" no matter what git did.
-    (hooks / "pre-push").write_text(
-        "#!/usr/bin/env bash\n"
-        'out="${PROBE_OUT:-/dev/null}"\n'
-        ': > "$out"\n'
-        'for v in GIT_DIR GIT_EXEC_PATH; do\n'
-        '  if [ -n "${!v:-}" ]; then printf "%s=%s\\n" "$v" "${!v}" >> "$out"; fi\n'
-        'done\n'
-        "exit 0\n",
-        encoding="utf-8")
-    (hooks / "pre-push").chmod(0o755)
-    assert _git(repo, "config", "--local", "core.hooksPath", str(hooks)).returncode == 0
 
-    def push_from(cwd: Path, branch: str, tag: str) -> str:
-        out = tmp_path / f"env-{tag}.txt"
-        env = _env(PROBE_OUT=str(out))
-        # Scrub the pointer names from the PARENT, so anything recorded was put
-        # there by git and not inherited from this test process.
-        for name in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE",
-                     "GIT_COMMON_DIR", "GIT_OBJECT_DIRECTORY"):
-            env.pop(name, None)
-        subprocess.run(["git", "-C", str(cwd), "push", "-q", "origin", branch],
-                       capture_output=True, text=True, env=env)
-        return out.read_text(encoding="utf-8") if out.exists() else ""
+    def arm(seen: Path):
+        mockbin.write_exec(
+            hooks / "pre-push",
+            f"env | grep -E '^GIT' | sort > {seen}\n"
+            "cat >/dev/null\nexit 0\n")
+
+    assert _git(work, "config", "--local", "core.hooksPath", str(hooks),
+                env=base).returncode == 0
 
     # --- arm 1: the MAIN checkout ------------------------------------------
-    assert _git(repo, "checkout", "-q", "-b", "from-main").returncode == 0
-    (repo / "b.txt").write_text("b\n", encoding="utf-8")
-    assert _git(repo, "add", "b.txt").returncode == 0
-    assert _git(repo, "commit", "-qm", "b").returncode == 0
-    main_env = push_from(repo, "from-main", "main")
+    arm(main_seen)
+    assert _git(work, "checkout", "-q", "-b", "from-main", env=base).returncode == 0
+    (work / "b.txt").write_text("b\n", encoding="utf-8")
+    assert _git(work, "add", "b.txt", env=base).returncode == 0
+    assert _git(work, "commit", "-qm", "b", env=base).returncode == 0
+    assert _git(work, "push", "-q", "origin", "from-main", env=base).returncode == 0
 
     # --- arm 2: a LINKED WORKTREE ------------------------------------------
     wt = tmp_path / "wt"
-    assert _git(repo, "worktree", "add", "-q", str(wt), "-b", "from-wt",
-                "main").returncode == 0
+    assert _git(work, "worktree", "add", "-q", str(wt), "-b", "from-wt", "main",
+                env=base).returncode == 0
+    arm(wt_seen)
     (wt / "c.txt").write_text("c\n", encoding="utf-8")
-    assert _git(wt, "add", "c.txt").returncode == 0
-    assert _git(wt, "commit", "-qm", "c").returncode == 0
-    wt_env = push_from(wt, "from-wt", "wt")
+    assert _git(wt, "add", "c.txt", env=base).returncode == 0
+    assert _git(wt, "commit", "-qm", "c", env=base).returncode == 0
+    assert _git(wt, "push", "-q", "origin", "from-wt", env=base).returncode == 0
 
-    # 🔴 POSITIVE CONTROL FIRST. git exports GIT_EXEC_PATH to hooks
-    # unconditionally, so if it is missing the hook never ran or never wrote,
-    # and an absent GIT_DIR below would prove nothing at all.
-    for tag, text in (("main-checkout", main_env), ("linked-worktree", wt_env)):
-        assert "GIT_EXEC_PATH=" in text, (
-            f"the {tag} probe recorded no GIT_EXEC_PATH, so the hook did not run "
-            f"or did not write. Nothing in this test was measured.\ngot: {text!r}")
+    def names(p: Path) -> set:
+        if not p.exists():
+            return set()
+        return {ln.split("=", 1)[0]
+                for ln in p.read_text(encoding="utf-8").splitlines()}
 
-    assert "GIT_DIR=" not in main_env, (
+    main_names, wt_names = names(main_seen), names(wt_seen)
+
+    # 🔴 POSITIVE CONTROL FIRST, BOTH ARMS. git exports GIT_EXEC_PATH to hooks
+    # unconditionally, so if it is missing the hook never ran or never wrote —
+    # and an absent GIT_DIR below would then prove nothing at all. Each arm has
+    # its OWN file, written and read within that arm, so arm 2 can never be
+    # scored on arm 1's leftovers.
+    for tag, seen in (("main-checkout", main_names), ("linked-worktree", wt_names)):
+        assert "GIT_EXEC_PATH" in seen, (
+            f"the {tag} hook did not run or did not write, so nothing in this "
+            f"test was measured.\nsaw: {sorted(seen)}")
+
+    assert "GIT_DIR" not in main_names, (
         "git exported GIT_DIR to pre-push from the MAIN checkout. The asymmetry "
-        "this test pins has changed; re-measure and update the comment in "
-        f"githooks/pre-push.\ngot: {main_env!r}")
+        "this canary pins has changed — re-measure and rewrite the root-cause "
+        f"block in githooks/pre-push.\nsaw: {sorted(main_names)}")
 
-    assert "GIT_DIR=" in wt_env, (
+    assert "GIT_DIR" in wt_names, (
         "git did NOT export GIT_DIR to pre-push from a LINKED WORKTREE. That is "
         "the precondition behind GUARD 9's strip and behind the clawgate#322 "
-        "diagnosis. If git genuinely changed, update the root-cause comment in "
+        "diagnosis. If git genuinely changed, rewrite the root-cause block in "
         "githooks/pre-push — do NOT weaken the strip on one version's "
-        f"behaviour.\ngot: {wt_env!r}")
+        f"behaviour.\nsaw: {sorted(wt_names)}")
 
     # Name it precisely: it points at the WORKTREE's gitdir, which is why a
-    # `-C` lookup elsewhere resolves into this repo rather than the target.
-    assert "/worktrees/" in wt_env, (
-        "GIT_DIR was exported but does not point at a linked worktree's gitdir; "
-        f"the mechanism may differ from the one documented.\ngot: {wt_env!r}")
+    # `-C` lookup elsewhere resolves back into this repo instead of the target.
+    wt_git_dir = next(
+        ln.split("=", 1)[1]
+        for ln in wt_seen.read_text(encoding="utf-8").splitlines()
+        if ln.startswith("GIT_DIR="))
+    assert "/worktrees/" in wt_git_dir, (
+        "GIT_DIR was exported but does not name a linked worktree's gitdir, so "
+        f"the mechanism may differ from the documented one.\ngot: {wt_git_dir!r}")

--- a/scripts/tests/test_git_repo_isolation.py
+++ b/scripts/tests/test_git_repo_isolation.py
@@ -22,12 +22,32 @@ and a plugin rather than a patch in fourteen test files. The tmpdir
 paths written into the real config are the tell: the tests computed the RIGHT
 value and git wrote it into the WRONG repository.
 
-🔴 WHAT IS **NOT** KNOWN, stated here because #683's body asserted it and it was
-relayed onward: nothing has identified WHAT exported `GIT_DIR` into that run.
-`git push` does not hand `GIT_DIR` to `pre-push` (measured, git 2.55.0 — see
-`test_git_push_does_not_export_GIT_DIR_to_pre_push`), so the hook's old
-`GIT_DIR=` line was a route only when an outer caller had already exported the
-name. The rename is hygiene, not a diagnosis.
+✅ WHAT EXPORTED `GIT_DIR` — ANSWERED 2026-08-25, AND THIS PARAGRAPH USED TO SAY
+IT WAS UNKNOWN. It read: "nothing has identified WHAT exported `GIT_DIR` into
+that run. `git push` does not hand `GIT_DIR` to `pre-push`." The measurement
+behind that was taken from a MAIN CHECKOUT only, and the unqualified sentence is
+false. Measured on git 2.55.0 with the parent scrubbed of every `GIT_*` name,
+reproduced on two independent rigs:
+
+    push from a MAIN checkout   -> GIT_EXEC_PATH, GIT_PREFIX.  no GIT_DIR
+    push from a LINKED WORKTREE -> GIT_DIR=<repo>/.git/worktrees/<name>
+
+**git itself exports it; no outer caller is required**, and the 2026-08-21
+incident was a push from a linked worktree. `--separate-git-dir` clones,
+submodules (`<super>/.git/modules/<sub>`) and bare repos (a RELATIVE `.`) do it
+too — so "this is not a worktree" is NO evidence that `GIT_DIR` is unset.
+
+🔴 THIS PARAGRAPH IS THE FIRST THING ANYONE READS BEFORE TOUCHING
+`REPO_POINTER_VARS`, WHICH IS WHY IT MATTERED THAT IT WAS WRONG: it argued the
+strip was hygiene against an exotic caller. It is not — pushing from a worktree
+is the ORDINARY path here, since worktree isolation is the standing default for
+file-modifying agents. Do not prune `GIT_DIR` from the ledger.
+
+The two arms are pinned by
+`test_git_push_from_a_MAIN_CHECKOUT_does_not_export_GIT_DIR_to_pre_push` and
+`test_git_exports_GIT_DIR_to_pre_push_from_a_worktree_but_not_a_main_checkout`.
+The #683 rename remains correct hygiene and is still not, by itself, the
+diagnosis.
 
 HOW THIS FILE IS BUILT, and why each layer is not redundant with the next:
 
@@ -2212,7 +2232,7 @@ def test_git_exports_GIT_DIR_to_pre_push_from_a_worktree_but_not_a_main_checkout
     def arm(seen: Path):
         mockbin.write_exec(
             hooks / "pre-push",
-            f"env | grep -E '^GIT' | sort > {seen}\n"
+            f"env | grep -E '^GIT' | sort > '{seen}'\n"
             "cat >/dev/null\nexit 0\n")
 
     assert _git(work, "config", "--local", "core.hooksPath", str(hooks),
@@ -2246,9 +2266,15 @@ def test_git_exports_GIT_DIR_to_pre_push_from_a_worktree_but_not_a_main_checkout
 
     # 🔴 POSITIVE CONTROL FIRST, BOTH ARMS. git exports GIT_EXEC_PATH to hooks
     # unconditionally, so if it is missing the hook never ran or never wrote —
-    # and an absent GIT_DIR below would then prove nothing at all. Each arm has
-    # its OWN file, written and read within that arm, so arm 2 can never be
-    # scored on arm 1's leftovers.
+    # and an absent GIT_DIR below would then prove nothing at all.
+    # Each arm WRITES its own file, and `arm()` re-installs the hook pointing at
+    # that file before each push, so a hook that fails to fire in arm 2 leaves
+    # `wt_seen` ABSENT rather than holding arm 1's contents — `names()` returns
+    # an empty set and the positive control above fires. (Both files are read
+    # together after both pushes; it is the per-arm WRITE that closes the
+    # leftovers hole, not the read order. An earlier version of this comment
+    # said "written and read within that arm", which described the read wrongly
+    # while the property it claims is genuinely held.)
     for tag, seen in (("main-checkout", main_names), ("linked-worktree", wt_names)):
         assert "GIT_EXEC_PATH" in seen, (
             f"the {tag} hook did not run or did not write, so nothing in this "


### PR DESCRIPTION
`githooks/pre-push` currently states, in bold, that **"pushing does not, on its own, hand `GIT_DIR` to anything"**, and separately that **"🔴 THE ROOT CAUSE OF THE INCIDENT — what exported `GIT_DIR` into that gate run — REMAINS UNIDENTIFIED."**

The pair of measurements behind that sentence is real. The generalisation drawn from it is false, and this PR identifies the root cause.

## The measurement

Both points in the original pair were taken on the same side of a dimension that changes the answer: **which checkout the push came from.** Measured 2026-08-25 on git 2.55.0, parent explicitly scrubbed (`env -u GIT_DIR -u GIT_WORK_TREE`), reproduced twice, both arms:

```
push from the MAIN checkout  ->  GIT_EXEC_PATH only.        no GIT_DIR
push from a LINKED WORKTREE  ->  GIT_DIR=<repo>/.git/worktrees/<name>
```

**git itself exports it. No outer caller is required.**

And `clawgate#322` — the incident — was reported as `git push -u origin <branch>` **from a linked worktree**. The match is exact.

## The damage mechanism, reproduced in isolation

`GIT_DIR` overrides `-C`. So a child asking `git -C <scope> rev-parse --show-toplevel` about a **plain, non-repo directory** gets `<scope>` itself back instead of the repo enclosing it:

```
clean env         ->  <repoA>                  (correct: scope is nested in repoA)
GIT_DIR leaked    ->  <repoA>/nested/scope     (scope reports as its own toplevel)
after the strip   ->  <repoA>                  (restored)
```

A nesting guard asking *"is this its own repo?"* therefore gets **YES for a directory that is not a repo at all**, skips, and the write lands in the foreign repository `GIT_DIR` names.

## Why this matters beyond the comment

The old text is an argument for believing the strip in `tests-on-push.sh` is belt-and-braces — something that only matters if an exotic caller misbehaves. It isn't. **It is load-bearing on the ordinary path**, because pushing from a worktree is ordinary here (worktree isolation is the standing default for file-modifying agents). The corrected comment says so explicitly and warns against weakening it on one git version's behaviour.

## The test

`test_git_exports_GIT_DIR_to_pre_push_only_from_a_linked_worktree`, in `test_git_repo_isolation.py` (GUARD 9's file, same hazard).

🔴 **Labelled as what it is: a CANARY ON GIT'S BEHAVIOUR, not a test of our code.** Its job is that if a future git stops exporting this, somebody is *told* the precondition moved — instead of this comment quietly rotting into the same false generalisation it replaces.

### 🔴 My first probe reported the OPPOSITE, and that shaped the test

The first version printed to stdout instead of the file its verdict grepped. The file was therefore always empty and it concluded **"TRIGGER ABSENT"** regardless of what git did — while the truth sat in the raw output two lines above. A broken instrument returning a confident, wrong answer.

So the shipped test asserts a **positive control first**: git exports `GIT_EXEC_PATH` to hooks unconditionally, so if it is missing the hook never ran or never wrote — and an absent `GIT_DIR` would prove nothing. Both arms are checked, because without the main-checkout arm "git does not export it" and "the hook is dead" are indistinguishable.

### Mutation battery — 4/4, each on its own assertion

| mutant | must die on |
|---|---|
| recorder writes nowhere | `the hook did not run or did not write` |
| parent leaks `GIT_DIR` (the documented pass-through) | `exported GIT_DIR ... from the MAIN checkout` |
| arm 2 is not actually a linked worktree | `did NOT export GIT_DIR ... LINKED WORKTREE` |

Plus the positive control (unmutated passes). Every assertion proven reachable.

## Verification

- `test_git_repo_isolation.py`: **113 passed**.
- ⚠ The full dev-host tier could **not** be run to a verdict here: it stopped on GUARD 10 reporting that the git **common-dir** `.git/config` changed mid-run and that it **cannot attribute** the change — it names live processes inside the repo that are not the run's. That is the shared-checkout condition the guard documents, not a defect in this change; `git worktree add` in any worktree rewrites that shared file. The hermetic tier (`nix build .#checks.x86_64-linux.pytests`, a `.git`-less store copy) is running, and CI gates on it.
- The wrapper for that run **exited 0 while printing `RESULT: FAIL (exit=1)`** — the documented pipe trap. Reading the `RESULT:` line rather than the status is what caught it.

## Scope

Two files: one comment block, one test. No behaviour change to the hook, the strip, or the runner — the strip was already correct; what was wrong was the recorded reason for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)