### PR TITLE
docs(handoff): discord-embed-ext rescue — all three PRs merged, both hosts deployed and verified, and the duplicate resolved itself onto main

### DIFF
--- a/claudedocs/handoff-discord-embed-ext-rescue.md
+++ b/claudedocs/handoff-discord-embed-ext-rescue.md
@@ -22,27 +22,42 @@ dead session. Outcome: preserve everything, land the salvageable half properly, 
 the part that was measurably dead.
 
 ## State now
-- **Branch:** `feat/discord-embed-enlarge`, head `8635f168`, 10 commits.
-- **PR #804 — OPEN, `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN`.** Both required
-  checks green: `tekton/devrc-nodetests` SUCCESS, `tekton/devrc-pytests` SUCCESS.
-  Merges clean into `origin/main` `324693fd` (re-checked at handoff time; main moved
-  four times during this work).
-- **NOT MERGED, deliberately.** See "Open investigations" — a second, independent
-  implementation of the same feature is in flight and does not know this PR exists.
-- **Preserved, nothing discarded:**
-  - `rescue/discord-embed-ext` `42563d57` — the original 13-file orphan, verbatim. It had
-    never been rescued before; this was the only copy.
-  - `rescue/discord-embed-ext-concurrent` `14be8300` — two snapshots of a *different*,
-    concurrent rebuild found in the shared clone (see below).
-  - `rescue/initiative-scan-resolved-filter` — a third stranded item (`initiative-scan.py`,
-    67 insertions) that turned out to be already preserved by an earlier session; my
-    duplicate branch was deleted.
-- **Shared base clone left exactly as found**: `scripts/run-node-tests.sh` modified and
-  `scripts/discord-embed-ext/` untracked are **another agent's live WIP**, not mine.
-  I hold no worktrees.
-- **What landed in the PR:** the enlarge + lightbox half only. 118 tests, floor 113.
-  Merged-tree runner: 1320 tests, 0 fail. Nix deploy path added
-  (`home.activation.discordEmbedExtension`), which the code never had.
+🔴 **ALL LANDED AND DEPLOYED.** Everything the previous version of this doc listed as
+open is merged, shipped to both hosts, and verified by content.
+
+- **Branch:** none — `feat/discord-embed-enlarge` merged and deleted. Base clone on
+  `main` at `origin/main`.
+- **Merged (verified by CONTENT, never ancestry — a squash is never an ancestor):**
+  - `#804` → squash `eaf68c96` — the extension. 11 files on `origin/main`, SUITES entry
+    `scripts/discord-embed-ext/tests|2|113` present.
+  - `#818` → squash `5d6ebb43` — this handoff doc.
+  - `#832` → squash `4500b88c` — `claude/RULES.md` worktree mandate reworded (below).
+- **Deployed and verified on BOTH hosts** — `scripts/ship.sh`, cross-host agreement
+  CONFIRMED (not the one-host `NOT COMPARED` case): both at `f82272c3`.
+
+  | check | workbench | laptop |
+  |---|---|---|
+  | `~/.local/share/discord-embed-ext` | `embed_enlarge.js lightbox.js manifest.json icons` | same |
+  | `save_button.js` present? | **no** — correct build | no |
+  | reworded rule in `~/.claude/RULES.md` | ✓ | ✓ |
+  | reworded rule in `~/.config/opencode/AGENTS.md` | ✓ | ✓ |
+
+- **clawgate task 357 FILED (open, untouched)** — "Handoff next-steps is a work queue
+  with no claim step". Solution design is deliberately IN SCOPE for the pickup. Its body
+  was updated post-creation with two measured facts (see Gotchas).
+- **Four rescue branches on origin, nothing discarded:**
+  `rescue/discord-embed-ext` `42563d57` (the original orphan) ·
+  `rescue/discord-embed-ext-concurrent` `63b8e22c` (three snapshots of the concurrent
+  rebuild) · `rescue/discord-embed-ext-committed-to-main` `74f3a389` (that rebuild as it
+  was finally committed) · `rescue/initiative-scan-resolved-filter` (pre-existing; the
+  `--exclude-slugs` work has since landed independently as `#824`).
+- **Carried forward from the pre-merge version of this section** (still true, and the
+  REPLACE would otherwise drop it): what landed is the enlarge + lightbox half only —
+  118 tests, floor 113, merged-tree runner 1320/0 — and the nix deploy path
+  `home.activation.discordEmbedExtension` in `nix/home.nix`, which the code never had.
+- **Base clone tree:** two untracked files that are NOT mine and NOT this work —
+  `nix/system/apply-nebula-443.sh.LOCAL-preserved-2026-08-02`,
+  `scripts/dl-router/tests/load_test_store.sh`. Left alone.
 
 ## Open investigations — live diagnosis state
 
