### PR TITLE
fix(agent-ledger): make the tmux budget reachable from all six exposures, not two

### DIFF
--- a/scripts/claude-hooks/tests/test_agent_ledger_hook.py
+++ b/scripts/claude-hooks/tests/test_agent_ledger_hook.py
@@ -69,6 +69,14 @@ def run_hook(data, home, env=None, args=()):
     e = dict(os.environ)
     e["HOME"] = str(home)
     e.pop("TMUX_PANE", None)           # no tmux by default; opt in per test
+    # 🔴 A CEILING, NOT A SLEEP. The hook calls `AL.tmux_context(pane=...)` with
+    # no timeout knob at all, so the env var is the only way to stop a pane-keyed
+    # assertion here silently depending on the 2.0s production default — which
+    # under the devrc-ci leg is the #810 flake. In the harness rather than in the
+    # two tests that need it today, so the next author cannot forget it. A
+    # passing stub call returns in ~3ms (0.197s worst at a 20x CPU stall), so 60s
+    # is ~300x the worst contended observation and costs a passing run nothing.
+    e["AGENT_LEDGER_TMUX_TIMEOUT_S"] = "60.0"
     e.update(env or {})
     return subprocess.run(
         [sys.executable, HOOK, *args],

--- a/scripts/lib/agent_ledger.py
+++ b/scripts/lib/agent_ledger.py
@@ -165,6 +165,61 @@ DEFAULT_THROTTLE = 30
 # (devrc-ci-wwj4d). Reproduced end-to-end by making the stub sleep 2.5s.
 DEFAULT_TMUX_TIMEOUT_S = 2.0
 
+# 🔴 THE ENV VAR EXISTS BECAUSE A PARAMETER CANNOT REACH FOUR OF THE SIX
+# EXPOSURES. #810 gave the CLI a `--tmux-timeout` flag, and an audit found it
+# covers 2 of 6: `scripts/opencode/plugin/ledger.js` HARDCODES its argv
+# (:114-129) so no flag can be injected, and `scripts/claude-hooks/
+# agent-ledger-hook.py` calls `tmux_context(pane=...)` with no knob at all. Both
+# read the process environment, so this is the one mechanism that reaches every
+# caller — including the four sibling tests whose pane-keyed assertions
+# otherwise depend on how loaded the machine is, which is the #810 flake.
+#
+# Precedence: an explicit `timeout=` argument WINS (a caller that named a number
+# meant it), then this, then the constant.
+TMUX_TIMEOUT_ENV = "AGENT_LEDGER_TMUX_TIMEOUT_S"
+
+
+def resolve_tmux_budget(timeout=None, environ=None, warn=None):
+    """Seconds to allow tmux: explicit arg > `$AGENT_LEDGER_TMUX_TIMEOUT_S` >
+    `DEFAULT_TMUX_TIMEOUT_S`.
+
+    🔴 NEVER RAISES, and that is load-bearing rather than defensive: this sits on
+    `PostToolUse` and on every opencode tool call, and `tmux_context`'s docstring
+    promises every failure is `(None, None)`. An audit of #810 found `float()`
+    outside the `try`, so `timeout="abc"` raised `ValueError` straight through a
+    contract that said it could not — contained only because the one caller that
+    takes user input validated first.
+
+    🔴 AN INVALID BUDGET IS NOT SILENTLY ACCEPTED. `timeout=0` and `timeout=-5`
+    previously reached `subprocess.run` and forced an instant timeout — i.e. the
+    degraded session-keyed path, silently. That is precisely the failure the
+    CLI's own guard exists to prevent, reachable from Python one layer down. Junk
+    now falls back to the default AND says so on stderr: a typo'd env var in a
+    test must not read as "the budget I asked for", because that puts the
+    assertion right back on the machine's load.
+    """
+    warn = warn if warn is not None else (
+        lambda m: print(m, file=sys.stderr, flush=True))
+    if timeout is not None:
+        src, raw = "timeout=", timeout
+    else:
+        env = os.environ if environ is None else environ
+        raw = env.get(TMUX_TIMEOUT_ENV)
+        if raw is None or raw == "":
+            return DEFAULT_TMUX_TIMEOUT_S
+        src = TMUX_TIMEOUT_ENV + "="
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        warn(f"agent_ledger: ignoring {src}{raw!r} (not a number); "
+             f"using {DEFAULT_TMUX_TIMEOUT_S}s")
+        return DEFAULT_TMUX_TIMEOUT_S
+    if not val > 0 or val != val or val == float("inf"):
+        warn(f"agent_ledger: ignoring {src}{raw!r} (must be finite and > 0); "
+             f"using {DEFAULT_TMUX_TIMEOUT_S}s")
+        return DEFAULT_TMUX_TIMEOUT_S
+    return val
+
 RUNTIMES = ("claude", "opencode", "clawgate")
 
 # `@41` -> `41`, matching the naming `tmux-task-hook.sh` used (`${WIN_ID//[@%]/}`).
@@ -659,14 +714,23 @@ def tmux_context(runner=None, pane=None, timeout=None):
     TWO callers: the Claude hook and the `--write` CLI. It is here so there is
     one resolver rather than one per writer.
 
-    `timeout` is the seconds to allow tmux, defaulting to
-    `DEFAULT_TMUX_TIMEOUT_S` — read that constant for why the default is short
-    and why a caller must be able to raise it.
+    `timeout` is the seconds to allow tmux. Resolution — explicit argument,
+    then `$AGENT_LEDGER_TMUX_TIMEOUT_S`, then `DEFAULT_TMUX_TIMEOUT_S` — lives in
+    `resolve_tmux_budget`; read that for why the env var exists (a parameter
+    cannot reach four of this function's six exposures) and why junk falls back
+    loudly rather than silently forcing the degraded path.
+
+    ⚠ `timeout`/the env var apply to the DEFAULT runner only. A caller supplying
+    `runner=` owns its own deadline — the budget is not threaded into an injected
+    runner, so a test passing both would get a false green about the budget.
     """
     pane = os.environ.get("TMUX_PANE") if pane is None else pane
     if not pane:
         return None, None
-    budget = DEFAULT_TMUX_TIMEOUT_S if timeout is None else float(timeout)
+    # Never raises, so it is safe outside the `try` — see its docstring. The
+    # previous `float(timeout)` here was NOT, which broke this function's own
+    # "every failure is (None, None)" promise.
+    budget = resolve_tmux_budget(timeout)
     argv = ["tmux", "display-message", "-t", pane, "-p", "#{window_id}|#{pid}"]
     try:
         run = runner or (lambda a: subprocess.run(
@@ -704,10 +768,21 @@ def main(argv=None) -> int:
     p.add_argument("--session", required=True)
     p.add_argument("--transcript-path", default=None)
     p.add_argument("--throttle", type=float, default=DEFAULT_THROTTLE)
-    p.add_argument("--tmux-timeout", type=float, default=DEFAULT_TMUX_TIMEOUT_S,
-                   help="seconds to allow tmux to answer (default %(default)s). "
-                        "Raise it when the pane-keyed filename must be RELIABLE "
-                        "rather than cheap — see DEFAULT_TMUX_TIMEOUT_S.")
+    # 🔴 default=None, NOT the constant — and the help text spells the constant
+    # itself rather than `%(default)s`. An argparse default is an EXPLICIT
+    # argument by the time `main` sees it, and an explicit argument beats the
+    # env var by design, so defaulting to the constant here made
+    # `$AGENT_LEDGER_TMUX_TIMEOUT_S` structurally unreachable on the CLI path —
+    # i.e. on the opencode plugin, which is one of the two exposures the env var
+    # exists to serve. Measured: with default=<constant>, the plugin's
+    # pane-keyed tests still went red under a mutated constant despite the
+    # variable being set. None means "nobody said", which is what lets
+    # `resolve_tmux_budget` consult the environment.
+    p.add_argument("--tmux-timeout", type=float, default=None,
+                   help="seconds to allow tmux to answer (default %s, or "
+                        "$%s). Raise it when the pane-keyed filename must be "
+                        "RELIABLE rather than cheap — see DEFAULT_TMUX_TIMEOUT_S."
+                        % (DEFAULT_TMUX_TIMEOUT_S, TMUX_TIMEOUT_ENV))
     p.add_argument("--prune", action="store_true",
                    help="also reap records past the retention window; the "
                         "caller does this on a session boundary, not per call")
@@ -718,7 +793,13 @@ def main(argv=None) -> int:
     # immediately, so a typo would silently force the DEGRADED session-keyed
     # path on every write while the CLI still exited 0. argparse's own exit
     # code (2) is the right one: this is a bad invocation, not a failed write.
-    if not args.tmux_timeout > 0 or args.tmux_timeout == float("inf"):
+    # Only when the flag was actually GIVEN: `None` means nobody said, which is
+    # not a bad invocation — it hands the decision to `resolve_tmux_budget`,
+    # which consults $AGENT_LEDGER_TMUX_TIMEOUT_S and then the constant, and
+    # warns rather than raising if THAT is junk. Guarding on `is not None` also
+    # stops the comparison below raising TypeError on the default path.
+    if args.tmux_timeout is not None and (
+            not args.tmux_timeout > 0 or args.tmux_timeout == float("inf")):
         p.error("--tmux-timeout must be a positive, finite number of seconds "
                 "(got %r); it bounds the tmux lookup, and a non-positive value "
                 "silently forces the session-keyed fallback" % args.tmux_timeout)

--- a/scripts/opencode/tests/test_ledger_plugin.py
+++ b/scripts/opencode/tests/test_ledger_plugin.py
@@ -42,9 +42,23 @@ sys.path.insert(0, str(ROOT / "scripts"))
 from testlib import mockbin as M  # noqa: E402
 
 
+# 🔴 A CEILING, NOT A SLEEP, and it belongs in the HARNESS rather than in the
+# tests that happen to need it today. `ledger.js` HARDCODES its argv (:114-129),
+# so no `--tmux-timeout` flag can reach the CLI it spawns — the env var is the
+# only mechanism that does. Set here so every test in this file measures the
+# record shape instead of the host's spare capacity, and so the next test author
+# cannot forget it. A passing stub call returns in ~3ms (0.197s worst at a 20x
+# CPU stall), so 60s is ~300x the worst contended observation and costs nothing.
+# Two tests here previously asserted a PANE-KEYED filename while silently
+# depending on the 2.0s production default; under the devrc-ci leg that is the
+# #810 flake.
+_TMUX_BUDGET_S = "60.0"
+
+
 def run_node(code: str, env: dict | None = None) -> subprocess.CompletedProcess:
     base = dict(os.environ)
     base.pop("TMUX_PANE", None)
+    base["AGENT_LEDGER_TMUX_TIMEOUT_S"] = _TMUX_BUDGET_S
     base.update(env or {})
     return subprocess.run(["node", "--input-type=module", "-e", code],
                           capture_output=True, text=True, env=base, timeout=30)

--- a/scripts/tests/test_agent_ledger.py
+++ b/scripts/tests/test_agent_ledger.py
@@ -968,6 +968,81 @@ def test_the_default_tmux_budget_STAYS_THE_RIGHT_ORDER_OF_MAGNITUDE():
         f"say in the commit message which measurement moved.")
 
 
+# =========================================================================== #
+# resolve_tmux_budget — the knob that reaches the callers a FLAG cannot
+# =========================================================================== #
+def _warns():
+    """Collector standing in for stderr, so 'it warned' is an assertion."""
+    seen = []
+    return seen, seen.append
+
+
+def test_an_explicit_timeout_BEATS_the_env_var():
+    """A caller that named a number meant it. The env var is the fallback for
+    callers that have no way to name one, not an override of those that do."""
+    got, _ = AL.resolve_tmux_budget(7.5, environ={AL.TMUX_TIMEOUT_ENV: "60"}), None
+    assert got == 7.5
+
+
+def test_the_ENV_VAR_is_read_when_no_argument_is_passed():
+    """🔴 THE WHOLE POINT. `ledger.js` hardcodes its argv and the Claude hook
+    passes no timeout, so this is the only path by which those two — 4 of the 6
+    exposures — can be given a budget at all."""
+    assert AL.resolve_tmux_budget(environ={AL.TMUX_TIMEOUT_ENV: "42.5"}) == 42.5
+
+
+def test_the_constant_is_the_floor_of_the_chain():
+    assert AL.resolve_tmux_budget(environ={}) == AL.DEFAULT_TMUX_TIMEOUT_S
+    assert AL.resolve_tmux_budget(environ={AL.TMUX_TIMEOUT_ENV: ""}) == \
+        AL.DEFAULT_TMUX_TIMEOUT_S
+
+
+def test_an_UNPARSEABLE_env_var_falls_back_LOUDLY():
+    """🔴 Silence here would re-create the bug this change exists to fix: a
+    typo'd variable would read as "the budget I asked for" while the assertion
+    quietly went back to depending on machine load."""
+    seen, warn = _warns()
+    assert AL.resolve_tmux_budget(
+        environ={AL.TMUX_TIMEOUT_ENV: "2 seconds"}, warn=warn) == \
+        AL.DEFAULT_TMUX_TIMEOUT_S
+    assert seen and AL.TMUX_TIMEOUT_ENV in seen[0] and "2 seconds" in seen[0]
+
+
+def test_a_NON_POSITIVE_budget_does_not_silently_force_the_degraded_path():
+    """🔴 The audit finding. `timeout=0` and `timeout=-5` used to reach
+    subprocess.run, which times out instantly — i.e. the degraded session-keyed
+    path, silently. That is exactly what the CLI's own guard exists to prevent,
+    reachable from Python one layer down."""
+    for bad in (0, -5, float("nan"), float("inf")):
+        seen, warn = _warns()
+        assert AL.resolve_tmux_budget(bad, warn=warn) == AL.DEFAULT_TMUX_TIMEOUT_S, bad
+        assert seen, f"{bad!r} fell back SILENTLY"
+
+
+def test_it_NEVER_RAISES_because_tmux_context_promises_it_cannot():
+    """`tmux_context` documents that every failure is `(None, None)`, and it
+    runs on PostToolUse and every opencode tool call. An audit found `float()`
+    outside the `try` there, so `timeout="abc"` raised straight through that
+    contract."""
+    for junk in ("abc", object(), [], {}, "1e"):
+        seen, warn = _warns()
+        assert AL.resolve_tmux_budget(junk, warn=warn) == AL.DEFAULT_TMUX_TIMEOUT_S
+        assert seen, f"{junk!r} fell back SILENTLY"
+
+
+def test_tmux_context_survives_a_junk_timeout_END_TO_END():
+    """The seam, not just the helper: a junk budget must reach `(None, None)`
+    through the real function rather than an exception."""
+    got = AL.tmux_context(pane="%1", timeout="abc",
+                          runner=lambda a: _Proc(0, "@41|99\n"))
+    assert got == ("@41", "99")
+
+
+class _Proc:
+    def __init__(self, rc, out):
+        self.returncode, self.stdout = rc, out
+
+
 def test_a_cross_runtime_conflict_NAMES_THE_RUNTIMES():
     """🔴 The commonest real conflict is cross-runtime, and two opaque session
     ids do not say so. `claude, opencode` is the difference between "which agent


### PR DESCRIPTION
Closes the largest remaining follow-up from #810's audit: the `--tmux-timeout` flag covers **2 of 6** callers, and the other four are *structurally* out of reach — `scripts/opencode/plugin/ledger.js` hardcodes its argv (`:114-129`), and `scripts/claude-hooks/agent-ledger-hook.py` calls `tmux_context(pane=...)` with no knob at all.

Both read the process environment, so `$AGENT_LEDGER_TMUX_TIMEOUT_S` is the one mechanism that reaches every caller. Precedence: **explicit argument > env var > constant.**

## 🔴 The env var alone was not enough

Worth recording because it is invisible in review. The CLI's argparse carried `default=DEFAULT_TMUX_TIMEOUT_S`, so `timeout` was **never `None`** at that call site — and an explicit argument beats the env var *by design*. The variable was therefore structurally unreachable on exactly the path it exists to serve.

Measured: with the old default, the plugin's pane-keyed tests **still went red** under a mutated constant despite the variable being set. I only caught it because the mutation matrix disagreed with the intent.

Fixed with `default=None` ("nobody said"), the help text spelling the constant instead of `%(default)s` so the existing help-pin test still holds, and the fail-closed validation guarded on `is not None` — a junk *flag* is still argparse exit 2; an *absent* flag defers to the chain.

## Two audit findings closed in the same resolver

- **`float(timeout)` sat outside `tmux_context`'s `try`**, so `timeout="abc"` raised `ValueError` straight through a docstring promising every failure is `(None, None)` — on a function running on `PostToolUse` and every opencode tool call. `resolve_tmux_budget` never raises.
- **`timeout=0` / `-5` reached `subprocess.run`** and expired instantly, silently forcing the degraded session-keyed path — the exact failure the CLI's own guard prevents, reachable from Python one layer down. Junk now falls back **and warns**: a silent fallback would put the assertion straight back on machine load, which is the bug this whole line of work is about.

## Two-way proof

Run under `PYTHONDONTWRITEBYTECODE=1` so no stale `.pyc` can score a mutant as survived:

| condition | result | |
|---|---|---|
| base, constant `0.001` | **4 failed** | the audit's four, vulnerable |
| HEAD, constant `0.001`, env `60.0` | **0 failed** | env **protects** |
| HEAD, constant `2.0`, env `0.001` | **4 failed** | env **controls** — load-bearing |

The third row is the one that matters: it reddens *precisely* those four and no others, so they pass for the stated reason rather than incidentally.

## Placement

Budgets go in the two **harnesses**, not the four tests that need them today — every test in those files is covered, and the next author cannot forget. `60.0` reuses #810's constant and rationale (a passing stub call is ~3ms; 0.197s worst at a 20× CPU stall; a ceiling costs a passing run nothing).

## Suites

126 passed across `test_agent_ledger` + both sibling files. The broad run (`scripts/tests` + `claude-hooks` + `opencode`) is 67 failed / 10362 passed — an **identical failure set** to `origin/main` under the same command, zero difference in either direction. Those are dependency gaps in an ad-hoc `nix-shell`, not this change.

⚠ Left as-is and now **documented** rather than silently true: `timeout`/env do not apply when a caller supplies `runner=`, which owns its own deadline.

Remaining #810 follow-ups after this: only the smaller nits (`agent_ledger.py:261`'s stale "2s timeout" prose, and the narrow arm's misleading failure message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NsRe3TW5xbSgzkqB7Catv