@@ -93,29 +108,60 @@ the part that was measurably dead.
 - **Next probe:** after a `home-manager switch`, do the three-step Load unpacked above and
   open a Discord channel that has an image attachment.
 
-## Next steps (ranked)
-1. **Reconcile with the concurrent rebuild before merging #804.** `IN FLIGHT: devrc#804`.
-   Touches `scripts/discord-embed-ext/**` and `scripts/run-node-tests.sh` SUITES. Merging
-   first strands a live effort; the two measurements that apply to *either*
-   implementation are in the PR thread (comment `#issuecomment-5404745780`).
-2. **Merge #804** once (1) is settled — it is `MERGEABLE`/`CLEAN` with both required
-   checks green, and merges clean into `324693fd`.
-3. **`scripts/ship.sh`**, then the manual `Load unpacked` step, then open a Discord
-   channel with an image to close the second investigation above.
-4. **Decide `rescue/initiative-scan-resolved-filter`** — a stranded
-   `--exclude-slugs`/`--include-resolved` feature for `initiative-scan.py`, 67 insertions,
-   **zero tests**, and it changes DEFAULT behaviour: an initiative whose handoff merely
-   contains the word "DONE" is hidden unless `--include-resolved` is passed. Needs a
-   regression test shown red before it goes anywhere.
-5. **Prune the rescue branches** once each is landed or explicitly abandoned:
-   `rescue/discord-embed-ext`, `rescue/discord-embed-ext-concurrent`.
+### RESOLVED — the concurrent rebuild ended up COMMITTED TO `main` in the shared clone
+- **Symptom + exact repro:** `git -C ~/workspace/devrc merge --ff-only origin/main` →
+  `hint: Diverging branches can't be fast-forwarded`. HEAD `74f3a389`, origin `b242fc2d`.
+- **Observed (with values):** `git rev-list --count origin/main..HEAD` = **1**;
+  `HEAD..origin/main` = **9**. The one local commit was
+  `74f3a389 feat(discord): add discord-embed-enlarge extension` — 13 files including
+  `extension/save_button.js`, `tests/save_button.test.mjs` and
+  `tests/fixtures/discord_embeds.html`, plus `scripts/run-node-tests.sh`. That is the
+  OTHER agent's duplicate implementation, committed onto the deploy-target branch.
+- **Why it mattered:** this is the 🔴 failure `devrc/CLAUDE.md` records twice
+  (2026-08-06, 2026-08-09) — `ship.sh` converges with `merge --ff-only`, so a diverged
+  host is skipped and left as found, then silently stops receiving every future change
+  while still looking healthy.
+- **Resolution — preserve, verify, THEN move the pointer.** Never reset first:
+  `git branch rescue/discord-embed-ext-committed-to-main 74f3a389` → push → verify on
+  origin from an independent read (same sha **and** same tree OID `2fe66a1a`, 13 files)
+  → `git reset --keep origin/main` (`--keep` refuses rather than destroys). Confirmed
+  after: HEAD == origin/main, `merge --ff-only` → `Already up to date`, and the
+  preserved commit still reachable.
 
-🔴 **This list is a WORK QUEUE WITH NO LOCK** — every `/resume` session draws
-from it, so a *better* ranked list produces *more* duplicate work, not less.
-Make each item cheap to check: name the repo and the files it will touch, and
-**mark anything in flight `IN FLIGHT: <repo>#<pr>`** rather than leaving it
-looking unclaimed. Worktrees do NOT prevent this. 📖 the measurements and the
-refutation: `~/.claude/skills/handoff/reference/shared-queue.md`.
+### STILL OPEN — the extension has never been registered in Brave
+- **Symptom + exact repro:** "installs cleanly as an unpacked extension" is UNTESTED.
+  `brave://extensions` → Developer mode → **Load unpacked** →
+  `~/.local/share/discord-embed-ext` has never been performed on either host.
+- **Observed (with values):** the directory now EXISTS on both hosts with exactly
+  `embed_enlarge.js lightbox.js manifest.json icons` (verified post-`ship.sh`).
+  Everything else was verified against a real Chromium by injecting the shipped sources
+  into a live page: attachment enlarged (`data-dee-enlarged="1"`), avatar in the same row
+  untouched (`null`), 400px cap gone (computed `max-width: none`), lightbox opened by a
+  real bubbling click, `position: fixed`, `z-index: 2147483647`, covers viewport, Escape
+  closes — against a container using a HASHED class (`imageWrapper__74e4d`).
+- **Ruled out:** nothing — this is a gap, not a failure. No evidence of a problem.
+- **Leading hypothesis:** it loads. MV3-valid manifest, zero `permissions`, no
+  `host_permissions`, no `background`.
+- **Next probe:** do the three-step Load unpacked above, then open a Discord channel
+  that has an **image attachment** (not just avatars — a channel with only avatars/icons
+  will correctly show NO enlargement and reads as a failure).
+
+## Next steps (ranked)
+1. **The manual `Load unpacked` step** — the only untested claim in the chain. Three
+   clicks, `~/.local/share/discord-embed-ext`, then a Discord channel with a real image
+   attachment. Nothing else can close it; nix cannot register an unpacked extension.
+2. **clawgate task 357** — the queue-collision cause. `IN FLIGHT: none`, unclaimed,
+   solution design in scope. devrc, lands in `claude/skills/` + possibly `RULES.md` +
+   `scripts/`. 🔴 Read its Non-goals first: "do not add more prose and call it done".
+3. **Decide the four `rescue/*` branches** — all four are backups of work that is either
+   landed or superseded. `rescue/initiative-scan-resolved-filter` is now redundant
+   (`#824` landed that work). Prune what is genuinely dead; each is one `git push
+   --delete`.
+4. **Reconcile the duplicate implementation, or close it out** — `#804` landed the
+   enlarge+lightbox half; `rescue/discord-embed-ext-committed-to-main` holds the other
+   agent's full version including the save button. The save button is measurably dead
+   (401, below), so the realistic outcome is "delete the branch", but that is the other
+   author's call.
 
 ## Gotchas / decisions / dead-ends
 
@@ -168,28 +214,79 @@ refutation: `~/.claude/skills/handoff/reference/shared-queue.md`.
 - **zsh does not word-split unquoted parameters** — bit me mid-verification: a
   `set -- $t` loop printed blanks for all three gate results instead of erroring.
 
+- 🔴 **A clawgate `PATCH /api/tasks/{id}` with `{"content": …}` returns HTTP 200, bumps
+  `updatedAt`, and CHANGES NOTHING.** The write key is **`body`**. `task-api.md` line 14
+  says "content + dispatch config", so the DOCUMENTED field silently no-ops. Measured on
+  task 357: `{content:…}` → 200, body stayed 6687 bytes; `{body:…}` → body became 7870.
+  A `-o /dev/null` on that first call would have shipped "task updated" as a false claim.
+  The route returns the FULL updated task — read `.body|length` back, never the status.
+- 🔴 **`error` is not `failure` on a required check.** `#818`'s two Tekton checks came
+  back `error` with `COULD NOT RUN: <leg> — the gate stopped before this leg reported`,
+  and NO PipelineRun existed in `tekton-ci` for that sha at all. That is a broken gate,
+  not a bad diff — do not debug your change against it. The discriminator: `#804` showed
+  `SUCCESS` on the same gate at the same moment. Remedy is a **fresh push** (an empty
+  commit is enough); the checks then moved `ERROR → PENDING`, i.e. a real run existed.
+- ⚠ **A gate that sits `PENDING` with a frozen log tail is usually NOT wedged.** Read
+  CONTAINER STATE, not the log: `kubectl -n tekton-ci get pod <run>-gate-pod -o json |
+  jq '.status.containerStatuses[]'` plus `kubectl top pod --containers`. On `#804`,
+  `step-pytests` was at 1053m CPU while `kubectl logs` showed a tail from a *different,
+  already-terminated* container. Pod-relative elapsed time is the honest clock — the gate
+  is a documented 25–43 min check and I twice miscounted from the push instead.
+- 🔴 **`AGENTS.md` is CONCATENATED, not imported, and that is deliberate.**
+  `nix/home.nix:1414` builds `~/.config/opencode/AGENTS.md` from `PRINCIPLES.md` +
+  `RULES.md` + `opencode-addendum.md`. **opencode does NOT expand `@`-imports** (measured
+  on v1.18.4 with an all-tools-denied agent: an imported passphrase came back NONE, the
+  same content inline came back verbatim), and `~/.claude/CLAUDE.md` is ~1.5 KB of import
+  lines — so pointing opencode at it would deliver ZERO rules. Adding `devrc/CLAUDE.md`
+  to that concat is NOT free: `test_opencode_config.py` pins a 100 KB ceiling and a
+  331 KB `AGENTS.md` causes a permanent compaction loop.
+- **So the earlier claim "opencode may never load the rule" was WRONG.** `RULES.md` IS
+  delivered to opencode. The real gap was narrower: the worktree mandate's SUBJECT said
+  "any **subagent**" and its only MECHANISM was `isolation: "worktree"` — a Claude
+  Agent-tool parameter opencode cannot pass. A rule you can read but cannot execute reads
+  as one not addressed to you. Reworded in `#832` to name ANY agent and give
+  `git worktree add` as the runtime-neutral mechanism. `+172` bytes, **197 left** under
+  the ceiling `scripts/tests/test_rules_size.py` owns — hence a reword in place, not a
+  new paragraph.
+- ⚠ **`#832` does NOT fix the duplicate WORK** and must not be read as progress on 357.
+  `shared-queue.md` refutes worktrees for task-allocation collisions — every session
+  colliding there was already correctly isolated. Two independent failures happened
+  together: a task-allocation collision (357) and a filesystem one (`#832`).
+- **Why the two agents collided, measured:** `handoff-handoff-skill-hardening.md`
+  next-step #1 was drawn twice. The `IN FLIGHT` rule + `shared-queue.md` merged at
+  **14:18**, home-manager generation **556** switched them live at **18:00:50**, and the
+  collision started at **18:06** — six minutes later. I opened `#804` at 16:00, two hours
+  before the rule was deployed, and never marked the item in flight afterwards. The only
+  `IN FLIGHT` string in that doc is a section LABEL, not a claim on any item.
+- **The `/handoff` writeback guard fires on a task you AUTHORED.** Reading task 357 back
+  to verify the create linked this session to it; the Stop hook then demanded a
+  write-back for work that was never 357's. Correct action is `--dismiss <id> --session
+  <uuid>`, NOT a comment: any `claude-code` comment permanently silences that guard for
+  the card. To add findings to a task you filed, **PATCH the body** — authoring — rather
+  than commenting.
+
 ## How to verify
 ```bash
-# 1. the PR is still mergeable and both required checks are green
-gh pr view 804 --json mergeable,mergeStateStatus,statusCheckRollup \
-  --jq '"\(.mergeable) \(.mergeStateStatus)", (.statusCheckRollup[]|"\(.name): \(.conclusion)")'
+# 1. all three merges are on main, by CONTENT (a squash is never an ancestor)
+cd /home/zach/workspace/devrc && git fetch origin -q
+git ls-tree -r --name-only origin/main -- scripts/discord-embed-ext | wc -l      # 11
+git show origin/main:scripts/run-node-tests.sh | grep 'discord-embed-ext/tests|' # |2|113
+git show origin/main:claude/RULES.md | grep -c 'standing default for ANY agent'  # 1
+test -f claudedocs/handoff-discord-embed-ext-rescue.md && echo "handoff doc present"
 
-# 2. this suite, on the branch
-git -C /home/zach/workspace/devrc worktree add /tmp/dee-verify 8635f168
-node --test /tmp/dee-verify/scripts/discord-embed-ext/tests/*.test.mjs   # expect 118 pass, 0 fail
+# 2. BOTH hosts deployed — nix decides this, git does not
+for h in "" "ssh zach@10.42.0.100"; do
+  $h ls ~/.local/share/discord-embed-ext/                      # 4 entries, NO save_button.js
+  $h grep -c 'standing default for ANY agent' ~/.claude/RULES.md          # 1
+  $h grep -c 'standing default for ANY agent' ~/.config/opencode/AGENTS.md # 1  <- the point of #832
+done
 
-# 3. the MERGED tree, which is the claim that matters (strict=false)
-git -C /tmp/dee-verify merge --no-commit --no-ff origin/main   # expect clean
-nix develop /tmp/dee-verify --command bash /tmp/dee-verify/scripts/run-node-tests.sh
-#    expect: PASS scripts/discord-embed-ext/tests (files=2 tests=118 floor=113), RESULT: PASS
+# 3. the suite, on main
+node --test scripts/discord-embed-ext/tests/*.test.mjs        # 118 pass, 0 fail
 
-# 4. the GATED tier — the one Tekton runs and the merge depends on
-nix build /tmp/dee-verify#checks.x86_64-linux.nodetests --no-link
-nix build /tmp/dee-verify#checks.x86_64-linux.pytests  --no-link
-git -C /home/zach/workspace/devrc worktree remove --force /tmp/dee-verify
-
-# 5. the save-button finding, if you doubt it (needs the sidecar running)
-curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8791/healthz            # 401
-curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $(cat ~/.config/dl-router/token)" \
-  http://127.0.0.1:8791/healthz                                                   # 200
+# 4. the save-button finding, if ever doubted (needs the sidecar up)
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8791/healthz   # 401
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -H "Authorization: Bearer $(cat ~/.config/dl-router/token)" \
+  http://127.0.0.1:8791/healthz                                          # 200
 ```


### PR DESCRIPTION
`/handoff` update to `claudedocs/handoff-discord-embed-ext-rescue.md`. Landed from a worktree because devrc forbids committing to `main`.

Everything the previous version listed as open is now **merged and deployed**, so the status sections are replaced and the findings appended (`buckets:` confirmed: `State now`/`Next steps`/`How to verify` → REPLACE, `Open investigations`/`Gotchas` → APPEND, so the earlier text survives verbatim).

What changed since the doc was written:

- **#804** merged (squash `eaf68c96`) — the extension, 11 files on `main`, SUITES `|2|113`
- **#832** merged (squash `4500b88c`) — the worktree mandate now names ANY agent with a runtime-neutral mechanism
- **Both hosts deployed and verified by content** at `f82272c3`, cross-host agreement **CONFIRMED** — including the reworded rule reaching `~/.config/opencode/AGENTS.md`, which was the whole point of #832
- **clawgate task 357** filed for the queue-collision cause
- The concurrent rebuild **resolved itself by being committed to `main`** in the shared clone (`74f3a389`), diverging it 1-ahead/9-behind and blocking `ship.sh` — recovered by preserve → verify → `git reset --keep`, preserved on `rescue/discord-embed-ext-committed-to-main`

One durable line was explicitly carried forward rather than let the REPLACE drop it (the nix deploy path and the 118/113 counts) — flagged in the doc itself so the next reader knows it was deliberate.

Only untested claim remaining, and it's stated as such: the manual `brave://extensions` → Load unpacked step, on a Discord channel with a real image attachment.
